### PR TITLE
Dynamic Mapping support for Pluggable Data Formats

### DIFF
--- a/libs/concurrent-queue/src/main/java/org/opensearch/common/queue/ConcurrentQueue.java
+++ b/libs/concurrent-queue/src/main/java/org/opensearch/common/queue/ConcurrentQueue.java
@@ -31,7 +31,6 @@ public final class ConcurrentQueue<T> {
     private final int concurrency;
     private final Lock[] locks;
     private final Queue<T>[] queues;
-    private final Supplier<Queue<T>> queueSupplier;
 
     ConcurrentQueue(Supplier<Queue<T>> queueSupplier, int concurrency) {
         if (concurrency < MIN_CONCURRENCY || concurrency > MAX_CONCURRENCY) {
@@ -40,7 +39,6 @@ public final class ConcurrentQueue<T> {
             );
         }
         this.concurrency = concurrency;
-        this.queueSupplier = queueSupplier;
         locks = new Lock[concurrency];
         @SuppressWarnings({ "rawtypes", "unchecked" })
         Queue<T>[] queues = new Queue[concurrency];
@@ -81,6 +79,10 @@ public final class ConcurrentQueue<T> {
     }
 
     T poll(Predicate<T> predicate) {
+        return pollAndDropIncompatible(e -> true, predicate);
+    }
+
+    T pollAndDropIncompatible(Predicate<T> isCompatible, Predicate<T> predicate) {
         final int threadHash = Thread.currentThread().hashCode() & 0xFFFF;
         for (int i = 0; i < concurrency; ++i) {
             final int index = (threadHash + i) % concurrency;
@@ -88,14 +90,8 @@ public final class ConcurrentQueue<T> {
             final Queue<T> queue = queues[index];
             if (lock.tryLock()) {
                 try {
-                    Iterator<T> it = queue.iterator();
-                    while (it.hasNext()) {
-                        T entry = it.next();
-                        if (predicate.test(entry)) {
-                            it.remove();
-                            return entry;
-                        }
-                    }
+                    T matched = scanAndDropIncompatible(queue, isCompatible, predicate);
+                    if (matched != null) return matched;
                 } finally {
                     lock.unlock();
                 }
@@ -107,14 +103,8 @@ public final class ConcurrentQueue<T> {
             final Queue<T> queue = queues[index];
             lock.lock();
             try {
-                Iterator<T> it = queue.iterator();
-                while (it.hasNext()) {
-                    T entry = it.next();
-                    if (predicate.test(entry)) {
-                        it.remove();
-                        return entry;
-                    }
-                }
+                T matched = scanAndDropIncompatible(queue, isCompatible, predicate);
+                if (matched != null) return matched;
             } finally {
                 lock.unlock();
             }
@@ -136,5 +126,19 @@ public final class ConcurrentQueue<T> {
             }
         }
         return false;
+    }
+
+    private T scanAndDropIncompatible(Queue<T> queue, Predicate<T> isCompatible, Predicate<T> predicate) {
+        Iterator<T> it = queue.iterator();
+        while (it.hasNext()) {
+            T entry = it.next();
+            if (isCompatible.test(entry) == false) {
+                it.remove();
+            } else if (predicate.test(entry)) {
+                it.remove();
+                return entry;
+            }
+        }
+        return null;
     }
 }

--- a/libs/concurrent-queue/src/main/java/org/opensearch/common/queue/LockableConcurrentQueue.java
+++ b/libs/concurrent-queue/src/main/java/org/opensearch/common/queue/LockableConcurrentQueue.java
@@ -10,6 +10,7 @@ package org.opensearch.common.queue;
 
 import java.util.Queue;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 /**
@@ -53,6 +54,26 @@ public final class LockableConcurrentQueue<T extends Lockable> {
             // If an entry has been added to the queue in the meantime, try again.
         } while (addAndUnlockCount != addAndUnlockCounter.get());
 
+        return null;
+    }
+
+    /**
+     * Poll with compatibility filter. Scans the queue for a compatible entry that can be locked.
+     * Incompatible entries are removed from the queue.
+     * Compatible entries that cannot be locked (held by another thread) are skipped.
+     *
+     * @param isCompatible predicate to test compatibility — failing entries are removed
+     * @return the locked matched entry, or null if none found
+     */
+    public T lockAndPollWithRejects(Predicate<T> isCompatible) {
+        int addAndUnlockCount;
+        do {
+            addAndUnlockCount = addAndUnlockCounter.get();
+            T entry = queue.pollAndDropIncompatible(isCompatible, Lockable::tryLock);
+            if (entry != null) {
+                return entry;
+            }
+        } while (addAndUnlockCount != addAndUnlockCounter.get());
         return null;
     }
 

--- a/libs/concurrent-queue/src/main/java/org/opensearch/common/queue/LockablePool.java
+++ b/libs/concurrent-queue/src/main/java/org/opensearch/common/queue/LockablePool.java
@@ -18,14 +18,20 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Queue;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 /**
  * A thread-safe pool of {@link Lockable} items backed by a {@link LockableConcurrentQueue}.
  * Items are locked on checkout and unlocked on release, ensuring safe reuse across threads.
  * <p>
- * The pool is created with a supplier that produces new items on demand when the pool
- * is empty. Items are tracked in a set for registration checks and iteration.
+ * The pool supports two modes of checkout:
+ * <ul>
+ *   <li>{@link #getAndLock()} — returns any available item, or creates a new one</li>
+ *   <li>{@link #getAndLock(Predicate)} — returns a compatible item (per predicate),
+ *       rejecting incompatible ones. Rejected items are removed from the available queue
+ *       but remain tracked by the pool and included in {@link #checkoutAll()}.</li>
+ * </ul>
  *
  * @param <T> the pooled item type, must implement {@link Lockable}
  */
@@ -56,9 +62,21 @@ public final class LockablePool<T extends Lockable> implements Iterable<T>, Clos
      * @throws IllegalStateException if the pool is closed
      */
     public T getAndLock() {
+        return getAndLock(e -> true);
+    }
+
+    /**
+     * Locks and polls a compatible item from the pool in a single pass. Items that fail
+     * the predicate are removed from the available queue but remain tracked by the pool.
+     * If no compatible item is found, a new one is created using the constructor's item supplier.
+     *
+     * @param isCompatible predicate to test each polled item
+     * @return a locked, compatible item
+     * @throws IllegalStateException if the pool is closed
+     */
+    public T getAndLock(Predicate<T> isCompatible) {
         ensureOpen();
-        T item = availableItems.lockAndPoll();
-        return Objects.requireNonNullElseGet(item, this::fetchItem);
+        return Objects.requireNonNullElseGet(availableItems.lockAndPollWithRejects(isCompatible), this::fetchItem);
     }
 
     private synchronized T fetchItem() {

--- a/libs/concurrent-queue/src/test/java/org/opensearch/common/queue/ConcurrentQueueTests.java
+++ b/libs/concurrent-queue/src/test/java/org/opensearch/common/queue/ConcurrentQueueTests.java
@@ -160,4 +160,73 @@ public class ConcurrentQueueTests extends OpenSearchTestCase {
         pollLatch.await();
         assertEquals(numThreads * itemsPerThread, totalPolled.get());
     }
+
+    // --- Tests for pollWithRejects ---
+
+    public void testPollAndDropIncompatibleReturnsCompatibleAndDropsIncompatible() {
+        ConcurrentQueue<Integer> queue = new ConcurrentQueue<>(LinkedList::new, 1);
+        queue.add(1);
+        queue.add(2);
+        queue.add(3);
+
+        // Compatible: even numbers. canSelect: always true.
+        Integer result = queue.pollAndDropIncompatible(n -> n % 2 == 0, n -> true);
+        assertEquals(Integer.valueOf(2), result);
+        // 1 was rejected (removed), 3 still in queue (after the match, not scanned)
+        assertEquals(Integer.valueOf(3), queue.poll(e -> true));
+        assertNull(queue.poll(e -> true)); // 1 was removed
+    }
+
+    public void testPollAndDropIncompatibleAllIncompatible() {
+        ConcurrentQueue<Integer> queue = new ConcurrentQueue<>(LinkedList::new, 1);
+        queue.add(1);
+        queue.add(3);
+        queue.add(5);
+
+        Integer result = queue.pollAndDropIncompatible(n -> n % 2 == 0, n -> true);
+        assertNull(result);
+        // All removed as incompatible
+        assertNull(queue.poll(e -> true));
+    }
+
+    public void testPollAndDropIncompatibleEmptyQueue() {
+        ConcurrentQueue<Integer> queue = new ConcurrentQueue<>(LinkedList::new, 1);
+        Integer result = queue.pollAndDropIncompatible(n -> true, n -> true);
+        assertNull(result);
+    }
+
+    public void testPollAndDropIncompatibleSkipsCompatibleButUnselectable() {
+        ConcurrentQueue<Integer> queue = new ConcurrentQueue<>(LinkedList::new, 1);
+        queue.add(1);  // incompatible
+        queue.add(2);  // compatible but canSelect=false
+        queue.add(4);  // compatible and canSelect=true
+
+        Integer result = queue.pollAndDropIncompatible(
+            n -> n % 2 == 0,       // compatible: even
+            n -> n > 3             // canSelect: > 3
+        );
+        assertEquals(Integer.valueOf(4), result);
+        // 1 was rejected (removed), 2 should still be in queue (compatible but not selectable)
+        assertEquals(Integer.valueOf(2), queue.poll(e -> true));
+        assertNull(queue.poll(e -> true));
+    }
+
+    public void testPollAndDropIncompatibleMultipleStripes() {
+        ConcurrentQueue<Integer> queue = new ConcurrentQueue<>(LinkedList::new, 4);
+        for (int i = 0; i < 20; i++) {
+            queue.add(i);
+        }
+
+        // Drop 0-9 as incompatible, select first compatible entry (>= 10)
+        Integer first = queue.pollAndDropIncompatible(n -> n >= 10, n -> true);
+        assertNotNull(first);
+        assertTrue(first >= 10);
+
+        // Poll all remaining entries
+        int count = 1; // counting the first result
+        while (queue.poll(e -> true) != null) {
+            count++;
+        }
+        assertEquals(10, count);
+    }
 }

--- a/libs/concurrent-queue/src/test/java/org/opensearch/common/queue/LockableConcurrentQueueTests.java
+++ b/libs/concurrent-queue/src/test/java/org/opensearch/common/queue/LockableConcurrentQueueTests.java
@@ -215,4 +215,36 @@ public class LockableConcurrentQueueTests extends OpenSearchTestCase {
         }
         assertEquals(numEntries, remaining);
     }
+
+    public void testLockAndPollWithRejectsReturnsCompatibleEntry() {
+        LockableConcurrentQueue<LockableEntry> queue = new LockableConcurrentQueue<>(LinkedList::new, 1);
+        LockableEntry e1 = new LockableEntry("old");
+        LockableEntry e2 = new LockableEntry("old");
+        LockableEntry e3 = new LockableEntry("current");
+        seedEntry(queue, e1);
+        seedEntry(queue, e2);
+        seedEntry(queue, e3);
+
+        LockableEntry result = queue.lockAndPollWithRejects(e -> e.id.equals("current"));
+        assertSame(e3, result);
+        assertTrue(result.isHeldByCurrentThread());
+        // e1 and e2 were incompatible and should have been dropped
+        assertNull(queue.lockAndPoll());
+        result.unlock();
+    }
+
+    public void testLockAndPollWithRejectsAllIncompatible() {
+        LockableConcurrentQueue<LockableEntry> queue = new LockableConcurrentQueue<>(LinkedList::new, 1);
+        seedEntry(queue, new LockableEntry("old"));
+        seedEntry(queue, new LockableEntry("old"));
+
+        assertNull(queue.lockAndPollWithRejects(e -> e.id.equals("new")));
+        // Queue should be empty after all incompatible entries were dropped
+        assertNull(queue.lockAndPoll());
+    }
+
+    public void testLockAndPollWithRejectsEmptyQueue() {
+        LockableConcurrentQueue<LockableEntry> queue = new LockableConcurrentQueue<>(LinkedList::new, 1);
+        assertNull(queue.lockAndPollWithRejects(e -> true));
+    }
 }

--- a/libs/concurrent-queue/src/test/java/org/opensearch/common/queue/LockablePoolTests.java
+++ b/libs/concurrent-queue/src/test/java/org/opensearch/common/queue/LockablePoolTests.java
@@ -143,4 +143,57 @@ public class LockablePoolTests extends OpenSearchTestCase {
         IllegalStateException ex = expectThrows(IllegalStateException.class, pool::checkoutAll);
         assertEquals("LockablePool is already closed", ex.getMessage());
     }
+
+    // --- Tests for filtered getAndLock with rejection ---
+
+    public void testFilteredGetAndLockReturnsCompatibleItem() {
+        LockablePool<LockableEntry> pool = createPool();
+        LockableEntry item = pool.getAndLock();
+        pool.releaseAndUnlock(item);
+
+        LockableEntry result = pool.getAndLock(e -> true);
+        assertSame(item, result);
+        pool.releaseAndUnlock(result);
+    }
+
+    public void testFilteredGetAndLockRejectsIncompatibleItem() {
+        LockablePool<LockableEntry> pool = createPool();
+        LockableEntry item = pool.getAndLock();
+        pool.releaseAndUnlock(item);
+
+        // Reject the existing item — predicate fails, pool creates new via supplier
+        LockableEntry result = pool.getAndLock(e -> !e.id.equals(item.id));
+        assertNotSame(item, result);
+        pool.releaseAndUnlock(result);
+    }
+
+    public void testCheckoutAllIncludesRejectedItems() {
+        LockablePool<LockableEntry> pool = createPool();
+        LockableEntry item = pool.getAndLock();
+        pool.releaseAndUnlock(item);
+
+        // Reject the existing item
+        LockableEntry fresh = pool.getAndLock(e -> !e.id.equals(item.id));
+        pool.releaseAndUnlock(fresh);
+
+        List<LockableEntry> all = pool.checkoutAll();
+        assertEquals(2, all.size());
+        assertTrue(all.contains(item));
+        assertTrue(all.contains(fresh));
+    }
+
+    public void testRejectedItemNotReturnedBySubsequentPoll() {
+        LockablePool<LockableEntry> pool = createPool();
+        LockableEntry item = pool.getAndLock();
+        pool.releaseAndUnlock(item);
+
+        // Reject it
+        LockableEntry fresh = pool.getAndLock(e -> !e.id.equals(item.id));
+        pool.releaseAndUnlock(fresh);
+
+        // Next poll should return fresh, not the rejected item
+        LockableEntry next = pool.getAndLock();
+        assertSame(fresh, next);
+        pool.releaseAndUnlock(next);
+    }
 }

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_executor.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_executor.rs
@@ -427,12 +427,10 @@ pub async unsafe fn execute_indexed_with_context(
     // with IndexedTableProvider after plan decoding.
     ctx.deregister_table(&table_name)?;
 
-    let store = ctx
-        .state()
-        .runtime_env()
-        .object_store(&table_path)?;
+    let state = ctx.state();
+    let store = state.runtime_env().object_store(&table_path)?;
 
-    let (segments, schema) = build_segments(Arc::clone(&store), object_metas.as_ref())
+    let (segments, schema) = build_segments(&state, Arc::clone(&store), object_metas.as_ref())
         .await
         .map_err(DataFusionError::Execution)?;
     for (i, seg) in segments.iter().enumerate() {

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/segment_info.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/segment_info.rs
@@ -19,24 +19,41 @@ use super::stream::RowGroupInfo;
 use super::table_provider::SegmentFileInfo;
 use std::sync::Arc;
 
+use datafusion::catalog::Session;
+use datafusion::datasource::file_format::parquet::ParquetFormat;
+use datafusion::datasource::file_format::FileFormat;
+
 /// Build `SegmentFileInfo` from the shard's object metas. Each entry is one
 /// segment; its max_doc is derived from the sum of row-group row counts.
+///
+/// The returned schema is the **union across all segment parquet files**,
+/// computed by `ParquetFormat::infer_schema` — the same function
+/// `ListingTable` uses.
+///
+/// We do get all `ParquetFormat` knobs
+/// (skip_metadata, coerce_int96, binary_as_string, force_view_types,
+/// file_metadata_cache, meta_fetch_concurrency, parquet_encryption)
 pub async fn build_segments(
+    state: &dyn Session,
     store: Arc<dyn object_store::ObjectStore>,
     object_metas: &[object_store::ObjectMeta],
 ) -> Result<(Vec<SegmentFileInfo>, arrow::datatypes::SchemaRef), String> {
+    if object_metas.is_empty() {
+        return Err("No parquet files provided".to_string());
+    }
+
     let mut segments = Vec::with_capacity(object_metas.len());
-    let mut schema: Option<arrow::datatypes::SchemaRef> = None;
 
     for (seg_ord, meta) in object_metas.iter().enumerate() {
-        let (file_schema, size, pq_meta) =
+        // Per-segment parquet metadata (RG info, page index) — still needed
+        // regardless of schema derivation. The file_metadata_cache on the
+        // RuntimeEnv that `infer_schema` uses below shares this data when
+        // both are pointed at the same object location, so this isn't a
+        // duplicated cold fetch in practice.
+        let (_file_schema, size, pq_meta) =
             parquet_bridge::load_parquet_metadata(Arc::clone(&store), &meta.location)
                 .await
                 .map_err(|e| format!("parquet metadata {}: {}", meta.location, e))?;
-
-        if schema.is_none() {
-            schema = Some(file_schema);
-        }
 
         let mut row_groups = Vec::new();
         let mut offset: i64 = 0;
@@ -61,6 +78,260 @@ pub async fn build_segments(
         });
     }
 
-    let schema = schema.ok_or_else(|| "No parquet files provided".to_string())?;
+    // Delegate to DataFusion's canonical schema inference. Internally:
+    //   1. Fetch each file's schema concurrently (meta_fetch_concurrency).
+    //   2. Sort by location for determinism (see apache/datafusion#6629).
+    //   3. Strip field-level metadata when skip_metadata=true (default).
+    //   4. `arrow::datatypes::Schema::try_merge` — union by field name,
+    //      first-seen order, nullability OR'd, types must match for
+    //      primitives (recursively merged for Struct/List/Union).
+    //   5. Apply `binary_as_string` and `force_view_types` transforms
+    //      if configured.
+    let format = ParquetFormat::new();
+    let schema = FileFormat::infer_schema(&format, state, &store, object_metas)
+        .await
+        .map_err(|e| format!("infer_schema union: {}", e))?;
+
     Ok((segments, schema))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::datatypes::{DataType, Field, Schema};
+    use arrow_array::{Int32Array, RecordBatch, StringArray};
+    use datafusion::execution::context::SessionContext;
+    use datafusion::parquet::arrow::ArrowWriter;
+    use object_store::{local::LocalFileSystem, path::Path as ObjectPath, ObjectStore, ObjectStoreExt};
+    use tempfile::tempdir;
+
+    /// Write a parquet file with the given schema + arrays into `dir`
+    /// under `filename`. Returns the absolute filesystem path.
+    fn write_parquet(
+        dir: &std::path::Path,
+        filename: &str,
+        schema: arrow::datatypes::SchemaRef,
+        arrays: Vec<Arc<dyn arrow::array::Array>>,
+    ) -> std::path::PathBuf {
+        let path = dir.join(filename);
+        let file = std::fs::File::create(&path).unwrap();
+        let batch = RecordBatch::try_new(schema.clone(), arrays).unwrap();
+        let mut writer = ArrowWriter::try_new(file, schema, None).unwrap();
+        writer.write(&batch).unwrap();
+        writer.close().unwrap();
+        path
+    }
+
+    /// Build `[ObjectMeta]` pointing at the given absolute paths via
+    /// the local filesystem object store.
+    async fn object_metas(
+        store: &dyn ObjectStore,
+        paths: &[std::path::PathBuf],
+    ) -> Vec<object_store::ObjectMeta> {
+        let mut out = Vec::new();
+        for p in paths {
+            let loc = ObjectPath::from(p.to_string_lossy().as_ref());
+            out.push(store.head(&loc).await.unwrap());
+        }
+        out
+    }
+
+    /// Two segments with identical schemas: the union equals that
+    /// schema (field-level metadata stripped per `skip_metadata`
+    /// default, which is fine for default writers that emit none).
+    #[tokio::test]
+    async fn identical_schemas_merge_to_themselves() {
+        let dir = tempdir().unwrap();
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("name", DataType::Utf8, false),
+            Field::new("score", DataType::Int32, false),
+        ]));
+        let p0 = write_parquet(
+            dir.path(),
+            "a.parquet",
+            schema.clone(),
+            vec![
+                Arc::new(StringArray::from(vec!["x", "y"])),
+                Arc::new(Int32Array::from(vec![1, 2])),
+            ],
+        );
+        let p1 = write_parquet(
+            dir.path(),
+            "b.parquet",
+            schema.clone(),
+            vec![
+                Arc::new(StringArray::from(vec!["z"])),
+                Arc::new(Int32Array::from(vec![3])),
+            ],
+        );
+
+        let store: Arc<dyn ObjectStore> = Arc::new(LocalFileSystem::new());
+        let metas = object_metas(store.as_ref(), &[p0, p1]).await;
+        let ctx = SessionContext::new();
+        let (segments, merged) = build_segments(&ctx.state(), Arc::clone(&store), &metas)
+            .await
+            .unwrap();
+
+        assert_eq!(segments.len(), 2);
+        assert_eq!(merged.fields().len(), 2);
+        assert_eq!(merged.field(0).name(), "name");
+        assert_eq!(merged.field(1).name(), "score");
+    }
+
+    /// Schema evolution: seg0 lacks `created_day` that seg1 has. The
+    /// union must include every field, first-seen-order, with the
+    /// "new" field nullable because seg0 didn't declare it as
+    /// non-null.
+    #[tokio::test]
+    async fn union_contains_fields_from_all_segments() {
+        let dir = tempdir().unwrap();
+        let narrow = Arc::new(Schema::new(vec![
+            Field::new("name", DataType::Utf8, false),
+            Field::new("score", DataType::Int32, false),
+        ]));
+        let wide = Arc::new(Schema::new(vec![
+            Field::new("name", DataType::Utf8, false),
+            Field::new("score", DataType::Int32, false),
+            Field::new("created_day", DataType::Int32, true),
+        ]));
+        let p0 = write_parquet(
+            dir.path(),
+            "a.parquet",
+            narrow.clone(),
+            vec![
+                Arc::new(StringArray::from(vec!["x"])),
+                Arc::new(Int32Array::from(vec![1])),
+            ],
+        );
+        let p1 = write_parquet(
+            dir.path(),
+            "b.parquet",
+            wide.clone(),
+            vec![
+                Arc::new(StringArray::from(vec!["y"])),
+                Arc::new(Int32Array::from(vec![2])),
+                Arc::new(Int32Array::from(vec![Some(42)])),
+            ],
+        );
+
+        let store: Arc<dyn ObjectStore> = Arc::new(LocalFileSystem::new());
+        let metas = object_metas(store.as_ref(), &[p0, p1]).await;
+        let ctx = SessionContext::new();
+        let (_segments, merged) = build_segments(&ctx.state(), Arc::clone(&store), &metas)
+            .await
+            .unwrap();
+
+        let names: Vec<&str> = merged.fields().iter().map(|f| f.name().as_str()).collect();
+        assert_eq!(
+            names,
+            vec!["name", "score", "created_day"],
+            "union must contain every field across segments in first-seen order"
+        );
+        let created_day = merged.field_with_name("created_day").unwrap();
+        assert_eq!(created_day.data_type(), &DataType::Int32);
+        assert!(
+            created_day.is_nullable(),
+            "field from only-one-segment must be nullable in the union"
+        );
+    }
+
+    /// Determinism: schema merge is invariant under object-store
+    /// listing order. `ParquetFormat` sorts by location before merge
+    /// (apache/datafusion#6629). Assert both orderings produce
+    /// identical field order.
+    #[tokio::test]
+    async fn merge_is_deterministic_across_input_ordering() {
+        let dir = tempdir().unwrap();
+        let schema_a = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Utf8, false),
+            Field::new("b", DataType::Int32, false),
+        ]));
+        let schema_b = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Utf8, false),
+            Field::new("c", DataType::Int32, true),
+        ]));
+        let p0 = write_parquet(
+            dir.path(),
+            "a.parquet",
+            schema_a,
+            vec![
+                Arc::new(StringArray::from(vec!["x"])),
+                Arc::new(Int32Array::from(vec![1])),
+            ],
+        );
+        let p1 = write_parquet(
+            dir.path(),
+            "b.parquet",
+            schema_b,
+            vec![
+                Arc::new(StringArray::from(vec!["y"])),
+                Arc::new(Int32Array::from(vec![Some(2)])),
+            ],
+        );
+
+        let store: Arc<dyn ObjectStore> = Arc::new(LocalFileSystem::new());
+        let ctx = SessionContext::new();
+        let metas_ab = object_metas(store.as_ref(), &[p0.clone(), p1.clone()]).await;
+        let metas_ba = object_metas(store.as_ref(), &[p1, p0]).await;
+
+        let (_, schema_ab) = build_segments(&ctx.state(), Arc::clone(&store), &metas_ab)
+            .await
+            .unwrap();
+        let (_, schema_ba) = build_segments(&ctx.state(), Arc::clone(&store), &metas_ba)
+            .await
+            .unwrap();
+
+        let fields_ab: Vec<&str> = schema_ab
+            .fields()
+            .iter()
+            .map(|f| f.name().as_str())
+            .collect();
+        let fields_ba: Vec<&str> = schema_ba
+            .fields()
+            .iter()
+            .map(|f| f.name().as_str())
+            .collect();
+        assert_eq!(
+            fields_ab, fields_ba,
+            "schema order must not depend on object-meta input ordering"
+        );
+    }
+
+    /// Incompatible types (Int32 vs Int64 on the same field name) is
+    /// a fail-fast: the Arrow `Schema::try_merge` rejects it, and we
+    /// bubble the error up. Catches accidental type widening at the
+    /// shard-read boundary rather than silently at decode time.
+    #[tokio::test]
+    async fn incompatible_types_on_same_field_error() {
+        let dir = tempdir().unwrap();
+        let s_i32 = Arc::new(Schema::new(vec![Field::new("n", DataType::Int32, false)]));
+        let s_i64 = Arc::new(Schema::new(vec![Field::new("n", DataType::Int64, false)]));
+        let p0 = write_parquet(
+            dir.path(),
+            "a.parquet",
+            s_i32,
+            vec![Arc::new(Int32Array::from(vec![1]))],
+        );
+        let p1 = write_parquet(
+            dir.path(),
+            "b.parquet",
+            s_i64,
+            vec![Arc::new(arrow_array::Int64Array::from(vec![2i64]))],
+        );
+
+        let store: Arc<dyn ObjectStore> = Arc::new(LocalFileSystem::new());
+        let metas = object_metas(store.as_ref(), &[p0, p1]).await;
+        let ctx = SessionContext::new();
+        let result = build_segments(&ctx.state(), Arc::clone(&store), &metas).await;
+        assert!(
+            result.is_err(),
+            "conflicting Int32 / Int64 on same field name must fail at schema-union time"
+        );
+        let msg = result.unwrap_err();
+        assert!(
+            msg.contains("infer_schema union"),
+            "error must originate from infer_schema path, got: {}",
+            msg
+        );
+    }
 }

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/index/LuceneIndexingExecutionEngine.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/index/LuceneIndexingExecutionEngine.java
@@ -32,6 +32,7 @@ import org.opensearch.index.engine.dataformat.Merger;
 import org.opensearch.index.engine.dataformat.RefreshInput;
 import org.opensearch.index.engine.dataformat.RefreshResult;
 import org.opensearch.index.engine.dataformat.Writer;
+import org.opensearch.index.engine.dataformat.WriterConfig;
 import org.opensearch.index.engine.exec.Segment;
 import org.opensearch.index.engine.exec.WriterFileSet;
 import org.opensearch.index.engine.exec.commit.IndexStoreProvider;
@@ -53,7 +54,7 @@ import java.util.Set;
  * Lucene-specific {@link IndexingExecutionEngine} that manages per-writer Lucene segments
  * and incorporates them into the shared {@link LuceneCommitter} writer during refresh.
  *
- * Write path: Each call to {@link #createWriter(long)} creates a {@link LuceneWriter} with its own
+ * Write path: Each call to {@link #createWriter(WriterConfig)} creates a {@link LuceneWriter} with its own
  * {@link IndexWriter} in an isolated temp directory. Documents are indexed into this
  * per-writer segment. On flush, the writer force-merges to exactly 1 segment.
  *
@@ -149,17 +150,24 @@ public class LuceneIndexingExecutionEngine implements IndexingExecutionEngine<Lu
      * Creates a new {@link LuceneWriter} for the given generation in an isolated temp directory
      * under the shard's Lucene base directory.
      *
-     * @param writerGeneration the generation number for the new writer
+     * @param config the writer configuration
      * @return a new writer
      * @throws RuntimeException wrapping an {@link IOException} if writer creation fails
      */
     @Override
-    public Writer<LuceneDocumentInput> createWriter(long writerGeneration) {
+    public Writer<LuceneDocumentInput> createWriter(WriterConfig config) {
         assert sharedWriter.isOpen() : "Cannot create writer — shared IndexWriter is closed";
         try {
-            return new LuceneWriter(writerGeneration, dataFormat, baseDirectory, analyzer, codec, sharedWriter.getConfig().getIndexSort());
+            return new LuceneWriter(
+                config.writerGeneration(),
+                dataFormat,
+                baseDirectory,
+                analyzer,
+                codec,
+                sharedWriter.getConfig().getIndexSort()
+            );
         } catch (IOException e) {
-            throw new RuntimeException("Failed to create LuceneWriter for generation " + writerGeneration, e);
+            throw new RuntimeException("Failed to create LuceneWriter for generation " + config.writerGeneration(), e);
         }
     }
 

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/index/LuceneIndexingExecutionEngine.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/index/LuceneIndexingExecutionEngine.java
@@ -77,6 +77,7 @@ public class LuceneIndexingExecutionEngine implements IndexingExecutionEngine<Lu
 
     private final LuceneDataFormat dataFormat;
     private final MergeIndexWriter sharedWriter;
+    private final MapperService mapperService;
     private final Store store;
     private final Path baseDirectory;
     private final Analyzer analyzer;
@@ -101,6 +102,7 @@ public class LuceneIndexingExecutionEngine implements IndexingExecutionEngine<Lu
             throw new IllegalArgumentException("LuceneCommitter must not be null");
         }
         this.dataFormat = dataFormat;
+        this.mapperService = mapperService;
         this.sharedWriter = luceneCommitter.getIndexWriter();
         this.store = store;
         this.baseDirectory = store.shardPath().resolve(LuceneDataFormat.LUCENE_FORMAT_NAME);
@@ -158,8 +160,10 @@ public class LuceneIndexingExecutionEngine implements IndexingExecutionEngine<Lu
     public Writer<LuceneDocumentInput> createWriter(WriterConfig config) {
         assert sharedWriter.isOpen() : "Cannot create writer — shared IndexWriter is closed";
         try {
+            long mappingVersion = mapperService.getIndexSettings().getIndexMetadata().getMappingVersion();
             return new LuceneWriter(
                 config.writerGeneration(),
+                mappingVersion,
                 dataFormat,
                 baseDirectory,
                 analyzer,

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/index/LuceneWriter.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/index/LuceneWriter.java
@@ -72,6 +72,7 @@ public class LuceneWriter implements Writer<LuceneDocumentInput> {
     private final Path tempDirectory;
     private final Directory directory;
     private final IndexWriter indexWriter;
+    private long mappingVersion;
     private volatile long docCount;
 
     /**
@@ -202,6 +203,23 @@ public class LuceneWriter implements Writer<LuceneDocumentInput> {
     @Override
     public long generation() {
         return writerGeneration;
+    }
+
+    @Override
+    public boolean isSchemaMutable() {
+        return true;
+    }
+
+    @Override
+    public long mappingVersion() {
+        return mappingVersion;
+    }
+
+    @Override
+    public void updateMappingVersion(long newVersion) {
+        if (newVersion > this.mappingVersion) {
+            this.mappingVersion = newVersion;
+        }
     }
 
     /**

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/index/LuceneWriter.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/index/LuceneWriter.java
@@ -79,6 +79,7 @@ public class LuceneWriter implements Writer<LuceneDocumentInput> {
      * Creates a new LuceneWriter for the given generation.
      *
      * @param writerGeneration the writer generation number
+     * @param mappingVersion   the initial mapping version
      * @param dataFormat       the Lucene data format descriptor
      * @param baseDirectory    the base directory under which to create the temp directory
      * @param analyzer         the analyzer to use for tokenized fields, or null for default
@@ -88,6 +89,7 @@ public class LuceneWriter implements Writer<LuceneDocumentInput> {
      */
     public LuceneWriter(
         long writerGeneration,
+        long mappingVersion,
         LuceneDataFormat dataFormat,
         Path baseDirectory,
         Analyzer analyzer,
@@ -95,6 +97,7 @@ public class LuceneWriter implements Writer<LuceneDocumentInput> {
         Sort indexSort
     ) throws IOException {
         this.writerGeneration = writerGeneration;
+        this.mappingVersion = mappingVersion;
         this.dataFormat = dataFormat;
         this.docCount = 0;
 

--- a/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/index/LuceneIndexingExecutionEngineTests.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/index/LuceneIndexingExecutionEngineTests.java
@@ -168,7 +168,7 @@ public class LuceneIndexingExecutionEngineTests extends OpenSearchTestCase {
         when(textField.name()).thenReturn("content");
 
         long generation = 1L;
-        try (LuceneWriter luceneWriter = new LuceneWriter(generation, luceneDataFormat, tempBase, null, Codec.getDefault(), null)) {
+        try (LuceneWriter luceneWriter = new LuceneWriter(generation, 0L, luceneDataFormat, tempBase, null, Codec.getDefault(), null)) {
             for (int i = 0; i < numDocs; i++) {
                 LuceneDocumentInput input = new LuceneDocumentInput();
                 input.addField(textField, "doc_" + i);

--- a/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/index/LuceneIndexingExecutionEngineTests.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/index/LuceneIndexingExecutionEngineTests.java
@@ -26,6 +26,7 @@ import org.opensearch.index.engine.EngineConfigFactory;
 import org.opensearch.index.engine.dataformat.FileInfos;
 import org.opensearch.index.engine.dataformat.RefreshInput;
 import org.opensearch.index.engine.dataformat.RefreshResult;
+import org.opensearch.index.engine.dataformat.WriterConfig;
 import org.opensearch.index.engine.exec.Segment;
 import org.opensearch.index.engine.exec.WriterFileSet;
 import org.opensearch.index.engine.exec.commit.CommitterConfig;
@@ -272,7 +273,7 @@ public class LuceneIndexingExecutionEngineTests extends OpenSearchTestCase {
         when(keywordField.hasDocValues()).thenReturn(true);
 
         // Create writer through the engine
-        LuceneWriter writer = (LuceneWriter) engine.createWriter(generation);
+        LuceneWriter writer = (LuceneWriter) engine.createWriter(new WriterConfig(generation));
         try {
             for (int i = 0; i < numDocs; i++) {
                 LuceneDocumentInput input = engine.newDocumentInput();
@@ -328,8 +329,8 @@ public class LuceneIndexingExecutionEngineTests extends OpenSearchTestCase {
 
         // Create writers through the engine — do NOT close them before refresh,
         // because close() deletes the temp directory that refresh needs to read.
-        LuceneWriter writer1 = (LuceneWriter) engine.createWriter(gen1);
-        LuceneWriter writer2 = (LuceneWriter) engine.createWriter(gen2);
+        LuceneWriter writer1 = (LuceneWriter) engine.createWriter(new WriterConfig(gen1));
+        LuceneWriter writer2 = (LuceneWriter) engine.createWriter(new WriterConfig(gen2));
         try {
             for (int i = 0; i < numDocs1; i++) {
                 LuceneDocumentInput input = engine.newDocumentInput();

--- a/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/index/LuceneWriterTests.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/index/LuceneWriterTests.java
@@ -64,7 +64,7 @@ public class LuceneWriterTests extends OpenSearchTestCase {
 
     public void testAddDocAndFlushProducesSingleSegment() throws IOException {
         Path baseDir = createTempDir();
-        try (LuceneWriter writer = new LuceneWriter(1L, dataFormat, baseDir, null, Codec.getDefault(), null)) {
+        try (LuceneWriter writer = new LuceneWriter(1L, 0L, dataFormat, baseDir, null, Codec.getDefault(), null)) {
             int numDocs = randomIntBetween(5, 20);
             MappedFieldType textField = mockTextField("content");
             for (int i = 0; i < numDocs; i++) {
@@ -95,7 +95,7 @@ public class LuceneWriterTests extends OpenSearchTestCase {
         Path baseDir = createTempDir();
         int numDocs = randomIntBetween(10, 50);
         MappedFieldType textField = mockTextField("content");
-        try (LuceneWriter writer = new LuceneWriter(1L, dataFormat, baseDir, null, Codec.getDefault(), null)) {
+        try (LuceneWriter writer = new LuceneWriter(1L, 0L, dataFormat, baseDir, null, Codec.getDefault(), null)) {
             for (int i = 0; i < numDocs; i++) {
                 LuceneDocumentInput input = new LuceneDocumentInput();
                 input.addField(textField, "doc " + i);
@@ -122,7 +122,7 @@ public class LuceneWriterTests extends OpenSearchTestCase {
 
     public void testFlushWithNoDocsReturnsEmpty() throws IOException {
         Path baseDir = createTempDir();
-        try (LuceneWriter writer = new LuceneWriter(1L, dataFormat, baseDir, null, Codec.getDefault(), null)) {
+        try (LuceneWriter writer = new LuceneWriter(1L, 0L, dataFormat, baseDir, null, Codec.getDefault(), null)) {
             FileInfos fileInfos = writer.flush();
             assertTrue(fileInfos.writerFilesMap().isEmpty());
         }
@@ -132,7 +132,7 @@ public class LuceneWriterTests extends OpenSearchTestCase {
         Path baseDir = createTempDir();
         long gen = randomLongBetween(1, 100);
         MappedFieldType textField = mockTextField("content");
-        try (LuceneWriter writer = new LuceneWriter(gen, dataFormat, baseDir, null, Codec.getDefault(), null)) {
+        try (LuceneWriter writer = new LuceneWriter(gen, 0L, dataFormat, baseDir, null, Codec.getDefault(), null)) {
             assertThat(writer.generation(), equalTo(gen));
 
             LuceneDocumentInput input = new LuceneDocumentInput();
@@ -149,7 +149,7 @@ public class LuceneWriterTests extends OpenSearchTestCase {
     public void testKeywordFieldsAreIndexed() throws IOException {
         Path baseDir = createTempDir();
         MappedFieldType keywordField = mockKeywordField("status");
-        try (LuceneWriter writer = new LuceneWriter(1L, dataFormat, baseDir, null, Codec.getDefault(), null)) {
+        try (LuceneWriter writer = new LuceneWriter(1L, 0L, dataFormat, baseDir, null, Codec.getDefault(), null)) {
             LuceneDocumentInput input = new LuceneDocumentInput();
             input.addField(keywordField, "active");
             input.setRowId(LuceneDocumentInput.ROW_ID_FIELD, 0);
@@ -171,7 +171,7 @@ public class LuceneWriterTests extends OpenSearchTestCase {
         when(numericField.typeName()).thenReturn("integer");
         when(numericField.name()).thenReturn("count");
 
-        try (LuceneWriter writer = new LuceneWriter(1L, dataFormat, baseDir, null, Codec.getDefault(), null)) {
+        try (LuceneWriter writer = new LuceneWriter(1L, 0L, dataFormat, baseDir, null, Codec.getDefault(), null)) {
             LuceneDocumentInput input = new LuceneDocumentInput();
             // Should not throw — unsupported types are silently skipped (handled by other formats)
             input.addField(numericField, 42);
@@ -185,7 +185,7 @@ public class LuceneWriterTests extends OpenSearchTestCase {
         MappedFieldType textField = mockTextField("title");
         MappedFieldType keywordField = mockKeywordField("category");
 
-        try (LuceneWriter writer = new LuceneWriter(1L, dataFormat, baseDir, null, Codec.getDefault(), null)) {
+        try (LuceneWriter writer = new LuceneWriter(1L, 0L, dataFormat, baseDir, null, Codec.getDefault(), null)) {
             int numDocs = randomIntBetween(5, 15);
             for (int i = 0; i < numDocs; i++) {
                 LuceneDocumentInput input = new LuceneDocumentInput();
@@ -212,7 +212,7 @@ public class LuceneWriterTests extends OpenSearchTestCase {
         MappedFieldType keywordField = mockKeywordField("status");
         int numDocs = randomIntBetween(5, 20);
 
-        try (LuceneWriter writer = new LuceneWriter(1L, dataFormat, baseDir, null, Codec.getDefault(), null)) {
+        try (LuceneWriter writer = new LuceneWriter(1L, 0L, dataFormat, baseDir, null, Codec.getDefault(), null)) {
             for (int i = 0; i < numDocs; i++) {
                 LuceneDocumentInput input = new LuceneDocumentInput();
                 input.addField(textField, "hello world " + i);
@@ -263,8 +263,8 @@ public class LuceneWriterTests extends OpenSearchTestCase {
 
         // Create both writers without closing them until after verification,
         // because close() deletes the temp directory.
-        LuceneWriter writer1 = new LuceneWriter(gen1, dataFormat, baseDir, null, Codec.getDefault(), null);
-        LuceneWriter writer2 = new LuceneWriter(gen2, dataFormat, baseDir, null, Codec.getDefault(), null);
+        LuceneWriter writer1 = new LuceneWriter(gen1, 0L, dataFormat, baseDir, null, Codec.getDefault(), null);
+        LuceneWriter writer2 = new LuceneWriter(gen2, 0L, dataFormat, baseDir, null, Codec.getDefault(), null);
         try {
             for (int i = 0; i < numDocs1; i++) {
                 LuceneDocumentInput input = new LuceneDocumentInput();

--- a/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/CompositeDynamicMappingIT.java
+++ b/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/CompositeDynamicMappingIT.java
@@ -8,6 +8,15 @@
 
 package org.opensearch.composite;
 
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.DocValuesType;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.SortedNumericDocValues;
+import org.apache.lucene.index.SortedSetDocValues;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.NIOFSDirectory;
 import org.opensearch.action.admin.indices.create.CreateIndexResponse;
 import org.opensearch.action.admin.indices.flush.FlushResponse;
 import org.opensearch.action.admin.indices.mapping.get.GetMappingsResponse;
@@ -38,6 +47,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -85,14 +95,7 @@ public class CompositeDynamicMappingIT extends OpenSearchIntegTestCase {
      * 5. Verify all documents indexed, parquet files generated with correct segments
      */
     public void testDynamicMappingWithParquet() throws IOException {
-        Settings indexSettings = Settings.builder()
-            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
-            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
-            .put("index.pluggable.dataformat.enabled", true)
-            .put("index.pluggable.dataformat", "composite")
-            .put("index.composite.primary_data_format", "parquet")
-            .putList("index.composite.secondary_data_formats")
-            .build();
+        Settings indexSettings = parquetOnlySettings();
 
         // Create index with initial mapping
         CreateIndexResponse createResponse = client().admin()
@@ -124,22 +127,7 @@ public class CompositeDynamicMappingIT extends OpenSearchIntegTestCase {
         assertFalse("Mapping should NOT contain 'dynamic_long' yet", properties.containsKey("dynamic_long"));
 
         // Index documents with NEW dynamic fields
-        for (int i = 5; i < 10; i++) {
-            IndexResponse response = client().prepareIndex()
-                .setIndex(INDEX_NAME)
-                .setSource(
-                    "field_keyword",
-                    "value_" + i,
-                    "field_number",
-                    i,
-                    "dynamic_text",
-                    "dynamic_value_" + i,
-                    "dynamic_long",
-                    (long) i * 1000
-                )
-                .get();
-            assertEquals(RestStatus.CREATED, response.status());
-        }
+        indexDocsWithDynamicFields(INDEX_NAME, 5, 10);
 
         // Verify dynamic fields are now present in the mapping
         mappingsResponse = client().admin().indices().prepareGetMappings(INDEX_NAME).get();
@@ -156,40 +144,22 @@ public class CompositeDynamicMappingIT extends OpenSearchIntegTestCase {
         assertEquals(RestStatus.OK, flushResponse.getStatus());
 
         // Verify parquet files on disk
-        IndexShard shard = getIndexShard(
-            internalCluster().getDataNodeNames().iterator().next(),
-            new ShardId(resolveIndex(INDEX_NAME), 0),
-            INDEX_NAME
-        );
+        IndexShard shard = getIndexShard(INDEX_NAME);
         Path parquetDir = shard.shardPath().getDataPath().resolve("parquet");
         assertTrue("Parquet directory should exist", Files.isDirectory(parquetDir));
 
-        List<Path> parquetFiles;
-        try (Stream<Path> paths = Files.list(parquetDir)) {
-            parquetFiles = paths.filter(p -> p.toString().endsWith(".parquet")).collect(Collectors.toList());
-        }
+        List<Path> parquetFiles = listParquetFiles(parquetDir);
         assertFalse("Should have at least one parquet file", parquetFiles.isEmpty());
 
         // Verify row count from parquet file metadata
-        long totalRows = 0;
-        for (Path pf : parquetFiles) {
-            ParquetFileMetadata meta = RustBridge.getFileMetadata(pf.toString());
-            assertNotNull("Parquet file metadata should not be null: " + pf, meta);
-            totalRows += meta.numRows();
-        }
+        long totalRows = getParquetRowCount(parquetFiles);
         assertEquals("Total rows across parquet files should equal 10", 10, totalRows);
 
         // Verify content via readAsJson
-        List<Map<String, Object>> allRows = new ArrayList<>();
-        for (Path pf : parquetFiles) {
-            allRows.addAll(parseJsonRows(RustBridge.readAsJson(pf.toString())));
-        }
+        List<Map<String, Object>> allRows = readAllParquetRows(parquetFiles);
         assertEquals(10, allRows.size());
         // Verify dynamic fields are present in the rows that should have them
-        long rowsWithDynamicFields = allRows.stream()
-            .filter(row -> row.containsKey("dynamic_text") && row.get("dynamic_text") != null)
-            .count();
-        assertEquals("5 rows should have dynamic_text field populated", 5, rowsWithDynamicFields);
+        assertDynamicFieldCount(allRows, "dynamic_text", 5);
 
         // After flush, the writer is now immutable. Index more docs with another new dynamic field
         // to verify schema evolution across writer generations (new writer created with fresh schema).
@@ -213,40 +183,80 @@ public class CompositeDynamicMappingIT extends OpenSearchIntegTestCase {
         client().admin().indices().prepareFlush(INDEX_NAME).get();
 
         // Verify all 15 rows on disk
-        try (Stream<Path> paths = Files.list(parquetDir)) {
-            parquetFiles = paths.filter(p -> p.toString().endsWith(".parquet")).collect(Collectors.toList());
-        }
-        totalRows = 0;
-        for (Path pf : parquetFiles) {
-            totalRows += RustBridge.getFileMetadata(pf.toString()).numRows();
-        }
+        parquetFiles = listParquetFiles(parquetDir);
+        totalRows = getParquetRowCount(parquetFiles);
         assertEquals("Total rows across parquet files should equal 15", 15, totalRows);
 
         // Verify content
-        allRows.clear();
-        for (Path pf : parquetFiles) {
-            allRows.addAll(parseJsonRows(RustBridge.readAsJson(pf.toString())));
-        }
+        allRows = readAllParquetRows(parquetFiles);
         assertEquals(15, allRows.size());
-        long rowsWithExtra = allRows.stream().filter(row -> row.containsKey("dynamic_extra") && row.get("dynamic_extra") != null).count();
-        assertEquals("5 rows should have dynamic_extra field populated", 5, rowsWithExtra);
+        assertDynamicFieldCount(allRows, "dynamic_extra", 5);
 
         ensureGreen(INDEX_NAME);
+    }
+
+    /**
+     * Tests dynamic mapping with parquet primary + lucene secondary.
+     * Verifies that dynamically added fields appear in both formats.
+     *
+     * Note: The Lucene secondary writer stores inverted indexes for text/keyword fields
+     * (for search) and __row_id__ as doc values (for cross-format correlation).
+     * Numeric fields and field values are only in Parquet.
+     */
+    public void testDynamicMappingWithParquetPrimaryLuceneSecondary() throws Exception {
+        String indexName = "test-dynamic-composite";
+
+        CreateIndexResponse createResponse = client().admin()
+            .indices()
+            .prepareCreate(indexName)
+            .setSettings(parquetPrimaryLuceneSecondarySettings())
+            .setMapping("field_keyword", "type=keyword", "field_number", "type=integer")
+            .get();
+        assertTrue(createResponse.isAcknowledged());
+        ensureGreen(indexName);
+
+        // Index docs with initial schema
+        for (int i = 0; i < 5; i++) {
+            IndexResponse response = client().prepareIndex()
+                .setIndex(indexName)
+                .setSource("field_keyword", "value_" + i, "field_number", i)
+                .get();
+            assertEquals(RestStatus.CREATED, response.status());
+        }
+
+        // Index docs with dynamic fields
+        indexDocsWithDynamicFields(indexName, 5, 10);
+
+        // Refresh + flush
+        client().admin().indices().prepareRefresh(indexName).get();
+        client().admin().indices().prepareFlush(indexName).get();
+
+        // Verify parquet
+        IndexShard shard = getIndexShard(indexName);
+        Path parquetDir = shard.shardPath().getDataPath().resolve("parquet");
+        List<Path> parquetFiles = listParquetFiles(parquetDir);
+        List<Map<String, Object>> parquetRows = readAllParquetRows(parquetFiles);
+        assertEquals("Parquet should have 10 rows", 10, parquetRows.size());
+        assertDynamicFieldCount(parquetRows, "dynamic_text", 5);
+        assertDynamicFieldCount(parquetRows, "dynamic_long", 5);
+
+        // Verify lucene secondary: doc count + indexed fields present
+        Path luceneDir = shard.shardPath().resolveIndex();
+        List<Map<String, Object>> luceneRows = readAllLuceneDocs(luceneDir);
+        assertEquals("Lucene should have 10 docs", 10, luceneRows.size());
+
+        // __row_id__ should be present in all docs (only doc values field in lucene secondary)
+        long rowsWithRowId = luceneRows.stream().filter(r -> r.containsKey("__row_id__")).count();
+        assertEquals("All 10 Lucene docs should have __row_id__", 10, rowsWithRowId);
+
+        // Verify that the lucene index has the expected indexed fields (inverted index)
+        assertLuceneIndexedFieldsPresent(luceneDir, Set.of("field_keyword", "dynamic_text", "dynamic_text.keyword"));
     }
 
     public void testConflictingDynamicMappings() {
         String indexName = "test-conflict";
 
-        Settings indexSettings = Settings.builder()
-            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
-            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
-            .put("index.pluggable.dataformat.enabled", true)
-            .put("index.pluggable.dataformat", "composite")
-            .put("index.composite.primary_data_format", "parquet")
-            .putList("index.composite.secondary_data_formats")
-            .build();
-
-        CreateIndexResponse createResponse = client().admin().indices().prepareCreate(indexName).setSettings(indexSettings).get();
+        CreateIndexResponse createResponse = client().admin().indices().prepareCreate(indexName).setSettings(parquetOnlySettings()).get();
         assertTrue(createResponse.isAcknowledged());
         ensureGreen(indexName);
 
@@ -269,7 +279,82 @@ public class CompositeDynamicMappingIT extends OpenSearchIntegTestCase {
     public void testConcurrentDynamicUpdates() throws Throwable {
         String indexName = "test-concurrent";
 
-        Settings indexSettings = Settings.builder()
+        CreateIndexResponse createResponse = client().admin().indices().prepareCreate(indexName).setSettings(parquetOnlySettings()).get();
+        assertTrue(createResponse.isAcknowledged());
+        ensureGreen(indexName);
+
+        final int numThreads = 32;
+        runConcurrentIndexing(indexName, numThreads);
+
+        // Verify all 64 fields in mapping
+        assertConcurrentMappings(indexName, numThreads);
+
+        // Verify parquet content
+        IndexShard shard = getIndexShard(indexName);
+        Path parquetDir = shard.shardPath().getDataPath().resolve("parquet");
+        List<Path> parquetFiles = listParquetFiles(parquetDir);
+
+        assertEquals("Total rows should equal 64", 64, getParquetRowCount(parquetFiles));
+
+        List<Map<String, Object>> allRows = readAllParquetRows(parquetFiles);
+        assertEquals(64, allRows.size());
+        assertConcurrentFieldValues(allRows, numThreads);
+    }
+
+    /**
+     * Tests concurrent dynamic mapping updates with parquet primary + lucene secondary.
+     * Verifies both formats contain all dynamically created fields.
+     */
+    public void testConcurrentDynamicUpdatesWithLuceneSecondary() throws Throwable {
+        String indexName = "test-concurrent-composite";
+
+        CreateIndexResponse createResponse = client().admin()
+            .indices()
+            .prepareCreate(indexName)
+            .setSettings(parquetPrimaryLuceneSecondarySettings())
+            .get();
+        assertTrue(createResponse.isAcknowledged());
+        ensureGreen(indexName);
+
+        final int numThreads = 32;
+        runConcurrentIndexing(indexName, numThreads);
+
+        // Verify mappings
+        assertConcurrentMappings(indexName, numThreads);
+
+        // Verify parquet
+        IndexShard shard = getIndexShard(indexName);
+        Path parquetDir = shard.shardPath().getDataPath().resolve("parquet");
+        List<Path> parquetFiles = listParquetFiles(parquetDir);
+        assertEquals("Parquet total rows should be 64", 64, getParquetRowCount(parquetFiles));
+        List<Map<String, Object>> parquetRows = readAllParquetRows(parquetFiles);
+        assertEquals(64, parquetRows.size());
+        assertConcurrentFieldValues(parquetRows, numThreads);
+
+        // Verify lucene secondary: doc count + all dynamic fields indexed
+        Path luceneDir = shard.shardPath().resolveIndex();
+        List<Map<String, Object>> luceneRows = readAllLuceneDocs(luceneDir);
+        assertEquals("Lucene doc count should be 64", 64, luceneRows.size());
+
+        // __row_id__ present in all docs
+        long rowsWithRowId = luceneRows.stream().filter(r -> r.containsKey("__row_id__")).count();
+        assertEquals("All 64 Lucene docs should have __row_id__", 64, rowsWithRowId);
+
+        // Verify all dynamic fieldA_*/fieldB_* are indexed in Lucene
+        Set<String> expectedFields = new HashSet<>();
+        for (int i = 0; i < numThreads; i++) {
+            expectedFields.add("fieldA_" + i);
+            expectedFields.add("fieldB_" + i);
+        }
+        assertLuceneIndexedFieldsPresent(luceneDir, expectedFields);
+    }
+
+    // ══════════════════════════════════════════════════════════════════════
+    // Private helpers: index settings
+    // ══════════════════════════════════════════════════════════════════════
+
+    private Settings parquetOnlySettings() {
+        return Settings.builder()
             .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
             .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
             .put("index.pluggable.dataformat.enabled", true)
@@ -277,12 +362,43 @@ public class CompositeDynamicMappingIT extends OpenSearchIntegTestCase {
             .put("index.composite.primary_data_format", "parquet")
             .putList("index.composite.secondary_data_formats")
             .build();
+    }
 
-        CreateIndexResponse createResponse = client().admin().indices().prepareCreate(indexName).setSettings(indexSettings).get();
-        assertTrue(createResponse.isAcknowledged());
-        ensureGreen(indexName);
+    private Settings parquetPrimaryLuceneSecondarySettings() {
+        return Settings.builder()
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+            .put("index.pluggable.dataformat.enabled", true)
+            .put("index.pluggable.dataformat", "composite")
+            .put("index.composite.primary_data_format", "parquet")
+            .putList("index.composite.secondary_data_formats", "lucene")
+            .build();
+    }
 
-        final int numThreads = 32;
+    // ══════════════════════════════════════════════════════════════════════
+    // Private helpers: indexing
+    // ══════════════════════════════════════════════════════════════════════
+
+    private void indexDocsWithDynamicFields(String indexName, int from, int to) {
+        for (int i = from; i < to; i++) {
+            IndexResponse response = client().prepareIndex()
+                .setIndex(indexName)
+                .setSource(
+                    "field_keyword",
+                    "value_" + i,
+                    "field_number",
+                    i,
+                    "dynamic_text",
+                    "dynamic_value_" + i,
+                    "dynamic_long",
+                    (long) i * 1000
+                )
+                .get();
+            assertEquals(RestStatus.CREATED, response.status());
+        }
+    }
+
+    private void runConcurrentIndexing(String indexName, int numThreads) throws Throwable {
         final Thread[] indexThreads = new Thread[numThreads];
         final CountDownLatch startLatch = new CountDownLatch(1);
         final AtomicReference<Throwable> error = new AtomicReference<>();
@@ -311,63 +427,47 @@ public class CompositeDynamicMappingIT extends OpenSearchIntegTestCase {
             throw error.get();
         }
 
-        // Final refresh + flush to ensure everything is on disk
+        // Final refresh + flush
         client().admin().indices().prepareRefresh(indexName).get();
         client().admin().indices().prepareFlush(indexName).get();
+    }
 
-        // Verify all 64 fields (32 fieldA + 32 fieldB) in mapping
-        GetMappingsResponse mappings = client().admin().indices().prepareGetMappings(indexName).get();
-        Map<String, Object> mappingSource = mappings.getMappings().get(indexName).sourceAsMap();
-        @SuppressWarnings("unchecked")
-        Map<String, Object> properties = (Map<String, Object>) mappingSource.get("properties");
-        for (int i = 0; i < numThreads; i++) {
-            assertTrue("Mapping should contain fieldA_" + i, properties.containsKey("fieldA_" + i));
-            assertTrue("Mapping should contain fieldB_" + i, properties.containsKey("fieldB_" + i));
-        }
+    // ══════════════════════════════════════════════════════════════════════
+    // Private helpers: shard access
+    // ══════════════════════════════════════════════════════════════════════
 
-        // Read parquet files and verify content
-        IndexShard shard = getIndexShard(
-            internalCluster().getDataNodeNames().iterator().next(),
-            new ShardId(resolveIndex(indexName), 0),
-            indexName
-        );
-        Path parquetDir = shard.shardPath().getDataPath().resolve("parquet");
+    private IndexShard getIndexShard(String indexName) {
+        return getIndexShard(internalCluster().getDataNodeNames().iterator().next(), new ShardId(resolveIndex(indexName), 0), indexName);
+    }
+
+    // ══════════════════════════════════════════════════════════════════════
+    // Private helpers: parquet verification
+    // ══════════════════════════════════════════════════════════════════════
+
+    private List<Path> listParquetFiles(Path parquetDir) throws IOException {
         assertTrue("Parquet directory should exist", Files.isDirectory(parquetDir));
-
-        List<Path> parquetFiles;
         try (Stream<Path> paths = Files.list(parquetDir)) {
-            parquetFiles = paths.filter(p -> p.toString().endsWith(".parquet")).collect(Collectors.toList());
+            return paths.filter(p -> p.toString().endsWith(".parquet")).collect(Collectors.toList());
         }
+    }
 
-        // Verify row count
+    private long getParquetRowCount(List<Path> parquetFiles) throws IOException {
         long totalRows = 0;
         for (Path pf : parquetFiles) {
-            totalRows += RustBridge.getFileMetadata(pf.toString()).numRows();
+            ParquetFileMetadata meta = RustBridge.getFileMetadata(pf.toString());
+            assertNotNull("Parquet file metadata should not be null: " + pf, meta);
+            totalRows += meta.numRows();
         }
-        assertEquals("Total rows should equal 64 (32 threads * 2 docs each)", 64, totalRows);
+        return totalRows;
+    }
 
-        // Verify content
+    @SuppressForbidden(reason = "JSON parsing for test verification of parquet output")
+    private List<Map<String, Object>> readAllParquetRows(List<Path> parquetFiles) throws IOException {
         List<Map<String, Object>> allRows = new ArrayList<>();
         for (Path pf : parquetFiles) {
             allRows.addAll(parseJsonRows(RustBridge.readAsJson(pf.toString())));
         }
-        assertEquals(64, allRows.size());
-
-        // Verify each fieldA_{i} and fieldB_{i} has its value in exactly one row
-        Set<String> foundA = new HashSet<>();
-        Set<String> foundB = new HashSet<>();
-        for (Map<String, Object> row : allRows) {
-            for (int i = 0; i < numThreads; i++) {
-                if (("valueA_" + i).equals(row.get("fieldA_" + i))) {
-                    foundA.add("fieldA_" + i);
-                }
-                if (("valueB_" + i).equals(row.get("fieldB_" + i))) {
-                    foundB.add("fieldB_" + i);
-                }
-            }
-        }
-        assertEquals("All 32 fieldA values should be in parquet", numThreads, foundA.size());
-        assertEquals("All 32 fieldB values should be in parquet", numThreads, foundB.size());
+        return allRows;
     }
 
     @SuppressWarnings("unchecked")
@@ -381,6 +481,98 @@ public class CompositeDynamicMappingIT extends OpenSearchIntegTestCase {
             )
         ) {
             return parser.list().stream().map(o -> (Map<String, Object>) o).collect(Collectors.toList());
+        }
+    }
+
+    // ══════════════════════════════════════════════════════════════════════
+    // Private helpers: lucene verification
+    // ══════════════════════════════════════════════════════════════════════
+
+    /**
+     * Reads all documents from a Lucene index directory, extracting doc values fields
+     * into a list of maps (one map per document).
+     */
+    private List<Map<String, Object>> readAllLuceneDocs(Path luceneDir) throws IOException {
+        List<Map<String, Object>> rows = new ArrayList<>();
+        try (Directory dir = NIOFSDirectory.open(luceneDir); DirectoryReader reader = DirectoryReader.open(dir)) {
+            for (LeafReaderContext ctx : reader.leaves()) {
+                LeafReader leaf = ctx.reader();
+                for (int doc = 0; doc < leaf.maxDoc(); doc++) {
+                    Map<String, Object> row = new HashMap<>();
+                    for (FieldInfo fi : leaf.getFieldInfos()) {
+                        if (fi.getDocValuesType() == DocValuesType.SORTED_NUMERIC) {
+                            SortedNumericDocValues dv = leaf.getSortedNumericDocValues(fi.name);
+                            if (dv != null && dv.advanceExact(doc)) {
+                                row.put(fi.name, dv.nextValue());
+                            }
+                        } else if (fi.getDocValuesType() == DocValuesType.SORTED_SET) {
+                            SortedSetDocValues dv = leaf.getSortedSetDocValues(fi.name);
+                            if (dv != null && dv.advanceExact(doc)) {
+                                long ord = dv.nextOrd();
+                                if (ord >= 0) {
+                                    row.put(fi.name, dv.lookupOrd(ord).utf8ToString());
+                                }
+                            }
+                        }
+                    }
+                    rows.add(row);
+                }
+            }
+        }
+        return rows;
+    }
+
+    // ══════════════════════════════════════════════════════════════════════
+    // Private helpers: assertions
+    // ══════════════════════════════════════════════════════════════════════
+
+    private void assertDynamicFieldCount(List<Map<String, Object>> rows, String fieldName, long expectedCount) {
+        long count = rows.stream().filter(row -> row.containsKey(fieldName) && row.get(fieldName) != null).count();
+        assertEquals(expectedCount + " rows should have " + fieldName + " field populated", expectedCount, count);
+    }
+
+    private void assertConcurrentMappings(String indexName, int numThreads) throws IOException {
+        GetMappingsResponse mappings = client().admin().indices().prepareGetMappings(indexName).get();
+        Map<String, Object> mappingSource = mappings.getMappings().get(indexName).sourceAsMap();
+        @SuppressWarnings("unchecked")
+        Map<String, Object> properties = (Map<String, Object>) mappingSource.get("properties");
+        for (int i = 0; i < numThreads; i++) {
+            assertTrue("Mapping should contain fieldA_" + i, properties.containsKey("fieldA_" + i));
+            assertTrue("Mapping should contain fieldB_" + i, properties.containsKey("fieldB_" + i));
+        }
+    }
+
+    private void assertConcurrentFieldValues(List<Map<String, Object>> rows, int numThreads) {
+        Set<String> foundA = new HashSet<>();
+        Set<String> foundB = new HashSet<>();
+        for (Map<String, Object> row : rows) {
+            for (int i = 0; i < numThreads; i++) {
+                if (("valueA_" + i).equals(row.get("fieldA_" + i))) foundA.add("fieldA_" + i);
+                if (("valueB_" + i).equals(row.get("fieldB_" + i))) foundB.add("fieldB_" + i);
+            }
+        }
+        assertEquals("All 32 fieldA values should be present", numThreads, foundA.size());
+        assertEquals("All 32 fieldB values should be present", numThreads, foundB.size());
+    }
+
+    /**
+     * Asserts that the given fields exist in the Lucene index as indexed fields (inverted index).
+     * The Lucene secondary stores inverted indexes for search but not doc values for field values.
+     */
+    private void assertLuceneIndexedFieldsPresent(Path luceneDir, Set<String> expectedFields) throws IOException {
+        try (Directory dir = NIOFSDirectory.open(luceneDir); DirectoryReader reader = DirectoryReader.open(dir)) {
+            Set<String> allFields = new HashSet<>();
+            for (LeafReaderContext ctx : reader.leaves()) {
+                for (FieldInfo fi : ctx.reader().getFieldInfos()) {
+                    allFields.add(fi.name);
+                }
+            }
+            for (String expected : expectedFields) {
+                assertTrue(
+                    "Lucene index should contain field '" + expected + "', found fields: " + allFields,
+                    allFields.contains(expected)
+                );
+            }
         }
     }
 }

--- a/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/CompositeDynamicMappingIT.java
+++ b/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/CompositeDynamicMappingIT.java
@@ -1,0 +1,386 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.composite;
+
+import org.opensearch.action.admin.indices.create.CreateIndexResponse;
+import org.opensearch.action.admin.indices.flush.FlushResponse;
+import org.opensearch.action.admin.indices.mapping.get.GetMappingsResponse;
+import org.opensearch.action.admin.indices.refresh.RefreshResponse;
+import org.opensearch.action.index.IndexResponse;
+import org.opensearch.be.datafusion.DataFusionPlugin;
+import org.opensearch.be.lucene.LucenePlugin;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.SuppressForbidden;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.FeatureFlags;
+import org.opensearch.common.xcontent.json.JsonXContent;
+import org.opensearch.core.index.shard.ShardId;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.core.xcontent.DeprecationHandler;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.index.shard.IndexShard;
+import org.opensearch.parquet.ParquetDataFormatPlugin;
+import org.opensearch.parquet.bridge.ParquetFileMetadata;
+import org.opensearch.parquet.bridge.RustBridge;
+import org.opensearch.plugins.Plugin;
+import org.opensearch.test.OpenSearchIntegTestCase;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Integration test validating dynamic mapping support with composite parquet index.
+ * Documents with new fields (not in the original mapping) should be indexed successfully,
+ * and the resulting Parquet files should contain all fields including dynamically added ones.
+ *
+ * Requires JDK 25 and sandbox enabled. Run with:
+ * ./gradlew :sandbox:plugins:composite-engine:internalClusterTest \
+ *   --tests "*.CompositeDynamicMappingIT" \
+ *   -Dsandbox.enabled=true
+ */
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.SUITE, numDataNodes = 1)
+public class CompositeDynamicMappingIT extends OpenSearchIntegTestCase {
+
+    private static final String INDEX_NAME = "test-dynamic-mapping";
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return Arrays.asList(ParquetDataFormatPlugin.class, CompositeDataFormatPlugin.class, LucenePlugin.class, DataFusionPlugin.class);
+    }
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return Settings.builder()
+            .put(super.nodeSettings(nodeOrdinal))
+            .put(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG, true)
+            .build();
+    }
+
+    /**
+     * Tests that documents with dynamically added fields are indexed successfully
+     * into a composite parquet index. The flow is:
+     * 1. Create index with initial mapping (field_keyword, field_number)
+     * 2. Index documents matching the initial schema
+     * 3. Index documents with NEW fields not in the original mapping (dynamic mapping)
+     * 4. Refresh + flush
+     * 5. Verify all documents indexed, parquet files generated with correct segments
+     */
+    public void testDynamicMappingWithParquet() throws IOException {
+        Settings indexSettings = Settings.builder()
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+            .put("index.pluggable.dataformat.enabled", true)
+            .put("index.pluggable.dataformat", "composite")
+            .put("index.composite.primary_data_format", "parquet")
+            .putList("index.composite.secondary_data_formats")
+            .build();
+
+        // Create index with initial mapping
+        CreateIndexResponse createResponse = client().admin()
+            .indices()
+            .prepareCreate(INDEX_NAME)
+            .setSettings(indexSettings)
+            .setMapping("field_keyword", "type=keyword", "field_number", "type=integer")
+            .get();
+        assertTrue("Index creation should be acknowledged", createResponse.isAcknowledged());
+        ensureGreen(INDEX_NAME);
+
+        // Index documents with initial schema
+        for (int i = 0; i < 5; i++) {
+            IndexResponse response = client().prepareIndex()
+                .setIndex(INDEX_NAME)
+                .setSource("field_keyword", "value_" + i, "field_number", i)
+                .get();
+            assertEquals(RestStatus.CREATED, response.status());
+        }
+
+        // Verify dynamic fields are NOT yet in the mapping
+        GetMappingsResponse mappingsResponse = client().admin().indices().prepareGetMappings(INDEX_NAME).get();
+        Map<String, Object> mappingSource = mappingsResponse.mappings().get(INDEX_NAME).sourceAsMap();
+        @SuppressWarnings("unchecked")
+        Map<String, Object> properties = (Map<String, Object>) mappingSource.get("properties");
+        assertTrue("Mapping should contain initial field 'field_keyword'", properties.containsKey("field_keyword"));
+        assertTrue("Mapping should contain initial field 'field_number'", properties.containsKey("field_number"));
+        assertFalse("Mapping should NOT contain 'dynamic_text' yet", properties.containsKey("dynamic_text"));
+        assertFalse("Mapping should NOT contain 'dynamic_long' yet", properties.containsKey("dynamic_long"));
+
+        // Index documents with NEW dynamic fields
+        for (int i = 5; i < 10; i++) {
+            IndexResponse response = client().prepareIndex()
+                .setIndex(INDEX_NAME)
+                .setSource(
+                    "field_keyword",
+                    "value_" + i,
+                    "field_number",
+                    i,
+                    "dynamic_text",
+                    "dynamic_value_" + i,
+                    "dynamic_long",
+                    (long) i * 1000
+                )
+                .get();
+            assertEquals(RestStatus.CREATED, response.status());
+        }
+
+        // Verify dynamic fields are now present in the mapping
+        mappingsResponse = client().admin().indices().prepareGetMappings(INDEX_NAME).get();
+        mappingSource = mappingsResponse.mappings().get(INDEX_NAME).sourceAsMap();
+        @SuppressWarnings("unchecked")
+        Map<String, Object> updatedProperties = (Map<String, Object>) mappingSource.get("properties");
+        assertTrue("Mapping should contain dynamic field 'dynamic_text'", updatedProperties.containsKey("dynamic_text"));
+        assertTrue("Mapping should contain dynamic field 'dynamic_long'", updatedProperties.containsKey("dynamic_long"));
+
+        // Refresh and flush to produce parquet files
+        RefreshResponse refreshResponse = client().admin().indices().prepareRefresh(INDEX_NAME).get();
+        assertEquals(RestStatus.OK, refreshResponse.getStatus());
+        FlushResponse flushResponse = client().admin().indices().prepareFlush(INDEX_NAME).get();
+        assertEquals(RestStatus.OK, flushResponse.getStatus());
+
+        // Verify parquet files on disk
+        IndexShard shard = getIndexShard(
+            internalCluster().getDataNodeNames().iterator().next(),
+            new ShardId(resolveIndex(INDEX_NAME), 0),
+            INDEX_NAME
+        );
+        Path parquetDir = shard.shardPath().getDataPath().resolve("parquet");
+        assertTrue("Parquet directory should exist", Files.isDirectory(parquetDir));
+
+        List<Path> parquetFiles;
+        try (Stream<Path> paths = Files.list(parquetDir)) {
+            parquetFiles = paths.filter(p -> p.toString().endsWith(".parquet")).collect(Collectors.toList());
+        }
+        assertFalse("Should have at least one parquet file", parquetFiles.isEmpty());
+
+        // Verify row count from parquet file metadata
+        long totalRows = 0;
+        for (Path pf : parquetFiles) {
+            ParquetFileMetadata meta = RustBridge.getFileMetadata(pf.toString());
+            assertNotNull("Parquet file metadata should not be null: " + pf, meta);
+            totalRows += meta.numRows();
+        }
+        assertEquals("Total rows across parquet files should equal 10", 10, totalRows);
+
+        // Verify content via readAsJson
+        List<Map<String, Object>> allRows = new ArrayList<>();
+        for (Path pf : parquetFiles) {
+            allRows.addAll(parseJsonRows(RustBridge.readAsJson(pf.toString())));
+        }
+        assertEquals(10, allRows.size());
+        // Verify dynamic fields are present in the rows that should have them
+        long rowsWithDynamicFields = allRows.stream()
+            .filter(row -> row.containsKey("dynamic_text") && row.get("dynamic_text") != null)
+            .count();
+        assertEquals("5 rows should have dynamic_text field populated", 5, rowsWithDynamicFields);
+
+        // After flush, the writer is now immutable. Index more docs with another new dynamic field
+        // to verify schema evolution across writer generations (new writer created with fresh schema).
+        for (int i = 10; i < 15; i++) {
+            IndexResponse response = client().prepareIndex()
+                .setIndex(INDEX_NAME)
+                .setSource("field_keyword", "value_" + i, "field_number", i, "dynamic_extra", "extra_" + i)
+                .get();
+            assertEquals(RestStatus.CREATED, response.status());
+        }
+
+        // Verify new dynamic field in mapping
+        mappingsResponse = client().admin().indices().prepareGetMappings(INDEX_NAME).get();
+        mappingSource = mappingsResponse.mappings().get(INDEX_NAME).sourceAsMap();
+        @SuppressWarnings("unchecked")
+        Map<String, Object> finalProperties = (Map<String, Object>) mappingSource.get("properties");
+        assertTrue("Mapping should contain dynamic field 'dynamic_extra'", finalProperties.containsKey("dynamic_extra"));
+
+        // Refresh + flush again
+        client().admin().indices().prepareRefresh(INDEX_NAME).get();
+        client().admin().indices().prepareFlush(INDEX_NAME).get();
+
+        // Verify all 15 rows on disk
+        try (Stream<Path> paths = Files.list(parquetDir)) {
+            parquetFiles = paths.filter(p -> p.toString().endsWith(".parquet")).collect(Collectors.toList());
+        }
+        totalRows = 0;
+        for (Path pf : parquetFiles) {
+            totalRows += RustBridge.getFileMetadata(pf.toString()).numRows();
+        }
+        assertEquals("Total rows across parquet files should equal 15", 15, totalRows);
+
+        // Verify content
+        allRows.clear();
+        for (Path pf : parquetFiles) {
+            allRows.addAll(parseJsonRows(RustBridge.readAsJson(pf.toString())));
+        }
+        assertEquals(15, allRows.size());
+        long rowsWithExtra = allRows.stream().filter(row -> row.containsKey("dynamic_extra") && row.get("dynamic_extra") != null).count();
+        assertEquals("5 rows should have dynamic_extra field populated", 5, rowsWithExtra);
+
+        ensureGreen(INDEX_NAME);
+    }
+
+    public void testConflictingDynamicMappings() {
+        String indexName = "test-conflict";
+
+        Settings indexSettings = Settings.builder()
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+            .put("index.pluggable.dataformat.enabled", true)
+            .put("index.pluggable.dataformat", "composite")
+            .put("index.composite.primary_data_format", "parquet")
+            .putList("index.composite.secondary_data_formats")
+            .build();
+
+        CreateIndexResponse createResponse = client().admin().indices().prepareCreate(indexName).setSettings(indexSettings).get();
+        assertTrue(createResponse.isAcknowledged());
+        ensureGreen(indexName);
+
+        // First doc: foo inferred as long
+        client().prepareIndex(indexName).setId("1").setSource("foo", 3).get();
+
+        // Second doc: foo as text — should fail
+        try {
+            client().prepareIndex(indexName).setId("2").setSource("foo", "bar").get();
+            fail("Indexing request should have failed!");
+        } catch (Exception e) {
+            assertTrue(
+                "Expected type conflict error but got: " + e.getMessage(),
+                e.getMessage().contains("failed to parse field [foo] of type [long]")
+                    || e.getMessage().contains("mapper [foo] cannot be changed from type [long] to [text]")
+            );
+        }
+    }
+
+    public void testConcurrentDynamicUpdates() throws Throwable {
+        String indexName = "test-concurrent";
+
+        Settings indexSettings = Settings.builder()
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+            .put("index.pluggable.dataformat.enabled", true)
+            .put("index.pluggable.dataformat", "composite")
+            .put("index.composite.primary_data_format", "parquet")
+            .putList("index.composite.secondary_data_formats")
+            .build();
+
+        CreateIndexResponse createResponse = client().admin().indices().prepareCreate(indexName).setSettings(indexSettings).get();
+        assertTrue(createResponse.isAcknowledged());
+        ensureGreen(indexName);
+
+        final int numThreads = 32;
+        final Thread[] indexThreads = new Thread[numThreads];
+        final CountDownLatch startLatch = new CountDownLatch(1);
+        final AtomicReference<Throwable> error = new AtomicReference<>();
+
+        for (int i = 0; i < numThreads; i++) {
+            final int threadId = i;
+            indexThreads[i] = new Thread(() -> {
+                try {
+                    startLatch.await();
+                    client().prepareIndex(indexName).setId("a_" + threadId).setSource("fieldA_" + threadId, "valueA_" + threadId).get();
+                    Thread.sleep(1000);
+                    client().prepareIndex(indexName).setId("b_" + threadId).setSource("fieldB_" + threadId, "valueB_" + threadId).get();
+                    Thread.sleep(1000);
+                    client().admin().indices().prepareRefresh(indexName).get();
+                } catch (Exception e) {
+                    error.compareAndSet(null, e);
+                }
+            });
+            indexThreads[i].start();
+        }
+        startLatch.countDown();
+        for (Thread thread : indexThreads) {
+            thread.join();
+        }
+        if (error.get() != null) {
+            throw error.get();
+        }
+
+        // Final refresh + flush to ensure everything is on disk
+        client().admin().indices().prepareRefresh(indexName).get();
+        client().admin().indices().prepareFlush(indexName).get();
+
+        // Verify all 64 fields (32 fieldA + 32 fieldB) in mapping
+        GetMappingsResponse mappings = client().admin().indices().prepareGetMappings(indexName).get();
+        Map<String, Object> mappingSource = mappings.getMappings().get(indexName).sourceAsMap();
+        @SuppressWarnings("unchecked")
+        Map<String, Object> properties = (Map<String, Object>) mappingSource.get("properties");
+        for (int i = 0; i < numThreads; i++) {
+            assertTrue("Mapping should contain fieldA_" + i, properties.containsKey("fieldA_" + i));
+            assertTrue("Mapping should contain fieldB_" + i, properties.containsKey("fieldB_" + i));
+        }
+
+        // Read parquet files and verify content
+        IndexShard shard = getIndexShard(
+            internalCluster().getDataNodeNames().iterator().next(),
+            new ShardId(resolveIndex(indexName), 0),
+            indexName
+        );
+        Path parquetDir = shard.shardPath().getDataPath().resolve("parquet");
+        assertTrue("Parquet directory should exist", Files.isDirectory(parquetDir));
+
+        List<Path> parquetFiles;
+        try (Stream<Path> paths = Files.list(parquetDir)) {
+            parquetFiles = paths.filter(p -> p.toString().endsWith(".parquet")).collect(Collectors.toList());
+        }
+
+        // Verify row count
+        long totalRows = 0;
+        for (Path pf : parquetFiles) {
+            totalRows += RustBridge.getFileMetadata(pf.toString()).numRows();
+        }
+        assertEquals("Total rows should equal 64 (32 threads * 2 docs each)", 64, totalRows);
+
+        // Verify content
+        List<Map<String, Object>> allRows = new ArrayList<>();
+        for (Path pf : parquetFiles) {
+            allRows.addAll(parseJsonRows(RustBridge.readAsJson(pf.toString())));
+        }
+        assertEquals(64, allRows.size());
+
+        // Verify each fieldA_{i} and fieldB_{i} has its value in exactly one row
+        Set<String> foundA = new HashSet<>();
+        Set<String> foundB = new HashSet<>();
+        for (Map<String, Object> row : allRows) {
+            for (int i = 0; i < numThreads; i++) {
+                if (("valueA_" + i).equals(row.get("fieldA_" + i))) {
+                    foundA.add("fieldA_" + i);
+                }
+                if (("valueB_" + i).equals(row.get("fieldB_" + i))) {
+                    foundB.add("fieldB_" + i);
+                }
+            }
+        }
+        assertEquals("All 32 fieldA values should be in parquet", numThreads, foundA.size());
+        assertEquals("All 32 fieldB values should be in parquet", numThreads, foundB.size());
+    }
+
+    @SuppressWarnings("unchecked")
+    @SuppressForbidden(reason = "JSON parsing for test verification of parquet output")
+    private List<Map<String, Object>> parseJsonRows(String json) throws IOException {
+        try (
+            XContentParser parser = JsonXContent.jsonXContent.createParser(
+                NamedXContentRegistry.EMPTY,
+                DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
+                json
+            )
+        ) {
+            return parser.list().stream().map(o -> (Map<String, Object>) o).collect(Collectors.toList());
+        }
+    }
+}

--- a/sandbox/plugins/composite-engine/src/main/java/org/opensearch/composite/CompositeIndexingExecutionEngine.java
+++ b/sandbox/plugins/composite-engine/src/main/java/org/opensearch/composite/CompositeIndexingExecutionEngine.java
@@ -26,6 +26,7 @@ import org.opensearch.index.engine.dataformat.ReaderManagerConfig;
 import org.opensearch.index.engine.dataformat.RefreshInput;
 import org.opensearch.index.engine.dataformat.RefreshResult;
 import org.opensearch.index.engine.dataformat.Writer;
+import org.opensearch.index.engine.dataformat.WriterConfig;
 import org.opensearch.index.engine.exec.EngineReaderManager;
 import org.opensearch.index.engine.exec.Segment;
 import org.opensearch.index.engine.exec.WriterFileSet;
@@ -178,12 +179,12 @@ public class CompositeIndexingExecutionEngine implements IndexingExecutionEngine
     /**
      * Creates a {@link CompositeWriter} that fans out writes to all per-format engines.
      *
-     * @param writerGeneration the generation number for the new writer
+     * @param config the writer configuration
      * @return a composite writer bound to this engine
      */
     @Override
-    public Writer<CompositeDocumentInput> createWriter(long writerGeneration) {
-        return new CompositeWriter(this, writerGeneration);
+    public Writer<CompositeDocumentInput> createWriter(WriterConfig config) {
+        return new CompositeWriter(this, config);
     }
 
     /** {@inheritDoc} Delegates to the primary engine's merger. */

--- a/sandbox/plugins/composite-engine/src/main/java/org/opensearch/composite/CompositeWriter.java
+++ b/sandbox/plugins/composite-engine/src/main/java/org/opensearch/composite/CompositeWriter.java
@@ -92,7 +92,7 @@ class CompositeWriter implements Writer<CompositeDocumentInput> {
         Map<DataFormat, Writer<DocumentInput<?>>> secondaries = new IdentityHashMap<>();
         for (IndexingExecutionEngine<?, ?> delegate : engine.getSecondaryDelegates()) {
             Writer<DocumentInput<?>> secondary = (Writer<DocumentInput<?>>) delegate.createWriter(config);
-            assert secondary.isSchemaMutable() || secondary.mappingVersion() == this.mappingVersion : "Secondary writer mapping version ["
+            assert secondary.isSchemaMutable() && secondary.mappingVersion() >= this.mappingVersion : "Secondary writer mapping version ["
                 + secondary.mappingVersion()
                 + "] must match primary ["
                 + this.mappingVersion

--- a/sandbox/plugins/composite-engine/src/main/java/org/opensearch/composite/CompositeWriter.java
+++ b/sandbox/plugins/composite-engine/src/main/java/org/opensearch/composite/CompositeWriter.java
@@ -17,6 +17,7 @@ import org.opensearch.index.engine.dataformat.FileInfos;
 import org.opensearch.index.engine.dataformat.IndexingExecutionEngine;
 import org.opensearch.index.engine.dataformat.WriteResult;
 import org.opensearch.index.engine.dataformat.Writer;
+import org.opensearch.index.engine.dataformat.WriterConfig;
 import org.opensearch.index.engine.exec.WriterFileSet;
 
 import java.io.IOException;
@@ -47,6 +48,7 @@ class CompositeWriter implements Writer<CompositeDocumentInput> {
     private final Map<DataFormat, Writer<DocumentInput<?>>> secondaryWritersByFormat;
     private final long writerGeneration;
     private final AtomicReference<WriterState> state;
+    private long mappingVersion;
 
     /**
      * Represents the lifecycle state of a {@link CompositeWriter}.
@@ -75,20 +77,27 @@ class CompositeWriter implements Writer<CompositeDocumentInput> {
      * to the engine's writer pool.
      *
      * @param engine           the composite indexing execution engine
-     * @param writerGeneration the writer generation number
+     * @param config           the writer configuration
      */
     @SuppressWarnings("unchecked")
-    CompositeWriter(CompositeIndexingExecutionEngine engine, long writerGeneration) {
+    CompositeWriter(CompositeIndexingExecutionEngine engine, WriterConfig config) {
         this.state = new AtomicReference<>(WriterState.ACTIVE);
-        this.writerGeneration = writerGeneration;
+        this.writerGeneration = config.writerGeneration();
 
         IndexingExecutionEngine<?, ?> primaryDelegate = engine.getPrimaryDelegate();
         this.primaryFormat = primaryDelegate.getDataFormat();
-        this.primaryWriter = (Writer<DocumentInput<?>>) primaryDelegate.createWriter(writerGeneration);
+        this.primaryWriter = (Writer<DocumentInput<?>>) primaryDelegate.createWriter(config);
+        this.mappingVersion = primaryWriter.mappingVersion();
 
         Map<DataFormat, Writer<DocumentInput<?>>> secondaries = new IdentityHashMap<>();
         for (IndexingExecutionEngine<?, ?> delegate : engine.getSecondaryDelegates()) {
-            secondaries.put(delegate.getDataFormat(), (Writer<DocumentInput<?>>) delegate.createWriter(writerGeneration));
+            Writer<DocumentInput<?>> secondary = (Writer<DocumentInput<?>>) delegate.createWriter(config);
+            assert secondary.isSchemaMutable() || secondary.mappingVersion() == this.mappingVersion : "Secondary writer mapping version ["
+                + secondary.mappingVersion()
+                + "] must match primary ["
+                + this.mappingVersion
+                + "]";
+            secondaries.put(delegate.getDataFormat(), secondary);
         }
         this.secondaryWritersByFormat = Collections.unmodifiableMap(secondaries);
     }
@@ -176,6 +185,31 @@ class CompositeWriter implements Writer<CompositeDocumentInput> {
     @Override
     public long generation() {
         return getWriterGeneration();
+    }
+
+    @Override
+    public boolean isSchemaMutable() {
+        if (primaryWriter.isSchemaMutable() == false) return false;
+        for (Writer<?> w : secondaryWritersByFormat.values()) {
+            if (w.isSchemaMutable() == false) return false;
+        }
+        return true;
+    }
+
+    @Override
+    public long mappingVersion() {
+        return mappingVersion;
+    }
+
+    @Override
+    public void updateMappingVersion(long newVersion) {
+        if (newVersion > this.mappingVersion) {
+            this.mappingVersion = newVersion;
+            primaryWriter.updateMappingVersion(newVersion);
+            for (Writer<?> w : secondaryWritersByFormat.values()) {
+                w.updateMappingVersion(newVersion);
+            }
+        }
     }
 
     @Override

--- a/sandbox/plugins/composite-engine/src/test/java/org/opensearch/composite/CompositeIndexingExecutionEngineTests.java
+++ b/sandbox/plugins/composite-engine/src/test/java/org/opensearch/composite/CompositeIndexingExecutionEngineTests.java
@@ -18,6 +18,7 @@ import org.opensearch.index.engine.dataformat.DataFormat;
 import org.opensearch.index.engine.dataformat.DataFormatPlugin;
 import org.opensearch.index.engine.dataformat.DataFormatRegistry;
 import org.opensearch.index.engine.dataformat.RefreshInput;
+import org.opensearch.index.engine.dataformat.WriterConfig;
 import org.opensearch.index.engine.exec.commit.Committer;
 import org.opensearch.index.engine.exec.coord.CatalogSnapshot;
 import org.opensearch.test.OpenSearchTestCase;
@@ -159,7 +160,7 @@ public class CompositeIndexingExecutionEngineTests extends OpenSearchTestCase {
 
     public void testCreateWriterReturnsCompositeWriter() throws IOException {
         CompositeIndexingExecutionEngine engine = CompositeTestHelper.createStubEngine("lucene");
-        CompositeWriter writer = (CompositeWriter) engine.createWriter(42L);
+        CompositeWriter writer = (CompositeWriter) engine.createWriter(new WriterConfig(42L));
         assertNotNull(writer);
         assertEquals(42L, writer.getWriterGeneration());
         writer.close();

--- a/sandbox/plugins/composite-engine/src/test/java/org/opensearch/composite/CompositeTestHelper.java
+++ b/sandbox/plugins/composite-engine/src/test/java/org/opensearch/composite/CompositeTestHelper.java
@@ -28,6 +28,7 @@ import org.opensearch.index.engine.dataformat.RefreshInput;
 import org.opensearch.index.engine.dataformat.RefreshResult;
 import org.opensearch.index.engine.dataformat.WriteResult;
 import org.opensearch.index.engine.dataformat.Writer;
+import org.opensearch.index.engine.dataformat.WriterConfig;
 import org.opensearch.index.engine.exec.commit.Committer;
 import org.opensearch.index.engine.exec.commit.IndexStoreProvider;
 import org.opensearch.index.engine.exec.coord.CatalogSnapshot;
@@ -157,9 +158,12 @@ final class CompositeTestHelper {
             this.dataFormat = dataFormat;
         }
 
+        StubWriter lastCreatedWriter;
+
         @Override
-        public Writer<DocumentInput<?>> createWriter(long writerGeneration) {
-            return new StubWriter(dataFormat);
+        public Writer<DocumentInput<?>> createWriter(WriterConfig config) {
+            lastCreatedWriter = new StubWriter(dataFormat);
+            return lastCreatedWriter;
         }
 
         @Override
@@ -208,6 +212,8 @@ final class CompositeTestHelper {
 
         private final DataFormat format;
         private WriteResult resultToReturn = new WriteResult.Success(1, 1, 1);
+        private boolean schemaMutable = true;
+        private long mappingVersion = 0;
 
         StubWriter(DataFormat format) {
             this.format = format;
@@ -215,6 +221,10 @@ final class CompositeTestHelper {
 
         void setResultToReturn(WriteResult result) {
             this.resultToReturn = result;
+        }
+
+        void setSchemaMutable(boolean mutable) {
+            this.schemaMutable = mutable;
         }
 
         @Override
@@ -236,6 +246,21 @@ final class CompositeTestHelper {
         @Override
         public long generation() {
             return 0;
+        }
+
+        @Override
+        public boolean isSchemaMutable() {
+            return schemaMutable;
+        }
+
+        @Override
+        public long mappingVersion() {
+            return mappingVersion;
+        }
+
+        @Override
+        public void updateMappingVersion(long newVersion) {
+            this.mappingVersion = newVersion;
         }
     }
 

--- a/sandbox/plugins/composite-engine/src/test/java/org/opensearch/composite/CompositeWriterTests.java
+++ b/sandbox/plugins/composite-engine/src/test/java/org/opensearch/composite/CompositeWriterTests.java
@@ -9,6 +9,7 @@
 package org.opensearch.composite;
 
 import org.opensearch.index.engine.dataformat.FileInfos;
+import org.opensearch.index.engine.dataformat.WriterConfig;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.io.IOException;
@@ -28,20 +29,20 @@ public class CompositeWriterTests extends OpenSearchTestCase {
 
     public void testWriterGenerationIsPreserved() throws IOException {
         long gen = randomLongBetween(0, 1000);
-        CompositeWriter writer = new CompositeWriter(engine, gen);
+        CompositeWriter writer = new CompositeWriter(engine, new WriterConfig(gen));
         assertEquals(gen, writer.getWriterGeneration());
         writer.close();
     }
 
     public void testAbortedDefaultsToFalse() throws IOException {
-        CompositeWriter writer = new CompositeWriter(engine, 0);
+        CompositeWriter writer = new CompositeWriter(engine, new WriterConfig(0));
         assertFalse(writer.isAborted());
         assertEquals(CompositeWriter.WriterState.ACTIVE, writer.getState());
         writer.close();
     }
 
     public void testAbortSetsAbortedFlag() throws IOException {
-        CompositeWriter writer = new CompositeWriter(engine, 0);
+        CompositeWriter writer = new CompositeWriter(engine, new WriterConfig(0));
         writer.abort();
         assertTrue(writer.isAborted());
         assertEquals(CompositeWriter.WriterState.ABORTED, writer.getState());
@@ -49,14 +50,14 @@ public class CompositeWriterTests extends OpenSearchTestCase {
     }
 
     public void testFlushPendingDefaultsToFalse() throws IOException {
-        CompositeWriter writer = new CompositeWriter(engine, 0);
+        CompositeWriter writer = new CompositeWriter(engine, new WriterConfig(0));
         assertFalse(writer.isFlushPending());
         assertEquals(CompositeWriter.WriterState.ACTIVE, writer.getState());
         writer.close();
     }
 
     public void testSetFlushPendingSetsFlag() throws IOException {
-        CompositeWriter writer = new CompositeWriter(engine, 0);
+        CompositeWriter writer = new CompositeWriter(engine, new WriterConfig(0));
         writer.setFlushPending();
         assertTrue(writer.isFlushPending());
         assertEquals(CompositeWriter.WriterState.FLUSH_PENDING, writer.getState());
@@ -64,7 +65,7 @@ public class CompositeWriterTests extends OpenSearchTestCase {
     }
 
     public void testAbortDoesNotTransitionFromFlushPending() throws IOException {
-        CompositeWriter writer = new CompositeWriter(engine, 0);
+        CompositeWriter writer = new CompositeWriter(engine, new WriterConfig(0));
         writer.setFlushPending();
         expectThrows(IllegalStateException.class, writer::abort);
         assertTrue(writer.isFlushPending());
@@ -73,7 +74,7 @@ public class CompositeWriterTests extends OpenSearchTestCase {
     }
 
     public void testFlushPendingDoesNotTransitionFromAborted() throws IOException {
-        CompositeWriter writer = new CompositeWriter(engine, 0);
+        CompositeWriter writer = new CompositeWriter(engine, new WriterConfig(0));
         writer.abort();
         expectThrows(IllegalStateException.class, writer::setFlushPending);
         assertTrue(writer.isAborted());
@@ -82,22 +83,48 @@ public class CompositeWriterTests extends OpenSearchTestCase {
     }
 
     public void testFlushReturnsFileInfos() throws IOException {
-        CompositeWriter writer = new CompositeWriter(engine, 0);
+        CompositeWriter writer = new CompositeWriter(engine, new WriterConfig(0));
         FileInfos fileInfos = writer.flush();
         assertNotNull(fileInfos);
         writer.close();
     }
 
     public void testSyncDoesNotThrow() throws IOException {
-        CompositeWriter writer = new CompositeWriter(engine, 0);
+        CompositeWriter writer = new CompositeWriter(engine, new WriterConfig(0));
         writer.sync();
         writer.close();
     }
 
     public void testCloseDoesNotThrow() throws IOException {
-        CompositeWriter writer = new CompositeWriter(engine, 0);
+        CompositeWriter writer = new CompositeWriter(engine, new WriterConfig(0));
         writer.close();
         // calling close again should also not throw
+        writer.close();
+    }
+
+    public void testMappingVersionSetAtConstruction() throws IOException {
+        CompositeWriter writer = new CompositeWriter(engine, new WriterConfig(0));
+        assertEquals(0L, writer.mappingVersion());
+        writer.close();
+    }
+
+    public void testUpdateMappingVersionPropagates() throws IOException {
+        CompositeWriter writer = new CompositeWriter(engine, new WriterConfig(0));
+        writer.updateMappingVersion(5L);
+        assertEquals(5L, writer.mappingVersion());
+        writer.close();
+    }
+
+    public void testIsSchemaMutableReturnsFalseWhenAnySubWriterImmutable() throws IOException {
+        CompositeWriter writer = new CompositeWriter(engine, new WriterConfig(0));
+        assertTrue(writer.isSchemaMutable());
+
+        // Make the primary sub-writer immutable
+        CompositeTestHelper.StubIndexingExecutionEngine primaryEngine = (CompositeTestHelper.StubIndexingExecutionEngine) engine
+            .getPrimaryDelegate();
+        primaryEngine.lastCreatedWriter.setSchemaMutable(false);
+        assertFalse(writer.isSchemaMutable());
+
         writer.close();
     }
 

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/ParquetDataFormatPlugin.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/ParquetDataFormatPlugin.java
@@ -28,7 +28,6 @@ import org.opensearch.index.engine.dataformat.StoreStrategy;
 import org.opensearch.index.store.PrecomputedChecksumStrategy;
 import org.opensearch.parquet.engine.ParquetDataFormat;
 import org.opensearch.parquet.engine.ParquetIndexingEngine;
-import org.opensearch.parquet.fields.ArrowSchemaBuilder;
 import org.opensearch.parquet.store.ParquetStoreStrategy;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.repositories.RepositoriesService;
@@ -103,7 +102,7 @@ public class ParquetDataFormatPlugin extends Plugin implements DataFormatPlugin 
             settings,
             PARQUET_DATA_FORMAT,
             engineConfig.store().shardPath(),
-            () -> ArrowSchemaBuilder.getSchema(engineConfig.mapperService()),
+            engineConfig.mapperService(),
             engineConfig.indexSettings(),
             threadPool,
             engineConfig.checksumStrategies().get(ParquetDataFormat.PARQUET_DATA_FORMAT_NAME)

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/bridge/NativeParquetWriter.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/bridge/NativeParquetWriter.java
@@ -18,7 +18,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
  *
  * <p>Wraps the stateless JNI methods in {@link RustBridge} with a file-scoped lifecycle:
  * <ol>
- *   <li>{@code new NativeParquetWriter(filePath, indexName, schemaAddress, sortConfig, writerGeneration)} — creates the native writer</li>
+ *   <li>{@code new NativeParquetWriter(filePath)} — creates the handle (no native call)</li>
+ *   <li>{@link #initialize(String, long, ParquetSortConfig, long)} — creates the native writer with the final schema</li>
  *   <li>{@link #write(long, long)} — sends one or more Arrow batches (repeatable)</li>
  *   <li>{@link #flush()} — finalizes the Parquet file and returns metadata</li>
  *   <li>{@link #sync()} — fsyncs the file to durable storage (calls flush if needed)</li>
@@ -32,21 +33,44 @@ public class NativeParquetWriter {
     private final AtomicBoolean writerFlushed = new AtomicBoolean(false);
     private final String filePath;
     private final SetOnce<ParquetFileMetadata> metadata = new SetOnce<>();
+    private volatile boolean initialized = false;
 
     /**
-     * Creates a new NativeParquetWriter.
+     * Creates a new NativeParquetWriter handle. Does not create the native writer —
+     * call {@link #initialize(String, long, ParquetSortConfig, long)} before the first write.
      *
-     * @param filePath          the path to the Parquet file to write
+     * @param filePath the path to the Parquet file to write
+     */
+    public NativeParquetWriter(String filePath) {
+        this.filePath = filePath;
+    }
+
+    /**
+     * Initializes the native Rust Parquet writer with the given schema.
+     * Must be called exactly once before the first {@link #write}.
+     *
      * @param indexName         the index name for settings lookup
      * @param schemaAddress     the native memory address of the Arrow schema
      * @param sortConfig        the sort configuration for the Parquet file
      * @param writerGeneration  the writer generation to store in file metadata
      * @throws IOException if the native writer creation fails
+     * @throws IllegalStateException if already initialized
      */
-    public NativeParquetWriter(String filePath, String indexName, long schemaAddress, ParquetSortConfig sortConfig, long writerGeneration)
-        throws IOException {
-        this.filePath = filePath;
+    public void initialize(String indexName, long schemaAddress, ParquetSortConfig sortConfig, long writerGeneration) throws IOException {
+        if (initialized) {
+            throw new IllegalStateException("Writer already initialized: " + filePath);
+        }
         RustBridge.createWriter(filePath, indexName, schemaAddress, sortConfig, writerGeneration);
+        initialized = true;
+    }
+
+    /**
+     * Returns whether the native writer has been initialized.
+     *
+     * @return true if {@link #initialize} has been called
+     */
+    public boolean isInitialized() {
+        return initialized;
     }
 
     /**
@@ -55,23 +79,31 @@ public class NativeParquetWriter {
      * @param arrayAddress  the native memory address of the Arrow array
      * @param schemaAddress the native memory address of the Arrow schema
      * @throws IOException if the write fails or the writer is flushed
+     * @throws IllegalStateException if the writer has not been initialized
      */
     public void write(long arrayAddress, long schemaAddress) throws IOException {
         if (writerFlushed.get()) {
             throw new IOException("Cannot write to flushed Parquet writer: " + filePath);
         }
+        if (initialized == false) {
+            throw new IllegalStateException("Writer not initialized: " + filePath);
+        }
         RustBridge.write(filePath, arrayAddress, schemaAddress);
     }
 
     /**
-     * Finalizes the Parquet file and returns metadata.
+     * Finalizes the Parquet file and returns metadata. If the writer was never initialized
+     * (no documents were written), returns null rather than throwing — this is expected
+     * when a writer is flushed during refresh without having received any documents.
      *
-     * @return the file metadata
+     * @return the file metadata, or null if the writer was never initialized
      * @throws IOException if the finalization fails
      */
     public ParquetFileMetadata flush() throws IOException {
         if (writerFlushed.compareAndSet(false, true)) {
-            metadata.set(RustBridge.finalizeWriter(filePath));
+            if (initialized) {
+                metadata.set(RustBridge.finalizeWriter(filePath));
+            }
         }
         return metadata.get();
     }

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/engine/ParquetIndexingEngine.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/engine/ParquetIndexingEngine.java
@@ -18,14 +18,17 @@ import org.opensearch.index.engine.dataformat.Merger;
 import org.opensearch.index.engine.dataformat.RefreshInput;
 import org.opensearch.index.engine.dataformat.RefreshResult;
 import org.opensearch.index.engine.dataformat.Writer;
+import org.opensearch.index.engine.dataformat.WriterConfig;
 import org.opensearch.index.engine.exec.Segment;
 import org.opensearch.index.engine.exec.commit.IndexStoreProvider;
+import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.shard.ShardPath;
 import org.opensearch.index.store.FormatChecksumStrategy;
 import org.opensearch.index.store.PrecomputedChecksumStrategy;
 import org.opensearch.parquet.ParquetSettings;
 import org.opensearch.parquet.bridge.NativeSettings;
 import org.opensearch.parquet.bridge.RustBridge;
+import org.opensearch.parquet.fields.ArrowSchemaBuilder;
 import org.opensearch.parquet.memory.ArrowBufferPool;
 import org.opensearch.parquet.merge.NativeParquetMergeStrategy;
 import org.opensearch.parquet.merge.ParquetMergeExecutor;
@@ -42,7 +45,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Supplier;
 
 import static org.opensearch.parquet.ParquetDataFormatPlugin.PARQUET_DATA_FORMAT;
 
@@ -72,7 +74,9 @@ public class ParquetIndexingEngine implements IndexingExecutionEngine<ParquetDat
 
     private final ParquetDataFormat dataFormat;
     private final ShardPath shardPath;
-    private final Supplier<Schema> schemaSupplier;
+    private final MapperService mapperService;
+    private volatile long cachedSchemaVersion = -1;
+    private volatile Schema cachedSchema;
     private final ArrowBufferPool bufferPool;
     private final IndexSettings indexSettings;
     private final Settings nodeSettings;
@@ -86,7 +90,7 @@ public class ParquetIndexingEngine implements IndexingExecutionEngine<ParquetDat
      * @param settings          the node-level settings
      * @param dataFormat        the Parquet data format descriptor
      * @param shardPath         the shard path for file storage
-     * @param schemaSupplier    supplier for the Arrow schema
+     * @param mapperService     the mapper service for schema resolution
      * @param indexSettings     the index-level settings
      * @param threadPool        the thread pool for background native writes
      */
@@ -94,24 +98,20 @@ public class ParquetIndexingEngine implements IndexingExecutionEngine<ParquetDat
         Settings settings,
         ParquetDataFormat dataFormat,
         ShardPath shardPath,
-        Supplier<Schema> schemaSupplier,
+        MapperService mapperService,
         IndexSettings indexSettings,
         ThreadPool threadPool
     ) {
-        this(settings, dataFormat, shardPath, schemaSupplier, indexSettings, threadPool, new PrecomputedChecksumStrategy());
+        this(settings, dataFormat, shardPath, mapperService, indexSettings, threadPool, new PrecomputedChecksumStrategy());
     }
 
     /**
      * Creates a new ParquetIndexingEngine with an externally provided checksum strategy.
      *
-     * <p>Use this constructor when the checksum strategy is shared with the
-     * {@link org.opensearch.index.store.DataFormatAwareStoreDirectory} so that
-     * pre-computed CRC32 values registered during write are visible to the upload path.
-     *
      * @param settings          the node-level settings
      * @param dataFormat        the Parquet data format descriptor
      * @param shardPath         the shard path for file storage
-     * @param schemaSupplier    supplier for the Arrow schema
+     * @param mapperService     the mapper service for schema resolution
      * @param indexSettings     the index-level settings
      * @param threadPool        the thread pool for background native writes
      * @param checksumStrategy  the checksum strategy to use (shared with the directory)
@@ -120,14 +120,14 @@ public class ParquetIndexingEngine implements IndexingExecutionEngine<ParquetDat
         Settings settings,
         ParquetDataFormat dataFormat,
         ShardPath shardPath,
-        Supplier<Schema> schemaSupplier,
+        MapperService mapperService,
         IndexSettings indexSettings,
         ThreadPool threadPool,
         FormatChecksumStrategy checksumStrategy
     ) {
         this.dataFormat = dataFormat;
         this.shardPath = shardPath;
-        this.schemaSupplier = schemaSupplier;
+        this.mapperService = mapperService;
         this.bufferPool = new ArrowBufferPool(settings);
         this.indexSettings = indexSettings;
         this.nodeSettings = settings;
@@ -182,13 +182,16 @@ public class ParquetIndexingEngine implements IndexingExecutionEngine<ParquetDat
     }
 
     @Override
-    public Writer<ParquetDocumentInput> createWriter(long writerGeneration) {
-        Path filePath = buildParquetFilePath(shardPath, writerGeneration, null);
+    public Writer<ParquetDocumentInput> createWriter(WriterConfig config) {
+        long mappingVersion = mapperService.getIndexSettings().getIndexMetadata().getMappingVersion();
+        Schema schema = getOrBuildSchema(mappingVersion);
+        Path filePath = buildParquetFilePath(shardPath, config.writerGeneration(), null);
         return new ParquetWriter(
             filePath.toString(),
-            writerGeneration,
+            config.writerGeneration(),
+            mappingVersion,
             dataFormat,
-            schemaSupplier.get(),
+            schema,
             bufferPool,
             indexSettings,
             threadPool,
@@ -254,6 +257,15 @@ public class ParquetIndexingEngine implements IndexingExecutionEngine<ParquetDat
     @Override
     public IndexStoreProvider getProvider() {
         return null;
+    }
+
+    private Schema getOrBuildSchema(long mappingVersion) {
+        if (cachedSchemaVersion == mappingVersion && cachedSchema != null) {
+            return cachedSchema;
+        }
+        cachedSchema = ArrowSchemaBuilder.getSchema(mapperService);
+        cachedSchemaVersion = mappingVersion;
+        return cachedSchema;
     }
 
     @Override

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/ArrowSchemaBuilder.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/ArrowSchemaBuilder.java
@@ -37,23 +37,23 @@ public final class ArrowSchemaBuilder {
     /**
      * Creates an Arrow Schema from the MapperService.
      * @param mapperService the mapper service containing field mappings
+     * TODO - Get the mapping version while creating the schema
      */
     public static Schema getSchema(MapperService mapperService) {
         Objects.requireNonNull(mapperService, "MapperService cannot be null");
-        if (mapperService.documentMapper() == null) {
-            throw new IllegalStateException("DocumentMapper is not initialized");
-        }
         List<Field> fields = new ArrayList<>();
-        for (Mapper mapper : mapperService.documentMapper().mappers()) {
-            if (isUnsupportedMetadataField(mapper)) {
-                logger.debug("Skipping unsupported metadata field: [{}] of type [{}]", mapper.name(), mapper.typeName());
-                continue;
-            }
-            ParquetField parquetField = ArrowFieldRegistry.getParquetField(mapper.typeName());
-            if (parquetField != null) {
-                fields.add(new Field(mapper.name(), parquetField.getFieldType(), null));
-            } else {
-                logger.debug("No ParquetField registered for field: [{}] of type [{}]", mapper.name(), mapper.typeName());
+        if (mapperService.documentMapper() != null) {
+            for (Mapper mapper : mapperService.documentMapper().mappers()) {
+                if (isUnsupportedMetadataField(mapper)) {
+                    logger.debug("Skipping unsupported metadata field: [{}] of type [{}]", mapper.name(), mapper.typeName());
+                    continue;
+                }
+                ParquetField parquetField = ArrowFieldRegistry.getParquetField(mapper.typeName());
+                if (parquetField != null) {
+                    fields.add(new Field(mapper.name(), parquetField.getFieldType(), null));
+                } else {
+                    logger.debug("No ParquetField registered for field: [{}] of type [{}]", mapper.name(), mapper.typeName());
+                }
             }
         }
         // Add row ID field (long)

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/vsr/ManagedVSR.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/vsr/ManagedVSR.java
@@ -20,7 +20,9 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.nativebridge.spi.ArrowExport;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -46,7 +48,7 @@ public class ManagedVSR implements AutoCloseable {
     private static final Logger logger = LogManager.getLogger(ManagedVSR.class);
 
     private final String id;
-    private final VectorSchemaRoot vsr;
+    private VectorSchemaRoot vsr;
     private final BufferAllocator allocator;
     private final AtomicReference<VSRState> state = new AtomicReference<>(VSRState.ACTIVE);
     private final Map<String, FieldVector> fields = new HashMap<>();
@@ -134,6 +136,35 @@ public class ManagedVSR implements AutoCloseable {
      */
     public VSRState getState() {
         return state.get();
+    }
+
+    /**
+     * Dynamically adds a new field to this VSR. Creates the vector using the internal
+     * allocator and appends it to the schema. Only allowed in ACTIVE state.
+     *
+     * @param field the Arrow field descriptor
+     */
+    public void addFieldVector(Field field) {
+        if (state.get() != VSRState.ACTIVE) {
+            throw new IllegalStateException("Cannot add field to VSR in state: " + state.get());
+        }
+        FieldVector vector = field.createVector(allocator);
+        List<FieldVector> vectors = new ArrayList<>(vsr.getFieldVectors());
+        vectors.add(vector);
+        List<Field> newFields = new ArrayList<>(vsr.getSchema().getFields());
+        newFields.add(field);
+        int rowCount = vsr.getRowCount();
+        vsr = new VectorSchemaRoot(newFields, vectors, rowCount);
+        fields.put(field.getName(), vector);
+    }
+
+    /**
+     * Returns the current Arrow schema of this VSR.
+     *
+     * @return the schema
+     */
+    public Schema getSchema() {
+        return vsr.getSchema();
     }
 
     /**

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/vsr/VSRManager.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/vsr/VSRManager.java
@@ -10,6 +10,8 @@ package org.opensearch.parquet.vsr;
 
 import org.apache.arrow.c.ArrowSchema;
 import org.apache.arrow.vector.BigIntVector;
+import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -116,7 +118,7 @@ public class VSRManager implements AutoCloseable {
         this.threadPool = threadPool;
         this.vsrRotationThread = runAsync ? ParquetDataFormatPlugin.PARQUET_THREAD_POOL_NAME : ThreadPool.Names.SAME;
         this.managedVSR.set(vsrPool.getActiveVSR());
-        initializeWriter();
+        this.writer = new NativeParquetWriter(fileName);
     }
 
     /**
@@ -127,13 +129,20 @@ public class VSRManager implements AutoCloseable {
      * @param doc the document input containing field-value pairs
      */
     public void addDocument(ParquetDocumentInput doc) throws IOException {
-        maybeRotateActiveVSR();
         ManagedVSR activeVSR = managedVSR.get();
         for (FieldValuePair pair : doc.getFinalInput()) {
             MappedFieldType fieldType = pair.getFieldType();
             ParquetField parquetField = ArrowFieldRegistry.getParquetField(fieldType.typeName());
             if (parquetField == null) {
                 continue;
+            }
+            // Dynamic field vector addition: create vector if not present in VSR
+            FieldVector vector = activeVSR.getVector(fieldType.name());
+            if (vector == null) {
+                Field field = new Field(fieldType.name(), parquetField.getFieldType(), null);
+                activeVSR.addFieldVector(field);
+                // Update pool schema so future VSRs include this field
+                vsrPool.updateSchema(activeVSR.getSchema());
             }
             parquetField.createField(fieldType, activeVSR, pair.getValue());
         }
@@ -143,6 +152,7 @@ public class VSRManager implements AutoCloseable {
             rowIdVector.setSafe(rowIndex, doc.getRowId());
         }
         activeVSR.setRowCount(rowIndex + 1);
+        maybeRotateActiveVSR();
     }
 
     /**
@@ -160,10 +170,13 @@ public class VSRManager implements AutoCloseable {
         ManagedVSR frozenVSR = vsrPool.getFrozenVSR();
         if (frozenVSR != null) {
             logger.debug("Writing frozen VSR {} ({} rows) for {}", frozenVSR.getId(), frozenVSR.getRowCount(), fileName);
+            maybeInitializeWriter(frozenVSR);
             Runnable writeTask = () -> {
-                try (ArrowExport export = frozenVSR.exportToArrow()) {
-                    rowCount.add(frozenVSR.getRowCount());
-                    writer.write(export.getArrayAddress(), export.getSchemaAddress());
+                try {
+                    try (ArrowExport export = frozenVSR.exportToArrow()) {
+                        rowCount.add(frozenVSR.getRowCount());
+                        writer.write(export.getArrayAddress(), export.getSchemaAddress());
+                    }
                 } catch (IOException e) {
                     throw new RuntimeException(e);
                 }
@@ -191,6 +204,7 @@ public class VSRManager implements AutoCloseable {
         if (currentVSR != null && currentVSR.getRowCount() > 0) {
             logger.info("Flushing {} rows for {}", currentVSR.getRowCount(), fileName);
             currentVSR.moveToFrozen();
+            maybeInitializeWriter(currentVSR);
             try (ArrowExport export = currentVSR.exportToArrow()) {
                 rowCount.add(currentVSR.getRowCount());
                 writer.write(export.getArrayAddress(), export.getSchemaAddress());
@@ -199,7 +213,7 @@ public class VSRManager implements AutoCloseable {
             managedVSR.set(null);
         }
         ParquetFileMetadata metadata = writer.flush();
-        assert metadata.numRows() == rowCount.sum() : "Row count mismatch between Java managed VSR and Rust writer";
+        assert metadata == null || metadata.numRows() == rowCount.sum() : "Row count mismatch between Java managed VSR and Rust writer";
         logger.debug("Flush completed for {} with metadata: {}", fileName, metadata);
         return metadata;
     }
@@ -227,18 +241,16 @@ public class VSRManager implements AutoCloseable {
         }
     }
 
-    private void initializeWriter() {
-        ParquetSortConfig sortConfig = new ParquetSortConfig(indexSettings);
-        String indexName = indexSettings.getIndex().getName();
-
-        ArrowSchema arrowSchema = managedVSR.get().exportSchema();
-        try {
-            writer = new NativeParquetWriter(fileName, indexName, arrowSchema.memoryAddress(), sortConfig, writerGeneration);
-        } catch (Exception e) {
-            throw new RuntimeException("Failed to initialize Parquet writer: " + e.getMessage(), e);
-        } finally {
-            arrowSchema.release();
-            arrowSchema.close();
+    /**
+     * Initializes the native writer on first use, using the schema from the given VSR.
+     */
+    private void maybeInitializeWriter(ManagedVSR vsr) throws IOException {
+        if (writer.isInitialized() == false) {
+            String indexName = indexSettings.getIndex().getName();
+            ParquetSortConfig sortConfig = new ParquetSortConfig(indexSettings);
+            try (ArrowSchema schema = vsr.exportSchema()) {
+                writer.initialize(indexName, schema.memoryAddress(), sortConfig, writerGeneration);
+            }
         }
     }
 
@@ -269,6 +281,15 @@ public class VSRManager implements AutoCloseable {
         } finally {
             pendingWrite = null;
         }
+    }
+
+    /**
+     * Returns whether the schema can still evolve (native writer not yet initialized).
+     *
+     * @return true if the schema is mutable
+     */
+    public boolean isSchemaMutable() {
+        return writer.isInitialized() == false;
     }
 
     // Visible for testing only

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/vsr/VSRPool.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/vsr/VSRPool.java
@@ -34,7 +34,7 @@ public class VSRPool implements AutoCloseable {
 
     private static final Logger logger = LogManager.getLogger(VSRPool.class);
 
-    private final Schema schema;
+    private volatile Schema schema;
     private final ArrowBufferPool bufferPool;
     private final String poolId;
     private final AtomicReference<ManagedVSR> activeVSR;
@@ -168,6 +168,16 @@ public class VSRPool implements AutoCloseable {
         String vsrId = poolId + "-vsr-" + vsrCounter.incrementAndGet();
         BufferAllocator allocator = bufferPool.createChildAllocator(vsrId);
         return new ManagedVSR(vsrId, schema, allocator);
+    }
+
+    /**
+     * Updates the schema used for creating new VSRs. Called when dynamic fields
+     * are added to the active VSR so that subsequent VSRs include those fields.
+     *
+     * @param newSchema the updated schema
+     */
+    public void updateSchema(Schema newSchema) {
+        this.schema = newSchema;
     }
 
     private void freezeVSR(ManagedVSR vsr) {

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/writer/ParquetWriter.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/writer/ParquetWriter.java
@@ -45,12 +45,14 @@ public class ParquetWriter implements Writer<ParquetDocumentInput> {
     private final ParquetDataFormat dataFormat;
     private final VSRManager vsrManager;
     private final FormatChecksumStrategy checksumStrategy;
+    private long mappingVersion;
 
     /**
      * Creates a new ParquetWriter.
      *
      * @param file output Parquet file path
      * @param writerGeneration generation number for this writer
+     * @param mappingVersion the initial mapping version
      * @param dataFormat the Parquet data format instance
      * @param schema Arrow schema for vector creation
      * @param bufferPool shared Arrow buffer pool
@@ -61,6 +63,7 @@ public class ParquetWriter implements Writer<ParquetDocumentInput> {
     public ParquetWriter(
         String file,
         long writerGeneration,
+        long mappingVersion,
         ParquetDataFormat dataFormat,
         Schema schema,
         ArrowBufferPool bufferPool,
@@ -70,6 +73,7 @@ public class ParquetWriter implements Writer<ParquetDocumentInput> {
     ) {
         this.file = file;
         this.writerGeneration = writerGeneration;
+        this.mappingVersion = mappingVersion;
         this.dataFormat = dataFormat;
         this.checksumStrategy = checksumStrategy;
         this.vsrManager = new VSRManager(
@@ -122,6 +126,23 @@ public class ParquetWriter implements Writer<ParquetDocumentInput> {
     @Override
     public long generation() {
         return writerGeneration;
+    }
+
+    @Override
+    public boolean isSchemaMutable() {
+        return vsrManager.isSchemaMutable();
+    }
+
+    @Override
+    public long mappingVersion() {
+        return mappingVersion;
+    }
+
+    @Override
+    public void updateMappingVersion(long newVersion) {
+        if (newVersion > this.mappingVersion) {
+            this.mappingVersion = newVersion;
+        }
     }
 
     @Override

--- a/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/bridge/NativeParquetWriterTests.java
+++ b/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/bridge/NativeParquetWriterTests.java
@@ -100,15 +100,21 @@ public class NativeParquetWriterTests extends OpenSearchTestCase {
 
     public void testFlushWithoutWrite() throws Exception {
         String filePath = createTempDir().resolve("close-only.parquet").toString();
-        NativeParquetWriter writer = createWriter(filePath);
-        writer.flush();
-        assertNotNull(writer.getMetadata());
-        assertEquals(0, writer.getMetadata().numRows());
+        NativeParquetWriter writer = new NativeParquetWriter(filePath);
+        ParquetFileMetadata metadata = writer.flush();
+        // Writer was never initialized, so flush returns null
+        assertNull(metadata);
     }
 
     public void testFlushIsIdempotent() throws Exception {
         String filePath = createTempDir().resolve("idempotent.parquet").toString();
         NativeParquetWriter writer = createWriter(filePath);
+
+        // Write some data first so the writer gets initialized
+        try (ArrowExport export = exportData(new int[] { 1 }, new String[] { "alice" }, new long[] { 10L })) {
+            writer.write(export.getArrayAddress(), export.getSchemaAddress());
+        }
+
         writer.flush();
         ParquetFileMetadata first = writer.getMetadata();
         writer.flush();
@@ -134,6 +140,11 @@ public class NativeParquetWriterTests extends OpenSearchTestCase {
     public void testWriteAfterFlushThrows() throws Exception {
         String filePath = createTempDir().resolve("write-after-flush.parquet").toString();
         NativeParquetWriter writer = createWriter(filePath);
+
+        // Initialize writer with a write, then flush
+        try (ArrowExport export = exportData(new int[] { 1 }, new String[] { "a" }, new long[] { 1L })) {
+            writer.write(export.getArrayAddress(), export.getSchemaAddress());
+        }
         writer.flush();
 
         try (ArrowExport export = exportData(new int[] { 1 }, new String[] { "alice" }, new long[] { 10L })) {
@@ -141,30 +152,34 @@ public class NativeParquetWriterTests extends OpenSearchTestCase {
         }
     }
 
-    public void testCreateWriterWithNonExistentDirectory() {
-        expectThrows(IOException.class, () -> {
-            try (ArrowExport export = exportSchema()) {
-                new NativeParquetWriter(
-                    "/nonexistent/dir/file.parquet",
-                    "test-index",
-                    export.getSchemaAddress(),
-                    ParquetSortConfig.empty(),
-                    0L
-                );
-            }
-        });
+    public void testCreateWriterWithNonExistentDirectory() throws Exception {
+        // Constructor is lightweight — error surfaces on initialize
+        NativeParquetWriter writer = new NativeParquetWriter("/nonexistent/dir/file.parquet");
+        try (ArrowExport export = exportSchema()) {
+            expectThrows(
+                IOException.class,
+                () -> writer.initialize("test-index", export.getSchemaAddress(), ParquetSortConfig.empty(), 0L)
+            );
+        }
     }
 
-    public void testCreateWriterWithInvalidSchemaAddress() {
+    public void testCreateWriterWithInvalidSchemaAddress() throws Exception {
         String filePath = createTempDir().resolve("bad-schema.parquet").toString();
-        expectThrows(Exception.class, () -> new NativeParquetWriter(filePath, "test-index", 0L, ParquetSortConfig.empty(), 0L));
+        NativeParquetWriter writer = new NativeParquetWriter(filePath);
+        assertFalse(writer.isInitialized());
+        expectThrows(Exception.class, () -> writer.initialize("test-index", 0L, ParquetSortConfig.empty(), 0L));
     }
 
     public void testWriteWithSchemaMismatch() throws Exception {
         String filePath = createTempDir().resolve("mismatch.parquet").toString();
         NativeParquetWriter writer = createWriter(filePath);
 
-        // Writer was created with (id:int, name:utf8, score:long), write with (other_field:int)
+        // First write initializes the writer with the correct schema
+        try (ArrowExport export = exportData(new int[] { 1 }, new String[] { "a" }, new long[] { 1L })) {
+            writer.write(export.getArrayAddress(), export.getSchemaAddress());
+        }
+
+        // Second write with mismatched schema
         try (
             ArrowExport export = exportDataWithSchema(
                 new Schema(List.of(new Field("other_field", FieldType.nullable(new ArrowType.Int(32, true)), null))),
@@ -174,10 +189,17 @@ public class NativeParquetWriterTests extends OpenSearchTestCase {
                 }
             )
         ) {
-            writer.write(export.getArrayAddress(), export.getSchemaAddress());
+            // Rust side may or may not throw on schema mismatch during write;
+            // the mismatch is detected at flush time
+            try {
+                writer.write(export.getArrayAddress(), export.getSchemaAddress());
+            } catch (IOException e) {
+                // Expected — some Rust versions detect mismatch at write time
+                return;
+            }
         }
 
-        // Flush fails — Parquet ArrowWriter detects row count mismatch between columns
+        // If write didn't throw, flush should detect the mismatch
         expectThrows(IOException.class, writer::flush);
     }
 
@@ -185,8 +207,19 @@ public class NativeParquetWriterTests extends OpenSearchTestCase {
         String filePath = createTempDir().resolve("duplicate.parquet").toString();
         NativeParquetWriter writer1 = createWriter(filePath);
 
+        // Initialize writer1 by writing data
+        try (ArrowExport export = exportData(new int[] { 1 }, new String[] { "a" }, new long[] { 1L })) {
+            writer1.write(export.getArrayAddress(), export.getSchemaAddress());
+        }
+
         // Native side rejects creating a second writer for the same file
-        expectThrows(IOException.class, () -> createWriter(filePath));
+        NativeParquetWriter writer2 = new NativeParquetWriter(filePath);
+        try (ArrowExport export = exportSchema()) {
+            expectThrows(
+                IOException.class,
+                () -> writer2.initialize("test-index", export.getSchemaAddress(), ParquetSortConfig.empty(), 0L)
+            );
+        }
 
         writer1.flush();
     }
@@ -216,7 +249,6 @@ public class NativeParquetWriterTests extends OpenSearchTestCase {
 
         writer.flush();
         assertNotNull(writer.getMetadata());
-        assertEquals(0, writer.getMetadata().numRows());
     }
 
     public void testWriteWithNullAddresses() throws Exception {
@@ -235,14 +267,14 @@ public class NativeParquetWriterTests extends OpenSearchTestCase {
         try (ArrowExport dataExport = exportData(new int[] { 1 }, new String[] { "a" }, new long[] { 1L })) {
             expectThrows(IOException.class, () -> writer.write(dataExport.getArrayAddress(), 0L));
         }
-
-        writer.flush();
     }
 
     private NativeParquetWriter createWriter(String filePath) throws Exception {
+        NativeParquetWriter writer = new NativeParquetWriter(filePath);
         try (ArrowExport export = exportSchema()) {
-            return new NativeParquetWriter(filePath, "test-index", export.getSchemaAddress(), ParquetSortConfig.empty(), 0L);
+            writer.initialize("test-index", export.getSchemaAddress(), ParquetSortConfig.empty(), 0L);
         }
+        return writer;
     }
 
     private ArrowExport exportSchema() {

--- a/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/bridge/ParquetMergeIntegrationTests.java
+++ b/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/bridge/ParquetMergeIntegrationTests.java
@@ -128,7 +128,8 @@ public class ParquetMergeIntegrationTests extends OpenSearchTestCase {
         ParquetSortConfig sortConfig = new ParquetSortConfig(List.of("timestamp"), List.of(false), List.of(false));
 
         try (ArrowExport schemaExport = exportSchema()) {
-            NativeParquetWriter writer = new NativeParquetWriter(filePath, INDEX_NAME, schemaExport.getSchemaAddress(), sortConfig, 0L);
+            NativeParquetWriter writer = new NativeParquetWriter(filePath);
+            writer.initialize(INDEX_NAME, schemaExport.getSchemaAddress(), sortConfig, 0L);
 
             try (ArrowExport dataExport = exportData(timestamps, messages)) {
                 writer.write(dataExport.getArrayAddress(), dataExport.getSchemaAddress());

--- a/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/engine/ParquetIndexingEngineTests.java
+++ b/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/engine/ParquetIndexingEngineTests.java
@@ -19,8 +19,10 @@ import org.opensearch.index.engine.dataformat.FileInfos;
 import org.opensearch.index.engine.dataformat.RefreshInput;
 import org.opensearch.index.engine.dataformat.RefreshResult;
 import org.opensearch.index.engine.dataformat.Writer;
+import org.opensearch.index.engine.dataformat.WriterConfig;
 import org.opensearch.index.mapper.KeywordFieldMapper;
 import org.opensearch.index.mapper.MappedFieldType;
+import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.mapper.NumberFieldMapper;
 import org.opensearch.index.shard.ShardPath;
 import org.opensearch.parquet.ParquetDataFormatPlugin;
@@ -37,6 +39,9 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class ParquetIndexingEngineTests extends OpenSearchTestCase {
 
@@ -78,7 +83,7 @@ public class ParquetIndexingEngineTests extends OpenSearchTestCase {
     }
 
     public void testCreateWriterAndFlush() throws Exception {
-        Writer<ParquetDocumentInput> writer = engine.createWriter(1L);
+        Writer<ParquetDocumentInput> writer = engine.createWriter(new WriterConfig(1L));
 
         for (int i = 0; i < 5; i++) {
             ParquetDocumentInput doc = engine.newDocumentInput();
@@ -97,7 +102,7 @@ public class ParquetIndexingEngineTests extends OpenSearchTestCase {
 
     public void testMultipleWriterGenerations() throws Exception {
         for (long gen = 1; gen <= 3; gen++) {
-            Writer<ParquetDocumentInput> writer = engine.createWriter(gen);
+            Writer<ParquetDocumentInput> writer = engine.createWriter(new WriterConfig(gen));
             ParquetDocumentInput doc = engine.newDocumentInput();
             doc.addField(idField, (int) gen);
             doc.addField(nameField, "user_" + gen);
@@ -156,7 +161,7 @@ public class ParquetIndexingEngineTests extends OpenSearchTestCase {
     }
 
     public void testFlushWithNoDocumentsReturnsEmpty() throws Exception {
-        Writer<ParquetDocumentInput> writer = engine.createWriter(1L);
+        Writer<ParquetDocumentInput> writer = engine.createWriter(new WriterConfig(1L));
         assertEquals(FileInfos.empty(), writer.flush());
     }
 
@@ -174,7 +179,14 @@ public class ParquetIndexingEngineTests extends OpenSearchTestCase {
                 .build();
             IndexMetadata indexMetadata = IndexMetadata.builder("test_index").settings(indexSettingsBuilder).build();
             IndexSettings indexSettings = new IndexSettings(indexMetadata, Settings.EMPTY);
-            return new ParquetIndexingEngine(Settings.EMPTY, new ParquetDataFormat(), shardPath, () -> schema, indexSettings, threadPool);
+            return new ParquetIndexingEngine(
+                Settings.EMPTY,
+                new ParquetDataFormat(),
+                shardPath,
+                createMockMapperService(schema, indexSettings),
+                indexSettings,
+                threadPool
+            );
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -196,5 +208,12 @@ public class ParquetIndexingEngineTests extends OpenSearchTestCase {
             fields.add(new Field(ft.name(), pf.getFieldType(), null));
         }
         return new Schema(fields);
+    }
+
+    private MapperService createMockMapperService(Schema schema, IndexSettings indexSettings) {
+        MapperService mapperService = mock(MapperService.class);
+        when(mapperService.documentMapper()).thenReturn(null);
+        when(mapperService.getIndexSettings()).thenReturn(indexSettings);
+        return mapperService;
     }
 }

--- a/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/vsr/ManagedVSRTests.java
+++ b/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/vsr/ManagedVSRTests.java
@@ -147,4 +147,42 @@ public class ManagedVSRTests extends OpenSearchTestCase {
         vsr.moveToFrozen();
         vsr.close();
     }
+
+    public void testAddFieldVectorAddsNewField() {
+        ManagedVSR vsr = createVSR("test-add-field");
+        vsr.addFieldVector(new Field("name", FieldType.nullable(new ArrowType.Utf8()), null));
+        assertNotNull(vsr.getVector("name"));
+        assertEquals(2, vsr.getSchema().getFields().size());
+        cleanup(vsr);
+    }
+
+    public void testAddFieldVectorPreservesExistingData() {
+        ManagedVSR vsr = createVSR("test-preserve-data");
+        IntVector vec = (IntVector) vsr.getVector("val");
+        vec.setSafe(0, 100);
+        vsr.setRowCount(1);
+        vsr.addFieldVector(new Field("name", FieldType.nullable(new ArrowType.Utf8()), null));
+        assertEquals(100, ((IntVector) vsr.getVector("val")).get(0));
+        assertEquals(1, vsr.getRowCount());
+        cleanup(vsr);
+    }
+
+    public void testAddFieldVectorThrowsOnFrozenState() {
+        ManagedVSR vsr = createVSR("test-add-frozen");
+        vsr.moveToFrozen();
+        expectThrows(IllegalStateException.class, () -> vsr.addFieldVector(new Field("x", FieldType.nullable(new ArrowType.Utf8()), null)));
+        vsr.close();
+    }
+
+    public void testGetSchemaReflectsDynamicAdditions() {
+        ManagedVSR vsr = createVSR("test-schema-dynamic");
+        vsr.addFieldVector(new Field("f1", FieldType.nullable(new ArrowType.Utf8()), null));
+        vsr.addFieldVector(new Field("f2", FieldType.nullable(new ArrowType.Int(64, true)), null));
+        assertEquals(3, vsr.getSchema().getFields().size());
+        List<String> names = vsr.getSchema().getFields().stream().map(Field::getName).collect(java.util.stream.Collectors.toList());
+        assertTrue(names.contains("val"));
+        assertTrue(names.contains("f1"));
+        assertTrue(names.contains("f2"));
+        cleanup(vsr);
+    }
 }

--- a/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/vsr/VSRManagerTests.java
+++ b/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/vsr/VSRManagerTests.java
@@ -17,6 +17,7 @@ import org.opensearch.Version;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.index.IndexSettings;
+import org.opensearch.index.mapper.KeywordFieldMapper;
 import org.opensearch.index.mapper.NumberFieldMapper;
 import org.opensearch.parquet.ParquetDataFormatPlugin;
 import org.opensearch.parquet.bridge.ParquetFileMetadata;
@@ -82,8 +83,8 @@ public class VSRManagerTests extends OpenSearchTestCase {
         String filePath = createTempDir().resolve("empty.parquet").toString();
         VSRManager manager = new VSRManager(filePath, indexSettings, schema, bufferPool, 50000, threadPool, 0L);
         ParquetFileMetadata metadata = manager.flush();
-        assertNotNull(metadata);
-        assertEquals(0, metadata.numRows());
+        // With lazy native writer init, flush returns null when no data was written
+        assertNull(metadata);
     }
 
     public void testFlushWithData() throws Exception {
@@ -284,5 +285,78 @@ public class VSRManagerTests extends OpenSearchTestCase {
 
         // Close should not throw — it should await the background write gracefully
         manager.close();
+    }
+
+    public void testAddDocumentWithUnknownFieldDynamicallyAddsVector() throws Exception {
+        String filePath = createTempDir().resolve("unknown-field.parquet").toString();
+        VSRManager manager = new VSRManager(filePath, indexSettings, schema, bufferPool, 50000, threadPool, 1L);
+
+        NumberFieldMapper.NumberFieldType valField = new NumberFieldMapper.NumberFieldType("val", NumberFieldMapper.NumberType.INTEGER);
+        KeywordFieldMapper.KeywordFieldType tagField = new KeywordFieldMapper.KeywordFieldType("tag");
+        ParquetDocumentInput doc = new ParquetDocumentInput();
+        doc.addField(valField, 42);
+        doc.addField(tagField, "hello");
+        manager.addDocument(doc);
+
+        ParquetFileMetadata metadata = manager.flush();
+        assertNotNull(metadata);
+        assertEquals(1, metadata.numRows());
+    }
+
+    public void testIsSchemaMutableBeforeAndAfterFlush() throws Exception {
+        String filePath = createTempDir().resolve("schema-mutable.parquet").toString();
+        VSRManager manager = new VSRManager(filePath, indexSettings, schema, bufferPool, 50000, threadPool, 1L);
+
+        assertTrue(manager.isSchemaMutable());
+
+        NumberFieldMapper.NumberFieldType valField = new NumberFieldMapper.NumberFieldType("val", NumberFieldMapper.NumberType.INTEGER);
+        ParquetDocumentInput doc = new ParquetDocumentInput();
+        doc.addField(valField, 1);
+        manager.addDocument(doc);
+
+        manager.flush();
+        assertFalse(manager.isSchemaMutable());
+    }
+
+    public void testSchemaUpdatePropagatesAcrossRotation() throws Exception {
+        String filePath = createTempDir().resolve("schema-rotation.parquet").toString();
+        VSRManager manager = new VSRManager(filePath, indexSettings, schema, bufferPool, 1, threadPool, 1L);
+
+        NumberFieldMapper.NumberFieldType valField = new NumberFieldMapper.NumberFieldType("val", NumberFieldMapper.NumberType.INTEGER);
+        KeywordFieldMapper.KeywordFieldType tagField = new KeywordFieldMapper.KeywordFieldType("tag");
+
+        ParquetDocumentInput doc1 = new ParquetDocumentInput();
+        doc1.addField(valField, 1);
+        doc1.addField(tagField, "a");
+        manager.addDocument(doc1);
+
+        ParquetDocumentInput doc2 = new ParquetDocumentInput();
+        doc2.addField(valField, 2);
+        doc2.addField(tagField, "b");
+        manager.addDocument(doc2);
+
+        ParquetFileMetadata metadata = manager.flush();
+        assertEquals(2, metadata.numRows());
+    }
+
+    public void testAddDocumentWithMultipleUnknownFields() throws Exception {
+        String filePath = createTempDir().resolve("multi-unknown.parquet").toString();
+        VSRManager manager = new VSRManager(filePath, indexSettings, schema, bufferPool, 50000, threadPool, 1L);
+
+        NumberFieldMapper.NumberFieldType valField = new NumberFieldMapper.NumberFieldType("val", NumberFieldMapper.NumberType.INTEGER);
+        KeywordFieldMapper.KeywordFieldType tag1Field = new KeywordFieldMapper.KeywordFieldType("tag1");
+        KeywordFieldMapper.KeywordFieldType tag2Field = new KeywordFieldMapper.KeywordFieldType("tag2");
+        KeywordFieldMapper.KeywordFieldType tag3Field = new KeywordFieldMapper.KeywordFieldType("tag3");
+
+        ParquetDocumentInput doc = new ParquetDocumentInput();
+        doc.addField(valField, 1);
+        doc.addField(tag1Field, "a");
+        doc.addField(tag2Field, "b");
+        doc.addField(tag3Field, "c");
+        manager.addDocument(doc);
+
+        ParquetFileMetadata metadata = manager.flush();
+        assertNotNull(metadata);
+        assertEquals(1, metadata.numRows());
     }
 }

--- a/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/writer/ParquetWriterTests.java
+++ b/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/writer/ParquetWriterTests.java
@@ -15,6 +15,7 @@ import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.index.engine.dataformat.FileInfos;
+import org.opensearch.index.engine.dataformat.WriteResult;
 import org.opensearch.index.mapper.KeywordFieldMapper;
 import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.index.mapper.NumberFieldMapper;
@@ -84,6 +85,56 @@ public class ParquetWriterTests extends OpenSearchTestCase {
         ParquetWriter writer = new ParquetWriter(
             filePath,
             1L,
+            1L,
+            new ParquetDataFormat(),
+            schema,
+            bufferPool,
+            indexSettings,
+            threadPool,
+            null
+        );
+
+        ParquetDocumentInput doc = new ParquetDocumentInput();
+        doc.addField(idField, 1);
+        doc.addField(nameField, "alice");
+        doc.addField(scoreField, 100L);
+        WriteResult result = writer.addDoc(doc);
+        assertTrue(result instanceof WriteResult.Success);
+        doc.close();
+        writer.flush();
+    }
+
+    public void testSingleDocumentFlush() throws Exception {
+        String filePath = createTempDir().resolve("single.parquet").toString();
+        ParquetWriter writer = new ParquetWriter(
+            filePath,
+            1L,
+            1L,
+            new ParquetDataFormat(),
+            schema,
+            bufferPool,
+            indexSettings,
+            threadPool,
+            null
+        );
+
+        ParquetDocumentInput doc = new ParquetDocumentInput();
+        doc.addField(idField, 42);
+        doc.addField(nameField, "bob");
+        doc.addField(scoreField, 500L);
+        writer.addDoc(doc);
+        doc.close();
+
+        writer.flush();
+        assertEquals(1, RustBridge.getFileMetadata(filePath).numRows());
+    }
+
+    public void testMultipleDocumentsFlush() throws Exception {
+        String filePath = createTempDir().resolve("multi.parquet").toString();
+        ParquetWriter writer = new ParquetWriter(
+            filePath,
+            1L,
+            1L,
             new ParquetDataFormat(),
             schema,
             bufferPool,
@@ -111,6 +162,23 @@ public class ParquetWriterTests extends OpenSearchTestCase {
         String filePath = createTempDir().resolve("empty.parquet").toString();
         ParquetWriter writer = new ParquetWriter(
             filePath,
+            1L,
+            1L,
+            new ParquetDataFormat(),
+            schema,
+            bufferPool,
+            indexSettings,
+            threadPool,
+            null
+        );
+        assertEquals(FileInfos.empty(), writer.flush());
+    }
+
+    public void testSyncAfterFlush() throws Exception {
+        String filePath = createTempDir().resolve("sync.parquet").toString();
+        ParquetWriter writer = new ParquetWriter(
+            filePath,
+            1L,
             1L,
             new ParquetDataFormat(),
             schema,

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/DynamicMappingSearchIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/DynamicMappingSearchIT.java
@@ -1,0 +1,241 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.qa;
+
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * End-to-end integration test for dynamic mapping with search verification.
+ * <p>
+ * Validates that documents with dynamically added fields (not in the original mapping)
+ * are correctly indexed into a composite parquet index AND are searchable via PPL
+ * through both the vanilla scan path and the indexed executor (filter delegation) path.
+ * <p>
+ * Run with:
+ * ./gradlew :sandbox:qa:analytics-engine-rest:integTest --tests "*.DynamicMappingSearchIT" -Dsandbox.enabled=true
+ */
+public class DynamicMappingSearchIT extends AnalyticsRestTestCase {
+
+    private static final String INDEX = "dynamic_mapping_search_e2e";
+
+    // ── Field name constants ────────────────────────────────────────────────
+    private static final String FIELD_NAME = "name";
+    private static final String FIELD_AGE = "age";
+    private static final String FIELD_CITY = "city";
+    private static final String FIELD_POINTS = "points";
+    private static final String FIELD_PRIORITY = "priority";
+
+    /**
+     * Full end-to-end test: 3-phase ingestion with progressive schema evolution,
+     * verifying search works correctly at each stage via both vanilla and indexed paths.
+     */
+    public void testSearchOnDynamicallyAddedFields() throws Exception {
+        createIndex();
+
+        // ── Phase 1: Initial schema (name, age) ─────────────────────────────
+        bulkIndex(docs(
+            doc("alice", 30),
+            doc("bob", 25),
+            doc("carol", 35),
+            doc("dave", 28),
+            doc("eve", 32)
+        ));
+        flush();
+
+        // Dynamic fields should NOT be in mapping yet
+        assertMappingContains(FIELD_NAME, FIELD_AGE);
+        assertMappingNotContains(FIELD_CITY, FIELD_POINTS, FIELD_PRIORITY);
+
+        assertCount("stats count() as cnt", 5);
+
+        // ── Phase 2: Dynamic fields (city, points) ──────────────────────────
+        bulkIndex(docs(
+            doc("frank", 40, "seattle", 95),
+            doc("grace", 22, "portland", 88),
+            doc("hank", 45, "seattle", 72),
+            doc("iris", 29, "portland", 91),
+            doc("jack", 33, "seattle", 85)
+        ));
+        flush();
+
+        // city and points now in mapping; priority still absent
+        assertMappingContains(FIELD_CITY, FIELD_POINTS);
+        assertMappingNotContains(FIELD_PRIORITY);
+
+        assertCount("stats count() as cnt", 10);
+        assertCount("where " + FIELD_CITY + " = 'seattle' | stats count() as cnt", 3);
+        assertCount("where " + FIELD_POINTS + " >= 90 | stats count() as cnt", 2);
+        assertValue("stats sum(" + FIELD_POINTS + ") as total", "total", 431.0);
+        assertCount("where isnull(" + FIELD_CITY + ") | stats count() as cnt", 5);
+        assertCount("where " + FIELD_AGE + " > 30 | stats count() as cnt", 5);
+
+        // ── Phase 3: Another new field (priority) ───────────────────────────
+        bulkIndex(docs(
+            doc("kate", 27, "seattle", 90, 1),
+            doc("leo", 38, "portland", 78, 2),
+            doc("mia", 31, "seattle", 94, 1)
+        ));
+        flush();
+
+        // All fields now present in mapping
+        assertMappingContains(FIELD_NAME, FIELD_AGE, FIELD_CITY, FIELD_POINTS, FIELD_PRIORITY);
+
+        assertCount("stats count() as cnt", 13);
+        assertCount("where isnotnull(" + FIELD_PRIORITY + ") | stats count() as cnt", 3);
+        assertCount("where " + FIELD_PRIORITY + " = 1 | stats count() as cnt", 2);
+        assertCount("where " + FIELD_CITY + " = 'seattle' | stats count() as cnt", 5);
+        assertValue("stats sum(" + FIELD_POINTS + ") as total", "total", 693.0);
+
+        // ── Indexed executor path (filter delegation via match()) ────────────
+        assertCount("where match(" + FIELD_NAME + ", 'kate') | stats count() as cnt", 1);
+        assertCount("where match(" + FIELD_NAME + ", 'alice') | stats count() as cnt", 1);
+        assertValue("where match(" + FIELD_NAME + ", 'hank') | stats sum(" + FIELD_POINTS + ") as total", "total", 72.0);
+        assertCount("where match(" + FIELD_CITY + ", 'seattle') | stats count() as cnt", 5);
+        assertValue("where match(" + FIELD_NAME + ", 'frank') | stats sum(" + FIELD_POINTS + ") as total", "total", 95.0);
+        assertValue("where match(" + FIELD_NAME + ", 'mia') | stats sum(" + FIELD_PRIORITY + ") as total", "total", 1.0);
+    }
+
+    // ── Document builders ───────────────────────────────────────────────────
+
+    /** Phase 1 doc: name + age only */
+    private static String doc(String name, int age) {
+        return "{\"" + FIELD_NAME + "\": \"" + name + "\", \"" + FIELD_AGE + "\": " + age + "}";
+    }
+
+    /** Phase 2 doc: name + age + city + points */
+    private static String doc(String name, int age, String city, int points) {
+        return "{\"" + FIELD_NAME + "\": \"" + name + "\", \"" + FIELD_AGE + "\": " + age
+            + ", \"" + FIELD_CITY + "\": \"" + city + "\", \"" + FIELD_POINTS + "\": " + points + "}";
+    }
+
+    /** Phase 3 doc: name + age + city + points + priority */
+    private static String doc(String name, int age, String city, int points, int priority) {
+        return "{\"" + FIELD_NAME + "\": \"" + name + "\", \"" + FIELD_AGE + "\": " + age
+            + ", \"" + FIELD_CITY + "\": \"" + city + "\", \"" + FIELD_POINTS + "\": " + points
+            + ", \"" + FIELD_PRIORITY + "\": " + priority + "}";
+    }
+
+    /** Combine docs into bulk NDJSON */
+    private static String docs(String... documents) {
+        StringBuilder sb = new StringBuilder();
+        for (String doc : documents) {
+            sb.append("{\"index\": {}}\n").append(doc).append("\n");
+        }
+        return sb.toString();
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────────
+
+    private void createIndex() throws Exception {
+        try {
+            client().performRequest(new Request("DELETE", "/" + INDEX));
+        } catch (Exception ignored) {}
+
+        String body = "{"
+            + "\"settings\": {"
+            + "  \"number_of_shards\": 1,"
+            + "  \"number_of_replicas\": 0,"
+            + "  \"index.pluggable.dataformat.enabled\": true,"
+            + "  \"index.pluggable.dataformat\": \"composite\","
+            + "  \"index.composite.primary_data_format\": \"parquet\","
+            + "  \"index.composite.secondary_data_formats\": \"lucene\""
+            + "},"
+            + "\"mappings\": {"
+            + "  \"properties\": {"
+            + "    \"" + FIELD_NAME + "\": { \"type\": \"keyword\" },"
+            + "    \"" + FIELD_AGE + "\": { \"type\": \"integer\" }"
+            + "  }"
+            + "}"
+            + "}";
+
+        Request req = new Request("PUT", "/" + INDEX);
+        req.setJsonEntity(body);
+        Map<String, Object> response = assertOkAndParse(client().performRequest(req), "Create index");
+        assertEquals(true, response.get("acknowledged"));
+
+        Request health = new Request("GET", "/_cluster/health/" + INDEX);
+        health.addParameter("wait_for_status", "green");
+        health.addParameter("timeout", "30s");
+        client().performRequest(health);
+    }
+
+    private void bulkIndex(String ndjson) throws Exception {
+        Request req = new Request("POST", "/" + INDEX + "/_bulk");
+        req.setJsonEntity(ndjson);
+        req.addParameter("refresh", "true");
+        req.setOptions(req.getOptions().toBuilder().addHeader("Content-Type", "application/x-ndjson").build());
+        Map<String, Object> response = assertOkAndParse(client().performRequest(req), "Bulk index");
+        assertEquals("Bulk indexing should have no errors", false, response.get("errors"));
+    }
+
+    private void flush() throws Exception {
+        client().performRequest(new Request("POST", "/" + INDEX + "/_flush?force=true"));
+    }
+
+    private Map<String, Object> executePPL(String ppl) throws IOException {
+        Request req = new Request("POST", "/_analytics/ppl");
+        req.setJsonEntity("{\"query\": \"" + escapeJson(ppl) + "\"}");
+        Response response = client().performRequest(req);
+        return assertOkAndParse(response, "PPL: " + ppl);
+    }
+
+    private void assertCount(String pplSuffix, int expected) throws IOException {
+        String ppl = "source = " + INDEX + " | " + pplSuffix;
+        Map<String, Object> result = executePPL(ppl);
+        @SuppressWarnings("unchecked")
+        List<List<Object>> rows = (List<List<Object>>) result.get("rows");
+        assertNotNull("Response missing 'rows' for: " + ppl, rows);
+        assertEquals("Expected 1 row for count query: " + ppl, 1, rows.size());
+        long actual = ((Number) rows.get(0).get(0)).longValue();
+        assertEquals("Count mismatch for: " + ppl, expected, actual);
+    }
+
+    private void assertValue(String pplSuffix, String column, double expected) throws IOException {
+        String ppl = "source = " + INDEX + " | " + pplSuffix;
+        Map<String, Object> result = executePPL(ppl);
+        @SuppressWarnings("unchecked")
+        List<String> columns = (List<String>) result.get("columns");
+        @SuppressWarnings("unchecked")
+        List<List<Object>> rows = (List<List<Object>>) result.get("rows");
+        assertNotNull("Response missing 'rows' for: " + ppl, rows);
+        assertEquals(1, rows.size());
+        int idx = columns.indexOf(column);
+        assertTrue("Column '" + column + "' not found in: " + columns, idx >= 0);
+        double actual = ((Number) rows.get(0).get(idx)).doubleValue();
+        assertEquals("Value mismatch for: " + ppl, expected, actual, 0.01);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> getMappingProperties() throws IOException {
+        Response response = client().performRequest(new Request("GET", "/" + INDEX + "/_mapping"));
+        Map<String, Object> map = assertOkAndParse(response, "Get mapping");
+        Map<String, Object> indexMap = (Map<String, Object>) map.get(INDEX);
+        Map<String, Object> mappings = (Map<String, Object>) indexMap.get("mappings");
+        return (Map<String, Object>) mappings.get("properties");
+    }
+
+    private void assertMappingContains(String... fields) throws IOException {
+        Map<String, Object> properties = getMappingProperties();
+        for (String field : fields) {
+            assertTrue("Mapping should contain field '" + field + "'", properties.containsKey(field));
+        }
+    }
+
+    private void assertMappingNotContains(String... fields) throws IOException {
+        Map<String, Object> properties = getMappingProperties();
+        for (String field : fields) {
+            assertFalse("Mapping should NOT contain field '" + field + "' yet", properties.containsKey(field));
+        }
+    }
+}

--- a/server/src/main/java/org/opensearch/index/engine/DataFormatAwareEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/DataFormatAwareEngine.java
@@ -44,6 +44,7 @@ import org.opensearch.index.engine.dataformat.RefreshResult;
 import org.opensearch.index.engine.dataformat.RowIdAwareWriter;
 import org.opensearch.index.engine.dataformat.WriteResult;
 import org.opensearch.index.engine.dataformat.Writer;
+import org.opensearch.index.engine.dataformat.WriterConfig;
 import org.opensearch.index.engine.dataformat.merge.DataFormatAwareMergePolicy;
 import org.opensearch.index.engine.dataformat.merge.MergeFailedEngineException;
 import org.opensearch.index.engine.dataformat.merge.MergeHandler;
@@ -286,7 +287,7 @@ public class DataFormatAwareEngine implements Indexer {
             this.writerPool = new LockablePool<>(() -> {
                 long gen = writerGenerationCounter.incrementAndGet();
                 assert gen > 0 : "writer generation must be positive but was: " + gen;
-                return DefaultLockableHolder.of(new RowIdAwareWriter<>(indexingExecutionEngine.createWriter(gen)));
+                return DefaultLockableHolder.of(new RowIdAwareWriter<>(indexingExecutionEngine.createWriter(new WriterConfig(gen))));
             }, LinkedList::new, Runtime.getRuntime().availableProcessors());
             // Create Reader managers
             // We will pass IndexStoreProvider to this, which would contain store
@@ -559,9 +560,13 @@ public class DataFormatAwareEngine implements Indexer {
 
         // Convert ParsedDocument to DocumentInput and write via the execution engine's writer
         Writer currentWriter = null;
-        DefaultLockableHolder<Writer<?>> lockedWriter = writerPool.getAndLock();
+        long mappingVersion = currentMappingVersion();
+        DefaultLockableHolder<Writer<?>> lockedWriter = writerPool.getAndLock(
+            h -> h.get().isSchemaMutable() || h.get().mappingVersion() == mappingVersion
+        );
         try {
             currentWriter = lockedWriter.get();
+            currentWriter.updateMappingVersion(mappingVersion);
             // Writer pool must never return null — it creates on demand via the supplier
             assert currentWriter != null : "writer pool returned null writer";
             assert index.seqNo() >= 0 : "seqNo must be assigned before writing but was: " + index.seqNo();
@@ -1474,6 +1479,10 @@ public class DataFormatAwareEngine implements Indexer {
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
         }
+    }
+
+    private long currentMappingVersion() {
+        return engineConfig.getMapperService().getIndexSettings().getIndexMetadata().getMappingVersion();
     }
 
     private boolean failOnTragicEvent(AlreadyClosedException ex) {

--- a/server/src/main/java/org/opensearch/index/engine/DataFormatAwareEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/DataFormatAwareEngine.java
@@ -562,7 +562,7 @@ public class DataFormatAwareEngine implements Indexer {
         Writer currentWriter = null;
         long mappingVersion = currentMappingVersion();
         DefaultLockableHolder<Writer<?>> lockedWriter = writerPool.getAndLock(
-            h -> h.get().isSchemaMutable() || h.get().mappingVersion() == mappingVersion
+            h -> h.get().isSchemaMutable() || h.get().mappingVersion() >= mappingVersion
         );
         try {
             currentWriter = lockedWriter.get();

--- a/server/src/main/java/org/opensearch/index/engine/dataformat/IndexingExecutionEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/dataformat/IndexingExecutionEngine.java
@@ -32,10 +32,10 @@ public interface IndexingExecutionEngine<T extends DataFormat, P extends Documen
     /**
      * Creates a new writer for the given writer generation.
      *
-     * @param writerGeneration the writer generation number
+     * @param config the writer configuration
      * @return a new writer instance
      */
-    Writer<P> createWriter(long writerGeneration);
+    Writer<P> createWriter(WriterConfig config);
 
     /**
      * Returns the merger for combining writer file sets.

--- a/server/src/main/java/org/opensearch/index/engine/dataformat/RowIdAwareWriter.java
+++ b/server/src/main/java/org/opensearch/index/engine/dataformat/RowIdAwareWriter.java
@@ -85,6 +85,24 @@ public class RowIdAwareWriter<P extends DocumentInput<?>> implements Writer<P> {
         return delegate.generation();
     }
 
+    /** {@inheritDoc} Delegates to the underlying writer. */
+    @Override
+    public boolean isSchemaMutable() {
+        return delegate.isSchemaMutable();
+    }
+
+    /** {@inheritDoc} Delegates to the underlying writer. */
+    @Override
+    public long mappingVersion() {
+        return delegate.mappingVersion();
+    }
+
+    /** {@inheritDoc} Delegates to the underlying writer. */
+    @Override
+    public void updateMappingVersion(long newVersion) {
+        delegate.updateMappingVersion(newVersion);
+    }
+
     /** {@inheritDoc} Closes the underlying writer. */
     @Override
     public void close() throws IOException {

--- a/server/src/main/java/org/opensearch/index/engine/dataformat/Writer.java
+++ b/server/src/main/java/org/opensearch/index/engine/dataformat/Writer.java
@@ -52,4 +52,28 @@ public interface Writer<P extends DocumentInput<?>> extends Closeable {
      * @return the generation number
      */
     long generation();
+
+    /**
+     * Whether this writer's schema can still evolve.
+     * Formats that handle schema evolution natively (e.g., Lucene) can always return true.
+     *
+     * @return true if the schema is mutable
+     */
+    boolean isSchemaMutable();
+
+    /**
+     * The current mapping version this writer is associated with.
+     *
+     * @return the mapping version
+     */
+    long mappingVersion();
+
+    /**
+     * Update the mapping version on a writer. Implementations must ignore
+     * the call if {@code newVersion} is less than or equal to the current version
+     * (i.e., mapping version must only move forward).
+     *
+     * @param newVersion the new mapping version
+     */
+    void updateMappingVersion(long newVersion);
 }

--- a/server/src/main/java/org/opensearch/index/engine/dataformat/WriterConfig.java
+++ b/server/src/main/java/org/opensearch/index/engine/dataformat/WriterConfig.java
@@ -1,0 +1,21 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.engine.dataformat;
+
+import org.opensearch.common.annotation.ExperimentalApi;
+
+/**
+ * Configuration for creating a new {@link Writer}.
+ *
+ * @param writerGeneration the writer generation number
+ * @opensearch.experimental
+ */
+@ExperimentalApi
+public record WriterConfig(long writerGeneration) {
+}

--- a/server/src/test/java/org/opensearch/index/engine/DataFormatAwareEngineTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/DataFormatAwareEngineTests.java
@@ -39,6 +39,7 @@ import org.opensearch.index.engine.exec.WriterFileSet;
 import org.opensearch.index.engine.exec.commit.CommitterFactory;
 import org.opensearch.index.engine.exec.coord.CatalogSnapshot;
 import org.opensearch.index.mapper.IdFieldMapper;
+import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.mapper.ParsedDocument;
 import org.opensearch.index.mapper.SeqNoFieldMapper;
 import org.opensearch.index.mapper.Uid;
@@ -203,6 +204,9 @@ public class DataFormatAwareEngineTests extends OpenSearchTestCase {
         DataFormatRegistry registry = createMockRegistry();
         CommitterFactory committerFactory = config -> new InMemoryCommitter(store);
 
+        MapperService mapperService = mock(MapperService.class);
+        when(mapperService.getIndexSettings()).thenReturn(indexSettings);
+
         return new EngineConfig.Builder().shardId(shardId)
             .threadPool(threadPool)
             .indexSettings(indexSettings)
@@ -218,6 +222,7 @@ public class DataFormatAwareEngineTests extends OpenSearchTestCase {
             .tombstoneDocSupplier(tombstoneDocSupplier())
             .dataFormatRegistry(registry)
             .committerFactory(committerFactory)
+            .mapperService(mapperService)
             .build();
     }
 

--- a/server/src/test/java/org/opensearch/index/engine/dataformat/DataFormatPluginTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/dataformat/DataFormatPluginTests.java
@@ -94,7 +94,7 @@ public class DataFormatPluginTests extends OpenSearchTestCase {
         assertEquals(format, engine.getDataFormat());
 
         // 2. Create a writer and write documents
-        Writer<MockDocumentInput> writer = engine.createWriter(1L);
+        Writer<MockDocumentInput> writer = engine.createWriter(new WriterConfig(1L));
 
         MockDocumentInput doc1 = engine.newDocumentInput();
         doc1.setRowId("_row_id", 0);
@@ -120,7 +120,7 @@ public class DataFormatPluginTests extends OpenSearchTestCase {
         writer.close();
 
         // 4. Write a second batch with a new writer generation
-        Writer<MockDocumentInput> writer2 = engine.createWriter(2L);
+        Writer<MockDocumentInput> writer2 = engine.createWriter(new WriterConfig(2L));
         MockDocumentInput doc3 = engine.newDocumentInput();
         doc3.setRowId("_row_id", 2);
         doc3.addField(mock(MappedFieldType.class), "Bob");
@@ -264,7 +264,7 @@ public class DataFormatPluginTests extends OpenSearchTestCase {
         MockIndexingExecutionEngine indexEngine = new MockIndexingExecutionEngine(format);
 
         // Batch 1
-        Writer<MockDocumentInput> w1 = indexEngine.createWriter(1L);
+        Writer<MockDocumentInput> w1 = indexEngine.createWriter(new WriterConfig(1L));
         MockDocumentInput d1 = indexEngine.newDocumentInput();
         d1.addField(mock(MappedFieldType.class), "Alice");
         d1.setRowId("_row_id", 0);
@@ -299,7 +299,7 @@ public class DataFormatPluginTests extends OpenSearchTestCase {
         assertEquals(1L, snapshot1.getGeneration());
 
         // New refresh arrives — commit replaces snapshot
-        Writer<MockDocumentInput> w2 = indexEngine.createWriter(2L);
+        Writer<MockDocumentInput> w2 = indexEngine.createWriter(new WriterConfig(2L));
         MockDocumentInput d2 = indexEngine.newDocumentInput();
         d2.addField(mock(MappedFieldType.class), "Bob");
         d2.setRowId("_row_id", 1);
@@ -412,7 +412,7 @@ public class DataFormatPluginTests extends OpenSearchTestCase {
         MockDataFormat format = new MockDataFormat();
         MockIndexingExecutionEngine indexEngine = new MockIndexingExecutionEngine(format);
 
-        Writer<MockDocumentInput> w = indexEngine.createWriter(1L);
+        Writer<MockDocumentInput> w = indexEngine.createWriter(new WriterConfig(1L));
         MockDocumentInput d = indexEngine.newDocumentInput();
         d.addField(mock(MappedFieldType.class), "x");
         d.setRowId("_row_id", 0);

--- a/test/framework/src/main/java/org/opensearch/index/engine/dataformat/stub/MockIndexingExecutionEngine.java
+++ b/test/framework/src/main/java/org/opensearch/index/engine/dataformat/stub/MockIndexingExecutionEngine.java
@@ -15,6 +15,7 @@ import org.opensearch.index.engine.dataformat.ReaderManagerConfig;
 import org.opensearch.index.engine.dataformat.RefreshInput;
 import org.opensearch.index.engine.dataformat.RefreshResult;
 import org.opensearch.index.engine.dataformat.Writer;
+import org.opensearch.index.engine.dataformat.WriterConfig;
 import org.opensearch.index.engine.exec.EngineReaderManager;
 import org.opensearch.index.engine.exec.Segment;
 import org.opensearch.index.engine.exec.commit.IndexStoreProvider;
@@ -44,8 +45,8 @@ public class MockIndexingExecutionEngine implements IndexingExecutionEngine<Data
     }
 
     @Override
-    public Writer<MockDocumentInput> createWriter(long writerGeneration) {
-        return new MockWriter(writerGeneration, dataFormat, directory, seqNo);
+    public Writer<MockDocumentInput> createWriter(WriterConfig config) {
+        return new MockWriter(config.writerGeneration(), dataFormat, directory, seqNo);
     }
 
     @Override

--- a/test/framework/src/main/java/org/opensearch/index/engine/dataformat/stub/MockWriter.java
+++ b/test/framework/src/main/java/org/opensearch/index/engine/dataformat/stub/MockWriter.java
@@ -63,5 +63,18 @@ public class MockWriter implements Writer<MockDocumentInput> {
     }
 
     @Override
+    public boolean isSchemaMutable() {
+        return true;
+    }
+
+    @Override
+    public long mappingVersion() {
+        return 0;
+    }
+
+    @Override
+    public void updateMappingVersion(long newVersion) {}
+
+    @Override
     public void close() {}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description

**Why dynamic mapping support is needed for pluggable formats**
  
  OpenSearch supports dynamic mapping — when a document contains a field not in the index mapping, the field is automatically added. This works transparently with Lucene because Lucene is inherently schema-on-write: each document can have any fields regardless of what previous documents had. There's no upfront schema declaration.
  
  Parquet (and columnar formats in general) are fundamentally different. A Parquet file has a fixed schema declared at creation time. Every row in the file must conform to that schema. Once the native writer is initialized with a schema, it cannot accept rows with new columns. This means dynamic mapping — where new fields can appear at any time — requires explicit handling at
  the engine level.
  
  **How it works at the DataFormatAwareEngine level**
  
  The engine maintains a pool of writers. Each writer tracks:
  
  - Whether its schema can still evolve (isSchemaMutable)
  - What mapping version it was created with (mappingVersion)
  
  **Normal indexing flow (no new fields):**
  
  1. Document arrives → engine reads current mapping version
  2. Engine checks out a writer from the pool (predicate: writer is mutable OR its version matches)
  3. Document is written to the writer
  4. Writer is returned to the pool
  
  **When a new field arrives (dynamic mapping):**
  
  1. OpenSearch's bulk action detects the new field, sends mapping update to cluster manager
  2. Cluster state updates → mapping version increments → MapperService updated
  3. Document is retried with the new mapping in place
  4. Engine reads the new mapping version → checks out a writer:
    - If a mutable writer exists → it's selected (schema evolves dynamically inside)
    - If only immutable writers exist with old versions → they're evicted from the available queue, a new writer is created with the fresh schema
  5. Document is written successfully
  
  This design is format-agnostic. Lucene writers are always mutable (isSchemaMutable = true), so they always pass the predicate and handle any document regardless of schema changes. The version tracking and eviction logic is invisible to Lucene — it just works.
  
  **How Parquet handles it**
  
  On the Parquet side, the key insight is that the native writer initialization (which locks the schema) must be deferred until we're certain the schema is complete.
  
  Writer lifecycle:
  
  1. Writer is created with an initial Arrow schema from the current mapping → but the native Parquet writer is NOT initialized yet (isSchemaMutable = true)
  2. Documents arrive → if a document has a field not in the current Arrow schema, the field vector is dynamically added to the in-memory batch (VSR)
  3. When the batch is full (rotation) or flush is triggered:
    - The batch is frozen (no more writes)
    - The native writer is initialized with the frozen batch's schema (which includes all dynamically added fields)
    - isSchemaMutable becomes false
    - The batch is written to the native writer
  4. After initialization, any document with a newer mapping version will not match this writer → a new writer is created with the updated schema

### Related Issues
#21587 
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
