### PR TITLE
Add AnalyticsFrontEndExtension SPI + AnalyticsServices bundle for analytics-engine frontend integration

### DIFF
--- a/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/AnalyticsFrontEndExtension.java
+++ b/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/AnalyticsFrontEndExtension.java
@@ -1,0 +1,42 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.spi;
+
+/**
+ * SPI for frontend plugins (e.g., opensearch-sql) that integrate with analytics-engine.
+ *
+ * <p>Implementers are discovered by {@code AnalyticsPlugin} via
+ * {@link org.opensearch.plugins.ExtensiblePlugin#loadExtensions}; analytics-engine pushes its
+ * services to each consumer once Guice has constructed them. Mirrors the
+ * {@code JobSchedulerExtension} pattern from opensearch-job-scheduler — the consumer plugin
+ * declares its capability via this interface; the publishing plugin (analytics-engine) handles
+ * discovery and lifecycle.
+ *
+ * <p>This SPI lets a frontend declare analytics-engine as an OPTIONAL extended plugin
+ * ({@code extendedPlugins = ['analytics-engine;optional=true']}). When analytics-engine is not
+ * installed, no consumer ever receives a callback; analytics-routing code paths stay inert and
+ * the frontend plugin boots normally.
+ *
+ * <p><b>Lifecycle.</b> {@link #setAnalyticsServices} is invoked exactly once per consumer per node
+ * lifecycle, AFTER the node Guice injector is built (i.e., after every plugin's
+ * {@code createComponents} returns) and BEFORE the first analytics query is dispatched.
+ * Implementations should stash the bundle for later use; do not assume the services are available
+ * during {@code createComponents}.
+ *
+ * @opensearch.internal
+ */
+public interface AnalyticsFrontEndExtension {
+
+    /**
+     * Receives the bundle of analytics-engine services. Called exactly once after the services are
+     * constructed and before any analytics query is dispatched. Each service inside the bundle is
+     * safe to invoke from any thread once received.
+     */
+    void setAnalyticsServices(AnalyticsServices services);
+}

--- a/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/AnalyticsServices.java
+++ b/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/AnalyticsServices.java
@@ -1,0 +1,29 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.spi;
+
+import org.apache.calcite.rel.RelNode;
+import org.opensearch.analytics.exec.QueryPlanExecutor;
+import org.opensearch.analytics.schema.SchemaProvider;
+
+/**
+ * Bundle of services that {@code AnalyticsPlugin} pushes to each {@link AnalyticsFrontEndExtension}
+ * consumer once Guice has constructed them.
+ *
+ * <p>Bundled rather than passed through individual setters so future analytics-engine services can
+ * be added without changing the {@link AnalyticsFrontEndExtension} signature — frontends that do
+ * not consume the new service simply ignore the new accessor.
+ *
+ * @param queryPlanExecutor coordinator-level query plan executor
+ * @param schemaProvider    builds a Calcite {@code SchemaPlus} from the current cluster state
+ *
+ * @opensearch.internal
+ */
+public record AnalyticsServices(QueryPlanExecutor<RelNode, Iterable<Object[]>> queryPlanExecutor, SchemaProvider schemaProvider) {
+}


### PR DESCRIPTION
## Summary

Adds an SPI interface and a services bundle in `analytics-framework` that let frontend plugins (e.g., `opensearch-sql`) integrate with `analytics-engine` without taking a hard install-time dependency on it.

Mirrors the `JobSchedulerExtension` pattern from `opensearch-job-scheduler`: the frontend plugin declares its capability via `AnalyticsFrontEndExtension`; the publishing plugin (analytics-engine) discovers consumers via `ExtensiblePlugin#loadExtensions` and pushes an `AnalyticsServices` bundle to each consumer once Guice has constructed them.

## Why

Today, `opensearch-sql` declares `extendedPlugins = [..., 'analytics-engine']` as a HARD dependency. This causes the SQL plugin install to fail on stock OpenSearch distros that don't ship `analytics-engine` (`Missing plugin [analytics-engine], dependency of [opensearch-sql]`). Marking it `;optional=true` is necessary but not sufficient — `TransportPPLQueryAction` Guice-injects `QueryPlanExecutor`, and Guice cannot satisfy that binding when the providing plugin is absent.

The SPI inverts the dependency. Frontend plugins implement `AnalyticsFrontEndExtension` to receive analytics-engine's services through a push lifecycle; analytics-engine never imports the frontend.

## What's in this PR

Two new files in `sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/`:

- **`AnalyticsFrontEndExtension`** — the SPI interface. Single method:
  ```java
  void setAnalyticsServices(AnalyticsServices services);
  ```
- **`AnalyticsServices`** — the services bundle (record). Initial fields:
  - `QueryPlanExecutor<RelNode, Iterable<Object[]>> queryPlanExecutor`
  - `SchemaProvider schemaProvider` (already exists in `analytics-framework`)

Bundled rather than separate setters so future analytics-engine services can be added without changing the SPI signature — frontends that don't consume the new service simply ignore the new accessor.

JavaDoc on the interface spells out the lifecycle (discovery via `ExtensiblePlugin#loadExtensions`, push after Guice builds the node injector, exactly once per consumer per node, before first analytics query).

## What's NOT in this PR

- No producer-side wiring in `AnalyticsPlugin` (`loadExtensions` collection + Guice listener for `DefaultPlanExecutor` + push to consumers). That's a follow-up by the analytics-engine team.
- No frontend consumer changes — those land in opensearch-sql separately.

## Related

Coordination thread: https://github.com/opensearch-project/sql/pull/5398 — the SQL-side draft of this same interface, which gets deleted once this PR merges and a new `analytics-framework` JAR is vendored into opensearch-sql.

## Test plan

- [x] `./gradlew :sandbox:libs:analytics-framework:compileJava -Dsandbox.enabled=true` — passes.

The interface has no implementations or callers in this PR, so there are no behavioral tests.