### PR TITLE
Add AnalyticsFrontEndExtension SPI + producer-side wiring in AnalyticsPlugin

### DIFF
--- a/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/AnalyticsFrontEndExtension.java
+++ b/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/AnalyticsFrontEndExtension.java
@@ -1,0 +1,42 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.spi;
+
+/**
+ * SPI for frontend plugins (e.g., opensearch-sql) that integrate with analytics-engine.
+ *
+ * <p>Implementers are discovered by {@code AnalyticsPlugin} via
+ * {@link org.opensearch.plugins.ExtensiblePlugin#loadExtensions}; analytics-engine pushes its
+ * services to each consumer once Guice has constructed them. Mirrors the
+ * {@code JobSchedulerExtension} pattern from opensearch-job-scheduler — the consumer plugin
+ * declares its capability via this interface; the publishing plugin (analytics-engine) handles
+ * discovery and lifecycle.
+ *
+ * <p>This SPI lets a frontend declare analytics-engine as an OPTIONAL extended plugin
+ * ({@code extendedPlugins = ['analytics-engine;optional=true']}). When analytics-engine is not
+ * installed, no consumer ever receives a callback; analytics-routing code paths stay inert and
+ * the frontend plugin boots normally.
+ *
+ * <p><b>Lifecycle.</b> {@link #setAnalyticsServices} is invoked exactly once per consumer per node
+ * lifecycle, AFTER the node Guice injector is built (i.e., after every plugin's
+ * {@code createComponents} returns) and BEFORE the first analytics query is dispatched.
+ * Implementations should stash the bundle for later use; do not assume the services are available
+ * during {@code createComponents}.
+ *
+ * @opensearch.internal
+ */
+public interface AnalyticsFrontEndExtension {
+
+    /**
+     * Receives the bundle of analytics-engine services. Called exactly once after the services are
+     * constructed and before any analytics query is dispatched. Each service inside the bundle is
+     * safe to invoke from any thread once received.
+     */
+    void setAnalyticsServices(AnalyticsServices services);
+}

--- a/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/AnalyticsServices.java
+++ b/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/AnalyticsServices.java
@@ -1,0 +1,29 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.spi;
+
+import org.apache.calcite.rel.RelNode;
+import org.opensearch.analytics.exec.QueryPlanExecutor;
+import org.opensearch.analytics.schema.SchemaProvider;
+
+/**
+ * Bundle of services that {@code AnalyticsPlugin} pushes to each {@link AnalyticsFrontEndExtension}
+ * consumer once Guice has constructed them.
+ *
+ * <p>Bundled rather than passed through individual setters so future analytics-engine services can
+ * be added without changing the {@link AnalyticsFrontEndExtension} signature — frontends that do
+ * not consume the new service simply ignore the new accessor.
+ *
+ * @param queryPlanExecutor coordinator-level query plan executor
+ * @param schemaProvider    builds a Calcite {@code SchemaPlus} from the current cluster state
+ *
+ * @opensearch.internal
+ */
+public record AnalyticsServices(QueryPlanExecutor<RelNode, Iterable<Object[]>> queryPlanExecutor, SchemaProvider schemaProvider) {
+}

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/AnalyticsPlugin.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/AnalyticsPlugin.java
@@ -24,11 +24,19 @@ import org.opensearch.analytics.exec.action.AnalyticsQueryAction;
 import org.opensearch.analytics.planner.CapabilityRegistry;
 import org.opensearch.analytics.planner.FieldStorageResolver;
 import org.opensearch.analytics.schema.OpenSearchSchemaBuilder;
+import org.opensearch.analytics.schema.SchemaProvider;
+import org.opensearch.analytics.spi.AnalyticsFrontEndExtension;
 import org.opensearch.analytics.spi.AnalyticsSearchBackendPlugin;
+import org.opensearch.analytics.spi.AnalyticsServices;
+import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Module;
 import org.opensearch.common.inject.TypeLiteral;
+import org.opensearch.common.inject.matcher.Matchers;
+import org.opensearch.common.inject.spi.InjectionListener;
+import org.opensearch.common.inject.spi.TypeEncounter;
+import org.opensearch.common.inject.spi.TypeListener;
 import org.opensearch.core.action.ActionResponse;
 import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
@@ -66,12 +74,14 @@ public class AnalyticsPlugin extends Plugin implements ExtensiblePlugin, ActionP
     public AnalyticsPlugin() {}
 
     private final List<AnalyticsSearchBackendPlugin> backEnds = new ArrayList<>();
+    private final List<AnalyticsFrontEndExtension> frontEnds = new ArrayList<>();
     private SqlOperatorTable operatorTable;
 
     @SuppressWarnings("rawtypes")
     @Override
     public void loadExtensions(ExtensionLoader loader) {
         backEnds.addAll(loader.loadExtensions(AnalyticsSearchBackendPlugin.class));
+        frontEnds.addAll(loader.loadExtensions(AnalyticsFrontEndExtension.class));
     }
 
     @Override
@@ -112,7 +122,38 @@ public class AnalyticsPlugin extends Plugin implements ExtensiblePlugin, ActionP
             }).to(DefaultPlanExecutor.class);
             b.bind(EngineContext.class).to(DefaultEngineContext.class);
             b.bind(Scheduler.class).to(QueryScheduler.class);
+            // Push the executor + schemaProvider bundle to every registered AnalyticsFrontEndExtension
+            // once Guice constructs DefaultPlanExecutor. The InjectionListener fires on the singleton
+            // construction; pushAnalyticsServices guards against re-firing if Guice ever instantiates
+            // more than once.
+            b.bindListener(Matchers.any(), new TypeListener() {
+                @Override
+                public <I> void hear(TypeLiteral<I> type, TypeEncounter<I> encounter) {
+                    if (!DefaultPlanExecutor.class.isAssignableFrom(type.getRawType())) {
+                        return;
+                    }
+                    encounter.register((InjectionListener<I>) instance -> pushAnalyticsServices((DefaultPlanExecutor) instance));
+                }
+            });
         });
+    }
+
+    private boolean servicesPushed = false;
+
+    private synchronized void pushAnalyticsServices(DefaultPlanExecutor executor) {
+        if (servicesPushed) {
+            return;
+        }
+        servicesPushed = true;
+        SchemaProvider schemaProvider = clusterState -> OpenSearchSchemaBuilder.buildSchema((ClusterState) clusterState);
+        AnalyticsServices services = new AnalyticsServices(executor, schemaProvider);
+        for (AnalyticsFrontEndExtension consumer : frontEnds) {
+            try {
+                consumer.setAnalyticsServices(services);
+            } catch (Exception e) {
+                logger.warn("AnalyticsFrontEndExtension {} threw on setAnalyticsServices", consumer.getClass().getName(), e);
+            }
+        }
     }
 
     @Override


### PR DESCRIPTION
## Summary

Adds an SPI in `analytics-framework` that lets frontend plugins (e.g., `opensearch-sql`) consume analytics-engine services without taking a hard install-time dependency on analytics-engine. Adds the matching producer-side wiring in `AnalyticsPlugin`: discover consumers via `ExtensiblePlugin#loadExtensions`, push the executor + schemaProvider once Guice constructs `DefaultPlanExecutor`.

Mirrors the `JobSchedulerExtension` pattern from `opensearch-job-scheduler`.

## Why

Today `opensearch-sql` declares `extendedPlugins = [..., 'analytics-engine']` as a HARD dependency. SQL plugin install fails on stock OpenSearch distros that don't ship `analytics-engine` (`Missing plugin [analytics-engine]`). Marking it `;optional=true` is necessary but not sufficient — `TransportPPLQueryAction` Guice-injects `QueryPlanExecutor`, and Guice cannot satisfy that binding when the providing plugin is absent.

The SPI inverts the dependency. Frontend plugins implement `AnalyticsFrontEndExtension` to receive analytics-engine's services through a push lifecycle; analytics-engine never imports the frontend.

## What's in this PR

**`sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/`:**
- `AnalyticsFrontEndExtension` — single-method SPI: `setAnalyticsServices(AnalyticsServices)`. Implementers declared via standard Java SPI (`META-INF/services`).
- `AnalyticsServices` — record bundling `QueryPlanExecutor<RelNode, Iterable<Object[]>>` and `SchemaProvider`. Bundled (rather than separate setters) so future analytics-engine services can be added without changing the SPI signature.

**`sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/AnalyticsPlugin.java`:**
- `loadExtensions(loader)` — collects `AnalyticsFrontEndExtension` consumers alongside the existing `AnalyticsSearchBackendPlugin` collection.
- `createGuiceModules` — adds a Guice `TypeListener` that fires when `DefaultPlanExecutor` is instantiated. The `InjectionListener` wraps `OpenSearchSchemaBuilder::buildSchema` as a `SchemaProvider`, packs both into `AnalyticsServices`, and pushes to every registered consumer.
- `pushAnalyticsServices(...)` — idempotent (guarded by `servicesPushed` flag) so Guice re-instantiation doesn't re-fire the callback. Per-consumer `try/catch` so one bad consumer doesn't crash the others.

## End-to-end verification

Built this branch + the matching consumer-side PR ([opensearch-project/sql#5xxx](https://github.com/opensearch-project/sql/pulls?q=feature/analytics-spi-e2e)), assembled an OpenSearch 3.7 distro, and ran `bin/opensearch-plugin install` followed by real PPL queries against a single-node cluster.

### Scenario A — analytics-engine INSTALLED

```
$ bin/opensearch-plugin install --batch file:///.../opensearch-job-scheduler-3.7.0.0-SNAPSHOT.zip
-> Installed opensearch-job-scheduler with folder name opensearch-job-scheduler

$ bin/opensearch-plugin install --batch file:///.../analytics-engine-3.7.0-SNAPSHOT.zip
-> Installed analytics-engine with folder name analytics-engine

$ bin/opensearch-plugin install --batch file:///.../opensearch-sql-3.7.0.0-SNAPSHOT.zip
-> Installed opensearch-sql with folder name opensearch-sql
```

Node started cleanly:

```
$ curl -s 'http://localhost:19201/_cat/plugins?v'
name         component                version
6c7e67cac848 analytics-engine         3.7.0-SNAPSHOT
6c7e67cac848 opensearch-job-scheduler 3.7.0.0-SNAPSHOT
6c7e67cac848 opensearch-sql           3.7.0.0-SNAPSHOT
```

Lucene PPL query against a regular index:

```
$ curl -s -X POST 'http://localhost:19201/_plugins/_ppl' -H 'Content-Type: application/json' \
       -d '{"query":"source = accounts | fields name, age"}'
{
  "schema":[{"name":"name","type":"string"},{"name":"age","type":"int"}],
  "datarows":[["Alice",30]],
  "total":1, "size":1
}
```

Parquet-prefixed PPL query (routes through analytics-engine — confirms the SPI fired and the executor was received):

```
$ curl -s -X POST 'http://localhost:19201/_plugins/_ppl/_explain' -H 'Content-Type: application/json' \
       -d '{"query":"source = parquet_logs | head 1"}'
{
  "calcite":{
    "logical":"LogicalSystemLimit(fetch=[10000], type=[QUERY_SIZE_LIMIT])\n  LogicalSort(fetch=[1])\n    LogicalTableScan(table=[[opensearch, parquet_logs]])\n"
  }
}
```

The `calcite.logical` block is produced only by the analytics-engine planner — it confirms the routing went through `RestUnifiedQueryAction → AnalyticsExecutionEngine`, which proves the SPI push lifecycle worked end-to-end (consumer received services, holder was populated, lazy handler was constructed, request was dispatched).

### Scenario B — analytics-engine NOT installed (the optional path)

```
$ bin/opensearch-plugin install --batch file:///.../opensearch-job-scheduler-3.7.0.0-SNAPSHOT.zip
-> Installed opensearch-job-scheduler with folder name opensearch-job-scheduler

$ bin/opensearch-plugin install --batch file:///.../opensearch-sql-3.7.0.0-SNAPSHOT.zip
2026-05-01T... main WARN Missing plugin [analytics-engine], dependency of [opensearch-sql]
-> Installed opensearch-sql with folder name opensearch-sql
```

Note the **WARN** (not ERROR) for the missing optional dep — that's the `;optional=true` mechanism in `PluginsService.checkBundleJarHell` working as intended.

Node started cleanly with only two plugins:

```
$ curl -s 'http://localhost:19200/_cat/plugins?v'
name         component                version
6c7e67cac848 opensearch-job-scheduler 3.7.0.0-SNAPSHOT
6c7e67cac848 opensearch-sql           3.7.0.0-SNAPSHOT
```

Lucene PPL query (the legacy path) — works:

```
$ curl -s -X POST 'http://localhost:19200/_plugins/_ppl' -H 'Content-Type: application/json' \
       -d '{"query":"source = accounts | fields name, age"}'
{
  "schema":[{"name":"name","type":"string"},{"name":"age","type":"int"}],
  "datarows":[["Alice",30],["Bob",25]],
  "total":2, "size":2
}
```

Parquet-prefixed PPL query — falls through to legacy (no SPI push ever fired, holder stays null, `analyticsHandler()` returns null, request takes the legacy path):

```
$ curl -s -X POST 'http://localhost:19200/_plugins/_ppl' -H 'Content-Type: application/json' \
       -d '{"query":"source = parquet_logs | head 1"}'
{
  "error":{
    "reason":"Error occurred in OpenSearch engine: no such index [parquet_logs]",
    "type":"IndexNotFoundException"
  },
  "status":404
}
```

This is the critical assertion: a clean `IndexNotFoundException` from the legacy engine — **NOT** `NoClassDefFoundError: org/opensearch/analytics/exec/QueryPlanExecutor` (the failure mode this SPI is designed to prevent). The SQL plugin's bytecode never resolves an analytics-framework type when analytics-engine is absent.

## Reproducing locally

The full reproduction is in the PR body: build this branch + the SQL PR, then for each scenario:

```bash
DIST=opensearch-min-3.7.0-SNAPSHOT-darwin-arm64.tar.gz
tar xzf $DIST -C /tmp/test
cd /tmp/test/opensearch-3.7.0-SNAPSHOT
bin/opensearch-plugin install --batch file://.../opensearch-job-scheduler-3.7.0.0-SNAPSHOT.zip
# Scenario A only:
bin/opensearch-plugin install --batch file://.../analytics-engine-3.7.0-SNAPSHOT.zip
bin/opensearch-plugin install --batch file://.../opensearch-sql-3.7.0.0-SNAPSHOT.zip
OPENSEARCH_JAVA_HOME=$(/usr/libexec/java_home) bin/opensearch -E discovery.type=single-node ...
```

## Pairs with

[opensearch-project/sql#5xxx](https://github.com/opensearch-project/sql/pulls?q=feature/analytics-spi-e2e) — the SQL-side consumer wiring, must merge after this so it can vendor the rebuilt `analytics-framework-3.7.0-SNAPSHOT.jar`.