### PR TITLE
Skip root transfer for byte-serialized via handler marker

### DIFF
--- a/plugins/arrow-flight-rpc/src/internalClusterTest/java/org/opensearch/arrow/flight/NativeArrowTransportIT.java
+++ b/plugins/arrow-flight-rpc/src/internalClusterTest/java/org/opensearch/arrow/flight/NativeArrowTransportIT.java
@@ -23,9 +23,9 @@ import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.action.ActionType;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.TransportAction;
+import org.opensearch.arrow.flight.transport.ArrowAllocatorProvider;
 import org.opensearch.arrow.flight.transport.ArrowBatchResponse;
 import org.opensearch.arrow.flight.transport.ArrowBatchResponseHandler;
-import org.opensearch.arrow.flight.transport.ArrowFlightChannel;
 import org.opensearch.arrow.flight.transport.FlightStreamPlugin;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.common.inject.Inject;
@@ -264,7 +264,7 @@ public class NativeArrowTransportIT extends OpenSearchIntegTestCase {
         }
     }
 
-    /** Deep-copies data from a VectorSchemaRoot. */
+    /** Deep-copies data out of the Arrow batch so the root can be closed immediately. */
     static class ReceivedBatch {
         final int rowCount;
         final int batchId;
@@ -272,11 +272,11 @@ public class NativeArrowTransportIT extends OpenSearchIntegTestCase {
         final List<String> names;
         final List<Integer> values;
 
-        ReceivedBatch(VectorSchemaRoot root) {
-            this.rowCount = root.getRowCount();
-            IntVector batchIdVector = (IntVector) root.getVector("batch_id");
-            VarCharVector nameVector = (VarCharVector) root.getVector("name");
-            IntVector valueVector = (IntVector) root.getVector("value");
+        ReceivedBatch(VectorSchemaRoot batch) {
+            this.rowCount = batch.getRowCount();
+            IntVector batchIdVector = (IntVector) batch.getVector("batch_id");
+            VarCharVector nameVector = (VarCharVector) batch.getVector("name");
+            IntVector valueVector = (IntVector) batch.getVector("value");
             this.batchIds = new ArrayList<>();
             this.names = new ArrayList<>();
             this.values = new ArrayList<>();
@@ -350,10 +350,12 @@ public class NativeArrowTransportIT extends OpenSearchIntegTestCase {
      * on the executor thread.
      */
     public static class TransportTestArrowAction extends TransportAction<TestArrowRequest, TestArrowResponse> {
+        private final BufferAllocator allocator;
 
         @Inject
         public TransportTestArrowAction(StreamTransportService streamTransportService, ActionFilters actionFilters) {
             super(TestArrowAction.NAME, actionFilters, streamTransportService.getTaskManager());
+            this.allocator = ArrowAllocatorProvider.newChildAllocator("native-arrow-test", Long.MAX_VALUE);
             streamTransportService.registerRequestHandler(
                 TestArrowAction.NAME,
                 ThreadPool.Names.GENERIC,
@@ -368,7 +370,6 @@ public class NativeArrowTransportIT extends OpenSearchIntegTestCase {
         }
 
         private void handleStreamRequest(TestArrowRequest request, TransportChannel channel, Task task) throws IOException {
-            BufferAllocator allocator = ArrowFlightChannel.from(channel).getAllocator();
 
             try {
                 if (request.parallelism <= 1) {
@@ -453,13 +454,15 @@ public class NativeArrowTransportIT extends OpenSearchIntegTestCase {
             try {
                 TestArrowResponse response;
                 while ((response = streamResponse.nextResponse()) != null) {
-                    batches.add(new ReceivedBatch(response.getRoot()));
+                    try (VectorSchemaRoot batch = response.getRoot()) {
+                        batches.add(new ReceivedBatch(batch));
+                    }
                 }
                 streamResponse.close();
-                latch.countDown();
             } catch (Exception e) {
                 failure.set(e);
                 streamResponse.cancel("Test error", e);
+            } finally {
                 latch.countDown();
             }
         }

--- a/plugins/arrow-flight-rpc/src/internalClusterTest/java/org/opensearch/arrow/flight/NativeArrowTransportIT.java
+++ b/plugins/arrow-flight-rpc/src/internalClusterTest/java/org/opensearch/arrow/flight/NativeArrowTransportIT.java
@@ -349,13 +349,29 @@ public class NativeArrowTransportIT extends OpenSearchIntegTestCase {
      * batches via sendResponseBatch(). The framework does zero-copy transfer
      * on the executor thread.
      */
+    public static class TestAllocatorHolder {
+        private final BufferAllocator allocator;
+
+        TestAllocatorHolder(BufferAllocator allocator) {
+            this.allocator = allocator;
+        }
+
+        BufferAllocator get() {
+            return allocator;
+        }
+    }
+
     public static class TransportTestArrowAction extends TransportAction<TestArrowRequest, TestArrowResponse> {
         private final BufferAllocator allocator;
 
         @Inject
-        public TransportTestArrowAction(StreamTransportService streamTransportService, ActionFilters actionFilters) {
+        public TransportTestArrowAction(
+            StreamTransportService streamTransportService,
+            ActionFilters actionFilters,
+            TestAllocatorHolder allocatorHolder
+        ) {
             super(TestArrowAction.NAME, actionFilters, streamTransportService.getTaskManager());
-            this.allocator = ArrowAllocatorProvider.newChildAllocator("native-arrow-test", Long.MAX_VALUE);
+            this.allocator = allocatorHolder.get();
             streamTransportService.registerRequestHandler(
                 TestArrowAction.NAME,
                 ThreadPool.Names.GENERIC,
@@ -485,11 +501,35 @@ public class NativeArrowTransportIT extends OpenSearchIntegTestCase {
     }
 
     public static class NativeArrowTestPlugin extends Plugin implements ActionPlugin {
+        private final BufferAllocator allocator = ArrowAllocatorProvider.newChildAllocator("native-arrow-test", Long.MAX_VALUE);
+
         public NativeArrowTestPlugin() {}
+
+        @Override
+        public Collection<Object> createComponents(
+            org.opensearch.transport.client.Client client,
+            org.opensearch.cluster.service.ClusterService clusterService,
+            ThreadPool threadPool,
+            org.opensearch.watcher.ResourceWatcherService resourceWatcherService,
+            org.opensearch.script.ScriptService scriptService,
+            org.opensearch.core.xcontent.NamedXContentRegistry xContentRegistry,
+            org.opensearch.env.Environment environment,
+            org.opensearch.env.NodeEnvironment nodeEnvironment,
+            org.opensearch.core.common.io.stream.NamedWriteableRegistry namedWriteableRegistry,
+            org.opensearch.cluster.metadata.IndexNameExpressionResolver indexNameExpressionResolver,
+            java.util.function.Supplier<org.opensearch.repositories.RepositoriesService> repositoriesServiceSupplier
+        ) {
+            return List.of(new TestAllocatorHolder(allocator));
+        }
 
         @Override
         public List<ActionHandler<? extends ActionRequest, ? extends ActionResponse>> getActions() {
             return List.of(new ActionHandler<>(TestArrowAction.INSTANCE, TransportTestArrowAction.class));
+        }
+
+        @Override
+        public void close() {
+            allocator.close();
         }
     }
 }

--- a/plugins/arrow-flight-rpc/src/internalClusterTest/java/org/opensearch/arrow/flight/NativeArrowTransportIT.java
+++ b/plugins/arrow-flight-rpc/src/internalClusterTest/java/org/opensearch/arrow/flight/NativeArrowTransportIT.java
@@ -24,6 +24,7 @@ import org.opensearch.action.ActionType;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.TransportAction;
 import org.opensearch.arrow.flight.transport.ArrowBatchResponse;
+import org.opensearch.arrow.flight.transport.ArrowBatchResponseHandler;
 import org.opensearch.arrow.flight.transport.ArrowFlightChannel;
 import org.opensearch.arrow.flight.transport.FlightStreamPlugin;
 import org.opensearch.cluster.node.DiscoveryNode;
@@ -37,7 +38,6 @@ import org.opensearch.plugins.Plugin;
 import org.opensearch.tasks.Task;
 import org.opensearch.test.OpenSearchIntegTestCase;
 import org.opensearch.threadpool.ThreadPool;
-import org.opensearch.transport.StreamTransportResponseHandler;
 import org.opensearch.transport.StreamTransportService;
 import org.opensearch.transport.TransportChannel;
 import org.opensearch.transport.TransportException;
@@ -144,7 +144,7 @@ public class NativeArrowTransportIT extends OpenSearchIntegTestCase {
             TestArrowAction.NAME,
             new TestArrowRequest(batchCount, rowsPerBatch, 1),
             TransportRequestOptions.builder().withType(TransportRequestOptions.Type.STREAM).build(),
-            new StreamTransportResponseHandler<TestArrowResponse>() {
+            new ArrowBatchResponseHandler<TestArrowResponse>() {
                 @Override
                 public void handleStreamResponse(StreamTransportResponse<TestArrowResponse> streamResponse) {
                     try {
@@ -437,7 +437,7 @@ public class NativeArrowTransportIT extends OpenSearchIntegTestCase {
         }
     }
 
-    static class TestArrowResponseHandler implements StreamTransportResponseHandler<TestArrowResponse> {
+    static class TestArrowResponseHandler extends ArrowBatchResponseHandler<TestArrowResponse> {
         private final List<ReceivedBatch> batches;
         private final CountDownLatch latch;
         private final AtomicReference<Exception> failure;

--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/ArrowAllocatorProvider.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/ArrowAllocatorProvider.java
@@ -1,0 +1,49 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.arrow.flight.transport;
+
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.opensearch.common.annotation.ExperimentalApi;
+
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+
+/**
+ * Node-level Arrow allocator shared across plugins.
+ *
+ * <p>Every caller of {@link #newChildAllocator(String, long)} gets a child of one
+ * {@link RootAllocator}. Cross-plugin buffer handoffs (e.g., producer → Flight stream,
+ * Flight stream → consumer) pass Arrow's {@link org.apache.arrow.memory.AllocationManager}
+ * associate check, which requires {@code source.getRoot() == target.getRoot()}.
+ *
+ * @opensearch.experimental
+ */
+@ExperimentalApi
+@SuppressWarnings("removal")
+public final class ArrowAllocatorProvider {
+
+    private static final RootAllocator ROOT = AccessController.doPrivileged(
+        (PrivilegedAction<RootAllocator>) () -> new RootAllocator(Long.MAX_VALUE)
+    );
+
+    private ArrowAllocatorProvider() {}
+
+    /**
+     * Creates a named child of the shared root with an independent memory limit.
+     * Callers own the returned allocator and must close it.
+     *
+     * @param name descriptive name for debugging (e.g., "flight", "analytics-search")
+     * @param limit maximum bytes this child can allocate
+     * @return a new child allocator
+     */
+    public static BufferAllocator newChildAllocator(String name, long limit) {
+        return ROOT.newChildAllocator(name, 0, limit);
+    }
+}

--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/ArrowBatchResponse.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/ArrowBatchResponse.java
@@ -47,12 +47,16 @@ import java.io.IOException;
  * <ul>
  *   <li><b>Send side:</b> Use a child of {@link ArrowAllocatorProvider}. All allocators
  *       must share the same root so zero-copy transfers pass Arrow's
- *       {@code AllocationManager} associate check.</li>
+ *       {@code AllocationManager} associate check. The framework creates the Flight
+ *       stream root from the producer's allocator to ensure same-allocator transfer —
+ *       this avoids an Arrow bug with cross-allocator transfer of foreign-backed
+ *       buffers from C data import.</li>
+ *   <li><b>Send side:</b> Allocators must outlive the gRPC stream — gRPC's zero-copy write
+ *       path retains buffer references beyond stream completion. Do not create and close a
+ *       child allocator per request.</li>
  *   <li><b>Receive side:</b> The framework transfers vectors from the Flight stream's
  *       allocator into the response. The consumer can then transfer them into its own
  *       allocator — which must also be a child of {@link ArrowAllocatorProvider}.</li>
- *   <li>Allocators must outlive the gRPC stream — gRPC's zero-copy write path retains
- *       buffer references beyond stream completion.</li>
  * </ul>
  *
  * @opensearch.experimental
@@ -60,25 +64,25 @@ import java.io.IOException;
 @ExperimentalApi
 public abstract class ArrowBatchResponse extends ActionResponse {
 
-    private final VectorSchemaRoot batch;
+    private final VectorSchemaRoot batchRoot;
 
     /**
-     * Send-side constructor: wraps a batch populated by the producer.
-     * @param batch the batch to send; ownership transfers to the transport
+     * Send-side constructor: wraps a root populated by the producer.
+     * @param batchRoot the root to send; ownership transfers to the transport
      */
-    protected ArrowBatchResponse(VectorSchemaRoot batch) {
-        this.batch = batch;
+    protected ArrowBatchResponse(VectorSchemaRoot batchRoot) {
+        this.batchRoot = batchRoot;
     }
 
     /**
-     * Receive-side constructor: claims ownership of the consumer batch from the input.
+     * Receive-side constructor: claims ownership of the consumer root from the input.
      * @param in must be a {@link VectorStreamInput.NativeArrow}; throws otherwise
      * @throws IOException if reading fails
      */
     protected ArrowBatchResponse(StreamInput in) throws IOException {
         super(in);
         if (in instanceof VectorStreamInput.NativeArrow nativeIn) {
-            this.batch = nativeIn.getRoot();
+            this.batchRoot = nativeIn.getRoot();
             nativeIn.claimOwnership();
         } else {
             throw new IllegalStateException(
@@ -90,9 +94,9 @@ public abstract class ArrowBatchResponse extends ActionResponse {
         }
     }
 
-    /** Returns the Arrow batch holding the response vectors. */
+    /** Returns the Arrow root holding the response vectors. */
     public VectorSchemaRoot getRoot() {
-        return batch;
+        return batchRoot;
     }
 
     @Override

--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/ArrowBatchResponse.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/ArrowBatchResponse.java
@@ -17,39 +17,38 @@ import org.opensearch.core.common.io.stream.StreamOutput;
 import java.io.IOException;
 
 /**
- * Base class for transport responses carrying native Arrow data.
+ * Base class for transport responses carrying native Arrow data. Subclasses must provide
+ * two constructors — one for sending (wraps a populated root) and one for receiving
+ * (takes ownership of vectors from the Flight stream via {@link StreamInput}):
  *
- * <p>The producer creates vectors using the channel's allocator and populates them freely
- * on any thread. When the executor processes this batch, it does a zero-copy transfer
- * of the producer's buffers into the channel's shared root — no memcpy, no serialization.
- * After transfer, the framework closes the producer's root, releasing its buffers back
- * to the allocator.
+ * <pre>{@code
+ * public class MyResponse extends ArrowBatchResponse {
+ *     public MyResponse(VectorSchemaRoot root) { super(root); }       // send side
+ *     public MyResponse(StreamInput in) throws IOException { super(in); } // receive side
+ * }
+ * }</pre>
  *
- * <p><b>Allocator guidelines:</b> The allocator used for producer roots must outlive the
- * gRPC stream — do not create and close a child allocator per request. gRPC's zero-copy
- * write path retains buffer references beyond stream completion, and closing the allocator
- * while gRPC still holds these references causes memory accounting errors. Use either the
- * channel allocator (via {@code ArrowFlightChannel.from(channel).getAllocator()}) or a
- * long-lived application allocator. The framework creates the shared root from the
- * producer's allocator to ensure same-allocator transfer, which avoids an Arrow bug with
- * cross-allocator transfer of foreign-backed buffers from C data import.
+ * <p><b>Send side:</b> The producer populates a {@link VectorSchemaRoot} and wraps it.
+ * The framework zero-copy transfers the vectors into the Flight stream via
+ * {@link #transferTo(VectorSchemaRoot)} — no memcpy, no serialization.
  *
- * <p>Usage (send side):
  * <pre>{@code
  * BufferAllocator allocator = ArrowFlightChannel.from(channel).getAllocator();
  * VectorSchemaRoot producerRoot = VectorSchemaRoot.create(schema, allocator);
- * // populate producerRoot on any thread...
+ * // populate producerRoot...
  * channel.sendResponseBatch(new MyResponse(producerRoot));
  * // producerRoot is now owned by the framework — don't reuse or close it
  * }</pre>
  *
- * <p>Usage (receive side):
- * <pre>{@code
- * public class MyResponse extends ArrowBatchResponse {
- *     public MyResponse(VectorSchemaRoot root) { super(root); }
- *     public MyResponse(StreamInput in) throws IOException { super(in); }
- * }
- * }</pre>
+ * <p><b>Receive side:</b> The framework calls {@code handler.read(in)} where {@code in} is
+ * a {@link VectorStreamInput.NativeArrow} holding vectors transferred from the Flight stream.
+ * The {@link #ArrowBatchResponse(StreamInput)} constructor claims ownership of those vectors.
+ *
+ * <p><b>Allocator guidelines:</b> The allocator for producer roots must outlive the gRPC
+ * stream. gRPC's zero-copy write path retains buffer references beyond stream completion;
+ * closing the allocator early causes memory accounting errors. Use the channel allocator
+ * ({@code ArrowFlightChannel.from(channel).getAllocator()}) or a long-lived application
+ * allocator.
  *
  * @opensearch.experimental
  */
@@ -59,38 +58,41 @@ public abstract class ArrowBatchResponse extends ActionResponse {
     private final VectorSchemaRoot producerRoot;
 
     /**
-     * Creates a response with the given producer root (send side).
-     * @param producerRoot the root populated by the producer
+     * Send-side constructor: wraps a root populated by the producer.
+     * @param producerRoot the root to send; ownership transfers to the framework
      */
     protected ArrowBatchResponse(VectorSchemaRoot producerRoot) {
         this.producerRoot = producerRoot;
     }
 
     /**
-     * Deserializes a response from a StreamInput (receive side).
-     * @param in the stream input containing the Arrow root
-     * @throws IOException if deserialization fails
+     * Receive-side constructor: claims ownership of the Arrow vectors from the input.
+     * @param in must be a {@link VectorStreamInput.NativeArrow}; throws otherwise
+     * @throws IOException if reading fails
      */
     protected ArrowBatchResponse(StreamInput in) throws IOException {
         super(in);
-        this.producerRoot = ((VectorStreamInput) in).getRoot();
+        if (in instanceof VectorStreamInput.NativeArrow nativeIn) {
+            this.producerRoot = nativeIn.getRoot();
+            nativeIn.claimOwnership();
+        } else {
+            throw new IllegalStateException(
+                "ArrowBatchResponse decoded from a non-native-Arrow StreamInput ("
+                    + (in == null ? "null" : in.getClass().getName())
+                    + "). Wrapping handlers around ArrowBatchResponseHandler must forward "
+                    + "TransportResponseHandler#skipsDeserialization()."
+            );
+        }
     }
 
-    /**
-     * Returns the producer's root. On the send side, this is the root populated
-     * by the producer. On the receive side, this is the root from the Flight stream.
-     */
+    /** Returns the Arrow root holding the response vectors. */
     public VectorSchemaRoot getRoot() {
         return producerRoot;
     }
 
     /**
      * Zero-copy transfers the producer's vectors into the target root.
-     * Called by the framework on the executor thread before {@code putNext()}.
-     * After transfer, the producer's buffers are moved to the target — the producer
-     * root becomes empty.
-     *
-     * @param target the channel's shared root (bound to the Flight stream via start())
+     * @param target the channel's stream root (bound to the Flight stream via start())
      */
     void transferTo(VectorSchemaRoot target) {
         FlightUtils.transferRoot(producerRoot, target);

--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/ArrowBatchResponse.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/ArrowBatchResponse.java
@@ -29,11 +29,10 @@ import java.io.IOException;
  * }</pre>
  *
  * <p><b>Send side:</b> The producer populates a {@link VectorSchemaRoot} and wraps it.
- * The framework zero-copy transfers the vectors into the Flight stream via
- * {@link #transferTo(VectorSchemaRoot)} — no memcpy, no serialization.
+ * The framework zero-copy transfers the vectors into the Flight stream — no memcpy,
+ * no serialization.
  *
  * <pre>{@code
- * BufferAllocator allocator = ArrowFlightChannel.from(channel).getAllocator();
  * VectorSchemaRoot producerRoot = VectorSchemaRoot.create(schema, allocator);
  * // populate producerRoot...
  * channel.sendResponseBatch(new MyResponse(producerRoot));
@@ -46,10 +45,9 @@ import java.io.IOException;
  *
  * <p><b>Allocator rules:</b>
  * <ul>
- *   <li><b>Send side:</b> Use the channel allocator
- *       ({@code ArrowFlightChannel.from(channel).getAllocator()}) or a child of
- *       {@link ArrowAllocatorProvider}. All allocators must share the same root so
- *       zero-copy transfers pass Arrow's {@code AllocationManager} associate check.</li>
+ *   <li><b>Send side:</b> Use a child of {@link ArrowAllocatorProvider}. All allocators
+ *       must share the same root so zero-copy transfers pass Arrow's
+ *       {@code AllocationManager} associate check.</li>
  *   <li><b>Receive side:</b> The framework transfers vectors from the Flight stream's
  *       allocator into the response. The consumer can then transfer them into its own
  *       allocator — which must also be a child of {@link ArrowAllocatorProvider}.</li>
@@ -62,25 +60,25 @@ import java.io.IOException;
 @ExperimentalApi
 public abstract class ArrowBatchResponse extends ActionResponse {
 
-    private final VectorSchemaRoot producerRoot;
+    private final VectorSchemaRoot batch;
 
     /**
-     * Send-side constructor: wraps a root populated by the producer.
-     * @param producerRoot the root to send; ownership transfers to the framework
+     * Send-side constructor: wraps a batch populated by the producer.
+     * @param batch the batch to send; ownership transfers to the transport
      */
-    protected ArrowBatchResponse(VectorSchemaRoot producerRoot) {
-        this.producerRoot = producerRoot;
+    protected ArrowBatchResponse(VectorSchemaRoot batch) {
+        this.batch = batch;
     }
 
     /**
-     * Receive-side constructor: claims ownership of the Arrow vectors from the input.
+     * Receive-side constructor: claims ownership of the consumer batch from the input.
      * @param in must be a {@link VectorStreamInput.NativeArrow}; throws otherwise
      * @throws IOException if reading fails
      */
     protected ArrowBatchResponse(StreamInput in) throws IOException {
         super(in);
         if (in instanceof VectorStreamInput.NativeArrow nativeIn) {
-            this.producerRoot = nativeIn.getRoot();
+            this.batch = nativeIn.getRoot();
             nativeIn.claimOwnership();
         } else {
             throw new IllegalStateException(
@@ -92,21 +90,13 @@ public abstract class ArrowBatchResponse extends ActionResponse {
         }
     }
 
-    /** Returns the Arrow root holding the response vectors. */
+    /** Returns the Arrow batch holding the response vectors. */
     public VectorSchemaRoot getRoot() {
-        return producerRoot;
-    }
-
-    /**
-     * Zero-copy transfers the producer's vectors into the target root.
-     * @param target the channel's stream root (bound to the Flight stream via start())
-     */
-    void transferTo(VectorSchemaRoot target) {
-        FlightUtils.transferRoot(producerRoot, target);
+        return batch;
     }
 
     @Override
     public final void writeTo(StreamOutput out) throws IOException {
-        // no-op: the framework handles transfer via transferTo()
+        // no-op: the framework transfers vectors directly via FlightUtils.transferRoot()
     }
 }

--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/ArrowBatchResponse.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/ArrowBatchResponse.java
@@ -44,11 +44,18 @@ import java.io.IOException;
  * a {@link VectorStreamInput.NativeArrow} holding vectors transferred from the Flight stream.
  * The {@link #ArrowBatchResponse(StreamInput)} constructor claims ownership of those vectors.
  *
- * <p><b>Allocator guidelines:</b> The allocator for producer roots must outlive the gRPC
- * stream. gRPC's zero-copy write path retains buffer references beyond stream completion;
- * closing the allocator early causes memory accounting errors. Use the channel allocator
- * ({@code ArrowFlightChannel.from(channel).getAllocator()}) or a long-lived application
- * allocator.
+ * <p><b>Allocator rules:</b>
+ * <ul>
+ *   <li><b>Send side:</b> Use the channel allocator
+ *       ({@code ArrowFlightChannel.from(channel).getAllocator()}) or a child of
+ *       {@link ArrowAllocatorProvider}. All allocators must share the same root so
+ *       zero-copy transfers pass Arrow's {@code AllocationManager} associate check.</li>
+ *   <li><b>Receive side:</b> The framework transfers vectors from the Flight stream's
+ *       allocator into the response. The consumer can then transfer them into its own
+ *       allocator — which must also be a child of {@link ArrowAllocatorProvider}.</li>
+ *   <li>Allocators must outlive the gRPC stream — gRPC's zero-copy write path retains
+ *       buffer references beyond stream completion.</li>
+ * </ul>
  *
  * @opensearch.experimental
  */

--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/ArrowBatchResponseHandler.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/ArrowBatchResponseHandler.java
@@ -20,6 +20,9 @@ import org.opensearch.transport.StreamTransportResponseHandler;
  */
 @ExperimentalApi
 public abstract class ArrowBatchResponseHandler<T extends ArrowBatchResponse> implements StreamTransportResponseHandler<T> {
+    /** Constructor. */
+    protected ArrowBatchResponseHandler() {}
+
     @Override
     public final boolean skipsDeserialization() {
         return true;

--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/ArrowBatchResponseHandler.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/ArrowBatchResponseHandler.java
@@ -1,0 +1,27 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.arrow.flight.transport;
+
+import org.opensearch.common.annotation.ExperimentalApi;
+import org.opensearch.transport.StreamTransportResponseHandler;
+
+/**
+ * Receive-side base for handlers that consume {@link ArrowBatchResponse}. Pins
+ * {@link #skipsDeserialization()} to {@code true} so the Flight transport routes to the native
+ * Arrow path.
+ *
+ * @opensearch.experimental
+ */
+@ExperimentalApi
+public abstract class ArrowBatchResponseHandler<T extends ArrowBatchResponse> implements StreamTransportResponseHandler<T> {
+    @Override
+    public final boolean skipsDeserialization() {
+        return true;
+    }
+}

--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightOutboundHandler.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightOutboundHandler.java
@@ -6,17 +6,10 @@
  * compatible open source license.
  */
 
-/*
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- */
-
 package org.opensearch.arrow.flight.transport;
 
 import org.apache.arrow.flight.FlightRuntimeException;
+import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.opensearch.Version;
 import org.opensearch.cluster.node.DiscoveryNode;
@@ -36,6 +29,7 @@ import org.opensearch.transport.stream.StreamException;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -157,12 +151,15 @@ class FlightOutboundHandler extends ProtocolOutboundHandler {
                 // Native Arrow path: zero-copy transfer producer's vectors into stream root
                 VectorSchemaRoot streamRoot = flightChannel.getRoot();
                 if (streamRoot == null) {
-                    // Create stream root from the producer's allocator — same root required
-                    // for Arrow's AllocationManager associate check (see ArrowAllocatorProvider).
-                    streamRoot = VectorSchemaRoot.create(
-                        arrowResponse.getRoot().getSchema(),
-                        arrowResponse.getRoot().getFieldVectors().get(0).getAllocator()
-                    );
+                    // Create stream root using the producer's allocator for same-allocator transfer.
+                    // This avoids an Arrow bug where cross-allocator transferOwnership of foreign-backed
+                    // buffers (from C data import) doesn't properly free the ArrowArray C struct.
+                    // The producer's allocator must be long-lived (not closed per-request).
+                    List<FieldVector> fieldVectors = arrowResponse.getRoot().getFieldVectors();
+                    if (fieldVectors.isEmpty()) {
+                        throw new IllegalStateException("Native Arrow batch has no field vectors");
+                    }
+                    streamRoot = VectorSchemaRoot.create(arrowResponse.getRoot().getSchema(), fieldVectors.getFirst().getAllocator());
                 }
                 FlightUtils.transferRoot(arrowResponse.getRoot(), streamRoot);
                 arrowResponse.getRoot().close();

--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightOutboundHandler.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightOutboundHandler.java
@@ -154,21 +154,19 @@ class FlightOutboundHandler extends ProtocolOutboundHandler {
         try {
             VectorStreamOutput out;
             if (task.response() instanceof ArrowBatchResponse arrowResponse) {
-                // Native Arrow path: zero-copy transfer producer's vectors into shared root
-                VectorSchemaRoot sharedRoot = flightChannel.getRoot();
-                if (sharedRoot == null) {
-                    // Create shared root using the producer's allocator for same-allocator transfer.
-                    // This avoids an Arrow bug where cross-allocator transferOwnership of foreign-backed
-                    // buffers (from C data import) doesn't properly free the ArrowArray C struct.
-                    // The producer's allocator must be long-lived (not closed per-request).
-                    sharedRoot = VectorSchemaRoot.create(
+                // Native Arrow path: zero-copy transfer producer's vectors into stream root
+                VectorSchemaRoot streamRoot = flightChannel.getRoot();
+                if (streamRoot == null) {
+                    // Create stream root from the producer's allocator — same root required
+                    // for Arrow's AllocationManager associate check (see ArrowAllocatorProvider).
+                    streamRoot = VectorSchemaRoot.create(
                         arrowResponse.getRoot().getSchema(),
                         arrowResponse.getRoot().getFieldVectors().get(0).getAllocator()
                     );
                 }
-                arrowResponse.transferTo(sharedRoot);
-                arrowResponse.getRoot().close();  // release producer's buffers — safe, they've been moved
-                out = VectorStreamOutput.forNativeArrow(sharedRoot);
+                arrowResponse.transferTo(streamRoot);
+                arrowResponse.getRoot().close();
+                out = VectorStreamOutput.forNativeArrow(streamRoot);
             } else {
                 out = VectorStreamOutput.create(flightChannel.getAllocator(), flightChannel.getRoot());
                 task.response().writeTo(out);

--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightOutboundHandler.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightOutboundHandler.java
@@ -164,7 +164,7 @@ class FlightOutboundHandler extends ProtocolOutboundHandler {
                         arrowResponse.getRoot().getFieldVectors().get(0).getAllocator()
                     );
                 }
-                arrowResponse.transferTo(streamRoot);
+                FlightUtils.transferRoot(arrowResponse.getRoot(), streamRoot);
                 arrowResponse.getRoot().close();
                 out = VectorStreamOutput.forNativeArrow(streamRoot);
             } else {

--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightTransport.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightTransport.java
@@ -16,7 +16,6 @@ import org.apache.arrow.flight.Location;
 import org.apache.arrow.flight.OSFlightClient;
 import org.apache.arrow.flight.OSFlightServer;
 import org.apache.arrow.memory.BufferAllocator;
-import org.apache.arrow.memory.RootAllocator;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.Version;
@@ -54,8 +53,6 @@ import org.opensearch.transport.TransportKeepAlive;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -97,7 +94,7 @@ class FlightTransport extends TcpTransport {
     private final AtomicInteger nextExecutorIndex = new AtomicInteger(0);
 
     private final ThreadPool threadPool;
-    private RootAllocator rootAllocator;
+    private BufferAllocator rootAllocator;
     private BufferAllocator serverAllocator;
     private BufferAllocator clientAllocator;
 
@@ -146,7 +143,7 @@ class FlightTransport extends TcpTransport {
     protected void doStart() {
         boolean success = false;
         try {
-            rootAllocator = AccessController.doPrivileged((PrivilegedAction<RootAllocator>) () -> new RootAllocator(Integer.MAX_VALUE));
+            rootAllocator = ArrowAllocatorProvider.newChildAllocator("flight", Long.MAX_VALUE);
             serverAllocator = rootAllocator.newChildAllocator("server", 0, rootAllocator.getLimit());
             clientAllocator = rootAllocator.newChildAllocator("client", 0, rootAllocator.getLimit());
             if (statsCollector != null) {

--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightTransport.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightTransport.java
@@ -94,7 +94,7 @@ class FlightTransport extends TcpTransport {
     private final AtomicInteger nextExecutorIndex = new AtomicInteger(0);
 
     private final ThreadPool threadPool;
-    private BufferAllocator rootAllocator;
+    private BufferAllocator flightAllocator;
     private BufferAllocator serverAllocator;
     private BufferAllocator clientAllocator;
 
@@ -143,14 +143,14 @@ class FlightTransport extends TcpTransport {
     protected void doStart() {
         boolean success = false;
         try {
-            rootAllocator = ArrowAllocatorProvider.newChildAllocator("flight", Long.MAX_VALUE);
-            serverAllocator = rootAllocator.newChildAllocator("server", 0, rootAllocator.getLimit());
-            clientAllocator = rootAllocator.newChildAllocator("client", 0, rootAllocator.getLimit());
+            flightAllocator = ArrowAllocatorProvider.newChildAllocator("flight", Integer.MAX_VALUE);
+            serverAllocator = flightAllocator.newChildAllocator("server", 0, flightAllocator.getLimit());
+            clientAllocator = flightAllocator.newChildAllocator("client", 0, flightAllocator.getLimit());
             if (statsCollector != null) {
-                statsCollector.setBufferAllocator(rootAllocator);
+                statsCollector.setBufferAllocator(flightAllocator);
                 statsCollector.setThreadPool(threadPool);
             }
-            flightProducer = new ArrowFlightProducer(this, rootAllocator, SERVER_HEADER_KEY, statsCollector);
+            flightProducer = new ArrowFlightProducer(this, flightAllocator, SERVER_HEADER_KEY, statsCollector);
             bindServer();
             success = true;
             if (statsCollector != null) {
@@ -265,7 +265,7 @@ class FlightTransport extends TcpTransport {
             }
             serverAllocator.close();
             clientAllocator.close();
-            rootAllocator.close();
+            flightAllocator.close();
             gracefullyShutdownELG(bossEventLoopGroup, "os-grpc-boss-ELG");
             gracefullyShutdownELG(workerEventLoopGroup, "os-grpc-worker-ELG");
 

--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightTransportResponse.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightTransportResponse.java
@@ -44,6 +44,7 @@ class FlightTransportResponse<T extends TransportResponse> implements StreamTran
     private final NamedWriteableRegistry namedWriteableRegistry;
     private final HeaderContext headerContext;
     private final TransportResponseHandler<T> handler;
+    private final boolean isNativeHandler;
     private final FlightTransportConfig config;
     private final long correlationId;
 
@@ -64,6 +65,7 @@ class FlightTransportResponse<T extends TransportResponse> implements StreamTran
         FlightTransportConfig config
     ) {
         this.handler = Objects.requireNonNull(handler);
+        this.isNativeHandler = handler.skipsDeserialization();
         this.correlationId = correlationId;
         this.flightClient = Objects.requireNonNull(flightClient);
         this.headerContext = Objects.requireNonNull(headerContext);
@@ -121,10 +123,9 @@ class FlightTransportResponse<T extends TransportResponse> implements StreamTran
             boolean hasNext = firstBatchConsumed ? flightStream.next() : (firstBatchConsumed = true);
             if (!hasNext) return null;
 
-            VectorSchemaRoot sharedRoot = flightStream.getRoot();
-            currentBatchSize = FlightUtils.calculateVectorSchemaRootSize(sharedRoot);
-            VectorSchemaRoot ownedRoot = transferToOwnedRoot(sharedRoot);
-            try (VectorStreamInput input = new VectorStreamInput(ownedRoot, namedWriteableRegistry)) {
+            VectorSchemaRoot streamRoot = flightStream.getRoot();
+            currentBatchSize = FlightUtils.calculateVectorSchemaRootSize(streamRoot);
+            try (VectorStreamInput input = newStreamInput(streamRoot)) {
                 input.setVersion(initialHeader.getVersion());
                 return handler.read(input);
             }
@@ -145,19 +146,10 @@ class FlightTransportResponse<T extends TransportResponse> implements StreamTran
         return currentBatchSize;
     }
 
-    /**
-     * Transfers the shared root's vectors into a response-owned root so the returned response
-     * is independent of FlightStream's lifecycle. The next call to {@code flightStream.next()}
-     * clears the shared root, and {@code stream.close()} releases its vectors — both would wipe
-     * the data out from under an async listener if we handed back a reference to the shared root.
-     */
-    private static VectorSchemaRoot transferToOwnedRoot(VectorSchemaRoot sharedRoot) {
-        VectorSchemaRoot ownedRoot = VectorSchemaRoot.create(
-            sharedRoot.getSchema(),
-            sharedRoot.getFieldVectors().getFirst().getAllocator()
-        );
-        FlightUtils.transferRoot(sharedRoot, ownedRoot);
-        return ownedRoot;
+    private VectorStreamInput newStreamInput(VectorSchemaRoot streamRoot) {
+        return isNativeHandler
+            ? VectorStreamInput.forNativeArrow(streamRoot, namedWriteableRegistry)
+            : VectorStreamInput.forByteSerialized(streamRoot, namedWriteableRegistry);
     }
 
     @Override

--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/MetricsTrackingResponseHandler.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/MetricsTrackingResponseHandler.java
@@ -94,6 +94,11 @@ class MetricsTrackingResponseHandler<T extends TransportResponse> implements Tra
         return delegate.executor();
     }
 
+    @Override
+    public boolean skipsDeserialization() {
+        return delegate.skipsDeserialization();
+    }
+
     /**
      * A stream response wrapper that tracks metrics for batches.
      */

--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/VectorStreamInput.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/VectorStreamInput.java
@@ -22,93 +22,68 @@ import java.nio.ByteBuffer;
 /**
  * A {@link StreamInput} backed by a {@link VectorSchemaRoot} from the Flight transport.
  *
+ * <p>Two factories, mirroring {@link VectorStreamOutput}:
+ * <ul>
+ *   <li>{@link #forByteSerialized} — reads bytes directly from the shared root. Used when the
+ *       response is not an {@link ArrowBatchResponse}: {@code handler.read()} copies bytes into
+ *       the response's Java fields, so no ownership transfer is needed.</li>
+ *   <li>{@link #forNativeArrow} — zero-copy transfers the shared root's vectors into a
+ *       response-owned root before reading, so the returned {@link ArrowBatchResponse} is
+ *       independent of the FlightStream lifecycle.</li>
+ * </ul>
+ *
+ * <p>The caller ({@link FlightTransportResponse#nextResponse}) picks the factory based on whether
+ * the registered handler is an {@link ArrowBatchResponseHandler}.
+ *
  * @opensearch.internal
  */
-class VectorStreamInput extends StreamInput {
+abstract class VectorStreamInput extends StreamInput {
 
-    private final VarBinaryVector vector;
-    private final VectorSchemaRoot root;
-    private final NamedWriteableRegistry registry;
-    private int row = 0;
-    private ByteBuffer buffer = null;
+    protected final VectorSchemaRoot root;
+    protected final NamedWriteableRegistry registry;
 
-    /**
-     * Creates a new VectorStreamInput.
-     * @param root the Arrow root containing the data
-     * @param registry the named writeable registry
-     */
-    public VectorStreamInput(VectorSchemaRoot root, NamedWriteableRegistry registry) {
+    protected VectorStreamInput(VectorSchemaRoot root, NamedWriteableRegistry registry) {
         this.root = root;
-        vector = (VarBinaryVector) root.getVector("0");
         this.registry = registry;
     }
 
     /**
-     * Returns the underlying {@link VectorSchemaRoot}.
+     * Byte-serialized path: the shared root carries a single {@code VarBinary} column of chunked
+     * bytes written by {@link VectorStreamOutput.ByteSerialized}. Reads are over the shared root;
+     * FlightStream retains ownership.
+     */
+    static VectorStreamInput forByteSerialized(VectorSchemaRoot streamRoot, NamedWriteableRegistry registry) {
+        return new ByteSerialized(streamRoot, registry);
+    }
+
+    /**
+     * Transfers the stream root's vectors into a response-owned root so the returned response
+     * outlives the next FlightStream batch. Owned root is released by {@link NativeArrow#close()}
+     * unless the response takes ownership via {@link NativeArrow#claimOwnership()}.
+     */
+    static VectorStreamInput forNativeArrow(VectorSchemaRoot streamRoot, NamedWriteableRegistry registry) {
+        if (streamRoot.getFieldVectors().isEmpty()) {
+            throw new IllegalStateException("Native Arrow batch has no field vectors");
+        }
+        VectorSchemaRoot ownedRoot = VectorSchemaRoot.create(
+            streamRoot.getSchema(),
+            streamRoot.getFieldVectors().getFirst().getAllocator()
+        );
+        try {
+            FlightUtils.transferRoot(streamRoot, ownedRoot);
+        } catch (Throwable t) {
+            ownedRoot.close();
+            throw t;
+        }
+        return new NativeArrow(ownedRoot, registry);
+    }
+
+    /**
+     * Returns the underlying {@link VectorSchemaRoot}. For {@link NativeArrow} this is the
+     * response-owned root; {@link ArrowBatchResponse} grabs it via the receive-side constructor.
      */
     public VectorSchemaRoot getRoot() {
         return root;
-    }
-
-    @Override
-    public byte readByte() throws IOException {
-        // Check if buffer has remaining bytes
-        if (buffer != null && buffer.hasRemaining()) {
-            return buffer.get();
-        }
-        // No buffer or buffer exhausted, read from vector
-        if (row >= vector.getValueCount()) {
-            throw new EOFException("No more rows available in vector");
-        }
-        byte[] v = vector.get(row++);
-        if (v.length == 0) {
-            throw new IOException("Empty byte array in vector at row " + (row - 1));
-        }
-        // Wrap the byte array in buffer for future reads
-        buffer = ByteBuffer.wrap(v);
-        return buffer.get(); // Read the first byte
-    }
-
-    @Override
-    public void readBytes(byte[] b, int offset, int len) throws IOException {
-        if (offset < 0 || len < 0 || offset + len > b.length) {
-            throw new IllegalArgumentException("Invalid offset or length");
-        }
-        int remaining = len;
-
-        // First, exhaust any remaining bytes in the buffer
-        if (buffer != null && buffer.hasRemaining()) {
-            int bufferBytes = Math.min(buffer.remaining(), remaining);
-            buffer.get(b, offset, bufferBytes);
-            offset += bufferBytes;
-            remaining -= bufferBytes;
-            if (!buffer.hasRemaining()) {
-                buffer = null; // Clear buffer if exhausted
-            }
-        }
-
-        // Read from vector if more bytes are needed
-        while (remaining > 0) {
-            if (row >= vector.getValueCount()) {
-                throw new EOFException("No more rows available in vector");
-            }
-            byte[] v = vector.get(row++);
-            if (v.length == 0) {
-                throw new IOException("Empty byte array in vector at row " + (row - 1));
-            }
-            if (v.length <= remaining) {
-                // The entire vector row can be consumed
-                System.arraycopy(v, 0, b, offset, v.length);
-                offset += v.length;
-                remaining -= v.length;
-            } else {
-                // Partial read from vector row
-                System.arraycopy(v, 0, b, offset, remaining);
-                // Store remaining bytes in buffer without copying
-                buffer = ByteBuffer.wrap(v, remaining, v.length - remaining);
-                remaining = 0;
-            }
-        }
     }
 
     @Override
@@ -130,24 +105,121 @@ class VectorStreamInput extends StreamInput {
     }
 
     @Override
-    public void close() throws IOException {
-        if (vector != null) {
-            vector.close();
-        }
-    }
-
-    @Override
     public int read() throws IOException {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public int available() throws IOException {
+    public int available() {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    protected void ensureCanReadBytes(int length) throws EOFException {
+    protected void ensureCanReadBytes(int length) {}
 
+    // ── Byte serialization ──
+
+    static final class ByteSerialized extends VectorStreamInput {
+        private final VarBinaryVector vector;
+        private int row = 0;
+        private ByteBuffer buffer = null;
+
+        ByteSerialized(VectorSchemaRoot root, NamedWriteableRegistry registry) {
+            super(root, registry);
+            this.vector = (VarBinaryVector) root.getVector("0");
+        }
+
+        @Override
+        public byte readByte() throws IOException {
+            if (buffer != null && buffer.hasRemaining()) {
+                return buffer.get();
+            }
+            if (row >= vector.getValueCount()) {
+                throw new EOFException("No more rows available in vector");
+            }
+            byte[] v = vector.get(row++);
+            if (v.length == 0) {
+                throw new IOException("Empty byte array in vector at row " + (row - 1));
+            }
+            buffer = ByteBuffer.wrap(v);
+            return buffer.get();
+        }
+
+        @Override
+        public void readBytes(byte[] b, int offset, int len) throws IOException {
+            if (offset < 0 || len < 0 || offset + len > b.length) {
+                throw new IllegalArgumentException("Invalid offset or length");
+            }
+            int remaining = len;
+
+            if (buffer != null && buffer.hasRemaining()) {
+                int bufferBytes = Math.min(buffer.remaining(), remaining);
+                buffer.get(b, offset, bufferBytes);
+                offset += bufferBytes;
+                remaining -= bufferBytes;
+                if (!buffer.hasRemaining()) {
+                    buffer = null;
+                }
+            }
+
+            while (remaining > 0) {
+                if (row >= vector.getValueCount()) {
+                    throw new EOFException("No more rows available in vector");
+                }
+                byte[] v = vector.get(row++);
+                if (v.length == 0) {
+                    throw new IOException("Empty byte array in vector at row " + (row - 1));
+                }
+                if (v.length <= remaining) {
+                    System.arraycopy(v, 0, b, offset, v.length);
+                    offset += v.length;
+                    remaining -= v.length;
+                } else {
+                    System.arraycopy(v, 0, b, offset, remaining);
+                    buffer = ByteBuffer.wrap(v, remaining, v.length - remaining);
+                    remaining = 0;
+                }
+            }
+        }
+
+        /**
+         * No-op: the shared root belongs to {@link org.apache.arrow.flight.FlightStream}, which
+         * clears the vectors on the next {@code next()} and closes them on stream close.
+         */
+        @Override
+        public void close() {}
+    }
+
+    // ── Native Arrow ──
+
+    static final class NativeArrow extends VectorStreamInput {
+        private boolean transferred = false;
+
+        NativeArrow(VectorSchemaRoot root, NamedWriteableRegistry registry) {
+            super(root, registry);
+        }
+
+        @Override
+        public byte readByte() {
+            throw new UnsupportedOperationException("Native Arrow responses read vectors directly from getRoot()");
+        }
+
+        @Override
+        public void readBytes(byte[] b, int offset, int len) {
+            throw new UnsupportedOperationException("Native Arrow responses read vectors directly from getRoot()");
+        }
+
+        /** Response claims the owned root; {@link #close()} becomes a no-op. */
+        void claimOwnership() {
+            transferred = true;
+        }
+
+        /** Releases the owned root unless {@link #claimOwnership()} was called. */
+        @Override
+        public void close() {
+            if (!transferred && root != null) {
+                root.close();
+            }
+        }
     }
 }

--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/VectorStreamInput.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/VectorStreamInput.java
@@ -28,7 +28,7 @@ import java.nio.ByteBuffer;
  *       response is not an {@link ArrowBatchResponse}: {@code handler.read()} copies bytes into
  *       the response's Java fields, so no ownership transfer is needed.</li>
  *   <li>{@link #forNativeArrow} — zero-copy transfers the stream root's vectors into a
- *       response-owned root before reading, so the returned {@link ArrowBatchResponse} is
+ *       consumer root before reading, so the returned {@link ArrowBatchResponse} is
  *       independent of the FlightStream lifecycle.</li>
  * </ul>
  *
@@ -57,30 +57,30 @@ abstract class VectorStreamInput extends StreamInput {
     }
 
     /**
-     * Transfers the stream root's vectors into a response-owned root so the returned response
-     * outlives the next FlightStream batch. Owned root is released by {@link NativeArrow#close()}
+     * Transfers the stream root's vectors into a consumer root so the returned response
+     * outlives the next FlightStream batch. The consumer root is released by {@link NativeArrow#close()}
      * unless the response takes ownership via {@link NativeArrow#claimOwnership()}.
      */
     static VectorStreamInput forNativeArrow(VectorSchemaRoot streamRoot, NamedWriteableRegistry registry) {
         if (streamRoot.getFieldVectors().isEmpty()) {
             throw new IllegalStateException("Native Arrow batch has no field vectors");
         }
-        VectorSchemaRoot ownedRoot = VectorSchemaRoot.create(
+        VectorSchemaRoot consumerRoot = VectorSchemaRoot.create(
             streamRoot.getSchema(),
             streamRoot.getFieldVectors().getFirst().getAllocator()
         );
         try {
-            FlightUtils.transferRoot(streamRoot, ownedRoot);
+            FlightUtils.transferRoot(streamRoot, consumerRoot);
         } catch (Throwable t) {
-            ownedRoot.close();
+            consumerRoot.close();
             throw t;
         }
-        return new NativeArrow(ownedRoot, registry);
+        return new NativeArrow(consumerRoot, registry);
     }
 
     /**
      * Returns the underlying {@link VectorSchemaRoot}. For {@link NativeArrow} this is the
-     * response-owned root; {@link ArrowBatchResponse} grabs it via the receive-side constructor.
+     * consumer root; {@link ArrowBatchResponse} grabs it via the receive-side constructor.
      */
     public VectorSchemaRoot getRoot() {
         return root;
@@ -209,12 +209,12 @@ abstract class VectorStreamInput extends StreamInput {
             throw new UnsupportedOperationException("Native Arrow responses read vectors directly from getRoot()");
         }
 
-        /** Response claims the owned root; {@link #close()} becomes a no-op. */
+        /** Response claims the consumer root; {@link #close()} becomes a no-op. */
         void claimOwnership() {
             transferred = true;
         }
 
-        /** Releases the owned root unless {@link #claimOwnership()} was called. */
+        /** Releases the consumer root unless {@link #claimOwnership()} was called. */
         @Override
         public void close() {
             if (!transferred && root != null) {

--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/VectorStreamInput.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/VectorStreamInput.java
@@ -114,6 +114,11 @@ abstract class VectorStreamInput extends StreamInput {
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * No-op: bounds checks happen at read time, not as a pre-check.
+     * {@link ByteSerialized#readByte} and {@link ByteSerialized#readBytes} throw
+     * {@link EOFException} when the column is exhausted.
+     */
     @Override
     protected void ensureCanReadBytes(int length) {}
 

--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/VectorStreamInput.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/VectorStreamInput.java
@@ -24,10 +24,10 @@ import java.nio.ByteBuffer;
  *
  * <p>Two factories, mirroring {@link VectorStreamOutput}:
  * <ul>
- *   <li>{@link #forByteSerialized} — reads bytes directly from the shared root. Used when the
+ *   <li>{@link #forByteSerialized} — reads bytes directly from the stream root. Used when the
  *       response is not an {@link ArrowBatchResponse}: {@code handler.read()} copies bytes into
  *       the response's Java fields, so no ownership transfer is needed.</li>
- *   <li>{@link #forNativeArrow} — zero-copy transfers the shared root's vectors into a
+ *   <li>{@link #forNativeArrow} — zero-copy transfers the stream root's vectors into a
  *       response-owned root before reading, so the returned {@link ArrowBatchResponse} is
  *       independent of the FlightStream lifecycle.</li>
  * </ul>
@@ -48,8 +48,8 @@ abstract class VectorStreamInput extends StreamInput {
     }
 
     /**
-     * Byte-serialized path: the shared root carries a single {@code VarBinary} column of chunked
-     * bytes written by {@link VectorStreamOutput.ByteSerialized}. Reads are over the shared root;
+     * Byte-serialized path: the stream root carries a single {@code VarBinary} column of chunked
+     * bytes written by {@link VectorStreamOutput.ByteSerialized}. Reads are over the stream root;
      * FlightStream retains ownership.
      */
     static VectorStreamInput forByteSerialized(VectorSchemaRoot streamRoot, NamedWriteableRegistry registry) {
@@ -183,7 +183,7 @@ abstract class VectorStreamInput extends StreamInput {
         }
 
         /**
-         * No-op: the shared root belongs to {@link org.apache.arrow.flight.FlightStream}, which
+         * No-op: the stream root belongs to {@link org.apache.arrow.flight.FlightStream}, which
          * clears the vectors on the next {@code next()} and closes them on stream close.
          */
         @Override

--- a/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/ArrowBatchResponseTests.java
+++ b/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/ArrowBatchResponseTests.java
@@ -84,8 +84,7 @@ public class ArrowBatchResponseTests extends OpenSearchTestCase {
         src.setRowCount(2);
 
         VectorSchemaRoot dst = VectorSchemaRoot.create(schema, allocator);
-        TestResponse response = new TestResponse(src);
-        response.transferTo(dst);
+        FlightUtils.transferRoot(src, dst);
 
         assertEquals(2, dst.getRowCount());
         IntVector dstVec = (IntVector) dst.getVector("val");
@@ -115,9 +114,9 @@ public class ArrowBatchResponseTests extends OpenSearchTestCase {
         src.setRowCount(2);
 
         VectorSchemaRoot dst = VectorSchemaRoot.create(schema, allocator);
-        new TestResponse(src).transferTo(dst);
+        FlightUtils.transferRoot(src, dst);
 
-        // Close the source — simulates FlightStream clearing/closing its shared root.
+        // Close the source — simulates FlightStream clearing/closing its stream root.
         src.close();
 
         assertEquals(2, dst.getRowCount());
@@ -139,13 +138,12 @@ public class ArrowBatchResponseTests extends OpenSearchTestCase {
         org.opensearch.core.common.io.stream.NamedWriteableRegistry registry =
             new org.opensearch.core.common.io.stream.NamedWriteableRegistry(java.util.Collections.emptyList());
         VectorStreamInput.NativeArrow in = (VectorStreamInput.NativeArrow) VectorStreamInput.forNativeArrow(shared, registry);
-        VectorSchemaRoot ownedRoot = in.getRoot();
+        VectorSchemaRoot consumerRoot = in.getRoot();
 
         TestResponse response = new TestResponse(in);
-        // Root reference captured from the input.
-        assertSame(ownedRoot, response.getRoot());
+        assertSame(consumerRoot, response.getRoot());
 
-        // claimOwnership must have fired — close() is a no-op, owned root survives.
+        // claimOwnership must have fired — close() is a no-op, consumer root survives.
         in.close();
         assertEquals(42, ((IntVector) response.getRoot().getVector("val")).get(0));
 
@@ -186,7 +184,7 @@ public class ArrowBatchResponseTests extends OpenSearchTestCase {
         src.setRowCount(1);
 
         VectorSchemaRoot dst = VectorSchemaRoot.create(multiSchema, allocator);
-        new TestResponse(src).transferTo(dst);
+        FlightUtils.transferRoot(src, dst);
 
         assertEquals(1, dst.getRowCount());
         assertEquals(1, ((IntVector) dst.getVector("a")).get(0));

--- a/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/ArrowBatchResponseTests.java
+++ b/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/ArrowBatchResponseTests.java
@@ -129,6 +129,45 @@ public class ArrowBatchResponseTests extends OpenSearchTestCase {
         dst.close();
     }
 
+    public void testStreamInputConstructorCapturesRootAndMarksTransferred() throws IOException {
+        VectorSchemaRoot shared = VectorSchemaRoot.create(schema, allocator);
+        ((IntVector) shared.getVector("val")).allocateNew();
+        ((IntVector) shared.getVector("val")).setSafe(0, 42);
+        ((IntVector) shared.getVector("val")).setValueCount(1);
+        shared.setRowCount(1);
+
+        org.opensearch.core.common.io.stream.NamedWriteableRegistry registry =
+            new org.opensearch.core.common.io.stream.NamedWriteableRegistry(java.util.Collections.emptyList());
+        VectorStreamInput.NativeArrow in = (VectorStreamInput.NativeArrow) VectorStreamInput.forNativeArrow(shared, registry);
+        VectorSchemaRoot ownedRoot = in.getRoot();
+
+        TestResponse response = new TestResponse(in);
+        // Root reference captured from the input.
+        assertSame(ownedRoot, response.getRoot());
+
+        // claimOwnership must have fired — close() is a no-op, owned root survives.
+        in.close();
+        assertEquals(42, ((IntVector) response.getRoot().getVector("val")).get(0));
+
+        response.getRoot().close();
+        shared.close();
+    }
+
+    public void testStreamInputConstructorRejectsByteSerializedInput() throws IOException {
+        VectorSchemaRoot shared = VectorSchemaRoot.create(
+            new Schema(List.of(new Field("0", FieldType.nullable(new ArrowType.Binary()), null))),
+            allocator
+        );
+        org.opensearch.core.common.io.stream.NamedWriteableRegistry registry =
+            new org.opensearch.core.common.io.stream.NamedWriteableRegistry(java.util.Collections.emptyList());
+        try (VectorStreamInput in = VectorStreamInput.forByteSerialized(shared, registry)) {
+            IllegalStateException e = expectThrows(IllegalStateException.class, () -> new TestResponse(in));
+            assertTrue("message should point at skipsDeserialization()", e.getMessage().contains("skipsDeserialization"));
+        } finally {
+            shared.close();
+        }
+    }
+
     public void testTransferToWithMultipleVectors() {
         Schema multiSchema = new Schema(
             List.of(

--- a/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/ArrowStreamSerializationTests.java
+++ b/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/ArrowStreamSerializationTests.java
@@ -54,7 +54,7 @@ public class ArrowStreamSerializationTests extends OpenSearchTestCase {
             output.writeNamedWriteable(original);
             VectorSchemaRoot unifiedRoot = output.getRoot();
 
-            try (VectorStreamInput input = new VectorStreamInput(unifiedRoot, registry)) {
+            try (VectorStreamInput input = VectorStreamInput.forByteSerialized(unifiedRoot, registry)) {
                 StringTerms deserialized = input.readNamedWriteable(StringTerms.class);
                 assertEquals(String.valueOf(original), String.valueOf(deserialized));
             }

--- a/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/FlightOutboundHandlerTests.java
+++ b/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/FlightOutboundHandlerTests.java
@@ -224,7 +224,7 @@ public class FlightOutboundHandlerTests extends OpenSearchTestCase {
             vec.setValueCount(1);
             producerRoot.setRowCount(1);
 
-            // First batch: sharedRoot is null, so it should be created
+            // First batch: streamRoot is null, so it should be created
             when(mockFlightChannel.getRoot()).thenReturn(null);
 
             CountDownLatch latch = new CountDownLatch(1);
@@ -242,7 +242,7 @@ public class FlightOutboundHandlerTests extends OpenSearchTestCase {
                 assertNotNull(sentRoot);
                 assertEquals(1, sentRoot.getRowCount());
                 assertEquals(42, ((IntVector) sentRoot.getVector("val")).get(0));
-                // Clean up the shared root created by the handler
+                // Clean up the stream root created by the handler
                 sentRoot.close();
                 return null;
             }).when(mockFlightChannel).sendBatch(any(), any(VectorStreamOutput.class));
@@ -265,13 +265,13 @@ public class FlightOutboundHandlerTests extends OpenSearchTestCase {
         }
     }
 
-    public void testProcessBatchTaskNativeArrowWithExistingSharedRoot() throws Exception {
+    public void testProcessBatchTaskNativeArrowWithExistingStreamRoot() throws Exception {
         try (RootAllocator allocator = new RootAllocator()) {
             Schema schema = new Schema(List.of(new Field("val", FieldType.nullable(new ArrowType.Int(32, true)), null)));
 
-            // Simulate existing shared root (second batch scenario)
-            VectorSchemaRoot sharedRoot = VectorSchemaRoot.create(schema, allocator);
-            when(mockFlightChannel.getRoot()).thenReturn(sharedRoot);
+            // Simulate existing stream root (second batch scenario)
+            VectorSchemaRoot streamRoot = VectorSchemaRoot.create(schema, allocator);
+            when(mockFlightChannel.getRoot()).thenReturn(streamRoot);
 
             VectorSchemaRoot producerRoot = VectorSchemaRoot.create(schema, allocator);
             IntVector vec = (IntVector) producerRoot.getVector("val");
@@ -285,8 +285,8 @@ public class FlightOutboundHandlerTests extends OpenSearchTestCase {
             doAnswer(invocation -> {
                 VectorStreamOutput out = invocation.getArgument(1);
                 VectorSchemaRoot sentRoot = out.getRoot();
-                // Should reuse the existing shared root
-                assertSame(sharedRoot, sentRoot);
+                // Should reuse the existing stream root
+                assertSame(streamRoot, sentRoot);
                 assertEquals(1, sentRoot.getRowCount());
                 assertEquals(99, ((IntVector) sentRoot.getVector("val")).get(0));
                 return null;
@@ -311,7 +311,7 @@ public class FlightOutboundHandlerTests extends OpenSearchTestCase {
             );
 
             assertTrue("Task should complete", latch.await(5, TimeUnit.SECONDS));
-            sharedRoot.close();
+            streamRoot.close();
         }
     }
 

--- a/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/FlightTransportResponseTests.java
+++ b/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/FlightTransportResponseTests.java
@@ -1,0 +1,117 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.arrow.flight.transport;
+
+import org.opensearch.core.transport.TransportResponse;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.transport.StreamTransportResponseHandler;
+import org.opensearch.transport.TransportException;
+import org.opensearch.transport.TransportResponseHandler;
+
+import java.io.IOException;
+
+public class FlightTransportResponseTests extends OpenSearchTestCase {
+
+    public void testArrowHandlerSkipsDeserialization() {
+        assertTrue(new TestArrowHandler().skipsDeserialization());
+    }
+
+    public void testNonArrowHandlerDoesNotSkip() {
+        assertFalse(new TestByteHandler().skipsDeserialization());
+    }
+
+    public void testWrapperForwardsTrueFromArrowHandler() {
+        assertTrue(new ForwardingWrapper<>(new TestArrowHandler()).skipsDeserialization());
+    }
+
+    public void testWrapperForwardsFalseFromNonArrowHandler() {
+        assertFalse(new ForwardingWrapper<>(new TestByteHandler()).skipsDeserialization());
+    }
+
+    public void testRealMetricsTrackingWrapperForwards() {
+        // MetricsTrackingResponseHandler in production path; null tracker is fine for this check.
+        MetricsTrackingResponseHandler<TestArrowResponse> wrapped = new MetricsTrackingResponseHandler<>(new TestArrowHandler(), null);
+        assertTrue(wrapped.skipsDeserialization());
+    }
+
+    private static final class TestArrowHandler extends ArrowBatchResponseHandler<TestArrowResponse> {
+        @Override
+        public TestArrowResponse read(org.opensearch.core.common.io.stream.StreamInput in) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void handleResponse(TestArrowResponse response) {}
+
+        @Override
+        public void handleException(TransportException exp) {}
+
+        @Override
+        public String executor() {
+            return "same";
+        }
+    }
+
+    private static final class TestByteHandler implements StreamTransportResponseHandler<TransportResponse> {
+        @Override
+        public TransportResponse read(org.opensearch.core.common.io.stream.StreamInput in) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void handleResponse(TransportResponse response) {}
+
+        @Override
+        public void handleException(TransportException exp) {}
+
+        @Override
+        public String executor() {
+            return "same";
+        }
+    }
+
+    private static final class ForwardingWrapper<T extends TransportResponse> implements TransportResponseHandler<T> {
+        private final TransportResponseHandler<T> delegate;
+
+        ForwardingWrapper(TransportResponseHandler<T> delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public T read(org.opensearch.core.common.io.stream.StreamInput in) throws IOException {
+            return delegate.read(in);
+        }
+
+        @Override
+        public void handleResponse(T response) {
+            delegate.handleResponse(response);
+        }
+
+        @Override
+        public void handleException(TransportException exp) {
+            delegate.handleException(exp);
+        }
+
+        @Override
+        public String executor() {
+            return delegate.executor();
+        }
+
+        @Override
+        public boolean skipsDeserialization() {
+            return delegate.skipsDeserialization();
+        }
+    }
+
+    private static final class TestArrowResponse extends ArrowBatchResponse {
+        TestArrowResponse() {
+            super((org.apache.arrow.vector.VectorSchemaRoot) null);
+        }
+    }
+}

--- a/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/VectorStreamInputTests.java
+++ b/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/VectorStreamInputTests.java
@@ -10,6 +10,7 @@ package org.opensearch.arrow.flight.transport;
 
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.IntVector;
 import org.apache.arrow.vector.VarBinaryVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.types.pojo.ArrowType;
@@ -21,6 +22,7 @@ import org.opensearch.test.OpenSearchTestCase;
 import org.junit.After;
 import org.junit.Before;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 
@@ -44,27 +46,263 @@ public class VectorStreamInputTests extends OpenSearchTestCase {
         super.tearDown();
     }
 
-    public void testGetRootReturnsRoot() {
-        Schema schema = new Schema(List.of(new Field("0", FieldType.nullable(new ArrowType.Binary()), null)));
-        VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator);
-        VarBinaryVector vec = (VarBinaryVector) root.getVector("0");
-        vec.allocateNew();
-        vec.setValueCount(0);
-        root.setRowCount(0);
-
-        VectorStreamInput input = new VectorStreamInput(root, registry);
-        assertSame(root, input.getRoot());
-        root.close();
+    public void testByteSerializedReadsFromSharedRoot() throws IOException {
+        VectorSchemaRoot shared = newByteSerializedRoot();
+        try (VectorStreamInput input = VectorStreamInput.forByteSerialized(shared, registry)) {
+            assertTrue(input instanceof VectorStreamInput.ByteSerialized);
+            assertSame("ByteSerialized holds the shared root — no transfer", shared, input.getRoot());
+        }
+        shared.close();
     }
 
-    public void testCloseWithNullVector() throws Exception {
-        // Create a root with no vector named "0" so vector field is null
-        Schema schema = new Schema(List.of(new Field("other", FieldType.nullable(new ArrowType.Utf8()), null)));
-        VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator);
+    public void testNativeArrowTransfersIntoOwnedRoot() throws IOException {
+        VectorSchemaRoot shared = newNativeArrowRoot();
+        IntVector srcVec = (IntVector) shared.getVector("val");
+        srcVec.allocateNew();
+        srcVec.setSafe(0, 42);
+        srcVec.setValueCount(1);
+        shared.setRowCount(1);
 
-        VectorStreamInput input = new VectorStreamInput(root, registry);
-        // close() should not throw even though vector is null
+        VectorStreamInput.NativeArrow input = (VectorStreamInput.NativeArrow) VectorStreamInput.forNativeArrow(shared, registry);
+        try {
+            assertNotSame("NativeArrow transfers into a fresh owned root", shared, input.getRoot());
+            IntVector dstVec = (IntVector) input.getRoot().getVector("val");
+            assertEquals(1, input.getRoot().getRowCount());
+            assertEquals(42, dstVec.get(0));
+            assertEquals("source must be drained", 0, shared.getRowCount());
+
+            // Close the shared root immediately — owned root must survive.
+            shared.close();
+            assertEquals("owned root survives shared-root close", 42, dstVec.get(0));
+
+            // Simulate ArrowBatchResponse taking ownership, then close the owned root on the response side.
+            input.claimOwnership();
+        } finally {
+            input.close(); // no-op after claimOwnership
+            input.getRoot().close();
+        }
+    }
+
+    public void testByteSerializedCloseIsNoOpOnSharedRoot() throws IOException {
+        VectorSchemaRoot shared = newByteSerializedRoot();
+        VarBinaryVector vec = (VarBinaryVector) shared.getVector("0");
+        vec.allocateNew();
+        vec.setSafe(0, new byte[] { 1, 2, 3 });
+        vec.setValueCount(1);
+        shared.setRowCount(1);
+
+        VectorStreamInput input = VectorStreamInput.forByteSerialized(shared, registry);
         input.close();
-        root.close();
+
+        // Shared root must remain fully usable — FlightStream owns its lifecycle.
+        assertEquals(1, shared.getRowCount());
+        assertEquals(3, ((VarBinaryVector) shared.getVector("0")).get(0).length);
+        shared.close();
+    }
+
+    public void testNativeArrowCloseReleasesRootIfNotTransferred() throws IOException {
+        // read() throws or never runs: the owned root must be released by close(), not leaked.
+        VectorSchemaRoot shared = newNativeArrowRoot();
+        IntVector srcVec = (IntVector) shared.getVector("val");
+        srcVec.allocateNew();
+        srcVec.setSafe(0, 7);
+        srcVec.setValueCount(1);
+        shared.setRowCount(1);
+
+        long beforeClose;
+        try (VectorStreamInput.NativeArrow input = (VectorStreamInput.NativeArrow) VectorStreamInput.forNativeArrow(shared, registry)) {
+            beforeClose = allocator.getAllocatedMemory();
+            assertTrue("owned root should hold memory before close", beforeClose > 0);
+        }
+        // After try-with-resources: close() ran, transferred==false, root should be released.
+        assertTrue(
+            "owned root must be released when not transferred (was " + beforeClose + ", now " + allocator.getAllocatedMemory() + ")",
+            allocator.getAllocatedMemory() < beforeClose
+        );
+        shared.close();
+    }
+
+    public void testNativeArrowCloseIsNoOpAfterMarkTransferred() throws IOException {
+        // ArrowBatchResponse(StreamInput) calls claimOwnership to take ownership.
+        // After that, close() must leave the root alone so the response can use it.
+        VectorSchemaRoot shared = newNativeArrowRoot();
+        IntVector srcVec = (IntVector) shared.getVector("val");
+        srcVec.allocateNew();
+        srcVec.setSafe(0, 7);
+        srcVec.setValueCount(1);
+        shared.setRowCount(1);
+
+        VectorStreamInput.NativeArrow input = (VectorStreamInput.NativeArrow) VectorStreamInput.forNativeArrow(shared, registry);
+        VectorSchemaRoot owned = input.getRoot();
+        input.claimOwnership();
+        input.close();
+
+        // Owned root must remain usable — ArrowBatchResponse owns it after handoff.
+        assertEquals(1, owned.getRowCount());
+        assertEquals(7, ((IntVector) owned.getVector("val")).get(0));
+        owned.close();
+        shared.close();
+    }
+
+    public void testForNativeArrowRejectsEmptySchema() {
+        Schema emptySchema = new Schema(List.<Field>of());
+        VectorSchemaRoot shared = VectorSchemaRoot.create(emptySchema, allocator);
+        try {
+            IllegalStateException e = expectThrows(IllegalStateException.class, () -> VectorStreamInput.forNativeArrow(shared, registry));
+            assertTrue(e.getMessage().contains("no field vectors"));
+        } finally {
+            shared.close();
+        }
+    }
+
+    public void testByteSerializedReadsBytesFromSharedVector() throws IOException {
+        VectorSchemaRoot shared = newByteSerializedRoot();
+        VarBinaryVector vec = (VarBinaryVector) shared.getVector("0");
+        vec.allocateNew();
+        vec.setSafe(0, new byte[] { 10, 20, 30 });
+        vec.setValueCount(1);
+        shared.setRowCount(1);
+
+        try (VectorStreamInput input = VectorStreamInput.forByteSerialized(shared, registry)) {
+            assertEquals((byte) 10, input.readByte());
+            assertEquals((byte) 20, input.readByte());
+            assertEquals((byte) 30, input.readByte());
+        }
+        shared.close();
+    }
+
+    public void testNativeArrowRejectsByteReads() throws IOException {
+        VectorSchemaRoot shared = newNativeArrowRoot();
+        try (VectorStreamInput input = VectorStreamInput.forNativeArrow(shared, registry)) {
+            expectThrows(UnsupportedOperationException.class, input::readByte);
+            expectThrows(UnsupportedOperationException.class, () -> input.readBytes(new byte[1], 0, 1));
+            // Do not call input.getRoot().close() — the try-with-resources close() releases the
+            // owned root (transferred==false).
+        }
+        shared.close();
+    }
+
+    public void testReadByteEofWhenRowsExhausted() throws IOException {
+        VectorSchemaRoot shared = newByteSerializedRoot();
+        ((VarBinaryVector) shared.getVector("0")).allocateNew();
+        shared.setRowCount(0);
+        try (VectorStreamInput input = VectorStreamInput.forByteSerialized(shared, registry)) {
+            expectThrows(java.io.EOFException.class, input::readByte);
+        }
+        shared.close();
+    }
+
+    public void testReadByteRejectsEmptyRow() throws IOException {
+        VectorSchemaRoot shared = newByteSerializedRoot();
+        VarBinaryVector vec = (VarBinaryVector) shared.getVector("0");
+        vec.allocateNew();
+        vec.setSafe(0, new byte[0]);
+        vec.setValueCount(1);
+        shared.setRowCount(1);
+        try (VectorStreamInput input = VectorStreamInput.forByteSerialized(shared, registry)) {
+            expectThrows(IOException.class, input::readByte);
+        }
+        shared.close();
+    }
+
+    public void testReadBytesInvalidOffsetThrows() throws IOException {
+        VectorSchemaRoot shared = newByteSerializedRoot();
+        try (VectorStreamInput input = VectorStreamInput.forByteSerialized(shared, registry)) {
+            byte[] target = new byte[4];
+            expectThrows(IllegalArgumentException.class, () -> input.readBytes(target, -1, 2));
+            expectThrows(IllegalArgumentException.class, () -> input.readBytes(target, 0, -1));
+            expectThrows(IllegalArgumentException.class, () -> input.readBytes(target, 3, 5));
+        }
+        shared.close();
+    }
+
+    public void testReadBytesSpansMultipleRowsWithLeftover() throws IOException {
+        // Row 0: 3 bytes, row 1: 4 bytes. Read 5 bytes — spans both rows, leaves 2 in buffer
+        // for a follow-up readByte.
+        VectorSchemaRoot shared = newByteSerializedRoot();
+        VarBinaryVector vec = (VarBinaryVector) shared.getVector("0");
+        vec.allocateNew();
+        vec.setSafe(0, new byte[] { 1, 2, 3 });
+        vec.setSafe(1, new byte[] { 4, 5, 6, 7 });
+        vec.setValueCount(2);
+        shared.setRowCount(2);
+
+        try (VectorStreamInput input = VectorStreamInput.forByteSerialized(shared, registry)) {
+            byte[] out = new byte[5];
+            input.readBytes(out, 0, 5);
+            assertArrayEquals(new byte[] { 1, 2, 3, 4, 5 }, out);
+            // Remaining buffered bytes from row 1 feed readByte.
+            assertEquals((byte) 6, input.readByte());
+            assertEquals((byte) 7, input.readByte());
+        }
+        shared.close();
+    }
+
+    public void testReadBytesEofWhenRowsExhausted() throws IOException {
+        VectorSchemaRoot shared = newByteSerializedRoot();
+        VarBinaryVector vec = (VarBinaryVector) shared.getVector("0");
+        vec.allocateNew();
+        vec.setSafe(0, new byte[] { 1, 2 });
+        vec.setValueCount(1);
+        shared.setRowCount(1);
+
+        try (VectorStreamInput input = VectorStreamInput.forByteSerialized(shared, registry)) {
+            byte[] out = new byte[4];
+            expectThrows(java.io.EOFException.class, () -> input.readBytes(out, 0, 4));
+        }
+        shared.close();
+    }
+
+    public void testReadBytesRejectsEmptyRow() throws IOException {
+        VectorSchemaRoot shared = newByteSerializedRoot();
+        VarBinaryVector vec = (VarBinaryVector) shared.getVector("0");
+        vec.allocateNew();
+        vec.setSafe(0, new byte[0]);
+        vec.setValueCount(1);
+        shared.setRowCount(1);
+
+        try (VectorStreamInput input = VectorStreamInput.forByteSerialized(shared, registry)) {
+            byte[] out = new byte[2];
+            expectThrows(IOException.class, () -> input.readBytes(out, 0, 2));
+        }
+        shared.close();
+    }
+
+    public void testReadBytesZeroLengthIsNoOp() throws IOException {
+        VectorSchemaRoot shared = newByteSerializedRoot();
+        try (VectorStreamInput input = VectorStreamInput.forByteSerialized(shared, registry)) {
+            input.readBytes(new byte[4], 0, 0); // must not throw, must not advance
+        }
+        shared.close();
+    }
+
+    public void testReadBytesDrainsBufferThenAdvancesRow() throws IOException {
+        // readByte advances row 0 into the internal buffer; readBytes must then drain the
+        // buffer (1 byte left) before pulling row 1.
+        VectorSchemaRoot shared = newByteSerializedRoot();
+        VarBinaryVector vec = (VarBinaryVector) shared.getVector("0");
+        vec.allocateNew();
+        vec.setSafe(0, new byte[] { 10, 20 });
+        vec.setSafe(1, new byte[] { 30, 40 });
+        vec.setValueCount(2);
+        shared.setRowCount(2);
+
+        try (VectorStreamInput input = VectorStreamInput.forByteSerialized(shared, registry)) {
+            assertEquals((byte) 10, input.readByte());
+            byte[] out = new byte[3];
+            input.readBytes(out, 0, 3);
+            assertArrayEquals(new byte[] { 20, 30, 40 }, out);
+        }
+        shared.close();
+    }
+
+    private VectorSchemaRoot newByteSerializedRoot() {
+        Schema schema = new Schema(List.of(new Field("0", FieldType.nullable(new ArrowType.Binary()), null)));
+        return VectorSchemaRoot.create(schema, allocator);
+    }
+
+    private VectorSchemaRoot newNativeArrowRoot() {
+        Schema schema = new Schema(List.of(new Field("val", FieldType.nullable(new ArrowType.Int(32, true)), null)));
+        return VectorSchemaRoot.create(schema, allocator);
     }
 }

--- a/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/VectorStreamInputTests.java
+++ b/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/VectorStreamInputTests.java
@@ -65,17 +65,17 @@ public class VectorStreamInputTests extends OpenSearchTestCase {
 
         VectorStreamInput.NativeArrow input = (VectorStreamInput.NativeArrow) VectorStreamInput.forNativeArrow(shared, registry);
         try {
-            assertNotSame("NativeArrow transfers into a fresh owned root", shared, input.getRoot());
+            assertNotSame("NativeArrow transfers into a fresh consumer root", shared, input.getRoot());
             IntVector dstVec = (IntVector) input.getRoot().getVector("val");
             assertEquals(1, input.getRoot().getRowCount());
             assertEquals(42, dstVec.get(0));
             assertEquals("source must be drained", 0, shared.getRowCount());
 
-            // Close the shared root immediately — owned root must survive.
+            // Close the stream root immediately — consumer root must survive.
             shared.close();
-            assertEquals("owned root survives shared-root close", 42, dstVec.get(0));
+            assertEquals("consumer root survives stream root close", 42, dstVec.get(0));
 
-            // Simulate ArrowBatchResponse taking ownership, then close the owned root on the response side.
+            // Simulate ArrowBatchResponse taking ownership, then close the consumer root on the response side.
             input.claimOwnership();
         } finally {
             input.close(); // no-op after claimOwnership
@@ -101,7 +101,7 @@ public class VectorStreamInputTests extends OpenSearchTestCase {
     }
 
     public void testNativeArrowCloseReleasesRootIfNotTransferred() throws IOException {
-        // read() throws or never runs: the owned root must be released by close(), not leaked.
+        // read() throws or never runs: the consumer root must be released by close(), not leaked.
         VectorSchemaRoot shared = newNativeArrowRoot();
         IntVector srcVec = (IntVector) shared.getVector("val");
         srcVec.allocateNew();
@@ -112,11 +112,11 @@ public class VectorStreamInputTests extends OpenSearchTestCase {
         long beforeClose;
         try (VectorStreamInput.NativeArrow input = (VectorStreamInput.NativeArrow) VectorStreamInput.forNativeArrow(shared, registry)) {
             beforeClose = allocator.getAllocatedMemory();
-            assertTrue("owned root should hold memory before close", beforeClose > 0);
+            assertTrue("consumer root should hold memory before close", beforeClose > 0);
         }
         // After try-with-resources: close() ran, transferred==false, root should be released.
         assertTrue(
-            "owned root must be released when not transferred (was " + beforeClose + ", now " + allocator.getAllocatedMemory() + ")",
+            "consumer root must be released when not transferred (was " + beforeClose + ", now " + allocator.getAllocatedMemory() + ")",
             allocator.getAllocatedMemory() < beforeClose
         );
         shared.close();
@@ -133,14 +133,14 @@ public class VectorStreamInputTests extends OpenSearchTestCase {
         shared.setRowCount(1);
 
         VectorStreamInput.NativeArrow input = (VectorStreamInput.NativeArrow) VectorStreamInput.forNativeArrow(shared, registry);
-        VectorSchemaRoot owned = input.getRoot();
+        VectorSchemaRoot consumerRoot = input.getRoot();
         input.claimOwnership();
         input.close();
 
-        // Owned root must remain usable — ArrowBatchResponse owns it after handoff.
-        assertEquals(1, owned.getRowCount());
-        assertEquals(7, ((IntVector) owned.getVector("val")).get(0));
-        owned.close();
+        // Consumer root must remain usable — ArrowBatchResponse owns it after handoff.
+        assertEquals(1, consumerRoot.getRowCount());
+        assertEquals(7, ((IntVector) consumerRoot.getVector("val")).get(0));
+        consumerRoot.close();
         shared.close();
     }
 
@@ -177,7 +177,7 @@ public class VectorStreamInputTests extends OpenSearchTestCase {
             expectThrows(UnsupportedOperationException.class, input::readByte);
             expectThrows(UnsupportedOperationException.class, () -> input.readBytes(new byte[1], 0, 1));
             // Do not call input.getRoot().close() — the try-with-resources close() releases the
-            // owned root (transferred==false).
+            // consumer root (transferred==false).
         }
         shared.close();
     }

--- a/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/VectorStreamInputTests.java
+++ b/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/VectorStreamInputTests.java
@@ -50,7 +50,7 @@ public class VectorStreamInputTests extends OpenSearchTestCase {
         VectorSchemaRoot shared = newByteSerializedRoot();
         try (VectorStreamInput input = VectorStreamInput.forByteSerialized(shared, registry)) {
             assertTrue(input instanceof VectorStreamInput.ByteSerialized);
-            assertSame("ByteSerialized holds the shared root — no transfer", shared, input.getRoot());
+            assertSame("ByteSerialized holds the stream root — no transfer", shared, input.getRoot());
         }
         shared.close();
     }

--- a/plugins/examples/stream-transport-example/src/internalClusterTest/java/org/opensearch/example/stream/NativeArrowStreamTransportExampleIT.java
+++ b/plugins/examples/stream-transport-example/src/internalClusterTest/java/org/opensearch/example/stream/NativeArrowStreamTransportExampleIT.java
@@ -11,13 +11,13 @@ package org.opensearch.example.stream;
 import org.apache.arrow.vector.IntVector;
 import org.apache.arrow.vector.VarCharVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
+import org.opensearch.arrow.flight.transport.ArrowBatchResponseHandler;
 import org.opensearch.arrow.flight.transport.FlightStreamPlugin;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.test.OpenSearchIntegTestCase;
 import org.opensearch.threadpool.ThreadPool;
-import org.opensearch.transport.StreamTransportResponseHandler;
 import org.opensearch.transport.StreamTransportService;
 import org.opensearch.transport.TransportException;
 import org.opensearch.transport.TransportRequestOptions;
@@ -134,7 +134,7 @@ public class NativeArrowStreamTransportExampleIT extends OpenSearchIntegTestCase
     }
 
     /** Standard handler — read() uses the normal StreamInput contract. */
-    static class NativeArrowResponseHandler implements StreamTransportResponseHandler<NativeArrowStreamDataResponse> {
+    static class NativeArrowResponseHandler extends ArrowBatchResponseHandler<NativeArrowStreamDataResponse> {
         private final List<ReceivedBatch> batches;
         private final CountDownLatch latch;
         private final AtomicReference<Exception> failure;

--- a/plugins/examples/stream-transport-example/src/internalClusterTest/java/org/opensearch/example/stream/NativeArrowStreamTransportExampleIT.java
+++ b/plugins/examples/stream-transport-example/src/internalClusterTest/java/org/opensearch/example/stream/NativeArrowStreamTransportExampleIT.java
@@ -11,6 +11,7 @@ package org.opensearch.example.stream;
 import org.apache.arrow.vector.IntVector;
 import org.apache.arrow.vector.VarCharVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.types.pojo.Field;
 import org.opensearch.arrow.flight.transport.ArrowBatchResponseHandler;
 import org.opensearch.arrow.flight.transport.FlightStreamPlugin;
 import org.opensearch.cluster.node.DiscoveryNode;
@@ -112,18 +113,18 @@ public class NativeArrowStreamTransportExampleIT extends OpenSearchIntegTestCase
         }
     }
 
-    /** Deep-copies data from the root since FlightStream reuses it between next() calls. */
+    /** Deep-copies data out of the Arrow batch so the root can be closed immediately. */
     static class ReceivedBatch {
         final int rowCount;
         final List<String> fieldNames;
         final List<String> names;
         final List<Integer> ages;
 
-        ReceivedBatch(VectorSchemaRoot root) {
-            this.rowCount = root.getRowCount();
-            this.fieldNames = root.getSchema().getFields().stream().map(f -> f.getName()).toList();
-            VarCharVector nameVector = (VarCharVector) root.getVector("name");
-            IntVector ageVector = (IntVector) root.getVector("age");
+        ReceivedBatch(VectorSchemaRoot batch) {
+            this.rowCount = batch.getRowCount();
+            this.fieldNames = batch.getSchema().getFields().stream().map(Field::getName).toList();
+            VarCharVector nameVector = (VarCharVector) batch.getVector("name");
+            IntVector ageVector = (IntVector) batch.getVector("age");
             this.names = new ArrayList<>();
             this.ages = new ArrayList<>();
             for (int i = 0; i < rowCount; i++) {
@@ -133,7 +134,6 @@ public class NativeArrowStreamTransportExampleIT extends OpenSearchIntegTestCase
         }
     }
 
-    /** Standard handler — read() uses the normal StreamInput contract. */
     static class NativeArrowResponseHandler extends ArrowBatchResponseHandler<NativeArrowStreamDataResponse> {
         private final List<ReceivedBatch> batches;
         private final CountDownLatch latch;
@@ -150,13 +150,15 @@ public class NativeArrowStreamTransportExampleIT extends OpenSearchIntegTestCase
             try {
                 NativeArrowStreamDataResponse response;
                 while ((response = streamResponse.nextResponse()) != null) {
-                    batches.add(new ReceivedBatch(response.getRoot()));
+                    try (VectorSchemaRoot batch = response.getRoot()) {
+                        batches.add(new ReceivedBatch(batch));
+                    }
                 }
                 streamResponse.close();
-                latch.countDown();
             } catch (Exception e) {
                 failure.set(e);
                 streamResponse.cancel("Test error", e);
+            } finally {
                 latch.countDown();
             }
         }

--- a/plugins/examples/stream-transport-example/src/main/java/org/opensearch/example/stream/ExampleAllocator.java
+++ b/plugins/examples/stream-transport-example/src/main/java/org/opensearch/example/stream/ExampleAllocator.java
@@ -1,0 +1,24 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.example.stream;
+
+import org.apache.arrow.memory.BufferAllocator;
+
+/** Wrapper exposing a {@link BufferAllocator} to Guice for injection into example actions. */
+final class ExampleAllocator {
+    private final BufferAllocator allocator;
+
+    ExampleAllocator(BufferAllocator allocator) {
+        this.allocator = allocator;
+    }
+
+    BufferAllocator get() {
+        return allocator;
+    }
+}

--- a/plugins/examples/stream-transport-example/src/main/java/org/opensearch/example/stream/NativeArrowStreamDataResponse.java
+++ b/plugins/examples/stream-transport-example/src/main/java/org/opensearch/example/stream/NativeArrowStreamDataResponse.java
@@ -15,15 +15,8 @@ import org.opensearch.core.common.io.stream.StreamInput;
 import java.io.IOException;
 
 /**
- * Example native Arrow response — just extend {@link ArrowBatchResponse}.
- *
- * <p>The framework handles everything:
- * <ul>
- *   <li>Send side: zero-copy transfers the root's buffers into the Flight stream</li>
- *   <li>Receive side: provides the root via {@link #getRoot()} — no deserialization</li>
- * </ul>
- *
- * <p>No writeTo/read override needed. The base class handles both.
+ * Example native Arrow response. Extend {@link ArrowBatchResponse} and provide two constructors:
+ * one wrapping a {@link VectorSchemaRoot} (send side) and one taking {@link StreamInput} (receive side).
  */
 class NativeArrowStreamDataResponse extends ArrowBatchResponse {
 

--- a/plugins/examples/stream-transport-example/src/main/java/org/opensearch/example/stream/StreamTransportExamplePlugin.java
+++ b/plugins/examples/stream-transport-example/src/main/java/org/opensearch/example/stream/StreamTransportExamplePlugin.java
@@ -8,16 +8,50 @@
 
 package org.opensearch.example.stream;
 
+import org.apache.arrow.memory.BufferAllocator;
 import org.opensearch.action.ActionRequest;
+import org.opensearch.arrow.flight.transport.ArrowAllocatorProvider;
+import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
+import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.core.action.ActionResponse;
+import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.env.Environment;
+import org.opensearch.env.NodeEnvironment;
 import org.opensearch.plugins.ActionPlugin;
 import org.opensearch.plugins.Plugin;
+import org.opensearch.repositories.RepositoriesService;
+import org.opensearch.script.ScriptService;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.client.Client;
+import org.opensearch.watcher.ResourceWatcherService;
 
+import java.util.Collection;
 import java.util.List;
+import java.util.function.Supplier;
 
 public class StreamTransportExamplePlugin extends Plugin implements ActionPlugin {
 
+    private final BufferAllocator allocator = ArrowAllocatorProvider.newChildAllocator("stream-transport-example", Long.MAX_VALUE);
+
     public StreamTransportExamplePlugin() {}
+
+    @Override
+    public Collection<Object> createComponents(
+        Client client,
+        ClusterService clusterService,
+        ThreadPool threadPool,
+        ResourceWatcherService resourceWatcherService,
+        ScriptService scriptService,
+        NamedXContentRegistry xContentRegistry,
+        Environment environment,
+        NodeEnvironment nodeEnvironment,
+        NamedWriteableRegistry namedWriteableRegistry,
+        IndexNameExpressionResolver indexNameExpressionResolver,
+        Supplier<RepositoriesService> repositoriesServiceSupplier
+    ) {
+        return List.of(new ExampleAllocator(allocator));
+    }
 
     @Override
     public List<ActionHandler<? extends ActionRequest, ? extends ActionResponse>> getActions() {
@@ -25,5 +59,10 @@ public class StreamTransportExamplePlugin extends Plugin implements ActionPlugin
             new ActionHandler<>(StreamDataAction.INSTANCE, TransportStreamDataAction.class),
             new ActionHandler<>(NativeArrowStreamDataAction.INSTANCE, TransportNativeArrowStreamDataAction.class)
         );
+    }
+
+    @Override
+    public void close() {
+        allocator.close();
     }
 }

--- a/plugins/examples/stream-transport-example/src/main/java/org/opensearch/example/stream/TransportNativeArrowStreamDataAction.java
+++ b/plugins/examples/stream-transport-example/src/main/java/org/opensearch/example/stream/TransportNativeArrowStreamDataAction.java
@@ -18,7 +18,6 @@ import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.TransportAction;
-import org.opensearch.arrow.flight.transport.ArrowAllocatorProvider;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.tasks.Task;
@@ -37,7 +36,7 @@ import java.util.List;
  *
  * <p>Demonstrates the pipelined producer pattern:
  * <ol>
- *   <li>Get an allocator via {@link ArrowAllocatorProvider#newChildAllocator}</li>
+ *   <li>Receive an allocator owned by the plugin (closed in {@link StreamTransportExamplePlugin#close()})</li>
  *   <li>For each batch, create a {@link VectorSchemaRoot}, populate it, and wrap it in a response</li>
  *   <li>Send via {@code sendResponseBatch()} — the framework zero-copy transfers
  *       the vectors into the Flight stream on the executor thread</li>
@@ -50,9 +49,13 @@ public class TransportNativeArrowStreamDataAction extends TransportAction<Native
     private final BufferAllocator allocator;
 
     @Inject
-    public TransportNativeArrowStreamDataAction(StreamTransportService streamTransportService, ActionFilters actionFilters) {
+    public TransportNativeArrowStreamDataAction(
+        StreamTransportService streamTransportService,
+        ActionFilters actionFilters,
+        ExampleAllocator exampleAllocator
+    ) {
         super(NativeArrowStreamDataAction.NAME, actionFilters, streamTransportService.getTaskManager());
-        this.allocator = ArrowAllocatorProvider.newChildAllocator("native-arrow-example", Long.MAX_VALUE);
+        this.allocator = exampleAllocator.get();
         streamTransportService.registerRequestHandler(
             NativeArrowStreamDataAction.NAME,
             ThreadPool.Names.GENERIC,

--- a/plugins/examples/stream-transport-example/src/main/java/org/opensearch/example/stream/TransportNativeArrowStreamDataAction.java
+++ b/plugins/examples/stream-transport-example/src/main/java/org/opensearch/example/stream/TransportNativeArrowStreamDataAction.java
@@ -18,7 +18,7 @@ import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.TransportAction;
-import org.opensearch.arrow.flight.transport.ArrowFlightChannel;
+import org.opensearch.arrow.flight.transport.ArrowAllocatorProvider;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.tasks.Task;
@@ -37,24 +37,22 @@ import java.util.List;
  *
  * <p>Demonstrates the pipelined producer pattern:
  * <ol>
- *   <li>Get the channel's allocator via {@link ArrowFlightChannel#from(TransportChannel)}</li>
- *   <li>For each batch, create a producer root using the channel allocator</li>
- *   <li>Populate the root with typed vectors (VarChar, Int, etc.)</li>
- *   <li>Send via {@code sendResponseBatch()} — the framework does zero-copy transfer
- *       of the producer's buffers into the channel's shared root on the executor thread</li>
- *   <li>The producer root is closed by the framework after transfer — don't reuse it</li>
+ *   <li>Get an allocator via {@link ArrowAllocatorProvider#newChildAllocator}</li>
+ *   <li>For each batch, create a {@link VectorSchemaRoot}, populate it, and wrap it in a response</li>
+ *   <li>Send via {@code sendResponseBatch()} — the framework zero-copy transfers
+ *       the vectors into the Flight stream on the executor thread</li>
+ *   <li>Call {@code completeStream()} when done</li>
  * </ol>
- *
- * <p>The channel allocator is a child of {@link org.opensearch.arrow.flight.transport.ArrowAllocatorProvider},
- * ensuring all Arrow buffers share the same root for zero-copy transfers.
  */
 public class TransportNativeArrowStreamDataAction extends TransportAction<NativeArrowStreamDataRequest, NativeArrowStreamDataResponse> {
 
     private static final String[] NAMES = { "Alice", "Bob", "Carol", "Dave", "Eve" };
+    private final BufferAllocator allocator;
 
     @Inject
     public TransportNativeArrowStreamDataAction(StreamTransportService streamTransportService, ActionFilters actionFilters) {
         super(NativeArrowStreamDataAction.NAME, actionFilters, streamTransportService.getTaskManager());
+        this.allocator = ArrowAllocatorProvider.newChildAllocator("native-arrow-example", Long.MAX_VALUE);
         streamTransportService.registerRequestHandler(
             NativeArrowStreamDataAction.NAME,
             ThreadPool.Names.GENERIC,
@@ -69,9 +67,6 @@ public class TransportNativeArrowStreamDataAction extends TransportAction<Native
     }
 
     private void handleStreamRequest(NativeArrowStreamDataRequest request, TransportChannel channel, Task task) throws IOException {
-        // Channel allocator shares the same root as the Flight transport (ArrowAllocatorProvider).
-        BufferAllocator allocator = ArrowFlightChannel.from(channel).getAllocator();
-
         Schema schema = new Schema(
             List.of(
                 new Field("name", FieldType.nullable(new ArrowType.Utf8()), null),

--- a/plugins/examples/stream-transport-example/src/main/java/org/opensearch/example/stream/TransportNativeArrowStreamDataAction.java
+++ b/plugins/examples/stream-transport-example/src/main/java/org/opensearch/example/stream/TransportNativeArrowStreamDataAction.java
@@ -45,8 +45,8 @@ import java.util.List;
  *   <li>The producer root is closed by the framework after transfer — don't reuse it</li>
  * </ol>
  *
- * <p>The channel allocator must be used directly (not a per-request child allocator)
- * because gRPC's zero-copy write path retains buffer references beyond stream completion.
+ * <p>The channel allocator is a child of {@link org.opensearch.arrow.flight.transport.ArrowAllocatorProvider},
+ * ensuring all Arrow buffers share the same root for zero-copy transfers.
  */
 public class TransportNativeArrowStreamDataAction extends TransportAction<NativeArrowStreamDataRequest, NativeArrowStreamDataResponse> {
 
@@ -69,8 +69,7 @@ public class TransportNativeArrowStreamDataAction extends TransportAction<Native
     }
 
     private void handleStreamRequest(NativeArrowStreamDataRequest request, TransportChannel channel, Task task) throws IOException {
-        // Get the channel's allocator. Use this directly for producer roots to ensure
-        // same-allocator transfer (avoids Arrow's cross-allocator foreign buffer bug).
+        // Channel allocator shares the same root as the Flight transport (ArrowAllocatorProvider).
         BufferAllocator allocator = ArrowFlightChannel.from(channel).getAllocator();
 
         Schema schema = new Schema(

--- a/server/src/main/java/org/opensearch/telemetry/tracing/handler/TraceableTransportResponseHandler.java
+++ b/server/src/main/java/org/opensearch/telemetry/tracing/handler/TraceableTransportResponseHandler.java
@@ -101,6 +101,11 @@ public class TraceableTransportResponseHandler<T extends TransportResponse> impl
     }
 
     @Override
+    public boolean skipsDeserialization() {
+        return delegate.skipsDeserialization();
+    }
+
+    @Override
     public String toString() {
         return delegate.toString();
     }

--- a/server/src/main/java/org/opensearch/transport/TransportResponseHandler.java
+++ b/server/src/main/java/org/opensearch/transport/TransportResponseHandler.java
@@ -102,6 +102,16 @@ public interface TransportResponseHandler<T extends TransportResponse> extends W
      */
     default void handleRejection(Exception exp) {}
 
+    /**
+     * True if this handler consumes the response payload directly (e.g. Flight's native Arrow
+     * path) instead of going through byte-level deserialization. Wrappers must forward their
+     * delegate's value.
+     */
+    @ExperimentalApi
+    default boolean skipsDeserialization() {
+        return false;
+    }
+
     default <Q extends TransportResponse> TransportResponseHandler<Q> wrap(Function<Q, T> converter, Writeable.Reader<Q> reader) {
         final TransportResponseHandler<T> self = this;
         return new TransportResponseHandler<Q>() {

--- a/server/src/main/java/org/opensearch/transport/TransportService.java
+++ b/server/src/main/java/org/opensearch/transport/TransportService.java
@@ -1614,6 +1614,11 @@ public class TransportService extends AbstractLifecycleComponent
         }
 
         @Override
+        public boolean skipsDeserialization() {
+            return delegate.skipsDeserialization();
+        }
+
+        @Override
         public String toString() {
             return getClass().getName() + "/" + delegate.toString();
         }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description

On the receiving side of stream transport, `FlightTransportResponse.nextResponse()` transfers the Flight stream root into a response-owned root on every batch — but byte-serialized responses copy bytes into Java fields via handler.read() and never touch the vectors. The transfer is wasted work on that path.

This PR splits VectorStreamInput into two subclasses and let the handler decide which path to take.

```mermaid
flowchart LR
    stream["FlightStream<br/>(stream root)"]
    dispatch{"handler.skips<br/>Deserialization()?"}
    byte["ByteSerialized<br/>reads bytes from stream root"]
    native["NativeArrow<br/>transfers into consumer root"]

    stream --> dispatch
    dispatch -- false --> byte
    dispatch -- true --> native
```

#### Handler marker

TransportResponseHandler gains a skipsDeserialization() bit (default false). ArrowBatchResponseHandler pins it to true. Wrappers forward their delegate's value:

```mermaid
flowchart LR
    M["MetricsTracking"] --> C["ContextRestore"] --> T["Traceable<br/>(optional)"] --> U["User handler"]

    M -. "skipsDeserialization()" .-> U
```

#### Ownership lifecycle of Arrow on the Receive End

```mermaid
sequenceDiagram
    participant FS as FlightStream
    participant FTR as FlightTransportResponse
    participant VSI as VectorStreamInput.NativeArrow
    participant ABR as ArrowBatchResponse

    FTR->>FS: getRoot()
    FS-->>FTR: stream root
    FTR->>VSI: newStreamInput(streamRoot)
    Note over VSI: transfer to consumer
    FTR->>ABR: handler.read(input)
    ABR->>VSI: getRoot() + claimOwnership()
    Note over ABR: response now owns the root
    FTR->>VSI: close()
    Note over VSI: no-op (ownership claimed)
```

#### Shared allocator

ArrowAllocatorProvider provides a single node-level RootAllocator so all Arrow plugins share the same root — required for zero-copy transfers to pass Arrow's AllocationManager associate check.

```mermaid
flowchart TD
    root["ArrowAllocatorProvider.ROOT"]
    flight["flight"]
    server["server"]
    client["client"]
    plugin["plugin allocators<br/>(e.g. analytics-search)"]

    root --> flight
    root --> plugin
    flight --> server
    flight --> client
```

### Who should close the Arrow resource

Send: arrow batch is transfered from producer to flight, so flight should close
Receive: arrow batch is transfered from flight to consumer, so consumer should close

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
