### PR TITLE
Fail write op when primary closes mid-replication

### DIFF
--- a/server/src/main/java/org/opensearch/action/support/replication/ReplicationOperation.java
+++ b/server/src/main/java/org/opensearch/action/support/replication/ReplicationOperation.java
@@ -54,6 +54,7 @@ import org.opensearch.core.concurrency.OpenSearchRejectedExecutionException;
 import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.index.seqno.SequenceNumbers;
+import org.opensearch.index.shard.PrimaryShardClosedException;
 import org.opensearch.index.shard.ReplicationGroup;
 import org.opensearch.node.NodeClosedException;
 import org.opensearch.threadpool.ThreadPool;
@@ -273,6 +274,18 @@ public class ReplicationOperation<
                     ),
                     replicaException
                 );
+                // When the primary shard is closed mid-replication, we can't know whether the replica observed this
+                // op. Fail the op instead so the coordinator retries against the new primary.
+                if (ExceptionsHelper.unwrapCause(replicaException) instanceof PrimaryShardClosedException) {
+                    finishAsFailed(
+                        new RetryOnPrimaryException(
+                            primary.routingEntry().shardId(),
+                            "primary shard was closed while replicating to " + shard,
+                            replicaException
+                        )
+                    );
+                    return;
+                }
                 // Only report "critical" exceptions
                 // TODO: Reach out to the cluster-manager node to get the latest shard state then report.
                 if (TransportActions.isShardNotAvailableException(replicaException) == false) {

--- a/server/src/main/java/org/opensearch/action/support/replication/TransportWriteAction.java
+++ b/server/src/main/java/org/opensearch/action/support/replication/TransportWriteAction.java
@@ -54,7 +54,6 @@ import org.opensearch.index.IndexingPressureService;
 import org.opensearch.index.engine.Engine;
 import org.opensearch.index.mapper.MapperParsingException;
 import org.opensearch.index.shard.IndexShard;
-import org.opensearch.index.shard.PrimaryShardClosedException;
 import org.opensearch.index.translog.Translog;
 import org.opensearch.index.translog.Translog.Location;
 import org.opensearch.indices.IndicesService;
@@ -573,23 +572,15 @@ public abstract class TransportWriteAction<
             if (TransportActions.isShardNotAvailableException(exception) == false) {
                 logger.warn(new ParameterizedMessage("[{}] {}", replica.shardId(), message), exception);
             }
-            // If a write action fails due to the closure of the primary shard
-            // then the replicas should not be marked as failed since they are
-            // still up-to-date with the (now closed) primary shard
-            if (exception instanceof PrimaryShardClosedException == false) {
-                shardStateAction.remoteShardFailed(
-                    replica.shardId(),
-                    replica.allocationId().getId(),
-                    primaryTerm,
-                    true,
-                    message,
-                    exception,
-                    listener
-                );
-            } else {
-                // always call listener
-                listener.onResponse(null);
-            }
+            shardStateAction.remoteShardFailed(
+                replica.shardId(),
+                replica.allocationId().getId(),
+                primaryTerm,
+                true,
+                message,
+                exception,
+                listener
+            );
         }
 
         @Override

--- a/server/src/test/java/org/opensearch/action/support/replication/ReplicationOperationTests.java
+++ b/server/src/test/java/org/opensearch/action/support/replication/ReplicationOperationTests.java
@@ -67,6 +67,7 @@ import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.index.shard.IndexShardNotStartedException;
 import org.opensearch.index.shard.IndexShardState;
 import org.opensearch.index.shard.IndexShardTestUtils;
+import org.opensearch.index.shard.PrimaryShardClosedException;
 import org.opensearch.index.shard.ReplicationGroup;
 import org.opensearch.node.NodeClosedException;
 import org.opensearch.test.OpenSearchTestCase;
@@ -88,6 +89,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -99,6 +101,7 @@ import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_SE
 import static org.opensearch.cluster.routing.TestShardRouting.newShardRouting;
 import static org.hamcrest.Matchers.arrayWithSize;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
@@ -762,6 +765,101 @@ public class ReplicationOperationTests extends OpenSearchTestCase {
             assertFalse(primaryFailed.get());
         }
         assertListenerThrows("should throw exception to trigger retry", listener, RetryOnPrimaryException.class);
+    }
+
+    public void testPrimaryClosedDuringFullReplicationTriggersRetry() throws Exception {
+        runPrimaryClosedDuringReplicationTest((replicasProxy, indexShardRoutingTable) -> new FanoutReplicationProxy<>(replicasProxy));
+    }
+
+    public void testPrimaryClosedDuringPrimaryTermValidationTriggersRetry() throws Exception {
+        // Remote-store write path: primary writes to remote, replicas receive only primary-term validation requests via
+        // ReplicationModeAwareProxy. The PrimaryShardClosedException intercept lives in ReplicationOperation's replica
+        // listener, so it must trip the retry path regardless of which proxy delivered the failure.
+        runPrimaryClosedDuringReplicationTest(
+            (replicasProxy, indexShardRoutingTable) -> new ReplicationModeAwareProxy<>(
+                ReplicationMode.PRIMARY_TERM_VALIDATION,
+                buildRemoteStoreEnabledDiscoveryNodes(indexShardRoutingTable),
+                replicasProxy,
+                replicasProxy,
+                true
+            )
+        );
+    }
+
+    private void runPrimaryClosedDuringReplicationTest(
+        BiFunction<TestReplicaProxy, IndexShardRoutingTable, ReplicationProxy<Request>> proxyFactory
+    ) throws Exception {
+        final String index = "test";
+        final ShardId shardId = new ShardId(index, "_na_", 0);
+
+        // Deterministic setup: one primary and two started replicas, all tracked. Two replicas so that the non-closed
+        // replica exercises the successful path alongside the closed one.
+        final ClusterState initialState = state(
+            index,
+            true,
+            ShardRoutingState.STARTED,
+            ShardRoutingState.STARTED,
+            ShardRoutingState.STARTED
+        );
+        IndexMetadata indexMetadata = initialState.getMetadata().index(index);
+        final long primaryTerm = indexMetadata.primaryTerm(0);
+        final IndexShardRoutingTable indexShardRoutingTable = initialState.getRoutingTable().shardRoutingTable(shardId);
+        final ShardRouting primaryShard = indexShardRoutingTable.primaryShard();
+
+        final Set<String> inSyncAllocationIds = indexMetadata.inSyncAllocationIds(0);
+        final Set<String> trackedShards = new HashSet<>();
+        for (ShardRouting shr : indexShardRoutingTable.shards()) {
+            trackedShards.add(shr.allocationId().getId());
+        }
+        final ReplicationGroup replicationGroup = new ReplicationGroup(indexShardRoutingTable, inSyncAllocationIds, trackedShards, 0);
+        final Set<ShardRouting> expectedReplicas = getExpectedReplicas(shardId, initialState, trackedShards);
+        assertThat("test requires two replicas", expectedReplicas, hasSize(2));
+        final ShardRouting closedReplica = expectedReplicas.iterator().next();
+
+        // Simulate a PrimaryShardClosedException on the chosen replica's performOn. This mirrors what
+        // PendingReplicationActions.close() does to in-flight replica requests when IndexShard closes.
+        final Map<ShardRouting, Exception> simulatedFailures = new HashMap<>();
+        simulatedFailures.put(closedReplica, new PrimaryShardClosedException(shardId));
+
+        final AtomicBoolean failShardCalled = new AtomicBoolean(false);
+        final TestReplicaProxy replicasProxy = new TestReplicaProxy(simulatedFailures) {
+            @Override
+            public void failShardIfNeeded(
+                ShardRouting replica,
+                long term,
+                String message,
+                Exception exception,
+                ActionListener<Void> shardActionListener
+            ) {
+                failShardCalled.set(true);
+                shardActionListener.onResponse(null);
+            }
+        };
+
+        Request request = new Request(shardId);
+        PlainActionFuture<TestPrimary.Result> listener = new PlainActionFuture<>();
+        final TestPrimary primary = new TestPrimary(primaryShard, () -> replicationGroup, threadPool);
+        final TestReplicationOperation op = new TestReplicationOperation(
+            request,
+            primary,
+            listener,
+            replicasProxy,
+            primaryTerm,
+            proxyFactory.apply(replicasProxy, indexShardRoutingTable)
+        );
+        op.execute();
+
+        assertTrue("request was not processed on primary", request.processedOnPrimary.get());
+        assertTrue("listener is not marked as done", listener.isDone());
+        assertFalse(
+            "failShardIfNeeded must not be invoked for PrimaryShardClosedException; the op should fail earlier",
+            failShardCalled.get()
+        );
+        assertListenerThrows(
+            "primary shard closed during replication must surface as a retry-able failure, not a silent ack",
+            listener,
+            RetryOnPrimaryException.class
+        );
     }
 
     public void testAddedReplicaAfterPrimaryOperation() throws Exception {

--- a/server/src/test/java/org/opensearch/action/support/replication/TransportWriteActionTests.java
+++ b/server/src/test/java/org/opensearch/action/support/replication/TransportWriteActionTests.java
@@ -58,7 +58,6 @@ import org.opensearch.core.transport.TransportResponse;
 import org.opensearch.index.IndexService;
 import org.opensearch.index.IndexingPressureService;
 import org.opensearch.index.shard.IndexShard;
-import org.opensearch.index.shard.PrimaryShardClosedException;
 import org.opensearch.index.shard.ShardNotFoundException;
 import org.opensearch.index.translog.Translog;
 import org.opensearch.indices.IndicesService;
@@ -74,7 +73,6 @@ import org.opensearch.transport.Transport;
 import org.opensearch.transport.TransportException;
 import org.opensearch.transport.TransportService;
 import org.opensearch.transport.client.transport.NoNodeAvailableException;
-import org.hamcrest.MatcherAssert;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -97,7 +95,6 @@ import org.mockito.ArgumentCaptor;
 import static java.util.Collections.emptyMap;
 import static org.opensearch.test.ClusterServiceUtils.createClusterService;
 import static org.hamcrest.Matchers.arrayWithSize;
-import static org.hamcrest.Matchers.emptyArray;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.mockito.Mockito.any;
@@ -399,49 +396,6 @@ public class TransportWriteActionTests extends OpenSearchTestCase {
             assertFalse(success.get());
             assertNotNull(failure.get());
         }
-    }
-
-    public void testPrimaryClosedDoesNotFailShard() {
-        final CapturingTransport transport = new CapturingTransport();
-        final TransportService transportService = transport.createTransportService(
-            clusterService.getSettings(),
-            threadPool,
-            TransportService.NOOP_TRANSPORT_INTERCEPTOR,
-            x -> clusterService.localNode(),
-            null,
-            Collections.emptySet(),
-            NoopTracer.INSTANCE
-        );
-        transportService.start();
-        transportService.acceptIncomingRequests();
-        final ShardStateAction shardStateAction = new ShardStateAction(clusterService, transportService, null, null, threadPool);
-        final TestAction action = new TestAction(
-            Settings.EMPTY,
-            "internal:testAction",
-            transportService,
-            clusterService,
-            shardStateAction,
-            threadPool
-        );
-        final String index = "test";
-        final ShardId shardId = new ShardId(index, "_na_", 0);
-        final ClusterState state = ClusterStateCreationUtils.stateWithActivePrimary(index, true, 1, 0);
-        ClusterServiceUtils.setState(clusterService, state);
-        final long primaryTerm = state.metadata().index(index).primaryTerm(0);
-        final ShardRouting shardRouting = state.routingTable().shardRoutingTable(shardId).replicaShards().get(0);
-
-        // Assert that failShardIfNeeded is a no-op for the PrimaryShardClosedException failure
-        final AtomicInteger callbackCount = new AtomicInteger(0);
-        action.newReplicasProxy()
-            .failShardIfNeeded(
-                shardRouting,
-                primaryTerm,
-                "test",
-                new PrimaryShardClosedException(shardId),
-                ActionListener.wrap(callbackCount::incrementAndGet)
-            );
-        MatcherAssert.assertThat(transport.getCapturedRequestsAndClear(), emptyArray());
-        MatcherAssert.assertThat(callbackCount.get(), equalTo(1));
     }
 
     private class TestAction extends TransportWriteAction<TestRequest, TestRequest, TestResponse> {


### PR DESCRIPTION
Writes from a primary that was demoted during a network partition could
be acknowledged to the client even when its replicas would reject
replication. The stale primary's in-flight replica requests were cancelled
with PrimaryShardClosedException during IndexShard close;
WriteActionReplicasProxy.failShardIfNeeded then skipped the cluster
manager call (short-circuit introduced in https://github.com/opensearch-project/OpenSearch/pull/4133 to fix https://github.com/opensearch-project/OpenSearch/issues/803) and,
after https://github.com/opensearch-project/OpenSearch/pull/21305 added the missing listener.onResponse(null) to that
branch, resolved the replication listener successfully, so the
ReplicationOperation finished with successful=1, failures=[] and the
write was ack'd despite never being applied on any live copy. See
[this example failure of ConcurrentSeqNoVersioningIT][1] for how this
can produce incorrect results.

Intercept PrimaryShardClosedException in ReplicationOperation's replica
listener and call finishAsFailed with RetryOnPrimaryException directly.
The coordinator then retries against the current primary instead of
the client seeing a silent ack. Add a deterministic unit test that
reproduces the silent-ack behaviour and would fail without this
interceptor.

Moving the short-circuit logic up to ReplicationOperation simplifies
things and ensures the final fallback is to fail the replica, which is
the behavior that existed prior to https://github.com/opensearch-project/OpenSearch/pull/4133.

[1]: https://build.ci.opensearch.org/job/gradle-check/75218/testReport/org.opensearch.versioning/ConcurrentSeqNoVersioningIT/testSeqNoCASLinearizability/

### Related Issues
Resolves #21378


### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
