### PR TITLE
Update Transport.assertDefaultThreadContext to allow all Task.REQUEST_HEADERS

### DIFF
--- a/server/src/main/java/org/opensearch/transport/Transports.java
+++ b/server/src/main/java/org/opensearch/transport/Transports.java
@@ -83,11 +83,10 @@ public enum Transports {
 
     public static boolean assertDefaultThreadContext(ThreadContext threadContext) {
         final Map<String, String> requestHeaders = threadContext.getRequestHeadersOnly();
-        assert requestHeaders.isEmpty()
-            || Task.REQUEST_HEADERS.containsAll(requestHeaders.keySet()) : "expected empty context but was "
-                + requestHeaders
-                + " on "
-                + Thread.currentThread().getName();
+        assert requestHeaders.isEmpty() || Task.REQUEST_HEADERS.containsAll(requestHeaders.keySet()) : "expected empty context but was "
+            + requestHeaders
+            + " on "
+            + Thread.currentThread().getName();
         return true;
     }
 }

--- a/server/src/main/java/org/opensearch/transport/Transports.java
+++ b/server/src/main/java/org/opensearch/transport/Transports.java
@@ -37,6 +37,7 @@ import org.opensearch.http.HttpServerTransport;
 import org.opensearch.tasks.Task;
 
 import java.util.Arrays;
+import java.util.Map;
 
 /**
  * Utility class for transport
@@ -81,9 +82,12 @@ public enum Transports {
     }
 
     public static boolean assertDefaultThreadContext(ThreadContext threadContext) {
-        assert threadContext.getRequestHeadersOnly().isEmpty()
-            || threadContext.getRequestHeadersOnly().size() == 1 && threadContext.getRequestHeadersOnly().containsKey(Task.X_OPAQUE_ID)
-            : "expected empty context but was " + threadContext.getRequestHeadersOnly() + " on " + Thread.currentThread().getName();
+        final Map<String, String> requestHeaders = threadContext.getRequestHeadersOnly();
+        assert requestHeaders.isEmpty()
+            || Task.REQUEST_HEADERS.containsAll(requestHeaders.keySet()) : "expected empty context but was "
+                + requestHeaders
+                + " on "
+                + Thread.currentThread().getName();
         return true;
     }
 }

--- a/server/src/test/java/org/opensearch/transport/TransportsTests.java
+++ b/server/src/test/java/org/opensearch/transport/TransportsTests.java
@@ -1,0 +1,32 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.transport;
+
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.tasks.Task;
+import org.opensearch.test.OpenSearchTestCase;
+
+public class TransportsTests extends OpenSearchTestCase {
+
+    public void testAssertDefaultThreadContextAllowsTaskRequestHeaders() {
+        final ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
+        threadContext.putHeader(Task.X_OPAQUE_ID, "opaque-id");
+        threadContext.putHeader(Task.X_REQUEST_ID, "1234567890abcdef1234567890abcdef");
+
+        assertTrue(Transports.assertDefaultThreadContext(threadContext));
+    }
+
+    public void testAssertDefaultThreadContextRejectsNonTaskRequestHeaders() {
+        final ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
+        threadContext.putHeader("custom-header", "value");
+
+        expectThrows(AssertionError.class, () -> Transports.assertDefaultThreadContext(threadContext));
+    }
+}


### PR DESCRIPTION
### Description

This PR fixes test failures seen in the security repo.

```
  java.lang.AssertionError: expected empty context but was {X-Opaque-Id=testOpaqueId, X-Request-Id=abcd1234abcd1234abcd1234abcd1234}
  on opensearch[node_utest...][transport_worker][T#1]
      at org.opensearch.transport.Transports.assertDefaultThreadContext(Transports.java:86)
      at org.opensearch.transport.netty4.Netty4MessageChannelHandler.write(Netty4MessageChannelHandler.java:116)
      at org.opensearch.transport.netty4.Netty4TcpChannel.sendMessage(Netty4TcpChannel.java:161)
      at org.opensearch.transport.TcpChannel.sendMessage(TcpChannel.java:96)
      at org.opensearch.transport.OutboundHandler.sendBytes(OutboundHandler.java:86)
      at org.opensearch.transport.nativeprotocol.NativeOutboundHandler.sendMessage(NativeOutboundHandler.java:187)
      at org.opensearch.transport.nativeprotocol.NativeOutboundHandler.sendRequest(NativeOutboundHandler.java:121)
      at org.opensearch.transport.TcpTransport$NodeChannels.sendRequest(TcpTransport.java:374)
      at org.opensearch.transport.TransportService.sendRequestInternal(TransportService.java:1070)
      at org.opensearch.security.transport.SecurityInterceptor.sendRequestDecorate(SecurityInterceptor.java:295)
```

### Related Issues

Resolves CI failures like: https://github.com/cwperks/security/actions/runs/25255296838/job/74053773192?pr=92

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
