### PR TITLE
Speed up Script Engine initialization

### DIFF
--- a/modules/lang-painless/spi/src/main/java/org/opensearch/painless/spi/AllowlistLoader.java
+++ b/modules/lang-painless/spi/src/main/java/org/opensearch/painless/spi/AllowlistLoader.java
@@ -47,9 +47,12 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 /** Loads and creates a {@link Allowlist} from one to many text files. */
 public final class AllowlistLoader {
+
+    private static final Pattern WHITESPACE = Pattern.compile("\\s+");
 
     /**
      * Loads and creates a {@link Allowlist} from one to many text files using only the base annotation parsers.
@@ -312,9 +315,9 @@ public final class AllowlistLoader {
                             );
                         }
 
-                        String[] canonicalTypeNameParameters = line.substring(parameterStartIndex + 1, parameterEndIndex)
-                            .replaceAll("\\s+", "")
-                            .split(",");
+                        String[] canonicalTypeNameParameters = WHITESPACE.matcher(
+                            line.substring(parameterStartIndex + 1, parameterEndIndex)
+                        ).replaceAll("").split(",");
 
                         // Handle the case for a method with no parameters.
                         if ("".equals(canonicalTypeNameParameters[0])) {
@@ -397,7 +400,9 @@ public final class AllowlistLoader {
                                 );
                             }
 
-                            String[] canonicalTypeNameParameters = line.substring(1, parameterEndIndex).replaceAll("\\s+", "").split(",");
+                            String[] canonicalTypeNameParameters = WHITESPACE.matcher(line.substring(1, parameterEndIndex))
+                                .replaceAll("")
+                                .split(",");
 
                             // Handle the case for a constructor with no parameters.
                             if ("".equals(canonicalTypeNameParameters[0])) {
@@ -447,9 +452,9 @@ public final class AllowlistLoader {
                                 );
                             }
 
-                            String[] canonicalTypeNameParameters = line.substring(parameterStartIndex + 1, parameterEndIndex)
-                                .replaceAll("\\s+", "")
-                                .split(",");
+                            String[] canonicalTypeNameParameters = WHITESPACE.matcher(
+                                line.substring(parameterStartIndex + 1, parameterEndIndex)
+                            ).replaceAll("").split(",");
 
                             // Handle the case for a method with no parameters.
                             if ("".equals(canonicalTypeNameParameters[0])) {
@@ -521,7 +526,7 @@ public final class AllowlistLoader {
 
         List<Object> annotations;
 
-        if ("".equals(line.replaceAll("\\s+", ""))) {
+        if (line.isBlank()) {
             annotations = Collections.emptyList();
         } else {
             line = line.trim();

--- a/modules/lang-painless/src/main/java/org/opensearch/painless/PainlessScriptEngine.java
+++ b/modules/lang-painless/src/main/java/org/opensearch/painless/PainlessScriptEngine.java
@@ -95,11 +95,7 @@ public final class PainlessScriptEngine implements ScriptEngine {
         for (Map.Entry<ScriptContext<?>, List<Allowlist>> entry : contexts.entrySet()) {
             ScriptContext<?> context = entry.getKey();
             List<Allowlist> allowlists = List.copyOf(entry.getValue());
-            PainlessLookup lookup = allowlistsToLookups.get(allowlists);
-            if (lookup == null) {
-                lookup = PainlessLookupBuilder.buildFromAllowlists(allowlists);
-                allowlistsToLookups.put(allowlists, lookup);
-            }
+            PainlessLookup lookup = allowlistsToLookups.computeIfAbsent(allowlists, PainlessLookupBuilder::buildFromAllowlists);
             contextsToCompilers.put(
                 context,
                 new Compiler(context.instanceClazz, context.factoryClazz, context.statefulFactoryClazz, lookup)

--- a/modules/lang-painless/src/main/java/org/opensearch/painless/PainlessScriptEngine.java
+++ b/modules/lang-painless/src/main/java/org/opensearch/painless/PainlessScriptEngine.java
@@ -90,10 +90,16 @@ public final class PainlessScriptEngine implements ScriptEngine {
 
         Map<ScriptContext<?>, Compiler> contextsToCompilers = new HashMap<>();
         Map<ScriptContext<?>, PainlessLookup> contextsToLookups = new HashMap<>();
+        Map<List<Allowlist>, PainlessLookup> allowlistsToLookups = new HashMap<>();
 
         for (Map.Entry<ScriptContext<?>, List<Allowlist>> entry : contexts.entrySet()) {
             ScriptContext<?> context = entry.getKey();
-            PainlessLookup lookup = PainlessLookupBuilder.buildFromAllowlists(entry.getValue());
+            List<Allowlist> allowlists = List.copyOf(entry.getValue());
+            PainlessLookup lookup = allowlistsToLookups.get(allowlists);
+            if (lookup == null) {
+                lookup = PainlessLookupBuilder.buildFromAllowlists(allowlists);
+                allowlistsToLookups.put(allowlists, lookup);
+            }
             contextsToCompilers.put(
                 context,
                 new Compiler(context.instanceClazz, context.factoryClazz, context.statefulFactoryClazz, lookup)

--- a/modules/lang-painless/src/main/java/org/opensearch/painless/lookup/PainlessLookupBuilder.java
+++ b/modules/lang-painless/src/main/java/org/opensearch/painless/lookup/PainlessLookupBuilder.java
@@ -65,9 +65,11 @@ import java.security.cert.Certificate;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 import static org.opensearch.painless.WriterConstants.DEF_TO_B_BYTE_IMPLICIT;
@@ -1925,20 +1927,23 @@ public final class PainlessLookupBuilder {
             classesToPainlessClasses.put(painlessClassBuilderEntry.getKey(), painlessClassBuilderEntry.getValue().build());
         }
 
-        if (javaClassNamesToClasses.values().containsAll(canonicalClassNamesToClasses.values()) == false) {
+        Set<Class<?>> javaClasses = new HashSet<>(javaClassNamesToClasses.values());
+        Set<Class<?>> canonicalClasses = new HashSet<>(canonicalClassNamesToClasses.values());
+        Set<Class<?>> painlessClasses = classesToPainlessClasses.keySet();
+
+        if (javaClasses.containsAll(canonicalClasses) == false) {
             throw new IllegalArgumentException(
                 "the values of java class names to classes " + "must be a superset of the values of canonical class names to classes"
             );
         }
 
-        if (javaClassNamesToClasses.values().containsAll(classesToPainlessClasses.keySet()) == false) {
+        if (javaClasses.containsAll(painlessClasses) == false) {
             throw new IllegalArgumentException(
                 "the values of java class names to classes " + "must be a superset of the keys of classes to painless classes"
             );
         }
 
-        if (canonicalClassNamesToClasses.values().containsAll(classesToPainlessClasses.keySet()) == false
-            || classesToPainlessClasses.keySet().containsAll(canonicalClassNamesToClasses.values()) == false) {
+        if (canonicalClasses.equals(painlessClasses) == false) {
             throw new IllegalArgumentException(
                 "the values of canonical class names to classes " + "must have the same classes as the keys of classes to painless classes"
             );


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Small improvements to Painless Script Engine initialization to reduce OpenSearch startup time.
- Compile the whitespace pattern only once
- Reuse `PainlessLookup` instances for identical allowlist sequences
- Use sets to avoid repeated linear scans during lookup validation

| Version |Time to Node "started" using ./gradlew run (best of 5) |
|---------|------|
| Before  | 2012 ms |
| After   | 1815 ms |

Improvement: ~197 ms, about 9.8%.

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
