### PR TITLE
Avoiding repeated encoding and compression operation for the sort column included writes

### DIFF
--- a/sandbox/libs/dataformat-native/rust/Cargo.toml
+++ b/sandbox/libs/dataformat-native/rust/Cargo.toml
@@ -18,6 +18,7 @@ members = [
 # Arrow / Parquet
 arrow = { version = "57.3.0", features = ["ffi"] }
 arrow-array = "57.3.0"
+arrow-ipc = "57.3.0"
 arrow-schema = "57.3.0"
 arrow-buffer = "57.3.0"
 parquet = "57.3.0"

--- a/sandbox/plugins/parquet-data-format/src/main/rust/Cargo.toml
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/Cargo.toml
@@ -15,6 +15,7 @@ crate-type = ["rlib"]
 [dependencies]
 arrow = { workspace = true }
 parquet = { workspace = true }
+arrow-ipc = { workspace = true }
 lazy_static = { workspace = true }
 dashmap = { workspace = true }
 tempfile = { workspace = true }

--- a/sandbox/plugins/parquet-data-format/src/main/rust/src/merge/heap.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/src/merge/heap.rs
@@ -14,7 +14,7 @@ use arrow::datatypes::{
     DataType as ArrowDataType, Date32Type, Date64Type, DurationMicrosecondType,
     DurationMillisecondType, DurationNanosecondType, DurationSecondType, Float32Type, Float64Type,
     Int16Type, Int32Type, Int64Type, Int8Type, TimestampMicrosecondType,
-    TimestampMillisecondType, TimestampNanosecondType, TimestampSecondType, UInt32Type,
+    TimestampMillisecondType, TimestampNanosecondType, TimestampSecondType,
 };
 
 use super::error::{MergeError, MergeResult};
@@ -138,7 +138,6 @@ pub fn get_sort_value(
         ArrowDataType::Int32 => SortKey::Int(col.as_primitive::<Int32Type>().value(row) as i64),
         ArrowDataType::Int16 => SortKey::Int(col.as_primitive::<Int16Type>().value(row) as i64),
         ArrowDataType::Int8 => SortKey::Int(col.as_primitive::<Int8Type>().value(row) as i64),
-        ArrowDataType::UInt32 => SortKey::Int(col.as_primitive::<UInt32Type>().value(row) as i64),
         ArrowDataType::Date32 => SortKey::Int(col.as_primitive::<Date32Type>().value(row) as i64),
         ArrowDataType::Date64 => SortKey::Int(col.as_primitive::<Date64Type>().value(row)),
         ArrowDataType::Timestamp(unit, _) => SortKey::Int(match unit {

--- a/sandbox/plugins/parquet-data-format/src/main/rust/src/tests/mod.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/src/tests/mod.rs
@@ -276,6 +276,238 @@ fn test_unsorted_writer_preserves_insertion_order() {
     cleanup_ffi_schema(schema_ptr);
 }
 
+// ===== Arrow IPC staging path tests =====
+
+#[test]
+fn test_ipc_staging_sorted_writer_creates_and_cleans_up_staging_file() {
+    let (_temp_dir, filename) = get_temp_file_path("ipc_cleanup.parquet");
+    let (_schema, schema_ptr) = create_sorted_writer_and_assert_success(&filename, "id", false);
+
+    // The IPC staging file should exist while the writer is open
+    let temp_filename = format!(
+        "{}/temp-{}",
+        Path::new(&filename).parent().unwrap().to_string_lossy(),
+        Path::new(&filename).file_name().unwrap().to_string_lossy()
+    );
+    let ipc_staging_path = format!("{}.arrow_ipc_staging", temp_filename);
+    assert!(Path::new(&ipc_staging_path).exists(), "IPC staging file should exist while writer is open");
+
+    let (ap, sp) = create_test_ffi_data_with_ids(vec![30, 10, 20], vec![Some("C"), Some("A"), Some("B")]).unwrap();
+    NativeParquetWriter::write_data(filename.clone(), ap, sp).unwrap();
+    cleanup_ffi_data(ap, sp);
+
+    NativeParquetWriter::finalize_writer(filename.clone()).unwrap();
+
+    // After finalize, the IPC staging file should be cleaned up
+    assert!(!Path::new(&ipc_staging_path).exists(), "IPC staging file should be deleted after finalize");
+    // The final Parquet file should exist
+    assert!(Path::new(&filename).exists(), "Final Parquet file should exist");
+
+    // Verify data is sorted
+    let ids = read_parquet_file_sorted_ids(&filename);
+    assert_eq!(ids, vec![10, 20, 30]);
+
+    cleanup_ffi_schema(schema_ptr);
+}
+
+#[test]
+fn test_ipc_staging_has_writer_returns_true() {
+    let (_temp_dir, filename) = get_temp_file_path("ipc_has_writer.parquet");
+    let (_schema, schema_ptr) = create_sorted_writer_and_assert_success(&filename, "id", false);
+
+    assert!(NativeParquetWriter::has_writer(&filename), "has_writer should return true for IPC writer");
+
+    close_writer_and_cleanup_schema(&filename, schema_ptr);
+}
+
+#[test]
+fn test_ipc_staging_duplicate_writer_rejected() {
+    let (_temp_dir, filename) = get_temp_file_path("ipc_dup.parquet");
+    let (_schema, schema_ptr) = create_sorted_writer_and_assert_success(&filename, "id", false);
+
+    let (_, schema_ptr2) = create_test_ffi_schema();
+    let result = NativeParquetWriter::create_writer(
+        filename.clone(), "test-index".to_string(), schema_ptr2,
+        vec!["id".to_string()], vec![false], vec![false], 0
+    );
+    assert!(result.is_err());
+    assert!(result.unwrap_err().to_string().contains("Writer already exists"));
+
+    cleanup_ffi_schema(schema_ptr2);
+    close_writer_and_cleanup_schema(&filename, schema_ptr);
+}
+
+#[test]
+fn test_ipc_staging_empty_data_produces_valid_parquet() {
+    let (_temp_dir, filename) = get_temp_file_path("ipc_empty.parquet");
+    let (_schema, schema_ptr) = create_sorted_writer_and_assert_success(&filename, "id", false);
+
+    // Finalize without writing any data
+    let result = NativeParquetWriter::finalize_writer(filename.clone());
+    assert!(result.is_ok());
+    assert!(Path::new(&filename).exists(), "Empty Parquet file should be created");
+
+    let metadata = result.unwrap().unwrap();
+    assert_eq!(metadata.metadata.file_metadata().num_rows(), 0);
+
+    cleanup_ffi_schema(schema_ptr);
+}
+
+#[test]
+fn test_ipc_staging_multi_batch_sort() {
+    let (_temp_dir, filename) = get_temp_file_path("ipc_multi_batch.parquet");
+    let (_schema, schema_ptr) = create_sorted_writer_and_assert_success(&filename, "id", false);
+
+    // Write multiple batches with interleaved values
+    let (ap1, sp1) = create_test_ffi_data_with_ids(vec![50, 10], vec![Some("E"), Some("A")]).unwrap();
+    NativeParquetWriter::write_data(filename.clone(), ap1, sp1).unwrap();
+    cleanup_ffi_data(ap1, sp1);
+
+    let (ap2, sp2) = create_test_ffi_data_with_ids(vec![30, 20], vec![Some("C"), Some("B")]).unwrap();
+    NativeParquetWriter::write_data(filename.clone(), ap2, sp2).unwrap();
+    cleanup_ffi_data(ap2, sp2);
+
+    let (ap3, sp3) = create_test_ffi_data_with_ids(vec![40, 60], vec![Some("D"), Some("F")]).unwrap();
+    NativeParquetWriter::write_data(filename.clone(), ap3, sp3).unwrap();
+    cleanup_ffi_data(ap3, sp3);
+
+    NativeParquetWriter::finalize_writer(filename.clone()).unwrap();
+
+    let ids = read_parquet_file_sorted_ids(&filename);
+    assert_eq!(ids, vec![10, 20, 30, 40, 50, 60], "Multiple IPC batches should be sorted correctly");
+
+    cleanup_ffi_schema(schema_ptr);
+}
+
+#[test]
+fn test_ipc_staging_descending_sort() {
+    let (_temp_dir, filename) = get_temp_file_path("ipc_desc.parquet");
+    let (_schema, schema_ptr) = create_sorted_writer_and_assert_success(&filename, "id", true);
+
+    let (ap, sp) = create_test_ffi_data_with_ids(vec![10, 30, 20], vec![Some("A"), Some("C"), Some("B")]).unwrap();
+    NativeParquetWriter::write_data(filename.clone(), ap, sp).unwrap();
+    cleanup_ffi_data(ap, sp);
+
+    NativeParquetWriter::finalize_writer(filename.clone()).unwrap();
+
+    let ids = read_parquet_file_sorted_ids(&filename);
+    assert_eq!(ids, vec![30, 20, 10], "IPC path should support descending sort");
+
+    cleanup_ffi_schema(schema_ptr);
+}
+
+#[test]
+fn test_ipc_and_parquet_writers_coexist() {
+    let (_temp_dir1, sorted_file) = get_temp_file_path("ipc_sorted.parquet");
+    let (_temp_dir2, unsorted_file) = get_temp_file_path("parquet_unsorted.parquet");
+
+    // Create one IPC writer (sorted) and one Parquet writer (unsorted)
+    let (_schema1, sp1) = create_sorted_writer_and_assert_success(&sorted_file, "id", false);
+    let (_schema2, sp2) = create_writer_and_assert_success(&unsorted_file);
+
+    // Write to both
+    let (ap1, dp1) = create_test_ffi_data_with_ids(vec![30, 10, 20], vec![Some("C"), Some("A"), Some("B")]).unwrap();
+    NativeParquetWriter::write_data(sorted_file.clone(), ap1, dp1).unwrap();
+    cleanup_ffi_data(ap1, dp1);
+
+    let (ap2, dp2) = create_test_ffi_data_with_ids(vec![30, 10, 20], vec![Some("C"), Some("A"), Some("B")]).unwrap();
+    NativeParquetWriter::write_data(unsorted_file.clone(), ap2, dp2).unwrap();
+    cleanup_ffi_data(ap2, dp2);
+
+    // Finalize both
+    NativeParquetWriter::finalize_writer(sorted_file.clone()).unwrap();
+    NativeParquetWriter::finalize_writer(unsorted_file.clone()).unwrap();
+
+    // Sorted file should be sorted
+    let sorted_ids = read_parquet_file_sorted_ids(&sorted_file);
+    assert_eq!(sorted_ids, vec![10, 20, 30]);
+
+    // Unsorted file should preserve insertion order
+    let unsorted_ids = read_parquet_file_sorted_ids(&unsorted_file);
+    assert_eq!(unsorted_ids, vec![30, 10, 20]);
+
+    cleanup_ffi_schema(sp1);
+    cleanup_ffi_schema(sp2);
+}
+
+#[test]
+fn test_ipc_staging_concurrent_sorted_writers() {
+    let temp_dir = tempdir().unwrap();
+    let thread_count = 6;
+    let success_count = Arc::new(AtomicUsize::new(0));
+    let mut handles = vec![];
+
+    for i in 0..thread_count {
+        let temp_dir_path = temp_dir.path().to_path_buf();
+        let success_count = Arc::clone(&success_count);
+        let handle = thread::spawn(move || {
+            let file_path = temp_dir_path.join(format!("ipc_concurrent_{}.parquet", i));
+            let filename = file_path.to_string_lossy().to_string();
+            let (_schema, schema_ptr) = create_test_ffi_schema();
+
+            if NativeParquetWriter::create_writer(
+                filename.clone(), "test-index".to_string(), schema_ptr,
+                vec!["id".to_string()], vec![false], vec![false], 0
+            ).is_ok() {
+                let (ap, sp) = create_test_ffi_data_with_ids(
+                    vec![30, 10, 20], vec![Some("C"), Some("A"), Some("B")]
+                ).unwrap();
+                let write_ok = NativeParquetWriter::write_data(filename.clone(), ap, sp).is_ok();
+                cleanup_ffi_data(ap, sp);
+
+                if write_ok {
+                    if let Ok(Some(metadata)) = NativeParquetWriter::finalize_writer(filename.clone()) {
+                        if metadata.metadata.file_metadata().num_rows() == 3 {
+                            let ids = read_parquet_file_sorted_ids(&filename);
+                            if ids == vec![10, 20, 30] {
+                                success_count.fetch_add(1, Ordering::SeqCst);
+                            }
+                        }
+                    }
+                }
+            }
+            cleanup_ffi_schema(schema_ptr);
+        });
+        handles.push(handle);
+    }
+
+    for handle in handles {
+        handle.join().unwrap();
+    }
+    assert_eq!(success_count.load(Ordering::SeqCst), thread_count);
+}
+
+#[test]
+fn test_ipc_staging_complete_lifecycle_with_sync() {
+    let (_temp_dir, filename) = get_temp_file_path("ipc_lifecycle.parquet");
+    let file_path = Path::new(&filename);
+    let (_schema, schema_ptr) = create_sorted_writer_and_assert_success(&filename, "id", false);
+
+    for batch_ids in [vec![50, 30], vec![10, 40], vec![20, 60]] {
+        let names: Vec<Option<&str>> = batch_ids.iter().map(|_| Some("x")).collect();
+        let (ap, sp) = create_test_ffi_data_with_ids(batch_ids, names).unwrap();
+        NativeParquetWriter::write_data(filename.clone(), ap, sp).unwrap();
+        cleanup_ffi_data(ap, sp);
+    }
+
+    let result = NativeParquetWriter::finalize_writer(filename.clone());
+    assert!(result.is_ok());
+    let metadata = result.unwrap().unwrap();
+    assert_eq!(metadata.metadata.file_metadata().num_rows(), 6);
+
+    assert!(NativeParquetWriter::sync_to_disk(filename.clone()).is_ok());
+    assert!(file_path.exists());
+    assert!(file_path.metadata().unwrap().len() > 0);
+
+    let ids = read_parquet_file_sorted_ids(&filename);
+    assert_eq!(ids, vec![10, 20, 30, 40, 50, 60]);
+
+    let read_metadata = NativeParquetWriter::get_file_metadata(filename.clone()).unwrap();
+    assert_eq!(read_metadata.num_rows(), 6);
+
+    cleanup_ffi_schema(schema_ptr);
+}
+
 #[test]
 fn test_get_filtered_writer_memory_usage_with_writers() {
     let (_temp_dir, filename1) = get_temp_file_path("test1.parquet");

--- a/sandbox/plugins/parquet-data-format/src/main/rust/src/writer.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/src/writer.rs
@@ -8,16 +8,19 @@
 
 use arrow::ffi::{FFI_ArrowArray, FFI_ArrowSchema};
 use arrow::record_batch::RecordBatch;
-use arrow::compute::{lexsort_to_indices, take, SortColumn};
+use arrow::compute::{concat_batches, take};
+use arrow::row::{RowConverter, SortField};
+use arrow_ipc::writer::FileWriter as IpcFileWriter;
+use arrow_ipc::reader::FileReader as IpcFileReader;
 use dashmap::DashMap;
 use lazy_static::lazy_static;
-use parquet::arrow::{arrow_reader::ParquetRecordBatchReaderBuilder, ArrowWriter};
+use parquet::arrow::ArrowWriter;
 use parquet::file::reader::{FileReader, SerializedFileReader};
 use std::fs::File;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 
-use crate::{log_error, log_debug};
+use crate::{log_error, log_debug, log_info};
 use crate::crc_writer::CrcWriter;
 use crate::merge::{merge_sorted, schema::ROW_ID_COLUMN_NAME};
 use crate::native_settings::NativeSettings;
@@ -30,17 +33,34 @@ pub struct FinalizeResult {
     pub crc32: u32,
 }
 
+/// The underlying writer — either direct Parquet or Arrow IPC staging.
+/// When sort columns are configured, the IPC variant is used so that
+/// batches can be cheaply read back for sorting — Arrow IPC is a raw
+/// dump of in-memory Arrow buffers with minimal framing overhead.
+enum WriterVariant {
+    /// Direct Parquet writer — used when no sort columns are configured.
+    Parquet(Arc<Mutex<ArrowWriter<CrcWriter<File>>>>),
+    /// Arrow IPC staging writer — used when sort columns are configured.
+    /// Batches are written as raw Arrow IPC; on close they are read back,
+    /// sorted, and written as a final Parquet file.
+    Ipc(Arc<Mutex<IpcFileWriter<File>>>),
+}
+
 /// Bundles all per-writer resources so a single `DashMap::remove` atomically
 /// drops the writer, closes the file handle, and cleans up sort config.
 struct WriterState {
-    writer: Arc<Mutex<ArrowWriter<CrcWriter<File>>>>,
+    variant: WriterVariant,
     settings: NativeSettings,
-    crc_handle: crate::crc_writer::CrcHandle,
+    crc_handle: Option<crate::crc_writer::CrcHandle>,
     writer_generation: i64,
 }
 
+/// Path suffix for the intermediate Arrow IPC file used during sort-on-close.
+const IPC_STAGING_SUFFIX: &str = ".arrow_ipc_staging";
+
 lazy_static! {
     /// Unified per-writer registry. Keyed by temp filename.
+    /// Holds both Parquet and IPC writers via the `WriterVariant` enum.
     static ref WRITERS: DashMap<String, WriterState> = DashMap::new();
     pub static ref SETTINGS_STORE: DashMap<String, NativeSettings> = DashMap::new();
     /// Holds file handles for finalized files pending fsync. Removed after sync.
@@ -75,7 +95,7 @@ impl NativeParquetWriter {
         writer_generation: i64,
     ) -> Result<(), Box<dyn std::error::Error>> {
         log_debug!(
-            "create_writer called for file: {}, index: {}, schema_address: {}, sort_columns: {:?}, reverse_sorts: {:?}, nulls_first: {:?}, generation: {}",
+            "create_writer called for file: {}, index: {}, schema_address: {}, sort_columns: {:?}, reverse_sorts: {:?}, nulls_first: {:?}, writer_generation: {}",
             filename, index_name, schema_address, sort_columns, reverse_sorts, nulls_first, writer_generation
         );
 
@@ -95,9 +115,6 @@ impl NativeParquetWriter {
         let schema = Arc::new(arrow::datatypes::Schema::try_from(&arrow_schema)?);
         log_debug!("Schema created with {} fields", schema.fields().len());
 
-        let file = File::create(&temp_filename)?;
-        let (crc_file, crc_handle) = CrcWriter::new(file);
-
         let mut settings: NativeSettings = SETTINGS_STORE
             .get(&index_name)
             .map(|r| r.clone())
@@ -107,14 +124,25 @@ impl NativeParquetWriter {
         settings.reverse_sorts = reverse_sorts;
         settings.nulls_first = nulls_first;
 
-        let props = WriterPropertiesBuilder::build_with_generation(&settings, Some(writer_generation));
-
         SETTINGS_STORE.insert(index_name, settings.clone());
 
-        let writer = ArrowWriter::try_new(crc_file, schema, Some(props))?;
+        // If sort columns are configured, use Arrow IPC staging path so
+        // batches can be cheaply read back for sorting before writing Parquet.
+        let (variant, crc_handle) = if !settings.sort_columns.is_empty() {
+            let ipc_path = format!("{}{}", temp_filename, IPC_STAGING_SUFFIX);
+            let file = File::create(&ipc_path)?;
+            let ipc_writer = IpcFileWriter::try_new(file, &schema)?;
+            (WriterVariant::Ipc(Arc::new(Mutex::new(ipc_writer))), None)
+        } else {
+            let file = File::create(&temp_filename)?;
+            let (crc_file, crc_handle) = CrcWriter::new(file);
+            let props = WriterPropertiesBuilder::build_with_generation(&settings, Some(writer_generation));
+            let writer = ArrowWriter::try_new(crc_file, schema, Some(props))?;
+            (WriterVariant::Parquet(Arc::new(Mutex::new(writer))), Some(crc_handle))
+        };
 
         WRITERS.insert(temp_filename, WriterState {
-            writer: Arc::new(Mutex::new(writer)),
+            variant,
             settings,
             crc_handle,
             writer_generation,
@@ -144,8 +172,18 @@ impl NativeParquetWriter {
                 log_debug!("Created RecordBatch with {} rows and {} columns", record_batch.num_rows(), record_batch.num_columns());
 
                 if let Some(state) = WRITERS.get(&temp_filename) {
-                    let mut writer = state.writer.lock().unwrap();
-                    writer.write(&record_batch)?;
+                    match &state.variant {
+                        WriterVariant::Ipc(writer_arc) => {
+                            log_debug!("Writing RecordBatch to IPC staging file");
+                            let mut writer = writer_arc.lock().unwrap();
+                            writer.write(&record_batch)?;
+                        }
+                        WriterVariant::Parquet(writer_arc) => {
+                            log_debug!("Writing RecordBatch to Parquet file");
+                            let mut writer = writer_arc.lock().unwrap();
+                            writer.write(&record_batch)?;
+                        }
+                    }
                     Ok(())
                 } else {
                     log_error!("ERROR: No writer found for temp file: {}", temp_filename);
@@ -163,46 +201,72 @@ impl NativeParquetWriter {
         log_debug!("finalize_writer called for file: {} (temp: {})", filename, temp_filename);
 
         if let Some((_, state)) = WRITERS.remove(&temp_filename) {
-            let WriterState { writer: writer_arc, settings, crc_handle, writer_generation } = state;
+            let WriterState { variant, settings, crc_handle, writer_generation } = state;
             let index_name = settings.index_name.as_deref().unwrap_or("");
-            match Arc::try_unwrap(writer_arc) {
-                Ok(mutex) => {
-                    let writer = mutex.into_inner().unwrap();
-                    match writer.close() {
-                        Ok(_) => {
-                            let temp_crc32 = crc_handle.crc32();
-                            log_debug!("Successfully closed temp writer for: {}", temp_filename);
 
-                            let crc32 = Self::sort_and_rewrite_parquet(&temp_filename, &filename, index_name, &settings.sort_columns, &settings.reverse_sorts, &settings.nulls_first, temp_crc32, writer_generation)?;
+            match variant {
+                WriterVariant::Ipc(writer_arc) => {
+                    match Arc::try_unwrap(writer_arc) {
+                        Ok(mutex) => {
+                            let mut writer = mutex.into_inner().unwrap();
+                            writer.finish()?;
+                            log_info!("Successfully closed IPC staging writer for: {}", temp_filename);
 
-                            if Path::new(&temp_filename).exists() {
-                                if let Err(e) = std::fs::remove_file(&temp_filename) {
-                                    log_error!("Failed to remove temp file {}: {}", temp_filename, e);
-                                }
-                            }
+                            let ipc_path = format!("{}{}", temp_filename, IPC_STAGING_SUFFIX);
+                            let crc32 = Self::sort_and_rewrite_parquet(&ipc_path, &filename, index_name, &settings.sort_columns, &settings.reverse_sorts, &settings.nulls_first, writer_generation)?;
+                            let _ = std::fs::remove_file(&ipc_path);
 
                             log_debug!("CRC32 for file {}: {:#010x}", filename, crc32);
 
-                            // Keep a handle for sync_to_disk
                             let file_for_sync = File::open(&filename)?;
                             FILE_MANAGER.insert(filename.clone(), file_for_sync);
 
-                            // Read full ParquetMetaData from the final file
                             let file = File::open(&filename)?;
                             let reader = SerializedFileReader::new(file)?;
                             let parquet_metadata = reader.metadata().clone();
 
                             Ok(Some(FinalizeResult { metadata: parquet_metadata, crc32 }))
                         }
-                        Err(e) => {
-                            log_error!("ERROR: Failed to close writer for temp file: {}", temp_filename);
-                            Err(e.into())
+                        Err(_) => {
+                            log_error!("ERROR: IPC Writer still in use for temp file: {}", temp_filename);
+                            Err("IPC Writer still in use".into())
                         }
                     }
                 }
-                Err(_) => {
-                    log_error!("ERROR: Writer still in use for temp file: {}", temp_filename);
-                    Err("Writer still in use".into())
+                WriterVariant::Parquet(writer_arc) => {
+                    match Arc::try_unwrap(writer_arc) {
+                        Ok(mutex) => {
+                            let writer = mutex.into_inner().unwrap();
+                            match writer.close() {
+                                Ok(_) => {
+                                    let crc32 = crc_handle.map(|h| h.crc32()).unwrap_or(0);
+                                    log_info!("Successfully closed temp writer for: {}", temp_filename);
+
+                                    // Parquet variant is used for non-sorted data; just rename.
+                                    std::fs::rename(&temp_filename, &filename)?;
+
+                                    log_debug!("CRC32 for file {}: {:#010x}", filename, crc32);
+
+                                    let file_for_sync = File::open(&filename)?;
+                                    FILE_MANAGER.insert(filename.clone(), file_for_sync);
+
+                                    let file = File::open(&filename)?;
+                                    let reader = SerializedFileReader::new(file)?;
+                                    let parquet_metadata = reader.metadata().clone();
+
+                                    Ok(Some(FinalizeResult { metadata: parquet_metadata, crc32 }))
+                                }
+                                Err(e) => {
+                                    log_error!("ERROR: Failed to close writer for temp file: {}", temp_filename);
+                                    Err(e.into())
+                                }
+                            }
+                        }
+                        Err(_) => {
+                            log_error!("ERROR: Writer still in use for temp file: {}", temp_filename);
+                            Err("Writer still in use".into())
+                        }
+                    }
                 }
             }
         } else {
@@ -211,7 +275,6 @@ impl NativeParquetWriter {
         }
     }
 
-
     fn sort_and_rewrite_parquet(
         temp_filename: &str,
         output_filename: &str,
@@ -219,19 +282,12 @@ impl NativeParquetWriter {
         sort_columns: &[String],
         reverse_sorts: &[bool],
         nulls_first: &[bool],
-        temp_crc32: u32,
         writer_generation: i64,
     ) -> Result<u32, Box<dyn std::error::Error>> {
         log_debug!(
             "sort_and_rewrite_parquet: temp={}, output={}, sort_columns={:?}, reverse_sorts={:?}, nulls_first={:?}",
             temp_filename, output_filename, sort_columns, reverse_sorts, nulls_first
         );
-
-        if sort_columns.is_empty() {
-            log_debug!("No sort columns specified, renaming temp file to final");
-            std::fs::rename(temp_filename, output_filename)?;
-            return Ok(temp_crc32);
-        }
 
         let config = SETTINGS_STORE
             .get(index_name)
@@ -247,7 +303,6 @@ impl NativeParquetWriter {
         }
     }
 
-    /// In-memory sort for small files: read all batches, concat, sort, rewrite row IDs, write.
     fn sort_small_file(
         temp_filename: &str,
         output_filename: &str,
@@ -260,31 +315,43 @@ impl NativeParquetWriter {
         log_debug!("Using in-memory sort for small file: {}", temp_filename);
 
         let file = File::open(temp_filename)?;
-        let builder = ParquetRecordBatchReaderBuilder::try_new(file)?;
-        let row_count = builder.metadata().file_metadata().num_rows() as usize;
-        let arrow_reader = builder.with_batch_size(row_count).build()?;
+        let reader = IpcFileReader::try_new(file, None)?;
+        let schema = reader.schema();
 
-        let batch = match arrow_reader.into_iter().next() {
-            Some(Ok(b)) if b.num_rows() > 0 => b,
-            Some(Err(e)) => return Err(e.into()),
-            _ => {
-                log_debug!("No data to sort in file: {}", temp_filename);
-                std::fs::rename(temp_filename, output_filename)?;
-                return Ok(0);
+        let mut all_batches: Vec<RecordBatch> = Vec::new();
+        for batch_result in reader {
+            let batch = batch_result?;
+            if batch.num_rows() > 0 {
+                all_batches.push(batch);
             }
-        };
+        }
 
-        let schema = batch.schema();
-        let sorted_batch = Self::sort_batch(&batch, sort_columns, reverse_sorts, nulls_first)?;
+        if all_batches.is_empty() {
+            log_info!("No data in temp file: {}", temp_filename);
+            let props = WriterPropertiesBuilder::build_with_generation(
+                &SETTINGS_STORE.get(index_name).map(|r| r.clone()).unwrap_or_default(),
+                Some(writer_generation),
+            );
+            let file = File::create(output_filename)?;
+            let writer = ArrowWriter::try_new(file, schema, Some(props))?;
+            writer.close()?;
+            return Ok(0);
+        }
+
+        let combined_batch = concat_batches(&schema, &all_batches)?;
+        let sorted_batch = Self::sort_batch(&combined_batch, sort_columns, reverse_sorts, nulls_first)?;
         let final_batch = Self::rewrite_row_ids(&sorted_batch, &schema)?;
 
         let crc32 = Self::write_final_file(output_filename, index_name, &final_batch, schema, Some(writer_generation))?;
+
+        log_info!(
+            "sort_small_file: sorted {} rows, wrote Parquet to {}",
+            final_batch.num_rows(),
+            output_filename
+        );
         Ok(crc32)
     }
 
-    /// For large files: read in batches, sort each batch individually, write each
-    /// as a separate sorted chunk file, then use the streaming k-way merge to
-    /// produce the final globally-sorted output.
     fn sort_large_file(
         temp_filename: &str,
         output_filename: &str,
@@ -297,39 +364,51 @@ impl NativeParquetWriter {
         log_debug!("Using streaming merge sort for large file: {}", temp_filename);
 
         let file = File::open(temp_filename)?;
-        let builder = ParquetRecordBatchReaderBuilder::try_new(file)?;
-        let arrow_reader = builder.with_batch_size(batch_size).build()?;
+        let reader = IpcFileReader::try_new(file, None)?;
+        let schema = reader.schema();
 
         let mut chunk_paths: Vec<String> = Vec::new();
         let mut batch_count = 0;
         let chunk_dir = Path::new(output_filename).parent().unwrap_or_else(|| Path::new("."));
 
-        for batch_result in arrow_reader {
+        for batch_result in reader {
             let batch = batch_result?;
-            let schema = batch.schema();
-            let sorted_batch = Self::sort_batch(&batch, sort_columns, reverse_sorts, nulls_first)?;
+            if batch.num_rows() == 0 {
+                continue;
+            }
 
-            let chunk_filename = chunk_dir
-                .join(format!("temp_sort_chunk_{}_{}.parquet", batch_count, std::process::id()))
-                .to_string_lossy()
-                .to_string();
-            // CRC for temp chunks is not needed, discard it
-            Self::write_final_file(&chunk_filename, index_name, &sorted_batch, schema, None)?;
+            // IpcFileReader returns batches at whatever size they were written.
+            // Slice into batch_size chunks to bound memory during sort.
+            let mut offset = 0;
+            while offset < batch.num_rows() {
+                let len = std::cmp::min(batch_size, batch.num_rows() - offset);
+                let slice = batch.slice(offset, len);
+                offset += len;
 
-            chunk_paths.push(chunk_filename);
-            batch_count += 1;
+                let sorted_batch = Self::sort_batch(&slice, sort_columns, reverse_sorts, nulls_first)?;
+
+                let chunk_filename = chunk_dir
+                    .join(format!("temp_sort_chunk_{}_{}.parquet", batch_count, std::process::id()))
+                    .to_string_lossy()
+                    .to_string();
+                // CRC for temp chunks is not needed, discard it
+                Self::write_final_file(&chunk_filename, index_name, &sorted_batch, schema.clone(), None)?;
+
+                chunk_paths.push(chunk_filename);
+                batch_count += 1;
+            }
         }
 
         if chunk_paths.is_empty() {
             log_debug!("No data to sort in file: {}", temp_filename);
-            std::fs::rename(temp_filename, output_filename)?;
             return Ok(0);
         }
 
-        log_debug!("Created {} sorted chunks, merging via streaming k-way merge", batch_count);
+        log_debug!(
+            "Created {} sorted Parquet chunks, merging via streaming k-way merge",
+            batch_count
+        );
 
-        // merge_sorted returns MergeOutput; we discard it here because the
-        // sort-and-rewrite path produces the final file directly.
         let _merge_output = merge_sorted(
             &chunk_paths,
             output_filename,
@@ -337,42 +416,63 @@ impl NativeParquetWriter {
             sort_columns,
             reverse_sorts,
             nulls_first,
-        ).map_err(|e| -> Box<dyn std::error::Error> { format!("Streaming merge failed: {}", e).into() })?;
+        )
+        .map_err(|e| -> Box<dyn std::error::Error> {
+            format!("Streaming merge failed: {}", e).into()
+        })?;
 
         // Clean up temp chunk files
         for path in &chunk_paths {
             let _ = std::fs::remove_file(path);
         }
 
+        log_info!(
+            "sort_large_file: merged {} chunks, wrote Parquet to {}",
+            batch_count,
+            output_filename
+        );
         Ok(0)
     }
 
+    /// Sort a batch using RowConverter: converts sort columns into compact
+    /// byte-comparable rows, sorts indices by comparing those rows, then
+    /// reorders all columns via take.
     fn sort_batch(
         batch: &RecordBatch,
         sort_columns: &[String],
         reverse_sorts: &[bool],
         nulls_first: &[bool],
     ) -> Result<RecordBatch, Box<dyn std::error::Error>> {
-        let columns: Vec<SortColumn> = sort_columns
+        let sort_fields: Vec<SortField> = sort_columns
             .iter()
             .enumerate()
             .map(|(i, col_name)| {
-                let reverse = reverse_sorts.get(i).copied().unwrap_or(false);
-                let nf = nulls_first.get(i).copied().unwrap_or(false);
-                let options = arrow::compute::SortOptions {
-                    descending: reverse,
-                    nulls_first: nf,
-                };
                 let col_index = batch.schema().index_of(col_name)
                     .map_err(|_| format!("Sort column '{}' not found in schema", col_name))?;
-                Ok(SortColumn {
-                    values: batch.column(col_index).clone(),
-                    options: Some(options),
-                })
+                let data_type = batch.schema().field(col_index).data_type().clone();
+                let options = arrow::compute::SortOptions {
+                    descending: reverse_sorts.get(i).copied().unwrap_or(false),
+                    nulls_first: nulls_first.get(i).copied().unwrap_or(false),
+                };
+                Ok(SortField::new_with_options(data_type, options))
             })
             .collect::<Result<Vec<_>, Box<dyn std::error::Error>>>()?;
 
-        let indices = lexsort_to_indices(&columns, None)?;
+        let converter = RowConverter::new(sort_fields)?;
+
+        let sort_arrays: Vec<Arc<dyn arrow::array::Array>> = sort_columns
+            .iter()
+            .map(|col_name| {
+                let col_index = batch.schema().index_of(col_name).unwrap();
+                batch.column(col_index).clone()
+            })
+            .collect();
+
+        let rows = converter.convert_columns(&sort_arrays)?;
+        let mut sort_indices: Vec<u32> = (0..batch.num_rows() as u32).collect();
+        sort_indices.sort_unstable_by(|&a, &b| rows.row(a as usize).cmp(&rows.row(b as usize)));
+
+        let indices = arrow::array::UInt32Array::from(sort_indices);
         let sorted_columns: Result<Vec<_>, _> = batch
             .columns()
             .iter()
@@ -443,9 +543,12 @@ impl NativeParquetWriter {
         let mut total_memory = 0;
         for entry in WRITERS.iter() {
             if entry.key().starts_with(&path_prefix) {
-                if let Ok(writer) = entry.value().writer.lock() {
-                    total_memory += writer.memory_size();
+                if let WriterVariant::Parquet(writer_arc) = &entry.value().variant {
+                    if let Ok(writer) = writer_arc.lock() {
+                        total_memory += writer.memory_size();
+                    }
                 }
+                // IPC writers don't expose memory_size()
             }
         }
         Ok(total_memory)

--- a/sandbox/plugins/parquet-data-format/src/main/rust/tests/writer_integration_tests.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/tests/writer_integration_tests.rs
@@ -50,7 +50,7 @@ fn test_concurrent_writer_creation() {
             let file_path = temp_dir_path.join(format!("concurrent_{}.parquet", i));
             let filename = file_path.to_string_lossy().to_string();
             let (_schema, schema_ptr) = create_test_ffi_schema();
-            if NativeParquetWriter::create_writer(filename.clone(), "test-index".to_string(), schema_ptr, vec![], vec![], vec![]).is_ok() {
+            if NativeParquetWriter::create_writer(filename.clone(), "test-index".to_string(), schema_ptr, vec![], vec![], vec![], 0).is_ok() {
                 success_count.fetch_add(1, Ordering::SeqCst);
                 let _ = NativeParquetWriter::finalize_writer(filename);
             }
@@ -173,7 +173,7 @@ fn test_concurrent_complete_writer_lifecycle() {
             let filename = file_path.to_string_lossy().to_string();
             let (_schema, schema_ptr) = create_test_ffi_schema();
 
-            if NativeParquetWriter::create_writer(filename.clone(), "test-index".to_string(), schema_ptr, vec![], vec![], vec![]).is_ok() {
+            if NativeParquetWriter::create_writer(filename.clone(), "test-index".to_string(), schema_ptr, vec![], vec![], vec![], 0).is_ok() {
                 let (array_ptr, data_schema_ptr) = create_test_ffi_data().unwrap();
                 let write_ok = NativeParquetWriter::write_data(filename.clone(), array_ptr, data_schema_ptr).is_ok();
                 cleanup_ffi_data(array_ptr, data_schema_ptr);
@@ -185,6 +185,146 @@ fn test_concurrent_complete_writer_lifecycle() {
                             && file_path.exists()
                         {
                             success_count.fetch_add(1, Ordering::SeqCst);
+                        }
+                    }
+                }
+            }
+            cleanup_ffi_schema(schema_ptr);
+        });
+        handles.push(handle);
+    }
+
+    for handle in handles {
+        handle.join().unwrap();
+    }
+    assert_eq!(success_count.load(Ordering::SeqCst), thread_count);
+}
+
+// ===== Arrow IPC staging integration tests =====
+
+#[test]
+fn test_ipc_staging_sorted_writer_integration() {
+    let (_temp_dir, filename) = get_temp_file_path("ipc_integ_sorted.parquet");
+    let (_schema, schema_ptr) = create_test_ffi_schema();
+
+    NativeParquetWriter::create_writer(
+        filename.clone(), "test-index".to_string(), schema_ptr,
+        vec!["id".to_string()], vec![false], vec![false], 0
+    ).unwrap();
+
+    // Write multiple batches with out-of-order data
+    for batch_ids in [vec![50, 30, 10], vec![40, 20, 60]] {
+        let names: Vec<Option<&str>> = batch_ids.iter().map(|_| Some("x")).collect();
+        let (ap, sp) = create_test_ffi_data_with_ids(batch_ids, names).unwrap();
+        NativeParquetWriter::write_data(filename.clone(), ap, sp).unwrap();
+        cleanup_ffi_data(ap, sp);
+    }
+
+    let result = NativeParquetWriter::finalize_writer(filename.clone());
+    assert!(result.is_ok());
+    let metadata = result.unwrap().unwrap();
+    assert_eq!(metadata.metadata.file_metadata().num_rows(), 6);
+
+    assert!(NativeParquetWriter::sync_to_disk(filename.clone()).is_ok());
+
+    let ids = read_parquet_file_sorted_ids(&filename);
+    assert_eq!(ids, vec![10, 20, 30, 40, 50, 60]);
+
+    let read_metadata = NativeParquetWriter::get_file_metadata(filename).unwrap();
+    assert_eq!(read_metadata.num_rows(), 6);
+
+    cleanup_ffi_schema(schema_ptr);
+}
+
+#[test]
+fn test_ipc_staging_concurrent_sorted_lifecycle() {
+    let temp_dir = tempdir().unwrap();
+    let thread_count = 6;
+    let success_count = Arc::new(AtomicUsize::new(0));
+    let mut handles = vec![];
+
+    for i in 0..thread_count {
+        let temp_dir_path = temp_dir.path().to_path_buf();
+        let success_count = Arc::clone(&success_count);
+        let handle = thread::spawn(move || {
+            let file_path = temp_dir_path.join(format!("ipc_lifecycle_{}.parquet", i));
+            let filename = file_path.to_string_lossy().to_string();
+            let (_schema, schema_ptr) = create_test_ffi_schema();
+
+            if NativeParquetWriter::create_writer(
+                filename.clone(), "test-index".to_string(), schema_ptr,
+                vec!["id".to_string()], vec![false], vec![false], 0
+            ).is_ok() {
+                let (ap, sp) = create_test_ffi_data_with_ids(
+                    vec![30, 10, 20], vec![Some("C"), Some("A"), Some("B")]
+                ).unwrap();
+                let write_ok = NativeParquetWriter::write_data(filename.clone(), ap, sp).is_ok();
+                cleanup_ffi_data(ap, sp);
+
+                if write_ok {
+                    if let Ok(Some(metadata)) = NativeParquetWriter::finalize_writer(filename.clone()) {
+                        if metadata.metadata.file_metadata().num_rows() == 3
+                            && NativeParquetWriter::sync_to_disk(filename.clone()).is_ok()
+                            && file_path.exists()
+                        {
+                            let ids = read_parquet_file_sorted_ids(&filename);
+                            if ids == vec![10, 20, 30] {
+                                success_count.fetch_add(1, Ordering::SeqCst);
+                            }
+                        }
+                    }
+                }
+            }
+            cleanup_ffi_schema(schema_ptr);
+        });
+        handles.push(handle);
+    }
+
+    for handle in handles {
+        handle.join().unwrap();
+    }
+    assert_eq!(success_count.load(Ordering::SeqCst), thread_count);
+}
+
+#[test]
+fn test_ipc_and_parquet_mixed_concurrent_lifecycle() {
+    let temp_dir = tempdir().unwrap();
+    let thread_count = 8;
+    let success_count = Arc::new(AtomicUsize::new(0));
+    let mut handles = vec![];
+
+    for i in 0..thread_count {
+        let temp_dir_path = temp_dir.path().to_path_buf();
+        let success_count = Arc::clone(&success_count);
+        let use_sort = i % 2 == 0; // Even threads use IPC (sorted), odd use Parquet (unsorted)
+
+        let handle = thread::spawn(move || {
+            let file_path = temp_dir_path.join(format!("mixed_{}.parquet", i));
+            let filename = file_path.to_string_lossy().to_string();
+            let (_schema, schema_ptr) = create_test_ffi_schema();
+
+            let sort_cols = if use_sort { vec!["id".to_string()] } else { vec![] };
+            let reverse = if use_sort { vec![false] } else { vec![] };
+            let nulls = if use_sort { vec![false] } else { vec![] };
+
+            if NativeParquetWriter::create_writer(
+                filename.clone(), "test-index".to_string(), schema_ptr,
+                sort_cols, reverse, nulls, 0
+            ).is_ok() {
+                let (ap, sp) = create_test_ffi_data_with_ids(
+                    vec![30, 10, 20], vec![Some("C"), Some("A"), Some("B")]
+                ).unwrap();
+                let write_ok = NativeParquetWriter::write_data(filename.clone(), ap, sp).is_ok();
+                cleanup_ffi_data(ap, sp);
+
+                if write_ok {
+                    if let Ok(Some(metadata)) = NativeParquetWriter::finalize_writer(filename.clone()) {
+                        if metadata.metadata.file_metadata().num_rows() == 3 && file_path.exists() {
+                            let ids = read_parquet_file_sorted_ids(&filename);
+                            let expected = if use_sort { vec![10, 20, 30] } else { vec![30, 10, 20] };
+                            if ids == expected {
+                                success_count.fetch_add(1, Ordering::SeqCst);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## Summary

When sort columns are configured, the writer now stages incoming batches as Arrow IPC instead of Parquet, avoiding redundant Parquet encoding and compression before the sort-on-close step. For large files, batches are individually sorted and written as Parquet chunks, then merged via the existing streaming k-way merge. The per-batch sort uses Arrow's `RowConverter` for compact byte-comparable row encoding. 

## Details

### Arrow IPC staging for sorted writes

Previously, all data was written as Parquet regardless of whether sort columns were configured. On finalize, the Parquet file was read back (decoded), sorted, and re-written as Parquet — a full encode-decode-encode cycle. Now, when sort columns are present, a `WriterVariant::Ipc` path writes batches as Arrow IPC (raw in-memory Arrow buffers with minimal framing). On finalize, the IPC file is read back with near-zero deserialization cost, sorted, and written as the final Parquet file — a single encode step.

When no sort columns are configured, the `WriterVariant::Parquet` path is used as before, and finalize simply renames the temp file to the final path.

### Small and large file sort strategies

The sort-on-close path (`sort_and_rewrite_parquet`) uses a size-based threshold (`sort_in_memory_threshold_bytes`, default 32 MB) to choose between two strategies:

- Small files (`sort_small_file`): All IPC batches are read into memory, concatenated, sorted, row IDs rewritten, and written as a single Parquet file.
- Large files (`sort_large_file`): Each IPC batch is sliced into `sort_batch_size` chunks (to bound memory since IPC batches can be arbitrarily large), each chunk is sorted individually and written as a temporary Parquet chunk file, then the existing streaming k-way merge produces the final globally-sorted Parquet output. Chunk files are cleaned up after the merge.

### RowConverter-based per-batch sort

The `sort_batch` function now uses Arrow's `RowConverter` instead of `lexsort_to_indices`. `RowConverter` converts sort columns into compact byte-comparable rows where sort direction and null ordering are baked into the encoding. Sorting then reduces to comparing opaque byte sequences via `sort_unstable_by`, followed by a `take` to reorder all columns. This approach handles all Arrow data types uniformly without a per-type dispatch in the sort comparator.

### CRC32 integration

The IPC staging path integrates with the existing `CrcWriter`-based CRC32 computation. Since IPC batches are not Parquet-encoded, the CRC is computed during the final Parquet write step (`write_final_file` for small files, `merge_sorted` for large files) rather than during the initial staging write. The `WriterState.crc_handle` field is `Option<CrcHandle>` — `Some` for the Parquet variant, `None` for IPC.

### Testing

Existing tests cover both sorted (IPC path) and unsorted (Parquet path) writer lifecycles, including concurrent writers, empty data, multi-batch sorting, ascending/descending sort, and mixed IPC+Parquet coexistence. New integration tests validate the IPC staging cleanup, sorted output correctness, and concurrent sorted writer behavior.

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]


### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
