### PR TITLE
Add live version map in DataFormatAwareEngine.

### DIFF
--- a/server/src/main/java/org/opensearch/index/engine/DataFormatAwareEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/DataFormatAwareEngine.java
@@ -14,6 +14,7 @@ import org.apache.lucene.index.IndexCommit;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.ReferenceManager;
 import org.apache.lucene.store.AlreadyClosedException;
+import org.apache.lucene.util.BytesRef;
 import org.opensearch.OpenSearchException;
 import org.opensearch.common.Booleans;
 import org.opensearch.common.Nullable;
@@ -23,6 +24,7 @@ import org.opensearch.common.concurrent.GatedCloseable;
 import org.opensearch.common.concurrent.GatedConditionalCloseable;
 import org.opensearch.common.lease.Releasable;
 import org.opensearch.common.logging.Loggers;
+import org.opensearch.common.metrics.CounterMetric;
 import org.opensearch.common.queue.DefaultLockableHolder;
 import org.opensearch.common.queue.LockablePool;
 import org.opensearch.common.unit.TimeValue;
@@ -176,6 +178,9 @@ public class DataFormatAwareEngine implements Indexer {
     // Refresh tracker
     private final LastRefreshedCheckpointListener lastRefreshedCheckpointListener;
 
+    //LiveVersionMap
+    private final LiveVersionMap versionMap;
+
     // Merge
     private final MergeScheduler mergeScheduler;
 
@@ -203,6 +208,7 @@ public class DataFormatAwareEngine implements Indexer {
         this.shardId = engineConfig.getShardId();
         this.store = engineConfig.getStore();
         this.throttle = new IndexingThrottler();
+        this.versionMap = new LiveVersionMap();
 
         List<ReferenceManager.RefreshListener> refreshListeners = new ArrayList<>();
         if (engineConfig.getInternalRefreshListener() != null) {
@@ -333,13 +339,13 @@ public class DataFormatAwareEngine implements Indexer {
             this.indexingStrategyPlanner = new IndexingStrategyPlanner(
                 engineConfig.getIndexSettings(),
                 engineConfig.getShardId(),
-                new LiveVersionMap(),
+                this.versionMap,
                 maxUnsafeAutoIdTimestamp::get,
                 () -> 0L,
                 localCheckpointTracker::getProcessedCheckpoint,
                 this::hasBeenProcessedBefore,
                 op -> OpVsEngineDocStatus.OP_NEWER,
-                (a, b) -> null,
+                this::resolveDocVersion,
                 this::updateAutoIdTimestamp,
                 (a, b) -> null
             );
@@ -485,9 +491,12 @@ public class DataFormatAwareEngine implements Indexer {
         assert (index.origin() == Engine.Operation.Origin.PRIMARY || index.origin() == Engine.Operation.Origin.LOCAL_TRANSLOG_RECOVERY)
             : "DataFormatAwareEngine only supports PRIMARY origin but got: " + index.origin();
         final boolean doThrottle = index.origin().isRecovery() == false;
-        try (ReleasableLock ignored = readLock.acquire()) {
+        try (ReleasableLock releasableLock = readLock.acquire()) {
             ensureOpen();
-            try (Releasable indexThrottle = doThrottle ? throttle.acquireThrottle() : () -> {}) {
+            try (
+                Releasable ignored = versionMap.acquireLock(index.uid().bytes());
+                Releasable indexThrottle = doThrottle ? throttle.acquireThrottle() : () -> {}
+            ) {
                 lastWriteNanos = index.startTime();
                 final IndexingStrategy plan;
                 if (index.origin() == Engine.Operation.Origin.PRIMARY) {
@@ -559,6 +568,7 @@ public class DataFormatAwareEngine implements Indexer {
 
         // Convert ParsedDocument to DocumentInput and write via the execution engine's writer
         Writer currentWriter = null;
+        long writerGeneration = -1;
         DefaultLockableHolder<Writer<?>> lockedWriter = writerPool.getAndLock();
         try {
             currentWriter = lockedWriter.get();
@@ -570,6 +580,7 @@ public class DataFormatAwareEngine implements Indexer {
 
             if (result instanceof WriteResult.Success) {
                 indexResult = new Engine.IndexResult(plan.version, index.primaryTerm(), index.seqNo(), true);
+                writerGeneration = currentWriter.generation();
                 // The result must carry the same seq no that was assigned to the operation
                 assert indexResult.getSeqNo() == index.seqNo() : "IndexResult seq no ["
                     + indexResult.getSeqNo()
@@ -592,6 +603,10 @@ public class DataFormatAwareEngine implements Indexer {
             final Translog.Location location;
             if (indexResult.getResultType() == Engine.Result.Type.SUCCESS) {
                 location = translogManager.add(new Translog.Index(index, indexResult));
+                versionMap.maybePutIndexUnderLock(
+                    index.uid().bytes(),
+                    new DataFormatVersionValue(location, indexResult.getVersion(), index.seqNo(), index.primaryTerm(), writerGeneration)
+                );
             } else if (indexResult.getSeqNo() != UNASSIGNED_SEQ_NO
                 && indexResult.getFailure() != null
                 && !(indexResult.getFailure() instanceof AppendOnlyIndexOperationRetryException)) {
@@ -736,6 +751,9 @@ public class DataFormatAwareEngine implements Indexer {
             refreshLock.lock();
             try (GatedCloseable<CatalogSnapshot> catalogSnapshot = catalogSnapshotManager.acquireSnapshot()) {
                 if (store.tryIncRef()) {
+                    // Rotate the version map so new writes go to a fresh map while refresh is in progress.
+                    // afterRefresh will drop the old map once the new snapshot makes those versions resolvable.
+                    versionMap.beforeRefresh();
                     try {
                         List<DefaultLockableHolder<Writer<?>>> writers = writerPool.checkoutAll();
                         List<Segment> existingSegments = catalogSnapshot.get().getSegments();
@@ -793,9 +811,14 @@ public class DataFormatAwareEngine implements Indexer {
                         notifyRefreshListenersAfter(refreshed);
                     } finally {
                         store.decRef();
+                        versionMap.afterRefresh(refreshed);
                     }
                     if (refreshed) {
                         lastRefreshedCheckpointListener.updateRefreshedCheckpoint(localCheckpointBeforeRefresh);
+                        versionMap.pruneTombstones(
+                            engineConfig.getThreadPool().relativeTimeInMillis() - engineConfig.getIndexSettings().getGcDeletesInMillis(),
+                            localCheckpointTracker.getProcessedCheckpoint()
+                        );
                         triggerPossibleMerges(); // trigger merges
                     }
                 }
@@ -1075,7 +1098,11 @@ public class DataFormatAwareEngine implements Indexer {
 
     @Override
     public void advanceMaxSeqNoOfUpdatesOrDeletes(long maxSeqNoOfUpdatesOnPrimary) {
-        throw new UnsupportedOperationException("updates/deletes not supported");
+        if (maxSeqNoOfUpdatesOnPrimary == SequenceNumbers.UNASSIGNED_SEQ_NO) {
+            assert false : "max_seq_no_of_updates on primary is unassigned";
+            throw new IllegalArgumentException("max_seq_no_of_updates on primary is unassigned");
+        }
+        this.maxSeqNoOfUpdatesOrDeletes.updateAndGet(curr -> Math.max(curr, maxSeqNoOfUpdatesOnPrimary));
     }
 
     @Override
@@ -1500,6 +1527,39 @@ public class DataFormatAwareEngine implements Indexer {
         // sequence number should not be set when operation origin is primary
         assert seqNo == UNASSIGNED_SEQ_NO : "primary operations must never have an assigned sequence number but was [" + seqNo + "]";
         return true;
+    }
+
+    private VersionValue getVersionFromMap(BytesRef id) {
+        if (versionMap.isUnsafe()) {
+            synchronized (versionMap) {
+                // we are switching from an unsafe map to a safe map. This might happen concurrently,
+                // but we only need to do this once since the last operation per ID is to add to the version
+                // map so once we pass this point we can safely look up from the version map.
+                if (versionMap.isUnsafe()) {
+                    refresh("unsafe_version_map");
+                }
+                versionMap.enforceSafeAccess();
+            }
+        }
+        return versionMap.getUnderLock(id);
+    }
+
+    /**
+     * Resolves the current version of a document by looking it up in the live version map.
+     * Returns {@code null} if the document is not found or if a delete tombstone has expired
+     * past the {@code index.gc_deletes} threshold.
+     */
+    private VersionValue resolveDocVersion(final Engine.Operation op, boolean loadSeqNo) throws IOException {
+        VersionValue versionValue = getVersionFromMap(op.uid().bytes());
+        if (versionValue != null
+            && engineConfig.isEnableGcDeletes()
+            && versionValue.isDelete()
+            && (engineConfig.getThreadPool().relativeTimeInMillis() - ((DeleteVersionValue) versionValue).time) > engineConfig
+            .getIndexSettings()
+            .getGcDeletesInMillis()) {
+            versionValue = null;
+        }
+        return versionValue;
     }
 
     private boolean hasBeenProcessedBefore(Engine.Operation op) {

--- a/server/src/main/java/org/opensearch/index/engine/DataFormatVersionValue.java
+++ b/server/src/main/java/org/opensearch/index/engine/DataFormatVersionValue.java
@@ -1,0 +1,66 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.engine;
+
+import org.apache.lucene.util.RamUsageEstimator;
+import org.opensearch.index.translog.Translog;
+
+import java.util.Objects;
+
+/**
+ * Extends {@link IndexVersionValue} with a writer generation for data-format-aware engines.
+ * The writer generation identifies which writer (and thus which Parquet file / Lucene segment)
+ * the document belongs to, used by the delete path to route deletes to the correct writer.
+ *
+ * @opensearch.internal
+ */
+final class DataFormatVersionValue extends IndexVersionValue {
+
+    private static final long RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(DataFormatVersionValue.class);
+
+    final long writerGeneration;
+
+    DataFormatVersionValue(Translog.Location translogLocation, long version, long seqNo, long term, long writerGeneration) {
+        super(translogLocation, version, seqNo, term);
+        this.writerGeneration = writerGeneration;
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        return RAM_BYTES_USED;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (super.equals(o) == false) return false;
+        DataFormatVersionValue that = (DataFormatVersionValue) o;
+        return writerGeneration == that.writerGeneration;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), writerGeneration);
+    }
+
+    @Override
+    public String toString() {
+        return "DataFormatVersionValue{"
+            + "version="
+            + version
+            + ", seqNo="
+            + seqNo
+            + ", term="
+            + term
+            + ", writerGeneration="
+            + writerGeneration
+            + '}';
+    }
+}

--- a/server/src/main/java/org/opensearch/index/engine/IndexVersionValue.java
+++ b/server/src/main/java/org/opensearch/index/engine/IndexVersionValue.java
@@ -42,7 +42,7 @@ import java.util.Objects;
  *
  * @opensearch.internal
  */
-final class IndexVersionValue extends VersionValue {
+class IndexVersionValue extends VersionValue {
 
     private static final long RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(IndexVersionValue.class);
     private static final long TRANSLOG_LOC_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(Translog.Location.class);


### PR DESCRIPTION
### Description

Integrates `LiveVersionMap` into `DataFormatAwareEngine`.

**What this PR does:**

- Adds a `LiveVersionMap` to `DataFormatAwareEngine` and wires it into the `IndexingStrategyPlanner` (replacing the no-op `(a, b) -> null` version resolver)
- Introduces `DataFormatVersionValue`, extending `IndexVersionValue` with `rowId` (0-based row position in the parquet file) and a `Writer` reference, enabling the delete path to locate documents in format-specific storage. 
- Stores version entries in the map after successful indexing, keyed by document `_id`
- Adds version map lifecycle hooks in the refresh path: `beforeRefresh()` / `afterRefresh()` / `pruneTombstones()`
- Implements `resolveDocVersion()` for version lookups. 
- Implements `getVersionFromMap()` . 
- Adds `rowId` field to `WriteResult.Success` so writers can report the row position back to the engine

### Related Issues
Resolves #[Issue number]

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).