### PR TITLE
Wire Rust native library build into assemble lifecycle

### DIFF
--- a/sandbox/libs/dataformat-native/build.gradle
+++ b/sandbox/libs/dataformat-native/build.gradle
@@ -87,6 +87,8 @@ task buildRustLibrary(type: Exec) {
 // Expose the native lib path so plugins can reference it for tests
 ext.nativeLibPath = nativeLibFile
 
+assemble.dependsOn buildRustLibrary
+
 test {
     systemProperty 'tests.security.manager', 'false'
     systemProperty 'native.lib.path', nativeLibFile.absolutePath


### PR DESCRIPTION
## Summary

`buildRustLibrary` (which builds `libopensearch_native` from Rust via Cargo) was only wired as a dependency of the `test` task. This meant `./gradlew assemble -Dsandbox.enabled=true` never triggered the Rust build, so the native library did not exist on disk when opensearch-build's `build.sh` tried to package it.

This caused assembled distributions to crash at startup:
```
java.lang.RuntimeException: Failed to load native library 'opensearch_native'
    at NativeLibraryLoader.loadLibrary(NativeLibraryLoader.java:168)
    at NativeBridge.<clinit>(NativeBridge.java:63)
    at DataFusionService.doStart(DataFusionService.java:64)
    at DataFusionPlugin.createComponents(DataFusionPlugin.java:129)
```

## Changes

**`sandbox/libs/dataformat-native/build.gradle`**
- Add `assemble.dependsOn buildRustLibrary` — ensures the Rust native library is built as part of the normal assemble/publish lifecycle, not just for tests
- Support `-PrustRelease` flag that opensearch-build's `build.sh` already passes (previously a no-op since code only checked `-PrustDebug`)

## Companion PR

opensearch-project/opensearch-build#6177 — bundles the built native library into plugin zips and wires `JAVA_LIBRARY_PATH`/`LD_LIBRARY_PATH` at startup.

## Test plan

- [x] `./gradlew :sandbox:libs:dataformat-native:assemble -Dsandbox.enabled=true` successfully triggers Rust build and produces `libopensearch_native.dylib`
- [x] `./gradlew :sandbox:plugins:analytics-backend-datafusion:assemble -Dsandbox.enabled=true` completes with native lib available for packaging
- [ ] CI build passes with sandbox enabled
