### PR TITLE
Add coordinator side hash joins to analytics engine

### DIFF
--- a/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/EngineCapability.java
+++ b/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/EngineCapability.java
@@ -21,5 +21,6 @@ package org.opensearch.analytics.spi;
  */
 public enum EngineCapability {
     SORT,
-    UNION
+    UNION,
+    JOIN
 }

--- a/sandbox/plugins/analytics-backend-datafusion/src/internalClusterTest/java/org/opensearch/be/datafusion/CoordinatorJoinIT.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/internalClusterTest/java/org/opensearch/be/datafusion/CoordinatorJoinIT.java
@@ -1,0 +1,182 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion;
+
+import org.opensearch.Version;
+import org.opensearch.action.admin.indices.create.CreateIndexResponse;
+import org.opensearch.analytics.AnalyticsPlugin;
+import org.opensearch.arrow.flight.transport.FlightStreamPlugin;
+import org.opensearch.be.lucene.LucenePlugin;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.FeatureFlags;
+import org.opensearch.composite.CompositeDataFormatPlugin;
+import org.opensearch.parquet.ParquetDataFormatPlugin;
+import org.opensearch.plugins.Plugin;
+import org.opensearch.plugins.PluginInfo;
+import org.opensearch.ppl.TestPPLPlugin;
+import org.opensearch.ppl.action.PPLRequest;
+import org.opensearch.ppl.action.PPLResponse;
+import org.opensearch.ppl.action.UnifiedPPLExecuteAction;
+import org.opensearch.test.OpenSearchIntegTestCase;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * End-to-end smoke test for the coordinator-side hash join path:
+ *
+ * <pre>
+ *   PPL `join` → planner → 2 SHARD_FRAGMENT child stages (one per table)
+ *       → ExchangeSink.feed(inputIndex, batch) → DatafusionReduceSink registers 2
+ *         partition streams ("input-0", "input-1") against one LocalSession
+ *       → DataFusion executes JoinRel as HashJoinExec
+ *       → drain → downstream → assembled PPLResponse
+ * </pre>
+ *
+ * <p>Builds two parquet-backed indices ({@code t1}, {@code t2}) each with two shards
+ * and overlapping join keys, runs a PPL inner equi-join, and asserts that joined
+ * rows materialize.
+ */
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.SUITE, numDataNodes = 2)
+public class CoordinatorJoinIT extends OpenSearchIntegTestCase {
+
+    private static final String T1 = "join_e2e_t1";
+    private static final String T2 = "join_e2e_t2";
+    private static final int NUM_SHARDS = 2;
+    /** Number of overlapping keys (also rows per index) — keep small to keep the IT fast. */
+    private static final int NUM_KEYS = 6;
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return List.of(TestPPLPlugin.class, FlightStreamPlugin.class, CompositeDataFormatPlugin.class, LucenePlugin.class);
+    }
+
+    @Override
+    protected Collection<PluginInfo> additionalNodePlugins() {
+        return List.of(
+            classpathPlugin(AnalyticsPlugin.class, Collections.emptyList()),
+            classpathPlugin(ParquetDataFormatPlugin.class, Collections.emptyList()),
+            classpathPlugin(DataFusionPlugin.class, List.of(AnalyticsPlugin.class.getName()))
+        );
+    }
+
+    private static PluginInfo classpathPlugin(Class<? extends Plugin> pluginClass, List<String> extendedPlugins) {
+        return new PluginInfo(
+            pluginClass.getName(),
+            "classpath plugin",
+            "NA",
+            Version.CURRENT,
+            "1.8",
+            pluginClass.getName(),
+            null,
+            extendedPlugins,
+            false
+        );
+    }
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return Settings.builder()
+            .put(super.nodeSettings(nodeOrdinal))
+            .put(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG, true)
+            // STREAM_TRANSPORT intentionally OFF — see CoordinatorReduceIT for the rationale.
+            .build();
+    }
+
+    /**
+     * Inner equi-join across two 2-shard indices. Each index has the same set of keys
+     * 1..NUM_KEYS, so an INNER JOIN ON {@code k} returns NUM_KEYS rows.
+     */
+    public void testInnerEquiJoinAcrossShards() throws Exception {
+        createParquetBackedIndex(T1, "v");
+        createParquetBackedIndex(T2, "w");
+        indexKeyedDocs(T1, "v");
+        indexKeyedDocs(T2, "w");
+
+        // PPL inner join on equality of `k`. The frontend lowers this to
+        // LogicalProject(LogicalJoin(scan(t1), scan(t2))) which our HEP marker
+        // converts to OpenSearchJoin (under the LogicalProject), and Volcano's
+        // trait enforcer wraps each input in an OpenSearchExchangeReducer.
+        String ppl = "source=" + T1 + " | join on " + T1 + ".k = " + T2 + ".k " + T2;
+        PPLResponse response = executePPL(ppl);
+
+        assertNotNull("PPLResponse must not be null", response);
+        assertTrue("response columns must include 'k', got " + response.getColumns(), response.getColumns().contains("k"));
+        assertTrue("response columns must include 'v', got " + response.getColumns(), response.getColumns().contains("v"));
+        assertTrue("response columns must include 'w', got " + response.getColumns(), response.getColumns().contains("w"));
+
+        // Both sides have keys 1..NUM_KEYS, so the inner equi-join yields exactly NUM_KEYS rows.
+        assertEquals("inner equi-join row count", NUM_KEYS, response.getRows().size());
+
+        int kIdx = response.getColumns().indexOf("k");
+        int vIdx = response.getColumns().indexOf("v");
+        int wIdx = response.getColumns().indexOf("w");
+
+        // Each row must have the same key referenced from both sides; the v / w payloads
+        // are deterministic functions of the key.
+        Set<Integer> seenKeys = new HashSet<>();
+        for (Object[] row : response.getRows()) {
+            int key = ((Number) row[kIdx]).intValue();
+            int vCell = ((Number) row[vIdx]).intValue();
+            int wCell = ((Number) row[wIdx]).intValue();
+            assertTrue("key in expected range, got " + key, key >= 1 && key <= NUM_KEYS);
+            assertEquals("v payload follows the per-key formula", expectedV(key), vCell);
+            assertEquals("w payload follows the per-key formula", expectedW(key), wCell);
+            assertTrue("each key appears at most once (no duplicates in source data)", seenKeys.add(key));
+        }
+        assertEquals("every key in [1, NUM_KEYS] appears exactly once", NUM_KEYS, seenKeys.size());
+    }
+
+    /** Per-key formula for {@code t1.v}; arbitrary but deterministic so we can assert exact values. */
+    private static int expectedV(int key) {
+        return key * 10;
+    }
+
+    /** Per-key formula for {@code t2.w}; distinct from v so column order matters in the assertion. */
+    private static int expectedW(int key) {
+        return key * 100;
+    }
+
+    private void createParquetBackedIndex(String indexName, String payloadField) {
+        Settings indexSettings = Settings.builder()
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, NUM_SHARDS)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+            .put("index.pluggable.dataformat.enabled", true)
+            .put("index.pluggable.dataformat", "composite")
+            .put("index.composite.primary_data_format", "parquet")
+            .putList("index.composite.secondary_data_formats")
+            .build();
+
+        CreateIndexResponse response = client().admin()
+            .indices()
+            .prepareCreate(indexName)
+            .setSettings(indexSettings)
+            .setMapping("k", "type=integer", payloadField, "type=integer")
+            .get();
+        assertTrue("index creation must be acknowledged", response.isAcknowledged());
+        ensureGreen(indexName);
+    }
+
+    private void indexKeyedDocs(String indexName, String payloadField) {
+        for (int key = 1; key <= NUM_KEYS; key++) {
+            int payload = payloadField.equals("v") ? expectedV(key) : expectedW(key);
+            client().prepareIndex(indexName).setId(indexName + "_" + key).setSource("k", key, payloadField, payload).get();
+        }
+        client().admin().indices().prepareRefresh(indexName).get();
+        client().admin().indices().prepareFlush(indexName).get();
+    }
+
+    private PPLResponse executePPL(String ppl) {
+        return client().execute(UnifiedPPLExecuteAction.INSTANCE, new PPLRequest(ppl)).actionGet();
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/src/internalClusterTest/java/org/opensearch/be/datafusion/CoordinatorJoinMultiNodeIT.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/internalClusterTest/java/org/opensearch/be/datafusion/CoordinatorJoinMultiNodeIT.java
@@ -1,0 +1,400 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion;
+
+import org.opensearch.Version;
+import org.opensearch.action.admin.indices.create.CreateIndexResponse;
+import org.opensearch.analytics.AnalyticsPlugin;
+import org.opensearch.arrow.flight.transport.FlightStreamPlugin;
+import org.opensearch.be.lucene.LucenePlugin;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.common.util.FeatureFlags;
+import org.opensearch.composite.CompositeDataFormatPlugin;
+import org.opensearch.parquet.ParquetDataFormatPlugin;
+import org.opensearch.plugins.Plugin;
+import org.opensearch.plugins.PluginInfo;
+import org.opensearch.ppl.TestPPLPlugin;
+import org.opensearch.ppl.action.PPLRequest;
+import org.opensearch.ppl.action.PPLResponse;
+import org.opensearch.ppl.action.UnifiedPPLExecuteAction;
+import org.opensearch.test.OpenSearchIntegTestCase;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.function.IntUnaryOperator;
+
+/**
+ * Scale + edge-case suite for the coordinator-side hash join path: 3 data nodes,
+ * 5 primary shards per index. Exercises the multi-input reduce sink under heavier
+ * fan-in than {@link CoordinatorJoinIT}'s 2×2 baseline (10 child shard tasks fan
+ * into two registered partition streams) plus a battery of correctness edge cases
+ * that the small-cluster IT can't easily reach.
+ *
+ * <p><b>Replicas are intentionally disabled.</b> The parquet-backed composite
+ * engine does not implement {@code acquireSafeIndexCommit}, which is required
+ * for replica recovery; setting {@code number_of_replicas > 0} causes every
+ * replica to fail allocation with {@code RecoveryFailedException} and the
+ * cluster never reaches green. Once the composite engine adds replica support,
+ * this IT should be expanded to validate replica-aware shard-target resolution.
+ *
+ * <p>What this stresses that the small-cluster IT doesn't:
+ * <ul>
+ *   <li>Lock-free {@code feed(int inputIndex, batch)} contention from many
+ *       concurrent shard responses fanning into the two input channels.</li>
+ *   <li>{@link DatafusionReduceSink#closeUnderLock}'s in-flight-feeds barrier
+ *       under realistic shutdown timing.</li>
+ *   <li>Asymmetric per-side cardinality + many-to-many fan-out on duplicates.</li>
+ *   <li>Empty-side and no-overlap edge cases (build or probe side empty must
+ *       not hang the drain thread).</li>
+ *   <li>NULL key semantics ({@code NULL = NULL} is unknown, must filter out).</li>
+ *   <li>Self-join: same physical table on both sides, two distinct registered
+ *       inputs.</li>
+ *   <li>Large data with sustained streaming throughput.</li>
+ *   <li>Single-shard degenerate case (one side SINGLETON, the other RANDOM).</li>
+ *   <li>Concurrent queries (session-level isolation).</li>
+ * </ul>
+ *
+ * <p>Each test method creates its own pair of indices with names of the form
+ * {@code join_mn_<scenario>_*}; {@link #tearDown()} deletes everything matching
+ * {@code join_mn_*} so the SUITE-scoped cluster never accumulates more than the
+ * current test's shards.
+ */
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.SUITE, numDataNodes = 3)
+public class CoordinatorJoinMultiNodeIT extends OpenSearchIntegTestCase {
+
+    private static final int NUM_SHARDS = 5;
+    /** See class javadoc — composite engine doesn't implement acquireSafeIndexCommit
+     *  yet, so replicas can't be recovered. Fixed at 0 until that lands. */
+    private static final int NUM_REPLICAS = 0;
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return List.of(TestPPLPlugin.class, FlightStreamPlugin.class, CompositeDataFormatPlugin.class, LucenePlugin.class);
+    }
+
+    @Override
+    protected Collection<PluginInfo> additionalNodePlugins() {
+        return List.of(
+            classpathPlugin(AnalyticsPlugin.class, Collections.emptyList()),
+            classpathPlugin(ParquetDataFormatPlugin.class, Collections.emptyList()),
+            classpathPlugin(DataFusionPlugin.class, List.of(AnalyticsPlugin.class.getName()))
+        );
+    }
+
+    private static PluginInfo classpathPlugin(Class<? extends Plugin> pluginClass, List<String> extendedPlugins) {
+        return new PluginInfo(
+            pluginClass.getName(),
+            "classpath plugin",
+            "NA",
+            Version.CURRENT,
+            "1.8",
+            pluginClass.getName(),
+            null,
+            extendedPlugins,
+            false
+        );
+    }
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return Settings.builder()
+            .put(super.nodeSettings(nodeOrdinal))
+            .put(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG, true)
+            // STREAM_TRANSPORT intentionally OFF — see CoordinatorReduceIT for rationale.
+            .build();
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        // Drop every test index between methods so the SUITE-scoped cluster doesn't
+        // accumulate shard copies across tests. Wildcard delete is cheap when nothing
+        // matches.
+        try {
+            client().admin().indices().prepareDelete("join_mn_*").get();
+        } catch (Exception ignore) {
+            // Best-effort cleanup; some scenarios may have already deleted their indices.
+        }
+        super.tearDown();
+    }
+
+    // ── Baseline scale + asymmetric overlap + duplicates ────────────────
+
+    /**
+     * Asymmetric inner equi-join with right-side duplicates across 5+5 primary
+     * shards on 3 data nodes. Asserts:
+     * <ul>
+     *   <li>Row count equals overlap × DUPES.</li>
+     *   <li>Every joined key lies in the overlap range (filters out non-overlap).</li>
+     *   <li>Each overlap key appears exactly DUPES times.</li>
+     * </ul>
+     */
+    public void testJoinAcrossManyShardsAndNodes() throws Exception {
+        final int NUM_KEYS = 60;
+        final int OFFSET = NUM_KEYS / 3;
+        final int DUPES = 4;
+        String t1 = "join_mn_base_t1";
+        String t2 = "join_mn_base_t2";
+        createParquetIndex(t1, NUM_SHARDS, "v");
+        createParquetIndex(t2, NUM_SHARDS, "w");
+        indexUnique(t1, "v", 1, NUM_KEYS, k -> k * 11);
+        indexWithDuplicates(t2, "w", OFFSET + 1, NUM_KEYS + OFFSET, DUPES);
+
+        PPLResponse response = executePPL("source=" + t1 + " | join on " + t1 + ".k = " + t2 + ".k " + t2);
+
+        assertColumns(response, "k", "v", "w");
+        int overlapLo = OFFSET + 1;
+        int overlapHi = NUM_KEYS;
+        int overlapSize = overlapHi - overlapLo + 1;
+        assertEquals("rows = overlap × DUPES", overlapSize * DUPES, response.getRows().size());
+
+        int kIdx = response.getColumns().indexOf("k");
+        Map<Integer, Integer> perKeyCount = new HashMap<>();
+        for (Object[] row : response.getRows()) {
+            int key = ((Number) row[kIdx]).intValue();
+            assertTrue("joined key in overlap [" + overlapLo + ", " + overlapHi + "], got " + key, key >= overlapLo && key <= overlapHi);
+            perKeyCount.merge(key, 1, Integer::sum);
+        }
+        assertEquals("every overlap key appears", overlapSize, perKeyCount.size());
+        for (Map.Entry<Integer, Integer> entry : perKeyCount.entrySet()) {
+            assertEquals("key " + entry.getKey() + " × " + DUPES, DUPES, entry.getValue().intValue());
+        }
+    }
+
+    // ── Edge case: no key overlap ────────────────────────────────────────
+
+    /**
+     * Both sides populated but with disjoint key ranges. Inner equi-join must
+     * return 0 rows. Catches a bug where the HashJoin's empty-result path fails
+     * to flush through the drain thread.
+     */
+    public void testNoKeyOverlap() throws Exception {
+        String t1 = "join_mn_disjoint_t1";
+        String t2 = "join_mn_disjoint_t2";
+        createParquetIndex(t1, NUM_SHARDS, "v");
+        createParquetIndex(t2, NUM_SHARDS, "w");
+        indexUnique(t1, "v", 1, 30, k -> k * 11);
+        indexUnique(t2, "w", 1000, 1030, k -> k * 113);
+
+        PPLResponse response = executePPL("source=" + t1 + " | join on " + t1 + ".k = " + t2 + ".k " + t2);
+        assertColumns(response, "k", "v", "w");
+        assertEquals("disjoint ranges must produce 0 rows", 0, response.getRows().size());
+    }
+
+    // ── Edge case: self-join ─────────────────────────────────────────────
+
+    /**
+     * Self-join on the same physical table. Two distinct registered inputs
+     * ({@code "input-0"} and {@code "input-1"}) must point at independent
+     * partition streams even though the underlying {@code OpenSearchTableScan}
+     * resolves the same index — i.e., the planner must produce two separate
+     * child shard-fragment stages, not alias a single one.
+     *
+     * <p>Each row joins with itself (k = k always holds for same-key rows), so
+     * the result row count equals the input row count for unique keys.
+     */
+    public void testSelfJoin() throws Exception {
+        String t1 = "join_mn_self_t1";
+        createParquetIndex(t1, NUM_SHARDS, "v");
+        indexUnique(t1, "v", 1, 20, k -> k * 11);
+
+        // PPL self-join via aliases. Both sides reference the same table; the
+        // aliases let PPL disambiguate the field references in the join condition.
+        PPLResponse response = executePPL("source=" + t1 + " as a | join on a.k = b.k " + t1 + " as b");
+        assertNotNull(response);
+        assertEquals("self-join with unique keys: each row matches itself once", 20, response.getRows().size());
+    }
+
+    // ── Edge case #5: large data with sustained streaming ────────────────
+
+    /**
+     * Large symmetric inner join exercising sustained streaming-feed throughput
+     * and the drain thread under prolonged build/probe windows. Catches
+     * regressions where the lock-free {@code feed(int, batch)} path or the
+     * in-flight barrier in {@code closeUnderLock} mishandle longer queries.
+     */
+    public void testLargeDataInnerJoin() throws Exception {
+        final int NUM_KEYS = 2000;
+        String t1 = "join_mn_large_t1";
+        String t2 = "join_mn_large_t2";
+        createParquetIndex(t1, NUM_SHARDS, "v");
+        createParquetIndex(t2, NUM_SHARDS, "w");
+        bulkIndexUnique(t1, "v", 1, NUM_KEYS, k -> k * 11);
+        bulkIndexUnique(t2, "w", 1, NUM_KEYS, k -> k * 113);
+
+        PPLResponse response = executePPL("source=" + t1 + " | join on " + t1 + ".k = " + t2 + ".k " + t2);
+        assertColumns(response, "k", "v", "w");
+        assertEquals("symmetric large join: every key matches once", NUM_KEYS, response.getRows().size());
+        int kIdx = response.getColumns().indexOf("k");
+        Set<Integer> seenKeys = new HashSet<>();
+        for (Object[] row : response.getRows()) {
+            seenKeys.add(((Number) row[kIdx]).intValue());
+        }
+        assertEquals("every key appears exactly once", NUM_KEYS, seenKeys.size());
+    }
+
+    // ── Edge case #6: single-shard side ──────────────────────────────────
+
+    /**
+     * One side is single-shard (SINGLETON distribution at the OpenSearchTableScan
+     * level), the other is multi-shard (RANDOM). Catches a bug where the planner
+     * treats the SINGLETON side differently — e.g., skips the
+     * {@code OpenSearchExchangeReducer} insertion that the DAG builder relies on
+     * to cut the child stage.
+     */
+    public void testSingleShardOneSide() throws Exception {
+        String t1 = "join_mn_1shard_t1";
+        String t2 = "join_mn_1shard_t2";
+        createParquetIndex(t1, 1, "v");                 // 1 shard
+        createParquetIndex(t2, NUM_SHARDS, "w");        // 5 shards
+        indexUnique(t1, "v", 1, 30, k -> k * 11);
+        indexUnique(t2, "w", 1, 30, k -> k * 113);
+
+        PPLResponse response = executePPL("source=" + t1 + " | join on " + t1 + ".k = " + t2 + ".k " + t2);
+        assertColumns(response, "k", "v", "w");
+        assertEquals("1×5-shard symmetric join: every key matches", 30, response.getRows().size());
+    }
+
+    // ── Edge case #8: concurrent queries ─────────────────────────────────
+
+    /**
+     * Fires N joins simultaneously against the same indices. Each query must
+     * get its own {@link DatafusionLocalSession} and {@link DatafusionReduceSink};
+     * cross-query state leaks would manifest as wrong row counts or mixed
+     * columns across responses.
+     */
+    public void testConcurrentJoinsAreIsolated() throws Exception {
+        final int NUM_KEYS = 30;
+        final int N_QUERIES = 4;
+        String t1 = "join_mn_conc_t1";
+        String t2 = "join_mn_conc_t2";
+        createParquetIndex(t1, NUM_SHARDS, "v");
+        createParquetIndex(t2, NUM_SHARDS, "w");
+        indexUnique(t1, "v", 1, NUM_KEYS, k -> k * 11);
+        indexUnique(t2, "w", 1, NUM_KEYS, k -> k * 113);
+
+        ExecutorService pool = Executors.newFixedThreadPool(N_QUERIES);
+        try {
+            @SuppressWarnings("unchecked")
+            CompletableFuture<PPLResponse>[] futures = new CompletableFuture[N_QUERIES];
+            for (int i = 0; i < N_QUERIES; i++) {
+                futures[i] = CompletableFuture.supplyAsync(
+                    () -> executePPL("source=" + t1 + " | join on " + t1 + ".k = " + t2 + ".k " + t2),
+                    pool
+                );
+            }
+            for (int i = 0; i < N_QUERIES; i++) {
+                PPLResponse response;
+                try {
+                    response = futures[i].get(60, TimeUnit.SECONDS);
+                } catch (ExecutionException e) {
+                    throw new AssertionError("query " + i + " threw", e.getCause());
+                }
+                assertColumns(response, "k", "v", "w");
+                assertEquals("query " + i + " row count", NUM_KEYS, response.getRows().size());
+            }
+        } finally {
+            pool.shutdown();
+            assertTrue("executor must terminate", pool.awaitTermination(10, TimeUnit.SECONDS));
+        }
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────
+
+    private void createParquetIndex(String indexName, int numShards, String payloadField) {
+        Settings indexSettings = Settings.builder()
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, numShards)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, NUM_REPLICAS)
+            .put("index.pluggable.dataformat.enabled", true)
+            .put("index.pluggable.dataformat", "composite")
+            .put("index.composite.primary_data_format", "parquet")
+            .putList("index.composite.secondary_data_formats")
+            .build();
+        CreateIndexResponse response = client().admin()
+            .indices()
+            .prepareCreate(indexName)
+            .setSettings(indexSettings)
+            .setMapping("k", "type=integer", payloadField, "type=integer")
+            .get();
+        assertTrue("index creation must be acknowledged for " + indexName, response.isAcknowledged());
+        ensureGreen(TimeValue.timeValueSeconds(60), indexName);
+    }
+
+    /** One document per key in {@code [keyLo, keyHi]}. Sequential — fine for small N. */
+    private void indexUnique(String indexName, String payloadField, int keyLo, int keyHi, IntUnaryOperator keyToPayload) {
+        for (int key = keyLo; key <= keyHi; key++) {
+            client().prepareIndex(indexName)
+                .setId(indexName + "_" + key)
+                .setSource("k", key, payloadField, keyToPayload.applyAsInt(key))
+                .get();
+        }
+        client().admin().indices().prepareRefresh(indexName).get();
+        client().admin().indices().prepareFlush(indexName).get();
+    }
+
+    /** Bulk-indexed equivalent of {@link #indexUnique} for large datasets. */
+    private void bulkIndexUnique(String indexName, String payloadField, int keyLo, int keyHi, IntUnaryOperator keyToPayload) {
+        final int batchSize = 500;
+        for (int batchStart = keyLo; batchStart <= keyHi; batchStart += batchSize) {
+            int batchEnd = Math.min(batchStart + batchSize - 1, keyHi);
+            org.opensearch.action.bulk.BulkRequestBuilder bulk = client().prepareBulk();
+            for (int key = batchStart; key <= batchEnd; key++) {
+                bulk.add(
+                    client().prepareIndex(indexName)
+                        .setId(indexName + "_" + key)
+                        .setSource("k", key, payloadField, keyToPayload.applyAsInt(key))
+                );
+            }
+            org.opensearch.action.bulk.BulkResponse response = bulk.get();
+            assertFalse(
+                "bulk index batch [" + batchStart + ", " + batchEnd + "] had failures: " + response.buildFailureMessage(),
+                response.hasFailures()
+            );
+        }
+        client().admin().indices().prepareRefresh(indexName).get();
+        client().admin().indices().prepareFlush(indexName).get();
+    }
+
+    /** {@code dupes} documents per key in {@code [keyLo, keyHi]}, distinct payloads. */
+    private void indexWithDuplicates(String indexName, String payloadField, int keyLo, int keyHi, int dupes) {
+        for (int key = keyLo; key <= keyHi; key++) {
+            for (int d = 0; d < dupes; d++) {
+                int payload = key * 1000 + d;
+                client().prepareIndex(indexName).setId(indexName + "_" + key + "_" + d).setSource("k", key, payloadField, payload).get();
+            }
+        }
+        client().admin().indices().prepareRefresh(indexName).get();
+        client().admin().indices().prepareFlush(indexName).get();
+    }
+
+    private static void assertColumns(PPLResponse response, String... expected) {
+        assertNotNull("PPLResponse must not be null", response);
+        for (String column : expected) {
+            assertTrue(
+                "response columns must include '" + column + "', got " + response.getColumns(),
+                response.getColumns().contains(column)
+            );
+        }
+    }
+
+    private PPLResponse executePPL(String ppl) {
+        return client().execute(UnifiedPPLExecuteAction.INSTANCE, new PPLRequest(ppl)).actionGet();
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionAnalyticsBackendPlugin.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionAnalyticsBackendPlugin.java
@@ -43,7 +43,7 @@ import java.util.Set;
  */
 public class DataFusionAnalyticsBackendPlugin implements AnalyticsSearchBackendPlugin {
 
-    private static final Set<EngineCapability> ENGINE_CAPS = Set.of(EngineCapability.SORT, EngineCapability.UNION);
+    private static final Set<EngineCapability> ENGINE_CAPS = Set.of(EngineCapability.SORT, EngineCapability.UNION, EngineCapability.JOIN);
 
     private static final Set<FieldType> SUPPORTED_FIELD_TYPES = new HashSet<>();
     static {
@@ -166,6 +166,8 @@ public class DataFusionAnalyticsBackendPlugin implements AnalyticsSearchBackendP
                 Set<String> formats = Set.copyOf(plugin.getSupportedFormats());
                 Set<ProjectCapability> caps = new HashSet<>();
                 for (ScalarFunction op : STANDARD_PROJECT_OPS) {
+                    // supportsLiteralEvaluation=true lets literal-only CAST expressions (rare in
+                    // practice) resolve as well as field-ref ones — DataFusion handles both.
                     caps.add(new ProjectCapability.Scalar(op, Set.copyOf(SUPPORTED_FIELD_TYPES), formats, true));
                 }
                 return Set.copyOf(caps);

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionFragmentConvertor.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionFragmentConvertor.java
@@ -69,7 +69,7 @@ import io.substrait.relation.Sort;
  *   <li>{@link #attachPartialAggOnTop(RelNode, byte[])} and
  *       {@link #attachFragmentOnTop(RelNode, byte[])} — convert the wrapping
  *       operator standalone, then rewire its input to the decoded inner plan's
- *       root via {@link #rewire(Plan, Rel)}.</li>
+ *       root via {@link #rewire(Plan, Rel, List)}.</li>
  * </ul>
  *
  * @opensearch.internal
@@ -113,7 +113,8 @@ public class DataFusionFragmentConvertor implements FragmentConvertor {
         LOGGER.debug("Attaching partial aggregate on top of {} inner bytes", innerBytes.length);
         Plan inner = decodePlan(innerBytes);
         Rel wrapper = convertStandalone(partialAggFragment);
-        Plan rewired = rewire(inner, withAggregationPhase(wrapper, Expression.AggregationPhase.INITIAL_TO_INTERMEDIATE));
+        List<String> wrapperNames = rowTypeFieldNames(partialAggFragment);
+        Plan rewired = rewire(inner, withAggregationPhase(wrapper, Expression.AggregationPhase.INITIAL_TO_INTERMEDIATE), wrapperNames);
         return serializePlan(rewired);
     }
 
@@ -137,7 +138,8 @@ public class DataFusionFragmentConvertor implements FragmentConvertor {
         // the visitor still walks them top-down to build the wrapper rel.
         RelNode rewritten = rewriteStageInputScans(fragment);
         Rel wrapper = convertStandalone(rewritten);
-        return serializePlan(rewire(inner, wrapper));
+        List<String> wrapperNames = rowTypeFieldNames(fragment);
+        return serializePlan(rewire(inner, wrapper, wrapperNames));
     }
 
     // ── Core conversion helpers ─────────────────────────────────────────────────
@@ -165,7 +167,7 @@ public class DataFusionFragmentConvertor implements FragmentConvertor {
      * children (e.g. the {@code attachPartialAggOnTop} caller passes a
      * {@code LogicalAggregate} whose input is the already-stripped inner tree); we
      * deliberately discard those children by taking only the outermost rel of the
-     * conversion and rewiring its input during {@link #rewire(Plan, Rel)}.
+     * conversion and rewiring its input during {@link #rewire(Plan, Rel, List)}.
      */
     private Rel convertStandalone(RelNode operator) {
         SubstraitRelVisitor visitor = createVisitor(operator);
@@ -175,18 +177,30 @@ public class DataFusionFragmentConvertor implements FragmentConvertor {
     /**
      * Rewires the Substrait {@code wrapper} rel to sit above the root relation of
      * {@code inner}. Returns a new {@link Plan} whose single root is
-     * {@code wrapper(inner.root)}. Supports the known single-input wrappers emitted
-     * by our four SPI methods ({@link Aggregate}, {@link Sort}, {@link Filter},
-     * {@link Project}).
+     * {@code wrapper(inner.root)} with {@code wrapperNames} attached as the root's
+     * names list. Supports the known single-input wrappers emitted by our four SPI
+     * methods ({@link Aggregate}, {@link Sort}, {@link Filter}, {@link Project}).
+     *
+     * <p>The names list must describe the flattened leaf schema of the final plan —
+     * one entry per leaf field in the wrapper's output row type. DataFusion's
+     * Substrait consumer walks the top plan's output schema once per leaf and
+     * fails with "Names list must match exactly to nested schema" if the two
+     * disagree (e.g. reusing the inner's pre-wrap names when the wrapper shrinks
+     * or widens the schema, as an Aggregate-over-Join does).
      */
-    static Plan rewire(Plan inner, Rel wrapper) {
+    static Plan rewire(Plan inner, Rel wrapper, List<String> wrapperNames) {
         if (inner.getRoots().isEmpty()) {
             throw new IllegalArgumentException("Inner Substrait plan has no root relation to rewire under wrapper");
         }
         Plan.Root innerRoot = inner.getRoots().get(0);
         Rel innerRel = innerRoot.getInput();
         Rel rewired = replaceInput(wrapper, innerRel);
-        return Plan.builder().addRoots(Plan.Root.builder().input(rewired).names(innerRoot.getNames()).build()).build();
+        return Plan.builder().addRoots(Plan.Root.builder().input(rewired).names(wrapperNames).build()).build();
+    }
+
+    /** Top-level output column names of a Calcite RelNode — one entry per leaf field in the row type. */
+    private static List<String> rowTypeFieldNames(RelNode node) {
+        return node.getRowType().getFieldList().stream().map(f -> f.getName()).toList();
     }
 
     private static Rel replaceInput(Rel wrapper, Rel newInput) {

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionReaderManager.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionReaderManager.java
@@ -86,7 +86,10 @@ public class DatafusionReaderManager implements EngineReaderManager<DatafusionRe
 
     @Override
     public void afterRefresh(boolean didRefresh, CatalogSnapshot catalogSnapshot) throws IOException {
-        if (didRefresh == false) return;
+        // Register a reader even when no files were flushed (empty-shard case). Without
+        // this, queries against an empty shard throw "No DataFusion reader available"
+        // because refresh listeners are only invoked when didRefresh==true, but getReader
+        // is called on every query regardless of whether any docs were ever indexed.
         if (readers.containsKey(catalogSnapshot)) return;
         DatafusionReader reader = new DatafusionReader(directoryPath, catalogSnapshot.getSearchableFiles(dataFormat.name()));
         readers.put(catalogSnapshot, reader);

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionFragmentConvertorTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionFragmentConvertorTests.java
@@ -15,8 +15,10 @@ import org.apache.calcite.plan.hep.HepProgramBuilder;
 import org.apache.calcite.rel.RelCollations;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.AggregateCall;
+import org.apache.calcite.rel.core.JoinRelType;
 import org.apache.calcite.rel.logical.LogicalAggregate;
 import org.apache.calcite.rel.logical.LogicalFilter;
+import org.apache.calcite.rel.logical.LogicalJoin;
 import org.apache.calcite.rel.logical.LogicalSort;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
@@ -38,10 +40,12 @@ import io.substrait.proto.AggregateRel;
 import io.substrait.proto.AggregationPhase;
 import io.substrait.proto.Expression;
 import io.substrait.proto.FilterRel;
+import io.substrait.proto.JoinRel;
 import io.substrait.proto.Plan;
 import io.substrait.proto.PlanRel;
 import io.substrait.proto.ReadRel;
 import io.substrait.proto.Rel;
+import io.substrait.proto.RelRoot;
 import io.substrait.proto.SortRel;
 
 /**
@@ -322,6 +326,71 @@ public class DataFusionFragmentConvertorTests extends OpenSearchTestCase {
         Expression delegatedArg = andFunc.getArguments(1).getValue();
         assertTrue("second AND arg must be a scalar function", delegatedArg.hasScalarFunction());
         assertEquals(7, delegatedArg.getScalarFunction().getArguments(0).getValue().getLiteral().getI32());
+    }
+
+    /**
+     * A {@code LogicalJoin} fragment converts to {@code JoinRel} whose plan root
+     * carries a {@code names} list that matches the concatenated left + right schemas —
+     * DataFusion's Substrait consumer walks the output schema once per leaf field and
+     * fails with "Names list must match exactly to nested schema" if the two disagree.
+     */
+    public void testConvertFinalAggFragment_JoinPreservesFlatNamesList() throws Exception {
+        RelNode leftScan = buildTableScan("left_input", "lk", "lv");
+        RelNode rightScan = buildTableScan("right_input", "rk", "rv");
+        // Equi condition: left.lk = right.rk (left has 2 fields, so right.rk is index 2).
+        RexNode condition = rexBuilder.makeCall(
+            SqlStdOperatorTable.EQUALS,
+            rexBuilder.makeInputRef(leftScan, 0),
+            rexBuilder.makeInputRef(typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.INTEGER), true), 2)
+        );
+        LogicalJoin join = LogicalJoin.create(leftScan, rightScan, List.of(), condition, java.util.Set.of(), JoinRelType.INNER);
+
+        byte[] bytes = newConvertor().convertFinalAggFragment(join);
+
+        Plan plan = decodeSubstrait(bytes);
+        RelRoot root = plan.getRelations(0).getRoot();
+        assertTrue("root input must be a JoinRel", root.getInput().hasJoin());
+        JoinRel joinRel = root.getInput().getJoin();
+        assertTrue("JoinRel must carry a left input", joinRel.hasLeft());
+        assertTrue("JoinRel must carry a right input", joinRel.hasRight());
+        // Names list must match the flat concat of left + right schemas — Substrait consumer
+        // walks N leaf fields and expects N names. Any mismatch surfaces as the "Names list
+        // must match exactly to nested schema" error at plan decode time.
+        assertEquals("names list must match join's flat output schema", List.of("lk", "lv", "rk", "rv"), root.getNamesList());
+    }
+
+    /**
+     * Attaching an Aggregate fragment on top of a Join-derived inner plan must override
+     * the names list to the Aggregate's single output column — not the Join's 4-column
+     * names list. DataFusion's consumer walks the final plan's output schema; if we reuse
+     * the inner's names, it reports "Names list must match exactly to nested schema, but
+     * found N uses for M names" where N is the Aggregate's output column count and M is
+     * the Join's.
+     */
+    public void testAttachFragmentOnTop_AggregateOverJoinShrinksNamesList() throws Exception {
+        DataFusionFragmentConvertor convertor = newConvertor();
+
+        // Inner: Join with 4-column output.
+        RelNode leftScan = buildTableScan("left_input", "lk", "lv");
+        RelNode rightScan = buildTableScan("right_input", "rk", "rv");
+        RexNode condition = rexBuilder.makeCall(
+            SqlStdOperatorTable.EQUALS,
+            rexBuilder.makeInputRef(leftScan, 0),
+            rexBuilder.makeInputRef(typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.INTEGER), true), 2)
+        );
+        LogicalJoin join = LogicalJoin.create(leftScan, rightScan, List.of(), condition, java.util.Set.of(), JoinRelType.INNER);
+        byte[] innerBytes = convertor.convertFinalAggFragment(join);
+
+        // Outer: Aggregate producing a single count column.
+        LogicalAggregate aggregate = buildSumAggregate(join, 0);
+        byte[] combined = convertor.attachFragmentOnTop(aggregate, innerBytes);
+
+        Plan plan = decodeSubstrait(combined);
+        RelRoot root = plan.getRelations(0).getRoot();
+        assertTrue("root input must be an AggregateRel after rewire", root.getInput().hasAggregate());
+        // Aggregate's output row type has 1 column (`sum_col`), so names must be a single
+        // element — if we'd reused inner's 4-name list, this assertion would fail with 4.
+        assertEquals("names list must match aggregate's 1-column output schema", List.of("sum_col"), root.getNamesList());
     }
 
     /**

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/PlanWalker.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/PlanWalker.java
@@ -211,6 +211,12 @@ public class PlanWalker {
             switch (to) {
                 case SUCCEEDED -> fireTerminal(() -> completionListener.onResponse(producer.outputSource().readResult()));
                 case FAILED, CANCELLED -> {
+                    // Release any batches the root sink buffered before the failure fired — the
+                    // consumer's happy-path drain (which closes each batch) never runs on this
+                    // branch, so the query allocator's close() would otherwise report a leak.
+                    if (producer.outputSource() instanceof RowProducingSink rps) {
+                        rps.releaseUnread();
+                    }
                     Exception failure = rootExec.getFailure();
                     if (config.parentTask() instanceof CancellableTask ct && ct.isCancelled()) {
                         fireTerminal(() -> completionListener.onFailure(new TaskCancelledException("query cancelled")));

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/RowProducingSink.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/RowProducingSink.java
@@ -87,8 +87,29 @@ public class RowProducingSink implements ExchangeSink, ExchangeSource {
         batches.add(batch);
     }
 
+    /**
+     * Signals end-of-feed. This sink is the terminal buffer feeding the external query
+     * API — the consumer (e.g. {@code DefaultPlanExecutor#batchesToRows}) drains batches
+     * via {@link #readResult} and closes each one as it is materialized. close() is a
+     * no-op here so that buffered batches survive until the consumer has read them;
+     * producers (e.g. {@code ShardFragmentStageExecution#onShardTerminated}) call close()
+     * BEFORE the root stage transitions to SUCCEEDED, and the consumer runs inside that
+     * transition. Eager release would make readResult return an empty list.
+     *
+     * <p>Error-path cleanup lives with {@link #releaseUnread}, invoked by the query
+     * context when a query fails before the consumer runs.
+     */
     @Override
     public synchronized void close() {
+        // no-op — see javadoc
+    }
+
+    /**
+     * Release any buffered batches that were never drained by the consumer. Intended for
+     * the error path only — on the happy path the consumer closes each batch itself.
+     * Idempotent.
+     */
+    public synchronized void releaseUnread() {
         for (VectorSchemaRoot batch : batches) {
             batch.close();
         }

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stage/ShardFragmentStageExecution.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stage/ShardFragmentStageExecution.java
@@ -122,13 +122,23 @@ final class ShardFragmentStageExecution extends AbstractStageExecution implement
                         return;
                     }
 
-                    VectorSchemaRoot vsr = toVsr.apply(response);
-                    outputSink.feed(vsr);
-                    metrics.addRowsProcessed(vsr.getRowCount());
+                    try {
+                        VectorSchemaRoot vsr = toVsr.apply(response);
+                        outputSink.feed(vsr);
+                        metrics.addRowsProcessed(vsr.getRowCount());
 
-                    if (isLast) {
-                        metrics.incrementTasksCompleted();
-                        onShardTerminated();
+                        if (isLast) {
+                            metrics.incrementTasksCompleted();
+                            onShardTerminated();
+                        }
+                    } catch (IllegalStateException closed) {
+                        // QueryContext closed while this response was in flight — another
+                        // shard failed and tore down teardown. Silently drop; onShardTerminated
+                        // still needs to run so inFlight drains and the stage's terminal
+                        // transition isn't wedged.
+                        if (isLast) {
+                            onShardTerminated();
+                        }
                     }
                 });
             }
@@ -151,6 +161,14 @@ final class ShardFragmentStageExecution extends AbstractStageExecution implement
     private void onShardTerminated() {
         if (inFlight.decrementAndGet() == 0) {
             Exception captured = getFailure();
+            try {
+                outputSink.close();
+            } catch (Exception closeError) {
+                if (captured == null) {
+                    captureFailure(closeError);
+                    captured = closeError;
+                }
+            }
             transitionTo(captured != null ? StageExecution.State.FAILED : StageExecution.State.SUCCEEDED);
         }
     }

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/PlannerImpl.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/PlannerImpl.java
@@ -30,6 +30,7 @@ import org.opensearch.analytics.planner.rel.OpenSearchDistributionTraitDef;
 import org.opensearch.analytics.planner.rules.OpenSearchAggregateRule;
 import org.opensearch.analytics.planner.rules.OpenSearchAggregateSplitRule;
 import org.opensearch.analytics.planner.rules.OpenSearchFilterRule;
+import org.opensearch.analytics.planner.rules.OpenSearchJoinRule;
 import org.opensearch.analytics.planner.rules.OpenSearchProjectRule;
 import org.opensearch.analytics.planner.rules.OpenSearchSortRule;
 import org.opensearch.analytics.planner.rules.OpenSearchTableScanRule;
@@ -101,6 +102,7 @@ public class PlannerImpl {
                 new OpenSearchFilterRule(context),
                 new OpenSearchProjectRule(context),
                 new OpenSearchAggregateRule(context),
+                new OpenSearchJoinRule(context),
                 new OpenSearchSortRule(context),
                 new OpenSearchUnionRule(context)
             )

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/RelNodeUtils.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/RelNodeUtils.java
@@ -18,6 +18,7 @@ import org.opensearch.analytics.planner.rel.OpenSearchDistribution;
 import org.opensearch.analytics.planner.rel.OpenSearchDistributionTraitDef;
 import org.opensearch.analytics.planner.rel.OpenSearchExchangeReducer;
 import org.opensearch.analytics.planner.rel.OpenSearchFilter;
+import org.opensearch.analytics.planner.rel.OpenSearchJoin;
 import org.opensearch.analytics.planner.rel.OpenSearchProject;
 import org.opensearch.analytics.planner.rel.OpenSearchSort;
 import org.opensearch.analytics.planner.rel.OpenSearchTableScan;
@@ -88,10 +89,20 @@ public class RelNodeUtils {
                 project.getRowType(),
                 project.getViableBackends()
             );
+        } else if (node instanceof OpenSearchJoin join) {
+            return new OpenSearchJoin(
+                newCluster,
+                newTraits,
+                newInputs.get(0),
+                newInputs.get(1),
+                join.getCondition(),
+                join.getJoinType(),
+                join.getViableBackends()
+            );
         } else if (node instanceof OpenSearchUnion union) {
             return new OpenSearchUnion(newCluster, newTraits, newInputs, union.all, union.getViableBackends());
-        } else if (node instanceof OpenSearchExchangeReducer exchange) {
-            return new OpenSearchExchangeReducer(newCluster, newTraits, newInputs.getFirst(), exchange.getViableBackends());
+        } else if (node instanceof OpenSearchExchangeReducer reducer) {
+            return new OpenSearchExchangeReducer(newCluster, newTraits, newInputs.getFirst(), reducer.getViableBackends());
         }
 
         throw new UnsupportedOperationException("Cannot copy node type: " + node.getClass().getSimpleName());

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/dag/DAGBuilder.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/dag/DAGBuilder.java
@@ -52,7 +52,7 @@ public class DAGBuilder {
             // Root IS an ExchangeReducer — pure gather (no compute above the exchange).
             // Cut directly: child stage is the subtree below, root fragment is
             // ExchangeReducer → StageInputScan.
-            rootFragment = cutSingleton(reducer, counter, childStages, clusterService);
+            rootFragment = cutSingleton(reducer, counter, childStages, registry, clusterService);
         } else {
             rootFragment = sever(cboOutput, counter, childStages, registry, clusterService);
         }
@@ -82,7 +82,7 @@ public class DAGBuilder {
         List<RelNode> newInputs = new ArrayList<>();
         for (RelNode input : node.getInputs()) {
             if (input instanceof OpenSearchExchangeReducer reducer) {
-                newInputs.add(cutSingleton(reducer, counter, childStages, clusterService));
+                newInputs.add(cutSingleton(reducer, counter, childStages, registry, clusterService));
             } else {
                 newInputs.add(sever(input, counter, childStages, registry, clusterService));
             }
@@ -102,27 +102,27 @@ public class DAGBuilder {
         OpenSearchExchangeReducer reducer,
         int[] counter,
         List<Stage> parentChildStages,
+        CapabilityRegistry registry,
         ClusterService clusterService
     ) {
-        // Recurse into child fragment to handle nested exchanges.
-        // TODO: recurse with full sever() (passing registry) when shuffle/broadcast
-        // exchanges are added — not needed for PR2 (pure DF, max 2 stages).
-        // TODO: for joins, each side has its own ExchangeReducer cut producing a
-        // StageInputScan per join input. cutSingleton handles one side; sever() handles
-        // both sides via its input iteration loop.
+        // Recurse into the child fragment with full sever() so any nested ExchangeReducers
+        // (e.g. a Join below a top-level gather Reducer) are also cut into their own child
+        // stages rather than being left intact inside the shard-local fragment.
         List<Stage> grandchildren = new ArrayList<>();
-        RelNode childFragment = reducer.getInput();
+        RelNode childFragment = sever(reducer.getInput(), counter, grandchildren, registry, clusterService);
 
         int childStageId = counter[0]++;
+        // A leaf stage (no grandchildren) runs on shards and needs a ShardTargetResolver.
+        // An intermediate stage (some grandchildren were cut out below) runs at the
+        // coordinator and consumes its grandchildren's outputs via an ExchangeSinkProvider.
+        TargetResolver targetResolver = grandchildren.isEmpty() ? new ShardTargetResolver(childFragment, clusterService) : null;
+        ExchangeSinkProvider childSinkProvider = null;
+        if (!grandchildren.isEmpty()) {
+            List<String> reduceViable = CapabilityResolutionUtils.filterByReduceCapability(registry, reducer.getViableBackends());
+            childSinkProvider = registry.getBackend(reduceViable.getFirst()).getExchangeSinkProvider();
+        }
         parentChildStages.add(
-            new Stage(
-                childStageId,
-                childFragment,
-                grandchildren,
-                ExchangeInfo.singleton(),
-                null,
-                new ShardTargetResolver(childFragment, clusterService)
-            )
+            new Stage(childStageId, childFragment, grandchildren, ExchangeInfo.singleton(), childSinkProvider, targetResolver)
         );
 
         // Replace the reducer's input with a StageInputScan placeholder.

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/dag/FragmentConversionDriver.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/dag/FragmentConversionDriver.java
@@ -266,8 +266,9 @@ public class FragmentConversionDriver {
         IntraOperatorDelegationBytes delegationBytes
     ) {
         if (node instanceof OpenSearchExchangeReducer) {
-            // Strip ExchangeReducer — StageInputScan below it is the schema source
-            // This should never be reached directly; handled by the parent (final agg)
+            // Root ExchangeReducer — the coordinator fragment is just the reducer over
+            // the data-node child stage's output. Convert the inner subtree (with
+            // StageInputScan as the schema-carrying leaf) as the final-agg fragment.
             return convertor.convertFinalAggFragment(strip(node.getInputs().getFirst(), delegationBytes));
         }
         if (node instanceof OpenSearchRelNode openSearchNode) {
@@ -275,25 +276,18 @@ public class FragmentConversionDriver {
             Function<OperatorAnnotation, RexNode> resolver = delegationBytes.resolverFor(openSearchNode, node.getCluster().getRexBuilder());
             RelNode strippedNode = openSearchNode.stripAnnotations(strippedInputs, resolver);
 
-            if (!finalAggConverted) {
-                // First OpenSearchRelNode whose ALL inputs are ExchangeReducers is treated as the
-                // boundary between the coordinator-side fragment and the data-node child stages.
-                // For single-input shapes (Sort/Project/Aggregate over a partial agg) this is the
-                // final-aggregate operator; for multi-input shapes (Union) every branch is itself
-                // an ER → StageInputScan, and the entire Union+ER subtree is converted as one
-                // fragment so all branches end up in the same Substrait plan reading from their
-                // respective input partitions.
-                boolean allChildrenAreExchangeReducer = !node.getInputs().isEmpty()
-                    && node.getInputs().stream().allMatch(input -> input instanceof OpenSearchExchangeReducer);
-                if (allChildrenAreExchangeReducer) {
-                    List<RelNode> finalAggInputs = new ArrayList<>(node.getInputs().size());
-                    for (RelNode input : node.getInputs()) {
-                        // Skip the ER, keep StageInputScan below it as the leaf for schema inference.
-                        finalAggInputs.add(strip(input.getInputs().getFirst(), delegationBytes));
-                    }
-                    RelNode finalAggFragment = openSearchNode.stripAnnotations(finalAggInputs, resolver);
-                    return convertor.convertFinalAggFragment(finalAggFragment);
-                }
+            if (!finalAggConverted && isFinalAggBoundary(node)) {
+                // Boundary between coordinator-side fragment and data-node child stages. For
+                // single-input shapes (Sort/Project/Aggregate over a partial agg) this is the
+                // final-aggregate operator; for multi-input shapes (Union, coord-side Join,
+                // future set-ops) every branch is an ER → StageInputScan and the entire
+                // operator+branches subtree converts as one fragment so all branches end up in
+                // the same Substrait plan reading from their respective input partitions.
+                //
+                // strippedInputs already resolves each ER to the StageInputScan below it via
+                // the strip() helper, so strippedNode is the final-agg fragment ready for
+                // conversion — no further per-branch rewrite is needed.
+                return convertor.convertFinalAggFragment(strippedNode);
             }
 
             // Operator above the final-fragment boundary — convert child first, then attach.
@@ -301,6 +295,19 @@ public class FragmentConversionDriver {
             return convertor.attachFragmentOnTop(strippedNode, innerBytes);
         }
         throw new IllegalStateException("Unexpected reduce stage node: " + node.getClass().getSimpleName());
+    }
+
+    /**
+     * True when {@code node} sits on the boundary between the coordinator-side fragment and
+     * the data-node child stages — either a multi-input shape with every branch in its own
+     * ExchangeReducer (Union, coord-side Join) or a single-input operator directly above
+     * one ExchangeReducer (final agg over a partial-agg child stage).
+     */
+    private static boolean isFinalAggBoundary(RelNode node) {
+        if (MultiInputShape.detect(node).isPresent()) {
+            return true;
+        }
+        return node.getInputs().size() == 1 && node.getInputs().getFirst() instanceof OpenSearchExchangeReducer;
     }
 
     /** Recursively strips annotations bottom-up. Keeps OpenSearchStageInputScan as-is. */

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/dag/MultiInputShape.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/dag/MultiInputShape.java
@@ -1,0 +1,73 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.planner.dag;
+
+import org.apache.calcite.rel.RelNode;
+import org.opensearch.analytics.planner.rel.OpenSearchExchangeReducer;
+import org.opensearch.analytics.planner.rel.OpenSearchStageInputScan;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Detects the N-input coordinator-fragment shape where every child of an N-input
+ * operator is an {@link OpenSearchExchangeReducer} wrapping an
+ * {@link OpenSearchStageInputScan}. This is the shape produced when a rule wraps
+ * each branch of a multi-input operator (Union, coord-side Join, future set-ops)
+ * in an ExchangeReducer so {@code DAGBuilder} cuts a separate child stage per branch.
+ *
+ * <p>Used by {@link FragmentConversionDriver} to distinguish a multi-input
+ * coordinator fragment (Union / Join above per-branch child stages) from a
+ * single-input fragment (final aggregate / sort above a partial-agg child stage).
+ *
+ * @opensearch.internal
+ */
+public final class MultiInputShape {
+
+    private final List<OpenSearchStageInputScan> branchScans;
+
+    private MultiInputShape(List<OpenSearchStageInputScan> branchScans) {
+        this.branchScans = branchScans;
+    }
+
+    /**
+     * Returns {@code Optional.of(shape)} if {@code node} has at least two inputs and
+     * every input is an {@link OpenSearchExchangeReducer} whose own input is an
+     * {@link OpenSearchStageInputScan}. Returns {@code Optional.empty()} otherwise.
+     *
+     * <p>The branch {@link OpenSearchStageInputScan}s are returned in the same order
+     * as the parent's inputs — callers that care about column ordering (Union, Join)
+     * can rely on positional correspondence with the parent operator's input list.
+     */
+    public static Optional<MultiInputShape> detect(RelNode node) {
+        List<RelNode> inputs = node.getInputs();
+        if (inputs.size() < 2) {
+            return Optional.empty();
+        }
+        List<OpenSearchStageInputScan> scans = new ArrayList<>(inputs.size());
+        for (RelNode input : inputs) {
+            if (!(input instanceof OpenSearchExchangeReducer reducer)) {
+                return Optional.empty();
+            }
+            if (!(reducer.getInput() instanceof OpenSearchStageInputScan scan)) {
+                return Optional.empty();
+            }
+            scans.add(scan);
+        }
+        return Optional.of(new MultiInputShape(scans));
+    }
+
+    /**
+     * The {@link OpenSearchStageInputScan} under each branch's ExchangeReducer, in input order.
+     */
+    public List<OpenSearchStageInputScan> getBranchScans() {
+        return branchScans;
+    }
+}

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/dag/PlanForker.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/dag/PlanForker.java
@@ -73,39 +73,56 @@ public class PlanForker {
             return results;
         }
 
-        // Multi-input: take the first alternative from each child. With a single backend
-        // (pure DataFusion), each child has exactly one alternative anyway. For correctness
-        // we require all children to agree on the chosen backend — a multi-input operator
-        // cannot straddle backends within a single stage.
-        // TODO: when multi-backend pipelines are added, fan out the Cartesian product of
-        // child alternatives and prune by backend agreement.
-        List<RelNode> resolvedChildren = new ArrayList<>(childAlternativeSets.size());
-        String agreedBackend = null;
+        // Multi-input operator (Union, coord-side Join, future set-ops). Enumerate the
+        // cartesian product of child plan alternatives, keeping only combinations where
+        // every child agrees on a single backend — a multi-input operator cannot straddle
+        // backends within a single stage. With a single backend (pure DataFusion today)
+        // every alternative shares the same backend and the product collapses to one combo;
+        // with N backends viable at every branch, the product produces at most N combos
+        // per operator (one per backend tuple that survives the agreement filter).
+        List<Resolved> results = new ArrayList<>();
         for (List<Resolved> childAlts : childAlternativeSets) {
             if (childAlts.isEmpty()) {
                 throw new IllegalStateException(
                     "Multi-input child of [" + node.getClass().getSimpleName() + "] produced no plan alternatives"
                 );
             }
-            Resolved childAlt = childAlts.getFirst();
-            resolvedChildren.add(childAlt.node);
-            if (agreedBackend == null) {
-                agreedBackend = childAlt.chosenBackend;
-            } else if (childAlt.chosenBackend != null
-                && !childAlt.chosenBackend.isEmpty()
-                && !childAlt.chosenBackend.equals(agreedBackend)) {
-                    throw new IllegalStateException(
-                        "Multi-input operator ["
-                            + node.getClass().getSimpleName()
-                            + "] requires all children to share a backend; got ["
-                            + agreedBackend
-                            + "] vs ["
-                            + childAlt.chosenBackend
-                            + "]"
-                    );
-                }
         }
-        return resolveOperator(node, resolvedChildren, agreedBackend);
+        crossProduct(childAlternativeSets, 0, new ArrayList<>(), null, (chosenBackend, combo) -> {
+            results.addAll(resolveOperator(node, combo, chosenBackend));
+        });
+        return results;
+    }
+
+    private interface ComboHandler {
+        void accept(String chosenBackend, List<RelNode> combo);
+    }
+
+    private static void crossProduct(
+        List<List<Resolved>> childAlternativeSets,
+        int depth,
+        List<RelNode> partial,
+        String agreedBackend,
+        ComboHandler handler
+    ) {
+        if (depth == childAlternativeSets.size()) {
+            handler.accept(agreedBackend, List.copyOf(partial));
+            return;
+        }
+        for (Resolved alt : childAlternativeSets.get(depth)) {
+            // All children must converge on the same backend so the parent operator's
+            // backend resolution stays unambiguous. The null / empty chosenBackend case
+            // (non-OpenSearch pass-through nodes, e.g. StageInputScan infrastructure)
+            // does not constrain the agreed backend.
+            boolean childContributesBackend = alt.chosenBackend != null && !alt.chosenBackend.isEmpty();
+            if (agreedBackend != null && childContributesBackend && !agreedBackend.equals(alt.chosenBackend)) {
+                continue;
+            }
+            String next = agreedBackend != null ? agreedBackend : (childContributesBackend ? alt.chosenBackend : null);
+            partial.add(alt.node);
+            crossProduct(childAlternativeSets, depth + 1, partial, next, handler);
+            partial.removeLast();
+        }
     }
 
     private static List<Resolved> resolveOperator(RelNode node, List<RelNode> children, String childBackend) {

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rel/OpenSearchJoin.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rel/OpenSearchJoin.java
@@ -1,0 +1,128 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.planner.rel;
+
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelOptCost;
+import org.apache.calcite.plan.RelOptPlanner;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.RelWriter;
+import org.apache.calcite.rel.core.CorrelationId;
+import org.apache.calcite.rel.core.Join;
+import org.apache.calcite.rel.core.JoinRelType;
+import org.apache.calcite.rel.logical.LogicalJoin;
+import org.apache.calcite.rel.metadata.RelMetadataQuery;
+import org.apache.calcite.rex.RexNode;
+import org.opensearch.analytics.planner.RelNodeUtils;
+import org.opensearch.analytics.spi.FieldStorageInfo;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * OpenSearch custom Join carrying viable backend list.
+ *
+ * <p>This spec only emits a coord-side hash join: both inputs request SINGLETON
+ * distribution so Volcano inserts an {@link OpenSearchExchangeReducer} above each.
+ * The DAG builder cuts each reducer into its own child stage; the coordinator
+ * stage's substrait fragment becomes a {@code JoinRel} with two {@code NamedScan}
+ * inputs ({@code "input-0"}, {@code "input-1"}).
+ *
+ * <p>Build-side contract: {@code right} input is always the build side. Calcite's
+ * {@code LogicalJoin.right} maps to substrait {@code JoinRel.right}; users can
+ * order inputs to control which side gets buffered. Stats-driven swap is a future
+ * spec.
+ *
+ * @opensearch.internal
+ */
+public class OpenSearchJoin extends Join implements OpenSearchRelNode {
+
+    private final List<String> viableBackends;
+
+    public OpenSearchJoin(
+        RelOptCluster cluster,
+        RelTraitSet traitSet,
+        RelNode left,
+        RelNode right,
+        RexNode condition,
+        JoinRelType joinType,
+        List<String> viableBackends
+    ) {
+        super(cluster, traitSet, List.of(), left, right, condition, Set.of(), joinType);
+        this.viableBackends = viableBackends;
+    }
+
+    @Override
+    public List<String> getViableBackends() {
+        return viableBackends;
+    }
+
+    /**
+     * Output field storage is the concatenation of left and right input storage —
+     * matches Calcite's join row type ordering (left fields first, then right).
+     */
+    @Override
+    public List<FieldStorageInfo> getOutputFieldStorage() {
+        List<FieldStorageInfo> result = new ArrayList<>();
+        appendChildStorage(getLeft(), result);
+        appendChildStorage(getRight(), result);
+        return result;
+    }
+
+    private static void appendChildStorage(RelNode child, List<FieldStorageInfo> out) {
+        RelNode unwrapped = RelNodeUtils.unwrapHep(child);
+        if (unwrapped instanceof OpenSearchRelNode os) {
+            out.addAll(os.getOutputFieldStorage());
+        }
+    }
+
+    @Override
+    public Join copy(RelTraitSet traitSet, RexNode conditionExpr, RelNode left, RelNode right, JoinRelType joinType, boolean semiJoinDone) {
+        return new OpenSearchJoin(getCluster(), traitSet, left, right, conditionExpr, joinType, viableBackends);
+    }
+
+    @Override
+    public RelOptCost computeSelfCost(RelOptPlanner planner, RelMetadataQuery mq) {
+        // Constant non-zero cost — enough to keep Volcano from oscillating, not enough
+        // to compete with future broadcast-join rules. Stats-driven costing is a future spec.
+        return planner.getCostFactory().makeCost(100, 100, 0);
+    }
+
+    @Override
+    public RelWriter explainTerms(RelWriter pw) {
+        return super.explainTerms(pw).item("viableBackends", viableBackends);
+    }
+
+    @Override
+    public RelNode copyResolved(String backend, List<RelNode> children, List<OperatorAnnotation> resolvedAnnotations) {
+        return new OpenSearchJoin(
+            getCluster(),
+            getTraitSet(),
+            children.get(0),
+            children.get(1),
+            getCondition(),
+            getJoinType(),
+            List.of(backend)
+        );
+    }
+
+    @Override
+    public RelNode stripAnnotations(List<RelNode> strippedChildren) {
+        return LogicalJoin.create(
+            strippedChildren.get(0),
+            strippedChildren.get(1),
+            List.of(),
+            getCondition(),
+            Set.<CorrelationId>of(),
+            getJoinType()
+        );
+    }
+}

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchFilterRule.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchFilterRule.java
@@ -26,7 +26,6 @@ import org.opensearch.analytics.planner.rel.OpenSearchFilter;
 import org.opensearch.analytics.planner.rel.OpenSearchRelNode;
 import org.opensearch.analytics.spi.DelegationType;
 import org.opensearch.analytics.spi.FieldStorageInfo;
-import org.opensearch.analytics.spi.FieldType;
 import org.opensearch.analytics.spi.ScalarFunction;
 
 import java.util.ArrayList;
@@ -163,26 +162,27 @@ public class OpenSearchFilterRule extends RelOptRule {
 
         for (int fieldIndex : fieldIndices) {
             FieldStorageInfo storageInfo = FieldStorageInfo.resolve(fieldStorageInfos, fieldIndex);
-            FieldType fieldType = storageInfo.getFieldType();
 
-            Set<String> fieldViable;
             if (storageInfo.isDerived()) {
-                // Post-Union / post-Project columns have no physical storage formats — the
-                // column is materialised at the operator that produced it (e.g. Union of two
-                // branches with divergent storage, or a literal/expression projection). The
-                // filter still has to run somewhere; resolve viability against any backend
-                // that supports the function on this field type, ignoring storage formats.
-                // The format-aware Lucene-pushdown path stays as the primary lookup for
-                // non-derived columns above.
-                // TODO: for FULL_TEXT operators, extract required params from RexCall
-                fieldViable = new HashSet<>(registry.filterBackendsAnyFormat(function, fieldType));
-            } else {
-                // Format-aware: backends that can access this field's storage (doc values + index).
-                // A backend is viable only if it has the field in its own storage formats — ensuring
-                // delegation targets are also field-storage-aware (e.g. Lucene is viable for a keyword
-                // field only when the field has indexFormats=[lucene] set in the mapping).
-                fieldViable = new HashSet<>(registry.filterBackendsForField(function, storageInfo));
+                // Derived columns (post-Union, post-Project, HAVING on aggregate outputs) have no
+                // physical storage formats. Picking a backend for the filter therefore requires a
+                // within-stage delegation model (DelegationType split plus a DataTransferCapability
+                // telling the planner which backend can read the producing operator's output).
+                // Until that model exists, refuse to produce a plan rather than silently picking
+                // a backend that might not be able to consume the upstream column at runtime.
+                throw new IllegalStateException(
+                    "filter on derived column ["
+                        + storageInfo.getFieldName()
+                        + "] not supported: "
+                        + "delegation model for derived columns is not yet implemented"
+                );
             }
+            // Format-aware: backends that can access this field's storage (doc values + index).
+            // A backend is viable only if it has the field in its own storage formats — ensuring
+            // delegation targets are also field-storage-aware (e.g. Lucene is viable for a keyword
+            // field only when the field has indexFormats=[lucene] set in the mapping).
+            // TODO: for FULL_TEXT operators, extract required params from RexCall
+            Set<String> fieldViable = new HashSet<>(registry.filterBackendsForField(function, storageInfo));
 
             viableSet.retainAll(fieldViable);
         }

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchJoinRule.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchJoinRule.java
@@ -1,0 +1,157 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.planner.rules;
+
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.plan.hep.HepRelVertex;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.JoinInfo;
+import org.apache.calcite.rel.core.JoinRelType;
+import org.apache.calcite.rel.logical.LogicalJoin;
+import org.opensearch.analytics.planner.PlannerContext;
+import org.opensearch.analytics.planner.rel.OpenSearchConvention;
+import org.opensearch.analytics.planner.rel.OpenSearchExchangeReducer;
+import org.opensearch.analytics.planner.rel.OpenSearchJoin;
+import org.opensearch.analytics.planner.rel.OpenSearchRelNode;
+import org.opensearch.analytics.spi.EngineCapability;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * HEP-marker rule that converts a Calcite {@link LogicalJoin} into an
+ * {@link OpenSearchJoin} in {@link OpenSearchConvention}.
+ *
+ * <p>The marked join wraps each input in an {@link OpenSearchExchangeReducer}
+ * carrying SINGLETON distribution. The DAG builder cuts at every reducer, producing
+ * one child stage per join input (a 3-stage DAG: 2 children + 1 coord parent).
+ *
+ * <p><b>Match criteria</b> (Requirement 1):
+ * <ul>
+ *   <li>{@link JoinRelType#INNER}, {@link JoinRelType#LEFT}, or {@link JoinRelType#RIGHT}.
+ *       FULL OUTER / SEMI / ANTI remain out of scope until their DataFusion substrait
+ *       execution paths are validated end-to-end.</li>
+ *   <li>Equi-condition only ({@link JoinInfo#isEqui()} true). This covers both the
+ *       normal case (at least one equi-clause) and the degenerate cross join shape
+ *       (empty leftKeys AND empty nonEquiConditions — e.g. {@code ON 1=1}). Isthmus
+ *       emits the latter as a substrait {@code Cross} rel, which DataFusion executes
+ *       as a NestedLoopJoin. Pure non-equi joins (e.g. {@code t1.a &lt; t2.b}, where
+ *       nonEquiConditions is non-empty) are still rejected — they'd need a separate
+ *       non-equi codepath we don't enable yet.</li>
+ * </ul>
+ *
+ * <p><b>Build-side contract</b> (Requirement 8): {@link LogicalJoin#getRight()} becomes
+ * the {@code right} input of the substrait {@code JoinRel}, which is DataFusion's
+ * default build side. Users can hint by ordering inputs as
+ * {@code SELECT ... FROM <probe> JOIN <build> ON ...}. The Calcite rewrite does NOT
+ * swap left/right based on size estimates — CBO-driven swap is a future spec.
+ *
+ * @opensearch.internal
+ */
+public class OpenSearchJoinRule extends RelOptRule {
+
+    private final PlannerContext context;
+
+    public OpenSearchJoinRule(PlannerContext context) {
+        super(operand(LogicalJoin.class, any()), "OpenSearchJoinRule");
+        this.context = context;
+    }
+
+    @Override
+    public boolean matches(RelOptRuleCall call) {
+        LogicalJoin join = call.rel(0);
+        JoinRelType joinType = join.getJoinType();
+        // Accept INNER / LEFT / RIGHT equi-joins. PPL's `lookup` command and other
+        // outer-join-producing front ends rely on LEFT; widening here lets the
+        // marking pass descend through the join for downstream rules. FULL / SEMI /
+        // ANTI remain out until DataFusion execution is verified for them.
+        if (joinType != JoinRelType.INNER && joinType != JoinRelType.LEFT && joinType != JoinRelType.RIGHT) {
+            return false;
+        }
+        // Accept equi-joins and cross joins (both satisfy JoinInfo.isEqui() — empty
+        // nonEquiConditions). A pure non-equi predicate (e.g. t1.a < t2.b) yields
+        // isEqui()=false and stays rejected — DataFusion would need a non-equi
+        // NestedLoopJoin path we don't enable yet.
+        JoinInfo info = join.analyzeCondition();
+        return info.isEqui();
+    }
+
+    @Override
+    public void onMatch(RelOptRuleCall call) {
+        LogicalJoin join = call.rel(0);
+
+        // Compute viable backends as the intersection of the inputs' viable backends,
+        // then retain only backends that declare JOIN capability. Inputs are
+        // HepRelVertex-wrapped marked nodes (OpenSearchTableScan etc.) by the time this
+        // rule fires; the bottom-up HEP traversal guarantees they're already in
+        // OpenSearchConvention.
+        List<String> viableBackends = computeViableBackends(join.getLeft(), join.getRight());
+        List<String> joinCapable = context.getCapabilityRegistry().operatorBackends(EngineCapability.JOIN);
+        viableBackends.retainAll(joinCapable);
+        if (viableBackends.isEmpty()) {
+            throw new IllegalStateException("No backend supports JOIN among viable backends after intersecting inputs");
+        }
+        RelTraitSet singletonTraits = join.getTraitSet()
+            .replace(OpenSearchConvention.INSTANCE)
+            .replace(context.getDistributionTraitDef().singleton());
+
+        // Wrap each input in an OpenSearchExchangeReducer to gather it to the coord.
+        // The DAG builder cuts at every reducer, producing one child stage per join input.
+        // The join itself is SINGLETON since both gathered inputs are SINGLETON — declaring
+        // this on the join's trait set lets any operator above it (e.g. Project) inherit
+        // SINGLETON without Volcano inserting a redundant top-level reducer.
+        RelNode left = wrapInExchange(join.getLeft(), singletonTraits, viableBackends);
+        RelNode right = wrapInExchange(join.getRight(), singletonTraits, viableBackends);
+
+        OpenSearchJoin osJoin = new OpenSearchJoin(
+            join.getCluster(),
+            singletonTraits,
+            left,
+            right,
+            join.getCondition(),
+            join.getJoinType(),
+            viableBackends
+        );
+        call.transformTo(osJoin);
+    }
+
+    private static RelNode wrapInExchange(RelNode input, RelTraitSet singletonTraits, List<String> viableBackends) {
+        return new OpenSearchExchangeReducer(input.getCluster(), singletonTraits, input, viableBackends);
+    }
+
+    /** Intersection of viable backends from left and right children. Children may be
+     *  {@link HepRelVertex}-wrapped — unwrap to read viableBackends if it's an
+     *  {@link OpenSearchRelNode}. onMatch then intersects with backends that declare
+     *  {@link EngineCapability#JOIN} so a backend that happens to be viable on both
+     *  inputs without supporting coord-side join is filtered out. */
+    private static List<String> computeViableBackends(RelNode left, RelNode right) {
+        List<String> leftBackends = viableBackendsOf(left);
+        List<String> rightBackends = viableBackendsOf(right);
+
+        Set<String> intersection = new LinkedHashSet<>(leftBackends);
+        intersection.retainAll(rightBackends);
+        return new ArrayList<>(intersection);
+    }
+
+    private static List<String> viableBackendsOf(RelNode rel) {
+        RelNode unwrapped = rel;
+        if (unwrapped instanceof HepRelVertex vertex) {
+            unwrapped = vertex.getCurrentRel();
+        }
+        if (unwrapped instanceof OpenSearchRelNode osNode) {
+            return osNode.getViableBackends();
+        }
+        // Not yet marked — empty list forces the fallback path above.
+        return List.of();
+    }
+}

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/RowProducingSinkTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/RowProducingSinkTests.java
@@ -53,6 +53,8 @@ public class RowProducingSinkTests extends OpenSearchTestCase {
         assertSame(batch, it.next());
         assertFalse(it.hasNext());
 
+        // readResult() transferred ownership, so close() is now a no-op — drain batches explicitly.
+        batch.close();
         sink.close();
     }
 
@@ -74,6 +76,10 @@ public class RowProducingSinkTests extends OpenSearchTestCase {
         assertSame(r3, it.next());
         assertFalse(it.hasNext());
 
+        // readResult() transferred ownership, so close() is now a no-op — drain batches explicitly.
+        r1.close();
+        r2.close();
+        r3.close();
         sink.close();
     }
 
@@ -92,6 +98,8 @@ public class RowProducingSinkTests extends OpenSearchTestCase {
         // Field names should come from the second batch
         assertEquals("y", sink.getValueAt("col_a", 0).toString());
 
+        // readResult() not called — releaseUnread() frees buffers so the allocator doesn't leak.
+        sink.releaseUnread();
         sink.close();
     }
 
@@ -104,6 +112,8 @@ public class RowProducingSinkTests extends OpenSearchTestCase {
         assertEquals("hello", sink.getValueAt("col1", 0).toString());
         assertEquals("42", sink.getValueAt("col2", 0).toString());
 
+        // readResult() not called — releaseUnread() frees buffers so the allocator doesn't leak.
+        sink.releaseUnread();
         sink.close();
     }
 
@@ -115,6 +125,8 @@ public class RowProducingSinkTests extends OpenSearchTestCase {
 
         assertNull(sink.getValueAt("nonexistent", 0));
 
+        // readResult() not called — releaseUnread() frees buffers so the allocator doesn't leak.
+        sink.releaseUnread();
         sink.close();
     }
 
@@ -126,6 +138,8 @@ public class RowProducingSinkTests extends OpenSearchTestCase {
 
         assertNull(sink.getValueAt("col1", 5));
 
+        // readResult() not called — releaseUnread() frees buffers so the allocator doesn't leak.
+        sink.releaseUnread();
         sink.close();
     }
 
@@ -137,6 +151,49 @@ public class RowProducingSinkTests extends OpenSearchTestCase {
         assertFalse(it.hasNext());
 
         sink.close();
+    }
+
+    /**
+     * Regression: ShardFragmentStageExecution.onShardTerminated calls {@code outputSink.close()}
+     * BEFORE transitioning to SUCCEEDED, which fires the PlanWalker's completion listener, which
+     * calls {@code readResult()}. The older close() implementation cleared batches eagerly, so
+     * readResult returned an empty list even though feed had delivered rows. Close must leave the
+     * buffered batches intact until the consumer has drained them.
+     */
+    public void testCloseBeforeReadResultRetainsBatches() {
+        RowProducingSink sink = new RowProducingSink();
+
+        VectorSchemaRoot batch = makeVsr(List.of("id"), new Object[][] { { "7" } });
+        sink.feed(batch);
+
+        sink.close();
+
+        // readResult called AFTER close must still return the fed batch.
+        Iterator<VectorSchemaRoot> it = sink.readResult().iterator();
+        assertTrue("close() must not drop buffered batches when result hasn't been read yet", it.hasNext());
+        assertSame(batch, it.next());
+        assertFalse(it.hasNext());
+
+        // Consumer owns the batch after readResult — close it here in lieu of the production
+        // consumer (DefaultPlanExecutor#batchesToRows) closing each batch.
+        batch.close();
+    }
+
+    /**
+     * Error path: releaseUnread() cleans up buffered batches so the query allocator
+     * doesn't detect a leak on the failure path where readResult() never runs.
+     */
+    public void testReleaseUnreadReleasesBatches() {
+        RowProducingSink sink = new RowProducingSink();
+
+        VectorSchemaRoot batch = makeVsr(List.of("id"), new Object[][] { { "x" } });
+        sink.feed(batch);
+
+        // Drop the sink without reading — e.g. query failed before the listener fired.
+        sink.releaseUnread();
+
+        // Following readResult returns empty (batches were released).
+        assertFalse(sink.readResult().iterator().hasNext());
     }
 
     // ─── Helpers ────────────────────────────────────────────────────────

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/FilterRuleTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/FilterRuleTests.java
@@ -217,16 +217,13 @@ public class FilterRuleTests extends BasePlannerRulesTests {
 
     /**
      * HAVING on a derived column (here, the aggregate's {@code total_size} output)
-     * resolves via the format-agnostic fallback: {@code filterBackendsAnyFormat}
-     * looks up backends supporting the function on the field type without requiring
-     * a doc-value or index format. Any backend with the operator + type capability
-     * is viable.
-     *
-     * <p>This was previously a fail-fast path because the rule had no way to map a
-     * derived column to a storage format. The fallback unblocks Filter on Union
-     * outputs, Project outputs, and HAVING on aggregate outputs alike.
+     * fails fast — derived-column filtering is not yet supported. A delegation model
+     * for derived/expression columns is required to map the column back to a physical
+     * backend (within-stage delegation); until that exists, the planner refuses to
+     * produce a plan rather than silently picking a backend that might not be able to
+     * read the operator's output at runtime.
      */
-    public void testFilterOnDerivedColumnsAfterAggregateResolvesAnyFormat() {
+    public void testFilterOnDerivedColumnFailsFast() {
         PlannerContext context = buildContext("parquet", 1, Map.of("status", Map.of("type", "integer"), "size", Map.of("type", "integer")));
 
         RelOptTable table = mockTable("test_index", "status", "size");
@@ -255,23 +252,15 @@ public class FilterRuleTests extends BasePlannerRulesTests {
         );
         LogicalFilter having = LogicalFilter.create(aggregate, havingCondition);
 
-        RelNode result = unwrapExchange(runPlanner(having, context));
-        OpenSearchFilter filter = findOpenSearchFilter(result);
-        assertNotNull("Expected an OpenSearchFilter somewhere in the planned tree, got:\n" + RelOptUtil.toString(result), filter);
+        IllegalStateException exception = expectThrows(IllegalStateException.class, () -> runPlanner(having, context));
         assertTrue(
-            "DataFusion must be a viable backend for HAVING on derived total_size; got " + filter.getViableBackends(),
-            filter.getViableBackends().contains(MockDataFusionBackend.NAME)
+            "exception message must mention the derived column name; got: " + exception.getMessage(),
+            exception.getMessage().contains("total_size")
         );
-    }
-
-    /** Walks the resolved tree top-down and returns the first {@link OpenSearchFilter}, or null. */
-    private static OpenSearchFilter findOpenSearchFilter(RelNode node) {
-        if (node instanceof OpenSearchFilter f) return f;
-        for (RelNode input : node.getInputs()) {
-            OpenSearchFilter found = findOpenSearchFilter(input);
-            if (found != null) return found;
-        }
-        return null;
+        assertTrue(
+            "exception message must identify the unsupported path; got: " + exception.getMessage(),
+            exception.getMessage().contains("derived column")
+        );
     }
 
     // ---- Helpers ----

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/JoinRuleTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/JoinRuleTests.java
@@ -1,0 +1,194 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.planner;
+
+import org.apache.calcite.plan.RelOptTable;
+import org.apache.calcite.plan.RelOptUtil;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.JoinRelType;
+import org.apache.calcite.rel.logical.LogicalJoin;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.analytics.planner.rel.OpenSearchExchangeReducer;
+import org.opensearch.analytics.planner.rel.OpenSearchJoin;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Tests for {@link org.opensearch.analytics.planner.rules.OpenSearchJoinRule}: matches
+ * inner equi-joins, produces an {@link OpenSearchJoin} with both inputs SINGLETON-converted
+ * (i.e. wrapped in {@link OpenSearchExchangeReducer} by Volcano), and rejects non-inner
+ * and pure non-equi joins.
+ */
+public class JoinRuleTests extends BasePlannerRulesTests {
+
+    private static final Logger LOGGER = LogManager.getLogger(JoinRuleTests.class);
+
+    public void testInnerEquiJoinMatchesAndProducesOpenSearchJoin() {
+        RelNode result = runJoin(JoinRelType.INNER, equiJoinCondition());
+
+        // Volcano may wrap the SINGLETON-producing OpenSearchJoin in a redundant top-level
+        // OpenSearchExchangeReducer when satisfying the root's required SINGLETON trait —
+        // unwrap one layer if so.
+        RelNode unwrapped = RelNodeUtils.unwrapHep(result);
+        if (unwrapped instanceof OpenSearchExchangeReducer wrapper) {
+            unwrapped = RelNodeUtils.unwrapHep(wrapper.getInput());
+        }
+        assertTrue("rule should produce OpenSearchJoin, got " + unwrapped.getClass().getSimpleName(), unwrapped instanceof OpenSearchJoin);
+
+        OpenSearchJoin osJoin = (OpenSearchJoin) unwrapped;
+        assertEquals("inner join type preserved", JoinRelType.INNER, osJoin.getJoinType());
+        RelNode left = RelNodeUtils.unwrapHep(osJoin.getLeft());
+        RelNode right = RelNodeUtils.unwrapHep(osJoin.getRight());
+        assertTrue(
+            "left input wrapped in OpenSearchExchangeReducer, got " + left.getClass().getSimpleName(),
+            left instanceof OpenSearchExchangeReducer
+        );
+        assertTrue(
+            "right input wrapped in OpenSearchExchangeReducer, got " + right.getClass().getSimpleName(),
+            right instanceof OpenSearchExchangeReducer
+        );
+    }
+
+    public void testLeftEquiJoinMatchesAndProducesOpenSearchJoin() {
+        assertEquiJoinMatches(JoinRelType.LEFT);
+    }
+
+    public void testRightEquiJoinMatchesAndProducesOpenSearchJoin() {
+        assertEquiJoinMatches(JoinRelType.RIGHT);
+    }
+
+    public void testFullOuterJoinDoesNotMatch() {
+        // FULL OUTER remains out of scope for this wave: DataFusion's substrait consumer
+        // historically has gaps around FULL OUTER execution, so we deliberately don't
+        // widen the rule to it yet. When it's enabled, flip this to
+        // {@link #assertEquiJoinMatches(JoinRelType)} and add an IT validation.
+        assertNonInnerJoinDoesNotMatch(JoinRelType.FULL);
+    }
+
+    private void assertEquiJoinMatches(JoinRelType joinType) {
+        RelNode result = runJoin(joinType, equiJoinCondition());
+
+        RelNode unwrapped = RelNodeUtils.unwrapHep(result);
+        if (unwrapped instanceof OpenSearchExchangeReducer wrapper) {
+            unwrapped = RelNodeUtils.unwrapHep(wrapper.getInput());
+        }
+        assertTrue(
+            "rule should produce OpenSearchJoin for " + joinType + ", got " + unwrapped.getClass().getSimpleName(),
+            unwrapped instanceof OpenSearchJoin
+        );
+
+        OpenSearchJoin osJoin = (OpenSearchJoin) unwrapped;
+        assertEquals(joinType + " join type preserved", joinType, osJoin.getJoinType());
+        RelNode left = RelNodeUtils.unwrapHep(osJoin.getLeft());
+        RelNode right = RelNodeUtils.unwrapHep(osJoin.getRight());
+        assertTrue(
+            "left input wrapped in OpenSearchExchangeReducer, got " + left.getClass().getSimpleName(),
+            left instanceof OpenSearchExchangeReducer
+        );
+        assertTrue(
+            "right input wrapped in OpenSearchExchangeReducer, got " + right.getClass().getSimpleName(),
+            right instanceof OpenSearchExchangeReducer
+        );
+    }
+
+    public void testCrossJoinMatchesAndProducesOpenSearchJoin() {
+        // ON 1 = 1 — literal-only condition. Calcite folds this to condition=TRUE: empty
+        // leftKeys, empty nonEquiConditions → JoinInfo.isEqui()=true. The rule must accept
+        // this shape so the downstream OpenSearchAggregateRule finds a marked child. Isthmus
+        // emits it as a substrait Cross rel, which DataFusion executes as NestedLoopJoin.
+        RexNode trueCondition = rexBuilder.makeLiteral(true);
+        RelNode result = runJoin(JoinRelType.INNER, trueCondition);
+
+        RelNode unwrapped = RelNodeUtils.unwrapHep(result);
+        if (unwrapped instanceof OpenSearchExchangeReducer wrapper) {
+            unwrapped = RelNodeUtils.unwrapHep(wrapper.getInput());
+        }
+        assertTrue(
+            "rule should produce OpenSearchJoin for cross joins, got " + unwrapped.getClass().getSimpleName(),
+            unwrapped instanceof OpenSearchJoin
+        );
+    }
+
+    public void testPureNonEquiJoinDoesNotMatch() {
+        // left.k < right.k — no equi-condition, the rule's analyzeCondition().leftKeys is empty.
+        RexNode lt = rexBuilder.makeCall(
+            SqlStdOperatorTable.LESS_THAN,
+            rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.INTEGER), 0),
+            rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.INTEGER), 2)
+        );
+        // Non-equi inner join — the rule doesn't match, so the LogicalJoin survives through
+        // HEP marking. The downstream Volcano stage may not be able to plan it (no rule to
+        // turn LogicalJoin into something with a coord-side execution path), which surfaces
+        // as a planner failure. We only assert that whatever does come back is NOT an
+        // OpenSearchJoin — i.e. our rule did not (incorrectly) match a pure non-equi join.
+        try {
+            RelNode result = runJoin(JoinRelType.INNER, lt);
+            assertFalse("rule must not match pure non-equi inner joins", containsOpenSearchJoin(result));
+        } catch (RuntimeException expected) {
+            // Volcano can't plan a non-equi join through OpenSearch — that's fine; the
+            // important thing is that our rule didn't pick it up.
+        }
+    }
+
+    private void assertNonInnerJoinDoesNotMatch(JoinRelType joinType) {
+        // Volcano can't produce a SINGLETON-distributed plan for a non-inner LogicalJoin
+        // because no rule converts LogicalJoin → OpenSearchJoin for non-inner types and the
+        // distribution trait def can't bridge from NONE convention. The planner failure is
+        // the expected outcome; the contract we verify is that our rule did NOT match.
+        try {
+            RelNode result = runJoin(joinType, equiJoinCondition());
+            assertFalse("rule must not match non-inner joins (joinType=" + joinType + ")", containsOpenSearchJoin(result));
+        } catch (RuntimeException expected) {
+            // Acceptable — see above.
+        }
+    }
+
+    private static boolean containsOpenSearchJoin(RelNode root) {
+        RelNode unwrapped = RelNodeUtils.unwrapHep(root);
+        if (unwrapped instanceof OpenSearchJoin) return true;
+        for (RelNode input : unwrapped.getInputs()) {
+            if (containsOpenSearchJoin(input)) return true;
+        }
+        return false;
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────
+
+    private RelNode runJoin(JoinRelType joinType, RexNode condition) {
+        // Both sides use the same mocked index (the planner's table-mark step looks up cluster
+        // state by qualified name, and the test fixture only mocks "test_index"). The join
+        // rule we're testing doesn't care about table identity — it only inspects the join
+        // shape and condition.
+        PlannerContext context = buildContext("parquet", 2, Map.of("k", Map.of("type", "integer"), "v", Map.of("type", "integer")));
+        RelOptTable table = mockTable("test_index", "k", "v");
+        RelNode left = stubScan(table);
+        RelNode right = stubScan(table);
+        LogicalJoin join = LogicalJoin.create(left, right, List.of(), condition, Set.of(), joinType);
+
+        LOGGER.info("Input join:\n{}", RelOptUtil.toString(join));
+        RelNode result = runPlanner(join, context);
+        LOGGER.info("Marked+CBO output:\n{}", RelOptUtil.toString(result));
+        return result;
+    }
+
+    private RexNode equiJoinCondition() {
+        // left.k = right.k — left field 0 = right field 0 (offset by left fieldCount=2).
+        return rexBuilder.makeCall(
+            SqlStdOperatorTable.EQUALS,
+            rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.INTEGER), 0),
+            rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.INTEGER), 2)
+        );
+    }
+}

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/MockDataFusionBackend.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/MockDataFusionBackend.java
@@ -40,7 +40,7 @@ public class MockDataFusionBackend extends MockBackend implements SearchBackEndP
     public static final String PARQUET_DATA_FORMAT = "parquet";
     private static final Set<String> DATAFUSION_FORMATS = Set.of(PARQUET_DATA_FORMAT);
 
-    private static final Set<EngineCapability> OPERATOR_CAPS = Set.of(EngineCapability.SORT);
+    private static final Set<EngineCapability> OPERATOR_CAPS = Set.of(EngineCapability.SORT, EngineCapability.JOIN);
 
     private static final Set<FieldType> SUPPORTED_TYPES = new HashSet<>();
     static {

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/dag/MultiInputShapeTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/dag/MultiInputShapeTests.java
@@ -1,0 +1,102 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.planner.dag;
+
+import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.hep.HepPlanner;
+import org.apache.calcite.plan.hep.HepProgramBuilder;
+import org.apache.calcite.rel.AbstractRelNode;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.opensearch.analytics.planner.rel.OpenSearchExchangeReducer;
+import org.opensearch.analytics.planner.rel.OpenSearchStageInputScan;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Tests for {@link MultiInputShape} — verifies detection of the N-input coordinator
+ * shape where all children are {@link OpenSearchExchangeReducer}s each wrapping an
+ * {@link OpenSearchStageInputScan}.
+ */
+public class MultiInputShapeTests extends OpenSearchTestCase {
+
+    private RelOptCluster cluster;
+    private RelDataType rowType;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        RelDataTypeFactory typeFactory = new JavaTypeFactoryImpl();
+        RexBuilder rexBuilder = new RexBuilder(typeFactory);
+        HepPlanner planner = new HepPlanner(new HepProgramBuilder().build());
+        cluster = RelOptCluster.create(planner, rexBuilder);
+        rowType = typeFactory.builder().add("a", typeFactory.createSqlType(SqlTypeName.INTEGER)).build();
+    }
+
+    /** Two ER children each wrapping a StageInputScan — detected, returns the two scans in order. */
+    public void testTwoExchangeReducersWrappingStageInputScans() {
+        OpenSearchStageInputScan leftScan = new OpenSearchStageInputScan(cluster, cluster.traitSet(), 1, rowType, List.of("df"));
+        OpenSearchStageInputScan rightScan = new OpenSearchStageInputScan(cluster, cluster.traitSet(), 2, rowType, List.of("df"));
+        OpenSearchExchangeReducer leftReducer = new OpenSearchExchangeReducer(cluster, cluster.traitSet(), leftScan, List.of("df"));
+        OpenSearchExchangeReducer rightReducer = new OpenSearchExchangeReducer(cluster, cluster.traitSet(), rightScan, List.of("df"));
+        RelNode multiInput = new StubMultiInput(cluster, List.of(leftReducer, rightReducer));
+
+        Optional<MultiInputShape> result = MultiInputShape.detect(multiInput);
+
+        assertTrue("expected MultiInputShape for two ER-wrapped StageInputScans", result.isPresent());
+        List<OpenSearchStageInputScan> scans = result.get().getBranchScans();
+        assertEquals(2, scans.size());
+        assertSame(leftScan, scans.get(0));
+        assertSame(rightScan, scans.get(1));
+    }
+
+    /** Single-input node — not a multi-input shape, returns empty. */
+    public void testSingleInputReturnsEmpty() {
+        OpenSearchStageInputScan scan = new OpenSearchStageInputScan(cluster, cluster.traitSet(), 1, rowType, List.of("df"));
+        OpenSearchExchangeReducer reducer = new OpenSearchExchangeReducer(cluster, cluster.traitSet(), scan, List.of("df"));
+        RelNode singleInput = new StubMultiInput(cluster, List.of(reducer));
+
+        Optional<MultiInputShape> result = MultiInputShape.detect(singleInput);
+
+        assertTrue("single-input shape must not be treated as multi-input", result.isEmpty());
+    }
+
+    /** Mixed children (one ER, one non-ER leaf) — not a multi-input shape, returns empty. */
+    public void testMixedChildrenReturnsEmpty() {
+        OpenSearchStageInputScan scan = new OpenSearchStageInputScan(cluster, cluster.traitSet(), 1, rowType, List.of("df"));
+        OpenSearchExchangeReducer reducer = new OpenSearchExchangeReducer(cluster, cluster.traitSet(), scan, List.of("df"));
+        OpenSearchStageInputScan bareScan = new OpenSearchStageInputScan(cluster, cluster.traitSet(), 2, rowType, List.of("df"));
+        RelNode mixed = new StubMultiInput(cluster, List.of(reducer, bareScan));
+
+        Optional<MultiInputShape> result = MultiInputShape.detect(mixed);
+
+        assertTrue("mixed-child shape must not be treated as multi-input", result.isEmpty());
+    }
+
+    /** Minimal multi-input stub — Calcite RelNode with N inputs and no side effects. */
+    private static final class StubMultiInput extends AbstractRelNode {
+        private final List<RelNode> inputs;
+
+        StubMultiInput(RelOptCluster cluster, List<RelNode> inputs) {
+            super(cluster, cluster.traitSet());
+            this.inputs = List.copyOf(inputs);
+        }
+
+        @Override
+        public List<RelNode> getInputs() {
+            return inputs;
+        }
+    }
+}

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/JoinCommandIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/JoinCommandIT.java
@@ -1,0 +1,238 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.qa;
+
+import org.apache.lucene.tests.util.LuceneTestCase.AwaitsFix;
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+import org.opensearch.client.ResponseException;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Integration tests for PPL commands that lower to {@code LogicalJoin} on the
+ * analytics-engine route (POST /_analytics/ppl).
+ *
+ * <p>Exercises the three commands that produce a join RelNode:
+ * <ul>
+ *   <li>{@code join} — direct LogicalJoin (inner / left / cross)</li>
+ *   <li>{@code lookup} — LogicalJoin (LEFT) with rename/replace semantics</li>
+ *   <li>{@code appendcol} — LogicalJoin (FULL OUTER) by synthesized row number</li>
+ * </ul>
+ *
+ * <p>{@code graphLookup} is intentionally out of scope for this IT — it requires
+ * a graph-shaped dataset with self-referential edges that the calcs dataset
+ * does not provide.
+ *
+ * <p>Uses the {@code calcs} dataset provisioned into two indices ({@code calcs}
+ * and {@code calcs_alt}) so two-table joins have distinct right-hand operands
+ * without pulling in a second dataset. Row-count assertions are used for this
+ * exploratory coverage — the IT focuses on whether each command plans, converts
+ * to Substrait, and executes end-to-end rather than on exact row values.
+ *
+ * <p>All join / lookup tests pass end-to-end. {@code testAppendcol} remains
+ * {@code @AwaitsFix} — the analytics-framework has no window-function
+ * capability track yet, so {@code ROW_NUMBER()} (emitted by the appendcol
+ * lowering) cannot be declared by any backend.
+ */
+public class JoinCommandIT extends AnalyticsRestTestCase {
+
+    private static final Dataset CALCS = new Dataset("calcs", "calcs");
+    private static final Dataset CALCS_ALT = new Dataset("calcs", "calcs_alt");
+
+    private static boolean dataProvisioned = false;
+
+    /**
+     * Lazily provision both calcs indices on first invocation. Called inside test
+     * methods — {@code client()} is not available in {@code @BeforeClass}.
+     */
+    private void ensureDataProvisioned() throws IOException {
+        if (dataProvisioned == false) {
+            DatasetProvisioner.provision(client(), CALCS);
+            DatasetProvisioner.provision(client(), CALCS_ALT);
+            dataProvisioned = true;
+        }
+    }
+
+    // ── join (direct LogicalJoin) ──────────────────────────────────────────────
+    //
+    // NOTE on schema narrowing: the calcs dataset carries date/time/datetime
+    // fields that map to Calcite TIMESTAMP / DATE types. The analytics-engine
+    // Arrow schema converter (ArrowSchemaFromCalcite) currently rejects those
+    // types, so every query below projects down to int/string/boolean columns
+    // via an explicit {@code fields …} or an aggregation before the join output
+    // surfaces to Arrow. Removing the projection surfaces
+    // {@code IllegalArgumentException: Unsupported Calcite SQL type: TIMESTAMP}.
+
+    /**
+     * Inner equi-join across two indices of the calcs dataset, grouped on
+     * {@code str0}. Both sides are pre-aggregated to a narrow keyword-only
+     * schema so the join output has no TIMESTAMP/DATE columns.
+     */
+    public void testInnerJoin() throws IOException {
+        final String ppl = "source="
+            + CALCS.indexName
+            + " | stats count() as left_cnt by str0"
+            + " | inner join left=a, right=b ON a.str0 = b.str0"
+            + " [ source="
+            + CALCS_ALT.indexName
+            + " | stats count() as right_cnt by str0 ]"
+            + " | stats count() as cnt";
+        assertSingleCount(ppl, 3L);
+    }
+
+    /**
+     * Left outer join. Drops one str0 value from the right side via a filter so
+     * a subset of left rows have no match and appear with nulls on the right.
+     */
+    public void testLeftOuterJoin() throws IOException {
+        final String ppl = "source="
+            + CALCS.indexName
+            + " | fields key, str0"
+            + " | left join left=a, right=b ON a.str0 = b.str0"
+            + " [ source="
+            + CALCS_ALT.indexName
+            + " | where str0 = 'TECHNOLOGY' | fields key, str0 ]"
+            + " | stats count() as cnt";
+        assertSingleCount(ppl, 89L);
+    }
+
+    /**
+     * Cross join (join predicate {@code 1=1}). Exercises the degenerate
+     * no-equi-condition shape — Isthmus emits it as a Substrait {@code Cross}
+     * rel, which DataFusion executes as a NestedLoopJoin.
+     */
+    public void testCrossJoin() throws IOException {
+        final String ppl = "source="
+            + CALCS.indexName
+            + " | fields key"
+            + " | join left=a, right=b on 1=1"
+            + " [ source="
+            + CALCS_ALT.indexName
+            + " | fields key ]"
+            + " | stats count() as cnt";
+        assertSingleCount(ppl, 289L);
+    }
+
+    // ── lookup (LogicalJoin LEFT) ──────────────────────────────────────────────
+
+    /**
+     * Lookup with REPLACE: left table rows are enriched with {@code str0} from
+     * the right table, matched on {@code key}. LEFT join semantics — every left
+     * row is retained.
+     */
+    public void testLookup() throws IOException {
+        final String ppl = "source="
+            + CALCS.indexName
+            + " | fields key, int0, str0"
+            + " | lookup "
+            + CALCS_ALT.indexName
+            + " key REPLACE str0"
+            + " | stats count() as cnt";
+        assertSingleCount(ppl, 17L);
+    }
+
+    /**
+     * Lookup with REPLACE … AS rename — the right-side value overwrites a
+     * differently-named left column. Exercises the projection wrapper emitted by
+     * the lookup → LogicalJoin lowering.
+     */
+    public void testLookupReplaceWithRename() throws IOException {
+        final String ppl = "source="
+            + CALCS.indexName
+            + " | fields key, int0, str0"
+            + " | lookup "
+            + CALCS_ALT.indexName
+            + " key REPLACE str0 AS str2"
+            + " | stats count() as cnt";
+        assertSingleCount(ppl, 17L);
+    }
+
+    // ── appendcol (LogicalJoin FULL OUTER by row_num) ──────────────────────────
+
+    /**
+     * appendcol pairs the outer pipeline with a subsearch by synthesized row
+     * number. PPL grammar does not allow {@code source=…} inside the
+     * {@code appendcol [ … ]} brackets — the subsearch operates on the implicit
+     * upstream input.
+     *
+     * <p><b>Pending (window-function track)</b>: appendcol lowers to
+     * {@code ROW_NUMBER() OVER (ORDER BY …)} for pairing rows. The
+     * analytics-framework has no window-function capability track — no
+     * {@code WindowFunction} enum, no {@code windowFunctionCapabilities()} on
+     * {@link org.opensearch.analytics.spi.BackendCapabilityProvider}, and
+     * {@link org.opensearch.analytics.spi.ScalarFunction} has no ROW_NUMBER
+     * entry either (scalar functions are per-row; window functions are per-row
+     * over an aggregation frame — modelling them as scalars breaks the
+     * capability-type contract). Wiring the full track is a follow-up.
+     */
+    @AwaitsFix(bugUrl = "analytics-framework lacks a window-function capability track — appendcol's ROW_NUMBER() cannot register")
+    public void testAppendcol() throws IOException {
+        final String ppl = "source="
+            + CALCS.indexName
+            + " | stats count() as total by str0 | sort str0"
+            + " | appendcol [ stats count() as alt_total ]"
+            + " | stats count() as cnt";
+        assertSingleCount(ppl, 3L);
+    }
+
+    // ── helpers ────────────────────────────────────────────────────────────────
+
+    /** Execute a PPL query expected to return a single {@code cnt} row and assert the value. */
+    private void assertSingleCount(String ppl, long expected) throws IOException {
+        Map<String, Object> response = executePpl(ppl);
+        @SuppressWarnings("unchecked")
+        List<List<Object>> rows = (List<List<Object>>) response.get("rows");
+        assertNotNull("Response missing 'rows' for query: " + ppl, rows);
+        assertEquals("Expected single count row for query: " + ppl, 1, rows.size());
+        Object actual = rows.get(0).get(0);
+        assertTrue(
+            "Expected numeric count for query: " + ppl + " but got: " + actual,
+            actual instanceof Number
+        );
+        assertEquals("Count mismatch for query: " + ppl, expected, ((Number) actual).longValue());
+    }
+
+    /** Send {@code POST /_analytics/ppl} and return the parsed JSON body. */
+    private Map<String, Object> executePpl(String ppl) throws IOException {
+        ensureDataProvisioned();
+        Request request = new Request("POST", "/_analytics/ppl");
+        request.setJsonEntity("{\"query\": \"" + escapeJson(ppl) + "\"}");
+        Response response = client().performRequest(request);
+        return assertOkAndParse(response, "PPL: " + ppl);
+    }
+
+    /**
+     * Send a PPL query expecting a failure and assert the response body contains
+     * {@code expectedSubstring}. Kept for future use when a gated test is
+     * converted to pin an expected error rather than skip entirely.
+     */
+    @SuppressWarnings("unused")
+    private void assertErrorContains(String ppl, String expectedSubstring) {
+        try {
+            Map<String, Object> response = executePpl(ppl);
+            fail("Expected query to fail with [" + expectedSubstring + "] but got response: " + response);
+        } catch (ResponseException e) {
+            String body;
+            try {
+                body = org.opensearch.test.rest.OpenSearchRestTestCase.entityAsMap(e.getResponse()).toString();
+            } catch (IOException ioe) {
+                body = e.getMessage();
+            }
+            assertTrue(
+                "Expected response body to contain [" + expectedSubstring + "] but was: " + body,
+                body.contains(expectedSubstring)
+            );
+        } catch (IOException e) {
+            fail("Unexpected IOException: " + e);
+        }
+    }
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
  ## Summary

  Brings PPL join coverage (inner, left outer, cross, lookup, lookup+rename) online through the analytics-engine route, plus fixes uncovered during the merge from `main`.

  - **`JoinCommandIT`** — 6 ITs covering inner, left outer, cross, lookup, lookup+rename (all green). appendcol skipped with `@AwaitsFix` — depends on window-function capability track (separate PR).
  - **Cross join marking** — `OpenSearchJoinRule.matches` relaxed from `!leftKeys.isEmpty()` to `info.isEqui()`.
  - **`CAST` project capability** — added `Scalar(CAST, ...)` to `DataFusionAnalyticsBackendPlugin.projectCapabilities()`. LEFT OUTER JOIN injects CAST for nullable coercion; without this the project rule rejected the expression.
  - **Substrait names-list emission fix** (general correctness — not just joins) — `DataFusionFragmentConvertor.rewire(Plan, Rel)` previously reused `innerRoot.getNames()` for the wrapper's output names. When the wrapper's output schema differs from the inner plan's (e.g. `Aggregate` over `Join` shrinks 4 columns → 1), this emitted a mismatched `Plan.Root.names` list and DataFusion rejected with `"Names list must match exactly to nested schema, but found N uses for M names"`. Fixed
  by taking the wrapper's own names.
  - **`RowProducingSink.close()` no longer drops buffered batches** — `close()` used to release and clear the buffer. `ShardFragmentStageExecution.onShardTerminated` invokes `close()` before the SUCCEEDED transition; the PlanWalker's completion listener reads results during that transition → saw 0 rows. Terminal root sink is now a no-op on close; the downstream consumer (`DefaultPlanExecutor#batchesToRows`) already owns per-batch cleanup. Error path keeps leak safety via new
  `releaseUnread()`.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
