### PR TITLE
Fix wildcard query analyzer match-all leak

### DIFF
--- a/modules/analysis-common/src/internalClusterTest/java/org/opensearch/analysis/common/QueryStringWithAnalyzersIT.java
+++ b/modules/analysis-common/src/internalClusterTest/java/org/opensearch/analysis/common/QueryStringWithAnalyzersIT.java
@@ -100,4 +100,80 @@ public class QueryStringWithAnalyzersIT extends ParameterizedStaticSettingsOpenS
             .get();
         assertHitCount(response, 1L);
     }
+
+    private static final String DIGITS_INDEX = "digits_analyzer_idx";
+
+    private void createDigitsOnlyAnalyzerIndex() {
+        assertAcked(
+            client().admin()
+                .indices()
+                .prepareCreate(DIGITS_INDEX)
+                .setSettings(
+                    Settings.builder()
+                        .put("analysis.char_filter.strip_nondigits.type", "pattern_replace")
+                        .put("analysis.char_filter.strip_nondigits.pattern", "\\D")
+                        .put("analysis.char_filter.strip_nondigits.replacement", "")
+                        .put("analysis.filter.remove_empty_tokens.type", "length")
+                        .put("analysis.filter.remove_empty_tokens.min", 1)
+                        .put("analysis.filter.replace_empty_with_null.type", "pattern_replace")
+                        .put("analysis.filter.replace_empty_with_null.pattern", "^$")
+                        .put("analysis.filter.replace_empty_with_null.replacement", "<NULL>")
+                        .put("analysis.analyzer.digits_only.type", "custom")
+                        .put("analysis.analyzer.digits_only.char_filter", "strip_nondigits")
+                        .put("analysis.analyzer.digits_only.tokenizer", "keyword")
+                        .put("analysis.analyzer.digits_only.filter", "remove_empty_tokens")
+                        .put("analysis.analyzer.digits_only_search.type", "custom")
+                        .put("analysis.analyzer.digits_only_search.char_filter", "strip_nondigits")
+                        .put("analysis.analyzer.digits_only_search.tokenizer", "keyword")
+                        .put("analysis.analyzer.digits_only_search.filter", "replace_empty_with_null")
+                )
+                .setMapping("number_field", "type=text,analyzer=digits_only,search_analyzer=digits_only_search")
+        );
+
+        client().prepareIndex(DIGITS_INDEX).setId("1").setSource("number_field", "1234").get();
+        refresh();
+    }
+
+    /**
+     * Issue #21280: when the analyzer strips every literal character of a wildcard term, the
+     * empty token would otherwise be compiled into a match-all automaton and silently widen
+     * the search to an exists query. Covers both the explicit analyzer override and the
+     * field-configured search_analyzer paths reported in the issue.
+     */
+    public void testWildcardWithStrippedLiteralsReturnsNoHits() {
+        createDigitsOnlyAnalyzerIndex();
+
+        assertHitCount(
+            client().prepareSearch(DIGITS_INDEX).setQuery(queryStringQuery("*asdf*").field("number_field").analyzer("digits_only")).get(),
+            0L
+        );
+        assertHitCount(
+            client().prepareSearch(DIGITS_INDEX)
+                .setQuery(queryStringQuery("*asdf*").field("number_field").analyzer("digits_only_search"))
+                .get(),
+            0L
+        );
+        assertHitCount(client().prepareSearch(DIGITS_INDEX).setQuery(queryStringQuery("*asdf*").field("number_field")).get(), 0L);
+        assertHitCount(
+            client().prepareSearch(DIGITS_INDEX).setQuery(queryStringQuery("*asdf*").field("number_field").analyzeWildcard(true)).get(),
+            0L
+        );
+    }
+
+    public void testWildcardPreservesUserTypedMatchAll() {
+        createDigitsOnlyAnalyzerIndex();
+
+        assertHitCount(client().prepareSearch(DIGITS_INDEX).setQuery(queryStringQuery("**").field("number_field")).get(), 1L);
+        assertHitCount(client().prepareSearch(DIGITS_INDEX).setQuery(queryStringQuery("***").field("number_field")).get(), 1L);
+    }
+
+    public void testWildcardWithSurvivingLiteralsStillMatches() {
+        createDigitsOnlyAnalyzerIndex();
+
+        assertHitCount(
+            client().prepareSearch(DIGITS_INDEX).setQuery(queryStringQuery("*123*").field("number_field").analyzer("digits_only")).get(),
+            1L
+        );
+        assertHitCount(client().prepareSearch(DIGITS_INDEX).setQuery(queryStringQuery("123*").field("number_field")).get(), 1L);
+    }
 }

--- a/server/src/main/java/org/opensearch/index/search/QueryStringQueryParser.java
+++ b/server/src/main/java/org/opensearch/index/search/QueryStringQueryParser.java
@@ -45,6 +45,7 @@ import org.apache.lucene.queries.spans.SpanQuery;
 import org.apache.lucene.queryparser.classic.ParseException;
 import org.apache.lucene.queryparser.classic.Token;
 import org.apache.lucene.queryparser.classic.XQueryParser;
+import org.apache.lucene.search.AutomatonQuery;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BoostAttribute;
 import org.apache.lucene.search.BoostQuery;
@@ -58,6 +59,7 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.SynonymQuery;
 import org.apache.lucene.search.WildcardQuery;
 import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.automaton.CompiledAutomaton;
 import org.apache.lucene.util.automaton.RegExp;
 import org.apache.lucene.util.automaton.TooComplexToDeterminizeException;
 import org.opensearch.common.lucene.search.Queries;
@@ -733,13 +735,15 @@ public class QueryStringQueryParser extends XQueryParser {
             }
             if (forceAnalyzer != null && (analyzeWildcard || currentFieldType.getTextSearchInfo().isTokenized())) {
                 setAnalyzer(forceAnalyzer);
-                return super.getWildcardQuery(currentFieldType.name(), termStr);
+                Query query = super.getWildcardQuery(currentFieldType.name(), termStr);
+                return rejectAnalyzerInducedMatchAll(termStr, query);
             }
             if (getAllowLeadingWildcard() == false && (termStr.startsWith("*") || termStr.startsWith("?"))) {
                 throw new ParseException("'*' or '?' not allowed as first character in WildcardQuery");
             }
             // query string query is always normalized
-            return currentFieldType.normalizedWildcardQuery(termStr, getMultiTermRewriteMethod(), context);
+            Query query = currentFieldType.normalizedWildcardQuery(termStr, getMultiTermRewriteMethod(), context);
+            return rejectAnalyzerInducedMatchAll(termStr, query);
         } catch (RuntimeException e) {
             if (lenient) {
                 return newLenientFieldQuery(field, e);
@@ -748,6 +752,21 @@ public class QueryStringQueryParser extends XQueryParser {
         } finally {
             setAnalyzer(oldAnalyzer);
         }
+    }
+
+    /**
+     * If the analyzer strips every literal of the wildcard (e.g. *asdf* through a
+     * digits-only filter), Lucene compiles the result into a match-all automaton and
+     * the query silently widens to "exists". Treat that as no match, unless the user
+     * actually typed a match-all pattern such as ** or ***. See #21280.
+     */
+    private static Query rejectAnalyzerInducedMatchAll(String termStr, Query query) {
+        if (query instanceof AutomatonQuery automatonQuery
+            && automatonQuery.getCompiled().type == CompiledAutomaton.AUTOMATON_TYPE.ALL
+            && termStr.chars().allMatch(c -> c == '*') == false) {
+            return Queries.newMatchNoDocsQuery("Wildcard pattern normalized to match-all by analyzer");
+        }
+        return query;
     }
 
     private Analyzer getSearchAnalyzer(MappedFieldType currentFieldType) {

--- a/server/src/test/java/org/opensearch/index/query/QueryStringQueryBuilderTests.java
+++ b/server/src/test/java/org/opensearch/index/query/QueryStringQueryBuilderTests.java
@@ -32,6 +32,8 @@
 
 package org.opensearch.index.query;
 
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.core.KeywordTokenizer;
 import org.apache.lucene.document.LongPoint;
 import org.apache.lucene.document.SortedNumericDocValuesField;
 import org.apache.lucene.index.Term;
@@ -84,6 +86,8 @@ import org.hamcrest.CoreMatchers;
 import org.hamcrest.Matchers;
 
 import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
 import java.time.DateTimeException;
 import java.time.ZoneId;
 import java.util.ArrayList;
@@ -611,6 +615,28 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
             ).add(new TermQuery(new Term("prefix_field", "g")), Occur.SHOULD).build()
         );
         assertThat(query, equalTo(expectedQuery));
+    }
+
+    public void testWildcardForcedAnalyzerRejectsInducedMatchAll() throws Exception {
+        // #21280: char_filter that strips a wildcard chunk to empty must not widen to match-all.
+        Analyzer dropAll = new Analyzer() {
+            @Override
+            protected TokenStreamComponents createComponents(String fieldName) {
+                return new TokenStreamComponents(new KeywordTokenizer());
+            }
+
+            @Override
+            protected Reader initReaderForNormalization(String fieldName, Reader reader) {
+                return new StringReader("");
+            }
+        };
+
+        QueryStringQueryParser parser = new QueryStringQueryParser(createShardContext(), TEXT_FIELD_NAME);
+        parser.setAnalyzeWildcard(true);
+        parser.setAllowLeadingWildcard(true);
+        parser.setForceAnalyzer(dropAll);
+
+        assertThat(parser.parse("*foo*"), instanceOf(MatchNoDocsQuery.class));
     }
 
     public void testToQueryWildcardQueryWithSynonyms() throws Exception {


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This PR fixes a `query_string` wildcard query correctness bug where analyzer-stripped wildcard patterns can unintentionally match documents.

Example scenario:
- A user searches with a wildcard pattern such as `*asdf*`.
- The field/search analyzer is configured to keep only digits.
- The literal part of the pattern, `asdf`, is stripped during analysis.
- The remaining wildcard pattern can compile to a match-all automaton.
- As a result, documents with unrelated indexed terms, such as `1234`, can be returned.

Expected behavior:
- If analysis removes all searchable literal content from the wildcard query, the query should not match documents.
- User-typed match-all wildcard patterns such as `*`, `**`, and `***` should continue to behave as match-all patterns.

Fix:
- Detect wildcard queries that analysis turns into Lucene's match-all automaton (`CompiledAutomaton.AUTOMATON_TYPE.ALL`).
- Rewrite those analyzer-induced match-all wildcard queries to `match_no_docs`.
- Preserve user-typed match-all wildcard patterns.
- The guard fires only on `AUTOMATON_TYPE.ALL`, so `?`-based patterns (`?`, `??`, `*?*`, `**?`) compile to `NORMAL` and are unaffected.

### Related Issues
Resolves #21280

### Check List
- [x] Functionality includes testing.
  -  Added regression tests covering analyzer-stripped wildcard queries, configured search analyzers, and preserved user-typed match-all wildcard patterns.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
  -  Not applicable because this change does not modify any REST API request or response specification.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.
  - Not applicable because this is a bug fix with no new user-facing API, setting, or documented behavior to add.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
