### PR TITLE
Fix IndicesRequestCacheCleanupIT flakiness by removing too-short assertBusy timeouts

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/indices/IndicesRequestCacheCleanupIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/IndicesRequestCacheCleanupIT.java
@@ -55,7 +55,6 @@ import org.opensearch.transport.client.Client;
 
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.concurrent.TimeUnit;
 
 import static org.opensearch.indices.IndicesRequestCache.INDICES_REQUEST_CACHE_STALENESS_THRESHOLD_SETTING;
 import static org.opensearch.indices.IndicesService.INDICES_CACHE_CLEANUP_INTERVAL_SETTING_KEY;
@@ -65,8 +64,6 @@ import static org.hamcrest.Matchers.equalTo;
 
 @OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 0, supportsDedicatedMasters = false)
 public class IndicesRequestCacheCleanupIT extends OpenSearchIntegTestCase {
-
-    private static final long MAX_ITERATIONS = 5;
 
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {
@@ -196,7 +193,7 @@ public class IndicesRequestCacheCleanupIT extends OpenSearchIntegTestCase {
             assertEquals(0, getRequestCacheStats(client, index2).getMemorySizeInBytes());
             // cache cleaner should NOT have cleaned from index 1
             assertEquals(finalMemorySizeForIndex1, getRequestCacheStats(client, index1).getMemorySizeInBytes());
-        }, cacheCleanIntervalInMillis * MAX_ITERATIONS, TimeUnit.MILLISECONDS);
+        });
         // sleep until cache cleaner would have cleaned up the stale key from index 2
     }
 
@@ -246,7 +243,7 @@ public class IndicesRequestCacheCleanupIT extends OpenSearchIntegTestCase {
             assertEquals(0, getRequestCacheStats(client, index2).getMemorySizeInBytes());
             // cache cleaner should NOT have cleaned from index 1
             assertEquals(finalMemorySizeForIndex1, getRequestCacheStats(client, index1).getMemorySizeInBytes());
-        }, cacheCleanIntervalInMillis * MAX_ITERATIONS, TimeUnit.MILLISECONDS);
+        });
     }
 
     // when staleness threshold is higher than staleness, it should NOT clean the cache
@@ -294,7 +291,7 @@ public class IndicesRequestCacheCleanupIT extends OpenSearchIntegTestCase {
             assertTrue(getRequestCacheStats(client, index2).getMemorySizeInBytes() > 0);
             // cache cleaner should NOT have cleaned from index 1
             assertEquals(finalMemorySizeForIndex1, getRequestCacheStats(client, index1).getMemorySizeInBytes());
-        }, cacheCleanIntervalInMillis * MAX_ITERATIONS, TimeUnit.MILLISECONDS);
+        });
     }
 
     // when staleness threshold is explicitly set to 0, cache cleaner regularly cleans up stale keys.
@@ -342,7 +339,7 @@ public class IndicesRequestCacheCleanupIT extends OpenSearchIntegTestCase {
             assertEquals(0, getRequestCacheStats(client, index2).getMemorySizeInBytes());
             // cache cleaner should NOT have cleaned from index 1
             assertEquals(finalMemorySizeForIndex1, getRequestCacheStats(client, index1).getMemorySizeInBytes());
-        }, cacheCleanIntervalInMillis * MAX_ITERATIONS, TimeUnit.MILLISECONDS);
+        });
     }
 
     // when staleness threshold is not explicitly set, cache cleaner regularly cleans up stale keys
@@ -389,7 +386,7 @@ public class IndicesRequestCacheCleanupIT extends OpenSearchIntegTestCase {
             assertEquals(0, getRequestCacheStats(client, index2).getMemorySizeInBytes());
             // cache cleaner should NOT have cleaned from index 1
             assertEquals(finalMemorySizeForIndex1, getRequestCacheStats(client, index1).getMemorySizeInBytes());
-        }, cacheCleanIntervalInMillis * MAX_ITERATIONS, TimeUnit.MILLISECONDS);
+        });
     }
 
     // when cache cleaner interval setting is not set, cache cleaner is configured appropriately with the fall-back setting
@@ -433,7 +430,7 @@ public class IndicesRequestCacheCleanupIT extends OpenSearchIntegTestCase {
             assertEquals(0, getRequestCacheStats(client, index2).getMemorySizeInBytes());
             // cache cleaner should NOT have cleaned from index 1
             assertEquals(finalMemorySizeForIndex1, getRequestCacheStats(client, index1).getMemorySizeInBytes());
-        }, cacheCleanIntervalInMillis * MAX_ITERATIONS, TimeUnit.MILLISECONDS);
+        });
     }
 
     // staleness threshold updates flows through to the cache cleaner
@@ -476,7 +473,7 @@ public class IndicesRequestCacheCleanupIT extends OpenSearchIntegTestCase {
         assertBusy(() -> {
             // cache cleaner should NOT have cleaned up the stale key from index 2
             assertTrue(getRequestCacheStats(client, index2).getMemorySizeInBytes() > 0);
-        }, cacheCleanIntervalInMillis * MAX_ITERATIONS, TimeUnit.MILLISECONDS);
+        });
 
         // Update indices.requests.cache.cleanup.staleness_threshold to "10%"
         ClusterUpdateSettingsRequest updateSettingsRequest = new ClusterUpdateSettingsRequest();
@@ -491,7 +488,7 @@ public class IndicesRequestCacheCleanupIT extends OpenSearchIntegTestCase {
             assertEquals(0, getRequestCacheStats(client, index2).getMemorySizeInBytes());
             // cache cleaner should NOT have cleaned from index 1
             assertEquals(finalMemorySizeForIndex1, getRequestCacheStats(client, index1).getMemorySizeInBytes());
-        }, cacheCleanIntervalInMillis * MAX_ITERATIONS, TimeUnit.MILLISECONDS);
+        });
     }
 
     // staleness threshold dynamic updates should throw exceptions on invalid input
@@ -543,7 +540,7 @@ public class IndicesRequestCacheCleanupIT extends OpenSearchIntegTestCase {
         assertBusy(() -> {
             // cache cleaner should have cleaned up the stale keys from index
             assertEquals(0, getNodeCacheStats(client).getMemorySizeInBytes());
-        }, cacheCleanIntervalInMillis * MAX_ITERATIONS, TimeUnit.MILLISECONDS);
+        });
     }
 
     // deleting the Index after caching will clean up from Indices Request Cache
@@ -584,7 +581,7 @@ public class IndicesRequestCacheCleanupIT extends OpenSearchIntegTestCase {
         assertBusy(() -> {
             // cache cleaner should have cleaned up the stale keys from index
             assertEquals(0, getNodeCacheStats(client).getMemorySizeInBytes());
-        }, cacheCleanIntervalInMillis * MAX_ITERATIONS, TimeUnit.MILLISECONDS);
+        });
     }
 
     // when staleness threshold is lower than staleness, it should clean the cache from all indices having stale keys
@@ -629,11 +626,7 @@ public class IndicesRequestCacheCleanupIT extends OpenSearchIntegTestCase {
         indexRandom(false, client.prepareIndex(index1).setId("1").setSource("d", "hello"));
         forceMerge(client, index1);
         // Assert cache is cleared up
-        assertBusy(
-            () -> { assertEquals(0, getRequestCacheStats(client, index1).getMemorySizeInBytes()); },
-            cacheCleanIntervalInMillis * MAX_ITERATIONS,
-            TimeUnit.MILLISECONDS
-        );
+        assertBusy(() -> { assertEquals(0, getRequestCacheStats(client, index1).getMemorySizeInBytes()); });
 
         // invalidate the cache for index2
         indexRandom(false, client.prepareIndex(index2).setId("1").setSource("d", "hello"));
@@ -653,7 +646,7 @@ public class IndicesRequestCacheCleanupIT extends OpenSearchIntegTestCase {
             long currentMemorySizeInBytesForIndex1 = getRequestCacheStats(client, index1).getMemorySizeInBytes();
             // assert the memory size of index1 to only contain 1 entry added after flushAndRefresh
             assertEquals(memorySizeForIndex1With1Entries, currentMemorySizeInBytesForIndex1);
-        }, cacheCleanIntervalInMillis * MAX_ITERATIONS, TimeUnit.MILLISECONDS);
+        });
     }
 
     private void setupIndex(Client client, String index) throws Exception {


### PR DESCRIPTION
### Description

Fixes long-standing flakiness in `IndicesRequestCacheCleanupIT` by removing
too-short custom timeouts on every `assertBusy` call.

**Root cause.** Every `assertBusy` in the file passed
`cacheCleanIntervalInMillis * MAX_ITERATIONS` (with `MAX_ITERATIONS = 5`)
as the wall-clock timeout. The `cacheCleanIntervalInMillis` values set per
test were `1`, `10`, `50`, or `100` ms — yielding timeout budgets of just
**5 ms, 50 ms, 250 ms, or 500 ms** for async cluster operations (flush,
force-merge, scheduled cache-cleanup, stats propagation across nodes).
Under normal CI load these windows are routinely missed; the resulting
`AssertionError` has no race behind it — the test just ran out of time
while the cluster was still converging.

Evidence that this is timeout sizing, not a product race:

- The [historical stack trace in #13503](https://github.com/opensearch-project/OpenSearch/issues/13503)
  shows `AssertionError` at the assertion line, not a timeout/interrupt
  exception.
- Every flaky method AutoCut has filed against this class (see #21397)
  uses the buggy pattern — a 1:1 overlap.
- Locally reproduces as transient timeout under load; green with the
  default 10-s budget.

**Fix.** Drop the custom timeout on all 12 `assertBusy` call sites and
rely on `assertBusy`'s default 10-second budget, which is the convention
elsewhere in the codebase for async cluster assertions. Also remove the
now-unused `MAX_ITERATIONS` constant and `java.util.concurrent.TimeUnit`
import.

Why this is safe for the "negative" tests (e.g.
`testCacheCleanupSkipsWithHighStalenessThreshold`, which asserts cleanup
did **not** happen): `assertBusy` returns on the first successful
iteration, so the 10-s budget is a no-op on passing runs — it only
extends the failure path.

`cacheCleanIntervalInMillis` values themselves are unchanged — they
legitimately configure the cleaner thread cadence so the test can observe
cleanup quickly; only the test's wall-clock deadline was wrong.

### Related Issues
Relates to #21397

### Verification

Ran locally on the modified file against a fresh `main`:

```
./gradlew :server:internalClusterTest \
  --tests "...IndicesRequestCacheCleanupIT.testCacheCleanupOnEqualStalenessAndThreshold" \
  -Dtests.iters=10
# BUILD SUCCESSFUL (10/10)

./gradlew :server:internalClusterTest \
  --tests "...testStaleKeysCleanupWithLowThreshold" \
  --tests "...testCacheCleanupSkipsWithHighStalenessThreshold" \
  --tests "...testStaleKeysRemovalWithoutExplicitThreshold" \
  -Dtests.iters=5
# BUILD SUCCESSFUL (15/15)
```

25 consecutive passes across 4 of the previously-flaky methods.

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
