### PR TITLE
Fix waitForReplication race with INITIALIZING replicas

### DIFF
--- a/test/framework/src/main/java/org/opensearch/test/OpenSearchIntegTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/test/OpenSearchIntegTestCase.java
@@ -83,6 +83,7 @@ import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.cluster.routing.IndexRoutingTable;
 import org.opensearch.cluster.routing.IndexShardRoutingTable;
 import org.opensearch.cluster.routing.ShardRouting;
+import org.opensearch.cluster.routing.ShardRoutingState;
 import org.opensearch.cluster.routing.UnassignedInfo;
 import org.opensearch.cluster.routing.allocation.AwarenessReplicaBalance;
 import org.opensearch.cluster.routing.allocation.DiskThresholdSettings;
@@ -2552,38 +2553,35 @@ public abstract class OpenSearchIntegTestCase extends OpenSearchTestCase {
         try {
             for (String index : indices) {
                 if (isSegmentReplicationEnabledForIndex(index)) {
-                    if (isInternalCluster()) {
+                    assertTrue("Unable to wait for replication with external test cluster", isInternalCluster());
+                    assertBusy(() -> {
                         IndexRoutingTable indexRoutingTable = getClusterState().routingTable().index(index);
                         if (indexRoutingTable != null) {
-                            assertBusy(() -> {
-                                for (IndexShardRoutingTable shardRoutingTable : indexRoutingTable) {
-                                    final ShardRouting primaryRouting = shardRoutingTable.primaryShard();
-                                    if (primaryRouting.state().toString().equals("STARTED")) {
-                                        if (isSegmentReplicationEnabledForIndex(index)) {
-                                            final List<ShardRouting> replicaRouting = shardRoutingTable.replicaShards();
-                                            final IndexShard primaryShard = getIndexShard(primaryRouting, index);
-                                            for (ShardRouting replica : replicaRouting) {
-                                                if (replica.state().toString().equals("STARTED")) {
-                                                    IndexShard replicaShard = getIndexShard(replica, index);
-                                                    if (replicaShard.indexSettings().isSegRepEnabledOrRemoteNode()) {
-                                                        assertEquals(
-                                                            "replica shards haven't caught up with primary",
-                                                            getLatestSegmentInfoVersion(primaryShard),
-                                                            getLatestSegmentInfoVersion(replicaShard)
-                                                        );
-                                                    }
+                            for (IndexShardRoutingTable shardRoutingTable : indexRoutingTable) {
+                                final ShardRouting primaryRouting = shardRoutingTable.primaryShard();
+                                if (primaryRouting.state() == ShardRoutingState.STARTED) {
+                                    if (isSegmentReplicationEnabledForIndex(index)) {
+                                        final List<ShardRouting> replicaRouting = shardRoutingTable.replicaShards();
+                                        final IndexShard primaryShard = getIndexShard(primaryRouting, index);
+                                        for (ShardRouting replica : replicaRouting) {
+                                            if (replica.state() == ShardRoutingState.STARTED) {
+                                                IndexShard replicaShard = getIndexShard(replica, index);
+                                                if (replicaShard.indexSettings().isSegRepEnabledOrRemoteNode()) {
+                                                    assertEquals(
+                                                        "replica shards haven't caught up with primary",
+                                                        getLatestSegmentInfoVersion(primaryShard),
+                                                        getLatestSegmentInfoVersion(replicaShard)
+                                                    );
                                                 }
+                                            } else if (replica.state() == ShardRoutingState.INITIALIZING) {
+                                                fail("replica shard still INITIALIZING, not caught up with primary");
                                             }
                                         }
                                     }
                                 }
-                            }, 30, TimeUnit.SECONDS);
+                            }
                         }
-                    } else {
-                        throw new IllegalStateException(
-                            "Segment Replication is not supported for testing tests using External Test Cluster"
-                        );
-                    }
+                    }, 30, TimeUnit.SECONDS);
                 }
             }
         } catch (Exception e) {


### PR DESCRIPTION
Previously the waitForReplication() test helper would only check if STARTED shards had caught up. However, we should wait for INITIALIZING replicas to catch up as well since they will be stale immediately after they transition to STARTED. This change also pulls a fresh cluster state in each assertBusy iteration to ensure it gets the latest shard state.

I have some evidence that this will fix the race in [IndexActionIT](#21381) but I'm not 100% sure. This fix seems correct on the merits though.

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
