### PR TITLE
Grpc client poc

### DIFF
--- a/modules/transport-grpc/src/main/java/org/opensearch/transport/grpc/proto/request/document/bulk/BulkProtoConverter.java
+++ b/modules/transport-grpc/src/main/java/org/opensearch/transport/grpc/proto/request/document/bulk/BulkProtoConverter.java
@@ -1,0 +1,274 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.transport.grpc.proto.request.document.bulk;
+
+import com.google.protobuf.ByteString;
+import org.opensearch.action.DocWriteRequest;
+import org.opensearch.action.bulk.BulkRequest;
+import org.opensearch.action.delete.DeleteRequest;
+import org.opensearch.action.index.IndexRequest;
+import org.opensearch.action.support.ActiveShardCount;
+import org.opensearch.action.support.WriteRequest.RefreshPolicy;
+import org.opensearch.action.update.UpdateRequest;
+import org.opensearch.core.common.bytes.BytesArray;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.index.VersionType;
+import org.opensearch.index.seqno.SequenceNumbers;
+
+/**
+ * Converts a server-internal {@link BulkRequest} into a {@code protobufs.BulkRequest}.
+ *
+ * <p>This is the inverse of {@link BulkRequestProtoUtils#prepareRequest}, which lives next door and translates the same
+ * proto type back into a server-internal {@code BulkRequest}. Co-locating both directions enables round-trip parity tests
+ * that catch divergence as the schema evolves.
+ *
+ * <p>This converter exists so client libraries (HLRC's API model, opensearch-java in the future) can take a server-internal
+ * request object and emit a proto for transmission over gRPC. The cluster-side code already in this module then consumes
+ * that proto and reconstructs the server-internal object.
+ *
+ * <p><b>Canonicalization rules</b> (chosen so {@code prepareRequest(toProto(s))} reconstructs an equivalent
+ * {@code BulkRequest}):
+ * <ul>
+ *   <li>{@link RefreshPolicy#NONE} maps to proto unset (default {@code REFRESH_UNSPECIFIED}); the forward path treats both
+ *       {@code REFRESH_FALSE} and {@code REFRESH_UNSPECIFIED} as {@code RefreshPolicy.NONE}, so we pick the unset form.</li>
+ *   <li>{@link VersionType#INTERNAL} (server default) maps to proto unset.</li>
+ *   <li>{@link ActiveShardCount#DEFAULT} maps to proto unset.</li>
+ *   <li>Unassigned {@code ifSeqNo} / {@code ifPrimaryTerm} are not emitted.</li>
+ *   <li>{@code Versions.MATCH_ANY} is not emitted as a {@code version} field.</li>
+ *   <li>Server {@code globalIndex} / {@code globalRouting} / {@code globalPipeline} / {@code globalRequireAlias} are not
+ *       carried — the forward path inlines top-level proto defaults into per-row requests at parse time and never reads
+ *       these slots back, so the round-trippable form is per-row only.</li>
+ *   <li>A {@code CREATE} op type with version control is emitted as {@code IndexOperation} with {@code op_type=CREATE},
+ *       since {@code WriteOperation} (the dedicated CREATE proto) lacks those fields in the current schema.</li>
+ * </ul>
+ */
+public final class BulkProtoConverter {
+
+    private BulkProtoConverter() {}
+
+    /**
+     * Converts a server-internal {@link BulkRequest} to its protobuf equivalent.
+     *
+     * @param serverBulk the request to convert
+     * @return the equivalent {@code protobufs.BulkRequest}
+     */
+    public static org.opensearch.protobufs.BulkRequest toProto(BulkRequest serverBulk) {
+        org.opensearch.protobufs.BulkRequest.Builder builder = org.opensearch.protobufs.BulkRequest.newBuilder();
+
+        if (serverBulk.timeout() != null) {
+            builder.setTimeout(serverBulk.timeout().getStringRep());
+        }
+
+        org.opensearch.protobufs.Refresh refresh = toProtoRefresh(serverBulk.getRefreshPolicy());
+        if (refresh != null) {
+            builder.setRefresh(refresh);
+        }
+
+        org.opensearch.protobufs.WaitForActiveShards was = toProtoWaitForActiveShards(serverBulk.waitForActiveShards());
+        if (was != null) {
+            builder.setWaitForActiveShards(was);
+        }
+
+        for (DocWriteRequest<?> req : serverBulk.requests()) {
+            builder.addBulkRequestBody(toRequestBody(req));
+        }
+
+        return builder.build();
+    }
+
+    private static org.opensearch.protobufs.BulkRequestBody toRequestBody(DocWriteRequest<?> req) {
+        org.opensearch.protobufs.BulkRequestBody.Builder body = org.opensearch.protobufs.BulkRequestBody.newBuilder();
+        org.opensearch.protobufs.OperationContainer.Builder container = org.opensearch.protobufs.OperationContainer.newBuilder();
+
+        if (req instanceof IndexRequest) {
+            IndexRequest indexReq = (IndexRequest) req;
+            if (indexReq.opType() == DocWriteRequest.OpType.CREATE) {
+                if (hasVersionControl(indexReq)) {
+                    container.setIndex(toIndexOperation(indexReq, true));
+                } else {
+                    container.setCreate(toCreateWriteOperation(indexReq));
+                }
+            } else {
+                container.setIndex(toIndexOperation(indexReq, false));
+            }
+            body.setOperationContainer(container);
+            attachSource(body, indexReq.source());
+        } else if (req instanceof UpdateRequest) {
+            UpdateRequest updateReq = (UpdateRequest) req;
+            container.setUpdate(toUpdateOperation(updateReq));
+            body.setOperationContainer(container);
+            body.setUpdateAction(buildUpdateAction(updateReq));
+            // The forward parser reads update doc bytes from BulkRequestBody.object and ignores
+            // UpdateAction.doc; mirror that here so the round trip is clean.
+            if (updateReq.doc() != null && updateReq.doc().source() != null) {
+                body.setObject(toByteString(updateReq.doc().source()));
+            }
+        } else if (req instanceof DeleteRequest) {
+            DeleteRequest deleteReq = (DeleteRequest) req;
+            container.setDelete(toDeleteOperation(deleteReq));
+            body.setOperationContainer(container);
+        } else {
+            throw new IllegalStateException("unsupported DocWriteRequest type: " + req.getClass());
+        }
+
+        return body.build();
+    }
+
+    private static boolean hasVersionControl(IndexRequest req) {
+        // For CREATE op type with no explicit version, IndexRequest.version() returns
+        // Versions.MATCH_DELETED rather than MATCH_ANY (see IndexRequest#resolveVersionDefaults).
+        // Treat both as "no explicit version requested".
+        long v = req.version();
+        boolean explicitVersion = v != org.opensearch.common.lucene.uid.Versions.MATCH_ANY
+            && v != org.opensearch.common.lucene.uid.Versions.MATCH_DELETED;
+        return explicitVersion
+            || (req.versionType() != null && req.versionType() != VersionType.INTERNAL)
+            || req.ifSeqNo() != SequenceNumbers.UNASSIGNED_SEQ_NO
+            || req.ifPrimaryTerm() != SequenceNumbers.UNASSIGNED_PRIMARY_TERM;
+    }
+
+    private static org.opensearch.protobufs.IndexOperation toIndexOperation(IndexRequest req, boolean isCreate) {
+        org.opensearch.protobufs.IndexOperation.Builder b = org.opensearch.protobufs.IndexOperation.newBuilder();
+
+        if (req.index() != null) b.setXIndex(req.index());
+        if (req.id() != null) b.setXId(req.id());
+        if (req.routing() != null) b.setRouting(req.routing());
+        if (req.getPipeline() != null) b.setPipeline(req.getPipeline());
+        if (req.isRequireAlias()) b.setRequireAlias(true);
+        if (isCreate) b.setOpType(org.opensearch.protobufs.OpType.OP_TYPE_CREATE);
+
+        long v = req.version();
+        if (v != org.opensearch.common.lucene.uid.Versions.MATCH_ANY && v != org.opensearch.common.lucene.uid.Versions.MATCH_DELETED) {
+            b.setVersion(v);
+        }
+        org.opensearch.protobufs.VersionType vt = toProtoVersionType(req.versionType());
+        if (vt != null) b.setVersionType(vt);
+        if (req.ifSeqNo() != SequenceNumbers.UNASSIGNED_SEQ_NO) b.setIfSeqNo(req.ifSeqNo());
+        if (req.ifPrimaryTerm() != SequenceNumbers.UNASSIGNED_PRIMARY_TERM) b.setIfPrimaryTerm(req.ifPrimaryTerm());
+
+        return b.build();
+    }
+
+    private static org.opensearch.protobufs.WriteOperation toCreateWriteOperation(IndexRequest req) {
+        org.opensearch.protobufs.WriteOperation.Builder b = org.opensearch.protobufs.WriteOperation.newBuilder();
+
+        if (req.index() != null) b.setXIndex(req.index());
+        if (req.id() != null) b.setXId(req.id());
+        if (req.routing() != null) b.setRouting(req.routing());
+        if (req.getPipeline() != null) b.setPipeline(req.getPipeline());
+        if (req.isRequireAlias()) b.setRequireAlias(true);
+        // WriteOperation has no version / versionType / ifSeqNo / ifPrimaryTerm in the proto schema.
+
+        return b.build();
+    }
+
+    private static org.opensearch.protobufs.UpdateOperation toUpdateOperation(UpdateRequest req) {
+        org.opensearch.protobufs.UpdateOperation.Builder b = org.opensearch.protobufs.UpdateOperation.newBuilder();
+
+        if (req.index() != null) b.setXIndex(req.index());
+        if (req.id() != null) b.setXId(req.id());
+        if (req.routing() != null) b.setRouting(req.routing());
+        if (req.isRequireAlias()) b.setRequireAlias(true);
+        if (req.retryOnConflict() > 0) b.setRetryOnConflict(req.retryOnConflict());
+
+        if (req.ifSeqNo() != SequenceNumbers.UNASSIGNED_SEQ_NO) b.setIfSeqNo(req.ifSeqNo());
+        if (req.ifPrimaryTerm() != SequenceNumbers.UNASSIGNED_PRIMARY_TERM) b.setIfPrimaryTerm(req.ifPrimaryTerm());
+
+        return b.build();
+    }
+
+    private static org.opensearch.protobufs.DeleteOperation toDeleteOperation(DeleteRequest req) {
+        org.opensearch.protobufs.DeleteOperation.Builder b = org.opensearch.protobufs.DeleteOperation.newBuilder();
+
+        if (req.index() != null) b.setXIndex(req.index());
+        if (req.id() != null) b.setXId(req.id());
+        if (req.routing() != null) b.setRouting(req.routing());
+
+        if (req.version() != org.opensearch.common.lucene.uid.Versions.MATCH_ANY) {
+            b.setVersion(req.version());
+        }
+        org.opensearch.protobufs.VersionType vt = toProtoVersionType(req.versionType());
+        if (vt != null) b.setVersionType(vt);
+        if (req.ifSeqNo() != SequenceNumbers.UNASSIGNED_SEQ_NO) b.setIfSeqNo(req.ifSeqNo());
+        if (req.ifPrimaryTerm() != SequenceNumbers.UNASSIGNED_PRIMARY_TERM) b.setIfPrimaryTerm(req.ifPrimaryTerm());
+
+        return b.build();
+    }
+
+    private static void attachSource(org.opensearch.protobufs.BulkRequestBody.Builder body, BytesReference source) {
+        if (source != null && source.length() > 0) {
+            body.setObject(toByteString(source));
+        }
+    }
+
+    private static org.opensearch.protobufs.UpdateAction buildUpdateAction(UpdateRequest req) {
+        org.opensearch.protobufs.UpdateAction.Builder action = org.opensearch.protobufs.UpdateAction.newBuilder();
+
+        // Note: doc bytes go on BulkRequestBody.object, not UpdateAction.doc; see toRequestBody.
+        if (req.upsertRequest() != null && req.upsertRequest().source() != null) {
+            action.setUpsert(toByteString(req.upsertRequest().source()));
+        }
+        if (req.docAsUpsert()) action.setDocAsUpsert(true);
+        if (req.scriptedUpsert()) action.setScriptedUpsert(true);
+        if (req.detectNoop() == false) action.setDetectNoop(false); // server default is true
+        // Script support deferred — the Script proto is a non-trivial subgraph.
+
+        return action.build();
+    }
+
+    private static ByteString toByteString(BytesReference bytes) {
+        BytesArray ba = (bytes instanceof BytesArray) ? (BytesArray) bytes : new BytesArray(bytes.toBytesRef());
+        return ByteString.copyFrom(ba.array(), ba.offset(), ba.length());
+    }
+
+    private static org.opensearch.protobufs.Refresh toProtoRefresh(RefreshPolicy policy) {
+        if (policy == null || policy == RefreshPolicy.NONE) return null;
+        switch (policy) {
+            case IMMEDIATE:
+                return org.opensearch.protobufs.Refresh.REFRESH_TRUE;
+            case WAIT_UNTIL:
+                return org.opensearch.protobufs.Refresh.REFRESH_WAIT_FOR;
+            default:
+                return null;
+        }
+    }
+
+    private static org.opensearch.protobufs.VersionType toProtoVersionType(VersionType vt) {
+        if (vt == null || vt == VersionType.INTERNAL) return null;
+        switch (vt) {
+            case EXTERNAL:
+                return org.opensearch.protobufs.VersionType.VERSION_TYPE_EXTERNAL;
+            case EXTERNAL_GTE:
+                return org.opensearch.protobufs.VersionType.VERSION_TYPE_EXTERNAL_GTE;
+            default:
+                return null;
+        }
+    }
+
+    private static org.opensearch.protobufs.WaitForActiveShards toProtoWaitForActiveShards(ActiveShardCount count) {
+        if (count == null || count == ActiveShardCount.DEFAULT) return null;
+        org.opensearch.protobufs.WaitForActiveShards.Builder b = org.opensearch.protobufs.WaitForActiveShards.newBuilder();
+        if (count == ActiveShardCount.ALL) {
+            b.setOption(org.opensearch.protobufs.WaitForActiveShardOptions.WAIT_FOR_ACTIVE_SHARD_OPTIONS_ALL);
+        } else {
+            b.setCount(parseActiveShardCount(count));
+        }
+        return b.build();
+    }
+
+    private static int parseActiveShardCount(ActiveShardCount count) {
+        if (count == ActiveShardCount.NONE) return 0;
+        if (count == ActiveShardCount.ONE) return 1;
+        try {
+            return Integer.parseInt(count.toString());
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("unexpected ActiveShardCount: " + count, e);
+        }
+    }
+}

--- a/modules/transport-grpc/src/main/java/org/opensearch/transport/grpc/proto/request/document/bulk/BulkProtoConverter.java
+++ b/modules/transport-grpc/src/main/java/org/opensearch/transport/grpc/proto/request/document/bulk/BulkProtoConverter.java
@@ -16,7 +16,6 @@ import org.opensearch.action.index.IndexRequest;
 import org.opensearch.action.support.ActiveShardCount;
 import org.opensearch.action.support.WriteRequest.RefreshPolicy;
 import org.opensearch.action.update.UpdateRequest;
-import org.opensearch.core.common.bytes.BytesArray;
 import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.index.VersionType;
 import org.opensearch.index.seqno.SequenceNumbers;
@@ -104,11 +103,6 @@ public final class BulkProtoConverter {
             container.setUpdate(toUpdateOperation(updateReq));
             body.setOperationContainer(container);
             body.setUpdateAction(buildUpdateAction(updateReq));
-            // The forward parser reads update doc bytes from BulkRequestBody.object and ignores
-            // UpdateAction.doc; mirror that here so the round trip is clean.
-            if (updateReq.doc() != null && updateReq.doc().source() != null) {
-                body.setObject(toByteString(updateReq.doc().source()));
-            }
         } else if (req instanceof DeleteRequest) {
             DeleteRequest deleteReq = (DeleteRequest) req;
             container.setDelete(toDeleteOperation(deleteReq));
@@ -210,21 +204,25 @@ public final class BulkProtoConverter {
     private static org.opensearch.protobufs.UpdateAction buildUpdateAction(UpdateRequest req) {
         org.opensearch.protobufs.UpdateAction.Builder action = org.opensearch.protobufs.UpdateAction.newBuilder();
 
-        // Note: doc bytes go on BulkRequestBody.object, not UpdateAction.doc; see toRequestBody.
+        if (req.doc() != null && req.doc().source() != null) {
+            action.setDoc(toByteString(req.doc().source()));
+        }
         if (req.upsertRequest() != null && req.upsertRequest().source() != null) {
             action.setUpsert(toByteString(req.upsertRequest().source()));
         }
         if (req.docAsUpsert()) action.setDocAsUpsert(true);
         if (req.scriptedUpsert()) action.setScriptedUpsert(true);
         if (req.detectNoop() == false) action.setDetectNoop(false); // server default is true
-        // Script support deferred — the Script proto is a non-trivial subgraph.
+        if (req.script() != null) {
+            throw new UnsupportedOperationException("Script in update requests is not yet supported by the gRPC converter");
+        }
 
         return action.build();
     }
 
     private static ByteString toByteString(BytesReference bytes) {
-        BytesArray ba = (bytes instanceof BytesArray) ? (BytesArray) bytes : new BytesArray(bytes.toBytesRef());
-        return ByteString.copyFrom(ba.array(), ba.offset(), ba.length());
+        org.apache.lucene.util.BytesRef ref = bytes.toBytesRef();
+        return ByteString.copyFrom(ref.bytes, ref.offset, ref.length);
     }
 
     private static org.opensearch.protobufs.Refresh toProtoRefresh(RefreshPolicy policy) {

--- a/modules/transport-grpc/src/main/java/org/opensearch/transport/grpc/proto/request/search/SearchProtoConverter.java
+++ b/modules/transport-grpc/src/main/java/org/opensearch/transport/grpc/proto/request/search/SearchProtoConverter.java
@@ -1,0 +1,182 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.transport.grpc.proto.request.search;
+
+import org.apache.lucene.util.BytesRef;
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.index.query.MatchAllQueryBuilder;
+import org.opensearch.index.query.MatchNoneQueryBuilder;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.TermQueryBuilder;
+import org.opensearch.index.query.TermsQueryBuilder;
+import org.opensearch.indices.TermsLookup;
+import org.opensearch.search.builder.SearchSourceBuilder;
+
+/**
+ * Converts a server-internal {@link SearchRequest} into a {@code protobufs.SearchRequest}.
+ *
+ * <p>This is the inverse of {@link SearchRequestProtoUtils#prepareRequest}, which lives next door. Co-locating both
+ * directions enables round-trip parity tests that catch divergence as the schema evolves.
+ *
+ * <p><b>Current scope</b> (intentionally narrow for the PoC):
+ * <ul>
+ *   <li>Top-level {@code indices}.</li>
+ *   <li>Body fields: {@code from}, {@code size}, {@code query}.</li>
+ *   <li>Query types: {@code match_all}, {@code match_none}, {@code term}, {@code terms} — the four query types currently
+ *       wired up on the cluster's gRPC parsing path. Anything else throws {@link UnsupportedOperationException}.</li>
+ * </ul>
+ *
+ * <p>The full {@code SearchRequest} surface (indices_options, routing, preference, scroll, search_type, aggregations,
+ * sort, suggest, source filtering, highlight, …) is not covered here.
+ */
+public final class SearchProtoConverter {
+
+    private SearchProtoConverter() {}
+
+    /**
+     * Converts a server-internal {@link SearchRequest} to its protobuf equivalent.
+     *
+     * @param serverReq the request to convert
+     * @return the equivalent {@code protobufs.SearchRequest}
+     * @throws UnsupportedOperationException if the body uses a query type not yet supported by this converter
+     */
+    public static org.opensearch.protobufs.SearchRequest toProto(SearchRequest serverReq) {
+        org.opensearch.protobufs.SearchRequest.Builder builder = org.opensearch.protobufs.SearchRequest.newBuilder();
+
+        if (serverReq.indices() != null) {
+            for (String idx : serverReq.indices()) {
+                builder.addIndex(idx);
+            }
+        }
+
+        SearchSourceBuilder src = serverReq.source();
+        if (src != null) {
+            builder.setSearchRequestBody(toProtoBody(src));
+        }
+
+        return builder.build();
+    }
+
+    private static org.opensearch.protobufs.SearchRequestBody toProtoBody(SearchSourceBuilder src) {
+        org.opensearch.protobufs.SearchRequestBody.Builder body = org.opensearch.protobufs.SearchRequestBody.newBuilder();
+
+        if (src.from() >= 0) body.setFrom(src.from());
+        if (src.size() >= 0) body.setSize(src.size());
+
+        QueryBuilder q = src.query();
+        if (q != null) {
+            body.setQuery(toProtoQuery(q));
+        }
+        // Sort, source filtering, highlight, aggs, etc. are deliberately not handled here.
+        return body.build();
+    }
+
+    private static org.opensearch.protobufs.QueryContainer toProtoQuery(QueryBuilder q) {
+        org.opensearch.protobufs.QueryContainer.Builder container = org.opensearch.protobufs.QueryContainer.newBuilder();
+
+        if (q instanceof MatchAllQueryBuilder) {
+            container.setMatchAll(toMatchAll((MatchAllQueryBuilder) q));
+        } else if (q instanceof MatchNoneQueryBuilder) {
+            container.setMatchNone(toMatchNone((MatchNoneQueryBuilder) q));
+        } else if (q instanceof TermQueryBuilder) {
+            container.setTerm(toTerm((TermQueryBuilder) q));
+        } else if (q instanceof TermsQueryBuilder) {
+            container.setTerms(toTerms((TermsQueryBuilder) q));
+        } else {
+            throw new UnsupportedOperationException("query type not yet supported: " + q.getClass().getSimpleName());
+        }
+
+        return container.build();
+    }
+
+    private static org.opensearch.protobufs.MatchAllQuery toMatchAll(MatchAllQueryBuilder ma) {
+        org.opensearch.protobufs.MatchAllQuery.Builder b = org.opensearch.protobufs.MatchAllQuery.newBuilder();
+        if (ma.boost() != 1.0f) b.setBoost(ma.boost());
+        if (ma.queryName() != null) b.setXName(ma.queryName());
+        return b.build();
+    }
+
+    private static org.opensearch.protobufs.MatchNoneQuery toMatchNone(MatchNoneQueryBuilder mn) {
+        org.opensearch.protobufs.MatchNoneQuery.Builder b = org.opensearch.protobufs.MatchNoneQuery.newBuilder();
+        if (mn.boost() != 1.0f) b.setBoost(mn.boost());
+        if (mn.queryName() != null) b.setXName(mn.queryName());
+        return b.build();
+    }
+
+    private static org.opensearch.protobufs.TermQuery toTerm(TermQueryBuilder tq) {
+        org.opensearch.protobufs.TermQuery.Builder b = org.opensearch.protobufs.TermQuery.newBuilder()
+            .setField(tq.fieldName())
+            .setValue(toFieldValue(tq.value()));
+        if (tq.boost() != 1.0f) b.setBoost(tq.boost());
+        if (tq.queryName() != null) b.setXName(tq.queryName());
+        if (tq.caseInsensitive()) b.setCaseInsensitive(true);
+        return b.build();
+    }
+
+    private static org.opensearch.protobufs.TermsQuery toTerms(TermsQueryBuilder tsq) {
+        org.opensearch.protobufs.TermsQuery.Builder b = org.opensearch.protobufs.TermsQuery.newBuilder();
+        if (tsq.boost() != 1.0f) b.setBoost(tsq.boost());
+        if (tsq.queryName() != null) b.setXName(tsq.queryName());
+
+        org.opensearch.protobufs.TermsQueryField.Builder field = org.opensearch.protobufs.TermsQueryField.newBuilder();
+        if (tsq.termsLookup() != null) {
+            field.setLookup(toTermsLookup(tsq.termsLookup()));
+        } else {
+            org.opensearch.protobufs.FieldValueArray.Builder arr = org.opensearch.protobufs.FieldValueArray.newBuilder();
+            for (Object v : tsq.values()) {
+                arr.addFieldValueArray(toFieldValue(v));
+            }
+            field.setValue(arr);
+        }
+        b.putTerms(tsq.fieldName(), field.build());
+        return b.build();
+    }
+
+    private static org.opensearch.protobufs.TermsLookup toTermsLookup(TermsLookup lookup) {
+        org.opensearch.protobufs.TermsLookup.Builder b = org.opensearch.protobufs.TermsLookup.newBuilder()
+            .setIndex(lookup.index())
+            .setId(lookup.id())
+            .setPath(lookup.path());
+        if (lookup.routing() != null) b.setRouting(lookup.routing());
+        return b.build();
+    }
+
+    /**
+     * Converts an arbitrary value to a proto {@code FieldValue}. Server-side query builders carry values as
+     * {@link Object}; concrete types are {@code String}, {@code Long}, {@code Integer}, {@code Double}, {@code Float},
+     * {@code Boolean}, or {@link BytesRef}. {@code BytesRef} is unwrapped to its UTF-8 string form, since the proto
+     * forward parser does not accept it directly.
+     *
+     * @throws IllegalArgumentException if {@code value} is none of the supported runtime types
+     */
+    private static org.opensearch.protobufs.FieldValue toFieldValue(Object value) {
+        org.opensearch.protobufs.FieldValue.Builder b = org.opensearch.protobufs.FieldValue.newBuilder();
+        if (value == null) {
+            b.setNullValue(org.opensearch.protobufs.NullValue.NULL_VALUE_NULL);
+        } else if (value instanceof BytesRef) {
+            b.setString(((BytesRef) value).utf8ToString());
+        } else if (value instanceof String) {
+            b.setString((String) value);
+        } else if (value instanceof Boolean) {
+            b.setBool((Boolean) value);
+        } else if (value instanceof Number) {
+            Number num = (Number) value;
+            org.opensearch.protobufs.GeneralNumber.Builder n = org.opensearch.protobufs.GeneralNumber.newBuilder();
+            if (num instanceof Long || num instanceof Integer || num instanceof Short || num instanceof Byte) {
+                n.setInt64Value(num.longValue());
+            } else {
+                n.setDoubleValue(num.doubleValue());
+            }
+            b.setGeneralNumber(n);
+        } else {
+            throw new IllegalArgumentException("unsupported FieldValue type: " + value.getClass().getName());
+        }
+        return b.build();
+    }
+}

--- a/modules/transport-grpc/src/main/java/org/opensearch/transport/grpc/proto/request/search/SearchProtoConverter.java
+++ b/modules/transport-grpc/src/main/java/org/opensearch/transport/grpc/proto/request/search/SearchProtoConverter.java
@@ -17,6 +17,7 @@ import org.opensearch.index.query.TermQueryBuilder;
 import org.opensearch.index.query.TermsQueryBuilder;
 import org.opensearch.indices.TermsLookup;
 import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.transport.grpc.proto.response.common.FieldValueProtoUtils;
 
 /**
  * Converts a server-internal {@link SearchRequest} into a {@code protobufs.SearchRequest}.
@@ -135,7 +136,20 @@ public final class SearchProtoConverter {
             field.setValue(arr);
         }
         b.putTerms(tsq.fieldName(), field.build());
+
+        if (tsq.valueType() != null && tsq.valueType() != TermsQueryBuilder.ValueType.DEFAULT) {
+            b.setValueType(toProtoTermsValueType(tsq.valueType()));
+        }
         return b.build();
+    }
+
+    private static org.opensearch.protobufs.TermsQueryValueType toProtoTermsValueType(TermsQueryBuilder.ValueType vt) {
+        switch (vt) {
+            case BITMAP:
+                return org.opensearch.protobufs.TermsQueryValueType.TERMS_QUERY_VALUE_TYPE_BITMAP;
+            default:
+                return org.opensearch.protobufs.TermsQueryValueType.TERMS_QUERY_VALUE_TYPE_DEFAULT;
+        }
     }
 
     private static org.opensearch.protobufs.TermsLookup toTermsLookup(TermsLookup lookup) {
@@ -147,36 +161,15 @@ public final class SearchProtoConverter {
         return b.build();
     }
 
-    /**
-     * Converts an arbitrary value to a proto {@code FieldValue}. Server-side query builders carry values as
-     * {@link Object}; concrete types are {@code String}, {@code Long}, {@code Integer}, {@code Double}, {@code Float},
-     * {@code Boolean}, or {@link BytesRef}. {@code BytesRef} is unwrapped to its UTF-8 string form, since the proto
-     * forward parser does not accept it directly.
-     *
-     * @throws IllegalArgumentException if {@code value} is none of the supported runtime types
-     */
     private static org.opensearch.protobufs.FieldValue toFieldValue(Object value) {
-        org.opensearch.protobufs.FieldValue.Builder b = org.opensearch.protobufs.FieldValue.newBuilder();
         if (value == null) {
-            b.setNullValue(org.opensearch.protobufs.NullValue.NULL_VALUE_NULL);
-        } else if (value instanceof BytesRef) {
-            b.setString(((BytesRef) value).utf8ToString());
-        } else if (value instanceof String) {
-            b.setString((String) value);
-        } else if (value instanceof Boolean) {
-            b.setBool((Boolean) value);
-        } else if (value instanceof Number) {
-            Number num = (Number) value;
-            org.opensearch.protobufs.GeneralNumber.Builder n = org.opensearch.protobufs.GeneralNumber.newBuilder();
-            if (num instanceof Long || num instanceof Integer || num instanceof Short || num instanceof Byte) {
-                n.setInt64Value(num.longValue());
-            } else {
-                n.setDoubleValue(num.doubleValue());
-            }
-            b.setGeneralNumber(n);
-        } else {
-            throw new IllegalArgumentException("unsupported FieldValue type: " + value.getClass().getName());
+            return org.opensearch.protobufs.FieldValue.newBuilder()
+                .setNullValue(org.opensearch.protobufs.NullValue.NULL_VALUE_NULL)
+                .build();
         }
-        return b.build();
+        if (value instanceof BytesRef) {
+            return FieldValueProtoUtils.toProto(((BytesRef) value).utf8ToString());
+        }
+        return FieldValueProtoUtils.toProto(value);
     }
 }

--- a/modules/transport-grpc/src/main/java/org/opensearch/transport/grpc/proto/response/document/bulk/BulkResponseProtoConverter.java
+++ b/modules/transport-grpc/src/main/java/org/opensearch/transport/grpc/proto/response/document/bulk/BulkResponseProtoConverter.java
@@ -1,0 +1,172 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.transport.grpc.proto.response.document.bulk;
+
+import org.opensearch.OpenSearchException;
+import org.opensearch.action.DocWriteRequest;
+import org.opensearch.action.DocWriteResponse;
+import org.opensearch.action.bulk.BulkItemResponse;
+import org.opensearch.action.bulk.BulkResponse;
+import org.opensearch.action.delete.DeleteResponse;
+import org.opensearch.action.index.IndexResponse;
+import org.opensearch.action.support.replication.ReplicationResponse;
+import org.opensearch.action.update.UpdateResponse;
+import org.opensearch.core.index.Index;
+import org.opensearch.core.index.shard.ShardId;
+import org.opensearch.protobufs.Item;
+import org.opensearch.protobufs.ResponseItem;
+
+/**
+ * Converts a {@code protobufs.BulkResponse} (received over gRPC) into the server-internal {@link BulkResponse}.
+ *
+ * <p>This is the inverse of {@link BulkResponseProtoUtils} which lives next door. Co-locating both directions enables a
+ * round-trip parity test that catches divergence as the schema evolves.
+ *
+ * <p><b>Known lossy conversions</b> (limitations of the proto schema, not bugs in this converter):
+ * <ul>
+ *   <li>Proto carries no shard UUID or shard id, so each item is given a placeholder
+ *       {@link ShardId} ({@link Index} uuid {@code "_na_"}, shard id {@code -1}).</li>
+ *   <li>The wire-level {@code status} (a REST status int) is many-to-one with {@link DocWriteResponse.Result}; we derive
+ *       the {@code Result} enum from the {@code result} string field and let the response object compute its own status.</li>
+ *   <li>Failure subclasses are unrecoverable from the proto representation: every failure becomes a
+ *       {@link BulkItemResponse.Failure} backed by {@link OpenSearchException} regardless of the original server-side
+ *       exception type.</li>
+ * </ul>
+ */
+public final class BulkResponseProtoConverter {
+
+    private BulkResponseProtoConverter() {}
+
+    /**
+     * Converts a {@code protobufs.BulkResponse} into a server-internal {@link BulkResponse}.
+     *
+     * @param proto the proto response received over gRPC
+     * @return the equivalent {@link BulkResponse}
+     */
+    public static BulkResponse fromProto(org.opensearch.protobufs.BulkResponse proto) {
+        int n = proto.getItemsCount();
+        BulkItemResponse[] items = new BulkItemResponse[n];
+        for (int i = 0; i < n; i++) {
+            items[i] = fromProto(i, proto.getItems(i));
+        }
+        long ingestTook = proto.hasIngestTook() ? proto.getIngestTook() : -1L;
+        return new BulkResponse(items, proto.getTook(), ingestTook);
+    }
+
+    private static BulkItemResponse fromProto(int id, Item protoItem) {
+        switch (protoItem.getItemCase()) {
+            case INDEX:
+                return buildItem(id, DocWriteRequest.OpType.INDEX, protoItem.getIndex());
+            case CREATE:
+                return buildItem(id, DocWriteRequest.OpType.CREATE, protoItem.getCreate());
+            case UPDATE:
+                return buildItem(id, DocWriteRequest.OpType.UPDATE, protoItem.getUpdate());
+            case DELETE:
+                return buildItem(id, DocWriteRequest.OpType.DELETE, protoItem.getDelete());
+            case ITEM_NOT_SET:
+            default:
+                throw new IllegalStateException("Item has no operation case set");
+        }
+    }
+
+    private static BulkItemResponse buildItem(int id, DocWriteRequest.OpType opType, ResponseItem ri) {
+        if (ri.hasError()) {
+            return new BulkItemResponse(id, opType, toFailure(ri));
+        }
+
+        DocWriteResponse response;
+        switch (opType) {
+            case INDEX:
+            case CREATE: {
+                IndexResponse ir = new IndexResponse(
+                    shardIdFor(ri),
+                    ri.hasXId() ? ri.getXId() : null,
+                    ri.hasXSeqNo() ? ri.getXSeqNo() : -2L,
+                    ri.hasXPrimaryTerm() ? ri.getXPrimaryTerm() : 0L,
+                    ri.hasXVersion() ? ri.getXVersion() : -1L,
+                    parseResult(ri.getResult()) == DocWriteResponse.Result.CREATED
+                );
+                ir.setShardInfo(toShardInfo(ri));
+                ir.setForcedRefresh(ri.getForcedRefresh());
+                response = ir;
+                break;
+            }
+            case DELETE: {
+                DeleteResponse dr = new DeleteResponse(
+                    shardIdFor(ri),
+                    ri.hasXId() ? ri.getXId() : null,
+                    ri.hasXSeqNo() ? ri.getXSeqNo() : -2L,
+                    ri.hasXPrimaryTerm() ? ri.getXPrimaryTerm() : 0L,
+                    ri.hasXVersion() ? ri.getXVersion() : -1L,
+                    parseResult(ri.getResult()) != DocWriteResponse.Result.NOT_FOUND
+                );
+                dr.setShardInfo(toShardInfo(ri));
+                dr.setForcedRefresh(ri.getForcedRefresh());
+                response = dr;
+                break;
+            }
+            case UPDATE: {
+                UpdateResponse ur = new UpdateResponse(
+                    shardIdFor(ri),
+                    ri.hasXId() ? ri.getXId() : null,
+                    ri.hasXSeqNo() ? ri.getXSeqNo() : -2L,
+                    ri.hasXPrimaryTerm() ? ri.getXPrimaryTerm() : 0L,
+                    ri.hasXVersion() ? ri.getXVersion() : -1L,
+                    parseResult(ri.getResult())
+                );
+                ur.setShardInfo(toShardInfo(ri));
+                ur.setForcedRefresh(ri.getForcedRefresh());
+                response = ur;
+                break;
+            }
+            default:
+                throw new IllegalStateException("unsupported op type: " + opType);
+        }
+        return new BulkItemResponse(id, opType, response);
+    }
+
+    private static BulkItemResponse.Failure toFailure(ResponseItem ri) {
+        org.opensearch.protobufs.ErrorCause err = ri.getError();
+        String reason = err.hasReason() ? err.getReason() : err.getType();
+        Exception cause = new OpenSearchException("[" + err.getType() + "] " + reason);
+        return new BulkItemResponse.Failure(ri.getXIndex(), ri.hasXId() ? ri.getXId() : null, cause);
+    }
+
+    private static ShardId shardIdFor(ResponseItem ri) {
+        return new ShardId(new Index(ri.getXIndex(), "_na_"), -1);
+    }
+
+    private static ReplicationResponse.ShardInfo toShardInfo(ResponseItem ri) {
+        if (ri.hasXShards() == false) {
+            return new ReplicationResponse.ShardInfo();
+        }
+        org.opensearch.protobufs.ShardInfo s = ri.getXShards();
+        return new ReplicationResponse.ShardInfo(s.getTotal(), s.getSuccessful());
+    }
+
+    private static DocWriteResponse.Result parseResult(String result) {
+        if (result == null || result.isEmpty()) {
+            return DocWriteResponse.Result.NOOP;
+        }
+        switch (result.toLowerCase(java.util.Locale.ROOT)) {
+            case "created":
+                return DocWriteResponse.Result.CREATED;
+            case "updated":
+                return DocWriteResponse.Result.UPDATED;
+            case "deleted":
+                return DocWriteResponse.Result.DELETED;
+            case "not_found":
+                return DocWriteResponse.Result.NOT_FOUND;
+            case "noop":
+                return DocWriteResponse.Result.NOOP;
+            default:
+                throw new IllegalArgumentException("unknown result: " + result);
+        }
+    }
+}

--- a/modules/transport-grpc/src/main/java/org/opensearch/transport/grpc/proto/response/document/bulk/BulkResponseProtoConverter.java
+++ b/modules/transport-grpc/src/main/java/org/opensearch/transport/grpc/proto/response/document/bulk/BulkResponseProtoConverter.java
@@ -55,7 +55,7 @@ public final class BulkResponseProtoConverter {
         for (int i = 0; i < n; i++) {
             items[i] = fromProto(i, proto.getItems(i));
         }
-        long ingestTook = proto.hasIngestTook() ? proto.getIngestTook() : -1L;
+        long ingestTook = proto.hasIngestTook() ? proto.getIngestTook() : BulkResponse.NO_INGEST_TOOK;
         return new BulkResponse(items, proto.getTook(), ingestTook);
     }
 

--- a/modules/transport-grpc/src/main/java/org/opensearch/transport/grpc/proto/response/search/SearchResponseProtoConverter.java
+++ b/modules/transport-grpc/src/main/java/org/opensearch/transport/grpc/proto/response/search/SearchResponseProtoConverter.java
@@ -1,0 +1,144 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.transport.grpc.proto.response.search;
+
+import org.apache.lucene.search.TotalHits;
+import org.opensearch.action.OriginalIndices;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.action.search.SearchResponseSections;
+import org.opensearch.action.search.ShardSearchFailure;
+import org.opensearch.core.common.bytes.BytesArray;
+import org.opensearch.core.index.Index;
+import org.opensearch.core.index.shard.ShardId;
+import org.opensearch.protobufs.HitXScore;
+import org.opensearch.protobufs.HitsMetadata;
+import org.opensearch.protobufs.HitsMetadataHitsInner;
+import org.opensearch.protobufs.HitsMetadataMaxScore;
+import org.opensearch.protobufs.HitsMetadataTotal;
+import org.opensearch.protobufs.ShardStatistics;
+import org.opensearch.protobufs.TotalHitsRelation;
+import org.opensearch.search.SearchHit;
+import org.opensearch.search.SearchHits;
+import org.opensearch.search.SearchShardTarget;
+
+import java.util.Map;
+
+/**
+ * Converts a {@code protobufs.SearchResponse} (received over gRPC) into the server-internal {@link SearchResponse}.
+ *
+ * <p>This is the inverse of {@link SearchResponseProtoUtils}, which lives next door. Co-locating both directions
+ * enables a round-trip parity test that catches divergence as the schema evolves.
+ *
+ * <p><b>Known lossy or deferred conversions</b>:
+ * <ul>
+ *   <li>Aggregations / suggest / profile / processor results are not decoded — server-side encoders for these are stubs
+ *       on the proto path today, so they should not appear in responses.</li>
+ *   <li>Shard failures are not yet decoded — empty array placeholder.</li>
+ *   <li>Per-hit shard target uses a placeholder {@link ShardId} ({@link Index} uuid {@code "_na_"}, shard id {@code -1})
+ *       since proto carries no shard UUID/id.</li>
+ *   <li>NaN scores: the forward path emits a {@code null_value} sentinel for {@code NaN}; we restore to {@link Float#NaN}.</li>
+ *   <li>Per-hit fields not yet decoded: {@code sortValues}, {@code fields}, {@code highlightFields},
+ *       {@code matchedQueries}, {@code explanation}, {@code innerHits}, {@code nestedIdentity}, {@code ignored}.</li>
+ * </ul>
+ */
+public final class SearchResponseProtoConverter {
+
+    private SearchResponseProtoConverter() {}
+
+    /**
+     * Converts a {@code protobufs.SearchResponse} into a server-internal {@link SearchResponse}.
+     *
+     * @param proto the proto response received over gRPC
+     * @return the equivalent {@link SearchResponse}
+     */
+    public static SearchResponse fromProto(org.opensearch.protobufs.SearchResponse proto) {
+        SearchHits hits = toSearchHits(proto.hasHits() ? proto.getHits() : null);
+        SearchResponseSections sections = new SearchResponseSections(hits, null, null, proto.getTimedOut(), null, null, 0);
+
+        ShardStatistics shards = proto.hasXShards() ? proto.getXShards() : null;
+        int totalShards = shards != null ? shards.getTotal() : 0;
+        int successful = shards != null ? shards.getSuccessful() : 0;
+        int skipped = shards != null && shards.hasSkipped() ? shards.getSkipped() : 0;
+
+        return new SearchResponse(
+            sections,
+            null,                       // scrollId — deferred
+            totalShards,
+            successful,
+            skipped,
+            proto.getTook(),
+            new ShardSearchFailure[0],  // shard failures — deferred
+            SearchResponse.Clusters.EMPTY
+        );
+    }
+
+    private static SearchHits toSearchHits(HitsMetadata hm) {
+        if (hm == null) {
+            return new SearchHits(new SearchHit[0], new TotalHits(0, TotalHits.Relation.EQUAL_TO), Float.NaN);
+        }
+        int n = hm.getHitsCount();
+        SearchHit[] arr = new SearchHit[n];
+        for (int i = 0; i < n; i++) {
+            arr[i] = toSearchHit(hm.getHits(i));
+        }
+        TotalHits total = toTotalHits(hm.hasTotal() ? hm.getTotal() : null);
+        float maxScore = hm.hasMaxScore() ? toFloat(hm.getMaxScore()) : Float.NaN;
+        return new SearchHits(arr, total, maxScore);
+    }
+
+    private static SearchHit toSearchHit(HitsMetadataHitsInner h) {
+        SearchHit hit = new SearchHit(
+            -1,                                  // docId placeholder
+            h.hasXId() ? h.getXId() : null,
+            null,                                // nestedIdentity — deferred
+            Map.of(),                            // documentFields — deferred
+            Map.of()                             // metaFields — deferred
+        );
+
+        if (h.hasXScore()) hit.score(toFloat(h.getXScore()));
+        if (h.hasXVersion()) hit.version(h.getXVersion());
+        if (h.hasXSeqNo()) hit.setSeqNo(h.getXSeqNo());
+        if (h.hasXPrimaryTerm()) hit.setPrimaryTerm(h.getXPrimaryTerm());
+        if (h.hasXSource()) hit.sourceRef(new BytesArray(h.getXSource().toByteArray()));
+
+        if (h.hasXIndex()) {
+            ShardId sid = new ShardId(new Index(h.getXIndex(), "_na_"), -1);
+            hit.shard(new SearchShardTarget(null, sid, null, OriginalIndices.NONE));
+        }
+        return hit;
+    }
+
+    private static TotalHits toTotalHits(HitsMetadataTotal t) {
+        if (t == null) {
+            return new TotalHits(0, TotalHits.Relation.EQUAL_TO);
+        }
+        switch (t.getHitsMetadataTotalCase()) {
+            case TOTAL_HITS: {
+                org.opensearch.protobufs.TotalHits th = t.getTotalHits();
+                TotalHits.Relation rel = th.getRelation() == TotalHitsRelation.TOTAL_HITS_RELATION_GTE
+                    ? TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO
+                    : TotalHits.Relation.EQUAL_TO;
+                return new TotalHits(th.getValue(), rel);
+            }
+            case INT64:
+                return new TotalHits(t.getInt64(), TotalHits.Relation.EQUAL_TO);
+            case HITSMETADATATOTAL_NOT_SET:
+            default:
+                return new TotalHits(0, TotalHits.Relation.EQUAL_TO);
+        }
+    }
+
+    private static float toFloat(HitXScore s) {
+        return s.hasNullValue() ? Float.NaN : (float) s.getDouble();
+    }
+
+    private static float toFloat(HitsMetadataMaxScore m) {
+        return m.hasNullValue() ? Float.NaN : m.getFloat();
+    }
+}

--- a/modules/transport-grpc/src/test/java/org/opensearch/transport/grpc/proto/request/document/bulk/BulkProtoConverterTests.java
+++ b/modules/transport-grpc/src/test/java/org/opensearch/transport/grpc/proto/request/document/bulk/BulkProtoConverterTests.java
@@ -1,0 +1,203 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.transport.grpc.proto.request.document.bulk;
+
+import org.opensearch.action.bulk.BulkRequest;
+import org.opensearch.action.delete.DeleteRequest;
+import org.opensearch.action.index.IndexRequest;
+import org.opensearch.action.support.ActiveShardCount;
+import org.opensearch.action.support.WriteRequest.RefreshPolicy;
+import org.opensearch.action.update.UpdateRequest;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.index.VersionType;
+import org.opensearch.protobufs.BulkRequestBody;
+import org.opensearch.protobufs.IndexOperation;
+import org.opensearch.protobufs.OpType;
+import org.opensearch.protobufs.OperationContainer;
+import org.opensearch.protobufs.Refresh;
+import org.opensearch.protobufs.WaitForActiveShardOptions;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.Map;
+
+public class BulkProtoConverterTests extends OpenSearchTestCase {
+
+    public void testIndexOp() {
+        BulkRequest bulk = new BulkRequest();
+        bulk.add(new IndexRequest("orders").id("1").source(Map.of("k", 1), XContentType.JSON));
+        var proto = BulkProtoConverter.toProto(bulk);
+
+        assertEquals(1, proto.getBulkRequestBodyCount());
+        BulkRequestBody body = proto.getBulkRequestBody(0);
+        OperationContainer container = body.getOperationContainer();
+        assertTrue(container.hasIndex());
+        IndexOperation idx = container.getIndex();
+        assertEquals("orders", idx.getXIndex());
+        assertEquals("1", idx.getXId());
+        assertEquals(OpType.OP_TYPE_UNSPECIFIED, idx.getOpType()); // op_type unset for plain INDEX
+        assertTrue(body.getObject().size() > 0); // doc bytes attached
+    }
+
+    public void testCreateOpWithoutVersionControl_emitsWriteOperation() {
+        BulkRequest bulk = new BulkRequest();
+        bulk.add(new IndexRequest("orders").id("1").opType(IndexRequest.OpType.CREATE).source(Map.of("k", 1), XContentType.JSON));
+        var proto = BulkProtoConverter.toProto(bulk);
+
+        OperationContainer container = proto.getBulkRequestBody(0).getOperationContainer();
+        assertTrue("CREATE without version control uses WriteOperation", container.hasCreate());
+        assertFalse(container.hasIndex());
+        assertEquals("orders", container.getCreate().getXIndex());
+    }
+
+    public void testCreateOpWithVersionControl_fallsBackToIndexOpWithCreateType() {
+        // WriteOperation has no version fields — fall back to IndexOperation{op_type=CREATE}.
+        BulkRequest bulk = new BulkRequest();
+        bulk.add(
+            new IndexRequest("orders").id("1")
+                .opType(IndexRequest.OpType.CREATE)
+                .versionType(VersionType.EXTERNAL)
+                .version(7L)
+                .source(Map.of("k", 1), XContentType.JSON)
+        );
+        var proto = BulkProtoConverter.toProto(bulk);
+
+        OperationContainer container = proto.getBulkRequestBody(0).getOperationContainer();
+        assertTrue("CREATE with version control falls back to IndexOperation", container.hasIndex());
+        assertFalse(container.hasCreate());
+        IndexOperation idx = container.getIndex();
+        assertEquals(OpType.OP_TYPE_CREATE, idx.getOpType());
+        assertEquals(7L, idx.getVersion());
+    }
+
+    public void testUpdateOp_docBytesGoToBodyObject_notUpdateActionDoc() {
+        BulkRequest bulk = new BulkRequest();
+        bulk.add(new UpdateRequest("orders", "1").doc(Map.of("k", 2), XContentType.JSON));
+        var proto = BulkProtoConverter.toProto(bulk);
+
+        BulkRequestBody body = proto.getBulkRequestBody(0);
+        assertTrue(body.getOperationContainer().hasUpdate());
+        // Forward parses update doc bytes from body.object, ignoring update_action.doc.
+        assertTrue("update doc must be on body.object", body.getObject().size() > 0);
+        assertTrue("UpdateAction is still present for upsert/script flags", body.hasUpdateAction());
+    }
+
+    public void testDeleteOp() {
+        BulkRequest bulk = new BulkRequest();
+        bulk.add(new DeleteRequest("orders", "1").setIfSeqNo(100L).setIfPrimaryTerm(2L));
+        var proto = BulkProtoConverter.toProto(bulk);
+
+        var del = proto.getBulkRequestBody(0).getOperationContainer().getDelete();
+        assertEquals("1", del.getXId());
+        assertEquals(100L, del.getIfSeqNo());
+        assertEquals(2L, del.getIfPrimaryTerm());
+    }
+
+    public void testRefreshPolicy_NONE_isNotEmitted() {
+        BulkRequest bulk = newBulkWithOneIndex();
+        bulk.setRefreshPolicy(RefreshPolicy.NONE);
+        assertEquals("RefreshPolicy.NONE → proto unset", Refresh.REFRESH_UNSPECIFIED, BulkProtoConverter.toProto(bulk).getRefresh());
+    }
+
+    public void testRefreshPolicy_IMMEDIATE_mapsToTrue() {
+        BulkRequest bulk = newBulkWithOneIndex();
+        bulk.setRefreshPolicy(RefreshPolicy.IMMEDIATE);
+        assertEquals(Refresh.REFRESH_TRUE, BulkProtoConverter.toProto(bulk).getRefresh());
+    }
+
+    public void testRefreshPolicy_WAIT_UNTIL_mapsToWaitFor() {
+        BulkRequest bulk = newBulkWithOneIndex();
+        bulk.setRefreshPolicy(RefreshPolicy.WAIT_UNTIL);
+        assertEquals(Refresh.REFRESH_WAIT_FOR, BulkProtoConverter.toProto(bulk).getRefresh());
+    }
+
+    public void testVersionType_INTERNAL_isNotEmitted() {
+        BulkRequest bulk = new BulkRequest();
+        bulk.add(new IndexRequest("orders").id("1").versionType(VersionType.INTERNAL).source(Map.of(), XContentType.JSON));
+        var idx = BulkProtoConverter.toProto(bulk).getBulkRequestBody(0).getOperationContainer().getIndex();
+        assertFalse("VersionType.INTERNAL should not emit version_type on proto", idx.hasVersionType());
+    }
+
+    public void testVersionType_EXTERNAL_emitsExternal() {
+        BulkRequest bulk = new BulkRequest();
+        bulk.add(new IndexRequest("orders").id("1").versionType(VersionType.EXTERNAL).version(5L).source(Map.of(), XContentType.JSON));
+        var idx = BulkProtoConverter.toProto(bulk).getBulkRequestBody(0).getOperationContainer().getIndex();
+        assertEquals(org.opensearch.protobufs.VersionType.VERSION_TYPE_EXTERNAL, idx.getVersionType());
+        assertEquals(5L, idx.getVersion());
+    }
+
+    public void testActiveShardCount_DEFAULT_isNotEmitted() {
+        BulkRequest bulk = newBulkWithOneIndex();
+        bulk.waitForActiveShards(ActiveShardCount.DEFAULT);
+        assertFalse(BulkProtoConverter.toProto(bulk).hasWaitForActiveShards());
+    }
+
+    public void testActiveShardCount_ALL_emitsOptionEnum() {
+        BulkRequest bulk = newBulkWithOneIndex();
+        bulk.waitForActiveShards(ActiveShardCount.ALL);
+        var was = BulkProtoConverter.toProto(bulk).getWaitForActiveShards();
+        assertTrue(was.hasOption());
+        assertEquals(WaitForActiveShardOptions.WAIT_FOR_ACTIVE_SHARD_OPTIONS_ALL, was.getOption());
+    }
+
+    public void testActiveShardCount_NONE_emitsCountZero() {
+        BulkRequest bulk = newBulkWithOneIndex();
+        bulk.waitForActiveShards(ActiveShardCount.NONE);
+        var was = BulkProtoConverter.toProto(bulk).getWaitForActiveShards();
+        assertTrue(was.hasCount());
+        assertEquals(0, was.getCount());
+    }
+
+    public void testUnassignedSeqNoNotEmitted() {
+        BulkRequest bulk = new BulkRequest();
+        bulk.add(new IndexRequest("orders").id("1").source(Map.of(), XContentType.JSON));
+        var idx = BulkProtoConverter.toProto(bulk).getBulkRequestBody(0).getOperationContainer().getIndex();
+        assertFalse(idx.hasIfSeqNo());
+        assertFalse(idx.hasIfPrimaryTerm());
+    }
+
+    public void testRequireAliasFalse_isNotEmitted() {
+        BulkRequest bulk = new BulkRequest();
+        bulk.add(new IndexRequest("orders").id("1").setRequireAlias(false).source(Map.of(), XContentType.JSON));
+        var idx = BulkProtoConverter.toProto(bulk).getBulkRequestBody(0).getOperationContainer().getIndex();
+        assertFalse(idx.getRequireAlias());
+    }
+
+    public void testEmptyBulk_producesEmptyBodyList() {
+        var proto = BulkProtoConverter.toProto(new BulkRequest());
+        assertEquals(0, proto.getBulkRequestBodyCount());
+    }
+
+    public void testTimeoutEmittedAsString() {
+        BulkRequest bulk = newBulkWithOneIndex();
+        bulk.timeout(TimeValue.timeValueSeconds(30));
+        assertEquals("30s", BulkProtoConverter.toProto(bulk).getTimeout());
+    }
+
+    public void testFourOpMixedBulk_preservesOrder() {
+        BulkRequest bulk = new BulkRequest();
+        bulk.add(new IndexRequest("o").id("a").source(Map.of("k", 1), XContentType.JSON));
+        bulk.add(new IndexRequest("o").id("b").source(Map.of("k", 2), XContentType.JSON).opType(IndexRequest.OpType.CREATE));
+        bulk.add(new UpdateRequest("o", "c").doc(Map.of("k", 3), XContentType.JSON));
+        bulk.add(new DeleteRequest("o", "d"));
+        var proto = BulkProtoConverter.toProto(bulk);
+
+        assertEquals(4, proto.getBulkRequestBodyCount());
+        assertTrue(proto.getBulkRequestBody(0).getOperationContainer().hasIndex());
+        assertTrue(proto.getBulkRequestBody(1).getOperationContainer().hasCreate());
+        assertTrue(proto.getBulkRequestBody(2).getOperationContainer().hasUpdate());
+        assertTrue(proto.getBulkRequestBody(3).getOperationContainer().hasDelete());
+    }
+
+    private static BulkRequest newBulkWithOneIndex() {
+        BulkRequest bulk = new BulkRequest();
+        bulk.add(new IndexRequest("orders").id("1").source(Map.of("k", 1), XContentType.JSON));
+        return bulk;
+    }
+}

--- a/modules/transport-grpc/src/test/java/org/opensearch/transport/grpc/proto/request/document/bulk/BulkProtoConverterTests.java
+++ b/modules/transport-grpc/src/test/java/org/opensearch/transport/grpc/proto/request/document/bulk/BulkProtoConverterTests.java
@@ -76,16 +76,15 @@ public class BulkProtoConverterTests extends OpenSearchTestCase {
         assertEquals(7L, idx.getVersion());
     }
 
-    public void testUpdateOp_docBytesGoToBodyObject_notUpdateActionDoc() {
+    public void testUpdateOp_docBytesGoToUpdateActionDoc() {
         BulkRequest bulk = new BulkRequest();
         bulk.add(new UpdateRequest("orders", "1").doc(Map.of("k", 2), XContentType.JSON));
         var proto = BulkProtoConverter.toProto(bulk);
 
         BulkRequestBody body = proto.getBulkRequestBody(0);
         assertTrue(body.getOperationContainer().hasUpdate());
-        // Forward parses update doc bytes from body.object, ignoring update_action.doc.
-        assertTrue("update doc must be on body.object", body.getObject().size() > 0);
-        assertTrue("UpdateAction is still present for upsert/script flags", body.hasUpdateAction());
+        assertTrue("UpdateAction is present", body.hasUpdateAction());
+        assertTrue("update doc must be on UpdateAction.doc", body.getUpdateAction().getDoc().size() > 0);
     }
 
     public void testDeleteOp() {

--- a/modules/transport-grpc/src/test/java/org/opensearch/transport/grpc/proto/request/document/bulk/BulkRoundTripTests.java
+++ b/modules/transport-grpc/src/test/java/org/opensearch/transport/grpc/proto/request/document/bulk/BulkRoundTripTests.java
@@ -1,0 +1,147 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.transport.grpc.proto.request.document.bulk;
+
+import org.opensearch.action.DocWriteRequest;
+import org.opensearch.action.bulk.BulkRequest;
+import org.opensearch.action.delete.DeleteRequest;
+import org.opensearch.action.index.IndexRequest;
+import org.opensearch.action.support.ActiveShardCount;
+import org.opensearch.action.support.WriteRequest.RefreshPolicy;
+import org.opensearch.action.update.UpdateRequest;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.index.VersionType;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.Map;
+
+/**
+ * Round-trip parity tests for bulk requests:
+ *   server BulkRequest s
+ *     -> BulkProtoConverter.toProto(s)            (this module: server -> proto)
+ *     -> BulkRequestProtoUtils.prepareRequest(p)  (this module: proto -> server)
+ *   assert s ~= s'  (per-row + cluster-level fields)
+ *
+ * Co-locating both directions in this module is what makes this test possible without crossing
+ * subproject boundaries. Failures here are early-warning signals that the two converters have
+ * diverged as the proto schema evolves.
+ *
+ * Fixtures avoid known non-injective collapse zones so equality can hold (top-level
+ * routing/index/pipeline are inlined per-row by the forward parser; we test per-row only).
+ */
+public class BulkRoundTripTests extends OpenSearchTestCase {
+
+    public void testPlainIndex() {
+        BulkRequest s = new BulkRequest();
+        s.add(new IndexRequest("orders").id("o-1").source(Map.of("status", "new", "amount", 99), XContentType.JSON).routing("c-42"));
+        assertRoundTrip(s);
+    }
+
+    public void testCreateWithExternalVersion() {
+        BulkRequest s = new BulkRequest();
+        s.add(
+            new IndexRequest("orders").id("o-2")
+                .source(Map.of("status", "new", "amount", 150), XContentType.JSON)
+                .opType(IndexRequest.OpType.CREATE)
+                .versionType(VersionType.EXTERNAL)
+                .version(7L)
+        );
+        assertRoundTrip(s);
+    }
+
+    public void testUpdateWithDocAndUpsertAndRetry() {
+        BulkRequest s = new BulkRequest();
+        s.add(
+            new UpdateRequest("orders", "o-1").doc(Map.of("status", "shipped"), XContentType.JSON)
+                .upsert(Map.of("status", "shipped", "amount", 0), XContentType.JSON)
+                .retryOnConflict(3)
+        );
+        assertRoundTrip(s);
+    }
+
+    public void testDeleteWithOptimisticConcurrency() {
+        BulkRequest s = new BulkRequest();
+        s.add(new DeleteRequest("orders", "o-3").setIfSeqNo(100L).setIfPrimaryTerm(2L));
+        assertRoundTrip(s);
+    }
+
+    public void testClusterLevelFields() {
+        BulkRequest s = new BulkRequest();
+        s.timeout(TimeValue.timeValueSeconds(30));
+        s.setRefreshPolicy(RefreshPolicy.IMMEDIATE);
+        s.waitForActiveShards(ActiveShardCount.ALL);
+        s.add(new IndexRequest("orders").id("a").source("{}", XContentType.JSON));
+        assertRoundTrip(s);
+    }
+
+    public void testMixedFourOpBulk() {
+        BulkRequest s = new BulkRequest();
+        s.add(new IndexRequest("o").id("a").source(Map.of("k", 1), XContentType.JSON));
+        s.add(new IndexRequest("o").id("b").source(Map.of("k", 2), XContentType.JSON).opType(IndexRequest.OpType.CREATE));
+        s.add(new UpdateRequest("o", "c").doc(Map.of("k", 3), XContentType.JSON));
+        s.add(new DeleteRequest("o", "d"));
+        assertRoundTrip(s);
+    }
+
+    /** Runs the round trip and asserts the reconstructed BulkRequest equals the original on every field we care about. */
+    private static void assertRoundTrip(BulkRequest s) {
+        org.opensearch.protobufs.BulkRequest proto = BulkProtoConverter.toProto(s);
+        BulkRequest s2 = BulkRequestProtoUtils.prepareRequest(proto);
+        assertBulkEquivalent(s, s2);
+    }
+
+    /**
+     * Manual field-by-field equivalence check. {@link BulkRequest} doesn't override {@code equals()}, and the framework's
+     * notion of equality (reference identity) isn't useful for round-trip validation.
+     */
+    private static void assertBulkEquivalent(BulkRequest a, BulkRequest b) {
+        assertEquals("timeout", a.timeout(), b.timeout());
+        assertEquals("refresh", a.getRefreshPolicy(), b.getRefreshPolicy());
+        assertEquals("waitForActiveShards", a.waitForActiveShards(), b.waitForActiveShards());
+        assertEquals("ops count", a.requests().size(), b.requests().size());
+        for (int i = 0; i < a.requests().size(); i++) {
+            assertDocWriteEquivalent("op[" + i + "]", a.requests().get(i), b.requests().get(i));
+        }
+    }
+
+    private static void assertDocWriteEquivalent(String prefix, DocWriteRequest<?> a, DocWriteRequest<?> b) {
+        assertEquals(prefix + " class", a.getClass(), b.getClass());
+        assertEquals(prefix + " index", a.index(), b.index());
+        assertEquals(prefix + " id", a.id(), b.id());
+        assertEquals(prefix + " routing", a.routing(), b.routing());
+        assertEquals(prefix + " opType", a.opType(), b.opType());
+        assertEquals(prefix + " version", a.version(), b.version());
+        assertEquals(prefix + " versionType", a.versionType(), b.versionType());
+
+        if (a instanceof IndexRequest && b instanceof IndexRequest) {
+            IndexRequest ia = (IndexRequest) a, ib = (IndexRequest) b;
+            assertEquals(prefix + " source", ia.source(), ib.source());
+            assertEquals(prefix + " pipeline", ia.getPipeline(), ib.getPipeline());
+            assertEquals(prefix + " ifSeqNo", ia.ifSeqNo(), ib.ifSeqNo());
+            assertEquals(prefix + " ifPrimaryTerm", ia.ifPrimaryTerm(), ib.ifPrimaryTerm());
+        } else if (a instanceof UpdateRequest && b instanceof UpdateRequest) {
+            UpdateRequest ua = (UpdateRequest) a, ub = (UpdateRequest) b;
+            assertEquals(prefix + " retryOnConflict", ua.retryOnConflict(), ub.retryOnConflict());
+            assertEquals(prefix + " docAsUpsert", ua.docAsUpsert(), ub.docAsUpsert());
+            assertEquals(prefix + " doc presence", ua.doc() == null, ub.doc() == null);
+            if (ua.doc() != null && ub.doc() != null) {
+                assertEquals(prefix + " doc source", ua.doc().source(), ub.doc().source());
+            }
+            assertEquals(prefix + " upsert presence", ua.upsertRequest() == null, ub.upsertRequest() == null);
+            if (ua.upsertRequest() != null && ub.upsertRequest() != null) {
+                assertEquals(prefix + " upsert source", ua.upsertRequest().source(), ub.upsertRequest().source());
+            }
+        } else if (a instanceof DeleteRequest && b instanceof DeleteRequest) {
+            DeleteRequest da = (DeleteRequest) a, db = (DeleteRequest) b;
+            assertEquals(prefix + " ifSeqNo", da.ifSeqNo(), db.ifSeqNo());
+            assertEquals(prefix + " ifPrimaryTerm", da.ifPrimaryTerm(), db.ifPrimaryTerm());
+        }
+    }
+}

--- a/modules/transport-grpc/src/test/java/org/opensearch/transport/grpc/proto/request/search/SearchProtoConverterTests.java
+++ b/modules/transport-grpc/src/test/java/org/opensearch/transport/grpc/proto/request/search/SearchProtoConverterTests.java
@@ -1,0 +1,119 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.transport.grpc.proto.request.search;
+
+import org.apache.lucene.util.BytesRef;
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.index.query.MatchAllQueryBuilder;
+import org.opensearch.index.query.MatchNoneQueryBuilder;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.index.query.RangeQueryBuilder;
+import org.opensearch.index.query.TermQueryBuilder;
+import org.opensearch.index.query.TermsQueryBuilder;
+import org.opensearch.indices.TermsLookup;
+import org.opensearch.protobufs.QueryContainer;
+import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.List;
+
+public class SearchProtoConverterTests extends OpenSearchTestCase {
+
+    public void testIndices_areEmittedInOrder() {
+        SearchRequest req = new SearchRequest("a", "b", "c");
+        var proto = SearchProtoConverter.toProto(req);
+        assertEquals(List.of("a", "b", "c"), proto.getIndexList());
+    }
+
+    public void testFromAndSize_round_trip() {
+        SearchRequest req = new SearchRequest("idx").source(
+            new SearchSourceBuilder().from(10).size(25).query(QueryBuilders.matchAllQuery())
+        );
+        var body = SearchProtoConverter.toProto(req).getSearchRequestBody();
+        assertEquals(10, body.getFrom());
+        assertEquals(25, body.getSize());
+    }
+
+    public void testMatchAllQuery() {
+        var container = queryContainer(QueryBuilders.matchAllQuery());
+        assertTrue(container.hasMatchAll());
+    }
+
+    public void testMatchAllQuery_boostAndName() {
+        MatchAllQueryBuilder q = QueryBuilders.matchAllQuery().boost(2.5f).queryName("named");
+        var container = queryContainer(q);
+        assertEquals(2.5f, container.getMatchAll().getBoost(), 0.0001f);
+        assertEquals("named", container.getMatchAll().getXName());
+    }
+
+    public void testMatchNoneQuery() {
+        var container = queryContainer(new MatchNoneQueryBuilder());
+        assertTrue(container.hasMatchNone());
+    }
+
+    public void testTermQuery_string() {
+        TermQueryBuilder q = QueryBuilders.termQuery("status", "active");
+        var container = queryContainer(q);
+        assertTrue(container.hasTerm());
+        assertEquals("status", container.getTerm().getField());
+        assertEquals("active", container.getTerm().getValue().getString());
+    }
+
+    public void testTermQuery_long() {
+        var container = queryContainer(QueryBuilders.termQuery("n", 42L));
+        assertEquals(42L, container.getTerm().getValue().getGeneralNumber().getInt64Value());
+    }
+
+    public void testTermQuery_caseInsensitiveOnlyEmittedWhenTrue() {
+        TermQueryBuilder q1 = QueryBuilders.termQuery("f", "v");
+        assertFalse(queryContainer(q1).getTerm().getCaseInsensitive());
+        TermQueryBuilder q2 = QueryBuilders.termQuery("f", "v").caseInsensitive(true);
+        assertTrue(queryContainer(q2).getTerm().getCaseInsensitive());
+    }
+
+    public void testTermQuery_bytesRefIsUnwrappedToString() {
+        TermQueryBuilder q = QueryBuilders.termQuery("f", new BytesRef("alice"));
+        assertEquals("alice", queryContainer(q).getTerm().getValue().getString());
+    }
+
+    public void testTermsQuery_inlineValues() {
+        TermsQueryBuilder q = new TermsQueryBuilder("color", List.of("red", "green", "blue"));
+        var container = queryContainer(q);
+        assertTrue(container.hasTerms());
+        assertEquals(1, container.getTerms().getTermsCount());
+        var field = container.getTerms().getTermsOrThrow("color");
+        assertTrue(field.hasValue());
+        assertEquals(3, field.getValue().getFieldValueArrayCount());
+        assertEquals("red", field.getValue().getFieldValueArray(0).getString());
+    }
+
+    public void testTermsQuery_lookup() {
+        TermsLookup lookup = new TermsLookup("users", "u1", "tags");
+        lookup.routing("r");
+        TermsQueryBuilder q = new TermsQueryBuilder("user", lookup);
+        var container = queryContainer(q);
+        var field = container.getTerms().getTermsOrThrow("user");
+        assertTrue(field.hasLookup());
+        assertEquals("users", field.getLookup().getIndex());
+        assertEquals("u1", field.getLookup().getId());
+        assertEquals("tags", field.getLookup().getPath());
+        assertEquals("r", field.getLookup().getRouting());
+    }
+
+    public void testUnsupportedQueryType_throws() {
+        SearchRequest req = new SearchRequest("idx").source(new SearchSourceBuilder().query(new RangeQueryBuilder("n").gte(0)));
+        UnsupportedOperationException e = expectThrows(UnsupportedOperationException.class, () -> SearchProtoConverter.toProto(req));
+        assertTrue(e.getMessage().contains("RangeQueryBuilder"));
+    }
+
+    private static QueryContainer queryContainer(org.opensearch.index.query.QueryBuilder q) {
+        SearchRequest req = new SearchRequest("idx").source(new SearchSourceBuilder().query(q));
+        return SearchProtoConverter.toProto(req).getSearchRequestBody().getQuery();
+    }
+}

--- a/modules/transport-grpc/src/test/java/org/opensearch/transport/grpc/proto/response/document/bulk/BulkResponseProtoConverterTests.java
+++ b/modules/transport-grpc/src/test/java/org/opensearch/transport/grpc/proto/response/document/bulk/BulkResponseProtoConverterTests.java
@@ -1,0 +1,170 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.transport.grpc.proto.response.document.bulk;
+
+import org.opensearch.action.DocWriteRequest;
+import org.opensearch.action.DocWriteResponse;
+import org.opensearch.action.bulk.BulkItemResponse;
+import org.opensearch.action.bulk.BulkResponse;
+import org.opensearch.action.delete.DeleteResponse;
+import org.opensearch.action.index.IndexResponse;
+import org.opensearch.action.update.UpdateResponse;
+import org.opensearch.protobufs.ErrorCause;
+import org.opensearch.protobufs.Item;
+import org.opensearch.protobufs.ResponseItem;
+import org.opensearch.protobufs.ShardInfo;
+import org.opensearch.test.OpenSearchTestCase;
+
+public class BulkResponseProtoConverterTests extends OpenSearchTestCase {
+
+    public void testTookAndIngestTookRoundTrip() {
+        org.opensearch.protobufs.BulkResponse proto = org.opensearch.protobufs.BulkResponse.newBuilder()
+            .setTook(42L)
+            .setIngestTook(7L)
+            .build();
+        BulkResponse server = BulkResponseProtoConverter.fromProto(proto);
+        assertEquals(42L, server.getTook().millis());
+        assertEquals(7L, server.getIngestTookInMillis());
+    }
+
+    public void testIngestTookOptional_absent() {
+        org.opensearch.protobufs.BulkResponse proto = org.opensearch.protobufs.BulkResponse.newBuilder().setTook(10L).build();
+        BulkResponse server = BulkResponseProtoConverter.fromProto(proto);
+        assertEquals(-1L, server.getIngestTookInMillis()); // -1 = not set
+    }
+
+    public void testIndexItem_mapsToIndexResponse() {
+        org.opensearch.protobufs.BulkResponse proto = withItem(
+            Item.newBuilder()
+                .setIndex(
+                    ResponseItem.newBuilder()
+                        .setXIndex("orders")
+                        .setXId("1")
+                        .setXVersion(1L)
+                        .setXSeqNo(0L)
+                        .setXPrimaryTerm(1L)
+                        .setResult("created")
+                        .build()
+                )
+                .build()
+        );
+        BulkResponse server = BulkResponseProtoConverter.fromProto(proto);
+        assertEquals(1, server.getItems().length);
+
+        BulkItemResponse item = server.getItems()[0];
+        assertEquals(DocWriteRequest.OpType.INDEX, item.getOpType());
+        assertTrue(item.getResponse() instanceof IndexResponse);
+        IndexResponse resp = item.getResponse();
+        assertEquals("orders", resp.getIndex());
+        assertEquals("1", resp.getId());
+        assertEquals(DocWriteResponse.Result.CREATED, resp.getResult());
+        assertEquals(1L, resp.getVersion());
+    }
+
+    public void testCreateItem_mapsToIndexResponseWithCreatedFlag() {
+        org.opensearch.protobufs.BulkResponse proto = withItem(
+            Item.newBuilder().setCreate(ResponseItem.newBuilder().setXIndex("o").setXId("1").setResult("created").build()).build()
+        );
+        BulkResponse server = BulkResponseProtoConverter.fromProto(proto);
+        BulkItemResponse item = server.getItems()[0];
+        assertEquals(DocWriteRequest.OpType.CREATE, item.getOpType());
+        assertTrue(item.getResponse() instanceof IndexResponse);
+    }
+
+    public void testUpdateItem_mapsToUpdateResponse() {
+        org.opensearch.protobufs.BulkResponse proto = withItem(
+            Item.newBuilder().setUpdate(ResponseItem.newBuilder().setXIndex("o").setXId("1").setResult("updated").build()).build()
+        );
+        BulkResponse server = BulkResponseProtoConverter.fromProto(proto);
+        BulkItemResponse item = server.getItems()[0];
+        assertEquals(DocWriteRequest.OpType.UPDATE, item.getOpType());
+        assertTrue(item.getResponse() instanceof UpdateResponse);
+        assertEquals(DocWriteResponse.Result.UPDATED, item.getResponse().getResult());
+    }
+
+    public void testDeleteItem_mapsToDeleteResponse_withFoundFlag() {
+        org.opensearch.protobufs.BulkResponse proto = withItem(
+            Item.newBuilder().setDelete(ResponseItem.newBuilder().setXIndex("o").setXId("1").setResult("deleted").build()).build()
+        );
+        BulkResponse server = BulkResponseProtoConverter.fromProto(proto);
+        BulkItemResponse item = server.getItems()[0];
+        assertEquals(DocWriteRequest.OpType.DELETE, item.getOpType());
+        assertTrue(item.getResponse() instanceof DeleteResponse);
+        assertEquals(DocWriteResponse.Result.DELETED, item.getResponse().getResult());
+    }
+
+    public void testDeleteItem_notFound_setsFoundFalse() {
+        org.opensearch.protobufs.BulkResponse proto = withItem(
+            Item.newBuilder().setDelete(ResponseItem.newBuilder().setXIndex("o").setXId("missing").setResult("not_found").build()).build()
+        );
+        BulkResponse server = BulkResponseProtoConverter.fromProto(proto);
+        DeleteResponse resp = (DeleteResponse) server.getItems()[0].getResponse();
+        assertEquals(DocWriteResponse.Result.NOT_FOUND, resp.getResult());
+    }
+
+    public void testFailureItem_producesFailureWithOpenSearchException() {
+        org.opensearch.protobufs.BulkResponse proto = withItem(
+            Item.newBuilder()
+                .setIndex(
+                    ResponseItem.newBuilder()
+                        .setXIndex("o")
+                        .setXId("1")
+                        .setError(ErrorCause.newBuilder().setType("version_conflict").setReason("doc exists").build())
+                        .build()
+                )
+                .build()
+        );
+        BulkResponse server = BulkResponseProtoConverter.fromProto(proto);
+        assertTrue(server.hasFailures());
+        BulkItemResponse item = server.getItems()[0];
+        assertTrue(item.isFailed());
+        assertNotNull(item.getFailure());
+        assertEquals("o", item.getFailure().getIndex());
+        assertEquals("1", item.getFailure().getId());
+        assertNotNull(item.getFailure().getCause());
+        assertTrue(item.getFailure().getMessage().contains("version_conflict"));
+        assertTrue(item.getFailure().getMessage().contains("doc exists"));
+    }
+
+    public void testShardInfo_populatedFromProto() {
+        ShardInfo shards = ShardInfo.newBuilder().setTotal(2).setSuccessful(1).setFailed(1).build();
+        org.opensearch.protobufs.BulkResponse proto = withItem(
+            Item.newBuilder()
+                .setIndex(ResponseItem.newBuilder().setXIndex("o").setXId("1").setResult("created").setXShards(shards).build())
+                .build()
+        );
+        BulkResponse server = BulkResponseProtoConverter.fromProto(proto);
+        IndexResponse resp = (IndexResponse) server.getItems()[0].getResponse();
+        assertEquals(2, resp.getShardInfo().getTotal());
+        assertEquals(1, resp.getShardInfo().getSuccessful());
+    }
+
+    public void testForcedRefresh_propagated() {
+        org.opensearch.protobufs.BulkResponse proto = withItem(
+            Item.newBuilder()
+                .setIndex(ResponseItem.newBuilder().setXIndex("o").setXId("1").setResult("created").setForcedRefresh(true).build())
+                .build()
+        );
+        BulkResponse server = BulkResponseProtoConverter.fromProto(proto);
+        IndexResponse resp = (IndexResponse) server.getItems()[0].getResponse();
+        assertTrue(resp.forcedRefresh());
+    }
+
+    public void testUnknownResultString_throws() {
+        org.opensearch.protobufs.BulkResponse proto = withItem(
+            Item.newBuilder().setIndex(ResponseItem.newBuilder().setXIndex("o").setXId("1").setResult("frobnicated").build()).build()
+        );
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> BulkResponseProtoConverter.fromProto(proto));
+        assertTrue(e.getMessage().contains("unknown result"));
+    }
+
+    private static org.opensearch.protobufs.BulkResponse withItem(Item item) {
+        return org.opensearch.protobufs.BulkResponse.newBuilder().setTook(1L).addItems(item).build();
+    }
+}

--- a/modules/transport-grpc/src/test/java/org/opensearch/transport/grpc/proto/response/search/SearchResponseProtoConverterTests.java
+++ b/modules/transport-grpc/src/test/java/org/opensearch/transport/grpc/proto/response/search/SearchResponseProtoConverterTests.java
@@ -1,0 +1,135 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.transport.grpc.proto.response.search;
+
+import com.google.protobuf.ByteString;
+import org.apache.lucene.search.TotalHits;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.protobufs.HitXScore;
+import org.opensearch.protobufs.HitsMetadata;
+import org.opensearch.protobufs.HitsMetadataHitsInner;
+import org.opensearch.protobufs.HitsMetadataMaxScore;
+import org.opensearch.protobufs.HitsMetadataTotal;
+import org.opensearch.protobufs.NullValue;
+import org.opensearch.protobufs.ShardStatistics;
+import org.opensearch.protobufs.TotalHitsRelation;
+import org.opensearch.search.SearchHit;
+import org.opensearch.test.OpenSearchTestCase;
+
+public class SearchResponseProtoConverterTests extends OpenSearchTestCase {
+
+    public void testTookAndTimedOut_roundTrip() {
+        org.opensearch.protobufs.SearchResponse proto = baseProto().setTook(123L).setTimedOut(true).build();
+        SearchResponse server = SearchResponseProtoConverter.fromProto(proto);
+        assertEquals(123L, server.getTook().millis());
+        assertTrue(server.isTimedOut());
+    }
+
+    public void testShards_roundTrip() {
+        ShardStatistics shards = ShardStatistics.newBuilder().setTotal(5).setSuccessful(4).setSkipped(1).setFailed(0).build();
+        org.opensearch.protobufs.SearchResponse proto = baseProto().setXShards(shards).build();
+        SearchResponse server = SearchResponseProtoConverter.fromProto(proto);
+        assertEquals(5, server.getTotalShards());
+        assertEquals(4, server.getSuccessfulShards());
+        assertEquals(1, server.getSkippedShards());
+    }
+
+    public void testTotalHits_eqRelation() {
+        org.opensearch.protobufs.SearchResponse proto = baseProto().setHits(
+            HitsMetadata.newBuilder()
+                .setTotal(
+                    HitsMetadataTotal.newBuilder()
+                        .setTotalHits(
+                            org.opensearch.protobufs.TotalHits.newBuilder()
+                                .setValue(42L)
+                                .setRelation(TotalHitsRelation.TOTAL_HITS_RELATION_EQ)
+                                .build()
+                        )
+                        .build()
+                )
+                .build()
+        ).build();
+        SearchResponse server = SearchResponseProtoConverter.fromProto(proto);
+        TotalHits total = server.getHits().getTotalHits();
+        assertEquals(42L, total.value());
+        assertEquals(TotalHits.Relation.EQUAL_TO, total.relation());
+    }
+
+    public void testTotalHits_gteRelation() {
+        org.opensearch.protobufs.SearchResponse proto = baseProto().setHits(
+            HitsMetadata.newBuilder()
+                .setTotal(
+                    HitsMetadataTotal.newBuilder()
+                        .setTotalHits(
+                            org.opensearch.protobufs.TotalHits.newBuilder()
+                                .setValue(10000L)
+                                .setRelation(TotalHitsRelation.TOTAL_HITS_RELATION_GTE)
+                                .build()
+                        )
+                        .build()
+                )
+                .build()
+        ).build();
+        TotalHits total = SearchResponseProtoConverter.fromProto(proto).getHits().getTotalHits();
+        assertEquals(10000L, total.value());
+        assertEquals(TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO, total.relation());
+    }
+
+    public void testNaNScoreSentinel_perHit() {
+        HitsMetadataHitsInner hit = HitsMetadataHitsInner.newBuilder()
+            .setXIndex("idx")
+            .setXId("1")
+            .setXScore(HitXScore.newBuilder().setNullValue(NullValue.NULL_VALUE_NULL).build())
+            .build();
+        org.opensearch.protobufs.SearchResponse proto = baseProto().setHits(HitsMetadata.newBuilder().addHits(hit).build()).build();
+        SearchResponse server = SearchResponseProtoConverter.fromProto(proto);
+        assertTrue("score must be NaN, was " + server.getHits().getAt(0).getScore(), Float.isNaN(server.getHits().getAt(0).getScore()));
+    }
+
+    public void testNaNScoreSentinel_maxScore() {
+        org.opensearch.protobufs.SearchResponse proto = baseProto().setHits(
+            HitsMetadata.newBuilder().setMaxScore(HitsMetadataMaxScore.newBuilder().setNullValue(NullValue.NULL_VALUE_NULL).build()).build()
+        ).build();
+        SearchResponse server = SearchResponseProtoConverter.fromProto(proto);
+        assertTrue(Float.isNaN(server.getHits().getMaxScore()));
+    }
+
+    public void testHitFields_propagated() {
+        HitsMetadataHitsInner hit = HitsMetadataHitsInner.newBuilder()
+            .setXIndex("idx")
+            .setXId("1")
+            .setXVersion(3L)
+            .setXSeqNo(7L)
+            .setXPrimaryTerm(2L)
+            .setXScore(HitXScore.newBuilder().setDouble(1.5d).build())
+            .setXSource(ByteString.copyFromUtf8("{\"k\":1}"))
+            .build();
+        org.opensearch.protobufs.SearchResponse proto = baseProto().setHits(HitsMetadata.newBuilder().addHits(hit).build()).build();
+
+        SearchResponse server = SearchResponseProtoConverter.fromProto(proto);
+        SearchHit h = server.getHits().getAt(0);
+        assertEquals("idx", h.getIndex());
+        assertEquals("1", h.getId());
+        assertEquals(3L, h.getVersion());
+        assertEquals(7L, h.getSeqNo());
+        assertEquals(2L, h.getPrimaryTerm());
+        assertEquals(1.5f, h.getScore(), 0.0001f);
+        assertEquals("{\"k\":1}", h.getSourceAsString());
+    }
+
+    public void testEmptyHits() {
+        org.opensearch.protobufs.SearchResponse proto = baseProto().build();
+        SearchResponse server = SearchResponseProtoConverter.fromProto(proto);
+        assertEquals(0, server.getHits().getHits().length);
+    }
+
+    private static org.opensearch.protobufs.SearchResponse.Builder baseProto() {
+        return org.opensearch.protobufs.SearchResponse.newBuilder().setTook(1L);
+    }
+}


### PR DESCRIPTION
### Description
Adds reverse converters for Bulk and a subset of Search queries alongside the existing forward parsers in `modules/transport-grpc`

BulkProtoConverter handles INDEX, CREATE, UPDATE, and DELETE, along with cluster level fields. The BulkResponseProtoConverter converts the proto bulk responses back into BulkResponse objects. 

SearchProtoConverter does the same but for search requests. Supports 4 query types (match_all, match_none, term, terms) + TermsLookup. Other query types should throw UnsupportedOperationException

Tested using round trip tests (BulkRoundTrips.java) which calls BulkProtoConverter.toProto -> BulkRequestProtoUtils.prepareRequest and asserts that the fields are equivalent across the board + unit tests.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
