### PR TITLE
Fix dynamic_templates merge in legacy index templates

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/MetadataCreateIndexService.java
@@ -1011,6 +1011,18 @@ public class MetadataCreateIndexService {
             if (!target.containsKey(key)) {
                 // Key doesn't exist in target, add it
                 target.put(key, sourceValue);
+            } else if (key.equals("dynamic_templates")
+                && sourceValue instanceof List
+                && target.get(key) instanceof List) {
+                // Special handling for dynamic_templates — it is a List, so combine both lists
+                // instead of overwriting. Fixes: https://github.com/opensearch-project/OpenSearch/issues/21430
+                @SuppressWarnings("unchecked")
+                List<Object> targetList = (List<Object>) target.get(key);
+                @SuppressWarnings("unchecked")
+                List<Object> sourceList = (List<Object>) sourceValue;
+                List<Object> combined = new ArrayList<>(targetList);
+                combined.addAll(sourceList);
+                target.put(key, combined);
             } else if (key.equals("properties") && sourceValue instanceof Map && target.get(key) instanceof Map) {
                 // Special handling for "properties" section - merge field definitions with replacement
                 @SuppressWarnings("unchecked")

--- a/server/src/test/java/org/opensearch/cluster/metadata/MetadataCreateIndexServiceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/MetadataCreateIndexServiceTests.java
@@ -4030,7 +4030,7 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
         List<?> dynamicTemplates = (List<?>) doc.get("dynamic_templates");
 
         assertNotNull("dynamic_templates should not be null after merge", dynamicTemplates);
-        assertEquals("dynamic_templates from Multiple legacy templats should be merged", 2, dynamicTemplates.size());
+        assertEquals("dynamic_templates from multiple legacy templates should be merged", 2, dynamicTemplates.size());
 
         // Verify both template rules are present regardless of order
         boolean hasStrings = false;

--- a/server/src/test/java/org/opensearch/cluster/metadata/MetadataCreateIndexServiceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/MetadataCreateIndexServiceTests.java
@@ -3992,4 +3992,55 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
 
         MetadataCreateIndexService.validateIngestionSourceSettings(settings, state);
     }
+
+    public void testValidateDynamicTemplatesMerge() throws Exception {
+        CompressedXContent template_1 = new CompressedXContent(
+            "{\""
+                + MapperService.SINGLE_MAPPING_NAME
+                + "\":{"
+                + "\"dynamic_templates\":["
+                + "{\"strings\":{"
+                + "\"match\":\"s_*\","
+                + "\"match_mapping_type\":\"*\","
+                + "\"mapping\":{\"type\":\"text\"}"
+                + "}}"
+                + "]}}"
+        );
+
+        // Template 2 (order 0): matches fields starting with "f_" as float
+        CompressedXContent template_2 = new CompressedXContent(
+            "{\""
+                + MapperService.SINGLE_MAPPING_NAME
+                + "\":{"
+                + "\"dynamic_templates\":["
+                + "{\"floats\":{"
+                + "\"match\":\"f_*\","
+                + "\"match_mapping_type\":\"*\","
+                + "\"mapping\":{\"type\":\"float\"}"
+                + "}}"
+                + "]}}"
+        );
+
+        List<CompressedXContent> templates = Arrays.asList(template_1, template_2);
+        Map<String, Object> result = MetadataCreateIndexService.parseV1Mappings("",
+            templates,
+            NamedXContentRegistry.EMPTY);
+
+        Map<String, Object> doc = (Map<String, Object>) result.get(MapperService.SINGLE_MAPPING_NAME);
+        List<?> dynamicTemplates = (List<?>) doc.get("dynamic_templates");
+
+        assertNotNull("dynamic_templates should not be null after merge", dynamicTemplates);
+        assertEquals("dynamic_templates from Multiple legacy templats should be merged", 2, dynamicTemplates.size());
+
+        // Verify both template rules are present regardless of order
+        boolean hasStrings = false;
+        boolean hasFloats = false;
+        for (Object entry : dynamicTemplates) {
+            Map<?, ?> templateMap = (Map<?, ?>) entry;
+            if (templateMap.containsKey("strings")) hasStrings = true;
+            if (templateMap.containsKey("floats")) hasFloats = true;
+        }
+        assertTrue("Expected 'strings' dynamic template from template1", hasStrings);
+        assertTrue("Expected 'floats' dynamic template from template2", hasFloats);
+    }
 }


### PR DESCRIPTION
## Description
Fixes `dynamic_templates` merge regression in legacy index templates.

## Issues Resolved
Fixes #21430

## Problem
When multiple legacy index templates (`_template` API) matching the
same index pattern each define `dynamic_templates`, only one template's
dynamic_templates survive in the final mapping. The others are
silently lost. This worked correctly in 2.19.0 but regressed in 3.x.

## Root Cause
In `MetadataCreateIndexService.mergeTemplateFieldMappings()`, there
was no special handling for the `dynamic_templates` key which holds
a List. When the target map already contained `dynamic_templates`,
the source list was silently ignored.

## Fix
Added explicit handling to combine both lists instead of ignoring
the source list.

## Testing
- Manually reproduced bug on OpenSearch 3.6.0 via Docker
- Verified fix works on local 3.7.0-SNAPSHOT build
- Added unit test `testValidateDynamicTemplatesMerge`

## Checklist
- [x] By submitting this pull request, I confirm that my contribution
      is made under the terms of the Apache 2.0 license.
      For more information on following Developer Certificate of Origin
      and signing off your commits, please check
      [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md).