### PR TITLE
Wire DataFusion backend for PPL fields/rename/head/sort + QA ITs

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionAnalyticsBackendPlugin.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionAnalyticsBackendPlugin.java
@@ -96,6 +96,13 @@ public class DataFusionAnalyticsBackendPlugin implements AnalyticsSearchBackendP
         ScalarFunction.CAST,
         ScalarFunction.CONCAT,
         ScalarFunction.SAFE_CAST,
+        // ABS / SUBSTRING — `eval x = abs(...)` and `eval s = substring(...)` projections that PPL
+        // sort-pushdown moves into the project tree (see CalciteSortCommandIT
+        // testPushdownSortExpressionContainsNull and CalcitePPLSortIT
+        // testPushdownSortStringExpression). DataFusion has both natively; isthmus default catalog
+        // already binds them.
+        ScalarFunction.ABS,
+        ScalarFunction.SUBSTRING,
         ScalarFunction.SARG_PREDICATE,
         ScalarFunction.EQUALS,
         ScalarFunction.NOT_EQUALS,

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/FieldsCommandIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/FieldsCommandIT.java
@@ -1,0 +1,162 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.qa;
+
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Self-contained integration test for PPL {@code fields} on the analytics-engine route.
+ *
+ * <p>Mirrors {@code CalciteFieldsCommandIT} from the {@code opensearch-project/sql}
+ * repository so the analytics-engine path can be verified inside core without cross-plugin
+ * dependencies. Each test sends a PPL query through {@code POST /_analytics/ppl}, which
+ * runs the same {@code UnifiedQueryPlanner} → {@code CalciteRelNodeVisitor} → Substrait
+ * → DataFusion pipeline as the SQL plugin's force-routed analytics path.
+ *
+ * <p>Covers the field-projection surface this PR cares about: explicit single/multi-field
+ * lists, wildcard include patterns, and field exclusion. Wildcard suffix/prefix patterns
+ * delegate to {@code CalciteRelNodeVisitor.visitProject} which expands them at plan time;
+ * the exclusion form (`fields - x, y`) goes through the same code path with `exclude=true`.
+ */
+public class FieldsCommandIT extends AnalyticsRestTestCase {
+
+    private static final Dataset DATASET = new Dataset("calcs", "calcs");
+
+    private static boolean dataProvisioned = false;
+
+    private void ensureDataProvisioned() throws IOException {
+        if (dataProvisioned == false) {
+            DatasetProvisioner.provision(client(), DATASET);
+            dataProvisioned = true;
+        }
+    }
+
+    public void testFieldsBasic() throws IOException {
+        // Two-column projection. Row order is the document insertion order; the analytics
+        // path reads from parquet which preserves that.
+        assertColumns("source=" + DATASET.indexName + " | fields str2, num0 | head 3", "str2", "num0");
+    }
+
+    public void testFieldsSingleColumn() throws IOException {
+        assertRowsEqual(
+            "source=" + DATASET.indexName + " | fields str2 | head 5",
+            row("one"),
+            row("two"),
+            row("three"),
+            row((Object) null),
+            row("five")
+        );
+    }
+
+    public void testFieldsExplicitOrder() throws IOException {
+        // Column order must match the | fields list, not the document/storage order.
+        assertColumns(
+            "source=" + DATASET.indexName + " | fields num0, str2 | head 1",
+            "num0",
+            "str2"
+        );
+    }
+
+    public void testFieldsSuffixWildcard() throws IOException {
+        // *0 expands to all columns ending in '0' — {num0, str0, int0, bool0, date0, time0,
+        // datetime0}. Order isn't guaranteed (analyzer resolves wildcards by mapping iteration
+        // order, which is alphabetical here). Verify the set rather than the sequence.
+        Map<String, Object> response = executePpl(
+            "source=" + DATASET.indexName + " | fields *0 | head 1"
+        );
+        @SuppressWarnings("unchecked")
+        List<String> columns = (List<String>) response.get("columns");
+        assertNotNull("Response missing 'columns'", columns);
+        java.util.Set<String> actual = new java.util.HashSet<>(columns);
+        java.util.Set<String> expected = new java.util.HashSet<>(
+            Arrays.asList("num0", "str0", "int0", "bool0", "date0", "time0", "datetime0")
+        );
+        assertEquals("Wildcard *0 column set", expected, actual);
+    }
+
+    public void testFieldsExclusion() throws IOException {
+        // `fields - num0, num1, num2, num3, num4` removes those five columns from the
+        // projection. Validate the result no longer contains num*.
+        Map<String, Object> response = executePpl(
+            "source=" + DATASET.indexName + " | fields - num0, num1, num2, num3, num4 | head 1"
+        );
+        @SuppressWarnings("unchecked")
+        List<String> columns = (List<String>) response.get("columns");
+        assertNotNull("Response missing 'columns'", columns);
+        for (String name : columns) {
+            assertFalse("Excluded column should not appear: " + name, name.startsWith("num"));
+        }
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────────────
+
+    private static List<Object> row(Object... values) {
+        return Arrays.asList(values);
+    }
+
+    @SafeVarargs
+    @SuppressWarnings("varargs")
+    private final void assertRowsEqual(String ppl, List<Object>... expected) throws IOException {
+        Map<String, Object> response = executePpl(ppl);
+        @SuppressWarnings("unchecked")
+        List<List<Object>> actualRows = (List<List<Object>>) response.get("rows");
+        assertNotNull("Response missing 'rows' for query: " + ppl, actualRows);
+        assertEquals("Row count mismatch for query: " + ppl, expected.length, actualRows.size());
+        for (int i = 0; i < expected.length; i++) {
+            List<Object> want = expected[i];
+            List<Object> got = actualRows.get(i);
+            assertEquals(
+                "Column count mismatch at row " + i + " for query: " + ppl,
+                want.size(),
+                got.size()
+            );
+            for (int j = 0; j < want.size(); j++) {
+                assertEquals(
+                    "Cell mismatch at row " + i + ", col " + j + " for query: " + ppl,
+                    want.get(j),
+                    got.get(j)
+                );
+            }
+        }
+    }
+
+    /** Assert the response has the expected column names in order. */
+    private void assertColumns(String ppl, String... expectedColumns) throws IOException {
+        Map<String, Object> response = executePpl(ppl);
+        @SuppressWarnings("unchecked")
+        List<String> columns = (List<String>) response.get("columns");
+        assertNotNull("Response missing 'columns' for query: " + ppl, columns);
+        assertEquals(
+            "Column count for query: " + ppl,
+            expectedColumns.length,
+            columns.size()
+        );
+        for (int i = 0; i < expectedColumns.length; i++) {
+            assertEquals(
+                "Column at position " + i + " for query: " + ppl,
+                expectedColumns[i],
+                columns.get(i)
+            );
+        }
+    }
+
+    private Map<String, Object> executePpl(String ppl) throws IOException {
+        ensureDataProvisioned();
+        Request request = new Request("POST", "/_analytics/ppl");
+        request.setJsonEntity("{\"query\": \"" + escapeJson(ppl) + "\"}");
+        Response response = client().performRequest(request);
+        return assertOkAndParse(response, "PPL: " + ppl);
+    }
+}

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/HeadCommandIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/HeadCommandIT.java
@@ -1,0 +1,111 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.qa;
+
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Self-contained integration test for PPL {@code head} on the analytics-engine route.
+ *
+ * <p>Mirrors {@code CalciteHeadCommandIT}. {@code head N} lowers to {@code LogicalSort}
+ * with {@code fetch=N} (no sort key); {@code head N from M} adds {@code offset=M}.
+ * Pure relational op, no scalar surface — exercises the row-cap path through
+ * {@code OpenSearchSort} and the DataFusion fragment driver's limit propagation.
+ */
+public class HeadCommandIT extends AnalyticsRestTestCase {
+
+    private static final Dataset DATASET = new Dataset("calcs", "calcs");
+
+    private static boolean dataProvisioned = false;
+
+    private void ensureDataProvisioned() throws IOException {
+        if (dataProvisioned == false) {
+            DatasetProvisioner.provision(client(), DATASET);
+            dataProvisioned = true;
+        }
+    }
+
+    public void testHeadDefault() throws IOException {
+        // `head` without a count defaults to 10.
+        assertRowCount("source=" + DATASET.indexName + " | fields str2 | head", 10);
+    }
+
+    public void testHeadWithCount() throws IOException {
+        assertRowCount("source=" + DATASET.indexName + " | fields str2 | head 3", 3);
+    }
+
+    public void testHeadWithCountLargerThanData() throws IOException {
+        // Calcs has 17 rows. Asking for more should cap at 17, not error.
+        assertRowCount("source=" + DATASET.indexName + " | fields str2 | head 100", 17);
+    }
+
+    public void testHeadFromOffset() throws IOException {
+        // `head N from M` skips M rows and returns the next N. With 17 rows total,
+        // `head 5 from 14` returns rows 14, 15, 16 (only 3 left).
+        assertRowCount("source=" + DATASET.indexName + " | fields str2 | head 5 from 14", 3);
+    }
+
+    public void testHeadValuesMatchInsertionOrder() throws IOException {
+        // Parquet returns rows in storage / insertion order. The first 5 calcs rows
+        // (key00..key04) have str2 = one, two, three, null, five.
+        assertRowsEqual(
+            "source=" + DATASET.indexName + " | fields str2 | head 5",
+            row("one"),
+            row("two"),
+            row("three"),
+            row((Object) null),
+            row("five")
+        );
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────────────
+
+    private static List<Object> row(Object... values) {
+        return Arrays.asList(values);
+    }
+
+    @SafeVarargs
+    @SuppressWarnings("varargs")
+    private final void assertRowsEqual(String ppl, List<Object>... expected) throws IOException {
+        Map<String, Object> response = executePpl(ppl);
+        @SuppressWarnings("unchecked")
+        List<List<Object>> actualRows = (List<List<Object>>) response.get("rows");
+        assertNotNull("Response missing 'rows' for query: " + ppl, actualRows);
+        assertEquals("Row count for query: " + ppl, expected.length, actualRows.size());
+        for (int i = 0; i < expected.length; i++) {
+            assertEquals(
+                "Cell mismatch at row " + i + " for query: " + ppl,
+                expected[i],
+                actualRows.get(i)
+            );
+        }
+    }
+
+    private void assertRowCount(String ppl, int expected) throws IOException {
+        Map<String, Object> response = executePpl(ppl);
+        @SuppressWarnings("unchecked")
+        List<List<Object>> rows = (List<List<Object>>) response.get("rows");
+        assertNotNull("Response missing 'rows' for query: " + ppl, rows);
+        assertEquals("Row count for query: " + ppl, expected, rows.size());
+    }
+
+    private Map<String, Object> executePpl(String ppl) throws IOException {
+        ensureDataProvisioned();
+        Request request = new Request("POST", "/_analytics/ppl");
+        request.setJsonEntity("{\"query\": \"" + escapeJson(ppl) + "\"}");
+        Response response = client().performRequest(request);
+        return assertOkAndParse(response, "PPL: " + ppl);
+    }
+}

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/RenameCommandIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/RenameCommandIT.java
@@ -1,0 +1,124 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.qa;
+
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Self-contained integration test for PPL {@code rename} on the analytics-engine route.
+ *
+ * <p>Mirrors {@code CalciteRenameCommandIT} from the {@code opensearch-project/sql}
+ * repository so the analytics-engine path can be verified inside core. The {@code rename}
+ * command lowers to a Calcite {@code LogicalProject} with renamed output column names —
+ * pure projection, no scalar functions, no capability-registry dependencies. The IT here
+ * is a smoke test for the full pipeline: PPL parse → AstBuilder → CalciteRelNodeVisitor
+ * → analytics-engine planner → DataFusion execution → JSON response.
+ */
+public class RenameCommandIT extends AnalyticsRestTestCase {
+
+    private static final Dataset DATASET = new Dataset("calcs", "calcs");
+
+    private static boolean dataProvisioned = false;
+
+    private void ensureDataProvisioned() throws IOException {
+        if (dataProvisioned == false) {
+            DatasetProvisioner.provision(client(), DATASET);
+            dataProvisioned = true;
+        }
+    }
+
+    public void testRenameSingleField() throws IOException {
+        // The output column name must be the rename target ("label"), not "str2".
+        Map<String, Object> response = executePpl(
+            "source=" + DATASET.indexName + " | rename str2 as label | fields label | head 3"
+        );
+        assertSingletonColumn(response, "label");
+
+        @SuppressWarnings("unchecked")
+        List<List<Object>> rows = (List<List<Object>>) response.get("rows");
+        assertEquals("Row count", 3, rows.size());
+    }
+
+    public void testRenameMultipleFields() throws IOException {
+        // Two renames in one command, then explicit projection in the renamed names.
+        Map<String, Object> response = executePpl(
+            "source="
+                + DATASET.indexName
+                + " | rename str2 as label, num0 as value | fields label, value | head 5"
+        );
+        @SuppressWarnings("unchecked")
+        List<String> columns = (List<String>) response.get("columns");
+        assertNotNull("Response missing 'columns'", columns);
+        assertEquals("Column count", 2, columns.size());
+        assertEquals("First renamed column", "label", columns.get(0));
+        assertEquals("Second renamed column", "value", columns.get(1));
+    }
+
+    public void testRenameThenReferenceOriginalFails() {
+        // After renaming, the original name is no longer addressable. Mirrors
+        // CalcitePPLRenameIT.testRefRenamedField — analytics path should surface
+        // the same "Field [...] not found" error from the analyzer.
+        assertErrorContains(
+            "source=" + DATASET.indexName + " | rename str2 as label | fields str2",
+            "not found"
+        );
+    }
+
+    public void testRenameWithBackticks() throws IOException {
+        Map<String, Object> response = executePpl(
+            "source="
+                + DATASET.indexName
+                + " | rename str2 as `renamed_label` | fields `renamed_label` | head 1"
+        );
+        assertSingletonColumn(response, "renamed_label");
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────────────
+
+    private void assertSingletonColumn(Map<String, Object> response, String expectedName) {
+        @SuppressWarnings("unchecked")
+        List<String> columns = (List<String>) response.get("columns");
+        assertNotNull("Response missing 'columns'", columns);
+        assertEquals("Column count", 1, columns.size());
+        assertEquals("Column name", expectedName, columns.get(0));
+    }
+
+    private void assertErrorContains(String ppl, String expectedSubstring) {
+        try {
+            Map<String, Object> response = executePpl(ppl);
+            fail("Expected query to fail with [" + expectedSubstring + "] but got response: " + response);
+        } catch (org.opensearch.client.ResponseException e) {
+            String body;
+            try {
+                body = org.opensearch.test.rest.OpenSearchRestTestCase.entityAsMap(e.getResponse()).toString();
+            } catch (IOException ioe) {
+                body = e.getMessage();
+            }
+            assertTrue(
+                "Expected response body to contain [" + expectedSubstring + "] but was: " + body,
+                body.contains(expectedSubstring)
+            );
+        } catch (IOException e) {
+            fail("Unexpected IOException: " + e);
+        }
+    }
+
+    private Map<String, Object> executePpl(String ppl) throws IOException {
+        ensureDataProvisioned();
+        Request request = new Request("POST", "/_analytics/ppl");
+        request.setJsonEntity("{\"query\": \"" + escapeJson(ppl) + "\"}");
+        Response response = client().performRequest(request);
+        return assertOkAndParse(response, "PPL: " + ppl);
+    }
+}

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/SortCommandIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/SortCommandIT.java
@@ -1,0 +1,198 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.qa;
+
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Self-contained integration test for PPL {@code sort} on the analytics-engine route.
+ *
+ * <p>Mirrors {@code CalciteSortCommandIT} / {@code CalcitePPLSortIT}. {@code sort} lowers
+ * to {@code LogicalSort}; the asc / desc / nulls-first / nulls-last variants set the
+ * collation field on the same RelNode. Push-down sort by an expression (`sort abs(num0)`)
+ * lifts the expression into a {@code LogicalProject} child of the sort, which is what
+ * exercises the new project-side capabilities for {@link org.opensearch.analytics.spi.ScalarFunction#ABS}
+ * and {@link org.opensearch.analytics.spi.ScalarFunction#SUBSTRING} added in this PR.
+ */
+public class SortCommandIT extends AnalyticsRestTestCase {
+
+    private static final Dataset DATASET = new Dataset("calcs", "calcs");
+
+    private static boolean dataProvisioned = false;
+
+    private void ensureDataProvisioned() throws IOException {
+        if (dataProvisioned == false) {
+            DatasetProvisioner.provision(client(), DATASET);
+            dataProvisioned = true;
+        }
+    }
+
+    // ── plain field sort ───────────────────────────────────────────────────────
+
+    public void testSortAscByInt() throws IOException {
+        // int0 across the 17 calcs rows: [1, null, null, null, 7, 3, 8, null, null, 8, 4, 10,
+        // null, 4, 11, 4, 8] — 6 nulls and 11 integers. Default sort is ASC nulls-first.
+        assertRowsEqual(
+            "source=" + DATASET.indexName + " | sort int0 | fields int0",
+            row((Object) null), row((Object) null), row((Object) null),
+            row((Object) null), row((Object) null), row((Object) null),
+            row(1), row(3), row(4), row(4), row(4), row(7), row(8), row(8), row(8), row(10), row(11)
+        );
+    }
+
+    public void testSortDescByInt() throws IOException {
+        // DESC nulls-last (the analytics path follows Calcite's default DESC = NULLS LAST).
+        assertRowsEqual(
+            "source=" + DATASET.indexName + " | sort -int0 | fields int0",
+            row(11), row(10), row(8), row(8), row(8), row(7), row(4), row(4), row(4),
+            row(3), row(1),
+            row((Object) null), row((Object) null), row((Object) null),
+            row((Object) null), row((Object) null), row((Object) null)
+        );
+    }
+
+    // ── push-down sort by scalar expression — exercises ABS / SUBSTRING capabilities ──
+
+    public void testSortByAbsExpression() throws IOException {
+        // `abs(num0)` lowers to ABS($N) inside a LogicalProject child of the sort. Without
+        // ABS in STANDARD_PROJECT_OPS, the analytics planner rejects the projection with
+        // "No backend supports scalar function [ABS] among [datafusion]".
+        //
+        // Calcs num0: [12.3, -12.3, 15.7, -15.7, 3.5, -3.5, 0, null, 10, null x8] — 9 nulls
+        // and 8 non-nulls. abs(num0) preserves null and yields {0, 3.5, 3.5, 10, 12.3, 12.3,
+        // 15.7, 15.7} for the non-null tail. Sorted ASC nulls-first puts the 9 nulls first.
+        Map<String, Object> response = executePpl(
+            "source=" + DATASET.indexName + " | eval n = abs(num0) | sort n | fields n | head 9"
+        );
+        @SuppressWarnings("unchecked")
+        List<List<Object>> rows = (List<List<Object>>) response.get("rows");
+        assertNotNull("Response missing 'rows'", rows);
+        assertEquals("Row count", 9, rows.size());
+        for (int i = 0; i < 9; i++) {
+            assertNull("Row " + i + " should be null", rows.get(i).get(0));
+        }
+    }
+
+    public void testSortByAbsTakesNonNullsFromTail() throws IOException {
+        // Skip past the 9 nulls and verify the 8 non-null abs values appear in ASC order.
+        Map<String, Object> response = executePpl(
+            "source="
+                + DATASET.indexName
+                + " | eval n = abs(num0) | sort n | fields n | head 8 from 9"
+        );
+        @SuppressWarnings("unchecked")
+        List<List<Object>> rows = (List<List<Object>>) response.get("rows");
+        assertNotNull("Response missing 'rows'", rows);
+        assertEquals("Row count after 9 nulls", 8, rows.size());
+        double[] expectedSorted = { 0, 3.5, 3.5, 10, 12.3, 12.3, 15.7, 15.7 };
+        for (int i = 0; i < expectedSorted.length; i++) {
+            Object v = rows.get(i).get(0);
+            assertNotNull("Row " + i + " unexpectedly null", v);
+            assertEquals(
+                "abs(num0) sorted value at row " + i,
+                expectedSorted[i],
+                ((Number) v).doubleValue(),
+                1e-9
+            );
+        }
+    }
+
+    public void testSortBySubstringExpression() throws IOException {
+        // `substring(str2, 1, 3)` lowers to SUBSTRING($N, 1, 3) inside a LogicalProject child of
+        // the sort. Without SUBSTRING in STANDARD_PROJECT_OPS, the planner rejects it with
+        // "No backend supports scalar function [SUBSTRING] among [datafusion]".
+        //
+        // Calcs str2 first 3 chars (where non-null): one, two, thr, fiv, six, eig, nin, ten,
+        // ele, twe, fou, fif, six. Sort ASC nulls-first puts the 4 nulls first.
+        Map<String, Object> response = executePpl(
+            "source=" + DATASET.indexName + " | eval s = substring(str2, 1, 3) | sort s | fields s"
+        );
+        @SuppressWarnings("unchecked")
+        List<List<Object>> rows = (List<List<Object>>) response.get("rows");
+        assertNotNull("Response missing 'rows'", rows);
+        assertEquals("Row count == calcs row count", 17, rows.size());
+        // First 4 rows must be nulls (4 null str2 values in calcs).
+        for (int i = 0; i < 4; i++) {
+            assertNull("Expected null at row " + i + " (sorted ASC nulls-first)", rows.get(i).get(0));
+        }
+        // The remaining 13 must be sorted alphabetically.
+        for (int i = 5; i < rows.size(); i++) {
+            String prev = (String) rows.get(i - 1).get(0);
+            String curr = (String) rows.get(i).get(0);
+            assertNotNull("Non-null after null block", curr);
+            assertTrue(
+                "Sort order violation at row " + i + ": " + prev + " > " + curr,
+                prev.compareTo(curr) <= 0
+            );
+        }
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────────────
+
+    private static List<Object> row(Object... values) {
+        return Arrays.asList(values);
+    }
+
+    @SafeVarargs
+    @SuppressWarnings("varargs")
+    private final void assertRowsEqual(String ppl, List<Object>... expected) throws IOException {
+        Map<String, Object> response = executePpl(ppl);
+        @SuppressWarnings("unchecked")
+        List<List<Object>> actualRows = (List<List<Object>>) response.get("rows");
+        assertNotNull("Response missing 'rows' for query: " + ppl, actualRows);
+        assertEquals("Row count mismatch for query: " + ppl, expected.length, actualRows.size());
+        for (int i = 0; i < expected.length; i++) {
+            List<Object> want = expected[i];
+            List<Object> got = actualRows.get(i);
+            assertEquals(
+                "Column count mismatch at row " + i + " for query: " + ppl,
+                want.size(),
+                got.size()
+            );
+            for (int j = 0; j < want.size(); j++) {
+                assertCellEquals(
+                    "Cell mismatch at row " + i + ", col " + j + " for query: " + ppl,
+                    want.get(j),
+                    got.get(j)
+                );
+            }
+        }
+    }
+
+    /** Numeric-tolerant cell comparator (Jackson returns Integer/Long/Double interchangeably). */
+    private static void assertCellEquals(String message, Object expected, Object actual) {
+        if (expected == null || actual == null) {
+            assertEquals(message, expected, actual);
+            return;
+        }
+        if (expected instanceof Number && actual instanceof Number) {
+            double e = ((Number) expected).doubleValue();
+            double a = ((Number) actual).doubleValue();
+            if (Double.compare(e, a) != 0) {
+                fail(message + ": expected <" + expected + "> but was <" + actual + ">");
+            }
+            return;
+        }
+        assertEquals(message, expected, actual);
+    }
+
+    private Map<String, Object> executePpl(String ppl) throws IOException {
+        ensureDataProvisioned();
+        Request request = new Request("POST", "/_analytics/ppl");
+        request.setJsonEntity("{\"query\": \"" + escapeJson(ppl) + "\"}");
+        Response response = client().performRequest(request);
+        return assertOkAndParse(response, "PPL: " + ppl);
+    }
+}


### PR DESCRIPTION
## Summary

Bucket-1 capability-registry expansion for the analytics-engine route, **scoped strictly to the PPL `fields` / `rename` / `head` / `sort` commands**. No aggregation-side work in this PR — `AVG` / `COUNT` / `SUM` / `STDDEV` / `VAR` and the surface that depends on them (`stats`, `count(eval(...))`, etc.) belong to a separate work track and stay broken on the analytics path until that lands.

After this PR (with #21498's eval-side surface already on main):
- `CalciteFieldsCommandIT`, `CalciteRenameCommandIT`, `CalciteHeadCommandIT` 100% green on the analytics path under `tests.analytics.force_routing=true`
- `CalciteSortCommandIT` and `CalcitePPLSortIT` pick up the cast / abs / substring push-down failures (CAST is already in `STANDARD_PROJECT_OPS` upstream from #21476; `ABS` and `SUBSTRING` are this PR's contribution)
- `CalcitePPLRenameIT` 20 / 22 (the 12 column-order asserts are fixed by the companion [opensearch-project/sql#5413](https://github.com/opensearch-project/sql/pull/5413); the 2 remaining failures are aggregation-blocked)

## Changes

**1. `DataFusionAnalyticsBackendPlugin` — `STANDARD_PROJECT_OPS` += `ABS`, `SUBSTRING`.**
PPL sort push-down lifts an expression like `abs(num0)` or `substring(str0, 1, 3)` into a `LogicalProject` child of the sort, which is what the project rule's capability check sees. DataFusion has both natively; isthmus' default extension catalog already binds them. Without this, the analytics planner rejects the projection with `No backend supports scalar function [ABS] among [datafusion]`.

**2. QA ITs in `sandbox/qa/analytics-engine-rest`** — one per command, each self-contained and provisioning the existing `calcs` parquet-backed dataset via `DatasetProvisioner`. Tests fire through `POST /_analytics/ppl` so the core build can validate the analytics-engine path without the SQL plugin. Mirror the failing surface in `Calcite{Fields,Rename,Head,Sort}CommandIT`:

| IT | Tests | Coverage |
|---|---|---|
| `FieldsCommandIT` | 5 | basic projection, single-column, explicit order, suffix-wildcard `*0` (set-equality — wildcard expansion order isn't part of the contract), and `fields - num*` exclusion |
| `RenameCommandIT` | 4 | single rename, multi-rename, post-rename reference fails with "not found", backtick-quoted target names |
| `HeadCommandIT` | 5 | default-10 cap, explicit count, count > total rows, `head N from M` offset, value-equality on first 5 rows |
| `SortCommandIT` | 5 | plain ASC/DESC by integer (with calcs' 6 null `int0` entries placed per Calcite's nulls-first/last defaults), `eval n = abs(num0) \| sort n` (9 null + 8 non-null abs values), `eval s = substring(str2, 1, 3) \| sort s` (validates SUBSTRING capability end-to-end against the 17-row calcs dataset) |

## SQL-plugin Calcite IT status (analytics-engine route, `tests.analytics.force_routing=true`)

Companion test fixes in [opensearch-project/sql#5413](https://github.com/opensearch-project/sql/pull/5413). Routing verified end-to-end: 348 analytics-engine `PlannerImpl` entries, 0 v2 `PPLService.Incoming` entries during the 7-IT sweep.

| IT | Pass | Notes |
|---|---|---|
| `CalciteFieldsCommandIT` | **39 / 39** | ✅ scope of this PR |
| `CalciteRenameCommandIT` | **2 / 2** | ✅ scope of this PR |
| `CalciteHeadCommandIT` | **4 / 4** (2 skipped) | ✅ scope of this PR |
| `CalcitePPLRenameIT` | **20 / 22** | 12 column-order asserts fixed by sql#5413's column-name-aware row matcher; **2 remaining are `testRenameInAgg` / `testRenameWithBackticksInAgg` — out of scope (aggregation work)** |
| `CalcitePPLSortIT` | 14 / 18 | 4 fail: tie-break ordering (parquet vs Lucene return equal sort keys in different stable position) and date-format diff (`2017-10-23T00:00` vs `2017-10-23 00:00:00`). Output-shape diffs that need their own follow-up PRs (date-format alignment, schema-position-aware row matcher); **not aggregation-blocked, just outside this PR's scope** |
| `CalciteSortCommandIT` | 26 / 30 | 4 fail: `weblogs` index has IP-type fields the analytics-engine planner doesn't yet support scanning. Storage-engine gap, **not aggregation, but still outside this PR's scope** |

## Out of scope — explicit list

This PR **does not** cover any of the following surfaces. Each is tracked as a separate work track:

1. **Aggregation surface** (`AVG` / `SUM` / `COUNT` / `STDDEV_*` / `VAR_*`). The Substrait isthmus default `AggregateFunctionConverter` doesn't bind the SQL plugin's custom `NullableSqlAvgAggFunction` (it extends `SqlAggFunction`, not `SqlAvgAggFunction`, so isthmus' `AggregateFunctions.toSubstraitAggVariant` translator skips it and the lookup falls through to a non-existent map key → `Unable to find binding for call AVG($N)`). Resolving this is a separate cross-plugin design discussion: either rebase the SQL plugin's nullable agg variants on `SqlAvgAggFunction` directly, or add an `additionalAggregateSigs` SPI hook to `BackendCapabilityProvider` so backends can declare custom-class → substrait-name mappings. **Out of scope for this PR**; blocks the 2 remaining `CalcitePPLRenameIT` failures, all of `CalcitePPLAggregationIT`, and the `stats`/`count(eval(...))` tail of every other IT.
2. **Window functions.** `dedup` lowers to `ROW_NUMBER OVER`, which `RexOver` doesn't recognize via `ScalarFunction.fromSqlKind`. Blocks `CalciteDedupCommandIT` and `CalcitePPLDedupIT`.
3. **Advanced aggregates / PPL functions.** `first`, `last`, `take`, `arg_max`, `percentile_approx`, `distinct_count_approx`, PPL `span`. Each needs a new `AggregateFunction` enum constant plus a DataFusion adapter or YAML extension.
4. **Date-format alignment / schema-position-aware row matcher / IP-type scan.** The 4 + 4 failures in `CalcitePPLSortIT` / `CalciteSortCommandIT`. Independent fixes, each meriting its own PR.

## Test plan

- [x] `./gradlew :sandbox:qa:analytics-engine-rest:integTest -Dsandbox.enabled=true --tests "*FieldsCommandIT" --tests "*RenameCommandIT" --tests "*HeadCommandIT" --tests "*SortCommandIT"` — **19 / 19 green**.
- [x] `./gradlew check -p sandbox -Dsandbox.enabled=true` — **green** (the unrelated `ScalarDateTimeFunctionIT.testConvertTz` flake from a stale local `libopensearch_native.dylib` resolved by rebuilding the Rust crate; not caused by this PR — `convert_tz` UDF was added by #21476 after my last cargo build).
- [x] SQL-plugin Calcite ITs against this branch + companion [opensearch-project/sql#5413](https://github.com/opensearch-project/sql/pull/5413), with `-Dtests.analytics.force_routing=true -Dtests.analytics.parquet_indices=true`: see the per-IT table above.