### PR TITLE
Fix race in EhcacheDiskCacheManagerTests close phase

### DIFF
--- a/plugins/cache-ehcache/src/test/java/org/opensearch/cache/store/disk/EhcacheDiskCacheManagerTests.java
+++ b/plugins/cache-ehcache/src/test/java/org/opensearch/cache/store/disk/EhcacheDiskCacheManagerTests.java
@@ -45,14 +45,17 @@ public class EhcacheDiskCacheManagerTests extends OpenSearchSingleNodeTestCase {
             EhcacheDiskCacheManager.getCacheManager(CacheType.INDICES_REQUEST_CACHE, path, settings, THREAD_POOL_ALIAS);
         }
         int randomThreads = randomIntBetween(5, 10);
+        // Pre-populate aliases to avoid concurrent writes
+        List<String> diskCacheAliases = new ArrayList<>(randomThreads);
+        for (int i = 0; i < randomThreads; i++) {
+            diskCacheAliases.add(UUID.randomUUID().toString());
+        }
         Thread[] threads = new Thread[randomThreads];
         Phaser phaser = new Phaser(randomThreads + 1);
         CountDownLatch countDownLatch = new CountDownLatch(randomThreads);
-        List<String> diskCacheAliases = new ArrayList<>();
         for (int i = 0; i < randomThreads; i++) {
+            String diskCacheAlias = diskCacheAliases.get(i);
             threads[i] = new Thread(() -> {
-                String diskCacheAlias = UUID.randomUUID().toString();
-                diskCacheAliases.add(diskCacheAlias);
                 phaser.arriveAndAwaitAdvance();
                 EhcacheDiskCacheManager.createCache(CacheType.INDICES_REQUEST_CACHE, diskCacheAlias, getCacheConfigurationBuilder());
                 countDownLatch.countDown();
@@ -68,10 +71,10 @@ public class EhcacheDiskCacheManagerTests extends OpenSearchSingleNodeTestCase {
         CountDownLatch countDownLatch2 = new CountDownLatch(randomThreads);
         for (int i = 0; i < randomThreads; i++) {
             String finalPath = path;
-            int finalI = i;
+            String diskCacheAlias = diskCacheAliases.get(i);
             threads[i] = new Thread(() -> {
                 phaser2.arriveAndAwaitAdvance();
-                EhcacheDiskCacheManager.closeCache(CacheType.INDICES_REQUEST_CACHE, diskCacheAliases.get(finalI), finalPath);
+                EhcacheDiskCacheManager.closeCache(CacheType.INDICES_REQUEST_CACHE, diskCacheAlias, finalPath);
                 countDownLatch2.countDown();
             });
             threads[i].start();


### PR DESCRIPTION
testCreateAndCloseCacheConcurrently populated the diskCacheAliases ArrayList from multiple worker threads without synchronization. When concurrent add() calls dropped an entry the list ended up shorter than randomThreads, and the close-phase lambda's diskCacheAliases.get(finalI) then threw IndexOutOfBoundsException on the thread holding the last index. That worker died without calling countDownLatch2.countDown(), so the main thread blocked forever on countDownLatch2.await() and the suite hit its 20-minute timeout (e.g. build 76071, seed DF0F4253E4345108).

Pre-populate the aliases list in a single-threaded setup loop before spawning the worker threads, so the list is only read concurrently, never written. Each worker captures its alias by index in the loop instead of looking it up from the shared list.

Verified with the original failing seed and with tests.iters=50.

### Related Issues
Resolves #19722

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
