### PR TITLE
[QA] Add AppendPipeCommandIT and TableCommandIT for the analytics-engine REST path

### DIFF
--- a/sandbox/plugins/test-ppl-frontend/src/main/java/org/opensearch/ppl/action/UnifiedQueryService.java
+++ b/sandbox/plugins/test-ppl-frontend/src/main/java/org/opensearch/ppl/action/UnifiedQueryService.java
@@ -80,6 +80,11 @@ public class UnifiedQueryService {
                 .language(QueryType.PPL)
                 .catalog(DEFAULT_CATALOG, flatSchema)
                 .defaultNamespace(DEFAULT_CATALOG)
+                // The unified PPL parser reuses the v2 AstBuilder, which gates Calcite-only
+                // commands (table, regex, rex, convert) on plugins.calcite.enabled. The unified
+                // path is by definition Calcite-based — flag it on so those commands lower
+                // through the same Project/Filter RelNodes as their non-aliased counterparts.
+                .setting("plugins.calcite.enabled", true)
                 .build()
         ) {
 

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/AppendPipeCommandIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/AppendPipeCommandIT.java
@@ -1,0 +1,232 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.qa;
+
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+import org.opensearch.client.ResponseException;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Self-contained integration test for PPL {@code appendpipe} on the analytics-engine route.
+ *
+ * <p>Mirrors {@code CalcitePPLAppendPipeCommandIT} from the {@code opensearch-project/sql}
+ * repository so the analytics-engine path can be verified inside core without cross-plugin
+ * dependencies. Each test sends a PPL query through {@code POST /_analytics/ppl} (exposed
+ * by the {@code test-ppl-frontend} plugin), which runs the same {@code UnifiedQueryPlanner}
+ * → {@code CalciteRelNodeVisitor} → Substrait → DataFusion pipeline as the SQL plugin's
+ * force-routed analytics path.
+ *
+ * <p>{@code appendpipe} differs from {@code append} (covered by {@link AppendCommandIT}):
+ * {@code appendpipe [pipeline]} duplicates the current intermediate result, applies the
+ * inline {@code [pipeline]} to the duplicate, and appends the duplicate's output to the
+ * original. {@code append [search]} runs an entirely separate sub-query and unions its
+ * output. Both lower to a Calcite {@code LogicalUnion} but the upper-stage shape differs
+ * because {@code appendpipe} reuses the original's row stream as its input rather than
+ * starting a fresh {@code source=...}.
+ *
+ * <p>Provisions the {@code calcs} dataset once. {@link AnalyticsRestTestCase#preserveIndicesUponCompletion()}
+ * keeps it across test methods.
+ */
+public class AppendPipeCommandIT extends AnalyticsRestTestCase {
+
+    private static final Dataset DATASET = new Dataset("calcs", "calcs");
+
+    private static boolean dataProvisioned = false;
+
+    private void ensureDataProvisioned() throws IOException {
+        if (dataProvisioned == false) {
+            DatasetProvisioner.provision(client(), DATASET);
+            dataProvisioned = true;
+        }
+    }
+
+    // ── duplicate + inline sort, then head ──────────────────────────────────────
+
+    public void testAppendPipeSort() throws IOException {
+        // Branch: stats sum(int0) by str0 → 3 rows (FURNITURE=1, OFFICE SUPPLIES=18, TECHNOLOGY=49).
+        // Outer `sort str0` pins the original to alphabetical order. `appendpipe [sort -sum_int0_by_str0]`
+        // duplicates the 3 rows and re-sorts them descending, then appends. `head 5` keeps the first
+        // 5 of the 6 total rows: original 3 + first 2 of the descending duplicate.
+        assertRows(
+            "source="
+                + DATASET.indexName
+                + " | stats sum(int0) as sum_int0_by_str0 by str0 | sort str0"
+                + " | appendpipe [ sort -sum_int0_by_str0 ]"
+                + " | head 5",
+            row(1, "FURNITURE"),
+            row(18, "OFFICE SUPPLIES"),
+            row(49, "TECHNOLOGY"),
+            row(49, "TECHNOLOGY"),
+            row(18, "OFFICE SUPPLIES")
+        );
+    }
+
+    // ── duplicate + inline stats producing a smaller schema (merged column) ─────
+
+    public void testAppendPipeWithMergedColumn() throws IOException {
+        // Outer stats: sum(int0) by str0 → 3 rows. `appendpipe [stats sum(sum) as sum]` runs an inner
+        // stats over the duplicate, collapsing it to a single row carrying only the `sum` column.
+        // Schema unification keeps both the original branch's `str0` and the inner branch's
+        // `sum` column; the inner row is null-padded for the missing `str0`. The two branches
+        // arrive at the coordinator's union in non-deterministic order (each is its own data-node
+        // stage), so compare as a multiset rather than positionally.
+        assertRowsAnyOrder(
+            "source="
+                + DATASET.indexName
+                + " | stats sum(int0) as sum by str0 | sort str0"
+                + " | appendpipe [ stats sum(sum) as sum ]",
+            row(1, "FURNITURE"),
+            row(18, "OFFICE SUPPLIES"),
+            row(49, "TECHNOLOGY"),
+            row(68, null)
+        );
+    }
+
+    // ── duplicate + inline cast that clashes with the original's column type ───
+
+    public void testAppendPipeWithConflictTypeColumn() {
+        // Branch 1 produces `sum` as BIGINT (sum over int0). The inner pipeline of
+        // `appendpipe [eval sum = cast(sum as double)]` rewrites the same-named column to
+        // DOUBLE. SchemaUnifier refuses to merge the diverging types and surfaces a
+        // planner-side validation error before execution.
+        assertErrorContains(
+            "source="
+                + DATASET.indexName
+                + " | stats sum(int0) as sum by str0 | sort str0"
+                + " | appendpipe [ eval sum = cast(sum as double) ]"
+                + " | head 5",
+            "due to incompatible types"
+        );
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────────────
+
+    private static List<Object> row(Object... values) {
+        return Arrays.asList(values);
+    }
+
+    /**
+     * Multiset comparison — branch ordering at the coordinator's Union is non-deterministic.
+     * Used by {@link #testAppendPipeWithMergedColumn} where the original-branch stats output
+     * (3 rows) and the inner-branch collapsed-sum (1 row) can arrive in either order.
+     */
+    @SafeVarargs
+    @SuppressWarnings("varargs")
+    private final void assertRowsAnyOrder(String ppl, List<Object>... expected) throws IOException {
+        Map<String, Object> response = executePpl(ppl);
+        @SuppressWarnings("unchecked")
+        List<List<Object>> actualRows = (List<List<Object>>) response.get("rows");
+        assertNotNull("Response missing 'rows' for query: " + ppl, actualRows);
+        assertEquals("Row count mismatch for query: " + ppl, expected.length, actualRows.size());
+        java.util.List<List<Object>> remaining = new java.util.ArrayList<>(actualRows);
+        outer:
+        for (List<Object> want : expected) {
+            for (int i = 0; i < remaining.size(); i++) {
+                if (rowsEqual(want, remaining.get(i))) {
+                    remaining.remove(i);
+                    continue outer;
+                }
+            }
+            fail("Expected row not found for query: " + ppl + " — missing: " + want + " in actual: " + actualRows);
+        }
+    }
+
+    private static boolean rowsEqual(List<Object> a, List<Object> b) {
+        if (a.size() != b.size()) return false;
+        for (int i = 0; i < a.size(); i++) {
+            Object ax = a.get(i);
+            Object bx = b.get(i);
+            if (ax == null || bx == null) {
+                if (ax != bx) return false;
+                continue;
+            }
+            if (ax instanceof Number && bx instanceof Number) {
+                if (Double.compare(((Number) ax).doubleValue(), ((Number) bx).doubleValue()) != 0) return false;
+                continue;
+            }
+            if (!ax.equals(bx)) return false;
+        }
+        return true;
+    }
+
+    @SafeVarargs
+    @SuppressWarnings("varargs")
+    private final void assertRows(String ppl, List<Object>... expected) throws IOException {
+        Map<String, Object> response = executePpl(ppl);
+        @SuppressWarnings("unchecked")
+        List<List<Object>> actualRows = (List<List<Object>>) response.get("rows");
+        assertNotNull("Response missing 'rows' for query: " + ppl, actualRows);
+        assertEquals("Row count mismatch for query: " + ppl, expected.length, actualRows.size());
+        for (int i = 0; i < expected.length; i++) {
+            List<Object> want = expected[i];
+            List<Object> got = actualRows.get(i);
+            assertEquals(
+                "Column count mismatch at row " + i + " for query: " + ppl,
+                want.size(),
+                got.size()
+            );
+            for (int j = 0; j < want.size(); j++) {
+                assertCellEquals(
+                    "Cell mismatch at row " + i + ", col " + j + " for query: " + ppl,
+                    want.get(j),
+                    got.get(j)
+                );
+            }
+        }
+    }
+
+    private void assertErrorContains(String ppl, String expectedSubstring) {
+        try {
+            Map<String, Object> response = executePpl(ppl);
+            fail("Expected query to fail with [" + expectedSubstring + "] but got response: " + response);
+        } catch (ResponseException e) {
+            String body;
+            try {
+                body = org.opensearch.test.rest.OpenSearchRestTestCase.entityAsMap(e.getResponse()).toString();
+            } catch (IOException ioe) {
+                body = e.getMessage();
+            }
+            assertTrue(
+                "Expected response body to contain [" + expectedSubstring + "] but was: " + body,
+                body.contains(expectedSubstring)
+            );
+        } catch (IOException e) {
+            fail("Unexpected IOException: " + e);
+        }
+    }
+
+    private Map<String, Object> executePpl(String ppl) throws IOException {
+        ensureDataProvisioned();
+        Request request = new Request("POST", "/_analytics/ppl");
+        request.setJsonEntity("{\"query\": \"" + escapeJson(ppl) + "\"}");
+        Response response = client().performRequest(request);
+        return assertOkAndParse(response, "PPL: " + ppl);
+    }
+
+    private static void assertCellEquals(String message, Object expected, Object actual) {
+        if (expected == null || actual == null) {
+            assertEquals(message, expected, actual);
+            return;
+        }
+        if (expected instanceof Number && actual instanceof Number) {
+            double e = ((Number) expected).doubleValue();
+            double a = ((Number) actual).doubleValue();
+            if (Double.compare(e, a) != 0) {
+                fail(message + ": expected <" + expected + "> but was <" + actual + ">");
+            }
+            return;
+        }
+        assertEquals(message, expected, actual);
+    }
+}

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/TableCommandIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/TableCommandIT.java
@@ -1,0 +1,143 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.qa;
+
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Self-contained integration test for PPL {@code table} on the analytics-engine route.
+ *
+ * <p>{@code table} is a syntactic alias of {@code fields} — the SQL plugin's
+ * {@code AstBuilder.visitTableCommand} reuses {@code buildProjectCommand} (the same
+ * code path {@code fields} dispatches to) once {@code plugins.calcite.enabled=true} is
+ * propagated through the {@code UnifiedQueryContext} (see
+ * <a href="https://github.com/opensearch-project/sql/pull/5413">opensearch-project/sql#5413</a>).
+ * The added value of {@code table} is a more permissive token shape: it accepts
+ * space-delimited field lists, leading-{@code -} exclusion forms, and mixes those with
+ * commas — surfaces {@code fields} doesn't expose.
+ *
+ * <p>This IT covers the surfaces specific to the {@code table} keyword to lock in that
+ * the analytics path lowers them to the same Calcite {@code Project} RelNode as the v2 /
+ * Calcite path does. Plain projection semantics (already covered by {@code FieldsCommandIT})
+ * are not duplicated here.
+ *
+ * <p>Reuses the {@code calcs} parquet-backed dataset.
+ */
+public class TableCommandIT extends AnalyticsRestTestCase {
+
+    private static final Dataset DATASET = new Dataset("calcs", "calcs");
+
+    private static boolean dataProvisioned = false;
+
+    private void ensureDataProvisioned() throws IOException {
+        if (dataProvisioned == false) {
+            DatasetProvisioner.provision(client(), DATASET);
+            dataProvisioned = true;
+        }
+    }
+
+    public void testTableCommaDelimited() throws IOException {
+        // Comma-delimited form — same shape as `fields a, b`. Sanity check that the table
+        // keyword reaches buildProjectCommand without falling back to the v2-only error.
+        assertColumns(
+            "source=" + DATASET.indexName + " | table str0, num0 | head 3",
+            "str0",
+            "num0"
+        );
+    }
+
+    public void testTableSpaceDelimited() throws IOException {
+        // Space-delimited form — unique to `table`. Validates the lexer accepts whitespace as
+        // a separator and the AstBuilder folds the multi-token list into a single Project.
+        assertColumns(
+            "source=" + DATASET.indexName + " | table str0 num0 int0 | head 3",
+            "str0",
+            "num0",
+            "int0"
+        );
+    }
+
+    public void testTableSuffixWildcard() throws IOException {
+        // *0 expands at parse time to all columns ending in '0'. Identical to
+        // FieldsCommandIT.testFieldsSuffixWildcard on the analytics path; pinned here
+        // for the `table` lowering specifically. Order is analyzer-dependent, so set-equality.
+        Map<String, Object> response = executePpl(
+            "source=" + DATASET.indexName + " | table *0 | head 1"
+        );
+        @SuppressWarnings("unchecked")
+        List<String> columns = (List<String>) response.get("columns");
+        assertNotNull("Response missing 'columns'", columns);
+        java.util.Set<String> actual = new java.util.HashSet<>(columns);
+        java.util.Set<String> expected = new java.util.HashSet<>(
+            java.util.Arrays.asList("num0", "str0", "int0", "bool0", "date0", "time0", "datetime0")
+        );
+        assertEquals("Wildcard *0 column set", expected, actual);
+    }
+
+    public void testTableMinusExclusion() throws IOException {
+        // `table - num0, num1, num2, num3, num4` removes those five columns. The leading
+        // minus form is unique to `table`; `fields` uses `fields - a, b, ...` with a
+        // comma-separated list (no space-delimiting). Validates analytics path retains
+        // exclusion semantics.
+        Map<String, Object> response = executePpl(
+            "source=" + DATASET.indexName + " | table - num0, num1, num2, num3, num4 | head 1"
+        );
+        @SuppressWarnings("unchecked")
+        List<String> columns = (List<String>) response.get("columns");
+        assertNotNull("Response missing 'columns'", columns);
+        for (String name : columns) {
+            assertFalse("Excluded column should not appear: " + name, name.startsWith("num"));
+        }
+    }
+
+    public void testFieldsAndTableEquivalence() throws IOException {
+        // Cross-check that `fields a, b, c` and `table a, b, c` produce identical
+        // schema + rows. Makes the alias claim explicit at the response level so a
+        // future divergence (e.g. `table` accidentally adds a Sort or rewires the
+        // Project) is caught here.
+        Map<String, Object> fieldsResp = executePpl(
+            "source=" + DATASET.indexName + " | fields str0, num0, int0 | head 3"
+        );
+        Map<String, Object> tableResp = executePpl(
+            "source=" + DATASET.indexName + " | table str0, num0, int0 | head 3"
+        );
+        assertEquals("columns from fields vs table", fieldsResp.get("columns"), tableResp.get("columns"));
+        assertEquals("rows from fields vs table", fieldsResp.get("rows"), tableResp.get("rows"));
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────────────
+
+    private void assertColumns(String ppl, String... expectedColumns) throws IOException {
+        Map<String, Object> response = executePpl(ppl);
+        @SuppressWarnings("unchecked")
+        List<String> columns = (List<String>) response.get("columns");
+        assertNotNull("Response missing 'columns' for query: " + ppl, columns);
+        assertEquals("Column count for query: " + ppl, expectedColumns.length, columns.size());
+        for (int i = 0; i < expectedColumns.length; i++) {
+            assertEquals(
+                "Column at position " + i + " for query: " + ppl,
+                expectedColumns[i],
+                columns.get(i)
+            );
+        }
+    }
+
+    private Map<String, Object> executePpl(String ppl) throws IOException {
+        ensureDataProvisioned();
+        Request request = new Request("POST", "/_analytics/ppl");
+        request.setJsonEntity("{\"query\": \"" + escapeJson(ppl) + "\"}");
+        Response response = client().performRequest(request);
+        return assertOkAndParse(response, "PPL: " + ppl);
+    }
+}


### PR DESCRIPTION
## Summary

Lands two QA ITs against the analytics-engine REST path so PPL `appendpipe` and `table` are verified inside core without cross-plugin dependencies on the SQL plugin. Both reuse the existing `calcs` parquet-backed dataset via `DatasetProvisioner`; no new fixtures.

### `AppendPipeCommandIT` — 3 tests

`appendpipe` already passes 4/4 of its v2-side `CalcitePPLAppendPipeCommandIT` cases on the analytics-engine route under `tests.analytics.force_routing=true`. The existing capability surface (LogicalUnion + LogicalAggregate over SUM + SchemaUnifier type-conflict) is sufficient — no code changes in core for this command.

| Test | Shape | Notes |
|---|---|---|
| `testAppendPipeSort` | Duplicate post-stats stream, re-sort the duplicate inline | Exercises Union over identical schemas. The outer `sort str0` and the inner `sort -sum_int0_by_str0` pin both branches' orders, so positional row comparison works. |
| `testAppendPipeWithMergedColumn` | Duplicate post-stats stream, collapse via inner `stats sum(sum) as sum` | Exercises SchemaUnifier merging the str0-bearing original branch with the inner-branch single-row that has only `sum`. Branch arrival order at the coordinator's Union is non-deterministic, so multiset comparison. |
| `testAppendPipeWithConflictTypeColumn` | Inner pipeline rewrites same-named column to different type | Exercises the SchemaUnifier validation path that surfaces `"due to incompatible types"` before execution. |

`testAppendDifferentIndex` from the v2-side IT is intentionally not ported: it exercises `append` (separate `source=...` sub-search), which is already covered by [`AppendCommandIT`](sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/AppendCommandIT.java).

### `TableCommandIT` — 5 tests + 1 small fix in `test-ppl-frontend`

`table` is a syntactic alias of `fields` — the v2 `AstBuilder` dispatches both through `buildProjectCommand` once `plugins.calcite.enabled=true` is visible to the AstBuilder via the `UnifiedQueryContext`. The mirror fix on the SQL plugin side landed in [opensearch-project/sql#5413](https://github.com/opensearch-project/sql/pull/5413); this PR closes the same gap on the test-ppl-frontend side, where the `UnifiedQueryContext` is constructed locally rather than coming from the SQL plugin.

Two changes:

* **`UnifiedQueryService`** now sets `plugins.calcite.enabled=true` on the context. The unified path is Calcite-based by definition; without this flag the AstBuilder rejects `table` / `regex` / `rex` / `convert`.
* **New `TableCommandIT`** covering surfaces specific to the `table` keyword: comma-delimited, space-delimited, suffix wildcard, leading-`-` exclusion, and `fields` ↔ `table` row-and-schema equivalence on identical inputs. Plain projection semantics already covered by `FieldsCommandIT` are not duplicated.

| Test | Shape |
|---|---|
| `testTableCommaDelimited` | `table str0, num0` — same as `fields a, b`; sanity on the `table` keyword reaching `buildProjectCommand`. |
| `testTableSpaceDelimited` | `table str0 num0 int0` — unique to `table`; lexer accepts whitespace as separator. |
| `testTableSuffixWildcard` | `table *0` — wildcard expansion at parse time; analyzer-dependent column order, so set-equality. |
| `testTableMinusExclusion` | `table - num0, num1, num2, num3, num4` — leading-`-` exclusion form; analytics path retains exclusion semantics. |
| `testFieldsAndTableEquivalence` | `fields a, b, c` vs `table a, b, c` — identical schema and rows; alias claim made explicit at the response level. |

## Test plan

- [x] `./gradlew :sandbox:qa:analytics-engine-rest:integTest -Dsandbox.enabled=true --tests "*AppendPipeCommandIT"` — **3 / 3 green**
- [x] `./gradlew :sandbox:qa:analytics-engine-rest:integTest -Dsandbox.enabled=true --tests "*TableCommandIT"` — **5 / 5 green**
- [x] SQL-plugin-side `CalcitePPLAppendPipeCommandIT` against this branch with `-Dtests.analytics.force_routing=true -Dtests.analytics.parquet_indices=true` — **4 / 4** (verified before this PR — analytics path was already fine, no code changes needed in core)

## Out of scope

PPL `multisearch` was originally bundled with this PR. Triage showed ~12 of its 15 analytics-route failures are blocked on a Substrait-side issue: DataFusion's substrait consumer rejects the Plan emitted for `LogicalUnion(StageInputScan, StageInputScan)` with

```
Substrait error: Names list must match exactly to nested schema, but found 2 uses for 12 names
  at NativeBridge.executeLocalPlan(...)
  at DatafusionReduceSink.<init>(...)
  at DataFusionAnalyticsBackendPlugin.lambda$getExchangeSinkProvider$0(...)
  at LocalStageScheduler.createExecution(...)
```

The registered child-stage Arrow schema width vs. the `Plan.Root.names` width disagree somewhere between `LocalStageScheduler.buildChildInputs` and DataFusion's `make_renamed_schema`. Diagnostic logging confirms we send 12 names + a Substrait `set` rel with two `read.named_table` inputs whose `base_schema` each has 12 fields — DataFusion's `make_renamed_schema` only consumes 2 of the 12 names against the deserialized Union output schema, suggesting the registered partition table for `input-<stageId>` is exposing a 2-field schema instead of the expected 12-field one. Root cause not yet identified — out of scope here; tracked for a follow-up PR.

Other categories are kept out of scope by the same scope discipline as #21521:

* Aggregation surface (`AVG` Substrait-isthmus binding)
* TIMESTAMP / DATE type-system (`ArrowSchemaFromCalcite.toArrowType` doesn't handle `TIMESTAMP` / `DATE` / `TIME` / `TIMESTAMP_WITH_LOCAL_TIME_ZONE`)
* Eval-predicate scalars (`AND`/`OR`/`NOT`/`IS_NULL`/etc. in CASE projections)
* PPL `span` time-bucketing

Each is its own focused PR.