### PR TITLE
[Analytics Backend / DataFusion] Substrait Plan.Root.names + CASE + untyped-NULL fixes for multisearch

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionAnalyticsBackendPlugin.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionAnalyticsBackendPlugin.java
@@ -101,6 +101,14 @@ public class DataFusionAnalyticsBackendPlugin implements AnalyticsSearchBackendP
         ScalarFunction.CAST,
         ScalarFunction.CONCAT,
         ScalarFunction.SAFE_CAST,
+        // CASE — Calcite emits CASE WHEN ... THEN ... END for conditional expressions, including
+        // PPL `count(eval(predicate))` (lowered to COUNT(CASE WHEN predicate THEN ... ELSE NULL END))
+        // and explicit `eval x = case(cond, val, ...)`. Isthmus translates SqlKind.CASE structurally
+        // to a Substrait IfThen rel — no extension lookup needed, no adapter required. DataFusion's
+        // substrait consumer handles IfThen natively. Without this entry, the analytics planner
+        // rejects the operator with "No backend supports scalar function [CASE] among [datafusion]"
+        // before substrait emission.
+        ScalarFunction.CASE,
         // ABS / SUBSTRING — `eval x = abs(...)` and `eval s = substring(...)` projections that PPL
         // sort-pushdown moves into the project tree (see CalciteSortCommandIT
         // testPushdownSortExpressionContainsNull and CalcitePPLSortIT

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionFragmentConvertor.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionFragmentConvertor.java
@@ -160,8 +160,13 @@ public class DataFusionFragmentConvertor implements FragmentConvertor {
     // ── Core conversion helpers ─────────────────────────────────────────────────
 
     private byte[] convertToSubstrait(RelNode fragment) {
-        RelRoot root = RelRoot.of(fragment, SqlKind.SELECT);
-        SubstraitRelVisitor visitor = createVisitor(fragment);
+        // Rewrite SqlTypeName.NULL literals (Calcite's untyped null, emitted for the
+        // implicit ELSE arm of CASE) to typed nulls — isthmus' TypeConverter rejects NULL
+        // with "Unable to convert the type NULL". The widening only changes literal type
+        // tags; semantics and field names (used by Plan.Root.names) are unchanged.
+        RelNode preprocessed = UntypedNullPreprocessor.rewrite(fragment);
+        RelRoot root = RelRoot.of(preprocessed, SqlKind.SELECT);
+        SubstraitRelVisitor visitor = createVisitor(preprocessed);
         Rel substraitRel = visitor.apply(root.rel);
 
         List<String> fieldNames = root.fields.stream().map(field -> field.getValue()).toList();
@@ -185,8 +190,12 @@ public class DataFusionFragmentConvertor implements FragmentConvertor {
      * conversion and rewiring its input during {@link #rewire(Plan, Rel, List)}.
      */
     private Rel convertStandalone(RelNode operator) {
-        SubstraitRelVisitor visitor = createVisitor(operator);
-        return visitor.apply(operator);
+        // Same untyped-NULL preprocessing rationale as convertToSubstrait — the standalone
+        // wrapper conversion is just as susceptible to a SqlTypeName.NULL literal lurking in
+        // a CASE call attached on top of an inner plan.
+        RelNode preprocessed = UntypedNullPreprocessor.rewrite(operator);
+        SubstraitRelVisitor visitor = createVisitor(preprocessed);
+        return visitor.apply(preprocessed);
     }
 
     /**

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionFragmentConvertor.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionFragmentConvertor.java
@@ -70,7 +70,7 @@ import io.substrait.relation.Sort;
  *   <li>{@link #attachPartialAggOnTop(RelNode, byte[])} and
  *       {@link #attachFragmentOnTop(RelNode, byte[])} — convert the wrapping
  *       operator standalone, then rewire its input to the decoded inner plan's
- *       root via {@link #rewire(Plan, Rel)}.</li>
+ *       root via {@link #rewire(Plan, Rel, List)}.</li>
  * </ul>
  *
  * @opensearch.internal
@@ -126,7 +126,11 @@ public class DataFusionFragmentConvertor implements FragmentConvertor {
         LOGGER.debug("Attaching partial aggregate on top of {} inner bytes", innerBytes.length);
         Plan inner = decodePlan(innerBytes);
         Rel wrapper = convertStandalone(partialAggFragment);
-        Plan rewired = rewire(inner, withAggregationPhase(wrapper, Expression.AggregationPhase.INITIAL_TO_INTERMEDIATE));
+        Plan rewired = rewire(
+            inner,
+            withAggregationPhase(wrapper, Expression.AggregationPhase.INITIAL_TO_INTERMEDIATE),
+            fieldNames(partialAggFragment)
+        );
         return serializePlan(rewired);
     }
 
@@ -150,7 +154,7 @@ public class DataFusionFragmentConvertor implements FragmentConvertor {
         // the visitor still walks them top-down to build the wrapper rel.
         RelNode rewritten = rewriteStageInputScans(fragment);
         Rel wrapper = convertStandalone(rewritten);
-        return serializePlan(rewire(inner, wrapper));
+        return serializePlan(rewire(inner, wrapper, fieldNames(fragment)));
     }
 
     // ── Core conversion helpers ─────────────────────────────────────────────────
@@ -178,7 +182,7 @@ public class DataFusionFragmentConvertor implements FragmentConvertor {
      * children (e.g. the {@code attachPartialAggOnTop} caller passes a
      * {@code LogicalAggregate} whose input is the already-stripped inner tree); we
      * deliberately discard those children by taking only the outermost rel of the
-     * conversion and rewiring its input during {@link #rewire(Plan, Rel)}.
+     * conversion and rewiring its input during {@link #rewire(Plan, Rel, List)}.
      */
     private Rel convertStandalone(RelNode operator) {
         SubstraitRelVisitor visitor = createVisitor(operator);
@@ -191,15 +195,28 @@ public class DataFusionFragmentConvertor implements FragmentConvertor {
      * {@code wrapper(inner.root)}. Supports the known single-input wrappers emitted
      * by our four SPI methods ({@link Aggregate}, {@link Sort}, {@link Filter},
      * {@link Project}).
+     *
+     * <p>{@code wrapperNames} must be the wrapper's output column names — typically
+     * derived from the wrapper {@link RelNode}'s row type. For schema-preserving
+     * wrappers (Sort, Filter, Fetch) these match the inner plan's names; for
+     * schema-reshaping wrappers (Aggregate, Project) they don't, and using the
+     * inner's names there causes DataFusion's substrait consumer to reject the
+     * Plan with a "Names list must match exactly to nested schema" error in
+     * {@code make_renamed_schema}.
      */
-    static Plan rewire(Plan inner, Rel wrapper) {
+    static Plan rewire(Plan inner, Rel wrapper, List<String> wrapperNames) {
         if (inner.getRoots().isEmpty()) {
             throw new IllegalArgumentException("Inner Substrait plan has no root relation to rewire under wrapper");
         }
         Plan.Root innerRoot = inner.getRoots().get(0);
         Rel innerRel = innerRoot.getInput();
         Rel rewired = replaceInput(wrapper, innerRel);
-        return Plan.builder().addRoots(Plan.Root.builder().input(rewired).names(innerRoot.getNames()).build()).build();
+        return Plan.builder().addRoots(Plan.Root.builder().input(rewired).names(wrapperNames).build()).build();
+    }
+
+    /** Extracts a wrapper's output column names from its Calcite row type. */
+    private static List<String> fieldNames(RelNode fragment) {
+        return fragment.getRowType().getFieldList().stream().map(RelDataTypeField::getName).toList();
     }
 
     private static Rel replaceInput(Rel wrapper, Rel newInput) {

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/UntypedNullPreprocessor.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/UntypedNullPreprocessor.java
@@ -1,0 +1,120 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion;
+
+import org.apache.calcite.rel.RelHomogeneousShuttle;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexShuttle;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.type.SqlTypeName;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Pre-isthmus pass that rewrites untyped {@code NULL} literals
+ * ({@code RexLiteral} with {@link SqlTypeName#NULL}) to typed null literals
+ * inferred from their enclosing operator.
+ *
+ * <p>Calcite emits an untyped NULL for the implicit {@code ELSE} arm of
+ * {@code CASE WHEN cond THEN val END}, which is exactly the shape PPL
+ * {@code count(eval(predicate))} lowers to:
+ *
+ * <pre>{@code
+ *   COUNT(CASE WHEN predicate THEN <projected> END)   // ELSE is implicit NULL, type=NULL
+ * }</pre>
+ *
+ * <p>Isthmus' {@code TypeConverter.toSubstrait} rejects {@link SqlTypeName#NULL}
+ * with {@code "Unable to convert the type NULL"}. The CASE call's resolved
+ * return type already carries the right widened type ({@code NULLABLE BIGINT}
+ * for the count-eval shape, etc), so we substitute that.
+ *
+ * <p>Scope: only CASE call operands are rewritten today. Other untyped-NULL
+ * sites (function arguments, comparison RHS, etc) are rare in PPL-generated
+ * plans and would need per-operator type-inference to do safely; defer until
+ * a concrete test surfaces one.
+ *
+ * @opensearch.internal
+ */
+final class UntypedNullPreprocessor {
+
+    private UntypedNullPreprocessor() {}
+
+    /**
+     * Walk the RelNode tree, applying the rewrite to every node's expressions.
+     * Returns a new tree if any rewrite occurred, otherwise the input unchanged.
+     */
+    static RelNode rewrite(RelNode root) {
+        return root.accept(new RelHomogeneousShuttle() {
+            @Override
+            public RelNode visit(RelNode other) {
+                RelNode visited = super.visit(other);
+                return visited.accept(new CaseUntypedNullShuttle(visited.getCluster().getRexBuilder()));
+            }
+        });
+    }
+
+    /**
+     * Per-node rex shuttle: for every {@code CASE} call encountered, rewrite any
+     * {@link SqlTypeName#NULL}-typed literal operand into a typed null literal
+     * matching the CASE's resolved return type.
+     */
+    private static final class CaseUntypedNullShuttle extends RexShuttle {
+
+        private final RexBuilder rexBuilder;
+
+        CaseUntypedNullShuttle(RexBuilder rexBuilder) {
+            this.rexBuilder = rexBuilder;
+        }
+
+        @Override
+        public RexNode visitCall(RexCall call) {
+            // Recurse first so nested CASE calls are rewritten bottom-up — each inner CASE is
+            // resolved against its own return type, so by the time we look at the outer one,
+            // every operand is already typed.
+            RexCall recursed = (RexCall) super.visitCall(call);
+            if (recursed.getKind() != SqlKind.CASE) {
+                return recursed;
+            }
+            List<RexNode> operands = recursed.getOperands();
+            List<RexNode> rewritten = new ArrayList<>(operands.size());
+            boolean changed = false;
+            for (int i = 0; i < operands.size(); i++) {
+                RexNode op = operands.get(i);
+                if (isCaseValueOperand(i, operands.size()) && isUntypedNullLiteral(op)) {
+                    rewritten.add(rexBuilder.makeNullLiteral(recursed.getType()));
+                    changed = true;
+                } else {
+                    rewritten.add(op);
+                }
+            }
+            return changed ? recursed.clone(recursed.getType(), rewritten) : recursed;
+        }
+
+        /**
+         * Calcite's CASE operand layout is {@code [cond1, val1, cond2, val2, …, condN, valN, else]}.
+         * Conditions sit at even indices except the last operand (the ELSE), which is always
+         * a value. Returns true for value operands (the THEN/ELSE arms).
+         */
+        private static boolean isCaseValueOperand(int index, int total) {
+            return (index % 2 == 1) || (index == total - 1);
+        }
+
+        private static boolean isUntypedNullLiteral(RexNode node) {
+            if (!(node instanceof RexLiteral lit)) {
+                return false;
+            }
+            return lit.isNull() && lit.getType().getSqlTypeName() == SqlTypeName.NULL;
+        }
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionFragmentConvertorTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionFragmentConvertorTests.java
@@ -317,13 +317,7 @@ public class DataFusionFragmentConvertorTests extends OpenSearchTestCase {
         // For this regression, the inner doesn't need to be a final-agg — a bare scan-shaped
         // plan with 3-column rowType is enough to surface the wrapper-vs-inner names mismatch.
         // Use convertFinalAggFragment so the inner Plan.Root.names is the 3-column scan list.
-        RelNode innerStageScan = new OpenSearchStageInputScan(
-            cluster,
-            cluster.traitSet(),
-            0,
-            wideStageRowType,
-            List.of("datafusion")
-        );
+        RelNode innerStageScan = new OpenSearchStageInputScan(cluster, cluster.traitSet(), 0, wideStageRowType, List.of("datafusion"));
         // Wrap it in a no-op aggregate so the convertor accepts it as a final-agg fragment shape.
         // The inner's Plan.Root.names then carries the agg-output (1 col, "sum_col"), but the
         // *wrapper* we attach above has its own output rowType.

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionFragmentConvertorTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionFragmentConvertorTests.java
@@ -18,6 +18,7 @@ import org.apache.calcite.rel.core.AggregateCall;
 import org.apache.calcite.rel.logical.LogicalAggregate;
 import org.apache.calcite.rel.logical.LogicalFilter;
 import org.apache.calcite.rel.logical.LogicalSort;
+import org.apache.calcite.rel.logical.LogicalUnion;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rex.RexBuilder;
@@ -270,6 +271,169 @@ public class DataFusionFragmentConvertorTests extends OpenSearchTestCase {
         Rel aggInput = inner.getAggregate().getInput();
         assertTrue("Agg input must be a ReadRel", aggInput.hasRead());
         assertEquals(List.of("input-" + childStageId), aggInput.getRead().getNamedTable().getNamesList());
+    }
+
+    /**
+     * Regression: {@code attachPartialAggOnTop} must populate {@code Plan.Root.names}
+     * with the *wrapper aggregate's* output column names — not the inner scan's.
+     * Using the inner's names causes DataFusion's substrait consumer to fail
+     * {@code make_renamed_schema} with "Names list must match exactly to nested
+     * schema, but found {wrapper-width} uses for {inner-width} names" whenever
+     * the wrapper reshapes the schema (Aggregate, Project, etc).
+     */
+    public void testAttachPartialAggOnTop_PlanRootNamesMatchWrapperOutput() throws Exception {
+        DataFusionFragmentConvertor convertor = newConvertor();
+
+        // Inner scan has 3 columns; the partial-aggregate emits 1 (sum over col 0).
+        RelNode scan = buildTableScan("test_index", "A", "B", "C");
+        byte[] innerBytes = convertor.convertShardScanFragment("test_index", scan);
+        LogicalAggregate partialAgg = buildSumAggregate(scan, 0);
+
+        byte[] combined = convertor.attachPartialAggOnTop(partialAgg, innerBytes);
+
+        Plan plan = decodeSubstrait(combined);
+        List<String> rootNames = plan.getRelations(0).getRoot().getNamesList();
+        assertEquals(
+            "Plan.Root.names must match the wrapper aggregate's output schema (1 column), not the inner scan's (3 columns)",
+            List.of("sum_col"),
+            rootNames
+        );
+    }
+
+    /**
+     * Regression: {@code attachFragmentOnTop} for an Aggregate over a multi-column
+     * inner plan (e.g. Union of two stage-input scans) must populate
+     * {@code Plan.Root.names} with the aggregate's output names. Mirrors the
+     * multisearch coordinator-stage shape {@code Aggregate(Union(StageInputScan,
+     * StageInputScan))}.
+     */
+    public void testAttachFragmentOnTop_AggregateOverMultiColumnInner_PlanRootNamesMatchWrapperOutput() throws Exception {
+        DataFusionFragmentConvertor convertor = newConvertor();
+
+        // Inner: a final-agg fragment whose StageInputScan rowType is intentionally wide
+        // (3 columns). The aggregate above narrows it to 1 column.
+        RelDataType wideStageRowType = rowType("A", "B", "C");
+        RelNode stageInput = new OpenSearchStageInputScan(cluster, cluster.traitSet(), 0, wideStageRowType, List.of("datafusion"));
+        // For this regression, the inner doesn't need to be a final-agg — a bare scan-shaped
+        // plan with 3-column rowType is enough to surface the wrapper-vs-inner names mismatch.
+        // Use convertFinalAggFragment so the inner Plan.Root.names is the 3-column scan list.
+        RelNode innerStageScan = new OpenSearchStageInputScan(
+            cluster,
+            cluster.traitSet(),
+            0,
+            wideStageRowType,
+            List.of("datafusion")
+        );
+        // Wrap it in a no-op aggregate so the convertor accepts it as a final-agg fragment shape.
+        // The inner's Plan.Root.names then carries the agg-output (1 col, "sum_col"), but the
+        // *wrapper* we attach above has its own output rowType.
+        LogicalAggregate innerFinalAgg = buildSumAggregate(innerStageScan, 0);
+        byte[] innerBytes = convertor.convertFinalAggFragment(innerFinalAgg);
+
+        // Wrapper: a Project that maps the single inner column to two new aliases — this is
+        // the multisearch-style schema reshape that triggered the bug. We model it as another
+        // aggregate over the same input row type to keep the standalone conversion simple.
+        // The wrapper's output rowType has 1 column ("sum_col") which must end up in
+        // Plan.Root.names regardless of what the wide-row stage-input scan above looked like.
+        RelNode placeholderInput = buildTableScan("__placeholder__", "sum_col");
+        LogicalSort sortWrapper = LogicalSort.create(placeholderInput, RelCollations.of(0), null, null);
+
+        byte[] combined = convertor.attachFragmentOnTop(sortWrapper, innerBytes);
+
+        Plan plan = decodeSubstrait(combined);
+        List<String> rootNames = plan.getRelations(0).getRoot().getNamesList();
+        assertEquals(
+            "Plan.Root.names must reflect the Sort wrapper's output (1 column from the inner agg), "
+                + "not be miswritten with a wider list",
+            List.of("sum_col"),
+            rootNames
+        );
+    }
+
+    /**
+     * Mirror of multisearch's coordinator-stage shape:
+     * {@code Sort(Aggregate(Union(StageInputScan, StageInputScan, StageInputScan)))}.
+     * After the convertor chain runs (convertFinalAggFragment(Union) →
+     * attachFragmentOnTop(Aggregate) → attachFragmentOnTop(Sort)), the outermost
+     * {@code Plan.Root.names} must reflect the Sort's output schema (= the
+     * aggregate's 1-column output), not the inner Union's wider row type.
+     * This was the residual failure signature ("2 uses for 6 names") that the
+     * end-to-end IT surfaced even after the initial rewire fix.
+     */
+    public void testMultisearchShape_SortOverAggregateOverThreeWayUnion_PlanRootNamesMatchTopOutput() throws Exception {
+        DataFusionFragmentConvertor convertor = newConvertor();
+
+        // Inner: Union(Sin, Sin, Sin) — three branches, each 6 columns wide.
+        RelDataType branchRowType = rowType("a", "b", "c", "d", "e", "f");
+        RelNode sin1 = new OpenSearchStageInputScan(cluster, cluster.traitSet(), 1, branchRowType, List.of("datafusion"));
+        RelNode sin2 = new OpenSearchStageInputScan(cluster, cluster.traitSet(), 2, branchRowType, List.of("datafusion"));
+        RelNode sin3 = new OpenSearchStageInputScan(cluster, cluster.traitSet(), 3, branchRowType, List.of("datafusion"));
+        LogicalUnion union = LogicalUnion.create(List.of(sin1, sin2, sin3), true);
+        byte[] unionBytes = convertor.convertFinalAggFragment(union);
+
+        // Aggregate over the union: SUM(a) → 1 column output ("sum_col").
+        // attachFragmentOnTop expects the wrapper to carry its real input so the
+        // standalone visitor can derive types; the input is discarded by rewire.
+        LogicalAggregate aggregate = buildSumAggregate(union, 0);
+        byte[] aggBytes = convertor.attachFragmentOnTop(aggregate, unionBytes);
+
+        // Sort over the aggregate: schema-preserving wrapper.
+        LogicalSort sort = LogicalSort.create(aggregate, RelCollations.of(0), null, null);
+        byte[] combinedBytes = convertor.attachFragmentOnTop(sort, aggBytes);
+
+        Plan plan = decodeSubstrait(combinedBytes);
+        List<String> rootNames = plan.getRelations(0).getRoot().getNamesList();
+        assertEquals(
+            "Plan.Root.names must reflect the Sort wrapper's output (= aggregate's 1-column output), "
+                + "not the inner Union's 6-column row type — multisearch ThreeSubsearches regression",
+            List.of("sum_col"),
+            rootNames
+        );
+    }
+
+    /**
+     * Mirror of multisearch's full coordinator-stage shape including the implicit
+     * query-size LIMIT injected by {@code QueryService.convertToCalcitePlan}. The
+     * actual chain is:
+     *   Sort(fetch=N, collation=∅)          // system limit, lowered to a Substrait Fetch
+     *     Sort(collation=byKey, fetch=∅)    // user-level sort, lowered to a Substrait Sort
+     *       Aggregate(...)
+     *         Union(Sin, Sin, Sin)
+     */
+    public void testMultisearchShape_SystemLimitOverSortOverAggregateOverUnion_NamesMatchTopOutput() throws Exception {
+        DataFusionFragmentConvertor convertor = newConvertor();
+
+        // Inner: Union(Sin, Sin, Sin) — 6-column rows.
+        RelDataType branchRowType = rowType("a", "b", "c", "d", "e", "f");
+        RelNode sin1 = new OpenSearchStageInputScan(cluster, cluster.traitSet(), 1, branchRowType, List.of("datafusion"));
+        RelNode sin2 = new OpenSearchStageInputScan(cluster, cluster.traitSet(), 2, branchRowType, List.of("datafusion"));
+        RelNode sin3 = new OpenSearchStageInputScan(cluster, cluster.traitSet(), 3, branchRowType, List.of("datafusion"));
+        LogicalUnion union = LogicalUnion.create(List.of(sin1, sin2, sin3), true);
+        byte[] unionBytes = convertor.convertFinalAggFragment(union);
+
+        // Aggregate over the union: SUM(a) → 1 column.
+        LogicalAggregate aggregate = buildSumAggregate(union, 0);
+        byte[] aggBytes = convertor.attachFragmentOnTop(aggregate, unionBytes);
+
+        // User-level Sort by the single agg-output column — schema preserved.
+        LogicalSort userSort = LogicalSort.create(aggregate, RelCollations.of(0), null, null);
+        byte[] userSortBytes = convertor.attachFragmentOnTop(userSort, aggBytes);
+
+        // System limit = LogicalSort with no collation + fetch literal. Lowers to a
+        // Substrait Fetch rel (the convertor handles this in replaceInput).
+        org.apache.calcite.rex.RexNode fetchN = rexBuilder.makeLiteral(100, typeFactory.createSqlType(SqlTypeName.INTEGER), true);
+        LogicalSort systemLimit = LogicalSort.create(userSort, RelCollations.EMPTY, null, fetchN);
+        byte[] combinedBytes = convertor.attachFragmentOnTop(systemLimit, userSortBytes);
+
+        Plan plan = decodeSubstrait(combinedBytes);
+        List<String> rootNames = plan.getRelations(0).getRoot().getNamesList();
+        assertEquals(
+            "Plan.Root.names must reflect the system-limit Sort wrapper's output (= 1-column aggregate output), "
+                + "not the inner Union's 6-column row type — the implicit limit at the top of every "
+                + "analytics-engine plan must not surface stale inner-plan names.",
+            List.of("sum_col"),
+            rootNames
+        );
     }
 
     /**

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/UntypedNullPreprocessorTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/UntypedNullPreprocessorTests.java
@@ -1,0 +1,197 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion;
+
+import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.hep.HepPlanner;
+import org.apache.calcite.plan.hep.HepProgramBuilder;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.AggregateCall;
+import org.apache.calcite.rel.logical.LogicalAggregate;
+import org.apache.calcite.rel.logical.LogicalProject;
+import org.apache.calcite.rel.logical.LogicalValues;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.util.ImmutableBitSet;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.List;
+
+/**
+ * Tests for {@link UntypedNullPreprocessor}. Constructs Calcite RelNode trees that contain
+ * {@code SqlTypeName.NULL} literals in CASE branches and asserts the rewriter widens those
+ * to typed nulls matching the CASE's resolved return type.
+ */
+public class UntypedNullPreprocessorTests extends OpenSearchTestCase {
+
+    private RelDataTypeFactory typeFactory;
+    private RexBuilder rexBuilder;
+    private RelOptCluster cluster;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        typeFactory = new JavaTypeFactoryImpl();
+        rexBuilder = new RexBuilder(typeFactory);
+        HepPlanner planner = new HepPlanner(new HepProgramBuilder().build());
+        cluster = RelOptCluster.create(planner, rexBuilder);
+    }
+
+    /**
+     * The motivating shape: {@code COUNT(CASE WHEN cond THEN 1 ELSE NULL END)} — Calcite
+     * leaves the implicit ELSE arm as {@link SqlTypeName#NULL}, which isthmus rejects.
+     * After rewrite the ELSE literal must carry the CASE's resolved return type.
+     */
+    public void testCountEvalCaseRewritesElseNullToTypedNull() {
+        // Build: VALUES(true) → Project(CASE WHEN $0 THEN 1 ELSE null END as col)
+        RelDataType nullableInt = typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.INTEGER), true);
+        RelDataType boolType = typeFactory.createSqlType(SqlTypeName.BOOLEAN);
+
+        RelNode values = LogicalValues.createOneRow(cluster);
+        RexNode boolLit = rexBuilder.makeLiteral(true, boolType);
+        RexNode oneLit = rexBuilder.makeExactLiteral(java.math.BigDecimal.ONE, nullableInt);
+        // Untyped NULL — RexBuilder.constantNull() returns a literal whose type is NULL.
+        RexNode untypedNull = rexBuilder.constantNull();
+        // Sanity: the source literal is genuinely SqlTypeName.NULL.
+        assertEquals(SqlTypeName.NULL, untypedNull.getType().getSqlTypeName());
+
+        RexNode caseExpr = rexBuilder.makeCall(SqlStdOperatorTable.CASE, boolLit, oneLit, untypedNull);
+        RelDataType caseType = caseExpr.getType();
+        // Calcite resolves the CASE return type to the leastRestrictive of {INT, NULL} — so
+        // the CASE itself is already a nullable INT, but its untyped-NULL child operand is
+        // what isthmus chokes on.
+        assertEquals(SqlTypeName.INTEGER, caseType.getSqlTypeName());
+
+        RelNode project = LogicalProject.create(values, List.of(), List.of(caseExpr), List.of("col"), java.util.Set.of());
+
+        RelNode rewritten = UntypedNullPreprocessor.rewrite(project);
+
+        // Walk the rewritten Project's only expression: the CASE's ELSE arm must now be a
+        // typed null whose type matches the CASE's return type (nullable INT), not NULL.
+        LogicalProject rewrittenProj = (LogicalProject) rewritten;
+        RexCall rewrittenCase = (RexCall) rewrittenProj.getProjects().get(0);
+        RexNode rewrittenElse = rewrittenCase.getOperands().get(2);
+        assertTrue("ELSE arm must remain a literal", rewrittenElse instanceof RexLiteral);
+        assertEquals(
+            "ELSE arm type must be widened to the CASE return type, not NULL",
+            SqlTypeName.INTEGER,
+            rewrittenElse.getType().getSqlTypeName()
+        );
+        assertTrue("ELSE arm must still be null", ((RexLiteral) rewrittenElse).isNull());
+    }
+
+    /**
+     * THEN-arm null is rewritten the same way (the operand layout treats odd-indexed
+     * positions and the trailing operand as values; both can host an untyped NULL).
+     */
+    public void testCaseWithThenNullIsAlsoRewritten() {
+        RelDataType nullableInt = typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.INTEGER), true);
+        RelDataType boolType = typeFactory.createSqlType(SqlTypeName.BOOLEAN);
+        RelNode values = LogicalValues.createOneRow(cluster);
+
+        RexNode boolLit = rexBuilder.makeLiteral(true, boolType);
+        RexNode untypedNull = rexBuilder.constantNull();
+        RexNode oneLit = rexBuilder.makeExactLiteral(java.math.BigDecimal.ONE, nullableInt);
+
+        // CASE WHEN cond THEN <untyped null> ELSE 1 END — value-arm at index 1.
+        RexNode caseExpr = rexBuilder.makeCall(SqlStdOperatorTable.CASE, boolLit, untypedNull, oneLit);
+        RelNode project = LogicalProject.create(values, List.of(), List.of(caseExpr), List.of("col"), java.util.Set.of());
+
+        RelNode rewritten = UntypedNullPreprocessor.rewrite(project);
+        LogicalProject rewrittenProj = (LogicalProject) rewritten;
+        RexCall rewrittenCase = (RexCall) rewrittenProj.getProjects().get(0);
+        RexNode rewrittenThen = rewrittenCase.getOperands().get(1);
+        assertEquals(
+            "THEN arm null must also be widened to the CASE return type",
+            SqlTypeName.INTEGER,
+            rewrittenThen.getType().getSqlTypeName()
+        );
+    }
+
+    /**
+     * The condition operand at even indices (except the trailing else) is *not* a value
+     * arm — leave it alone. (We don't expect untyped NULLs as conditions, but the operand
+     * classifier should not touch even-index operands regardless.)
+     */
+    public void testCaseConditionOperandUnchanged() {
+        RelDataType nullableInt = typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.INTEGER), true);
+        RelDataType boolType = typeFactory.createSqlType(SqlTypeName.BOOLEAN);
+        RelNode values = LogicalValues.createOneRow(cluster);
+
+        RexNode boolLit = rexBuilder.makeLiteral(true, boolType);
+        RexNode oneLit = rexBuilder.makeExactLiteral(java.math.BigDecimal.ONE, nullableInt);
+        RexNode twoLit = rexBuilder.makeExactLiteral(java.math.BigDecimal.valueOf(2), nullableInt);
+
+        // CASE WHEN true THEN 1 ELSE 2 END — no untyped nulls; rewriter must be a no-op.
+        RexNode caseExpr = rexBuilder.makeCall(SqlStdOperatorTable.CASE, boolLit, oneLit, twoLit);
+        RelNode project = LogicalProject.create(values, List.of(), List.of(caseExpr), List.of("col"), java.util.Set.of());
+
+        RelNode rewritten = UntypedNullPreprocessor.rewrite(project);
+        LogicalProject rewrittenProj = (LogicalProject) rewritten;
+        RexCall rewrittenCase = (RexCall) rewrittenProj.getProjects().get(0);
+        // Operands unchanged structurally and by type.
+        for (int i = 0; i < 3; i++) {
+            assertEquals(
+                "Operand " + i + " should be unchanged when no untyped null is present",
+                caseExpr.accept(new org.apache.calcite.rex.RexShuttle() {}).toString(),
+                rewrittenCase.toString()
+            );
+            break;
+        }
+    }
+
+    /**
+     * End-to-end shape: the Project that motivates the rewrite usually feeds an Aggregate
+     * (e.g. {@code COUNT(case_col)}). Verify the Aggregate over a rewritten Project
+     * still type-checks and exposes the expected output schema.
+     */
+    public void testCountOverRewrittenCaseProjectionTypechecks() {
+        RelDataType nullableInt = typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.INTEGER), true);
+        RelDataType boolType = typeFactory.createSqlType(SqlTypeName.BOOLEAN);
+        RelNode values = LogicalValues.createOneRow(cluster);
+
+        RexNode boolLit = rexBuilder.makeLiteral(true, boolType);
+        RexNode oneLit = rexBuilder.makeExactLiteral(java.math.BigDecimal.ONE, nullableInt);
+        RexNode untypedNull = rexBuilder.constantNull();
+        RexNode caseExpr = rexBuilder.makeCall(SqlStdOperatorTable.CASE, boolLit, oneLit, untypedNull);
+
+        RelNode project = LogicalProject.create(values, List.of(), List.of(caseExpr), List.of("case_col"), java.util.Set.of());
+        AggregateCall countCall = AggregateCall.create(
+            SqlStdOperatorTable.COUNT,
+            false,
+            List.of(0),
+            -1,
+            typeFactory.createSqlType(SqlTypeName.BIGINT),
+            "good_count"
+        );
+        LogicalAggregate agg = LogicalAggregate.create(project, List.of(), ImmutableBitSet.of(), null, List.of(countCall));
+
+        RelNode rewritten = UntypedNullPreprocessor.rewrite(agg);
+        // The aggregate's input is the rewritten project; the project's CASE ELSE arm must
+        // now have a typed null. Walk one level down to verify.
+        LogicalAggregate rewrittenAgg = (LogicalAggregate) rewritten;
+        LogicalProject rewrittenProj = (LogicalProject) rewrittenAgg.getInput();
+        RexCall rewrittenCase = (RexCall) rewrittenProj.getProjects().get(0);
+        assertEquals(
+            "After Aggregate→Project recursion, the CASE's ELSE arm null must be typed",
+            SqlTypeName.INTEGER,
+            rewrittenCase.getOperands().get(2).getType().getSqlTypeName()
+        );
+        // And the COUNT aggregate output schema should still be a single BIGINT column.
+        assertEquals(1, rewrittenAgg.getRowType().getFieldCount());
+        assertEquals(SqlTypeName.BIGINT, rewrittenAgg.getRowType().getFieldList().get(0).getType().getSqlTypeName());
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/UntypedNullPreprocessorTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/UntypedNullPreprocessorTests.java
@@ -142,15 +142,9 @@ public class UntypedNullPreprocessorTests extends OpenSearchTestCase {
         RelNode rewritten = UntypedNullPreprocessor.rewrite(project);
         LogicalProject rewrittenProj = (LogicalProject) rewritten;
         RexCall rewrittenCase = (RexCall) rewrittenProj.getProjects().get(0);
-        // Operands unchanged structurally and by type.
-        for (int i = 0; i < 3; i++) {
-            assertEquals(
-                "Operand " + i + " should be unchanged when no untyped null is present",
-                caseExpr.accept(new org.apache.calcite.rex.RexShuttle() {}).toString(),
-                rewrittenCase.toString()
-            );
-            break;
-        }
+        // Whole CASE expression is structurally unchanged when no untyped nulls are present
+        // — the rewriter only fires on SqlTypeName.NULL operands.
+        assertEquals("CASE expression should be unchanged when no untyped null is present", caseExpr.toString(), rewrittenCase.toString());
     }
 
     /**

--- a/sandbox/plugins/test-ppl-frontend/build.gradle
+++ b/sandbox/plugins/test-ppl-frontend/build.gradle
@@ -17,8 +17,13 @@ apply plugin: 'opensearch.opensearchplugin'
 
 java { sourceCompatibility = JavaVersion.toVersion(25); targetCompatibility = JavaVersion.toVersion(25) }
 
-// SQL Unified Query API version (aligned with OpenSearch build version)
-def sqlUnifiedQueryVersion = '3.6.0.0-SNAPSHOT'
+// SQL Unified Query API version (aligned with OpenSearch build version).
+// Bumped to 3.7 so the bundled PPL grammar exposes commands added since 3.6
+// (multisearch, table, regex, rex, convert, …). The OpenSearch Snapshots repo
+// declared below carries the published 3.7.x.x-SNAPSHOT artifacts; for local
+// development against an unpublished sql-repo HEAD, run
+// `./gradlew :ppl:publishUnifiedQueryPublicationToMavenLocal` from the sql repo first.
+def sqlUnifiedQueryVersion = '3.7.0.0-SNAPSHOT'
 
 opensearchplugin {
   description = 'Test PPL front-end: REST endpoint backed by the unified PPL pipeline.'

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/MultisearchCommandIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/MultisearchCommandIT.java
@@ -128,6 +128,36 @@ public class MultisearchCommandIT extends AnalyticsRestTestCase {
         );
     }
 
+    // ── CASE with implicit ELSE NULL — `count(eval(predicate))` shape ──────────
+
+    public void testMultisearchCountEvalConditionalCount() throws IOException {
+        // Mirror of the v2-side `CalciteMultisearchCommandIT.testMultisearchSuccessRatePattern`:
+        // `count(eval(predicate))` is PPL's conditional-count idiom. Calcite lowers it to
+        // `COUNT(CASE WHEN predicate THEN <projected> END)`, where the implicit ELSE arm
+        // becomes a `RexLiteral` with `SqlTypeName.NULL`. Isthmus' TypeConverter rejects
+        // NULL with "Unable to convert the type NULL".
+        //
+        // The {@link UntypedNullPreprocessor} pass added in this PR rewrites every
+        // SqlTypeName.NULL operand in a CASE call to a typed null literal matching the
+        // CASE's resolved return type before the SubstraitRelVisitor sees the plan. CASE
+        // itself is registered in the project capability set so the planner doesn't reject
+        // the operator before substrait emission either.
+        //
+        // calcs int0 distribution (see testMultisearchTwoBranchesByCategory): 5 rows < 5,
+        // 6 rows >= 5; 6 nulls excluded by both branch predicates. After multisearch,
+        // 11 rows feed the count-eval. `count(eval(class = "low"))` matches 5 (the low-bucketed
+        // rows), `count(eval(class = "high"))` matches 6, and `count()` totals 11.
+        assertRows(
+            "| multisearch"
+                + "    [search source=" + DATASET.indexName + " | where int0 < 5  | eval class = \"low\"  | fields int0, class]"
+                + "    [search source=" + DATASET.indexName + " | where int0 >= 5 | eval class = \"high\" | fields int0, class]"
+                + " | stats count(eval(class = \"low\"))  as low_count,"
+                + "         count(eval(class = \"high\")) as high_count,"
+                + "         count() as grand_count",
+            row(5L, 6L, 11L)
+        );
+    }
+
     // ── arity check — caught at parse, never reaches the analytics path ────────
 
     public void testMultisearchSingleSubsearchRejected() throws IOException {

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/MultisearchCommandIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/MultisearchCommandIT.java
@@ -97,6 +97,37 @@ public class MultisearchCommandIT extends AnalyticsRestTestCase {
         );
     }
 
+    // ── CASE on the eval side — explicit case() expression lowers to CASE WHEN ──
+
+    public void testMultisearchEvalCaseProjection() throws IOException {
+        // PPL `eval x = case(cond, val, …)` lowers to a Calcite SqlKind.CASE which the
+        // analytics planner used to reject with "No backend supports scalar function
+        // [CASE] among [datafusion]" (capability not registered). With CASE in the
+        // project capability set, isthmus translates SqlKind.CASE structurally to a
+        // Substrait IfThen rel that DataFusion's substrait consumer handles natively —
+        // no extension lookup or adapter required.
+        //
+        // Each branch uses an explicit `else` arm so isthmus doesn't have to convert an
+        // untyped NULL literal — `eval bucket = case(int0 < 5, "low" else "rest")` keeps
+        // both arms VARCHAR. The `count(eval(predicate))` idiom (the v2-side
+        // testMultisearchSuccessRatePattern shape) generates an implicit `else NULL`
+        // whose type is SqlTypeName.NULL; isthmus' TypeConverter throws
+        // `Unable to convert the type NULL` on that, tracked separately.
+        //
+        // calcs int0 distribution (see testMultisearchTwoBranchesByCategory): 5 rows < 5,
+        // 6 rows >= 5; the union below feeds 11 rows total to the case-eval. low maps to
+        // ("low", 5), rest (the high branch's contribution) to ("rest", 6).
+        assertRows(
+            "| multisearch"
+                + "    [search source=" + DATASET.indexName + " | where int0 < 5  | fields int0]"
+                + "    [search source=" + DATASET.indexName + " | where int0 >= 5 | fields int0]"
+                + " | eval bucket = case(int0 < 5, \"low\" else \"rest\")"
+                + " | stats count by bucket | sort bucket",
+            row(5L, "low"),
+            row(6L, "rest")
+        );
+    }
+
     // ── arity check — caught at parse, never reaches the analytics path ────────
 
     public void testMultisearchSingleSubsearchRejected() throws IOException {

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/MultisearchCommandIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/MultisearchCommandIT.java
@@ -1,0 +1,187 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.qa;
+
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+import org.opensearch.client.ResponseException;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Self-contained integration test for PPL {@code multisearch} on the analytics-engine route.
+ *
+ * <p>Mirrors the simplest passing shapes from the SQL plugin's
+ * {@code CalciteMultisearchCommandIT}, narrowed to surfaces the analytics path
+ * already supports end-to-end (basic 2-way, 3-way, and the arity-check error).
+ *
+ * <p>{@code multisearch} produces a Calcite {@code LogicalUnion} of N branches with
+ * {@code SchemaUnifier} reconciling per-branch schemas. The coordinator stage shape
+ * the analytics path lowers is
+ * {@code Sort(Aggregate(Union(StageInputScan, …, StageInputScan)))} — the same
+ * shape the {@code DataFusionFragmentConvertor.rewire} fix
+ * (this PR's substrait `Plan.Root.names` repair) targets.
+ *
+ * <p>Reuses the {@code calcs} dataset; no new fixtures.
+ */
+public class MultisearchCommandIT extends AnalyticsRestTestCase {
+
+    private static final Dataset DATASET = new Dataset("calcs", "calcs");
+
+    private static boolean dataProvisioned = false;
+
+    private void ensureDataProvisioned() throws IOException {
+        if (dataProvisioned == false) {
+            DatasetProvisioner.provision(client(), DATASET);
+            dataProvisioned = true;
+        }
+    }
+
+    // ── basic 2-way multisearch with stats+sort ────────────────────────────────
+    // multisearch is a *statement-leading* command in the PPL grammar (it lives in the
+    // `pplCommands` alternation, not the mid-pipeline `commands` alternation). Each
+    // subsearch must carry its own `source=`; placing `source=... | multisearch …` is a
+    // syntax error.
+
+    public void testMultisearchTwoBranchesByCategory() throws IOException {
+        // Branch 1 keeps rows with int0 < 5 and labels them "low" via eval; branch 2 keeps
+        // int0 >= 5 and labels them "high". After Union, stats counts per `class` bucket.
+        // calcs int0 distribution: 1×{1, 3, 7, 10, 11}, 3×{4, 8}, 6×null.
+        // int0 < 5 → 5 rows (1 + 1 + 3 = low); int0 >= 5 → 6 rows (3 + 1 + 1 + 1 = high);
+        // 6 null rows excluded by both predicates (5 + 6 + 6 = 17 total).
+        // Verifies: Union over two same-schema projections + Aggregate(count by) on top —
+        // the convertReduceFragment chain attachFragmentOnTop(Sort,
+        // attachFragmentOnTop(Aggregate, convertFinalAggFragment(Union))).
+        // Each branch projects to (int0, class) so the union row type is scalar-only —
+        // calcs has date/time/datetime columns whose TIMESTAMP Calcite SQL type
+        // ArrowSchemaFromCalcite doesn't yet handle (separate follow-up).
+        assertRows(
+            "| multisearch"
+                + "    [search source=" + DATASET.indexName + " | where int0 < 5  | eval class = \"low\"  | fields int0, class]"
+                + "    [search source=" + DATASET.indexName + " | where int0 >= 5 | eval class = \"high\" | fields int0, class]"
+                + " | stats count by class | sort class",
+            row(6L, "high"),
+            row(5L, "low")
+        );
+    }
+
+    // ── 3-way multisearch — the shape that triggered the substrait names bug ───
+
+    public void testMultisearchThreeBranchesByStr0() throws IOException {
+        // Three string-equality branches over the calcs str0 column. `str0` distribution is
+        // FURNITURE=2, OFFICE SUPPLIES=6, TECHNOLOGY=9. The 3-way Union(ER, ER, ER) is the
+        // exact coordinator shape the DataFusionFragmentConvertor.rewire fix targets.
+        // Pre-fix: 500 with "Names list ... 2 uses for {row-type-width} names". Post-fix: the
+        // wrapper aggregate's [count, bucket] names propagate end-to-end, plan deserializes,
+        // DataFusion executes the Union+Aggregate.
+        // Each branch projects to (str0, bucket) — see testMultisearchTwoBranchesByCategory's
+        // comment for the reason.
+        assertRows(
+            "| multisearch"
+                + "    [search source=" + DATASET.indexName + " | where str0 = \"FURNITURE\"       | eval bucket = \"F\" | fields str0, bucket]"
+                + "    [search source=" + DATASET.indexName + " | where str0 = \"OFFICE SUPPLIES\" | eval bucket = \"O\" | fields str0, bucket]"
+                + "    [search source=" + DATASET.indexName + " | where str0 = \"TECHNOLOGY\"      | eval bucket = \"T\" | fields str0, bucket]"
+                + " | stats count by bucket | sort bucket",
+            row(2L, "F"),
+            row(6L, "O"),
+            row(9L, "T")
+        );
+    }
+
+    // ── arity check — caught at parse, never reaches the analytics path ────────
+
+    public void testMultisearchSingleSubsearchRejected() throws IOException {
+        // The PPL parser's AstBuilder.visitMultisearchCommand requires ≥2 subsearches and
+        // throws a SyntaxCheckException eagerly. This case exercises the parser-side guard
+        // — it never reaches CalciteRelNodeVisitor / SchemaUnifier / substrait emission, so
+        // it's a regression-pin against accidental relaxation of the arity check, not an
+        // analytics-path correctness check.
+        assertErrorContains(
+            "| multisearch [search source=" + DATASET.indexName + " | head 1]",
+            "Multisearch command requires at least two subsearches"
+        );
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────────────
+
+    private static List<Object> row(Object... values) {
+        return Arrays.asList(values);
+    }
+
+    @SafeVarargs
+    @SuppressWarnings("varargs")
+    private final void assertRows(String ppl, List<Object>... expected) throws IOException {
+        Map<String, Object> response = executePpl(ppl);
+        @SuppressWarnings("unchecked")
+        List<List<Object>> actualRows = (List<List<Object>>) response.get("rows");
+        assertNotNull("Response missing 'rows' for query: " + ppl, actualRows);
+        assertEquals("Row count mismatch for query: " + ppl, expected.length, actualRows.size());
+        for (int i = 0; i < expected.length; i++) {
+            List<Object> want = expected[i];
+            List<Object> got = actualRows.get(i);
+            assertEquals(
+                "Column count mismatch at row " + i + " for query: " + ppl,
+                want.size(),
+                got.size()
+            );
+            for (int j = 0; j < want.size(); j++) {
+                assertCellEquals(
+                    "Cell mismatch at row " + i + ", col " + j + " for query: " + ppl,
+                    want.get(j),
+                    got.get(j)
+                );
+            }
+        }
+    }
+
+    private void assertErrorContains(String ppl, String expectedSubstring) throws IOException {
+        try {
+            Map<String, Object> response = executePpl(ppl);
+            fail("Expected query to fail with [" + expectedSubstring + "] but got response: " + response);
+        } catch (ResponseException e) {
+            String body;
+            try {
+                body = org.opensearch.test.rest.OpenSearchRestTestCase.entityAsMap(e.getResponse()).toString();
+            } catch (IOException ioe) {
+                body = e.getMessage();
+            }
+            assertTrue(
+                "Expected response body to contain [" + expectedSubstring + "] but was: " + body,
+                body.contains(expectedSubstring)
+            );
+        }
+    }
+
+    private Map<String, Object> executePpl(String ppl) throws IOException {
+        ensureDataProvisioned();
+        Request request = new Request("POST", "/_analytics/ppl");
+        request.setJsonEntity("{\"query\": \"" + escapeJson(ppl) + "\"}");
+        Response response = client().performRequest(request);
+        return assertOkAndParse(response, "PPL: " + ppl);
+    }
+
+    private static void assertCellEquals(String message, Object expected, Object actual) {
+        if (expected == null || actual == null) {
+            assertEquals(message, expected, actual);
+            return;
+        }
+        if (expected instanceof Number && actual instanceof Number) {
+            double e = ((Number) expected).doubleValue();
+            double a = ((Number) actual).doubleValue();
+            if (Double.compare(e, a) != 0) {
+                fail(message + ": expected <" + expected + "> but was <" + actual + ">");
+            }
+            return;
+        }
+        assertEquals(message, expected, actual);
+    }
+}


### PR DESCRIPTION
## Summary

Three small analytics-engine fixes that together unblock the common PPL `multisearch` shapes, plus a QA IT that exercises the route end-to-end inside core.

### 1. Substrait `Plan.Root.names` mismatch on schema-reshaping wrappers

`DataFusionFragmentConvertor.rewire(...)` always populated the new `Plan.Root.names` list with the *inner* plan's column names. For schema-preserving wrappers (Sort, Filter, Fetch) those happen to coincide with the wrapper's output schema, so the bug was hidden. For schema-reshaping wrappers (Aggregate, Project) the wrapper's output width differs from the inner's, and DataFusion's substrait consumer rejects the plan in `make_renamed_schema` with:

```
Substrait error: Names list must match exactly to nested schema, but found {wrapper-width} uses for {inner-width} names
```

Multisearch hits this at `Sort(Aggregate(Union(StageInputScan, …)))` — the Aggregate narrows the wide Union row type. **Fix:** derive the new `Plan.Root.names` from the wrapper RelNode's row type (`fragment.getRowType().getFieldList()`), not the inner plan's names. Both `attachFragmentOnTop` and `attachPartialAggOnTop` already have the wrapper RelNode in scope, so this is a local change with no signature ripple beyond adding a `List<String> wrapperNames` parameter to `rewire`.

### 2. Register CASE in `STANDARD_PROJECT_OPS`

Calcite emits `SqlKind.CASE` for `eval x = case(cond, val, …)` and several other conditional shapes. The analytics planner used to reject it with `No backend supports scalar function [CASE] among [datafusion]` before substrait emission. CASE doesn't need a backend adapter — isthmus translates `SqlKind.CASE` structurally to a Substrait `IfThen` rel that DataFusion's consumer handles natively. Just registering the capability is enough.

### 3. Pre-isthmus untyped-NULL rewriter for CASE arms

Calcite emits a `RexLiteral` with `SqlTypeName.NULL` for the implicit ELSE arm of `CASE WHEN cond THEN val END` — exactly the shape PPL `count(eval(predicate))` lowers to (`COUNT(CASE WHEN predicate THEN <projected> END)`). Isthmus' `TypeConverter.toSubstrait` rejects `SqlTypeName.NULL` with `Unable to convert the type NULL`, blocking the analytics path before substrait emission.

**Fix:** new `UntypedNullPreprocessor` — a `RelHomogeneousShuttle` + `RexShuttle` pass applied in `convertToSubstrait` and `convertStandalone` *before* the SubstraitRelVisitor sees the plan. Walks every CASE call's value operands (THEN arms and the ELSE arm) and substitutes any `SqlTypeName.NULL` literal with a typed null literal matching the CASE's resolved return type. Calcite already widens the CASE's return type to the leastRestrictive of branches, so the substituted type is correct by construction.

Scope is intentionally narrow: only CASE call operands today. Other untyped-NULL contexts (function arguments, comparison RHS) are rare in PPL-generated plans and would need per-operator type inference to do safely; defer until a concrete test surfaces one.

## Test coverage

### Convertor unit tests (`DataFusionFragmentConvertorTests`, +4)

Each new test decodes the emitted Substrait plan and asserts `Plan.Root.names`:

| Test | Shape |
|---|---|
| `testAttachPartialAggOnTop_PlanRootNamesMatchWrapperOutput` | partial-agg path: 3-col scan → 1-col agg wrapper. |
| `testAttachFragmentOnTop_AggregateOverMultiColumnInner_PlanRootNamesMatchWrapperOutput` | the multisearch coordinator-stage shape. |
| `testMultisearchShape_SortOverAggregateOverThreeWayUnion_PlanRootNamesMatchTopOutput` | full chain `Sort → Aggregate → Union(Sin × 3)`. |
| `testMultisearchShape_SystemLimitOverSortOverAggregateOverUnion_NamesMatchTopOutput` | adds the implicit `LogicalSystemLimit` wrapper at the top of every analytics-engine plan. |

### Untyped-NULL rewriter unit tests (`UntypedNullPreprocessorTests`, new — 4)

| Test | Shape |
|---|---|
| `testCountEvalCaseRewritesElseNullToTypedNull` | the motivating shape `COUNT(CASE WHEN cond THEN 1 ELSE null END)`. |
| `testCaseWithThenNullIsAlsoRewritten` | null in the THEN arm. |
| `testCaseConditionOperandUnchanged` | even-index condition operands left alone. |
| `testCountOverRewrittenCaseProjectionTypechecks` | Aggregate(Project(CASE)) end-to-end type-check. |

### QA IT (`MultisearchCommandIT`, new — analytics-engine REST path)

Five tests against the in-process QA cluster, exercising the analytics path end-to-end via the `test-ppl-frontend` plugin:

| Test | Shape |
|---|---|
| `testMultisearchTwoBranchesByCategory` | Basic 2-way Union over int0 buckets — same convertReduceFragment chain the rewire fix targets. |
| `testMultisearchThreeBranchesByStr0` | 3-way Union — the exact `Union(ER, ER, ER)` shape that surfaced the residual "2 uses for 6 names" failure I'd flagged as a follow-up in an earlier draft of this PR description; the rewire fix already covers it. |
| `testMultisearchEvalCaseProjection` | `multisearch \| eval bucket = case(cond, val else default) \| stats count by bucket` — pins the CASE-registration path with explicit-else. |
| `testMultisearchCountEvalConditionalCount` | `multisearch \| stats count(eval(predicate))` — pins the CASE + untyped-NULL rewriter path; mirrors the v2-side `CalciteMultisearchCommandIT.testMultisearchSuccessRatePattern` shape. |
| `testMultisearchSingleSubsearchRejected` | Arity check pinned at the parser layer (regression-pin against accidental relaxation). |

Each subsearch projects to a scalar-only field set so the union row type sidesteps the calcs dataset's date/time/datetime columns — `ArrowSchemaFromCalcite.toArrowType` doesn't yet handle TIMESTAMP, tracked separately.

The PR also bumps `test-ppl-frontend` and `analytics-backend-datafusion`'s `unified-query-*` pin from `3.6.0.0-SNAPSHOT` to `3.7.0.0-SNAPSHOT` so the bundled PPL grammar exposes `multisearch` (along with `table`/`regex`/`rex`/`convert` added since 3.6). Both pins must move together because gradle resolution rejects mixed versions on `internalClusterTestCompileClasspath`.

## Test plan

- [x] `./gradlew :sandbox:plugins:analytics-backend-datafusion:test --tests '*FragmentConvertorTests' -Dsandbox.enabled=true` — **12 / 12 green**
- [x] `./gradlew :sandbox:plugins:analytics-backend-datafusion:test --tests '*UntypedNullPreprocessorTests' -Dsandbox.enabled=true` — **4 / 4 green**
- [x] `./gradlew :sandbox:qa:analytics-engine-rest:integTest --tests '*MultisearchCommandIT' -Dsandbox.enabled=true` — **5 / 5 green**
- [x] `./gradlew :sandbox:qa:analytics-engine-rest:integTest -Dsandbox.enabled=true` — **112 / 112 across 14 ITs** (no regressions in AppendCommandIT, FieldsCommandIT, RenameCommandIT, SortCommandIT, HeadCommandIT, EvalCommandIT, FillNullCommandIT, OperatorCommandIT, SearchOperatorIT, WhereCommandIT, ParquetDataFusionIT, PplClickBenchIT, DslClickBenchIT, MultisearchCommandIT).
- [x] `./gradlew check -p sandbox -Dsandbox.enabled=true` — green end-to-end.
- [x] SQL plugin's `CalciteMultisearchCommandIT` against the runTask cluster (`opensearch + analytics-engine + opensearch-sql-plugin + opensearch-job-scheduler`) via `:integ-test:analyticsCompatibilityTest --tests 'org.opensearch.sql.calcite.remote.CalciteMultisearchCommandIT'` — **12 / 21 pass** (was 0 / 21 before this PR; was 11 / 21 after the substrait Plan.Root.names + CASE-registration commits but before the untyped-NULL preprocessor; the preprocessor unblocks `testMultisearchSuccessRatePattern`).

## What's still failing on multisearch (out of scope here)

The remaining `CalciteMultisearchCommandIT` failures on the SQL plugin's runTask cluster are blocked on issues independent of these fixes:

* **`No backend supports scalar function [TIMESTAMP|SPAN]`** (4 tests) — same out-of-scope categories tracked from #21521 / #21526. Need backend capability registration in `DataFusionAnalyticsBackendPlugin`.
* **`Unsupported Calcite SQL type: TIMESTAMP`** (2 tests) — `ArrowSchemaFromCalcite.toArrowType` doesn't handle TIMESTAMP yet.
* **`Unable to find binding for call AVG($1)`** (1 test) — known Substrait-isthmus binding issue with `NullableSqlAvgAggFunction`.
* **`Execution error: Panic: primitive array`** (1 test on `testMultisearchWithTimeIndicesTimestampOrdering`) — Rust-side panic from DataFusion, separate triage.
* **Two SocketTimeoutException** (60s each, on the largest two queries) — likely benign slowness on parquet-backed indices, separate perf concern.

### Note on stale-state artifacts

An earlier draft of this PR description listed 8 `Field [...] not found` failures. Those were artifacts of running the IT against a cluster that had inherited indices from previous failed test runs — they do not reproduce on a fresh cluster, and aren't part of the residual set above.