### PR TITLE
Add IO task cancellation support for DataFusion queries

### DIFF
--- a/sandbox/libs/dataformat-native/rust/Cargo.toml
+++ b/sandbox/libs/dataformat-native/rust/Cargo.toml
@@ -33,6 +33,7 @@ datafusion-substrait = "52.1.0"
 
 # Async
 tokio = { version = "1.0", features = ["full"] }
+tokio-util = "0.7"
 futures = "0.3"
 tokio-stream = "0.1.17"
 

--- a/sandbox/plugins/analytics-backend-datafusion/rust/Cargo.toml
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/Cargo.toml
@@ -29,6 +29,7 @@ prost = { workspace = true }
 substrait = { workspace = true }
 
 tokio = { workspace = true }
+tokio-util = { workspace = true }
 futures = { workspace = true }
 tokio-stream = { workspace = true }
 parking_lot = { workspace = true }

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/api.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/api.rs
@@ -53,12 +53,13 @@ use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::prelude::SessionConfig;
 use futures::TryStreamExt;
 
+use crate::cancellation;
 use crate::cross_rt_stream::CrossRtStream;
 use crate::custom_cache_manager::CustomCacheManager;
 use crate::local_executor::LocalSession;
 use crate::memory::{DynamicLimitHandle, DynamicLimitPool};
 use crate::partition_stream::PartitionStreamSender;
-use crate::query_memory_pool_tracker::QueryTrackingContext;
+use crate::query_tracker::{self, QueryTrackingContext};
 use crate::runtime_manager::RuntimeManager;
 
 /// Bundles a stream with its query tracking context so that dropping the
@@ -259,6 +260,8 @@ pub unsafe fn close_reader(ptr: i64) {
 
 /// Executes a query. Returns a heap-allocated pointer (as i64) to the result stream.
 /// Caller must call `stream_close` exactly once to free it.
+/// If `context_id != 0`, registers a cancellation token in ACTIVE_QUERIES before
+/// execution so `cancel_query()` can interrupt it even during planning.
 ///
 /// This is an async function — the bridge layer decides how to run it
 /// (`block_on` for synchronous delivery, `spawn` for async delivery).
@@ -290,32 +293,39 @@ pub async unsafe fn execute_query(
     // index_filter(bytes) calls. Cheap — just bytes inspection.
     let is_indexed = plan_bytes_mentions_index_filter(plan_bytes);
 
-    let stream_ptr = if is_indexed {
-        let qc = Arc::new(query_config);
-        crate::indexed_executor::execute_indexed_query(
-            plan_bytes.to_vec(),
-            table_name.to_string(),
-            shard_view,
-            qc.target_partitions.max(1),
-            runtime,
-            cpu_executor,
-            query_memory_pool,
-            qc,
-        )
-        .await?
-    } else {
-        crate::query_executor::execute_query(
-            shard_view.table_path.clone(),
-            shard_view.object_metas.clone(),
-            table_name.to_string(),
-            plan_bytes.to_vec(),
-            runtime,
-            cpu_executor,
-            query_memory_pool,
-            &query_config,
-        )
-        .await?
+    // Register cancellation token.
+    let token = query_tracker::get_cancellation_token(context_id);
+
+    let query_future = async {
+        if is_indexed {
+            let qc = Arc::new(query_config);
+            crate::indexed_executor::execute_indexed_query(
+                plan_bytes.to_vec(),
+                table_name.to_string(),
+                shard_view,
+                qc.target_partitions.max(1),
+                runtime,
+                cpu_executor,
+                query_memory_pool,
+                qc,
+            ).await
+        } else {
+            crate::query_executor::execute_query(
+                shard_view.table_path.clone(),
+                shard_view.object_metas.clone(),
+                table_name.to_string(),
+                plan_bytes.to_vec(),
+                runtime,
+                cpu_executor,
+                query_memory_pool,
+                &query_config,
+            ).await
+        }
     };
+
+    let stream_ptr = cancellation::cancellable(token.as_ref(), context_id, query_future)
+        .await
+        .map_err(|e| DataFusionError::Execution(e))?;
 
     // Reconstruct the stream from the raw pointer returned by the executor.
     let stream = *Box::from_raw(stream_ptr as *mut RecordBatchStreamAdapter<CrossRtStream>);
@@ -356,7 +366,8 @@ pub unsafe fn stream_get_schema(stream_ptr: i64) -> Result<i64, DataFusionError>
 
 /// Loads the next record batch from the stream.
 ///
-/// Returns a heap-allocated FFI_ArrowArray pointer (as i64), or 0 if end-of-stream.
+/// Returns a heap-allocated FFI_ArrowArray pointer (as i64), or 0 if end-of-stream
+/// or cancelled.
 ///
 /// This is an async function — the bridge layer decides how to run it.
 ///
@@ -365,8 +376,14 @@ pub unsafe fn stream_get_schema(stream_ptr: i64) -> Result<i64, DataFusionError>
 /// on the same stream.
 pub async unsafe fn stream_next(stream_ptr: i64) -> Result<i64, DataFusionError> {
     let handle = &mut *(stream_ptr as *mut QueryStreamHandle);
+    let token = query_tracker::get_cancellation_token(handle._query_tracking_context.context_id());
 
-    let result = handle.stream.try_next().await?;
+    let result = cancellation::cancellable_or(
+        token.as_ref(),
+        None,
+        async { handle.stream.try_next().await.map_err(|e: DataFusionError| e) },
+    ).await
+    .map_err(|e| DataFusionError::Execution(e))?;
 
     match result {
         Some(batch) => {
@@ -389,6 +406,12 @@ pub unsafe fn stream_close(stream_ptr: i64) {
         // The context's Drop impl marks the query completed in the registry.
         let _ = Box::from_raw(stream_ptr as *mut QueryStreamHandle);
     }
+}
+
+/// Fires the cancellation token for the given context_id.
+/// No-op for unknown or already-completed queries.
+pub fn cancel_query(context_id: i64) {
+    query_tracker::cancel_query(context_id);
 }
 
 /// Converts SQL to Substrait plan bytes (test only).

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/cancellation.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/cancellation.rs
@@ -1,0 +1,59 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+//! Cancellation helpers for DataFusion query tasks.
+//!
+//! The cancellation token itself lives in [`crate::query_tracker::QueryTracker`].
+//! This module provides `select!`-based helpers that race a future against a token.
+
+use std::future::Future;
+use tokio_util::sync::CancellationToken;
+
+/// Race a future against a cancellation token. Returns a cancellation error string
+/// if the token fires first. Pass `None` for non-cancellable queries.
+pub async fn cancellable<F, T, E>(
+    token: Option<&CancellationToken>,
+    context_id: i64,
+    fut: F,
+) -> Result<T, String>
+where
+    F: Future<Output = Result<T, E>>,
+    E: std::fmt::Display,
+{
+    match token {
+        Some(token) => {
+            tokio::select! {
+                result = fut => result.map_err(|e| e.to_string()),
+                _ = token.cancelled() => Err(format!("Query {} cancelled", context_id)),
+            }
+        }
+        None => fut.await.map_err(|e| e.to_string()),
+    }
+}
+
+/// Variant that returns a sentinel value on cancellation instead of an error.
+/// Used by `stream_next` where `None` signals cancellation/EOF.
+pub async fn cancellable_or<F, T, E>(
+    token: Option<&CancellationToken>,
+    sentinel: T,
+    fut: F,
+) -> Result<T, String>
+where
+    F: Future<Output = Result<T, E>>,
+    E: std::fmt::Display,
+{
+    match token {
+        Some(token) => {
+            tokio::select! {
+                result = fut => result.map_err(|e| e.to_string()),
+                _ = token.cancelled() => Ok(sentinel),
+            }
+        }
+        None => fut.await.map_err(|e| e.to_string()),
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/ffm.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/ffm.rs
@@ -197,6 +197,11 @@ pub unsafe extern "C" fn df_stream_close(stream_ptr: i64) {
     api::stream_close(stream_ptr);
 }
 
+#[no_mangle]
+pub extern "C" fn df_cancel_query(context_id: i64) {
+    api::cancel_query(context_id);
+}
+
 #[ffm_safe]
 #[no_mangle]
 pub unsafe extern "C" fn df_sql_to_substrait(

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/lib.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/lib.rs
@@ -13,6 +13,7 @@
 
 pub mod api;
 pub mod cache;
+pub mod cancellation;
 pub mod cross_rt_stream;
 pub mod custom_cache_manager;
 pub mod datafusion_query_config;
@@ -26,7 +27,7 @@ pub mod local_executor;
 pub mod memory;
 pub mod partition_stream;
 pub mod query_executor;
-pub mod query_memory_pool_tracker;
+pub mod query_tracker;
 pub mod runtime_manager;
 pub mod session_context;
 pub mod statistics_cache;

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/query_tracker.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/query_tracker.rs
@@ -25,6 +25,7 @@ use std::time::Instant;
 use dashmap::DashMap;
 use log::debug;
 use once_cell::sync::Lazy;
+use tokio_util::sync::CancellationToken;
 
 use datafusion::common::DataFusionError;
 use datafusion::execution::memory_pool::{MemoryConsumer, MemoryPool, MemoryReservation};
@@ -115,6 +116,7 @@ pub struct QueryTracker {
     pub start_time: Instant,
     pub context_id: i64,
     pub memory_pool: Arc<QueryMemoryPool>,
+    pub cancellation_token: CancellationToken,
     completed: AtomicBool,
     wall_nanos: std::sync::atomic::AtomicU64,
 }
@@ -157,6 +159,19 @@ pub fn drain_completed_query(context_id: i64) -> Option<Arc<QueryTracker>> {
         .map(|(_, t)| t)
 }
 
+/// Fire the cancellation token for the given context_id.
+/// No-op for unknown or already-completed queries.
+pub fn cancel_query(context_id: i64) {
+    if let Some(tracker) = QUERY_REGISTRY.get(&context_id) {
+        tracker.cancellation_token.cancel();
+    }
+}
+
+/// Clone the cancellation token for the given context_id, if registered.
+pub fn get_cancellation_token(context_id: i64) -> Option<CancellationToken> {
+    QUERY_REGISTRY.get(&context_id).map(|t| t.cancellation_token.clone())
+}
+
 // ---------------------------------------------------------------------------
 // QueryTrackingContext
 // ---------------------------------------------------------------------------
@@ -185,6 +200,11 @@ impl QueryTrackingContext {
             start_time: Instant::now(),
             context_id,
             memory_pool: query_pool,
+            // CancellationToken is a thread-safe, cloneable handle that can be used to
+            // signal cancellation to async tasks via `token.cancelled().await` in a
+            // `tokio::select!` branch. Calling `token.cancel()` fires all waiters.
+            // See: https://github.com/tokio-rs/tokio/blob/master/tokio-util/src/sync/cancellation_token/tree_node.rs
+            cancellation_token: CancellationToken::new(),
             completed: AtomicBool::new(false),
             wall_nanos: std::sync::atomic::AtomicU64::new(0),
         });
@@ -198,6 +218,11 @@ impl QueryTrackingContext {
     /// if tracking is disabled.
     pub fn memory_pool(&self) -> Option<Arc<QueryMemoryPool>> {
         self.tracker.as_ref().map(|t| Arc::clone(&t.memory_pool))
+    }
+
+    /// The context_id for this query, or 0 if tracking is disabled.
+    pub fn context_id(&self) -> i64 {
+        self.tracker.as_ref().map_or(0, |t| t.context_id)
     }
 }
 

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/session_context.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/session_context.rs
@@ -29,7 +29,7 @@ use log::error;
 use object_store::ObjectMeta;
 
 use crate::api::{DataFusionRuntime, ShardView};
-use crate::query_memory_pool_tracker::QueryTrackingContext;
+use crate::query_tracker::QueryTrackingContext;
 
 /// Opaque handle holding a configured SessionContext between FFM calls.
 pub struct SessionContextHandle {

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/nativelib/NativeBridge.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/nativelib/NativeBridge.java
@@ -75,6 +75,7 @@ public final class NativeBridge {
     private static final MethodHandle CREATE_SESSION_CONTEXT;
     private static final MethodHandle CLOSE_SESSION_CONTEXT;
     private static final MethodHandle EXECUTE_WITH_CONTEXT;
+    private static final MethodHandle CANCEL_QUERY;
 
     static {
         SymbolLookup lib = NativeLibraryLoader.symbolLookup();
@@ -344,6 +345,8 @@ public final class NativeBridge {
             )
         );
 
+        CANCEL_QUERY = linker.downcallHandle(lib.find("df_cancel_query").orElseThrow(), FunctionDescriptor.ofVoid(ValueLayout.JAVA_LONG));
+
         // Hand the five filter-tree upcall stubs to Rust now. No explicit
         // caller step required — as soon as this class is loaded, callbacks
         // are installed and `df_execute_indexed_query` can dispatch into Java.
@@ -583,6 +586,13 @@ public final class NativeBridge {
 
     public static void streamClose(long streamPtr) {
         NativeCall.invokeVoid(STREAM_CLOSE, streamPtr);
+    }
+
+    // ---- Cancellation ----
+
+    /** Fires the cancellation token for the given context. No-op if already completed. */
+    public static void cancelQuery(long contextId) {
+        NativeCall.invokeVoid(CANCEL_QUERY, contextId);
     }
 
     // ---- Stubs ----


### PR DESCRIPTION
Introduce per-query CancellationToken registry (ACTIVE_QUERIES) in api.rs with select!-based cancellation for execute_query and stream_next. QueryStreamHandle auto-deregisters on drop.

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
