### PR TITLE
Handle null scripted metric combine results

### DIFF
--- a/server/src/main/java/org/opensearch/search/aggregations/metrics/ScriptedMetricAggregator.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/metrics/ScriptedMetricAggregator.java
@@ -158,7 +158,9 @@ class ScriptedMetricAggregator extends MetricsAggregator {
     @Override
     public InternalAggregation buildAggregation(long owningBucketOrdinal) {
         Object result = aggStateForResult(owningBucketOrdinal).combine();
-        if (result.getClass() != ScriptedAvg.class) StreamOutput.checkWriteable(result);
+        if (result != null && result.getClass() != ScriptedAvg.class) {
+            StreamOutput.checkWriteable(result);
+        }
         return new InternalScriptedMetric(name, singletonList(result), reduceScript, metadata());
     }
 

--- a/server/src/test/java/org/opensearch/search/aggregations/metrics/ScriptedMetricAggregatorTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/metrics/ScriptedMetricAggregatorTests.java
@@ -416,7 +416,10 @@ public class ScriptedMetricAggregatorTests extends AggregatorTestCase {
             }
             try (IndexReader indexReader = DirectoryReader.open(directory)) {
                 ScriptedMetricAggregationBuilder aggregationBuilder = new ScriptedMetricAggregationBuilder(AGG_NAME);
-                aggregationBuilder.initScript(INIT_SCRIPT).mapScript(MAP_SCRIPT).combineScript(COMBINE_SCRIPT_NULL).reduceScript(REDUCE_SCRIPT);
+                aggregationBuilder.initScript(INIT_SCRIPT)
+                    .mapScript(MAP_SCRIPT)
+                    .combineScript(COMBINE_SCRIPT_NULL)
+                    .reduceScript(REDUCE_SCRIPT);
                 ScriptedMetric scriptedMetric = searchAndReduce(
                     newSearcher(indexReader, true, true),
                     new MatchAllDocsQuery(),

--- a/server/src/test/java/org/opensearch/search/aggregations/metrics/ScriptedMetricAggregatorTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/metrics/ScriptedMetricAggregatorTests.java
@@ -126,6 +126,12 @@ public class ScriptedMetricAggregatorTests extends AggregatorTestCase {
         "combineScriptNoop",
         Collections.emptyMap()
     );
+    private static final Script COMBINE_SCRIPT_NULL = new Script(
+        ScriptType.INLINE,
+        MockScriptEngine.NAME,
+        "combineScriptNull",
+        Collections.emptyMap()
+    );
 
     private static final Script INIT_SCRIPT_PARAMS = new Script(
         ScriptType.INLINE,
@@ -202,6 +208,7 @@ public class ScriptedMetricAggregatorTests extends AggregatorTestCase {
             Map<String, Object> state = (Map<String, Object>) params.get("state");
             return state;
         });
+        SCRIPTS.put("combineScriptNull", params -> null);
         SCRIPTS.put("reduceScript", params -> {
             List<?> states = (List<?>) params.get("states");
             return states.stream().filter(a -> a instanceof Number).map(a -> (Number) a).mapToInt(Number::intValue).sum();
@@ -398,6 +405,25 @@ public class ScriptedMetricAggregatorTests extends AggregatorTestCase {
                 assertEquals(AGG_NAME, scriptedMetric.getName());
                 assertNotNull(scriptedMetric.aggregation());
                 assertEquals(numDocs, scriptedMetric.aggregation());
+            }
+        }
+    }
+
+    public void testScriptedMetricWithNullCombineResult() throws IOException {
+        try (Directory directory = newDirectory()) {
+            try (RandomIndexWriter indexWriter = new RandomIndexWriter(random(), directory)) {
+                indexWriter.addDocument(singleton(new SortedNumericDocValuesField("number", 1)));
+            }
+            try (IndexReader indexReader = DirectoryReader.open(directory)) {
+                ScriptedMetricAggregationBuilder aggregationBuilder = new ScriptedMetricAggregationBuilder(AGG_NAME);
+                aggregationBuilder.initScript(INIT_SCRIPT).mapScript(MAP_SCRIPT).combineScript(COMBINE_SCRIPT_NULL).reduceScript(REDUCE_SCRIPT);
+                ScriptedMetric scriptedMetric = searchAndReduce(
+                    newSearcher(indexReader, true, true),
+                    new MatchAllDocsQuery(),
+                    aggregationBuilder
+                );
+                assertEquals(AGG_NAME, scriptedMetric.getName());
+                assertEquals(0, scriptedMetric.aggregation());
             }
         }
     }


### PR DESCRIPTION
### Description

`ScriptedMetricAggregator` was checking `result.getClass()` before creating
the `InternalScriptedMetric`. When a combine script returns `null`, that throws
before the existing null aggregation value can be carried through reduction.

This skips the writeable type check for null combine results. I also added a
regression test with a scripted metric whose combine script returns null.

### Related Issues

Resolves #21507

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request created, if applicable. Not applicable.
- [x] Public documentation issue/PR created, if applicable. Not applicable.

Tests:

```text
./gradlew :server:test --tests org.opensearch.search.aggregations.metrics.ScriptedMetricAggregatorTests.testScriptedMetricWithNullCombineResult
./gradlew :server:test --tests org.opensearch.search.aggregations.metrics.ScriptedMetricAggregatorTests
```

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.