### PR TITLE
Remove Unsafe class injection from Java agent

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -421,7 +421,11 @@ gradle.projectsEvaluated {
         task.jvmArgs += [
             "--add-modules=jdk.incubator.vector",
             "--add-exports=java.base/com.sun.crypto.provider=ALL-UNNAMED",
-            "--enable-native-access=ALL-UNNAMED"
+            "--enable-native-access=ALL-UNNAMED",
+            // Disable ByteBuddy's Unsafe-based class injection path to avoid
+            // "sun.misc.Unsafe::objectFieldOffset has been called by ByteBuddy" JVM warnings on JDK 21+.
+            // ByteBuddy still falls back to Lookup/Reflection injection strategies.
+            "-Dnet.bytebuddy.safe=true"
         ]
 
         // Add Java Agent for security sandboxing

--- a/libs/agent-sm/agent-policy/src/main/java/org/opensearch/secure_sm/AccessController.java
+++ b/libs/agent-sm/agent-policy/src/main/java/org/opensearch/secure_sm/AccessController.java
@@ -17,7 +17,7 @@ import java.util.function.Supplier;
  * removal. All new code should use this class instead of the JDK's {@code AccessController}.
  *
  * Running code in a privileged context will ensure that the code has the necessary permissions
- * without traversing through the entire call stack. See {@code org.opensearch.javaagent.StackCallerProtectionDomainChainExtractor}
+ * without traversing through the entire call stack. See {@code org.opensearch.javaagent.bootstrap.internal.StackCallerProtectionDomainChainExtractor}
  *
  * Example usages:
  * <pre>

--- a/libs/agent-sm/agent/src/main/java/org/opensearch/javaagent/Agent.java
+++ b/libs/agent-sm/agent/src/main/java/org/opensearch/javaagent/Agent.java
@@ -8,7 +8,7 @@
 
 package org.opensearch.javaagent;
 
-import org.opensearch.javaagent.bootstrap.AgentPolicy;
+import org.opensearch.javaagent.bootstrap.internal.SubjectInterceptor;
 
 import javax.security.auth.Subject;
 
@@ -18,14 +18,11 @@ import java.nio.channels.FileChannel;
 import java.nio.channels.SocketChannel;
 import java.nio.file.Files;
 import java.nio.file.spi.FileSystemProvider;
-import java.util.Map;
 
 import net.bytebuddy.ByteBuddy;
 import net.bytebuddy.agent.builder.AgentBuilder;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
-import net.bytebuddy.dynamic.ClassFileLocator;
-import net.bytebuddy.dynamic.loading.ClassInjector;
 import net.bytebuddy.implementation.Implementation;
 import net.bytebuddy.implementation.MethodDelegation;
 import net.bytebuddy.matcher.ElementMatcher.Junction;
@@ -95,20 +92,6 @@ public class Agent {
         final AgentBuilder.Transformer subjectTransformer = (b, typeDescription, classLoader, module, pd) -> b.method(
             ElementMatchers.named("getSubject")
         ).intercept(MethodDelegation.to(SubjectInterceptor.class));
-
-        ClassInjector.UsingUnsafe.ofBootLoader()
-            .inject(
-                Map.of(
-                    new TypeDescription.ForLoadedType(StackCallerProtectionDomainChainExtractor.class),
-                    ClassFileLocator.ForClassLoader.read(StackCallerProtectionDomainChainExtractor.class),
-                    new TypeDescription.ForLoadedType(StackCallerClassChainExtractor.class),
-                    ClassFileLocator.ForClassLoader.read(StackCallerClassChainExtractor.class),
-                    new TypeDescription.ForLoadedType(AgentPolicy.class),
-                    ClassFileLocator.ForClassLoader.read(AgentPolicy.class),
-                    new TypeDescription.ForLoadedType(SubjectInterceptor.class),
-                    ClassFileLocator.ForClassLoader.read(SubjectInterceptor.class)
-                )
-            );
 
         final ByteBuddy byteBuddy = new ByteBuddy().with(Implementation.Context.Disabled.Factory.INSTANCE);
         var builder = new AgentBuilder.Default(byteBuddy).with(AgentBuilder.InitializationStrategy.NoOp.INSTANCE)

--- a/libs/agent-sm/agent/src/main/java/org/opensearch/javaagent/FileInterceptor.java
+++ b/libs/agent-sm/agent/src/main/java/org/opensearch/javaagent/FileInterceptor.java
@@ -9,6 +9,8 @@
 package org.opensearch.javaagent;
 
 import org.opensearch.javaagent.bootstrap.AgentPolicy;
+import org.opensearch.javaagent.bootstrap.internal.StackCallerClassChainExtractor;
+import org.opensearch.javaagent.bootstrap.internal.StackCallerProtectionDomainChainExtractor;
 
 import java.io.FilePermission;
 import java.lang.reflect.Method;

--- a/libs/agent-sm/agent/src/main/java/org/opensearch/javaagent/RuntimeHaltInterceptor.java
+++ b/libs/agent-sm/agent/src/main/java/org/opensearch/javaagent/RuntimeHaltInterceptor.java
@@ -9,6 +9,7 @@
 package org.opensearch.javaagent;
 
 import org.opensearch.javaagent.bootstrap.AgentPolicy;
+import org.opensearch.javaagent.bootstrap.internal.StackCallerClassChainExtractor;
 
 import java.lang.StackWalker.Option;
 import java.security.Policy;

--- a/libs/agent-sm/agent/src/main/java/org/opensearch/javaagent/SocketChannelInterceptor.java
+++ b/libs/agent-sm/agent/src/main/java/org/opensearch/javaagent/SocketChannelInterceptor.java
@@ -9,6 +9,7 @@
 package org.opensearch.javaagent;
 
 import org.opensearch.javaagent.bootstrap.AgentPolicy;
+import org.opensearch.javaagent.bootstrap.internal.StackCallerProtectionDomainChainExtractor;
 
 import java.lang.reflect.Method;
 import java.net.InetSocketAddress;

--- a/libs/agent-sm/agent/src/main/java/org/opensearch/javaagent/SystemExitInterceptor.java
+++ b/libs/agent-sm/agent/src/main/java/org/opensearch/javaagent/SystemExitInterceptor.java
@@ -9,6 +9,7 @@
 package org.opensearch.javaagent;
 
 import org.opensearch.javaagent.bootstrap.AgentPolicy;
+import org.opensearch.javaagent.bootstrap.internal.StackCallerClassChainExtractor;
 
 import java.lang.StackWalker.Option;
 import java.security.Policy;

--- a/libs/agent-sm/agent/src/test/java/org/opensearch/javaagent/StackCallerProtectionDomainExtractorTests.java
+++ b/libs/agent-sm/agent/src/test/java/org/opensearch/javaagent/StackCallerProtectionDomainExtractorTests.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.javaagent;
 
+import org.opensearch.javaagent.bootstrap.internal.StackCallerProtectionDomainChainExtractor;
 import org.junit.Assume;
 import org.junit.Test;
 

--- a/libs/agent-sm/bootstrap/src/main/java/org/opensearch/javaagent/bootstrap/internal/StackCallerClassChainExtractor.java
+++ b/libs/agent-sm/bootstrap/src/main/java/org/opensearch/javaagent/bootstrap/internal/StackCallerClassChainExtractor.java
@@ -6,7 +6,7 @@
  * compatible open source license.
  */
 
-package org.opensearch.javaagent;
+package org.opensearch.javaagent.bootstrap.internal;
 
 import java.lang.StackWalker.StackFrame;
 import java.util.Collection;

--- a/libs/agent-sm/bootstrap/src/main/java/org/opensearch/javaagent/bootstrap/internal/StackCallerProtectionDomainChainExtractor.java
+++ b/libs/agent-sm/bootstrap/src/main/java/org/opensearch/javaagent/bootstrap/internal/StackCallerProtectionDomainChainExtractor.java
@@ -6,7 +6,7 @@
  * compatible open source license.
  */
 
-package org.opensearch.javaagent;
+package org.opensearch.javaagent.bootstrap.internal;
 
 import java.lang.StackWalker.StackFrame;
 import java.security.ProtectionDomain;

--- a/libs/agent-sm/bootstrap/src/main/java/org/opensearch/javaagent/bootstrap/internal/SubjectInterceptor.java
+++ b/libs/agent-sm/bootstrap/src/main/java/org/opensearch/javaagent/bootstrap/internal/SubjectInterceptor.java
@@ -6,7 +6,7 @@
  * compatible open source license.
  */
 
-package org.opensearch.javaagent;
+package org.opensearch.javaagent.bootstrap.internal;
 
 import javax.security.auth.Subject;
 

--- a/libs/agent-sm/bootstrap/src/main/java/org/opensearch/javaagent/bootstrap/internal/package-info.java
+++ b/libs/agent-sm/bootstrap/src/main/java/org/opensearch/javaagent/bootstrap/internal/package-info.java
@@ -1,0 +1,16 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/**
+ * Internal agent support classes that must be loaded by the boot classloader
+ * so that bytecode woven into JDK classes (either inlined ByteBuddy Advice or
+ * MethodDelegation stubs) can resolve them. These classes are implementation
+ * details of the Java agent and are not part of any public API; do not depend
+ * on them from outside {@code :libs:agent-sm:agent}.
+ */
+package org.opensearch.javaagent.bootstrap.internal;


### PR DESCRIPTION
The Java agent previously used ClassInjector.UsingUnsafe at premain time to inject AgentPolicy, SubjectInterceptor, and the two stack caller chain extractors into the boot classloader. This relied on sun.misc.Unsafe, which is deprecated for removal on recent JDKs and emits JVM warnings.

This change relocates StackCallerClassChainExtractor, StackCallerProtectionDomainChainExtractor, and SubjectInterceptor from :libs:agent-sm:agent into :libs:agent-sm:bootstrap, under a new org.opensearch.javaagent.bootstrap.internal subpackage to distinguish them from AgentPolicy, which is the shared API between the server and the agent. The bootstrap jar is listed on the agent jar's Boot-Class-Path manifest attribute, so the JVM loads these classes into the boot classloader natively with no runtime injection needed.

Also set -Dnet.bytebuddy.safe=true on test JVMs to disable the Unsafe-based dispatchers inside ByteBuddy's ClassInjector. ByteBuddy falls back to MethodHandles.Lookup / reflection injection, which works on JDK 9+.

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
