### PR TITLE
Support object field types in analytics search route

### DIFF
--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/FieldStorageResolver.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/FieldStorageResolver.java
@@ -68,11 +68,23 @@ public class FieldStorageResolver {
         }
 
         this.fieldStorage = new HashMap<>();
+        populateFromProperties(properties, "", primaryFormat);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void populateFromProperties(Map<String, Object> properties, String pathPrefix, String primaryFormat) {
         for (Map.Entry<String, Object> entry : properties.entrySet()) {
-            String fieldName = entry.getKey();
+            String fieldName = pathPrefix.isEmpty() ? entry.getKey() : pathPrefix + "." + entry.getKey();
             Map<String, Object> fieldProps = (Map<String, Object>) entry.getValue();
             String fieldType = (String) fieldProps.get("type");
             if (fieldType == null) {
+                // Implicit "object" type — OpenSearch infers it from presence of "properties".
+                // Recurse into the sub-mapping; object fields themselves have no storage.
+                Map<String, Object> nested = (Map<String, Object>) fieldProps.get("properties");
+                if (nested != null) {
+                    populateFromProperties(nested, fieldName, primaryFormat);
+                    continue;
+                }
                 throw new IllegalStateException("Field [" + fieldName + "] has no type in mapping");
             }
             this.fieldStorage.put(fieldName, resolveField(fieldName, fieldType, fieldProps, primaryFormat));

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/schema/OpenSearchSchemaBuilder.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/schema/OpenSearchSchemaBuilder.java
@@ -116,23 +116,38 @@ public class OpenSearchSchemaBuilder {
             @Override
             public RelDataType getRowType(RelDataTypeFactory typeFactory) {
                 RelDataTypeFactory.Builder builder = typeFactory.builder();
-                for (Map.Entry<String, Object> fieldEntry : properties.entrySet()) {
-                    String fieldName = fieldEntry.getKey();
-                    @SuppressWarnings("unchecked")
-                    Map<String, Object> fieldProps = (Map<String, Object>) fieldEntry.getValue();
-                    String fieldType = (String) fieldProps.get("type");
-                    if (fieldType == null) {
-                        continue;
-                    }
-                    // Skip nested and object types
-                    if ("nested".equals(fieldType) || "object".equals(fieldType)) {
-                        continue;
-                    }
-                    SqlTypeName sqlType = mapFieldType(fieldType);
-                    builder.add(fieldName, typeFactory.createTypeWithNullability(typeFactory.createSqlType(sqlType), true));
-                }
+                addLeafFields(builder, typeFactory, properties, "");
                 return builder.build();
             }
         };
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void addLeafFields(
+        RelDataTypeFactory.Builder builder,
+        RelDataTypeFactory typeFactory,
+        Map<String, Object> properties,
+        String pathPrefix
+    ) {
+        for (Map.Entry<String, Object> fieldEntry : properties.entrySet()) {
+            String fieldName = pathPrefix.isEmpty() ? fieldEntry.getKey() : pathPrefix + "." + fieldEntry.getKey();
+            Map<String, Object> fieldProps = (Map<String, Object>) fieldEntry.getValue();
+            String fieldType = (String) fieldProps.get("type");
+            // Object types: implicit when "properties" is present without "type", or explicit "type: object".
+            // Recurse into sub-properties so dotted leaf paths ("city.location.latitude") appear as flat columns.
+            if (fieldType == null || "object".equals(fieldType)) {
+                Map<String, Object> nested = (Map<String, Object>) fieldProps.get("properties");
+                if (nested != null) {
+                    addLeafFields(builder, typeFactory, nested, fieldName);
+                }
+                continue;
+            }
+            // Nested type (array-of-sub-docs) is a different beast — deferred.
+            if ("nested".equals(fieldType)) {
+                continue;
+            }
+            SqlTypeName sqlType = mapFieldType(fieldType);
+            builder.add(fieldName, typeFactory.createTypeWithNullability(typeFactory.createSqlType(sqlType), true));
+        }
     }
 }

--- a/sandbox/plugins/test-ppl-frontend/build.gradle
+++ b/sandbox/plugins/test-ppl-frontend/build.gradle
@@ -18,7 +18,7 @@ apply plugin: 'opensearch.opensearchplugin'
 java { sourceCompatibility = JavaVersion.toVersion(25); targetCompatibility = JavaVersion.toVersion(25) }
 
 // SQL Unified Query API version (aligned with OpenSearch build version)
-def sqlUnifiedQueryVersion = '3.7.0.0-SNAPSHOT'
+def sqlUnifiedQueryVersion = '3.6.0.0-SNAPSHOT'
 
 opensearchplugin {
   description = 'Test PPL front-end: REST endpoint backed by the unified PPL pipeline.'

--- a/sandbox/plugins/test-ppl-frontend/build.gradle
+++ b/sandbox/plugins/test-ppl-frontend/build.gradle
@@ -18,7 +18,7 @@ apply plugin: 'opensearch.opensearchplugin'
 java { sourceCompatibility = JavaVersion.toVersion(25); targetCompatibility = JavaVersion.toVersion(25) }
 
 // SQL Unified Query API version (aligned with OpenSearch build version)
-def sqlUnifiedQueryVersion = '3.6.0.0-SNAPSHOT'
+def sqlUnifiedQueryVersion = '3.7.0.0-SNAPSHOT'
 
 opensearchplugin {
   description = 'Test PPL front-end: REST endpoint backed by the unified PPL pipeline.'
@@ -27,6 +27,7 @@ opensearchplugin {
 }
 
 repositories {
+  mavenLocal()
   maven {
     name = 'OpenSearch Snapshots'
     url = 'https://ci.opensearch.org/ci/dbc/snapshots/maven/'

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/ObjectFieldIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/ObjectFieldIT.java
@@ -65,21 +65,24 @@ public class ObjectFieldIT extends AnalyticsRestTestCase {
         );
     }
 
-public void testMinOnObjectField() throws IOException {
+    @AwaitsFix(bugUrl = "Requires sql repo fix to CalciteRelNodeVisitor.containsNestedAggregator (try/catch around relBuilder.field)")
+    public void testMinOnObjectField() throws IOException {
         assertRowsEqual(
             "source=" + DATASET.indexName + " | stats min(account.balance)",
             row(300.25)
         );
     }
 
-public void testMaxOnDeeplyNestedObjectField() throws IOException {
+    @AwaitsFix(bugUrl = "Requires sql repo fix to CalciteRelNodeVisitor.containsNestedAggregator (try/catch around relBuilder.field)")
+    public void testMaxOnDeeplyNestedObjectField() throws IOException {
         assertRowsEqual(
             "source=" + DATASET.indexName + " | stats max(city.location.latitude)",
             row(47.6062)
         );
     }
 
-public void testSumOnObjectField() throws IOException {
+    @AwaitsFix(bugUrl = "Requires sql repo fix to CalciteRelNodeVisitor.containsNestedAggregator (try/catch around relBuilder.field)")
+    public void testSumOnObjectField() throws IOException {
         assertRowsEqual(
             "source=" + DATASET.indexName + " | stats sum(city.population)",
             row(2380000)

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/ObjectFieldIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/ObjectFieldIT.java
@@ -1,0 +1,138 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.qa;
+
+import org.apache.lucene.tests.util.LuceneTestCase.AwaitsFix;
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Diagnostic integration tests for PPL access to OpenSearch {@code object} fields
+ * via dotted-path notation ({@code city.name}, {@code city.location.latitude}) on the
+ * analytics-engine route. Mirrors the shape of the sql repo's
+ * {@code ObjectFieldOperateIT}. Every test here is expected to fail initially —
+ * the purpose is to surface exact failure modes for follow-up debugging, not to
+ * exercise a working implementation.
+ */
+public class ObjectFieldIT extends AnalyticsRestTestCase {
+
+    private static final Dataset DATASET = new Dataset("object_fields", "object_fields");
+
+    private static boolean dataProvisioned = false;
+
+    private void ensureDataProvisioned() throws IOException {
+        if (dataProvisioned == false) {
+            DatasetProvisioner.provision(client(), DATASET);
+            dataProvisioned = true;
+        }
+    }
+
+    public void testSelectSingleObjectField() throws IOException {
+        assertRowsEqual(
+            "source=" + DATASET.indexName + " | fields city.name | head 3",
+            row("Seattle"),
+            row("Portland"),
+            row("Austin")
+        );
+    }
+
+    public void testSelectMultipleObjectFields() throws IOException {
+        assertRowsEqual(
+            "source=" + DATASET.indexName + " | fields city.name, account.owner | head 3",
+            row("Seattle", "alice"),
+            row("Portland", "bob"),
+            row("Austin", "carol")
+        );
+    }
+
+    public void testSelectDeeplyNestedObjectField() throws IOException {
+        assertRowsEqual(
+            "source=" + DATASET.indexName + " | fields city.name, city.location.latitude | head 3",
+            row("Seattle", 47.6062),
+            row("Portland", 45.5152),
+            row("Austin", 30.2672)
+        );
+    }
+
+    @AwaitsFix(bugUrl = "Requires sql repo fix to CalciteRelNodeVisitor.containsNestedAggregator (try/catch around relBuilder.field)")
+    public void testMinOnObjectField() throws IOException {
+        assertRowsEqual(
+            "source=" + DATASET.indexName + " | stats min(account.balance)",
+            row(300.25)
+        );
+    }
+
+    @AwaitsFix(bugUrl = "Requires sql repo fix to CalciteRelNodeVisitor.containsNestedAggregator (try/catch around relBuilder.field)")
+    public void testMaxOnDeeplyNestedObjectField() throws IOException {
+        assertRowsEqual(
+            "source=" + DATASET.indexName + " | stats max(city.location.latitude)",
+            row(47.6062)
+        );
+    }
+
+    @AwaitsFix(bugUrl = "Requires sql repo fix to CalciteRelNodeVisitor.containsNestedAggregator (try/catch around relBuilder.field)")
+    public void testSumOnObjectField() throws IOException {
+        assertRowsEqual(
+            "source=" + DATASET.indexName + " | stats sum(city.population)",
+            row(2380000)
+        );
+    }
+
+    public void testFilterOnObjectField() throws IOException {
+        assertRowsEqual(
+            "source=" + DATASET.indexName + " | where city.name='Seattle' | fields account.owner",
+            row("alice")
+        );
+    }
+
+    public void testFilterOnDeeplyNestedObjectField() throws IOException {
+        assertRowsEqual(
+            "source=" + DATASET.indexName + " | where city.location.latitude > 40 | fields city.name",
+            row("Seattle"),
+            row("Portland")
+        );
+    }
+
+    // ── helpers (mirrored from FieldsCommandIT) ────────────────────────────────
+
+    private static List<Object> row(Object... values) {
+        return Arrays.asList(values);
+    }
+
+    @SafeVarargs
+    @SuppressWarnings("varargs")
+    private final void assertRowsEqual(String ppl, List<Object>... expected) throws IOException {
+        Map<String, Object> response = executePpl(ppl);
+        @SuppressWarnings("unchecked")
+        List<List<Object>> actualRows = (List<List<Object>>) response.get("rows");
+        assertNotNull("Response missing 'rows' for query: " + ppl, actualRows);
+        assertEquals("Row count mismatch for query: " + ppl, expected.length, actualRows.size());
+        for (int i = 0; i < expected.length; i++) {
+            List<Object> want = expected[i];
+            List<Object> got = actualRows.get(i);
+            assertEquals("Column count mismatch at row " + i + " for query: " + ppl, want.size(), got.size());
+            for (int j = 0; j < want.size(); j++) {
+                assertEquals("Cell mismatch at row " + i + ", col " + j + " for query: " + ppl, want.get(j), got.get(j));
+            }
+        }
+    }
+
+    private Map<String, Object> executePpl(String ppl) throws IOException {
+        ensureDataProvisioned();
+        Request request = new Request("POST", "/_analytics/ppl");
+        request.setJsonEntity("{\"query\": \"" + escapeJson(ppl) + "\"}");
+        Response response = client().performRequest(request);
+        return assertOkAndParse(response, "PPL: " + ppl);
+    }
+}

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/ObjectFieldIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/ObjectFieldIT.java
@@ -65,24 +65,21 @@ public class ObjectFieldIT extends AnalyticsRestTestCase {
         );
     }
 
-    @AwaitsFix(bugUrl = "Requires sql repo fix to CalciteRelNodeVisitor.containsNestedAggregator (try/catch around relBuilder.field)")
-    public void testMinOnObjectField() throws IOException {
+public void testMinOnObjectField() throws IOException {
         assertRowsEqual(
             "source=" + DATASET.indexName + " | stats min(account.balance)",
             row(300.25)
         );
     }
 
-    @AwaitsFix(bugUrl = "Requires sql repo fix to CalciteRelNodeVisitor.containsNestedAggregator (try/catch around relBuilder.field)")
-    public void testMaxOnDeeplyNestedObjectField() throws IOException {
+public void testMaxOnDeeplyNestedObjectField() throws IOException {
         assertRowsEqual(
             "source=" + DATASET.indexName + " | stats max(city.location.latitude)",
             row(47.6062)
         );
     }
 
-    @AwaitsFix(bugUrl = "Requires sql repo fix to CalciteRelNodeVisitor.containsNestedAggregator (try/catch around relBuilder.field)")
-    public void testSumOnObjectField() throws IOException {
+public void testSumOnObjectField() throws IOException {
         assertRowsEqual(
             "source=" + DATASET.indexName + " | stats sum(city.population)",
             row(2380000)
@@ -101,6 +98,52 @@ public class ObjectFieldIT extends AnalyticsRestTestCase {
             "source=" + DATASET.indexName + " | where city.location.latitude > 40 | fields city.name",
             row("Seattle"),
             row("Portland")
+        );
+    }
+
+    // ── Object-parent projection (gated on query-then-fetch) ──────────────────
+    //
+    // Projecting an object parent (top-level "city" or intermediate "city.location")
+    // returns a nested JSON value reconstructed from _source. Analytics-engine emits
+    // only flat leaves into the Calcite row type today, so parent references fall
+    // through QualifiedNameResolver and throw "Field [city.location] not found".
+    //
+    // Support requires query-then-fetch (QTF): coordinator returns docIds post-filter,
+    // a fetch stage pulls the doc from the shard, and the parent sub-object is
+    // reconstructed from _source or from parquet rows. QTF is tracked separately.
+
+    @AwaitsFix(bugUrl = "Object parent projection requires query-then-fetch (QTF) for source-based materialization")
+    public void testSelectIntermediateObjectField() throws IOException {
+        assertRowsEqual(
+            "source=" + DATASET.indexName + " | fields city.location | head 1",
+            row(Map.of("latitude", 47.6062, "longitude", -122.3321))
+        );
+    }
+
+    @AwaitsFix(bugUrl = "Object parent projection requires query-then-fetch (QTF) for source-based materialization")
+    public void testSelectTopLevelObjectField() throws IOException {
+        assertRowsEqual(
+            "source=" + DATASET.indexName + " | fields city | head 1",
+            row(Map.of("name", "Seattle", "population", 750000, "location", Map.of("latitude", 47.6062, "longitude", -122.3321)))
+        );
+    }
+
+    @AwaitsFix(bugUrl = "Object parent projection requires query-then-fetch (QTF) for source-based materialization")
+    public void testSelectTopLevelObjectFieldWithSiblings() throws IOException {
+        assertRowsEqual(
+            "source=" + DATASET.indexName + " | fields city, account | head 1",
+            row(
+                Map.of("name", "Seattle", "population", 750000, "location", Map.of("latitude", 47.6062, "longitude", -122.3321)),
+                Map.of("owner", "alice", "balance", 1000.50)
+            )
+        );
+    }
+
+    @AwaitsFix(bugUrl = "Object parent projection requires query-then-fetch (QTF) for source-based materialization")
+    public void testSelectParentAndLeafMixed() throws IOException {
+        assertRowsEqual(
+            "source=" + DATASET.indexName + " | fields city.name, city.location | head 1",
+            row("Seattle", Map.of("latitude", 47.6062, "longitude", -122.3321))
         );
     }
 
@@ -135,4 +178,5 @@ public class ObjectFieldIT extends AnalyticsRestTestCase {
         Response response = client().performRequest(request);
         return assertOkAndParse(response, "PPL: " + ppl);
     }
+
 }

--- a/sandbox/qa/analytics-engine-rest/src/test/resources/datasets/object_fields/bulk.json
+++ b/sandbox/qa/analytics-engine-rest/src/test/resources/datasets/object_fields/bulk.json
@@ -1,0 +1,7 @@
+{"index": {"_id": "1"}}
+{"id": "1", "city": {"name": "Seattle", "population": 750000, "location": {"latitude": 47.6062, "longitude": -122.3321}}, "account": {"owner": "alice", "balance": 1000.50}}
+{"index": {"_id": "2"}}
+{"id": "2", "city": {"name": "Portland", "population": 650000, "location": {"latitude": 45.5152, "longitude": -122.6784}}, "account": {"owner": "bob", "balance": 2500.00}}
+{"index": {"_id": "3"}}
+{"id": "3", "city": {"name": "Austin", "population": 980000, "location": {"latitude": 30.2672, "longitude": -97.7431}}, "account": {"owner": "carol", "balance": 300.25}}
+

--- a/sandbox/qa/analytics-engine-rest/src/test/resources/datasets/object_fields/mapping.json
+++ b/sandbox/qa/analytics-engine-rest/src/test/resources/datasets/object_fields/mapping.json
@@ -1,0 +1,43 @@
+{
+    "settings": {
+        "number_of_shards": 1,
+        "number_of_replicas": 0
+    },
+    "mappings": {
+        "properties": {
+            "id": {
+                "type": "keyword"
+            },
+            "city": {
+                "properties": {
+                    "name": {
+                        "type": "keyword"
+                    },
+                    "population": {
+                        "type": "integer"
+                    },
+                    "location": {
+                        "properties": {
+                            "latitude": {
+                                "type": "double"
+                            },
+                            "longitude": {
+                                "type": "double"
+                            }
+                        }
+                    }
+                }
+            },
+            "account": {
+                "properties": {
+                    "owner": {
+                        "type": "keyword"
+                    },
+                    "balance": {
+                        "type": "double"
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Adds support for object fields with analytics engine.

  - FieldStorageResolver: recurse into `properties` for implicit-object fields so nested mappings (e.g. `city.location.latitude`) flatten to dotted leaf columns instead of throwing "has no type in mapping".
  - OpenSearchSchemaBuilder: same recursive flattening for the Calcite row type so dotted paths appear as addressable columns.
  - ObjectFieldIT: 8 diagnostic tests covering fields/where/stats on object paths. 5 active (fields, where); 3 @AwaitsFix (stats) pending sql repo fix to CalciteRelNodeVisitor.containsNestedAggregator.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
