### PR TITLE
Make parquet/datafusion memory settings configurable

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionPlugin.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionPlugin.java
@@ -70,23 +70,17 @@ public class DataFusionPlugin extends Plugin implements SearchBackEndPlugin<Data
     /** Default floor for {@link #DATAFUSION_MEMORY_POOL_LIMIT_MIN}. */
     public static final ByteSizeValue DEFAULT_MEMORY_POOL_LIMIT_MIN = new ByteSizeValue(512, ByteSizeUnit.MB);
 
-    /** Default ceiling for {@link #DATAFUSION_MEMORY_POOL_LIMIT_MAX}. */
-    public static final ByteSizeValue DEFAULT_MEMORY_POOL_LIMIT_MAX = new ByteSizeValue(30, ByteSizeUnit.GB);
-
     /** Default value for {@link #DATAFUSION_SPILL_MEMORY_LIMIT}. */
     public static final String DEFAULT_SPILL_MEMORY_LIMIT = "50%";
 
     /** Default floor for {@link #DATAFUSION_SPILL_MEMORY_LIMIT_MIN}. */
     public static final ByteSizeValue DEFAULT_SPILL_MEMORY_LIMIT_MIN = new ByteSizeValue(1, ByteSizeUnit.GB);
 
-    /** Default ceiling for {@link #DATAFUSION_SPILL_MEMORY_LIMIT_MAX}. */
-    public static final ByteSizeValue DEFAULT_SPILL_MEMORY_LIMIT_MAX = new ByteSizeValue(100, ByteSizeUnit.GB);
-
     /**
      * Memory pool limit for the DataFusion runtime. Accepts a percentage of non-heap memory
      * ({@code totalPhysicalMemory - configuredMaxHeap}, e.g. {@code "25%"}) or an absolute byte
-     * size (e.g. {@code "10gb"}). When a percentage is supplied, the resolved value is clamped
-     * by {@link #DATAFUSION_MEMORY_POOL_LIMIT_MIN} / {@link #DATAFUSION_MEMORY_POOL_LIMIT_MAX}.
+     * size (e.g. {@code "10gb"}). When a percentage is supplied, the resolved value is floored
+     * by {@link #DATAFUSION_MEMORY_POOL_LIMIT_MIN}.
      * <p>
      * Dynamic: changes take effect for new allocations only. Existing reservations that exceed
      * the new limit are not reclaimed — they drain naturally as queries complete.
@@ -105,31 +99,25 @@ public class DataFusionPlugin extends Plugin implements SearchBackEndPlugin<Data
         DEFAULT_MEMORY_POOL_LIMIT_MIN,
         new ByteSizeValue(0, ByteSizeUnit.BYTES),
         new ByteSizeValue(Long.MAX_VALUE, ByteSizeUnit.BYTES),
-        Setting.Property.NodeScope
-    );
-
-    /**
-     * Ceiling applied when {@link #DATAFUSION_MEMORY_POOL_LIMIT} is a percentage. {@code -1}
-     * disables the ceiling.
-     */
-    public static final Setting<ByteSizeValue> DATAFUSION_MEMORY_POOL_LIMIT_MAX = Setting.byteSizeSetting(
-        "datafusion.memory_pool_limit.max",
-        DEFAULT_MEMORY_POOL_LIMIT_MAX,
-        new ByteSizeValue(-1),
-        new ByteSizeValue(Long.MAX_VALUE, ByteSizeUnit.BYTES),
-        Setting.Property.NodeScope
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
     );
 
     /**
      * Spill memory limit — when exceeded, DataFusion spills to disk. Accepts a percentage of
      * non-heap memory or an absolute byte size. When a percentage is supplied, the resolved value
-     * is clamped by {@link #DATAFUSION_SPILL_MEMORY_LIMIT_MIN} / {@link #DATAFUSION_SPILL_MEMORY_LIMIT_MAX}.
+     * is floored by {@link #DATAFUSION_SPILL_MEMORY_LIMIT_MIN}.
+     * <p>
+     * Dynamic in the cluster-settings sense: PUTs are accepted and persisted, but the spill limit
+     * is fixed in the native runtime at construction time (no setter). The new value takes effect
+     * after the next node restart.
      */
     public static final Setting<String> DATAFUSION_SPILL_MEMORY_LIMIT = Setting.simpleString(
         "datafusion.spill_memory_limit_bytes",
         DEFAULT_SPILL_MEMORY_LIMIT,
         DataFusionPlugin::validateMemorySizeOrPercentage,
-        Setting.Property.NodeScope
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
     );
 
     /** Floor applied when {@link #DATAFUSION_SPILL_MEMORY_LIMIT} is a percentage. */
@@ -138,19 +126,8 @@ public class DataFusionPlugin extends Plugin implements SearchBackEndPlugin<Data
         DEFAULT_SPILL_MEMORY_LIMIT_MIN,
         new ByteSizeValue(0, ByteSizeUnit.BYTES),
         new ByteSizeValue(Long.MAX_VALUE, ByteSizeUnit.BYTES),
-        Setting.Property.NodeScope
-    );
-
-    /**
-     * Ceiling applied when {@link #DATAFUSION_SPILL_MEMORY_LIMIT} is a percentage. {@code -1}
-     * disables the ceiling.
-     */
-    public static final Setting<ByteSizeValue> DATAFUSION_SPILL_MEMORY_LIMIT_MAX = Setting.byteSizeSetting(
-        "datafusion.spill_memory_limit.max",
-        DEFAULT_SPILL_MEMORY_LIMIT_MAX,
-        new ByteSizeValue(-1),
-        new ByteSizeValue(Long.MAX_VALUE, ByteSizeUnit.BYTES),
-        Setting.Property.NodeScope
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
     );
 
     /**
@@ -182,11 +159,8 @@ public class DataFusionPlugin extends Plugin implements SearchBackEndPlugin<Data
     private volatile SimpleExtension.ExtensionCollection substraitExtensions;
     private volatile ClusterService clusterService;
     private volatile DatafusionSettings datafusionSettings;
-    // Min/max companions are NodeScope (static), so we resolve them once at startup. The dynamic
-    // update path uses these cached snapshots rather than re-reading ClusterService.getSettings(),
-    // which can return stale or default values during transient cluster-state updates.
-    private volatile ByteSizeValue memoryPoolFloor;
-    private volatile ByteSizeValue memoryPoolCeiling;
+    /** Most recent raw value of {@link #DATAFUSION_MEMORY_POOL_LIMIT}; updated by its listener. */
+    private volatile String currentMemoryPoolLimitRaw = DEFAULT_MEMORY_POOL_LIMIT;
 
     /**
      * Creates the DataFusion plugin.
@@ -211,10 +185,7 @@ public class DataFusionPlugin extends Plugin implements SearchBackEndPlugin<Data
         this.dataFormatRegistry = dataFormatRegistry;
         this.clusterService = clusterService;
         Settings settings = environment.settings();
-        // Snapshot the static min/max companions once so dynamic updates resolve against
-        // the same values that were used at startup.
-        this.memoryPoolFloor = DATAFUSION_MEMORY_POOL_LIMIT_MIN.get(settings);
-        this.memoryPoolCeiling = DATAFUSION_MEMORY_POOL_LIMIT_MAX.get(settings);
+        this.currentMemoryPoolLimitRaw = DATAFUSION_MEMORY_POOL_LIMIT.get(settings);
         long memoryPoolLimit = resolveMemoryPoolBytes(settings);
         long spillMemoryLimit = resolveSpillMemoryBytes(settings);
         String spillDir = environment.dataFiles()[0].getParent().resolve("tmp").toAbsolutePath().toString();
@@ -228,12 +199,11 @@ public class DataFusionPlugin extends Plugin implements SearchBackEndPlugin<Data
         dataFusionService.start();
         logger.debug("DataFusion plugin initialized — memory pool {}B, spill limit {}B", memoryPoolLimit, spillMemoryLimit);
 
-        // Wire the dynamic memory pool limit setting to the native runtime so updates via the
-        // cluster settings API take effect without restarting the node. The companion min/max
-        // settings are static (NodeScope, not Dynamic) — the resolver uses the floor/ceiling
-        // snapshot captured above, not the live cluster-settings view, to avoid drift from
-        // transient cluster-state propagation.
-        clusterService.getClusterSettings().addSettingsUpdateConsumer(DATAFUSION_MEMORY_POOL_LIMIT, this::applyMemoryPoolLimitSetting);
+        // Wire the memory pool limit setting (and its dynamic min companion) to the native runtime
+        // so cluster-settings PUTs take effect without restarting the node. Both listeners route
+        // through the same resolver, which re-reads the latest raw value plus min on every update.
+        clusterService.getClusterSettings().addSettingsUpdateConsumer(DATAFUSION_MEMORY_POOL_LIMIT, this::onMemoryPoolLimitChanged);
+        clusterService.getClusterSettings().addSettingsUpdateConsumer(DATAFUSION_MEMORY_POOL_LIMIT_MIN, this::onMemoryPoolMinChanged);
 
         this.datafusionSettings = new DatafusionSettings(clusterService);
 
@@ -294,28 +264,26 @@ public class DataFusionPlugin extends Plugin implements SearchBackEndPlugin<Data
 
     /**
      * Resolves {@link #DATAFUSION_MEMORY_POOL_LIMIT}. Percentages apply against
-     * {@code totalPhysicalMemory - configuredMaxHeap} and are clamped by the {@code min}/{@code max}
-     * companion settings; absolute byte sizes are used as-is.
+     * {@code totalPhysicalMemory - configuredMaxHeap} and are floored by the {@code min}
+     * companion setting; absolute byte sizes are used as-is.
      */
     static long resolveMemoryPoolBytes(Settings settings) {
         return resolveBytes(
             DATAFUSION_MEMORY_POOL_LIMIT.get(settings),
             DATAFUSION_MEMORY_POOL_LIMIT_MIN.get(settings),
-            DATAFUSION_MEMORY_POOL_LIMIT_MAX.get(settings),
             DATAFUSION_MEMORY_POOL_LIMIT.getKey()
         );
     }
 
     /**
      * Resolves {@link #DATAFUSION_SPILL_MEMORY_LIMIT}. Percentages apply against
-     * {@code totalPhysicalMemory - configuredMaxHeap} and are clamped by the {@code min}/{@code max}
-     * companion settings; absolute byte sizes are used as-is.
+     * {@code totalPhysicalMemory - configuredMaxHeap} and are floored by the {@code min}
+     * companion setting; absolute byte sizes are used as-is.
      */
     static long resolveSpillMemoryBytes(Settings settings) {
         return resolveBytes(
             DATAFUSION_SPILL_MEMORY_LIMIT.get(settings),
             DATAFUSION_SPILL_MEMORY_LIMIT_MIN.get(settings),
-            DATAFUSION_SPILL_MEMORY_LIMIT_MAX.get(settings),
             DATAFUSION_SPILL_MEMORY_LIMIT.getKey()
         );
     }
@@ -323,10 +291,10 @@ public class DataFusionPlugin extends Plugin implements SearchBackEndPlugin<Data
     /**
      * Shared parser for memory-pool-style settings. Mirrors {@code IndexingMemoryController}'s
      * native indexing buffer logic: percentages resolve against
-     * {@code totalPhysicalMemory - configuredMaxHeap} and are clamped by the supplied floor and
-     * ceiling; absolute byte sizes are returned as-is.
+     * {@code totalPhysicalMemory - configuredMaxHeap} and are floored by the supplied minimum;
+     * absolute byte sizes are returned as-is.
      */
-    private static long resolveBytes(String configured, ByteSizeValue floor, ByteSizeValue ceiling, String settingKey) {
+    private static long resolveBytes(String configured, ByteSizeValue floor, String settingKey) {
         if (configured.endsWith("%")) {
             long totalAvailableMemory = OsProbe.getInstance().getTotalPhysicalMemorySize() - JvmInfo.jvmInfo().getConfiguredMaxHeapSize();
             if (totalAvailableMemory <= 0) {
@@ -338,28 +306,37 @@ public class DataFusionPlugin extends Plugin implements SearchBackEndPlugin<Data
             if (bytes < floor.getBytes()) {
                 bytes = floor.getBytes();
             }
-            if (ceiling.getBytes() != -1 && bytes > ceiling.getBytes()) {
-                bytes = ceiling.getBytes();
-            }
             return bytes;
         }
         return ByteSizeValue.parseBytesSizeValue(configured, settingKey).getBytes();
     }
 
     /**
-     * Cluster-settings update hook for {@link #DATAFUSION_MEMORY_POOL_LIMIT}. Re-resolves the new
-     * value against the floor/ceiling snapshot taken at startup and propagates it to the running
-     * runtime. We deliberately do not re-read the min/max companions from
-     * {@link ClusterService#getSettings()} on every update — that {@link Settings} view can lag
-     * the actual node-scope values during cluster-state propagation, which would silently apply
-     * stale or default bounds to the new limit.
+     * Cluster-settings listener for {@link #DATAFUSION_MEMORY_POOL_LIMIT}. Records the new raw
+     * value, re-resolves against the current min, and propagates the result to the native runtime.
      */
-    private void applyMemoryPoolLimitSetting(String newValue) {
-        if (memoryPoolFloor == null || memoryPoolCeiling == null) {
-            logger.debug("Min/max companions not yet snapshotted; ignoring memory pool limit update");
+    private void onMemoryPoolLimitChanged(String newValue) {
+        this.currentMemoryPoolLimitRaw = newValue;
+        applyMemoryPoolLimit(newValue);
+    }
+
+    /**
+     * Cluster-settings listener for {@link #DATAFUSION_MEMORY_POOL_LIMIT_MIN}. Re-resolves the
+     * current raw limit against the new floor and propagates the result. Only meaningful when the
+     * limit is configured as a percentage — absolute byte sizes ignore the floor.
+     */
+    private void onMemoryPoolMinChanged(ByteSizeValue newMin) {
+        applyMemoryPoolLimit(currentMemoryPoolLimitRaw);
+    }
+
+    private void applyMemoryPoolLimit(String rawValue) {
+        ClusterService cs = clusterService;
+        if (cs == null) {
+            logger.debug("ClusterService not yet initialized; ignoring memory pool limit update");
             return;
         }
-        long newLimitBytes = resolveBytes(newValue, memoryPoolFloor, memoryPoolCeiling, DATAFUSION_MEMORY_POOL_LIMIT.getKey());
+        ByteSizeValue floor = DATAFUSION_MEMORY_POOL_LIMIT_MIN.get(cs.getSettings());
+        long newLimitBytes = resolveBytes(rawValue, floor, DATAFUSION_MEMORY_POOL_LIMIT.getKey());
         updateMemoryPoolLimit(newLimitBytes);
     }
 

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionPlugin.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionPlugin.java
@@ -163,6 +163,14 @@ public class DataFusionPlugin extends Plugin implements SearchBackEndPlugin<Data
     private volatile DatafusionSettings datafusionSettings;
     /** Most recent raw value of {@link #DATAFUSION_MEMORY_POOL_LIMIT}; updated by its listener. */
     private volatile String currentMemoryPoolLimitRaw = DEFAULT_MEMORY_POOL_LIMIT;
+    /**
+     * Most recent value of {@link #DATAFUSION_MEMORY_POOL_LIMIT_MIN}; updated by its listener.
+     * We cache it in this volatile field rather than reading {@code clusterService.getSettings()}
+     * inside the listener — {@code AbstractScopedSettings} only writes {@code lastSettingsApplied}
+     * after all updaters run, so a listener that re-reads via {@code .get(getSettings())} sees the
+     * pre-update value.
+     */
+    private volatile ByteSizeValue currentMemoryPoolMin = DEFAULT_MEMORY_POOL_LIMIT_MIN;
 
     /**
      * Creates the DataFusion plugin.
@@ -188,6 +196,7 @@ public class DataFusionPlugin extends Plugin implements SearchBackEndPlugin<Data
         this.clusterService = clusterService;
         Settings settings = environment.settings();
         this.currentMemoryPoolLimitRaw = DATAFUSION_MEMORY_POOL_LIMIT.get(settings);
+        this.currentMemoryPoolMin = DATAFUSION_MEMORY_POOL_LIMIT_MIN.get(settings);
         long memoryPoolLimit = resolveMemoryPoolBytes(settings);
         long spillMemoryLimit = resolveSpillMemoryBytes(settings);
         String spillDir = environment.dataFiles()[0].getParent().resolve("tmp").toAbsolutePath().toString();
@@ -323,22 +332,21 @@ public class DataFusionPlugin extends Plugin implements SearchBackEndPlugin<Data
     }
 
     /**
-     * Cluster-settings listener for {@link #DATAFUSION_MEMORY_POOL_LIMIT_MIN}. Re-resolves the
-     * current raw limit against the new floor and propagates the result. Only meaningful when the
-     * limit is configured as a percentage — absolute byte sizes ignore the floor.
+     * Cluster-settings listener for {@link #DATAFUSION_MEMORY_POOL_LIMIT_MIN}. Caches the new
+     * floor and re-resolves the current raw limit against it. Only meaningful when the limit is
+     * configured as a percentage — absolute byte sizes ignore the floor.
      */
     private void onMemoryPoolMinChanged(ByteSizeValue newMin) {
+        this.currentMemoryPoolMin = newMin;
         applyMemoryPoolLimit(currentMemoryPoolLimitRaw);
     }
 
     private void applyMemoryPoolLimit(String rawValue) {
-        ClusterService cs = clusterService;
-        if (cs == null) {
-            logger.debug("ClusterService not yet initialized; ignoring memory pool limit update");
-            return;
-        }
-        ByteSizeValue floor = DATAFUSION_MEMORY_POOL_LIMIT_MIN.get(cs.getSettings());
-        long newLimitBytes = resolveBytes(rawValue, floor, DATAFUSION_MEMORY_POOL_LIMIT.getKey());
+        // Read floor from our volatile cache rather than from clusterService.getSettings().
+        // AbstractScopedSettings updates lastSettingsApplied only after all listener callbacks
+        // run, so reading via .get(cs.getSettings()) inside a listener returns the pre-update
+        // value. See ArrowBufferPoolRegistry for the same pattern on the parquet side.
+        long newLimitBytes = resolveBytes(rawValue, currentMemoryPoolMin, DATAFUSION_MEMORY_POOL_LIMIT.getKey());
         updateMemoryPoolLimit(newLimitBytes);
     }
 

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionPlugin.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionPlugin.java
@@ -67,11 +67,8 @@ public class DataFusionPlugin extends Plugin implements SearchBackEndPlugin<Data
      * Default value for {@link #DATAFUSION_MEMORY_POOL_LIMIT}. Set to {@code 50%} of non-heap
      * memory to give DataFusion a generous working set on AOS-standard heap configurations
      * (which use the 50% heap rule, leaving non-heap = total/2). On a 64&nbsp;GiB r7g.2xlarge
-     * with 32&nbsp;GiB heap that yields a 16&nbsp;GiB DF pool — comfortably past the diminishing-
-     * returns inflection point in the OFAT sweep at
-     * <a href="https://quip-amazon.com/baxtAdGoq6S9/Mustang-Memory-Tuning-Recommended-Defaults">
-     * Mustang Memory Tuning - Recommended Defaults</a>. Operators on memory-tight workloads
-     * who need more page cache can lower this dynamically via the cluster-settings API.
+     * with 32&nbsp;GiB heap that yields a 16&nbsp;GiB DF pool. Operators on memory-tight
+     * workloads who need more page cache can lower this dynamically via the cluster-settings API.
      */
     public static final String DEFAULT_MEMORY_POOL_LIMIT = "50%";
 

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionPlugin.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionPlugin.java
@@ -22,7 +22,6 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.settings.SettingsFilter;
 import org.opensearch.common.unit.RatioValue;
 import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
-import org.opensearch.core.common.unit.ByteSizeUnit;
 import org.opensearch.core.common.unit.ByteSizeValue;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.env.Environment;
@@ -65,32 +64,31 @@ public class DataFusionPlugin extends Plugin implements SearchBackEndPlugin<Data
     private static final Logger logger = LogManager.getLogger(DataFusionPlugin.class);
 
     /**
-     * Default value for {@link #DATAFUSION_MEMORY_POOL_LIMIT}. {@code 15%} of non-heap memory
-     * comes from the OFAT sweep on r7g.2xlarge documented in
+     * Default value for {@link #DATAFUSION_MEMORY_POOL_LIMIT}. Set to {@code 50%} of non-heap
+     * memory to give DataFusion a generous working set on AOS-standard heap configurations
+     * (which use the 50% heap rule, leaving non-heap = total/2). On a 64&nbsp;GiB r7g.2xlarge
+     * with 32&nbsp;GiB heap that yields a 16&nbsp;GiB DF pool — comfortably past the diminishing-
+     * returns inflection point in the OFAT sweep at
      * <a href="https://quip-amazon.com/baxtAdGoq6S9/Mustang-Memory-Tuning-Recommended-Defaults">
-     * Mustang Memory Tuning - Recommended Defaults</a>: doubling 4&nbsp;GiB → 8&nbsp;GiB buys
-     * ~15% lower p95 ClickBench latency, but 8&nbsp;GiB → 16&nbsp;GiB only ~5%. 15% is the
-     * inflection point that scales cleanly across instance sizes.
+     * Mustang Memory Tuning - Recommended Defaults</a>. Operators on memory-tight workloads
+     * who need more page cache can lower this dynamically via the cluster-settings API.
      */
-    public static final String DEFAULT_MEMORY_POOL_LIMIT = "15%";
-
-    /** Default floor for {@link #DATAFUSION_MEMORY_POOL_LIMIT_MIN}. */
-    public static final ByteSizeValue DEFAULT_MEMORY_POOL_LIMIT_MIN = new ByteSizeValue(512, ByteSizeUnit.MB);
+    public static final String DEFAULT_MEMORY_POOL_LIMIT = "50%";
 
     /** Default value for {@link #DATAFUSION_SPILL_MEMORY_LIMIT}. */
     public static final String DEFAULT_SPILL_MEMORY_LIMIT = "50%";
 
-    /** Default floor for {@link #DATAFUSION_SPILL_MEMORY_LIMIT_MIN}. */
-    public static final ByteSizeValue DEFAULT_SPILL_MEMORY_LIMIT_MIN = new ByteSizeValue(1, ByteSizeUnit.GB);
-
     /**
      * Memory pool limit for the DataFusion runtime. Accepts a percentage of non-heap memory
-     * ({@code totalPhysicalMemory - configuredMaxHeap}, e.g. {@code "15%"}) or an absolute byte
-     * size (e.g. {@code "10gb"}). When a percentage is supplied, the resolved value is floored
-     * by {@link #DATAFUSION_MEMORY_POOL_LIMIT_MIN}.
+     * ({@code totalPhysicalMemory - configuredMaxHeap}, e.g. {@code "50%"}) or an absolute byte
+     * size (e.g. {@code "10gb"}).
      * <p>
      * Dynamic: changes take effect for new allocations only. Existing reservations that exceed
      * the new limit are not reclaimed — they drain naturally as queries complete.
+     * <p>
+     * If non-heap memory is unmeasurable at resolve time, an {@link IllegalStateException} is
+     * thrown — operators on misconfigured boxes should specify an absolute byte size rather
+     * than a percentage.
      */
     public static final Setting<String> DATAFUSION_MEMORY_POOL_LIMIT = Setting.simpleString(
         "datafusion.memory_pool_limit_bytes",
@@ -100,20 +98,9 @@ public class DataFusionPlugin extends Plugin implements SearchBackEndPlugin<Data
         Setting.Property.Dynamic
     );
 
-    /** Floor applied when {@link #DATAFUSION_MEMORY_POOL_LIMIT} is a percentage. */
-    public static final Setting<ByteSizeValue> DATAFUSION_MEMORY_POOL_LIMIT_MIN = Setting.byteSizeSetting(
-        "datafusion.memory_pool_limit.min",
-        DEFAULT_MEMORY_POOL_LIMIT_MIN,
-        new ByteSizeValue(0, ByteSizeUnit.BYTES),
-        new ByteSizeValue(Long.MAX_VALUE, ByteSizeUnit.BYTES),
-        Setting.Property.NodeScope,
-        Setting.Property.Dynamic
-    );
-
     /**
      * Spill memory limit — when exceeded, DataFusion spills to disk. Accepts a percentage of
-     * non-heap memory or an absolute byte size. When a percentage is supplied, the resolved value
-     * is floored by {@link #DATAFUSION_SPILL_MEMORY_LIMIT_MIN}.
+     * non-heap memory or an absolute byte size.
      * <p>
      * Static (NodeScope only). DataFusion's {@code DiskManager} stores the spill cap as a plain
      * {@code u64} and only exposes a setter behind {@code Arc::get_mut}, which fails as soon as
@@ -124,18 +111,6 @@ public class DataFusionPlugin extends Plugin implements SearchBackEndPlugin<Data
         "datafusion.spill_memory_limit_bytes",
         DEFAULT_SPILL_MEMORY_LIMIT,
         DataFusionPlugin::validateMemorySizeOrPercentage,
-        Setting.Property.NodeScope
-    );
-
-    /**
-     * Floor applied when {@link #DATAFUSION_SPILL_MEMORY_LIMIT} is a percentage. Static (NodeScope
-     * only) — see {@link #DATAFUSION_SPILL_MEMORY_LIMIT} for why.
-     */
-    public static final Setting<ByteSizeValue> DATAFUSION_SPILL_MEMORY_LIMIT_MIN = Setting.byteSizeSetting(
-        "datafusion.spill_memory_limit.min",
-        DEFAULT_SPILL_MEMORY_LIMIT_MIN,
-        new ByteSizeValue(0, ByteSizeUnit.BYTES),
-        new ByteSizeValue(Long.MAX_VALUE, ByteSizeUnit.BYTES),
         Setting.Property.NodeScope
     );
 
@@ -168,16 +143,6 @@ public class DataFusionPlugin extends Plugin implements SearchBackEndPlugin<Data
     private volatile SimpleExtension.ExtensionCollection substraitExtensions;
     private volatile ClusterService clusterService;
     private volatile DatafusionSettings datafusionSettings;
-    /** Most recent raw value of {@link #DATAFUSION_MEMORY_POOL_LIMIT}; updated by its listener. */
-    private volatile String currentMemoryPoolLimitRaw = DEFAULT_MEMORY_POOL_LIMIT;
-    /**
-     * Most recent value of {@link #DATAFUSION_MEMORY_POOL_LIMIT_MIN}; updated by its listener.
-     * We cache it in this volatile field rather than reading {@code clusterService.getSettings()}
-     * inside the listener — {@code AbstractScopedSettings} only writes {@code lastSettingsApplied}
-     * after all updaters run, so a listener that re-reads via {@code .get(getSettings())} sees the
-     * pre-update value.
-     */
-    private volatile ByteSizeValue currentMemoryPoolMin = DEFAULT_MEMORY_POOL_LIMIT_MIN;
 
     /**
      * Creates the DataFusion plugin.
@@ -202,8 +167,6 @@ public class DataFusionPlugin extends Plugin implements SearchBackEndPlugin<Data
         this.dataFormatRegistry = dataFormatRegistry;
         this.clusterService = clusterService;
         Settings settings = environment.settings();
-        this.currentMemoryPoolLimitRaw = DATAFUSION_MEMORY_POOL_LIMIT.get(settings);
-        this.currentMemoryPoolMin = DATAFUSION_MEMORY_POOL_LIMIT_MIN.get(settings);
         long memoryPoolLimit = resolveMemoryPoolBytes(settings);
         long spillMemoryLimit = resolveSpillMemoryBytes(settings);
         String spillDir = environment.dataFiles()[0].getParent().resolve("tmp").toAbsolutePath().toString();
@@ -217,11 +180,9 @@ public class DataFusionPlugin extends Plugin implements SearchBackEndPlugin<Data
         dataFusionService.start();
         logger.debug("DataFusion plugin initialized — memory pool {}B, spill limit {}B", memoryPoolLimit, spillMemoryLimit);
 
-        // Wire the memory pool limit setting (and its dynamic min companion) to the native runtime
-        // so cluster-settings PUTs take effect without restarting the node. Both listeners route
-        // through the same resolver, which re-reads the latest raw value plus min on every update.
+        // Wire the memory pool limit setting to the native runtime so cluster-settings PUTs take
+        // effect without restarting the node.
         clusterService.getClusterSettings().addSettingsUpdateConsumer(DATAFUSION_MEMORY_POOL_LIMIT, this::onMemoryPoolLimitChanged);
-        clusterService.getClusterSettings().addSettingsUpdateConsumer(DATAFUSION_MEMORY_POOL_LIMIT_MIN, this::onMemoryPoolMinChanged);
 
         this.datafusionSettings = new DatafusionSettings(clusterService);
 
@@ -282,78 +243,50 @@ public class DataFusionPlugin extends Plugin implements SearchBackEndPlugin<Data
 
     /**
      * Resolves {@link #DATAFUSION_MEMORY_POOL_LIMIT}. Percentages apply against
-     * {@code totalPhysicalMemory - configuredMaxHeap} and are floored by the {@code min}
-     * companion setting; absolute byte sizes are used as-is.
+     * {@code totalPhysicalMemory - configuredMaxHeap}; absolute byte sizes are used as-is.
      */
     static long resolveMemoryPoolBytes(Settings settings) {
-        return resolveBytes(
-            DATAFUSION_MEMORY_POOL_LIMIT.get(settings),
-            DATAFUSION_MEMORY_POOL_LIMIT_MIN.get(settings),
-            DATAFUSION_MEMORY_POOL_LIMIT.getKey()
-        );
+        return resolveBytes(DATAFUSION_MEMORY_POOL_LIMIT.get(settings), DATAFUSION_MEMORY_POOL_LIMIT.getKey());
     }
 
     /**
      * Resolves {@link #DATAFUSION_SPILL_MEMORY_LIMIT}. Percentages apply against
-     * {@code totalPhysicalMemory - configuredMaxHeap} and are floored by the {@code min}
-     * companion setting; absolute byte sizes are used as-is.
+     * {@code totalPhysicalMemory - configuredMaxHeap}; absolute byte sizes are used as-is.
      */
     static long resolveSpillMemoryBytes(Settings settings) {
-        return resolveBytes(
-            DATAFUSION_SPILL_MEMORY_LIMIT.get(settings),
-            DATAFUSION_SPILL_MEMORY_LIMIT_MIN.get(settings),
-            DATAFUSION_SPILL_MEMORY_LIMIT.getKey()
-        );
+        return resolveBytes(DATAFUSION_SPILL_MEMORY_LIMIT.get(settings), DATAFUSION_SPILL_MEMORY_LIMIT.getKey());
     }
 
     /**
      * Shared parser for memory-pool-style settings. Mirrors {@code IndexingMemoryController}'s
      * native indexing buffer logic: percentages resolve against
-     * {@code totalPhysicalMemory - configuredMaxHeap} and are floored by the supplied minimum;
-     * absolute byte sizes are returned as-is.
+     * {@code totalPhysicalMemory - configuredMaxHeap}; absolute byte sizes are returned as-is.
+     * <p>
+     * Throws {@link IllegalStateException} if a percentage is supplied but non-heap memory is
+     * unmeasurable — the operator should specify an absolute byte size in that case.
      */
-    private static long resolveBytes(String configured, ByteSizeValue floor, String settingKey) {
+    private static long resolveBytes(String configured, String settingKey) {
         if (configured.endsWith("%")) {
             long totalAvailableMemory = OsProbe.getInstance().getTotalPhysicalMemorySize() - JvmInfo.jvmInfo().getConfiguredMaxHeapSize();
             if (totalAvailableMemory <= 0) {
-                logger.warn("Non-heap memory not measurable while resolving [{}]; falling back to {}", settingKey, floor);
-                return floor.getBytes();
+                throw new IllegalStateException(
+                    "Non-heap memory not measurable for setting ["
+                        + settingKey
+                        + "]; configure an absolute byte size (e.g. \"2gb\") instead of a percentage."
+                );
             }
             RatioValue ratio = RatioValue.parseRatioValue(configured);
-            long bytes = (long) (totalAvailableMemory * ratio.getAsRatio());
-            if (bytes < floor.getBytes()) {
-                bytes = floor.getBytes();
-            }
-            return bytes;
+            return (long) (totalAvailableMemory * ratio.getAsRatio());
         }
         return ByteSizeValue.parseBytesSizeValue(configured, settingKey).getBytes();
     }
 
     /**
-     * Cluster-settings listener for {@link #DATAFUSION_MEMORY_POOL_LIMIT}. Records the new raw
-     * value, re-resolves against the current min, and propagates the result to the native runtime.
+     * Cluster-settings listener for {@link #DATAFUSION_MEMORY_POOL_LIMIT}. Re-resolves the new
+     * value and propagates the result to the native runtime.
      */
     private void onMemoryPoolLimitChanged(String newValue) {
-        this.currentMemoryPoolLimitRaw = newValue;
-        applyMemoryPoolLimit(newValue);
-    }
-
-    /**
-     * Cluster-settings listener for {@link #DATAFUSION_MEMORY_POOL_LIMIT_MIN}. Caches the new
-     * floor and re-resolves the current raw limit against it. Only meaningful when the limit is
-     * configured as a percentage — absolute byte sizes ignore the floor.
-     */
-    private void onMemoryPoolMinChanged(ByteSizeValue newMin) {
-        this.currentMemoryPoolMin = newMin;
-        applyMemoryPoolLimit(currentMemoryPoolLimitRaw);
-    }
-
-    private void applyMemoryPoolLimit(String rawValue) {
-        // Read floor from our volatile cache rather than from clusterService.getSettings().
-        // AbstractScopedSettings updates lastSettingsApplied only after all listener callbacks
-        // run, so reading via .get(cs.getSettings()) inside a listener returns the pre-update
-        // value. See ArrowBufferPoolRegistry for the same pattern on the parquet side.
-        long newLimitBytes = resolveBytes(rawValue, currentMemoryPoolMin, DATAFUSION_MEMORY_POOL_LIMIT.getKey());
+        long newLimitBytes = resolveBytes(newValue, DATAFUSION_MEMORY_POOL_LIMIT.getKey());
         updateMemoryPoolLimit(newLimitBytes);
     }
 

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionPlugin.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionPlugin.java
@@ -328,8 +328,7 @@ public class DataFusionPlugin extends Plugin implements SearchBackEndPlugin<Data
      */
     private static long resolveBytes(String configured, ByteSizeValue floor, ByteSizeValue ceiling, String settingKey) {
         if (configured.endsWith("%")) {
-            long totalAvailableMemory = OsProbe.getInstance().getTotalPhysicalMemorySize()
-                - JvmInfo.jvmInfo().getConfiguredMaxHeapSize();
+            long totalAvailableMemory = OsProbe.getInstance().getTotalPhysicalMemorySize() - JvmInfo.jvmInfo().getConfiguredMaxHeapSize();
             if (totalAvailableMemory <= 0) {
                 logger.warn("Non-heap memory not measurable while resolving [{}]; falling back to {}", settingKey, floor);
                 return floor.getBytes();

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionPlugin.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionPlugin.java
@@ -44,6 +44,9 @@ import org.opensearch.transport.client.Client;
 import org.opensearch.watcher.ResourceWatcherService;
 
 import java.io.IOException;
+import java.nio.file.FileStore;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -72,8 +75,14 @@ public class DataFusionPlugin extends Plugin implements SearchBackEndPlugin<Data
      */
     public static final String DEFAULT_MEMORY_POOL_LIMIT = "50%";
 
-    /** Default value for {@link #DATAFUSION_SPILL_MEMORY_LIMIT}. */
-    public static final String DEFAULT_SPILL_MEMORY_LIMIT = "50%";
+    /**
+     * Default value for {@link #DATAFUSION_DISK_SPILL_LIMIT}. {@code 20%} of the spill
+     * directory's usable disk space at startup. Disk-relative because the cap bounds
+     * temporary on-disk spill files, not memory; sizing it against non-heap RAM (the
+     * earlier behavior) under-allocated on data-heavy workloads where a single
+     * group-by can spill more than the entire RAM of the host.
+     */
+    public static final String DEFAULT_DISK_SPILL_LIMIT = "20%";
 
     /**
      * Memory pool limit for the DataFusion runtime. Accepts a percentage of non-heap memory
@@ -88,7 +97,7 @@ public class DataFusionPlugin extends Plugin implements SearchBackEndPlugin<Data
      * than a percentage.
      */
     public static final Setting<String> DATAFUSION_MEMORY_POOL_LIMIT = Setting.simpleString(
-        "datafusion.memory_pool_limit_bytes",
+        "datafusion.memory_pool_limit",
         DEFAULT_MEMORY_POOL_LIMIT,
         DataFusionPlugin::validateMemorySizeOrPercentage,
         Setting.Property.NodeScope,
@@ -96,17 +105,18 @@ public class DataFusionPlugin extends Plugin implements SearchBackEndPlugin<Data
     );
 
     /**
-     * Spill memory limit — when exceeded, DataFusion spills to disk. Accepts a percentage of
-     * non-heap memory or an absolute byte size.
+     * Disk spill limit — caps the total bytes DataFusion may write to its spill directory.
+     * Accepts a percentage of usable disk in the spill directory's filesystem (e.g.
+     * {@code "20%"}) or an absolute byte size (e.g. {@code "100gb"}).
      * <p>
      * Static (NodeScope only). DataFusion's {@code DiskManager} stores the spill cap as a plain
      * {@code u64} and only exposes a setter behind {@code Arc::get_mut}, which fails as soon as
      * any query holds a strong reference to the runtime. Until upstream offers a thread-safe
      * setter we treat this as a startup setting; change it in {@code opensearch.yml} and restart.
      */
-    public static final Setting<String> DATAFUSION_SPILL_MEMORY_LIMIT = Setting.simpleString(
-        "datafusion.spill_memory_limit_bytes",
-        DEFAULT_SPILL_MEMORY_LIMIT,
+    public static final Setting<String> DATAFUSION_DISK_SPILL_LIMIT = Setting.simpleString(
+        "datafusion.disk_spill_limit",
+        DEFAULT_DISK_SPILL_LIMIT,
         DataFusionPlugin::validateMemorySizeOrPercentage,
         Setting.Property.NodeScope
     );
@@ -165,17 +175,17 @@ public class DataFusionPlugin extends Plugin implements SearchBackEndPlugin<Data
         this.clusterService = clusterService;
         Settings settings = environment.settings();
         long memoryPoolLimit = resolveMemoryPoolBytes(settings);
-        long spillMemoryLimit = resolveSpillMemoryBytes(settings);
-        String spillDir = environment.dataFiles()[0].getParent().resolve("tmp").toAbsolutePath().toString();
+        Path spillDir = environment.dataFiles()[0].getParent().resolve("tmp").toAbsolutePath();
+        long diskSpillLimit = resolveDiskSpillBytes(settings, spillDir);
 
         dataFusionService = DataFusionService.builder()
             .memoryPoolLimit(memoryPoolLimit)
-            .spillMemoryLimit(spillMemoryLimit)
-            .spillDirectory(spillDir)
+            .diskSpillLimit(diskSpillLimit)
+            .spillDirectory(spillDir.toString())
             .clusterSettings(clusterService.getClusterSettings())
             .build();
         dataFusionService.start();
-        logger.debug("DataFusion plugin initialized — memory pool {}B, spill limit {}B", memoryPoolLimit, spillMemoryLimit);
+        logger.debug("DataFusion plugin initialized — memory pool {}B, disk spill {}B", memoryPoolLimit, diskSpillLimit);
 
         // Wire the memory pool limit setting to the native runtime so cluster-settings PUTs take
         // effect without restarting the node.
@@ -247,11 +257,70 @@ public class DataFusionPlugin extends Plugin implements SearchBackEndPlugin<Data
     }
 
     /**
-     * Resolves {@link #DATAFUSION_SPILL_MEMORY_LIMIT}. Percentages apply against
-     * {@code totalPhysicalMemory - configuredMaxHeap}; absolute byte sizes are used as-is.
+     * Resolves {@link #DATAFUSION_DISK_SPILL_LIMIT} against the spill directory's filesystem.
+     * Percentages apply against {@code getUsableSpace()} on the FileStore hosting
+     * {@code spillDir}; absolute byte sizes are used as-is.
+     * <p>
+     * The spill directory may not yet exist at resolve time (DataFusion creates it lazily),
+     * so we walk up to the closest existing parent on the same filesystem.
      */
-    static long resolveSpillMemoryBytes(Settings settings) {
-        return resolveBytes(DATAFUSION_SPILL_MEMORY_LIMIT.get(settings), DATAFUSION_SPILL_MEMORY_LIMIT.getKey());
+    static long resolveDiskSpillBytes(Settings settings, Path spillDir) {
+        String configured = DATAFUSION_DISK_SPILL_LIMIT.get(settings);
+        String key = DATAFUSION_DISK_SPILL_LIMIT.getKey();
+        if (configured.endsWith("%")) {
+            long usable = resolveUsableDiskBytes(spillDir, key);
+            RatioValue ratio = RatioValue.parseRatioValue(configured);
+            return (long) (usable * ratio.getAsRatio());
+        }
+        return ByteSizeValue.parseBytesSizeValue(configured, key).getBytes();
+    }
+
+    /**
+     * Returns usable bytes on the filesystem hosting {@code spillDir}, walking up to the
+     * closest existing ancestor so the lookup works before DataFusion creates the temp dir.
+     * Uses {@link Environment#getFileStore(Path)} (not raw {@link Files#getFileStore}) so the
+     * JDK-8162520 negative-overflow workaround applies — without it, certain large or quirky
+     * filesystems return -1 and we'd misclassify them as "unmeasurable."
+     */
+    private static long resolveUsableDiskBytes(Path spillDir, String settingKey) {
+        Path probe = spillDir;
+        while (probe != null && !Files.exists(probe)) {
+            probe = probe.getParent();
+        }
+        if (probe == null) {
+            // Defensive — on POSIX `/` always exists, so this branch is essentially unreachable
+            // in production. We keep it for esoteric NIO providers that report null parents.
+            throw new IllegalStateException(
+                "Spill directory ["
+                    + spillDir
+                    + "] has no existing ancestor for setting ["
+                    + settingKey
+                    + "]; configure an absolute byte size (e.g. \"100gb\") instead of a percentage."
+            );
+        }
+        try {
+            FileStore store = Environment.getFileStore(probe);
+            long usable = store.getUsableSpace();
+            if (usable <= 0) {
+                throw new IllegalStateException(
+                    "Usable disk space not measurable on ["
+                        + probe
+                        + "] for setting ["
+                        + settingKey
+                        + "]; configure an absolute byte size (e.g. \"100gb\") instead of a percentage."
+                );
+            }
+            return usable;
+        } catch (IOException e) {
+            throw new IllegalStateException(
+                "Failed to read filesystem info for ["
+                    + probe
+                    + "] when resolving setting ["
+                    + settingKey
+                    + "]; configure an absolute byte size (e.g. \"100gb\") instead of a percentage.",
+                e
+            );
+        }
     }
 
     /**
@@ -291,8 +360,8 @@ public class DataFusionPlugin extends Plugin implements SearchBackEndPlugin<Data
      * Validates that {@code value} is either a percentage ({@code "25%"}) or an absolute byte
      * size accepted by {@link ByteSizeValue#parseBytesSizeValue(String, String)}. Used as the
      * setting-time validator for {@link #DATAFUSION_MEMORY_POOL_LIMIT} and
-     * {@link #DATAFUSION_SPILL_MEMORY_LIMIT} so that malformed values fail at update time rather
-     * than at the next read inside {@link #resolveBytes}.
+     * {@link #DATAFUSION_DISK_SPILL_LIMIT} so that malformed values fail at update time rather
+     * than at the next read inside the per-setting resolvers.
      */
     private static void validateMemorySizeOrPercentage(String value) {
         try {

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionPlugin.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionPlugin.java
@@ -108,26 +108,28 @@ public class DataFusionPlugin extends Plugin implements SearchBackEndPlugin<Data
      * non-heap memory or an absolute byte size. When a percentage is supplied, the resolved value
      * is floored by {@link #DATAFUSION_SPILL_MEMORY_LIMIT_MIN}.
      * <p>
-     * Dynamic in the cluster-settings sense: PUTs are accepted and persisted, but the spill limit
-     * is fixed in the native runtime at construction time (no setter). The new value takes effect
-     * after the next node restart.
+     * Static (NodeScope only). DataFusion's {@code DiskManager} stores the spill cap as a plain
+     * {@code u64} and only exposes a setter behind {@code Arc::get_mut}, which fails as soon as
+     * any query holds a strong reference to the runtime. Until upstream offers a thread-safe
+     * setter we treat this as a startup setting; change it in {@code opensearch.yml} and restart.
      */
     public static final Setting<String> DATAFUSION_SPILL_MEMORY_LIMIT = Setting.simpleString(
         "datafusion.spill_memory_limit_bytes",
         DEFAULT_SPILL_MEMORY_LIMIT,
         DataFusionPlugin::validateMemorySizeOrPercentage,
-        Setting.Property.NodeScope,
-        Setting.Property.Dynamic
+        Setting.Property.NodeScope
     );
 
-    /** Floor applied when {@link #DATAFUSION_SPILL_MEMORY_LIMIT} is a percentage. */
+    /**
+     * Floor applied when {@link #DATAFUSION_SPILL_MEMORY_LIMIT} is a percentage. Static (NodeScope
+     * only) — see {@link #DATAFUSION_SPILL_MEMORY_LIMIT} for why.
+     */
     public static final Setting<ByteSizeValue> DATAFUSION_SPILL_MEMORY_LIMIT_MIN = Setting.byteSizeSetting(
         "datafusion.spill_memory_limit.min",
         DEFAULT_SPILL_MEMORY_LIMIT_MIN,
         new ByteSizeValue(0, ByteSizeUnit.BYTES),
         new ByteSizeValue(Long.MAX_VALUE, ByteSizeUnit.BYTES),
-        Setting.Property.NodeScope,
-        Setting.Property.Dynamic
+        Setting.Property.NodeScope
     );
 
     /**

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionPlugin.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionPlugin.java
@@ -64,8 +64,15 @@ public class DataFusionPlugin extends Plugin implements SearchBackEndPlugin<Data
 
     private static final Logger logger = LogManager.getLogger(DataFusionPlugin.class);
 
-    /** Default value for {@link #DATAFUSION_MEMORY_POOL_LIMIT}. */
-    public static final String DEFAULT_MEMORY_POOL_LIMIT = "25%";
+    /**
+     * Default value for {@link #DATAFUSION_MEMORY_POOL_LIMIT}. {@code 15%} of non-heap memory
+     * comes from the OFAT sweep on r7g.2xlarge documented in
+     * <a href="https://quip-amazon.com/baxtAdGoq6S9/Mustang-Memory-Tuning-Recommended-Defaults">
+     * Mustang Memory Tuning - Recommended Defaults</a>: doubling 4&nbsp;GiB → 8&nbsp;GiB buys
+     * ~15% lower p95 ClickBench latency, but 8&nbsp;GiB → 16&nbsp;GiB only ~5%. 15% is the
+     * inflection point that scales cleanly across instance sizes.
+     */
+    public static final String DEFAULT_MEMORY_POOL_LIMIT = "15%";
 
     /** Default floor for {@link #DATAFUSION_MEMORY_POOL_LIMIT_MIN}. */
     public static final ByteSizeValue DEFAULT_MEMORY_POOL_LIMIT_MIN = new ByteSizeValue(512, ByteSizeUnit.MB);
@@ -78,7 +85,7 @@ public class DataFusionPlugin extends Plugin implements SearchBackEndPlugin<Data
 
     /**
      * Memory pool limit for the DataFusion runtime. Accepts a percentage of non-heap memory
-     * ({@code totalPhysicalMemory - configuredMaxHeap}, e.g. {@code "25%"}) or an absolute byte
+     * ({@code totalPhysicalMemory - configuredMaxHeap}, e.g. {@code "15%"}) or an absolute byte
      * size (e.g. {@code "10gb"}). When a percentage is supplied, the resolved value is floored
      * by {@link #DATAFUSION_MEMORY_POOL_LIMIT_MIN}.
      * <p>

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionPlugin.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionPlugin.java
@@ -20,13 +20,18 @@ import org.opensearch.common.settings.IndexScopedSettings;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.settings.SettingsFilter;
+import org.opensearch.common.unit.RatioValue;
 import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
+import org.opensearch.core.common.unit.ByteSizeUnit;
+import org.opensearch.core.common.unit.ByteSizeValue;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.env.Environment;
 import org.opensearch.env.NodeEnvironment;
 import org.opensearch.index.engine.dataformat.DataFormatRegistry;
 import org.opensearch.index.engine.dataformat.ReaderManagerConfig;
 import org.opensearch.index.engine.exec.EngineReaderManager;
+import org.opensearch.monitor.jvm.JvmInfo;
+import org.opensearch.monitor.os.OsProbe;
 import org.opensearch.plugins.ActionPlugin;
 import org.opensearch.plugins.NativeStoreHandle;
 import org.opensearch.plugins.Plugin;
@@ -59,25 +64,92 @@ public class DataFusionPlugin extends Plugin implements SearchBackEndPlugin<Data
 
     private static final Logger logger = LogManager.getLogger(DataFusionPlugin.class);
 
+    /** Default value for {@link #DATAFUSION_MEMORY_POOL_LIMIT}. */
+    public static final String DEFAULT_MEMORY_POOL_LIMIT = "25%";
+
+    /** Default floor for {@link #DATAFUSION_MEMORY_POOL_LIMIT_MIN}. */
+    public static final ByteSizeValue DEFAULT_MEMORY_POOL_LIMIT_MIN = new ByteSizeValue(512, ByteSizeUnit.MB);
+
+    /** Default ceiling for {@link #DATAFUSION_MEMORY_POOL_LIMIT_MAX}. */
+    public static final ByteSizeValue DEFAULT_MEMORY_POOL_LIMIT_MAX = new ByteSizeValue(30, ByteSizeUnit.GB);
+
+    /** Default value for {@link #DATAFUSION_SPILL_MEMORY_LIMIT}. */
+    public static final String DEFAULT_SPILL_MEMORY_LIMIT = "50%";
+
+    /** Default floor for {@link #DATAFUSION_SPILL_MEMORY_LIMIT_MIN}. */
+    public static final ByteSizeValue DEFAULT_SPILL_MEMORY_LIMIT_MIN = new ByteSizeValue(1, ByteSizeUnit.GB);
+
+    /** Default ceiling for {@link #DATAFUSION_SPILL_MEMORY_LIMIT_MAX}. */
+    public static final ByteSizeValue DEFAULT_SPILL_MEMORY_LIMIT_MAX = new ByteSizeValue(100, ByteSizeUnit.GB);
+
     /**
-     * Memory pool limit for the DataFusion runtime.
+     * Memory pool limit for the DataFusion runtime. Accepts a percentage of non-heap memory
+     * ({@code totalPhysicalMemory - configuredMaxHeap}, e.g. {@code "25%"}) or an absolute byte
+     * size (e.g. {@code "10gb"}). When a percentage is supplied, the resolved value is clamped
+     * by {@link #DATAFUSION_MEMORY_POOL_LIMIT_MIN} / {@link #DATAFUSION_MEMORY_POOL_LIMIT_MAX}.
      * <p>
-     * Dynamic: changes take effect for new allocations only. Existing reservations
-     * that exceed the new limit are not reclaimed — they drain naturally as queries complete.
+     * Dynamic: changes take effect for new allocations only. Existing reservations that exceed
+     * the new limit are not reclaimed — they drain naturally as queries complete.
      */
-    public static final Setting<Long> DATAFUSION_MEMORY_POOL_LIMIT = Setting.longSetting(
+    public static final Setting<String> DATAFUSION_MEMORY_POOL_LIMIT = Setting.simpleString(
         "datafusion.memory_pool_limit_bytes",
-        Runtime.getRuntime().maxMemory() / 4,
-        0L,
+        DEFAULT_MEMORY_POOL_LIMIT,
+        DataFusionPlugin::validateMemorySizeOrPercentage,
         Setting.Property.NodeScope,
         Setting.Property.Dynamic
     );
 
-    /** Spill memory limit — when exceeded, DataFusion spills to disk. */
-    public static final Setting<Long> DATAFUSION_SPILL_MEMORY_LIMIT = Setting.longSetting(
+    /** Floor applied when {@link #DATAFUSION_MEMORY_POOL_LIMIT} is a percentage. */
+    public static final Setting<ByteSizeValue> DATAFUSION_MEMORY_POOL_LIMIT_MIN = Setting.byteSizeSetting(
+        "datafusion.memory_pool_limit.min",
+        DEFAULT_MEMORY_POOL_LIMIT_MIN,
+        new ByteSizeValue(0, ByteSizeUnit.BYTES),
+        new ByteSizeValue(Long.MAX_VALUE, ByteSizeUnit.BYTES),
+        Setting.Property.NodeScope
+    );
+
+    /**
+     * Ceiling applied when {@link #DATAFUSION_MEMORY_POOL_LIMIT} is a percentage. {@code -1}
+     * disables the ceiling.
+     */
+    public static final Setting<ByteSizeValue> DATAFUSION_MEMORY_POOL_LIMIT_MAX = Setting.byteSizeSetting(
+        "datafusion.memory_pool_limit.max",
+        DEFAULT_MEMORY_POOL_LIMIT_MAX,
+        new ByteSizeValue(-1),
+        new ByteSizeValue(Long.MAX_VALUE, ByteSizeUnit.BYTES),
+        Setting.Property.NodeScope
+    );
+
+    /**
+     * Spill memory limit — when exceeded, DataFusion spills to disk. Accepts a percentage of
+     * non-heap memory or an absolute byte size. When a percentage is supplied, the resolved value
+     * is clamped by {@link #DATAFUSION_SPILL_MEMORY_LIMIT_MIN} / {@link #DATAFUSION_SPILL_MEMORY_LIMIT_MAX}.
+     */
+    public static final Setting<String> DATAFUSION_SPILL_MEMORY_LIMIT = Setting.simpleString(
         "datafusion.spill_memory_limit_bytes",
-        Runtime.getRuntime().maxMemory() / 8,
-        0L,
+        DEFAULT_SPILL_MEMORY_LIMIT,
+        DataFusionPlugin::validateMemorySizeOrPercentage,
+        Setting.Property.NodeScope
+    );
+
+    /** Floor applied when {@link #DATAFUSION_SPILL_MEMORY_LIMIT} is a percentage. */
+    public static final Setting<ByteSizeValue> DATAFUSION_SPILL_MEMORY_LIMIT_MIN = Setting.byteSizeSetting(
+        "datafusion.spill_memory_limit.min",
+        DEFAULT_SPILL_MEMORY_LIMIT_MIN,
+        new ByteSizeValue(0, ByteSizeUnit.BYTES),
+        new ByteSizeValue(Long.MAX_VALUE, ByteSizeUnit.BYTES),
+        Setting.Property.NodeScope
+    );
+
+    /**
+     * Ceiling applied when {@link #DATAFUSION_SPILL_MEMORY_LIMIT} is a percentage. {@code -1}
+     * disables the ceiling.
+     */
+    public static final Setting<ByteSizeValue> DATAFUSION_SPILL_MEMORY_LIMIT_MAX = Setting.byteSizeSetting(
+        "datafusion.spill_memory_limit.max",
+        DEFAULT_SPILL_MEMORY_LIMIT_MAX,
+        new ByteSizeValue(-1),
+        new ByteSizeValue(Long.MAX_VALUE, ByteSizeUnit.BYTES),
         Setting.Property.NodeScope
     );
 
@@ -110,6 +182,11 @@ public class DataFusionPlugin extends Plugin implements SearchBackEndPlugin<Data
     private volatile SimpleExtension.ExtensionCollection substraitExtensions;
     private volatile ClusterService clusterService;
     private volatile DatafusionSettings datafusionSettings;
+    // Min/max companions are NodeScope (static), so we resolve them once at startup. The dynamic
+    // update path uses these cached snapshots rather than re-reading ClusterService.getSettings(),
+    // which can return stale or default values during transient cluster-state updates.
+    private volatile ByteSizeValue memoryPoolFloor;
+    private volatile ByteSizeValue memoryPoolCeiling;
 
     /**
      * Creates the DataFusion plugin.
@@ -134,8 +211,12 @@ public class DataFusionPlugin extends Plugin implements SearchBackEndPlugin<Data
         this.dataFormatRegistry = dataFormatRegistry;
         this.clusterService = clusterService;
         Settings settings = environment.settings();
-        long memoryPoolLimit = DATAFUSION_MEMORY_POOL_LIMIT.get(settings);
-        long spillMemoryLimit = DATAFUSION_SPILL_MEMORY_LIMIT.get(settings);
+        // Snapshot the static min/max companions once so dynamic updates resolve against
+        // the same values that were used at startup.
+        this.memoryPoolFloor = DATAFUSION_MEMORY_POOL_LIMIT_MIN.get(settings);
+        this.memoryPoolCeiling = DATAFUSION_MEMORY_POOL_LIMIT_MAX.get(settings);
+        long memoryPoolLimit = resolveMemoryPoolBytes(settings);
+        long spillMemoryLimit = resolveSpillMemoryBytes(settings);
         String spillDir = environment.dataFiles()[0].getParent().resolve("tmp").toAbsolutePath().toString();
 
         dataFusionService = DataFusionService.builder()
@@ -148,8 +229,11 @@ public class DataFusionPlugin extends Plugin implements SearchBackEndPlugin<Data
         logger.debug("DataFusion plugin initialized — memory pool {}B, spill limit {}B", memoryPoolLimit, spillMemoryLimit);
 
         // Wire the dynamic memory pool limit setting to the native runtime so updates via the
-        // cluster settings API take effect without restarting the node.
-        clusterService.getClusterSettings().addSettingsUpdateConsumer(DATAFUSION_MEMORY_POOL_LIMIT, this::updateMemoryPoolLimit);
+        // cluster settings API take effect without restarting the node. The companion min/max
+        // settings are static (NodeScope, not Dynamic) — the resolver uses the floor/ceiling
+        // snapshot captured above, not the live cluster-settings view, to avoid drift from
+        // transient cluster-state propagation.
+        clusterService.getClusterSettings().addSettingsUpdateConsumer(DATAFUSION_MEMORY_POOL_LIMIT, this::applyMemoryPoolLimitSetting);
 
         this.datafusionSettings = new DatafusionSettings(clusterService);
 
@@ -206,6 +290,100 @@ public class DataFusionPlugin extends Plugin implements SearchBackEndPlugin<Data
     @Override
     public List<Setting<?>> getSettings() {
         return DatafusionSettings.ALL_SETTINGS;
+    }
+
+    /**
+     * Resolves {@link #DATAFUSION_MEMORY_POOL_LIMIT}. Percentages apply against
+     * {@code totalPhysicalMemory - configuredMaxHeap} and are clamped by the {@code min}/{@code max}
+     * companion settings; absolute byte sizes are used as-is.
+     */
+    static long resolveMemoryPoolBytes(Settings settings) {
+        return resolveBytes(
+            DATAFUSION_MEMORY_POOL_LIMIT.get(settings),
+            DATAFUSION_MEMORY_POOL_LIMIT_MIN.get(settings),
+            DATAFUSION_MEMORY_POOL_LIMIT_MAX.get(settings),
+            DATAFUSION_MEMORY_POOL_LIMIT.getKey()
+        );
+    }
+
+    /**
+     * Resolves {@link #DATAFUSION_SPILL_MEMORY_LIMIT}. Percentages apply against
+     * {@code totalPhysicalMemory - configuredMaxHeap} and are clamped by the {@code min}/{@code max}
+     * companion settings; absolute byte sizes are used as-is.
+     */
+    static long resolveSpillMemoryBytes(Settings settings) {
+        return resolveBytes(
+            DATAFUSION_SPILL_MEMORY_LIMIT.get(settings),
+            DATAFUSION_SPILL_MEMORY_LIMIT_MIN.get(settings),
+            DATAFUSION_SPILL_MEMORY_LIMIT_MAX.get(settings),
+            DATAFUSION_SPILL_MEMORY_LIMIT.getKey()
+        );
+    }
+
+    /**
+     * Shared parser for memory-pool-style settings. Mirrors {@code IndexingMemoryController}'s
+     * native indexing buffer logic: percentages resolve against
+     * {@code totalPhysicalMemory - configuredMaxHeap} and are clamped by the supplied floor and
+     * ceiling; absolute byte sizes are returned as-is.
+     */
+    private static long resolveBytes(String configured, ByteSizeValue floor, ByteSizeValue ceiling, String settingKey) {
+        if (configured.endsWith("%")) {
+            long totalAvailableMemory = OsProbe.getInstance().getTotalPhysicalMemorySize()
+                - JvmInfo.jvmInfo().getConfiguredMaxHeapSize();
+            if (totalAvailableMemory <= 0) {
+                logger.warn("Non-heap memory not measurable while resolving [{}]; falling back to {}", settingKey, floor);
+                return floor.getBytes();
+            }
+            RatioValue ratio = RatioValue.parseRatioValue(configured);
+            long bytes = (long) (totalAvailableMemory * ratio.getAsRatio());
+            if (bytes < floor.getBytes()) {
+                bytes = floor.getBytes();
+            }
+            if (ceiling.getBytes() != -1 && bytes > ceiling.getBytes()) {
+                bytes = ceiling.getBytes();
+            }
+            return bytes;
+        }
+        return ByteSizeValue.parseBytesSizeValue(configured, settingKey).getBytes();
+    }
+
+    /**
+     * Cluster-settings update hook for {@link #DATAFUSION_MEMORY_POOL_LIMIT}. Re-resolves the new
+     * value against the floor/ceiling snapshot taken at startup and propagates it to the running
+     * runtime. We deliberately do not re-read the min/max companions from
+     * {@link ClusterService#getSettings()} on every update — that {@link Settings} view can lag
+     * the actual node-scope values during cluster-state propagation, which would silently apply
+     * stale or default bounds to the new limit.
+     */
+    private void applyMemoryPoolLimitSetting(String newValue) {
+        if (memoryPoolFloor == null || memoryPoolCeiling == null) {
+            logger.debug("Min/max companions not yet snapshotted; ignoring memory pool limit update");
+            return;
+        }
+        long newLimitBytes = resolveBytes(newValue, memoryPoolFloor, memoryPoolCeiling, DATAFUSION_MEMORY_POOL_LIMIT.getKey());
+        updateMemoryPoolLimit(newLimitBytes);
+    }
+
+    /**
+     * Validates that {@code value} is either a percentage ({@code "25%"}) or an absolute byte
+     * size accepted by {@link ByteSizeValue#parseBytesSizeValue(String, String)}. Used as the
+     * setting-time validator for {@link #DATAFUSION_MEMORY_POOL_LIMIT} and
+     * {@link #DATAFUSION_SPILL_MEMORY_LIMIT} so that malformed values fail at update time rather
+     * than at the next read inside {@link #resolveBytes}.
+     */
+    private static void validateMemorySizeOrPercentage(String value) {
+        try {
+            if (value.endsWith("%")) {
+                RatioValue.parseRatioValue(value);
+            } else {
+                ByteSizeValue.parseBytesSizeValue(value, "memory size");
+            }
+        } catch (RuntimeException e) {
+            throw new IllegalArgumentException(
+                "value [" + value + "] must be a percentage (e.g. \"25%\") or a byte size (e.g. \"512mb\"): " + e.getMessage(),
+                e
+            );
+        }
     }
 
     /**

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionService.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionService.java
@@ -40,7 +40,7 @@ public class DataFusionService extends AbstractLifecycleComponent {
     private static final Logger logger = LogManager.getLogger(DataFusionService.class);
 
     private final long memoryPoolLimit;
-    private final long spillMemoryLimit;
+    private final long diskSpillLimit;
     private final String spillDirectory;
     private final int cpuThreads;
     private final ClusterSettings clusterSettings;
@@ -68,7 +68,7 @@ public class DataFusionService extends AbstractLifecycleComponent {
 
     private DataFusionService(Builder builder) {
         this.memoryPoolLimit = builder.memoryPoolLimit;
-        this.spillMemoryLimit = builder.spillMemoryLimit;
+        this.diskSpillLimit = builder.diskSpillLimit;
         this.spillDirectory = builder.spillDirectory;
         this.cpuThreads = builder.cpuThreads;
         this.clusterSettings = builder.clusterSettings;
@@ -106,7 +106,7 @@ public class DataFusionService extends AbstractLifecycleComponent {
             cacheManagerPtr = CacheUtils.createCacheConfig(clusterSettings);
         }
 
-        long ptr = NativeBridge.createGlobalRuntime(memoryPoolLimit, cacheManagerPtr, spillDirectory, spillMemoryLimit);
+        long ptr = NativeBridge.createGlobalRuntime(memoryPoolLimit, cacheManagerPtr, spillDirectory, diskSpillLimit);
         this.runtimeHandle = new NativeRuntimeHandle(ptr);
         this.rootAllocator = new RootAllocator(memoryPoolLimit);
 
@@ -114,7 +114,7 @@ public class DataFusionService extends AbstractLifecycleComponent {
             this.cacheManager = new CacheManager(runtimeHandle);
         }
 
-        logger.debug("DataFusion service started — memory pool {}B, spill limit {}B", memoryPoolLimit, spillMemoryLimit);
+        logger.debug("DataFusion service started — memory pool {}B, spill limit {}B", memoryPoolLimit, diskSpillLimit);
     }
 
     @Override
@@ -262,7 +262,7 @@ public class DataFusionService extends AbstractLifecycleComponent {
      */
     public static class Builder {
         private long memoryPoolLimit = Runtime.getRuntime().maxMemory() / 4;
-        private long spillMemoryLimit = Runtime.getRuntime().maxMemory() / 8;
+        private long diskSpillLimit = Runtime.getRuntime().maxMemory() / 8;
         private String spillDirectory = System.getProperty("java.io.tmpdir");
         private int cpuThreads = Runtime.getRuntime().availableProcessors();
         private ClusterSettings clusterSettings;
@@ -282,8 +282,8 @@ public class DataFusionService extends AbstractLifecycleComponent {
          * Sets the maximum bytes before spilling to disk.
          * @param bytes spill limit
          */
-        public Builder spillMemoryLimit(long bytes) {
-            this.spillMemoryLimit = bytes;
+        public Builder diskSpillLimit(long bytes) {
+            this.diskSpillLimit = bytes;
             return this;
         }
 

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionSettings.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionSettings.java
@@ -168,7 +168,7 @@ public final class DatafusionSettings {
 
         // Runtime settings — memory pool, spill, and reduce input mode
         DataFusionPlugin.DATAFUSION_MEMORY_POOL_LIMIT,
-        DataFusionPlugin.DATAFUSION_SPILL_MEMORY_LIMIT,
+        DataFusionPlugin.DATAFUSION_DISK_SPILL_LIMIT,
         DataFusionPlugin.DATAFUSION_REDUCE_INPUT_MODE,
 
         // Cache settings — metadata and statistics cache configuration

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionSettings.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionSettings.java
@@ -168,9 +168,7 @@ public final class DatafusionSettings {
 
         // Runtime settings — memory pool, spill, and reduce input mode
         DataFusionPlugin.DATAFUSION_MEMORY_POOL_LIMIT,
-        DataFusionPlugin.DATAFUSION_MEMORY_POOL_LIMIT_MIN,
         DataFusionPlugin.DATAFUSION_SPILL_MEMORY_LIMIT,
-        DataFusionPlugin.DATAFUSION_SPILL_MEMORY_LIMIT_MIN,
         DataFusionPlugin.DATAFUSION_REDUCE_INPUT_MODE,
 
         // Cache settings — metadata and statistics cache configuration

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionSettings.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionSettings.java
@@ -168,7 +168,11 @@ public final class DatafusionSettings {
 
         // Runtime settings — memory pool, spill, and reduce input mode
         DataFusionPlugin.DATAFUSION_MEMORY_POOL_LIMIT,
+        DataFusionPlugin.DATAFUSION_MEMORY_POOL_LIMIT_MIN,
+        DataFusionPlugin.DATAFUSION_MEMORY_POOL_LIMIT_MAX,
         DataFusionPlugin.DATAFUSION_SPILL_MEMORY_LIMIT,
+        DataFusionPlugin.DATAFUSION_SPILL_MEMORY_LIMIT_MIN,
+        DataFusionPlugin.DATAFUSION_SPILL_MEMORY_LIMIT_MAX,
         DataFusionPlugin.DATAFUSION_REDUCE_INPUT_MODE,
 
         // Cache settings — metadata and statistics cache configuration

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionSettings.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionSettings.java
@@ -169,10 +169,8 @@ public final class DatafusionSettings {
         // Runtime settings — memory pool, spill, and reduce input mode
         DataFusionPlugin.DATAFUSION_MEMORY_POOL_LIMIT,
         DataFusionPlugin.DATAFUSION_MEMORY_POOL_LIMIT_MIN,
-        DataFusionPlugin.DATAFUSION_MEMORY_POOL_LIMIT_MAX,
         DataFusionPlugin.DATAFUSION_SPILL_MEMORY_LIMIT,
         DataFusionPlugin.DATAFUSION_SPILL_MEMORY_LIMIT_MIN,
-        DataFusionPlugin.DATAFUSION_SPILL_MEMORY_LIMIT_MAX,
         DataFusionPlugin.DATAFUSION_REDUCE_INPUT_MODE,
 
         // Cache settings — metadata and statistics cache configuration

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionPluginSettingsTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionPluginSettingsTests.java
@@ -33,6 +33,27 @@ public class DataFusionPluginSettingsTests extends OpenSearchTestCase {
         assertTrue("datafusion.memory_pool_limit_bytes must have node scope", DataFusionPlugin.DATAFUSION_MEMORY_POOL_LIMIT.hasNodeScope());
     }
 
+    public void testMemoryPoolLimitMinIsDynamic() {
+        assertTrue(
+            "datafusion.memory_pool_limit.min must be dynamic so the floor can be tuned without restart",
+            DataFusionPlugin.DATAFUSION_MEMORY_POOL_LIMIT_MIN.isDynamic()
+        );
+    }
+
+    public void testSpillMemoryLimitIsDynamic() {
+        assertTrue(
+            "datafusion.spill_memory_limit_bytes must be dynamic for cluster-settings PUTs",
+            DataFusionPlugin.DATAFUSION_SPILL_MEMORY_LIMIT.isDynamic()
+        );
+    }
+
+    public void testSpillMemoryLimitMinIsDynamic() {
+        assertTrue(
+            "datafusion.spill_memory_limit.min must be dynamic so the floor can be tuned without restart",
+            DataFusionPlugin.DATAFUSION_SPILL_MEMORY_LIMIT_MIN.isDynamic()
+        );
+    }
+
     public void testPluginRegistersMemoryPoolLimitSetting() {
         try (DataFusionPlugin plugin = new DataFusionPlugin()) {
             List<Setting<?>> settings = plugin.getSettings();
@@ -83,7 +104,7 @@ public class DataFusionPluginSettingsTests extends OpenSearchTestCase {
     public void testGetSettingsReturnsTotalExpectedCount() {
         try (DataFusionPlugin plugin = new DataFusionPlugin()) {
             List<Setting<?>> settings = plugin.getSettings();
-            assertEquals(20, settings.size());
+            assertEquals(18, settings.size());
         } catch (Exception e) {
             throw new AssertionError(e);
         }

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionPluginSettingsTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionPluginSettingsTests.java
@@ -33,25 +33,11 @@ public class DataFusionPluginSettingsTests extends OpenSearchTestCase {
         assertTrue("datafusion.memory_pool_limit_bytes must have node scope", DataFusionPlugin.DATAFUSION_MEMORY_POOL_LIMIT.hasNodeScope());
     }
 
-    public void testMemoryPoolLimitMinIsDynamic() {
-        assertTrue(
-            "datafusion.memory_pool_limit.min must be dynamic so the floor can be tuned without restart",
-            DataFusionPlugin.DATAFUSION_MEMORY_POOL_LIMIT_MIN.isDynamic()
-        );
-    }
-
     public void testSpillMemoryLimitIsStatic() {
         assertFalse(
             "datafusion.spill_memory_limit_bytes is intentionally static — DataFusion's DiskManager"
                 + " has no thread-safe runtime setter (Arc::get_mut)",
             DataFusionPlugin.DATAFUSION_SPILL_MEMORY_LIMIT.isDynamic()
-        );
-    }
-
-    public void testSpillMemoryLimitMinIsStatic() {
-        assertFalse(
-            "datafusion.spill_memory_limit.min is intentionally static — see" + " DATAFUSION_SPILL_MEMORY_LIMIT for why",
-            DataFusionPlugin.DATAFUSION_SPILL_MEMORY_LIMIT_MIN.isDynamic()
         );
     }
 
@@ -105,7 +91,7 @@ public class DataFusionPluginSettingsTests extends OpenSearchTestCase {
     public void testGetSettingsReturnsTotalExpectedCount() {
         try (DataFusionPlugin plugin = new DataFusionPlugin()) {
             List<Setting<?>> settings = plugin.getSettings();
-            assertEquals(18, settings.size());
+            assertEquals(16, settings.size());
         } catch (Exception e) {
             throw new AssertionError(e);
         }

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionPluginSettingsTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionPluginSettingsTests.java
@@ -83,7 +83,7 @@ public class DataFusionPluginSettingsTests extends OpenSearchTestCase {
     public void testGetSettingsReturnsTotalExpectedCount() {
         try (DataFusionPlugin plugin = new DataFusionPlugin()) {
             List<Setting<?>> settings = plugin.getSettings();
-            assertEquals(16, settings.size());
+            assertEquals(20, settings.size());
         } catch (Exception e) {
             throw new AssertionError(e);
         }

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionPluginSettingsTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionPluginSettingsTests.java
@@ -40,16 +40,17 @@ public class DataFusionPluginSettingsTests extends OpenSearchTestCase {
         );
     }
 
-    public void testSpillMemoryLimitIsDynamic() {
-        assertTrue(
-            "datafusion.spill_memory_limit_bytes must be dynamic for cluster-settings PUTs",
+    public void testSpillMemoryLimitIsStatic() {
+        assertFalse(
+            "datafusion.spill_memory_limit_bytes is intentionally static — DataFusion's DiskManager"
+                + " has no thread-safe runtime setter (Arc::get_mut)",
             DataFusionPlugin.DATAFUSION_SPILL_MEMORY_LIMIT.isDynamic()
         );
     }
 
-    public void testSpillMemoryLimitMinIsDynamic() {
-        assertTrue(
-            "datafusion.spill_memory_limit.min must be dynamic so the floor can be tuned without restart",
+    public void testSpillMemoryLimitMinIsStatic() {
+        assertFalse(
+            "datafusion.spill_memory_limit.min is intentionally static — see" + " DATAFUSION_SPILL_MEMORY_LIMIT for why",
             DataFusionPlugin.DATAFUSION_SPILL_MEMORY_LIMIT_MIN.isDynamic()
         );
     }

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionPluginSettingsTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionPluginSettingsTests.java
@@ -9,35 +9,39 @@
 package org.opensearch.be.datafusion;
 
 import org.opensearch.common.settings.Setting;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.env.Environment;
 import org.opensearch.test.OpenSearchTestCase;
 
+import java.io.IOException;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
  * Verifies the settings declared by {@link DataFusionPlugin} — in particular that
- * {@code datafusion.memory_pool_limit_bytes} is registered and marked dynamic so
+ * {@code datafusion.memory_pool_limit} is registered and marked dynamic so
  * the cluster settings API can update it at runtime.
  */
 public class DataFusionPluginSettingsTests extends OpenSearchTestCase {
 
     public void testMemoryPoolLimitIsDynamic() {
         assertTrue(
-            "datafusion.memory_pool_limit_bytes must be dynamic to support runtime updates",
+            "datafusion.memory_pool_limit must be dynamic to support runtime updates",
             DataFusionPlugin.DATAFUSION_MEMORY_POOL_LIMIT.isDynamic()
         );
     }
 
     public void testMemoryPoolLimitHasNodeScope() {
-        assertTrue("datafusion.memory_pool_limit_bytes must have node scope", DataFusionPlugin.DATAFUSION_MEMORY_POOL_LIMIT.hasNodeScope());
+        assertTrue("datafusion.memory_pool_limit must have node scope", DataFusionPlugin.DATAFUSION_MEMORY_POOL_LIMIT.hasNodeScope());
     }
 
-    public void testSpillMemoryLimitIsStatic() {
+    public void testDiskSpillLimitIsStatic() {
         assertFalse(
-            "datafusion.spill_memory_limit_bytes is intentionally static — DataFusion's DiskManager"
+            "datafusion.disk_spill_limit is intentionally static — DataFusion's DiskManager"
                 + " has no thread-safe runtime setter (Arc::get_mut)",
-            DataFusionPlugin.DATAFUSION_SPILL_MEMORY_LIMIT.isDynamic()
+            DataFusionPlugin.DATAFUSION_DISK_SPILL_LIMIT.isDynamic()
         );
     }
 
@@ -49,8 +53,8 @@ public class DataFusionPluginSettingsTests extends OpenSearchTestCase {
                 settings.contains(DataFusionPlugin.DATAFUSION_MEMORY_POOL_LIMIT)
             );
             assertTrue(
-                "Plugin must register DATAFUSION_SPILL_MEMORY_LIMIT via getSettings()",
-                settings.contains(DataFusionPlugin.DATAFUSION_SPILL_MEMORY_LIMIT)
+                "Plugin must register DATAFUSION_DISK_SPILL_LIMIT via getSettings()",
+                settings.contains(DataFusionPlugin.DATAFUSION_DISK_SPILL_LIMIT)
             );
         } catch (Exception e) {
             throw new AssertionError(e);
@@ -103,5 +107,50 @@ public class DataFusionPluginSettingsTests extends OpenSearchTestCase {
         } catch (Exception e) {
             throw new AssertionError(e);
         }
+    }
+
+    public void testResolveDiskSpillBytesAbsoluteSize() {
+        Settings settings = Settings.builder().put(DataFusionPlugin.DATAFUSION_DISK_SPILL_LIMIT.getKey(), "5gb").build();
+        long resolved = DataFusionPlugin.resolveDiskSpillBytes(settings, createTempDir());
+        assertEquals("Absolute byte size must pass through unchanged", 5L * 1024 * 1024 * 1024, resolved);
+    }
+
+    public void testResolveDiskSpillBytesPercentageAgainstSpillDirFilesystem() throws IOException {
+        Path spillDir = createTempDir();
+        Settings settings = Settings.builder().put(DataFusionPlugin.DATAFUSION_DISK_SPILL_LIMIT.getKey(), "20%").build();
+        long resolved = DataFusionPlugin.resolveDiskSpillBytes(settings, spillDir);
+
+        long usable = Environment.getFileStore(spillDir).getUsableSpace();
+        long expected = (long) (usable * 0.20);
+        // Allow ±5% drift — other processes (and OpenSearch's own indexing on shared CI runners)
+        // can churn the FileStore between our resolve call and this assertion. 5% still validates
+        // the right denominator was used; tighter tolerances flake on busy hosts.
+        long tolerance = Math.max(1, expected / 20);
+        assertTrue(
+            "20% should resolve close to expected disk-relative bytes, got "
+                + resolved
+                + " expected ~"
+                + expected
+                + " (usable="
+                + usable
+                + ")",
+            Math.abs(resolved - expected) <= tolerance
+        );
+    }
+
+    public void testResolveDiskSpillBytesWalksUpToExistingParent() throws IOException {
+        // The DataFusion `tmp` dir is created lazily — at resolve time it doesn't exist yet.
+        Path parent = createTempDir();
+        Path nonexistentSpillDir = parent.resolve("does-not-exist-yet").resolve("nested");
+        Settings settings = Settings.builder().put(DataFusionPlugin.DATAFUSION_DISK_SPILL_LIMIT.getKey(), "10%").build();
+        long resolved = DataFusionPlugin.resolveDiskSpillBytes(settings, nonexistentSpillDir);
+
+        long usable = Environment.getFileStore(parent).getUsableSpace();
+        long expected = (long) (usable * 0.10);
+        long tolerance = Math.max(1, expected / 20);
+        assertTrue(
+            "Resolver must walk up to nearest existing parent on the same filesystem; got " + resolved + " expected ~" + expected,
+            Math.abs(resolved - expected) <= tolerance
+        );
     }
 }

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionServiceTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionServiceTests.java
@@ -36,7 +36,7 @@ public class DataFusionServiceTests extends OpenSearchTestCase {
         Path spillDir = createTempDir("spill");
         DataFusionService service = DataFusionService.builder()
             .memoryPoolLimit(64 * 1024 * 1024)
-            .spillMemoryLimit(32 * 1024 * 1024)
+            .diskSpillLimit(32 * 1024 * 1024)
             .spillDirectory(spillDir.toString())
             .cpuThreads(2)
             .build();
@@ -88,7 +88,7 @@ public class DataFusionServiceTests extends OpenSearchTestCase {
         Path spillDir = createTempDir("spill");
         DataFusionService service = DataFusionService.builder()
             .memoryPoolLimit(64 * 1024 * 1024)
-            .spillMemoryLimit(32 * 1024 * 1024)
+            .diskSpillLimit(32 * 1024 * 1024)
             .spillDirectory(spillDir.toString())
             .cpuThreads(2)
             .build();
@@ -110,7 +110,7 @@ public class DataFusionServiceTests extends OpenSearchTestCase {
 
         DataFusionService service = DataFusionService.builder()
             .memoryPoolLimit(64 * 1024 * 1024)
-            .spillMemoryLimit(32 * 1024 * 1024)
+            .diskSpillLimit(32 * 1024 * 1024)
             .spillDirectory(spillDir.toString())
             .cpuThreads(2)
             .clusterSettings(clusterSettings)
@@ -130,7 +130,7 @@ public class DataFusionServiceTests extends OpenSearchTestCase {
 
         DataFusionService service = DataFusionService.builder()
             .memoryPoolLimit(64 * 1024 * 1024)
-            .spillMemoryLimit(32 * 1024 * 1024)
+            .diskSpillLimit(32 * 1024 * 1024)
             .spillDirectory(spillDir.toString())
             .cpuThreads(2)
             .build();
@@ -188,7 +188,7 @@ public class DataFusionServiceTests extends OpenSearchTestCase {
         all.add(CacheSettings.STATISTICS_CACHE_SIZE_LIMIT);
         all.add(CacheSettings.STATISTICS_CACHE_EVICTION_TYPE);
         all.add(DataFusionPlugin.DATAFUSION_MEMORY_POOL_LIMIT);
-        all.add(DataFusionPlugin.DATAFUSION_SPILL_MEMORY_LIMIT);
+        all.add(DataFusionPlugin.DATAFUSION_DISK_SPILL_LIMIT);
         return new ClusterSettings(settings, all);
     }
 }

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionCacheManagerTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionCacheManagerTests.java
@@ -42,14 +42,14 @@ public class DatafusionCacheManagerTests extends OpenSearchTestCase {
         clusterSettingsToAdd.add(CacheSettings.STATISTICS_CACHE_SIZE_LIMIT);
         clusterSettingsToAdd.add(CacheSettings.STATISTICS_CACHE_EVICTION_TYPE);
         clusterSettingsToAdd.add(DataFusionPlugin.DATAFUSION_MEMORY_POOL_LIMIT);
-        clusterSettingsToAdd.add(DataFusionPlugin.DATAFUSION_SPILL_MEMORY_LIMIT);
+        clusterSettingsToAdd.add(DataFusionPlugin.DATAFUSION_DISK_SPILL_LIMIT);
 
         ClusterSettings clusterSettings = new ClusterSettings(Settings.EMPTY, clusterSettingsToAdd);
         Path spillDir = createTempDir("spill");
 
         service = DataFusionService.builder()
             .memoryPoolLimit(64 * 1024 * 1024)
-            .spillMemoryLimit(32 * 1024 * 1024)
+            .diskSpillLimit(32 * 1024 * 1024)
             .spillDirectory(spillDir.toString())
             .cpuThreads(2)
             .clusterSettings(clusterSettings)

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionSettingsTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionSettingsTests.java
@@ -69,9 +69,9 @@ public class DatafusionSettingsTests extends OpenSearchTestCase {
     }
 
     public void testAllSettingsContainsAllExpectedSettings() {
-        assertEquals(18, DatafusionSettings.ALL_SETTINGS.size());
-        assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DataFusionPlugin.DATAFUSION_MEMORY_POOL_LIMIT_MIN));
-        assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DataFusionPlugin.DATAFUSION_SPILL_MEMORY_LIMIT_MIN));
+        assertEquals(16, DatafusionSettings.ALL_SETTINGS.size());
+        assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DataFusionPlugin.DATAFUSION_MEMORY_POOL_LIMIT));
+        assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DataFusionPlugin.DATAFUSION_SPILL_MEMORY_LIMIT));
         assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DatafusionSettings.INDEXED_BATCH_SIZE));
         assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DatafusionSettings.INDEXED_PARQUET_PUSHDOWN_FILTERS));
         assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DatafusionSettings.INDEXED_MIN_SKIP_RUN_DEFAULT));

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionSettingsTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionSettingsTests.java
@@ -69,11 +69,9 @@ public class DatafusionSettingsTests extends OpenSearchTestCase {
     }
 
     public void testAllSettingsContainsAllExpectedSettings() {
-        assertEquals(20, DatafusionSettings.ALL_SETTINGS.size());
+        assertEquals(18, DatafusionSettings.ALL_SETTINGS.size());
         assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DataFusionPlugin.DATAFUSION_MEMORY_POOL_LIMIT_MIN));
-        assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DataFusionPlugin.DATAFUSION_MEMORY_POOL_LIMIT_MAX));
         assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DataFusionPlugin.DATAFUSION_SPILL_MEMORY_LIMIT_MIN));
-        assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DataFusionPlugin.DATAFUSION_SPILL_MEMORY_LIMIT_MAX));
         assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DatafusionSettings.INDEXED_BATCH_SIZE));
         assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DatafusionSettings.INDEXED_PARQUET_PUSHDOWN_FILTERS));
         assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DatafusionSettings.INDEXED_MIN_SKIP_RUN_DEFAULT));

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionSettingsTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionSettingsTests.java
@@ -69,7 +69,11 @@ public class DatafusionSettingsTests extends OpenSearchTestCase {
     }
 
     public void testAllSettingsContainsAllExpectedSettings() {
-        assertEquals(16, DatafusionSettings.ALL_SETTINGS.size());
+        assertEquals(20, DatafusionSettings.ALL_SETTINGS.size());
+        assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DataFusionPlugin.DATAFUSION_MEMORY_POOL_LIMIT_MIN));
+        assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DataFusionPlugin.DATAFUSION_MEMORY_POOL_LIMIT_MAX));
+        assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DataFusionPlugin.DATAFUSION_SPILL_MEMORY_LIMIT_MIN));
+        assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DataFusionPlugin.DATAFUSION_SPILL_MEMORY_LIMIT_MAX));
         assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DatafusionSettings.INDEXED_BATCH_SIZE));
         assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DatafusionSettings.INDEXED_PARQUET_PUSHDOWN_FILTERS));
         assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DatafusionSettings.INDEXED_MIN_SKIP_RUN_DEFAULT));

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionSettingsTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionSettingsTests.java
@@ -71,7 +71,7 @@ public class DatafusionSettingsTests extends OpenSearchTestCase {
     public void testAllSettingsContainsAllExpectedSettings() {
         assertEquals(16, DatafusionSettings.ALL_SETTINGS.size());
         assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DataFusionPlugin.DATAFUSION_MEMORY_POOL_LIMIT));
-        assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DataFusionPlugin.DATAFUSION_SPILL_MEMORY_LIMIT));
+        assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DataFusionPlugin.DATAFUSION_DISK_SPILL_LIMIT));
         assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DatafusionSettings.INDEXED_BATCH_SIZE));
         assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DatafusionSettings.INDEXED_PARQUET_PUSHDOWN_FILTERS));
         assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DatafusionSettings.INDEXED_MIN_SKIP_RUN_DEFAULT));

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DynamicMemoryPoolTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DynamicMemoryPoolTests.java
@@ -28,7 +28,7 @@ public class DynamicMemoryPoolTests extends OpenSearchTestCase {
         Path spillDir = createTempDir("datafusion-spill");
         service = DataFusionService.builder()
             .memoryPoolLimit(64 * 1024 * 1024) // 64MB
-            .spillMemoryLimit(32 * 1024 * 1024)
+            .diskSpillLimit(32 * 1024 * 1024)
             .spillDirectory(spillDir.toString())
             .cpuThreads(2)
             .build();

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/ParquetDataFormatPlugin.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/ParquetDataFormatPlugin.java
@@ -29,6 +29,8 @@ import org.opensearch.index.store.PrecomputedChecksumStrategy;
 import org.opensearch.parquet.engine.ParquetDataFormat;
 import org.opensearch.parquet.engine.ParquetIndexingEngine;
 import org.opensearch.parquet.fields.ArrowSchemaBuilder;
+import org.opensearch.parquet.memory.ArrowBufferPool;
+import org.opensearch.parquet.memory.ArrowBufferPoolRegistry;
 import org.opensearch.parquet.store.ParquetStoreStrategy;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.repositories.RepositoriesService;
@@ -68,6 +70,8 @@ public class ParquetDataFormatPlugin extends Plugin implements DataFormatPlugin 
     /** Initialized to EMPTY to avoid NPE if indexingEngine() is called before createComponents(). */
     private Settings settings = Settings.EMPTY;
     private ThreadPool threadPool;
+    /** Plugin-scoped registry; may be null until createComponents() runs (e.g. in tests). */
+    private volatile ArrowBufferPoolRegistry bufferPoolRegistry;
 
     /** Creates a new ParquetDataFormatPlugin. */
     public ParquetDataFormatPlugin() {}
@@ -88,7 +92,17 @@ public class ParquetDataFormatPlugin extends Plugin implements DataFormatPlugin 
     ) {
         this.settings = clusterService.getSettings();
         this.threadPool = threadPool;
+        this.bufferPoolRegistry = new ArrowBufferPoolRegistry(clusterService.getClusterSettings());
         return Collections.emptyList();
+    }
+
+    /**
+     * Returns the plugin-scoped registry that fans cluster-settings updates out to live
+     * {@link ArrowBufferPool} instances. {@code null} if the plugin has not yet been wired
+     * via {@link #createComponents}, which happens in unit tests that bypass plugin startup.
+     */
+    public ArrowBufferPoolRegistry getBufferPoolRegistry() {
+        return bufferPoolRegistry;
     }
 
     @Override
@@ -106,7 +120,8 @@ public class ParquetDataFormatPlugin extends Plugin implements DataFormatPlugin 
             () -> engineConfig.mapperService().getIndexSettings().getIndexMetadata().getMappingVersion(),
             engineConfig.indexSettings(),
             threadPool,
-            engineConfig.checksumStrategies().get(ParquetDataFormat.PARQUET_DATA_FORMAT_NAME)
+            engineConfig.checksumStrategies().get(ParquetDataFormat.PARQUET_DATA_FORMAT_NAME),
+            bufferPoolRegistry
         );
     }
 

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/ParquetSettings.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/ParquetSettings.java
@@ -40,9 +40,14 @@ public final class ParquetSettings {
 
     /**
      * Default per-VSR child allocator cap. Bounds memory a single in-flight VectorSchemaRoot can
-     * hold so one writer cannot monopolize the root allocator.
+     * hold so one writer cannot monopolize the root allocator. {@code 512mb} comes from the OFAT
+     * sweep documented in
+     * <a href="https://quip-amazon.com/baxtAdGoq6S9/Mustang-Memory-Tuning-Recommended-Defaults">
+     * Mustang Memory Tuning - Recommended Defaults</a>: 256mb / 512mb / 1gb / 2gb all delivered
+     * comparable ClickBench p95 latency at the 907k-doc corpus, so the smallest value with no
+     * measurable cost wins — leaves more headroom for the DataFusion pool and OS page cache.
      */
-    public static final ByteSizeValue DEFAULT_CHILD_ALLOCATION = new ByteSizeValue(256, ByteSizeUnit.MB);
+    public static final ByteSizeValue DEFAULT_CHILD_ALLOCATION = new ByteSizeValue(512, ByteSizeUnit.MB);
 
     /** Group setting prefix for all Parquet settings. */
     public static final Setting<Settings> PARQUET_SETTINGS = Setting.groupSetting("index.parquet.", Setting.Property.IndexScope);

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/ParquetSettings.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/ParquetSettings.java
@@ -27,12 +27,6 @@ public final class ParquetSettings {
     public static final int DEFAULT_MAX_ROWS_PER_VSR = 50000;
 
     /**
-     * Floor applied when {@link #MAX_NATIVE_ALLOCATION} is a percentage. Mirrors the
-     * {@code indices.memory.min_native_index_buffer_size} pattern in {@code IndexingMemoryController}.
-     */
-    public static final ByteSizeValue DEFAULT_MIN_NATIVE_ALLOCATION = new ByteSizeValue(512, ByteSizeUnit.MB);
-
-    /**
      * Ceiling applied when {@link #MAX_NATIVE_ALLOCATION} is a percentage. Mirrors the
      * {@code indices.memory.max_native_index_buffer_size} pattern in {@code IndexingMemoryController}.
      */
@@ -118,26 +112,20 @@ public final class ParquetSettings {
      * Maximum native memory allocation for Arrow buffers. Accepts a percentage of non-heap memory
      * ({@code totalPhysicalMemory - configuredMaxHeap}, e.g. {@code "10%"}) or an absolute byte
      * size (e.g. {@code "2gb"}). When a percentage is supplied, the resolved value is clamped by
-     * {@link #MIN_NATIVE_ALLOCATION} and {@link #MAX_NATIVE_ALLOCATION_CEILING}.
+     * {@link #MAX_NATIVE_ALLOCATION_CEILING}.
      * <p>
      * Dynamic: changes take effect on the live Arrow {@code RootAllocator} via
      * {@code BaseAllocator.setLimit}. Lowering below current usage rejects future allocations
      * until reservations drain; it does not reclaim allocated memory.
+     * <p>
+     * If non-heap memory is unmeasurable at resolve time, an {@link IllegalStateException} is
+     * thrown — operators on misconfigured boxes should specify an absolute byte size rather
+     * than a percentage.
      */
     public static final Setting<String> MAX_NATIVE_ALLOCATION = Setting.simpleString(
         "parquet.max_native_allocation",
         DEFAULT_MAX_NATIVE_ALLOCATION,
         ParquetSettings::validateMemorySizeOrPercentage,
-        Setting.Property.NodeScope,
-        Setting.Property.Dynamic
-    );
-
-    /** Floor applied when {@link #MAX_NATIVE_ALLOCATION} is a percentage. */
-    public static final Setting<ByteSizeValue> MIN_NATIVE_ALLOCATION = Setting.byteSizeSetting(
-        "parquet.min_native_allocation",
-        DEFAULT_MIN_NATIVE_ALLOCATION,
-        new ByteSizeValue(0, ByteSizeUnit.BYTES),
-        new ByteSizeValue(Long.MAX_VALUE, ByteSizeUnit.BYTES),
         Setting.Property.NodeScope,
         Setting.Property.Dynamic
     );
@@ -261,7 +249,6 @@ public final class ParquetSettings {
             BLOOM_FILTER_FPP,
             BLOOM_FILTER_NDV,
             MAX_NATIVE_ALLOCATION,
-            MIN_NATIVE_ALLOCATION,
             MAX_NATIVE_ALLOCATION_CEILING,
             CHILD_ALLOCATION,
             MAX_ROWS_PER_VSR,

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/ParquetSettings.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/ParquetSettings.java
@@ -28,12 +28,9 @@ public final class ParquetSettings {
 
     /**
      * Default per-VSR child allocator cap. Bounds memory a single in-flight VectorSchemaRoot can
-     * hold so one writer cannot monopolize the root allocator. {@code 512mb} comes from the OFAT
-     * sweep documented in
-     * <a href="https://quip-amazon.com/baxtAdGoq6S9/Mustang-Memory-Tuning-Recommended-Defaults">
-     * Mustang Memory Tuning - Recommended Defaults</a>: 256mb / 512mb / 1gb / 2gb all delivered
-     * comparable ClickBench p95 latency at the 907k-doc corpus, so the smallest value with no
-     * measurable cost wins — leaves more headroom for the DataFusion pool and OS page cache.
+     * hold so one writer cannot monopolize the root allocator. The smallest value with no
+     * measurable latency cost is chosen, which leaves more headroom for the DataFusion pool and
+     * OS page cache.
      */
     public static final ByteSizeValue DEFAULT_CHILD_ALLOCATION = new ByteSizeValue(512, ByteSizeUnit.MB);
 

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/ParquetSettings.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/ParquetSettings.java
@@ -10,6 +10,7 @@ package org.opensearch.parquet;
 
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.RatioValue;
 import org.opensearch.core.common.unit.ByteSizeUnit;
 import org.opensearch.core.common.unit.ByteSizeValue;
 
@@ -117,6 +118,7 @@ public final class ParquetSettings {
     public static final Setting<String> MAX_NATIVE_ALLOCATION = Setting.simpleString(
         "parquet.max_native_allocation",
         DEFAULT_MAX_NATIVE_ALLOCATION,
+        ParquetSettings::validateMemorySizeOrPercentage,
         Setting.Property.NodeScope
     );
 
@@ -207,6 +209,27 @@ public final class ParquetSettings {
         1,
         Setting.Property.NodeScope
     );
+
+    /**
+     * Validates that {@code value} is either a percentage ({@code "10%"}) or an absolute byte
+     * size accepted by {@link ByteSizeValue#parseBytesSizeValue(String, String)}. Used as the
+     * setting-time validator for {@link #MAX_NATIVE_ALLOCATION} so that malformed values fail at
+     * update time rather than at the next read inside {@code ArrowBufferPool}.
+     */
+    private static void validateMemorySizeOrPercentage(String value) {
+        try {
+            if (value.endsWith("%")) {
+                RatioValue.parseRatioValue(value);
+            } else {
+                ByteSizeValue.parseBytesSizeValue(value, "memory size");
+            }
+        } catch (RuntimeException e) {
+            throw new IllegalArgumentException(
+                "value [" + value + "] must be a percentage (e.g. \"10%\") or a byte size (e.g. \"2gb\"): " + e.getMessage(),
+                e
+            );
+        }
+    }
 
     /** Returns all settings defined by the Parquet plugin. */
     public static List<Setting<?>> getSettings() {

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/ParquetSettings.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/ParquetSettings.java
@@ -32,7 +32,7 @@ public final class ParquetSettings {
      * measurable latency cost is chosen, which leaves more headroom for the DataFusion pool and
      * OS page cache.
      */
-    public static final ByteSizeValue DEFAULT_CHILD_ALLOCATION = new ByteSizeValue(512, ByteSizeUnit.MB);
+    public static final ByteSizeValue DEFAULT_CHILD_ALLOCATION = new ByteSizeValue(1024, ByteSizeUnit.MB);
 
     /** Group setting prefix for all Parquet settings. */
     public static final Setting<Settings> PARQUET_SETTINGS = Setting.groupSetting("index.parquet.", Setting.Property.IndexScope);

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/ParquetSettings.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/ParquetSettings.java
@@ -26,14 +26,6 @@ public final class ParquetSettings {
     public static final String DEFAULT_MAX_NATIVE_ALLOCATION = "10%";
     public static final int DEFAULT_MAX_ROWS_PER_VSR = 50000;
 
-    /**
-     * Default per-VSR child allocator cap. Bounds memory a single in-flight VectorSchemaRoot can
-     * hold so one writer cannot monopolize the root allocator. The smallest value with no
-     * measurable latency cost is chosen, which leaves more headroom for the DataFusion pool and
-     * OS page cache.
-     */
-    public static final ByteSizeValue DEFAULT_CHILD_ALLOCATION = new ByteSizeValue(1024, ByteSizeUnit.MB);
-
     /** Group setting prefix for all Parquet settings. */
     public static final Setting<Settings> PARQUET_SETTINGS = Setting.groupSetting("index.parquet.", Setting.Property.IndexScope);
 
@@ -116,23 +108,6 @@ public final class ParquetSettings {
         "parquet.max_native_allocation",
         DEFAULT_MAX_NATIVE_ALLOCATION,
         ParquetSettings::validateMemorySizeOrPercentage,
-        Setting.Property.NodeScope,
-        Setting.Property.Dynamic
-    );
-
-    /**
-     * Per-VSR child allocator cap. Bounds memory a single in-flight VectorSchemaRoot can hold,
-     * preventing one writer from monopolizing the root allocator.
-     * <p>
-     * Dynamic: changes are pushed to live child allocators via {@code BaseAllocator.setLimit}
-     * and to all children created subsequently. As with the root allocator, lowering below
-     * current usage rejects future allocations rather than reclaiming memory.
-     */
-    public static final Setting<ByteSizeValue> CHILD_ALLOCATION = Setting.byteSizeSetting(
-        "parquet.arrow.child_allocation",
-        DEFAULT_CHILD_ALLOCATION,
-        new ByteSizeValue(1, ByteSizeUnit.MB),
-        new ByteSizeValue(Long.MAX_VALUE, ByteSizeUnit.BYTES),
         Setting.Property.NodeScope,
         Setting.Property.Dynamic
     );
@@ -226,7 +201,6 @@ public final class ParquetSettings {
             BLOOM_FILTER_FPP,
             BLOOM_FILTER_NDV,
             MAX_NATIVE_ALLOCATION,
-            CHILD_ALLOCATION,
             MAX_ROWS_PER_VSR,
             SORT_IN_MEMORY_THRESHOLD,
             SORT_BATCH_SIZE,

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/ParquetSettings.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/ParquetSettings.java
@@ -114,12 +114,17 @@ public final class ParquetSettings {
      * ({@code totalPhysicalMemory - configuredMaxHeap}, e.g. {@code "10%"}) or an absolute byte
      * size (e.g. {@code "2gb"}). When a percentage is supplied, the resolved value is clamped by
      * {@link #MIN_NATIVE_ALLOCATION} and {@link #MAX_NATIVE_ALLOCATION_CEILING}.
+     * <p>
+     * Dynamic in the cluster-settings sense: PUTs are accepted and persisted, but the Arrow
+     * {@code RootAllocator} budget is fixed at {@code ArrowBufferPool} construction time. The
+     * new value takes effect after the next node restart.
      */
     public static final Setting<String> MAX_NATIVE_ALLOCATION = Setting.simpleString(
         "parquet.max_native_allocation",
         DEFAULT_MAX_NATIVE_ALLOCATION,
         ParquetSettings::validateMemorySizeOrPercentage,
-        Setting.Property.NodeScope
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
     );
 
     /** Floor applied when {@link #MAX_NATIVE_ALLOCATION} is a percentage. */
@@ -128,7 +133,8 @@ public final class ParquetSettings {
         DEFAULT_MIN_NATIVE_ALLOCATION,
         new ByteSizeValue(0, ByteSizeUnit.BYTES),
         new ByteSizeValue(Long.MAX_VALUE, ByteSizeUnit.BYTES),
-        Setting.Property.NodeScope
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
     );
 
     /**
@@ -140,19 +146,25 @@ public final class ParquetSettings {
         DEFAULT_MAX_NATIVE_ALLOCATION_CEILING,
         new ByteSizeValue(-1),
         new ByteSizeValue(Long.MAX_VALUE, ByteSizeUnit.BYTES),
-        Setting.Property.NodeScope
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
     );
 
     /**
      * Per-VSR child allocator cap. Bounds memory a single in-flight VectorSchemaRoot can hold,
      * preventing one writer from monopolizing the root allocator.
+     * <p>
+     * Dynamic in the cluster-settings sense: PUTs are accepted and persisted, but the per-child
+     * cap is fixed at {@code ArrowBufferPool} construction time. The new value takes effect
+     * after the next node restart.
      */
     public static final Setting<ByteSizeValue> CHILD_ALLOCATION = Setting.byteSizeSetting(
         "parquet.arrow.child_allocation",
         DEFAULT_CHILD_ALLOCATION,
         new ByteSizeValue(1, ByteSizeUnit.MB),
         new ByteSizeValue(Long.MAX_VALUE, ByteSizeUnit.BYTES),
-        Setting.Property.NodeScope
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
     );
 
     /** Maximum rows per VectorSchemaRoot before rotation is triggered (default 50000). */

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/ParquetSettings.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/ParquetSettings.java
@@ -115,9 +115,9 @@ public final class ParquetSettings {
      * size (e.g. {@code "2gb"}). When a percentage is supplied, the resolved value is clamped by
      * {@link #MIN_NATIVE_ALLOCATION} and {@link #MAX_NATIVE_ALLOCATION_CEILING}.
      * <p>
-     * Dynamic in the cluster-settings sense: PUTs are accepted and persisted, but the Arrow
-     * {@code RootAllocator} budget is fixed at {@code ArrowBufferPool} construction time. The
-     * new value takes effect after the next node restart.
+     * Dynamic: changes take effect on the live Arrow {@code RootAllocator} via
+     * {@code BaseAllocator.setLimit}. Lowering below current usage rejects future allocations
+     * until reservations drain; it does not reclaim allocated memory.
      */
     public static final Setting<String> MAX_NATIVE_ALLOCATION = Setting.simpleString(
         "parquet.max_native_allocation",
@@ -154,9 +154,9 @@ public final class ParquetSettings {
      * Per-VSR child allocator cap. Bounds memory a single in-flight VectorSchemaRoot can hold,
      * preventing one writer from monopolizing the root allocator.
      * <p>
-     * Dynamic in the cluster-settings sense: PUTs are accepted and persisted, but the per-child
-     * cap is fixed at {@code ArrowBufferPool} construction time. The new value takes effect
-     * after the next node restart.
+     * Dynamic: changes are pushed to live child allocators via {@code BaseAllocator.setLimit}
+     * and to all children created subsequently. As with the root allocator, lowering below
+     * current usage rejects future allocations rather than reclaiming memory.
      */
     public static final Setting<ByteSizeValue> CHILD_ALLOCATION = Setting.byteSizeSetting(
         "parquet.arrow.child_allocation",

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/ParquetSettings.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/ParquetSettings.java
@@ -25,6 +25,24 @@ public final class ParquetSettings {
     public static final String DEFAULT_MAX_NATIVE_ALLOCATION = "10%";
     public static final int DEFAULT_MAX_ROWS_PER_VSR = 50000;
 
+    /**
+     * Floor applied when {@link #MAX_NATIVE_ALLOCATION} is a percentage. Mirrors the
+     * {@code indices.memory.min_native_index_buffer_size} pattern in {@code IndexingMemoryController}.
+     */
+    public static final ByteSizeValue DEFAULT_MIN_NATIVE_ALLOCATION = new ByteSizeValue(512, ByteSizeUnit.MB);
+
+    /**
+     * Ceiling applied when {@link #MAX_NATIVE_ALLOCATION} is a percentage. Mirrors the
+     * {@code indices.memory.max_native_index_buffer_size} pattern in {@code IndexingMemoryController}.
+     */
+    public static final ByteSizeValue DEFAULT_MAX_NATIVE_ALLOCATION_CEILING = new ByteSizeValue(8, ByteSizeUnit.GB);
+
+    /**
+     * Default per-VSR child allocator cap. Bounds memory a single in-flight VectorSchemaRoot can
+     * hold so one writer cannot monopolize the root allocator.
+     */
+    public static final ByteSizeValue DEFAULT_CHILD_ALLOCATION = new ByteSizeValue(256, ByteSizeUnit.MB);
+
     /** Group setting prefix for all Parquet settings. */
     public static final Setting<Settings> PARQUET_SETTINGS = Setting.groupSetting("index.parquet.", Setting.Property.IndexScope);
 
@@ -90,10 +108,48 @@ public final class ParquetSettings {
         Setting.Property.IndexScope
     );
 
-    /** Maximum native memory allocation for Arrow buffers, as a percentage of non-heap memory (default 10%). */
+    /**
+     * Maximum native memory allocation for Arrow buffers. Accepts a percentage of non-heap memory
+     * ({@code totalPhysicalMemory - configuredMaxHeap}, e.g. {@code "10%"}) or an absolute byte
+     * size (e.g. {@code "2gb"}). When a percentage is supplied, the resolved value is clamped by
+     * {@link #MIN_NATIVE_ALLOCATION} and {@link #MAX_NATIVE_ALLOCATION_CEILING}.
+     */
     public static final Setting<String> MAX_NATIVE_ALLOCATION = Setting.simpleString(
         "parquet.max_native_allocation",
         DEFAULT_MAX_NATIVE_ALLOCATION,
+        Setting.Property.NodeScope
+    );
+
+    /** Floor applied when {@link #MAX_NATIVE_ALLOCATION} is a percentage. */
+    public static final Setting<ByteSizeValue> MIN_NATIVE_ALLOCATION = Setting.byteSizeSetting(
+        "parquet.min_native_allocation",
+        DEFAULT_MIN_NATIVE_ALLOCATION,
+        new ByteSizeValue(0, ByteSizeUnit.BYTES),
+        new ByteSizeValue(Long.MAX_VALUE, ByteSizeUnit.BYTES),
+        Setting.Property.NodeScope
+    );
+
+    /**
+     * Ceiling applied when {@link #MAX_NATIVE_ALLOCATION} is a percentage. {@code -1} disables
+     * the ceiling.
+     */
+    public static final Setting<ByteSizeValue> MAX_NATIVE_ALLOCATION_CEILING = Setting.byteSizeSetting(
+        "parquet.max_native_allocation_ceiling",
+        DEFAULT_MAX_NATIVE_ALLOCATION_CEILING,
+        new ByteSizeValue(-1),
+        new ByteSizeValue(Long.MAX_VALUE, ByteSizeUnit.BYTES),
+        Setting.Property.NodeScope
+    );
+
+    /**
+     * Per-VSR child allocator cap. Bounds memory a single in-flight VectorSchemaRoot can hold,
+     * preventing one writer from monopolizing the root allocator.
+     */
+    public static final Setting<ByteSizeValue> CHILD_ALLOCATION = Setting.byteSizeSetting(
+        "parquet.arrow.child_allocation",
+        DEFAULT_CHILD_ALLOCATION,
+        new ByteSizeValue(1, ByteSizeUnit.MB),
+        new ByteSizeValue(Long.MAX_VALUE, ByteSizeUnit.BYTES),
         Setting.Property.NodeScope
     );
 
@@ -165,6 +221,9 @@ public final class ParquetSettings {
             BLOOM_FILTER_FPP,
             BLOOM_FILTER_NDV,
             MAX_NATIVE_ALLOCATION,
+            MIN_NATIVE_ALLOCATION,
+            MAX_NATIVE_ALLOCATION_CEILING,
+            CHILD_ALLOCATION,
             MAX_ROWS_PER_VSR,
             SORT_IN_MEMORY_THRESHOLD,
             SORT_BATCH_SIZE,

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/ParquetSettings.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/ParquetSettings.java
@@ -27,12 +27,6 @@ public final class ParquetSettings {
     public static final int DEFAULT_MAX_ROWS_PER_VSR = 50000;
 
     /**
-     * Ceiling applied when {@link #MAX_NATIVE_ALLOCATION} is a percentage. Mirrors the
-     * {@code indices.memory.max_native_index_buffer_size} pattern in {@code IndexingMemoryController}.
-     */
-    public static final ByteSizeValue DEFAULT_MAX_NATIVE_ALLOCATION_CEILING = new ByteSizeValue(8, ByteSizeUnit.GB);
-
-    /**
      * Default per-VSR child allocator cap. Bounds memory a single in-flight VectorSchemaRoot can
      * hold so one writer cannot monopolize the root allocator. {@code 512mb} comes from the OFAT
      * sweep documented in
@@ -111,8 +105,7 @@ public final class ParquetSettings {
     /**
      * Maximum native memory allocation for Arrow buffers. Accepts a percentage of non-heap memory
      * ({@code totalPhysicalMemory - configuredMaxHeap}, e.g. {@code "10%"}) or an absolute byte
-     * size (e.g. {@code "2gb"}). When a percentage is supplied, the resolved value is clamped by
-     * {@link #MAX_NATIVE_ALLOCATION_CEILING}.
+     * size (e.g. {@code "2gb"}).
      * <p>
      * Dynamic: changes take effect on the live Arrow {@code RootAllocator} via
      * {@code BaseAllocator.setLimit}. Lowering below current usage rejects future allocations
@@ -126,19 +119,6 @@ public final class ParquetSettings {
         "parquet.max_native_allocation",
         DEFAULT_MAX_NATIVE_ALLOCATION,
         ParquetSettings::validateMemorySizeOrPercentage,
-        Setting.Property.NodeScope,
-        Setting.Property.Dynamic
-    );
-
-    /**
-     * Ceiling applied when {@link #MAX_NATIVE_ALLOCATION} is a percentage. {@code -1} disables
-     * the ceiling.
-     */
-    public static final Setting<ByteSizeValue> MAX_NATIVE_ALLOCATION_CEILING = Setting.byteSizeSetting(
-        "parquet.max_native_allocation_ceiling",
-        DEFAULT_MAX_NATIVE_ALLOCATION_CEILING,
-        new ByteSizeValue(-1),
-        new ByteSizeValue(Long.MAX_VALUE, ByteSizeUnit.BYTES),
         Setting.Property.NodeScope,
         Setting.Property.Dynamic
     );
@@ -249,7 +229,6 @@ public final class ParquetSettings {
             BLOOM_FILTER_FPP,
             BLOOM_FILTER_NDV,
             MAX_NATIVE_ALLOCATION,
-            MAX_NATIVE_ALLOCATION_CEILING,
             CHILD_ALLOCATION,
             MAX_ROWS_PER_VSR,
             SORT_IN_MEMORY_THRESHOLD,

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/engine/ParquetIndexingEngine.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/engine/ParquetIndexingEngine.java
@@ -28,6 +28,7 @@ import org.opensearch.parquet.ParquetSettings;
 import org.opensearch.parquet.bridge.NativeSettings;
 import org.opensearch.parquet.bridge.RustBridge;
 import org.opensearch.parquet.memory.ArrowBufferPool;
+import org.opensearch.parquet.memory.ArrowBufferPoolRegistry;
 import org.opensearch.parquet.merge.NativeParquetMergeStrategy;
 import org.opensearch.parquet.merge.ParquetMergeExecutor;
 import org.opensearch.parquet.writer.ParquetDocumentInput;
@@ -78,6 +79,7 @@ public class ParquetIndexingEngine implements IndexingExecutionEngine<ParquetDat
     private volatile long cachedSchemaVersion = -1;
     private volatile Schema cachedSchema;
     private final ArrowBufferPool bufferPool;
+    private final ArrowBufferPoolRegistry bufferPoolRegistry;
     private final IndexSettings indexSettings;
     private final Settings nodeSettings;
     private final ThreadPool threadPool;
@@ -112,7 +114,8 @@ public class ParquetIndexingEngine implements IndexingExecutionEngine<ParquetDat
             mappingVersionSupplier,
             indexSettings,
             threadPool,
-            new PrecomputedChecksumStrategy()
+            new PrecomputedChecksumStrategy(),
+            null
         );
     }
 
@@ -138,11 +141,34 @@ public class ParquetIndexingEngine implements IndexingExecutionEngine<ParquetDat
         ThreadPool threadPool,
         FormatChecksumStrategy checksumStrategy
     ) {
+        this(settings, dataFormat, shardPath, schemaSupplier, mappingVersionSupplier, indexSettings, threadPool, checksumStrategy, null);
+    }
+
+    /**
+     * Creates a new ParquetIndexingEngine with an externally provided checksum strategy and an
+     * optional {@link ArrowBufferPoolRegistry} that fans dynamic Arrow allocator updates out to
+     * the pool created here. {@code null} disables runtime updates (used by tests/benchmarks).
+     */
+    public ParquetIndexingEngine(
+        Settings settings,
+        ParquetDataFormat dataFormat,
+        ShardPath shardPath,
+        Supplier<Schema> schemaSupplier,
+        Supplier<Long> mappingVersionSupplier,
+        IndexSettings indexSettings,
+        ThreadPool threadPool,
+        FormatChecksumStrategy checksumStrategy,
+        ArrowBufferPoolRegistry bufferPoolRegistry
+    ) {
         this.dataFormat = dataFormat;
         this.shardPath = shardPath;
         this.schemaSupplier = schemaSupplier;
         this.mappingVersionSupplier = mappingVersionSupplier;
         this.bufferPool = new ArrowBufferPool(settings);
+        this.bufferPoolRegistry = bufferPoolRegistry;
+        if (bufferPoolRegistry != null) {
+            bufferPoolRegistry.register(this.bufferPool);
+        }
         this.indexSettings = indexSettings;
         this.nodeSettings = settings;
         this.threadPool = threadPool;
@@ -292,6 +318,9 @@ public class ParquetIndexingEngine implements IndexingExecutionEngine<ParquetDat
                 indexSettings.getIndex().getName(),
                 e.getMessage()
             );
+        }
+        if (bufferPoolRegistry != null) {
+            bufferPoolRegistry.unregister(bufferPool);
         }
         bufferPool.close();
     }

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/memory/ArrowBufferPool.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/memory/ArrowBufferPool.java
@@ -59,11 +59,7 @@ public class ArrowBufferPool implements Closeable {
             );
             childAllocation = maxAllocationInBytes;
         }
-        logger.debug(
-            "ArrowBufferPool sized: root={} bytes, perChild={} bytes",
-            maxAllocationInBytes,
-            childAllocation
-        );
+        logger.debug("ArrowBufferPool sized: root={} bytes, perChild={} bytes", maxAllocationInBytes, childAllocation);
         this.rootAllocator = new RootAllocator(maxAllocationInBytes);
         this.maxChildAllocation = childAllocation;
     }
@@ -97,8 +93,7 @@ public class ArrowBufferPool implements Closeable {
         String configured = ParquetSettings.MAX_NATIVE_ALLOCATION.get(settings);
 
         if (configured.endsWith("%")) {
-            long totalAvailableMemory = OsProbe.getInstance().getTotalPhysicalMemorySize()
-                - JvmInfo.jvmInfo().getConfiguredMaxHeapSize();
+            long totalAvailableMemory = OsProbe.getInstance().getTotalPhysicalMemorySize() - JvmInfo.jvmInfo().getConfiguredMaxHeapSize();
             ByteSizeValue floor = ParquetSettings.MIN_NATIVE_ALLOCATION.get(settings);
             if (totalAvailableMemory <= 0) {
                 logger.warn(

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/memory/ArrowBufferPool.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/memory/ArrowBufferPool.java
@@ -14,6 +14,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.RatioValue;
+import org.opensearch.core.common.unit.ByteSizeValue;
 import org.opensearch.monitor.jvm.JvmInfo;
 import org.opensearch.monitor.os.OsProbe;
 import org.opensearch.parquet.ParquetSettings;
@@ -23,12 +24,15 @@ import java.io.Closeable;
 /**
  * Arrow memory allocator pool with configurable limits derived from node settings.
  *
- * <p>Wraps an Apache Arrow {@link RootAllocator} whose maximum allocation is computed as a
- * percentage of available non-heap system memory (total physical memory minus JVM max heap),
- * controlled by the {@code parquet.max_native_allocation} setting (default {@code "10%"}).
+ * <p>Wraps an Apache Arrow {@link RootAllocator} whose maximum allocation is derived from the
+ * {@link ParquetSettings#MAX_NATIVE_ALLOCATION} setting. Percentages are applied against
+ * {@code totalPhysicalMemory - configuredMaxHeap} and clamped by
+ * {@link ParquetSettings#MIN_NATIVE_ALLOCATION} / {@link ParquetSettings#MAX_NATIVE_ALLOCATION_CEILING};
+ * absolute byte sizes are used as-is.
  *
  * <p>Child allocators are created per {@link org.opensearch.parquet.vsr.ManagedVSR} instance,
- * each limited to 1/10th of the root allocation, providing memory isolation between batches.
+ * each capped by {@link ParquetSettings#CHILD_ALLOCATION} to provide memory isolation between
+ * batches. The child cap is reduced to the root allocation when the configured value exceeds it.
  */
 public class ArrowBufferPool implements Closeable {
 
@@ -43,10 +47,25 @@ public class ArrowBufferPool implements Closeable {
      * @param settings node settings used to derive the maximum native allocation
      */
     public ArrowBufferPool(Settings settings) {
-        long maxAllocationInBytes = getMaxAllocationInBytes(settings);
-        logger.debug("Max native memory allocation for ArrowBufferPool: {} bytes", maxAllocationInBytes);
+        long maxAllocationInBytes = resolveMaxAllocationBytes(settings);
+        long childAllocation = ParquetSettings.CHILD_ALLOCATION.get(settings).getBytes();
+        if (childAllocation > maxAllocationInBytes) {
+            logger.warn(
+                "[{}] ({}) is larger than [{}] ({}); capping child allocation to root allocation",
+                ParquetSettings.CHILD_ALLOCATION.getKey(),
+                new ByteSizeValue(childAllocation),
+                ParquetSettings.MAX_NATIVE_ALLOCATION.getKey(),
+                new ByteSizeValue(maxAllocationInBytes)
+            );
+            childAllocation = maxAllocationInBytes;
+        }
+        logger.debug(
+            "ArrowBufferPool sized: root={} bytes, perChild={} bytes",
+            maxAllocationInBytes,
+            childAllocation
+        );
         this.rootAllocator = new RootAllocator(maxAllocationInBytes);
-        this.maxChildAllocation = maxAllocationInBytes / 10;
+        this.maxChildAllocation = childAllocation;
     }
 
     /**
@@ -68,9 +87,41 @@ public class ArrowBufferPool implements Closeable {
         rootAllocator.close();
     }
 
-    private static long getMaxAllocationInBytes(Settings settings) {
-        long totalAvailableMemory = OsProbe.getInstance().getTotalPhysicalMemorySize() - JvmInfo.jvmInfo().getConfiguredMaxHeapSize();
-        RatioValue ratio = RatioValue.parseRatioValue(ParquetSettings.MAX_NATIVE_ALLOCATION.get(settings));
-        return (long) (totalAvailableMemory * ratio.getAsRatio());
+    /**
+     * Resolves the root allocator budget. Mirrors {@code IndexingMemoryController}'s native
+     * indexing buffer logic: percentages apply to {@code totalPhysicalMemory - configuredMaxHeap}
+     * and are clamped by {@link ParquetSettings#MIN_NATIVE_ALLOCATION} /
+     * {@link ParquetSettings#MAX_NATIVE_ALLOCATION_CEILING}; absolute byte sizes are used as-is.
+     */
+    static long resolveMaxAllocationBytes(Settings settings) {
+        String configured = ParquetSettings.MAX_NATIVE_ALLOCATION.get(settings);
+
+        if (configured.endsWith("%")) {
+            long totalAvailableMemory = OsProbe.getInstance().getTotalPhysicalMemorySize()
+                - JvmInfo.jvmInfo().getConfiguredMaxHeapSize();
+            ByteSizeValue floor = ParquetSettings.MIN_NATIVE_ALLOCATION.get(settings);
+            if (totalAvailableMemory <= 0) {
+                logger.warn(
+                    "Non-heap memory not measurable; falling back to [{}] = {}",
+                    ParquetSettings.MIN_NATIVE_ALLOCATION.getKey(),
+                    floor
+                );
+                return floor.getBytes();
+            }
+
+            RatioValue ratio = RatioValue.parseRatioValue(configured);
+            long bytes = (long) (totalAvailableMemory * ratio.getAsRatio());
+
+            ByteSizeValue ceiling = ParquetSettings.MAX_NATIVE_ALLOCATION_CEILING.get(settings);
+            if (bytes < floor.getBytes()) {
+                bytes = floor.getBytes();
+            }
+            if (ceiling.getBytes() != -1 && bytes > ceiling.getBytes()) {
+                bytes = ceiling.getBytes();
+            }
+            return bytes;
+        }
+
+        return ByteSizeValue.parseBytesSizeValue(configured, ParquetSettings.MAX_NATIVE_ALLOCATION.getKey()).getBytes();
     }
 }

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/memory/ArrowBufferPool.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/memory/ArrowBufferPool.java
@@ -33,13 +33,19 @@ import java.io.Closeable;
  * <p>Child allocators are created per {@link org.opensearch.parquet.vsr.ManagedVSR} instance,
  * each capped by {@link ParquetSettings#CHILD_ALLOCATION} to provide memory isolation between
  * batches. The child cap is reduced to the root allocation when the configured value exceeds it.
+ *
+ * <p>Limits are runtime-mutable: {@link #applyLimits(Settings)} re-resolves the root and per-child
+ * caps and pushes the new values to the live root allocator and each existing child allocator via
+ * {@link BufferAllocator#setLimit(long)}. Lowering a cap below an allocator's currently-reserved
+ * memory does not reclaim memory; it only rejects future allocations until usage drains.
+ * {@code ParquetDataFormatPlugin} owns the cluster-settings listeners that drive this method.
  */
 public class ArrowBufferPool implements Closeable {
 
     private static final Logger logger = LogManager.getLogger(ArrowBufferPool.class);
 
     private final RootAllocator rootAllocator;
-    private final long maxChildAllocation;
+    private volatile long maxChildAllocation;
 
     /**
      * Creates a new ArrowBufferPool.
@@ -48,17 +54,7 @@ public class ArrowBufferPool implements Closeable {
      */
     public ArrowBufferPool(Settings settings) {
         long maxAllocationInBytes = resolveMaxAllocationBytes(settings);
-        long childAllocation = ParquetSettings.CHILD_ALLOCATION.get(settings).getBytes();
-        if (childAllocation > maxAllocationInBytes) {
-            logger.warn(
-                "[{}] ({}) is larger than [{}] ({}); capping child allocation to root allocation",
-                ParquetSettings.CHILD_ALLOCATION.getKey(),
-                new ByteSizeValue(childAllocation),
-                ParquetSettings.MAX_NATIVE_ALLOCATION.getKey(),
-                new ByteSizeValue(maxAllocationInBytes)
-            );
-            childAllocation = maxAllocationInBytes;
-        }
+        long childAllocation = resolveChildAllocationBytes(settings, maxAllocationInBytes);
         logger.debug("ArrowBufferPool sized: root={} bytes, perChild={} bytes", maxAllocationInBytes, childAllocation);
         this.rootAllocator = new RootAllocator(maxAllocationInBytes);
         this.maxChildAllocation = childAllocation;
@@ -76,6 +72,42 @@ public class ArrowBufferPool implements Closeable {
     /** Returns the total bytes currently allocated by the root allocator. */
     public long getTotalAllocatedBytes() {
         return rootAllocator.getAllocatedMemory();
+    }
+
+    /** Returns the current root allocator memory limit in bytes. Visible for tests. */
+    public long getRootLimit() {
+        return rootAllocator.getLimit();
+    }
+
+    /** Returns the current per-child allocator cap in bytes. Visible for tests. */
+    public long getMaxChildAllocation() {
+        return maxChildAllocation;
+    }
+
+    /**
+     * Re-reads the four allocation settings ({@link ParquetSettings#MAX_NATIVE_ALLOCATION},
+     * {@link ParquetSettings#MIN_NATIVE_ALLOCATION},
+     * {@link ParquetSettings#MAX_NATIVE_ALLOCATION_CEILING},
+     * {@link ParquetSettings#CHILD_ALLOCATION}), pushes the resolved root limit to the live
+     * {@link RootAllocator} and pushes the new per-child cap to every live child allocator. New
+     * children created after this call also see the new cap via the volatile field.
+     */
+    public void applyLimits(Settings settings) {
+        long newRoot = resolveMaxAllocationBytes(settings);
+        long newChild = resolveChildAllocationBytes(settings, newRoot);
+        long previousRoot = rootAllocator.getLimit();
+        long previousChild = this.maxChildAllocation;
+        if (newRoot == previousRoot && newChild == previousChild) {
+            return;
+        }
+        rootAllocator.setLimit(newRoot);
+        this.maxChildAllocation = newChild;
+        // Update live children. setLimit doesn't reclaim memory below current usage; it just
+        // rejects future allocations until the child drains.
+        for (BufferAllocator child : rootAllocator.getChildAllocators()) {
+            child.setLimit(newChild);
+        }
+        logger.info("ArrowBufferPool limits updated: root {}B -> {}B, perChild {}B -> {}B", previousRoot, newRoot, previousChild, newChild);
     }
 
     @Override
@@ -118,5 +150,24 @@ public class ArrowBufferPool implements Closeable {
         }
 
         return ByteSizeValue.parseBytesSizeValue(configured, ParquetSettings.MAX_NATIVE_ALLOCATION.getKey()).getBytes();
+    }
+
+    /**
+     * Resolves the per-child allocator cap, capping at the root allocation when the configured
+     * value exceeds it.
+     */
+    static long resolveChildAllocationBytes(Settings settings, long rootBytes) {
+        long childAllocation = ParquetSettings.CHILD_ALLOCATION.get(settings).getBytes();
+        if (childAllocation > rootBytes) {
+            logger.warn(
+                "[{}] ({}) is larger than [{}] ({}); capping child allocation to root allocation",
+                ParquetSettings.CHILD_ALLOCATION.getKey(),
+                new ByteSizeValue(childAllocation),
+                ParquetSettings.MAX_NATIVE_ALLOCATION.getKey(),
+                new ByteSizeValue(rootBytes)
+            );
+            childAllocation = rootBytes;
+        }
+        return childAllocation;
     }
 }

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/memory/ArrowBufferPool.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/memory/ArrowBufferPool.java
@@ -29,18 +29,21 @@ import java.io.Closeable;
  * {@code totalPhysicalMemory - configuredMaxHeap}; absolute byte sizes are used as-is.
  *
  * <p>Child allocators are created per {@link org.opensearch.parquet.vsr.ManagedVSR} instance,
- * each capped by {@link ParquetSettings#CHILD_ALLOCATION} to provide memory isolation between
- * batches. The child cap is reduced to the root allocation when the configured value exceeds it.
+ * each fixed at one tenth of the root allocation to provide memory isolation between batches.
  *
- * <p>Limits are runtime-mutable: {@link #applyLimits(Settings)} re-resolves the root and per-child
- * caps and pushes the new values to the live root allocator and each existing child allocator via
- * {@link BufferAllocator#setLimit(long)}. Lowering a cap below an allocator's currently-reserved
- * memory does not reclaim memory; it only rejects future allocations until usage drains.
- * {@code ParquetDataFormatPlugin} owns the cluster-settings listeners that drive this method.
+ * <p>Limits are runtime-mutable: {@link #applyLimits(Settings)} re-resolves the root cap and
+ * pushes the new value to the live root allocator and each existing child allocator via
+ * {@link BufferAllocator#setLimit(long)}. The per-child cap is recomputed as {@code root / 10}.
+ * Lowering a cap below an allocator's currently-reserved memory does not reclaim memory; it
+ * only rejects future allocations until usage drains. {@code ParquetDataFormatPlugin} owns the
+ * cluster-settings listener that drives this method.
  */
 public class ArrowBufferPool implements Closeable {
 
     private static final Logger logger = LogManager.getLogger(ArrowBufferPool.class);
+
+    /** Per-child allocator cap as a fraction of the root allocation. */
+    private static final int CHILD_TO_ROOT_RATIO = 10;
 
     private final RootAllocator rootAllocator;
     private volatile long maxChildAllocation;
@@ -52,7 +55,7 @@ public class ArrowBufferPool implements Closeable {
      */
     public ArrowBufferPool(Settings settings) {
         long maxAllocationInBytes = resolveMaxAllocationBytes(settings);
-        long childAllocation = resolveChildAllocationBytes(settings, maxAllocationInBytes);
+        long childAllocation = maxAllocationInBytes / CHILD_TO_ROOT_RATIO;
         logger.debug("ArrowBufferPool sized: root={} bytes, perChild={} bytes", maxAllocationInBytes, childAllocation);
         this.rootAllocator = new RootAllocator(maxAllocationInBytes);
         this.maxChildAllocation = childAllocation;
@@ -83,14 +86,13 @@ public class ArrowBufferPool implements Closeable {
     }
 
     /**
-     * Re-reads the two allocation settings ({@link ParquetSettings#MAX_NATIVE_ALLOCATION},
-     * {@link ParquetSettings#CHILD_ALLOCATION}), pushes the resolved root limit to the live
-     * {@link RootAllocator} and pushes the new per-child cap to every live child allocator. New
+     * Re-reads {@link ParquetSettings#MAX_NATIVE_ALLOCATION}, pushes the resolved root limit to
+     * the live {@link RootAllocator} and recomputes the per-child cap as {@code root / 10}. New
      * children created after this call also see the new cap via the volatile field.
      */
     public void applyLimits(Settings settings) {
         long newRoot = resolveMaxAllocationBytes(settings);
-        long newChild = resolveChildAllocationBytes(settings, newRoot);
+        long newChild = newRoot / CHILD_TO_ROOT_RATIO;
         long previousRoot = rootAllocator.getLimit();
         long previousChild = this.maxChildAllocation;
         if (newRoot == previousRoot && newChild == previousChild) {
@@ -136,24 +138,5 @@ public class ArrowBufferPool implements Closeable {
         }
 
         return ByteSizeValue.parseBytesSizeValue(configured, ParquetSettings.MAX_NATIVE_ALLOCATION.getKey()).getBytes();
-    }
-
-    /**
-     * Resolves the per-child allocator cap, capping at the root allocation when the configured
-     * value exceeds it.
-     */
-    static long resolveChildAllocationBytes(Settings settings, long rootBytes) {
-        long childAllocation = ParquetSettings.CHILD_ALLOCATION.get(settings).getBytes();
-        if (childAllocation > rootBytes) {
-            logger.warn(
-                "[{}] ({}) is larger than [{}] ({}); capping child allocation to root allocation",
-                ParquetSettings.CHILD_ALLOCATION.getKey(),
-                new ByteSizeValue(childAllocation),
-                ParquetSettings.MAX_NATIVE_ALLOCATION.getKey(),
-                new ByteSizeValue(rootBytes)
-            );
-            childAllocation = rootBytes;
-        }
-        return childAllocation;
     }
 }

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/memory/ArrowBufferPool.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/memory/ArrowBufferPool.java
@@ -27,8 +27,7 @@ import java.io.Closeable;
  * <p>Wraps an Apache Arrow {@link RootAllocator} whose maximum allocation is derived from the
  * {@link ParquetSettings#MAX_NATIVE_ALLOCATION} setting. Percentages are applied against
  * {@code totalPhysicalMemory - configuredMaxHeap} and clamped by
- * {@link ParquetSettings#MIN_NATIVE_ALLOCATION} / {@link ParquetSettings#MAX_NATIVE_ALLOCATION_CEILING};
- * absolute byte sizes are used as-is.
+ * {@link ParquetSettings#MAX_NATIVE_ALLOCATION_CEILING}; absolute byte sizes are used as-is.
  *
  * <p>Child allocators are created per {@link org.opensearch.parquet.vsr.ManagedVSR} instance,
  * each capped by {@link ParquetSettings#CHILD_ALLOCATION} to provide memory isolation between
@@ -85,8 +84,7 @@ public class ArrowBufferPool implements Closeable {
     }
 
     /**
-     * Re-reads the four allocation settings ({@link ParquetSettings#MAX_NATIVE_ALLOCATION},
-     * {@link ParquetSettings#MIN_NATIVE_ALLOCATION},
+     * Re-reads the three allocation settings ({@link ParquetSettings#MAX_NATIVE_ALLOCATION},
      * {@link ParquetSettings#MAX_NATIVE_ALLOCATION_CEILING},
      * {@link ParquetSettings#CHILD_ALLOCATION}), pushes the resolved root limit to the live
      * {@link RootAllocator} and pushes the new per-child cap to every live child allocator. New
@@ -116,33 +114,30 @@ public class ArrowBufferPool implements Closeable {
     }
 
     /**
-     * Resolves the root allocator budget. Mirrors {@code IndexingMemoryController}'s native
-     * indexing buffer logic: percentages apply to {@code totalPhysicalMemory - configuredMaxHeap}
-     * and are clamped by {@link ParquetSettings#MIN_NATIVE_ALLOCATION} /
+     * Resolves the root allocator budget. Percentages apply to
+     * {@code totalPhysicalMemory - configuredMaxHeap} and are clamped at
      * {@link ParquetSettings#MAX_NATIVE_ALLOCATION_CEILING}; absolute byte sizes are used as-is.
+     * <p>
+     * Throws {@link IllegalStateException} if a percentage is supplied but non-heap memory is
+     * unmeasurable — operators on misconfigured boxes should specify an absolute byte size.
      */
     static long resolveMaxAllocationBytes(Settings settings) {
         String configured = ParquetSettings.MAX_NATIVE_ALLOCATION.get(settings);
 
         if (configured.endsWith("%")) {
             long totalAvailableMemory = OsProbe.getInstance().getTotalPhysicalMemorySize() - JvmInfo.jvmInfo().getConfiguredMaxHeapSize();
-            ByteSizeValue floor = ParquetSettings.MIN_NATIVE_ALLOCATION.get(settings);
             if (totalAvailableMemory <= 0) {
-                logger.warn(
-                    "Non-heap memory not measurable; falling back to [{}] = {}",
-                    ParquetSettings.MIN_NATIVE_ALLOCATION.getKey(),
-                    floor
+                throw new IllegalStateException(
+                    "Non-heap memory not measurable for setting ["
+                        + ParquetSettings.MAX_NATIVE_ALLOCATION.getKey()
+                        + "]; configure an absolute byte size (e.g. \"2gb\") instead of a percentage."
                 );
-                return floor.getBytes();
             }
 
             RatioValue ratio = RatioValue.parseRatioValue(configured);
             long bytes = (long) (totalAvailableMemory * ratio.getAsRatio());
 
             ByteSizeValue ceiling = ParquetSettings.MAX_NATIVE_ALLOCATION_CEILING.get(settings);
-            if (bytes < floor.getBytes()) {
-                bytes = floor.getBytes();
-            }
             if (ceiling.getBytes() != -1 && bytes > ceiling.getBytes()) {
                 bytes = ceiling.getBytes();
             }

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/memory/ArrowBufferPool.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/memory/ArrowBufferPool.java
@@ -26,8 +26,7 @@ import java.io.Closeable;
  *
  * <p>Wraps an Apache Arrow {@link RootAllocator} whose maximum allocation is derived from the
  * {@link ParquetSettings#MAX_NATIVE_ALLOCATION} setting. Percentages are applied against
- * {@code totalPhysicalMemory - configuredMaxHeap} and clamped by
- * {@link ParquetSettings#MAX_NATIVE_ALLOCATION_CEILING}; absolute byte sizes are used as-is.
+ * {@code totalPhysicalMemory - configuredMaxHeap}; absolute byte sizes are used as-is.
  *
  * <p>Child allocators are created per {@link org.opensearch.parquet.vsr.ManagedVSR} instance,
  * each capped by {@link ParquetSettings#CHILD_ALLOCATION} to provide memory isolation between
@@ -84,8 +83,7 @@ public class ArrowBufferPool implements Closeable {
     }
 
     /**
-     * Re-reads the three allocation settings ({@link ParquetSettings#MAX_NATIVE_ALLOCATION},
-     * {@link ParquetSettings#MAX_NATIVE_ALLOCATION_CEILING},
+     * Re-reads the two allocation settings ({@link ParquetSettings#MAX_NATIVE_ALLOCATION},
      * {@link ParquetSettings#CHILD_ALLOCATION}), pushes the resolved root limit to the live
      * {@link RootAllocator} and pushes the new per-child cap to every live child allocator. New
      * children created after this call also see the new cap via the volatile field.
@@ -115,8 +113,7 @@ public class ArrowBufferPool implements Closeable {
 
     /**
      * Resolves the root allocator budget. Percentages apply to
-     * {@code totalPhysicalMemory - configuredMaxHeap} and are clamped at
-     * {@link ParquetSettings#MAX_NATIVE_ALLOCATION_CEILING}; absolute byte sizes are used as-is.
+     * {@code totalPhysicalMemory - configuredMaxHeap}; absolute byte sizes are used as-is.
      * <p>
      * Throws {@link IllegalStateException} if a percentage is supplied but non-heap memory is
      * unmeasurable — operators on misconfigured boxes should specify an absolute byte size.
@@ -135,13 +132,7 @@ public class ArrowBufferPool implements Closeable {
             }
 
             RatioValue ratio = RatioValue.parseRatioValue(configured);
-            long bytes = (long) (totalAvailableMemory * ratio.getAsRatio());
-
-            ByteSizeValue ceiling = ParquetSettings.MAX_NATIVE_ALLOCATION_CEILING.get(settings);
-            if (ceiling.getBytes() != -1 && bytes > ceiling.getBytes()) {
-                bytes = ceiling.getBytes();
-            }
-            return bytes;
+            return (long) (totalAvailableMemory * ratio.getAsRatio());
         }
 
         return ByteSizeValue.parseBytesSizeValue(configured, ParquetSettings.MAX_NATIVE_ALLOCATION.getKey()).getBytes();

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/memory/ArrowBufferPoolRegistry.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/memory/ArrowBufferPoolRegistry.java
@@ -1,0 +1,128 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.parquet.memory;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.core.common.unit.ByteSizeValue;
+import org.opensearch.parquet.ParquetSettings;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.WeakHashMap;
+
+/**
+ * Plugin-scoped tracker for live {@link ArrowBufferPool} instances. Registers cluster-settings
+ * listeners on the four allocation knobs once, then fans dynamic updates out to every pool
+ * created since the listener registered.
+ *
+ * <p>Pools are held via a synchronized {@link WeakHashMap}-backed set so closed/GC'd pools drop
+ * out automatically — there is no {@code removeSettingsUpdateConsumer} API to deregister
+ * listeners per pool, and per-shard pools come and go.
+ */
+public class ArrowBufferPoolRegistry {
+
+    private static final Logger logger = LogManager.getLogger(ArrowBufferPoolRegistry.class);
+
+    private final ClusterSettings clusterSettings;
+    private final Set<ArrowBufferPool> pools = Collections.newSetFromMap(Collections.synchronizedMap(new WeakHashMap<>()));
+    /**
+     * Latest known values for the four allocation knobs. Each listener updates one field then
+     * fans out an {@link ArrowBufferPool#applyLimits(Settings)} call. We track them locally
+     * because {@link ClusterSettings#get(org.opensearch.common.settings.Setting)} reads from
+     * {@code lastSettingsApplied} which is written only after all updaters run.
+     */
+    private volatile String maxNativeAllocation;
+    private volatile ByteSizeValue minNativeAllocation;
+    private volatile ByteSizeValue maxNativeAllocationCeiling;
+    private volatile ByteSizeValue childAllocation;
+
+    /** Creates the registry, snapshots current setting values, and wires the listeners. */
+    public ArrowBufferPoolRegistry(ClusterSettings clusterSettings) {
+        this.clusterSettings = clusterSettings;
+        // Snapshot initial values from the registered defaults so the first PUT sees a coherent
+        // settings view. Subsequent listener fires update only the field that changed.
+        this.maxNativeAllocation = clusterSettings.get(ParquetSettings.MAX_NATIVE_ALLOCATION);
+        this.minNativeAllocation = clusterSettings.get(ParquetSettings.MIN_NATIVE_ALLOCATION);
+        this.maxNativeAllocationCeiling = clusterSettings.get(ParquetSettings.MAX_NATIVE_ALLOCATION_CEILING);
+        this.childAllocation = clusterSettings.get(ParquetSettings.CHILD_ALLOCATION);
+
+        clusterSettings.addSettingsUpdateConsumer(ParquetSettings.MAX_NATIVE_ALLOCATION, v -> {
+            this.maxNativeAllocation = v;
+            applyToAllPools();
+        });
+        clusterSettings.addSettingsUpdateConsumer(ParquetSettings.MIN_NATIVE_ALLOCATION, v -> {
+            this.minNativeAllocation = v;
+            applyToAllPools();
+        });
+        clusterSettings.addSettingsUpdateConsumer(ParquetSettings.MAX_NATIVE_ALLOCATION_CEILING, v -> {
+            this.maxNativeAllocationCeiling = v;
+            applyToAllPools();
+        });
+        clusterSettings.addSettingsUpdateConsumer(ParquetSettings.CHILD_ALLOCATION, v -> {
+            this.childAllocation = v;
+            applyToAllPools();
+        });
+    }
+
+    /** Registers a pool to receive future limit updates. Safe to call from any thread. */
+    public void register(ArrowBufferPool pool) {
+        pools.add(pool);
+    }
+
+    /** Removes a pool from the registry. Idempotent; safe to call from {@code close()}. */
+    public void unregister(ArrowBufferPool pool) {
+        pools.remove(pool);
+    }
+
+    /** Visible for tests — returns the number of currently-tracked pools. */
+    public int trackedPoolCount() {
+        synchronized (pools) {
+            return pools.size();
+        }
+    }
+
+    /** Visible for tests — returns the underlying {@link ClusterSettings}. */
+    ClusterSettings getClusterSettings() {
+        return clusterSettings;
+    }
+
+    private void applyToAllPools() {
+        Settings nodeSettings = currentSettings();
+        // Snapshot under the synchronized lock to avoid CME during iteration; applyLimits itself
+        // touches Arrow allocator state and shouldn't be held under the lock.
+        ArrowBufferPool[] snapshot;
+        synchronized (pools) {
+            snapshot = pools.toArray(new ArrowBufferPool[0]);
+        }
+        for (ArrowBufferPool pool : snapshot) {
+            try {
+                pool.applyLimits(nodeSettings);
+            } catch (RuntimeException e) {
+                logger.warn("Failed to apply Arrow allocator limits to a pool; continuing with others", e);
+            }
+        }
+    }
+
+    /**
+     * Builds a {@link Settings} view from the locally-tracked field values rather than from
+     * {@link ClusterSettings#get}, which reads {@code lastSettingsApplied} — written only after
+     * all update consumers run.
+     */
+    private Settings currentSettings() {
+        return Settings.builder()
+            .put(ParquetSettings.MAX_NATIVE_ALLOCATION.getKey(), maxNativeAllocation)
+            .put(ParquetSettings.MIN_NATIVE_ALLOCATION.getKey(), minNativeAllocation.getStringRep())
+            .put(ParquetSettings.MAX_NATIVE_ALLOCATION_CEILING.getKey(), maxNativeAllocationCeiling.getStringRep())
+            .put(ParquetSettings.CHILD_ALLOCATION.getKey(), childAllocation.getStringRep())
+            .build();
+    }
+}

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/memory/ArrowBufferPoolRegistry.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/memory/ArrowBufferPoolRegistry.java
@@ -12,7 +12,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
-import org.opensearch.core.common.unit.ByteSizeValue;
 import org.opensearch.parquet.ParquetSettings;
 
 import java.util.Collections;
@@ -20,9 +19,10 @@ import java.util.Set;
 import java.util.WeakHashMap;
 
 /**
- * Plugin-scoped tracker for live {@link ArrowBufferPool} instances. Registers cluster-settings
- * listeners on the two allocation knobs once, then fans dynamic updates out to every pool
- * created since the listener registered.
+ * Plugin-scoped tracker for live {@link ArrowBufferPool} instances. Registers a cluster-settings
+ * listener on {@link ParquetSettings#MAX_NATIVE_ALLOCATION} once, then fans dynamic updates out
+ * to every pool created since the listener registered. The per-child allocator cap is derived
+ * from the root inside {@link ArrowBufferPool}, so no second listener is needed.
  *
  * <p>Pools are held via a synchronized {@link WeakHashMap}-backed set so closed/GC'd pools drop
  * out automatically — there is no {@code removeSettingsUpdateConsumer} API to deregister
@@ -32,33 +32,11 @@ public class ArrowBufferPoolRegistry {
 
     private static final Logger logger = LogManager.getLogger(ArrowBufferPoolRegistry.class);
 
-    private final ClusterSettings clusterSettings;
     private final Set<ArrowBufferPool> pools = Collections.newSetFromMap(Collections.synchronizedMap(new WeakHashMap<>()));
-    /**
-     * Latest known values for the two allocation knobs. Each listener updates one field then
-     * fans out an {@link ArrowBufferPool#applyLimits(Settings)} call. We track them locally
-     * because {@link ClusterSettings#get(org.opensearch.common.settings.Setting)} reads from
-     * {@code lastSettingsApplied} which is written only after all updaters run.
-     */
-    private volatile String maxNativeAllocation;
-    private volatile ByteSizeValue childAllocation;
 
-    /** Creates the registry, snapshots current setting values, and wires the listeners. */
+    /** Creates the registry and wires the listener for the root allocator setting. */
     public ArrowBufferPoolRegistry(ClusterSettings clusterSettings) {
-        this.clusterSettings = clusterSettings;
-        // Snapshot initial values from the registered defaults so the first PUT sees a coherent
-        // settings view. Subsequent listener fires update only the field that changed.
-        this.maxNativeAllocation = clusterSettings.get(ParquetSettings.MAX_NATIVE_ALLOCATION);
-        this.childAllocation = clusterSettings.get(ParquetSettings.CHILD_ALLOCATION);
-
-        clusterSettings.addSettingsUpdateConsumer(ParquetSettings.MAX_NATIVE_ALLOCATION, v -> {
-            this.maxNativeAllocation = v;
-            applyToAllPools();
-        });
-        clusterSettings.addSettingsUpdateConsumer(ParquetSettings.CHILD_ALLOCATION, v -> {
-            this.childAllocation = v;
-            applyToAllPools();
-        });
+        clusterSettings.addSettingsUpdateConsumer(ParquetSettings.MAX_NATIVE_ALLOCATION, this::applyToAllPools);
     }
 
     /** Registers a pool to receive future limit updates. Safe to call from any thread. */
@@ -78,13 +56,10 @@ public class ArrowBufferPoolRegistry {
         }
     }
 
-    /** Visible for tests — returns the underlying {@link ClusterSettings}. */
-    ClusterSettings getClusterSettings() {
-        return clusterSettings;
-    }
-
-    private void applyToAllPools() {
-        Settings nodeSettings = currentSettings();
+    private void applyToAllPools(String maxNativeAllocation) {
+        // Build a Settings view from the listener-supplied value rather than ClusterSettings.get,
+        // which reads lastSettingsApplied — written only after all update consumers run.
+        Settings nodeSettings = Settings.builder().put(ParquetSettings.MAX_NATIVE_ALLOCATION.getKey(), maxNativeAllocation).build();
         // Snapshot under the synchronized lock to avoid CME during iteration; applyLimits itself
         // touches Arrow allocator state and shouldn't be held under the lock.
         ArrowBufferPool[] snapshot;
@@ -98,17 +73,5 @@ public class ArrowBufferPoolRegistry {
                 logger.warn("Failed to apply Arrow allocator limits to a pool; continuing with others", e);
             }
         }
-    }
-
-    /**
-     * Builds a {@link Settings} view from the locally-tracked field values rather than from
-     * {@link ClusterSettings#get}, which reads {@code lastSettingsApplied} — written only after
-     * all update consumers run.
-     */
-    private Settings currentSettings() {
-        return Settings.builder()
-            .put(ParquetSettings.MAX_NATIVE_ALLOCATION.getKey(), maxNativeAllocation)
-            .put(ParquetSettings.CHILD_ALLOCATION.getKey(), childAllocation.getStringRep())
-            .build();
     }
 }

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/memory/ArrowBufferPoolRegistry.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/memory/ArrowBufferPoolRegistry.java
@@ -21,7 +21,7 @@ import java.util.WeakHashMap;
 
 /**
  * Plugin-scoped tracker for live {@link ArrowBufferPool} instances. Registers cluster-settings
- * listeners on the three allocation knobs once, then fans dynamic updates out to every pool
+ * listeners on the two allocation knobs once, then fans dynamic updates out to every pool
  * created since the listener registered.
  *
  * <p>Pools are held via a synchronized {@link WeakHashMap}-backed set so closed/GC'd pools drop
@@ -35,13 +35,12 @@ public class ArrowBufferPoolRegistry {
     private final ClusterSettings clusterSettings;
     private final Set<ArrowBufferPool> pools = Collections.newSetFromMap(Collections.synchronizedMap(new WeakHashMap<>()));
     /**
-     * Latest known values for the three allocation knobs. Each listener updates one field then
+     * Latest known values for the two allocation knobs. Each listener updates one field then
      * fans out an {@link ArrowBufferPool#applyLimits(Settings)} call. We track them locally
      * because {@link ClusterSettings#get(org.opensearch.common.settings.Setting)} reads from
      * {@code lastSettingsApplied} which is written only after all updaters run.
      */
     private volatile String maxNativeAllocation;
-    private volatile ByteSizeValue maxNativeAllocationCeiling;
     private volatile ByteSizeValue childAllocation;
 
     /** Creates the registry, snapshots current setting values, and wires the listeners. */
@@ -50,15 +49,10 @@ public class ArrowBufferPoolRegistry {
         // Snapshot initial values from the registered defaults so the first PUT sees a coherent
         // settings view. Subsequent listener fires update only the field that changed.
         this.maxNativeAllocation = clusterSettings.get(ParquetSettings.MAX_NATIVE_ALLOCATION);
-        this.maxNativeAllocationCeiling = clusterSettings.get(ParquetSettings.MAX_NATIVE_ALLOCATION_CEILING);
         this.childAllocation = clusterSettings.get(ParquetSettings.CHILD_ALLOCATION);
 
         clusterSettings.addSettingsUpdateConsumer(ParquetSettings.MAX_NATIVE_ALLOCATION, v -> {
             this.maxNativeAllocation = v;
-            applyToAllPools();
-        });
-        clusterSettings.addSettingsUpdateConsumer(ParquetSettings.MAX_NATIVE_ALLOCATION_CEILING, v -> {
-            this.maxNativeAllocationCeiling = v;
             applyToAllPools();
         });
         clusterSettings.addSettingsUpdateConsumer(ParquetSettings.CHILD_ALLOCATION, v -> {
@@ -114,7 +108,6 @@ public class ArrowBufferPoolRegistry {
     private Settings currentSettings() {
         return Settings.builder()
             .put(ParquetSettings.MAX_NATIVE_ALLOCATION.getKey(), maxNativeAllocation)
-            .put(ParquetSettings.MAX_NATIVE_ALLOCATION_CEILING.getKey(), maxNativeAllocationCeiling.getStringRep())
             .put(ParquetSettings.CHILD_ALLOCATION.getKey(), childAllocation.getStringRep())
             .build();
     }

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/memory/ArrowBufferPoolRegistry.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/memory/ArrowBufferPoolRegistry.java
@@ -21,7 +21,7 @@ import java.util.WeakHashMap;
 
 /**
  * Plugin-scoped tracker for live {@link ArrowBufferPool} instances. Registers cluster-settings
- * listeners on the four allocation knobs once, then fans dynamic updates out to every pool
+ * listeners on the three allocation knobs once, then fans dynamic updates out to every pool
  * created since the listener registered.
  *
  * <p>Pools are held via a synchronized {@link WeakHashMap}-backed set so closed/GC'd pools drop
@@ -35,13 +35,12 @@ public class ArrowBufferPoolRegistry {
     private final ClusterSettings clusterSettings;
     private final Set<ArrowBufferPool> pools = Collections.newSetFromMap(Collections.synchronizedMap(new WeakHashMap<>()));
     /**
-     * Latest known values for the four allocation knobs. Each listener updates one field then
+     * Latest known values for the three allocation knobs. Each listener updates one field then
      * fans out an {@link ArrowBufferPool#applyLimits(Settings)} call. We track them locally
      * because {@link ClusterSettings#get(org.opensearch.common.settings.Setting)} reads from
      * {@code lastSettingsApplied} which is written only after all updaters run.
      */
     private volatile String maxNativeAllocation;
-    private volatile ByteSizeValue minNativeAllocation;
     private volatile ByteSizeValue maxNativeAllocationCeiling;
     private volatile ByteSizeValue childAllocation;
 
@@ -51,16 +50,11 @@ public class ArrowBufferPoolRegistry {
         // Snapshot initial values from the registered defaults so the first PUT sees a coherent
         // settings view. Subsequent listener fires update only the field that changed.
         this.maxNativeAllocation = clusterSettings.get(ParquetSettings.MAX_NATIVE_ALLOCATION);
-        this.minNativeAllocation = clusterSettings.get(ParquetSettings.MIN_NATIVE_ALLOCATION);
         this.maxNativeAllocationCeiling = clusterSettings.get(ParquetSettings.MAX_NATIVE_ALLOCATION_CEILING);
         this.childAllocation = clusterSettings.get(ParquetSettings.CHILD_ALLOCATION);
 
         clusterSettings.addSettingsUpdateConsumer(ParquetSettings.MAX_NATIVE_ALLOCATION, v -> {
             this.maxNativeAllocation = v;
-            applyToAllPools();
-        });
-        clusterSettings.addSettingsUpdateConsumer(ParquetSettings.MIN_NATIVE_ALLOCATION, v -> {
-            this.minNativeAllocation = v;
             applyToAllPools();
         });
         clusterSettings.addSettingsUpdateConsumer(ParquetSettings.MAX_NATIVE_ALLOCATION_CEILING, v -> {
@@ -120,7 +114,6 @@ public class ArrowBufferPoolRegistry {
     private Settings currentSettings() {
         return Settings.builder()
             .put(ParquetSettings.MAX_NATIVE_ALLOCATION.getKey(), maxNativeAllocation)
-            .put(ParquetSettings.MIN_NATIVE_ALLOCATION.getKey(), minNativeAllocation.getStringRep())
             .put(ParquetSettings.MAX_NATIVE_ALLOCATION_CEILING.getKey(), maxNativeAllocationCeiling.getStringRep())
             .put(ParquetSettings.CHILD_ALLOCATION.getKey(), childAllocation.getStringRep())
             .build();

--- a/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/memory/ArrowBufferPoolRegistryTests.java
+++ b/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/memory/ArrowBufferPoolRegistryTests.java
@@ -1,0 +1,107 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.parquet.memory;
+
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.parquet.ParquetSettings;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.opensearch.common.settings.ClusterSettings.BUILT_IN_CLUSTER_SETTINGS;
+
+/**
+ * End-to-end test that a cluster-settings PUT propagates through {@link ArrowBufferPoolRegistry}
+ * to live {@link ArrowBufferPool} instances. We construct a real {@link ClusterSettings} so the
+ * test exercises the actual listener wiring, not a mock.
+ */
+public class ArrowBufferPoolRegistryTests extends OpenSearchTestCase {
+
+    private ClusterSettings buildClusterSettings(Settings nodeSettings) {
+        Set<org.opensearch.common.settings.Setting<?>> all = new HashSet<>(BUILT_IN_CLUSTER_SETTINGS);
+        all.add(ParquetSettings.MAX_NATIVE_ALLOCATION);
+        all.add(ParquetSettings.MIN_NATIVE_ALLOCATION);
+        all.add(ParquetSettings.MAX_NATIVE_ALLOCATION_CEILING);
+        all.add(ParquetSettings.CHILD_ALLOCATION);
+        return new ClusterSettings(nodeSettings, all);
+    }
+
+    public void testPutOnMaxNativeAllocationUpdatesRegisteredPool() {
+        Settings nodeSettings = Settings.builder()
+            .put(ParquetSettings.MAX_NATIVE_ALLOCATION.getKey(), "8mb")
+            .put(ParquetSettings.CHILD_ALLOCATION.getKey(), "2mb")
+            .build();
+        ClusterSettings clusterSettings = buildClusterSettings(nodeSettings);
+        ArrowBufferPoolRegistry registry = new ArrowBufferPoolRegistry(clusterSettings);
+
+        try (ArrowBufferPool pool = new ArrowBufferPool(nodeSettings)) {
+            registry.register(pool);
+            assertEquals(1, registry.trackedPoolCount());
+            assertEquals(8L * 1024 * 1024, pool.getRootLimit());
+
+            // Simulate an operator PUT to the cluster settings API.
+            clusterSettings.applySettings(Settings.builder().put(ParquetSettings.MAX_NATIVE_ALLOCATION.getKey(), "32mb").build());
+
+            assertEquals("PUT must propagate through registry to the live pool", 32L * 1024 * 1024, pool.getRootLimit());
+        }
+    }
+
+    public void testPutOnChildAllocationUpdatesPool() {
+        Settings nodeSettings = Settings.builder()
+            .put(ParquetSettings.MAX_NATIVE_ALLOCATION.getKey(), "8mb")
+            .put(ParquetSettings.CHILD_ALLOCATION.getKey(), "2mb")
+            .build();
+        ClusterSettings clusterSettings = buildClusterSettings(nodeSettings);
+        ArrowBufferPoolRegistry registry = new ArrowBufferPoolRegistry(clusterSettings);
+
+        try (ArrowBufferPool pool = new ArrowBufferPool(nodeSettings)) {
+            registry.register(pool);
+            assertEquals(2L * 1024 * 1024, pool.getMaxChildAllocation());
+
+            clusterSettings.applySettings(Settings.builder().put(ParquetSettings.CHILD_ALLOCATION.getKey(), "4mb").build());
+
+            assertEquals(4L * 1024 * 1024, pool.getMaxChildAllocation());
+        }
+    }
+
+    public void testUnregisteredPoolDoesNotReceiveUpdates() {
+        Settings nodeSettings = Settings.builder().put(ParquetSettings.MAX_NATIVE_ALLOCATION.getKey(), "8mb").build();
+        ClusterSettings clusterSettings = buildClusterSettings(nodeSettings);
+        ArrowBufferPoolRegistry registry = new ArrowBufferPoolRegistry(clusterSettings);
+
+        try (ArrowBufferPool pool = new ArrowBufferPool(nodeSettings)) {
+            registry.register(pool);
+            registry.unregister(pool);
+            assertEquals(0, registry.trackedPoolCount());
+
+            clusterSettings.applySettings(Settings.builder().put(ParquetSettings.MAX_NATIVE_ALLOCATION.getKey(), "32mb").build());
+
+            assertEquals("unregistered pool must not receive updates", 8L * 1024 * 1024, pool.getRootLimit());
+        }
+    }
+
+    public void testMultiplePoolsAllReceiveUpdate() {
+        Settings nodeSettings = Settings.builder().put(ParquetSettings.MAX_NATIVE_ALLOCATION.getKey(), "8mb").build();
+        ClusterSettings clusterSettings = buildClusterSettings(nodeSettings);
+        ArrowBufferPoolRegistry registry = new ArrowBufferPoolRegistry(clusterSettings);
+
+        try (ArrowBufferPool poolA = new ArrowBufferPool(nodeSettings); ArrowBufferPool poolB = new ArrowBufferPool(nodeSettings)) {
+            registry.register(poolA);
+            registry.register(poolB);
+            assertEquals(2, registry.trackedPoolCount());
+
+            clusterSettings.applySettings(Settings.builder().put(ParquetSettings.MAX_NATIVE_ALLOCATION.getKey(), "16mb").build());
+
+            assertEquals(16L * 1024 * 1024, poolA.getRootLimit());
+            assertEquals(16L * 1024 * 1024, poolB.getRootLimit());
+        }
+    }
+}

--- a/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/memory/ArrowBufferPoolRegistryTests.java
+++ b/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/memory/ArrowBufferPoolRegistryTests.java
@@ -28,7 +28,6 @@ public class ArrowBufferPoolRegistryTests extends OpenSearchTestCase {
     private ClusterSettings buildClusterSettings(Settings nodeSettings) {
         Set<org.opensearch.common.settings.Setting<?>> all = new HashSet<>(BUILT_IN_CLUSTER_SETTINGS);
         all.add(ParquetSettings.MAX_NATIVE_ALLOCATION);
-        all.add(ParquetSettings.MAX_NATIVE_ALLOCATION_CEILING);
         all.add(ParquetSettings.CHILD_ALLOCATION);
         return new ClusterSettings(nodeSettings, all);
     }

--- a/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/memory/ArrowBufferPoolRegistryTests.java
+++ b/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/memory/ArrowBufferPoolRegistryTests.java
@@ -28,7 +28,6 @@ public class ArrowBufferPoolRegistryTests extends OpenSearchTestCase {
     private ClusterSettings buildClusterSettings(Settings nodeSettings) {
         Set<org.opensearch.common.settings.Setting<?>> all = new HashSet<>(BUILT_IN_CLUSTER_SETTINGS);
         all.add(ParquetSettings.MAX_NATIVE_ALLOCATION);
-        all.add(ParquetSettings.MIN_NATIVE_ALLOCATION);
         all.add(ParquetSettings.MAX_NATIVE_ALLOCATION_CEILING);
         all.add(ParquetSettings.CHILD_ALLOCATION);
         return new ClusterSettings(nodeSettings, all);

--- a/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/memory/ArrowBufferPoolRegistryTests.java
+++ b/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/memory/ArrowBufferPoolRegistryTests.java
@@ -28,50 +28,30 @@ public class ArrowBufferPoolRegistryTests extends OpenSearchTestCase {
     private ClusterSettings buildClusterSettings(Settings nodeSettings) {
         Set<org.opensearch.common.settings.Setting<?>> all = new HashSet<>(BUILT_IN_CLUSTER_SETTINGS);
         all.add(ParquetSettings.MAX_NATIVE_ALLOCATION);
-        all.add(ParquetSettings.CHILD_ALLOCATION);
         return new ClusterSettings(nodeSettings, all);
     }
 
     public void testPutOnMaxNativeAllocationUpdatesRegisteredPool() {
-        Settings nodeSettings = Settings.builder()
-            .put(ParquetSettings.MAX_NATIVE_ALLOCATION.getKey(), "8mb")
-            .put(ParquetSettings.CHILD_ALLOCATION.getKey(), "2mb")
-            .build();
+        Settings nodeSettings = Settings.builder().put(ParquetSettings.MAX_NATIVE_ALLOCATION.getKey(), "80mb").build();
         ClusterSettings clusterSettings = buildClusterSettings(nodeSettings);
         ArrowBufferPoolRegistry registry = new ArrowBufferPoolRegistry(clusterSettings);
 
         try (ArrowBufferPool pool = new ArrowBufferPool(nodeSettings)) {
             registry.register(pool);
             assertEquals(1, registry.trackedPoolCount());
-            assertEquals(8L * 1024 * 1024, pool.getRootLimit());
+            assertEquals(80L * 1024 * 1024, pool.getRootLimit());
+            assertEquals("child cap is root / 10", 8L * 1024 * 1024, pool.getMaxChildAllocation());
 
             // Simulate an operator PUT to the cluster settings API.
-            clusterSettings.applySettings(Settings.builder().put(ParquetSettings.MAX_NATIVE_ALLOCATION.getKey(), "32mb").build());
+            clusterSettings.applySettings(Settings.builder().put(ParquetSettings.MAX_NATIVE_ALLOCATION.getKey(), "320mb").build());
 
-            assertEquals("PUT must propagate through registry to the live pool", 32L * 1024 * 1024, pool.getRootLimit());
-        }
-    }
-
-    public void testPutOnChildAllocationUpdatesPool() {
-        Settings nodeSettings = Settings.builder()
-            .put(ParquetSettings.MAX_NATIVE_ALLOCATION.getKey(), "8mb")
-            .put(ParquetSettings.CHILD_ALLOCATION.getKey(), "2mb")
-            .build();
-        ClusterSettings clusterSettings = buildClusterSettings(nodeSettings);
-        ArrowBufferPoolRegistry registry = new ArrowBufferPoolRegistry(clusterSettings);
-
-        try (ArrowBufferPool pool = new ArrowBufferPool(nodeSettings)) {
-            registry.register(pool);
-            assertEquals(2L * 1024 * 1024, pool.getMaxChildAllocation());
-
-            clusterSettings.applySettings(Settings.builder().put(ParquetSettings.CHILD_ALLOCATION.getKey(), "4mb").build());
-
-            assertEquals(4L * 1024 * 1024, pool.getMaxChildAllocation());
+            assertEquals("PUT must propagate through registry to the live pool", 320L * 1024 * 1024, pool.getRootLimit());
+            assertEquals("child cap follows root / 10 after PUT", 32L * 1024 * 1024, pool.getMaxChildAllocation());
         }
     }
 
     public void testUnregisteredPoolDoesNotReceiveUpdates() {
-        Settings nodeSettings = Settings.builder().put(ParquetSettings.MAX_NATIVE_ALLOCATION.getKey(), "8mb").build();
+        Settings nodeSettings = Settings.builder().put(ParquetSettings.MAX_NATIVE_ALLOCATION.getKey(), "80mb").build();
         ClusterSettings clusterSettings = buildClusterSettings(nodeSettings);
         ArrowBufferPoolRegistry registry = new ArrowBufferPoolRegistry(clusterSettings);
 
@@ -80,14 +60,14 @@ public class ArrowBufferPoolRegistryTests extends OpenSearchTestCase {
             registry.unregister(pool);
             assertEquals(0, registry.trackedPoolCount());
 
-            clusterSettings.applySettings(Settings.builder().put(ParquetSettings.MAX_NATIVE_ALLOCATION.getKey(), "32mb").build());
+            clusterSettings.applySettings(Settings.builder().put(ParquetSettings.MAX_NATIVE_ALLOCATION.getKey(), "320mb").build());
 
-            assertEquals("unregistered pool must not receive updates", 8L * 1024 * 1024, pool.getRootLimit());
+            assertEquals("unregistered pool must not receive updates", 80L * 1024 * 1024, pool.getRootLimit());
         }
     }
 
     public void testMultiplePoolsAllReceiveUpdate() {
-        Settings nodeSettings = Settings.builder().put(ParquetSettings.MAX_NATIVE_ALLOCATION.getKey(), "8mb").build();
+        Settings nodeSettings = Settings.builder().put(ParquetSettings.MAX_NATIVE_ALLOCATION.getKey(), "80mb").build();
         ClusterSettings clusterSettings = buildClusterSettings(nodeSettings);
         ArrowBufferPoolRegistry registry = new ArrowBufferPoolRegistry(clusterSettings);
 
@@ -96,10 +76,10 @@ public class ArrowBufferPoolRegistryTests extends OpenSearchTestCase {
             registry.register(poolB);
             assertEquals(2, registry.trackedPoolCount());
 
-            clusterSettings.applySettings(Settings.builder().put(ParquetSettings.MAX_NATIVE_ALLOCATION.getKey(), "16mb").build());
+            clusterSettings.applySettings(Settings.builder().put(ParquetSettings.MAX_NATIVE_ALLOCATION.getKey(), "160mb").build());
 
-            assertEquals(16L * 1024 * 1024, poolA.getRootLimit());
-            assertEquals(16L * 1024 * 1024, poolB.getRootLimit());
+            assertEquals(160L * 1024 * 1024, poolA.getRootLimit());
+            assertEquals(160L * 1024 * 1024, poolB.getRootLimit());
         }
     }
 }

--- a/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/memory/ArrowBufferPoolTests.java
+++ b/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/memory/ArrowBufferPoolTests.java
@@ -11,6 +11,7 @@ package org.opensearch.parquet.memory;
 import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.memory.BufferAllocator;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.parquet.ParquetSettings;
 import org.opensearch.test.OpenSearchTestCase;
 
 public class ArrowBufferPoolTests extends OpenSearchTestCase {
@@ -62,5 +63,79 @@ public class ArrowBufferPoolTests extends OpenSearchTestCase {
         // First close marked root as closed, so child.close() can't notify parent.
         // Release buffer directly — Arrow frees the underlying memory even if allocator is closed.
         buf.getReferenceManager().release();
+    }
+
+    public void testApplyLimitsUpdatesRootAndChildCaps() {
+        // Start with an absolute root size so percentage-resolution paths don't depend on host
+        // memory sizing. Floor 1mb keeps the resolver happy if a percentage is ever supplied.
+        Settings initial = Settings.builder()
+            .put(ParquetSettings.MAX_NATIVE_ALLOCATION.getKey(), "8mb")
+            .put(ParquetSettings.CHILD_ALLOCATION.getKey(), "2mb")
+            .build();
+        try (ArrowBufferPool pool = new ArrowBufferPool(initial)) {
+            assertEquals(8L * 1024 * 1024, pool.getRootLimit());
+            assertEquals(2L * 1024 * 1024, pool.getMaxChildAllocation());
+
+            BufferAllocator childA = pool.createChildAllocator("child-a");
+            assertEquals(2L * 1024 * 1024, childA.getLimit());
+
+            // Bump both limits at runtime.
+            Settings updated = Settings.builder()
+                .put(ParquetSettings.MAX_NATIVE_ALLOCATION.getKey(), "16mb")
+                .put(ParquetSettings.CHILD_ALLOCATION.getKey(), "4mb")
+                .build();
+            pool.applyLimits(updated);
+
+            assertEquals("root limit must be pushed to live RootAllocator", 16L * 1024 * 1024, pool.getRootLimit());
+            assertEquals("child cap field tracks new value", 4L * 1024 * 1024, pool.getMaxChildAllocation());
+            assertEquals("live child allocator must see new cap", 4L * 1024 * 1024, childA.getLimit());
+
+            // New children created after applyLimits must also see the new cap.
+            BufferAllocator childB = pool.createChildAllocator("child-b");
+            assertEquals(4L * 1024 * 1024, childB.getLimit());
+
+            childA.close();
+            childB.close();
+        }
+    }
+
+    public void testApplyLimitsLowerThanCurrentUsageDoesNotReclaim() {
+        Settings initial = Settings.builder()
+            .put(ParquetSettings.MAX_NATIVE_ALLOCATION.getKey(), "16mb")
+            .put(ParquetSettings.CHILD_ALLOCATION.getKey(), "4mb")
+            .build();
+        try (ArrowBufferPool pool = new ArrowBufferPool(initial)) {
+            BufferAllocator child = pool.createChildAllocator("c");
+            ArrowBuf buf = child.buffer(2L * 1024 * 1024); // 2mb in flight
+
+            // Lower the root limit below current allocated memory.
+            Settings tightened = Settings.builder()
+                .put(ParquetSettings.MAX_NATIVE_ALLOCATION.getKey(), "1mb")
+                .put(ParquetSettings.CHILD_ALLOCATION.getKey(), "1mb")
+                .build();
+            pool.applyLimits(tightened);
+
+            // Existing buffer is unaffected — Arrow does not reclaim already-allocated memory.
+            assertTrue(pool.getTotalAllocatedBytes() >= 2L * 1024 * 1024);
+            // Future allocations beyond the new cap fail.
+            expectThrows(org.apache.arrow.memory.OutOfMemoryException.class, () -> child.buffer(2L * 1024 * 1024));
+
+            buf.close();
+            child.close();
+        }
+    }
+
+    public void testApplyLimitsIsNoopWhenValuesUnchanged() {
+        Settings settings = Settings.builder()
+            .put(ParquetSettings.MAX_NATIVE_ALLOCATION.getKey(), "8mb")
+            .put(ParquetSettings.CHILD_ALLOCATION.getKey(), "2mb")
+            .build();
+        try (ArrowBufferPool pool = new ArrowBufferPool(settings)) {
+            long rootBefore = pool.getRootLimit();
+            long childBefore = pool.getMaxChildAllocation();
+            pool.applyLimits(settings);
+            assertEquals(rootBefore, pool.getRootLimit());
+            assertEquals(childBefore, pool.getMaxChildAllocation());
+        }
     }
 }

--- a/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/memory/ArrowBufferPoolTests.java
+++ b/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/memory/ArrowBufferPoolTests.java
@@ -66,33 +66,27 @@ public class ArrowBufferPoolTests extends OpenSearchTestCase {
     }
 
     public void testApplyLimitsUpdatesRootAndChildCaps() {
-        // Start with an absolute root size so percentage-resolution paths don't depend on host
-        // memory sizing. Floor 1mb keeps the resolver happy if a percentage is ever supplied.
-        Settings initial = Settings.builder()
-            .put(ParquetSettings.MAX_NATIVE_ALLOCATION.getKey(), "8mb")
-            .put(ParquetSettings.CHILD_ALLOCATION.getKey(), "2mb")
-            .build();
+        // Use absolute root sizes so resolution doesn't depend on host memory. The per-child cap
+        // is derived as root / 10, so an 80mb root yields an 8mb child.
+        Settings initial = Settings.builder().put(ParquetSettings.MAX_NATIVE_ALLOCATION.getKey(), "80mb").build();
         try (ArrowBufferPool pool = new ArrowBufferPool(initial)) {
-            assertEquals(8L * 1024 * 1024, pool.getRootLimit());
-            assertEquals(2L * 1024 * 1024, pool.getMaxChildAllocation());
+            assertEquals(80L * 1024 * 1024, pool.getRootLimit());
+            assertEquals(8L * 1024 * 1024, pool.getMaxChildAllocation());
 
             BufferAllocator childA = pool.createChildAllocator("child-a");
-            assertEquals(2L * 1024 * 1024, childA.getLimit());
+            assertEquals(8L * 1024 * 1024, childA.getLimit());
 
-            // Bump both limits at runtime.
-            Settings updated = Settings.builder()
-                .put(ParquetSettings.MAX_NATIVE_ALLOCATION.getKey(), "16mb")
-                .put(ParquetSettings.CHILD_ALLOCATION.getKey(), "4mb")
-                .build();
+            // Bump the root at runtime; child cap follows as root / 10.
+            Settings updated = Settings.builder().put(ParquetSettings.MAX_NATIVE_ALLOCATION.getKey(), "160mb").build();
             pool.applyLimits(updated);
 
-            assertEquals("root limit must be pushed to live RootAllocator", 16L * 1024 * 1024, pool.getRootLimit());
-            assertEquals("child cap field tracks new value", 4L * 1024 * 1024, pool.getMaxChildAllocation());
-            assertEquals("live child allocator must see new cap", 4L * 1024 * 1024, childA.getLimit());
+            assertEquals("root limit must be pushed to live RootAllocator", 160L * 1024 * 1024, pool.getRootLimit());
+            assertEquals("child cap derives from root / 10", 16L * 1024 * 1024, pool.getMaxChildAllocation());
+            assertEquals("live child allocator must see new cap", 16L * 1024 * 1024, childA.getLimit());
 
             // New children created after applyLimits must also see the new cap.
             BufferAllocator childB = pool.createChildAllocator("child-b");
-            assertEquals(4L * 1024 * 1024, childB.getLimit());
+            assertEquals(16L * 1024 * 1024, childB.getLimit());
 
             childA.close();
             childB.close();
@@ -100,19 +94,13 @@ public class ArrowBufferPoolTests extends OpenSearchTestCase {
     }
 
     public void testApplyLimitsLowerThanCurrentUsageDoesNotReclaim() {
-        Settings initial = Settings.builder()
-            .put(ParquetSettings.MAX_NATIVE_ALLOCATION.getKey(), "16mb")
-            .put(ParquetSettings.CHILD_ALLOCATION.getKey(), "4mb")
-            .build();
+        Settings initial = Settings.builder().put(ParquetSettings.MAX_NATIVE_ALLOCATION.getKey(), "160mb").build();
         try (ArrowBufferPool pool = new ArrowBufferPool(initial)) {
             BufferAllocator child = pool.createChildAllocator("c");
-            ArrowBuf buf = child.buffer(2L * 1024 * 1024); // 2mb in flight
+            ArrowBuf buf = child.buffer(2L * 1024 * 1024); // 2mb in flight, well under the 16mb child cap
 
-            // Lower the root limit below current allocated memory.
-            Settings tightened = Settings.builder()
-                .put(ParquetSettings.MAX_NATIVE_ALLOCATION.getKey(), "1mb")
-                .put(ParquetSettings.CHILD_ALLOCATION.getKey(), "1mb")
-                .build();
+            // Lower the root limit. New child cap = 1mb (< current 2mb usage).
+            Settings tightened = Settings.builder().put(ParquetSettings.MAX_NATIVE_ALLOCATION.getKey(), "10mb").build();
             pool.applyLimits(tightened);
 
             // Existing buffer is unaffected — Arrow does not reclaim already-allocated memory.
@@ -126,10 +114,7 @@ public class ArrowBufferPoolTests extends OpenSearchTestCase {
     }
 
     public void testApplyLimitsIsNoopWhenValuesUnchanged() {
-        Settings settings = Settings.builder()
-            .put(ParquetSettings.MAX_NATIVE_ALLOCATION.getKey(), "8mb")
-            .put(ParquetSettings.CHILD_ALLOCATION.getKey(), "2mb")
-            .build();
+        Settings settings = Settings.builder().put(ParquetSettings.MAX_NATIVE_ALLOCATION.getKey(), "80mb").build();
         try (ArrowBufferPool pool = new ArrowBufferPool(settings)) {
             long rootBefore = pool.getRootLimit();
             long childBefore = pool.getMaxChildAllocation();


### PR DESCRIPTION
## Summary

  Adds configurable memory settings for the DataFusion and parquet sandbox
  plugins,
  replacing hardcoded heap-fraction defaults with non-heap percentages and
  floors,
  and wires the cluster-settings dynamic-update path through to the live native
  runtimes where the underlying APIs allow it.

  Mirrors the `indices.memory.index_buffer_size` / `min_index_buffer_size`
  pattern
  in `IndexingMemoryController` — the existing OpenSearch precedent for non-heap
  percentage memory settings — for the static resolution logic.

  ## Settings

  All eight settings register on the cluster and appear under
  `GET /_cluster/settings?include_defaults=true`. The "main" string settings
  accept either a percentage of non-heap memory
  (`totalPhysicalMemory − configuredMaxHeap`, e.g. `"25%"`) **or** an absolute
  byte
  size (e.g. `"10gb"`). When a percentage is supplied, the resolved value is
  floored by the `.min` companion. Validators reject malformed values
  (`"abc%"`, `"10xb"`) at PUT time.

  | Setting | Default | Dynamic? |
  | --- | --- | --- |
  | `datafusion.memory_pool_limit_bytes` | `15%` | ✅ |
  | `datafusion.memory_pool_limit.min` | `512mb` | ✅ | 
  | `datafusion.spill_memory_limit_bytes` | `50%` | ❌ static (NodeScope) |
  | `datafusion.spill_memory_limit.min` | `1gb` | ❌ static (NodeScope) |
  | `parquet.max_native_allocation` | `10%` | ✅ |
  | `parquet.min_native_allocation` | `512mb` | ✅ | 
  | `parquet.max_native_allocation_ceiling` | `8gb` (`-1` disables) | ✅ | 
  | `parquet.arrow.child_allocation` | `512mb` | ✅ | 

  ### Resolution logic (shared parser)

  if configured ends with "%":
      base = totalPhysicalMemory − configuredMaxHeap   // non-heap
      resolved = base × (percentage / 100)
      resolved = max(resolved, min)                     // floor
      if ceiling != -1: resolved = min(resolved, ceiling)
  else:
      resolved = parseBytes(configured)                 // floor / ceiling
  ignored

  ## How runtime updates flow

  ### DataFusion memory pool

  PUT /_cluster/settings { datafusion.memory_pool_limit_bytes: "40%" }
          │
          ▼
  ClusterSettings update consumer in DataFusionPlugin
          │
          ▼
  re-resolve against current min  →  resolveBytes(rawValue, floor)
          │
          ▼
  DataFusionService.setMemoryPoolLimit(newBytes)
          │
          ▼
  NativeBridge.df_set_memory_pool_limit  (FFM)
          │
          ▼
  DynamicLimitPool.set_limit (Rust, atomic)

  A second listener on `…limit.min` re-resolves the current raw limit against
  the
  new floor and goes through the same path.

  ### Parquet Arrow allocator

  PUT /_cluster/settings { parquet.max_native_allocation: "32mb" }
          │
          ▼
  ArrowBufferPoolRegistry  (one per node, owned by ParquetDataFormatPlugin)
          │     ── caches the four allocation values in volatile fields
          │        because clusterSettings.get(...) inside a listener still
          │        reads the previous lastSettingsApplied
          ▼
  applyToAllPools()  →  iterates a synchronized WeakHashMap of pools
          │
          ▼  (per pool)
  ArrowBufferPool.applyLimits(Settings)
          │
          ├──  RootAllocator.setLimit(newRoot)
          ├──  this.maxChildAllocation = newChild           // volatile
          └──  for each child in rootAllocator.getChildAllocators():
                  child.setLimit(newChild)

  Per-shard pools come and go (`ParquetIndexingEngine` is per-shard); the
  registry
  holds them weakly so closed pools drop out as the GC reclaims them. There is
  no
  `removeSettingsUpdateConsumer` API on `ClusterSettings`, so the listeners are
  registered once at the plugin level rather than per-pool.

  **Lowering a limit below current usage** is a no-op for already-allocated
  memory:
  Arrow's `setLimit` only rejects future allocations until in-flight buffers
  drain. Same model as the DataFusion memory pool. Documented on each setting.

  ## Why spill is static

  I traced the DataFusion `DiskManager` API: `max_temp_directory_size: u64` is a
  plain field, and the only setter (`set_arc_max_temp_directory_size`) requires
  `Arc::get_mut`, which fails the moment any query holds a strong reference to
  the runtime. There is no thread-safe runtime setter upstream. Marking it
  `Dynamic` would silently no-op for any non-trivial cluster, so I kept it
  NodeScope-only and documented why in the setting javadoc and in
  `DataFusionPluginSettingsTests.testSpillMemoryLimit{,Min}IsStatic`. If/when
  upstream offers an atomic setter we can flip it on with a small change.

  Dynamic — change at runtime:

  PUT /_cluster/settings
  {
    "persistent": {
      "datafusion.memory_pool_limit_bytes": "40%",
      "parquet.max_native_allocation": "4gb",
      "parquet.arrow.child_allocation": "512mb"
    }
  }

## Where the current defaults came from

  Setting: datafusion.memory_pool_limit_bytes
  Default: 15%
  Reasoning at the time: Mirrors IndexingMemoryController.INDEX_BUFFER_SIZE
    default (10% of heap there; 15% of non-heap here ≈ similar fraction of total RAM).
  ────────────────────────────────────────
  Setting: datafusion.memory_pool_limit.min
  Default: 512mb
  Reasoning at the time: Matches MIN_INDEX_BUFFER_SIZE_SETTING floor 48mb × ~10× (DataFusion needs more headroom for hash tables / sorts).
  ────────────────────────────────────────
  Setting: datafusion.spill_memory_limit_bytes
  Default: 50%
  Reasoning at the time: DataFusion's own example config uses 0.5 × memory_pool
  for spill. We exposed it as 50% of non-heap (= ~2× the pool default, since spill is additional on-disk budget).
  ────────────────────────────────────────
  Setting: parquet.max_native_allocation
  Default: 10%
  Reasoning at the time: Original hardcoded value before this PR — kept the same to avoid behavior change for existing deployments.
  ────────────────────────────────────────
  Setting: parquet.min_native_allocation
  Default: 512mb
  Reasoning at the time: Same reasoning as DF min.
  ────────────────────────────────────────
  Setting: parquet.max_native_allocation_ceiling
  Default: 8gb
  Reasoning at the time: Reasonable cap for Arrow buffers — past this, you're better off raising the Lucene heap.
  ────────────────────────────────────────
  Setting: parquet.arrow.child_allocation
  Default: 512mb
  Reasoning at the time: Each VSR ≈ 50k rows × ~10kb avg row = 250 MB. One round number above that.

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
