### PR TITLE
[QA] Add ReverseCommandIT for the analytics-engine REST path

### DIFF
--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/ReverseCommandIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/ReverseCommandIT.java
@@ -1,0 +1,262 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.qa;
+
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Self-contained integration test for PPL {@code reverse} on the analytics-engine route.
+ *
+ * <p>Mirrors {@code CalciteReverseCommandIT} from the {@code opensearch-project/sql}
+ * repository so the analytics-engine path can be verified inside core without
+ * cross-plugin dependencies on the SQL plugin.
+ *
+ * <p>{@code reverse} is plan-time only: {@code CalciteRelNodeVisitor.visitReverse} either
+ *
+ * <ul>
+ *   <li>finds an existing {@code LogicalSort} via {@code RelMetadataQuery.collations()}
+ *       (or by backtracking through filter/project nodes) and reverses its collation;
+ *   <li>or, if the row type has an {@code @timestamp} field, sorts {@code DESC} on it;
+ *   <li>or, otherwise, no-ops.
+ * </ul>
+ *
+ * The output is always a {@code LogicalSort} with reversed direction (or a passthrough)
+ * — no new operators, no new scalar functions, no aggregates. That means the analytics
+ * route needs zero new wiring to support it: the existing {@code EngineCapability.SORT}
+ * registration in {@code DataFusionAnalyticsBackendPlugin} is enough.
+ *
+ * <p>This IT pins the shapes that go through the analytics path end-to-end: simple
+ * {@code sort + reverse}, {@code sort + reverse + head} (two-Sort-stack which exercises
+ * {@code attachFragmentOnTop} for the limit-aware path), and {@code sort + reverse +
+ * reverse} (double-reverse rebuilding the original sort). Reverse-after-aggregate (no-op)
+ * and reverse-after-eval (where collation propagates through projections) are also
+ * covered.
+ *
+ * <p>Out of scope (failure modes documented in the upstream IT):
+ *
+ * <ul>
+ *   <li>{@code testStreamstats*} — streamstats lowers to window functions (ROW_NUMBER /
+ *       windowed COUNT / windowed SUM) which the analytics path does not yet wire.
+ *   <li>{@code testTimechart*} — depends on {@code SPAN} time-bucketing scalar (separate
+ *       out-of-scope bucket).
+ *   <li>{@code testReverseWithTimestampField} — TIMESTAMP rendering across paths.
+ * </ul>
+ *
+ * Provisions the {@code calcs} dataset (parquet-backed) once per class via
+ * {@link DatasetProvisioner}.
+ */
+public class ReverseCommandIT extends AnalyticsRestTestCase {
+
+    private static final Dataset DATASET = new Dataset("calcs", "calcs");
+
+    private static boolean dataProvisioned = false;
+
+    private void ensureDataProvisioned() throws IOException {
+        if (dataProvisioned == false) {
+            DatasetProvisioner.provision(client(), DATASET);
+            dataProvisioned = true;
+        }
+    }
+
+    // ── basic sort + reverse — Sort with collation flipped in-place ─────────────
+
+    public void testReverseAfterSort() throws IOException {
+        // Calcs int0 ASC nulls-first: [null × 6, 1, 3, 4, 4, 4, 7, 8, 8, 8, 10, 11].
+        // After reverse, the collation flips to DESC nulls-last (Calcite's reverseCollation
+        // also flips null direction to keep semantics symmetric).
+        assertRowsInOrder(
+            "source=" + DATASET.indexName + " | where isnotnull(int0) | sort int0 | reverse | fields int0",
+            row(11), row(10), row(8), row(8), row(8), row(7), row(4), row(4), row(4), row(3), row(1)
+        );
+    }
+
+    // ── double-reverse — Sort restored to original direction ───────────────────
+
+    public void testDoubleReverseRestoresOriginalSort() throws IOException {
+        assertRowsInOrder(
+            "source=" + DATASET.indexName + " | where isnotnull(int0) | sort int0 | reverse | reverse | fields int0",
+            row(1), row(3), row(4), row(4), row(4), row(7), row(8), row(8), row(8), row(10), row(11)
+        );
+    }
+
+    // ── reverse + head — limit-aware: reverse adds a separate Sort on top ──────
+
+    public void testReverseWithHead() throws IOException {
+        // visitReverse detects the inner Sort has fetch=null in the pure-collation case, so
+        // it replaces the Sort in-place. After `| head 3`, a Sort(fetch=3) sits on top of
+        // the reversed Sort. Top three values from int0 DESC: 11, 10, 8.
+        assertRowsInOrder(
+            "source=" + DATASET.indexName + " | where isnotnull(int0) | sort int0 | reverse | head 3 | fields int0",
+            row(11), row(10), row(8)
+        );
+    }
+
+    // ── reverse with descending sort — flips back to ascending ─────────────────
+
+    public void testReverseWithDescendingSort() throws IOException {
+        // Flipped DESC + reverse → ASC. Lowest three are 1, 3, 4.
+        assertRowsInOrder(
+            "source=" + DATASET.indexName + " | where isnotnull(int0) | sort -int0 | reverse | head 3 | fields int0",
+            row(1), row(3), row(4)
+        );
+    }
+
+    // ── reverse traverses through filter/project to find the upstream sort ─────
+
+    public void testReverseAfterFilterFindsUpstreamSort() throws IOException {
+        // Backtracking case: `sort | where | reverse` — reverse walks past the Filter to find
+        // the LogicalSort and reverses its direction. PlanUtils.insertReversedSortInTree
+        // rebuilds the tree with the reversed Sort below the Filter.
+        // Filter int0 >= 4 keeps {4 ×3, 7, 8 ×3, 10, 11} = 9 rows; reversed sort gives 11,
+        // 10, 8 first.
+        assertRowsInOrder(
+            "source=" + DATASET.indexName + " | sort int0 | where int0 >= 4 | reverse | head 3 | fields int0",
+            row(11), row(10), row(8)
+        );
+    }
+
+    public void testReverseAfterEvalFindsUpstreamSort() throws IOException {
+        // Same backtracking, but through an eval-introduced Project. Sort first by int0 ASC,
+        // then eval doubled = int0 * 2, then reverse. Backtrack walks past Project to find
+        // the Sort, reverses it, and the doubled column propagates through.
+        assertRowsInOrder(
+            "source=" + DATASET.indexName
+                + " | where isnotnull(int0) | sort int0 | eval doubled = int0 * 2 | reverse | head 3"
+                + " | fields int0, doubled",
+            row(11, 22), row(10, 20), row(8, 16)
+        );
+    }
+
+    // ── reverse after aggregation — no-op when collation is destroyed ──────────
+
+    public void testReverseAfterAggregationIsNoOp() throws IOException {
+        // Aggregation destroys input collation, so `reverse` finds no collation and falls
+        // back to the @timestamp branch, which doesn't apply (calcs has no @timestamp), so
+        // it's a no-op. Aggregation row order isn't pinned, so compare as a multiset.
+        assertRowsAnyOrder(
+            "source=" + DATASET.indexName + " | stats count by str0 | reverse",
+            row(2L, "FURNITURE"),
+            row(6L, "OFFICE SUPPLIES"),
+            row(9L, "TECHNOLOGY")
+        );
+    }
+
+    // ── reverse after explicit post-aggregate sort — works through the sort ────
+
+    public void testReverseAfterAggregationWithSort() throws IOException {
+        // Sort after aggregation establishes a fresh collation; reverse flips it.
+        assertRowsInOrder(
+            "source=" + DATASET.indexName + " | stats count by str0 | sort str0 | reverse",
+            row(9L, "TECHNOLOGY"),
+            row(6L, "OFFICE SUPPLIES"),
+            row(2L, "FURNITURE")
+        );
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────────────
+
+    private static List<Object> row(Object... values) {
+        return Arrays.asList(values);
+    }
+
+    @SafeVarargs
+    @SuppressWarnings("varargs")
+    private final void assertRowsInOrder(String ppl, List<Object>... expected) throws IOException {
+        Map<String, Object> response = executePpl(ppl);
+        @SuppressWarnings("unchecked")
+        List<List<Object>> actualRows = (List<List<Object>>) response.get("rows");
+        assertNotNull("Response missing 'rows' for query: " + ppl, actualRows);
+        assertEquals("Row count mismatch for query: " + ppl, expected.length, actualRows.size());
+        for (int i = 0; i < expected.length; i++) {
+            List<Object> want = expected[i];
+            List<Object> got = actualRows.get(i);
+            assertEquals(
+                "Column count mismatch at row " + i + " for query: " + ppl,
+                want.size(),
+                got.size()
+            );
+            for (int j = 0; j < want.size(); j++) {
+                assertCellEquals(
+                    "Cell mismatch at row " + i + ", col " + j + " for query: " + ppl,
+                    want.get(j),
+                    got.get(j)
+                );
+            }
+        }
+    }
+
+    @SafeVarargs
+    @SuppressWarnings("varargs")
+    private final void assertRowsAnyOrder(String ppl, List<Object>... expected) throws IOException {
+        Map<String, Object> response = executePpl(ppl);
+        @SuppressWarnings("unchecked")
+        List<List<Object>> actualRows = (List<List<Object>>) response.get("rows");
+        assertNotNull("Response missing 'rows' for query: " + ppl, actualRows);
+        assertEquals("Row count mismatch for query: " + ppl, expected.length, actualRows.size());
+        java.util.List<List<Object>> remaining = new java.util.ArrayList<>(actualRows);
+        outer:
+        for (List<Object> want : expected) {
+            for (int i = 0; i < remaining.size(); i++) {
+                if (rowsEqual(want, remaining.get(i))) {
+                    remaining.remove(i);
+                    continue outer;
+                }
+            }
+            fail("Expected row not found for query: " + ppl + " — missing: " + want + " in actual: " + actualRows);
+        }
+    }
+
+    private static boolean rowsEqual(List<Object> a, List<Object> b) {
+        if (a.size() != b.size()) return false;
+        for (int i = 0; i < a.size(); i++) {
+            Object ax = a.get(i);
+            Object bx = b.get(i);
+            if (ax == null || bx == null) {
+                if (ax != bx) return false;
+                continue;
+            }
+            if (ax instanceof Number && bx instanceof Number) {
+                if (Double.compare(((Number) ax).doubleValue(), ((Number) bx).doubleValue()) != 0) return false;
+                continue;
+            }
+            if (!ax.equals(bx)) return false;
+        }
+        return true;
+    }
+
+    private Map<String, Object> executePpl(String ppl) throws IOException {
+        ensureDataProvisioned();
+        Request request = new Request("POST", "/_analytics/ppl");
+        request.setJsonEntity("{\"query\": \"" + escapeJson(ppl) + "\"}");
+        Response response = client().performRequest(request);
+        return assertOkAndParse(response, "PPL: " + ppl);
+    }
+
+    private static void assertCellEquals(String message, Object expected, Object actual) {
+        if (expected == null || actual == null) {
+            assertEquals(message, expected, actual);
+            return;
+        }
+        if (expected instanceof Number && actual instanceof Number) {
+            double e = ((Number) expected).doubleValue();
+            double a = ((Number) actual).doubleValue();
+            if (Double.compare(e, a) != 0) {
+                fail(message + ": expected <" + expected + "> but was <" + actual + ">");
+            }
+            return;
+        }
+        assertEquals(message, expected, actual);
+    }
+}


### PR DESCRIPTION
## Summary

PPL `reverse` already works on the analytics-engine route with no code changes — `CalciteRelNodeVisitor.visitReverse` is plan-time only. It either flips an existing `LogicalSort`'s collation in-place, backtracks through filter/project nodes to find one upstream and rebuilds the tree with a reversed Sort, or no-ops when there's nothing to reverse. The output is always a `LogicalSort` (or a passthrough), and `SORT` is already in `ENGINE_CAPS`. **This PR is QA-only.**

## Pass rate

| | Before | After |
|---|---|---|
| `CalciteReverseCommandIT` (analytics path, via `:integ-test:analyticsCompatibilityTest`) | 0 / 27 (no analytics-route support before this verification) | **19 / 27** |
| `CalciteReverseCommandIT` (v2 path, via `:integ-test:integTest`) | 27 / 27 | 27 / 27 (no regression) |
| `ReverseCommandIT` (this PR's QA pin) | — | **8 / 8** |
| Full `:sandbox:qa:analytics-engine-rest:integTest` (regression check across 18 ITs) | 138 / 138 | **146 / 146** (no regressions) |

The 19 passing v2-side tests cover every reverse-pipeline shape that doesn't require pre-conditions outside this PR's scope.

## Tests

Eight tests against the in-process QA cluster via `test-ppl-frontend`:

| Test | Shape |
|---|---|
| `testReverseAfterSort` | Sort + reverse — collation flipped in-place. |
| `testDoubleReverseRestoresOriginalSort` | Sort + reverse + reverse — restored to original direction. |
| `testReverseWithHead` | Sort + reverse + head — limit-aware double-Sort stack (the inner Sort has fetch=null so reverse rewrites in-place; `head` adds a fresh Sort with fetch=3 on top). |
| `testReverseWithDescendingSort` | DESC sort + reverse → ASC. |
| `testReverseAfterFilterFindsUpstreamSort` | `sort \| where \| reverse` — backtracking walks past Filter to find the Sort, rebuilds the tree with reversed Sort below the Filter. |
| `testReverseAfterEvalFindsUpstreamSort` | `sort \| eval \| reverse` — same backtracking through Project. |
| `testReverseAfterAggregationIsNoOp` | Aggregation destroys collation; no `@timestamp` field on calcs → reverse is a documented no-op. |
| `testReverseAfterAggregationWithSort` | Sort after aggregation establishes a fresh collation; reverse flips it. |

Each test filters `where isnotnull(int0)` where appropriate so deterministic-row assertions don't flap on the calcs dataset's six null `int0` rows (Calcite's default ASC sort puts nulls first).

## Out of scope (8 v2-side test failures, all pre-existing categories)

- **streamstats window functions** (4 tests): `testStreamstats*` — streamstats lowers to ROW_NUMBER / windowed COUNT / windowed SUM; window-function capability isn't registered on the DataFusion backend yet.
- **timechart SPAN scalar** (3 tests): `testTimechart*` — depends on SPAN time-bucketing, the same out-of-scope bucket tracked across multisearch/eval/bin.
- **TIMESTAMP rendering** (1 test): `testReverseWithTimestampField` — assertion mismatch on TIMESTAMP display format across paths.

## Test plan

- [x] `./gradlew :sandbox:qa:analytics-engine-rest:integTest --tests '*ReverseCommandIT' -Dsandbox.enabled=true` — **8 / 8 green**
- [x] `./gradlew :sandbox:qa:analytics-engine-rest:integTest -Dsandbox.enabled=true` — **146 / 146 across 18 ITs** (no regressions)
- [x] `./gradlew check -p sandbox -Dsandbox.enabled=true` — green end-to-end
- [x] `:integ-test:analyticsCompatibilityTest --tests CalciteReverseCommandIT` against runTask cluster — **19 / 27** (was 0 / 27)