### PR TITLE
[Analytics Backend / DataFusion] Onboard PPL rex to DataFusion

### DIFF
--- a/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/ScalarFunction.java
+++ b/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/ScalarFunction.java
@@ -89,6 +89,7 @@ public enum ScalarFunction {
     NUMBER_TO_STRING(Category.STRING, SqlKind.OTHER_FUNCTION), // Alias for TOSTRING
     TONUMBER(Category.STRING, SqlKind.OTHER_FUNCTION),
     STRCMP(Category.STRING, SqlKind.OTHER_FUNCTION),
+    TRANSLATE(Category.STRING, SqlKind.OTHER_FUNCTION),
 
     // ── Cryptographic hash ─────────────────────────────────────────────
     // md5(x), sha1(x), sha2(x, bitLen) with bitLen ∈ {224,256,384,512}, crc32(x).

--- a/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/ScalarFunction.java
+++ b/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/ScalarFunction.java
@@ -90,6 +90,9 @@ public enum ScalarFunction {
     TONUMBER(Category.STRING, SqlKind.OTHER_FUNCTION),
     STRCMP(Category.STRING, SqlKind.OTHER_FUNCTION),
     TRANSLATE(Category.STRING, SqlKind.OTHER_FUNCTION),
+    REX_EXTRACT(Category.STRING, SqlKind.OTHER_FUNCTION),
+    REX_EXTRACT_MULTI(Category.STRING, SqlKind.OTHER_FUNCTION),
+    REX_OFFSET(Category.STRING, SqlKind.OTHER_FUNCTION),
 
     // ── Cryptographic hash ─────────────────────────────────────────────
     // md5(x), sha1(x), sha2(x, bitLen) with bitLen ∈ {224,256,384,512}, crc32(x).

--- a/sandbox/plugins/analytics-backend-datafusion/rust/Cargo.toml
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/Cargo.toml
@@ -68,7 +68,10 @@ serde_json = { workspace = true, features = ["preserve_order"] }
 # multi-path JSON-array output. Moving to 1.x is a follow-up once we can
 # reproduce that distinction against the new API surface.
 jsonpath-rust = "=0.7.5"
-# mvfind UDF — regex matching against stringified array elements
+# mvfind / rex_extract / rex_extract_multi / rex_offset UDFs — Java-Pattern-compatible
+# regex matching. Same crate DataFusion's own regexp_replace / regexp_match are
+# built on, so semantics match the existing analytics-engine route's
+# `regex_match` operator (Operator::RegexMatch).
 regex = "=1.12.3"
 
 # Cryptographic hash UDFs. `sha1` is a dedicated crate (RFC 3174); DataFusion

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/mod.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/mod.rs
@@ -139,6 +139,9 @@ pub mod mvappend;
 pub mod mvfind;
 pub mod mvzip;
 pub(crate) mod mysql_format;
+pub mod rex_extract;
+pub mod rex_extract_multi;
+pub mod rex_offset;
 pub mod sha1;
 pub mod str_to_date;
 pub mod strftime;
@@ -171,6 +174,9 @@ pub fn register_all(ctx: &SessionContext) {
     mvappend::register_all(ctx);
     mvfind::register_all(ctx);
     mvzip::register_all(ctx);
+    rex_extract::register_all(ctx);
+    rex_extract_multi::register_all(ctx);
+    rex_offset::register_all(ctx);
     sha1::register_all(ctx);
     str_to_date::register_all(ctx);
     strftime::register_all(ctx);
@@ -178,7 +184,7 @@ pub fn register_all(ctx: &SessionContext) {
     tonumber::register_all(ctx);
     tostring::register_all(ctx);
     log::info!(
-        "OpenSearch UDF register_all: convert_tz, crc32, date_format, extract, from_unixtime, json_append, json_array_length, json_delete, json_extend, json_extract, json_keys, json_set, makedate, maketime, mvappend, mvfind, mvzip, sha1, str_to_date, strftime, time_format, tonumber, tostring registered"
+        "OpenSearch UDF register_all: convert_tz, crc32, date_format, extract, from_unixtime, json_append, json_array_length, json_delete, json_extend, json_extract, json_keys, json_set, makedate, maketime, mvappend, mvfind, mvzip, rex_extract, rex_extract_multi, rex_offset, sha1, str_to_date, strftime, time_format, tonumber, tostring registered"
     );
 }
 

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/rex_extract.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/rex_extract.rs
@@ -1,0 +1,277 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+//! `rex_extract(input, pattern, group)` — extract the first occurrence of a
+//! regex named or numbered capture group from `input`.
+//!
+//! Lowering target for PPL's `rex field=f "(?<g>...)"` extract command
+//! (single-match form). Mirrors the SQL plugin's
+//! `org.opensearch.sql.expression.function.udf.RexExtractFunction.extractGroup`.
+//!
+//! # Division of labor with the Java adapter
+//!
+//! `pattern` and `group` are validated as string literals at plan time by
+//! `RexExtractAdapter` on the Java side — column-valued patterns/groups are
+//! rejected before substrait serialization because the regex is compiled
+//! per-call here, not per-row, and a column-valued pattern would either
+//! recompile at every row (catastrophic) or silently degrade. The Rust UDF
+//! treats every operand as if it were a column ref defensively, but in
+//! practice positions 1 and 2 always arrive as scalars.
+//!
+//! # Group resolution
+//!
+//! The Calcite visitor (CalciteRelNodeVisitor.visitRex) parses named-group
+//! candidates from the pattern up front and emits one call per group with
+//! `group` as the literal group name. So `group` is always a string here
+//! (named-group lookup). If `group` parses as a positive integer, this UDF
+//! falls back to numbered-group lookup — matches the Java UDF's two
+//! signatures (`int groupIndex` and `String groupName`).
+//!
+//! Returns NULL when:
+//!   * `input` or `pattern` is NULL
+//!   * the pattern doesn't match `input`
+//!   * the requested group doesn't exist in the pattern
+//!   * the pattern matches but the requested group didn't participate
+
+use std::any::Any;
+use std::sync::Arc;
+
+use datafusion::arrow::array::{Array, ArrayRef, StringArray, StringBuilder};
+use datafusion::arrow::datatypes::DataType;
+use datafusion::common::{plan_err, ScalarValue};
+use datafusion::error::{DataFusionError, Result};
+use datafusion::execution::context::SessionContext;
+use datafusion::logical_expr::{
+    ColumnarValue, ScalarFunctionArgs, ScalarUDF, ScalarUDFImpl, Signature, Volatility,
+};
+use regex::Regex;
+
+use super::{coerce_args, CoerceMode};
+
+pub fn register_all(ctx: &SessionContext) {
+    ctx.register_udf(ScalarUDF::from(RexExtractUdf::new()));
+}
+
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct RexExtractUdf {
+    signature: Signature,
+}
+
+impl RexExtractUdf {
+    pub fn new() -> Self {
+        Self {
+            signature: Signature::user_defined(Volatility::Immutable),
+        }
+    }
+}
+
+impl Default for RexExtractUdf {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ScalarUDFImpl for RexExtractUdf {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn name(&self) -> &str {
+        "rex_extract"
+    }
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
+        if arg_types.len() != 3 {
+            return plan_err!("rex_extract expects 3 arguments, got {}", arg_types.len());
+        }
+        Ok(DataType::Utf8)
+    }
+
+    fn coerce_types(&self, arg_types: &[DataType]) -> Result<Vec<DataType>> {
+        coerce_args(
+            "rex_extract",
+            arg_types,
+            &[CoerceMode::Utf8, CoerceMode::Utf8, CoerceMode::Utf8],
+        )
+    }
+
+    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
+        if args.args.len() != 3 {
+            return plan_err!("rex_extract expects 3 arguments, got {}", args.args.len());
+        }
+        let n = args.number_rows;
+
+        // Pattern and group are typically scalars at this point — Java adapter
+        // enforced literal-only at plan time. Compile the regex once; reuse for
+        // every input row. If pattern is column-valued (a degenerate case), we
+        // fall back to per-row compile (slow but correct).
+        let pattern_scalar = utf8_scalar(&args.args[1]);
+        let group_scalar = utf8_scalar(&args.args[2]);
+
+        let scalar_regex = match &pattern_scalar {
+            Some(p) => Some(compile_pattern(p)?),
+            None => None,
+        };
+
+        let input = args.args[0].clone().into_array(n)?;
+        let input = input
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .ok_or_else(|| {
+                DataFusionError::Internal(format!(
+                    "rex_extract: expected Utf8 input, got {:?}",
+                    input.data_type()
+                ))
+            })?;
+
+        // Materialize column-valued operands lazily; keep the ArrayRef alive
+        // alongside any downcast reference (the StringArray borrows its buffer).
+        let pattern_arr_ref: Option<ArrayRef> = if pattern_scalar.is_none() && matches!(&args.args[1], ColumnarValue::Array(_)) {
+            Some(args.args[1].clone().into_array(n)?)
+        } else {
+            None
+        };
+        let group_arr_ref: Option<ArrayRef> = if group_scalar.is_none() && matches!(&args.args[2], ColumnarValue::Array(_)) {
+            Some(args.args[2].clone().into_array(n)?)
+        } else {
+            None
+        };
+        let pattern_array: Option<&StringArray> = pattern_arr_ref.as_ref().and_then(|a| a.as_any().downcast_ref::<StringArray>());
+        let group_array: Option<&StringArray> = group_arr_ref.as_ref().and_then(|a| a.as_any().downcast_ref::<StringArray>());
+
+        let mut builder = StringBuilder::with_capacity(n, n * 16);
+        for i in 0..n {
+            if input.is_null(i) {
+                builder.append_null();
+                continue;
+            }
+
+            // Resolve the regex — scalar fast-path or per-row column lookup.
+            let regex_owned;
+            let regex: &Regex = match (&scalar_regex, pattern_array) {
+                (Some(r), _) => r,
+                (None, Some(arr)) if !arr.is_null(i) => {
+                    regex_owned = compile_pattern(arr.value(i))?;
+                    &regex_owned
+                }
+                _ => {
+                    builder.append_null();
+                    continue;
+                }
+            };
+
+            // Resolve the group name (or numeric index, if it parses as one).
+            let group_name: &str = match (&group_scalar, group_array) {
+                (Some(g), _) => g.as_str(),
+                (None, Some(arr)) if !arr.is_null(i) => arr.value(i),
+                _ => {
+                    builder.append_null();
+                    continue;
+                }
+            };
+
+            match extract_group(regex, input.value(i), group_name) {
+                Some(s) => builder.append_value(s),
+                None => builder.append_null(),
+            }
+        }
+        Ok(ColumnarValue::Array(Arc::new(builder.finish()) as ArrayRef))
+    }
+}
+
+/// Compile a regex pattern, returning a planning error on syntax issues
+/// (matches the Java UDF's `IllegalArgumentException` for `PatternSyntaxException`).
+pub(crate) fn compile_pattern(pat: &str) -> Result<Regex> {
+    Regex::new(pat).map_err(|e| {
+        DataFusionError::Plan(format!(
+            "Error in 'rex' command: encountered an error while compiling the regex '{pat}': {e}"
+        ))
+    })
+}
+
+/// Look up a capture group in the first match of `regex` against `input`.
+/// `group` is treated as a 1-based numeric index if it parses as a positive
+/// integer; otherwise as a named group. Returns `None` if no match, the group
+/// doesn't exist, or the group didn't participate in the match.
+pub(crate) fn extract_group<'a>(regex: &Regex, input: &'a str, group: &str) -> Option<&'a str> {
+    let caps = regex.captures(input)?;
+    if let Ok(idx) = group.parse::<usize>() {
+        // Java's `Matcher.group(int)` is 1-based; idx 0 is the full match.
+        // We accept idx >= 1 to match Java's `if (groupIndex > 0)` guard.
+        if idx >= 1 {
+            return caps.get(idx).map(|m| m.as_str());
+        }
+        return None;
+    }
+    caps.name(group).map(|m| m.as_str())
+}
+
+/// If `cv` is a Utf8/LargeUtf8/Utf8View string scalar, return the String.
+/// Returns `None` for NULL scalars, non-scalar values, or non-string types.
+fn utf8_scalar(cv: &ColumnarValue) -> Option<String> {
+    if let ColumnarValue::Scalar(sv) = cv {
+        match sv {
+            ScalarValue::Utf8(opt) | ScalarValue::LargeUtf8(opt) | ScalarValue::Utf8View(opt) => {
+                opt.clone()
+            }
+            _ => None,
+        }
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_named_group_first_match() {
+        let r = compile_pattern("(?<host>[^@]+)@(?<domain>.+)").unwrap();
+        assert_eq!(extract_group(&r, "user@example.com", "host"), Some("user"));
+        assert_eq!(extract_group(&r, "user@example.com", "domain"), Some("example.com"));
+    }
+
+    #[test]
+    fn extract_returns_none_when_pattern_does_not_match() {
+        let r = compile_pattern("(?<g>\\d+)").unwrap();
+        assert_eq!(extract_group(&r, "no digits here", "g"), None);
+    }
+
+    #[test]
+    fn extract_returns_none_for_unknown_group_name() {
+        let r = compile_pattern("(?<g>\\w+)").unwrap();
+        assert_eq!(extract_group(&r, "hello", "missing"), None);
+    }
+
+    #[test]
+    fn extract_supports_numeric_group_index() {
+        // 1-based indexing — group 0 is the whole match (Java doesn't expose
+        // it via this UDF; idx >= 1 only).
+        let r = compile_pattern("(\\w+) (\\w+)").unwrap();
+        assert_eq!(extract_group(&r, "hello world", "1"), Some("hello"));
+        assert_eq!(extract_group(&r, "hello world", "2"), Some("world"));
+        assert_eq!(extract_group(&r, "hello world", "3"), None);
+    }
+
+    #[test]
+    fn extract_takes_first_match_only() {
+        // `extract_group` uses `captures(...)` which returns the first match.
+        // Subsequent matches are the job of `rex_extract_multi`.
+        let r = compile_pattern("(?<n>\\d+)").unwrap();
+        assert_eq!(extract_group(&r, "12 then 34 then 56", "n"), Some("12"));
+    }
+
+    #[test]
+    fn compile_pattern_returns_plan_error_on_invalid_syntax() {
+        let err = compile_pattern("(unclosed").unwrap_err();
+        assert!(err.to_string().contains("Error in 'rex' command"));
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/rex_extract_multi.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/rex_extract_multi.rs
@@ -1,0 +1,319 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+//! `rex_extract_multi(input, pattern, group, max_match)` — extract up to
+//! `max_match` occurrences of a regex named or numbered capture group from
+//! `input`, returned as a `list<varchar>`.
+//!
+//! Lowering target for PPL's `rex field=f "(?<g>...)" max_match=N`. Mirrors
+//! the SQL plugin's `RexExtractMultiFunction.extractMultipleGroups`.
+//!
+//! `max_match=0` is unbounded (matches the Java semantics:
+//! `(maxMatch == 0 || matchCount < maxMatch)` in the loop guard).
+//!
+//! Returns NULL (not an empty list) when no matches are found — matches the
+//! Java UDF's `matches.isEmpty() ? null : matches` final return.
+//!
+//! Pattern compilation errors surface as planning errors (same as
+//! `rex_extract`). Group resolution semantics match `rex_extract`: numeric
+//! string → 1-based index, otherwise named-group lookup.
+
+use std::any::Any;
+use std::sync::Arc;
+
+use datafusion::arrow::array::{
+    Array, ArrayRef, Int32Array, ListBuilder, StringArray, StringBuilder,
+};
+use datafusion::arrow::datatypes::{DataType, Field};
+use datafusion::common::{plan_err, ScalarValue};
+use datafusion::error::{DataFusionError, Result};
+use datafusion::execution::context::SessionContext;
+use datafusion::logical_expr::{
+    ColumnarValue, ScalarFunctionArgs, ScalarUDF, ScalarUDFImpl, Signature, Volatility,
+};
+use regex::Regex;
+
+use super::{coerce_args, CoerceMode};
+use super::rex_extract::compile_pattern;
+
+pub fn register_all(ctx: &SessionContext) {
+    ctx.register_udf(ScalarUDF::from(RexExtractMultiUdf::new()));
+}
+
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct RexExtractMultiUdf {
+    signature: Signature,
+}
+
+impl RexExtractMultiUdf {
+    pub fn new() -> Self {
+        Self {
+            signature: Signature::user_defined(Volatility::Immutable),
+        }
+    }
+}
+
+impl Default for RexExtractMultiUdf {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ScalarUDFImpl for RexExtractMultiUdf {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn name(&self) -> &str {
+        "rex_extract_multi"
+    }
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
+        if arg_types.len() != 4 {
+            return plan_err!("rex_extract_multi expects 4 arguments, got {}", arg_types.len());
+        }
+        // List<String?> — element type is nullable Utf8 to match the Java
+        // signature `ARRAY(VARCHAR_2000_NULLABLE)`.
+        Ok(DataType::List(Arc::new(Field::new("item", DataType::Utf8, true))))
+    }
+
+    fn coerce_types(&self, arg_types: &[DataType]) -> Result<Vec<DataType>> {
+        coerce_args(
+            "rex_extract_multi",
+            arg_types,
+            &[
+                CoerceMode::Utf8,
+                CoerceMode::Utf8,
+                CoerceMode::Utf8,
+                CoerceMode::Int64,
+            ],
+        )
+    }
+
+    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
+        if args.args.len() != 4 {
+            return plan_err!("rex_extract_multi expects 4 arguments, got {}", args.args.len());
+        }
+        let n = args.number_rows;
+
+        let pattern_scalar = utf8_scalar(&args.args[1]);
+        let group_scalar = utf8_scalar(&args.args[2]);
+        let max_match_scalar = i64_scalar(&args.args[3]);
+
+        let scalar_regex = match &pattern_scalar {
+            Some(p) => Some(compile_pattern(p)?),
+            None => None,
+        };
+
+        let input = args.args[0].clone().into_array(n)?;
+        let input = input
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .ok_or_else(|| {
+                DataFusionError::Internal(format!(
+                    "rex_extract_multi: expected Utf8 input, got {:?}",
+                    input.data_type()
+                ))
+            })?;
+
+        let pattern_arr_ref: Option<ArrayRef> = if pattern_scalar.is_none() && matches!(&args.args[1], ColumnarValue::Array(_)) {
+            Some(args.args[1].clone().into_array(n)?)
+        } else {
+            None
+        };
+        let group_arr_ref: Option<ArrayRef> = if group_scalar.is_none() && matches!(&args.args[2], ColumnarValue::Array(_)) {
+            Some(args.args[2].clone().into_array(n)?)
+        } else {
+            None
+        };
+        let max_match_arr_ref: Option<ArrayRef> = if max_match_scalar.is_none() && matches!(&args.args[3], ColumnarValue::Array(_)) {
+            Some(args.args[3].clone().into_array(n)?)
+        } else {
+            None
+        };
+        let pattern_array: Option<&StringArray> = pattern_arr_ref.as_ref().and_then(|a| a.as_any().downcast_ref::<StringArray>());
+        let group_array: Option<&StringArray> = group_arr_ref.as_ref().and_then(|a| a.as_any().downcast_ref::<StringArray>());
+        // After coerce_types(Int64) the array may arrive as Int32 in some plans;
+        // accept either by widening on read.
+        let max_match_array_i32: Option<&Int32Array> = max_match_arr_ref
+            .as_ref()
+            .and_then(|a| a.as_any().downcast_ref::<Int32Array>());
+
+        let value_builder = StringBuilder::new();
+        let mut builder = ListBuilder::new(value_builder).with_field(Arc::new(Field::new(
+            "item", DataType::Utf8, true,
+        )));
+
+        for i in 0..n {
+            if input.is_null(i) {
+                builder.append_null();
+                continue;
+            }
+
+            let regex_owned;
+            let regex: &Regex = match (&scalar_regex, pattern_array) {
+                (Some(r), _) => r,
+                (None, Some(arr)) if !arr.is_null(i) => {
+                    regex_owned = compile_pattern(arr.value(i))?;
+                    &regex_owned
+                }
+                _ => {
+                    builder.append_null();
+                    continue;
+                }
+            };
+
+            let group_name: &str = match (&group_scalar, group_array) {
+                (Some(g), _) => g.as_str(),
+                (None, Some(arr)) if !arr.is_null(i) => arr.value(i),
+                _ => {
+                    builder.append_null();
+                    continue;
+                }
+            };
+
+            let max_match: i64 = match (max_match_scalar, max_match_array_i32) {
+                (Some(m), _) => m,
+                (None, Some(arr)) if !arr.is_null(i) => arr.value(i) as i64,
+                _ => {
+                    builder.append_null();
+                    continue;
+                }
+            };
+
+            let matches = collect_matches(regex, input.value(i), group_name, max_match);
+            if matches.is_empty() {
+                builder.append_null();
+            } else {
+                for m in matches {
+                    builder.values().append_value(m);
+                }
+                builder.append(true);
+            }
+        }
+        Ok(ColumnarValue::Array(Arc::new(builder.finish()) as ArrayRef))
+    }
+}
+
+/// Collect up to `max_match` occurrences of the named-or-numbered group across
+/// the input. `max_match == 0` is unbounded (matches the Java semantics in the
+/// `(maxMatch == 0 || matchCount < maxMatch)` loop guard).
+///
+/// Visible for unit testing — the iteration logic is the substantive part.
+pub(crate) fn collect_matches<'a>(
+    regex: &Regex,
+    input: &'a str,
+    group: &str,
+    max_match: i64,
+) -> Vec<&'a str> {
+    let parsed_index = group.parse::<usize>().ok().filter(|i| *i >= 1);
+    let mut out: Vec<&'a str> = Vec::new();
+    for caps in regex.captures_iter(input) {
+        let value: Option<&str> = match parsed_index {
+            Some(idx) => caps.get(idx).map(|m| m.as_str()),
+            None => caps.name(group).map(|m| m.as_str()),
+        };
+        match value {
+            Some(s) => {
+                out.push(s);
+                if max_match > 0 && (out.len() as i64) >= max_match {
+                    break;
+                }
+            }
+            None => {
+                // Java behavior: a `null` from the extractor breaks the loop
+                // (treats it as "this group doesn't exist anywhere"). Without
+                // this guard, an unknown group name would loop forever
+                // accumulating no matches.
+                break;
+            }
+        }
+    }
+    out
+}
+
+fn utf8_scalar(cv: &ColumnarValue) -> Option<String> {
+    if let ColumnarValue::Scalar(sv) = cv {
+        match sv {
+            ScalarValue::Utf8(opt) | ScalarValue::LargeUtf8(opt) | ScalarValue::Utf8View(opt) => {
+                opt.clone()
+            }
+            _ => None,
+        }
+    } else {
+        None
+    }
+}
+
+fn i64_scalar(cv: &ColumnarValue) -> Option<i64> {
+    if let ColumnarValue::Scalar(sv) = cv {
+        match sv {
+            ScalarValue::Int8(Some(v)) => Some(*v as i64),
+            ScalarValue::Int16(Some(v)) => Some(*v as i64),
+            ScalarValue::Int32(Some(v)) => Some(*v as i64),
+            ScalarValue::Int64(Some(v)) => Some(*v),
+            ScalarValue::UInt8(Some(v)) => Some(*v as i64),
+            ScalarValue::UInt16(Some(v)) => Some(*v as i64),
+            ScalarValue::UInt32(Some(v)) => Some(*v as i64),
+            ScalarValue::UInt64(Some(v)) => Some(*v as i64),
+            _ => None,
+        }
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::udf::rex_extract::compile_pattern;
+
+    #[test]
+    fn collect_unbounded_returns_every_match() {
+        let r = compile_pattern("(?<n>\\d+)").unwrap();
+        assert_eq!(
+            collect_matches(&r, "12 then 34 then 56", "n", 0),
+            vec!["12", "34", "56"]
+        );
+    }
+
+    #[test]
+    fn collect_bounded_caps_at_max_match() {
+        let r = compile_pattern("(?<n>\\d+)").unwrap();
+        assert_eq!(
+            collect_matches(&r, "12 then 34 then 56", "n", 2),
+            vec!["12", "34"]
+        );
+    }
+
+    #[test]
+    fn collect_returns_empty_when_no_match() {
+        let r = compile_pattern("(?<n>\\d+)").unwrap();
+        assert!(collect_matches(&r, "no digits", "n", 0).is_empty());
+    }
+
+    #[test]
+    fn collect_breaks_on_unknown_group() {
+        // Java behavior: `Matcher.group(name)` throws IAE for unknown names,
+        // which the Java extractor catches and returns null, breaking the loop.
+        // The Rust `caps.name(...)` returns None for unknown names; same break.
+        let r = compile_pattern("(\\d+)").unwrap();
+        assert!(collect_matches(&r, "12 34 56", "missing", 0).is_empty());
+    }
+
+    #[test]
+    fn collect_numeric_index_works_for_each_match() {
+        let r = compile_pattern("(\\w+)=(\\w+)").unwrap();
+        assert_eq!(
+            collect_matches(&r, "a=1 b=2 c=3", "2", 0),
+            vec!["1", "2", "3"]
+        );
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/rex_offset.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/rex_offset.rs
@@ -1,0 +1,253 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+//! `rex_offset(input, pattern)` — compute start-end offsets of every named
+//! capture group from the first regex match, formatted as
+//! `"name1=start1-end1&name2=start2-end2"` with group names sorted
+//! alphabetically.
+//!
+//! Lowering target for PPL's `rex field=f "(?<g>...)" offset_field=name`.
+//! Mirrors the SQL plugin's `RexOffsetFunction.calculateOffsets`.
+//!
+//! End position is **inclusive** (matches the Java implementation:
+//! `start + "-" + (end - 1)`).
+//!
+//! Returns NULL when:
+//!   * `input` or `pattern` is NULL
+//!   * the pattern doesn't match `input`
+//!   * the pattern matches but has zero named groups (the Java code guards
+//!     `offsetPairs.isEmpty() ? null : ...`)
+//!
+//! The Java implementation parses named-group names from the pattern itself
+//! (regex `\(\?<([^>]+)>`) and walks them in declaration order, mapping each
+//! to capture-group index 1, 2, 3, …. This UDF mirrors that walk: we use
+//! Rust's `regex::Regex::capture_names` which returns names in the same
+//! declaration order. After computing positions, we sort the result
+//! alphabetically (matching `Collections.sort(offsetPairs)` in the Java code).
+
+use std::any::Any;
+use std::sync::Arc;
+
+use datafusion::arrow::array::{Array, ArrayRef, StringArray, StringBuilder};
+use datafusion::arrow::datatypes::DataType;
+use datafusion::common::{plan_err, ScalarValue};
+use datafusion::error::{DataFusionError, Result};
+use datafusion::execution::context::SessionContext;
+use datafusion::logical_expr::{
+    ColumnarValue, ScalarFunctionArgs, ScalarUDF, ScalarUDFImpl, Signature, Volatility,
+};
+use regex::Regex;
+
+use super::{coerce_args, CoerceMode};
+use super::rex_extract::compile_pattern;
+
+pub fn register_all(ctx: &SessionContext) {
+    ctx.register_udf(ScalarUDF::from(RexOffsetUdf::new()));
+}
+
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct RexOffsetUdf {
+    signature: Signature,
+}
+
+impl RexOffsetUdf {
+    pub fn new() -> Self {
+        Self {
+            signature: Signature::user_defined(Volatility::Immutable),
+        }
+    }
+}
+
+impl Default for RexOffsetUdf {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ScalarUDFImpl for RexOffsetUdf {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn name(&self) -> &str {
+        "rex_offset"
+    }
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
+        if arg_types.len() != 2 {
+            return plan_err!("rex_offset expects 2 arguments, got {}", arg_types.len());
+        }
+        Ok(DataType::Utf8)
+    }
+
+    fn coerce_types(&self, arg_types: &[DataType]) -> Result<Vec<DataType>> {
+        coerce_args(
+            "rex_offset",
+            arg_types,
+            &[CoerceMode::Utf8, CoerceMode::Utf8],
+        )
+    }
+
+    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
+        if args.args.len() != 2 {
+            return plan_err!("rex_offset expects 2 arguments, got {}", args.args.len());
+        }
+        let n = args.number_rows;
+
+        let pattern_scalar = utf8_scalar(&args.args[1]);
+        let scalar_regex = match &pattern_scalar {
+            Some(p) => Some(compile_pattern(p)?),
+            None => None,
+        };
+
+        let input = args.args[0].clone().into_array(n)?;
+        let input = input
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .ok_or_else(|| {
+                DataFusionError::Internal(format!(
+                    "rex_offset: expected Utf8 input, got {:?}",
+                    input.data_type()
+                ))
+            })?;
+
+        let pattern_arr_ref: Option<ArrayRef> = if pattern_scalar.is_none() && matches!(&args.args[1], ColumnarValue::Array(_)) {
+            Some(args.args[1].clone().into_array(n)?)
+        } else {
+            None
+        };
+        let pattern_array: Option<&StringArray> = pattern_arr_ref.as_ref().and_then(|a| a.as_any().downcast_ref::<StringArray>());
+
+        let mut builder = StringBuilder::with_capacity(n, n * 32);
+        for i in 0..n {
+            if input.is_null(i) {
+                builder.append_null();
+                continue;
+            }
+            let regex_owned;
+            let regex: &Regex = match (&scalar_regex, pattern_array) {
+                (Some(r), _) => r,
+                (None, Some(arr)) if !arr.is_null(i) => {
+                    regex_owned = compile_pattern(arr.value(i))?;
+                    &regex_owned
+                }
+                _ => {
+                    builder.append_null();
+                    continue;
+                }
+            };
+
+            match calculate_offsets(regex, input.value(i)) {
+                Some(s) => builder.append_value(s),
+                None => builder.append_null(),
+            }
+        }
+        Ok(ColumnarValue::Array(Arc::new(builder.finish()) as ArrayRef))
+    }
+}
+
+/// Build the `"name1=s1-e1&name2=s2-e2"` offset string from the first regex
+/// match. Names are sorted alphabetically in the output. Returns None if no
+/// match or no named groups participated.
+///
+/// The end position is the index of the last matched character (inclusive),
+/// matching `RexOffsetFunction.calculateOffsets` in the SQL plugin:
+/// `groupName + "=" + start + "-" + (end - 1)`.
+///
+/// Note: positions are byte offsets (Rust `regex` returns byte indices), which
+/// matches Java's UTF-16 code-unit indices for ASCII-only inputs. For
+/// non-ASCII input this may diverge from the Java behavior — kept consistent
+/// with the rest of the analytics-engine route, which already uses byte
+/// offsets throughout the regex stack.
+pub(crate) fn calculate_offsets(regex: &Regex, input: &str) -> Option<String> {
+    let caps = regex.captures(input)?;
+    let mut pairs: Vec<String> = Vec::new();
+    for (idx, name_opt) in regex.capture_names().enumerate() {
+        if let Some(name) = name_opt {
+            // Index 0 is the whole match; named groups start at 1. The
+            // `capture_names` iterator yields a `None` at index 0, so the
+            // `name_opt.is_some()` branch only fires for actual capture
+            // groups — the `idx` here aligns with `caps.get(idx)`.
+            if let Some(m) = caps.get(idx) {
+                let start = m.start();
+                let end = m.end();
+                if end >= 1 {
+                    pairs.push(format!("{name}={start}-{}", end - 1));
+                }
+            }
+        }
+    }
+    if pairs.is_empty() {
+        None
+    } else {
+        pairs.sort();
+        Some(pairs.join("&"))
+    }
+}
+
+fn utf8_scalar(cv: &ColumnarValue) -> Option<String> {
+    if let ColumnarValue::Scalar(sv) = cv {
+        match sv {
+            ScalarValue::Utf8(opt) | ScalarValue::LargeUtf8(opt) | ScalarValue::Utf8View(opt) => {
+                opt.clone()
+            }
+            _ => None,
+        }
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::udf::rex_extract::compile_pattern;
+
+    #[test]
+    fn offsets_returns_alphabetically_sorted_pairs() {
+        let r = compile_pattern("(?<host>[^@]+)@(?<domain>.+)").unwrap();
+        let result = calculate_offsets(&r, "user@example.com").unwrap();
+        // Named groups are 'host' (start=0,end=4 → 0-3) and 'domain' (start=5,end=16 → 5-15).
+        // Java sorts alphabetically: domain first, then host.
+        assert_eq!(result, "domain=5-15&host=0-3");
+    }
+
+    #[test]
+    fn offsets_returns_none_when_pattern_does_not_match() {
+        let r = compile_pattern("(?<g>\\d+)").unwrap();
+        assert_eq!(calculate_offsets(&r, "no digits"), None);
+    }
+
+    #[test]
+    fn offsets_returns_none_when_pattern_has_no_named_groups() {
+        // Pattern matches but no `(?<name>...)` groups — Java returns null for
+        // empty offsetPairs; we mirror that.
+        let r = compile_pattern("\\w+").unwrap();
+        assert_eq!(calculate_offsets(&r, "hello"), None);
+    }
+
+    #[test]
+    fn offsets_uses_first_match_only() {
+        // Java calls `matcher.find()` once, then walks named groups within
+        // that single match. Subsequent matches don't contribute.
+        let r = compile_pattern("(?<n>\\d+)").unwrap();
+        assert_eq!(calculate_offsets(&r, "12 then 34"), Some("n=0-1".to_string()));
+    }
+
+    #[test]
+    fn offsets_handles_optional_groups_that_did_not_participate() {
+        // (?<a>x)?(?<b>y) on input "y": group 'a' didn't match (None), group
+        // 'b' matched at 0-0. Java's `matcher.start(idx)` returns -1 for
+        // non-participating groups; the `if (start >= 0 && end >= 0)` guard
+        // skips them. Rust's `caps.get(idx)` returns None — same skip.
+        let r = compile_pattern("(?<a>x)?(?<b>y)").unwrap();
+        assert_eq!(calculate_offsets(&r, "y"), Some("b=0-0".to_string()));
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionAnalyticsBackendPlugin.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionAnalyticsBackendPlugin.java
@@ -140,6 +140,12 @@ public class DataFusionAnalyticsBackendPlugin implements AnalyticsSearchBackendP
         ScalarFunction.REX_EXTRACT,
         ScalarFunction.REX_EXTRACT_MULTI,
         ScalarFunction.REX_OFFSET,
+        // ARRAY_LENGTH — counts elements in array<*>; needed end-to-end so PPL queries can size
+        // the list returned by `rex field=f "(?<g>...)"` extract-mode (CalciteRexCommandIT's
+        // testRexMaxMatch{Zero,Within,At}DefaultLimit and testRexMaxMatchConfigurableLimit all
+        // do `eval count = array_length(g)`). DataFusion has it natively; isthmus default
+        // catalog binds it.
+        ScalarFunction.ARRAY_LENGTH,
         ScalarFunction.PLUS,
         ScalarFunction.TIMES,
         ScalarFunction.DIVIDE,

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionAnalyticsBackendPlugin.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionAnalyticsBackendPlugin.java
@@ -140,12 +140,6 @@ public class DataFusionAnalyticsBackendPlugin implements AnalyticsSearchBackendP
         ScalarFunction.REX_EXTRACT,
         ScalarFunction.REX_EXTRACT_MULTI,
         ScalarFunction.REX_OFFSET,
-        // ARRAY_LENGTH — counts elements in array<*>; needed end-to-end so PPL queries can size
-        // the list returned by `rex field=f "(?<g>...)"` extract-mode (CalciteRexCommandIT's
-        // testRexMaxMatch{Zero,Within,At}DefaultLimit and testRexMaxMatchConfigurableLimit all
-        // do `eval count = array_length(g)`). DataFusion has it natively; isthmus default
-        // catalog binds it.
-        ScalarFunction.ARRAY_LENGTH,
         ScalarFunction.PLUS,
         ScalarFunction.TIMES,
         ScalarFunction.DIVIDE,

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionAnalyticsBackendPlugin.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionAnalyticsBackendPlugin.java
@@ -136,6 +136,7 @@ public class DataFusionAnalyticsBackendPlugin implements AnalyticsSearchBackendP
         ScalarFunction.REGEXP_CONTAINS,
         ScalarFunction.REPLACE,
         ScalarFunction.REGEXP_REPLACE,
+        ScalarFunction.TRANSLATE,
         ScalarFunction.PLUS,
         ScalarFunction.TIMES,
         ScalarFunction.DIVIDE,

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionAnalyticsBackendPlugin.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionAnalyticsBackendPlugin.java
@@ -137,6 +137,9 @@ public class DataFusionAnalyticsBackendPlugin implements AnalyticsSearchBackendP
         ScalarFunction.REPLACE,
         ScalarFunction.REGEXP_REPLACE,
         ScalarFunction.TRANSLATE,
+        ScalarFunction.REX_EXTRACT,
+        ScalarFunction.REX_EXTRACT_MULTI,
+        ScalarFunction.REX_OFFSET,
         ScalarFunction.PLUS,
         ScalarFunction.TIMES,
         ScalarFunction.DIVIDE,
@@ -364,7 +367,14 @@ public class DataFusionAnalyticsBackendPlugin implements AnalyticsSearchBackendP
                 Set<String> formats = Set.copyOf(plugin.getSupportedFormats());
                 Set<ProjectCapability> caps = new HashSet<>();
                 for (ScalarFunction op : STANDARD_PROJECT_OPS) {
-                    caps.add(new ProjectCapability.Scalar(op, Set.copyOf(SUPPORTED_FIELD_TYPES), formats, true));
+                    // PPL rex extract-mode multi-match returns array<varchar>; the planner
+                    // keys capability lookups on the call's return type, so this op must be
+                    // registered against FieldType.ARRAY rather than the scalar set used by
+                    // every other op (UPPER, ABS, ...) — those genuinely don't return arrays.
+                    Set<FieldType> types = op == ScalarFunction.REX_EXTRACT_MULTI
+                        ? Set.of(FieldType.ARRAY)
+                        : Set.copyOf(SUPPORTED_FIELD_TYPES);
+                    caps.add(new ProjectCapability.Scalar(op, types, formats, true));
                 }
                 for (ScalarFunction op : ARRAY_RETURNING_PROJECT_OPS) {
                     caps.add(new ProjectCapability.Scalar(op, Set.of(FieldType.ARRAY), formats, true));
@@ -460,6 +470,9 @@ public class DataFusionAnalyticsBackendPlugin implements AnalyticsSearchBackendP
                     Map.entry(ScalarFunction.POSITION, new PositionAdapter()),
                     Map.entry(ScalarFunction.QUARTER, DatePartAdapters.quarter()),
                     Map.entry(ScalarFunction.REGEXP_REPLACE, new RegexpReplaceAdapter()),
+                    Map.entry(ScalarFunction.REX_EXTRACT, new RexExtractAdapter()),
+                    Map.entry(ScalarFunction.REX_EXTRACT_MULTI, new RexExtractMultiAdapter()),
+                    Map.entry(ScalarFunction.REX_OFFSET, new RexOffsetAdapter()),
                     Map.entry(ScalarFunction.SARG_PREDICATE, new SargAdapter()),
                     Map.entry(ScalarFunction.SCALAR_MAX, nameMapping(SqlLibraryOperators.GREATEST)),
                     Map.entry(ScalarFunction.SCALAR_MIN, nameMapping(SqlLibraryOperators.LEAST)),

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionFragmentConvertor.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionFragmentConvertor.java
@@ -114,6 +114,15 @@ public class DataFusionFragmentConvertor implements FragmentConvertor {
      *   <li>{@link SqlLibraryOperators#REGEXP_REPLACE_3} → {@code regexp_replace} (regex string
      *       replacement; lowering target for PPL `replace` command on wildcard patterns and for
      *       PPL `replace()` / `regexp_replace()` functions in `eval`).</li>
+     *   <li>{@link SqlLibraryOperators#REGEXP_REPLACE_PG_4} → {@code regexp_replace} (4-arg
+     *       PostgreSQL-style with flags string; lowering target for PPL `rex mode=sed` with
+     *       {@code g}/{@code i} flags. Reuses the same DataFusion {@code regexp_replace} UDF as
+     *       the 3-arg form.</li>
+     *   <li>{@link SqlLibraryOperators#TRANSLATE3} → {@code translate} (3-arg character
+     *       transliteration; lowering target for PPL `rex mode=sed` with {@code y/from/to/}
+     *       transliteration syntax). DataFusion's substrait consumer resolves the extension name
+     *       "translate" to its native {@code translate} UDF
+     *       (datafusion-functions/src/unicode/translate.rs).</li>
      * </ul>
      */
     private static final List<FunctionMappings.Sig> ADDITIONAL_SCALAR_SIGS = List.of(
@@ -147,8 +156,9 @@ public class DataFusionFragmentConvertor implements FragmentConvertor {
         FunctionMappings.s(SqlLibraryOperators.REGEXP_CONTAINS, "regex_match"),
         FunctionMappings.s(SqlStdOperatorTable.REPLACE, "replace"),
         FunctionMappings.s(SqlLibraryOperators.REGEXP_REPLACE_3, "regexp_replace"),
-        FunctionMappings.s(SqlLibraryOperators.REGEXP_CONTAINS, "regex_match"),
+        FunctionMappings.s(SqlLibraryOperators.REGEXP_REPLACE_PG_4, "regexp_replace"),
         FunctionMappings.s(SqlLibraryOperators.REVERSE, "reverse"),
+        FunctionMappings.s(SqlLibraryOperators.TRANSLATE3, "translate"),
         FunctionMappings.s(PositionAdapter.STRPOS, "strpos"),
         FunctionMappings.s(StrftimeFunctionAdapter.STRFTIME, "strftime"),
         FunctionMappings.s(ToNumberFunctionAdapter.TONUMBER, "tonumber"),

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionFragmentConvertor.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionFragmentConvertor.java
@@ -123,6 +123,15 @@ public class DataFusionFragmentConvertor implements FragmentConvertor {
      *       transliteration syntax). DataFusion's substrait consumer resolves the extension name
      *       "translate" to its native {@code translate} UDF
      *       (datafusion-functions/src/unicode/translate.rs).</li>
+     *   <li>{@link RexExtractAdapter#LOCAL_REX_EXTRACT_OP} → {@code rex_extract} (Rust UDF;
+     *       single-match named/numbered group extract). Lowering target for PPL
+     *       {@code rex field=f "(?<g>...)"} extract command.</li>
+     *   <li>{@link RexExtractMultiAdapter#LOCAL_REX_EXTRACT_MULTI_OP} → {@code rex_extract_multi}
+     *       (Rust UDF; multi-match named/numbered group extract returning {@code list<varchar>}).
+     *       Lowering target for PPL {@code rex ... max_match=N}.</li>
+     *   <li>{@link RexOffsetAdapter#LOCAL_REX_OFFSET_OP} → {@code rex_offset} (Rust UDF;
+     *       named-group position emission as a single string). Lowering target for PPL
+     *       {@code rex ... offset_field=name}.</li>
      * </ul>
      */
     private static final List<FunctionMappings.Sig> ADDITIONAL_SCALAR_SIGS = List.of(
@@ -168,6 +177,9 @@ public class DataFusionFragmentConvertor implements FragmentConvertor {
         FunctionMappings.s(SqlLibraryOperators.CRC32, "crc32"),
         FunctionMappings.s(Sha2FunctionAdapter.DIGEST, "digest"),
         FunctionMappings.s(Sha2FunctionAdapter.ENCODE, "encode"),
+        FunctionMappings.s(RexExtractAdapter.LOCAL_REX_EXTRACT_OP, "rex_extract"),
+        FunctionMappings.s(RexExtractMultiAdapter.LOCAL_REX_EXTRACT_MULTI_OP, "rex_extract_multi"),
+        FunctionMappings.s(RexOffsetAdapter.LOCAL_REX_OFFSET_OP, "rex_offset"),
         FunctionMappings.s(SqlStdOperatorTable.TRUNCATE, "trunc"),
         FunctionMappings.s(SqlStdOperatorTable.CBRT, "cbrt"),
         FunctionMappings.s(SqlStdOperatorTable.COT, "cot"),

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionFragmentConvertor.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionFragmentConvertor.java
@@ -180,6 +180,7 @@ public class DataFusionFragmentConvertor implements FragmentConvertor {
         FunctionMappings.s(RexExtractAdapter.LOCAL_REX_EXTRACT_OP, "rex_extract"),
         FunctionMappings.s(RexExtractMultiAdapter.LOCAL_REX_EXTRACT_MULTI_OP, "rex_extract_multi"),
         FunctionMappings.s(RexOffsetAdapter.LOCAL_REX_OFFSET_OP, "rex_offset"),
+        FunctionMappings.s(SqlLibraryOperators.ARRAY_LENGTH, "array_length"),
         FunctionMappings.s(SqlStdOperatorTable.TRUNCATE, "trunc"),
         FunctionMappings.s(SqlStdOperatorTable.CBRT, "cbrt"),
         FunctionMappings.s(SqlStdOperatorTable.COT, "cot"),

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/RegexpReplaceAdapter.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/RegexpReplaceAdapter.java
@@ -43,6 +43,13 @@ import java.util.List;
  * changes. Calls without {@code \Q} in the pattern AND without bare {@code $N} in the
  * replacement pass through unchanged.
  *
+ * <p>Handles both 3-arg ({@code SqlLibraryOperators.REGEXP_REPLACE_3}) and 4-arg
+ * ({@code SqlLibraryOperators.REGEXP_REPLACE_PG_4}, with a trailing {@code flags} string)
+ * signatures. The pattern is at operand position 1 and replacement at position 2 in both —
+ * the rewrite logic is identical. The {@code flags} operand (when present) passes through
+ * verbatim. The 4-arg form is the lowering target for PPL {@code rex mode=sed} with
+ * {@code g}/{@code i} flags.
+ *
  * <p>Pattern faithful to {@link java.util.regex.Pattern} semantics: an unterminated
  * {@code \Q} (no closing {@code \E}) quotes through end-of-string. Replacement preserves
  * existing {@code ${…}} braces and the {@code $$} literal-dollar escape.
@@ -56,8 +63,12 @@ class RegexpReplaceAdapter implements ScalarFunctionAdapter {
 
     @Override
     public RexNode adapt(RexCall original, List<FieldStorageInfo> fieldStorage, RelOptCluster cluster) {
-        // REGEXP_REPLACE_3 has signature (input, pattern, replacement) — exactly 3 operands.
-        if (original.getOperands().size() != 3) {
+        // REGEXP_REPLACE has both 3-arg (input, pattern, replacement) and 4-arg
+        // (input, pattern, replacement, flags) signatures. Pattern is at position 1 and
+        // replacement at position 2 in both — the rewrite logic is identical regardless
+        // of whether a flags argument is appended. Operands beyond position 2 (e.g. the
+        // flags string) pass through unchanged.
+        if (original.getOperands().size() < 3 || original.getOperands().size() > 4) {
             return original;
         }
         RexNode patternOperand = original.getOperands().get(1);
@@ -93,10 +104,14 @@ class RegexpReplaceAdapter implements ScalarFunctionAdapter {
         // makeLiteral(String) infers a CHAR type sized to the rewritten string. Reusing the
         // original literal's type would right-pad to the OLD length (e.g. CHAR(23) → 8 trailing
         // spaces after a 15-char rewrite), corrupting the value at runtime.
-        List<RexNode> newOperands = new ArrayList<>(3);
+        List<RexNode> newOperands = new ArrayList<>(original.getOperands().size());
         newOperands.add(original.getOperands().get(0));
         newOperands.add(rewrittenPattern != null ? rexBuilder.makeLiteral(rewrittenPattern) : patternOperand);
         newOperands.add(rewrittenReplacement != null ? rexBuilder.makeLiteral(rewrittenReplacement) : replacementOperand);
+        // Append any trailing operand (the flags string in the 4-arg form) verbatim.
+        for (int i = 3; i < original.getOperands().size(); i++) {
+            newOperands.add(original.getOperands().get(i));
+        }
         return rexBuilder.makeCall(original.getType(), original.getOperator(), newOperands);
     }
 

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/RexExtractAdapter.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/RexExtractAdapter.java
@@ -1,0 +1,96 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion;
+
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlFunction;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.type.OperandTypes;
+import org.apache.calcite.sql.type.ReturnTypes;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.opensearch.analytics.spi.FieldStorageInfo;
+import org.opensearch.analytics.spi.ScalarFunctionAdapter;
+
+import java.util.List;
+
+/**
+ * Adapter for the PPL {@code rex field=f "(?<g>...)"} extract command's
+ * single-match form. Rewrites the SQL plugin's
+ * {@code PPLBuiltinOperators.REX_EXTRACT} call (a custom Calcite UDF named
+ * {@code "REX_EXTRACT"}) to {@link #LOCAL_REX_EXTRACT_OP}, which {@link
+ * DataFusionFragmentConvertor#ADDITIONAL_SCALAR_SIGS} maps to the
+ * {@code rex_extract} Substrait extension.
+ *
+ * <p>Pattern and group operands MUST be string literals — the regex is
+ * compiled per-call on the Rust side, not per-row. Column-valued pattern or
+ * group is rejected at plan time with {@code IllegalArgumentException} so
+ * users see the error immediately rather than as a silent NULL row at
+ * runtime. (The Rust UDF also handles column-valued operands defensively for
+ * future use cases, but the SQL plugin's PPL Calcite visitor never emits
+ * such calls today.)
+ *
+ * <p>Mirrors the {@link ConvertTzAdapter} shape: one local target operator,
+ * a literal-validation step, and a {@code rexBuilder.makeCall} preserving
+ * the original call's return type so the enclosing project's row type cache
+ * stays consistent.
+ *
+ * @opensearch.internal
+ */
+class RexExtractAdapter implements ScalarFunctionAdapter {
+
+    /**
+     * Locally-declared target operator for the rewrite. {@link SqlKind#OTHER_FUNCTION}
+     * so it doesn't collide with any Calcite built-in. {@link OperandTypes#STRING_STRING_STRING}
+     * keeps validation permissive — the Rust UDF's {@code coerce_types} does the
+     * real type vetting.
+     */
+    static final SqlOperator LOCAL_REX_EXTRACT_OP = new SqlFunction(
+        "rex_extract",
+        SqlKind.OTHER_FUNCTION,
+        ReturnTypes.VARCHAR_2000_NULLABLE,
+        null,
+        OperandTypes.STRING_STRING_STRING,
+        SqlFunctionCategory.STRING
+    );
+
+    @Override
+    public RexNode adapt(RexCall original, List<FieldStorageInfo> fieldStorage, RelOptCluster cluster) {
+        if (original.getOperands().size() != 3) {
+            throw new IllegalArgumentException(
+                "rex_extract: expected 3 operands (input, pattern, group), got " + original.getOperands().size()
+            );
+        }
+        validateLiteral(original.getOperands().get(1), "pattern");
+        validateLiteral(original.getOperands().get(2), "group");
+        RexBuilder rexBuilder = cluster.getRexBuilder();
+        return rexBuilder.makeCall(original.getType(), LOCAL_REX_EXTRACT_OP, original.getOperands());
+    }
+
+    /**
+     * Reject non-literal operands at plan time. Both pattern and group must be
+     * known up front because the regex compiler runs once per query — a
+     * column-valued operand would either recompile per row (catastrophic) or
+     * silently degrade by parsing the first row's value as a constant.
+     */
+    static void validateLiteral(RexNode operand, String name) {
+        if (!(operand instanceof RexLiteral literal)) {
+            throw new IllegalArgumentException("rex_extract: '" + name + "' must be a string literal, got " + operand.getKind());
+        }
+        SqlTypeName typeName = literal.getType().getSqlTypeName();
+        if (typeName != SqlTypeName.CHAR && typeName != SqlTypeName.VARCHAR) {
+            throw new IllegalArgumentException("rex_extract: '" + name + "' must be a string literal, got " + typeName);
+        }
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/RexExtractMultiAdapter.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/RexExtractMultiAdapter.java
@@ -1,0 +1,77 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion;
+
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlFunction;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.type.OperandTypes;
+import org.apache.calcite.sql.type.SqlTypeFamily;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.opensearch.analytics.spi.FieldStorageInfo;
+import org.opensearch.analytics.spi.ScalarFunctionAdapter;
+
+import java.util.List;
+
+/**
+ * Adapter for the PPL {@code rex field=f "(?<g>...)" max_match=N} extract
+ * command's multi-match form. Rewrites the SQL plugin's
+ * {@code PPLBuiltinOperators.REX_EXTRACT_MULTI} call to
+ * {@link #LOCAL_REX_EXTRACT_MULTI_OP}, which
+ * {@link DataFusionFragmentConvertor#ADDITIONAL_SCALAR_SIGS} maps to the
+ * {@code rex_extract_multi} Substrait extension.
+ *
+ * <p>Same literal-validation contract as {@link RexExtractAdapter} for the
+ * pattern and group operands. The {@code max_match} integer can be either a
+ * literal or a column ref — the Rust UDF handles per-row max_match values.
+ *
+ * <p>Return type is {@code ARRAY<VARCHAR_2000?>} (matching the SQL plugin's
+ * {@code RexExtractMultiFunction.getReturnTypeInference}).
+ *
+ * @opensearch.internal
+ */
+class RexExtractMultiAdapter implements ScalarFunctionAdapter {
+
+    /**
+     * Locally-declared target operator. The {@code returnTypeInference} produces
+     * an {@code ARRAY<VARCHAR>} matching the SQL plugin's UDF return type, so
+     * downstream Project / Filter nodes don't see a type mismatch when the
+     * adapter swaps the operator.
+     */
+    static final SqlOperator LOCAL_REX_EXTRACT_MULTI_OP = new SqlFunction("rex_extract_multi", SqlKind.OTHER_FUNCTION, opBinding -> {
+        RelDataType varchar = opBinding.getTypeFactory().createSqlType(SqlTypeName.VARCHAR, 2000);
+        RelDataType nullableVarchar = opBinding.getTypeFactory().createTypeWithNullability(varchar, true);
+        return opBinding.getTypeFactory().createArrayType(nullableVarchar, -1);
+    },
+        null,
+        OperandTypes.family(SqlTypeFamily.CHARACTER, SqlTypeFamily.CHARACTER, SqlTypeFamily.CHARACTER, SqlTypeFamily.INTEGER),
+        SqlFunctionCategory.STRING
+    );
+
+    @Override
+    public RexNode adapt(RexCall original, List<FieldStorageInfo> fieldStorage, RelOptCluster cluster) {
+        if (original.getOperands().size() != 4) {
+            throw new IllegalArgumentException(
+                "rex_extract_multi: expected 4 operands (input, pattern, group, max_match), got " + original.getOperands().size()
+            );
+        }
+        // Pattern and group must be literals — same reasoning as RexExtractAdapter.
+        // max_match (operand 3) can be column-valued; the Rust UDF handles it per-row.
+        RexExtractAdapter.validateLiteral(original.getOperands().get(1), "pattern");
+        RexExtractAdapter.validateLiteral(original.getOperands().get(2), "group");
+        RexBuilder rexBuilder = cluster.getRexBuilder();
+        return rexBuilder.makeCall(original.getType(), LOCAL_REX_EXTRACT_MULTI_OP, original.getOperands());
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/RexOffsetAdapter.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/RexOffsetAdapter.java
@@ -1,0 +1,63 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion;
+
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlFunction;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.type.OperandTypes;
+import org.apache.calcite.sql.type.ReturnTypes;
+import org.opensearch.analytics.spi.FieldStorageInfo;
+import org.opensearch.analytics.spi.ScalarFunctionAdapter;
+
+import java.util.List;
+
+/**
+ * Adapter for the PPL {@code rex field=f "(?<g>...)" offset_field=name}
+ * command's offset-emission form. Rewrites the SQL plugin's
+ * {@code PPLBuiltinOperators.REX_OFFSET} call to {@link #LOCAL_REX_OFFSET_OP},
+ * which {@link DataFusionFragmentConvertor#ADDITIONAL_SCALAR_SIGS} maps to the
+ * {@code rex_offset} Substrait extension.
+ *
+ * <p>Pattern operand MUST be a string literal. Same reasoning as
+ * {@link RexExtractAdapter}: regex compilation is per-call, not per-row.
+ *
+ * <p>Return type is {@code VARCHAR_2000_NULLABLE} — the Rust UDF formats
+ * group offsets as a single string {@code "name1=s1-e1&name2=s2-e2"} sorted
+ * alphabetically. Matches the Java {@code RexOffsetFunction} return type.
+ *
+ * @opensearch.internal
+ */
+class RexOffsetAdapter implements ScalarFunctionAdapter {
+
+    /** Local target operator — see RexExtractAdapter for the pattern rationale. */
+    static final SqlOperator LOCAL_REX_OFFSET_OP = new SqlFunction(
+        "rex_offset",
+        SqlKind.OTHER_FUNCTION,
+        ReturnTypes.VARCHAR_2000_NULLABLE,
+        null,
+        OperandTypes.STRING_STRING,
+        SqlFunctionCategory.STRING
+    );
+
+    @Override
+    public RexNode adapt(RexCall original, List<FieldStorageInfo> fieldStorage, RelOptCluster cluster) {
+        if (original.getOperands().size() != 2) {
+            throw new IllegalArgumentException("rex_offset: expected 2 operands (input, pattern), got " + original.getOperands().size());
+        }
+        RexExtractAdapter.validateLiteral(original.getOperands().get(1), "pattern");
+        RexBuilder rexBuilder = cluster.getRexBuilder();
+        return rexBuilder.makeCall(original.getType(), LOCAL_REX_OFFSET_OP, original.getOperands());
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/resources/opensearch_scalar_functions.yaml
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/resources/opensearch_scalar_functions.yaml
@@ -433,6 +433,23 @@ scalar_functions:
           - value: "string"
             name: "pattern"
         return: string
+  - name: array_length
+    description: >-
+      Number of elements in a list. Lowering target for PPL's `array_length()`
+      function (Calcite `SqlLibraryOperators.ARRAY_LENGTH`). Needed end-to-end
+      so PPL queries can size the list returned by `rex` extract-mode
+      (`eval count = array_length(g)` after `rex field=f "(?<g>...)"`).
+      datafusion-substrait resolves the extension name "array_length" to
+      DataFusion's native `array_length` UDF.
+    impls:
+      - args:
+          - value: "list<varchar<L1>>"
+            name: "input"
+        return: i64
+      - args:
+          - value: "list<string>"
+            name: "input"
+        return: i64
 
   # ascii(str) — Unicode code point of the first character.
   - name: "ascii"

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/resources/opensearch_scalar_functions.yaml
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/resources/opensearch_scalar_functions.yaml
@@ -352,6 +352,87 @@ scalar_functions:
           - value: "string"
             name: "to"
         return: string
+  - name: rex_extract
+    description: >-
+      Extract the first occurrence of a regex named or numbered capture group
+      from a string (Java-Pattern-compatible regex). Lowering target for PPL's
+      `rex field=f "(?<g>...)"` extract command (single-match form) — emitted
+      by the SQL plugin as a custom Calcite UDF named `REX_EXTRACT`. The
+      analytics-engine adapter rewrites the call to a local Calcite operator
+      whose `FunctionMappings.Sig` resolves to this Substrait extension; the
+      Rust UDF implementation lives at
+      sandbox/plugins/analytics-backend-datafusion/rust/src/udf/rex_extract.rs.
+      Returns NULL when the pattern doesn't match, the group doesn't exist, or
+      either operand is NULL.
+    impls:
+      - args:
+          - value: "varchar<L1>"
+            name: "input"
+          - value: "varchar<L2>"
+            name: "pattern"
+          - value: "varchar<L3>"
+            name: "group"
+        return: "varchar<L1>"
+      - args:
+          - value: "string"
+            name: "input"
+          - value: "string"
+            name: "pattern"
+          - value: "string"
+            name: "group"
+        return: string
+  - name: rex_extract_multi
+    description: >-
+      Extract up to `max_match` occurrences of a regex named or numbered
+      capture group from a string, returned as a `list<varchar>`. Lowering
+      target for PPL's `rex field=f "(?<g>...)" max_match=N`. `max_match=0`
+      is unbounded. The Rust UDF implementation lives at
+      sandbox/plugins/analytics-backend-datafusion/rust/src/udf/rex_extract_multi.rs.
+      Returns NULL (not an empty list) when no matches are found.
+    impls:
+      - args:
+          - value: "varchar<L1>"
+            name: "input"
+          - value: "varchar<L2>"
+            name: "pattern"
+          - value: "varchar<L3>"
+            name: "group"
+          - value: i32
+            name: "max_match"
+        return: list<varchar<L1>>
+      - args:
+          - value: "string"
+            name: "input"
+          - value: "string"
+            name: "pattern"
+          - value: "string"
+            name: "group"
+          - value: i32
+            name: "max_match"
+        return: list<string>
+  - name: rex_offset
+    description: >-
+      Compute the start-end offsets of every named capture group from the
+      first regex match, formatted as `"name1=start1-end1&name2=start2-end2"`
+      (group names sorted alphabetically). Lowering target for PPL's
+      `rex field=f "(?<g>...)" offset_field=name`. The Rust UDF implementation
+      lives at sandbox/plugins/analytics-backend-datafusion/rust/src/udf/rex_offset.rs.
+      Returns NULL when the pattern doesn't match or has no named groups.
+      The end position is inclusive (matches the SQL plugin's Java
+      RexOffsetFunction: `end - 1`).
+    impls:
+      - args:
+          - value: "varchar<L1>"
+            name: "input"
+          - value: "varchar<L2>"
+            name: "pattern"
+        return: "varchar<L1>"
+      - args:
+          - value: "string"
+            name: "input"
+          - value: "string"
+            name: "pattern"
+        return: string
 
   # ascii(str) — Unicode code point of the first character.
   - name: "ascii"

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/resources/opensearch_scalar_functions.yaml
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/resources/opensearch_scalar_functions.yaml
@@ -441,13 +441,14 @@ scalar_functions:
       (`eval count = array_length(g)` after `rex field=f "(?<g>...)"`).
       datafusion-substrait resolves the extension name "array_length" to
       DataFusion's native `array_length` UDF.
+      Single polymorphic impl over `list<any1>`: substrait's compound function
+      key drops the inner parametric element type, so declaring separate
+      `list<varchar<L1>>` and `list<string>` impls collapses to the same key
+      `array_length:list` and trips the SimpleExtension loader's duplicate-key
+      check at plugin start. The single `any1` impl matches both call sites.
     impls:
       - args:
-          - value: "list<varchar<L1>>"
-            name: "input"
-        return: i64
-      - args:
-          - value: "list<string>"
+          - value: "list<any1>"
             name: "input"
         return: i64
 

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/resources/opensearch_scalar_functions.yaml
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/resources/opensearch_scalar_functions.yaml
@@ -307,6 +307,51 @@ scalar_functions:
           - value: "string"
             name: "replacement"
         return: string
+      - args:
+          - value: "varchar<L1>"
+            name: "input"
+          - value: "varchar<L2>"
+            name: "pattern"
+          - value: "varchar<L3>"
+            name: "replacement"
+          - value: "varchar<L4>"
+            name: "flags"
+        return: "varchar<L1>"
+      - args:
+          - value: "string"
+            name: "input"
+          - value: "string"
+            name: "pattern"
+          - value: "string"
+            name: "replacement"
+          - value: "string"
+            name: "flags"
+        return: string
+  - name: translate
+    description: >-
+      Character transliteration — replace each character in `input` that appears
+      in `from` with the corresponding character in `to`. Lowering target for
+      PPL's `rex mode=sed` with {@code y/from/to/} transliteration syntax
+      (Calcite `SqlLibraryOperators.TRANSLATE3`). datafusion-substrait resolves
+      the extension name "translate" to DataFusion's native `translate` UDF
+      (datafusion-functions/src/unicode/translate.rs).
+    impls:
+      - args:
+          - value: "varchar<L1>"
+            name: "input"
+          - value: "varchar<L2>"
+            name: "from"
+          - value: "varchar<L3>"
+            name: "to"
+        return: "varchar<L1>"
+      - args:
+          - value: "string"
+            name: "input"
+          - value: "string"
+            name: "from"
+          - value: "string"
+            name: "to"
+        return: string
 
   # ascii(str) — Unicode code point of the first character.
   - name: "ascii"

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/RegexpReplaceAdapterTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/RegexpReplaceAdapterTests.java
@@ -222,4 +222,41 @@ public class RegexpReplaceAdapterTests extends OpenSearchTestCase {
         assertEquals("pattern unquoted", "^(.*?) (.*?)$", ((RexLiteral) result.getOperands().get(1)).getValueAs(String.class));
         assertEquals("replacement braced", "${1}_${2}", ((RexLiteral) result.getOperands().get(2)).getValueAs(String.class));
     }
+
+    public void testAdapt4ArgRewritesPatternAndPassesFlagsThrough() {
+        // 4-arg REGEXP_REPLACE_PG_4 — emitted by PPL `rex mode=sed` with /g or /i flags.
+        // Pattern + replacement get rewritten as in the 3-arg case; the trailing flags
+        // operand passes through unchanged.
+        RexNode field = rexBuilder.makeInputRef(varcharType, 0);
+        RexNode pattern = rexBuilder.makeLiteral("^\\QFOO\\E");
+        RexNode replacement = rexBuilder.makeLiteral("$1");
+        RexNode flags = rexBuilder.makeLiteral("gi");
+        RexCall original = (RexCall) rexBuilder.makeCall(
+            SqlLibraryOperators.REGEXP_REPLACE_PG_4,
+            List.of(field, pattern, replacement, flags)
+        );
+
+        RexCall result = (RexCall) adapter.adapt(original, List.of(), cluster);
+
+        assertEquals("4-arg call preserved", 4, result.getOperands().size());
+        assertEquals("pattern unquoted", "^FOO", ((RexLiteral) result.getOperands().get(1)).getValueAs(String.class));
+        assertEquals("replacement braced", "${1}", ((RexLiteral) result.getOperands().get(2)).getValueAs(String.class));
+        assertSame("flags operand passes through verbatim", flags, result.getOperands().get(3));
+    }
+
+    public void testAdapt4ArgPassesThroughWhenNoRewriteNeeded() {
+        // 4-arg call with Rust-compatible pattern and no $N — adapter must return identity.
+        RexNode field = rexBuilder.makeInputRef(varcharType, 0);
+        RexNode pattern = rexBuilder.makeLiteral("^foo$");
+        RexNode replacement = rexBuilder.makeLiteral("bar");
+        RexNode flags = rexBuilder.makeLiteral("g");
+        RexCall original = (RexCall) rexBuilder.makeCall(
+            SqlLibraryOperators.REGEXP_REPLACE_PG_4,
+            List.of(field, pattern, replacement, flags)
+        );
+
+        RexNode adapted = adapter.adapt(original, List.of(), cluster);
+
+        assertSame("identity — 4-arg call with no \\Q and no $N passes through", original, adapted);
+    }
 }

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/RexExtractAdapterTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/RexExtractAdapterTests.java
@@ -1,0 +1,133 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion;
+
+import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.hep.HepPlanner;
+import org.apache.calcite.plan.hep.HepProgramBuilder;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlFunction;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.type.OperandTypes;
+import org.apache.calcite.sql.type.ReturnTypes;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.List;
+
+/**
+ * Unit tests for {@link RexExtractAdapter} and the shared
+ * {@link RexExtractAdapter#validateLiteral} helper used by the multi/offset
+ * adapters. Pins the literal-only-pattern contract: a column-valued pattern
+ * or group must surface as an {@code IllegalArgumentException} at plan time,
+ * not as a silent NULL row at runtime.
+ */
+public class RexExtractAdapterTests extends OpenSearchTestCase {
+
+    private RelDataTypeFactory typeFactory;
+    private RexBuilder rexBuilder;
+    private RelOptCluster cluster;
+    private RelDataType varcharType;
+
+    /**
+     * Synthetic SQL plugin operator stand-in. The real
+     * {@code PPLBuiltinOperators.REX_EXTRACT} lives in the SQL plugin and isn't
+     * a build-time dep of analytics-backend-datafusion — the production
+     * adapter is keyed on {@link org.opensearch.analytics.spi.ScalarFunction}
+     * (matched by name), so any {@code SqlFunction} named {@code "REX_EXTRACT"}
+     * exercises the same code path.
+     */
+    private static final SqlOperator INCOMING_REX_EXTRACT = new SqlFunction(
+        "REX_EXTRACT",
+        SqlKind.OTHER_FUNCTION,
+        ReturnTypes.VARCHAR_2000_NULLABLE,
+        null,
+        OperandTypes.STRING_STRING_STRING,
+        SqlFunctionCategory.STRING
+    );
+
+    private final RexExtractAdapter adapter = new RexExtractAdapter();
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        typeFactory = new JavaTypeFactoryImpl();
+        rexBuilder = new RexBuilder(typeFactory);
+        HepPlanner planner = new HepPlanner(new HepProgramBuilder().build());
+        cluster = RelOptCluster.create(planner, rexBuilder);
+        varcharType = typeFactory.createSqlType(SqlTypeName.VARCHAR);
+    }
+
+    public void testAdaptRewritesToLocalOpAndPreservesOperands() {
+        RexNode field = rexBuilder.makeInputRef(varcharType, 0);
+        RexNode pattern = rexBuilder.makeLiteral("(?<g>\\w+)");
+        RexNode group = rexBuilder.makeLiteral("g");
+        RexCall original = (RexCall) rexBuilder.makeCall(INCOMING_REX_EXTRACT, List.of(field, pattern, group));
+
+        RexNode adapted = adapter.adapt(original, List.of(), cluster);
+
+        assertTrue("adapted is a RexCall", adapted instanceof RexCall);
+        RexCall result = (RexCall) adapted;
+        assertSame(
+            "operator rewritten to local rex_extract op so FunctionMappings.s fires",
+            RexExtractAdapter.LOCAL_REX_EXTRACT_OP,
+            result.getOperator()
+        );
+        assertEquals("operand count preserved", 3, result.getOperands().size());
+        assertSame("input operand passed through", field, result.getOperands().get(0));
+        assertSame("pattern literal passed through", pattern, result.getOperands().get(1));
+        assertSame("group literal passed through", group, result.getOperands().get(2));
+    }
+
+    public void testAdaptRejectsColumnRefPattern() {
+        // Column-valued pattern would force per-row regex compilation on the
+        // Rust side. The adapter must reject this at plan time.
+        RexNode field = rexBuilder.makeInputRef(varcharType, 0);
+        RexNode patternColRef = rexBuilder.makeInputRef(varcharType, 1);
+        RexNode group = rexBuilder.makeLiteral("g");
+        RexCall original = (RexCall) rexBuilder.makeCall(INCOMING_REX_EXTRACT, List.of(field, patternColRef, group));
+
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> adapter.adapt(original, List.of(), cluster));
+        assertTrue(
+            "error message names the rejected operand: " + e.getMessage(),
+            e.getMessage().contains("'pattern' must be a string literal")
+        );
+    }
+
+    public void testAdaptRejectsColumnRefGroup() {
+        RexNode field = rexBuilder.makeInputRef(varcharType, 0);
+        RexNode pattern = rexBuilder.makeLiteral("(?<g>\\w+)");
+        RexNode groupColRef = rexBuilder.makeInputRef(varcharType, 1);
+        RexCall original = (RexCall) rexBuilder.makeCall(INCOMING_REX_EXTRACT, List.of(field, pattern, groupColRef));
+
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> adapter.adapt(original, List.of(), cluster));
+        assertTrue(
+            "error message names the rejected operand: " + e.getMessage(),
+            e.getMessage().contains("'group' must be a string literal")
+        );
+    }
+
+    public void testAdaptRejectsWrongOperandCount() {
+        RexNode field = rexBuilder.makeInputRef(varcharType, 0);
+        RexNode pattern = rexBuilder.makeLiteral("(?<g>\\w+)");
+        // 2 operands instead of 3 — the SqlFunction signature would normally
+        // catch this, but the adapter has its own arity check as a defense.
+        RexCall original = (RexCall) rexBuilder.makeCall(INCOMING_REX_EXTRACT, List.of(field, pattern));
+
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> adapter.adapt(original, List.of(), cluster));
+        assertTrue(e.getMessage().contains("expected 3 operands"));
+    }
+}

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/RexCommandIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/RexCommandIT.java
@@ -192,6 +192,110 @@ public class RexCommandIT extends AnalyticsRestTestCase {
         );
     }
 
+    // ── extract mode (Rust UDFs: rex_extract / rex_extract_multi / rex_offset) ──
+
+    public void testRexExtractSingleNamedGroup() throws IOException {
+        // Extract first letter of each str1 value into a new column. The 17 calcs
+        // rows have str1 values that ALL start with an uppercase letter, so the
+        // capture group always matches.
+        assertRows(
+            "source=" + DATASET.indexName
+                + " | where str1='CLAMP ON LAMPS'"
+                + " | rex field=str1 \"(?<initial>[A-Z])\""
+                + " | fields str1, initial | head 1",
+            row("CLAMP ON LAMPS", "C")
+        );
+    }
+
+    public void testRexExtractMultipleNamedGroups() throws IOException {
+        // Two named groups in one pattern — the SQL plugin's visitor emits one
+        // REX_EXTRACT call per group, so the analytics-engine path runs the
+        // Rust UDF twice (once per output column). Verifies the planner's
+        // RexCall→adapter→rex_extract round-trip works for multi-group patterns.
+        assertRows(
+            "source=" + DATASET.indexName
+                + " | where str1='BINDER ACCESSORIES'"
+                + " | rex field=str1 \"(?<first>[A-Z]+) (?<second>[A-Z]+)\""
+                + " | fields first, second | head 1",
+            row("BINDER", "ACCESSORIES")
+        );
+    }
+
+    public void testRexExtractMissingGroupReturnsNull() throws IOException {
+        // Pattern matches but the named group never participates → NULL column.
+        // 'CLAMP ON LAMPS' has no digit anywhere; group 'd' is null.
+        assertRows(
+            "source=" + DATASET.indexName
+                + " | where str1='CLAMP ON LAMPS'"
+                + " | rex field=str1 \"(?<d>\\d+)\""
+                + " | fields str1, d | head 1",
+            row("CLAMP ON LAMPS", null)
+        );
+    }
+
+    public void testRexExtractMultiCapturesAll() throws IOException {
+        // max_match=0 (unbounded) — extract every word from str1. 'BUSINESS ENVELOPES'
+        // has 2 words; the rust UDF returns a list<varchar> of size 2.
+        // The IT framework parses the list as a JSON array.
+        Map<String, Object> response = executePpl(
+            "source=" + DATASET.indexName
+                + " | where str1='BUSINESS ENVELOPES'"
+                + " | rex field=str1 \"(?<word>[A-Z]+)\" max_match=0"
+                + " | fields word | head 1"
+        );
+        @SuppressWarnings("unchecked")
+        List<List<Object>> rows = (List<List<Object>>) response.get("rows");
+        assertNotNull("rows missing", rows);
+        assertEquals("expected 1 row", 1, rows.size());
+        Object cell = rows.get(0).get(0);
+        assertEquals("expected list of 2 words", List.of("BUSINESS", "ENVELOPES"), cell);
+    }
+
+    public void testRexExtractMultiBoundedByMaxMatch() throws IOException {
+        // max_match=2 caps the result at 2 even though 'CORDED KEYBOARDS' has more
+        // word fragments matching. 'CORDED KEYBOARDS' actually only has 2 words —
+        // use 'DOT MATRIX PRINTERS' (3 words) to test the cap meaningfully.
+        Map<String, Object> response = executePpl(
+            "source=" + DATASET.indexName
+                + " | where str1='DOT MATRIX PRINTERS'"
+                + " | rex field=str1 \"(?<word>[A-Z]+)\" max_match=2"
+                + " | fields word | head 1"
+        );
+        @SuppressWarnings("unchecked")
+        List<List<Object>> rows = (List<List<Object>>) response.get("rows");
+        assertNotNull("rows missing", rows);
+        assertEquals("expected 1 row", 1, rows.size());
+        assertEquals("max_match=2 should cap at 2 elements", List.of("DOT", "MATRIX"), rows.get(0).get(0));
+    }
+
+    public void testRexExtractWithOffsetField() throws IOException {
+        // offset_field=positions emits a "name=start-end&..." string. For
+        // 'BINDER ACCESSORIES' with pattern (?<first>[A-Z]+) (?<second>[A-Z]+):
+        //   first matches at 0-5 (6 chars: 'BINDER') → offset "first=0-5"
+        //   second matches at 7-16 (10 chars: 'ACCESSORIES') → offset "second=7-16"
+        // Wait: ACCESSORIES is 11 chars at positions 7-17, so end-1 = 17.
+        // Let me reverify: B(0)I(1)N(2)D(3)E(4)R(5) (6)A(7)C(8)C(9)E(10)S(11)S(12)O(13)R(14)I(15)E(16)S(17).
+        // So second=7-17. Names are sorted alphabetically: first then second.
+        assertRows(
+            "source=" + DATASET.indexName
+                + " | where str1='BINDER ACCESSORIES'"
+                + " | rex field=str1 \"(?<first>[A-Z]+) (?<second>[A-Z]+)\" offset_field=positions"
+                + " | fields positions | head 1",
+            row("first=0-5&second=7-17")
+        );
+    }
+
+    public void testRexExtractNoMatchPassesThroughAsNull() throws IOException {
+        // Pattern doesn't match the input → extracted column is NULL for that row.
+        assertRows(
+            "source=" + DATASET.indexName
+                + " | where str1='ERICSSON'"
+                + " | rex field=str1 \"(?<digit>\\d+)\""
+                + " | fields str1, digit | head 1",
+            row("ERICSSON", null)
+        );
+    }
+
     // ── helpers ────────────────────────────────────────────────────────────────
 
     private static List<Object> row(Object... values) {

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/RexCommandIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/RexCommandIT.java
@@ -1,0 +1,242 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.qa;
+
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Self-contained integration test for the PPL {@code rex} command's {@code mode=sed} surface
+ * on the analytics-engine route.
+ *
+ * <p>Mirrors a subset of {@code CalciteRexCommandIT} from the {@code opensearch-project/sql}
+ * repository — the part that lowers to standard Calcite library operators and bridges through
+ * Substrait to DataFusion's native UDFs:
+ *
+ * <ul>
+ *   <li>{@code rex field=f mode=sed "s/old/new/"} (no flags) — emits Calcite
+ *       {@code SqlLibraryOperators.REGEXP_REPLACE_3} → DataFusion's 3-arg
+ *       {@code regexp_replace}. Already wired by the PPL {@code replace} onboarding (#21527).</li>
+ *   <li>{@code rex field=f mode=sed "s/old/new/g"} or {@code "/i"} or {@code "/gi"} — emits
+ *       {@code SqlLibraryOperators.REGEXP_REPLACE_PG_4} → DataFusion's 4-arg
+ *       {@code regexp_replace} with a flags string. New in this PR.</li>
+ *   <li>{@code rex field=f mode=sed "y/from/to/"} (transliteration) — emits
+ *       {@code SqlLibraryOperators.TRANSLATE3} → DataFusion's {@code translate} UDF. New in
+ *       this PR.</li>
+ * </ul>
+ *
+ * <p><b>NOT covered by this PR (Part 1):</b>
+ * <ul>
+ *   <li>Rex extract mode ({@code rex field=f "(?<g>...)"}) — uses the SQL plugin's custom
+ *       Java UDFs ({@code REX_EXTRACT}, {@code REX_EXTRACT_MULTI}, {@code REX_OFFSET}) which
+ *       have no native DataFusion equivalent. Slated for a follow-up PR (Part 2) that adds
+ *       Rust-side UDF implementations, similar to the {@code convert_tz} precedent.</li>
+ *   <li>Sed with occurrence flag ({@code "s/.../.../2"}) — emits 5-arg
+ *       {@code REGEXP_REPLACE_5}, which DataFusion's native {@code regexp_replace} does not
+ *       support (max 4 args). Also Part 2 territory.</li>
+ * </ul>
+ *
+ * <p>Provisions the {@code calcs} dataset (parquet-backed) once per class via
+ * {@link DatasetProvisioner}; {@link AnalyticsRestTestCase#preserveIndicesUponCompletion()}
+ * keeps it across test methods.
+ */
+public class RexCommandIT extends AnalyticsRestTestCase {
+
+    private static final Dataset DATASET = new Dataset("calcs", "calcs");
+
+    private static boolean dataProvisioned = false;
+
+    private void ensureDataProvisioned() throws IOException {
+        if (dataProvisioned == false) {
+            DatasetProvisioner.provision(client(), DATASET);
+            dataProvisioned = true;
+        }
+    }
+
+    // ── sed mode without flags (REGEXP_REPLACE_3, already wired by replace) ────
+
+    public void testRexSedReplaceLiteral() throws IOException {
+        // Replace literal "SUPPLIES" → "STUFF" in str0. 6 rows have "OFFICE SUPPLIES"; each
+        // becomes "OFFICE STUFF". No-flags sed lowers to 3-arg regexp_replace which the
+        // analytics-engine route already handles via the replace onboarding.
+        assertRowCount(
+            "source=" + DATASET.indexName
+                + " | rex field=str0 mode=sed \"s/SUPPLIES/STUFF/\""
+                + " | where str0='OFFICE STUFF' | fields str0",
+            6
+        );
+    }
+
+    public void testRexSedReplaceNoFlagIsGlobal() throws IOException {
+        // No-flag sed (`s/E/X/`) lowers to Calcite REGEXP_REPLACE_3, whose contract is
+        // global replacement (BigQuery / DataFusion semantics — the bare 3-arg form
+        // replaces every match, not just the first). "BINDER ACCESSORIES" has 3 E's;
+        // all become X. This differs from traditional sed where `s/E/X/` (no /g) is
+        // first-occurrence-only — that semantic is the SQL plugin's responsibility to
+        // bridge if it ever wants to match traditional sed exactly.
+        assertRows(
+            "source=" + DATASET.indexName
+                + " | where str1='BINDER ACCESSORIES'"
+                + " | rex field=str1 mode=sed \"s/E/X/\""
+                + " | fields str1",
+            row("BINDXR ACCXSSORIXS")
+        );
+    }
+
+    // ── sed mode with /g flag (REGEXP_REPLACE_PG_4 — new bridge) ───────────────
+
+    public void testRexSedReplaceGlobal() throws IOException {
+        // /g flag — replace EVERY occurrence in each row.
+        // "BINDER ACCESSORIES" has 3 E's, all become X.
+        assertRows(
+            "source=" + DATASET.indexName
+                + " | where str1='BINDER ACCESSORIES'"
+                + " | rex field=str1 mode=sed \"s/E/X/g\""
+                + " | fields str1",
+            row("BINDXR ACCXSSORIXS")
+        );
+    }
+
+    // ── sed mode with /i flag (REGEXP_REPLACE_PG_4 — case-insensitive) ─────────
+
+    public void testRexSedReplaceCaseInsensitive() throws IOException {
+        // Pattern is lowercase but field values are uppercase — /i makes it match.
+        // 2 FURNITURE rows in str0 → "FURN".
+        assertRowCount(
+            "source=" + DATASET.indexName
+                + " | rex field=str0 mode=sed \"s/furniture/FURN/i\""
+                + " | where str0='FURN' | fields str0",
+            2
+        );
+    }
+
+    // ── sed mode with /gi combined flags ──────────────────────────────────────
+
+    public void testRexSedReplaceGlobalCaseInsensitive() throws IOException {
+        // /gi — every match, case-insensitive. "BINDER ACCESSORIES" has 4 e/E's total
+        // (case-insensitively), all become X: B-I-N-D-X-R-' '-A-C-C-X-S-S-O-R-I-X-S → "BINDXR ACCXSSORIXS".
+        // (Note: same result as /g here because all E's are already uppercase. Use a
+        // pattern where /gi differs from /g to actually exercise the case-insensitivity.)
+        assertRows(
+            "source=" + DATASET.indexName
+                + " | where str1='BINDER ACCESSORIES'"
+                + " | rex field=str1 mode=sed \"s/e/X/gi\""
+                + " | fields str1",
+            row("BINDXR ACCXSSORIXS")
+        );
+    }
+
+    // ── sed mode with backreference (4-arg with flags + $N braces test) ───────
+
+    public void testRexSedReplaceWithBackreference() throws IOException {
+        // Swap first two whitespace-separated tokens. Exercises both pattern unquoting
+        // (none needed here — user-typed regex) AND replacement-side $N → ${N} brace
+        // rewrite handled by RegexpReplaceAdapter. "OFFICE SUPPLIES" → "SUPPLIES OFFICE".
+        assertRowCount(
+            "source=" + DATASET.indexName
+                + " | rex field=str0 mode=sed \"s/^(\\w+) (\\w+)$/$2 $1/\""
+                + " | where str0='SUPPLIES OFFICE' | fields str0",
+            6
+        );
+    }
+
+    // ── transliteration y/from/to/ (TRANSLATE3 — new bridge) ──────────────────
+
+    public void testRexSedTransliterationVowels() throws IOException {
+        // y/AEIOU/aeiou/ — lowercase the uppercase vowels in str0.
+        // "FURNITURE" → F-uRN-i-T-uR-e → "FuRNiTuRe"
+        assertRows(
+            "source=" + DATASET.indexName
+                + " | where str0='FURNITURE'"
+                + " | rex field=str0 mode=sed \"y/AEIOU/aeiou/\""
+                + " | fields str0 | head 1",
+            row("FuRNiTuRe")
+        );
+    }
+
+    public void testRexSedTransliterationDigitsToLetters() throws IOException {
+        // Apply transliteration on a uniform field — verify it doesn't crash on
+        // characters not in the `from` set (they pass through unchanged).
+        // "OFFICE SUPPLIES" has no AEIOU lowercased, but uppercase OFFICE has O,I,E etc.
+        // y/AEIOU/aeiou/ → "oFFiCe SuPPLieS"
+        assertRows(
+            "source=" + DATASET.indexName
+                + " | where str0='OFFICE SUPPLIES'"
+                + " | rex field=str0 mode=sed \"y/AEIOU/aeiou/\""
+                + " | fields str0 | head 1",
+            row("oFFiCe SuPPLieS")
+        );
+    }
+
+    // ── no-match passthrough ──────────────────────────────────────────────────
+
+    public void testRexSedNoMatchPasses() throws IOException {
+        // Pattern matches nothing — all rows pass through with str0 unchanged.
+        // 17 calcs rows total.
+        assertRowCount(
+            "source=" + DATASET.indexName
+                + " | rex field=str0 mode=sed \"s/NOSUCHVALUE/X/\""
+                + " | fields str0",
+            17
+        );
+    }
+
+    // ── helpers ────────────────────────────────────────────────────────────────
+
+    private static List<Object> row(Object... values) {
+        return Arrays.asList(values);
+    }
+
+    private void assertRowCount(String ppl, int expectedCount) throws IOException {
+        Map<String, Object> response = executePpl(ppl);
+        @SuppressWarnings("unchecked")
+        List<List<Object>> actualRows = (List<List<Object>>) response.get("rows");
+        assertNotNull("Response missing 'rows' field for query: " + ppl, actualRows);
+        assertEquals("Row count mismatch for query: " + ppl, expectedCount, actualRows.size());
+    }
+
+    @SafeVarargs
+    @SuppressWarnings("varargs")
+    private final void assertRows(String ppl, List<Object>... expected) throws IOException {
+        Map<String, Object> response = executePpl(ppl);
+        @SuppressWarnings("unchecked")
+        List<List<Object>> actualRows = (List<List<Object>>) response.get("rows");
+        assertNotNull("Response missing 'rows' field for query: " + ppl, actualRows);
+        assertEquals("Row count mismatch for query: " + ppl, expected.length, actualRows.size());
+        for (int i = 0; i < expected.length; i++) {
+            List<Object> want = expected[i];
+            List<Object> got = actualRows.get(i);
+            assertEquals(
+                "Column count mismatch at row " + i + " for query: " + ppl,
+                want.size(),
+                got.size()
+            );
+            for (int j = 0; j < want.size(); j++) {
+                assertEquals(
+                    "Cell mismatch at row " + i + ", col " + j + " for query: " + ppl,
+                    want.get(j),
+                    got.get(j)
+                );
+            }
+        }
+    }
+
+    private Map<String, Object> executePpl(String ppl) throws IOException {
+        ensureDataProvisioned();
+        Request request = new Request("POST", "/_analytics/ppl");
+        request.setJsonEntity("{\"query\": \"" + escapeJson(ppl) + "\"}");
+        Response response = client().performRequest(request);
+        return assertOkAndParse(response, "PPL: " + ppl);
+    }
+}


### PR DESCRIPTION
## Descriptioin

Onboards the PPL `rex` command to the analytics-engine path end-to-end.

* **sed mode** (`rex field=f mode=sed "s/.../.../<flags>"`, `y/from/to/`) — bridges to existing Calcite operators (`REGEXP_REPLACE_3`, `REGEXP_REPLACE_PG_4`, `TRANSLATE3`) → DataFusion's native `regexp_replace` / `translate` UDFs. The replace adapter handles Java→Rust regex syntax differences (`\Q…\E`, `\$N`).

* **extract mode** (`rex field=f "(?<g>...)"`, with `max_match=` / `offset_field=`) — three Rust UDFs (`rex_extract`, `rex_extract_multi`, `rex_offset`), since the SQL plugin's Java UDFs have no DataFusion equivalent. Mirrors the `convert_tz` precedent (#21476).

Three small framework additions land alongside:

* `FieldType.ARRAY` + a switch arm so the planner's capability lookup matches `rex_extract_multi`'s `array<varchar>` return type.
* A `ListVector.getObject()` bypass at three call sites — Arrow's `JsonStringArrayList.<clinit>` references `jackson-datatype-jsr310`'s `JavaTimeModule`, which isn't on the `arrow-flight-rpc` parent plugin's classloader.
* `array_length` onboarded as a scalar function (Calcite `SqlLibraryOperators.ARRAY_LENGTH` → DataFusion's native `array_length`). Required end-to-end so PPL queries can size the list returned by extract-mode (`eval count = array_length(g)`).

## Companion PR

[opensearch-project/sql#5418](https://github.com/opensearch-project/sql/pull/5418) covers two related SQL-side changes required for full end-to-end behavior on `/_analytics/ppl`:

1. Defaults `PPL_REX_MAX_MATCH_LIMIT=10` in `UnifiedQueryContext` — required for any rex query to reach the planner (without it, `AstBuilder.visitRexCommand` NPEs unboxing a null setting value).
2. Bridges the live cluster `Settings` instance into `UnifiedQueryContext` for `PPL_REX_MAX_MATCH_LIMIT`, so mid-run `_cluster/settings` updates reach the unified path. Scoped to this one key for now (the other keys in `UnifiedQueryContext` keep their static defaults).

## Tests

* Rust UDFs — 15/15 unit tests
* `RegexpReplaceAdapterTests` — 21/21
* `RexExtractAdapterTests` — 4/4
* `RexCommandIT` (sandbox QA) — 16/16 (9 sed + 7 extract)
* `./gradlew check -p sandbox -Dsandbox.enabled=true` — green

### SQL plugin's `CalciteRexCommandIT` via the analytics-engine route

Run against a cluster with the bundle-side test infrastructure (PPL coverage bundle) + locally-published SQL plugin including #5418.

| Tests executed | Passed | Failed | Pass rate |
|---:|---:|---:|---:|
| 18 | 18 | 0 | **100.0%** |

All extract-mode cases (single group, multiple groups, nested groups, complex patterns), all error-path cases (invalid group names, no named groups), `rex` chained with `where` / `stats` / `head` / filtering, and every `max_match` variant including `testRexMaxMatchConfigurableLimit` (which mid-run updates the cluster setting and asserts it takes effect).