### PR TITLE
Exclude warm nodes from local shard limit count

### DIFF
--- a/server/src/main/java/org/opensearch/indices/ShardLimitValidator.java
+++ b/server/src/main/java/org/opensearch/indices/ShardLimitValidator.java
@@ -343,9 +343,14 @@ public class ShardLimitValidator {
                 state.getMetadata().getTotalOpenIndexShards(),
                 getShardLimitPerNode(),
                 getShardLimitPerCluster(),
-                state.getNodes().getDataNodes().size(),
+                getLocalOnlyDataNodeCount(state),
                 shardPool
             );
+    }
+
+    private static int getLocalOnlyDataNodeCount(ClusterState state) {
+        final Map<String, ?> warmNodes = state.getNodes().getWarmNodes();
+        return (int) state.getNodes().getDataNodes().keySet().stream().filter(nodeId -> warmNodes.containsKey(nodeId) == false).count();
     }
 
     // package-private for testing

--- a/server/src/test/java/org/opensearch/indices/ShardLimitValidatorTests.java
+++ b/server/src/test/java/org/opensearch/indices/ShardLimitValidatorTests.java
@@ -158,6 +158,55 @@ public class ShardLimitValidatorTests extends OpenSearchTestCase {
         assertFalse(errorMessage.isPresent());
     }
 
+    public void testLocalOnlyShardLimitCountsOnlyNonWarmDataNodes() {
+        final int totalDataNodes = randomIntBetween(3, 10);
+        final int warmNodes = randomIntBetween(1, totalDataNodes - 1);
+        final int localOnlyNodes = totalDataNodes - warmNodes;
+        final int maxShardsPerNode = randomIntBetween(1, 10);
+
+        final ClusterState state = createClusterStateWithDataAndWarmNodes(totalDataNodes, warmNodes);
+        final ShardLimitValidator shardLimitValidator = createTestShardLimitService(maxShardsPerNode, false);
+
+        final int shardsToAdd = (localOnlyNodes * maxShardsPerNode) + 1;
+        final Optional<String> errorMessage = shardLimitValidator.checkShardLimit(shardsToAdd, state, RoutingPool.LOCAL_ONLY);
+
+        assertTrue(errorMessage.isPresent());
+        assertEquals(
+            "this action would add ["
+                + shardsToAdd
+                + "] total LOCAL_ONLY shards, but this cluster currently has [0]/["
+                + (localOnlyNodes * maxShardsPerNode)
+                + "] maximum LOCAL_ONLY shards open",
+            errorMessage.get()
+        );
+    }
+
+    public void testRemoteCapableShardLimitStillCountsWarmNodes() {
+        final int totalDataNodes = randomIntBetween(3, 10);
+        final int warmNodes = randomIntBetween(1, totalDataNodes - 1);
+        final int maxRemoteCapableShardsPerNode = randomIntBetween(1, 10);
+
+        final Settings shardLimitSettings = Settings.builder()
+            .put(SETTING_CLUSTER_MAX_SHARDS_PER_NODE.getKey(), randomIntBetween(100, 1000))
+            .put(ShardLimitValidator.SETTING_CLUSTER_MAX_REMOTE_CAPABLE_SHARDS_PER_NODE.getKey(), maxRemoteCapableShardsPerNode)
+            .build();
+        final ShardLimitValidator shardLimitValidator = createTestShardLimitService(shardLimitSettings);
+        final ClusterState state = createClusterStateWithDataAndWarmNodes(totalDataNodes, warmNodes);
+
+        final int shardsToAdd = (warmNodes * maxRemoteCapableShardsPerNode) + 1;
+        final Optional<String> errorMessage = shardLimitValidator.checkShardLimit(shardsToAdd, state, RoutingPool.REMOTE_CAPABLE);
+
+        assertTrue(errorMessage.isPresent());
+        assertEquals(
+            "this action would add ["
+                + shardsToAdd
+                + "] total REMOTE_CAPABLE shards, but this cluster currently has [0]/["
+                + (warmNodes * maxRemoteCapableShardsPerNode)
+                + "] maximum REMOTE_CAPABLE shards open",
+            errorMessage.get()
+        );
+    }
+
     /**
      * This test validates that system index creation succeeds
      * even though it exceeds the cluster max shard limit
@@ -616,6 +665,32 @@ public class ShardLimitValidatorTests extends OpenSearchTestCase {
             closedIndexShards,
             closedIndexReplicas
         );
+    }
+
+    private static ClusterState createClusterStateWithDataAndWarmNodes(int totalDataNodes, int warmNodes) {
+        assertTrue("warm node count must be <= total data node count", warmNodes <= totalDataNodes);
+
+        final Map<String, DiscoveryNode> dataNodes = new HashMap<>();
+        final Map<String, DiscoveryNode> warmNodeMap = new HashMap<>();
+        for (int i = 0; i < totalDataNodes; i++) {
+            final String nodeId = randomAlphaOfLengthBetween(5, 15);
+            final DiscoveryNode node = mock(DiscoveryNode.class);
+            dataNodes.put(nodeId, node);
+            if (i < warmNodes) {
+                warmNodeMap.put(nodeId, node);
+            }
+        }
+        final DiscoveryNodes nodes = mock(DiscoveryNodes.class);
+        when(nodes.getDataNodes()).thenReturn(dataNodes);
+        when(nodes.getWarmNodes()).thenReturn(warmNodeMap);
+
+        final Metadata.Builder metadata = Metadata.builder();
+        if (randomBoolean()) {
+            metadata.persistentSettings(Settings.EMPTY);
+        } else {
+            metadata.transientSettings(Settings.EMPTY);
+        }
+        return ClusterState.builder(ClusterName.DEFAULT).metadata(metadata).nodes(nodes).build();
     }
 
     /**


### PR DESCRIPTION
### Description
Fixes shard limit validation for clusters that include warm nodes.

Warm nodes are included in `DiscoveryNodes#getDataNodes()` because the warm role
can contain data, but local-only shard validation should use only local-only data
nodes. This changes the `LOCAL_ONLY` path to exclude nodes also present in
`DiscoveryNodes#getWarmNodes()`, while preserving `REMOTE_CAPABLE` validation
against the warm-node count.

Added focused tests for local-only validation with mixed data/warm nodes and for
unchanged remote-capable validation.

### Related Issues
Resolves #21484
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).