### PR TITLE
Add multi-partition consumer and partition-aware pointer for flexible shard-to-partition mapping

### DIFF
--- a/plugins/ingestion-kafka/src/main/java/org/opensearch/plugin/kafka/KafkaConsumerFactory.java
+++ b/plugins/ingestion-kafka/src/main/java/org/opensearch/plugin/kafka/KafkaConsumerFactory.java
@@ -11,6 +11,7 @@ package org.opensearch.plugin.kafka;
 import org.opensearch.cluster.metadata.IngestionSource;
 import org.opensearch.index.IngestionConsumerFactory;
 
+import java.io.IOException;
 import java.util.List;
 
 /**
@@ -60,6 +61,8 @@ public class KafkaConsumerFactory implements IngestionConsumerFactory<KafkaParti
         )) {
             cachedPartitionCount = tempConsumer.getPartitionCount();
             return cachedPartitionCount;
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to close temporary consumer while querying partition count", e);
         }
     }
 

--- a/plugins/ingestion-kafka/src/main/java/org/opensearch/plugin/kafka/KafkaConsumerFactory.java
+++ b/plugins/ingestion-kafka/src/main/java/org/opensearch/plugin/kafka/KafkaConsumerFactory.java
@@ -10,14 +10,20 @@ package org.opensearch.plugin.kafka;
 
 import org.opensearch.cluster.metadata.IngestionSource;
 import org.opensearch.index.IngestionConsumerFactory;
+import org.opensearch.index.IngestionShardConsumer;
 
 import java.io.IOException;
 import java.util.List;
 
 /**
- * Factory for creating Kafka consumers
+ * Factory for creating Kafka consumers.
+ * <p>
+ * The type parameter uses {@code IngestionShardConsumer<KafkaOffset, KafkaMessage>} rather than a
+ * concrete consumer class, allowing the factory to return either {@link KafkaPartitionConsumer}
+ * (single-partition) or {@link KafkaMultiPartitionConsumer} (multi-partition) from different methods.
  */
-public class KafkaConsumerFactory implements IngestionConsumerFactory<KafkaPartitionConsumer, KafkaOffset> {
+public class KafkaConsumerFactory
+    implements IngestionConsumerFactory<IngestionShardConsumer<KafkaOffset, KafkaMessage>, KafkaOffset> {
 
     /**
      * Configuration for the Kafka source
@@ -37,13 +43,18 @@ public class KafkaConsumerFactory implements IngestionConsumerFactory<KafkaParti
     }
 
     @Override
-    public KafkaPartitionConsumer createShardConsumer(String clientId, int shardId) {
+    public IngestionShardConsumer<KafkaOffset, KafkaMessage> createShardConsumer(String clientId, int shardId) {
         assert config != null;
         return new KafkaPartitionConsumer(clientId, config, shardId);
     }
 
     @Override
     public KafkaOffset parsePointerFromString(String pointer) {
+        if (pointer.contains(":")) {
+            // Multi-partition format: "partition:offset"
+            String[] parts = pointer.split(":");
+            return new KafkaPartitionOffset(Integer.parseInt(parts[0]), Long.parseLong(parts[1]));
+        }
         return new KafkaOffset(Long.valueOf(pointer));
     }
 
@@ -53,7 +64,9 @@ public class KafkaConsumerFactory implements IngestionConsumerFactory<KafkaParti
             return cachedPartitionCount;
         }
         assert config != null;
-        // Create a temporary consumer to query partition metadata
+        // TODO: Consider using Kafka AdminClient instead of creating a full consumer just for
+        // partition metadata. AdminClient is lighter (no group coordinator handshake). Acceptable
+        // for now since the result is cached and called once per shard lifecycle.
         try (KafkaPartitionConsumer tempConsumer = new KafkaPartitionConsumer(
             "partition-count-query",
             config,
@@ -67,14 +80,11 @@ public class KafkaConsumerFactory implements IngestionConsumerFactory<KafkaParti
     }
 
     @Override
-    public KafkaPartitionConsumer createMultiPartitionShardConsumer(String clientId, int shardId, List<Integer> partitionIds) {
+    public IngestionShardConsumer<KafkaOffset, KafkaMessage> createMultiPartitionShardConsumer(String clientId, int shardId, List<Integer> partitionIds) {
         assert config != null;
         if (partitionIds.size() == 1) {
             return new KafkaPartitionConsumer(clientId, config, partitionIds.get(0));
         }
-        // TODO: Return KafkaMultiPartitionConsumer once implemented (PR 3)
-        throw new UnsupportedOperationException(
-            "Multi-partition consumer not yet implemented. Assign a single partition per shard or use partition_strategy=fixed."
-        );
+        return new KafkaMultiPartitionConsumer(clientId, config, shardId, partitionIds);
     }
 }

--- a/plugins/ingestion-kafka/src/main/java/org/opensearch/plugin/kafka/KafkaConsumerFactory.java
+++ b/plugins/ingestion-kafka/src/main/java/org/opensearch/plugin/kafka/KafkaConsumerFactory.java
@@ -8,11 +8,15 @@
 
 package org.opensearch.plugin.kafka;
 
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.common.PartitionInfo;
 import org.opensearch.cluster.metadata.IngestionSource;
 import org.opensearch.index.IngestionConsumerFactory;
 import org.opensearch.index.IngestionShardConsumer;
 
-import java.io.IOException;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.time.Duration;
 import java.util.List;
 
 /**
@@ -22,8 +26,8 @@ import java.util.List;
  * concrete consumer class, allowing the factory to return either {@link KafkaPartitionConsumer}
  * (single-partition) or {@link KafkaMultiPartitionConsumer} (multi-partition) from different methods.
  */
-public class KafkaConsumerFactory
-    implements IngestionConsumerFactory<IngestionShardConsumer<KafkaOffset, KafkaMessage>, KafkaOffset> {
+@SuppressWarnings("removal")
+public class KafkaConsumerFactory implements IngestionConsumerFactory<IngestionShardConsumer<KafkaOffset, KafkaMessage>, KafkaOffset> {
 
     /**
      * Configuration for the Kafka source
@@ -52,7 +56,12 @@ public class KafkaConsumerFactory
     public KafkaOffset parsePointerFromString(String pointer) {
         if (pointer.contains(":")) {
             // Multi-partition format: "partition:offset"
-            String[] parts = pointer.split(":");
+            String[] parts = pointer.split(":", -1);
+            if (parts.length != 2 || parts[0].isEmpty() || parts[1].isEmpty()) {
+                throw new IllegalArgumentException(
+                    "Invalid multi-partition pointer format. Expected 'partition:offset' (e.g., '3:42'), got: " + pointer
+                );
+            }
             return new KafkaPartitionOffset(Integer.parseInt(parts[0]), Long.parseLong(parts[1]));
         }
         return new KafkaOffset(Long.valueOf(pointer));
@@ -64,27 +73,36 @@ public class KafkaConsumerFactory
             return cachedPartitionCount;
         }
         assert config != null;
-        // TODO: Consider using Kafka AdminClient instead of creating a full consumer just for
-        // partition metadata. AdminClient is lighter (no group coordinator handshake). Acceptable
-        // for now since the result is cached and called once per shard lifecycle.
-        try (KafkaPartitionConsumer tempConsumer = new KafkaPartitionConsumer(
-            "partition-count-query",
-            config,
-            0
-        )) {
-            cachedPartitionCount = tempConsumer.getPartitionCount();
+        // TODO: Consider using Kafka AdminClient instead. AdminClient is lighter (no group
+        // coordinator handshake). Acceptable for now since the result is cached and called once
+        // per shard lifecycle.
+        Consumer<byte[], byte[]> rawConsumer = KafkaPartitionConsumer.createConsumer("partition-count-query", config);
+        try {
+            String topic = config.getTopic();
+            List<PartitionInfo> partitionInfos = AccessController.doPrivileged(
+                (PrivilegedAction<List<PartitionInfo>>) () -> rawConsumer.partitionsFor(
+                    topic,
+                    Duration.ofMillis(config.getTopicMetadataFetchTimeoutMs())
+                )
+            );
+            if (partitionInfos == null) {
+                throw new IllegalArgumentException("Topic " + topic + " does not exist");
+            }
+            cachedPartitionCount = partitionInfos.size();
             return cachedPartitionCount;
-        } catch (IOException e) {
-            throw new RuntimeException("Failed to close temporary consumer while querying partition count", e);
+        } finally {
+            rawConsumer.close();
         }
     }
 
     @Override
-    public IngestionShardConsumer<KafkaOffset, KafkaMessage> createMultiPartitionShardConsumer(String clientId, int shardId, List<Integer> partitionIds) {
+    public IngestionShardConsumer<KafkaOffset, KafkaMessage> createMultiPartitionShardConsumer(
+        String clientId,
+        int shardId,
+        List<Integer> partitionIds
+    ) {
         assert config != null;
-        if (partitionIds.size() == 1) {
-            return new KafkaPartitionConsumer(clientId, config, partitionIds.get(0));
-        }
+        // Return KafkaMultiPartitionConsumer, so that produced pointers are KafkaPartitionOffset
         return new KafkaMultiPartitionConsumer(clientId, config, shardId, partitionIds);
     }
 }

--- a/plugins/ingestion-kafka/src/main/java/org/opensearch/plugin/kafka/KafkaConsumerFactory.java
+++ b/plugins/ingestion-kafka/src/main/java/org/opensearch/plugin/kafka/KafkaConsumerFactory.java
@@ -11,6 +11,8 @@ package org.opensearch.plugin.kafka;
 import org.opensearch.cluster.metadata.IngestionSource;
 import org.opensearch.index.IngestionConsumerFactory;
 
+import java.util.List;
+
 /**
  * Factory for creating Kafka consumers
  */
@@ -20,6 +22,8 @@ public class KafkaConsumerFactory implements IngestionConsumerFactory<KafkaParti
      * Configuration for the Kafka source
      */
     protected KafkaSourceConfig config;
+
+    private volatile int cachedPartitionCount = -1;
 
     /**
      * Constructor.
@@ -40,5 +44,34 @@ public class KafkaConsumerFactory implements IngestionConsumerFactory<KafkaParti
     @Override
     public KafkaOffset parsePointerFromString(String pointer) {
         return new KafkaOffset(Long.valueOf(pointer));
+    }
+
+    @Override
+    public int getSourcePartitionCount() {
+        if (cachedPartitionCount > 0) {
+            return cachedPartitionCount;
+        }
+        assert config != null;
+        // Create a temporary consumer to query partition metadata
+        try (KafkaPartitionConsumer tempConsumer = new KafkaPartitionConsumer(
+            "partition-count-query",
+            config,
+            0
+        )) {
+            cachedPartitionCount = tempConsumer.getPartitionCount();
+            return cachedPartitionCount;
+        }
+    }
+
+    @Override
+    public KafkaPartitionConsumer createMultiPartitionShardConsumer(String clientId, int shardId, List<Integer> partitionIds) {
+        assert config != null;
+        if (partitionIds.size() == 1) {
+            return new KafkaPartitionConsumer(clientId, config, partitionIds.get(0));
+        }
+        // TODO: Return KafkaMultiPartitionConsumer once implemented (PR 3)
+        throw new UnsupportedOperationException(
+            "Multi-partition consumer not yet implemented. Assign a single partition per shard or use partition_strategy=fixed."
+        );
     }
 }

--- a/plugins/ingestion-kafka/src/main/java/org/opensearch/plugin/kafka/KafkaConsumerFactory.java
+++ b/plugins/ingestion-kafka/src/main/java/org/opensearch/plugin/kafka/KafkaConsumerFactory.java
@@ -55,14 +55,8 @@ public class KafkaConsumerFactory implements IngestionConsumerFactory<IngestionS
     @Override
     public KafkaOffset parsePointerFromString(String pointer) {
         if (pointer.contains(":")) {
-            // Multi-partition format: "partition:offset"
-            String[] parts = pointer.split(":", -1);
-            if (parts.length != 2 || parts[0].isEmpty() || parts[1].isEmpty()) {
-                throw new IllegalArgumentException(
-                    "Invalid multi-partition pointer format. Expected 'partition:offset' (e.g., '3:42'), got: " + pointer
-                );
-            }
-            return new KafkaPartitionOffset(Integer.parseInt(parts[0]), Long.parseLong(parts[1]));
+            // Multi-partition format: "partition:offset" — delegate to the shared parser.
+            return KafkaPartitionOffset.parse(pointer);
         }
         return new KafkaOffset(Long.valueOf(pointer));
     }

--- a/plugins/ingestion-kafka/src/main/java/org/opensearch/plugin/kafka/KafkaMultiPartitionConsumer.java
+++ b/plugins/ingestion-kafka/src/main/java/org/opensearch/plugin/kafka/KafkaMultiPartitionConsumer.java
@@ -175,11 +175,14 @@ public class KafkaMultiPartitionConsumer implements IngestionShardConsumer<Kafka
      * Seeks all assigned partitions to the beginning. Used for RESET_TO_EARLIEST.
      * <p>
      * TODO: Promote {@code seekToBeginning()} / {@code seekToEnd()} to default methods on
-     * {@link IngestionShardConsumer} when the management API for resets lands. That
-     * eliminates the {@code instanceof KafkaMultiPartitionConsumer} cast the poller's reset
-     * flow would otherwise need. Today {@code DefaultStreamPoller.getResetShardPointer()}
-     * uses {@link #earliestPointer()} + {@link #readNext} which only seeks one partition —
-     * the multi-partition reset path must call {@code seekToBeginning()} directly instead.
+     * {@link IngestionShardConsumer} when the management API for resets lands. Today, the
+     * multi-partition consumer's {@link #earliestPointer()} and {@link #readNext(KafkaOffset, boolean, long, int)}
+     * throw {@code UnsupportedOperationException}, so callers cannot use the fixed
+     * {@code earliestPointer() + readNext(offset, ...)} pattern that
+     * {@code DefaultStreamPoller.getResetShardPointer()} relies on for single-partition mode.
+     * The multi-partition reset path must call {@code seekToBeginning()} directly via an
+     * {@code instanceof KafkaMultiPartitionConsumer} cast in the poller — promoting these methods
+     * to interface defaults would eliminate the cast.
      */
     public void seekToBeginning() {
         AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
@@ -245,7 +248,8 @@ public class KafkaMultiPartitionConsumer implements IngestionShardConsumer<Kafka
     public IngestionShardPointer pointerFromTimestampMillis(long timestampMillis) {
         throw new UnsupportedOperationException(
             "pointerFromTimestampMillis() returns a single pointer, which can't represent N assigned "
-                + "partitions in multi-partition mode."
+                + "partitions in multi-partition mode. RESET_BY_TIMESTAMP needs a per-partition variant — "
+                + "tracked in subsequent management API work."
         );
     }
 
@@ -260,26 +264,44 @@ public class KafkaMultiPartitionConsumer implements IngestionShardConsumer<Kafka
                 "Multi-partition mode requires offset in 'partition:offset' format (e.g., '3:42'), got: " + offset
             );
         }
-        String[] parts = offset.split(":");
+        String[] parts = offset.split(":", -1);
+        if (parts.length != 2 || parts[0].isEmpty() || parts[1].isEmpty()) {
+            throw new IllegalArgumentException(
+                "Invalid multi-partition pointer format. Expected 'partition:offset' (e.g., '3:42'), got: " + offset
+            );
+        }
         return new KafkaPartitionOffset(Integer.parseInt(parts[0]), Long.parseLong(parts[1]));
     }
 
     /**
      * Seek all assigned partitions to their respective offsets. Used for recovery with per-partition checkpoints.
-     * @param partitionOffsets map of partition ID to pointer to seek to
+     * <p>
+     * Entries for partitions not in {@link #assignedPartitions} are logged and skipped — they
+     * shouldn't normally appear (assignment is fixed at consumer construction), but a stale
+     * checkpoint map from recovery could include them if assignment changes between commits.
+     * Logging makes the silent-skip visible for debugging.
+     *
+     * @param partitionOffsets map of partition ID to a pointer to seek to
      */
     @Override
     public void seekToPartitionOffsets(Map<Integer, ? extends IngestionShardPointer> partitionOffsets) {
         for (Map.Entry<Integer, ? extends IngestionShardPointer> entry : partitionOffsets.entrySet()) {
             TopicPartition tp = new TopicPartition(config.getTopic(), entry.getKey());
-            if (assignedPartitions.contains(tp)) {
-                long seekOffset = ((KafkaOffset) entry.getValue()).getOffset();
-                AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-                    consumer.seek(tp, seekOffset);
-                    return null;
-                });
-                lastFetchedOffsets.put(entry.getKey(), seekOffset - 1);
+            if (assignedPartitions.contains(tp) == false) {
+                logger.warn(
+                    "seekToPartitionOffsets: skipping partition {} (not assigned to shard {}); assigned partitions are {}",
+                    entry.getKey(),
+                    shardId,
+                    assignedPartitions.stream().map(TopicPartition::partition).toList()
+                );
+                continue;
             }
+            long seekOffset = ((KafkaOffset) entry.getValue()).getOffset();
+            AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+                consumer.seek(tp, seekOffset);
+                return null;
+            });
+            lastFetchedOffsets.put(entry.getKey(), seekOffset - 1);
         }
     }
 
@@ -334,7 +356,7 @@ public class KafkaMultiPartitionConsumer implements IngestionShardConsumer<Kafka
      * Returns the list of assigned partition IDs.
      */
     public List<Integer> getAssignedPartitionIds() {
-        return assignedPartitions.stream().map(TopicPartition::partition).collect(Collectors.toUnmodifiableList());
+        return assignedPartitions.stream().map(TopicPartition::partition).toList();
     }
 
     @Override

--- a/plugins/ingestion-kafka/src/main/java/org/opensearch/plugin/kafka/KafkaMultiPartitionConsumer.java
+++ b/plugins/ingestion-kafka/src/main/java/org/opensearch/plugin/kafka/KafkaMultiPartitionConsumer.java
@@ -1,0 +1,328 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.kafka;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.index.IngestionShardConsumer;
+import org.opensearch.index.IngestionShardPointer;
+
+import java.io.IOException;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
+
+/**
+ * Kafka consumer that reads from multiple partitions for a single OpenSearch shard.
+ * Used when {@code partition_strategy=auto} assigns multiple source partitions to one shard.
+ * <p>
+ * Uses composition (not inheritance) — holds its own {@link Consumer} instance and implements
+ * {@link IngestionShardConsumer} directly. Consumer creation is delegated to
+ * {@link KafkaPartitionConsumer#createConsumer(String, KafkaSourceConfig)}.
+ */
+@SuppressWarnings("removal")
+public class KafkaMultiPartitionConsumer implements IngestionShardConsumer<KafkaOffset, KafkaMessage> {
+
+    private static final Logger logger = LogManager.getLogger(KafkaMultiPartitionConsumer.class);
+
+    private final int shardId;
+    private final String clientId;
+    private final Consumer<byte[], byte[]> consumer;
+    private final KafkaSourceConfig config;
+    private final List<TopicPartition> assignedPartitions;
+    private final Map<Integer, Long> lastFetchedOffsets;
+    // TODO: make this configurable
+    private final int defaultTimeoutMillis = 1000;
+
+    /**
+     * Constructor
+     * @param clientId the client ID for this consumer
+     * @param config the Kafka source configuration
+     * @param shardId the OpenSearch shard ID this consumer belongs to
+     * @param partitionIds the list of Kafka partition IDs to consume from
+     */
+    public KafkaMultiPartitionConsumer(String clientId, KafkaSourceConfig config, int shardId, List<Integer> partitionIds) {
+        this(clientId, config, shardId, partitionIds, KafkaPartitionConsumer.createConsumer(clientId, config));
+    }
+
+    /**
+     * Constructor visible for testing
+     */
+    protected KafkaMultiPartitionConsumer(
+        String clientId,
+        KafkaSourceConfig config,
+        int shardId,
+        List<Integer> partitionIds,
+        Consumer<byte[], byte[]> consumer
+    ) {
+        this.clientId = clientId;
+        this.config = config;
+        this.shardId = shardId;
+        this.consumer = consumer;
+        this.lastFetchedOffsets = new HashMap<>();
+
+        String topic = config.getTopic();
+        List<PartitionInfo> partitionInfos = AccessController.doPrivileged(
+            (PrivilegedAction<List<PartitionInfo>>) () -> consumer.partitionsFor(topic, Duration.ofMillis(defaultTimeoutMillis))
+        );
+        if (partitionInfos == null) {
+            throw new IllegalArgumentException("Topic " + topic + " does not exist");
+        }
+        int maxPartition = partitionInfos.size();
+        for (int partitionId : partitionIds) {
+            if (partitionId >= maxPartition) {
+                throw new IllegalArgumentException(
+                    "Partition " + partitionId + " does not exist in topic " + topic + " (max: " + (maxPartition - 1) + ")"
+                );
+            }
+        }
+
+        this.assignedPartitions = partitionIds.stream()
+            .map(p -> new TopicPartition(topic, p))
+            .collect(Collectors.toUnmodifiableList());
+
+        consumer.assign(assignedPartitions);
+        logger.info("Kafka multi-partition consumer created for topic {} partitions {} (shard {})", topic, partitionIds, shardId);
+    }
+
+    @Override
+    public List<ReadResult<KafkaOffset, KafkaMessage>> readNext(
+        KafkaOffset offset,
+        boolean includeStart,
+        long maxMessages,
+        int timeoutMillis
+    ) throws TimeoutException {
+        if (offset instanceof KafkaPartitionOffset) {
+            KafkaPartitionOffset partitionOffset = (KafkaPartitionOffset) offset;
+            TopicPartition tp = new TopicPartition(config.getTopic(), partitionOffset.getPartition());
+            long seekOffset = includeStart ? partitionOffset.getOffset() : partitionOffset.getOffset() + 1;
+            AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+                consumer.seek(tp, seekOffset);
+                return null;
+            });
+            lastFetchedOffsets.put(partitionOffset.getPartition(), seekOffset - 1);
+        } else {
+            // Legacy pointer without partition — seek first assigned partition
+            TopicPartition tp = assignedPartitions.get(0);
+            long seekOffset = includeStart ? offset.getOffset() : offset.getOffset() + 1;
+            AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+                consumer.seek(tp, seekOffset);
+                return null;
+            });
+            lastFetchedOffsets.put(tp.partition(), seekOffset - 1);
+        }
+        return pollAllPartitions(timeoutMillis);
+    }
+
+    @Override
+    public List<ReadResult<KafkaOffset, KafkaMessage>> readNext(long maxMessages, int timeoutMillis) throws TimeoutException {
+        return pollAllPartitions(timeoutMillis);
+    }
+
+    // Not thread-safe — must be called from the poller thread only, consistent with KafkaPartitionConsumer contract.
+    private List<ReadResult<KafkaOffset, KafkaMessage>> pollAllPartitions(int timeoutMillis) {
+        ConsumerRecords<byte[], byte[]> consumerRecords = AccessController.doPrivileged(
+            (PrivilegedAction<ConsumerRecords<byte[], byte[]>>) () -> consumer.poll(Duration.ofMillis(timeoutMillis))
+        );
+
+        List<ReadResult<KafkaOffset, KafkaMessage>> results = new ArrayList<>();
+        for (TopicPartition tp : assignedPartitions) {
+            for (ConsumerRecord<byte[], byte[]> record : consumerRecords.records(tp)) {
+                int partition = record.partition();
+                long currentOffset = record.offset();
+                lastFetchedOffsets.put(partition, currentOffset);
+                KafkaPartitionOffset pointer = new KafkaPartitionOffset(partition, currentOffset);
+                KafkaMessage message = new KafkaMessage(record.key(), record.value(), record.timestamp());
+                results.add(new ReadResult<>(pointer, message));
+            }
+        }
+        return results;
+    }
+
+    /**
+     * Seeks all assigned partitions to the beginning. Used for RESET_TO_EARLIEST.
+     * <p>
+     * TODO: Add seekToBeginning()/seekToEnd() as default methods on IngestionShardConsumer interface
+     * so the poller can call them without instanceof checks. The poller's reset flow
+     * (DefaultStreamPoller.getResetShardPointer()) currently calls earliestPointer() + readNext()
+     * which only seeks one partition. The poller PR needs to use these methods for proper
+     * multi-partition reset.
+     */
+    public void seekToBeginning() {
+        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+            consumer.seekToBeginning(assignedPartitions);
+            return null;
+        });
+        lastFetchedOffsets.clear();
+    }
+
+    /**
+     * Seeks all assigned partitions to the end. Used for RESET_TO_LATEST.
+     */
+    public void seekToEnd() {
+        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+            consumer.seekToEnd(assignedPartitions);
+            return null;
+        });
+        lastFetchedOffsets.clear();
+    }
+
+    @Override
+    public IngestionShardPointer earliestPointer() {
+        Map<TopicPartition, Long> beginnings = AccessController.doPrivileged(
+            (PrivilegedAction<Map<TopicPartition, Long>>) () -> consumer.beginningOffsets(assignedPartitions)
+        );
+        // TODO: This returns a single pointer for only the first partition. Callers using this for
+        // RESET_TO_EARLIEST will only seek one partition. The poller PR must use seekToBeginning()
+        // for proper multi-partition reset instead of earliestPointer() + readNext().
+        TopicPartition first = assignedPartitions.get(0);
+        return new KafkaPartitionOffset(first.partition(), beginnings.getOrDefault(first, 0L));
+    }
+
+    @Override
+    public IngestionShardPointer latestPointer() {
+        Map<TopicPartition, Long> endings = AccessController.doPrivileged(
+            (PrivilegedAction<Map<TopicPartition, Long>>) () -> consumer.endOffsets(assignedPartitions)
+        );
+        // TODO: Same limitation as earliestPointer() — returns single pointer for last partition only.
+        // For multi-partition reset, use seekToEnd() instead.
+        TopicPartition last = assignedPartitions.get(assignedPartitions.size() - 1);
+        return new KafkaPartitionOffset(last.partition(), endings.getOrDefault(last, 0L));
+    }
+
+    @Override
+    public IngestionShardPointer pointerFromTimestampMillis(long timestampMillis) {
+        Map<TopicPartition, Long> timestamps = new HashMap<>();
+        for (TopicPartition tp : assignedPartitions) {
+            timestamps.put(tp, timestampMillis);
+        }
+
+        Map<TopicPartition, OffsetAndTimestamp> offsets = AccessController.doPrivileged(
+            (PrivilegedAction<Map<TopicPartition, OffsetAndTimestamp>>) () -> consumer.offsetsForTimes(timestamps)
+        );
+
+        // Return the first partition offset found for the timestamp
+        for (TopicPartition tp : assignedPartitions) {
+            OffsetAndTimestamp oat = offsets.get(tp);
+            if (oat != null) {
+                return new KafkaPartitionOffset(tp.partition(), oat.offset());
+            }
+        }
+
+        // Fallback to auto.offset.reset policy
+        String autoOffsetResetConfig = config.getAutoOffsetResetConfig();
+        if (OffsetResetStrategy.EARLIEST.toString().equals(autoOffsetResetConfig)) {
+            seekToBeginning();
+            return earliestPointer();
+        } else if (OffsetResetStrategy.LATEST.toString().equals(autoOffsetResetConfig)) {
+            seekToEnd();
+            return latestPointer();
+        }
+        throw new IllegalArgumentException("No message found for timestamp " + timestampMillis + " across any assigned partition");
+    }
+
+    @Override
+    public IngestionShardPointer pointerFromOffset(String offset) {
+        if (offset.contains(":")) {
+            String[] parts = offset.split(":");
+            return new KafkaPartitionOffset(Integer.parseInt(parts[0]), Long.parseLong(parts[1]));
+        }
+        // Fallback: treat as plain offset for first assigned partition
+        long offsetValue = Long.parseLong(offset);
+        int firstPartition = assignedPartitions.get(0).partition();
+        return new KafkaPartitionOffset(firstPartition, offsetValue);
+    }
+
+    /**
+     * Seek all assigned partitions to their respective offsets. Used for recovery with per-partition checkpoints.
+     * @param partitionOffsets map of partition ID to pointer to seek to
+     */
+    @Override
+    public void seekToPartitionOffsets(Map<Integer, ? extends IngestionShardPointer> partitionOffsets) {
+        for (Map.Entry<Integer, ? extends IngestionShardPointer> entry : partitionOffsets.entrySet()) {
+            TopicPartition tp = new TopicPartition(config.getTopic(), entry.getKey());
+            if (assignedPartitions.contains(tp)) {
+                long seekOffset = ((KafkaOffset) entry.getValue()).getOffset();
+                AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+                    consumer.seek(tp, seekOffset);
+                    return null;
+                });
+                lastFetchedOffsets.put(entry.getKey(), seekOffset - 1);
+            }
+        }
+    }
+
+    @Override
+    public int getShardId() {
+        return shardId;
+    }
+
+    /**
+     * Computes the total lag across all assigned partitions as the sum of per-partition lags.
+     */
+    @Override
+    public long getPointerBasedLag(IngestionShardPointer expectedStartPointer) {
+        try {
+            Map<TopicPartition, Long> endOffsets = AccessController.doPrivileged(
+                (PrivilegedAction<Map<TopicPartition, Long>>) () -> consumer.endOffsets(assignedPartitions)
+            );
+
+            long totalLag = 0;
+            for (TopicPartition tp : assignedPartitions) {
+                long endOffset = endOffsets.getOrDefault(tp, 0L);
+                Long lastFetched = lastFetchedOffsets.get(tp.partition());
+                if (lastFetched == null || lastFetched < 0) {
+                    if (expectedStartPointer instanceof KafkaPartitionOffset) {
+                        KafkaPartitionOffset startPtr = (KafkaPartitionOffset) expectedStartPointer;
+                        if (startPtr.getPartition() == tp.partition()) {
+                            totalLag += Math.max(0, endOffset - startPtr.getOffset());
+                            continue;
+                        }
+                    }
+                    totalLag += endOffset;
+                } else {
+                    totalLag += Math.max(0, endOffset - lastFetched - 1);
+                }
+            }
+            return totalLag;
+        } catch (Exception e) {
+            logger.warn("Failed to calculate pointer based lag for shard {}: {}", shardId, e.getMessage());
+            return -1;
+        }
+    }
+
+    /**
+     * Returns the list of assigned partition IDs.
+     */
+    public List<Integer> getAssignedPartitionIds() {
+        return assignedPartitions.stream().map(TopicPartition::partition).collect(Collectors.toUnmodifiableList());
+    }
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    @Override
+    public void close() throws IOException {
+        consumer.close();
+    }
+}

--- a/plugins/ingestion-kafka/src/main/java/org/opensearch/plugin/kafka/KafkaMultiPartitionConsumer.java
+++ b/plugins/ingestion-kafka/src/main/java/org/opensearch/plugin/kafka/KafkaMultiPartitionConsumer.java
@@ -11,8 +11,6 @@ package org.opensearch.plugin.kafka;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
-import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
-import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.logging.log4j.LogManager;
@@ -33,9 +31,9 @@ import java.util.stream.Collectors;
 
 /**
  * Kafka consumer that reads from multiple partitions for a single OpenSearch shard.
- * Used when {@code partition_strategy=auto} assigns multiple source partitions to one shard.
+ * Used when {@code source_partition_strategy} assigns multiple source partitions to one shard.
  * <p>
- * Uses composition (not inheritance) — holds its own {@link Consumer} instance and implements
+ * Uses composition - holds its own {@link Consumer} instance and implements
  * {@link IngestionShardConsumer} directly. Consumer creation is delegated to
  * {@link KafkaPartitionConsumer#createConsumer(String, KafkaSourceConfig)}.
  */
@@ -45,13 +43,10 @@ public class KafkaMultiPartitionConsumer implements IngestionShardConsumer<Kafka
     private static final Logger logger = LogManager.getLogger(KafkaMultiPartitionConsumer.class);
 
     private final int shardId;
-    private final String clientId;
     private final Consumer<byte[], byte[]> consumer;
     private final KafkaSourceConfig config;
     private final List<TopicPartition> assignedPartitions;
     private final Map<Integer, Long> lastFetchedOffsets;
-    // TODO: make this configurable
-    private final int defaultTimeoutMillis = 1000;
 
     /**
      * Constructor
@@ -61,20 +56,18 @@ public class KafkaMultiPartitionConsumer implements IngestionShardConsumer<Kafka
      * @param partitionIds the list of Kafka partition IDs to consume from
      */
     public KafkaMultiPartitionConsumer(String clientId, KafkaSourceConfig config, int shardId, List<Integer> partitionIds) {
-        this(clientId, config, shardId, partitionIds, KafkaPartitionConsumer.createConsumer(clientId, config));
+        this(config, shardId, partitionIds, KafkaPartitionConsumer.createConsumer(clientId, config));
     }
 
     /**
      * Constructor visible for testing
      */
     protected KafkaMultiPartitionConsumer(
-        String clientId,
         KafkaSourceConfig config,
         int shardId,
         List<Integer> partitionIds,
         Consumer<byte[], byte[]> consumer
     ) {
-        this.clientId = clientId;
         this.config = config;
         this.shardId = shardId;
         this.consumer = consumer;
@@ -82,7 +75,10 @@ public class KafkaMultiPartitionConsumer implements IngestionShardConsumer<Kafka
 
         String topic = config.getTopic();
         List<PartitionInfo> partitionInfos = AccessController.doPrivileged(
-            (PrivilegedAction<List<PartitionInfo>>) () -> consumer.partitionsFor(topic, Duration.ofMillis(defaultTimeoutMillis))
+            (PrivilegedAction<List<PartitionInfo>>) () -> consumer.partitionsFor(
+                topic,
+                Duration.ofMillis(config.getTopicMetadataFetchTimeoutMs())
+            )
         );
         if (partitionInfos == null) {
             throw new IllegalArgumentException("Topic " + topic + " does not exist");
@@ -96,14 +92,22 @@ public class KafkaMultiPartitionConsumer implements IngestionShardConsumer<Kafka
             }
         }
 
-        this.assignedPartitions = partitionIds.stream()
-            .map(p -> new TopicPartition(topic, p))
-            .collect(Collectors.toUnmodifiableList());
+        this.assignedPartitions = partitionIds.stream().map(p -> new TopicPartition(topic, p)).collect(Collectors.toUnmodifiableList());
 
         consumer.assign(assignedPartitions);
         logger.info("Kafka multi-partition consumer created for topic {} partitions {} (shard {})", topic, partitionIds, shardId);
     }
 
+    /**
+     * Single-partition seek-then-poll semantics don't fit a multi-partition consumer — a single
+     * pointer can only reposition one of N partitions, leaving the others in an undefined
+     * intermediate state that no caller actually wants. Multi-partition recovery should use
+     * {@link #seekToPartitionOffsets(Map)} (covers all assigned partitions atomically) followed
+     * by {@link #readNext(long, int)} for continuation polls. To seek a single partition,
+     * use {@code seekToPartitionOffsets(Map.of(partition, pointer))}.
+     *
+     * @throws UnsupportedOperationException always
+     */
     @Override
     public List<ReadResult<KafkaOffset, KafkaMessage>> readNext(
         KafkaOffset offset,
@@ -111,35 +115,44 @@ public class KafkaMultiPartitionConsumer implements IngestionShardConsumer<Kafka
         long maxMessages,
         int timeoutMillis
     ) throws TimeoutException {
-        if (offset instanceof KafkaPartitionOffset) {
-            KafkaPartitionOffset partitionOffset = (KafkaPartitionOffset) offset;
-            TopicPartition tp = new TopicPartition(config.getTopic(), partitionOffset.getPartition());
-            long seekOffset = includeStart ? partitionOffset.getOffset() : partitionOffset.getOffset() + 1;
-            AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-                consumer.seek(tp, seekOffset);
-                return null;
-            });
-            lastFetchedOffsets.put(partitionOffset.getPartition(), seekOffset - 1);
-        } else {
-            // Legacy pointer without partition — seek first assigned partition
-            TopicPartition tp = assignedPartitions.get(0);
-            long seekOffset = includeStart ? offset.getOffset() : offset.getOffset() + 1;
-            AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-                consumer.seek(tp, seekOffset);
-                return null;
-            });
-            lastFetchedOffsets.put(tp.partition(), seekOffset - 1);
-        }
-        return pollAllPartitions(timeoutMillis);
+        throw new UnsupportedOperationException(
+            "readNext(offset, ...) has single-partition seek semantics that don't fit a multi-partition "
+                + "consumer. Use seekToPartitionOffsets(Map) to seek per-partition checkpoints, then "
+                + "readNext(maxMessages, timeoutMillis) for continuation polls. To seek a single partition, "
+                + "call seekToPartitionOffsets(Map.of(partition, pointer))."
+        );
     }
 
+    /**
+     * Continue reading from the current consumer position across all assigned partitions.
+     *
+     * @param maxMessages  NOT honored — the per-poll batch size is governed by Kafka's
+     *                     {@code max.poll.records} consumer config, set at consumer initialization.
+     *                     Same limitation as {@link KafkaPartitionConsumer#readNext}.
+     * @param timeoutMillis maximum time to wait for messages
+     */
     @Override
     public List<ReadResult<KafkaOffset, KafkaMessage>> readNext(long maxMessages, int timeoutMillis) throws TimeoutException {
         return pollAllPartitions(timeoutMillis);
     }
 
-    // Not thread-safe — must be called from the poller thread only, consistent with KafkaPartitionConsumer contract.
-    private List<ReadResult<KafkaOffset, KafkaMessage>> pollAllPartitions(int timeoutMillis) {
+    /**
+     * Single {@code consumer.poll()} that returns records across ALL assigned partitions, then
+     * iterates by partition to wrap each record with a {@link KafkaPartitionOffset}.
+     * <p>
+     * <b>{@code max.poll.records} is shared across all assigned partitions.</b>
+     * A {@code consumer.poll()} call returns up to {@code max.poll.records} records <em>total</em>,
+     * not per partition. With N assigned partitions, each effectively gets ~1/N of the records per
+     * poll compared to the equivalent single-partition consumer with the same setting. Users
+     * migrating from single-partition to multi-partition mode (e.g., 1 shard now consuming N
+     * partitions instead of 1) may need to bump {@code max.poll.records} proportionally to
+     * maintain per-partition throughput.
+     * <p>
+     * {@code synchronized} for parity with {@link KafkaPartitionConsumer}'s internal fetch — Kafka
+     * itself does not allow concurrent {@code poll()} calls, but the lock is defense-in-depth for
+     * the documented single-poller-thread contract.
+     */
+    private synchronized List<ReadResult<KafkaOffset, KafkaMessage>> pollAllPartitions(int timeoutMillis) {
         ConsumerRecords<byte[], byte[]> consumerRecords = AccessController.doPrivileged(
             (PrivilegedAction<ConsumerRecords<byte[], byte[]>>) () -> consumer.poll(Duration.ofMillis(timeoutMillis))
         );
@@ -161,11 +174,12 @@ public class KafkaMultiPartitionConsumer implements IngestionShardConsumer<Kafka
     /**
      * Seeks all assigned partitions to the beginning. Used for RESET_TO_EARLIEST.
      * <p>
-     * TODO: Add seekToBeginning()/seekToEnd() as default methods on IngestionShardConsumer interface
-     * so the poller can call them without instanceof checks. The poller's reset flow
-     * (DefaultStreamPoller.getResetShardPointer()) currently calls earliestPointer() + readNext()
-     * which only seeks one partition. The poller PR needs to use these methods for proper
-     * multi-partition reset.
+     * TODO: Promote {@code seekToBeginning()} / {@code seekToEnd()} to default methods on
+     * {@link IngestionShardConsumer} when the management API for resets lands. That
+     * eliminates the {@code instanceof KafkaMultiPartitionConsumer} cast the poller's reset
+     * flow would otherwise need. Today {@code DefaultStreamPoller.getResetShardPointer()}
+     * uses {@link #earliestPointer()} + {@link #readNext} which only seeks one partition —
+     * the multi-partition reset path must call {@code seekToBeginning()} directly instead.
      */
     public void seekToBeginning() {
         AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
@@ -186,70 +200,68 @@ public class KafkaMultiPartitionConsumer implements IngestionShardConsumer<Kafka
         lastFetchedOffsets.clear();
     }
 
+    /**
+     * Single-pointer earliest is unsupported in multi-partition mode — a single pointer can only
+     * represent one of N assigned partitions. For RESET_TO_EARLIEST across all partitions, use
+     * {@link #seekToBeginning()} directly. The {@link IngestionShardConsumer} interface predates
+     * multi-partition consumption; TODO: Subsequent change should add a {@code Map<Integer, IngestionShardPointer>
+     * earliestPointers()} default method.
+     *
+     * @throws UnsupportedOperationException always
+     */
     @Override
     public IngestionShardPointer earliestPointer() {
-        Map<TopicPartition, Long> beginnings = AccessController.doPrivileged(
-            (PrivilegedAction<Map<TopicPartition, Long>>) () -> consumer.beginningOffsets(assignedPartitions)
+        throw new UnsupportedOperationException(
+            "earliestPointer() returns a single pointer, which can't represent N assigned partitions in "
+                + "multi-partition mode. Use seekToBeginning() directly for RESET_TO_EARLIEST."
         );
-        // TODO: This returns a single pointer for only the first partition. Callers using this for
-        // RESET_TO_EARLIEST will only seek one partition. The poller PR must use seekToBeginning()
-        // for proper multi-partition reset instead of earliestPointer() + readNext().
-        TopicPartition first = assignedPartitions.get(0);
-        return new KafkaPartitionOffset(first.partition(), beginnings.getOrDefault(first, 0L));
     }
 
+    /**
+     * Single-pointer latest is unsupported in multi-partition mode — same limitation as
+     * {@link #earliestPointer()}. For RESET_TO_LATEST across all partitions, use {@link #seekToEnd()}
+     * directly.
+     *
+     * @throws UnsupportedOperationException always
+     */
     @Override
     public IngestionShardPointer latestPointer() {
-        Map<TopicPartition, Long> endings = AccessController.doPrivileged(
-            (PrivilegedAction<Map<TopicPartition, Long>>) () -> consumer.endOffsets(assignedPartitions)
+        throw new UnsupportedOperationException(
+            "latestPointer() returns a single pointer, which can't represent N assigned partitions in "
+                + "multi-partition mode. Use seekToEnd() directly for RESET_TO_LATEST."
         );
-        // TODO: Same limitation as earliestPointer() — returns single pointer for last partition only.
-        // For multi-partition reset, use seekToEnd() instead.
-        TopicPartition last = assignedPartitions.get(assignedPartitions.size() - 1);
-        return new KafkaPartitionOffset(last.partition(), endings.getOrDefault(last, 0L));
     }
 
+    /**
+     * Single-pointer timestamp resolution is unsupported in multi-partition mode — Kafka's
+     * {@code offsetsForTimes} returns per-partition offsets and there's no meaningful single-pointer
+     * answer across N partitions (the first non-null partition is non-deterministic and useless for
+     * resetting all partitions). Subsequent PR should add a per-partition variant on the interface, e.g.
+     * {@code Map<Integer, IngestionShardPointer> pointersFromTimestampMillis(long ts)}.
+     *
+     * @throws UnsupportedOperationException always
+     */
     @Override
     public IngestionShardPointer pointerFromTimestampMillis(long timestampMillis) {
-        Map<TopicPartition, Long> timestamps = new HashMap<>();
-        for (TopicPartition tp : assignedPartitions) {
-            timestamps.put(tp, timestampMillis);
-        }
-
-        Map<TopicPartition, OffsetAndTimestamp> offsets = AccessController.doPrivileged(
-            (PrivilegedAction<Map<TopicPartition, OffsetAndTimestamp>>) () -> consumer.offsetsForTimes(timestamps)
+        throw new UnsupportedOperationException(
+            "pointerFromTimestampMillis() returns a single pointer, which can't represent N assigned "
+                + "partitions in multi-partition mode."
         );
-
-        // Return the first partition offset found for the timestamp
-        for (TopicPartition tp : assignedPartitions) {
-            OffsetAndTimestamp oat = offsets.get(tp);
-            if (oat != null) {
-                return new KafkaPartitionOffset(tp.partition(), oat.offset());
-            }
-        }
-
-        // Fallback to auto.offset.reset policy
-        String autoOffsetResetConfig = config.getAutoOffsetResetConfig();
-        if (OffsetResetStrategy.EARLIEST.toString().equals(autoOffsetResetConfig)) {
-            seekToBeginning();
-            return earliestPointer();
-        } else if (OffsetResetStrategy.LATEST.toString().equals(autoOffsetResetConfig)) {
-            seekToEnd();
-            return latestPointer();
-        }
-        throw new IllegalArgumentException("No message found for timestamp " + timestampMillis + " across any assigned partition");
     }
 
     @Override
     public IngestionShardPointer pointerFromOffset(String offset) {
-        if (offset.contains(":")) {
-            String[] parts = offset.split(":");
-            return new KafkaPartitionOffset(Integer.parseInt(parts[0]), Long.parseLong(parts[1]));
+        if (!offset.contains(":")) {
+            // Multi-partition mode requires explicit partition info to avoid silent
+            // wrong-partition reads. A bare numeric offset is ambiguous (which of the
+            // assigned partitions does it belong to?) — fail loudly so callers fix
+            // their input rather than getting data from an arbitrary partition.
+            throw new IllegalArgumentException(
+                "Multi-partition mode requires offset in 'partition:offset' format (e.g., '3:42'), got: " + offset
+            );
         }
-        // Fallback: treat as plain offset for first assigned partition
-        long offsetValue = Long.parseLong(offset);
-        int firstPartition = assignedPartitions.get(0).partition();
-        return new KafkaPartitionOffset(firstPartition, offsetValue);
+        String[] parts = offset.split(":");
+        return new KafkaPartitionOffset(Integer.parseInt(parts[0]), Long.parseLong(parts[1]));
     }
 
     /**
@@ -278,6 +290,14 @@ public class KafkaMultiPartitionConsumer implements IngestionShardConsumer<Kafka
 
     /**
      * Computes the total lag across all assigned partitions as the sum of per-partition lags.
+     * <p>
+     * <b>TODO: takes a single {@code expectedStartPointer} but multi-partition mode needs per-partition
+     * starts.</b> Today this method best-effort-handles a {@link KafkaPartitionOffset} for the one
+     * partition it references, and falls back to "use endOffset (full lag)" for other partitions
+     * with no {@code lastFetched} record. Subsequent PR should add a {@code long getPointerBasedLag(Map<Integer,
+     * IngestionShardPointer>)} default method on {@link IngestionShardConsumer} so callers can supply
+     * per-partition expected starts. Once that exists, this single-pointer overload can either delegate
+     * to the per-partition variant or throw, mirroring the {@link #earliestPointer()} pattern.
      */
     @Override
     public long getPointerBasedLag(IngestionShardPointer expectedStartPointer) {
@@ -293,7 +313,7 @@ public class KafkaMultiPartitionConsumer implements IngestionShardConsumer<Kafka
                 if (lastFetched == null || lastFetched < 0) {
                     if (expectedStartPointer instanceof KafkaPartitionOffset) {
                         KafkaPartitionOffset startPtr = (KafkaPartitionOffset) expectedStartPointer;
-                        if (startPtr.getPartition() == tp.partition()) {
+                        if (startPtr.getSourcePartition() == tp.partition()) {
                             totalLag += Math.max(0, endOffset - startPtr.getOffset());
                             continue;
                         }
@@ -315,10 +335,6 @@ public class KafkaMultiPartitionConsumer implements IngestionShardConsumer<Kafka
      */
     public List<Integer> getAssignedPartitionIds() {
         return assignedPartitions.stream().map(TopicPartition::partition).collect(Collectors.toUnmodifiableList());
-    }
-
-    public String getClientId() {
-        return clientId;
     }
 
     @Override

--- a/plugins/ingestion-kafka/src/main/java/org/opensearch/plugin/kafka/KafkaMultiPartitionConsumer.java
+++ b/plugins/ingestion-kafka/src/main/java/org/opensearch/plugin/kafka/KafkaMultiPartitionConsumer.java
@@ -264,13 +264,8 @@ public class KafkaMultiPartitionConsumer implements IngestionShardConsumer<Kafka
                 "Multi-partition mode requires offset in 'partition:offset' format (e.g., '3:42'), got: " + offset
             );
         }
-        String[] parts = offset.split(":", -1);
-        if (parts.length != 2 || parts[0].isEmpty() || parts[1].isEmpty()) {
-            throw new IllegalArgumentException(
-                "Invalid multi-partition pointer format. Expected 'partition:offset' (e.g., '3:42'), got: " + offset
-            );
-        }
-        return new KafkaPartitionOffset(Integer.parseInt(parts[0]), Long.parseLong(parts[1]));
+        // Shared parser with KafkaConsumerFactory.parsePointerFromString
+        return KafkaPartitionOffset.parse(offset);
     }
 
     /**

--- a/plugins/ingestion-kafka/src/main/java/org/opensearch/plugin/kafka/KafkaOffset.java
+++ b/plugins/ingestion-kafka/src/main/java/org/opensearch/plugin/kafka/KafkaOffset.java
@@ -71,6 +71,11 @@ public class KafkaOffset implements IngestionShardPointer {
         if (o == null) {
             throw new IllegalArgumentException("the pointer is null");
         }
+        if (o instanceof KafkaPartitionOffset) {
+            // KafkaOffset always sorts before KafkaPartitionOffset, matching the inverse in
+            // KafkaPartitionOffset.compareTo(KafkaOffset) which returns 1.
+            return -1;
+        }
         if (!(o instanceof KafkaOffset other)) {
             throw new IllegalArgumentException("the pointer is of type " + o.getClass() + " and not KafkaOffset");
         }

--- a/plugins/ingestion-kafka/src/main/java/org/opensearch/plugin/kafka/KafkaPartitionConsumer.java
+++ b/plugins/ingestion-kafka/src/main/java/org/opensearch/plugin/kafka/KafkaPartitionConsumer.java
@@ -294,27 +294,4 @@ public class KafkaPartitionConsumer implements IngestionShardConsumer<KafkaOffse
     public void close() throws IOException {
         consumer.close();
     }
-
-    /**
-     * Get the client id
-     * @return the client id
-     */
-    public String getClientId() {
-        return clientId;
-    }
-
-    /**
-     * Returns the total number of partitions for the configured topic.
-     * @return the partition count
-     */
-    public int getPartitionCount() {
-        String topic = config.getTopic();
-        List<PartitionInfo> partitionInfos = AccessController.doPrivileged(
-            (PrivilegedAction<List<PartitionInfo>>) () -> consumer.partitionsFor(topic, Duration.ofMillis(timeoutMillis))
-        );
-        if (partitionInfos == null) {
-            throw new IllegalArgumentException("Topic " + topic + " does not exist");
-        }
-        return partitionInfos.size();
-    }
 }

--- a/plugins/ingestion-kafka/src/main/java/org/opensearch/plugin/kafka/KafkaPartitionConsumer.java
+++ b/plugins/ingestion-kafka/src/main/java/org/opensearch/plugin/kafka/KafkaPartitionConsumer.java
@@ -302,4 +302,19 @@ public class KafkaPartitionConsumer implements IngestionShardConsumer<KafkaOffse
     public String getClientId() {
         return clientId;
     }
+
+    /**
+     * Returns the total number of partitions for the configured topic.
+     * @return the partition count
+     */
+    public int getPartitionCount() {
+        String topic = config.getTopic();
+        List<PartitionInfo> partitionInfos = AccessController.doPrivileged(
+            (PrivilegedAction<List<PartitionInfo>>) () -> consumer.partitionsFor(topic, Duration.ofMillis(timeoutMillis))
+        );
+        if (partitionInfos == null) {
+            throw new IllegalArgumentException("Topic " + topic + " does not exist");
+        }
+        return partitionInfos.size();
+    }
 }

--- a/plugins/ingestion-kafka/src/main/java/org/opensearch/plugin/kafka/KafkaPartitionOffset.java
+++ b/plugins/ingestion-kafka/src/main/java/org/opensearch/plugin/kafka/KafkaPartitionOffset.java
@@ -1,0 +1,120 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.kafka;
+
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.LongPoint;
+import org.apache.lucene.search.Query;
+import org.opensearch.index.IngestionShardPointer;
+import org.opensearch.index.PartitionAwarePointer;
+
+import java.nio.ByteBuffer;
+import java.util.Objects;
+
+/**
+ * A partition-aware Kafka offset that encodes both the partition ID and offset.
+ * Extends {@link KafkaOffset} so it can be used wherever KafkaOffset is expected,
+ * while adding partition information via {@link PartitionAwarePointer}.
+ */
+public class KafkaPartitionOffset extends KafkaOffset implements PartitionAwarePointer {
+
+    private final int partition;
+
+    /**
+     * Constructor
+     * @param partition the Kafka partition ID
+     * @param offset the offset within the partition
+     */
+    public KafkaPartitionOffset(int partition, long offset) {
+        super(offset);
+        assert partition >= 0 : "partition must be non-negative";
+        this.partition = partition;
+    }
+
+    @Override
+    public int getPartition() {
+        return partition;
+    }
+
+    @Override
+    public byte[] serialize() {
+        ByteBuffer buffer = ByteBuffer.allocate(Integer.BYTES + Long.BYTES);
+        buffer.putInt(partition);
+        buffer.putLong(getOffset());
+        return buffer.array();
+    }
+
+    /**
+     * Returns string representation in "partition:offset" format (e.g., "3:42").
+     * The parser in {@link KafkaConsumerFactory#parsePointerFromString(String)} detects the ":"
+     * to distinguish this format from the legacy plain offset format.
+     */
+    @Override
+    public String asString() {
+        return partition + ":" + getOffset();
+    }
+
+    @Override
+    public Field asPointField(String fieldName) {
+        // Encode as a single long for Lucene point indexing.
+        // Partition is stored in upper 16 bits (max 65,535 partitions),
+        // offset in lower 48 bits (max ~281 trillion).
+        // This preserves sort order within a partition.
+        // Note: Kafka topics exceeding 65,535 partitions will produce incorrect encoding.
+        long encoded = ((long) partition << 48) | (getOffset() & 0x0000FFFFFFFFFFFFL);
+        return new LongPoint(fieldName, encoded);
+    }
+
+    @Override
+    public Query newRangeQueryGreaterThan(String fieldName) {
+        // Scope the range query to the SAME partition — don't match offsets from other partitions.
+        long lower = ((long) partition << 48) | (getOffset() & 0x0000FFFFFFFFFFFFL);
+        long upper = ((long) partition << 48) | 0x0000FFFFFFFFFFFFL;
+        return LongPoint.newRangeQuery(fieldName, lower, upper);
+    }
+
+    /**
+     * Compares by partition first, then by offset within the same partition.
+     * Cross-partition comparison is ordered by partition ID — this is meaningful for checkpoint
+     * aggregation (min across partitions) but does NOT imply temporal ordering across partitions.
+     */
+    @Override
+    public int compareTo(IngestionShardPointer o) {
+        if (o == null) {
+            throw new IllegalArgumentException("the pointer is null");
+        }
+        if (o instanceof KafkaPartitionOffset other) {
+            int cmp = Integer.compare(partition, other.partition);
+            return cmp != 0 ? cmp : Long.compare(getOffset(), other.getOffset());
+        }
+        if (o instanceof KafkaOffset other) {
+            // Cross-type comparison: treat KafkaOffset as partition -1 so it sorts before all partition offsets
+            return 1; // KafkaPartitionOffset always > KafkaOffset
+        }
+        throw new IllegalArgumentException("Cannot compare KafkaPartitionOffset with " + o.getClass().getSimpleName());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        KafkaPartitionOffset that = (KafkaPartitionOffset) o;
+        return partition == that.partition && getOffset() == that.getOffset();
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(partition, getOffset());
+    }
+
+    @Override
+    public String toString() {
+        return "KafkaPartitionOffset{partition=" + partition + ", offset=" + getOffset() + '}';
+    }
+}

--- a/plugins/ingestion-kafka/src/main/java/org/opensearch/plugin/kafka/KafkaPartitionOffset.java
+++ b/plugins/ingestion-kafka/src/main/java/org/opensearch/plugin/kafka/KafkaPartitionOffset.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.plugin.kafka;
 
+import org.apache.lucene.search.Query;
 import org.opensearch.index.IngestionShardPointer;
 import org.opensearch.index.SourcePartitionAwarePointer;
 
@@ -20,9 +21,17 @@ import java.util.Objects;
  * while adding partition information via {@link SourcePartitionAwarePointer}.
  *
  * <p><b>TODO: partition-aware Lucene point field / range query.</b>
- * This class intentionally inherits {@link KafkaOffset#asPointField(String)} and
- * {@link KafkaOffset#newRangeQueryGreaterThan(String)}, so the indexed Lucene
- * {@code _offset} field carries only the raw offset (no partition).
+ * The write side ({@link #asPointField(String)}) intentionally inherits {@link KafkaOffset}'s
+ * implementation, so the indexed Lucene {@code _offset} field carries only the raw offset (no
+ * partition). Every multi-partition document writes this field on indexing — but it cannot be
+ * queried correctly per-partition until a proper per-partition field design lands.
+ *
+ * <p>The companion read method {@link #newRangeQueryGreaterThan(String)} is overridden to
+ * <b>throw</b> {@code UnsupportedOperationException} rather than silently returning the inherited
+ * cross-partition query (which would match documents from ANY partition with offset greater than
+ * this pointer's offset). The asymmetry is intentional: writing a placeholder field is harmless
+ * and required by the indexing path, but reading it via the standard pointer query API would
+ * silently produce wrong results.
  *
  * <p>This is not needed per se right now because:
  * <ul>
@@ -38,7 +47,10 @@ import java.util.Objects;
  *
  * <p>When this becomes needed (e.g., per-partition offset-range dedup as a fallback to
  * {@code _id} overwrite, partition-scoped diagnostic queries, or post-recovery cleanup),
- * the right design is two separate point fields.
+ * the right design is two separate point fields — an {@code IntPoint} for partition + the
+ * existing {@code LongPoint} for offset, combined via a {@code BooleanQuery}. That requires
+ * extending the {@link IngestionShardPointer} contract to return multiple fields, which should
+ * be done deliberately at the point a real caller is wired in.
  */
 public class KafkaPartitionOffset extends KafkaOffset implements SourcePartitionAwarePointer {
 
@@ -76,6 +88,28 @@ public class KafkaPartitionOffset extends KafkaOffset implements SourcePartition
     @Override
     public String asString() {
         return partition + ":" + getOffset();
+    }
+
+    /**
+     * Throws {@code UnsupportedOperationException} — see class-level Javadoc. Inheriting
+     * {@link KafkaOffset#newRangeQueryGreaterThan(String)} would silently match documents from
+     * ANY partition with an offset greater than this pointer's offset, since the indexed
+     * {@code _offset} field carries no partition info. Per-partition queries need a different
+     * field design (two separate indexed fields combined via {@code BooleanQuery}); throwing
+     * here forces future callers to recognize the multi-partition case rather than getting
+     * cross-partition matches by accident. No production caller today.
+     *
+     * @throws UnsupportedOperationException always
+     */
+    @Override
+    public Query newRangeQueryGreaterThan(String fieldName) {
+        throw new UnsupportedOperationException(
+            "newRangeQueryGreaterThan() inherited from KafkaOffset would match documents from ANY "
+                + "partition with offset greater than this pointer's offset, because the indexed "
+                + "_offset field carries no partition info. For per-partition dedup queries, the right "
+                + "design is two separate indexed fields (IntPoint for partition + LongPoint for offset) "
+                + "combined via BooleanQuery — requires extending the IngestionShardPointer interface."
+        );
     }
 
     /**

--- a/plugins/ingestion-kafka/src/main/java/org/opensearch/plugin/kafka/KafkaPartitionOffset.java
+++ b/plugins/ingestion-kafka/src/main/java/org/opensearch/plugin/kafka/KafkaPartitionOffset.java
@@ -8,11 +8,8 @@
 
 package org.opensearch.plugin.kafka;
 
-import org.apache.lucene.document.Field;
-import org.apache.lucene.document.LongPoint;
-import org.apache.lucene.search.Query;
 import org.opensearch.index.IngestionShardPointer;
-import org.opensearch.index.PartitionAwarePointer;
+import org.opensearch.index.SourcePartitionAwarePointer;
 
 import java.nio.ByteBuffer;
 import java.util.Objects;
@@ -20,9 +17,30 @@ import java.util.Objects;
 /**
  * A partition-aware Kafka offset that encodes both the partition ID and offset.
  * Extends {@link KafkaOffset} so it can be used wherever KafkaOffset is expected,
- * while adding partition information via {@link PartitionAwarePointer}.
+ * while adding partition information via {@link SourcePartitionAwarePointer}.
+ *
+ * <p><b>TODO: partition-aware Lucene point field / range query.</b>
+ * This class intentionally inherits {@link KafkaOffset#asPointField(String)} and
+ * {@link KafkaOffset#newRangeQueryGreaterThan(String)}, so the indexed Lucene
+ * {@code _offset} field carries only the raw offset (no partition).
+ *
+ * <p>This is not needed per se right now because:
+ * <ul>
+ *   <li>{@code newRangeQueryGreaterThan} has no production callers in the recovery path.
+ *       {@code IngestionEngine} recovers from per-partition checkpoints in Lucene commit
+ *       user data ({@code batch_start_p{N}}) and re-consumes from the source. Document-level
+ *       dedup relies on {@code _id}-based overwrite via Lucene's term-level update semantics,
+ *       not offset range queries.</li>
+ *   <li>Partition info is preserved where it is necessary: {@link #asString()} (stored field
+ *       and persisted commit data), {@link #serialize()}, {@link #compareTo}, equals/hashCode,
+ *       and {@link #getSourcePartition()} for in-memory per-partition checkpoint tracking.</li>
+ * </ul>
+ *
+ * <p>When this becomes needed (e.g., per-partition offset-range dedup as a fallback to
+ * {@code _id} overwrite, partition-scoped diagnostic queries, or post-recovery cleanup),
+ * the right design is two separate point fields.
  */
-public class KafkaPartitionOffset extends KafkaOffset implements PartitionAwarePointer {
+public class KafkaPartitionOffset extends KafkaOffset implements SourcePartitionAwarePointer {
 
     private final int partition;
 
@@ -38,7 +56,7 @@ public class KafkaPartitionOffset extends KafkaOffset implements PartitionAwareP
     }
 
     @Override
-    public int getPartition() {
+    public int getSourcePartition() {
         return partition;
     }
 
@@ -53,35 +71,16 @@ public class KafkaPartitionOffset extends KafkaOffset implements PartitionAwareP
     /**
      * Returns string representation in "partition:offset" format (e.g., "3:42").
      * The parser in {@link KafkaConsumerFactory#parsePointerFromString(String)} detects the ":"
-     * to distinguish this format from the legacy plain offset format.
+     * to distinguish this format from the simple plain offset format.
      */
     @Override
     public String asString() {
         return partition + ":" + getOffset();
     }
 
-    @Override
-    public Field asPointField(String fieldName) {
-        // Encode as a single long for Lucene point indexing.
-        // Partition is stored in upper 16 bits (max 65,535 partitions),
-        // offset in lower 48 bits (max ~281 trillion).
-        // This preserves sort order within a partition.
-        // Note: Kafka topics exceeding 65,535 partitions will produce incorrect encoding.
-        long encoded = ((long) partition << 48) | (getOffset() & 0x0000FFFFFFFFFFFFL);
-        return new LongPoint(fieldName, encoded);
-    }
-
-    @Override
-    public Query newRangeQueryGreaterThan(String fieldName) {
-        // Scope the range query to the SAME partition — don't match offsets from other partitions.
-        long lower = ((long) partition << 48) | (getOffset() & 0x0000FFFFFFFFFFFFL);
-        long upper = ((long) partition << 48) | 0x0000FFFFFFFFFFFFL;
-        return LongPoint.newRangeQuery(fieldName, lower, upper);
-    }
-
     /**
      * Compares by partition first, then by offset within the same partition.
-     * Cross-partition comparison is ordered by partition ID — this is meaningful for checkpoint
+     * Cross-partition comparison is ordered by partition ID, which is meaningful for checkpoint
      * aggregation (min across partitions) but does NOT imply temporal ordering across partitions.
      */
     @Override
@@ -93,9 +92,10 @@ public class KafkaPartitionOffset extends KafkaOffset implements PartitionAwareP
             int cmp = Integer.compare(partition, other.partition);
             return cmp != 0 ? cmp : Long.compare(getOffset(), other.getOffset());
         }
-        if (o instanceof KafkaOffset other) {
-            // Cross-type comparison: treat KafkaOffset as partition -1 so it sorts before all partition offsets
-            return 1; // KafkaPartitionOffset always > KafkaOffset
+        if (o instanceof KafkaOffset) {
+            // Cross-type comparison: KafkaPartitionOffset always sorts after legacy KafkaOffset.
+            // Matches the inverse in KafkaOffset.compareTo(KafkaPartitionOffset) which returns -1.
+            return 1;
         }
         throw new IllegalArgumentException("Cannot compare KafkaPartitionOffset with " + o.getClass().getSimpleName());
     }

--- a/plugins/ingestion-kafka/src/main/java/org/opensearch/plugin/kafka/KafkaPartitionOffset.java
+++ b/plugins/ingestion-kafka/src/main/java/org/opensearch/plugin/kafka/KafkaPartitionOffset.java
@@ -67,6 +67,33 @@ public class KafkaPartitionOffset extends KafkaOffset implements SourcePartition
         this.partition = partition;
     }
 
+    /**
+     * Parses a {@code "partition:offset"} string (e.g., {@code "3:42"}) into a
+     * {@link KafkaPartitionOffset}. Inverse of {@link #asString()}.
+     *
+     * @param s the {@code "partition:offset"} string
+     * @return the parsed {@link KafkaPartitionOffset}
+     * @throws IllegalArgumentException if {@code s} is not exactly two non-empty parts separated
+     *                                  by {@code ":"}, or if either part is not a valid number
+     */
+    public static KafkaPartitionOffset parse(String s) {
+        // split(":", -1) preserves trailing empty fields so "3:" yields ["3", ""] (length 2)
+        String[] parts = s.split(":", -1);
+        if (parts.length != 2 || parts[0].isEmpty() || parts[1].isEmpty()) {
+            throw new IllegalArgumentException(
+                "Invalid multi-partition pointer format. Expected 'partition:offset' (e.g., '3:42'), got: " + s
+            );
+        }
+        try {
+            return new KafkaPartitionOffset(Integer.parseInt(parts[0]), Long.parseLong(parts[1]));
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException(
+                "Invalid multi-partition pointer format. Expected numeric 'partition:offset' (e.g., '3:42'), got: " + s,
+                e
+            );
+        }
+    }
+
     @Override
     public int getSourcePartition() {
         return partition;

--- a/plugins/ingestion-kafka/src/test/java/org/opensearch/plugin/kafka/KafkaConsumerFactoryTests.java
+++ b/plugins/ingestion-kafka/src/test/java/org/opensearch/plugin/kafka/KafkaConsumerFactoryTests.java
@@ -39,6 +39,17 @@ public class KafkaConsumerFactoryTests extends OpenSearchTestCase {
         Assert.assertEquals("Offset value should be correctly parsed", 12345L, offset.getOffset());
     }
 
+    public void testParsePartitionOffsetFromString() {
+        KafkaConsumerFactory factory = new KafkaConsumerFactory();
+        KafkaOffset offset = factory.parsePointerFromString("3:42");
+
+        Assert.assertNotNull("Offset should be parsed", offset);
+        Assert.assertTrue("Should be KafkaPartitionOffset", offset instanceof KafkaPartitionOffset);
+        KafkaPartitionOffset partitionOffset = (KafkaPartitionOffset) offset;
+        Assert.assertEquals("Partition should be correctly parsed", 3, partitionOffset.getPartition());
+        Assert.assertEquals("Offset should be correctly parsed", 42L, partitionOffset.getOffset());
+    }
+
     public void testGetSourcePartitionCountBeforeInitialize() {
         KafkaConsumerFactory factory = new KafkaConsumerFactory();
         // Before initialize, config is null — calling getSourcePartitionCount should fail gracefully
@@ -52,8 +63,8 @@ public class KafkaConsumerFactoryTests extends OpenSearchTestCase {
         params.put("bootstrap_servers", "localhost:9092");
         factory.initialize(new IngestionSource.Builder("KAFKA").setParams(params).build());
 
-        // Single partition should delegate to createShardConsumer — will fail connecting to Kafka
-        // but we can verify it doesn't throw UnsupportedOperationException
+        // Single partition delegates to createShardConsumer — will fail connecting to Kafka
+        // but we verify it doesn't throw UnsupportedOperationException
         try {
             factory.createMultiPartitionShardConsumer("test-client", 0, List.of(0));
             fail("Expected exception connecting to Kafka");
@@ -71,11 +82,15 @@ public class KafkaConsumerFactoryTests extends OpenSearchTestCase {
         params.put("bootstrap_servers", "localhost:9092");
         factory.initialize(new IngestionSource.Builder("KAFKA").setParams(params).build());
 
-        // Multiple partitions should throw UnsupportedOperationException until KafkaMultiPartitionConsumer is implemented
-        UnsupportedOperationException e = expectThrows(
-            UnsupportedOperationException.class,
-            () -> factory.createMultiPartitionShardConsumer("test-client", 0, List.of(0, 4, 8))
-        );
-        assertTrue(e.getMessage().contains("Multi-partition consumer not yet implemented"));
+        // Multiple partitions creates KafkaMultiPartitionConsumer — will fail connecting to Kafka
+        // but we verify it doesn't throw UnsupportedOperationException
+        try {
+            factory.createMultiPartitionShardConsumer("test-client", 0, List.of(0, 4, 8));
+            fail("Expected exception connecting to Kafka");
+        } catch (UnsupportedOperationException e) {
+            fail("Multi-partition should not throw UnsupportedOperationException");
+        } catch (Exception e) {
+            // Expected — Kafka broker not available in unit test
+        }
     }
 }

--- a/plugins/ingestion-kafka/src/test/java/org/opensearch/plugin/kafka/KafkaConsumerFactoryTests.java
+++ b/plugins/ingestion-kafka/src/test/java/org/opensearch/plugin/kafka/KafkaConsumerFactoryTests.java
@@ -46,8 +46,26 @@ public class KafkaConsumerFactoryTests extends OpenSearchTestCase {
         Assert.assertNotNull("Offset should be parsed", offset);
         Assert.assertTrue("Should be KafkaPartitionOffset", offset instanceof KafkaPartitionOffset);
         KafkaPartitionOffset partitionOffset = (KafkaPartitionOffset) offset;
-        Assert.assertEquals("Partition should be correctly parsed", 3, partitionOffset.getPartition());
+        Assert.assertEquals("Partition should be correctly parsed", 3, partitionOffset.getSourcePartition());
         Assert.assertEquals("Offset should be correctly parsed", 42L, partitionOffset.getOffset());
+    }
+
+    public void testParsePartitionOffsetRejectsMalformed() {
+        KafkaConsumerFactory factory = new KafkaConsumerFactory();
+        // Three parts — should reject, not silently take first two
+        IllegalArgumentException tooManyParts = expectThrows(
+            IllegalArgumentException.class,
+            () -> factory.parsePointerFromString("3:42:99")
+        );
+        Assert.assertTrue(tooManyParts.getMessage().contains("partition:offset"));
+
+        // Empty partition
+        IllegalArgumentException emptyPartition = expectThrows(IllegalArgumentException.class, () -> factory.parsePointerFromString(":42"));
+        Assert.assertTrue(emptyPartition.getMessage().contains("partition:offset"));
+
+        // Empty offset
+        IllegalArgumentException emptyOffset = expectThrows(IllegalArgumentException.class, () -> factory.parsePointerFromString("3:"));
+        Assert.assertTrue(emptyOffset.getMessage().contains("partition:offset"));
     }
 
     public void testGetSourcePartitionCountBeforeInitialize() {
@@ -63,8 +81,11 @@ public class KafkaConsumerFactoryTests extends OpenSearchTestCase {
         params.put("bootstrap_servers", "localhost:9092");
         factory.initialize(new IngestionSource.Builder("KAFKA").setParams(params).build());
 
-        // Single partition delegates to createShardConsumer — will fail connecting to Kafka
-        // but we verify it doesn't throw UnsupportedOperationException
+        // Single-partition assignment now creates KafkaMultiPartitionConsumer (not
+        // KafkaPartitionConsumer) so produced pointers are KafkaPartitionOffset, preserving
+        // partition info needed by the per-partition checkpoint tracking. Will fail connecting
+        // to Kafka in a unit-test environment — we just verify it doesn't throw
+        // UnsupportedOperationException.
         try {
             factory.createMultiPartitionShardConsumer("test-client", 0, List.of(0));
             fail("Expected exception connecting to Kafka");

--- a/plugins/ingestion-kafka/src/test/java/org/opensearch/plugin/kafka/KafkaConsumerFactoryTests.java
+++ b/plugins/ingestion-kafka/src/test/java/org/opensearch/plugin/kafka/KafkaConsumerFactoryTests.java
@@ -13,6 +13,7 @@ import org.opensearch.test.OpenSearchTestCase;
 import org.junit.Assert;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class KafkaConsumerFactoryTests extends OpenSearchTestCase {
@@ -36,5 +37,45 @@ public class KafkaConsumerFactoryTests extends OpenSearchTestCase {
 
         Assert.assertNotNull("Offset should be parsed", offset);
         Assert.assertEquals("Offset value should be correctly parsed", 12345L, offset.getOffset());
+    }
+
+    public void testGetSourcePartitionCountBeforeInitialize() {
+        KafkaConsumerFactory factory = new KafkaConsumerFactory();
+        // Before initialize, config is null — calling getSourcePartitionCount should fail gracefully
+        expectThrows(AssertionError.class, factory::getSourcePartitionCount);
+    }
+
+    public void testCreateMultiPartitionShardConsumerSinglePartition() {
+        KafkaConsumerFactory factory = new KafkaConsumerFactory();
+        Map<String, Object> params = new HashMap<>();
+        params.put("topic", "test-topic");
+        params.put("bootstrap_servers", "localhost:9092");
+        factory.initialize(new IngestionSource.Builder("KAFKA").setParams(params).build());
+
+        // Single partition should delegate to createShardConsumer — will fail connecting to Kafka
+        // but we can verify it doesn't throw UnsupportedOperationException
+        try {
+            factory.createMultiPartitionShardConsumer("test-client", 0, List.of(0));
+            fail("Expected exception connecting to Kafka");
+        } catch (UnsupportedOperationException e) {
+            fail("Single partition should not throw UnsupportedOperationException");
+        } catch (Exception e) {
+            // Expected — Kafka broker not available in unit test
+        }
+    }
+
+    public void testCreateMultiPartitionShardConsumerMultiplePartitions() {
+        KafkaConsumerFactory factory = new KafkaConsumerFactory();
+        Map<String, Object> params = new HashMap<>();
+        params.put("topic", "test-topic");
+        params.put("bootstrap_servers", "localhost:9092");
+        factory.initialize(new IngestionSource.Builder("KAFKA").setParams(params).build());
+
+        // Multiple partitions should throw UnsupportedOperationException until KafkaMultiPartitionConsumer is implemented
+        UnsupportedOperationException e = expectThrows(
+            UnsupportedOperationException.class,
+            () -> factory.createMultiPartitionShardConsumer("test-client", 0, List.of(0, 4, 8))
+        );
+        assertTrue(e.getMessage().contains("Multi-partition consumer not yet implemented"));
     }
 }

--- a/plugins/ingestion-kafka/src/test/java/org/opensearch/plugin/kafka/KafkaMultiPartitionConsumerTests.java
+++ b/plugins/ingestion-kafka/src/test/java/org/opensearch/plugin/kafka/KafkaMultiPartitionConsumerTests.java
@@ -57,7 +57,7 @@ public class KafkaMultiPartitionConsumerTests extends OpenSearchTestCase {
     }
 
     private KafkaMultiPartitionConsumer createConsumer(List<Integer> partitionIds) {
-        return new KafkaMultiPartitionConsumer("test-client", config, 0, partitionIds, mockConsumer);
+        return new KafkaMultiPartitionConsumer(config, 0, partitionIds, mockConsumer);
     }
 
     // --- Construction ---
@@ -96,12 +96,8 @@ public class KafkaMultiPartitionConsumerTests extends OpenSearchTestCase {
         TopicPartition tp0 = new TopicPartition(TOPIC, 0);
         TopicPartition tp4 = new TopicPartition(TOPIC, 4);
         Map<TopicPartition, List<ConsumerRecord<byte[], byte[]>>> recordMap = new HashMap<>();
-        recordMap.put(tp0, List.of(
-            new ConsumerRecord<>(TOPIC, 0, 10L, "key0".getBytes(), "val0".getBytes())
-        ));
-        recordMap.put(tp4, List.of(
-            new ConsumerRecord<>(TOPIC, 4, 20L, "key4".getBytes(), "val4".getBytes())
-        ));
+        recordMap.put(tp0, List.of(new ConsumerRecord<>(TOPIC, 0, 10L, "key0".getBytes(), "val0".getBytes())));
+        recordMap.put(tp4, List.of(new ConsumerRecord<>(TOPIC, 4, 20L, "key4".getBytes(), "val4".getBytes())));
         ConsumerRecords<byte[], byte[]> consumerRecords = new ConsumerRecords<>(recordMap);
         when(mockConsumer.poll(any())).thenReturn(consumerRecords);
 
@@ -111,12 +107,12 @@ public class KafkaMultiPartitionConsumerTests extends OpenSearchTestCase {
 
         // First result from partition 0
         KafkaPartitionOffset ptr0 = (KafkaPartitionOffset) results.get(0).getPointer();
-        assertEquals(0, ptr0.getPartition());
+        assertEquals(0, ptr0.getSourcePartition());
         assertEquals(10L, ptr0.getOffset());
 
         // Second result from partition 4
         KafkaPartitionOffset ptr4 = (KafkaPartitionOffset) results.get(1).getPointer();
-        assertEquals(4, ptr4.getPartition());
+        assertEquals(4, ptr4.getSourcePartition());
         assertEquals(20L, ptr4.getOffset());
     }
 
@@ -129,28 +125,64 @@ public class KafkaMultiPartitionConsumerTests extends OpenSearchTestCase {
         assertTrue(results.isEmpty());
     }
 
-    // --- readNext with seek ---
+    // --- readNext(offset, ...) is unsupported in multi-partition mode ---
 
-    public void testReadNextWithPartitionOffsetSeeks() throws Exception {
+    public void testReadNextWithOffsetThrowsUnsupported() throws Exception {
+        // The seeking variant of readNext() has single-partition semantics that don't fit a
+        // multi-partition consumer (a single pointer can only reposition one of N partitions).
+        // Multi-partition seek must go through seekToPartitionOffsets(Map) instead. Verify the
+        // method throws for both KafkaPartitionOffset and plain KafkaOffset inputs.
         KafkaMultiPartitionConsumer consumer = createConsumer(List.of(0, 4));
-        when(mockConsumer.poll(any())).thenReturn(new ConsumerRecords<>(Collections.emptyMap()));
 
-        KafkaPartitionOffset offset = new KafkaPartitionOffset(4, 50);
-        consumer.readNext(offset, true, 100, 1000);
+        UnsupportedOperationException withPartitionOffset = expectThrows(
+            UnsupportedOperationException.class,
+            () -> consumer.readNext(new KafkaPartitionOffset(4, 50), true, 100, 1000)
+        );
+        assertTrue(withPartitionOffset.getMessage().contains("seekToPartitionOffsets"));
 
-        // Should seek partition 4 to offset 50
-        verify(mockConsumer).seek(new TopicPartition(TOPIC, 4), 50L);
+        UnsupportedOperationException withLegacyOffset = expectThrows(
+            UnsupportedOperationException.class,
+            () -> consumer.readNext(new KafkaOffset(50), true, 100, 1000)
+        );
+        assertTrue(withLegacyOffset.getMessage().contains("seekToPartitionOffsets"));
     }
 
-    public void testReadNextWithPartitionOffsetExcludeStart() throws Exception {
+    public void testPointerFromOffsetRejectsBareOffset() {
+        // Multi-partition mode requires explicit "partition:offset" — a bare numeric offset is
+        // ambiguous (which assigned partition?) so it must throw rather than silently fall back.
         KafkaMultiPartitionConsumer consumer = createConsumer(List.of(0, 4));
-        when(mockConsumer.poll(any())).thenReturn(new ConsumerRecords<>(Collections.emptyMap()));
 
-        KafkaPartitionOffset offset = new KafkaPartitionOffset(4, 50);
-        consumer.readNext(offset, false, 100, 1000);
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> consumer.pointerFromOffset("42"));
+        assertTrue(e.getMessage().contains("partition:offset"));
+    }
 
-        // Should seek partition 4 to offset 51 (exclude start)
-        verify(mockConsumer).seek(new TopicPartition(TOPIC, 4), 51L);
+    // --- Single-pointer methods are unsupported in multi-partition mode ---
+
+    public void testEarliestPointerThrowsUnsupported() {
+        // earliestPointer() returns a single pointer — meaningless across N assigned partitions.
+        // Callers must use seekToBeginning() directly for RESET_TO_EARLIEST.
+        KafkaMultiPartitionConsumer consumer = createConsumer(List.of(0, 4));
+        UnsupportedOperationException e = expectThrows(UnsupportedOperationException.class, consumer::earliestPointer);
+        assertTrue(e.getMessage().contains("seekToBeginning"));
+    }
+
+    public void testLatestPointerThrowsUnsupported() {
+        // latestPointer() — same single-partition limitation as earliestPointer().
+        // Callers must use seekToEnd() directly for RESET_TO_LATEST.
+        KafkaMultiPartitionConsumer consumer = createConsumer(List.of(0, 4));
+        UnsupportedOperationException e = expectThrows(UnsupportedOperationException.class, consumer::latestPointer);
+        assertTrue(e.getMessage().contains("seekToEnd"));
+    }
+
+    public void testPointerFromTimestampMillisThrowsUnsupported() {
+        // pointerFromTimestampMillis() returns single pointer for the first partition with data —
+        // non-deterministic and useless for multi-partition reset. PR 7.5 needs a per-partition variant.
+        KafkaMultiPartitionConsumer consumer = createConsumer(List.of(0, 4));
+        UnsupportedOperationException e = expectThrows(
+            UnsupportedOperationException.class,
+            () -> consumer.pointerFromTimestampMillis(System.currentTimeMillis())
+        );
+        assertTrue(e.getMessage().contains("per-partition"));
     }
 
     // --- seekToPartitionOffsets ---
@@ -158,10 +190,7 @@ public class KafkaMultiPartitionConsumerTests extends OpenSearchTestCase {
     public void testSeekToPartitionOffsets() {
         KafkaMultiPartitionConsumer consumer = createConsumer(List.of(0, 4));
 
-        Map<Integer, KafkaPartitionOffset> offsets = Map.of(
-            0, new KafkaPartitionOffset(0, 100),
-            4, new KafkaPartitionOffset(4, 200)
-        );
+        Map<Integer, KafkaPartitionOffset> offsets = Map.of(0, new KafkaPartitionOffset(0, 100), 4, new KafkaPartitionOffset(4, 200));
         consumer.seekToPartitionOffsets(offsets);
 
         verify(mockConsumer).seek(new TopicPartition(TOPIC, 0), 100L);
@@ -173,8 +202,10 @@ public class KafkaMultiPartitionConsumerTests extends OpenSearchTestCase {
 
         // Partition 7 is not assigned to this consumer — should be ignored
         Map<Integer, KafkaPartitionOffset> offsets = Map.of(
-            0, new KafkaPartitionOffset(0, 100),
-            7, new KafkaPartitionOffset(7, 300) // not assigned
+            0,
+            new KafkaPartitionOffset(0, 100),
+            7,
+            new KafkaPartitionOffset(7, 300) // not assigned
         );
         consumer.seekToPartitionOffsets(offsets);
 
@@ -188,10 +219,7 @@ public class KafkaMultiPartitionConsumerTests extends OpenSearchTestCase {
         KafkaMultiPartitionConsumer consumer = createConsumer(List.of(0, 4));
         consumer.seekToBeginning();
 
-        List<TopicPartition> expected = List.of(
-            new TopicPartition(TOPIC, 0),
-            new TopicPartition(TOPIC, 4)
-        );
+        List<TopicPartition> expected = List.of(new TopicPartition(TOPIC, 0), new TopicPartition(TOPIC, 4));
         verify(mockConsumer).seekToBeginning(expected);
     }
 
@@ -199,10 +227,7 @@ public class KafkaMultiPartitionConsumerTests extends OpenSearchTestCase {
         KafkaMultiPartitionConsumer consumer = createConsumer(List.of(0, 4));
         consumer.seekToEnd();
 
-        List<TopicPartition> expected = List.of(
-            new TopicPartition(TOPIC, 0),
-            new TopicPartition(TOPIC, 4)
-        );
+        List<TopicPartition> expected = List.of(new TopicPartition(TOPIC, 0), new TopicPartition(TOPIC, 4));
         verify(mockConsumer).seekToEnd(expected);
     }
 

--- a/plugins/ingestion-kafka/src/test/java/org/opensearch/plugin/kafka/KafkaMultiPartitionConsumerTests.java
+++ b/plugins/ingestion-kafka/src/test/java/org/opensearch/plugin/kafka/KafkaMultiPartitionConsumerTests.java
@@ -174,16 +174,10 @@ public class KafkaMultiPartitionConsumerTests extends OpenSearchTestCase {
         // and "3:" used to throw a cryptic ArrayIndexOutOfBoundsException.
         KafkaMultiPartitionConsumer consumer = createConsumer(List.of(0, 4));
 
-        IllegalArgumentException tooManyParts = expectThrows(
-            IllegalArgumentException.class,
-            () -> consumer.pointerFromOffset("3:42:99")
-        );
+        IllegalArgumentException tooManyParts = expectThrows(IllegalArgumentException.class, () -> consumer.pointerFromOffset("3:42:99"));
         assertTrue(tooManyParts.getMessage().contains("partition:offset"));
 
-        IllegalArgumentException emptyPartition = expectThrows(
-            IllegalArgumentException.class,
-            () -> consumer.pointerFromOffset(":42")
-        );
+        IllegalArgumentException emptyPartition = expectThrows(IllegalArgumentException.class, () -> consumer.pointerFromOffset(":42"));
         assertTrue(emptyPartition.getMessage().contains("partition:offset"));
 
         IllegalArgumentException emptyOffset = expectThrows(IllegalArgumentException.class, () -> consumer.pointerFromOffset("3:"));
@@ -290,6 +284,79 @@ public class KafkaMultiPartitionConsumerTests extends OpenSearchTestCase {
         // Lag: (100 - 90 - 1) + (100 - 80 - 1) = 9 + 19 = 28
         long lag = consumer.getPointerBasedLag(new KafkaPartitionOffset(0, 0));
         assertEquals(28, lag);
+    }
+
+    public void testGetPointerBasedLagBeforeAnyFetchUsesMatchingExpectedStartPointer() {
+        // No prior poll → lastFetchedOffsets is empty for both assigned partitions. The
+        // expectedStartPointer (KafkaPartitionOffset for partition 4) should be used as the
+        // start for partition 4 only; partition 0 has no matching expected start so falls
+        // through to "full lag = endOffset".
+        KafkaMultiPartitionConsumer consumer = createConsumer(List.of(0, 4));
+        TopicPartition tp0 = new TopicPartition(TOPIC, 0);
+        TopicPartition tp4 = new TopicPartition(TOPIC, 4);
+        Map<TopicPartition, Long> endOffsets = Map.of(tp0, 50L, tp4, 200L);
+        when(mockConsumer.endOffsets(anyCollection())).thenReturn(endOffsets);
+
+        // Expected start for partition 4 only at offset 100. Partition 0 has no expected start.
+        long lag = consumer.getPointerBasedLag(new KafkaPartitionOffset(4, 100));
+
+        // p0: no lastFetched + expectedStartPointer doesn't match (it's for p4) → use endOffset = 50
+        // p4: no lastFetched + expectedStartPointer matches → endOffset - startOffset = 200 - 100 = 100
+        // Total: 150
+        assertEquals(150, lag);
+    }
+
+    public void testGetPointerBasedLagWithLegacyKafkaOffsetExpectedStartFallsThroughToEndOffset() {
+        // expectedStartPointer is a plain KafkaOffset (not partition-aware). The instanceof
+        // KafkaPartitionOffset check fails for every partition, so each unfetched partition
+        // falls through to "full lag = endOffset". The legacy pointer is effectively ignored
+        // — documented best-effort behavior for mismatched pointer types.
+        KafkaMultiPartitionConsumer consumer = createConsumer(List.of(0, 4));
+        TopicPartition tp0 = new TopicPartition(TOPIC, 0);
+        TopicPartition tp4 = new TopicPartition(TOPIC, 4);
+        Map<TopicPartition, Long> endOffsets = Map.of(tp0, 50L, tp4, 200L);
+        when(mockConsumer.endOffsets(anyCollection())).thenReturn(endOffsets);
+
+        long lag = consumer.getPointerBasedLag(new KafkaOffset(100));
+
+        // Both partitions: no lastFetched + non-partition-aware expected → endOffset for each
+        // p0: 50, p4: 200, total: 250 (the start offset 100 is ignored — it can't be applied
+        // to any specific partition)
+        assertEquals(250, lag);
+    }
+
+    public void testGetPointerBasedLagMixedFetchedAndUnfetched() throws Exception {
+        // Realistic scenario: one partition has been polled (lastFetched populated), another
+        // hasn't (lastFetched null/missing). The expectedStartPointer covers the unfetched one.
+        KafkaMultiPartitionConsumer consumer = createConsumer(List.of(0, 4));
+        TopicPartition tp0 = new TopicPartition(TOPIC, 0);
+        TopicPartition tp4 = new TopicPartition(TOPIC, 4);
+
+        // Polling populates lastFetched for partition 0 only (partition 4 has no records).
+        Map<TopicPartition, List<ConsumerRecord<byte[], byte[]>>> recordMap = new HashMap<>();
+        recordMap.put(tp0, List.of(new ConsumerRecord<>(TOPIC, 0, 30L, null, null)));
+        when(mockConsumer.poll(any())).thenReturn(new ConsumerRecords<>(recordMap));
+        consumer.readNext(100, 1000);
+
+        Map<TopicPartition, Long> endOffsets = Map.of(tp0, 50L, tp4, 200L);
+        when(mockConsumer.endOffsets(anyCollection())).thenReturn(endOffsets);
+
+        // Expected start for partition 4 at offset 150.
+        long lag = consumer.getPointerBasedLag(new KafkaPartitionOffset(4, 150));
+
+        // p0: lastFetched=30 → endOffset - lastFetched - 1 = 50 - 30 - 1 = 19
+        // p4: no lastFetched + expectedStartPointer matches → 200 - 150 = 50
+        // Total: 69
+        assertEquals(69, lag);
+    }
+
+    public void testGetPointerBasedLagReturnsMinusOneOnException() {
+        // endOffsets() throwing should surface as -1, not propagate, per the catch in the method.
+        KafkaMultiPartitionConsumer consumer = createConsumer(List.of(0, 4));
+        when(mockConsumer.endOffsets(anyCollection())).thenThrow(new RuntimeException("kafka unavailable"));
+
+        long lag = consumer.getPointerBasedLag(new KafkaPartitionOffset(0, 0));
+        assertEquals(-1, lag);
     }
 
     // --- close ---

--- a/plugins/ingestion-kafka/src/test/java/org/opensearch/plugin/kafka/KafkaMultiPartitionConsumerTests.java
+++ b/plugins/ingestion-kafka/src/test/java/org/opensearch/plugin/kafka/KafkaMultiPartitionConsumerTests.java
@@ -1,0 +1,243 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.kafka;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
+import org.opensearch.index.IngestionShardConsumer;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@SuppressWarnings("unchecked")
+public class KafkaMultiPartitionConsumerTests extends OpenSearchTestCase {
+
+    private static final String TOPIC = "test-topic";
+
+    private Consumer<byte[], byte[]> mockConsumer;
+    private KafkaSourceConfig config;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        mockConsumer = mock(Consumer.class);
+        config = mock(KafkaSourceConfig.class);
+        when(config.getTopic()).thenReturn(TOPIC);
+
+        // Mock partition metadata — topic has 8 partitions
+        List<PartitionInfo> partitionInfos = List.of(
+            new PartitionInfo(TOPIC, 0, null, null, null),
+            new PartitionInfo(TOPIC, 1, null, null, null),
+            new PartitionInfo(TOPIC, 2, null, null, null),
+            new PartitionInfo(TOPIC, 3, null, null, null),
+            new PartitionInfo(TOPIC, 4, null, null, null),
+            new PartitionInfo(TOPIC, 5, null, null, null),
+            new PartitionInfo(TOPIC, 6, null, null, null),
+            new PartitionInfo(TOPIC, 7, null, null, null)
+        );
+        when(mockConsumer.partitionsFor(any(), any())).thenReturn(partitionInfos);
+    }
+
+    private KafkaMultiPartitionConsumer createConsumer(List<Integer> partitionIds) {
+        return new KafkaMultiPartitionConsumer("test-client", config, 0, partitionIds, mockConsumer);
+    }
+
+    // --- Construction ---
+
+    public void testConstructionAssignsAllPartitions() {
+        KafkaMultiPartitionConsumer consumer = createConsumer(List.of(0, 2, 4, 6));
+
+        List<TopicPartition> expected = List.of(
+            new TopicPartition(TOPIC, 0),
+            new TopicPartition(TOPIC, 2),
+            new TopicPartition(TOPIC, 4),
+            new TopicPartition(TOPIC, 6)
+        );
+        verify(mockConsumer).assign(expected);
+        assertEquals(List.of(0, 2, 4, 6), consumer.getAssignedPartitionIds());
+    }
+
+    public void testConstructionWithInvalidPartition() {
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> createConsumer(List.of(0, 9)) // partition 9 doesn't exist
+        );
+    }
+
+    public void testGetShardIdReturnsOpenSearchShardId() {
+        KafkaMultiPartitionConsumer consumer = createConsumer(List.of(0, 4));
+        assertEquals(0, consumer.getShardId()); // shard ID, not partition ID
+    }
+
+    // --- readNext (continuation) ---
+
+    public void testReadNextContinuation() throws Exception {
+        KafkaMultiPartitionConsumer consumer = createConsumer(List.of(0, 4));
+
+        // Mock poll returning records from both partitions
+        TopicPartition tp0 = new TopicPartition(TOPIC, 0);
+        TopicPartition tp4 = new TopicPartition(TOPIC, 4);
+        Map<TopicPartition, List<ConsumerRecord<byte[], byte[]>>> recordMap = new HashMap<>();
+        recordMap.put(tp0, List.of(
+            new ConsumerRecord<>(TOPIC, 0, 10L, "key0".getBytes(), "val0".getBytes())
+        ));
+        recordMap.put(tp4, List.of(
+            new ConsumerRecord<>(TOPIC, 4, 20L, "key4".getBytes(), "val4".getBytes())
+        ));
+        ConsumerRecords<byte[], byte[]> consumerRecords = new ConsumerRecords<>(recordMap);
+        when(mockConsumer.poll(any())).thenReturn(consumerRecords);
+
+        List<IngestionShardConsumer.ReadResult<KafkaOffset, KafkaMessage>> results = consumer.readNext(100, 1000);
+
+        assertEquals(2, results.size());
+
+        // First result from partition 0
+        KafkaPartitionOffset ptr0 = (KafkaPartitionOffset) results.get(0).getPointer();
+        assertEquals(0, ptr0.getPartition());
+        assertEquals(10L, ptr0.getOffset());
+
+        // Second result from partition 4
+        KafkaPartitionOffset ptr4 = (KafkaPartitionOffset) results.get(1).getPointer();
+        assertEquals(4, ptr4.getPartition());
+        assertEquals(20L, ptr4.getOffset());
+    }
+
+    public void testReadNextEmptyPoll() throws Exception {
+        KafkaMultiPartitionConsumer consumer = createConsumer(List.of(0, 4));
+
+        when(mockConsumer.poll(any())).thenReturn(new ConsumerRecords<>(Collections.emptyMap()));
+
+        List<IngestionShardConsumer.ReadResult<KafkaOffset, KafkaMessage>> results = consumer.readNext(100, 1000);
+        assertTrue(results.isEmpty());
+    }
+
+    // --- readNext with seek ---
+
+    public void testReadNextWithPartitionOffsetSeeks() throws Exception {
+        KafkaMultiPartitionConsumer consumer = createConsumer(List.of(0, 4));
+        when(mockConsumer.poll(any())).thenReturn(new ConsumerRecords<>(Collections.emptyMap()));
+
+        KafkaPartitionOffset offset = new KafkaPartitionOffset(4, 50);
+        consumer.readNext(offset, true, 100, 1000);
+
+        // Should seek partition 4 to offset 50
+        verify(mockConsumer).seek(new TopicPartition(TOPIC, 4), 50L);
+    }
+
+    public void testReadNextWithPartitionOffsetExcludeStart() throws Exception {
+        KafkaMultiPartitionConsumer consumer = createConsumer(List.of(0, 4));
+        when(mockConsumer.poll(any())).thenReturn(new ConsumerRecords<>(Collections.emptyMap()));
+
+        KafkaPartitionOffset offset = new KafkaPartitionOffset(4, 50);
+        consumer.readNext(offset, false, 100, 1000);
+
+        // Should seek partition 4 to offset 51 (exclude start)
+        verify(mockConsumer).seek(new TopicPartition(TOPIC, 4), 51L);
+    }
+
+    // --- seekToPartitionOffsets ---
+
+    public void testSeekToPartitionOffsets() {
+        KafkaMultiPartitionConsumer consumer = createConsumer(List.of(0, 4));
+
+        Map<Integer, KafkaPartitionOffset> offsets = Map.of(
+            0, new KafkaPartitionOffset(0, 100),
+            4, new KafkaPartitionOffset(4, 200)
+        );
+        consumer.seekToPartitionOffsets(offsets);
+
+        verify(mockConsumer).seek(new TopicPartition(TOPIC, 0), 100L);
+        verify(mockConsumer).seek(new TopicPartition(TOPIC, 4), 200L);
+    }
+
+    public void testSeekToPartitionOffsetsIgnoresUnassigned() {
+        KafkaMultiPartitionConsumer consumer = createConsumer(List.of(0, 4));
+
+        // Partition 7 is not assigned to this consumer — should be ignored
+        Map<Integer, KafkaPartitionOffset> offsets = Map.of(
+            0, new KafkaPartitionOffset(0, 100),
+            7, new KafkaPartitionOffset(7, 300) // not assigned
+        );
+        consumer.seekToPartitionOffsets(offsets);
+
+        verify(mockConsumer).seek(new TopicPartition(TOPIC, 0), 100L);
+        // partition 7 seek should NOT be called
+    }
+
+    // --- seekToBeginning / seekToEnd ---
+
+    public void testSeekToBeginning() {
+        KafkaMultiPartitionConsumer consumer = createConsumer(List.of(0, 4));
+        consumer.seekToBeginning();
+
+        List<TopicPartition> expected = List.of(
+            new TopicPartition(TOPIC, 0),
+            new TopicPartition(TOPIC, 4)
+        );
+        verify(mockConsumer).seekToBeginning(expected);
+    }
+
+    public void testSeekToEnd() {
+        KafkaMultiPartitionConsumer consumer = createConsumer(List.of(0, 4));
+        consumer.seekToEnd();
+
+        List<TopicPartition> expected = List.of(
+            new TopicPartition(TOPIC, 0),
+            new TopicPartition(TOPIC, 4)
+        );
+        verify(mockConsumer).seekToEnd(expected);
+    }
+
+    // --- getPointerBasedLag ---
+
+    public void testGetPointerBasedLagSumsAcrossPartitions() {
+        KafkaMultiPartitionConsumer consumer = createConsumer(List.of(0, 4));
+
+        // Simulate fetched offsets by polling
+        TopicPartition tp0 = new TopicPartition(TOPIC, 0);
+        TopicPartition tp4 = new TopicPartition(TOPIC, 4);
+        Map<TopicPartition, List<ConsumerRecord<byte[], byte[]>>> recordMap = new HashMap<>();
+        recordMap.put(tp0, List.of(new ConsumerRecord<>(TOPIC, 0, 90L, null, null)));
+        recordMap.put(tp4, List.of(new ConsumerRecord<>(TOPIC, 4, 80L, null, null)));
+        when(mockConsumer.poll(any())).thenReturn(new ConsumerRecords<>(recordMap));
+        try {
+            consumer.readNext(100, 1000);
+        } catch (Exception e) {
+            // ignore
+        }
+
+        // Mock end offsets
+        Map<TopicPartition, Long> endOffsets = Map.of(tp0, 100L, tp4, 100L);
+        when(mockConsumer.endOffsets(anyCollection())).thenReturn(endOffsets);
+
+        // Lag: (100 - 90 - 1) + (100 - 80 - 1) = 9 + 19 = 28
+        long lag = consumer.getPointerBasedLag(new KafkaPartitionOffset(0, 0));
+        assertEquals(28, lag);
+    }
+
+    // --- close ---
+
+    public void testClose() throws Exception {
+        KafkaMultiPartitionConsumer consumer = createConsumer(List.of(0, 4));
+        consumer.close();
+        verify(mockConsumer).close();
+    }
+}

--- a/plugins/ingestion-kafka/src/test/java/org/opensearch/plugin/kafka/KafkaMultiPartitionConsumerTests.java
+++ b/plugins/ingestion-kafka/src/test/java/org/opensearch/plugin/kafka/KafkaMultiPartitionConsumerTests.java
@@ -14,6 +14,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.opensearch.index.IngestionShardConsumer;
+import org.opensearch.index.IngestionShardPointer;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.util.Collections;
@@ -154,6 +155,39 @@ public class KafkaMultiPartitionConsumerTests extends OpenSearchTestCase {
 
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> consumer.pointerFromOffset("42"));
         assertTrue(e.getMessage().contains("partition:offset"));
+    }
+
+    public void testPointerFromOffsetParsesPartitionOffset() {
+        // Happy path — "partition:offset" parses to a KafkaPartitionOffset with the right values.
+        KafkaMultiPartitionConsumer consumer = createConsumer(List.of(0, 4));
+
+        IngestionShardPointer pointer = consumer.pointerFromOffset("4:42");
+        assertTrue("Should be KafkaPartitionOffset", pointer instanceof KafkaPartitionOffset);
+        KafkaPartitionOffset partitionOffset = (KafkaPartitionOffset) pointer;
+        assertEquals(4, partitionOffset.getSourcePartition());
+        assertEquals(42L, partitionOffset.getOffset());
+    }
+
+    public void testPointerFromOffsetRejectsMalformed() {
+        // Mirrors KafkaConsumerFactoryTests.testParsePartitionOffsetRejectsMalformed — both parsers
+        // must validate identically. Without this, "3:42:99" used to silently truncate to (3, 42)
+        // and "3:" used to throw a cryptic ArrayIndexOutOfBoundsException.
+        KafkaMultiPartitionConsumer consumer = createConsumer(List.of(0, 4));
+
+        IllegalArgumentException tooManyParts = expectThrows(
+            IllegalArgumentException.class,
+            () -> consumer.pointerFromOffset("3:42:99")
+        );
+        assertTrue(tooManyParts.getMessage().contains("partition:offset"));
+
+        IllegalArgumentException emptyPartition = expectThrows(
+            IllegalArgumentException.class,
+            () -> consumer.pointerFromOffset(":42")
+        );
+        assertTrue(emptyPartition.getMessage().contains("partition:offset"));
+
+        IllegalArgumentException emptyOffset = expectThrows(IllegalArgumentException.class, () -> consumer.pointerFromOffset("3:"));
+        assertTrue(emptyOffset.getMessage().contains("partition:offset"));
     }
 
     // --- Single-pointer methods are unsupported in multi-partition mode ---

--- a/plugins/ingestion-kafka/src/test/java/org/opensearch/plugin/kafka/KafkaPartitionConsumerTests.java
+++ b/plugins/ingestion-kafka/src/test/java/org/opensearch/plugin/kafka/KafkaPartitionConsumerTests.java
@@ -67,7 +67,6 @@ public class KafkaPartitionConsumerTests extends OpenSearchTestCase {
         assertEquals(1, result.size());
         assertEquals("message", new String(result.get(0).getMessage().getPayload(), StandardCharsets.UTF_8));
         assertEquals(0, consumer.getShardId());
-        assertEquals("client1", consumer.getClientId());
     }
 
     public void testEarliestPointer() {

--- a/plugins/ingestion-kafka/src/test/java/org/opensearch/plugin/kafka/KafkaPartitionOffsetTests.java
+++ b/plugins/ingestion-kafka/src/test/java/org/opensearch/plugin/kafka/KafkaPartitionOffsetTests.java
@@ -8,10 +8,8 @@
 
 package org.opensearch.plugin.kafka;
 
-import org.apache.lucene.document.Field;
-import org.apache.lucene.document.LongPoint;
-import org.apache.lucene.search.Query;
 import org.opensearch.index.IngestionShardPointer;
+import org.opensearch.index.SourcePartitionAwarePointer;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.nio.ByteBuffer;
@@ -32,7 +30,7 @@ public class KafkaPartitionOffsetTests extends OpenSearchTestCase {
 
     public void testGetters() {
         KafkaPartitionOffset offset = new KafkaPartitionOffset(7, 12345);
-        assertEquals(7, offset.getPartition());
+        assertEquals(7, offset.getSourcePartition());
         assertEquals(12345L, offset.getOffset());
     }
 
@@ -110,30 +108,6 @@ public class KafkaPartitionOffsetTests extends OpenSearchTestCase {
         assertNotEquals(legacyOffset, partitionOffset); // symmetry
     }
 
-    // --- asPointField encoding ---
-
-    public void testAsPointFieldEncoding() {
-        KafkaPartitionOffset offset = new KafkaPartitionOffset(3, 42);
-        Field field = offset.asPointField("test_field");
-        assertNotNull(field);
-        // Partition 3 in upper 16 bits, offset 42 in lower 48 bits
-        long expected = ((long) 3 << 48) | 42L;
-        // LongPoint stores the value internally — we verify via the encoded bytes
-        assertEquals("test_field", field.name());
-    }
-
-    // --- newRangeQueryGreaterThan scoped to same partition ---
-
-    public void testRangeQueryScopedToPartition() {
-        KafkaPartitionOffset offset = new KafkaPartitionOffset(3, 42);
-        Query query = offset.newRangeQueryGreaterThan("test_field");
-        assertNotNull(query);
-        // The query should be a range within partition 3 only
-        // Verify it's a LongPoint range query (toString includes the range bounds)
-        String queryStr = query.toString();
-        assertTrue("Query should be a point range query", queryStr.contains("test_field"));
-    }
-
     // --- toString ---
 
     public void testToString() {
@@ -145,8 +119,8 @@ public class KafkaPartitionOffsetTests extends OpenSearchTestCase {
 
     public void testImplementsPartitionAwarePointer() {
         KafkaPartitionOffset offset = new KafkaPartitionOffset(5, 100);
-        assertTrue(offset instanceof org.opensearch.index.PartitionAwarePointer);
-        assertEquals(5, offset.getPartition());
+        assertTrue(offset instanceof SourcePartitionAwarePointer);
+        assertEquals(5, offset.getSourcePartition());
     }
 
     // --- extends KafkaOffset ---

--- a/plugins/ingestion-kafka/src/test/java/org/opensearch/plugin/kafka/KafkaPartitionOffsetTests.java
+++ b/plugins/ingestion-kafka/src/test/java/org/opensearch/plugin/kafka/KafkaPartitionOffsetTests.java
@@ -130,4 +130,19 @@ public class KafkaPartitionOffsetTests extends OpenSearchTestCase {
         assertTrue(offset instanceof KafkaOffset);
         assertTrue(offset instanceof IngestionShardPointer);
     }
+
+    // --- newRangeQueryGreaterThan throws (overridden, see class-level Javadoc) ---
+
+    public void testNewRangeQueryGreaterThanThrowsUnsupported() {
+        // Inheriting KafkaOffset.newRangeQueryGreaterThan would silently match documents from ANY
+        // partition with offset > this pointer's offset (the indexed _offset field carries no
+        // partition info). Override throws to prevent that cross-partition false-match. Per-partition
+        // queries need a different field design — guarded by this throw until that lands.
+        KafkaPartitionOffset offset = new KafkaPartitionOffset(3, 42);
+        UnsupportedOperationException e = expectThrows(
+            UnsupportedOperationException.class,
+            () -> offset.newRangeQueryGreaterThan("test_field")
+        );
+        assertTrue(e.getMessage().contains("partition"));
+    }
 }

--- a/plugins/ingestion-kafka/src/test/java/org/opensearch/plugin/kafka/KafkaPartitionOffsetTests.java
+++ b/plugins/ingestion-kafka/src/test/java/org/opensearch/plugin/kafka/KafkaPartitionOffsetTests.java
@@ -1,0 +1,159 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.kafka;
+
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.LongPoint;
+import org.apache.lucene.search.Query;
+import org.opensearch.index.IngestionShardPointer;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.nio.ByteBuffer;
+
+public class KafkaPartitionOffsetTests extends OpenSearchTestCase {
+
+    // --- asString / parse roundtrip ---
+
+    public void testAsString() {
+        KafkaPartitionOffset offset = new KafkaPartitionOffset(3, 42);
+        assertEquals("3:42", offset.asString());
+    }
+
+    public void testAsStringZeros() {
+        KafkaPartitionOffset offset = new KafkaPartitionOffset(0, 0);
+        assertEquals("0:0", offset.asString());
+    }
+
+    public void testGetters() {
+        KafkaPartitionOffset offset = new KafkaPartitionOffset(7, 12345);
+        assertEquals(7, offset.getPartition());
+        assertEquals(12345L, offset.getOffset());
+    }
+
+    // --- serialize / deserialize ---
+
+    public void testSerialize() {
+        KafkaPartitionOffset offset = new KafkaPartitionOffset(3, 42);
+        byte[] bytes = offset.serialize();
+        assertEquals(Integer.BYTES + Long.BYTES, bytes.length);
+
+        ByteBuffer buf = ByteBuffer.wrap(bytes);
+        assertEquals(3, buf.getInt());
+        assertEquals(42L, buf.getLong());
+    }
+
+    // --- compareTo ---
+
+    public void testCompareSamePartitionDifferentOffset() {
+        KafkaPartitionOffset a = new KafkaPartitionOffset(3, 42);
+        KafkaPartitionOffset b = new KafkaPartitionOffset(3, 100);
+        assertTrue(a.compareTo(b) < 0);
+        assertTrue(b.compareTo(a) > 0);
+    }
+
+    public void testCompareSamePartitionSameOffset() {
+        KafkaPartitionOffset a = new KafkaPartitionOffset(3, 42);
+        KafkaPartitionOffset b = new KafkaPartitionOffset(3, 42);
+        assertEquals(0, a.compareTo(b));
+    }
+
+    public void testCompareDifferentPartitions() {
+        KafkaPartitionOffset a = new KafkaPartitionOffset(1, 1000);
+        KafkaPartitionOffset b = new KafkaPartitionOffset(5, 1);
+        assertTrue(a.compareTo(b) < 0); // partition 1 < partition 5
+    }
+
+    public void testCompareWithLegacyKafkaOffset() {
+        KafkaPartitionOffset partitionOffset = new KafkaPartitionOffset(3, 42);
+        KafkaOffset legacyOffset = new KafkaOffset(42);
+        // KafkaPartitionOffset always sorts after legacy KafkaOffset
+        assertTrue(partitionOffset.compareTo(legacyOffset) > 0);
+    }
+
+    public void testCompareWithNull() {
+        KafkaPartitionOffset offset = new KafkaPartitionOffset(3, 42);
+        expectThrows(IllegalArgumentException.class, () -> offset.compareTo(null));
+    }
+
+    // --- equals / hashCode ---
+
+    public void testEqualsSame() {
+        KafkaPartitionOffset a = new KafkaPartitionOffset(3, 42);
+        KafkaPartitionOffset b = new KafkaPartitionOffset(3, 42);
+        assertEquals(a, b);
+        assertEquals(a.hashCode(), b.hashCode());
+    }
+
+    public void testNotEqualsDifferentPartition() {
+        KafkaPartitionOffset a = new KafkaPartitionOffset(3, 42);
+        KafkaPartitionOffset b = new KafkaPartitionOffset(4, 42);
+        assertNotEquals(a, b);
+    }
+
+    public void testNotEqualsDifferentOffset() {
+        KafkaPartitionOffset a = new KafkaPartitionOffset(3, 42);
+        KafkaPartitionOffset b = new KafkaPartitionOffset(3, 43);
+        assertNotEquals(a, b);
+    }
+
+    public void testEqualsSymmetryWithLegacyKafkaOffset() {
+        // KafkaPartitionOffset uses getClass() check — not equal to KafkaOffset even with same offset
+        KafkaPartitionOffset partitionOffset = new KafkaPartitionOffset(3, 42);
+        KafkaOffset legacyOffset = new KafkaOffset(42);
+        assertNotEquals(partitionOffset, legacyOffset);
+        assertNotEquals(legacyOffset, partitionOffset); // symmetry
+    }
+
+    // --- asPointField encoding ---
+
+    public void testAsPointFieldEncoding() {
+        KafkaPartitionOffset offset = new KafkaPartitionOffset(3, 42);
+        Field field = offset.asPointField("test_field");
+        assertNotNull(field);
+        // Partition 3 in upper 16 bits, offset 42 in lower 48 bits
+        long expected = ((long) 3 << 48) | 42L;
+        // LongPoint stores the value internally — we verify via the encoded bytes
+        assertEquals("test_field", field.name());
+    }
+
+    // --- newRangeQueryGreaterThan scoped to same partition ---
+
+    public void testRangeQueryScopedToPartition() {
+        KafkaPartitionOffset offset = new KafkaPartitionOffset(3, 42);
+        Query query = offset.newRangeQueryGreaterThan("test_field");
+        assertNotNull(query);
+        // The query should be a range within partition 3 only
+        // Verify it's a LongPoint range query (toString includes the range bounds)
+        String queryStr = query.toString();
+        assertTrue("Query should be a point range query", queryStr.contains("test_field"));
+    }
+
+    // --- toString ---
+
+    public void testToString() {
+        KafkaPartitionOffset offset = new KafkaPartitionOffset(3, 42);
+        assertEquals("KafkaPartitionOffset{partition=3, offset=42}", offset.toString());
+    }
+
+    // --- PartitionAwarePointer interface ---
+
+    public void testImplementsPartitionAwarePointer() {
+        KafkaPartitionOffset offset = new KafkaPartitionOffset(5, 100);
+        assertTrue(offset instanceof org.opensearch.index.PartitionAwarePointer);
+        assertEquals(5, offset.getPartition());
+    }
+
+    // --- extends KafkaOffset ---
+
+    public void testExtendsKafkaOffset() {
+        KafkaPartitionOffset offset = new KafkaPartitionOffset(3, 42);
+        assertTrue(offset instanceof KafkaOffset);
+        assertTrue(offset instanceof IngestionShardPointer);
+    }
+}

--- a/server/src/main/java/org/opensearch/index/IngestionConsumerFactory.java
+++ b/server/src/main/java/org/opensearch/index/IngestionConsumerFactory.java
@@ -11,6 +11,8 @@ package org.opensearch.index;
 import org.opensearch.cluster.metadata.IngestionSource;
 import org.opensearch.common.annotation.PublicApi;
 
+import java.util.List;
+
 /**
  * A factory for creating {@link IngestionShardConsumer}.
  *
@@ -45,4 +47,34 @@ public interface IngestionConsumerFactory<T extends IngestionShardConsumer, P ex
      * @return the recovered pointer
      */
     P parsePointerFromString(String pointer);
+
+    /**
+     * Returns the total number of partitions available in the source stream. This is used to compute
+     * partition-to-shard assignments when {@code partition_strategy} is set to {@code auto}.
+     * <p>
+     * The default implementation returns -1, indicating that the source does not support partition
+     * count discovery. Implementations should override this method to enable multi-partition consumption.
+     *
+     * @return the total number of source partitions, or -1 if unknown
+     */
+    default int getSourcePartitionCount() {
+        return -1;
+    }
+
+    /**
+     * Create a consumer for a shard that reads from multiple source partitions. This is used when
+     * {@code partition_strategy} is set to {@code auto} and a shard is assigned more than one partition.
+     * <p>
+     * The default implementation falls back to {@link #createShardConsumer(String, int)}, which creates
+     * a single-partition consumer using the shard ID as the partition ID (legacy 1:1 behavior).
+     * Implementations should override this method to support multi-partition consumption.
+     *
+     * @param clientId the client id assigned to the consumer
+     * @param shardId the OpenSearch shard id
+     * @param partitionIds the list of source partition IDs to consume from
+     * @return the created consumer
+     */
+    default T createMultiPartitionShardConsumer(String clientId, int shardId, List<Integer> partitionIds) {
+        return createShardConsumer(clientId, shardId);
+    }
 }

--- a/server/src/main/java/org/opensearch/index/IngestionConsumerFactory.java
+++ b/server/src/main/java/org/opensearch/index/IngestionConsumerFactory.java
@@ -50,7 +50,7 @@ public interface IngestionConsumerFactory<T extends IngestionShardConsumer, P ex
 
     /**
      * Returns the total number of partitions available in the source stream. This is used to compute
-     * partition-to-shard assignments when {@code partition_strategy} is set to {@code auto}.
+     * partition-to-shard assignments. See {@link org.opensearch.indices.pollingingest.SourcePartitionAssignment}
      * <p>
      * The default implementation returns -1, indicating that the source does not support partition
      * count discovery. Implementations should override this method to enable multi-partition consumption.
@@ -62,11 +62,10 @@ public interface IngestionConsumerFactory<T extends IngestionShardConsumer, P ex
     }
 
     /**
-     * Create a consumer for a shard that reads from multiple source partitions. This is used when
-     * {@code partition_strategy} is set to {@code auto} and a shard is assigned more than one partition.
+     * Create a consumer for a shard that reads from multiple source partitions. This is used when a shard is assigned more than one partition.
      * <p>
      * The default implementation falls back to {@link #createShardConsumer(String, int)}, which creates
-     * a single-partition consumer using the shard ID as the partition ID (legacy 1:1 behavior).
+     * a single-partition consumer using the shard ID as the partition ID (simple 1:1 behavior).
      * Implementations should override this method to support multi-partition consumption.
      *
      * @param clientId the client id assigned to the consumer

--- a/server/src/main/java/org/opensearch/index/IngestionShardConsumer.java
+++ b/server/src/main/java/org/opensearch/index/IngestionShardConsumer.java
@@ -12,6 +12,7 @@ import org.opensearch.common.annotation.PublicApi;
 
 import java.io.Closeable;
 import java.util.List;
+import java.util.Map;
 
 /**
  * A consumer for reading messages from an ingestion shard.
@@ -116,4 +117,18 @@ public interface IngestionShardConsumer<T extends IngestionShardPointer, M exten
      * @return pointer based lag if available, else 0.
      */
     long getPointerBasedLag(IngestionShardPointer expectedStartPointer);
+
+    /**
+     * Seek multiple partitions to their respective offsets in a single operation. Used during recovery
+     * when a shard consumes from multiple source partitions and each partition must resume from its
+     * own checkpoint.
+     * <p>
+     * The default implementation is a no-op. Consumers that support multi-partition consumption
+     * should override this method.
+     *
+     * @param partitionOffsets map of source partition ID to the offset to seek to
+     */
+    default void seekToPartitionOffsets(Map<Integer, ? extends IngestionShardPointer> partitionOffsets) {
+        // no-op for single-partition consumers
+    }
 }

--- a/server/src/main/java/org/opensearch/index/PartitionAwarePointer.java
+++ b/server/src/main/java/org/opensearch/index/PartitionAwarePointer.java
@@ -1,0 +1,25 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index;
+
+/**
+ * Marker interface for {@link IngestionShardPointer} implementations that carry source partition
+ * information. Used by the checkpoint tracking layer to maintain per-partition progress when a
+ * single shard consumes from multiple source partitions.
+ * <p>
+ * Implementations should return the source partition ID (e.g., Kafka partition number) from
+ * {@link #getPartition()}.
+ */
+public interface PartitionAwarePointer {
+    /**
+     * Returns the source partition ID that this pointer belongs to.
+     * @return the partition ID
+     */
+    int getPartition();
+}

--- a/server/src/main/java/org/opensearch/index/SourcePartitionAwarePointer.java
+++ b/server/src/main/java/org/opensearch/index/SourcePartitionAwarePointer.java
@@ -8,18 +8,21 @@
 
 package org.opensearch.index;
 
+import org.opensearch.common.annotation.PublicApi;
+
 /**
  * Marker interface for {@link IngestionShardPointer} implementations that carry source partition
  * information. Used by the checkpoint tracking layer to maintain per-partition progress when a
  * single shard consumes from multiple source partitions.
  * <p>
  * Implementations should return the source partition ID (e.g., Kafka partition number) from
- * {@link #getPartition()}.
+ * {@link #getSourcePartition()}.
  */
-public interface PartitionAwarePointer {
+@PublicApi(since = "3.7.0")
+public interface SourcePartitionAwarePointer {
     /**
      * Returns the source partition ID that this pointer belongs to.
      * @return the partition ID
      */
-    int getPartition();
+    int getSourcePartition();
 }

--- a/server/src/test/java/org/opensearch/indices/pollingingest/IngestionConsumerFactoryDefaultMethodsTests.java
+++ b/server/src/test/java/org/opensearch/indices/pollingingest/IngestionConsumerFactoryDefaultMethodsTests.java
@@ -1,0 +1,62 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.indices.pollingingest;
+
+import org.opensearch.cluster.metadata.IngestionSource;
+import org.opensearch.index.IngestionConsumerFactory;
+import org.opensearch.index.IngestionShardConsumer;
+import org.opensearch.index.IngestionShardPointer;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+
+public class IngestionConsumerFactoryDefaultMethodsTests extends OpenSearchTestCase {
+
+    /**
+     * Minimal implementation that only implements required methods — verifies default methods work.
+     */
+    private static class MinimalFactory implements IngestionConsumerFactory<IngestionShardConsumer, IngestionShardPointer> {
+        @Override
+        public void initialize(IngestionSource ingestionSource) {}
+
+        @Override
+        public IngestionShardConsumer createShardConsumer(String clientId, int shardId) {
+            return mock(IngestionShardConsumer.class);
+        }
+
+        @Override
+        public IngestionShardPointer parsePointerFromString(String pointer) {
+            return mock(IngestionShardPointer.class);
+        }
+    }
+
+    public void testDefaultGetSourcePartitionCount() {
+        MinimalFactory factory = new MinimalFactory();
+        assertEquals(-1, factory.getSourcePartitionCount());
+    }
+
+    public void testDefaultCreateMultiPartitionShardConsumer() {
+        MinimalFactory factory = new MinimalFactory();
+        // Default falls back to createShardConsumer — should not throw
+        IngestionShardConsumer consumer = factory.createMultiPartitionShardConsumer("client", 0, List.of(0, 1, 2));
+        assertNotNull(consumer);
+    }
+
+    public void testDefaultCreateMultiPartitionShardConsumerIgnoresPartitionIds() {
+        MinimalFactory factory = new MinimalFactory();
+        // Default implementation ignores partitionIds and calls createShardConsumer(clientId, shardId)
+        // So it should work with any partition list
+        IngestionShardConsumer consumer1 = factory.createMultiPartitionShardConsumer("client", 0, List.of(5));
+        IngestionShardConsumer consumer2 = factory.createMultiPartitionShardConsumer("client", 0, List.of(0, 4, 8, 12));
+        assertNotNull(consumer1);
+        assertNotNull(consumer2);
+    }
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Introduces the consumer layer for flexible shard-to-partition mapping, enabling a single OpenSearch shard to consume from multiple Kafka partitions. 

### Related Issues
Resolves #21260

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
