### PR TITLE
Fix TOCTOU race in newEngineReference null checks during engine reset (#21404)

### DIFF
--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -5544,28 +5544,31 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
             ) {
                 @Override
                 public GatedCloseable<IndexCommit> acquireLastIndexCommit(boolean flushFirst) {
-                    if (newEngineReference.get() == null) {
+                    Indexer indexer = newEngineReference.get();
+                    if (indexer == null) {
                         throw new AlreadyClosedException("engine was closed");
                     }
                     // ignore flushFirst since we flushed above and we do not want to interfere with ongoing translog replay
-                    return applyOnEngine(newEngineReference.get(), engine -> engine.acquireLastIndexCommit(false));
+                    return applyOnEngine(indexer, e -> e.acquireLastIndexCommit(false));
                 }
 
                 @Override
                 public GatedCloseable<IndexCommit> acquireSafeIndexCommit() {
-                    if (newEngineReference.get() == null) {
+                    Indexer indexer = newEngineReference.get();
+                    if (indexer == null) {
                         throw new AlreadyClosedException("engine was closed");
                     }
-                    return applyOnEngine(newEngineReference.get(), Engine::acquireSafeIndexCommit);
+                    return applyOnEngine(indexer, Engine::acquireSafeIndexCommit);
                 }
 
                 @Override
                 public GatedCloseable<CatalogSnapshot> acquireSafeCatalogSnapshot() {
                     synchronized (engineMutex) {
-                        if (newEngineReference.get() == null) {
+                        Indexer indexer = newEngineReference.get();
+                        if (indexer == null) {
                             throw new AlreadyClosedException("engine was closed");
                         }
-                        return applyOnEngine(newEngineReference.get(), Engine::acquireSafeCatalogSnapshot);
+                        return applyOnEngine(indexer, Engine::acquireSafeCatalogSnapshot);
                     }
                 }
 


### PR DESCRIPTION
Store newEngineReference.get() in a local variable before the null check to prevent a race where another thread nulls the reference between the check and subsequent use, which would cause a NullPointerException.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
