### PR TITLE
Enable streaming transport in analytics-engine-rest QA by default

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionReduceSink.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionReduceSink.java
@@ -10,6 +10,7 @@ package org.opensearch.be.datafusion;
 
 import org.apache.arrow.c.ArrowArray;
 import org.apache.arrow.c.ArrowSchema;
+import org.apache.arrow.c.CDataDictionaryProvider;
 import org.apache.arrow.c.Data;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.vector.FieldVector;
@@ -17,6 +18,7 @@ import org.apache.arrow.vector.VarCharVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.ViewVarCharVector;
 import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -26,8 +28,12 @@ import org.opensearch.analytics.spi.MultiInputExchangeSink;
 import org.opensearch.be.datafusion.nativelib.NativeBridge;
 import org.opensearch.be.datafusion.nativelib.StreamHandle;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -88,6 +94,13 @@ public final class DatafusionReduceSink extends AbstractDatafusionReduceSink imp
     private final Thread drainThread;
     /** Captures any throwable from the drain thread for surfacing during close(). */
     private final AtomicReference<Throwable> drainFailure = new AtomicReference<>();
+    /**
+     * Signalled by the drain thread each time it (re-)enters the blocking
+     * {@code streamNext} call. Used by {@link #closeUnderLock()} to detect that all
+     * previously-available output has been consumed before closing the next sender.
+     * Starts with 0 permits; the drain loop releases one permit before each poll.
+     */
+    private final Semaphore drainEnteredPoll = new Semaphore(0);
 
     public DatafusionReduceSink(ExchangeSinkContext ctx, NativeRuntimeHandle runtimeHandle) {
         this(ctx, runtimeHandle, null);
@@ -149,13 +162,41 @@ public final class DatafusionReduceSink extends AbstractDatafusionReduceSink imp
     /**
      * Drain loop body. Runs on {@link #drainThread} from sink construction until the
      * FINAL plan reaches EOF (which only happens after every sender is closed).
+     *
+     * <p>Signals {@link #drainEnteredPoll} before each blocking {@code streamNext} call
+     * so that {@link #closeUnderLock()} can detect that all previously-available output
+     * has been fully consumed.
      */
     private void drainLoop() {
         try {
-            drainOutputIntoDownstream(outStream);
+            drainOutputIntoDownstreamWithSignal(outStream);
         } catch (Throwable t) {
             drainFailure.set(t);
             logger.warn("[ReduceSink] drain thread terminated with error", t);
+        }
+    }
+
+    private void drainOutputIntoDownstreamWithSignal(StreamHandle stream) {
+        BufferAllocator alloc = ctx.allocator();
+        try (CDataDictionaryProvider dictProvider = new CDataDictionaryProvider()) {
+            long schemaAddr = asyncCall(listener -> NativeBridge.streamGetSchema(stream.getPointer(), listener));
+            Schema outSchema;
+            try (ArrowSchema arrowSchema = ArrowSchema.wrap(schemaAddr)) {
+                Field structField = Data.importField(alloc, arrowSchema, dictProvider);
+                outSchema = new Schema(structField.getChildren(), structField.getMetadata());
+            }
+            while (true) {
+                drainEnteredPoll.release();
+                long arrayAddr = asyncCall(listener -> NativeBridge.streamNext(runtimeHandle.get(), stream.getPointer(), listener));
+                if (arrayAddr == 0) {
+                    break;
+                }
+                VectorSchemaRoot vsr = VectorSchemaRoot.create(outSchema, alloc);
+                try (ArrowArray arrowArray = ArrowArray.wrap(arrayAddr)) {
+                    Data.importIntoVectorSchemaRoot(alloc, arrowArray, vsr, dictProvider);
+                }
+                ctx.downstream().feed(vsr);
+            }
         }
     }
 
@@ -343,15 +384,37 @@ public final class DatafusionReduceSink extends AbstractDatafusionReduceSink imp
     @Override
     protected Throwable closeUnderLock() {
         Throwable failure = null;
-        // 1. Signal EOF on every still-open sender. The drain thread, which is already
-        // polling the output stream, will receive the final batches and then EOF, then
-        // exit cleanly. Senders that were already closed by their ChildSink wrapper are
-        // no-ops (the underlying senderClose is idempotent on the Rust side).
-        for (DatafusionPartitionSender sender : sendersByChildStageId.values()) {
+        // 1. Close senders sequentially. For appendpipe (UnionExec), the native plan is
+        //    CoalescePartitions → UnionExec(SortExec(input-0), SortExec(input-1)).
+        //    CoalescePartitionsExec polls all partitions concurrently and emits whichever
+        //    completes first — no ordering guarantee. To ensure branch 0 (original data)
+        //    appears before branch 1 (appended results), we close sender-0, wait for the
+        //    drain thread to consume all of branch 0's output (it will block on the next
+        //    streamNext since branch 1's Sort is still waiting for EOF), THEN close
+        //    sender-1. This serialises output regardless of tokio scheduling.
+        //
+        //    For single-sender cases this degenerates to a single close (no wait needed).
+        List<DatafusionPartitionSender> senders = new ArrayList<>(sendersByChildStageId.values());
+        for (int i = 0; i < senders.size(); i++) {
             try {
-                sender.close();
+                // Drain any stale permits accumulated before this close sequence.
+                drainEnteredPoll.drainPermits();
+                senders.get(i).close();
             } catch (Throwable t) {
                 failure = accumulate(failure, t);
+            }
+            // After closing sender i (except the last), wait for the drain thread to
+            // re-enter streamNext — meaning all output from branch i has been consumed
+            // and the plan is now blocked waiting for branch i+1's data.
+            if (i < senders.size() - 1) {
+                try {
+                    if (!drainEnteredPoll.tryAcquire(30, TimeUnit.SECONDS)) {
+                        logger.warn("[ReduceSink] timed out waiting for branch {} drain; proceeding", i);
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    failure = accumulate(failure, e);
+                }
             }
         }
         // 2. Wait for the drain thread to finish processing remaining output.

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stage/ShardFragmentStageExecution.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stage/ShardFragmentStageExecution.java
@@ -123,6 +123,12 @@ final class ShardFragmentStageExecution extends AbstractStageExecution implement
                     }
 
                     VectorSchemaRoot vsr = toVsr.apply(response);
+                    // DataFusion promotes string columns to Utf8View inside aggregations. The
+                    // reducer's partition streams are declared Utf8 (from Calcite), so a
+                    // Utf8View batch reinterprets as broken Utf8 — the 16-byte-per-entry view
+                    // layout read as 32-bit offsets yields multi-GB lengths or negative sizes.
+                    // Normalize to Utf8 so the reducer sees the declared layout.
+                    vsr = VsrNormalizer.toUtf8Strings(vsr, config.bufferAllocator());
                     outputSink.feed(vsr);
                     metrics.addRowsProcessed(vsr.getRowCount());
 

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stage/VsrNormalizer.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stage/VsrNormalizer.java
@@ -1,0 +1,127 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.exec.stage;
+
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.LargeVarCharVector;
+import org.apache.arrow.vector.VarCharVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.ViewVarCharVector;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.apache.arrow.vector.types.pojo.Schema;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Normalizes Arrow {@link VectorSchemaRoot}s received from data-node shards so that
+ * variable-width string columns are materialized as {@link VarCharVector} (Utf8)
+ * regardless of what the shard produced ({@link ViewVarCharVector} / {@link LargeVarCharVector}).
+ *
+ * <p>DataFusion's physical plan can promote {@code Utf8} to {@code Utf8View} inside
+ * aggregations (group-by keys, hash tables). When the shard ships that VSR to the
+ * coordinator via Arrow C Data + Flight, the coordinator's reduce-sink partition
+ * stream is declared as {@code Utf8} (the type Calcite emits). The buffer layout of
+ * {@code Utf8View} (16-byte per-entry views) doesn't round-trip through a {@code Utf8}
+ * declaration — the consumer reinterprets view bytes as 32-bit offsets, producing
+ * garbage offsets that either OOM the heap ({@code new byte[endOffset - startOffset]}
+ * with a multi-GB length) or yield {@link NegativeArraySizeException}.
+ *
+ * <p>This normalizer copies each view/large-varchar column into a fresh
+ * {@link VarCharVector}, swaps it into the VSR, and closes the original. Other vector
+ * types pass through untouched.
+ */
+final class VsrNormalizer {
+
+    private VsrNormalizer() {}
+
+    /**
+     * Returns a VSR whose variable-width string columns are all {@code Utf8}. If no
+     * columns need conversion, returns {@code vsr} unchanged. Otherwise returns a new
+     * VSR built from {@code vsr}'s contents — caller must close whichever is returned
+     * (the returned VSR owns every field vector, including any that were passed through).
+     */
+    static VectorSchemaRoot toUtf8Strings(VectorSchemaRoot vsr, BufferAllocator allocator) {
+        if (!hasNonUtf8StringColumn(vsr)) {
+            return vsr;
+        }
+
+        int rowCount = vsr.getRowCount();
+        List<FieldVector> newVectors = new ArrayList<>(vsr.getFieldVectors().size());
+        List<Field> newFields = new ArrayList<>(vsr.getFieldVectors().size());
+
+        try {
+            for (FieldVector original : vsr.getFieldVectors()) {
+                FieldVector replacement;
+                if (original instanceof ViewVarCharVector view) {
+                    replacement = copyToVarChar(view.getName(), rowCount, allocator, view::isNull, view::get);
+                } else if (original instanceof LargeVarCharVector large) {
+                    replacement = copyToVarChar(large.getName(), rowCount, allocator, large::isNull, large::get);
+                } else {
+                    // Transfer ownership so the original VSR's close() won't free the buffers.
+                    replacement = transferVector(original, allocator);
+                }
+                newVectors.add(replacement);
+                newFields.add(replacement.getField());
+            }
+        } catch (RuntimeException e) {
+            for (FieldVector v : newVectors)
+                v.close();
+            throw e;
+        }
+
+        VectorSchemaRoot normalized = new VectorSchemaRoot(new Schema(newFields), newVectors, rowCount);
+        vsr.close();
+        return normalized;
+    }
+
+    private static boolean hasNonUtf8StringColumn(VectorSchemaRoot vsr) {
+        for (FieldVector v : vsr.getFieldVectors()) {
+            if (v instanceof ViewVarCharVector || v instanceof LargeVarCharVector) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static VarCharVector copyToVarChar(
+        String name,
+        int rowCount,
+        BufferAllocator allocator,
+        java.util.function.IntPredicate isNull,
+        java.util.function.IntFunction<byte[]> getBytes
+    ) {
+        Field field = new Field(name, FieldType.nullable(ArrowType.Utf8.INSTANCE), null);
+        VarCharVector dst = (VarCharVector) field.createVector(allocator);
+        try {
+            dst.allocateNew(rowCount);
+            for (int i = 0; i < rowCount; i++) {
+                if (isNull.test(i)) {
+                    dst.setNull(i);
+                } else {
+                    dst.setSafe(i, getBytes.apply(i));
+                }
+            }
+            dst.setValueCount(rowCount);
+            return dst;
+        } catch (RuntimeException e) {
+            dst.close();
+            throw e;
+        }
+    }
+
+    private static FieldVector transferVector(FieldVector src, BufferAllocator allocator) {
+        FieldVector dst = src.getField().createVector(allocator);
+        src.makeTransferPair(dst).transfer();
+        return dst;
+    }
+}

--- a/sandbox/qa/analytics-engine-rest/build.gradle
+++ b/sandbox/qa/analytics-engine-rest/build.gradle
@@ -69,12 +69,12 @@ def configureAnalyticsCluster = { cluster ->
 testClusters.integTest {
     numberOfNodes = 2
     configureAnalyticsCluster(delegate)
+    systemProperty 'opensearch.experimental.feature.transport.stream.enabled', 'true'
 }
 
 integTest {
     systemProperty 'tests.security.manager', 'false'
     exclude '**/CoordinatorReduceMemtableIT.class'
-    exclude '**/StreamingCoordinatorReduceIT.class'
 }
 
 // ── Memtable variant: 2 nodes, datafusion.reduce.input_mode=memtable ─────────
@@ -93,24 +93,6 @@ testClusters.integTestMemtable {
     numberOfNodes = 2
     configureAnalyticsCluster(delegate)
     setting 'datafusion.reduce.input_mode', 'memtable'
-}
-
-// ── Streaming variant: 2 nodes, Arrow Flight stream transport enabled ────────
-task integTestStreaming(type: RestIntegTestTask) {
-    description = 'Runs coordinator-reduce tests with Arrow Flight streaming'
-    testClassesDirs = sourceSets.test.output.classesDirs
-    classpath = sourceSets.test.runtimeClasspath
-    filter {
-        includeTestsMatching 'org.opensearch.analytics.qa.StreamingCoordinatorReduceIT'
-    }
-    systemProperty 'tests.security.manager', 'false'
-}
-check.dependsOn(integTestStreaming)
-
-testClusters.integTestStreaming {
-    numberOfNodes = 2
-    configureAnalyticsCluster(delegate)
-    systemProperty 'opensearch.experimental.feature.transport.stream.enabled', 'true'
 }
 
 // Run against an external cluster (no testClusters lifecycle):


### PR DESCRIPTION
## Description

Make streaming transport the default in the `analytics-engine-rest` QA suite so every IT runs with the `opensearch.experimental.feature.transport.stream.enabled` flag enabled, rather than only the dedicated `StreamingCoordinatorReduceIT`. This guards against regressions in the Arrow Flight stream transport across the full IT surface instead of a single test.

Note: the single-shard / single-node path short-circuits local transport, so flag-enabled does not guarantee Flight RPC is exercised for every test — it just ensures no regression when it is.

## Changes

- Add `systemProperty 'opensearch.experimental.feature.transport.stream.enabled', 'true'` to the default `testClusters.integTest` configuration.
- Remove the `exclude '**/StreamingCoordinatorReduceIT.class'` line from `integTest` so the streaming test runs alongside the rest.
- Delete the now-redundant `integTestStreaming` task and its `testClusters.integTestStreaming` configuration (its coverage is subsumed by the default `integTest`).

## Known issue

Enabling the flag across the full IT suite may cause a cluster OOM mid-suite. This is being triaged in parallel under `stream:qa-oom` and is not resolved by this PR. A follow-up may be needed once the root cause is identified.

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).