### PR TITLE
add merge large file correctness tests and fixes

### DIFF
--- a/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/CompositeMergeIT.java
+++ b/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/CompositeMergeIT.java
@@ -17,13 +17,12 @@ import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.NIOFSDirectory;
 import org.opensearch.action.admin.indices.refresh.RefreshResponse;
-import org.opensearch.action.admin.indices.stats.IndicesStatsResponse;
-import org.opensearch.action.admin.indices.stats.ShardStats;
 import org.opensearch.action.index.IndexResponse;
 import org.opensearch.be.datafusion.DataFusionPlugin;
 import org.opensearch.be.lucene.LucenePlugin;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.SuppressForbidden;
+import org.opensearch.common.concurrent.GatedCloseable;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.common.xcontent.json.JsonXContent;
@@ -32,11 +31,11 @@ import org.opensearch.core.xcontent.DeprecationHandler;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.index.IndexService;
-import org.opensearch.index.engine.CommitStats;
+import org.opensearch.index.engine.dataformat.DocumentInput;
 import org.opensearch.index.engine.exec.Segment;
 import org.opensearch.index.engine.exec.WriterFileSet;
+import org.opensearch.index.engine.exec.coord.CatalogSnapshot;
 import org.opensearch.index.engine.exec.coord.DataformatAwareCatalogSnapshot;
-import org.opensearch.index.merge.MergeStats;
 import org.opensearch.index.shard.IndexShard;
 import org.opensearch.indices.IndicesService;
 import org.opensearch.parquet.ParquetDataFormatPlugin;
@@ -55,6 +54,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 // The Tokio IO runtime worker thread (used by the Rust merge k-way merge sort) is a process-lifetime
 // singleton that persists after tests complete. It polls for new async IO tasks between merges.
@@ -121,19 +121,7 @@ public class CompositeMergeIT extends OpenSearchIntegTestCase {
         indexDocsAcrossMultipleRefreshes(refreshCycles, docsPerCycle);
         int totalDocs = refreshCycles * docsPerCycle;
 
-        assertBusy(() -> {
-            flush(INDEX_NAME);
-            DataformatAwareCatalogSnapshot snapshot = getCatalogSnapshot();
-            assertTrue(
-                "Expected merges to reduce segment count below " + refreshCycles + ", but got: " + snapshot.getSegments().size(),
-                snapshot.getSegments().size() < refreshCycles
-            );
-        });
-
-        MergeStats mergeStats = getMergeStats();
-        assertTrue("Expected at least one merge to have occurred", mergeStats.getTotal() > 0);
-
-        DataformatAwareCatalogSnapshot snapshot = getCatalogSnapshot();
+        DataformatAwareCatalogSnapshot snapshot = waitForMerge(refreshCycles);
         assertEquals(Set.of("parquet"), snapshot.getDataFormats());
 
         verifyRowCount(snapshot, totalDocs);
@@ -158,19 +146,7 @@ public class CompositeMergeIT extends OpenSearchIntegTestCase {
         indexDocsWithNullsAcrossRefreshes(refreshCycles, docsPerCycle);
         int totalDocs = refreshCycles * docsPerCycle;
 
-        assertBusy(() -> {
-            flush(INDEX_NAME);
-            DataformatAwareCatalogSnapshot snapshot = getCatalogSnapshot();
-            assertTrue(
-                "Expected merges to reduce segment count below " + refreshCycles + ", but got: " + snapshot.getSegments().size(),
-                snapshot.getSegments().size() < refreshCycles
-            );
-        });
-
-        MergeStats mergeStats = getMergeStats();
-        assertTrue("Expected at least one merge to have occurred", mergeStats.getTotal() > 0);
-
-        DataformatAwareCatalogSnapshot snapshot = getCatalogSnapshot();
+        DataformatAwareCatalogSnapshot snapshot = waitForMerge(refreshCycles);
         assertEquals(Set.of("parquet"), snapshot.getDataFormats());
 
         verifyRowCount(snapshot, totalDocs);
@@ -208,20 +184,7 @@ public class CompositeMergeIT extends OpenSearchIntegTestCase {
         indexDocsAcrossMultipleRefreshes(refreshCycles, docsPerCycle);
         int totalDocs = refreshCycles * docsPerCycle;
 
-        // Wait for merge to reduce segment count
-        assertBusy(() -> {
-            flush(INDEX_NAME);
-            DataformatAwareCatalogSnapshot snapshot = getCatalogSnapshot();
-            assertTrue(
-                "Expected merges to reduce segment count below " + refreshCycles + ", but got: " + snapshot.getSegments().size(),
-                snapshot.getSegments().size() < refreshCycles
-            );
-        });
-
-        MergeStats mergeStats = getMergeStats();
-        assertTrue("Expected at least one merge to have occurred", mergeStats.getTotal() > 0);
-
-        DataformatAwareCatalogSnapshot snapshot = getCatalogSnapshot();
+        DataformatAwareCatalogSnapshot snapshot = waitForMerge(refreshCycles);
 
         // Both formats must be present in the catalog
         Set<String> formats = snapshot.getDataFormats();
@@ -268,19 +231,7 @@ public class CompositeMergeIT extends OpenSearchIntegTestCase {
         indexDocsWithNullsAcrossRefreshes(refreshCycles, docsPerCycle);
         int totalDocs = refreshCycles * docsPerCycle;
 
-        assertBusy(() -> {
-            flush(INDEX_NAME);
-            DataformatAwareCatalogSnapshot snapshot = getCatalogSnapshot();
-            assertTrue(
-                "Expected merges to reduce segment count below " + refreshCycles + ", but got: " + snapshot.getSegments().size(),
-                snapshot.getSegments().size() < refreshCycles
-            );
-        });
-
-        MergeStats mergeStats = getMergeStats();
-        assertTrue("Expected at least one merge to have occurred", mergeStats.getTotal() > 0);
-
-        DataformatAwareCatalogSnapshot snapshot = getCatalogSnapshot();
+        DataformatAwareCatalogSnapshot snapshot = waitForMerge(refreshCycles);
 
         Set<String> formats = snapshot.getDataFormats();
         assertTrue("Catalog should contain 'parquet'", formats.contains("parquet"));
@@ -538,7 +489,7 @@ public class CompositeMergeIT extends OpenSearchIntegTestCase {
 
         try (Directory dir = NIOFSDirectory.open(luceneDir); DirectoryReader reader = DirectoryReader.open(dir)) {
             for (LeafReaderContext ctx : reader.leaves()) {
-                SortedNumericDocValues rowIdDV = ctx.reader().getSortedNumericDocValues("__row_id__");
+                SortedNumericDocValues rowIdDV = ctx.reader().getSortedNumericDocValues(DocumentInput.ROW_ID_FIELD);
                 if (rowIdDV == null) continue;
 
                 long expectedRowId = 0;
@@ -546,7 +497,8 @@ public class CompositeMergeIT extends OpenSearchIntegTestCase {
                     if (rowIdDV.advanceExact(doc)) {
                         long rowId = rowIdDV.nextValue();
                         assertEquals(
-                            "__row_id__ should be sequential within segment, expected "
+                            DocumentInput.ROW_ID_FIELD
+                                + " should be sequential within segment, expected "
                                 + expectedRowId
                                 + " but got "
                                 + rowId
@@ -601,7 +553,7 @@ public class CompositeMergeIT extends OpenSearchIntegTestCase {
                     for (Object obj : parser.list()) {
                         @SuppressWarnings("unchecked")
                         Map<String, Object> row = (Map<String, Object>) obj;
-                        long rowId = ((Number) row.get("__row_id__")).longValue();
+                        long rowId = ((Number) row.get(DocumentInput.ROW_ID_FIELD)).longValue();
                         rowsInSegment.put(rowId, row);
                     }
                 }
@@ -633,7 +585,7 @@ public class CompositeMergeIT extends OpenSearchIntegTestCase {
                 assertNotNull("No parquet segment found with matching row count " + leafDocs, matchingSegment);
                 parquetSegments.remove(matchingSegment);
 
-                SortedNumericDocValues rowIdDV = ctx.reader().getSortedNumericDocValues("__row_id__");
+                SortedNumericDocValues rowIdDV = ctx.reader().getSortedNumericDocValues(DocumentInput.ROW_ID_FIELD);
                 SortedNumericDocValues ageDV = ctx.reader().getSortedNumericDocValues("age");
                 SortedSetDocValues nameDV = ctx.reader().getSortedSetDocValues("name");
 
@@ -644,13 +596,19 @@ public class CompositeMergeIT extends OpenSearchIntegTestCase {
                     long luceneRowId = rowIdDV.nextValue();
 
                     Map<String, Object> parquetRow = matchingSegment.get(luceneRowId);
-                    assertNotNull("Lucene doc with __row_id__=" + luceneRowId + " should have a matching parquet row", parquetRow);
+                    assertNotNull(
+                        "Lucene doc with " + DocumentInput.ROW_ID_FIELD + "=" + luceneRowId + " should have a matching parquet row",
+                        parquetRow
+                    );
 
                     // Compare age field
                     if (ageDV != null && ageDV.advanceExact(doc)) {
                         long luceneAge = ageDV.nextValue();
                         Object parquetAge = parquetRow.get("age");
-                        assertNotNull("Parquet row at __row_id__=" + luceneRowId + " should have 'age' field", parquetAge);
+                        assertNotNull(
+                            "Parquet row at " + DocumentInput.ROW_ID_FIELD + "=" + luceneRowId + " should have 'age' field",
+                            parquetAge
+                        );
                         assertEquals("Age mismatch at row_id=" + luceneRowId, ((Number) parquetAge).longValue(), luceneAge);
                     }
 
@@ -660,7 +618,10 @@ public class CompositeMergeIT extends OpenSearchIntegTestCase {
                         if (ord >= 0) {
                             String luceneName = nameDV.lookupOrd(ord).utf8ToString();
                             Object parquetName = parquetRow.get("name");
-                            assertNotNull("Parquet row at __row_id__=" + luceneRowId + " should have 'name' field", parquetName);
+                            assertNotNull(
+                                "Parquet row at " + DocumentInput.ROW_ID_FIELD + "=" + luceneRowId + " should have 'name' field",
+                                parquetName
+                            );
                             assertEquals("Name mismatch at row_id=" + luceneRowId, parquetName.toString(), luceneName);
                         }
                     }
@@ -700,19 +661,291 @@ public class CompositeMergeIT extends OpenSearchIntegTestCase {
     }
 
     private DataformatAwareCatalogSnapshot getCatalogSnapshot() throws IOException {
-        IndicesStatsResponse statsResponse = client().admin().indices().prepareStats(INDEX_NAME).clear().setStore(true).get();
-        ShardStats shardStats = statsResponse.getIndex(INDEX_NAME).getShards()[0];
-        CommitStats commitStats = shardStats.getCommitStats();
-        assertNotNull(commitStats);
-        assertTrue(commitStats.getUserData().containsKey(DataformatAwareCatalogSnapshot.CATALOG_SNAPSHOT_KEY));
-        return DataformatAwareCatalogSnapshot.deserializeFromString(
-            commitStats.getUserData().get(DataformatAwareCatalogSnapshot.CATALOG_SNAPSHOT_KEY),
-            Function.identity()
-        );
+        IndexShard shard = getPrimaryShard();
+        try (GatedCloseable<CatalogSnapshot> snapshot = shard.getCatalogSnapshot()) {
+            return DataformatAwareCatalogSnapshot.deserializeFromString(snapshot.get().serializeToString(), Function.identity());
+        }
     }
 
-    private MergeStats getMergeStats() {
-        IndicesStatsResponse statsResponse = client().admin().indices().prepareStats(INDEX_NAME).clear().setMerge(true).get();
-        return statsResponse.getIndex(INDEX_NAME).getShards()[0].getStats().getMerge();
+    // ── Randomized sort tests across data types ──
+
+    public void testSortedMergeBySingleField() throws Exception {
+        long now = System.currentTimeMillis();
+        List<Object[]> fieldSpecs = List.of(
+            new Object[] {
+                "value_long",
+                "type=long",
+                (Supplier<Object>) () -> randomBoolean() ? null : randomLongBetween(-1_000_000L, 1_000_000L) },
+            new Object[] { "value_float", "type=float", (Supplier<Object>) () -> randomBoolean() ? null : randomFloat() * 1000 },
+            new Object[] {
+                "value_double",
+                "type=double",
+                (Supplier<Object>) () -> randomBoolean() ? null : randomDoubleBetween(-1e6, 1e6, true) },
+            new Object[] {
+                "timestamp",
+                "type=date",
+                (Supplier<Object>) () -> randomBoolean() ? null : now - randomLongBetween(0, 86400000L * 365) },
+            new Object[] { "tag", "type=keyword", (Supplier<Object>) () -> randomBoolean() ? null : randomAlphaOfLengthBetween(3, 8) }
+        );
+
+        for (Object[] spec : fieldSpecs) {
+            String fieldName = (String) spec[0];
+            String fieldType = (String) spec[1];
+            @SuppressWarnings("unchecked")
+            Supplier<Object> valueSupplier = (Supplier<Object>) spec[2];
+
+            for (String order : List.of("asc", "desc")) {
+                for (String missing : List.of("_first", "_last")) {
+                    try {
+                        Settings settings = Settings.builder()
+                            .put(unsortedSettings())
+                            .putList("index.sort.field", fieldName)
+                            .putList("index.sort.order", order)
+                            .putList("index.sort.missing", missing)
+                            .build();
+
+                        client().admin().indices().prepareCreate(INDEX_NAME).setSettings(settings).setMapping(fieldName, fieldType).get();
+                        ensureGreen(INDEX_NAME);
+
+                        int docsPerCycle = 10;
+                        int refreshCycles = 15;
+                        indexRandomDocs(refreshCycles, docsPerCycle, fieldName, valueSupplier);
+                        int totalDocs = refreshCycles * docsPerCycle;
+
+                        DataformatAwareCatalogSnapshot snapshot = waitForMerge(refreshCycles);
+                        verifyRowCount(snapshot, totalDocs);
+                        verifySortOrderGeneric(snapshot, List.of(fieldName), List.of(order), List.of(missing));
+                    } finally {
+                        client().admin().indices().prepareDelete(INDEX_NAME).get();
+                    }
+                }
+            }
+        }
     }
+
+    public void testSortedMergeMultiColumnRandomized() throws Exception {
+        String[] fields = { "age", "score", "tag" };
+        String[] types = { "type=integer", "type=long", "type=keyword" };
+        String[] orders = { randomFrom("asc", "desc"), randomFrom("asc", "desc"), randomFrom("asc", "desc") };
+        String[] missings = { randomFrom("_first", "_last"), randomFrom("_first", "_last"), randomFrom("_first", "_last") };
+
+        Settings settings = Settings.builder()
+            .put(unsortedSettings())
+            .putList("index.sort.field", fields)
+            .putList("index.sort.order", orders)
+            .putList("index.sort.missing", missings)
+            .build();
+
+        client().admin()
+            .indices()
+            .prepareCreate(INDEX_NAME)
+            .setSettings(settings)
+            .setMapping("age", types[0], "score", types[1], "tag", types[2])
+            .get();
+        ensureGreen(INDEX_NAME);
+
+        int docsPerCycle = 10;
+        int refreshCycles = 15;
+        for (int cycle = 0; cycle < refreshCycles; cycle++) {
+            for (int i = 0; i < docsPerCycle; i++) {
+                var source = new java.util.HashMap<String, Object>();
+                source.put("age", randomBoolean() ? null : randomIntBetween(0, 100));
+                source.put("score", randomBoolean() ? null : randomLongBetween(0, 10000));
+                source.put("tag", randomBoolean() ? null : randomAlphaOfLengthBetween(3, 6));
+                // Remove null entries so they appear as missing in the doc
+                source.values().removeIf(java.util.Objects::isNull);
+                IndexResponse response = client().prepareIndex().setIndex(INDEX_NAME).setSource(source).get();
+                assertEquals(RestStatus.CREATED, response.status());
+            }
+            client().admin().indices().prepareRefresh(INDEX_NAME).get();
+        }
+        int totalDocs = refreshCycles * docsPerCycle;
+
+        waitForMerge(refreshCycles);
+        DataformatAwareCatalogSnapshot snapshot = getCatalogSnapshot();
+        verifyRowCount(snapshot, totalDocs);
+        verifySortOrderGeneric(snapshot, List.of(fields), List.of(orders), List.of(missings));
+    }
+
+    public void testUnsortedMergeWithAllTypes() throws Exception {
+        client().admin()
+            .indices()
+            .prepareCreate(INDEX_NAME)
+            .setSettings(unsortedSettings())
+            .setMapping(
+                "val_int",
+                "type=integer",
+                "val_long",
+                "type=long",
+                "val_float",
+                "type=float",
+                "val_double",
+                "type=double",
+                "val_date",
+                "type=date",
+                "val_keyword",
+                "type=keyword"
+            )
+            .get();
+        ensureGreen(INDEX_NAME);
+
+        int docsPerCycle = 8;
+        int refreshCycles = 15;
+        long now = System.currentTimeMillis();
+        for (int cycle = 0; cycle < refreshCycles; cycle++) {
+            for (int i = 0; i < docsPerCycle; i++) {
+                IndexResponse response = client().prepareIndex()
+                    .setIndex(INDEX_NAME)
+                    .setSource(
+                        "val_int",
+                        randomIntBetween(-100, 100),
+                        "val_long",
+                        randomLongBetween(-100000, 100000),
+                        "val_float",
+                        randomFloat() * 200 - 100,
+                        "val_double",
+                        randomDoubleBetween(-1000, 1000, true),
+                        "val_date",
+                        now - randomLongBetween(0, 86400000L * 30),
+                        "val_keyword",
+                        randomAlphaOfLength(6)
+                    )
+                    .get();
+                assertEquals(RestStatus.CREATED, response.status());
+            }
+            client().admin().indices().prepareRefresh(INDEX_NAME).get();
+        }
+        int totalDocs = refreshCycles * docsPerCycle;
+
+        waitForMerge(refreshCycles);
+        DataformatAwareCatalogSnapshot snapshot = getCatalogSnapshot();
+        verifyRowCount(snapshot, totalDocs);
+    }
+
+    // ── Helpers for randomized tests ──
+
+    private DataformatAwareCatalogSnapshot waitForMerge(int refreshCycles) throws Exception {
+        flush(INDEX_NAME);
+        assertBusy(() -> {
+            DataformatAwareCatalogSnapshot snap = getCatalogSnapshot();
+            assertTrue(
+                "Expected merges to reduce segment count below " + refreshCycles + ", but got: " + snap.getSegments().size(),
+                snap.getSegments().size() < refreshCycles
+            );
+        });
+        return getCatalogSnapshot();
+    }
+
+    private void indexRandomDocs(int refreshCycles, int docsPerCycle, String fieldName, Supplier<Object> valueSupplier) {
+        for (int cycle = 0; cycle < refreshCycles; cycle++) {
+            for (int i = 0; i < docsPerCycle; i++) {
+                Object value = valueSupplier.get();
+                IndexResponse response;
+                if (value == null) {
+                    response = client().prepareIndex().setIndex(INDEX_NAME).setSource(java.util.Collections.emptyMap()).get();
+                } else {
+                    response = client().prepareIndex().setIndex(INDEX_NAME).setSource(fieldName, value).get();
+                }
+                assertEquals(RestStatus.CREATED, response.status());
+            }
+            client().admin().indices().prepareRefresh(INDEX_NAME).get();
+        }
+    }
+
+    @SuppressForbidden(reason = "JSON parsing for generic sort verification")
+    private void verifySortOrderGeneric(
+        DataformatAwareCatalogSnapshot snapshot,
+        List<String> sortFields,
+        List<String> sortOrders,
+        List<String> sortMissing
+    ) throws Exception {
+        Path parquetDir = getParquetDir();
+        for (Segment segment : snapshot.getSegments()) {
+            WriterFileSet wfs = segment.dfGroupedSearchableFiles().get("parquet");
+            for (String file : wfs.files()) {
+                Path filePath = parquetDir.resolve(file);
+                String json = RustBridge.readAsJson(filePath.toString());
+                List<Map<String, Object>> rows;
+                try (
+                    XContentParser parser = JsonXContent.jsonXContent.createParser(
+                        NamedXContentRegistry.EMPTY,
+                        DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
+                        json
+                    )
+                ) {
+                    rows = parser.list().stream().map(o -> {
+                        @SuppressWarnings("unchecked")
+                        Map<String, Object> m = (Map<String, Object>) o;
+                        return m;
+                    }).toList();
+                }
+                if (rows.size() <= 1) continue;
+
+                for (int i = 1; i < rows.size(); i++) {
+                    int cmp = compareRows(rows.get(i - 1), rows.get(i), sortFields, sortOrders, sortMissing);
+                    assertTrue(
+                        "Sort order violated at row "
+                            + i
+                            + " in file "
+                            + file
+                            + ": prev="
+                            + extractSortValues(rows.get(i - 1), sortFields)
+                            + " curr="
+                            + extractSortValues(rows.get(i), sortFields)
+                            + " fields="
+                            + sortFields
+                            + " orders="
+                            + sortOrders
+                            + " missing="
+                            + sortMissing,
+                        cmp <= 0
+                    );
+                }
+            }
+        }
+    }
+
+    private int compareRows(
+        Map<String, Object> prev,
+        Map<String, Object> curr,
+        List<String> sortFields,
+        List<String> sortOrders,
+        List<String> sortMissing
+    ) {
+        for (int f = 0; f < sortFields.size(); f++) {
+            String field = sortFields.get(f);
+            boolean desc = "desc".equals(sortOrders.get(f));
+            boolean nullsFirst = "_first".equals(sortMissing.get(f));
+
+            Object prevVal = prev.get(field);
+            Object currVal = curr.get(field);
+
+            int cmp = compareValues(prevVal, currVal, desc, nullsFirst);
+            if (cmp != 0) return cmp;
+        }
+        return 0;
+    }
+
+    @SuppressWarnings("unchecked")
+    private int compareValues(Object prev, Object curr, boolean desc, boolean nullsFirst) {
+        if (prev == null && curr == null) return 0;
+        if (prev == null) return nullsFirst ? -1 : 1;
+        if (curr == null) return nullsFirst ? 1 : -1;
+
+        int cmp;
+        if (prev instanceof Number && curr instanceof Number) {
+            cmp = Double.compare(((Number) prev).doubleValue(), ((Number) curr).doubleValue());
+        } else if (prev instanceof String && curr instanceof String) {
+            cmp = ((String) prev).compareTo((String) curr);
+        } else {
+            cmp = prev.toString().compareTo(curr.toString());
+        }
+
+        return desc ? -cmp : cmp;
+    }
+
+    private List<Object> extractSortValues(Map<String, Object> row, List<String> sortFields) {
+        return sortFields.stream().map(row::get).toList();
+    }
+
 }

--- a/sandbox/plugins/parquet-data-format/src/main/rust/src/merge/sorted.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/src/merge/sorted.rs
@@ -196,6 +196,16 @@ pub fn merge_sorted(
                 if !cursor.advance_past_batch()? {
                     break;
                 }
+                // Check if cursor should yield after loading new batch
+                let val = cursor.current_sort_values()?;
+                if cmp_sort_values(&val, heap_top, reverse_sorts) == Ordering::Greater {
+                    heap.push(HeapItem {
+                        sort_values: val,
+                        file_id,
+                        reverse_sorts: Arc::clone(&reverse_sorts_arc),
+                    });
+                    break;
+                }
                 continue;
             }
 
@@ -241,15 +251,15 @@ pub fn merge_sorted(
                 break;
             }
 
-            let next_val = cursor.current_sort_values()?;
-            if cmp_sort_values(&next_val, heap_top, reverse_sorts) == Ordering::Greater {
-                heap.push(HeapItem {
-                    sort_values: next_val,
-                    file_id,
-                    reverse_sorts: Arc::clone(&reverse_sorts_arc),
-                });
-                break;
-            }
+            // Binary search invariant guarantees cursor.current_value > heap_top
+            // so we always yield here (no need for conditional check)
+            let val = cursor.current_sort_values()?;
+            heap.push(HeapItem {
+                sort_values: val,
+                file_id,
+                reverse_sorts: Arc::clone(&reverse_sorts_arc),
+            });
+            break;
         }
     }
 

--- a/sandbox/plugins/parquet-data-format/src/main/rust/src/tests/mod.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/src/tests/mod.rs
@@ -14,6 +14,8 @@ use tempfile::tempdir;
 
 use crate::test_utils::*;
 use crate::writer::NativeParquetWriter;
+use crate::writer::SETTINGS_STORE;
+use crate::native_settings::NativeSettings;
 
 use std::fs::File;
 use std::io::Read;
@@ -720,4 +722,61 @@ fn test_concurrent_writes_different_files() {
     for (i, filename) in filenames.iter().enumerate() {
         close_writer_and_cleanup_schema(filename, schema_ptrs[i]);
     }
+}
+
+#[test]
+fn test_bloom_filter_false_propagates_through_settings_store() {
+    let index_name = "test-bloom-false-index-unique1";
+    let settings = NativeSettings {
+        index_name: Some(index_name.to_string()),
+        bloom_filter_enabled: Some(false),
+        ..Default::default()
+    };
+    SETTINGS_STORE.insert(index_name.to_string(), settings);
+
+    let stored = SETTINGS_STORE.get(index_name).unwrap();
+    assert_eq!(stored.bloom_filter_enabled, Some(false));
+    assert_eq!(stored.get_bloom_filter_enabled(), false);
+    drop(stored);
+
+    let (_temp_dir, filename) = get_temp_file_path("bloom_test.parquet");
+    let (_schema, schema_ptr) = create_test_ffi_schema();
+    let result = NativeParquetWriter::create_writer(
+        filename.clone(), index_name.to_string(), schema_ptr, vec![], vec![], vec![], 0
+    );
+    assert!(result.is_ok());
+
+    let stored_after = SETTINGS_STORE.get(index_name).unwrap();
+    assert_eq!(
+        stored_after.bloom_filter_enabled, Some(false),
+        "bloom_filter_enabled should remain false after create_writer, but got: {:?}",
+        stored_after.bloom_filter_enabled
+    );
+    assert_eq!(stored_after.get_bloom_filter_enabled(), false);
+    drop(stored_after);
+
+    close_writer_and_cleanup_schema(&filename, schema_ptr);
+    SETTINGS_STORE.remove(index_name);
+}
+
+#[test]
+fn test_bloom_filter_default_when_no_settings() {
+    let index_name = "test-bloom-default-index-unique2";
+
+    let (_temp_dir, filename) = get_temp_file_path("bloom_default.parquet");
+    let (_schema, schema_ptr) = create_test_ffi_schema();
+    let result = NativeParquetWriter::create_writer(
+        filename.clone(), index_name.to_string(), schema_ptr, vec![], vec![], vec![], 0
+    );
+    assert!(result.is_ok());
+
+    let stored = SETTINGS_STORE.get(index_name).unwrap();
+    assert_eq!(
+        stored.get_bloom_filter_enabled(), true,
+        "Default bloom_filter_enabled should be true when no settings exist"
+    );
+    drop(stored);
+
+    close_writer_and_cleanup_schema(&filename, schema_ptr);
+    SETTINGS_STORE.remove(index_name);
 }

--- a/sandbox/plugins/parquet-data-format/src/main/rust/src/writer_properties_builder.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/src/writer_properties_builder.rs
@@ -137,9 +137,11 @@ impl WriterPropertiesBuilder {
         mut builder: parquet::file::properties::WriterPropertiesBuilder,
         config: &NativeSettings
     ) -> parquet::file::properties::WriterPropertiesBuilder {
-        builder = builder.set_bloom_filter_enabled(config.get_bloom_filter_enabled());
-        builder = builder.set_bloom_filter_fpp(config.get_bloom_filter_fpp());
-        builder = builder.set_bloom_filter_ndv(config.get_bloom_filter_ndv());
+        if config.get_bloom_filter_enabled() {
+            builder = builder.set_bloom_filter_enabled(true);
+            builder = builder.set_bloom_filter_fpp(config.get_bloom_filter_fpp());
+            builder = builder.set_bloom_filter_ndv(config.get_bloom_filter_ndv());
+        }
         builder
     }
 
@@ -225,5 +227,45 @@ mod tests {
             WriterPropertiesBuilder::parse_compression_type("GZIP", 6),
             Compression::GZIP(_)
         ));
+    }
+
+    #[test]
+    fn test_bloom_filter_disabled_propagates() {
+        let config = NativeSettings {
+            bloom_filter_enabled: Some(false),
+            ..Default::default()
+        };
+        let props = WriterPropertiesBuilder::build(&config);
+        let col_path = parquet::schema::types::ColumnPath::from("test_col");
+        // When bloom filter is disabled, no bloom filter properties should be set
+        assert!(
+            props.bloom_filter_properties(&col_path).is_none(),
+            "bloom_filter_properties should be None when disabled, got: {:?}",
+            props.bloom_filter_properties(&col_path)
+        );
+    }
+
+    #[test]
+    fn test_bloom_filter_enabled_propagates() {
+        let config = NativeSettings {
+            bloom_filter_enabled: Some(true),
+            bloom_filter_fpp: Some(0.1),
+            bloom_filter_ndv: Some(100_000),
+            ..Default::default()
+        };
+        let props = WriterPropertiesBuilder::build(&config);
+        let col_path = parquet::schema::types::ColumnPath::from("test_col");
+        let bf_props = props.bloom_filter_properties(&col_path);
+        assert!(bf_props.is_some(), "bloom_filter_properties should be Some when enabled");
+    }
+
+    #[test]
+    fn test_bloom_filter_default_is_true() {
+        let config = NativeSettings::default();
+        assert_eq!(config.get_bloom_filter_enabled(), true);
+        let props = WriterPropertiesBuilder::build(&config);
+        let col_path = parquet::schema::types::ColumnPath::from("test_col");
+        let bf_props = props.bloom_filter_properties(&col_path);
+        assert!(bf_props.is_some(), "Default should have bloom filter enabled");
     }
 }

--- a/sandbox/plugins/parquet-data-format/src/main/rust/tests/merge_integration_tests.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/tests/merge_integration_tests.rs
@@ -6,14 +6,52 @@
  * compatible open source license.
  */
 
-use arrow::array::{Array, PrimitiveArray};
-use arrow::array::types::TimestampMillisecondType;
-use opensearch_parquet_format::merge::{merge_sorted, merge_unsorted};
-use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
-use parquet::file::reader::{FileReader, SerializedFileReader};
 use std::fs::File;
 use std::path::Path;
+use std::sync::Arc;
 use tempfile::tempdir;
+
+use arrow::array::*;
+use arrow::array::types::TimestampMillisecondType;
+use arrow::datatypes::{DataType, Field, Schema};
+use opensearch_parquet_format::merge::{merge_sorted, merge_unsorted};
+use opensearch_parquet_format::native_settings::NativeSettings;
+use opensearch_parquet_format::writer::SETTINGS_STORE;
+use parquet::arrow::ArrowWriter;
+use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+use parquet::file::reader::{FileReader, SerializedFileReader};
+
+/// Register a small merge_batch_size for the given index so the cursor splits into multiple batches.
+fn register_small_batch_size(index_name: &str, batch_size: usize) {
+    SETTINGS_STORE.insert(index_name.to_string(), NativeSettings {
+        merge_batch_size: Some(batch_size),
+        ..Default::default()
+    });
+}
+
+/// Write a single RecordBatch to a Parquet file.
+fn write_parquet(path: &str, batch: &RecordBatch) {
+    let file = File::create(path).unwrap();
+    let mut writer = ArrowWriter::try_new(file, batch.schema(), None).unwrap();
+    writer.write(batch).unwrap();
+    writer.close().unwrap();
+}
+
+/// Read all Int64 values from a column.
+fn read_all_int64(path: &str, col: &str) -> Vec<i64> {
+    let file = File::open(path).unwrap();
+    let reader = ParquetRecordBatchReaderBuilder::try_new(file).unwrap().build().unwrap();
+    let mut vals = Vec::new();
+    for batch in reader {
+        let batch = batch.unwrap();
+        let idx = batch.schema().index_of(col).unwrap();
+        let arr = batch.column(idx).as_primitive::<arrow::datatypes::Int64Type>();
+        for i in 0..arr.len() {
+            vals.push(arr.value(i));
+        }
+    }
+    vals
+}
 
 /// Helper: collect all parquet files in a directory (sorted by name).
 fn list_parquet_files(dir: &str) -> Vec<String> {
@@ -181,5 +219,679 @@ fn test_sorted_merge_real_files() {
 
     println!("Verified EventDate sort order across {} non-null rows", rows_checked);
     assert_eq!(out_of_order, 0, "Found {} out-of-order rows in EventDate", out_of_order);
+}
+
+// ─── TIER 2 yield-to-heap tests ─────────────────────────────────────────────
+// These tests exercise the logic where after TIER 2 drains a full batch and
+// loads a new one, the new batch's first value is greater than the heap top,
+// so the cursor must yield back to the heap.
+
+/// Two files where file A has two batches (small row group size forces batch boundary).
+/// After TIER 2 drains A's first batch, A's second batch starts higher than B's
+/// current position, so A must yield to the heap.
+#[test]
+fn test_tier2_yield_after_batch_boundary() {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("v", DataType::Int64, false),
+    ]));
+
+    // File A: [1, 2, 3, 10, 11, 12] with batch_size=3 → cursor batches [1,2,3] then [10,11,12]
+    // File B: [5, 6, 7]
+    //
+    // Expected merge: 1,2,3,5,6,7,10,11,12
+    // After TIER 2 drains A batch 0 [1,2,3], A loads batch 1 starting at 10.
+    // heap_top from B is 5. Since 10 > 5, A must yield to heap.
+    let index = "test_tier2_yield_after_batch_boundary";
+    register_small_batch_size(index, 3);
+
+    let batch_a = RecordBatch::try_new(
+        schema.clone(),
+        vec![Arc::new(Int64Array::from(vec![1, 2, 3, 10, 11, 12]))],
+    ).unwrap();
+    let batch_b = RecordBatch::try_new(
+        schema.clone(),
+        vec![Arc::new(Int64Array::from(vec![5, 6, 7]))],
+    ).unwrap();
+
+    let tmp = tempdir().unwrap();
+    let file_a = tmp.path().join("a.parquet").to_string_lossy().to_string();
+    let file_b = tmp.path().join("b.parquet").to_string_lossy().to_string();
+    write_parquet(&file_a, &batch_a);
+    write_parquet(&file_b, &batch_b);
+
+    let output = tmp.path().join("merged.parquet").to_string_lossy().to_string();
+    merge_sorted(
+        &[file_a, file_b], &output, index,
+        &["v".into()], &[false], &[false],
+    ).unwrap();
+
+    let vals = read_all_int64(&output, "v");
+    assert_eq!(vals, vec![1, 2, 3, 5, 6, 7, 10, 11, 12]);
+}
+
+/// Three files with interleaved batch boundaries to force multiple yield events.
+#[test]
+fn test_tier2_yield_multiple_cursors() {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("v", DataType::Int64, false),
+    ]));
+
+    // File A: [1, 2, 20, 21] with batch_size=2 → cursor batches [1,2] and [20,21]
+    // File B: [3, 4, 30, 31] with batch_size=2 → cursor batches [3,4] and [30,31]
+    // File C: [10, 11, 12]
+    //
+    // Expected: 1,2,3,4,10,11,12,20,21,30,31
+    let index = "test_tier2_yield_multiple_cursors";
+    register_small_batch_size(index, 2);
+
+    let batch_a = RecordBatch::try_new(
+        schema.clone(),
+        vec![Arc::new(Int64Array::from(vec![1, 2, 20, 21]))],
+    ).unwrap();
+    let batch_b = RecordBatch::try_new(
+        schema.clone(),
+        vec![Arc::new(Int64Array::from(vec![3, 4, 30, 31]))],
+    ).unwrap();
+    let batch_c = RecordBatch::try_new(
+        schema.clone(),
+        vec![Arc::new(Int64Array::from(vec![10, 11, 12]))],
+    ).unwrap();
+
+    let tmp = tempdir().unwrap();
+    let file_a = tmp.path().join("a.parquet").to_string_lossy().to_string();
+    let file_b = tmp.path().join("b.parquet").to_string_lossy().to_string();
+    let file_c = tmp.path().join("c.parquet").to_string_lossy().to_string();
+    write_parquet(&file_a, &batch_a);
+    write_parquet(&file_b, &batch_b);
+    write_parquet(&file_c, &batch_c);
+
+    let output = tmp.path().join("merged.parquet").to_string_lossy().to_string();
+    merge_sorted(
+        &[file_a, file_b, file_c], &output, index,
+        &["v".into()], &[false], &[false],
+    ).unwrap();
+
+    let vals = read_all_int64(&output, "v");
+    assert_eq!(vals, vec![1, 2, 3, 4, 10, 11, 12, 20, 21, 30, 31]);
+}
+
+/// Descending sort with yield-to-heap after batch boundary.
+#[test]
+fn test_tier2_yield_descending() {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("v", DataType::Int64, false),
+    ]));
+
+    // File A: [12, 11, 10, 3, 2, 1] with batch_size=3 → cursor batches [12,11,10] and [3,2,1]
+    // File B: [7, 6, 5]
+    //
+    // Descending merge expected: 12,11,10,7,6,5,3,2,1
+    // After TIER 2 drains A batch 0 [12,11,10], A loads batch 1 starting at 3.
+    // heap_top from B is 7. In descending, 3 < 7 means A should yield.
+    let index = "test_tier2_yield_descending";
+    register_small_batch_size(index, 3);
+
+    let batch_a = RecordBatch::try_new(
+        schema.clone(),
+        vec![Arc::new(Int64Array::from(vec![12, 11, 10, 3, 2, 1]))],
+    ).unwrap();
+    let batch_b = RecordBatch::try_new(
+        schema.clone(),
+        vec![Arc::new(Int64Array::from(vec![7, 6, 5]))],
+    ).unwrap();
+
+    let tmp = tempdir().unwrap();
+    let file_a = tmp.path().join("a.parquet").to_string_lossy().to_string();
+    let file_b = tmp.path().join("b.parquet").to_string_lossy().to_string();
+    write_parquet(&file_a, &batch_a);
+    write_parquet(&file_b, &batch_b);
+
+    let output = tmp.path().join("merged.parquet").to_string_lossy().to_string();
+    merge_sorted(
+        &[file_a, file_b], &output, index,
+        &["v".into()], &[true], &[false],
+    ).unwrap();
+
+    let vals = read_all_int64(&output, "v");
+    assert_eq!(vals, vec![12, 11, 10, 7, 6, 5, 3, 2, 1]);
+}
+
+/// Edge case: new batch starts exactly equal to heap top (should NOT yield).
+#[test]
+fn test_tier2_no_yield_when_equal_to_heap_top() {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("v", DataType::Int64, false),
+    ]));
+
+    // File A: [1, 2, 5, 6] with batch_size=2 → cursor batches [1,2] and [5,6]
+    // File B: [5, 7, 8]
+    //
+    // After TIER 2 drains A batch 0 [1,2], A loads batch 1 starting at 5.
+    // heap_top from B is also 5. Since 5 == 5 (not Greater), A should NOT yield.
+    // Expected: 1,2,5,5,6,7,8
+    let index = "test_tier2_no_yield_when_equal_to_heap_top";
+    register_small_batch_size(index, 2);
+
+    let batch_a = RecordBatch::try_new(
+        schema.clone(),
+        vec![Arc::new(Int64Array::from(vec![1, 2, 5, 6]))],
+    ).unwrap();
+    let batch_b = RecordBatch::try_new(
+        schema.clone(),
+        vec![Arc::new(Int64Array::from(vec![5, 7, 8]))],
+    ).unwrap();
+
+    let tmp = tempdir().unwrap();
+    let file_a = tmp.path().join("a.parquet").to_string_lossy().to_string();
+    let file_b = tmp.path().join("b.parquet").to_string_lossy().to_string();
+    write_parquet(&file_a, &batch_a);
+    write_parquet(&file_b, &batch_b);
+
+    let output = tmp.path().join("merged.parquet").to_string_lossy().to_string();
+    merge_sorted(
+        &[file_a, file_b], &output, index,
+        &["v".into()], &[false], &[false],
+    ).unwrap();
+
+    let vals = read_all_int64(&output, "v");
+    assert_eq!(vals, vec![1, 2, 5, 5, 6, 7, 8]);
+}
+
+/// Stress test: many small batches forcing repeated yield-to-heap transitions.
+#[test]
+fn test_tier2_yield_many_small_batches() {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("v", DataType::Int64, false),
+    ]));
+
+    // File A: [1,2, 11,12, 21,22, 31,32, 41,42] with batch_size=2
+    // File B: [5,6, 15,16, 25,26, 35,36, 45,46] with batch_size=2
+    //
+    // This forces many yield events as each batch boundary in A jumps past B's
+    // current position and vice versa.
+    let index = "test_tier2_yield_many_small_batches";
+    register_small_batch_size(index, 2);
+
+    let a_vals: Vec<i64> = (0..5).flat_map(|i| vec![i * 10 + 1, i * 10 + 2]).collect();
+    let b_vals: Vec<i64> = (0..5).flat_map(|i| vec![i * 10 + 5, i * 10 + 6]).collect();
+
+    let batch_a = RecordBatch::try_new(
+        schema.clone(),
+        vec![Arc::new(Int64Array::from(a_vals.clone()))],
+    ).unwrap();
+    let batch_b = RecordBatch::try_new(
+        schema.clone(),
+        vec![Arc::new(Int64Array::from(b_vals.clone()))],
+    ).unwrap();
+
+    let tmp = tempdir().unwrap();
+    let file_a = tmp.path().join("a.parquet").to_string_lossy().to_string();
+    let file_b = tmp.path().join("b.parquet").to_string_lossy().to_string();
+    write_parquet(&file_a, &batch_a);
+    write_parquet(&file_b, &batch_b);
+
+    let output = tmp.path().join("merged.parquet").to_string_lossy().to_string();
+    merge_sorted(
+        &[file_a, file_b], &output, index,
+        &["v".into()], &[false], &[false],
+    ).unwrap();
+
+    let vals = read_all_int64(&output, "v");
+    let mut expected: Vec<i64> = a_vals.iter().chain(b_vals.iter()).copied().collect();
+    expected.sort();
+    assert_eq!(vals, expected);
+}
+
+// ─── Default batch size / row-group size tests ───────────────────────────────
+// Uses default settings (merge_batch_size=100_000, row_group_max_rows=1_000_000).
+// Writes 1.4M rows across 2 files to force exactly 2 row groups.
+// Verifies:
+//   - Exact row group sizes (first=1_000_000, second=400_000)
+//   - Every single output value matches the expected sorted sequence
+//   - RG boundary: last value of RG0 < first value of RG1 (ascending)
+//   - Exact null count and null positions for nulls_first/nulls_last
+
+const RG_MAX: i64     = 1_000_000;
+const ROWS_PER_FILE: i64 = 700_000; // 2 files → 1_400_000 total → RG0=1_000_000, RG1=400_000
+
+/// Returns (row_group_sizes, per_rg_first_value, per_rg_last_value) for a nullable Int64 column.
+fn inspect_row_groups(path: &str, col: &str) -> (Vec<i64>, Vec<Option<i64>>, Vec<Option<i64>>) {
+    let reader = SerializedFileReader::new(File::open(path).unwrap()).unwrap();
+    let meta   = reader.metadata();
+    let n_rg   = meta.num_row_groups();
+    let sizes: Vec<i64> = (0..n_rg).map(|i| meta.row_group(i).num_rows()).collect();
+
+    // Read all values in order, then slice per RG
+    let file    = File::open(path).unwrap();
+    let builder = ParquetRecordBatchReaderBuilder::try_new(file).unwrap();
+    let rdr     = builder.build().unwrap();
+    let mut all: Vec<Option<i64>> = Vec::new();
+    for batch in rdr {
+        let batch = batch.unwrap();
+        let idx   = batch.schema().index_of(col).unwrap();
+        let arr   = batch.column(idx).as_primitive::<arrow::datatypes::Int64Type>();
+        for i in 0..arr.len() {
+            all.push(if arr.is_null(i) { None } else { Some(arr.value(i)) });
+        }
+    }
+
+    let mut firsts = Vec::new();
+    let mut lasts  = Vec::new();
+    let mut offset = 0usize;
+    for &sz in &sizes {
+        let end = offset + sz as usize;
+        firsts.push(all[offset]);
+        lasts.push(all[end - 1]);
+        offset = end;
+    }
+    (sizes, firsts, lasts)
+}
+
+/// Read every value of a nullable Int64 column.
+fn read_col_i64(path: &str, col: &str) -> Vec<Option<i64>> {
+    let file = File::open(path).unwrap();
+    let rdr  = ParquetRecordBatchReaderBuilder::try_new(file).unwrap().build().unwrap();
+    let mut vals = Vec::new();
+    for batch in rdr {
+        let batch = batch.unwrap();
+        let idx   = batch.schema().index_of(col).unwrap();
+        let arr   = batch.column(idx).as_primitive::<arrow::datatypes::Int64Type>();
+        for i in 0..arr.len() {
+            vals.push(if arr.is_null(i) { None } else { Some(arr.value(i)) });
+        }
+    }
+    vals
+}
+
+#[test]
+fn test_default_settings_ascending_nulls_last() {
+    // File A: evens  [0, 2, 4, ..., (ROWS_PER_FILE-1)*2]   — 700_000 values
+    // File B: odds   [1, 3, 5, ..., (ROWS_PER_FILE-1)*2+1] — 700_000 values
+    // Merged ascending: 0, 1, 2, 3, ..., 1_399_999
+    // RG0 = rows 0..999_999  → values 0..999_999
+    // RG1 = rows 1_000_000..1_399_999 → values 1_000_000..1_399_999
+    let schema = Arc::new(Schema::new(vec![Field::new("v", DataType::Int64, false)]));
+    let a_vals: Vec<i64> = (0..ROWS_PER_FILE).map(|i| i * 2).collect();
+    let b_vals: Vec<i64> = (0..ROWS_PER_FILE).map(|i| i * 2 + 1).collect();
+
+    let tmp    = tempdir().unwrap();
+    let file_a = tmp.path().join("a.parquet").to_string_lossy().to_string();
+    let file_b = tmp.path().join("b.parquet").to_string_lossy().to_string();
+    write_parquet(&file_a, &RecordBatch::try_new(schema.clone(), vec![Arc::new(Int64Array::from(a_vals))]).unwrap());
+    write_parquet(&file_b, &RecordBatch::try_new(schema.clone(), vec![Arc::new(Int64Array::from(b_vals))]).unwrap());
+
+    let output = tmp.path().join("out.parquet").to_string_lossy().to_string();
+    merge_sorted(&[file_a, file_b], &output, "test_default_asc_nulls_last",
+        &["v".into()], &[false], &[false]).unwrap();
+
+    // ── Row group structure ──────────────────────────────────────────────
+    // With default batch_size=100_000 which divides evenly into RG_MAX=1_000_000,
+    // RG0 is exactly RG_MAX rows. If batch_size didn't divide evenly, RG0 could
+    // overshoot (see test_rg_size_overshoots_when_batch_straddles_threshold).
+    let (rg_sizes, rg_firsts, rg_lasts) = inspect_row_groups(&output, "v");
+    assert_eq!(rg_sizes.len(), 2, "expected exactly 2 row groups");
+    assert_eq!(rg_sizes[0], RG_MAX,                    "RG0 size: exact because batch_size=100_000 divides RG_MAX");
+    assert_eq!(rg_sizes[1], ROWS_PER_FILE * 2 - RG_MAX, "RG1 size");
+    // RG boundary: last of RG0 must be strictly less than first of RG1
+    assert_eq!(rg_lasts[0],  Some(RG_MAX - 1),         "RG0 last value");
+    assert_eq!(rg_firsts[1], Some(RG_MAX),              "RG1 first value");
+
+    // ── Exact value check ────────────────────────────────────────────────
+    let vals = read_col_i64(&output, "v");
+    assert_eq!(vals.len() as i64, ROWS_PER_FILE * 2);
+    for (i, v) in vals.iter().enumerate() {
+        assert_eq!(*v, Some(i as i64), "wrong value at row {}", i);
+    }
+}
+
+#[test]
+fn test_default_settings_descending_nulls_last() {
+    // File A: evens descending  [(ROWS_PER_FILE-1)*2, ..., 2, 0]
+    // File B: odds  descending  [(ROWS_PER_FILE-1)*2+1, ..., 3, 1]
+    // Merged descending: 1_399_999, 1_399_998, ..., 1, 0
+    // RG0 last  value = 1_399_999 - (RG_MAX-1) = 400_000
+    // RG0 first value = 1_399_999
+    let schema = Arc::new(Schema::new(vec![Field::new("v", DataType::Int64, false)]));
+    let total  = ROWS_PER_FILE * 2;
+    let a_vals: Vec<i64> = (0..ROWS_PER_FILE).rev().map(|i| i * 2).collect();
+    let b_vals: Vec<i64> = (0..ROWS_PER_FILE).rev().map(|i| i * 2 + 1).collect();
+
+    let tmp    = tempdir().unwrap();
+    let file_a = tmp.path().join("a.parquet").to_string_lossy().to_string();
+    let file_b = tmp.path().join("b.parquet").to_string_lossy().to_string();
+    write_parquet(&file_a, &RecordBatch::try_new(schema.clone(), vec![Arc::new(Int64Array::from(a_vals))]).unwrap());
+    write_parquet(&file_b, &RecordBatch::try_new(schema.clone(), vec![Arc::new(Int64Array::from(b_vals))]).unwrap());
+
+    let output = tmp.path().join("out.parquet").to_string_lossy().to_string();
+    merge_sorted(&[file_a, file_b], &output, "test_default_desc_nulls_last",
+        &["v".into()], &[true], &[false]).unwrap();
+
+    // ── Row group structure ──────────────────────────────────────────────
+    let (rg_sizes, rg_firsts, rg_lasts) = inspect_row_groups(&output, "v");
+    assert_eq!(rg_sizes.len(), 2);
+    assert_eq!(rg_sizes[0], RG_MAX);
+    assert_eq!(rg_sizes[1], total - RG_MAX);
+    // Descending: RG0 starts at max, ends at total-RG_MAX; RG1 starts one below that
+    assert_eq!(rg_firsts[0], Some(total - 1),        "RG0 first value");
+    assert_eq!(rg_lasts[0],  Some(total - RG_MAX),   "RG0 last value");
+    assert_eq!(rg_firsts[1], Some(total - RG_MAX - 1), "RG1 first value");
+    assert_eq!(rg_lasts[1],  Some(0),                "RG1 last value");
+
+    // ── Exact value check ────────────────────────────────────────────────
+    let vals = read_col_i64(&output, "v");
+    assert_eq!(vals.len() as i64, total);
+    for (i, v) in vals.iter().enumerate() {
+        assert_eq!(*v, Some(total - 1 - i as i64), "wrong value at row {}", i);
+    }
+}
+
+#[test]
+fn test_default_settings_ascending_nulls_first() {
+    // File A: [null * half, 0, 2, 4, ..., (half-1)*2]
+    // File B: [null * half, 1, 3, 5, ..., (half-1)*2+1]
+    // nulls_first=true → merged: null*(half*2), 0, 1, 2, ..., (half-1)*2+1
+    //
+    // half = 350_000, so:
+    //   total nulls  = 700_000
+    //   total non-nulls = 700_000  (values 0..699_999)
+    //   total rows   = 1_400_000
+    //
+    // RG0 = 1_000_000 rows: all 700_000 nulls + first 300_000 non-nulls (0..299_999)
+    // RG1 =   400_000 rows: remaining non-nulls (300_000..699_999)
+    let schema = Arc::new(Schema::new(vec![Field::new("v", DataType::Int64, true)]));
+    let half   = ROWS_PER_FILE / 2; // 350_000
+    let total  = ROWS_PER_FILE * 2; // 1_400_000
+    let total_nulls    = half * 2;  // 700_000
+    let total_nonnulls = half * 2;  // 700_000  (values 0..699_999)
+
+    let a_vals: Vec<Option<i64>> = (0..half).map(|_| None)
+        .chain((0..half).map(|i| Some(i * 2)))
+        .collect();
+    let b_vals: Vec<Option<i64>> = (0..half).map(|_| None)
+        .chain((0..half).map(|i| Some(i * 2 + 1)))
+        .collect();
+
+    let tmp    = tempdir().unwrap();
+    let file_a = tmp.path().join("a.parquet").to_string_lossy().to_string();
+    let file_b = tmp.path().join("b.parquet").to_string_lossy().to_string();
+    write_parquet(&file_a, &RecordBatch::try_new(schema.clone(), vec![Arc::new(Int64Array::from(a_vals))]).unwrap());
+    write_parquet(&file_b, &RecordBatch::try_new(schema.clone(), vec![Arc::new(Int64Array::from(b_vals))]).unwrap());
+
+    let output = tmp.path().join("out.parquet").to_string_lossy().to_string();
+    merge_sorted(&[file_a, file_b], &output, "test_default_asc_nulls_first",
+        &["v".into()], &[false], &[true]).unwrap();
+
+    // ── Row group structure ──────────────────────────────────────────────
+    let (rg_sizes, rg_firsts, rg_lasts) = inspect_row_groups(&output, "v");
+    assert_eq!(rg_sizes.len(), 2);
+    assert_eq!(rg_sizes[0], RG_MAX);
+    assert_eq!(rg_sizes[1], total - RG_MAX);
+    // RG0: all nulls first, then non-nulls 0..(RG_MAX - total_nulls - 1)
+    assert_eq!(rg_firsts[0], None, "RG0 should start with null");
+    let rg0_last_nonnull = RG_MAX - total_nulls - 1; // = 1_000_000 - 700_000 - 1 = 299_999
+    assert_eq!(rg_lasts[0], Some(rg0_last_nonnull), "RG0 last value");
+    // RG1: non-nulls (rg0_last_nonnull+1)..total_nonnulls-1
+    assert_eq!(rg_firsts[1], Some(rg0_last_nonnull + 1), "RG1 first value");
+    assert_eq!(rg_lasts[1],  Some(total_nonnulls - 1),   "RG1 last value");
+
+    // ── Exact value check ────────────────────────────────────────────────
+    let vals = read_col_i64(&output, "v");
+    assert_eq!(vals.len() as i64, total);
+    // First total_nulls rows must all be None
+    for i in 0..total_nulls as usize {
+        assert_eq!(vals[i], None, "expected null at row {}", i);
+    }
+    // Remaining rows must be exactly 0, 1, 2, ..., total_nonnulls-1
+    for i in 0..total_nonnulls as usize {
+        assert_eq!(vals[total_nulls as usize + i], Some(i as i64),
+            "wrong non-null value at row {}", total_nulls as usize + i);
+    }
+}
+
+// ─── Large-file edge case tests ───────────────────────────────────────────────────
+
+/// Single file with >1M rows: no merge needed, just copy through.
+/// Verifies TIER 1 drain handles multiple batch boundaries and produces
+/// correct RG splits with exact values.
+#[test]
+fn test_single_large_file_passthrough() {
+    // 1_500_000 rows in one file → RG0=1_000_000, RG1=500_000
+    let n: i64 = 1_500_000;
+    let schema = Arc::new(Schema::new(vec![Field::new("v", DataType::Int64, false)]));
+    let vals: Vec<i64> = (0..n).collect();
+
+    let tmp    = tempdir().unwrap();
+    let file_a = tmp.path().join("a.parquet").to_string_lossy().to_string();
+    write_parquet(&file_a, &RecordBatch::try_new(schema.clone(), vec![Arc::new(Int64Array::from(vals))]).unwrap());
+
+    let output = tmp.path().join("out.parquet").to_string_lossy().to_string();
+    merge_sorted(&[file_a], &output, "test_single_large_file",
+        &["v".into()], &[false], &[false]).unwrap();
+
+    let (rg_sizes, rg_firsts, rg_lasts) = inspect_row_groups(&output, "v");
+    assert_eq!(rg_sizes.len(), 2);
+    assert_eq!(rg_sizes[0], RG_MAX);
+    assert_eq!(rg_sizes[1], n - RG_MAX);
+    assert_eq!(rg_firsts[0], Some(0));
+    assert_eq!(rg_lasts[0],  Some(RG_MAX - 1));
+    assert_eq!(rg_firsts[1], Some(RG_MAX));
+    assert_eq!(rg_lasts[1],  Some(n - 1));
+
+    let out_vals = read_col_i64(&output, "v");
+    assert_eq!(out_vals.len() as i64, n);
+    for (i, v) in out_vals.iter().enumerate() {
+        assert_eq!(*v, Some(i as i64), "wrong value at row {}", i);
+    }
+}
+
+/// Heavily skewed file sizes: file A has 1.2M rows, file B has 200K rows.
+/// File B exhausts while file A is mid-batch, forcing TIER 1 drain of A
+/// with row_idx > 0 (mid-batch position from a prior TIER 3 operation).
+#[test]
+fn test_skewed_file_sizes_large_small() {
+    // File A: evens 0, 2, 4, ..., 2_399_998  (1_200_000 values)
+    // File B: odds  1, 3, 5, ...,   399_999  (200_000 values, exhausts early)
+    // Merged: 0,1,2,3,...,399_999, 400_000,400_002,...,2_399_998
+    let large: i64 = 1_200_000;
+    let small: i64 =   200_000;
+    let schema = Arc::new(Schema::new(vec![Field::new("v", DataType::Int64, false)]));
+
+    let a_vals: Vec<i64> = (0..large).map(|i| i * 2).collect();
+    let b_vals: Vec<i64> = (0..small).map(|i| i * 2 + 1).collect();
+
+    let tmp    = tempdir().unwrap();
+    let file_a = tmp.path().join("a.parquet").to_string_lossy().to_string();
+    let file_b = tmp.path().join("b.parquet").to_string_lossy().to_string();
+    write_parquet(&file_a, &RecordBatch::try_new(schema.clone(), vec![Arc::new(Int64Array::from(a_vals))]).unwrap());
+    write_parquet(&file_b, &RecordBatch::try_new(schema.clone(), vec![Arc::new(Int64Array::from(b_vals))]).unwrap());
+
+    let output = tmp.path().join("out.parquet").to_string_lossy().to_string();
+    merge_sorted(&[file_a, file_b], &output, "test_skewed_large_small",
+        &["v".into()], &[false], &[false]).unwrap();
+
+    let total = large + small;
+    let out_vals = read_col_i64(&output, "v");
+    assert_eq!(out_vals.len() as i64, total);
+
+    // Build expected: interleaved evens/odds up to 399_999, then remaining evens
+    let mut expected: Vec<i64> = (0..small).map(|i| i * 2).collect();     // evens 0..399_998
+    let odds: Vec<i64>         = (0..small).map(|i| i * 2 + 1).collect(); // odds  1..399_999
+    expected.extend(odds);
+    expected.sort();
+    // After interleaved section: remaining evens from 400_000 to 2_399_998
+    expected.extend((small..large).map(|i| i * 2));
+
+    for (i, (got, exp)) in out_vals.iter().zip(expected.iter()).enumerate() {
+        assert_eq!(*got, Some(*exp), "wrong value at row {}", i);
+    }
+}
+
+/// Three files where the middle file exhausts first, forcing a TIER 1
+/// transition mid-merge with two remaining cursors still active.
+#[test]
+fn test_three_files_middle_exhausts_first() {
+    // File A: [0, 3, 6, ..., 299_997]  (100_000 values, step 3)
+    // File B: [1, 4, 7, ...,  29_998]  ( 10_000 values, step 3 — exhausts first)
+    // File C: [2, 5, 8, ..., 299_999]  (100_000 values, step 3)
+    // Merged: 0,1,2,3,4,5,...,29_998,29_999(missing from B),30_000,...
+    // After B exhausts, A and C continue interleaving.
+    let a_count: i64 = 100_000;
+    let b_count: i64 =  10_000;
+    let c_count: i64 = 100_000;
+    let schema = Arc::new(Schema::new(vec![Field::new("v", DataType::Int64, false)]));
+
+    let a_vals: Vec<i64> = (0..a_count).map(|i| i * 3).collect();
+    let b_vals: Vec<i64> = (0..b_count).map(|i| i * 3 + 1).collect();
+    let c_vals: Vec<i64> = (0..c_count).map(|i| i * 3 + 2).collect();
+
+    let tmp    = tempdir().unwrap();
+    let file_a = tmp.path().join("a.parquet").to_string_lossy().to_string();
+    let file_b = tmp.path().join("b.parquet").to_string_lossy().to_string();
+    let file_c = tmp.path().join("c.parquet").to_string_lossy().to_string();
+    write_parquet(&file_a, &RecordBatch::try_new(schema.clone(), vec![Arc::new(Int64Array::from(a_vals.clone()))]).unwrap());
+    write_parquet(&file_b, &RecordBatch::try_new(schema.clone(), vec![Arc::new(Int64Array::from(b_vals.clone()))]).unwrap());
+    write_parquet(&file_c, &RecordBatch::try_new(schema.clone(), vec![Arc::new(Int64Array::from(c_vals.clone()))]).unwrap());
+
+    let output = tmp.path().join("out.parquet").to_string_lossy().to_string();
+    merge_sorted(&[file_a, file_b, file_c], &output, "test_three_files_middle_exhausts",
+        &["v".into()], &[false], &[false]).unwrap();
+
+    let total = a_count + b_count + c_count;
+    let out_vals = read_col_i64(&output, "v");
+    assert_eq!(out_vals.len() as i64, total);
+
+    let mut expected: Vec<i64> = a_vals.iter().chain(b_vals.iter()).chain(c_vals.iter()).copied().collect();
+    expected.sort();
+    for (i, (got, exp)) in out_vals.iter().zip(expected.iter()).enumerate() {
+        assert_eq!(*got, Some(*exp), "wrong value at row {}", i);
+    }
+}
+
+/// All-duplicate values: every row in every file has the same sort key.
+/// Verifies total row count is preserved and no rows are dropped or duplicated.
+#[test]
+fn test_all_duplicate_sort_keys_large() {
+    // 3 files × 500_000 rows, all with value=42
+    // Total: 1_500_000 rows → 2 RGs
+    let n: i64 = 500_000;
+    let schema = Arc::new(Schema::new(vec![Field::new("v", DataType::Int64, false)]));
+    let vals: Vec<i64> = vec![42i64; n as usize];
+
+    let tmp    = tempdir().unwrap();
+    let files: Vec<String> = (0..3).map(|i| {
+        let p = tmp.path().join(format!("{}.parquet", i)).to_string_lossy().to_string();
+        write_parquet(&p, &RecordBatch::try_new(schema.clone(), vec![Arc::new(Int64Array::from(vals.clone()))]).unwrap());
+        p
+    }).collect();
+
+    let output = tmp.path().join("out.parquet").to_string_lossy().to_string();
+    merge_sorted(&files, &output, "test_all_dupes_large",
+        &["v".into()], &[false], &[false]).unwrap();
+
+    let total = n * 3;
+    let (rg_sizes, rg_firsts, rg_lasts) = inspect_row_groups(&output, "v");
+    assert_eq!(rg_sizes.len(), 2);
+    assert_eq!(rg_sizes[0], RG_MAX);
+    assert_eq!(rg_sizes[1], total - RG_MAX);
+    assert!(rg_firsts.iter().all(|v| *v == Some(42)));
+    assert!(rg_lasts.iter().all(|v| *v == Some(42)));
+
+    let out_vals = read_col_i64(&output, "v");
+    assert_eq!(out_vals.len() as i64, total);
+    assert!(out_vals.iter().all(|v| *v == Some(42)));
+}
+
+/// File sizes that are not multiples of batch_size (100_000):
+/// 150_001 + 149_999 = 300_000 rows. Verifies no off-by-one at batch boundaries.
+#[test]
+fn test_non_multiple_of_batch_size() {
+    let a_count: i64 = 150_001;
+    let b_count: i64 = 149_999;
+    let schema = Arc::new(Schema::new(vec![Field::new("v", DataType::Int64, false)]));
+
+    // File A: evens, File B: odds — interleaved merge = 0,1,2,...
+    // But counts differ so the last few values come only from one file.
+    let a_vals: Vec<i64> = (0..a_count).map(|i| i * 2).collect();
+    let b_vals: Vec<i64> = (0..b_count).map(|i| i * 2 + 1).collect();
+
+    let tmp    = tempdir().unwrap();
+    let file_a = tmp.path().join("a.parquet").to_string_lossy().to_string();
+    let file_b = tmp.path().join("b.parquet").to_string_lossy().to_string();
+    write_parquet(&file_a, &RecordBatch::try_new(schema.clone(), vec![Arc::new(Int64Array::from(a_vals.clone()))]).unwrap());
+    write_parquet(&file_b, &RecordBatch::try_new(schema.clone(), vec![Arc::new(Int64Array::from(b_vals.clone()))]).unwrap());
+
+    let output = tmp.path().join("out.parquet").to_string_lossy().to_string();
+    merge_sorted(&[file_a, file_b], &output, "test_non_multiple_batch",
+        &["v".into()], &[false], &[false]).unwrap();
+
+    let total = a_count + b_count;
+    let out_vals = read_col_i64(&output, "v");
+    assert_eq!(out_vals.len() as i64, total);
+
+    let mut expected: Vec<i64> = a_vals.iter().chain(b_vals.iter()).copied().collect();
+    expected.sort();
+    for (i, (got, exp)) in out_vals.iter().zip(expected.iter()).enumerate() {
+        assert_eq!(*got, Some(*exp), "wrong value at row {}", i);
+    }
+}
+
+/// Verifies that RG size can exceed RG_MAX when a pushed slice straddles the
+/// flush threshold (output_row_count >= output_flush_rows fires AFTER the
+/// batch is buffered, so the RG contains all buffered rows including the
+/// overshoot).
+///
+/// Setup: batch_size=100_001 so each cursor batch is 100_001 rows.
+/// output_flush_rows=1_000_000. After 9 batches: 900_009 rows buffered.
+/// 10th batch pushes 100_001 more → 1_000_010 rows → flush with 1_000_010.
+/// RG0 will be 1_000_010, not exactly 1_000_000.
+#[test]
+fn test_rg_size_overshoots_when_batch_straddles_threshold() {
+    // Use a batch_size that doesn't divide evenly into RG_MAX
+    let batch_size: usize = 100_001;
+    let index = "test_rg_overshoot";
+    SETTINGS_STORE.insert(index.to_string(), NativeSettings {
+        merge_batch_size: Some(batch_size),
+        ..Default::default()
+    });
+
+    // One file with 2_000_002 rows (20 full batches of 100_001)
+    // RG0 flushes after 10 batches = 1_000_010 rows (overshoots by 10)
+    // RG1 gets the remaining 1_000_010 - wait, 20 * 100_001 = 2_000_020 rows
+    // RG0: 1_000_010, RG1: 1_000_010
+    let n: i64 = (batch_size * 20) as i64; // 2_000_020
+    let schema = Arc::new(Schema::new(vec![Field::new("v", DataType::Int64, false)]));
+    let vals: Vec<i64> = (0..n).collect();
+
+    let tmp    = tempdir().unwrap();
+    let file_a = tmp.path().join("a.parquet").to_string_lossy().to_string();
+    write_parquet(&file_a, &RecordBatch::try_new(schema.clone(), vec![Arc::new(Int64Array::from(vals))]).unwrap());
+
+    let output = tmp.path().join("out.parquet").to_string_lossy().to_string();
+    merge_sorted(&[file_a], &output, index,
+        &["v".into()], &[false], &[false]).unwrap();
+
+    let (rg_sizes, rg_firsts, rg_lasts) = inspect_row_groups(&output, "v");
+    assert_eq!(rg_sizes.len(), 2);
+
+    // Each RG should be exactly 10 * batch_size = 1_000_010 (overshoots RG_MAX by 10)
+    let expected_rg_size = (batch_size * 10) as i64; // 1_000_010
+    assert_eq!(rg_sizes[0], expected_rg_size,
+        "RG0 size should be {} (overshoots RG_MAX={} by {}), got {}.",
+        expected_rg_size, RG_MAX, expected_rg_size - RG_MAX, rg_sizes[0]);
+    assert_eq!(rg_sizes[1], expected_rg_size, "RG1 size");
+    assert_eq!(rg_sizes.iter().sum::<i64>(), n);
+
+    // Exact boundary values
+    assert_eq!(rg_firsts[0], Some(0));
+    assert_eq!(rg_lasts[0],  Some(expected_rg_size - 1));
+    assert_eq!(rg_firsts[1], Some(expected_rg_size));
+    assert_eq!(rg_lasts[1],  Some(n - 1));
+
+    // Exact value check
+    let out_vals = read_col_i64(&output, "v");
+    assert_eq!(out_vals.len() as i64, n);
+    for (i, v) in out_vals.iter().enumerate() {
+        assert_eq!(*v, Some(i as i64), "wrong value at row {}", i);
+    }
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Tests:
Added Large file merge correctness tests and, 
Fixes: 
Bloom filter config not propagating: When bloom_filter_enabled = false, bloom filter metadata was still being written. Fixed by only setting bloom filter properties when enabled. [ we were setting bloom filter FPP / NDV settings after disabling bloom filter, setting them implicitly enables boom filter]

TIER 2 merge edge case: After draining a full batch and loading the next via advance_past_batch(), the cursor wasn't yielding back to the heap, could emit rows out of global sort order. Added yield check at batch boundary.



### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
