### PR TITLE
[Sandbox SQL snapshot] Pin org.opensearch.query:* (unified-query-*) snapshots to mavenLocal

### DIFF
--- a/sandbox/build.gradle
+++ b/sandbox/build.gradle
@@ -62,6 +62,14 @@ subprojects {
   // Drop this exclusion once the SQL feature branch merges to sql/main and
   // remote snapshots catch up.
   repositories {
+    // mavenLocal serves org.opensearch.query:* (unified-query-*) only — the
+    // sandbox-check workflow's pre-step populates it from the SQL feature branch
+    // (publishUnifiedQueryPublicationToMavenLocal). Restricting via includeGroup
+    // keeps mavenLocal off the resolution path for everything else, where it
+    // would otherwise mask intentionally-pinned remote artifacts.
+    mavenLocal {
+      mavenContent { includeGroup 'org.opensearch.query' }
+    }
     maven {
       name = 'OpenSearch Snapshots'
       url = 'https://ci.opensearch.org/ci/dbc/snapshots/maven/'

--- a/sandbox/build.gradle
+++ b/sandbox/build.gradle
@@ -46,11 +46,26 @@ subprojects {
   // The patched calcite-core / calcite-linq4j live in the OpenSearch
   // snapshots Maven repo; analytics-framework advertises them as `api`,
   // so every consumer of analytics-framework needs both the repo and a
-  // `force` to win over transitive vanilla calcite
+  // `force` to win over transitive vanilla calcite.
+  //
+  // org.opensearch.query (unified-query-*) is excluded from this remote and
+  // pinned to mavenLocal in the consuming subprojects (see analytics-engine
+  // and test-ppl-frontend build.gradle). The remote OpenSearch Snapshots repo
+  // only republishes from sql/main, not from sql/feature/mustang-ppl-integration,
+  // so its 3.7.0.0-SNAPSHOT jars trail the feature branch by however many merges.
+  // Gradle's default SNAPSHOT resolution weighs the remote's explicit
+  // <buildNumber>/timestamp metadata higher than mavenLocal's <localCopy>true>,
+  // so the stale remote wins even when mavenLocal has a newer <lastUpdated>.
+  // Excluding the group here forces gradle to fall through to mavenLocal,
+  // populated by the sandbox-check workflow's pre-step
+  // (publishUnifiedQueryPublicationToMavenLocal from the feature branch).
+  // Drop this exclusion once the SQL feature branch merges to sql/main and
+  // remote snapshots catch up.
   repositories {
     maven {
       name = 'OpenSearch Snapshots'
       url = 'https://ci.opensearch.org/ci/dbc/snapshots/maven/'
+      mavenContent { excludeGroup 'org.opensearch.query' }
     }
   }
 

--- a/sandbox/plugins/analytics-backend-datafusion/build.gradle
+++ b/sandbox/plugins/analytics-backend-datafusion/build.gradle
@@ -16,6 +16,9 @@ repositories {
   maven {
     name = 'OpenSearch Snapshots'
     url = 'https://ci.opensearch.org/ci/dbc/snapshots/maven/'
+    // unified-query-* artifacts are pinned to mavenLocal — see comment in
+    // sandbox/build.gradle's subprojects { repositories } block.
+    mavenContent { excludeGroup 'org.opensearch.query' }
   }
 }
 

--- a/sandbox/plugins/analytics-engine/build.gradle
+++ b/sandbox/plugins/analytics-engine/build.gradle
@@ -14,8 +14,16 @@
 
 apply plugin: 'opensearch.internal-cluster-test'
 
-// SQL Unified Query API version (aligned with OpenSearch build version)
-def sqlUnifiedQueryVersion = '3.6.0.0-SNAPSHOT'
+// SQL Unified Query API version (aligned with OpenSearch build version).
+// Bumped to 3.7 to match the rest of the sandbox (test-ppl-frontend declares
+// the same '3.7.0.0-SNAPSHOT'). org.opensearch.query:* is also pinned to
+// mavenLocal in sandbox/build.gradle's subprojects { repositories } block,
+// so the remote OpenSearch Snapshots repo no longer serves this group;
+// 3.6 jars don't exist in mavenLocal (only 3.7 from the feature branch's
+// publishUnifiedQueryPublicationToMavenLocal pre-step), so the older pin
+// caused `Could not find org.opensearch.query:unified-query-api:3.6.0.0-SNAPSHOT`
+// at internal-cluster-test resolution.
+def sqlUnifiedQueryVersion = '3.7.0.0-SNAPSHOT'
 
 opensearchplugin {
   description = 'Analytics engine hub: discovers and wires query extensions via ExtensiblePlugin SPI.'

--- a/sandbox/plugins/test-ppl-frontend/build.gradle
+++ b/sandbox/plugins/test-ppl-frontend/build.gradle
@@ -32,10 +32,24 @@ opensearchplugin {
 }
 
 repositories {
-  mavenLocal()
+  // Pin org.opensearch.query:* (unified-query-*) artifacts to mavenLocal only.
+  // The remote OpenSearch Snapshots repo only republishes from sql/main, not from
+  // sql/feature/mustang-ppl-integration, so its 3.7.0.0-SNAPSHOT jars trail the
+  // feature branch by however many merges. Gradle's default SNAPSHOT resolution
+  // weighs the remote's explicit <buildNumber>/timestamp metadata higher than
+  // mavenLocal's bare <localCopy>true>, so the stale remote wins even when
+  // mavenLocal has a newer <lastUpdated>. Restrict the unified-query group to
+  // mavenLocal and exclude it from the remote so the sandbox-check workflow's
+  // pre-step (publishUnifiedQueryPublicationToMavenLocal from the feature branch)
+  // is the authoritative source. Drop this filter once SQL feature branch merges
+  // to sql/main and remote snapshots catch up.
+  mavenLocal {
+    mavenContent { includeGroup 'org.opensearch.query' }
+  }
   maven {
     name = 'OpenSearch Snapshots'
     url = 'https://ci.opensearch.org/ci/dbc/snapshots/maven/'
+    mavenContent { excludeGroup 'org.opensearch.query' }
   }
 }
 


### PR DESCRIPTION
## Description

Follow-up to #21569. The sandbox-check workflow's pre-step `publishUnifiedQueryPublicationToMavenLocal` publishes the SQL feature branch's `unified-query-*` jars to mavenLocal so analytics-engine sandbox plugins build against the latest API surface. **The publish itself works, but Gradle's default SNAPSHOT resolution still prefers the stale remote** — every test that exercises the unified-query path picks up jars built from `sql/main`, not the feature branch.

### Confirmed via `dependencyInsight`

```
$ ./gradlew :sandbox:plugins:test-ppl-frontend:dependencyInsight \
    --dependency unified-query-api --configuration runtimeClasspath \
    --refresh-dependencies
org.opensearch.query:unified-query-api:3.7.0.0-SNAPSHOT:20260507.224009-12   ← REMOTE timestamp
```

### Why mavenLocal loses

Comparing `maven-metadata.xml` from each source for `unified-query-api:3.7.0.0-SNAPSHOT`:

| Source | `<lastUpdated>` | `<buildNumber>` | Identifier |
|---|---|---|---|
| **mavenLocal** (post-publish) | `20260508200435` (newer) | none, just `<localCopy>true</localCopy>` | bare `3.7.0.0-SNAPSHOT` |
| **Remote OpenSearch Snapshots** | `20260507224009` (older) | `12` | timestamped `3.7.0.0-20260507.224009-12` |

Gradle's resolver weighs the remote's explicit `<buildNumber>` + timestamp metadata higher than mavenLocal's bare `<localCopy>true>`, so the older remote wins even when mavenLocal is newer. End-to-end consequence: `test-ppl-frontend` bundles the stale 60kB `unified-query-api-3.7.0.0-SNAPSHOT.jar` (42 classes) instead of the freshly-published 29kB feature-branch jar (21 classes), and the runtime cluster ends up running the older `UnifiedQueryContext$Builder` that's missing `PPL_REX_MAX_MATCH_LIMIT`, `CALCITE_ENGINE_ENABLED`, and any other field the feature branch has added but `sql/main` hasn't received yet.

This causes `RexCommandIT` and any other IT exercising rex max-match (or anything else introduced post-`sql/main`) to fail with `Cannot invoke 'java.lang.Integer.intValue()' because Settings.getSettingValue(...) is null` at plan time, even though the workflow publish step succeeds.

## Fix

Tell Gradle's repository content filters that `org.opensearch.query` is owned by mavenLocal:

* **`sandbox/build.gradle`** `subprojects { repositories }` — add `mavenLocal { mavenContent { includeGroup 'org.opensearch.query' } }` and add `mavenContent { excludeGroup 'org.opensearch.query' }` to the existing OpenSearch Snapshots remote. Every sandbox subproject now resolves the unified-query group exclusively from mavenLocal; everything else still goes to the remote unchanged.
* **`sandbox/plugins/analytics-backend-datafusion/build.gradle`** — same `excludeGroup` filter on its own remote declaration (the file-local block isn't covered by the parent `subprojects` block, which only adds repos rather than replacing them).
* **`sandbox/plugins/test-ppl-frontend/build.gradle`** — same `includeGroup` / `excludeGroup` pair locally so `bundlePlugin` actually picks the mavenLocal jar at bundle time.
* **`sandbox/plugins/analytics-engine/build.gradle`** — bump `sqlUnifiedQueryVersion` from `3.6.0.0-SNAPSHOT` → `3.7.0.0-SNAPSHOT` to match `test-ppl-frontend`. The 3.6 line was stale; with the new filter the remote no longer serves it, and the older pin caused `Could not find org.opensearch.query:unified-query-api:3.6.0.0-SNAPSHOT` at internal-cluster-test resolution.

## Verification

* `./gradlew :sandbox:plugins:test-ppl-frontend:bundlePlugin --refresh-dependencies` — bundled `unified-query-api-3.7.0.0-SNAPSHOT.jar` drops 60kB → 29kB and the constant pool now references `PPL_REX_MAX_MATCH_LIMIT`.
* `./gradlew :sandbox:qa:analytics-engine-rest:integTest --tests RexCommandIT` — 0/16 → 16/16.
* `./gradlew :sandbox:plugins:analytics-engine:compileJava :sandbox:plugins:analytics-engine:compileTestJava` — green (the 3.7 bump resolves cleanly through mavenLocal now).

## Drop conditions

This is a temporary workaround mirroring the temporary nature of #21569. Drop both filters once the SQL feature branch merges to `sql/main` and the OpenSearch Snapshots remote starts republishing the unified-query group. At that point Gradle resolution will be correct without any content-filter intervention.