### PR TITLE
Revert "[Sandbox SQL snapshot] Pin org.opensearch.query:* (unified-query-*) snapshots to mavenLocal"

### DIFF
--- a/sandbox/build.gradle
+++ b/sandbox/build.gradle
@@ -46,34 +46,11 @@ subprojects {
   // The patched calcite-core / calcite-linq4j live in the OpenSearch
   // snapshots Maven repo; analytics-framework advertises them as `api`,
   // so every consumer of analytics-framework needs both the repo and a
-  // `force` to win over transitive vanilla calcite.
-  //
-  // org.opensearch.query (unified-query-*) is excluded from this remote and
-  // pinned to mavenLocal in the consuming subprojects (see analytics-engine
-  // and test-ppl-frontend build.gradle). The remote OpenSearch Snapshots repo
-  // only republishes from sql/main, not from sql/feature/mustang-ppl-integration,
-  // so its 3.7.0.0-SNAPSHOT jars trail the feature branch by however many merges.
-  // Gradle's default SNAPSHOT resolution weighs the remote's explicit
-  // <buildNumber>/timestamp metadata higher than mavenLocal's <localCopy>true>,
-  // so the stale remote wins even when mavenLocal has a newer <lastUpdated>.
-  // Excluding the group here forces gradle to fall through to mavenLocal,
-  // populated by the sandbox-check workflow's pre-step
-  // (publishUnifiedQueryPublicationToMavenLocal from the feature branch).
-  // Drop this exclusion once the SQL feature branch merges to sql/main and
-  // remote snapshots catch up.
+  // `force` to win over transitive vanilla calcite
   repositories {
-    // mavenLocal serves org.opensearch.query:* (unified-query-*) only — the
-    // sandbox-check workflow's pre-step populates it from the SQL feature branch
-    // (publishUnifiedQueryPublicationToMavenLocal). Restricting via includeGroup
-    // keeps mavenLocal off the resolution path for everything else, where it
-    // would otherwise mask intentionally-pinned remote artifacts.
-    mavenLocal {
-      mavenContent { includeGroup 'org.opensearch.query' }
-    }
     maven {
       name = 'OpenSearch Snapshots'
       url = 'https://ci.opensearch.org/ci/dbc/snapshots/maven/'
-      mavenContent { excludeGroup 'org.opensearch.query' }
     }
   }
 

--- a/sandbox/plugins/analytics-backend-datafusion/build.gradle
+++ b/sandbox/plugins/analytics-backend-datafusion/build.gradle
@@ -16,9 +16,6 @@ repositories {
   maven {
     name = 'OpenSearch Snapshots'
     url = 'https://ci.opensearch.org/ci/dbc/snapshots/maven/'
-    // unified-query-* artifacts are pinned to mavenLocal — see comment in
-    // sandbox/build.gradle's subprojects { repositories } block.
-    mavenContent { excludeGroup 'org.opensearch.query' }
   }
 }
 

--- a/sandbox/plugins/analytics-engine/build.gradle
+++ b/sandbox/plugins/analytics-engine/build.gradle
@@ -14,16 +14,8 @@
 
 apply plugin: 'opensearch.internal-cluster-test'
 
-// SQL Unified Query API version (aligned with OpenSearch build version).
-// Bumped to 3.7 to match the rest of the sandbox (test-ppl-frontend declares
-// the same '3.7.0.0-SNAPSHOT'). org.opensearch.query:* is also pinned to
-// mavenLocal in sandbox/build.gradle's subprojects { repositories } block,
-// so the remote OpenSearch Snapshots repo no longer serves this group;
-// 3.6 jars don't exist in mavenLocal (only 3.7 from the feature branch's
-// publishUnifiedQueryPublicationToMavenLocal pre-step), so the older pin
-// caused `Could not find org.opensearch.query:unified-query-api:3.6.0.0-SNAPSHOT`
-// at internal-cluster-test resolution.
-def sqlUnifiedQueryVersion = '3.7.0.0-SNAPSHOT'
+// SQL Unified Query API version (aligned with OpenSearch build version)
+def sqlUnifiedQueryVersion = '3.6.0.0-SNAPSHOT'
 
 opensearchplugin {
   description = 'Analytics engine hub: discovers and wires query extensions via ExtensiblePlugin SPI.'

--- a/sandbox/plugins/test-ppl-frontend/build.gradle
+++ b/sandbox/plugins/test-ppl-frontend/build.gradle
@@ -32,24 +32,10 @@ opensearchplugin {
 }
 
 repositories {
-  // Pin org.opensearch.query:* (unified-query-*) artifacts to mavenLocal only.
-  // The remote OpenSearch Snapshots repo only republishes from sql/main, not from
-  // sql/feature/mustang-ppl-integration, so its 3.7.0.0-SNAPSHOT jars trail the
-  // feature branch by however many merges. Gradle's default SNAPSHOT resolution
-  // weighs the remote's explicit <buildNumber>/timestamp metadata higher than
-  // mavenLocal's bare <localCopy>true>, so the stale remote wins even when
-  // mavenLocal has a newer <lastUpdated>. Restrict the unified-query group to
-  // mavenLocal and exclude it from the remote so the sandbox-check workflow's
-  // pre-step (publishUnifiedQueryPublicationToMavenLocal from the feature branch)
-  // is the authoritative source. Drop this filter once SQL feature branch merges
-  // to sql/main and remote snapshots catch up.
-  mavenLocal {
-    mavenContent { includeGroup 'org.opensearch.query' }
-  }
+  mavenLocal()
   maven {
     name = 'OpenSearch Snapshots'
     url = 'https://ci.opensearch.org/ci/dbc/snapshots/maven/'
-    mavenContent { excludeGroup 'org.opensearch.query' }
   }
 }
 


### PR DESCRIPTION
Reverts opensearch-project/OpenSearch#21578 - this is breaking snapshot publish workflow.