### PR TITLE
Stub support for streaming-transport request handlers in MockTransportService

### DIFF
--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stage/ShardFragmentStageExecution.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stage/ShardFragmentStageExecution.java
@@ -114,23 +114,25 @@ final class ShardFragmentStageExecution extends AbstractStageExecution implement
 
     private <T extends ActionResponse> StreamingResponseListener<T> responseListener(Function<T, VectorSchemaRoot> toVsr) {
         return new StreamingResponseListener<>() {
+            // Runs inline on the per-stream virtual thread driving handleStreamResponse.
+            // Must NOT offload to a thread pool: reordering across batches would let the
+            // isLast=true task race ahead, flip state to SUCCEEDED, and drop queued
+            // earlier batches via the isDone() short-circuit.
             @Override
             public void onStreamResponse(T response, boolean isLast) {
-                config.searchExecutor().execute(() -> {
-                    if (isDone()) {
-                        releaseResponseResources(response);
-                        return;
-                    }
+                if (isDone()) {
+                    releaseResponseResources(response);
+                    return;
+                }
 
-                    VectorSchemaRoot vsr = toVsr.apply(response);
-                    outputSink.feed(vsr);
-                    metrics.addRowsProcessed(vsr.getRowCount());
+                VectorSchemaRoot vsr = toVsr.apply(response);
+                outputSink.feed(vsr);
+                metrics.addRowsProcessed(vsr.getRowCount());
 
-                    if (isLast) {
-                        metrics.incrementTasksCompleted();
-                        onShardTerminated();
-                    }
-                });
+                if (isLast) {
+                    metrics.incrementTasksCompleted();
+                    onShardTerminated();
+                }
             }
 
             @Override

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/stage/ShardFragmentStageExecutionTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/stage/ShardFragmentStageExecutionTests.java
@@ -30,6 +30,7 @@ import org.opensearch.analytics.spi.ExchangeSink;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.core.action.ActionResponse;
 import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.test.OpenSearchTestCase;
 
@@ -177,7 +178,7 @@ public class ShardFragmentStageExecutionTests extends OpenSearchTestCase {
     // ── helpers ──────────────────────────────────────────────────────────
 
     @SuppressWarnings("unchecked")
-    private <T extends org.opensearch.core.action.ActionResponse> ShardFragmentStageExecution buildExecution(
+    private <T extends ActionResponse> ShardFragmentStageExecution buildExecution(
         CapturingSink sink,
         boolean streaming,
         AtomicReference<StreamingResponseListener<T>> listenerCapture
@@ -186,7 +187,7 @@ public class ShardFragmentStageExecutionTests extends OpenSearchTestCase {
     }
 
     @SuppressWarnings("unchecked")
-    private <T extends org.opensearch.core.action.ActionResponse> ShardFragmentStageExecution buildExecution(
+    private <T extends ActionResponse> ShardFragmentStageExecution buildExecution(
         CapturingSink sink,
         boolean streaming,
         AtomicReference<StreamingResponseListener<T>> listenerCapture,

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/stage/ShardFragmentStageExecutionTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/stage/ShardFragmentStageExecutionTests.java
@@ -35,6 +35,7 @@ import org.opensearch.test.OpenSearchTestCase;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
@@ -131,6 +132,39 @@ public class ShardFragmentStageExecutionTests extends OpenSearchTestCase {
     }
 
     /**
+     * Reproduces the lookahead-reordering bug: if the listener offloads
+     * {@code onStreamResponse} bodies onto a multi-threaded executor, the
+     * {@code isLast=true} task can complete before earlier batches' tasks
+     * have started — flipping the stage to SUCCEEDED so the still-queued
+     * earlier tasks short-circuit via {@code isDone()} and drop their data.
+     *
+     * <p>Forces the worst-case schedule deterministically with a manual
+     * executor that runs tasks in reverse submission order.
+     */
+    public void testListenerPreservesBatchesAcrossReorderedExecution() {
+        AtomicReference<StreamingResponseListener<FragmentExecutionArrowResponse>> capturedListener = new AtomicReference<>();
+        CapturingSink sink = new CapturingSink();
+        ManualExecutor manualExecutor = new ManualExecutor();
+
+        ShardFragmentStageExecution exec = buildExecution(sink, true, capturedListener, manualExecutor);
+        exec.start();
+
+        FragmentExecutionArrowResponse first = new FragmentExecutionArrowResponse(createTestBatch(2));
+        FragmentExecutionArrowResponse last = new FragmentExecutionArrowResponse(createTestBatch(3));
+
+        capturedListener.get().onStreamResponse(first, false);
+        capturedListener.get().onStreamResponse(last, true);
+
+        // Force the bug's worst case: isLast=true task runs first, transitions
+        // to SUCCEEDED; the earlier task then sees isDone()=true if the
+        // implementation is still offloading to the executor.
+        manualExecutor.runInReverseOrder();
+
+        assertEquals("both batches must be fed despite reverse-order execution", 2, sink.fed.size());
+        sink.close();
+    }
+
+    /**
      * Verifies that RowResponseCodec rejects null allocator.
      */
     public void testRowResponseCodecRejectsNullAllocator() {
@@ -148,8 +182,18 @@ public class ShardFragmentStageExecutionTests extends OpenSearchTestCase {
         boolean streaming,
         AtomicReference<StreamingResponseListener<T>> listenerCapture
     ) {
+        return buildExecution(sink, streaming, listenerCapture, Runnable::run);
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T extends org.opensearch.core.action.ActionResponse> ShardFragmentStageExecution buildExecution(
+        CapturingSink sink,
+        boolean streaming,
+        AtomicReference<StreamingResponseListener<T>> listenerCapture,
+        Executor searchExecutor
+    ) {
         Stage stage = mockStage();
-        QueryContext config = mockQueryContext();
+        QueryContext config = mockQueryContext(searchExecutor);
         ClusterService clusterService = mockClusterService();
         AnalyticsSearchTransportService dispatcher = mock(AnalyticsSearchTransportService.class);
         when(dispatcher.isStreamingEnabled()).thenReturn(streaming);
@@ -209,12 +253,37 @@ public class ShardFragmentStageExecutionTests extends OpenSearchTestCase {
     }
 
     private QueryContext mockQueryContext() {
+        return mockQueryContext(Runnable::run);
+    }
+
+    private QueryContext mockQueryContext(Executor searchExecutor) {
         QueryContext config = mock(QueryContext.class);
-        when(config.searchExecutor()).thenReturn(Runnable::run);
+        when(config.searchExecutor()).thenReturn(searchExecutor);
         when(config.parentTask()).thenReturn(mock(AnalyticsQueryTask.class));
         when(config.maxConcurrentShardRequests()).thenReturn(5);
         when(config.bufferAllocator()).thenReturn(allocator);
         return config;
+    }
+
+    /**
+     * Test executor that records submitted tasks instead of running them.
+     * Run them explicitly in any order to deterministically simulate the
+     * worst-case multi-thread completion order on a real pool.
+     */
+    private static final class ManualExecutor implements Executor {
+        private final List<Runnable> queue = new ArrayList<>();
+
+        @Override
+        public synchronized void execute(Runnable command) {
+            queue.add(command);
+        }
+
+        synchronized void runInReverseOrder() {
+            for (int i = queue.size() - 1; i >= 0; i--) {
+                queue.get(i).run();
+            }
+            queue.clear();
+        }
     }
 
     private ClusterService mockClusterService() {

--- a/sandbox/qa/analytics-engine-coordinator/build.gradle
+++ b/sandbox/qa/analytics-engine-coordinator/build.gradle
@@ -1,0 +1,134 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Coordinator-level integration tests for analytics-engine. Lives outside
+ * the analytics-engine plugin so the test classpath can pull in the
+ * DataFusion backend, Arrow Flight, and the test-ppl frontend without
+ * dragging those deps onto the plugin's own classpath.
+ */
+
+apply plugin: 'opensearch.internal-cluster-test'
+
+java { sourceCompatibility = JavaVersion.toVersion(25); targetCompatibility = JavaVersion.toVersion(25) }
+
+// Calcite transitively brings Guava onto the test compile classpath; OpenSearch's
+// forbidden-dependencies check rejects Guava on compileClasspath. Allow it here for ITs.
+configurations {
+  compileClasspath { exclude group: 'com.google.guava' }
+  testCompileClasspath { exclude group: 'com.google.guava' }
+}
+
+dependencies {
+  // Test framework provides :server, JUnit, MockTransportService, MockCommitterEnginePlugin,
+  // OpenSearchIntegTestCase, and the rest of the IT infrastructure.
+  internalClusterTestImplementation project(':test:framework')
+
+  // Plugin under test
+  internalClusterTestImplementation project(':sandbox:plugins:analytics-engine')
+
+  // Arrow Flight streaming transport — provides the streaming TransportService.
+  internalClusterTestImplementation project(':plugins:arrow-flight-rpc')
+
+  // DataFusion backend exercised end-to-end. Test-only — production analytics-engine
+  // doesn't link against a specific backend.
+  internalClusterTestImplementation project(':sandbox:plugins:analytics-backend-datafusion')
+
+  // Parquet data format — primary data format for the resilience tests.
+  internalClusterTestImplementation project(':sandbox:plugins:parquet-data-format')
+  // Composite engine plugin — provides the composite format dispatcher.
+  internalClusterTestImplementation project(':sandbox:plugins:composite-engine')
+  // TestPPLPlugin + UnifiedPPL action for driving queries from ITs.
+  internalClusterTestImplementation project(':sandbox:plugins:test-ppl-frontend')
+
+  // Guava is excluded from analytics-engine's runtime classpath (provided by
+  // arrow-flight-rpc at runtime in production). The classpath-plugin test
+  // launcher doesn't hydrate the extended-plugin classloader, so Guava must
+  // be on the test runtime classpath here.
+  internalClusterTestRuntimeOnly "com.google.guava:guava:33.3.1-jre"
+  internalClusterTestRuntimeOnly "com.google.guava:failureaccess:1.0.1"
+}
+
+tasks.withType(JavaCompile).configureEach {
+  options.compilerArgs -= '-Werror'
+}
+
+// internalClusterTest runs on a flat classpath (no plugin classloader for the classpath
+// plugins). Calcite's SqlKind clinit pulls com.google.common.collect.Sets, so Guava MUST
+// be present. Hard-attach via a detached configuration that bypasses any inherited excludes.
+def guavaRuntimeJars = configurations.detachedConfiguration(
+  dependencies.create('com.google.guava:guava:33.3.1-jre') { transitive = false },
+  dependencies.create('com.google.guava:failureaccess:1.0.1') { transitive = false },
+  dependencies.create("org.slf4j:slf4j-api:${versions.slf4j}") { transitive = false },
+  dependencies.create("commons-codec:commons-codec:${versions.commonscodec}") { transitive = false },
+  dependencies.create("com.fasterxml.jackson.core:jackson-core:${versions.jackson}") { transitive = false },
+  dependencies.create("com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}") { transitive = false },
+  dependencies.create("com.fasterxml.jackson.core:jackson-annotations:${versions.jackson_annotations}") { transitive = false }
+)
+sourceSets.internalClusterTest.runtimeClasspath += guavaRuntimeJars
+
+configurations.all {
+  // okhttp-aws-signer is a transitive of unified-query-common, only published on JitPack.
+  exclude group: 'com.github.babbel', module: 'okhttp-aws-signer'
+
+  resolutionStrategy {
+    force 'com.google.guava:guava:33.3.1-jre'
+    force 'com.google.guava:failureaccess:1.0.1'
+    force 'com.google.errorprone:error_prone_annotations:2.36.0'
+    force 'org.checkerframework:checker-qual:3.43.0'
+    force "com.fasterxml.jackson:jackson-bom:${versions.jackson}"
+    force "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"
+    force "com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}"
+    force "com.fasterxml.jackson.core:jackson-annotations:${versions.jackson_annotations}"
+    force "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${versions.jackson}"
+    force "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:${versions.jackson}"
+    force "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${versions.jackson}"
+    force "org.slf4j:slf4j-api:${versions.slf4j}"
+    force "com.google.flatbuffers:flatbuffers-java:${versions.flatbuffers}"
+    force "org.locationtech.jts:jts-core:${versions.jts}"
+    force "commons-codec:commons-codec:${versions.commonscodec}"
+    force "joda-time:joda-time:2.12.7"
+    force "org.yaml:snakeyaml:2.4"
+    force "org.codehaus.janino:janino:3.1.12"
+    force "org.codehaus.janino:commons-compiler:3.1.12"
+    force "commons-io:commons-io:${versions.commonsio}"
+    force "org.apache.commons:commons-lang3:3.18.0"
+    force "org.apache.commons:commons-text:1.11.0"
+    force "commons-logging:commons-logging:1.3.5"
+    force "net.minidev:json-smart:2.5.2"
+    force "org.apache.httpcomponents.client5:httpclient5:5.6"
+    force "org.apache.httpcomponents.core5:httpcore5:5.4"
+    force "com.squareup.okhttp3:okhttp:4.12.0"
+    force "org.jetbrains.kotlin:kotlin-stdlib:1.8.21"
+    force "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.21"
+    force "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.21"
+    force "org.jetbrains.kotlin:kotlin-stdlib-common:1.9.10"
+    force "org.apache.logging.log4j:log4j-api:${versions.log4j}"
+    force "org.apache.logging.log4j:log4j-core:${versions.log4j}"
+    // io.substrait:core (transitively via analytics-backend-datafusion) drags
+    // protobuf-java 3.25.8; project :server uses 3.25.9. Force the higher version.
+    force "com.google.protobuf:protobuf-java:3.25.9"
+  }
+}
+
+// Arrow/Flight requires these JVM flags. DataFusion backend requires the native lib
+// path so JNI can locate libopensearch_native.dylib built by dataformat-native.
+internalClusterTest {
+  jvmArgs '--add-opens=java.base/java.nio=ALL-UNNAMED'
+  jvmArgs '--add-opens=java.base/java.lang=ALL-UNNAMED'
+  jvmArgs '--add-opens=java.base/sun.nio.ch=ALL-UNNAMED'
+  jvmArgs '--enable-native-access=ALL-UNNAMED'
+  jvmArgs '-Darrow.memory.debug.allocator=false'
+  systemProperty 'io.netty.allocator.numDirectArenas', '1'
+  systemProperty 'io.netty.noUnsafe', 'false'
+  systemProperty 'io.netty.tryUnsafe', 'true'
+  systemProperty 'io.netty.tryReflectionSetAccessible', 'true'
+  systemProperty 'native.lib.path', project(':sandbox:libs:dataformat-native').ext.nativeLibPath.absolutePath
+  dependsOn ':sandbox:libs:dataformat-native:buildRustLibrary'
+  jvmArgs += ["--add-opens", "java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED"]
+}

--- a/sandbox/qa/analytics-engine-coordinator/src/internalClusterTest/java/org/opensearch/analytics/resilience/CoordinatorResilienceIT.java
+++ b/sandbox/qa/analytics-engine-coordinator/src/internalClusterTest/java/org/opensearch/analytics/resilience/CoordinatorResilienceIT.java
@@ -1,0 +1,238 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.resilience;
+
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.opensearch.Version;
+import org.opensearch.action.admin.indices.create.CreateIndexResponse;
+import org.opensearch.analytics.AnalyticsPlugin;
+import org.opensearch.analytics.exec.action.FragmentExecutionAction;
+import org.opensearch.analytics.exec.action.FragmentExecutionArrowResponse;
+import org.opensearch.arrow.flight.transport.FlightStreamPlugin;
+import org.opensearch.be.datafusion.DataFusionPlugin;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.routing.ShardRouting;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.common.util.FeatureFlags;
+import org.opensearch.composite.CompositeDataFormatPlugin;
+import org.opensearch.index.engine.dataformat.stub.MockCommitterEnginePlugin;
+import org.opensearch.parquet.ParquetDataFormatPlugin;
+import org.opensearch.plugins.Plugin;
+import org.opensearch.plugins.PluginInfo;
+import org.opensearch.ppl.TestPPLPlugin;
+import org.opensearch.ppl.action.PPLRequest;
+import org.opensearch.ppl.action.PPLResponse;
+import org.opensearch.ppl.action.UnifiedPPLExecuteAction;
+import org.opensearch.test.OpenSearchIntegTestCase;
+import org.opensearch.test.transport.MockTransportService;
+import org.opensearch.transport.TransportService;
+import org.junit.After;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.lessThan;
+
+/**
+ * Demonstrates {@link MockTransportService#addRequestHandlingBehavior} routing
+ * to handlers registered on the streaming transport. The analytics-engine
+ * registers {@link FragmentExecutionAction#NAME} on
+ * {@link org.opensearch.transport.StreamTransportService} when streaming is
+ * enabled (its handler runs on the streaming side, not the regular transport),
+ * so test-only request stubbing previously had no way to intercept it.
+ *
+ * <p>The change in this PR makes {@code addRequestHandlingBehavior} fall back
+ * to the streaming-transport's stub registry when the action is not found in
+ * the regular transport. This IT exercises that path end-to-end.
+ *
+ * @opensearch.internal
+ */
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 3, numClientNodes = 0)
+public class CoordinatorResilienceIT extends OpenSearchIntegTestCase {
+
+    private static final String INDEX = "resilience_idx";
+    private static final int NUM_SHARDS = 3;
+    private static final int DOCS_PER_SHARD_TARGET = 10;
+    private static final int VALUE = 7;
+    private static final int TOTAL_DOCS = NUM_SHARDS * DOCS_PER_SHARD_TARGET;
+    private static final long EXPECTED_SUM = (long) TOTAL_DOCS * VALUE;
+    private static final TimeValue QUERY_TIMEOUT = TimeValue.timeValueSeconds(30);
+
+    private BufferAllocator stubAllocator;
+
+    @After
+    public void closeStubAllocator() {
+        if (stubAllocator != null) {
+            stubAllocator.close();
+            stubAllocator = null;
+        }
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return List.of(
+            TestPPLPlugin.class,
+            FlightStreamPlugin.class,
+            CompositeDataFormatPlugin.class,
+            MockTransportService.TestPlugin.class,
+            // Stub committer factory satisfies the EngineConfigFactory boot-time
+            // check (`committerFactories.isEmpty() && isPluggableDataFormatEnabled`)
+            // without pulling the Lucene backend onto the IT classpath.
+            MockCommitterEnginePlugin.class
+        );
+    }
+
+    @Override
+    protected Collection<PluginInfo> additionalNodePlugins() {
+        return List.of(
+            classpathPlugin(AnalyticsPlugin.class, Collections.emptyList()),
+            classpathPlugin(ParquetDataFormatPlugin.class, Collections.emptyList()),
+            classpathPlugin(DataFusionPlugin.class, List.of(AnalyticsPlugin.class.getName()))
+        );
+    }
+
+    private static PluginInfo classpathPlugin(Class<? extends Plugin> pluginClass, List<String> extendedPlugins) {
+        return new PluginInfo(
+            pluginClass.getName(),
+            "classpath plugin",
+            "NA",
+            Version.CURRENT,
+            "1.8",
+            pluginClass.getName(),
+            null,
+            extendedPlugins,
+            false
+        );
+    }
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return Settings.builder()
+            .put(super.nodeSettings(nodeOrdinal))
+            .put(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG, true)
+            .put(FeatureFlags.STREAM_TRANSPORT, true)
+            .build();
+    }
+
+    /**
+     * Stubs one shard's {@link FragmentExecutionAction} entirely — no real
+     * handler runs, the data node never produces real data. Instead the stub
+     * returns a single zero-row Arrow batch carrying a minimal schema, then
+     * completes the stream. Coordinator must still produce a valid (smaller)
+     * result from the other two shards.
+     *
+     * <p>Exercises the streaming-fallback path in {@link MockTransportService}:
+     * {@link FragmentExecutionAction#NAME} is registered only on the streaming
+     * transport, so without the fallback the stub would never bind.
+     */
+    public void testStubReplacesStreamingShardResponseWithEmptyBatch() throws Exception {
+        createAndSeedIndex();
+        stubAllocator = new RootAllocator();
+        Schema schema = new Schema(List.of(new Field("value", FieldType.nullable(new ArrowType.Int(32, true)), null)));
+
+        AtomicInteger stubCalls = new AtomicInteger();
+        String victim = pickShardHostingNode();
+        MockTransportService mts = (MockTransportService) internalCluster().getInstance(TransportService.class, victim);
+        mts.addRequestHandlingBehavior(FragmentExecutionAction.NAME, (handler, request, channel, task) -> {
+            stubCalls.incrementAndGet();
+            VectorSchemaRoot vsr = VectorSchemaRoot.create(schema, stubAllocator);
+            vsr.allocateNew();
+            vsr.setRowCount(0);
+            // sendResponseBatch transfers buffer ownership to the wire. Honors the Flight protocol
+            // invariant that ≥1 schema-bearing frame must precede completeStream.
+            channel.sendResponseBatch(new FragmentExecutionArrowResponse(vsr));
+            channel.completeStream();
+        });
+        try {
+            PPLResponse response = executePPL("source = " + INDEX + " | stats sum(value) as total", QUERY_TIMEOUT);
+            assertThat("stub must fire on the streaming-only fragment action", stubCalls.get(), greaterThan(0));
+            assertNotNull("coordinator must produce a response when one shard contributes nothing", response);
+            long actual = ((Number) response.getRows().get(0)[response.getColumns().indexOf("total")]).longValue();
+            assertThat("Partial sum must be < full when a shard contributes nothing; got " + actual, actual, lessThan(EXPECTED_SUM));
+            assertThat("Partial sum must be ≥ 0 given the other two shards' contribution", actual, greaterThan(-1L));
+        } finally {
+            mts.clearAllRules();
+        }
+    }
+
+    /**
+     * Creates + seeds the test index. Composite-parquet flush-durability is
+     * not synchronous with prepareFlush().get(), so we assertBusy on the
+     * analytics-path sum until the seed is visible.
+     */
+    private void createAndSeedIndex() {
+        Settings indexSettings = Settings.builder()
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, NUM_SHARDS)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+            .put("index.pluggable.dataformat.enabled", true)
+            .put("index.pluggable.dataformat", "composite")
+            .put("index.composite.primary_data_format", "parquet")
+            .putList("index.composite.secondary_data_formats")
+            .build();
+
+        CreateIndexResponse response = client().admin()
+            .indices()
+            .prepareCreate(INDEX)
+            .setSettings(indexSettings)
+            .setMapping("value", "type=integer")
+            .get();
+        assertTrue("index creation must be acknowledged", response.isAcknowledged());
+        ensureGreen(INDEX);
+
+        for (int i = 0; i < TOTAL_DOCS; i++) {
+            client().prepareIndex(INDEX).setId(String.valueOf(i)).setSource("value", VALUE).get();
+        }
+        client().admin().indices().prepareRefresh(INDEX).get();
+        client().admin().indices().prepareFlush(INDEX).get();
+        try {
+            assertBusy(() -> {
+                PPLResponse r = executePPL("source = " + INDEX + " | stats sum(value) as total");
+                long actual = ((Number) r.getRows().get(0)[r.getColumns().indexOf("total")]).longValue();
+                assertEquals("seed not yet visible to analytics path", EXPECTED_SUM, actual);
+            }, 30, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            throw new AssertionError("createAndSeedIndex: timed out waiting for seed durability", e);
+        }
+    }
+
+    private PPLResponse executePPL(String ppl) {
+        return client().execute(UnifiedPPLExecuteAction.INSTANCE, new PPLRequest(ppl)).actionGet();
+    }
+
+    private PPLResponse executePPL(String ppl, TimeValue timeout) {
+        return client().execute(UnifiedPPLExecuteAction.INSTANCE, new PPLRequest(ppl)).actionGet(timeout);
+    }
+
+    /** Return one node name that currently hosts a primary of {@link #INDEX}. */
+    private String pickShardHostingNode() {
+        Map<Integer, String> out = new HashMap<>();
+        for (ShardRouting sr : clusterService().state()
+            .routingTable()
+            .index(INDEX)
+            .shardsWithState(org.opensearch.cluster.routing.ShardRoutingState.STARTED)) {
+            if (sr.primary()) {
+                out.put(sr.id(), clusterService().state().nodes().get(sr.currentNodeId()).getName());
+            }
+        }
+        return out.values().iterator().next();
+    }
+}

--- a/server/src/main/java/org/opensearch/node/Node.java
+++ b/server/src/main/java/org/opensearch/node/Node.java
@@ -1347,7 +1347,7 @@ public class Node implements Closeable {
             if (FeatureFlags.isEnabled(STREAM_TRANSPORT) && streamTransportSupplier == null) {
                 throw new IllegalStateException(STREAM_TRANSPORT + " is enabled but no stream transport supplier is provided");
             }
-            final Transport streamTransport = (streamTransportSupplier != null ? streamTransportSupplier.get() : null);
+            final Transport streamTransport = wrapStreamTransport(streamTransportSupplier != null ? streamTransportSupplier.get() : null);
 
             Set<String> taskHeaders = Stream.concat(
                 pluginsService.filterPlugins(ActionPlugin.class).stream().flatMap(p -> p.getTaskHeaders().stream()),
@@ -1830,6 +1830,18 @@ public class Node implements Closeable {
             taskHeaders,
             tracer
         );
+    }
+
+    /**
+     * Hook to wrap the stream transport before it is shared between the
+     * regular {@link TransportService} and {@link StreamTransportService}.
+     * Default returns its input unchanged. Test-framework subclasses (e.g.
+     * {@code MockNode}) override to install a stubbable wrapper so
+     * test-only request-handler interception works on the streaming path
+     * too.
+     */
+    protected Transport wrapStreamTransport(@Nullable Transport streamTransport) {
+        return streamTransport;
     }
 
     /**

--- a/test/framework/src/main/java/org/opensearch/node/MockNode.java
+++ b/test/framework/src/main/java/org/opensearch/node/MockNode.java
@@ -217,6 +217,25 @@ public class MockNode extends Node {
     }
 
     @Override
+    protected Transport wrapStreamTransport(@Nullable Transport streamTransport) {
+        if (streamTransport == null) return null;
+        // Only wrap when MockTransportService is actually in use; otherwise
+        // the regular transport stays unwrapped and we shouldn't wrap stream
+        // either (no one will look up the wrapped registry).
+        if (getPluginsService().filterPlugins(MockTransportService.TestPlugin.class).isEmpty()) {
+            return streamTransport;
+        }
+        // Same StubbableTransport used for the regular transport — both end
+        // up sharing the same stub-discovery semantics. Wrapping here means
+        // both this wrapped instance and the StreamTransportService Node
+        // builds will see the same wrapper, so handlers registered on
+        // StreamTransportService land in StubbableTransport's delegate
+        // request-handler registry — which addRequestHandlingBehavior can
+        // then see.
+        return new org.opensearch.test.transport.StubbableTransport(streamTransport);
+    }
+
+    @Override
     protected TransportService newTransportService(
         Settings settings,
         Transport transport,

--- a/test/framework/src/main/java/org/opensearch/node/MockNode.java
+++ b/test/framework/src/main/java/org/opensearch/node/MockNode.java
@@ -67,6 +67,7 @@ import org.opensearch.tasks.TaskResourceTrackingService;
 import org.opensearch.telemetry.tracing.Tracer;
 import org.opensearch.test.MockHttpTransport;
 import org.opensearch.test.transport.MockTransportService;
+import org.opensearch.test.transport.StubbableTransport;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.Transport;
 import org.opensearch.transport.TransportInterceptor;
@@ -232,7 +233,7 @@ public class MockNode extends Node {
         // StreamTransportService land in StubbableTransport's delegate
         // request-handler registry — which addRequestHandlingBehavior can
         // then see.
-        return new org.opensearch.test.transport.StubbableTransport(streamTransport);
+        return new StubbableTransport(streamTransport);
     }
 
     @Override

--- a/test/framework/src/main/java/org/opensearch/test/transport/MockTransportService.java
+++ b/test/framework/src/main/java/org/opensearch/test/transport/MockTransportService.java
@@ -627,7 +627,6 @@ public final class MockTransportService extends TransportService {
         stub.addRequestHandlingBehavior(actionName, handlingBehavior);
     }
 
-
     /**
      * Adds a new send behavior that is used for communication with the given delegate service.
      *

--- a/test/framework/src/main/java/org/opensearch/test/transport/MockTransportService.java
+++ b/test/framework/src/main/java/org/opensearch/test/transport/MockTransportService.java
@@ -66,6 +66,7 @@ import org.opensearch.transport.ClusterConnectionManager;
 import org.opensearch.transport.ConnectTransportException;
 import org.opensearch.transport.ConnectionProfile;
 import org.opensearch.transport.RequestHandlerRegistry;
+import org.opensearch.transport.StreamTransportService;
 import org.opensearch.transport.Transport;
 import org.opensearch.transport.TransportInterceptor;
 import org.opensearch.transport.TransportRequest;
@@ -189,6 +190,8 @@ public final class MockTransportService extends TransportService {
     }
 
     private final Transport original;
+    @Nullable
+    private final StubbableTransport streamTransportStub;
 
     /**
      * Build the service.
@@ -262,10 +265,15 @@ public final class MockTransportService extends TransportService {
         Set<String> taskHeaders,
         Tracer tracer
     ) {
+        // streamTransport may already be a StubbableTransport when MockNode
+        // installed the wrapper via wrapStreamTransport — in that case we
+        // share the SAME instance so the streamTransportService and this
+        // MockTransportService see the same handler registry. Wrap only if
+        // it's a plain Transport (legacy callers that bypass the Node hook).
         this(
             settings,
             new StubbableTransport(transport),
-            streamTransport != null ? new StubbableTransport(streamTransport) : null,
+            asStubbableStreamTransport(streamTransport),
             threadPool,
             interceptor,
             localNodeFactory,
@@ -273,6 +281,12 @@ public final class MockTransportService extends TransportService {
             taskHeaders,
             tracer
         );
+    }
+
+    private static StubbableTransport asStubbableStreamTransport(@Nullable Transport streamTransport) {
+        if (streamTransport == null) return null;
+        if (streamTransport instanceof StubbableTransport stubbable) return stubbable;
+        return new StubbableTransport(streamTransport);
     }
 
     private MockTransportService(
@@ -299,6 +313,7 @@ public final class MockTransportService extends TransportService {
             tracer
         );
         this.original = transport.getDelegate();
+        this.streamTransportStub = streamTransport;
     }
 
     private static TransportAddress[] extractTransportAddresses(TransportService transportService) {
@@ -584,13 +599,34 @@ public final class MockTransportService extends TransportService {
 
     /**
      * Adds a new handling behavior that is used when the defined request is received.
+     *
+     * <p>When the streaming transport is in use (e.g. {@code FlightStreamPlugin}
+     * is loaded), {@code FragmentExecutionAction.NAME}-style handlers are
+     * registered on {@link StreamTransportService}'s underlying transport, not
+     * on the regular transport. We try the regular transport's registry first
+     * (production-typical actions); if no handler is registered there, we fall
+     * back to the streaming transport's registry. Either way, the behavior
+     * fires when the matching request arrives.
      */
     public <R extends TransportRequest> void addRequestHandlingBehavior(
         String actionName,
         StubbableTransport.RequestHandlingBehavior<R> handlingBehavior
     ) {
-        transport().addRequestHandlingBehavior(actionName, handlingBehavior);
+        StubbableTransport stub = transport();
+        if (stub.hasHandler(actionName)) {
+            stub.addRequestHandlingBehavior(actionName, handlingBehavior);
+            return;
+        }
+        if (streamTransportStub != null && streamTransportStub.hasHandler(actionName)) {
+            streamTransportStub.addRequestHandlingBehavior(actionName, handlingBehavior);
+            return;
+        }
+        // Defer to the regular transport's behavior (which throws with a
+        // useful message) so the caller error matches what they'd get
+        // pre-streaming.
+        stub.addRequestHandlingBehavior(actionName, handlingBehavior);
     }
+
 
     /**
      * Adds a new send behavior that is used for communication with the given delegate service.

--- a/test/framework/src/main/java/org/opensearch/test/transport/StubbableTransport.java
+++ b/test/framework/src/main/java/org/opensearch/test/transport/StubbableTransport.java
@@ -105,6 +105,16 @@ public class StubbableTransport implements Transport {
         requestHandlers.forceRegister(newRegistry);
     }
 
+    /**
+     * Returns {@code true} if the underlying delegate transport has a
+     * registered request handler for the given action name. Used by
+     * {@link MockTransportService#addRequestHandlingBehavior(String, RequestHandlingBehavior)}
+     * to decide which transport (regular vs streaming) owns the action.
+     */
+    boolean hasHandler(String actionName) {
+        return delegate.getRequestHandlers().getHandler(actionName) != null;
+    }
+
     void clearBehaviors() {
         clearOutboundBehaviors();
         clearInboundBehaviors();


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This change adds stub support for InternalClusterTests to stub streaming responses in tests. Also includes a sandbox/qa module that uses it with a simple test case, a bug it uncovered, and a deterministic unit test for the fix.

### Related Issues

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
