### PR TITLE
[Analytics Backend / DataFusion] Wire SPAN scalar through analytics-engine route

### DIFF
--- a/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/ScalarFunction.java
+++ b/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/ScalarFunction.java
@@ -269,7 +269,19 @@ public enum ScalarFunction {
      * and preserves nulls, so the analytics-backend-datafusion plugin ships a
      * custom Rust UDF ({@code udf::mvappend}) registered on its session context.
      */
-    MVAPPEND(Category.SCALAR, SqlKind.OTHER_FUNCTION);
+    MVAPPEND(Category.SCALAR, SqlKind.OTHER_FUNCTION),
+    /**
+     * PPL {@code span(field, interval, unit?)} — bucket {@code field} into
+     * fixed-width buckets. PPL's {@code stats … by span(field, N)} lowers to
+     * a 3-arg call where the third argument is {@code NULL} for numeric
+     * buckets and a unit-name string ({@code "y"}, {@code "M"}, {@code "d"},
+     * …) for time buckets. Resolves through the SQL plugin's
+     * {@code SpanFunction} UDF named {@code "SPAN"}. The analytics-backend
+     * adapter rewrites numeric span to {@code floor(field/interval)*interval}
+     * and time span (interval=1) to {@code date_trunc(unit, field)} so the
+     * Substrait-emitted plan reaches DataFusion as standard primitives.
+     */
+    SPAN(Category.SCALAR, SqlKind.OTHER_FUNCTION);
 
     /**
      * Category of scalar function.

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionAnalyticsBackendPlugin.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionAnalyticsBackendPlugin.java
@@ -286,7 +286,11 @@ public class DataFusionAnalyticsBackendPlugin implements AnalyticsSearchBackendP
         ScalarFunction.MD5,
         ScalarFunction.SHA1,
         ScalarFunction.SHA2,
-        ScalarFunction.CRC32
+        ScalarFunction.CRC32,
+        // PPL `span(field, interval, unit?)` — bucketing for `stats … by span(...)`. Numeric
+        // span lowers to {@code floor(field/interval)*interval}; time span (interval=1) to
+        // {@code date_trunc(unit, field)}. Both targets are substrait-default operators.
+        ScalarFunction.SPAN
     );
 
     /**
@@ -512,6 +516,7 @@ public class DataFusionAnalyticsBackendPlugin implements AnalyticsSearchBackendP
                     Map.entry(ScalarFunction.SHA2, new Sha2FunctionAdapter()),
                     Map.entry(ScalarFunction.SIGN, nameMapping(SignumFunction.FUNCTION)),
                     Map.entry(ScalarFunction.SINH, new HyperbolicOperatorAdapter(SqlLibraryOperators.SINH)),
+                    Map.entry(ScalarFunction.SPAN, new SpanAdapter()),
                     Map.entry(ScalarFunction.STRCMP, new StrcmpFunctionAdapter()),
                     Map.entry(ScalarFunction.STRFTIME, new StrftimeFunctionAdapter()),
                     Map.entry(ScalarFunction.STR_TO_DATE, new RustUdfDateTimeAdapters.StrToDateAdapter()),

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionFragmentConvertor.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionFragmentConvertor.java
@@ -146,6 +146,7 @@ public class DataFusionFragmentConvertor implements FragmentConvertor {
         // Routes Calcite's TO_CHAR call to DataFusion's native `to_char` so PPL's
         // documented space-separator timestamp output is preserved on the AE path.
         FunctionMappings.s(SqlLibraryOperators.TO_CHAR, "to_char"),
+        FunctionMappings.s(SqlLibraryOperators.DATE_TRUNC, "date_trunc"),
         FunctionMappings.s(ConvertTzAdapter.LOCAL_CONVERT_TZ_OP, "convert_tz"),
         FunctionMappings.s(UnixTimestampAdapter.LOCAL_TO_UNIXTIME_OP, "to_unixtime"),
         // Niladic ops from DateTimeAdapters — each maps 1:1 to a DF builtin.

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/SpanAdapter.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/SpanAdapter.java
@@ -1,0 +1,132 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion;
+
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.fun.SqlLibraryOperators;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.opensearch.analytics.spi.FieldStorageInfo;
+import org.opensearch.analytics.spi.ScalarFunctionAdapter;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Rewrites PPL's {@code SPAN(field, interval, unit)} UDF into a Substrait-friendly
+ * expression tree that DataFusion can execute natively.
+ *
+ * <p>SPAN's third argument distinguishes the two modes:
+ * <ul>
+ *   <li><b>Numeric span</b> ({@code unit} is a typed-NULL literal): rewritten to
+ *       {@code FLOOR(field / interval) * interval} for non-integer numerics, or to
+ *       {@code (field / interval) * interval} for integer types (where Calcite's
+ *       integer division already truncates).</li>
+ *   <li><b>Time span</b> ({@code unit} is a single-letter unit string like
+ *       {@code "y"}, {@code "M"}, {@code "d"}, etc.): rewritten to
+ *       {@code DATE_TRUNC(<unit>, field)} when {@code interval == 1}. Multi-unit
+ *       intervals like {@code 12h} aren't expressible as {@code date_trunc} and
+ *       fall through to the original UDF, which surfaces as a normal substrait
+ *       binding error rather than a silent wrong-result.</li>
+ * </ul>
+ *
+ * <p>The unit-letter mapping mirrors PPL's {@code SpanUnit} enum (defined in the SQL
+ * plugin so not directly referenced here):
+ * {@code us → microsecond, ms → millisecond, s → second, m → minute, h → hour,
+ *  d → day, w → week, M → month, q → quarter, y → year}. DataFusion's
+ * {@code date_trunc} accepts the long-form names.
+ *
+ * @opensearch.internal
+ */
+class SpanAdapter implements ScalarFunctionAdapter {
+
+    /** Single-letter PPL span unit → DataFusion {@code date_trunc} unit name. */
+    private static final Map<String, String> UNIT_TO_DATE_TRUNC = Map.ofEntries(
+        Map.entry("us", "microsecond"),
+        Map.entry("ms", "millisecond"),
+        Map.entry("s", "second"),
+        Map.entry("m", "minute"),
+        Map.entry("h", "hour"),
+        Map.entry("d", "day"),
+        Map.entry("w", "week"),
+        Map.entry("M", "month"),
+        Map.entry("q", "quarter"),
+        Map.entry("y", "year")
+    );
+
+    @Override
+    public RexNode adapt(RexCall original, List<FieldStorageInfo> fieldStorage, RelOptCluster cluster) {
+        if (!original.getOperator().getName().equalsIgnoreCase("SPAN")) {
+            return original;
+        }
+        if (original.getOperands().size() != 3) {
+            return original;
+        }
+        RexNode field = original.getOperands().get(0);
+        RexNode interval = original.getOperands().get(1);
+        RexNode unit = original.getOperands().get(2);
+        RexBuilder rexBuilder = cluster.getRexBuilder();
+
+        // Numeric span: unit operand is typed-NULL.
+        if (unit.getType().getSqlTypeName() == SqlTypeName.NULL || (unit instanceof RexLiteral lit && lit.isNull())) {
+            return rewriteNumericSpan(rexBuilder, field, interval, original.getType());
+        }
+
+        // Time span: unit operand is a string literal.
+        if (unit instanceof RexLiteral lit && lit.getValue() != null) {
+            String unitText = lit.getValueAs(String.class);
+            String dateTruncUnit = unitText == null ? null : UNIT_TO_DATE_TRUNC.get(unitText);
+            if (dateTruncUnit != null && isUnitInterval(interval)) {
+                RexNode unitArg = rexBuilder.makeLiteral(dateTruncUnit);
+                return rexBuilder.makeCall(original.getType(), SqlLibraryOperators.DATE_TRUNC, List.of(unitArg, field));
+            }
+        }
+
+        // Anything else falls through unchanged.
+        return original;
+    }
+
+    private static RexNode rewriteNumericSpan(RexBuilder rexBuilder, RexNode field, RexNode interval, RelDataType resultType) {
+        SqlTypeName resultTypeName = resultType.getSqlTypeName();
+        boolean integerResult = resultTypeName == SqlTypeName.INTEGER
+            || resultTypeName == SqlTypeName.BIGINT
+            || resultTypeName == SqlTypeName.SMALLINT
+            || resultTypeName == SqlTypeName.TINYINT;
+        RexNode quotient = rexBuilder.makeCall(SqlStdOperatorTable.DIVIDE, field, interval);
+        RexNode bucket = integerResult ? quotient : rexBuilder.makeCall(SqlStdOperatorTable.FLOOR, quotient);
+        RexNode product = rexBuilder.makeCall(SqlStdOperatorTable.MULTIPLY, bucket, interval);
+        // Pin the rewritten expression to the SPAN call's declared return type. Calcite's
+        // multiplication-precision inference can produce a wider DECIMAL than the SPAN UDF
+        // declared (e.g. DECIMAL(31,1) vs DECIMAL(20,1)), and the surrounding Project's
+        // typeMatchesInferred check throws AssertionError if the substituted expression's
+        // type differs from the original call site's type.
+        return rexBuilder.makeCast(resultType, product, true);
+    }
+
+    /** True when the interval RexNode is a numeric literal exactly equal to 1. */
+    private static boolean isUnitInterval(RexNode interval) {
+        if (!(interval instanceof RexLiteral lit)) {
+            return false;
+        }
+        Object value = lit.getValue();
+        if (value instanceof BigDecimal bd) {
+            return bd.compareTo(BigDecimal.ONE) == 0;
+        }
+        if (value instanceof Number n) {
+            return n.doubleValue() == 1.0;
+        }
+        return false;
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/resources/opensearch_scalar_functions.yaml
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/resources/opensearch_scalar_functions.yaml
@@ -47,6 +47,23 @@ scalar_functions:
           - { value: string, name: "part" }
           - { value: "date", name: "value" }
         return: fp64
+  - name: "date_trunc"
+    description: >-
+      Truncate a timestamp/date to the given unit. Lowering target for PPL's
+      time-based `span(field, 1<unit>)` (rewritten by `SpanAdapter`). Same arg
+      shape as `date_part` — string unit then precision_timestamp/date — for
+      the same isthmus matchKeys reason documented on `date_part`. Return type
+      mirrors the input timestamp precision; DataFusion's `date_trunc` returns
+      the same temporal kind as its input.
+    impls:
+      - args:
+          - { value: string, name: "unit" }
+          - { value: "precision_timestamp<P>", name: "value" }
+        return: precision_timestamp<P>
+      - args:
+          - { value: string, name: "unit" }
+          - { value: "date", name: "value" }
+        return: date
   - name: "convert_tz"
     description: >-
       Shift a timestamp from one timezone to another. IANA names and +/-HH:MM

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/StatsCommandIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/StatsCommandIT.java
@@ -1,0 +1,237 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.qa;
+
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Self-contained integration test for PPL {@code stats} on the analytics-engine route.
+ *
+ * <p>Mirrors {@code CalciteStatsCommandIT} from the {@code opensearch-project/sql} repository
+ * for the operators reachable from this PR — SPAN over numerics (the wiring added here) plus
+ * the broader stats family (AVG, SUM, COUNT, MIN/MAX, DISTINCT_COUNT, STDDEV_POP / SAMP,
+ * VAR_POP / SAMP) which already flow through the analytics-engine route via Calcite's
+ * {@link org.opensearch.analytics.planner.rules.OpenSearchAggregateReduceRule} decomposition.
+ * Each test sends a PPL query through {@code POST /_analytics/ppl} (exposed by the
+ * {@code test-ppl-frontend} plugin), exercising the same {@code UnifiedQueryPlanner} →
+ * {@code CalciteRelNodeVisitor} → Substrait → DataFusion pipeline as the SQL plugin's
+ * analytics-route ITs, but inside core without depending on the SQL plugin.
+ *
+ * <p>Group-by tests use an explicit {@code | sort} suffix because the analytics-engine backend's
+ * hash-aggregation output order is non-deterministic.
+ *
+ * <p>Provisions the {@code calcs} dataset (parquet-backed) once per class via
+ * {@link DatasetProvisioner}; {@link AnalyticsRestTestCase#preserveIndicesUponCompletion()}
+ * keeps it across test methods.
+ */
+public class StatsCommandIT extends AnalyticsRestTestCase {
+
+    private static final Dataset DATASET = new Dataset("calcs", "calcs");
+
+    private static boolean dataProvisioned = false;
+
+    private void ensureDataProvisioned() throws IOException {
+        if (dataProvisioned == false) {
+            DatasetProvisioner.provision(client(), DATASET);
+            dataProvisioned = true;
+        }
+    }
+
+    // ── single-value aggregates ────────────────────────────────────────────────
+
+    public void testStatsCount() throws IOException {
+        // 17 rows in calcs.
+        assertRowsEqual("source=" + DATASET.indexName + " | stats count()", row(17));
+    }
+
+    public void testStatsCountField() throws IOException {
+        // num0 has 9 nulls and 8 non-nulls; count(num0) counts non-nulls only.
+        assertRowsEqual("source=" + DATASET.indexName + " | stats count(num0)", row(8));
+    }
+
+    public void testStatsSum() throws IOException {
+        // num0 non-nulls sum to 10.0 (12.3 + -12.3 + 15.7 + -15.7 + 3.5 + -3.5 + 0 + 10).
+        assertRowsEqual("source=" + DATASET.indexName + " | stats sum(num0)", row(10.0));
+    }
+
+    public void testStatsAvg() throws IOException {
+        // 10.0 / 8 = 1.25.
+        assertRowsEqual("source=" + DATASET.indexName + " | stats avg(num0)", row(1.25));
+    }
+
+    public void testStatsMin() throws IOException {
+        assertRowsEqual("source=" + DATASET.indexName + " | stats min(num0)", row(-15.7));
+    }
+
+    public void testStatsMax() throws IOException {
+        assertRowsEqual("source=" + DATASET.indexName + " | stats max(num0)", row(15.7));
+    }
+
+    public void testStatsDistinctCount() throws IOException {
+        // str0 takes 3 distinct values: FURNITURE, OFFICE SUPPLIES, TECHNOLOGY (plus nulls).
+        assertRowsEqual(
+            "source=" + DATASET.indexName + " | stats distinct_count(str0)",
+            row(3)
+        );
+    }
+
+    // ── filter + aggregate ─────────────────────────────────────────────────────
+
+    public void testStatsWithFilter() throws IOException {
+        // Positive-num0 values: 12.3 + 15.7 + 3.5 + 10 = 41.5.
+        assertRowsEqual(
+            "source=" + DATASET.indexName + " | where num0 > 0 | stats sum(num0)",
+            row(41.5)
+        );
+    }
+
+    // ── group-by aggregates ────────────────────────────────────────────────────
+
+    public void testStatsCountByGroup() throws IOException {
+        // calcs str0: 2 FURNITURE, 6 OFFICE SUPPLIES, 9 TECHNOLOGY rows (no nulls).
+        assertRowsEqual(
+            "source=" + DATASET.indexName + " | stats count() by str0 | sort str0",
+            row(2, "FURNITURE"),
+            row(6, "OFFICE SUPPLIES"),
+            row(9, "TECHNOLOGY")
+        );
+    }
+
+    public void testStatsSumByGroup() throws IOException {
+        // num0 sums per str0 bucket. FURNITURE and OFFICE SUPPLIES happen to net to 0.0;
+        // TECHNOLOGY nets to 10.0.
+        assertRowsEqual(
+            "source=" + DATASET.indexName + " | stats sum(num0) by str0 | sort str0",
+            row(0.0, "FURNITURE"),
+            row(0.0, "OFFICE SUPPLIES"),
+            row(10.0, "TECHNOLOGY")
+        );
+    }
+
+    public void testStatsAvgByGroup() throws IOException {
+        // num0 averages per str0 bucket. FURNITURE: {12.3, -12.3} → 0. OFFICE SUPPLIES:
+        // {15.7, -15.7} → 0. TECHNOLOGY non-null num0 is just {10} → 10. The other
+        // TECHNOLOGY rows have null num0 and don't contribute to the average.
+        assertRowsEqual(
+            "source=" + DATASET.indexName + " | stats avg(num0) by str0 | sort str0",
+            row(0.0, "FURNITURE"),
+            row(0.0, "OFFICE SUPPLIES"),
+            row(10.0, "TECHNOLOGY")
+        );
+    }
+
+    // ── statistical aggregates (STDDEV / VAR) ──────────────────────────────────
+
+    public void testStatsStddevPop() throws IOException {
+        assertRowsEqual(
+            "source=" + DATASET.indexName + " | stats stddev_pop(num0)",
+            row(10.651056285646039)
+        );
+    }
+
+    public void testStatsStddevSamp() throws IOException {
+        assertRowsEqual(
+            "source=" + DATASET.indexName + " | stats stddev_samp(num0)",
+            row(11.386458122323578)
+        );
+    }
+
+    public void testStatsVarPop() throws IOException {
+        assertRowsEqual(
+            "source=" + DATASET.indexName + " | stats var_pop(num0)",
+            row(113.445)
+        );
+    }
+
+    public void testStatsVarSamp() throws IOException {
+        assertRowsEqual(
+            "source=" + DATASET.indexName + " | stats var_samp(num0)",
+            row(129.65142857142857)
+        );
+    }
+
+    // ── span (numeric bucketing) ───────────────────────────────────────────────
+
+    public void testStatsCountBySpanNumeric() throws IOException {
+        // int0 buckets at width 5: {0:[1,3,4,4,4], 5:[7,8,8], 10:[10,11], null:6}.
+        // Sort by the bucket field so the test is deterministic across engines; ASC sort
+        // puts the null bucket first.
+        assertRowsEqual(
+            "source=" + DATASET.indexName
+                + " | stats count() by span(int0, 5) as bucket | sort bucket",
+            row(6, (Object) null),
+            row(5, 0),
+            row(4, 5),
+            row(2, 10)
+        );
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────────────
+
+    private static List<Object> row(Object... values) {
+        return Arrays.asList(values);
+    }
+
+    @SafeVarargs
+    @SuppressWarnings("varargs")
+    private final void assertRowsEqual(String ppl, List<Object>... expected) throws IOException {
+        Map<String, Object> response = executePpl(ppl);
+        @SuppressWarnings("unchecked")
+        List<List<Object>> actualRows = (List<List<Object>>) response.get("rows");
+        assertNotNull("Response missing 'rows' for query: " + ppl, actualRows);
+        assertEquals("Row count mismatch for query: " + ppl, expected.length, actualRows.size());
+        for (int i = 0; i < expected.length; i++) {
+            List<Object> want = expected[i];
+            List<Object> got = actualRows.get(i);
+            assertEquals(
+                "Column count mismatch at row " + i + " for query: " + ppl,
+                want.size(),
+                got.size()
+            );
+            for (int j = 0; j < want.size(); j++) {
+                assertCellEquals(
+                    "Cell mismatch at row " + i + ", col " + j + " for query: " + ppl,
+                    want.get(j),
+                    got.get(j)
+                );
+            }
+        }
+    }
+
+    /** Numeric-tolerant cell comparator (Jackson returns Integer/Long/Double interchangeably). */
+    private static void assertCellEquals(String message, Object expected, Object actual) {
+        if (expected == null || actual == null) {
+            assertEquals(message, expected, actual);
+            return;
+        }
+        if (expected instanceof Number && actual instanceof Number) {
+            double e = ((Number) expected).doubleValue();
+            double a = ((Number) actual).doubleValue();
+            if (Double.compare(e, a) != 0) {
+                fail(message + ": expected <" + expected + "> but was <" + actual + ">");
+            }
+            return;
+        }
+        assertEquals(message, expected, actual);
+    }
+
+    private Map<String, Object> executePpl(String ppl) throws IOException {
+        ensureDataProvisioned();
+        Request request = new Request("POST", "/_analytics/ppl");
+        request.setJsonEntity("{\"query\": \"" + escapeJson(ppl) + "\"}");
+        Response response = client().performRequest(request);
+        return assertOkAndParse(response, "PPL: " + ppl);
+    }
+}


### PR DESCRIPTION
## Summary

Wires the PPL `span(...)` scalar through the analytics-engine route to DataFusion. Repurposed per @sandeshkr419's [review](https://github.com/opensearch-project/OpenSearch/pull/21584#pullrequestreview-) — the AVG / STDDEV / VAR custom-Sig collection, percentile_approx UDAF onboarding, and defensive try/catch wrappers have all been dropped. AVG / STDDEV_POP / STDDEV_SAMP / VAR_POP / VAR_SAMP now flow through Calcite's `OpenSearchAggregateReduceRule` decomposition (landed in [#21645](https://github.com/opensearch-project/OpenSearch/pull/21645)) — no hand-holding needed.

The PR now contains two commits:

1. **`[Analytics Backend / DataFusion] Wire SPAN scalar for stats`** — adds the bucketing primitive used by `stats … by span(...)`. Numeric span lowers to `FLOOR(field/interval)*interval`; time span with `interval=1` lowers to `DATE_TRUNC(<unit>, field)`. Multi-unit time spans (`12h`, …) fall through unchanged — separate follow-up (DataFusion `date_bin`).
2. **`[QA] Add self-contained StatsCommandIT mirror`** — 16 self-contained tests under `sandbox/qa/analytics-engine-rest` exercising the `stats` operators reachable from this PR (SPAN, plus the broader stats family that already flows through the analytics route via #21645's decomposition).

The previous `[Rebase tax] Add missing FieldType import` commit is dropped — [#21663](https://github.com/opensearch-project/OpenSearch/pull/21663) fixed it upstream.

## What changed since the last review

| @sandeshkr419 comment | Disposition |
|---|---|
| `DataFusionFragmentConvertor.java:479` — *"We are decomposing the methods via Calcite decomposition. I think all these cases/functions here are covered."* | **Done.** `collectCustomAggregateSigs` + `substraitNameForCustomAgg` removed. |
| `SubstraitPlanRewriter.java:94` — *"These changes should go away as well as they seem related to support the above decomposed methods."* | **Done.** The whole `percentile_approx` UDAF onboarding commit was dropped (including the `SubstraitPlanRewriter` Aggregate visitor literal-lift). |
| `DataFusionAnalyticsBackendPlugin.java:316` — *"This can go away as well."* | **Done.** STDDEV/VAR `AGG_FUNCTIONS` additions + `AggregateCapability` type-dispatch removed. |

Additionally dropped (related cleanup): `PlannerImpl` / `FragmentConversionDriver` defensive `AssertionError` try/catch wrappers; `AggregateFunction.fromNameOrError` case-insensitive lookup; `OpenSearchAggregateSplitRule` `percentile_approx` skip guard.

## Files

| File | Change |
|---|---|
| `…/analytics-framework/.../spi/ScalarFunction.java` | `ScalarFunction.SPAN` enum entry |
| `…/analytics-backend-datafusion/.../be/datafusion/SpanAdapter.java` | **New.** Rewrites SPAN → FLOOR/MULTIPLY (numeric) or DATE_TRUNC (time) |
| `…/analytics-backend-datafusion/.../be/datafusion/DataFusionAnalyticsBackendPlugin.java` | Registers `SpanAdapter` + `ScalarFunction.SPAN` in `PROJECT_SCALAR_FUNCTIONS` |
| `…/analytics-backend-datafusion/.../be/datafusion/DataFusionFragmentConvertor.java` | +1: `SqlLibraryOperators.DATE_TRUNC` → `"date_trunc"` substrait mapping |
| `…/analytics-backend-datafusion/src/main/resources/opensearch_scalar_functions.yaml` | Declares `date_trunc` so the time-span rewrite resolves through isthmus binding |
| `…/qa/analytics-engine-rest/.../analytics/qa/StatsCommandIT.java` | **New.** 16 self-contained PPL `stats` tests over the parquet-backed `calcs` dataset |

## Verification

### `CalciteStatsCommandIT` against the analytics-engine route

Configuration: this PR + [sql#5435](https://github.com/opensearch-project/sql/pull/5435) (deterministic tiebreaker queries) + [sql#5436](https://github.com/opensearch-project/sql/pull/5436) (`tests.analytics.parquet_indices` toggle). Force-routed via `-Dtests.analytics.parquet_indices=true`. Rebased onto current `upstream/main` (post-[#21650](https://github.com/opensearch-project/OpenSearch/pull/21650) `to_char` rewrite, post-[#21663](https://github.com/opensearch-project/OpenSearch/pull/21663) FieldType import fix, post-[#21645](https://github.com/opensearch-project/OpenSearch/pull/21645) AggregateDecompositionResolver collapse).

| Result | Count | Bucket |
|---|---|---|
| **PASS** | **51 / 63** | — |
| FAIL | 8 / 63 | `percentile_approx` UDAF — intentionally dropped per Sandesh's "repurpose for span explicitly" guidance. Tests: `testStatsPercentile`, `testStatsPercentileByNullValue`, `testStatsPercentileByNullValueNonNullBucket`, `testStatsPercentileBySpan`, `testStatsPercentileWhere`, `testStatsPercentileWithCompression`, `testStatsPercentileWithMin`, `testStatsPercentileWithNull`. |
| FAIL | 1 / 63 | Schema-type mismatch on `span(birthdate, 1y)` (now returns `string` instead of `timestamp` after [#21650](https://github.com/opensearch-project/OpenSearch/pull/21650)'s `to_char` rewrite — separate concern). Test: `testStatsTimeSpan`. |
| FAIL | 1 / 63 | Multi-unit time-span unsupported (`span(@timestamp, 12h)` falls through `SpanAdapter` — only `interval=1` is rewritten to `DATE_TRUNC`). Test: `testStatsBySpanTimeWithNullBucket`. |
| FAIL | 1 / 63 | `head 2 from 1` returns `size != 2` on the analytics path (pagination quirk to investigate). Test: `testStatsWithLimit`. |
| SKIP | 1 / 63 | `testDisableLegacyPreferred` — semantic divergence between v2 default-engine preference and the analytics route's default-on. |

**Delta from previous review**: 50 → 51 (+1 PASS) thanks to [#21650](https://github.com/opensearch-project/OpenSearch/pull/21650) which fixed `testStatsSpanSortOnMeasure`'s datetime cast format divergence ([sql#5420](https://github.com/opensearch-project/sql/issues/5420)).

### QA mirror

`./gradlew :sandbox:qa:analytics-engine-rest:integTest -Dsandbox.enabled=true --tests "*StatsCommandIT"` — **16 / 16 pass** (single-value aggregates · filter + aggregate · group-by · STDDEV_POP/SAMP · VAR_POP/SAMP · numeric SPAN).

### Sandbox build

`./gradlew :sandbox:plugins:analytics-backend-datafusion:assemble :sandbox:plugins:analytics-engine:assemble -Dsandbox.enabled=true` — passes on current `upstream/main`.

## Reproduction

```bash
# Terminal A — boot the analytics-engine cluster (JDK 25, sandbox plugin set)
cd /path/to/OpenSearch
JAVA_HOME=/path/to/temurin-25 ./gradlew :run -Dsandbox.enabled=true \
  -PinstalledPlugins="['opensearch-job-scheduler:3.7.0.0-SNAPSHOT', \
    'arrow-flight-rpc', 'analytics-engine', 'parquet-data-format', \
    'analytics-backend-datafusion', 'analytics-backend-lucene', \
    'composite-engine', 'opensearch-sql-plugin:3.7.0.0-SNAPSHOT']"

# Terminal B — run the IT through the analytics path
cd /path/to/sql  # branch with sql#5435 + sql#5436 applied
./gradlew :integ-test:integTestRemote \
  -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9300 \
  -Dtests.clustername=runTask \
  -Dtests.analytics.parquet_indices=true \
  --tests "org.opensearch.sql.calcite.remote.CalciteStatsCommandIT"
```

## Test plan

- [x] `:sandbox:plugins:analytics-backend-datafusion:assemble` + `:sandbox:plugins:analytics-engine:assemble` pass on current upstream/main.
- [x] `:sandbox:qa:analytics-engine-rest:integTest --tests "*StatsCommandIT"` — 16 / 16 pass.
- [x] `CalciteStatsCommandIT` against the rebased analytics-engine cluster — **51 / 63 pass + 1 skip + 11 fail** (breakdown above).
- [ ] CI on this PR.
