### PR TITLE
Add indexing support for metadata fields.

### DIFF
--- a/modules/parent-join/src/main/java/org/opensearch/join/mapper/ParentJoinFieldMapper.java
+++ b/modules/parent-join/src/main/java/org/opensearch/join/mapper/ParentJoinFieldMapper.java
@@ -378,6 +378,9 @@ public final class ParentJoinFieldMapper extends FieldMapper {
 
     @Override
     public void parse(ParseContext context) throws IOException {
+        if (isPluggableDataFormatFeatureEnabled(context)) {
+            throw new UnsupportedOperationException("Field type: " + CONTENT_TYPE + " is not supported for pluggable formats");
+        }
         context.path().add(simpleName());
         XContentParser.Token token = context.parser().currentToken();
         String name = null;
@@ -435,13 +438,8 @@ public final class ParentJoinFieldMapper extends FieldMapper {
         }
 
         BytesRef binaryValue = new BytesRef(name);
-        if (isPluggableDataFormatFeatureEnabled(context)) {
-            context.documentInput().addField(fieldType(), binaryValue);
-        } else {
-            context.doc().add(new Field(fieldType().name(), binaryValue, fieldType));
-            context.doc().add(new SortedDocValuesField(fieldType().name(), binaryValue));
-        }
-
+        context.doc().add(new Field(fieldType().name(), binaryValue, fieldType));
+        context.doc().add(new SortedDocValuesField(fieldType().name(), binaryValue));
         context.path().remove();
     }
 

--- a/modules/parent-join/src/test/java/org/opensearch/join/mapper/ParentJoinFieldMapperTests.java
+++ b/modules/parent-join/src/test/java/org/opensearch/join/mapper/ParentJoinFieldMapperTests.java
@@ -39,24 +39,21 @@ import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.index.IndexService;
-import org.opensearch.index.engine.dataformat.DocumentInput;
 import org.opensearch.index.engine.dataformat.stub.MockCommitterEnginePlugin;
 import org.opensearch.index.engine.dataformat.stub.MockDataFormatPlugin;
 import org.opensearch.index.mapper.DocumentMapper;
-import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.index.mapper.MapperException;
 import org.opensearch.index.mapper.MapperParsingException;
 import org.opensearch.index.mapper.MapperService;
+import org.opensearch.index.mapper.MapperServiceTestCase.CapturingDocumentInput;
 import org.opensearch.index.mapper.ParsedDocument;
 import org.opensearch.index.mapper.SourceToParse;
 import org.opensearch.join.ParentJoinModulePlugin;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.test.OpenSearchSingleNodeTestCase;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 
 import static org.hamcrest.Matchers.containsString;
 
@@ -682,27 +679,20 @@ public class ParentJoinFieldMapperTests extends OpenSearchSingleNodeTestCase {
         DocumentMapper docMapper = service.mapperService()
             .merge("type", new CompressedXContent(mapping), MapperService.MergeReason.MAPPING_UPDATE);
 
-        TestDocumentInput docInput = new TestDocumentInput();
-        docMapper.parse(
-            new SourceToParse(
-                "test",
-                "1",
-                BytesReference.bytes(XContentFactory.jsonBuilder().startObject().field("join_field", "parent").endObject()),
-                MediaTypeRegistry.JSON
-            ),
-            docInput
+        CapturingDocumentInput docInput = new CapturingDocumentInput();
+        Throwable t = expectThrows(
+            MapperParsingException.class,
+            () -> docMapper.parse(
+                new SourceToParse(
+                    "test",
+                    "1",
+                    BytesReference.bytes(XContentFactory.jsonBuilder().startObject().field("join_field", "parent").endObject()),
+                    MediaTypeRegistry.JSON
+                ),
+                docInput
+            )
         );
-
-        // ParentJoinFieldMapper writes the join name ("parent") via documentInput
-        assertTrue(
-            "Expected join_field captured with value containing 'parent'",
-            docInput.getCapturedFields().stream().anyMatch(e -> e.getKey().name().equals("join_field"))
-        );
-        // ParentIdFieldMapper writes the doc id via documentInput (parseCreateFieldForPluggableFormat)
-        assertTrue(
-            "Expected join_field#parent captured via ParentIdFieldMapper",
-            docInput.getCapturedFields().stream().anyMatch(e -> e.getKey().name().equals("join_field#parent"))
-        );
+        assertEquals(UnsupportedOperationException.class, t.getCause().getClass());
     }
 
     @LockFeatureFlag(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)
@@ -724,63 +714,29 @@ public class ParentJoinFieldMapperTests extends OpenSearchSingleNodeTestCase {
         DocumentMapper docMapper = service.mapperService()
             .merge("type", new CompressedXContent(mapping), MapperService.MergeReason.MAPPING_UPDATE);
 
-        TestDocumentInput docInput = new TestDocumentInput();
-        docMapper.parse(
-            new SourceToParse(
-                "test",
-                "2",
-                BytesReference.bytes(
-                    XContentFactory.jsonBuilder()
-                        .startObject()
-                        .startObject("join_field")
-                        .field("name", "child")
-                        .field("parent", "1")
-                        .endObject()
-                        .endObject()
+        CapturingDocumentInput docInput = new CapturingDocumentInput();
+        Throwable t = expectThrows(
+            MapperParsingException.class,
+            () -> docMapper.parse(
+                new SourceToParse(
+                    "test",
+                    "2",
+                    BytesReference.bytes(
+                        XContentFactory.jsonBuilder()
+                            .startObject()
+                            .startObject("join_field")
+                            .field("name", "child")
+                            .field("parent", "1")
+                            .endObject()
+                            .endObject()
+                    ),
+                    MediaTypeRegistry.JSON,
+                    "1"
                 ),
-                MediaTypeRegistry.JSON,
-                "1"
-            ),
-            docInput
+                docInput
+            )
         );
-
-        // ParentJoinFieldMapper writes the join name ("child") via documentInput
-        assertTrue(
-            "Expected join_field captured with value containing 'child'",
-            docInput.getCapturedFields().stream().anyMatch(e -> e.getKey().name().equals("join_field"))
-        );
-        // ParentIdFieldMapper writes the parent ref via documentInput (parseCreateFieldForPluggableFormat)
-        assertTrue(
-            "Expected join_field#parent captured via ParentIdFieldMapper",
-            docInput.getCapturedFields().stream().anyMatch(e -> e.getKey().name().equals("join_field#parent"))
-        );
-    }
-
-    /**
-     * Simple DocumentInput that captures addField calls for assertion.
-     */
-    private static class TestDocumentInput implements DocumentInput<Object> {
-        private final List<Map.Entry<MappedFieldType, Object>> capturedFields = new ArrayList<>();
-
-        @Override
-        public Object getFinalInput() {
-            return null;
-        }
-
-        @Override
-        public void addField(MappedFieldType fieldType, Object value) {
-            capturedFields.add(Map.entry(fieldType, value));
-        }
-
-        @Override
-        public void setRowId(String rowIdFieldName, long rowId) {}
-
-        @Override
-        public void close() {}
-
-        public List<Map.Entry<MappedFieldType, Object>> getCapturedFields() {
-            return capturedFields;
-        }
+        assertEquals(UnsupportedOperationException.class, t.getCause().getClass());
     }
 
     @LockFeatureFlag(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)

--- a/plugins/analysis-icu/src/test/java/org/opensearch/index/mapper/ICUCollationKeywordFieldMapperTests.java
+++ b/plugins/analysis-icu/src/test/java/org/opensearch/index/mapper/ICUCollationKeywordFieldMapperTests.java
@@ -42,16 +42,13 @@ import org.apache.lucene.util.BytesRef;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.core.xcontent.XContentBuilder;
-import org.opensearch.index.engine.dataformat.DocumentInput;
 import org.opensearch.plugin.analysis.icu.AnalysisICUPlugin;
 import org.opensearch.plugins.Plugin;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 import static org.hamcrest.Matchers.containsString;
@@ -317,7 +314,7 @@ public class ICUCollationKeywordFieldMapperTests extends FieldMapperTestCase2<IC
     public void testPluggableDataFormatCollationKeyword() throws IOException {
         Settings pluggableSettings = Settings.builder().put(getIndexSettings()).put("index.pluggable.dataformat.enabled", true).build();
         DocumentMapper mapper = createDocumentMapper(pluggableSettings, fieldMapping(this::minimalMapping));
-        TestDocumentInput docInput = new TestDocumentInput();
+        CapturingDocumentInput docInput = new CapturingDocumentInput();
         mapper.parse(source(b -> b.field("field", "test_value")), docInput);
 
         boolean found = docInput.getCapturedFields().stream().anyMatch(e -> e.getKey().name().equals("field"));
@@ -328,7 +325,7 @@ public class ICUCollationKeywordFieldMapperTests extends FieldMapperTestCase2<IC
     public void testPluggableDataFormatCollationKeywordNullSkipped() throws IOException {
         Settings pluggableSettings = Settings.builder().put(getIndexSettings()).put("index.pluggable.dataformat.enabled", true).build();
         DocumentMapper mapper = createDocumentMapper(pluggableSettings, fieldMapping(this::minimalMapping));
-        TestDocumentInput docInput = new TestDocumentInput();
+        CapturingDocumentInput docInput = new CapturingDocumentInput();
         mapper.parse(source(b -> b.nullField("field")), docInput);
 
         boolean hasField = docInput.getCapturedFields().stream().anyMatch(e -> e.getKey().name().equals("field"));
@@ -346,7 +343,7 @@ public class ICUCollationKeywordFieldMapperTests extends FieldMapperTestCase2<IC
             IndexableField[] luceneFields = luceneDoc.rootDoc().getFields("field");
 
             DocumentMapper pluggableMapper = createDocumentMapper(pluggableSettings, fieldMapping(this::minimalMapping));
-            TestDocumentInput docInput = new TestDocumentInput();
+            CapturingDocumentInput docInput = new CapturingDocumentInput();
             pluggableMapper.parse(source(b -> b.field("field", "1234")), docInput);
 
             assertTrue("Lucene path should produce field 'field'", luceneFields.length > 0);
@@ -361,36 +358,12 @@ public class ICUCollationKeywordFieldMapperTests extends FieldMapperTestCase2<IC
             IndexableField[] luceneFields = luceneDoc.rootDoc().getFields("field");
 
             DocumentMapper pluggableMapper = createDocumentMapper(pluggableSettings, fieldMapping(this::minimalMapping));
-            TestDocumentInput docInput = new TestDocumentInput();
+            CapturingDocumentInput docInput = new CapturingDocumentInput();
             pluggableMapper.parse(source(b -> b.nullField("field")), docInput);
 
             assertEquals("Lucene path should produce no field 'field'", 0, luceneFields.length);
             boolean pluggableHasField = docInput.getCapturedFields().stream().anyMatch(e -> e.getKey().name().equals("field"));
             assertFalse("Pluggable path should produce no field 'field'", pluggableHasField);
-        }
-    }
-
-    private static class TestDocumentInput implements DocumentInput<Object> {
-        private final List<Map.Entry<MappedFieldType, Object>> capturedFields = new ArrayList<>();
-
-        @Override
-        public Object getFinalInput() {
-            return null;
-        }
-
-        @Override
-        public void addField(MappedFieldType fieldType, Object value) {
-            capturedFields.add(Map.entry(fieldType, value));
-        }
-
-        @Override
-        public void setRowId(String rowIdFieldName, long rowId) {}
-
-        @Override
-        public void close() {}
-
-        public List<Map.Entry<MappedFieldType, Object>> getCapturedFields() {
-            return capturedFields;
         }
     }
 }

--- a/plugins/mapper-annotated-text/src/internalClusterTest/java/org/opensearch/index/mapper/annotatedtext/AnnotatedTextFieldMapperTests.java
+++ b/plugins/mapper-annotated-text/src/internalClusterTest/java/org/opensearch/index/mapper/annotatedtext/AnnotatedTextFieldMapperTests.java
@@ -60,9 +60,7 @@ import org.opensearch.index.analysis.IndexAnalyzers;
 import org.opensearch.index.analysis.NamedAnalyzer;
 import org.opensearch.index.analysis.StandardTokenizerFactory;
 import org.opensearch.index.analysis.TokenFilterFactory;
-import org.opensearch.index.engine.dataformat.DocumentInput;
 import org.opensearch.index.mapper.DocumentMapper;
-import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.index.mapper.MapperParsingException;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.mapper.MapperTestCase;
@@ -72,13 +70,11 @@ import org.opensearch.plugin.mapper.AnnotatedTextPlugin;
 import org.opensearch.plugins.Plugin;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -619,7 +615,7 @@ public class AnnotatedTextFieldMapperTests extends MapperTestCase {
     @LockFeatureFlag(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)
     public void testPluggableDataFormatAnnotatedText() throws IOException {
         DocumentMapper mapper = createDocumentMapper(pluggableSettings(), fieldMapping(this::minimalMapping));
-        TestDocumentInput docInput = new TestDocumentInput();
+        CapturingDocumentInput docInput = new CapturingDocumentInput();
         mapper.parse(source(b -> b.field("field", "some annotated text")), docInput);
 
         boolean found = docInput.getCapturedFields()
@@ -631,7 +627,7 @@ public class AnnotatedTextFieldMapperTests extends MapperTestCase {
     @LockFeatureFlag(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)
     public void testPluggableDataFormatNullValueSkipped() throws IOException {
         DocumentMapper mapper = createDocumentMapper(pluggableSettings(), fieldMapping(this::minimalMapping));
-        TestDocumentInput docInput = new TestDocumentInput();
+        CapturingDocumentInput docInput = new CapturingDocumentInput();
         mapper.parse(source(b -> b.nullField("field")), docInput);
 
         boolean hasField = docInput.getCapturedFields().stream().anyMatch(e -> e.getKey().name().equals("field"));
@@ -648,7 +644,7 @@ public class AnnotatedTextFieldMapperTests extends MapperTestCase {
             b.endObject();
             b.endObject();
         }));
-        TestDocumentInput docInput = new TestDocumentInput();
+        CapturingDocumentInput docInput = new CapturingDocumentInput();
         mapper.parse(source(b -> b.field("text_field", "external_value")), docInput);
 
         boolean found = docInput.getCapturedFields()
@@ -666,7 +662,7 @@ public class AnnotatedTextFieldMapperTests extends MapperTestCase {
             IndexableField[] luceneFields = luceneDoc.rootDoc().getFields("field");
 
             DocumentMapper pluggableMapper = createDocumentMapper(pluggableSettings(), fieldMapping(this::minimalMapping));
-            TestDocumentInput docInput = new TestDocumentInput();
+            CapturingDocumentInput docInput = new CapturingDocumentInput();
             pluggableMapper.parse(source(b -> b.field("field", "some annotated text")), docInput);
 
             assertTrue("Lucene path should produce field 'field'", luceneFields.length > 0);
@@ -684,36 +680,12 @@ public class AnnotatedTextFieldMapperTests extends MapperTestCase {
             IndexableField[] luceneFields = luceneDoc.rootDoc().getFields("field");
 
             DocumentMapper pluggableMapper = createDocumentMapper(pluggableSettings(), fieldMapping(this::minimalMapping));
-            TestDocumentInput docInput = new TestDocumentInput();
+            CapturingDocumentInput docInput = new CapturingDocumentInput();
             pluggableMapper.parse(source(b -> b.nullField("field")), docInput);
 
             assertEquals("Lucene path should produce no field 'field'", 0, luceneFields.length);
             boolean pluggableHasField = docInput.getCapturedFields().stream().anyMatch(e -> e.getKey().name().equals("field"));
             assertFalse("Pluggable path should produce no field 'field'", pluggableHasField);
-        }
-    }
-
-    private static class TestDocumentInput implements DocumentInput<Object> {
-        private final List<Map.Entry<MappedFieldType, Object>> capturedFields = new ArrayList<>();
-
-        @Override
-        public Object getFinalInput() {
-            return null;
-        }
-
-        @Override
-        public void addField(MappedFieldType fieldType, Object value) {
-            capturedFields.add(Map.entry(fieldType, value));
-        }
-
-        @Override
-        public void setRowId(String rowIdFieldName, long rowId) {}
-
-        @Override
-        public void close() {}
-
-        public List<Map.Entry<MappedFieldType, Object>> getCapturedFields() {
-            return capturedFields;
         }
     }
 }

--- a/plugins/mapper-murmur3/src/test/java/org/opensearch/index/mapper/murmur3/Murmur3FieldMapperTests.java
+++ b/plugins/mapper-murmur3/src/test/java/org/opensearch/index/mapper/murmur3/Murmur3FieldMapperTests.java
@@ -40,20 +40,16 @@ import org.opensearch.common.hash.MurmurHash3;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.core.xcontent.XContentBuilder;
-import org.opensearch.index.engine.dataformat.DocumentInput;
 import org.opensearch.index.mapper.DocumentMapper;
-import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.index.mapper.MapperTestCase;
 import org.opensearch.index.mapper.ParsedDocument;
 import org.opensearch.plugin.mapper.MapperMurmur3Plugin;
 import org.opensearch.plugins.Plugin;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 
 public class Murmur3FieldMapperTests extends MapperTestCase {
 
@@ -92,7 +88,7 @@ public class Murmur3FieldMapperTests extends MapperTestCase {
     public void testPluggableDataFormatMurmur3() throws IOException {
         Settings pluggableSettings = Settings.builder().put(getIndexSettings()).put("index.pluggable.dataformat.enabled", true).build();
         DocumentMapper mapper = createDocumentMapper(pluggableSettings, fieldMapping(this::minimalMapping));
-        TestDocumentInput docInput = new TestDocumentInput();
+        CapturingDocumentInput docInput = new CapturingDocumentInput();
         mapper.parse(source(b -> b.field("field", "test_value")), docInput);
 
         boolean found = docInput.getCapturedFields().stream().anyMatch(e -> e.getKey().name().equals("field"));
@@ -103,7 +99,7 @@ public class Murmur3FieldMapperTests extends MapperTestCase {
     public void testPluggableDataFormatMurmur3NullSkipped() throws IOException {
         Settings pluggableSettings = Settings.builder().put(getIndexSettings()).put("index.pluggable.dataformat.enabled", true).build();
         DocumentMapper mapper = createDocumentMapper(pluggableSettings, fieldMapping(this::minimalMapping));
-        TestDocumentInput docInput = new TestDocumentInput();
+        CapturingDocumentInput docInput = new CapturingDocumentInput();
         mapper.parse(source(b -> b.nullField("field")), docInput);
 
         boolean hasField = docInput.getCapturedFields().stream().anyMatch(e -> e.getKey().name().equals("field"));
@@ -121,7 +117,7 @@ public class Murmur3FieldMapperTests extends MapperTestCase {
             IndexableField[] luceneFields = luceneDoc.rootDoc().getFields("field");
 
             DocumentMapper pluggableMapper = createDocumentMapper(pluggableSettings, fieldMapping(this::minimalMapping));
-            TestDocumentInput docInput = new TestDocumentInput();
+            CapturingDocumentInput docInput = new CapturingDocumentInput();
             pluggableMapper.parse(source(b -> b.field("field", "test_value")), docInput);
 
             assertTrue("Lucene path should produce field 'field'", luceneFields.length > 0);
@@ -136,7 +132,7 @@ public class Murmur3FieldMapperTests extends MapperTestCase {
             IndexableField[] luceneFields = luceneDoc.rootDoc().getFields("field");
 
             DocumentMapper pluggableMapper = createDocumentMapper(pluggableSettings, fieldMapping(this::minimalMapping));
-            TestDocumentInput docInput = new TestDocumentInput();
+            CapturingDocumentInput docInput = new CapturingDocumentInput();
             pluggableMapper.parse(source(b -> b.nullField("field")), docInput);
 
             assertEquals("Lucene path should produce no field 'field'", 0, luceneFields.length);
@@ -157,29 +153,5 @@ public class Murmur3FieldMapperTests extends MapperTestCase {
         BytesRef bytes2 = new BytesRef(testValue);
         long hash2 = MurmurHash3.hash128(bytes2.bytes, bytes2.offset, bytes2.length, 0, new MurmurHash3.Hash128()).h1;
         assertEquals("Hash should be consistent for same input", hash, hash2);
-    }
-
-    private static class TestDocumentInput implements DocumentInput<Object> {
-        private final List<Map.Entry<MappedFieldType, Object>> capturedFields = new ArrayList<>();
-
-        @Override
-        public Object getFinalInput() {
-            return null;
-        }
-
-        @Override
-        public void addField(MappedFieldType fieldType, Object value) {
-            capturedFields.add(Map.entry(fieldType, value));
-        }
-
-        @Override
-        public void setRowId(String rowIdFieldName, long rowId) {}
-
-        @Override
-        public void close() {}
-
-        public List<Map.Entry<MappedFieldType, Object>> getCapturedFields() {
-            return capturedFields;
-        }
     }
 }

--- a/plugins/mapper-size/src/internalClusterTest/java/org/opensearch/index/mapper/size/SizeMappingTests.java
+++ b/plugins/mapper-size/src/internalClusterTest/java/org/opensearch/index/mapper/size/SizeMappingTests.java
@@ -40,12 +40,11 @@ import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.index.IndexService;
-import org.opensearch.index.engine.dataformat.DocumentInput;
 import org.opensearch.index.engine.dataformat.stub.MockCommitterEnginePlugin;
 import org.opensearch.index.engine.dataformat.stub.MockDataFormatPlugin;
 import org.opensearch.index.mapper.DocumentMapper;
-import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.index.mapper.MapperService;
+import org.opensearch.index.mapper.MapperServiceTestCase.CapturingDocumentInput;
 import org.opensearch.index.mapper.ParsedDocument;
 import org.opensearch.index.mapper.SourceToParse;
 import org.opensearch.plugin.mapper.MapperSizePlugin;
@@ -53,10 +52,7 @@ import org.opensearch.plugins.Plugin;
 import org.opensearch.test.InternalSettingsPlugin;
 import org.opensearch.test.OpenSearchSingleNodeTestCase;
 
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
-import java.util.Map;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
@@ -143,7 +139,7 @@ public class SizeMappingTests extends OpenSearchSingleNodeTestCase {
         DocumentMapper docMapper = service.mapperService()
             .merge("type", new CompressedXContent(mapping), MapperService.MergeReason.MAPPING_UPDATE);
 
-        TestDocumentInput docInput = new TestDocumentInput();
+        CapturingDocumentInput docInput = new CapturingDocumentInput();
         docMapper.parse(
             new SourceToParse(
                 "test",
@@ -157,29 +153,5 @@ public class SizeMappingTests extends OpenSearchSingleNodeTestCase {
         // SizeFieldMapper.postParse adds the source length via documentInput when pluggable format is enabled
         boolean found = docInput.getCapturedFields().stream().anyMatch(e -> e.getKey().name().equals("_size"));
         assertTrue("Expected _size field captured via postParse pluggable format path", found);
-    }
-
-    private static class TestDocumentInput implements DocumentInput<Object> {
-        private final List<Map.Entry<MappedFieldType, Object>> capturedFields = new ArrayList<>();
-
-        @Override
-        public Object getFinalInput() {
-            return null;
-        }
-
-        @Override
-        public void addField(MappedFieldType fieldType, Object value) {
-            capturedFields.add(Map.entry(fieldType, value));
-        }
-
-        @Override
-        public void setRowId(String rowIdFieldName, long rowId) {}
-
-        @Override
-        public void close() {}
-
-        public List<Map.Entry<MappedFieldType, Object>> getCapturedFields() {
-            return capturedFields;
-        }
     }
 }

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/LuceneFieldFactory.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/LuceneFieldFactory.java
@@ -9,6 +9,7 @@
 package org.opensearch.be.lucene;
 
 import org.apache.lucene.document.Document;
+import org.apache.lucene.index.IndexableFieldType;
 import org.opensearch.common.annotation.ExperimentalApi;
 import org.opensearch.index.mapper.MappedFieldType;
 
@@ -29,5 +30,5 @@ public interface LuceneFieldFactory {
      * @param fieldType the OpenSearch mapped field type (carries name, analyzer, doc-values config)
      * @param value     the field value
      */
-    void addField(Document document, MappedFieldType fieldType, Object value);
+    void addField(Document document, MappedFieldType fieldType, Object value, IndexableFieldType luceneFieldType);
 }

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/LuceneFieldFactoryRegistry.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/LuceneFieldFactoryRegistry.java
@@ -9,10 +9,14 @@
 package org.opensearch.be.lucene;
 
 import org.apache.lucene.document.Field;
-import org.apache.lucene.document.FieldType;
-import org.apache.lucene.index.IndexOptions;
+import org.apache.lucene.document.LongPoint;
 import org.apache.lucene.util.BytesRef;
 import org.opensearch.common.annotation.ExperimentalApi;
+import org.opensearch.index.mapper.IdFieldMapper;
+import org.opensearch.index.mapper.KeywordFieldMapper;
+import org.opensearch.index.mapper.MatchOnlyTextFieldMapper;
+import org.opensearch.index.mapper.SeqNoFieldMapper;
+import org.opensearch.index.mapper.TextFieldMapper;
 
 import java.util.Map;
 import java.util.Set;
@@ -30,56 +34,25 @@ import java.util.concurrent.ConcurrentHashMap;
 @ExperimentalApi
 public final class LuceneFieldFactoryRegistry {
 
-    // ── Pre-built Lucene FieldTypes matching OpenSearch mapper defaults ──
-
-    /** Matches {@code TextFieldMapper.Defaults.FIELD_TYPE}. */
-    private static final FieldType TEXT_FIELD_TYPE;
-    static {
-        TEXT_FIELD_TYPE = new FieldType();
-        TEXT_FIELD_TYPE.setTokenized(true);
-        TEXT_FIELD_TYPE.setStored(false);
-        TEXT_FIELD_TYPE.setStoreTermVectors(false);
-        TEXT_FIELD_TYPE.setOmitNorms(false);
-        TEXT_FIELD_TYPE.setIndexOptions(IndexOptions.DOCS_AND_FREQS_AND_POSITIONS);
-        TEXT_FIELD_TYPE.freeze();
-    }
-
-    /** Matches {@code KeywordFieldMapper.Defaults.FIELD_TYPE}. */
-    private static final FieldType KEYWORD_FIELD_TYPE;
-    static {
-        KEYWORD_FIELD_TYPE = new FieldType();
-        KEYWORD_FIELD_TYPE.setTokenized(false);
-        KEYWORD_FIELD_TYPE.setStored(false);
-        KEYWORD_FIELD_TYPE.setOmitNorms(true);
-        KEYWORD_FIELD_TYPE.setIndexOptions(IndexOptions.DOCS);
-        KEYWORD_FIELD_TYPE.freeze();
-    }
-
-    /** Matches {@code MatchOnlyTextFieldMapper.FIELD_TYPE}. */
-    private static final FieldType MATCH_ONLY_TEXT_FIELD_TYPE;
-    static {
-        MATCH_ONLY_TEXT_FIELD_TYPE = new FieldType();
-        MATCH_ONLY_TEXT_FIELD_TYPE.setTokenized(true);
-        MATCH_ONLY_TEXT_FIELD_TYPE.setStored(false);
-        MATCH_ONLY_TEXT_FIELD_TYPE.setStoreTermVectors(false);
-        MATCH_ONLY_TEXT_FIELD_TYPE.setOmitNorms(true);
-        MATCH_ONLY_TEXT_FIELD_TYPE.setIndexOptions(IndexOptions.DOCS);
-        MATCH_ONLY_TEXT_FIELD_TYPE.freeze();
-    }
-
     // ── Default factories ──
-
-    private static final LuceneFieldFactory TEXT_FACTORY = (doc, ft, value) -> {
-        doc.add(new Field(ft.name(), value.toString(), TEXT_FIELD_TYPE));
+    private static final LuceneFieldFactory TEXT_FACTORY = (doc, ft, value, lft) -> {
+        doc.add(new Field(ft.name(), value.toString(), lft));
     };
 
-    private static final LuceneFieldFactory KEYWORD_FACTORY = (doc, ft, value) -> {
-        BytesRef binaryValue = new BytesRef(value.toString());
-        doc.add(new Field(ft.name(), binaryValue, KEYWORD_FIELD_TYPE));
+    private static final LuceneFieldFactory KEYWORD_FACTORY = (doc, ft, value, lft) -> {
+        doc.add(new Field(ft.name(), value.toString(), lft));
     };
 
-    private static final LuceneFieldFactory MATCH_ONLY_TEXT_FACTORY = (doc, ft, value) -> {
-        doc.add(new Field(ft.name(), value.toString(), MATCH_ONLY_TEXT_FIELD_TYPE));
+    private static final LuceneFieldFactory MATCH_ONLY_TEXT_FACTORY = (doc, ft, value, lft) -> {
+        doc.add(new Field(ft.name(), value.toString(), lft));
+    };
+
+    private static final LuceneFieldFactory ID_FIELD_FACTORY = (doc, ft, value, lft) -> {
+        doc.add(new Field(ft.name(), new BytesRef((byte[]) value), IdFieldMapper.Defaults.FIELD_TYPE));
+    };
+
+    private static final LuceneFieldFactory SEQ_NO_FIELD_FACTORY = (doc, ft, value, lft) -> {
+        doc.add(new LongPoint(ft.name(), (long) value));
     };
 
     // ── Registry ──
@@ -90,9 +63,11 @@ public final class LuceneFieldFactoryRegistry {
      * Creates a registry pre-populated with the default full-text-searchable field factories.
      */
     public LuceneFieldFactoryRegistry() {
-        factories.put("text", TEXT_FACTORY);
-        factories.put("keyword", KEYWORD_FACTORY);
-        factories.put("match_only_text", MATCH_ONLY_TEXT_FACTORY);
+        register(TextFieldMapper.CONTENT_TYPE, TEXT_FACTORY);
+        register(KeywordFieldMapper.CONTENT_TYPE, KEYWORD_FACTORY);
+        register(MatchOnlyTextFieldMapper.CONTENT_TYPE, MATCH_ONLY_TEXT_FACTORY);
+        register(IdFieldMapper.CONTENT_TYPE, ID_FIELD_FACTORY);
+        register(SeqNoFieldMapper.CONTENT_TYPE, SEQ_NO_FIELD_FACTORY);
     }
 
     /**

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/index/LuceneDocumentInput.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/index/LuceneDocumentInput.java
@@ -9,7 +9,9 @@
 package org.opensearch.be.lucene.index;
 
 import org.apache.lucene.document.Document;
+import org.apache.lucene.document.FieldType;
 import org.apache.lucene.document.SortedNumericDocValuesField;
+import org.apache.lucene.index.DocValuesType;
 import org.opensearch.be.lucene.LuceneFieldFactory;
 import org.opensearch.be.lucene.LuceneFieldFactoryRegistry;
 import org.opensearch.common.annotation.ExperimentalApi;
@@ -34,13 +36,6 @@ import org.opensearch.index.mapper.MappedFieldType;
  */
 @ExperimentalApi
 public class LuceneDocumentInput implements DocumentInput<Document> {
-
-    /**
-     * Name of the row ID field stored in each Lucene document.
-     * @deprecated Use {@link DocumentInput#ROW_ID_FIELD} instead.
-     */
-    @Deprecated
-    public static final String ROW_ID_FIELD = DocumentInput.ROW_ID_FIELD;
 
     private final Document document;
     private final LuceneFieldFactoryRegistry fieldFactoryRegistry;
@@ -82,17 +77,27 @@ public class LuceneDocumentInput implements DocumentInput<Document> {
      */
     @Override
     public void addField(MappedFieldType fieldType, Object value) {
-        if (value == null || fieldType == null) {
-            return;
-        }
-
-        String typeName = fieldType.typeName();
-        LuceneFieldFactory factory = fieldFactoryRegistry.get(typeName);
+        assert value != null : "Field value must not be null";
+        LuceneFieldFactory factory = fieldFactory(fieldType);
         if (factory == null) {
             return;
         }
+        FieldType luceneFieldType;
+        if (fieldType.getTextSearchInfo() != null && fieldType.getTextSearchInfo().getLuceneFieldType() != null) {
+            luceneFieldType = new FieldType(fieldType.getTextSearchInfo().getLuceneFieldType());
+            luceneFieldType.setDocValuesType(DocValuesType.NONE);
+            luceneFieldType.setStored(false);
+        } else {
+            luceneFieldType = null;
+        }
+        factory.addField(document, fieldType, value, luceneFieldType);
+    }
 
-        factory.addField(document, fieldType, value);
+    private LuceneFieldFactory fieldFactory(MappedFieldType fieldType) {
+        if (fieldType == null) {
+            throw new IllegalArgumentException("Field type and value must not be null");
+        }
+        return fieldFactoryRegistry.get(fieldType.typeName());
     }
 
     /**
@@ -105,6 +110,11 @@ public class LuceneDocumentInput implements DocumentInput<Document> {
     @Override
     public void setRowId(String rowIdFieldName, long rowId) {
         document.add(new SortedNumericDocValuesField(rowIdFieldName, rowId));
+    }
+
+    @Override
+    public long getFieldCount(String fieldName) {
+        return document.getFields(fieldName).length;
     }
 
     /** No-op — this document input holds no closeable resources. */

--- a/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/LuceneDataFormatAwareEngineTests.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/LuceneDataFormatAwareEngineTests.java
@@ -1,0 +1,149 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.lucene;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.apache.lucene.index.NoMergePolicy;
+import org.apache.lucene.search.ReferenceManager;
+import org.opensearch.Version;
+import org.opensearch.be.lucene.index.LuceneCommitterFactory;
+import org.opensearch.be.lucene.index.LuceneDocumentInput;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.common.util.BigArrays;
+import org.opensearch.index.IndexSettings;
+import org.opensearch.index.codec.CodecService;
+import org.opensearch.index.engine.EngineConfig;
+import org.opensearch.index.engine.dataformat.AbstractDataFormatAwareEngineTestCase;
+import org.opensearch.index.engine.dataformat.DataFormatPlugin;
+import org.opensearch.index.engine.dataformat.DataFormatRegistry;
+import org.opensearch.index.engine.dataformat.DocumentInput;
+import org.opensearch.index.engine.exec.commit.CommitterFactory;
+import org.opensearch.index.mapper.MappedFieldType;
+import org.opensearch.index.mapper.MapperService;
+import org.opensearch.index.mapper.SeqNoFieldMapper;
+import org.opensearch.index.mapper.VersionFieldMapper;
+import org.opensearch.index.seqno.RetentionLeases;
+import org.opensearch.index.seqno.SequenceNumbers;
+import org.opensearch.index.store.Store;
+import org.opensearch.index.translog.TranslogConfig;
+import org.opensearch.plugins.PluginsService;
+import org.opensearch.plugins.SearchBackEndPlugin;
+import org.opensearch.test.IndexSettingsModule;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.opensearch.index.engine.EngineTestCase.tombstoneDocSupplier;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Runs the {@link AbstractDataFormatAwareEngineTestCase} suite with the real
+ * Lucene {@link LucenePlugin} engine, validating that the DFAE orchestration
+ * layer (indexing, refresh, flush, concurrency, catalog snapshots) works
+ * correctly with Lucene's inverted index writer and segment management.
+ *
+ * <p>Overrides {@link #buildEngineConfig} to provide the {@link CodecService}
+ * and {@link StandardAnalyzer} that the {@link LuceneCommitterFactory} requires
+ * for creating the shared {@code IndexWriter}.
+ */
+public class LuceneDataFormatAwareEngineTests extends AbstractDataFormatAwareEngineTestCase {
+
+    @Override
+    protected DataFormatPlugin createDataFormatPlugin() {
+        return new LucenePlugin();
+    }
+
+    @Override
+    protected SearchBackEndPlugin<?> createSearchBackEndPlugin() {
+        return new LucenePlugin();
+    }
+
+    @Override
+    protected String dataFormatName() {
+        return LuceneDataFormat.LUCENE_FORMAT_NAME;
+    }
+
+    @Override
+    protected CommitterFactory createCommitterFactory(Store store) {
+        return new LuceneCommitterFactory();
+    }
+
+    @Override
+    protected DocumentInput<?> createDocumentInput() {
+        return new LuceneDocumentInput(new LuceneFieldFactoryRegistry());
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected EngineConfig buildEngineConfig(
+        Store store,
+        Path translogPath,
+        List<ReferenceManager.RefreshListener> externalListeners,
+        List<ReferenceManager.RefreshListener> internalListeners
+    ) {
+        Settings.Builder settingsBuilder = Settings.builder()
+            .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+            .put(IndexSettings.INDEX_SOFT_DELETES_SETTING.getKey(), true)
+            .put(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), true)
+            .put(IndexSettings.PLUGGABLE_DATAFORMAT_VALUE_SETTING.getKey(), dataFormatName())
+            .put(additionalIndexSettings());
+        IndexSettings indexSettings = IndexSettingsModule.newIndexSettings("test", settingsBuilder.build());
+
+        TranslogConfig translogConfig = new TranslogConfig(
+            shardId,
+            translogPath,
+            indexSettings,
+            BigArrays.NON_RECYCLING_INSTANCE,
+            "",
+            false
+        );
+
+        PluginsService pluginsService = mock(PluginsService.class);
+        when(pluginsService.filterPlugins(DataFormatPlugin.class)).thenReturn(List.of(createDataFormatPlugin()));
+        when(pluginsService.filterPlugins(SearchBackEndPlugin.class)).thenReturn(List.of(createSearchBackEndPlugin()));
+        DataFormatRegistry registry = new DataFormatRegistry(pluginsService);
+
+        CodecService codecService = new CodecService(null, indexSettings, LogManager.getLogger(getClass()), List.of());
+
+        MapperService mapperService = mock(MapperService.class);
+        MappedFieldType versionFieldType = mock(MappedFieldType.class);
+        when(versionFieldType.typeName()).thenReturn(VersionFieldMapper.CONTENT_TYPE);
+        when(versionFieldType.name()).thenReturn(VersionFieldMapper.NAME);
+        MappedFieldType seqNoFieldType = mock(MappedFieldType.class);
+        when(seqNoFieldType.typeName()).thenReturn(SeqNoFieldMapper.CONTENT_TYPE);
+        when(seqNoFieldType.name()).thenReturn(SeqNoFieldMapper.NAME);
+        when(mapperService.fieldType(VersionFieldMapper.NAME)).thenReturn(versionFieldType);
+        when(mapperService.fieldType(SeqNoFieldMapper.NAME)).thenReturn(seqNoFieldType);
+        when(mapperService.getIndexSettings()).thenReturn(indexSettings);
+
+        return new EngineConfig.Builder().shardId(shardId)
+            .threadPool(threadPool)
+            .indexSettings(indexSettings)
+            .store(store)
+            .mergePolicy(NoMergePolicy.INSTANCE)
+            .analyzer(new StandardAnalyzer())
+            .codecService(codecService)
+            .translogConfig(translogConfig)
+            .flushMergesAfter(TimeValue.timeValueMinutes(5))
+            .externalRefreshListener(externalListeners)
+            .internalRefreshListener(internalListeners)
+            .globalCheckpointSupplier(() -> SequenceNumbers.NO_OPS_PERFORMED)
+            .retentionLeasesSupplier(() -> RetentionLeases.EMPTY)
+            .primaryTermSupplier(primaryTerm::get)
+            .tombstoneDocSupplier(tombstoneDocSupplier())
+            .dataFormatRegistry(registry)
+            .mapperService(mapperService)
+            .committerFactory(createCommitterFactory(store))
+            .build();
+    }
+}

--- a/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/index/LuceneIndexingExecutionEngineTests.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/index/LuceneIndexingExecutionEngineTests.java
@@ -10,6 +10,8 @@ package org.opensearch.be.lucene.index;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.document.FieldType;
+import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.store.NIOFSDirectory;
 import org.apache.lucene.tests.analysis.MockAnalyzer;
@@ -26,12 +28,15 @@ import org.opensearch.index.engine.EngineConfigFactory;
 import org.opensearch.index.engine.dataformat.FileInfos;
 import org.opensearch.index.engine.dataformat.RefreshInput;
 import org.opensearch.index.engine.dataformat.RefreshResult;
+import org.opensearch.index.engine.dataformat.Writer;
 import org.opensearch.index.engine.dataformat.WriterConfig;
 import org.opensearch.index.engine.exec.Segment;
 import org.opensearch.index.engine.exec.WriterFileSet;
 import org.opensearch.index.engine.exec.commit.CommitterConfig;
+import org.opensearch.index.mapper.KeywordFieldMapper.KeywordFieldType;
 import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.index.mapper.MapperService;
+import org.opensearch.index.mapper.TextFieldMapper.TextFieldType;
 import org.opensearch.index.seqno.RetentionLeases;
 import org.opensearch.index.shard.ShardPath;
 import org.opensearch.index.store.Store;
@@ -163,9 +168,7 @@ public class LuceneIndexingExecutionEngineTests extends OpenSearchTestCase {
 
         // Use LuceneWriter to create segments (which sets the writer_generation attribute via LuceneWriterCodec)
         Path tempBase = createTempDir();
-        MappedFieldType textField = mock(MappedFieldType.class);
-        when(textField.typeName()).thenReturn("text");
-        when(textField.name()).thenReturn("content");
+        MappedFieldType textField = new org.opensearch.index.mapper.TextFieldMapper.TextFieldType("content");
 
         long generation = 1L;
         try (LuceneWriter luceneWriter = new LuceneWriter(generation, 0L, luceneDataFormat, tempBase, null, Codec.getDefault(), null)) {
@@ -263,17 +266,17 @@ public class LuceneIndexingExecutionEngineTests extends OpenSearchTestCase {
         int numDocs = randomIntBetween(3, 15);
         long generation = 1L;
 
-        MappedFieldType textField = mock(MappedFieldType.class);
-        when(textField.typeName()).thenReturn("text");
-        when(textField.name()).thenReturn("content");
-
-        MappedFieldType keywordField = mock(MappedFieldType.class);
-        when(keywordField.typeName()).thenReturn("keyword");
-        when(keywordField.name()).thenReturn("tag");
-        when(keywordField.hasDocValues()).thenReturn(true);
+        MappedFieldType textField = new TextFieldType("content");
+        final FieldType keywordFieldType = new FieldType();
+        keywordFieldType.setTokenized(false);
+        keywordFieldType.setStored(false);
+        keywordFieldType.setOmitNorms(true);
+        keywordFieldType.setIndexOptions(IndexOptions.DOCS);
+        keywordFieldType.freeze();
+        MappedFieldType keywordField = new KeywordFieldType("tag", keywordFieldType);
 
         // Create writer through the engine
-        LuceneWriter writer = (LuceneWriter) engine.createWriter(new WriterConfig(generation));
+        Writer<LuceneDocumentInput> writer = engine.createWriter(new WriterConfig(generation));
         try {
             for (int i = 0; i < numDocs; i++) {
                 LuceneDocumentInput input = engine.newDocumentInput();
@@ -318,9 +321,7 @@ public class LuceneIndexingExecutionEngineTests extends OpenSearchTestCase {
         LuceneIndexingExecutionEngine engine = new LuceneIndexingExecutionEngine(luceneDataFormat, committer, mapperService, store);
         IndexWriter sharedWriter = committer.getIndexWriter();
 
-        MappedFieldType textField = mock(MappedFieldType.class);
-        when(textField.typeName()).thenReturn("text");
-        when(textField.name()).thenReturn("body");
+        MappedFieldType textField = new org.opensearch.index.mapper.TextFieldMapper.TextFieldType("content");
 
         long gen1 = 1L;
         long gen2 = 2L;

--- a/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/index/LuceneWriterTests.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/index/LuceneWriterTests.java
@@ -9,7 +9,9 @@
 package org.opensearch.be.lucene.index;
 
 import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.document.FieldType;
 import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.LeafReaderContext;
@@ -23,7 +25,9 @@ import org.opensearch.be.lucene.LuceneDataFormat;
 import org.opensearch.index.engine.dataformat.FileInfos;
 import org.opensearch.index.engine.dataformat.WriteResult;
 import org.opensearch.index.engine.exec.WriterFileSet;
+import org.opensearch.index.mapper.KeywordFieldMapper;
 import org.opensearch.index.mapper.MappedFieldType;
+import org.opensearch.index.mapper.TextFieldMapper;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.io.IOException;
@@ -48,18 +52,17 @@ public class LuceneWriterTests extends OpenSearchTestCase {
     }
 
     private MappedFieldType mockTextField(String name) {
-        MappedFieldType ft = mock(MappedFieldType.class);
-        when(ft.typeName()).thenReturn("text");
-        when(ft.name()).thenReturn(name);
-        return ft;
+        return new TextFieldMapper.TextFieldType(name);
     }
 
     private MappedFieldType mockKeywordField(String name) {
-        MappedFieldType ft = mock(MappedFieldType.class);
-        when(ft.typeName()).thenReturn("keyword");
-        when(ft.name()).thenReturn(name);
-        when(ft.hasDocValues()).thenReturn(true);
-        return ft;
+        final FieldType keywordFieldType = new FieldType();
+        keywordFieldType.setTokenized(false);
+        keywordFieldType.setStored(false);
+        keywordFieldType.setOmitNorms(true);
+        keywordFieldType.setIndexOptions(IndexOptions.DOCS);
+        keywordFieldType.freeze();
+        return new KeywordFieldMapper.KeywordFieldType(name, keywordFieldType);
     }
 
     public void testAddDocAndFlushProducesSingleSegment() throws IOException {

--- a/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/CompositeConcurrentIndexingIT.java
+++ b/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/CompositeConcurrentIndexingIT.java
@@ -1,0 +1,315 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.composite;
+
+import org.opensearch.action.admin.indices.stats.IndicesStatsResponse;
+import org.opensearch.action.admin.indices.stats.ShardStats;
+import org.opensearch.action.index.IndexResponse;
+import org.opensearch.be.datafusion.DataFusionPlugin;
+import org.opensearch.be.lucene.LucenePlugin;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.FeatureFlags;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.index.engine.CommitStats;
+import org.opensearch.index.engine.exec.Segment;
+import org.opensearch.index.engine.exec.WriterFileSet;
+import org.opensearch.index.engine.exec.coord.DataformatAwareCatalogSnapshot;
+import org.opensearch.parquet.ParquetDataFormatPlugin;
+import org.opensearch.plugins.Plugin;
+import org.opensearch.test.OpenSearchIntegTestCase;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+
+/**
+ * Integration test for concurrent indexing across multiple indices and shards
+ * with the composite engine (Parquet primary format).
+ *
+ * <p>Validates that the {@link org.opensearch.index.engine.DataFormatAwareEngine}
+ * correctly handles concurrent document writes, refresh, flush, and merge across
+ * multiple indices with multiple shards, ensuring:
+ * <ul>
+ *   <li>No documents are lost under concurrent writes</li>
+ *   <li>Segment generations are unique within each shard</li>
+ *   <li>Row counts in catalog snapshots match the number of indexed documents</li>
+ *   <li>Flush produces valid commit data with catalog snapshots</li>
+ * </ul>
+ *
+ * <p>Run with:
+ * <pre>
+ * ./gradlew :sandbox:plugins:composite-engine:internalClusterTest \
+ *   --tests "*.CompositeConcurrentIndexingIT" -Dsandbox.enabled=true
+ * </pre>
+ */
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 2)
+public class CompositeConcurrentIndexingIT extends OpenSearchIntegTestCase {
+
+    private static final String[] INDEX_NAMES = { "concurrent-idx-1", "concurrent-idx-2", "concurrent-idx-3" };
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return Arrays.asList(ParquetDataFormatPlugin.class, CompositeDataFormatPlugin.class, LucenePlugin.class, DataFusionPlugin.class);
+    }
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return Settings.builder()
+            .put(super.nodeSettings(nodeOrdinal))
+            .put(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG, true)
+            .build();
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        try {
+            for (String idx : INDEX_NAMES) {
+                try {
+                    client().admin().indices().prepareDelete(idx).get();
+                } catch (Exception e) {
+                    // index may not exist
+                }
+            }
+        } finally {
+            super.tearDown();
+        }
+    }
+
+    /**
+     * Indexes documents concurrently across multiple indices with multiple shards,
+     * then verifies row counts, segment generation uniqueness, and commit integrity.
+     */
+    public void testConcurrentIndexingAcrossMultipleIndicesAndShards() throws Exception {
+        int numShards = randomIntBetween(2, 4);
+        int docsPerThread = randomIntBetween(20, 50);
+        int threadsPerIndex = randomIntBetween(2, 4);
+
+        // Create indices with multiple shards
+        for (String idx : INDEX_NAMES) {
+            client().admin()
+                .indices()
+                .prepareCreate(idx)
+                .setSettings(indexSettings(numShards))
+                .setMapping("name", "type=keyword", "value", "type=integer")
+                .get();
+        }
+        for (String idx : INDEX_NAMES) {
+            ensureGreen(idx);
+        }
+
+        // Concurrent indexing across all indices
+        int totalThreads = INDEX_NAMES.length * threadsPerIndex;
+        CyclicBarrier barrier = new CyclicBarrier(totalThreads);
+        AtomicInteger failures = new AtomicInteger(0);
+        Thread[] threads = new Thread[totalThreads];
+
+        for (int idxOrd = 0; idxOrd < INDEX_NAMES.length; idxOrd++) {
+            String indexName = INDEX_NAMES[idxOrd];
+            for (int t = 0; t < threadsPerIndex; t++) {
+                int threadId = idxOrd * threadsPerIndex + t;
+                threads[threadId] = new Thread(() -> {
+                    try {
+                        barrier.await();
+                        for (int d = 0; d < docsPerThread; d++) {
+                            IndexResponse response = client().prepareIndex()
+                                .setIndex(indexName)
+                                .setSource("name", "thread_" + threadId + "_doc_" + d, "value", randomIntBetween(1, 10000))
+                                .get();
+                            assertEquals(RestStatus.CREATED, response.status());
+                        }
+                    } catch (Exception e) {
+                        logger.error("Indexing failed in thread " + threadId, e);
+                        failures.incrementAndGet();
+                    }
+                }, "indexer-" + threadId);
+                threads[threadId].start();
+            }
+        }
+
+        for (Thread t : threads) {
+            t.join(60_000);
+            assertFalse("Thread did not finish in time: " + t.getName(), t.isAlive());
+        }
+        assertEquals("No indexing threads should have failed", 0, failures.get());
+
+        // Refresh and flush all indices
+        for (String idx : INDEX_NAMES) {
+            client().admin().indices().prepareRefresh(idx).get();
+            client().admin().indices().prepareFlush(idx).setForce(true).setWaitIfOngoing(true).get();
+        }
+
+        // Verify each index
+        int expectedDocsPerIndex = threadsPerIndex * docsPerThread;
+        for (String idx : INDEX_NAMES) {
+            verifyIndex(idx, numShards, expectedDocsPerIndex);
+        }
+    }
+
+    /**
+     * Interleaves indexing with refresh and flush operations concurrently.
+     */
+    public void testInterleavedIndexRefreshFlush() throws Exception {
+        String indexName = INDEX_NAMES[0];
+        int numShards = 2;
+        int totalDocs = randomIntBetween(50, 100);
+
+        client().admin()
+            .indices()
+            .prepareCreate(indexName)
+            .setSettings(indexSettings(numShards))
+            .setMapping("name", "type=keyword", "value", "type=integer")
+            .get();
+        ensureGreen(indexName);
+
+        AtomicInteger failures = new AtomicInteger(0);
+        AtomicInteger indexedCount = new AtomicInteger(0);
+        CyclicBarrier barrier = new CyclicBarrier(4);
+
+        // 2 indexing threads
+        Thread indexer1 = new Thread(() -> {
+            try {
+                barrier.await();
+                for (int i = 0; i < totalDocs / 2; i++) {
+                    client().prepareIndex().setIndex(indexName).setSource("name", "idx1_" + i, "value", i).get();
+                    indexedCount.incrementAndGet();
+                    if (i % 10 == 0) {
+                        Thread.yield();
+                    }
+                }
+            } catch (Exception e) {
+                failures.incrementAndGet();
+            }
+        }, "indexer-1");
+
+        Thread indexer2 = new Thread(() -> {
+            try {
+                barrier.await();
+                for (int i = 0; i < totalDocs / 2; i++) {
+                    client().prepareIndex().setIndex(indexName).setSource("name", "idx2_" + i, "value", i + 1000).get();
+                    indexedCount.incrementAndGet();
+                    if (i % 10 == 0) {
+                        Thread.yield();
+                    }
+                }
+            } catch (Exception e) {
+                failures.incrementAndGet();
+            }
+        }, "indexer-2");
+
+        // 1 refresh thread
+        Thread refresher = new Thread(() -> {
+            try {
+                barrier.await();
+                for (int i = 0; i < 5; i++) {
+                    Thread.sleep(randomIntBetween(50, 200));
+                    client().admin().indices().prepareRefresh(indexName).get();
+                }
+            } catch (Exception e) {
+                failures.incrementAndGet();
+            }
+        }, "refresher");
+
+        // 1 flush thread
+        Thread flusher = new Thread(() -> {
+            try {
+                barrier.await();
+                for (int i = 0; i < 3; i++) {
+                    Thread.sleep(randomIntBetween(100, 300));
+                    client().admin().indices().prepareFlush(indexName).setForce(false).setWaitIfOngoing(true).get();
+                }
+            } catch (Exception e) {
+                failures.incrementAndGet();
+            }
+        }, "flusher");
+
+        indexer1.start();
+        indexer2.start();
+        refresher.start();
+        flusher.start();
+
+        indexer1.join(60_000);
+        indexer2.join(60_000);
+        refresher.join(60_000);
+        flusher.join(60_000);
+
+        assertEquals("No threads should have failed", 0, failures.get());
+
+        // Final refresh + flush
+        client().admin().indices().prepareRefresh(indexName).get();
+        client().admin().indices().prepareFlush(indexName).setForce(true).setWaitIfOngoing(true).get();
+
+        verifyIndex(indexName, numShards, indexedCount.get());
+    }
+
+    // ── Helpers ──
+
+    private Settings indexSettings(int numShards) {
+        return Settings.builder()
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, numShards)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+            .put("index.refresh_interval", "-1")
+            .put("index.pluggable.dataformat.enabled", true)
+            .put("index.pluggable.dataformat", "composite")
+            .put("index.composite.primary_data_format", "parquet")
+            .putList("index.composite.secondary_data_formats")
+            .build();
+    }
+
+    private void verifyIndex(String indexName, int numShards, int expectedTotalDocs) throws IOException {
+        long totalRows = 0;
+        Set<Long> allGenerations = new HashSet<>();
+
+        IndicesStatsResponse statsResponse = client().admin().indices().prepareStats(indexName).clear().setStore(true).get();
+        ShardStats[] shardStats = statsResponse.getIndex(indexName).getShards();
+
+        for (ShardStats ss : shardStats) {
+            if (ss.getShardRouting().primary() == false) {
+                continue;
+            }
+            CommitStats commitStats = ss.getCommitStats();
+            assertNotNull("Commit stats should exist for shard " + ss.getShardRouting().shardId(), commitStats);
+
+            String snapshotKey = DataformatAwareCatalogSnapshot.CATALOG_SNAPSHOT_KEY;
+            assertTrue(
+                "Commit data should contain catalog snapshot for shard " + ss.getShardRouting().shardId(),
+                commitStats.getUserData().containsKey(snapshotKey)
+            );
+
+            DataformatAwareCatalogSnapshot snapshot = DataformatAwareCatalogSnapshot.deserializeFromString(
+                commitStats.getUserData().get(snapshotKey),
+                Function.identity()
+            );
+
+            // Verify segment generation uniqueness within this shard
+            Set<Long> shardGenerations = new HashSet<>();
+            for (Segment seg : snapshot.getSegments()) {
+                assertTrue(
+                    "Duplicate generation " + seg.generation() + " in shard " + ss.getShardRouting().shardId(),
+                    shardGenerations.add(seg.generation())
+                );
+                // Every segment must have files
+                assertFalse("Segment " + seg.generation() + " has no files", seg.dfGroupedSearchableFiles().isEmpty());
+                for (WriterFileSet wfs : seg.dfGroupedSearchableFiles().values()) {
+                    assertTrue("WriterFileSet must have positive row count", wfs.numRows() > 0);
+                    assertFalse("WriterFileSet must have files", wfs.files().isEmpty());
+                    totalRows += wfs.numRows();
+                }
+            }
+            allGenerations.addAll(shardGenerations);
+        }
+
+        assertEquals("Total rows across all shards of " + indexName + " must match indexed docs", expectedTotalDocs, totalRows);
+    }
+}

--- a/sandbox/plugins/composite-engine/src/main/java/org/opensearch/composite/CompositeDocumentInput.java
+++ b/sandbox/plugins/composite-engine/src/main/java/org/opensearch/composite/CompositeDocumentInput.java
@@ -83,6 +83,11 @@ public class CompositeDocumentInput implements DocumentInput<List<? extends Docu
         }
     }
 
+    public long getFieldCount(String fieldName) {
+        // Return the field count from the primary document input
+        return primaryDocumentInput.getFieldCount(fieldName);
+    }
+
     @Override
     public List<? extends DocumentInput<?>> getFinalInput() {
         return null;

--- a/sandbox/plugins/composite-engine/src/test/java/org/opensearch/composite/CompositeDocumentInputTests.java
+++ b/sandbox/plugins/composite-engine/src/test/java/org/opensearch/composite/CompositeDocumentInputTests.java
@@ -188,6 +188,11 @@ public class CompositeDocumentInputTests extends OpenSearchTestCase {
         }
 
         @Override
+        public long getFieldCount(String fieldName) {
+            return 0;
+        }
+
+        @Override
         public void close() {}
     }
 }

--- a/sandbox/plugins/composite-engine/src/test/java/org/opensearch/composite/CompositeTestHelper.java
+++ b/sandbox/plugins/composite-engine/src/test/java/org/opensearch/composite/CompositeTestHelper.java
@@ -280,6 +280,11 @@ final class CompositeTestHelper {
         public void setRowId(String rowIdFieldName, long rowId) {}
 
         @Override
+        public long getFieldCount(String fieldName) {
+            return 0;
+        }
+
+        @Override
         public void close() {}
     }
 

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/ParquetDataFormatPlugin.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/ParquetDataFormatPlugin.java
@@ -28,6 +28,7 @@ import org.opensearch.index.engine.dataformat.StoreStrategy;
 import org.opensearch.index.store.PrecomputedChecksumStrategy;
 import org.opensearch.parquet.engine.ParquetDataFormat;
 import org.opensearch.parquet.engine.ParquetIndexingEngine;
+import org.opensearch.parquet.fields.ArrowSchemaBuilder;
 import org.opensearch.parquet.store.ParquetStoreStrategy;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.repositories.RepositoriesService;
@@ -101,7 +102,8 @@ public class ParquetDataFormatPlugin extends Plugin implements DataFormatPlugin 
             settings,
             PARQUET_DATA_FORMAT,
             engineConfig.store().shardPath(),
-            engineConfig.mapperService(),
+            () -> ArrowSchemaBuilder.getSchema(engineConfig.mapperService()),
+            () -> engineConfig.mapperService().getIndexSettings().getIndexMetadata().getMappingVersion(),
             engineConfig.indexSettings(),
             threadPool,
             engineConfig.checksumStrategies().get(ParquetDataFormat.PARQUET_DATA_FORMAT_NAME)

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/engine/ParquetIndexingEngine.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/engine/ParquetIndexingEngine.java
@@ -21,14 +21,12 @@ import org.opensearch.index.engine.dataformat.Writer;
 import org.opensearch.index.engine.dataformat.WriterConfig;
 import org.opensearch.index.engine.exec.Segment;
 import org.opensearch.index.engine.exec.commit.IndexStoreProvider;
-import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.shard.ShardPath;
 import org.opensearch.index.store.FormatChecksumStrategy;
 import org.opensearch.index.store.PrecomputedChecksumStrategy;
 import org.opensearch.parquet.ParquetSettings;
 import org.opensearch.parquet.bridge.NativeSettings;
 import org.opensearch.parquet.bridge.RustBridge;
-import org.opensearch.parquet.fields.ArrowSchemaBuilder;
 import org.opensearch.parquet.memory.ArrowBufferPool;
 import org.opensearch.parquet.merge.NativeParquetMergeStrategy;
 import org.opensearch.parquet.merge.ParquetMergeExecutor;
@@ -45,6 +43,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 
 import static org.opensearch.parquet.ParquetDataFormatPlugin.PARQUET_DATA_FORMAT;
 
@@ -74,7 +73,8 @@ public class ParquetIndexingEngine implements IndexingExecutionEngine<ParquetDat
 
     private final ParquetDataFormat dataFormat;
     private final ShardPath shardPath;
-    private final MapperService mapperService;
+    private Supplier<Schema> schemaSupplier;
+    private Supplier<Long> mappingVersionSupplier;
     private volatile long cachedSchemaVersion = -1;
     private volatile Schema cachedSchema;
     private final ArrowBufferPool bufferPool;
@@ -90,7 +90,8 @@ public class ParquetIndexingEngine implements IndexingExecutionEngine<ParquetDat
      * @param settings          the node-level settings
      * @param dataFormat        the Parquet data format descriptor
      * @param shardPath         the shard path for file storage
-     * @param mapperService     the mapper service for schema resolution
+     * @param schemaSupplier     the supplier for schema resolution
+     * @param mappingVersionSupplier     the supplier for mapping version resolution
      * @param indexSettings     the index-level settings
      * @param threadPool        the thread pool for background native writes
      */
@@ -98,11 +99,21 @@ public class ParquetIndexingEngine implements IndexingExecutionEngine<ParquetDat
         Settings settings,
         ParquetDataFormat dataFormat,
         ShardPath shardPath,
-        MapperService mapperService,
+        Supplier<Schema> schemaSupplier,
+        Supplier<Long> mappingVersionSupplier,
         IndexSettings indexSettings,
         ThreadPool threadPool
     ) {
-        this(settings, dataFormat, shardPath, mapperService, indexSettings, threadPool, new PrecomputedChecksumStrategy());
+        this(
+            settings,
+            dataFormat,
+            shardPath,
+            schemaSupplier,
+            mappingVersionSupplier,
+            indexSettings,
+            threadPool,
+            new PrecomputedChecksumStrategy()
+        );
     }
 
     /**
@@ -111,7 +122,8 @@ public class ParquetIndexingEngine implements IndexingExecutionEngine<ParquetDat
      * @param settings          the node-level settings
      * @param dataFormat        the Parquet data format descriptor
      * @param shardPath         the shard path for file storage
-     * @param mapperService     the mapper service for schema resolution
+     * @param schemaSupplier     the supplier for schema resolution
+     * @param mappingVersionSupplier     the supplier for mapping version resolution
      * @param indexSettings     the index-level settings
      * @param threadPool        the thread pool for background native writes
      * @param checksumStrategy  the checksum strategy to use (shared with the directory)
@@ -120,14 +132,16 @@ public class ParquetIndexingEngine implements IndexingExecutionEngine<ParquetDat
         Settings settings,
         ParquetDataFormat dataFormat,
         ShardPath shardPath,
-        MapperService mapperService,
+        Supplier<Schema> schemaSupplier,
+        Supplier<Long> mappingVersionSupplier,
         IndexSettings indexSettings,
         ThreadPool threadPool,
         FormatChecksumStrategy checksumStrategy
     ) {
         this.dataFormat = dataFormat;
         this.shardPath = shardPath;
-        this.mapperService = mapperService;
+        this.schemaSupplier = schemaSupplier;
+        this.mappingVersionSupplier = mappingVersionSupplier;
         this.bufferPool = new ArrowBufferPool(settings);
         this.indexSettings = indexSettings;
         this.nodeSettings = settings;
@@ -183,7 +197,7 @@ public class ParquetIndexingEngine implements IndexingExecutionEngine<ParquetDat
 
     @Override
     public Writer<ParquetDocumentInput> createWriter(WriterConfig config) {
-        long mappingVersion = mapperService.getIndexSettings().getIndexMetadata().getMappingVersion();
+        long mappingVersion = mappingVersionSupplier.get();
         Schema schema = getOrBuildSchema(mappingVersion);
         Path filePath = buildParquetFilePath(shardPath, config.writerGeneration(), null);
         return new ParquetWriter(
@@ -263,7 +277,7 @@ public class ParquetIndexingEngine implements IndexingExecutionEngine<ParquetDat
         if (cachedSchemaVersion == mappingVersion && cachedSchema != null) {
             return cachedSchema;
         }
-        cachedSchema = ArrowSchemaBuilder.getSchema(mapperService);
+        cachedSchema = schemaSupplier.get();
         cachedSchemaVersion = mappingVersion;
         return cachedSchema;
     }

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/ArrowSchemaBuilder.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/ArrowSchemaBuilder.java
@@ -18,6 +18,7 @@ import org.opensearch.index.mapper.IndexFieldMapper;
 import org.opensearch.index.mapper.Mapper;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.mapper.NestedPathFieldMapper;
+import org.opensearch.index.mapper.SeqNoFieldMapper;
 import org.opensearch.index.mapper.SourceFieldMapper;
 import org.opensearch.parquet.fields.core.data.number.LongParquetField;
 
@@ -57,8 +58,9 @@ public final class ArrowSchemaBuilder {
             }
         }
         // Add row ID field (long)
-        LongParquetField longField = new LongParquetField();
+        LongParquetField longField = new LongParquetField(false);
         fields.add(new Field(DocumentInput.ROW_ID_FIELD, longField.getFieldType(), null));
+        fields.add(new Field(SeqNoFieldMapper.PRIMARY_TERM_NAME, new LongParquetField(false).getFieldType(), null));
         return new Schema(fields);
     }
 

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/number/ByteParquetField.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/number/ByteParquetField.java
@@ -25,7 +25,7 @@ public class ByteParquetField extends ParquetField {
 
     @Override
     protected void addToGroup(MappedFieldType mappedFieldType, ManagedVSR managedVSR, Object parseValue) {
-        ((TinyIntVector) managedVSR.getVector(mappedFieldType.name())).setSafe(managedVSR.getRowCount(), (Byte) parseValue);
+        ((TinyIntVector) managedVSR.getVector(mappedFieldType.name())).setSafe(managedVSR.getRowCount(), ((Number) parseValue).byteValue());
     }
 
     @Override

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/number/HalfFloatParquetField.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/number/HalfFloatParquetField.java
@@ -26,7 +26,7 @@ public class HalfFloatParquetField extends ParquetField {
 
     @Override
     protected void addToGroup(MappedFieldType mappedFieldType, ManagedVSR managedVSR, Object parseValue) {
-        ((Float2Vector) managedVSR.getVector(mappedFieldType.name())).setSafe(managedVSR.getRowCount(), (Short) parseValue);
+        ((Float2Vector) managedVSR.getVector(mappedFieldType.name())).setSafe(managedVSR.getRowCount(), ((Number) parseValue).shortValue());
     }
 
     @Override

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/number/LongParquetField.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/number/LongParquetField.java
@@ -20,8 +20,16 @@ import org.opensearch.parquet.vsr.ManagedVSR;
  */
 public class LongParquetField extends ParquetField {
 
+    private final boolean nullable;
+
     /** Creates a new LongParquetField. */
-    public LongParquetField() {}
+    public LongParquetField() {
+        this(true);
+    }
+
+    public LongParquetField(boolean nullable) {
+        this.nullable = nullable;
+    }
 
     @Override
     protected void addToGroup(MappedFieldType mappedFieldType, ManagedVSR managedVSR, Object parseValue) {
@@ -35,6 +43,6 @@ public class LongParquetField extends ParquetField {
 
     @Override
     public FieldType getFieldType() {
-        return FieldType.nullable(getArrowType());
+        return nullable ? FieldType.nullable(getArrowType()) : FieldType.notNullable(getArrowType());
     }
 }

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/metadata/IdParquetField.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/metadata/IdParquetField.java
@@ -11,7 +11,6 @@ package org.opensearch.parquet.fields.core.metadata;
 import org.apache.arrow.vector.VarBinaryVector;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.FieldType;
-import org.apache.lucene.util.BytesRef;
 import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.parquet.fields.ParquetField;
 import org.opensearch.parquet.vsr.ManagedVSR;
@@ -27,8 +26,7 @@ public class IdParquetField extends ParquetField {
     @Override
     protected void addToGroup(MappedFieldType mappedFieldType, ManagedVSR managedVSR, Object parseValue) {
         VarBinaryVector vector = (VarBinaryVector) managedVSR.getVector(mappedFieldType.name());
-        BytesRef bytesRef = (BytesRef) parseValue;
-        vector.setSafe(managedVSR.getRowCount(), bytesRef.bytes, bytesRef.offset, bytesRef.length);
+        vector.setSafe(managedVSR.getRowCount(), (byte[]) parseValue);
     }
 
     @Override
@@ -38,6 +36,6 @@ public class IdParquetField extends ParquetField {
 
     @Override
     public FieldType getFieldType() {
-        return FieldType.nullable(getArrowType());
+        return FieldType.notNullable(getArrowType());
     }
 }

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/metadata/package-info.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/metadata/package-info.java
@@ -14,7 +14,7 @@
  *
  * <ul>
  *   <li>{@link org.opensearch.parquet.fields.core.metadata.IdParquetField} — Document {@code _id},
- *       stored as binary ({@code VarBinaryVector}) from Lucene {@code BytesRef}.</li>
+ *       stored as binary ({@code VarBinaryVector}) from {@code byte[]}.</li>
  *   <li>{@link org.opensearch.parquet.fields.core.metadata.RoutingParquetField} — Document {@code _routing},
  *       stored as UTF-8 text ({@code VarCharVector}).</li>
  *   <li>{@link org.opensearch.parquet.fields.core.metadata.IgnoredParquetField} — The {@code _ignored}

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/plugins/CoreDataFieldPlugin.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/plugins/CoreDataFieldPlugin.java
@@ -13,6 +13,7 @@ import org.opensearch.index.mapper.BooleanFieldMapper;
 import org.opensearch.index.mapper.DateFieldMapper;
 import org.opensearch.index.mapper.IpFieldMapper;
 import org.opensearch.index.mapper.KeywordFieldMapper;
+import org.opensearch.index.mapper.MatchOnlyTextFieldMapper;
 import org.opensearch.index.mapper.NumberFieldMapper;
 import org.opensearch.index.mapper.TextFieldMapper;
 import org.opensearch.parquet.fields.ParquetField;
@@ -81,6 +82,7 @@ public class CoreDataFieldPlugin implements ParquetFieldPlugin {
         fieldMap.put(TextFieldMapper.CONTENT_TYPE, new TextParquetField());
         fieldMap.put(KeywordFieldMapper.CONTENT_TYPE, new KeywordParquetField());
         fieldMap.put(IpFieldMapper.CONTENT_TYPE, new IpParquetField());
+        fieldMap.put(MatchOnlyTextFieldMapper.CONTENT_TYPE, new TextParquetField());
     }
 
     private static void registerBinaryFields(Map<String, ParquetField> fieldMap) {

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/plugins/MetadataFieldPlugin.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/plugins/MetadataFieldPlugin.java
@@ -15,11 +15,11 @@ import org.opensearch.index.mapper.RoutingFieldMapper;
 import org.opensearch.index.mapper.SeqNoFieldMapper;
 import org.opensearch.index.mapper.VersionFieldMapper;
 import org.opensearch.parquet.fields.ParquetField;
+import org.opensearch.parquet.fields.core.data.number.IntegerParquetField;
 import org.opensearch.parquet.fields.core.data.number.LongParquetField;
 import org.opensearch.parquet.fields.core.metadata.IdParquetField;
 import org.opensearch.parquet.fields.core.metadata.IgnoredParquetField;
 import org.opensearch.parquet.fields.core.metadata.RoutingParquetField;
-import org.opensearch.parquet.fields.core.metadata.SizeParquetField;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -36,13 +36,13 @@ public class MetadataFieldPlugin implements ParquetFieldPlugin {
     public Map<String, ParquetField> getParquetFields() {
         final Map<String, ParquetField> fieldMap = new HashMap<>();
         fieldMap.put(DocCountFieldMapper.CONTENT_TYPE, new LongParquetField());
-        fieldMap.put("_size", new SizeParquetField());
+        fieldMap.put("_size", new IntegerParquetField());
         fieldMap.put(RoutingFieldMapper.CONTENT_TYPE, new RoutingParquetField());
         fieldMap.put(IgnoredFieldMapper.CONTENT_TYPE, new IgnoredParquetField());
         fieldMap.put(IdFieldMapper.CONTENT_TYPE, new IdParquetField());
-        fieldMap.put(SeqNoFieldMapper.CONTENT_TYPE, new LongParquetField());
-        fieldMap.put(SeqNoFieldMapper.PRIMARY_TERM_NAME, new LongParquetField());
-        fieldMap.put(VersionFieldMapper.CONTENT_TYPE, new LongParquetField());
+        fieldMap.put(SeqNoFieldMapper.CONTENT_TYPE, new LongParquetField(false));
+        fieldMap.put(SeqNoFieldMapper.PRIMARY_TERM_NAME, new LongParquetField(false));
+        fieldMap.put(VersionFieldMapper.CONTENT_TYPE, new LongParquetField(false));
         return fieldMap;
     }
 }

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/vsr/VSRManager.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/vsr/VSRManager.java
@@ -129,37 +129,30 @@ public class VSRManager implements AutoCloseable {
      * @param doc the document input containing field-value pairs
      */
     public void addDocument(ParquetDocumentInput doc) throws IOException {
-        String name = "";
-        try {
-            ManagedVSR activeVSR = managedVSR.get();
-            for (FieldValuePair pair : doc.getFinalInput()) {
-                MappedFieldType fieldType = pair.getFieldType();
-                name = fieldType.name();
-                ParquetField parquetField = ArrowFieldRegistry.getParquetField(fieldType.typeName());
-                if (parquetField == null) {
-                    continue;
-                }
-                // Dynamic field vector addition: create vector if not present in VSR
-                FieldVector vector = activeVSR.getVector(fieldType.name());
-                if (vector == null) {
-                    Field field = new Field(fieldType.name(), parquetField.getFieldType(), null);
-                    activeVSR.addFieldVector(field);
-                    // Update pool schema so future VSRs include this field
-                    vsrPool.updateSchema(activeVSR.getSchema());
-                }
-                parquetField.createField(fieldType, activeVSR, pair.getValue());
+        ManagedVSR activeVSR = managedVSR.get();
+        for (FieldValuePair pair : doc.getFinalInput()) {
+            MappedFieldType fieldType = pair.getFieldType();
+            ParquetField parquetField = ArrowFieldRegistry.getParquetField(fieldType.typeName());
+            if (parquetField == null) {
+                continue;
             }
-            int rowIndex = activeVSR.getRowCount();
-            BigIntVector rowIdVector = (BigIntVector) activeVSR.getVector(DocumentInput.ROW_ID_FIELD);
-            if (rowIdVector != null) {
-                rowIdVector.setSafe(rowIndex, doc.getRowId());
+            // Dynamic field vector addition: create vector if not present in VSR
+            FieldVector vector = activeVSR.getVector(fieldType.name());
+            if (vector == null) {
+                Field field = new Field(fieldType.name(), parquetField.getFieldType(), null);
+                activeVSR.addFieldVector(field);
+                // Update pool schema so future VSRs include this field
+                vsrPool.updateSchema(activeVSR.getSchema());
             }
-            activeVSR.setRowCount(rowIndex + 1);
-            maybeRotateActiveVSR();
-        } catch (Exception ex) {
-            logger.error("{}: ", name, ex);
-            throw ex;
+            parquetField.createField(fieldType, activeVSR, pair.getValue());
         }
+        int rowIndex = activeVSR.getRowCount();
+        BigIntVector rowIdVector = (BigIntVector) activeVSR.getVector(DocumentInput.ROW_ID_FIELD);
+        if (rowIdVector != null) {
+            rowIdVector.setSafe(rowIndex, doc.getRowId());
+        }
+        activeVSR.setRowCount(rowIndex + 1);
+        maybeRotateActiveVSR();
     }
 
     /**

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/vsr/VSRManager.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/vsr/VSRManager.java
@@ -129,30 +129,37 @@ public class VSRManager implements AutoCloseable {
      * @param doc the document input containing field-value pairs
      */
     public void addDocument(ParquetDocumentInput doc) throws IOException {
-        ManagedVSR activeVSR = managedVSR.get();
-        for (FieldValuePair pair : doc.getFinalInput()) {
-            MappedFieldType fieldType = pair.getFieldType();
-            ParquetField parquetField = ArrowFieldRegistry.getParquetField(fieldType.typeName());
-            if (parquetField == null) {
-                continue;
+        String name = "";
+        try {
+            ManagedVSR activeVSR = managedVSR.get();
+            for (FieldValuePair pair : doc.getFinalInput()) {
+                MappedFieldType fieldType = pair.getFieldType();
+                name = fieldType.name();
+                ParquetField parquetField = ArrowFieldRegistry.getParquetField(fieldType.typeName());
+                if (parquetField == null) {
+                    continue;
+                }
+                // Dynamic field vector addition: create vector if not present in VSR
+                FieldVector vector = activeVSR.getVector(fieldType.name());
+                if (vector == null) {
+                    Field field = new Field(fieldType.name(), parquetField.getFieldType(), null);
+                    activeVSR.addFieldVector(field);
+                    // Update pool schema so future VSRs include this field
+                    vsrPool.updateSchema(activeVSR.getSchema());
+                }
+                parquetField.createField(fieldType, activeVSR, pair.getValue());
             }
-            // Dynamic field vector addition: create vector if not present in VSR
-            FieldVector vector = activeVSR.getVector(fieldType.name());
-            if (vector == null) {
-                Field field = new Field(fieldType.name(), parquetField.getFieldType(), null);
-                activeVSR.addFieldVector(field);
-                // Update pool schema so future VSRs include this field
-                vsrPool.updateSchema(activeVSR.getSchema());
+            int rowIndex = activeVSR.getRowCount();
+            BigIntVector rowIdVector = (BigIntVector) activeVSR.getVector(DocumentInput.ROW_ID_FIELD);
+            if (rowIdVector != null) {
+                rowIdVector.setSafe(rowIndex, doc.getRowId());
             }
-            parquetField.createField(fieldType, activeVSR, pair.getValue());
+            activeVSR.setRowCount(rowIndex + 1);
+            maybeRotateActiveVSR();
+        } catch (Exception ex) {
+            logger.error("{}: ", name, ex);
+            throw ex;
         }
-        int rowIndex = activeVSR.getRowCount();
-        BigIntVector rowIdVector = (BigIntVector) activeVSR.getVector(DocumentInput.ROW_ID_FIELD);
-        if (rowIdVector != null) {
-            rowIdVector.setSafe(rowIndex, doc.getRowId());
-        }
-        activeVSR.setRowCount(rowIndex + 1);
-        maybeRotateActiveVSR();
     }
 
     /**

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/writer/ParquetDocumentInput.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/writer/ParquetDocumentInput.java
@@ -9,7 +9,10 @@
 package org.opensearch.parquet.writer;
 
 import org.opensearch.index.engine.dataformat.DocumentInput;
+import org.opensearch.index.mapper.IdFieldMapper;
 import org.opensearch.index.mapper.MappedFieldType;
+import org.opensearch.index.mapper.SeqNoFieldMapper;
+import org.opensearch.index.mapper.VersionFieldMapper;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -28,29 +31,53 @@ public class ParquetDocumentInput implements DocumentInput<List<FieldValuePair>>
 
     private final List<FieldValuePair> collectedFields = new ArrayList<>();
     private long rowId = -1;
+    private boolean isClosed = false;
 
     /** Creates a new ParquetDocumentInput. */
     public ParquetDocumentInput() {}
 
     @Override
     public void addField(MappedFieldType fieldType, Object value) {
+        ensureOpen();
         collectedFields.add(new FieldValuePair(fieldType, value));
     }
 
     @Override
     public void setRowId(String rowIdFieldName, long rowId) {
+        ensureOpen();
         this.rowId = rowId;
     }
 
     @Override
     public List<FieldValuePair> getFinalInput() {
+        if (!isClosed) {
+            assert rowId >= 0 : "Row ID must be set before calling getFinalInput";
+            // assertions for parquet primary
+            // TODO: once parquet is supported in secondary mode, this assertion would change
+            assert getFieldCount(IdFieldMapper.NAME) == 1;
+            assert getFieldCount(SeqNoFieldMapper.NAME) == 1;
+            assert getFieldCount(VersionFieldMapper.NAME) == 1;
+            assert getFieldCount(SeqNoFieldMapper.PRIMARY_TERM_NAME) == 1;
+        }
         return collectedFields;
     }
 
     @Override
+    public long getFieldCount(String fieldName) {
+        return collectedFields.stream().filter(fvp -> fvp.getFieldType().name().equals(fieldName)).count();
+    }
+
+    @Override
     public void close() {
+        isClosed = true;
         collectedFields.clear();
         rowId = -1;
+    }
+
+    private void ensureOpen() {
+        if (isClosed) {
+            throw new IllegalStateException("Cannot add more fields to a frozen document input");
+        }
     }
 
     /**

--- a/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/engine/ParquetDataFormatAwareEngineTests.java
+++ b/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/engine/ParquetDataFormatAwareEngineTests.java
@@ -1,0 +1,270 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.parquet.engine;
+
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.apache.lucene.search.Query;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.network.InetAddresses;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.index.IndexSettings;
+import org.opensearch.index.engine.dataformat.AbstractDataFormatAwareEngineTestCase;
+import org.opensearch.index.engine.dataformat.DataFormatPlugin;
+import org.opensearch.index.engine.dataformat.DocumentInput;
+import org.opensearch.index.engine.dataformat.IndexingEngineConfig;
+import org.opensearch.index.engine.dataformat.IndexingExecutionEngine;
+import org.opensearch.index.engine.dataformat.stub.MockSearchBackEndPlugin;
+import org.opensearch.index.mapper.BinaryFieldMapper.BinaryFieldType;
+import org.opensearch.index.mapper.BooleanFieldMapper.BooleanFieldType;
+import org.opensearch.index.mapper.DateFieldMapper;
+import org.opensearch.index.mapper.DateFieldMapper.DateFieldType;
+import org.opensearch.index.mapper.IdFieldMapper;
+import org.opensearch.index.mapper.IpFieldMapper.IpFieldType;
+import org.opensearch.index.mapper.KeywordFieldMapper;
+import org.opensearch.index.mapper.MappedFieldType;
+import org.opensearch.index.mapper.MatchOnlyTextFieldMapper;
+import org.opensearch.index.mapper.MatchOnlyTextFieldMapper.MatchOnlyTextFieldType;
+import org.opensearch.index.mapper.NumberFieldMapper;
+import org.opensearch.index.mapper.ParametrizedFieldMapper;
+import org.opensearch.index.mapper.SeqNoFieldMapper;
+import org.opensearch.index.mapper.TextFieldMapper.TextFieldType;
+import org.opensearch.index.mapper.TextSearchInfo;
+import org.opensearch.index.mapper.ValueFetcher;
+import org.opensearch.index.mapper.VersionFieldMapper;
+import org.opensearch.index.query.QueryShardContext;
+import org.opensearch.index.shard.ShardPath;
+import org.opensearch.index.store.PrecomputedChecksumStrategy;
+import org.opensearch.index.store.Store;
+import org.opensearch.parquet.ParquetDataFormatPlugin;
+import org.opensearch.parquet.bridge.RustBridge;
+import org.opensearch.parquet.fields.ArrowFieldRegistry;
+import org.opensearch.parquet.fields.ParquetField;
+import org.opensearch.parquet.fields.plugins.CoreDataFieldPlugin;
+import org.opensearch.parquet.writer.ParquetDocumentInput;
+import org.opensearch.plugins.SearchBackEndPlugin;
+import org.opensearch.search.lookup.SearchLookup;
+import org.opensearch.test.IndexSettingsModule;
+import org.opensearch.threadpool.FixedExecutorBuilder;
+import org.opensearch.threadpool.TestThreadPool;
+import org.opensearch.threadpool.ThreadPool;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.opensearch.parquet.engine.ParquetIndexingEngineTests.metadataFields;
+
+/**
+ * Runs the {@link AbstractDataFormatAwareEngineTestCase} suite with the real
+ * Parquet native engine. Validates that the DFAE orchestration layer works
+ * correctly with the Parquet writer, native Rust bridge, and Arrow vectors.
+ *
+ * <p>Requires the native library ({@code libopensearch_native}) to be built
+ * and available on the library path. The Gradle task {@code buildRustLibrary}
+ * is a dependency of the test task in the Parquet plugin's {@code build.gradle}.
+ *
+ * <p>Provides a hardcoded Arrow schema with keyword and integer fields,
+ * bypassing the need for a real {@link org.opensearch.index.mapper.MapperService}.
+ */
+public class ParquetDataFormatAwareEngineTests extends AbstractDataFormatAwareEngineTestCase {
+
+    private static final MappedFieldType NAME_FIELD = new KeywordFieldMapper.KeywordFieldType("name");
+    private static final MappedFieldType AGE_FIELD = new NumberFieldMapper.NumberFieldType("age", NumberFieldMapper.NumberType.INTEGER);
+    public static final MappedFieldType SEQ_NO_FIELD = new NumberFieldMapper.NumberFieldType(
+        SeqNoFieldMapper.NAME,
+        NumberFieldMapper.NumberType.LONG
+    );
+    public static final MappedFieldType VERSION_FIELD = new NumberFieldMapper.NumberFieldType(
+        VersionFieldMapper.NAME,
+        NumberFieldMapper.NumberType.LONG
+    );
+    public static final MappedFieldType ID_FIELD = new MappedFieldType(
+        IdFieldMapper.CONTENT_TYPE,
+        true,
+        true,
+        true,
+        TextSearchInfo.SIMPLE_MATCH_ONLY,
+        Map.of()
+    ) {
+        @Override
+        public ValueFetcher valueFetcher(QueryShardContext context, SearchLookup searchLookup, String format) {
+            return null;
+        }
+
+        @Override
+        public String typeName() {
+            return IdFieldMapper.CONTENT_TYPE;
+        }
+
+        @Override
+        public Query termQuery(Object value, QueryShardContext context) {
+            return null;
+        }
+    };
+
+    private Schema schema;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        RustBridge.initLogger();
+        schema = buildSchema();
+    }
+
+    @Override
+    protected Store createStore() throws IOException {
+        // Parquet engine needs a real filesystem path for writing .parquet files
+        Path dataPath = createTempDir().resolve(shardId.getIndex().getUUID()).resolve(String.valueOf(shardId.id()));
+        java.nio.file.Files.createDirectories(dataPath);
+        IndexSettings indexSettings = IndexSettingsModule.newIndexSettings(
+            "test",
+            Settings.builder()
+                .put(IndexMetadata.SETTING_VERSION_CREATED, org.opensearch.Version.CURRENT)
+                .put(IndexSettings.INDEX_SOFT_DELETES_SETTING.getKey(), true)
+                .build()
+        );
+        ShardPath shardPath = new ShardPath(false, dataPath, dataPath, shardId);
+        return new Store(
+            shardId,
+            indexSettings,
+            new org.apache.lucene.store.NIOFSDirectory(dataPath),
+            new org.opensearch.test.DummyShardLock(shardId),
+            Store.OnClose.EMPTY,
+            shardPath
+        );
+    }
+
+    @Override
+    protected ThreadPool buildThreadPool() {
+        Settings settings = Settings.builder().put("node.name", "parquet-dfae-test").build();
+        return new TestThreadPool(
+            getClass().getName(),
+            settings,
+            new FixedExecutorBuilder(
+                settings,
+                ParquetDataFormatPlugin.PARQUET_THREAD_POOL_NAME,
+                1,
+                -1,
+                "thread_pool." + ParquetDataFormatPlugin.PARQUET_THREAD_POOL_NAME
+            )
+        );
+    }
+
+    @Override
+    protected DataFormatPlugin createDataFormatPlugin() {
+        // Create a plugin that bypasses MapperService and uses our hardcoded schema
+        return new DataFormatPlugin() {
+            private final ParquetDataFormat dataFormat = new ParquetDataFormat();
+
+            @Override
+            public org.opensearch.index.engine.dataformat.DataFormat getDataFormat() {
+                return dataFormat;
+            }
+
+            @Override
+            public IndexingExecutionEngine<?, ?> indexingEngine(IndexingEngineConfig engineConfig) {
+                return new ParquetIndexingEngine(
+                    Settings.EMPTY,
+                    dataFormat,
+                    engineConfig.store().shardPath(),
+                    () -> schema,
+                    () -> 1L,
+                    engineConfig.indexSettings(),
+                    threadPool,
+                    new PrecomputedChecksumStrategy()
+                );
+            }
+        };
+    }
+
+    @Override
+    protected SearchBackEndPlugin<?> createSearchBackEndPlugin() {
+        return new MockSearchBackEndPlugin(List.of(ParquetDataFormat.PARQUET_DATA_FORMAT_NAME));
+    }
+
+    @Override
+    protected String dataFormatName() {
+        return ParquetDataFormat.PARQUET_DATA_FORMAT_NAME;
+    }
+
+    @Override
+    protected DocumentInput<?> createDocumentInput() {
+        ParquetDocumentInput input = new ParquetDocumentInput();
+        input.addField(ID_FIELD, "doc-id".getBytes(StandardCharsets.UTF_8));
+        input.addField(NAME_FIELD, "name");
+        input.addField(new NumberFieldMapper.NumberFieldType(BYTE_FIELD_NAME, NumberFieldMapper.NumberType.BYTE), Byte.MAX_VALUE);
+        input.addField(new NumberFieldMapper.NumberFieldType(SHORT_FIELD_NAME, NumberFieldMapper.NumberType.SHORT), Short.MAX_VALUE);
+        input.addField(new NumberFieldMapper.NumberFieldType(INT_FIELD_NAME, NumberFieldMapper.NumberType.INTEGER), Integer.MAX_VALUE);
+        input.addField(new NumberFieldMapper.NumberFieldType(LONG_FIELD_NAME, NumberFieldMapper.NumberType.LONG), Long.MAX_VALUE);
+        input.addField(new NumberFieldMapper.NumberFieldType(FLOAT_FIELD_NAME, NumberFieldMapper.NumberType.FLOAT), Float.MAX_VALUE);
+        input.addField(new NumberFieldMapper.NumberFieldType(DOUBLE_FIELD_NAME, NumberFieldMapper.NumberType.DOUBLE), Double.MAX_VALUE);
+        input.addField(
+            new NumberFieldMapper.NumberFieldType(HALF_FLOAT_FIELD_NAME, NumberFieldMapper.NumberType.HALF_FLOAT),
+            Short.MAX_VALUE
+        );
+        input.addField(
+            new NumberFieldMapper.NumberFieldType(UNSIGNED_LONG_FIELD_NAME, NumberFieldMapper.NumberType.UNSIGNED_LONG),
+            Long.MAX_VALUE
+        );
+        input.addField(new TextFieldType(TEXT_FIELD_NAME), randomAlphaOfLength(100));
+        input.addField(new DateFieldType(DATE_FIELD_NAME), System.currentTimeMillis());
+        input.addField(new DateFieldType(DATE_NANOS_FIELD_NAME, DateFieldMapper.Resolution.NANOSECONDS), System.nanoTime());
+        input.addField(new IpFieldType(IP_FIELD_NAME), InetAddresses.forString("0.0.0.0"));
+        input.addField(new BinaryFieldType(BINARY_FIELD_NAME), randomAlphaOfLength(100).getBytes(StandardCharsets.UTF_8));
+        input.addField(new BooleanFieldType(BOOLEAN_FIELD_NAME), randomBoolean());
+        input.addField(matchOnlyTextFieldType, randomAlphaOfLength(100));
+        return input;
+    }
+
+    private static final String BYTE_FIELD_NAME = "byte_field";
+    private static final String SHORT_FIELD_NAME = "short_field";
+    private static final String INT_FIELD_NAME = "int_field";
+    private static final String LONG_FIELD_NAME = "long_field";
+    private static final String FLOAT_FIELD_NAME = "float_field";
+    private static final String DOUBLE_FIELD_NAME = "double_field";
+    private static final String HALF_FLOAT_FIELD_NAME = "half_float_field";
+    private static final String UNSIGNED_LONG_FIELD_NAME = "unsigned_long_field";
+    private static final String TEXT_FIELD_NAME = "text_field";
+    private static final String DATE_FIELD_NAME = "date_field";
+    private static final String DATE_NANOS_FIELD_NAME = "date_nanos_field";
+    private static final String IP_FIELD_NAME = "ip_field";
+    private static final String BINARY_FIELD_NAME = "binary_field";
+    private static final String BOOLEAN_FIELD_NAME = "boolean_field";
+    private static final String MATCH_ONLY_TEXT_FIELD_NAME = "match_only_text_field";
+
+    MatchOnlyTextFieldType matchOnlyTextFieldType = new MatchOnlyTextFieldMapper.MatchOnlyTextFieldType(
+        MATCH_ONLY_TEXT_FIELD_NAME,
+        true,
+        false,
+        TextSearchInfo.SIMPLE_MATCH_ONLY,
+        ParametrizedFieldMapper.Parameter.metaParam().get()
+    );
+
+    private Schema buildSchema() {
+        List<Field> fields = new ArrayList<>();
+        for (MappedFieldType ft : List.of(NAME_FIELD, AGE_FIELD)) {
+            ParquetField pf = ArrowFieldRegistry.getParquetField(ft.typeName());
+            fields.add(new Field(ft.name(), pf.getFieldType(), null));
+        }
+        for (Map.Entry<String, ParquetField> dataField : new CoreDataFieldPlugin().getParquetFields().entrySet()) {
+            fields.add(new Field(dataField.getKey() + "_field", dataField.getValue().getFieldType(), null));
+        }
+        // Metadata fields (long, not nullable)
+        fields.addAll(metadataFields());
+        // Row ID field (long) — added by RowIdAwareWriter
+        fields.add(new Field(DocumentInput.ROW_ID_FIELD, FieldType.notNullable(new ArrowType.Int(64, true)), null));
+        return new Schema(fields);
+    }
+}

--- a/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/engine/ParquetIndexingEngineTests.java
+++ b/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/engine/ParquetIndexingEngineTests.java
@@ -8,7 +8,9 @@
 
 package org.opensearch.parquet.engine;
 
+import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.opensearch.Version;
 import org.opensearch.cluster.metadata.IndexMetadata;
@@ -20,26 +22,35 @@ import org.opensearch.index.engine.dataformat.RefreshInput;
 import org.opensearch.index.engine.dataformat.RefreshResult;
 import org.opensearch.index.engine.dataformat.Writer;
 import org.opensearch.index.engine.dataformat.WriterConfig;
+import org.opensearch.index.engine.exec.PrimaryTermFieldType;
+import org.opensearch.index.mapper.IdFieldMapper;
 import org.opensearch.index.mapper.KeywordFieldMapper;
 import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.mapper.NumberFieldMapper;
+import org.opensearch.index.mapper.SeqNoFieldMapper;
+import org.opensearch.index.mapper.VersionFieldMapper;
 import org.opensearch.index.shard.ShardPath;
 import org.opensearch.parquet.ParquetDataFormatPlugin;
 import org.opensearch.parquet.bridge.RustBridge;
 import org.opensearch.parquet.fields.ArrowFieldRegistry;
+import org.opensearch.parquet.fields.ArrowSchemaBuilder;
 import org.opensearch.parquet.fields.ParquetField;
 import org.opensearch.parquet.writer.ParquetDocumentInput;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.FixedExecutorBuilder;
 import org.opensearch.threadpool.ThreadPool;
 
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import static org.opensearch.parquet.engine.ParquetDataFormatAwareEngineTests.ID_FIELD;
+import static org.opensearch.parquet.engine.ParquetDataFormatAwareEngineTests.SEQ_NO_FIELD;
+import static org.opensearch.parquet.engine.ParquetDataFormatAwareEngineTests.VERSION_FIELD;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -87,9 +98,11 @@ public class ParquetIndexingEngineTests extends OpenSearchTestCase {
 
         for (int i = 0; i < 5; i++) {
             ParquetDocumentInput doc = engine.newDocumentInput();
+            populateMetadataFields(doc);
             doc.addField(idField, i);
             doc.addField(nameField, "user_" + i);
             doc.addField(scoreField, (long) (i * 100));
+            doc.setRowId("__row_id__", i);
             writer.addDoc(doc);
             doc.close();
         }
@@ -104,9 +117,12 @@ public class ParquetIndexingEngineTests extends OpenSearchTestCase {
         for (long gen = 1; gen <= 3; gen++) {
             Writer<ParquetDocumentInput> writer = engine.createWriter(new WriterConfig(gen));
             ParquetDocumentInput doc = engine.newDocumentInput();
+            populateMetadataFields(doc);
             doc.addField(idField, (int) gen);
             doc.addField(nameField, "user_" + gen);
             doc.addField(scoreField, gen * 100);
+            doc.setRowId("__row_id__", gen);
+
             writer.addDoc(doc);
             doc.close();
             writer.flush();
@@ -116,8 +132,10 @@ public class ParquetIndexingEngineTests extends OpenSearchTestCase {
 
     public void testNewDocumentInput() {
         ParquetDocumentInput doc = engine.newDocumentInput();
+        populateMetadataFields(doc);
         assertNotNull(doc);
-        assertTrue(doc.getFinalInput().isEmpty());
+        doc.setRowId("__row_id__", 0);
+        assertEquals(4, doc.getFinalInput().size());
     }
 
     public void testGetDataFormat() {
@@ -179,11 +197,13 @@ public class ParquetIndexingEngineTests extends OpenSearchTestCase {
                 .build();
             IndexMetadata indexMetadata = IndexMetadata.builder("test_index").settings(indexSettingsBuilder).build();
             IndexSettings indexSettings = new IndexSettings(indexMetadata, Settings.EMPTY);
+            MapperService mapperService = createMockMapperService(schema, indexSettings);
             return new ParquetIndexingEngine(
                 Settings.EMPTY,
                 new ParquetDataFormat(),
                 shardPath,
-                createMockMapperService(schema, indexSettings),
+                () -> ArrowSchemaBuilder.getSchema(mapperService),
+                () -> mapperService.getIndexSettings().getIndexMetadata().getMappingVersion(),
                 indexSettings,
                 threadPool
             );
@@ -207,6 +227,7 @@ public class ParquetIndexingEngineTests extends OpenSearchTestCase {
             assertNotNull("No ParquetField registered for type: " + ft.typeName(), pf);
             fields.add(new Field(ft.name(), pf.getFieldType(), null));
         }
+        fields.addAll(metadataFields());
         return new Schema(fields);
     }
 
@@ -215,5 +236,21 @@ public class ParquetIndexingEngineTests extends OpenSearchTestCase {
         when(mapperService.documentMapper()).thenReturn(null);
         when(mapperService.getIndexSettings()).thenReturn(indexSettings);
         return mapperService;
+    }
+
+    public static List<Field> metadataFields() {
+        List<Field> fields = new ArrayList<>();
+        fields.add(new Field(VersionFieldMapper.NAME, FieldType.notNullable(new ArrowType.Int(64, true)), null));
+        fields.add(new Field(SeqNoFieldMapper.NAME, FieldType.notNullable(new ArrowType.Int(64, true)), null));
+        fields.add(new Field(SeqNoFieldMapper.PRIMARY_TERM_NAME, FieldType.notNullable(new ArrowType.Int(64, true)), null));
+        fields.add(new Field(IdFieldMapper.NAME, FieldType.notNullable(new ArrowType.Binary()), null));
+        return fields;
+    }
+
+    public static void populateMetadataFields(ParquetDocumentInput input) {
+        input.addField(SEQ_NO_FIELD, 100L);
+        input.addField(ID_FIELD, "id".getBytes(StandardCharsets.UTF_8));
+        input.addField(VERSION_FIELD, 1L);
+        input.addField(PrimaryTermFieldType.INSTANCE, 1L);
     }
 }

--- a/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/fields/ArrowFieldRegistryTests.java
+++ b/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/fields/ArrowFieldRegistryTests.java
@@ -59,8 +59,7 @@ public class ArrowFieldRegistryTests extends OpenSearchTestCase {
             IgnoredFieldMapper.CONTENT_TYPE,
             IdFieldMapper.CONTENT_TYPE,
             SeqNoFieldMapper.CONTENT_TYPE,
-            VersionFieldMapper.CONTENT_TYPE,
-            SeqNoFieldMapper.PRIMARY_TERM_NAME, };
+            VersionFieldMapper.CONTENT_TYPE, };
         for (String type : expectedTypes) {
             assertNotNull("Missing registration for: " + type, ArrowFieldRegistry.getParquetField(type));
         }

--- a/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/fields/core/metadata/MetadataParquetFieldTests.java
+++ b/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/fields/core/metadata/MetadataParquetFieldTests.java
@@ -15,7 +15,6 @@ import org.apache.arrow.vector.VarCharVector;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.Schema;
-import org.apache.lucene.util.BytesRef;
 import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.parquet.fields.ParquetField;
 import org.opensearch.parquet.vsr.ManagedVSR;
@@ -51,7 +50,7 @@ public class MetadataParquetFieldTests extends OpenSearchTestCase {
         IdParquetField field = new IdParquetField();
         MappedFieldType ft = mockFieldType("_id");
         ManagedVSR vsr = createVSR("id-test", field, "_id");
-        BytesRef ref = new BytesRef("doc-id-1");
+        byte[] ref = "doc-id-1".getBytes(StandardCharsets.UTF_8);
         field.createField(ft, vsr, ref);
         vsr.setRowCount(1);
         byte[] result = ((VarBinaryVector) vsr.getVector("_id")).get(0);
@@ -76,13 +75,6 @@ public class MetadataParquetFieldTests extends OpenSearchTestCase {
 
     public void testIgnoredFieldArrowType() {
         assertTrue(new IgnoredParquetField().getArrowType() instanceof ArrowType.Utf8);
-    }
-
-    public void testSizeFieldArrowType() {
-        SizeParquetField field = new SizeParquetField();
-        ArrowType.Int type = (ArrowType.Int) field.getArrowType();
-        assertEquals(32, type.getBitWidth());
-        assertTrue(type.getIsSigned());
     }
 
     private MappedFieldType mockFieldType(String name) {

--- a/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/fields/plugins/CoreDataFieldPluginTests.java
+++ b/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/fields/plugins/CoreDataFieldPluginTests.java
@@ -32,7 +32,7 @@ public class CoreDataFieldPluginTests extends OpenSearchTestCase {
 
     public void testFieldCount() {
         // 10 numeric + 2 temporal + 1 boolean + 3 text + 1 binary = 17
-        assertEquals(17, fields.size());
+        assertEquals(18, fields.size());
     }
 
     public void testAllNumericTypesPresent() {

--- a/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/fields/plugins/MetadataFieldPluginTests.java
+++ b/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/fields/plugins/MetadataFieldPluginTests.java
@@ -40,6 +40,7 @@ public class MetadataFieldPluginTests extends OpenSearchTestCase {
         assertNotNull(fields.get(IgnoredFieldMapper.CONTENT_TYPE));
         assertNotNull(fields.get(IdFieldMapper.CONTENT_TYPE));
         assertNotNull(fields.get(SeqNoFieldMapper.CONTENT_TYPE));
+        assertNotNull(fields.get(SeqNoFieldMapper.PRIMARY_TERM_NAME));
         assertNotNull(fields.get(VersionFieldMapper.CONTENT_TYPE));
     }
 

--- a/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/vsr/VSRManagerTests.java
+++ b/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/vsr/VSRManagerTests.java
@@ -17,6 +17,7 @@ import org.opensearch.Version;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.index.IndexSettings;
+import org.opensearch.index.engine.dataformat.DocumentInput;
 import org.opensearch.index.mapper.KeywordFieldMapper;
 import org.opensearch.index.mapper.NumberFieldMapper;
 import org.opensearch.parquet.ParquetDataFormatPlugin;
@@ -28,7 +29,11 @@ import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.FixedExecutorBuilder;
 import org.opensearch.threadpool.ThreadPool;
 
+import java.util.ArrayList;
 import java.util.List;
+
+import static org.opensearch.parquet.engine.ParquetIndexingEngineTests.metadataFields;
+import static org.opensearch.parquet.engine.ParquetIndexingEngineTests.populateMetadataFields;
 
 public class VSRManagerTests extends OpenSearchTestCase {
 
@@ -104,12 +109,19 @@ public class VSRManagerTests extends OpenSearchTestCase {
     }
 
     public void testAddDocument() throws Exception {
+        List<Field> fields = new ArrayList<>();
+        fields.addAll(metadataFields());
+        fields.add(new Field("val", FieldType.nullable(new ArrowType.Int(32, true)), null));
+        schema = new Schema(fields);
+
         String filePath = createTempDir().resolve("add-doc.parquet").toString();
         VSRManager manager = new VSRManager(filePath, indexSettings, schema, bufferPool, 50000, threadPool, 0L);
 
         NumberFieldMapper.NumberFieldType valField = new NumberFieldMapper.NumberFieldType("val", NumberFieldMapper.NumberType.INTEGER);
         ParquetDocumentInput doc = new ParquetDocumentInput();
+        populateMetadataFields(doc);
         doc.addField(valField, 42);
+        doc.setRowId("__row_id__", 0);
         manager.addDocument(doc);
 
         assertEquals(1, manager.getActiveManagedVSR().getRowCount());
@@ -294,6 +306,8 @@ public class VSRManagerTests extends OpenSearchTestCase {
         NumberFieldMapper.NumberFieldType valField = new NumberFieldMapper.NumberFieldType("val", NumberFieldMapper.NumberType.INTEGER);
         KeywordFieldMapper.KeywordFieldType tagField = new KeywordFieldMapper.KeywordFieldType("tag");
         ParquetDocumentInput doc = new ParquetDocumentInput();
+        populateMetadataFields(doc);
+        doc.setRowId(DocumentInput.ROW_ID_FIELD, 1);
         doc.addField(valField, 42);
         doc.addField(tagField, "hello");
         manager.addDocument(doc);
@@ -311,6 +325,8 @@ public class VSRManagerTests extends OpenSearchTestCase {
 
         NumberFieldMapper.NumberFieldType valField = new NumberFieldMapper.NumberFieldType("val", NumberFieldMapper.NumberType.INTEGER);
         ParquetDocumentInput doc = new ParquetDocumentInput();
+        populateMetadataFields(doc);
+        doc.setRowId(DocumentInput.ROW_ID_FIELD, 1);
         doc.addField(valField, 1);
         manager.addDocument(doc);
 
@@ -326,11 +342,15 @@ public class VSRManagerTests extends OpenSearchTestCase {
         KeywordFieldMapper.KeywordFieldType tagField = new KeywordFieldMapper.KeywordFieldType("tag");
 
         ParquetDocumentInput doc1 = new ParquetDocumentInput();
+        populateMetadataFields(doc1);
+        doc1.setRowId(DocumentInput.ROW_ID_FIELD, 1L);
         doc1.addField(valField, 1);
         doc1.addField(tagField, "a");
         manager.addDocument(doc1);
 
         ParquetDocumentInput doc2 = new ParquetDocumentInput();
+        populateMetadataFields(doc2);
+        doc2.setRowId(DocumentInput.ROW_ID_FIELD, 2L);
         doc2.addField(valField, 2);
         doc2.addField(tagField, "b");
         manager.addDocument(doc2);
@@ -349,6 +369,8 @@ public class VSRManagerTests extends OpenSearchTestCase {
         KeywordFieldMapper.KeywordFieldType tag3Field = new KeywordFieldMapper.KeywordFieldType("tag3");
 
         ParquetDocumentInput doc = new ParquetDocumentInput();
+        populateMetadataFields(doc);
+        doc.setRowId(DocumentInput.ROW_ID_FIELD, 1L);
         doc.addField(valField, 1);
         doc.addField(tag1Field, "a");
         doc.addField(tag2Field, "b");

--- a/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/writer/ParquetDocumentInputTests.java
+++ b/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/writer/ParquetDocumentInputTests.java
@@ -15,14 +15,18 @@ import org.opensearch.test.OpenSearchTestCase;
 
 import java.util.List;
 
+import static org.opensearch.parquet.engine.ParquetIndexingEngineTests.populateMetadataFields;
+
 public class ParquetDocumentInputTests extends OpenSearchTestCase {
 
     public void testAddFieldAndGetFinalInput() {
         ParquetDocumentInput input = new ParquetDocumentInput();
         MappedFieldType ft = new NumberFieldMapper.NumberFieldType("age", NumberFieldMapper.NumberType.INTEGER);
         input.addField(ft, 25);
+        input.setRowId("__row_id__", 0L);
+        populateMetadataFields(input);
         List<FieldValuePair> result = input.getFinalInput();
-        assertEquals(1, result.size());
+        assertEquals(5, result.size());
         assertSame(ft, result.getFirst().getFieldType());
         assertEquals(25, result.getFirst().getValue());
     }
@@ -33,30 +37,38 @@ public class ParquetDocumentInputTests extends OpenSearchTestCase {
         MappedFieldType ft2 = new KeywordFieldMapper.KeywordFieldType("b");
         input.addField(ft1, 1);
         input.addField(ft2, "val");
-        assertEquals(2, input.getFinalInput().size());
+        input.setRowId("__row_id__", 0L);
+        populateMetadataFields(input);
+        assertEquals(6, input.getFinalInput().size());
     }
 
     public void testEmptyInput() {
         ParquetDocumentInput input = new ParquetDocumentInput();
-        assertTrue(input.getFinalInput().isEmpty());
+        populateMetadataFields(input);
+        input.setRowId("__row_id__", 0L);
+        assertEquals(4, input.getFinalInput().size());
     }
 
     public void testSetRowId() {
         ParquetDocumentInput input = new ParquetDocumentInput();
+        populateMetadataFields(input);
         input.setRowId("_row_id", 42L);
         assertEquals(42L, input.getRowId());
     }
 
     public void testAddFieldRejectsNullFieldType() {
         ParquetDocumentInput input = new ParquetDocumentInput();
+        populateMetadataFields(input);
         expectThrows(IllegalArgumentException.class, () -> input.addField(null, "ignored"));
     }
 
     public void testCloseClearsState() {
         ParquetDocumentInput input = new ParquetDocumentInput();
+        populateMetadataFields(input);
         MappedFieldType ft = new NumberFieldMapper.NumberFieldType("age", NumberFieldMapper.NumberType.INTEGER);
         input.addField(ft, 25);
-        assertEquals(1, input.getFinalInput().size());
+        input.setRowId("__row_id__", 0L);
+        assertEquals(5, input.getFinalInput().size());
 
         input.close();
         assertTrue(input.getFinalInput().isEmpty());

--- a/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/writer/ParquetWriterTests.java
+++ b/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/writer/ParquetWriterTests.java
@@ -14,6 +14,7 @@ import org.opensearch.Version;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.index.IndexSettings;
+import org.opensearch.index.engine.dataformat.DocumentInput;
 import org.opensearch.index.engine.dataformat.FileInfos;
 import org.opensearch.index.engine.dataformat.WriteResult;
 import org.opensearch.index.mapper.KeywordFieldMapper;
@@ -33,6 +34,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+
+import static org.opensearch.parquet.engine.ParquetIndexingEngineTests.metadataFields;
+import static org.opensearch.parquet.engine.ParquetIndexingEngineTests.populateMetadataFields;
 
 public class ParquetWriterTests extends OpenSearchTestCase {
 
@@ -95,9 +99,11 @@ public class ParquetWriterTests extends OpenSearchTestCase {
         );
 
         ParquetDocumentInput doc = new ParquetDocumentInput();
+        populateMetadataFields(doc);
         doc.addField(idField, 1);
         doc.addField(nameField, "alice");
         doc.addField(scoreField, 100L);
+        doc.setRowId(DocumentInput.ROW_ID_FIELD, 1);
         WriteResult result = writer.addDoc(doc);
         assertTrue(result instanceof WriteResult.Success);
         doc.close();
@@ -119,9 +125,11 @@ public class ParquetWriterTests extends OpenSearchTestCase {
         );
 
         ParquetDocumentInput doc = new ParquetDocumentInput();
+        populateMetadataFields(doc);
         doc.addField(idField, 42);
         doc.addField(nameField, "bob");
         doc.addField(scoreField, 500L);
+        doc.setRowId(DocumentInput.ROW_ID_FIELD, 1);
         writer.addDoc(doc);
         doc.close();
 
@@ -145,9 +153,11 @@ public class ParquetWriterTests extends OpenSearchTestCase {
 
         for (int i = 0; i < 10; i++) {
             ParquetDocumentInput doc = new ParquetDocumentInput();
+            populateMetadataFields(doc);
             doc.addField(idField, i);
             doc.addField(nameField, "user_" + i);
             doc.addField(scoreField, (long) (i * 100));
+            doc.setRowId("__row_id__", i);
             writer.addDoc(doc);
             doc.close();
         }
@@ -189,9 +199,11 @@ public class ParquetWriterTests extends OpenSearchTestCase {
         );
 
         ParquetDocumentInput doc = new ParquetDocumentInput();
+        populateMetadataFields(doc);
         doc.addField(idField, 1);
         doc.addField(nameField, "alice");
         doc.addField(scoreField, 100L);
+        doc.setRowId("__row_id__", 0);
         writer.addDoc(doc);
         doc.close();
 
@@ -207,6 +219,7 @@ public class ParquetWriterTests extends OpenSearchTestCase {
             assertNotNull("No ParquetField registered for type: " + ft.typeName(), pf);
             fields.add(new Field(ft.name(), pf.getFieldType(), null));
         }
+        fields.addAll(metadataFields());
         return new Schema(fields);
     }
 }

--- a/server/src/main/java/org/opensearch/index/engine/DataFormatAwareEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/DataFormatAwareEngine.java
@@ -57,6 +57,7 @@ import org.opensearch.index.engine.exec.FileDeleter;
 import org.opensearch.index.engine.exec.FilesListener;
 import org.opensearch.index.engine.exec.IndexReaderProvider;
 import org.opensearch.index.engine.exec.Indexer;
+import org.opensearch.index.engine.exec.PrimaryTermFieldType;
 import org.opensearch.index.engine.exec.Segment;
 import org.opensearch.index.engine.exec.WriterFileSet;
 import org.opensearch.index.engine.exec.commit.Committer;
@@ -66,8 +67,10 @@ import org.opensearch.index.engine.exec.coord.CatalogSnapshotManager;
 import org.opensearch.index.mapper.DocumentMapperForType;
 import org.opensearch.index.mapper.IdFieldMapper;
 import org.opensearch.index.mapper.ParsedDocument;
+import org.opensearch.index.mapper.SeqNoFieldMapper;
 import org.opensearch.index.mapper.SourceToParse;
 import org.opensearch.index.mapper.Uid;
+import org.opensearch.index.mapper.VersionFieldMapper;
 import org.opensearch.index.merge.MergeStats;
 import org.opensearch.index.seqno.LocalCheckpointTracker;
 import org.opensearch.index.seqno.SeqNoStats;
@@ -96,6 +99,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -569,9 +573,12 @@ public class DataFormatAwareEngine implements Indexer {
             currentWriter = lockedWriter.get();
             currentWriter.updateMappingVersion(mappingVersion);
             // Writer pool must never return null — it creates on demand via the supplier
-            assert currentWriter != null : "writer pool returned null writer";
             assert index.seqNo() >= 0 : "seqNo must be assigned before writing but was: " + index.seqNo();
             assert index.primaryTerm() > 0 : "primaryTerm must be positive but was: " + index.primaryTerm();
+            index.parsedDoc().getDocumentInput().addField(engineConfig.getMapperService().fieldType(VersionFieldMapper.NAME), plan.version);
+            index.parsedDoc().getDocumentInput().addField(engineConfig.getMapperService().fieldType(SeqNoFieldMapper.NAME), index.seqNo());
+            index.parsedDoc().getDocumentInput().addField(PrimaryTermFieldType.INSTANCE, index.primaryTerm());
+
             WriteResult result = currentWriter.addDoc(index.parsedDoc().getDocumentInput());
 
             if (result instanceof WriteResult.Success) {
@@ -1163,7 +1170,13 @@ public class DataFormatAwareEngine implements Indexer {
             long count = snapshot.get()
                 .getSegments()
                 .stream()
-                .flatMap(segment -> segment.dfGroupedSearchableFiles().values().stream())
+                .map(
+                    segment -> segment.dfGroupedSearchableFiles()
+                        .values()
+                        .stream()
+                        .findFirst()
+                        .orElseGet(() -> new WriterFileSet("", -1L, Set.of(), 0))
+                )
                 .mapToLong(WriterFileSet::numRows)
                 .sum();
             long totalSize = snapshot.get()
@@ -1425,7 +1438,7 @@ public class DataFormatAwareEngine implements Indexer {
     }
 
     private void triggerPossibleMerges() {
-        if (Booleans.parseBoolean(System.getProperty(MERGE_ENABLED_PROPERTY, Boolean.FALSE.toString())) == false) {
+        if (Booleans.parseBoolean(System.getProperty(MERGE_ENABLED_PROPERTY, Boolean.TRUE.toString())) == false) {
             logger.debug("Pluggable dataformat merge is disabled via system property [{}], skipping merge", MERGE_ENABLED_PROPERTY);
             return;
         }

--- a/server/src/main/java/org/opensearch/index/engine/dataformat/DocumentInput.java
+++ b/server/src/main/java/org/opensearch/index/engine/dataformat/DocumentInput.java
@@ -46,4 +46,11 @@ public interface DocumentInput<T> extends AutoCloseable {
      * @param rowId the row ID value
      */
     void setRowId(String rowIdFieldName, long rowId);
+
+    /**
+     * Given a field name, returns the number of values associated with that field in the document.
+     * @param fieldName name of the field to lookup
+     * @return count of field values
+     */
+    long getFieldCount(String fieldName);
 }

--- a/server/src/main/java/org/opensearch/index/engine/exec/PrimaryTermFieldType.java
+++ b/server/src/main/java/org/opensearch/index/engine/exec/PrimaryTermFieldType.java
@@ -1,0 +1,57 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.engine.exec;
+
+import org.apache.lucene.search.Query;
+import org.opensearch.common.annotation.ExperimentalApi;
+import org.opensearch.index.mapper.MappedFieldType;
+import org.opensearch.index.mapper.SeqNoFieldMapper;
+import org.opensearch.index.mapper.TextSearchInfo;
+import org.opensearch.index.mapper.ValueFetcher;
+import org.opensearch.index.query.QueryShardContext;
+import org.opensearch.search.lookup.SearchLookup;
+
+import java.util.Map;
+
+/**
+ * A synthetic {@link MappedFieldType} for the {@code _primary_term} metadata field,
+ * used by {@link org.opensearch.index.engine.DataFormatAwareEngine} to pass the primary
+ * term value to pluggable data format document inputs during indexing.
+ * <p>
+ * This field type is not searchable, stored, or doc-valued — it exists solely as a
+ * type-safe carrier for the field name and type name so that
+ * {@link org.opensearch.index.engine.dataformat.DocumentInput#addField} can route the
+ * primary term to the appropriate format-specific handler.
+ *
+ * @opensearch.experimental
+ */
+@ExperimentalApi
+public class PrimaryTermFieldType extends MappedFieldType {
+
+    public static PrimaryTermFieldType INSTANCE = new PrimaryTermFieldType();
+
+    private PrimaryTermFieldType() {
+        super(SeqNoFieldMapper.PRIMARY_TERM_NAME, false, false, false, TextSearchInfo.NONE, Map.of());
+    }
+
+    @Override
+    public ValueFetcher valueFetcher(QueryShardContext context, SearchLookup searchLookup, String format) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String typeName() {
+        return SeqNoFieldMapper.PRIMARY_TERM_NAME;
+    }
+
+    @Override
+    public Query termQuery(Object value, QueryShardContext context) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/server/src/main/java/org/opensearch/index/mapper/DataStreamFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/DataStreamFieldMapper.java
@@ -146,13 +146,18 @@ public class DataStreamFieldMapper extends MetadataFieldMapper {
         // 1. LongPoint (indexed = true; an indexed long field to allow fast range filters on the timestamp field value)
         // 2. SortedNumericDocValuesField (hasDocValues = true; allows sorting, aggregations and access to the timestamp field value)
 
-        Document document = context.doc();
-        IndexableField[] fields = document.getFields(timestampField.getName());
+        long numTimestampValues = 0L;
+        if (context.indexSettings().isPluggableDataFormatEnabled() == false) {
+            Document document = context.doc();
+            IndexableField[] fields = document.getFields(timestampField.getName());
 
-        // Documents must contain exactly one value for the timestamp field.
-        long numTimestampValues = Arrays.stream(fields)
-            .filter(field -> field.fieldType().docValuesType() == DocValuesType.SORTED_NUMERIC)
-            .count();
+            // Documents must contain exactly one value for the timestamp field.
+            numTimestampValues = Arrays.stream(fields)
+                .filter(field -> field.fieldType().docValuesType() == DocValuesType.SORTED_NUMERIC)
+                .count();
+        } else {
+            numTimestampValues = context.documentInput().getFieldCount(timestampField.getName());
+        }
 
         if (numTimestampValues != 1) {
             throw new IllegalArgumentException(

--- a/server/src/main/java/org/opensearch/index/mapper/FlatObjectFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/FlatObjectFieldMapper.java
@@ -569,14 +569,6 @@ public final class FlatObjectFieldMapper extends DynamicKeyFieldMapper {
         }
     }
 
-    @Override
-    protected void parseCreateFieldForPluggableFormat(ParseContext context) throws IOException {
-        HashSet<String> pathParts = parseObjectPathParts(context);
-        if (pathParts != null) {
-            createPathFieldsForPluggableFormat(context, pathParts);
-        }
-    }
-
     /**
      * Parses the flat_object field value and returns the collected path parts,
      * or {@code null} if the field should be skipped (null value or not searchable/stored/docvalues).

--- a/server/src/main/java/org/opensearch/index/mapper/IdFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/IdFieldMapper.java
@@ -298,7 +298,13 @@ public class IdFieldMapper extends MetadataFieldMapper {
     @Override
     public void preParse(ParseContext context) {
         BytesRef id = Uid.encodeId(context.sourceToParse().id());
-        context.doc().add(new Field(NAME, id, Defaults.FIELD_TYPE));
+        if (context.indexSettings().isPluggableDataFormatEnabled()) {
+            byte[] idToStore = new byte[id.length];
+            System.arraycopy(id.bytes, id.offset, idToStore, 0, id.length);
+            context.documentInput().addField(fieldType(), idToStore);
+        } else {
+            context.doc().add(new Field(NAME, id, Defaults.FIELD_TYPE));
+        }
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/index/mapper/MetadataFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/MetadataFieldMapper.java
@@ -225,5 +225,4 @@ public abstract class MetadataFieldMapper extends ParametrizedFieldMapper {
     public void postParse(ParseContext context) throws IOException {
         // do nothing
     }
-
 }

--- a/server/src/main/java/org/opensearch/index/mapper/TextSearchInfo.java
+++ b/server/src/main/java/org/opensearch/index/mapper/TextSearchInfo.java
@@ -144,6 +144,10 @@ public class TextSearchInfo {
         return luceneFieldType.tokenized();
     }
 
+    public FieldType getLuceneFieldType() {
+        return luceneFieldType;
+    }
+
     /**
      * What sort of term vectors are available
      *

--- a/server/src/test/java/org/opensearch/index/mapper/ConstantKeywordFieldMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/ConstantKeywordFieldMapperTests.java
@@ -28,6 +28,7 @@ import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.index.IndexService;
 import org.opensearch.index.engine.dataformat.stub.MockCommitterEnginePlugin;
 import org.opensearch.index.engine.dataformat.stub.MockDataFormatPlugin;
+import org.opensearch.index.engine.dataformat.stub.MockDocumentInput;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.test.InternalSettingsPlugin;
 import org.opensearch.test.OpenSearchSingleNodeTestCase;
@@ -193,7 +194,8 @@ public class ConstantKeywordFieldMapperTests extends OpenSearchSingleNodeTestCas
                     "1",
                     BytesReference.bytes(XContentFactory.jsonBuilder().startObject().field("field", "foo").endObject()),
                     MediaTypeRegistry.JSON
-                )
+                ),
+                new MockDocumentInput()
             );
     }
 }

--- a/server/src/test/java/org/opensearch/index/mapper/DocumentMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/DocumentMapperTests.java
@@ -378,6 +378,11 @@ public class DocumentMapperTests extends MapperServiceTestCase {
         }
 
         @Override
+        public long getFieldCount(String fieldName) {
+            return fields.containsKey(fieldName) ? 1 : 0;
+        }
+
+        @Override
         public void close() {}
     }
 }

--- a/server/src/test/java/org/opensearch/index/mapper/DocumentParserTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/DocumentParserTests.java
@@ -42,7 +42,6 @@ import org.opensearch.core.common.bytes.BytesArray;
 import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.index.IndexSettings;
-import org.opensearch.index.engine.dataformat.DocumentInput;
 import org.opensearch.index.mapper.ParseContext.Document;
 import org.opensearch.plugins.Plugin;
 
@@ -53,9 +52,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import static java.util.Collections.singletonList;
 import static org.opensearch.test.StreamsUtils.copyToBytesFromClasspath;
@@ -3582,7 +3579,7 @@ public class DocumentParserTests extends MapperServiceTestCase {
 
     public void testParseDocumentWithDocumentInputPropagated() throws Exception {
         DocumentMapper mapper = createDocumentMapper(mapping(b -> b.startObject("field").field("type", "text").endObject()));
-        DocumentInput<Map<String, Object>> mockInput = new TestDocumentInput();
+        CapturingDocumentInput mockInput = new CapturingDocumentInput();
 
         ParsedDocument doc = mapper.parse(source(b -> b.field("field", "value")), mockInput);
 
@@ -3608,7 +3605,7 @@ public class DocumentParserTests extends MapperServiceTestCase {
 
     public void testParseDocumentWithDocumentInputAndDynamicMapping() throws Exception {
         DocumentMapper mapper = createDocumentMapper(mapping(b -> {}));
-        DocumentInput<Map<String, Object>> mockInput = new TestDocumentInput();
+        CapturingDocumentInput mockInput = new CapturingDocumentInput();
 
         ParsedDocument doc = mapper.parse(source(b -> b.field("dynamic_field", "value")), mockInput);
 
@@ -3628,7 +3625,7 @@ public class DocumentParserTests extends MapperServiceTestCase {
             }
             b.endObject();
         }));
-        DocumentInput<Map<String, Object>> mockInput = new TestDocumentInput();
+        CapturingDocumentInput mockInput = new CapturingDocumentInput();
 
         ParsedDocument doc = mapper.parse(source(b -> {
             b.startObject("obj");
@@ -3638,27 +3635,5 @@ public class DocumentParserTests extends MapperServiceTestCase {
 
         assertThat(doc.getDocumentInput(), sameInstance(mockInput));
         assertNotNull(doc.rootDoc().getField("obj.inner"));
-    }
-
-    private static class TestDocumentInput implements DocumentInput<Map<String, Object>> {
-        private final Map<String, Object> fields = new HashMap<>();
-
-        @Override
-        public Map<String, Object> getFinalInput() {
-            return Collections.unmodifiableMap(fields);
-        }
-
-        @Override
-        public void addField(MappedFieldType fieldType, Object value) {
-            fields.put(fieldType != null ? fieldType.name() : "field_" + fields.size(), value);
-        }
-
-        @Override
-        public void setRowId(String rowIdFieldName, long rowId) {
-            fields.put(rowIdFieldName, rowId);
-        }
-
-        @Override
-        public void close() {}
     }
 }

--- a/server/src/test/java/org/opensearch/index/mapper/FlatObjectFieldMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/FlatObjectFieldMapperTests.java
@@ -17,8 +17,6 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.util.BytesRef;
 import org.opensearch.common.TriFunction;
-import org.opensearch.common.settings.Settings;
-import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.common.util.set.Sets;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.common.xcontent.json.JsonXContent;
@@ -30,7 +28,6 @@ import org.hamcrest.MatcherAssert;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 import static org.opensearch.index.mapper.FlatObjectFieldMapper.CONTENT_TYPE;
@@ -418,100 +415,6 @@ public class FlatObjectFieldMapperTests extends MapperTestCase {
     @Override
     protected void registerParameters(ParameterChecker checker) throws IOException {
         // In the future we will want to make sure parameter updates are covered.
-    }
-
-    private Settings pluggableSettings() {
-        return Settings.builder().put(getIndexSettings()).put("index.pluggable.dataformat.enabled", true).build();
-    }
-
-    @LockFeatureFlag(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)
-    public void testPluggableDataFormatSimpleObject() throws IOException {
-        DocumentMapper mapper = createDocumentMapper(
-            pluggableSettings(),
-            mapping(b -> b.startObject("field").field("type", "flat_object").endObject())
-        );
-        CapturingDocumentInput docInput = new CapturingDocumentInput();
-        String json = "{\"field\":{\"foo\":\"bar\"}}";
-        mapper.parse(source(json), docInput);
-
-        List<Map.Entry<MappedFieldType, Object>> captured = docInput.getCapturedFields();
-        boolean found = captured.stream()
-            .anyMatch(e -> e.getKey().name().equals("field") && e.getValue().equals(new BytesRef("field.foo")));
-        assertTrue("Expected flat_object path field captured", found);
-    }
-
-    @LockFeatureFlag(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)
-    public void testPluggableDataFormatNullValue() throws IOException {
-        DocumentMapper mapper = createDocumentMapper(
-            pluggableSettings(),
-            mapping(b -> b.startObject("field").field("type", "flat_object").endObject())
-        );
-        CapturingDocumentInput docInput = new CapturingDocumentInput();
-        mapper.parse(source(b -> b.nullField("field")), docInput);
-
-        boolean hasField = docInput.getCapturedFields().stream().anyMatch(e -> e.getKey().name().equals("field"));
-        assertFalse("Expected no captured field for null value", hasField);
-    }
-
-    @LockFeatureFlag(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)
-    public void testPluggableDataFormatNonObjectThrows() throws IOException {
-        DocumentMapper mapper = createDocumentMapper(
-            pluggableSettings(),
-            mapping(b -> b.startObject("field").field("type", "flat_object").endObject())
-        );
-        CapturingDocumentInput docInput = new CapturingDocumentInput();
-        Exception e = expectThrows(
-            MapperParsingException.class,
-            () -> mapper.parse(source(b -> b.field("field", "string_value")), docInput)
-        );
-        assertThat(e.getCause().getMessage(), org.hamcrest.Matchers.containsString("unexpected token"));
-    }
-
-    @LockFeatureFlag(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)
-    public void testPluggableDataFormatNestedObject() throws IOException {
-        DocumentMapper mapper = createDocumentMapper(
-            pluggableSettings(),
-            mapping(b -> b.startObject("field").field("type", "flat_object").endObject())
-        );
-        CapturingDocumentInput docInput = new CapturingDocumentInput();
-        String json = "{\"field\":{\"a\":\"1\",\"b\":\"2\"}}";
-        mapper.parse(source(json), docInput);
-
-        List<Map.Entry<MappedFieldType, Object>> captured = docInput.getCapturedFields();
-        assertEquals(2, captured.size());
-        Set<Object> values = Set.of(captured.get(0).getValue(), captured.get(1).getValue());
-        assertTrue(values.contains(new BytesRef("field.a")));
-        assertTrue(values.contains(new BytesRef("field.b")));
-    }
-
-    @LockFeatureFlag(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)
-    public void testPluggableDataFormatWithNullFieldsInObject() throws IOException {
-        DocumentMapper mapper = createDocumentMapper(
-            pluggableSettings(),
-            mapping(b -> b.startObject("field").field("type", "flat_object").endObject())
-        );
-        CapturingDocumentInput docInput = new CapturingDocumentInput();
-        String json = "{\"field\":{\"name\":null,\"age\":3}}";
-        mapper.parse(source(json), docInput);
-
-        List<Map.Entry<MappedFieldType, Object>> captured = docInput.getCapturedFields();
-        assertEquals(1, captured.size());
-        assertEquals(new BytesRef("field.age"), captured.get(0).getValue());
-    }
-
-    @LockFeatureFlag(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)
-    public void testPluggableDataFormatDeepNestedObject() throws IOException {
-        DocumentMapper mapper = createDocumentMapper(
-            pluggableSettings(),
-            mapping(b -> b.startObject("field").field("type", "flat_object").endObject())
-        );
-        CapturingDocumentInput docInput = new CapturingDocumentInput();
-        String json = "{\"field\":{\"a\":{\"b\":\"val\"}}}";
-        mapper.parse(source(json), docInput);
-
-        List<Map.Entry<MappedFieldType, Object>> captured = docInput.getCapturedFields();
-        assertTrue(captured.stream().anyMatch(e -> e.getValue().equals(new BytesRef("field.a"))));
-        assertTrue(captured.stream().anyMatch(e -> e.getValue().equals(new BytesRef("field.b"))));
     }
 
     public void testDefaultsDoNotUseDocumentInput() throws Exception {

--- a/test/framework/src/main/java/org/opensearch/index/engine/dataformat/AbstractDataFormatAwareEngineTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/index/engine/dataformat/AbstractDataFormatAwareEngineTestCase.java
@@ -1,0 +1,532 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.engine.dataformat;
+
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.NoMergePolicy;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.ReferenceManager;
+import org.apache.lucene.store.Directory;
+import org.opensearch.Version;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.concurrent.GatedCloseable;
+import org.opensearch.common.lucene.Lucene;
+import org.opensearch.common.lucene.uid.Versions;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.common.util.BigArrays;
+import org.opensearch.core.index.Index;
+import org.opensearch.core.index.shard.ShardId;
+import org.opensearch.index.IndexSettings;
+import org.opensearch.index.VersionType;
+import org.opensearch.index.engine.DataFormatAwareEngine;
+import org.opensearch.index.engine.Engine;
+import org.opensearch.index.engine.EngineConfig;
+import org.opensearch.index.engine.dataformat.stub.InMemoryCommitter;
+import org.opensearch.index.engine.dataformat.stub.MockDocumentInput;
+import org.opensearch.index.engine.exec.Segment;
+import org.opensearch.index.engine.exec.WriterFileSet;
+import org.opensearch.index.engine.exec.commit.CommitterFactory;
+import org.opensearch.index.engine.exec.coord.CatalogSnapshot;
+import org.opensearch.index.mapper.IdFieldMapper;
+import org.opensearch.index.mapper.MapperService;
+import org.opensearch.index.mapper.ParsedDocument;
+import org.opensearch.index.mapper.SeqNoFieldMapper;
+import org.opensearch.index.mapper.Uid;
+import org.opensearch.index.seqno.RetentionLeases;
+import org.opensearch.index.seqno.SequenceNumbers;
+import org.opensearch.index.shard.ShardPath;
+import org.opensearch.index.store.FsDirectoryFactory;
+import org.opensearch.index.store.Store;
+import org.opensearch.index.translog.Translog;
+import org.opensearch.index.translog.TranslogConfig;
+import org.opensearch.plugins.PluginsService;
+import org.opensearch.plugins.SearchBackEndPlugin;
+import org.opensearch.test.DummyShardLock;
+import org.opensearch.test.IndexSettingsModule;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.threadpool.TestThreadPool;
+import org.opensearch.threadpool.ThreadPool;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.opensearch.index.engine.EngineTestCase.createParsedDoc;
+import static org.opensearch.index.engine.EngineTestCase.tombstoneDocSupplier;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Abstract base class for testing {@link DataFormatAwareEngine} with any
+ * {@link IndexingExecutionEngine} implementation.
+ *
+ * <p>Subclasses provide the engine-specific components via {@link #createDataFormatPlugin()}
+ * and {@link #createSearchBackEndPlugin()}. The base class handles all DFAE lifecycle,
+ * translog, store, and commit infrastructure.
+ *
+ * <p>Tests cover: indexing, refresh, flush, catalog snapshots, concurrency,
+ * merge invariants, and failure handling — all driven through the real DFAE
+ * orchestration layer with the injected engine.
+ */
+public abstract class AbstractDataFormatAwareEngineTestCase extends OpenSearchTestCase {
+
+    protected ThreadPool threadPool;
+    protected Store store;
+    protected ShardId shardId;
+    protected AtomicLong primaryTerm;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        shardId = new ShardId(new Index("test", "_na_"), 0);
+        primaryTerm = new AtomicLong(randomLongBetween(1, Long.MAX_VALUE));
+        threadPool = buildThreadPool();
+        store = createStore();
+    }
+
+    /**
+     * Override to provide a custom {@link ThreadPool} with plugin-specific executors
+     * (e.g., the {@code parquet_native_write} executor for the Parquet engine).
+     * Default creates a standard {@link TestThreadPool}.
+     */
+    protected ThreadPool buildThreadPool() {
+        return new TestThreadPool(getClass().getName());
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        try {
+            store.close();
+        } finally {
+            terminate(threadPool);
+        }
+        super.tearDown();
+    }
+
+    // ── Extension points ──
+
+    /** Returns the DataFormatPlugin that provides the IndexingExecutionEngine under test. */
+    protected abstract DataFormatPlugin createDataFormatPlugin();
+
+    /** Returns the SearchBackEndPlugin for reader manager creation. */
+    protected abstract SearchBackEndPlugin<?> createSearchBackEndPlugin();
+
+    /** Returns the data format name (e.g., "composite", "parquet"). */
+    protected abstract String dataFormatName();
+
+    /** Override to provide a custom CommitterFactory (e.g., LuceneCommitterFactory). Default uses InMemoryCommitter. */
+    protected CommitterFactory createCommitterFactory(Store store) {
+        return config -> new InMemoryCommitter(store);
+    }
+
+    /** Override to add plugin-specific index settings (e.g., sort config, parquet settings). */
+    protected Settings additionalIndexSettings() {
+        return Settings.EMPTY;
+    }
+
+    // ── Infrastructure ──
+
+    /**
+     * Creates a fresh {@link Store} backed by a temporary directory for each test.
+     * Subclasses may override to provide a store with custom directory implementations.
+     */
+    protected Store createStore() throws IOException {
+        Directory dir = newDirectory();
+        IndexSettings indexSettings = IndexSettingsModule.newIndexSettings(
+            "test",
+            Settings.builder()
+                .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+                .put(IndexSettings.INDEX_SOFT_DELETES_SETTING.getKey(), true)
+                .build()
+        );
+        Path path = createTempDir().resolve(shardId.getIndex().getUUID()).resolve(String.valueOf(shardId.id()));
+        ShardPath shardPath = new ShardPath(false, path, path, shardId);
+        return new Store(
+            shardId,
+            indexSettings,
+            dir,
+            new DummyShardLock(shardId),
+            Store.OnClose.EMPTY,
+            shardPath,
+            new FsDirectoryFactory()
+        );
+    }
+
+    /**
+     * Bootstraps the store's Lucene commit with the metadata that {@link DataFormatAwareEngine}
+     * expects: translog UUID, sequence number markers, and history UUID.
+     */
+    protected void bootstrapStoreWithMetadata(Store store, String translogUUID) throws IOException {
+        try (
+            IndexWriter writer = new IndexWriter(
+                store.directory(),
+                new IndexWriterConfig(Lucene.STANDARD_ANALYZER).setMergePolicy(NoMergePolicy.INSTANCE)
+                    .setOpenMode(IndexWriterConfig.OpenMode.CREATE)
+            )
+        ) {
+            Map<String, String> commitData = new HashMap<>();
+            commitData.put(Translog.TRANSLOG_UUID_KEY, translogUUID);
+            commitData.put(SequenceNumbers.LOCAL_CHECKPOINT_KEY, Long.toString(SequenceNumbers.NO_OPS_PERFORMED));
+            commitData.put(SequenceNumbers.MAX_SEQ_NO, Long.toString(SequenceNumbers.NO_OPS_PERFORMED));
+            commitData.put(Engine.MAX_UNSAFE_AUTO_ID_TIMESTAMP_COMMIT_ID, "-1");
+            commitData.put(Engine.HISTORY_UUID_KEY, UUID.randomUUID().toString());
+            writer.setLiveCommitData(commitData.entrySet());
+            writer.commit();
+        }
+    }
+
+    /**
+     * Creates a fully wired {@link DataFormatAwareEngine} with translog, store, and the
+     * plugin-provided {@link IndexingExecutionEngine}. Each call creates a fresh translog
+     * and bootstraps the store's commit metadata.
+     */
+    protected DataFormatAwareEngine createEngine() throws IOException {
+        Path translogPath = createTempDir();
+        String uuid = Translog.createEmptyTranslog(translogPath, SequenceNumbers.NO_OPS_PERFORMED, shardId, primaryTerm.get());
+        bootstrapStoreWithMetadata(store, uuid);
+        return new DataFormatAwareEngine(buildEngineConfig(store, translogPath, List.of(), List.of()));
+    }
+
+    /**
+     * Builds the {@link EngineConfig} wiring together the store, translog, data format registry,
+     * committer factory, and refresh listeners. Subclasses may override to add engine-specific
+     * configuration (e.g., {@link org.opensearch.index.codec.CodecService} for Lucene).
+     */
+    protected EngineConfig buildEngineConfig(
+        Store store,
+        Path translogPath,
+        List<ReferenceManager.RefreshListener> externalListeners,
+        List<ReferenceManager.RefreshListener> internalListeners
+    ) {
+        Settings.Builder settingsBuilder = Settings.builder()
+            .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+            .put(IndexSettings.INDEX_SOFT_DELETES_SETTING.getKey(), true)
+            .put(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), true)
+            .put(IndexSettings.PLUGGABLE_DATAFORMAT_VALUE_SETTING.getKey(), dataFormatName())
+            .put(additionalIndexSettings());
+        IndexSettings indexSettings = IndexSettingsModule.newIndexSettings("test", settingsBuilder.build());
+        TranslogConfig translogConfig = new TranslogConfig(
+            shardId,
+            translogPath,
+            indexSettings,
+            BigArrays.NON_RECYCLING_INSTANCE,
+            "",
+            false
+        );
+        DataFormatRegistry registry = createRegistry();
+        CommitterFactory committerFactory = createCommitterFactory(store);
+
+        return new EngineConfig.Builder().shardId(shardId)
+            .threadPool(threadPool)
+            .indexSettings(indexSettings)
+            .store(store)
+            .mergePolicy(NoMergePolicy.INSTANCE)
+            .translogConfig(translogConfig)
+            .flushMergesAfter(TimeValue.timeValueMinutes(5))
+            .externalRefreshListener(externalListeners)
+            .internalRefreshListener(internalListeners)
+            .globalCheckpointSupplier(() -> SequenceNumbers.NO_OPS_PERFORMED)
+            .retentionLeasesSupplier(() -> RetentionLeases.EMPTY)
+            .primaryTermSupplier(primaryTerm::get)
+            .tombstoneDocSupplier(tombstoneDocSupplier())
+            .dataFormatRegistry(registry)
+            .mapperService(createMockMapperService(indexSettings))
+            .committerFactory(committerFactory)
+            .build();
+    }
+
+    /**
+     * Creates a mock {@link MapperService} that returns
+     * field types for metadata fields required by {@link DataFormatAwareEngine#indexIntoEngine}.
+     * Subclasses may override to provide additional field type mappings.
+     */
+    protected MapperService createMockMapperService(IndexSettings indexSettings) {
+        MapperService ms = mock(MapperService.class);
+        org.opensearch.index.mapper.MappedFieldType versionFieldType = mock(org.opensearch.index.mapper.MappedFieldType.class);
+        when(versionFieldType.typeName()).thenReturn("_version");
+        when(versionFieldType.name()).thenReturn("_version");
+        org.opensearch.index.mapper.MappedFieldType seqNoFieldType = mock(org.opensearch.index.mapper.MappedFieldType.class);
+        when(seqNoFieldType.typeName()).thenReturn("_seq_no");
+        when(seqNoFieldType.name()).thenReturn("_seq_no");
+        when(ms.fieldType("_version")).thenReturn(versionFieldType);
+        when(ms.fieldType("_seq_no")).thenReturn(seqNoFieldType);
+        when(ms.getIndexSettings()).thenReturn(indexSettings);
+        return ms;
+    }
+
+    @SuppressWarnings("unchecked")
+    private DataFormatRegistry createRegistry() {
+        PluginsService pluginsService = mock(PluginsService.class);
+        when(pluginsService.filterPlugins(DataFormatPlugin.class)).thenReturn(List.of(createDataFormatPlugin()));
+        when(pluginsService.filterPlugins(SearchBackEndPlugin.class)).thenReturn(List.of(createSearchBackEndPlugin()));
+        return new DataFormatRegistry(pluginsService);
+    }
+
+    // ── Helpers ──
+
+    protected Engine.Index indexOp(ParsedDocument doc) {
+        return new Engine.Index(
+            new Term(IdFieldMapper.NAME, Uid.encodeId(doc.id())),
+            doc,
+            SequenceNumbers.UNASSIGNED_SEQ_NO,
+            primaryTerm.get(),
+            Versions.MATCH_ANY,
+            VersionType.INTERNAL,
+            Engine.Operation.Origin.PRIMARY,
+            System.nanoTime(),
+            -1,
+            false,
+            SequenceNumbers.UNASSIGNED_SEQ_NO,
+            0
+        );
+    }
+
+    /** Override to provide a custom DocumentInput for the engine under test. Default uses MockDocumentInput. */
+    protected DocumentInput<?> createDocumentInput() {
+        return new MockDocumentInput();
+    }
+
+    protected ParsedDocument createParsedDocWithInput(String id, String routing) {
+        ParsedDocument base = createParsedDoc(id, routing);
+        return new ParsedDocument(
+            base.version(),
+            SeqNoFieldMapper.SequenceIDFields.emptySeqID(),
+            base.id(),
+            base.routing(),
+            base.docs(),
+            base.source(),
+            base.getMediaType(),
+            null,
+            createDocumentInput()
+        );
+    }
+
+    // ── Common tests ──
+
+    /** Indexes documents, refreshes, and verifies segments have unique generations and positive row counts. */
+    public void testIndexAndRefreshProducesSegments() throws IOException {
+        try (DataFormatAwareEngine engine = createEngine()) {
+            int numDocs = randomIntBetween(3, 10);
+            for (int i = 0; i < numDocs; i++) {
+                Engine.IndexResult result = engine.index(indexOp(createParsedDocWithInput(Integer.toString(i), null)));
+                assertThat(result.getSeqNo(), equalTo((long) i));
+            }
+            engine.refresh("test");
+
+            try (GatedCloseable<CatalogSnapshot> ref = engine.acquireSnapshot()) {
+                CatalogSnapshot snapshot = ref.get();
+                assertThat(snapshot.getSegments().size(), greaterThan(0));
+                // Verify segment generation uniqueness
+                Set<Long> gens = new HashSet<>();
+                for (Segment seg : snapshot.getSegments()) {
+                    assertTrue("duplicate generation: " + seg.generation(), gens.add(seg.generation()));
+                    assertThat(seg.dfGroupedSearchableFiles().isEmpty(), equalTo(false));
+                    for (WriterFileSet wfs : seg.dfGroupedSearchableFiles().values()) {
+                        assertThat(wfs.numRows(), greaterThan(0L));
+                        assertThat(wfs.files().isEmpty(), equalTo(false));
+                    }
+                }
+            }
+            assertThat(engine.getProcessedLocalCheckpoint(), equalTo((long) numDocs - 1));
+            assertThat(engine.lastRefreshedCheckpoint(), equalTo((long) numDocs - 1));
+        }
+    }
+
+    /** Flushes after indexing and verifies the catalog snapshot preserves total row count. */
+    public void testFlushCommitsAndPreservesData() throws IOException {
+        try (DataFormatAwareEngine engine = createEngine()) {
+            engine.translogManager().recoverFromTranslog(ignore -> 0, engine.getProcessedLocalCheckpoint(), Long.MAX_VALUE);
+            int numDocs = randomIntBetween(3, 10);
+            for (int i = 0; i < numDocs; i++) {
+                engine.index(indexOp(createParsedDocWithInput(Integer.toString(i), null)));
+            }
+            engine.flush(false, true);
+
+            try (GatedCloseable<CatalogSnapshot> ref = engine.acquireSnapshot()) {
+                CatalogSnapshot snapshot = ref.get();
+                assertThat(snapshot.getSegments().size(), greaterThan(0));
+                long totalRows = snapshot.getSegments()
+                    .stream()
+                    .flatMap(s -> s.dfGroupedSearchableFiles().values().stream())
+                    .mapToLong(WriterFileSet::numRows)
+                    .sum();
+                assertThat(totalRows, equalTo((long) numDocs));
+            }
+            assertThat(engine.getProcessedLocalCheckpoint(), equalTo((long) numDocs - 1));
+        }
+    }
+
+    /** Multi-threaded indexing must produce a contiguous checkpoint with no gaps. */
+    public void testConcurrentIndexingPreservesCheckpoint() throws Exception {
+        try (DataFormatAwareEngine engine = createEngine()) {
+            int numThreads = randomIntBetween(2, 4);
+            int docsPerThread = randomIntBetween(10, 25);
+            CyclicBarrier barrier = new CyclicBarrier(numThreads);
+            AtomicInteger failures = new AtomicInteger(0);
+            AtomicLong maxSeqNo = new AtomicLong(-1);
+
+            Thread[] threads = new Thread[numThreads];
+            for (int t = 0; t < numThreads; t++) {
+                final int threadId = t;
+                threads[t] = new Thread(() -> {
+                    try {
+                        barrier.await();
+                        for (int d = 0; d < docsPerThread; d++) {
+                            Engine.IndexResult result = engine.index(indexOp(createParsedDocWithInput(threadId + "_" + d, null)));
+                            maxSeqNo.accumulateAndGet(result.getSeqNo(), Math::max);
+                        }
+                    } catch (Exception e) {
+                        failures.incrementAndGet();
+                    }
+                });
+                threads[t].start();
+            }
+            for (Thread t : threads)
+                t.join();
+
+            assertThat(failures.get(), equalTo(0));
+            int totalDocs = numThreads * docsPerThread;
+            assertThat(maxSeqNo.get(), equalTo((long) totalDocs - 1));
+            assertThat(engine.getProcessedLocalCheckpoint(), equalTo((long) totalDocs - 1));
+        }
+    }
+
+    /** Each refresh cycle produces a new segment; all generations must be unique. */
+    public void testMultipleRefreshesAccumulateSegmentsWithUniqueGenerations() throws IOException {
+        try (DataFormatAwareEngine engine = createEngine()) {
+            int numBatches = randomIntBetween(3, 6);
+            for (int batch = 0; batch < numBatches; batch++) {
+                engine.index(indexOp(createParsedDocWithInput(Integer.toString(batch), null)));
+                engine.refresh("batch-" + batch);
+            }
+
+            try (GatedCloseable<CatalogSnapshot> ref = engine.acquireSnapshot()) {
+                CatalogSnapshot snapshot = ref.get();
+                assertThat(snapshot.getSegments().size(), equalTo(numBatches));
+                // Verify all generations are unique
+                Set<Long> gens = new HashSet<>();
+                for (Segment seg : snapshot.getSegments()) {
+                    assertTrue("duplicate generation: " + seg.generation(), gens.add(seg.generation()));
+                }
+                // Verify total row count
+                long totalRows = snapshot.getSegments()
+                    .stream()
+                    .flatMap(s -> s.dfGroupedSearchableFiles().values().stream())
+                    .mapToLong(WriterFileSet::numRows)
+                    .sum();
+                assertThat(totalRows, equalTo((long) numBatches));
+            }
+        }
+    }
+
+    /** Snapshot generation must strictly increase across refreshes. */
+    public void testSnapshotGenerationAdvancesMonotonically() throws IOException {
+        try (DataFormatAwareEngine engine = createEngine()) {
+            long prevGen = -1;
+            for (int i = 0; i < randomIntBetween(3, 6); i++) {
+                engine.index(indexOp(createParsedDocWithInput(Integer.toString(i), null)));
+                engine.refresh("cycle-" + i);
+                try (GatedCloseable<CatalogSnapshot> ref = engine.acquireSnapshot()) {
+                    long gen = ref.get().getGeneration();
+                    assertThat("generation must advance monotonically", gen, greaterThan(prevGen));
+                    prevGen = gen;
+                }
+            }
+        }
+    }
+
+    /** Every primary-origin index operation must produce a non-null translog location. */
+    public void testTranslogRecordsAllPrimaryOps() throws IOException {
+        try (DataFormatAwareEngine engine = createEngine()) {
+            int numDocs = randomIntBetween(5, 15);
+            for (int i = 0; i < numDocs; i++) {
+                Engine.IndexResult result = engine.index(indexOp(createParsedDocWithInput(Integer.toString(i), null)));
+                assertThat(result.getTranslogLocation(), notNullValue());
+            }
+            assertThat(engine.translogManager().getTranslogStats().estimatedNumberOfOperations(), equalTo(numDocs));
+        }
+    }
+
+    /** Concurrent indexing followed by refresh and flush must preserve total row count. */
+    public void testConcurrentIndexThenRefreshAndFlush() throws Exception {
+        try (DataFormatAwareEngine engine = createEngine()) {
+            engine.translogManager().recoverFromTranslog(ignore -> 0, engine.getProcessedLocalCheckpoint(), Long.MAX_VALUE);
+            int totalDocs = randomIntBetween(20, 50);
+            AtomicInteger failures = new AtomicInteger(0);
+
+            // Index concurrently
+            int numThreads = randomIntBetween(2, 4);
+            CyclicBarrier barrier = new CyclicBarrier(numThreads);
+            AtomicInteger docCounter = new AtomicInteger(0);
+            Thread[] threads = new Thread[numThreads];
+            for (int t = 0; t < numThreads; t++) {
+                threads[t] = new Thread(() -> {
+                    try {
+                        barrier.await();
+                        int idx;
+                        while ((idx = docCounter.getAndIncrement()) < totalDocs) {
+                            engine.index(indexOp(createParsedDocWithInput(Integer.toString(idx), null)));
+                        }
+                    } catch (Exception e) {
+                        failures.incrementAndGet();
+                    }
+                });
+                threads[t].start();
+            }
+            for (Thread t : threads)
+                t.join();
+            assertThat(failures.get(), equalTo(0));
+
+            // Refresh and flush
+            engine.refresh("after-indexing");
+            engine.flush(false, true);
+
+            assertThat(engine.getProcessedLocalCheckpoint(), equalTo((long) totalDocs - 1));
+            try (GatedCloseable<CatalogSnapshot> ref = engine.acquireSnapshot()) {
+                assertThat(ref.get().getSegments().size(), greaterThan(0));
+                long totalRows = ref.get()
+                    .getSegments()
+                    .stream()
+                    .flatMap(s -> s.dfGroupedSearchableFiles().values().stream())
+                    .mapToLong(WriterFileSet::numRows)
+                    .sum();
+                assertThat("total rows must match indexed docs", totalRows, equalTo((long) totalDocs));
+            }
+        }
+    }
+
+    /** DocStats count must reflect the number of indexed documents after refresh. */
+    public void testDocStatsReflectsIndexedDocuments() throws IOException {
+        try (DataFormatAwareEngine engine = createEngine()) {
+            int numDocs = randomIntBetween(3, 10);
+            for (int i = 0; i < numDocs; i++) {
+                engine.index(indexOp(createParsedDocWithInput(Integer.toString(i), null)));
+            }
+            engine.refresh("test");
+
+            var stats = engine.docStats();
+            assertThat(stats.getCount(), equalTo((long) numDocs));
+            assertThat(stats.getCount(), greaterThanOrEqualTo(0L));
+        }
+    }
+}

--- a/test/framework/src/main/java/org/opensearch/index/engine/dataformat/stub/MockDocumentInput.java
+++ b/test/framework/src/main/java/org/opensearch/index/engine/dataformat/stub/MockDocumentInput.java
@@ -37,5 +37,10 @@ public class MockDocumentInput implements DocumentInput<Map<String, Object>> {
     }
 
     @Override
+    public long getFieldCount(String fieldName) {
+        return fields.containsKey(fieldName) ? 1 : 0;
+    }
+
+    @Override
     public void close() {}
 }

--- a/test/framework/src/main/java/org/opensearch/index/mapper/MapperServiceTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/index/mapper/MapperServiceTestCase.java
@@ -353,7 +353,7 @@ public abstract class MapperServiceTestCase extends OpenSearchTestCase {
     /**
      * A simple capturing {@link DocumentInput} that records addField calls for assertion in pluggable dataformat tests.
      */
-    protected static class CapturingDocumentInput implements DocumentInput<Object> {
+    public static class CapturingDocumentInput implements DocumentInput<Object> {
         private final List<Map.Entry<MappedFieldType, Object>> capturedFields = new ArrayList<>();
 
         @Override
@@ -368,6 +368,11 @@ public abstract class MapperServiceTestCase extends OpenSearchTestCase {
 
         @Override
         public void setRowId(String rowIdFieldName, long rowId) {}
+
+        @Override
+        public long getFieldCount(String fieldName) {
+            return capturedFields.stream().filter(e -> e.getKey().name().equals(fieldName)).count();
+        }
 
         @Override
         public void close() {}


### PR DESCRIPTION
Improve Lucene field parser logic to use BytesRef directly

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Add field support for metadata fields.
Id, seq no, version, primary term are the non-nullable fields which should be present in every document.
Currently, the code is with assumption around parquet as primary, with lucene containing indices for seq no and id.


### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
