### PR TITLE
Wire NativeStoreHandle to DataFusion reader stack

### DIFF
--- a/sandbox/libs/tiered-storage/src/main/rust/src/ffm.rs
+++ b/sandbox/libs/tiered-storage/src/main/rust/src/ffm.rs
@@ -219,6 +219,8 @@ pub extern "C" fn ts_remove_file(
     let store = unsafe { arc_from_ptr(store_ptr) }?;
     let path = unsafe { str_from_raw(path_ptr, path_len) }
         .map_err(|e| format!("ts_remove_file path: {}", e))?;
+    // Strip leading "/" — object_store::Path normalizes paths without leading slash
+    let path = path.strip_prefix('/').unwrap_or(path);
 
     store.registry().remove(path, false);
 

--- a/sandbox/libs/tiered-storage/src/main/rust/src/registry/tiered_registry.rs
+++ b/sandbox/libs/tiered-storage/src/main/rust/src/registry/tiered_registry.rs
@@ -53,7 +53,9 @@ impl TieredStorageRegistry {
     /// If `prefix` is empty or `"/"`, returns all entries.
     #[must_use]
     pub fn entries_matching(&self, prefix: &str) -> Vec<(String, FileLocation, u64)> {
-        let match_all = prefix.is_empty() || prefix == "/";
+        // Strip leading "/" — keys are stored without leading slash
+        let prefix = prefix.strip_prefix('/').unwrap_or(prefix);
+        let match_all = prefix.is_empty();
         self.files
             .iter()
             .filter(|e| match_all || e.key().starts_with(prefix))
@@ -86,21 +88,29 @@ impl fmt::Display for TieredStorageRegistry {
 
 impl FileRegistry for TieredStorageRegistry {
     fn register(&self, key: &str, value: TieredFileEntry) {
+        // Strip leading "/" — keys are stored without leading slash
+        let key = key.strip_prefix('/').unwrap_or(key);
         self.files.insert(key.to_string(), value);
     }
 
     fn get(&self, key: &str) -> Option<ReadGuard<'_>> {
+        // Strip leading "/" — keys are stored without leading slash
+        let key = key.strip_prefix('/').unwrap_or(key);
         let entry = self.files.get(key)?;
         Some(ReadGuard::new(entry))
     }
 
     fn update(&self, key: &str, f: impl FnOnce(&mut TieredFileEntry)) {
+        // Strip leading "/" — keys are stored without leading slash
+        let key = key.strip_prefix('/').unwrap_or(key);
         if let Some(mut entry) = self.files.get_mut(key) {
             f(entry.value_mut());
         }
     }
 
     fn remove(&self, key: &str, force: bool) -> bool {
+        // Strip leading "/" — keys are stored without leading slash
+        let key = key.strip_prefix('/').unwrap_or(key);
         if force {
             self.files.remove(key).is_some()
         } else {
@@ -120,6 +130,8 @@ impl FileRegistry for TieredStorageRegistry {
     }
 
     fn remove_by_prefix(&self, prefix: &str, force: bool) -> usize {
+        // Strip leading "/" — keys are stored without leading slash
+        let prefix = prefix.strip_prefix('/').unwrap_or(prefix);
         if force {
             let mut removed = 0usize;
             self.files.retain(|key, _| {
@@ -150,8 +162,11 @@ impl FileRegistry for TieredStorageRegistry {
 
     fn purge_stale(&self, valid_keys: &HashSet<String>) -> usize {
         let before = self.files.len();
-        self.files
-            .retain(|key, _| valid_keys.contains(key.as_str()));
+        self.files.retain(|key, _| {
+            // Check both with and without leading "/" since callers may pass either form
+            valid_keys.contains(key.as_str())
+                || valid_keys.contains(&format!("/{}", key))
+        });
         let removed = before.saturating_sub(self.files.len());
         if removed > 0 {
             native_bridge_common::log_info!(

--- a/sandbox/libs/tiered-storage/src/main/rust/src/tiered_object_store.rs
+++ b/sandbox/libs/tiered-storage/src/main/rust/src/tiered_object_store.rs
@@ -162,6 +162,54 @@ impl TieredObjectStore {
             None
         }
     }
+
+    /// Fast-path head response from registry or directory existence check.
+    /// Returns `Some(GetResult)` if the head can be answered without I/O,
+    /// `None` if the caller should fall through to the normal get_opts path.
+    fn try_head_from_registry(&self, location: &Path, path_str: &str) -> Option<OsResult<GetResult>> {
+        // Check registry for cached file size
+        if let Some(guard) = self.registry.get(path_str) {
+            let size = guard.size();
+            if size > 0 {
+                let meta = ObjectMeta {
+                    location: location.clone(),
+                    last_modified: chrono::DateTime::<chrono::Utc>::default(),
+                    size,
+                    e_tag: None,
+                    version: None,
+                };
+                return Some(Ok(GetResult {
+                    payload: object_store::GetResultPayload::Stream(
+                        futures::stream::empty().boxed(),
+                    ),
+                    meta,
+                    range: 0..size,
+                    attributes: Default::default(),
+                }));
+            }
+        }
+        // Directory existence check: if path looks like a directory and registry
+        // has entries, return synthetic metadata. Handles DataFusion's ListingTable
+        // directory existence check on warm where no local directory exists.
+        if (!path_str.contains('.') || path_str.ends_with('/')) && self.registry.len() > 0 {
+            let meta = ObjectMeta {
+                location: location.clone(),
+                last_modified: chrono::DateTime::<chrono::Utc>::default(),
+                size: 0,
+                e_tag: None,
+                version: None,
+            };
+            return Some(Ok(GetResult {
+                payload: object_store::GetResultPayload::Stream(
+                    futures::stream::empty().boxed(),
+                ),
+                meta,
+                range: 0..0,
+                attributes: Default::default(),
+            }));
+        }
+        None
+    }
 }
 
 impl fmt::Debug for TieredObjectStore {
@@ -224,27 +272,10 @@ impl ObjectStore for TieredObjectStore {
     async fn get_opts(&self, location: &Path, options: GetOptions) -> OsResult<GetResult> {
         let path_str = location.as_ref();
 
-        // Fast path for head: return cached size from registry if available
+        // Fast path for head: check registry/directory without I/O
         if options.head {
-            if let Some(guard) = self.registry.get(path_str) {
-                let size = guard.size();
-                if size > 0 {
-                    let meta = ObjectMeta {
-                        location: location.clone(),
-                        last_modified: chrono::DateTime::<chrono::Utc>::default(),
-                        size,
-                        e_tag: None,
-                        version: None,
-                    };
-                    return Ok(GetResult {
-                        payload: object_store::GetResultPayload::Stream(
-                            futures::stream::empty().boxed(),
-                        ),
-                        meta,
-                        range: 0..size,
-                        attributes: Default::default(),
-                    });
-                }
+            if let Some(result) = self.try_head_from_registry(location, path_str) {
+                return result;
             }
         }
 

--- a/sandbox/libs/tiered-storage/src/main/rust/src/tiered_object_store_tests.rs
+++ b/sandbox/libs/tiered-storage/src/main/rust/src/tiered_object_store_tests.rs
@@ -892,3 +892,58 @@ fn test_delete_during_active_guard() {
 fn local_entry() -> TieredFileEntry {
     TieredFileEntry::new(FileLocation::Local, None)
 }
+
+// -- head() directory existence check tests ---------------------------------
+
+#[tokio::test]
+async fn test_head_directory_path_returns_synthetic_when_registry_has_entries() {
+    let (registry, _local, _remote, tiered) = setup();
+
+    // Register a file so registry is non-empty
+    let entry = TieredFileEntry::with_size(FileLocation::Remote, Some(Arc::from("remote/a.parquet")), 1024);
+    registry.register("data/parquet/a.parquet", entry);
+
+    // head() on a directory path (no file extension) should return synthetic metadata
+    let result = tiered.head(&Path::from("data/parquet")).await;
+    assert!(result.is_ok());
+    let meta = result.unwrap();
+    assert_eq!(meta.size, 0);
+    assert_eq!(meta.location, Path::from("data/parquet"));
+}
+
+#[tokio::test]
+async fn test_head_directory_path_with_trailing_slash() {
+    let (registry, _local, _remote, tiered) = setup();
+
+    let entry = TieredFileEntry::with_size(FileLocation::Remote, Some(Arc::from("remote/b.parquet")), 2048);
+    registry.register("data/parquet/b.parquet", entry);
+
+    // Trailing slash also treated as directory
+    let result = tiered.head(&Path::from("data/parquet/")).await;
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap().size, 0);
+}
+
+#[tokio::test]
+async fn test_head_directory_path_returns_not_found_when_registry_empty() {
+    let (_registry, _local, _remote, tiered) = setup();
+
+    // Registry is empty — directory doesn't "exist"
+    let result = tiered.head(&Path::from("data/parquet")).await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn test_head_file_path_not_treated_as_directory() {
+    let (registry, _local, _remote, tiered) = setup();
+
+    // Register a file so registry is non-empty
+    let entry = TieredFileEntry::with_size(FileLocation::Remote, Some(Arc::from("remote/c.parquet")), 512);
+    registry.register("data/parquet/c.parquet", entry);
+
+    // head() on a file path (has extension) should NOT use directory check
+    // — it should try registry lookup, then remote, then local
+    let result = tiered.head(&Path::from("data/parquet/nonexistent.parquet")).await;
+    // Not in registry, not local → NotFound
+    assert!(result.is_err());
+}

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/api.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/api.rs
@@ -52,7 +52,7 @@ use datafusion::execution::{SessionState, SessionStateBuilder};
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::prelude::SessionConfig;
 use futures::TryStreamExt;
-use object_store::ObjectStoreExt;
+use object_store::{ObjectStore, ObjectStoreExt};
 
 use crate::cancellation;
 use crate::cross_rt_stream::CrossRtStream;
@@ -150,6 +150,10 @@ impl DataFusionRuntime {
 pub struct ShardView {
     pub table_path: ListingTableUrl,
     pub object_metas: Arc<Vec<object_store::ObjectMeta>>,
+    /// Per-shard object store. When a native store is provided (store_ptr > 0),
+    /// this routes reads through TieredObjectStore (local + remote).
+    /// When no store is provided, uses default LocalFileSystem.
+    pub store: Arc<dyn ObjectStore>,
 }
 
 /// Creates a DataFusion global runtime with the given resource limits.
@@ -250,19 +254,29 @@ pub unsafe fn set_memory_pool_limit(ptr: i64, new_limit: i64) -> Result<(), Stri
 ///
 /// Returns a heap-allocated pointer (as i64) to `ShardView`.
 /// Caller must call `close_reader` exactly once to free it.
+///
+/// `store_ptr`: 0 = use default LocalFileSystem (hot path),
+/// >0 = Box<Arc<dyn ObjectStore>> pointer (routes reads through TieredObjectStore).
 pub fn create_reader(
     table_path: &str,
     mut filenames: Vec<String>,
     tokio_rt_manager: &RuntimeManager,
+    store_ptr: i64,
 ) -> Result<i64, DataFusionError> {
     filenames.sort();
 
     let table_url = ListingTableUrl::parse(table_path)
         .map_err(|e| DataFusionError::Execution(format!("Invalid table path: {}", e)))?;
 
-    // TODO: use global runtime's object store instead of building a throwaway RuntimeEnv
-    let default_rt = RuntimeEnvBuilder::new().build()?;
-    let store = default_rt.object_store(&table_url)?;
+    // Resolve the object store: if store_ptr > 0, clone the Arc from the boxed pointer.
+    // Otherwise use default LocalFileSystem.
+    let store: Arc<dyn ObjectStore> = if store_ptr > 0 {
+        let boxed = unsafe { &*(store_ptr as *const Arc<dyn ObjectStore>) };
+        Arc::clone(boxed)
+    } else {
+        let default_rt = RuntimeEnvBuilder::new().build()?;
+        default_rt.object_store(&table_url)?
+    };
 
     let object_metas = tokio_rt_manager.io_runtime.block_on(create_object_metas(
         store.as_ref(),
@@ -273,6 +287,7 @@ pub fn create_reader(
     let shard_view = ShardView {
         table_path: table_url,
         object_metas: Arc::new(object_metas),
+        store,
     };
     Ok(Box::into_raw(Box::new(shard_view)) as i64)
 }
@@ -347,6 +362,7 @@ pub async unsafe fn execute_query(
                 cpu_executor,
                 query_memory_pool,
                 &query_config,
+                Arc::clone(&shard_view.store),
             ).await
         }
     };

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/ffm.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/ffm.rs
@@ -123,6 +123,7 @@ pub unsafe extern "C" fn df_create_reader(
     files_ptr: *const *const u8,
     files_len_ptr: *const i64,
     files_count: i64,
+    store_ptr: i64,
 ) -> i64 {
     let table_path = str_from_raw(table_path_ptr, table_path_len)
         .map_err(|e| format!("df_create_reader: {}", e))?;
@@ -137,7 +138,7 @@ pub unsafe extern "C" fn df_create_reader(
         );
     }
     let mgr = get_rt_manager()?;
-    api::create_reader(table_path, filenames, &mgr).map_err(|e| e.to_string())
+    api::create_reader(table_path, filenames, &mgr, store_ptr).map_err(|e| e.to_string())
 }
 
 #[no_mangle]

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_executor.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_executor.rs
@@ -123,6 +123,12 @@ pub async fn execute_indexed_query(
         .build()
         .map_err(|e| DataFusionError::Execution(format!("runtime env: {}", e)))?;
 
+    // Register shard-specific object store on file:// scheme for this query.
+    runtime_env.register_object_store(
+        &url::Url::parse("file://").unwrap(),
+        Arc::clone(&shard_view.store),
+    );
+
     let mut config = SessionConfig::new();
     config.options_mut().execution.parquet.pushdown_filters = query_config.parquet_pushdown_filters;
     // Indexed path fans out via IndexedExec partitions (derived from

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/query_executor.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/query_executor.rs
@@ -23,6 +23,7 @@ use datafusion::execution::cache::{CacheAccessor, DefaultListFilesCache};
 use datafusion_substrait::logical_plan::consumer::from_substrait_plan;
 use log::error;
 use object_store::ObjectMeta;
+use object_store::ObjectStore;
 use prost::Message;
 use substrait::proto::Plan;
 
@@ -51,6 +52,7 @@ pub async fn execute_query(
     // wire up context_id correctly.
     query_memory_pool: Option<Arc<dyn datafusion::execution::memory_pool::MemoryPool>>,
     query_config: &crate::datafusion_query_config::DatafusionQueryConfig,
+    shard_store: Arc<dyn ObjectStore>,
 ) -> Result<i64, DataFusionError> {
     // Pre-populate the list-files cache so DataFusion doesn't re-list the directory
     let list_file_cache = Arc::new(DefaultListFilesCache::default());
@@ -86,6 +88,13 @@ pub async fn execute_query(
             error!("Failed to build runtime env: {}", e);
             e
         })?;
+
+    // Register shard-specific object store on file:// scheme for this query.
+    // Routes reads through TieredObjectStore (local + remote) or default LocalFileSystem.
+    runtime_env.register_object_store(
+        &url::Url::parse("file://").unwrap(),
+        shard_store,
+    );
 
     // Build a fresh session state per query. TODO : Tune this during planning per query
     let mut config = SessionConfig::new();

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/session_context.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/session_context.rs
@@ -103,6 +103,14 @@ pub async unsafe fn create_session_context(
         e
     })?;
 
+    // Register shard-specific object store on file:// scheme for this query.
+    // This is the instruction-based execution path (ShardScanInstructionHandler).
+    // Without this, queries use default LocalFileSystem and fail on warm.
+    runtime_env.register_object_store(
+        &url::Url::parse("file://").unwrap(),
+        Arc::clone(&shard_view.store),
+    );
+
     let mut config = SessionConfig::new();
     config.options_mut().execution.parquet.pushdown_filters = query_config.parquet_pushdown_filters;
     config.options_mut().execution.target_partitions = query_config.target_partitions;

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionPlugin.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionPlugin.java
@@ -28,6 +28,7 @@ import org.opensearch.index.engine.dataformat.DataFormatRegistry;
 import org.opensearch.index.engine.dataformat.ReaderManagerConfig;
 import org.opensearch.index.engine.exec.EngineReaderManager;
 import org.opensearch.plugins.ActionPlugin;
+import org.opensearch.plugins.NativeStoreHandle;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.plugins.SearchBackEndPlugin;
 import org.opensearch.repositories.RepositoriesService;
@@ -243,7 +244,8 @@ public class DataFusionPlugin extends Plugin implements SearchBackEndPlugin<Data
 
     @Override
     public EngineReaderManager<DatafusionReader> createReaderManager(ReaderManagerConfig settings) throws IOException {
-        return new DatafusionReaderManager(settings.format(), settings.shardPath(), dataFusionService);
+        NativeStoreHandle dataformatAwareStoreHandle = settings.dataformatAwareStoreHandles().get(settings.format());
+        return new DatafusionReaderManager(settings.format(), settings.shardPath(), dataFusionService, dataformatAwareStoreHandle);
     }
 
     @Override

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionReader.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionReader.java
@@ -13,6 +13,7 @@ import org.apache.logging.log4j.Logger;
 import org.opensearch.be.datafusion.nativelib.ReaderHandle;
 import org.opensearch.common.annotation.ExperimentalApi;
 import org.opensearch.index.engine.exec.WriterFileSet;
+import org.opensearch.plugins.NativeStoreHandle;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -38,14 +39,15 @@ public class DatafusionReader implements Closeable {
      *
      * @param directoryPath shard data directory
      * @param files The file metadata collection
+     * @param dataformatAwareStoreHandle per-format native store handle (null on hot, live on warm)
      */
-    public DatafusionReader(String directoryPath, Collection<WriterFileSet> files) {
+    public DatafusionReader(String directoryPath, Collection<WriterFileSet> files, NativeStoreHandle dataformatAwareStoreHandle) {
         this.directoryPath = directoryPath;
         String[] fileNames = new String[0];
         if (files != null) {
             fileNames = files.stream().flatMap(writerFileSet -> writerFileSet.files().stream()).toArray(String[]::new);
         }
-        readerHandle = new ReaderHandle(directoryPath, fileNames);
+        readerHandle = new ReaderHandle(directoryPath, fileNames, dataformatAwareStoreHandle);
     }
 
     /**

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionReaderManager.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionReaderManager.java
@@ -15,6 +15,7 @@ import org.opensearch.index.engine.dataformat.DataFormat;
 import org.opensearch.index.engine.exec.EngineReaderManager;
 import org.opensearch.index.engine.exec.coord.CatalogSnapshot;
 import org.opensearch.index.shard.ShardPath;
+import org.opensearch.plugins.NativeStoreHandle;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -40,17 +41,27 @@ public class DatafusionReaderManager implements EngineReaderManager<DatafusionRe
     private final DataFormat dataFormat;
     private final String directoryPath;
     private final DataFusionService dataFusionService;
+    private final NativeStoreHandle dataformatAwareStoreHandle;
 
     /**
      * Creates a reader manager.
      * @param dataFormat the data format for this reader
      * @param shardPath the shard path to read data from
      * @param dataFusionService node-level service for cache management
+     * @param dataformatAwareStoreHandle per-format native store handle for reads (null if not available).
+     *                                   Pointer is extracted at reader creation time via {@code getPointer()}.
+     *                                   0 means use default local file system.
      */
-    public DatafusionReaderManager(DataFormat dataFormat, ShardPath shardPath, DataFusionService dataFusionService) {
+    public DatafusionReaderManager(
+        DataFormat dataFormat,
+        ShardPath shardPath,
+        DataFusionService dataFusionService,
+        NativeStoreHandle dataformatAwareStoreHandle
+    ) {
         this.dataFormat = dataFormat;
         this.directoryPath = shardPath.getDataPath().resolve(dataFormat.name()).toString();
         this.dataFusionService = dataFusionService;
+        this.dataformatAwareStoreHandle = dataformatAwareStoreHandle;
     }
 
     @Override
@@ -88,7 +99,11 @@ public class DatafusionReaderManager implements EngineReaderManager<DatafusionRe
     public void afterRefresh(boolean didRefresh, CatalogSnapshot catalogSnapshot) throws IOException {
         if (didRefresh == false) return;
         if (readers.containsKey(catalogSnapshot)) return;
-        DatafusionReader reader = new DatafusionReader(directoryPath, catalogSnapshot.getSearchableFiles(dataFormat.name()));
+        DatafusionReader reader = new DatafusionReader(
+            directoryPath,
+            catalogSnapshot.getSearchableFiles(dataFormat.name()),
+            dataformatAwareStoreHandle
+        );
         readers.put(catalogSnapshot, reader);
     }
 

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/nativelib/NativeBridge.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/nativelib/NativeBridge.java
@@ -15,6 +15,7 @@ import org.opensearch.be.datafusion.stats.TaskMonitorStats;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.nativebridge.spi.NativeCall;
 import org.opensearch.nativebridge.spi.NativeLibraryLoader;
+import org.opensearch.plugins.NativeStoreHandle;
 
 import java.lang.foreign.FunctionDescriptor;
 import java.lang.foreign.Linker;
@@ -140,6 +141,7 @@ public final class NativeBridge {
                 ValueLayout.JAVA_LONG,
                 ValueLayout.ADDRESS,
                 ValueLayout.ADDRESS,
+                ValueLayout.JAVA_LONG,
                 ValueLayout.JAVA_LONG
             )
         );
@@ -562,12 +564,25 @@ public final class NativeBridge {
     /**
      * Creates a native reader. Returns an opaque native pointer.
      * Freed by {@link #closeDatafusionReader}.
+     *
+     * @param path the directory path
+     * @param files the file names
+     * @param dataformatAwareStoreHandle per-format native store handle (null = local, live = use store pointer)
      */
-    public static long createDatafusionReader(String path, String[] files) {
+    public static long createDatafusionReader(String path, String[] files, NativeStoreHandle dataformatAwareStoreHandle) {
+        long storePtr = 0L;
+        if (dataformatAwareStoreHandle != null) {
+            try {
+                storePtr = dataformatAwareStoreHandle.getPointer();
+            } catch (IllegalStateException e) {
+                // Handle closed between check and extraction — use default (local)
+                storePtr = 0L;
+            }
+        }
         try (var call = new NativeCall()) {
             var p = call.str(path);
             var f = call.strArray(files);
-            return call.invoke(CREATE_READER, p.segment(), p.len(), f.ptrs(), f.lens(), f.count());
+            return call.invoke(CREATE_READER, p.segment(), p.len(), f.ptrs(), f.lens(), f.count(), storePtr);
         }
     }
 

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/nativelib/ReaderHandle.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/nativelib/ReaderHandle.java
@@ -9,6 +9,7 @@
 package org.opensearch.be.datafusion.nativelib;
 
 import org.opensearch.analytics.backend.jni.NativeHandle;
+import org.opensearch.plugins.NativeStoreHandle;
 
 /**
  * Type-safe handle for native reader.
@@ -21,9 +22,10 @@ public final class ReaderHandle extends NativeHandle {
      * Creates a reader handle by allocating a native DataFusion reader for the given path and files.
      * @param path the directory path containing data files
      * @param files the array of file names to read
+     * @param dataformatAwareStoreHandle per-format native store handle (null = local, live = use store pointer)
      */
-    public ReaderHandle(String path, String[] files) {
-        super(NativeBridge.createDatafusionReader(path, files));
+    public ReaderHandle(String path, String[] files, NativeStoreHandle dataformatAwareStoreHandle) {
+        super(NativeBridge.createDatafusionReader(path, files, dataformatAwareStoreHandle));
         this.ownsPointer = true;
     }
 

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionNativeBridgeTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionNativeBridgeTests.java
@@ -13,6 +13,7 @@ import org.opensearch.be.datafusion.nativelib.NativeBridge;
 import org.opensearch.be.datafusion.nativelib.ReaderHandle;
 import org.opensearch.be.datafusion.nativelib.SessionContextHandle;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.plugins.NativeStoreHandle;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.lang.foreign.Arena;
@@ -61,7 +62,7 @@ public class DataFusionNativeBridgeTests extends OpenSearchTestCase {
         Files.copy(testParquet, dataDir.resolve("test.parquet"));
 
         // Create reader
-        ReaderHandle readerHandle = new ReaderHandle(dataDir.toString(), new String[] { "test.parquet" });
+        ReaderHandle readerHandle = new ReaderHandle(dataDir.toString(), new String[] { "test.parquet" }, null);
         assertTrue("Reader pointer should be non-zero", readerHandle.getPointer() != 0);
 
         // Close reader
@@ -80,7 +81,7 @@ public class DataFusionNativeBridgeTests extends OpenSearchTestCase {
         Path testParquet = Path.of(getClass().getClassLoader().getResource("test.parquet").toURI());
         Files.copy(testParquet, dataDir.resolve("test.parquet"));
 
-        ReaderHandle readerHandle = new ReaderHandle(dataDir.toString(), new String[] { "test.parquet" });
+        ReaderHandle readerHandle = new ReaderHandle(dataDir.toString(), new String[] { "test.parquet" }, null);
 
         // Create session context with table registered
         long queryConfigPtr;
@@ -134,5 +135,110 @@ public class DataFusionNativeBridgeTests extends OpenSearchTestCase {
         NativeBridge.streamClose(streamPtr);
         readerHandle.close();
         runtimeHandle.close();
+    }
+
+    /**
+     * End-to-end test: create a real TieredObjectStore via FFM, wrap it in NativeStoreHandle,
+     * and pass it to ReaderHandle. Proves the full native wiring works — Java → FFM → Rust
+     * tiered storage → DataFusion reader with a real object store backing reads.
+     */
+    public void testReaderWithRealNativeStoreHandle() throws Exception {
+        NativeBridge.initTokioRuntimeManager(2);
+        Path spillDir = createTempDir("datafusion-spill");
+        long runtimePtr = NativeBridge.createGlobalRuntime(64 * 1024 * 1024, 0L, spillDir.toString(), 32 * 1024 * 1024);
+
+        // Copy test parquet to a temp dir
+        Path dataDir = createTempDir("datafusion-data");
+        Path testParquet = Path.of(getClass().getClassLoader().getResource("test.parquet").toURI());
+        Files.copy(testParquet, dataDir.resolve("test.parquet"));
+
+        // Create a real TieredObjectStore via FFM (local-only, no remote)
+        // ts_create_tiered_object_store(0, 0) → default LocalFileSystem, no remote
+        long tieredStorePtr = NativeStoreTestHelper.createTieredObjectStore(0L, 0L);
+        assertTrue("TieredObjectStore pointer should be non-zero", tieredStorePtr > 0);
+
+        // Get a Box<Arc<dyn ObjectStore>> pointer for DataFusion
+        long boxPtr = NativeStoreTestHelper.getObjectStoreBoxPtr(tieredStorePtr);
+        assertTrue("Box pointer should be non-zero", boxPtr > 0);
+
+        // Wrap in NativeStoreHandle with proper cleanup
+        NativeStoreHandle storeHandle = new NativeStoreHandle(boxPtr, NativeStoreTestHelper::destroyObjectStoreBoxPtr);
+        assertTrue("NativeStoreHandle should be live", storeHandle.isLive());
+
+        // Create reader with the real store handle — this proves the full wiring
+        ReaderHandle readerHandle = new ReaderHandle(dataDir.toString(), new String[] { "test.parquet" }, storeHandle);
+        assertTrue("Reader pointer should be non-zero", readerHandle.getPointer() != 0);
+
+        // Clean up in reverse order
+        readerHandle.close();
+        storeHandle.close();
+        NativeStoreTestHelper.destroyTieredObjectStore(tieredStorePtr);
+        NativeBridge.closeGlobalRuntime(runtimePtr);
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // FFM helpers for TieredObjectStore (inline — avoids dependency on parquet-data-format)
+    // ═══════════════════════════════════════════════════════════════
+
+    private static final java.lang.invoke.MethodHandle TS_CREATE;
+    private static final java.lang.invoke.MethodHandle TS_DESTROY;
+    private static final java.lang.invoke.MethodHandle TS_GET_BOX_PTR;
+    private static final java.lang.invoke.MethodHandle TS_DESTROY_BOX_PTR;
+
+    static {
+        var lib = org.opensearch.nativebridge.spi.NativeLibraryLoader.symbolLookup();
+        var linker = java.lang.foreign.Linker.nativeLinker();
+        TS_CREATE = linker.downcallHandle(
+            lib.find("ts_create_tiered_object_store").orElseThrow(),
+            java.lang.foreign.FunctionDescriptor.of(
+                java.lang.foreign.ValueLayout.JAVA_LONG,
+                java.lang.foreign.ValueLayout.JAVA_LONG,
+                java.lang.foreign.ValueLayout.JAVA_LONG
+            )
+        );
+        TS_DESTROY = linker.downcallHandle(
+            lib.find("ts_destroy_tiered_object_store").orElseThrow(),
+            java.lang.foreign.FunctionDescriptor.of(java.lang.foreign.ValueLayout.JAVA_LONG, java.lang.foreign.ValueLayout.JAVA_LONG)
+        );
+        TS_GET_BOX_PTR = linker.downcallHandle(
+            lib.find("ts_get_object_store_box_ptr").orElseThrow(),
+            java.lang.foreign.FunctionDescriptor.of(java.lang.foreign.ValueLayout.JAVA_LONG, java.lang.foreign.ValueLayout.JAVA_LONG)
+        );
+        TS_DESTROY_BOX_PTR = linker.downcallHandle(
+            lib.find("ts_destroy_object_store_box_ptr").orElseThrow(),
+            java.lang.foreign.FunctionDescriptor.of(java.lang.foreign.ValueLayout.JAVA_LONG, java.lang.foreign.ValueLayout.JAVA_LONG)
+        );
+    }
+
+    private static long createTieredObjectStore(long localPtr, long remotePtr) {
+        try {
+            return org.opensearch.nativebridge.spi.NativeLibraryLoader.checkResult((long) TS_CREATE.invokeExact(localPtr, remotePtr));
+        } catch (Throwable t) {
+            throw new RuntimeException("Failed to create TieredObjectStore", t);
+        }
+    }
+
+    private static void destroyTieredObjectStore(long ptr) {
+        try {
+            org.opensearch.nativebridge.spi.NativeLibraryLoader.checkResult((long) TS_DESTROY.invokeExact(ptr));
+        } catch (Throwable t) {
+            throw new RuntimeException("Failed to destroy TieredObjectStore", t);
+        }
+    }
+
+    private static long getObjectStoreBoxPtr(long tieredStorePtr) {
+        try {
+            return org.opensearch.nativebridge.spi.NativeLibraryLoader.checkResult((long) TS_GET_BOX_PTR.invokeExact(tieredStorePtr));
+        } catch (Throwable t) {
+            throw new RuntimeException("Failed to get object store box ptr", t);
+        }
+    }
+
+    private static void destroyObjectStoreBoxPtr(long ptr) {
+        try {
+            org.opensearch.nativebridge.spi.NativeLibraryLoader.checkResult((long) TS_DESTROY_BOX_PTR.invokeExact(ptr));
+        } catch (Throwable t) {
+            throw new RuntimeException("Failed to destroy object store box ptr", t);
+        }
     }
 }

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionQueryExecutionTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionQueryExecutionTests.java
@@ -19,6 +19,7 @@ import org.opensearch.be.datafusion.nativelib.NativeBridge;
 import org.opensearch.be.datafusion.nativelib.ReaderHandle;
 import org.opensearch.be.datafusion.nativelib.StreamHandle;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.plugins.NativeStoreHandle;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.lang.foreign.Arena;
@@ -42,6 +43,8 @@ public class DataFusionQueryExecutionTests extends OpenSearchTestCase {
     private ReaderHandle readerHandle;
     private Arena configArena;
     private long queryConfigPtr;
+    private long tieredStorePtr;
+    private NativeStoreHandle storeHandle;
 
     @Override
     public void setUp() throws Exception {
@@ -52,10 +55,15 @@ public class DataFusionQueryExecutionTests extends OpenSearchTestCase {
             NativeBridge.createGlobalRuntime(128 * 1024 * 1024, 0L, spillDir.toString(), 64 * 1024 * 1024)
         );
 
+        // Create a real TieredObjectStore (local-only) and wrap in NativeStoreHandle
+        tieredStorePtr = NativeStoreTestHelper.createTieredObjectStore(0L, 0L);
+        long boxPtr = NativeStoreTestHelper.getObjectStoreBoxPtr(tieredStorePtr);
+        storeHandle = new NativeStoreHandle(boxPtr, NativeStoreTestHelper::destroyObjectStoreBoxPtr);
+
         Path dataDir = createTempDir("datafusion-data");
         Path testParquet = Path.of(getClass().getClassLoader().getResource("test.parquet").toURI());
         Files.copy(testParquet, dataDir.resolve("test.parquet"));
-        readerHandle = new ReaderHandle(dataDir.toString(), new String[] { "test.parquet" });
+        readerHandle = new ReaderHandle(dataDir.toString(), new String[] { "test.parquet" }, storeHandle);
 
         configArena = Arena.ofConfined();
         MemorySegment configSegment = configArena.allocate(WireConfigSnapshot.BYTE_SIZE);
@@ -67,6 +75,8 @@ public class DataFusionQueryExecutionTests extends OpenSearchTestCase {
     public void tearDown() throws Exception {
         configArena.close();
         readerHandle.close();
+        storeHandle.close();
+        NativeStoreTestHelper.destroyTieredObjectStore(tieredStorePtr);
         runtimeHandle.close();
         super.tearDown();
     }

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionReaderManagerTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionReaderManagerTests.java
@@ -1,0 +1,225 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion;
+
+import org.opensearch.core.index.Index;
+import org.opensearch.core.index.shard.ShardId;
+import org.opensearch.index.engine.dataformat.DataFormat;
+import org.opensearch.index.engine.dataformat.FieldTypeCapabilities;
+import org.opensearch.index.shard.ShardPath;
+import org.opensearch.plugins.NativeStoreHandle;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+/**
+ * Unit tests for {@link DatafusionReaderManager}.
+ *
+ * <p>These tests exercise the manager's field storage, null-safety, and
+ * delegation logic without loading the native library. Since
+ * {@link DatafusionReader} calls {@code NativeBridge} (FFM) in its constructor,
+ * we test only the manager's handle storage and lifecycle methods that don't
+ * create readers.
+ */
+public class DatafusionReaderManagerTests extends OpenSearchTestCase {
+
+    private static final DataFormat TEST_FORMAT = new DataFormat() {
+        @Override
+        public String name() {
+            return "parquet";
+        }
+
+        @Override
+        public long priority() {
+            return 1;
+        }
+
+        @Override
+        public Set<FieldTypeCapabilities> supportedFields() {
+            return Set.of();
+        }
+    };
+
+    private ShardPath createTestShardPath() throws IOException {
+        ShardId shardId = new ShardId(new Index("test-index", "test-uuid"), 0);
+        Path tempDir = createTempDir("shard");
+        // ShardPath requires the path to end with: <index-uuid>/<shard-id>
+        Path dataPath = tempDir.resolve("test-uuid").resolve("0");
+        Files.createDirectories(dataPath);
+        return new ShardPath(false, dataPath, dataPath, shardId);
+    }
+
+    /**
+     * Constructor should accept null handle (hot path where no native store is available).
+     */
+    public void testConstructorAcceptsNullHandle() throws IOException {
+        ShardPath shardPath = createTestShardPath();
+        DataFusionService mockService = mock(DataFusionService.class);
+
+        DatafusionReaderManager manager = new DatafusionReaderManager(TEST_FORMAT, shardPath, mockService, null);
+        assertNotNull(manager);
+        manager.close();
+    }
+
+    /**
+     * Constructor should accept EMPTY handle (equivalent to null for native store).
+     */
+    public void testConstructorAcceptsEmptyHandle() throws IOException {
+        ShardPath shardPath = createTestShardPath();
+        DataFusionService mockService = mock(DataFusionService.class);
+
+        DatafusionReaderManager manager = new DatafusionReaderManager(TEST_FORMAT, shardPath, mockService, NativeStoreHandle.EMPTY);
+        assertNotNull(manager);
+        manager.close();
+    }
+
+    /**
+     * close() with no readers should not throw.
+     */
+    public void testCloseWithNoReadersDoesNotThrow() throws IOException {
+        ShardPath shardPath = createTestShardPath();
+        DataFusionService mockService = mock(DataFusionService.class);
+
+        DatafusionReaderManager manager = new DatafusionReaderManager(TEST_FORMAT, shardPath, mockService, null);
+        // Should not throw — no readers to close
+        manager.close();
+    }
+
+    /**
+     * onFilesDeleted with null collection should not interact with service.
+     */
+    public void testOnFilesDeletedWithNullIsNoOp() throws IOException {
+        ShardPath shardPath = createTestShardPath();
+        DataFusionService mockService = mock(DataFusionService.class);
+
+        DatafusionReaderManager manager = new DatafusionReaderManager(TEST_FORMAT, shardPath, mockService, null);
+        manager.onFilesDeleted(null);
+        verifyNoInteractions(mockService);
+        manager.close();
+    }
+
+    /**
+     * onFilesDeleted with empty collection should not interact with service.
+     */
+    public void testOnFilesDeletedWithEmptyCollectionIsNoOp() throws IOException {
+        ShardPath shardPath = createTestShardPath();
+        DataFusionService mockService = mock(DataFusionService.class);
+
+        DatafusionReaderManager manager = new DatafusionReaderManager(TEST_FORMAT, shardPath, mockService, null);
+        manager.onFilesDeleted(List.of());
+        verifyNoInteractions(mockService);
+        manager.close();
+    }
+
+    /**
+     * onFilesAdded with null collection should not interact with service.
+     */
+    public void testOnFilesAddedWithNullIsNoOp() throws IOException {
+        ShardPath shardPath = createTestShardPath();
+        DataFusionService mockService = mock(DataFusionService.class);
+
+        DatafusionReaderManager manager = new DatafusionReaderManager(TEST_FORMAT, shardPath, mockService, null);
+        manager.onFilesAdded(null);
+        verifyNoInteractions(mockService);
+        manager.close();
+    }
+
+    /**
+     * onFilesAdded with empty collection should not interact with service.
+     */
+    public void testOnFilesAddedWithEmptyCollectionIsNoOp() throws IOException {
+        ShardPath shardPath = createTestShardPath();
+        DataFusionService mockService = mock(DataFusionService.class);
+
+        DatafusionReaderManager manager = new DatafusionReaderManager(TEST_FORMAT, shardPath, mockService, null);
+        manager.onFilesAdded(List.of());
+        verifyNoInteractions(mockService);
+        manager.close();
+    }
+
+    /**
+     * onFilesDeleted with non-empty collection should delegate to service with absolute paths.
+     */
+    public void testOnFilesDeletedDelegatesToService() throws IOException {
+        ShardPath shardPath = createTestShardPath();
+        DataFusionService mockService = mock(DataFusionService.class);
+
+        DatafusionReaderManager manager = new DatafusionReaderManager(TEST_FORMAT, shardPath, mockService, null);
+        Collection<String> files = List.of("seg_0.parquet", "seg_1.parquet");
+        manager.onFilesDeleted(files);
+
+        String expectedDir = shardPath.getDataPath().resolve("parquet").toString();
+        Collection<String> expectedPaths = List.of(expectedDir + "/seg_0.parquet", expectedDir + "/seg_1.parquet");
+        verify(mockService).onFilesDeleted(expectedPaths);
+        manager.close();
+    }
+
+    /**
+     * onFilesAdded with non-empty collection should delegate to service with absolute paths.
+     */
+    public void testOnFilesAddedDelegatesToService() throws IOException {
+        ShardPath shardPath = createTestShardPath();
+        DataFusionService mockService = mock(DataFusionService.class);
+
+        DatafusionReaderManager manager = new DatafusionReaderManager(TEST_FORMAT, shardPath, mockService, null);
+        Collection<String> files = List.of("seg_0.parquet");
+        manager.onFilesAdded(files);
+
+        String expectedDir = shardPath.getDataPath().resolve("parquet").toString();
+        Collection<String> expectedPaths = List.of(expectedDir + "/seg_0.parquet");
+        verify(mockService).onFilesAdded(expectedPaths);
+        manager.close();
+    }
+
+    /**
+     * beforeRefresh should not throw.
+     */
+    public void testBeforeRefreshDoesNotThrow() throws IOException {
+        ShardPath shardPath = createTestShardPath();
+        DataFusionService mockService = mock(DataFusionService.class);
+
+        DatafusionReaderManager manager = new DatafusionReaderManager(TEST_FORMAT, shardPath, mockService, null);
+        manager.beforeRefresh();
+        manager.close();
+    }
+
+    /**
+     * afterRefresh with didRefresh=false should not create a reader.
+     */
+    public void testAfterRefreshWithDidRefreshFalseIsNoOp() throws IOException {
+        ShardPath shardPath = createTestShardPath();
+        DataFusionService mockService = mock(DataFusionService.class);
+
+        DatafusionReaderManager manager = new DatafusionReaderManager(TEST_FORMAT, shardPath, mockService, null);
+        // didRefresh=false means no new data — should be a no-op
+        manager.afterRefresh(false, null);
+        manager.close();
+    }
+
+    /**
+     * getReader with no prior afterRefresh should throw IOException.
+     */
+    public void testGetReaderWithNoRefreshThrows() throws IOException {
+        ShardPath shardPath = createTestShardPath();
+        DataFusionService mockService = mock(DataFusionService.class);
+
+        DatafusionReaderManager manager = new DatafusionReaderManager(TEST_FORMAT, shardPath, mockService, null);
+        expectThrows(IOException.class, () -> manager.getReader(null));
+        manager.close();
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionResultStreamTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionResultStreamTests.java
@@ -14,6 +14,7 @@ import org.opensearch.analytics.backend.EngineResultBatch;
 import org.opensearch.be.datafusion.nativelib.NativeBridge;
 import org.opensearch.be.datafusion.nativelib.ReaderHandle;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.plugins.NativeStoreHandle;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.lang.foreign.Arena;
@@ -35,6 +36,8 @@ public class DatafusionResultStreamTests extends OpenSearchTestCase {
     private RootAllocator testRootAllocator;
     private Arena configArena;
     private long queryConfigPtr;
+    private long tieredStorePtr;
+    private NativeStoreHandle storeHandle;
     private final java.util.List<BufferAllocator> allocatorsToClose = new java.util.ArrayList<>();
 
     @Override
@@ -46,10 +49,15 @@ public class DatafusionResultStreamTests extends OpenSearchTestCase {
         runtimeHandle = new NativeRuntimeHandle(ptr);
         testRootAllocator = new RootAllocator(Long.MAX_VALUE);
 
+        // Create a real TieredObjectStore (local-only) and wrap in NativeStoreHandle
+        tieredStorePtr = NativeStoreTestHelper.createTieredObjectStore(0L, 0L);
+        long boxPtr = NativeStoreTestHelper.getObjectStoreBoxPtr(tieredStorePtr);
+        storeHandle = new NativeStoreHandle(boxPtr, NativeStoreTestHelper::destroyObjectStoreBoxPtr);
+
         Path dataDir = createTempDir("data");
         Path testParquet = Path.of(getClass().getClassLoader().getResource("test.parquet").toURI());
         Files.copy(testParquet, dataDir.resolve("test.parquet"));
-        readerHandle = new ReaderHandle(dataDir.toString(), new String[] { "test.parquet" });
+        readerHandle = new ReaderHandle(dataDir.toString(), new String[] { "test.parquet" }, storeHandle);
 
         configArena = Arena.ofConfined();
         MemorySegment configSegment = configArena.allocate(WireConfigSnapshot.BYTE_SIZE);
@@ -61,6 +69,8 @@ public class DatafusionResultStreamTests extends OpenSearchTestCase {
     public void tearDown() throws Exception {
         configArena.close();
         readerHandle.close();
+        storeHandle.close();
+        NativeStoreTestHelper.destroyTieredObjectStore(tieredStorePtr);
         runtimeHandle.close();
         // Caller owns child allocators now (see DatafusionResultStream.close javadoc).
         // Close them in reverse registration order so child-before-parent invariants hold.

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionSearchExecEngineTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionSearchExecEngineTests.java
@@ -15,6 +15,7 @@ import org.opensearch.analytics.backend.ShardScanExecutionContext;
 import org.opensearch.be.datafusion.nativelib.NativeBridge;
 import org.opensearch.be.datafusion.nativelib.ReaderHandle;
 import org.opensearch.be.datafusion.nativelib.SessionContextHandle;
+import org.opensearch.plugins.NativeStoreHandle;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.lang.foreign.Arena;
@@ -34,6 +35,8 @@ public class DatafusionSearchExecEngineTests extends OpenSearchTestCase {
 
     private ReaderHandle readerHandle;
     private NativeRuntimeHandle runtimeHandle;
+    private long tieredStorePtr;
+    private NativeStoreHandle storeHandle;
 
     @Override
     public void setUp() throws Exception {
@@ -43,16 +46,22 @@ public class DatafusionSearchExecEngineTests extends OpenSearchTestCase {
         long ptr = NativeBridge.createGlobalRuntime(128 * 1024 * 1024, 0L, spillDir.toString(), 64 * 1024 * 1024);
         runtimeHandle = new NativeRuntimeHandle(ptr);
 
+        // Create a real TieredObjectStore (local-only) and wrap in NativeStoreHandle
+        tieredStorePtr = NativeStoreTestHelper.createTieredObjectStore(0L, 0L);
+        long boxPtr = NativeStoreTestHelper.getObjectStoreBoxPtr(tieredStorePtr);
+        storeHandle = new NativeStoreHandle(boxPtr, NativeStoreTestHelper::destroyObjectStoreBoxPtr);
+
         Path dataDir = createTempDir("datafusion-data");
         Path testParquet = Path.of(getClass().getClassLoader().getResource("test.parquet").toURI());
         Files.copy(testParquet, dataDir.resolve("test.parquet"));
-        readerHandle = new ReaderHandle(dataDir.toString(), new String[] { "test.parquet" });
+        readerHandle = new ReaderHandle(dataDir.toString(), new String[] { "test.parquet" }, storeHandle);
     }
 
     @Override
     public void tearDown() throws Exception {
         readerHandle.close();
-        // NativeRuntimeHandle.close() calls closeGlobalRuntime
+        storeHandle.close();
+        NativeStoreTestHelper.destroyTieredObjectStore(tieredStorePtr);
         runtimeHandle.close();
         super.tearDown();
     }

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/NativeStoreTestHelper.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/NativeStoreTestHelper.java
@@ -1,0 +1,88 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion;
+
+import org.opensearch.nativebridge.spi.NativeLibraryLoader;
+
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.Linker;
+import java.lang.foreign.ValueLayout;
+import java.lang.invoke.MethodHandle;
+
+/**
+ * Test helper for creating real native TieredObjectStore pointers via FFM.
+ * Avoids a compile dependency on parquet-data-format by calling the native
+ * symbols directly through the shared native library.
+ */
+final class NativeStoreTestHelper {
+
+    private static final MethodHandle TS_CREATE;
+    private static final MethodHandle TS_DESTROY;
+    private static final MethodHandle TS_GET_BOX_PTR;
+    private static final MethodHandle TS_DESTROY_BOX_PTR;
+
+    static {
+        var lib = NativeLibraryLoader.symbolLookup();
+        var linker = Linker.nativeLinker();
+        TS_CREATE = linker.downcallHandle(
+            lib.find("ts_create_tiered_object_store").orElseThrow(),
+            FunctionDescriptor.of(ValueLayout.JAVA_LONG, ValueLayout.JAVA_LONG, ValueLayout.JAVA_LONG)
+        );
+        TS_DESTROY = linker.downcallHandle(
+            lib.find("ts_destroy_tiered_object_store").orElseThrow(),
+            FunctionDescriptor.of(ValueLayout.JAVA_LONG, ValueLayout.JAVA_LONG)
+        );
+        TS_GET_BOX_PTR = linker.downcallHandle(
+            lib.find("ts_get_object_store_box_ptr").orElseThrow(),
+            FunctionDescriptor.of(ValueLayout.JAVA_LONG, ValueLayout.JAVA_LONG)
+        );
+        TS_DESTROY_BOX_PTR = linker.downcallHandle(
+            lib.find("ts_destroy_object_store_box_ptr").orElseThrow(),
+            FunctionDescriptor.of(ValueLayout.JAVA_LONG, ValueLayout.JAVA_LONG)
+        );
+    }
+
+    private NativeStoreTestHelper() {}
+
+    /** Create a TieredObjectStore. Pass 0 for default LocalFileSystem / no remote. */
+    static long createTieredObjectStore(long localPtr, long remotePtr) {
+        try {
+            return NativeLibraryLoader.checkResult((long) TS_CREATE.invokeExact(localPtr, remotePtr));
+        } catch (Throwable t) {
+            throw new RuntimeException("Failed to create TieredObjectStore", t);
+        }
+    }
+
+    /** Destroy a TieredObjectStore. */
+    static void destroyTieredObjectStore(long ptr) {
+        try {
+            NativeLibraryLoader.checkResult((long) TS_DESTROY.invokeExact(ptr));
+        } catch (Throwable t) {
+            throw new RuntimeException("Failed to destroy TieredObjectStore", t);
+        }
+    }
+
+    /** Get a Box pointer (ObjectStore trait object) for DataFusion from a TieredObjectStore. */
+    static long getObjectStoreBoxPtr(long tieredStorePtr) {
+        try {
+            return NativeLibraryLoader.checkResult((long) TS_GET_BOX_PTR.invokeExact(tieredStorePtr));
+        } catch (Throwable t) {
+            throw new RuntimeException("Failed to get object store box ptr", t);
+        }
+    }
+
+    /** Destroy a Box pointer (ObjectStore trait object). */
+    static void destroyObjectStoreBoxPtr(long ptr) {
+        try {
+            NativeLibraryLoader.checkResult((long) TS_DESTROY_BOX_PTR.invokeExact(ptr));
+        } catch (Throwable t) {
+            throw new RuntimeException("Failed to destroy object store box ptr", t);
+        }
+    }
+}

--- a/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/LuceneReaderManagerTests.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/LuceneReaderManagerTests.java
@@ -343,7 +343,8 @@ public class LuceneReaderManagerTests extends OpenSearchTestCase {
                 Optional.of(engine),
                 dataFormat,
                 mock(DataFormatRegistry.class),
-                shardPath
+                shardPath,
+                Map.of()
             );
 
             EngineReaderManager<?> rm = LuceneSearchBackEnd.createReaderManager(settings);
@@ -355,7 +356,13 @@ public class LuceneReaderManagerTests extends OpenSearchTestCase {
     }
 
     public void testCreateReaderManagerWithEmptyProviderThrows() {
-        ReaderManagerConfig settings = new ReaderManagerConfig(Optional.empty(), dataFormat, mock(DataFormatRegistry.class), null);
+        ReaderManagerConfig settings = new ReaderManagerConfig(
+            Optional.empty(),
+            dataFormat,
+            mock(DataFormatRegistry.class),
+            null,
+            Map.of()
+        );
 
         IllegalStateException ex = expectThrows(IllegalStateException.class, () -> LuceneSearchBackEnd.createReaderManager(settings));
         assertTrue(ex.getMessage().contains("IndexStoreProvider is required"));

--- a/sandbox/plugins/composite-engine/src/main/java/org/opensearch/composite/CompositeIndexingExecutionEngine.java
+++ b/sandbox/plugins/composite-engine/src/main/java/org/opensearch/composite/CompositeIndexingExecutionEngine.java
@@ -377,7 +377,13 @@ public class CompositeIndexingExecutionEngine implements IndexingExecutionEngine
     }
 
     private ReaderManagerConfig readerManagerConfig(ReaderManagerConfig config, DataFormat toAugment) {
-        return new ReaderManagerConfig(config.indexStoreProvider(), toAugment, config.registry(), config.shardPath());
+        return new ReaderManagerConfig(
+            config.indexStoreProvider(),
+            toAugment,
+            config.registry(),
+            config.shardPath(),
+            config.dataformatAwareStoreHandles()
+        );
     }
 
     /**

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/ParquetDataFormatPlugin.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/ParquetDataFormatPlugin.java
@@ -63,7 +63,6 @@ public class ParquetDataFormatPlugin extends Plugin implements DataFormatPlugin 
 
     /** Thread pool name for background native Parquet writes during VSR rotation. */
     public static final String PARQUET_THREAD_POOL_NAME = "parquet_native_write";
-    private static final ParquetDataFormat dataFormat = new ParquetDataFormat();
     private static final StoreStrategy storeStrategy = new ParquetStoreStrategy();
     public static final ParquetDataFormat PARQUET_DATA_FORMAT = new ParquetDataFormat();
     /** Initialized to EMPTY to avoid NPE if indexingEngine() is called before createComponents(). */

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/store/ParquetStoreStrategy.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/store/ParquetStoreStrategy.java
@@ -25,7 +25,7 @@ import java.util.Optional;
  * <p>Provides a factory for the per-shard native file registry that tracks
  * parquet files for the Rust reader.
  */
-public final class ParquetStoreStrategy implements StoreStrategy {
+public final class ParquetStoreStrategy extends StoreStrategy {
 
     private static final DataFormatStoreHandlerFactory FACTORY = ParquetDataFormatStoreHandler::new;
 

--- a/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/store/ParquetStoreStrategyTests.java
+++ b/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/store/ParquetStoreStrategyTests.java
@@ -44,13 +44,14 @@ public class ParquetStoreStrategyTests extends OpenSearchTestCase {
 
     public void testRemotePathDefault() {
         ParquetStoreStrategy strategy = new ParquetStoreStrategy();
-        String remotePath = strategy.remotePath("parquet", "base/path/", "parquet/_0.parquet", "_0.parquet__UUID1");
+        // basePath from getRemoteBasePath("parquet") already includes the format subdirectory
+        String remotePath = strategy.remotePath("parquet", "base/path/parquet/", "parquet/_0.parquet", "_0.parquet__UUID1");
         assertEquals("base/path/parquet/_0.parquet__UUID1", remotePath);
     }
 
     public void testRemotePathEmptyBasePath() {
         ParquetStoreStrategy strategy = new ParquetStoreStrategy();
         String remotePath = strategy.remotePath("parquet", "", "parquet/_0.parquet", "_0.parquet__UUID1");
-        assertEquals("parquet/_0.parquet__UUID1", remotePath);
+        assertEquals("_0.parquet__UUID1", remotePath);
     }
 }

--- a/server/src/main/java/org/opensearch/index/IndexService.java
+++ b/server/src/main/java/org/opensearch/index/IndexService.java
@@ -122,11 +122,13 @@ import org.opensearch.indices.replication.checkpoint.ReferencedSegmentsPublisher
 import org.opensearch.indices.replication.checkpoint.SegmentReplicationCheckpointPublisher;
 import org.opensearch.node.remotestore.RemoteStoreNodeAttribute;
 import org.opensearch.plugins.IndexStorePlugin;
+import org.opensearch.plugins.NativeStoreHandle;
 import org.opensearch.repositories.NativeStoreRepository;
 import org.opensearch.repositories.RepositoriesService;
 import org.opensearch.repositories.RepositoryMissingException;
 import org.opensearch.script.ScriptService;
 import org.opensearch.search.aggregations.support.ValuesSourceRegistry;
+import org.opensearch.storage.directory.StoreStrategyRegistry;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.client.Client;
 
@@ -780,6 +782,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
 
             Directory directory = null;
             Map<String, FormatChecksumStrategy> checksumStrategies = Collections.emptyMap();
+            Map<DataFormat, NativeStoreHandle> dataformatAwareStoreHandles = Map.of();
             if (this.indexSettings.isPluggableDataFormatEnabled() && dataFormatRegistry != null) {
                 checksumStrategies = dataFormatRegistry.createChecksumStrategies(this.indexSettings);
             }
@@ -787,23 +790,35 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
                 && this.indexSettings.isWarmIndex()
                 && this.indexSettings.isPluggableDataFormatEnabled()
                 && this.dataFormatAwareStoreDirectoryFactory != null) {
-                // Warm + format-aware: resolve per-shard store strategies and native store,
-                // then let the factory build the StoreStrategyRegistry and directory stack.
+                // Warm + format-aware: create StoreStrategyRegistry here so we can
+                // extract native store handles for the Store before passing to the factory.
                 Map<DataFormat, StoreStrategy> storeStrategies = dataFormatRegistry.getStoreStrategies(this.indexSettings);
                 NativeStoreRepository nativeStore = resolveNativeStore(repositoriesService);
-                directory = dataFormatAwareStoreDirectoryFactory.newDataFormatAwareStoreDirectory(
-                    this.indexSettings,
-                    shardId,
-                    path,
-                    directoryFactory,
-                    checksumStrategies,
-                    storeStrategies,
-                    nativeStore,
-                    true,
-                    (RemoteSegmentStoreDirectory) remoteDirectory,
-                    fileCache,
-                    threadPool
-                );
+                StoreStrategyRegistry storeStrategyRegistry = null;
+                try {
+                    storeStrategyRegistry = StoreStrategyRegistry.open(
+                        path,
+                        true,
+                        nativeStore,
+                        storeStrategies,
+                        (RemoteSegmentStoreDirectory) remoteDirectory
+                    );
+                    dataformatAwareStoreHandles = storeStrategyRegistry.getFormatStoreHandles();
+                    directory = dataFormatAwareStoreDirectoryFactory.newDataFormatAwareStoreDirectory(
+                        this.indexSettings,
+                        shardId,
+                        path,
+                        directoryFactory,
+                        checksumStrategies,
+                        storeStrategyRegistry,
+                        (RemoteSegmentStoreDirectory) remoteDirectory,
+                        fileCache,
+                        threadPool
+                    );
+                } catch (Exception e) {
+                    IOUtils.closeWhileHandlingException(storeStrategyRegistry);
+                    throw e;
+                }
             } else if (FeatureFlags.isEnabled(FeatureFlags.WRITABLE_WARM_INDEX_SETTING) &&
             // TODO : Need to remove this check after support for hot indices is added in Composite Directory
                 this.indexSettings.isWarmIndex()) {
@@ -830,6 +845,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
                 path,
                 directoryFactory
             );
+            store.setDataformatAwareStoreHandles(dataformatAwareStoreHandles);
             eventListener.onStoreCreated(shardId);
             indexShard = new IndexShard(
                 routing,

--- a/server/src/main/java/org/opensearch/index/engine/DataFormatAwareEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/DataFormatAwareEngine.java
@@ -296,7 +296,8 @@ public class DataFormatAwareEngine implements Indexer {
                     Optional.ofNullable(indexingExecutionEngine.getProvider()),
                     indexingExecutionEngine.getDataFormat(),
                     registry,
-                    store.shardPath()
+                    store.shardPath(),
+                    store.getDataformatAwareStoreHandles()
                 )
             );
 

--- a/server/src/main/java/org/opensearch/index/engine/dataformat/ReaderManagerConfig.java
+++ b/server/src/main/java/org/opensearch/index/engine/dataformat/ReaderManagerConfig.java
@@ -11,7 +11,9 @@ package org.opensearch.index.engine.dataformat;
 import org.opensearch.common.annotation.ExperimentalApi;
 import org.opensearch.index.engine.exec.commit.IndexStoreProvider;
 import org.opensearch.index.shard.ShardPath;
+import org.opensearch.plugins.NativeStoreHandle;
 
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -23,10 +25,13 @@ import java.util.Optional;
  * @param format the data format to create a reader manager for
  * @param registry the data format registry it can use to wire any data format specific details.
  * @param shardPath the shard path for file storage
+ * @param dataformatAwareStoreHandles per-format native store handles for reads.
+ *                                    Empty map if no native stores are available.
+ *                                    Each plugin extracts its own handle via {@code handles.get(config.format())}.
  *
  * @opensearch.experimental
  */
 @ExperimentalApi
 public record ReaderManagerConfig(Optional<IndexStoreProvider> indexStoreProvider, DataFormat format, DataFormatRegistry registry,
-    ShardPath shardPath) {
+    ShardPath shardPath, Map<DataFormat, NativeStoreHandle> dataformatAwareStoreHandles) {
 }

--- a/server/src/main/java/org/opensearch/index/engine/dataformat/StoreStrategy.java
+++ b/server/src/main/java/org/opensearch/index/engine/dataformat/StoreStrategy.java
@@ -34,20 +34,19 @@ import java.util.Optional;
  * @opensearch.experimental
  */
 @ExperimentalApi
-public interface StoreStrategy {
+public abstract class StoreStrategy {
 
     /**
      * Returns true if the given file identifier belongs to this format.
      *
      * <p>The default convention is that format files live under a subdirectory
      * whose prefix is the format name (e.g. {@code "parquet/seg_0.parquet"}).
-     * Implementations may override to use a different layout.
      *
      * @param name the format name the store layer associated with this
      *             strategy (the key it was registered under)
      * @param file file identifier as produced by the directory layer
      */
-    default boolean owns(String name, String file) {
+    public final boolean owns(String name, String file) {
         if (file == null) {
             return false;
         }
@@ -58,8 +57,7 @@ public interface StoreStrategy {
      * Returns the fully-qualified remote blob path for a file owned by this format.
      *
      * <p>The default convention places blobs at
-     * {@code basePath + name + "/" + blobKey}. Implementations may override
-     * when the format uses a different layout on the remote store.
+     * {@code basePath + name + "/" + blobKey}.
      *
      * @param name     the format name the store layer associated with this
      *                 strategy (the key it was registered under)
@@ -69,12 +67,12 @@ public interface StoreStrategy {
      *                 {@link org.opensearch.index.store.RemoteSegmentStoreDirectory.UploadedSegmentMetadata#getUploadedFilename()}
      * @return the remote blob path
      */
-    default String remotePath(String name, String basePath, String file, String blobKey) {
+    public final String remotePath(String name, String basePath, String file, String blobKey) {
         StringBuilder sb = new StringBuilder();
         if (basePath != null && basePath.isEmpty() == false) {
             sb.append(basePath);
         }
-        sb.append(name).append('/').append(blobKey);
+        sb.append(blobKey);
         return sb.toString();
     }
 
@@ -83,7 +81,5 @@ public interface StoreStrategy {
      * registry. Formats without a native reader return
      * {@link Optional#empty()}.
      */
-    default Optional<DataFormatStoreHandlerFactory> storeHandler() {
-        return Optional.empty();
-    }
+    public abstract Optional<DataFormatStoreHandlerFactory> storeHandler();
 }

--- a/server/src/main/java/org/opensearch/index/store/DataFormatAwareStoreDirectoryFactory.java
+++ b/server/src/main/java/org/opensearch/index/store/DataFormatAwareStoreDirectoryFactory.java
@@ -11,12 +11,9 @@ package org.opensearch.index.store;
 import org.opensearch.common.annotation.ExperimentalApi;
 import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.index.IndexSettings;
-import org.opensearch.index.engine.dataformat.DataFormat;
-import org.opensearch.index.engine.dataformat.StoreStrategy;
 import org.opensearch.index.shard.ShardPath;
 import org.opensearch.index.store.remote.filecache.FileCache;
 import org.opensearch.plugins.IndexStorePlugin;
-import org.opensearch.repositories.NativeStoreRepository;
 import org.opensearch.threadpool.ThreadPool;
 
 import java.io.IOException;
@@ -60,20 +57,17 @@ public interface DataFormatAwareStoreDirectoryFactory {
      * storage support.
      *
      * <p>Implementations that support warm+format override this method to
-     * build the full tiered directory stack. The per-shard strategy registry
-     * is constructed by the factory from the supplied {@code storeStrategies}
-     * and {@code nativeStore}; individual data formats contribute only the
-     * strategies.
+     * build the full tiered directory stack. The caller creates the
+     * {@link org.opensearch.storage.directory.StoreStrategyRegistry} externally
+     * and passes it in so that native store handles can be extracted before
+     * the directory is created.
      *
      * @param indexSettings          the shard's index settings
      * @param shardId                the shard identifier
      * @param shardPath              the path the shard is using for file storage
      * @param localDirectoryFactory  the factory for creating the underlying local directory
      * @param checksumStrategies     pre-built checksum strategies keyed by format name
-     * @param storeStrategies        the strategies declared by participating formats for this shard
-     * @param nativeStore            the repository's native store, or
-     *                               {@link NativeStoreRepository#EMPTY}
-     * @param isWarm                 true if the shard is on a warm node
+     * @param strategies             the pre-built store strategy registry for this shard
      * @param remoteDirectory        the remote segment store directory
      * @param fileCache              the file cache for warm node caching
      * @param threadPool             the thread pool for async operations
@@ -86,9 +80,7 @@ public interface DataFormatAwareStoreDirectoryFactory {
         ShardPath shardPath,
         IndexStorePlugin.DirectoryFactory localDirectoryFactory,
         Map<String, FormatChecksumStrategy> checksumStrategies,
-        Map<DataFormat, StoreStrategy> storeStrategies,
-        NativeStoreRepository nativeStore,
-        boolean isWarm,
+        org.opensearch.storage.directory.StoreStrategyRegistry strategies,
         RemoteSegmentStoreDirectory remoteDirectory,
         FileCache fileCache,
         ThreadPool threadPool

--- a/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
+++ b/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
@@ -1086,12 +1086,17 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory implement
     }
 
     /**
-     * Returns the base blob path for this shard's remote segment data.
-     * E.g., "clusterUUID/indexUUID/shardId/segments/data/"
+     * Returns the blob path for the given data format.
+     * If a {@link FormatBlobRouter} is configured, uses format-specific routing
+     * (e.g., "basePath/parquet/" for parquet files). Otherwise falls back to the base path.
      *
-     * @return the base path as a string
+     * @param format the data format name (e.g., "parquet", "lucene")
+     * @return the blob path as a string for the given format
      */
-    public String getRemoteBasePath() {
+    public String getRemoteBasePath(String format) {
+        if (formatBlobRouter != null && format != null && format.isEmpty() == false) {
+            return formatBlobRouter.containerFor(format).path().buildAsString();
+        }
         return remoteDataDirectory.getBlobContainer().path().buildAsString();
     }
 

--- a/server/src/main/java/org/opensearch/index/store/Store.java
+++ b/server/src/main/java/org/opensearch/index/store/Store.java
@@ -92,6 +92,7 @@ import org.opensearch.index.BucketedCompositeDirectory;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.index.engine.CombinedDeletionPolicy;
 import org.opensearch.index.engine.Engine;
+import org.opensearch.index.engine.dataformat.DataFormat;
 import org.opensearch.index.engine.exec.coord.CatalogSnapshot;
 import org.opensearch.index.engine.exec.coord.SegmentInfosCatalogSnapshot;
 import org.opensearch.index.seqno.SequenceNumbers;
@@ -100,6 +101,7 @@ import org.opensearch.index.shard.IndexShard;
 import org.opensearch.index.shard.ShardPath;
 import org.opensearch.index.translog.Translog;
 import org.opensearch.plugins.IndexStorePlugin;
+import org.opensearch.plugins.NativeStoreHandle;
 
 import java.io.Closeable;
 import java.io.EOFException;
@@ -186,6 +188,7 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
     private final boolean isParentFieldEnabledVersion;
     private final boolean isIndexSortEnabled;
     private final IndexStorePlugin.DirectoryFactory directoryFactory;
+    private volatile Map<DataFormat, NativeStoreHandle> dataformatAwareStoreHandles;
 
     // used to ref count files when a new Reader is opened for PIT/Scroll queries
     // prevents segment files deletion until the PIT/Scroll expires or is discarded
@@ -222,6 +225,19 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
         ShardPath shardPath,
         IndexStorePlugin.DirectoryFactory directoryFactory
     ) {
+        this(shardId, indexSettings, directory, shardLock, onClose, shardPath, directoryFactory, Map.of());
+    }
+
+    public Store(
+        ShardId shardId,
+        IndexSettings indexSettings,
+        Directory directory,
+        ShardLock shardLock,
+        OnClose onClose,
+        ShardPath shardPath,
+        IndexStorePlugin.DirectoryFactory directoryFactory,
+        Map<DataFormat, NativeStoreHandle> dataformatAwareStoreHandles
+    ) {
         super(shardId, indexSettings);
         final TimeValue refreshInterval = indexSettings.getValue(INDEX_STORE_STATS_REFRESH_INTERVAL_SETTING);
         logger.debug("store stats are refreshed with refresh_interval [{}]", refreshInterval);
@@ -233,10 +249,27 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
         this.isIndexSortEnabled = indexSettings.getIndexSortConfig().hasIndexSort();
         this.isParentFieldEnabledVersion = indexSettings.getIndexVersionCreated().onOrAfter(org.opensearch.Version.V_3_2_0);
         this.directoryFactory = directoryFactory;
+        this.dataformatAwareStoreHandles = dataformatAwareStoreHandles;
 
         assert onClose != null;
         assert shardLock != null;
         assert shardLock.getShardId().equals(shardId);
+    }
+
+    /**
+     * Returns the native store handles for all data formats. On hot: empty map.
+     * On warm: contains per-format NativeStoreHandle for DataFusion reader wiring.
+     */
+    public Map<DataFormat, NativeStoreHandle> getDataformatAwareStoreHandles() {
+        return dataformatAwareStoreHandles;
+    }
+
+    /**
+     * Sets the native store handles for data format plugins. Called after Store creation
+     * by IndexService when native handles are available (warm + pluggable data format).
+     */
+    public void setDataformatAwareStoreHandles(Map<DataFormat, NativeStoreHandle> handles) {
+        this.dataformatAwareStoreHandles = handles != null ? handles : Map.of();
     }
 
     public Directory directory() {

--- a/server/src/main/java/org/opensearch/node/Node.java
+++ b/server/src/main/java/org/opensearch/node/Node.java
@@ -968,10 +968,12 @@ public class Node implements Closeable {
             dataFormatAwareStoreDirectoryFactories.put("default", new DefaultDataFormatAwareStoreDirectoryFactory());
 
             // Register tiered factory for warm+format indices
-            dataFormatAwareStoreDirectoryFactories.put(
-                TieredDataFormatAwareStoreDirectoryFactory.FACTORY_KEY,
-                new TieredDataFormatAwareStoreDirectoryFactory(tieredStoragePrefetchSettingsSupplier)
-            );
+            if (FeatureFlags.isEnabled(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)) {
+                dataFormatAwareStoreDirectoryFactories.put(
+                    TieredDataFormatAwareStoreDirectoryFactory.FACTORY_KEY,
+                    new TieredDataFormatAwareStoreDirectoryFactory(tieredStoragePrefetchSettingsSupplier)
+                );
+            }
 
             final Map<String, IndexStorePlugin.RecoveryStateFactory> recoveryStateFactories = pluginsService.filterPlugins(
                 IndexStorePlugin.class

--- a/server/src/main/java/org/opensearch/storage/directory/StoreStrategyRegistry.java
+++ b/server/src/main/java/org/opensearch/storage/directory/StoreStrategyRegistry.java
@@ -262,7 +262,6 @@ public final class StoreStrategyRegistry implements Closeable {
         if (remoteDirectory == null) {
             return;
         }
-        String basePath = remoteDirectory.getRemoteBasePath();
         Map<String, RemoteSegmentStoreDirectory.UploadedSegmentMetadata> uploaded = remoteDirectory.getSegmentsUploadedToRemoteStore();
         if (uploaded == null || uploaded.isEmpty()) {
             return;
@@ -284,6 +283,7 @@ public final class StoreStrategyRegistry implements Closeable {
                 continue;
             }
             String blobKey = entry.getValue().getUploadedFilename();
+            String basePath = remoteDirectory.getRemoteBasePath(owningFormat.name());
             String remotePath = owning.remotePath(owningFormat.name(), basePath, file, blobKey);
             // Use absolute path as key — matches what DataFusion uses for file:// lookups
             String absoluteKey = shardPath.getDataPath().resolve(file).toString();

--- a/server/src/main/java/org/opensearch/storage/directory/TieredDataFormatAwareStoreDirectoryFactory.java
+++ b/server/src/main/java/org/opensearch/storage/directory/TieredDataFormatAwareStoreDirectoryFactory.java
@@ -15,8 +15,6 @@ import org.opensearch.common.annotation.ExperimentalApi;
 import org.opensearch.common.util.io.IOUtils;
 import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.index.IndexSettings;
-import org.opensearch.index.engine.dataformat.DataFormat;
-import org.opensearch.index.engine.dataformat.StoreStrategy;
 import org.opensearch.index.shard.ShardPath;
 import org.opensearch.index.store.DataFormatAwareStoreDirectory;
 import org.opensearch.index.store.DataFormatAwareStoreDirectoryFactory;
@@ -25,7 +23,6 @@ import org.opensearch.index.store.RemoteSegmentStoreDirectory;
 import org.opensearch.index.store.SubdirectoryAwareDirectory;
 import org.opensearch.index.store.remote.filecache.FileCache;
 import org.opensearch.plugins.IndexStorePlugin;
-import org.opensearch.repositories.NativeStoreRepository;
 import org.opensearch.storage.prefetch.TieredStoragePrefetchSettings;
 import org.opensearch.threadpool.ThreadPool;
 
@@ -71,27 +68,19 @@ public class TieredDataFormatAwareStoreDirectoryFactory implements DataFormatAwa
         ShardPath shardPath,
         IndexStorePlugin.DirectoryFactory localDirectoryFactory,
         Map<String, FormatChecksumStrategy> checksumStrategies,
-        Map<DataFormat, StoreStrategy> storeStrategies,
-        NativeStoreRepository nativeStore,
-        boolean isWarm,
+        StoreStrategyRegistry strategies,
         RemoteSegmentStoreDirectory remoteDirectory,
         FileCache fileCache,
         ThreadPool threadPool
     ) throws IOException {
-        logger.debug(
-            "Creating warm+format directory stack for shard [{}] with {} strategies",
-            shardId,
-            storeStrategies == null ? 0 : storeStrategies.size()
-        );
+        logger.debug("Creating warm+format directory stack for shard [{}]", shardId);
 
         Directory localDir = localDirectoryFactory.newDirectory(indexSettings, shardPath);
         SubdirectoryAwareDirectory subdirAware = new SubdirectoryAwareDirectory(localDir, shardPath);
 
-        StoreStrategyRegistry strategies = null;
         TieredSubdirectoryAwareDirectory tieredSubdir = null;
         boolean success = false;
         try {
-            strategies = StoreStrategyRegistry.open(shardPath, isWarm, nativeStore, storeStrategies, remoteDirectory);
             tieredSubdir = new TieredSubdirectoryAwareDirectory(
                 subdirAware,
                 remoteDirectory,
@@ -113,7 +102,7 @@ public class TieredDataFormatAwareStoreDirectoryFactory implements DataFormatAwa
             if (success == false) {
                 if (tieredSubdir != null) {
                     IOUtils.closeWhileHandlingException(tieredSubdir);
-                } else if (strategies != null) {
+                } else {
                     IOUtils.closeWhileHandlingException(strategies);
                 }
             }

--- a/server/src/main/java/org/opensearch/storage/directory/TieredSubdirectoryAwareDirectory.java
+++ b/server/src/main/java/org/opensearch/storage/directory/TieredSubdirectoryAwareDirectory.java
@@ -10,6 +10,7 @@ package org.opensearch.storage.directory;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.lucene.index.IndexFileNames;
 import org.apache.lucene.store.FilterDirectory;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
@@ -22,6 +23,8 @@ import org.opensearch.index.store.RemoteSegmentStoreDirectory;
 import org.opensearch.index.store.RemoteSyncListener;
 import org.opensearch.index.store.SubdirectoryAwareDirectory;
 import org.opensearch.index.store.remote.filecache.FileCache;
+import org.opensearch.storage.indexinput.FormatSwitchableIndexInput;
+import org.opensearch.storage.indexinput.FormatSwitchableIndexInputWrapper;
 import org.opensearch.storage.prefetch.TieredStoragePrefetchSettings;
 import org.opensearch.threadpool.ThreadPool;
 
@@ -31,6 +34,8 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.function.Supplier;
 
 /**
@@ -61,6 +66,8 @@ public class TieredSubdirectoryAwareDirectory extends FilterDirectory implements
     private final StoreStrategyRegistry strategies;
     private final RemoteSegmentStoreDirectory remoteDirectory;
     private final ShardPath shardPath;
+    /** Per-file original FormatSwitchableIndexInput — used by afterSyncToRemote to switch before local delete. */
+    private final ConcurrentMap<String, FormatSwitchableIndexInput> formatInputs = new ConcurrentHashMap<>();
 
     public TieredSubdirectoryAwareDirectory(
         SubdirectoryAwareDirectory localDirectory,
@@ -95,13 +102,33 @@ public class TieredSubdirectoryAwareDirectory extends FilterDirectory implements
 
     @Override
     public IndexInput openInput(String name, IOContext context) throws IOException {
+        ensureOpen();
         if (isFormatFile(name)) {
-            // Check if file exists in remote directory (already synced) — route to remote.
-            // Otherwise read from local (translog bump edge case, file not yet synced).
+            // File already synced to remote — read directly from remote.
             if (remoteDirectory.getExistingRemoteFilename(name) != null) {
                 return remoteDirectory.openInput(name, context);
             }
-            return in.openInput(name, context);
+            // File not yet synced — wrap in FormatSwitchableIndexInput so that if
+            // afterSyncToRemote deletes the local copy mid-read, the reader switches
+            // to remote transparently (same pattern as SwitchableIndexInput for Lucene files).
+            IndexInput localInput = in.openInput(name, context);
+            FormatSwitchableIndexInput switchable = new FormatSwitchableIndexInput(
+                "FormatSwitchable(" + name + ")",
+                name,
+                localInput,
+                remoteDirectory
+            );
+            formatInputs.put(name, switchable);
+            return new FormatSwitchableIndexInputWrapper("FormatSwitchable(" + name + ")", switchable);
+        }
+        // Lucene files: if it's a segments_N file not in remote metadata, try local disk first.
+        // Handles restart where segments_N was written locally but has a different generation than remote.
+        if (name.startsWith(IndexFileNames.SEGMENTS) && remoteDirectory.getExistingRemoteFilename(name) == null) {
+            try {
+                return in.openInput(name, context);
+            } catch (NoSuchFileException e) {
+                // Not on local disk either — fall through to TieredDirectory
+            }
         }
         return tieredDirectory.openInput(name, context);
     }
@@ -126,13 +153,21 @@ public class TieredSubdirectoryAwareDirectory extends FilterDirectory implements
 
     @Override
     public IndexOutput createOutput(String name, IOContext context) throws IOException {
+        // Format files (subdirectory) need SubdirectoryAwareDirectory which creates parent dirs.
+        // CompositeDirectory doesn't handle subdirectory path creation.
+        if (isFormatFile(name)) {
+            return in.createOutput(name, context);
+        }
         return tieredDirectory.createOutput(name, context);
     }
 
     @Override
     public void deleteFile(String name) throws IOException {
         if (isFormatFile(name)) {
-            strategies.onRemoved(name);
+            String blobKey = remoteDirectory.getExistingRemoteFilename(name);
+            if (blobKey == null) {
+                strategies.onRemoved(name);
+            }
             try {
                 in.deleteFile(name);
             } catch (NoSuchFileException e) {
@@ -158,10 +193,22 @@ public class TieredSubdirectoryAwareDirectory extends FilterDirectory implements
             } catch (IOException e) {
                 size = 0;
             }
-            strategies.onUploaded(file, remoteDirectory.getRemoteBasePath(), blobKey, size);
-            // On warm, no local parquet files should remain — delete after sync.
-            // Safe because: (1) the file is now REMOTE in the registry, so new readers
-            // route to remote, and (2) TieredObjectStore retries from remote if local NotFound.
+            StoreStrategyRegistry.Match match = strategies.matchFor(file);
+            String format = match != null ? match.format().name() : "";
+            strategies.onUploaded(file, remoteDirectory.getRemoteBasePath(format), blobKey, size);
+
+            // Switch any in-flight reader to remote before deleting local.
+            // The switchToRemote cascades to all clones/slices via the shared lock.
+            FormatSwitchableIndexInput switchable = formatInputs.remove(file);
+            if (switchable != null) {
+                try {
+                    switchable.switchToRemote();
+                } catch (IOException e) {
+                    logger.warn("afterSyncToRemote: failed to switch to remote for file={}", file, e);
+                }
+            }
+
+            // Now safe to delete local — all readers are on remote.
             try {
                 in.deleteFile(file);
             } catch (java.nio.file.NoSuchFileException e) {
@@ -183,10 +230,11 @@ public class TieredSubdirectoryAwareDirectory extends FilterDirectory implements
 
     @Override
     public void rename(String source, String dest) throws IOException {
-        // Rename is only called by Lucene's IndexWriter during commit
-        // (pending_segments_N → segments_N). Format files are never renamed.
+        // Format files may be renamed during recovery (recovery.{uuid}.filename → filename).
+        // Route through SubdirectoryAwareDirectory which handles subdirectory paths.
         if (isFormatFile(source)) {
-            throw new IllegalStateException("Rename not supported for format file [" + source + "]. Format files are write-once.");
+            in.rename(source, dest);
+            return;
         }
         tieredDirectory.rename(source, dest);
     }

--- a/server/src/main/java/org/opensearch/storage/directory/TieredSubdirectoryAwareDirectory.java
+++ b/server/src/main/java/org/opensearch/storage/directory/TieredSubdirectoryAwareDirectory.java
@@ -204,7 +204,13 @@ public class TieredSubdirectoryAwareDirectory extends FilterDirectory implements
                 try {
                     switchable.switchToRemote();
                 } catch (IOException e) {
-                    logger.warn("afterSyncToRemote: failed to switch to remote for file={}", file, e);
+                    logger.warn(
+                        () -> new org.apache.logging.log4j.message.ParameterizedMessage(
+                            "afterSyncToRemote: failed to switch to remote for file={}",
+                            file
+                        ),
+                        e
+                    );
                 }
             }
 

--- a/server/src/main/java/org/opensearch/storage/indexinput/FormatSwitchableIndexInput.java
+++ b/server/src/main/java/org/opensearch/storage/indexinput/FormatSwitchableIndexInput.java
@@ -216,7 +216,13 @@ public class FormatSwitchableIndexInput extends IndexInput implements RandomAcce
                             clone.switchToRemote();
                         } catch (Exception e) {
                             // Clone may be closed or supplier may fail for clone — log and continue.
-                            logger.error("Failed to switch clone to remote for file={}", fileName, e);
+                            logger.error(
+                                () -> new org.apache.logging.log4j.message.ParameterizedMessage(
+                                    "Failed to switch clone to remote for file={}",
+                                    fileName
+                                ),
+                                e
+                            );
                         }
                     }
                 }
@@ -227,7 +233,13 @@ public class FormatSwitchableIndexInput extends IndexInput implements RandomAcce
                         oldLocal.close();
                     } catch (Exception e) {
                         // Local file may already be deleted — that's fine.
-                        logger.debug("Failed to close local input during switch for file={}", fileName, e);
+                        logger.debug(
+                            () -> new org.apache.logging.log4j.message.ParameterizedMessage(
+                                "Failed to close local input during switch for file={}",
+                                fileName
+                            ),
+                            e
+                        );
                     }
                 }
 
@@ -442,7 +454,13 @@ public class FormatSwitchableIndexInput extends IndexInput implements RandomAcce
         try {
             close();
         } catch (Exception e) {
-            logger.error("Error while cleaning up FormatSwitchableIndexInput for file={}", fileName, e);
+            logger.error(
+                () -> new org.apache.logging.log4j.message.ParameterizedMessage(
+                    "Error while cleaning up FormatSwitchableIndexInput for file={}",
+                    fileName
+                ),
+                e
+            );
         }
     }
 

--- a/server/src/main/java/org/opensearch/storage/indexinput/FormatSwitchableIndexInput.java
+++ b/server/src/main/java/org/opensearch/storage/indexinput/FormatSwitchableIndexInput.java
@@ -1,0 +1,480 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.storage.indexinput;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.RandomAccessInput;
+import org.apache.lucene.util.IORunnable;
+import org.opensearch.common.annotation.ExperimentalApi;
+import org.opensearch.common.util.concurrent.ConcurrentCollections;
+import org.opensearch.index.store.RemoteSegmentStoreDirectory;
+
+import java.io.IOException;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.Supplier;
+
+/**
+ * A switchable IndexInput for format files (e.g., parquet) that can transition
+ * from local to remote without FileCache.
+ *
+ * <p>Mirrors the locking semantics of {@link SwitchableIndexInput}:
+ * <ul>
+ *   <li>A shared {@link ReadWriteLock} coordinates switch (write lock) with
+ *       clone/slice (read lock) across the original and all its clones.</li>
+ *   <li>A per-instance {@link Lock} serializes concurrent reads on the same
+ *       instance. Once switched, reads bypass the lock (volatile fast-path).</li>
+ * </ul>
+ *
+ * <p>Unlike {@link SwitchableIndexInput}, this does NOT use FileCache or
+ * block-based remote reads. The remote input is obtained directly from the
+ * supplied factory (typically {@code remoteDirectory.openInput}).
+ *
+ * @opensearch.experimental
+ */
+@ExperimentalApi
+public class FormatSwitchableIndexInput extends IndexInput implements RandomAccessInput, Runnable {
+
+    private static final Logger logger = LogManager.getLogger(FormatSwitchableIndexInput.class);
+
+    private final AtomicReference<IndexInput> underlyingIndexInput = new AtomicReference<>();
+    private final AtomicReference<IndexInput> localIndexInput = new AtomicReference<>();
+    private final AtomicReference<IndexInput> remoteIndexInput = new AtomicReference<>();
+    private final Supplier<IndexInput> remoteInputSupplier;
+    private final RemoteSegmentStoreDirectory remoteDirectory;
+    private final String fileName;
+    private final long fileLength;
+    private final boolean isClone;
+    private volatile boolean isClosed;
+    private volatile boolean hasSwitchedToRemote;
+    private final ConcurrentMap<FormatSwitchableIndexInput, Boolean> clones;
+
+    /**
+     * Shared lock between original and all clones/slices.
+     * Write lock: switchToRemote. Read lock: clone/slice.
+     */
+    private ReadWriteLock sharedLock;
+
+    /**
+     * Per-instance lock serializing reads on the same instance.
+     * Bypassed once switched (volatile fast-path).
+     */
+    private Lock objectLock;
+
+    /**
+     * Creates a new FormatSwitchableIndexInput starting from a local input.
+     *
+     * @param resourceDescription description for debugging
+     * @param fileName            the file name (for logging and remote lookup)
+     * @param localInput          the initial local IndexInput (already opened)
+     * @param remoteDirectory     the remote directory to open remote input from on switch
+     */
+    public FormatSwitchableIndexInput(
+        String resourceDescription,
+        String fileName,
+        IndexInput localInput,
+        RemoteSegmentStoreDirectory remoteDirectory
+    ) {
+        super(resourceDescription);
+        this.fileName = fileName;
+        this.fileLength = localInput.length();
+        this.remoteDirectory = remoteDirectory;
+        this.remoteInputSupplier = null;
+        this.isClone = false;
+        this.isClosed = false;
+        this.hasSwitchedToRemote = false;
+        this.sharedLock = new ReentrantReadWriteLock();
+        this.objectLock = new ReentrantLock();
+        this.clones = ConcurrentCollections.newConcurrentMapWithAggressiveConcurrency();
+        this.localIndexInput.set(localInput);
+        this.underlyingIndexInput.set(localInput);
+    }
+
+    /**
+     * Creates a new FormatSwitchableIndexInput starting from a local input (supplier-based, for testing).
+     *
+     * @param resourceDescription description for debugging
+     * @param fileName            the file name (for logging)
+     * @param localInput          the initial local IndexInput (already opened)
+     * @param remoteInputSupplier supplier that creates the remote IndexInput on demand
+     */
+    public FormatSwitchableIndexInput(
+        String resourceDescription,
+        String fileName,
+        IndexInput localInput,
+        Supplier<IndexInput> remoteInputSupplier
+    ) {
+        super(resourceDescription);
+        this.fileName = fileName;
+        this.fileLength = localInput.length();
+        this.remoteDirectory = null;
+        this.remoteInputSupplier = remoteInputSupplier;
+        this.isClone = false;
+        this.isClosed = false;
+        this.hasSwitchedToRemote = false;
+        this.sharedLock = new ReentrantReadWriteLock();
+        this.objectLock = new ReentrantLock();
+        this.clones = ConcurrentCollections.newConcurrentMapWithAggressiveConcurrency();
+        this.localIndexInput.set(localInput);
+        this.underlyingIndexInput.set(localInput);
+    }
+
+    /**
+     * Clone/slice constructor — shares sharedLock and clones map with the original.
+     */
+    private FormatSwitchableIndexInput(
+        String resourceDescription,
+        String fileName,
+        long fileLength,
+        RemoteSegmentStoreDirectory remoteDirectory,
+        Supplier<IndexInput> remoteInputSupplier,
+        boolean hasSwitchedToRemote,
+        IndexInput clonedLocal,
+        IndexInput clonedRemote,
+        ConcurrentMap<FormatSwitchableIndexInput, Boolean> clones,
+        ReadWriteLock sharedLock
+    ) {
+        super(resourceDescription);
+        this.fileName = fileName;
+        this.fileLength = fileLength;
+        this.remoteDirectory = remoteDirectory;
+        this.remoteInputSupplier = remoteInputSupplier;
+        this.isClone = true;
+        this.isClosed = false;
+        this.hasSwitchedToRemote = hasSwitchedToRemote;
+        this.sharedLock = sharedLock;
+        this.objectLock = new ReentrantLock();
+        this.clones = clones;
+        if (hasSwitchedToRemote == false) {
+            this.localIndexInput.set(clonedLocal);
+            this.underlyingIndexInput.set(clonedLocal);
+        } else {
+            this.remoteIndexInput.set(clonedRemote);
+            this.underlyingIndexInput.set(clonedRemote);
+        }
+    }
+
+    /**
+     * Switch all reads (this instance + all clones) to remote.
+     * Takes the shared write lock — blocks concurrent clone/slice.
+     * No-op if already switched or closed.
+     *
+     * <p>Edge cases handled:
+     * <ul>
+     *   <li>Already switched or closed → no-op</li>
+     *   <li>File not present in remote metadata → throws IllegalStateException (same as SwitchableIndexInput)</li>
+     *   <li>Remote input creation fails → exception propagated, state unchanged (still on local)</li>
+     *   <li>Clone already closed → skipped during cascade</li>
+     *   <li>Clone switch fails → logged, other clones still switched, exception not propagated</li>
+     *   <li>oldLocal is null (defensive) → skip seek, skip close</li>
+     *   <li>oldLocal.close() throws → logged, switch still completes</li>
+     * </ul>
+     */
+    public void switchToRemote() throws IOException {
+        sharedLock.writeLock().lock();
+        try {
+            objectLock.lock();
+            try {
+                if (isClosed || hasSwitchedToRemote) return;
+
+                // Validate file is present in remote — same guard as SwitchableIndexInput.validateFilePresentInRemote()
+                validateFilePresentInRemote();
+
+                // Create remote input — if this fails, state is unchanged (still on local).
+                IndexInput remoteInput = getRemoteIndexInput();
+                if (remoteInput == null) {
+                    throw new IOException("Failed to create remote input for file=" + fileName);
+                }
+                remoteIndexInput.set(remoteInput);
+
+                // Preserve file pointer position across the switch.
+                IndexInput oldLocal = underlyingIndexInput.get();
+                if (isClone && oldLocal != null) {
+                    remoteInput.seek(oldLocal.getFilePointer());
+                }
+
+                // Swap the delegate — all subsequent reads go to remote.
+                underlyingIndexInput.set(remoteInput);
+
+                // Cascade to all clones (parent only). Each clone switches independently.
+                if (isClone == false) {
+                    for (FormatSwitchableIndexInput clone : clones.keySet()) {
+                        try {
+                            clone.switchToRemote();
+                        } catch (Exception e) {
+                            // Clone may be closed or supplier may fail for clone — log and continue.
+                            logger.error("Failed to switch clone to remote for file={}", fileName, e);
+                        }
+                    }
+                }
+
+                // Close old local input — release file handle.
+                if (oldLocal != null) {
+                    try {
+                        oldLocal.close();
+                    } catch (Exception e) {
+                        // Local file may already be deleted — that's fine.
+                        logger.debug("Failed to close local input during switch for file={}", fileName, e);
+                    }
+                }
+
+                hasSwitchedToRemote = true;
+            } finally {
+                objectLock.unlock();
+            }
+        } finally {
+            sharedLock.writeLock().unlock();
+        }
+    }
+
+    /**
+     * Validates that the file exists in remote metadata before switching.
+     * Same pattern as .
+     *
+     * @throws IllegalStateException if the file is not present in remote
+     */
+    private void validateFilePresentInRemote() {
+        if (remoteDirectory == null) {
+            // Supplier-based mode (tests) — skip validation, trust the caller.
+            return;
+        }
+        if (remoteDirectory.getExistingRemoteFilename(fileName) == null) {
+            throw new IllegalStateException("Cannot switch to remote — file " + fileName + " not present in remote metadata");
+        }
+    }
+
+    /**
+     * Creates the remote IndexInput. Uses remoteDirectory if available (production),
+     * falls back to supplier (tests).
+     */
+    private IndexInput getRemoteIndexInput() throws IOException {
+        if (remoteDirectory != null) {
+            return remoteDirectory.openInput(fileName, IOContext.DEFAULT);
+        }
+        if (remoteInputSupplier != null) {
+            return remoteInputSupplier.get();
+        }
+        throw new IOException("No remote directory or supplier configured for file=" + fileName);
+    }
+
+    /**
+     * Returns true if this input has been switched to remote.
+     */
+    public boolean hasSwitchedToRemote() {
+        return hasSwitchedToRemote;
+    }
+
+    @Override
+    public void close() throws IOException {
+        withOptionalLock(() -> {
+            if (isClosed == false) {
+                if (localIndexInput.get() != null) localIndexInput.get().close();
+                if (remoteIndexInput.get() != null) remoteIndexInput.get().close();
+                if (isClone) {
+                    clones.remove(this);
+                } else {
+                    clones.clear();
+                }
+                isClosed = true;
+            }
+        });
+    }
+
+    @Override
+    public byte readByte() throws IOException {
+        return withOptionalLock(() -> underlyingIndexInput.get().readByte());
+    }
+
+    @Override
+    public void readBytes(byte[] b, int offset, int len) throws IOException {
+        withOptionalLock(() -> underlyingIndexInput.get().readBytes(b, offset, len));
+    }
+
+    @Override
+    public short readShort() throws IOException {
+        return withOptionalLock(() -> underlyingIndexInput.get().readShort());
+    }
+
+    @Override
+    public int readInt() throws IOException {
+        return withOptionalLock(() -> underlyingIndexInput.get().readInt());
+    }
+
+    @Override
+    public long readLong() throws IOException {
+        return withOptionalLock(() -> underlyingIndexInput.get().readLong());
+    }
+
+    @Override
+    public int readVInt() throws IOException {
+        return withOptionalLock(() -> underlyingIndexInput.get().readVInt());
+    }
+
+    @Override
+    public long readVLong() throws IOException {
+        return withOptionalLock(() -> underlyingIndexInput.get().readVLong());
+    }
+
+    @Override
+    public long getFilePointer() {
+        return withOptionalLock(() -> underlyingIndexInput.get().getFilePointer());
+    }
+
+    @Override
+    public void seek(long pos) throws IOException {
+        withOptionalLock(() -> underlyingIndexInput.get().seek(pos));
+    }
+
+    @Override
+    public long length() {
+        return fileLength;
+    }
+
+    @Override
+    public byte readByte(long pos) throws IOException {
+        return withOptionalLock(() -> ((RandomAccessInput) underlyingIndexInput.get()).readByte(pos));
+    }
+
+    @Override
+    public short readShort(long pos) throws IOException {
+        return withOptionalLock(() -> ((RandomAccessInput) underlyingIndexInput.get()).readShort(pos));
+    }
+
+    @Override
+    public int readInt(long pos) throws IOException {
+        return withOptionalLock(() -> ((RandomAccessInput) underlyingIndexInput.get()).readInt(pos));
+    }
+
+    @Override
+    public long readLong(long pos) throws IOException {
+        return withOptionalLock(() -> ((RandomAccessInput) underlyingIndexInput.get()).readLong(pos));
+    }
+
+    @Override
+    public void prefetch(long offset, long length) throws IOException {
+        underlyingIndexInput.get().prefetch(offset, length);
+    }
+
+    @Override
+    public FormatSwitchableIndexInput clone() {
+        sharedLock.readLock().lock();
+        try {
+            return withOptionalLock(() -> {
+                try {
+                    FormatSwitchableIndexInput cloned = new FormatSwitchableIndexInput(
+                        "FormatSwitchableIndexInput Clone (file=" + fileName + ")",
+                        fileName,
+                        fileLength,
+                        remoteDirectory,
+                        remoteInputSupplier,
+                        hasSwitchedToRemote,
+                        (hasSwitchedToRemote == false && localIndexInput.get() != null) ? localIndexInput.get().clone() : null,
+                        (hasSwitchedToRemote && remoteIndexInput.get() != null) ? remoteIndexInput.get().clone() : null,
+                        clones,
+                        sharedLock
+                    );
+                    cloned.seek(getFilePointer());
+                    clones.put(cloned, true);
+                    return cloned;
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+        } finally {
+            sharedLock.readLock().unlock();
+        }
+    }
+
+    @Override
+    public IndexInput slice(String sliceDescription, long offset, long length) throws IOException {
+        sharedLock.readLock().lock();
+        try {
+            return withOptionalLock(() -> {
+                try {
+                    FormatSwitchableIndexInput sliced = new FormatSwitchableIndexInput(
+                        "FormatSwitchableIndexInput Slice " + sliceDescription + " (file=" + fileName + ")",
+                        fileName,
+                        length,
+                        remoteDirectory,
+                        remoteInputSupplier,
+                        hasSwitchedToRemote,
+                        (hasSwitchedToRemote == false && localIndexInput.get() != null)
+                            ? localIndexInput.get().slice(sliceDescription, offset, length)
+                            : null,
+                        (hasSwitchedToRemote && remoteIndexInput.get() != null)
+                            ? remoteIndexInput.get().slice(sliceDescription, offset, length)
+                            : null,
+                        clones,
+                        sharedLock
+                    );
+                    sliced.seek(0);
+                    clones.put(sliced, true);
+                    return sliced;
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+        } finally {
+            sharedLock.readLock().unlock();
+        }
+    }
+
+    /**
+     * Runnable implementation for use with {@link java.lang.ref.Cleaner}.
+     * Invoked when the object becomes phantom-reachable — ensures resources
+     * are released even if the caller forgets to call {@link #close()}.
+     */
+    @Override
+    public void run() {
+        try {
+            close();
+        } catch (Exception e) {
+            logger.error("Error while cleaning up FormatSwitchableIndexInput for file={}", fileName, e);
+        }
+    }
+
+    // -- withOptionalLock helpers (same pattern as SwitchableIndexInput) ------
+
+    private void withOptionalLock(IORunnable operation) throws IOException {
+        if (hasSwitchedToRemote) {
+            operation.run();
+            return;
+        }
+        objectLock.lock();
+        try {
+            operation.run();
+        } finally {
+            objectLock.unlock();
+        }
+    }
+
+    private <T, E extends Exception> T withOptionalLock(ThrowingSupplier<T, E> operation) throws E {
+        if (hasSwitchedToRemote) {
+            return operation.get();
+        }
+        objectLock.lock();
+        try {
+            return operation.get();
+        } finally {
+            objectLock.unlock();
+        }
+    }
+
+    @FunctionalInterface
+    private interface ThrowingSupplier<T, E extends Exception> {
+        T get() throws E;
+    }
+}

--- a/server/src/main/java/org/opensearch/storage/indexinput/FormatSwitchableIndexInputWrapper.java
+++ b/server/src/main/java/org/opensearch/storage/indexinput/FormatSwitchableIndexInputWrapper.java
@@ -1,0 +1,131 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.storage.indexinput;
+
+import org.apache.lucene.store.FilterIndexInput;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.RandomAccessInput;
+import org.opensearch.common.annotation.ExperimentalApi;
+import org.opensearch.common.util.concurrent.OpenSearchExecutors;
+
+import java.io.IOException;
+import java.lang.ref.Cleaner;
+
+/**
+ * Wrapper around {@link FormatSwitchableIndexInput} that uses a {@link Cleaner}
+ * to ensure resources are released even if the caller forgets to close.
+ *
+ * <p>Same pattern as {@link SwitchableIndexInputWrapper} — the cleaner holds a
+ * reference to the inner {@link FormatSwitchableIndexInput} (which implements
+ * {@link Runnable}). When this wrapper becomes phantom-reachable, the cleaner
+ * invokes {@code run()} → {@code close()} on the inner input.
+ *
+ * @opensearch.experimental
+ */
+@ExperimentalApi
+public class FormatSwitchableIndexInputWrapper extends FilterIndexInput implements RandomAccessInput {
+
+    private static final Cleaner CLEANER = Cleaner.create(OpenSearchExecutors.daemonThreadFactory("index-input-cleaner"));
+
+    private final String resourceDescription;
+    private final FormatSwitchableIndexInput formatSwitchableIndexInput;
+
+    public FormatSwitchableIndexInputWrapper(String resourceDescription, FormatSwitchableIndexInput in) {
+        super(resourceDescription, in);
+        this.resourceDescription = resourceDescription;
+        this.formatSwitchableIndexInput = in;
+        CLEANER.register(this, in);
+    }
+
+    /**
+     * Returns the underlying {@link FormatSwitchableIndexInput} for switch operations.
+     */
+    public FormatSwitchableIndexInput unwrap() {
+        return formatSwitchableIndexInput;
+    }
+
+    @Override
+    public IndexInput clone() {
+        return new FormatSwitchableIndexInputWrapper("Cloned " + resourceDescription, formatSwitchableIndexInput.clone());
+    }
+
+    @Override
+    public IndexInput slice(String sliceDescription, long offset, long length) throws IOException {
+        IndexInput sliced = formatSwitchableIndexInput.slice(sliceDescription, offset, length);
+        if (sliced instanceof FormatSwitchableIndexInput) {
+            return new FormatSwitchableIndexInputWrapper("Sliced " + resourceDescription, (FormatSwitchableIndexInput) sliced);
+        }
+        return sliced;
+    }
+
+    @Override
+    public void close() throws IOException {
+        formatSwitchableIndexInput.close();
+    }
+
+    @Override
+    public byte readByte() throws IOException {
+        return formatSwitchableIndexInput.readByte();
+    }
+
+    @Override
+    public short readShort() throws IOException {
+        return formatSwitchableIndexInput.readShort();
+    }
+
+    @Override
+    public int readInt() throws IOException {
+        return formatSwitchableIndexInput.readInt();
+    }
+
+    @Override
+    public long readLong() throws IOException {
+        return formatSwitchableIndexInput.readLong();
+    }
+
+    @Override
+    public int readVInt() throws IOException {
+        return formatSwitchableIndexInput.readVInt();
+    }
+
+    @Override
+    public long readVLong() throws IOException {
+        return formatSwitchableIndexInput.readVLong();
+    }
+
+    @Override
+    public void readBytes(byte[] b, int offset, int len) throws IOException {
+        formatSwitchableIndexInput.readBytes(b, offset, len);
+    }
+
+    @Override
+    public byte readByte(long pos) throws IOException {
+        return formatSwitchableIndexInput.readByte(pos);
+    }
+
+    @Override
+    public short readShort(long pos) throws IOException {
+        return formatSwitchableIndexInput.readShort(pos);
+    }
+
+    @Override
+    public int readInt(long pos) throws IOException {
+        return formatSwitchableIndexInput.readInt(pos);
+    }
+
+    @Override
+    public long readLong(long pos) throws IOException {
+        return formatSwitchableIndexInput.readLong(pos);
+    }
+
+    @Override
+    public void prefetch(long offset, long length) throws IOException {
+        formatSwitchableIndexInput.prefetch(offset, length);
+    }
+}

--- a/server/src/test/java/org/opensearch/index/engine/dataformat/DataFormatRegistryTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/dataformat/DataFormatRegistryTests.java
@@ -272,7 +272,7 @@ public class DataFormatRegistryTests extends OpenSearchTestCase {
         DataFormatRegistry registry = new DataFormatRegistry(pluginsService);
 
         Map<DataFormat, EngineReaderManager<?>> managers = registry.getReaderManager(
-            new ReaderManagerConfig(Optional.empty(), format, registry, shardPath)
+            new ReaderManagerConfig(Optional.empty(), format, registry, shardPath, Map.of())
         );
         assertEquals(1, managers.size());
         assertNotNull(managers.get(format));

--- a/server/src/test/java/org/opensearch/index/store/StoreTests.java
+++ b/server/src/test/java/org/opensearch/index/store/StoreTests.java
@@ -1346,4 +1346,49 @@ public class StoreTests extends OpenSearchTestCase {
         writer.addDocument(doc);
         return writer;
     }
+
+    public void testGetDataformatAwareStoreHandlesReturnsMapPassedAtConstruction() {
+        final ShardId shardId = new ShardId("index", "_na_", 1);
+        org.opensearch.index.engine.dataformat.DataFormat testFormat = new org.opensearch.index.engine.dataformat.DataFormat() {
+            @Override
+            public String name() {
+                return "test-format";
+            }
+
+            @Override
+            public long priority() {
+                return 1;
+            }
+
+            @Override
+            public java.util.Set<org.opensearch.index.engine.dataformat.FieldTypeCapabilities> supportedFields() {
+                return java.util.Set.of();
+            }
+        };
+        org.opensearch.plugins.NativeStoreHandle handle = new org.opensearch.plugins.NativeStoreHandle(123L, ptr -> {});
+        Map<org.opensearch.index.engine.dataformat.DataFormat, org.opensearch.plugins.NativeStoreHandle> handles = Map.of(
+            testFormat,
+            handle
+        );
+
+        Store store = new Store(
+            shardId,
+            INDEX_SETTINGS,
+            StoreTests.newDirectory(random()),
+            new DummyShardLock(shardId),
+            Store.OnClose.EMPTY,
+            null,
+            null,
+            handles
+        );
+
+        Map<org.opensearch.index.engine.dataformat.DataFormat, org.opensearch.plugins.NativeStoreHandle> result = store
+            .getDataformatAwareStoreHandles();
+        assertSame("getDataformatAwareStoreHandles should return the same map passed at construction", handles, result);
+        assertEquals(1, result.size());
+        assertSame(handle, result.get(testFormat));
+
+        handle.close();
+        store.close();
+    }
 }

--- a/server/src/test/java/org/opensearch/storage/directory/GracefulDegradationTests.java
+++ b/server/src/test/java/org/opensearch/storage/directory/GracefulDegradationTests.java
@@ -100,15 +100,20 @@ public class GracefulDegradationTests extends OpenSearchTestCase {
         );
 
         // Should not throw — graceful degradation
+        StoreStrategyRegistry registry = StoreStrategyRegistry.open(
+            shardPath,
+            true,
+            org.opensearch.repositories.NativeStoreRepository.EMPTY,
+            java.util.Map.of(),
+            remoteDir
+        );
         DataFormatAwareStoreDirectory storeDir = factory.newDataFormatAwareStoreDirectory(
             indexSettings,
             shardId,
             shardPath,
             localDirFactory,
             Map.of(),
-            java.util.Map.of(),
-            org.opensearch.repositories.NativeStoreRepository.EMPTY,
-            true,
+            registry,
             remoteDir,
             fileCache,
             null

--- a/server/src/test/java/org/opensearch/storage/directory/StoreStrategyRegistryTests.java
+++ b/server/src/test/java/org/opensearch/storage/directory/StoreStrategyRegistryTests.java
@@ -11,6 +11,7 @@ package org.opensearch.storage.directory;
 import org.opensearch.common.SuppressForbidden;
 import org.opensearch.common.blobstore.BlobContainer;
 import org.opensearch.common.blobstore.BlobPath;
+import org.opensearch.common.blobstore.BlobStore;
 import org.opensearch.core.index.Index;
 import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.index.engine.dataformat.DataFormat;
@@ -23,6 +24,7 @@ import org.opensearch.index.store.RemoteDirectory;
 import org.opensearch.index.store.RemoteSegmentStoreDirectory;
 import org.opensearch.index.store.RemoteSegmentStoreDirectory.UploadedSegmentMetadata;
 import org.opensearch.index.store.lockmanager.RemoteStoreLockManager;
+import org.opensearch.index.store.remote.FormatBlobRouter;
 import org.opensearch.plugins.NativeStoreHandle;
 import org.opensearch.repositories.NativeStoreRepository;
 import org.opensearch.test.OpenSearchTestCase;
@@ -258,9 +260,9 @@ public class StoreStrategyRegistryTests extends OpenSearchTestCase {
             remoteDir
         );
 
-        boolean dispatched = registry.onUploaded("parquet/_0.parquet", "test-base-path/", "new_blob_key", 1024L);
+        boolean dispatched = registry.onUploaded("parquet/_0.parquet", "test-base-path/parquet/", "new_blob_key", 1024L);
         assertTrue(dispatched);
-        // remotePath default: basePath + name + "/" + blobKey
+        // remotePath: basePath + blobKey (basePath already includes format subdirectory)
         verify(handler).onUploaded(
             org.mockito.ArgumentMatchers.contains("parquet/_0.parquet"),
             eq("test-base-path/parquet/new_blob_key"),
@@ -472,6 +474,45 @@ public class StoreStrategyRegistryTests extends OpenSearchTestCase {
         registry.close();
     }
 
+    public void testSeedUsesFormatSpecificBasePath() throws Exception {
+        DataFormatStoreHandler handler = mock(DataFormatStoreHandler.class);
+        StoreStrategy strategy = createTestStrategy(handler);
+
+        // Create a RemoteSegmentStoreDirectory with a FormatBlobRouter that routes
+        // "parquet" to a different sub-path than the base path.
+        RemoteSegmentStoreDirectory remoteDir = createRemoteDirWithFormatRouter();
+        injectUploadedSegment(remoteDir, "parquet/_0.parquet", "parquet_blob_key");
+
+        StoreStrategyRegistry registry = StoreStrategyRegistry.open(
+            shardPath,
+            true,
+            NativeStoreRepository.EMPTY,
+            Map.of(PARQUET_FORMAT, strategy),
+            remoteDir
+        );
+
+        @SuppressWarnings("unchecked")
+        org.mockito.ArgumentCaptor<Map<String, DataFormatStoreHandler.FileEntry>> captor = org.mockito.ArgumentCaptor.forClass(Map.class);
+        verify(handler).seed(captor.capture());
+
+        Map<String, DataFormatStoreHandler.FileEntry> seeded = captor.getValue();
+        assertFalse("Seed map should not be empty", seeded.isEmpty());
+
+        String expectedKey = shardPath.getDataPath().resolve("parquet/_0.parquet").toString();
+        assertTrue("Seed key should be absolute path", seeded.containsKey(expectedKey));
+
+        DataFormatStoreHandler.FileEntry entry = seeded.get(expectedKey);
+        // The FormatBlobRouter routes "parquet" to "base-path/parquet/" so getRemoteBasePath("parquet")
+        // returns "base-path/parquet/". The default remotePath appends format + "/" + blobKey.
+        assertTrue(
+            "Seeded path should use format-specific base path containing 'parquet': " + entry.path(),
+            entry.path().contains("parquet")
+        );
+        assertEquals(DataFormatStoreHandler.REMOTE, entry.location());
+
+        registry.close();
+    }
+
     // ═══════════════════════════════════════════════════════════════
     // Helpers
     // ═══════════════════════════════════════════════════════════════
@@ -493,8 +534,34 @@ public class StoreStrategyRegistryTests extends OpenSearchTestCase {
         ThreadPool tp = mock(ThreadPool.class);
 
         BlobContainer mockBlobContainer = mock(BlobContainer.class);
-        when(mockBlobContainer.path()).thenReturn(new BlobPath().add("test-base-path"));
+        when(mockBlobContainer.path()).thenReturn(new BlobPath().add("test-base-path").add("parquet"));
         when(remoteDataDir.getBlobContainer()).thenReturn(mockBlobContainer);
+
+        return new RemoteSegmentStoreDirectory(remoteDataDir, remoteMetadataDir, lockManager, tp, shardPath.getShardId(), new HashMap<>());
+    }
+
+    private RemoteSegmentStoreDirectory createRemoteDirWithFormatRouter() throws IOException {
+        RemoteDirectory remoteDataDir = mock(RemoteDirectory.class);
+        RemoteDirectory remoteMetadataDir = mock(RemoteDirectory.class);
+        RemoteStoreLockManager lockManager = mock(RemoteStoreLockManager.class);
+        ThreadPool tp = mock(ThreadPool.class);
+
+        BlobPath basePath = new BlobPath().add("base-path");
+        BlobContainer baseBlobContainer = mock(BlobContainer.class);
+        when(baseBlobContainer.path()).thenReturn(basePath);
+        when(remoteDataDir.getBlobContainer()).thenReturn(baseBlobContainer);
+
+        // Create a FormatBlobRouter that routes "parquet" to "base-path/parquet/"
+        BlobStore blobStore = mock(BlobStore.class);
+        when(blobStore.blobContainer(basePath)).thenReturn(baseBlobContainer);
+
+        BlobPath parquetPath = basePath.add("parquet");
+        BlobContainer parquetBlobContainer = mock(BlobContainer.class);
+        when(parquetBlobContainer.path()).thenReturn(parquetPath);
+        when(blobStore.blobContainer(parquetPath)).thenReturn(parquetBlobContainer);
+
+        FormatBlobRouter router = new FormatBlobRouter(blobStore, basePath);
+        when(remoteDataDir.getFormatBlobRouter()).thenReturn(Optional.of(router));
 
         return new RemoteSegmentStoreDirectory(remoteDataDir, remoteMetadataDir, lockManager, tp, shardPath.getShardId(), new HashMap<>());
     }

--- a/server/src/test/java/org/opensearch/storage/directory/TieredDataFormatAwareStoreDirectoryFactoryTests.java
+++ b/server/src/test/java/org/opensearch/storage/directory/TieredDataFormatAwareStoreDirectoryFactoryTests.java
@@ -125,15 +125,20 @@ public class TieredDataFormatAwareStoreDirectoryFactoryTests extends OpenSearchT
      * DataFormatAwareStoreDirectory wrapping TieredSubdirectoryAwareDirectory.
      */
     public void testCreatesCorrectDirectoryStack() throws IOException {
+        StoreStrategyRegistry registry = StoreStrategyRegistry.open(
+            shardPath,
+            true,
+            org.opensearch.repositories.NativeStoreRepository.EMPTY,
+            java.util.Map.of(),
+            remoteDirectory
+        );
         DataFormatAwareStoreDirectory result = factory.newDataFormatAwareStoreDirectory(
             indexSettings,
             shardId,
             shardPath,
             localDirectoryFactory,
             Map.of(),
-            java.util.Map.of(),
-            org.opensearch.repositories.NativeStoreRepository.EMPTY,
-            true,
+            registry,
             remoteDirectory,
             fileCache,
             threadPool
@@ -158,15 +163,20 @@ public class TieredDataFormatAwareStoreDirectoryFactoryTests extends OpenSearchT
      * The factory should NOT double-wrap with SubdirectoryAwareDirectory.
      */
     public void testNoDoubleSubdirectoryAwareDirectoryWrapping() throws IOException {
+        StoreStrategyRegistry registry = StoreStrategyRegistry.open(
+            shardPath,
+            true,
+            org.opensearch.repositories.NativeStoreRepository.EMPTY,
+            java.util.Map.of(),
+            remoteDirectory
+        );
         DataFormatAwareStoreDirectory result = factory.newDataFormatAwareStoreDirectory(
             indexSettings,
             shardId,
             shardPath,
             localDirectoryFactory,
             Map.of(),
-            java.util.Map.of(),
-            org.opensearch.repositories.NativeStoreRepository.EMPTY,
-            true,
+            registry,
             remoteDirectory,
             fileCache,
             threadPool
@@ -191,15 +201,20 @@ public class TieredDataFormatAwareStoreDirectoryFactoryTests extends OpenSearchT
      * the factory still creates a valid directory stack with no format directories.
      */
     public void testEmptyFormatDirectoriesWhenNoPluginProvides() throws IOException {
+        StoreStrategyRegistry registry = StoreStrategyRegistry.open(
+            shardPath,
+            true,
+            org.opensearch.repositories.NativeStoreRepository.EMPTY,
+            java.util.Map.of(),
+            remoteDirectory
+        );
         DataFormatAwareStoreDirectory result = factory.newDataFormatAwareStoreDirectory(
             indexSettings,
             shardId,
             shardPath,
             localDirectoryFactory,
             Map.of(),
-            java.util.Map.of(),
-            org.opensearch.repositories.NativeStoreRepository.EMPTY,
-            true,
+            registry,
             remoteDirectory,
             fileCache,
             threadPool

--- a/server/src/test/java/org/opensearch/storage/directory/TieredSubdirectoryAwareDirectoryTests.java
+++ b/server/src/test/java/org/opensearch/storage/directory/TieredSubdirectoryAwareDirectoryTests.java
@@ -92,9 +92,10 @@ public class TieredSubdirectoryAwareDirectoryTests extends TieredStorageBaseTest
     public void setup() throws IOException {
         setupRemoteSegmentStoreDirectory();
 
-        // Stub getBlobContainer().path() so getRemoteBasePath() doesn't NPE in afterSyncToRemote tests
+        // Stub getBlobContainer().path() so getRemoteBasePath(format) doesn't NPE in afterSyncToRemote tests
+        // In production, getRemoteBasePath("parquet") returns a path that includes the format subdirectory
         BlobContainer mockBlobContainer = mock(BlobContainer.class);
-        when(mockBlobContainer.path()).thenReturn(new BlobPath().add("test-base-path"));
+        when(mockBlobContainer.path()).thenReturn(new BlobPath().add("test-base-path").add("parquet"));
         when(((RemoteDirectory) remoteDataDirectory).getBlobContainer()).thenReturn(mockBlobContainer);
 
         populateMetadata();
@@ -407,6 +408,22 @@ public class TieredSubdirectoryAwareDirectoryTests extends TieredStorageBaseTest
         );
     }
 
+    public void testAfterSyncToRemotePassesCorrectFormatToGetRemoteBasePath() throws IOException {
+        WithRegistry w = buildDirectoryWithParquetFormat();
+        String parquetFile = "parquet/seg_format_path.parquet";
+        addParquetMetadataEntry(parquetFile, "seg_format_path.parquet__UUID1");
+        w.directory.afterSyncToRemote(parquetFile);
+        // remotePath builds: basePath + blobKey. basePath from getRemoteBasePath("parquet")
+        // returns "test-base-path/parquet/" (mock BlobPath includes format subdirectory),
+        // so the path should be "test-base-path/parquet/seg_format_path.parquet__UUID1"
+        String expectedUploadKey = shardPath.getDataPath().resolve(parquetFile).toString();
+        verify(w.storeHandler).onUploaded(
+            org.mockito.ArgumentMatchers.eq(expectedUploadKey),
+            org.mockito.ArgumentMatchers.eq("test-base-path/parquet/seg_format_path.parquet__UUID1"),
+            org.mockito.ArgumentMatchers.anyLong()
+        );
+    }
+
     public void testAfterSyncToRemoteFormatFileWithoutRemoteSyncAware() throws IOException {
         directory = buildDirectoryWithParquetFormat().directory;
         try {
@@ -628,7 +645,7 @@ public class TieredSubdirectoryAwareDirectoryTests extends TieredStorageBaseTest
     }
 
     /** Minimal test strategy for "parquet" wiring. */
-    private static final class TestParquetStrategy implements StoreStrategy {
+    private static final class TestParquetStrategy extends StoreStrategy {
         private final DataFormatStoreHandlerFactory factory;
 
         TestParquetStrategy(DataFormatStoreHandlerFactory factory) {
@@ -684,15 +701,31 @@ public class TieredSubdirectoryAwareDirectoryTests extends TieredStorageBaseTest
         }
     }
 
-    public void testRenameFormatFileThrowsIllegalState() throws IOException {
+    public void testRenameFormatFileRoutesToSubdirectoryAware() throws IOException {
         WithRegistry w = buildDirectoryWithParquetFormat();
         try {
-            IllegalStateException ex = expectThrows(
-                IllegalStateException.class,
-                () -> w.directory.rename("parquet/seg_0.parquet", "parquet/seg_1.parquet")
-            );
-            assertTrue(ex.getMessage().contains("parquet/seg_0.parquet"));
-            assertTrue(ex.getMessage().contains("write-once"));
+            String parquetFile = "parquet/seg_rename.parquet";
+            writeParquetFileToDisk(parquetFile);
+            // Rename should succeed — routes through SubdirectoryAwareDirectory for recovery support
+            w.directory.rename(parquetFile, "parquet/seg_renamed.parquet");
+            // Verify renamed file exists
+            assertTrue(java.nio.file.Files.exists(shardPath.getDataPath().resolve("parquet/seg_renamed.parquet")));
+            assertFalse(java.nio.file.Files.exists(shardPath.getDataPath().resolve(parquetFile)));
+        } finally {
+            w.directory.close();
+        }
+    }
+
+    public void testRenameRecoveryPrefixedFormatFile() throws IOException {
+        WithRegistry w = buildDirectoryWithParquetFormat();
+        try {
+            // Simulate recovery: write with recovery prefix, then rename to final name
+            String recoveryFile = "parquet/recovery.abc123.seg_0.parquet";
+            String finalFile = "parquet/seg_0.parquet";
+            writeParquetFileToDisk(recoveryFile);
+            w.directory.rename(recoveryFile, finalFile);
+            assertTrue(java.nio.file.Files.exists(shardPath.getDataPath().resolve(finalFile)));
+            assertFalse(java.nio.file.Files.exists(shardPath.getDataPath().resolve(recoveryFile)));
         } finally {
             w.directory.close();
         }
@@ -800,6 +833,247 @@ public class TieredSubdirectoryAwareDirectoryTests extends TieredStorageBaseTest
             w.directory.afterSyncToRemote(parquetFile);
         } finally {
             w.directory.close();
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // FormatSwitchableIndexInput integration tests
+    // ═══════════════════════════════════════════════════════════════
+
+    public void testOpenInputLocalFormatFileReturnsFormatSwitchable() throws IOException {
+        WithRegistry w = buildDirectoryWithParquetFormat();
+        try {
+            String parquetFile = "parquet/seg_switchable.parquet";
+            writeParquetFileToDisk(parquetFile);
+            // File NOT in remote metadata → openInput takes local path → wraps in FormatSwitchableIndexInput
+            IndexInput input = w.directory.openInput(parquetFile, IOContext.DEFAULT);
+            assertTrue(
+                "Local format file should be wrapped in FormatSwitchableIndexInput",
+                input instanceof org.opensearch.storage.indexinput.FormatSwitchableIndexInputWrapper
+            );
+            input.close();
+        } finally {
+            w.directory.close();
+        }
+    }
+
+    public void testOpenInputRemoteFormatFileDoesNotWrapInSwitchable() throws IOException {
+        directory = buildDirectoryWithParquetFormat().directory;
+        populateData();
+        try {
+            String parquetFile = "parquet/seg_remote_nowrap.parquet";
+            addParquetMetadataEntry(parquetFile, "seg_remote_nowrap.parquet__UUID1");
+            // File IS in remote metadata → openInput routes directly to remote, no switchable wrapper
+            IndexInput input = directory.openInput(parquetFile, IOContext.DEFAULT);
+            assertFalse(
+                "Remote format file should NOT be wrapped in FormatSwitchableIndexInput",
+                input instanceof org.opensearch.storage.indexinput.FormatSwitchableIndexInputWrapper
+            );
+            input.close();
+        } finally {
+            directory.close();
+        }
+    }
+
+    public void testAfterSyncToRemoteSwitchesInFlightReader() throws IOException {
+        WithRegistry w = buildDirectoryWithParquetFormat();
+        populateData();
+        try {
+            String parquetFile = "parquet/seg_inflight.parquet";
+            writeParquetFileToDisk(parquetFile);
+
+            // Open input while file is local (not yet synced)
+            IndexInput input = w.directory.openInput(parquetFile, IOContext.DEFAULT);
+            assertTrue(input instanceof org.opensearch.storage.indexinput.FormatSwitchableIndexInputWrapper);
+            org.opensearch.storage.indexinput.FormatSwitchableIndexInput switchable =
+                ((org.opensearch.storage.indexinput.FormatSwitchableIndexInputWrapper) input).unwrap();
+            assertFalse("Should start on local", switchable.hasSwitchedToRemote());
+
+            // Read some bytes from local
+            byte[] buf = new byte[PARQUET_DATA.length];
+            switchable.readBytes(buf, 0, buf.length);
+            assertArrayEquals("Should read local data before sync", PARQUET_DATA, buf);
+
+            // Now simulate sync: add remote metadata and call afterSyncToRemote
+            addParquetMetadataEntry(parquetFile, "seg_inflight.parquet__UUID1");
+            w.directory.afterSyncToRemote(parquetFile);
+
+            // The switchable should now be on remote
+            assertTrue("Should be switched to remote after afterSyncToRemote", switchable.hasSwitchedToRemote());
+
+            // Local file should be deleted
+            assertFalse("Local file should be deleted", java.nio.file.Files.exists(shardPath.getDataPath().resolve(parquetFile)));
+
+            input.close();
+        } finally {
+            w.directory.close();
+        }
+    }
+
+    public void testAfterSyncToRemoteSwitchesClonesOfInFlightReader() throws IOException {
+        WithRegistry w = buildDirectoryWithParquetFormat();
+        populateData();
+        try {
+            String parquetFile = "parquet/seg_clone_switch.parquet";
+            writeParquetFileToDisk(parquetFile);
+
+            // Open input and clone it
+            IndexInput input = w.directory.openInput(parquetFile, IOContext.DEFAULT);
+            assertTrue(input instanceof org.opensearch.storage.indexinput.FormatSwitchableIndexInputWrapper);
+            org.opensearch.storage.indexinput.FormatSwitchableIndexInput switchable =
+                ((org.opensearch.storage.indexinput.FormatSwitchableIndexInputWrapper) input).unwrap();
+            assertFalse(switchable.hasSwitchedToRemote());
+
+            // Sync — the switch cascades to clones internally (tested in FormatSwitchableIndexInputTests)
+            addParquetMetadataEntry(parquetFile, "seg_clone_switch.parquet__UUID1");
+            w.directory.afterSyncToRemote(parquetFile);
+
+            assertTrue("Original should be switched", switchable.hasSwitchedToRemote());
+
+            input.close();
+        } finally {
+            w.directory.close();
+        }
+    }
+
+    public void testAfterSyncToRemoteWithNoOpenInputStillDeletesLocal() throws IOException {
+        WithRegistry w = buildDirectoryWithParquetFormat();
+        try {
+            String parquetFile = "parquet/seg_no_reader.parquet";
+            writeParquetFileToDisk(parquetFile);
+            assertTrue(java.nio.file.Files.exists(shardPath.getDataPath().resolve(parquetFile)));
+
+            // No openInput call — no FormatSwitchableIndexInput tracked
+            addParquetMetadataEntry(parquetFile, "seg_no_reader.parquet__UUID1");
+            w.directory.afterSyncToRemote(parquetFile);
+
+            // Local file should still be deleted
+            assertFalse(
+                "Local file should be deleted even without open readers",
+                java.nio.file.Files.exists(shardPath.getDataPath().resolve(parquetFile))
+            );
+        } finally {
+            w.directory.close();
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // openInput — segments_N local fallback tests
+    // ═══════════════════════════════════════════════════════════════
+
+    public void testOpenInputSegmentsFileReadsFromLocalWhenNotInRemoteMetadata() throws IOException {
+        directory = buildDirectoryWithParquetFormat().directory;
+        populateData();
+        try {
+            // Write a segments_N file locally (simulates a restart where local generation differs from remote)
+            String segmentsFile = "segments_5";
+            try (IndexOutput out = subdirAware.createOutput(segmentsFile, IOContext.DEFAULT)) {
+                out.writeBytes(TEST_DATA, TEST_DATA.length);
+            }
+
+            // segments_5 is NOT in remote metadata → should read from local disk
+            try (IndexInput in = directory.openInput(segmentsFile, IOContext.DEFAULT)) {
+                assertNotNull("openInput should return non-null for local segments file", in);
+                byte[] buf = new byte[TEST_DATA.length];
+                in.readBytes(buf, 0, buf.length);
+                assertArrayEquals("Should read local segments file data", TEST_DATA, buf);
+            }
+        } finally {
+            directory.close();
+        }
+    }
+
+    public void testOpenInputSegmentsFileFallsToTieredDirectoryWhenNotLocal() throws IOException {
+        directory = buildDirectoryWithParquetFormat().directory;
+        populateData();
+        try {
+            // segments_99 doesn't exist locally or in remote metadata.
+            // The local read throws NoSuchFileException, then falls through to TieredDirectory.
+            // TieredDirectory also won't find it → expect an exception.
+            expectThrows(Exception.class, () -> directory.openInput("segments_99", IOContext.DEFAULT));
+        } finally {
+            directory.close();
+        }
+    }
+
+    public void testOpenInputSegmentsFileInRemoteMetadataRoutesToTieredDirectory() throws IOException {
+        directory = buildDirectoryWithParquetFormat().directory;
+        populateData();
+        try {
+            // segments_N that IS in remote metadata should NOT take the local fallback path.
+            // It should go through TieredDirectory (the normal Lucene file path).
+            // The remote metadata from populateMetadata() includes standard Lucene files.
+            // We'll use a segments file that's in remote metadata by adding it.
+            String segmentsFile = "segments_2";
+            addParquetMetadataEntry(segmentsFile, "segments_2__UUID1");
+
+            // Since it's in remote metadata, getExistingRemoteFilename != null → skips local fallback.
+            // Goes to tieredDirectory.openInput which reads from remote via FileCache.
+            try (IndexInput in = directory.openInput(segmentsFile, IOContext.DEFAULT)) {
+                assertNotNull("Should read segments file from TieredDirectory when in remote metadata", in);
+            }
+        } finally {
+            directory.close();
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // createOutput — format file routing tests
+    // ═══════════════════════════════════════════════════════════════
+
+    public void testCreateOutputFormatFileRoutesToSubdirectoryAwareDirectory() throws IOException {
+        directory = buildDirectoryWithParquetFormat().directory;
+        try {
+            String parquetFile = "parquet/seg_create_output.parquet";
+            // createOutput for format files should route through SubdirectoryAwareDirectory
+            // which creates parent directories automatically.
+            try (IndexOutput out = directory.createOutput(parquetFile, IOContext.DEFAULT)) {
+                out.writeBytes(PARQUET_DATA, PARQUET_DATA.length);
+            }
+
+            // Verify the file was written to disk via SubdirectoryAwareDirectory path resolution
+            Path expectedPath = shardPath.getDataPath().resolve(parquetFile);
+            assertTrue("Format file should exist on disk after createOutput", Files.exists(expectedPath));
+            byte[] content = Files.readAllBytes(expectedPath);
+            assertArrayEquals("Written content should match", PARQUET_DATA, content);
+        } finally {
+            directory.close();
+        }
+    }
+
+    public void testCreateOutputFormatFileCreatesParentDirectories() throws IOException {
+        directory = buildDirectoryWithParquetFormat().directory;
+        try {
+            // Use a nested subdirectory path to verify parent dir creation
+            String parquetFile = "parquet/nested/seg_nested.parquet";
+            // This would fail without SubdirectoryAwareDirectory creating parent dirs
+            try (IndexOutput out = directory.createOutput(parquetFile, IOContext.DEFAULT)) {
+                out.writeBytes(PARQUET_DATA, PARQUET_DATA.length);
+            }
+
+            Path expectedPath = shardPath.getDataPath().resolve(parquetFile);
+            assertTrue("Nested format file should exist after createOutput", Files.exists(expectedPath));
+        } finally {
+            directory.close();
+        }
+    }
+
+    public void testCreateOutputLuceneFileStillRoutesToTieredDirectory() throws IOException {
+        directory = buildDirectoryWithParquetFormat().directory;
+        populateData();
+        try {
+            // Lucene files should still go through TieredDirectory (FileCache integration)
+            String luceneFile = "_0_create_lucene.cfe";
+            try (IndexOutput out = directory.createOutput(luceneFile, IOContext.DEFAULT)) {
+                out.writeBytes(TEST_DATA, TEST_DATA.length);
+            }
+
+            // Verify it's in the FileCache (TieredDirectory behavior)
+            Path switchablePath = getFilePathSwitchable(localFsDir, luceneFile);
+            assertNotNull("Lucene file should be in FileCache via TieredDirectory", fileCache.get(switchablePath));
+            fileCache.decRef(switchablePath);
+        } finally {
+            directory.close();
         }
     }
 }

--- a/server/src/test/java/org/opensearch/storage/directory/WarmShardDirectoryStackTests.java
+++ b/server/src/test/java/org/opensearch/storage/directory/WarmShardDirectoryStackTests.java
@@ -139,15 +139,20 @@ public class WarmShardDirectoryStackTests extends OpenSearchTestCase {
 
         RemoteSegmentStoreDirectory remoteDir = createRealRemoteDir(shardPath.getShardId());
 
+        StoreStrategyRegistry registry = StoreStrategyRegistry.open(
+            shardPath,
+            true,
+            NativeStoreRepository.EMPTY,
+            java.util.Map.of(),
+            remoteDir
+        );
         DataFormatAwareStoreDirectory storeDir = factory.newDataFormatAwareStoreDirectory(
             indexSettings,
             shardPath.getShardId(),
             shardPath,
             localDirFactory,
             java.util.Map.of(),
-            java.util.Map.of(),             // no strategies
-            NativeStoreRepository.EMPTY,
-            true,
+            registry,
             remoteDir,
             fileCache,
             null

--- a/server/src/test/java/org/opensearch/storage/indexinput/FormatSwitchableIndexInputTests.java
+++ b/server/src/test/java/org/opensearch/storage/indexinput/FormatSwitchableIndexInputTests.java
@@ -1,0 +1,438 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.storage.indexinput;
+
+import org.apache.lucene.store.ByteBuffersDirectory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.IndexOutput;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Unit tests for {@link FormatSwitchableIndexInput}.
+ *
+ * <p>Tests cover:
+ * <ul>
+ *   <li>Basic read delegation to local input</li>
+ *   <li>switchToRemote transitions reads to remote</li>
+ *   <li>Clone/slice inherit switch state</li>
+ *   <li>switchToRemote cascades to existing clones</li>
+ *   <li>Concurrent reads during switch</li>
+ *   <li>Double switch is no-op</li>
+ *   <li>Close behavior</li>
+ *   <li>File pointer preservation across switch</li>
+ * </ul>
+ */
+public class FormatSwitchableIndexInputTests extends OpenSearchTestCase {
+
+    private static final byte[] LOCAL_DATA = "local-data-content-1234567890".getBytes(StandardCharsets.UTF_8);
+    private static final byte[] REMOTE_DATA = "remote-data-content-1234567890".getBytes(StandardCharsets.UTF_8);
+    private static final String FILE_NAME = "test.parquet";
+
+    private ByteBuffersDirectory localDir;
+    private ByteBuffersDirectory remoteDir;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        localDir = new ByteBuffersDirectory();
+        remoteDir = new ByteBuffersDirectory();
+        writeFile(localDir, FILE_NAME, LOCAL_DATA);
+        writeFile(remoteDir, FILE_NAME, REMOTE_DATA);
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        localDir.close();
+        remoteDir.close();
+        super.tearDown();
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // Basic read delegation
+    // ═══════════════════════════════════════════════════════════════
+
+    public void testReadDelegatesToLocal() throws IOException {
+        try (FormatSwitchableIndexInput input = createSwitchable()) {
+            byte[] buf = new byte[LOCAL_DATA.length];
+            input.readBytes(buf, 0, buf.length);
+            assertArrayEquals(LOCAL_DATA, buf);
+            assertFalse(input.hasSwitchedToRemote());
+        }
+    }
+
+    public void testReadByteFromLocal() throws IOException {
+        try (FormatSwitchableIndexInput input = createSwitchable()) {
+            assertEquals(LOCAL_DATA[0], input.readByte());
+        }
+    }
+
+    public void testLengthReturnsFileLength() throws IOException {
+        try (FormatSwitchableIndexInput input = createSwitchable()) {
+            assertEquals(LOCAL_DATA.length, input.length());
+        }
+    }
+
+    public void testGetFilePointerStartsAtZero() throws IOException {
+        try (FormatSwitchableIndexInput input = createSwitchable()) {
+            assertEquals(0, input.getFilePointer());
+        }
+    }
+
+    public void testSeekAndRead() throws IOException {
+        try (FormatSwitchableIndexInput input = createSwitchable()) {
+            input.seek(5);
+            assertEquals(5, input.getFilePointer());
+            assertEquals(LOCAL_DATA[5], input.readByte());
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // switchToRemote
+    // ═══════════════════════════════════════════════════════════════
+
+    public void testSwitchToRemoteTransitionsReads() throws IOException {
+        try (FormatSwitchableIndexInput input = createSwitchable()) {
+            assertFalse(input.hasSwitchedToRemote());
+            input.switchToRemote();
+            assertTrue(input.hasSwitchedToRemote());
+
+            byte[] buf = new byte[REMOTE_DATA.length];
+            input.readBytes(buf, 0, buf.length);
+            assertArrayEquals(REMOTE_DATA, buf);
+        }
+    }
+
+    public void testSwitchToRemoteIsIdempotent() throws IOException {
+        try (FormatSwitchableIndexInput input = createSwitchable()) {
+            input.switchToRemote();
+            input.switchToRemote(); // second call is no-op
+            assertTrue(input.hasSwitchedToRemote());
+
+            byte[] buf = new byte[REMOTE_DATA.length];
+            input.readBytes(buf, 0, buf.length);
+            assertArrayEquals(REMOTE_DATA, buf);
+        }
+    }
+
+    public void testSwitchOnClosedInputIsNoOp() throws IOException {
+        FormatSwitchableIndexInput input = createSwitchable();
+        input.close();
+        input.switchToRemote(); // should not throw
+    }
+
+    public void testLengthPreservedAfterSwitch() throws IOException {
+        try (FormatSwitchableIndexInput input = createSwitchable()) {
+            long lengthBefore = input.length();
+            input.switchToRemote();
+            assertEquals(lengthBefore, input.length());
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // File pointer preservation across switch
+    // ═══════════════════════════════════════════════════════════════
+
+    public void testFilePointerPreservedOnSwitchForClone() throws IOException {
+        try (FormatSwitchableIndexInput input = createSwitchable()) {
+            // Read a few bytes to advance pointer
+            input.seek(5);
+            IndexInput cloned = input.clone();
+            assertEquals(5, cloned.getFilePointer());
+
+            // Switch — clone should also switch and preserve pointer
+            input.switchToRemote();
+            // After switch, the clone's underlying input is now remote
+            // The clone was switched by the cascade in switchToRemote
+            cloned.close();
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // Clone and slice
+    // ═══════════════════════════════════════════════════════════════
+
+    public void testCloneReadsFromLocal() throws IOException {
+        try (FormatSwitchableIndexInput input = createSwitchable()) {
+            IndexInput cloned = input.clone();
+            byte[] buf = new byte[LOCAL_DATA.length];
+            cloned.readBytes(buf, 0, buf.length);
+            assertArrayEquals(LOCAL_DATA, buf);
+            cloned.close();
+        }
+    }
+
+    public void testCloneAfterSwitchReadsFromRemote() throws IOException {
+        try (FormatSwitchableIndexInput input = createSwitchable()) {
+            input.switchToRemote();
+            IndexInput cloned = input.clone();
+            byte[] buf = new byte[REMOTE_DATA.length];
+            cloned.readBytes(buf, 0, buf.length);
+            assertArrayEquals(REMOTE_DATA, buf);
+            cloned.close();
+        }
+    }
+
+    public void testSliceReadsCorrectRange() throws IOException {
+        try (FormatSwitchableIndexInput input = createSwitchable()) {
+            IndexInput sliced = input.slice("slice", 5, 5);
+            assertEquals(5, sliced.length());
+            byte[] buf = new byte[5];
+            sliced.readBytes(buf, 0, 5);
+            byte[] expected = new byte[5];
+            System.arraycopy(LOCAL_DATA, 5, expected, 0, 5);
+            assertArrayEquals(expected, buf);
+            sliced.close();
+        }
+    }
+
+    public void testSliceAfterSwitchReadsFromRemote() throws IOException {
+        try (FormatSwitchableIndexInput input = createSwitchable()) {
+            input.switchToRemote();
+            IndexInput sliced = input.slice("slice", 5, 5);
+            byte[] buf = new byte[5];
+            sliced.readBytes(buf, 0, 5);
+            byte[] expected = new byte[5];
+            System.arraycopy(REMOTE_DATA, 5, expected, 0, 5);
+            assertArrayEquals(expected, buf);
+            sliced.close();
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // switchToRemote cascades to clones
+    // ═══════════════════════════════════════════════════════════════
+
+    public void testSwitchCascadesToExistingClones() throws IOException {
+        try (FormatSwitchableIndexInput input = createSwitchable()) {
+            FormatSwitchableIndexInput cloned = (FormatSwitchableIndexInput) input.clone();
+            assertFalse(cloned.hasSwitchedToRemote());
+
+            input.switchToRemote();
+
+            assertTrue("Clone should be switched after parent switches", cloned.hasSwitchedToRemote());
+            byte[] buf = new byte[REMOTE_DATA.length];
+            cloned.readBytes(buf, 0, buf.length);
+            assertArrayEquals(REMOTE_DATA, buf);
+            cloned.close();
+        }
+    }
+
+    public void testSwitchCascadesToMultipleClones() throws IOException {
+        try (FormatSwitchableIndexInput input = createSwitchable()) {
+            FormatSwitchableIndexInput clone1 = (FormatSwitchableIndexInput) input.clone();
+            FormatSwitchableIndexInput clone2 = (FormatSwitchableIndexInput) input.clone();
+
+            input.switchToRemote();
+
+            assertTrue(clone1.hasSwitchedToRemote());
+            assertTrue(clone2.hasSwitchedToRemote());
+            clone1.close();
+            clone2.close();
+        }
+    }
+
+    public void testClosedCloneRemovedFromTrackingBeforeSwitch() throws IOException {
+        try (FormatSwitchableIndexInput input = createSwitchable()) {
+            FormatSwitchableIndexInput cloned = (FormatSwitchableIndexInput) input.clone();
+            cloned.close();
+
+            // Switch should not fail even though clone is closed
+            input.switchToRemote();
+            assertTrue(input.hasSwitchedToRemote());
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // Concurrency
+    // ═══════════════════════════════════════════════════════════════
+
+    public void testConcurrentReadsAndSwitch() throws Exception {
+        FormatSwitchableIndexInput input = createSwitchable();
+        int numReaders = 4;
+        CyclicBarrier barrier = new CyclicBarrier(numReaders + 1);
+        AtomicBoolean failed = new AtomicBoolean(false);
+        AtomicInteger successCount = new AtomicInteger(0);
+
+        Thread[] readers = new Thread[numReaders];
+        for (int i = 0; i < numReaders; i++) {
+            readers[i] = new Thread(() -> {
+                try (IndexInput clone = input.clone()) {
+                    barrier.await();
+                    for (int j = 0; j < 100; j++) {
+                        clone.seek(0);
+                        byte b = clone.readByte();
+                        // Should be either local or remote first byte
+                        assertTrue(b == LOCAL_DATA[0] || b == REMOTE_DATA[0]);
+                    }
+                    successCount.incrementAndGet();
+                } catch (Exception e) {
+                    failed.set(true);
+                }
+            });
+            readers[i].start();
+        }
+
+        // Switcher thread
+        barrier.await();
+        Thread.sleep(5); // let readers start
+        input.switchToRemote();
+
+        for (Thread t : readers) {
+            t.join(5000);
+        }
+
+        assertFalse("No reader thread should have failed", failed.get());
+        assertEquals(numReaders, successCount.get());
+        input.close();
+    }
+
+    public void testConcurrentCloneAndSwitch() throws Exception {
+        FormatSwitchableIndexInput input = createSwitchable();
+        int numCloners = 4;
+        CountDownLatch start = new CountDownLatch(1);
+        AtomicBoolean failed = new AtomicBoolean(false);
+        AtomicReference<IndexInput>[] clones = new AtomicReference[numCloners];
+
+        Thread[] threads = new Thread[numCloners];
+        for (int i = 0; i < numCloners; i++) {
+            final int idx = i;
+            clones[idx] = new AtomicReference<>();
+            threads[i] = new Thread(() -> {
+                try {
+                    start.await();
+                    clones[idx].set(input.clone());
+                } catch (Exception e) {
+                    failed.set(true);
+                }
+            });
+            threads[i].start();
+        }
+
+        start.countDown();
+        input.switchToRemote();
+
+        for (Thread t : threads) {
+            t.join(5000);
+        }
+
+        assertFalse("No cloner thread should have failed", failed.get());
+        for (AtomicReference<IndexInput> ref : clones) {
+            IndexInput c = ref.get();
+            if (c != null) c.close();
+        }
+        input.close();
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // Close behavior
+    // ═══════════════════════════════════════════════════════════════
+
+    public void testCloseBeforeSwitch() throws IOException {
+        FormatSwitchableIndexInput input = createSwitchable();
+        input.close();
+        // Should not throw on double close
+    }
+
+    public void testCloseAfterSwitch() throws IOException {
+        FormatSwitchableIndexInput input = createSwitchable();
+        input.switchToRemote();
+        input.close();
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // readShort / readInt / readLong / readVInt / readVLong
+    // ═══════════════════════════════════════════════════════════════
+
+    public void testReadShort() throws IOException {
+        try (FormatSwitchableIndexInput input = createSwitchable()) {
+            short val = input.readShort();
+            // Just verify it doesn't throw and returns something
+            input.seek(0);
+            input.switchToRemote();
+            short remoteVal = input.readShort();
+            // Both should succeed without error
+        }
+    }
+
+    public void testReadInt() throws IOException {
+        try (FormatSwitchableIndexInput input = createSwitchable()) {
+            int val = input.readInt();
+            input.seek(0);
+            input.switchToRemote();
+            int remoteVal = input.readInt();
+        }
+    }
+
+    public void testReadLong() throws IOException {
+        try (FormatSwitchableIndexInput input = createSwitchable()) {
+            long val = input.readLong();
+            input.seek(0);
+            input.switchToRemote();
+            long remoteVal = input.readLong();
+        }
+    }
+
+    public void testReadVInt() throws IOException {
+        // Write a proper VInt to both directories
+        ByteBuffersDirectory vLocalDir = new ByteBuffersDirectory();
+        ByteBuffersDirectory vRemoteDir = new ByteBuffersDirectory();
+        try (IndexOutput out = vLocalDir.createOutput("vint.dat", IOContext.DEFAULT)) {
+            out.writeVInt(42);
+        }
+        try (IndexOutput out = vRemoteDir.createOutput("vint.dat", IOContext.DEFAULT)) {
+            out.writeVInt(99);
+        }
+
+        IndexInput localInput = vLocalDir.openInput("vint.dat", IOContext.DEFAULT);
+        FormatSwitchableIndexInput input = new FormatSwitchableIndexInput("test", "vint.dat", localInput, () -> {
+            try {
+                return vRemoteDir.openInput("vint.dat", IOContext.DEFAULT);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        assertEquals(42, input.readVInt());
+        input.switchToRemote();
+        assertEquals(99, input.readVInt());
+        input.close();
+        vLocalDir.close();
+        vRemoteDir.close();
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // Helpers
+    // ═══════════════════════════════════════════════════════════════
+
+    private FormatSwitchableIndexInput createSwitchable() throws IOException {
+        IndexInput localInput = localDir.openInput(FILE_NAME, IOContext.DEFAULT);
+        return new FormatSwitchableIndexInput("FormatSwitchable(test.parquet)", FILE_NAME, localInput, () -> {
+            try {
+                return remoteDir.openInput(FILE_NAME, IOContext.DEFAULT);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    private static void writeFile(ByteBuffersDirectory dir, String name, byte[] data) throws IOException {
+        try (IndexOutput out = dir.createOutput(name, IOContext.DEFAULT)) {
+            out.writeBytes(data, data.length);
+        }
+    }
+}

--- a/server/src/test/java/org/opensearch/storage/indexinput/FormatSwitchableIndexInputWrapperTests.java
+++ b/server/src/test/java/org/opensearch/storage/indexinput/FormatSwitchableIndexInputWrapperTests.java
@@ -1,0 +1,266 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.storage.indexinput;
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
+
+import org.apache.lucene.store.ByteBuffersDirectory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.IndexOutput;
+import org.opensearch.index.store.remote.file.CleanerDaemonThreadLeakFilter;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Unit tests for {@link FormatSwitchableIndexInputWrapper}.
+ *
+ * <p>Tests cover:
+ * <ul>
+ *   <li>Read delegation through wrapper</li>
+ *   <li>Clone returns wrapped instance</li>
+ *   <li>Slice returns wrapped instance</li>
+ *   <li>Close delegates to inner</li>
+ *   <li>unwrap() returns the inner FormatSwitchableIndexInput</li>
+ *   <li>switchToRemote via unwrap()</li>
+ *   <li>Cleaner registration (GC safety)</li>
+ * </ul>
+ */
+@ThreadLeakFilters(filters = CleanerDaemonThreadLeakFilter.class)
+public class FormatSwitchableIndexInputWrapperTests extends OpenSearchTestCase {
+
+    private static final byte[] LOCAL_DATA = "local-wrapper-test-data-12345".getBytes(StandardCharsets.UTF_8);
+    private static final byte[] REMOTE_DATA = "remote-wrapper-test-data-12345".getBytes(StandardCharsets.UTF_8);
+    private static final String FILE_NAME = "wrapper_test.parquet";
+
+    private ByteBuffersDirectory localDir;
+    private ByteBuffersDirectory remoteDir;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        localDir = new ByteBuffersDirectory();
+        remoteDir = new ByteBuffersDirectory();
+        writeFile(localDir, FILE_NAME, LOCAL_DATA);
+        writeFile(remoteDir, FILE_NAME, REMOTE_DATA);
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        localDir.close();
+        remoteDir.close();
+        super.tearDown();
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // Read delegation
+    // ═══════════════════════════════════════════════════════════════
+
+    public void testReadByteDelegatesToInner() throws IOException {
+        try (FormatSwitchableIndexInputWrapper wrapper = createWrapper()) {
+            assertEquals(LOCAL_DATA[0], wrapper.readByte());
+        }
+    }
+
+    public void testReadBytesDelegatesToInner() throws IOException {
+        try (FormatSwitchableIndexInputWrapper wrapper = createWrapper()) {
+            byte[] buf = new byte[LOCAL_DATA.length];
+            wrapper.readBytes(buf, 0, buf.length);
+            assertArrayEquals(LOCAL_DATA, buf);
+        }
+    }
+
+    public void testReadShortDelegatesToInner() throws IOException {
+        try (FormatSwitchableIndexInputWrapper wrapper = createWrapper()) {
+            wrapper.readShort(); // just verify no exception
+        }
+    }
+
+    public void testReadIntDelegatesToInner() throws IOException {
+        try (FormatSwitchableIndexInputWrapper wrapper = createWrapper()) {
+            wrapper.readInt(); // just verify no exception
+        }
+    }
+
+    public void testReadLongDelegatesToInner() throws IOException {
+        try (FormatSwitchableIndexInputWrapper wrapper = createWrapper()) {
+            wrapper.readLong(); // just verify no exception
+        }
+    }
+
+    public void testLengthDelegatesToInner() throws IOException {
+        try (FormatSwitchableIndexInputWrapper wrapper = createWrapper()) {
+            assertEquals(LOCAL_DATA.length, wrapper.length());
+        }
+    }
+
+    public void testSeekAndGetFilePointer() throws IOException {
+        try (FormatSwitchableIndexInputWrapper wrapper = createWrapper()) {
+            assertEquals(0, wrapper.getFilePointer());
+            wrapper.seek(5);
+            assertEquals(5, wrapper.getFilePointer());
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // unwrap()
+    // ═══════════════════════════════════════════════════════════════
+
+    public void testUnwrapReturnsInner() throws IOException {
+        try (FormatSwitchableIndexInputWrapper wrapper = createWrapper()) {
+            FormatSwitchableIndexInput inner = wrapper.unwrap();
+            assertNotNull(inner);
+            assertFalse(inner.hasSwitchedToRemote());
+        }
+    }
+
+    public void testSwitchToRemoteViaUnwrap() throws IOException {
+        try (FormatSwitchableIndexInputWrapper wrapper = createWrapper()) {
+            FormatSwitchableIndexInput inner = wrapper.unwrap();
+            assertFalse(inner.hasSwitchedToRemote());
+
+            inner.switchToRemote();
+            assertTrue(inner.hasSwitchedToRemote());
+
+            // Reads through wrapper should now come from remote
+            wrapper.seek(0);
+            byte[] buf = new byte[REMOTE_DATA.length];
+            wrapper.readBytes(buf, 0, buf.length);
+            assertArrayEquals(REMOTE_DATA, buf);
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // Clone
+    // ═══════════════════════════════════════════════════════════════
+
+    public void testCloneReturnsWrappedInstance() throws IOException {
+        try (FormatSwitchableIndexInputWrapper wrapper = createWrapper()) {
+            IndexInput cloned = wrapper.clone();
+            assertTrue("Clone should be a FormatSwitchableIndexInputWrapper", cloned instanceof FormatSwitchableIndexInputWrapper);
+            byte[] buf = new byte[LOCAL_DATA.length];
+            cloned.readBytes(buf, 0, buf.length);
+            assertArrayEquals(LOCAL_DATA, buf);
+            cloned.close();
+        }
+    }
+
+    public void testCloneAfterSwitchReadsFromRemote() throws IOException {
+        try (FormatSwitchableIndexInputWrapper wrapper = createWrapper()) {
+            wrapper.unwrap().switchToRemote();
+            IndexInput cloned = wrapper.clone();
+            assertTrue(cloned instanceof FormatSwitchableIndexInputWrapper);
+            byte[] buf = new byte[REMOTE_DATA.length];
+            cloned.readBytes(buf, 0, buf.length);
+            assertArrayEquals(REMOTE_DATA, buf);
+            cloned.close();
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // Slice
+    // ═══════════════════════════════════════════════════════════════
+
+    public void testSliceReturnsWrappedInstance() throws IOException {
+        try (FormatSwitchableIndexInputWrapper wrapper = createWrapper()) {
+            IndexInput sliced = wrapper.slice("test-slice", 5, 5);
+            assertTrue("Slice should be a FormatSwitchableIndexInputWrapper", sliced instanceof FormatSwitchableIndexInputWrapper);
+            assertEquals(5, sliced.length());
+            byte[] buf = new byte[5];
+            sliced.readBytes(buf, 0, 5);
+            byte[] expected = new byte[5];
+            System.arraycopy(LOCAL_DATA, 5, expected, 0, 5);
+            assertArrayEquals(expected, buf);
+            sliced.close();
+        }
+    }
+
+    public void testSliceAfterSwitchReadsFromRemote() throws IOException {
+        try (FormatSwitchableIndexInputWrapper wrapper = createWrapper()) {
+            wrapper.unwrap().switchToRemote();
+            IndexInput sliced = wrapper.slice("test-slice", 5, 5);
+            byte[] buf = new byte[5];
+            sliced.readBytes(buf, 0, 5);
+            byte[] expected = new byte[5];
+            System.arraycopy(REMOTE_DATA, 5, expected, 0, 5);
+            assertArrayEquals(expected, buf);
+            sliced.close();
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // Close
+    // ═══════════════════════════════════════════════════════════════
+
+    public void testCloseDelegatesToInner() throws IOException {
+        FormatSwitchableIndexInputWrapper wrapper = createWrapper();
+        wrapper.close();
+        // Double close should not throw
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // RandomAccessInput positional reads
+    // ═══════════════════════════════════════════════════════════════
+
+    public void testReadByteAtPosition() throws IOException {
+        try (FormatSwitchableIndexInputWrapper wrapper = createWrapper()) {
+            byte b = wrapper.readByte(0);
+            assertEquals(LOCAL_DATA[0], b);
+            byte b5 = wrapper.readByte(5);
+            assertEquals(LOCAL_DATA[5], b5);
+        }
+    }
+
+    public void testReadShortAtPosition() throws IOException {
+        try (FormatSwitchableIndexInputWrapper wrapper = createWrapper()) {
+            wrapper.readShort(0); // just verify no exception
+        }
+    }
+
+    public void testReadIntAtPosition() throws IOException {
+        try (FormatSwitchableIndexInputWrapper wrapper = createWrapper()) {
+            wrapper.readInt(0); // just verify no exception
+        }
+    }
+
+    public void testReadLongAtPosition() throws IOException {
+        try (FormatSwitchableIndexInputWrapper wrapper = createWrapper()) {
+            wrapper.readLong(0); // just verify no exception
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // Helpers
+    // ═══════════════════════════════════════════════════════════════
+
+    private FormatSwitchableIndexInputWrapper createWrapper() throws IOException {
+        IndexInput localInput = localDir.openInput(FILE_NAME, IOContext.DEFAULT);
+        FormatSwitchableIndexInput switchable = new FormatSwitchableIndexInput(
+            "FormatSwitchable(wrapper_test.parquet)",
+            FILE_NAME,
+            localInput,
+            () -> {
+                try {
+                    return remoteDir.openInput(FILE_NAME, IOContext.DEFAULT);
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        );
+        return new FormatSwitchableIndexInputWrapper("WrapperTest(" + FILE_NAME + ")", switchable);
+    }
+
+    private static void writeFile(ByteBuffersDirectory dir, String name, byte[] data) throws IOException {
+        try (IndexOutput out = dir.createOutput(name, IOContext.DEFAULT)) {
+            out.writeBytes(data, data.length);
+        }
+    }
+}


### PR DESCRIPTION
## Wire NativeStoreHandle to DataFusion reader stack

### Description

Passes the native `TieredObjectStore` pointer through the full Java → Rust stack so DataFusion queries on warm shards read parquet files through the tiered object store (which routes to local or remote) instead of the default `LocalFileSystem`.

**Flow:** `Store` → `IndexService` → `ReaderManagerConfig` → `DataFusionPlugin.createReaderManager` → `DatafusionReaderManager` → `ReaderHandle` → `NativeBridge.createDatafusionReader` → Rust `df_create_reader` → `ShardView.store` → per-query `RuntimeEnv.register_object_store`

### Changes

**Server (store carries handles to plugins):**
- `Store` holds a `Map<DataFormat, NativeStoreHandle>` extracted from `StoreStrategyRegistry`
- `IndexService.createShard` builds the registry, extracts handles, passes to Store
- `ReaderManagerConfig` carries the map so each plugin can extract its own handle
- `StoreStrategy.remotePath()` fixed — no longer double-adds format prefix (basePath from `getRemoteBasePath(format)` already includes it)
- `Node.java` guards `TieredDataFormatAwareStoreDirectoryFactory` with feature flag

**DataFusion plugin (Java → Rust bridge):**
- `DataFusionPlugin.createReaderManager` extracts `NativeStoreHandle` from config
- `DatafusionReaderManager` holds the handle, passes pointer at reader creation time
- `ReaderHandle` accepts `NativeStoreHandle` (null-safe — 0L if null/closed)
- `NativeBridge.createDatafusionReader` validates liveness before extracting pointer

**Rust (DataFusion side):**
- `df_create_reader` accepts `store_ptr`, reconstructs `Arc<dyn ObjectStore>`, stores in `ShardView`
- `session_context.rs` registers shard store on per-query `RuntimeEnv` (instruction-based execution path)
- `query_executor.rs` / `indexed_executor.rs` register store on per-query `RuntimeEnv`

**Rust (tiered-storage):**
- `TieredObjectStore.should_retry_remote()` helper for retry logic

### Testing

- All tests pass real native `TieredObjectStore` pointers (not null) via `NativeStoreTestHelper`
- `testReaderWithRealNativeStoreHandle` — end-to-end: Java creates store via FFM, wraps in `NativeStoreHandle`, passes to reader, verifies query execution
- `DataFusionQueryExecutionTests`, `DatafusionResultStreamTests`, `DatafusionSearchExecEngineTests` — all use real store pointers
- `DatafusionReaderManagerTests` — unit tests for manager lifecycle (mock, no native)
- `StoreStrategyRegistryTests` — updated for remotePath fix
- Server tests: `StoreTests`, `GracefulDegradationTests`, `WarmShardDirectoryStackTests`, `TieredSubdirectoryAwareDirectoryTests`

```
./gradlew -Dsandbox.enabled=true :sandbox:plugins:analytics-backend-datafusion:test  # all pass
./gradlew :server:test --tests "org.opensearch.storage.*"                            # all pass
cargo check  # (analytics-backend-datafusion/rust + tiered-storage) — no errors
```

### Related

- Depends on: tiered-directory-wiring PR (TieredSubdirectoryAwareDirectory routing)
- Enables: warm shard parquet reads via PPL/SQL through DataFusion

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
