### PR TITLE
[Sandbox] Make sqlUnifiedQueryVersion overridable; force mavenLocal precedence

### DIFF
--- a/sandbox/plugins/analytics-engine/build.gradle
+++ b/sandbox/plugins/analytics-engine/build.gradle
@@ -14,9 +14,6 @@
 
 apply plugin: 'opensearch.internal-cluster-test'
 
-// SQL Unified Query API version (aligned with OpenSearch build version)
-def sqlUnifiedQueryVersion = '3.6.0.0-SNAPSHOT'
-
 opensearchplugin {
   description = 'Analytics engine hub: discovers and wires query extensions via ExtensiblePlugin SPI.'
   classname = 'org.opensearch.analytics.AnalyticsPlugin'
@@ -27,6 +24,17 @@ opensearchplugin {
 }
 
 java { sourceCompatibility = JavaVersion.toVersion(25); targetCompatibility = JavaVersion.toVersion(25) }
+
+// Force mavenLocal to position 0 so the transitive unified-query SNAPSHOT (pulled in via the
+// `:sandbox:plugins:test-ppl-frontend` project dep) resolves against a freshly-published
+// local SQL plugin checkout instead of ci.opensearch.org. Sandbox-only; CI's empty `~/.m2/`
+// makes this a no-op there. Transitive resolution uses the consumer's repo list, not the
+// dependee's, so test-ppl-frontend's own mavenLocal precedence isn't enough.
+repositories {
+  def local = mavenLocal()
+  remove(local)
+  add(0, local)
+}
 
 // Guava comes transitively from calcite-core and unified-query — forbidden on
 // compile classpaths by OpenSearch. Main sources don't need it; test sources do
@@ -132,17 +140,6 @@ dependencies {
   testRuntimeOnly "org.slf4j:slf4j-api:${versions.slf4j}"
   testRuntimeOnly "com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}"
   testRuntimeOnly "com.fasterxml.jackson.core:jackson-annotations:${versions.jackson_annotations}"
-
-  // SQL Unified Query API for PPL parsing
-  testImplementation("org.opensearch.query:unified-query-api:${sqlUnifiedQueryVersion}") {
-    exclude group: 'org.opensearch'
-  }
-  testImplementation("org.opensearch.query:unified-query-core:${sqlUnifiedQueryVersion}") {
-    exclude group: 'org.opensearch'
-  }
-  testImplementation("org.opensearch.query:unified-query-ppl:${sqlUnifiedQueryVersion}") {
-    exclude group: 'org.opensearch'
-  }
 
   // Arrow Flight streaming transport for ITs
   internalClusterTestImplementation project(':plugins:arrow-flight-rpc')

--- a/sandbox/plugins/test-ppl-frontend/build.gradle
+++ b/sandbox/plugins/test-ppl-frontend/build.gradle
@@ -23,7 +23,9 @@ java { sourceCompatibility = JavaVersion.toVersion(25); targetCompatibility = Ja
 // declared below carries the published 3.7.x.x-SNAPSHOT artifacts; for local
 // development against an unpublished sql-repo HEAD, run
 // `./gradlew :ppl:publishUnifiedQueryPublicationToMavenLocal` from the sql repo first.
-def sqlUnifiedQueryVersion = '3.7.0.0-SNAPSHOT'
+// Override via `-PsqlUnifiedQueryVersion=<version>` for local development against an
+// out-of-tree SQL plugin checkout (e.g. feature/mustang-ppl-integration).
+def sqlUnifiedQueryVersion = providers.gradleProperty('sqlUnifiedQueryVersion').getOrElse('3.7.0.0-SNAPSHOT')
 
 opensearchplugin {
   description = 'Test PPL front-end: REST endpoint backed by the unified PPL pipeline.'
@@ -32,11 +34,18 @@ opensearchplugin {
 }
 
 repositories {
-  mavenLocal()
   maven {
     name = 'OpenSearch Snapshots'
     url = 'https://ci.opensearch.org/ci/dbc/snapshots/maven/'
   }
+  // Force mavenLocal to position 0. Declaring `mavenLocal()` first inside this block isn't
+  // enough: `apply plugin: 'opensearch.test'` above contributes its own remote repos at
+  // plugin-application time (before this block runs), so any mavenLocal() here lands at
+  // position 5+ and gradle resolves the remote SNAPSHOT first. Sandbox-only; CI's empty
+  // `~/.m2/` makes this a no-op there.
+  def local = mavenLocal()
+  remove(local)
+  add(0, local)
 }
 
 // Guava comes transitively from calcite-core and unified-query — forbidden on


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
  - `test-ppl-frontend/build.gradle`: `sqlUnifiedQueryVersion` now reads `-PsqlUnifiedQueryVersion=…` with default `3.7.0.0-SNAPSHOT`. No build.gradle edit needed for local SQL plugin checkouts.
  - `test-ppl-frontend` + `analytics-engine` build.gradle: force `mavenLocal` to repo position 0. Declaring `mavenLocal()` first isn't enough — plugin chains prepend remote repos before our block runs, so we re-insert: `def local = mavenLocal(); remove(local); add(0, local)`. Fresh feature-branch jars now win over stale ci.opensearch.org SNAPSHOTs.
  - `analytics-engine`: drop redundant `testImplementation` for `unified-query-{api,core,ppl}` — already pulled in transitively via the test-ppl-frontend project dep.

  Same intent as the reverted #21578 (rest-test plugin zips bundle the fresh feature-branch unified-query), but doesn't break publish: empty `~/.m2/` on the publish runner makes `add(0, mavenLocal)` a no-op there, falling through to OS Snapshots — unlike #21578's `excludeGroup`, which left publish with nothing to resolve from.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
