### PR TITLE
Changes to upgrade datafusion and arrow to latest versions

### DIFF
--- a/sandbox/libs/dataformat-native/rust/Cargo.toml
+++ b/sandbox/libs/dataformat-native/rust/Cargo.toml
@@ -16,62 +16,62 @@ members = [
 
 [workspace.dependencies]
 # Arrow / Parquet
-arrow = { version = "57.3.0", features = ["ffi"] }
-arrow-array = "57.3.0"
-arrow-ipc = "57.3.0"
-arrow-schema = "57.3.0"
-arrow-buffer = "57.3.0"
-parquet = "57.3.0"
+arrow = { version = "=58.2.0", features = ["ffi"] }
+arrow-array = "=58.2.0"
+arrow-ipc = "=58.2.0"
+arrow-schema = "=58.2.0"
+arrow-buffer = "=58.2.0"
+parquet = "=58.2.0"
 
 # DataFusion
-datafusion = "52.1.0"
-datafusion-expr = "52.1.0"
-datafusion-datasource = "52.1.0"
-datafusion-common = "52.1.0"
-datafusion-execution = "52.1.0"
-datafusion-physical-expr = "52.1.0"
-datafusion-substrait = "52.1.0"
+datafusion = "=53.1.0"
+datafusion-expr = "=53.1.0"
+datafusion-datasource = "=53.1.0"
+datafusion-common = "=53.1.0"
+datafusion-execution = "=53.1.0"
+datafusion-physical-expr = "=53.1.0"
+datafusion-substrait = "=53.1.0"
 
 # Async
-tokio = { version = "1.0", features = ["full"] }
-tokio-util = "0.7"
-futures = "0.3"
-tokio-stream = "0.1.17"
+tokio = { version = "=1.51.0", features = ["full"] }
+tokio-util = "=0.7.18"
+futures = "=0.3.32"
+tokio-stream = "=0.1.18"
 
 # Serialization
-prost = "0.14"
-substrait = "=0.62.0"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+prost = "=0.14.3"
+substrait = "=0.62.2"
+serde = { version = "=1.0.228", features = ["derive"] }
+serde_json = "=1.0.149"
 
 # Logging
-log = "0.4"
+log = "=0.4.29"
 
 # Allocator
 # disable_initial_exec_tls: Required because this library is loaded at runtime via dlopen/JVM FFM.
 # Without it, jemalloc uses initial-exec TLS which fails on aarch64 Linux with:
 #   "cannot allocate memory in static TLS block"
 # The feature switches to global-dynamic TLS model, compatible with runtime loading.
-tikv-jemallocator = { version = "0.6", features = ["disable_initial_exec_tls"] }
-tikv-jemalloc-ctl = { version = "0.6", features = ["stats"] }
+tikv-jemallocator = { version = "=0.6.1", features = ["disable_initial_exec_tls"] }
+tikv-jemalloc-ctl = { version = "=0.6.1", features = ["stats"] }
 
 # Misc
-dashmap = "5.5"
-num_cpus = "1.16"
-object_store = "0.12.5"
-url = "2.0"
-tempfile = "3.0"
-chrono = "0.4"
-once_cell = "1.21.3"
-crc32fast = "1.4"
-parking_lot = "0.12.5"
-lazy_static = "1.4.0"
-rayon = "1.10"
-thiserror = "1.0"
-async-trait = "0.1"
-bytes = "1"
-criterion = { version = "0.5", features = ["async_tokio"] }
-tokio-metrics = { version = "0.5", features = ["rt"] }
+dashmap = "=5.5.3"
+num_cpus = "=1.17.0"
+object_store = "=0.13.2"
+url = "=2.5.8"
+tempfile = "=3.27.0"
+chrono = "=0.4.44"
+once_cell = "=1.21.4"
+crc32fast = "=1.5.0"
+parking_lot = "=0.12.5"
+lazy_static = "=1.5.0"
+rayon = "=1.11.0"
+thiserror = "=1.0.69"
+async-trait = "=0.1.89"
+bytes = "=1.11.1"
+criterion = { version = "=0.5.1", features = ["async_tokio"] }
+tokio-metrics = { version = "=0.5.0", features = ["rt"] }
 
 # Internal
 native-bridge-common = { path = "common" }

--- a/sandbox/libs/dataformat-native/rust/macros/Cargo.toml
+++ b/sandbox/libs/dataformat-native/rust/macros/Cargo.toml
@@ -8,6 +8,6 @@ license = "Apache-2.0"
 proc-macro = true
 
 [dependencies]
-quote = "1"
-syn = { version = "2", features = ["full"] }
-proc-macro2 = "1"
+quote = "=1.0.45"
+syn = { version = "=2.0.117", features = ["full"] }
+proc-macro2 = "=1.0.106"

--- a/sandbox/libs/tiered-storage/src/main/rust/src/tiered_object_store.rs
+++ b/sandbox/libs/tiered-storage/src/main/rust/src/tiered_object_store.rs
@@ -19,16 +19,14 @@
 //! registry's atomics and DashMap — no locks are held during I/O.
 
 use std::fmt;
-use std::ops::Range;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use bytes::Bytes;
 use futures::stream::BoxStream;
 use futures::StreamExt;
 use object_store::{
-    path::Path, GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta, ObjectStore,
-    PutMultipartOptions, PutOptions, PutPayload, PutResult, Result as OsResult,
+    path::Path, CopyOptions, GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta,
+    ObjectStore, PutMultipartOptions, PutOptions, PutPayload, PutResult, Result as OsResult,
 };
 
 use crate::registry::traits::FileRegistry;
@@ -220,8 +218,35 @@ impl ObjectStore for TieredObjectStore {
 
     /// Primary read path: check registry for remote routing, otherwise local.
     /// If local read fails with NotFound and file transitioned to REMOTE, retries from remote.
+    ///
+    /// Also handles head requests (options.head == true) by returning cached
+    /// size from the registry when available — avoids I/O for the common case.
     async fn get_opts(&self, location: &Path, options: GetOptions) -> OsResult<GetResult> {
         let path_str = location.as_ref();
+
+        // Fast path for head: return cached size from registry if available
+        if options.head {
+            if let Some(guard) = self.registry.get(path_str) {
+                let size = guard.size();
+                if size > 0 {
+                    let meta = ObjectMeta {
+                        location: location.clone(),
+                        last_modified: chrono::DateTime::<chrono::Utc>::default(),
+                        size,
+                        e_tag: None,
+                        version: None,
+                    };
+                    return Ok(GetResult {
+                        payload: object_store::GetResultPayload::Stream(
+                            futures::stream::empty().boxed(),
+                        ),
+                        meta,
+                        range: 0..size,
+                        attributes: Default::default(),
+                    });
+                }
+            }
+        }
 
         if let Some((rp, store)) = self.resolve_remote(path_str) {
             native_bridge_common::log_debug!(
@@ -240,76 +265,20 @@ impl ObjectStore for TieredObjectStore {
         result
     }
 
-    /// Range read with local-fail-retry-remote.
-    async fn get_range(&self, location: &Path, range: Range<u64>) -> OsResult<Bytes> {
-        let path_str = location.as_ref();
-
-        if let Some((rp, store)) = self.resolve_remote(path_str) {
-            return store.get_range(&rp, range).await;
-        }
-
-        let result = self.local.get_range(location, range.clone()).await;
-        if let Err(ref e) = result {
-            if let Some((rp, store)) = self.should_retry_remote(path_str, e) {
-                return store.get_range(&rp, range).await;
+    /// Delete stream: remove each path from registry only, NO local delete.
+    /// Local file deletion is handled by the Java layer.
+    fn delete_stream(
+        &self,
+        locations: BoxStream<'static, OsResult<Path>>,
+    ) -> BoxStream<'static, OsResult<Path>> {
+        let registry = Arc::clone(&self.registry);
+        let mapped = locations.map(move |result| {
+            if let Ok(ref path) = result {
+                registry.remove(path.as_ref(), true);
             }
-        }
-        result
-    }
-
-    /// Multi-range read with local-fail-retry-remote.
-    async fn get_ranges(&self, location: &Path, ranges: &[Range<u64>]) -> OsResult<Vec<Bytes>> {
-        let path_str = location.as_ref();
-
-        if let Some((rp, store)) = self.resolve_remote(path_str) {
-            return store.get_ranges(&rp, ranges).await;
-        }
-
-        let result = self.local.get_ranges(location, ranges).await;
-        if let Err(ref e) = result {
-            if let Some((rp, store)) = self.should_retry_remote(path_str, e) {
-                return store.get_ranges(&rp, ranges).await;
-            }
-        }
-        result
-    }
-
-    /// Head: check registry first (cached size), then local, then remote.
-    /// Head: check registry for cached size first (no I/O), then route via resolve_remote.
-    async fn head(&self, location: &Path) -> OsResult<ObjectMeta> {
-        let path_str = location.as_ref();
-
-        // Check registry for cached size — return immediately if available
-        if let Some(guard) = self.registry.get(path_str) {
-            let size = guard.size();
-            if size > 0 {
-                return Ok(ObjectMeta {
-                    location: location.clone(),
-                    last_modified: chrono::DateTime::<chrono::Utc>::default(),
-                    size,
-                    e_tag: None,
-                    version: None,
-                });
-            }
-        }
-
-        // Size not cached — route via resolve_remote (REMOTE → remote store)
-        if let Some((rp, store)) = self.resolve_remote(path_str) {
-            return store.head(&rp).await;
-        }
-
-        // Not remote — try local
-        self.local.head(location).await
-    }
-
-    /// Delete: remove from registry only, NO local delete.
-    /// Local file deletion is handled by the Java layer
-    /// (TieredSubdirectoryAwareDirectory.deleteFile). Eviction (local copy
-    /// removal after sync) is a writable warm concern — not implemented.
-    async fn delete(&self, location: &Path) -> OsResult<()> {
-        let path_str = location.as_ref();
-        self.registry.remove(path_str, true);
-        Ok(())
+            result
+        });
+        Box::pin(mapped)
     }
 
     /// List: local entries first, then remote-only entries from registry (deduplicated).
@@ -364,21 +333,9 @@ impl ObjectStore for TieredObjectStore {
         Ok(result)
     }
 
-    async fn copy(&self, _from: &Path, _to: &Path) -> OsResult<()> {
+    async fn copy_opts(&self, _from: &Path, _to: &Path, _options: CopyOptions) -> OsResult<()> {
         Err(object_store::Error::NotSupported {
             source: "TieredObjectStore does not support copy".into(),
-        })
-    }
-
-    async fn copy_if_not_exists(&self, _from: &Path, _to: &Path) -> OsResult<()> {
-        Err(object_store::Error::NotSupported {
-            source: "TieredObjectStore does not support copy_if_not_exists".into(),
-        })
-    }
-
-    async fn rename_if_not_exists(&self, _from: &Path, _to: &Path) -> OsResult<()> {
-        Err(object_store::Error::NotSupported {
-            source: "TieredObjectStore does not support rename_if_not_exists".into(),
         })
     }
 }

--- a/sandbox/libs/tiered-storage/src/main/rust/src/tiered_object_store_tests.rs
+++ b/sandbox/libs/tiered-storage/src/main/rust/src/tiered_object_store_tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use futures::StreamExt;
 use object_store::memory::InMemory;
-use object_store::PutPayload;
+use object_store::{CopyOptions, ObjectStoreExt, PutPayload};
 use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
 
 /// Helper: create a registry + tiered store backed by in-memory stores.
@@ -514,10 +514,6 @@ impl ObjectStore for CallCountingStore {
         self.inner.get_opts(location, options).await
     }
 
-    async fn head(&self, location: &Path) -> OsResult<ObjectMeta> {
-        self.inner.head(location).await
-    }
-
     async fn put_opts(
         &self,
         location: &Path,
@@ -535,8 +531,11 @@ impl ObjectStore for CallCountingStore {
         self.inner.put_multipart_opts(location, opts).await
     }
 
-    async fn delete(&self, location: &Path) -> OsResult<()> {
-        self.inner.delete(location).await
+    fn delete_stream(
+        &self,
+        locations: BoxStream<'static, OsResult<Path>>,
+    ) -> BoxStream<'static, OsResult<Path>> {
+        self.inner.delete_stream(locations)
     }
 
     fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, OsResult<ObjectMeta>> {
@@ -547,16 +546,8 @@ impl ObjectStore for CallCountingStore {
         self.inner.list_with_delimiter(prefix).await
     }
 
-    async fn copy(&self, from: &Path, to: &Path) -> OsResult<()> {
-        self.inner.copy(from, to).await
-    }
-
-    async fn copy_if_not_exists(&self, from: &Path, to: &Path) -> OsResult<()> {
-        self.inner.copy_if_not_exists(from, to).await
-    }
-
-    async fn rename_if_not_exists(&self, from: &Path, to: &Path) -> OsResult<()> {
-        self.inner.rename_if_not_exists(from, to).await
+    async fn copy_opts(&self, from: &Path, to: &Path, options: CopyOptions) -> OsResult<()> {
+        self.inner.copy_opts(from, to, options).await
     }
 }
 
@@ -617,13 +608,6 @@ impl ObjectStore for ErrorStore {
         })
     }
 
-    async fn head(&self, _location: &Path) -> OsResult<ObjectMeta> {
-        Err(object_store::Error::Generic {
-            store: "ErrorStore",
-            source: "simulated error".into(),
-        })
-    }
-
     async fn put_opts(
         &self,
         _location: &Path,
@@ -647,11 +631,14 @@ impl ObjectStore for ErrorStore {
         })
     }
 
-    async fn delete(&self, _location: &Path) -> OsResult<()> {
-        Err(object_store::Error::Generic {
+    fn delete_stream(
+        &self,
+        locations: BoxStream<'static, OsResult<Path>>,
+    ) -> BoxStream<'static, OsResult<Path>> {
+        Box::pin(locations.map(|_| Err(object_store::Error::Generic {
             store: "ErrorStore",
             source: "simulated error".into(),
-        })
+        })))
     }
 
     fn list(&self, _prefix: Option<&Path>) -> BoxStream<'static, OsResult<ObjectMeta>> {
@@ -665,19 +652,7 @@ impl ObjectStore for ErrorStore {
         })
     }
 
-    async fn copy(&self, _from: &Path, _to: &Path) -> OsResult<()> {
-        Err(object_store::Error::NotSupported {
-            source: "not supported".into(),
-        })
-    }
-
-    async fn copy_if_not_exists(&self, _from: &Path, _to: &Path) -> OsResult<()> {
-        Err(object_store::Error::NotSupported {
-            source: "not supported".into(),
-        })
-    }
-
-    async fn rename_if_not_exists(&self, _from: &Path, _to: &Path) -> OsResult<()> {
+    async fn copy_opts(&self, _from: &Path, _to: &Path, _options: CopyOptions) -> OsResult<()> {
         Err(object_store::Error::NotSupported {
             source: "not supported".into(),
         })

--- a/sandbox/plugins/analytics-backend-datafusion/rust/Cargo.toml
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/Cargo.toml
@@ -41,11 +41,11 @@ num_cpus = { workspace = true }
 native-bridge-common = { workspace = true }
 async-trait = { workspace = true }
 chrono = { workspace = true }
-roaring = "0.10"
+roaring = "=0.10.12"
 thiserror = { workspace = true }
 
 # convert_tz UDF
-chrono-tz = "0.10"
+chrono-tz = "=0.10.4"
 
 tokio-metrics = { workspace = true }
 
@@ -67,14 +67,14 @@ serde_json = { workspace = true, features = ["preserve_order"] }
 # relies on to render missing-path matches as literal `null` elements in the
 # multi-path JSON-array output. Moving to 1.x is a follow-up once we can
 # reproduce that distinction against the new API surface.
-jsonpath-rust = "0.7"
+jsonpath-rust = "=0.7.5"
 # mvfind UDF — regex matching against stringified array elements
-regex = "1.10"
+regex = "=1.12.3"
 
 [dev-dependencies]
 criterion = { workspace = true }
 tempfile = { workspace = true }
-rand = "0.8"
+rand = "=0.8.6"
 
 [[bench]]
 name = "query_bench"

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/api.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/api.rs
@@ -52,6 +52,7 @@ use datafusion::execution::{SessionState, SessionStateBuilder};
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::prelude::SessionConfig;
 use futures::TryStreamExt;
+use object_store::ObjectStoreExt;
 
 use crate::cancellation;
 use crate::cross_rt_stream::CrossRtStream;
@@ -454,7 +455,7 @@ pub unsafe fn sql_to_substrait(
 ) -> Result<Vec<u8>, DataFusionError> {
     use datafusion::datasource::file_format::parquet::ParquetFormat;
     use datafusion::datasource::listing::{ListingOptions, ListingTable, ListingTableConfig};
-    use datafusion::execution::cache::cache_manager::CacheManagerConfig;
+    use datafusion::execution::cache::cache_manager::{CacheManagerConfig, CachedFileList};
     use datafusion::execution::cache::{CacheAccessor, DefaultListFilesCache};
     use datafusion_substrait::logical_plan::producer::to_substrait_plan;
     use prost::Message;
@@ -472,7 +473,7 @@ pub unsafe fn sql_to_substrait(
                 table: None,
                 path: table_path.prefix().clone(),
             },
-            object_metas,
+            CachedFileList::new(object_metas.as_ref().clone()),
         );
         let runtime_env = RuntimeEnvBuilder::from_runtime_env(&runtime.runtime_env)
             .with_cache_manager(

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/cache.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/cache.rs
@@ -8,11 +8,13 @@
 
 use std::sync::{Arc, Mutex};
 
-use datafusion::execution::cache::cache_manager::FileMetadataCache;
+use datafusion::execution::cache::cache_manager::{
+    CachedFileMetadataEntry, FileMetadataCache, FileMetadataCacheEntry,
+};
 use datafusion::execution::cache::cache_unit::DefaultFilesMetadataCache;
 use datafusion::execution::cache::CacheAccessor;
 use log::error;
-use object_store::ObjectMeta;
+use object_store::path::Path;
 
 // Cache type constants
 pub const CACHE_TYPE_METADATA: &str = "METADATA";
@@ -35,7 +37,7 @@ impl MutexFileMetadataCache {
         }
     }
 
-    pub fn clear(&self) {
+    pub fn clear_cache(&self) {
         if let Ok(cache) = self.inner.lock() {
             cache.clear();
         }
@@ -47,7 +49,7 @@ impl MutexFileMetadataCache {
         }
     }
 
-    pub fn cache_limit(&self) -> usize {
+    pub fn get_cache_limit(&self) -> usize {
         if let Ok(cache) = self.inner.lock() {
             cache.cache_limit()
         } else {
@@ -56,57 +58,54 @@ impl MutexFileMetadataCache {
     }
 }
 
-
-// Implement CacheAccessor which is required by FileMetadataCache
-impl CacheAccessor<ObjectMeta, Arc<dyn datafusion::execution::cache::cache_manager::FileMetadata>> for MutexFileMetadataCache {
-    type Extra = ObjectMeta;
-
-    fn get(&self, k: &ObjectMeta) -> Option<Arc<dyn datafusion::execution::cache::cache_manager::FileMetadata>> {
+impl CacheAccessor<Path, CachedFileMetadataEntry> for MutexFileMetadataCache {
+    fn get(&self, k: &Path) -> Option<CachedFileMetadataEntry> {
         match self.inner.lock() {
             Ok(cache) => cache.get(k),
-            Err(e) => { log_cache_error("get", &e.to_string()); None }
+            Err(e) => {
+                log_cache_error("get", &e.to_string());
+                None
+            }
         }
     }
 
-    fn get_with_extra(&self, k: &ObjectMeta, extra: &Self::Extra) -> Option<Arc<dyn datafusion::execution::cache::cache_manager::FileMetadata>> {
-        match self.inner.lock() {
-            Ok(cache) => cache.get_with_extra(k, extra),
-            Err(e) => { log_cache_error("get_with_extra", &e.to_string()); None }
-        }
-    }
-
-    fn put(&self, k: &ObjectMeta, v: Arc<dyn datafusion::execution::cache::cache_manager::FileMetadata>) -> Option<Arc<dyn datafusion::execution::cache::cache_manager::FileMetadata>> {
+    fn put(&self, k: &Path, v: CachedFileMetadataEntry) -> Option<CachedFileMetadataEntry> {
         match self.inner.lock() {
             Ok(cache) => cache.put(k, v),
-            Err(e) => { log_cache_error("put", &e.to_string()); None }
+            Err(e) => {
+                log_cache_error("put", &e.to_string());
+                None
+            }
         }
     }
 
-    fn put_with_extra(&self, k: &ObjectMeta, v: Arc<dyn datafusion::execution::cache::cache_manager::FileMetadata>, e: &Self::Extra) -> Option<Arc<dyn datafusion::execution::cache::cache_manager::FileMetadata>> {
-        match self.inner.lock() {
-            Ok(cache) => cache.put_with_extra(k, v, e),
-            Err(err) => { log_cache_error("put_with_extra", &err.to_string()); None }
-        }
-    }
-
-    fn remove(&self, k: &ObjectMeta) -> Option<Arc<dyn datafusion::execution::cache::cache_manager::FileMetadata>> {
+    fn remove(&self, k: &Path) -> Option<CachedFileMetadataEntry> {
         match self.inner.lock() {
             Ok(cache) => cache.remove(k),
-            Err(e) => { log_cache_error("remove", &e.to_string()); None }
+            Err(e) => {
+                log_cache_error("remove", &e.to_string());
+                None
+            }
         }
     }
 
-    fn contains_key(&self, k: &ObjectMeta) -> bool {
+    fn contains_key(&self, k: &Path) -> bool {
         match self.inner.lock() {
             Ok(cache) => cache.contains_key(k),
-            Err(e) => { log_cache_error("contains_key", &e.to_string()); false }
+            Err(e) => {
+                log_cache_error("contains_key", &e.to_string());
+                false
+            }
         }
     }
 
     fn len(&self) -> usize {
         match self.inner.lock() {
             Ok(cache) => cache.len(),
-            Err(e) => { log_cache_error("len", &e.to_string()); 0 }
+            Err(e) => {
+                log_cache_error("len", &e.to_string());
+                0
+            }
         }
     }
 
@@ -120,7 +119,10 @@ impl CacheAccessor<ObjectMeta, Arc<dyn datafusion::execution::cache::cache_manag
     fn name(&self) -> String {
         match self.inner.lock() {
             Ok(cache) => cache.name(),
-            Err(e) => { log_cache_error("name", &e.to_string()); "cache_error".to_string() }
+            Err(e) => {
+                log_cache_error("name", &e.to_string());
+                "cache_error".to_string()
+            }
         }
     }
 }
@@ -129,7 +131,10 @@ impl FileMetadataCache for MutexFileMetadataCache {
     fn cache_limit(&self) -> usize {
         match self.inner.lock() {
             Ok(cache) => cache.cache_limit(),
-            Err(e) => { log_cache_error("cache_limit", &e.to_string()); 0 }
+            Err(e) => {
+                log_cache_error("cache_limit", &e.to_string());
+                0
+            }
         }
     }
 
@@ -140,10 +145,13 @@ impl FileMetadataCache for MutexFileMetadataCache {
         }
     }
 
-    fn list_entries(&self) -> std::collections::HashMap<object_store::path::Path, datafusion::execution::cache::cache_manager::FileMetadataCacheEntry> {
+    fn list_entries(&self) -> std::collections::HashMap<Path, FileMetadataCacheEntry> {
         match self.inner.lock() {
             Ok(cache) => cache.list_entries(),
-            Err(e) => { log_cache_error("list_entries", &e.to_string()); std::collections::HashMap::new() }
+            Err(e) => {
+                log_cache_error("list_entries", &e.to_string());
+                std::collections::HashMap::new()
+            }
         }
     }
 }

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/custom_cache_manager.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/custom_cache_manager.rs
@@ -162,29 +162,23 @@ impl CustomCacheManager {
             let mut errors = Vec::new();
 
             // Remove from metadata cache
-            match create_object_meta_from_file(file_path) {
-                Ok(object_metas) => {
-                    if let Some(cache) = &self.file_metadata_cache {
-                        match cache.inner.lock() {
-                            Ok(cache_guard) => {
-                                if let Some(object_meta) = object_metas.first() {
-                                    if cache_guard.remove(object_meta).is_some() {
-                                        any_removed = true;
-                                    } else {
-                                        debug!("[CACHE INFO] File not found in metadata cache: {}", file_path);
-                                    }
-                                }
-                            }
-                            Err(e) => {
-                                errors.push(format!("Metadata cache: Cache remove failed: {}", e));
+            {
+                let path = Path::from(file_path.clone());
+                if let Some(cache) = &self.file_metadata_cache {
+                    match cache.inner.lock() {
+                        Ok(cache_guard) => {
+                            if cache_guard.remove(&path).is_some() {
+                                any_removed = true;
+                            } else {
+                                debug!("[CACHE INFO] File not found in metadata cache: {}", file_path);
                             }
                         }
-                    } else {
-                        errors.push("No metadata cache configured".to_string());
+                        Err(e) => {
+                            errors.push(format!("Metadata cache: Cache remove failed: {}", e));
+                        }
                     }
-                }
-                Err(e) => {
-                    errors.push(format!("Failed to get object metadata: {}", e));
+                } else {
+                    errors.push("No metadata cache configured".to_string());
                 }
             }
 
@@ -214,18 +208,12 @@ impl CustomCacheManager {
         let mut found = false;
 
         // Check metadata cache
-        match create_object_meta_from_file(file_path) {
-            Ok(object_metas) => {
-                if let Some(cache) = &self.file_metadata_cache {
-                    if let Some(object_meta) = object_metas.first() {
-                        if cache.get(object_meta).is_some() {
-                            found = true;
-                        }
-                    }
+        {
+            let path = Path::from(file_path);
+            if let Some(cache) = &self.file_metadata_cache {
+                if cache.get(&path).is_some() {
+                    found = true;
                 }
-            }
-            Err(e) => {
-                error!("Failed to get object metadata for {}: {}", file_path, e);
             }
         }
 
@@ -244,10 +232,10 @@ impl CustomCacheManager {
     pub fn contains_file_by_type(&self, file_path: &str, cache_type: &str) -> bool {
         match cache_type {
             crate::cache::CACHE_TYPE_METADATA => {
-                create_object_meta_from_file(file_path)
-                    .ok()
-                    .and_then(|metas| metas.first().cloned())
-                    .and_then(|meta| self.file_metadata_cache.as_ref()?.get(&meta))
+                let path = Path::from(file_path);
+                self.file_metadata_cache
+                    .as_ref()
+                    .and_then(|cache| cache.get(&path))
                     .is_some()
             }
             crate::cache::CACHE_TYPE_STATS => {
@@ -393,7 +381,8 @@ impl CustomCacheManager {
         // Verify the metadata was cached properly
         match cache_ref.inner.lock() {
             Ok(cache_guard) => {
-                if cache_guard.contains_key(object_meta) {
+                let path = Path::from(file_path.to_string());
+                if cache_guard.contains_key(&path) {
                     Ok(true)
                 } else {
                     debug!("[CACHE ERROR] Failed to cache metadata for: {}", file_path);
@@ -429,7 +418,7 @@ impl CustomCacheManager {
                     version: None,
                 };
 
-                cache.put_with_extra(&path, Arc::new(stats), &meta);
+                cache.put_statistics(&path, Arc::new(stats), &meta);
                 Ok(true)
             }
             Err(e) => {
@@ -466,7 +455,7 @@ impl CustomCacheManager {
                         version: None,
                     };
 
-                    cache.put_with_extra(&path, Arc::new(stats), &meta);
+                    cache.put_statistics(&path, Arc::new(stats), &meta);
                     success_count += 1;
                 }
                 Err(e) => {

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_executor.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_executor.rs
@@ -32,7 +32,7 @@ use datafusion::{
     catalog::Session,
     common::tree_node::{TreeNode, TreeNodeRecursion},
     datasource::{TableProvider, TableType},
-    execution::cache::cache_manager::CacheManagerConfig,
+    execution::cache::cache_manager::{CacheManagerConfig, CachedFileList},
     execution::cache::{CacheAccessor, DefaultListFilesCache, TableScopedPath},
     execution::memory_pool::MemoryPool,
     execution::object_store::ObjectStoreUrl,
@@ -103,7 +103,7 @@ pub async fn execute_indexed_query(
         table: None,
         path: shard_view.table_path.prefix().clone(),
     };
-    list_file_cache.put(&table_scoped_path, shard_view.object_metas.clone());
+    list_file_cache.put(&table_scoped_path, CachedFileList::new(shard_view.object_metas.as_ref().clone()));
 
     let mut runtime_env_builder = RuntimeEnvBuilder::from_runtime_env(&runtime.runtime_env)
         .with_cache_manager(

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/parquet_bridge.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/parquet_bridge.rs
@@ -40,7 +40,7 @@ use datafusion_datasource::source::DataSourceExec;
 use datafusion_datasource::PartitionedFile;
 use futures::future::BoxFuture;
 use futures::FutureExt;
-use object_store::ObjectStore;
+use object_store::{ObjectStore, ObjectStoreExt};
 use prost::bytes::Bytes;
 
 // ── Parquet Metadata Loading ─────────────────────────────────────────

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/stream.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/stream.rs
@@ -258,7 +258,7 @@ pub struct IndexedExec {
     pub(crate) store_url: datafusion::execution::object_store::ObjectStoreUrl,
     pub(crate) row_groups: Vec<RowGroupInfo>,
     pub(crate) projection: Option<Vec<usize>>,
-    pub(crate) properties: PlanProperties,
+    pub(crate) properties: Arc<PlanProperties>,
     pub(crate) metadata: Arc<ParquetMetaData>,
     pub(crate) predicate: Option<Arc<dyn datafusion::physical_expr::PhysicalExpr>>,
     /// Pluggable bitset source (SingleCollector or RustTree).
@@ -309,7 +309,7 @@ impl ExecutionPlan for IndexedExec {
     fn schema(&self) -> SchemaRef {
         self.schema.clone()
     }
-    fn properties(&self) -> &PlanProperties {
+    fn properties(&self) -> &Arc<PlanProperties> {
         &self.properties
     }
     fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/table_provider.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/table_provider.rs
@@ -222,12 +222,12 @@ impl TableProvider for IndexedTableProvider {
         let assignments =
             compute_assignments(&layouts, self.config.query_config.target_partitions.max(1));
 
-        let properties = PlanProperties::new(
+        let properties = Arc::new(PlanProperties::new(
             EquivalenceProperties::new(projected_schema.clone()),
             Partitioning::UnknownPartitioning(assignments.len().max(1)),
             EmissionType::Incremental,
             Boundedness::Bounded,
-        );
+        ));
 
         Ok(Arc::new(QueryShardExec {
             config: Arc::clone(&self.config),
@@ -257,7 +257,7 @@ pub struct QueryShardExec {
     projected_schema: SchemaRef,
     projection: Option<Vec<usize>>,
     assignments: Vec<PartitionAssignment>,
-    properties: PlanProperties,
+    properties: Arc<PlanProperties>,
     /// Residual physical predicate pushed down from the planner. Threaded
     /// into each `IndexedExec` so `ParquetSource.with_predicate(...)` can
     /// apply it during decode.
@@ -296,7 +296,7 @@ impl ExecutionPlan for QueryShardExec {
     fn schema(&self) -> SchemaRef {
         self.projected_schema.clone()
     }
-    fn properties(&self) -> &PlanProperties {
+    fn properties(&self) -> &Arc<PlanProperties> {
         &self.properties
     }
     fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
@@ -361,12 +361,12 @@ impl ExecutionPlan for QueryShardExec {
             let evaluator = (self.config.evaluator_factory)(segment, chunk, &stream_metrics)
                 .map_err(|e| DataFusionError::External(e.into()))?;
 
-            let props = PlanProperties::new(
+            let props = Arc::new(PlanProperties::new(
                 EquivalenceProperties::new(self.projected_schema.clone()),
                 Partitioning::UnknownPartitioning(1),
                 EmissionType::Incremental,
                 Boundedness::Bounded,
-            );
+            ));
 
             let exec = IndexedExec {
                 schema: self.projected_schema.clone(),

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/query_executor.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/query_executor.rs
@@ -18,7 +18,7 @@ use datafusion::{
     prelude::*,
 };
 use datafusion::datasource::file_format::parquet::ParquetFormat;
-use datafusion::execution::cache::cache_manager::CacheManagerConfig;
+use datafusion::execution::cache::cache_manager::{CacheManagerConfig, CachedFileList};
 use datafusion::execution::cache::{CacheAccessor, DefaultListFilesCache};
 use datafusion_substrait::logical_plan::consumer::from_substrait_plan;
 use log::error;
@@ -58,7 +58,7 @@ pub async fn execute_query(
         table: None,
         path: table_path.prefix().clone(),
     };
-    list_file_cache.put(&table_scoped_path, object_metas);
+    list_file_cache.put(&table_scoped_path, CachedFileList::new(object_metas.as_ref().clone()));
 
     // Build a per-query RuntimeEnv sharing the global memory pool + caches,
     // but with a fresh list-files cache for this query's shard files.

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/session_context.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/session_context.rs
@@ -17,7 +17,7 @@ use datafusion::{
     common::DataFusionError,
     datasource::file_format::parquet::ParquetFormat,
     datasource::listing::{ListingOptions, ListingTable, ListingTableConfig, ListingTableUrl},
-    execution::cache::cache_manager::CacheManagerConfig,
+    execution::cache::cache_manager::{CacheManagerConfig, CachedFileList},
     execution::cache::{CacheAccessor, DefaultListFilesCache},
     execution::context::SessionContext,
     execution::memory_pool::MemoryPool,
@@ -79,7 +79,7 @@ pub async unsafe fn create_session_context(
             table: None,
             path: shard_view.table_path.prefix().clone(),
         },
-        shard_view.object_metas.clone(),
+        CachedFileList::new(shard_view.object_metas.as_ref().clone()),
     );
 
     let mut runtime_env_builder = RuntimeEnvBuilder::from_runtime_env(&runtime.runtime_env)

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/statistics_cache.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/statistics_cache.rs
@@ -14,6 +14,7 @@ use datafusion::common::stats::{ColumnStatistics, Precision};
 use datafusion::common::ScalarValue;
 use dashmap::DashMap;
 use datafusion::execution::cache::CacheAccessor;
+use datafusion::execution::cache::cache_manager::{CachedFileMetadata, FileStatisticsCache, FileStatisticsCacheEntry};
 use datafusion::physical_plan::Statistics;
 use object_store::{path::Path, ObjectMeta};
 use std::collections::HashMap;
@@ -114,7 +115,7 @@ impl StatisticsMemorySize for Statistics {
 /// and adds memory tracking + policy-based eviction on top.
 pub struct CustomStatisticsCache {
     /// The underlying DataFusion statistics cache (DashMap-based, already thread-safe)
-    inner_cache: DashMap<Path, (ObjectMeta, Arc<Statistics>)>,
+    inner_cache: DashMap<Path, CachedFileMetadata>,
     /// The eviction policy (thread-safe)
     policy: Arc<Mutex<Box<dyn CachePolicy>>>,
     /// Size limit for the cache in bytes
@@ -152,7 +153,7 @@ impl CustomStatisticsCache {
     }
 
     /// Get the underlying cache for compatibility
-    pub fn inner(&self) -> &DashMap<Path, (ObjectMeta, Arc<Statistics>)> {
+    pub fn inner(&self) -> &DashMap<Path, CachedFileMetadata> {
         &self.inner_cache
     }
 
@@ -271,13 +272,29 @@ impl CustomStatisticsCache {
         Ok(freed_size)
     }
 
+    /// Convenience method: put statistics with associated metadata (replaces old put_with_extra)
+    pub fn put_statistics(
+        &self,
+        k: &Path,
+        stats: Arc<Statistics>,
+        meta: &ObjectMeta,
+    ) -> Option<CachedFileMetadata> {
+        let cached = CachedFileMetadata::new(meta.clone(), stats, None);
+        self.put(k, cached)
+    }
+
+    /// Convenience method: get just the statistics Arc (for callers that don't need full CachedFileMetadata)
+    pub fn get_statistics(&self, k: &Path) -> Option<Arc<Statistics>> {
+        self.get(k).map(|c| c.statistics)
+    }
+
     /// Parse cache key back to Path
     fn parse_key_to_path(&self, key: &str) -> CacheResult<Path> {
         Ok(Path::from(key))
     }
 
     /// Remove entry internally (works with &self since inner_cache is thread-safe)
-    fn remove_internal(&self, k: &Path) -> Option<Arc<Statistics>> {
+    fn remove_internal(&self, k: &Path) -> Option<CachedFileMetadata> {
         let key = k.to_string();
         let result = self.inner_cache.remove(k);
         if result.is_some() {
@@ -292,15 +309,13 @@ impl CustomStatisticsCache {
                 policy_guard.on_remove(&key);
             }
         }
-        result.map(|x| x.1 .1)
+        result.map(|x| x.1)
     }
 }
 
-// Implement CacheAccessor - DashMap handles concurrency, we just need to handle the &mut self requirement
-impl CacheAccessor<Path, Arc<Statistics>> for CustomStatisticsCache {
-    type Extra = ObjectMeta;
-
-    fn get(&self, k: &Path) -> Option<Arc<Statistics>> {
+// Implement CacheAccessor - DashMap handles concurrency
+impl CacheAccessor<Path, CachedFileMetadata> for CustomStatisticsCache {
+    fn get(&self, k: &Path) -> Option<CachedFileMetadata> {
         let result = self.inner_cache.get(k);
 
         if result.is_some() {
@@ -316,34 +331,14 @@ impl CacheAccessor<Path, Arc<Statistics>> for CustomStatisticsCache {
             if let Ok(mut misses) = self.miss_count.lock() { *misses += 1; }
         }
 
-        result.map(|s| Some(Arc::clone(&s.value().1))).unwrap_or(None)
+        result.map(|s| s.value().clone())
     }
 
-    fn get_with_extra(&self, k: &Path, _extra: &Self::Extra) -> Option<Arc<Statistics>> {
-        self.get(k)
-    }
-
-    fn put(&self, k: &Path, v: Arc<Statistics>) -> Option<Arc<Statistics>> {
-        let meta = ObjectMeta {
-            location: k.clone(),
-            last_modified: chrono::Utc::now(),
-            size: 0,
-            e_tag: None,
-            version: None,
-        };
-        self.put_with_extra(k, v, &meta)
-    }
-
-    fn put_with_extra(
-        &self,
-        k: &Path,
-        v: Arc<Statistics>,
-        e: &Self::Extra,
-    ) -> Option<Arc<Statistics>> {
+    fn put(&self, k: &Path, v: CachedFileMetadata) -> Option<CachedFileMetadata> {
         let key = k.to_string();
-        let memory_size = v.memory_size();
+        let memory_size = v.statistics.memory_size();
 
-        let eviction_candidates = if let Ok(tracker) = self.memory_tracker.lock() {
+        let eviction_candidates = if let Ok(_tracker) = self.memory_tracker.lock() {
             if let Ok(total) = self.total_memory.lock() {
                 let current_size = *total;
                 let size_limit = self.size_limit.load(Ordering::Relaxed);
@@ -363,7 +358,7 @@ impl CacheAccessor<Path, Arc<Statistics>> for CustomStatisticsCache {
             }
         }
 
-        let result = self.inner_cache.insert(k.clone(), (e.clone(), v)).map(|x| x.1);
+        let result = self.inner_cache.insert(k.clone(), v);
 
         if let Ok(mut tracker) = self.memory_tracker.lock() {
             if let Ok(mut total) = self.total_memory.lock() {
@@ -382,7 +377,7 @@ impl CacheAccessor<Path, Arc<Statistics>> for CustomStatisticsCache {
         result
     }
 
-    fn remove(&self, k: &Path) -> Option<Arc<Statistics>> {
+    fn remove(&self, k: &Path) -> Option<CachedFileMetadata> {
         let key = k.to_string();
         let result = self.inner_cache.remove(k);
         if result.is_some() {
@@ -397,7 +392,7 @@ impl CacheAccessor<Path, Arc<Statistics>> for CustomStatisticsCache {
                 policy_guard.on_remove(&key);
             }
         }
-        result.map(|x| x.1 .1)
+        result.map(|x| x.1)
     }
 
     fn contains_key(&self, k: &Path) -> bool {
@@ -424,8 +419,8 @@ impl CacheAccessor<Path, Arc<Statistics>> for CustomStatisticsCache {
     }
 }
 
-impl datafusion::execution::cache::cache_manager::FileStatisticsCache for CustomStatisticsCache {
-    fn list_entries(&self) -> std::collections::HashMap<object_store::path::Path, datafusion::execution::cache::cache_manager::FileStatisticsCacheEntry> {
+impl FileStatisticsCache for CustomStatisticsCache {
+    fn list_entries(&self) -> std::collections::HashMap<Path, FileStatisticsCacheEntry> {
         std::collections::HashMap::new()
     }
 }
@@ -511,7 +506,7 @@ mod tests {
         let path = create_test_path("file1");
         let meta = create_test_meta(&path);
         let stats = Arc::new(create_test_statistics());
-        cache.put_with_extra(&path, stats, &meta);
+        cache.put_statistics(&path, stats, &meta);
 
         assert!(cache.memory_consumed() > 0);
         assert_eq!(cache.len(), 1);
@@ -525,7 +520,7 @@ mod tests {
             let path = create_test_path(&format!("file{}", i));
             let meta = create_test_meta(&path);
             let stats = Arc::new(create_test_statistics());
-            cache.put_with_extra(&path, stats, &meta);
+            cache.put_statistics(&path, stats, &meta);
         }
         assert!(cache.memory_consumed() <= 1000);
         assert!(cache.len() > 0);
@@ -538,7 +533,7 @@ mod tests {
             let path = create_test_path(&format!("file{}", i));
             let meta = create_test_meta(&path);
             let stats = Arc::new(create_test_statistics());
-            cache.put_with_extra(&path, stats, &meta);
+            cache.put_statistics(&path, stats, &meta);
         }
         let memory_before = cache.memory_consumed();
         assert!(memory_before > 0);
@@ -554,7 +549,7 @@ mod tests {
             let path = create_test_path(&format!("file{}", i));
             let meta = create_test_meta(&path);
             let stats = Arc::new(create_test_statistics());
-            cache.put_with_extra(&path, stats, &meta);
+            cache.put_statistics(&path, stats, &meta);
         }
         let memory_before = cache.memory_consumed();
         assert_eq!(cache.policy_name().unwrap(), "lru");
@@ -572,8 +567,8 @@ mod tests {
         let meta2 = create_test_meta(&path2);
         let stats = Arc::new(create_test_statistics());
 
-        cache.put_with_extra(&path1, stats.clone(), &meta1);
-        cache.put_with_extra(&path2, stats, &meta2);
+        cache.put_statistics(&path1, stats.clone(), &meta1);
+        cache.put_statistics(&path2, stats, &meta2);
         let memory_with_two = cache.memory_consumed();
         assert_eq!(cache.len(), 2);
 
@@ -593,7 +588,7 @@ mod tests {
             let path = create_test_path(&format!("file{}", i));
             let meta = create_test_meta(&path);
             let stats = Arc::new(create_test_statistics());
-            cache.put_with_extra(&path, stats, &meta);
+            cache.put_statistics(&path, stats, &meta);
         }
         assert!(cache.memory_consumed() > 0);
         cache.clear();
@@ -607,7 +602,7 @@ mod tests {
         let path = create_test_path("file1");
         let meta = create_test_meta(&path);
         let stats = Arc::new(create_test_statistics());
-        cache.put_with_extra(&path, stats, &meta);
+        cache.put_statistics(&path, stats, &meta);
 
         assert!(cache.get(&path).is_some());
         assert_eq!(cache.hit_count(), 1);
@@ -635,7 +630,7 @@ mod tests {
         let path1 = create_test_path("file1");
         let meta1 = create_test_meta(&path1);
         let stats = Arc::new(create_test_statistics());
-        cache.put_with_extra(&path1, stats, &meta1);
+        cache.put_statistics(&path1, stats, &meta1);
 
         cache.get(&path1); // hit
         cache.get(&path1); // hit
@@ -652,7 +647,7 @@ mod tests {
         let path = create_test_path("file1");
         let meta = create_test_meta(&path);
         let stats = Arc::new(create_test_statistics());
-        cache.put_with_extra(&path, stats, &meta);
+        cache.put_statistics(&path, stats, &meta);
 
         cache.get(&path);
         let path2 = create_test_path("missing");
@@ -672,7 +667,7 @@ mod tests {
         let path = create_test_path("file1");
         let meta = create_test_meta(&path);
         let stats = Arc::new(create_test_statistics());
-        cache.put_with_extra(&path, stats, &meta);
+        cache.put_statistics(&path, stats, &meta);
         cache.get(&path);
 
         cache.clear();
@@ -693,7 +688,7 @@ mod tests {
                 let path = create_test_path(&format!("concurrent{}", i));
                 let meta = create_test_meta(&path);
                 let stats = Arc::new(create_test_statistics());
-                cache_clone.put_with_extra(&path, stats, &meta);
+                cache_clone.put_statistics(&path, stats, &meta);
                 assert!(cache_clone.get(&path).is_some());
             });
             handles.push(handle);

--- a/sandbox/plugins/analytics-backend-datafusion/rust/tests/local_exec_test.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/tests/local_exec_test.rs
@@ -79,6 +79,7 @@ impl RuntimeGuard {
         let rc = unsafe {
             df_create_global_runtime(
                 128 * 1024 * 1024,
+                0, // no cache manager
                 spill_bytes.as_ptr(),
                 spill_bytes.len() as i64,
                 64 * 1024 * 1024,

--- a/sandbox/plugins/block-cache-foyer/src/main/rust/Cargo.toml
+++ b/sandbox/plugins/block-cache-foyer/src/main/rust/Cargo.toml
@@ -11,7 +11,7 @@ name = "opensearch_block_cache"
 crate-type = ["rlib"]
 
 [dependencies]
-foyer                = "0.22"
+foyer                = "=0.22.3"
 bytes                = { workspace = true }
 dashmap              = { workspace = true }
 tokio                = { workspace = true }

--- a/sandbox/plugins/block-cache-foyer/src/main/rust/src/range_cache.rs
+++ b/sandbox/plugins/block-cache-foyer/src/main/rust/src/range_cache.rs
@@ -72,7 +72,7 @@ impl CacheKey {
 ///
 /// # Example
 /// ```
-/// use opensearch_page_cache::range_cache::range_cache_key;
+/// use opensearch_block_cache::range_cache::range_cache_key;
 /// let key = range_cache_key("data/nodes/0/_0.parquet", 0, 4096);
 /// assert_eq!(key.as_str(), "data/nodes/0/_0.parquet\x1f0-4096");
 /// ```

--- a/sandbox/plugins/native-repository-fs/src/main/rust/src/fs.rs
+++ b/sandbox/plugins/native-repository-fs/src/main/rust/src/fs.rs
@@ -34,7 +34,7 @@ pub fn build(
 mod tests {
     use super::*;
     use object_store::path::Path;
-    use object_store::PutPayload;
+    use object_store::{ObjectStoreExt, PutPayload};
     use futures::TryStreamExt;
 
     #[test]


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Upgrades datafusion to v53 and arrow to v58 , also have made the changes to lock the version in all the cargo toml files.

Changes in general were minor
```
1. object_store 0.12 -> 0.13
Methods moved from ObjectStore trait to ObjectStoreExt extension trait:

get_range, head, delete, copy, copy_if_not_exists, rename_if_not_exists
These are now auto-implemented via ObjectStoreExt using get_opts/delete_stream/copy_opts
Callers need use object_store::ObjectStoreExt; in scope
New required trait methods:

delete_stream(BoxStream<'static, Result<Path>>) -> BoxStream<'static, Result<Path>>
copy_opts(&self, from: &Path, to: &Path, options: CopyOptions) -> Result<()>

2. DataFusion CacheAccessor trait simplification
Old API (DF 52):

trait CacheAccessor<K, V> {
    type Extra;
    fn get(&self, k: &K) -> Option<V>;
    fn get_with_extra(&self, k: &K, extra: &Self::Extra) -> Option<V>;
    fn put(&self, k: &K, v: V) -> Option<V>;
    fn put_with_extra(&self, k: &K, v: V, extra: &Self::Extra) -> Option<V>;
    fn remove, contains_key, len, clear, name...
}
New API (DF 53):

trait CacheAccessor<K, V> {
    fn get(&self, k: &K) -> Option<V>;
    fn put(&self, k: &K, v: V) -> Option<V>;
    fn remove, contains_key, len, clear, name...
}
FileStatisticsCache: Changed from CacheAccessor<Path, Arc<Statistics>> with Extra=ObjectMeta to CacheAccessor<Path, CachedFileMetadata> where CachedFileMetadata bundles {meta: ObjectMeta, statistics: Arc<Statistics>, ordering: Option<LexOrdering>}.

FileMetadataCache: Changed key from ObjectMeta to Path. Value changed from Arc<dyn FileMetadata> to CachedFileMetadataEntry which bundles {meta: ObjectMeta, file_metadata: Arc<dyn FileMetadata>}.

ListFilesCache: Value changed from Arc<Vec<ObjectMeta>> to CachedFileList (wraps Arc<Vec<ObjectMeta>>).

3. ExecutionPlan::properties() return type
Changed from &PlanProperties to &Arc<PlanProperties>.

```
### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
