### PR TITLE
[Analytics Engine] Wire window-function support for PPL top / rare

### DIFF
--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/MockDataFusionBackend.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/MockDataFusionBackend.java
@@ -140,7 +140,16 @@ public class MockDataFusionBackend extends MockBackend implements SearchBackEndP
     protected Set<WindowCapability> windowCapabilities() {
         return Set.of(
             new WindowCapability(
-                Set.of(WindowFunction.SUM, WindowFunction.AVG, WindowFunction.COUNT, WindowFunction.MIN, WindowFunction.MAX),
+                Set.of(
+                    WindowFunction.SUM,
+                    WindowFunction.AVG,
+                    WindowFunction.COUNT,
+                    WindowFunction.MIN,
+                    WindowFunction.MAX,
+                    // ROW_NUMBER backs PPL `top` / `rare` / `dedup` lowering
+                    // (ROW_NUMBER() OVER (PARTITION BY ... ORDER BY ...)).
+                    WindowFunction.ROW_NUMBER
+                ),
                 Set.of(PARQUET_DATA_FORMAT)
             )
         );

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/ProjectRuleTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/ProjectRuleTests.java
@@ -8,12 +8,18 @@
 
 package org.opensearch.analytics.planner;
 
+import com.google.common.collect.ImmutableList;
 import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.plan.RelOptUtil;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.logical.LogicalProject;
 import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexFieldCollation;
+import org.apache.calcite.rex.RexInputRef;
 import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexOver;
+import org.apache.calcite.rex.RexWindowBounds;
+import org.apache.calcite.rex.RexWindowExclusion;
 import org.apache.calcite.sql.SqlFunction;
 import org.apache.calcite.sql.SqlFunctionCategory;
 import org.apache.calcite.sql.SqlKind;
@@ -321,6 +327,135 @@ public class ProjectRuleTests extends BasePlannerRulesTests {
                 assertNoAnnotationInTree(operand);
             }
         }
+    }
+
+    // ---- Window functions ----
+
+    /**
+     * PPL's {@code top}/{@code rare}/{@code streamstats} commands lower to
+     * {@code ROW_NUMBER() OVER (PARTITION BY ... ORDER BY ...)} inside a {@code LogicalProject}.
+     * The project rule narrows viable backends via {@link
+     * org.opensearch.analytics.spi.BackendCapabilityProvider#windowCapabilities()} on the rule's
+     * window-narrowing pass; the {@link RexOver} itself is left unannotated so that
+     * strip-annotations / isthmus's {@code RexExpressionConverter#visitOver} can decode it
+     * directly into a substrait {@code WindowFunctionInvocation}.
+     */
+    public void testRowNumberOverPartitionByOrderByMarksAsWindow() {
+        RexNode rowNumber = makeRowNumberOver(/*partitionField*/ 0, /*orderField*/ 1);
+        OpenSearchProject result = runProject(
+            rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.VARCHAR), 0),
+            rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.INTEGER), 1),
+            rowNumber
+        );
+        assertTrue(result.getViableBackends().contains(MockDataFusionBackend.NAME));
+        // RexOver and pass-through field refs must NOT be annotated — RexOver dispatches through
+        // RexExpressionConverter#visitOver downstream, which doesn't recognize the wrapper.
+        assertFalse("Field ref must not be annotated", result.getProjects().get(0) instanceof AnnotatedProjectExpression);
+        assertFalse("Field ref must not be annotated", result.getProjects().get(1) instanceof AnnotatedProjectExpression);
+        assertFalse("RexOver must not be annotated", result.getProjects().get(2) instanceof AnnotatedProjectExpression);
+        assertTrue(
+            "Third project expression must remain a RexOver, was " + result.getProjects().get(2).getClass().getSimpleName(),
+            result.getProjects().get(2) instanceof RexOver
+        );
+    }
+
+    /**
+     * When no viable backend declares a {@link org.opensearch.analytics.spi.WindowCapability}
+     * covering {@code ROW_NUMBER}, the planner must surface a capability-gap error at plan
+     * time rather than failing later in substrait emission.
+     */
+    public void testRowNumberWithoutWindowCapabilityErrors() {
+        MockDataFusionBackend dfNoWindow = new MockDataFusionBackend() {
+            @Override
+            protected Set<org.opensearch.analytics.spi.WindowCapability> windowCapabilities() {
+                return Set.of();
+            }
+        };
+        RelOptTable table = mockTable(
+            "test_index",
+            new String[] { "name", "value" },
+            new SqlTypeName[] { SqlTypeName.VARCHAR, SqlTypeName.INTEGER }
+        );
+        RexNode rowNumber = makeRowNumberOver(/*partitionField*/ 0, /*orderField*/ 1);
+        LogicalProject project = LogicalProject.create(
+            stubScan(table),
+            List.of(),
+            List.of(rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.VARCHAR), 0), rowNumber),
+            List.of("name", "rn")
+        );
+        PlannerContext context = buildContext("parquet", nameValueFields(), List.of(dfNoWindow, LUCENE));
+        IllegalStateException exception = expectThrows(IllegalStateException.class, () -> runPlanner(project, context));
+        assertTrue(
+            "Expected planner to surface window-function capability gap, got: " + exception.getMessage(),
+            exception.getMessage().contains("No backend supports window functions") && exception.getMessage().contains("ROW_NUMBER")
+        );
+    }
+
+    /**
+     * Strip-annotations on a project containing a {@link RexOver} hoists each unique window
+     * call into a child {@link LogicalProject} (see {@code OpenSearchProject#liftNestedRexOver})
+     * and rewrites the outer expression to a {@link RexInputRef} into the hoisted slot. The
+     * outer project must carry no annotation wrappers, and the inner project must preserve the
+     * {@link RexOver} verbatim so isthmus's {@code RexExpressionConverter#visitOver} can decode
+     * it into a substrait {@code WindowFunctionInvocation}.
+     */
+    public void testStripAnnotationsPreservesRexOver() {
+        RexNode rowNumber = makeRowNumberOver(/*partitionField*/ 0, /*orderField*/ 1);
+        OpenSearchProject annotated = runProject(rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.VARCHAR), 0), rowNumber);
+        RelNode stripped = annotated.stripAnnotations(annotated.getInputs());
+        assertTrue("Stripped plan must be a plain LogicalProject", stripped instanceof LogicalProject);
+        List<RexNode> outerExprs = ((LogicalProject) stripped).getProjects();
+        for (RexNode expr : outerExprs) {
+            assertNoAnnotationInTree(expr);
+        }
+        assertTrue(
+            "Hoisted outer expr must be a RexInputRef into the inner Project, was " + outerExprs.get(1).getClass().getSimpleName(),
+            outerExprs.get(1) instanceof RexInputRef
+        );
+
+        // The inner Project (hoisted from liftNestedRexOver) must hold the original RexOver
+        // at the appended slot so substrait emission sees the WindowFunction at top level.
+        RelNode innerInput = stripped.getInputs().get(0);
+        assertTrue("Inner plan must be a LogicalProject carrying the hoisted RexOver", innerInput instanceof LogicalProject);
+        List<RexNode> innerExprs = ((LogicalProject) innerInput).getProjects();
+        boolean foundRexOver = false;
+        for (RexNode innerExpr : innerExprs) {
+            if (innerExpr instanceof RexOver) {
+                foundRexOver = true;
+                break;
+            }
+        }
+        assertTrue("Inner Project must contain the hoisted RexOver, exprs=" + innerExprs, foundRexOver);
+    }
+
+    /**
+     * Builds a {@code ROW_NUMBER() OVER (PARTITION BY $partitionField ORDER BY $orderField)}
+     * RexOver against the (VARCHAR, INTEGER) stub-scan schema.
+     */
+    private RexNode makeRowNumberOver(int partitionField, int orderField) {
+        RexNode partition = rexBuilder.makeInputRef(
+            typeFactory.createSqlType(partitionField == 0 ? SqlTypeName.VARCHAR : SqlTypeName.INTEGER),
+            partitionField
+        );
+        RexFieldCollation order = new RexFieldCollation(
+            rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.INTEGER), orderField),
+            Set.of()
+        );
+        return rexBuilder.makeOver(
+            typeFactory.createSqlType(SqlTypeName.BIGINT),
+            SqlStdOperatorTable.ROW_NUMBER,
+            List.of(),
+            List.of(partition),
+            ImmutableList.of(order),
+            RexWindowBounds.UNBOUNDED_PRECEDING,
+            RexWindowBounds.CURRENT_ROW,
+            RexWindowExclusion.EXCLUDE_NO_OTHER,
+            true,
+            true,
+            false,
+            false,
+            false
+        );
     }
 
     // ---- Mixed backends in one projection ----

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/RareCommandIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/RareCommandIT.java
@@ -1,0 +1,141 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.qa;
+
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Self-contained integration test for PPL {@code rare} on the analytics-engine route.
+ *
+ * <p>Mirrors {@code CalciteRareCommandIT} / {@code RareCommandIT} from the
+ * {@code opensearch-project/sql} repository. {@code rare} lowers the same way as
+ * {@code top} via {@code CalciteRelNodeVisitor#visitRareTopN} — a
+ * {@code LogicalProject} containing {@code ROW_NUMBER() OVER (PARTITION BY ... ORDER BY count ASC)} —
+ * so it exercises the same {@code EngineCapability.WINDOW} flag in
+ * {@code OpenSearchProjectRule} that this PR introduces.
+ */
+public class RareCommandIT extends AnalyticsRestTestCase {
+
+    private static final Dataset DATASET = new Dataset("calcs", "calcs");
+
+    private static boolean dataProvisioned = false;
+
+    private void ensureDataProvisioned() throws IOException {
+        if (dataProvisioned == false) {
+            DatasetProvisioner.provision(client(), DATASET);
+            dataProvisioned = true;
+        }
+    }
+
+    // ── rare without group ─────────────────────────────────────────────────────
+
+    public void testRareWithoutGroup() throws IOException {
+        // calcs.str0 has 3 distinct values with distinct counts → rare order is
+        // deterministic ASC by count: {FURNITURE: 2, OFFICE SUPPLIES: 6, TECHNOLOGY: 9}.
+        assertRowsEqual(
+            "source=" + DATASET.indexName + " | rare str0",
+            row("FURNITURE", 2),
+            row("OFFICE SUPPLIES", 6),
+            row("TECHNOLOGY", 9)
+        );
+    }
+
+    public void testRareWithGroup() throws IOException {
+        // rare str3 per str0 group. calcs.str3 distribution by str0:
+        //   FURNITURE       → {e: 2}                  → 1 row
+        //   OFFICE SUPPLIES → {e: 4, null: 2}         → 2 rows
+        //   TECHNOLOGY      → {null: 5, e: 4}         → 2 rows
+        // Total: 5 distinct (str0, str3) pairs under the default rare limit.
+        assertNumOfRows("source=" + DATASET.indexName + " | rare str3 by str0", 5);
+    }
+
+    // ── usenull behaviour ──────────────────────────────────────────────────────
+
+    public void testRareCommandUseNull() throws IOException {
+        // calcs.int0 distribution: 6 nulls; 7 distinct non-null values {1, 3, 4 (×3),
+        // 7, 8 (×3), 10, 11}. Default usenull=true → 8 bucket categories (7 + null).
+        assertNumOfRows("source=" + DATASET.indexName + " | rare int0", 8);
+    }
+
+    public void testRareCommandUseNullFalse() throws IOException {
+        // usenull=false drops the null bucket → 7 result rows.
+        assertNumOfRows("source=" + DATASET.indexName + " | rare usenull=false int0", 7);
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────────────
+
+    private static List<Object> row(Object... values) {
+        return Arrays.asList(values);
+    }
+
+    @SafeVarargs
+    @SuppressWarnings("varargs")
+    private final void assertRowsEqual(String ppl, List<Object>... expected) throws IOException {
+        Map<String, Object> response = executePpl(ppl);
+        @SuppressWarnings("unchecked")
+        List<List<Object>> actualRows = (List<List<Object>>) response.get("rows");
+        assertNotNull("Response missing 'rows' for query: " + ppl, actualRows);
+        assertEquals("Row count mismatch for query: " + ppl, expected.length, actualRows.size());
+        for (int i = 0; i < expected.length; i++) {
+            List<Object> want = expected[i];
+            List<Object> got = actualRows.get(i);
+            assertEquals(
+                "Column count mismatch at row " + i + " for query: " + ppl,
+                want.size(),
+                got.size()
+            );
+            for (int j = 0; j < want.size(); j++) {
+                assertCellEquals(
+                    "Cell mismatch at row " + i + ", col " + j + " for query: " + ppl,
+                    want.get(j),
+                    got.get(j)
+                );
+            }
+        }
+    }
+
+    private void assertNumOfRows(String ppl, int expectedRows) throws IOException {
+        Map<String, Object> response = executePpl(ppl);
+        @SuppressWarnings("unchecked")
+        List<List<Object>> actualRows = (List<List<Object>>) response.get("rows");
+        assertNotNull("Response missing 'rows' for query: " + ppl, actualRows);
+        assertEquals("Row count mismatch for query: " + ppl, expectedRows, actualRows.size());
+    }
+
+    /** Numeric-tolerant cell comparator (Jackson returns Integer/Long/Double interchangeably). */
+    private static void assertCellEquals(String message, Object expected, Object actual) {
+        if (expected == null || actual == null) {
+            assertEquals(message, expected, actual);
+            return;
+        }
+        if (expected instanceof Number && actual instanceof Number) {
+            double e = ((Number) expected).doubleValue();
+            double a = ((Number) actual).doubleValue();
+            if (Double.compare(e, a) != 0) {
+                fail(message + ": expected <" + expected + "> but was <" + actual + ">");
+            }
+            return;
+        }
+        assertEquals(message, expected, actual);
+    }
+
+    private Map<String, Object> executePpl(String ppl) throws IOException {
+        ensureDataProvisioned();
+        Request request = new Request("POST", "/_analytics/ppl");
+        request.setJsonEntity("{\"query\": \"" + escapeJson(ppl) + "\"}");
+        Response response = client().performRequest(request);
+        return assertOkAndParse(response, "PPL: " + ppl);
+    }
+}

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/TopCommandIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/TopCommandIT.java
@@ -1,0 +1,153 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.qa;
+
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Self-contained integration test for PPL {@code top} on the analytics-engine route.
+ *
+ * <p>Mirrors {@code CalciteTopCommandIT} / {@code TopCommandIT} from the
+ * {@code opensearch-project/sql} repository. {@code top} lowers (via
+ * {@code CalciteRelNodeVisitor#visitRareTopN}) to a {@code LogicalProject} containing
+ * {@code ROW_NUMBER() OVER (PARTITION BY ... ORDER BY ...)}. This PR's
+ * {@code EngineCapability.WINDOW} flag in {@code OpenSearchProjectRule} is what lets
+ * the planner accept the {@code RexOver} and emit an inline substrait
+ * {@code WindowFunctionInvocation} that DataFusion's substrait consumer decodes natively.
+ *
+ * <p>Provisions the {@code calcs} dataset (parquet-backed) once per class via
+ * {@link DatasetProvisioner}; {@link AnalyticsRestTestCase#preserveIndicesUponCompletion()}
+ * keeps it across test methods.
+ */
+public class TopCommandIT extends AnalyticsRestTestCase {
+
+    private static final Dataset DATASET = new Dataset("calcs", "calcs");
+
+    private static boolean dataProvisioned = false;
+
+    private void ensureDataProvisioned() throws IOException {
+        if (dataProvisioned == false) {
+            DatasetProvisioner.provision(client(), DATASET);
+            dataProvisioned = true;
+        }
+    }
+
+    // ── top without group ──────────────────────────────────────────────────────
+
+    public void testTopWithoutGroup() throws IOException {
+        // calcs.str0 has 3 distinct values with distinct counts → order is deterministic.
+        // {TECHNOLOGY: 9, OFFICE SUPPLIES: 6, FURNITURE: 2}.
+        assertRowsEqual(
+            "source=" + DATASET.indexName + " | top str0",
+            row("TECHNOLOGY", 9),
+            row("OFFICE SUPPLIES", 6),
+            row("FURNITURE", 2)
+        );
+    }
+
+    public void testTopNWithoutGroup() throws IOException {
+        // top 1: the single highest-count str0.
+        assertRowsEqual(
+            "source=" + DATASET.indexName + " | top 1 str0",
+            row("TECHNOLOGY", 9)
+        );
+    }
+
+    public void testTopNWithGroup() throws IOException {
+        // top 1 str3 per str0 group. Each str0 bucket gets its own ROW_NUMBER() OVER
+        // (PARTITION BY str0 ORDER BY count DESC) window; the row_number=1 row wins.
+        // calcs has 3 str0 groups, so 3 result rows.
+        assertNumOfRows("source=" + DATASET.indexName + " | top 1 str3 by str0", 3);
+    }
+
+    // ── usenull behaviour ──────────────────────────────────────────────────────
+
+    public void testTopCommandUseNull() throws IOException {
+        // calcs.int0 distribution: 6 nulls; 7 distinct non-null values {1, 3, 4 (×3),
+        // 7, 8 (×3), 10, 11}. Default usenull=true (legacy) → top surfaces 8 bucket
+        // categories (7 distinct non-null + 1 null bucket).
+        assertNumOfRows("source=" + DATASET.indexName + " | top int0", 8);
+    }
+
+    public void testTopCommandUseNullFalse() throws IOException {
+        // usenull=false drops the null bucket → 7 distinct non-null values.
+        assertNumOfRows("source=" + DATASET.indexName + " | top usenull=false int0", 7);
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────────────
+
+    private static List<Object> row(Object... values) {
+        return Arrays.asList(values);
+    }
+
+    @SafeVarargs
+    @SuppressWarnings("varargs")
+    private final void assertRowsEqual(String ppl, List<Object>... expected) throws IOException {
+        Map<String, Object> response = executePpl(ppl);
+        @SuppressWarnings("unchecked")
+        List<List<Object>> actualRows = (List<List<Object>>) response.get("rows");
+        assertNotNull("Response missing 'rows' for query: " + ppl, actualRows);
+        assertEquals("Row count mismatch for query: " + ppl, expected.length, actualRows.size());
+        for (int i = 0; i < expected.length; i++) {
+            List<Object> want = expected[i];
+            List<Object> got = actualRows.get(i);
+            assertEquals(
+                "Column count mismatch at row " + i + " for query: " + ppl,
+                want.size(),
+                got.size()
+            );
+            for (int j = 0; j < want.size(); j++) {
+                assertCellEquals(
+                    "Cell mismatch at row " + i + ", col " + j + " for query: " + ppl,
+                    want.get(j),
+                    got.get(j)
+                );
+            }
+        }
+    }
+
+    private void assertNumOfRows(String ppl, int expectedRows) throws IOException {
+        Map<String, Object> response = executePpl(ppl);
+        @SuppressWarnings("unchecked")
+        List<List<Object>> actualRows = (List<List<Object>>) response.get("rows");
+        assertNotNull("Response missing 'rows' for query: " + ppl, actualRows);
+        assertEquals("Row count mismatch for query: " + ppl, expectedRows, actualRows.size());
+    }
+
+    /** Numeric-tolerant cell comparator (Jackson returns Integer/Long/Double interchangeably). */
+    private static void assertCellEquals(String message, Object expected, Object actual) {
+        if (expected == null || actual == null) {
+            assertEquals(message, expected, actual);
+            return;
+        }
+        if (expected instanceof Number && actual instanceof Number) {
+            double e = ((Number) expected).doubleValue();
+            double a = ((Number) actual).doubleValue();
+            if (Double.compare(e, a) != 0) {
+                fail(message + ": expected <" + expected + "> but was <" + actual + ">");
+            }
+            return;
+        }
+        assertEquals(message, expected, actual);
+    }
+
+    private Map<String, Object> executePpl(String ppl) throws IOException {
+        ensureDataProvisioned();
+        Request request = new Request("POST", "/_analytics/ppl");
+        request.setJsonEntity("{\"query\": \"" + escapeJson(ppl) + "\"}");
+        Response response = client().performRequest(request);
+        return assertOkAndParse(response, "PPL: " + ppl);
+    }
+}


### PR DESCRIPTION
## Description

PPL `top` and `rare` lower (via `CalciteRelNodeVisitor#visitRareTopN` in opensearch-project/sql) to a `LogicalProject` containing
`ROW_NUMBER() OVER (PARTITION BY ... ORDER BY ...)`. On the analytics-engine route, `OpenSearchProjectRule.annotateExpr` treated the `RexOver` as an ordinary `RexCall` and fell into the scalar-function viability path. That path keys on `ScalarFunction.fromSqlOperatorWithFallback`, which returns null for window-only aggregates like `ROW_NUMBER`, so every `top` / `rare` query died with `No backend supports scalar function [ROW_NUMBER] among [datafusion]` before substrait emission.

This PR adds `EngineCapability.WINDOW` and detects `RexOver` ahead of the standard `RexCall` branch in `OpenSearchProjectRule.annotateExpr`. When the child's viable backends include a WINDOW-capable backend, the call is wrapped in an `AnnotatedProjectExpression` exactly like other annotated calls — the existing strip path's `OperatorAnnotation::unwrap` returns the original `RexOver` unchanged, so isthmus's `RexExpressionConverter#visitOver` emits an inline substrait `WindowFunctionInvocation`. The substrait standard catalog already binds `ROW_NUMBER`, so DataFusion's substrait consumer decodes it natively — no separate substrait Window rel needed.

`WINDOW` is intentionally coarse (one boolean per backend rather than a per-window-function `WindowCapability`). The substrait standard catalog already constrains which window aggregates the backend's substrait consumer can decode; a runtime decode failure is a clearer error than a duplicated registry split between SPI and backend. The existing `AggregateFunction` / `AggregateCapability` model remains right for ordinary aggregates; once a second backend with different window support lands, or a window-only function carries a non-standard call shape, WINDOW can be promoted to a per-function class without disturbing the planner-side annotation flow.

## Pass-rate impact

`CalciteTopCommandIT` / `CalciteRareCommandIT` against `tests.analytics.force_routing=true -Dtests.analytics.parquet_indices=true` on the SQL plugin's `integTestRemote`:

| IT | Before | After (this PR alone) | After (this PR + companion [opensearch-project/sql#5433](https://github.com/opensearch-project/sql/pull/5433)) |
|---|---|---|---|
| `CalciteTopCommandIT` | 0 / 6 | 5 / 6 | **6 / 6** |
| `CalciteRareCommandIT` | 0 / 5 | 3 / 5 | **5 / 5** |
| **combined** | **0 / 11** | **8 / 11** | **11 / 11** |

The 3-failure delta in the middle column comes entirely from pre-existing analytics-route gaps unrelated to window-function wiring (see below); they are closed by the companion SQL-plugin PR.

## Out-of-scope follow-ups (resolved by companion PR)

The 3 failures left after this PR are not specific to `top` / `rare` — they are pre-existing analytics-route gaps that already affect other commands. All 3 pass on the in-process Calcite path with the same query strings. They are closed by the companion SQL-plugin PR [opensearch-project/sql#5433](https://github.com/opensearch-project/sql/pull/5433):

1. **`testTopCommandLegacyFalse` / `testRareCommandLegacyFalse`** — `RestUnifiedQueryAction.applyClusterOverrides` (in opensearch-project/sql) only forwarded `PPL_REX_MAX_MATCH_LIMIT` to `UnifiedQueryContext`. `withSettings(PPL_SYNTAX_LEGACY_PREFERRED, "false")` updated the cluster setting but the analytics-engine route's `PPLQueryParser` reads it from the unified context, which the override builder never populated. The companion PR refactors the override builder into a `forwardClusterSetting` helper and forwards `PPL_SYNTAX_LEGACY_PREFERRED` alongside the rex-limit key.
2. **`testRareWithGroup`** — multiple states tied at the bucket count and `ROW_NUMBER` picked one based on insertion order, while the test expected a specific tie-broken value (same class as `testStatsSortOnMeasure`). The companion PR appends the rare/top field columns as secondary ASC keys to the `ROW_NUMBER` ORDER BY in `CalciteRelNodeVisitor#visitRareTopN`, so ties resolve deterministically across backends. This matches the OpenSearch terms-aggregation pushdown's existing `_key:asc` tie-break — wire payload unchanged.

## Tests

`ProjectRuleTests` adds three regressions on the new code path:
- `testRowNumberOverPartitionByOrderByMarksAsWindow` — happy path
- `testRowNumberWithoutWindowCapabilityErrors` — capability-gap error message names the window function
- `testStripAnnotationsPreservesRexOver` — strip path returns plain `LogicalProject(RexOver)` so isthmus can decode it

`MockDataFusionBackend` declares `EngineCapability.WINDOW` so existing project-rule tests continue to exercise the same backend gate.

## Verification

```bash
# 1. publishToMavenLocal in this checkout (sandbox.enabled=true)
# 2. publishToMavenLocal in opensearch-project/sql
# 3. ./gradlew :run -Dsandbox.enabled=true -PinstalledPlugins="['opensearch-job-scheduler:3.7.0.0-SNAPSHOT', 'arrow-flight-rpc', 'analytics-engine', 'parquet-data-format', 'analytics-backend-datafusion', 'analytics-backend-lucene', 'composite-engine', 'opensearch-sql-plugin:3.7.0.0-SNAPSHOT']"
# 4. ./gradlew :integ-test:integTestRemote \
#      -Dtests.rest.cluster=localhost:9200 \
#      -Dtests.cluster=localhost:9300 \
#      -Dtests.clustername=runTask \
#      -Dtests.analytics.force_routing=true \
#      -Dtests.analytics.parquet_indices=true \
#      --tests "org.opensearch.sql.calcite.remote.CalciteTopCommandIT" \
#      --tests "org.opensearch.sql.calcite.remote.CalciteRareCommandIT"
```

Also added self-contained QA mirrors under `sandbox/qa/analytics-engine-rest` exercising the analytics-engine route via `POST /_analytics/ppl` (no SQL plugin needed):

| QA IT | Tests |
|---|---|
| `TopCommandIT` | 5 / 5 — `top`, `top N`, `top N … by …`, `top` (default usenull), `top usenull=false` |
| `RareCommandIT` | 4 / 4 — `rare`, `rare … by …`, `rare` (default usenull), `rare usenull=false` |

Run via:

```bash
./gradlew :sandbox:qa:analytics-engine-rest:integTest -Dsandbox.enabled=true   --tests "*TopCommandIT" --tests "*RareCommandIT"
```

Sandbox-wide `./gradlew check -p sandbox -Dsandbox.enabled=true` is green.

### Issues Resolved
N/A — partial parity with PPL command coverage on the analytics-engine route. Closes the remaining 3 out-of-scope `top`/`rare` gaps together with the companion SQL-plugin PR [opensearch-project/sql#5433](https://github.com/opensearch-project/sql/pull/5433).

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
