### PR TITLE
Refactor datafusion stats - simplify structure and naming

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/action/DataFusionStatsAction.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/action/DataFusionStatsAction.java
@@ -20,7 +20,7 @@ import org.opensearch.transport.client.node.NodeClient;
 import java.util.List;
 
 /**
- * REST handler for {@code GET _plugins/datafusion/stats}.
+ * REST handler for {@code GET _plugins/analytics_backend_datafusion/stats}.
  * <p>
  * Collects native executor metrics (Tokio runtime + task monitors) from
  * {@link DataFusionService} and returns them as a JSON response. Follows
@@ -47,7 +47,7 @@ public class DataFusionStatsAction extends BaseRestHandler {
 
     @Override
     public List<Route> routes() {
-        return List.of(new Route(RestRequest.Method.GET, "_plugins/datafusion/stats"));
+        return List.of(new Route(RestRequest.Method.GET, "_plugins/analytics_backend_datafusion/stats"));
     }
 
     @Override

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/nativelib/NativeBridge.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/nativelib/NativeBridge.java
@@ -11,6 +11,7 @@ package org.opensearch.be.datafusion.nativelib;
 import org.opensearch.analytics.backend.jni.NativeHandle;
 import org.opensearch.be.datafusion.stats.DataFusionStats;
 import org.opensearch.be.datafusion.stats.NativeExecutorsStats;
+import org.opensearch.be.datafusion.stats.TaskMonitorStats;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.nativebridge.spi.NativeCall;
 import org.opensearch.nativebridge.spi.NativeLibraryLoader;
@@ -665,7 +666,7 @@ public final class NativeBridge {
             var cpuRuntime = StatsLayout.readRuntimeMetrics(seg, "cpu_runtime");
 
             // Task monitors
-            var taskMonitors = new LinkedHashMap<String, NativeExecutorsStats.TaskMonitorStats>();
+            var taskMonitors = new LinkedHashMap<String, TaskMonitorStats>();
             for (NativeExecutorsStats.OperationType op : NativeExecutorsStats.OperationType.values()) {
                 taskMonitors.put(op.key(), StatsLayout.readTaskMonitor(seg, op.key()));
             }

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/nativelib/StatsLayout.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/nativelib/StatsLayout.java
@@ -8,7 +8,8 @@
 
 package org.opensearch.be.datafusion.nativelib;
 
-import org.opensearch.be.datafusion.stats.NativeExecutorsStats;
+import org.opensearch.be.datafusion.stats.RuntimeMetrics;
+import org.opensearch.be.datafusion.stats.TaskMonitorStats;
 
 import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemoryLayout.PathElement;
@@ -120,9 +121,9 @@ public final class StatsLayout {
      * @param group "io_runtime" or "cpu_runtime"
      * @return a populated RuntimeMetrics instance
      */
-    public static NativeExecutorsStats.RuntimeMetrics readRuntimeMetrics(MemorySegment seg, String group) {
+    public static RuntimeMetrics readRuntimeMetrics(MemorySegment seg, String group) {
         VarHandle[] handles = runtimeHandles(group);
-        return new NativeExecutorsStats.RuntimeMetrics(
+        return new RuntimeMetrics(
             (long) handles[0].get(seg, 0L),
             (long) handles[1].get(seg, 0L),
             (long) handles[2].get(seg, 0L),
@@ -142,13 +143,9 @@ public final class StatsLayout {
      * @param group "query_execution", "stream_next", "fetch_phase", or "segment_stats"
      * @return a populated TaskMonitorStats instance
      */
-    public static NativeExecutorsStats.TaskMonitorStats readTaskMonitor(MemorySegment seg, String group) {
+    public static TaskMonitorStats readTaskMonitor(MemorySegment seg, String group) {
         VarHandle[] handles = taskMonitorHandles(group);
-        return new NativeExecutorsStats.TaskMonitorStats(
-            (long) handles[0].get(seg, 0L),
-            (long) handles[1].get(seg, 0L),
-            (long) handles[2].get(seg, 0L)
-        );
+        return new TaskMonitorStats((long) handles[0].get(seg, 0L), (long) handles[1].get(seg, 0L), (long) handles[2].get(seg, 0L));
     }
 
     // ---- Private helpers ----

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/stats/NativeExecutorsStats.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/stats/NativeExecutorsStats.java
@@ -102,8 +102,6 @@ public class NativeExecutorsStats implements Writeable, ToXContentFragment {
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject("native_executors");
-
         builder.startObject("io_runtime");
         ioRuntime.toXContent(builder);
         builder.endObject();
@@ -114,15 +112,11 @@ public class NativeExecutorsStats implements Writeable, ToXContentFragment {
             builder.endObject();
         }
 
-        builder.startObject("task_monitors");
         for (Map.Entry<String, TaskMonitorStats> entry : taskMonitors.entrySet()) {
             builder.startObject(entry.getKey());
             entry.getValue().toXContent(builder);
             builder.endObject();
         }
-        builder.endObject(); // task_monitors
-
-        builder.endObject(); // native_executors
         return builder;
     }
 
@@ -156,214 +150,4 @@ public class NativeExecutorsStats implements Writeable, ToXContentFragment {
         return Objects.hash(ioRuntime, cpuRuntime, taskMonitors);
     }
 
-    /**
-     * 8 fields from {@code tokio_metrics::RuntimeMonitor} describing
-     * per-worker thread pool behavior for a single Tokio runtime.
-     */
-    public static class RuntimeMetrics implements Writeable {
-        /** Number of worker threads in the runtime. */
-        public final long workersCount;
-        /** Total number of task polls across all workers. */
-        public final long totalPollsCount;
-        /** Total time workers spent executing tasks, in milliseconds. */
-        public final long totalBusyDurationMs;
-        /** Total number of times tasks were pushed to the overflow queue. */
-        public final long totalOverflowCount;
-        /** Current depth of the global injection queue. */
-        public final long globalQueueDepth;
-        /** Current depth of the blocking thread pool queue. */
-        public final long blockingQueueDepth;
-        /** Number of tasks currently alive (spawned but not yet completed) on this runtime. */
-        public final long numAliveTasks;
-        /** Total number of tasks spawned on this runtime since creation. */
-        public final long spawnedTasksCount;
-        /** Sum of all per-worker local queue depths (tasks queued on worker-local run queues). */
-        public final long totalLocalQueueDepth;
-
-        /**
-         * Construct from explicit field values.
-         *
-         * @param workersCount        number of worker threads
-         * @param totalPollsCount     total task polls across all workers
-         * @param totalBusyDurationMs total busy time in milliseconds
-         * @param totalOverflowCount  total overflow queue pushes
-         * @param globalQueueDepth    current global injection queue depth
-         * @param blockingQueueDepth  current blocking thread pool queue depth
-         * @param numAliveTasks       tasks currently alive
-         * @param spawnedTasksCount   total tasks spawned since creation
-         * @param totalLocalQueueDepth     sum of per-worker local queue depths
-         */
-        public RuntimeMetrics(
-            long workersCount,
-            long totalPollsCount,
-            long totalBusyDurationMs,
-            long totalOverflowCount,
-            long globalQueueDepth,
-            long blockingQueueDepth,
-            long numAliveTasks,
-            long spawnedTasksCount,
-            long totalLocalQueueDepth
-        ) {
-            this.workersCount = workersCount;
-            this.totalPollsCount = totalPollsCount;
-            this.totalBusyDurationMs = totalBusyDurationMs;
-            this.totalOverflowCount = totalOverflowCount;
-            this.globalQueueDepth = globalQueueDepth;
-            this.blockingQueueDepth = blockingQueueDepth;
-            this.numAliveTasks = numAliveTasks;
-            this.spawnedTasksCount = spawnedTasksCount;
-            this.totalLocalQueueDepth = totalLocalQueueDepth;
-        }
-
-        /**
-         * Deserialize from stream.
-         *
-         * @param in the stream input
-         * @throws IOException if deserialization fails
-         */
-        public RuntimeMetrics(StreamInput in) throws IOException {
-            this.workersCount = in.readVLong();
-            this.totalPollsCount = in.readVLong();
-            this.totalBusyDurationMs = in.readVLong();
-            this.totalOverflowCount = in.readVLong();
-            this.globalQueueDepth = in.readVLong();
-            this.blockingQueueDepth = in.readVLong();
-            this.numAliveTasks = in.readVLong();
-            this.spawnedTasksCount = in.readVLong();
-            this.totalLocalQueueDepth = in.readVLong();
-        }
-
-        @Override
-        public void writeTo(StreamOutput out) throws IOException {
-            out.writeVLong(workersCount);
-            out.writeVLong(totalPollsCount);
-            out.writeVLong(totalBusyDurationMs);
-            out.writeVLong(totalOverflowCount);
-            out.writeVLong(globalQueueDepth);
-            out.writeVLong(blockingQueueDepth);
-            out.writeVLong(numAliveTasks);
-            out.writeVLong(spawnedTasksCount);
-            out.writeVLong(totalLocalQueueDepth);
-        }
-
-        /**
-         * Render all 8 fields as snake_case JSON fields.
-         *
-         * @param builder the XContent builder to write to
-         * @throws IOException if writing fails
-         */
-        public void toXContent(XContentBuilder builder) throws IOException {
-            builder.field("workers_count", workersCount);
-            builder.field("total_polls_count", totalPollsCount);
-            builder.field("total_busy_duration_ms", totalBusyDurationMs);
-            builder.field("total_overflow_count", totalOverflowCount);
-            builder.field("global_queue_depth", globalQueueDepth);
-            builder.field("blocking_queue_depth", blockingQueueDepth);
-            builder.field("num_alive_tasks", numAliveTasks);
-            builder.field("spawned_tasks_count", spawnedTasksCount);
-            builder.field("total_local_queue_depth", totalLocalQueueDepth);
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-            RuntimeMetrics that = (RuntimeMetrics) o;
-            return workersCount == that.workersCount
-                && totalPollsCount == that.totalPollsCount
-                && totalBusyDurationMs == that.totalBusyDurationMs
-                && totalOverflowCount == that.totalOverflowCount
-                && globalQueueDepth == that.globalQueueDepth
-                && blockingQueueDepth == that.blockingQueueDepth
-                && numAliveTasks == that.numAliveTasks
-                && spawnedTasksCount == that.spawnedTasksCount
-                && totalLocalQueueDepth == that.totalLocalQueueDepth;
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(
-                workersCount,
-                totalPollsCount,
-                totalBusyDurationMs,
-                totalOverflowCount,
-                globalQueueDepth,
-                blockingQueueDepth,
-                numAliveTasks,
-                spawnedTasksCount,
-                totalLocalQueueDepth
-            );
-        }
-    }
-
-    /**
-     * 3 duration fields per operation type from {@code tokio_metrics::TaskMonitor::cumulative()}.
-     */
-    public static class TaskMonitorStats implements Writeable {
-        /** Total time spent polling instrumented futures, in milliseconds. */
-        public final long totalPollDurationMs;
-        /** Total time tasks spent waiting in the scheduler queue, in milliseconds. */
-        public final long totalScheduledDurationMs;
-        /** Total time tasks spent idle between polls, in milliseconds. */
-        public final long totalIdleDurationMs;
-
-        /**
-         * Construct from explicit field values.
-         *
-         * @param totalPollDurationMs      total poll duration in milliseconds
-         * @param totalScheduledDurationMs total scheduled duration in milliseconds
-         * @param totalIdleDurationMs      total idle duration in milliseconds
-         */
-        public TaskMonitorStats(long totalPollDurationMs, long totalScheduledDurationMs, long totalIdleDurationMs) {
-            this.totalPollDurationMs = totalPollDurationMs;
-            this.totalScheduledDurationMs = totalScheduledDurationMs;
-            this.totalIdleDurationMs = totalIdleDurationMs;
-        }
-
-        /**
-         * Deserialize from stream.
-         *
-         * @param in the stream input
-         * @throws IOException if deserialization fails
-         */
-        public TaskMonitorStats(StreamInput in) throws IOException {
-            this.totalPollDurationMs = in.readVLong();
-            this.totalScheduledDurationMs = in.readVLong();
-            this.totalIdleDurationMs = in.readVLong();
-        }
-
-        @Override
-        public void writeTo(StreamOutput out) throws IOException {
-            out.writeVLong(totalPollDurationMs);
-            out.writeVLong(totalScheduledDurationMs);
-            out.writeVLong(totalIdleDurationMs);
-        }
-
-        /**
-         * Render all 3 fields as snake_case JSON fields.
-         *
-         * @param builder the XContent builder to write to
-         * @throws IOException if writing fails
-         */
-        public void toXContent(XContentBuilder builder) throws IOException {
-            builder.field("total_poll_duration_ms", totalPollDurationMs);
-            builder.field("total_scheduled_duration_ms", totalScheduledDurationMs);
-            builder.field("total_idle_duration_ms", totalIdleDurationMs);
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-            TaskMonitorStats that = (TaskMonitorStats) o;
-            return totalPollDurationMs == that.totalPollDurationMs
-                && totalScheduledDurationMs == that.totalScheduledDurationMs
-                && totalIdleDurationMs == that.totalIdleDurationMs;
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(totalPollDurationMs, totalScheduledDurationMs, totalIdleDurationMs);
-        }
-    }
 }

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/stats/RuntimeMetrics.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/stats/RuntimeMetrics.java
@@ -1,0 +1,157 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion.stats;
+
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.common.io.stream.Writeable;
+import org.opensearch.core.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * 8 fields from {@code tokio_metrics::RuntimeMonitor} describing
+ * per-worker thread pool behavior for a single Tokio runtime.
+ */
+public class RuntimeMetrics implements Writeable {
+    /** Number of worker threads in the runtime. */
+    public final long workersCount;
+    /** Total number of task polls across all workers. */
+    public final long totalPollsCount;
+    /** Total time workers spent executing tasks, in milliseconds. */
+    public final long totalBusyDurationMs;
+    /** Total number of times tasks were pushed to the overflow queue. */
+    public final long totalOverflowCount;
+    /** Current depth of the global injection queue. */
+    public final long globalQueueDepth;
+    /** Current depth of the blocking thread pool queue. */
+    public final long blockingQueueDepth;
+    /** Number of tasks currently alive (spawned but not yet completed) on this runtime. */
+    public final long numAliveTasks;
+    /** Total number of tasks spawned on this runtime since creation. */
+    public final long spawnedTasksCount;
+    /** Sum of all per-worker local queue depths (tasks queued on worker-local run queues). */
+    public final long totalLocalQueueDepth;
+
+    /**
+     * Construct from explicit field values.
+     *
+     * @param workersCount        number of worker threads
+     * @param totalPollsCount     total task polls across all workers
+     * @param totalBusyDurationMs total busy time in milliseconds
+     * @param totalOverflowCount  total overflow queue pushes
+     * @param globalQueueDepth    current global injection queue depth
+     * @param blockingQueueDepth  current blocking thread pool queue depth
+     * @param numAliveTasks       tasks currently alive
+     * @param spawnedTasksCount   total tasks spawned since creation
+     * @param totalLocalQueueDepth     sum of per-worker local queue depths
+     */
+    public RuntimeMetrics(
+        long workersCount,
+        long totalPollsCount,
+        long totalBusyDurationMs,
+        long totalOverflowCount,
+        long globalQueueDepth,
+        long blockingQueueDepth,
+        long numAliveTasks,
+        long spawnedTasksCount,
+        long totalLocalQueueDepth
+    ) {
+        this.workersCount = workersCount;
+        this.totalPollsCount = totalPollsCount;
+        this.totalBusyDurationMs = totalBusyDurationMs;
+        this.totalOverflowCount = totalOverflowCount;
+        this.globalQueueDepth = globalQueueDepth;
+        this.blockingQueueDepth = blockingQueueDepth;
+        this.numAliveTasks = numAliveTasks;
+        this.spawnedTasksCount = spawnedTasksCount;
+        this.totalLocalQueueDepth = totalLocalQueueDepth;
+    }
+
+    /**
+     * Deserialize from stream.
+     *
+     * @param in the stream input
+     * @throws IOException if deserialization fails
+     */
+    public RuntimeMetrics(StreamInput in) throws IOException {
+        this.workersCount = in.readVLong();
+        this.totalPollsCount = in.readVLong();
+        this.totalBusyDurationMs = in.readVLong();
+        this.totalOverflowCount = in.readVLong();
+        this.globalQueueDepth = in.readVLong();
+        this.blockingQueueDepth = in.readVLong();
+        this.numAliveTasks = in.readVLong();
+        this.spawnedTasksCount = in.readVLong();
+        this.totalLocalQueueDepth = in.readVLong();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeVLong(workersCount);
+        out.writeVLong(totalPollsCount);
+        out.writeVLong(totalBusyDurationMs);
+        out.writeVLong(totalOverflowCount);
+        out.writeVLong(globalQueueDepth);
+        out.writeVLong(blockingQueueDepth);
+        out.writeVLong(numAliveTasks);
+        out.writeVLong(spawnedTasksCount);
+        out.writeVLong(totalLocalQueueDepth);
+    }
+
+    /**
+     * Render all 8 fields as snake_case JSON fields.
+     *
+     * @param builder the XContent builder to write to
+     * @throws IOException if writing fails
+     */
+    public void toXContent(XContentBuilder builder) throws IOException {
+        builder.field("workers_count", workersCount);
+        builder.field("total_polls_count", totalPollsCount);
+        builder.field("total_busy_duration_ms", totalBusyDurationMs);
+        builder.field("total_overflow_count", totalOverflowCount);
+        builder.field("global_queue_depth", globalQueueDepth);
+        builder.field("blocking_queue_depth", blockingQueueDepth);
+        builder.field("num_alive_tasks", numAliveTasks);
+        builder.field("spawned_tasks_count", spawnedTasksCount);
+        builder.field("total_local_queue_depth", totalLocalQueueDepth);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        RuntimeMetrics that = (RuntimeMetrics) o;
+        return workersCount == that.workersCount
+            && totalPollsCount == that.totalPollsCount
+            && totalBusyDurationMs == that.totalBusyDurationMs
+            && totalOverflowCount == that.totalOverflowCount
+            && globalQueueDepth == that.globalQueueDepth
+            && blockingQueueDepth == that.blockingQueueDepth
+            && numAliveTasks == that.numAliveTasks
+            && spawnedTasksCount == that.spawnedTasksCount
+            && totalLocalQueueDepth == that.totalLocalQueueDepth;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+            workersCount,
+            totalPollsCount,
+            totalBusyDurationMs,
+            totalOverflowCount,
+            globalQueueDepth,
+            blockingQueueDepth,
+            numAliveTasks,
+            spawnedTasksCount,
+            totalLocalQueueDepth
+        );
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/stats/TaskMonitorStats.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/stats/TaskMonitorStats.java
@@ -1,0 +1,88 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion.stats;
+
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.common.io.stream.Writeable;
+import org.opensearch.core.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * 3 duration fields per operation type from {@code tokio_metrics::TaskMonitor::cumulative()}.
+ */
+public class TaskMonitorStats implements Writeable {
+    /** Total time spent polling instrumented futures, in milliseconds. */
+    public final long totalPollDurationMs;
+    /** Total time tasks spent waiting in the scheduler queue, in milliseconds. */
+    public final long totalScheduledDurationMs;
+    /** Total time tasks spent idle between polls, in milliseconds. */
+    public final long totalIdleDurationMs;
+
+    /**
+     * Construct from explicit field values.
+     *
+     * @param totalPollDurationMs      total poll duration in milliseconds
+     * @param totalScheduledDurationMs total scheduled duration in milliseconds
+     * @param totalIdleDurationMs      total idle duration in milliseconds
+     */
+    public TaskMonitorStats(long totalPollDurationMs, long totalScheduledDurationMs, long totalIdleDurationMs) {
+        this.totalPollDurationMs = totalPollDurationMs;
+        this.totalScheduledDurationMs = totalScheduledDurationMs;
+        this.totalIdleDurationMs = totalIdleDurationMs;
+    }
+
+    /**
+     * Deserialize from stream.
+     *
+     * @param in the stream input
+     * @throws IOException if deserialization fails
+     */
+    public TaskMonitorStats(StreamInput in) throws IOException {
+        this.totalPollDurationMs = in.readVLong();
+        this.totalScheduledDurationMs = in.readVLong();
+        this.totalIdleDurationMs = in.readVLong();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeVLong(totalPollDurationMs);
+        out.writeVLong(totalScheduledDurationMs);
+        out.writeVLong(totalIdleDurationMs);
+    }
+
+    /**
+     * Render all 3 fields as snake_case JSON fields.
+     *
+     * @param builder the XContent builder to write to
+     * @throws IOException if writing fails
+     */
+    public void toXContent(XContentBuilder builder) throws IOException {
+        builder.field("total_poll_duration_ms", totalPollDurationMs);
+        builder.field("total_scheduled_duration_ms", totalScheduledDurationMs);
+        builder.field("total_idle_duration_ms", totalIdleDurationMs);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        TaskMonitorStats that = (TaskMonitorStats) o;
+        return totalPollDurationMs == that.totalPollDurationMs
+            && totalScheduledDurationMs == that.totalScheduledDurationMs
+            && totalIdleDurationMs == that.totalIdleDurationMs;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(totalPollDurationMs, totalScheduledDurationMs, totalIdleDurationMs);
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/src/propertyTest/java/org/opensearch/be/datafusion/nativelib/StatsLayoutPropertyTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/propertyTest/java/org/opensearch/be/datafusion/nativelib/StatsLayoutPropertyTests.java
@@ -9,8 +9,8 @@
 package org.opensearch.be.datafusion.nativelib;
 
 import org.opensearch.be.datafusion.stats.NativeExecutorsStats;
-import org.opensearch.be.datafusion.stats.NativeExecutorsStats.RuntimeMetrics;
-import org.opensearch.be.datafusion.stats.NativeExecutorsStats.TaskMonitorStats;
+import org.opensearch.be.datafusion.stats.RuntimeMetrics;
+import org.opensearch.be.datafusion.stats.TaskMonitorStats;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.core.common.io.stream.StreamInput;
 

--- a/sandbox/plugins/analytics-backend-datafusion/src/propertyTest/java/org/opensearch/be/datafusion/stats/DataFusionStatsPropertyTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/propertyTest/java/org/opensearch/be/datafusion/stats/DataFusionStatsPropertyTests.java
@@ -12,8 +12,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.opensearch.be.datafusion.stats.NativeExecutorsStats.OperationType;
-import org.opensearch.be.datafusion.stats.NativeExecutorsStats.RuntimeMetrics;
-import org.opensearch.be.datafusion.stats.NativeExecutorsStats.TaskMonitorStats;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.common.bytes.BytesReference;
@@ -49,7 +47,7 @@ public class DataFusionStatsPropertyTests {
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
-    /** JSON field names for RuntimeMetrics in documented order (8 fields). */
+    /** JSON field names for RuntimeMetrics in documented order (9 fields). */
     private static final String[] RUNTIME_FIELD_NAMES = {
         "workers_count",
         "total_polls_count",
@@ -58,7 +56,8 @@ public class DataFusionStatsPropertyTests {
         "global_queue_depth",
         "blocking_queue_depth",
         "num_alive_tasks",
-        "spawned_tasks_count" };
+        "spawned_tasks_count",
+        "total_local_queue_depth" };
 
     /** JSON field names for TaskMonitorStats in documented order (3 fields). */
     private static final String[] TASK_FIELD_NAMES = { "total_poll_duration_ms", "total_scheduled_duration_ms", "total_idle_duration_ms" };
@@ -174,28 +173,23 @@ public class DataFusionStatsPropertyTests {
 
         String json = renderJson(stats);
         JsonNode root = MAPPER.readTree(json);
-        JsonNode nativeExecutors = root.get("native_executors");
-        assertNotNull(nativeExecutors, "native_executors must be present");
 
-        // IO runtime: 8 fields
-        JsonNode ioRuntime = nativeExecutors.get("io_runtime");
+        // IO runtime: 9 fields
+        JsonNode ioRuntime = root.get("io_runtime");
         assertNotNull(ioRuntime, "io_runtime must be present");
-        assertEquals(8, ioRuntime.size(), "io_runtime must have exactly 8 fields");
+        assertEquals(9, ioRuntime.size(), "io_runtime must have exactly 9 fields");
         verifyRuntimeFields(nes.getIoRuntime(), ioRuntime);
 
-        // CPU runtime: 8 fields
-        assertTrue(nativeExecutors.has("cpu_runtime"), "cpu_runtime must be present");
-        JsonNode cpuRuntime = nativeExecutors.get("cpu_runtime");
-        assertEquals(8, cpuRuntime.size(), "cpu_runtime must have exactly 8 fields");
+        // CPU runtime: 9 fields
+        assertTrue(root.has("cpu_runtime"), "cpu_runtime must be present");
+        JsonNode cpuRuntime = root.get("cpu_runtime");
+        assertEquals(9, cpuRuntime.size(), "cpu_runtime must have exactly 9 fields");
         verifyRuntimeFields(nes.getCpuRuntime(), cpuRuntime);
 
-        // Task monitors: 4 ops × 3 fields
-        JsonNode taskMonitors = nativeExecutors.get("task_monitors");
-        assertNotNull(taskMonitors, "task_monitors must be present");
-        assertEquals(4, taskMonitors.size());
+        // Task monitors: 4 ops × 3 fields (at top level, no task_monitors wrapper)
         for (OperationType opType : OperationType.values()) {
-            JsonNode monitor = taskMonitors.get(opType.key());
-            assertNotNull(monitor, "task_monitors." + opType.key() + " must be present");
+            JsonNode monitor = root.get(opType.key());
+            assertNotNull(monitor, opType.key() + " must be present");
             assertEquals(3, monitor.size());
             verifyTaskMonitorFields(nes.getTaskMonitors().get(opType.key()), monitor, opType.key());
         }
@@ -211,25 +205,20 @@ public class DataFusionStatsPropertyTests {
 
         String json = renderJson(stats);
         JsonNode root = MAPPER.readTree(json);
-        JsonNode nativeExecutors = root.get("native_executors");
-        assertNotNull(nativeExecutors, "native_executors must be present");
 
-        // IO runtime: 8 fields
-        JsonNode ioRuntime = nativeExecutors.get("io_runtime");
+        // IO runtime: 9 fields
+        JsonNode ioRuntime = root.get("io_runtime");
         assertNotNull(ioRuntime, "io_runtime must be present");
-        assertEquals(8, ioRuntime.size(), "io_runtime must have exactly 8 fields");
+        assertEquals(9, ioRuntime.size(), "io_runtime must have exactly 9 fields");
         verifyRuntimeFields(nes.getIoRuntime(), ioRuntime);
 
         // CPU runtime absent
-        assertFalse(nativeExecutors.has("cpu_runtime"), "cpu_runtime must be absent when cpuRuntime is null");
+        assertFalse(root.has("cpu_runtime"), "cpu_runtime must be absent when cpuRuntime is null");
 
-        // Task monitors
-        JsonNode taskMonitors = nativeExecutors.get("task_monitors");
-        assertNotNull(taskMonitors);
-        assertEquals(4, taskMonitors.size());
+        // Task monitors: at top level, no task_monitors wrapper
         for (OperationType opType : OperationType.values()) {
-            JsonNode monitor = taskMonitors.get(opType.key());
-            assertNotNull(monitor);
+            JsonNode monitor = root.get(opType.key());
+            assertNotNull(monitor, opType.key() + " must be present");
             assertEquals(3, monitor.size());
             verifyTaskMonitorFields(nes.getTaskMonitors().get(opType.key()), monitor, opType.key());
         }
@@ -308,7 +297,8 @@ public class DataFusionStatsPropertyTests {
             rm.globalQueueDepth,
             rm.blockingQueueDepth,
             rm.numAliveTasks,
-            rm.spawnedTasksCount };
+            rm.spawnedTasksCount,
+            rm.totalLocalQueueDepth };
         for (int i = 0; i < RUNTIME_FIELD_NAMES.length; i++) {
             String fieldName = RUNTIME_FIELD_NAMES[i];
             assertTrue(runtimeNode.has(fieldName), "Runtime field '" + fieldName + "' must be present");

--- a/sandbox/plugins/analytics-backend-datafusion/src/propertyTest/java/org/opensearch/be/datafusion/stats/NativeExecutorsStatsTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/propertyTest/java/org/opensearch/be/datafusion/stats/NativeExecutorsStatsTests.java
@@ -9,8 +9,6 @@
 package org.opensearch.be.datafusion.stats;
 
 import org.opensearch.be.datafusion.stats.NativeExecutorsStats.OperationType;
-import org.opensearch.be.datafusion.stats.NativeExecutorsStats.RuntimeMetrics;
-import org.opensearch.be.datafusion.stats.NativeExecutorsStats.TaskMonitorStats;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.core.common.io.stream.StreamInput;
 

--- a/sandbox/plugins/analytics-backend-datafusion/src/propertyTest/java/org/opensearch/be/datafusion/stats/NodeStatsNativeMetricRoundTripTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/propertyTest/java/org/opensearch/be/datafusion/stats/NodeStatsNativeMetricRoundTripTests.java
@@ -9,8 +9,6 @@
 package org.opensearch.be.datafusion.stats;
 
 import org.opensearch.be.datafusion.stats.NativeExecutorsStats.OperationType;
-import org.opensearch.be.datafusion.stats.NativeExecutorsStats.RuntimeMetrics;
-import org.opensearch.be.datafusion.stats.NativeExecutorsStats.TaskMonitorStats;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.core.common.io.stream.StreamInput;
 

--- a/sandbox/plugins/analytics-backend-datafusion/src/propertyTest/java/org/opensearch/be/datafusion/stats/StatsEndpointRefactorPropertyTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/propertyTest/java/org/opensearch/be/datafusion/stats/StatsEndpointRefactorPropertyTests.java
@@ -1,0 +1,293 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion.stats;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.opensearch.be.datafusion.stats.NativeExecutorsStats.OperationType;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.Combinators;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.Provide;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Property-based tests for the stats-endpoint-refactor spec.
+ *
+ * <p>Validates that the flattened JSON serialization preserves all metric values,
+ * CPU runtime conditional presence, and transport round-trip correctness.
+ *
+ * <p>Tag: Feature: stats-endpoint-refactor
+ */
+public class StatsEndpointRefactorPropertyTests {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    /** JSON field names for RuntimeMetrics in documented order (9 fields). */
+    private static final String[] RUNTIME_FIELD_NAMES = {
+        "workers_count",
+        "total_polls_count",
+        "total_busy_duration_ms",
+        "total_overflow_count",
+        "global_queue_depth",
+        "blocking_queue_depth",
+        "num_alive_tasks",
+        "spawned_tasks_count",
+        "total_local_queue_depth" };
+
+    /** JSON field names for TaskMonitorStats in documented order (3 fields). */
+    private static final String[] TASK_FIELD_NAMES = { "total_poll_duration_ms", "total_scheduled_duration_ms", "total_idle_duration_ms" };
+
+    // ---- Object generators ----
+
+    @Provide
+    Arbitrary<RuntimeMetrics> runtimeMetrics() {
+        return Arbitraries.longs()
+            .between(0, Long.MAX_VALUE / 2)
+            .list()
+            .ofSize(9)
+            .map(l -> new RuntimeMetrics(l.get(0), l.get(1), l.get(2), l.get(3), l.get(4), l.get(5), l.get(6), l.get(7), l.get(8)));
+    }
+
+    @Provide
+    Arbitrary<TaskMonitorStats> taskMonitorStats() {
+        Arbitrary<Long> nonNeg = Arbitraries.longs().between(0, Long.MAX_VALUE / 2);
+        return Combinators.combine(nonNeg, nonNeg, nonNeg).as(TaskMonitorStats::new);
+    }
+
+    /** NativeExecutorsStats with CPU runtime present (workersCount > 0). */
+    @Provide
+    Arbitrary<NativeExecutorsStats> nativeExecutorsStatsCpuPresent() {
+        return Combinators.combine(runtimeMetrics(), runtimeMetrics().map(rt -> {
+            if (rt.workersCount == 0) {
+                return new RuntimeMetrics(
+                    1,
+                    rt.totalPollsCount,
+                    rt.totalBusyDurationMs,
+                    rt.totalOverflowCount,
+                    rt.globalQueueDepth,
+                    rt.blockingQueueDepth,
+                    rt.numAliveTasks,
+                    rt.spawnedTasksCount,
+                    rt.totalLocalQueueDepth
+                );
+            }
+            return rt;
+        }), taskMonitorStats(), taskMonitorStats(), taskMonitorStats(), taskMonitorStats()).as((io, cpu, qe, sn, fp, ss) -> {
+            Map<String, TaskMonitorStats> monitors = new LinkedHashMap<>();
+            monitors.put("query_execution", qe);
+            monitors.put("stream_next", sn);
+            monitors.put("fetch_phase", fp);
+            monitors.put("segment_stats", ss);
+            return new NativeExecutorsStats(io, cpu, monitors);
+        });
+    }
+
+    /** NativeExecutorsStats with CPU runtime absent (null). */
+    @Provide
+    Arbitrary<NativeExecutorsStats> nativeExecutorsStatsCpuAbsent() {
+        return Combinators.combine(runtimeMetrics(), taskMonitorStats(), taskMonitorStats(), taskMonitorStats(), taskMonitorStats())
+            .as((io, qe, sn, fp, ss) -> {
+                Map<String, TaskMonitorStats> monitors = new LinkedHashMap<>();
+                monitors.put("query_execution", qe);
+                monitors.put("stream_next", sn);
+                monitors.put("fetch_phase", fp);
+                monitors.put("segment_stats", ss);
+                return new NativeExecutorsStats(io, null, monitors);
+            });
+    }
+
+    /** DataFusionStats with non-null NativeExecutorsStats (CPU present or absent). */
+    @Provide
+    Arbitrary<DataFusionStats> dataFusionStats() {
+        return Arbitraries.oneOf(
+            nativeExecutorsStatsCpuPresent().map(DataFusionStats::new),
+            nativeExecutorsStatsCpuAbsent().map(DataFusionStats::new)
+        );
+    }
+
+    // ---- Property 1: Flat JSON serialization preserves all metric values at top level ----
+
+    /**
+     * Feature: stats-endpoint-refactor, Property 1: Flat JSON serialization preserves all metric values at top level.
+     *
+     * <p>For any valid NativeExecutorsStats, toXContent produces JSON with io_runtime, each task monitor,
+     * and optionally cpu_runtime as direct top-level keys with correct field values, and native_executors
+     * and task_monitors keys are absent.
+     *
+     * <p>Validates: Requirements 2.1, 2.4, 2.5, 3.1, 3.2
+     */
+    @Property(tries = 200)
+    void flatJsonSerializationPreservesAllMetricValues(@ForAll("nativeExecutorsStatsCpuPresent") NativeExecutorsStats nes)
+        throws IOException {
+        String json = renderNativeExecutorsJson(nes);
+        JsonNode root = MAPPER.readTree(json);
+
+        // Verify native_executors and task_monitors wrappers are absent
+        assertFalse(root.has("native_executors"), "native_executors wrapper must be absent");
+        assertFalse(root.has("task_monitors"), "task_monitors wrapper must be absent");
+
+        // Verify io_runtime is a top-level key with all 9 fields
+        JsonNode ioRuntime = root.get("io_runtime");
+        assertNotNull(ioRuntime, "io_runtime must be present at top level");
+        verifyRuntimeFields(nes.getIoRuntime(), ioRuntime);
+
+        // Verify cpu_runtime is a top-level key with all 9 fields (present case)
+        JsonNode cpuRuntime = root.get("cpu_runtime");
+        assertNotNull(cpuRuntime, "cpu_runtime must be present at top level when non-null");
+        verifyRuntimeFields(nes.getCpuRuntime(), cpuRuntime);
+
+        // Verify each task monitor is a top-level key with correct fields
+        for (OperationType opType : OperationType.values()) {
+            JsonNode monitor = root.get(opType.key());
+            assertNotNull(monitor, opType.key() + " must be present at top level");
+            verifyTaskMonitorFields(nes.getTaskMonitors().get(opType.key()), monitor, opType.key());
+        }
+    }
+
+    /**
+     * Feature: stats-endpoint-refactor, Property 1 (CPU absent variant).
+     *
+     * <p>Validates: Requirements 2.1, 2.4, 2.5, 3.1, 3.2
+     */
+    @Property(tries = 200)
+    void flatJsonSerializationPreservesAllMetricValuesCpuAbsent(@ForAll("nativeExecutorsStatsCpuAbsent") NativeExecutorsStats nes)
+        throws IOException {
+        String json = renderNativeExecutorsJson(nes);
+        JsonNode root = MAPPER.readTree(json);
+
+        // Verify native_executors and task_monitors wrappers are absent
+        assertFalse(root.has("native_executors"), "native_executors wrapper must be absent");
+        assertFalse(root.has("task_monitors"), "task_monitors wrapper must be absent");
+
+        // Verify io_runtime is a top-level key with all 9 fields
+        JsonNode ioRuntime = root.get("io_runtime");
+        assertNotNull(ioRuntime, "io_runtime must be present at top level");
+        verifyRuntimeFields(nes.getIoRuntime(), ioRuntime);
+
+        // cpu_runtime absent
+        assertFalse(root.has("cpu_runtime"), "cpu_runtime must be absent when null");
+
+        // Verify each task monitor is a top-level key with correct fields
+        for (OperationType opType : OperationType.values()) {
+            JsonNode monitor = root.get(opType.key());
+            assertNotNull(monitor, opType.key() + " must be present at top level");
+            verifyTaskMonitorFields(nes.getTaskMonitors().get(opType.key()), monitor, opType.key());
+        }
+    }
+
+    // ---- Property 2: CPU runtime conditional presence ----
+
+    /**
+     * Feature: stats-endpoint-refactor, Property 2: CPU runtime conditional presence (present case).
+     *
+     * <p>For any valid NativeExecutorsStats with non-null cpuRuntime, serialized JSON contains
+     * cpu_runtime top-level key with correct values.
+     *
+     * <p>Validates: Requirements 2.2, 2.3
+     */
+    @Property(tries = 200)
+    void cpuRuntimePresentWhenNonNull(@ForAll("nativeExecutorsStatsCpuPresent") NativeExecutorsStats nes) throws IOException {
+        String json = renderNativeExecutorsJson(nes);
+        JsonNode root = MAPPER.readTree(json);
+
+        assertTrue(root.has("cpu_runtime"), "cpu_runtime must be present when cpuRuntime is non-null");
+        JsonNode cpuRuntime = root.get("cpu_runtime");
+        verifyRuntimeFields(nes.getCpuRuntime(), cpuRuntime);
+    }
+
+    /**
+     * Feature: stats-endpoint-refactor, Property 2: CPU runtime conditional presence (absent case).
+     *
+     * <p>For any valid NativeExecutorsStats with null cpuRuntime, serialized JSON does not contain
+     * cpu_runtime key.
+     *
+     * <p>Validates: Requirements 2.2, 2.3
+     */
+    @Property(tries = 200)
+    void cpuRuntimeAbsentWhenNull(@ForAll("nativeExecutorsStatsCpuAbsent") NativeExecutorsStats nes) throws IOException {
+        String json = renderNativeExecutorsJson(nes);
+        JsonNode root = MAPPER.readTree(json);
+
+        assertFalse(root.has("cpu_runtime"), "cpu_runtime must be absent when cpuRuntime is null");
+    }
+
+    // ---- Property 3: Transport serialization round-trip ----
+
+    /**
+     * Feature: stats-endpoint-refactor, Property 3: Transport serialization round-trip.
+     *
+     * <p>For any valid DataFusionStats, writing to StreamOutput and reading back from StreamInput
+     * produces an object equal to the original.
+     *
+     * <p>Validates: Requirements 4.1, 4.2
+     */
+    @Property(tries = 200)
+    void transportSerializationRoundTrip(@ForAll("dataFusionStats") DataFusionStats original) throws IOException {
+        BytesStreamOutput out = new BytesStreamOutput();
+        original.writeTo(out);
+        StreamInput in = out.bytes().streamInput();
+        DataFusionStats deserialized = new DataFusionStats(in);
+        assertEquals(original, deserialized, "Transport round-trip must preserve all fields");
+    }
+
+    // ---- Helper methods ----
+
+    private String renderNativeExecutorsJson(NativeExecutorsStats nes) throws IOException {
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        builder.startObject();
+        nes.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        builder.endObject();
+        return builder.toString();
+    }
+
+    private void verifyRuntimeFields(RuntimeMetrics rm, JsonNode runtimeNode) {
+        long[] expected = {
+            rm.workersCount,
+            rm.totalPollsCount,
+            rm.totalBusyDurationMs,
+            rm.totalOverflowCount,
+            rm.globalQueueDepth,
+            rm.blockingQueueDepth,
+            rm.numAliveTasks,
+            rm.spawnedTasksCount,
+            rm.totalLocalQueueDepth };
+        for (int i = 0; i < RUNTIME_FIELD_NAMES.length; i++) {
+            String fieldName = RUNTIME_FIELD_NAMES[i];
+            assertTrue(runtimeNode.has(fieldName), "Runtime field '" + fieldName + "' must be present");
+            assertEquals(expected[i], runtimeNode.get(fieldName).asLong(), "Runtime field '" + fieldName + "': expected " + expected[i]);
+        }
+    }
+
+    private void verifyTaskMonitorFields(TaskMonitorStats tm, JsonNode monitorNode, String opType) {
+        long[] expected = { tm.totalPollDurationMs, tm.totalScheduledDurationMs, tm.totalIdleDurationMs };
+        for (int i = 0; i < TASK_FIELD_NAMES.length; i++) {
+            String fieldName = TASK_FIELD_NAMES[i];
+            assertTrue(monitorNode.has(fieldName), opType + " field '" + fieldName + "' must be present");
+            assertEquals(expected[i], monitorNode.get(fieldName).asLong(), opType + " field '" + fieldName + "': expected " + expected[i]);
+        }
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/action/DataFusionStatsActionTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/action/DataFusionStatsActionTests.java
@@ -12,8 +12,8 @@ import org.opensearch.be.datafusion.DataFusionPlugin;
 import org.opensearch.be.datafusion.DataFusionService;
 import org.opensearch.be.datafusion.stats.DataFusionStats;
 import org.opensearch.be.datafusion.stats.NativeExecutorsStats;
-import org.opensearch.be.datafusion.stats.NativeExecutorsStats.RuntimeMetrics;
-import org.opensearch.be.datafusion.stats.NativeExecutorsStats.TaskMonitorStats;
+import org.opensearch.be.datafusion.stats.RuntimeMetrics;
+import org.opensearch.be.datafusion.stats.TaskMonitorStats;
 import org.opensearch.common.SuppressForbidden;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.rest.RestHandler;
@@ -67,7 +67,7 @@ public class DataFusionStatsActionTests extends OpenSearchTestCase {
         List<Route> routes = action.routes();
         assertEquals(1, routes.size());
         assertEquals(RestRequest.Method.GET, routes.get(0).getMethod());
-        assertEquals("_plugins/datafusion/stats", routes.get(0).getPath());
+        assertEquals("_plugins/analytics_backend_datafusion/stats", routes.get(0).getPath());
     }
 
     // ---- Test: getName() returns "datafusion_stats_action" (Requirement 1.1) ----
@@ -106,10 +106,11 @@ public class DataFusionStatsActionTests extends OpenSearchTestCase {
         // Verify the response
         assertEquals(200, channel.capturedResponse().status().getStatus());
         String responseBody = channel.capturedResponse().content().utf8ToString();
-        assertTrue("Response should contain native_executors", responseBody.contains("native_executors"));
-        assertTrue("Response should contain io_runtime", responseBody.contains("io_runtime"));
-        assertTrue("Response should contain task_monitors", responseBody.contains("task_monitors"));
-        assertTrue("Response should contain query_execution", responseBody.contains("query_execution"));
+        assertFalse("Response should NOT contain native_executors wrapper", responseBody.contains("native_executors"));
+        assertFalse("Response should NOT contain task_monitors wrapper", responseBody.contains("task_monitors"));
+        assertTrue("Response should contain io_runtime at top level", responseBody.contains("io_runtime"));
+        assertTrue("Response should contain cpu_runtime at top level", responseBody.contains("cpu_runtime"));
+        assertTrue("Response should contain query_execution at top level", responseBody.contains("query_execution"));
     }
 
     // ---- Test: prepareRequest returns 500 when service throws exception (Requirement 6.1) ----

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/nativelib/StatsLayoutTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/nativelib/StatsLayoutTests.java
@@ -8,7 +8,7 @@
 
 package org.opensearch.be.datafusion.nativelib;
 
-import org.opensearch.be.datafusion.stats.NativeExecutorsStats;
+import org.opensearch.be.datafusion.stats.RuntimeMetrics;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.lang.foreign.Arena;
@@ -73,7 +73,7 @@ public class StatsLayoutTests extends OpenSearchTestCase {
             assertEquals(0L, cpuWorkers);
 
             // Simulate the NativeBridge logic
-            NativeExecutorsStats.RuntimeMetrics cpuRuntime = null;
+            RuntimeMetrics cpuRuntime = null;
             if (cpuWorkers > 0) {
                 cpuRuntime = StatsLayout.readRuntimeMetrics(seg, "cpu_runtime");
             }
@@ -95,7 +95,7 @@ public class StatsLayoutTests extends OpenSearchTestCase {
             long cpuWorkers = StatsLayout.readField(seg, "cpu_runtime", "workers_count");
             assertEquals(5L, cpuWorkers);
 
-            NativeExecutorsStats.RuntimeMetrics cpuRuntime = null;
+            RuntimeMetrics cpuRuntime = null;
             if (cpuWorkers > 0) {
                 cpuRuntime = StatsLayout.readRuntimeMetrics(seg, "cpu_runtime");
             }

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/stats/DataFusionStatsTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/stats/DataFusionStatsTests.java
@@ -8,8 +8,6 @@
 
 package org.opensearch.be.datafusion.stats;
 
-import org.opensearch.be.datafusion.stats.NativeExecutorsStats.RuntimeMetrics;
-import org.opensearch.be.datafusion.stats.NativeExecutorsStats.TaskMonitorStats;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
@@ -22,7 +20,7 @@ import java.util.Map;
 /**
  * Unit tests for {@link DataFusionStats} constructed via direct constructors.
  *
- * <p>Layout: IO RuntimeMetrics (8 fields), optional CPU RuntimeMetrics (8 fields),
+ * <p>Layout: IO RuntimeMetrics (9 fields), optional CPU RuntimeMetrics (9 fields),
  * 4 TaskMonitorStats (3 fields each).
  */
 public class DataFusionStatsTests extends OpenSearchTestCase {
@@ -123,7 +121,11 @@ public class DataFusionStatsTests extends OpenSearchTestCase {
         String json = toJsonString(stats);
         assertFalse("cpu_runtime should be omitted when null", json.contains("cpu_runtime"));
         assertTrue("io_runtime should still be present", json.contains("io_runtime"));
-        assertTrue("task_monitors should still be present", json.contains("task_monitors"));
+        // Task monitors are at top level (flat structure, no "task_monitors" wrapper)
+        assertTrue("query_execution should still be present", json.contains("query_execution"));
+        assertTrue("stream_next should still be present", json.contains("stream_next"));
+        assertTrue("fetch_phase should still be present", json.contains("fetch_phase"));
+        assertTrue("segment_stats should still be present", json.contains("segment_stats"));
     }
 
     // ---- Test: non-null CPU runtime → cpuRuntime present in JSON ----
@@ -155,11 +157,13 @@ public class DataFusionStatsTests extends OpenSearchTestCase {
         DataFusionStats stats = sequentialStats();
         String json = toJsonString(stats);
 
-        assertTrue(json.contains("\"native_executors\""));
+        // Flat structure: no "native_executors" or "task_monitors" wrappers
+        assertFalse(json.contains("\"native_executors\""));
         assertTrue(json.contains("\"io_runtime\""));
         assertTrue(json.contains("\"cpu_runtime\""));
-        assertTrue(json.contains("\"task_monitors\""));
+        assertFalse(json.contains("\"task_monitors\""));
 
+        // Task monitors at top level
         assertTrue(json.contains("\"query_execution\""));
         assertTrue(json.contains("\"stream_next\""));
         assertTrue(json.contains("\"fetch_phase\""));
@@ -171,7 +175,7 @@ public class DataFusionStatsTests extends OpenSearchTestCase {
         }
 
         // IO runtime: workers_count = 1
-        assertTrue(json.contains("\"workers_count\":1,"));
+        assertTrue(json.contains("\"workers_count\":1"));
         // query_execution: total_poll_duration_ms = 17
         assertTrue(json.contains("\"total_poll_duration_ms\":17"));
     }
@@ -191,7 +195,9 @@ public class DataFusionStatsTests extends OpenSearchTestCase {
 
         assertTrue(json.contains("\"io_runtime\""));
         assertFalse("cpu_runtime should not appear", json.contains("\"cpu_runtime\""));
-        assertTrue(json.contains("\"task_monitors\""));
+        // Task monitors at top level (no wrapper)
+        assertTrue(json.contains("\"query_execution\""));
+        assertTrue(json.contains("\"segment_stats\""));
     }
 
     // ---- Test: exactly 4 task monitor keys ----


### PR DESCRIPTION
### Description
1. Rename endpoint from `datafusion` to `analytics_backend_datafusion`
2. Simplify inner structure of stats

```
% curl -s 'http://localhost:9200/_plugins/analytics_backend_datafusion/stats?pretty' 
{
    "io_runtime": {
        "workers_count": 16,
        "total_polls_count": 12,
        "total_busy_duration_ms": 4,
        "total_overflow_count": 0,
        "global_queue_depth": 0,
        "blocking_queue_depth": 0,
        "num_alive_tasks": 0,
        "spawned_tasks_count": 6,
        "total_local_queue_depth": 0
    },
    "cpu_runtime": {
        "workers_count": 8,
        "total_polls_count": 1,
        "total_busy_duration_ms": 0,
        "total_overflow_count": 0,
        "global_queue_depth": 0,
        "blocking_queue_depth": 0,
        "num_alive_tasks": 0,
        "spawned_tasks_count": 1,
        "total_local_queue_depth": 0
    },
    "query_execution": {
        "total_poll_duration_ms": 0,
        "total_scheduled_duration_ms": 0,
        "total_idle_duration_ms": 0
    },
    "stream_next": {
        "total_poll_duration_ms": 0,
        "total_scheduled_duration_ms": 0,
        "total_idle_duration_ms": 0
    },
    "fetch_phase": {
        "total_poll_duration_ms": 0,
        "total_scheduled_duration_ms": 0,
        "total_idle_duration_ms": 0
    },
    "segment_stats": {
        "total_poll_duration_ms": 0,
        "total_scheduled_duration_ms": 0,
        "total_idle_duration_ms": 0
    }
}
```

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
