### PR TITLE
deletion handling during merge

### DIFF
--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/LuceneReaderManager.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/LuceneReaderManager.java
@@ -28,11 +28,9 @@ import org.opensearch.index.engine.exec.coord.CatalogSnapshot;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 
 import static org.opensearch.be.lucene.index.LuceneWriter.WRITER_GENERATION_ATTRIBUTE;
 
@@ -131,25 +129,28 @@ public class LuceneReaderManager implements EngineReaderManager<LuceneReader> {
     }
 
     private static Map<Long, String> buildGenerationToSegmentName(CatalogSnapshot catalogSnapshot, List<LeafReaderContext> leaves) {
-        // Index leaves by their file set → segment name
-        Map<Set<String>, String> filesToSegName = new HashMap<>(leaves.size());
+        // Match catalog segments to leaves by writer generation (immutable per-segment),
+        // not by file set. The leaf's .liv files come and go as deletes accumulate — the
+        // writer generation stamped at segment creation never changes.
+        Map<Long, String> genToSegName = new HashMap<>(leaves.size());
         for (int i = 0; i < leaves.size(); i++) {
             SegmentReader sr = (SegmentReader) leaves.get(i).reader();
-            try {
-                filesToSegName.put(new HashSet<>(sr.getSegmentInfo().files()), sr.getSegmentInfo().info.name);
-            } catch (IOException e) {
-                throw new IllegalStateException("Failed to read files for leaf " + i, e);
+            String genAttr = sr.getSegmentInfo().info.getAttribute(WRITER_GENERATION_ATTRIBUTE);
+            if (genAttr == null) {
+                throw new IllegalStateException(
+                    "Lucene leaf " + sr.getSegmentInfo().info.name + " is missing " + WRITER_GENERATION_ATTRIBUTE + " attribute"
+                );
             }
+            genToSegName.put(Long.parseLong(genAttr), sr.getSegmentInfo().info.name);
         }
 
-        // Match catalog segments to leaves via file sets
         Map<Long, String> out = new HashMap<>();
         for (Segment seg : catalogSnapshot.getSegments()) {
             WriterFileSet wfs = seg.dfGroupedSearchableFiles().get(LuceneDataFormat.LUCENE_FORMAT_NAME);
             if (wfs == null) {
                 continue;
             }
-            String segName = filesToSegName.get(wfs.files());
+            String segName = genToSegName.get(seg.generation());
             if (segName == null) {
                 throw new IllegalStateException(
                     "Catalog segment gen=" + seg.generation() + " files=" + wfs.files() + " has no matching Lucene leaf"

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/index/LuceneDeleteExecutionEngine.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/index/LuceneDeleteExecutionEngine.java
@@ -10,7 +10,7 @@ package org.opensearch.be.lucene.index;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.MergeIndexWriter;
 import org.apache.lucene.index.Term;
 import org.opensearch.be.lucene.LuceneDataFormat;
 import org.opensearch.be.lucene.stats.LuceneShardStatsTracker;
@@ -52,7 +52,7 @@ public class LuceneDeleteExecutionEngine implements DeleteExecutionEngine<DataFo
 
     private final Map<Long, Deleter> generationToDeleterMap;
     private final DataFormat dataFormat;
-    private final IndexWriter parentWriter;
+    private final MergeIndexWriter parentWriter;
     private final ConcurrentMap<String, Long> idToGen;
     private final Store store;
 

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/merge/LuceneMergeStrategy.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/merge/LuceneMergeStrategy.java
@@ -9,6 +9,7 @@
 package org.opensearch.be.lucene.merge;
 
 import org.apache.lucene.index.MergePolicy;
+import org.apache.lucene.index.PreparableOneMerge;
 import org.apache.lucene.index.SegmentCommitInfo;
 import org.opensearch.common.annotation.ExperimentalApi;
 import org.opensearch.index.engine.dataformat.MergeInput;
@@ -35,11 +36,17 @@ import java.util.List;
 public interface LuceneMergeStrategy {
 
     /**
-     * Creates the {@link MergePolicy.OneMerge} that controls how segments are merged.
+     * Creates the {@link PreparableOneMerge} that controls how segments are merged.
      *
-     * <p>Primary strategy: returns a plain {@code OneMerge} (no reader wrapping).
+     * <p>Primary strategy: returns a plain {@code PreparableOneMerge} (no reader wrapping).
      * <p>Secondary strategy: returns a {@link RowIdRemappingOneMerge} that wraps readers
      * with {@link RowIdRemappingCodecReader} for row ID remapping.
+     *
+     * <p>Returning a {@link PreparableOneMerge} (rather than a plain {@link MergePolicy.OneMerge})
+     * lets callers feed the OneMerge through the two-phase
+     * {@link org.apache.lucene.index.MergeIndexWriter#prepareMerge prepareMerge} /
+     * {@link org.apache.lucene.index.MergeIndexWriter#executeMerge executeMerge} flow when
+     * cross-format snapshot consistency is required.
      *
      * @param segments the segments to merge
      * @param rowIdMapping the row ID mapping from the primary format, or null if this is the primary
@@ -49,7 +56,7 @@ public interface LuceneMergeStrategy {
      *                               {@code .si} file via {@code setMergeInfo}
      * @return the configured OneMerge for execution
      */
-    MergePolicy.OneMerge createOneMerge(List<SegmentCommitInfo> segments, RowIdMapping rowIdMapping, long outputWriterGeneration);
+    PreparableOneMerge createOneMerge(List<SegmentCommitInfo> segments, RowIdMapping rowIdMapping, long outputWriterGeneration);
 
     /**
      * Builds or resolves the {@link RowIdMapping} after the merge completes.

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/merge/LuceneMerger.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/merge/LuceneMerger.java
@@ -12,13 +12,14 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.MergeIndexWriter;
-import org.apache.lucene.index.MergePolicy;
+import org.apache.lucene.index.PreparableOneMerge;
 import org.apache.lucene.index.SegmentCommitInfo;
 import org.apache.lucene.index.SegmentInfos;
 import org.opensearch.be.lucene.stats.LuceneShardStatsTracker;
 import org.opensearch.common.SuppressForbidden;
 import org.opensearch.common.annotation.ExperimentalApi;
 import org.opensearch.index.engine.dataformat.DataFormat;
+import org.opensearch.index.engine.dataformat.LiveDocs;
 import org.opensearch.index.engine.dataformat.MergeInput;
 import org.opensearch.index.engine.dataformat.MergeResult;
 import org.opensearch.index.engine.dataformat.Merger;
@@ -41,6 +42,9 @@ import static org.opensearch.be.lucene.index.LuceneWriter.WRITER_GENERATION_ATTR
 /**
  * Lucene-specific {@link Merger} that merges segments using Lucene's internal
  * {@code merge(OneMerge)} path with IndexSort-based document reordering.
+ *
+ * <p>Supports the two-phase prepare/execute flow so a primary-format merger can read
+ * Lucene's frozen live-docs snapshot before {@code mergeMiddle} runs.
  *
  * <h2>How it works</h2>
  *
@@ -93,6 +97,43 @@ public class LuceneMerger implements Merger {
         this.stats = stats;
         // TODO implement primary and integrate the same here
         this.strategy = new SecondaryLuceneMergeStrategy();
+    }
+
+    @Override
+    public LiveDocs prepareMerge(MergeInput mergeInput) throws IOException {
+        List<Segment> segments = mergeInput.segments();
+        if (segments.isEmpty()) {
+            return LiveDocs.ALL_ALIVE;
+        }
+        Set<Long> generationsToMerge = new HashSet<>();
+        for (Segment segment : segments) {
+            generationsToMerge.add(segment.generation());
+        }
+
+        SegmentInfos segmentInfos;
+        try {
+            segmentInfos = (SegmentInfos) SEGMENT_INFOS_FIELD.get(indexWriter);
+        } catch (IllegalAccessException e) {
+            throw new IOException("Failed to access IndexWriter segmentInfos via reflection", e);
+        }
+        if (segmentInfos.size() == 0) {
+            return LiveDocs.ALL_ALIVE;
+        }
+        List<SegmentCommitInfo> matchingSegments = findMatchingSegments(segmentInfos, generationsToMerge);
+        if (matchingSegments.isEmpty()) {
+            return LiveDocs.ALL_ALIVE;
+        }
+
+        // Build with null mapping; merge() sets it once the primary has produced it.
+        PreparableOneMerge oneMerge = strategy.createOneMerge(matchingSegments, null, mergeInput.newWriterGeneration());
+        indexWriter.prepareMerge(oneMerge, mergeInput.newWriterGeneration());
+
+        return LiveDocs.fromPackedBits(packLiveDocsFromMergeReaders(oneMerge));
+    }
+
+    @Override
+    public void abortPreparedMerge(MergeInput mergeInput) throws IOException {
+        indexWriter.abortPreparedMerge(mergeInput.newWriterGeneration());
     }
 
     @Override
@@ -158,16 +199,35 @@ public class LuceneMerger implements Merger {
                 generationsToMerge
             );
 
-            // Delegate OneMerge creation to the strategy (primary vs secondary behavior).
-            // For the secondary path, the returned RowIdRemappingOneMerge stamps the
-            // writer_generation attribute onto the merged SegmentInfo via setMergeInfo, which
-            // Lucene invokes immediately before codec.segmentInfoFormat().write(...) — so the
-            // attribute is persisted to the .si file and survives a writer reopen.
-            MergePolicy.OneMerge oneMerge = strategy.createOneMerge(matchingSegments, rowIdMapping, mergeInput.newWriterGeneration());
+            // Prefer the prepared OneMerge from prepareMerge (its snapshot is what the primary's
+            // bitmap was derived from). Fall back to a fresh OneMerge for code paths that did not
+            // go through the two-phase flow (e.g. tests). For the secondary path, the returned
+            // RowIdRemappingOneMerge stamps the writer_generation attribute onto the merged
+            // SegmentInfo via setMergeInfo, which Lucene invokes immediately before
+            // codec.segmentInfoFormat().write(...) — so the attribute is persisted to the .si
+            // file and survives a writer reopen.
+            PreparableOneMerge prepared = indexWriter.takePreparedMerge(mergeInput.newWriterGeneration());
+            PreparableOneMerge oneMerge;
+            if (prepared != null) {
+                if (prepared instanceof RowIdRemappingOneMerge rowIdMerge) {
+                    rowIdMerge.setRowIdMapping(rowIdMapping);
+                }
+                oneMerge = prepared;
+            } else {
+                oneMerge = strategy.createOneMerge(matchingSegments, rowIdMapping, mergeInput.newWriterGeneration());
+            }
             indexWriter.executeMerge(oneMerge, mergeInput.newWriterGeneration());
 
             // Build the merged WriterFileSet from the output segment info
             SegmentCommitInfo mergedInfo = oneMerge.getMergeInfo();
+
+            // If carryOverHardDeletes produced in-memory deletes for the merged segment
+            // (concurrent deletes that arrived during the merge), force the .liv file to be
+            // written now so mergedInfo.files() includes it. Otherwise the catalog records
+            // a file set without .liv, but a later flush writes the .liv onto disk — and
+            // the next refresh fails with "Catalog segment ... has no matching Lucene leaf".
+            indexWriter.flushLiveDocsForMergedSegment(mergedInfo);
+
             WriterFileSet mergedFileSet = buildMergedFileSet(mergedInfo, mergeInput.newWriterGeneration());
 
             // Delegate RowIdMapping production to the strategy
@@ -189,6 +249,19 @@ public class LuceneMerger implements Merger {
         } finally {
             stats.addMergeTimeMillis(TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start));
         }
+    }
+
+    /**
+     * Builds the per-segment live-docs map from a {@link PreparableOneMerge} whose merge
+     * readers have been populated by {@link org.apache.lucene.index.MergeIndexWriter#prepareMerge}.
+     * Reads the frozen {@code hardLiveDocs} via {@link PreparableOneMerge#packLiveDocsByGeneration}
+     * so the bitmap matches the snapshot Lucene's {@code mergeMiddle} will use for physical drops.
+     */
+    private static Map<Long, long[]> packLiveDocsFromMergeReaders(PreparableOneMerge oneMerge) {
+        return oneMerge.packLiveDocsByGeneration(sci -> {
+            String genAttr = sci.info.getAttribute(WRITER_GENERATION_ATTRIBUTE);
+            return genAttr == null ? -1L : Long.parseLong(genAttr);
+        });
     }
 
     /**

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/merge/PrimaryLuceneMergeStrategy.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/merge/PrimaryLuceneMergeStrategy.java
@@ -9,6 +9,7 @@
 package org.opensearch.be.lucene.merge;
 
 import org.apache.lucene.index.MergePolicy;
+import org.apache.lucene.index.PreparableOneMerge;
 import org.apache.lucene.index.SegmentCommitInfo;
 import org.opensearch.common.annotation.ExperimentalApi;
 import org.opensearch.index.engine.dataformat.MergeInput;
@@ -32,7 +33,7 @@ import java.util.List;
 public class PrimaryLuceneMergeStrategy implements LuceneMergeStrategy {
 
     @Override
-    public MergePolicy.OneMerge createOneMerge(List<SegmentCommitInfo> segments, RowIdMapping rowIdMapping, long outputWriterGeneration) {
+    public PreparableOneMerge createOneMerge(List<SegmentCommitInfo> segments, RowIdMapping rowIdMapping, long outputWriterGeneration) {
         throw new UnsupportedOperationException("Primary Lucene merge strategy is not yet implemented");
     }
 

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/merge/RowIdRemappingOneMerge.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/merge/RowIdRemappingOneMerge.java
@@ -9,7 +9,7 @@
 package org.opensearch.be.lucene.merge;
 
 import org.apache.lucene.index.CodecReader;
-import org.apache.lucene.index.MergePolicy;
+import org.apache.lucene.index.PreparableOneMerge;
 import org.apache.lucene.index.SegmentCommitInfo;
 import org.apache.lucene.index.SegmentReader;
 import org.opensearch.common.annotation.ExperimentalApi;
@@ -21,7 +21,7 @@ import java.util.List;
 import static org.opensearch.be.lucene.index.LuceneWriter.WRITER_GENERATION_ATTRIBUTE;
 
 /**
- * A custom {@link MergePolicy.OneMerge} that wraps each segment's {@link CodecReader}
+ * A {@link PreparableOneMerge} that wraps each segment's {@link CodecReader}
  * with a {@link RowIdRemappingCodecReader} during the merge process.
  *
  * <p>The wrapped reader remaps row ID doc values so the merged segment stores
@@ -36,12 +36,15 @@ import static org.opensearch.be.lucene.index.LuceneWriter.WRITER_GENERATION_ATTR
  * merged segment, so the attribute is persisted to the {@code .si} file and survives a
  * writer reopen. No codec, thread-local, or commit-data plumbing is needed.
  *
+ * <p>Inheriting from {@link PreparableOneMerge} makes this OneMerge compatible with the
+ * two-phase prepare/execute flow used to keep cross-format live-docs snapshots consistent.
+ *
  * @opensearch.experimental
  */
 @ExperimentalApi
-class RowIdRemappingOneMerge extends MergePolicy.OneMerge {
+class RowIdRemappingOneMerge extends PreparableOneMerge {
 
-    private final RowIdMapping rowIdMapping;
+    private RowIdMapping rowIdMapping;
     private final long outputWriterGeneration;
     private int nextRowIdOffset;
 
@@ -50,6 +53,15 @@ class RowIdRemappingOneMerge extends MergePolicy.OneMerge {
         this.rowIdMapping = rowIdMapping;
         this.outputWriterGeneration = outputWriterGeneration;
         this.nextRowIdOffset = 0;
+    }
+
+    /**
+     * Sets the row-ID mapping. Used when the OneMerge is constructed before the primary
+     * format's merge runs (so the mapping isn't known yet) and updated once the primary
+     * produces its mapping. Must be called before {@code wrapForMerge} runs.
+     */
+    void setRowIdMapping(RowIdMapping rowIdMapping) {
+        this.rowIdMapping = rowIdMapping;
     }
 
     @Override

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/merge/SecondaryLuceneMergeStrategy.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/merge/SecondaryLuceneMergeStrategy.java
@@ -9,6 +9,7 @@
 package org.opensearch.be.lucene.merge;
 
 import org.apache.lucene.index.MergePolicy;
+import org.apache.lucene.index.PreparableOneMerge;
 import org.apache.lucene.index.SegmentCommitInfo;
 import org.opensearch.common.annotation.ExperimentalApi;
 import org.opensearch.index.engine.dataformat.MergeInput;
@@ -38,7 +39,7 @@ import java.util.List;
 public class SecondaryLuceneMergeStrategy implements LuceneMergeStrategy {
 
     @Override
-    public MergePolicy.OneMerge createOneMerge(List<SegmentCommitInfo> segments, RowIdMapping rowIdMapping, long outputWriterGeneration) {
+    public PreparableOneMerge createOneMerge(List<SegmentCommitInfo> segments, RowIdMapping rowIdMapping, long outputWriterGeneration) {
         return new RowIdRemappingOneMerge(segments, rowIdMapping, outputWriterGeneration);
     }
 

--- a/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/LuceneMergerTests.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/LuceneMergerTests.java
@@ -33,6 +33,7 @@ import org.opensearch.be.lucene.merge.LuceneMerger;
 import org.opensearch.be.lucene.stats.LuceneShardStatsTracker;
 import org.opensearch.common.SuppressForbidden;
 import org.opensearch.index.engine.dataformat.DocumentInput;
+import org.opensearch.index.engine.dataformat.LiveDocs;
 import org.opensearch.index.engine.dataformat.MergeInput;
 import org.opensearch.index.engine.dataformat.MergeResult;
 import org.opensearch.index.engine.dataformat.PackedRowIdMapping;
@@ -328,6 +329,98 @@ public class LuceneMergerTests extends OpenSearchTestCase {
             }
         }
         return null;
+    }
+
+    // ========== prepareMerge / abortPreparedMerge ==========
+
+    /** Empty input returns ALL_ALIVE without taking any state. */
+    public void testPrepareMergeWithEmptySegmentsReturnsAllAlive() throws IOException {
+        LuceneMerger merger = new LuceneMerger(writer, new LuceneDataFormat(), dataPath, new LuceneShardStatsTracker());
+        MergeInput input = MergeInput.builder().segments(List.of()).newWriterGeneration(99L).build();
+
+        LiveDocs result = merger.prepareMerge(input);
+        assertTrue(result.allAlive());
+    }
+
+    /** Calling prepareMerge twice for the same generation trips the double-prepare assertion. */
+    public void testPrepareMergeFailsAssertionOnDoublePrepare() throws IOException {
+        assumeTrue("requires assertions enabled", LuceneMergerTests.class.desiredAssertionStatus());
+        writeSegment(writer, 1L, 0, 3);
+        writeSegment(writer, 2L, 3, 2);
+        writer.commit();
+
+        LuceneMerger merger = new LuceneMerger(writer, new LuceneDataFormat(), dataPath, new LuceneShardStatsTracker());
+        List<Segment> segments = buildSegments(getSegmentInfos(writer));
+
+        long gen = 99L;
+        MergeInput input = MergeInput.builder().segments(segments).newWriterGeneration(gen).build();
+        merger.prepareMerge(input);
+
+        AssertionError err = expectThrows(AssertionError.class, () -> merger.prepareMerge(input));
+        assertTrue(err.getMessage(), err.getMessage().contains("already has a prepared merge"));
+
+        // Release prepared state before tearDown closes the writer.
+        writer.abortPreparedMerge(gen);
+    }
+
+    /** abortPreparedMerge releases the prepared state and is idempotent. */
+    public void testAbortPreparedMergeReleasesState() throws IOException {
+        writeSegment(writer, 1L, 0, 3);
+        writeSegment(writer, 2L, 3, 2);
+        writer.commit();
+
+        LuceneMerger merger = new LuceneMerger(writer, new LuceneDataFormat(), dataPath, new LuceneShardStatsTracker());
+        List<Segment> segments = buildSegments(getSegmentInfos(writer));
+
+        long gen = 99L;
+        MergeInput input = MergeInput.builder().segments(segments).newWriterGeneration(gen).build();
+        merger.prepareMerge(input);
+
+        merger.abortPreparedMerge(input);
+        assertNull("entry must be drained from preparedMerges", writer.takePreparedMerge(gen));
+
+        // idempotent
+        merger.abortPreparedMerge(input);
+    }
+
+    /** merge() consumes the OneMerge prepared by prepareMerge — no fresh OneMerge is created. */
+    public void testMergeConsumesPreparedOneMerge() throws IOException {
+        writeSegment(writer, 1L, 0, 3);
+        writeSegment(writer, 2L, 3, 2);
+        writer.commit();
+
+        LuceneMerger merger = new LuceneMerger(writer, new LuceneDataFormat(), dataPath, new LuceneShardStatsTracker());
+        List<Segment> segments = buildSegments(getSegmentInfos(writer));
+
+        long gen = 99L;
+        merger.prepareMerge(MergeInput.builder().segments(segments).newWriterGeneration(gen).build());
+
+        RowIdMapping identity = new RowIdMapping() {
+            @Override
+            public long getNewRowId(long oldId, long oldGeneration) {
+                return oldId;
+            }
+
+            @Override
+            public long getOldRowId(long newId) {
+                return newId;
+            }
+
+            @Override
+            public boolean isNewToOldSupported() {
+                return true;
+            }
+
+            @Override
+            public int size() {
+                return 0;
+            }
+        };
+        MergeInput mergeInput = MergeInput.builder().segments(segments).rowIdMapping(identity).newWriterGeneration(gen).build();
+        MergeResult result = merger.merge(mergeInput);
+
+        assertFalse(result.getMergedWriterFileSet().isEmpty());
+        assertNull("prepared state must be consumed by merge()", writer.takePreparedMerge(gen));
     }
 
     // ========== Helper Methods ==========

--- a/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/LuceneMergerTests.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/LuceneMergerTests.java
@@ -383,6 +383,35 @@ public class LuceneMergerTests extends OpenSearchTestCase {
         merger.abortPreparedMerge(input);
     }
 
+    /** prepareMerge surfaces per-generation live-docs bitmaps reflecting applied deletes. */
+    public void testPrepareMergeReturnsLiveDocsForDeletedRows() throws IOException {
+        writeSegment(writer, 1L, 0, 3); // docs doc_0..doc_2
+        writeSegment(writer, 2L, 3, 2); // docs doc_3..doc_4, no deletes
+        writer.deleteDocuments(new org.apache.lucene.index.Term("id", "doc_1"));
+        writer.commit(); // applies the delete: doc 1 of gen=1 is dead
+
+        LuceneMerger merger = new LuceneMerger(writer, new LuceneDataFormat(), dataPath, new LuceneShardStatsTracker());
+        List<Segment> segments = buildSegments(getSegmentInfos(writer));
+
+        long gen = 99L;
+        MergeInput input = MergeInput.builder().segments(segments).newWriterGeneration(gen).build();
+        LiveDocs liveDocs = merger.prepareMerge(input);
+        try {
+            assertFalse("segment gen=1 has a delete", liveDocs.allAlive());
+            assertEquals(1, liveDocs.segmentsWithDeletes());
+
+            assertFalse(liveDocs.allAlive(1L));
+            assertTrue(liveDocs.isAlive(1L, 0));
+            assertFalse("deleted doc must be flagged dead", liveDocs.isAlive(1L, 1));
+            assertTrue(liveDocs.isAlive(1L, 2));
+
+            assertTrue("gen=2 has no deletes", liveDocs.allAlive(2L));
+            assertNull(liveDocs.packedBits(2L));
+        } finally {
+            writer.abortPreparedMerge(gen);
+        }
+    }
+
     /** merge() consumes the OneMerge prepared by prepareMerge — no fresh OneMerge is created. */
     public void testMergeConsumesPreparedOneMerge() throws IOException {
         writeSegment(writer, 1L, 0, 3);

--- a/sandbox/plugins/composite-engine/src/main/java/org/opensearch/composite/merge/CompositeMergeExecutor.java
+++ b/sandbox/plugins/composite-engine/src/main/java/org/opensearch/composite/merge/CompositeMergeExecutor.java
@@ -41,6 +41,13 @@ public class CompositeMergeExecutor {
     }
 
     /**
+     * Returns the merger registered for the given data format, or {@code null} if absent.
+     */
+    public Merger getMerger(DataFormat format) {
+        return mergers.get(format);
+    }
+
+    /**
      * Executes the merge described by the plan.
      *
      * @param plan the pre-validated merge plan
@@ -105,7 +112,14 @@ public class CompositeMergeExecutor {
         for (WriterFileSet wfs : files) {
             segments.add(Segment.builder(wfs.writerGeneration()).addSearchableFiles(format, wfs).build());
         }
-        MergeResult result = merger.merge(new MergeInput(segments, mapping, plan.mergedWriterGeneration()));
+        MergeResult result = merger.merge(
+            MergeInput.builder()
+                .segments(segments)
+                .rowIdMapping(mapping)
+                .newWriterGeneration(plan.mergedWriterGeneration())
+                .liveDocs(plan.liveDocs())
+                .build()
+        );
         return new FormatMergeResult(format, result.getMergedWriterFileSetForDataformat(format), result.rowIdMapping().orElse(null));
     }
 

--- a/sandbox/plugins/composite-engine/src/main/java/org/opensearch/composite/merge/CompositeMerger.java
+++ b/sandbox/plugins/composite-engine/src/main/java/org/opensearch/composite/merge/CompositeMerger.java
@@ -14,6 +14,7 @@ import org.opensearch.composite.CompositeIndexingExecutionEngine;
 import org.opensearch.composite.stats.CompositeShardStatsTracker;
 import org.opensearch.index.engine.dataformat.DataFormat;
 import org.opensearch.index.engine.dataformat.IndexingExecutionEngine;
+import org.opensearch.index.engine.dataformat.LiveDocs;
 import org.opensearch.index.engine.dataformat.MergeInput;
 import org.opensearch.index.engine.dataformat.MergeResult;
 import org.opensearch.index.engine.dataformat.Merger;
@@ -51,14 +52,99 @@ public class CompositeMerger implements Merger {
         this.statsTracker = engine.statsTracker();
     }
 
+    /**
+     * Two-phase merge: phase 1 freezes each secondary's snapshot via {@link #prepareMerge};
+     * phase 2 runs primary → secondaries with that frozen bitmap. On failure between phases,
+     * {@link #abortPreparedMerge} releases prepared state. The bitmap from prepareMerge
+     * overrides any {@link MergeInput#liveDocs()} the caller passed in.
+     */
     @Override
     public MergeResult merge(MergeInput mergeInput) throws IOException {
         // recordOutcome: time always, merge_total on success, merge_failures on throw.
         return StatsRecorder.recordOutcome(() -> {
-            Map<DataFormat, List<WriterFileSet>> filesByFormat = extractFilesByFormat(mergeInput.segments());
-            MergePlan plan = new MergePlan(mergeInput.newWriterGeneration(), primaryFormat, secondaryFormats, filesByFormat);
-            return executor.execute(plan);
+            LiveDocs frozenLiveDocs = prepareMerge(mergeInput);
+            assert frozenLiveDocs != null : "merger returned null live-docs";
+            assert assertLiveDocsShape(mergeInput.segments(), frozenLiveDocs) : "live-docs shape doesn't match segment row counts";
+
+            try {
+                Map<DataFormat, List<WriterFileSet>> filesByFormat = extractFilesByFormat(mergeInput.segments());
+                MergePlan plan = new MergePlan(
+                    mergeInput.newWriterGeneration(),
+                    primaryFormat,
+                    secondaryFormats,
+                    filesByFormat,
+                    frozenLiveDocs
+                );
+                return executor.execute(plan);
+            } catch (Throwable t) {
+                try {
+                    abortPreparedMerge(mergeInput);
+                } catch (Throwable suppress) {
+                    t.addSuppressed(suppress);
+                }
+                throw t;
+            }
         }, statsTracker::addMergeTimeMillis, statsTracker::incMergeTotal, statsTracker::incMergeFailures);
+    }
+
+    /** Verifies the bitmap has at least as many bits as the segment's row count. */
+    private static boolean assertLiveDocsShape(List<Segment> segments, LiveDocs liveDocs) {
+        for (Segment seg : segments) {
+            long[] bits = liveDocs.packedBits(seg.generation());
+            if (bits == null) {
+                continue;
+            }
+            long capacity = (long) bits.length * 64L;
+            long expected = totalRowsForSegment(seg);
+            assert capacity >= expected : "live-docs bitmap for gen="
+                + seg.generation()
+                + " has "
+                + capacity
+                + " bits but segment has "
+                + expected
+                + " rows";
+        }
+        return true;
+    }
+
+    private static long totalRowsForSegment(Segment seg) {
+        long total = 0L;
+        for (var wfs : seg.dfGroupedSearchableFiles().values()) {
+            total = Math.max(total, wfs.numRows());
+        }
+        return total;
+    }
+
+    @Override
+    public LiveDocs prepareMerge(MergeInput mergeInput) throws IOException {
+        // Drive prepare on every secondary so each freezes its own state. Today returns
+        // the first non-empty bitmap;
+        LiveDocs firstNonEmpty = LiveDocs.ALL_ALIVE;
+        for (DataFormat secondary : secondaryFormats) {
+            Merger merger = executor.getMerger(secondary);
+            if (merger == null) continue;
+            LiveDocs partial = merger.prepareMerge(mergeInput);
+            if (partial != null && partial.allAlive() == false && firstNonEmpty.allAlive()) {
+                firstNonEmpty = partial;
+            }
+        }
+        return firstNonEmpty;
+    }
+
+    @Override
+    public void abortPreparedMerge(MergeInput mergeInput) throws IOException {
+        IOException firstFailure = null;
+        for (DataFormat secondary : secondaryFormats) {
+            Merger merger = executor.getMerger(secondary);
+            if (merger == null) continue;
+            try {
+                merger.abortPreparedMerge(mergeInput);
+            } catch (IOException e) {
+                if (firstFailure == null) firstFailure = e;
+                else firstFailure.addSuppressed(e);
+            }
+        }
+        if (firstFailure != null) throw firstFailure;
     }
 
     private Map<DataFormat, List<WriterFileSet>> extractFilesByFormat(List<Segment> segments) {

--- a/sandbox/plugins/composite-engine/src/main/java/org/opensearch/composite/merge/MergePlan.java
+++ b/sandbox/plugins/composite-engine/src/main/java/org/opensearch/composite/merge/MergePlan.java
@@ -10,6 +10,7 @@ package org.opensearch.composite.merge;
 
 import org.opensearch.common.annotation.ExperimentalApi;
 import org.opensearch.index.engine.dataformat.DataFormat;
+import org.opensearch.index.engine.dataformat.LiveDocs;
 import org.opensearch.index.engine.dataformat.merge.OneMerge;
 import org.opensearch.index.engine.exec.Segment;
 import org.opensearch.index.engine.exec.WriterFileSet;
@@ -30,7 +31,7 @@ import java.util.Set;
 @ExperimentalApi
 public record MergePlan(long mergedWriterGeneration, DataFormat primaryFormat, List<DataFormat> secondaryFormats, Map<
     DataFormat,
-    List<WriterFileSet>> filesByFormat) {
+    List<WriterFileSet>> filesByFormat, LiveDocs liveDocs) {
 
     public MergePlan {
         secondaryFormats = List.copyOf(secondaryFormats);
@@ -48,9 +49,16 @@ public record MergePlan(long mergedWriterGeneration, DataFormat primaryFormat, L
     }
 
     /**
-     * Builds a plan from a merge operation, a primary format, secondary formats, and a generation.
+     * Builds a plan from a merge operation, a primary format, secondary formats, a generation,
+     * and live-docs.
      */
-    public static MergePlan from(OneMerge oneMerge, DataFormat primaryFormat, List<DataFormat> secondaryFormats, long generation) {
+    public static MergePlan from(
+        OneMerge oneMerge,
+        DataFormat primaryFormat,
+        List<DataFormat> secondaryFormats,
+        long generation,
+        LiveDocs liveDocs
+    ) {
         Set<DataFormat> allFormats = new LinkedHashSet<>();
         allFormats.add(primaryFormat);
         allFormats.addAll(secondaryFormats);
@@ -66,6 +74,6 @@ public record MergePlan(long mergedWriterGeneration, DataFormat primaryFormat, L
             }
             filesByFormat.put(format, List.copyOf(files));
         }
-        return new MergePlan(generation, primaryFormat, secondaryFormats, filesByFormat);
+        return new MergePlan(generation, primaryFormat, secondaryFormats, filesByFormat, liveDocs);
     }
 }

--- a/sandbox/plugins/composite-engine/src/test/java/org/opensearch/composite/merge/CompositeMergerTests.java
+++ b/sandbox/plugins/composite-engine/src/test/java/org/opensearch/composite/merge/CompositeMergerTests.java
@@ -21,6 +21,7 @@ import org.opensearch.index.IndexSettings;
 import org.opensearch.index.engine.dataformat.DataFormat;
 import org.opensearch.index.engine.dataformat.FieldTypeCapabilities;
 import org.opensearch.index.engine.dataformat.IndexingExecutionEngine;
+import org.opensearch.index.engine.dataformat.LiveDocs;
 import org.opensearch.index.engine.dataformat.MergeInput;
 import org.opensearch.index.engine.dataformat.MergeResult;
 import org.opensearch.index.engine.dataformat.Merger;
@@ -668,7 +669,7 @@ public class CompositeMergerTests extends OpenSearchTestCase {
         WriterFileSet inputP = new WriterFileSet(createTempDir().toString(), 1L, Set.of("in.parquet"), 50, 1L);
         WriterFileSet inputS = new WriterFileSet(createTempDir().toString(), 1L, Set.of("in.si"), 50, 1L);
 
-        MergePlan plan = new MergePlan(10L, primary, List.of(secondary), Map.of(primary, List.of(inputP), secondary, List.of(inputS)));
+        MergePlan plan = new MergePlan(10L, primary, List.of(secondary), Map.of(primary, List.of(inputP), secondary, List.of(inputS)), LiveDocs.ALL_ALIVE);
 
         IllegalStateException ex = expectThrows(IllegalStateException.class, () -> executor.execute(plan));
         assertTrue(ex.getMessage().contains("returned null"));
@@ -695,7 +696,7 @@ public class CompositeMergerTests extends OpenSearchTestCase {
         WriterFileSet inputP = new WriterFileSet(createTempDir().toString(), 1L, Set.of("in.parquet"), 50, 1L);
         WriterFileSet inputS = new WriterFileSet(createTempDir().toString(), 1L, Set.of("in.si"), 50, 1L);
 
-        MergePlan plan = new MergePlan(10L, primary, List.of(secondary), Map.of(primary, List.of(inputP), secondary, List.of(inputS)));
+        MergePlan plan = new MergePlan(10L, primary, List.of(secondary), Map.of(primary, List.of(inputP), secondary, List.of(inputS)), LiveDocs.ALL_ALIVE);
 
         IllegalStateException ex = expectThrows(IllegalStateException.class, () -> executor.execute(plan));
         assertTrue(ex.getMessage().contains("Row count mismatch"));

--- a/sandbox/plugins/composite-engine/src/test/java/org/opensearch/composite/merge/CompositeMergerTests.java
+++ b/sandbox/plugins/composite-engine/src/test/java/org/opensearch/composite/merge/CompositeMergerTests.java
@@ -46,9 +46,13 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
 
+import org.mockito.ArgumentCaptor;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -646,6 +650,236 @@ public class CompositeMergerTests extends OpenSearchTestCase {
         return snapshot;
     }
 
+    // ── Two-phase merge: prepareMerge / abortPreparedMerge / live-docs propagation ──
+
+    /** Returns a CompositeMerger built from the default primary+secondary test engines. */
+    private CompositeMerger createCompositeMerger() {
+        return new CompositeMerger(compositeEngine, compositeDataFormat);
+    }
+
+    private MergeInput mergeInputFor(Segment... segments) {
+        return MergeInput.builder().segments(List.of(segments)).newWriterGeneration(99L).build();
+    }
+
+    private Segment defaultSegment(Path tempDir, long generation, long numRows) {
+        WriterFileSet pWfs = wfs(tempDir, generation, Set.of("p" + generation + ".dat"), numRows);
+        WriterFileSet sWfs = wfs(tempDir, generation, Set.of("s" + generation + ".dat"), numRows);
+        return buildSegment(generation, primaryFormat, pWfs, secondaryFormat, sWfs);
+    }
+
+    /** prepareMerge with no secondaries reporting deletes returns ALL_ALIVE. */
+    public void testPrepareMergeReturnsAllAliveWhenSecondariesHaveNoDeletes() throws IOException {
+        when(secondaryMerger.prepareMerge(any())).thenReturn(LiveDocs.ALL_ALIVE);
+
+        CompositeMerger merger = createCompositeMerger();
+        LiveDocs result = merger.prepareMerge(mergeInputFor(defaultSegment(createTempDir(), 1L, 5)));
+
+        assertTrue(result.allAlive());
+        verify(secondaryMerger, times(1)).prepareMerge(any());
+        // The primary must never be asked to prepare — only secondaries freeze state.
+        verify(primaryMerger, never()).prepareMerge(any());
+    }
+
+    /** prepareMerge tolerates a secondary returning null (treated as all-alive). */
+    public void testPrepareMergeToleratesNullFromSecondary() throws IOException {
+        when(secondaryMerger.prepareMerge(any())).thenReturn(null);
+
+        CompositeMerger merger = createCompositeMerger();
+        LiveDocs result = merger.prepareMerge(mergeInputFor(defaultSegment(createTempDir(), 1L, 5)));
+
+        assertTrue(result.allAlive());
+    }
+
+    /** prepareMerge surfaces the first non-empty bitmap produced by a secondary. */
+    public void testPrepareMergeReturnsSecondaryBitmap() throws IOException {
+        LiveDocs frozen = LiveDocs.fromPackedBits(Map.of(1L, new long[] { 0b101L }));
+        when(secondaryMerger.prepareMerge(any())).thenReturn(frozen);
+
+        CompositeMerger merger = createCompositeMerger();
+        LiveDocs result = merger.prepareMerge(mergeInputFor(defaultSegment(createTempDir(), 1L, 3)));
+
+        assertSame(frozen, result);
+    }
+
+    /** merge() forwards the frozen bitmap from the secondary's prepareMerge to every format's MergeInput. */
+    public void testMergePropagatesFrozenLiveDocsToAllFormats() throws IOException {
+        Path tempDir = createTempDir();
+        Segment segment = defaultSegment(tempDir, 1L, 3);
+
+        LiveDocs frozen = LiveDocs.fromPackedBits(Map.of(1L, new long[] { 0b101L }));
+        when(secondaryMerger.prepareMerge(any())).thenReturn(frozen);
+
+        WriterFileSet mergedP = wfs(tempDir, 99L, Set.of("mp.dat"), 2);
+        WriterFileSet mergedS = wfs(tempDir, 99L, Set.of("ms.dat"), 2);
+        when(primaryMerger.merge(any())).thenReturn(new MergeResult(Map.of(primaryFormat, mergedP), STUB_ROW_ID_MAPPING));
+        when(secondaryMerger.merge(any())).thenReturn(new MergeResult(Map.of(secondaryFormat, mergedS)));
+
+        CompositeMerger merger = createCompositeMerger();
+        MergeResult result = merger.merge(mergeInputFor(segment));
+        assertNotNull(result);
+
+        ArgumentCaptor<MergeInput> primaryCaptor = ArgumentCaptor.forClass(MergeInput.class);
+        verify(primaryMerger).merge(primaryCaptor.capture());
+        assertSame("primary must merge with the frozen bitmap", frozen, primaryCaptor.getValue().liveDocs());
+        assertArrayEquals(new long[] { 0b101L }, primaryCaptor.getValue().getLiveDocsForSegment(1L));
+
+        ArgumentCaptor<MergeInput> secondaryCaptor = ArgumentCaptor.forClass(MergeInput.class);
+        verify(secondaryMerger).merge(secondaryCaptor.capture());
+        assertSame("secondary must merge with the same frozen bitmap", frozen, secondaryCaptor.getValue().liveDocs());
+    }
+
+    /** merge() uses ALL_ALIVE for all formats when no secondary reports deletes. */
+    public void testMergeUsesAllAliveWhenNothingFrozen() throws IOException {
+        Path tempDir = createTempDir();
+        Segment segment = defaultSegment(tempDir, 1L, 3);
+
+        when(secondaryMerger.prepareMerge(any())).thenReturn(LiveDocs.ALL_ALIVE);
+        WriterFileSet mergedP = wfs(tempDir, 99L, Set.of("mp.dat"), 3);
+        WriterFileSet mergedS = wfs(tempDir, 99L, Set.of("ms.dat"), 3);
+        when(primaryMerger.merge(any())).thenReturn(new MergeResult(Map.of(primaryFormat, mergedP), STUB_ROW_ID_MAPPING));
+        when(secondaryMerger.merge(any())).thenReturn(new MergeResult(Map.of(secondaryFormat, mergedS)));
+
+        CompositeMerger merger = createCompositeMerger();
+        merger.merge(mergeInputFor(segment));
+
+        ArgumentCaptor<MergeInput> captor = ArgumentCaptor.forClass(MergeInput.class);
+        verify(primaryMerger).merge(captor.capture());
+        assertTrue(captor.getValue().liveDocs().allAlive());
+    }
+
+    /** When the primary merge fails after prepare, the secondary's prepared state is aborted. */
+    public void testMergeAbortsPreparedStateOnPrimaryFailure() throws IOException {
+        Path tempDir = createTempDir();
+        Segment segment = defaultSegment(tempDir, 1L, 3);
+
+        LiveDocs frozen = LiveDocs.fromPackedBits(Map.of(1L, new long[] { 0b1L }));
+        when(secondaryMerger.prepareMerge(any())).thenReturn(frozen);
+        when(primaryMerger.merge(any())).thenThrow(new IOException("primary exploded"));
+
+        CompositeMerger merger = createCompositeMerger();
+        Exception ex = expectThrows(Exception.class, () -> merger.merge(mergeInputFor(segment)));
+        assertTrue(ex.getMessage().contains("primary exploded") || ex.getCause().getMessage().contains("primary exploded"));
+
+        verify(secondaryMerger, times(1)).abortPreparedMerge(any());
+        verify(secondaryMerger, never()).merge(any());
+    }
+
+    /** A failing abort is suppressed onto the original merge failure, not thrown in its place. */
+    public void testMergeSuppressesAbortFailureOntoOriginalError() throws IOException {
+        Path tempDir = createTempDir();
+        Segment segment = defaultSegment(tempDir, 1L, 3);
+
+        when(secondaryMerger.prepareMerge(any())).thenReturn(LiveDocs.fromPackedBits(Map.of(1L, new long[] { 0b1L })));
+        when(primaryMerger.merge(any())).thenThrow(new IOException("original failure"));
+        doThrow(new IOException("abort failure")).when(secondaryMerger).abortPreparedMerge(any());
+
+        CompositeMerger merger = createCompositeMerger();
+        Exception ex = expectThrows(Exception.class, () -> merger.merge(mergeInputFor(segment)));
+
+        // The executor wraps the primary IOException in an UncheckedIOException; the abort
+        // failure is suppressed onto whatever throwable escaped the execute phase.
+        Throwable root = ex instanceof java.io.UncheckedIOException && ex.getCause() != null ? ex.getCause() : ex;
+        assertTrue("original failure must win", root.getMessage().contains("original failure"));
+        assertTrue(
+            "abort failure must be suppressed onto the original",
+            containsSuppressed(ex, "abort failure") || containsSuppressed(root, "abort failure")
+        );
+    }
+
+    private static boolean containsSuppressed(Throwable t, String message) {
+        for (Throwable suppressed : t.getSuppressed()) {
+            if (suppressed.getMessage() != null && suppressed.getMessage().contains(message)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /** abortPreparedMerge fans out to every secondary and aggregates IOExceptions. */
+    public void testAbortPreparedMergeAggregatesSecondaryFailures() throws IOException {
+        DataFormat secondaryFormat2 = stubFormat("arrow");
+        Merger secondaryMerger2 = mock(Merger.class);
+
+        CompositeIndexingExecutionEngine multiEngine = mock(CompositeIndexingExecutionEngine.class);
+        when(multiEngine.statsTracker()).thenReturn(new CompositeShardStatsTracker());
+        doReturn(mockEngine(primaryFormat, primaryMerger)).when(multiEngine).getPrimaryDelegate();
+        doReturn(Set.of(mockEngine(secondaryFormat, secondaryMerger), mockEngine(secondaryFormat2, secondaryMerger2))).when(multiEngine)
+            .getSecondaryDelegates();
+
+        CompositeDataFormat multiFormat = new CompositeDataFormat(primaryFormat, List.of(primaryFormat, secondaryFormat, secondaryFormat2));
+        CompositeMerger merger = new CompositeMerger(multiEngine, multiFormat);
+
+        doThrow(new IOException("first abort failed")).when(secondaryMerger).abortPreparedMerge(any());
+        doThrow(new IOException("second abort failed")).when(secondaryMerger2).abortPreparedMerge(any());
+
+        MergeInput input = mergeInputFor(defaultSegment(createTempDir(), 1L, 3));
+        IOException ex = expectThrows(IOException.class, () -> merger.abortPreparedMerge(input));
+
+        // Both secondaries were attempted; one failure primary, the other suppressed.
+        verify(secondaryMerger, times(1)).abortPreparedMerge(any());
+        verify(secondaryMerger2, times(1)).abortPreparedMerge(any());
+        assertEquals(1, ex.getSuppressed().length);
+    }
+
+    /** The live-docs shape assertion trips when the bitmap is too small for the segment's rows. */
+    public void testMergeAssertsOnUndersizedLiveDocsBitmap() throws IOException {
+        assumeTrue("requires assertions enabled", CompositeMergerTests.class.desiredAssertionStatus());
+        Path tempDir = createTempDir();
+        // Segment claims 100 rows but the frozen bitmap covers only 64 bits (one word).
+        Segment segment = defaultSegment(tempDir, 1L, 100);
+        when(secondaryMerger.prepareMerge(any())).thenReturn(LiveDocs.fromPackedBits(Map.of(1L, new long[] { 0b1L })));
+
+        CompositeMerger merger = createCompositeMerger();
+        AssertionError err = expectThrows(AssertionError.class, () -> merger.merge(mergeInputFor(segment)));
+        assertTrue(err.getMessage(), err.getMessage().contains("live-docs"));
+    }
+
+    // ── CompositeMergeExecutor.getMerger ──
+
+    public void testExecutorGetMergerReturnsRegisteredMerger() {
+        CompositeMergeExecutor executor = new CompositeMergeExecutor(
+            Map.of(primaryFormat, primaryMerger, secondaryFormat, secondaryMerger)
+        );
+        assertSame(primaryMerger, executor.getMerger(primaryFormat));
+        assertSame(secondaryMerger, executor.getMerger(secondaryFormat));
+        assertNull(executor.getMerger(stubFormat("unknown")));
+    }
+
+    /** The executor threads the plan's liveDocs into the MergeInput of every format it merges. */
+    public void testExecutorPassesPlanLiveDocsIntoMergeInput() throws IOException {
+        Path tempDir = createTempDir();
+        LiveDocs liveDocs = LiveDocs.fromPackedBits(Map.of(1L, new long[] { 0b11L }));
+
+        WriterFileSet inputP = wfs(tempDir, 1L, Set.of("in.parquet"), 2);
+        WriterFileSet mergedP = wfs(tempDir, 10L, Set.of("out.parquet"), 2);
+        when(primaryMerger.merge(any())).thenReturn(new MergeResult(Map.of(primaryFormat, mergedP), STUB_ROW_ID_MAPPING));
+
+        CompositeMergeExecutor executor = new CompositeMergeExecutor(Map.of(primaryFormat, primaryMerger));
+        MergePlan plan = new MergePlan(10L, primaryFormat, List.of(), Map.of(primaryFormat, List.of(inputP)), liveDocs);
+        executor.execute(plan);
+
+        ArgumentCaptor<MergeInput> captor = ArgumentCaptor.forClass(MergeInput.class);
+        verify(primaryMerger).merge(captor.capture());
+        assertSame(liveDocs, captor.getValue().liveDocs());
+    }
+
+    // ── MergePlan liveDocs propagation ──
+
+    public void testMergePlanFromCarriesLiveDocs() {
+        Path tempDir = createTempDir();
+        LiveDocs liveDocs = LiveDocs.fromPackedBits(Map.of(1L, new long[] { 0b1L }));
+        Segment segment = defaultSegment(tempDir, 1L, 3);
+        OneMerge oneMerge = new OneMerge(List.of(segment));
+
+        MergePlan plan = MergePlan.from(oneMerge, primaryFormat, List.of(secondaryFormat), 10L, liveDocs);
+
+        assertSame(liveDocs, plan.liveDocs());
+        assertEquals(10L, plan.mergedWriterGeneration());
+        assertEquals(1, plan.filesFor(primaryFormat).size());
+        assertEquals(1, plan.filesFor(secondaryFormat).size());
+        assertTrue(plan.hasSecondaries());
+    }
+
     // ── Cross-format merge verification tests ──
 
     public void testExecutorThrowsWhenSecondaryReturnsNullButPrimaryHasOutput() throws IOException {
@@ -669,7 +903,13 @@ public class CompositeMergerTests extends OpenSearchTestCase {
         WriterFileSet inputP = new WriterFileSet(createTempDir().toString(), 1L, Set.of("in.parquet"), 50, 1L);
         WriterFileSet inputS = new WriterFileSet(createTempDir().toString(), 1L, Set.of("in.si"), 50, 1L);
 
-        MergePlan plan = new MergePlan(10L, primary, List.of(secondary), Map.of(primary, List.of(inputP), secondary, List.of(inputS)), LiveDocs.ALL_ALIVE);
+        MergePlan plan = new MergePlan(
+            10L,
+            primary,
+            List.of(secondary),
+            Map.of(primary, List.of(inputP), secondary, List.of(inputS)),
+            LiveDocs.ALL_ALIVE
+        );
 
         IllegalStateException ex = expectThrows(IllegalStateException.class, () -> executor.execute(plan));
         assertTrue(ex.getMessage().contains("returned null"));
@@ -696,7 +936,13 @@ public class CompositeMergerTests extends OpenSearchTestCase {
         WriterFileSet inputP = new WriterFileSet(createTempDir().toString(), 1L, Set.of("in.parquet"), 50, 1L);
         WriterFileSet inputS = new WriterFileSet(createTempDir().toString(), 1L, Set.of("in.si"), 50, 1L);
 
-        MergePlan plan = new MergePlan(10L, primary, List.of(secondary), Map.of(primary, List.of(inputP), secondary, List.of(inputS)), LiveDocs.ALL_ALIVE);
+        MergePlan plan = new MergePlan(
+            10L,
+            primary,
+            List.of(secondary),
+            Map.of(primary, List.of(inputP), secondary, List.of(inputS)),
+            LiveDocs.ALL_ALIVE
+        );
 
         IllegalStateException ex = expectThrows(IllegalStateException.class, () -> executor.execute(plan));
         assertTrue(ex.getMessage().contains("Row count mismatch"));

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/bridge/RustBridge.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/bridge/RustBridge.java
@@ -228,7 +228,10 @@ public class RustBridge {
                 ValueLayout.ADDRESS,    // out_gen_count
                 ValueLayout.ADDRESS,    // out_flush_and_sort_chunk_count
                 ValueLayout.ADDRESS,    // out_flush_and_sort_chunk_time_millis
-                ValueLayout.ADDRESS     // out_row_id_mapping_max
+                ValueLayout.ADDRESS,    // out_row_id_mapping_max
+                ValueLayout.ADDRESS,    // live-docs ptrs (per-input bitsets)
+                ValueLayout.ADDRESS,    // live-docs lens
+                ValueLayout.JAVA_LONG   // live-docs count (0 = all alive)
             )
         );
         FREE_MERGE_RESULT = linker.downcallHandle(
@@ -541,13 +544,29 @@ public class RustBridge {
         }
     }
 
+    /**
+     * Performs a native k-way merge of {@code inputFiles} into {@code outputFile}. Dead rows
+     * flagged in {@code liveBitsPerInput} are dropped from the output; row count is bounded by
+     * the input sum.
+     *
+     * <p>{@code liveBitsPerInput} is parallel to {@code inputFiles} — each bitset uses Lucene
+     * {@code FixedBitSet#getBits()} layout (bit 0 = row 0 alive). A {@code null} entry, or
+     * passing {@code null} / zero-length outer array, disables filtering (zero-copy fast path).</p>
+     */
     public static MergeFilesResult mergeParquetFilesInRust(
         List<Path> inputFiles,
+        long[][] liveBitsPerInput,
         String outputFile,
         String indexName,
         long outputWriterGeneration
     ) {
         String[] paths = inputFiles.stream().map(Path::toString).toArray(String[]::new);
+        boolean hasLiveDocs = liveBitsPerInput != null && liveBitsPerInput.length > 0;
+        if (hasLiveDocs && liveBitsPerInput.length != paths.length) {
+            throw new IllegalArgumentException(
+                "liveBitsPerInput length (" + liveBitsPerInput.length + ") must match inputFiles (" + paths.length + ")"
+            );
+        }
         try (var call = new NativeCall()) {
             var inputs = call.strArray(paths);
             var out = call.str(outputFile);
@@ -570,6 +589,30 @@ public class RustBridge {
             var outFlushChunkCount = call.longOut();
             var outFlushChunkTimeMillis = call.longOut();
             var outRowIdMappingMax = call.longOut();
+
+            // Live-docs per input (parallel arrays of pointer+length). Null or empty ⇒ skip filter.
+            final MemorySegment liveBitsPtrs;
+            final MemorySegment liveBitsLens;
+            final long liveBitsCount;
+            if (hasLiveDocs) {
+                liveBitsPtrs = call.buf(paths.length * (int) ValueLayout.ADDRESS.byteSize());
+                liveBitsLens = call.buf(paths.length * Long.BYTES);
+                for (int i = 0; i < paths.length; i++) {
+                    long[] bits = liveBitsPerInput[i];
+                    if (bits == null || bits.length == 0) {
+                        liveBitsPtrs.setAtIndex(ValueLayout.ADDRESS, i, MemorySegment.NULL);
+                        liveBitsLens.setAtIndex(ValueLayout.JAVA_LONG, i, 0L);
+                    } else {
+                        liveBitsPtrs.setAtIndex(ValueLayout.ADDRESS, i, call.longs(bits));
+                        liveBitsLens.setAtIndex(ValueLayout.JAVA_LONG, i, (long) bits.length);
+                    }
+                }
+                liveBitsCount = paths.length;
+            } else {
+                liveBitsPtrs = MemorySegment.NULL;
+                liveBitsLens = MemorySegment.NULL;
+                liveBitsCount = 0L;
+            }
 
             call.invokeIO(
                 MERGE_FILES,
@@ -595,7 +638,10 @@ public class RustBridge {
                 outGenCount,
                 outFlushChunkCount,
                 outFlushChunkTimeMillis,
-                outRowIdMappingMax
+                outRowIdMappingMax,
+                liveBitsPtrs,
+                liveBitsLens,
+                liveBitsCount
             );
 
             int createdByLen = (int) createdByOut.lenOut().get(ValueLayout.JAVA_LONG, 0);

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/merge/NativeParquetMergeStrategy.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/merge/NativeParquetMergeStrategy.java
@@ -80,24 +80,48 @@ public class NativeParquetMergeStrategy implements ParquetMergeStrategy {
         assert filePaths.stream().allMatch(p -> java.nio.file.Files.exists(p)) : "all input files must exist on disk before merge: "
             + filePaths.stream().filter(p -> java.nio.file.Files.exists(p) == false).toList();
 
+        // Build per-input live-docs bitsets from MergeInput. A null entry means all rows alive.
+        long[][] liveBitsPerInput = new long[files.size()][];
+        boolean anyLiveDocs = false;
+        for (int i = 0; i < files.size(); i++) {
+            long[] bits = mergeInput.getLiveDocsForSegment(files.get(i).writerGeneration());
+            if (bits != null && bits.length > 0) {
+                liveBitsPerInput[i] = bits;
+                anyLiveDocs = true;
+            }
+        }
+        long[][] liveBitsArg = anyLiveDocs ? liveBitsPerInput : null;
+
         Path mergedFilePath = ParquetIndexingEngine.buildParquetFilePath(shardPath, writerGeneration, "merged");
         String mergedFileName = mergedFilePath.getFileName().toString();
 
         long startNanos = System.nanoTime();
         try {
             // Merge files in Rust
-            MergeFilesResult merged = RustBridge.mergeParquetFilesInRust(filePaths, mergedFilePath.toString(), indexName, writerGeneration);
+            MergeFilesResult merged = RustBridge.mergeParquetFilesInRust(
+                filePaths,
+                liveBitsArg,
+                mergedFilePath.toString(),
+                indexName,
+                writerGeneration
+            );
             ParquetFileMetadata mergeMetadata = merged.metadata();
             RowIdMapping rowIdMapping = merged.rowIdMapping();
 
             assert mergeMetadata.numRows() > 0 : "Merged file should contain at least one row";
 
             long expectedRows = files.stream().mapToLong(MonoFileWriterSet::numRows).sum();
-            assert mergeMetadata.numRows() == expectedRows : "Merged row count ["
+            // With live-docs, output is bounded by input sum. Without, strict equality.
+            assert mergeMetadata.numRows() <= expectedRows : "Merged row count ["
+                + mergeMetadata.numRows()
+                + "] must not exceed sum of input row counts ["
+                + expectedRows
+                + "]";
+            assert anyLiveDocs || mergeMetadata.numRows() == expectedRows : "Merged row count ["
                 + mergeMetadata.numRows()
                 + "] must equal sum of input row counts ["
                 + expectedRows
-                + "]";
+                + "] when no live-docs are supplied";
 
             MonoFileWriterSet mergedWriterFileSet = MonoFileWriterSet.of(
                 mergedFilePath.getParent().toAbsolutePath(),

--- a/sandbox/plugins/parquet-data-format/src/main/rust/src/ffm.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/src/ffm.rs
@@ -14,7 +14,7 @@
 use std::slice;
 use std::str;
 
-use native_bridge_common::{ffm_safe, log_debug};
+use native_bridge_common::ffm_safe;
 
 use crate::field_config::FieldConfig;
 use crate::merge;
@@ -61,6 +61,36 @@ unsafe fn bool_array_from_raw(vals: *const i64, count: i64) -> Vec<bool> {
     }
     let n = count as usize;
     (0..n).map(|i| *vals.add(i) != 0).collect()
+}
+
+/// Decode a parallel array of (pointer, length) pairs into a vector of owned `u64` bitsets.
+/// Each entry corresponds to one input file. Null pointer or zero length ⇒ "all alive".
+/// Bitsets use Lucene `FixedBitSet#getBits()` layout.
+unsafe fn live_bits_array_from_raw(
+    ptrs: *const *const i64,
+    lens: *const i64,
+    count: i64,
+) -> Vec<Option<Vec<u64>>> {
+    if count == 0 || lens.is_null() {
+        return vec![];
+    }
+    let n = count as usize;
+    let mut out = Vec::with_capacity(n);
+    for i in 0..n {
+        let l = *lens.add(i);
+        if l <= 0 || ptrs.is_null() {
+            out.push(None);
+            continue;
+        }
+        let p = *ptrs.add(i);
+        if p.is_null() {
+            out.push(None);
+            continue;
+        }
+        let slice = slice::from_raw_parts(p as *const u64, l as usize);
+        out.push(Some(slice.to_vec()));
+    }
+    out
 }
 
 // ---------------------------------------------------------------------------
@@ -663,6 +693,11 @@ pub unsafe extern "C" fn parquet_merge_files(
     out_flush_and_sort_chunk_count: *mut i64,
     out_flush_and_sort_chunk_time_millis: *mut i64,
     out_row_id_mapping_max: *mut i64,
+    // Per-input live-docs bitsets (parallel to input_ptrs) in Lucene `FixedBitSet#getBits()`
+    // layout. Pass `live_bits_count == 0`, or per-file length 0, for "all alive".
+    live_bits_ptrs: *const *const i64,
+    live_bits_lens: *const i64,
+    live_bits_count: i64,
 ) -> i64 {
     let input_files = str_array_from_raw(input_ptrs, input_lens, input_count)
         .map_err(|e| format!("parquet_merge_files inputs: {}", e))?;
@@ -670,6 +705,12 @@ pub unsafe extern "C" fn parquet_merge_files(
         .map_err(|e| format!("parquet_merge_files output: {}", e))?;
     let index_name = str_from_raw(index_name_ptr, index_name_len)
         .map_err(|e| format!("parquet_merge_files index_name: {}", e))?;
+
+    // Decode live-docs; pad with None to cover every input file.
+    let mut live_docs = live_bits_array_from_raw(live_bits_ptrs, live_bits_lens, live_bits_count);
+    if live_docs.len() < input_files.len() {
+        live_docs.resize(input_files.len(), None);
+    }
 
     let (sort_cols, reverse_flags, nulls_first_flags) = match SETTINGS_STORE.get(index_name) {
         Some(s) => {
@@ -696,6 +737,7 @@ pub unsafe extern "C" fn parquet_merge_files(
             output_path,
             index_name,
             output_writer_generation,
+            &live_docs,
         )
     } else {
         merge::merge_sorted(
@@ -706,6 +748,7 @@ pub unsafe extern "C" fn parquet_merge_files(
             &reverse_flags,
             &nulls_first_flags,
             output_writer_generation,
+            &live_docs,
         )
     }
     .map_err(|e| format!("{}", e))?;
@@ -1003,5 +1046,118 @@ pub unsafe extern "C" fn parquet_get_pool_stats(out_buf: *mut i64) {
     let stats = crate::memory::get_stats();
     for (i, val) in stats.iter().enumerate() {
         *out_buf.add(i) = *val as i64;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ===== live_bits_array_from_raw =====
+
+    #[test]
+    fn live_bits_array_from_raw_zero_count_returns_empty() {
+        let result = unsafe { live_bits_array_from_raw(std::ptr::null(), std::ptr::null(), 0) };
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn live_bits_array_from_raw_null_lens_returns_empty() {
+        let invalid_ptr: *const i64 = usize::MAX as *const i64;
+        let invalid_ptrs: *const *const i64 = &invalid_ptr;
+        let result = unsafe { live_bits_array_from_raw(invalid_ptrs, std::ptr::null(), 1) };
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn live_bits_array_from_raw_decodes_single_input() {
+        let bits: Vec<i64> = vec![0xFFFF_FFFF_FFFF_FFFEu64 as i64];
+        let ptr = bits.as_ptr();
+        let ptrs: Vec<*const i64> = vec![ptr];
+        let lens: Vec<i64> = vec![bits.len() as i64];
+
+        let result = unsafe { live_bits_array_from_raw(ptrs.as_ptr(), lens.as_ptr(), 1) };
+
+        assert_eq!(result.len(), 1);
+        let decoded = result[0].as_ref().expect("expected non-None entry");
+        assert_eq!(decoded.len(), 1);
+        // i64 0xFFFF_FFFF_FFFF_FFFE reinterpreted as u64 ⇒ 0xFFFF_FFFF_FFFF_FFFE
+        assert_eq!(decoded[0], 0xFFFF_FFFF_FFFF_FFFEu64);
+    }
+
+    #[test]
+    fn live_bits_array_from_raw_zero_length_entry_yields_none() {
+        let lens: Vec<i64> = vec![0];
+        let ptrs: Vec<*const i64> = vec![std::ptr::null()];
+
+        let result = unsafe { live_bits_array_from_raw(ptrs.as_ptr(), lens.as_ptr(), 1) };
+
+        assert_eq!(result.len(), 1);
+        assert!(result[0].is_none());
+    }
+
+    #[test]
+    fn live_bits_array_from_raw_negative_length_entry_yields_none() {
+        let lens: Vec<i64> = vec![-1];
+        let ptrs: Vec<*const i64> = vec![std::ptr::null()];
+
+        let result = unsafe { live_bits_array_from_raw(ptrs.as_ptr(), lens.as_ptr(), 1) };
+
+        assert_eq!(result.len(), 1);
+        assert!(result[0].is_none());
+    }
+
+    #[test]
+    fn live_bits_array_from_raw_null_inner_ptr_yields_none() {
+        let lens: Vec<i64> = vec![1];
+        let ptrs: Vec<*const i64> = vec![std::ptr::null()];
+
+        let result = unsafe { live_bits_array_from_raw(ptrs.as_ptr(), lens.as_ptr(), 1) };
+
+        assert_eq!(result.len(), 1);
+        assert!(
+            result[0].is_none(),
+            "null pointer with positive length should yield None"
+        );
+    }
+
+    #[test]
+    fn live_bits_array_from_raw_mixed_some_none() {
+        let bits_a: Vec<i64> = vec![0x0000_0000_0000_000Fi64];
+        let bits_c: Vec<i64> = vec![0x00FF_FF00_0000_0000u64 as i64];
+
+        let ptrs: Vec<*const i64> = vec![bits_a.as_ptr(), std::ptr::null(), bits_c.as_ptr()];
+        let lens: Vec<i64> = vec![bits_a.len() as i64, 0, bits_c.len() as i64];
+
+        let result = unsafe { live_bits_array_from_raw(ptrs.as_ptr(), lens.as_ptr(), 3) };
+
+        assert_eq!(result.len(), 3);
+        assert!(result[0].is_some());
+        assert!(
+            result[1].is_none(),
+            "middle entry with len=0 should be None"
+        );
+        assert!(result[2].is_some());
+        assert_eq!(result[0].as_ref().unwrap()[0], 0x0000_0000_0000_000Fu64);
+        assert_eq!(result[2].as_ref().unwrap()[0], 0x00FF_FF00_0000_0000u64);
+    }
+
+    #[test]
+    fn live_bits_array_from_raw_multi_word_bitmap() {
+        let bits: Vec<i64> = vec![1i64, 0i64, 0x0123_4567i64];
+        let ptrs: Vec<*const i64> = vec![bits.as_ptr()];
+        let lens: Vec<i64> = vec![bits.len() as i64];
+
+        let result = unsafe { live_bits_array_from_raw(ptrs.as_ptr(), lens.as_ptr(), 1) };
+
+        let decoded = result[0].as_ref().expect("expected Some");
+        assert_eq!(decoded.len(), 3);
+        assert_eq!(decoded[0], 1u64);
+        assert_eq!(decoded[1], 0u64);
+        assert_eq!(decoded[2], 0x0123_4567u64);
     }
 }

--- a/sandbox/plugins/parquet-data-format/src/main/rust/src/merge/cursor.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/src/merge/cursor.rs
@@ -9,7 +9,8 @@
 use std::fs::File;
 use std::sync::{Arc, Mutex};
 
-use arrow::array::RecordBatch;
+use arrow::array::{BooleanArray, RecordBatch};
+use arrow::compute::filter_record_batch;
 use arrow::datatypes::{DataType as ArrowDataType, Schema as ArrowSchema};
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use parquet::schema::types::SchemaDescriptor;
@@ -26,7 +27,12 @@ use native_bridge_common::memory_pool::MemoryReservation;
 /// When deferred mode is active (controlled by the dynamic index setting
 /// `index.parquet.merge_deferred_column_threshold`, default 0 = always deferred),
 /// uses two readers: a sort-only reader for the merge heap and a data reader
-/// loaded on demand. Otherwise uses a single all-column reader.
+/// loaded on demand. Otherwise uses a single all-column reader. The sort reader
+/// prefetches the next batch on the shared Rayon pool to overlap IO with merge
+/// computation.
+///
+/// When `live_bits` is `Some`, dead rows are skipped so `row_idx` always points
+/// at a live row (or the cursor is exhausted).
 pub struct FileCursor {
     sort_reader: Arc<Mutex<parquet::arrow::arrow_reader::ParquetRecordBatchReader>>,
     sort_prefetch_rx: std::sync::mpsc::Receiver<Option<MergeResult<RecordBatch>>>,
@@ -47,9 +53,81 @@ pub struct FileCursor {
     pub nulls_first: Vec<bool>,
     current_sort_batch_bytes: usize,
     current_data_batch_bytes: usize,
+
+    /// Packed live-docs bitset in Lucene `FixedBitSet#getBits()` layout. `None` = all alive.
+    live_bits: Option<Arc<Vec<u64>>>,
+    /// Total source rows. Bits at indices `>= num_rows` are ignored.
+    num_rows: u64,
+    /// Source row-id offset at the start of the current sort batch.
+    pub base_row_id: u64,
+}
+
+/// Returns `true` if `abs_row_id` is alive given the optional `live_bits` packed bitset.
+/// `None` ⇒ all alive; rows beyond `num_rows` or beyond the bitset's length are treated
+/// as alive (defensive — Java-side contract is that absent bits mean "all alive").
+///
+/// Delegates to [`super::live_docs::is_alive_in_words`] for the core bit logic.
+#[inline]
+pub fn is_row_id_alive(live_bits: Option<&[u64]>, num_rows: u64, abs_row_id: u64) -> bool {
+    match live_bits {
+        None => true,
+        Some(bits) => super::live_docs::is_alive_in_words(bits, num_rows, abs_row_id),
+    }
+}
+
+/// One past the highest live-row index within `[0, batch_upper)` for the batch starting
+/// at `base_row_id`. `None` live_bits ⇒ all alive ⇒ returns `batch_upper`. If no row in
+/// the range is alive, returns 0.
+#[inline]
+pub fn last_live_index_plus_one(
+    live_bits: Option<&[u64]>,
+    num_rows: u64,
+    base_row_id: u64,
+    batch_upper: usize,
+) -> usize {
+    match live_bits {
+        None => batch_upper,
+        Some(_) => {
+            let mut i = batch_upper;
+            while i > 0 {
+                let idx = i - 1;
+                if is_row_id_alive(live_bits, num_rows, base_row_id + idx as u64) {
+                    return i;
+                }
+                i -= 1;
+            }
+            0
+        }
+    }
 }
 
 impl FileCursor {
+    /// Returns `true` if the given absolute source row id is alive.
+    #[inline]
+    pub fn is_row_id_alive(&self, abs_row_id: u64) -> bool {
+        is_row_id_alive(
+            self.live_bits.as_deref().map(|v| v.as_slice()),
+            self.num_rows,
+            abs_row_id,
+        )
+    }
+
+    /// One past the highest live-row index within `[0, batch_upper)`.
+    #[inline]
+    fn last_live_index_plus_one(&self, batch_upper: usize) -> usize {
+        last_live_index_plus_one(
+            self.live_bits.as_deref().map(|v| v.as_slice()),
+            self.num_rows,
+            self.base_row_id,
+            batch_upper,
+        )
+    }
+
+    /// Opens a Parquet file and creates a cursor positioned at the first live row.
+    ///
+    /// Returns `(cursor, projected_arrow_schema, parquet_schema_descriptor, writer_generation, total_row_count)`
+    /// so the caller can build union schemas and row-ID mappings without re-opening the file.
+    /// `live_bits` is an optional packed bitset of live rows (Lucene layout).
     pub fn new(
         path: &str,
         file_id: usize,
@@ -58,6 +136,7 @@ impl FileCursor {
         batch_size: usize,
         deferred_threshold: usize,
         reservation: &mut MemoryReservation,
+        live_bits: Option<Arc<Vec<u64>>>,
     ) -> MergeResult<(Self, Arc<ArrowSchema>, SchemaDescriptor, i64, usize)> {
         // Open file and read metadata
         let file = File::open(path)?;
@@ -209,6 +288,9 @@ impl FileCursor {
             nulls_first: nulls_first.to_vec(),
             current_sort_batch_bytes: 0,
             current_data_batch_bytes: 0,
+            live_bits,
+            num_rows: total_row_count as u64,
+            base_row_id: 0,
         };
 
         // Track sort batch + prefetch (estimate 2x first batch)
@@ -217,6 +299,8 @@ impl FileCursor {
         cursor.current_sort_batch_bytes = batch_bytes;
 
         cursor.start_sort_prefetch();
+        // Position at the first live row (no-op when live_bits is None).
+        cursor.skip_to_next_live_row(reservation)?;
         Ok((
             cursor,
             projected_schema,
@@ -224,6 +308,35 @@ impl FileCursor {
             writer_generation,
             total_row_count,
         ))
+    }
+
+    /// Returns `true` if the cursor's current row is alive.
+    #[inline]
+    fn is_current_row_alive(&self) -> bool {
+        self.is_row_id_alive(self.base_row_id + self.row_idx as u64)
+    }
+
+    /// Advances `row_idx` past dead rows, loading successor batches as needed.
+    /// After this, either `row_idx` points at a live row or the cursor is exhausted.
+    fn skip_to_next_live_row(&mut self, reservation: &mut MemoryReservation) -> MergeResult<()> {
+        if self.live_bits.is_none() {
+            return Ok(());
+        }
+        loop {
+            let n = match self.sort_batch.as_ref() {
+                Some(b) => b.num_rows(),
+                None => return Ok(()),
+            };
+            while self.row_idx < n && !self.is_current_row_alive() {
+                self.row_idx += 1;
+            }
+            if self.row_idx < n {
+                return Ok(());
+            }
+            if !self.load_next_batch(reservation)? {
+                return Ok(());
+            }
+        }
     }
 
     fn start_sort_prefetch(&mut self) {
@@ -246,6 +359,11 @@ impl FileCursor {
 
     pub fn load_next_batch(&mut self, reservation: &mut MemoryReservation) -> MergeResult<bool> {
         let old_sort_bytes = self.current_sort_batch_bytes;
+        let prev_rows = self
+            .sort_batch
+            .as_ref()
+            .map(|b| b.num_rows() as u64)
+            .unwrap_or(0);
         self.sort_batch = None;
 
         // Release data batch tracking — previous data_batch is dropped
@@ -272,6 +390,8 @@ impl FileCursor {
             Some(batch) => {
                 let new_bytes = batch.get_array_memory_size();
                 self.sort_batch = Some(batch);
+                // Advance the absolute source row-id offset past the batch we just dropped.
+                self.base_row_id += prev_rows;
                 self.row_idx = 0;
                 self.sort_batch_index += 1;
                 self.start_sort_prefetch();
@@ -386,15 +506,20 @@ impl FileCursor {
         )
     }
 
-    #[inline]
+    /// Returns sort values at the cursor's last live row in the current batch.
     pub fn last_sort_values(&self) -> MergeResult<Vec<SortKey>> {
         let batch = self
             .sort_batch
             .as_ref()
             .ok_or_else(|| MergeError::Logic("Cursor exhausted".into()))?;
+        let end_excl = self.last_live_index_plus_one(batch.num_rows());
+        assert!(
+            end_excl > self.row_idx,
+            "last_sort_values called on cursor with no live row"
+        );
         get_sort_values(
             batch,
-            batch.num_rows() - 1,
+            end_excl - 1,
             &self.sort_col_indices,
             &self.sort_col_types,
             &self.nulls_first,
@@ -406,26 +531,42 @@ impl FileCursor {
         self.sort_batch.as_ref().map_or(0, |b| b.num_rows())
     }
 
-    #[inline]
+    /// Returns the sub-batch `[start, start+len)` with dead rows filtered out.
+    ///
+    /// In deferred mode the slice is taken from the on-demand data reader; otherwise
+    /// from the sort batch. When `live_bits` is `Some`, dead rows are removed via a
+    /// boolean mask keyed on absolute source row ids. Zero-copy when `live_bits` is `None`.
     pub fn take_slice(
         &mut self,
         start: usize,
         len: usize,
         reservation: &mut MemoryReservation,
     ) -> MergeResult<RecordBatch> {
-        if self.deferred {
+        let slice = if self.deferred {
             self.ensure_data_loaded(reservation)?;
             let batch = self
                 .data_batch
                 .as_ref()
                 .ok_or_else(|| MergeError::Logic("Data batch not loaded".into()))?;
-            Ok(batch.slice(start, len))
+            batch.slice(start, len)
         } else {
             let batch = self
                 .sort_batch
                 .as_ref()
                 .ok_or_else(|| MergeError::Logic("Batch is None".into()))?;
-            Ok(batch.slice(start, len))
+            batch.slice(start, len)
+        };
+        match &self.live_bits {
+            None => Ok(slice),
+            Some(_) => {
+                let mut mask_values: Vec<bool> = Vec::with_capacity(len);
+                let start_abs = self.base_row_id + start as u64;
+                for i in 0..len {
+                    mask_values.push(self.is_row_id_alive(start_abs + i as u64));
+                }
+                let mask = BooleanArray::from(mask_values);
+                Ok(filter_record_batch(&slice, &mask)?)
+            }
         }
     }
 
@@ -442,7 +583,13 @@ impl FileCursor {
                 reservation.shrink(self.current_data_batch_bytes);
                 self.current_data_batch_bytes = 0;
             }
-            return self.load_next_batch(reservation);
+            if !self.load_next_batch(reservation)? {
+                return Ok(false);
+            }
+        }
+        if self.live_bits.is_some() {
+            self.skip_to_next_live_row(reservation)?;
+            return Ok(self.sort_batch.is_some());
         }
         Ok(true)
     }
@@ -455,6 +602,143 @@ impl FileCursor {
             reservation.shrink(self.current_data_batch_bytes);
             self.current_data_batch_bytes = 0;
         }
-        self.load_next_batch(reservation)
+        if !self.load_next_batch(reservation)? {
+            return Ok(false);
+        }
+        if self.live_bits.is_some() {
+            self.skip_to_next_live_row(reservation)?;
+            return Ok(self.sort_batch.is_some());
+        }
+        Ok(true)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod is_row_id_alive_tests {
+    use super::is_row_id_alive;
+
+    #[test]
+    fn none_bits_returns_true_for_any_row() {
+        assert!(is_row_id_alive(None, 0, 0));
+        assert!(is_row_id_alive(None, 100, 0));
+        assert!(is_row_id_alive(None, 100, 99));
+        assert!(is_row_id_alive(None, 100, 1_000_000));
+    }
+
+    #[test]
+    fn bit_zero_alive_and_dead() {
+        let all_alive: Vec<u64> = vec![!0u64];
+        assert!(is_row_id_alive(Some(&all_alive), 64, 0));
+        let row_zero_dead: Vec<u64> = vec![!0u64 & !1u64];
+        assert!(!is_row_id_alive(Some(&row_zero_dead), 64, 0));
+    }
+
+    #[test]
+    fn bit_at_word_boundary_63() {
+        let bits: Vec<u64> = vec![1u64 << 63];
+        assert!(is_row_id_alive(Some(&bits), 64, 63));
+        for r in 0..63 {
+            assert!(
+                !is_row_id_alive(Some(&bits), 64, r),
+                "row {} should be dead",
+                r
+            );
+        }
+    }
+
+    #[test]
+    fn bit_crosses_word_boundary_64() {
+        let bits: Vec<u64> = vec![0u64, 1u64];
+        assert!(is_row_id_alive(Some(&bits), 128, 64));
+        assert!(!is_row_id_alive(Some(&bits), 128, 63));
+        assert!(!is_row_id_alive(Some(&bits), 128, 65));
+    }
+
+    #[test]
+    fn bit_at_word_boundary_127() {
+        let bits: Vec<u64> = vec![0u64, 1u64 << 63];
+        assert!(is_row_id_alive(Some(&bits), 128, 127));
+        assert!(!is_row_id_alive(Some(&bits), 128, 126));
+    }
+
+    #[test]
+    fn out_of_bounds_returns_alive_defensively() {
+        let bits: Vec<u64> = vec![0u64];
+        // num_rows=10 — anything >= 10 must come back alive even though all bits are 0.
+        assert!(is_row_id_alive(Some(&bits), 10, 10));
+        assert!(is_row_id_alive(Some(&bits), 10, 100));
+    }
+
+    #[test]
+    fn short_bitmap_treats_missing_words_as_alive() {
+        // Bitmap covers only 64 bits, but num_rows says 128.
+        let bits: Vec<u64> = vec![0u64];
+        // Row 64 lives in word 1, which is missing.
+        assert!(is_row_id_alive(Some(&bits), 128, 64));
+        // Row 0 is in word 0 and explicitly dead.
+        assert!(!is_row_id_alive(Some(&bits), 128, 0));
+    }
+
+    #[test]
+    fn empty_bitmap_returns_alive_for_all() {
+        let bits: Vec<u64> = vec![];
+        assert!(is_row_id_alive(Some(&bits), 0, 0));
+        assert!(is_row_id_alive(Some(&bits), 100, 0));
+    }
+}
+
+#[cfg(test)]
+mod last_live_index_plus_one_tests {
+    use super::last_live_index_plus_one;
+
+    #[test]
+    fn none_bits_returns_batch_upper() {
+        assert_eq!(last_live_index_plus_one(None, 100, 0, 50), 50);
+        assert_eq!(last_live_index_plus_one(None, 100, 25, 25), 25);
+    }
+
+    #[test]
+    fn empty_batch_returns_zero() {
+        let bits: Vec<u64> = vec![!0u64];
+        assert_eq!(last_live_index_plus_one(Some(&bits), 64, 0, 0), 0);
+    }
+
+    #[test]
+    fn all_rows_alive_returns_batch_upper() {
+        let bits: Vec<u64> = vec![!0u64];
+        assert_eq!(last_live_index_plus_one(Some(&bits), 64, 0, 10), 10);
+    }
+
+    #[test]
+    fn last_row_dead_returns_index_of_previous_alive() {
+        // Rows 0..9 alive, row 10 dead.
+        let bits: Vec<u64> = vec![0x3FFu64];
+        assert_eq!(last_live_index_plus_one(Some(&bits), 64, 0, 11), 10);
+    }
+
+    #[test]
+    fn trailing_dead_rows_skipped() {
+        // Rows 0..4 alive, rows 5..15 dead.
+        let bits: Vec<u64> = vec![0x1Fu64];
+        assert_eq!(last_live_index_plus_one(Some(&bits), 64, 0, 16), 5);
+    }
+
+    #[test]
+    fn all_rows_dead_returns_zero() {
+        let bits: Vec<u64> = vec![0u64];
+        assert_eq!(last_live_index_plus_one(Some(&bits), 64, 0, 10), 0);
+    }
+
+    #[test]
+    fn respects_base_row_id_offset() {
+        // bit at abs row 10 alive, all others dead.
+        let bits: Vec<u64> = vec![1u64 << 10];
+        // Cursor is at base_row_id=5, asking about a 10-row batch ⇒ checks abs rows 5..14.
+        // Last alive in that range is abs 10 (= local idx 5 in this batch). Result is 5+1=6.
+        assert_eq!(last_live_index_plus_one(Some(&bits), 64, 5, 10), 6);
     }
 }

--- a/sandbox/plugins/parquet-data-format/src/main/rust/src/merge/live_docs.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/src/merge/live_docs.rs
@@ -1,0 +1,169 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+//! Shared live-docs bitset utilities for merge filtering.
+//!
+//! A `LiveBits` is an optional packed bitset in Lucene `FixedBitSet#getBits()` layout:
+//! bit `i` set means row `i` is alive. `None` means all rows are alive (fast path).
+
+use std::sync::Arc;
+
+/// Per-file live-docs filter. `None` = all rows alive (no filtering needed).
+pub type LiveBits = Option<Arc<Vec<u64>>>;
+
+/// Returns `true` if the row at `abs_row_id` is alive.
+///
+/// - `None` bits → all alive
+/// - Row beyond `num_rows` → alive (defensive)
+/// - Word beyond bitset length → alive (defensive)
+#[inline]
+pub fn is_alive(bits: &LiveBits, num_rows: u64, abs_row_id: u64) -> bool {
+    match bits {
+        None => true,
+        Some(words) => is_alive_in_words(words, num_rows, abs_row_id),
+    }
+}
+
+/// Core bit check against a raw word slice.
+#[inline]
+pub fn is_alive_in_words(words: &[u64], num_rows: u64, abs_row_id: u64) -> bool {
+    if abs_row_id >= num_rows {
+        return true;
+    }
+    let word_idx = (abs_row_id / 64) as usize;
+    let bit_idx = abs_row_id % 64;
+    match words.get(word_idx) {
+        Some(&word) => (word & (1u64 << bit_idx)) != 0,
+        None => true,
+    }
+}
+
+/// Builds a boolean filter mask for a batch of `batch_len` rows starting at `base_row_id`.
+///
+/// Returns `None` if all rows in the batch are alive (caller should skip filtering).
+/// Otherwise returns `(mask, alive_count)`.
+#[inline]
+pub fn build_filter_mask(
+    bits: &LiveBits,
+    num_rows: u64,
+    base_row_id: u64,
+    batch_len: usize,
+) -> Option<(Vec<bool>, usize)> {
+    match bits {
+        None => None,
+        Some(words) => {
+            let mut mask = Vec::with_capacity(batch_len);
+            let mut alive_count = 0usize;
+            for i in 0..batch_len {
+                let alive = is_alive_in_words(words, num_rows, base_row_id + i as u64);
+                if alive {
+                    alive_count += 1;
+                }
+                mask.push(alive);
+            }
+            if alive_count == batch_len {
+                None // all alive — caller skips filter_record_batch
+            } else {
+                Some((mask, alive_count))
+            }
+        }
+    }
+}
+
+/// Counts total alive rows in `[0, num_rows)`.
+/// Returns `num_rows` if bits is `None`.
+pub fn count_alive(bits: &LiveBits, num_rows: u64) -> u64 {
+    match bits {
+        None => num_rows,
+        Some(words) => {
+            let full_words = (num_rows / 64) as usize;
+            let remainder = num_rows % 64;
+            let mut count: u64 = 0;
+
+            for &word in words.iter().take(full_words) {
+                count += word.count_ones() as u64;
+            }
+
+            if remainder > 0 {
+                if let Some(&last_word) = words.get(full_words) {
+                    let mask = (1u64 << remainder) - 1;
+                    count += (last_word & mask).count_ones() as u64;
+                }
+            }
+
+            count
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_none_is_all_alive() {
+        let bits: LiveBits = None;
+        for i in 0..100 {
+            assert!(is_alive(&bits, 100, i));
+        }
+    }
+
+    #[test]
+    fn test_specific_bits() {
+        let bits: LiveBits = Some(Arc::new(vec![0b101])); // rows 0,2 alive; row 1 dead
+        assert!(is_alive(&bits, 3, 0));
+        assert!(!is_alive(&bits, 3, 1));
+        assert!(is_alive(&bits, 3, 2));
+    }
+
+    #[test]
+    fn test_beyond_num_rows_is_alive() {
+        let bits: LiveBits = Some(Arc::new(vec![0b101]));
+        assert!(is_alive(&bits, 3, 99));
+    }
+
+    #[test]
+    fn test_build_filter_mask_all_alive() {
+        let bits: LiveBits = None;
+        assert!(build_filter_mask(&bits, 100, 0, 10).is_none());
+    }
+
+    #[test]
+    fn test_build_filter_mask_some_dead() {
+        let bits: LiveBits = Some(Arc::new(vec![0b1011])); // rows 0,1,3 alive; row 2 dead
+        let result = build_filter_mask(&bits, 4, 0, 4);
+        assert!(result.is_some());
+        let (mask, count) = result.unwrap();
+        assert_eq!(mask, vec![true, true, false, true]);
+        assert_eq!(count, 3);
+    }
+
+    #[test]
+    fn test_build_filter_mask_all_alive_in_batch() {
+        let bits: LiveBits = Some(Arc::new(vec![0xFF]));
+        assert!(build_filter_mask(&bits, 8, 0, 4).is_none());
+    }
+
+    #[test]
+    fn test_count_alive() {
+        let bits: LiveBits = Some(Arc::new(vec![0b1011]));
+        assert_eq!(count_alive(&bits, 4), 3);
+    }
+
+    #[test]
+    fn test_count_alive_none() {
+        let bits: LiveBits = None;
+        assert_eq!(count_alive(&bits, 100), 100);
+    }
+
+    #[test]
+    fn test_count_alive_multi_word() {
+        let bits: LiveBits = Some(Arc::new(vec![u64::MAX, 0b11]));
+        assert_eq!(count_alive(&bits, 66), 66);
+    }
+}

--- a/sandbox/plugins/parquet-data-format/src/main/rust/src/merge/mod.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/src/merge/mod.rs
@@ -11,6 +11,7 @@ mod cursor;
 pub mod error;
 pub mod heap;
 pub mod io_task;
+pub mod live_docs;
 pub mod metrics;
 pub mod schema;
 mod sorted;

--- a/sandbox/plugins/parquet-data-format/src/main/rust/src/merge/sorted.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/src/merge/sorted.rs
@@ -25,6 +25,8 @@ use crate::memory::merge_pool;
 use native_bridge_common::memory_pool::{MemoryReservation, PoolBehavior};
 
 /// Performs a streaming k-way merge with an explicit sort direction per column.
+/// `live_docs_per_input` is parallel to `input_files`; a `None` (or absent) entry
+/// disables filtering for that file (zero-copy fast path).
 pub fn merge_sorted(
     input_files: &[String],
     output_path: &str,
@@ -33,6 +35,7 @@ pub fn merge_sorted(
     reverse_sorts: &[bool],
     nulls_first: &[bool],
     output_writer_generation: i64,
+    live_docs_per_input: &[Option<Vec<u64>>],
 ) -> super::MergeResult<super::MergeOutput> {
     let mut reservation =
         MemoryReservation::new(merge_pool(), "merge_sorted", PoolBehavior::Reject);
@@ -45,10 +48,13 @@ pub fn merge_sorted(
         nulls_first,
         output_writer_generation,
         &mut reservation,
+        live_docs_per_input,
     )
 }
 
 /// Performs a streaming k-way merge using the provided memory reservation.
+/// `live_docs_per_input` is parallel to `input_files`; a `None` (or absent) entry
+/// disables filtering for that file (zero-copy fast path).
 pub fn merge_sorted_with_pool(
     input_files: &[String],
     output_path: &str,
@@ -58,6 +64,7 @@ pub fn merge_sorted_with_pool(
     nulls_first: &[bool],
     output_writer_generation: i64,
     reservation: &mut MemoryReservation,
+    live_docs_per_input: &[Option<Vec<u64>>],
 ) -> super::MergeResult<super::MergeOutput> {
     let config = crate::writer::SETTINGS_STORE
         .get(index_name)
@@ -110,6 +117,10 @@ pub fn merge_sorted_with_pool(
 
     for (file_id, path) in input_files.iter().enumerate() {
         log_debug!("[RUST] Opening cursor {} for file: {}", file_id, path);
+        let live_bits = live_docs_per_input
+            .get(file_id)
+            .and_then(|opt| opt.as_ref())
+            .map(|bits| Arc::new(bits.clone()));
         let (cursor, projected_schema, parquet_descr, generation, row_count) = FileCursor::new(
             path,
             file_id,
@@ -118,6 +129,7 @@ pub fn merge_sorted_with_pool(
             batch_size,
             deferred_threshold,
             reservation,
+            live_bits,
         )?;
         cursors.push(cursor);
         arrow_schemas.push(projected_schema.as_ref().clone());
@@ -149,14 +161,16 @@ pub fn merge_sorted_with_pool(
         .collect();
 
     // Row-ID mapping: pre-allocate the flat mapping array and compute offsets
-    // from file metadata row counts (known before reading any data).
+    // from file metadata row counts (known before reading any data). The mapping
+    // is indexed by absolute source row id; dead (deleted) rows keep the -1
+    // sentinel since they are never emitted.
     let total_rows: usize = file_row_counts.iter().sum();
     let mapping_bytes = total_rows * std::mem::size_of::<i64>();
     // Reserve for row-ID mapping Vec<i64> — total_rows × 8 bytes, allocated next line
     reservation
         .request(mapping_bytes)
         .map_err(|e| super::MergeError::Logic(format!("Merge pool exceeded (mapping): {}", e)))?;
-    let mut mapping: Vec<i64> = vec![0i64; total_rows];
+    let mut mapping: Vec<i64> = vec![-1i64; total_rows];
     let mut gen_keys: Vec<i64> = Vec::with_capacity(num_cursors);
     let mut gen_offsets: Vec<i32> = Vec::with_capacity(num_cursors);
     let mut gen_sizes: Vec<i32> = Vec::with_capacity(num_cursors);
@@ -170,8 +184,6 @@ pub fn merge_sorted_with_pool(
         offset += size;
     }
 
-    // Per-file counters: tracks how many rows have been emitted from each file
-    let mut rows_emitted_per_file: Vec<usize> = vec![0; num_cursors];
     let mut new_row_id: i64 = 0;
 
     log_debug!(
@@ -184,6 +196,10 @@ pub fn merge_sorted_with_pool(
     let reverse_sorts_arc = Arc::new(reverse_sorts.to_vec());
     let mut heap: BinaryHeap<HeapItem> = BinaryHeap::with_capacity(num_cursors);
     for cursor in &cursors {
+        // Cursors with all-dead data are already exhausted — skip.
+        if cursor.sort_batch.is_none() {
+            continue;
+        }
         let sv = cursor.current_sort_values()?;
         heap.push(HeapItem {
             sort_values: sv,
@@ -202,15 +218,22 @@ pub fn merge_sorted_with_pool(
             let col_mapping = &col_mappings[file_id];
             let file_offset = gen_offsets[file_id] as usize;
             loop {
-                let remaining = cursor.batch_height() - cursor.row_idx;
+                let start_idx = cursor.row_idx;
+                let base_row_id = cursor.base_row_id;
+                let remaining = cursor.batch_height() - start_idx;
                 if remaining > 0 {
-                    let slice = cursor.take_slice(cursor.row_idx, remaining, reservation)?;
-                    for _ in 0..remaining {
-                        mapping[file_offset + rows_emitted_per_file[file_id]] = new_row_id;
-                        rows_emitted_per_file[file_id] += 1;
-                        new_row_id += 1;
+                    let slice = cursor.take_slice(start_idx, remaining, reservation)?;
+                    // Build mapping for surviving rows (indexed by absolute source row id).
+                    for i in 0..remaining {
+                        let abs = base_row_id + (start_idx + i) as u64;
+                        if cursor.is_row_id_alive(abs) {
+                            mapping[file_offset + abs as usize] = new_row_id;
+                            new_row_id += 1;
+                        }
                     }
-                    ctx.push_batch(col_mapping.pad_batch(&slice)?)?;
+                    if slice.num_rows() > 0 {
+                        ctx.push_batch(col_mapping.pad_batch(&slice)?)?;
+                    }
                 }
                 if !cursor.advance_past_batch(reservation)? {
                     break;
@@ -230,14 +253,20 @@ pub fn merge_sorted_with_pool(
             // TIER 2: Entire remaining batch fits before heap top
             let last_val = cursor.last_sort_values()?;
             if cmp_sort_values(&last_val, heap_top, reverse_sorts) != Ordering::Greater {
-                let remaining = cursor.batch_height() - cursor.row_idx;
-                let slice = cursor.take_slice(cursor.row_idx, remaining, reservation)?;
-                for _ in 0..remaining {
-                    mapping[file_offset + rows_emitted_per_file[file_id]] = new_row_id;
-                    rows_emitted_per_file[file_id] += 1;
-                    new_row_id += 1;
+                let start_idx = cursor.row_idx;
+                let base_row_id = cursor.base_row_id;
+                let remaining = cursor.batch_height() - start_idx;
+                let slice = cursor.take_slice(start_idx, remaining, reservation)?;
+                for i in 0..remaining {
+                    let abs = base_row_id + (start_idx + i) as u64;
+                    if cursor.is_row_id_alive(abs) {
+                        mapping[file_offset + abs as usize] = new_row_id;
+                        new_row_id += 1;
+                    }
                 }
-                ctx.push_batch(col_mapping.pad_batch(&slice)?)?;
+                if slice.num_rows() > 0 {
+                    ctx.push_batch(col_mapping.pad_batch(&slice)?)?;
+                }
 
                 if !cursor.advance_past_batch(reservation)? {
                     break;
@@ -257,6 +286,7 @@ pub fn merge_sorted_with_pool(
 
             // TIER 3: Binary search for the exact boundary
             let run_start = cursor.row_idx;
+            let base_row_id = cursor.base_row_id;
             let batch_h = cursor.batch_height();
             let batch = cursor.sort_batch.as_ref().unwrap();
 
@@ -284,12 +314,16 @@ pub fn merge_sorted_with_pool(
             let run_len = run_end - run_start + 1;
             if run_len > 0 {
                 let slice = cursor.take_slice(run_start, run_len, reservation)?;
-                for _ in 0..run_len {
-                    mapping[file_offset + rows_emitted_per_file[file_id]] = new_row_id;
-                    rows_emitted_per_file[file_id] += 1;
-                    new_row_id += 1;
+                for i in 0..run_len {
+                    let abs = base_row_id + (run_start + i) as u64;
+                    if cursor.is_row_id_alive(abs) {
+                        mapping[file_offset + abs as usize] = new_row_id;
+                        new_row_id += 1;
+                    }
                 }
-                ctx.push_batch(col_mapping.pad_batch(&slice)?)?;
+                if slice.num_rows() > 0 {
+                    ctx.push_batch(col_mapping.pad_batch(&slice)?)?;
+                }
             }
 
             cursor.row_idx = run_end;

--- a/sandbox/plugins/parquet-data-format/src/main/rust/src/merge/unsorted.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/src/merge/unsorted.rs
@@ -8,7 +8,8 @@
 
 use std::fs::File;
 
-use arrow::array::RecordBatchReader;
+use arrow::array::{BooleanArray, RecordBatchReader};
+use arrow::compute::filter_record_batch;
 use arrow::datatypes::Schema as ArrowSchema;
 use parquet::arrow::arrow_reader::{ParquetRecordBatchReader, ParquetRecordBatchReaderBuilder};
 use parquet::schema::types::SchemaDescriptor;
@@ -24,11 +25,13 @@ use native_bridge_common::memory_pool::{MemoryReservation, PoolBehavior};
 
 /// Unsorted merge: reads each input file sequentially, pads to union schema,
 /// rewrites `__row_id__` with globally sequential values. No sorting performed.
+/// `live_docs_per_input` follows the same contract as `merge_sorted`.
 pub fn merge_unsorted(
     input_files: &[String],
     output_path: &str,
     index_name: &str,
     output_writer_generation: i64,
+    live_docs_per_input: &[Option<Vec<u64>>],
 ) -> MergeResult<super::MergeOutput> {
     let mut reservation =
         MemoryReservation::new(merge_pool(), "merge_unsorted", PoolBehavior::Reject);
@@ -38,16 +41,19 @@ pub fn merge_unsorted(
         index_name,
         output_writer_generation,
         &mut reservation,
+        live_docs_per_input,
     )
 }
 
 /// Unsorted merge with an explicit memory reservation.
+/// `live_docs_per_input` follows the same contract as `merge_sorted`.
 pub fn merge_unsorted_with_pool(
     input_files: &[String],
     output_path: &str,
     index_name: &str,
     output_writer_generation: i64,
     reservation: &mut MemoryReservation,
+    live_docs_per_input: &[Option<Vec<u64>>],
 ) -> MergeResult<super::MergeOutput> {
     let config = crate::writer::SETTINGS_STORE
         .get(index_name)
@@ -63,7 +69,6 @@ pub fn merge_unsorted_with_pool(
         output_path
     );
 
-    // Single pass: collect schemas and build readers.
     let mut arrow_schemas: Vec<ArrowSchema> = Vec::with_capacity(input_files.len());
     let mut parquet_descriptors: Vec<SchemaDescriptor> = Vec::with_capacity(input_files.len());
     let mut readers: Vec<ParquetRecordBatchReader> = Vec::with_capacity(input_files.len());
@@ -88,7 +93,6 @@ pub fn merge_unsorted_with_pool(
             .with_projection(projection)
             .build()?;
 
-        // The reader's schema is the projected schema (__row_id__ excluded).
         arrow_schemas.push(reader.schema().as_ref().clone());
         parquet_descriptors.push(parquet_descr);
         readers.push(reader);
@@ -109,20 +113,19 @@ pub fn merge_unsorted_with_pool(
         ctx_reservation,
     )?;
 
-    // Precompute column mappings per reader
     let col_mappings: Vec<ColumnMapping> = arrow_schemas
         .iter()
         .map(|s| ColumnMapping::new(s, ctx.data_schema()))
         .collect();
 
-    // Build row-ID mapping: for unsorted merge, files are concatenated sequentially.
-    // old_row_id maps directly to new_row_id with a per-file offset.
+    // Row-ID mapping: sized to total source rows; dead rows map to -1.
     let total_rows: usize = file_row_counts.iter().sum();
     let mapping_bytes = total_rows * std::mem::size_of::<i64>();
     reservation
         .request(mapping_bytes)
         .map_err(|e| super::MergeError::Logic(format!("Merge pool exceeded (mapping): {}", e)))?;
-    let mut mapping: Vec<i64> = vec![0i64; total_rows];
+    // Indexed by absolute source row id; dead (deleted) rows keep the -1 sentinel.
+    let mut mapping: Vec<i64> = vec![-1i64; total_rows];
     let mut gen_keys: Vec<i64> = Vec::with_capacity(input_files.len());
     let mut gen_offsets: Vec<i32> = Vec::with_capacity(input_files.len());
     let mut gen_sizes: Vec<i32> = Vec::with_capacity(input_files.len());
@@ -130,7 +133,6 @@ pub fn merge_unsorted_with_pool(
     let mut mapping_offset: usize = 0;
     let mut new_row_id: i64 = 0;
 
-    // Iterate readers for data.
     for (file_idx, reader) in readers.into_iter().enumerate() {
         log_debug!(
             "[RUST] Unsorted merge: processing file {} of {}",
@@ -140,13 +142,18 @@ pub fn merge_unsorted_with_pool(
 
         gen_keys.push(file_generations[file_idx]);
         gen_offsets.push(mapping_offset as i32);
-        let file_start_row_id = new_row_id;
+        let file_start_offset = mapping_offset;
+        let file_num_rows = file_row_counts[file_idx];
+        let live_bits: Option<&Vec<u64>> = live_docs_per_input
+            .get(file_idx)
+            .and_then(|opt| opt.as_ref());
 
         let col_mapping = &col_mappings[file_idx];
+        let mut base_row_id: u64 = 0;
         let mut batch_tracked: usize = 0;
         for batch_result in reader {
             let batch = batch_result?;
-            let num_rows = batch.num_rows();
+            let batch_rows = batch.num_rows();
             let batch_bytes = batch.get_array_memory_size();
             // Track reader batch memory: grow on first batch, delta-adjust on subsequent
             if batch_tracked == 0 {
@@ -160,18 +167,43 @@ pub fn merge_unsorted_with_pool(
                 }
                 batch_tracked = batch_bytes;
             }
-            for _ in 0..num_rows {
-                mapping[mapping_offset] = new_row_id;
-                mapping_offset += 1;
-                new_row_id += 1;
+
+            let (filtered, alive_count) = match live_bits {
+                None => {
+                    for _ in 0..batch_rows {
+                        mapping[mapping_offset] = new_row_id;
+                        mapping_offset += 1;
+                        new_row_id += 1;
+                    }
+                    (batch, batch_rows)
+                }
+                Some(bits) => {
+                    let mut mask_values: Vec<bool> = Vec::with_capacity(batch_rows);
+                    let mut alive = 0usize;
+                    for i in 0..batch_rows {
+                        let abs = base_row_id + i as u64;
+                        let alive_flag = is_alive(bits, abs, file_num_rows as u64);
+                        if alive_flag {
+                            mapping[mapping_offset] = new_row_id;
+                            new_row_id += 1;
+                            alive += 1;
+                        }
+                        mapping_offset += 1;
+                        mask_values.push(alive_flag);
+                    }
+                    let mask = BooleanArray::from(mask_values);
+                    (filter_record_batch(&batch, &mask)?, alive)
+                }
+            };
+            base_row_id += batch_rows as u64;
+            if alive_count > 0 {
+                ctx.push_batch(col_mapping.pad_batch(&filtered)?)?;
             }
-            ctx.push_batch(col_mapping.pad_batch(&batch)?)?;
         }
         // File done — release batch memory (reader dropped, batch no longer alive)
         reservation.shrink(batch_tracked);
 
-        let file_rows = (new_row_id - file_start_row_id) as i32;
-        gen_sizes.push(file_rows);
+        gen_sizes.push((mapping_offset - file_start_offset) as i32);
     }
 
     let stats = ctx.finish()?;
@@ -198,4 +230,9 @@ pub fn merge_unsorted_with_pool(
         flush_and_sort_chunk_time_millis: stats.flush_and_sort_chunk_time_millis,
         row_id_mapping_max: stats.row_id_mapping_max,
     })
+}
+
+#[inline]
+fn is_alive(bits: &[u64], abs_row_id: u64, num_rows: u64) -> bool {
+    super::live_docs::is_alive_in_words(bits, num_rows, abs_row_id)
 }

--- a/sandbox/plugins/parquet-data-format/src/main/rust/src/writer.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/src/writer.rs
@@ -792,6 +792,8 @@ impl NativeParquetWriter {
             nulls_first,
             writer_generation,
             &mut merge_reservation,
+            // Chunk finalization merges freshly written chunks; no deletes apply here.
+            &[],
         )
         .map_err(|e| -> Box<dyn std::error::Error> {
             format!("Streaming merge failed: {}", e).into()

--- a/sandbox/plugins/parquet-data-format/src/main/rust/tests/merge_integration_tests.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/tests/merge_integration_tests.rs
@@ -124,7 +124,7 @@ fn test_unsorted_merge_real_files() {
     let output_str = output.to_string_lossy().to_string();
 
     // Empty sort columns → unsorted merge
-    merge_unsorted(&files, &output_str, "test-index", 0).unwrap();
+    merge_unsorted(&files, &output_str, "test-index", 0, &[]).unwrap();
 
     assert!(output.exists(), "Output file was not created");
     let actual_rows = count_rows(&output_str);
@@ -193,6 +193,7 @@ fn test_sorted_merge_real_files() {
         &reverse,
         &nulls_first,
         0,
+        &[],
     )
     .unwrap();
 
@@ -305,6 +306,7 @@ fn test_tier2_yield_after_batch_boundary() {
         &[false],
         &[false],
         0,
+        &[],
     )
     .unwrap();
 
@@ -362,6 +364,7 @@ fn test_tier2_yield_multiple_cursors() {
         &[false],
         &[false],
         0,
+        &[],
     )
     .unwrap();
 
@@ -413,6 +416,7 @@ fn test_tier2_yield_descending() {
         &[true],
         &[false],
         0,
+        &[],
     )
     .unwrap();
 
@@ -464,6 +468,7 @@ fn test_tier2_no_yield_when_equal_to_heap_top() {
         &[false],
         &[false],
         0,
+        &[],
     )
     .unwrap();
 
@@ -517,6 +522,7 @@ fn test_tier2_yield_many_small_batches() {
         &[false],
         &[false],
         0,
+        &[],
     )
     .unwrap();
 
@@ -634,6 +640,7 @@ fn test_default_settings_ascending_nulls_last() {
         &[false],
         &[false],
         0,
+        &[],
     )
     .unwrap();
 
@@ -693,6 +700,7 @@ fn test_default_settings_descending_nulls_last() {
         &[true],
         &[false],
         0,
+        &[],
     )
     .unwrap();
 
@@ -764,6 +772,7 @@ fn test_default_settings_ascending_nulls_first() {
         &[false],
         &[true],
         0,
+        &[],
     )
     .unwrap();
 
@@ -826,6 +835,7 @@ fn test_single_large_file_passthrough() {
         &[false],
         &[false],
         0,
+        &[],
     )
     .unwrap();
 
@@ -881,6 +891,7 @@ fn test_skewed_file_sizes_large_small() {
         &[false],
         &[false],
         0,
+        &[],
     )
     .unwrap();
 
@@ -957,6 +968,7 @@ fn test_three_files_middle_exhausts_first() {
         &[false],
         &[false],
         0,
+        &[],
     )
     .unwrap();
 
@@ -1015,6 +1027,7 @@ fn test_all_duplicate_sort_keys_large() {
         &[false],
         &[false],
         0,
+        &[],
     )
     .unwrap();
 
@@ -1073,6 +1086,7 @@ fn test_non_multiple_of_batch_size() {
         &[false],
         &[false],
         0,
+        &[],
     )
     .unwrap();
 
@@ -1133,6 +1147,7 @@ fn test_rg_size_overshoots_when_batch_straddles_threshold() {
         &[false],
         &[false],
         0,
+        &[],
     )
     .unwrap();
 
@@ -1260,6 +1275,7 @@ fn test_deferred_wide_schema_correctness() {
         &[false],
         &[false],
         0,
+        &[],
     )
     .unwrap();
 
@@ -1330,6 +1346,7 @@ fn test_eager_forced_by_high_threshold() {
         &[false],
         &[false],
         0,
+        &[],
     )
     .unwrap();
 
@@ -1391,6 +1408,7 @@ fn test_deferred_multi_batch_sync() {
         &[false],
         &[false],
         0,
+        &[],
     )
     .unwrap();
 
@@ -1452,6 +1470,7 @@ fn test_deferred_tier3_interleaved() {
         &[false],
         &[false],
         0,
+        &[],
     )
     .unwrap();
 
@@ -1518,6 +1537,7 @@ fn test_deferred_vs_eager_identical_output() {
         &[false],
         &[false],
         0,
+        &[],
     )
     .unwrap();
 
@@ -1537,6 +1557,7 @@ fn test_deferred_vs_eager_identical_output() {
         &[false],
         &[false],
         0,
+        &[],
     )
     .unwrap();
 
@@ -1609,6 +1630,7 @@ fn test_deferred_tier1_single_cursor_drain() {
         &[false],
         &[false],
         0,
+        &[],
     )
     .unwrap();
 
@@ -1673,6 +1695,7 @@ fn test_deferred_tier1_multi_batch_drain() {
         &[false],
         &[false],
         0,
+        &[],
     )
     .unwrap();
 
@@ -1736,6 +1759,7 @@ fn test_deferred_tier2_full_batch_emit() {
         &[false],
         &[false],
         0,
+        &[],
     )
     .unwrap();
 
@@ -1799,7 +1823,8 @@ fn test_deferred_tier2_descending() {
         &["ts".into()],
         &[true],
         &[false],
-        0, // reverse=true (descending)
+        0, // reverse=true (descending),
+        &[],
     )
     .unwrap();
 
@@ -1871,6 +1896,7 @@ fn test_deferred_tier3_many_cursors() {
         &[false],
         &[false],
         0,
+        &[],
     )
     .unwrap();
 
@@ -1945,6 +1971,7 @@ fn test_deferred_different_schemas() {
         &[false],
         &[false],
         0,
+        &[],
     )
     .unwrap();
 
@@ -2075,6 +2102,7 @@ fn test_deferred_three_files_different_schemas() {
         &[false],
         &[false],
         0,
+        &[],
     )
     .unwrap();
 

--- a/sandbox/plugins/parquet-data-format/src/main/rust/tests/merge_with_deletes_tests.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/tests/merge_with_deletes_tests.rs
@@ -1,0 +1,335 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+//! End-to-end tests for the live-docs path of merge_sorted and merge_unsorted.
+//! Inputs are tiny self-contained Parquet files; outputs are read back and the
+//! surviving rows compared against expectations.
+
+use std::fs::File;
+use std::sync::Arc;
+
+use arrow::array::*;
+use arrow::datatypes::{DataType, Field, Schema};
+use opensearch_parquet_format::merge::{merge_sorted, merge_unsorted};
+use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+use parquet::arrow::ArrowWriter;
+use tempfile::tempdir;
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+fn write_parquet(path: &str, batch: &RecordBatch) {
+    let file = File::create(path).unwrap();
+    let mut writer = ArrowWriter::try_new(file, batch.schema(), None).unwrap();
+    writer.write(batch).unwrap();
+    writer.close().unwrap();
+}
+
+fn read_int64_col(path: &str, col: &str) -> Vec<i64> {
+    let file = File::open(path).unwrap();
+    let reader = ParquetRecordBatchReaderBuilder::try_new(file)
+        .unwrap()
+        .build()
+        .unwrap();
+    let mut vals = Vec::new();
+    for batch in reader {
+        let batch = batch.unwrap();
+        let idx = batch.schema().index_of(col).unwrap();
+        let arr = batch
+            .column(idx)
+            .as_primitive::<arrow::datatypes::Int64Type>();
+        for i in 0..arr.len() {
+            vals.push(arr.value(i));
+        }
+    }
+    vals
+}
+
+fn count_rows(path: &str) -> usize {
+    let file = File::open(path).unwrap();
+    let reader = ParquetRecordBatchReaderBuilder::try_new(file)
+        .unwrap()
+        .build()
+        .unwrap();
+    reader.map(|b| b.unwrap().num_rows()).sum()
+}
+
+/// Pack alive-row positions into a Lucene-layout bitmap.
+fn pack_bits(num_rows: usize, alive: &[usize]) -> Vec<u64> {
+    let words = (num_rows + 63) / 64;
+    let mut bits = vec![0u64; words];
+    for &row in alive {
+        bits[row / 64] |= 1u64 << (row % 64);
+    }
+    bits
+}
+
+fn write_int64_file(path: &str, vals: Vec<i64>) {
+    let schema = Arc::new(Schema::new(vec![Field::new("val", DataType::Int64, false)]));
+    let batch = RecordBatch::try_new(schema, vec![Arc::new(Int64Array::from(vals))]).unwrap();
+    write_parquet(path, &batch);
+}
+
+// ─── Sorted merge ───────────────────────────────────────────────────────────
+
+#[test]
+fn sorted_merge_with_no_deletes_returns_full_output() {
+    let tmp = tempdir().unwrap();
+    let f1 = tmp.path().join("a.parquet").to_string_lossy().to_string();
+    let f2 = tmp.path().join("b.parquet").to_string_lossy().to_string();
+    write_int64_file(&f1, vec![1, 3, 5]);
+    write_int64_file(&f2, vec![2, 4, 6]);
+
+    let out = tmp
+        .path()
+        .join("merged.parquet")
+        .to_string_lossy()
+        .to_string();
+    merge_sorted(
+        &[f1, f2],
+        &out,
+        "test",
+        &["val".into()],
+        &[false],
+        &[false],
+        0,
+        &[None, None],
+    )
+    .unwrap();
+
+    let vals = read_int64_col(&out, "val");
+    assert_eq!(vals, vec![1, 2, 3, 4, 5, 6]);
+}
+
+#[test]
+fn sorted_merge_drops_deleted_rows() {
+    let tmp = tempdir().unwrap();
+    let f1 = tmp.path().join("a.parquet").to_string_lossy().to_string();
+    let f2 = tmp.path().join("b.parquet").to_string_lossy().to_string();
+    write_int64_file(&f1, vec![1, 3, 5]);
+    write_int64_file(&f2, vec![2, 4, 6]);
+
+    // Drop row 1 from each file (i.e. value 3 from f1, value 4 from f2).
+    let f1_alive = pack_bits(3, &[0, 2]);
+    let f2_alive = pack_bits(3, &[0, 2]);
+
+    let out = tmp
+        .path()
+        .join("merged.parquet")
+        .to_string_lossy()
+        .to_string();
+    merge_sorted(
+        &[f1, f2],
+        &out,
+        "test",
+        &["val".into()],
+        &[false],
+        &[false],
+        0,
+        &[Some(f1_alive), Some(f2_alive)],
+    )
+    .unwrap();
+
+    let vals = read_int64_col(&out, "val");
+    assert_eq!(vals, vec![1, 2, 5, 6]);
+    assert_eq!(count_rows(&out), 4);
+}
+
+#[test]
+fn sorted_merge_with_one_file_fully_dead() {
+    let tmp = tempdir().unwrap();
+    let f1 = tmp.path().join("a.parquet").to_string_lossy().to_string();
+    let f2 = tmp.path().join("b.parquet").to_string_lossy().to_string();
+    write_int64_file(&f1, vec![1, 3, 5]);
+    write_int64_file(&f2, vec![2, 4, 6]);
+
+    let f1_all_dead = pack_bits(3, &[]);
+
+    let out = tmp
+        .path()
+        .join("merged.parquet")
+        .to_string_lossy()
+        .to_string();
+    merge_sorted(
+        &[f1, f2],
+        &out,
+        "test",
+        &["val".into()],
+        &[false],
+        &[false],
+        0,
+        &[Some(f1_all_dead), None],
+    )
+    .unwrap();
+
+    let vals = read_int64_col(&out, "val");
+    assert_eq!(vals, vec![2, 4, 6]);
+}
+
+#[test]
+fn sorted_merge_drops_first_row_so_initial_heap_value_is_alive() {
+    let tmp = tempdir().unwrap();
+    let f1 = tmp.path().join("a.parquet").to_string_lossy().to_string();
+    write_int64_file(&f1, vec![1, 3, 5]);
+
+    // Drop row 0 (val=1). Initial heap value must be 3, not 1.
+    let alive = pack_bits(3, &[1, 2]);
+
+    let out = tmp
+        .path()
+        .join("merged.parquet")
+        .to_string_lossy()
+        .to_string();
+    merge_sorted(
+        &[f1],
+        &out,
+        "test",
+        &["val".into()],
+        &[false],
+        &[false],
+        0,
+        &[Some(alive)],
+    )
+    .unwrap();
+
+    let vals = read_int64_col(&out, "val");
+    assert_eq!(vals, vec![3, 5]);
+}
+
+#[test]
+fn sorted_merge_with_padding_treats_extra_inputs_as_all_alive() {
+    let tmp = tempdir().unwrap();
+    let f1 = tmp.path().join("a.parquet").to_string_lossy().to_string();
+    let f2 = tmp.path().join("b.parquet").to_string_lossy().to_string();
+    write_int64_file(&f1, vec![1, 3, 5]);
+    write_int64_file(&f2, vec![2, 4, 6]);
+
+    // Provide live-docs for f1 only; f2 gets padded to None ⇒ all alive.
+    let f1_alive = pack_bits(3, &[0, 1, 2]);
+
+    let out = tmp
+        .path()
+        .join("merged.parquet")
+        .to_string_lossy()
+        .to_string();
+    merge_sorted(
+        &[f1, f2],
+        &out,
+        "test",
+        &["val".into()],
+        &[false],
+        &[false],
+        0,
+        &[Some(f1_alive)],
+    )
+    .unwrap();
+
+    let vals = read_int64_col(&out, "val");
+    assert_eq!(vals, vec![1, 2, 3, 4, 5, 6]);
+}
+
+// ─── Unsorted merge ─────────────────────────────────────────────────────────
+
+#[test]
+fn unsorted_merge_with_no_deletes_returns_full_output() {
+    let tmp = tempdir().unwrap();
+    let f1 = tmp.path().join("a.parquet").to_string_lossy().to_string();
+    let f2 = tmp.path().join("b.parquet").to_string_lossy().to_string();
+    write_int64_file(&f1, vec![10, 20, 30]);
+    write_int64_file(&f2, vec![40, 50]);
+
+    let out = tmp
+        .path()
+        .join("merged.parquet")
+        .to_string_lossy()
+        .to_string();
+    merge_unsorted(&[f1, f2], &out, "test", 0, &[None, None]).unwrap();
+
+    let vals = read_int64_col(&out, "val");
+    assert_eq!(vals, vec![10, 20, 30, 40, 50]);
+}
+
+#[test]
+fn unsorted_merge_drops_deleted_rows() {
+    let tmp = tempdir().unwrap();
+    let f1 = tmp.path().join("a.parquet").to_string_lossy().to_string();
+    let f2 = tmp.path().join("b.parquet").to_string_lossy().to_string();
+    write_int64_file(&f1, vec![10, 20, 30]);
+    write_int64_file(&f2, vec![40, 50]);
+
+    // Keep rows 0 and 2 from f1 (values 10, 30); keep row 1 from f2 (value 50).
+    let f1_alive = pack_bits(3, &[0, 2]);
+    let f2_alive = pack_bits(2, &[1]);
+
+    let out = tmp
+        .path()
+        .join("merged.parquet")
+        .to_string_lossy()
+        .to_string();
+    merge_unsorted(
+        &[f1, f2],
+        &out,
+        "test",
+        0,
+        &[Some(f1_alive), Some(f2_alive)],
+    )
+    .unwrap();
+
+    let vals = read_int64_col(&out, "val");
+    assert_eq!(vals, vec![10, 30, 50]);
+}
+
+#[test]
+fn unsorted_merge_skips_entirely_dead_input_file() {
+    let tmp = tempdir().unwrap();
+    let f1 = tmp.path().join("a.parquet").to_string_lossy().to_string();
+    let f2 = tmp.path().join("b.parquet").to_string_lossy().to_string();
+    write_int64_file(&f1, vec![10, 20, 30]);
+    write_int64_file(&f2, vec![40, 50]);
+
+    let f1_all_dead = pack_bits(3, &[]);
+
+    let out = tmp
+        .path()
+        .join("merged.parquet")
+        .to_string_lossy()
+        .to_string();
+    merge_unsorted(&[f1, f2], &out, "test", 0, &[Some(f1_all_dead), None]).unwrap();
+
+    let vals = read_int64_col(&out, "val");
+    assert_eq!(vals, vec![40, 50]);
+}
+
+#[test]
+fn unsorted_merge_assigns_sequential_row_ids_after_deletes() {
+    let tmp = tempdir().unwrap();
+    let f1 = tmp.path().join("a.parquet").to_string_lossy().to_string();
+    let f2 = tmp.path().join("b.parquet").to_string_lossy().to_string();
+    write_int64_file(&f1, vec![10, 20, 30, 40]);
+    write_int64_file(&f2, vec![50, 60]);
+
+    // Drop two rows; the merger writes sequential __row_id__ across surviving rows.
+    let f1_alive = pack_bits(4, &[0, 2]);
+    let f2_alive = pack_bits(2, &[1]);
+
+    let out = tmp
+        .path()
+        .join("merged.parquet")
+        .to_string_lossy()
+        .to_string();
+    merge_unsorted(
+        &[f1, f2],
+        &out,
+        "test",
+        0,
+        &[Some(f1_alive), Some(f2_alive)],
+    )
+    .unwrap();
+
+    let row_ids = read_int64_col(&out, "__row_id__");
+    assert_eq!(row_ids, vec![0, 1, 2]);
+}

--- a/sandbox/plugins/parquet-data-format/src/main/rust/tests/sort_types_tests.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/tests/sort_types_tests.rs
@@ -136,6 +136,7 @@ fn test_merge_sort_by_int64() {
         &[false],
         &[false],
         0,
+        &[],
     )
     .unwrap();
 
@@ -190,6 +191,7 @@ fn test_merge_sort_by_int64_with_nulls() {
         &[false],
         &[false],
         0,
+        &[],
     )
     .unwrap();
 
@@ -241,6 +243,7 @@ fn test_merge_sort_by_int32() {
         &[false],
         &[false],
         0,
+        &[],
     )
     .unwrap();
 
@@ -297,6 +300,7 @@ fn test_merge_sort_by_float64() {
         &[false],
         &[false],
         0,
+        &[],
     )
     .unwrap();
 
@@ -361,6 +365,7 @@ fn test_merge_sort_by_float64_with_nulls() {
         &[false],
         &[true],
         0,
+        &[],
     )
     .unwrap();
 
@@ -419,6 +424,7 @@ fn test_merge_sort_by_float32() {
         &[false],
         &[false],
         0,
+        &[],
     )
     .unwrap();
 
@@ -479,6 +485,7 @@ fn test_merge_sort_by_float32_with_nulls() {
         &[false],
         &[false],
         0,
+        &[],
     )
     .unwrap();
 
@@ -533,6 +540,7 @@ fn test_merge_sort_by_string() {
         &[false],
         &[false],
         0,
+        &[],
     )
     .unwrap();
 
@@ -596,6 +604,7 @@ fn test_merge_sort_by_string_with_nulls() {
         &[false],
         &[true],
         0,
+        &[],
     )
     .unwrap();
 
@@ -663,6 +672,7 @@ fn test_merge_sort_descending() {
         &[true],
         &[false],
         0,
+        &[],
     )
     .unwrap();
 
@@ -727,6 +737,7 @@ fn test_merge_sort_multi_column_string_and_int() {
         &[false, false],
         &[false, false],
         0,
+        &[],
     )
     .unwrap();
 
@@ -788,6 +799,7 @@ fn test_merge_sort_with_nulls_first() {
         &[false],
         &[true],
         0,
+        &[],
     )
     .unwrap();
 
@@ -838,6 +850,7 @@ fn test_merge_sort_with_nulls_last() {
         &[false],
         &[false],
         0,
+        &[],
     )
     .unwrap();
 

--- a/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/bridge/ParquetMergeIntegrationTests.java
+++ b/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/bridge/ParquetMergeIntegrationTests.java
@@ -122,6 +122,88 @@ public class ParquetMergeIntegrationTests extends OpenSearchTestCase {
         RustBridge.removeSettings(INDEX_NAME);
     }
 
+    // ========== Live-docs delete filtering ==========
+
+    /** Rows flagged dead in the live-docs bitset are dropped from the merged output. */
+    public void testMergeWithLiveDocsDropsDeletedRows() throws Exception {
+        NativeSettings settings = NativeSettings.builder().indexName(INDEX_NAME).compressionType("LZ4_RAW").build();
+        RustBridge.onSettingsUpdate(settings);
+
+        Path tempDir = createTempDir();
+        String file1 = createSortedFile(tempDir, "f1.parquet", new long[] { 100, 200, 300 }, new String[] { "a", "b", "c" });
+        String file2 = createSortedFile(tempDir, "f2.parquet", new long[] { 400, 500, 600 }, new String[] { "d", "e", "f" });
+
+        // file1: rows 0 and 2 alive, row 1 dead. file2: only row 1 alive.
+        long[][] liveBits = new long[][] { { 0b101L }, { 0b010L } };
+
+        String mergedFile = tempDir.resolve("merged.parquet").toString();
+        RustBridge.mergeParquetFilesInRust(List.of(Path.of(file1), Path.of(file2)), liveBits, mergedFile, INDEX_NAME, 0L);
+
+        assertEquals("2 rows from file1 + 1 row from file2 must survive", 3, RustBridge.getFileMetadata(mergedFile).numRows());
+
+        RustBridge.removeSettings(INDEX_NAME);
+    }
+
+    /** A null bitset entry disables filtering for that file only. */
+    public void testMergeWithNullLiveDocsEntryKeepsFileUnfiltered() throws Exception {
+        NativeSettings settings = NativeSettings.builder().indexName(INDEX_NAME).compressionType("LZ4_RAW").build();
+        RustBridge.onSettingsUpdate(settings);
+
+        Path tempDir = createTempDir();
+        String file1 = createSortedFile(tempDir, "f1.parquet", new long[] { 100, 200, 300 }, new String[] { "a", "b", "c" });
+        String file2 = createSortedFile(tempDir, "f2.parquet", new long[] { 400, 500, 600 }, new String[] { "d", "e", "f" });
+
+        // file1 unfiltered (null entry); file2 keeps only row 0.
+        long[][] liveBits = new long[][] { null, { 0b001L } };
+
+        String mergedFile = tempDir.resolve("merged.parquet").toString();
+        RustBridge.mergeParquetFilesInRust(List.of(Path.of(file1), Path.of(file2)), liveBits, mergedFile, INDEX_NAME, 0L);
+
+        assertEquals("3 unfiltered rows + 1 surviving row", 4, RustBridge.getFileMetadata(mergedFile).numRows());
+
+        RustBridge.removeSettings(INDEX_NAME);
+    }
+
+    /** An all-ones bitmap behaves exactly like passing no live-docs at all. */
+    public void testMergeWithAllAliveBitmapKeepsEveryRow() throws Exception {
+        NativeSettings settings = NativeSettings.builder().indexName(INDEX_NAME).compressionType("LZ4_RAW").build();
+        RustBridge.onSettingsUpdate(settings);
+
+        Path tempDir = createTempDir();
+        String file1 = createSortedFile(tempDir, "f1.parquet", new long[] { 100, 200, 300 }, new String[] { "a", "b", "c" });
+        String file2 = createSortedFile(tempDir, "f2.parquet", new long[] { 400, 500, 600 }, new String[] { "d", "e", "f" });
+
+        long[][] liveBits = new long[][] { { 0b111L }, { 0b111L } };
+
+        String mergedFile = tempDir.resolve("merged.parquet").toString();
+        RustBridge.mergeParquetFilesInRust(List.of(Path.of(file1), Path.of(file2)), liveBits, mergedFile, INDEX_NAME, 0L);
+
+        assertEquals(6, RustBridge.getFileMetadata(mergedFile).numRows());
+
+        RustBridge.removeSettings(INDEX_NAME);
+    }
+
+    /** A live-docs array whose length doesn't match the input file count is rejected up front. */
+    public void testMergeWithMismatchedLiveDocsLengthThrows() throws Exception {
+        NativeSettings settings = NativeSettings.builder().indexName(INDEX_NAME).compressionType("LZ4_RAW").build();
+        RustBridge.onSettingsUpdate(settings);
+
+        Path tempDir = createTempDir();
+        String file1 = createSortedFile(tempDir, "f1.parquet", new long[] { 100 }, new String[] { "a" });
+        String file2 = createSortedFile(tempDir, "f2.parquet", new long[] { 200 }, new String[] { "b" });
+
+        long[][] liveBits = new long[][] { { 0b1L } }; // 1 entry for 2 files
+
+        String mergedFile = tempDir.resolve("merged.parquet").toString();
+        IllegalArgumentException ex = expectThrows(
+            IllegalArgumentException.class,
+            () -> RustBridge.mergeParquetFilesInRust(List.of(Path.of(file1), Path.of(file2)), liveBits, mergedFile, INDEX_NAME, 0L)
+        );
+        assertTrue(ex.getMessage().contains("must match"));
+
+        RustBridge.removeSettings(INDEX_NAME);
+    }
+
     /**
      * Creates a sorted Parquet file via the full Rust writer pipeline:
      * createWriter (with sort config) → write → finalizeWriter.

--- a/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/bridge/ParquetMergeIntegrationTests.java
+++ b/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/bridge/ParquetMergeIntegrationTests.java
@@ -76,7 +76,8 @@ public class ParquetMergeIntegrationTests extends OpenSearchTestCase {
 
         // 3. Merge
         String mergedFile = tempDir.resolve("merged.parquet").toString();
-        RustBridge.mergeParquetFilesInRust(List.of(Path.of(file1), Path.of(file2), Path.of(file3)), mergedFile, INDEX_NAME, 0L);
+
+        RustBridge.mergeParquetFilesInRust(List.of(Path.of(file1), Path.of(file2), Path.of(file3)), null, mergedFile, INDEX_NAME, 0L);
 
         // 4. Verify merged output
         ParquetFileMetadata mergedMeta = RustBridge.getFileMetadata(mergedFile);
@@ -97,7 +98,8 @@ public class ParquetMergeIntegrationTests extends OpenSearchTestCase {
         String file2 = createSortedFile(tempDir, "f2.parquet", new long[] { 200, 400, 600 }, new String[] { "b", "d", "f" });
 
         String mergedFile = tempDir.resolve("merged.parquet").toString();
-        RustBridge.mergeParquetFilesInRust(List.of(Path.of(file1), Path.of(file2)), mergedFile, INDEX_NAME, 0L);
+
+        RustBridge.mergeParquetFilesInRust(List.of(Path.of(file1), Path.of(file2)), null, mergedFile, INDEX_NAME, 0L);
 
         assertEquals(6, RustBridge.getFileMetadata(mergedFile).numRows());
 
@@ -112,7 +114,8 @@ public class ParquetMergeIntegrationTests extends OpenSearchTestCase {
         String file1 = createSortedFile(tempDir, "f1.parquet", new long[] { 10, 20, 30 }, new String[] { "x", "y", "z" });
 
         String mergedFile = tempDir.resolve("merged.parquet").toString();
-        RustBridge.mergeParquetFilesInRust(List.of(Path.of(file1)), mergedFile, INDEX_NAME, 0L);
+
+        RustBridge.mergeParquetFilesInRust(List.of(Path.of(file1)), null, mergedFile, INDEX_NAME, 0L);
 
         assertEquals(3, RustBridge.getFileMetadata(mergedFile).numRows());
 

--- a/server/src/main/java/org/apache/lucene/index/MergeIndexWriter.java
+++ b/server/src/main/java/org/apache/lucene/index/MergeIndexWriter.java
@@ -9,8 +9,11 @@
 package org.apache.lucene.index;
 
 import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.IOContext;
 
 import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * An {@link IndexWriter} subclass that exposes Lucene's internal {@code merge(OneMerge)}
@@ -41,12 +44,167 @@ import java.io.IOException;
  * the refresh lock, and only the short {@code commitMerge} window is serialized against
  * refreshes.
  *
+ * <h2>Two-phase merge for cross-format snapshot consistency</h2>
+ *
+ * <p>For composite engines where Lucene is a secondary format, the live-docs snapshot used by
+ * the primary-format merger must match what Lucene will physically drop in {@code mergeMiddle}.
+ * Without coordination, the snapshot is captured later than the primary's bitmap and a delete
+ * arriving in between produces a row-count mismatch across formats. To avoid this,
+ * {@link #prepareMerge(PreparableOneMerge, long)} is invoked first — it runs Lucene's
+ * {@code mergeInit} and then explicitly populates the {@link PreparableOneMerge}'s merge readers
+ * (which causes a copy-on-write flip on each source segment's live docs). The frozen
+ * {@code MergeReader.hardLiveDocs} can then be read by callers to construct the cross-format
+ * bitmap. The subsequent call to {@link #executeMerge(MergePolicy.OneMerge, long)} reuses the
+ * prepared merge object so {@code mergeMiddle} proceeds with the same snapshot. Callers that
+ * do not need the two-phase split simply call {@link #executeMerge}.
+ *
  * @opensearch.experimental
  */
 public class MergeIndexWriter extends IndexWriter {
 
+    private final Map<Long, PreparableOneMerge> preparedMerges = new ConcurrentHashMap<>();
+
     public MergeIndexWriter(Directory d, IndexWriterConfig conf) throws IOException {
         super(d, conf);
+    }
+
+    /**
+     * Forces any in-memory live-docs deletes for the given segment to be persisted to
+     * disk as a {@code .liv} file. Required after a merge whose
+     * {@code carryOverHardDeletes} produced new dead bits on the merged segment, so
+     * the catalog publish that follows sees the {@code .liv} file in
+     * {@link SegmentCommitInfo#files()} and stays consistent with what readers will
+     * see on subsequent refresh.
+     *
+     * <p>Without this, the merged segment's {@code SegmentCommitInfo} reports
+     * {@code hasDeletions() == false} immediately after merge (because
+     * {@code ReaderPool} writes live-docs lazily on flush), so the catalog records
+     * a file set without {@code .liv}; later when a flush triggers the {@code .liv}
+     * write, the leaf has one extra file and the catalog/leaf mismatch surfaces as
+     * {@code "Catalog segment ... has no matching Lucene leaf"} on the next refresh.
+     */
+    public synchronized void flushLiveDocsForMergedSegment(SegmentCommitInfo mergedInfo) throws IOException {
+        ReadersAndUpdates rld = getPooledInstance(mergedInfo, false);
+        if (rld == null) {
+            return;
+        }
+        rld.writeLiveDocs(getDirectory());
+    }
+
+    /**
+     * Prepares a merge by running {@code mergeInit} and populating its merge readers — which
+     * triggers a copy-on-write flip on each source segment's live docs, freezing the snapshot.
+     * Files referenced by each opened reader are pinned via the same per-reader
+     * {@code deleter.incRef} hook Lucene's own {@code mergeMiddle} uses, so they survive the
+     * gap between this call and the eventual {@link #executeMerge} call. The matching
+     * {@code decRef} happens through Lucene's normal {@code closeMergeReaders} cleanup once
+     * the merge runs (success or failure).
+     *
+     * <p>After this returns, callers can read the frozen snapshot through
+     * {@code oneMerge.getMergeReader().get(i).hardLiveDocs} to build a bitmap that matches
+     * exactly what {@code mergeMiddle} will use for physical drops.
+     *
+     * <p>{@link #executeMerge(MergePolicy.OneMerge, long)} must subsequently be invoked with
+     * the same generation; it picks up the prepared merge from an internal map and runs the
+     * rest of the merge. If the parquet phase fails before {@code executeMerge}, the caller
+     * must invoke {@link #abortPreparedMerge(long)} to release reader-pool and deleter refs.
+     *
+     * <p>If this method itself fails partway through {@code initMergeReaders}, it walks
+     * Lucene's standard abort path ({@code setAborted} then {@code merge}) so any readers
+     * that were opened before the failure get closed, their file refs decremented, and
+     * their {@code setIsMerging} flags cleared. Only the original exception is rethrown;
+     * any abort-path failure is suppressed.
+     *
+     * @param oneMerge        the merge to prepare
+     * @param mergeGeneration the writer generation for the merged output segment; used as the
+     *                        coordination key for {@link #executeMerge} and
+     *                        {@link #abortPreparedMerge}
+     */
+    public void prepareMerge(PreparableOneMerge oneMerge, long mergeGeneration) throws IOException {
+        assert preparedMerges.containsKey(mergeGeneration) == false : "prepareMerge invoked for generation "
+            + mergeGeneration
+            + " that already has a prepared merge";
+        synchronized (this) {
+            oneMerge.mergeGen = mergeGeneration;
+            oneMerge.isExternal = false;
+            oneMerge.maxNumSegments = -1;
+            oneMerge.registerDone = true;
+        }
+        // mergeInit asserts !Thread.holdsLock(this); waitApplyForMerge resolves any pending
+        // delete packets covering source segments, _mergeInit creates the output SegmentInfo.
+        mergeInit(oneMerge);
+
+        try {
+            IOContext ctx = IOContext.merge(oneMerge.getStoreMergeInfo());
+            oneMerge.initMergeReaders(sci -> {
+                ReadersAndUpdates rld = getPooledInstance(sci, true);
+                rld.setIsMerging();
+                synchronized (this) {
+                    // Per-reader incRef matches what Lucene's own mergeMiddle does. The matching
+                    // decRef fires from closeMergeReaders during executeMerge cleanup. Per-reader
+                    // accounting (not bulk incRefDeleter) means partial-failure cleanup via
+                    // Lucene's standard abort path balances correctly: only opened readers were
+                    // incRef'd, only opened readers get decRef'd.
+                    return rld.getReaderForMerge(ctx, mr -> {
+                        SegmentInfos perReader = new SegmentInfos(getConfig().getIndexCreatedVersionMajor());
+                        perReader.add(mr.reader.getSegmentInfo());
+                        incRefDeleter(perReader);
+                    });
+                }
+            });
+            preparedMerges.put(mergeGeneration, oneMerge);
+        } catch (Throwable t) {
+            // Ride Lucene's own abort path: setAborted + merge fast-fails inside mergeMiddle's
+            // checkAborted and the surrounding finally runs closeMergeReaders, which closes any
+            // readers we managed to open, decRefs their files (balancing our per-reader incRef),
+            // and clears the setIsMerging flags. We swallow the expected MergeAbortedException
+            // and suppress any other cleanup failure into the original throwable.
+            try {
+                oneMerge.setAborted();
+                merge(oneMerge);
+            } catch (MergePolicy.MergeAbortedException expected) {
+                // expected — cleanup ran in merge()'s finally
+            } catch (Throwable suppress) {
+                t.addSuppressed(suppress);
+            }
+            throw t;
+        }
+    }
+
+    /**
+     * Returns the prepared merge for {@code mergeGeneration} if one exists, removing it from
+     * the internal map. Returns {@code null} if no merge was prepared (or if it has already
+     * been consumed). The caller is responsible for invoking {@link #executeMerge} with the
+     * returned OneMerge — its reader-pool and deleter references must be released by the
+     * surrounding merge cleanup.
+     */
+    public PreparableOneMerge takePreparedMerge(long mergeGeneration) {
+        return preparedMerges.remove(mergeGeneration);
+    }
+
+    /**
+     * Aborts a prepared merge and releases its reader-pool and deleter references.
+     * Callers must invoke this if the parquet (primary) phase fails between
+     * {@link #prepareMerge} and the call to {@link #executeMerge} that would have consumed
+     * the prepared state.
+     *
+     * <p>Marks the prepared merge as aborted and invokes {@link IndexWriter#merge}; the
+     * inner {@code mergeMiddle.checkAborted()} fast-fails with a
+     * {@link MergePolicy.MergeAbortedException} which we swallow here, while the
+     * surrounding finally block in {@code merge()} releases the reader-pool and deleter
+     * references that {@link #prepareMerge} took.
+     */
+    public void abortPreparedMerge(long mergeGeneration) throws IOException {
+        PreparableOneMerge prepared = preparedMerges.remove(mergeGeneration);
+        if (prepared == null) {
+            return;
+        }
+        prepared.setAborted();
+        try {
+            merge(prepared);
+        } catch (MergePolicy.MergeAbortedException expected) {
+            // Cleanup ran inside merge()'s finally block.
+        }
     }
 
     /**
@@ -68,16 +226,22 @@ public class MergeIndexWriter extends IndexWriter {
      * <p>Refresh-lock coordination is handled by the {@code MergedSegmentWarmer} installed on
      * this writer's {@link IndexWriterConfig} — see the class Javadoc for details.
      *
-     * @param oneMerge       the merge to execute
+     * @param oneMerge        the merge to execute. May be a {@link PreparableOneMerge} returned
+     *                        by {@link #takePreparedMerge} (in which case {@code mergeMiddle}
+     *                        reuses the captured snapshot) or a fresh OneMerge (in which case
+     *                        {@code mergeMiddle} captures its own snapshot inline).
      * @param mergeGeneration the writer generation for the merged output segment
      * @throws IOException if the merge fails
      */
     public void executeMerge(MergePolicy.OneMerge oneMerge, long mergeGeneration) throws IOException {
-        synchronized (this) {
-            oneMerge.mergeGen = mergeGeneration;
-            oneMerge.isExternal = false;
-            oneMerge.maxNumSegments = -1;
-            oneMerge.registerDone = true;
+        boolean alreadyRegistered = oneMerge instanceof PreparableOneMerge p && p.readersInitialized();
+        if (alreadyRegistered == false) {
+            synchronized (this) {
+                oneMerge.mergeGen = mergeGeneration;
+                oneMerge.isExternal = false;
+                oneMerge.maxNumSegments = -1;
+                oneMerge.registerDone = true;
+            }
         }
         // merge() must be called without holding the lock — mergeInit asserts !Thread.holdsLock(this).
         // Refresh-lock acquisition happens inside the MergedSegmentWarmer configured on this writer,

--- a/server/src/main/java/org/apache/lucene/index/PreparableOneMerge.java
+++ b/server/src/main/java/org/apache/lucene/index/PreparableOneMerge.java
@@ -1,0 +1,80 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.apache.lucene.index;
+
+import org.apache.lucene.util.Bits;
+import org.apache.lucene.util.FixedBitSet;
+import org.apache.lucene.util.IOFunction;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.ToLongFunction;
+
+/**
+ * A {@link MergePolicy.OneMerge} that supports being prepared (its merge readers populated
+ * and live-docs snapshot frozen via copy-on-write) ahead of {@link IndexWriter#merge}. The
+ * idempotent {@link #initMergeReaders} override lets {@code mergeMiddle} re-enter without
+ * re-snapshotting. Lives in {@code org.apache.lucene.index} to access package-private
+ * Lucene internals.
+ *
+ * @opensearch.experimental
+ */
+public class PreparableOneMerge extends MergePolicy.OneMerge {
+
+    private boolean readersInitialized = false;
+
+    public PreparableOneMerge(List<SegmentCommitInfo> segments) {
+        super(segments);
+    }
+
+    @Override
+    void initMergeReaders(IOFunction<SegmentCommitInfo, MergePolicy.MergeReader> readerFactory) throws IOException {
+        if (readersInitialized) {
+            return;
+        }
+        super.initMergeReaders(readerFactory);
+        readersInitialized = true;
+    }
+
+    public boolean readersInitialized() {
+        return readersInitialized;
+    }
+
+    /**
+     * Packs the per-segment frozen {@code hardLiveDocs} snapshot (FixedBitSet layout, bit set
+     * = alive) keyed by application generation. Segments with no deletes are absent from the
+     * result. Must be invoked after {@link #initMergeReaders} has populated the merge readers.
+     */
+    public Map<Long, long[]> packLiveDocsByGeneration(ToLongFunction<SegmentCommitInfo> generationOf) {
+        List<MergePolicy.MergeReader> readers = getMergeReader();
+        if (readers.isEmpty()) {
+            return Map.of();
+        }
+        Map<Long, long[]> result = new HashMap<>();
+        for (int i = 0; i < readers.size(); i++) {
+            MergePolicy.MergeReader mr = readers.get(i);
+            Bits hardLive = mr.hardLiveDocs;
+            if (hardLive == null) {
+                continue;
+            }
+            long gen = generationOf.applyAsLong(segments.get(i));
+            int maxDoc = mr.reader.maxDoc();
+            FixedBitSet bitSet = new FixedBitSet(maxDoc);
+            for (int d = 0; d < maxDoc; d++) {
+                if (hardLive.get(d)) {
+                    bitSet.set(d);
+                }
+            }
+            result.put(gen, bitSet.getBits());
+        }
+        return result;
+    }
+}

--- a/server/src/main/java/org/opensearch/index/engine/dataformat/LiveDocs.java
+++ b/server/src/main/java/org/opensearch/index/engine/dataformat/LiveDocs.java
@@ -1,0 +1,111 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.engine.dataformat;
+
+import org.opensearch.common.annotation.ExperimentalApi;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Format-neutral per-segment live-docs abstraction.
+ *
+ * <p>Wraps a per-segment bitset indicating which rows are alive (not deleted).
+ * Consumers use this at read time (to filter scan results) and at merge time
+ * (to drop dead rows from the output).
+ *
+ * <p>The internal representation uses Lucene's {@code FixedBitSet#getBits()} layout
+ * (packed {@code long[]} where bit {@code i} set = row {@code i} alive), but consumers
+ * interact through the typed API without knowing the wire format.
+ *
+ * @opensearch.experimental
+ */
+@ExperimentalApi
+public final class LiveDocs {
+
+    /** Singleton representing "all rows alive everywhere" — no filtering needed. */
+    public static final LiveDocs ALL_ALIVE = new LiveDocs(Collections.emptyMap());
+
+    private final Map<Long, long[]> perSegment;
+
+    private LiveDocs(Map<Long, long[]> perSegment) {
+        this.perSegment = perSegment;
+    }
+
+    /**
+     * Creates a LiveDocs instance from raw per-segment bitsets.
+     * Defensively clones each array to prevent aliasing.
+     *
+     * @param rawBitsets map of segment generation → packed bitset (Lucene layout)
+     * @return a new LiveDocs instance
+     */
+    public static LiveDocs fromPackedBits(Map<Long, long[]> rawBitsets) {
+        if (rawBitsets == null || rawBitsets.isEmpty()) {
+            return ALL_ALIVE;
+        }
+        Map<Long, long[]> copy = new HashMap<>(rawBitsets.size());
+        for (Map.Entry<Long, long[]> entry : rawBitsets.entrySet()) {
+            copy.put(entry.getKey(), entry.getValue().clone());
+        }
+        return new LiveDocs(Collections.unmodifiableMap(copy));
+    }
+
+    /**
+     * Returns true if all rows in all segments are alive (no deletes anywhere).
+     */
+    public boolean allAlive() {
+        return perSegment.isEmpty();
+    }
+
+    /**
+     * Returns true if all rows in the given segment are alive.
+     *
+     * @param segmentGeneration the segment generation
+     */
+    public boolean allAlive(long segmentGeneration) {
+        return !perSegment.containsKey(segmentGeneration);
+    }
+
+    /**
+     * Returns true if the row at the given ID in the given segment is alive.
+     *
+     * @param segmentGeneration the segment generation
+     * @param rowId the row ID within the segment
+     */
+    public boolean isAlive(long segmentGeneration, long rowId) {
+        long[] bits = perSegment.get(segmentGeneration);
+        if (bits == null) {
+            return true; // no deletes in this segment
+        }
+        int wordIdx = (int) (rowId / 64);
+        long bitIdx = rowId % 64;
+        if (wordIdx >= bits.length) {
+            return true; // beyond bitset — defensive
+        }
+        return (bits[wordIdx] & (1L << bitIdx)) != 0;
+    }
+
+    /**
+     * Returns the raw packed bitset for a segment, for FFI-friendly consumers (e.g., Rust via JNI).
+     * Returns null if all rows in the segment are alive.
+     *
+     * @param segmentGeneration the segment generation
+     */
+    public long[] packedBits(long segmentGeneration) {
+        return perSegment.get(segmentGeneration);
+    }
+
+    /**
+     * Returns the number of segments that have deletes.
+     */
+    public int segmentsWithDeletes() {
+        return perSegment.size();
+    }
+}

--- a/server/src/main/java/org/opensearch/index/engine/dataformat/MergeInput.java
+++ b/server/src/main/java/org/opensearch/index/engine/dataformat/MergeInput.java
@@ -17,20 +17,25 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * input data for a merge operation.
+ * Input data for a merge operation.
  * Use {@link Builder} to construct instances.
+ *
+ * <p>{@code liveDocs} provides per-segment delete filtering. See {@link LiveDocs} for
+ * the contract. The snapshot is taken once at merge start; mid-merge deletes are not
+ * reflected.</p>
  *
  * @opensearch.experimental
  */
 @ExperimentalApi
-public record MergeInput(List<Segment> segments, RowIdMapping rowIdMapping, long newWriterGeneration) {
+public record MergeInput(List<Segment> segments, RowIdMapping rowIdMapping, long newWriterGeneration, LiveDocs liveDocs) {
 
     public MergeInput {
         segments = List.copyOf(segments);
+        Objects.requireNonNull(liveDocs, "liveDocs must not be null; use LiveDocs.ALL_ALIVE for no filtering");
     }
 
     private MergeInput(Builder builder) {
-        this(new ArrayList<>(builder.segments), builder.rowIdMapping, builder.newWriterGeneration);
+        this(new ArrayList<>(builder.segments), builder.rowIdMapping, builder.newWriterGeneration, builder.liveDocs);
     }
 
     /**
@@ -41,6 +46,14 @@ public record MergeInput(List<Segment> segments, RowIdMapping rowIdMapping, long
      */
     public List<WriterFileSet> getFilesForFormat(String formatName) {
         return segments.stream().map(seg -> seg.dfGroupedSearchableFiles().get(formatName)).filter(Objects::nonNull).toList();
+    }
+
+    /**
+     * Returns the live-docs bitset for the given segment generation, or {@code null} if all
+     * rows in that segment are alive. Convenience delegate to {@link LiveDocs#packedBits(long)}.
+     */
+    public long[] getLiveDocsForSegment(long generation) {
+        return liveDocs.packedBits(generation);
     }
 
     /**
@@ -60,6 +73,7 @@ public record MergeInput(List<Segment> segments, RowIdMapping rowIdMapping, long
         private List<Segment> segments = new ArrayList<>();
         private RowIdMapping rowIdMapping;
         private long newWriterGeneration;
+        private LiveDocs liveDocs = LiveDocs.ALL_ALIVE;
 
         private Builder() {}
 
@@ -104,6 +118,17 @@ public record MergeInput(List<Segment> segments, RowIdMapping rowIdMapping, long
          */
         public Builder newWriterGeneration(long newWriterGeneration) {
             this.newWriterGeneration = newWriterGeneration;
+            return this;
+        }
+
+        /**
+         * Sets the live-docs for delete filtering during merge.
+         *
+         * @param liveDocs the live-docs instance
+         * @return this builder
+         */
+        public Builder liveDocs(LiveDocs liveDocs) {
+            this.liveDocs = Objects.requireNonNull(liveDocs, "liveDocs must not be null; use LiveDocs.ALL_ALIVE");
             return this;
         }
 

--- a/server/src/main/java/org/opensearch/index/engine/dataformat/Merger.java
+++ b/server/src/main/java/org/opensearch/index/engine/dataformat/Merger.java
@@ -26,4 +26,27 @@ public interface Merger {
      * @return merge result containing row ID mapping and merged file metadata
      */
     MergeResult merge(MergeInput mergeInput) throws IOException;
+
+    /**
+     * Optional pre-merge hook. Implementations that need to freeze format-internal state
+     * (e.g. a Lucene secondary capturing its live-docs snapshot via
+     * {@link org.apache.lucene.index.MergeIndexWriter#prepareMerge}) do so here and return a
+     * per-segment {@link LiveDocs} reflecting that frozen view, so the primary-format merger
+     * drops the same rows the secondary will physically drop.
+     *
+     * <p>If the returned LiveDocs is non-empty, the caller must subsequently invoke
+     * {@link #merge} or {@link #abortPreparedMerge} with the same generation to release any
+     * resources taken here. Default returns {@link LiveDocs#ALL_ALIVE} (no-op).
+     */
+    default LiveDocs prepareMerge(MergeInput mergeInput) throws IOException {
+        return LiveDocs.ALL_ALIVE;
+    }
+
+    /**
+     * Releases resources acquired by {@link #prepareMerge} when the subsequent
+     * {@link #merge} call won't happen. Default no-op.
+     */
+    default void abortPreparedMerge(MergeInput mergeInput) throws IOException {
+        // no-op
+    }
 }

--- a/server/src/main/java/org/opensearch/index/engine/dataformat/merge/MergeHandler.java
+++ b/server/src/main/java/org/opensearch/index/engine/dataformat/merge/MergeHandler.java
@@ -243,7 +243,7 @@ public class MergeHandler {
     }
 
     /**
-     * Executes the given merge operation by delegating to the {@link Merger}.
+     * Executes the given merge by delegating to the {@link Merger}.
      *
      * @param oneMerge the merge to execute
      * @return the result of the merge
@@ -253,7 +253,9 @@ public class MergeHandler {
         assert oneMerge.getSegmentsToMerge().isEmpty() == false : "merge must have at least one segment";
         long generation = generationProvider.get();
         assert generation > 0 : "merge writer generation must be positive but was: " + generation;
+
         MergeInput mergeInput = MergeInput.builder().segments(oneMerge.getSegmentsToMerge()).newWriterGeneration(generation).build();
+
         MergeResult result = merger.merge(mergeInput);
         assert result != null : "merger must return a non-null MergeResult";
         assert result.getMergedWriterFileSet().isEmpty() == false : "merge result must contain at least one format's files";

--- a/server/src/main/java/org/opensearch/index/engine/exec/coord/CatalogSnapshotManager.java
+++ b/server/src/main/java/org/opensearch/index/engine/exec/coord/CatalogSnapshotManager.java
@@ -175,7 +175,9 @@ public class CatalogSnapshotManager implements Closeable {
             );
         }
 
-        // Row count conservation: merged output must have the same total rows as the inputs
+        // Row count conservation: merged output must not exceed sum of input rows.
+        // Compaction with deletes may drop rows, so the merged total can be lower —
+        // only a merged count strictly greater than the source total is an invariant violation.
         if (!assertRowCountConservation(segmentsToRemove, segmentToAdd)) {
             long inputRows = segmentsToRemove.stream()
                 .flatMap(s -> s.dfGroupedSearchableFiles().values().stream())
@@ -660,9 +662,10 @@ public class CatalogSnapshotManager implements Closeable {
     }
 
     /**
-     * Asserts that the total row count across all formats in the merged segment equals
-     * the total row count across all formats in the source segments. This catches bugs
-     * where rows are silently dropped or duplicated during merge.
+     * Asserts that the total row count across all formats in the merged segment does not
+     * exceed the total row count across all formats in the source segments. Catches bugs
+     * where rows are duplicated during merge. Rows may be legitimately dropped when the
+     * merger compacts deleted rows (see {@code MergeInput#liveDocs}).
      */
     private boolean assertRowCountConservation(Set<Segment> sourceSegments, Segment mergedSegment) {
         long sourceRows = 0;
@@ -675,7 +678,7 @@ public class CatalogSnapshotManager implements Closeable {
         for (WriterFileSet wfs : mergedSegment.dfGroupedSearchableFiles().values()) {
             mergedRows += wfs.numRows();
         }
-        if (sourceRows != mergedRows) {
+        if (mergedRows > sourceRows) {
             logger.error("Row count mismatch: source segments have {} rows but merged segment has {} rows", sourceRows, mergedRows);
             return false;
         }

--- a/server/src/test/java/org/opensearch/index/engine/dataformat/LiveDocsTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/dataformat/LiveDocsTests.java
@@ -1,0 +1,119 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.engine.dataformat;
+
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Unit tests for {@link LiveDocs}.
+ */
+public class LiveDocsTests extends OpenSearchTestCase {
+
+    // ========== fromPackedBits ==========
+
+    public void testFromPackedBitsNullReturnsAllAlive() {
+        assertSame(LiveDocs.ALL_ALIVE, LiveDocs.fromPackedBits(null));
+    }
+
+    public void testFromPackedBitsEmptyMapReturnsAllAlive() {
+        assertSame(LiveDocs.ALL_ALIVE, LiveDocs.fromPackedBits(Map.of()));
+    }
+
+    public void testFromPackedBitsDefensivelyClonesArrays() {
+        long[] bits = new long[] { 0b101L };
+        Map<Long, long[]> raw = new HashMap<>();
+        raw.put(1L, bits);
+        LiveDocs liveDocs = LiveDocs.fromPackedBits(raw);
+
+        assertTrue(liveDocs.isAlive(1L, 0));
+        assertFalse(liveDocs.isAlive(1L, 1));
+
+        // Mutating the caller's array must not affect the LiveDocs instance.
+        bits[0] = 0L;
+        assertTrue("LiveDocs must clone input arrays", liveDocs.isAlive(1L, 0));
+    }
+
+    // ========== allAlive ==========
+
+    public void testAllAliveSingleton() {
+        assertTrue(LiveDocs.ALL_ALIVE.allAlive());
+        assertTrue(LiveDocs.ALL_ALIVE.allAlive(randomLong()));
+        assertEquals(0, LiveDocs.ALL_ALIVE.segmentsWithDeletes());
+    }
+
+    public void testAllAliveFalseWhenSegmentHasDeletes() {
+        LiveDocs liveDocs = LiveDocs.fromPackedBits(Map.of(5L, new long[] { 0b1L }));
+        assertFalse(liveDocs.allAlive());
+        assertFalse(liveDocs.allAlive(5L));
+        assertTrue("other segments have no deletes", liveDocs.allAlive(6L));
+        assertEquals(1, liveDocs.segmentsWithDeletes());
+    }
+
+    // ========== isAlive ==========
+
+    public void testIsAliveReadsBits() {
+        // rows 0 and 2 alive, row 1 dead
+        LiveDocs liveDocs = LiveDocs.fromPackedBits(Map.of(1L, new long[] { 0b101L }));
+        assertTrue(liveDocs.isAlive(1L, 0));
+        assertFalse(liveDocs.isAlive(1L, 1));
+        assertTrue(liveDocs.isAlive(1L, 2));
+    }
+
+    public void testIsAliveForSegmentWithoutDeletesReturnsTrue() {
+        LiveDocs liveDocs = LiveDocs.fromPackedBits(Map.of(1L, new long[] { 0b101L }));
+        // Segment 2 has no entry — everything is alive.
+        assertTrue(liveDocs.isAlive(2L, 0));
+        assertTrue(liveDocs.isAlive(2L, randomLongBetween(0, 1_000_000)));
+    }
+
+    public void testIsAliveAtWordBoundaries() {
+        // Word 0: only bit 63 set. Word 1: only bit 0 set (row 64).
+        long[] bits = new long[] { 1L << 63, 1L };
+        LiveDocs liveDocs = LiveDocs.fromPackedBits(Map.of(1L, bits));
+
+        assertTrue(liveDocs.isAlive(1L, 63));
+        assertTrue(liveDocs.isAlive(1L, 64));
+        assertFalse(liveDocs.isAlive(1L, 62));
+        assertFalse(liveDocs.isAlive(1L, 65));
+    }
+
+    public void testIsAliveBeyondBitsetReturnsTrueDefensively() {
+        LiveDocs liveDocs = LiveDocs.fromPackedBits(Map.of(1L, new long[] { 0L }));
+        // Word index 1 is beyond the one-word bitset — treated as alive.
+        assertTrue(liveDocs.isAlive(1L, 64));
+        assertTrue(liveDocs.isAlive(1L, 1_000_000));
+        // Within the bitset, all bits are 0 — dead.
+        assertFalse(liveDocs.isAlive(1L, 0));
+        assertFalse(liveDocs.isAlive(1L, 63));
+    }
+
+    // ========== packedBits ==========
+
+    public void testPackedBitsReturnsBitsForSegmentWithDeletes() {
+        long[] bits = new long[] { 0b1011L };
+        LiveDocs liveDocs = LiveDocs.fromPackedBits(Map.of(7L, bits));
+        assertArrayEquals(bits, liveDocs.packedBits(7L));
+    }
+
+    public void testPackedBitsReturnsNullForSegmentWithoutDeletes() {
+        LiveDocs liveDocs = LiveDocs.fromPackedBits(Map.of(7L, new long[] { 0b1L }));
+        assertNull(liveDocs.packedBits(8L));
+        assertNull(LiveDocs.ALL_ALIVE.packedBits(7L));
+    }
+
+    // ========== segmentsWithDeletes ==========
+
+    public void testSegmentsWithDeletesCountsEntries() {
+        LiveDocs liveDocs = LiveDocs.fromPackedBits(Map.of(1L, new long[] { 0b1L }, 2L, new long[] { 0b10L }));
+        assertEquals(2, liveDocs.segmentsWithDeletes());
+    }
+}

--- a/server/src/test/java/org/opensearch/index/engine/dataformat/MergeInputTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/dataformat/MergeInputTests.java
@@ -1,0 +1,90 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.engine.dataformat;
+
+import org.opensearch.index.engine.exec.Segment;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Unit tests for {@link MergeInput} live-docs plumbing and the {@link Merger}
+ * prepare/abort default implementations.
+ */
+public class MergeInputTests extends OpenSearchTestCase {
+
+    // ========== liveDocs defaults and validation ==========
+
+    public void testBuilderDefaultsLiveDocsToAllAlive() {
+        MergeInput input = MergeInput.builder().segments(List.of()).newWriterGeneration(1L).build();
+        assertSame(LiveDocs.ALL_ALIVE, input.liveDocs());
+    }
+
+    public void testBuilderRejectsNullLiveDocs() {
+        NullPointerException e = expectThrows(NullPointerException.class, () -> MergeInput.builder().liveDocs(null));
+        assertTrue(e.getMessage().contains("liveDocs must not be null"));
+    }
+
+    public void testCanonicalConstructorRejectsNullLiveDocs() {
+        NullPointerException e = expectThrows(NullPointerException.class, () -> new MergeInput(List.of(), null, 1L, null));
+        assertTrue(e.getMessage().contains("liveDocs must not be null"));
+    }
+
+    public void testBuilderCarriesExplicitLiveDocs() {
+        LiveDocs liveDocs = LiveDocs.fromPackedBits(Map.of(3L, new long[] { 0b1L }));
+        MergeInput input = MergeInput.builder().segments(List.of()).newWriterGeneration(1L).liveDocs(liveDocs).build();
+        assertSame(liveDocs, input.liveDocs());
+    }
+
+    // ========== getLiveDocsForSegment ==========
+
+    public void testGetLiveDocsForSegmentDelegatesToLiveDocs() {
+        long[] bits = new long[] { 0b101L };
+        LiveDocs liveDocs = LiveDocs.fromPackedBits(Map.of(3L, bits));
+        MergeInput input = MergeInput.builder().segments(List.of()).newWriterGeneration(1L).liveDocs(liveDocs).build();
+
+        assertArrayEquals(bits, input.getLiveDocsForSegment(3L));
+        assertNull("segments without deletes must return null", input.getLiveDocsForSegment(4L));
+    }
+
+    public void testGetLiveDocsForSegmentAllAliveReturnsNull() {
+        MergeInput input = MergeInput.builder().segments(List.of()).newWriterGeneration(1L).build();
+        assertNull(input.getLiveDocsForSegment(randomLong()));
+    }
+
+    // ========== segments immutability ==========
+
+    public void testSegmentsAreCopiedDefensively() {
+        List<Segment> segments = new java.util.ArrayList<>();
+        segments.add(Segment.builder(1L).build());
+        MergeInput input = MergeInput.builder().segments(segments).newWriterGeneration(1L).build();
+
+        segments.add(Segment.builder(2L).build());
+        assertEquals("MergeInput must copy the segment list", 1, input.segments().size());
+        expectThrows(UnsupportedOperationException.class, () -> input.segments().add(Segment.builder(3L).build()));
+    }
+
+    // ========== Merger default prepare/abort hooks ==========
+
+    public void testMergerDefaultPrepareMergeReturnsAllAlive() throws IOException {
+        Merger merger = mergeInput -> null; // lambda implements only merge()
+        MergeInput input = MergeInput.builder().segments(List.of()).newWriterGeneration(1L).build();
+
+        assertSame(LiveDocs.ALL_ALIVE, merger.prepareMerge(input));
+    }
+
+    public void testMergerDefaultAbortPreparedMergeIsNoOp() throws IOException {
+        Merger merger = mergeInput -> null;
+        MergeInput input = MergeInput.builder().segments(List.of()).newWriterGeneration(1L).build();
+
+        merger.abortPreparedMerge(input); // must not throw
+    }
+}

--- a/server/src/test/java/org/opensearch/lucene/index/MergeIndexWriterTests.java
+++ b/server/src/test/java/org/opensearch/lucene/index/MergeIndexWriterTests.java
@@ -1,0 +1,377 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.lucene.index;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.MergeIndexWriter;
+import org.apache.lucene.index.MergePolicy;
+import org.apache.lucene.index.NoMergePolicy;
+import org.apache.lucene.index.PreparableOneMerge;
+import org.apache.lucene.index.SegmentCommitInfo;
+import org.apache.lucene.index.SegmentInfos;
+import org.apache.lucene.index.SerialMergeScheduler;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.analysis.MockAnalyzer;
+import org.apache.lucene.util.IOFunction;
+import org.opensearch.common.SuppressForbidden;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.ToLongFunction;
+
+/**
+ * Unit tests for {@link MergeIndexWriter}'s two-phase prepare/execute merge flow and
+ * {@link PreparableOneMerge}.
+ */
+public class MergeIndexWriterTests extends OpenSearchTestCase {
+
+    private Directory directory;
+    private MergeIndexWriter writer;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        directory = newDirectory();
+        writer = new MergeIndexWriter(directory, newConfig());
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        if (writer != null) {
+            writer.close();
+        }
+        if (directory != null) {
+            directory.close();
+        }
+        super.tearDown();
+    }
+
+    private IndexWriterConfig newConfig() {
+        IndexWriterConfig iwc = new IndexWriterConfig(new MockAnalyzer(random()));
+        iwc.setMergeScheduler(new SerialMergeScheduler());
+        iwc.setMergePolicy(NoMergePolicy.INSTANCE);
+        return iwc;
+    }
+
+    // ========== prepareMerge: frozen live-docs snapshot ==========
+
+    /** prepareMerge exposes the frozen hardLiveDocs of segments with deletes; delete-free segments are absent. */
+    public void testPrepareMergeExposesFrozenLiveDocs() throws IOException {
+        addSegment("a", 3); // docids 0..2, ids a_0..a_2
+        addSegment("b", 2); // no deletes
+        writer.deleteDocuments(new Term("id", "a_1"));
+        writer.commit(); // applies the delete: doc 1 of segment a is dead
+
+        List<SegmentCommitInfo> segments = liveSegments();
+        assertEquals(2, segments.size());
+
+        PreparableOneMerge oneMerge = new PreparableOneMerge(segments);
+        long gen = 42L;
+        writer.prepareMerge(oneMerge, gen);
+        try {
+            assertTrue(oneMerge.readersInitialized());
+
+            Map<Long, long[]> packed = oneMerge.packLiveDocsByGeneration(bySegmentOrdinal(segments));
+            assertEquals("only the segment with deletes contributes a bitmap", 1, packed.size());
+
+            long[] bits = packed.get(0L);
+            assertNotNull("segment a (ordinal 0) has deletes", bits);
+            assertEquals(1, bits.length);
+            assertEquals("docs 0 and 2 alive, doc 1 dead", 0b101L, bits[0]);
+        } finally {
+            writer.abortPreparedMerge(gen);
+        }
+    }
+
+    /** The snapshot captured by prepareMerge does not observe deletes applied after preparation. */
+    public void testPrepareMergeSnapshotIsFrozenAgainstLaterDeletes() throws IOException {
+        addSegment("a", 3);
+        addSegment("b", 2);
+        writer.deleteDocuments(new Term("id", "a_1"));
+        writer.commit();
+
+        List<SegmentCommitInfo> segments = liveSegments();
+        PreparableOneMerge oneMerge = new PreparableOneMerge(segments);
+        long gen = 42L;
+        writer.prepareMerge(oneMerge, gen);
+
+        Map<Long, long[]> before = oneMerge.packLiveDocsByGeneration(bySegmentOrdinal(segments));
+
+        // A delete arriving between prepare and execute must not alter the frozen snapshot.
+        writer.deleteDocuments(new Term("id", "b_0"));
+        DirectoryReader.open(writer).close(); // force-apply buffered deletes
+
+        Map<Long, long[]> after = oneMerge.packLiveDocsByGeneration(bySegmentOrdinal(segments));
+        assertEquals(before.keySet(), after.keySet());
+        for (Long key : before.keySet()) {
+            assertArrayEquals("frozen snapshot must not change for ordinal " + key, before.get(key), after.get(key));
+        }
+        assertNull("segment b's late delete must not appear in the frozen snapshot", after.get(1L));
+
+        // Execute: mergeMiddle physically drops only the frozen-dead doc; the late delete is
+        // carried over onto the merged segment as a live-docs delete, not a physical drop.
+        PreparableOneMerge taken = writer.takePreparedMerge(gen);
+        assertSame(oneMerge, taken);
+        writer.executeMerge(taken, gen);
+        writer.commit();
+
+        try (DirectoryReader reader = DirectoryReader.open(writer)) {
+            assertEquals("merged maxDoc drops only the frozen-dead doc", 4, reader.maxDoc());
+            assertEquals("carried-over delete leaves 3 live docs", 3, reader.numDocs());
+        }
+    }
+
+    /** Double-prepare for the same generation trips the guard assertion. */
+    public void testPrepareMergeRejectsDoublePrepare() throws IOException {
+        assumeTrue("requires assertions enabled", MergeIndexWriterTests.class.desiredAssertionStatus());
+        addSegment("a", 2);
+        addSegment("b", 2);
+        writer.commit();
+
+        long gen = 7L;
+        writer.prepareMerge(new PreparableOneMerge(liveSegments()), gen);
+        try {
+            AssertionError err = expectThrows(AssertionError.class, () -> writer.prepareMerge(new PreparableOneMerge(liveSegments()), gen));
+            assertTrue(err.getMessage(), err.getMessage().contains("already has a prepared merge"));
+        } finally {
+            writer.abortPreparedMerge(gen);
+        }
+    }
+
+    // ========== takePreparedMerge ==========
+
+    /** takePreparedMerge drains the entry: the second call returns null; unknown generations return null. */
+    public void testTakePreparedMergeDrainsEntry() throws IOException {
+        addSegment("a", 2);
+        addSegment("b", 2);
+        writer.commit();
+
+        assertNull("nothing prepared yet", writer.takePreparedMerge(5L));
+
+        PreparableOneMerge oneMerge = new PreparableOneMerge(liveSegments());
+        writer.prepareMerge(oneMerge, 5L);
+
+        PreparableOneMerge taken = writer.takePreparedMerge(5L);
+        assertSame(oneMerge, taken);
+        assertNull("entry must be drained", writer.takePreparedMerge(5L));
+
+        // Finish the merge to release reader-pool and deleter refs taken by prepareMerge.
+        writer.executeMerge(taken, 5L);
+        assertEquals("segments merged into one", 1, liveSegments().size());
+    }
+
+    // ========== abortPreparedMerge ==========
+
+    /** abortPreparedMerge releases prepared state; source segments stay intact; unknown generations are a no-op. */
+    public void testAbortPreparedMergeReleasesStateAndKeepsSegments() throws IOException {
+        addSegment("a", 2);
+        addSegment("b", 2);
+        writer.commit();
+
+        long gen = 9L;
+        writer.prepareMerge(new PreparableOneMerge(liveSegments()), gen);
+        writer.abortPreparedMerge(gen);
+
+        assertNull(writer.takePreparedMerge(gen));
+        assertEquals("aborted merge must not touch source segments", 2, liveSegments().size());
+
+        // Idempotent / unknown generation: no-op.
+        writer.abortPreparedMerge(gen);
+        writer.abortPreparedMerge(12345L);
+
+        // The writer must still be fully usable after an abort.
+        addSegment("c", 1);
+        writer.commit();
+        assertEquals(3, liveSegments().size());
+    }
+
+    // ========== executeMerge ==========
+
+    /** executeMerge with a fresh (unprepared) OneMerge registers it inline and merges. */
+    public void testExecuteMergeWithFreshOneMerge() throws IOException {
+        addSegment("a", 3);
+        addSegment("b", 2);
+        writer.commit();
+
+        PreparableOneMerge oneMerge = new PreparableOneMerge(liveSegments());
+        assertFalse(oneMerge.readersInitialized());
+
+        writer.executeMerge(oneMerge, 11L);
+        writer.commit();
+
+        assertEquals(1, liveSegments().size());
+        try (DirectoryReader reader = DirectoryReader.open(writer)) {
+            assertEquals(5, reader.numDocs());
+        }
+    }
+
+    /** executeMerge after prepareMerge physically drops the frozen-dead docs from the merged segment. */
+    public void testExecuteMergeDropsFrozenDeadDocs() throws IOException {
+        addSegment("a", 3);
+        addSegment("b", 2);
+        writer.deleteDocuments(new Term("id", "a_0"), new Term("id", "b_1"));
+        writer.commit();
+
+        long gen = 13L;
+        writer.prepareMerge(new PreparableOneMerge(liveSegments()), gen);
+        writer.executeMerge(writer.takePreparedMerge(gen), gen);
+        writer.commit();
+
+        assertEquals(1, liveSegments().size());
+        try (DirectoryReader reader = DirectoryReader.open(writer)) {
+            assertEquals("both deleted docs must be physically dropped", 3, reader.maxDoc());
+            assertEquals(3, reader.numDocs());
+        }
+    }
+
+    // ========== flushLiveDocsForMergedSegment ==========
+
+    /** No pooled reader state for the segment means no-op. */
+    public void testFlushLiveDocsForMergedSegmentIsNoOpWithoutPooledState() throws IOException {
+        addSegment("a", 2);
+        writer.commit();
+
+        SegmentCommitInfo sci = liveSegments().get(0);
+        writer.flushLiveDocsForMergedSegment(sci); // must not throw
+        assertFalse(sci.hasDeletions());
+    }
+
+    /** In-memory deletes on a pooled segment are forced to a .liv file so files() includes it. */
+    public void testFlushLiveDocsForMergedSegmentWritesLivFile() throws IOException {
+        addSegment("a", 2);
+        writer.commit();
+
+        SegmentCommitInfo sci = liveSegments().get(0);
+        try (DirectoryReader reader = DirectoryReader.open(writer)) {
+            // tryDeleteDocument records the delete directly on the pooled ReadersAndUpdates
+            // without writing the .liv file — mirroring carryOverHardDeletes after a merge.
+            assertTrue(writer.tryDeleteDocument(reader, 0) >= 0);
+
+            assertTrue("no .liv file before the forced flush", sci.files().stream().noneMatch(f -> f.endsWith(".liv")));
+
+            writer.flushLiveDocsForMergedSegment(sci);
+
+            assertTrue("forced flush must persist the .liv file", sci.files().stream().anyMatch(f -> f.endsWith(".liv")));
+            assertTrue(sci.hasDeletions());
+        }
+    }
+
+    // ========== PreparableOneMerge ==========
+
+    /** initMergeReaders is idempotent once prepared — the factory must not be invoked again. */
+    public void testPreparableOneMergeInitMergeReadersIsIdempotent() throws Exception {
+        addSegment("a", 2);
+        addSegment("b", 2);
+        writer.commit();
+
+        PreparableOneMerge oneMerge = new PreparableOneMerge(liveSegments());
+        long gen = 21L;
+        writer.prepareMerge(oneMerge, gen);
+        try {
+            assertTrue(oneMerge.readersInitialized());
+            // A second init must be a no-op: the factory below would fail the test if invoked.
+            // (MergePolicy.MergeReader is package-private; erasure lets us pass Object here
+            // since the factory unconditionally throws and never produces a value.)
+            IOFunction<SegmentCommitInfo, Object> throwingFactory = sci -> {
+                throw new IOException("factory must not be re-invoked after prepare");
+            };
+            invokeInitMergeReaders(oneMerge, throwingFactory);
+        } finally {
+            writer.abortPreparedMerge(gen);
+        }
+    }
+
+    /** Invokes the package-private {@code initMergeReaders} via reflection. */
+    @SuppressForbidden(reason = "Reflection needed to invoke package-private initMergeReaders from outside org.apache.lucene.index")
+    private static void invokeInitMergeReaders(PreparableOneMerge oneMerge, IOFunction<SegmentCommitInfo, Object> factory)
+        throws Exception {
+        java.lang.reflect.Method m = MergePolicy.OneMerge.class.getDeclaredMethod("initMergeReaders", IOFunction.class);
+        m.setAccessible(true);
+        try {
+            m.invoke(oneMerge, factory);
+        } catch (java.lang.reflect.InvocationTargetException e) {
+            if (e.getCause() instanceof Exception cause) {
+                throw cause;
+            }
+            throw e;
+        }
+    }
+
+    /** Before initialization, readersInitialized is false and packLiveDocsByGeneration is empty. */
+    public void testPreparableOneMergeBeforeInitialization() throws IOException {
+        addSegment("a", 2);
+        writer.commit();
+
+        PreparableOneMerge oneMerge = new PreparableOneMerge(liveSegments());
+        assertFalse(oneMerge.readersInitialized());
+        assertTrue(oneMerge.packLiveDocsByGeneration(sci -> 0L).isEmpty());
+    }
+
+    /** Segments whose readers report no deletes are omitted from the packed map. */
+    public void testPackLiveDocsByGenerationOmitsDeleteFreeSegments() throws IOException {
+        addSegment("a", 2);
+        addSegment("b", 2);
+        writer.commit();
+
+        PreparableOneMerge oneMerge = new PreparableOneMerge(liveSegments());
+        long gen = 33L;
+        writer.prepareMerge(oneMerge, gen);
+        try {
+            assertTrue(oneMerge.packLiveDocsByGeneration(bySegmentOrdinal(liveSegments())).isEmpty());
+        } finally {
+            writer.abortPreparedMerge(gen);
+        }
+    }
+
+    // ========== Helpers ==========
+
+    /** Adds {@code numDocs} docs with ids {@code prefix_0..} and flushes them into their own segment. */
+    private void addSegment(String prefix, int numDocs) throws IOException {
+        for (int i = 0; i < numDocs; i++) {
+            Document doc = new Document();
+            doc.add(new StringField("id", prefix + "_" + i, Field.Store.YES));
+            writer.addDocument(doc);
+        }
+        writer.flush();
+    }
+
+    /** Returns the writer's live segments. */
+    @SuppressForbidden(reason = "Reflection needed to read IndexWriter's private live SegmentInfos for test assertions")
+    private List<SegmentCommitInfo> liveSegments() throws IOException {
+        try {
+            java.lang.reflect.Field segInfosField = IndexWriter.class.getDeclaredField("segmentInfos");
+            segInfosField.setAccessible(true);
+            SegmentInfos segmentInfos = (SegmentInfos) segInfosField.get(writer);
+            synchronized (writer) {
+                return new ArrayList<>(segmentInfos.asList());
+            }
+        } catch (ReflectiveOperationException e) {
+            throw new IOException("Failed to access segmentInfos via reflection", e);
+        }
+    }
+
+    /** Keys segments by their ordinal in {@code segments}, mirroring a generation lookup. */
+    private static ToLongFunction<SegmentCommitInfo> bySegmentOrdinal(List<SegmentCommitInfo> segments) {
+        Map<String, Long> byName = new HashMap<>();
+        for (int i = 0; i < segments.size(); i++) {
+            byName.put(segments.get(i).info.name, (long) i);
+        }
+        return sci -> byName.getOrDefault(sci.info.name, -1L);
+    }
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Adds live-docs filtering during Parquet merges so that hard-deleted rows are physically removed from the merged output file.

### What this does:
- Adds getLiveDocsForSegments(List<Segment>) to DeleteExecutionEngine — returns a per-segment bitmap of live rows using an NRT reader over the shared Lucene IndexWriter
- MergeHandler.doMerge calls this at merge start and passes the bitmap through MergeInput to the Rust merger
- The Rust merger (cursor.rs, sorted.rs, unsorted.rs) skips dead rows during the k-way merge, producing a smaller output file
- Fixes LuceneDeleteExecutionEngine.createDeleter to return null for parquet-only writers instead of throwing (was breaking indexing on parquet-only indices)

### Testing
- Added relevant unit / integ tests wherever required
- End to End tests for merge to follow once delete API's are plugged int
- Manual verification: Ran a local single-node cluster with -Dopensearch.pluggable.dataformat.merge.enabled=true and hardcoded map to drop first 2 nodes in each segment. Indexed 50 docs across multiple segments, triggered force-merge, confirmed merged Parquet file had the expected reduced row count and no errors in logs. This exercises the full Java → FFM → Rust live-docs path end-to-end.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
