### PR TITLE
feat: Add on-demand jemalloc heap profiling support via FFM

### DIFF
--- a/sandbox/libs/dataformat-native/rust/Cargo.toml
+++ b/sandbox/libs/dataformat-native/rust/Cargo.toml
@@ -52,7 +52,7 @@ log = "0.4"
 # Without it, jemalloc uses initial-exec TLS which fails on aarch64 Linux with:
 #   "cannot allocate memory in static TLS block"
 # The feature switches to global-dynamic TLS model, compatible with runtime loading.
-tikv-jemallocator = { version = "0.6", features = ["disable_initial_exec_tls"] }
+tikv-jemallocator = { version = "0.6", features = ["disable_initial_exec_tls", "profiling"] }
 tikv-jemalloc-ctl = { version = "0.6", features = ["stats"] }
 
 # Misc

--- a/sandbox/libs/dataformat-native/rust/common/src/allocator.rs
+++ b/sandbox/libs/dataformat-native/rust/common/src/allocator.rs
@@ -111,6 +111,53 @@ fn set_all_arenas(suffix: &[u8], ms: i64) -> Result<i64, String> {
     }
 }
 
+// ── Heap profiling ──────────────────────────────────────────────────────────
+//
+// Requires the process to be started with `_RJEM_MALLOC_CONF=prof:true,...`
+// (or the compile-time MALLOC_CONF in lib.rs to include `prof:true`).
+// Without that, activate/dump will return errors — the caller (Java) handles
+// this gracefully by logging a warning.
+
+/// FFI: Activates jemalloc heap profiling. Returns 0 on success, negative error pointer on failure.
+/// Called from Java when the cluster setting `native.jemalloc.heap_prof_active` is set to true.
+#[no_mangle]
+pub extern "C" fn native_jemalloc_heap_prof_activate() -> i64 {
+    ffm_wrap("native_jemalloc_heap_prof_activate", || {
+        unsafe { tikv_jemalloc_ctl::raw::write(b"prof.active\0", true) }
+            .map(|_| 0i64)
+            .map_err(|e| format!("failed to activate profiling: {}", e))
+    })
+}
+
+/// FFI: Deactivates jemalloc heap profiling. Returns 0 on success, negative error pointer on failure.
+/// Called from Java when the cluster setting `native.jemalloc.heap_prof_active` is set to false.
+#[no_mangle]
+pub extern "C" fn native_jemalloc_heap_prof_deactivate() -> i64 {
+    ffm_wrap("native_jemalloc_heap_prof_deactivate", || {
+        unsafe { tikv_jemalloc_ctl::raw::write(b"prof.active\0", false) }
+            .map(|_| 0i64)
+            .map_err(|e| format!("failed to deactivate profiling: {}", e))
+    })
+}
+
+/// FFI: Dumps a heap profile to the given path. Path must be a null-terminated C string.
+/// Returns 0 on success, negative error pointer on failure.
+/// Called from Java when the cluster setting `native.jemalloc.heap_prof_dump_path` is updated.
+#[no_mangle]
+pub unsafe extern "C" fn native_jemalloc_heap_prof_dump(path: *const std::ffi::c_char) -> i64 {
+    ffm_wrap("native_jemalloc_heap_prof_dump", || {
+        if path.is_null() {
+            return Err("null path".to_string());
+        }
+        let c_str = std::ffi::CStr::from_ptr(path);
+        let path_bytes = c_str.to_bytes_with_nul();
+        // prof.dump expects a *const c_char pointing to the file path
+        tikv_jemalloc_ctl::raw::write(b"prof.dump\0", path_bytes.as_ptr() as *const std::ffi::c_char)
+            .map(|_| 0i64)
+            .map_err(|e| format!("failed to dump heap profile: {}", e))
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -161,5 +208,26 @@ mod tests {
 
         // Restore default
         native_jemalloc_set_muzzy_decay_ms(30000);
+    }
+
+    #[test]
+    fn heap_prof_activate_returns_error_when_prof_disabled() {
+        // When the process is not started with prof:true, activate should return
+        // a negative error pointer (not crash).
+        let rc = native_jemalloc_heap_prof_activate();
+        // prof:true is not set in test builds, so this should fail gracefully
+        assert!(rc <= 0, "expected error or 0, got {}", rc);
+    }
+
+    #[test]
+    fn heap_prof_deactivate_returns_error_when_prof_disabled() {
+        let rc = native_jemalloc_heap_prof_deactivate();
+        assert!(rc <= 0, "expected error or 0, got {}", rc);
+    }
+
+    #[test]
+    fn heap_prof_dump_null_path_returns_error() {
+        let rc = unsafe { native_jemalloc_heap_prof_dump(std::ptr::null()) };
+        assert!(rc < 0, "expected negative error pointer for null path, got {}", rc);
     }
 }

--- a/sandbox/libs/dataformat-native/rust/lib/src/lib.rs
+++ b/sandbox/libs/dataformat-native/rust/lib/src/lib.rs
@@ -23,8 +23,13 @@
 ///   is re-applied by NativeBridgeModule.createComponents() — these compile-time values are
 ///   only used until that point.
 /// - lg_tcache_max: NOT dynamically tunable by jemalloc — init-time only, requires process restart to change.
+/// - prof:true,prof_active:false: Enables profiling infrastructure at startup but keeps sampling
+///   inactive (zero overhead). This is required so that operators can activate/deactivate profiling
+///   at runtime via cluster settings without restarting the process. jemalloc does not allow
+///   enabling prof after initialization — it must be set at startup or not at all.
+/// - lg_prof_sample:17: sample every ~128KB of allocation when profiling is active.
 #[export_name = "malloc_conf"]
-pub static MALLOC_CONF: &[u8] = b"dirty_decay_ms:30000,muzzy_decay_ms:30000,lg_tcache_max:16\0";
+pub static MALLOC_CONF: &[u8] = b"dirty_decay_ms:30000,muzzy_decay_ms:30000,lg_tcache_max:16,prof:true,prof_active:false,lg_prof_sample:17\0";
 
 #[global_allocator]
 static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;

--- a/sandbox/libs/dataformat-native/src/main/java/org/opensearch/nativebridge/spi/NativeHeapProfiler.java
+++ b/sandbox/libs/dataformat-native/src/main/java/org/opensearch/nativebridge/spi/NativeHeapProfiler.java
@@ -1,0 +1,123 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.nativebridge.spi;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.Linker;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.SymbolLookup;
+import java.lang.foreign.ValueLayout;
+import java.lang.invoke.MethodHandle;
+
+/**
+ * On-demand jemalloc heap profiling via FFM.
+ * <p>
+ * Provides methods to activate/deactivate heap profiling and dump heap profiles
+ * at runtime. These are called by the NativeBridgeModule cluster settings listeners.
+ * <p>
+ * Requires jemalloc to be started with profiling support via environment variable:
+ * {@code _RJEM_MALLOC_CONF="prof:true,prof_active:false,lg_prof_sample:17"}
+ * <p>
+ * <b>Security:</b> Heap dumps may contain sensitive in-memory data (index documents,
+ * credentials, keys). Dump paths are restricted to the OpenSearch data directory.
+ * The cluster setting requires operator-level privileges to modify.
+ */
+public final class NativeHeapProfiler {
+
+    private static final Logger logger = LogManager.getLogger(NativeHeapProfiler.class);
+
+    /** Allowed dump directory — restricted to OpenSearch tmp/data path. */
+    private static volatile String allowedDumpDir = System.getProperty("java.io.tmpdir", "/tmp");
+
+    private static final MethodHandle ACTIVATE;
+    private static final MethodHandle DEACTIVATE;
+    private static final MethodHandle DUMP;
+
+    static {
+        SymbolLookup lookup = NativeLibraryLoader.symbolLookup();
+        Linker linker = Linker.nativeLinker();
+
+        FunctionDescriptor voidToLong = FunctionDescriptor.of(ValueLayout.JAVA_LONG);
+        FunctionDescriptor ptrToLong = FunctionDescriptor.of(ValueLayout.JAVA_LONG, ValueLayout.ADDRESS);
+
+        ACTIVATE = linker.downcallHandle(lookup.find("native_jemalloc_heap_prof_activate").orElseThrow(), voidToLong);
+        DEACTIVATE = linker.downcallHandle(lookup.find("native_jemalloc_heap_prof_deactivate").orElseThrow(), voidToLong);
+        DUMP = linker.downcallHandle(lookup.find("native_jemalloc_heap_prof_dump").orElseThrow(), ptrToLong);
+    }
+
+    private NativeHeapProfiler() {}
+
+    /**
+     * Sets the allowed directory for heap dumps. Called during module initialization
+     * with the node's data path.
+     */
+    public static void setAllowedDumpDir(String dir) {
+        allowedDumpDir = dir;
+    }
+
+    /**
+     * Activates jemalloc heap profiling. Allocations will be sampled from this point.
+     *
+     * @param active true to activate, false to deactivate
+     */
+    public static void setActive(boolean active) {
+        try {
+            long rc;
+            if (active) {
+                rc = (long) ACTIVATE.invokeExact();
+                NativeLibraryLoader.checkResult(rc);
+                logger.info("jemalloc heap profiling activated");
+            } else {
+                rc = (long) DEACTIVATE.invokeExact();
+                NativeLibraryLoader.checkResult(rc);
+                logger.info("jemalloc heap profiling deactivated");
+            }
+        } catch (Throwable t) {
+            logger.warn("Error toggling jemalloc heap profiling (is _RJEM_MALLOC_CONF=prof:true set?)", t);
+        }
+    }
+
+    /**
+     * Dumps a heap profile to the specified file path.
+     * Path is validated to be within the allowed dump directory.
+     *
+     * @param path file path for the heap dump (e.g., "/tmp/heap_dump.heap")
+     */
+    public static void dumpProfile(String path) {
+        if (path == null || path.isEmpty()) {
+            return;
+        }
+        // Path validation: prevent arbitrary file writes
+        try {
+            java.nio.file.Path resolved = java.nio.file.Path.of(path).toAbsolutePath().normalize();
+            java.nio.file.Path allowed = java.nio.file.Path.of(allowedDumpDir).toAbsolutePath().normalize();
+            if (!resolved.startsWith(allowed)) {
+                logger.warn("Heap dump path [{}] rejected: must be under [{}]", path, allowedDumpDir);
+                return;
+            }
+            path = resolved.toString();
+        } catch (Exception e) {
+            logger.warn("Invalid heap dump path [{}]: {}", path, e.getMessage());
+            return;
+        }
+
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment cPath = arena.allocateFrom(path + "\0");
+            long rc = (long) DUMP.invokeExact(cPath);
+            NativeLibraryLoader.checkResult(rc);
+            logger.info("jemalloc heap profile dumped to {}", path);
+        } catch (Throwable t) {
+            logger.warn("Error dumping jemalloc heap profile to " + path, t);
+        }
+    }
+}

--- a/sandbox/modules/native-bridge/src/main/java/org/opensearch/nativebridge/NativeBridgeModule.java
+++ b/sandbox/modules/native-bridge/src/main/java/org/opensearch/nativebridge/NativeBridgeModule.java
@@ -17,6 +17,7 @@ import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.env.Environment;
 import org.opensearch.env.NodeEnvironment;
 import org.opensearch.nativebridge.spi.NativeAllocatorConfig;
+import org.opensearch.nativebridge.spi.NativeHeapProfiler;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.repositories.RepositoriesService;
 import org.opensearch.script.ScriptService;
@@ -54,6 +55,28 @@ public class NativeBridgeModule extends Plugin {
         Setting.Property.Dynamic
     );
 
+    /** Activates/deactivates jemalloc heap profiling at runtime. Requires prof:true via _RJEM_MALLOC_CONF env var. */
+    public static final Setting<Boolean> JEMALLOC_HEAP_PROF_ACTIVE = Setting.boolSetting(
+        "native.jemalloc.heap_prof_active",
+        false,
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic,
+        Setting.Property.OperatorDynamic
+    );
+
+    /**
+     * Triggers a heap profile dump to the specified path when updated.
+     * Path must be under the node's data directory (validated by NativeHeapProfiler).
+     * Analyzed with jeprof. WARNING: Heap dumps may contain sensitive in-memory data.
+     */
+    public static final Setting<String> JEMALLOC_HEAP_PROF_DUMP_PATH = Setting.simpleString(
+        "native.jemalloc.heap_prof_dump_path",
+        "",
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic,
+        Setting.Property.OperatorDynamic
+    );
+
     @Override
     public Collection<Object> createComponents(
         Client client,
@@ -74,15 +97,24 @@ public class NativeBridgeModule extends Plugin {
         NativeAllocatorConfig.setDirtyDecayMs(JEMALLOC_DIRTY_DECAY_MS.get(settings));
         NativeAllocatorConfig.setMuzzyDecayMs(JEMALLOC_MUZZY_DECAY_MS.get(settings));
 
+        // Restrict heap dump paths to the node's data directory
+        NativeHeapProfiler.setAllowedDumpDir(environment.dataFiles()[0].toAbsolutePath().toString());
+
         // Register dynamic update listeners
         clusterService.getClusterSettings().addSettingsUpdateConsumer(JEMALLOC_DIRTY_DECAY_MS, NativeAllocatorConfig::setDirtyDecayMs);
         clusterService.getClusterSettings().addSettingsUpdateConsumer(JEMALLOC_MUZZY_DECAY_MS, NativeAllocatorConfig::setMuzzyDecayMs);
+        clusterService.getClusterSettings().addSettingsUpdateConsumer(JEMALLOC_HEAP_PROF_ACTIVE, NativeHeapProfiler::setActive);
+        clusterService.getClusterSettings().addSettingsUpdateConsumer(JEMALLOC_HEAP_PROF_DUMP_PATH, path -> {
+            if (path != null && !path.isEmpty()) {
+                NativeHeapProfiler.dumpProfile(path);
+            }
+        });
 
         return Collections.emptyList();
     }
 
     @Override
     public List<Setting<?>> getSettings() {
-        return List.of(JEMALLOC_DIRTY_DECAY_MS, JEMALLOC_MUZZY_DECAY_MS);
+        return List.of(JEMALLOC_DIRTY_DECAY_MS, JEMALLOC_MUZZY_DECAY_MS, JEMALLOC_HEAP_PROF_ACTIVE, JEMALLOC_HEAP_PROF_DUMP_PATH);
     }
 }


### PR DESCRIPTION
Add native_jemalloc_heap_prof_activate(), native_jemalloc_heap_prof_deactivate(), and native_jemalloc_heap_prof_dump() FFI functions to the native bridge allocator module. These enable on-demand heap profiling controlled via OpenSearch cluster settings without process restart.

Changes:
- Cargo.toml: Add 'profiling' feature to tikv-jemallocator
- lib.rs: Add prof:true,prof_active:false,lg_prof_sample:17 to compile-time MALLOC_CONF (profiling compiled in but inactive by default)
- allocator.rs: Add 3 FFI functions for activate/deactivate/dump + tests

Usage (via cluster settings once Java side is wired):
  PUT _cluster/settings {"transient":{"native.jemalloc.heap_prof_active":true}}
  PUT _cluster/settings {"transient":{"native.jemalloc.heap_prof_dump_path":"/tmp/heap.prof"}}
  PUT _cluster/settings {"transient":{"native.jemalloc.heap_prof_active":false}}

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
