### PR TITLE
FIxing the update of writer generation for lucene segment info for pluggable dataformat feature

### DIFF
--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/merge/LuceneMergeStrategy.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/merge/LuceneMergeStrategy.java
@@ -43,9 +43,13 @@ public interface LuceneMergeStrategy {
      *
      * @param segments the segments to merge
      * @param rowIdMapping the row ID mapping from the primary format, or null if this is the primary
+     * @param outputWriterGeneration the writer generation to assign to the merged output segment;
+     *                               strategies that produce a {@link RowIdRemappingOneMerge} use this
+     *                               to stamp the {@code writer_generation} attribute onto the merged
+     *                               {@code .si} file via {@code setMergeInfo}
      * @return the configured OneMerge for execution
      */
-    MergePolicy.OneMerge createOneMerge(List<SegmentCommitInfo> segments, RowIdMapping rowIdMapping);
+    MergePolicy.OneMerge createOneMerge(List<SegmentCommitInfo> segments, RowIdMapping rowIdMapping, long outputWriterGeneration);
 
     /**
      * Builds or resolves the {@link RowIdMapping} after the merge completes.

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/merge/LuceneMerger.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/merge/LuceneMerger.java
@@ -130,24 +130,16 @@ public class LuceneMerger implements Merger {
             generationsToMerge
         );
 
-        // Delegate OneMerge creation to the strategy (primary vs secondary behavior)
-        MergePolicy.OneMerge oneMerge = strategy.createOneMerge(matchingSegments, rowIdMapping);
+        // Delegate OneMerge creation to the strategy (primary vs secondary behavior).
+        // For the secondary path, the returned RowIdRemappingOneMerge stamps the
+        // writer_generation attribute onto the merged SegmentInfo via setMergeInfo, which
+        // Lucene invokes immediately before codec.segmentInfoFormat().write(...) — so the
+        // attribute is persisted to the .si file and survives a writer reopen.
+        MergePolicy.OneMerge oneMerge = strategy.createOneMerge(matchingSegments, rowIdMapping, mergeInput.newWriterGeneration());
         indexWriter.executeMerge(oneMerge, mergeInput.newWriterGeneration());
 
-        // Stamp the merged segment with its writer generation so downstream lookups
-        // (e.g. findMatchingSegments on a subsequent merge) can correlate it.
-        //
-        // This mutation is in-memory only: Lucene writes the .si file exactly once at
-        // segment creation via SegmentInfoFormat.write(...) and does not rewrite it on
-        // later commits, so this attribute will not survive a writer reopen. That is
-        // acceptable here because the attribute is only consumed within the lifetime
-        // of the live IndexWriter's SegmentInfos.
-        SegmentCommitInfo mergedInfo = oneMerge.getMergeInfo();
-        if (mergedInfo != null) {
-            mergedInfo.info.putAttribute(WRITER_GENERATION_ATTRIBUTE, String.valueOf(mergeInput.newWriterGeneration()));
-        }
-
         // Build the merged WriterFileSet from the output segment info
+        SegmentCommitInfo mergedInfo = oneMerge.getMergeInfo();
         WriterFileSet mergedFileSet = buildMergedFileSet(mergedInfo, mergeInput.newWriterGeneration());
 
         // Delegate RowIdMapping production to the strategy

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/merge/PrimaryLuceneMergeStrategy.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/merge/PrimaryLuceneMergeStrategy.java
@@ -32,7 +32,7 @@ import java.util.List;
 public class PrimaryLuceneMergeStrategy implements LuceneMergeStrategy {
 
     @Override
-    public MergePolicy.OneMerge createOneMerge(List<SegmentCommitInfo> segments, RowIdMapping rowIdMapping) {
+    public MergePolicy.OneMerge createOneMerge(List<SegmentCommitInfo> segments, RowIdMapping rowIdMapping, long outputWriterGeneration) {
         throw new UnsupportedOperationException("Primary Lucene merge strategy is not yet implemented");
     }
 

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/merge/RowIdRemappingOneMerge.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/merge/RowIdRemappingOneMerge.java
@@ -29,17 +29,26 @@ import static org.opensearch.be.lucene.index.LuceneWriter.WRITER_GENERATION_ATTR
  * {@code SortedNumericSortField} on the row ID field) — {@code MultiSorter} reads the
  * already-remapped values and builds DocMaps for reordering.
  *
+ * <p>This class also stamps the {@link org.opensearch.be.lucene.index.LuceneWriter#WRITER_GENERATION_ATTRIBUTE}
+ * onto the merged segment's {@link org.apache.lucene.index.SegmentInfo} via
+ * {@link #setMergeInfo(SegmentCommitInfo)}. Lucene's {@code IndexWriter.mergeMiddle} invokes
+ * this hook immediately before calling {@code codec.segmentInfoFormat().write(...)} on the
+ * merged segment, so the attribute is persisted to the {@code .si} file and survives a
+ * writer reopen. No codec, thread-local, or commit-data plumbing is needed.
+ *
  * @opensearch.experimental
  */
 @ExperimentalApi
 class RowIdRemappingOneMerge extends MergePolicy.OneMerge {
 
     private final RowIdMapping rowIdMapping;
+    private final long outputWriterGeneration;
     private int nextRowIdOffset;
 
-    RowIdRemappingOneMerge(List<SegmentCommitInfo> segments, RowIdMapping rowIdMapping) {
+    RowIdRemappingOneMerge(List<SegmentCommitInfo> segments, RowIdMapping rowIdMapping, long outputWriterGeneration) {
         super(segments);
         this.rowIdMapping = rowIdMapping;
+        this.outputWriterGeneration = outputWriterGeneration;
         this.nextRowIdOffset = 0;
     }
 
@@ -50,6 +59,25 @@ class RowIdRemappingOneMerge extends MergePolicy.OneMerge {
         int offset = nextRowIdOffset;
         nextRowIdOffset += wrapped.maxDoc();
         return new RowIdRemappingCodecReader(wrapped, rowIdMapping, generation, offset);
+    }
+
+    /**
+     * Stamps the writer generation attribute on the merged segment so it is persisted when
+     * Lucene writes the {@code .si} file.
+     *
+     * <p>Lucene's {@code IndexWriter} calls this hook twice during a merge: once in
+     * {@code _mergeInit} right after the output {@link SegmentCommitInfo} is created, and a
+     * second time in {@code mergeMiddle} immediately before
+     * {@code codec.segmentInfoFormat().write(...)} persists the {@code .si}. The second call
+     * is the one that causes the attribute to land on disk. Stamping is idempotent, so the
+     * double-invocation is harmless.
+     */
+    @Override
+    public void setMergeInfo(SegmentCommitInfo info) {
+        super.setMergeInfo(info);
+        if (info != null) {
+            info.info.putAttribute(WRITER_GENERATION_ATTRIBUTE, String.valueOf(outputWriterGeneration));
+        }
     }
 
     private long resolveGeneration(CodecReader reader) {

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/merge/SecondaryLuceneMergeStrategy.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/merge/SecondaryLuceneMergeStrategy.java
@@ -38,8 +38,8 @@ import java.util.List;
 public class SecondaryLuceneMergeStrategy implements LuceneMergeStrategy {
 
     @Override
-    public MergePolicy.OneMerge createOneMerge(List<SegmentCommitInfo> segments, RowIdMapping rowIdMapping) {
-        return new RowIdRemappingOneMerge(segments, rowIdMapping);
+    public MergePolicy.OneMerge createOneMerge(List<SegmentCommitInfo> segments, RowIdMapping rowIdMapping, long outputWriterGeneration) {
+        return new RowIdRemappingOneMerge(segments, rowIdMapping, outputWriterGeneration);
     }
 
     @Override

--- a/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/LuceneMergerTests.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/LuceneMergerTests.java
@@ -249,6 +249,77 @@ public class LuceneMergerTests extends OpenSearchTestCase {
         expectThrows(IllegalArgumentException.class, () -> new LuceneMerger(null, new LuceneDataFormat(), Path.of(".")));
     }
 
+    /**
+     * Regression guard for the {@code writer_generation} stamping path. Verifies two things:
+     * <ol>
+     *   <li>The merged segment carries the {@code writer_generation} attribute in the live
+     *       {@link SegmentInfos} immediately after the merge completes — catches regressions
+     *       where the {@link org.opensearch.be.lucene.merge.RowIdRemappingOneMerge#setMergeInfo}
+     *       override stops running.</li>
+     *   <li>The attribute is <em>persisted</em> to the {@code .si} file and survives a writer
+     *       reopen — catches regressions that would revert to an in-memory-only stamp (e.g.
+     *       moving the {@code putAttribute} call back to {@code LuceneMerger#merge} after
+     *       {@code executeMerge}, which runs too late to influence the codec write).</li>
+     * </ol>
+     */
+    public void testMergedSegmentWriterGenerationIsPersisted() throws IOException {
+        long newGeneration = 99L;
+
+        writeSegment(writer, 1L, 0, 3);
+        writeSegment(writer, 2L, 3, 2);
+        writer.commit();
+
+        LuceneMerger merger = new LuceneMerger(writer, new LuceneDataFormat(), dataPath);
+        SegmentInfos infos = getSegmentInfos(writer);
+        List<Segment> segments = buildSegments(infos);
+
+        RowIdMapping identity = (oldId, oldGeneration) -> oldId;
+        MergeInput input = MergeInput.builder().segments(segments).rowIdMapping(identity).newWriterGeneration(newGeneration).build();
+
+        merger.merge(input);
+
+        // Assertion 1: attribute is set on the live (in-memory) merged SegmentCommitInfo
+        SegmentCommitInfo mergedInMemory = findSegmentWithGeneration(getSegmentInfos(writer), newGeneration);
+        assertNotNull("Merged segment must carry writer_generation=" + newGeneration + " in the live SegmentInfos", mergedInMemory);
+
+        // Persist to disk, close the writer, and reopen against the same directory to verify
+        // the attribute survives — i.e. it was stamped before Lucene wrote the .si file.
+        writer.commit();
+        writer.close();
+
+        SegmentInfos onDisk = SegmentInfos.readLatestCommit(directory);
+        SegmentCommitInfo mergedAfterReopen = findSegmentWithGeneration(onDisk, newGeneration);
+        assertNotNull(
+            "Merged segment must carry writer_generation="
+                + newGeneration
+                + " after reopen — the attribute must be written to the .si file during the merge, "
+                + "not stamped in-memory after executeMerge returns",
+            mergedAfterReopen
+        );
+        assertEquals(
+            "Persisted writer_generation attribute must match the one passed to MergeInput#newWriterGeneration",
+            String.valueOf(newGeneration),
+            mergedAfterReopen.info.getAttribute(WRITER_GENERATION_ATTRIBUTE)
+        );
+
+        // Reopen for the tearDown close() to be a no-op on an already-closed writer.
+        IndexWriterConfig iwc = new IndexWriterConfig(new MockAnalyzer(random()));
+        iwc.setMergeScheduler(new SerialMergeScheduler());
+        iwc.setMergePolicy(NoMergePolicy.INSTANCE);
+        iwc.setIndexSort(new Sort(new SortedNumericSortField(ROW_ID_FIELD, SortField.Type.LONG)));
+        writer = new MergeIndexWriter(directory, iwc);
+    }
+
+    private SegmentCommitInfo findSegmentWithGeneration(SegmentInfos infos, long generation) {
+        String target = String.valueOf(generation);
+        for (SegmentCommitInfo sci : infos.asList()) {
+            if (target.equals(sci.info.getAttribute(WRITER_GENERATION_ATTRIBUTE))) {
+                return sci;
+            }
+        }
+        return null;
+    }
+
     // ========== Helper Methods ==========
 
     private void writeSegment(IndexWriter w, long generation, int startRowId, int numDocs) throws IOException {


### PR DESCRIPTION


<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
FIxing the update of writer generation for lucene segment info for pluggable dataformat feature

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
