### PR TITLE
add lucene ffm callbacks to task tracking

### DIFF
--- a/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/AnalyticsSearchBackendPlugin.java
+++ b/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/AnalyticsSearchBackendPlugin.java
@@ -113,4 +113,16 @@ public interface AnalyticsSearchBackendPlugin {
     default void configureFilterDelegation(FilterDelegationHandle handle, BackendExecutionContext backendContext) {
         throw new UnsupportedOperationException("configureFilterDelegation not implemented for [" + name() + "]");
     }
+
+    /**
+     * Configure task-level resource tracking for delegation callbacks executing on foreign threads.
+     * Called after {@link #configureFilterDelegation}. Backends should wrap their callback dispatch
+     * with start/finish tracking calls for the given task.
+     */
+    default void configureTaskTracking(org.opensearch.tasks.TaskResourceTrackingService trackingService, long taskId) {}
+
+    /**
+     * Clear task tracking state after fragment execution completes.
+     */
+    default void clearTaskTracking() {}
 }

--- a/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/AnalyticsSearchBackendPlugin.java
+++ b/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/AnalyticsSearchBackendPlugin.java
@@ -115,14 +115,8 @@ public interface AnalyticsSearchBackendPlugin {
     }
 
     /**
-     * Configure task-level resource tracking for delegation callbacks executing on foreign threads.
-     * Called after {@link #configureFilterDelegation}. Backends should wrap their callback dispatch
-     * with start/finish tracking calls for the given task.
+     * Install a thread tracker for attribution of delegation callbacks executing on foreign threads.
+     * Called after {@link #configureFilterDelegation}. Pass {@code null} to clear.
      */
-    default void configureTaskTracking(org.opensearch.tasks.TaskResourceTrackingService trackingService, long taskId) {}
-
-    /**
-     * Clear task tracking state after fragment execution completes.
-     */
-    default void clearTaskTracking() {}
+    default void setDelegationThreadTracker(DelegationThreadTracker tracker) {}
 }

--- a/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/DelegationThreadTracker.java
+++ b/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/DelegationThreadTracker.java
@@ -1,0 +1,32 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.spi;
+
+/**
+ * Tracks thread-level resource attribution for delegation callbacks executing
+ * on foreign threads (e.g., DataFusion/Tokio workers invoking Lucene via FFM).
+ *
+ * @opensearch.internal
+ */
+public interface DelegationThreadTracker {
+
+    /**
+     * Signal that delegation work has started on the current thread.
+     *
+     * @return thread id to pass to {@link #trackEnd}, or {@code -1} if tracking is inactive
+     */
+    long trackStart();
+
+    /**
+     * Signal that delegation work has finished on the given thread.
+     *
+     * @param threadId the value returned by {@link #trackStart}
+     */
+    void trackEnd(long threadId);
+}

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/query_tracker.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/query_tracker.rs
@@ -14,9 +14,8 @@
 //! usage independently.
 //!
 //! [`QueryTrackingContext`] owns the per-query pool and tracker, auto-registers
-//! in the global [`QueryRegistry`] on creation, and marks the query completed
-//! on [`Drop`]. The registry retains completed entries so Java can retrieve
-//! final metrics via JNI before explicitly draining them.
+//! in the global [`QueryRegistry`] on creation, and removes the entry
+//! on [`Drop`].
 
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
@@ -151,14 +150,6 @@ impl QueryTracker {
 
 static QUERY_REGISTRY: Lazy<DashMap<i64, Arc<QueryTracker>>> = Lazy::new(DashMap::new);
 
-/// Remove a completed tracker from the registry and return it.
-/// Called from JNI after Java has consumed the metrics.
-pub fn drain_completed_query(context_id: i64) -> Option<Arc<QueryTracker>> {
-    QUERY_REGISTRY
-        .remove_if(&context_id, |_, t| t.is_completed())
-        .map(|(_, t)| t)
-}
-
 /// Fire the cancellation token for the given context_id.
 /// No-op for unknown or already-completed queries.
 pub fn cancel_query(context_id: i64) {
@@ -179,8 +170,7 @@ pub fn get_cancellation_token(context_id: i64) -> Option<CancellationToken> {
 /// Per-query context that owns the memory pool and tracker.
 ///
 /// - On creation: registers the tracker in the global registry.
-/// - On [`Drop`]: marks the tracker completed and logs final metrics.
-///   The tracker stays in the registry for JNI retrieval.
+/// - On [`Drop`]: removes the tracker from the registry and logs final metrics.
 ///
 /// For `context_id == 0` (unset), no tracking is performed.
 #[derive(Debug)]
@@ -237,6 +227,7 @@ impl Drop for QueryTrackingContext {
                 tracker.memory_pool.current_bytes(),
                 tracker.memory_pool.peak_bytes(),
             );
+            QUERY_REGISTRY.remove(&tracker.context_id);
         }
     }
 }
@@ -324,7 +315,7 @@ mod tests {
     }
 
     #[test]
-    fn test_context_registers_in_registry() {
+    fn test_context_registers_and_removes_on_drop() {
         let global = make_global_pool(10_000);
         let ctx_id = 50_000;
         let ctx = QueryTrackingContext::new(ctx_id, global);
@@ -332,33 +323,22 @@ mod tests {
         assert!(QUERY_REGISTRY.contains_key(&ctx_id));
 
         drop(ctx);
-        // Still in registry after drop (completed, not drained)
-        assert!(QUERY_REGISTRY.contains_key(&ctx_id));
-        assert!(QUERY_REGISTRY.get(&ctx_id).unwrap().is_completed());
-
-        // Drain removes it
-        let drained = drain_completed_query(ctx_id);
-        assert!(drained.is_some());
+        // Removed from registry after drop
         assert!(!QUERY_REGISTRY.contains_key(&ctx_id));
     }
 
     #[test]
-    fn test_drop_marks_completed_and_freezes_wall_time() {
+    fn test_drop_removes_from_registry() {
         let global = make_global_pool(10_000);
         let ctx_id = 50_001;
         let ctx = QueryTrackingContext::new(ctx_id, global);
 
+        assert!(QUERY_REGISTRY.contains_key(&ctx_id));
         thread::sleep(Duration::from_millis(50));
         drop(ctx);
 
-        let tracker = QUERY_REGISTRY.get(&ctx_id).unwrap();
-        assert!(tracker.is_completed());
-        let frozen = tracker.wall_secs();
-        thread::sleep(Duration::from_millis(50));
-        assert!((tracker.wall_secs() - frozen).abs() < 0.001);
-
-        drop(tracker);
-        QUERY_REGISTRY.remove(&ctx_id);
+        // Entry is gone after drop
+        assert!(!QUERY_REGISTRY.contains_key(&ctx_id));
     }
 
     #[test]
@@ -373,26 +353,7 @@ mod tests {
         assert!(t2 - t1 >= 0.04);
 
         drop(_ctx);
-        QUERY_REGISTRY.remove(&ctx_id);
-    }
-
-    #[test]
-    fn test_drain_returns_none_for_active_query() {
-        let global = make_global_pool(10_000);
-        let ctx_id = 50_003;
-        let _ctx = QueryTrackingContext::new(ctx_id, global);
-
-        // Cannot drain while still active
-        assert!(drain_completed_query(ctx_id).is_none());
-        assert!(QUERY_REGISTRY.contains_key(&ctx_id));
-
-        drop(_ctx);
-        assert!(drain_completed_query(ctx_id).is_some());
-    }
-
-    #[test]
-    fn test_drain_nonexistent_is_none() {
-        assert!(drain_completed_query(99_999).is_none());
+        // drop removes from registry automatically
     }
 
     #[test]
@@ -416,21 +377,15 @@ mod tests {
         assert_eq!(qp.current_bytes(), 2000);
         assert_eq!(qp.peak_bytes(), 8000);
 
-        // Drop context — marks completed
+        // Drop context — removes from registry
         drop(ctx);
-        {
-            let tracker = QUERY_REGISTRY.get(&ctx_id).unwrap();
-            assert!(tracker.is_completed());
-            assert_eq!(tracker.memory_pool.peak_bytes(), 8000);
-            assert!(tracker.wall_secs() > 0.0);
-        }
+        assert!(!QUERY_REGISTRY.contains_key(&ctx_id));
 
-        // Drop reservation — current goes to 0, peak stays
-        drop(reservation);
-        assert_eq!(qp.current_bytes(), 0);
+        // Pool still works (Arc kept alive by qp)
         assert_eq!(qp.peak_bytes(), 8000);
 
-        QUERY_REGISTRY.remove(&ctx_id);
+        drop(reservation);
+        assert_eq!(qp.current_bytes(), 0);
     }
 
     #[test]
@@ -457,14 +412,13 @@ mod tests {
 
         // Drop one, other keeps running
         drop(ctx_a);
-        assert!(QUERY_REGISTRY.get(&ctx_a_id).unwrap().is_completed());
-        assert!(!QUERY_REGISTRY.get(&ctx_b_id).unwrap().is_completed());
+        assert!(!QUERY_REGISTRY.contains_key(&ctx_a_id));
+        assert!(QUERY_REGISTRY.contains_key(&ctx_b_id));
 
         drop(res_a);
         drop(res_b);
         drop(ctx_b);
-        QUERY_REGISTRY.remove(&ctx_a_id);
-        QUERY_REGISTRY.remove(&ctx_b_id);
+        assert!(!QUERY_REGISTRY.contains_key(&ctx_b_id));
     }
 
     // -----------------------------------------------------------------------
@@ -472,7 +426,7 @@ mod tests {
     // -----------------------------------------------------------------------
 
     #[test]
-    fn test_context_completes_on_normal_drop_with_stream() {
+    fn test_context_removes_on_normal_drop_with_stream() {
         // Simulates: query succeeds → stream is consumed → handle dropped
         let global = make_global_pool(1_000_000);
         let ctx_id = 50_010;
@@ -485,25 +439,21 @@ mod tests {
         // Simulate allocations during stream consumption
         reservation.try_grow(4000).unwrap();
         assert_eq!(qp.peak_bytes(), 4000);
-        assert!(!QUERY_REGISTRY.get(&ctx_id).unwrap().is_completed());
+        assert!(QUERY_REGISTRY.contains_key(&ctx_id));
 
         // Stream fully consumed — reservation and context dropped together
-        // (mirrors QueryStreamHandle being dropped in streamClose)
         drop(reservation);
         drop(ctx);
 
-        let tracker = QUERY_REGISTRY.get(&ctx_id).unwrap();
-        assert!(tracker.is_completed());
-        assert_eq!(tracker.memory_pool.peak_bytes(), 4000);
-        assert_eq!(tracker.memory_pool.current_bytes(), 0);
-        assert!(tracker.wall_secs() > 0.0);
-
-        drop(tracker);
-        QUERY_REGISTRY.remove(&ctx_id);
+        // Removed from registry
+        assert!(!QUERY_REGISTRY.contains_key(&ctx_id));
+        // Pool stats still accessible via Arc
+        assert_eq!(qp.peak_bytes(), 4000);
+        assert_eq!(qp.current_bytes(), 0);
     }
 
     #[test]
-    fn test_context_completes_on_error_drop() {
+    fn test_context_removes_on_error_drop() {
         // Simulates: query execution fails → context dropped without
         // explicit cleanup (the error path in executeQueryPhaseAsync)
         let global = make_global_pool(1_000_000);
@@ -512,18 +462,9 @@ mod tests {
         {
             let ctx = QueryTrackingContext::new(ctx_id, global);
             let _pool = ctx.memory_pool();
-            assert!(!QUERY_REGISTRY.get(&ctx_id).unwrap().is_completed());
+            assert!(QUERY_REGISTRY.contains_key(&ctx_id));
+        } // ctx dropped here — removes from registry
 
-            // Simulate error: context goes out of scope, no stream was created
-        } // ctx dropped here — should still mark completed
-
-        let tracker = QUERY_REGISTRY.get(&ctx_id).unwrap();
-        assert!(tracker.is_completed());
-        assert_eq!(tracker.memory_pool.peak_bytes(), 0);
-        assert_eq!(tracker.memory_pool.current_bytes(), 0);
-
-        drop(tracker);
-        let drained = drain_completed_query(ctx_id);
-        assert!(drained.is_some());
+        assert!(!QUERY_REGISTRY.contains_key(&ctx_id));
     }
 }

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionAnalyticsBackendPlugin.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionAnalyticsBackendPlugin.java
@@ -575,12 +575,7 @@ public class DataFusionAnalyticsBackendPlugin implements AnalyticsSearchBackendP
     }
 
     @Override
-    public void configureTaskTracking(org.opensearch.tasks.TaskResourceTrackingService trackingService, long taskId) {
-        FilterTreeCallbacks.setTaskTracking(trackingService, taskId);
-    }
-
-    @Override
-    public void clearTaskTracking() {
-        FilterTreeCallbacks.setTaskTracking(null, -1);
+    public void setDelegationThreadTracker(org.opensearch.analytics.spi.DelegationThreadTracker tracker) {
+        FilterTreeCallbacks.setThreadTracker(tracker);
     }
 }

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionAnalyticsBackendPlugin.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionAnalyticsBackendPlugin.java
@@ -573,4 +573,14 @@ public class DataFusionAnalyticsBackendPlugin implements AnalyticsSearchBackendP
         // (createProvider, createCollector, collectDocs, release*) route to it.
         FilterTreeCallbacks.setHandle(handle);
     }
+
+    @Override
+    public void configureTaskTracking(org.opensearch.tasks.TaskResourceTrackingService trackingService, long taskId) {
+        FilterTreeCallbacks.setTaskTracking(trackingService, taskId);
+    }
+
+    @Override
+    public void clearTaskTracking() {
+        FilterTreeCallbacks.setTaskTracking(null, -1);
+    }
 }

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/indexfilter/FilterTreeCallbacks.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/indexfilter/FilterTreeCallbacks.java
@@ -11,8 +11,8 @@ package org.opensearch.be.datafusion.indexfilter;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.opensearch.analytics.spi.DelegationThreadTracker;
 import org.opensearch.analytics.spi.FilterDelegationHandle;
-import org.opensearch.tasks.TaskResourceTrackingService;
 
 import java.lang.foreign.MemorySegment;
 import java.util.concurrent.atomic.AtomicReference;
@@ -36,8 +36,7 @@ public final class FilterTreeCallbacks {
     private static final Logger LOGGER = LogManager.getLogger(FilterTreeCallbacks.class);
 
     private static final AtomicReference<FilterDelegationHandle> HANDLE = new AtomicReference<>();
-    private static final AtomicReference<TaskResourceTrackingService> TRACKING_SERVICE = new AtomicReference<>();
-    private static long currentTaskId = -1;
+    private static final AtomicReference<DelegationThreadTracker> TRACKER = new AtomicReference<>();
 
     private FilterTreeCallbacks() {}
 
@@ -51,25 +50,21 @@ public final class FilterTreeCallbacks {
     }
 
     /**
-     * Configure task resource tracking. All subsequent callbacks will attribute
-     * CPU/heap to the given task until cleared.
+     * Install or clear the thread tracker for resource attribution.
      */
-    public static void setTaskTracking(TaskResourceTrackingService trackingService, long taskId) {
-        TRACKING_SERVICE.set(trackingService);
-        currentTaskId = taskId;
+    public static void setThreadTracker(DelegationThreadTracker tracker) {
+        TRACKER.set(tracker);
     }
 
     private static long trackStart() {
-        TaskResourceTrackingService tracker = TRACKING_SERVICE.get();
-        if (tracker == null || currentTaskId < 0) return -1;
-        long threadId = Thread.currentThread().threadId();
-        tracker.taskExecutionStartedOnThread(currentTaskId, threadId);
-        return threadId;
+        DelegationThreadTracker t = TRACKER.get();
+        return (t != null) ? t.trackStart() : -1;
     }
 
     private static void trackEnd(long threadId) {
         if (threadId < 0) return;
-        TRACKING_SERVICE.get().taskExecutionFinishedOnThread(currentTaskId, threadId);
+        DelegationThreadTracker t = TRACKER.get();
+        if (t != null) t.trackEnd(threadId);
     }
 
     // ── Provider lifecycle (cold path, once per query) ────────────────

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/indexfilter/FilterTreeCallbacks.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/indexfilter/FilterTreeCallbacks.java
@@ -12,6 +12,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.opensearch.analytics.spi.FilterDelegationHandle;
+import org.opensearch.tasks.TaskResourceTrackingService;
 
 import java.lang.foreign.MemorySegment;
 import java.util.concurrent.atomic.AtomicReference;
@@ -35,6 +36,8 @@ public final class FilterTreeCallbacks {
     private static final Logger LOGGER = LogManager.getLogger(FilterTreeCallbacks.class);
 
     private static final AtomicReference<FilterDelegationHandle> HANDLE = new AtomicReference<>();
+    private static final AtomicReference<TaskResourceTrackingService> TRACKING_SERVICE = new AtomicReference<>();
+    private static long currentTaskId = -1;
 
     private FilterTreeCallbacks() {}
 
@@ -47,12 +50,35 @@ public final class FilterTreeCallbacks {
         HANDLE.set(handle);
     }
 
+    /**
+     * Configure task resource tracking. All subsequent callbacks will attribute
+     * CPU/heap to the given task until cleared.
+     */
+    public static void setTaskTracking(TaskResourceTrackingService trackingService, long taskId) {
+        TRACKING_SERVICE.set(trackingService);
+        currentTaskId = taskId;
+    }
+
+    private static long trackStart() {
+        TaskResourceTrackingService tracker = TRACKING_SERVICE.get();
+        if (tracker == null || currentTaskId < 0) return -1;
+        long threadId = Thread.currentThread().threadId();
+        tracker.taskExecutionStartedOnThread(currentTaskId, threadId);
+        return threadId;
+    }
+
+    private static void trackEnd(long threadId) {
+        if (threadId < 0) return;
+        TRACKING_SERVICE.get().taskExecutionFinishedOnThread(currentTaskId, threadId);
+    }
+
     // ── Provider lifecycle (cold path, once per query) ────────────────
 
     /**
      * {@code createProvider(annotationId) -> providerKey|-1}.
      */
     public static int createProvider(int annotationId) {
+        long tid = trackStart();
         try {
             FilterDelegationHandle handle = HANDLE.get();
             if (handle == null) {
@@ -62,6 +88,8 @@ public final class FilterTreeCallbacks {
         } catch (Throwable throwable) {
             LOGGER.error("createProvider failed for annotationId=" + annotationId, throwable);
             return -1;
+        } finally {
+            trackEnd(tid);
         }
     }
 
@@ -85,6 +113,7 @@ public final class FilterTreeCallbacks {
      * {@code createCollector(providerKey, segmentOrd, minDoc, maxDoc) -> collectorKey|-1}.
      */
     public static int createCollector(int providerKey, int segmentOrd, int minDoc, int maxDoc) {
+        long tid = trackStart();
         try {
             FilterDelegationHandle handle = HANDLE.get();
             if (handle == null) {
@@ -103,6 +132,8 @@ public final class FilterTreeCallbacks {
                 throwable
             );
             return -1;
+        } finally {
+            trackEnd(tid);
         }
     }
 
@@ -110,6 +141,7 @@ public final class FilterTreeCallbacks {
      * {@code collectDocs(collectorKey, minDoc, maxDoc, outPtr, outWordCap) -> wordsWritten|-1}.
      */
     public static long collectDocs(int collectorKey, int minDoc, int maxDoc, MemorySegment outPtr, long outWordCap) {
+        long tid = trackStart();
         try {
             FilterDelegationHandle handle = HANDLE.get();
             if (handle == null) {
@@ -125,6 +157,8 @@ public final class FilterTreeCallbacks {
                 throwable
             );
             return -1L;
+        } finally {
+            trackEnd(tid);
         }
     }
 

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/indexfilter/DelegationTaskTrackingTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/indexfilter/DelegationTaskTrackingTests.java
@@ -1,0 +1,226 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion.indexfilter;
+
+import org.opensearch.analytics.exec.task.AnalyticsShardTask;
+import org.opensearch.analytics.spi.FilterDelegationHandle;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.core.tasks.TaskId;
+import org.opensearch.core.tasks.resourcetracker.ThreadResourceInfo;
+import org.opensearch.tasks.TaskResourceTrackingService;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.threadpool.TestThreadPool;
+import org.opensearch.threadpool.ThreadPool;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Tests verifying that FilterTreeCallbacks correctly attributes delegation
+ * callback work to the AnalyticsShardTask via TaskResourceTrackingService.
+ */
+public class DelegationTaskTrackingTests extends OpenSearchTestCase {
+
+    private ThreadPool threadPool;
+    private TaskResourceTrackingService trackingService;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        threadPool = new TestThreadPool(getTestName(), new AtomicReference<>());
+        trackingService = new TaskResourceTrackingService(
+            Settings.EMPTY,
+            new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS),
+            threadPool
+        );
+        trackingService.setTaskResourceTrackingEnabled(true);
+        FilterTreeCallbacks.setHandle(null);
+        FilterTreeCallbacks.setTaskTracking(null, -1);
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        FilterTreeCallbacks.setTaskTracking(null, -1);
+        FilterTreeCallbacks.setHandle(null);
+        terminate(threadPool);
+        super.tearDown();
+    }
+
+    /**
+     * Tests the full production wiring: configureTaskTracking via SPI, then
+     * all three callback methods (createProvider, createCollector, collectDocs)
+     * on a foreign thread. Verifies the thread is tracked against the task.
+     */
+    public void testAllCallbackMethodsTrackedOnForeignThread() throws Exception {
+        AnalyticsShardTask task = createAndTrackTask(1);
+
+        var backendPlugin = new org.opensearch.be.datafusion.DataFusionAnalyticsBackendPlugin(null);
+        backendPlugin.configureTaskTracking(trackingService, task.getId());
+        FilterTreeCallbacks.setHandle(new MockHandle(new long[] { 0xCAFEL }));
+
+        CountDownLatch done = new CountDownLatch(1);
+        Thread foreignThread = new Thread(() -> {
+            int pk = FilterTreeCallbacks.createProvider(1);
+            int ck = FilterTreeCallbacks.createCollector(pk, 0, 0, 64);
+            try (Arena arena = Arena.ofConfined()) {
+                MemorySegment buf = arena.allocate(Long.BYTES);
+                FilterTreeCallbacks.collectDocs(ck, 0, 64, buf, 1);
+            }
+            FilterTreeCallbacks.releaseCollector(ck);
+            FilterTreeCallbacks.releaseProvider(pk);
+            done.countDown();
+        }, "test-tokio-worker");
+        foreignThread.start();
+        assertTrue(done.await(5, TimeUnit.SECONDS));
+
+        backendPlugin.clearTaskTracking();
+        trackingService.stopTracking(task);
+
+        Map<Long, List<ThreadResourceInfo>> stats = task.getResourceStats();
+        assertTrue("Foreign thread should be tracked. Got threads: " + stats.keySet(), stats.containsKey(foreignThread.threadId()));
+    }
+
+    /**
+     * Tests that clearTaskTracking stops attribution. After clearing,
+     * callbacks on a new thread should NOT be attributed to the old task.
+     */
+    public void testClearTaskTrackingStopsAttribution() throws Exception {
+        AnalyticsShardTask task = createAndTrackTask(2);
+
+        FilterTreeCallbacks.setTaskTracking(trackingService, task.getId());
+        FilterTreeCallbacks.setHandle(new MockHandle(new long[] { 1L }));
+
+        // Clear tracking BEFORE running callbacks
+        FilterTreeCallbacks.setTaskTracking(null, -1);
+
+        CountDownLatch done = new CountDownLatch(1);
+        Thread foreignThread = new Thread(() -> {
+            int pk = FilterTreeCallbacks.createProvider(1);
+            int ck = FilterTreeCallbacks.createCollector(pk, 0, 0, 64);
+            try (Arena arena = Arena.ofConfined()) {
+                MemorySegment buf = arena.allocate(Long.BYTES);
+                FilterTreeCallbacks.collectDocs(ck, 0, 64, buf, 1);
+            }
+            FilterTreeCallbacks.releaseCollector(ck);
+            FilterTreeCallbacks.releaseProvider(pk);
+            done.countDown();
+        }, "post-clear-thread");
+        foreignThread.start();
+        assertTrue(done.await(5, TimeUnit.SECONDS));
+
+        trackingService.stopTracking(task);
+
+        Map<Long, List<ThreadResourceInfo>> stats = task.getResourceStats();
+        assertFalse("Thread after clearTaskTracking should NOT be tracked", stats.containsKey(foreignThread.threadId()));
+    }
+
+    /**
+     * Tests that multiple concurrent threads calling collectDocs are all tracked.
+     */
+    public void testConcurrentThreadsAllTracked() throws Exception {
+        AnalyticsShardTask task = createAndTrackTask(3);
+
+        FilterTreeCallbacks.setTaskTracking(trackingService, task.getId());
+        FilterTreeCallbacks.setHandle(new MockHandle(new long[] { 0xFFL }));
+
+        int threadCount = 4;
+        CyclicBarrier barrier = new CyclicBarrier(threadCount);
+        CountDownLatch done = new CountDownLatch(threadCount);
+        Thread[] threads = new Thread[threadCount];
+
+        for (int i = 0; i < threadCount; i++) {
+            threads[i] = new Thread(() -> {
+                try {
+                    barrier.await(5, TimeUnit.SECONDS);
+                    int pk = FilterTreeCallbacks.createProvider(1);
+                    int ck = FilterTreeCallbacks.createCollector(pk, 0, 0, 64);
+                    try (Arena arena = Arena.ofConfined()) {
+                        MemorySegment buf = arena.allocate(Long.BYTES);
+                        FilterTreeCallbacks.collectDocs(ck, 0, 64, buf, 1);
+                    }
+                    FilterTreeCallbacks.releaseCollector(ck);
+                    FilterTreeCallbacks.releaseProvider(pk);
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                } finally {
+                    done.countDown();
+                }
+            }, "concurrent-worker-" + i);
+            threads[i].start();
+        }
+        assertTrue(done.await(10, TimeUnit.SECONDS));
+
+        FilterTreeCallbacks.setTaskTracking(null, -1);
+        trackingService.stopTracking(task);
+
+        Map<Long, List<ThreadResourceInfo>> stats = task.getResourceStats();
+        for (Thread t : threads) {
+            assertTrue("Thread " + t.getName() + " (id=" + t.threadId() + ") should be tracked", stats.containsKey(t.threadId()));
+        }
+    }
+
+    private AnalyticsShardTask createAndTrackTask(long id) {
+        AnalyticsShardTask task = new AnalyticsShardTask(
+            id,
+            "transport",
+            "indices:data/read/analytics/fragment",
+            "test-task-" + id,
+            TaskId.EMPTY_TASK_ID,
+            new HashMap<>()
+        );
+        assertTrue(task.supportsResourceTracking());
+        trackingService.startTracking(task);
+        return task;
+    }
+
+    private static final class MockHandle implements FilterDelegationHandle {
+        private final long[] words;
+        private int nextKey = 1;
+
+        MockHandle(long[] words) {
+            this.words = words;
+        }
+
+        @Override
+        public int createProvider(int annotationId) {
+            return nextKey++;
+        }
+
+        @Override
+        public int createCollector(int providerKey, int segmentOrd, int minDoc, int maxDoc) {
+            return nextKey++;
+        }
+
+        @Override
+        public int collectDocs(int collectorKey, int minDoc, int maxDoc, MemorySegment out) {
+            int n = Math.min(words.length, (int) (out.byteSize() / Long.BYTES));
+            for (int i = 0; i < n; i++)
+                out.setAtIndex(ValueLayout.JAVA_LONG, i, words[i]);
+            return n;
+        }
+
+        @Override
+        public void releaseCollector(int collectorKey) {}
+
+        @Override
+        public void releaseProvider(int providerKey) {}
+
+        @Override
+        public void close() {}
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/indexfilter/DelegationTaskTrackingTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/indexfilter/DelegationTaskTrackingTests.java
@@ -9,6 +9,7 @@
 package org.opensearch.be.datafusion.indexfilter;
 
 import org.opensearch.analytics.exec.task.AnalyticsShardTask;
+import org.opensearch.analytics.spi.DelegationThreadTracker;
 import org.opensearch.analytics.spi.FilterDelegationHandle;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
@@ -50,19 +51,19 @@ public class DelegationTaskTrackingTests extends OpenSearchTestCase {
         );
         trackingService.setTaskResourceTrackingEnabled(true);
         FilterTreeCallbacks.setHandle(null);
-        FilterTreeCallbacks.setTaskTracking(null, -1);
+        FilterTreeCallbacks.setThreadTracker(null);
     }
 
     @Override
     public void tearDown() throws Exception {
-        FilterTreeCallbacks.setTaskTracking(null, -1);
+        FilterTreeCallbacks.setThreadTracker(null);
         FilterTreeCallbacks.setHandle(null);
         terminate(threadPool);
         super.tearDown();
     }
 
     /**
-     * Tests the full production wiring: configureTaskTracking via SPI, then
+     * Tests the full production wiring: setDelegationThreadTracker via SPI, then
      * all three callback methods (createProvider, createCollector, collectDocs)
      * on a foreign thread. Verifies the thread is tracked against the task.
      */
@@ -70,7 +71,7 @@ public class DelegationTaskTrackingTests extends OpenSearchTestCase {
         AnalyticsShardTask task = createAndTrackTask(1);
 
         var backendPlugin = new org.opensearch.be.datafusion.DataFusionAnalyticsBackendPlugin(null);
-        backendPlugin.configureTaskTracking(trackingService, task.getId());
+        backendPlugin.setDelegationThreadTracker(createTracker(task.getId()));
         FilterTreeCallbacks.setHandle(new MockHandle(new long[] { 0xCAFEL }));
 
         CountDownLatch done = new CountDownLatch(1);
@@ -88,7 +89,7 @@ public class DelegationTaskTrackingTests extends OpenSearchTestCase {
         foreignThread.start();
         assertTrue(done.await(5, TimeUnit.SECONDS));
 
-        backendPlugin.clearTaskTracking();
+        backendPlugin.setDelegationThreadTracker(null);
         trackingService.stopTracking(task);
 
         Map<Long, List<ThreadResourceInfo>> stats = task.getResourceStats();
@@ -96,17 +97,17 @@ public class DelegationTaskTrackingTests extends OpenSearchTestCase {
     }
 
     /**
-     * Tests that clearTaskTracking stops attribution. After clearing,
+     * Tests that clearing the thread tracker stops attribution. After clearing,
      * callbacks on a new thread should NOT be attributed to the old task.
      */
     public void testClearTaskTrackingStopsAttribution() throws Exception {
         AnalyticsShardTask task = createAndTrackTask(2);
 
-        FilterTreeCallbacks.setTaskTracking(trackingService, task.getId());
+        FilterTreeCallbacks.setThreadTracker(createTracker(task.getId()));
         FilterTreeCallbacks.setHandle(new MockHandle(new long[] { 1L }));
 
         // Clear tracking BEFORE running callbacks
-        FilterTreeCallbacks.setTaskTracking(null, -1);
+        FilterTreeCallbacks.setThreadTracker(null);
 
         CountDownLatch done = new CountDownLatch(1);
         Thread foreignThread = new Thread(() -> {
@@ -126,7 +127,7 @@ public class DelegationTaskTrackingTests extends OpenSearchTestCase {
         trackingService.stopTracking(task);
 
         Map<Long, List<ThreadResourceInfo>> stats = task.getResourceStats();
-        assertFalse("Thread after clearTaskTracking should NOT be tracked", stats.containsKey(foreignThread.threadId()));
+        assertFalse("Thread after clearing tracker should NOT be tracked", stats.containsKey(foreignThread.threadId()));
     }
 
     /**
@@ -135,7 +136,7 @@ public class DelegationTaskTrackingTests extends OpenSearchTestCase {
     public void testConcurrentThreadsAllTracked() throws Exception {
         AnalyticsShardTask task = createAndTrackTask(3);
 
-        FilterTreeCallbacks.setTaskTracking(trackingService, task.getId());
+        FilterTreeCallbacks.setThreadTracker(createTracker(task.getId()));
         FilterTreeCallbacks.setHandle(new MockHandle(new long[] { 0xFFL }));
 
         int threadCount = 4;
@@ -165,13 +166,30 @@ public class DelegationTaskTrackingTests extends OpenSearchTestCase {
         }
         assertTrue(done.await(10, TimeUnit.SECONDS));
 
-        FilterTreeCallbacks.setTaskTracking(null, -1);
+        FilterTreeCallbacks.setThreadTracker(null);
         trackingService.stopTracking(task);
 
         Map<Long, List<ThreadResourceInfo>> stats = task.getResourceStats();
         for (Thread t : threads) {
             assertTrue("Thread " + t.getName() + " (id=" + t.threadId() + ") should be tracked", stats.containsKey(t.threadId()));
         }
+    }
+
+    private DelegationThreadTracker createTracker(long taskId) {
+        TaskResourceTrackingService service = trackingService;
+        return new DelegationThreadTracker() {
+            @Override
+            public long trackStart() {
+                long threadId = Thread.currentThread().threadId();
+                service.taskExecutionStartedOnThread(taskId, threadId);
+                return threadId;
+            }
+
+            @Override
+            public void trackEnd(long threadId) {
+                service.taskExecutionFinishedOnThread(taskId, threadId);
+            }
+        };
     }
 
     private AnalyticsShardTask createAndTrackTask(long id) {

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/AnalyticsSearchService.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/AnalyticsSearchService.java
@@ -30,6 +30,7 @@ import org.opensearch.index.engine.exec.IndexReaderProvider;
 import org.opensearch.index.engine.exec.IndexReaderProvider.Reader;
 import org.opensearch.index.shard.IndexShard;
 import org.opensearch.tasks.Task;
+import org.opensearch.tasks.TaskResourceTrackingService;
 
 import java.io.IOException;
 import java.util.List;
@@ -58,6 +59,7 @@ public class AnalyticsSearchService implements AutoCloseable {
     private final AnalyticsOperationListener listener;
     private final BufferAllocator allocator;
     private final NamedWriteableRegistry namedWriteableRegistry;
+    private TaskResourceTrackingService taskResourceTrackingService;
 
     public AnalyticsSearchService(Map<String, AnalyticsSearchBackendPlugin> backends) {
         this(backends, List.of(), null);
@@ -83,6 +85,10 @@ public class AnalyticsSearchService implements AutoCloseable {
         allocator.close();
     }
 
+    public void setTaskResourceTrackingService(TaskResourceTrackingService service) {
+        this.taskResourceTrackingService = service;
+    }
+
     public FragmentResources executeFragmentStreaming(FragmentExecutionRequest request, IndexShard shard, AnalyticsShardTask task) {
         ResolvedFragment resolved = resolveFragment(request, shard);
         try {
@@ -93,6 +99,8 @@ public class AnalyticsSearchService implements AutoCloseable {
         } catch (Exception e) {
             listener.onFragmentFailure(resolved.queryId, resolved.stageId, resolved.shardIdStr, e);
             throw new RuntimeException("Failed to start streaming fragment on " + shard.shardId(), e);
+        } finally {
+            backends.get(resolved.plan.getBackendId()).clearTaskTracking();
         }
     }
 
@@ -125,6 +133,10 @@ public class AnalyticsSearchService implements AutoCloseable {
                 AnalyticsSearchBackendPlugin acceptingBackend = backends.get(acceptingBackendId);
                 FilterDelegationHandle handle = acceptingBackend.getFilterDelegationHandle(delegation.delegatedExpressions(), ctx);
                 backend.configureFilterDelegation(handle, backendContext);
+
+                if (task != null && taskResourceTrackingService != null) {
+                    backend.configureTaskTracking(taskResourceTrackingService, task.getId());
+                }
             }
 
             engine = backend.getSearchExecEngineProvider().createSearchExecEngine(ctx, backendContext);

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/AnalyticsSearchService.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/AnalyticsSearchService.java
@@ -18,6 +18,7 @@ import org.opensearch.analytics.exec.task.AnalyticsShardTask;
 import org.opensearch.analytics.spi.AnalyticsSearchBackendPlugin;
 import org.opensearch.analytics.spi.BackendExecutionContext;
 import org.opensearch.analytics.spi.DelegationDescriptor;
+import org.opensearch.analytics.spi.DelegationThreadTracker;
 import org.opensearch.analytics.spi.FilterDelegationHandle;
 import org.opensearch.analytics.spi.FragmentInstructionHandler;
 import org.opensearch.analytics.spi.FragmentInstructionHandlerFactory;
@@ -99,8 +100,6 @@ public class AnalyticsSearchService implements AutoCloseable {
         } catch (Exception e) {
             listener.onFragmentFailure(resolved.queryId, resolved.stageId, resolved.shardIdStr, e);
             throw new RuntimeException("Failed to start streaming fragment on " + shard.shardId(), e);
-        } finally {
-            backends.get(resolved.plan.getBackendId()).clearTaskTracking();
         }
     }
 
@@ -110,6 +109,7 @@ public class AnalyticsSearchService implements AutoCloseable {
         SearchExecEngine<ShardScanExecutionContext, EngineResultStream> engine = null;
         EngineResultStream stream = null;
         BackendExecutionContext backendContext = null;
+        Runnable trackerCleanup = null;
         try {
             ShardScanExecutionContext ctx = buildContext(request, gatedReader.get(), resolved.plan, shard, task);
             AnalyticsSearchBackendPlugin backend = backends.get(resolved.plan.getBackendId());
@@ -135,16 +135,31 @@ public class AnalyticsSearchService implements AutoCloseable {
                 backend.configureFilterDelegation(handle, backendContext);
 
                 if (task != null && taskResourceTrackingService != null) {
-                    backend.configureTaskTracking(taskResourceTrackingService, task.getId());
+                    long taskId = task.getId();
+                    TaskResourceTrackingService service = taskResourceTrackingService;
+                    backend.setDelegationThreadTracker(new DelegationThreadTracker() {
+                        @Override
+                        public long trackStart() {
+                            long threadId = Thread.currentThread().threadId();
+                            service.taskExecutionStartedOnThread(taskId, threadId);
+                            return threadId;
+                        }
+
+                        @Override
+                        public void trackEnd(long threadId) {
+                            service.taskExecutionFinishedOnThread(taskId, threadId);
+                        }
+                    });
+                    trackerCleanup = () -> backend.setDelegationThreadTracker(null);
                 }
             }
 
             engine = backend.getSearchExecEngineProvider().createSearchExecEngine(ctx, backendContext);
             stream = engine.execute(ctx);
-            return new FragmentResources(gatedReader, engine, stream);
+            return new FragmentResources(gatedReader, engine, stream, trackerCleanup);
         } catch (Exception e) {
             try {
-                new FragmentResources(gatedReader, engine, stream).close();
+                new FragmentResources(gatedReader, engine, stream, trackerCleanup).close();
             } catch (Exception suppressed) {
                 e.addSuppressed(suppressed);
             }

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/AnalyticsSearchTransportService.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/AnalyticsSearchTransportService.java
@@ -22,6 +22,7 @@ import org.opensearch.index.shard.IndexShard;
 import org.opensearch.indices.IndicesService;
 import org.opensearch.ratelimitting.admissioncontrol.enums.AdmissionControlActionType;
 import org.opensearch.tasks.Task;
+import org.opensearch.tasks.TaskResourceTrackingService;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.StreamTransportService;
 import org.opensearch.transport.Transport;
@@ -55,7 +56,8 @@ public class AnalyticsSearchTransportService {
         StreamTransportService streamTransportService,
         ClusterService clusterService,
         AnalyticsSearchService searchService,
-        IndicesService indicesService
+        IndicesService indicesService,
+        TaskResourceTrackingService taskResourceTrackingService
     ) {
         if (streamTransportService == null) {
             throw new IllegalStateException(
@@ -63,6 +65,7 @@ public class AnalyticsSearchTransportService {
                     + "(opensearch.experimental.feature.stream_transport.enabled=true)"
             );
         }
+        searchService.setTaskResourceTrackingService(taskResourceTrackingService);
         this.transportService = streamTransportService;
         this.clusterService = clusterService;
         registerStreamingFragmentHandler(this.transportService, searchService, indicesService);

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/FragmentResources.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/FragmentResources.java
@@ -25,15 +25,26 @@ public final class FragmentResources implements AutoCloseable {
     private final GatedCloseable<Reader> gatedReader;
     private final SearchExecEngine<ShardScanExecutionContext, EngineResultStream> engine;
     private final EngineResultStream stream;
+    private final Runnable onClose;
 
     public FragmentResources(
         GatedCloseable<Reader> gatedReader,
         SearchExecEngine<ShardScanExecutionContext, EngineResultStream> engine,
         EngineResultStream stream
     ) {
+        this(gatedReader, engine, stream, null);
+    }
+
+    public FragmentResources(
+        GatedCloseable<Reader> gatedReader,
+        SearchExecEngine<ShardScanExecutionContext, EngineResultStream> engine,
+        EngineResultStream stream,
+        Runnable onClose
+    ) {
         this.gatedReader = gatedReader;
         this.engine = engine;
         this.stream = stream;
+        this.onClose = onClose;
     }
 
     public EngineResultStream stream() {
@@ -42,8 +53,15 @@ public final class FragmentResources implements AutoCloseable {
 
     @Override
     public void close() throws Exception {
-        Exception first;
-        first = closeQuietly(stream, null);
+        Exception first = null;
+        if (onClose != null) {
+            try {
+                onClose.run();
+            } catch (Exception e) {
+                first = e;
+            }
+        }
+        first = closeQuietly(stream, first);
         first = closeQuietly(engine, first);
         first = closeQuietly(gatedReader, first);
         if (first != null) throw first;

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/task/AnalyticsShardTask.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/task/AnalyticsShardTask.java
@@ -30,4 +30,9 @@ public class AnalyticsShardTask extends CancellableTask {
     public boolean shouldCancelChildrenOnCancellation() {
         return false;
     }
+
+    @Override
+    public boolean supportsResourceTracking() {
+        return true;
+    }
 }


### PR DESCRIPTION


### Description
#### Problem

When DataFusion delegates filter predicates to Lucene via FFM upcalls (createProvider, createCollector, collectDocs), the work executes on DataFusion/Tokio worker threads that are invisible to OpenSearch's TaskResourceTrackingService. This means CPU time and heap allocation during Lucene Weight creation, Scorer iteration, and bitset population are not attributed to the AnalyticsShardTask, creating a blind spot in resource accounting.

#### Solution

Wire TaskResourceTrackingService into the FFM callback dispatch path so that all delegation work on foreign threads is attributed to the parent task.

#### Changes:

    AnalyticsShardTask — override supportsResourceTracking() → true to opt into tracking
    FilterTreeCallbacks — add trackStart()/trackEnd() helper methods that call taskExecutionStartedOnThread/taskExecutionFinishedOnThread around each callback (createProvider, createCollector, collectDocs)
    AnalyticsSearchBackendPlugin (SPI) — add configureTaskTracking()/clearTaskTracking() default methods
    DataFusionAnalyticsBackendPlugin — override SPI methods to wire FilterTreeCallbacks.setTaskTracking()
    AnalyticsSearchService — call configureTaskTracking after configureFilterDelegation in startFragment(), clear in executeFragment() finally block
    AnalyticsSearchTransportService — inject TaskResourceTrackingService via Guice and pass to AnalyticsSearchService


### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
