### PR TITLE
Fix ExceptionsHelper.status() to handle fasterxml Jackson exceptions

### DIFF
--- a/libs/core/src/main/java/org/opensearch/ExceptionsHelper.java
+++ b/libs/core/src/main/java/org/opensearch/ExceptionsHelper.java
@@ -132,7 +132,17 @@ public final class ExceptionsHelper {
             case JsonParseException ignored -> RestStatus.BAD_REQUEST;
             case NotXContentException ignored -> RestStatus.BAD_REQUEST;
             case OpenSearchRejectedExecutionException ignored -> RestStatus.TOO_MANY_REQUESTS;
-            case null, default -> RestStatus.INTERNAL_SERVER_ERROR;
+            case null -> RestStatus.INTERNAL_SERVER_ERROR;
+            default -> {
+                // Handle fasterxml Jackson exceptions by class name since libs/core
+                // does not depend on com.fasterxml.jackson.core directly
+                String className = t.getClass().getName();
+                if (className.equals("com.fasterxml.jackson.core.JsonParseException")
+                    || className.equals("com.fasterxml.jackson.core.exc.InputCoercionException")) {
+                    yield RestStatus.BAD_REQUEST;
+                }
+                yield RestStatus.INTERNAL_SERVER_ERROR;
+            }
         };
     }
 
@@ -143,7 +153,16 @@ public final class ExceptionsHelper {
             case InputCoercionException ignored -> ErrorMessages.JSON_COERCION_FAILED;
             case JsonParseException ignored -> ErrorMessages.JSON_PARSE_FAILED;
             case OpenSearchRejectedExecutionException ignored -> ErrorMessages.TOO_MANY_REQUESTS;
-            case null, default -> "Internal failure";
+            case null -> "Internal failure";
+            default -> {
+                String className = t.getClass().getName();
+                if (className.equals("com.fasterxml.jackson.core.JsonParseException")) {
+                    yield ErrorMessages.JSON_PARSE_FAILED;
+                } else if (className.equals("com.fasterxml.jackson.core.exc.InputCoercionException")) {
+                    yield ErrorMessages.JSON_COERCION_FAILED;
+                }
+                yield "Internal failure";
+            }
         };
     }
 

--- a/server/src/test/java/org/opensearch/ExceptionsHelperTests.java
+++ b/server/src/test/java/org/opensearch/ExceptionsHelperTests.java
@@ -113,6 +113,11 @@ public class ExceptionsHelperTests extends OpenSearchTestCase {
         assertThat(ExceptionsHelper.status(new InputCoercionException("illegal")), equalTo(RestStatus.BAD_REQUEST));
         assertThat(ExceptionsHelper.status(new JsonParseException("illegal")), equalTo(RestStatus.BAD_REQUEST));
         assertThat(ExceptionsHelper.status(new OpenSearchRejectedExecutionException("rejected")), equalTo(RestStatus.TOO_MANY_REQUESTS));
+        // fasterxml Jackson 2 exceptions should also map to BAD_REQUEST
+        assertThat(
+            ExceptionsHelper.status(new com.fasterxml.jackson.core.JsonParseException(null, "illegal")),
+            equalTo(RestStatus.BAD_REQUEST)
+        );
     }
 
     public void testSummaryMessage() {
@@ -120,6 +125,11 @@ public class ExceptionsHelperTests extends OpenSearchTestCase {
         assertThat(ExceptionsHelper.summaryMessage(new InputCoercionException("illegal")), equalTo("Incompatible JSON value"));
         assertThat(ExceptionsHelper.summaryMessage(new JsonParseException("illegal")), equalTo("Failed to parse JSON"));
         assertThat(ExceptionsHelper.summaryMessage(new OpenSearchRejectedExecutionException("rejected")), equalTo("Too many requests"));
+        // fasterxml Jackson 2 exceptions should also get proper summary
+        assertThat(
+            ExceptionsHelper.summaryMessage(new com.fasterxml.jackson.core.JsonParseException(null, "illegal")),
+            equalTo("Failed to parse JSON")
+        );
     }
 
     public void testGroupBy() {


### PR DESCRIPTION
### Description

Fixes #21612.

PR #21029 introduced Jackson 3.x support and changed `ExceptionsHelper.status()` to match `org.opensearch.tools.jackson.core.JsonParseException`. However, `com.fasterxml.jackson.core.JsonParseException` (Jackson 2) is still on the classpath and actively used by plugins. It now falls through to the default case (`INTERNAL_SERVER_ERROR`) instead of `BAD_REQUEST`.

### Impact

- Plugins throwing fasterxml `JsonParseException` get 500 instead of 400
- Exception-based retry logic treats parse errors as retryable (causes infinite retries in anomaly-detection: opensearch-project/anomaly-detection#1714)
- Affects any plugin using fasterxml Jackson directly

### Fix

Since `libs/core` cannot depend on `com.fasterxml.jackson.core` directly, this fix matches fasterxml exceptions by class name in the default case of both `status()` and `summaryMessage()`.

### Testing

- Added tests for `com.fasterxml.jackson.core.JsonParseException` in `ExceptionsHelperTests`
- `./gradlew :server:test --tests org.opensearch.ExceptionsHelperTests` passes

cc @reta