### PR TITLE
[analytics-engine] Fix redundant instructions in FragmentConversionDriver

### DIFF
--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/dag/FragmentConversionDriver.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/dag/FragmentConversionDriver.java
@@ -134,19 +134,7 @@ public class FragmentConversionDriver {
             } else {
                 factory.createShardScanNode().ifPresent(instructions::add);
             }
-            if (plan.resolvedFragment() instanceof OpenSearchAggregate agg && agg.getMode() == AggregateMode.PARTIAL) {
-                factory.createPartialAggregateNode().ifPresent(instructions::add);
-            }
         }
-        // Coord-side reduce stages (OpenSearchStageInputScan leaf) intentionally don't
-        // register FinalAggregateInstructionHandler. That handler routes through Rust's
-        // apply_aggregate_mode(Mode::Final), whose strip leaves DataFusion's Final with
-        // dangling intermediate-column refs (cnt[sum]/cnt[count]) that the wire schema
-        // doesn't carry. The legacy executeLocalPlan path handles every coord-side reduce
-        // (aggregate, join, sort, ...) uniformly — DataFusion plans Partial+Final itself
-        // and the math is correct because all aggregates that reach the FINAL stage have
-        // associative reducers (SUM-of-SUMs, MIN-of-MINs, COUNT->SUM after function-swap).
-
         return instructions;
     }
 

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/dag/FragmentConversionDriver.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/dag/FragmentConversionDriver.java
@@ -137,9 +137,15 @@ public class FragmentConversionDriver {
             if (plan.resolvedFragment() instanceof OpenSearchAggregate agg && agg.getMode() == AggregateMode.PARTIAL) {
                 factory.createPartialAggregateNode().ifPresent(instructions::add);
             }
-        } else if (leaf instanceof OpenSearchStageInputScan) {
-            factory.createFinalAggregateNode().ifPresent(instructions::add);
         }
+        // Coord-side reduce stages (OpenSearchStageInputScan leaf) intentionally don't
+        // register FinalAggregateInstructionHandler. That handler routes through Rust's
+        // apply_aggregate_mode(Mode::Final), whose strip leaves DataFusion's Final with
+        // dangling intermediate-column refs (cnt[sum]/cnt[count]) that the wire schema
+        // doesn't carry. The legacy executeLocalPlan path handles every coord-side reduce
+        // (aggregate, join, sort, ...) uniformly — DataFusion plans Partial+Final itself
+        // and the math is correct because all aggregates that reach the FINAL stage have
+        // associative reducers (SUM-of-SUMs, MIN-of-MINs, COUNT->SUM after function-swap).
 
         return instructions;
     }

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchAggregateReduceRule.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchAggregateReduceRule.java
@@ -32,18 +32,24 @@ import java.util.EnumSet;
  * primitive aggregate calls, and the Volcano split rule downstream operates on those
  * primitives.
  *
- * <p><b>Reduction set</b>: narrowed via {@code FUNCTIONS_TO_REDUCE} to AVG only. AVG's
- * reduction uses only SUM, COUNT, DIVIDE, and CAST — all either capability-declared
- * aggregates or baseline scalar operators ({@link OpenSearchProjectRule#BASELINE_SCALAR_OPS}).
- * STDDEV_POP / STDDEV_SAMP / VAR_POP / VAR_SAMP also emit {@code POWER(x, 2)} which is
- * not in the baseline set; extending the set is a one-line change once a backend declares
- * POWER as a project capability.
+ * <p><b>Reduction set</b>: {@code AVG} + {@code STDDEV_POP/VAR_POP}. AVG reduces to
+ * SUM/COUNT/DIVIDE/CAST. STDDEV_POP/VAR_POP additionally emit {@code MULTIPLY} (for
+ * {@code x*x}) and {@code POWER(variance, 0.5)} (sqrt) — both expected in
+ * {@link OpenSearchProjectRule#BASELINE_SCALAR_OPS}. All emitted aggregates are SUM/COUNT
+ * primitives that the resolver decomposes through the standard single-field path.
+ *
+ * <p><b>Excluded: {@code STDDEV_SAMP} / {@code VAR_SAMP}.</b> The sample variants emit a
+ * {@code CASE WHEN count > 1 THEN ... ELSE NULL END} guard for Bessel's correction. The
+ * boolean comparison inside the CASE gets wrapped in {@code AnnotatedProjectExpression}
+ * by {@link OpenSearchProjectRule}, and the current {@code stripAnnotations} doesn't
+ * unwrap boolean operands — so substrait conversion fails with "Unable to convert call
+ * ANNOTATED_PROJECT_EXPR(boolean)". Re-add once that strip path is extended.
  *
  * @opensearch.internal
  */
 public class OpenSearchAggregateReduceRule extends AggregateReduceFunctionsRule {
 
-    private static final EnumSet<SqlKind> FUNCTIONS_TO_REDUCE = EnumSet.of(SqlKind.AVG);
+    private static final EnumSet<SqlKind> FUNCTIONS_TO_REDUCE = EnumSet.of(SqlKind.AVG, SqlKind.STDDEV_POP, SqlKind.VAR_POP);
 
     public OpenSearchAggregateReduceRule() {
         super(LogicalAggregate.class, RelBuilder.proto(Contexts.empty()), FUNCTIONS_TO_REDUCE);

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchAggregateReduceRule.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchAggregateReduceRule.java
@@ -32,24 +32,28 @@ import java.util.EnumSet;
  * primitive aggregate calls, and the Volcano split rule downstream operates on those
  * primitives.
  *
- * <p><b>Reduction set</b>: {@code AVG} + {@code STDDEV_POP/VAR_POP}. AVG reduces to
- * SUM/COUNT/DIVIDE/CAST. STDDEV_POP/VAR_POP additionally emit {@code MULTIPLY} (for
- * {@code x*x}) and {@code POWER(variance, 0.5)} (sqrt) — both expected in
- * {@link OpenSearchProjectRule#BASELINE_SCALAR_OPS}. All emitted aggregates are SUM/COUNT
- * primitives that the resolver decomposes through the standard single-field path.
- *
- * <p><b>Excluded: {@code STDDEV_SAMP} / {@code VAR_SAMP}.</b> The sample variants emit a
- * {@code CASE WHEN count > 1 THEN ... ELSE NULL END} guard for Bessel's correction. The
- * boolean comparison inside the CASE gets wrapped in {@code AnnotatedProjectExpression}
- * by {@link OpenSearchProjectRule}, and the current {@code stripAnnotations} doesn't
- * unwrap boolean operands — so substrait conversion fails with "Unable to convert call
- * ANNOTATED_PROJECT_EXPR(boolean)". Re-add once that strip path is extended.
+ * <p><b>Reduction set</b>: {@code AVG} + {@code STDDEV_POP}/{@code VAR_POP} +
+ * {@code STDDEV_SAMP}/{@code VAR_SAMP}. AVG reduces to SUM/COUNT/DIVIDE/CAST.
+ * STDDEV/VAR additionally emit {@code MULTIPLY} (for {@code x*x}) and
+ * {@code POWER(variance, 0.5)} (sqrt). The {@code SAMP} variants also emit a
+ * {@code CASE WHEN count > 1 THEN sqrt(variance) ELSE NULL END} Bessel's-correction
+ * guard — the {@code >} comparison operator is in
+ * {@link OpenSearchProjectRule#BASELINE_SCALAR_OPS} so it flows through without being
+ * wrapped in {@code AnnotatedProjectExpression}. All emitted aggregates are
+ * SUM/COUNT primitives that the resolver decomposes through the standard single-field
+ * path.
  *
  * @opensearch.internal
  */
 public class OpenSearchAggregateReduceRule extends AggregateReduceFunctionsRule {
 
-    private static final EnumSet<SqlKind> FUNCTIONS_TO_REDUCE = EnumSet.of(SqlKind.AVG, SqlKind.STDDEV_POP, SqlKind.VAR_POP);
+    private static final EnumSet<SqlKind> FUNCTIONS_TO_REDUCE = EnumSet.of(
+        SqlKind.AVG,
+        SqlKind.STDDEV_POP,
+        SqlKind.STDDEV_SAMP,
+        SqlKind.VAR_POP,
+        SqlKind.VAR_SAMP
+    );
 
     public OpenSearchAggregateReduceRule() {
         super(LogicalAggregate.class, RelBuilder.proto(Contexts.empty()), FUNCTIONS_TO_REDUCE);

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchProjectRule.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchProjectRule.java
@@ -82,6 +82,8 @@ public class OpenSearchProjectRule extends RelOptRule {
         SqlStdOperatorTable.DIVIDE,
         SqlStdOperatorTable.UNARY_MINUS,
         SqlStdOperatorTable.UNARY_PLUS,
+        // Math (emitted by Calcite's AggregateReduceFunctionsRule for STDDEV: POWER(v, 0.5) = sqrt)
+        SqlStdOperatorTable.POWER,
         // Type coercion
         SqlStdOperatorTable.CAST,
         // Null handling

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchProjectRule.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchProjectRule.java
@@ -84,6 +84,14 @@ public class OpenSearchProjectRule extends RelOptRule {
         SqlStdOperatorTable.UNARY_PLUS,
         // Math (emitted by Calcite's AggregateReduceFunctionsRule for STDDEV: POWER(v, 0.5) = sqrt)
         SqlStdOperatorTable.POWER,
+        // Comparison (emitted by Calcite's AggregateReduceFunctionsRule for STDDEV_SAMP / VAR_SAMP:
+        // CASE WHEN count > 1 THEN sqrt(variance) ELSE NULL END — Bessel's correction guard)
+        SqlStdOperatorTable.GREATER_THAN,
+        SqlStdOperatorTable.GREATER_THAN_OR_EQUAL,
+        SqlStdOperatorTable.LESS_THAN,
+        SqlStdOperatorTable.LESS_THAN_OR_EQUAL,
+        SqlStdOperatorTable.EQUALS,
+        SqlStdOperatorTable.NOT_EQUALS,
         // Type coercion
         SqlStdOperatorTable.CAST,
         // Null handling

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/AggregateRuleTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/AggregateRuleTests.java
@@ -18,6 +18,7 @@ import org.opensearch.analytics.planner.rel.AggregateMode;
 import org.opensearch.analytics.planner.rel.OpenSearchAggregate;
 import org.opensearch.analytics.planner.rel.OpenSearchExchangeReducer;
 import org.opensearch.analytics.planner.rel.OpenSearchFilter;
+import org.opensearch.analytics.planner.rel.OpenSearchProject;
 import org.opensearch.analytics.planner.rel.OpenSearchTableScan;
 import org.opensearch.analytics.spi.AggregateCapability;
 import org.opensearch.analytics.spi.AggregateFunction;
@@ -240,24 +241,35 @@ public class AggregateRuleTests extends BasePlannerRulesTests {
         PlannerContext context = buildContext("parquet", 1, intFields(), List.of(dfWithDelegation, luceneAccepting));
         RelNode result = runPlanner(makeMultiCallAggregate(sumCall(), stddevCall()), context);
         logger.info("Plan:\n{}", RelOptUtil.toString(result));
+        // OpenSearchAggregateReduceRule decomposes STDDEV_POP into SUM+COUNT wrapped in
+        // Project(sqrt) above / Project(squared-inputs) below the Aggregate.
         assertPipelineViableBackends(
             result,
-            List.of(OpenSearchAggregate.class, OpenSearchTableScan.class),
+            List.of(OpenSearchProject.class, OpenSearchAggregate.class, OpenSearchProject.class, OpenSearchTableScan.class),
             Set.of(MockDataFusionBackend.NAME)
         );
     }
 
     public void testAggregateErrorsWithoutDelegation() {
-        MockLuceneBackend luceneWithStddev = new MockLuceneBackend() {
+        // DF declares only COUNT — can't satisfy STDDEV_POP's reduction (needs SUM(x) and
+        // SUM(x*x)) on its own. Lucene has SUM but refuses delegation.
+        MockDataFusionBackend dfNoSum = new MockDataFusionBackend() {
             @Override
             protected Set<AggregateCapability> aggregateCapabilities() {
                 return aggCaps(
-                    Set.of(MockLuceneBackend.LUCENE_DATA_FORMAT),
-                    Map.of(AggregateFunction.STDDEV_POP, Set.of(FieldType.INTEGER))
+                    Set.of(MockDataFusionBackend.PARQUET_DATA_FORMAT),
+                    Map.of(AggregateFunction.COUNT, Set.of(FieldType.INTEGER))
                 );
             }
         };
-        PlannerContext context = buildContext("parquet", 1, intFields(), List.of(DATAFUSION, luceneWithStddev));
+        MockLuceneBackend luceneWithSum = new MockLuceneBackend() {
+            @Override
+            protected Set<AggregateCapability> aggregateCapabilities() {
+                return aggCaps(Set.of(MockLuceneBackend.LUCENE_DATA_FORMAT), Map.of(AggregateFunction.SUM, Set.of(FieldType.INTEGER)));
+            }
+            // No acceptedDelegations() override → delegation is refused.
+        };
+        PlannerContext context = buildContext("parquet", 1, intFields(), List.of(dfNoSum, luceneWithSum));
         IllegalStateException exception = expectThrows(
             IllegalStateException.class,
             () -> runPlanner(makeMultiCallAggregate(sumCall(), stddevCall()), context)

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/ProjectRuleTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/ProjectRuleTests.java
@@ -262,8 +262,8 @@ public class ProjectRuleTests extends BasePlannerRulesTests {
     // ---- Nested expressions ----
 
     public void testNestedScalarFunctions() {
-        // POWER(CEIL(v_int), v_int) — outer and inner both capability-declared scalars so
-        // annotation happens at both levels. CAST / PLUS are baseline scalars (see
+        // FLOOR(CEIL(v_int)) — outer and inner both capability-declared scalars so
+        // annotation happens at both levels. CAST / PLUS / POWER are baseline scalars (see
         // OpenSearchProjectRule.BASELINE_SCALAR_OPS) and are deliberately not used here
         // because they bypass capability enforcement and would not produce an
         // AnnotatedProjectExpression.
@@ -271,36 +271,32 @@ public class ProjectRuleTests extends BasePlannerRulesTests {
             SqlStdOperatorTable.CEIL,
             rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.INTEGER), 1)
         );
-        RexNode powerExpr = rexBuilder.makeCall(
-            SqlStdOperatorTable.POWER,
-            ceilExpr,
-            rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.INTEGER), 1)
-        );
-        OpenSearchProject result = runProject(powerExpr);
+        RexNode outerExpr = rexBuilder.makeCall(SqlStdOperatorTable.FLOOR, ceilExpr);
+        OpenSearchProject result = runProject(outerExpr);
         assertTrue(result.getViableBackends().contains(MockDataFusionBackend.NAME));
         assertAnnotation(result.getProjects().get(0), MockDataFusionBackend.NAME);
     }
 
     public void testStripAnnotationsRecursivelyUnwrapsNestedExpressions() {
-        // POWER(CEIL(value), value) — a non-baseline scalar call with another non-baseline
+        // FLOOR(CEIL(value)) — a non-baseline scalar call with another non-baseline
         // scalar call as an operand. The project rule recurses into operands
-        // (annotateExpr), so both POWER and the inner CEIL get wrapped in
+        // (annotateExpr), so both FLOOR and the inner CEIL get wrapped in
         // AnnotatedProjectExpression. stripAnnotations must remove every wrapper at every
         // depth before the plan reaches the backend FragmentConvertor — Substrait isthmus
         // has no converter for ANNOTATED_PROJECT_EXPR and would throw "Unable to convert
         // call".
         //
-        // PLUS was used previously but is baseline (see OpenSearchProjectRule
-        // .BASELINE_SCALAR_OPS); POWER preserves the nested-call-with-nested-annotation
-        // structure this test exercises while still going through capability resolution.
+        // PLUS / POWER are baseline (see OpenSearchProjectRule.BASELINE_SCALAR_OPS), so
+        // this test uses FLOOR+CEIL to preserve the nested-call-with-nested-annotation
+        // structure while still going through capability resolution.
         RexNode value = rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.INTEGER), 1);
         RexNode ceilCall = rexBuilder.makeCall(SqlStdOperatorTable.CEIL, value);
-        RexNode powerCall = rexBuilder.makeCall(SqlStdOperatorTable.POWER, ceilCall, value);
-        OpenSearchProject annotated = runProject(powerCall);
+        RexNode floorCall = rexBuilder.makeCall(SqlStdOperatorTable.FLOOR, ceilCall);
+        OpenSearchProject annotated = runProject(floorCall);
 
         // Sanity: confirm the rule produced the nested-wrapper shape this test exercises.
         RexNode topLevel = annotated.getProjects().get(0);
-        assertTrue("Outer POWER must be annotated", topLevel instanceof AnnotatedProjectExpression);
+        assertTrue("Outer FLOOR must be annotated", topLevel instanceof AnnotatedProjectExpression);
         RexCall outerOriginal = (RexCall) ((AnnotatedProjectExpression) topLevel).getOriginal();
         assertTrue(
             "Inner CEIL must also be annotated (recursive annotateExpr behavior)",

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/dag/FragmentConversionDriverTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/dag/FragmentConversionDriverTests.java
@@ -124,14 +124,12 @@ public class FragmentConversionDriverTests extends BasePlannerRulesTests {
         assertTrue("convertFinalAggFragment must be called", convertor.finalAggCalled);
         assertDoesntContainOperators(convertor.reduceFragment, OPENSEARCH_OPERATORS);
         assertDoesntContainOperators(convertor.reduceFragment, ANNOTATION_MARKERS);
-        // Instruction assertions
+        // Coord-side reduce stages no longer register FinalAggregateInstructionHandler.
+        // DataFusion plans the substrait Aggregate's Partial+Final pair itself via the legacy
+        // executeLocalPlan path; the previous SETUP_FINAL_AGGREGATE instruction routed through
+        // Rust's apply_aggregate_mode strip, which corrupted column refs (cnt[sum]/cnt[count]).
         StagePlan plan = stage.getPlanAlternatives().getFirst();
-        assertFalse("instructions must not be empty", plan.instructions().isEmpty());
-        assertEquals(
-            "reduce stage must have FINAL_AGGREGATE",
-            InstructionType.SETUP_FINAL_AGGREGATE,
-            plan.instructions().getFirst().type()
-        );
+        assertTrue("coord-side reduce instructions must be empty", plan.instructions().isEmpty());
     }
 
     // ---- Single-stage query shapes ----

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/AppendPipeCommandIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/AppendPipeCommandIT.java
@@ -14,8 +14,10 @@ import org.opensearch.client.ResponseException;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Self-contained integration test for PPL {@code appendpipe} on the analytics-engine route.
@@ -64,7 +66,7 @@ public class AppendPipeCommandIT extends AnalyticsRestTestCase {
         // The concrete invariant: the distinct buckets FURNITURE/OFFICE SUPPLIES/TECHNOLOGY all
         // appear, and the two branches' rows are identical modulo ordering, so the multiset
         // count of each bucket is at least 1 and no bucket count exceeds 2.
-        java.util.List<java.util.List<Object>> actual = getRows(
+        List<List<Object>> actual = getRows(
             "source="
                 + DATASET.indexName
                 + " | stats sum(int0) as sum_int0_by_str0 by str0 | sort str0"
@@ -72,14 +74,14 @@ public class AppendPipeCommandIT extends AnalyticsRestTestCase {
                 + " | head 5"
         );
         assertEquals("head 5 must return 5 rows", 5, actual.size());
-        java.util.Map<String, Integer> bucketCounts = new java.util.HashMap<>();
-        for (java.util.List<Object> r : actual) {
+        Map<String, Integer> bucketCounts = new HashMap<>();
+        for (List<Object> r : actual) {
             String bucket = (String) r.get(1);
             bucketCounts.merge(bucket, 1, Integer::sum);
         }
         assertEquals(
             "all three buckets must appear",
-            java.util.Set.of("FURNITURE", "OFFICE SUPPLIES", "TECHNOLOGY"),
+            Set.of("FURNITURE", "OFFICE SUPPLIES", "TECHNOLOGY"),
             bucketCounts.keySet()
         );
         for (Map.Entry<String, Integer> e : bucketCounts.entrySet()) {
@@ -88,9 +90,9 @@ public class AppendPipeCommandIT extends AnalyticsRestTestCase {
     }
 
     @SuppressWarnings("unchecked")
-    private java.util.List<java.util.List<Object>> getRows(String ppl) throws IOException {
+    private List<List<Object>> getRows(String ppl) throws IOException {
         Map<String, Object> response = executePpl(ppl);
-        return (java.util.List<java.util.List<Object>>) response.get("rows");
+        return (List<List<Object>>) response.get("rows");
     }
 
     // ── duplicate + inline stats producing a smaller schema (merged column) ─────

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/AppendPipeCommandIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/AppendPipeCommandIT.java
@@ -55,21 +55,42 @@ public class AppendPipeCommandIT extends AnalyticsRestTestCase {
 
     public void testAppendPipeSort() throws IOException {
         // Branch: stats sum(int0) by str0 → 3 rows (FURNITURE=1, OFFICE SUPPLIES=18, TECHNOLOGY=49).
-        // Outer `sort str0` pins the original to alphabetical order. `appendpipe [sort -sum_int0_by_str0]`
-        // duplicates the 3 rows and re-sorts them descending, then appends. `head 5` keeps the first
-        // 5 of the 6 total rows: original 3 + first 2 of the descending duplicate.
-        assertRows(
+        // `appendpipe [sort -sum_int0_by_str0]` duplicates them desc-sorted and appends. `head 5`
+        // keeps the first 5 of the 6 total rows. Branch arrival order at the union is
+        // non-deterministic (each is its own streaming stage), so `head 5` drops a different
+        // row depending on which branch arrives first. Assert the shape instead:
+        //  - total 5 rows
+        //  - at least one asc branch is fully represented (3 rows) and the other contributes 2.
+        // The concrete invariant: the distinct buckets FURNITURE/OFFICE SUPPLIES/TECHNOLOGY all
+        // appear, and the two branches' rows are identical modulo ordering, so the multiset
+        // count of each bucket is at least 1 and no bucket count exceeds 2.
+        java.util.List<java.util.List<Object>> actual = getRows(
             "source="
                 + DATASET.indexName
                 + " | stats sum(int0) as sum_int0_by_str0 by str0 | sort str0"
                 + " | appendpipe [ sort -sum_int0_by_str0 ]"
-                + " | head 5",
-            row(1, "FURNITURE"),
-            row(18, "OFFICE SUPPLIES"),
-            row(49, "TECHNOLOGY"),
-            row(49, "TECHNOLOGY"),
-            row(18, "OFFICE SUPPLIES")
+                + " | head 5"
         );
+        assertEquals("head 5 must return 5 rows", 5, actual.size());
+        java.util.Map<String, Integer> bucketCounts = new java.util.HashMap<>();
+        for (java.util.List<Object> r : actual) {
+            String bucket = (String) r.get(1);
+            bucketCounts.merge(bucket, 1, Integer::sum);
+        }
+        assertEquals(
+            "all three buckets must appear",
+            java.util.Set.of("FURNITURE", "OFFICE SUPPLIES", "TECHNOLOGY"),
+            bucketCounts.keySet()
+        );
+        for (Map.Entry<String, Integer> e : bucketCounts.entrySet()) {
+            assertTrue("bucket " + e.getKey() + " count out of range: " + e.getValue(), e.getValue() >= 1 && e.getValue() <= 2);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private java.util.List<java.util.List<Object>> getRows(String ppl) throws IOException {
+        Map<String, Object> response = executePpl(ppl);
+        return (java.util.List<java.util.List<Object>>) response.get("rows");
     }
 
     // ── duplicate + inline stats producing a smaller schema (merged column) ─────

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/MultisearchCommandIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/MultisearchCommandIT.java
@@ -8,7 +8,6 @@
 
 package org.opensearch.analytics.qa;
 
-import org.apache.lucene.tests.util.LuceneTestCase.AwaitsFix;
 import org.opensearch.client.Request;
 import org.opensearch.client.Response;
 import org.opensearch.client.ResponseException;
@@ -131,7 +130,6 @@ public class MultisearchCommandIT extends AnalyticsRestTestCase {
 
     // ── CASE with implicit ELSE NULL — `count(eval(predicate))` shape ──────────
 
-    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/pull/21457")
     public void testMultisearchCountEvalConditionalCount() throws IOException {
         // Mirror of the v2-side `CalciteMultisearchCommandIT.testMultisearchSuccessRatePattern`:
         // `count(eval(predicate))` is PPL's conditional-count idiom. Calcite lowers it to

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/ObjectFieldIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/ObjectFieldIT.java
@@ -8,7 +8,6 @@
 
 package org.opensearch.analytics.qa;
 
-import org.apache.lucene.tests.util.LuceneTestCase.AwaitsFix;
 import org.opensearch.client.Request;
 import org.opensearch.client.Response;
 
@@ -65,7 +64,6 @@ public class ObjectFieldIT extends AnalyticsRestTestCase {
         );
     }
 
-    @AwaitsFix(bugUrl = "Requires sql repo fix to CalciteRelNodeVisitor.containsNestedAggregator (try/catch around relBuilder.field)")
     public void testMinOnObjectField() throws IOException {
         assertRowsEqual(
             "source=" + DATASET.indexName + " | stats min(account.balance)",
@@ -73,7 +71,6 @@ public class ObjectFieldIT extends AnalyticsRestTestCase {
         );
     }
 
-    @AwaitsFix(bugUrl = "Requires sql repo fix to CalciteRelNodeVisitor.containsNestedAggregator (try/catch around relBuilder.field)")
     public void testMaxOnDeeplyNestedObjectField() throws IOException {
         assertRowsEqual(
             "source=" + DATASET.indexName + " | stats max(city.location.latitude)",
@@ -81,7 +78,6 @@ public class ObjectFieldIT extends AnalyticsRestTestCase {
         );
     }
 
-    @AwaitsFix(bugUrl = "Requires sql repo fix to CalciteRelNodeVisitor.containsNestedAggregator (try/catch around relBuilder.field)")
     public void testSumOnObjectField() throws IOException {
         assertRowsEqual(
             "source=" + DATASET.indexName + " | stats sum(city.population)",

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/StreamingCoordinatorReduceIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/StreamingCoordinatorReduceIT.java
@@ -13,6 +13,7 @@ import org.opensearch.client.Response;
 
 import java.util.List;
 import java.util.Map;
+import java.util.function.IntUnaryOperator;
 
 /**
  * Streaming variant of {@link CoordinatorReduceIT}: same 2-shard parquet-backed index and
@@ -59,6 +60,201 @@ public class StreamingCoordinatorReduceIT extends AnalyticsRestTestCase {
             assertNotNull("value cell must not be null", cell);
             assertEquals("every doc has value=" + VALUE, (long) VALUE, ((Number) cell).longValue());
         }
+    }
+
+    /**
+     * {@code stats avg(value) as a} — primitive decomposition. PARTIAL emits
+     * {@code [count:Int64, sum:Float64]}; FINAL reduces each with SUM and a Project wraps
+     * {@code finalExpression = sum/count}. Exercises the multi-field intermediate path over
+     * the streaming reduce-sink: each shard ships sum + count intermediates via Flight, the
+     * coordinator merges them, then divides.
+     *
+     * <p>Uses varied per-doc values (value = doc index) so the AVG is non-trivial — a
+     * per-shard pass-through (e.g. concatenating partial AVGs) would yield a different
+     * answer than the correct cross-shard merge.
+     */
+    public void testAvgAcrossShards() throws Exception {
+        createParquetBackedIndex();
+        int total = NUM_SHARDS * DOCS_PER_SHARD
+        indexValuedDocs(i -> i);
+
+        // Expected: AVG(0, 1, ..., total-1) = (total - 1) / 2.0
+        double expected = (total - 1) / 2.0;
+
+        Map<String, Object> result = executePPL("source = " + INDEX + " | stats avg(value) as a");
+        List<List<Object>> rows = scalarRows(result, "a");
+
+        double actual = ((Number) rows.get(0).get(0)).doubleValue();
+        assertEquals("AVG(value) across shards should be " + expected, expected, actual, 0.001);
+    }
+
+    /**
+     * {@code stats dc(value) as dc} — engine-native HLL merge. PARTIAL emits a single Binary
+     * sketch column per shard; FINAL invokes DataFusion's {@code approx_distinct} merge
+     * which combines sketches across shards. Exercises the engine-native (reducer == self)
+     * single-field intermediate path over streaming.
+     *
+     * <p>Tolerance is 10% — HLL is approximate; with 20 distinct values the error margin
+     * easily covers the variance.
+     */
+    public void testDistinctCountAcrossShards() throws Exception {
+        createParquetBackedIndex();
+        int total = NUM_SHARDS * DOCS_PER_SHARD;
+        indexValuedDocs(i -> i); // all distinct
+
+        Map<String, Object> result = executePPL("source = " + INDEX + " | stats dc(value) as dc");
+        List<List<Object>> rows = scalarRows(result, "dc");
+
+        long actual = ((Number) rows.get(0).get(0)).longValue();
+        assertTrue(
+            "dc(value) should be approximately " + total + " (±10%), got " + actual,
+            actual >= (long) (total * 0.9) && actual <= (long) (total * 1.1)
+        );
+    }
+
+    /**
+     * {@code stats stddev_pop(value) as s} — multi-field statistical aggregate. Reduced by
+     * {@link org.opensearch.analytics.planner.rules.OpenSearchAggregateReduceRule} into
+     * SUM, SUM-of-squares, and COUNT primitives at HEP-marking time, then finalised with
+     * POWER(variance, 0.5).
+     *
+     * <p>Expected: population stddev of (0..19) = sqrt(33.25) ≈ 5.766.
+     */
+    public void testStddevPopAcrossShards() throws Exception {
+        createParquetBackedIndex();
+        int total = NUM_SHARDS * DOCS_PER_SHARD;
+        indexValuedDocs(i -> i);
+
+        double mean = (total - 1) / 2.0;
+        double sumSquares = 0;
+        for (int i = 0; i < total; i++) {
+            sumSquares += (i - mean) * (i - mean);
+        }
+        double expected = Math.sqrt(sumSquares / total);
+
+        Map<String, Object> result = executePPL("source = " + INDEX + " | stats stddev_pop(value) as s");
+        List<List<Object>> rows = scalarRows(result, "s");
+
+        double actual = ((Number) rows.get(0).get(0)).doubleValue();
+        assertEquals("STDDEV_POP(value) across shards should be " + expected, expected, actual, 0.001);
+    }
+
+    /**
+     * {@code stats stddev_samp(value) as s} — sample standard deviation. Reduced to
+     * {@code sqrt(SUM((x - mean)^2) / (N - 1))}. Same reduction path as STDDEV_POP but
+     * with Bessel's correction in the denominator.
+     *
+     * <p>Expected: sample stddev of (0..19) = sqrt(sum((i - mean)^2) / (N - 1)) = sqrt(35) ≈ 5.916.
+     */
+    @org.apache.lucene.tests.util.LuceneTestCase.AwaitsFix(
+        bugUrl = "OpenSearchAggregateReduceRule excludes STDDEV_SAMP — Calcite's reduction emits a"
+            + " CASE-WHEN-boolean guard that OpenSearchProject.stripAnnotations doesn't unwrap."
+    )
+    public void testStddevSampAcrossShards() throws Exception {
+        createParquetBackedIndex();
+        int total = NUM_SHARDS * DOCS_PER_SHARD;
+        indexValuedDocs(i -> i);
+
+        double mean = (total - 1) / 2.0;
+        double sumSquares = 0;
+        for (int i = 0; i < total; i++) {
+            sumSquares += (i - mean) * (i - mean);
+        }
+        double expected = Math.sqrt(sumSquares / (total - 1));
+
+        Map<String, Object> result = executePPL("source = " + INDEX + " | stats stddev_samp(value) as s");
+        List<List<Object>> rows = scalarRows(result, "s");
+
+        double actual = ((Number) rows.get(0).get(0)).doubleValue();
+        assertEquals("STDDEV_SAMP(value) across shards should be " + expected, expected, actual, 0.001);
+    }
+
+    /**
+     * {@code stats var_pop(value) as v} — population variance. Reduced to
+     * {@code SUM((x - mean)^2) / N}, the same primitives as STDDEV_POP minus the final sqrt.
+     *
+     * <p>Expected: population variance of (0..19) = 33.25.
+     */
+    public void testVarPopAcrossShards() throws Exception {
+        createParquetBackedIndex();
+        int total = NUM_SHARDS * DOCS_PER_SHARD;
+        indexValuedDocs(i -> i);
+
+        double mean = (total - 1) / 2.0;
+        double sumSquares = 0;
+        for (int i = 0; i < total; i++) {
+            sumSquares += (i - mean) * (i - mean);
+        }
+        double expected = sumSquares / total;
+
+        Map<String, Object> result = executePPL("source = " + INDEX + " | stats var_pop(value) as v");
+        List<List<Object>> rows = scalarRows(result, "v");
+
+        double actual = ((Number) rows.get(0).get(0)).doubleValue();
+        assertEquals("VAR_POP(value) across shards should be " + expected, expected, actual, 0.001);
+    }
+
+    /**
+     * {@code stats var_samp(value) as v} — sample variance. Reduced to
+     * {@code SUM((x - mean)^2) / (N - 1)}.
+     *
+     * <p>Expected: sample variance of (0..19) = 35.0.
+     */
+    @org.apache.lucene.tests.util.LuceneTestCase.AwaitsFix(
+        bugUrl = "OpenSearchAggregateReduceRule excludes VAR_SAMP — Calcite's reduction emits a"
+            + " CASE-WHEN-boolean guard that OpenSearchProject.stripAnnotations doesn't unwrap."
+    )
+    public void testVarSampAcrossShards() throws Exception {
+        createParquetBackedIndex();
+        int total = NUM_SHARDS * DOCS_PER_SHARD;
+        indexValuedDocs(i -> i);
+
+        double mean = (total - 1) / 2.0;
+        double sumSquares = 0;
+        for (int i = 0; i < total; i++) {
+            sumSquares += (i - mean) * (i - mean);
+        }
+        double expected = sumSquares / (total - 1);
+
+        Map<String, Object> result = executePPL("source = " + INDEX + " | stats var_samp(value) as v");
+        List<List<Object>> rows = scalarRows(result, "v");
+
+        double actual = ((Number) rows.get(0).get(0)).doubleValue();
+        assertEquals("VAR_SAMP(value) across shards should be " + expected, expected, actual, 0.001);
+    }
+
+    /** Indexes {@code NUM_SHARDS * DOCS_PER_SHARD} docs with values produced by {@code valueFn}. */
+    private void indexValuedDocs(IntUnaryOperator valueFn) throws Exception {
+        int total = NUM_SHARDS * DOCS_PER_SHARD;
+        StringBuilder bulk = new StringBuilder();
+        for (int i = 0; i < total; i++) {
+            bulk.append("{\"index\": {\"_id\": \"").append(i).append("\"}}\n");
+            bulk.append("{\"value\": ").append(valueFn.applyAsInt(i)).append("}\n");
+        }
+
+        Request bulkRequest = new Request("POST", "/" + INDEX + "/_bulk");
+        bulkRequest.setJsonEntity(bulk.toString());
+        bulkRequest.addParameter("refresh", "true");
+        client().performRequest(bulkRequest);
+
+        client().performRequest(new Request("POST", "/" + INDEX + "/_flush?force=true"));
+    }
+
+    /** Local copy of {@code CoordinatorReduceIT.scalarRows} (the original is package-private). */
+    private static List<List<Object>> scalarRows(Map<String, Object> result, String columnName) {
+        @SuppressWarnings("unchecked")
+        List<String> columns = (List<String>) result.get("columns");
+        assertNotNull("columns must not be null", columns);
+        assertTrue("columns must contain '" + columnName + "', got " + columns, columns.contains(columnName));
+
+        @SuppressWarnings("unchecked")
+        List<List<Object>> rows = (List<List<Object>>) result.get("rows");
+        assertNotNull("rows must not be null", rows);
+        assertEquals("scalar agg must return exactly 1 row", 1, rows.size());
+
+        Object cell = rows.get(0).get(columns.indexOf(columnName));
+        assertNotNull("cell for '" + columnName + "' must not be null — coordinator-reduce returned no value", cell);
+        return rows;
     }
 
     private void createParquetBackedIndex() throws Exception {

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/StreamingCoordinatorReduceIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/StreamingCoordinatorReduceIT.java
@@ -75,7 +75,7 @@ public class StreamingCoordinatorReduceIT extends AnalyticsRestTestCase {
      */
     public void testAvgAcrossShards() throws Exception {
         createParquetBackedIndex();
-        int total = NUM_SHARDS * DOCS_PER_SHARD
+        int total = NUM_SHARDS * DOCS_PER_SHARD;
         indexValuedDocs(i -> i);
 
         // Expected: AVG(0, 1, ..., total-1) = (total - 1) / 2.0
@@ -146,10 +146,6 @@ public class StreamingCoordinatorReduceIT extends AnalyticsRestTestCase {
      *
      * <p>Expected: sample stddev of (0..19) = sqrt(sum((i - mean)^2) / (N - 1)) = sqrt(35) ≈ 5.916.
      */
-    @org.apache.lucene.tests.util.LuceneTestCase.AwaitsFix(
-        bugUrl = "OpenSearchAggregateReduceRule excludes STDDEV_SAMP — Calcite's reduction emits a"
-            + " CASE-WHEN-boolean guard that OpenSearchProject.stripAnnotations doesn't unwrap."
-    )
     public void testStddevSampAcrossShards() throws Exception {
         createParquetBackedIndex();
         int total = NUM_SHARDS * DOCS_PER_SHARD;
@@ -200,10 +196,6 @@ public class StreamingCoordinatorReduceIT extends AnalyticsRestTestCase {
      *
      * <p>Expected: sample variance of (0..19) = 35.0.
      */
-    @org.apache.lucene.tests.util.LuceneTestCase.AwaitsFix(
-        bugUrl = "OpenSearchAggregateReduceRule excludes VAR_SAMP — Calcite's reduction emits a"
-            + " CASE-WHEN-boolean guard that OpenSearchProject.stripAnnotations doesn't unwrap."
-    )
     public void testVarSampAcrossShards() throws Exception {
         createParquetBackedIndex();
         int total = NUM_SHARDS * DOCS_PER_SHARD;


### PR DESCRIPTION


Signed-off-by: 
Marc Handalian <marc.handalian@gmail.com>
Sandesh Kumar <sandeshkr419@gmail.com>
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->


## Summary

- Fixes an Int32/Int64 type mismatch that panicked DataFusion's count accumulator on
   `count(eval(predicate))`
-  enables `STDDEV_SAMP` / `VAR_SAMP` on the analytics-engine route.

The mode decomposition was being applied twice: once at the Calcite layer by`OpenSearchAggregateSplitRule` + `AggregateDecompositionResolver` (which already produces separate PARTIAL and FINAL fragments), and again at the instruction layer where `FragmentConversionDriver` emitted `PartialAggregate` / `FinalAggregate` nodes that invoked Rust's`force_aggregate_mode` strip.

For `count(eval(pred))` — which Calcite lowers to `COUNT(CASE WHEN pred THEN 1 ELSE NULL END)` —the CASE result type is Int32. The second (strip-based) mode application fused that Int32 column into the Final count accumulator, whose `merge_batch` hard-codes `downcast_value!(states[0], Int64Array)`:

Internal error: could not cast array of type Int32 to arrow_array::array::primitive_array::PrimitiveArray<arrow_array::types::Int64Type>(datafusion-functions-aggregate/src/count.rs, merge_batch)

Dropping the redundant instruction emissions resolves the panic. Each fragment now takes DataFusion's normal planning path; the Calcite split still gives it two correctly decomposed halves, and every aggregate that reaches either stage is associative, so results are preserved. `FinalAggregateInstructionHandler`, `PartialAggregateInstructionHandler`, the `preparePartialPlan` / `prepareFinalPlan` FFI, and Rust's `force_aggregate_mode` remain compiled and unit-tested — dormant, one-line-revertable when upstream DataFusion's substrait consumer respects `aggregation_phase`.

## Changes

- **`FragmentConversionDriver.assembleInstructions`** — remove both the PARTIAL-leaf and FINAL-leaf instruction-emission branches.
- **`OpenSearchAggregateReduceRule.FUNCTIONS_TO_REDUCE`** — expanded to the full statistical set `{AVG, STDDEV_POP, STDDEV_SAMP, VAR_POP, VAR_SAMP}`.
- **`OpenSearchProjectRule.BASELINE_SCALAR_OPS`** — added `POWER` (for Calcite's `sqrt(variance)` emission) and the six SQL comparison operators (`>`, `>=`, `<`, `<=`, `=`, `!=`) needed for the SAMP-variant `CASE WHEN count > 1 …` Bessel's-correction guard. Comparisons are SQL-execution primitives every backend supports, consistent with the existing baseline rationale.
 - **New `StreamingCoordinatorReduceIT`** (7 tests) — AVG, DC (engine-native HLL merge),
     STDDEV_POP/SAMP, VAR_POP/SAMP across 2 shards with Arrow Flight streaming.
- **Unmuted tests**: `MultisearchCommandIT.testMultisearchCountEvalConditionalCount` (original repro), `AppendPipeCommandIT.testAppendPipeSort` (rewritten with order-tolerant assertions),  and 3 `ObjectFieldIT` tests unblocked by an unrelated prior fix on main.
- Planner unit tests updated for the new post-reduction plan shape and empty coord-side instruction list.

## Verification

`:sandbox:plugins:analytics-engine:test`, `:sandbox:plugins:analytics-engine:test`, `:sandbox:qa:analytics-engine-rest:integTestStreaming


### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
