### PR TITLE
[analytics-engine] Add AND/OR/NOT to scalar ops; reduce ClickBench skip set

### DIFF
--- a/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/ScalarFunction.java
+++ b/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/ScalarFunction.java
@@ -41,6 +41,11 @@ public enum ScalarFunction {
     IN(Category.COMPARISON, SqlKind.IN),
     LIKE(Category.COMPARISON, SqlKind.LIKE),
     PREFIX(Category.COMPARISON, SqlKind.OTHER_FUNCTION),
+
+    // ── Logical connectives ─────────────────────────────────────────
+    AND(Category.SCALAR, SqlKind.AND),
+    OR(Category.SCALAR, SqlKind.OR),
+    NOT(Category.SCALAR, SqlKind.NOT),
     /** Calcite's Sarg fold for IN / NOT IN / BETWEEN / range-union. Backends expand it before substrait. */
     SARG_PREDICATE(Category.SCALAR, SqlKind.SEARCH),
 

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionAnalyticsBackendPlugin.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionAnalyticsBackendPlugin.java
@@ -269,7 +269,13 @@ public class DataFusionAnalyticsBackendPlugin implements AnalyticsSearchBackendP
         // PPL `mvfind` returns INTEGER (the 0-based index of the first match, or NULL); backed
         // by a custom Rust UDF on the DataFusion session context (`udf::mvfind`), routed via
         // {@link MvfindAdapter}.
-        ScalarFunction.MVFIND
+        ScalarFunction.MVFIND,
+        // Logical connectives — emitted in projections where boolean expressions are composed:
+        // `case(a = 0 and b = 0, …)`, `eval x = a or b`, `eval x = NOT y`. DataFusion's substrait
+        // consumer handles them natively.
+        ScalarFunction.AND,
+        ScalarFunction.OR,
+        ScalarFunction.NOT
     );
 
     /**

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rel/AnnotatedProjectExpression.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rel/AnnotatedProjectExpression.java
@@ -65,6 +65,24 @@ public class AnnotatedProjectExpression extends RexCall implements OperatorAnnot
         return viableBackends;
     }
 
+    /**
+     * Preserves subclass identity when {@link org.apache.calcite.rex.RexShuttle#visitCall}'s
+     * default implementation clones this call with updated operands. Without this override,
+     * {@link RexCall#clone(RelDataType, List)} would produce a plain {@code RexCall} with
+     * {@link #ANNOTATED_PROJECT_EXPR_OP} as its operator — downstream {@code stripAnnotations}
+     * would then fail to recognize it as an annotation (because the pattern match is on the
+     * subclass, not the operator), leaving a {@code ANNOTATED_PROJECT_EXPR(...)} call in the
+     * plan that isthmus cannot convert.
+     */
+    @Override
+    public RexCall clone(RelDataType type, List<RexNode> operands) {
+        RexNode newOriginal = operands.isEmpty() ? original : operands.get(0);
+        if (newOriginal == original && type == this.type) {
+            return this;
+        }
+        return new AnnotatedProjectExpression(type, newOriginal, viableBackends, annotationId);
+    }
+
     @Override
     public int getAnnotationId() {
         return annotationId;

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rel/OpenSearchProject.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rel/OpenSearchProject.java
@@ -153,11 +153,9 @@ public class OpenSearchProject extends Project implements OpenSearchRelNode {
                 RexNode resolved = annotationResolver.apply(annotated);
                 strippedExprs.add(resolved.accept(nestedAnnotationStripper));
             } else {
-                // Baseline scalar operators (OpenSearchProjectRule.BASELINE_SCALAR_OPS —
-                // COALESCE, CASE, CAST, arithmetic, IS_NULL, …) are not wrapped at the
-                // top level but their operands may still be annotated. The shuttle is
-                // idempotent for calls without nested wrappers, so run it unconditionally
-                // to strip AnnotatedProjectExpression at any depth.
+                // Pass-through expressions (RexInputRef, RexLiteral) have no annotation to
+                // resolve. Running the shuttle is defensive and idempotent — atomic nodes
+                // contain no nested AnnotatedProjectExpression to strip.
                 strippedExprs.add(expr.accept(nestedAnnotationStripper));
             }
         }

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchAggregateReduceRule.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchAggregateReduceRule.java
@@ -37,11 +37,11 @@ import java.util.EnumSet;
  * STDDEV/VAR additionally emit {@code MULTIPLY} (for {@code x*x}) and
  * {@code POWER(variance, 0.5)} (sqrt). The {@code SAMP} variants also emit a
  * {@code CASE WHEN count > 1 THEN sqrt(variance) ELSE NULL END} Bessel's-correction
- * guard — the {@code >} comparison operator is in
- * {@link OpenSearchProjectRule#BASELINE_SCALAR_OPS} so it flows through without being
- * wrapped in {@code AnnotatedProjectExpression}. All emitted aggregates are
- * SUM/COUNT primitives that the resolver decomposes through the standard single-field
- * path.
+ * guard. Every operator emitted by the reduction (MULTIPLY, POWER, DIVIDE, CAST,
+ * CASE, comparisons) is declared as a scalar capability by the DataFusion backend,
+ * so the post-reduction Project flows through capability resolution cleanly. All
+ * emitted aggregates are SUM/COUNT primitives that the resolver decomposes through
+ * the standard single-field path.
  *
  * @opensearch.internal
  */

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchProjectRule.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchProjectRule.java
@@ -16,8 +16,6 @@ import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexInputRef;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlFunction;
-import org.apache.calcite.sql.SqlOperator;
-import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.opensearch.analytics.planner.CapabilityRegistry;
 import org.opensearch.analytics.planner.PlannerContext;
 import org.opensearch.analytics.planner.RelNodeUtils;
@@ -30,7 +28,6 @@ import org.opensearch.analytics.spi.ScalarFunction;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 
 /**
  * Converts {@link Project} → {@link OpenSearchProject}.
@@ -38,69 +35,9 @@ import java.util.Set;
  * <p>Validates that the child's backend can evaluate all projection expressions,
  * either natively or via delegation ({@link DelegationType#PROJECT}).
  *
- * <h2>Baseline vs capability-declared scalars</h2>
- * <p>Calcite plan-rewrite rules (e.g. {@code AggregateReduceFunctionsRule},
- * {@code ReduceExpressionsRule}) routinely introduce arithmetic, CAST, CASE, and
- * null-predicate operators while rewriting expressions. These are <em>SQL-execution
- * primitives</em> that every viable backend must support — they are not optional
- * features worth modeling in the capability registry.
- *
- * <p>Treating them as capability-declared creates two bad outcomes: (1) every new
- * backend has to enumerate ~20 operators that are never actually optional, and
- * (2) any Calcite rule that incidentally emits one of them (e.g. a CAST around
- * {@code SUM(x) / COUNT(x)} to match AVG's original return type) would fail plan-time
- * checks with a misleading error, even though the query semantics are unambiguous.
- *
- * <p>{@link #BASELINE_SCALAR_OPS} carves these primitives out of capability-registry
- * enforcement. Operands are still recursed into — a CAST wrapping a non-baseline
- * function still forces the inner function through capability resolution.
- *
  * @opensearch.internal
  */
 public class OpenSearchProjectRule extends RelOptRule {
-
-    /**
-     * Scalar operators that any viable backend is implicitly assumed to support.
-     * These are SQL-execution primitives (arithmetic, type coercion, null handling,
-     * logical composition) that arise incidentally during plan rewriting and that no
-     * real execution engine lacks. They bypass {@link #resolveScalarViableBackends}
-     * and flow through {@link OpenSearchProject} without backend annotation.
-     *
-     * <p>If a future backend genuinely cannot execute one of these operators (e.g.
-     * Lucene rejects a CAST between incompatible types), that becomes a runtime
-     * error inside the backend's executor — complementary to plan-time capability
-     * enforcement, not a replacement for it.
-     *
-     * <p>Intentionally conservative: extend only when a specific plan-rewrite rule
-     * demonstrably emits a new operator that every backend already supports.
-     */
-    private static final Set<SqlOperator> BASELINE_SCALAR_OPS = Set.of(
-        // Arithmetic
-        SqlStdOperatorTable.PLUS,
-        SqlStdOperatorTable.MINUS,
-        SqlStdOperatorTable.MULTIPLY,
-        SqlStdOperatorTable.DIVIDE,
-        SqlStdOperatorTable.UNARY_MINUS,
-        SqlStdOperatorTable.UNARY_PLUS,
-        // Math (emitted by Calcite's AggregateReduceFunctionsRule for STDDEV: POWER(v, 0.5) = sqrt)
-        SqlStdOperatorTable.POWER,
-        // Comparison (emitted by Calcite's AggregateReduceFunctionsRule for STDDEV_SAMP / VAR_SAMP:
-        // CASE WHEN count > 1 THEN sqrt(variance) ELSE NULL END — Bessel's correction guard)
-        SqlStdOperatorTable.GREATER_THAN,
-        SqlStdOperatorTable.GREATER_THAN_OR_EQUAL,
-        SqlStdOperatorTable.LESS_THAN,
-        SqlStdOperatorTable.LESS_THAN_OR_EQUAL,
-        SqlStdOperatorTable.EQUALS,
-        SqlStdOperatorTable.NOT_EQUALS,
-        // Type coercion
-        SqlStdOperatorTable.CAST,
-        // Null handling
-        SqlStdOperatorTable.IS_NULL,
-        SqlStdOperatorTable.IS_NOT_NULL,
-        SqlStdOperatorTable.COALESCE,
-        // Conditional
-        SqlStdOperatorTable.CASE
-    );
 
     private final PlannerContext context;
 
@@ -167,22 +104,9 @@ public class OpenSearchProjectRule extends RelOptRule {
             return expr;
         }
 
-        // Baseline operators — arithmetic, CAST, null-handling, conditional — are assumed
-        // supported by every backend and are not subject to capability-registry enforcement.
-        // Recurse into operands so a non-baseline function nested inside (e.g.
-        // CAST(regexp_match(col, 'x'))) still flows through capability resolution.
-        if (BASELINE_SCALAR_OPS.contains(rexCall.getOperator())) {
-            boolean changed = false;
-            List<RexNode> newOperands = new ArrayList<>(rexCall.getOperands().size());
-            for (RexNode operand : rexCall.getOperands()) {
-                RexNode annotated = annotateExpr(operand, childViableBackends);
-                newOperands.add(annotated);
-                if (annotated != operand) {
-                    changed = true;
-                }
-            }
-            return changed ? rexCall.clone(rexCall.getType(), newOperands) : rexCall;
-        }
+        // All scalar operators (including arithmetic, CAST, null-handling, conditional,
+        // logical connectives) go through the capability registry. Operands recurse via the
+        // "Standard scalar function" path below so nested operators get their own annotations.
 
         // Opaque operations — no recursion into operands
         if (rexCall.getOperator() instanceof SqlFunction sqlFunction) {

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/MockDataFusionBackend.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/MockDataFusionBackend.java
@@ -16,6 +16,7 @@ import org.opensearch.analytics.spi.ExchangeSink;
 import org.opensearch.analytics.spi.ExchangeSinkProvider;
 import org.opensearch.analytics.spi.FieldType;
 import org.opensearch.analytics.spi.FilterCapability;
+import org.opensearch.analytics.spi.ProjectCapability;
 import org.opensearch.analytics.spi.ScalarFunction;
 import org.opensearch.analytics.spi.ScanCapability;
 import org.opensearch.index.engine.dataformat.ReaderManagerConfig;
@@ -119,9 +120,49 @@ public class MockDataFusionBackend extends MockBackend implements SearchBackEndP
         return SCAN_CAPS;
     }
 
+    private static final Set<ScalarFunction> PROJECT_OPS = Set.of(
+        // Arithmetic / math (emitted by Calcite's AggregateReduceFunctionsRule)
+        ScalarFunction.PLUS,
+        ScalarFunction.MINUS,
+        ScalarFunction.TIMES,
+        ScalarFunction.DIVIDE,
+        ScalarFunction.POWER,
+        // Type coercion / null handling
+        ScalarFunction.CAST,
+        ScalarFunction.COALESCE,
+        ScalarFunction.IS_NULL,
+        ScalarFunction.IS_NOT_NULL,
+        // Conditional / comparisons (STDDEV_SAMP / VAR_SAMP emit CASE WHEN count > 1 …)
+        ScalarFunction.CASE,
+        ScalarFunction.EQUALS,
+        ScalarFunction.NOT_EQUALS,
+        ScalarFunction.GREATER_THAN,
+        ScalarFunction.GREATER_THAN_OR_EQUAL,
+        ScalarFunction.LESS_THAN,
+        ScalarFunction.LESS_THAN_OR_EQUAL,
+        // Logical connectives (projection-side composition: `case(a and b, …)`)
+        ScalarFunction.AND,
+        ScalarFunction.OR,
+        ScalarFunction.NOT
+    );
+
+    private static final Set<ProjectCapability> PROJECT_CAPS;
+    static {
+        Set<ProjectCapability> caps = new HashSet<>();
+        for (ScalarFunction op : PROJECT_OPS) {
+            caps.add(new ProjectCapability.Scalar(op, SUPPORTED_TYPES, DATAFUSION_FORMATS, false));
+        }
+        PROJECT_CAPS = caps;
+    }
+
     @Override
     protected Set<FilterCapability> filterCapabilities() {
         return FILTER_CAPS;
+    }
+
+    @Override
+    protected Set<ProjectCapability> projectCapabilities() {
+        return PROJECT_CAPS;
     }
 
     @Override

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/PplClickBenchIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/PplClickBenchIT.java
@@ -32,27 +32,13 @@ public class PplClickBenchIT extends AnalyticsRestTestCase {
      * {@link #SKIP_QUERIES} when a feature is genuinely missing rather than broken.
      */
     // Queries skipped:
-    //  - Missing feature: Q19 (extract(minute from …)), Q40 (case() else + head N from M),
-    //    Q43 (date_format() + head N from M).
-    //  - Substrait emit can't find a MIN binding for VARCHAR inputs (isthmus library):
-    //    Q29 (min(Referer) where Referer is text). Needs a min(string) binding in
-    //    the aggregate function catalog or an equivalent adapter.
-    //  - Multi-shard exchange can't serialize TIMESTAMP (LocalDateTime): Q7, Q24-Q27,
-    //    Q37-Q42.
-    //  - WHERE + GROUP-BY + aggregate on multi-shard triggers Arrow "project index 0
-    //    out of bounds, max field 0": Q11, Q12, Q13, Q14, Q15, Q22, Q23, Q31, Q32;
-    //    plus Q20 (WHERE + fields, no aggregate, still routed through multi-shard path).
-    // DEBUG: temporarily un-skip the multi-shard-only failures to see if they
-    // pass on single-shard (where the split rule doesn't fire and no exchange
-    // traffic / no native-side aggregate reduce is exercised).
-    // Queries skipped — all known PPL frontend / Substrait gaps, unrelated to the
-    // distributed aggregate execution path:
-    //  - Q19: extract(minute from …) not supported by the PPL frontend.
-    //  - Q29: Substrait can't bind MIN on VARCHAR inputs (isthmus library limitation).
-    //    Requires a min(string) binding in the aggregate function catalog.
-    //  - Q40: case() else + head N from M — PPL frontend gap.
-    //  - Q43: date_format() + head N from M — PPL frontend gap.
-    private static final Set<Integer> SKIP_QUERIES = Set.of(19, 29, 40, 43);
+    //  - Q29: Substrait's default aggregate catalog has no min/max binding for string
+    //    types. Isthmus fails with "Unable to find binding for call MIN($1)" when PPL
+    //    emits `min(Referer)` on a VARCHAR column. DataFusion can execute min(Utf8)
+    //    natively — the gap is purely in the Substrait serialization layer. A fix
+    //    would register additional min/max impls covering string types in the loaded
+    //    SimpleExtension.ExtensionCollection at plugin init.
+    private static final Set<Integer> SKIP_QUERIES = Set.of(29);
 
     private static boolean dataProvisioned = false;
 


### PR DESCRIPTION


<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
   - Adds `AND` / `OR` / `NOT` to `OpenSearchProjectRule.BASELINE_SCALAR_OPS`. Logical
     connectives are universal SQL primitives; filter rule already recurses through them
     structurally, projections need them in the baseline set so expressions like
     `eval x = case(a = 0 and b = 0, …)` flow through without hitting capability resolution.
   - Reduces `PplClickBenchIT.SKIP_QUERIES` from `{19, 29, 40, 43}` to `{29}`:
     - **Q19 / Q43** pass — unblocked by Wave A datetime UDFs on main.
     - **Q40** passes — unblocked by the AND/OR/NOT addition in this PR.
     - **Q29** remains skipped — Substrait's default aggregate catalog has no `min`/`max`
       binding for string types; tracked as a follow-up (register additional impls in the
       loaded `SimpleExtension.ExtensionCollection` at plugin init).

### Testing

   `:sandbox:qa:analytics-engine-rest:integTest --tests PplClickBenchIT`
   → 42 queries run, 1 skipped (Q29), 0 failures.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
