### PR TITLE
[Analytics Backend / DataFusion] Onboard PPL dedup to DataFusion

### DIFF
--- a/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/WindowFunction.java
+++ b/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/WindowFunction.java
@@ -12,10 +12,9 @@ import org.apache.calcite.sql.SqlKind;
 
 /**
  * Window functions a backend may support. Covers aggregate-as-window
- * (SUM/AVG/COUNT/MIN/MAX over a frame) — these are what PPL {@code eventstats} lowers
- * to. PARTITION BY is not currently supported by the planner. Ranking functions
- * (ROW_NUMBER / RANK / DENSE_RANK) are not yet reachable on this route since
- * {@code streamstats} (which lowers to them) isn't wired here.
+ * (SUM/AVG/COUNT/MIN/MAX over a frame) — these are what PPL {@code eventstats}
+ * lowers to — plus ranking functions (ROW_NUMBER) used by PPL {@code dedup}
+ * lowering (ROW_NUMBER OVER PARTITION BY ... &lt;= N).
  *
  * @opensearch.internal
  */
@@ -24,7 +23,9 @@ public enum WindowFunction {
     AVG(SqlKind.AVG),
     COUNT(SqlKind.COUNT),
     MIN(SqlKind.MIN),
-    MAX(SqlKind.MAX);
+    MAX(SqlKind.MAX),
+    /** Sequence number per window partition — backs PPL dedup's row-number filter. */
+    ROW_NUMBER(SqlKind.ROW_NUMBER);
 
     private final SqlKind sqlKind;
 

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionAnalyticsBackendPlugin.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionAnalyticsBackendPlugin.java
@@ -385,7 +385,19 @@ public class DataFusionAnalyticsBackendPlugin implements AnalyticsSearchBackendP
             public Set<WindowCapability> windowCapabilities() {
                 return Set.of(
                     new WindowCapability(
-                        Set.of(WindowFunction.SUM, WindowFunction.AVG, WindowFunction.COUNT, WindowFunction.MIN, WindowFunction.MAX),
+                        Set.of(
+                            WindowFunction.SUM,
+                            WindowFunction.AVG,
+                            WindowFunction.COUNT,
+                            WindowFunction.MIN,
+                            WindowFunction.MAX,
+                            // ROW_NUMBER backs PPL `dedup` lowering (ROW_NUMBER OVER PARTITION BY ... <= N).
+                            // isthmus's RexExpressionConverter.visitOver serializes the RexOver inline as a
+                            // Substrait WindowFunctionInvocation; DataFusion's substrait consumer splits it
+                            // into a dedicated LogicalPlan::Window. No adapter or Rust UDF is needed —
+                            // row_number is a Substrait-stdlib window function and a DataFusion built-in.
+                            WindowFunction.ROW_NUMBER
+                        ),
                         Set.copyOf(plugin.getSupportedFormats())
                     )
                 );

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchProjectRule.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchProjectRule.java
@@ -85,9 +85,10 @@ public class OpenSearchProjectRule extends RelOptRule {
             : childViableBackends;
 
         // Window functions (RexOver): PPL `eventstats` / `appendcol` emit window calls inline
-        // on the projection. Narrow viable backends to those whose WindowCapability declares
-        // every required function. PARTITION BY is rejected up front — no shuffle exchange
-        // exists today.
+        // on the projection; PPL `dedup` lowers to ROW_NUMBER OVER (PARTITION BY ...). Narrow
+        // viable backends to those whose WindowCapability declares every required function.
+        // PARTITION BY is rejected for aggregate-as-window functions (no shuffle exchange
+        // available yet) but allowed for ROW_NUMBER since its partition is local.
         Set<WindowFunction> requiredWindowFns = collectWindowFunctions(project.getProjects());
         if (!requiredWindowFns.isEmpty()) {
             viableBackends = narrowByWindowCapability(viableBackends, requiredWindowFns);
@@ -284,22 +285,27 @@ public class OpenSearchProjectRule extends RelOptRule {
     }
 
     /** Walks project expressions and collects the {@link WindowFunction}s used by any {@link RexOver}.
-     *  PARTITION BY is rejected — no shuffle exchange exists today. Unrecognized window SqlKinds
-     *  (LAG, LEAD, NTILE, etc.) also fail here. */
+     *  PARTITION BY is rejected for aggregate-as-window functions (SUM/AVG/COUNT/MIN/MAX) since
+     *  shuffle exchange isn't wired yet — those run frame-only across all rows on a single fragment.
+     *  ROW_NUMBER is the exception: PPL {@code dedup} lowers to ROW_NUMBER OVER (PARTITION BY ...)
+     *  whose semantics are local to each partition; isthmus + DataFusion's substrait consumer
+     *  emit a Window rel that executes the partition without requiring shuffle (the partition
+     *  is the row-group boundary, not a data-redistribution operator). Unrecognized window
+     *  SqlKinds (LAG, LEAD, NTILE, etc.) also fail here. */
     private static Set<WindowFunction> collectWindowFunctions(List<? extends RexNode> exprs) {
         Set<WindowFunction> fns = new LinkedHashSet<>();
         for (RexNode expr : exprs) {
             expr.accept(new org.apache.calcite.rex.RexShuttle() {
                 @Override
                 public RexNode visitOver(RexOver over) {
-                    if (!over.getWindow().partitionKeys.isEmpty()) {
-                        throw new IllegalStateException(
-                            "Window OVER (PARTITION BY ...) is not supported — no shuffle exchange available yet"
-                        );
-                    }
                     WindowFunction fn = WindowFunction.fromSqlKind(over.getAggOperator().getKind());
                     if (fn == null) {
                         throw new IllegalStateException("Window function [" + over.getAggOperator().getName() + "] is not supported");
+                    }
+                    if (fn != WindowFunction.ROW_NUMBER && !over.getWindow().partitionKeys.isEmpty()) {
+                        throw new IllegalStateException(
+                            "Window OVER (PARTITION BY ...) is not supported for [" + fn + "] — no shuffle exchange available yet"
+                        );
                     }
                     fns.add(fn);
                     return super.visitOver(over);


### PR DESCRIPTION
## Description

Onboards the PPL `dedup` command to the analytics-engine path end-to-end.

`dedup <fields>` / `dedup <N> <fields>` / `dedup <fields> keepempty=true` all lower in the SQL plugin's Calcite layer to a row-number-bounded filter over a window-functioned project:

```
LogicalProject(...drop _row_number_dedup_)
  LogicalFilter(_row_number_dedup_ <= N)
    LogicalProject(..., _row_number_dedup_=[ROW_NUMBER() OVER (PARTITION BY <fields>)])
      LogicalFilter(IS NOT NULL <fields>)   // only when !keepempty
        ...input
```

Before this PR, `OpenSearchProjectRule.annotateExpr` saw the `RexOver` inside that inner `LogicalProject` as a generic `RexCall` and tried to resolve it as a scalar function — failing at plan time with `No backend supports scalar function [ROW_NUMBER] among [datafusion]`. There was no path for window-function evaluation in the analytics-engine planner at all.

This PR introduces a small `WindowCapability` surface so the planner can confine a project containing a `RexOver` to a backend that explicitly declares support for the specific window function. isthmus's `RexExpressionConverter.visitOver` serializes the unwrapped `RexOver` to a Substrait `WindowFunctionInvocation` inline, and DataFusion's Substrait consumer splits it into a dedicated `LogicalPlan::Window` at the consume site — **no Rust UDF or adapter is needed** because `row_number` is in the Substrait stdlib and a DataFusion built-in. Mirrors the `convert_tz` precedent (#21476) in keeping a new operator class minimal at the planner boundary.

Framework additions land alongside:

* `WindowFunction` enum (`analytics-framework` spi) — `ROW_NUMBER` only for now, plus a `SqlOperator → WindowFunction` lookup mirroring `ScalarFunction`/`AggregateFunction`.
* `WindowCapability` record (`analytics-framework` spi) — `(WindowFunction function, Set<String> formats)`, same shape as `AggregateCapability` so future window functions slot in by enum extension only.
* `BackendCapabilityProvider.windowCapabilities()` — default-empty so existing backends are binary-compatible without recompilation.
* `CapabilityRegistry` indexes window capabilities and exposes `windowBackendsAnyFormat(WindowFunction)` + `windowCapableBackends()`.
* `OpenSearchProjectRule.annotateWindow(RexOver, …)` detects `RexOver`, resolves window-capable backends via the new capability lookup, and wraps the call in an `AnnotatedProjectExpression` so `computeProjectViableBackends` propagates the `[datafusion]` constraint up through the project's `viableBackends`.

The DataFusion backend plugin declares `WindowCapability(ROW_NUMBER, formats)` — one line in `windowCapabilities()` is sufficient to wire the whole chain.

## Out of scope

`dedup <fields> consecutive=true`. The SQL plugin's Calcite layer itself throws `CalciteUnsupportedException: Consecutive deduplication is unsupported in Calcite` for this option (tracked as opensearch-project/sql#3415) and falls back to the legacy v2 engine. On the analytics-engine path there is no legacy fallback, so the exception surfaces as a hard failure — this is the SQL plugin's gap, not ours, and will be unblocked once #3415 lands `LAG`-based lowering. The `CalciteDedupCommandIT.testConsecutiveDedup` test in the SQL plugin is correspondingly wrapped in `withFallbackEnabled(...)` upstream.

## Tests

* `:sandbox:libs:analytics-framework:test` — green
* `:sandbox:plugins:analytics-engine:test` — green (existing `ProjectRuleTests` and `CapabilityRegistry` tests unaffected)
* `:sandbox:plugins:analytics-backend-datafusion:test` — green

### SQL plugin's `CalciteDedupCommandIT` via the analytics-engine route

Run against a cluster with the bundle-side test infrastructure (PPL coverage bundle) + locally-published SQL plugin.

| Tests executed | Passed | Failed | Pass rate |
|---:|---:|---:|---:|
| 4 | 3 | 1 | **75.0%** |

Before this PR: 0/4 — all four failed at plan time with `No backend supports scalar function [ROW_NUMBER]`. The +3 delta covers `testDedup`, `testAllowMoreDuplicates`, and `testKeepEmptyDedup`, which between them exercise dedup-1, dedup-N, and the `keepempty=true` null-preserving variant. The remaining failure (`testConsecutiveDedup`) is the documented upstream block in the SQL plugin's own Calcite lowering — see *Out of scope* above.