### PR TITLE
Added scan support for indexed fieldTypes

### DIFF
--- a/.github/workflows/sandbox-check.yml
+++ b/.github/workflows/sandbox-check.yml
@@ -32,18 +32,8 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
       - name: Install protobuf compiler
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
-      - name: Check out SQL repo (mustang-ppl-integration)
-        uses: actions/checkout@v6
-        with:
-          repository: opensearch-project/sql
-          ref: feature/mustang-ppl-integration
-          path: sql
-      - name: Publish unified-query artifacts to maven local
-        working-directory: sql
-        continue-on-error: true
-        run: ./gradlew publishUnifiedQueryPublicationToMavenLocal
       - name: Run sandbox check
-        run: ./gradlew check -p sandbox -Dsandbox.enabled=true -Drepos.mavenLocal=true -PrustDebug
+        run: ./gradlew check -p sandbox -Dsandbox.enabled=true -PrustDebug
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v4

--- a/sandbox/libs/analytics-api/src/main/java/org/opensearch/analytics/schema/OpenSearchSchemaBuilder.java
+++ b/sandbox/libs/analytics-api/src/main/java/org/opensearch/analytics/schema/OpenSearchSchemaBuilder.java
@@ -68,18 +68,22 @@ public class OpenSearchSchemaBuilder {
      *
      * <p>Type mapping:
      * <ul>
-     *   <li>keyword/text -> VARCHAR</li>
+     *   <li>keyword/text/match_only_text -> VARCHAR</li>
      *   <li>long -> BIGINT</li>
+     *   <li>unsigned_long -> BIGINT</li>
      *   <li>integer -> INTEGER</li>
      *   <li>short -> SMALLINT</li>
      *   <li>byte -> TINYINT</li>
      *   <li>double -> DOUBLE</li>
-     *   <li>float -> FLOAT</li>
+     *   <li>float -> REAL</li>
+     *   <li>scaled_float -> BIGINT</li>
      *   <li>boolean -> BOOLEAN</li>
      *   <li>date -> TIMESTAMP</li>
-     *   <li>ip -> VARCHAR</li>
+     *   <li>date_nanos -> TIMESTAMP</li>
+     *   <li>ip -> VARBINARY</li>
+     *   <li>binary -> VARBINARY</li>
      *   <li>nested/object -> skip (not mapped)</li>
-     *   <li>unknown -> VARCHAR (default)</li>
+     *   <li>unknown -> throws IllegalArgumentException</li>
      * </ul>
      *
      * @param opensearchType the OpenSearch field type string
@@ -88,9 +92,13 @@ public class OpenSearchSchemaBuilder {
         switch (opensearchType) {
             case "keyword":
             case "text":
-            case "ip":
+            case "match_only_text":
                 return SqlTypeName.VARCHAR;
             case "long":
+            case "unsigned_long":
+                // unsigned_long: values above 2^63 - 1 wrap into negatives because BIGINT is
+                // signed and Substrait has no unsigned integer types. Smaller values are safe.
+            case "scaled_float":
                 return SqlTypeName.BIGINT;
             case "integer":
                 return SqlTypeName.INTEGER;
@@ -101,13 +109,17 @@ public class OpenSearchSchemaBuilder {
             case "double":
                 return SqlTypeName.DOUBLE;
             case "float":
-                return SqlTypeName.FLOAT;
+                return SqlTypeName.REAL;
             case "boolean":
                 return SqlTypeName.BOOLEAN;
             case "date":
+            case "date_nanos":
                 return SqlTypeName.TIMESTAMP;
+            case "ip":
+            case "binary":
+                return SqlTypeName.VARBINARY;
             default:
-                return SqlTypeName.VARCHAR;
+                throw new IllegalArgumentException("Unsupported OpenSearch field type: " + opensearchType);
         }
     }
 

--- a/sandbox/libs/analytics-api/src/main/java/org/opensearch/analytics/schema/OpenSearchSchemaBuilder.java
+++ b/sandbox/libs/analytics-api/src/main/java/org/opensearch/analytics/schema/OpenSearchSchemaBuilder.java
@@ -76,6 +76,7 @@ public class OpenSearchSchemaBuilder {
      *   <li>byte -> TINYINT</li>
      *   <li>double -> DOUBLE</li>
      *   <li>float -> REAL</li>
+     *   <li>half_float -> REAL</li>
      *   <li>scaled_float -> BIGINT</li>
      *   <li>boolean -> BOOLEAN</li>
      *   <li>date -> TIMESTAMP</li>
@@ -98,6 +99,8 @@ public class OpenSearchSchemaBuilder {
             case "unsigned_long":
                 // unsigned_long: values above 2^63 - 1 wrap into negatives because BIGINT is
                 // signed and Substrait has no unsigned integer types. Smaller values are safe.
+                // TODO: values above 2^63 - 1 wrap into negatives. Drop the UInt64 → Int64 narrowing
+                // (see schema_coerce.rs) when we have a proper solution.
             case "scaled_float":
                 return SqlTypeName.BIGINT;
             case "integer":
@@ -109,6 +112,13 @@ public class OpenSearchSchemaBuilder {
             case "double":
                 return SqlTypeName.DOUBLE;
             case "float":
+            case "half_float":
+                // half_float lands as Arrow Float16 on disk. Calcite has no fp16 type; widen to
+                // REAL so the planner sees the same shape as a regular float column. The parquet
+                // reader's SchemaAdapter casts Float16 → Float32 per batch.
+                // TODO: every record batch goes through a Float16 → Float32 cast (see
+                // schema_coerce.rs) and downstream operators see Float32. Drop the widening when
+                // we have a proper solution.
                 return SqlTypeName.REAL;
             case "boolean":
                 return SqlTypeName.BOOLEAN;

--- a/sandbox/libs/analytics-api/src/main/java/org/opensearch/analytics/schema/OpenSearchSchemaBuilder.java
+++ b/sandbox/libs/analytics-api/src/main/java/org/opensearch/analytics/schema/OpenSearchSchemaBuilder.java
@@ -117,6 +117,9 @@ public class OpenSearchSchemaBuilder {
                 return SqlTypeName.TIMESTAMP;
             case "ip":
             case "binary":
+                // TODO: differentiate ip and binary as separate UDTs instead of collapsing both
+                // to VARBINARY. With the type preserved, literals can be converted into the
+                // on-disk byte form the planner expects.
                 return SqlTypeName.VARBINARY;
             default:
                 throw new IllegalArgumentException("Unsupported OpenSearch field type: " + opensearchType);

--- a/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/ScalarFunction.java
+++ b/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/ScalarFunction.java
@@ -165,6 +165,9 @@ public enum ScalarFunction {
 
     EXTRACT(Category.SCALAR, SqlKind.EXTRACT),
 
+    // ── Conversion (placeholder UDFs rewritten by backend adapters) ──
+    BINARY(Category.SCALAR, SqlKind.OTHER_FUNCTION),
+
     // ── Datetime ────────────────────────────────────────────────────
     // fromSqlFunction resolves via valueOf(name.toUpperCase()), so the enum name IS
     // the wire contract. Aliases each need their own entry; the adapter map points

--- a/sandbox/plugins/analytics-backend-datafusion/build.gradle
+++ b/sandbox/plugins/analytics-backend-datafusion/build.gradle
@@ -72,6 +72,9 @@ dependencies {
   // Substrait — Calcite RelNode to Substrait plan conversion for DataFusion native runtime
   implementation "io.substrait:isthmus:0.89.1"
   implementation "io.substrait:core:0.89.1"
+  // avatica ByteString is needed at compile time for IpBinaryFunctionAdapter's VARBINARY
+  // literal construction; runtime is provided by analytics-framework's runtimeOnly avatica.
+  compileOnly "org.apache.calcite.avatica:avatica-core:1.27.0"
   implementation "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:${versions.jackson}"
   // jackson-datatype-jsr310 — added to arrow-flight-rpc (the parent plugin that bundles
   // arrow-vector). arrow-vector's JsonStringArrayList eagerly registers JavaTimeModule on

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/api.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/api.rs
@@ -518,7 +518,7 @@ pub unsafe fn sql_to_substrait(
         let schema = listing_options
             .infer_schema(&ctx.state(), &table_path)
             .await?;
-        let schema = crate::schema_coerce::coerce_for_substrait(schema);
+        let schema = crate::schema_coerce::coerce_inferred_schema(schema);
         let config = ListingTableConfig::new(table_path)
             .with_listing_options(listing_options)
             .with_schema(schema);

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/api.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/api.rs
@@ -518,6 +518,7 @@ pub unsafe fn sql_to_substrait(
         let schema = listing_options
             .infer_schema(&ctx.state(), &table_path)
             .await?;
+        let schema = crate::schema_coerce::coerce_for_substrait(schema);
         let config = ListingTableConfig::new(table_path)
             .with_listing_options(listing_options)
             .with_schema(schema);

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_executor.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_executor.rs
@@ -156,7 +156,7 @@ pub async fn execute_indexed_query(
     let resolved_schema = listing_options
         .infer_schema(&ctx.state(), &shard_view.table_path)
         .await?;
-    let resolved_schema = crate::schema_coerce::coerce_for_substrait(resolved_schema);
+    let resolved_schema = crate::schema_coerce::coerce_inferred_schema(resolved_schema);
     let table_config = datafusion::datasource::listing::ListingTableConfig::new(shard_view.table_path.clone())
         .with_listing_options(listing_options)
         .with_schema(resolved_schema);

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_executor.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_executor.rs
@@ -156,6 +156,7 @@ pub async fn execute_indexed_query(
     let resolved_schema = listing_options
         .infer_schema(&ctx.state(), &shard_view.table_path)
         .await?;
+    let resolved_schema = crate::schema_coerce::coerce_for_substrait(resolved_schema);
     let table_config = datafusion::datasource::listing::ListingTableConfig::new(shard_view.table_path.clone())
         .with_listing_options(listing_options)
         .with_schema(resolved_schema);

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/lib.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/lib.rs
@@ -30,6 +30,7 @@ pub mod partition_stream;
 pub mod query_executor;
 pub mod query_tracker;
 pub mod runtime_manager;
+pub mod schema_coerce;
 pub mod session_context;
 pub mod statistics_cache;
 pub mod udf;

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/query_executor.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/query_executor.rs
@@ -126,7 +126,7 @@ pub async fn execute_query(
             error!("Failed to infer schema: {}", e);
             e
         })?;
-    let resolved_schema = crate::schema_coerce::coerce_for_substrait(resolved_schema);
+    let resolved_schema = crate::schema_coerce::coerce_inferred_schema(resolved_schema);
 
     let table_config = ListingTableConfig::new(table_path)
         .with_listing_options(listing_options)

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/query_executor.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/query_executor.rs
@@ -126,6 +126,7 @@ pub async fn execute_query(
             error!("Failed to infer schema: {}", e);
             e
         })?;
+    let resolved_schema = crate::schema_coerce::coerce_for_substrait(resolved_schema);
 
     let table_config = ListingTableConfig::new(table_path)
         .with_listing_options(listing_options)

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/schema_coerce.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/schema_coerce.rs
@@ -34,6 +34,11 @@
 //!     no arm for them today (DF 53). If it becomes available in DataFusion,
 //!     the `BinaryView → Binary` rewrite here can be removed.
 //!
+//!     TODO: every record batch goes through a `BinaryView → Binary` cast in the
+//!     SchemaAdapter (offset+data buffer copy), and downstream operators see
+//!     `Binary` rather than `BinaryView`. Drop this arm when we have a proper
+//!     solution.
+//!
 //!   - `(Int64, UInt64)` is a Substrait + Calcite gap. Substrait's integer
 //!     types are signed-only and Calcite has no unsigned `BIGINT`, so the
 //!     unsigned semantics are lost before the plan reaches DataFusion. Values

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/schema_coerce.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/schema_coerce.rs
@@ -10,12 +10,11 @@
 //!
 //! Substrait's type system is narrower than Arrow's. The DataFusion Substrait
 //! consumer rejects scans whose table-provider schema is not
-//! `datatype_is_logically_equal` to the schema declared in the plan. That
-//! function in DataFusion 53 has hardcoded equivalences for `(Utf8, Utf8View)`
-//! but not for several other Arrow/Substrait-incompatible pairs we hit:
+//! `datatype_is_logically_equal` to the schema declared in the plan. The pairs
+//! we hit on this path:
 //!
 //!   - `BinaryView`  ← parquet emits this for variable-length byte columns
-//!     (and for fixed-width byte arrays like OpenSearch's 16-byte `ip`) when
+//!     (including OpenSearch's 16-byte `ip` and `binary` mappings) when
 //!     `schema_force_view_types` is on. Substrait has no view types — isthmus
 //!     serializes `VARBINARY` as plain `binary`, which arrives as
 //!     `DataType::Binary`.
@@ -24,14 +23,45 @@
 //!     Substrait integers are signed only — Calcite `BIGINT` serializes as
 //!     `i64`, which arrives as `DataType::Int64`.
 //!
-//! Until upstream patches add equivalence arms (mirroring the existing
-//! Utf8/Utf8View pair), we normalize the inferred schema at the table-provider
-//! boundary: substitute the Arrow-only types with their Substrait-compatible
-//! counterparts before handing the schema to `ListingTableConfig`. The parquet
-//! reader's `SchemaAdapter` inserts the per-batch cast at read time.
+//! `Utf8View` doesn't need coercing: DataFusion 53's
+//! `DFSchema::datatype_is_logically_equal` (in `datafusion-common/src/dfschema.rs`)
+//! has hardcoded match arms `(Utf8, Utf8View) => true` and `(Utf8View, Utf8) => true`,
+//! so a Substrait plan declaring `Utf8` binds cleanly against a table column
+//! reporting `Utf8View`. The two cases above are different in nature:
 //!
-//! Strings keep their `Utf8View` layout because the upstream Utf8/Utf8View
-//! equivalence already lets them pass through without a coerce.
+//!   - `(Binary, BinaryView)` is a missing equivalence in DataFusion. The two
+//!     types are semantically identical, but `datatype_is_logically_equal` has
+//!     no arm for them today (DF 53). If it becomes available in DataFusion,
+//!     the `BinaryView → Binary` rewrite here can be removed.
+//!
+//!   - `(Int64, UInt64)` is a Substrait + Calcite gap. Substrait's integer
+//!     types are signed-only and Calcite has no unsigned `BIGINT`, so the
+//!     unsigned semantics are lost before the plan reaches DataFusion. Values
+//!     above `2^63 - 1` wrap into negatives — documented in
+//!     `OpenSearchSchemaBuilder.mapFieldType`. Narrowing at the scan boundary
+//!     is the only fix until Substrait grows unsigned types (see Substrait
+//!     `proto/type.proto`).
+//!
+//! We rewrite the inferred schema at the table-provider boundary: substitute the
+//! Arrow-only types with their Substrait-compatible counterparts before handing
+//! the schema to `ListingTableConfig`. The parquet reader's `SchemaAdapter` then
+//! inserts the per-batch cast at read time (zero-copy bit reinterpret for
+//! `UInt64 → Int64`; cheap buffer relabeling for `BinaryView → Binary`).
+//!
+//! Alternatives considered:
+//!
+//!   - Disable view types entirely with
+//!     `execution.parquet.schema_force_view_types = false` (threaded into
+//!     `ParquetFormat::with_options`). Makes the reader emit `Utf8/Binary` instead
+//!     of `Utf8View/BinaryView`. Removes the BinaryView mismatch but also strips
+//!     `Utf8View` from string columns, giving up the inline-prefix optimization
+//!     on filter/group-by/hash paths.
+//!
+//!   - Skip `infer_schema` entirely and construct the Arrow schema directly from
+//!     the OpenSearch mapping (the same source Calcite reads). Single source of
+//!     truth, no post-process step. Costs the cross-language plumbing to ship
+//!     the schema from Java to Rust and adds a second mapping table to keep in
+//!     sync with `OpenSearchSchemaBuilder.mapFieldType`.
 
 use std::sync::Arc;
 
@@ -45,7 +75,7 @@ use datafusion::arrow::datatypes::{DataType, Field, Fields, Schema, SchemaRef};
 /// `Union`, and `Dictionary`. Returns the input unchanged when no rewrite is
 /// needed so callers avoid an unnecessary `Arc` reallocation in the common
 /// case.
-pub fn coerce_for_substrait(schema: SchemaRef) -> SchemaRef {
+pub fn coerce_inferred_schema(schema: SchemaRef) -> SchemaRef {
     if !schema_needs_coerce(&schema) {
         return schema;
     }
@@ -113,7 +143,7 @@ mod tests {
             Field::new("a", DataType::Int64, true),
             Field::new("b", DataType::BinaryView, true),
         ]));
-        let out = coerce_for_substrait(schema);
+        let out = coerce_inferred_schema(schema);
         assert_eq!(out.field(0).data_type(), &DataType::Int64);
         assert_eq!(out.field(1).data_type(), &DataType::Binary);
     }
@@ -124,7 +154,7 @@ mod tests {
             Field::new("a", DataType::UInt64, true),
             Field::new("b", DataType::Int64, true),
         ]));
-        let out = coerce_for_substrait(schema);
+        let out = coerce_inferred_schema(schema);
         assert_eq!(out.field(0).data_type(), &DataType::Int64);
         assert_eq!(out.field(1).data_type(), &DataType::Int64);
     }
@@ -136,7 +166,7 @@ mod tests {
             Field::new("b", DataType::Utf8View, true),
         ]));
         let before = Arc::as_ptr(&schema);
-        let out = coerce_for_substrait(schema);
+        let out = coerce_inferred_schema(schema);
         assert_eq!(Arc::as_ptr(&out), before, "unchanged schema must not reallocate");
     }
 
@@ -146,7 +176,7 @@ mod tests {
         let schema = Arc::new(Schema::new(vec![
             Field::new("xs", DataType::List(Arc::new(inner)), true),
         ]));
-        let out = coerce_for_substrait(schema);
+        let out = coerce_inferred_schema(schema);
         match out.field(0).data_type() {
             DataType::List(f) => assert_eq!(f.data_type(), &DataType::Binary),
             other => panic!("expected List, got {other:?}"),
@@ -159,7 +189,7 @@ mod tests {
         let schema = Arc::new(Schema::new(vec![
             Field::new("xs", DataType::List(Arc::new(inner)), true),
         ]));
-        let out = coerce_for_substrait(schema);
+        let out = coerce_inferred_schema(schema);
         match out.field(0).data_type() {
             DataType::List(f) => assert_eq!(f.data_type(), &DataType::Int64),
             other => panic!("expected List, got {other:?}"),
@@ -172,7 +202,7 @@ mod tests {
         md.insert("key".to_string(), "value".to_string());
         let f = Field::new("b", DataType::BinaryView, false).with_metadata(md.clone());
         let schema = Arc::new(Schema::new(vec![f]));
-        let out = coerce_for_substrait(schema);
+        let out = coerce_inferred_schema(schema);
         assert!(!out.field(0).is_nullable());
         assert_eq!(out.field(0).metadata(), &md);
     }
@@ -183,7 +213,7 @@ mod tests {
             Field::new("s", DataType::Utf8View, true),
             Field::new("b", DataType::BinaryView, true),
         ]));
-        let out = coerce_for_substrait(schema);
+        let out = coerce_inferred_schema(schema);
         assert_eq!(out.field(0).data_type(), &DataType::Utf8View);
         assert_eq!(out.field(1).data_type(), &DataType::Binary);
     }
@@ -200,7 +230,7 @@ mod tests {
             Field::new("c", DataType::UInt32, true),
         ]));
         let before = Arc::as_ptr(&schema);
-        let out = coerce_for_substrait(schema);
+        let out = coerce_inferred_schema(schema);
         assert_eq!(Arc::as_ptr(&out), before);
     }
 }

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/schema_coerce.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/schema_coerce.rs
@@ -23,6 +23,10 @@
 //!     Substrait integers are signed only — Calcite `BIGINT` serializes as
 //!     `i64`, which arrives as `DataType::Int64`.
 //!
+//!   - `Float16`     ← parquet emits this for `half_float` columns. Calcite has
+//!     no fp16 type; `OpenSearchSchemaBuilder` maps it to `REAL` which Substrait
+//!     serializes as `fp32`, arriving as `DataType::Float32`.
+//!
 //! `Utf8View` doesn't need coercing: DataFusion 53's
 //! `DFSchema::datatype_is_logically_equal` (in `datafusion-common/src/dfschema.rs`)
 //! has hardcoded match arms `(Utf8, Utf8View) => true` and `(Utf8View, Utf8) => true`,
@@ -46,6 +50,19 @@
 //!     `OpenSearchSchemaBuilder.mapFieldType`. Narrowing at the scan boundary
 //!     is the only fix until Substrait grows unsigned types (see Substrait
 //!     `proto/type.proto`).
+//!
+//!     TODO: values above `2^63 - 1` wrap into negatives. Drop this arm when we
+//!     have a proper solution.
+//!
+//!   - `(Float32, Float16)` is a Calcite-side gap: Calcite has no fp16 type, so
+//!     `half_float` columns are widened to `REAL` (fp32) at the Java planner.
+//!     Every record batch goes through a `Float16 → Float32` cast in the
+//!     SchemaAdapter, and downstream operators see `Float32` rather than
+//!     `Float16` — so we lose the half-precision storage benefit at compute time.
+//!
+//!     TODO: every record batch goes through a `Float16 → Float32` cast and
+//!     downstream operators see `Float32`. Drop this arm when we have a proper
+//!     solution.
 //!
 //! We rewrite the inferred schema at the table-provider boundary: substitute the
 //! Arrow-only types with their Substrait-compatible counterparts before handing
@@ -75,6 +92,7 @@ use datafusion::arrow::datatypes::{DataType, Field, Fields, Schema, SchemaRef};
 /// Rewrite the schema to forms Substrait can bind against:
 ///   - `BinaryView` → `Binary`
 ///   - `UInt64`     → `Int64`
+///   - `Float16`    → `Float32`
 ///
 /// Recurses into `List`, `LargeList`, `FixedSizeList`, `Map`, `Struct`,
 /// `Union`, and `Dictionary`. Returns the input unchanged when no rewrite is
@@ -101,7 +119,7 @@ fn schema_needs_coerce(schema: &Schema) -> bool {
 
 fn contains_incompatible(dt: &DataType) -> bool {
     match dt {
-        DataType::BinaryView | DataType::UInt64 => true,
+        DataType::BinaryView | DataType::UInt64 | DataType::Float16 => true,
         DataType::List(f) | DataType::LargeList(f) | DataType::FixedSizeList(f, _) => {
             contains_incompatible(f.data_type())
         }
@@ -123,6 +141,7 @@ fn rewrite_data_type(dt: &DataType) -> DataType {
     match dt {
         DataType::BinaryView => DataType::Binary,
         DataType::UInt64 => DataType::Int64,
+        DataType::Float16 => DataType::Float32,
         DataType::List(f) => DataType::List(Arc::new(rewrite_field(f))),
         DataType::LargeList(f) => DataType::LargeList(Arc::new(rewrite_field(f))),
         DataType::FixedSizeList(f, n) => DataType::FixedSizeList(Arc::new(rewrite_field(f)), *n),

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/schema_coerce.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/schema_coerce.rs
@@ -1,0 +1,206 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+//! Schema coercion at the Substrait/DataFusion scan boundary.
+//!
+//! Substrait's type system is narrower than Arrow's. The DataFusion Substrait
+//! consumer rejects scans whose table-provider schema is not
+//! `datatype_is_logically_equal` to the schema declared in the plan. That
+//! function in DataFusion 53 has hardcoded equivalences for `(Utf8, Utf8View)`
+//! but not for several other Arrow/Substrait-incompatible pairs we hit:
+//!
+//!   - `BinaryView`  ← parquet emits this for variable-length byte columns
+//!     (and for fixed-width byte arrays like OpenSearch's 16-byte `ip`) when
+//!     `schema_force_view_types` is on. Substrait has no view types — isthmus
+//!     serializes `VARBINARY` as plain `binary`, which arrives as
+//!     `DataType::Binary`.
+//!
+//!   - `UInt64`      ← parquet emits this for `unsigned_long` columns.
+//!     Substrait integers are signed only — Calcite `BIGINT` serializes as
+//!     `i64`, which arrives as `DataType::Int64`.
+//!
+//! Until upstream patches add equivalence arms (mirroring the existing
+//! Utf8/Utf8View pair), we normalize the inferred schema at the table-provider
+//! boundary: substitute the Arrow-only types with their Substrait-compatible
+//! counterparts before handing the schema to `ListingTableConfig`. The parquet
+//! reader's `SchemaAdapter` inserts the per-batch cast at read time.
+//!
+//! Strings keep their `Utf8View` layout because the upstream Utf8/Utf8View
+//! equivalence already lets them pass through without a coerce.
+
+use std::sync::Arc;
+
+use datafusion::arrow::datatypes::{DataType, Field, Fields, Schema, SchemaRef};
+
+/// Rewrite the schema to forms Substrait can bind against:
+///   - `BinaryView` → `Binary`
+///   - `UInt64`     → `Int64`
+///
+/// Recurses into `List`, `LargeList`, `FixedSizeList`, `Map`, `Struct`,
+/// `Union`, and `Dictionary`. Returns the input unchanged when no rewrite is
+/// needed so callers avoid an unnecessary `Arc` reallocation in the common
+/// case.
+pub fn coerce_for_substrait(schema: SchemaRef) -> SchemaRef {
+    if !schema_needs_coerce(&schema) {
+        return schema;
+    }
+    let rewritten_fields: Vec<Field> = schema
+        .fields()
+        .iter()
+        .map(|f| rewrite_field(f))
+        .collect();
+    Arc::new(Schema::new_with_metadata(
+        rewritten_fields,
+        schema.metadata().clone(),
+    ))
+}
+
+fn schema_needs_coerce(schema: &Schema) -> bool {
+    schema.fields().iter().any(|f| contains_incompatible(f.data_type()))
+}
+
+fn contains_incompatible(dt: &DataType) -> bool {
+    match dt {
+        DataType::BinaryView | DataType::UInt64 => true,
+        DataType::List(f) | DataType::LargeList(f) | DataType::FixedSizeList(f, _) => {
+            contains_incompatible(f.data_type())
+        }
+        DataType::Map(f, _) => contains_incompatible(f.data_type()),
+        DataType::Struct(fields) => fields.iter().any(|f| contains_incompatible(f.data_type())),
+        DataType::Union(fields, _) => fields.iter().any(|(_, f)| contains_incompatible(f.data_type())),
+        DataType::Dictionary(_, value_type) => contains_incompatible(value_type),
+        _ => false,
+    }
+}
+
+fn rewrite_field(field: &Field) -> Field {
+    let new_type = rewrite_data_type(field.data_type());
+    Field::new(field.name(), new_type, field.is_nullable())
+        .with_metadata(field.metadata().clone())
+}
+
+fn rewrite_data_type(dt: &DataType) -> DataType {
+    match dt {
+        DataType::BinaryView => DataType::Binary,
+        DataType::UInt64 => DataType::Int64,
+        DataType::List(f) => DataType::List(Arc::new(rewrite_field(f))),
+        DataType::LargeList(f) => DataType::LargeList(Arc::new(rewrite_field(f))),
+        DataType::FixedSizeList(f, n) => DataType::FixedSizeList(Arc::new(rewrite_field(f)), *n),
+        DataType::Map(f, sorted) => DataType::Map(Arc::new(rewrite_field(f)), *sorted),
+        DataType::Struct(fields) => {
+            let new_fields: Vec<Field> = fields.iter().map(|f| rewrite_field(f)).collect();
+            DataType::Struct(Fields::from(new_fields))
+        }
+        DataType::Dictionary(key, value) => {
+            DataType::Dictionary(key.clone(), Box::new(rewrite_data_type(value)))
+        }
+        other => other.clone(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn top_level_binary_view_gets_rewritten() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int64, true),
+            Field::new("b", DataType::BinaryView, true),
+        ]));
+        let out = coerce_for_substrait(schema);
+        assert_eq!(out.field(0).data_type(), &DataType::Int64);
+        assert_eq!(out.field(1).data_type(), &DataType::Binary);
+    }
+
+    #[test]
+    fn top_level_uint64_gets_rewritten() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::UInt64, true),
+            Field::new("b", DataType::Int64, true),
+        ]));
+        let out = coerce_for_substrait(schema);
+        assert_eq!(out.field(0).data_type(), &DataType::Int64);
+        assert_eq!(out.field(1).data_type(), &DataType::Int64);
+    }
+
+    #[test]
+    fn schema_without_incompatible_types_is_returned_unchanged() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int64, true),
+            Field::new("b", DataType::Utf8View, true),
+        ]));
+        let before = Arc::as_ptr(&schema);
+        let out = coerce_for_substrait(schema);
+        assert_eq!(Arc::as_ptr(&out), before, "unchanged schema must not reallocate");
+    }
+
+    #[test]
+    fn nested_list_of_binary_view_gets_rewritten() {
+        let inner = Field::new("item", DataType::BinaryView, true);
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("xs", DataType::List(Arc::new(inner)), true),
+        ]));
+        let out = coerce_for_substrait(schema);
+        match out.field(0).data_type() {
+            DataType::List(f) => assert_eq!(f.data_type(), &DataType::Binary),
+            other => panic!("expected List, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn nested_list_of_uint64_gets_rewritten() {
+        let inner = Field::new("item", DataType::UInt64, true);
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("xs", DataType::List(Arc::new(inner)), true),
+        ]));
+        let out = coerce_for_substrait(schema);
+        match out.field(0).data_type() {
+            DataType::List(f) => assert_eq!(f.data_type(), &DataType::Int64),
+            other => panic!("expected List, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn field_metadata_and_nullability_preserved() {
+        let mut md = std::collections::HashMap::new();
+        md.insert("key".to_string(), "value".to_string());
+        let f = Field::new("b", DataType::BinaryView, false).with_metadata(md.clone());
+        let schema = Arc::new(Schema::new(vec![f]));
+        let out = coerce_for_substrait(schema);
+        assert!(!out.field(0).is_nullable());
+        assert_eq!(out.field(0).metadata(), &md);
+    }
+
+    #[test]
+    fn utf8_view_is_left_alone() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("s", DataType::Utf8View, true),
+            Field::new("b", DataType::BinaryView, true),
+        ]));
+        let out = coerce_for_substrait(schema);
+        assert_eq!(out.field(0).data_type(), &DataType::Utf8View);
+        assert_eq!(out.field(1).data_type(), &DataType::Binary);
+    }
+
+    #[test]
+    fn other_unsigned_ints_are_left_alone() {
+        // Only UInt64 ↔ Int64 needs coercion for OpenSearch's unsigned_long
+        // mapping today. Smaller unsigned widths aren't produced by any current
+        // OpenSearch field type, and Calcite has no SMALLINT-equivalent
+        // unsigned type to mismatch against, so we leave them untouched.
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::UInt8, true),
+            Field::new("b", DataType::UInt16, true),
+            Field::new("c", DataType::UInt32, true),
+        ]));
+        let before = Arc::as_ptr(&schema);
+        let out = coerce_for_substrait(schema);
+        assert_eq!(Arc::as_ptr(&out), before);
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/session_context.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/session_context.rs
@@ -144,7 +144,7 @@ pub async unsafe fn create_session_context(
         })?;
     // Substrait's type system is narrower than Arrow's; normalize the inferred
     // schema to forms the Substrait consumer can bind against. See crate::schema_coerce.
-    let resolved_schema = crate::schema_coerce::coerce_for_substrait(resolved_schema);
+    let resolved_schema = crate::schema_coerce::coerce_inferred_schema(resolved_schema);
 
     let table_config = ListingTableConfig::new(shard_view.table_path.clone())
         .with_listing_options(listing_options)

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/session_context.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/session_context.rs
@@ -142,6 +142,9 @@ pub async unsafe fn create_session_context(
             error!("create_session_context: failed to infer schema: {}", e);
             e
         })?;
+    // Substrait's type system is narrower than Arrow's; normalize the inferred
+    // schema to forms the Substrait consumer can bind against. See crate::schema_coerce.
+    let resolved_schema = crate::schema_coerce::coerce_for_substrait(resolved_schema);
 
     let table_config = ListingTableConfig::new(shard_view.table_path.clone())
         .with_listing_options(listing_options)

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/BinaryFunctionAdapter.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/BinaryFunctionAdapter.java
@@ -79,8 +79,9 @@ class BinaryFunctionAdapter implements ScalarFunctionAdapter {
         }
 
         RexBuilder rexBuilder = cluster.getRexBuilder();
-        RelDataType varbinary = cluster.getTypeFactory().createSqlType(SqlTypeName.VARBINARY);
-        return rexBuilder.makeLiteral(new ByteString(bytes), varbinary, false);
+        RelDataType varbinary = cluster.getTypeFactory()
+            .createTypeWithNullability(cluster.getTypeFactory().createSqlType(SqlTypeName.VARBINARY), true);
+        return rexBuilder.makeAbstractCast(varbinary, rexBuilder.makeLiteral(new ByteString(bytes), varbinary, false), false);
     }
 
     /**

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/BinaryFunctionAdapter.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/BinaryFunctionAdapter.java
@@ -1,0 +1,115 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion;
+
+import org.apache.calcite.avatica.util.ByteString;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.opensearch.analytics.spi.FieldStorageInfo;
+import org.opensearch.analytics.spi.ScalarFunctionAdapter;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Base64;
+import java.util.List;
+
+/**
+ * Converts {@code BINARY(varchar_literal)} into a VARBINARY literal whose bytes
+ * match the on-disk encoding of {@code ip} / {@code binary} fields.
+ *
+ * <p>The SQL plugin emits {@code BINARY(varchar)} whenever a VARCHAR literal is
+ * compared to a VARBINARY column (see ExtendedRexBuilder.makeCast in the sql repo).
+ * This adapter resolves the placeholder so DataFusion's native byte-comparison
+ * operators can run against the parquet column.
+ *
+ * <p>Disambiguation between {@code ip} and {@code binary} encoding is by the
+ * literal's text shape: try IP first, fall back to base64. IP literals contain
+ * {@code .} or {@code :} which are invalid base64; base64 literals don't contain
+ * those characters so they fail {@code InetAddress.getByName} for IPv4/IPv6 forms.
+ *
+ * <p>Output is a {@code SqlTypeName.VARBINARY} literal — not BINARY. Calcite's
+ * {@code makeBinaryLiteral} produces BINARY with a fixed precision which isthmus
+ * serializes as Substrait FixedBinary(N), mismatching the parquet column's
+ * variable-length Binary type.
+ *
+ * <p>TODO: Frontends (SQL plugin / PPL parser) should hand the analytics core a
+ * plan whose literals are already in the correct on-disk byte form, with the
+ * field-type distinction (ip vs binary) preserved end-to-end. This adapter
+ * exists today because OpenSearchSchemaBuilder collapses both ip and binary
+ * fields to plain VARBINARY before the plan reaches the SQL plugin's coercion
+ * layer, so the encoding decision can't be made there. The adapter recovers
+ * the necessary context here in the analytics backend (via FieldStorageInfo)
+ * and rewrites the placeholder accordingly.
+ *
+ * @opensearch.internal
+ */
+class BinaryFunctionAdapter implements ScalarFunctionAdapter {
+
+    @Override
+    public RexNode adapt(RexCall original, List<FieldStorageInfo> fieldStorage, RelOptCluster cluster) {
+        if (original.getOperands().size() != 1
+            || !(original.getOperands().get(0) instanceof RexLiteral lit)
+            || lit.getType().getSqlTypeName() != SqlTypeName.VARCHAR) {
+            return original;
+        }
+        String value = lit.getValueAs(String.class);
+        if (value == null) {
+            return original;
+        }
+
+        byte[] bytes = encodeAsIp(value);
+        if (bytes == null) {
+            bytes = encodeAsBinary(value);
+        }
+        if (bytes == null) {
+            throw new IllegalArgumentException(
+                "BINARY operand '" + value + "' is neither a valid IP address nor a valid base64-encoded binary value"
+            );
+        }
+
+        RexBuilder rexBuilder = cluster.getRexBuilder();
+        RelDataType varbinary = cluster.getTypeFactory().createSqlType(SqlTypeName.VARBINARY);
+        return rexBuilder.makeLiteral(new ByteString(bytes), varbinary, false);
+    }
+
+    /**
+     * IPv6-mapped 16-byte encoding matching Lucene's {@code InetAddressPoint.encode} —
+     * the same encoding the parquet writer uses for {@code ip} fields. IPv4 is encoded
+     * as 10 zero bytes + {@code 0xff 0xff} + 4 IPv4 bytes (RFC 4291 §2.5.5.2).
+     * IPv6 is the raw 16 bytes.
+     */
+    private static byte[] encodeAsIp(String value) {
+        try {
+            byte[] addr = InetAddress.getByName(value).getAddress();
+            if (addr.length == 16) {
+                return addr;
+            }
+            byte[] mapped = new byte[16];
+            mapped[10] = (byte) 0xff;
+            mapped[11] = (byte) 0xff;
+            System.arraycopy(addr, 0, mapped, 12, 4);
+            return mapped;
+        } catch (UnknownHostException e) {
+            return null;
+        }
+    }
+
+    private static byte[] encodeAsBinary(String value) {
+        try {
+            return Base64.getDecoder().decode(value);
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionAnalyticsBackendPlugin.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionAnalyticsBackendPlugin.java
@@ -280,6 +280,7 @@ public class DataFusionAnalyticsBackendPlugin implements AnalyticsSearchBackendP
         // by a custom Rust UDF on the DataFusion session context (`udf::mvfind`), routed via
         // {@link MvfindAdapter}.
         ScalarFunction.MVFIND,
+        ScalarFunction.BINARY,
         // Logical connectives — emitted in projections where boolean expressions are composed:
         // `case(a = 0 and b = 0, …)`, `eval x = a or b`, `eval x = NOT y`. DataFusion's substrait
         // consumer handles them natively.

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionAnalyticsBackendPlugin.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionAnalyticsBackendPlugin.java
@@ -472,6 +472,7 @@ public class DataFusionAnalyticsBackendPlugin implements AnalyticsSearchBackendP
                     Map.entry(ScalarFunction.MVFIND, new MvfindAdapter()),
                     Map.entry(ScalarFunction.MVZIP, new MvzipAdapter()),
                     Map.entry(ScalarFunction.MVAPPEND, new MvappendAdapter()),
+                    Map.entry(ScalarFunction.BINARY, new BinaryFunctionAdapter()),
                     Map.entry(ScalarFunction.CONCAT, new ConcatFunctionAdapter()),
                     Map.entry(ScalarFunction.CONVERT_TZ, new ConvertTzAdapter()),
                     Map.entry(ScalarFunction.COSH, new HyperbolicOperatorAdapter(SqlLibraryOperators.COSH)),

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionAnalyticsBackendPlugin.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionAnalyticsBackendPlugin.java
@@ -62,6 +62,9 @@ public class DataFusionAnalyticsBackendPlugin implements AnalyticsSearchBackendP
         SUPPORTED_FIELD_TYPES.addAll(FieldType.date());
         SUPPORTED_FIELD_TYPES.add(FieldType.BOOLEAN);
         SUPPORTED_FIELD_TYPES.add(FieldType.TEXT);
+        SUPPORTED_FIELD_TYPES.add(FieldType.BINARY);
+        SUPPORTED_FIELD_TYPES.add(FieldType.IP);
+        SUPPORTED_FIELD_TYPES.add(FieldType.MATCH_ONLY_TEXT);
     }
 
     // Filter-side scalar functions DataFusion can evaluate natively. Comparisons, arithmetic

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rel/OpenSearchFilter.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rel/OpenSearchFilter.java
@@ -19,6 +19,7 @@ import org.apache.calcite.rel.logical.LogicalFilter;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexUtil;
 import org.opensearch.analytics.planner.RelNodeUtils;
 import org.opensearch.analytics.spi.FieldStorageInfo;
 
@@ -102,7 +103,18 @@ public class OpenSearchFilter extends Filter implements OpenSearchRelNode {
 
     @Override
     public RelNode stripAnnotations(List<RelNode> strippedChildren, Function<OperatorAnnotation, RexNode> annotationResolver) {
-        return LogicalFilter.create(strippedChildren.getFirst(), resolveCondition(getCondition(), annotationResolver));
+        RexNode resolved = resolveCondition(getCondition(), annotationResolver);
+        // Defensive flatten just before LogicalFilter.<init> asserts isFlat on the condition.
+        // Two known re-nesting sources to guard against:
+        //   1. Calcite's SARG → AND/OR decomposition. A flat input like
+        //      AND(p1, p2, SEARCH(col, Sarg[100..5000])) gets expanded into
+        //      AND(p1, p2, AND(col>=100, col<=5000)) by downstream rules without re-flattening.
+        //   2. Annotation unwrap (resolveCondition above) when the unwrapped RexNode is itself
+        //      an AND/OR — e.g. when a function adapter rewrote a predicate into a conjunction.
+        // Both shapes pass the parent AND's clone() unchanged but trip the Filter constructor's
+        // assertion. RexUtil.flatten canonicalizes the tree so the assertion holds.
+        RexNode flattened = RexUtil.flatten(getCluster().getRexBuilder(), resolved);
+        return LogicalFilter.create(strippedChildren.getFirst(), flattened);
     }
 
     private RexNode replaceAnnotations(RexNode node, ListIterator<OperatorAnnotation> annotationIterator) {

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rel/OpenSearchFilter.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rel/OpenSearchFilter.java
@@ -104,15 +104,10 @@ public class OpenSearchFilter extends Filter implements OpenSearchRelNode {
     @Override
     public RelNode stripAnnotations(List<RelNode> strippedChildren, Function<OperatorAnnotation, RexNode> annotationResolver) {
         RexNode resolved = resolveCondition(getCondition(), annotationResolver);
-        // Defensive flatten just before LogicalFilter.<init> asserts isFlat on the condition.
-        // Two known re-nesting sources to guard against:
-        //   1. Calcite's SARG → AND/OR decomposition. A flat input like
-        //      AND(p1, p2, SEARCH(col, Sarg[100..5000])) gets expanded into
-        //      AND(p1, p2, AND(col>=100, col<=5000)) by downstream rules without re-flattening.
-        //   2. Annotation unwrap (resolveCondition above) when the unwrapped RexNode is itself
-        //      an AND/OR — e.g. when a function adapter rewrote a predicate into a conjunction.
-        // Both shapes pass the parent AND's clone() unchanged but trip the Filter constructor's
-        // assertion. RexUtil.flatten canonicalizes the tree so the assertion holds.
+        // LogicalFilter.<init> asserts isFlat on the condition: an AND must not contain an
+        // AND child, and an OR must not contain an OR child. Adapter substitutions in
+        // BackendPlanAdapter.adaptRex can introduce that nesting (e.g. SargAdapter expands
+        // SEARCH into AND(>=, <=) under a parent AND). Flatten canonicalizes the tree.
         RexNode flattened = RexUtil.flatten(getCluster().getRexBuilder(), resolved);
         return LogicalFilter.create(strippedChildren.getFirst(), flattened);
     }

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/engine/OpenSearchSchemaBuilderTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/engine/OpenSearchSchemaBuilderTests.java
@@ -146,6 +146,7 @@ public class OpenSearchSchemaBuilderTests extends OpenSearchTestCase {
         assertEquals(SqlTypeName.TINYINT, OpenSearchSchemaBuilder.mapFieldType("byte"));
         assertEquals(SqlTypeName.DOUBLE, OpenSearchSchemaBuilder.mapFieldType("double"));
         assertEquals(SqlTypeName.REAL, OpenSearchSchemaBuilder.mapFieldType("float"));
+        assertEquals(SqlTypeName.REAL, OpenSearchSchemaBuilder.mapFieldType("half_float"));
         assertEquals(SqlTypeName.BOOLEAN, OpenSearchSchemaBuilder.mapFieldType("boolean"));
         assertEquals(SqlTypeName.TIMESTAMP, OpenSearchSchemaBuilder.mapFieldType("date"));
         assertEquals(SqlTypeName.TIMESTAMP, OpenSearchSchemaBuilder.mapFieldType("date_nanos"));

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/engine/OpenSearchSchemaBuilderTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/engine/OpenSearchSchemaBuilderTests.java
@@ -60,7 +60,7 @@ public class OpenSearchSchemaBuilderTests extends OpenSearchTestCase {
 
         RelDataType rowType = table.getRowType(new org.apache.calcite.jdbc.JavaTypeFactoryImpl());
         assertFieldType(rowType, "count", SqlTypeName.INTEGER);
-        assertFieldType(rowType, "ratio", SqlTypeName.FLOAT);
+        assertFieldType(rowType, "ratio", SqlTypeName.REAL);
         assertFieldType(rowType, "active", SqlTypeName.BOOLEAN);
     }
 
@@ -79,7 +79,7 @@ public class OpenSearchSchemaBuilderTests extends OpenSearchTestCase {
 
         RelDataType rowType = table.getRowType(new org.apache.calcite.jdbc.JavaTypeFactoryImpl());
         assertFieldType(rowType, "created", SqlTypeName.TIMESTAMP);
-        assertFieldType(rowType, "address", SqlTypeName.VARCHAR);
+        assertFieldType(rowType, "address", SqlTypeName.VARBINARY);
         assertFieldType(rowType, "content", SqlTypeName.VARCHAR);
         assertFieldType(rowType, "small_num", SqlTypeName.SMALLINT);
         assertFieldType(rowType, "tiny_num", SqlTypeName.TINYINT);
@@ -137,23 +137,28 @@ public class OpenSearchSchemaBuilderTests extends OpenSearchTestCase {
     public void testMapFieldTypeForAllSupportedTypes() {
         assertEquals(SqlTypeName.VARCHAR, OpenSearchSchemaBuilder.mapFieldType("keyword"));
         assertEquals(SqlTypeName.VARCHAR, OpenSearchSchemaBuilder.mapFieldType("text"));
+        assertEquals(SqlTypeName.VARCHAR, OpenSearchSchemaBuilder.mapFieldType("match_only_text"));
         assertEquals(SqlTypeName.BIGINT, OpenSearchSchemaBuilder.mapFieldType("long"));
+        assertEquals(SqlTypeName.BIGINT, OpenSearchSchemaBuilder.mapFieldType("unsigned_long"));
+        assertEquals(SqlTypeName.BIGINT, OpenSearchSchemaBuilder.mapFieldType("scaled_float"));
         assertEquals(SqlTypeName.INTEGER, OpenSearchSchemaBuilder.mapFieldType("integer"));
         assertEquals(SqlTypeName.SMALLINT, OpenSearchSchemaBuilder.mapFieldType("short"));
         assertEquals(SqlTypeName.TINYINT, OpenSearchSchemaBuilder.mapFieldType("byte"));
         assertEquals(SqlTypeName.DOUBLE, OpenSearchSchemaBuilder.mapFieldType("double"));
-        assertEquals(SqlTypeName.FLOAT, OpenSearchSchemaBuilder.mapFieldType("float"));
+        assertEquals(SqlTypeName.REAL, OpenSearchSchemaBuilder.mapFieldType("float"));
         assertEquals(SqlTypeName.BOOLEAN, OpenSearchSchemaBuilder.mapFieldType("boolean"));
         assertEquals(SqlTypeName.TIMESTAMP, OpenSearchSchemaBuilder.mapFieldType("date"));
-        assertEquals(SqlTypeName.VARCHAR, OpenSearchSchemaBuilder.mapFieldType("ip"));
+        assertEquals(SqlTypeName.TIMESTAMP, OpenSearchSchemaBuilder.mapFieldType("date_nanos"));
+        assertEquals(SqlTypeName.VARBINARY, OpenSearchSchemaBuilder.mapFieldType("ip"));
+        assertEquals(SqlTypeName.VARBINARY, OpenSearchSchemaBuilder.mapFieldType("binary"));
     }
 
     /**
-     * Test that unknown field types default to VARCHAR.
+     * Test that unknown field types throw IllegalArgumentException naming the offending type.
      */
-    public void testUnknownFieldTypeDefaultsToVarchar() {
-        assertEquals(SqlTypeName.VARCHAR, OpenSearchSchemaBuilder.mapFieldType("unknown_type"));
-        assertEquals(SqlTypeName.VARCHAR, OpenSearchSchemaBuilder.mapFieldType("geo_point"));
+    public void testUnknownFieldTypeThrows() {
+        IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () -> OpenSearchSchemaBuilder.mapFieldType("geo_point"));
+        assertTrue("Exception message should mention the unsupported type, was: " + ex.getMessage(), ex.getMessage().contains("geo_point"));
     }
 
     // --- helpers ---

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/FieldTypeCoverageIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/FieldTypeCoverageIT.java
@@ -226,6 +226,29 @@ public class FieldTypeCoverageIT extends AnalyticsRestTestCase {
         );
     }
 
+    /**
+     * Project-side coverage of {@code BinaryFunctionAdapter}. PPL {@code eval if(col=lit, …)},
+     * {@code case(col=lit, …)}, and {@code count(eval(col=lit))} all lower to a
+     * {@code BINARY('lit':VARCHAR)} placeholder inside a {@code LogicalProject} (or a CASE in
+     * the project tree above an aggregate).
+     */
+    public void testIpAndBinaryProjectExpressions() throws IOException {
+        Map<String, Object> ipBulk = ingest("ft_ip_project", "ip", "\"192.168.1.1\"", "\"10.0.0.1\"", "\"172.16.0.1\"");
+        assertBulkSucceeded(ipBulk, "ft_ip_project");
+        assertFilterRowCount("source=ft_ip_project | eval is_local=if(val='192.168.1.1','y','n')", 3);
+        assertFilterRowCount(
+            "source=ft_ip_project | eval cls=case(val='192.168.1.1','a',val='10.0.0.1','b',true,'c')",
+            3
+        );
+        assertFilterRowCount("source=ft_ip_project | stats count(eval(val='192.168.1.1')) as cnt", 1);
+
+        Map<String, Object> binBulk = ingest("ft_binary_project", "binary", "\"YWxpY2U=\"", "\"Ym9i\"", "\"Y2Fyb2w=\"");
+        assertBulkSucceeded(binBulk, "ft_binary_project");
+        assertFilterRowCount("source=ft_binary_project | eval is_alice=if(val='YWxpY2U=','y','n')", 3);
+        assertFilterRowCount("source=ft_binary_project | stats count(eval(val='YWxpY2U=')) as c", 1);
+        assertFilterRowCount("source=ft_ip_project | where val='192.168.1.1' | fields val", 1);
+    }
+
     // ── Phase 1: Ingest ──────────────────────────────────────────────────────────
 
     /**

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/FieldTypeCoverageIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/FieldTypeCoverageIT.java
@@ -165,9 +165,10 @@ public class FieldTypeCoverageIT extends AnalyticsRestTestCase {
 
     public void testBinary() throws IOException {
         // Scan binds as VARBINARY; the BinaryView → Binary rewrite happens in
-        // schema_coerce::coerce_for_substrait. Predicates on binary columns still fail at
-        // planning ("Unsupported conversion for Relational Data type: VARBINARY"), but
-        // count() / projections / group-by work.
+        // schema_coerce::coerce_for_substrait. Predicates on binary columns now work via the
+        // BINARY(varchar) placeholder (BinaryFunctionAdapter rewrites it into a VARBINARY
+        // literal that DataFusion compares natively). Filter coverage lives in testIpFilters
+        // — binary columns share the same code path.
         Map<String, Object> bulk = ingest("ft_binary", "binary", "\"YWxpY2U=\"", "\"Ym9i\"", "\"Y2Fyb2w=\"");
         assertBulkSucceeded(bulk, "ft_binary");
         assertScanSucceeds("ft_binary", 3);
@@ -176,11 +177,53 @@ public class FieldTypeCoverageIT extends AnalyticsRestTestCase {
     public void testIp() throws IOException {
         // Scan binds as VARBINARY; the BinaryView → Binary rewrite happens in
         // schema_coerce::coerce_for_substrait. Projections return raw 16-byte IPv6-mapped
-        // bytes. Predicates fail at planning until VARBINARY is wired through the PPL
-        // expression planner.
+        // bytes. Filter / aggregation coverage on `ip` columns is in testIpFilters.
         Map<String, Object> bulk = ingest("ft_ip", "ip", "\"192.168.1.1\"", "\"10.0.0.1\"", "\"172.16.0.1\"");
         assertBulkSucceeded(bulk, "ft_ip");
         assertScanSucceeds("ft_ip", 3);
+    }
+
+    /**
+     * End-to-end coverage of filter / aggregation shapes against an {@code ip} column.
+     * Each predicate shape exercises a different code path:
+     * <ul>
+     *   <li>{@code =} — comparator with VARBINARY column + VARCHAR literal, expanded via
+     *       {@code ExtendedRexBuilder.makeCast} to {@code BINARY(varchar)} and resolved by
+     *       {@code BinaryFunctionAdapter}.</li>
+     *   <li>{@code !=}, {@code >} — same path, different comparator.</li>
+     *   <li>{@code IN} — exercised the {@code OpenSearchTypeFactory.leastRestrictive} override
+     *       for VARBINARY ⇄ VARCHAR.</li>
+     *   <li>{@code BETWEEN} — same {@code leastRestrictive} path with a 3-arg shape.</li>
+     *   <li>{@code cidrmatch} — exercised the inline expansion in
+     *       {@code PPLFuncImpTable.populate} that rewrites cidr literals into byte-range AND.</li>
+     *   <li>{@code AND}-combination — exercised the {@code RexUtil.flatten} guard in
+     *       {@code OpenSearchFilter.stripAnnotations}.</li>
+     * </ul>
+     */
+    public void testIpFilters() throws IOException {
+        Map<String, Object> bulk = ingest("ft_ip_filters", "ip", "\"192.168.1.1\"", "\"10.0.0.1\"", "\"172.16.0.1\"");
+        assertBulkSucceeded(bulk, "ft_ip_filters");
+        assertScanSucceeds("ft_ip_filters", 3);
+
+        assertFilterRowCount("source=ft_ip_filters | where val = '192.168.1.1'", 1);
+        assertFilterRowCount("source=ft_ip_filters | where val != '192.168.1.1'", 2);
+        assertFilterRowCount("source=ft_ip_filters | where val > '10.0.0.50'", 2);
+        assertFilterRowCount("source=ft_ip_filters | where val < '172.16.0.1'", 1);
+        assertFilterRowCount("source=ft_ip_filters | where val in ('192.168.1.1', '10.0.0.1')", 2);
+        assertFilterRowCount("source=ft_ip_filters | where val between '10.0.0.0' and '10.255.255.255'", 1);
+
+        assertFilterRowCount("source=ft_ip_filters | where cidrmatch(val, '192.168.0.0/16')", 1);
+        assertFilterRowCount("source=ft_ip_filters | where cidrmatch(val, '10.0.0.0/8')", 1);
+        assertFilterRowCount("source=ft_ip_filters | where cidrmatch(val, '0.0.0.0/0')", 3);
+        assertFilterRowCount("source=ft_ip_filters | where NOT cidrmatch(val, '192.168.0.0/16')", 2);
+
+        // AND-combination exercises the flatten guard in OpenSearchFilter.stripAnnotations
+        // (>= 4 conjuncts after SARG/cidr expansion).
+        assertFilterRowCount(
+            "source=ft_ip_filters | where val > '10.0.0.0' AND val < '200.0.0.0'"
+                + " AND cidrmatch(val, '0.0.0.0/0')",
+            3
+        );
     }
 
     // ── Phase 1: Ingest ──────────────────────────────────────────────────────────
@@ -244,6 +287,19 @@ public class FieldTypeCoverageIT extends AnalyticsRestTestCase {
         List<List<Object>> rows = (List<List<Object>>) resp.get("rows");
         assertNotNull("source=" + index + " response missing rows", rows);
         assertEquals("source=" + index + " row count", expected, rows.size());
+    }
+
+    /**
+     * Runs a PPL query and asserts the row count matches {@code expected}. Used by tests
+     * that exercise filter / aggregation shapes (e.g. {@link #testIpFilters}) where the
+     * row count is the meaningful signal.
+     */
+    private void assertFilterRowCount(String ppl, int expected) throws IOException {
+        Map<String, Object> resp = executePpl(ppl);
+        @SuppressWarnings("unchecked")
+        List<List<Object>> rows = (List<List<Object>>) resp.get("rows");
+        assertNotNull("[" + ppl + "] response missing rows", rows);
+        assertEquals("[" + ppl + "] row count", expected, rows.size());
     }
 
     /**

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/FieldTypeCoverageIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/FieldTypeCoverageIT.java
@@ -39,10 +39,9 @@ public class FieldTypeCoverageIT extends AnalyticsRestTestCase {
     // ── Numeric ───────────────────────────────────────────────────────────────────
 
     public void testByte() throws IOException {
-        // Known bug: byte ingest fails at the parquet writer (ByteParquetField throws).
-        // The bulk response reports errors=true with unsupported_operation_exception.
         Map<String, Object> bulk = ingest("ft_byte", "byte", 1, 2, 3);
-        assertBulkErrored(bulk, "byte");
+        assertBulkSucceeded(bulk, "ft_byte");
+        assertScanSucceeds("ft_byte", 3);
     }
 
     public void testShort() throws IOException {
@@ -77,9 +76,12 @@ public class FieldTypeCoverageIT extends AnalyticsRestTestCase {
     }
 
     public void testHalfFloat() throws IOException {
-        // Known bug: half_float ingest fails (HalfFloatParquetField throws). Same shape as byte.
+        // half_float lands as Arrow Float16. OpenSearchSchemaBuilder maps it to REAL and
+        // schema_coerce widens Float16 → Float32 before substrait binds; SchemaAdapter
+        // inserts the IEEE half→single cast per batch on read.
         Map<String, Object> bulk = ingest("ft_half_float", "half_float", 47.6, 45.5, 52.1);
-        assertBulkErrored(bulk, "half_float");
+        assertBulkSucceeded(bulk, "ft_half_float");
+        assertScanSucceeds("ft_half_float", 3);
     }
 
     public void testFloat() throws IOException {
@@ -117,11 +119,6 @@ public class FieldTypeCoverageIT extends AnalyticsRestTestCase {
     }
 
     public void testMatchOnlyText() throws IOException {
-        // Scan unsupported: match_only_text has no doc_values, so the parquet writer skips
-        // the val column entirely (verified by inspecting the parquet footer schema). The
-        // value lives only in the Lucene secondary's inverted index, which is search-only
-        // — not readable as a column. PPL scan therefore fails at DataFusion with "No field
-        // named val". Coverage stops at ingest.
         Map<String, Object> bulk = ingest(
             "ft_match_only_text",
             "match_only_text",
@@ -130,7 +127,7 @@ public class FieldTypeCoverageIT extends AnalyticsRestTestCase {
             "tls handshake error"
         );
         assertBulkSucceeded(bulk, "ft_match_only_text");
-        assertScanFails("ft_match_only_text");
+        assertScanSucceeds("ft_match_only_text", 3);
     }
 
     // ── Temporal ─────────────────────────────────────────────────────────────────

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/FieldTypeCoverageIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/FieldTypeCoverageIT.java
@@ -1,0 +1,360 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.qa;
+
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+import org.opensearch.client.ResponseException;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Per-type coverage test for composite-engine + parquet indexing and the analytics-engine
+ * PPL read path. One test method per OpenSearch mapping type the sandbox targets.
+ *
+ * <p>Each test is a two-phase script:
+ * <ol>
+ *   <li><b>Ingest phase</b> — {@link #ingest} creates the index, posts N docs, and returns
+ *       the raw bulk response without asserting on it.</li>
+ *   <li><b>Assertion phase</b> — one or more of:
+ *     <ul>
+ *       <li>{@link #assertBulkSucceeded} — {@code errors=false} and flush. Use first when ingest is expected to succeed.</li>
+ *       <li>{@link #assertBulkErrored} — {@code errors=true}. For types whose parquet writer throws.</li>
+ *       <li>{@link #assertScanSucceeds} — bare {@code source=<index>} scan; materializes every column.</li>
+ *       <li>{@link #assertScanFails} — bare scan must throw. Known-bug guard for types DataFusion can't materialize.</li>
+ *     </ul>
+ *   </li>
+ * </ol>
+ */
+public class FieldTypeCoverageIT extends AnalyticsRestTestCase {
+
+    // ── Numeric ───────────────────────────────────────────────────────────────────
+
+    public void testByte() throws IOException {
+        // Known bug: byte ingest fails at the parquet writer (ByteParquetField throws).
+        // The bulk response reports errors=true with unsupported_operation_exception.
+        Map<String, Object> bulk = ingest("ft_byte", "byte", 1, 2, 3);
+        assertBulkErrored(bulk, "byte");
+    }
+
+    public void testShort() throws IOException {
+        Map<String, Object> bulk = ingest("ft_short", "short", 100, 200, 300);
+        assertBulkSucceeded(bulk, "ft_short");
+        assertScanSucceeds("ft_short", 3);
+    }
+
+    public void testInteger() throws IOException {
+        Map<String, Object> bulk = ingest("ft_integer", "integer", 1000, 2000, 3000);
+        assertBulkSucceeded(bulk, "ft_integer");
+        assertScanSucceeds("ft_integer", 3);
+    }
+
+    public void testLong() throws IOException {
+        Map<String, Object> bulk = ingest("ft_long", "long", 100000000L, 200000000L, 300000000L);
+        assertBulkSucceeded(bulk, "ft_long");
+        assertScanSucceeds("ft_long", 3);
+    }
+
+    public void testUnsignedLong() throws IOException {
+        // Test values stay below 2^63 - 1 because BIGINT is signed; values above wrap.
+        Map<String, Object> bulk = ingest(
+            "ft_unsigned_long",
+            "unsigned_long",
+            12345678901234567L,
+            23456789012345678L,
+            34567890123456789L
+        );
+        assertBulkSucceeded(bulk, "ft_unsigned_long");
+        assertScanSucceeds("ft_unsigned_long", 3);
+    }
+
+    public void testHalfFloat() throws IOException {
+        // Known bug: half_float ingest fails (HalfFloatParquetField throws). Same shape as byte.
+        Map<String, Object> bulk = ingest("ft_half_float", "half_float", 47.6, 45.5, 52.1);
+        assertBulkErrored(bulk, "half_float");
+    }
+
+    public void testFloat() throws IOException {
+        Map<String, Object> bulk = ingest("ft_float", "float", 47.6, 45.5, 52.1);
+        assertBulkSucceeded(bulk, "ft_float");
+        assertScanSucceeds("ft_float", 3);
+    }
+
+    public void testDouble() throws IOException {
+        Map<String, Object> bulk = ingest("ft_double", "double", 47.6, 45.5, 52.1);
+        assertBulkSucceeded(bulk, "ft_double");
+        assertScanSucceeds("ft_double", 3);
+    }
+
+    public void testScaledFloat() throws IOException {
+        // Scan binds as BIGINT (storage is Int64). Projections / predicates / aggregates
+        // expose the *scaled* long, not the original float.
+        Map<String, Object> bulk = ingestWithMapping("ft_scaled_float", "scaled_float", ", \"scaling_factor\": 100", 19.99, 25.50, 99.00);
+        assertBulkSucceeded(bulk, "ft_scaled_float");
+        assertScanSucceeds("ft_scaled_float", 3);
+    }
+
+    // ── Text / keyword ────────────────────────────────────────────────────────────
+
+    public void testKeyword() throws IOException {
+        Map<String, Object> bulk = ingest("ft_keyword", "keyword", "alice", "bob", "carol");
+        assertBulkSucceeded(bulk, "ft_keyword");
+        assertScanSucceeds("ft_keyword", 3);
+    }
+
+    public void testText() throws IOException {
+        Map<String, Object> bulk = ingest("ft_text", "text", "connection refused", "host unreachable", "peer reset");
+        assertBulkSucceeded(bulk, "ft_text");
+        assertScanSucceeds("ft_text", 3);
+    }
+
+    public void testMatchOnlyText() throws IOException {
+        // Scan unsupported: match_only_text has no doc_values, so the parquet writer skips
+        // the val column entirely (verified by inspecting the parquet footer schema). The
+        // value lives only in the Lucene secondary's inverted index, which is search-only
+        // — not readable as a column. PPL scan therefore fails at DataFusion with "No field
+        // named val". Coverage stops at ingest.
+        Map<String, Object> bulk = ingest(
+            "ft_match_only_text",
+            "match_only_text",
+            "timeout on socket",
+            "dns lookup failed",
+            "tls handshake error"
+        );
+        assertBulkSucceeded(bulk, "ft_match_only_text");
+        assertScanFails("ft_match_only_text");
+    }
+
+    // ── Temporal ─────────────────────────────────────────────────────────────────
+
+    public void testDate() throws IOException {
+        Map<String, Object> bulk = ingest("ft_date", "date", "\"1990-01-15\"", "\"1995-05-20\"", "\"1988-03-10\"");
+        assertBulkSucceeded(bulk, "ft_date");
+        assertScanSucceeds("ft_date", 3);
+    }
+
+    public void testDateNanos() throws IOException {
+        // Scan binds as TIMESTAMP. Sub-millisecond precision is silently truncated because
+        // Calcite TIMESTAMP is millisecond-precision.
+        Map<String, Object> bulk = ingest(
+            "ft_date_nanos",
+            "date_nanos",
+            "\"1990-01-15T10:00:00.123456789Z\"",
+            "\"1995-05-20T11:00:00.987654321Z\"",
+            "\"1988-03-10T12:00:00.111222333Z\""
+        );
+        assertBulkSucceeded(bulk, "ft_date_nanos");
+        assertScanSucceeds("ft_date_nanos", 3);
+    }
+
+    // ── Other ────────────────────────────────────────────────────────────────────
+
+    public void testBoolean() throws IOException {
+        Map<String, Object> bulk = ingest("ft_boolean", "boolean", true, false, true);
+        assertBulkSucceeded(bulk, "ft_boolean");
+        assertScanSucceeds("ft_boolean", 3);
+    }
+
+    public void testBinary() throws IOException {
+        // Scan binds as VARBINARY; the BinaryView → Binary rewrite happens in
+        // schema_coerce::coerce_for_substrait. Predicates on binary columns still fail at
+        // planning ("Unsupported conversion for Relational Data type: VARBINARY"), but
+        // count() / projections / group-by work.
+        Map<String, Object> bulk = ingest("ft_binary", "binary", "\"YWxpY2U=\"", "\"Ym9i\"", "\"Y2Fyb2w=\"");
+        assertBulkSucceeded(bulk, "ft_binary");
+        assertScanSucceeds("ft_binary", 3);
+    }
+
+    public void testIp() throws IOException {
+        // Scan binds as VARBINARY; the BinaryView → Binary rewrite happens in
+        // schema_coerce::coerce_for_substrait. Projections return raw 16-byte IPv6-mapped
+        // bytes. Predicates fail at planning until VARBINARY is wired through the PPL
+        // expression planner.
+        Map<String, Object> bulk = ingest("ft_ip", "ip", "\"192.168.1.1\"", "\"10.0.0.1\"", "\"172.16.0.1\"");
+        assertBulkSucceeded(bulk, "ft_ip");
+        assertScanSucceeds("ft_ip", 3);
+    }
+
+    // ── Phase 1: Ingest ──────────────────────────────────────────────────────────
+
+    /**
+     * Create a single-field index and post N docs (named a/b/c/...). Returns the parsed
+     * bulk response without asserting on it — the caller decides whether to expect
+     * success ({@link #assertBulkSucceeded}) or failure ({@link #assertBulkErrored}).
+     */
+    private Map<String, Object> ingest(String index, String type, Object... values) throws IOException {
+        return ingestWithMapping(index, type, "", values);
+    }
+
+    /**
+     * Variant of {@link #ingest} that lets the caller inject extra mapping properties into
+     * the field definition (e.g. {@code ", \"scaling_factor\": 100"} for {@code scaled_float}).
+     * The fragment must be a leading-comma-prefixed JSON snippet or empty.
+     *
+     * <p>Distinct method name (rather than another {@code ingest} overload) because
+     * {@code ingest(idx, type, "...string-value...", ...)} would otherwise bind to the
+     * extra-mapping overload — Java picks {@code String} over {@code Object} as more specific
+     * — silently eating the first row value as a mapping fragment.
+     */
+    private Map<String, Object> ingestWithMapping(String index, String type, String extraMappingJson, Object... values)
+        throws IOException {
+        String mapping = "\"val\": { \"type\": \"" + type + "\"" + extraMappingJson + " }";
+        createIndex(index, createBody(index, mapping));
+        return bulkRaw(index, asJsonArray(values));
+    }
+
+    // ── Phase 2: Query assertions ────────────────────────────────────────────────
+
+    /**
+     * Bulk response must report {@code errors=false}. Flushes so the parquet rowgroup is
+     * sealed before any subsequent scan assertion runs.
+     */
+    private void assertBulkSucceeded(Map<String, Object> bulkResponse, String index) throws IOException {
+        assertEquals("Expected bulk ingest to succeed for [" + index + "]", Boolean.FALSE, bulkResponse.get("errors"));
+        flush(index);
+    }
+
+    /**
+     * Bulk response must report {@code errors=true}. For types where the primary writer's
+     * {@code ParquetField} throws (byte, half_float).
+     */
+    private void assertBulkErrored(Map<String, Object> bulkResponse, String type) {
+        assertEquals(
+            "Type [" + type + "] unexpectedly succeeded at ingest. Known-bug guard: update the test if this is now fixed.",
+            Boolean.TRUE,
+            bulkResponse.get("errors")
+        );
+    }
+
+    /**
+     * Bare {@code source=<index>} scan must return {@code expected} rows. Materializes every
+     * column, so this catches per-column read-path bugs that {@code count()} misses.
+     */
+    private void assertScanSucceeds(String index, int expected) throws IOException {
+        Map<String, Object> resp = executePpl("source=" + index);
+        @SuppressWarnings("unchecked")
+        List<List<Object>> rows = (List<List<Object>>) resp.get("rows");
+        assertNotNull("source=" + index + " response missing rows", rows);
+        assertEquals("source=" + index + " row count", expected, rows.size());
+    }
+
+    /**
+     * Bare {@code source=<index>} scan must throw. Known-bug guard for types where the
+     * column never lands in parquet (e.g. match_only_text has no parquet writer). When
+     * the underlying gap is closed and the scan starts succeeding, this assertion will
+     * fail and prompt the test to be flipped to {@link #assertScanSucceeds}.
+     */
+    private void assertScanFails(String index) {
+        Request req = new Request("POST", "/_analytics/ppl");
+        req.setJsonEntity("{\"query\": \"source=" + index + "\"}");
+        try {
+            Response resp = client().performRequest(req);
+            fail(
+                "Expected source=" + index + " to fail, got status "
+                    + resp.getStatusLine().getStatusCode()
+                    + ". Known-bug guard: update the test if this is now fixed."
+            );
+        } catch (ResponseException expected) {
+            assertTrue(
+                "Expected 5xx for source=" + index + ", got " + expected.getResponse().getStatusLine().getStatusCode(),
+                expected.getResponse().getStatusLine().getStatusCode() >= 500
+            );
+        } catch (IOException io) {
+            // Transport-level error — also counts as "scan failed".
+        }
+    }
+
+    // ── Lower-level helpers ──────────────────────────────────────────────────────
+
+    private static String createBody(String index, String valMappingFragment) {
+        return "{"
+            + "\"settings\": {"
+            + "  \"number_of_shards\": 1,"
+            + "  \"number_of_replicas\": 0,"
+            + "  \"index.pluggable.dataformat.enabled\": true,"
+            + "  \"index.pluggable.dataformat\": \"composite\","
+            + "  \"index.composite.primary_data_format\": \"parquet\","
+            + "  \"index.composite.secondary_data_formats\": [\"lucene\"]"
+            + "},"
+            + "\"mappings\": {"
+            + "  \"properties\": {"
+            + "    \"name\": { \"type\": \"keyword\" },"
+            + "    " + valMappingFragment
+            + "  }"
+            + "}"
+            + "}";
+    }
+
+    private void createIndex(String index, String body) throws IOException {
+        // Be forgiving of leftover state from previous runs (preserveIndicesUponCompletion = true).
+        try {
+            client().performRequest(new Request("DELETE", "/" + index));
+        } catch (ResponseException ignored) {
+            // expected on first run
+        }
+        Request create = new Request("PUT", "/" + index);
+        create.setJsonEntity(body);
+        Map<String, Object> resp = assertOkAndParse(client().performRequest(create), "Create index " + index);
+        assertEquals(Boolean.TRUE, resp.get("acknowledged"));
+    }
+
+    /** Convert each value to its JSON literal form. Strings get wrapped in quotes unless already pre-quoted. */
+    private static String[] asJsonArray(Object... values) {
+        String[] out = new String[values.length];
+        for (int i = 0; i < values.length; i++) {
+            Object v = values[i];
+            if (v instanceof String) {
+                String s = (String) v;
+                out[i] = s.startsWith("\"") ? s : "\"" + s + "\"";
+            } else {
+                out[i] = String.valueOf(v);
+            }
+        }
+        return out;
+    }
+
+    /**
+     * Fire an N-doc bulk with sequential names {@code a, b, c, …} and {@code val=jsonValues[i]},
+     * returning the parsed response.
+     */
+    private Map<String, Object> bulkRaw(String index, String[] jsonValues) throws IOException {
+        StringBuilder body = new StringBuilder();
+        for (int i = 0; i < jsonValues.length; i++) {
+            body.append("{\"index\":{}}\n");
+            body.append("{\"name\":\"").append(rowName(i)).append("\",\"val\":").append(jsonValues[i]).append("}\n");
+        }
+        Request bulk = new Request("POST", "/" + index + "/_bulk");
+        bulk.addParameter("refresh", "true");
+        bulk.setOptions(bulk.getOptions().toBuilder().addHeader("Content-Type", "application/x-ndjson").build());
+        bulk.setJsonEntity(body.toString());
+        return assertOkAndParse(client().performRequest(bulk), "Bulk " + index);
+    }
+
+    /** Generate a stable row name for index i: a, b, …, z, aa, ab, … */
+    private static String rowName(int i) {
+        StringBuilder sb = new StringBuilder();
+        do {
+            sb.insert(0, (char) ('a' + (i % 26)));
+            i = i / 26 - 1;
+        } while (i >= 0);
+        return sb.toString();
+    }
+
+    private void flush(String index) throws IOException {
+        client().performRequest(new Request("POST", "/" + index + "/_flush?force=true"));
+    }
+
+    private Map<String, Object> executePpl(String ppl) throws IOException {
+        Request request = new Request("POST", "/_analytics/ppl");
+        request.setJsonEntity("{\"query\": \"" + escapeJson(ppl) + "\"}");
+        return assertOkAndParse(client().performRequest(request), "PPL: " + ppl);
+    }
+}


### PR DESCRIPTION
### Description
End-to-end support for `ip` and `binary` field types on the analytics-engine read path, plus the planner-side adaptations needed to compare a `VARCHAR` literal against the underlying `VARBINARY` columns.

Related change in opensearch-project/sql#5443, which extended the SQL plugin to emit a `BINARY(varchar)` placeholder whenever a VARCHAR literal is compared to a VARBINARY column. This PR tells the analytics-engine planner and the DataFusion backend to consume that placeholder and execute against the parquet-backed columns end-to-end.

 ### Scope

  Three layers, in the order the data flows through them:

  1. **Schema / scan** — `ip` and `binary` mappings now bind to a VARBINARY Calcite column. The Rust executor's substrait consumer normalizes the parquet `BinaryView` schema back to `Binary` before plan execution (`schema_coerce::coerce_inferred_schema`), since the DataFusion substrait consumer rejects the `BinaryView` shape that the parquet reader infers. DataFusion's `DefaultPhysicalPlanner` then inserts the runtime cast between the coerced schema and the underlying parquet `BinaryView` storage.


  2. **Predicates** — `BinaryFunctionAdapter` rewrites the SQL plugin's BINARY(varchar)` placeholder into a typed VARBINARY literal whose bytes match the on-disk encoding (`InetAddressPoint`-style 16-byte IPv6-mapped for `ip`, base64-decoded for `binary`). Wired into the filter / `IN` / `BETWEEN` / `cidrmatch` paths via `STANDARD_FILTER_OPS`, `OpenSearchTypeFactory.leastRestrictive`, and the existing CIDR expansion.

  3. **Project expressions** — `BINARY` is now in `STANDARD_PROJECT_OPS`, so PPL `eval if(col=lit, …)`, `eval case(col=lit, …)`, and `stats count(eval(col=lit))` no longer get rejected at the project gate. To keep the planner's per-slot type-validity assertion happy, the adapter now wraps its literal in `makeAbstractCast(nullableVarbinary, …, false)`  — `makeLiteral(ByteString, …)` always reports `BINARY(N) NOT NULL`, which mismatches the column slot's `nullable VARBINARY` type and crashes the node inside `LogicalProject.create` when the literal lands in  projection.



 `unsigned_long`

OpenSearch's unsigned_long is a 64-bit unsigned integer. Substrait integers are signed-only and Calcite has no UNSIGNED BIGINT, so the type doesn't survive through the plan as-is.

  1. Java side (OpenSearchSchemaBuilder.mapFieldType): map unsigned_long → BIGINT. The plan now treats the column as a signed 64-bit integer.
  2. Rust side (schema_coerce::coerce_inferred_schema): rewrite the parquet-inferred UInt64 schema to Int64 before handing it to the substrait consumer. The parquet reader's SchemaAdapter reinterprets each batch from UInt64 → Int64 — this
  is a bit-pattern relabel (zero copy, no value transform).


`half_float`
OpenSearch's half_float is a 16-bit IEEE float that lands as Arrow Float16 in parquet. Calcite has no fp16 type, and Substrait emits fp32, so the column doesn't bind end-to-end

 1. Java side (OpenSearchSchemaBuilder.mapFieldType): map half_float → REAL (Calcite's 32-bit float). The planner sees the same shape as a regular float column.
  2. Rust side (schema_coerce::coerce_inferred_schema): rewrite the parquet-inferred Float16 schema to Float32 before handing it to the substrait consumer. The parquet reader's SchemaAdapter widens each batch with a real IEEE half→single conversion.


### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
https://github.com/opensearch-project/sql/pull/5443

