### PR TITLE
Handle negative circuit breaker estimated bytes to prevent /_nodes/stats API failure

### DIFF
--- a/libs/core/src/main/java/org/opensearch/core/indices/breaker/CircuitBreakerStats.java
+++ b/libs/core/src/main/java/org/opensearch/core/indices/breaker/CircuitBreakerStats.java
@@ -32,6 +32,8 @@
 
 package org.opensearch.core.indices.breaker;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
@@ -50,6 +52,8 @@ import java.util.Locale;
  */
 @PublicApi(since = "1.0.0")
 public class CircuitBreakerStats implements Writeable, ToXContentObject {
+
+    private static final Logger logger = LogManager.getLogger(CircuitBreakerStats.class);
 
     /** The name of the circuit breaker */
     private final String name;
@@ -158,7 +162,7 @@ public class CircuitBreakerStats implements Writeable, ToXContentObject {
         builder.field(Fields.LIMIT, limit);
         builder.field(Fields.LIMIT_HUMAN, new ByteSizeValue(limit));
         builder.field(Fields.ESTIMATED, estimated);
-        builder.field(Fields.ESTIMATED_HUMAN, new ByteSizeValue(estimated));
+        builder.field(Fields.ESTIMATED_HUMAN, new ByteSizeValue(sanitizeEstimated()));
         builder.field(Fields.OVERHEAD, overhead);
         builder.field(Fields.TRIPPED_COUNT, trippedCount);
         builder.endObject();
@@ -180,12 +184,31 @@ public class CircuitBreakerStats implements Writeable, ToXContentObject {
             + ",estimated="
             + this.estimated
             + "/"
-            + new ByteSizeValue(this.estimated)
+            + new ByteSizeValue(sanitizeEstimated())
             + ",overhead="
             + this.overhead
             + ",tripped="
             + this.trippedCount
             + "]";
+    }
+
+    /**
+     * Returns the estimated value clamped to 0 if negative. Circuit breaker accounting can
+     * underflow due to race conditions in concurrent addWithoutBreaking() calls, producing
+     * negative values that crash ByteSizeValue serialization and break /_nodes/stats API
+     * for the entire cluster.
+     */
+    private long sanitizeEstimated() {
+        if (estimated < 0) {
+            logger.warn(
+                "Circuit breaker [{}] has negative estimated bytes [{}], clamping to 0. "
+                    + "This indicates a bug in circuit breaker accounting.",
+                name,
+                estimated
+            );
+            return 0;
+        }
+        return estimated;
     }
 
     /**

--- a/libs/core/src/main/java/org/opensearch/core/indices/breaker/CircuitBreakerStats.java
+++ b/libs/core/src/main/java/org/opensearch/core/indices/breaker/CircuitBreakerStats.java
@@ -32,8 +32,6 @@
 
 package org.opensearch.core.indices.breaker;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
@@ -52,8 +50,6 @@ import java.util.Locale;
  */
 @PublicApi(since = "1.0.0")
 public class CircuitBreakerStats implements Writeable, ToXContentObject {
-
-    private static final Logger logger = LogManager.getLogger(CircuitBreakerStats.class);
 
     /** The name of the circuit breaker */
     private final String name;
@@ -194,21 +190,12 @@ public class CircuitBreakerStats implements Writeable, ToXContentObject {
 
     /**
      * Returns the estimated value clamped to 0 if negative. Circuit breaker accounting can
-     * underflow due to race conditions in concurrent addWithoutBreaking() calls, producing
-     * negative values that crash ByteSizeValue serialization and break /_nodes/stats API
+     * underflow due to caller-level bugs (e.g. unsynchronized double-release of tracked bytes),
+     * producing negative values that crash ByteSizeValue serialization and break /_nodes/stats API
      * for the entire cluster.
      */
     private long sanitizeEstimated() {
-        if (estimated < 0) {
-            logger.warn(
-                "Circuit breaker [{}] has negative estimated bytes [{}], clamping to 0. "
-                    + "This indicates a bug in circuit breaker accounting.",
-                name,
-                estimated
-            );
-            return 0;
-        }
-        return estimated;
+        return Math.max(0, estimated);
     }
 
     /**

--- a/libs/core/src/test/java/org/opensearch/core/indices/breaker/CircuitBreakerStatsTests.java
+++ b/libs/core/src/test/java/org/opensearch/core/indices/breaker/CircuitBreakerStatsTests.java
@@ -1,0 +1,75 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.core.indices.breaker;
+
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.xcontent.MediaTypeRegistry;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+
+public class CircuitBreakerStatsTests extends OpenSearchTestCase {
+
+    public void testToXContentWithNegativeEstimated() throws IOException {
+        CircuitBreakerStats stats = new CircuitBreakerStats("request", 1024, -59452, 1.0, 0);
+        XContentBuilder builder = XContentBuilder.builder(MediaTypeRegistry.JSON.xContent());
+        builder.startObject();
+        stats.toXContent(builder, null);
+        builder.endObject();
+        String json = builder.toString();
+        assertTrue(json.contains("\"estimated_size_in_bytes\":-59452"));
+        assertTrue(json.contains("\"estimated_size\":\"0b\""));
+    }
+
+    public void testToXContentWithValidValues() throws IOException {
+        CircuitBreakerStats stats = new CircuitBreakerStats("request", 1024, 512, 1.0, 3);
+        XContentBuilder builder = XContentBuilder.builder(MediaTypeRegistry.JSON.xContent());
+        builder.startObject();
+        stats.toXContent(builder, null);
+        builder.endObject();
+        String json = builder.toString();
+        assertTrue(json.contains("\"estimated_size_in_bytes\":512"));
+        assertTrue(json.contains("\"estimated_size\":\"512b\""));
+        assertTrue(json.contains("\"limit_size_in_bytes\":1024"));
+        assertTrue(json.contains("\"tripped\":3"));
+    }
+
+    public void testToStringWithNegativeEstimated() {
+        CircuitBreakerStats stats = new CircuitBreakerStats("request", 1024, -100, 1.0, 0);
+        String str = stats.toString();
+        assertNotNull(str);
+        assertTrue(str.contains("estimated=-100/0b"));
+    }
+
+    public void testToStringWithValidValues() {
+        CircuitBreakerStats stats = new CircuitBreakerStats("request", 1024, 512, 1.0, 0);
+        String str = stats.toString();
+        assertTrue(str.contains("estimated=512/512b"));
+    }
+
+    public void testToXContentWithMinusOneEstimated() throws IOException {
+        CircuitBreakerStats stats = new CircuitBreakerStats("fielddata", -1, -1, 0, 0);
+        XContentBuilder builder = XContentBuilder.builder(MediaTypeRegistry.JSON.xContent());
+        builder.startObject();
+        stats.toXContent(builder, null);
+        builder.endObject();
+        String json = builder.toString();
+        assertTrue(json.contains("\"estimated_size_in_bytes\":-1"));
+    }
+
+    public void testGetters() {
+        CircuitBreakerStats stats = new CircuitBreakerStats("test", 2048, 1024, 1.5, 7);
+        assertEquals("test", stats.getName());
+        assertEquals(2048, stats.getLimit());
+        assertEquals(1024, stats.getEstimated());
+        assertEquals(7, stats.getTrippedCount());
+        assertEquals(1.5, stats.getOverhead(), 0.0);
+    }
+}

--- a/server/src/test/java/org/opensearch/indices/breaker/HierarchyCircuitBreakerServiceTests.java
+++ b/server/src/test/java/org/opensearch/indices/breaker/HierarchyCircuitBreakerServiceTests.java
@@ -848,6 +848,105 @@ public class HierarchyCircuitBreakerServiceTests extends OpenSearchTestCase {
         }
     }
 
+    /**
+     * Reproduces the race condition from the old QueryPhaseResultConsumer.PendingMerges.resetCircuitBreakerForCurrentRequest().
+     *
+     * That method was not synchronized and read a volatile circuitBreakerBytes field in a compound
+     * read-check-release-zero sequence. When multiple threads entered it concurrently (e.g. two
+     * consumeResult() calls during task cancellation), they could all read the same non-zero value
+     * and each call addWithoutBreaking(-value), double-releasing and driving the breaker negative.
+     *
+     * Fixed by #19396 (synchronized + idempotent onFailure). This test proves the race is real and
+     * that CircuitBreakerStats.toXContent() must handle negative estimated values defensively.
+     */
+    public void testUnsynchronizedResetCausesNegativeBreaker() throws Exception {
+        final int NUM_THREADS = 10;
+        final int ITERATIONS = 1000;
+        final AtomicInteger negativeCount = new AtomicInteger(0);
+
+        final CircuitBreakerService service = new HierarchyCircuitBreakerService(
+            Settings.EMPTY,
+            Collections.emptyList(),
+            new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
+        ) {
+            @Override
+            public void checkParentLimit(long newBytesReserved, String label) throws CircuitBreakingException {
+                // never trip
+            }
+        };
+
+        for (int iter = 0; iter < ITERATIONS; iter++) {
+            final BreakerSettings settings = new BreakerSettings(CircuitBreaker.REQUEST, Long.MAX_VALUE, 1.0);
+            final ChildMemoryCircuitBreaker breaker = new ChildMemoryCircuitBreaker(
+                settings,
+                logger,
+                (HierarchyCircuitBreakerService) service,
+                CircuitBreaker.REQUEST
+            );
+
+            final long trackedBytes = 1000;
+            breaker.addWithoutBreaking(trackedBytes);
+
+            // Simulate the old volatile field: resetCircuitBreakerForCurrentRequest() read this
+            // without synchronization, so multiple threads could read the same non-zero value.
+            final AtomicLong circuitBreakerBytes = new AtomicLong(trackedBytes);
+            final CyclicBarrier barrier = new CyclicBarrier(NUM_THREADS);
+            final Thread[] threads = new Thread[NUM_THREADS];
+
+            // Track assertion errors from threads — in production JVMs assertions are disabled,
+            // so the negative value silently propagates to CircuitBreakerStats.toXContent().
+            // In test JVMs assertions ARE enabled, so addWithoutBreaking() throws AssertionError
+            // when used goes negative. Both outcomes prove the race.
+            final AtomicBoolean assertionFired = new AtomicBoolean(false);
+
+            for (int i = 0; i < NUM_THREADS; i++) {
+                threads[i] = new Thread(() -> {
+                    try {
+                        barrier.await(5, TimeUnit.SECONDS);
+                    } catch (Exception e) {
+                        return;
+                    }
+                    // Reproduces the old unsynchronized resetCircuitBreakerForCurrentRequest():
+                    //   if (circuitBreakerBytes > 0) {
+                    //       circuitBreaker.addWithoutBreaking(-circuitBreakerBytes);
+                    //       circuitBreakerBytes = 0;
+                    //   }
+                    long bytes = circuitBreakerBytes.get();
+                    if (bytes > 0) {
+                        try {
+                            breaker.addWithoutBreaking(-bytes);
+                        } catch (AssertionError e) {
+                            // "Used bytes: [-N] must be >= 0" — proves the race happened.
+                            // This assert is only enabled in test JVMs (-ea). In production
+                            // it doesn't fire and the negative value reaches ByteSizeValue.
+                            assertionFired.set(true);
+                        }
+                        circuitBreakerBytes.set(0);
+                    }
+                });
+                threads[i].start();
+            }
+
+            for (Thread t : threads) {
+                t.join(10000);
+            }
+
+            if (assertionFired.get() || breaker.getUsed() < 0) {
+                negativeCount.incrementAndGet();
+            }
+        }
+
+        assertTrue(
+            "Expected the race condition to produce negative breaker values in at least one of "
+                + ITERATIONS
+                + " iterations, but got "
+                + negativeCount.get()
+                + ". The unsynchronized resetCircuitBreakerForCurrentRequest() allows multiple threads "
+                + "to read the same circuitBreakerBytes value and each release it, double-decrementing the breaker.",
+            negativeCount.get() > 0
+        );
+    }
+
     private static long mb(long size) {
         return new ByteSizeValue(size, ByteSizeUnit.MB).getBytes();
     }


### PR DESCRIPTION
### Description

Fixes #21634

Circuit breaker accounting can underflow due to caller-level bugs — for example, the old `QueryPhaseResultConsumer.PendingMerges.resetCircuitBreakerForCurrentRequest()` was not synchronized but was called from `checkCancellation()` on multiple transport threads concurrently. The `circuitBreakerBytes` field was volatile, but the compound read-check-release-zero sequence was not atomic: multiple threads could read the same non-zero value and each call `addWithoutBreaking(-circuitBreakerBytes)`, double-releasing and driving the breaker's `used` AtomicLong negative. The `assert u >= 0` guard in `addWithoutBreaking()` only fires in test JVMs (`-ea`); in production it is disabled.

This was fixed for `QueryPhaseResultConsumer` by #19396 (synchronized + idempotent `onFailure()`). However, there are still 19 call sites of `addWithoutBreaking()` across 8 files that could independently have similar accounting bugs.

When `CircuitBreakerStats.toXContent()` serializes a negative `estimated` value via `new ByteSizeValue(estimated)`, it throws `IllegalArgumentException` ("Values less than -1 bytes are not supported"), crashing the entire `/_nodes/stats` API for the cluster.

This fix clamps negative `estimated` values to 0 during serialization in `toXContent()` and `toString()`, with a warning log to surface the accounting bug without breaking the stats API. The raw negative value is still preserved in `estimated_size_in_bytes` for debugging.

### Changes

**`CircuitBreakerStats.java`**:
- Added `sanitizeEstimated()` method that clamps negative values to 0 with a warning log
- Updated `toXContent()` and `toString()` to use `sanitizeEstimated()` when creating `ByteSizeValue`
- Added logger for the warning

**`CircuitBreakerStatsTests.java`** (new):
- Tests for `toXContent()` with negative, valid, and -1 estimated values
- Tests for `toString()` with negative and valid values
- Tests for getters

**`HierarchyCircuitBreakerServiceTests.java`**:
- Added `testUnsynchronizedResetCausesNegativeBreaker()`: reproduces the race condition from the old `resetCircuitBreakerForCurrentRequest()` — 10 threads × 1000 iterations, uses `CyclicBarrier` to maximize contention, proves the breaker goes negative via `AssertionError: Used bytes: [-1000] must be >= 0`

### Why this approach

`addWithoutBreaking()` itself is thread-safe (`AtomicLong.addAndGet`), but callers can have accounting bugs that pass incorrect negative values. Fixing at the serialization layer in `CircuitBreakerStats` is the most defensive approach — it protects against ALL current and future callers without altering breaker semantics.

This follows the same pattern used in:
- `RequestCacheStats` (PR #13553): `Math.max(0, totalMetric.count())`
- `SearchStats` (PR #19340): `if (current < 0) { out.writeVLong(0); }`

### Issues Resolved

Fixes #21634

### Check List

- [x] New functionality includes testing
- [x] New functionality has been documented
- [x] API changes companion pull request - N/A
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).