### PR TITLE
Wire PPL conditional functions with analytics-backend-datafusion

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/CoalesceAdapter.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/CoalesceAdapter.java
@@ -1,0 +1,80 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion;
+
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.opensearch.analytics.spi.FieldStorageInfo;
+import org.opensearch.analytics.spi.ScalarFunctionAdapter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Adapter for coalesce(field1, field2, ...),
+ * returns the first non-null, non-missing value in the parameter list.
+ *
+ * <p>Stock {@link SqlStdOperatorTable#COALESCE} requires operands that already share a common type.
+ * So naively rewriting the call to stock {@code COALESCE} with the original operands would reject
+ * mixed-type inputs like {@code coalesce(VARCHAR, INTEGER, "fallback")} at plan validation.
+ *
+ * <p>This adapter moves the coercion step to plan time by:
+ * <ol>
+ *   <li>Computing {@code leastRestrictive} across all operand types</li>
+ *   <li>Falling back to nullable VARCHAR when the unification returns {@code null}</li>
+ *   <li>Inserting a plain CAST on each operand whose type differs from the common type.
+ *       Calcite's CAST covers numeric / boolean / character / date / time / timestamp
+ *       / decimal conversions</li>
+ *   <li>Rebuilding the call with {@link SqlStdOperatorTable#COALESCE} so isthmus serialises
+ *       it through the default Substrait catalog</li>
+ * </ol>
+ *
+ * @opensearch.internal
+ */
+class CoalesceAdapter implements ScalarFunctionAdapter {
+
+    @Override
+    public RexNode adapt(RexCall original, List<FieldStorageInfo> fieldStorage, RelOptCluster cluster) {
+        RexBuilder rexBuilder = cluster.getRexBuilder();
+        RelDataTypeFactory typeFactory = cluster.getTypeFactory();
+        List<RexNode> operands = original.getOperands();
+        if (operands.isEmpty()) {
+            return original;
+        }
+
+        // leastRestrictive([T]) is T, so single-operand coalesce degenerates to that operand's
+        // type and no CAST is needed. leastRestrictive across mixed numeric types returns the
+        // widest; across string + numeric returns VARCHAR; across incompatible type families
+        // (e.g. DATE + BIGINT) returns null, which we backstop with VARCHAR
+        List<RelDataType> operandTypes = operands.stream().map(RexNode::getType).toList();
+        RelDataType commonType = typeFactory.leastRestrictive(operandTypes);
+        if (commonType == null) {
+            commonType = typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.VARCHAR), true);
+        }
+
+        List<RexNode> coerced = new ArrayList<>(operands.size());
+        boolean anyCast = false;
+        for (RexNode operand : operands) {
+            if (operand.getType().equals(commonType)) {
+                coerced.add(operand);
+            } else {
+                coerced.add(rexBuilder.makeCast(commonType, operand, true, false));
+                anyCast = true;
+            }
+        }
+        List<RexNode> finalOperands = anyCast ? coerced : operands;
+        return rexBuilder.makeCall(original.getType(), SqlStdOperatorTable.COALESCE, finalOperands);
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionAnalyticsBackendPlugin.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionAnalyticsBackendPlugin.java
@@ -123,6 +123,9 @@ public class DataFusionAnalyticsBackendPlugin implements AnalyticsSearchBackendP
         // rejects the operator with "No backend supports scalar function [CASE] among [datafusion]"
         // before substrait emission.
         ScalarFunction.CASE,
+        ScalarFunction.IS_NULL,
+        ScalarFunction.IS_NOT_NULL,
+        ScalarFunction.NULLIF,
         // ABS / SUBSTRING — PPL sort-pushdown moves these into the project tree; DataFusion has
         // both natively and isthmus's default catalog binds them, so no adapter needed.
         ScalarFunction.ABS,
@@ -477,6 +480,7 @@ public class DataFusionAnalyticsBackendPlugin implements AnalyticsSearchBackendP
                     Map.entry(ScalarFunction.MVZIP, new MvzipAdapter()),
                     Map.entry(ScalarFunction.MVAPPEND, new MvappendAdapter()),
                     Map.entry(ScalarFunction.BINARY, new BinaryFunctionAdapter()),
+                    Map.entry(ScalarFunction.COALESCE, new CoalesceAdapter()),
                     Map.entry(ScalarFunction.CONCAT, new ConcatFunctionAdapter()),
                     Map.entry(ScalarFunction.CONVERT_TZ, new ConvertTzAdapter()),
                     Map.entry(ScalarFunction.COSH, new HyperbolicOperatorAdapter(SqlLibraryOperators.COSH)),

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/CoalesceAdapterTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/CoalesceAdapterTests.java
@@ -1,0 +1,192 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion;
+
+import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.hep.HepPlanner;
+import org.apache.calcite.plan.hep.HepProgramBuilder;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlFunction;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.type.OperandTypes;
+import org.apache.calcite.sql.type.ReturnTypes;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Unit tests for {@link CoalesceAdapter}.
+ */
+public class CoalesceAdapterTests extends OpenSearchTestCase {
+
+    private RelDataTypeFactory typeFactory;
+    private RexBuilder rexBuilder;
+    private RelOptCluster cluster;
+
+    private RelDataType nullableVarchar;
+    private RelDataType notNullVarchar;
+    private RelDataType nullableBigint;
+
+    private final CoalesceAdapter adapter = new CoalesceAdapter();
+    private SqlOperator coalesce;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        typeFactory = new JavaTypeFactoryImpl();
+        rexBuilder = new RexBuilder(typeFactory);
+        HepPlanner planner = new HepPlanner(new HepProgramBuilder().build());
+        cluster = RelOptCluster.create(planner, rexBuilder);
+
+        nullableVarchar = typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.VARCHAR), true);
+        notNullVarchar = typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.VARCHAR), false);
+        nullableBigint = typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.BIGINT), true);
+        coalesce = new SqlFunction(
+            "COALESCE",
+            SqlKind.OTHER_FUNCTION,
+            ReturnTypes.explicit(nullableVarchar),
+            null,
+            OperandTypes.VARIADIC,
+            SqlFunctionCategory.SYSTEM
+        );
+    }
+
+    /** Builds an COALESCE call over the provided operand types. */
+    private RexCall buildCoalesce(RelDataType... operandTypes) {
+        List<RexNode> operands = new ArrayList<>(operandTypes.length);
+        for (int i = 0; i < operandTypes.length; i++) {
+            operands.add(rexBuilder.makeInputRef(operandTypes[i], i));
+        }
+        RelDataType returnType = typeFactory.leastRestrictive(List.of(operandTypes));
+        if (returnType == null) {
+            returnType = nullableVarchar;
+        }
+        return (RexCall) rexBuilder.makeCall(returnType, coalesce, operands);
+    }
+
+    // ── operator identity rewrite ──────────────────────────────────────────
+
+    public void testAdaptRewritesOperatorToStockCoalesce() {
+        RexCall original = buildCoalesce(nullableVarchar, nullableVarchar);
+        RexNode adapted = adapter.adapt(original, List.of(), cluster);
+
+        assertTrue("expected RexCall, got " + adapted.getClass().getSimpleName(), adapted instanceof RexCall);
+        RexCall rewritten = (RexCall) adapted;
+        assertSame(
+            "operator must be rewritten to stock SqlStdOperatorTable.COALESCE — isthmus' default "
+                + "catalog binds this constant to substrait's coalesce, the UDF binding is opaque",
+            SqlStdOperatorTable.COALESCE,
+            rewritten.getOperator()
+        );
+    }
+
+    // ── type preservation ──────────────────────────────────────────────────
+
+    public void testAdaptPreservesOriginalReturnType() {
+        RexCall original = buildCoalesce(nullableVarchar, nullableVarchar);
+        RexNode adapted = adapter.adapt(original, List.of(), cluster);
+
+        assertEquals(
+            "rewritten COALESCE must declare the same return type as the original ENHANCED_COALESCE",
+            original.getType(),
+            adapted.getType()
+        );
+    }
+
+    // ── uniform-typed happy path ───────────────────────────────────────────
+
+    public void testAdaptOnUniformTypeOperandsSkipsCast() {
+        RexCall original = buildCoalesce(nullableVarchar, nullableVarchar, nullableVarchar);
+        RexCall rewritten = (RexCall) adapter.adapt(original, List.of(), cluster);
+
+        // No CAST inserted: operand list must reference-equal the original operands.
+        assertEquals(3, rewritten.getOperands().size());
+        for (int i = 0; i < 3; i++) {
+            assertSame(
+                "uniform-typed operand " + i + " must pass through without CAST",
+                original.getOperands().get(i),
+                rewritten.getOperands().get(i)
+            );
+        }
+    }
+
+    // ── mixed-type coercion ────────────────────────────────────────────────
+
+    public void testAdaptOnMixedTypeOperandsInsertsCastToLeastRestrictive() {
+        // VARCHAR + BIGINT + VARCHAR: leastRestrictive → VARCHAR (string wins over numeric in
+        // Calcite's common-type resolution). The BIGINT operand must get a CAST to VARCHAR
+        RexCall original = buildCoalesce(nullableVarchar, nullableBigint, nullableVarchar);
+        RexCall rewritten = (RexCall) adapter.adapt(original, List.of(), cluster);
+
+        assertEquals(3, rewritten.getOperands().size());
+        assertSame(
+            "VARCHAR operand [0] already matches leastRestrictive — no CAST needed",
+            original.getOperands().get(0),
+            rewritten.getOperands().get(0)
+        );
+
+        RexNode coercedMiddle = rewritten.getOperands().get(1);
+        assertTrue("BIGINT operand must be wrapped in CAST", coercedMiddle instanceof RexCall);
+        RexCall castCall = (RexCall) coercedMiddle;
+        assertEquals("wrapper must be CAST", SqlKind.CAST, castCall.getKind());
+        assertEquals(
+            "CAST target must be VARCHAR family (leastRestrictive resolution of VARCHAR + BIGINT)",
+            SqlTypeName.VARCHAR,
+            castCall.getType().getSqlTypeName()
+        );
+        assertSame("CAST must wrap the original BIGINT operand", original.getOperands().get(1), castCall.getOperands().get(0));
+
+        assertSame(
+            "VARCHAR operand [2] already matches leastRestrictive — no CAST needed",
+            original.getOperands().get(2),
+            rewritten.getOperands().get(2)
+        );
+    }
+
+    // ── nullability unification in leastRestrictive ────────────────────────
+
+    public void testAdaptOnNullablePlusNotNullVarcharUnifiesToNullable() {
+        // leastRestrictive(nullable VARCHAR, NOT NULL VARCHAR) = nullable VARCHAR (nullability is
+        // widened to accept both). The NOT NULL operand gets CAST to nullable so both operands
+        // share a type.
+        RexCall original = buildCoalesce(nullableVarchar, notNullVarchar);
+        RexCall rewritten = (RexCall) adapter.adapt(original, List.of(), cluster);
+
+        assertEquals(2, rewritten.getOperands().size());
+        assertSame(
+            "already-nullable operand [0] must pass through untouched",
+            original.getOperands().get(0),
+            rewritten.getOperands().get(0)
+        );
+
+        RexNode coerced = rewritten.getOperands().get(1);
+        assertTrue("NOT NULL VARCHAR operand must be wrapped in CAST to nullable-VARCHAR", coerced instanceof RexCall);
+        assertEquals(SqlKind.CAST, coerced.getKind());
+        assertTrue("CAST target must be nullable (leastRestrictive of nullable+not-null is nullable)", coerced.getType().isNullable());
+    }
+
+    // ── empty-operand pass-through ─────────────────────────────────────────
+
+    public void testAdaptOnEmptyOperandListPassesThrough() {
+        RexCall original = (RexCall) rexBuilder.makeCall(nullableVarchar, coalesce, List.of());
+        RexNode adapted = adapter.adapt(original, List.of(), cluster);
+
+        assertSame("empty-operand call must pass through unmodified", original, adapted);
+    }
+}

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/ConditionalFunctionsIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/ConditionalFunctionsIT.java
@@ -1,0 +1,309 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.qa;
+
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Ignore;
+
+/**
+ * End-to-end coverage for PPL
+ * <a href="https://docs.opensearch.org/latest/sql-and-ppl/ppl/functions/condition/">conditional
+ * functions</a>.
+ *
+ * <ul>
+ *   <li><b>Native structural (no adapter)</b> — {@code case ... when ... end}, {@code if}
+ *       (aliased to CASE by PPL), {@code ifnull} (aliased to COALESCE by PPL), {@code nullif}
+ *       (lowered to {@code CASE(EQUALS(a,b), NULL, a)} by PPL), {@code regexp_match}
+ *       (aliased to REGEXP_CONTAINS). The backend sees standard Substrait primitives and
+ *       DataFusion's substrait consumer handles each natively.</li>
+ *   <li><b>Predicate-shape in project</b> — {@code x IS NULL} / {@code x IS NOT NULL} /
+ *       {@code ispresent(x)} (PPL aliases the last to IS_NOT_NULL).</li>
+ * </ul>
+ *
+ * <p>Fixture columns from the {@code calcs} dataset (per row keyed by {@code key}):
+ * <ul>
+ *   <li>{@code int0}: nullable BIGINT — 6 null rows (key01, key02, key03, key07, key08, key12) out
+ *       of 17.</li>
+ *   <li>{@code num0}: nullable DOUBLE — nulls on key07, key09–key16.</li>
+ *   <li>{@code str0}: never null across the 17 rows; one of {@code FURNITURE},
+ *       {@code OFFICE SUPPLIES}, or {@code TECHNOLOGY}.</li>
+ *   <li>{@code str2}: nullable VARCHAR — null on key03, key06, key12, key16. Non-null value
+ *       {@code "one"} on key00.</li>
+ * </ul>
+ */
+public class ConditionalFunctionsIT extends AnalyticsRestTestCase {
+
+    private static final Dataset DATASET = new Dataset("calcs", "calcs");
+
+    private static boolean dataProvisioned = false;
+
+    private void ensureDataProvisioned() throws IOException {
+        if (dataProvisioned == false) {
+            DatasetProvisioner.provision(client(), DATASET);
+            dataProvisioned = true;
+        }
+    }
+
+    private String oneRow(String key) {
+        return "source=" + DATASET.indexName + " | where key='" + key + "' | head 1 ";
+    }
+
+    // ── case ────────────────────────────────────────────────────────────────
+
+    /** Basic two-branch CASE with else — exercises the structural IfThen shape. */
+    public void testCaseTwoBranches() throws IOException {
+        assertFirstRowString(
+            oneRow("key00") + "| eval v = case(str2 = 'one', 'match' else 'nomatch') | fields v",
+            "match"
+        );
+    }
+
+    /** Multi-branch CASE with fall-through to the final default arm. */
+    public void testCaseMultiBranchDefault() throws IOException {
+        assertFirstRowString(
+            oneRow("key00") + "| eval v = case(str2 = 'two', 'a', str2 = 'three', 'b' else 'else') | fields v",
+            "else"
+        );
+    }
+
+    /** CASE without an else clause returns NULL on fall-through. */
+    public void testCaseNoElseFallsThroughToNull() throws IOException {
+        Object cell = firstRowFirstCell(
+            oneRow("key00") + "| eval v = case(str2 = 'two', 'a', str2 = 'three', 'b') | fields v"
+        );
+        assertNull("case without else on no-match should be NULL but was " + cell, cell);
+    }
+
+    // ── if ──────────────────────────────────────────────────────────────────
+
+    /** {@code if(cond, t, f)} — registers this to {@code SqlStdOperatorTable.CASE}. */
+    public void testIfBranchesOnBoolean() throws IOException {
+        assertFirstRowString(oneRow("key00") + "| eval v = if(str2 = 'one', 'yes', 'no') | fields v", "yes");
+        assertFirstRowString(oneRow("key00") + "| eval v = if(str2 = 'two', 'yes', 'no') | fields v", "no");
+    }
+
+    /**
+     * {@code if(true, a, b)} and {@code if(false, a, b)} — constant-condition shape.
+     */
+    public void testIfConstantConditions() throws IOException {
+        assertFirstRowString(oneRow("key00") + "| eval v = if(true, 'first', 'second') | fields v", "first");
+        assertFirstRowString(oneRow("key00") + "| eval v = if(false, 'first', 'second') | fields v", "second");
+    }
+
+    // ── ifnull ──────────────────────────────────────────────────────────────
+
+    /**
+     * {@code ifnull(a, b)} — PPL aliases to stock {@code SqlStdOperatorTable.COALESCE}.
+     */
+    public void testIfnullReplacesNull() throws IOException {
+        // int0 is NULL for key02; ifnull should substitute the default.
+        Object cell = firstRowFirstCell(oneRow("key02") + "| eval v = ifnull(int0, -1) | fields v");
+        assertTrue("ifnull result should be numeric, got: " + cell, cell instanceof Number);
+        assertEquals(-1L, ((Number) cell).longValue());
+    }
+
+    /** Non-null input passes through. */
+    public void testIfnullPassesNonNullThrough() throws IOException {
+        // int0 = 1 on key00.
+        Object cell = firstRowFirstCell(oneRow("key00") + "| eval v = ifnull(int0, -1) | fields v");
+        assertTrue(cell instanceof Number);
+        assertEquals(1L, ((Number) cell).longValue());
+    }
+
+    /**
+     * {@code ifnull(x, x)} with a null column — both arguments resolve to NULL, so the result is
+     * NULL.
+     */
+    public void testIfnullBothArgsNullProducesNull() throws IOException {
+        Object cell = firstRowFirstCell(oneRow("key02") + "| eval v = ifnull(int0, int0) | fields v");
+        assertNull("ifnull(null, null) should be NULL but was " + cell, cell);
+    }
+
+    /**
+     * {@code ifnull(a, b)} where both operands are non-null literals — first wins, second never
+     * consulted.
+     */
+    public void testIfnullTwoNonNullLiteralsReturnsFirst() throws IOException {
+        Object cell = firstRowFirstCell(oneRow("key00") + "| eval v = ifnull(200, int0) | fields v");
+        assertTrue(cell instanceof Number);
+        assertEquals(200L, ((Number) cell).longValue());
+    }
+
+    // ── x IS NULL / IS NOT NULL / ispresent (project side) ───────────────────
+
+    /** {@code x IS NULL} in an eval projection. */
+    public void testIsNullInProject() throws IOException {
+        assertFirstRowBoolean(oneRow("key02") + "| eval v = int0 is null | fields v", true);
+        assertFirstRowBoolean(oneRow("key00") + "| eval v = int0 is null | fields v", false);
+    }
+
+    /** {@code x IS NOT NULL} in an eval projection. */
+    public void testIsNotNullInProject() throws IOException {
+        assertFirstRowBoolean(oneRow("key02") + "| eval v = int0 is not null | fields v", false);
+        assertFirstRowBoolean(oneRow("key00") + "| eval v = int0 is not null | fields v", true);
+    }
+
+    /** {@code ispresent(x)} — PPL aliases to {@code IS_NOT_NULL}. */
+    public void testIspresent() throws IOException {
+        assertFirstRowBoolean(oneRow("key00") + "| eval v = ispresent(int0) | fields v", true);
+        assertFirstRowBoolean(oneRow("key02") + "| eval v = ispresent(int0) | fields v", false);
+    }
+
+    // ── nullif ──────────────────────────────────────────────────────────────
+
+    /**
+     * PPL lowers {@code nullif(a, b)} to {@code CASE WHEN a = b THEN NULL ELSE a END}.
+     */
+    public void testNullifMatching() throws IOException {
+        Object cell = firstRowFirstCell(oneRow("key00") + "| eval v = nullif(str2, 'one') | fields v");
+        assertNull("nullif('one', 'one') should be NULL, got: " + cell, cell);
+    }
+
+    public void testNullifNonMatching() throws IOException {
+        assertFirstRowString(oneRow("key00") + "| eval v = nullif(str2, 'two') | fields v", "one");
+    }
+
+    public void testNullifSameColumnProducesNull() throws IOException {
+        Object cell = firstRowFirstCell(oneRow("key00") + "| eval v = nullif(str2, str2) | fields v");
+        assertNull("nullif(x, x) should be NULL but was " + cell, cell);
+    }
+
+    // ── coalesce ────────────────────────────────────────────────────────────
+
+    /**
+     * {@code coalesce(a, b, ...)} — returns the first non-null argument
+     */
+    public void testCoalesceReturnsFirstNonNull() throws IOException {
+        // int0 is NULL on key02; coalesce(int0, 42) → 42.
+        Object cell = firstRowFirstCell(oneRow("key02") + "| eval v = coalesce(int0, 42) | fields v");
+        assertTrue("coalesce result should be numeric, got: " + cell, cell instanceof Number);
+        assertEquals(42L, ((Number) cell).longValue());
+    }
+
+    /** Non-null first operand passes through. */
+    public void testCoalescePassesNonNullThrough() throws IOException {
+        Object cell = firstRowFirstCell(oneRow("key00") + "| eval v = coalesce(int0, 99) | fields v");
+        assertTrue(cell instanceof Number);
+        assertEquals(1L, ((Number) cell).longValue());
+    }
+
+    public void testCoalesceThreeArgs() throws IOException {
+        // key07: int0=null, num0=null → coalesce falls through to 7.
+        Object cell = firstRowFirstCell(oneRow("key07") + "| eval v = coalesce(int0, num0, 7) | fields v");
+        assertTrue(cell instanceof Number);
+        assertEquals(7.0, ((Number) cell).doubleValue(), 1e-9);
+    }
+
+    /**
+     * Mixed-type coalesce with VARCHAR + numeric.
+     *
+     * <p>key00 has str2='one', int0=1 — so coalesce(str2, int0, 'fallback') resolves to 'one'.
+     * The real coercion exercises on key12 (str2=null, int0=null), where the third literal
+     * 'fallback' wins.
+     */
+    public void testCoalesceMixedTypes() throws IOException {
+        assertFirstRowString(
+            oneRow("key00") + "| eval v = coalesce(str2, int0, 'fallback') | fields v",
+            "one"
+        );
+        assertFirstRowString(
+            oneRow("key12") + "| eval v = coalesce(str2, int0, 'fallback') | fields v",
+            "fallback"
+        );
+    }
+
+    // ── isempty ─────────────────────────────────────────────────────────────
+
+    /**
+     * {@code isempty(x)} — lowered to {@code OR(IS_NULL(x), IS_EMPTY(x))}; the adapter
+     * rewrites the IS_EMPTY arm to {@code CHAR_LENGTH(x) = 0}.
+     */
+    public void testIsemptyOnNonEmptyString() throws IOException {
+        assertFirstRowBoolean(oneRow("key00") + "| eval v = isempty(str2) | fields v", false);
+    }
+
+    public void testIsemptyOnEmptyLiteral() throws IOException {
+        assertFirstRowBoolean(oneRow("key00") + "| eval s = '' | eval v = isempty(s) | fields v", true);
+    }
+
+    public void testIsemptyOnNullInput() throws IOException {
+        // str2 is NULL on key12.
+        assertFirstRowBoolean(oneRow("key12") + "| eval v = isempty(str2) | fields v", true);
+    }
+
+    // ── isblank ─────────────────────────────────────────────────────────────
+
+    /**
+     * {@code isblank(x)} — lowered to {@code OR(IS_NULL(x), IS_EMPTY(TRIM(x)))}. With
+     * the adapter, the IS_EMPTY(TRIM(x)) arm becomes {@code CHAR_LENGTH(TRIM(x)) = 0}.
+     */
+    public void testIsblankOnWhitespaceOnly() throws IOException {
+        assertFirstRowBoolean(oneRow("key00") + "| eval s = '   ' | eval v = isblank(s) | fields v", true);
+    }
+
+    public void testIsblankOnNonEmpty() throws IOException {
+        assertFirstRowBoolean(oneRow("key00") + "| eval v = isblank(str2) | fields v", false);
+    }
+
+    public void testIsblankOnNullInput() throws IOException {
+        // str2 is NULL on key12.
+        assertFirstRowBoolean(oneRow("key12") + "| eval v = isblank(str2) | fields v", true);
+    }
+
+    // ── regexp_match ────────────────────────────────────────────────────────
+
+    /**
+     * {@code regexp_match(x, pattern)}.
+     */
+    public void testRegexpMatchMatches() throws IOException {
+        assertFirstRowBoolean(oneRow("key00") + "| eval v = regexp_match(str2, 'on.') | fields v", true);
+    }
+
+    public void testRegexpMatchNoMatch() throws IOException {
+        assertFirstRowBoolean(oneRow("key00") + "| eval v = regexp_match(str2, '^z') | fields v", false);
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────────
+
+    private void assertFirstRowString(String ppl, String expected) throws IOException {
+        Object cell = firstRowFirstCell(ppl);
+        assertNotNull("Expected non-null result for query [" + ppl + "]", cell);
+        assertEquals("Value mismatch for query: " + ppl, expected, cell);
+    }
+
+    private void assertFirstRowBoolean(String ppl, boolean expected) throws IOException {
+        Object cell = firstRowFirstCell(ppl);
+        assertNotNull("Expected non-null boolean result for query [" + ppl + "]", cell);
+        assertTrue("Expected boolean result for query [" + ppl + "] but got: " + cell, cell instanceof Boolean);
+        assertEquals("Value mismatch for query: " + ppl, expected, cell);
+    }
+
+    private Object firstRowFirstCell(String ppl) throws IOException {
+        Map<String, Object> response = executePpl(ppl);
+        @SuppressWarnings("unchecked")
+        List<List<Object>> rows = (List<List<Object>>) response.get("rows");
+        assertNotNull("Response missing 'rows' for query: " + ppl, rows);
+        assertTrue("Expected at least one row for query: " + ppl, rows.size() >= 1);
+        return rows.get(0).get(0);
+    }
+
+    private Map<String, Object> executePpl(String ppl) throws IOException {
+        ensureDataProvisioned();
+        Request request = new Request("POST", "/_analytics/ppl");
+        request.setJsonEntity("{\"query\": \"" + escapeJson(ppl) + "\"}");
+        Response response = client().performRequest(request);
+        return assertOkAndParse(response, "PPL: " + ppl);
+    }
+}


### PR DESCRIPTION
### Description

Wires PPL [conditional functions](https://docs.opensearch.org/latest/sql-and-ppl/ppl/functions/condition/) through the `analytics-backend-datafusion` plugin.

1. **`coalesce(...)`** — upstream registers to `PPLBuiltinOperators.ENHANCED_COALESCE`, a UDF that performs evaluation-time type coercion to the operands' `leastRestrictive` common type. Stock `SqlStdOperatorTable.COALESCE` doesn't coerce; its `SameOperandTypeChecker` requires pre-unified operand types. New `CoalesceAdapter` moves the UDF's runtime coercion to plan time by computing `leastRestrictive` and inserting CASTs, then rewrites to stock COALESCE. Parity with `EnhancedCoalesceFunction` on return type, null handling, mixed-type fallback to VARCHAR, and "first non-null wins" semantics.
2. **`isempty(x)` / `isblank(x)`** — PPL lowers both to structural shapes containing `SqlStdOperatorTable.IS_EMPTY`, which DataFusion doesn't have a native binding for. New `IsEmptyAdapter` rewrites `IS_EMPTY(x) → CHAR_LENGTH(x) = 0`, decomposing to primitives DataFusion already supports.

Project-side capability also needed to be broadened so `x IS NULL` / `x IS NOT NULL` / `ispresent(x)` work in `eval` expressions — they were already filter-capable but not project-capable.

### Functions covered

| PPL function | Return | Routing strategy |
|---|---|---|
| `case(cond1, val1, …, [else default])` | ANY | Native — PPL parses to `SqlStdOperatorTable.CASE`, isthmus serialises as Substrait `IfThen`. Already in `STANDARD_PROJECT_OPS`. |
| `if(cond, a, b)` | ANY | Native — PPL registers to `SqlStdOperatorTable.CASE` with a BOOL+ANY+ANY type checker. Same path as `case`. |
| `ifnull(a, b)` | ANY | Native — PPL registers to plain `SqlStdOperatorTable.COALESCE`. Serialises via isthmus' default catalog. Already in `STANDARD_PROJECT_OPS`. |
| `x IS NULL` / `x IS NOT NULL` | BOOLEAN | Native in filter; this PR adds them to `STANDARD_PROJECT_OPS` so they work in `eval` too. |
| `ispresent(x)` | BOOLEAN | Native — PPL aliases to `SqlStdOperatorTable.IS_NOT_NULL`. Same path as `x IS NOT NULL`. |
| `nullif(a, b)` | ANY | Native — PPL lowers to `CASE(EQUALS(a,b), NULL, a)`; backend sees CASE + EQUALS + a typed NULL literal (already handled by `UntypedNullPreprocessor`). Enum entry + capability declaration added for symmetry. |
| `coalesce(a, b, …)` | ANY | New `CoalesceAdapter` rewrites `ENHANCED_COALESCE(args…) → SqlStdOperatorTable.COALESCE(args…)`. |
| `isempty(x)` | BOOLEAN | PPL lowers to `OR(IS_NULL(x), IS_EMPTY(x))`; new `IsEmptyAdapter` rewrites the IS_EMPTY arm to `CHAR_LENGTH(x) = 0`. |
| `isblank(x)` | BOOLEAN | PPL lowers to `OR(IS_NULL(x), IS_EMPTY(TRIM(x)))`; same adapter handles the IS_EMPTY arm. |
| `regexp_match(x, pattern)` | BOOLEAN | Native — PPL aliases to `SqlLibraryOperators.REGEXP_CONTAINS`, already routed by `FunctionMappings.s(REGEXP_CONTAINS, "regex_match")` in our substrait catalog. |

### Changes

**`CoalesceAdapter`** — preserves `EnhancedCoalesceFunction` semantics by moving the UDF's evaluation-time type coercion to plan time. For each call:

1. Compute `typeFactory.leastRestrictive(operandTypes)` — the same source of truth `EnhancedCoalesceFunction.getReturnTypeInference` uses. Falls back to nullable VARCHAR when unification returns `null`, mirroring the UDF's same fallback.
2. Insert a plain CAST on any operand whose type differs from the common type. Calcite's CAST covers the same numeric / boolean / character / date / time / timestamp conversions that the UDF's `coerceToType` covers at runtime via `ExprValueUtils`.
3. Rebuild the call with `SqlStdOperatorTable.COALESCE` so isthmus' default catalog serialises to Substrait `coalesce`.

For the all-same-type happy path (every `ifnull(a, b)` via PPL's stock-COALESCE registration, plus uniform-typed user `coalesce(...)` calls) no CAST is added and the rewrite is a pure operator swap. The mixed-type path — `coalesce(str, int, "fallback")` — unifies to VARCHAR at plan time, inserts a CAST on the numeric operand, and DataFusion evaluates the call natively. End-to-end the user-visible result matches the SQL plugin's UDF: same return type, same "first non-null, coerced to common type" behavior, same VARCHAR fallback on unification failure.

**`IsEmptyAdapter`** — unary rewrite `IS_EMPTY(x) → CHAR_LENGTH(x) = 0`. CHAR_LENGTH is already in isthmus' default catalog as `length`, EQUALS is a stock binary operator. Null propagation rides through naturally: `CHAR_LENGTH(NULL) = NULL` and `NULL = 0 → NULL`, and the outer `OR(IS_NULL(x), …)` shape that PPL wraps around it already compensates.

**`ScalarFunction.IS_EMPTY`** — Calcite's `SqlStdOperatorTable.IS_EMPTY` is named `"IS EMPTY"` (with a space) and is of `SqlKind.OTHER`, so neither `fromSqlKind` nor identifier-name `valueOf` resolves it. Uses the `referenceOperator` singleton-identity hook — same pattern `CONCAT` uses for `"||"`.

**`STANDARD_PROJECT_OPS` additions** — `IS_NULL`, `IS_NOT_NULL`, `NULLIF`, `IS_EMPTY`. Native predicates were previously filter-only; conditional expressions in `eval` projections now route natively. `NULLIF` is cosmetic (PPL lowers to CASE+EQUALS before the backend sees it) but declared for capability-set completeness and to unblock any future planner pass that inspects `SqlKind.NULLIF` by enum.

**`BASELINE_SCALAR_OPS` additions** — `AND`, `OR`, `NOT` added to `OpenSearchProjectRule`'s baseline allow-list. These boolean combinators were previously only recursed into on the filter side (comment in `STANDARD_FILTER_OPS` says "`AND/OR/NOT` are recursed into by `OpenSearchFilterRule` structurally and never looked up here"). `isempty(x)` / `isblank(x)` surface `OR` in project position for the first time (they lower to `OR(IS_NULL(x), IS_EMPTY(…))`), so the project-side rule needs to treat them the same way — structural recursion into operands, no per-backend capability lookup on the combinator itself. Every backend already supports these primitives natively through isthmus' default substrait catalog.

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
