### PR TITLE
Add DataFusion logical and physical plan logging

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_executor.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_executor.rs
@@ -21,7 +21,9 @@
 
 use std::sync::Arc;
 
+use native_bridge_common::log_debug;
 use datafusion::{
+    physical_plan::displayable,
     physical_plan::execute_stream,
     execution::SessionStateBuilder,
     execution::runtime_env::RuntimeEnvBuilder,
@@ -689,8 +691,10 @@ pub async unsafe fn execute_indexed_with_context(
     ctx.register_table(&table_name, provider)?;
 
     let logical_plan = from_substrait_plan(&ctx.state(), &plan).await?;
+    log_debug!("DataFusion logical plan:\n{}", logical_plan.display_indent());
     let dataframe = ctx.execute_logical_plan(logical_plan).await?;
     let physical_plan = dataframe.create_physical_plan().await?;
+    log_debug!("DataFusion physical plan:\n{}", displayable(physical_plan.as_ref()).indent(true));
     let df_stream = execute_stream(physical_plan, ctx.task_ctx())
         .map_err(|e| DataFusionError::Execution(format!("execute_stream: {}", e)))?;
 

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/local_executor.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/local_executor.rs
@@ -143,7 +143,6 @@ impl LocalSession {
             DataFusionError::Execution(format!("Failed to decode Substrait plan: {}", e))
         })?;
         let logical_plan = from_substrait_plan(&self.ctx.state(), &plan).await?;
-        log_debug!("DataFusion logical plan (streaming):\n{}", logical_plan.display_indent());
         self.ctx
             .execute_logical_plan(logical_plan)
             .await?

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/local_executor.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/local_executor.rs
@@ -35,8 +35,10 @@ use datafusion::datasource::MemTable;
 use datafusion::execution::memory_pool::MemoryPool;
 use datafusion::execution::runtime_env::RuntimeEnv;
 use datafusion::execution::{SendableRecordBatchStream, SessionStateBuilder};
+use datafusion::physical_plan::displayable;
 use datafusion::physical_plan::streaming::PartitionStream;
 use datafusion::prelude::{SessionConfig, SessionContext};
+use native_bridge_common::log_debug;
 use datafusion_substrait::logical_plan::consumer::from_substrait_plan;
 use prost::Message;
 use substrait::proto::Plan;
@@ -141,6 +143,7 @@ impl LocalSession {
             DataFusionError::Execution(format!("Failed to decode Substrait plan: {}", e))
         })?;
         let logical_plan = from_substrait_plan(&self.ctx.state(), &plan).await?;
+        log_debug!("DataFusion logical plan (streaming):\n{}", logical_plan.display_indent());
         self.ctx
             .execute_logical_plan(logical_plan)
             .await?
@@ -173,8 +176,10 @@ impl LocalSession {
             ))
         })?;
         let logical_plan = from_substrait_plan(&self.ctx.state(), &plan).await?;
+        log_debug!("DataFusion logical plan (reduce):\n{}", logical_plan.display_indent());
         let dataframe = self.ctx.execute_logical_plan(logical_plan).await?;
         let physical_plan = dataframe.create_physical_plan().await?;
+        log_debug!("DataFusion physical plan (reduce):\n{}", displayable(physical_plan.as_ref()).indent(true));
         let stripped = crate::agg_mode::apply_aggregate_mode(
             physical_plan,
             crate::agg_mode::Mode::Final,

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/query_executor.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/query_executor.rs
@@ -8,12 +8,14 @@
 
 use std::sync::Arc;
 
+use native_bridge_common::log_debug;
 use datafusion::{
     common::DataFusionError,
     datasource::listing::{ListingOptions, ListingTable, ListingTableConfig, ListingTableUrl},
     execution::context::SessionContext,
     execution::runtime_env::RuntimeEnvBuilder,
     execution::SessionStateBuilder,
+    physical_plan::displayable,
     physical_plan::execute_stream,
     prelude::*,
 };
@@ -180,8 +182,10 @@ pub async fn execute_with_context(
     })?;
 
     let logical_plan = from_substrait_plan(&handle.ctx.state(), &substrait_plan).await?;
+    log_debug!("DataFusion logical plan:\n{}", logical_plan.display_indent());
     let dataframe = handle.ctx.execute_logical_plan(logical_plan).await?;
     let physical_plan = dataframe.create_physical_plan().await?;
+    log_debug!("DataFusion physical plan:\n{}", displayable(physical_plan.as_ref()).indent(true));
 
     let df_stream = execute_stream(physical_plan, handle.ctx.task_ctx()).map_err(|e| {
         error!("execute_with_context: failed to create stream: {}", e);


### PR DESCRIPTION
### Description

Add DEBUG-level logging of DataFusion logical and physical plans during query execution. Plans are hidden by default and can be enabled dynamically via cluster settings — no restart required.

**Enable:**
```
PUT _cluster/settings
{"transient": {"logger.org.opensearch.nativebridge.spi.RustLoggerBridge": "DEBUG"}}
```

**Disable:**
```
PUT _cluster/settings
{"transient": {"logger.org.opensearch.nativebridge.spi.RustLoggerBridge": "INFO"}}
```

**Execution paths covered:**
- `query_executor.rs` — shard-level parquet scan (`execute_with_context`)
- `local_executor.rs` — coordinator reduce (streaming and final-aggregate paths)
- `indexed_executor.rs` — indexed filter path

**Example output** for `source=parquet_test | stats sum(value) as total by city`:

```
[DEBUG][o.o.n.s.RustLoggerBridge ] DataFusion logical plan:
Projection: sum(parquet_test.value) AS total, parquet_test.city
  Limit: skip=0, fetch=10000
    Projection: sum(parquet_test.value), parquet_test.city
      Aggregate: groupBy=[[parquet_test.city]], aggr=[[sum(parquet_test.value)]]
        TableScan: parquet_test projection=[city, value]

[DEBUG][o.o.n.s.RustLoggerBridge ] DataFusion physical plan:
ProjectionExec: expr=[sum(parquet_test.value)@1 as total, city@0 as city]
  CoalescePartitionsExec: fetch=10000
    AggregateExec: mode=FinalPartitioned, gby=[city@0 as city], aggr=[sum(parquet_test.value)]
      RepartitionExec: partitioning=Hash([city@0], 4), input_partitions=1
        AggregateExec: mode=Partial, gby=[city@0 as city], aggr=[sum(parquet_test.value)]
          DataSourceExec: file_groups={1 group: [[...parquet]]}, projection=[city, value]
```

### Related Issues

N/A — observability improvement for benchmarking and debugging.

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).