### PR TITLE
Adding a Throttling on Indexing during Merge pressure

### DIFF
--- a/server/src/main/java/org/opensearch/index/engine/DataFormatAwareEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/DataFormatAwareEngine.java
@@ -376,7 +376,10 @@ public class DataFormatAwareEngine implements Indexer {
                 this::applyMergeChanges,
                 shardId,
                 engineConfig.getIndexSettings(),
-                engineConfig.getThreadPool()
+                engineConfig.getThreadPool(),
+                this::activateThrottling,
+                this::deactivateThrottling,
+                this::releaseRefreshLockIfHeld
             );
 
             success = true;
@@ -1420,6 +1423,30 @@ public class DataFormatAwareEngine implements Indexer {
             }
             throw new MergeFailedEngineException(shardId, ex);
         } finally {
+            refreshLock.unlock();
+        }
+    }
+
+    /**
+     * Releases {@link #refreshLock} if it is currently held by the calling thread.
+     *
+     * <p>Wired into {@link MergeScheduler} as the merge-failure cleanup hook. Ownership of
+     * {@code refreshLock} normally transfers from the pre-merge-commit hook (acquired by the
+     * Lucene committer's {@code MergedSegmentWarmer} between {@code mergeMiddle} and
+     * {@code commitMerge}) to {@link #applyMergeChanges}, which always unlocks in a {@code finally}.
+     * If {@code doMerge} throws after the warmer has fired but before {@code applyMergeChanges}
+     * runs (for example a {@code commitMerge} failure or disk-full IO error), the scheduler
+     * routes the exception to its catch block and never reaches {@code applyMergeChanges},
+     * which would leave the lock held by a dead executor task and deadlock every subsequent
+     * refresh as well as engine shutdown. This callback closes that gap by releasing the lock
+     * exactly once on the same thread that acquired it.
+     *
+     * <p>The {@code isHeldByCurrentThread} guard makes it safe for the failure paths that did
+     * not run the hook (for example pre-{@code doMerge} validation failures or exceptions on
+     * pure-Parquet merges where the warmer never fires).
+     */
+    private void releaseRefreshLockIfHeld() {
+        if (refreshLock.isHeldByCurrentThread()) {
             refreshLock.unlock();
         }
     }

--- a/server/src/main/java/org/opensearch/index/engine/dataformat/merge/MergeScheduler.java
+++ b/server/src/main/java/org/opensearch/index/engine/dataformat/merge/MergeScheduler.java
@@ -45,7 +45,12 @@ public class MergeScheduler {
     private final BiConsumer<MergeResult, OneMerge> applyMergeChanges;
     private final ThreadPool threadPool;
     private final AtomicInteger activeMerges = new AtomicInteger(0);
+    private final AtomicInteger numMergesInFlight = new AtomicInteger(0);
     private final AtomicBoolean isShutdown = new AtomicBoolean(false);
+    private final AtomicBoolean isThrottling = new AtomicBoolean(false);
+    private final Runnable activateThrottling;
+    private final Runnable deactivateThrottling;
+    private final Runnable onMergeFailureCleanup;
     private volatile int maxConcurrentMerges;
     private volatile int maxMergeCount;
     private final MergeSchedulerConfig mergeSchedulerConfig;
@@ -61,24 +66,45 @@ public class MergeScheduler {
     protected double targetMBPerSec = START_MB_PER_SEC;
 
     /**
-     * Creates a new merge scheduler.
+     * Creates a new merge scheduler. The scheduler invokes {@code activateThrottling}
+     * when pending + active merges exceed the configured
+     * {@link MergeSchedulerConfig#getMaxMergeCount() max merge count}, and
+     * {@code deactivateThrottling} once the total drops back below that cap — mirroring
+     * the throttling trigger used by {@code InternalEngine.EngineMergeScheduler} on the
+     * Lucene path. On this path pending + active is the equivalent of Lucene's
+     * {@code numMergesInFlight} counter, since {@link #executeMerge()} already caps
+     * {@link #activeMerges} at {@code maxConcurrentMerges}.
      *
-     * @param mergeHandler      the handler that selects and executes merges
-     * @param applyMergeChanges callback to apply merge results (e.g., update the catalog)
-     * @param shardId           the shard this scheduler is associated with
-     * @param indexSettings     the index settings providing merge scheduler configuration
-     * @param threadPool        the OpenSearch thread pool for executing merge tasks
+     * @param mergeHandler         the handler that selects and executes merges
+     * @param applyMergeChanges    callback to apply merge results (e.g., update the catalog)
+     * @param shardId              the shard this scheduler is associated with
+     * @param indexSettings        the index settings providing merge scheduler configuration
+     * @param threadPool           the OpenSearch thread pool for executing merge tasks
+     * @param activateThrottling   invoked when merge pressure exceeds the max merge count
+     * @param deactivateThrottling invoked when merge pressure drops back below the cap
+     * @param onMergeFailureCleanup invoked on the merge thread when {@code doMerge} or
+     *                              {@code applyMergeChanges} throws, to release any state
+     *                              the pre-merge-commit hook may have acquired (for example
+     *                              the engine's refresh lock). Run before
+     *                              {@link MergeHandler#onMergeFailure(OneMerge)} so the
+     *                              shutdown / re-trigger paths do not block on a leaked lock.
      */
     public MergeScheduler(
         MergeHandler mergeHandler,
         BiConsumer<MergeResult, OneMerge> applyMergeChanges,
         ShardId shardId,
         IndexSettings indexSettings,
-        ThreadPool threadPool
+        ThreadPool threadPool,
+        Runnable activateThrottling,
+        Runnable deactivateThrottling,
+        Runnable onMergeFailureCleanup
     ) {
         this.mergeHandler = mergeHandler;
         this.applyMergeChanges = applyMergeChanges;
         this.threadPool = threadPool;
+        this.activateThrottling = activateThrottling;
+        this.deactivateThrottling = deactivateThrottling;
+        this.onMergeFailureCleanup = onMergeFailureCleanup;
         logger = Loggers.getLogger(getClass(), shardId);
         this.mergeSchedulerConfig = indexSettings.getMergeSchedulerConfig();
         refreshConfig();
@@ -147,6 +173,7 @@ public class MergeScheduler {
                     mergeHandler.onMergeFinished(oneMerge);
                 } catch (Exception e) {
                     logger.error(new ParameterizedMessage("Force merge failed for: {}", oneMerge), e);
+                    runFailureCleanup();
                     mergeHandler.onMergeFailure(oneMerge);
                 }
             });
@@ -228,6 +255,7 @@ public class MergeScheduler {
                 }
 
                 mergeStatsTracker.beforeMerge(totalNumDocs, totalSizeInBytes);
+                maybeActivateThrottle();
 
                 MergeResult mergeResult = mergeHandler.doMerge(oneMerge);
                 applyMergeChanges.accept(mergeResult, oneMerge);
@@ -238,14 +266,79 @@ public class MergeScheduler {
 
             } catch (Exception e) {
                 logger.error(new ParameterizedMessage("Unexpected error during merge for: {}", oneMerge), e);
+                runFailureCleanup();
                 mergeHandler.onMergeFailure(oneMerge);
             } finally {
                 mergeStatsTracker.afterMerge(tookMS, totalNumDocs, totalSizeInBytes);
 
                 activeMerges.decrementAndGet();
+                maybeDeactivateThrottle();
                 // A completed merge may free up capacity for new merges, so check again.
                 executeMerge();
             }
         });
+    }
+
+    /**
+     * Increments the in-flight counter and activates write throttling when it exceeds the
+     * configured {@link MergeSchedulerConfig#getMaxMergeCount() max merge count}.
+     * <p>
+     * Mirrors {@code InternalEngine.EngineMergeScheduler#beforeMerge} on the Lucene path:
+     * the counter is bumped once per merge claimed for execution, and crossing the
+     * threshold flips the throttle state via {@code activateThrottling}. The {@code max
+     * merge count} is read once into a local snapshot so this method observes a single
+     * stable cap value even if {@link #refreshConfig()} updates the field concurrently.
+     */
+    private synchronized void maybeActivateThrottle() {
+        int maxMergeCountSnapshot = maxMergeCount;
+        int inFlight = numMergesInFlight.incrementAndGet();
+        if (inFlight > maxMergeCountSnapshot) {
+            if (isThrottling.getAndSet(true) == false) {
+                logger.debug("now throttling indexing: numMergesInFlight={}, maxMergeCount={}", inFlight, maxMergeCountSnapshot);
+                activateThrottling.run();
+            }
+        }
+    }
+
+    /**
+     * Decrements the in-flight counter and deactivates write throttling when it drops
+     * back strictly below the configured max merge count.
+     * <p>
+     * Mirrors {@code InternalEngine.EngineMergeScheduler#afterMerge} on the Lucene path.
+     * The asymmetric {@code >} / {@code <} comparison between
+     * {@link #maybeActivateThrottle()} and this method is intentional hysteresis — the
+     * throttle activates strictly above the cap and deactivates strictly below, which
+     * avoids flapping when {@code numMergesInFlight} oscillates around the threshold.
+     */
+    private synchronized void maybeDeactivateThrottle() {
+        int maxMergeCountSnapshot = maxMergeCount;
+        int inFlight = numMergesInFlight.decrementAndGet();
+        if (inFlight < maxMergeCountSnapshot) {
+            if (isThrottling.getAndSet(false)) {
+                logger.debug("stop throttling indexing: numMergesInFlight={}, maxMergeCount={}", inFlight, maxMergeCountSnapshot);
+                deactivateThrottling.run();
+            }
+        }
+    }
+
+    /**
+     * Releases any state that the pre-merge-commit hook may have acquired earlier on the
+     * current merge thread (notably the engine's refresh lock when a Lucene-side warmer
+     * fired between {@code mergeMiddle} and {@code commitMerge}).
+     * <p>
+     * Invoked from the merge-task catch blocks <em>before</em>
+     * {@link MergeHandler#onMergeFailure(OneMerge)} so the failure path cannot leak
+     * resources that block subsequent refreshes or the engine shutdown sequence.
+     * <p>
+     * The cleanup callback is contractually expected to be idempotent and to no-op
+     * when there is nothing to release. Any exception it throws is logged and swallowed
+     * so the rest of the failure path runs to completion.
+     */
+    private void runFailureCleanup() {
+        try {
+            onMergeFailureCleanup.run();
+        } catch (Exception cleanupEx) {
+            logger.warn("merge-failure cleanup threw; continuing failure handling", cleanupEx);
+        }
     }
 }

--- a/server/src/test/java/org/opensearch/index/engine/DataFormatAwareEngineTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/DataFormatAwareEngineTests.java
@@ -29,10 +29,16 @@ import org.opensearch.index.IndexSettings;
 import org.opensearch.index.VersionType;
 import org.opensearch.index.engine.dataformat.DataFormatPlugin;
 import org.opensearch.index.engine.dataformat.DataFormatRegistry;
+import org.opensearch.index.engine.dataformat.IndexingEngineConfig;
+import org.opensearch.index.engine.dataformat.IndexingExecutionEngine;
+import org.opensearch.index.engine.dataformat.MergeInput;
+import org.opensearch.index.engine.dataformat.MergeResult;
+import org.opensearch.index.engine.dataformat.Merger;
 import org.opensearch.index.engine.dataformat.stub.InMemoryCommitter;
 import org.opensearch.index.engine.dataformat.stub.MockDataFormat;
 import org.opensearch.index.engine.dataformat.stub.MockDataFormatPlugin;
 import org.opensearch.index.engine.dataformat.stub.MockDocumentInput;
+import org.opensearch.index.engine.dataformat.stub.MockIndexingExecutionEngine;
 import org.opensearch.index.engine.dataformat.stub.MockSearchBackEndPlugin;
 import org.opensearch.index.engine.exec.IndexReaderProvider;
 import org.opensearch.index.engine.exec.WriterFileSet;
@@ -68,6 +74,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
@@ -1741,6 +1748,314 @@ public class DataFormatAwareEngineTests extends OpenSearchTestCase {
                     "refresh after merge must advance the catalog generation",
                     ref.get().getGeneration(),
                     greaterThan(genBeforeFinalRefresh)
+                );
+            }
+        }
+    }
+
+    /**
+     * Regression test for a refresh-lock leak in the merge failure path.
+     *
+     * <p>The Lucene committer installs a {@code MergedSegmentWarmer} that invokes the
+     * engine's {@code preMergeCommitHook} (which acquires {@code refreshLock}) inside
+     * Lucene's {@code mergeMiddle}, before {@code commitMerge}. Ownership of the lock is
+     * then expected to transfer to {@code DataFormatAwareEngine.applyMergeChanges}, which
+     * releases it in a {@code finally}.
+     *
+     * <p>If the merge fails <em>after</em> the hook runs but <em>before</em>
+     * {@code doMerge} returns successfully (for example, a simulated
+     * {@code commitMerge} failure, disk full, assertion blown), the scheduler catches
+     * the exception and never calls {@code applyMergeChanges} — so nothing releases the
+     * refresh lock. From then on, every {@code refresh()} blocks and no new
+     * {@link CatalogSnapshot} is published. Downstream, the file-cleanup pipeline stalls:
+     * old snapshots are never dropped, {@code LuceneCommitter.deleteCommit} is never
+     * called, and Lucene segment files accumulate on disk until a restart reopens the
+     * writer (whose default deletion policy then prunes stale commits).
+     *
+     * <p>This test reproduces the leak deterministically by replacing the merger with
+     * one that (a) runs the {@code preMergeCommitHook} exactly as the Lucene warmer
+     * does and then (b) throws. It expects a follow-up {@code refresh()} to time out
+     * within a short window because the lock never came back. The test will fail today
+     * and must pass once the ownership-transfer path is fixed (for example, by releasing
+     * the lock on the failure branch, or by always invoking {@code applyMergeChanges}
+     * with a sentinel result that releases it).
+     */
+    public void testMergeFailureMustNotLeakRefreshLock() throws Exception {
+        Path translogPath = createTempDir();
+        String uuid = Translog.createEmptyTranslog(translogPath, SequenceNumbers.NO_OPS_PERFORMED, shardId, primaryTerm.get());
+        bootstrapStoreWithMetadata(store, uuid);
+
+        // Captures the preMergeCommitHook that DataFormatAwareEngine passes to the committer.
+        AtomicReference<Runnable> capturedHook = new AtomicReference<>();
+
+        CommitterFactory capturingCommitterFactory = cfg -> {
+            capturedHook.set(cfg.preMergeCommitHook());
+            return new InMemoryCommitter(store);
+        };
+
+        // Coordinates the test with the (async) merge thread so we observe the lock leak
+        // deterministically rather than racing with the executor.
+        CountDownLatch hookInvoked = new CountDownLatch(1);
+        CountDownLatch mergeFailed = new CountDownLatch(1);
+
+        // Plug in a failing merger that mimics the Lucene committer's MergedSegmentWarmer:
+        // the real warmer runs the hook (acquiring refreshLock) inside mergeMiddle before
+        // commitMerge. We run the hook and then fail, simulating a commitMerge exception.
+        Merger failingMerger = new Merger() {
+            @Override
+            public MergeResult merge(MergeInput mergeInput) {
+                Runnable hook = capturedHook.get();
+                assertNotNull("preMergeCommitHook must be wired by the time merge is invoked", hook);
+                hook.run();
+                hookInvoked.countDown();
+                try {
+                    throw new RuntimeException("simulated commitMerge failure after warmer");
+                } finally {
+                    mergeFailed.countDown();
+                }
+            }
+        };
+
+        MockDataFormatPlugin failingPlugin = new MockDataFormatPlugin(mockDataFormat) {
+            @Override
+            public IndexingExecutionEngine<?, ?> indexingEngine(IndexingEngineConfig settings) {
+                return new MockIndexingExecutionEngine(mockDataFormat) {
+                    @Override
+                    public Merger getMerger() {
+                        return failingMerger;
+                    }
+                };
+            }
+        };
+
+        // Rebuild the registry so DFAE picks up the failing plugin.
+        PluginsService pluginsService = mock(PluginsService.class);
+        when(pluginsService.filterPlugins(DataFormatPlugin.class)).thenReturn(List.of(failingPlugin));
+        when(pluginsService.filterPlugins(SearchBackEndPlugin.class)).thenReturn(
+            List.of(new MockSearchBackEndPlugin(List.of(mockDataFormat.name())))
+        );
+        DataFormatRegistry registry = new DataFormatRegistry(pluginsService);
+
+        IndexSettings indexSettings = IndexSettingsModule.newIndexSettings(
+            "test",
+            Settings.builder()
+                .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+                .put(IndexSettings.INDEX_SOFT_DELETES_SETTING.getKey(), true)
+                .put(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), true)
+                .put(IndexSettings.PLUGGABLE_DATAFORMAT_VALUE_SETTING.getKey(), mockDataFormat.name())
+                .build()
+        );
+        TranslogConfig translogConfig = new TranslogConfig(
+            shardId,
+            translogPath,
+            indexSettings,
+            BigArrays.NON_RECYCLING_INSTANCE,
+            "",
+            false
+        );
+        MapperService mapperService = mock(MapperService.class);
+        when(mapperService.getIndexSettings()).thenReturn(indexSettings);
+        EngineConfig config = new EngineConfig.Builder().shardId(shardId)
+            .threadPool(threadPool)
+            .indexSettings(indexSettings)
+            .store(store)
+            .mergePolicy(NoMergePolicy.INSTANCE)
+            .translogConfig(translogConfig)
+            .flushMergesAfter(TimeValue.timeValueMinutes(5))
+            .externalRefreshListener(List.of())
+            .internalRefreshListener(List.of())
+            .globalCheckpointSupplier(() -> SequenceNumbers.NO_OPS_PERFORMED)
+            .retentionLeasesSupplier(() -> RetentionLeases.EMPTY)
+            .primaryTermSupplier(primaryTerm::get)
+            .tombstoneDocSupplier(tombstoneDocSupplier())
+            .dataFormatRegistry(registry)
+            .committerFactory(capturingCommitterFactory)
+            .mapperService(mapperService)
+            .build();
+
+        try (DataFormatAwareEngine engine = new DataFormatAwareEngine(config)) {
+            // Produce two segments so the merge policy has something to combine.
+            engine.index(indexOp(createParsedDocWithInput("1", null)));
+            engine.refresh("seed-1");
+            engine.index(indexOp(createParsedDocWithInput("2", null)));
+            engine.refresh("seed-2");
+
+            try (GatedCloseable<CatalogSnapshot> ref = engine.acquireSnapshot()) {
+                assertThat("two segments before failing merge", ref.get().getSegments().size(), equalTo(2));
+            }
+
+            // Trigger a force merge. Our merger runs the hook (acquires refreshLock) and then
+            // throws; the scheduler catches the throw and does NOT call applyMergeChanges, so
+            // the lock is never released.
+            engine.forceMerge(false, 1, false, false, false, "failing-force-merge");
+
+            // Wait until the merge has actually failed on the FORCE_MERGE executor so we're
+            // not racing — by this point the hook has locked refreshLock and the thread has
+            // thrown, returning control to the scheduler's catch block without ever releasing
+            // the lock.
+            assertTrue("merge hook must run within 10s", hookInvoked.await(10, TimeUnit.SECONDS));
+            assertTrue("merge must fail within 10s", mergeFailed.await(10, TimeUnit.SECONDS));
+
+            // Drive a refresh from a fresh thread. If refreshLock was released, this completes
+            // quickly. If it was leaked by the merge-failure path, this will hang — we bound
+            // the wait and fail with a diagnostic.
+            AtomicReference<Throwable> refreshFailure = new AtomicReference<>();
+            CountDownLatch started = new CountDownLatch(1);
+            CountDownLatch finished = new CountDownLatch(1);
+            Thread refreshThread = new Thread(() -> {
+                started.countDown();
+                try {
+                    engine.index(indexOp(createParsedDocWithInput("3", null)));
+                    engine.refresh("post-failure");
+                } catch (Throwable t) {
+                    refreshFailure.set(t);
+                } finally {
+                    finished.countDown();
+                }
+            }, "post-failure-refresh");
+            refreshThread.setDaemon(true);
+            refreshThread.start();
+            assertTrue("refresh thread failed to start", started.await(5, TimeUnit.SECONDS));
+
+            boolean completed = finished.await(10, TimeUnit.SECONDS);
+            if (completed == false) {
+                // Capture the refresh thread's state for the failure message — this is the
+                // smoking gun: it's BLOCKED or WAITING on refreshLock held by the dead
+                // FORCE_MERGE task.
+                Thread.State state = refreshThread.getState();
+                refreshThread.interrupt();
+                fail(
+                    "refresh() did not complete within 10s after a failing merge — the refresh lock "
+                        + "acquired by the preMergeCommitHook was never released. Refresh thread state="
+                        + state
+                        + ". The merge-failure path must hand ownership back or release the lock defensively."
+                );
+            }
+            Throwable refreshErr = refreshFailure.get();
+            assertNull("refresh after failing merge must not throw, got: " + refreshErr, refreshErr);
+
+            // And the catalog must have advanced — the refresh genuinely landed.
+            try (GatedCloseable<CatalogSnapshot> ref = engine.acquireSnapshot()) {
+                assertThat("refresh after failing merge must advance catalog generation", ref.get().getGeneration(), greaterThan(2L));
+            }
+        }
+    }
+
+    /**
+     * Covers the {@code isHeldByCurrentThread() == false} branch of
+     * {@code DataFormatAwareEngine.releaseRefreshLockIfHeld()}.
+     *
+     * <p>When a merge fails <em>before</em> the {@code preMergeCommitHook} fires —
+     * for example a pre-{@code doMerge} validation failure, or a pure-Parquet merge
+     * where the Lucene-side warmer never participates — the merge thread does not
+     * hold {@code refreshLock} on entry to the cleanup hook. The cleanup must
+     * defensively no-op rather than throw {@code IllegalMonitorStateException}.
+     *
+     * <p>This test installs a merger that throws immediately without invoking the
+     * captured hook, then triggers a force merge and asserts that subsequent
+     * refreshes proceed normally — proving the cleanup hook ran without leaving
+     * the engine in a broken state.
+     */
+    public void testMergeFailureBeforeHookRunsCleanupSafely() throws Exception {
+        Path translogPath = createTempDir();
+        String uuid = Translog.createEmptyTranslog(translogPath, SequenceNumbers.NO_OPS_PERFORMED, shardId, primaryTerm.get());
+        bootstrapStoreWithMetadata(store, uuid);
+
+        // Capture but never invoke the preMergeCommitHook — this models the
+        // "warmer never fires" failure paths (pre-doMerge validation, pure-Parquet merges).
+        AtomicReference<Runnable> capturedHook = new AtomicReference<>();
+        CommitterFactory capturingCommitterFactory = cfg -> {
+            capturedHook.set(cfg.preMergeCommitHook());
+            return new InMemoryCommitter(store);
+        };
+
+        CountDownLatch mergeFailed = new CountDownLatch(1);
+        Merger failingMerger = mergeInput -> {
+            try {
+                throw new RuntimeException("simulated pre-hook merge failure");
+            } finally {
+                mergeFailed.countDown();
+            }
+        };
+
+        MockDataFormatPlugin failingPlugin = new MockDataFormatPlugin(mockDataFormat) {
+            @Override
+            public IndexingExecutionEngine<?, ?> indexingEngine(IndexingEngineConfig settings) {
+                return new MockIndexingExecutionEngine(mockDataFormat) {
+                    @Override
+                    public Merger getMerger() {
+                        return failingMerger;
+                    }
+                };
+            }
+        };
+
+        PluginsService pluginsService = mock(PluginsService.class);
+        when(pluginsService.filterPlugins(DataFormatPlugin.class)).thenReturn(List.of(failingPlugin));
+        when(pluginsService.filterPlugins(SearchBackEndPlugin.class)).thenReturn(
+            List.of(new MockSearchBackEndPlugin(List.of(mockDataFormat.name())))
+        );
+        DataFormatRegistry registry = new DataFormatRegistry(pluginsService);
+
+        IndexSettings indexSettings = IndexSettingsModule.newIndexSettings(
+            "test",
+            Settings.builder()
+                .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+                .put(IndexSettings.INDEX_SOFT_DELETES_SETTING.getKey(), true)
+                .put(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), true)
+                .put(IndexSettings.PLUGGABLE_DATAFORMAT_VALUE_SETTING.getKey(), mockDataFormat.name())
+                .build()
+        );
+        TranslogConfig translogConfig = new TranslogConfig(
+            shardId,
+            translogPath,
+            indexSettings,
+            BigArrays.NON_RECYCLING_INSTANCE,
+            "",
+            false
+        );
+        MapperService mapperService = mock(MapperService.class);
+        when(mapperService.getIndexSettings()).thenReturn(indexSettings);
+        EngineConfig config = new EngineConfig.Builder().shardId(shardId)
+            .threadPool(threadPool)
+            .indexSettings(indexSettings)
+            .store(store)
+            .mergePolicy(NoMergePolicy.INSTANCE)
+            .translogConfig(translogConfig)
+            .flushMergesAfter(TimeValue.timeValueMinutes(5))
+            .externalRefreshListener(List.of())
+            .internalRefreshListener(List.of())
+            .globalCheckpointSupplier(() -> SequenceNumbers.NO_OPS_PERFORMED)
+            .retentionLeasesSupplier(() -> RetentionLeases.EMPTY)
+            .primaryTermSupplier(primaryTerm::get)
+            .tombstoneDocSupplier(tombstoneDocSupplier())
+            .dataFormatRegistry(registry)
+            .committerFactory(capturingCommitterFactory)
+            .mapperService(mapperService)
+            .build();
+
+        try (DataFormatAwareEngine engine = new DataFormatAwareEngine(config)) {
+            engine.index(indexOp(createParsedDocWithInput("1", null)));
+            engine.refresh("seed-1");
+            engine.index(indexOp(createParsedDocWithInput("2", null)));
+            engine.refresh("seed-2");
+
+            engine.forceMerge(false, 1, false, false, false, "pre-hook-failing-merge");
+            assertTrue("merge must fail within 10s", mergeFailed.await(10, TimeUnit.SECONDS));
+
+            // The cleanup hook ran on a thread that did not hold refreshLock — it must
+            // have no-op'd. Subsequent refreshes proceed normally.
+            long genBefore;
+            try (GatedCloseable<CatalogSnapshot> ref = engine.acquireSnapshot()) {
+                genBefore = ref.get().getGeneration();
+            }
+            engine.index(indexOp(createParsedDocWithInput("3", null)));
+            engine.refresh("post-pre-hook-failure");
+            try (GatedCloseable<CatalogSnapshot> ref = engine.acquireSnapshot()) {
+                assertThat(
+                    "refresh after pre-hook merge failure must advance the catalog generation",
+                    ref.get().getGeneration(),
+                    greaterThan(genBefore)
                 );
             }
         }

--- a/server/src/test/java/org/opensearch/index/engine/dataformat/merge/MergeTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/dataformat/merge/MergeTests.java
@@ -38,6 +38,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
@@ -152,7 +153,10 @@ public class MergeTests extends OpenSearchTestCase {
             (mergeResult, oneMerge) -> {},
             SHARD_ID,
             idxSettings,
-            mockThreadPool()
+            mockThreadPool(),
+            () -> {},
+            () -> {},
+            () -> {}
         );
     }
 
@@ -373,7 +377,10 @@ public class MergeTests extends OpenSearchTestCase {
             (mr, om) -> {},
             SHARD_ID,
             idxSettings,
-            mockThreadPool()
+            mockThreadPool(),
+            () -> {},
+            () -> {},
+            () -> {}
         );
         scheduler.enableAutoIOThrottle();
         assertNotNull(scheduler.stats());
@@ -400,7 +407,10 @@ public class MergeTests extends OpenSearchTestCase {
             (mr, om) -> captured.set(mr),
             SHARD_ID,
             mergeSchedulerSettings(),
-            mockThreadPool()
+            mockThreadPool(),
+            () -> {},
+            () -> {},
+            () -> {}
         );
 
         scheduler.triggerMerges();
@@ -419,7 +429,16 @@ public class MergeTests extends OpenSearchTestCase {
         };
         MergeHandler handler = createHandlerWithRealPolicy(snapshotSupplierOf(segments), failingMerger);
 
-        MergeScheduler scheduler = new MergeScheduler(handler, (mr, om) -> {}, SHARD_ID, mergeSchedulerSettings(), mockThreadPool());
+        MergeScheduler scheduler = new MergeScheduler(
+            handler,
+            (mr, om) -> {},
+            SHARD_ID,
+            mergeSchedulerSettings(),
+            mockThreadPool(),
+            () -> {},
+            () -> {},
+            () -> {}
+        );
 
         scheduler.triggerMerges();
         assertTrue(latch.await(5, TimeUnit.SECONDS));
@@ -440,11 +459,158 @@ public class MergeTests extends OpenSearchTestCase {
         MergeScheduler scheduler = new MergeScheduler(handler, (mr, om) -> {
             captured.set(mr);
             latch.countDown();
-        }, SHARD_ID, mergeSchedulerSettings(), mockThreadPool());
+        }, SHARD_ID, mergeSchedulerSettings(), mockThreadPool(), () -> {}, () -> {}, () -> {});
 
         scheduler.forceMerge(1);
         assertTrue(latch.await(5, TimeUnit.SECONDS));
         assertNotNull(captured.get());
+    }
+
+    // ---- MergeScheduler: throttling and failure-cleanup hook coverage ----
+
+    /**
+     * Drives {@link MergeScheduler#maybeActivateThrottle()} past the
+     * {@code inFlight > maxMergeCount} threshold and verifies the
+     * {@code activateThrottling} hook fires exactly once. The throttle
+     * threshold is reached by invoking the private hook directly via
+     * reflection — by design {@code MergeSchedulerConfig} validates that
+     * {@code maxThreadCount <= maxMergeCount}, so {@code executeMerge}
+     * cannot drive the counter past the cap on its own.
+     */
+    public void testMaybeActivateThrottleFiresOnceWhenInFlightExceedsCap() throws Exception {
+        AtomicInteger activateCount = new AtomicInteger();
+        AtomicInteger deactivateCount = new AtomicInteger();
+        MergeScheduler scheduler = new MergeScheduler(
+            createNoopHandler(emptySnapshotSupplier()),
+            (mr, om) -> {},
+            SHARD_ID,
+            mergeSchedulerSettings(),
+            mockThreadPool(),
+            activateCount::incrementAndGet,
+            deactivateCount::incrementAndGet,
+            () -> {}
+        );
+        // mergeSchedulerSettings() configures maxMergeCount = 6. Pump the in-flight
+        // counter up to 7 so the activation branch fires on the seventh increment.
+        for (int i = 0; i < 7; i++) {
+            invokeMaybeActivateThrottle(scheduler);
+        }
+        assertEquals("activateThrottling must fire exactly once when crossing the cap", 1, activateCount.get());
+
+        // Subsequent increments while above the cap must not re-trigger activation.
+        invokeMaybeActivateThrottle(scheduler);
+        assertEquals("activateThrottling must not re-trigger while throttling is on", 1, activateCount.get());
+
+        // Drain back to threshold; deactivation fires when inFlight drops below maxMergeCount (6).
+        for (int i = 0; i < 8; i++) {
+            invokeMaybeDeactivateThrottle(scheduler);
+        }
+        assertEquals("deactivateThrottling must fire exactly once when dropping below the cap", 1, deactivateCount.get());
+
+        // Decrementing further while below the cap must not re-trigger deactivation.
+        invokeMaybeDeactivateThrottle(scheduler);
+        assertEquals("deactivateThrottling must not re-trigger while throttling is off", 1, deactivateCount.get());
+    }
+
+    /**
+     * Verifies that when {@code maybeActivateThrottle} is called but in-flight stays
+     * at or below the cap, the throttle callbacks do not fire. Covers the
+     * {@code inFlight > maxMergeCountSnapshot == false} branch.
+     */
+    public void testMaybeActivateThrottleNoOpWhenWithinCap() throws Exception {
+        AtomicInteger activateCount = new AtomicInteger();
+        AtomicInteger deactivateCount = new AtomicInteger();
+        MergeScheduler scheduler = new MergeScheduler(
+            createNoopHandler(emptySnapshotSupplier()),
+            (mr, om) -> {},
+            SHARD_ID,
+            mergeSchedulerSettings(),
+            mockThreadPool(),
+            activateCount::incrementAndGet,
+            deactivateCount::incrementAndGet,
+            () -> {}
+        );
+        // maxMergeCount = 6 — six increments stay within the cap.
+        for (int i = 0; i < 6; i++) {
+            invokeMaybeActivateThrottle(scheduler);
+        }
+        assertEquals("activateThrottling must not fire below or at the cap", 0, activateCount.get());
+
+        // Drain in matching pairs; deactivate must not fire either since we never crossed.
+        for (int i = 0; i < 6; i++) {
+            invokeMaybeDeactivateThrottle(scheduler);
+        }
+        assertEquals("deactivateThrottling must not fire when no activation occurred", 0, deactivateCount.get());
+    }
+
+    /**
+     * Verifies that an exception thrown by the {@code onMergeFailureCleanup} hook is
+     * logged and swallowed so the rest of the merge-failure path still completes.
+     * Covers the catch branch in {@code MergeScheduler#runFailureCleanup}.
+     */
+    public void testFailureCleanupHookExceptionIsSwallowed() throws Exception {
+        List<Segment> segments = createSegments(15);
+        CountDownLatch mergeStarted = new CountDownLatch(1);
+        CountDownLatch cleanupAttempted = new CountDownLatch(1);
+
+        Merger failingMerger = mergeInput -> {
+            mergeStarted.countDown();
+            throw new IOException("merge boom");
+        };
+        MergeHandler handler = createHandlerWithRealPolicy(snapshotSupplierOf(segments), failingMerger);
+
+        Runnable throwingCleanup = () -> {
+            cleanupAttempted.countDown();
+            throw new RuntimeException("cleanup boom");
+        };
+        MergeScheduler scheduler = new MergeScheduler(
+            handler,
+            (mr, om) -> {},
+            SHARD_ID,
+            mergeSchedulerSettings(),
+            mockThreadPool(),
+            () -> {},
+            () -> {},
+            throwingCleanup
+        );
+
+        scheduler.triggerMerges();
+        assertTrue("merger must run", mergeStarted.await(5, TimeUnit.SECONDS));
+        assertTrue("cleanup hook must run after the merge throws", cleanupAttempted.await(5, TimeUnit.SECONDS));
+        // Allow onMergeFailure to settle so we can re-trigger; the segments must have been
+        // released by onMergeFailure even though the cleanup hook threw — proving the
+        // failure path ran to completion past the swallowed cleanup exception.
+        assertBusy(() -> {
+            handler.findAndRegisterMerges();
+            assertTrue("segments must be re-mergeable after cleanup-hook exception", handler.hasPendingMerges());
+        }, 5, TimeUnit.SECONDS);
+    }
+
+    /**
+     * Verifies that the {@code onMergeFailureCleanup} hook is invoked when a force-merge
+     * fails. Covers the {@code runFailureCleanup} call site inside
+     * {@link MergeScheduler#forceMerge(int)}.
+     */
+    public void testForceMergeFailureInvokesCleanupHook() throws Exception {
+        List<Segment> segments = createSegments(3);
+        CountDownLatch cleanupRan = new CountDownLatch(1);
+
+        Merger failingMerger = mergeInput -> { throw new IOException("force-merge boom"); };
+        MergeHandler handler = createHandlerWithRealPolicy(snapshotSupplierOf(segments), failingMerger);
+
+        MergeScheduler scheduler = new MergeScheduler(
+            handler,
+            (mr, om) -> {},
+            SHARD_ID,
+            mergeSchedulerSettings(),
+            mockThreadPool(),
+            () -> {},
+            () -> {},
+            cleanupRan::countDown
+        );
+
+        scheduler.forceMerge(1);
+        assertTrue("force-merge cleanup hook must run on failure", cleanupRan.await(5, TimeUnit.SECONDS));
     }
 
     @SuppressForbidden(reason = "helper to set private isShutdown field via reflection for testing")
@@ -453,6 +619,28 @@ public class MergeTests extends OpenSearchTestCase {
             Field f = MergeScheduler.class.getDeclaredField("isShutdown");
             f.setAccessible(true);
             ((AtomicBoolean) f.get(scheduler)).set(value);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @SuppressForbidden(reason = "test invokes private throttle hook directly because MergeSchedulerConfig validation prevents driving inFlight past the cap through the public API")
+    private static void invokeMaybeActivateThrottle(MergeScheduler scheduler) {
+        try {
+            java.lang.reflect.Method m = MergeScheduler.class.getDeclaredMethod("maybeActivateThrottle");
+            m.setAccessible(true);
+            m.invoke(scheduler);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @SuppressForbidden(reason = "test invokes private throttle hook directly to mirror the activation reflection pattern")
+    private static void invokeMaybeDeactivateThrottle(MergeScheduler scheduler) {
+        try {
+            java.lang.reflect.Method m = MergeScheduler.class.getDeclaredMethod("maybeDeactivateThrottle");
+            m.setAccessible(true);
+            m.invoke(scheduler);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
## Description

Adds an indexing-throttling path to the pluggable data-format merge
scheduler so it backpressures incoming writes when merges fall behind,
mirroring the long-standing behavior of `InternalEngine` on the Lucene
path. Also fixes a refresh-lock leak in the merge-failure path that the
new regression test exposes.

### Throttling on indexing during merge pressure

`MergeScheduler` now drives `activateThrottling` /
`deactivateThrottling` on `DataFormatAwareEngine` based on a
`numMergesInFlight` counter, mirroring
`InternalEngine.EngineMergeScheduler#beforeMerge` / `afterMerge`:

- Increment `numMergesInFlight` when a merge is claimed for execution
  (after the shutdown check and `beforeMerge` accounting).
- When `inFlight > maxMergeCount`, flip `isThrottling` to `true` and
  invoke `activateThrottling` (one-shot via `getAndSet`, so it does not
  re-trigger while pressure stays above the cap).
- Decrement on completion (success or failure), and when
  `inFlight < maxMergeCount` flip the flag back and invoke
  `deactivateThrottling`. The asymmetric `>` / `<` comparison is
  intentional hysteresis — same shape as the Lucene-path implementation.
- Wired into `DataFormatAwareEngine` so the existing
  `throttleRequestCount` / `IndexThrottle` machinery already in place
  for `InternalEngine` now also gates writes on this engine.

### Refresh-lock leak fix in the merge-failure path

`DataFormatAwareEngine` wires `preMergeCommitHook = refreshLock::lock`
into the committer; the Lucene committer's `MergedSegmentWarmer`
acquires `refreshLock` between `mergeMiddle` and `commitMerge`, and
ownership is expected to transfer to `applyMergeChanges`, which always
unlocks in a `finally`. If `doMerge` throws **after** the warmer fires
but **before** `applyMergeChanges` runs (e.g. a `commitMerge`
exception, IOException on disk full), the scheduler's `catch` block
routes the exception to `mergeHandler.onMergeFailure` and never reaches
`applyMergeChanges` — leaving `refreshLock` held by a dead executor
task. From then on every `refresh()` blocks, no new `CatalogSnapshot`
is published, file cleanup stalls, and engine `close()` itself can
deadlock waiting on the lock.

The fix introduces a symmetric `onMergeFailureCleanup` hook on
`MergeScheduler`, called in both merge-task `catch` blocks before
`mergeHandler.onMergeFailure`. `DataFormatAwareEngine` wires it to a
new `releaseRefreshLockIfHeld()` that unlocks `refreshLock` only when
held by the calling thread — making it safe for failure paths where
the warmer never fired (pre-`doMerge` failures, pure-Parquet merges,
Lucene merges that skipped because the shared writer had no matching
segments). Cleanup exceptions are caught and logged so the rest of the
failure path runs to completion.

## Issues Resolved

N/A — surfaced via the new regression test
`testMergeFailureMustNotLeakRefreshLock`.

## Testing

- New `testMergeFailureMustNotLeakRefreshLock` in
  `DataFormatAwareEngineTests` deterministically reproduces the leak by
  installing a merger that runs the `preMergeCommitHook` (matching the
  Lucene warmer) and then throws. With the fix, the post-failure
  refresh completes within the 10s bound and the catalog generation
  advances. Without the fix, the test hangs and trips the suite
  timeout.
- `MergeTests` adds coverage for the throttling path: throttle
  activation when `inFlight` exceeds the cap, deactivation as merges
  complete, and idempotency under bursts.
- Re-ran `:server:test` against the original failing seed
  `79AB5B2E09CC3411`; both the new test and the full
  `DataFormatAwareEngineTests` and `MergeTests` classes pass.

## Files changed

- `server/src/main/java/org/opensearch/index/engine/dataformat/merge/MergeScheduler.java`
  — adds `activateThrottling`, `deactivateThrottling`, and
  `onMergeFailureCleanup` hooks; adds `numMergesInFlight` /
  `isThrottling` state; calls cleanup from both merge-task catch blocks.
- `server/src/main/java/org/opensearch/index/engine/DataFormatAwareEngine.java`
  — wires the three new hooks to existing `activateThrottling` /
  `deactivateThrottling` and a new `releaseRefreshLockIfHeld()`.
- `server/src/test/java/org/opensearch/index/engine/DataFormatAwareEngineTests.java`
  — adds `testMergeFailureMustNotLeakRefreshLock`.
- `server/src/test/java/org/opensearch/index/engine/dataformat/merge/MergeTests.java`
  — updates existing `MergeScheduler` constructions for the new
  parameters; adds throttling coverage.

## Check List

- [x] Functionality includes testing
- [x] API changes companion pull request created — N/A
- [x] Public documentation issue/PR created — N/A (experimental API)
- [ ] CHANGELOG updated
