### PR TITLE
[analytics engine] Add /_analytics/ppl/_explain endpoint with stage profiling

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -21,6 +21,9 @@ org.gradle.jvmargs=-Xmx3g -XX:+HeapDumpOnOutOfMemoryError -Xss2m \
     --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
 options.forkOptions.memoryMaximumSize=3g
 
+# Enable sandbox modules for IDE indexing (local only, do not commit)
+systemProp.sandbox.enabled=true
+
 # Disable duplicate project id detection
 # See https://docs.gradle.org/current/userguide/upgrading_version_6.html#duplicate_project_names_may_cause_publication_to_fail
 systemProp.org.gradle.dependency.duplicate.project.detection=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,9 +21,6 @@ org.gradle.jvmargs=-Xmx3g -XX:+HeapDumpOnOutOfMemoryError -Xss2m \
     --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
 options.forkOptions.memoryMaximumSize=3g
 
-# Enable sandbox modules for IDE indexing (local only, do not commit)
-systemProp.sandbox.enabled=true
-
 # Disable duplicate project id detection
 # See https://docs.gradle.org/current/userguide/upgrading_version_6.html#duplicate_project_names_may_cause_publication_to_fail
 systemProp.org.gradle.dependency.duplicate.project.detection=false

--- a/sandbox/libs/analytics-api/src/main/java/org/opensearch/analytics/exec/QueryPlanExecutor.java
+++ b/sandbox/libs/analytics-api/src/main/java/org/opensearch/analytics/exec/QueryPlanExecutor.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.analytics.exec;
 
+import org.opensearch.analytics.exec.profile.ProfiledResult;
 import org.opensearch.core.action.ActionListener;
 
 /**
@@ -15,7 +16,6 @@ import org.opensearch.core.action.ActionListener;
  *
  * @opensearch.internal
  */
-@FunctionalInterface
 public interface QueryPlanExecutor<LogicalPlan, Stream> {
 
     /**
@@ -27,4 +27,15 @@ public interface QueryPlanExecutor<LogicalPlan, Stream> {
      * @param listener receives the produced stream on success, or the failure cause on error
      */
     void execute(LogicalPlan plan, Object context, ActionListener<Stream> listener);
+
+    /**
+     * Executes the given logical fragment with profiling enabled. Captures per-stage
+     * timing from the coordinator's perspective and delivers a {@link ProfiledResult}
+     * containing both the query results and the profile snapshot.
+     *
+     * @param plan     the logical subtree to execute
+     * @param context  execution context (opaque Object to avoid server dependency)
+     * @param listener receives the profiled result on success, or the failure cause on error
+     */
+    void executeWithProfile(LogicalPlan plan, Object context, ActionListener<ProfiledResult> listener);
 }

--- a/sandbox/libs/analytics-api/src/main/java/org/opensearch/analytics/exec/QueryPlanExecutor.java
+++ b/sandbox/libs/analytics-api/src/main/java/org/opensearch/analytics/exec/QueryPlanExecutor.java
@@ -37,5 +37,7 @@ public interface QueryPlanExecutor<LogicalPlan, Stream> {
      * @param context  execution context (opaque Object to avoid server dependency)
      * @param listener receives the profiled result on success, or the failure cause on error
      */
-    void executeWithProfile(LogicalPlan plan, Object context, ActionListener<ProfiledResult> listener);
+    default void executeWithProfile(LogicalPlan plan, Object context, ActionListener<ProfiledResult> listener) {
+        listener.onFailure(new UnsupportedOperationException(getClass().getSimpleName() + " does not support executeWithProfile"));
+    }
 }

--- a/sandbox/libs/analytics-api/src/main/java/org/opensearch/analytics/exec/profile/ProfiledResult.java
+++ b/sandbox/libs/analytics-api/src/main/java/org/opensearch/analytics/exec/profile/ProfiledResult.java
@@ -1,0 +1,24 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.exec.profile;
+
+/**
+ * Pair of query result rows and the captured {@link QueryProfile}. Returned by
+ * {@code DefaultPlanExecutor.executeWithProfile} on <b>every</b> terminal path —
+ * success and failure — so callers always receive the profile regardless of outcome.
+ *
+ * @param rows    materialised query result rows, or null if the query failed
+ * @param failure the cause if the query failed, or null on success
+ * @param profile per-stage + per-task profile snapshot, never null
+ */
+public record ProfiledResult(Iterable<Object[]> rows, Throwable failure, QueryProfile profile) {
+    public boolean isSuccess() {
+        return failure == null;
+    }
+}

--- a/sandbox/libs/analytics-api/src/main/java/org/opensearch/analytics/exec/profile/QueryProfile.java
+++ b/sandbox/libs/analytics-api/src/main/java/org/opensearch/analytics/exec/profile/QueryProfile.java
@@ -1,0 +1,54 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.exec.profile;
+
+import org.opensearch.core.xcontent.ToXContentObject;
+import org.opensearch.core.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Query-level profile snapshot built from an execution graph plus the per-query
+ * {@code TaskTracker}. Safe to emit on both success and failure paths — every field
+ * is a plain value captured at snapshot time, not a live handle into the walker.
+ *
+ * @param queryId        per-query id from {@code QueryDAG.queryId()}
+ * @param fullPlan       the CBO-output Calcite plan rendered as an array of lines,
+ *                       captured before the DAG builder cut it at exchange boundaries;
+ *                       one element per indent level of the tree. Empty list if not supplied.
+ * @param planningTimeMs wall-clock time spent in the coordinator planning pipeline (PlannerImpl through FragmentConversionDriver)
+ * @param executionTimeMs wall-clock span from the earliest stage start to the latest stage end (0 if nothing ran)
+ * @param stages         per-stage profiles in DAG iteration order (root stage appears at whatever index the walker stored it)
+ */
+public record QueryProfile(String queryId, List<String> fullPlan, long planningTimeMs, long executionTimeMs, List<StageProfile> stages)
+    implements
+        ToXContentObject {
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.field("query_id", queryId);
+        if (fullPlan != null && fullPlan.isEmpty() == false) {
+            builder.startArray("full_plan");
+            for (String line : fullPlan)
+                builder.value(line);
+            builder.endArray();
+        }
+        builder.field("planning_time_ms", planningTimeMs);
+        builder.field("execution_time_ms", executionTimeMs);
+        builder.startArray("stages");
+        for (StageProfile s : stages) {
+            s.toXContent(builder, params);
+        }
+        builder.endArray();
+        builder.endObject();
+        return builder;
+    }
+}

--- a/sandbox/libs/analytics-api/src/main/java/org/opensearch/analytics/exec/profile/StageProfile.java
+++ b/sandbox/libs/analytics-api/src/main/java/org/opensearch/analytics/exec/profile/StageProfile.java
@@ -1,0 +1,67 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.exec.profile;
+
+import org.opensearch.core.xcontent.ToXContentObject;
+import org.opensearch.core.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Per-stage profile snapshot. Combines stage-level metadata (id, execution type,
+ * distribution), terminal state, wall-clock timing from {@code StageMetrics}, and
+ * the list of {@link TaskProfile}s for the stage's dispatched tasks.
+ *
+ * @param stageId              stage identifier from the DAG
+ * @param executionType        value of {@code StageExecutionType} as string (SHARD_FRAGMENT, COORDINATOR_REDUCE, LOCAL_PASSTHROUGH)
+ * @param distribution         Calcite distribution type this stage emits to its parent — e.g. SINGLETON, HASH_DISTRIBUTED; null for root
+ * @param state                terminal {@code StageExecution.State}
+ * @param startMs              wall-clock millis from {@code StageMetrics.recordStart()}, 0 if never started
+ * @param endMs                wall-clock millis from {@code StageMetrics.recordEnd()}, 0 if still running
+ * @param elapsedMs            {@code endMs - startMs}, or 0 if either stamp is missing
+ * @param rowsProcessed        counter from {@code StageMetrics.addRowsProcessed}
+ * @param tasksCompleted       counter from {@code StageMetrics.incrementTasksCompleted}
+ * @param tasksFailed          counter from {@code StageMetrics.incrementTasksFailed}
+ * @param fragment             Calcite {@code RelOptUtil.toString(stage.getFragment())} rendered as an
+ *                             array of lines (one element per level of indent) — much easier to read in
+ *                             raw JSON than a single multi-line escaped string
+ * @param tasks                per-partition task profiles registered with the TaskTracker
+ */
+public record StageProfile(int stageId, String executionType, String distribution, String state, long startMs, long endMs, long elapsedMs,
+    long rowsProcessed, long tasksCompleted, long tasksFailed, List<String> fragment, List<TaskProfile> tasks) implements ToXContentObject {
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.field("stage_id", stageId);
+        builder.field("execution_type", executionType);
+        if (distribution != null) builder.field("distribution", distribution);
+        builder.field("state", state);
+        if (startMs > 0) builder.field("start_ms", startMs);
+        if (endMs > 0) builder.field("end_ms", endMs);
+        builder.field("elapsed_ms", elapsedMs);
+        builder.field("rows_processed", rowsProcessed);
+        builder.field("tasks_completed", tasksCompleted);
+        builder.field("tasks_failed", tasksFailed);
+        if (fragment != null && fragment.isEmpty() == false) {
+            builder.startArray("fragment");
+            for (String line : fragment)
+                builder.value(line);
+            builder.endArray();
+        }
+        builder.startArray("tasks");
+        for (TaskProfile t : tasks) {
+            t.toXContent(builder, params);
+        }
+        builder.endArray();
+        builder.endObject();
+        return builder;
+    }
+}

--- a/sandbox/libs/analytics-api/src/main/java/org/opensearch/analytics/exec/profile/TaskProfile.java
+++ b/sandbox/libs/analytics-api/src/main/java/org/opensearch/analytics/exec/profile/TaskProfile.java
@@ -1,0 +1,45 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.exec.profile;
+
+import org.opensearch.core.xcontent.ToXContentObject;
+import org.opensearch.core.xcontent.XContentBuilder;
+
+import java.io.IOException;
+
+/**
+ * Per-task profile snapshot. Captures identity, target node, terminal state and
+ * wall-clock timing. A "task" is one dispatch unit within a stage (one shard for
+ * SOURCE, one partition for HASH_PARTITIONED, one total for COORDINATOR).
+ *
+ * @param stageId id of the owning stage
+ * @param partitionId ordinal of the task within its stage (0-based)
+ * @param node target node id the task ran on, or "(unresolved)" if dispatch never happened
+ * @param state terminal state — CREATED if the task was never dispatched
+ * @param startMs wall-clock millis of the first RUNNING transition, 0 if never dispatched
+ * @param endMs wall-clock millis of the first terminal transition, 0 if still running
+ * @param elapsedMs {@code endMs - startMs}, or 0 if either stamp is missing
+ */
+public record TaskProfile(int stageId, int partitionId, String node, String state, long startMs, long endMs, long elapsedMs)
+    implements
+        ToXContentObject {
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.field("partition_id", partitionId);
+        builder.field("node", node);
+        builder.field("state", state);
+        if (startMs > 0) builder.field("start_ms", startMs);
+        if (endMs > 0) builder.field("end_ms", endMs);
+        builder.field("elapsed_ms", elapsedMs);
+        builder.endObject();
+        return builder;
+    }
+}

--- a/sandbox/libs/analytics-api/src/main/java/org/opensearch/analytics/exec/profile/TaskProfile.java
+++ b/sandbox/libs/analytics-api/src/main/java/org/opensearch/analytics/exec/profile/TaskProfile.java
@@ -14,30 +14,21 @@ import org.opensearch.core.xcontent.XContentBuilder;
 import java.io.IOException;
 
 /**
- * Per-task profile snapshot. Captures identity, target node, terminal state and
- * wall-clock timing. A "task" is one dispatch unit within a stage (one shard for
- * SOURCE, one partition for HASH_PARTITIONED, one total for COORDINATOR).
+ * Per-task profile snapshot. Captures target node, terminal state and
+ * wall-clock elapsed time. A "task" is one dispatch unit within a stage
+ * (one shard for SOURCE, one partition for HASH_PARTITIONED, one total for COORDINATOR).
  *
- * @param stageId id of the owning stage
- * @param partitionId ordinal of the task within its stage (0-based)
- * @param node target node id the task ran on, or "(unresolved)" if dispatch never happened
+ * @param node target node and shard the task ran on, or "(unknown)" if dispatch never happened
  * @param state terminal state — CREATED if the task was never dispatched
- * @param startMs wall-clock millis of the first RUNNING transition, 0 if never dispatched
- * @param endMs wall-clock millis of the first terminal transition, 0 if still running
- * @param elapsedMs {@code endMs - startMs}, or 0 if either stamp is missing
+ * @param elapsedMs wall-clock time from dispatch to terminal, or 0 if never dispatched
  */
-public record TaskProfile(int stageId, int partitionId, String node, String state, long startMs, long endMs, long elapsedMs)
-    implements
-        ToXContentObject {
+public record TaskProfile(String node, String state, long elapsedMs) implements ToXContentObject {
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
-        builder.field("partition_id", partitionId);
         builder.field("node", node);
         builder.field("state", state);
-        if (startMs > 0) builder.field("start_ms", startMs);
-        if (endMs > 0) builder.field("end_ms", endMs);
         builder.field("elapsed_ms", elapsedMs);
         builder.endObject();
         return builder;

--- a/sandbox/libs/analytics-api/src/main/java/org/opensearch/analytics/exec/profile/package-info.java
+++ b/sandbox/libs/analytics-api/src/main/java/org/opensearch/analytics/exec/profile/package-info.java
@@ -1,0 +1,16 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/**
+ * Profile data model for the analytics engine explain/profile API.
+ * Contains immutable snapshot types captured after query execution:
+ * {@link org.opensearch.analytics.exec.profile.QueryProfile} (query-level),
+ * {@link org.opensearch.analytics.exec.profile.StageProfile} (per-stage),
+ * {@link org.opensearch.analytics.exec.profile.TaskProfile} (per-task/shard).
+ */
+package org.opensearch.analytics.exec.profile;

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/DefaultPlanExecutor.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/DefaultPlanExecutor.java
@@ -193,6 +193,11 @@ public class DefaultPlanExecutor extends HandledTransportAction<ActionRequest, A
             throw e;
         }
 
+        /*
+        Profile and explain are captured within the QueryExecution, however QueryExecution requires the complete
+        batchesListener to construct the ExecutionGraph. To get around this circular dependency we build a profiling
+        listener with an empty QueryExecution reference, and then populate it once constructed.
+         */
         final AtomicReference<QueryExecution> execRef = new AtomicReference<>();
 
         ActionListener<Iterable<Object[]>> rowsListener = profile

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/DefaultPlanExecutor.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/DefaultPlanExecutor.java
@@ -126,10 +126,11 @@ public class DefaultPlanExecutor extends HandledTransportAction<ActionRequest, A
         searchExecutor.execute(() -> {
             try {
                 // Non-profile path: unwrap rows from ProfiledResult (profile is null)
-                executeInternal(logicalFragment, false, ActionListener.wrap(
-                    result -> convertingListener.onResponse(result.rows()),
-                    convertingListener::onFailure
-                ));
+                executeInternal(
+                    logicalFragment,
+                    false,
+                    ActionListener.wrap(result -> convertingListener.onResponse(result.rows()), convertingListener::onFailure)
+                );
             } catch (Exception e) {
                 convertingListener.onFailure(e);
             }
@@ -144,9 +145,7 @@ public class DefaultPlanExecutor extends HandledTransportAction<ActionRequest, A
             } catch (Exception e) {
                 listener.onFailure(e);
             } catch (AssertionError e) {
-                listener.onFailure(
-                    new IllegalStateException("Analytics-engine executor rejected the plan: " + e.getMessage(), e)
-                );
+                listener.onFailure(new IllegalStateException("Analytics-engine executor rejected the plan: " + e.getMessage(), e));
             }
         });
     }

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/DefaultPlanExecutor.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/DefaultPlanExecutor.java
@@ -22,6 +22,9 @@ import org.opensearch.action.support.TimeoutTaskCancellationUtility;
 import org.opensearch.analytics.AnalyticsPlugin;
 import org.opensearch.analytics.EngineContext;
 import org.opensearch.analytics.exec.action.AnalyticsQueryAction;
+import org.opensearch.analytics.exec.profile.ProfiledResult;
+import org.opensearch.analytics.exec.profile.QueryProfile;
+import org.opensearch.analytics.exec.profile.QueryProfileBuilder;
 import org.opensearch.analytics.exec.task.AnalyticsQueryTask;
 import org.opensearch.analytics.exec.task.AnalyticsQueryTaskRequest;
 import org.opensearch.analytics.planner.CapabilityRegistry;
@@ -48,6 +51,7 @@ import org.opensearch.transport.client.node.NodeClient;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.opensearch.action.search.TransportSearchAction.SEARCH_CANCEL_AFTER_TIME_INTERVAL_SETTING;
 
@@ -113,29 +117,34 @@ public class DefaultPlanExecutor extends HandledTransportAction<ActionRequest, A
 
     @Override
     public void execute(RelNode logicalFragment, Object context, ActionListener<Iterable<Object[]>> listener) {
-        // Fork the entire query lifecycle (planning, scheduling, cleanup) onto the SEARCH
-        // executor so the calling thread — which may be a transport thread — is freed
-        // immediately. The scheduler then drives execution asynchronously and fires
-        // {@code listener} once the query terminates; nothing on this path blocks.
-        // The listener is wrapped to convert backend-specific exceptions (e.g., native memory
-        // errors arriving as StreamException from gRPC) into proper OpenSearch exception types.
+        // Wrap listener to convert backend-specific exceptions (e.g., native memory errors
+        // arriving as StreamException from gRPC) into proper OpenSearch exception types.
         ActionListener<Iterable<Object[]>> convertingListener = ActionListener.wrap(
             listener::onResponse,
             e -> listener.onFailure(e instanceof Exception ex ? engineContext.convertException(ex) : e)
         );
         searchExecutor.execute(() -> {
             try {
-                executeInternal(logicalFragment, convertingListener);
+                // Non-profile path: unwrap rows from ProfiledResult (profile is null)
+                executeInternal(logicalFragment, false, ActionListener.wrap(
+                    result -> convertingListener.onResponse(result.rows()),
+                    convertingListener::onFailure
+                ));
             } catch (Exception e) {
                 convertingListener.onFailure(e);
+            }
+        });
+    }
+
+    @Override
+    public void executeWithProfile(RelNode logicalFragment, Object context, ActionListener<ProfiledResult> listener) {
+        searchExecutor.execute(() -> {
+            try {
+                executeInternal(logicalFragment, true, listener);
+            } catch (Exception e) {
+                listener.onFailure(e);
             } catch (AssertionError e) {
-                // Calcite's Litmus.THROW (used by RelOptUtil.eq, RexUtil.isFlat, Project.isValid,
-                // RexChecker) throws AssertionError directly via Java code rather than via the
-                // `assert` keyword, so JVM -da doesn't gate them. If one fires inside this
-                // executor, OpenSearchUncaughtExceptionHandler exits the cluster JVM. Convert to
-                // an IllegalStateException so the query path treats it as a per-query failure
-                // (HTTP 500 with a bucketable message) instead of cluster-fatal.
-                convertingListener.onFailure(
+                listener.onFailure(
                     new IllegalStateException("Analytics-engine executor rejected the plan: " + e.getMessage(), e)
                 );
             }
@@ -143,30 +152,24 @@ public class DefaultPlanExecutor extends HandledTransportAction<ActionRequest, A
     }
 
     /**
-     * Plans, registers the query task, and dispatches to the {@link Scheduler}. Runs on
-     * the SEARCH thread pool — never on a transport thread. The result (or failure) is
-     * delivered to {@code listener} by the scheduler; this method returns as soon as the
-     * scheduler has accepted the query.
+     * Unified planning + execution path. When {@code profile} is true, captures the CBO
+     * plan text and snapshots per-stage timing into the {@link ProfiledResult}; when false,
+     * wraps rows into a ProfiledResult with null profile for uniform listener handling.
      */
-    private void executeInternal(RelNode logicalFragment, ActionListener<Iterable<Object[]>> listener) {
-        // Calcite's RelMetadataQuery reads its handler provider from a ThreadLocal
-        // (RelMetadataQueryBase.THREAD_PROVIDERS). The frontend seeds it on its own
-        // thread, but execute() hops to the SEARCH executor where the ThreadLocal is
-        // unset — RelOptUtil.toString / RelNode.explain inside PlannerImpl would then
-        // NPE on a null metadataHandlerProvider. Re-seed from the inbound cluster.
+    private void executeInternal(RelNode logicalFragment, boolean profile, ActionListener<ProfiledResult> listener) {
         RelMetadataQueryBase.THREAD_PROVIDERS.set(JaninoRelMetadataProvider.of(logicalFragment.getCluster().getMetadataProvider()));
         logicalFragment.getCluster().invalidateMetadataQuery();
 
+        final long planStartNanos = profile ? System.nanoTime() : 0;
         RelNode plan = PlannerImpl.createPlan(logicalFragment, new PlannerContext(capabilityRegistry, clusterService.state()));
+        final String fullPlan = profile ? org.apache.calcite.plan.RelOptUtil.toString(plan) : null;
         QueryDAG dag = DAGBuilder.build(plan, capabilityRegistry, clusterService);
         PlanForker.forkAll(dag, capabilityRegistry);
         BackendPlanAdapter.adaptAll(dag, capabilityRegistry);
         FragmentConversionDriver.convertAll(dag, capabilityRegistry);
+        final long planningTimeMs = profile ? java.util.concurrent.TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - planStartNanos) : 0;
         logger.debug("[DefaultPlanExecutor] QueryDAG:\n{}", dag);
 
-        // Register coordinator-level query task with TaskManager (like SearchTask).
-        // This gives us a proper unique ID, visibility in _tasks API, and cancellation support.
-        // TODO: accept a request type from FrontEnd including cancelAfterTimeInterval — set from cluster settings below, null in req.
         final AnalyticsQueryTask queryTask = (AnalyticsQueryTask) taskManager.register(
             "transport",
             "analytics_query",
@@ -190,8 +193,14 @@ public class DefaultPlanExecutor extends HandledTransportAction<ActionRequest, A
             throw e;
         }
 
+        final AtomicReference<QueryExecution> execRef = new AtomicReference<>();
+
+        ActionListener<Iterable<Object[]>> rowsListener = profile
+            ? buildProfilingRowsListener(execRef, context, fullPlan, planningTimeMs, listener)
+            : ActionListener.wrap(rows -> listener.onResponse(new ProfiledResult(rows, null, null)), listener::onFailure);
+
         ActionListener<Iterable<VectorSchemaRoot>> batchesListener = ActionListener.runAfter(
-            ActionListener.wrap(batches -> listener.onResponse(batchesToRows(batches)), listener::onFailure),
+            ActionListener.wrap(batches -> rowsListener.onResponse(batchesToRows(batches)), rowsListener::onFailure),
             () -> taskManager.unregister(queryTask)
         );
 
@@ -207,7 +216,29 @@ public class DefaultPlanExecutor extends HandledTransportAction<ActionRequest, A
             );
         }
 
-        scheduler.execute(context, batchesListener);
+        execRef.set(scheduler.execute(context, batchesListener)); // execRef read by profile listener after execution completes
+    }
+
+    /**
+     * Builds a rows listener that snapshots the {@link ExecutionGraph} into a {@link QueryProfile}
+     * at terminal, delivering a {@link ProfiledResult} on both success and failure paths.
+     */
+    private static ActionListener<Iterable<Object[]>> buildProfilingRowsListener(
+        AtomicReference<QueryExecution> execRef,
+        QueryContext context,
+        String fullPlan,
+        long planningTimeMs,
+        ActionListener<ProfiledResult> listener
+    ) {
+        return ActionListener.wrap(rows -> {
+            QueryProfile qp = QueryProfileBuilder.snapshot(execRef.get().getGraph(), context, fullPlan, planningTimeMs);
+            listener.onResponse(new ProfiledResult(rows, null, qp));
+        }, e -> {
+            QueryProfile qp = execRef.get() != null && execRef.get().getGraph() != null
+                ? QueryProfileBuilder.snapshot(execRef.get().getGraph(), context, fullPlan, planningTimeMs)
+                : new QueryProfile(context.queryId(), java.util.List.of(), planningTimeMs, 0L, java.util.List.of());
+            listener.onResponse(new ProfiledResult(null, e, qp));
+        });
     }
 
     @Override

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/QueryExecution.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/QueryExecution.java
@@ -110,6 +110,11 @@ public class QueryExecution {
         return state.get();
     }
 
+    /** Returns the execution graph for post-execution inspection (e.g. profiling). */
+    public ExecutionGraph getGraph() {
+        return graph;
+    }
+
     /**
      * Single-fire cleanup — closes terminal sink + per-query context. Each step under
      * {@link #runQuietly} so a failure in one doesn't skip the other. Auto-fired from any

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/QueryScheduler.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/QueryScheduler.java
@@ -45,7 +45,7 @@ public class QueryScheduler implements Scheduler {
     }
 
     @Override
-    public void execute(QueryContext context, ActionListener<Iterable<VectorSchemaRoot>> listener) {
+    public QueryExecution execute(QueryContext context, ActionListener<Iterable<VectorSchemaRoot>> listener) {
         final String queryId = context.queryId();
         final AnalyticsOperationListener.CompositeListener opListener = new AnalyticsOperationListener.CompositeListener(
             context.operationListeners()
@@ -70,6 +70,7 @@ public class QueryScheduler implements Scheduler {
         opListener.onQueryStart(queryId, graph.stageCount());
         logger.debug("[QueryScheduler] ExecutionGraph built:\n{}", graph.explain());
         execution.start();
+        return execution;
     }
 
     /**

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/Scheduler.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/Scheduler.java
@@ -34,6 +34,9 @@ public interface Scheduler {
      * for wrapping the listener with any caller-side cleanup hooks (task
      * unregister, etc.) — the scheduler's single-fire guarantee on the listener
      * makes {@link ActionListener#runAfter} the natural place to attach them.
+     *
+     * @return the {@link QueryExecution} driving this query, for post-execution inspection
+     *         (e.g. profiling). Callers that don't need it may ignore the return value.
      */
-    void execute(QueryContext context, ActionListener<Iterable<VectorSchemaRoot>> listener);
+    QueryExecution execute(QueryContext context, ActionListener<Iterable<VectorSchemaRoot>> listener);
 }

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/profile/QueryProfileBuilder.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/profile/QueryProfileBuilder.java
@@ -15,7 +15,6 @@ import org.opensearch.analytics.exec.stage.shard.ShardStageTask;
 import org.opensearch.analytics.exec.stage.StageExecution;
 import org.opensearch.analytics.exec.stage.StageMetrics;
 import org.opensearch.analytics.exec.stage.StageTask;
-import org.opensearch.analytics.exec.stage.StageTaskState;
 import org.opensearch.analytics.planner.dag.ShardExecutionTarget;
 import org.opensearch.analytics.planner.dag.Stage;
 
@@ -58,20 +57,22 @@ public final class QueryProfileBuilder {
             long tasksCompleted = taskProfiles.stream().filter(t -> "FINISHED".equals(t.state())).count();
             long tasksFailed = taskProfiles.stream().filter(t -> "FAILED".equals(t.state())).count();
 
-            stageProfiles.add(new StageProfile(
-                exec.getStageId(),
-                stage != null ? stage.getExecutionType().name() : exec.getClass().getSimpleName(),
-                distribution,
-                exec.getState().name(),
-                start,
-                end,
-                elapsed,
-                m.getRowsProcessed(),
-                tasksCompleted,
-                tasksFailed,
-                fragment,
-                taskProfiles
-            ));
+            stageProfiles.add(
+                new StageProfile(
+                    exec.getStageId(),
+                    stage != null ? stage.getExecutionType().name() : exec.getClass().getSimpleName(),
+                    distribution,
+                    exec.getState().name(),
+                    start,
+                    end,
+                    elapsed,
+                    m.getRowsProcessed(),
+                    tasksCompleted,
+                    tasksFailed,
+                    fragment,
+                    taskProfiles
+                )
+            );
         }
 
         long executionTimeMs = (earliestStart != Long.MAX_VALUE && latestEnd > 0) ? latestEnd - earliestStart : 0L;
@@ -85,15 +86,7 @@ public final class QueryProfileBuilder {
             long start = t.startedAtMs();
             long end = t.finishedAtMs();
             long elapsed = (start > 0 && end > 0) ? end - start : 0L;
-            out.add(new TaskProfile(
-                t.id().stageId(),
-                t.id().partitionId(),
-                describeTarget(t),
-                t.state().name(),
-                start,
-                end,
-                elapsed
-            ));
+            out.add(new TaskProfile(t.id().stageId(), t.id().partitionId(), describeTarget(t), t.state().name(), start, end, elapsed));
         }
         return out;
     }

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/profile/QueryProfileBuilder.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/profile/QueryProfileBuilder.java
@@ -11,10 +11,10 @@ package org.opensearch.analytics.exec.profile;
 import org.apache.calcite.plan.RelOptUtil;
 import org.opensearch.analytics.exec.ExecutionGraph;
 import org.opensearch.analytics.exec.QueryContext;
-import org.opensearch.analytics.exec.stage.shard.ShardStageTask;
 import org.opensearch.analytics.exec.stage.StageExecution;
 import org.opensearch.analytics.exec.stage.StageMetrics;
 import org.opensearch.analytics.exec.stage.StageTask;
+import org.opensearch.analytics.exec.stage.shard.ShardStageTask;
 import org.opensearch.analytics.planner.dag.ShardExecutionTarget;
 import org.opensearch.analytics.planner.dag.Stage;
 

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/profile/QueryProfileBuilder.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/profile/QueryProfileBuilder.java
@@ -86,7 +86,7 @@ public final class QueryProfileBuilder {
             long start = t.startedAtMs();
             long end = t.finishedAtMs();
             long elapsed = (start > 0 && end > 0) ? end - start : 0L;
-            out.add(new TaskProfile(t.id().stageId(), t.id().partitionId(), describeTarget(t), t.state().name(), start, end, elapsed));
+            out.add(new TaskProfile(describeTarget(t), t.state().name(), elapsed));
         }
         return out;
     }
@@ -98,10 +98,9 @@ public final class QueryProfileBuilder {
                 String nodeId = shardTarget.node() != null ? shardTarget.node().getId() : "(unknown)";
                 return nodeId + "/shard[" + shardTarget.shardId().getId() + "]";
             }
-            String nodeId = target.node() != null ? target.node().getId() : "(unknown)";
-            return nodeId;
+            return target.node() != null ? target.node().getId() : "(unknown)";
         }
-        return "(local)";
+        return task.id().toString();
     }
 
     private static List<String> splitPlanLines(String text) {

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/profile/QueryProfileBuilder.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/profile/QueryProfileBuilder.java
@@ -1,0 +1,132 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.exec.profile;
+
+import org.apache.calcite.plan.RelOptUtil;
+import org.opensearch.analytics.exec.ExecutionGraph;
+import org.opensearch.analytics.exec.QueryContext;
+import org.opensearch.analytics.exec.stage.shard.ShardStageTask;
+import org.opensearch.analytics.exec.stage.StageExecution;
+import org.opensearch.analytics.exec.stage.StageMetrics;
+import org.opensearch.analytics.exec.stage.StageTask;
+import org.opensearch.analytics.exec.stage.StageTaskState;
+import org.opensearch.analytics.planner.dag.ShardExecutionTarget;
+import org.opensearch.analytics.planner.dag.Stage;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Snapshots an {@link ExecutionGraph} into a {@link QueryProfile}. Pure read — no
+ * mutation of the graph. Safe to call on success, failure, or cancellation paths.
+ *
+ * @opensearch.internal
+ */
+public final class QueryProfileBuilder {
+
+    private QueryProfileBuilder() {}
+
+    public static QueryProfile snapshot(ExecutionGraph graph, QueryContext config, String fullPlan, long planningTimeMs) {
+        List<String> fullPlanLines = splitPlanLines(fullPlan);
+        List<StageProfile> stageProfiles = new ArrayList<>();
+        long earliestStart = Long.MAX_VALUE;
+        long latestEnd = 0L;
+
+        for (StageExecution exec : graph.allExecutions()) {
+            StageMetrics m = exec.getMetrics();
+            long start = m.getStartTimeMs();
+            long end = m.getEndTimeMs();
+            long elapsed = (start > 0 && end > 0) ? end - start : 0L;
+            if (start > 0) earliestStart = Math.min(earliestStart, start);
+            if (end > 0) latestEnd = Math.max(latestEnd, end);
+
+            Stage stage = findStageById(config.dag().rootStage(), exec.getStageId());
+            String distribution = (stage != null && stage.getExchangeInfo() != null)
+                ? stage.getExchangeInfo().distributionType().name()
+                : null;
+            List<String> fragment = stage != null && stage.getFragment() != null
+                ? splitPlanLines(RelOptUtil.toString(stage.getFragment()))
+                : List.of();
+
+            List<TaskProfile> taskProfiles = buildTaskProfiles(exec);
+            long tasksCompleted = taskProfiles.stream().filter(t -> "FINISHED".equals(t.state())).count();
+            long tasksFailed = taskProfiles.stream().filter(t -> "FAILED".equals(t.state())).count();
+
+            stageProfiles.add(new StageProfile(
+                exec.getStageId(),
+                stage != null ? stage.getExecutionType().name() : exec.getClass().getSimpleName(),
+                distribution,
+                exec.getState().name(),
+                start,
+                end,
+                elapsed,
+                m.getRowsProcessed(),
+                tasksCompleted,
+                tasksFailed,
+                fragment,
+                taskProfiles
+            ));
+        }
+
+        long executionTimeMs = (earliestStart != Long.MAX_VALUE && latestEnd > 0) ? latestEnd - earliestStart : 0L;
+        return new QueryProfile(graph.queryId(), fullPlanLines, planningTimeMs, executionTimeMs, stageProfiles);
+    }
+
+    private static List<TaskProfile> buildTaskProfiles(StageExecution exec) {
+        List<StageTask> tasks = exec.tasks();
+        List<TaskProfile> out = new ArrayList<>(tasks.size());
+        for (StageTask t : tasks) {
+            long start = t.startedAtMs();
+            long end = t.finishedAtMs();
+            long elapsed = (start > 0 && end > 0) ? end - start : 0L;
+            out.add(new TaskProfile(
+                t.id().stageId(),
+                t.id().partitionId(),
+                describeTarget(t),
+                t.state().name(),
+                start,
+                end,
+                elapsed
+            ));
+        }
+        return out;
+    }
+
+    private static String describeTarget(StageTask task) {
+        if (task instanceof ShardStageTask shardTask) {
+            var target = shardTask.target();
+            if (target instanceof ShardExecutionTarget shardTarget) {
+                String nodeId = shardTarget.node() != null ? shardTarget.node().getId() : "(unknown)";
+                return nodeId + "/shard[" + shardTarget.shardId().getId() + "]";
+            }
+            String nodeId = target.node() != null ? target.node().getId() : "(unknown)";
+            return nodeId;
+        }
+        return "(local)";
+    }
+
+    private static List<String> splitPlanLines(String text) {
+        if (text == null || text.isEmpty()) return List.of();
+        String[] raw = text.split("\n");
+        List<String> out = new ArrayList<>(raw.length);
+        for (String line : raw) {
+            if (line.isEmpty() == false) out.add(line);
+        }
+        return out;
+    }
+
+    private static Stage findStageById(Stage root, int stageId) {
+        if (root.getStageId() == stageId) return root;
+        for (Stage child : root.getChildStages()) {
+            Stage found = findStageById(child, stageId);
+            if (found != null) return found;
+        }
+        return null;
+    }
+}

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/profile/package-info.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/profile/package-info.java
@@ -1,0 +1,15 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/**
+ * Profile snapshot builder for the analytics engine explain API.
+ * {@link org.opensearch.analytics.exec.profile.QueryProfileBuilder} reads the
+ * {@link org.opensearch.analytics.exec.ExecutionGraph} after query execution
+ * and produces the profile data model defined in {@code analytics-api}.
+ */
+package org.opensearch.analytics.exec.profile;

--- a/sandbox/plugins/test-ppl-frontend/src/main/java/org/opensearch/ppl/action/PPLRequest.java
+++ b/sandbox/plugins/test-ppl-frontend/src/main/java/org/opensearch/ppl/action/PPLRequest.java
@@ -23,20 +23,28 @@ import static org.opensearch.action.ValidateActions.addValidationError;
 public class PPLRequest extends ActionRequest {
 
     private final String pplText;
+    private final boolean explain;
 
     public PPLRequest(String pplText) {
+        this(pplText, false);
+    }
+
+    public PPLRequest(String pplText, boolean explain) {
         this.pplText = pplText;
+        this.explain = explain;
     }
 
     public PPLRequest(StreamInput in) throws IOException {
         super(in);
         this.pplText = in.readString();
+        this.explain = in.readBoolean();
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeString(pplText);
+        out.writeBoolean(explain);
     }
 
     @Override
@@ -50,5 +58,9 @@ public class PPLRequest extends ActionRequest {
 
     public String getPplText() {
         return pplText;
+    }
+
+    public boolean isExplain() {
+        return explain;
     }
 }

--- a/sandbox/plugins/test-ppl-frontend/src/main/java/org/opensearch/ppl/action/PPLResponse.java
+++ b/sandbox/plugins/test-ppl-frontend/src/main/java/org/opensearch/ppl/action/PPLResponse.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.ppl.action;
 
+import org.opensearch.analytics.exec.profile.QueryProfile;
 import org.opensearch.core.action.ActionResponse;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
@@ -21,16 +22,23 @@ import java.util.List;
 
 /**
  * Transport-layer response carrying column names and result rows
- * from the unified PPL query execution pipeline.
+ * from the unified PPL query execution pipeline. Optionally carries
+ * a {@link QueryProfile} when the request was issued via the explain endpoint.
  */
 public class PPLResponse extends ActionResponse implements ToXContentObject {
 
     private final List<String> columns;
     private final List<Object[]> rows;
+    private final QueryProfile profile;
 
     public PPLResponse(List<String> columns, List<Object[]> rows) {
+        this(columns, rows, null);
+    }
+
+    public PPLResponse(List<String> columns, List<Object[]> rows, QueryProfile profile) {
         this.columns = columns;
         this.rows = rows;
+        this.profile = profile;
     }
 
     public PPLResponse(StreamInput in) throws IOException {
@@ -46,6 +54,8 @@ public class PPLResponse extends ActionResponse implements ToXContentObject {
             }
             rows.add(row);
         }
+        // Profile is not serialized over transport — it's only used in the local response path.
+        this.profile = null;
     }
 
     @Override
@@ -68,6 +78,10 @@ public class PPLResponse extends ActionResponse implements ToXContentObject {
         return rows;
     }
 
+    public QueryProfile getProfile() {
+        return profile;
+    }
+
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, ToXContent.Params params) throws IOException {
         builder.startObject();
@@ -85,6 +99,10 @@ public class PPLResponse extends ActionResponse implements ToXContentObject {
             builder.endArray();
         }
         builder.endArray();
+        if (profile != null) {
+            builder.field("profile");
+            profile.toXContent(builder, params);
+        }
         builder.endObject();
         return builder;
     }

--- a/sandbox/plugins/test-ppl-frontend/src/main/java/org/opensearch/ppl/action/RestPPLQueryAction.java
+++ b/sandbox/plugins/test-ppl-frontend/src/main/java/org/opensearch/ppl/action/RestPPLQueryAction.java
@@ -23,8 +23,14 @@ import static org.opensearch.rest.RestRequest.Method.POST;
  * REST handler for PPL queries: {@code POST /_analytics/ppl}.
  * Parses {@code {"query": "<ppl>"}} from the request body and
  * delegates to the transport action.
+ *
+ * <p>Also handles {@code POST /_analytics/ppl/_explain} which executes
+ * the query and returns profiling information (stage timings) alongside results.
  */
 public class RestPPLQueryAction extends BaseRestHandler {
+
+    private static final String QUERY_ENDPOINT = "/_analytics/ppl";
+    private static final String EXPLAIN_ENDPOINT = "/_analytics/ppl/_explain";
 
     @Override
     public String getName() {
@@ -33,7 +39,7 @@ public class RestPPLQueryAction extends BaseRestHandler {
 
     @Override
     public List<Route> routes() {
-        return List.of(new Route(POST, "/_analytics/ppl"));
+        return List.of(new Route(POST, QUERY_ENDPOINT), new Route(POST, EXPLAIN_ENDPOINT));
     }
 
     @Override
@@ -42,7 +48,8 @@ public class RestPPLQueryAction extends BaseRestHandler {
         try (XContentParser parser = request.contentParser()) {
             queryText = parseQueryText(parser);
         }
-        PPLRequest pplRequest = new PPLRequest(queryText);
+        boolean explain = request.path().endsWith("/_explain");
+        PPLRequest pplRequest = new PPLRequest(queryText, explain);
         return channel -> client.execute(UnifiedPPLExecuteAction.INSTANCE, pplRequest, new RestToXContentListener<>(channel));
     }
 

--- a/sandbox/plugins/test-ppl-frontend/src/main/java/org/opensearch/ppl/action/TestPPLTransportAction.java
+++ b/sandbox/plugins/test-ppl-frontend/src/main/java/org/opensearch/ppl/action/TestPPLTransportAction.java
@@ -69,7 +69,9 @@ public class TestPPLTransportAction extends HandledTransportAction<PPLRequest, P
         // TODO: update UnifiedQueryService to consume a listener that DefaultPlanExecutor does to avoid threadpool fork
         threadPool.executor(ThreadPool.Names.SEARCH).execute(() -> {
             try {
-                PPLResponse response = unifiedQueryService.execute(request.getPplText());
+                PPLResponse response = request.isExplain()
+                    ? unifiedQueryService.executeWithProfile(request.getPplText())
+                    : unifiedQueryService.execute(request.getPplText());
                 listener.onResponse(response);
             } catch (Exception e) {
                 logger.error("[UNIFIED_PPL] execution failed", e);

--- a/sandbox/plugins/test-ppl-frontend/src/main/java/org/opensearch/ppl/action/UnifiedQueryService.java
+++ b/sandbox/plugins/test-ppl-frontend/src/main/java/org/opensearch/ppl/action/UnifiedQueryService.java
@@ -18,6 +18,8 @@ import org.apache.logging.log4j.Logger;
 import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.analytics.EngineContext;
 import org.opensearch.analytics.exec.QueryPlanExecutor;
+import org.opensearch.analytics.exec.profile.ProfiledResult;
+import org.opensearch.analytics.exec.profile.QueryProfile;
 import org.opensearch.sql.api.UnifiedQueryContext;
 import org.opensearch.sql.api.UnifiedQueryPlanner;
 import org.opensearch.sql.executor.QueryType;
@@ -52,6 +54,18 @@ public class UnifiedQueryService {
      * PPL text → RelNode → planExecutor.execute() → PPLResponse.
      */
     public PPLResponse execute(String pplText) {
+        return execute(pplText, false);
+    }
+
+    /**
+     * Executes a PPL query with profiling: PPL text → RelNode →
+     * planExecutor.executeWithProfile() → PPLResponse with profile.
+     */
+    public PPLResponse executeWithProfile(String pplText) {
+        return execute(pplText, true);
+    }
+
+    private PPLResponse execute(String pplText, boolean profile) {
         // Extract tables from the SchemaPlus into a plain AbstractSchema.
         // SchemaPlus wraps CalciteSchema — passing it to catalog() causes double-nesting
         // where tables become inaccessible. A plain Schema avoids this.
@@ -93,6 +107,32 @@ public class UnifiedQueryService {
             UnifiedQueryPlanner planner = new UnifiedQueryPlanner(context);
             RelNode logicalPlan = planner.plan(pplText);
 
+            // Extract column names from the RelNode's row type
+            List<RelDataTypeField> fields = logicalPlan.getRowType().getFieldList();
+            List<String> columns = new ArrayList<>(fields.size());
+            for (RelDataTypeField field : fields) {
+                columns.add(field.getName());
+            }
+
+            if (profile) {
+                PlainActionFuture<ProfiledResult> future = new PlainActionFuture<>();
+                planExecutor.executeWithProfile(logicalPlan, null, future);
+                ProfiledResult result = future.actionGet();
+
+                if (result.isSuccess() == false) {
+                    Throwable failure = result.failure();
+                    if (failure instanceof RuntimeException re) throw re;
+                    throw new RuntimeException("Query failed: " + failure.getMessage(), failure);
+                }
+
+                QueryProfile queryProfile = result.profile();
+                List<Object[]> rows = new ArrayList<>();
+                for (Object[] row : result.rows()) {
+                    rows.add(row);
+                }
+                return new PPLResponse(columns, rows, queryProfile);
+            }
+
             // Execute directly via the back-end engine — no Janino compilation needed.
             // The executor API is async; this test frontend keeps a sync surface, so we bridge
             // via PlainActionFuture. The block happens off the transport thread (the executor
@@ -100,13 +140,6 @@ public class UnifiedQueryService {
             PlainActionFuture<Iterable<Object[]>> future = new PlainActionFuture<>();
             planExecutor.execute(logicalPlan, null, future);
             Iterable<Object[]> results = future.actionGet();
-
-            // Extract column names from the RelNode's row type
-            List<RelDataTypeField> fields = logicalPlan.getRowType().getFieldList();
-            List<String> columns = new ArrayList<>(fields.size());
-            for (RelDataTypeField field : fields) {
-                columns.add(field.getName());
-            }
 
             // Collect result rows
             List<Object[]> rows = new ArrayList<>();

--- a/sandbox/plugins/test-ppl-frontend/src/main/java/org/opensearch/ppl/action/UnifiedQueryService.java
+++ b/sandbox/plugins/test-ppl-frontend/src/main/java/org/opensearch/ppl/action/UnifiedQueryService.java
@@ -113,24 +113,36 @@ public class UnifiedQueryService {
                 columns.add(field.getName());
             }
 
-            // Always use executeWithProfile — the profile overhead is negligible and
-            // this avoids duplicating the execution + row-collection logic.
-            PlainActionFuture<ProfiledResult> future = new PlainActionFuture<>();
-            planExecutor.executeWithProfile(logicalPlan, null, future);
-            ProfiledResult result = future.actionGet();
+            if (profile) {
+                PlainActionFuture<ProfiledResult> future = new PlainActionFuture<>();
+                planExecutor.executeWithProfile(logicalPlan, null, future);
+                ProfiledResult result = future.actionGet();
 
-            if (result.isSuccess() == false) {
-                Throwable failure = result.failure();
-                if (failure instanceof RuntimeException re) throw re;
-                throw new RuntimeException("Query failed: " + failure.getMessage(), failure);
+                if (result.isSuccess() == false) {
+                    Throwable failure = result.failure();
+                    if (failure instanceof RuntimeException re) throw re;
+                    throw new RuntimeException("Query failed: " + failure.getMessage(), failure);
+                }
+
+                List<Object[]> rows = new ArrayList<>();
+                for (Object[] row : result.rows()) {
+                    rows.add(row);
+                }
+                return new PPLResponse(columns, rows, result.profile());
             }
+
+            // Non-profile path: use execute() directly so exception conversion
+            // (e.g. CircuitBreakingException) is handled by DefaultPlanExecutor's
+            // convertingListener without being wrapped in ProfiledResult.
+            PlainActionFuture<Iterable<Object[]>> future = new PlainActionFuture<>();
+            planExecutor.execute(logicalPlan, null, future);
+            Iterable<Object[]> results = future.actionGet();
 
             List<Object[]> rows = new ArrayList<>();
-            for (Object[] row : result.rows()) {
+            for (Object[] row : results) {
                 rows.add(row);
             }
-
-            return new PPLResponse(columns, rows, profile ? result.profile() : null);
+            return new PPLResponse(columns, rows);
         } catch (Exception e) {
             if (e instanceof RuntimeException) {
                 throw (RuntimeException) e;

--- a/sandbox/plugins/test-ppl-frontend/src/main/java/org/opensearch/ppl/action/UnifiedQueryService.java
+++ b/sandbox/plugins/test-ppl-frontend/src/main/java/org/opensearch/ppl/action/UnifiedQueryService.java
@@ -19,7 +19,6 @@ import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.analytics.EngineContext;
 import org.opensearch.analytics.exec.QueryPlanExecutor;
 import org.opensearch.analytics.exec.profile.ProfiledResult;
-import org.opensearch.analytics.exec.profile.QueryProfile;
 import org.opensearch.sql.api.UnifiedQueryContext;
 import org.opensearch.sql.api.UnifiedQueryPlanner;
 import org.opensearch.sql.executor.QueryType;
@@ -114,40 +113,24 @@ public class UnifiedQueryService {
                 columns.add(field.getName());
             }
 
-            if (profile) {
-                PlainActionFuture<ProfiledResult> future = new PlainActionFuture<>();
-                planExecutor.executeWithProfile(logicalPlan, null, future);
-                ProfiledResult result = future.actionGet();
+            // Always use executeWithProfile — the profile overhead is negligible and
+            // this avoids duplicating the execution + row-collection logic.
+            PlainActionFuture<ProfiledResult> future = new PlainActionFuture<>();
+            planExecutor.executeWithProfile(logicalPlan, null, future);
+            ProfiledResult result = future.actionGet();
 
-                if (result.isSuccess() == false) {
-                    Throwable failure = result.failure();
-                    if (failure instanceof RuntimeException re) throw re;
-                    throw new RuntimeException("Query failed: " + failure.getMessage(), failure);
-                }
-
-                QueryProfile queryProfile = result.profile();
-                List<Object[]> rows = new ArrayList<>();
-                for (Object[] row : result.rows()) {
-                    rows.add(row);
-                }
-                return new PPLResponse(columns, rows, queryProfile);
+            if (result.isSuccess() == false) {
+                Throwable failure = result.failure();
+                if (failure instanceof RuntimeException re) throw re;
+                throw new RuntimeException("Query failed: " + failure.getMessage(), failure);
             }
 
-            // Execute directly via the back-end engine — no Janino compilation needed.
-            // The executor API is async; this test frontend keeps a sync surface, so we bridge
-            // via PlainActionFuture. The block happens off the transport thread (the executor
-            // forks to SEARCH internally), so this is safe for test/IT use.
-            PlainActionFuture<Iterable<Object[]>> future = new PlainActionFuture<>();
-            planExecutor.execute(logicalPlan, null, future);
-            Iterable<Object[]> results = future.actionGet();
-
-            // Collect result rows
             List<Object[]> rows = new ArrayList<>();
-            for (Object[] row : results) {
+            for (Object[] row : result.rows()) {
                 rows.add(row);
             }
 
-            return new PPLResponse(columns, rows);
+            return new PPLResponse(columns, rows, profile ? result.profile() : null);
         } catch (Exception e) {
             if (e instanceof RuntimeException) {
                 throw (RuntimeException) e;

--- a/sandbox/plugins/test-ppl-frontend/src/test/java/org/opensearch/ppl/action/RestPPLQueryActionTests.java
+++ b/sandbox/plugins/test-ppl-frontend/src/test/java/org/opensearch/ppl/action/RestPPLQueryActionTests.java
@@ -23,9 +23,11 @@ public class RestPPLQueryActionTests extends OpenSearchTestCase {
     }
 
     public void testRoutes() {
-        assertEquals(1, action.routes().size());
+        assertEquals(2, action.routes().size());
         assertEquals(RestRequest.Method.POST, action.routes().get(0).getMethod());
         assertEquals("/_analytics/ppl", action.routes().get(0).getPath());
+        assertEquals(RestRequest.Method.POST, action.routes().get(1).getMethod());
+        assertEquals("/_analytics/ppl/_explain", action.routes().get(1).getPath());
     }
 
     public void testPrepareRequestMissingQuery() {

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/ExplainApiIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/ExplainApiIT.java
@@ -1,0 +1,181 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.qa;
+
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Integration test for {@code POST /_analytics/ppl/_explain}.
+ * Verifies that the explain endpoint executes the query and returns
+ * profiling information (stage timings, plan) alongside the normal results.
+ */
+public class ExplainApiIT extends AnalyticsRestTestCase {
+
+    private static final Dataset DATASET = new Dataset("calcs", "calcs");
+    private static final Dataset CLICKBENCH = ClickBenchTestHelper.DATASET;
+    private static boolean dataProvisioned = false;
+    private static boolean clickBenchProvisioned = false;
+
+    private void ensureDataProvisioned() throws IOException {
+        if (dataProvisioned == false) {
+            DatasetProvisioner.provision(client(), DATASET);
+            dataProvisioned = true;
+        }
+    }
+
+    private void ensureClickBenchProvisioned() throws IOException {
+        if (clickBenchProvisioned == false) {
+            DatasetProvisioner.provision(client(), CLICKBENCH);
+            clickBenchProvisioned = true;
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testExplainReturnsProfileWithStages() throws IOException {
+        ensureDataProvisioned();
+        Map<String, Object> result = executeExplain("source=" + DATASET.indexName + " | fields str0, num0");
+
+        // Should have normal query results
+        assertNotNull("columns present", result.get("columns"));
+        assertNotNull("rows present", result.get("rows"));
+
+        // Should have profile section
+        Map<String, Object> profile = (Map<String, Object>) result.get("profile");
+        assertNotNull("profile present", profile);
+        assertNotNull("query_id present", profile.get("query_id"));
+        assertNotNull("execution_time_ms present", profile.get("execution_time_ms"));
+
+        // Should have at least one stage
+        List<Map<String, Object>> stages = (List<Map<String, Object>>) profile.get("stages");
+        assertNotNull("stages present", stages);
+        assertFalse("at least one stage", stages.isEmpty());
+
+        // Each stage should have required fields
+        Map<String, Object> stage = stages.get(0);
+        assertNotNull("stage_id", stage.get("stage_id"));
+        assertNotNull("execution_type", stage.get("execution_type"));
+        assertNotNull("state", stage.get("state"));
+        assertNotNull("elapsed_ms", stage.get("elapsed_ms"));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testExplainReturnsFullPlan() throws IOException {
+        ensureDataProvisioned();
+        Map<String, Object> result = executeExplain("source=" + DATASET.indexName + " | where num0 > 0 | fields str0");
+
+        Map<String, Object> profile = (Map<String, Object>) result.get("profile");
+        assertNotNull("profile present", profile);
+
+        // full_plan should contain the optimized Calcite plan as lines
+        List<String> fullPlan = (List<String>) profile.get("full_plan");
+        assertNotNull("full_plan present", fullPlan);
+        assertFalse("full_plan not empty", fullPlan.isEmpty());
+
+        // Plan should reference the table being scanned
+        String planText = String.join("\n", fullPlan);
+        assertTrue("plan mentions table scan", planText.contains("TableScan") || planText.contains("Scan"));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testExplainWithAggregationShowsMultipleStages() throws IOException {
+        ensureClickBenchProvisioned();
+        Map<String, Object> result = executeExplain(
+            "source=" + CLICKBENCH.indexName + " | stats avg(AdvEngineID) by RegionID"
+        );
+
+        Map<String, Object> profile = (Map<String, Object>) result.get("profile");
+        assertNotNull("profile present", profile);
+
+        List<Map<String, Object>> stages = (List<Map<String, Object>>) profile.get("stages");
+        assertNotNull("stages present", stages);
+        // Multi-shard aggregation should produce at least 2 stages:
+        // SHARD_FRAGMENT (partial aggregate on data nodes) + COORDINATOR_REDUCE (final aggregate)
+        assertTrue("multi-shard aggregation produces multiple stages, got " + stages.size(), stages.size() >= 2);
+
+        // Verify we have both a SHARD_FRAGMENT and a COORDINATOR_REDUCE stage
+        boolean hasShardFragment = false;
+        boolean hasCoordinatorReduce = false;
+        for (Map<String, Object> stage : stages) {
+            String execType = (String) stage.get("execution_type");
+            if ("SHARD_FRAGMENT".equals(execType)) hasShardFragment = true;
+            if ("COORDINATOR_REDUCE".equals(execType)) hasCoordinatorReduce = true;
+        }
+        assertTrue("has SHARD_FRAGMENT stage", hasShardFragment);
+        assertTrue("has COORDINATOR_REDUCE stage", hasCoordinatorReduce);
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testExplainMultiStageShardFragmentHasTasks() throws IOException {
+        ensureClickBenchProvisioned();
+        Map<String, Object> result = executeExplain(
+            "source=" + CLICKBENCH.indexName + " | stats avg(AdvEngineID) by RegionID"
+        );
+
+        Map<String, Object> profile = (Map<String, Object>) result.get("profile");
+        List<Map<String, Object>> stages = (List<Map<String, Object>>) profile.get("stages");
+
+        // Find the SHARD_FRAGMENT stage and verify it has tasks (one per shard)
+        Map<String, Object> shardStage = stages.stream()
+            .filter(s -> "SHARD_FRAGMENT".equals(s.get("execution_type")))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("no SHARD_FRAGMENT stage"));
+
+        List<Map<String, Object>> tasks = (List<Map<String, Object>>) shardStage.get("tasks");
+        assertNotNull("shard stage has tasks", tasks);
+        // clickbench index has 2 shards
+        assertTrue("shard stage has at least 2 tasks (one per shard), got " + tasks.size(), tasks.size() >= 2);
+
+        for (Map<String, Object> task : tasks) {
+            assertEquals("task finished", "FINISHED", task.get("state"));
+            assertNotNull("task has node", task.get("node"));
+            long elapsed = ((Number) task.get("elapsed_ms")).longValue();
+            assertTrue("task elapsed is non-negative", elapsed >= 0);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testExplainStagesShowSucceededState() throws IOException {
+        ensureDataProvisioned();
+        Map<String, Object> result = executeExplain("source=" + DATASET.indexName + " | fields str0");
+
+        Map<String, Object> profile = (Map<String, Object>) result.get("profile");
+        List<Map<String, Object>> stages = (List<Map<String, Object>>) profile.get("stages");
+
+        for (Map<String, Object> stage : stages) {
+            assertEquals("stage succeeded", "SUCCEEDED", stage.get("state"));
+            long elapsed = ((Number) stage.get("elapsed_ms")).longValue();
+            assertTrue("elapsed is non-negative", elapsed >= 0);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testExplainTotalElapsedIsPositive() throws IOException {
+        ensureDataProvisioned();
+        Map<String, Object> result = executeExplain("source=" + DATASET.indexName + " | fields str0");
+
+        Map<String, Object> profile = (Map<String, Object>) result.get("profile");
+        long totalElapsed = ((Number) profile.get("execution_time_ms")).longValue();
+        assertTrue("execution_time_ms is positive", totalElapsed > 0);
+
+        long planningTime = ((Number) profile.get("planning_time_ms")).longValue();
+        assertTrue("planning_time_ms is non-negative", planningTime >= 0);
+    }
+
+    private Map<String, Object> executeExplain(String ppl) throws IOException {
+        Request request = new Request("POST", "/_analytics/ppl/_explain");
+        request.setJsonEntity("{\"query\": \"" + escapeJson(ppl) + "\"}");
+        Response response = client().performRequest(request);
+        return assertOkAndParse(response, "EXPLAIN: " + ppl);
+    }
+}


### PR DESCRIPTION
### Description

Adds an explain/profile API to the analytics engine, accessible via `POST /_analytics/ppl/_explain`. The endpoint executes the query and returns per-stage timing from the coordinator's perspective alongside normal results.

Follow up work which is not included in this PR:
- Integrate with SQL plugin's `RestUnifiedQueryAction.explain()` to use `executeWithProfile`
- Data-node-level profiling for fragments executed on shards

### Response format
Full response format with SQL plugin ([SQL PR](https://github.com/opensearch-project/sql/pull/5442)) with some test data.
```json
{
    "columns": [
        "avg(score)",
        "name"
    ],
    "rows": [
        [
            92.7,
            "eve"
        ],
        [
            91.0,
            "carol"
        ],
        [
            95.5,
            "alice"
        ],
        [
            88.1,
            "dave"
        ],
        [
            87.3,
            "bob"
        ]
    ],
    "profile": {
        "query_id": "a3009ddf-629b-45bc-ac61-5ab607d38cf5",
        "full_plan": [
            "OpenSearchProject(avg(score)=[$1], name=[$0], viableBackends=[[datafusion]])",
            "  OpenSearchProject(name=[$0], avg(score)=[ANNOTATED_PROJECT_EXPR(id=2, backends=[datafusion], /($1, $2))], viableBackends=[[datafusion]])",
            "    OpenSearchAggregate(group=[{0}], agg#0=[SUM(AGG_CALL_ANNOTATION(id=0, viableBackends=[datafusion]), $1)], agg#1=[COUNT(AGG_CALL_ANNOTATION(id=1, viableBackends=[datafusion]), $1)], mode=[FINAL], viableBackends=[[datafusion]])",
            "      OpenSearchExchangeReducer(viableBackends=[[datafusion]], exchange=[ExchangeInfo[distributionType=SINGLETON, partitionKeyIndices=[]]])",
            "        OpenSearchAggregate(group=[{0}], agg#0=[SUM(AGG_CALL_ANNOTATION(id=0, viableBackends=[datafusion]), $1)], agg#1=[COUNT(AGG_CALL_ANNOTATION(id=1, viableBackends=[datafusion]), $1)], mode=[PARTIAL], viableBackends=[[datafusion]])",
            "          OpenSearchProject(name=[$1], score=[$2], viableBackends=[[datafusion]])",
            "            OpenSearchTableScan(table=[[test_parquet]], viableBackends=[[datafusion]])"
        ],
        "planning_time_ms": 17,
        "execution_time_ms": 12,
        "stages": [
            {
                "stage_id": 0,
                "execution_type": "SHARD_FRAGMENT",
                "distribution": "SINGLETON",
                "state": "SUCCEEDED",
                "start_ms": 1779209122752,
                "end_ms": 1779209122763,
                "elapsed_ms": 11,
                "rows_processed": 5,
                "tasks_completed": 2,
                "tasks_failed": 0,
                "fragment": [
                    "OpenSearchAggregate(group=[{0}], agg#0=[SUM(AGG_CALL_ANNOTATION(id=0, viableBackends=[datafusion]), $1)], agg#1=[COUNT(AGG_CALL_ANNOTATION(id=1, viableBackends=[datafusion]), $1)], mode=[PARTIAL], viableBackends=[[datafusion]])",
                    "  OpenSearchProject(name=[$1], score=[$2], viableBackends=[[datafusion]])",
                    "    OpenSearchTableScan(table=[[test_parquet]], viableBackends=[[datafusion]])"
                ],
                "tasks": [
                    {
                        "partition_id": 0,
                        "node": "8L307qJ0RTmJLo6_vPhl4A/shard[0]",
                        "state": "FINISHED",
                        "start_ms": 1779209122752,
                        "end_ms": 1779209122762,
                        "elapsed_ms": 10
                    },
                    {
                        "partition_id": 1,
                        "node": "8L307qJ0RTmJLo6_vPhl4A/shard[1]",
                        "state": "FINISHED",
                        "start_ms": 1779209122752,
                        "end_ms": 1779209122763,
                        "elapsed_ms": 11
                    }
                ]
            },
            {
                "stage_id": 1,
                "execution_type": "COORDINATOR_REDUCE",
                "state": "SUCCEEDED",
                "start_ms": 1779209122752,
                "end_ms": 1779209122764,
                "elapsed_ms": 12,
                "rows_processed": 0,
                "tasks_completed": 1,
                "tasks_failed": 0,
                "fragment": [
                    "OpenSearchProject(avg(score)=[$1], name=[$0], viableBackends=[[datafusion]])",
                    "  OpenSearchProject(name=[$0], avg(score)=[ANNOTATED_PROJECT_EXPR(id=2, backends=[datafusion], /($1, $2))], viableBackends=[[datafusion]])",
                    "    OpenSearchAggregate(group=[{0}], agg#0=[SUM(AGG_CALL_ANNOTATION(id=0, viableBackends=[datafusion]), $1)], agg#1=[COUNT(AGG_CALL_ANNOTATION(id=1, viableBackends=[datafusion]), $1)], mode=[FINAL], viableBackends=[[datafusion]])",
                    "      OpenSearchExchangeReducer(viableBackends=[[datafusion]], exchange=[ExchangeInfo[distributionType=SINGLETON, partitionKeyIndices=[]]])",
                    "        OpenSearchStageInputScan(childStageId=[0], viableBackends=[[datafusion]])"
                ],
                "tasks": [
                    {
                        "partition_id": 0,
                        "node": "(local)",
                        "state": "FINISHED",
                        "start_ms": 1779209122752,
                        "end_ms": 1779209122764,
                        "elapsed_ms": 12
                    }
                ]
            }
        ]
    }
}
```

### Related Issues
N/A

### Check List
- [x] Functionality includes testing.
~~- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.~~
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

