### PR TITLE
Relevance Functions Optional Param Support, Refactor and support new functions

### DIFF
--- a/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/ScalarFunction.java
+++ b/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/ScalarFunction.java
@@ -61,6 +61,9 @@ public enum ScalarFunction {
     WILDCARD(Category.FULL_TEXT, SqlKind.OTHER_FUNCTION),
     REGEXP(Category.FULL_TEXT, SqlKind.OTHER_FUNCTION),
     REGEXP_CONTAINS(Category.FULL_TEXT, SqlKind.OTHER_FUNCTION),
+    WILDCARD_QUERY(Category.FULL_TEXT, SqlKind.OTHER_FUNCTION),
+    QUERY(Category.FULL_TEXT, SqlKind.OTHER_FUNCTION),
+    MATCHALL(Category.FULL_TEXT, SqlKind.OTHER_FUNCTION),
 
     // ── String ───────────────────────────────────────────────────────
     UPPER(Category.STRING, SqlKind.OTHER_FUNCTION),

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/TimestampFunctionAdapter.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/TimestampFunctionAdapter.java
@@ -94,6 +94,14 @@ class TimestampFunctionAdapter implements ScalarFunctionAdapter {
             return toTimestampString(ldt);
         } catch (DateTimeParseException ignored) {}
 
+        // Handle space-separated format: "yyyy-MM-dd HH:mm:ss" or "yyyy-MM-dd HH:mm:ss.SSS"
+        if (input.contains(" ") && !input.contains("T")) {
+            try {
+                LocalDateTime ldt = LocalDateTime.parse(input.replace(' ', 'T'));
+                return toTimestampString(ldt);
+            } catch (DateTimeParseException ignored) {}
+        }
+
         return new TimestampString(input);
     }
 

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/TimestampFunctionAdapterTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/TimestampFunctionAdapterTests.java
@@ -59,4 +59,9 @@ public class TimestampFunctionAdapterTests extends OpenSearchTestCase {
         TimestampString ts = transformer.parseTimestamp("2024-01-01 10:30:00");
         assertEquals("2024-01-01 10:30:00", ts.toString());
     }
+
+    public void testSpaceSeparatorWithMilliseconds() {
+        TimestampString ts = transformer.parseTimestamp("2024-01-01 10:30:00.123");
+        assertEquals("2024-01-01 10:30:00.123", ts.toString());
+    }
 }

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/ConversionUtils.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/ConversionUtils.java
@@ -19,7 +19,9 @@ import org.opensearch.index.query.QueryBuilder;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Reusable utilities for extracting fields and values from PPL relevance function
@@ -29,7 +31,7 @@ import java.util.List;
  * {@code func(MAP('field', $ref), MAP('query', literal), [MAP('param', literal)]...)}
  * Each MAP has exactly 2 operands: key at index 0, value at index 1.
  */
-final class ConversionUtils {
+public final class ConversionUtils {
 
     /** MAP key for single-field relevance operands. */
     static final String KEY_FIELD = "field";
@@ -77,7 +79,7 @@ final class ConversionUtils {
     /**
      * Serializes a QueryBuilder into bytes using NamedWriteable protocol.
      */
-    static byte[] serializeQueryBuilder(QueryBuilder queryBuilder) {
+    public static byte[] serializeQueryBuilder(QueryBuilder queryBuilder) {
         try (BytesStreamOutput output = new BytesStreamOutput()) {
             output.writeNamedWriteable(queryBuilder);
             return BytesReference.toBytes(output.bytes());
@@ -102,12 +104,52 @@ final class ConversionUtils {
     }
 
     /**
+     * Extracts optional key-value parameters from MAP_VALUE_CONSTRUCTOR operands
+     * starting at the given index.
+     *
+     * <p>Each operand at index {@code startIndex} and beyond is expected to be a
+     * MAP_VALUE_CONSTRUCTOR with exactly 2 children: a string key literal at index 0
+     * and a string value literal at index 1.
+     *
+     * <p>Example: for {@code match(field, 'query', operator='AND', analyzer='standard')},
+     * operands 2 and 3 are MAP('operator','AND') and MAP('analyzer','standard').
+     * Calling {@code extractOptionalParams(call, 2)} returns
+     * {@code Map.of("operator", "AND", "analyzer", "standard")}.
+     *
+     * @param call       the relevance function RexCall
+     * @param startIndex the first operand index to inspect (typically 2)
+     * @return map of parameter key → string value; empty if no optional params present
+     */
+    public static Map<String, String> extractOptionalParams(RexCall call, int startIndex) {
+        List<RexNode> operands = call.getOperands();
+        if (startIndex >= operands.size()) {
+            return Map.of();
+        }
+        Map<String, String> params = new LinkedHashMap<>();
+        for (int i = startIndex; i < operands.size(); i++) {
+            RexNode operand = operands.get(i);
+            if (operand instanceof RexCall mapCall && mapCall.getOperands().size() == 2) {
+                RexNode keyNode = mapCall.getOperands().get(0);
+                RexNode valueNode = mapCall.getOperands().get(1);
+                if (keyNode instanceof RexLiteral keyLit && valueNode instanceof RexLiteral valueLit) {
+                    String key = keyLit.getValueAs(String.class);
+                    String value = valueLit.getValueAs(String.class);
+                    if (key != null && value != null) {
+                        params.put(key, value);
+                    }
+                }
+            }
+        }
+        return params;
+    }
+
+    /**
      * Extracted operands from a relevance function RexCall.
      * @param fieldName  single field name (null if not present or multi-field)
      * @param fields     multiple field names (null if not present)
      * @param query      the query string (null if not found)
      */
-    record RelevanceOperands(String fieldName, List<String> fields, String query) {
+    public record RelevanceOperands(String fieldName, List<String> fields, String query) {
     }
 
     /**
@@ -118,7 +160,7 @@ final class ConversionUtils {
      * @param fieldStorage per-column storage metadata for resolving field names
      * @return extracted operands
      */
-    static RelevanceOperands extractRelevanceOperands(RexCall call, List<FieldStorageInfo> fieldStorage) {
+    public static RelevanceOperands extractRelevanceOperands(RexCall call, List<FieldStorageInfo> fieldStorage) {
         String fieldName = null;
         List<String> fields = null;
         String query = null;

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/LuceneAnalyticsBackendPlugin.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/LuceneAnalyticsBackendPlugin.java
@@ -71,7 +71,10 @@ public class LuceneAnalyticsBackendPlugin implements AnalyticsSearchBackendPlugi
         ScalarFunction.SIMPLE_QUERY_STRING,
         ScalarFunction.FUZZY,
         ScalarFunction.WILDCARD,
-        ScalarFunction.REGEXP
+        ScalarFunction.REGEXP,
+        ScalarFunction.WILDCARD_QUERY,
+        ScalarFunction.QUERY,
+        ScalarFunction.MATCHALL
     );
 
     private static final Set<FieldType> STANDARD_TYPES = new HashSet<>();

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/QuerySerializerRegistry.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/QuerySerializerRegistry.java
@@ -8,19 +8,16 @@
 
 package org.opensearch.be.lucene;
 
-import org.apache.calcite.rex.RexCall;
 import org.opensearch.analytics.spi.DelegatedPredicateSerializer;
-import org.opensearch.analytics.spi.FieldStorageInfo;
 import org.opensearch.analytics.spi.ScalarFunction;
-import org.opensearch.index.query.MatchBoolPrefixQueryBuilder;
-import org.opensearch.index.query.MatchPhrasePrefixQueryBuilder;
-import org.opensearch.index.query.MatchPhraseQueryBuilder;
-import org.opensearch.index.query.MatchQueryBuilder;
-import org.opensearch.index.query.MultiMatchQueryBuilder;
-import org.opensearch.index.query.QueryStringQueryBuilder;
-import org.opensearch.index.query.SimpleQueryStringBuilder;
+import org.opensearch.be.lucene.serializers.MatchBoolPrefixSerializer;
+import org.opensearch.be.lucene.serializers.MatchPhrasePrefixSerializer;
+import org.opensearch.be.lucene.serializers.MatchPhraseSerializer;
+import org.opensearch.be.lucene.serializers.MatchSerializer;
+import org.opensearch.be.lucene.serializers.MultiMatchSerializer;
+import org.opensearch.be.lucene.serializers.QueryStringSerializer;
+import org.opensearch.be.lucene.serializers.SimpleQueryStringSerializer;
 
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -31,104 +28,18 @@ import java.util.Map;
 final class QuerySerializerRegistry {
 
     private static final Map<ScalarFunction, DelegatedPredicateSerializer> SERIALIZERS = Map.ofEntries(
-        Map.entry(ScalarFunction.MATCH, QuerySerializerRegistry::serializeMatch),
-        Map.entry(ScalarFunction.MATCH_PHRASE, QuerySerializerRegistry::serializeMatchPhrase),
-        Map.entry(ScalarFunction.MATCH_BOOL_PREFIX, QuerySerializerRegistry::serializeMatchBoolPrefix),
-        Map.entry(ScalarFunction.MATCH_PHRASE_PREFIX, QuerySerializerRegistry::serializeMatchPhrasePrefix),
-        Map.entry(ScalarFunction.MULTI_MATCH, QuerySerializerRegistry::serializeMultiMatch),
-        Map.entry(ScalarFunction.QUERY_STRING, QuerySerializerRegistry::serializeQueryString),
-        Map.entry(ScalarFunction.SIMPLE_QUERY_STRING, QuerySerializerRegistry::serializeSimpleQueryString)
+        Map.entry(ScalarFunction.MATCH, new MatchSerializer()),
+        Map.entry(ScalarFunction.MATCH_PHRASE, new MatchPhraseSerializer()),
+        Map.entry(ScalarFunction.MATCH_BOOL_PREFIX, new MatchBoolPrefixSerializer()),
+        Map.entry(ScalarFunction.MATCH_PHRASE_PREFIX, new MatchPhrasePrefixSerializer()),
+        Map.entry(ScalarFunction.MULTI_MATCH, new MultiMatchSerializer()),
+        Map.entry(ScalarFunction.QUERY_STRING, new QueryStringSerializer()),
+        Map.entry(ScalarFunction.SIMPLE_QUERY_STRING, new SimpleQueryStringSerializer())
     );
 
     private QuerySerializerRegistry() {}
 
     static Map<ScalarFunction, DelegatedPredicateSerializer> getSerializers() {
         return SERIALIZERS;
-    }
-
-    // TODO: Extract each serialize* method into its own dedicated class once we handle more parameters.
-    // These methods are expected to grow significantly as optional parameters are added.
-
-    private static byte[] serializeMatch(RexCall call, List<FieldStorageInfo> fieldStorage) {
-        ConversionUtils.RelevanceOperands operands = ConversionUtils.extractRelevanceOperands(call, fieldStorage);
-        if (operands.fieldName() == null || operands.query() == null) {
-            throw new IllegalArgumentException("match requires 'field' and 'query' parameters, got: " + call);
-        }
-        // TODO: extract optional params (operator, analyzer, fuzziness, boost)
-        MatchQueryBuilder queryBuilder = new MatchQueryBuilder(operands.fieldName(), operands.query());
-        return ConversionUtils.serializeQueryBuilder(queryBuilder);
-    }
-
-    private static byte[] serializeMatchPhrase(RexCall call, List<FieldStorageInfo> fieldStorage) {
-        ConversionUtils.RelevanceOperands operands = ConversionUtils.extractRelevanceOperands(call, fieldStorage);
-        if (operands.fieldName() == null || operands.query() == null) {
-            throw new IllegalArgumentException("match_phrase requires 'field' and 'query' parameters, got: " + call);
-        }
-        // TODO: extract optional params (slop, analyzer, zero_terms_query)
-        MatchPhraseQueryBuilder queryBuilder = new MatchPhraseQueryBuilder(operands.fieldName(), operands.query());
-        return ConversionUtils.serializeQueryBuilder(queryBuilder);
-    }
-
-    private static byte[] serializeMatchBoolPrefix(RexCall call, List<FieldStorageInfo> fieldStorage) {
-        ConversionUtils.RelevanceOperands operands = ConversionUtils.extractRelevanceOperands(call, fieldStorage);
-        if (operands.fieldName() == null || operands.query() == null) {
-            throw new IllegalArgumentException("match_bool_prefix requires 'field' and 'query' parameters, got: " + call);
-        }
-        // TODO: extract optional params (analyzer, fuzziness, operator, minimum_should_match)
-        MatchBoolPrefixQueryBuilder queryBuilder = new MatchBoolPrefixQueryBuilder(operands.fieldName(), operands.query());
-        return ConversionUtils.serializeQueryBuilder(queryBuilder);
-    }
-
-    private static byte[] serializeMatchPhrasePrefix(RexCall call, List<FieldStorageInfo> fieldStorage) {
-        ConversionUtils.RelevanceOperands operands = ConversionUtils.extractRelevanceOperands(call, fieldStorage);
-        if (operands.fieldName() == null || operands.query() == null) {
-            throw new IllegalArgumentException("match_phrase_prefix requires 'field' and 'query' parameters, got: " + call);
-        }
-        // TODO: extract optional params (slop, analyzer, max_expansions, zero_terms_query)
-        MatchPhrasePrefixQueryBuilder queryBuilder = new MatchPhrasePrefixQueryBuilder(operands.fieldName(), operands.query());
-        return ConversionUtils.serializeQueryBuilder(queryBuilder);
-    }
-
-    private static byte[] serializeMultiMatch(RexCall call, List<FieldStorageInfo> fieldStorage) {
-        ConversionUtils.RelevanceOperands operands = ConversionUtils.extractRelevanceOperands(call, fieldStorage);
-        if (operands.query() == null) {
-            throw new IllegalArgumentException("multi_match requires a 'query' parameter, got: " + call);
-        }
-        // TODO: extract per-field boost values and optional params (type, operator, analyzer, fuzziness)
-        List<String> fields = operands.fields();
-        MultiMatchQueryBuilder queryBuilder = fields != null
-            ? new MultiMatchQueryBuilder(operands.query(), fields.toArray(String[]::new))
-            : new MultiMatchQueryBuilder(operands.query());
-        return ConversionUtils.serializeQueryBuilder(queryBuilder);
-    }
-
-    private static byte[] serializeQueryString(RexCall call, List<FieldStorageInfo> fieldStorage) {
-        ConversionUtils.RelevanceOperands operands = ConversionUtils.extractRelevanceOperands(call, fieldStorage);
-        if (operands.query() == null) {
-            throw new IllegalArgumentException("query_string requires a 'query' parameter, got: " + call);
-        }
-        // TODO: extract optional params (default_operator, analyzer, allow_leading_wildcard)
-        QueryStringQueryBuilder queryBuilder = new QueryStringQueryBuilder(operands.query());
-        if (operands.fields() != null) {
-            for (String field : operands.fields()) {
-                queryBuilder.field(field);
-            }
-        }
-        return ConversionUtils.serializeQueryBuilder(queryBuilder);
-    }
-
-    private static byte[] serializeSimpleQueryString(RexCall call, List<FieldStorageInfo> fieldStorage) {
-        ConversionUtils.RelevanceOperands operands = ConversionUtils.extractRelevanceOperands(call, fieldStorage);
-        if (operands.query() == null) {
-            throw new IllegalArgumentException("simple_query_string requires a 'query' parameter, got: " + call);
-        }
-        // TODO: extract optional params (default_operator, analyzer, flags, minimum_should_match)
-        SimpleQueryStringBuilder queryBuilder = new SimpleQueryStringBuilder(operands.query());
-        if (operands.fields() != null) {
-            for (String field : operands.fields()) {
-                queryBuilder.field(field);
-            }
-        }
-        return ConversionUtils.serializeQueryBuilder(queryBuilder);
     }
 }

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/QuerySerializerRegistry.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/QuerySerializerRegistry.java
@@ -10,13 +10,16 @@ package org.opensearch.be.lucene;
 
 import org.opensearch.analytics.spi.DelegatedPredicateSerializer;
 import org.opensearch.analytics.spi.ScalarFunction;
+import org.opensearch.be.lucene.serializers.MatchAllSerializer;
 import org.opensearch.be.lucene.serializers.MatchBoolPrefixSerializer;
 import org.opensearch.be.lucene.serializers.MatchPhrasePrefixSerializer;
 import org.opensearch.be.lucene.serializers.MatchPhraseSerializer;
 import org.opensearch.be.lucene.serializers.MatchSerializer;
 import org.opensearch.be.lucene.serializers.MultiMatchSerializer;
+import org.opensearch.be.lucene.serializers.QuerySerializer;
 import org.opensearch.be.lucene.serializers.QueryStringSerializer;
 import org.opensearch.be.lucene.serializers.SimpleQueryStringSerializer;
+import org.opensearch.be.lucene.serializers.WildcardQuerySerializer;
 
 import java.util.Map;
 
@@ -34,7 +37,10 @@ final class QuerySerializerRegistry {
         Map.entry(ScalarFunction.MATCH_PHRASE_PREFIX, new MatchPhrasePrefixSerializer()),
         Map.entry(ScalarFunction.MULTI_MATCH, new MultiMatchSerializer()),
         Map.entry(ScalarFunction.QUERY_STRING, new QueryStringSerializer()),
-        Map.entry(ScalarFunction.SIMPLE_QUERY_STRING, new SimpleQueryStringSerializer())
+        Map.entry(ScalarFunction.SIMPLE_QUERY_STRING, new SimpleQueryStringSerializer()),
+        Map.entry(ScalarFunction.WILDCARD_QUERY, new WildcardQuerySerializer()),
+        Map.entry(ScalarFunction.QUERY, new QuerySerializer()),
+        Map.entry(ScalarFunction.MATCHALL, new MatchAllSerializer())
     );
 
     private QuerySerializerRegistry() {}

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/AbstractQuerySerializer.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/AbstractQuerySerializer.java
@@ -1,0 +1,32 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.lucene.serializers;
+
+import org.apache.calcite.rex.RexCall;
+import org.opensearch.analytics.spi.DelegatedPredicateSerializer;
+import org.opensearch.analytics.spi.FieldStorageInfo;
+import org.opensearch.be.lucene.ConversionUtils;
+import org.opensearch.index.query.QueryBuilder;
+
+import java.util.List;
+
+/**
+ * Base class for query serializers. Implements the {@link DelegatedPredicateSerializer}
+ * contract by delegating to a template method that builds the {@link QueryBuilder}.
+ */
+public abstract class AbstractQuerySerializer implements DelegatedPredicateSerializer {
+
+    @Override
+    public final byte[] serialize(RexCall call, List<FieldStorageInfo> fieldStorage) {
+        QueryBuilder queryBuilder = buildQueryBuilder(call, fieldStorage);
+        return ConversionUtils.serializeQueryBuilder(queryBuilder);
+    }
+
+    protected abstract QueryBuilder buildQueryBuilder(RexCall call, List<FieldStorageInfo> fieldStorage);
+}

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/AbstractRelevanceSerializer.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/AbstractRelevanceSerializer.java
@@ -1,0 +1,51 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.lucene.serializers;
+
+import org.apache.calcite.rex.RexCall;
+import org.opensearch.analytics.spi.FieldStorageInfo;
+import org.opensearch.be.lucene.ConversionUtils;
+import org.opensearch.index.query.QueryBuilder;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Base class for relevance function serializers. Handles the common pattern of
+ * extracting operands, validating, creating the query builder, and applying
+ * optional parameters.
+ */
+public abstract class AbstractRelevanceSerializer extends AbstractQuerySerializer {
+
+    @Override
+    protected final QueryBuilder buildQueryBuilder(RexCall call, List<FieldStorageInfo> fieldStorage) {
+        ConversionUtils.RelevanceOperands operands = ConversionUtils.extractRelevanceOperands(call, fieldStorage);
+        validate(operands);
+        QueryBuilder qb = createQueryBuilder(operands);
+        Map<String, String> params = ConversionUtils.extractOptionalParams(call, optionalParamsStartIndex());
+        applyParams(qb, params);
+        return qb;
+    }
+
+    protected abstract QueryBuilder createQueryBuilder(ConversionUtils.RelevanceOperands operands);
+
+    protected abstract String functionName();
+
+    protected void applyParams(QueryBuilder qb, Map<String, String> params) {}
+
+    protected void validate(ConversionUtils.RelevanceOperands operands) {
+        if (operands.fieldName() == null || operands.query() == null) {
+            throw new IllegalArgumentException(functionName() + " requires 'field' and 'query' parameters");
+        }
+    }
+
+    protected int optionalParamsStartIndex() {
+        return 2;
+    }
+}

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/MatchAllSerializer.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/MatchAllSerializer.java
@@ -1,0 +1,29 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.lucene.serializers;
+
+import org.apache.calcite.rex.RexCall;
+import org.opensearch.analytics.spi.FieldStorageInfo;
+import org.opensearch.index.query.MatchAllQueryBuilder;
+import org.opensearch.index.query.QueryBuilder;
+
+import java.util.List;
+
+/**
+ * Serializer for the MATCHALL function.
+ * Extends AbstractQuerySerializer directly (not AbstractRelevanceSerializer)
+ * because MATCHALL is a zero-argument function with no MAP_VALUE_CONSTRUCTOR operands.
+ */
+public class MatchAllSerializer extends AbstractQuerySerializer {
+
+    @Override
+    protected QueryBuilder buildQueryBuilder(RexCall call, List<FieldStorageInfo> fieldStorage) {
+        return new MatchAllQueryBuilder();
+    }
+}

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/MatchBoolPrefixSerializer.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/MatchBoolPrefixSerializer.java
@@ -1,0 +1,53 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.lucene.serializers;
+
+import org.opensearch.be.lucene.ConversionUtils;
+import org.opensearch.common.unit.Fuzziness;
+import org.opensearch.index.query.MatchBoolPrefixQueryBuilder;
+import org.opensearch.index.query.Operator;
+import org.opensearch.index.query.QueryBuilder;
+
+import java.util.Map;
+
+/**
+ * Serializer for the MATCH_BOOL_PREFIX relevance function.
+ */
+public class MatchBoolPrefixSerializer extends AbstractRelevanceSerializer {
+
+    @Override
+    protected String functionName() {
+        return "match_bool_prefix";
+    }
+
+    @Override
+    protected QueryBuilder createQueryBuilder(ConversionUtils.RelevanceOperands operands) {
+        return new MatchBoolPrefixQueryBuilder(operands.fieldName(), operands.query());
+    }
+
+    @Override
+    protected void applyParams(QueryBuilder qb, Map<String, String> params) {
+        MatchBoolPrefixQueryBuilder matchBoolPrefixQb = (MatchBoolPrefixQueryBuilder) qb;
+        for (Map.Entry<String, String> entry : params.entrySet()) {
+            switch (entry.getKey()) {
+                case "analyzer" -> matchBoolPrefixQb.analyzer(entry.getValue());
+                case "fuzziness" -> matchBoolPrefixQb.fuzziness(Fuzziness.build(entry.getValue()));
+                case "operator" -> matchBoolPrefixQb.operator(Operator.fromString(entry.getValue()));
+                case "minimum_should_match" -> matchBoolPrefixQb.minimumShouldMatch(entry.getValue());
+                case "prefix_length" -> matchBoolPrefixQb.prefixLength(Integer.parseInt(entry.getValue()));
+                case "max_expansions" -> matchBoolPrefixQb.maxExpansions(Integer.parseInt(entry.getValue()));
+                case "fuzzy_transpositions" -> matchBoolPrefixQb.fuzzyTranspositions(Boolean.parseBoolean(entry.getValue()));
+                case "fuzzy_rewrite" -> matchBoolPrefixQb.fuzzyRewrite(entry.getValue());
+                case "boost" -> matchBoolPrefixQb.boost(Float.parseFloat(entry.getValue()));
+                default -> {
+                    /* ignore unrecognized params for forward compatibility */ }
+            }
+        }
+    }
+}

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/MatchPhrasePrefixSerializer.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/MatchPhrasePrefixSerializer.java
@@ -1,0 +1,51 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.lucene.serializers;
+
+import org.opensearch.be.lucene.ConversionUtils;
+import org.opensearch.index.query.MatchPhrasePrefixQueryBuilder;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.search.MatchQuery;
+
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Serializer for the MATCH_PHRASE_PREFIX relevance function.
+ */
+public class MatchPhrasePrefixSerializer extends AbstractRelevanceSerializer {
+
+    @Override
+    protected String functionName() {
+        return "match_phrase_prefix";
+    }
+
+    @Override
+    protected QueryBuilder createQueryBuilder(ConversionUtils.RelevanceOperands operands) {
+        return new MatchPhrasePrefixQueryBuilder(operands.fieldName(), operands.query());
+    }
+
+    @Override
+    protected void applyParams(QueryBuilder qb, Map<String, String> params) {
+        MatchPhrasePrefixQueryBuilder matchPhrasePrefixQb = (MatchPhrasePrefixQueryBuilder) qb;
+        for (Map.Entry<String, String> entry : params.entrySet()) {
+            switch (entry.getKey()) {
+                case "slop" -> matchPhrasePrefixQb.slop(Integer.parseInt(entry.getValue()));
+                case "analyzer" -> matchPhrasePrefixQb.analyzer(entry.getValue());
+                case "max_expansions" -> matchPhrasePrefixQb.maxExpansions(Integer.parseInt(entry.getValue()));
+                case "zero_terms_query" -> matchPhrasePrefixQb.zeroTermsQuery(
+                    MatchQuery.ZeroTermsQuery.valueOf(entry.getValue().toUpperCase(Locale.ROOT))
+                );
+                case "boost" -> matchPhrasePrefixQb.boost(Float.parseFloat(entry.getValue()));
+                default -> {
+                    /* ignore unrecognized params for forward compatibility */ }
+            }
+        }
+    }
+}

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/MatchPhraseSerializer.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/MatchPhraseSerializer.java
@@ -1,0 +1,50 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.lucene.serializers;
+
+import org.opensearch.be.lucene.ConversionUtils;
+import org.opensearch.index.query.MatchPhraseQueryBuilder;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.search.MatchQuery;
+
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Serializer for the MATCH_PHRASE relevance function.
+ */
+public class MatchPhraseSerializer extends AbstractRelevanceSerializer {
+
+    @Override
+    protected String functionName() {
+        return "match_phrase";
+    }
+
+    @Override
+    protected QueryBuilder createQueryBuilder(ConversionUtils.RelevanceOperands operands) {
+        return new MatchPhraseQueryBuilder(operands.fieldName(), operands.query());
+    }
+
+    @Override
+    protected void applyParams(QueryBuilder qb, Map<String, String> params) {
+        MatchPhraseQueryBuilder matchPhraseQb = (MatchPhraseQueryBuilder) qb;
+        for (Map.Entry<String, String> entry : params.entrySet()) {
+            switch (entry.getKey()) {
+                case "slop" -> matchPhraseQb.slop(Integer.parseInt(entry.getValue()));
+                case "analyzer" -> matchPhraseQb.analyzer(entry.getValue());
+                case "zero_terms_query" -> matchPhraseQb.zeroTermsQuery(
+                    MatchQuery.ZeroTermsQuery.valueOf(entry.getValue().toUpperCase(Locale.ROOT))
+                );
+                case "boost" -> matchPhraseQb.boost(Float.parseFloat(entry.getValue()));
+                default -> {
+                    /* ignore unrecognized params for forward compatibility */ }
+            }
+        }
+    }
+}

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/MatchSerializer.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/MatchSerializer.java
@@ -1,0 +1,62 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.lucene.serializers;
+
+import org.opensearch.be.lucene.ConversionUtils;
+import org.opensearch.common.unit.Fuzziness;
+import org.opensearch.index.query.MatchQueryBuilder;
+import org.opensearch.index.query.Operator;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.search.MatchQuery;
+
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Serializer for the MATCH relevance function.
+ */
+public class MatchSerializer extends AbstractRelevanceSerializer {
+
+    @Override
+    protected String functionName() {
+        return "match";
+    }
+
+    @Override
+    protected QueryBuilder createQueryBuilder(ConversionUtils.RelevanceOperands operands) {
+        return new MatchQueryBuilder(operands.fieldName(), operands.query());
+    }
+
+    @Override
+    protected void applyParams(QueryBuilder qb, Map<String, String> params) {
+        MatchQueryBuilder matchQb = (MatchQueryBuilder) qb;
+        for (Map.Entry<String, String> entry : params.entrySet()) {
+            switch (entry.getKey()) {
+                case "operator" -> matchQb.operator(Operator.fromString(entry.getValue()));
+                case "analyzer" -> matchQb.analyzer(entry.getValue());
+                case "fuzziness" -> matchQb.fuzziness(Fuzziness.build(entry.getValue()));
+                case "boost" -> matchQb.boost(Float.parseFloat(entry.getValue()));
+                case "zero_terms_query" -> matchQb.zeroTermsQuery(
+                    MatchQuery.ZeroTermsQuery.valueOf(entry.getValue().toUpperCase(Locale.ROOT))
+                );
+                case "minimum_should_match" -> matchQb.minimumShouldMatch(entry.getValue());
+                case "max_expansions" -> matchQb.maxExpansions(Integer.parseInt(entry.getValue()));
+                case "prefix_length" -> matchQb.prefixLength(Integer.parseInt(entry.getValue()));
+                case "fuzzy_transpositions" -> matchQb.fuzzyTranspositions(Boolean.parseBoolean(entry.getValue()));
+                case "fuzzy_rewrite" -> matchQb.fuzzyRewrite(entry.getValue());
+                case "lenient" -> matchQb.lenient(Boolean.parseBoolean(entry.getValue()));
+                case "auto_generate_synonyms_phrase_query" -> matchQb.autoGenerateSynonymsPhraseQuery(
+                    Boolean.parseBoolean(entry.getValue())
+                );
+                default -> {
+                    /* ignore unrecognized params for forward compatibility */ }
+            }
+        }
+    }
+}

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/MultiMatchSerializer.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/MultiMatchSerializer.java
@@ -1,0 +1,80 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.lucene.serializers;
+
+import org.opensearch.be.lucene.ConversionUtils;
+import org.opensearch.common.unit.Fuzziness;
+import org.opensearch.common.xcontent.LoggingDeprecationHandler;
+import org.opensearch.index.query.MultiMatchQueryBuilder;
+import org.opensearch.index.query.Operator;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.search.MatchQuery;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Serializer for the MULTI_MATCH relevance function.
+ */
+public class MultiMatchSerializer extends AbstractRelevanceSerializer {
+
+    @Override
+    protected String functionName() {
+        return "multi_match";
+    }
+
+    @Override
+    protected void validate(ConversionUtils.RelevanceOperands operands) {
+        if (operands.query() == null) {
+            throw new IllegalArgumentException(functionName() + " requires a 'query' parameter");
+        }
+    }
+
+    @Override
+    protected QueryBuilder createQueryBuilder(ConversionUtils.RelevanceOperands operands) {
+        List<String> fields = operands.fields();
+        if (fields != null) {
+            return new MultiMatchQueryBuilder(operands.query(), fields.toArray(String[]::new));
+        }
+        return new MultiMatchQueryBuilder(operands.query());
+    }
+
+    @Override
+    protected void applyParams(QueryBuilder qb, Map<String, String> params) {
+        MultiMatchQueryBuilder multiMatchQb = (MultiMatchQueryBuilder) qb;
+        for (Map.Entry<String, String> entry : params.entrySet()) {
+            switch (entry.getKey()) {
+                case "type" -> multiMatchQb.type(
+                    MultiMatchQueryBuilder.Type.parse(entry.getValue().toLowerCase(Locale.ROOT), LoggingDeprecationHandler.INSTANCE)
+                );
+                case "operator" -> multiMatchQb.operator(Operator.fromString(entry.getValue()));
+                case "analyzer" -> multiMatchQb.analyzer(entry.getValue());
+                case "fuzziness" -> multiMatchQb.fuzziness(Fuzziness.build(entry.getValue()));
+                case "minimum_should_match" -> multiMatchQb.minimumShouldMatch(entry.getValue());
+                case "slop" -> multiMatchQb.slop(Integer.parseInt(entry.getValue()));
+                case "zero_terms_query" -> multiMatchQb.zeroTermsQuery(
+                    MatchQuery.ZeroTermsQuery.valueOf(entry.getValue().toUpperCase(Locale.ROOT))
+                );
+                case "boost" -> multiMatchQb.boost(Float.parseFloat(entry.getValue()));
+                case "tie_breaker" -> multiMatchQb.tieBreaker(Float.parseFloat(entry.getValue()));
+                case "max_expansions" -> multiMatchQb.maxExpansions(Integer.parseInt(entry.getValue()));
+                case "prefix_length" -> multiMatchQb.prefixLength(Integer.parseInt(entry.getValue()));
+                case "lenient" -> multiMatchQb.lenient(Boolean.parseBoolean(entry.getValue()));
+                case "fuzzy_transpositions" -> multiMatchQb.fuzzyTranspositions(Boolean.parseBoolean(entry.getValue()));
+                case "fuzzy_rewrite" -> multiMatchQb.fuzzyRewrite(entry.getValue());
+                case "auto_generate_synonyms_phrase_query" -> multiMatchQb.autoGenerateSynonymsPhraseQuery(
+                    Boolean.parseBoolean(entry.getValue())
+                );
+                default -> {
+                    /* ignore unrecognized params for forward compatibility */ }
+            }
+        }
+    }
+}

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/QuerySerializer.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/QuerySerializer.java
@@ -38,6 +38,11 @@ public class QuerySerializer extends AbstractRelevanceSerializer {
     }
 
     @Override
+    protected int optionalParamsStartIndex() {
+        return 1;
+    }
+
+    @Override
     protected QueryBuilder createQueryBuilder(ConversionUtils.RelevanceOperands operands) {
         return new QueryStringQueryBuilder(operands.query());
     }

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/QuerySerializer.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/QuerySerializer.java
@@ -1,0 +1,81 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.lucene.serializers;
+
+import org.opensearch.be.lucene.ConversionUtils;
+import org.opensearch.common.unit.Fuzziness;
+import org.opensearch.common.xcontent.LoggingDeprecationHandler;
+import org.opensearch.index.query.MultiMatchQueryBuilder;
+import org.opensearch.index.query.Operator;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.QueryStringQueryBuilder;
+
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Serializer for the QUERY relevance function (no-field variant).
+ * Maps to QueryStringQueryBuilder without explicit field list (searches all fields).
+ */
+public class QuerySerializer extends AbstractRelevanceSerializer {
+
+    @Override
+    protected String functionName() {
+        return "query";
+    }
+
+    @Override
+    protected void validate(ConversionUtils.RelevanceOperands operands) {
+        if (operands.query() == null) {
+            throw new IllegalArgumentException(functionName() + " requires a 'query' parameter");
+        }
+    }
+
+    @Override
+    protected QueryBuilder createQueryBuilder(ConversionUtils.RelevanceOperands operands) {
+        return new QueryStringQueryBuilder(operands.query());
+    }
+
+    @Override
+    protected void applyParams(QueryBuilder qb, Map<String, String> params) {
+        QueryStringQueryBuilder queryStringQb = (QueryStringQueryBuilder) qb;
+        for (Map.Entry<String, String> entry : params.entrySet()) {
+            switch (entry.getKey()) {
+                case "default_operator" -> queryStringQb.defaultOperator(Operator.fromString(entry.getValue()));
+                case "analyzer" -> queryStringQb.analyzer(entry.getValue());
+                case "allow_leading_wildcard" -> queryStringQb.allowLeadingWildcard(Boolean.parseBoolean(entry.getValue()));
+                case "boost" -> queryStringQb.boost(Float.parseFloat(entry.getValue()));
+                case "fuzziness" -> queryStringQb.fuzziness(Fuzziness.build(entry.getValue()));
+                case "minimum_should_match" -> queryStringQb.minimumShouldMatch(entry.getValue());
+                case "type" -> queryStringQb.type(
+                    MultiMatchQueryBuilder.Type.parse(entry.getValue().toLowerCase(Locale.ROOT), LoggingDeprecationHandler.INSTANCE)
+                );
+                case "tie_breaker" -> queryStringQb.tieBreaker(Float.parseFloat(entry.getValue()));
+                case "phrase_slop" -> queryStringQb.phraseSlop(Integer.parseInt(entry.getValue()));
+                case "lenient" -> queryStringQb.lenient(Boolean.parseBoolean(entry.getValue()));
+                case "analyze_wildcard" -> queryStringQb.analyzeWildcard(Boolean.parseBoolean(entry.getValue()));
+                case "fuzzy_max_expansions" -> queryStringQb.fuzzyMaxExpansions(Integer.parseInt(entry.getValue()));
+                case "fuzzy_prefix_length" -> queryStringQb.fuzzyPrefixLength(Integer.parseInt(entry.getValue()));
+                case "fuzzy_transpositions" -> queryStringQb.fuzzyTranspositions(Boolean.parseBoolean(entry.getValue()));
+                case "max_determinized_states" -> queryStringQb.maxDeterminizedStates(Integer.parseInt(entry.getValue()));
+                case "quote_analyzer" -> queryStringQb.quoteAnalyzer(entry.getValue());
+                case "quote_field_suffix" -> queryStringQb.quoteFieldSuffix(entry.getValue());
+                case "rewrite" -> queryStringQb.rewrite(entry.getValue());
+                case "time_zone" -> queryStringQb.timeZone(entry.getValue());
+                case "escape" -> queryStringQb.escape(Boolean.parseBoolean(entry.getValue()));
+                case "enable_position_increments" -> queryStringQb.enablePositionIncrements(Boolean.parseBoolean(entry.getValue()));
+                case "auto_generate_synonyms_phrase_query" -> queryStringQb.autoGenerateSynonymsPhraseQuery(
+                    Boolean.parseBoolean(entry.getValue())
+                );
+                case "fuzzy_rewrite" -> queryStringQb.fuzzyRewrite(entry.getValue());
+                default -> { /* ignore unrecognized params for forward compatibility */ }
+            }
+        }
+    }
+}

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/QuerySerializer.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/QuerySerializer.java
@@ -74,7 +74,8 @@ public class QuerySerializer extends AbstractRelevanceSerializer {
                     Boolean.parseBoolean(entry.getValue())
                 );
                 case "fuzzy_rewrite" -> queryStringQb.fuzzyRewrite(entry.getValue());
-                default -> { /* ignore unrecognized params for forward compatibility */ }
+                default -> {
+                    /* ignore unrecognized params for forward compatibility */ }
             }
         }
     }

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/QueryStringSerializer.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/QueryStringSerializer.java
@@ -1,0 +1,87 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.lucene.serializers;
+
+import org.opensearch.be.lucene.ConversionUtils;
+import org.opensearch.common.unit.Fuzziness;
+import org.opensearch.common.xcontent.LoggingDeprecationHandler;
+import org.opensearch.index.query.MultiMatchQueryBuilder;
+import org.opensearch.index.query.Operator;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.QueryStringQueryBuilder;
+
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Serializer for the QUERY_STRING relevance function.
+ */
+public class QueryStringSerializer extends AbstractRelevanceSerializer {
+
+    @Override
+    protected String functionName() {
+        return "query_string";
+    }
+
+    @Override
+    protected void validate(ConversionUtils.RelevanceOperands operands) {
+        if (operands.query() == null) {
+            throw new IllegalArgumentException(functionName() + " requires a 'query' parameter");
+        }
+    }
+
+    @Override
+    protected QueryBuilder createQueryBuilder(ConversionUtils.RelevanceOperands operands) {
+        QueryStringQueryBuilder queryBuilder = new QueryStringQueryBuilder(operands.query());
+        if (operands.fields() != null) {
+            for (String field : operands.fields()) {
+                queryBuilder.field(field);
+            }
+        }
+        return queryBuilder;
+    }
+
+    @Override
+    protected void applyParams(QueryBuilder qb, Map<String, String> params) {
+        QueryStringQueryBuilder queryStringQb = (QueryStringQueryBuilder) qb;
+        for (Map.Entry<String, String> entry : params.entrySet()) {
+            switch (entry.getKey()) {
+                case "default_operator" -> queryStringQb.defaultOperator(Operator.fromString(entry.getValue()));
+                case "analyzer" -> queryStringQb.analyzer(entry.getValue());
+                case "allow_leading_wildcard" -> queryStringQb.allowLeadingWildcard(Boolean.parseBoolean(entry.getValue()));
+                case "boost" -> queryStringQb.boost(Float.parseFloat(entry.getValue()));
+                case "fuzziness" -> queryStringQb.fuzziness(Fuzziness.build(entry.getValue()));
+                case "minimum_should_match" -> queryStringQb.minimumShouldMatch(entry.getValue());
+                case "type" -> queryStringQb.type(
+                    MultiMatchQueryBuilder.Type.parse(entry.getValue().toLowerCase(Locale.ROOT), LoggingDeprecationHandler.INSTANCE)
+                );
+                case "tie_breaker" -> queryStringQb.tieBreaker(Float.parseFloat(entry.getValue()));
+                case "phrase_slop" -> queryStringQb.phraseSlop(Integer.parseInt(entry.getValue()));
+                case "lenient" -> queryStringQb.lenient(Boolean.parseBoolean(entry.getValue()));
+                case "analyze_wildcard" -> queryStringQb.analyzeWildcard(Boolean.parseBoolean(entry.getValue()));
+                case "fuzzy_max_expansions" -> queryStringQb.fuzzyMaxExpansions(Integer.parseInt(entry.getValue()));
+                case "fuzzy_prefix_length" -> queryStringQb.fuzzyPrefixLength(Integer.parseInt(entry.getValue()));
+                case "fuzzy_transpositions" -> queryStringQb.fuzzyTranspositions(Boolean.parseBoolean(entry.getValue()));
+                case "max_determinized_states" -> queryStringQb.maxDeterminizedStates(Integer.parseInt(entry.getValue()));
+                case "quote_analyzer" -> queryStringQb.quoteAnalyzer(entry.getValue());
+                case "quote_field_suffix" -> queryStringQb.quoteFieldSuffix(entry.getValue());
+                case "rewrite" -> queryStringQb.rewrite(entry.getValue());
+                case "time_zone" -> queryStringQb.timeZone(entry.getValue());
+                case "escape" -> queryStringQb.escape(Boolean.parseBoolean(entry.getValue()));
+                case "enable_position_increments" -> queryStringQb.enablePositionIncrements(Boolean.parseBoolean(entry.getValue()));
+                case "auto_generate_synonyms_phrase_query" -> queryStringQb.autoGenerateSynonymsPhraseQuery(
+                    Boolean.parseBoolean(entry.getValue())
+                );
+                case "fuzzy_rewrite" -> queryStringQb.fuzzyRewrite(entry.getValue());
+                default -> {
+                    /* ignore unrecognized params for forward compatibility */ }
+            }
+        }
+    }
+}

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/SimpleQueryStringSerializer.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/SimpleQueryStringSerializer.java
@@ -1,0 +1,79 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.lucene.serializers;
+
+import org.opensearch.be.lucene.ConversionUtils;
+import org.opensearch.index.query.Operator;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.SimpleQueryStringBuilder;
+import org.opensearch.index.query.SimpleQueryStringFlag;
+
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Serializer for the SIMPLE_QUERY_STRING relevance function.
+ */
+public class SimpleQueryStringSerializer extends AbstractRelevanceSerializer {
+
+    @Override
+    protected String functionName() {
+        return "simple_query_string";
+    }
+
+    @Override
+    protected void validate(ConversionUtils.RelevanceOperands operands) {
+        if (operands.query() == null) {
+            throw new IllegalArgumentException(functionName() + " requires a 'query' parameter");
+        }
+    }
+
+    @Override
+    protected QueryBuilder createQueryBuilder(ConversionUtils.RelevanceOperands operands) {
+        SimpleQueryStringBuilder queryBuilder = new SimpleQueryStringBuilder(operands.query());
+        if (operands.fields() != null) {
+            for (String field : operands.fields()) {
+                queryBuilder.field(field);
+            }
+        }
+        return queryBuilder;
+    }
+
+    @Override
+    protected void applyParams(QueryBuilder qb, Map<String, String> params) {
+        SimpleQueryStringBuilder simpleQsQb = (SimpleQueryStringBuilder) qb;
+        for (Map.Entry<String, String> entry : params.entrySet()) {
+            switch (entry.getKey()) {
+                case "default_operator" -> simpleQsQb.defaultOperator(Operator.fromString(entry.getValue()));
+                case "analyzer" -> simpleQsQb.analyzer(entry.getValue());
+                case "flags" -> {
+                    String[] flagNames = entry.getValue().toUpperCase(Locale.ROOT).split("\\|");
+                    SimpleQueryStringFlag[] flags = new SimpleQueryStringFlag[flagNames.length];
+                    for (int i = 0; i < flagNames.length; i++) {
+                        flags[i] = SimpleQueryStringFlag.valueOf(flagNames[i].trim());
+                    }
+                    simpleQsQb.flags(flags);
+                }
+                case "minimum_should_match" -> simpleQsQb.minimumShouldMatch(entry.getValue());
+                case "boost" -> simpleQsQb.boost(Float.parseFloat(entry.getValue()));
+                case "analyze_wildcard" -> simpleQsQb.analyzeWildcard(Boolean.parseBoolean(entry.getValue()));
+                case "auto_generate_synonyms_phrase_query" -> simpleQsQb.autoGenerateSynonymsPhraseQuery(
+                    Boolean.parseBoolean(entry.getValue())
+                );
+                case "fuzzy_max_expansions" -> simpleQsQb.fuzzyMaxExpansions(Integer.parseInt(entry.getValue()));
+                case "fuzzy_prefix_length" -> simpleQsQb.fuzzyPrefixLength(Integer.parseInt(entry.getValue()));
+                case "fuzzy_transpositions" -> simpleQsQb.fuzzyTranspositions(Boolean.parseBoolean(entry.getValue()));
+                case "lenient" -> simpleQsQb.lenient(Boolean.parseBoolean(entry.getValue()));
+                case "quote_field_suffix" -> simpleQsQb.quoteFieldSuffix(entry.getValue());
+                default -> {
+                    /* ignore unrecognized params for forward compatibility */ }
+            }
+        }
+    }
+}

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/WildcardQuerySerializer.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/WildcardQuerySerializer.java
@@ -38,7 +38,8 @@ public class WildcardQuerySerializer extends AbstractRelevanceSerializer {
                 case "boost" -> wildcardQb.boost(Float.parseFloat(entry.getValue()));
                 case "rewrite" -> wildcardQb.rewrite(entry.getValue());
                 case "case_insensitive" -> wildcardQb.caseInsensitive(Boolean.parseBoolean(entry.getValue()));
-                default -> { /* ignore unrecognized params for forward compatibility */ }
+                default -> {
+                    /* ignore unrecognized params for forward compatibility */ }
             }
         }
     }

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/WildcardQuerySerializer.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/WildcardQuerySerializer.java
@@ -1,0 +1,45 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.lucene.serializers;
+
+import org.opensearch.be.lucene.ConversionUtils;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.WildcardQueryBuilder;
+
+import java.util.Map;
+
+/**
+ * Serializer for the WILDCARD_QUERY relevance function.
+ * Maps to OpenSearch WildcardQueryBuilder (single-field, wildcard pattern).
+ */
+public class WildcardQuerySerializer extends AbstractRelevanceSerializer {
+
+    @Override
+    protected String functionName() {
+        return "wildcard_query";
+    }
+
+    @Override
+    protected QueryBuilder createQueryBuilder(ConversionUtils.RelevanceOperands operands) {
+        return new WildcardQueryBuilder(operands.fieldName(), operands.query());
+    }
+
+    @Override
+    protected void applyParams(QueryBuilder qb, Map<String, String> params) {
+        WildcardQueryBuilder wildcardQb = (WildcardQueryBuilder) qb;
+        for (Map.Entry<String, String> entry : params.entrySet()) {
+            switch (entry.getKey()) {
+                case "boost" -> wildcardQb.boost(Float.parseFloat(entry.getValue()));
+                case "rewrite" -> wildcardQb.rewrite(entry.getValue());
+                case "case_insensitive" -> wildcardQb.caseInsensitive(Boolean.parseBoolean(entry.getValue()));
+                default -> { /* ignore unrecognized params for forward compatibility */ }
+            }
+        }
+    }
+}

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/package-info.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/** Per-function query serializers for delegated predicates in the Lucene analytics backend. */
+package org.opensearch.be.lucene.serializers;

--- a/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/ConversionUtilsTests.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/ConversionUtilsTests.java
@@ -27,6 +27,7 @@ import org.opensearch.test.OpenSearchTestCase;
 
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Unit tests for {@link ConversionUtils}.
@@ -350,5 +351,153 @@ public class ConversionUtilsTests extends OpenSearchTestCase {
         assertEquals("status", operands.fieldName());
         assertNull(operands.fields());
         assertEquals("hello", operands.query());
+    }
+
+    // --- Tests for extractOptionalParams ---
+
+    /**
+     * Tests that extractOptionalParams extracts multiple key-value pairs from MAP operands.
+     * Structure: MATCH(MAP('field', $0), MAP('query', 'hello'), MAP('operator', 'AND'), MAP('analyzer', 'standard'))
+     * extractOptionalParams(call, 2) should return {"operator": "AND", "analyzer": "standard"}.
+     * Validates Requirement 11.1.
+     */
+    public void testExtractOptionalParams_multipleKeyValuePairs() {
+        RelDataType varcharType = typeFactory.createSqlType(SqlTypeName.VARCHAR);
+
+        RexNode fieldMap = rexBuilder.makeCall(
+            SqlStdOperatorTable.MAP_VALUE_CONSTRUCTOR,
+            rexBuilder.makeLiteral("field"),
+            rexBuilder.makeInputRef(varcharType, 0)
+        );
+
+        RexNode queryMap = rexBuilder.makeCall(
+            SqlStdOperatorTable.MAP_VALUE_CONSTRUCTOR,
+            rexBuilder.makeLiteral("query"),
+            rexBuilder.makeLiteral("hello")
+        );
+
+        RexNode operatorMap = rexBuilder.makeCall(
+            SqlStdOperatorTable.MAP_VALUE_CONSTRUCTOR,
+            rexBuilder.makeLiteral("operator"),
+            rexBuilder.makeLiteral("AND")
+        );
+
+        RexNode analyzerMap = rexBuilder.makeCall(
+            SqlStdOperatorTable.MAP_VALUE_CONSTRUCTOR,
+            rexBuilder.makeLiteral("analyzer"),
+            rexBuilder.makeLiteral("standard")
+        );
+
+        RexCall topCall = (RexCall) rexBuilder.makeCall(MATCH_FUNCTION, fieldMap, queryMap, operatorMap, analyzerMap);
+
+        Map<String, String> params = ConversionUtils.extractOptionalParams(topCall, 2);
+
+        assertEquals(2, params.size());
+        assertEquals("AND", params.get("operator"));
+        assertEquals("standard", params.get("analyzer"));
+    }
+
+    /**
+     * Tests that extractOptionalParams returns an empty map when startIndex exceeds operand count.
+     * Validates Requirement 11.9.
+     */
+    public void testExtractOptionalParams_emptyWhenStartIndexExceedsOperandCount() {
+        RelDataType varcharType = typeFactory.createSqlType(SqlTypeName.VARCHAR);
+
+        RexNode fieldMap = rexBuilder.makeCall(
+            SqlStdOperatorTable.MAP_VALUE_CONSTRUCTOR,
+            rexBuilder.makeLiteral("field"),
+            rexBuilder.makeInputRef(varcharType, 0)
+        );
+
+        RexNode queryMap = rexBuilder.makeCall(
+            SqlStdOperatorTable.MAP_VALUE_CONSTRUCTOR,
+            rexBuilder.makeLiteral("query"),
+            rexBuilder.makeLiteral("hello")
+        );
+
+        RexCall topCall = (RexCall) rexBuilder.makeCall(MATCH_FUNCTION, fieldMap, queryMap);
+
+        Map<String, String> params = ConversionUtils.extractOptionalParams(topCall, 2);
+
+        assertTrue("Should return empty map when no optional params", params.isEmpty());
+    }
+
+    /**
+     * Tests that extractOptionalParams silently skips non-MAP operands (e.g. plain RexLiteral).
+     * Validates Requirement 11.10.
+     */
+    public void testExtractOptionalParams_skipsNonMapOperands() {
+        RelDataType varcharType = typeFactory.createSqlType(SqlTypeName.VARCHAR);
+
+        RexNode fieldMap = rexBuilder.makeCall(
+            SqlStdOperatorTable.MAP_VALUE_CONSTRUCTOR,
+            rexBuilder.makeLiteral("field"),
+            rexBuilder.makeInputRef(varcharType, 0)
+        );
+
+        RexNode queryMap = rexBuilder.makeCall(
+            SqlStdOperatorTable.MAP_VALUE_CONSTRUCTOR,
+            rexBuilder.makeLiteral("query"),
+            rexBuilder.makeLiteral("hello")
+        );
+
+        // A valid MAP param
+        RexNode operatorMap = rexBuilder.makeCall(
+            SqlStdOperatorTable.MAP_VALUE_CONSTRUCTOR,
+            rexBuilder.makeLiteral("operator"),
+            rexBuilder.makeLiteral("AND")
+        );
+
+        // A plain literal (not a MAP) — should be skipped
+        RexNode plainLiteral = rexBuilder.makeLiteral("stray_value");
+
+        RexCall topCall = (RexCall) rexBuilder.makeCall(MATCH_FUNCTION, fieldMap, queryMap, operatorMap, plainLiteral);
+
+        Map<String, String> params = ConversionUtils.extractOptionalParams(topCall, 2);
+
+        assertEquals("Should only extract the valid MAP param", 1, params.size());
+        assertEquals("AND", params.get("operator"));
+    }
+
+    /**
+     * Tests that extractOptionalParams silently skips MAP operands with non-literal children.
+     * Validates Requirement 11.10.
+     */
+    public void testExtractOptionalParams_skipsMapWithNonLiteralChildren() {
+        RelDataType varcharType = typeFactory.createSqlType(SqlTypeName.VARCHAR);
+
+        RexNode fieldMap = rexBuilder.makeCall(
+            SqlStdOperatorTable.MAP_VALUE_CONSTRUCTOR,
+            rexBuilder.makeLiteral("field"),
+            rexBuilder.makeInputRef(varcharType, 0)
+        );
+
+        RexNode queryMap = rexBuilder.makeCall(
+            SqlStdOperatorTable.MAP_VALUE_CONSTRUCTOR,
+            rexBuilder.makeLiteral("query"),
+            rexBuilder.makeLiteral("hello")
+        );
+
+        // MAP with a RexInputRef as value (not a literal) — should be skipped
+        RexNode mapWithRef = rexBuilder.makeCall(
+            SqlStdOperatorTable.MAP_VALUE_CONSTRUCTOR,
+            rexBuilder.makeLiteral("bad_param"),
+            rexBuilder.makeInputRef(varcharType, 0)
+        );
+
+        // A valid MAP param
+        RexNode validMap = rexBuilder.makeCall(
+            SqlStdOperatorTable.MAP_VALUE_CONSTRUCTOR,
+            rexBuilder.makeLiteral("analyzer"),
+            rexBuilder.makeLiteral("whitespace")
+        );
+
+        RexCall topCall = (RexCall) rexBuilder.makeCall(MATCH_FUNCTION, fieldMap, queryMap, mapWithRef, validMap);
+
+        Map<String, String> params = ConversionUtils.extractOptionalParams(topCall, 2);
+
+        assertEquals("Should only extract the valid MAP param", 1, params.size());
+        assertEquals("whitespace", params.get("analyzer"));
     }
 }

--- a/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/QuerySerializerRegistryTests.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/QuerySerializerRegistryTests.java
@@ -29,6 +29,7 @@ import org.opensearch.common.unit.Fuzziness;
 import org.opensearch.core.common.io.stream.NamedWriteableAwareStreamInput;
 import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
 import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.index.query.MatchAllQueryBuilder;
 import org.opensearch.index.query.MatchBoolPrefixQueryBuilder;
 import org.opensearch.index.query.MatchPhrasePrefixQueryBuilder;
 import org.opensearch.index.query.MatchPhraseQueryBuilder;
@@ -39,16 +40,17 @@ import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryStringQueryBuilder;
 import org.opensearch.index.query.SimpleQueryStringBuilder;
 import org.opensearch.index.query.SimpleQueryStringFlag;
+import org.opensearch.index.query.WildcardQueryBuilder;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /**
- * Unit tests for optional parameter application in {@link QuerySerializerRegistry}.
- * Validates Requirements 11.2, 11.3, 11.4, 11.5, 11.6, 11.7, 11.8, 11.9, 11.10.
+ * Unit tests for {@link QuerySerializerRegistry} serializers — optional parameter round-trips
+ * and SQL text relevance serializer behavior (WILDCARD_QUERY, QUERY, MATCHALL).
  */
 public class QuerySerializerRegistryTests extends OpenSearchTestCase {
 
@@ -60,8 +62,37 @@ public class QuerySerializerRegistryTests extends OpenSearchTestCase {
             new NamedWriteableRegistry.Entry(QueryBuilder.class, MatchPhrasePrefixQueryBuilder.NAME, MatchPhrasePrefixQueryBuilder::new),
             new NamedWriteableRegistry.Entry(QueryBuilder.class, MultiMatchQueryBuilder.NAME, MultiMatchQueryBuilder::new),
             new NamedWriteableRegistry.Entry(QueryBuilder.class, QueryStringQueryBuilder.NAME, QueryStringQueryBuilder::new),
-            new NamedWriteableRegistry.Entry(QueryBuilder.class, SimpleQueryStringBuilder.NAME, SimpleQueryStringBuilder::new)
+            new NamedWriteableRegistry.Entry(QueryBuilder.class, SimpleQueryStringBuilder.NAME, SimpleQueryStringBuilder::new),
+            new NamedWriteableRegistry.Entry(QueryBuilder.class, WildcardQueryBuilder.NAME, WildcardQueryBuilder::new),
+            new NamedWriteableRegistry.Entry(QueryBuilder.class, MatchAllQueryBuilder.NAME, MatchAllQueryBuilder::new)
         )
+    );
+
+    private static final SqlFunction MATCHALL_FUNCTION = new SqlFunction(
+        "MATCHALL",
+        SqlKind.OTHER_FUNCTION,
+        ReturnTypes.BOOLEAN,
+        null,
+        OperandTypes.ANY,
+        SqlFunctionCategory.USER_DEFINED_FUNCTION
+    );
+
+    private static final SqlFunction WILDCARD_QUERY_FUNCTION = new SqlFunction(
+        "WILDCARD_QUERY",
+        SqlKind.OTHER_FUNCTION,
+        ReturnTypes.BOOLEAN,
+        null,
+        OperandTypes.ANY,
+        SqlFunctionCategory.USER_DEFINED_FUNCTION
+    );
+
+    private static final SqlFunction QUERY_FUNCTION = new SqlFunction(
+        "QUERY",
+        SqlKind.OTHER_FUNCTION,
+        ReturnTypes.BOOLEAN,
+        null,
+        OperandTypes.ANY,
+        SqlFunctionCategory.USER_DEFINED_FUNCTION
     );
 
     private RelDataTypeFactory typeFactory;
@@ -221,21 +252,257 @@ public class QuerySerializerRegistryTests extends OpenSearchTestCase {
         }
     }
 
+    // --- MatchAllSerializer tests ---
+
     /**
-     * Tests that the registry contains exactly 7 entries for the expected ScalarFunction keys.
+     * Tests MatchAllSerializer serialize → deserialize produces MatchAllQueryBuilder.
      */
-    public void testRegistryContainsExpectedEntries() {
-        assertEquals("Registry must contain exactly 7 serializers", 7, serializers.size());
-        Set<ScalarFunction> expectedKeys = Set.of(
-            ScalarFunction.MATCH,
-            ScalarFunction.MATCH_PHRASE,
-            ScalarFunction.MATCH_BOOL_PREFIX,
-            ScalarFunction.MATCH_PHRASE_PREFIX,
-            ScalarFunction.MULTI_MATCH,
-            ScalarFunction.QUERY_STRING,
-            ScalarFunction.SIMPLE_QUERY_STRING
+    public void testMatchAllSerializerRoundTrip() throws IOException {
+        DelegatedPredicateSerializer serializer = serializers.get(ScalarFunction.MATCHALL);
+        assertNotNull("MATCHALL serializer must be registered", serializer);
+
+        RexCall call = (RexCall) rexBuilder.makeCall(MATCHALL_FUNCTION);
+        List<FieldStorageInfo> fieldStorage = List.of();
+
+        byte[] serialized = serializer.serialize(call, fieldStorage);
+        assertNotNull("Serialized bytes must not be null", serialized);
+        assertTrue("Serialized bytes must not be empty", serialized.length > 0);
+
+        try (StreamInput input = new NamedWriteableAwareStreamInput(StreamInput.wrap(serialized), WRITEABLE_REGISTRY)) {
+            QueryBuilder deserialized = input.readNamedWriteable(QueryBuilder.class);
+            assertTrue("Deserialized must be MatchAllQueryBuilder", deserialized instanceof MatchAllQueryBuilder);
+        }
+    }
+
+    /**
+     * Tests MatchAllSerializer ignores unexpected operands without throwing.
+     */
+    public void testMatchAllSerializerIgnoresUnrecognizedOperands() throws IOException {
+        DelegatedPredicateSerializer serializer = serializers.get(ScalarFunction.MATCHALL);
+        assertNotNull("MATCHALL serializer must be registered", serializer);
+
+        RexNode extraMap = rexBuilder.makeCall(
+            SqlStdOperatorTable.MAP_VALUE_CONSTRUCTOR,
+            rexBuilder.makeLiteral("unexpected"),
+            rexBuilder.makeLiteral("value")
         );
-        assertEquals("Registry keys must match expected ScalarFunction set", expectedKeys, serializers.keySet());
+        RexCall call = (RexCall) rexBuilder.makeCall(MATCHALL_FUNCTION, extraMap);
+        List<FieldStorageInfo> fieldStorage = List.of();
+
+        byte[] serialized = serializer.serialize(call, fieldStorage);
+
+        try (StreamInput input = new NamedWriteableAwareStreamInput(StreamInput.wrap(serialized), WRITEABLE_REGISTRY)) {
+            QueryBuilder deserialized = input.readNamedWriteable(QueryBuilder.class);
+            assertTrue("Deserialized must be MatchAllQueryBuilder", deserialized instanceof MatchAllQueryBuilder);
+        }
+    }
+
+    // --- WildcardQuerySerializer tests ---
+
+    /**
+     * Tests WildcardQuerySerializer throws IllegalArgumentException with "wildcard_query" when field is missing.
+     */
+    public void testWildcardQuerySerializerThrowsWhenFieldMissing() {
+        DelegatedPredicateSerializer serializer = serializers.get(ScalarFunction.WILDCARD_QUERY);
+        assertNotNull("WILDCARD_QUERY serializer must be registered", serializer);
+
+        RexNode queryMap = rexBuilder.makeCall(
+            SqlStdOperatorTable.MAP_VALUE_CONSTRUCTOR,
+            rexBuilder.makeLiteral("query"),
+            rexBuilder.makeLiteral("test*")
+        );
+        RexCall call = (RexCall) rexBuilder.makeCall(WILDCARD_QUERY_FUNCTION, queryMap);
+        List<FieldStorageInfo> fieldStorage = List.of();
+
+        IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () -> serializer.serialize(call, fieldStorage));
+        assertTrue(
+            "Exception message must contain 'wildcard_query', got: " + exception.getMessage(),
+            exception.getMessage().contains("wildcard_query")
+        );
+    }
+
+    /**
+     * Tests WildcardQuerySerializer round-trip with field and pattern.
+     */
+    public void testWildcardQuerySerializerRoundTrip() throws IOException {
+        DelegatedPredicateSerializer serializer = serializers.get(ScalarFunction.WILDCARD_QUERY);
+        assertNotNull("WILDCARD_QUERY serializer must be registered", serializer);
+
+        RexCall call = buildSingleFieldRexCallWithParams("title", "test*", "WILDCARD_QUERY", Map.of());
+        List<FieldStorageInfo> fieldStorage = List.of(
+            new FieldStorageInfo("title", "text", FieldType.TEXT, List.of(), List.of("lucene"), List.of(), false)
+        );
+
+        byte[] serialized = serializer.serialize(call, fieldStorage);
+
+        try (StreamInput input = new NamedWriteableAwareStreamInput(StreamInput.wrap(serialized), WRITEABLE_REGISTRY)) {
+            QueryBuilder deserialized = input.readNamedWriteable(QueryBuilder.class);
+            assertTrue("Deserialized must be WildcardQueryBuilder", deserialized instanceof WildcardQueryBuilder);
+            WildcardQueryBuilder wildcardQb = (WildcardQueryBuilder) deserialized;
+            assertEquals("title", wildcardQb.fieldName());
+            assertEquals("test*", wildcardQb.value());
+        }
+    }
+
+    /**
+     * Tests WildcardQuerySerializer silently ignores unrecognized params.
+     */
+    public void testWildcardQuerySerializerIgnoresUnrecognizedParams() throws IOException {
+        DelegatedPredicateSerializer serializer = serializers.get(ScalarFunction.WILDCARD_QUERY);
+        assertNotNull("WILDCARD_QUERY serializer must be registered", serializer);
+
+        RexCall call = buildSingleFieldRexCallWithParams("title", "test*", "WILDCARD_QUERY", Map.of("unknown_param", "value"));
+        List<FieldStorageInfo> fieldStorage = List.of(
+            new FieldStorageInfo("title", "text", FieldType.TEXT, List.of(), List.of("lucene"), List.of(), false)
+        );
+
+        byte[] serialized = serializer.serialize(call, fieldStorage);
+
+        try (StreamInput input = new NamedWriteableAwareStreamInput(StreamInput.wrap(serialized), WRITEABLE_REGISTRY)) {
+            QueryBuilder deserialized = input.readNamedWriteable(QueryBuilder.class);
+            assertTrue("Deserialized must be WildcardQueryBuilder", deserialized instanceof WildcardQueryBuilder);
+            WildcardQueryBuilder wildcardQb = (WildcardQueryBuilder) deserialized;
+            assertEquals("title", wildcardQb.fieldName());
+            assertEquals("test*", wildcardQb.value());
+        }
+    }
+
+    /**
+     * Tests WildcardQuerySerializer with boost optional param round-trip.
+     */
+    public void testWildcardQuerySerializerWithBoost() throws IOException {
+        DelegatedPredicateSerializer serializer = serializers.get(ScalarFunction.WILDCARD_QUERY);
+        assertNotNull("WILDCARD_QUERY serializer must be registered", serializer);
+
+        RexCall call = buildSingleFieldRexCallWithParams("title", "test*", "WILDCARD_QUERY", Map.of("boost", "2.5"));
+        List<FieldStorageInfo> fieldStorage = List.of(
+            new FieldStorageInfo("title", "text", FieldType.TEXT, List.of(), List.of("lucene"), List.of(), false)
+        );
+
+        byte[] serialized = serializer.serialize(call, fieldStorage);
+
+        try (StreamInput input = new NamedWriteableAwareStreamInput(StreamInput.wrap(serialized), WRITEABLE_REGISTRY)) {
+            QueryBuilder deserialized = input.readNamedWriteable(QueryBuilder.class);
+            assertTrue("Deserialized must be WildcardQueryBuilder", deserialized instanceof WildcardQueryBuilder);
+            WildcardQueryBuilder wildcardQb = (WildcardQueryBuilder) deserialized;
+            assertEquals("title", wildcardQb.fieldName());
+            assertEquals("test*", wildcardQb.value());
+            assertEquals(2.5f, wildcardQb.boost(), 0.001f);
+        }
+    }
+
+    // --- QuerySerializer (no-field) tests ---
+
+    /**
+     * Tests QuerySerializer throws IllegalArgumentException with "query" when query is missing.
+     */
+    public void testQuerySerializerThrowsWhenQueryMissing() {
+        DelegatedPredicateSerializer serializer = serializers.get(ScalarFunction.QUERY);
+        assertNotNull("QUERY serializer must be registered", serializer);
+
+        RelDataType varcharType = typeFactory.createSqlType(SqlTypeName.VARCHAR);
+        RexNode fieldMap = rexBuilder.makeCall(
+            SqlStdOperatorTable.MAP_VALUE_CONSTRUCTOR,
+            rexBuilder.makeLiteral("field"),
+            rexBuilder.makeInputRef(varcharType, 0)
+        );
+        RexCall call = (RexCall) rexBuilder.makeCall(QUERY_FUNCTION, fieldMap);
+        List<FieldStorageInfo> fieldStorage = List.of(
+            new FieldStorageInfo("title", "text", FieldType.TEXT, List.of(), List.of("lucene"), List.of(), false)
+        );
+
+        IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () -> serializer.serialize(call, fieldStorage));
+        assertTrue(
+            "Exception message must contain 'query', got: " + exception.getMessage(),
+            exception.getMessage().contains("query")
+        );
+    }
+
+    /**
+     * Tests QuerySerializer accepts missing field without exception (no-field variant).
+     */
+    public void testQuerySerializerAcceptsMissingField() throws IOException {
+        DelegatedPredicateSerializer serializer = serializers.get(ScalarFunction.QUERY);
+        assertNotNull("QUERY serializer must be registered", serializer);
+
+        RexNode queryMap = rexBuilder.makeCall(
+            SqlStdOperatorTable.MAP_VALUE_CONSTRUCTOR,
+            rexBuilder.makeLiteral("query"),
+            rexBuilder.makeLiteral("status:active AND type:premium")
+        );
+        RexCall call = (RexCall) rexBuilder.makeCall(QUERY_FUNCTION, queryMap);
+        List<FieldStorageInfo> fieldStorage = List.of();
+
+        byte[] serialized = serializer.serialize(call, fieldStorage);
+        assertNotNull("Serialized bytes must not be null", serialized);
+
+        try (StreamInput input = new NamedWriteableAwareStreamInput(StreamInput.wrap(serialized), WRITEABLE_REGISTRY)) {
+            QueryBuilder deserialized = input.readNamedWriteable(QueryBuilder.class);
+            assertTrue("Deserialized must be QueryStringQueryBuilder", deserialized instanceof QueryStringQueryBuilder);
+            QueryStringQueryBuilder queryStringQb = (QueryStringQueryBuilder) deserialized;
+            assertEquals("status:active AND type:premium", queryStringQb.queryString());
+        }
+    }
+
+    /**
+     * Tests QuerySerializer silently ignores unrecognized params.
+     */
+    public void testQuerySerializerIgnoresUnrecognizedParams() throws IOException {
+        DelegatedPredicateSerializer serializer = serializers.get(ScalarFunction.QUERY);
+        assertNotNull("QUERY serializer must be registered", serializer);
+
+        RexNode queryMap = rexBuilder.makeCall(
+            SqlStdOperatorTable.MAP_VALUE_CONSTRUCTOR,
+            rexBuilder.makeLiteral("query"),
+            rexBuilder.makeLiteral("hello world")
+        );
+        RexNode unknownParamMap = rexBuilder.makeCall(
+            SqlStdOperatorTable.MAP_VALUE_CONSTRUCTOR,
+            rexBuilder.makeLiteral("unknown_param"),
+            rexBuilder.makeLiteral("some_value")
+        );
+        RexCall call = (RexCall) rexBuilder.makeCall(QUERY_FUNCTION, queryMap, unknownParamMap);
+        List<FieldStorageInfo> fieldStorage = List.of();
+
+        byte[] serialized = serializer.serialize(call, fieldStorage);
+
+        try (StreamInput input = new NamedWriteableAwareStreamInput(StreamInput.wrap(serialized), WRITEABLE_REGISTRY)) {
+            QueryBuilder deserialized = input.readNamedWriteable(QueryBuilder.class);
+            assertTrue("Deserialized must be QueryStringQueryBuilder", deserialized instanceof QueryStringQueryBuilder);
+            QueryStringQueryBuilder queryStringQb = (QueryStringQueryBuilder) deserialized;
+            assertEquals("hello world", queryStringQb.queryString());
+        }
+    }
+
+    /**
+     * Tests QuerySerializer with default_operator=AND optional param round-trip.
+     */
+    public void testQuerySerializerWithDefaultOperator() throws IOException {
+        DelegatedPredicateSerializer serializer = serializers.get(ScalarFunction.QUERY);
+        assertNotNull("QUERY serializer must be registered", serializer);
+
+        RexNode queryMap = rexBuilder.makeCall(
+            SqlStdOperatorTable.MAP_VALUE_CONSTRUCTOR,
+            rexBuilder.makeLiteral("query"),
+            rexBuilder.makeLiteral("hello world")
+        );
+        RexNode operatorMap = rexBuilder.makeCall(
+            SqlStdOperatorTable.MAP_VALUE_CONSTRUCTOR,
+            rexBuilder.makeLiteral("default_operator"),
+            rexBuilder.makeLiteral("AND")
+        );
+        RexCall call = (RexCall) rexBuilder.makeCall(QUERY_FUNCTION, queryMap, operatorMap);
+        List<FieldStorageInfo> fieldStorage = List.of();
+
+        byte[] serialized = serializer.serialize(call, fieldStorage);
+
+        try (StreamInput input = new NamedWriteableAwareStreamInput(StreamInput.wrap(serialized), WRITEABLE_REGISTRY)) {
+            QueryBuilder deserialized = input.readNamedWriteable(QueryBuilder.class);
+            assertTrue("Deserialized must be QueryStringQueryBuilder", deserialized instanceof QueryStringQueryBuilder);
+            QueryStringQueryBuilder queryStringQb = (QueryStringQueryBuilder) deserialized;
+            assertEquals("hello world", queryStringQb.queryString());
+            assertEquals(Operator.AND, queryStringQb.defaultOperator());
+        }
     }
 
     // --- New optional parameter round-trip tests ---
@@ -580,7 +847,7 @@ public class QuerySerializerRegistryTests extends OpenSearchTestCase {
         );
 
         // Build operand list: field, query, then optional params
-        List<RexNode> operands = new java.util.ArrayList<>();
+        List<RexNode> operands = new ArrayList<>();
         operands.add(fieldMap);
         operands.add(queryMap);
 
@@ -618,7 +885,7 @@ public class QuerySerializerRegistryTests extends OpenSearchTestCase {
         RelDataType doubleType = typeFactory.createSqlType(SqlTypeName.DOUBLE);
 
         // Build nested MAP with field/boost pairs
-        List<RexNode> nestedMapOperands = new java.util.ArrayList<>();
+        List<RexNode> nestedMapOperands = new ArrayList<>();
         for (String field : fields) {
             nestedMapOperands.add(rexBuilder.makeLiteral(field));
             nestedMapOperands.add(rexBuilder.makeExactLiteral(new java.math.BigDecimal("1.0"), doubleType));
@@ -636,7 +903,7 @@ public class QuerySerializerRegistryTests extends OpenSearchTestCase {
         );
 
         // Build operand list
-        List<RexNode> operands = new java.util.ArrayList<>();
+        List<RexNode> operands = new ArrayList<>();
         operands.add(outerMap);
         operands.add(queryMap);
 

--- a/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/QuerySerializerRegistryTests.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/QuerySerializerRegistryTests.java
@@ -1,0 +1,663 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.lucene;
+
+import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlFunction;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.type.OperandTypes;
+import org.apache.calcite.sql.type.ReturnTypes;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.opensearch.analytics.spi.DelegatedPredicateSerializer;
+import org.opensearch.analytics.spi.FieldStorageInfo;
+import org.opensearch.analytics.spi.FieldType;
+import org.opensearch.analytics.spi.ScalarFunction;
+import org.opensearch.common.unit.Fuzziness;
+import org.opensearch.core.common.io.stream.NamedWriteableAwareStreamInput;
+import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.index.query.MatchBoolPrefixQueryBuilder;
+import org.opensearch.index.query.MatchPhrasePrefixQueryBuilder;
+import org.opensearch.index.query.MatchPhraseQueryBuilder;
+import org.opensearch.index.query.MatchQueryBuilder;
+import org.opensearch.index.query.MultiMatchQueryBuilder;
+import org.opensearch.index.query.Operator;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.QueryStringQueryBuilder;
+import org.opensearch.index.query.SimpleQueryStringBuilder;
+import org.opensearch.index.query.SimpleQueryStringFlag;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Unit tests for optional parameter application in {@link QuerySerializerRegistry}.
+ * Validates Requirements 11.2, 11.3, 11.4, 11.5, 11.6, 11.7, 11.8, 11.9, 11.10.
+ */
+public class QuerySerializerRegistryTests extends OpenSearchTestCase {
+
+    private static final NamedWriteableRegistry WRITEABLE_REGISTRY = new NamedWriteableRegistry(
+        List.of(
+            new NamedWriteableRegistry.Entry(QueryBuilder.class, MatchQueryBuilder.NAME, MatchQueryBuilder::new),
+            new NamedWriteableRegistry.Entry(QueryBuilder.class, MatchPhraseQueryBuilder.NAME, MatchPhraseQueryBuilder::new),
+            new NamedWriteableRegistry.Entry(QueryBuilder.class, MatchBoolPrefixQueryBuilder.NAME, MatchBoolPrefixQueryBuilder::new),
+            new NamedWriteableRegistry.Entry(QueryBuilder.class, MatchPhrasePrefixQueryBuilder.NAME, MatchPhrasePrefixQueryBuilder::new),
+            new NamedWriteableRegistry.Entry(QueryBuilder.class, MultiMatchQueryBuilder.NAME, MultiMatchQueryBuilder::new),
+            new NamedWriteableRegistry.Entry(QueryBuilder.class, QueryStringQueryBuilder.NAME, QueryStringQueryBuilder::new),
+            new NamedWriteableRegistry.Entry(QueryBuilder.class, SimpleQueryStringBuilder.NAME, SimpleQueryStringBuilder::new)
+        )
+    );
+
+    private RelDataTypeFactory typeFactory;
+    private RexBuilder rexBuilder;
+    private Map<ScalarFunction, DelegatedPredicateSerializer> serializers;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        typeFactory = new JavaTypeFactoryImpl();
+        rexBuilder = new RexBuilder(typeFactory);
+        serializers = QuerySerializerRegistry.getSerializers();
+    }
+
+    /**
+     * Tests that serializeMatch with operator=AND produces a MatchQueryBuilder with AND operator.
+     * Validates Requirement 11.2.
+     */
+    public void testSerializeMatchWithOperatorAnd() throws IOException {
+        DelegatedPredicateSerializer serializer = serializers.get(ScalarFunction.MATCH);
+        assertNotNull("MATCH serializer must be registered", serializer);
+
+        RexCall call = buildSingleFieldRexCallWithParams("title", "hello world", "MATCH", Map.of("operator", "AND"));
+        List<FieldStorageInfo> fieldStorage = List.of(
+            new FieldStorageInfo("title", "text", FieldType.TEXT, List.of(), List.of("lucene"), List.of(), false)
+        );
+
+        byte[] serialized = serializer.serialize(call, fieldStorage);
+
+        try (StreamInput input = new NamedWriteableAwareStreamInput(StreamInput.wrap(serialized), WRITEABLE_REGISTRY)) {
+            QueryBuilder deserialized = input.readNamedWriteable(QueryBuilder.class);
+            assertTrue(deserialized instanceof MatchQueryBuilder);
+            MatchQueryBuilder matchQuery = (MatchQueryBuilder) deserialized;
+            assertEquals("title", matchQuery.fieldName());
+            assertEquals("hello world", matchQuery.value());
+            assertEquals(Operator.AND, matchQuery.operator());
+        }
+    }
+
+    /**
+     * Tests that serializeMatchPhrase with slop=2 produces a MatchPhraseQueryBuilder with slop=2.
+     * Validates Requirement 11.3.
+     */
+    public void testSerializeMatchPhraseWithSlop() throws IOException {
+        DelegatedPredicateSerializer serializer = serializers.get(ScalarFunction.MATCH_PHRASE);
+        assertNotNull("MATCH_PHRASE serializer must be registered", serializer);
+
+        RexCall call = buildSingleFieldRexCallWithParams("body", "quick fox", "MATCH_PHRASE", Map.of("slop", "2"));
+        List<FieldStorageInfo> fieldStorage = List.of(
+            new FieldStorageInfo("body", "text", FieldType.TEXT, List.of(), List.of("lucene"), List.of(), false)
+        );
+
+        byte[] serialized = serializer.serialize(call, fieldStorage);
+
+        try (StreamInput input = new NamedWriteableAwareStreamInput(StreamInput.wrap(serialized), WRITEABLE_REGISTRY)) {
+            QueryBuilder deserialized = input.readNamedWriteable(QueryBuilder.class);
+            assertTrue(deserialized instanceof MatchPhraseQueryBuilder);
+            MatchPhraseQueryBuilder matchPhrase = (MatchPhraseQueryBuilder) deserialized;
+            assertEquals("body", matchPhrase.fieldName());
+            assertEquals("quick fox", matchPhrase.value());
+            assertEquals(2, matchPhrase.slop());
+        }
+    }
+
+    /**
+     * Tests that serializeMultiMatch with type=phrase produces a MultiMatchQueryBuilder with PHRASE type.
+     * Validates Requirement 11.6.
+     */
+    public void testSerializeMultiMatchWithTypePhrase() throws IOException {
+        DelegatedPredicateSerializer serializer = serializers.get(ScalarFunction.MULTI_MATCH);
+        assertNotNull("MULTI_MATCH serializer must be registered", serializer);
+
+        RexCall call = buildMultiFieldRexCallWithParams(List.of("title", "body"), "search text", "MULTI_MATCH", Map.of("type", "phrase"));
+        List<FieldStorageInfo> fieldStorage = List.of();
+
+        byte[] serialized = serializer.serialize(call, fieldStorage);
+
+        try (StreamInput input = new NamedWriteableAwareStreamInput(StreamInput.wrap(serialized), WRITEABLE_REGISTRY)) {
+            QueryBuilder deserialized = input.readNamedWriteable(QueryBuilder.class);
+            assertTrue(deserialized instanceof MultiMatchQueryBuilder);
+            MultiMatchQueryBuilder multiMatch = (MultiMatchQueryBuilder) deserialized;
+            assertEquals("search text", multiMatch.value());
+            assertEquals(MultiMatchQueryBuilder.Type.PHRASE, multiMatch.getType());
+        }
+    }
+
+    /**
+     * Tests that unrecognized parameter keys are silently ignored (no exception thrown).
+     * Validates Requirement 11.10.
+     */
+    public void testUnrecognizedParameterKeysAreIgnored() throws IOException {
+        DelegatedPredicateSerializer serializer = serializers.get(ScalarFunction.MATCH);
+        assertNotNull("MATCH serializer must be registered", serializer);
+
+        RexCall call = buildSingleFieldRexCallWithParams(
+            "title",
+            "hello",
+            "MATCH",
+            Map.of("unknown_param", "some_value", "another_unknown", "42")
+        );
+        List<FieldStorageInfo> fieldStorage = List.of(
+            new FieldStorageInfo("title", "text", FieldType.TEXT, List.of(), List.of("lucene"), List.of(), false)
+        );
+
+        // Should not throw any exception
+        byte[] serialized = serializer.serialize(call, fieldStorage);
+
+        try (StreamInput input = new NamedWriteableAwareStreamInput(StreamInput.wrap(serialized), WRITEABLE_REGISTRY)) {
+            QueryBuilder deserialized = input.readNamedWriteable(QueryBuilder.class);
+            assertTrue(deserialized instanceof MatchQueryBuilder);
+            MatchQueryBuilder matchQuery = (MatchQueryBuilder) deserialized;
+            assertEquals("title", matchQuery.fieldName());
+            assertEquals("hello", matchQuery.value());
+        }
+    }
+
+    /**
+     * Tests that serializers with no optional params produce default QueryBuilders.
+     * Validates Requirement 11.9.
+     */
+    public void testSerializerWithNoOptionalParamsProducesDefaults() throws IOException {
+        DelegatedPredicateSerializer serializer = serializers.get(ScalarFunction.MATCH);
+        assertNotNull("MATCH serializer must be registered", serializer);
+
+        // Build a call with only field and query (no optional params)
+        RexCall call = buildSingleFieldRexCallWithParams("title", "hello", "MATCH", Map.of());
+        List<FieldStorageInfo> fieldStorage = List.of(
+            new FieldStorageInfo("title", "text", FieldType.TEXT, List.of(), List.of("lucene"), List.of(), false)
+        );
+
+        byte[] serialized = serializer.serialize(call, fieldStorage);
+
+        try (StreamInput input = new NamedWriteableAwareStreamInput(StreamInput.wrap(serialized), WRITEABLE_REGISTRY)) {
+            QueryBuilder deserialized = input.readNamedWriteable(QueryBuilder.class);
+            assertTrue(deserialized instanceof MatchQueryBuilder);
+            MatchQueryBuilder matchQuery = (MatchQueryBuilder) deserialized;
+            assertEquals("title", matchQuery.fieldName());
+            assertEquals("hello", matchQuery.value());
+            // Default operator is OR
+            assertEquals(Operator.OR, matchQuery.operator());
+        }
+    }
+
+    // --- Serializer refactoring verification tests ---
+
+    /**
+     * Tests that each serializer in the registry is an instance of DelegatedPredicateSerializer
+     * (class instances, not method references).
+     */
+    public void testSerializersAreDelegatedPredicateSerializerInstances() {
+        for (Map.Entry<ScalarFunction, DelegatedPredicateSerializer> entry : serializers.entrySet()) {
+            assertNotNull("Serializer for " + entry.getKey() + " must not be null", entry.getValue());
+            assertTrue(
+                "Serializer for " + entry.getKey() + " must be an instance of DelegatedPredicateSerializer",
+                entry.getValue() instanceof DelegatedPredicateSerializer
+            );
+        }
+    }
+
+    /**
+     * Tests that the registry contains exactly 7 entries for the expected ScalarFunction keys.
+     */
+    public void testRegistryContainsExpectedEntries() {
+        assertEquals("Registry must contain exactly 7 serializers", 7, serializers.size());
+        Set<ScalarFunction> expectedKeys = Set.of(
+            ScalarFunction.MATCH,
+            ScalarFunction.MATCH_PHRASE,
+            ScalarFunction.MATCH_BOOL_PREFIX,
+            ScalarFunction.MATCH_PHRASE_PREFIX,
+            ScalarFunction.MULTI_MATCH,
+            ScalarFunction.QUERY_STRING,
+            ScalarFunction.SIMPLE_QUERY_STRING
+        );
+        assertEquals("Registry keys must match expected ScalarFunction set", expectedKeys, serializers.keySet());
+    }
+
+    // --- New optional parameter round-trip tests ---
+
+    /**
+     * Tests that max_expansions=50 round-trips correctly on MatchQueryBuilder.
+     */
+    public void testSerializeMatchWithMaxExpansions() throws IOException {
+        DelegatedPredicateSerializer serializer = serializers.get(ScalarFunction.MATCH);
+        assertNotNull("MATCH serializer must be registered", serializer);
+
+        RexCall call = buildSingleFieldRexCallWithParams("title", "hello", "MATCH", Map.of("max_expansions", "50"));
+        List<FieldStorageInfo> fieldStorage = List.of(
+            new FieldStorageInfo("title", "text", FieldType.TEXT, List.of(), List.of("lucene"), List.of(), false)
+        );
+
+        byte[] serialized = serializer.serialize(call, fieldStorage);
+
+        try (StreamInput input = new NamedWriteableAwareStreamInput(StreamInput.wrap(serialized), WRITEABLE_REGISTRY)) {
+            QueryBuilder deserialized = input.readNamedWriteable(QueryBuilder.class);
+            assertTrue(deserialized instanceof MatchQueryBuilder);
+            MatchQueryBuilder matchQuery = (MatchQueryBuilder) deserialized;
+            assertEquals("title", matchQuery.fieldName());
+            assertEquals("hello", matchQuery.value());
+            assertEquals(50, matchQuery.maxExpansions());
+        }
+    }
+
+    /**
+     * Tests that lenient=true round-trips correctly on MatchQueryBuilder.
+     */
+    public void testSerializeMatchWithLenient() throws IOException {
+        DelegatedPredicateSerializer serializer = serializers.get(ScalarFunction.MATCH);
+        assertNotNull("MATCH serializer must be registered", serializer);
+
+        RexCall call = buildSingleFieldRexCallWithParams("title", "hello", "MATCH", Map.of("lenient", "true"));
+        List<FieldStorageInfo> fieldStorage = List.of(
+            new FieldStorageInfo("title", "text", FieldType.TEXT, List.of(), List.of("lucene"), List.of(), false)
+        );
+
+        byte[] serialized = serializer.serialize(call, fieldStorage);
+
+        try (StreamInput input = new NamedWriteableAwareStreamInput(StreamInput.wrap(serialized), WRITEABLE_REGISTRY)) {
+            QueryBuilder deserialized = input.readNamedWriteable(QueryBuilder.class);
+            assertTrue(deserialized instanceof MatchQueryBuilder);
+            MatchQueryBuilder matchQuery = (MatchQueryBuilder) deserialized;
+            assertEquals("title", matchQuery.fieldName());
+            assertEquals("hello", matchQuery.value());
+            assertTrue("lenient should be true", matchQuery.lenient());
+        }
+    }
+
+    /**
+     * Tests that prefix_length=3 round-trips correctly on MatchBoolPrefixQueryBuilder.
+     */
+    public void testSerializeMatchBoolPrefixWithPrefixLength() throws IOException {
+        DelegatedPredicateSerializer serializer = serializers.get(ScalarFunction.MATCH_BOOL_PREFIX);
+        assertNotNull("MATCH_BOOL_PREFIX serializer must be registered", serializer);
+
+        RexCall call = buildSingleFieldRexCallWithParams("title", "quick br", "MATCH_BOOL_PREFIX", Map.of("prefix_length", "3"));
+        List<FieldStorageInfo> fieldStorage = List.of(
+            new FieldStorageInfo("title", "text", FieldType.TEXT, List.of(), List.of("lucene"), List.of(), false)
+        );
+
+        byte[] serialized = serializer.serialize(call, fieldStorage);
+
+        try (StreamInput input = new NamedWriteableAwareStreamInput(StreamInput.wrap(serialized), WRITEABLE_REGISTRY)) {
+            QueryBuilder deserialized = input.readNamedWriteable(QueryBuilder.class);
+            assertTrue(deserialized instanceof MatchBoolPrefixQueryBuilder);
+            MatchBoolPrefixQueryBuilder matchBoolPrefix = (MatchBoolPrefixQueryBuilder) deserialized;
+            assertEquals("title", matchBoolPrefix.fieldName());
+            assertEquals("quick br", matchBoolPrefix.value());
+            assertEquals(3, matchBoolPrefix.prefixLength());
+        }
+    }
+
+    /**
+     * Tests that boost=2.5 round-trips correctly on MatchPhraseQueryBuilder.
+     */
+    public void testSerializeMatchPhraseWithBoost() throws IOException {
+        DelegatedPredicateSerializer serializer = serializers.get(ScalarFunction.MATCH_PHRASE);
+        assertNotNull("MATCH_PHRASE serializer must be registered", serializer);
+
+        RexCall call = buildSingleFieldRexCallWithParams("body", "quick fox", "MATCH_PHRASE", Map.of("boost", "2.5"));
+        List<FieldStorageInfo> fieldStorage = List.of(
+            new FieldStorageInfo("body", "text", FieldType.TEXT, List.of(), List.of("lucene"), List.of(), false)
+        );
+
+        byte[] serialized = serializer.serialize(call, fieldStorage);
+
+        try (StreamInput input = new NamedWriteableAwareStreamInput(StreamInput.wrap(serialized), WRITEABLE_REGISTRY)) {
+            QueryBuilder deserialized = input.readNamedWriteable(QueryBuilder.class);
+            assertTrue(deserialized instanceof MatchPhraseQueryBuilder);
+            MatchPhraseQueryBuilder matchPhrase = (MatchPhraseQueryBuilder) deserialized;
+            assertEquals("body", matchPhrase.fieldName());
+            assertEquals("quick fox", matchPhrase.value());
+            assertEquals(2.5f, matchPhrase.boost(), 0.001f);
+        }
+    }
+
+    /**
+     * Tests that boost=1.5 round-trips correctly on MatchPhrasePrefixQueryBuilder.
+     */
+    public void testSerializeMatchPhrasePrefixWithBoost() throws IOException {
+        DelegatedPredicateSerializer serializer = serializers.get(ScalarFunction.MATCH_PHRASE_PREFIX);
+        assertNotNull("MATCH_PHRASE_PREFIX serializer must be registered", serializer);
+
+        RexCall call = buildSingleFieldRexCallWithParams("body", "quick br", "MATCH_PHRASE_PREFIX", Map.of("boost", "1.5"));
+        List<FieldStorageInfo> fieldStorage = List.of(
+            new FieldStorageInfo("body", "text", FieldType.TEXT, List.of(), List.of("lucene"), List.of(), false)
+        );
+
+        byte[] serialized = serializer.serialize(call, fieldStorage);
+
+        try (StreamInput input = new NamedWriteableAwareStreamInput(StreamInput.wrap(serialized), WRITEABLE_REGISTRY)) {
+            QueryBuilder deserialized = input.readNamedWriteable(QueryBuilder.class);
+            assertTrue(deserialized instanceof MatchPhrasePrefixQueryBuilder);
+            MatchPhrasePrefixQueryBuilder matchPhrasePrefix = (MatchPhrasePrefixQueryBuilder) deserialized;
+            assertEquals("body", matchPhrasePrefix.fieldName());
+            assertEquals("quick br", matchPhrasePrefix.value());
+            assertEquals(1.5f, matchPhrasePrefix.boost(), 0.001f);
+        }
+    }
+
+    /**
+     * Tests that slop=3 round-trips correctly on MultiMatchQueryBuilder.
+     */
+    public void testSerializeMultiMatchWithSlop() throws IOException {
+        DelegatedPredicateSerializer serializer = serializers.get(ScalarFunction.MULTI_MATCH);
+        assertNotNull("MULTI_MATCH serializer must be registered", serializer);
+
+        RexCall call = buildMultiFieldRexCallWithParams(List.of("title", "body"), "search text", "MULTI_MATCH", Map.of("slop", "3"));
+        List<FieldStorageInfo> fieldStorage = List.of();
+
+        byte[] serialized = serializer.serialize(call, fieldStorage);
+
+        try (StreamInput input = new NamedWriteableAwareStreamInput(StreamInput.wrap(serialized), WRITEABLE_REGISTRY)) {
+            QueryBuilder deserialized = input.readNamedWriteable(QueryBuilder.class);
+            assertTrue(deserialized instanceof MultiMatchQueryBuilder);
+            MultiMatchQueryBuilder multiMatch = (MultiMatchQueryBuilder) deserialized;
+            assertEquals("search text", multiMatch.value());
+            assertEquals(3, multiMatch.slop());
+        }
+    }
+
+    /**
+     * Tests that fuzzy_rewrite="constant_score" round-trips correctly on MultiMatchQueryBuilder.
+     */
+    public void testSerializeMultiMatchWithFuzzyRewrite() throws IOException {
+        DelegatedPredicateSerializer serializer = serializers.get(ScalarFunction.MULTI_MATCH);
+        assertNotNull("MULTI_MATCH serializer must be registered", serializer);
+
+        RexCall call = buildMultiFieldRexCallWithParams(
+            List.of("title", "body"),
+            "search text",
+            "MULTI_MATCH",
+            Map.of("fuzzy_rewrite", "constant_score")
+        );
+        List<FieldStorageInfo> fieldStorage = List.of();
+
+        byte[] serialized = serializer.serialize(call, fieldStorage);
+
+        try (StreamInput input = new NamedWriteableAwareStreamInput(StreamInput.wrap(serialized), WRITEABLE_REGISTRY)) {
+            QueryBuilder deserialized = input.readNamedWriteable(QueryBuilder.class);
+            assertTrue(deserialized instanceof MultiMatchQueryBuilder);
+            MultiMatchQueryBuilder multiMatch = (MultiMatchQueryBuilder) deserialized;
+            assertEquals("search text", multiMatch.value());
+            assertEquals("constant_score", multiMatch.fuzzyRewrite());
+        }
+    }
+
+    /**
+     * Tests that fuzziness=AUTO round-trips correctly on QueryStringQueryBuilder.
+     */
+    public void testSerializeQueryStringWithFuzziness() throws IOException {
+        DelegatedPredicateSerializer serializer = serializers.get(ScalarFunction.QUERY_STRING);
+        assertNotNull("QUERY_STRING serializer must be registered", serializer);
+
+        RexCall call = buildMultiFieldRexCallWithParams(
+            List.of("title", "body"),
+            "search text",
+            "QUERY_STRING",
+            Map.of("fuzziness", "AUTO")
+        );
+        List<FieldStorageInfo> fieldStorage = List.of();
+
+        byte[] serialized = serializer.serialize(call, fieldStorage);
+
+        try (StreamInput input = new NamedWriteableAwareStreamInput(StreamInput.wrap(serialized), WRITEABLE_REGISTRY)) {
+            QueryBuilder deserialized = input.readNamedWriteable(QueryBuilder.class);
+            assertTrue(deserialized instanceof QueryStringQueryBuilder);
+            QueryStringQueryBuilder queryString = (QueryStringQueryBuilder) deserialized;
+            assertEquals("search text", queryString.queryString());
+            assertEquals(Fuzziness.AUTO, queryString.fuzziness());
+        }
+    }
+
+    /**
+     * Tests that phrase_slop=2 round-trips correctly on QueryStringQueryBuilder.
+     */
+    public void testSerializeQueryStringWithPhraseSlop() throws IOException {
+        DelegatedPredicateSerializer serializer = serializers.get(ScalarFunction.QUERY_STRING);
+        assertNotNull("QUERY_STRING serializer must be registered", serializer);
+
+        RexCall call = buildMultiFieldRexCallWithParams(
+            List.of("title", "body"),
+            "search text",
+            "QUERY_STRING",
+            Map.of("phrase_slop", "2")
+        );
+        List<FieldStorageInfo> fieldStorage = List.of();
+
+        byte[] serialized = serializer.serialize(call, fieldStorage);
+
+        try (StreamInput input = new NamedWriteableAwareStreamInput(StreamInput.wrap(serialized), WRITEABLE_REGISTRY)) {
+            QueryBuilder deserialized = input.readNamedWriteable(QueryBuilder.class);
+            assertTrue(deserialized instanceof QueryStringQueryBuilder);
+            QueryStringQueryBuilder queryString = (QueryStringQueryBuilder) deserialized;
+            assertEquals("search text", queryString.queryString());
+            assertEquals(2, queryString.phraseSlop());
+        }
+    }
+
+    /**
+     * Tests that lenient=true round-trips correctly on SimpleQueryStringBuilder.
+     */
+    public void testSerializeSimpleQueryStringWithLenient() throws IOException {
+        DelegatedPredicateSerializer serializer = serializers.get(ScalarFunction.SIMPLE_QUERY_STRING);
+        assertNotNull("SIMPLE_QUERY_STRING serializer must be registered", serializer);
+
+        RexCall call = buildMultiFieldRexCallWithParams(
+            List.of("title", "body"),
+            "search text",
+            "SIMPLE_QUERY_STRING",
+            Map.of("lenient", "true")
+        );
+        List<FieldStorageInfo> fieldStorage = List.of();
+
+        byte[] serialized = serializer.serialize(call, fieldStorage);
+
+        try (StreamInput input = new NamedWriteableAwareStreamInput(StreamInput.wrap(serialized), WRITEABLE_REGISTRY)) {
+            QueryBuilder deserialized = input.readNamedWriteable(QueryBuilder.class);
+            assertTrue(deserialized instanceof SimpleQueryStringBuilder);
+            SimpleQueryStringBuilder simpleQsQb = (SimpleQueryStringBuilder) deserialized;
+            assertEquals("search text", simpleQsQb.value());
+            assertTrue("lenient should be true", simpleQsQb.lenient());
+        }
+    }
+
+    // --- SimpleQueryString flags tests ---
+
+    /**
+     * Tests that pipe-separated flags "NONE|PREFIX|ESCAPE" round-trip correctly on SimpleQueryStringBuilder.
+     * The flags should be applied without throwing, and the deserialized builder should match
+     * an expected builder with the same flags set.
+     */
+    public void testSerializeSimpleQueryStringWithPipeSeparatedFlags() throws IOException {
+        DelegatedPredicateSerializer serializer = serializers.get(ScalarFunction.SIMPLE_QUERY_STRING);
+        assertNotNull("SIMPLE_QUERY_STRING serializer must be registered", serializer);
+
+        RexCall call = buildMultiFieldRexCallWithParams(
+            List.of("title", "body"),
+            "search text",
+            "SIMPLE_QUERY_STRING",
+            Map.of("flags", "NONE|PREFIX|ESCAPE")
+        );
+        List<FieldStorageInfo> fieldStorage = List.of();
+
+        byte[] serialized = serializer.serialize(call, fieldStorage);
+
+        try (StreamInput input = new NamedWriteableAwareStreamInput(StreamInput.wrap(serialized), WRITEABLE_REGISTRY)) {
+            QueryBuilder deserialized = input.readNamedWriteable(QueryBuilder.class);
+            assertTrue(deserialized instanceof SimpleQueryStringBuilder);
+            SimpleQueryStringBuilder simpleQsQb = (SimpleQueryStringBuilder) deserialized;
+            assertEquals("search text", simpleQsQb.value());
+            // Build an expected builder with the same flags to verify equality
+            SimpleQueryStringBuilder expected = new SimpleQueryStringBuilder("search text");
+            expected.field("title", 1.0f);
+            expected.field("body", 1.0f);
+            expected.flags(SimpleQueryStringFlag.NONE, SimpleQueryStringFlag.PREFIX, SimpleQueryStringFlag.ESCAPE);
+            assertEquals(expected, simpleQsQb);
+        }
+    }
+
+    /**
+     * Tests that flags="ALL" works correctly on SimpleQueryStringBuilder.
+     */
+    public void testSerializeSimpleQueryStringWithSingleFlag() throws IOException {
+        DelegatedPredicateSerializer serializer = serializers.get(ScalarFunction.SIMPLE_QUERY_STRING);
+        assertNotNull("SIMPLE_QUERY_STRING serializer must be registered", serializer);
+
+        RexCall call = buildMultiFieldRexCallWithParams(
+            List.of("title", "body"),
+            "search text",
+            "SIMPLE_QUERY_STRING",
+            Map.of("flags", "ALL")
+        );
+        List<FieldStorageInfo> fieldStorage = List.of();
+
+        byte[] serialized = serializer.serialize(call, fieldStorage);
+
+        try (StreamInput input = new NamedWriteableAwareStreamInput(StreamInput.wrap(serialized), WRITEABLE_REGISTRY)) {
+            QueryBuilder deserialized = input.readNamedWriteable(QueryBuilder.class);
+            assertTrue(deserialized instanceof SimpleQueryStringBuilder);
+            SimpleQueryStringBuilder simpleQsQb = (SimpleQueryStringBuilder) deserialized;
+            assertEquals("search text", simpleQsQb.value());
+            // Build an expected builder with ALL flag to verify equality
+            SimpleQueryStringBuilder expected = new SimpleQueryStringBuilder("search text");
+            expected.field("title", 1.0f);
+            expected.field("body", 1.0f);
+            expected.flags(SimpleQueryStringFlag.ALL);
+            assertEquals(expected, simpleQsQb);
+        }
+    }
+
+    // --- Helper methods ---
+
+    /**
+     * Builds a single-field RexCall with optional parameters:
+     * FUNC(MAP('field', $0), MAP('query', 'text'), MAP('key1', 'val1'), MAP('key2', 'val2'), ...)
+     */
+    private RexCall buildSingleFieldRexCallWithParams(
+        String fieldName,
+        String queryText,
+        String functionName,
+        Map<String, String> optionalParams
+    ) {
+        RelDataType varcharType = typeFactory.createSqlType(SqlTypeName.VARCHAR);
+
+        // Operand 0: MAP('field', $0)
+        RexNode fieldMap = rexBuilder.makeCall(
+            SqlStdOperatorTable.MAP_VALUE_CONSTRUCTOR,
+            rexBuilder.makeLiteral("field"),
+            rexBuilder.makeInputRef(varcharType, 0)
+        );
+
+        // Operand 1: MAP('query', 'queryText')
+        RexNode queryMap = rexBuilder.makeCall(
+            SqlStdOperatorTable.MAP_VALUE_CONSTRUCTOR,
+            rexBuilder.makeLiteral("query"),
+            rexBuilder.makeLiteral(queryText)
+        );
+
+        // Build operand list: field, query, then optional params
+        List<RexNode> operands = new java.util.ArrayList<>();
+        operands.add(fieldMap);
+        operands.add(queryMap);
+
+        for (Map.Entry<String, String> entry : optionalParams.entrySet()) {
+            RexNode paramMap = rexBuilder.makeCall(
+                SqlStdOperatorTable.MAP_VALUE_CONSTRUCTOR,
+                rexBuilder.makeLiteral(entry.getKey()),
+                rexBuilder.makeLiteral(entry.getValue())
+            );
+            operands.add(paramMap);
+        }
+
+        SqlFunction sqlFunction = new SqlFunction(
+            functionName,
+            SqlKind.OTHER_FUNCTION,
+            ReturnTypes.BOOLEAN,
+            null,
+            OperandTypes.ANY,
+            SqlFunctionCategory.USER_DEFINED_FUNCTION
+        );
+
+        return (RexCall) rexBuilder.makeCall(sqlFunction, operands);
+    }
+
+    /**
+     * Builds a multi-field RexCall with optional parameters:
+     * FUNC(MAP('fields', MAP('field1', 1.0, 'field2', 1.0, ...)), MAP('query', 'text'), MAP('key1', 'val1'), ...)
+     */
+    private RexCall buildMultiFieldRexCallWithParams(
+        List<String> fields,
+        String queryText,
+        String functionName,
+        Map<String, String> optionalParams
+    ) {
+        RelDataType doubleType = typeFactory.createSqlType(SqlTypeName.DOUBLE);
+
+        // Build nested MAP with field/boost pairs
+        List<RexNode> nestedMapOperands = new java.util.ArrayList<>();
+        for (String field : fields) {
+            nestedMapOperands.add(rexBuilder.makeLiteral(field));
+            nestedMapOperands.add(rexBuilder.makeExactLiteral(new java.math.BigDecimal("1.0"), doubleType));
+        }
+        RexNode nestedMap = rexBuilder.makeCall(SqlStdOperatorTable.MAP_VALUE_CONSTRUCTOR, nestedMapOperands);
+
+        // Outer MAP: MAP('fields', nestedMap)
+        RexNode outerMap = rexBuilder.makeCall(SqlStdOperatorTable.MAP_VALUE_CONSTRUCTOR, rexBuilder.makeLiteral("fields"), nestedMap);
+
+        // Query MAP: MAP('query', 'text')
+        RexNode queryMap = rexBuilder.makeCall(
+            SqlStdOperatorTable.MAP_VALUE_CONSTRUCTOR,
+            rexBuilder.makeLiteral("query"),
+            rexBuilder.makeLiteral(queryText)
+        );
+
+        // Build operand list
+        List<RexNode> operands = new java.util.ArrayList<>();
+        operands.add(outerMap);
+        operands.add(queryMap);
+
+        for (Map.Entry<String, String> entry : optionalParams.entrySet()) {
+            RexNode paramMap = rexBuilder.makeCall(
+                SqlStdOperatorTable.MAP_VALUE_CONSTRUCTOR,
+                rexBuilder.makeLiteral(entry.getKey()),
+                rexBuilder.makeLiteral(entry.getValue())
+            );
+            operands.add(paramMap);
+        }
+
+        SqlFunction sqlFunction = new SqlFunction(
+            functionName,
+            SqlKind.OTHER_FUNCTION,
+            ReturnTypes.BOOLEAN,
+            null,
+            OperandTypes.ANY,
+            SqlFunctionCategory.USER_DEFINED_FUNCTION
+        );
+
+        return (RexCall) rexBuilder.makeCall(sqlFunction, operands);
+    }
+}

--- a/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/QuerySerializerRegistryTests.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/QuerySerializerRegistryTests.java
@@ -412,10 +412,7 @@ public class QuerySerializerRegistryTests extends OpenSearchTestCase {
         );
 
         IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () -> serializer.serialize(call, fieldStorage));
-        assertTrue(
-            "Exception message must contain 'query', got: " + exception.getMessage(),
-            exception.getMessage().contains("query")
-        );
+        assertTrue("Exception message must contain 'query', got: " + exception.getMessage(), exception.getMessage().contains("query"));
     }
 
     /**


### PR DESCRIPTION
### Summary
  
- This PR refactors the Lucene backend's query serialization into a modular, self-contained architecture
- Added support for optional parameters serialization
- Adds support for three new relevance functions: wildcard_query, query, and match_all.
  
### Changes
  
New relevance function support:
  
  - Added WILDCARD_QUERY, QUERY, and MATCH_ALL to ScalarFunction enum
  - Implemented WildcardQuerySerializer, QuerySerializer, and MatchAllSerializer
  - Registered new functions in LuceneAnalyticsBackendPlugin capability provider
  
Modularized serializer architecture:
  
  - Extracted each relevance function's serialization logic into dedicated classes under serializers/ package
  - Introduced AbstractQuerySerializer (base for all serializers) and AbstractRelevanceSerializer (base for relevance functions with field/query/options pattern)
  - Created individual serializers: MatchSerializer, MatchPhraseSerializer, MatchPhrasePrefixSerializer, MatchBoolPrefixSerializer, MultiMatchSerializer,
  QueryStringSerializer, SimpleQueryStringSerializer
  - Each serializer is self-contained with its own sub-option handling, removing complex branching logic from ConversionUtils
  - Simplified QuerySerializerRegistry to delegate to the modular serializers
  
Bug fix — TimestampFunctionAdapter:
  
- Fixed parseTimestamp failing on space-separated datetime strings (e.g., "2014-01-20 00:00:00.000") by adding a fallback that replaces the space with T before parsing.Previously, these fell through to the raw TimestampString constructor which choked on trailing .000 (normalized to a bare .).
  
### Tests:
  - Added comprehensive QuerySerializerRegistryTests covering all serializers with sub-option validation
  - Added ConversionUtilsTests for utility method coverage
  - Added test case for the timestamp parsing fix

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
