### PR TITLE
Prevent negative fielddata stats by guarding against stale removals after shard reallocation

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/index/fielddata/FieldDataStatsNegativeIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/index/fielddata/FieldDataStatsNegativeIT.java
@@ -1,0 +1,128 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.fielddata;
+
+import org.opensearch.action.admin.cluster.node.stats.NodesStatsResponse;
+import org.opensearch.action.admin.indices.stats.IndicesStatsResponse;
+import org.opensearch.action.admin.indices.stats.ShardStats;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.index.query.MatchAllQueryBuilder;
+import org.opensearch.indices.IndicesService;
+import org.opensearch.search.sort.SortOrder;
+import org.opensearch.test.OpenSearchIntegTestCase;
+
+import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+
+/**
+ * Verifies fielddata byte counters do not go negative when a shard is relocated
+ * off and back to the same node while a sibling shard keeps the IndexService
+ * alive. Without the PR #21667 fix, stale CacheCleaner removals are routed by
+ * shardId to the current shard, decrementing a counter on bytes it never cached.
+ *
+ * Two timing levers:
+ * 1. Restore the production default cleanup interval (1m, vs the 1s set by
+ *    OpenSearchIntegTestCase) so the periodic cleaner cannot fire during the
+ *    relocation round-trips and prematurely drain stale entries.
+ * 2. After the round-trips are complete, drive cleanup synchronously via
+ *    IndicesFieldDataCache.clear() instead of waiting on the periodic timer.
+ *    Avoids Thread.sleep and runs deterministically.
+ */
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 0)
+public class FieldDataStatsNegativeIT extends OpenSearchIntegTestCase {
+
+    private static final String INDEX = "test_fd_stats";
+    private static final String FIELD = "name";
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return Settings.builder()
+            .put(super.nodeSettings(nodeOrdinal))
+            .put(IndicesService.INDICES_CACHE_CLEAN_INTERVAL_SETTING.getKey(), "1m")
+            .build();
+    }
+
+    public void testReproduceNegativeFieldDataStats() throws Exception {
+        final String node1 = internalCluster().startNode();
+        final String node2 = internalCluster().startNode();
+        ensureStableCluster(2);
+
+        assertAcked(
+            prepareCreate(INDEX).setSettings(
+                Settings.builder()
+                    .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 2)
+                    .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+                    .put("index.routing.allocation.include._name", node1)
+            ).setMapping(FIELD, "type=text,fielddata=true")
+        );
+        ensureGreen(INDEX);
+
+        // Multi-segment data: single-segment loadGlobal bypasses the cache.
+        for (int batch = 0; batch < 3; batch++) {
+            for (int i = 0; i < 5; i++) {
+                client().prepareIndex(INDEX).setSource(FIELD, "b" + batch + "_d" + i).get();
+            }
+            client().admin().indices().prepareRefresh(INDEX).get();
+            client().admin().indices().prepareFlush(INDEX).get();
+        }
+        populateCache();
+
+        assertThat("expected fielddata to be cached", getFieldDataBytes(), greaterThan(0L));
+
+        // 3 round-trips of shard 1. Shard 0 anchors the IndexService on node1.
+        for (int trip = 0; trip < 3; trip++) {
+            updateAllocationFilter(node1 + "," + node2);
+            ensureGreen(INDEX);
+            updateAllocationFilter(node1);
+            ensureGreen(INDEX);
+            populateCache();
+        }
+
+        // Drive cleanup synchronously instead of waiting for the periodic CacheCleaner.
+        // Equivalent to one cleaner tick: iterates marked stale keys and fires onRemoval
+        // for each — which is where the misrouted-decrement bug surfaces.
+        internalCluster().getInstance(IndicesService.class, node1).getIndicesFieldDataCache().clear();
+
+        // Assert non-negative bytes at every layer.
+        // 1) Per-shard counter (ShardFieldData.totalMetric).
+        IndicesStatsResponse indicesStats = client().admin().indices().prepareStats(INDEX).clear().setFieldData(true).get();
+        for (ShardStats shardStats : indicesStats.getShards()) {
+            long bytes = shardStats.getStats().getFieldData().getMemorySizeInBytes();
+            assertThat("shard " + shardStats.getShardRouting().shardId() + " bytes: " + bytes, bytes, greaterThanOrEqualTo(0L));
+        }
+
+        // 2) Node-level stats: serialization throws on negative bytes, surfacing
+        // as a per-node failure even when one shard's counter happens to net positive.
+        NodesStatsResponse nodesStats = client().admin().cluster().prepareNodesStats().clear().setIndices(true).get();
+        assertThat("node stats had failures", nodesStats.failures().size(), org.hamcrest.Matchers.equalTo(0));
+        for (var node : nodesStats.getNodes()) {
+            long bytes = node.getIndices().getFieldData().getMemorySizeInBytes();
+            assertThat("node " + node.getNode().getName() + " bytes: " + bytes, bytes, greaterThanOrEqualTo(0L));
+        }
+    }
+
+    private void populateCache() {
+        client().prepareSearch(INDEX).setQuery(new MatchAllQueryBuilder()).addSort(FIELD, SortOrder.ASC).setSize(20).get();
+    }
+
+    private void updateAllocationFilter(String includeNames) {
+        client().admin()
+            .indices()
+            .prepareUpdateSettings(INDEX)
+            .setSettings(Settings.builder().put("index.routing.allocation.include._name", includeNames))
+            .get();
+    }
+
+    private long getFieldDataBytes() {
+        IndicesStatsResponse stats = client().admin().indices().prepareStats(INDEX).clear().setFieldData(true).get();
+        return stats.getTotal().getFieldData().getMemorySizeInBytes();
+    }
+}

--- a/server/src/main/java/org/opensearch/index/IndexService.java
+++ b/server/src/main/java/org/opensearch/index/IndexService.java
@@ -320,6 +320,10 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
                 this.indexSortSupplier = () -> null;
             }
             indexFieldData.setListener(new FieldDataCacheListener(this));
+            indexFieldData.setShardIdentityResolver(shardId -> {
+                final IndexShard shard = getShardOrNull(shardId.id());
+                return shard == null ? 0 : System.identityHashCode(shard);
+            });
             this.bitsetFilterCache = new BitsetFilterCache(indexSettings, indicesBitsetFilterCache, new BitsetCacheListener(this));
             this.warmer = new IndexWarmer(
                 threadPool,
@@ -1248,6 +1252,23 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
                     shard.fieldData().onRemoval(shardId, fieldName, wasEvicted, sizeInBytes);
                 }
             }
+        }
+
+        // Skip the decrement if the shard has been replaced since this entry was cached.
+        // Prevents negative FieldDataStats.memorySize after shard reallocation (#20363).
+        @Override
+        public void onRemoval(ShardId shardId, String fieldName, boolean wasEvicted, long sizeInBytes, int shardIdentity) {
+            if (shardId == null) {
+                return;
+            }
+            final IndexShard shard = indexService.getShardOrNull(shardId.id());
+            if (shard == null) {
+                return;
+            }
+            if (shardIdentity != 0 && shardIdentity != System.identityHashCode(shard)) {
+                return;
+            }
+            shard.fieldData().onRemoval(shardId, fieldName, wasEvicted, sizeInBytes);
         }
     }
 

--- a/server/src/main/java/org/opensearch/index/IndexService.java
+++ b/server/src/main/java/org/opensearch/index/IndexService.java
@@ -1253,23 +1253,6 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
                 }
             }
         }
-
-        // Skip the decrement if the shard has been replaced since this entry was cached.
-        // Prevents negative FieldDataStats.memorySize after shard reallocation (#20363).
-        @Override
-        public void onRemoval(ShardId shardId, String fieldName, boolean wasEvicted, long sizeInBytes, int shardIdentity) {
-            if (shardId == null) {
-                return;
-            }
-            final IndexShard shard = indexService.getShardOrNull(shardId.id());
-            if (shard == null) {
-                return;
-            }
-            if (shardIdentity != 0 && shardIdentity != System.identityHashCode(shard)) {
-                return;
-            }
-            shard.fieldData().onRemoval(shardId, fieldName, wasEvicted, sizeInBytes);
-        }
     }
 
     public IndexMetadata getMetadata() {

--- a/server/src/main/java/org/opensearch/index/IndexService.java
+++ b/server/src/main/java/org/opensearch/index/IndexService.java
@@ -322,7 +322,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
             indexFieldData.setListener(new FieldDataCacheListener(this));
             indexFieldData.setShardIdentityResolver(shardId -> {
                 final IndexShard shard = getShardOrNull(shardId.id());
-                return shard == null ? 0 : System.identityHashCode(shard);
+                return shard == null ? IndicesFieldDataCache.Key.NO_SHARD_IDENTITY : System.identityHashCode(shard);
             });
             this.bitsetFilterCache = new BitsetFilterCache(indexSettings, indicesBitsetFilterCache, new BitsetCacheListener(this));
             this.warmer = new IndexWarmer(

--- a/server/src/main/java/org/opensearch/index/fielddata/IndexFieldDataCache.java
+++ b/server/src/main/java/org/opensearch/index/fielddata/IndexFieldDataCache.java
@@ -78,6 +78,25 @@ public interface IndexFieldDataCache {
          * Called after the fielddata is unloaded
          */
         default void onRemoval(ShardId shardId, String fieldName, boolean wasEvicted, long sizeInBytes) {}
+
+        /**
+         * Same as {@link #onCache(ShardId, String, Accountable)} but carries {@code shardIdentity} —
+         * the {@code System.identityHashCode} of the IndexShard at cache-load time.
+         */
+        default void onCache(ShardId shardId, String fieldName, Accountable ramUsage, int shardIdentity) {
+            onCache(shardId, fieldName, ramUsage);
+        }
+
+        /**
+         * Same as {@link #onRemoval(ShardId, String, boolean, long)} but carries the
+         * {@code shardIdentity} captured at cache-load time. Per-shard listeners should compare it
+         * to the current shard's identity and skip if they differ; this avoids decrementing a
+         * replacement shard for an entry it never cached (#20363). Node-wide listeners (e.g. the
+         * field-data circuit breaker) should ignore identity and always run.
+         */
+        default void onRemoval(ShardId shardId, String fieldName, boolean wasEvicted, long sizeInBytes, int shardIdentity) {
+            onRemoval(shardId, fieldName, wasEvicted, sizeInBytes);
+        }
     }
 
     /**

--- a/server/src/main/java/org/opensearch/index/fielddata/IndexFieldDataCache.java
+++ b/server/src/main/java/org/opensearch/index/fielddata/IndexFieldDataCache.java
@@ -78,25 +78,6 @@ public interface IndexFieldDataCache {
          * Called after the fielddata is unloaded
          */
         default void onRemoval(ShardId shardId, String fieldName, boolean wasEvicted, long sizeInBytes) {}
-
-        /**
-         * Same as {@link #onCache(ShardId, String, Accountable)} but carries {@code shardIdentity} —
-         * the {@code System.identityHashCode} of the IndexShard at cache-load time.
-         */
-        default void onCache(ShardId shardId, String fieldName, Accountable ramUsage, int shardIdentity) {
-            onCache(shardId, fieldName, ramUsage);
-        }
-
-        /**
-         * Same as {@link #onRemoval(ShardId, String, boolean, long)} but carries the
-         * {@code shardIdentity} captured at cache-load time. Per-shard listeners should compare it
-         * to the current shard's identity and skip if they differ; this avoids decrementing a
-         * replacement shard for an entry it never cached (#20363). Node-wide listeners (e.g. the
-         * field-data circuit breaker) should ignore identity and always run.
-         */
-        default void onRemoval(ShardId shardId, String fieldName, boolean wasEvicted, long sizeInBytes, int shardIdentity) {
-            onRemoval(shardId, fieldName, wasEvicted, sizeInBytes);
-        }
     }
 
     /**

--- a/server/src/main/java/org/opensearch/index/fielddata/IndexFieldDataService.java
+++ b/server/src/main/java/org/opensearch/index/fielddata/IndexFieldDataService.java
@@ -50,6 +50,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Supplier;
+import java.util.function.ToIntFunction;
 
 /**
  * Service for field data (cacheing, etc)
@@ -90,6 +91,7 @@ public class IndexFieldDataService extends AbstractIndexComponent implements Clo
         public void onRemoval(ShardId shardId, String fieldName, boolean wasEvicted, long sizeInBytes) {}
     };
     private volatile IndexFieldDataCache.Listener listener = DEFAULT_NOOP_LISTENER;
+    private volatile ToIntFunction<ShardId> shardIdentityResolver = shardId -> 0;
 
     public IndexFieldDataService(
         IndexSettings indexSettings,
@@ -136,7 +138,7 @@ public class IndexFieldDataService extends AbstractIndexComponent implements Clo
             if (cache == null) {
                 String cacheType = indexSettings.getValue(INDEX_FIELDDATA_CACHE_KEY);
                 if (FIELDDATA_CACHE_VALUE_NODE.equals(cacheType)) {
-                    cache = indicesFieldDataCache.buildIndexFieldDataCache(listener, index(), fieldName);
+                    cache = indicesFieldDataCache.buildIndexFieldDataCache(listener, index(), fieldName, shardIdentityResolver);
                 } else if ("none".equals(cacheType)) {
                     cache = new IndexFieldDataCache.None();
                 } else {
@@ -163,6 +165,18 @@ public class IndexFieldDataService extends AbstractIndexComponent implements Clo
             throw new IllegalStateException("can't set listener more than once");
         }
         this.listener = listener;
+    }
+
+    /**
+     * Sets the resolver that returns the current shard's {@code System.identityHashCode}
+     * (or 0 if none) for a given {@link ShardId}. Captured at cache-load time and used to
+     * skip stale decrements after shard reallocation.
+     */
+    public void setShardIdentityResolver(ToIntFunction<ShardId> shardIdentityResolver) {
+        if (shardIdentityResolver == null) {
+            throw new IllegalArgumentException("shardIdentityResolver must not be null");
+        }
+        this.shardIdentityResolver = shardIdentityResolver;
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/index/fielddata/IndexFieldDataService.java
+++ b/server/src/main/java/org/opensearch/index/fielddata/IndexFieldDataService.java
@@ -42,6 +42,7 @@ import org.opensearch.index.IndexSettings;
 import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.indices.fielddata.cache.IndicesFieldDataCache;
+import org.opensearch.indices.fielddata.cache.IndicesFieldDataCache.Key;
 import org.opensearch.search.lookup.SearchLookup;
 import org.opensearch.threadpool.ThreadPool;
 
@@ -91,7 +92,7 @@ public class IndexFieldDataService extends AbstractIndexComponent implements Clo
         public void onRemoval(ShardId shardId, String fieldName, boolean wasEvicted, long sizeInBytes) {}
     };
     private volatile IndexFieldDataCache.Listener listener = DEFAULT_NOOP_LISTENER;
-    private volatile ToIntFunction<ShardId> shardIdentityResolver = shardId -> 0;
+    private volatile ToIntFunction<ShardId> shardIdentityResolver = shardId -> Key.NO_SHARD_IDENTITY;
 
     public IndexFieldDataService(
         IndexSettings indexSettings,

--- a/server/src/main/java/org/opensearch/indices/fielddata/cache/IndicesFieldDataCache.java
+++ b/server/src/main/java/org/opensearch/indices/fielddata/cache/IndicesFieldDataCache.java
@@ -72,6 +72,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.ToIntFunction;
 import java.util.function.ToLongBiFunction;
 
 /**
@@ -144,7 +145,22 @@ public class IndicesFieldDataCache implements RemovalListener<IndicesFieldDataCa
     }
 
     public IndexFieldDataCache buildIndexFieldDataCache(IndexFieldDataCache.Listener listener, Index index, String fieldName) {
-        return new IndexFieldCache(logger, this, index, fieldName, indicesFieldDataCacheListener, listener);
+        return buildIndexFieldDataCache(listener, index, fieldName, shardId -> 0);
+    }
+
+    /**
+     * Build a cache that captures shard identity at load time. {@code shardIdentityResolver}
+     * returns the current shard's {@code System.identityHashCode} (or 0 if none) for a given
+     * {@link ShardId}. The captured value is stored on the {@link Key} and passed to
+     * identity-aware listener callbacks at removal time.
+     */
+    public IndexFieldDataCache buildIndexFieldDataCache(
+        IndexFieldDataCache.Listener listener,
+        Index index,
+        String fieldName,
+        ToIntFunction<ShardId> shardIdentityResolver
+    ) {
+        return new IndexFieldCache(logger, this, index, fieldName, shardIdentityResolver, indicesFieldDataCacheListener, listener);
     }
 
     public Cache<Key, Accountable> getCache() {
@@ -163,7 +179,8 @@ public class IndicesFieldDataCache implements RemovalListener<IndicesFieldDataCa
                     key.shardId,
                     indexCache.fieldName,
                     notification.getRemovalReason() == RemovalReason.EVICTED,
-                    value.ramBytesUsed()
+                    value.ramBytesUsed(),
+                    key.shardIdentity
                 );
             } catch (Exception e) {
                 // load anyway since listeners should not throw exceptions
@@ -263,14 +280,23 @@ public class IndicesFieldDataCache implements RemovalListener<IndicesFieldDataCa
         final Index index;
         final String fieldName;
         final IndicesFieldDataCache nodeLevelCache;
+        private final ToIntFunction<ShardId> shardIdentityResolver;
         private final Listener[] listeners;
 
-        IndexFieldCache(Logger logger, final IndicesFieldDataCache nodeLevelCache, Index index, String fieldName, Listener... listeners) {
+        IndexFieldCache(
+            Logger logger,
+            final IndicesFieldDataCache nodeLevelCache,
+            Index index,
+            String fieldName,
+            ToIntFunction<ShardId> shardIdentityResolver,
+            Listener... listeners
+        ) {
             this.logger = logger;
             this.listeners = listeners;
             this.index = index;
             this.fieldName = fieldName;
             this.nodeLevelCache = nodeLevelCache;
+            this.shardIdentityResolver = shardIdentityResolver;
         }
 
         @Override
@@ -282,7 +308,8 @@ public class IndicesFieldDataCache implements RemovalListener<IndicesFieldDataCa
             if (cacheHelper == null) {
                 throw new IllegalArgumentException("Reader " + context.reader() + " does not support caching");
             }
-            final Key key = new Key(this, cacheHelper.getKey(), shardId);
+            final int shardIdentity = shardId == null ? 0 : shardIdentityResolver.applyAsInt(shardId);
+            final Key key = new Key(this, cacheHelper.getKey(), shardId, shardIdentity);
             // noinspection unchecked
             final Accountable accountable = nodeLevelCache.getCache().computeIfAbsent(key, k -> {
                 cacheHelper.addClosedListener(IndexFieldCache.this);
@@ -290,7 +317,7 @@ public class IndicesFieldDataCache implements RemovalListener<IndicesFieldDataCa
                 final LeafFieldData fieldData = indexFieldData.loadDirect(context);
                 for (Listener listener : k.listeners) {
                     try {
-                        listener.onCache(shardId, fieldName, fieldData);
+                        listener.onCache(shardId, fieldName, fieldData, shardIdentity);
                     } catch (Exception e) {
                         // load anyway since listeners should not throw exceptions
                         logger.error("Failed to call listener on atomic field data loading", e);
@@ -312,7 +339,8 @@ public class IndicesFieldDataCache implements RemovalListener<IndicesFieldDataCa
             if (cacheHelper == null) {
                 throw new IllegalArgumentException("Reader " + indexReader + " does not support caching");
             }
-            final Key key = new Key(this, cacheHelper.getKey(), shardId);
+            final int shardIdentity = shardId == null ? 0 : shardIdentityResolver.applyAsInt(shardId);
+            final Key key = new Key(this, cacheHelper.getKey(), shardId, shardIdentity);
             // noinspection unchecked
             final Accountable accountable = nodeLevelCache.getCache().computeIfAbsent(key, k -> {
                 OpenSearchDirectoryReader.addReaderCloseListener(indexReader, IndexFieldCache.this);
@@ -320,7 +348,7 @@ public class IndicesFieldDataCache implements RemovalListener<IndicesFieldDataCa
                 final Accountable ifd = (Accountable) indexFieldData.loadGlobalDirect(indexReader);
                 for (Listener listener : k.listeners) {
                     try {
-                        listener.onCache(shardId, fieldName, ifd);
+                        listener.onCache(shardId, fieldName, ifd, shardIdentity);
                     } catch (Exception e) {
                         // load anyway since listeners should not throw exceptions
                         logger.error("Failed to call listener on global ordinals loading", e);
@@ -373,13 +401,23 @@ public class IndicesFieldDataCache implements RemovalListener<IndicesFieldDataCa
         public final IndexFieldCache indexCache;
         public final IndexReader.CacheKey readerKey;
         public final ShardId shardId;
+        /**
+         * Identity of the IndexShard that inserted this entry. Used at removal time to skip
+         * stale decrements after shard reallocation (#20363). Not part of equals/hashCode.
+         */
+        public final int shardIdentity;
 
         public final List<IndexFieldDataCache.Listener> listeners = new ArrayList<>();
 
         Key(IndexFieldCache indexCache, IndexReader.CacheKey readerKey, @Nullable ShardId shardId) {
+            this(indexCache, readerKey, shardId, 0);
+        }
+
+        Key(IndexFieldCache indexCache, IndexReader.CacheKey readerKey, @Nullable ShardId shardId, int shardIdentity) {
             this.indexCache = indexCache;
             this.readerKey = readerKey;
             this.shardId = shardId;
+            this.shardIdentity = shardIdentity;
         }
 
         @Override

--- a/server/src/main/java/org/opensearch/indices/fielddata/cache/IndicesFieldDataCache.java
+++ b/server/src/main/java/org/opensearch/indices/fielddata/cache/IndicesFieldDataCache.java
@@ -151,8 +151,9 @@ public class IndicesFieldDataCache implements RemovalListener<IndicesFieldDataCa
     /**
      * Build a cache that captures shard identity at load time. {@code shardIdentityResolver}
      * returns the current shard's {@code System.identityHashCode} (or 0 if none) for a given
-     * {@link ShardId}. The captured value is stored on the {@link Key} and passed to
-     * identity-aware listener callbacks at removal time.
+     * {@link ShardId}. The captured value is stored on the {@link Key} and compared with the
+     * current shard's identity at removal time to skip stale per-shard decrements after shard
+     * reallocation (#20363).
      */
     public IndexFieldDataCache buildIndexFieldDataCache(
         IndexFieldDataCache.Listener listener,
@@ -170,20 +171,31 @@ public class IndicesFieldDataCache implements RemovalListener<IndicesFieldDataCa
     @Override
     public void onRemoval(RemovalNotification<Key, Accountable> notification) {
         Key key = notification.getKey();
-        assert key != null && key.listeners != null;
+        assert key != null;
         IndexFieldCache indexCache = key.indexCache;
         final Accountable value = notification.getValue();
-        for (IndexFieldDataCache.Listener listener : key.listeners) {
+        final boolean wasEvicted = notification.getRemovalReason() == RemovalReason.EVICTED;
+        final long sizeInBytes = value.ramBytesUsed();
+
+        // Node-level listener (e.g. circuit breaker) must always fire — its accounting is
+        // node-wide, independent of which shard the entry belonged to.
+        try {
+            indexCache.nodeListener.onRemoval(key.shardId, indexCache.fieldName, wasEvicted, sizeInBytes);
+        } catch (Exception e) {
+            logger.error("Failed to call node-level listener on field data cache unloading", e);
+        }
+
+        // Per-shard listeners are skipped if the shard that originally cached this entry has been
+        // replaced (e.g. after reallocation). Without this check, the replacement shard would be
+        // decremented for memory it never accounted for, pushing stats negative (#20363).
+        final int currentShardIdentity = key.shardId == null ? 0 : indexCache.shardIdentityResolver.applyAsInt(key.shardId);
+        if (key.shardIdentity != 0 && key.shardIdentity != currentShardIdentity) {
+            return;
+        }
+        for (IndexFieldDataCache.Listener listener : indexCache.perShardListeners) {
             try {
-                listener.onRemoval(
-                    key.shardId,
-                    indexCache.fieldName,
-                    notification.getRemovalReason() == RemovalReason.EVICTED,
-                    value.ramBytesUsed(),
-                    key.shardIdentity
-                );
+                listener.onRemoval(key.shardId, indexCache.fieldName, wasEvicted, sizeInBytes);
             } catch (Exception e) {
-                // load anyway since listeners should not throw exceptions
                 logger.error("Failed to call listener on field data cache unloading", e);
             }
         }
@@ -280,8 +292,19 @@ public class IndicesFieldDataCache implements RemovalListener<IndicesFieldDataCa
         final Index index;
         final String fieldName;
         final IndicesFieldDataCache nodeLevelCache;
-        private final ToIntFunction<ShardId> shardIdentityResolver;
-        private final Listener[] listeners;
+        final ToIntFunction<ShardId> shardIdentityResolver;
+        /**
+         * Listener registered at node level (e.g. the field-data circuit breaker). Always fires
+         * on removal regardless of shard identity, since its accounting tracks node-wide bytes
+         * independent of which shard they were charged to.
+         */
+        final Listener nodeListener;
+        /**
+         * Per-shard listeners (e.g. {@link org.opensearch.index.fielddata.ShardFieldData}). Skipped
+         * at removal time when the entry's captured shard identity no longer matches the current
+         * shard's identity, to avoid stale decrements after shard reallocation.
+         */
+        private final Listener[] perShardListeners;
 
         IndexFieldCache(
             Logger logger,
@@ -289,10 +312,12 @@ public class IndicesFieldDataCache implements RemovalListener<IndicesFieldDataCa
             Index index,
             String fieldName,
             ToIntFunction<ShardId> shardIdentityResolver,
-            Listener... listeners
+            Listener nodeListener,
+            Listener... perShardListeners
         ) {
             this.logger = logger;
-            this.listeners = listeners;
+            this.nodeListener = nodeListener;
+            this.perShardListeners = perShardListeners;
             this.index = index;
             this.fieldName = fieldName;
             this.nodeLevelCache = nodeLevelCache;
@@ -313,16 +338,10 @@ public class IndicesFieldDataCache implements RemovalListener<IndicesFieldDataCa
             // noinspection unchecked
             final Accountable accountable = nodeLevelCache.getCache().computeIfAbsent(key, k -> {
                 cacheHelper.addClosedListener(IndexFieldCache.this);
-                Collections.addAll(k.listeners, this.listeners);
+                k.listeners.add(nodeListener);
+                Collections.addAll(k.listeners, perShardListeners);
                 final LeafFieldData fieldData = indexFieldData.loadDirect(context);
-                for (Listener listener : k.listeners) {
-                    try {
-                        listener.onCache(shardId, fieldName, fieldData, shardIdentity);
-                    } catch (Exception e) {
-                        // load anyway since listeners should not throw exceptions
-                        logger.error("Failed to call listener on atomic field data loading", e);
-                    }
-                }
+                notifyOnCache(shardId, fieldData);
                 return fieldData;
             });
             return (FD) accountable;
@@ -344,19 +363,28 @@ public class IndicesFieldDataCache implements RemovalListener<IndicesFieldDataCa
             // noinspection unchecked
             final Accountable accountable = nodeLevelCache.getCache().computeIfAbsent(key, k -> {
                 OpenSearchDirectoryReader.addReaderCloseListener(indexReader, IndexFieldCache.this);
-                Collections.addAll(k.listeners, this.listeners);
+                k.listeners.add(nodeListener);
+                Collections.addAll(k.listeners, perShardListeners);
                 final Accountable ifd = (Accountable) indexFieldData.loadGlobalDirect(indexReader);
-                for (Listener listener : k.listeners) {
-                    try {
-                        listener.onCache(shardId, fieldName, ifd, shardIdentity);
-                    } catch (Exception e) {
-                        // load anyway since listeners should not throw exceptions
-                        logger.error("Failed to call listener on global ordinals loading", e);
-                    }
-                }
+                notifyOnCache(shardId, ifd);
                 return ifd;
             });
             return (IFD) accountable;
+        }
+
+        private void notifyOnCache(ShardId shardId, Accountable accountable) {
+            try {
+                nodeListener.onCache(shardId, fieldName, accountable);
+            } catch (Exception e) {
+                logger.error("Failed to call node-level listener on field data loading", e);
+            }
+            for (Listener listener : perShardListeners) {
+                try {
+                    listener.onCache(shardId, fieldName, accountable);
+                } catch (Exception e) {
+                    logger.error("Failed to call listener on field data loading", e);
+                }
+            }
         }
 
         @Override

--- a/server/src/main/java/org/opensearch/indices/fielddata/cache/IndicesFieldDataCache.java
+++ b/server/src/main/java/org/opensearch/indices/fielddata/cache/IndicesFieldDataCache.java
@@ -145,7 +145,7 @@ public class IndicesFieldDataCache implements RemovalListener<IndicesFieldDataCa
     }
 
     public IndexFieldDataCache buildIndexFieldDataCache(IndexFieldDataCache.Listener listener, Index index, String fieldName) {
-        return buildIndexFieldDataCache(listener, index, fieldName, shardId -> 0);
+        return buildIndexFieldDataCache(listener, index, fieldName, shardId -> Key.NO_SHARD_IDENTITY);
     }
 
     /**
@@ -188,8 +188,10 @@ public class IndicesFieldDataCache implements RemovalListener<IndicesFieldDataCa
         // Per-shard listeners are skipped if the shard that originally cached this entry has been
         // replaced (e.g. after reallocation). Without this check, the replacement shard would be
         // decremented for memory it never accounted for, pushing stats negative (#20363).
-        final int currentShardIdentity = key.shardId == null ? 0 : indexCache.shardIdentityResolver.applyAsInt(key.shardId);
-        if (key.shardIdentity != 0 && key.shardIdentity != currentShardIdentity) {
+        final int currentShardIdentity = key.shardId == null
+            ? Key.NO_SHARD_IDENTITY
+            : indexCache.shardIdentityResolver.applyAsInt(key.shardId);
+        if (key.shardIdentity != Key.NO_SHARD_IDENTITY && key.shardIdentity != currentShardIdentity) {
             return;
         }
         for (IndexFieldDataCache.Listener listener : indexCache.perShardListeners) {
@@ -333,7 +335,7 @@ public class IndicesFieldDataCache implements RemovalListener<IndicesFieldDataCa
             if (cacheHelper == null) {
                 throw new IllegalArgumentException("Reader " + context.reader() + " does not support caching");
             }
-            final int shardIdentity = shardId == null ? 0 : shardIdentityResolver.applyAsInt(shardId);
+            final int shardIdentity = shardId == null ? Key.NO_SHARD_IDENTITY : shardIdentityResolver.applyAsInt(shardId);
             final Key key = new Key(this, cacheHelper.getKey(), shardId, shardIdentity);
             // noinspection unchecked
             final Accountable accountable = nodeLevelCache.getCache().computeIfAbsent(key, k -> {
@@ -358,7 +360,7 @@ public class IndicesFieldDataCache implements RemovalListener<IndicesFieldDataCa
             if (cacheHelper == null) {
                 throw new IllegalArgumentException("Reader " + indexReader + " does not support caching");
             }
-            final int shardIdentity = shardId == null ? 0 : shardIdentityResolver.applyAsInt(shardId);
+            final int shardIdentity = shardId == null ? Key.NO_SHARD_IDENTITY : shardIdentityResolver.applyAsInt(shardId);
             final Key key = new Key(this, cacheHelper.getKey(), shardId, shardIdentity);
             // noinspection unchecked
             final Accountable accountable = nodeLevelCache.getCache().computeIfAbsent(key, k -> {
@@ -426,19 +428,30 @@ public class IndicesFieldDataCache implements RemovalListener<IndicesFieldDataCa
      */
     @PublicApi(since = "1.0.0")
     public static class Key {
+        /**
+         * Sentinel meaning "no shard identity captured" — either tracking is disabled, the entry
+         * predates identity capture, or the shard was unresolvable at load time. The staleness
+         * check in {@link IndicesFieldDataCache#onRemoval(RemovalNotification)} treats this value
+         * as "always allow per-shard listeners through". Chosen as -1 because
+         * {@link System#identityHashCode(Object)} can return any int including 0, so 0 is not
+         * safe to use as a sentinel.
+         */
+        public static final int NO_SHARD_IDENTITY = -1;
+
         public final IndexFieldCache indexCache;
         public final IndexReader.CacheKey readerKey;
         public final ShardId shardId;
         /**
-         * Identity of the IndexShard that inserted this entry. Used at removal time to skip
-         * stale decrements after shard reallocation (#20363). Not part of equals/hashCode.
+         * Identity of the IndexShard that inserted this entry, or {@link #NO_SHARD_IDENTITY} if
+         * tracking is disabled. Used at removal time to skip stale decrements after shard
+         * reallocation (#20363). Not part of equals/hashCode.
          */
         public final int shardIdentity;
 
         public final List<IndexFieldDataCache.Listener> listeners = new ArrayList<>();
 
         Key(IndexFieldCache indexCache, IndexReader.CacheKey readerKey, @Nullable ShardId shardId) {
-            this(indexCache, readerKey, shardId, 0);
+            this(indexCache, readerKey, shardId, NO_SHARD_IDENTITY);
         }
 
         Key(IndexFieldCache indexCache, IndexReader.CacheKey readerKey, @Nullable ShardId shardId, int shardIdentity) {

--- a/server/src/test/java/org/opensearch/index/fielddata/FieldDataCacheTests.java
+++ b/server/src/test/java/org/opensearch/index/fielddata/FieldDataCacheTests.java
@@ -42,17 +42,23 @@ import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.NoMergePolicy;
 import org.apache.lucene.store.Directory;
+import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.BytesRef;
 import org.opensearch.common.lucene.index.OpenSearchDirectoryReader;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.core.index.Index;
 import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.core.indices.breaker.NoneCircuitBreakerService;
 import org.opensearch.index.fielddata.plain.AbstractLeafOrdinalsFieldData;
 import org.opensearch.index.fielddata.plain.PagedBytesIndexFieldData;
 import org.opensearch.index.fielddata.plain.SortedSetOrdinalsIndexFieldData;
 import org.opensearch.index.mapper.TextFieldMapper;
+import org.opensearch.indices.fielddata.cache.IndicesFieldDataCache;
 import org.opensearch.search.aggregations.support.CoreValuesSourceType;
 import org.opensearch.test.FieldMaskingReader;
 import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.hamcrest.Matchers.equalTo;
 
@@ -116,6 +122,55 @@ public class FieldDataCacheTests extends OpenSearchTestCase {
             TextFieldMapper.Defaults.FIELDDATA_MAX_FREQUENCY,
             TextFieldMapper.Defaults.FIELDDATA_MIN_SEGMENT_SIZE
         );
+    }
+
+    // End-to-end: a real cache load captures shardIdentity from the resolver, and the cache's
+    // own removal path forwards that identity to the listener.
+    public void testCacheCapturesAndForwardsShardIdentity() throws Exception {
+        Directory dir = newDirectory();
+        IndexWriterConfig iwc = new IndexWriterConfig(null);
+        iwc.setMergePolicy(NoMergePolicy.INSTANCE);
+        IndexWriter iw = new IndexWriter(dir, iwc);
+        // Two segments so loadGlobal goes through the cache path (single-segment is short-circuited).
+        for (int i = 0; i < 2; i++) {
+            Document doc = new Document();
+            doc.add(new SortedSetDocValuesField("field1", new BytesRef("v" + i)));
+            iw.addDocument(doc);
+            iw.commit();
+        }
+        iw.close();
+        DirectoryReader ir = OpenSearchDirectoryReader.wrap(DirectoryReader.open(dir), new ShardId("idx", "_na_", 0));
+
+        AtomicInteger onCacheIdentity = new AtomicInteger(-1);
+        AtomicInteger onRemovalIdentity = new AtomicInteger(-1);
+        IndexFieldDataCache.Listener listener = new IndexFieldDataCache.Listener() {
+            @Override
+            public void onCache(ShardId shardId, String fieldName, Accountable ramUsage, int shardIdentity) {
+                onCacheIdentity.set(shardIdentity);
+            }
+
+            @Override
+            public void onRemoval(ShardId shardId, String fieldName, boolean wasEvicted, long sizeInBytes, int shardIdentity) {
+                onRemovalIdentity.set(shardIdentity);
+            }
+        };
+
+        IndicesFieldDataCache nodeCache = new IndicesFieldDataCache(Settings.EMPTY, new IndexFieldDataCache.Listener() {
+        }, null, null);
+        Index index = new Index("idx", "_na_");
+        int expectedIdentity = 4242;
+        IndexFieldDataCache fieldCache = nodeCache.buildIndexFieldDataCache(listener, index, "field1", shardId -> expectedIdentity);
+
+        SortedSetOrdinalsIndexFieldData ifd = createSortedDV("field1", fieldCache);
+        ifd.loadGlobal(ir);
+        assertEquals(expectedIdentity, onCacheIdentity.get());
+
+        nodeCache.getCache().invalidateAll();
+        assertEquals(expectedIdentity, onRemovalIdentity.get());
+
+        ir.close();
+        dir.close();
+        nodeCache.close();
     }
 
     private class DummyAccountingFieldDataCache implements IndexFieldDataCache {

--- a/server/src/test/java/org/opensearch/index/fielddata/FieldDataCacheTests.java
+++ b/server/src/test/java/org/opensearch/index/fielddata/FieldDataCacheTests.java
@@ -239,6 +239,102 @@ public class FieldDataCacheTests extends OpenSearchTestCase {
         nodeCache.close();
     }
 
+    // When listeners throw from onCache/onRemoval, the cache must swallow and log so other
+    // listeners and the load itself proceed normally.
+    public void testListenerExceptionsAreSwallowedDuringCacheAndRemoval() throws Exception {
+        Directory dir = newDirectory();
+        IndexWriterConfig iwc = new IndexWriterConfig(null);
+        iwc.setMergePolicy(NoMergePolicy.INSTANCE);
+        IndexWriter iw = new IndexWriter(dir, iwc);
+        for (int i = 0; i < 2; i++) {
+            Document doc = new Document();
+            doc.add(new SortedSetDocValuesField("field1", new BytesRef("v" + i)));
+            iw.addDocument(doc);
+            iw.commit();
+        }
+        iw.close();
+        DirectoryReader ir = OpenSearchDirectoryReader.wrap(DirectoryReader.open(dir), new ShardId("idx", "_na_", 0));
+
+        IndexFieldDataCache.Listener throwingNode = new IndexFieldDataCache.Listener() {
+            @Override
+            public void onCache(ShardId shardId, String fieldName, Accountable ramUsage) {
+                throw new RuntimeException("boom-cache-node");
+            }
+
+            @Override
+            public void onRemoval(ShardId shardId, String fieldName, boolean wasEvicted, long sizeInBytes) {
+                throw new RuntimeException("boom-removal-node");
+            }
+        };
+        IndexFieldDataCache.Listener throwingPerShard = new IndexFieldDataCache.Listener() {
+            @Override
+            public void onCache(ShardId shardId, String fieldName, Accountable ramUsage) {
+                throw new RuntimeException("boom-cache-shard");
+            }
+
+            @Override
+            public void onRemoval(ShardId shardId, String fieldName, boolean wasEvicted, long sizeInBytes) {
+                throw new RuntimeException("boom-removal-shard");
+            }
+        };
+
+        IndicesFieldDataCache nodeCache = new IndicesFieldDataCache(Settings.EMPTY, throwingNode, null, null);
+        Index index = new Index("idx", "_na_");
+        IndexFieldDataCache fieldCache = nodeCache.buildIndexFieldDataCache(throwingPerShard, index, "field1", shardId -> 1);
+
+        SortedSetOrdinalsIndexFieldData ifd = createSortedDV("field1", fieldCache);
+        // load should succeed despite throwing onCache listeners
+        ifd.loadGlobal(ir);
+        // removal path should also tolerate throwing listeners
+        nodeCache.getCache().invalidateAll();
+
+        ir.close();
+        dir.close();
+        nodeCache.close();
+    }
+
+    // The 3-arg buildIndexFieldDataCache overload uses a default resolver that returns
+    // NO_SHARD_IDENTITY, which means the staleness check always allows per-shard listeners through.
+    public void testThreeArgBuildUsesNoShardIdentitySentinel() throws Exception {
+        Directory dir = newDirectory();
+        IndexWriterConfig iwc = new IndexWriterConfig(null);
+        iwc.setMergePolicy(NoMergePolicy.INSTANCE);
+        IndexWriter iw = new IndexWriter(dir, iwc);
+        for (int i = 0; i < 2; i++) {
+            Document doc = new Document();
+            doc.add(new SortedSetDocValuesField("field1", new BytesRef("v" + i)));
+            iw.addDocument(doc);
+            iw.commit();
+        }
+        iw.close();
+        DirectoryReader ir = OpenSearchDirectoryReader.wrap(DirectoryReader.open(dir), new ShardId("idx", "_na_", 0));
+
+        AtomicInteger perShardOnRemoval = new AtomicInteger();
+        IndexFieldDataCache.Listener perShardListener = new IndexFieldDataCache.Listener() {
+            @Override
+            public void onRemoval(ShardId shardId, String fieldName, boolean wasEvicted, long sizeInBytes) {
+                perShardOnRemoval.incrementAndGet();
+            }
+        };
+
+        IndicesFieldDataCache nodeCache = new IndicesFieldDataCache(Settings.EMPTY, new IndexFieldDataCache.Listener() {
+        }, null, null);
+        Index index = new Index("idx", "_na_");
+        // 3-arg overload — no shardIdentityResolver supplied
+        IndexFieldDataCache fieldCache = nodeCache.buildIndexFieldDataCache(perShardListener, index, "field1");
+
+        SortedSetOrdinalsIndexFieldData ifd = createSortedDV("field1", fieldCache);
+        ifd.loadGlobal(ir);
+        nodeCache.getCache().invalidateAll();
+
+        // Without identity tracking, every removal reaches the per-shard listener.
+        assertEquals(1, perShardOnRemoval.get());
+
+        ir.close();
+        dir.close();
+        nodeCache.close();
+    }
+
     private class DummyAccountingFieldDataCache implements IndexFieldDataCache {
 
         private int cachedGlobally = 0;

--- a/server/src/test/java/org/opensearch/index/fielddata/FieldDataCacheTests.java
+++ b/server/src/test/java/org/opensearch/index/fielddata/FieldDataCacheTests.java
@@ -124,9 +124,10 @@ public class FieldDataCacheTests extends OpenSearchTestCase {
         );
     }
 
-    // End-to-end: a real cache load captures shardIdentity from the resolver, and the cache's
-    // own removal path forwards that identity to the listener.
-    public void testCacheCapturesAndForwardsShardIdentity() throws Exception {
+    // The cache captures shardIdentity at load time and skips the per-shard listener's onRemoval
+    // when the current resolved identity differs (i.e. shard has been reallocated). The node-level
+    // listener must still fire so node-wide accounting (e.g. circuit breaker) stays consistent.
+    public void testCacheSkipsStalePerShardRemovalAfterReallocation() throws Exception {
         Directory dir = newDirectory();
         IndexWriterConfig iwc = new IndexWriterConfig(null);
         iwc.setMergePolicy(NoMergePolicy.INSTANCE);
@@ -141,32 +142,97 @@ public class FieldDataCacheTests extends OpenSearchTestCase {
         iw.close();
         DirectoryReader ir = OpenSearchDirectoryReader.wrap(DirectoryReader.open(dir), new ShardId("idx", "_na_", 0));
 
-        AtomicInteger onCacheIdentity = new AtomicInteger(-1);
-        AtomicInteger onRemovalIdentity = new AtomicInteger(-1);
-        IndexFieldDataCache.Listener listener = new IndexFieldDataCache.Listener() {
+        AtomicInteger nodeOnCache = new AtomicInteger();
+        AtomicInteger nodeOnRemoval = new AtomicInteger();
+        IndexFieldDataCache.Listener nodeListener = new IndexFieldDataCache.Listener() {
             @Override
-            public void onCache(ShardId shardId, String fieldName, Accountable ramUsage, int shardIdentity) {
-                onCacheIdentity.set(shardIdentity);
+            public void onCache(ShardId shardId, String fieldName, Accountable ramUsage) {
+                nodeOnCache.incrementAndGet();
             }
 
             @Override
-            public void onRemoval(ShardId shardId, String fieldName, boolean wasEvicted, long sizeInBytes, int shardIdentity) {
-                onRemovalIdentity.set(shardIdentity);
+            public void onRemoval(ShardId shardId, String fieldName, boolean wasEvicted, long sizeInBytes) {
+                nodeOnRemoval.incrementAndGet();
+            }
+        };
+
+        AtomicInteger perShardOnCache = new AtomicInteger();
+        AtomicInteger perShardOnRemoval = new AtomicInteger();
+        IndexFieldDataCache.Listener perShardListener = new IndexFieldDataCache.Listener() {
+            @Override
+            public void onCache(ShardId shardId, String fieldName, Accountable ramUsage) {
+                perShardOnCache.incrementAndGet();
+            }
+
+            @Override
+            public void onRemoval(ShardId shardId, String fieldName, boolean wasEvicted, long sizeInBytes) {
+                perShardOnRemoval.incrementAndGet();
+            }
+        };
+
+        IndicesFieldDataCache nodeCache = new IndicesFieldDataCache(Settings.EMPTY, nodeListener, null, null);
+        Index index = new Index("idx", "_na_");
+        AtomicInteger currentIdentity = new AtomicInteger(4242);
+        IndexFieldDataCache fieldCache = nodeCache.buildIndexFieldDataCache(
+            perShardListener,
+            index,
+            "field1",
+            shardId -> currentIdentity.get()
+        );
+
+        SortedSetOrdinalsIndexFieldData ifd = createSortedDV("field1", fieldCache);
+        ifd.loadGlobal(ir);
+        assertEquals(1, nodeOnCache.get());
+        assertEquals(1, perShardOnCache.get());
+
+        // Simulate shard reallocation: the resolver now returns a different identity. The cached
+        // entry's captured identity (4242) no longer matches → per-shard onRemoval is skipped,
+        // but the node-level onRemoval still fires.
+        currentIdentity.set(9999);
+        nodeCache.getCache().invalidateAll();
+
+        assertEquals(1, nodeOnRemoval.get());
+        assertEquals(0, perShardOnRemoval.get());
+
+        ir.close();
+        dir.close();
+        nodeCache.close();
+    }
+
+    // When the resolved identity matches the captured identity, the per-shard listener's onRemoval
+    // fires as normal.
+    public void testCacheFiresPerShardRemovalWhenIdentityUnchanged() throws Exception {
+        Directory dir = newDirectory();
+        IndexWriterConfig iwc = new IndexWriterConfig(null);
+        iwc.setMergePolicy(NoMergePolicy.INSTANCE);
+        IndexWriter iw = new IndexWriter(dir, iwc);
+        for (int i = 0; i < 2; i++) {
+            Document doc = new Document();
+            doc.add(new SortedSetDocValuesField("field1", new BytesRef("v" + i)));
+            iw.addDocument(doc);
+            iw.commit();
+        }
+        iw.close();
+        DirectoryReader ir = OpenSearchDirectoryReader.wrap(DirectoryReader.open(dir), new ShardId("idx", "_na_", 0));
+
+        AtomicInteger perShardOnRemoval = new AtomicInteger();
+        IndexFieldDataCache.Listener perShardListener = new IndexFieldDataCache.Listener() {
+            @Override
+            public void onRemoval(ShardId shardId, String fieldName, boolean wasEvicted, long sizeInBytes) {
+                perShardOnRemoval.incrementAndGet();
             }
         };
 
         IndicesFieldDataCache nodeCache = new IndicesFieldDataCache(Settings.EMPTY, new IndexFieldDataCache.Listener() {
         }, null, null);
         Index index = new Index("idx", "_na_");
-        int expectedIdentity = 4242;
-        IndexFieldDataCache fieldCache = nodeCache.buildIndexFieldDataCache(listener, index, "field1", shardId -> expectedIdentity);
+        IndexFieldDataCache fieldCache = nodeCache.buildIndexFieldDataCache(perShardListener, index, "field1", shardId -> 4242);
 
         SortedSetOrdinalsIndexFieldData ifd = createSortedDV("field1", fieldCache);
         ifd.loadGlobal(ir);
-        assertEquals(expectedIdentity, onCacheIdentity.get());
-
         nodeCache.getCache().invalidateAll();
-        assertEquals(expectedIdentity, onRemovalIdentity.get());
+
+        assertEquals(1, perShardOnRemoval.get());
 
         ir.close();
         dir.close();

--- a/server/src/test/java/org/opensearch/index/fielddata/FieldDataStatsTests.java
+++ b/server/src/test/java/org/opensearch/index/fielddata/FieldDataStatsTests.java
@@ -31,13 +31,18 @@
 
 package org.opensearch.index.fielddata;
 
+import org.apache.lucene.util.Accountable;
 import org.opensearch.common.FieldMemoryStats;
 import org.opensearch.common.FieldMemoryStatsTests;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class FieldDataStatsTests extends OpenSearchTestCase {
 
@@ -55,5 +60,113 @@ public class FieldDataStatsTests extends OpenSearchTestCase {
         assertEquals(stats.getEvictions(), read.getEvictions());
         assertEquals(stats.getMemorySize(), read.getMemorySize());
         assertEquals(stats.getFields(), read.getFields());
+    }
+
+    // onRemoval without a matching onCache pushes memorySize negative; writeVLong then throws.
+    public void testRemovalWithoutMatchingCacheGoesNegativeAndFailsSerialization() {
+        ShardFieldData data = new ShardFieldData();
+        ShardId shardId = new ShardId("index", "uuid", 0);
+        long bytes = 2_895_512L;
+
+        data.onRemoval(shardId, "foo", true, bytes);
+
+        FieldDataStats stats = data.stats("*");
+        assertEquals(-bytes, stats.getMemorySizeInBytes());
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        IllegalStateException e = expectThrows(IllegalStateException.class, () -> stats.writeTo(out));
+        assertTrue(e.getMessage().contains("Negative longs unsupported"));
+        assertTrue(e.getMessage().contains("-2895512"));
+    }
+
+    // With the identity guard, a stale removal is skipped — the new shard is not decremented.
+    public void testIdentityGuardSkipsStaleDecrementOnReallocation() {
+        AtomicReference<Object> currentShard = new AtomicReference<>();
+        AtomicReference<ShardFieldData> currentShardFieldData = new AtomicReference<>();
+        IndexFieldDataCache.Listener listener = new IndexFieldDataCache.Listener() {
+            @Override
+            public void onCache(ShardId shardId, String fieldName, Accountable ramUsage, int shardIdentity) {
+                ShardFieldData s = currentShardFieldData.get();
+                if (s != null) s.onCache(shardId, fieldName, ramUsage);
+            }
+
+            @Override
+            public void onRemoval(ShardId shardId, String fieldName, boolean wasEvicted, long sizeInBytes, int shardIdentity) {
+                Object shard = currentShard.get();
+                ShardFieldData s = currentShardFieldData.get();
+                if (shard == null || s == null) return;
+                if (shardIdentity != 0 && shardIdentity != System.identityHashCode(shard)) return;
+                s.onRemoval(shardId, fieldName, wasEvicted, sizeInBytes);
+            }
+        };
+
+        ShardId shardId = new ShardId("idx", "uuid", 0);
+        Object shardA = new Object();
+        ShardFieldData fdA = new ShardFieldData();
+        currentShard.set(shardA);
+        currentShardFieldData.set(fdA);
+
+        long bytes = 4_372_408L;
+        int identityA = System.identityHashCode(shardA);
+        listener.onCache(shardId, "user.name", accountableOf(bytes), identityA);
+        assertEquals(bytes, fdA.stats("*").getMemorySizeInBytes());
+
+        // Old shard is replaced. The stale removal still carries the old identity → guard skips it.
+        Object shardAPrime = new Object();
+        ShardFieldData fdAPrime = new ShardFieldData();
+        currentShard.set(shardAPrime);
+        currentShardFieldData.set(fdAPrime);
+
+        listener.onRemoval(shardId, "user.name", false, bytes, identityA);
+
+        assertEquals(0L, fdAPrime.stats("*").getMemorySizeInBytes());
+    }
+
+    // shardIdentity == 0 means "tracking disabled" — guard must let the removal through.
+    public void testIdentityGuardAllowsThroughWhenIdentityIsZero() {
+        AtomicReference<Object> currentShard = new AtomicReference<>();
+        AtomicReference<ShardFieldData> currentShardFieldData = new AtomicReference<>();
+        IndexFieldDataCache.Listener listener = new IndexFieldDataCache.Listener() {
+            @Override
+            public void onCache(ShardId shardId, String fieldName, Accountable ramUsage, int shardIdentity) {
+                ShardFieldData s = currentShardFieldData.get();
+                if (s != null) s.onCache(shardId, fieldName, ramUsage);
+            }
+
+            @Override
+            public void onRemoval(ShardId shardId, String fieldName, boolean wasEvicted, long sizeInBytes, int shardIdentity) {
+                Object shard = currentShard.get();
+                ShardFieldData s = currentShardFieldData.get();
+                if (shard == null || s == null) return;
+                if (shardIdentity != 0 && shardIdentity != System.identityHashCode(shard)) return;
+                s.onRemoval(shardId, fieldName, wasEvicted, sizeInBytes);
+            }
+        };
+
+        ShardId shardId = new ShardId("idx", "uuid", 0);
+        Object shardA = new Object();
+        ShardFieldData fdA = new ShardFieldData();
+        currentShard.set(shardA);
+        currentShardFieldData.set(fdA);
+
+        long bytes = 500_000L;
+        listener.onCache(shardId, "f", accountableOf(bytes), 0);
+        listener.onRemoval(shardId, "f", false, bytes, 0);
+
+        assertEquals(0L, fdA.stats("*").getMemorySizeInBytes());
+    }
+
+    private static Accountable accountableOf(long bytes) {
+        return new Accountable() {
+            @Override
+            public long ramBytesUsed() {
+                return bytes;
+            }
+
+            @Override
+            public Collection<Accountable> getChildResources() {
+                return Collections.emptyList();
+            }
+        };
     }
 }

--- a/server/src/test/java/org/opensearch/index/fielddata/FieldDataStatsTests.java
+++ b/server/src/test/java/org/opensearch/index/fielddata/FieldDataStatsTests.java
@@ -31,7 +31,6 @@
 
 package org.opensearch.index.fielddata;
 
-import org.apache.lucene.util.Accountable;
 import org.opensearch.common.FieldMemoryStats;
 import org.opensearch.common.FieldMemoryStatsTests;
 import org.opensearch.common.io.stream.BytesStreamOutput;
@@ -40,9 +39,6 @@ import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.io.IOException;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.concurrent.atomic.AtomicReference;
 
 public class FieldDataStatsTests extends OpenSearchTestCase {
 
@@ -79,94 +75,4 @@ public class FieldDataStatsTests extends OpenSearchTestCase {
         assertTrue(e.getMessage().contains("-2895512"));
     }
 
-    // With the identity guard, a stale removal is skipped — the new shard is not decremented.
-    public void testIdentityGuardSkipsStaleDecrementOnReallocation() {
-        AtomicReference<Object> currentShard = new AtomicReference<>();
-        AtomicReference<ShardFieldData> currentShardFieldData = new AtomicReference<>();
-        IndexFieldDataCache.Listener listener = new IndexFieldDataCache.Listener() {
-            @Override
-            public void onCache(ShardId shardId, String fieldName, Accountable ramUsage, int shardIdentity) {
-                ShardFieldData s = currentShardFieldData.get();
-                if (s != null) s.onCache(shardId, fieldName, ramUsage);
-            }
-
-            @Override
-            public void onRemoval(ShardId shardId, String fieldName, boolean wasEvicted, long sizeInBytes, int shardIdentity) {
-                Object shard = currentShard.get();
-                ShardFieldData s = currentShardFieldData.get();
-                if (shard == null || s == null) return;
-                if (shardIdentity != 0 && shardIdentity != System.identityHashCode(shard)) return;
-                s.onRemoval(shardId, fieldName, wasEvicted, sizeInBytes);
-            }
-        };
-
-        ShardId shardId = new ShardId("idx", "uuid", 0);
-        Object shardA = new Object();
-        ShardFieldData fdA = new ShardFieldData();
-        currentShard.set(shardA);
-        currentShardFieldData.set(fdA);
-
-        long bytes = 4_372_408L;
-        int identityA = System.identityHashCode(shardA);
-        listener.onCache(shardId, "user.name", accountableOf(bytes), identityA);
-        assertEquals(bytes, fdA.stats("*").getMemorySizeInBytes());
-
-        // Old shard is replaced. The stale removal still carries the old identity → guard skips it.
-        Object shardAPrime = new Object();
-        ShardFieldData fdAPrime = new ShardFieldData();
-        currentShard.set(shardAPrime);
-        currentShardFieldData.set(fdAPrime);
-
-        listener.onRemoval(shardId, "user.name", false, bytes, identityA);
-
-        assertEquals(0L, fdAPrime.stats("*").getMemorySizeInBytes());
-    }
-
-    // shardIdentity == 0 means "tracking disabled" — guard must let the removal through.
-    public void testIdentityGuardAllowsThroughWhenIdentityIsZero() {
-        AtomicReference<Object> currentShard = new AtomicReference<>();
-        AtomicReference<ShardFieldData> currentShardFieldData = new AtomicReference<>();
-        IndexFieldDataCache.Listener listener = new IndexFieldDataCache.Listener() {
-            @Override
-            public void onCache(ShardId shardId, String fieldName, Accountable ramUsage, int shardIdentity) {
-                ShardFieldData s = currentShardFieldData.get();
-                if (s != null) s.onCache(shardId, fieldName, ramUsage);
-            }
-
-            @Override
-            public void onRemoval(ShardId shardId, String fieldName, boolean wasEvicted, long sizeInBytes, int shardIdentity) {
-                Object shard = currentShard.get();
-                ShardFieldData s = currentShardFieldData.get();
-                if (shard == null || s == null) return;
-                if (shardIdentity != 0 && shardIdentity != System.identityHashCode(shard)) return;
-                s.onRemoval(shardId, fieldName, wasEvicted, sizeInBytes);
-            }
-        };
-
-        ShardId shardId = new ShardId("idx", "uuid", 0);
-        Object shardA = new Object();
-        ShardFieldData fdA = new ShardFieldData();
-        currentShard.set(shardA);
-        currentShardFieldData.set(fdA);
-
-        long bytes = 500_000L;
-        listener.onCache(shardId, "f", accountableOf(bytes), 0);
-        listener.onRemoval(shardId, "f", false, bytes, 0);
-
-        assertEquals(0L, fdA.stats("*").getMemorySizeInBytes());
-    }
-
-    private static Accountable accountableOf(long bytes) {
-        return new Accountable() {
-            @Override
-            public long ramBytesUsed() {
-                return bytes;
-            }
-
-            @Override
-            public Collection<Accountable> getChildResources() {
-                return Collections.emptyList();
-            }
-        };
-    }
 }

--- a/server/src/test/java/org/opensearch/index/fielddata/IndexFieldDataServiceTests.java
+++ b/server/src/test/java/org/opensearch/index/fielddata/IndexFieldDataServiceTests.java
@@ -630,4 +630,26 @@ public class IndexFieldDataServiceTests extends OpenSearchSingleNodeTestCase {
         // Ensure cache fully cleared before other tests in the suite begin
         fdCacheSpy.close();
     }
+
+    public void testSetShardIdentityResolverRejectsNull() {
+        ThreadPool threadPool = new TestThreadPool("test_set_resolver_null");
+        try {
+            IndicesFieldDataCache cache = new IndicesFieldDataCache(
+                Settings.EMPTY,
+                null,
+                getInstanceFromNode(ClusterService.class),
+                threadPool
+            );
+            IndexFieldDataService ifds = new IndexFieldDataService(
+                IndexSettingsModule.newIndexSettings("test", Settings.EMPTY),
+                cache,
+                null,
+                null,
+                threadPool
+            );
+            expectThrows(IllegalArgumentException.class, () -> ifds.setShardIdentityResolver(null));
+        } finally {
+            threadPool.shutdown();
+        }
+    }
 }


### PR DESCRIPTION
### Summary
Fixes negative `FieldDataStats.memorySize` causing API serialization error `IllegalStateException: Negative longs unsupported`.

### Root Cause
`FieldDataStats.memorySize` is tracked by a per-shard counter on each node. The counter is incremented when field data is inserted into the node's cache and decremented when field data is removed from the cache. However, cache invalidation and stats decrement runs lazily — fired by a periodic `CacheCleaner` (default 1 min). This timing gap allows field data stats to become corrupt when an `IndexShard` is destroyed and a new one is allocated on the same node with the same `shardId` while the index's `IndexService` (and its `FieldDataCacheListener`) stays alive on that node.

The `IndexService` survives an `IndexShard` recreation when **another shard of the same index keeps the `IndexService` alive on the same node**. Closing the entire index (`_close`/`_open`) destroys the `IndexService` and so does NOT trigger this bug — the stale decrement is dispatched to a listener whose `IndexService` is gone, and is silently dropped.

The trigger conditions on long-running clusters are:

- **Cluster rebalancing of multi-shard indices** — shards naturally migrate between nodes while another shard of the same index keeps the `IndexService` alive on each node.
- **Operator-driven shard moves** — allocation filter changes for node maintenance, zone evacuation, or capacity rebalancing. Repeated ops cause shards to revisit nodes they've previously lived on while sibling shards anchor the `IndexService`.
- **Tier-aware allocation routing** — allocation filter changes driven by hot/warm/cold setups (including ISM-driven routing) move shards between nodes while sibling shards keep the `IndexService` alive.
- **Heavy cluster activity** — concurrent force-merge, indexing surges, or other resource pressure can destabilize allocation and accelerate the conditions above. Segment churn from these workloads also changes the byte size of cached entries, so a stale decrement can be larger than the new shard's freshly-loaded counter.

A single misrouted decrement is often masked by the shard's own positive bytes, so the corruption accumulates slowly and the visible failure only appears after enough stale decrements have piled up. Restarting the affected node temporarily clears the bad state.

If shard A is destroyed and a new shard B is allocated on the same node with the same shard id before that decrement fires (and the `IndexService` survives because another shard anchors it), the removal listener resolves the shard by id, finds B, and decrements B's counter — even though B never cached the entry. This is how B's counter can become negative.

### Local Reproduction
I reproduced one of the error scenarios on a locally running 2-node cluster.

1. Create an index with two shards, pinned to one node.
2. Index documents across multiple flushes so each shard has multiple segments (fielddata cache is bypassed for single-segment loads).
3. Run a sort search to populate the fielddata cache.
4. Three times in a row: widen the allocation filter so the second shard moves to the other node, then re-narrow so it returns. The first shard never moves and keeps the `IndexService` alive on the original node throughout. Re-run the sort search after each round-trip so the new shard instance has cached bytes.
5. Wait long enough for the periodic `CacheCleaner` to fire (~90s, spans at least one default 60s tick).
6. Query `/_nodes/stats/indices/fielddata` — without the fix, the affected node reports a negative `memory_size_in_bytes` and the API returns HTTP 400 with `"Values less than -1 bytes are not supported"`.

The same procedure on a build with this fix applied returns HTTP 200 with non-negative bytes on every node. The reproduction was run 5 times on each branch (10 total) with consistent results: bug reproduced 5/5 on `main`, fix held 5/5 on the fix branch.

### Integration Test Reproduction
Added a new integ test `FieldDataStatsNegativeIT.testReproduceNegativeFieldDataStats` to reproduce negative stats using a similar procedure as above.

Test fails without this PR's fix
```
% ./gradlew :server:internalClusterTest --tests "org.opensearch.index.fielddata.FieldDataStatsNegativeIT"
=======================================
OpenSearch Build Hamster says Hello!
  Gradle Version        : 9.4.1
  OS Info               : Mac OS X 26.5 (aarch64)
  JDK Version           : 25 (Homebrew JDK 25 (25))
  JAVA_HOME             : /opt/homebrew/Cellar/openjdk/25/libexec/openjdk.jdk/Contents/Home
  Random Testing Seed   : EBF5A0D333EA8F82
  Crypto Standard       : any-supported
=======================================

> Task :server:internalClusterTest
WARNING: Using incubator modules: jdk.incubator.vector

REPRODUCE WITH: ./gradlew ':server:internalClusterTest' --tests 'org.opensearch.index.fielddata.FieldDataStatsNegativeIT.testReproduceNegativeFieldDataStats' -Dtests.seed=EBF5A0D333EA8F82 -Dtests.security.manager=true -Dtests.jvm.argline="-XX:TieredStopAtLevel=1 -XX:ReservedCodeCacheSize=64m" -Dtests.locale=kam -Dtests.timezone=Asia/Jerusalem -Druntime.java=25

FieldDataStatsNegativeIT > testReproduceNegativeFieldDataStats FAILED
    java.lang.AssertionError: shard [test_fd_stats][1] bytes: -2676
    Expected: a value equal to or greater than <0L>
         but: <-2676L> was less than <0L>
        at __randomizedtesting.SeedInfo.seed([EBF5A0D333EA8F82:ED8072CEB4AA408D]:0)
        at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:18)
        at org.apache.lucene.tests.util.LuceneTestCase.assertThat(LuceneTestCase.java:2123)
        at org.opensearch.index.fielddata.FieldDataStatsNegativeIT.testReproduceNegativeFieldDataStats(FieldDataStatsNegativeIT.java:95)

...
```

### Fix
When a cache entry is inserted, store a unique identifier of the shard that inserted it (using `System.identityHashCode` of the `IndexShard`). When a cache entry is removed, compare the current shard identity to the stored one. If they don't match, the original shard has been replaced — skip the decrement so the new shard's counter stays correct.

### Related Issues
Resolves #20363 & #5442

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
