### PR TITLE
analytics-engine: add window function support

### DIFF
--- a/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/BackendCapabilityProvider.java
+++ b/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/BackendCapabilityProvider.java
@@ -59,6 +59,17 @@ public interface BackendCapabilityProvider {
     }
 
     /**
+     * Window-function capabilities this backend can execute. Each {@link WindowCapability}
+     * declares a set of {@link WindowFunction}s (ROW_NUMBER, RANK, SUM/AVG/COUNT over a
+     * frame, etc.) and the storage formats those windows apply to. The planner narrows
+     * viable backends to those whose capabilities cover every required function. An empty
+     * set means the backend cannot execute window functions.
+     */
+    default Set<WindowCapability> windowCapabilities() {
+        return Set.of();
+    }
+
+    /**
      * Delegation types this backend can initiate — it has a custom physical operator
      * that calls Analytics Core's delegation API to offload work to another backend.
      */

--- a/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/WindowCapability.java
+++ b/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/WindowCapability.java
@@ -1,0 +1,21 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.spi;
+
+import java.util.Set;
+
+/**
+ * A backend's window-function support: the functions it can execute and the storage
+ * formats those windows apply to. The planner intersects a query's required
+ * {@link WindowFunction} set against {@link BackendCapabilityProvider#windowCapabilities()}.
+ *
+ * @opensearch.internal
+ */
+public record WindowCapability(Set<WindowFunction> functions, Set<String> formats) {
+}

--- a/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/WindowFunction.java
+++ b/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/WindowFunction.java
@@ -1,0 +1,46 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.spi;
+
+import org.apache.calcite.sql.SqlKind;
+
+/**
+ * Window functions a backend may support. Covers aggregate-as-window
+ * (SUM/AVG/COUNT/MIN/MAX over a frame) — these are what PPL {@code eventstats} lowers
+ * to. PARTITION BY is not currently supported by the planner. Ranking functions
+ * (ROW_NUMBER / RANK / DENSE_RANK) are not yet reachable on this route since
+ * {@code streamstats} (which lowers to them) isn't wired here.
+ *
+ * @opensearch.internal
+ */
+public enum WindowFunction {
+    SUM(SqlKind.SUM),
+    AVG(SqlKind.AVG),
+    COUNT(SqlKind.COUNT),
+    MIN(SqlKind.MIN),
+    MAX(SqlKind.MAX);
+
+    private final SqlKind sqlKind;
+
+    WindowFunction(SqlKind sqlKind) {
+        this.sqlKind = sqlKind;
+    }
+
+    public SqlKind getSqlKind() {
+        return sqlKind;
+    }
+
+    /** Returns the {@link WindowFunction} for {@code sqlKind}, or {@code null} if unsupported. */
+    public static WindowFunction fromSqlKind(SqlKind sqlKind) {
+        for (WindowFunction fn : values()) {
+            if (fn.sqlKind == sqlKind) return fn;
+        }
+        return null;
+    }
+}

--- a/sandbox/libs/analytics-framework/src/test/java/org/opensearch/analytics/spi/WindowFunctionTests.java
+++ b/sandbox/libs/analytics-framework/src/test/java/org/opensearch/analytics/spi/WindowFunctionTests.java
@@ -1,0 +1,28 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.spi;
+
+import org.apache.calcite.sql.SqlKind;
+import org.opensearch.test.OpenSearchTestCase;
+
+/**
+ * Asserts each {@link WindowFunction} entry maps to its Calcite {@link SqlKind} and
+ * {@link WindowFunction#fromSqlKind} round-trips that mapping.
+ */
+public class WindowFunctionTests extends OpenSearchTestCase {
+
+    public void testAggregateOverKinds() {
+        assertEquals(WindowFunction.SUM, WindowFunction.fromSqlKind(SqlKind.SUM));
+        assertEquals(WindowFunction.COUNT, WindowFunction.fromSqlKind(SqlKind.COUNT));
+        assertEquals(WindowFunction.AVG, WindowFunction.fromSqlKind(SqlKind.AVG));
+        assertEquals(WindowFunction.MIN, WindowFunction.fromSqlKind(SqlKind.MIN));
+        assertEquals(WindowFunction.MAX, WindowFunction.fromSqlKind(SqlKind.MAX));
+    }
+
+}

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionAnalyticsBackendPlugin.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionAnalyticsBackendPlugin.java
@@ -32,6 +32,8 @@ import org.opensearch.analytics.spi.ScalarFunctionAdapter;
 import org.opensearch.analytics.spi.ScanCapability;
 import org.opensearch.analytics.spi.SearchExecEngineProvider;
 import org.opensearch.analytics.spi.StdOperatorRewriteAdapter;
+import org.opensearch.analytics.spi.WindowCapability;
+import org.opensearch.analytics.spi.WindowFunction;
 import org.opensearch.be.datafusion.indexfilter.FilterTreeCallbacks;
 import org.opensearch.index.engine.dataformat.DataFormatRegistry;
 
@@ -349,6 +351,16 @@ public class DataFusionAnalyticsBackendPlugin implements AnalyticsSearchBackendP
                             JoinCapability.JoinKind.ANTI,
                             JoinCapability.JoinKind.CROSS
                         ),
+                        Set.copyOf(plugin.getSupportedFormats())
+                    )
+                );
+            }
+
+            @Override
+            public Set<WindowCapability> windowCapabilities() {
+                return Set.of(
+                    new WindowCapability(
+                        Set.of(WindowFunction.SUM, WindowFunction.AVG, WindowFunction.COUNT, WindowFunction.MIN, WindowFunction.MAX),
                         Set.copyOf(plugin.getSupportedFormats())
                     )
                 );

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchAggregateSplitRule.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchAggregateSplitRule.java
@@ -58,6 +58,25 @@ public class OpenSearchAggregateSplitRule extends RelOptRule {
         OpenSearchAggregate aggregate = call.rel(0);
         RelNode child = call.rel(1);
 
+        // SINGLE with input converted to SINGLETON. Volcano picks this when
+        // the child can offer SINGLETON cheaply — e.g. a windowed Project already gathers
+        // below it, so a follow-on Aggregate has no parallelism to gain from splitting.
+        // Mirrors the dual-alternative pattern in OpenSearchJoinSplitRule.
+        RelTraitSet singletonTraits = aggregate.getTraitSet().replace(context.getDistributionTraitDef().coordSingleton());
+        RelNode singletonChild = convert(child, singletonTraits);
+        OpenSearchAggregate singleOnSingleton = new OpenSearchAggregate(
+            aggregate.getCluster(),
+            singletonTraits,
+            singletonChild,
+            aggregate.getGroupSet(),
+            aggregate.getGroupSets(),
+            aggregate.getAggCallList(),
+            AggregateMode.SINGLE,
+            aggregate.getViableBackends()
+        );
+
+        // PARTIAL + ER + FINAL. Wins when child is shard-partitioned — the
+        // common case for an Aggregate directly above a Scan.
         RelTraitSet partialTraits = child.getTraitSet().replace(OpenSearchConvention.INSTANCE);
         OpenSearchAggregate partial = new OpenSearchAggregate(
             aggregate.getCluster(),
@@ -69,14 +88,11 @@ public class OpenSearchAggregateSplitRule extends RelOptRule {
             AggregateMode.PARTIAL,
             aggregate.getViableBackends()
         );
-
-        // Request SINGLETON distribution — Volcano inserts Exchange automatically
-        RelTraitSet singletonTraits = partial.getTraitSet().replace(context.getDistributionTraitDef().coordSingleton());
-        RelNode gathered = convert(partial, singletonTraits);
-
+        RelTraitSet finalTraits = partial.getTraitSet().replace(context.getDistributionTraitDef().coordSingleton());
+        RelNode gathered = convert(partial, finalTraits);
         OpenSearchAggregate finalAggregate = new OpenSearchAggregate(
             aggregate.getCluster(),
-            singletonTraits,
+            finalTraits,
             gathered,
             aggregate.getGroupSet(),
             aggregate.getGroupSets(),
@@ -85,6 +101,7 @@ public class OpenSearchAggregateSplitRule extends RelOptRule {
             aggregate.getViableBackends()
         );
 
+        call.getPlanner().ensureRegistered(singleOnSingleton, aggregate);
         call.transformTo(finalAggregate);
     }
 }

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchFilterRule.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchFilterRule.java
@@ -26,6 +26,7 @@ import org.opensearch.analytics.planner.rel.OpenSearchFilter;
 import org.opensearch.analytics.planner.rel.OpenSearchRelNode;
 import org.opensearch.analytics.spi.DelegationType;
 import org.opensearch.analytics.spi.FieldStorageInfo;
+import org.opensearch.analytics.spi.FieldType;
 import org.opensearch.analytics.spi.ScalarFunction;
 
 import java.util.ArrayList;

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchProjectRule.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchProjectRule.java
@@ -15,6 +15,7 @@ import org.apache.calcite.rel.core.Project;
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexInputRef;
 import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexOver;
 import org.apache.calcite.sql.SqlFunction;
 import org.opensearch.analytics.planner.CapabilityRegistry;
 import org.opensearch.analytics.planner.PlannerContext;
@@ -25,9 +26,13 @@ import org.opensearch.analytics.planner.rel.OpenSearchRelNode;
 import org.opensearch.analytics.spi.DelegationType;
 import org.opensearch.analytics.spi.FieldType;
 import org.opensearch.analytics.spi.ScalarFunction;
+import org.opensearch.analytics.spi.WindowCapability;
+import org.opensearch.analytics.spi.WindowFunction;
 
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Converts {@link Project} → {@link OpenSearchProject}.
@@ -79,6 +84,15 @@ public class OpenSearchProjectRule extends RelOptRule {
             ? computeProjectViableBackends(annotatedExprs, childViableBackends)
             : childViableBackends;
 
+        // Window functions (RexOver): PPL `eventstats` / `appendcol` emit window calls inline
+        // on the projection. Narrow viable backends to those whose WindowCapability declares
+        // every required function. PARTITION BY is rejected up front — no shuffle exchange
+        // exists today.
+        Set<WindowFunction> requiredWindowFns = collectWindowFunctions(project.getProjects());
+        if (!requiredWindowFns.isEmpty()) {
+            viableBackends = narrowByWindowCapability(viableBackends, requiredWindowFns);
+        }
+
         if (viableBackends.isEmpty()) {
             throw new IllegalStateException("No backend can execute all project expressions among " + childViableBackends);
         }
@@ -96,6 +110,12 @@ public class OpenSearchProjectRule extends RelOptRule {
     }
 
     private RexNode annotateExpr(RexNode expr, List<String> childViableBackends) {
+        if (expr instanceof RexOver) {
+            // Window functions are narrowed separately by narrowByWindowCapability — skip the
+            // scalar path (RexOver's aggregate operator is not a scalar function). Leave the
+            // RexOver as-is so substrait conversion receives the unwrapped shape.
+            return expr;
+        }
         if (!(expr instanceof RexCall rexCall)) {
             // TODO: RexInputRef and RexLiteral are left unannotated — they are implicitly handled
             // by whichever backend executes the operator (pass-through for refs, constant for literals).
@@ -261,5 +281,51 @@ public class OpenSearchProjectRule extends RelOptRule {
 
     private boolean isOpaqueOperation(String funcName) {
         return context.getCapabilityRegistry().isOpaqueOperation(funcName);
+    }
+
+    /** Walks project expressions and collects the {@link WindowFunction}s used by any {@link RexOver}.
+     *  PARTITION BY is rejected — no shuffle exchange exists today. Unrecognized window SqlKinds
+     *  (LAG, LEAD, NTILE, etc.) also fail here. */
+    private static Set<WindowFunction> collectWindowFunctions(List<? extends RexNode> exprs) {
+        Set<WindowFunction> fns = new LinkedHashSet<>();
+        for (RexNode expr : exprs) {
+            expr.accept(new org.apache.calcite.rex.RexShuttle() {
+                @Override
+                public RexNode visitOver(RexOver over) {
+                    if (!over.getWindow().partitionKeys.isEmpty()) {
+                        throw new IllegalStateException(
+                            "Window OVER (PARTITION BY ...) is not supported — no shuffle exchange available yet"
+                        );
+                    }
+                    WindowFunction fn = WindowFunction.fromSqlKind(over.getAggOperator().getKind());
+                    if (fn == null) {
+                        throw new IllegalStateException("Window function [" + over.getAggOperator().getName() + "] is not supported");
+                    }
+                    fns.add(fn);
+                    return super.visitOver(over);
+                }
+            });
+        }
+        return fns;
+    }
+
+    /** Keep backends whose {@link WindowCapability} covers every {@link WindowFunction} used. */
+    private List<String> narrowByWindowCapability(List<String> candidates, Set<WindowFunction> required) {
+        List<String> out = new ArrayList<>();
+        for (String backend : candidates) {
+            Set<WindowCapability> caps = context.getCapabilityRegistry().getBackend(backend).getCapabilityProvider().windowCapabilities();
+            boolean covers = false;
+            for (WindowCapability cap : caps) {
+                if (cap.functions().containsAll(required)) {
+                    covers = true;
+                    break;
+                }
+            }
+            if (covers) out.add(backend);
+        }
+        if (out.isEmpty()) {
+            throw new IllegalStateException("No backend supports window functions " + required + " among " + candidates);
+        }
+        return out;
     }
 }

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/MockBackend.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/MockBackend.java
@@ -30,6 +30,7 @@ import org.opensearch.analytics.spi.ScalarFunctionAdapter;
 import org.opensearch.analytics.spi.ScanCapability;
 import org.opensearch.analytics.spi.ShardScanInstructionNode;
 import org.opensearch.analytics.spi.ShardScanWithDelegationInstructionNode;
+import org.opensearch.analytics.spi.WindowCapability;
 
 import java.util.List;
 import java.util.Map;
@@ -80,6 +81,11 @@ abstract class MockBackend implements AnalyticsSearchBackendPlugin {
             }
 
             @Override
+            public Set<WindowCapability> windowCapabilities() {
+                return self.windowCapabilities();
+            }
+
+            @Override
             public Set<DelegationType> supportedDelegations() {
                 return self.supportedDelegations();
             }
@@ -123,6 +129,10 @@ abstract class MockBackend implements AnalyticsSearchBackendPlugin {
     }
 
     protected Set<JoinCapability> joinCapabilities() {
+        return Set.of();
+    }
+
+    protected Set<WindowCapability> windowCapabilities() {
         return Set.of();
     }
 

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/MockDataFusionBackend.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/MockDataFusionBackend.java
@@ -20,6 +20,8 @@ import org.opensearch.analytics.spi.JoinCapability;
 import org.opensearch.analytics.spi.ProjectCapability;
 import org.opensearch.analytics.spi.ScalarFunction;
 import org.opensearch.analytics.spi.ScanCapability;
+import org.opensearch.analytics.spi.WindowCapability;
+import org.opensearch.analytics.spi.WindowFunction;
 import org.opensearch.index.engine.dataformat.ReaderManagerConfig;
 import org.opensearch.index.engine.exec.EngineReaderManager;
 import org.opensearch.plugins.SearchBackEndPlugin;
@@ -129,6 +131,16 @@ public class MockDataFusionBackend extends MockBackend implements SearchBackEndP
                     JoinCapability.JoinKind.ANTI,
                     JoinCapability.JoinKind.CROSS
                 ),
+                Set.of(PARQUET_DATA_FORMAT)
+            )
+        );
+    }
+
+    @Override
+    protected Set<WindowCapability> windowCapabilities() {
+        return Set.of(
+            new WindowCapability(
+                Set.of(WindowFunction.SUM, WindowFunction.AVG, WindowFunction.COUNT, WindowFunction.MIN, WindowFunction.MAX),
                 Set.of(PARQUET_DATA_FORMAT)
             )
         );

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/WindowPlanShapeTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/WindowPlanShapeTests.java
@@ -1,0 +1,858 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.planner;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.calcite.plan.RelOptTable;
+import org.apache.calcite.rel.RelCollations;
+import org.apache.calcite.rel.RelFieldCollation;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.CorrelationId;
+import org.apache.calcite.rel.core.JoinRelType;
+import org.apache.calcite.rel.logical.LogicalAggregate;
+import org.apache.calcite.rel.logical.LogicalJoin;
+import org.apache.calcite.rel.logical.LogicalProject;
+import org.apache.calcite.rel.logical.LogicalSort;
+import org.apache.calcite.rel.logical.LogicalUnion;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexWindowBound;
+import org.apache.calcite.rex.RexWindowBounds;
+import org.apache.calcite.sql.SqlAggFunction;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.opensearch.analytics.spi.EngineCapability;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Plan-shape tests for window functions, expressed as {@code RexOver} inside a
+ * {@link LogicalProject} (the shape PPL {@code eventstats} / {@code appendcol} emit).
+ *
+ * <p>The planner detects RexOver inside {@code OpenSearchProjectRule}, narrows viable
+ * backends by {@link org.opensearch.analytics.spi.WindowCapability}, and applies a cost
+ * gate that requires {@code COORDINATOR+SINGLETON} input on the project when any
+ * expression is a RexOver.
+ */
+public class WindowPlanShapeTests extends PlanShapeTestBase {
+
+    /**
+     * 1-shard with empty OVER(). Scan emits SHARD+SINGLETON which satisfies the Project's
+     * RexOver cost gate (type=SINGLETON) AND the root's locality-agnostic SINGLETON demand,
+     * so no ER is inserted. The whole pipeline runs on the single shard's node.
+     */
+    public void testCountOverEmpty_1shard() {
+        RelNode plan = projectWithCountOverEmpty();
+        assertPlanShape("""
+            LogicalProject(status=[$0], size=[$1], cnt=[COUNT() OVER ()])
+              StubTableScan(table=[[test_index]])
+            """, plan);
+        RelNode result = runPlanner(plan, singleShardContext());
+        assertPlanShape("""
+            OpenSearchProject(status=[$0], size=[$1], cnt=[COUNT() OVER ()], viableBackends=[[mock-parquet]])
+              OpenSearchTableScan(table=[[test_index]], viableBackends=[[mock-parquet]])
+            """, result);
+    }
+
+    public void testCountOverEmpty_2shard() {
+        RelNode plan = projectWithCountOverEmpty();
+        assertPlanShape("""
+            LogicalProject(status=[$0], size=[$1], cnt=[COUNT() OVER ()])
+              StubTableScan(table=[[test_index]])
+            """, plan);
+        RelNode result = runPlanner(plan, multiShardContext());
+        assertPlanShape(
+            """
+                OpenSearchProject(status=[$0], size=[$1], cnt=[COUNT() OVER ()], viableBackends=[[mock-parquet]])
+                  OpenSearchExchangeReducer(viableBackends=[[mock-parquet]], exchange=[ExchangeInfo[distributionType=SINGLETON, partitionKeyIndices=[]]])
+                    OpenSearchTableScan(table=[[test_index]], viableBackends=[[mock-parquet]])
+                """,
+            result
+        );
+    }
+
+    public void testSumOverEmpty_2shard() {
+        RelNode plan = projectWithSumOverEmpty();
+        assertPlanShape("""
+            LogicalProject(status=[$0], size=[$1], s=[SUM($1) OVER ()])
+              StubTableScan(table=[[test_index]])
+            """, plan);
+        RelNode result = runPlanner(plan, multiShardContext());
+        assertPlanShape(
+            """
+                OpenSearchProject(status=[$0], size=[$1], s=[SUM($1) OVER ()], viableBackends=[[mock-parquet]])
+                  OpenSearchExchangeReducer(viableBackends=[[mock-parquet]], exchange=[ExchangeInfo[distributionType=SINGLETON, partitionKeyIndices=[]]])
+                    OpenSearchTableScan(table=[[test_index]], viableBackends=[[mock-parquet]])
+                """,
+            result
+        );
+    }
+
+    /**
+     * Window after a shard-side Filter (multi-shard). Filter is single-input passthrough,
+     * stays at SHARD; the RexOver Project's cost gate forces COORDINATOR input, so an ER
+     * sits between Filter and Project.
+     */
+    public void testSumOverEmpty_afterFilter_2shard() {
+        RelNode plan = projectWithSumOverEmpty(
+            makeFilter(stubScan(mockTable("test_index", "status", "size")), makeEquals(0, SqlTypeName.INTEGER, 200))
+        );
+        assertPlanShape("""
+            LogicalProject(status=[$0], size=[$1], s=[SUM($1) OVER ()])
+              LogicalFilter(condition=[=($0, 200)])
+                StubTableScan(table=[[test_index]])
+            """, plan);
+        RelNode result = runPlanner(plan, multiShardContext());
+        assertPlanShape(
+            """
+                OpenSearchProject(status=[$0], size=[$1], s=[SUM($1) OVER ()], viableBackends=[[mock-parquet]])
+                  OpenSearchExchangeReducer(viableBackends=[[mock-parquet]], exchange=[ExchangeInfo[distributionType=SINGLETON, partitionKeyIndices=[]]])
+                    OpenSearchFilter(condition=[ANNOTATED_PREDICATE(id=0, backends=[mock-lucene, mock-parquet], =($0, 200))], viableBackends=[[mock-parquet]])
+                      OpenSearchTableScan(table=[[test_index]], viableBackends=[[mock-parquet]])
+                """,
+            result
+        );
+    }
+
+    /**
+     * Window after a Filter on a 1-shard input. Filter propagates Scan's SHARD+SINGLETON
+     * upward, satisfying the Project's RexOver cost gate without an ER. Pipeline stays
+     * on the single shard's node.
+     */
+    public void testSumOverEmpty_afterFilter_1shard() {
+        RelNode plan = projectWithSumOverEmpty(
+            makeFilter(stubScan(mockTable("test_index", "status", "size")), makeEquals(0, SqlTypeName.INTEGER, 200))
+        );
+        assertPlanShape("""
+            LogicalProject(status=[$0], size=[$1], s=[SUM($1) OVER ()])
+              LogicalFilter(condition=[=($0, 200)])
+                StubTableScan(table=[[test_index]])
+            """, plan);
+        RelNode result = runPlanner(plan, singleShardContext());
+        assertPlanShape(
+            """
+                OpenSearchProject(status=[$0], size=[$1], s=[SUM($1) OVER ()], viableBackends=[[mock-parquet]])
+                  OpenSearchFilter(condition=[ANNOTATED_PREDICATE(id=0, backends=[mock-lucene, mock-parquet], =($0, 200))], viableBackends=[[mock-parquet]])
+                    OpenSearchTableScan(table=[[test_index]], viableBackends=[[mock-parquet]])
+                """,
+            result
+        );
+    }
+
+    /**
+     * Window after a collated Sort (multi-shard). Sort already gathers to SINGLETON via
+     * SortSplitRule, so the Project's RexOver cost gate is satisfied without a second ER —
+     * Sort's output IS the SINGLETON the Project demands.
+     */
+    public void testSumOverEmpty_afterSort_2shard() {
+        RelNode plan = projectWithSumOverEmpty(makeSort(stubScan(mockTable("test_index", "status", "size")), -1));
+        assertPlanShape("""
+            LogicalProject(status=[$0], size=[$1], s=[SUM($1) OVER ()])
+              LogicalSort(sort0=[$0], dir0=[ASC])
+                StubTableScan(table=[[test_index]])
+            """, plan);
+        RelNode result = runPlanner(plan, multiShardContext());
+        assertPlanShape(
+            """
+                OpenSearchProject(status=[$0], size=[$1], s=[SUM($1) OVER ()], viableBackends=[[mock-parquet]])
+                  OpenSearchSort(sort0=[$0], dir0=[ASC], viableBackends=[[mock-parquet]])
+                    OpenSearchExchangeReducer(viableBackends=[[mock-parquet]], exchange=[ExchangeInfo[distributionType=SINGLETON, partitionKeyIndices=[]]])
+                      OpenSearchTableScan(table=[[test_index]], viableBackends=[[mock-parquet]])
+                """,
+            result
+        );
+    }
+
+    /**
+     * Two RexOver expressions in the same Project — both empty OVER() — share one ER.
+     * Verifies the rule emits exactly one OpenSearchProject wrapping both windows and
+     * does not duplicate the ER per RexOver.
+     */
+    public void testMultipleRexOver_2shard() {
+        RelOptTable table = mockTable("test_index", "status", "size");
+        RelNode scan = stubScan(table);
+        RexBuilder rb = scan.getCluster().getRexBuilder();
+
+        RexNode countOver = makeOver(
+            rb,
+            scan,
+            SqlStdOperatorTable.COUNT,
+            List.of(),
+            SqlTypeName.BIGINT,
+            RexWindowBounds.UNBOUNDED_PRECEDING,
+            RexWindowBounds.UNBOUNDED_FOLLOWING
+        );
+        RexNode sumOver = makeOver(
+            rb,
+            scan,
+            SqlStdOperatorTable.SUM,
+            List.of(rb.makeInputRef(scan, 1)),
+            SqlTypeName.BIGINT,
+            RexWindowBounds.UNBOUNDED_PRECEDING,
+            RexWindowBounds.UNBOUNDED_FOLLOWING
+        );
+
+        RelNode plan = LogicalProject.create(
+            scan,
+            List.of(),
+            List.of(rb.makeInputRef(scan, 0), rb.makeInputRef(scan, 1), countOver, sumOver),
+            List.of("status", "size", "cnt", "s")
+        );
+        assertPlanShape("""
+            LogicalProject(status=[$0], size=[$1], cnt=[COUNT() OVER ()], s=[SUM($1) OVER ()])
+              StubTableScan(table=[[test_index]])
+            """, plan);
+        RelNode result = runPlanner(plan, multiShardContext());
+        assertPlanShape(
+            """
+                OpenSearchProject(status=[$0], size=[$1], cnt=[COUNT() OVER ()], s=[SUM($1) OVER ()], viableBackends=[[mock-parquet]])
+                  OpenSearchExchangeReducer(viableBackends=[[mock-parquet]], exchange=[ExchangeInfo[distributionType=SINGLETON, partitionKeyIndices=[]]])
+                    OpenSearchTableScan(table=[[test_index]], viableBackends=[[mock-parquet]])
+                """,
+            result
+        );
+    }
+
+    /**
+     * Non-default frame: SUM(x) OVER (ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) —
+     * a running aggregate. The frame bounds change the OVER() rendering but not the plan
+     * shape (still ER under Project, same backend narrowing). Today no PPL command on this
+     * route emits this frame ({@code streamstats} isn't wired here), but the planner must
+     * still handle it correctly because Calcite can construct it directly.
+     */
+    public void testSumOverRunningFrame_2shard() {
+        RelOptTable table = mockTable("test_index", "status", "size");
+        RelNode scan = stubScan(table);
+        RexBuilder rb = scan.getCluster().getRexBuilder();
+        RexNode runningSum = makeOver(
+            rb,
+            scan,
+            SqlStdOperatorTable.SUM,
+            List.of(rb.makeInputRef(scan, 1)),
+            SqlTypeName.BIGINT,
+            RexWindowBounds.UNBOUNDED_PRECEDING,
+            RexWindowBounds.CURRENT_ROW
+        );
+
+        RelNode plan = LogicalProject.create(
+            scan,
+            List.of(),
+            List.of(rb.makeInputRef(scan, 0), rb.makeInputRef(scan, 1), runningSum),
+            List.of("status", "size", "running_s")
+        );
+        assertPlanShape("""
+            LogicalProject(status=[$0], size=[$1], running_s=[SUM($1) OVER (ROWS UNBOUNDED PRECEDING)])
+              StubTableScan(table=[[test_index]])
+            """, plan);
+        RelNode result = runPlanner(plan, multiShardContext());
+        assertPlanShape(
+            """
+                OpenSearchProject(status=[$0], size=[$1], running_s=[SUM($1) OVER (ROWS UNBOUNDED PRECEDING)], viableBackends=[[mock-parquet]])
+                  OpenSearchExchangeReducer(viableBackends=[[mock-parquet]], exchange=[ExchangeInfo[distributionType=SINGLETON, partitionKeyIndices=[]]])
+                    OpenSearchTableScan(table=[[test_index]], viableBackends=[[mock-parquet]])
+                """,
+            result
+        );
+    }
+
+    /**
+     * Window after an Aggregate: {@code Project(group, total, SUM(total) OVER ())} over
+     * {@code Aggregate(group=[$0], total=SUM($1))} (multi-shard). The aggregate splits into
+     * PARTIAL + ER + FINAL. FINAL emits {@code COORDINATOR+SINGLETON}, which the windowed
+     * Project's cost gate accepts without a second ER. Mirrors the PPL pattern
+     * {@code stats sum(size) by status | eventstats sum(total)}.
+     */
+    public void testSumOverAfterAggregate_2shard() {
+        LogicalAggregate agg = makeAggregate(stubScan(mockTable("test_index", "status", "size")), sumCall());
+        RexBuilder rb = agg.getCluster().getRexBuilder();
+        RexNode over = makeOver(
+            rb,
+            agg,
+            SqlStdOperatorTable.SUM,
+            List.of(rb.makeInputRef(agg, 1)),
+            SqlTypeName.BIGINT,
+            RexWindowBounds.UNBOUNDED_PRECEDING,
+            RexWindowBounds.UNBOUNDED_FOLLOWING
+        );
+        RelNode plan = LogicalProject.create(
+            agg,
+            List.of(),
+            List.of(rb.makeInputRef(agg, 0), rb.makeInputRef(agg, 1), over),
+            List.of("status", "total_size", "grand_total")
+        );
+        assertPlanShape("""
+            LogicalProject(status=[$0], total_size=[$1], grand_total=[SUM($1) OVER ()])
+              LogicalAggregate(group=[{0}], total_size=[SUM($1)])
+                StubTableScan(table=[[test_index]])
+            """, plan);
+        RelNode result = runPlanner(plan, multiShardContext());
+        assertPlanShape(
+            """
+                OpenSearchProject(status=[$0], total_size=[$1], grand_total=[SUM($1) OVER ()], viableBackends=[[mock-parquet]])
+                  OpenSearchAggregate(group=[{0}], total_size=[SUM(AGG_CALL_ANNOTATION(id=0, viableBackends=[mock-parquet]), $1)], mode=[FINAL], viableBackends=[[mock-parquet]])
+                    OpenSearchExchangeReducer(viableBackends=[[mock-parquet]], exchange=[ExchangeInfo[distributionType=SINGLETON, partitionKeyIndices=[]]])
+                      OpenSearchAggregate(group=[{0}], total_size=[SUM(AGG_CALL_ANNOTATION(id=0, viableBackends=[mock-parquet]), $1)], mode=[PARTIAL], viableBackends=[[mock-parquet]])
+                        OpenSearchTableScan(table=[[test_index]], viableBackends=[[mock-parquet]])
+                """,
+            result
+        );
+    }
+
+    /**
+     * Sort placed after a windowed Project: {@code Sort(Project(scan, SUM($1) OVER ()))}.
+     * The Project's RexOver cost gate forces an ER below the Project; Sort is collated and
+     * doesn't add a second gather because its input is already SINGLETON.
+     */
+    public void testWindowThenSort_2shard() {
+        RelOptTable table = mockTable("test_index", "status", "size");
+        RelNode scan = stubScan(table);
+        RexBuilder rb = scan.getCluster().getRexBuilder();
+        RexNode sumOver = makeOver(
+            rb,
+            scan,
+            SqlStdOperatorTable.SUM,
+            List.of(rb.makeInputRef(scan, 1)),
+            SqlTypeName.BIGINT,
+            RexWindowBounds.UNBOUNDED_PRECEDING,
+            RexWindowBounds.UNBOUNDED_FOLLOWING
+        );
+        RelNode project = LogicalProject.create(
+            scan,
+            List.of(),
+            List.of(rb.makeInputRef(scan, 0), rb.makeInputRef(scan, 1), sumOver),
+            List.of("status", "size", "s")
+        );
+        RelNode plan = LogicalSort.create(
+            project,
+            RelCollations.of(new RelFieldCollation(0, RelFieldCollation.Direction.ASCENDING)),
+            null,
+            null
+        );
+        assertPlanShape("""
+            LogicalSort(sort0=[$0], dir0=[ASC])
+              LogicalProject(status=[$0], size=[$1], s=[SUM($1) OVER ()])
+                StubTableScan(table=[[test_index]])
+            """, plan);
+        RelNode result = runPlanner(plan, multiShardContext());
+        assertPlanShape(
+            """
+                OpenSearchSort(sort0=[$0], dir0=[ASC], viableBackends=[[mock-parquet]])
+                  OpenSearchProject(status=[$0], size=[$1], s=[SUM($1) OVER ()], viableBackends=[[mock-parquet]])
+                    OpenSearchExchangeReducer(viableBackends=[[mock-parquet]], exchange=[ExchangeInfo[distributionType=SINGLETON, partitionKeyIndices=[]]])
+                      OpenSearchTableScan(table=[[test_index]], viableBackends=[[mock-parquet]])
+                """,
+            result
+        );
+    }
+
+    /**
+     * Window after a Union: {@code Project(SUM(col) OVER ())} over a Union of two scans.
+     * Each Union arm gathers to COORDINATOR via the Union split rule; the Union itself is at
+     * COORDINATOR+SINGLETON, which satisfies the windowed Project's cost gate without an
+     * extra ER. Mirrors PPL {@code source=t | stats count() as c | append [ source=t | stats count() ] | eventstats sum(c)}.
+     */
+    public void testWindowAfterUnion_2shard() {
+        RelNode leftScan = stubScan(mockTable("test_index", "status", "size"));
+        RelNode rightScan = stubScan(mockTable("test_index", "status", "size"));
+        RelNode union = LogicalUnion.create(List.of(leftScan, rightScan), /* all */ true);
+        RexBuilder rb = union.getCluster().getRexBuilder();
+        RexNode sumOver = makeOver(
+            rb,
+            union,
+            SqlStdOperatorTable.SUM,
+            List.of(rb.makeInputRef(union, 1)),
+            SqlTypeName.BIGINT,
+            RexWindowBounds.UNBOUNDED_PRECEDING,
+            RexWindowBounds.UNBOUNDED_FOLLOWING
+        );
+        RelNode plan = LogicalProject.create(
+            union,
+            List.of(),
+            List.of(rb.makeInputRef(union, 0), rb.makeInputRef(union, 1), sumOver),
+            List.of("status", "size", "s")
+        );
+        assertPlanShape("""
+            LogicalProject(status=[$0], size=[$1], s=[SUM($1) OVER ()])
+              LogicalUnion(all=[true])
+                StubTableScan(table=[[test_index]])
+                StubTableScan(table=[[test_index]])
+            """, plan);
+        RelNode result = runPlanner(plan, unionContext("test_index", 2));
+        assertPlanShape(
+            """
+                OpenSearchProject(status=[$0], size=[$1], s=[SUM($1) OVER ()], viableBackends=[[mock-parquet]])
+                  OpenSearchUnion(all=[true], viableBackends=[[mock-parquet]])
+                    OpenSearchExchangeReducer(viableBackends=[[mock-parquet]], exchange=[ExchangeInfo[distributionType=SINGLETON, partitionKeyIndices=[]]])
+                      OpenSearchTableScan(table=[[test_index]], viableBackends=[[mock-parquet]])
+                    OpenSearchExchangeReducer(viableBackends=[[mock-parquet]], exchange=[ExchangeInfo[distributionType=SINGLETON, partitionKeyIndices=[]]])
+                      OpenSearchTableScan(table=[[test_index]], viableBackends=[[mock-parquet]])
+                """,
+            result
+        );
+    }
+
+    /**
+     * HAVING-like Filter sits ABOVE a windowed Project (1-shard). The Project's cost gate is
+     * satisfied by Scan's SHARD+SINGLETON, so no ER. Filter's input is already SINGLETON, so
+     * no ER above either. Filter on the windowed column ($2) is derived — viable backends
+     * narrow to {@code mock-parquet} only.
+     */
+    public void testHavingAfterWindow_1shard() {
+        RelNode plan = makeFilter(projectWithSumOverEmpty(), makeEquals(2, SqlTypeName.BIGINT, 100L));
+        assertPlanShape("""
+            LogicalFilter(condition=[=($2, 100)])
+              LogicalProject(status=[$0], size=[$1], s=[SUM($1) OVER ()])
+                StubTableScan(table=[[test_index]])
+            """, plan);
+        RelNode result = runPlanner(plan, singleShardContext());
+        assertPlanShape("""
+            OpenSearchFilter(condition=[ANNOTATED_PREDICATE(id=0, backends=[mock-parquet], =($2, 100))], viableBackends=[[mock-parquet]])
+              OpenSearchProject(status=[$0], size=[$1], s=[SUM($1) OVER ()], viableBackends=[[mock-parquet]])
+                OpenSearchTableScan(table=[[test_index]], viableBackends=[[mock-parquet]])
+            """, result);
+    }
+
+    /**
+     * HAVING-like Filter above a windowed Project (2-shard). The Project's RexOver gate forces
+     * ER below Project; Filter's input is the windowed Project (COORDINATOR+SINGLETON) and
+     * needs no ER.
+     */
+    public void testHavingAfterWindow_2shard() {
+        RelNode plan = makeFilter(projectWithSumOverEmpty(), makeEquals(2, SqlTypeName.BIGINT, 100L));
+        assertPlanShape("""
+            LogicalFilter(condition=[=($2, 100)])
+              LogicalProject(status=[$0], size=[$1], s=[SUM($1) OVER ()])
+                StubTableScan(table=[[test_index]])
+            """, plan);
+        RelNode result = runPlanner(plan, multiShardContext());
+        assertPlanShape(
+            """
+                OpenSearchFilter(condition=[ANNOTATED_PREDICATE(id=0, backends=[mock-parquet], =($2, 100))], viableBackends=[[mock-parquet]])
+                  OpenSearchProject(status=[$0], size=[$1], s=[SUM($1) OVER ()], viableBackends=[[mock-parquet]])
+                    OpenSearchExchangeReducer(viableBackends=[[mock-parquet]], exchange=[ExchangeInfo[distributionType=SINGLETON, partitionKeyIndices=[]]])
+                      OpenSearchTableScan(table=[[test_index]], viableBackends=[[mock-parquet]])
+                """,
+            result
+        );
+    }
+
+    /**
+     * GROUP BY + HAVING + window: {@code Project(SUM($1) OVER (), Filter(=$1,100, Aggregate))}.
+     * 1-shard: aggregate stays SINGLE (no split), Filter and Project layer above without ER.
+     */
+    public void testWindowAfterAggregateWithHaving_1shard() {
+        LogicalAggregate agg = makeAggregate(stubScan(mockTable("test_index", "status", "size")), sumCall());
+        RelNode filter = makeFilter(agg, makeEquals(1, SqlTypeName.INTEGER, 100));
+        RexBuilder rb = filter.getCluster().getRexBuilder();
+        RexNode over = makeOver(
+            rb,
+            filter,
+            SqlStdOperatorTable.SUM,
+            List.of(rb.makeInputRef(filter, 1)),
+            SqlTypeName.BIGINT,
+            RexWindowBounds.UNBOUNDED_PRECEDING,
+            RexWindowBounds.UNBOUNDED_FOLLOWING
+        );
+        RelNode plan = LogicalProject.create(
+            filter,
+            List.of(),
+            List.of(rb.makeInputRef(filter, 0), rb.makeInputRef(filter, 1), over),
+            List.of("status", "total_size", "grand_total")
+        );
+        assertPlanShape("""
+            LogicalProject(status=[$0], total_size=[$1], grand_total=[SUM($1) OVER ()])
+              LogicalFilter(condition=[=($1, 100)])
+                LogicalAggregate(group=[{0}], total_size=[SUM($1)])
+                  StubTableScan(table=[[test_index]])
+            """, plan);
+        RelNode result = runPlanner(plan, singleShardContext());
+        assertPlanShape(
+            """
+                OpenSearchProject(status=[$0], total_size=[$1], grand_total=[SUM($1) OVER ()], viableBackends=[[mock-parquet]])
+                  OpenSearchFilter(condition=[ANNOTATED_PREDICATE(id=1, backends=[mock-parquet], =($1, 100))], viableBackends=[[mock-parquet]])
+                    OpenSearchAggregate(group=[{0}], total_size=[SUM(AGG_CALL_ANNOTATION(id=0, viableBackends=[mock-parquet]), $1)], mode=[SINGLE], viableBackends=[[mock-parquet]])
+                      OpenSearchTableScan(table=[[test_index]], viableBackends=[[mock-parquet]])
+                """,
+            result
+        );
+    }
+
+    /**
+     * GROUP BY + HAVING + window (2-shard). Aggregate splits to PARTIAL+FINAL with one ER
+     * between. Filter sits above FINAL (already COORDINATOR+SINGLETON, no ER); windowed
+     * Project on top also needs no additional ER. Single ER total for the whole pipeline.
+     */
+    public void testWindowAfterAggregateWithHaving_2shard() {
+        LogicalAggregate agg = makeAggregate(stubScan(mockTable("test_index", "status", "size")), sumCall());
+        RelNode filter = makeFilter(agg, makeEquals(1, SqlTypeName.INTEGER, 100));
+        RexBuilder rb = filter.getCluster().getRexBuilder();
+        RexNode over = makeOver(
+            rb,
+            filter,
+            SqlStdOperatorTable.SUM,
+            List.of(rb.makeInputRef(filter, 1)),
+            SqlTypeName.BIGINT,
+            RexWindowBounds.UNBOUNDED_PRECEDING,
+            RexWindowBounds.UNBOUNDED_FOLLOWING
+        );
+        RelNode plan = LogicalProject.create(
+            filter,
+            List.of(),
+            List.of(rb.makeInputRef(filter, 0), rb.makeInputRef(filter, 1), over),
+            List.of("status", "total_size", "grand_total")
+        );
+        assertPlanShape("""
+            LogicalProject(status=[$0], total_size=[$1], grand_total=[SUM($1) OVER ()])
+              LogicalFilter(condition=[=($1, 100)])
+                LogicalAggregate(group=[{0}], total_size=[SUM($1)])
+                  StubTableScan(table=[[test_index]])
+            """, plan);
+        RelNode result = runPlanner(plan, multiShardContext());
+        assertPlanShape(
+            """
+                OpenSearchProject(status=[$0], total_size=[$1], grand_total=[SUM($1) OVER ()], viableBackends=[[mock-parquet]])
+                  OpenSearchFilter(condition=[ANNOTATED_PREDICATE(id=1, backends=[mock-parquet], =($1, 100))], viableBackends=[[mock-parquet]])
+                    OpenSearchAggregate(group=[{0}], total_size=[SUM(AGG_CALL_ANNOTATION(id=0, viableBackends=[mock-parquet]), $1)], mode=[FINAL], viableBackends=[[mock-parquet]])
+                      OpenSearchExchangeReducer(viableBackends=[[mock-parquet]], exchange=[ExchangeInfo[distributionType=SINGLETON, partitionKeyIndices=[]]])
+                        OpenSearchAggregate(group=[{0}], total_size=[SUM(AGG_CALL_ANNOTATION(id=0, viableBackends=[mock-parquet]), $1)], mode=[PARTIAL], viableBackends=[[mock-parquet]])
+                          OpenSearchTableScan(table=[[test_index]], viableBackends=[[mock-parquet]])
+                """,
+            result
+        );
+    }
+
+    /**
+     * Window above a Join (1-shard self-join). Co-location keeps Join on the shard with no
+     * per-arm ER, but unlike a windowed Project directly above a Scan, the Project's cost
+     * gate forces an ER above the Join. Documented here so future planner work — making Join
+     * propagate SHARD+SINGLETON the same way Scan does — has a regression target.
+     */
+    public void testWindowAfterJoin_1shard() {
+        RelNode join = makeSelfJoin();
+        RexBuilder rb = join.getCluster().getRexBuilder();
+        RexNode over = makeOver(
+            rb,
+            join,
+            SqlStdOperatorTable.SUM,
+            List.of(rb.makeInputRef(join, 1)),
+            SqlTypeName.BIGINT,
+            RexWindowBounds.UNBOUNDED_PRECEDING,
+            RexWindowBounds.UNBOUNDED_FOLLOWING
+        );
+        RelNode plan = LogicalProject.create(
+            join,
+            List.of(),
+            List.of(rb.makeInputRef(join, 0), rb.makeInputRef(join, 1), over),
+            List.of("status", "size", "s")
+        );
+        assertPlanShape("""
+            LogicalProject(status=[$0], size=[$1], s=[SUM($1) OVER ()])
+              LogicalJoin(condition=[=($0, $2)], joinType=[inner])
+                StubTableScan(table=[[test_index]])
+                StubTableScan(table=[[test_index]])
+            """, plan);
+        RelNode result = runPlanner(plan, perIndexContext(Map.of("test_index", 1)));
+        assertPlanShape(
+            """
+                OpenSearchProject(status=[$0], size=[$1], s=[SUM($1) OVER ()], viableBackends=[[mock-parquet]])
+                  OpenSearchExchangeReducer(viableBackends=[[mock-parquet]], exchange=[ExchangeInfo[distributionType=SINGLETON, partitionKeyIndices=[]]])
+                    OpenSearchJoin(condition=[=($0, $2)], joinType=[inner], viableBackends=[[mock-parquet]])
+                      OpenSearchTableScan(table=[[test_index]], viableBackends=[[mock-parquet]])
+                      OpenSearchTableScan(table=[[test_index]], viableBackends=[[mock-parquet]])
+                """,
+            result
+        );
+    }
+
+    /**
+     * Window above a Join (2-shard different tables). Each Join arm needs SINGLETON, so per-arm
+     * ER. Join emits COORDINATOR+SINGLETON which satisfies the windowed Project's cost gate —
+     * no second ER above Join.
+     */
+    public void testWindowAfterJoin_2shard() {
+        RelNode join = makeDifferentTablesJoin();
+        RexBuilder rb = join.getCluster().getRexBuilder();
+        RexNode over = makeOver(
+            rb,
+            join,
+            SqlStdOperatorTable.SUM,
+            List.of(rb.makeInputRef(join, 1)),
+            SqlTypeName.BIGINT,
+            RexWindowBounds.UNBOUNDED_PRECEDING,
+            RexWindowBounds.UNBOUNDED_FOLLOWING
+        );
+        RelNode plan = LogicalProject.create(
+            join,
+            List.of(),
+            List.of(rb.makeInputRef(join, 0), rb.makeInputRef(join, 1), over),
+            List.of("status", "size", "s")
+        );
+        assertPlanShape("""
+            LogicalProject(status=[$0], size=[$1], s=[SUM($1) OVER ()])
+              LogicalJoin(condition=[=($0, $2)], joinType=[inner])
+                StubTableScan(table=[[left_idx]])
+                StubTableScan(table=[[right_idx]])
+            """, plan);
+        RelNode result = runPlanner(plan, perIndexContext(Map.of("left_idx", 2, "right_idx", 2)));
+        assertPlanShape(
+            """
+                OpenSearchProject(status=[$0], size=[$1], s=[SUM($1) OVER ()], viableBackends=[[mock-parquet]])
+                  OpenSearchJoin(condition=[=($0, $2)], joinType=[inner], viableBackends=[[mock-parquet]])
+                    OpenSearchExchangeReducer(viableBackends=[[mock-parquet]], exchange=[ExchangeInfo[distributionType=SINGLETON, partitionKeyIndices=[]]])
+                      OpenSearchTableScan(table=[[left_idx]], viableBackends=[[mock-parquet]])
+                    OpenSearchExchangeReducer(viableBackends=[[mock-parquet]], exchange=[ExchangeInfo[distributionType=SINGLETON, partitionKeyIndices=[]]])
+                      OpenSearchTableScan(table=[[right_idx]], viableBackends=[[mock-parquet]])
+                """,
+            result
+        );
+    }
+
+    /**
+     * Aggregate stacked on top of a windowed Project (1-shard). The Project's cost gate accepts
+     * SHARD+SINGLETON Scan; the follow-on Aggregate stays SINGLE (input is already SINGLETON).
+     * Verifies an Aggregate atop a window doesn't re-split into PARTIAL+FINAL.
+     */
+    public void testAggregateAfterWindow_1shard() {
+        RelNode windowedProject = projectWithSumOverEmpty();
+        AggregateCallOnWindowedProject helper = aggCallOver(windowedProject, /* sumFieldIndex */ 1, "total_size");
+        RelNode plan = makeAggregate(windowedProject, helper.aggCall);
+        assertPlanShape("""
+            LogicalAggregate(group=[{0}], total_size=[SUM($1)])
+              LogicalProject(status=[$0], size=[$1], s=[SUM($1) OVER ()])
+                StubTableScan(table=[[test_index]])
+            """, plan);
+        RelNode result = runPlanner(plan, singleShardContext());
+        assertPlanShape(
+            """
+                OpenSearchAggregate(group=[{0}], total_size=[SUM(AGG_CALL_ANNOTATION(id=0, viableBackends=[mock-parquet]), $1)], mode=[SINGLE], viableBackends=[[mock-parquet]])
+                  OpenSearchProject(status=[$0], size=[$1], s=[SUM($1) OVER ()], viableBackends=[[mock-parquet]])
+                    OpenSearchTableScan(table=[[test_index]], viableBackends=[[mock-parquet]])
+                """,
+            result
+        );
+    }
+
+    /**
+     * Aggregate stacked on top of a windowed Project (2-shard). The Project's cost gate forces
+     * an ER below the Project; output is COORDINATOR+SINGLETON. The Aggregate sees an
+     * already-gathered input and stays SINGLE — split rule skips because the child is
+     * already SINGLETON, so we get one ER for the whole pipeline instead of a redundant
+     * PARTIAL+FINAL pair.
+     */
+    public void testAggregateAfterWindow_2shard() {
+        RelNode windowedProject = projectWithSumOverEmpty();
+        AggregateCallOnWindowedProject helper = aggCallOver(windowedProject, /* sumFieldIndex */ 1, "total_size");
+        RelNode plan = makeAggregate(windowedProject, helper.aggCall);
+        assertPlanShape("""
+            LogicalAggregate(group=[{0}], total_size=[SUM($1)])
+              LogicalProject(status=[$0], size=[$1], s=[SUM($1) OVER ()])
+                StubTableScan(table=[[test_index]])
+            """, plan);
+        RelNode result = runPlanner(plan, multiShardContext());
+        assertPlanShape(
+            """
+                OpenSearchAggregate(group=[{0}], total_size=[SUM(AGG_CALL_ANNOTATION(id=0, viableBackends=[mock-parquet]), $1)], mode=[SINGLE], viableBackends=[[mock-parquet]])
+                  OpenSearchProject(status=[$0], size=[$1], s=[SUM($1) OVER ()], viableBackends=[[mock-parquet]])
+                    OpenSearchExchangeReducer(viableBackends=[[mock-parquet]], exchange=[ExchangeInfo[distributionType=SINGLETON, partitionKeyIndices=[]]])
+                      OpenSearchTableScan(table=[[test_index]], viableBackends=[[mock-parquet]])
+                """,
+            result
+        );
+    }
+
+    /**
+     * OVER (PARTITION BY ...) is rejected at marking time — no shuffle exchange yet.
+     */
+    public void testRexOverPartitionBy_rejected() {
+        RelOptTable table = mockTable("test_index", "status", "size");
+        RelNode scan = stubScan(table);
+        RexBuilder rb = scan.getCluster().getRexBuilder();
+
+        RexNode over = rb.makeOver(
+            typeFactory.createSqlType(SqlTypeName.BIGINT),
+            (SqlAggFunction) SqlStdOperatorTable.SUM,
+            List.of(rb.makeInputRef(scan, 1)),
+            ImmutableList.of(rb.makeInputRef(scan, 0)),    // PARTITION BY status
+            ImmutableList.of(),
+            RexWindowBounds.UNBOUNDED_PRECEDING,
+            RexWindowBounds.UNBOUNDED_FOLLOWING,
+            true,
+            true,
+            false,
+            false,
+            false
+        );
+        RelNode plan = LogicalProject.create(
+            scan,
+            List.of(),
+            List.of(rb.makeInputRef(scan, 0), rb.makeInputRef(scan, 1), over),
+            List.of("status", "size", "s")
+        );
+        try {
+            runPlanner(plan, multiShardContext());
+            fail("Expected planner to reject PARTITION BY");
+        } catch (RuntimeException expected) {
+            // OK — rule rejected the RexOver.
+        }
+    }
+
+    // ── Builders ──────────────────────────────────────────────────────────
+
+    private RelNode projectWithCountOverEmpty() {
+        return buildProjectWithOver(SqlStdOperatorTable.COUNT, List.of(), "cnt", SqlTypeName.BIGINT);
+    }
+
+    private RelNode projectWithSumOverEmpty() {
+        RelOptTable table = mockTable("test_index", "status", "size");
+        RelNode scan = stubScan(table);
+        return projectWithSumOverEmpty(scan);
+    }
+
+    /** Same as {@link #projectWithSumOverEmpty()} but stacked on a caller-supplied input
+     *  (Filter, Sort, etc.). Input must have at least 2 fields ($0 status, $1 size). */
+    private RelNode projectWithSumOverEmpty(RelNode input) {
+        RexBuilder rb = input.getCluster().getRexBuilder();
+        RexNode over = makeOver(
+            rb,
+            input,
+            SqlStdOperatorTable.SUM,
+            List.of(rb.makeInputRef(input, 1)),
+            SqlTypeName.BIGINT,
+            RexWindowBounds.UNBOUNDED_PRECEDING,
+            RexWindowBounds.UNBOUNDED_FOLLOWING
+        );
+        return LogicalProject.create(
+            input,
+            List.of(),
+            List.of(rb.makeInputRef(input, 0), rb.makeInputRef(input, 1), over),
+            List.of("status", "size", "s")
+        );
+    }
+
+    /** Build a {@code RexOver} with the given function, operands, output type, and frame bounds.
+     *  Empty PARTITION BY and empty ORDER BY. */
+    private RexNode makeOver(
+        RexBuilder rb,
+        RelNode scan,
+        SqlAggFunction fn,
+        List<RexNode> operands,
+        SqlTypeName outType,
+        RexWindowBound lowerBound,
+        RexWindowBound upperBound
+    ) {
+        return rb.makeOver(
+            typeFactory.createSqlType(outType),
+            fn,
+            operands,
+            ImmutableList.of(),
+            ImmutableList.of(),
+            lowerBound,
+            upperBound,
+            true,
+            true,
+            false,
+            false,
+            false
+        );
+    }
+
+    /** Self-join on test_index — used by {@link #testWindowAfterJoin_1shard} for the
+     *  co-location fast path on 1-shard. */
+    private RelNode makeSelfJoin() {
+        RelOptTable left = mockTable("test_index", "status", "size");
+        RelOptTable right = mockTable("test_index", "status", "size");
+        RexNode cond = rexBuilder.makeCall(
+            SqlStdOperatorTable.EQUALS,
+            rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.INTEGER), 0),
+            rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.INTEGER), 2)
+        );
+        return LogicalJoin.create(stubScan(left), stubScan(right), List.of(), cond, java.util.Set.<CorrelationId>of(), JoinRelType.INNER);
+    }
+
+    /** Different-tables equi-join — used by {@link #testWindowAfterJoin_2shard} so the
+     *  co-location predicate fails and per-arm ER kicks in. */
+    private RelNode makeDifferentTablesJoin() {
+        RelOptTable left = mockTable("left_idx", "status", "size");
+        RelOptTable right = mockTable("right_idx", "status", "size");
+        RexNode cond = rexBuilder.makeCall(
+            SqlStdOperatorTable.EQUALS,
+            rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.INTEGER), 0),
+            rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.INTEGER), 2)
+        );
+        return LogicalJoin.create(stubScan(left), stubScan(right), List.of(), cond, java.util.Set.<CorrelationId>of(), JoinRelType.INNER);
+    }
+
+    /** Holder for the AggregateCall used by {@link #testAggregateAfterWindow_1shard}/_2shard. */
+    private record AggregateCallOnWindowedProject(org.apache.calcite.rel.core.AggregateCall aggCall) {
+    }
+
+    private AggregateCallOnWindowedProject aggCallOver(RelNode input, int sumFieldIndex, String alias) {
+        org.apache.calcite.rel.core.AggregateCall call = org.apache.calcite.rel.core.AggregateCall.create(
+            SqlStdOperatorTable.SUM,
+            false,
+            List.of(sumFieldIndex),
+            -1,
+            input,
+            typeFactory.createSqlType(SqlTypeName.INTEGER),
+            alias
+        );
+        return new AggregateCallOnWindowedProject(call);
+    }
+
+    /** Multi-shard context whose only DF backend declares {@link EngineCapability#UNION},
+     *  so the Union marker rule accepts the Union shape. */
+    private PlannerContext unionContext(String indexName, int shardCount) {
+        return buildContextPerIndex("parquet", Map.of(indexName, shardCount), intFields(), List.of(new UnionCapableBackend(), LUCENE));
+    }
+
+    /** Mock DF backend with EngineCapability.UNION — needed because UNION is opt-in. */
+    private static final class UnionCapableBackend extends MockDataFusionBackend {
+        @Override
+        protected Set<EngineCapability> supportedEngineCapabilities() {
+            Set<EngineCapability> caps = new HashSet<>(super.supportedEngineCapabilities());
+            caps.add(EngineCapability.UNION);
+            return caps;
+        }
+    }
+
+    /**
+     * Build a LogicalProject that passes through every scan column and adds one RexOver
+     * (empty OVER clause) as the final projected expression.
+     */
+    private RelNode buildProjectWithOver(SqlAggFunction fn, List<RexNode> operands, String outName, SqlTypeName outType) {
+        RelOptTable table = mockTable("test_index", "status", "size");
+        RelNode scan = stubScan(table);
+        RexBuilder rb = scan.getCluster().getRexBuilder();
+
+        RexNode over = rb.makeOver(
+            typeFactory.createSqlType(outType),
+            fn,
+            operands,
+            ImmutableList.of(),
+            ImmutableList.of(),
+            RexWindowBounds.UNBOUNDED_PRECEDING,
+            RexWindowBounds.UNBOUNDED_FOLLOWING,
+            true,
+            true,
+            false,
+            false,
+            false
+        );
+
+        return LogicalProject.create(
+            scan,
+            List.of(),
+            List.of(rb.makeInputRef(scan, 0), rb.makeInputRef(scan, 1), over),
+            List.of("status", "size", outName)
+        );
+    }
+}

--- a/sandbox/qa/analytics-engine-coordinator/build.gradle
+++ b/sandbox/qa/analytics-engine-coordinator/build.gradle
@@ -32,6 +32,10 @@ dependencies {
   // Plugin under test
   internalClusterTestImplementation project(':sandbox:plugins:analytics-engine')
 
+  // QueryPlanExecutor / OpenSearchSchemaBuilder live in analytics-api; SqlPlanRunner pulls
+  // these directly without going through analytics-engine's internal classes.
+  internalClusterTestImplementation project(':sandbox:libs:analytics-api')
+
   // Arrow Flight streaming transport — provides the streaming TransportService.
   internalClusterTestImplementation project(':plugins:arrow-flight-rpc')
 
@@ -49,7 +53,10 @@ dependencies {
   // Guava is excluded from analytics-engine's runtime classpath (provided by
   // arrow-flight-rpc at runtime in production). The classpath-plugin test
   // launcher doesn't hydrate the extended-plugin classloader, so Guava must
-  // be on the test runtime classpath here.
+  // be on the test runtime classpath here. Calcite's FrameworkConfig also
+  // references ImmutableList in its compile-time API (SqlPlanRunner imports
+  // it), so include Guava on the IT compile classpath too.
+  internalClusterTestCompileOnly "com.google.guava:guava:33.3.1-jre"
   internalClusterTestRuntimeOnly "com.google.guava:guava:33.3.1-jre"
   internalClusterTestRuntimeOnly "com.google.guava:failureaccess:1.0.1"
 }
@@ -71,6 +78,11 @@ def guavaRuntimeJars = configurations.detachedConfiguration(
   dependencies.create("com.fasterxml.jackson.core:jackson-annotations:${versions.jackson_annotations}") { transitive = false }
 )
 sourceSets.internalClusterTest.runtimeClasspath += guavaRuntimeJars
+// SqlPlanRunner references org.apache.calcite.tools.FrameworkConfig, whose API surface
+// has com.google.common.collect.ImmutableList in its bytecode signatures. javac needs
+// Guava on the compile classpath to read those signatures even though no Guava type
+// appears in the harness source.
+sourceSets.internalClusterTest.compileClasspath += guavaRuntimeJars
 
 configurations.all {
   // okhttp-aws-signer is a transitive of unified-query-common, only published on JitPack.

--- a/sandbox/qa/analytics-engine-coordinator/src/internalClusterTest/java/org/opensearch/analytics/sql/SqlPlanRunner.java
+++ b/sandbox/qa/analytics-engine-coordinator/src/internalClusterTest/java/org/opensearch/analytics/sql/SqlPlanRunner.java
@@ -1,0 +1,123 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.sql;
+
+import org.apache.calcite.config.CalciteConnectionConfig;
+import org.apache.calcite.config.CalciteConnectionConfigImpl;
+import org.apache.calcite.config.CalciteConnectionProperty;
+import org.apache.calcite.plan.Context;
+import org.apache.calcite.plan.Contexts;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.RelRoot;
+import org.apache.calcite.schema.SchemaPlus;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.parser.SqlParser;
+import org.apache.calcite.tools.FrameworkConfig;
+import org.apache.calcite.tools.Frameworks;
+import org.apache.calcite.tools.Planner;
+import org.apache.calcite.tools.RelBuilder;
+import org.opensearch.action.support.PlainActionFuture;
+import org.opensearch.analytics.exec.QueryPlanExecutor;
+import org.opensearch.analytics.schema.OpenSearchSchemaBuilder;
+import org.opensearch.cluster.service.ClusterService;
+
+import java.util.ArrayList;
+import java.util.Properties;
+
+/**
+ * Reusable test harness that turns a query into a {@code RelNode} and hands it to a
+ * {@link QueryPlanExecutor} for execution. Two entry points:
+ * <ul>
+ *   <li>{@link #executeSql(String)} — parse + validate + execute, for shapes that the
+ *       Calcite SQL parser produces cleanly.</li>
+ *   <li>{@link #executeRel(RelNode)} with {@link #relBuilder()} — execute a pre-built
+ *       {@code RelNode}. Use this when the SQL parser's lowering of a feature differs
+ *       from what the engine wants (e.g. {@code SUM(...) OVER ()} wrapped in a CASE for
+ *       SQL NULL-on-empty semantics).</li>
+ * </ul>
+ *
+ * <p>Schema is built fresh on each call from {@link ClusterService}'s current state via
+ * {@link OpenSearchSchemaBuilder}. Operator table is the Calcite standard table.
+ *
+ * <p>Synchronous by design — execute methods block on a {@link PlainActionFuture} so tests
+ * can assert on results directly. The executor forks to its own SEARCH executor internally,
+ * so blocking the calling thread is safe.
+ *
+ * @opensearch.internal
+ */
+public final class SqlPlanRunner {
+
+    private final ClusterService clusterService;
+    private final QueryPlanExecutor<RelNode, Iterable<Object[]>> planExecutor;
+
+    public SqlPlanRunner(ClusterService clusterService, QueryPlanExecutor<RelNode, Iterable<Object[]>> planExecutor) {
+        this.clusterService = clusterService;
+        this.planExecutor = planExecutor;
+    }
+
+    /**
+     * Parses, validates, and converts {@code sql} to a {@code RelNode}, then submits it to
+     * the executor and returns the materialised rows.
+     */
+    public java.util.List<Object[]> executeSql(String sql) {
+        return executeRel(parseToRel(sql));
+    }
+
+    /** Executes a pre-built {@code RelNode} and returns the materialised rows. Useful when
+     *  the SQL parser's lowering of a feature (e.g. {@code SUM(...) OVER ()} with its
+     *  CASE-wrap for SQL NULL-on-empty semantics) differs from the shape the engine wants —
+     *  tests can construct the {@code RelNode} directly via {@link #relBuilder()}. */
+    public java.util.List<Object[]> executeRel(RelNode plan) {
+        PlainActionFuture<Iterable<Object[]>> future = new PlainActionFuture<>();
+        planExecutor.execute(plan, null, future);
+        Iterable<Object[]> rows = future.actionGet();
+        java.util.List<Object[]> out = new ArrayList<>();
+        for (Object[] row : rows) {
+            out.add(row);
+        }
+        return out;
+    }
+
+    /** Returns a Calcite {@link RelBuilder} backed by the current cluster schema, for tests
+     *  that construct RelNodes programmatically rather than parsing SQL. */
+    public RelBuilder relBuilder() {
+        return RelBuilder.create(frameworkConfig());
+    }
+
+    private FrameworkConfig frameworkConfig() {
+        SchemaPlus rootSchema = OpenSearchSchemaBuilder.buildSchema(clusterService.state());
+        Properties properties = new Properties();
+        properties.setProperty(CalciteConnectionProperty.CASE_SENSITIVE.camelName(), "false");
+        properties.setProperty(CalciteConnectionProperty.UNQUOTED_CASING.camelName(), "UNCHANGED");
+        CalciteConnectionConfig connectionConfig = new CalciteConnectionConfigImpl(properties);
+        Context plannerContext = Contexts.of(connectionConfig);
+        return Frameworks.newConfigBuilder()
+            .parserConfig(SqlParser.config().withCaseSensitive(false))
+            .defaultSchema(rootSchema)
+            .operatorTable(SqlStdOperatorTable.instance())
+            .context(plannerContext)
+            .build();
+    }
+
+    /** Parses + validates + converts {@code sql} into a {@code RelNode} without executing it. */
+    public RelNode parseToRel(String sql) {
+        Planner planner = Frameworks.getPlanner(frameworkConfig());
+        try {
+            SqlNode parsed = planner.parse(sql);
+            SqlNode validated = planner.validate(parsed);
+            RelRoot root = planner.rel(validated);
+            return root.project();
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to plan SQL: [" + sql + "]", e);
+        } finally {
+            planner.close();
+        }
+    }
+}

--- a/sandbox/qa/analytics-engine-coordinator/src/internalClusterTest/java/org/opensearch/analytics/sql/WindowSqlIT.java
+++ b/sandbox/qa/analytics-engine-coordinator/src/internalClusterTest/java/org/opensearch/analytics/sql/WindowSqlIT.java
@@ -1,0 +1,190 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.sql;
+
+import com.google.common.collect.ImmutableList;
+
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexFieldCollation;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexWindowBounds;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.tools.RelBuilder;
+import org.opensearch.Version;
+import org.opensearch.action.admin.indices.create.CreateIndexResponse;
+import org.opensearch.analytics.AnalyticsPlugin;
+import org.opensearch.analytics.exec.DefaultPlanExecutor;
+import org.opensearch.arrow.flight.transport.FlightStreamPlugin;
+import org.opensearch.be.datafusion.DataFusionPlugin;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.FeatureFlags;
+import org.opensearch.composite.CompositeDataFormatPlugin;
+import org.opensearch.index.engine.dataformat.stub.MockCommitterEnginePlugin;
+import org.opensearch.parquet.ParquetDataFormatPlugin;
+import org.opensearch.plugins.Plugin;
+import org.opensearch.plugins.PluginInfo;
+import org.opensearch.test.OpenSearchIntegTestCase;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * End-to-end IT for window functions. Constructs {@code LogicalProject} carrying a
+ * {@code RexOver} programmatically via Calcite's {@link RelBuilder} — bypassing the SQL
+ * parser, which wraps {@code SUM(...) OVER ()} in a CASE expression for SQL
+ * NULL-on-empty-set semantics that DataFusion's physical planner doesn't yet support.
+ * This matches the shape PPL's {@code eventstats} produces (clean {@code SUM($0) OVER ()}
+ * with no nullability wrapper).
+ *
+ * @opensearch.internal
+ */
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.SUITE, numDataNodes = 2, numClientNodes = 0)
+public class WindowSqlIT extends OpenSearchIntegTestCase {
+
+    private static final String INDEX = "window_idx";
+    private static final int TOTAL_DOCS = 6;
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return List.of(FlightStreamPlugin.class, CompositeDataFormatPlugin.class, MockCommitterEnginePlugin.class);
+    }
+
+    @Override
+    protected Collection<PluginInfo> additionalNodePlugins() {
+        return List.of(
+            classpathPlugin(AnalyticsPlugin.class, Collections.emptyList()),
+            classpathPlugin(ParquetDataFormatPlugin.class, Collections.emptyList()),
+            classpathPlugin(DataFusionPlugin.class, List.of(AnalyticsPlugin.class.getName()))
+        );
+    }
+
+    private static PluginInfo classpathPlugin(Class<? extends Plugin> pluginClass, List<String> extendedPlugins) {
+        return new PluginInfo(
+            pluginClass.getName(),
+            "classpath plugin",
+            "NA",
+            Version.CURRENT,
+            "1.8",
+            pluginClass.getName(),
+            null,
+            extendedPlugins,
+            false
+        );
+    }
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return Settings.builder()
+            .put(super.nodeSettings(nodeOrdinal))
+            .put(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG, true)
+            .put(FeatureFlags.STREAM_TRANSPORT, true)
+            .build();
+    }
+
+    /** {@code SUM(val) OVER ()} — unframed grand total over a 2-shard index. RexOver in the
+     *  Project triggers the cost gate so the planner inserts a gather; the window evaluates
+     *  against the assembled stream. With val ∈ {1,2,3,1,2,3} the per-row total is 12,
+     *  repeated on every output row. */
+    public void testSumOver_unframed_2shard() {
+        createAndSeedIndex(2);
+        SqlPlanRunner runner = sqlPlanRunner();
+        RelNode plan = buildWindowedProject(runner, SqlStdOperatorTable.SUM, SqlTypeName.BIGINT);
+        List<Object[]> rows = runner.executeRel(plan);
+        assertEquals("one output row per input row", TOTAL_DOCS, rows.size());
+        for (Object[] row : rows) {
+            assertEquals("SUM(val) OVER () must equal grand total 12 on every row", 12L, ((Number) row[1]).longValue());
+        }
+    }
+
+    /** {@code COUNT(val) OVER ()} — unframed count of non-null vals over a 2-shard index.
+     *  Should equal {@link #TOTAL_DOCS}. */
+    public void testCountOver_unframed_2shard() {
+        createAndSeedIndex(2);
+        SqlPlanRunner runner = sqlPlanRunner();
+        RelNode plan = buildWindowedProject(runner, SqlStdOperatorTable.COUNT, SqlTypeName.BIGINT);
+        List<Object[]> rows = runner.executeRel(plan);
+        assertEquals(TOTAL_DOCS, rows.size());
+        for (Object[] row : rows) {
+            assertEquals((long) TOTAL_DOCS, ((Number) row[1]).longValue());
+        }
+    }
+
+    /**
+     * Builds {@code LogicalProject(val=$0, agg=AGG(val) OVER ()) FROM index} via RelBuilder +
+     * {@link RexBuilder#makeOver}. {@code nullWhenCountZero=false} suppresses Calcite's
+     * SUM-empty-set CASE wrap that the SQL parser would emit — matches the shape PPL's
+     * own RelNode lowering produces.
+     */
+    private RelNode buildWindowedProject(SqlPlanRunner runner, org.apache.calcite.sql.SqlAggFunction agg, SqlTypeName outType) {
+        RelBuilder b = runner.relBuilder();
+        b.scan(INDEX);
+        RexBuilder rex = b.getRexBuilder();
+        RelDataType outRelType = b.getTypeFactory().createTypeWithNullability(b.getTypeFactory().createSqlType(outType), true);
+        RexNode valRef = rex.makeInputRef(b.peek(), 0);
+        RexNode over = rex.makeOver(
+            outRelType,
+            agg,
+            List.of(valRef),
+            List.of(),
+            ImmutableList.<RexFieldCollation>of(),
+            RexWindowBounds.UNBOUNDED_PRECEDING,
+            RexWindowBounds.UNBOUNDED_FOLLOWING,
+            false,
+            true,
+            false,
+            false,
+            false
+        );
+        b.project(b.field(0), over);
+        b.rename(List.of("val", "agg"));
+        return b.build();
+    }
+
+    // ── Infrastructure ──────────────────────────────────────────────────────
+
+    private SqlPlanRunner sqlPlanRunner() {
+        String node = internalCluster().getNodeNames()[0];
+        ClusterService clusterService = internalCluster().getInstance(ClusterService.class, node);
+        DefaultPlanExecutor executor = internalCluster().getInstance(DefaultPlanExecutor.class, node);
+        return new SqlPlanRunner(clusterService, executor);
+    }
+
+    private void createAndSeedIndex(int shardCount) {
+        Settings indexSettings = Settings.builder()
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, shardCount)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+            .put("index.pluggable.dataformat.enabled", true)
+            .put("index.pluggable.dataformat", "composite")
+            .put("index.composite.primary_data_format", "parquet")
+            .putList("index.composite.secondary_data_formats")
+            .build();
+
+        CreateIndexResponse response = client().admin()
+            .indices()
+            .prepareCreate(INDEX)
+            .setSettings(indexSettings)
+            .setMapping("val", "type=integer")
+            .get();
+        assertTrue("index creation must be acknowledged", response.isAcknowledged());
+        ensureGreen(INDEX);
+
+        for (int i = 0; i < TOTAL_DOCS; i++) {
+            int val = (i % 3) + 1;
+            client().prepareIndex(INDEX).setId(String.valueOf(i)).setSource("val", val).get();
+        }
+        client().admin().indices().prepareRefresh(INDEX).get();
+        client().admin().indices().prepareFlush(INDEX).get();
+    }
+}


### PR DESCRIPTION


<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Add window capability declaration wiring and marking integration.

Other changes:
  AggregateSplitRule now registers both a SINGLE-on-singleton
  alternative and the PARTIAL+FINAL chain — so an aggregate above a
  windowed Project stays SINGLE instead of pointlessly splitting.

  Adds 20 WindowPlanShapeTests covering window with filter/sort/agg/join/
  union/HAVING (1- and 2-shard), a SqlPlanRunner harness, and a 2-shard
  WindowSqlIT for SUM/COUNT OVER (). One known gap: windowed Project
  above a 1-shard join keeps an extra Exchange.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
