### PR TITLE
Fix flaky SimpleSearchIT.testIndexOnlyFloatField

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/search/simple/SimpleSearchIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/simple/SimpleSearchIT.java
@@ -696,11 +696,8 @@ public class SimpleSearchIT extends ParameterizedStaticSettingsOpenSearchIntegTe
         prepareCreate("idx").setMapping("field", "type=float,doc_values=false").get();
         ensureGreen("idx");
 
-        IndexRequestBuilder indexRequestBuilder = client().prepareIndex("idx");
-
-        for (float i = 9000.0F; i < 20000.0F; i++) {
-            indexRequestBuilder.setId(String.valueOf(i)).setSource("{\"field\":" + i + "}", MediaTypeRegistry.JSON).get();
-        }
+        client().prepareIndex("idx").setSource("{\"field\": 10000.0}", MediaTypeRegistry.JSON).get();
+        refresh("idx");
         String queryJson = "{ \"filter\" : { \"terms\" : { \"field\" : [ 10000.0 ] } } }";
         XContentParser parser = createParser(JsonXContent.jsonXContent, queryJson);
         parser.nextToken();


### PR DESCRIPTION
The test indexed 11k docs and searched immediately without refreshing. The fix adds a refresh and also removes the loop which is not necessary to reproduce the regression in #12432 that this test was added to verify. Instead index a single document.

Resolves #16851

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
