### PR TITLE
fix(datafusion): tighten reduce-sink drain + sender lifecycle

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/AbstractDatafusionReduceSink.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/AbstractDatafusionReduceSink.java
@@ -8,17 +8,12 @@
 
 package org.opensearch.be.datafusion;
 
-import org.apache.arrow.c.ArrowArray;
-import org.apache.arrow.c.ArrowSchema;
 import org.apache.arrow.c.CDataDictionaryProvider;
-import org.apache.arrow.c.Data;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.vector.VectorSchemaRoot;
-import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.opensearch.analytics.spi.ExchangeSink;
 import org.opensearch.analytics.spi.ExchangeSinkContext;
-import org.opensearch.be.datafusion.nativelib.NativeBridge;
 import org.opensearch.be.datafusion.nativelib.StreamHandle;
 import org.opensearch.core.action.ActionListener;
 
@@ -27,8 +22,6 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Consumer;
-
-import static org.apache.arrow.c.Data.importField;
 
 /**
  * Shared lifecycle skeleton for coordinator-side {@link ExchangeSink}s backed by a native
@@ -41,8 +34,9 @@ import static org.apache.arrow.c.Data.importField;
  *       and always closes the supplied {@link VectorSchemaRoot} in {@code finally} regardless
  *       of whether {@link #feedBatchUnderLock} succeeds.</li>
  *   <li>{@link #close} flips {@link #closed} once under {@link #feedLock}, runs the
- *       subclass-specific {@link #closeUnderLock} hook, and unconditionally closes
- *       {@link #session} in {@code finally}, accumulating any failures and rethrowing.</li>
+ *       subclass-specific {@link #closeUnderLock} hook, and rethrows any accumulated
+ *       failure. Subclasses must close {@link #session} themselves inside
+ *       {@link #closeUnderLock} (typically last, after any owned native streams).</li>
  *   <li>The downstream from {@link ExchangeSinkContext#downstream()} is intentionally NOT
  *       closed here — it accumulates drained results consumed by the walker after the
  *       sink is done.</li>
@@ -179,9 +173,9 @@ abstract class AbstractDatafusionReduceSink implements ExchangeSink {
     protected abstract void feedBatchUnderLock(VectorSchemaRoot batch);
 
     /**
-     * Subclass-specific shutdown. Runs after {@link #closed} is set and before
-     * {@link #session} is closed. Implementations should close their owned native resources
-     * (sender, output stream, accumulated FFI structs, …) and drain any pending output.
+     * Subclass-specific shutdown. Runs after {@link #closed} is set. Implementations must
+     * close all owned native resources including {@link #session} — close owned streams
+     * before the session.
      *
      * @return the first failure encountered (use {@link #accumulate(Throwable, Throwable)}
      *         when multiple steps may fail), or {@code null} on clean shutdown.
@@ -189,28 +183,20 @@ abstract class AbstractDatafusionReduceSink implements ExchangeSink {
     protected abstract Throwable closeUnderLock();
 
     /**
-     * Drains a native output stream into {@link ExchangeSinkContext#downstream()}, importing
-     * each {@link ArrowArray} into a fresh {@link VectorSchemaRoot} on the Java side.
+     * Drains a native output stream into {@link ExchangeSinkContext#downstream()},
+     * importing each native batch into a fresh {@link VectorSchemaRoot}.
+     *
+     * <p>Uses {@link DatafusionResultStream.BatchIterator} directly (instead of
+     * {@link DatafusionResultStream}) so the caller retains ownership of {@code outStream} —
+     * the iterator manages schema, dictionary provider, and per-batch allocation, but
+     * does not close the underlying stream handle.
      */
     protected final void drainOutputIntoDownstream(StreamHandle outStream) {
         BufferAllocator alloc = ctx.allocator();
         try (CDataDictionaryProvider dictProvider = new CDataDictionaryProvider()) {
-            long schemaAddr = asyncCall(listener -> NativeBridge.streamGetSchema(outStream.getPointer(), listener));
-            Schema outSchema;
-            try (ArrowSchema arrowSchema = ArrowSchema.wrap(schemaAddr)) {
-                Field structField = importField(alloc, arrowSchema, dictProvider);
-                outSchema = new Schema(structField.getChildren(), structField.getMetadata());
-            }
-            while (true) {
-                long arrayAddr = asyncCall(listener -> NativeBridge.streamNext(runtimeHandle.get(), outStream.getPointer(), listener));
-                if (arrayAddr == 0) {
-                    break;
-                }
-                VectorSchemaRoot vsr = VectorSchemaRoot.create(outSchema, alloc);
-                try (ArrowArray arrowArray = ArrowArray.wrap(arrayAddr)) {
-                    Data.importIntoVectorSchemaRoot(alloc, arrowArray, vsr, dictProvider);
-                }
-                ctx.downstream().feed(vsr);
+            DatafusionResultStream.BatchIterator it = new DatafusionResultStream.BatchIterator(outStream, alloc, dictProvider);
+            while (it.hasNext()) {
+                ctx.downstream().feed(it.next().getArrowRoot());
             }
         }
     }

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionAnalyticsBackendPlugin.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionAnalyticsBackendPlugin.java
@@ -601,7 +601,7 @@ public class DataFusionAnalyticsBackendPlugin implements AnalyticsSearchBackendP
             if ("memtable".equals(mode) && ctx.childInputs().size() == 1 && preparedState == null) {
                 return new DatafusionMemtableReduceSink(ctx, svc.getNativeRuntime());
             }
-            return new DatafusionReduceSink(ctx, svc.getNativeRuntime(), preparedState);
+            return new DatafusionReduceSink(ctx, svc.getNativeRuntime(), svc.getDrainExecutor(), preparedState);
         };
     }
 

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionService.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionService.java
@@ -21,6 +21,9 @@ import org.opensearch.common.settings.ClusterSettings;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
@@ -42,6 +45,15 @@ public class DataFusionService extends AbstractLifecycleComponent {
     private final int cpuThreads;
     private final ClusterSettings clusterSettings;
 
+    /**
+     * Virtual-thread-per-task executor used for {@link DatafusionReduceSink}'s drain
+     * loop. Drain tasks park on {@code streamNext().join()} while the native side
+     * produces the next batch; on a virtual thread the park unmounts from its carrier
+     * so concurrent queries don't consume fixed platform-pool slots for the full
+     * query lifetime.
+     */
+    private volatile ExecutorService drainExecutor;
+
     /** Handle to the native DataFusion global runtime (memory pool + cache). */
     private volatile NativeRuntimeHandle runtimeHandle;
 
@@ -62,6 +74,20 @@ public class DataFusionService extends AbstractLifecycleComponent {
         this.clusterSettings = builder.clusterSettings;
     }
 
+    /**
+     * Returns the virtual-thread-per-task executor the coordinator-reduce sink uses for
+     * its drain loop. Tasks spawned here park on native futures; virtual threads unmount
+     * from their carriers during the park so concurrent queries don't consume fixed
+     * platform-pool slots for the query's full lifetime.
+     */
+    public Executor getDrainExecutor() {
+        ExecutorService exec = drainExecutor;
+        if (exec == null) {
+            throw new IllegalStateException("DataFusionService has not been started");
+        }
+        return exec;
+    }
+
     /** Creates a new builder. */
     public static Builder builder() {
         return new Builder();
@@ -72,6 +98,8 @@ public class DataFusionService extends AbstractLifecycleComponent {
         logger.debug("Starting DataFusion service");
         NativeBridge.initTokioRuntimeManager(cpuThreads);
         logger.debug("Tokio runtime manager initialized with {} CPU threads", cpuThreads);
+
+        this.drainExecutor = Executors.newThreadPerTaskExecutor(Thread.ofVirtual().name("analytics-reduce-drain-", 0).factory());
 
         long cacheManagerPtr = 0L;
         if (clusterSettings != null) {
@@ -101,7 +129,15 @@ public class DataFusionService extends AbstractLifecycleComponent {
                     rootAllocator = null;
                 }
             } finally {
-                NativeBridge.shutdownTokioRuntimeManager();
+                try {
+                    ExecutorService exec = drainExecutor;
+                    if (exec != null) {
+                        exec.shutdown();
+                        drainExecutor = null;
+                    }
+                } finally {
+                    NativeBridge.shutdownTokioRuntimeManager();
+                }
             }
         }
         logger.debug("DataFusion service stopped");

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionMemtableReduceSink.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionMemtableReduceSink.java
@@ -154,6 +154,7 @@ public final class DatafusionMemtableReduceSink extends AbstractDatafusionReduce
             if (streamPtr != 0) {
                 NativeBridge.streamClose(streamPtr);
             }
+            session.close();
         }
         return failure;
     }

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionPartitionSender.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionPartitionSender.java
@@ -43,6 +43,7 @@ public final class DatafusionPartitionSender extends NativeHandle {
     public void close() {
         lifecycle.writeLock().lock();
         try {
+            assert lifecycle.isWriteLockedByCurrentThread() : "close must hold the write lock across super.close()";
             super.close();
         } finally {
             lifecycle.writeLock().unlock();

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionReduceSink.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionReduceSink.java
@@ -28,35 +28,33 @@ import org.opensearch.be.datafusion.nativelib.StreamHandle;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.FutureTask;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Streaming coordinator-side reduce sink: opens one native partition stream per child
- * input, pushes each fed batch through a tokio mpsc-backed sender, and on close drains
- * the native output stream into {@link ExchangeSinkContext#downstream()}.
+ * input, pushes each fed batch through a tokio mpsc-backed sender, and drains the
+ * native output stream into {@link ExchangeSinkContext#downstream()} via a task
+ * submitted to the supplied {@link Executor} at construction.
  *
  * <p>Single-input shapes register one partition under {@link AbstractDatafusionReduceSink#INPUT_ID} and accept
  * batches via the inherited {@link #feed(VectorSchemaRoot)} method. Multi-input shapes
- * (Union) register one partition per child stage and require callers to obtain a
- * per-child wrapper via {@link #sinkForChild(int)} — feeds via the bare
+ * (Union, Join) register one partition per child stage and require callers to obtain
+ * a per-child wrapper via {@link #sinkForChild(int)} — feeds via the bare
  * {@link #feed(VectorSchemaRoot)} method are rejected since the routing target is
  * ambiguous.
  *
- * <p>Overrides the base class's {@code synchronized(feedLock)} with a lock-free
- * implementation for the per-sender feed path. Multiple shard response handlers call
- * {@link #feed} concurrently; backpressure comes from the native Rust mpsc channel
- * (bounded, capacity 4). The send-after-close race is handled by catching the native
- * error when the receiver has been dropped.
+ * <p>Multiple shard response handlers call {@link #feed} concurrently; backpressure
+ * comes from the bounded native input mpsc. The drain task runs concurrently with
+ * feeds: DataFusion's plan only makes progress when its output is being polled, so
+ * without a concurrent consumer feeds wedge once the input mpsc fills.
  *
- * <p>Lifecycle:
- * <ol>
- *   <li>Constructor registers all input partition streams and kicks off native execution.</li>
- *   <li>{@link #feed} (or {@link ChildSink#feed} via {@link #sinkForChild}) exports each
- *       batch via Arrow C Data and sends it lock-free to the appropriate sender.</li>
- *   <li>{@link #close} signals EOF on every still-open sender, drains output, and releases
- *       native resources.</li>
- * </ol>
+ * <p><b>Lifecycle.</b> {@link #closeUnderLock} closes senders (signal input EOF),
+ * joins the drain task (waits for the streamNext loop to drain remaining output and
+ * exit cleanly), then closes {@link #outStream} and {@link #session}.
  */
 public final class DatafusionReduceSink extends AbstractDatafusionReduceSink implements MultiInputExchangeSink {
 
@@ -70,33 +68,31 @@ public final class DatafusionReduceSink extends AbstractDatafusionReduceSink imp
     private final StreamHandle outStream;
     /** Cumulative batches fed into any native sender. */
     private final AtomicLong feedCount = new AtomicLong();
+
     /**
-     * Background thread that drains {@link #outStream} into the downstream sink as soon
-     * as the FINAL plan emits batches — running concurrently with feeds.
-     *
-     * <p>Without this thread, the FINAL plan's downstream side is not polled until
-     * {@code close()} runs {@link #drainOutputIntoDownstream}. That polling chain is
-     * what causes DataFusion's input operators to pull from our partition stream's
-     * receiver. Without a concurrent puller, producers wedge past the input mpsc
-     * capacity (verified empirically with target_partitions=1; without RepartitionExec
-     * or this drain thread, the 2nd send_blocking parks indefinitely).
-     *
-     * <p>The thread starts polling immediately at construction. It exits naturally
-     * when the FINAL plan reaches EOF (after every {@link #sendersByChildStageId} entry
-     * has been closed and DataFusion completes the last aggregation).
+     * Future for the drain task, submitted at construction. Joined in
+     * {@link #closeUnderLock} so the streamNext loop has finished and all output
+     * batches have been fed downstream before native handles are torn down.
      */
-    private final Thread drainThread;
-    /** Captures any throwable from the drain thread for surfacing during close(). */
+    private final FutureTask<Void> drainTask;
+    /** Captures any throwable from the drain task for surfacing during close(). */
     private final AtomicReference<Throwable> drainFailure = new AtomicReference<>();
 
-    public DatafusionReduceSink(ExchangeSinkContext ctx, NativeRuntimeHandle runtimeHandle) {
-        this(ctx, runtimeHandle, null);
+    public DatafusionReduceSink(ExchangeSinkContext ctx, NativeRuntimeHandle runtimeHandle, Executor drainExecutor) {
+        this(ctx, runtimeHandle, drainExecutor, null);
     }
 
-    public DatafusionReduceSink(ExchangeSinkContext ctx, NativeRuntimeHandle runtimeHandle, DataFusionReduceState preparedState) {
+    public DatafusionReduceSink(
+        ExchangeSinkContext ctx,
+        NativeRuntimeHandle runtimeHandle,
+        Executor drainExecutor,
+        DataFusionReduceState preparedState
+    ) {
         super(ctx, runtimeHandle, preparedState);
         Map<Integer, DatafusionPartitionSender> senders = new LinkedHashMap<>(childInputs.size());
         long streamPtr = 0;
+        StreamHandle outStreamLocal = null;
+        boolean success = false;
         try {
             if (preparedState != null) {
                 // Plan was already prepared by FinalAggregateInstructionHandler. The handler
@@ -121,41 +117,43 @@ public final class DatafusionReduceSink extends AbstractDatafusionReduceSink imp
                 }
                 streamPtr = NativeBridge.executeLocalPlan(session.getPointer(), ctx.fragmentBytes());
             }
-            this.outStream = new StreamHandle(streamPtr, runtimeHandle);
-        } catch (RuntimeException e) {
-            if (streamPtr != 0) {
-                NativeBridge.streamClose(streamPtr);
-            }
-            // Only close senders we allocated locally (legacy path). When preparedState
-            // owns them, the state's close() will.
-            if (preparedState == null) {
-                for (DatafusionPartitionSender sender : senders.values()) {
-                    try {
-                        sender.close();
-                    } catch (Throwable ignore) {}
+            outStreamLocal = new StreamHandle(streamPtr, runtimeHandle);
+            success = true;
+        } finally {
+            if (!success) {
+                if (streamPtr != 0) {
+                    NativeBridge.streamClose(streamPtr);
                 }
-                session.close();
+                // Only close senders we allocated locally (legacy path). When preparedState
+                // owns them, the state's close() will.
+                if (preparedState == null) {
+                    for (DatafusionPartitionSender sender : senders.values()) {
+                        sender.close();
+                    }
+                    session.close();
+                }
             }
-            throw e;
         }
+        this.outStream = outStreamLocal;
         this.sendersByChildStageId = senders;
-        // Spawn the drain thread AFTER the native handles are constructed so the catch-block
-        // doesn't have to deal with thread teardown on construction failure.
-        this.drainThread = new Thread(this::drainLoop, "df-reduce-drain-q" + ctx.queryId() + "-s" + ctx.stageId());
-        this.drainThread.setDaemon(true);
-        this.drainThread.start();
+
+        // Submit drain AFTER native handles are constructed so the catch-block above
+        // doesn't have to handle task teardown on construction failure.
+        this.drainTask = new FutureTask<>(this::drainLoop, null);
+        drainExecutor.execute(drainTask);
     }
 
-    /**
-     * Drain loop body. Runs on {@link #drainThread} from sink construction until the
-     * FINAL plan reaches EOF (which only happens after every sender is closed).
-     */
     private void drainLoop() {
+        // The drain parks on streamNext().join() — must run on a virtual thread so
+        // the park unmounts from its carrier. On a platform thread this would hold
+        // a platform-pool slot for the whole query's lifetime, capping concurrent
+        // analytics queries at pool size.
+        assert Thread.currentThread().isVirtual() : "drain must run on a virtual thread, got " + Thread.currentThread();
         try {
             drainOutputIntoDownstream(outStream);
         } catch (Throwable t) {
             drainFailure.set(t);
-            logger.warn("[ReduceSink] drain thread terminated with error", t);
+            logger.warn("[ReduceSink] drain task terminated with error", t);
         }
     }
 
@@ -209,25 +207,35 @@ public final class DatafusionReduceSink extends AbstractDatafusionReduceSink imp
         ArrowArray array = ArrowArray.allocateNew(alloc);
         ArrowSchema arrowSchema = ArrowSchema.allocateNew(alloc);
         try {
-            Data.exportVectorSchemaRoot(alloc, batch, null, array, arrowSchema);
-        } catch (Throwable t) {
-            array.close();
-            arrowSchema.close();
-            batch.close();
-            throw t;
-        } finally {
-            batch.close();
-        }
-        try {
-            sender.send(array.memoryAddress(), arrowSchema.memoryAddress());
-            feedCount.incrementAndGet();
-        } catch (RuntimeException e) {
-            if (closed) {
-                logger.debug("[ReduceSink] send-after-close race caught, discarding batch");
-                return;
+            try {
+                Data.exportVectorSchemaRoot(alloc, batch, null, array, arrowSchema);
+            } finally {
+                batch.close();
             }
-            throw e;
+            // sender.send acquires its read lock so the native borrow outlives concurrent
+            // close — see DatafusionPartitionSender. Throws IllegalStateException via
+            // NativeHandle.getPointer() if the sender was closed (the close-race path).
+            try {
+                sender.send(array.memoryAddress(), arrowSchema.memoryAddress());
+                feedCount.incrementAndGet();
+            } catch (IllegalStateException e) {
+                // Sender close raced our send — Rust didn't take ownership, so the FFI
+                // structs' release callbacks are still set. Invoke them explicitly to free
+                // the exported buffers back to the Java allocator. (ArrowArray.close /
+                // ArrowSchema.close in the finally below frees the wrapper but does NOT
+                // invoke the C release callback.)
+                array.release();
+                arrowSchema.release();
+                if (closed) {
+                    logger.debug("[ReduceSink] send-after-close race caught, discarding batch");
+                    return;
+                }
+                throw e;
+            }
         } finally {
+            // Free the wrappers. On the success path Rust nulled the release callback,
+            // so close is a no-op for the data. On the failure path we already invoked
+            // release explicitly above.
             array.close();
             arrowSchema.close();
         }
@@ -343,10 +351,7 @@ public final class DatafusionReduceSink extends AbstractDatafusionReduceSink imp
     @Override
     protected Throwable closeUnderLock() {
         Throwable failure = null;
-        // 1. Signal EOF on every still-open sender. The drain thread, which is already
-        // polling the output stream, will receive the final batches and then EOF, then
-        // exit cleanly. Senders that were already closed by their ChildSink wrapper are
-        // no-ops (the underlying senderClose is idempotent on the Rust side).
+        // 1. Signal EOF on every sender (ChildSink may have closed some already; idempotent).
         for (DatafusionPartitionSender sender : sendersByChildStageId.values()) {
             try {
                 sender.close();
@@ -354,24 +359,28 @@ public final class DatafusionReduceSink extends AbstractDatafusionReduceSink imp
                 failure = accumulate(failure, t);
             }
         }
-        // 2. Wait for the drain thread to finish processing remaining output.
+        // 2. Wait for drain to drain remaining output and exit on EOF. drainLoop catches
+        // every Throwable internally, so get() never surfaces an ExecutionException.
         try {
-            drainThread.join();
+            drainTask.get();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             failure = accumulate(failure, e);
+        } catch (ExecutionException e) {
+            failure = accumulate(failure, e.getCause());
         }
-        // 3. Surface any error captured by the drain thread.
         Throwable drainErr = drainFailure.get();
         if (drainErr != null) {
             failure = accumulate(failure, drainErr);
         }
-        // 4. Close native resources.
+        // 3. Close native resources (outStream first, then session, per drop ordering).
         try {
             outStream.close();
         } catch (Throwable t) {
             failure = accumulate(failure, t);
         }
+        session.close();
+        assert drainTask.isDone() : "drainTask must be DONE on closeUnderLock exit (closeUnderLock must await it)";
         return failure;
     }
 

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionReduceSinkTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionReduceSinkTests.java
@@ -36,6 +36,7 @@ import org.opensearch.test.OpenSearchTestCase;
 
 import java.nio.file.Path;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
 
 import io.substrait.extension.DefaultExtensionCatalog;
 import io.substrait.extension.SimpleExtension;
@@ -83,6 +84,7 @@ public class DatafusionReduceSinkTests extends OpenSearchTestCase {
         // Wrap in NativeRuntimeHandle so the pointer is registered in the
         // NativeHandle live-set that validatePointer consults.
         NativeRuntimeHandle runtimeHandle = new NativeRuntimeHandle(runtimePtr);
+        ExecutorService drainExec = java.util.concurrent.Executors.newThreadPerTaskExecutor(Thread.ofVirtual().factory());
 
         try (RootAllocator alloc = new RootAllocator(Long.MAX_VALUE)) {
             Schema inputSchema = new Schema(List.of(new Field("x", FieldType.nullable(new ArrowType.Int(64, true)), null)));
@@ -98,7 +100,7 @@ public class DatafusionReduceSinkTests extends OpenSearchTestCase {
                 downstream
             );
 
-            DatafusionReduceSink sink = new DatafusionReduceSink(ctx, runtimeHandle);
+            DatafusionReduceSink sink = new DatafusionReduceSink(ctx, runtimeHandle, drainExec);
             try {
                 sink.feed(makeBatch(alloc, inputSchema, new long[] { 1L, 2L, 3L }));
                 sink.feed(makeBatch(alloc, inputSchema, new long[] { 4L, 5L, 6L }));
@@ -108,47 +110,27 @@ public class DatafusionReduceSinkTests extends OpenSearchTestCase {
             }
 
             // Downstream is NOT closed by the reduce sink — its lifecycle is owned by
-            // the walker/orchestrator, which reads buffered batches after the sink drains.
+            // the walker/orchestrator, which reads results after the sink drains.
             assertFalse("downstream must NOT be closed by the reduce sink", downstream.closed);
             assertTrue("downstream should receive at least one row, got " + downstream.totalRows, downstream.totalRows >= 1);
             assertEquals("SUM(1..9) should be 45", 45L, downstream.total);
         } finally {
+            drainExec.shutdownNow();
             runtimeHandle.close();
         }
     }
 
     /**
-     * Demonstrates that producers wedge past the input mpsc capacity (4) when no
-     * consumer is draining — and proves that no consumer IS draining during the
-     * feed phase, because the CPU executor's spawned task only fires on the first
-     * poll of the output stream, which only happens inside {@code close()} via
-     * {@code drainOutputIntoDownstream → streamNext}.
-     *
-     * <p>Expected log signature when this test runs:
-     * <pre>
-     *   [partition_stream] send_blocking enter — channel capacity remaining: 4
-     *   [partition_stream] send_blocking returned ok=true
-     *   [partition_stream] send_blocking enter — channel capacity remaining: 3
-     *   [partition_stream] send_blocking returned ok=true
-     *   ... 4 successful sends ...
-     *   [partition_stream] send_blocking enter — channel capacity remaining: 0
-     *   (no return — parked)
-     *   (no [cross_rt_stream] driver polled message before close — proves CPU never started)
-     *   ...test asserts producer parked at 4 feeds...
-     *   ...test calls close()...
-     *   [cross_rt_stream] driver polled for first time — submitting CPU spawn
-     *   [cross_rt_stream] CPU task started — beginning to pull from input stream
-     * </pre>
-     *
-     * <p>The logs prove: producers are blocked, CPU executor hasn't spawned yet,
-     * and the spawn only fires when close() drains. Run with
-     * {@code -Dtests.logger.level=DEBUG} to see partition_stream logs.
+     * Verifies that the drain task — submitted to the executor at sink construction —
+     * runs concurrently with feeds, so producers complete every batch even when the
+     * total volume exceeds the bounded native input mpsc's capacity.
      */
-    public void testProducersDoNotWedgePastCapacity() throws Exception {
+    public void testDrainTaskKeepsUpWithProducer() throws Exception {
         NativeBridge.initTokioRuntimeManager(2);
         Path spillDir = createTempDir("datafusion-spill");
         long runtimePtr = NativeBridge.createGlobalRuntime(64 * 1024 * 1024, 0L, spillDir.toString(), 32 * 1024 * 1024);
         NativeRuntimeHandle runtimeHandle = new NativeRuntimeHandle(runtimePtr);
+        ExecutorService drainExec = java.util.concurrent.Executors.newThreadPerTaskExecutor(Thread.ofVirtual().factory());
 
         try (RootAllocator alloc = new RootAllocator(Long.MAX_VALUE)) {
             Schema inputSchema = new Schema(List.of(new Field("x", FieldType.nullable(new ArrowType.Int(64, true)), null)));
@@ -156,7 +138,7 @@ public class DatafusionReduceSinkTests extends OpenSearchTestCase {
 
             CapturingSink downstream = new CapturingSink();
             ExchangeSinkContext ctx = new ExchangeSinkContext(
-                "q-wedge",
+                "q-drain",
                 0,
                 substrait,
                 alloc,
@@ -164,66 +146,21 @@ public class DatafusionReduceSinkTests extends OpenSearchTestCase {
                 downstream
             );
 
-            DatafusionReduceSink sink = new DatafusionReduceSink(ctx, runtimeHandle);
-
-            final int totalBatches = 12;     // intentionally > capacity (4)
-            java.util.concurrent.atomic.AtomicInteger attempts = new java.util.concurrent.atomic.AtomicInteger();
-            Thread producer = new Thread(() -> {
+            DatafusionReduceSink sink = new DatafusionReduceSink(ctx, runtimeHandle, drainExec);
+            final int totalBatches = 12; // intentionally > native input mpsc capacity
+            try {
                 for (int i = 0; i < totalBatches; i++) {
-                    attempts.incrementAndGet();
                     sink.feed(makeBatch(alloc, inputSchema, new long[] { (long) i }));
                 }
-            }, "test-producer-wedge");
-            producer.setDaemon(true);
-            producer.start();
+            } finally {
+                sink.close();
+            }
 
-            // Give the producer plenty of wall-clock time to push every batch if it weren't blocked.
-            // 4 should land in the mpsc immediately; the 5th will park indefinitely.
-            Thread.sleep(1500);
-
-            long completed = sink.feedCount();
-            int attempted = attempts.get();
-            Thread.State state = producer.getState();
-            logger.info("After 1500ms wait: completed={}, attempted={}, producerState={}", completed, attempted, state);
-
-            // Channel capacity is 1 (intentionally reduced for diagnostic clarity). If no
-            // consumer is draining concurrently with feeds, we'd expect:
-            // completed = 1 (first push lands), attempted = 2 (second push parked),
-            // state = WAITING/TIMED_WAITING.
-            // If a consumer IS draining concurrently (e.g. RepartitionExec spawned a
-            // task during DataFusion plan setup), we'd expect:
-            // completed = totalBatches, state = TERMINATED.
-            // The actual outcome tells us which mental model is correct.
-            // After Part 1 (drain thread) is in place, the drain thread polls the output
-            // stream which cascades down to our partition stream's receiver — so even
-            // without RepartitionExec (target_partitions=1), there's a concurrent consumer.
-            // EXPECTATION: completed == totalBatches, producer terminated.
-            //
-            // Without the drain thread (and without RepartitionExec), we'd see:
-            // completed == 1, attempted == 2, state in {RUNNABLE (FFI-blocked), WAITING}.
-            // Note: a Java thread blocked inside an FFI call shows up as RUNNABLE in
-            // Thread.getState() because the JVM doesn't see Rust-level parking — the
-            // thread is "running native code" from the JVM's perspective.
-            assertEquals(
-                "with the drain thread, all " + totalBatches + " feeds should complete; got " + completed,
-                totalBatches,
-                completed
-            );
-            assertEquals("producer thread should be TERMINATED after completing all feeds; got " + state, Thread.State.TERMINATED, state);
-            assertEquals("attempted should equal completed", completed, attempted);
-
-            // Cleanup: close() drops the sender, which fails the parked tx.send futures with
-            // "receiver dropped". The producer thread errors out of senderSend; the lock-free
-            // feed catches the runtime exception when closed=true. close() then drains the
-            // (now empty) output stream and tears down. Producer thread becomes joinable.
-            sink.close();
-            producer.join(5_000);
-            assertFalse("producer thread should have exited after sink.close()", producer.isAlive());
-
-            // Final accounting: feedCount reflects only the feeds that actually deposited
-            // before the parked one was unblocked-by-error. Anywhere from 4..5 inclusive.
-            logger.info("After close: feedCount={}, downstream rows={}", sink.feedCount(), downstream.totalRows);
+            assertEquals("all " + totalBatches + " feeds should have completed", totalBatches, sink.feedCount());
+            assertTrue("downstream should receive at least one row, got " + downstream.totalRows, downstream.totalRows >= 1);
+            assertEquals("SUM(0..11) should be 66", 66L, downstream.total);
         } finally {
+            drainExec.shutdownNow();
             runtimeHandle.close();
         }
     }


### PR DESCRIPTION

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Lifecycle and correctness fixes on the coordinator reduce-sink path: locked sender_close, deterministic FFI release on drain/send races, shared drain + session teardown in AbstractDatafusionReduceSink, and moves the drain off SEARCH onto a virtual-thread executor.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
