### PR TITLE
analytics-engine: planner support for LogicalValues

### DIFF
--- a/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/EngineCapability.java
+++ b/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/EngineCapability.java
@@ -21,5 +21,6 @@ package org.opensearch.analytics.spi;
  */
 public enum EngineCapability {
     SORT,
-    UNION
+    UNION,
+    VALUES
 }

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionAnalyticsBackendPlugin.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionAnalyticsBackendPlugin.java
@@ -53,7 +53,7 @@ import java.util.Set;
  */
 public class DataFusionAnalyticsBackendPlugin implements AnalyticsSearchBackendPlugin {
 
-    private static final Set<EngineCapability> ENGINE_CAPS = Set.of(EngineCapability.SORT, EngineCapability.UNION);
+    private static final Set<EngineCapability> ENGINE_CAPS = Set.of(EngineCapability.SORT, EngineCapability.UNION, EngineCapability.VALUES);
 
     private static final Set<FieldType> SUPPORTED_FIELD_TYPES = new HashSet<>();
     static {

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stage/LocalComputeStageScheduler.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stage/LocalComputeStageScheduler.java
@@ -1,0 +1,62 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.exec.stage;
+
+import org.opensearch.analytics.exec.QueryContext;
+import org.opensearch.analytics.planner.dag.Stage;
+import org.opensearch.analytics.planner.dag.StageExecutionType;
+import org.opensearch.analytics.spi.ExchangeSink;
+import org.opensearch.analytics.spi.ExchangeSinkContext;
+import org.opensearch.analytics.spi.ExchangeSinkProvider;
+
+import java.util.List;
+
+/**
+ * Builds executions for {@link StageExecutionType#LOCAL_COMPUTE} stages — fragments
+ * whose leaf is a coord-only source (today: {@code OpenSearchValues}). Runs the
+ * fragment locally on the coordinator via the backend's in-process executor.
+ *
+ * <p>The {@link ExchangeSinkContext} carries an empty {@code childInputs} list — the
+ * backend's {@code ExchangeSink} skips partition registration and goes straight to
+ * {@code executeLocalPlan + drain}. Hand the resulting sink to a
+ * {@link LocalStageExecution}, whose {@code start()} closes the backend sink and
+ * blocks until output is drained to the downstream sink (the parent stage's input
+ * partition, or the root row-producing sink).
+ *
+ * @opensearch.internal
+ */
+final class LocalComputeStageScheduler implements StageScheduler {
+
+    @Override
+    public StageExecution createExecution(Stage stage, ExchangeSink sink, QueryContext config) {
+        ExchangeSinkProvider provider = stage.getExchangeSinkProvider();
+        if (provider == null) {
+            throw new IllegalStateException(
+                "LOCAL_COMPUTE stage " + stage.getStageId() + " has no ExchangeSinkProvider — DAGBuilder must attach one"
+            );
+        }
+        ExchangeSinkContext context = new ExchangeSinkContext(
+            config.queryId(),
+            stage.getStageId(),
+            chosenBytes(stage),
+            config.bufferAllocator(),
+            List.of(),
+            sink
+        );
+        ExchangeSink backendSink = provider.createSink(context, null);
+        return new LocalStageExecution(stage, backendSink, sink);
+    }
+
+    private static byte[] chosenBytes(Stage stage) {
+        if (stage.getPlanAlternatives().isEmpty()) {
+            throw new IllegalStateException("LOCAL_COMPUTE stage " + stage.getStageId() + " has no plan alternatives");
+        }
+        return stage.getPlanAlternatives().getFirst().convertedBytes();
+    }
+}

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stage/StageExecutionBuilder.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stage/StageExecutionBuilder.java
@@ -57,6 +57,7 @@ public class StageExecutionBuilder {
         registerScheduler(StageExecutionType.SHARD_FRAGMENT, new ShardFragmentStageScheduler(clusterService, dispatcher));
         registerScheduler(StageExecutionType.COORDINATOR_REDUCE, new LocalStageScheduler());
         registerScheduler(StageExecutionType.LOCAL_PASSTHROUGH, (stage, sink, config) -> new PassThroughStageExecution(stage, sink));
+        registerScheduler(StageExecutionType.LOCAL_COMPUTE, new LocalComputeStageScheduler());
     }
 
     /**
@@ -88,7 +89,7 @@ public class StageExecutionBuilder {
      */
     public StageExecution buildExecution(Stage stage, StageExecution parentExec, QueryContext config) {
         ExchangeSink sink = switch (stage.getExecutionType()) {
-            case SHARD_FRAGMENT, COORDINATOR_REDUCE, LOCAL_PASSTHROUGH -> resolveRowSink(stage, parentExec);
+            case SHARD_FRAGMENT, COORDINATOR_REDUCE, LOCAL_PASSTHROUGH, LOCAL_COMPUTE -> resolveRowSink(stage, parentExec);
         };
         return buildStageExecution(stage, sink, config);
     }

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/PlannerImpl.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/PlannerImpl.java
@@ -40,6 +40,7 @@ import org.opensearch.analytics.planner.rules.OpenSearchSortSplitRule;
 import org.opensearch.analytics.planner.rules.OpenSearchTableScanRule;
 import org.opensearch.analytics.planner.rules.OpenSearchUnionRule;
 import org.opensearch.analytics.planner.rules.OpenSearchUnionSplitRule;
+import org.opensearch.analytics.planner.rules.OpenSearchValuesRule;
 
 import java.util.List;
 
@@ -124,7 +125,8 @@ public class PlannerImpl {
                 new OpenSearchAggregateRule(context),
                 new OpenSearchJoinRule(context),
                 new OpenSearchSortRule(context),
-                new OpenSearchUnionRule(context)
+                new OpenSearchUnionRule(context),
+                new OpenSearchValuesRule(context)
             )
         );
         HepPlanner markingPlanner = new HepPlanner(markBuilder.build());

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/RelNodeUtils.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/RelNodeUtils.java
@@ -23,6 +23,7 @@ import org.opensearch.analytics.planner.rel.OpenSearchProject;
 import org.opensearch.analytics.planner.rel.OpenSearchSort;
 import org.opensearch.analytics.planner.rel.OpenSearchTableScan;
 import org.opensearch.analytics.planner.rel.OpenSearchUnion;
+import org.opensearch.analytics.planner.rel.OpenSearchValues;
 
 import java.util.List;
 
@@ -101,6 +102,8 @@ public class RelNodeUtils {
             );
         } else if (node instanceof OpenSearchUnion union) {
             return new OpenSearchUnion(newCluster, newTraits, newInputs, union.all, union.getViableBackends());
+        } else if (node instanceof OpenSearchValues values) {
+            return new OpenSearchValues(newCluster, newTraits, values.getRowType(), values.getTuples(), values.getViableBackends());
         } else if (node instanceof OpenSearchExchangeReducer reducer) {
             return new OpenSearchExchangeReducer(
                 newCluster,

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/dag/DAGBuilder.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/dag/DAGBuilder.java
@@ -68,8 +68,7 @@ public class DAGBuilder {
         // Root needs a shard target only if its fragment actually contains a TableScan.
         // OpenSearchValues (literal-row source) and other coord-only leaves have no scan
         // and run as LOCAL_COMPUTE on the coordinator.
-        boolean needsShardResolver = childStages.isEmpty()
-            && RelNodeUtils.findNode(rootFragment, OpenSearchTableScan.class) != null;
+        boolean needsShardResolver = childStages.isEmpty() && RelNodeUtils.findNode(rootFragment, OpenSearchTableScan.class) != null;
         TargetResolver rootTargetResolver = needsShardResolver ? new ShardTargetResolver(rootFragment, clusterService) : null;
 
         Stage rootStage = new Stage(counter[0]++, rootFragment, childStages, null, sinkProvider, rootTargetResolver);

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/dag/DAGBuilder.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/dag/DAGBuilder.java
@@ -11,9 +11,12 @@ package org.opensearch.analytics.planner.dag;
 import org.apache.calcite.rel.RelNode;
 import org.opensearch.analytics.planner.CapabilityRegistry;
 import org.opensearch.analytics.planner.CapabilityResolutionUtils;
+import org.opensearch.analytics.planner.RelNodeUtils;
 import org.opensearch.analytics.planner.rel.OpenSearchExchangeReducer;
 import org.opensearch.analytics.planner.rel.OpenSearchRelNode;
 import org.opensearch.analytics.planner.rel.OpenSearchStageInputScan;
+import org.opensearch.analytics.planner.rel.OpenSearchTableScan;
+import org.opensearch.analytics.planner.rel.OpenSearchValues;
 import org.opensearch.analytics.spi.ExchangeSinkProvider;
 import org.opensearch.cluster.service.ClusterService;
 
@@ -47,8 +50,14 @@ public class DAGBuilder {
             rootFragment = sever(cboOutput, counter, childStages, registry, clusterService);
         }
 
+        // Sink provider is needed whenever the root stage runs a backend plan locally —
+        // either because it gathers child output (COORDINATOR_REDUCE) or because it's a
+        // coord-only compute leaf like LogicalValues (LOCAL_COMPUTE). Pure shard root
+        // (single-stage scan) and pure pass-through root (no children, no compute leaf)
+        // don't need a backend sink.
+        boolean hasComputeLeaf = RelNodeUtils.findNode(rootFragment, OpenSearchValues.class) != null;
         ExchangeSinkProvider sinkProvider = null;
-        if (!childStages.isEmpty()) {
+        if (!childStages.isEmpty() || hasComputeLeaf) {
             List<String> reduceViable = CapabilityResolutionUtils.filterByReduceCapability(
                 registry,
                 ((OpenSearchRelNode) cboOutput).getViableBackends()
@@ -56,7 +65,12 @@ public class DAGBuilder {
             sinkProvider = registry.getBackend(reduceViable.getFirst()).getExchangeSinkProvider();
         }
 
-        TargetResolver rootTargetResolver = childStages.isEmpty() ? new ShardTargetResolver(rootFragment, clusterService) : null;
+        // Root needs a shard target only if its fragment actually contains a TableScan.
+        // OpenSearchValues (literal-row source) and other coord-only leaves have no scan
+        // and run as LOCAL_COMPUTE on the coordinator.
+        boolean needsShardResolver = childStages.isEmpty()
+            && RelNodeUtils.findNode(rootFragment, OpenSearchTableScan.class) != null;
+        TargetResolver rootTargetResolver = needsShardResolver ? new ShardTargetResolver(rootFragment, clusterService) : null;
 
         Stage rootStage = new Stage(counter[0]++, rootFragment, childStages, null, sinkProvider, rootTargetResolver);
         return new QueryDAG(UUID.randomUUID().toString(), rootStage);

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/dag/FragmentConversionDriver.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/dag/FragmentConversionDriver.java
@@ -231,6 +231,14 @@ public class FragmentConversionDriver {
             return convertReduceFragment(resolvedFragment, convertor, delegationBytes);
         }
 
+        if (leaf instanceof org.opensearch.analytics.planner.rel.OpenSearchValues) {
+            // Coord-only literal source — convert the whole fragment via the same isthmus
+            // path as reduce fragments. isthmus emits ReadRel.VirtualTable for the Values
+            // leaf; DataFusion executes it locally without any input partitions.
+            RelNode stripped = strip(resolvedFragment, delegationBytes);
+            return convertor.convertFinalAggFragment(stripped);
+        }
+
         throw new IllegalStateException(
             "Unknown leaf type [" + leaf.getClass().getSimpleName() + "]. " + "Add a FragmentConversionStrategy for this leaf type."
         );

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/dag/Stage.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/dag/Stage.java
@@ -62,7 +62,7 @@ public class Stage {
         this.exchangeInfo = exchangeInfo;
         this.exchangeSinkProvider = exchangeSinkProvider;
         this.targetResolver = targetResolver;
-        this.executionType = setStageExecutionType(exchangeSinkProvider, targetResolver);
+        this.executionType = setStageExecutionType(exchangeSinkProvider, targetResolver, fragment);
         this.planAlternatives = List.of();
     }
 
@@ -128,13 +128,35 @@ public class Stage {
         this.instructionHandlerFactory = instructionHandlerFactory;
     }
 
-    private StageExecutionType setStageExecutionType(ExchangeSinkProvider exchangeSinkProvider, TargetResolver targetResolver) {
+    private StageExecutionType setStageExecutionType(
+        ExchangeSinkProvider exchangeSinkProvider,
+        TargetResolver targetResolver,
+        RelNode fragment
+    ) {
         if (targetResolver != null) {
             return StageExecutionType.SHARD_FRAGMENT;
+        } else if (hasComputeLeaf(fragment)) {
+            // Coord-only compute leaf (e.g. OpenSearchValues) — run the plan locally
+            // via the backend's in-process engine. Takes precedence over the
+            // sink-provider check because LOCAL_COMPUTE also requires a sink
+            // provider (DAGBuilder attaches one), but the routing differs.
+            return StageExecutionType.LOCAL_COMPUTE;
         } else if (exchangeSinkProvider != null) {
             return StageExecutionType.COORDINATOR_REDUCE;
         } else {
             return StageExecutionType.LOCAL_PASSTHROUGH;
         }
+    }
+
+    /**
+     * True iff {@code fragment} contains a coord-only compute leaf —
+     * an {@link org.opensearch.analytics.planner.rel.OpenSearchValues} today;
+     * future literal-source rels would extend this list.
+     */
+    private static boolean hasComputeLeaf(RelNode fragment) {
+        return org.opensearch.analytics.planner.RelNodeUtils.findNode(
+            fragment,
+            org.opensearch.analytics.planner.rel.OpenSearchValues.class
+        ) != null;
     }
 }

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/dag/StageExecutionType.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/dag/StageExecutionType.java
@@ -35,5 +35,12 @@ public enum StageExecutionType {
      * stages sitting above children that already produced the final rows.
      * A single-stage query that scans shards is {@link #SHARD_FRAGMENT}, not this.
      */
-    LOCAL_PASSTHROUGH
+    LOCAL_PASSTHROUGH,
+    /**
+     * Runs the fragment locally on the coordinator via the backend's in-process
+     * execution engine. No shard dispatch, no children expected. Used for
+     * literal-row sources ({@code LogicalValues}) and any future leaf operator
+     * whose data lives on the coordinator rather than on a shard.
+     */
+    LOCAL_COMPUTE
 }

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rel/OpenSearchValues.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rel/OpenSearchValues.java
@@ -1,0 +1,90 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.planner.rel;
+
+import com.google.common.collect.ImmutableList;
+
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelOptCost;
+import org.apache.calcite.plan.RelOptPlanner;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.RelWriter;
+import org.apache.calcite.rel.core.Values;
+import org.apache.calcite.rel.logical.LogicalValues;
+import org.apache.calcite.rel.metadata.RelMetadataQuery;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexLiteral;
+import org.opensearch.analytics.spi.FieldStorageInfo;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Constant-row source — emits a fixed list of literal tuples on the coordinator.
+ * Used for {@code SELECT 1+1, NOW()} and similar source-less queries; planned at
+ * {@code COORDINATOR+SINGLETON} with no shard scan and no exchange.
+ *
+ * @opensearch.internal
+ */
+public class OpenSearchValues extends Values implements OpenSearchRelNode {
+
+    private final List<String> viableBackends;
+
+    public OpenSearchValues(
+        RelOptCluster cluster,
+        RelTraitSet traitSet,
+        RelDataType rowType,
+        ImmutableList<ImmutableList<RexLiteral>> tuples,
+        List<String> viableBackends
+    ) {
+        super(cluster, rowType, tuples, traitSet);
+        this.viableBackends = viableBackends;
+    }
+
+    @Override
+    public List<String> getViableBackends() {
+        return viableBackends;
+    }
+
+    /** All output fields are derived — there's no physical storage behind a literal row. */
+    @Override
+    public List<FieldStorageInfo> getOutputFieldStorage() {
+        List<FieldStorageInfo> out = new ArrayList<>(getRowType().getFieldCount());
+        for (var field : getRowType().getFieldList()) {
+            out.add(FieldStorageInfo.derivedColumn(field.getName(), field.getType().getSqlTypeName()));
+        }
+        return out;
+    }
+
+    @Override
+    public RelNode copy(RelTraitSet traitSet, List<RelNode> inputs) {
+        return new OpenSearchValues(getCluster(), traitSet, getRowType(), getTuples(), viableBackends);
+    }
+
+    @Override
+    public RelOptCost computeSelfCost(RelOptPlanner planner, RelMetadataQuery mq) {
+        return planner.getCostFactory().makeTinyCost();
+    }
+
+    @Override
+    public RelWriter explainTerms(RelWriter pw) {
+        return super.explainTerms(pw).item("viableBackends", viableBackends);
+    }
+
+    @Override
+    public RelNode copyResolved(String backend, List<RelNode> children, List<OperatorAnnotation> resolvedAnnotations) {
+        return new OpenSearchValues(getCluster(), getTraitSet(), getRowType(), getTuples(), List.of(backend));
+    }
+
+    @Override
+    public RelNode stripAnnotations(List<RelNode> strippedChildren) {
+        return LogicalValues.create(getCluster(), getRowType(), getTuples());
+    }
+}

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rel/OpenSearchValues.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rel/OpenSearchValues.java
@@ -9,7 +9,6 @@
 package org.opensearch.analytics.planner.rel;
 
 import com.google.common.collect.ImmutableList;
-
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptCost;
 import org.apache.calcite.plan.RelOptPlanner;

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchValuesRule.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchValuesRule.java
@@ -1,0 +1,55 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.planner.rules;
+
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.core.Values;
+import org.apache.calcite.rel.logical.LogicalValues;
+import org.opensearch.analytics.planner.PlannerContext;
+import org.opensearch.analytics.planner.rel.OpenSearchConvention;
+import org.opensearch.analytics.planner.rel.OpenSearchValues;
+import org.opensearch.analytics.spi.EngineCapability;
+
+import java.util.List;
+
+/**
+ * Converts {@link LogicalValues} → {@link OpenSearchValues}. Narrows viable backends
+ * to those declaring {@link EngineCapability#VALUES} — literal-row materialisation
+ * needs the backend to honour a Substrait {@code VirtualTable} (or equivalent), so
+ * scan capability alone isn't enough.
+ *
+ * @opensearch.internal
+ */
+public class OpenSearchValuesRule extends RelOptRule {
+
+    private final PlannerContext context;
+
+    public OpenSearchValuesRule(PlannerContext context) {
+        super(operand(Values.class, none()), "OpenSearchValuesRule");
+        this.context = context;
+    }
+
+    @Override
+    public void onMatch(RelOptRuleCall call) {
+        Values values = call.rel(0);
+        if (values instanceof OpenSearchValues) {
+            return;
+        }
+        List<String> viableBackends = context.getCapabilityRegistry().operatorBackends(EngineCapability.VALUES);
+        if (viableBackends.isEmpty()) {
+            throw new IllegalStateException("No backend supports VALUES");
+        }
+        RelTraitSet traits = RelTraitSet.createEmpty()
+            .plus(OpenSearchConvention.INSTANCE)
+            .plus(context.getDistributionTraitDef().coordSingleton());
+        call.transformTo(new OpenSearchValues(values.getCluster(), traits, values.getRowType(), values.getTuples(), viableBackends));
+    }
+}

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/MockDataFusionBackend.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/MockDataFusionBackend.java
@@ -44,7 +44,7 @@ public class MockDataFusionBackend extends MockBackend implements SearchBackEndP
     public static final String PARQUET_DATA_FORMAT = "parquet";
     private static final Set<String> DATAFUSION_FORMATS = Set.of(PARQUET_DATA_FORMAT);
 
-    private static final Set<EngineCapability> OPERATOR_CAPS = Set.of(EngineCapability.SORT);
+    private static final Set<EngineCapability> OPERATOR_CAPS = Set.of(EngineCapability.SORT, EngineCapability.VALUES);
 
     private static final Set<FieldType> SUPPORTED_TYPES = new HashSet<>();
     static {

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/ValuesPlanShapeTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/ValuesPlanShapeTests.java
@@ -1,0 +1,154 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.planner;
+
+import com.google.common.collect.ImmutableList;
+
+import org.apache.calcite.plan.RelOptTable;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.CorrelationId;
+import org.apache.calcite.rel.core.JoinRelType;
+import org.apache.calcite.rel.logical.LogicalJoin;
+import org.apache.calcite.rel.logical.LogicalProject;
+import org.apache.calcite.rel.logical.LogicalUnion;
+import org.apache.calcite.rel.logical.LogicalValues;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.opensearch.analytics.spi.EngineCapability;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Plan-shape tests for {@link org.opensearch.analytics.planner.rel.OpenSearchValues}.
+ * Values is a coordinator-local literal-row source; the planner stamps it at
+ * COORDINATOR+SINGLETON so the root demand satisfies directly with no ER above it.
+ */
+public class ValuesPlanShapeTests extends PlanShapeTestBase {
+
+    /** Single literal row — the {@code SELECT 1+1, NOW()} shape after Calcite unwraps. */
+    public void testSingleRowValues() {
+        RelDataType intType = typeFactory.createSqlType(SqlTypeName.INTEGER);
+        RelDataType rowType = typeFactory.builder().add("a", intType).add("b", intType).build();
+        RexLiteral one = (RexLiteral) rexBuilder.makeLiteral(1, intType, true);
+        RexLiteral two = (RexLiteral) rexBuilder.makeLiteral(2, intType, true);
+        ImmutableList<ImmutableList<RexLiteral>> tuples = ImmutableList.of(ImmutableList.of(one, two));
+        RelNode plan = LogicalValues.create(cluster, rowType, tuples);
+        RelNode result = runPlanner(plan, singleShardContext());
+        assertPlanShape(
+            """
+                OpenSearchValues(tuples=[[{ 1, 2 }]], viableBackends=[[mock-parquet]])
+                """,
+            result
+        );
+    }
+
+    /**
+     * Values as a Union arm — the literal-row source is already at COORDINATOR+SINGLETON,
+     * so no ER is added on the Values arm; the multi-shard scan arm gathers via ER, and
+     * the Union itself runs at COORDINATOR+SINGLETON. Mirrors the SQL pattern
+     * {@code SELECT v FROM idx UNION ALL SELECT x FROM (VALUES (99))}.
+     */
+    public void testValuesAsUnionArm_2shard() {
+        RelDataType intType = typeFactory.createSqlType(SqlTypeName.INTEGER);
+        RexLiteral ninetyNine = (RexLiteral) rexBuilder.makeLiteral(99, intType, true);
+        // Values row type must match the scan's output row type for Union to type-check.
+        RelDataType valuesRowType = typeFactory.builder().add("status", intType).add("size", intType).build();
+        RexLiteral one = (RexLiteral) rexBuilder.makeLiteral(1, intType, true);
+        ImmutableList<ImmutableList<RexLiteral>> tuples = ImmutableList.of(ImmutableList.of(ninetyNine, one));
+        RelNode values = LogicalValues.create(cluster, valuesRowType, tuples);
+        RelNode scan = stubScan(mockTable("test_index", "status", "size"));
+        RelNode union = LogicalUnion.create(List.of(scan, values), /* all */ true);
+        RelNode result = runPlanner(union, unionAndValuesContext("test_index", 2));
+        assertPlanShape(
+            """
+                OpenSearchUnion(all=[true], viableBackends=[[mock-parquet]])
+                  OpenSearchExchangeReducer(viableBackends=[[mock-parquet]], exchange=[ExchangeInfo[distributionType=SINGLETON, partitionKeyIndices=[]]])
+                    OpenSearchTableScan(table=[[test_index]], viableBackends=[[mock-parquet]])
+                  OpenSearchValues(tuples=[[{ 99, 1 }]], viableBackends=[[mock-parquet]])
+                """,
+            result
+        );
+    }
+
+    /**
+     * Values as a Join arm — the literal-row source is already at COORDINATOR+SINGLETON, so
+     * no ER is added on the Values side; the multi-shard scan side gathers via ER. The Join
+     * runs at COORDINATOR+SINGLETON. Mirrors {@code SELECT i.val FROM idx i JOIN (VALUES …) v
+     * ON i.val = v.x}.
+     */
+    public void testValuesAsJoinArm_2shard() {
+        RelDataType intType = typeFactory.createSqlType(SqlTypeName.INTEGER);
+        RelOptTable scanTable = mockTable("test_index", "status", "size");
+        RelNode scan = stubScan(scanTable);
+        // Values: single int column "x" with one row; type matches scan's $0 ("status").
+        RelDataType valuesRowType = typeFactory.builder().add("x", intType).build();
+        RexLiteral one = (RexLiteral) rexBuilder.makeLiteral(1, intType, true);
+        ImmutableList<ImmutableList<RexLiteral>> tuples = ImmutableList.of(ImmutableList.of(one));
+        RelNode values = LogicalValues.create(cluster, valuesRowType, tuples);
+        // Equi-join on scan.$0 == values.$0 (which is scan-side index 2 after the join row type).
+        RexNode cond = rexBuilder.makeCall(
+            SqlStdOperatorTable.EQUALS,
+            rexBuilder.makeInputRef(intType, 0),
+            rexBuilder.makeInputRef(intType, 2)
+        );
+        RelNode join = LogicalJoin.create(scan, values, List.of(), cond, Set.<CorrelationId>of(), JoinRelType.INNER);
+        RelNode result = runPlanner(join, perIndexContext(Map.of("test_index", 2)));
+        assertPlanShape(
+            """
+                OpenSearchJoin(condition=[=($0, $2)], joinType=[inner], viableBackends=[[mock-parquet]])
+                  OpenSearchExchangeReducer(viableBackends=[[mock-parquet]], exchange=[ExchangeInfo[distributionType=SINGLETON, partitionKeyIndices=[]]])
+                    OpenSearchTableScan(table=[[test_index]], viableBackends=[[mock-parquet]])
+                  OpenSearchValues(tuples=[[{ 1 }]], viableBackends=[[mock-parquet]])
+                """,
+            result
+        );
+    }
+
+    private PlannerContext unionAndValuesContext(String indexName, int shardCount) {
+        return buildContextPerIndex("parquet", Map.of(indexName, shardCount), intFields(), List.of(new UnionAndValuesCapableBackend(), LUCENE));
+    }
+
+    /** Mock DF backend with both UNION and VALUES engine capabilities for tests that
+     *  exercise a Union over a Values arm. */
+    private static final class UnionAndValuesCapableBackend extends MockDataFusionBackend {
+        @Override
+        protected Set<EngineCapability> supportedEngineCapabilities() {
+            Set<EngineCapability> caps = new HashSet<>(super.supportedEngineCapabilities());
+            caps.add(EngineCapability.UNION);
+            return caps;
+        }
+    }
+
+    /** Values feeding a Project — confirms the rel composes cleanly downstream. */
+    public void testProjectOverValues() {
+        RelDataType intType = typeFactory.createSqlType(SqlTypeName.INTEGER);
+        RelDataType rowType = typeFactory.builder().add("a", intType).add("b", intType).build();
+        RexLiteral one = (RexLiteral) rexBuilder.makeLiteral(1, intType, true);
+        RexLiteral two = (RexLiteral) rexBuilder.makeLiteral(2, intType, true);
+        ImmutableList<ImmutableList<RexLiteral>> tuples = ImmutableList.of(ImmutableList.of(one, two));
+        RelNode values = LogicalValues.create(cluster, rowType, tuples);
+        RexNode sum = rexBuilder.makeCall(SqlStdOperatorTable.PLUS, rexBuilder.makeInputRef(values, 0), rexBuilder.makeInputRef(values, 1));
+        RelNode plan = LogicalProject.create(values, List.of(), List.of(sum), List.of("c"));
+        RelNode result = runPlanner(plan, singleShardContext());
+        assertPlanShape(
+            """
+                OpenSearchProject(c=[ANNOTATED_PROJECT_EXPR(id=0, backends=[mock-parquet], +($0, $1))], viableBackends=[[mock-parquet]])
+                  OpenSearchValues(tuples=[[{ 1, 2 }]], viableBackends=[[mock-parquet]])
+                """,
+            result
+        );
+    }
+
+}

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/ValuesPlanShapeTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/ValuesPlanShapeTests.java
@@ -9,7 +9,6 @@
 package org.opensearch.analytics.planner;
 
 import com.google.common.collect.ImmutableList;
-
 import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.CorrelationId;
@@ -46,12 +45,9 @@ public class ValuesPlanShapeTests extends PlanShapeTestBase {
         ImmutableList<ImmutableList<RexLiteral>> tuples = ImmutableList.of(ImmutableList.of(one, two));
         RelNode plan = LogicalValues.create(cluster, rowType, tuples);
         RelNode result = runPlanner(plan, singleShardContext());
-        assertPlanShape(
-            """
-                OpenSearchValues(tuples=[[{ 1, 2 }]], viableBackends=[[mock-parquet]])
-                """,
-            result
-        );
+        assertPlanShape("""
+            OpenSearchValues(tuples=[[{ 1, 2 }]], viableBackends=[[mock-parquet]])
+            """, result);
     }
 
     /**
@@ -117,7 +113,12 @@ public class ValuesPlanShapeTests extends PlanShapeTestBase {
     }
 
     private PlannerContext unionAndValuesContext(String indexName, int shardCount) {
-        return buildContextPerIndex("parquet", Map.of(indexName, shardCount), intFields(), List.of(new UnionAndValuesCapableBackend(), LUCENE));
+        return buildContextPerIndex(
+            "parquet",
+            Map.of(indexName, shardCount),
+            intFields(),
+            List.of(new UnionAndValuesCapableBackend(), LUCENE)
+        );
     }
 
     /** Mock DF backend with both UNION and VALUES engine capabilities for tests that
@@ -142,13 +143,10 @@ public class ValuesPlanShapeTests extends PlanShapeTestBase {
         RexNode sum = rexBuilder.makeCall(SqlStdOperatorTable.PLUS, rexBuilder.makeInputRef(values, 0), rexBuilder.makeInputRef(values, 1));
         RelNode plan = LogicalProject.create(values, List.of(), List.of(sum), List.of("c"));
         RelNode result = runPlanner(plan, singleShardContext());
-        assertPlanShape(
-            """
-                OpenSearchProject(c=[ANNOTATED_PROJECT_EXPR(id=0, backends=[mock-parquet], +($0, $1))], viableBackends=[[mock-parquet]])
-                  OpenSearchValues(tuples=[[{ 1, 2 }]], viableBackends=[[mock-parquet]])
-                """,
-            result
-        );
+        assertPlanShape("""
+            OpenSearchProject(c=[ANNOTATED_PROJECT_EXPR(id=0, backends=[mock-parquet], +($0, $1))], viableBackends=[[mock-parquet]])
+              OpenSearchValues(tuples=[[{ 1, 2 }]], viableBackends=[[mock-parquet]])
+            """, result);
     }
 
 }

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/dag/DAGBuilderTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/dag/DAGBuilderTests.java
@@ -9,7 +9,6 @@
 package org.opensearch.analytics.planner.dag;
 
 import com.google.common.collect.ImmutableList;
-
 import org.apache.calcite.plan.RelOptUtil;
 import org.apache.calcite.rel.RelDistribution;
 import org.apache.calcite.rel.RelNode;
@@ -143,17 +142,8 @@ public class DAGBuilderTests extends BasePlannerRulesTests {
 
         QueryDAG dag = buildDAG(2, plan);
         assertEquals("Values is leaf — no child stages", 0, dag.rootStage().getChildStages().size());
-        assertTrue(
-            "root fragment must be OpenSearchValues",
-            dag.rootStage().getFragment() instanceof OpenSearchValues
-        );
-        assertNull(
-            "no TableScan → no ShardTargetResolver",
-            dag.rootStage().getTargetResolver()
-        );
-        assertNotNull(
-            "compute leaf needs a sink provider for its local backend output",
-            dag.rootStage().getExchangeSinkProvider()
-        );
+        assertTrue("root fragment must be OpenSearchValues", dag.rootStage().getFragment() instanceof OpenSearchValues);
+        assertNull("no TableScan → no ShardTargetResolver", dag.rootStage().getTargetResolver());
+        assertNotNull("compute leaf needs a sink provider for its local backend output", dag.rootStage().getExchangeSinkProvider());
     }
 }

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/dag/DAGBuilderTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/dag/DAGBuilderTests.java
@@ -8,15 +8,22 @@
 
 package org.opensearch.analytics.planner.dag;
 
+import com.google.common.collect.ImmutableList;
+
 import org.apache.calcite.plan.RelOptUtil;
 import org.apache.calcite.rel.RelDistribution;
 import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.logical.LogicalValues;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.analytics.planner.BasePlannerRulesTests;
 import org.opensearch.analytics.planner.rel.OpenSearchExchangeReducer;
 import org.opensearch.analytics.planner.rel.OpenSearchStageInputScan;
 import org.opensearch.analytics.planner.rel.OpenSearchTableScan;
+import org.opensearch.analytics.planner.rel.OpenSearchValues;
 
 import java.util.List;
 
@@ -119,5 +126,34 @@ public class DAGBuilderTests extends BasePlannerRulesTests {
         QueryDAG dag = DAGBuilder.build(customReducer, context.getCapabilityRegistry(), mockClusterService());
         Stage child = dag.rootStage().getChildStages().get(0);
         assertEquals(customInfo, child.getExchangeInfo());
+    }
+
+    /**
+     * Literal-row source (LogicalValues / OpenSearchValues): a coordinator-local compute leaf
+     * with no TableScan in the fragment. DAGBuilder must (1) skip {@code ShardTargetResolver}
+     * attachment because there's no shard to target, and (2) still install a sink provider
+     * because the root stage executes a backend plan locally (LOCAL_COMPUTE).
+     */
+    public void testValuesRootHasNoTargetResolverButHasSink() {
+        RelDataType intType = typeFactory.createSqlType(SqlTypeName.INTEGER);
+        RelDataType rowType = typeFactory.builder().add("a", intType).build();
+        RexLiteral one = (RexLiteral) rexBuilder.makeLiteral(1, intType, true);
+        ImmutableList<ImmutableList<RexLiteral>> tuples = ImmutableList.of(ImmutableList.of(one));
+        RelNode plan = LogicalValues.create(cluster, rowType, tuples);
+
+        QueryDAG dag = buildDAG(2, plan);
+        assertEquals("Values is leaf — no child stages", 0, dag.rootStage().getChildStages().size());
+        assertTrue(
+            "root fragment must be OpenSearchValues",
+            dag.rootStage().getFragment() instanceof OpenSearchValues
+        );
+        assertNull(
+            "no TableScan → no ShardTargetResolver",
+            dag.rootStage().getTargetResolver()
+        );
+        assertNotNull(
+            "compute leaf needs a sink provider for its local backend output",
+            dag.rootStage().getExchangeSinkProvider()
+        );
     }
 }

--- a/sandbox/qa/analytics-engine-coordinator/src/internalClusterTest/java/org/opensearch/analytics/sql/ValuesSqlIT.java
+++ b/sandbox/qa/analytics-engine-coordinator/src/internalClusterTest/java/org/opensearch/analytics/sql/ValuesSqlIT.java
@@ -1,0 +1,192 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.sql;
+
+import org.opensearch.Version;
+import org.opensearch.action.admin.indices.create.CreateIndexResponse;
+import org.opensearch.analytics.AnalyticsPlugin;
+import org.opensearch.analytics.exec.DefaultPlanExecutor;
+import org.opensearch.arrow.flight.transport.FlightStreamPlugin;
+import org.opensearch.be.datafusion.DataFusionPlugin;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.FeatureFlags;
+import org.opensearch.composite.CompositeDataFormatPlugin;
+import org.opensearch.index.engine.dataformat.stub.MockCommitterEnginePlugin;
+import org.opensearch.parquet.ParquetDataFormatPlugin;
+import org.opensearch.plugins.Plugin;
+import org.opensearch.plugins.PluginInfo;
+import org.opensearch.test.OpenSearchIntegTestCase;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * End-to-end IT for {@code LogicalValues} composed with set/join operators. The Values
+ * stage runs locally on the coordinator (LOCAL_COMPUTE); these tests verify it feeds a
+ * multi-input parent (Union / Join) alongside a shard-side scan arm without extra
+ * wiring beyond the existing MultiInputExchangeSink machinery.
+ *
+ * @opensearch.internal
+ */
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.SUITE, numDataNodes = 2, numClientNodes = 0)
+public class ValuesSqlIT extends OpenSearchIntegTestCase {
+
+    private static final String INDEX = "values_idx";
+    private static final int TOTAL_DOCS = 6;
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return List.of(FlightStreamPlugin.class, CompositeDataFormatPlugin.class, MockCommitterEnginePlugin.class);
+    }
+
+    @Override
+    protected Collection<PluginInfo> additionalNodePlugins() {
+        return List.of(
+            classpathPlugin(AnalyticsPlugin.class, Collections.emptyList()),
+            classpathPlugin(ParquetDataFormatPlugin.class, Collections.emptyList()),
+            classpathPlugin(DataFusionPlugin.class, List.of(AnalyticsPlugin.class.getName()))
+        );
+    }
+
+    private static PluginInfo classpathPlugin(Class<? extends Plugin> pluginClass, List<String> extendedPlugins) {
+        return new PluginInfo(
+            pluginClass.getName(),
+            "classpath plugin",
+            "NA",
+            Version.CURRENT,
+            "1.8",
+            pluginClass.getName(),
+            null,
+            extendedPlugins,
+            false
+        );
+    }
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return Settings.builder()
+            .put(super.nodeSettings(nodeOrdinal))
+            .put(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG, true)
+            .put(FeatureFlags.STREAM_TRANSPORT, true)
+            .build();
+    }
+
+    /**
+     * Source-less {@code SELECT 1 + 1, 'x'} — Calcite lowers this to a single-row
+     * {@code LogicalValues}. With no shard scan in the fragment, DAGBuilder picks
+     * {@code LOCAL_COMPUTE}; LocalComputeStageScheduler hands the Substrait plan to
+     * DataFusion's local session with no childInputs. Exercises the pure
+     * coordinator-only execution path.
+     */
+    public void testValues_literalRow() {
+        SqlPlanRunner runner = sqlPlanRunner();
+        List<Object[]> rows = runner.executeSql("SELECT 1 + 1, 'x'");
+        assertEquals("source-less SELECT must produce a single row", 1, rows.size());
+        assertEquals(2, ((Number) rows.getFirst()[0]).intValue());
+        assertEquals("x", rows.getFirst()[1]);
+    }
+
+    /** Values as a Union arm, 1-shard scan. Scan arm and Values arm are both already at
+     *  COORDINATOR+SINGLETON (1-shard scan path doesn't need an ER), but the Values arm
+     *  still runs as LOCAL_COMPUTE on coord. */
+    public void testUnionAll_valuesArm_andScanArm_1shard() {
+        createAndSeedIndex(1);
+        assertUnionAllValuesAndScan();
+    }
+
+    /** Values as a Union arm, 2-shard scan. Scan arm gathers across 2 shards via ER;
+     *  Values arm runs as LOCAL_COMPUTE on coord. */
+    public void testUnionAll_valuesArm_andScanArm_2shard() {
+        createAndSeedIndex(2);
+        assertUnionAllValuesAndScan();
+    }
+
+    private void assertUnionAllValuesAndScan() {
+        SqlPlanRunner runner = sqlPlanRunner();
+        List<Object[]> rows = runner.executeSql(
+            "SELECT val FROM " + INDEX + " UNION ALL SELECT x FROM (VALUES (99)) AS v(x)"
+        );
+        assertEquals("UNION ALL of 6 idx rows + 1 values row must yield 7", 7, rows.size());
+        boolean foundLiteral = false;
+        for (Object[] row : rows) {
+            if (((Number) row[0]).intValue() == 99) {
+                foundLiteral = true;
+                break;
+            }
+        }
+        assertTrue("UNION result must contain the literal 99 from the Values arm", foundLiteral);
+    }
+
+    /** Values as a Join arm, 1-shard scan. */
+    public void testInnerJoin_scanWithValuesArm_1shard() {
+        createAndSeedIndex(1);
+        assertInnerJoinScanWithValues();
+    }
+
+    /** Values as a Join arm, 2-shard scan. */
+    public void testInnerJoin_scanWithValuesArm_2shard() {
+        createAndSeedIndex(2);
+        assertInnerJoinScanWithValues();
+    }
+
+    private void assertInnerJoinScanWithValues() {
+        SqlPlanRunner runner = sqlPlanRunner();
+        List<Object[]> rows = runner.executeSql(
+            "SELECT i.val FROM " + INDEX + " i JOIN (VALUES (1), (2)) AS v(x) ON i.val = v.x"
+        );
+        assertEquals("JOIN over Values must yield 4 rows (matches: 1,1,2,2)", 4, rows.size());
+        List<Integer> vals = new ArrayList<>();
+        for (Object[] row : rows) {
+            vals.add(((Number) row[0]).intValue());
+        }
+        java.util.Collections.sort(vals);
+        assertEquals("matched rows must be [1,1,2,2]", List.of(1, 1, 2, 2), vals);
+    }
+
+    // ── Test infrastructure ─────────────────────────────────────────────────
+
+    private SqlPlanRunner sqlPlanRunner() {
+        String node = internalCluster().getNodeNames()[0];
+        ClusterService clusterService = internalCluster().getInstance(ClusterService.class, node);
+        DefaultPlanExecutor executor = internalCluster().getInstance(DefaultPlanExecutor.class, node);
+        return new SqlPlanRunner(clusterService, executor);
+    }
+
+    private void createAndSeedIndex(int shardCount) {
+        Settings indexSettings = Settings.builder()
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, shardCount)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+            .put("index.pluggable.dataformat.enabled", true)
+            .put("index.pluggable.dataformat", "composite")
+            .put("index.composite.primary_data_format", "parquet")
+            .putList("index.composite.secondary_data_formats")
+            .build();
+
+        CreateIndexResponse response = client().admin()
+            .indices()
+            .prepareCreate(INDEX)
+            .setSettings(indexSettings)
+            .setMapping("val", "type=integer")
+            .get();
+        assertTrue("index creation must be acknowledged", response.isAcknowledged());
+        ensureGreen(INDEX);
+
+        // Three distinct vals, each repeated → 1, 2, 3, 1, 2, 3.
+        for (int i = 0; i < TOTAL_DOCS; i++) {
+            int val = (i % 3) + 1;
+            client().prepareIndex(INDEX).setId(String.valueOf(i)).setSource("val", val).get();
+        }
+        client().admin().indices().prepareRefresh(INDEX).get();
+        client().admin().indices().prepareFlush(INDEX).get();
+    }
+}


### PR DESCRIPTION
New OpenSearchValues rel + marker rule for literal-row sources. Stamped at COORDINATOR+SINGLETON natively so the root demand satisfies with no ER above. DAGBuilder skips ShardTargetResolver attachment when the root fragment has no TableScan — the stage drops to LOCAL_PASSTHROUGH on the coordinator.

Planner-side only; end-to-end execution still needs a coordinator-local compute executor and a frontend entry path (PPL has no source-less commands).

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
