### PR TITLE
[Backport 3.6] Update pull-based ingestion consumer factory to be stateless

### DIFF
--- a/plugins/ingestion-fs/src/main/java/org/opensearch/plugin/ingestion/fs/FileConsumerFactory.java
+++ b/plugins/ingestion-fs/src/main/java/org/opensearch/plugin/ingestion/fs/FileConsumerFactory.java
@@ -16,22 +16,15 @@ import org.opensearch.index.IngestionConsumerFactory;
  */
 public class FileConsumerFactory implements IngestionConsumerFactory<FilePartitionConsumer, FileOffset> {
 
-    private FileSourceConfig config;
-
     /**
      * Initialize a FileConsumerFactory for file-based indexing.
      */
     public FileConsumerFactory() {}
 
     @Override
-    public void initialize(IngestionSource ingestionSource) {
-        this.config = new FileSourceConfig(ingestionSource.params());
-    }
-
-    @Override
-    public FilePartitionConsumer createShardConsumer(String clientId, int shardId) {
-        assert config != null;
-        return new FilePartitionConsumer(config, shardId);
+    public FilePartitionConsumer createShardConsumer(String clientId, int shardId, IngestionSource ingestionSource) {
+        FileSourceConfig localConfig = new FileSourceConfig(ingestionSource.params());
+        return new FilePartitionConsumer(localConfig, shardId);
     }
 
     @Override

--- a/plugins/ingestion-kafka/src/main/java/org/opensearch/plugin/kafka/KafkaConsumerFactory.java
+++ b/plugins/ingestion-kafka/src/main/java/org/opensearch/plugin/kafka/KafkaConsumerFactory.java
@@ -12,14 +12,9 @@ import org.opensearch.cluster.metadata.IngestionSource;
 import org.opensearch.index.IngestionConsumerFactory;
 
 /**
- * Factory for creating Kafka consumers
+ * Factory for creating Kafka consumers.
  */
 public class KafkaConsumerFactory implements IngestionConsumerFactory<KafkaPartitionConsumer, KafkaOffset> {
-
-    /**
-     * Configuration for the Kafka source
-     */
-    protected KafkaSourceConfig config;
 
     /**
      * Constructor.
@@ -27,14 +22,9 @@ public class KafkaConsumerFactory implements IngestionConsumerFactory<KafkaParti
     public KafkaConsumerFactory() {}
 
     @Override
-    public void initialize(IngestionSource ingestionSource) {
-        config = new KafkaSourceConfig((int) ingestionSource.getMaxPollSize(), ingestionSource.params());
-    }
-
-    @Override
-    public KafkaPartitionConsumer createShardConsumer(String clientId, int shardId) {
-        assert config != null;
-        return new KafkaPartitionConsumer(clientId, config, shardId);
+    public KafkaPartitionConsumer createShardConsumer(String clientId, int shardId, IngestionSource ingestionSource) {
+        KafkaSourceConfig localConfig = new KafkaSourceConfig((int) ingestionSource.getMaxPollSize(), ingestionSource.params());
+        return new KafkaPartitionConsumer(clientId, localConfig, shardId);
     }
 
     @Override

--- a/plugins/ingestion-kafka/src/test/java/org/opensearch/plugin/kafka/KafkaConsumerFactoryTests.java
+++ b/plugins/ingestion-kafka/src/test/java/org/opensearch/plugin/kafka/KafkaConsumerFactoryTests.java
@@ -8,26 +8,13 @@
 
 package org.opensearch.plugin.kafka;
 
-import org.opensearch.cluster.metadata.IngestionSource;
 import org.opensearch.test.OpenSearchTestCase;
 import org.junit.Assert;
 
-import java.util.HashMap;
-import java.util.Map;
-
 public class KafkaConsumerFactoryTests extends OpenSearchTestCase {
-    public void testInitialize() {
+    public void testCreateShardConsumerWithNullSource() {
         KafkaConsumerFactory factory = new KafkaConsumerFactory();
-        Map<String, Object> params = new HashMap<>();
-        params.put("topic", "test-topic");
-        params.put("bootstrap_servers", "localhost:9092");
-
-        factory.initialize(new IngestionSource.Builder("KAFKA").setParams(params).build());
-
-        KafkaSourceConfig config = factory.config;
-        Assert.assertNotNull("Config should be initialized", config);
-        Assert.assertEquals("Topic should be correctly initialized", "test-topic", config.getTopic());
-        Assert.assertEquals("Bootstrap servers should be correctly initialized", "localhost:9092", config.getBootstrapServers());
+        expectThrows(NullPointerException.class, () -> factory.createShardConsumer("test-client", 0, null));
     }
 
     public void testParsePointerFromString() {

--- a/plugins/ingestion-kinesis/src/main/java/org/opensearch/plugin/kinesis/KinesisConsumerFactory.java
+++ b/plugins/ingestion-kinesis/src/main/java/org/opensearch/plugin/kinesis/KinesisConsumerFactory.java
@@ -12,14 +12,9 @@ import org.opensearch.cluster.metadata.IngestionSource;
 import org.opensearch.index.IngestionConsumerFactory;
 
 /**
- * Factory for creating Kinesis consumers
+ * Factory for creating Kinesis consumers.
  */
 public class KinesisConsumerFactory implements IngestionConsumerFactory<KinesisShardConsumer, SequenceNumber> {
-
-    /**
-     * Configuration for the Kinesis source
-     */
-    protected KinesisSourceConfig config;
 
     /**
      * Constructor.
@@ -27,14 +22,9 @@ public class KinesisConsumerFactory implements IngestionConsumerFactory<KinesisS
     public KinesisConsumerFactory() {}
 
     @Override
-    public void initialize(IngestionSource ingestionSource) {
-        config = new KinesisSourceConfig(ingestionSource.params());
-    }
-
-    @Override
-    public KinesisShardConsumer createShardConsumer(String clientId, int shardId) {
-        assert config != null;
-        return new KinesisShardConsumer(clientId, config, shardId);
+    public KinesisShardConsumer createShardConsumer(String clientId, int shardId, IngestionSource ingestionSource) {
+        KinesisSourceConfig localConfig = new KinesisSourceConfig(ingestionSource.params());
+        return new KinesisShardConsumer(clientId, localConfig, shardId);
     }
 
     @Override

--- a/plugins/ingestion-kinesis/src/test/java/org/opensearch/plugin/kinesis/KinesisConsumerFactoryTests.java
+++ b/plugins/ingestion-kinesis/src/test/java/org/opensearch/plugin/kinesis/KinesisConsumerFactoryTests.java
@@ -8,45 +8,18 @@
 
 package org.opensearch.plugin.kinesis;
 
-import org.opensearch.cluster.metadata.IngestionSource;
 import org.opensearch.test.OpenSearchTestCase;
 import org.junit.Assert;
 
-import java.util.HashMap;
-import java.util.Map;
-
 public class KinesisConsumerFactoryTests extends OpenSearchTestCase {
-    public void testConstructorAndGetters() {
+    public void testConstructor() {
         KinesisConsumerFactory factory = new KinesisConsumerFactory();
-        Assert.assertNull("Config should be null before initialization", factory.config);
+        Assert.assertNotNull("Factory should be created", factory);
     }
 
-    public void testInitializeWithValidParams() {
+    public void testCreateShardConsumerWithNullSource() {
         KinesisConsumerFactory factory = new KinesisConsumerFactory();
-        Map<String, Object> params = new HashMap<>();
-        params.put("region", "us-west-2");
-        params.put("stream", "testStream");
-        params.put("secret_key", "testSecretKey");
-        params.put("access_key", "testAccessKey");
-
-        factory.initialize(new IngestionSource.Builder("KINESIS").setParams(params).build());
-
-        Assert.assertNotNull("Config should be initialized", factory.config);
-        Assert.assertEquals("Region should be correctly initialized", "us-west-2", factory.config.getRegion());
-        Assert.assertEquals("Stream should be correctly initialized", "testStream", factory.config.getStream());
-    }
-
-    public void testInitializeWithNullParams() {
-        KinesisConsumerFactory factory = new KinesisConsumerFactory();
-        try {
-            factory.initialize(null);
-            Assert.fail("Initialization should throw an exception when params is null");
-        } catch (NullPointerException e) {
-            Assert.assertNotNull(
-                "Cannot invoke \"[org.opensearch.cluster.metadata.IngestionSource.params()\" because \"ingestionSource]\" is null",
-                e.getMessage()
-            );
-        }
+        expectThrows(NullPointerException.class, () -> factory.createShardConsumer("test-client", 0, null));
     }
 
     public void testParsePointerFromString() {

--- a/server/src/main/java/org/opensearch/index/IngestionConsumerFactory.java
+++ b/server/src/main/java/org/opensearch/index/IngestionConsumerFactory.java
@@ -20,23 +20,31 @@ import org.opensearch.common.annotation.PublicApi;
 @PublicApi(since = "3.6.0")
 public interface IngestionConsumerFactory<T extends IngestionShardConsumer, P extends IngestionShardPointer> {
     /**
-     * Initialize the factory with the configuration parameters. This method is called once when the factory is created,
-     * and the required parameters are provided from the {@link org.opensearch.cluster.metadata.IngestionSource} in
-     * {@link  org.opensearch.cluster.metadata.IndexMetadata}.
+     * Initialize the factory with the configuration parameters.
+     *
      * @param ingestionSource the ingestion source with configuration parameters to initialize the factory
+     * @deprecated Implement {@link #createShardConsumer(String, int, IngestionSource)} instead, which receives
+     * the ingestion source directly and requires no separate initialization step.
      */
-    void initialize(IngestionSource ingestionSource);
+    @Deprecated(forRemoval = true)
+    default void initialize(IngestionSource ingestionSource) {
+        // no-op: implementations should override createShardConsumer(String, int, IngestionSource) instead
+    }
 
     /**
-     *  Create a consumer to ingest messages from a shard of the streams. When the ingestion engine created per shard,
-     *  this method is called to create the consumer in the poller. Before the invocation of this method, the configuration
-     *  is passed to the factory through the {@link #initialize(IngestionSource)} method.
+     * Create a consumer to ingest messages from a shard of the streams.
      *
      * @param clientId the client id assigned to the consumer
      * @param shardId the id of the shard
      * @return the created consumer
+     * @deprecated Use {@link #createShardConsumer(String, int, IngestionSource)} instead.
      */
-    T createShardConsumer(String clientId, int shardId);
+    @Deprecated(forRemoval = true)
+    default T createShardConsumer(String clientId, int shardId) {
+        throw new UnsupportedOperationException(
+            "Implement createShardConsumer(String, int, IngestionSource) instead of the deprecated two-step API."
+        );
+    }
 
     /**
      * Parses the pointer from a string representation to the pointer object. This is used for recovering from the index
@@ -45,4 +53,23 @@ public interface IngestionConsumerFactory<T extends IngestionShardConsumer, P ex
      * @return the recovered pointer
      */
     P parsePointerFromString(String pointer);
+
+    /**
+     * Create a consumer to ingest messages from a shard of the streams, using the provided ingestion source directly.
+     * Implementations should override this method rather than the deprecated
+     * {@link #initialize(IngestionSource)} and {@link #createShardConsumer(String, int)} pair.
+     * <p>
+     * The default implementation delegates to the deprecated two-step pair for backward compatibility
+     * with existing implementations that override {@link #initialize(IngestionSource)}.
+     *
+     * @param clientId        the client id assigned to the consumer
+     * @param shardId         the id of the shard
+     * @param ingestionSource the ingestion source configuration
+     * @return the created consumer
+     */
+    @SuppressWarnings("deprecation")
+    default T createShardConsumer(String clientId, int shardId, IngestionSource ingestionSource) {
+        initialize(ingestionSource);
+        return createShardConsumer(clientId, shardId);
+    }
 }

--- a/server/src/main/java/org/opensearch/index/engine/IngestionEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/IngestionEngine.java
@@ -60,7 +60,7 @@ import static org.opensearch.index.translog.Translog.EMPTY_TRANSLOG_SNAPSHOT;
  */
 public class IngestionEngine extends InternalEngine {
 
-    private StreamPoller streamPoller;
+    private volatile StreamPoller streamPoller;
     private final IngestionConsumerFactory ingestionConsumerFactory;
     private final Supplier<DocumentMapperForType> documentMapperForTypeSupplier;
     private final IngestService ingestService;
@@ -94,8 +94,6 @@ public class IngestionEngine extends InternalEngine {
         assert indexMetadata != null;
         IngestionSource ingestionSource = Objects.requireNonNull(indexMetadata.getIngestionSource());
 
-        // initialize the ingestion consumer factory
-        this.ingestionConsumerFactory.initialize(ingestionSource);
         String clientId = engineConfig.getIndexSettings().getNodeName()
             + "-"
             + engineConfig.getIndexSettings().getIndex().getName()
@@ -158,6 +156,7 @@ public class IngestionEngine extends InternalEngine {
             .mapperType(ingestionSource.getMapperType())
             .mapperSettings(ingestionSource.getMapperSettings())
             .warmupConfig(ingestionSource.getWarmupConfig())
+            .ingestionSource(ingestionSource)
             .build();
         registerStreamPollerListener();
 

--- a/server/src/main/java/org/opensearch/indices/pollingingest/DefaultStreamPoller.java
+++ b/server/src/main/java/org/opensearch/indices/pollingingest/DefaultStreamPoller.java
@@ -58,6 +58,9 @@ public class DefaultStreamPoller implements StreamPoller {
     // flag to indicate if consumer needs to be reinitialized
     private volatile boolean reinitializeConsumer;
 
+    // the ingestion source used to create the consumer; updated on settings changes
+    private volatile IngestionSource currentIngestionSource;
+
     private volatile long lastPolledMessageTimestamp = 0;
     private volatile long cachedPointerBasedLag = -1; // -1 indicates poller has not consumed any message yet
     private volatile long lastPointerBasedLagUpdateTime = 0;
@@ -69,7 +72,7 @@ public class DefaultStreamPoller implements StreamPoller {
     private final CountDownLatch warmupLatch = new CountDownLatch(1);
 
     @Nullable
-    private IngestionShardConsumer consumer;
+    private volatile IngestionShardConsumer consumer;
     private IngestionConsumerFactory consumerFactory;
     private String consumerClientId;
     private int shardId;
@@ -77,7 +80,7 @@ public class DefaultStreamPoller implements StreamPoller {
     private ExecutorService consumerThread;
 
     // start of the batch, inclusive
-    private IngestionShardPointer initialBatchStartPointer;
+    private volatile IngestionShardPointer initialBatchStartPointer;
 
     private ResetState resetState;
     private final String resetValue;
@@ -117,7 +120,8 @@ public class DefaultStreamPoller implements StreamPoller {
         long pointerBasedLagUpdateIntervalMs,
         IngestionMessageMapper.MapperType mapperType,
         Map<String, Object> mapperSettings,
-        IngestionSource.WarmupConfig warmupConfig
+        IngestionSource.WarmupConfig warmupConfig,
+        IngestionSource ingestionSource
     ) {
         this(
             startPointer,
@@ -134,7 +138,8 @@ public class DefaultStreamPoller implements StreamPoller {
             pointerBasedLagUpdateIntervalMs,
             ingestionEngine.config().getIndexSettings(),
             IngestionMessageMapper.create(mapperType.getName(), shardId, mapperSettings),
-            warmupConfig
+            warmupConfig,
+            ingestionSource
         );
     }
 
@@ -156,7 +161,8 @@ public class DefaultStreamPoller implements StreamPoller {
         long pointerBasedLagUpdateIntervalMs,
         IndexSettings indexSettings,
         IngestionMessageMapper messageMapper,
-        IngestionSource.WarmupConfig warmupConfig
+        IngestionSource.WarmupConfig warmupConfig,
+        IngestionSource ingestionSource
     ) {
         this.consumerFactory = Objects.requireNonNull(consumerFactory);
         this.consumerClientId = Objects.requireNonNull(consumerClientId);
@@ -176,6 +182,7 @@ public class DefaultStreamPoller implements StreamPoller {
         this.indexName = indexSettings.getIndex().getName();
         this.messageMapper = Objects.requireNonNull(messageMapper);
         this.warmupConfig = Objects.requireNonNull(warmupConfig);
+        this.currentIngestionSource = Objects.requireNonNull(ingestionSource);
 
         // handle initial poller states
         this.paused = initialState == State.PAUSED;
@@ -611,7 +618,7 @@ public class DefaultStreamPoller implements StreamPoller {
 
     /**
      * Mark the poller's consumer for reinitialization. A new consumer will be initialized and start consuming from the
-     * latest batchStartPointer. This method also reinitializes the consumer factory with the updated ingestion source.
+     * latest batchStartPointer using the updated ingestion source.
      * @param updatedIngestionSource the updated ingestion source with new configuration parameters
      */
     @Override
@@ -621,8 +628,7 @@ public class DefaultStreamPoller implements StreamPoller {
             return;
         }
 
-        // Reinitialize the consumer factory with updated configuration
-        consumerFactory.initialize(updatedIngestionSource);
+        this.currentIngestionSource = updatedIngestionSource;
         logger.info("Configuration parameters updated for index {} shard {}, requesting consumer reinitialization", indexName, shardId);
         reinitializeConsumer = true;
     }
@@ -706,7 +712,7 @@ public class DefaultStreamPoller implements StreamPoller {
     private synchronized void initializeConsumer() {
         try {
             reinitializeConsumer = false;
-            this.consumer = consumerFactory.createShardConsumer(consumerClientId, shardId);
+            this.consumer = consumerFactory.createShardConsumer(consumerClientId, shardId, currentIngestionSource);
             logger.info("Successfully initialized consumer for shard {}", shardId);
         } catch (Exception e) {
             logger.warn("Failed to create consumer for shard {}: {}", shardId, e.getMessage());
@@ -756,6 +762,7 @@ public class DefaultStreamPoller implements StreamPoller {
         private Map<String, Object> mapperSettings = Collections.emptyMap();
         // Warmup configuration - default matches IndexMetadata settings
         private IngestionSource.WarmupConfig warmupConfig = new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(-1), 100L);
+        private IngestionSource ingestionSource;
 
         /**
          * Initialize the builder with mandatory parameters
@@ -873,6 +880,14 @@ public class DefaultStreamPoller implements StreamPoller {
         }
 
         /**
+         * Set the ingestion source used to create the consumer.
+         */
+        public Builder ingestionSource(IngestionSource ingestionSource) {
+            this.ingestionSource = Objects.requireNonNull(ingestionSource);
+            return this;
+        }
+
+        /**
          * Build the DefaultStreamPoller instance
          */
         public DefaultStreamPoller build() {
@@ -893,7 +908,8 @@ public class DefaultStreamPoller implements StreamPoller {
                 pointerBasedLagUpdateIntervalMs,
                 mapperType,
                 mapperSettings,
-                warmupConfig
+                warmupConfig,
+                ingestionSource
             );
         }
     }

--- a/server/src/test/java/org/opensearch/index/engine/FakeIngestionSource.java
+++ b/server/src/test/java/org/opensearch/index/engine/FakeIngestionSource.java
@@ -37,10 +37,7 @@ public class FakeIngestionSource {
         }
 
         @Override
-        public void initialize(IngestionSource ingestionSource) {}
-
-        @Override
-        public FakeIngestionConsumer createShardConsumer(String clientId, int shardId) {
+        public FakeIngestionConsumer createShardConsumer(String clientId, int shardId, IngestionSource ingestionSource) {
             return new FakeIngestionConsumer(messages, shardId);
         }
 

--- a/server/src/test/java/org/opensearch/indices/pollingingest/DefaultStreamPollerTests.java
+++ b/server/src/test/java/org/opensearch/indices/pollingingest/DefaultStreamPollerTests.java
@@ -97,7 +97,8 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             10000,
             indexSettings,
             new DefaultIngestionMessageMapper(),
-            new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(-1), 0)
+            new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(-1), 0),
+            new IngestionSource.Builder("FAKE").build()
         );
         partitionedBlockingQueueContainer.startProcessorThreads();
     }
@@ -172,7 +173,8 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             10000,
             indexSettings,
             new DefaultIngestionMessageMapper(),
-            new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(-1), 0)
+            new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(-1), 0),
+            new IngestionSource.Builder("FAKE").build()
         );
         CountDownLatch latch = new CountDownLatch(2);
         doAnswer(invocation -> {
@@ -207,7 +209,8 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             10000,
             indexSettings,
             new DefaultIngestionMessageMapper(),
-            new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(-1), 0)
+            new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(-1), 0),
+            new IngestionSource.Builder("FAKE").build()
         );
 
         // Set up latch to wait for 2 messages to be processed
@@ -250,7 +253,8 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             10000,
             indexSettings,
             new DefaultIngestionMessageMapper(),
-            new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(-1), 0)
+            new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(-1), 0),
+            new IngestionSource.Builder("FAKE").build()
         );
         CountDownLatch latch = new CountDownLatch(1);
         doAnswer(invocation -> {
@@ -288,7 +292,11 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
     public void testDropErrorIngestionStrategy() throws TimeoutException, InterruptedException {
         messages.add("{\"_id\":\"3\",\"_source\":{\"name\":\"bob\", \"age\": 24}}".getBytes(StandardCharsets.UTF_8));
         messages.add("{\"_id\":\"4\",\"_source\":{\"name\":\"alice\", \"age\": 21}}".getBytes(StandardCharsets.UTF_8));
-        FakeIngestionSource.FakeIngestionConsumer fakeConsumer = fakeConsumerFactory.createShardConsumer("", 0);
+        FakeIngestionSource.FakeIngestionConsumer fakeConsumer = fakeConsumerFactory.createShardConsumer(
+            "",
+            0,
+            new IngestionSource.Builder("FAKE").build()
+        );
         List<
             IngestionShardConsumer.ReadResult<
                 FakeIngestionSource.FakeIngestionShardPointer,
@@ -320,7 +328,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
         blockingQueueContainer.startProcessorThreads();
 
         IngestionConsumerFactory mockConsumerFactory = mock(IngestionConsumerFactory.class);
-        when(mockConsumerFactory.createShardConsumer(anyString(), anyInt())).thenReturn(mockConsumer);
+        when(mockConsumerFactory.createShardConsumer(anyString(), anyInt(), any())).thenReturn(mockConsumer);
 
         poller = new DefaultStreamPoller(
             new FakeIngestionSource.FakeIngestionShardPointer(0),
@@ -337,7 +345,8 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             10000,
             indexSettings,
             new DefaultIngestionMessageMapper(),
-            new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(-1), 0)
+            new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(-1), 0),
+            new IngestionSource.Builder("FAKE").build()
         );
         poller.start();
         Thread.sleep(sleepTime);
@@ -353,7 +362,11 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
     public void testBlockErrorIngestionStrategy() throws TimeoutException, InterruptedException {
         messages.add("{\"_id\":\"3\",\"_source\":{\"name\":\"bob\", \"age\": 24}}".getBytes(StandardCharsets.UTF_8));
         messages.add("{\"_id\":\"4\",\"_source\":{\"name\":\"alice\", \"age\": 21}}".getBytes(StandardCharsets.UTF_8));
-        FakeIngestionSource.FakeIngestionConsumer fakeConsumer = fakeConsumerFactory.createShardConsumer("", 0);
+        FakeIngestionSource.FakeIngestionConsumer fakeConsumer = fakeConsumerFactory.createShardConsumer(
+            "",
+            0,
+            new IngestionSource.Builder("FAKE").build()
+        );
         List<
             IngestionShardConsumer.ReadResult<
                 FakeIngestionSource.FakeIngestionShardPointer,
@@ -384,7 +397,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
         PartitionedBlockingQueueContainer blockingQueueContainer = new PartitionedBlockingQueueContainer(processorRunnable, 0);
         blockingQueueContainer.startProcessorThreads();
         IngestionConsumerFactory mockConsumerFactory = mock(IngestionConsumerFactory.class);
-        when(mockConsumerFactory.createShardConsumer(anyString(), anyInt())).thenReturn(mockConsumer);
+        when(mockConsumerFactory.createShardConsumer(anyString(), anyInt(), any())).thenReturn(mockConsumer);
 
         poller = new DefaultStreamPoller(
             new FakeIngestionSource.FakeIngestionShardPointer(0),
@@ -401,7 +414,8 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             10000,
             indexSettings,
             new DefaultIngestionMessageMapper(),
-            new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(-1), 0)
+            new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(-1), 0),
+            new IngestionSource.Builder("FAKE").build()
         );
         poller.start();
         Thread.sleep(sleepTime);
@@ -439,7 +453,8 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             10000,
             indexSettings,
             new DefaultIngestionMessageMapper(),
-            new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(-1), 0)
+            new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(-1), 0),
+            new IngestionSource.Builder("FAKE").build()
         );
         poller.start();
         Thread.sleep(sleepTime);
@@ -463,7 +478,11 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
     public void testPersistedBatchStartPointer() throws TimeoutException, InterruptedException {
         messages.add("{\"_id\":\"3\",\"_source\":{\"name\":\"bob\", \"age\": 24}}".getBytes(StandardCharsets.UTF_8));
         messages.add("{\"_id\":\"4\",\"_source\":{\"name\":\"alice\", \"age\": 21}}".getBytes(StandardCharsets.UTF_8));
-        FakeIngestionSource.FakeIngestionConsumer fakeConsumer = fakeConsumerFactory.createShardConsumer("", 0);
+        FakeIngestionSource.FakeIngestionConsumer fakeConsumer = fakeConsumerFactory.createShardConsumer(
+            "",
+            0,
+            new IngestionSource.Builder("FAKE").build()
+        );
         List<
             IngestionShardConsumer.ReadResult<
                 FakeIngestionSource.FakeIngestionShardPointer,
@@ -496,7 +515,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
 
         when(mockConsumer.readNext(anyLong(), anyInt())).thenReturn(readResultsBatch2).thenReturn(Collections.emptyList());
         IngestionConsumerFactory mockConsumerFactory = mock(IngestionConsumerFactory.class);
-        when(mockConsumerFactory.createShardConsumer(anyString(), anyInt())).thenReturn(mockConsumer);
+        when(mockConsumerFactory.createShardConsumer(anyString(), anyInt(), any())).thenReturn(mockConsumer);
 
         poller = new DefaultStreamPoller(
             new FakeIngestionSource.FakeIngestionShardPointer(0),
@@ -513,7 +532,8 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             10000,
             indexSettings,
             new DefaultIngestionMessageMapper(),
-            new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(-1), 0)
+            new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(-1), 0),
+            new IngestionSource.Builder("FAKE").build()
         );
         poller.start();
         Thread.sleep(sleepTime);
@@ -564,7 +584,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
 
         // Create a mock consumer factory that fails on first call but succeeds on second call
         IngestionConsumerFactory mockConsumerFactory = mock(IngestionConsumerFactory.class);
-        when(mockConsumerFactory.createShardConsumer(anyString(), anyInt())).thenThrow(
+        when(mockConsumerFactory.createShardConsumer(anyString(), anyInt(), any())).thenThrow(
             new RuntimeException("Simulated consumer initialization failure")
         ).thenReturn(mockConsumer);
 
@@ -584,7 +604,8 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             10000,
             indexSettings,
             new DefaultIngestionMessageMapper(),
-            new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(-1), 0)
+            new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(-1), 0),
+            new IngestionSource.Builder("FAKE").build()
         );
 
         poller.start();
@@ -595,7 +616,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
         }, 30, TimeUnit.SECONDS);
 
         // Verify the consumer factory was called twice (once for failure, once for success)
-        verify(mockConsumerFactory, times(2)).createShardConsumer(anyString(), anyInt());
+        verify(mockConsumerFactory, times(2)).createShardConsumer(anyString(), anyInt(), any());
         assertNotNull(poller.getConsumer());
     }
 
@@ -628,7 +649,8 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             10000,
             indexSettings,
             new DefaultIngestionMessageMapper(),
-            new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(-1), 0)
+            new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(-1), 0),
+            new IngestionSource.Builder("FAKE").build()
         );
 
         // Start and wait for 2 messages to be processed
@@ -685,7 +707,8 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             10000,
             indexSettings,
             new DefaultIngestionMessageMapper(),
-            new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(-1), 0)
+            new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(-1), 0),
+            new IngestionSource.Builder("FAKE").build()
         );
 
         // Start poller
@@ -737,7 +760,8 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             10000,
             indexSettings,
             new DefaultIngestionMessageMapper(),
-            new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(-1), 0)
+            new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(-1), 0),
+            new IngestionSource.Builder("FAKE").build()
         );
 
         // When all queues return null and initialBatchStartPointer is null, getBatchStartPointer should return null
@@ -767,7 +791,8 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             10000,
             indexSettings,
             new DefaultIngestionMessageMapper(),
-            new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(-1), 0)
+            new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(-1), 0),
+            new IngestionSource.Builder("FAKE").build()
         );
 
         // Warmup should be considered complete when disabled
@@ -793,7 +818,8 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             10000,
             indexSettings,
             new DefaultIngestionMessageMapper(),
-            new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(300000), 0)
+            new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(300000), 0),
+            new IngestionSource.Builder("FAKE").build()
         );
 
         // Initially warmup is not complete
@@ -814,7 +840,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
         // Create a mock consumer factory that always reports high lag
         IngestionConsumerFactory mockFactory = mock(IngestionConsumerFactory.class);
         IngestionShardConsumer mockConsumer = mock(IngestionShardConsumer.class);
-        when(mockFactory.createShardConsumer(anyString(), anyInt())).thenReturn(mockConsumer);
+        when(mockFactory.createShardConsumer(anyString(), anyInt(), any())).thenReturn(mockConsumer);
         when(mockConsumer.getPointerBasedLag(any())).thenReturn(1000L); // High lag
         when(mockConsumer.readNext(anyLong(), anyInt())).thenReturn(Collections.emptyList());
 
@@ -833,7 +859,8 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             10000,
             indexSettings,
             new DefaultIngestionMessageMapper(),
-            new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(500), 0)
+            new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(500), 0),
+            new IngestionSource.Builder("FAKE").build()
         );
 
         warmupPoller.start();
@@ -862,7 +889,8 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             10000,
             indexSettings,
             new DefaultIngestionMessageMapper(),
-            new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(300000), 0)
+            new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(300000), 0),
+            new IngestionSource.Builder("FAKE").build()
         );
 
         // Initial state should be NONE
@@ -885,7 +913,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
         // Create a mock consumer factory that returns negative pointer-based lag (unsupported)
         IngestionConsumerFactory mockFactory = mock(IngestionConsumerFactory.class);
         IngestionShardConsumer mockConsumer = mock(IngestionShardConsumer.class);
-        when(mockFactory.createShardConsumer(anyString(), anyInt())).thenReturn(mockConsumer);
+        when(mockFactory.createShardConsumer(anyString(), anyInt(), any())).thenReturn(mockConsumer);
         when(mockConsumer.getPointerBasedLag(any())).thenReturn(-1L); // Negative means unsupported
         when(mockConsumer.readNext(anyLong(), anyInt())).thenReturn(Collections.emptyList());
 
@@ -904,7 +932,8 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             10000,
             indexSettings,
             new DefaultIngestionMessageMapper(),
-            new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(500), 0)
+            new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(500), 0),
+            new IngestionSource.Builder("FAKE").build()
         );
 
         warmupPoller.start();
@@ -920,7 +949,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
         // Create a mock consumer factory that reports lag slightly above threshold then drops to threshold
         IngestionConsumerFactory mockFactory = mock(IngestionConsumerFactory.class);
         IngestionShardConsumer mockConsumer = mock(IngestionShardConsumer.class);
-        when(mockFactory.createShardConsumer(anyString(), anyInt())).thenReturn(mockConsumer);
+        when(mockFactory.createShardConsumer(anyString(), anyInt(), any())).thenReturn(mockConsumer);
         // Return lag of 50 which is below threshold of 100
         when(mockConsumer.getPointerBasedLag(any())).thenReturn(50L);
         when(mockConsumer.readNext(anyLong(), anyInt())).thenReturn(Collections.emptyList());
@@ -940,7 +969,8 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             10000,
             indexSettings,
             new DefaultIngestionMessageMapper(),
-            new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(30000), 100)
+            new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(30000), 100),
+            new IngestionSource.Builder("FAKE").build()
         );
 
         warmupPoller.start();
@@ -970,7 +1000,8 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             10000,
             indexSettings,
             new DefaultIngestionMessageMapper(),
-            new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(-1), 0)
+            new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(-1), 0),
+            new IngestionSource.Builder("FAKE").build()
         );
 
         // Should return immediately without blocking since warmup is disabled
@@ -988,7 +1019,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
         // Create a poller with warmup enabled but starting in PAUSED state
         IngestionConsumerFactory mockFactory = mock(IngestionConsumerFactory.class);
         IngestionShardConsumer mockConsumer = mock(IngestionShardConsumer.class);
-        when(mockFactory.createShardConsumer(anyString(), anyInt())).thenReturn(mockConsumer);
+        when(mockFactory.createShardConsumer(anyString(), anyInt(), any())).thenReturn(mockConsumer);
         when(mockConsumer.getPointerBasedLag(any())).thenReturn(1000L);
         when(mockConsumer.readNext(anyLong(), anyInt())).thenReturn(Collections.emptyList());
 
@@ -1007,7 +1038,8 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             10000,
             indexSettings,
             new DefaultIngestionMessageMapper(),
-            new IngestionSource.WarmupConfig(TimeValue.timeValueMinutes(5), 100L)
+            new IngestionSource.WarmupConfig(TimeValue.timeValueMinutes(5), 100L),
+            new IngestionSource.Builder("FAKE").build()
         );
 
         // Start the poller - it will be paused, so warmup should be skipped
@@ -1041,7 +1073,8 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             10000,
             indexSettings,
             new DefaultIngestionMessageMapper(),
-            enabledConfig
+            enabledConfig,
+            new IngestionSource.Builder("FAKE").build()
         );
 
         // Warmup should not be complete yet
@@ -1061,7 +1094,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
         // Create a mock consumer that always reports high lag so warmup never completes on its own
         IngestionConsumerFactory mockFactory = mock(IngestionConsumerFactory.class);
         IngestionShardConsumer mockConsumer = mock(IngestionShardConsumer.class);
-        when(mockFactory.createShardConsumer(anyString(), anyInt())).thenReturn(mockConsumer);
+        when(mockFactory.createShardConsumer(anyString(), anyInt(), any())).thenReturn(mockConsumer);
         when(mockConsumer.getPointerBasedLag(any())).thenReturn(1000L);
         when(mockConsumer.readNext(anyLong(), anyInt())).thenReturn(Collections.emptyList());
 
@@ -1080,7 +1113,8 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             10000,
             indexSettings,
             new DefaultIngestionMessageMapper(),
-            new IngestionSource.WarmupConfig(TimeValue.timeValueMinutes(10), 100L)
+            new IngestionSource.WarmupConfig(TimeValue.timeValueMinutes(10), 100L),
+            new IngestionSource.Builder("FAKE").build()
         );
 
         // Start the poller
@@ -1115,7 +1149,8 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             10000,
             indexSettings,
             new DefaultIngestionMessageMapper(),
-            initialConfig
+            initialConfig,
+            new IngestionSource.Builder("FAKE").build()
         );
 
         // Warmup should not be complete yet
@@ -1149,7 +1184,8 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             10000,
             indexSettings,
             new DefaultIngestionMessageMapper(),
-            disabledConfig
+            disabledConfig,
+            new IngestionSource.Builder("FAKE").build()
         );
 
         // Warmup should be complete since it was disabled


### PR DESCRIPTION
### Description
Backport #21652 from 3.7 to 3.6.

Pull-based ingestion factory classes need to be stateless for correct behavior to prevent race conditions. The two step initialize and createConsumer can result in race conditions as the factory is a singleton. This PR updates the factory to receive the ingestion source when createConsumer is called.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
