### PR TITLE
Sandbox: leak fixes in coordinator-stage cleanup.

### DIFF
--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/PlanWalker.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/PlanWalker.java
@@ -16,6 +16,7 @@ import org.opensearch.analytics.exec.stage.DataProducer;
 import org.opensearch.analytics.exec.stage.StageExecution;
 import org.opensearch.analytics.exec.stage.StageExecutionBuilder;
 import org.opensearch.analytics.planner.dag.Stage;
+import org.opensearch.analytics.spi.ExchangeSink;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.tasks.TaskCancelledException;
 import org.opensearch.tasks.CancellableTask;
@@ -71,24 +72,80 @@ public class PlanWalker {
     /**
      * Phase 1: Build the execution graph without starting any stages.
      * All stages are in {@link StageExecution.State#CREATED} state.
-     * Listeners are wired. The graph is inspectable for EXPLAIN.
+     * The graph is inspectable for EXPLAIN.
+     *
+     * <p>The completion listener is NOT wired here — call {@link #wireCompletion()}
+     * after build succeeds and before exposing the walker to cancellation triggers.
+     * Build-time failures bubble unchecked; partial-graph cleanup runs in finally
+     * to release any native handles backend factories had already allocated.
      *
      * @return the fully-wired execution graph
      */
     public ExecutionGraph build() {
         Map<Integer, StageExecution> executions = new HashMap<>();
-
         Stage rootStage = config.dag().rootStage();
-        final StageExecution rootExec = stageExecutionBuilder.buildRootExecution(rootStage, config);
-        wireCompletionListener(rootExec);
-        executions.put(rootStage.getStageId(), rootExec);
+        boolean success = false;
+        try {
+            StageExecution rootExec = stageExecutionBuilder.buildRootExecution(rootStage, config);
+            executions.put(rootStage.getStageId(), rootExec);
 
-        buildChildrenRecursively(executions, rootExec, rootStage);
+            buildChildrenRecursively(executions, rootExec, rootStage);
 
-        List<StageExecution> leaves = findLeaves(executions, rootStage);
+            List<StageExecution> leaves = findLeaves(executions, rootStage);
+            this.graph = new ExecutionGraph(config.queryId(), executions, rootExec, leaves);
+            success = true;
+            return this.graph;
+        } finally {
+            if (!success) cancelPartialBuild(executions);
+        }
+    }
 
-        this.graph = new ExecutionGraph(config.queryId(), executions, rootExec, leaves);
-        return this.graph;
+    /**
+     * Wires the completion listener on the root execution. Must be called after
+     * {@link #build()} succeeds and before {@link #start(ExecutionGraph)} or any
+     * external cancellation trigger ({@link #cancelAll(String)}). The listener
+     * fires once on the root's terminal transition (SUCCEEDED / FAILED /
+     * CANCELLED) — see {@link #wireCompletionListener(StageExecution)}.
+     */
+    public void wireCompletion() {
+        ExecutionGraph g = this.graph;
+        if (g == null) {
+            throw new IllegalStateException("wireCompletion must be called after build() succeeds");
+        }
+        wireCompletionListener(g.rootExecution());
+    }
+
+    /**
+     * Cancels every stage built before {@link #build()} threw. If a stage's cancel itself
+     * throws, subsequent stages still get a chance to cancel — the first cancel failure
+     * is rethrown at the end with later ones attached as suppressed.
+     */
+    private void cancelPartialBuild(Map<Integer, StageExecution> executions) {
+        String reason = "stage-build failure";
+        IllegalStateException primary = null;
+        for (StageExecution exec : executions.values()) {
+            try {
+                exec.cancel(reason);
+            } catch (IllegalStateException t) {
+                if (primary == null) {
+                    primary = t;
+                } else {
+                    primary.addSuppressed(t);
+                }
+            }
+        }
+        assert allTerminal(executions) : "cancelPartialBuild left non-terminal stages";
+        if (primary != null) throw primary;
+    }
+
+    private static boolean allTerminal(Map<Integer, StageExecution> executions) {
+        for (StageExecution exec : executions.values()) {
+            StageExecution.State s = exec.getState();
+            if (s != StageExecution.State.SUCCEEDED && s != StageExecution.State.FAILED && s != StageExecution.State.CANCELLED) {
+                return false;
+            }
+        }
+        return true;
     }
 
     /**
@@ -104,11 +161,13 @@ public class PlanWalker {
     }
 
     /**
-     * Legacy single-call entry point. Builds the graph and starts
-     * execution in one shot. Equivalent to {@code start(build())}.
+     * Legacy single-call entry point. Builds the graph, wires the completion
+     * listener, and starts execution in one shot.
      */
     public void walk() {
-        start(build());
+        ExecutionGraph g = build();
+        wireCompletion();
+        start(g);
     }
 
     /**
@@ -211,6 +270,20 @@ public class PlanWalker {
             switch (to) {
                 case SUCCEEDED -> fireTerminal(() -> completionListener.onResponse(producer.outputSource().readResult()));
                 case FAILED, CANCELLED -> {
+                    // Release any batches the root producer already accumulated before
+                    // teardown. Success path closes batches in batchesToRows; failure path
+                    // skips that, so without this the VSRs sitting in the terminal sink
+                    // leak into the per-query allocator close check.
+                    if (producer.outputSource() instanceof ExchangeSink sink) {
+                        try {
+                            sink.close();
+                        } catch (IllegalStateException e) {
+                            // Arrow's allocator and FFI close paths throw IllegalStateException
+                            // on leak / double-release. Don't let a close failure replace the
+                            // primary stage failure en route to the completion listener.
+                            logger.warn(new ParameterizedMessage("[PlanWalker] terminal sink close failed on {}", to), e);
+                        }
+                    }
                     Exception failure = rootExec.getFailure();
                     if (config.parentTask() instanceof CancellableTask ct && ct.isCancelled()) {
                         fireTerminal(() -> completionListener.onFailure(new TaskCancelledException("query cancelled")));

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/QueryScheduler.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/QueryScheduler.java
@@ -69,6 +69,17 @@ public class QueryScheduler implements Scheduler {
         );
 
         PlanWalker walker = createWalker(config, listener, queryId, queryStartNanos, opListener);
+
+        // Build the graph first. On failure the partial graph cleans itself up via
+        // walker.build()'s try-finally; the RuntimeException bubbles to
+        // DefaultPlanExecutor's outer catch which fires listener.onFailure with the cause.
+        ExecutionGraph graph = walker.build();
+
+        // Wire the completion listener BEFORE registering the cancel callback so a
+        // post-build / pre-start cancellation reaches the listener via the cascade.
+        // Without this the user-facing listener is never registered and queries hang
+        // until the test or REST socket times out.
+        walker.wireCompletion();
         walkerPool.put(queryId, walker);
 
         final AnalyticsQueryTask queryTask = config.parentTask();
@@ -78,11 +89,7 @@ public class QueryScheduler implements Scheduler {
             walker.cancelAll(reason);
         });
 
-        // Two-phase: build graph, then start execution
-        ExecutionGraph graph = walker.build();
-
         opListener.onQueryStart(queryId, graph.stageCount());
-
         logger.info("[QueryScheduler] ExecutionGraph built:\n{}", graph.explain());
         walker.start(graph);
     }

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stage/LocalStageExecution.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stage/LocalStageExecution.java
@@ -16,6 +16,8 @@ import org.opensearch.analytics.planner.dag.Stage;
 import org.opensearch.analytics.spi.ExchangeSink;
 import org.opensearch.analytics.spi.MultiInputExchangeSink;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+
 /**
  * {@link StageExecution} implementation for COORDINATOR_REDUCE stages. Holds a
  * backend-provided {@link ExchangeSink} (from {@link org.opensearch.analytics.spi.ExchangeSinkProvider})
@@ -32,6 +34,15 @@ final class LocalStageExecution extends AbstractStageExecution implements SinkPr
 
     private final ExchangeSink backendSink;
     private final ExchangeSink downstream;
+    /**
+     * Single-fire gate on {@link #backendSink}.close(). Failure paths
+     * ({@link #failFromChild}, {@link #cancel}) are reachable both from the
+     * cascade (sibling failures fan in via ChildToParentCascade) and from
+     * external cancellation, so the same stage can have its terminal close
+     * triggered twice. Streaming reduce sinks block on draining the native
+     * pipeline; concurrent closes serialize on the sink's feedLock.
+     */
+    private final AtomicBoolean backendSinkClosed = new AtomicBoolean(false);
 
     public LocalStageExecution(Stage stage, ExchangeSink backendSink, ExchangeSink downstream) {
         super(stage);
@@ -77,7 +88,11 @@ final class LocalStageExecution extends AbstractStageExecution implements SinkPr
         if (transitionTo(State.RUNNING) == false) return;
         logger.info("[LocalStage] start() stageId={}", stage.getStageId());
         try {
-            backendSink.close();
+            // Mark the gate before close so subsequent failure-path callers don't
+            // re-close. Close exceptions surface here so the catch routes to FAILED.
+            if (backendSinkClosed.compareAndSet(false, true)) {
+                backendSink.close();
+            }
             if (transitionTo(State.SUCCEEDED)) {
                 logger.info("[LocalStage] SUCCEEDED stageId={}", stage.getStageId());
             }
@@ -94,10 +109,13 @@ final class LocalStageExecution extends AbstractStageExecution implements SinkPr
     public boolean failFromChild(Exception cause) {
         logger.error(new ParameterizedMessage("[LocalStage] failFromChild stageId={}", stage.getStageId()), cause);
         captureFailure(cause);
+        // Close sink BEFORE transitioning. transitionTo fires the walker terminal
+        // listener inline, which tears down the per-query allocator — if the
+        // sink's drain task is still importing, it would race a closed allocator.
+        // Gated by backendSinkClosed so a sibling-failure cascade or a follow-up
+        // external cancel doesn't pile up concurrent closes on the same sink.
+        closeBackendSinkOnce();
         if (transitionTo(State.FAILED)) {
-            try {
-                backendSink.close();
-            } catch (Exception ignore) {}
             metrics.incrementTasksFailed();
             return true;
         }
@@ -107,7 +125,16 @@ final class LocalStageExecution extends AbstractStageExecution implements SinkPr
     @Override
     public void cancel(String reason) {
         logger.info("[LocalStage] cancel stageId={} reason={}", stage.getStageId(), reason);
-        if (transitionTo(State.CANCELLED)) {
+        closeBackendSinkOnce();
+        transitionTo(State.CANCELLED);
+    }
+
+    /**
+     * Single-fire close on the failure path. Swallows exceptions because callers
+     * cannot meaningfully react and the primary cause has already been captured.
+     */
+    private void closeBackendSinkOnce() {
+        if (backendSinkClosed.compareAndSet(false, true)) {
             try {
                 backendSink.close();
             } catch (Exception ignore) {}

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stage/ShardFragmentStageExecution.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stage/ShardFragmentStageExecution.java
@@ -90,7 +90,8 @@ final class ShardFragmentStageExecution extends AbstractStageExecution implement
             // Runs inline on the per-stream virtual thread driving handleStreamResponse.
             // Must NOT offload to a thread pool: reordering across batches would let the
             // isLast=true task race ahead, flip state to SUCCEEDED, and drop queued
-            // earlier batches via the isDone() short-circuit.
+            // earlier batches via the isDone() short-circuit. Inline also preserves
+            // end-to-end backpressure (next nextResponse() blocks until feed() returns).
             @Override
             public void onStreamResponse(FragmentExecutionArrowResponse response, boolean isLast) {
                 if (isDone()) {
@@ -105,9 +106,17 @@ final class ShardFragmentStageExecution extends AbstractStageExecution implement
                 try {
                     outputSink.feed(vsr);
                 } catch (Exception e) {
-                    // Without this guard the exception only surfaces on the stream's virtual
-                    // thread; inFlight never decrements and the stage hangs to QUERY_TIMEOUT.
-                    captureFailure(new RuntimeException("Stage " + stage.getStageId() + " sink feed failed", e));
+                    // On feed failure, close the VSR ourselves — sink didn't take ownership.
+                    // Without surfacing via captureFailure the exception only lives on the
+                    // stream's virtual thread; inFlight never decrements and the stage hangs
+                    // to QUERY_TIMEOUT.
+                    RuntimeException wrapped = new RuntimeException("Stage " + stage.getStageId() + " sink feed failed", e);
+                    try {
+                        vsr.close();
+                    } catch (IllegalStateException closeFailure) {
+                        wrapped.addSuppressed(closeFailure);
+                    }
+                    captureFailure(wrapped);
                     metrics.incrementTasksFailed();
                     onShardTerminated();
                     return;
@@ -130,7 +139,9 @@ final class ShardFragmentStageExecution extends AbstractStageExecution implement
     }
 
     private void onShardTerminated() {
-        if (inFlight.decrementAndGet() == 0) {
+        int after = inFlight.decrementAndGet();
+        assert after >= 0 : "inFlight count went negative — a shard terminated more than once: " + after;
+        if (after == 0) {
             Exception captured = getFailure();
             transitionTo(captured != null ? StageExecution.State.FAILED : StageExecution.State.SUCCEEDED);
         }

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/PlanWalkerTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/PlanWalkerTests.java
@@ -1,0 +1,277 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.exec;
+
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.opensearch.analytics.backend.ExchangeSource;
+import org.opensearch.analytics.exec.stage.DataProducer;
+import org.opensearch.analytics.exec.stage.StageExecution;
+import org.opensearch.analytics.exec.stage.StageExecutionBuilder;
+import org.opensearch.analytics.exec.stage.StageMetrics;
+import org.opensearch.analytics.exec.stage.StageStateListener;
+import org.opensearch.analytics.exec.task.AnalyticsQueryTask;
+import org.opensearch.analytics.planner.dag.QueryDAG;
+import org.opensearch.analytics.planner.dag.Stage;
+import org.opensearch.analytics.planner.dag.StageExecutionType;
+import org.opensearch.analytics.spi.ExchangeSink;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.tasks.TaskId;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link PlanWalker}'s terminal-sink close-on-failure contract.
+ * Covers gaps not exercised through {@code RowProducingSink}: non-closeable sources,
+ * throwing closes, and the close-fires-exactly-once invariant.
+ */
+public class PlanWalkerTests extends OpenSearchTestCase {
+
+    private StageExecutionBuilder builder;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        builder = new StageExecutionBuilder(mock(org.opensearch.cluster.service.ClusterService.class), null);
+    }
+
+    public void testFailedTransitionClosesClosableTerminalSinkExactlyOnce() {
+        CountingCloseSink sink = new CountingCloseSink();
+        Stage rootStage = stageWithId(0);
+        TestRootExecution root = new TestRootExecution(rootStage, sink);
+        builder.registerScheduler(StageExecutionType.LOCAL_PASSTHROUGH, (stage, s, cfg) -> root);
+
+        AtomicReference<Exception> onFailure = new AtomicReference<>();
+        PlanWalker walker = new PlanWalker(
+            queryCtx(rootStage),
+            builder,
+            ActionListener.wrap(r -> fail("unexpected success"), onFailure::set)
+        );
+        walker.build();
+        walker.wireCompletion();
+
+        RuntimeException rootCause = new RuntimeException("stage failed");
+        root.failWith(rootCause);
+
+        assertEquals("terminal sink close fires exactly once on FAILED", 1, sink.closeCalls.get());
+        assertSame("original failure propagated to completion listener", rootCause, onFailure.get());
+    }
+
+    public void testFailedTransitionSkipsCloseWhenSourceIsNotASink() {
+        // Source doesn't implement ExchangeSink — walker must skip close, still fire onFailure.
+        ExchangeSource source = new ExchangeSource() {
+            @Override
+            public Iterable<VectorSchemaRoot> readResult() {
+                return Collections.emptyList();
+            }
+
+            @Override
+            public long getRowCount() {
+                return 0;
+            }
+        };
+        Stage rootStage = stageWithId(0);
+        TestRootExecution root = new TestRootExecution(rootStage, source);
+        builder.registerScheduler(StageExecutionType.LOCAL_PASSTHROUGH, (stage, s, cfg) -> root);
+
+        AtomicReference<Exception> onFailure = new AtomicReference<>();
+        PlanWalker walker = new PlanWalker(
+            queryCtx(rootStage),
+            builder,
+            ActionListener.wrap(r -> fail("unexpected success"), onFailure::set)
+        );
+        walker.build();
+        walker.wireCompletion();
+
+        RuntimeException rootCause = new RuntimeException("non-sink source path");
+        root.failWith(rootCause);
+
+        assertSame("original failure propagated despite non-sink source", rootCause, onFailure.get());
+    }
+
+    public void testFailedTransitionStillFiresOriginalFailureWhenTerminalSinkCloseThrows() {
+        ThrowingCloseSink sink = new ThrowingCloseSink();
+        Stage rootStage = stageWithId(0);
+        TestRootExecution root = new TestRootExecution(rootStage, sink);
+        builder.registerScheduler(StageExecutionType.LOCAL_PASSTHROUGH, (stage, s, cfg) -> root);
+
+        AtomicReference<Exception> onFailure = new AtomicReference<>();
+        PlanWalker walker = new PlanWalker(
+            queryCtx(rootStage),
+            builder,
+            ActionListener.wrap(r -> fail("unexpected success"), onFailure::set)
+        );
+        walker.build();
+        walker.wireCompletion();
+
+        RuntimeException rootCause = new RuntimeException("original failure");
+        root.failWith(rootCause);
+
+        assertSame("original stage failure must reach the listener even when terminal sink close throws", rootCause, onFailure.get());
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────
+
+    private static Stage stageWithId(int id) {
+        Stage stage = mock(Stage.class);
+        when(stage.getStageId()).thenReturn(id);
+        when(stage.getChildStages()).thenReturn(List.of());
+        when(stage.getExecutionType()).thenReturn(StageExecutionType.LOCAL_PASSTHROUGH);
+        return stage;
+    }
+
+    private static QueryContext queryCtx(Stage rootStage) {
+        AnalyticsQueryTask task = new AnalyticsQueryTask(
+            1L,
+            "transport",
+            "analytics_query",
+            "q-test",
+            TaskId.EMPTY_TASK_ID,
+            java.util.Map.of(),
+            null
+        );
+        QueryDAG dag = new QueryDAG("q-test", rootStage);
+        return new QueryContext(dag, Runnable::run, task, 1, Long.MAX_VALUE);
+    }
+
+    /**
+     * Minimal {@link StageExecution} + {@link DataProducer} for driving PlanWalker's
+     * completion listener. Implemented against the public interface so we don't
+     * depend on package-private {@code AbstractStageExecution}.
+     */
+    private static final class TestRootExecution implements StageExecution, DataProducer {
+        private final Stage stage;
+        private final ExchangeSource source;
+        private final AtomicReference<State> state = new AtomicReference<>(State.CREATED);
+        private final AtomicReference<Exception> failure = new AtomicReference<>();
+        private final List<StageStateListener> listeners = new ArrayList<>();
+        private final StageMetrics metrics = new StageMetrics();
+
+        TestRootExecution(Stage stage, ExchangeSource source) {
+            this.stage = stage;
+            this.source = source;
+        }
+
+        @Override
+        public int getStageId() {
+            return stage.getStageId();
+        }
+
+        @Override
+        public State getState() {
+            return state.get();
+        }
+
+        @Override
+        public StageMetrics getMetrics() {
+            return metrics;
+        }
+
+        @Override
+        public void start() {}
+
+        @Override
+        public void addStateListener(StageStateListener listener) {
+            listeners.add(listener);
+        }
+
+        @Override
+        public Exception getFailure() {
+            return failure.get();
+        }
+
+        @Override
+        public boolean failFromChild(Exception cause) {
+            failure.compareAndSet(null, cause);
+            State prev = state.getAndSet(State.FAILED);
+            if (prev == State.FAILED || prev == State.SUCCEEDED || prev == State.CANCELLED) {
+                return false;
+            }
+            for (StageStateListener l : listeners) {
+                l.onStateChange(prev, State.FAILED);
+            }
+            return true;
+        }
+
+        @Override
+        public void cancel(String reason) {
+            State prev = state.getAndSet(State.CANCELLED);
+            if (prev == State.FAILED || prev == State.SUCCEEDED || prev == State.CANCELLED) {
+                return;
+            }
+            for (StageStateListener l : listeners) {
+                l.onStateChange(prev, State.CANCELLED);
+            }
+        }
+
+        @Override
+        public ExchangeSource outputSource() {
+            return source;
+        }
+
+        void failWith(Exception cause) {
+            failFromChild(cause);
+        }
+    }
+
+    /** Sink+Source that counts close() invocations. */
+    private static final class CountingCloseSink implements ExchangeSink, ExchangeSource {
+        final AtomicInteger closeCalls = new AtomicInteger();
+
+        @Override
+        public void feed(VectorSchemaRoot batch) {
+            batch.close();
+        }
+
+        @Override
+        public void close() {
+            closeCalls.incrementAndGet();
+        }
+
+        @Override
+        public Iterable<VectorSchemaRoot> readResult() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public long getRowCount() {
+            return 0;
+        }
+    }
+
+    /** Sink+Source whose close() throws — models a misbehaving terminal collector. */
+    private static final class ThrowingCloseSink implements ExchangeSink, ExchangeSource {
+        @Override
+        public void feed(VectorSchemaRoot batch) {
+            batch.close();
+        }
+
+        @Override
+        public void close() {
+            throw new IllegalStateException("close() throws by design");
+        }
+
+        @Override
+        public Iterable<VectorSchemaRoot> readResult() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public long getRowCount() {
+            return 0;
+        }
+    }
+}

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/stage/LocalStageExecutionTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/stage/LocalStageExecutionTests.java
@@ -133,6 +133,47 @@ public class LocalStageExecutionTests extends OpenSearchTestCase {
         assertTrue(backend.closed);
     }
 
+    /**
+     * Cascade-driven double-close: a child failure causes failFromChild to close
+     * the backend sink and transition FAILED. A subsequent external cancel (e.g.
+     * task-cancel after the cascade has already failed the stage) must not close
+     * the sink a second time — streaming reduce sinks block on draining the
+     * native pipeline, and concurrent closes serialize on the sink's feedLock.
+     */
+    public void testCancelAfterFailFromChildDoesNotDoubleCloseBackendSink() {
+        CapturingSink backend = new CapturingSink();
+        LocalStageExecution exec = new LocalStageExecution(stageWithId(0), backend, new CapturingSink());
+
+        exec.failFromChild(new RuntimeException("child failed"));
+        assertEquals(StageExecution.State.FAILED, exec.getState());
+        assertEquals("first close fires from failFromChild", 1, backend.closeCount);
+
+        exec.cancel("late external cancel");
+
+        assertEquals("first terminal wins; cancel does not transition", StageExecution.State.FAILED, exec.getState());
+        assertEquals("backend sink close fires exactly once across both calls", 1, backend.closeCount);
+    }
+
+    /**
+     * Symmetric case: external cancel runs first, then a child-failure cascade
+     * fires failFromChild on the already-CANCELLED stage. failFromChild's
+     * transitionTo returns false but must not close the sink a second time.
+     */
+    public void testFailFromChildAfterCancelDoesNotDoubleCloseBackendSink() {
+        CapturingSink backend = new CapturingSink();
+        LocalStageExecution exec = new LocalStageExecution(stageWithId(0), backend, new CapturingSink());
+
+        exec.cancel("external cancel first");
+        assertEquals(StageExecution.State.CANCELLED, exec.getState());
+        assertEquals("first close fires from cancel", 1, backend.closeCount);
+
+        boolean transitioned = exec.failFromChild(new RuntimeException("late child failure"));
+
+        assertFalse("transition rejected — already terminal", transitioned);
+        assertEquals(StageExecution.State.CANCELLED, exec.getState());
+        assertEquals("backend sink close fires exactly once across both calls", 1, backend.closeCount);
+    }
+
     // ── helpers ──────────────────────────────────────────────────────────
 
     private Stage stageWithId(int id) {
@@ -146,6 +187,7 @@ public class LocalStageExecutionTests extends OpenSearchTestCase {
     private static final class CapturingSink implements ExchangeSink {
         final List<VectorSchemaRoot> fed = new ArrayList<>();
         boolean closed = false;
+        int closeCount = 0;
 
         @Override
         public void feed(VectorSchemaRoot batch) {
@@ -155,9 +197,11 @@ public class LocalStageExecutionTests extends OpenSearchTestCase {
         @Override
         public void close() {
             closed = true;
+            closeCount++;
             for (VectorSchemaRoot batch : fed) {
                 batch.close();
             }
+            fed.clear();
         }
     }
 }

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/stage/ShardFragmentStageExecutionTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/stage/ShardFragmentStageExecutionTests.java
@@ -164,7 +164,6 @@ public class ShardFragmentStageExecutionTests extends OpenSearchTestCase {
 
     private QueryContext mockQueryContext() {
         QueryContext config = mock(QueryContext.class);
-        when(config.searchExecutor()).thenReturn(Runnable::run);
         when(config.parentTask()).thenReturn(mock(AnalyticsQueryTask.class));
         when(config.maxConcurrentShardRequests()).thenReturn(5);
         when(config.bufferAllocator()).thenReturn(allocator);


### PR DESCRIPTION


<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Three independent fixes to coordinator-stage cleanup that previously left queries hung or leaked Arrow buffers on failure:

- ShardFragmentStageExecution: surface outputSink.feed() failures via captureFailure + decrement inFlight inline. Without this, an exception on the streaming virtual thread never reached the stage state machine and the stage hung to QUERY_TIMEOUT.

- PlanWalker: close terminal sink on FAILED/CANCELLED before firing the completion listener, and bundle partial-build cancel cleanup. Failure paths previously skipped the per-batch close that batchesToRows runs on success, leaking VSRs into the per-query allocator close check.

- LocalStageExecution: close the backend sink before transitioning to a terminal state. Closing after the transition raced the parent stage's drain — by the time the backend sink finished its FFI close, the parent had already inferred end-of-input from the state change.

Adds PlanWalkerTests covering the terminal-sink-close-on-failure contract: closeable terminal sink fires close exactly once on FAILED; non-closeable source skips close cleanly; close-throwing sink doesn't mask the original stage failure en route to the listener.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
