### PR TITLE
[analytics-engine] Coverage fixes for search command on the analytics-engine route

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_executor.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_executor.rs
@@ -450,6 +450,7 @@ pub async unsafe fn execute_indexed_with_context(
     let (segments, schema) = build_segments(&state, Arc::clone(&store), object_metas.as_ref(), writer_generations.as_ref())
         .await
         .map_err(DataFusionError::Execution)?;
+    let schema = crate::schema_coerce::coerce_inferred_schema(schema);
     for (i, seg) in segments.iter().enumerate() {
     }
 

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionAnalyticsBackendPlugin.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionAnalyticsBackendPlugin.java
@@ -232,11 +232,9 @@ public class DataFusionAnalyticsBackendPlugin implements AnalyticsSearchBackendP
         // see a real time/date type and Isthmus serializes accordingly.
         ScalarFunction.TIME,
         ScalarFunction.DATE,
+        ScalarFunction.TIMESTAMP,
         // PPL `datetime(expr)` — parse/cast into a TIMESTAMP. Routes to DF's
-        // builtin `to_timestamp` via DatetimeAdapter. The single-arg
-        // `timestamp(expr)` form shares these semantics but its ScalarFunction
-        // slot is already bound to TimestampFunctionAdapter for VARCHAR literal
-        // folding, so it stays on the legacy engine.
+        // builtin `to_timestamp` via DatetimeAdapter.
         ScalarFunction.DATETIME,
         // PPL extract / make* / format / from_unixtime are implemented as Rust UDFs
         // to preserve MySQL semantics that DataFusion builtins don't match: EXTRACT

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatetimeOutputCastRewriter.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatetimeOutputCastRewriter.java
@@ -82,9 +82,15 @@ final class DatetimeOutputCastRewriter {
     /**
      * PPL's documented timestamp output format (space separator). Mirrors the
      * format used by Calcite's reference planner so the analytics-engine path
-     * matches per-row output exactly.
+     * matches per-row output exactly. The trailing {@code %.f} is chrono's
+     * variable-length fractional-second specifier — a leading dot followed by
+     * 0-9 digits, omitted when the value has no sub-second precision. This
+     * matches PPL's legacy formatting for {@code date} and {@code date_nanos}
+     * fields where the displayed precision tracks the source value (e.g.
+     * {@code "2024-01-15 10:30:01.23456789"} for a date_nanos with 8 fractional
+     * digits, {@code "2025-08-01 03:47:41"} for a whole-second value).
      */
-    static final String PPL_TIMESTAMP_FORMAT = "%Y-%m-%d %H:%M:%S";
+    static final String PPL_TIMESTAMP_FORMAT = "%Y-%m-%d %H:%M:%S%.f";
 
     private DatetimeOutputCastRewriter() {}
 

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatetimeOutputCastRewriterTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatetimeOutputCastRewriterTests.java
@@ -55,8 +55,11 @@ public class DatetimeOutputCastRewriterTests extends OpenSearchTestCase {
 
     /**
      * Motivating shape: outer Project slot is exactly {@code CAST(<TIMESTAMP> AS VARCHAR)}.
-     * Rewriter must replace it with a {@code TO_CHAR(<TIMESTAMP>, '%Y-%m-%d %H:%M:%S')}
-     * call whose result type matches the original cast's VARCHAR type.
+     * Rewriter must replace it with a {@code TO_CHAR(<TIMESTAMP>, '%Y-%m-%d %H:%M:%S%.f')}
+     * call whose result type matches the original cast's VARCHAR type. The {@code %.f}
+     * tail is chrono's variable-length fractional-seconds specifier so source values
+     * with sub-second precision (DATE_NANOS) keep their fractional digits while
+     * whole-second values display cleanly without a trailing decimal.
      */
     public void testDirectTimestampOutputCastIsRewrittenToToChar() {
         RelDataType timestampType = typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.TIMESTAMP, 6), true);
@@ -236,11 +239,11 @@ public class DatetimeOutputCastRewriterTests extends OpenSearchTestCase {
     }
 
     /**
-     * The format string is {@code "%Y-%m-%d %H:%M:%S"} — seconds-only — to match
-     * Calcite's reference output for {@code CAST(TIMESTAMP AS VARCHAR)}, which
-     * truncates fractional seconds. This pins that contract: a TIMESTAMP(9)
-     * source still resolves to the seconds-only format literal in the
-     * rewritten {@code TO_CHAR} call.
+     * The format string is precision-agnostic: a TIMESTAMP(0) and a TIMESTAMP(9)
+     * source both resolve to the same {@code "%Y-%m-%d %H:%M:%S%.f"} literal in the
+     * rewritten {@code TO_CHAR} call. The {@code %.f} tail handles the runtime
+     * variation — whole-second values render without a trailing decimal, sub-second
+     * values render with as many fractional digits as the source carries.
      */
     public void testTimestampPrecisionDoesNotChangeFormat() {
         RelDataType nanoTimestampType = typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.TIMESTAMP, 9), true);
@@ -255,7 +258,7 @@ public class DatetimeOutputCastRewriterTests extends OpenSearchTestCase {
         RexCall call = (RexCall) ((LogicalProject) rewritten).getProjects().get(0);
         RexLiteral formatLit = (RexLiteral) call.getOperands().get(1);
         assertEquals(
-            "TIMESTAMP(9) source must still resolve to the seconds-only format — fractional seconds are dropped",
+            "Format literal is precision-agnostic — chrono's %.f handles the per-value fractional digits",
             DatetimeOutputCastRewriter.PPL_TIMESTAMP_FORMAT,
             formatLit.getValueAs(String.class)
         );

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/DefaultPlanExecutor.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/DefaultPlanExecutor.java
@@ -118,6 +118,14 @@ public class DefaultPlanExecutor extends HandledTransportAction<ActionRequest, A
                 executeInternal(logicalFragment, listener);
             } catch (Exception e) {
                 listener.onFailure(e);
+            } catch (AssertionError e) {
+                // Calcite's Litmus.THROW (used by RelOptUtil.eq, RexUtil.isFlat, Project.isValid,
+                // RexChecker) throws AssertionError directly via Java code rather than via the
+                // `assert` keyword, so JVM -da doesn't gate them. If one fires inside this
+                // executor, OpenSearchUncaughtExceptionHandler exits the cluster JVM. Convert to
+                // an IllegalStateException so the query path treats it as a per-query failure
+                // (HTTP 500 with a bucketable message) instead of cluster-fatal.
+                listener.onFailure(new IllegalStateException("Analytics-engine executor rejected the plan: " + e.getMessage(), e));
             }
         });
     }


### PR DESCRIPTION
### What this PR does

Four focused fixes in the analytics-engine sandbox plugins, narrowly scoped to the `search` command's analytics-engine route.

| # | Commit | What it fixes |
|---|---|---|
| 1 | `Register TIMESTAMP in STANDARD_PROJECT_OPS` | PPL `timestamp(expr)` (also implicit when the analyzer coerces a string literal to TIMESTAMP for `@timestamp="..."` comparisons) was rejected by `OpenSearchProjectRule` even though `TimestampFunctionAdapter` already wires it to DataFusion's `to_timestamp`. |
| 2 | `Catch Calcite Litmus.THROW AssertionError in DefaultPlanExecutor` | Calcite's `Litmus.THROW` raises raw `AssertionError` from non-asserted Java. Without a catch, the analytics-engine executor lets it bubble to `OpenSearchUncaughtExceptionHandler` and kills the cluster JVM. Mirrors the SQL-plugin-side catch in `UnifiedQueryPlanner.plan`. |
| 3 | `Preserve fractional seconds in DatetimeOutputCastRewriter` | Widens the `to_char` format from `'%Y-%m-%d %H:%M:%S'` to `'%Y-%m-%d %H:%M:%S%.f'` so `date_nanos` columns keep sub-second precision in the response. Follow-up to [#21650](https://github.com/opensearch-project/OpenSearch/pull/21650). |
| 4 | `Apply schema coercion on indexed-executor placeholder` | The indexed-execution path inferred the parquet schema via `build_segments` and registered it directly on the `PlaceholderProvider` that `from_substrait_plan` binds against — bypassing the `schema_coerce::coerce_inferred_schema` that the three other `infer_schema` sites (session_context, query_executor, api) all apply. So parquet's `BinaryView` for `ip` columns leaked to the substrait bind step, conflicting with isthmus's `Binary`. One-line fix: call `coerce_inferred_schema` on the schema returned by `build_segments`. |

### Why commit 4 matters

Without commit 4, every analytics-engine query against an OTEL-logs-style index (any mapping that includes an `ip` field) fails at fragment start with:

```
Substrait error: Field 'attributes.client.ip' in Substrait schema has a different type
(Binary) than the corresponding field in the table schema (BinaryView).
```

The Substrait plan declares `Binary` (isthmus has no view types), the table provider reports `BinaryView` (parquet's storage form). The three other `infer_schema` call sites coerce; only the indexed-executor path slipped. Adding the missing coerce call restores parity.

### Pass / fail breakdown

`CalciteSearchCommandIT` on the analytics-engine route, against current `upstream/main`:

| Step | PASS / 52 |
|---|---|
| Pre-#21631 baseline | 3 |
| + #21631 (IP/BINARY/MATCH_ONLY_TEXT scan + `schema_coerce` BinaryView↔Utf8) | ~24 |
| + #21698 + #21628 + #21622 + #21562 (unsupported-type drop + PPL conversion + dedup + relevance functions on Lucene secondary) | 27 (indexed-executor schema_coerce gap surfaces here) |
| + Commit 4 (schema_coerce on indexed-executor) | 34 (+7 — every OTEL-logs query that scans an `ip` column unblocked at the bind step) |
| + Commits 1, 2, 3 (TIMESTAMP capability, Litmus catch, fractional seconds) | 34 (no new passes; safety / precision improvements that the existing test queries don't directly assert on) |
| + [opensearch-project/sql#5447](https://github.com/opensearch-project/sql/pull/5447) (correctness fixes: datetime schema-type recovery + IP `byte[]` → `ExprIpValue`) | **26** |

The drop from 34 → 26 with sql#5447 is **not a regression**: sql#5447's earlier iteration carried an SQL-side workaround (lower numeric / boolean predicates to typed `RexCall` to skip `query_string`) that lifted the same suite to 38 / 52. That workaround was deliberately removed in the latest sql#5447 revision because the root cause — **Lucene-secondary `query_string` doesn't re-type literals inside the query body using the field mapping** — should be fixed at the Lucene-secondary layer rather than in every consumer.

### Remaining 25 failures — single upstream root cause, not blocking this PR

All 25 collapse to the typed-literal `query_string` gap on the analytics-engine Lucene-secondary path (adjacent to [opensearch-project/OpenSearch#21562](https://github.com/opensearch-project/OpenSearch/pull/21562)):

- 5 numeric / decimal range tests
- 10 date-math / date range tests
- 4 compound-predicate tests (mixed-AND, same family as #21562's tests 10c / 10d that the author flagged as "handled separately")
- 2 attribute / multi-field tests
- 1 IP-via-`query_string` test
- 2 Lucene-secondary edge cases (wildcard pattern, NOT semantics)
- 1 composite-engine empty-mapping streaming test

See [opensearch-project/sql#5447](https://github.com/opensearch-project/sql/pull/5447) for the per-test bucketing and a minimal smoking-gun repro:

```
where query_string([severityText], "ERROR")               # ✅ works
where query_string([severityNumber], "severityNumber:>15") # ❌ 0 rows (expected 6)
```

### Testing

- **Sandbox-wide check**: `./gradlew check -p sandbox -Dsandbox.enabled=true` — see CI
- **`CalciteSearchCommandIT` on analytics route**: 26 / 52 pass with this PR + sql#5447 against current `upstream/main`
