### PR TITLE
[analytics-engine] Trim TableScan row type before scan viability check

### DIFF
--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/PlannerImpl.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/PlannerImpl.java
@@ -35,6 +35,7 @@ import org.opensearch.analytics.planner.rules.OpenSearchFilterRule;
 import org.opensearch.analytics.planner.rules.OpenSearchJoinRule;
 import org.opensearch.analytics.planner.rules.OpenSearchJoinSplitRule;
 import org.opensearch.analytics.planner.rules.OpenSearchProjectRule;
+import org.opensearch.analytics.planner.rules.OpenSearchScanFieldTrimmer;
 import org.opensearch.analytics.planner.rules.OpenSearchSortRule;
 import org.opensearch.analytics.planner.rules.OpenSearchSortSplitRule;
 import org.opensearch.analytics.planner.rules.OpenSearchTableScanRule;
@@ -109,6 +110,18 @@ public class PlannerImpl {
         reducePlanner.setRoot(afterPre);
         RelNode afterReduce = reducePlanner.findBestExp();
 
+        // Phase 1b.5: Required-field propagation. Walks the plan top-down via Calcite's
+        // RelFieldTrimmer dispatch and at each TableScan narrows the scan's row type to
+        // just the columns the plan actually requires. Runs as its own pass before
+        // marking so OpenSearchTableScanRule sees the narrowed scan and computes
+        // viability over read columns only — unread columns whose mapping type lacks a
+        // viable scan backend (e.g. geo_point, date_nanos) no longer reject the index.
+        // Subclassing the trimmer (rather than running a tactical Project(TableScan)
+        // rule) covers Project, Filter, Aggregate, Sort, Join, SetOp, and Project-over-
+        // RexOver shapes uniformly through Calcite's existing dispatch.
+        RelBuilder trimBuilder = RelBuilder.proto(Contexts.empty()).create(rawRelNode.getCluster(), null);
+        RelNode afterTrim = new OpenSearchScanFieldTrimmer(context, trimBuilder).trim(afterReduce);
+
         // Phase 1c: Marking — convert LogicalXxx → OpenSearchXxx bottom-up
         // TODO: migrate rules from deprecated RelOptRule to RelRule<Config> once the planner
         // moves to its own Gradle module. The OpenSearch monorepo injects -proc:none globally,
@@ -130,7 +143,7 @@ public class PlannerImpl {
             )
         );
         HepPlanner markingPlanner = new HepPlanner(markBuilder.build());
-        markingPlanner.setRoot(afterReduce);
+        markingPlanner.setRoot(afterTrim);
         RelNode marked = markingPlanner.findBestExp();
 
         LOGGER.info("After marking:\n{}", RelOptUtil.toString(marked));

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchScanFieldTrimmer.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchScanFieldTrimmer.java
@@ -1,0 +1,222 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.planner.rules;
+
+import org.apache.calcite.plan.RelOptAbstractTable;
+import org.apache.calcite.plan.RelOptTable;
+import org.apache.calcite.rel.core.Project;
+import org.apache.calcite.rel.core.TableScan;
+import org.apache.calcite.rel.logical.LogicalTableScan;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.sql2rel.RelFieldTrimmer;
+import org.apache.calcite.tools.RelBuilder;
+import org.apache.calcite.util.ImmutableBitSet;
+import org.apache.calcite.util.mapping.Mapping;
+import org.apache.calcite.util.mapping.Mappings;
+import org.opensearch.analytics.planner.CapabilityRegistry;
+import org.opensearch.analytics.planner.FieldStorageResolver;
+import org.opensearch.analytics.planner.PlannerContext;
+import org.opensearch.analytics.spi.FieldStorageInfo;
+import org.opensearch.cluster.metadata.IndexMetadata;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Required-field propagation pass for analytics-engine plans.
+ *
+ * <p>Walks the plan top-down via Calcite's {@link RelFieldTrimmer} dispatch (Project,
+ * Filter, Aggregate, Sort, Join, SetOp, etc.) and at each {@link TableScan} narrows the
+ * scan's row type to only the columns the plan actually requires. The narrowed scan is
+ * then visible to {@link OpenSearchTableScanRule}, whose viability check is computed
+ * over the scan's exposed columns — so columns the query never reads (e.g. an unread
+ * {@code geo_point} on the same index) cannot reject viability for the index.
+ *
+ * <p>Why subclass {@link RelFieldTrimmer} instead of writing a tactical
+ * {@code Project(TableScan)} rule:
+ * <ul>
+ *   <li>The trimmer covers Project-over-Filter, Aggregate, Sort, Join, SetOp, and
+ *       Project-over-RexOver shapes uniformly. A pattern-based rule would need a case
+ *       per parent operator.</li>
+ *   <li>Calcite's {@link org.apache.calcite.plan.RelOptUtil.InputFinder} is the
+ *       canonical input-ref collector — it walks {@code RexCall}, {@code RexOver},
+ *       {@code RexCorrelVariable}, and other rex shapes correctly. Reusing it avoids
+ *       a hand-rolled recursion that drifts out of sync with new rex node types.</li>
+ *   <li>The {@link TrimResult} contract guarantees a {@code SourceMapping} that lets
+ *       the parent re-target its references to the narrowed child without manual
+ *       index bookkeeping.</li>
+ * </ul>
+ *
+ * <p>Window note: Calcite 1.41 has no {@code trimFields(Window, ...)} overload, so a
+ * top-level {@code Window} (a {@code LogicalWindow}, distinct from a {@code RexOver}
+ * inside a {@code Project}) falls into the generic-{@code RelNode} path that asks all
+ * its children for every field. The analytics-engine planner currently lowers window
+ * functions as {@code RexOver} inside {@code LogicalProject} (the PPL eventstats /
+ * appendcol shape), which {@code Project}'s {@code InputFinder} traverses correctly,
+ * so this limitation does not affect the planner's existing window paths.
+ *
+ * @opensearch.internal
+ */
+public class OpenSearchScanFieldTrimmer extends RelFieldTrimmer {
+
+    private final PlannerContext context;
+
+    public OpenSearchScanFieldTrimmer(PlannerContext context, RelBuilder relBuilder) {
+        super(null, relBuilder);
+        this.context = context;
+    }
+
+    // ---- Project scope guard ----
+    //
+    // Calcite's default {@code trimFields(Project, ...)} drops projection expressions
+    // whose output is unread by the consumer. That is correct for general query-rewrite
+    // passes, but wrong here: a windowed expression (RexOver) on a {@code LogicalProject}
+    // is the analytics-engine's lowering for PPL eventstats / appendcol, and downstream
+    // {@link OpenSearchProjectRule} relies on the windowed Project surviving the trim
+    // pass — a stats query whose windowed column is consumed by an outer aggregate would
+    // otherwise have its windowed Project deleted by Calcite's standard DCE.
+    //
+    // Forcing {@code fieldsUsed} to the full output range tells Calcite's standard
+    // Project trim to keep every projection (line 525-527 short-circuits when input is
+    // unchanged; otherwise the rebuild path at lines 559-565 visits every projection
+    // because {@code fieldsUsed.get(ord.i)} is true for all i). The InputFinder still
+    // collects referenced inputs across all projections — so a TableScan beneath gets
+    // narrowed correctly. We do NOT override {@code trimFields(Aggregate|Join|SetOp,...)}:
+    // those operators' default trim is what produces the column narrowing we want for
+    // the scan, and their effect on intermediate column indices is benign.
+    @Override
+    public TrimResult trimFields(Project project, ImmutableBitSet fieldsUsed, Set<RelDataTypeField> extraFields) {
+        return super.trimFields(project, ImmutableBitSet.range(project.getRowType().getFieldCount()), extraFields);
+    }
+
+    /**
+     * Overrides Calcite's default {@code trimFields(TableScan, ...)} which wraps the scan in a
+     * {@code Project} (leaving the scan's row type untouched). We instead replace the scan with
+     * a {@link LogicalTableScan} whose {@link RelOptTable} reports a narrowed row type — that
+     * is what {@link OpenSearchTableScanRule} reads when computing viability.
+     *
+     * <p>{@code extraFields} is intentionally ignored: analytics-engine tables expose their
+     * full schema through {@code RelOptTable.getRowType()}, and there are no
+     * non-row-type system columns (transaction id, version, snapshot, etc.) that callers can
+     * request via {@code extraFields}. Honoring an empty {@code extraFields} contract still
+     * preserves correctness for every caller in the analytics-engine flow.
+     */
+    @Override
+    public TrimResult trimFields(TableScan scan, ImmutableBitSet fieldsUsed, Set<RelDataTypeField> extraFields) {
+        List<RelDataTypeField> originalFields = scan.getRowType().getFieldList();
+        int fieldCount = originalFields.size();
+
+        if (fieldsUsed.cardinality() == fieldCount) {
+            // Plan reads every column; narrowing is a no-op.
+            return result(scan, Mappings.createIdentity(fieldCount));
+        }
+
+        ImmutableBitSet retained;
+        if (fieldsUsed.isEmpty()) {
+            // The plan reads zero columns from this scan (literal-only project, count(*) over a
+            // bare scan, etc.). The scan still has to expose at least one column so downstream
+            // operators (and Calcite type assertions) have something to reference. Pick the
+            // first column whose mapping has a NATIVE scan backend (delegation is excluded —
+            // a delegation-only column passes viability but DataFusion fails at runtime when
+            // the field isn't physically present in the columnar file the native scan opens).
+            Integer placeholder = pickReadableColumn(scan, originalFields);
+            if (placeholder == null) {
+                // No readable column on this index — leave the scan alone so the scan rule's
+                // viability error still surfaces (correct behavior: the index genuinely cannot
+                // be read by any backend).
+                return result(scan, Mappings.createIdentity(fieldCount));
+            }
+            retained = ImmutableBitSet.of(placeholder);
+        } else {
+            retained = fieldsUsed;
+        }
+
+        // Build the narrowed row type, preserving original column order so the resulting
+        // schema is a strict prefix-preserving subset of the original.
+        RelDataTypeFactory.Builder narrowedBuilder = scan.getCluster().getTypeFactory().builder();
+        for (int oldIndex : retained) {
+            narrowedBuilder.add(originalFields.get(oldIndex));
+        }
+        RelDataType narrowedRowType = narrowedBuilder.build();
+
+        LogicalTableScan narrowedScan = LogicalTableScan.create(
+            scan.getCluster(),
+            new NarrowedRowTypeTable(scan.getTable(), narrowedRowType),
+            scan.getHints()
+        );
+
+        // Mapping contract: SourceMapping with sourceCount=fieldCount (original) and
+        // targetCount=retained.cardinality() (narrowed). For each surviving original index
+        // i, mapping.set(i, newIndex) tells the parent "field i of the original lives at
+        // newIndex of the narrowed output". The createMapping helper inherited from
+        // RelFieldTrimmer builds exactly that shape.
+        Mapping mapping = createMapping(retained, fieldCount);
+
+        // result(...) preserves rel hints from the original scan and runs the correlation-
+        // variable rewrite pass — required for any tree that contains a LogicalCorrelate.
+        return result(narrowedScan, mapping, scan);
+    }
+
+    /**
+     * Returns the index of the first column whose mapping has a NATIVE scan backend.
+     * Delegation is intentionally excluded here: a placeholder column has to actually
+     * be present in the on-disk format the executing backend reads (e.g. a parquet
+     * field for the datafusion backend). A delegation-only column passes
+     * {@link OpenSearchTableScanRule}'s viability check but DataFusion fails at
+     * runtime with {@code Schema error: No field named <col>} because the field
+     * doesn't exist in the columnar file the native scan opens.
+     *
+     * <p>Returns {@code null} if no native scan-capable column exists, or if the
+     * index is not in cluster state. Skips derived columns: derived fields cannot
+     * legally appear in a {@code TableScan} row type (the scan rule throws on
+     * encountering one), so leaving them out of the placeholder pool keeps the
+     * trimmer aligned with that invariant.
+     */
+    private Integer pickReadableColumn(TableScan scan, List<RelDataTypeField> originalFields) {
+        String tableName = scan.getTable().getQualifiedName().getLast();
+        IndexMetadata indexMetadata = context.getClusterState().metadata().index(tableName);
+        if (indexMetadata == null) {
+            return null;
+        }
+
+        CapabilityRegistry registry = context.getCapabilityRegistry();
+        FieldStorageResolver resolver = registry.resolveFieldStorage(indexMetadata);
+        List<String> fieldNames = originalFields.stream().map(RelDataTypeField::getName).toList();
+        List<FieldStorageInfo> fieldStorage = resolver.resolve(fieldNames);
+
+        for (int i = 0; i < fieldStorage.size(); i++) {
+            FieldStorageInfo info = fieldStorage.get(i);
+            if (info.isDerived()) {
+                continue;
+            }
+            if (!registry.scanBackendsForField(info).isEmpty()) {
+                return i;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Wraps a {@code RelOptTable} returning a narrower row type than the underlying table.
+     * Used to feed a pruned schema into a {@link LogicalTableScan} without subclassing
+     * Calcite's {@code TableScan} or rebuilding the schema at the {@code SchemaPlus} level.
+     */
+    private static class NarrowedRowTypeTable extends RelOptAbstractTable {
+        NarrowedRowTypeTable(RelOptTable delegate, RelDataType rowType) {
+            super(delegate.getRelOptSchema(), nameFrom(delegate), rowType);
+        }
+
+        private static String nameFrom(RelOptTable delegate) {
+            List<String> qualifiedName = delegate.getQualifiedName();
+            return qualifiedName.get(qualifiedName.size() - 1);
+        }
+    }
+}

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchTableScanRule.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchTableScanRule.java
@@ -27,8 +27,14 @@ import java.util.List;
 
 /**
  * Converts {@link TableScan} → {@link OpenSearchTableScan}.
- * Resolves backend from index data format settings and populates
- * per-column {@link FieldStorageInfo} from IndexMetadata mappings.
+ * Resolves backend from index data format settings and populates per-column
+ * {@link FieldStorageInfo} from IndexMetadata mappings.
+ *
+ * <p>Viability is computed only over the columns the scan currently exposes — its row
+ * type is narrowed to query-referenced columns by {@link OpenSearchScanFieldTrimmer}
+ * before this rule fires. Columns the query does not reference (e.g. an unread
+ * {@code geo_point} field on the same index) are not part of the row type at this
+ * point and therefore do not affect viability.
  *
  * @opensearch.internal
  */
@@ -59,8 +65,10 @@ public class OpenSearchTableScanRule extends RelOptRule {
         CapabilityRegistry registry = context.getCapabilityRegistry();
         FieldStorageResolver fieldStorageResolver = registry.resolveFieldStorage(indexMetadata);
 
-        // TODO : This expects the FrontEnds to attach the row type with all fields.
-        // TODO : How will they attach if we perform the index resolution
+        // Resolves storage for columns currently in the scan's row type — already narrowed to
+        // query-referenced columns by OpenSearchScanFieldTrimmer. Frontends are responsible
+        // for attaching the full row type at parse time; the trimmer narrows it before
+        // marking begins.
         List<String> fieldNames = scan.getRowType().getFieldList().stream().map(RelDataTypeField::getName).toList();
         List<FieldStorageInfo> fieldStorage = fieldStorageResolver.resolve(fieldNames);
 

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/OpenSearchScanFieldTrimmerTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/OpenSearchScanFieldTrimmerTests.java
@@ -1,0 +1,337 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.planner;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.calcite.plan.RelOptTable;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.AggregateCall;
+import org.apache.calcite.rel.core.JoinRelType;
+import org.apache.calcite.rel.core.TableScan;
+import org.apache.calcite.rel.logical.LogicalAggregate;
+import org.apache.calcite.rel.logical.LogicalFilter;
+import org.apache.calcite.rel.logical.LogicalJoin;
+import org.apache.calcite.rel.logical.LogicalProject;
+import org.apache.calcite.rel.logical.LogicalSort;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.util.ImmutableBitSet;
+import org.opensearch.analytics.planner.rel.OpenSearchTableScan;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Tests for {@link org.opensearch.analytics.planner.rules.OpenSearchScanFieldTrimmer}
+ * exercised end-to-end via {@link PlannerImpl#markAndOptimize}.
+ *
+ * <p>The trimmer's contract is to narrow each {@code TableScan}'s row type to the columns
+ * the plan actually requires (collected via Calcite's required-field propagation through
+ * Project / Filter / Aggregate / Sort / Join / SetOp / Project-over-RexOver) before
+ * {@code OpenSearchTableScanRule} resolves backend viability. The high-leverage scenario
+ * is an index that contains a column whose mapping type has no scan-capable backend
+ * (e.g. {@code geo_point} on a parquet-only cluster) — without the trimmer, the scan
+ * rule rejects the whole index even when the query never reads that column.
+ */
+public class OpenSearchScanFieldTrimmerTests extends BasePlannerRulesTests {
+
+    public void testProjectOverScanNarrowsToReferencedColumn() {
+        // Project reads only `status`; `loc` (geo_point) is unread. Without trimming the
+        // unread geo_point would block viability for the whole index.
+        PlannerContext context = buildContext("parquet", twoIntsPlusGeoPoint());
+        RelOptTable table = mockThreeColTable();
+        TableScan scan = stubScan(table);
+
+        RelDataType intType = scan.getRowType().getFieldList().get(0).getType();
+        LogicalProject project = LogicalProject.create(
+            scan,
+            List.of(),
+            List.of(rexBuilder.makeInputRef(intType, 0)),
+            (List<String>) null,
+            Set.of()
+        );
+
+        OpenSearchTableScan narrowedScan = findScan(unwrapExchange(runPlanner(project, context)));
+        assertNotNull(narrowedScan);
+        assertEquals(1, narrowedScan.getOutputFieldStorage().size());
+        assertEquals("status", narrowedScan.getOutputFieldStorage().get(0).getFieldName());
+    }
+
+    public void testProjectOverFilterPropagatesFilterRefsThroughToScan() {
+        // SELECT status FROM t WHERE size > 0 — filter refers to `size`, project to `status`,
+        // both must survive the trim. `loc` (geo_point) must be dropped.
+        PlannerContext context = buildContext("parquet", twoIntsPlusGeoPoint());
+        RelOptTable table = mockThreeColTable();
+        TableScan scan = stubScan(table);
+
+        RelDataType intType = scan.getRowType().getFieldList().get(0).getType();
+        RexNode sizeGtZero = rexBuilder.makeCall(
+            SqlStdOperatorTable.GREATER_THAN,
+            rexBuilder.makeInputRef(intType, 1),
+            rexBuilder.makeLiteral(0, intType, true)
+        );
+        LogicalFilter filter = LogicalFilter.create(scan, sizeGtZero);
+        LogicalProject project = LogicalProject.create(
+            filter,
+            List.of(),
+            List.of(rexBuilder.makeInputRef(intType, 0)),
+            (List<String>) null,
+            Set.of()
+        );
+
+        OpenSearchTableScan narrowedScan = findScan(unwrapExchange(runPlanner(project, context)));
+        assertNotNull(narrowedScan);
+        assertEquals(2, narrowedScan.getOutputFieldStorage().size());
+        // Original column order is preserved (status before size).
+        assertEquals("status", narrowedScan.getOutputFieldStorage().get(0).getFieldName());
+        assertEquals("size", narrowedScan.getOutputFieldStorage().get(1).getFieldName());
+    }
+
+    public void testAggregateCountStarDropsAllScanColumnsButLeavesPlaceholder() {
+        // SELECT count(*) FROM t — aggregate references zero scan columns. The trimmer
+        // must leave at least one readable column so the scan still has a row type.
+        PlannerContext context = buildContext("parquet", twoIntsPlusGeoPoint());
+        RelOptTable table = mockThreeColTable();
+        TableScan scan = stubScan(table);
+
+        AggregateCall countStar = AggregateCall.create(
+            SqlStdOperatorTable.COUNT,
+            false,
+            List.of(),
+            -1,
+            scan,
+            typeFactory.createSqlType(SqlTypeName.BIGINT),
+            "count_star"
+        );
+        LogicalAggregate aggregate = LogicalAggregate.create(scan, List.of(), ImmutableBitSet.of(), null, List.of(countStar));
+
+        OpenSearchTableScan narrowedScan = findScan(unwrapExchange(runPlanner(aggregate, context)));
+        assertNotNull(narrowedScan);
+        // Exactly one placeholder column survives — and it must be a readable scalar (status
+        // or size), never the unreadable geo_point `loc`.
+        assertEquals(1, narrowedScan.getOutputFieldStorage().size());
+        String placeholder = narrowedScan.getOutputFieldStorage().get(0).getFieldName();
+        assertTrue(
+            "Placeholder must be a readable column, was [" + placeholder + "]",
+            placeholder.equals("status") || placeholder.equals("size")
+        );
+    }
+
+    public void testAggregateGroupByStatusSumSizeNarrowsToReferencedColumns() {
+        // SELECT status, sum(size) FROM t GROUP BY status — both `status` (group key) and
+        // `size` (aggregate input) must survive trimming. `loc` (geo_point) is unread and
+        // must be dropped before the scan rule's viability check runs.
+        PlannerContext context = buildContext("parquet", twoIntsPlusGeoPoint());
+        RelOptTable table = mockThreeColTable();
+        TableScan scan = stubScan(table);
+
+        AggregateCall sumSize = AggregateCall.create(
+            SqlStdOperatorTable.SUM,
+            false,
+            List.of(1),
+            -1,
+            scan,
+            typeFactory.createSqlType(SqlTypeName.INTEGER),
+            "sum_size"
+        );
+        LogicalAggregate aggregate = LogicalAggregate.create(scan, List.of(), ImmutableBitSet.of(0), null, List.of(sumSize));
+
+        OpenSearchTableScan narrowedScan = findScan(unwrapExchange(runPlanner(aggregate, context)));
+        assertNotNull(narrowedScan);
+        assertEquals(2, narrowedScan.getOutputFieldStorage().size());
+        // Original column order is preserved.
+        assertEquals("status", narrowedScan.getOutputFieldStorage().get(0).getFieldName());
+        assertEquals("size", narrowedScan.getOutputFieldStorage().get(1).getFieldName());
+    }
+
+    public void testProjectOverSortOverFilterCollectsFromAllThreeOperators() {
+        // SELECT status FROM t WHERE size > 0 ORDER BY status — three layers; the sort
+        // collation references `status`, the filter `size`, the project `status`. Trim
+        // should keep both scalars and drop `loc`.
+        PlannerContext context = buildContext("parquet", twoIntsPlusGeoPoint());
+        RelOptTable table = mockThreeColTable();
+        TableScan scan = stubScan(table);
+
+        RelDataType intType = scan.getRowType().getFieldList().get(0).getType();
+        RexNode sizeGtZero = rexBuilder.makeCall(
+            SqlStdOperatorTable.GREATER_THAN,
+            rexBuilder.makeInputRef(intType, 1),
+            rexBuilder.makeLiteral(0, intType, true)
+        );
+        LogicalFilter filter = LogicalFilter.create(scan, sizeGtZero);
+        LogicalSort sort = LogicalSort.create(
+            filter,
+            org.apache.calcite.rel.RelCollations.of(new org.apache.calcite.rel.RelFieldCollation(0)),
+            null,
+            null
+        );
+        LogicalProject project = LogicalProject.create(
+            sort,
+            List.of(),
+            List.of(rexBuilder.makeInputRef(intType, 0)),
+            (List<String>) null,
+            Set.of()
+        );
+
+        OpenSearchTableScan narrowedScan = findScan(unwrapExchange(runPlanner(project, context)));
+        assertNotNull(narrowedScan);
+        assertEquals(2, narrowedScan.getOutputFieldStorage().size());
+    }
+
+    public void testJoinOverTwoScansTrimEachIndependently() {
+        // Self-join on `status`; project picks `size` from one side. Each scan should be
+        // trimmed independently to only the columns referenced by its branch + the join
+        // condition.
+        PlannerContext context = buildContext("parquet", twoIntsPlusGeoPoint());
+        TableScan left = stubScan(mockThreeColTable());
+        TableScan right = stubScan(mockThreeColTable());
+
+        RelDataType intType = left.getRowType().getFieldList().get(0).getType();
+        // Join condition: left.status = right.status (left fields 0..2, right fields 3..5).
+        RexNode joinCond = rexBuilder.makeCall(
+            SqlStdOperatorTable.EQUALS,
+            rexBuilder.makeInputRef(intType, 0),
+            rexBuilder.makeInputRef(intType, 3)
+        );
+        LogicalJoin join = LogicalJoin.create(left, right, ImmutableList.of(), joinCond, Set.of(), JoinRelType.INNER);
+        // Project left.size only.
+        LogicalProject project = LogicalProject.create(
+            join,
+            List.of(),
+            List.of(rexBuilder.makeInputRef(intType, 1)),
+            (List<String>) null,
+            Set.of()
+        );
+
+        RelNode result = runPlanner(project, context);
+        // Two scans must remain in the marked tree, each with `loc` trimmed away.
+        long scanCount = countScans(result);
+        assertEquals("Expected two scans after marking the joined plan", 2L, scanCount);
+        forEachScan(result, narrowed -> {
+            for (var info : narrowed.getOutputFieldStorage()) {
+                assertNotEquals("geo_point column `loc` must not survive trimming", "loc", info.getFieldName());
+            }
+        });
+    }
+
+    public void testProjectReadingEveryColumnDoesNotNarrow() {
+        // SELECT status, size FROM t — the project reads every column on a 2-col index.
+        // The trimmer must leave the scan as-is (no synthetic narrowing).
+        PlannerContext context = buildContext("parquet", intFields());
+        RelOptTable table = mockTable("test_index", "status", "size");
+        TableScan scan = stubScan(table);
+
+        RelDataType intType = scan.getRowType().getFieldList().get(0).getType();
+        LogicalProject project = LogicalProject.create(
+            scan,
+            List.of(),
+            List.of(rexBuilder.makeInputRef(intType, 0), rexBuilder.makeInputRef(intType, 1)),
+            (List<String>) null,
+            Set.of()
+        );
+
+        OpenSearchTableScan narrowedScan = findScan(unwrapExchange(runPlanner(project, context)));
+        assertNotNull(narrowedScan);
+        assertEquals(2, narrowedScan.getOutputFieldStorage().size());
+    }
+
+    public void testLiteralOnlyProjectPicksReadablePlaceholderNotGeoPoint() {
+        // SELECT 1 FROM t — no input refs at all. Trimmer must pick a *readable* column
+        // (status or size), not the geo_point — otherwise it just relocates the same
+        // viability failure to the placeholder.
+        PlannerContext context = buildContext("parquet", twoIntsPlusGeoPoint());
+        RelOptTable table = mockThreeColTable();
+        TableScan scan = stubScan(table);
+
+        RelDataType intType = scan.getRowType().getFieldList().get(0).getType();
+        LogicalProject project = LogicalProject.create(
+            scan,
+            List.of(),
+            List.of(rexBuilder.makeLiteral(1, intType, true)),
+            (List<String>) null,
+            Set.of()
+        );
+
+        OpenSearchTableScan narrowedScan = findScan(unwrapExchange(runPlanner(project, context)));
+        assertNotNull(narrowedScan);
+        assertEquals(1, narrowedScan.getOutputFieldStorage().size());
+        String placeholder = narrowedScan.getOutputFieldStorage().get(0).getFieldName();
+        assertTrue(
+            "Placeholder must be a readable scalar (status/size), was [" + placeholder + "]",
+            placeholder.equals("status") || placeholder.equals("size")
+        );
+    }
+
+    public void testProjectExpressionStillCollectsTheReferencedColumn() {
+        // eval x = status + 1 — the project's only RexNode is a RexCall, but its leaf
+        // RexInputRef must still be discovered by the trimmer's input-finder traversal.
+        PlannerContext context = buildContext("parquet", twoIntsPlusGeoPoint());
+        RelOptTable table = mockThreeColTable();
+        TableScan scan = stubScan(table);
+
+        RelDataType intType = scan.getRowType().getFieldList().get(0).getType();
+        RexNode statusPlusOne = rexBuilder.makeCall(
+            SqlStdOperatorTable.PLUS,
+            rexBuilder.makeInputRef(intType, 0),
+            rexBuilder.makeLiteral(1, intType, true)
+        );
+        LogicalProject project = LogicalProject.create(scan, List.of(), List.of(statusPlusOne), (List<String>) null, Set.of());
+
+        OpenSearchTableScan narrowedScan = findScan(unwrapExchange(runPlanner(project, context)));
+        assertNotNull(narrowedScan);
+        assertEquals(1, narrowedScan.getOutputFieldStorage().size());
+        assertEquals("status", narrowedScan.getOutputFieldStorage().get(0).getFieldName());
+    }
+
+    // ---- helpers ----
+
+    private OpenSearchTableScan findScan(RelNode node) {
+        return RelNodeUtils.findNode(node, OpenSearchTableScan.class);
+    }
+
+    private long countScans(RelNode root) {
+        long[] counter = { 0L };
+        walkScans(root, s -> counter[0]++);
+        return counter[0];
+    }
+
+    private void forEachScan(RelNode root, java.util.function.Consumer<OpenSearchTableScan> fn) {
+        walkScans(root, fn);
+    }
+
+    private static void walkScans(RelNode node, java.util.function.Consumer<OpenSearchTableScan> fn) {
+        if (node instanceof OpenSearchTableScan scan) {
+            fn.accept(scan);
+            return;
+        }
+        for (RelNode input : node.getInputs()) {
+            walkScans(input, fn);
+        }
+    }
+
+    /**
+     * Three-column index: two readable INTEGERs + one geo_point that the parquet backend
+     * cannot scan. This is the canonical scan-viability shape — the trimmer must drop
+     * `loc` from the scan whenever the query does not actually read it.
+     */
+    private static Map<String, Map<String, Object>> twoIntsPlusGeoPoint() {
+        return Map.of("status", Map.of("type", "integer"), "size", Map.of("type", "integer"), "loc", Map.of("type", "geo_point"));
+    }
+
+    private RelOptTable mockThreeColTable() {
+        return mockTable(
+            "test_index",
+            new String[] { "status", "size", "loc" },
+            new SqlTypeName[] { SqlTypeName.INTEGER, SqlTypeName.INTEGER, SqlTypeName.VARCHAR }
+        );
+    }
+}

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/PlanShapeTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/PlanShapeTests.java
@@ -420,10 +420,14 @@ public class PlanShapeTests extends PlanShapeTestBase {
             List.of(countStarCall())
         );
         RelNode result = runPlanner(plan, perIndexContext(Map.of("left_idx", 2, "right_idx", 2)));
+        // Right scan is trimmed to its single join-key column by OpenSearchScanFieldTrimmer
+        // (the outer count-by-left.status query never reads any other right column), so the
+        // join condition's right-hand reference shifts from $2 (right.status @ position 2 in
+        // a 2-col-per-side join) to $1 (the only surviving right column).
         assertPlanShape(
             """
                 OpenSearchAggregate(group=[{0}], cnt=[COUNT(AGG_CALL_ANNOTATION(id=0, viableBackends=[mock-parquet]))], mode=[SINGLE], viableBackends=[[mock-parquet]])
-                  OpenSearchJoin(condition=[=($0, $2)], joinType=[inner], viableBackends=[[mock-parquet]])
+                  OpenSearchJoin(condition=[=($0, $1)], joinType=[inner], viableBackends=[[mock-parquet]])
                     OpenSearchExchangeReducer(viableBackends=[[mock-parquet]], exchange=[ExchangeInfo[distributionType=SINGLETON, partitionKeyIndices=[]]])
                       OpenSearchTableScan(table=[[left_idx]], viableBackends=[[mock-parquet]])
                     OpenSearchExchangeReducer(viableBackends=[[mock-parquet]], exchange=[ExchangeInfo[distributionType=SINGLETON, partitionKeyIndices=[]]])


### PR DESCRIPTION
## What changed

- Introduced `OpenSearchScanFieldTrimmer`, a Calcite `RelFieldTrimmer` subclass that walks the plan top-down and at each `TableScan` narrows the scan's row type to the columns the plan actually references.
- Added Phase 1b.5 in `PlannerImpl.markAndOptimize`, sandwiched between aggregate-reduction (Phase 1b) and marking (Phase 1c), so the marked tree sees the narrowed scan.
- Updated `OpenSearchTableScanRule`'s Javadoc to reflect the new contract: viability is computed strictly over the columns the scan currently exposes (already trimmed to query-referenced columns).
- Deleted the prior tactical `ProjectTableScanPushdownRule` and its test class — the trimmer subsumes their behavior on Project(TableScan) and extends it to every parent operator.

## Why

Indices that contain a column whose mapping type has no scan-capable backend on the target engine (e.g. `geo_point` or `date_nanos` on a parquet-only cluster) were rejecting `OpenSearchTableScanRule`'s viability check even when the query never read that column. The fix narrows `scan.getRowType()` to query-referenced columns before viability is computed, so unread mapping types whose backends cannot scan them no longer reject the index.

## Why a `RelFieldTrimmer` subclass instead of a tactical `Project(TableScan)` rule

- Calcite's trimmer dispatch covers Project, Filter, Aggregate, Sort, Join, SetOp, and Project-over-`RexOver` shapes uniformly. A pattern-based rule would need a case per parent operator and would have to be re-added every time a new parent shape was introduced.
- The trimmer reuses Calcite's canonical `RelOptUtil.InputFinder` to collect input references — it walks `RexCall`, `RexOver`, `RexCorrelVariable`, and other rex shapes correctly. New `RexNode` types are picked up automatically without hand-rolled recursion drift.
- The `TrimResult` contract returns a `SourceMapping` that lets the parent re-target its references to the narrowed child without manual index bookkeeping, eliminating the hand-coded re-indexing the tactical rule required.

## Known limitations (documented in code)

- Top-level `LogicalWindow` is unhandled because Calcite 1.41 has no `trimFields(Window, ...)` overload, so it falls into the generic-`RelNode` path that asks every child for every field. This does not affect today's PPL paths because eventstats / appendcol lower as `RexOver` inside `LogicalProject`, which the `Project` overload's `InputFinder` traverses correctly.
- When `fieldsUsed` is empty (literal-only project, `count(*)` over a bare scan), the trimmer must leave at least one column on the scan so downstream operators have a row type to reference. It picks the first column with a NATIVE scan backend — delegation is intentionally excluded, since a delegation-only placeholder passes viability but DataFusion fails at runtime with `Schema error: No field named <col>` because the field isn't physically in the columnar file the native scan opens.

## Verification

- New unit tests in `OpenSearchScanFieldTrimmerTests` (9 cases) cover Project-over-Scan, Project-over-Filter, Aggregate-count-star, Aggregate-with-group-by, Project-over-Sort-over-Filter, Join-over-two-scans, full-coverage-no-narrowing, literal-only-project placeholder selection, and Project-over-`RexCall` input-ref discovery — all green.
- Local CI gates green: `spotlessCheck` on analytics-engine + analytics-backend-datafusion, `:sandbox:plugins:analytics-engine:check` (34 test classes), `:sandbox:libs:analytics-framework:check`.
- Full A/B IT sweep across the calcite/remote integ-test classes is in progress; results will be posted as a follow-up comment, with any residual regressions addressed by follow-up commits on this branch.
