### PR TITLE
Added filter pushdown and capturing Calcite Rule Metrics for profiling

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/FilterDelegationForIndexFullConversionTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/FilterDelegationForIndexFullConversionTests.java
@@ -240,7 +240,7 @@ public class FilterDelegationForIndexFullConversionTests extends OpenSearchTestC
         LogicalFilter filter = LogicalFilter.create(new TableScan(cluster, cluster.traitSet(), List.of(), table) {
         }, condition);
 
-        RelNode marked = PlannerImpl.markAndOptimize(filter, context);
+        RelNode marked = PlannerImpl.runAllOptimizations(filter, context);
         QueryDAG dag = DAGBuilder.build(marked, context.getCapabilityRegistry(), mockClusterService());
         PlanForker.forkAll(dag, context.getCapabilityRegistry());
         FragmentConversionDriver.convertAll(dag, context.getCapabilityRegistry());

--- a/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/LuceneAnalyticsBackendPluginTests.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/LuceneAnalyticsBackendPluginTests.java
@@ -136,7 +136,7 @@ public class LuceneAnalyticsBackendPluginTests extends OpenSearchTestCase {
         LogicalFilter filter = LogicalFilter.create(new TableScan(cluster, cluster.traitSet(), List.of(), table) {
         }, condition);
 
-        RelNode marked = PlannerImpl.markAndOptimize(filter, context);
+        RelNode marked = PlannerImpl.runAllOptimizations(filter, context);
         QueryDAG dag = DAGBuilder.build(marked, context.getCapabilityRegistry(), mockClusterService());
         PlanForker.forkAll(dag, context.getCapabilityRegistry());
         FragmentConversionDriver.convertAll(dag, context.getCapabilityRegistry());

--- a/sandbox/plugins/analytics-engine/build.gradle
+++ b/sandbox/plugins/analytics-engine/build.gradle
@@ -146,6 +146,11 @@ dependencies {
 
   // Calcite bytecode references @Immutable from immutables — resolve at test compile time
   testCompileOnly 'org.immutables:value-annotations:2.8.8'
+
+  // CalciteCatalogReader's compile-time signature transitively requires Avatica's
+  // ConnectionConfigImpl (parent of CalciteConnectionConfigImpl). analytics-framework
+  // declares avatica-core as runtimeOnly only, so test compilation needs it explicitly.
+  testCompileOnly 'org.apache.calcite.avatica:avatica-core:1.27.0'
 }
 
 tasks.withType(JavaCompile).configureEach {

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/PlannerContext.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/PlannerContext.java
@@ -23,13 +23,34 @@ public class PlannerContext {
     private final CapabilityRegistry capabilityRegistry;
     private final ClusterState clusterState;
     private final OpenSearchDistributionTraitDef distributionTraitDef;
+    private final boolean profilingEnabled;
     private int annotationIdCounter;
+    private RuleProfilingListener.PlannerProfile lastProfile;
 
     public PlannerContext(CapabilityRegistry capabilityRegistry, ClusterState clusterState) {
+        this(capabilityRegistry, clusterState, false);
+    }
+
+    public PlannerContext(CapabilityRegistry capabilityRegistry, ClusterState clusterState, boolean profilingEnabled) {
         this.capabilityRegistry = capabilityRegistry;
         this.clusterState = clusterState;
         this.distributionTraitDef = new OpenSearchDistributionTraitDef(this);
+        this.profilingEnabled = profilingEnabled;
         this.annotationIdCounter = 0;
+    }
+
+    /** True when {@link PlannerImpl#runAllOptimizations} should attach a {@link RuleProfilingListener}. */
+    public boolean isProfilingEnabled() {
+        return profilingEnabled;
+    }
+
+    /** Stash the snapshot taken at the end of {@code runAllOptimizations}. Null when profiling was disabled. */
+    public void recordProfilingResults(RuleProfilingListener.PlannerProfile profile) {
+        this.lastProfile = profile;
+    }
+
+    public RuleProfilingListener.PlannerProfile getProfilingResults() {
+        return lastProfile;
     }
 
     /** Returns a unique annotation ID for marking phase. */

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/PlannerImpl.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/PlannerImpl.java
@@ -87,7 +87,8 @@ public class PlannerImpl {
         RuleProfilingListener listener = context.isProfilingEnabled() ? new RuleProfilingListener() : null;
 
         RelNode modifiedRelNode = rawRelNode;
-        modifiedRelNode = calciteCoreRules(modifiedRelNode, listener);
+        modifiedRelNode = reduceExpressions(modifiedRelNode, listener);
+        modifiedRelNode = pushdownRules(modifiedRelNode, listener);
         modifiedRelNode = decomposeAggregates(modifiedRelNode, listener);
         modifiedRelNode = mark(modifiedRelNode, context, listener);
         LOGGER.info("After marking:\n{}", RelOptUtil.toString(modifiedRelNode));
@@ -103,33 +104,57 @@ public class PlannerImpl {
     }
 
     /**
-     * Phase 1a: Calcite core rules. Pre-marking constant-expression reduction and Filter
-     * pushdown past Project / Aggregate / Join. Running pre-marking means transposes emit
-     * plain {@code Logical*} nodes, then marking lowers the canonical post-pushdown shape
-     * in one pass — no marking-loss problem from rule output.
+     * Phase 1a: constant-expression reduction on Filter and Project predicates. Kept in
+     * its own phase so {@code ProjectReduceExpressionsRule} cannot use a downstream
+     * Filter's predicates (introduced by {@link #pushdownRules} in Phase 1b) to rewrite
+     * Project expressions. Co-locating the reducer with the transposes lets Calcite
+     * simplify e.g. {@code m = (int0 <= 4)} into {@code m = IS NOT NULL(int0)} once the
+     * Filter sits below the Project — semantically correct but emits operators the
+     * Project may not have backend support for.
      */
-    private static RelNode calciteCoreRules(RelNode input, RuleProfilingListener listener) {
+    private static RelNode reduceExpressions(RelNode input, RuleProfilingListener listener) {
         HepProgramBuilder builder = new HepProgramBuilder();
         builder.addMatchOrder(HepMatchOrder.BOTTOM_UP);
         builder.addRuleCollection(
             List.of(
                 new ReduceExpressionsRule.FilterReduceExpressionsRule(Filter.class, RelBuilder.proto(Contexts.empty())),
-                new ReduceExpressionsRule.ProjectReduceExpressionsRule(Project.class, RelBuilder.proto(Contexts.empty())),
-                CoreRules.FILTER_PROJECT_TRANSPOSE,
-                CoreRules.FILTER_AGGREGATE_TRANSPOSE,
-                CoreRules.FILTER_INTO_JOIN
+                new ReduceExpressionsRule.ProjectReduceExpressionsRule(Project.class, RelBuilder.proto(Contexts.empty()))
             )
         );
         HepPlanner planner = new HepPlanner(builder.build());
         if (listener != null) {
             planner.addListener(listener);
-            listener.beginPhase("calcite-core-rules");
+            listener.beginPhase("reduce-expressions");
         }
         try {
             planner.setRoot(input);
             return planner.findBestExp();
         } finally {
-            if (listener != null) listener.endPhase("calcite-core-rules");
+            if (listener != null) listener.endPhase("reduce-expressions");
+        }
+    }
+
+    /**
+     * Phase 1b: Filter pushdown past Project / Aggregate / Join via Calcite's transpose rules.
+     * Pre-marking placement keeps marking single-pass — transposes emit plain {@code Logical*}
+     * nodes, then marking lowers the canonical post-pushdown shape in one go.
+     */
+    private static RelNode pushdownRules(RelNode input, RuleProfilingListener listener) {
+        HepProgramBuilder builder = new HepProgramBuilder();
+        builder.addMatchOrder(HepMatchOrder.BOTTOM_UP);
+        builder.addRuleCollection(
+            List.of(CoreRules.FILTER_PROJECT_TRANSPOSE, CoreRules.FILTER_AGGREGATE_TRANSPOSE, CoreRules.FILTER_INTO_JOIN)
+        );
+        HepPlanner planner = new HepPlanner(builder.build());
+        if (listener != null) {
+            planner.addListener(listener);
+            listener.beginPhase("pushdown-rules");
+        }
+        try {
+            planner.setRoot(input);
+            return planner.findBestExp();
+        } finally {
+            if (listener != null) listener.endPhase("pushdown-rules");
         }
     }
 

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/PlannerImpl.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/PlannerImpl.java
@@ -22,6 +22,7 @@ import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.Filter;
 import org.apache.calcite.rel.core.Project;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
+import org.apache.calcite.rel.rules.CoreRules;
 import org.apache.calcite.rel.rules.ReduceExpressionsRule;
 import org.apache.calcite.tools.RelBuilder;
 import org.apache.logging.log4j.LogManager;
@@ -56,6 +57,10 @@ import java.util.List;
  *       exchanges via trait enforcement where distribution mismatches.</li>
  * </ol>
  *
+ * <p>Each optimization phase lives in its own private method so a single
+ * {@link RuleProfilingListener} (when profiling is enabled on
+ * {@link PlannerContext}) can be threaded through every planner created here.
+ *
  * <p>TODO: eliminate copyToCluster — have frontends create RelNodes with Volcano cluster.
  * <p>TODO: DAG construction (cut at exchange boundaries, build stage tree)
  * <p>TODO: Per-stage plan forking (multiple plan generation)
@@ -69,55 +74,102 @@ public class PlannerImpl {
     private static final Logger LOGGER = LogManager.getLogger(PlannerImpl.class);
 
     public static RelNode createPlan(RelNode rawRelNode, PlannerContext context) {
-        return markAndOptimize(rawRelNode, context);
+        return runAllOptimizations(rawRelNode, context);
     }
 
     /**
      * Phase 1 (RBO marking) + Phase 2 (CBO exchange insertion).
      * Package-private so planner rule tests can inspect the marked+optimized tree.
      */
-    public static RelNode markAndOptimize(RelNode rawRelNode, PlannerContext context) {
+    public static RelNode runAllOptimizations(RelNode rawRelNode, PlannerContext context) {
         LOGGER.info("Input RelNode:\n{}", RelOptUtil.toString(rawRelNode));
 
-        // Phase 1a: Pre-marking logical optimizations: constant expression reduction on Filter
-        // and Project predicates. RexOver is preserved in-place on LogicalProject — downstream
-        // OpenSearchProjectRule detects RexOver and annotates it, and OpenSearchProject carries
-        // the "needs EXECUTION(SINGLETON) input" cost gate when any project expression is a
-        // windowed call.
-        HepProgramBuilder preBuilder = new HepProgramBuilder();
-        preBuilder.addMatchOrder(HepMatchOrder.ARBITRARY);
-        preBuilder.addRuleCollection(
+        RuleProfilingListener listener = context.isProfilingEnabled() ? new RuleProfilingListener() : null;
+
+        RelNode modifiedRelNode = rawRelNode;
+        modifiedRelNode = calciteCoreRules(modifiedRelNode, listener);
+        modifiedRelNode = decomposeAggregates(modifiedRelNode, listener);
+        modifiedRelNode = mark(modifiedRelNode, context, listener);
+        LOGGER.info("After marking:\n{}", RelOptUtil.toString(modifiedRelNode));
+        modifiedRelNode = cbo(modifiedRelNode, rawRelNode, context, listener);
+        LOGGER.info("After CBO:\n{}", RelOptUtil.toString(modifiedRelNode));
+
+        if (listener != null) {
+            RuleProfilingListener.PlannerProfile profile = listener.snapshot();
+            context.recordProfilingResults(profile);
+            LOGGER.info("Planner profile:\n{}", profile.format());
+        }
+        return modifiedRelNode;
+    }
+
+    /**
+     * Phase 1a: Calcite core rules. Pre-marking constant-expression reduction and Filter
+     * pushdown past Project / Aggregate / Join. Running pre-marking means transposes emit
+     * plain {@code Logical*} nodes, then marking lowers the canonical post-pushdown shape
+     * in one pass — no marking-loss problem from rule output.
+     */
+    private static RelNode calciteCoreRules(RelNode input, RuleProfilingListener listener) {
+        HepProgramBuilder builder = new HepProgramBuilder();
+        builder.addMatchOrder(HepMatchOrder.BOTTOM_UP);
+        builder.addRuleCollection(
             List.of(
                 new ReduceExpressionsRule.FilterReduceExpressionsRule(Filter.class, RelBuilder.proto(Contexts.empty())),
-                new ReduceExpressionsRule.ProjectReduceExpressionsRule(Project.class, RelBuilder.proto(Contexts.empty()))
+                new ReduceExpressionsRule.ProjectReduceExpressionsRule(Project.class, RelBuilder.proto(Contexts.empty())),
+                CoreRules.FILTER_PROJECT_TRANSPOSE,
+                CoreRules.FILTER_AGGREGATE_TRANSPOSE,
+                CoreRules.FILTER_INTO_JOIN
             )
         );
-        HepPlanner prePlanner = new HepPlanner(preBuilder.build());
-        prePlanner.setRoot(rawRelNode);
-        RelNode afterPre = prePlanner.findBestExp();
+        HepPlanner planner = new HepPlanner(builder.build());
+        if (listener != null) {
+            planner.addListener(listener);
+            listener.beginPhase("calcite-core-rules");
+        }
+        try {
+            planner.setRoot(input);
+            return planner.findBestExp();
+        } finally {
+            if (listener != null) listener.endPhase("calcite-core-rules");
+        }
+    }
 
-        // Phase 1b: Aggregate-reduction — decompose AVG / STDDEV / VAR into primitive SUM/COUNT
-        // (+ SUM_SQ for variance) plus a scalar LogicalProject computing the quotient. Runs as
-        // its own HEP pass on plain LogicalAggregate so Calcite's type inference is clean —
-        // no AGG_CALL_ANNOTATION wrappers in aggCall.rexList to propagate AVG's DOUBLE return
-        // type to the derived primitive calls. Downstream the marking phase, the Volcano split
-        // rule, and the AggregateDecompositionResolver see correctly-typed primitives.
-        HepProgramBuilder reduceBuilder = new HepProgramBuilder();
-        reduceBuilder.addMatchOrder(HepMatchOrder.BOTTOM_UP);
-        reduceBuilder.addRuleInstance(new OpenSearchAggregateReduceRule());
-        HepPlanner reducePlanner = new HepPlanner(reduceBuilder.build());
-        reducePlanner.setRoot(afterPre);
-        RelNode afterReduce = reducePlanner.findBestExp();
+    /**
+     * Phase 1b: decompose AVG / STDDEV / VAR into primitive SUM/COUNT (+ SUM_SQ for variance) plus a
+     * scalar LogicalProject computing the quotient. Runs as its own HEP pass on plain LogicalAggregate
+     * so Calcite's type inference is clean — no AGG_CALL_ANNOTATION wrappers in aggCall.rexList to
+     * propagate AVG's DOUBLE return type to the derived primitive calls. Downstream the marking phase,
+     * the Volcano split rule, and the AggregateDecompositionResolver see correctly-typed primitives.
+     */
+    private static RelNode decomposeAggregates(RelNode input, RuleProfilingListener listener) {
+        HepProgramBuilder builder = new HepProgramBuilder();
+        builder.addMatchOrder(HepMatchOrder.BOTTOM_UP);
+        builder.addRuleInstance(new OpenSearchAggregateReduceRule());
+        HepPlanner planner = new HepPlanner(builder.build());
+        if (listener != null) {
+            planner.addListener(listener);
+            listener.beginPhase("aggregate-decompose");
+        }
+        try {
+            planner.setRoot(input);
+            return planner.findBestExp();
+        } finally {
+            if (listener != null) listener.endPhase("aggregate-decompose");
+        }
+    }
 
-        // Phase 1c: Marking — convert LogicalXxx → OpenSearchXxx bottom-up
-        // TODO: migrate rules from deprecated RelOptRule to RelRule<Config> once the planner
-        // moves to its own Gradle module. The OpenSearch monorepo injects -proc:none globally,
-        // blocking the Immutables annotation processor required by RelRule.Config sub-interfaces.
-        // TODO: add SortPushdown rule here — pushes Sort below Exchange to data nodes for top-K
-        // optimization.
-        HepProgramBuilder markBuilder = new HepProgramBuilder();
-        markBuilder.addMatchOrder(HepMatchOrder.BOTTOM_UP);
-        markBuilder.addRuleCollection(
+    /**
+     * Phase 1c: marking — convert LogicalXxx → OpenSearchXxx bottom-up.
+     *
+     * <p>TODO: migrate rules from deprecated RelOptRule to RelRule&lt;Config&gt; once the planner
+     * moves to its own Gradle module. The OpenSearch monorepo injects -proc:none globally, blocking
+     * the Immutables annotation processor required by RelRule.Config sub-interfaces.
+     * <p>TODO: add SortPushdown rule here — pushes Sort below Exchange to data nodes for top-K
+     * optimization.
+     */
+    private static RelNode mark(RelNode input, PlannerContext context, RuleProfilingListener listener) {
+        HepProgramBuilder builder = new HepProgramBuilder();
+        builder.addMatchOrder(HepMatchOrder.BOTTOM_UP);
+        builder.addRuleCollection(
             List.of(
                 new OpenSearchTableScanRule(context),
                 new OpenSearchFilterRule(context),
@@ -129,13 +181,21 @@ public class PlannerImpl {
                 new OpenSearchValuesRule(context)
             )
         );
-        HepPlanner markingPlanner = new HepPlanner(markBuilder.build());
-        markingPlanner.setRoot(afterReduce);
-        RelNode marked = markingPlanner.findBestExp();
+        HepPlanner planner = new HepPlanner(builder.build());
+        if (listener != null) {
+            planner.addListener(listener);
+            listener.beginPhase("marking");
+        }
+        try {
+            planner.setRoot(input);
+            return planner.findBestExp();
+        } finally {
+            if (listener != null) listener.endPhase("marking");
+        }
+    }
 
-        LOGGER.info("After marking:\n{}", RelOptUtil.toString(marked));
-
-        // Phase 2: CBO — VolcanoPlanner for trait propagation + exchange insertion
+    /** Phase 2: VolcanoPlanner for trait propagation + exchange insertion. */
+    private static RelNode cbo(RelNode marked, RelNode rawRelNode, PlannerContext context, RuleProfilingListener listener) {
         VolcanoPlanner volcanoPlanner = new VolcanoPlanner();
         volcanoPlanner.addRelTraitDef(ConventionTraitDef.INSTANCE);
         OpenSearchDistributionTraitDef distTraitDef = context.getDistributionTraitDef();
@@ -147,24 +207,29 @@ public class PlannerImpl {
         volcanoPlanner.addRule(new OpenSearchDistributionDeriveRule(context));
         volcanoPlanner.addRule(AbstractConverter.ExpandConversionRule.INSTANCE);
 
-        RelOptCluster volcanoCluster = RelOptCluster.create(volcanoPlanner, rawRelNode.getCluster().getRexBuilder());
-        volcanoCluster.setMetadataQuerySupplier(RelMetadataQuery::instance);
-
-        // TODO: eliminate this copy
-        RelNode copied = RelNodeUtils.copyToCluster(marked, volcanoCluster, distTraitDef);
-
-        // Root demands SINGLETON with null locality — satisfied by either SHARD+SINGLETON
-        // (1-shard scan, no ER) or COORDINATOR+SINGLETON (after ER). Multi-shard scans stamp
-        // RANDOM → ER inserted by ExpandConversionRule + trait def's convert(). Single-shard
-        // scans stamp SHARD+SINGLETON → already satisfies, no top ER.
-        volcanoPlanner.setRoot(copied);
-        RelTraitSet desiredTraits = copied.getTraitSet().replace(distTraitDef.anySingleton());
-        if (!copied.getTraitSet().equals(desiredTraits)) {
-            volcanoPlanner.setRoot(volcanoPlanner.changeTraits(copied, desiredTraits));
+        if (listener != null) {
+            volcanoPlanner.addListener(listener);
+            listener.beginPhase("cbo");
         }
-        RelNode result = volcanoPlanner.findBestExp();
+        try {
+            RelOptCluster volcanoCluster = RelOptCluster.create(volcanoPlanner, rawRelNode.getCluster().getRexBuilder());
+            volcanoCluster.setMetadataQuerySupplier(RelMetadataQuery::instance);
 
-        LOGGER.info("After CBO:\n{}", RelOptUtil.toString(result));
-        return result;
+            // TODO: eliminate this copy
+            RelNode copied = RelNodeUtils.copyToCluster(marked, volcanoCluster, distTraitDef);
+
+            // Root demands SINGLETON with null locality — satisfied by either SHARD+SINGLETON
+            // (1-shard scan, no ER) or COORDINATOR+SINGLETON (after ER). Multi-shard scans stamp
+            // RANDOM → ER inserted by ExpandConversionRule + trait def's convert(). Single-shard
+            // scans stamp SHARD+SINGLETON → already satisfies, no top ER.
+            volcanoPlanner.setRoot(copied);
+            RelTraitSet desiredTraits = copied.getTraitSet().replace(distTraitDef.anySingleton());
+            if (!copied.getTraitSet().equals(desiredTraits)) {
+                volcanoPlanner.setRoot(volcanoPlanner.changeTraits(copied, desiredTraits));
+            }
+            return volcanoPlanner.findBestExp();
+        } finally {
+            if (listener != null) listener.endPhase("cbo");
+        }
     }
 }

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/RuleProfilingListener.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/RuleProfilingListener.java
@@ -1,0 +1,148 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.planner;
+
+import org.apache.calcite.plan.RelOptListener;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Per-query profiling listener for the planner. Single-threaded by construction —
+ * Calcite invokes listener callbacks sequentially from {@code AbstractRelOptPlanner.fireRule}.
+ *
+ * <p>Records two kinds of measurements:
+ * <ul>
+ *   <li>Phase wall-clock time, set explicitly via {@link #beginPhase(String)} /
+ *       {@link #endPhase(String)} bracketing each phase method's body.</li>
+ *   <li>Per-rule {@link RuleMetrics} (attempts, productions, totalNanos) accumulated
+ *       from {@code RuleAttemptedEvent} and {@code RuleProductionEvent} pairs.
+ *       Mirrors the pattern Calcite uses internally in
+ *       {@code AbstractRelOptPlanner.RuleAttemptsListener}.</li>
+ * </ul>
+ *
+ * <p>Created only when profiling is enabled on {@link PlannerContext}; otherwise the
+ * planner runs without any listener attached at all.
+ *
+ * @opensearch.internal
+ */
+public final class RuleProfilingListener implements RelOptListener {
+
+    private final Map<String, Long> phaseDurationsNs = new LinkedHashMap<>();
+    private final Map<String, RuleMetrics> ruleMetrics = new HashMap<>();
+
+    private long phaseStartNs;
+    private long ruleStartNs;
+
+    public void beginPhase(String name) {
+        phaseStartNs = System.nanoTime();
+    }
+
+    public void endPhase(String name) {
+        phaseDurationsNs.merge(name, System.nanoTime() - phaseStartNs, Long::sum);
+    }
+
+    @Override
+    public void ruleAttempted(RuleAttemptedEvent event) {
+        if (event.isBefore()) {
+            ruleStartNs = System.nanoTime();
+            return;
+        }
+        String rule = event.getRuleCall().getRule().toString();
+        long elapsed = System.nanoTime() - ruleStartNs;
+        RuleMetrics metrics = ruleMetrics.computeIfAbsent(rule, k -> new RuleMetrics());
+        metrics.attempts++;
+        metrics.totalNanos += elapsed;
+    }
+
+    @Override
+    public void ruleProductionSucceeded(RuleProductionEvent event) {
+        // Calcite fires this twice per successful transform (before & after registration).
+        // Count once on the "before" edge to match attempts semantics.
+        if (!event.isBefore()) return;
+        String rule = event.getRuleCall().getRule().toString();
+        ruleMetrics.computeIfAbsent(rule, k -> new RuleMetrics()).productions++;
+    }
+
+    @Override
+    public void relEquivalenceFound(RelEquivalenceEvent event) {}
+
+    @Override
+    public void relDiscarded(RelDiscardedEvent event) {}
+
+    @Override
+    public void relChosen(RelChosenEvent event) {}
+
+    /**
+     * Returns the live measurement maps. No defensive copy — callers must not mutate.
+     * Sorting / formatting is a {@link PlannerProfile#format()} responsibility.
+     */
+    public PlannerProfile snapshot() {
+        return new PlannerProfile(phaseDurationsNs, ruleMetrics);
+    }
+
+    /**
+     * Number of times a Rule was attempted and applied with total time taken.
+     */
+    public static final class RuleMetrics {
+        long attempts;
+        long productions;
+        long totalNanos;
+
+        public long attempts() {
+            return attempts;
+        }
+
+        public long productions() {
+            return productions;
+        }
+
+        public long totalNanos() {
+            return totalNanos;
+        }
+    }
+
+    /** Profile snapshot returned by {@link #snapshot()}. Live views into the listener's state. */
+    public record PlannerProfile(Map<String, Long> phaseDurationsNs, Map<String, RuleMetrics> rules) {
+
+        /** Multi-line text dump suitable for INFO-level logging. Sorts rules by total time desc. */
+        public String format() {
+            StringBuilder sb = new StringBuilder();
+            sb.append("Phase wall-clock:\n");
+            phaseDurationsNs.forEach(
+                (name, ns) -> sb.append(String.format(Locale.ROOT, "  %-28s %8d ms%n", name, TimeUnit.NANOSECONDS.toMillis(ns)))
+            );
+            sb.append("\nRules (sorted by total time):\n");
+            sb.append(String.format(Locale.ROOT, "  %-60s %10s %12s %12s%n", "Rule", "Attempts", "Productions", "Time (us)"));
+            rules.entrySet().stream().sorted((a, b) -> Long.compare(b.getValue().totalNanos, a.getValue().totalNanos)).forEach(e -> {
+                RuleMetrics m = e.getValue();
+                sb.append(
+                    String.format(
+                        Locale.ROOT,
+                        "  %-60s %10d %12d %12d%n",
+                        e.getKey(),
+                        m.attempts,
+                        m.productions,
+                        TimeUnit.NANOSECONDS.toMicros(m.totalNanos)
+                    )
+                );
+            });
+            return sb.toString();
+        }
+
+        /** Phase names in insertion order. */
+        public List<String> phases() {
+            return List.copyOf(phaseDurationsNs.keySet());
+        }
+    }
+}

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/BasePlannerRulesTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/BasePlannerRulesTests.java
@@ -91,7 +91,7 @@ public abstract class BasePlannerRulesTests extends OpenSearchTestCase {
     // ---- Plan execution ----
 
     protected RelNode runPlanner(RelNode input, PlannerContext context) {
-        return PlannerImpl.markAndOptimize(input, context);
+        return PlannerImpl.runAllOptimizations(input, context);
     }
 
     protected RelNode unwrapExchange(RelNode node) {

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/ClickBench.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/ClickBench.java
@@ -1,0 +1,42 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.planner;
+
+import java.util.Map;
+
+/**
+ * ClickBench workload schema for SQL-driven planner tests.
+ *
+ * <p>A subset of the ClickBench {@code hits} index covering the basic SQL types
+ * exercised by pushdown / filter-delegation tests: integer, long, short, keyword, date.
+ * Add fields when a test needs them.
+ */
+public final class ClickBench {
+
+    public static final String INDEX = "hits";
+
+    public static final Map<String, Map<String, Object>> BASIC_FIELDS = Map.of(
+        "CounterID",
+        Map.of("type", "integer"),
+        "UserID",
+        Map.of("type", "long"),
+        "URL",
+        Map.of("type", "keyword"),
+        "Title",
+        Map.of("type", "keyword"),
+        "EventDate",
+        Map.of("type", "date"),
+        "AdvEngineID",
+        Map.of("type", "short"),
+        "ParamPrice",
+        Map.of("type", "long")
+    );
+
+    private ClickBench() {}
+}

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/FilterPlanShapeTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/FilterPlanShapeTests.java
@@ -8,10 +8,20 @@
 
 package org.opensearch.analytics.planner;
 
+import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.AggregateCall;
+import org.apache.calcite.rel.core.CorrelationId;
+import org.apache.calcite.rel.core.JoinRelType;
+import org.apache.calcite.rel.logical.LogicalJoin;
+import org.apache.calcite.rel.logical.LogicalProject;
+import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.type.SqlTypeName;
+
+import java.util.List;
+import java.util.Set;
 
 /**
  * Plan-shape tests for {@link org.opensearch.analytics.planner.rel.OpenSearchFilter}.
@@ -43,6 +53,111 @@ public class FilterPlanShapeTests extends PlanShapeTestBase {
                 OpenSearchExchangeReducer(viableBackends=[[mock-parquet]], exchange=[ExchangeInfo[distributionType=SINGLETON, partitionKeyIndices=[]]])
                   OpenSearchFilter(condition=[ANNOTATED_PREDICATE(id=0, backends=[mock-lucene, mock-parquet], =($0, 200))], viableBackends=[[mock-parquet]])
                     OpenSearchTableScan(table=[[test_index]], viableBackends=[[mock-parquet]])
+                """,
+            result
+        );
+    }
+
+    // ---- Filter pushdown via Calcite core transposes ----
+
+    /**
+     * Filter sitting above a Project — {@code FilterProjectTransposeRule} should push
+     * the Filter through the Project so it sits adjacent to the Scan.
+     */
+    public void testFilterPastProject_pushed() {
+        RelOptTable table = mockTable("test_index", "status", "size");
+        RelNode scan = stubScan(table);
+        RelDataType intType = typeFactory.createSqlType(SqlTypeName.INTEGER);
+        LogicalProject project = LogicalProject.create(
+            scan,
+            List.of(),
+            List.of(rexBuilder.makeInputRef(intType, 0)),
+            List.of("status_out")
+        );
+        RelNode plan = makeFilter(project, makeEquals(0, SqlTypeName.INTEGER, 200));
+        RelNode result = runPlanner(plan, singleShardContext());
+        assertPlanShape(
+            """
+                OpenSearchProject(status_out=[$0], viableBackends=[[mock-parquet]])
+                  OpenSearchFilter(condition=[ANNOTATED_PREDICATE(id=0, backends=[mock-lucene, mock-parquet], =($0, 200))], viableBackends=[[mock-parquet]])
+                    OpenSearchTableScan(table=[[test_index]], viableBackends=[[mock-parquet]])
+                """,
+            result
+        );
+    }
+
+    /**
+     * HAVING-style Filter on a group-by column above an Aggregate — should push past the
+     * Aggregate via {@code FilterAggregateTransposeRule}, ending below it.
+     */
+    public void testFilterPastAggregateOnGroupKey_pushed() {
+        AggregateCall sum = sumCall();
+        RelNode aggregate = makeAggregate(sum);
+        // Filter on $0 — the group-by column, not the agg result.
+        RelNode plan = makeFilter(aggregate, makeEquals(0, SqlTypeName.INTEGER, 200));
+        RelNode result = runPlanner(plan, singleShardContext());
+        assertPlanShape(
+            """
+                OpenSearchAggregate(group=[{0}], total_size=[SUM(AGG_CALL_ANNOTATION(id=1, viableBackends=[mock-parquet]), $1)], mode=[SINGLE], viableBackends=[[mock-parquet]])
+                  OpenSearchFilter(condition=[ANNOTATED_PREDICATE(id=0, backends=[mock-lucene, mock-parquet], =($0, 200))], viableBackends=[[mock-parquet]])
+                    OpenSearchTableScan(table=[[test_index]], viableBackends=[[mock-parquet]])
+                """,
+            result
+        );
+    }
+
+    /**
+     * HAVING-style Filter on an aggregate result above an Aggregate — must NOT push, since
+     * the predicate references the agg output. Filter stays above Aggregate.
+     */
+    public void testFilterPastAggregateOnAggResult_notPushed() {
+        AggregateCall sum = sumCall();
+        RelNode aggregate = makeAggregate(sum);
+        // Filter on $1 — the SUM(size) result column, which the rule cannot push below the agg.
+        RelNode plan = makeFilter(aggregate, makeEquals(1, SqlTypeName.INTEGER, 1000));
+        RelNode result = runPlanner(plan, singleShardContext());
+        assertPlanShape(
+            """
+                OpenSearchFilter(condition=[ANNOTATED_PREDICATE(id=1, backends=[mock-parquet], =($1, 1000))], viableBackends=[[mock-parquet]])
+                  OpenSearchAggregate(group=[{0}], total_size=[SUM(AGG_CALL_ANNOTATION(id=0, viableBackends=[mock-parquet]), $1)], mode=[SINGLE], viableBackends=[[mock-parquet]])
+                    OpenSearchTableScan(table=[[test_index]], viableBackends=[[mock-parquet]])
+                """,
+            result
+        );
+    }
+
+    /**
+     * Filter referencing a column on the left side of a Join — {@code FilterIntoJoinRule}
+     * should push the Filter into the left input of the Join.
+     */
+    public void testFilterPastJoin_pushed() {
+        RelOptTable leftTable = mockTable("left_idx", "status", "size");
+        RelOptTable rightTable = mockTable("right_idx", "status", "size");
+        RelDataType intType = typeFactory.createSqlType(SqlTypeName.INTEGER);
+        RexNode joinCond = rexBuilder.makeCall(
+            SqlStdOperatorTable.EQUALS,
+            rexBuilder.makeInputRef(intType, 0),
+            rexBuilder.makeInputRef(intType, 2)
+        );
+        RelNode join = LogicalJoin.create(
+            stubScan(leftTable),
+            stubScan(rightTable),
+            List.of(),
+            joinCond,
+            Set.<CorrelationId>of(),
+            JoinRelType.INNER
+        );
+        // Filter on $0 — references only the left side; rule should push into left input.
+        RelNode plan = makeFilter(join, makeEquals(0, SqlTypeName.INTEGER, 200));
+        RelNode result = runPlanner(plan, perIndexContext(java.util.Map.of("left_idx", 1, "right_idx", 1)));
+        assertPlanShape(
+            """
+                OpenSearchJoin(condition=[=($0, $2)], joinType=[inner], viableBackends=[[mock-parquet]])
+                  OpenSearchExchangeReducer(viableBackends=[[mock-parquet]], exchange=[ExchangeInfo[distributionType=SINGLETON, partitionKeyIndices=[]]])
+                    OpenSearchFilter(condition=[ANNOTATED_PREDICATE(id=0, backends=[mock-lucene, mock-parquet], =($0, 200))], viableBackends=[[mock-parquet]])
+                      OpenSearchTableScan(table=[[left_idx]], viableBackends=[[mock-parquet]])
+                  OpenSearchExchangeReducer(viableBackends=[[mock-parquet]], exchange=[ExchangeInfo[distributionType=SINGLETON, partitionKeyIndices=[]]])
+                    OpenSearchTableScan(table=[[right_idx]], viableBackends=[[mock-parquet]])
                 """,
             result
         );

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/RuleProfilingListenerTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/RuleProfilingListenerTests.java
@@ -1,0 +1,185 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.planner;
+
+import org.apache.calcite.rel.RelNode;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.cluster.ClusterState;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Drives {@link PlannerImpl#runAllOptimizations} with profiling enabled across multiple
+ * SQL query shapes and asserts on the resulting {@link RuleProfilingListener.PlannerProfile}:
+ * phases ran in order, durations are non-negative, the rule-set matches exactly, and each
+ * rule's production count matches the expected value.
+ *
+ * <p>Plan-shape correctness is intentionally <strong>not</strong> asserted here — that's
+ * {@code *PlanShapeTests}' job. These tests only validate the profiling listener.
+ *
+ * <p>Productions (count of successful {@code transformTo} calls) are deterministic enough
+ * to assert exactly. Attempts and elapsed time depend on Volcano's exploration order and
+ * are only sanity-checked ({@code productions <= attempts}, {@code totalNanos >= 0}).
+ */
+public class RuleProfilingListenerTests extends BasePlannerRulesTests {
+
+    private static final Logger LOGGER = LogManager.getLogger(RuleProfilingListenerTests.class);
+
+    private static final List<String> EXPECTED_PHASES = List.of("calcite-core-rules", "aggregate-decompose", "marking", "cbo");
+
+    public void testProfilePureScan() {
+        runAndAssertRules(
+            1,
+            "SELECT URL FROM hits",
+            Map.of(
+                "ReduceExpressionsRule(Project)",
+                0L,
+                "OpenSearchProjectRule",
+                1L,
+                "OpenSearchTableScanRule",
+                1L,
+                "ExpandConversionRule",
+                1L
+            )
+        );
+    }
+
+    public void testProfileFilterOverScan() {
+        runAndAssertRules(
+            1,
+            "SELECT URL FROM hits WHERE CounterID = 100",
+            Map.of(
+                "ReduceExpressionsRule(Filter)",
+                0L,
+                "ReduceExpressionsRule(Project)",
+                0L,
+                "OpenSearchFilterRule",
+                1L,
+                "OpenSearchProjectRule",
+                1L,
+                "OpenSearchTableScanRule",
+                1L,
+                "ExpandConversionRule",
+                1L
+            )
+        );
+    }
+
+    public void testProfileAggregateOverFilterMultiShard() {
+        runAndAssertRules(
+            5,
+            "SELECT CounterID, SUM(ParamPrice) AS total FROM hits WHERE AdvEngineID = 5 GROUP BY CounterID",
+            Map.ofEntries(
+                Map.entry("ReduceExpressionsRule(Filter)", 0L),
+                Map.entry("ReduceExpressionsRule(Project)", 0L),
+                Map.entry("OpenSearchFilterRule", 1L),
+                Map.entry("OpenSearchProjectRule", 1L),
+                Map.entry("OpenSearchTableScanRule", 1L),
+                Map.entry("OpenSearchAggregateRule", 1L),
+                Map.entry("OpenSearchAggregateSplitRule", 4L),
+                Map.entry("OpenSearchDistributionDeriveRule", 3L),
+                Map.entry("ExpandConversionRule", 5L)
+            )
+        );
+    }
+
+    /** Self-join with aggregate on top — exercises {@code OpenSearchJoinRule} + {@code OpenSearchJoinSplitRule}. */
+    public void testProfileJoinWithAggregateMultiShard() {
+        runAndAssertRules(
+            5,
+            "SELECT l.CounterID, COUNT(*) AS cnt FROM hits l JOIN hits r ON l.CounterID = r.CounterID GROUP BY l.CounterID",
+            Map.of(
+                "ReduceExpressionsRule(Project)",
+                0L,
+                "OpenSearchTableScanRule",
+                1L,
+                "OpenSearchProjectRule",
+                1L,
+                "OpenSearchJoinRule",
+                1L,
+                "OpenSearchAggregateRule",
+                1L,
+                "OpenSearchAggregateSplitRule",
+                1L,
+                "OpenSearchJoinSplitRule",
+                1L,
+                "ExpandConversionRule",
+                2L
+            )
+        );
+    }
+
+    public void testProfilingDisabledLeavesContextNull() {
+        ClusterState state = clickBenchClusterState(1);
+        PlannerContext context = context(state, false);
+        RelNode parsed = SqlPlannerTestFixture.parseSql("SELECT URL FROM hits", state);
+
+        PlannerImpl.runAllOptimizations(parsed, context);
+
+        assertNull("Profiling disabled — getProfilingResults() must return null", context.getProfilingResults());
+    }
+
+    // ---- Shared assertion helper ----
+
+    /**
+     * Runs the SQL through {@link PlannerImpl#runAllOptimizations} with profiling enabled,
+     * then asserts:
+     * <ul>
+     *   <li>All four optimization phases ran in declared order with non-negative durations.</li>
+     *   <li>The set of fired rules matches {@code expectedProductionsByRule.keySet()} exactly.</li>
+     *   <li>Each rule's {@code productions} equals the expected value in the map.</li>
+     *   <li>Per-rule sanity: {@code attempts > 0}, {@code productions <= attempts},
+     *       {@code totalNanos >= 0}.</li>
+     * </ul>
+     */
+    private void runAndAssertRules(int shardCount, String sql, Map<String, Long> expectedProductionsByRule) {
+        ClusterState state = clickBenchClusterState(shardCount);
+        PlannerContext context = context(state, true);
+        RelNode parsed = SqlPlannerTestFixture.parseSql(sql, state);
+
+        PlannerImpl.runAllOptimizations(parsed, context);
+
+        RuleProfilingListener.PlannerProfile profile = context.getProfilingResults();
+        assertNotNull("Profiling enabled — profile must be recorded", profile);
+
+        assertEquals("All four optimization phases must run in declared order", EXPECTED_PHASES, profile.phases());
+
+        for (String phase : EXPECTED_PHASES) {
+            Long durationNs = profile.phaseDurationsNs().get(phase);
+            assertNotNull("Phase '" + phase + "' must have a duration recorded", durationNs);
+            assertTrue("Phase '" + phase + "' duration must be non-negative", durationNs >= 0);
+        }
+
+        // Rule-set match.
+        assertEquals("Profile rule-set must match expected rule-set exactly", expectedProductionsByRule.keySet(), profile.rules().keySet());
+
+        // Per-rule productions + sanity.
+        profile.rules().forEach((ruleName, metrics) -> {
+            long expectedProductions = expectedProductionsByRule.get(ruleName);
+            assertEquals("Rule '" + ruleName + "' production count must match expected", expectedProductions, metrics.productions());
+            assertTrue("Rule '" + ruleName + "' attempts must be > 0", metrics.attempts() > 0);
+            assertTrue("Rule '" + ruleName + "' productions must be <= attempts", metrics.productions() <= metrics.attempts());
+            assertTrue("Rule '" + ruleName + "' totalNanos must be >= 0", metrics.totalNanos() >= 0);
+        });
+
+        LOGGER.info("Profile:\n{}", profile.format());
+    }
+
+    // ---- Context wiring ----
+
+    private static ClusterState clickBenchClusterState(int shardCount) {
+        return SqlPlannerTestFixture.clusterStateWith(ClickBench.INDEX, ClickBench.BASIC_FIELDS, "parquet", shardCount);
+    }
+
+    private PlannerContext context(ClusterState state, boolean profilingEnabled) {
+        return new PlannerContext(new CapabilityRegistry(List.of(DATAFUSION, LUCENE), FieldStorageResolver::new), state, profilingEnabled);
+    }
+}

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/RuleProfilingListenerTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/RuleProfilingListenerTests.java
@@ -33,7 +33,13 @@ public class RuleProfilingListenerTests extends BasePlannerRulesTests {
 
     private static final Logger LOGGER = LogManager.getLogger(RuleProfilingListenerTests.class);
 
-    private static final List<String> EXPECTED_PHASES = List.of("calcite-core-rules", "aggregate-decompose", "marking", "cbo");
+    private static final List<String> EXPECTED_PHASES = List.of(
+        "reduce-expressions",
+        "pushdown-rules",
+        "aggregate-decompose",
+        "marking",
+        "cbo"
+    );
 
     public void testProfilePureScan() {
         runAndAssertRules(
@@ -133,7 +139,7 @@ public class RuleProfilingListenerTests extends BasePlannerRulesTests {
      * Runs the SQL through {@link PlannerImpl#runAllOptimizations} with profiling enabled,
      * then asserts:
      * <ul>
-     *   <li>All four optimization phases ran in declared order with non-negative durations.</li>
+     *   <li>All optimization phases ran in declared order with non-negative durations.</li>
      *   <li>The set of fired rules matches {@code expectedProductionsByRule.keySet()} exactly.</li>
      *   <li>Each rule's {@code productions} equals the expected value in the map.</li>
      *   <li>Per-rule sanity: {@code attempts > 0}, {@code productions <= attempts},
@@ -150,7 +156,7 @@ public class RuleProfilingListenerTests extends BasePlannerRulesTests {
         RuleProfilingListener.PlannerProfile profile = context.getProfilingResults();
         assertNotNull("Profiling enabled — profile must be recorded", profile);
 
-        assertEquals("All four optimization phases must run in declared order", EXPECTED_PHASES, profile.phases());
+        assertEquals("All optimization phases must run in declared order", EXPECTED_PHASES, profile.phases());
 
         for (String phase : EXPECTED_PHASES) {
             Long durationNs = profile.phaseDurationsNs().get(phase);

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/SqlPlannerTestFixture.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/SqlPlannerTestFixture.java
@@ -1,0 +1,137 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.planner;
+
+import org.apache.calcite.avatica.util.Casing;
+import org.apache.calcite.config.CalciteConnectionConfigImpl;
+import org.apache.calcite.jdbc.CalciteSchema;
+import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.hep.HepPlanner;
+import org.apache.calcite.plan.hep.HepProgramBuilder;
+import org.apache.calcite.prepare.CalciteCatalogReader;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.schema.SchemaPlus;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.parser.SqlParseException;
+import org.apache.calcite.sql.parser.SqlParser;
+import org.apache.calcite.sql.validate.SqlValidator;
+import org.apache.calcite.sql.validate.SqlValidatorUtil;
+import org.apache.calcite.sql2rel.SqlToRelConverter;
+import org.apache.calcite.sql2rel.StandardConvertletTable;
+import org.opensearch.Version;
+import org.opensearch.analytics.schema.OpenSearchSchemaBuilder;
+import org.opensearch.cluster.ClusterName;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.metadata.Metadata;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.core.xcontent.MediaTypeRegistry;
+import org.opensearch.core.xcontent.XContentBuilder;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * Parses SQL strings into Calcite {@link RelNode} trees for planner tests.
+ *
+ * <p>Schema construction reuses {@link OpenSearchSchemaBuilder} — the same code path
+ * production planner uses — so test SQL sees the row types the real planner receives.
+ * Tests feed the returned RelNode directly into
+ * {@link PlannerImpl#runAllOptimizations(RelNode, PlannerContext)}.
+ *
+ * <p>This fixture handles only SQL → LogicalRelNode conversion. Marking, pushdown,
+ * and CBO remain the test's concern.
+ */
+public final class SqlPlannerTestFixture {
+
+    private SqlPlannerTestFixture() {}
+
+    /** Parses {@code sql} against a schema built from {@code clusterState}. */
+    public static RelNode parseSql(String sql, ClusterState clusterState) {
+        SchemaPlus schema = OpenSearchSchemaBuilder.buildSchema(clusterState);
+        RelDataTypeFactory typeFactory = new JavaTypeFactoryImpl();
+        CalciteCatalogReader catalogReader = new CalciteCatalogReader(
+            CalciteSchema.from(schema),
+            Collections.singletonList(""),
+            typeFactory,
+            new CalciteConnectionConfigImpl(new Properties())
+        );
+
+        SqlValidator validator = SqlValidatorUtil.newValidator(
+            SqlStdOperatorTable.instance(),
+            catalogReader,
+            typeFactory,
+            SqlValidator.Config.DEFAULT
+        );
+
+        HepPlanner hepPlanner = new HepPlanner(new HepProgramBuilder().build());
+        RelOptCluster cluster = RelOptCluster.create(hepPlanner, new RexBuilder(typeFactory));
+
+        SqlParser.Config parserConfig = SqlParser.config().withUnquotedCasing(Casing.UNCHANGED);
+        SqlNode parsed;
+        try {
+            parsed = SqlParser.create(sql, parserConfig).parseQuery();
+        } catch (SqlParseException e) {
+            throw new AssertionError("Failed to parse SQL: " + sql, e);
+        }
+
+        SqlToRelConverter converter = new SqlToRelConverter((rowType, queryString, schemaPath, viewPath) -> {
+            throw new UnsupportedOperationException("View expansion not used in tests");
+        }, validator, catalogReader, cluster, StandardConvertletTable.INSTANCE, SqlToRelConverter.config());
+
+        return converter.convertQuery(parsed, true, true).rel;
+    }
+
+    /**
+     * Builds a single-index {@link ClusterState} from the given mapping {@code properties}.
+     * The properties shape matches {@link OpenSearchSchemaBuilder} expectations: each
+     * entry's value is a field-properties map with at minimum a {@code "type"} key.
+     *
+     * <p>Defaults to one shard. Use {@link #clusterStateWith(String, Map, String, int)}
+     * to control the primary data format and shard count.
+     */
+    public static ClusterState clusterStateWith(String indexName, Map<String, Map<String, Object>> fields) {
+        return clusterStateWith(indexName, fields, "parquet", 1);
+    }
+
+    /**
+     * Builds a single-index {@link ClusterState} with explicit primary data format and shard count.
+     * The primary format flows through to {@code FieldStorageResolver} and decides which backends
+     * can scan the index's fields.
+     */
+    public static ClusterState clusterStateWith(
+        String indexName,
+        Map<String, Map<String, Object>> fields,
+        String primaryDataFormat,
+        int shardCount
+    ) {
+        try (XContentBuilder mapping = XContentBuilder.builder(MediaTypeRegistry.JSON.xContent())) {
+            mapping.startObject().field("properties", fields).endObject();
+            IndexMetadata indexMetadata = IndexMetadata.builder(indexName)
+                .settings(
+                    Settings.builder()
+                        .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT.id)
+                        .put("index.composite.primary_data_format", primaryDataFormat)
+                )
+                .numberOfShards(shardCount)
+                .numberOfReplicas(0)
+                .putMapping(mapping.toString())
+                .build();
+            Metadata metadata = Metadata.builder().put(indexMetadata, false).build();
+            return ClusterState.builder(new ClusterName("test")).metadata(metadata).build();
+        } catch (Exception e) {
+            throw new AssertionError("Failed to build ClusterState for index: " + indexName, e);
+        }
+    }
+}


### PR DESCRIPTION
Divided up all optimizer passes into separate methods. 

Introduced a RelOptListener for capturing profiling metrics on demand. 

Added filter pushdown rules from Standard Calcite CoreRules for pushing filter past Aggregate/Join/
