### PR TITLE
Removed deleter creation from DataFormatAwareEngine

### DIFF
--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/index/LuceneDeleteExecutionEngine.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/index/LuceneDeleteExecutionEngine.java
@@ -1,3 +1,11 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
 package org.opensearch.be.lucene.index;
 
 import org.apache.logging.log4j.LogManager;

--- a/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/index/DeleterImplTests.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/index/DeleterImplTests.java
@@ -9,20 +9,12 @@
 package org.opensearch.be.lucene.index;
 
 import org.apache.lucene.codecs.Codec;
-import org.apache.lucene.index.DirectoryReader;
-import org.apache.lucene.index.IndexReader;
-import org.apache.lucene.index.Term;
-import org.apache.lucene.search.IndexSearcher;
-import org.apache.lucene.search.TermQuery;
-import org.apache.lucene.store.NIOFSDirectory;
 import org.apache.lucene.util.BytesRef;
 import org.opensearch.be.lucene.LuceneDataFormat;
 import org.opensearch.index.engine.dataformat.DeleteInput;
 import org.opensearch.index.engine.dataformat.DeleteResult;
 import org.opensearch.index.engine.dataformat.DeleterImpl;
-import org.opensearch.index.engine.dataformat.FileInfos;
-import org.opensearch.index.engine.exec.WriterFileSet;
-import org.opensearch.index.mapper.MappedFieldType;
+import org.opensearch.index.engine.dataformat.DocumentInput;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.io.IOException;
@@ -48,21 +40,20 @@ public class DeleterImplTests extends OpenSearchTestCase {
         return new LuceneWriter(generation, 0L, dataFormat, baseDir, null, Codec.getDefault(), null);
     }
 
-    private void addDoc(LuceneWriter writer, String id) throws IOException {
-        MappedFieldType keywordField = mock(MappedFieldType.class);
-        when(keywordField.typeName()).thenReturn("keyword");
-        when(keywordField.name()).thenReturn("_id");
-        when(keywordField.hasDocValues()).thenReturn(false);
-
+    private void addDoc(LuceneWriter writer, String id, int rowId) throws IOException {
         LuceneDocumentInput input = new LuceneDocumentInput();
-        input.addField(keywordField, id);
-        input.setRowId(LuceneDocumentInput.ROW_ID_FIELD, 0);
+        org.opensearch.index.mapper.MappedFieldType idField = mock(org.opensearch.index.mapper.MappedFieldType.class);
+        when(idField.typeName()).thenReturn("_id");
+        when(idField.name()).thenReturn("_id");
+        when(idField.hasDocValues()).thenReturn(false);
+        input.addField(idField, id.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+        input.setRowId(DocumentInput.ROW_ID_FIELD, rowId);
         writer.addDoc(input);
     }
 
     private LuceneWriter createWriterWithDoc(Path baseDir, long generation, String id) throws IOException {
         LuceneWriter writer = createWriter(baseDir, generation);
-        addDoc(writer, id);
+        addDoc(writer, id, 0);
         return writer;
     }
 

--- a/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/index/LuceneDeleteExecutionEngineTests.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/index/LuceneDeleteExecutionEngineTests.java
@@ -124,11 +124,11 @@ public class LuceneDeleteExecutionEngineTests extends OpenSearchTestCase {
 
     private void addDoc(LuceneWriter writer, String id, int rowId) throws IOException {
         LuceneDocumentInput input = new LuceneDocumentInput();
-        org.opensearch.index.mapper.MappedFieldType keywordField = mock(org.opensearch.index.mapper.MappedFieldType.class);
-        when(keywordField.typeName()).thenReturn("keyword");
-        when(keywordField.name()).thenReturn("_id");
-        when(keywordField.hasDocValues()).thenReturn(false);
-        input.addField(keywordField, id);
+        org.opensearch.index.mapper.MappedFieldType idField = mock(org.opensearch.index.mapper.MappedFieldType.class);
+        when(idField.typeName()).thenReturn("_id");
+        when(idField.name()).thenReturn("_id");
+        when(idField.hasDocValues()).thenReturn(false);
+        input.addField(idField, id.getBytes(java.nio.charset.StandardCharsets.UTF_8));
         input.setRowId(DocumentInput.ROW_ID_FIELD, rowId);
         writer.addDoc(input);
     }

--- a/sandbox/plugins/composite-engine/src/test/java/org/opensearch/composite/CompositeWriterTests.java
+++ b/sandbox/plugins/composite-engine/src/test/java/org/opensearch/composite/CompositeWriterTests.java
@@ -9,12 +9,10 @@
 package org.opensearch.composite;
 
 import org.opensearch.index.engine.dataformat.FileInfos;
-import org.opensearch.index.engine.dataformat.Writer;
 import org.opensearch.index.engine.dataformat.WriterConfig;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.io.IOException;
-import java.util.Optional;
 
 /**
  * Tests for {@link CompositeWriter}.
@@ -128,29 +126,5 @@ public class CompositeWriterTests extends OpenSearchTestCase {
         assertFalse(writer.isSchemaMutable());
 
         writer.close();
-    }
-
-    public void testGetWriterForFormatReturnsLuceneWriter() throws IOException {
-        CompositeWriter writer = new CompositeWriter(engine, new WriterConfig(1L));
-        Optional<Writer<?>> result = writer.getWriterForFormat("lucene");
-
-        assertTrue("Should return present for 'lucene'", result.isPresent());
-        assertEquals("Returned writer generation should match", 1L, result.get().generation());
-    }
-
-    public void testGetWriterForFormatReturnsParquetWriter() throws IOException {
-        CompositeWriter writer = new CompositeWriter(engine, new WriterConfig(1L));
-        Optional<Writer<?>> result = writer.getWriterForFormat("parquet");
-
-        assertTrue("Should return present for 'parquet'", result.isPresent());
-        assertEquals("Returned writer generation should match", 1L, result.get().generation());
-    }
-
-    public void testGetWriterForFormatReturnsEmptyForUnknownFormat() throws IOException {
-        CompositeWriter writer = new CompositeWriter(engine, new WriterConfig(1L));
-        Optional<Writer<?>> result = writer.getWriterForFormat("unknown");
-
-        assertFalse("Should return empty for unknown format", result.isPresent());
-        assertEquals("Writer generation should still be accessible", 1L, writer.generation());
     }
 }

--- a/server/src/main/java/org/opensearch/index/engine/DataFormatAwareEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/DataFormatAwareEngine.java
@@ -34,7 +34,6 @@ import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.index.VersionType;
 import org.opensearch.index.engine.dataformat.DataFormat;
 import org.opensearch.index.engine.dataformat.DataFormatRegistry;
-import org.opensearch.index.engine.dataformat.DeleteExecutionEngine;
 import org.opensearch.index.engine.dataformat.FileInfos;
 import org.opensearch.index.engine.dataformat.IndexingEngineConfig;
 import org.opensearch.index.engine.dataformat.IndexingExecutionEngine;
@@ -140,7 +139,6 @@ public class DataFormatAwareEngine implements Indexer {
     private final Store store;
 
     private final IndexingExecutionEngine indexingExecutionEngine;
-    private final DeleteExecutionEngine<?> deleteExecutionEngine;
     private final IndexingStrategyPlanner indexingStrategyPlanner;
     private final LockablePool<DefaultLockableHolder<Writer<?>>> writerPool;
     private final AtomicLong writerGenerationCounter;
@@ -279,8 +277,6 @@ public class DataFormatAwareEngine implements Indexer {
                 registry.format(config().getIndexSettings().pluggableDataFormat())
             );
 
-            this.deleteExecutionEngine = registry.getDeleteExecutionEngine(committer);
-
             long maxGenFromCommit = 0L;
             try {
                 List<CatalogSnapshot> initSnapshots = committer.listCommittedSnapshots();
@@ -297,7 +293,6 @@ public class DataFormatAwareEngine implements Indexer {
                 long gen = writerGenerationCounter.incrementAndGet();
                 assert gen > 0 : "writer generation must be positive but was: " + gen;
                 Writer<?> writer = indexingExecutionEngine.createWriter(new WriterConfig(gen));
-                deleteExecutionEngine.createDeleter(writer);
                 return DefaultLockableHolder.of(new RowIdAwareWriter<>(writer));
             }, LinkedList::new, Runtime.getRuntime().availableProcessors());
             // Create Reader managers


### PR DESCRIPTION
### Description

Removes deleter creation from the writer pool supplier in DataFormatAwareEngine. 

Also cleans up unused imports in DeleterImplTests. 

### Related Issues

Resolves #[Issue number to be closed when this PR is merged]

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).