### PR TITLE
Enable native access for FIPS launchers

### DIFF
--- a/distribution/src/bin/opensearch-env
+++ b/distribution/src/bin/opensearch-env
@@ -121,6 +121,7 @@ OPENSEARCH_FIPS_MODE="$(echo "$OPENSEARCH_FIPS_MODE" | tr '[:upper:]' '[:lower:]
 
 if [[ "$OPENSEARCH_FIPS_MODE" == "true" ]] && ls "$OPENSEARCH_HOME/lib" | grep -E -q "bc-fips.*\.jar"; then
   echo "FIPS mode enabled, setting JVM options."
+  export OPENSEARCH_JAVA_OPTS="--enable-native-access=ALL-UNNAMED ${OPENSEARCH_JAVA_OPTS}"
   export OPENSEARCH_JAVA_OPTS="-Djava.security.properties=${OPENSEARCH_PATH_CONF}/fips_java.security ${OPENSEARCH_JAVA_OPTS}"
 
   # Ensure BC-FIPS "approved only" mode is on when FIPS mode is enabled

--- a/distribution/src/bin/opensearch-env.bat
+++ b/distribution/src/bin/opensearch-env.bat
@@ -44,7 +44,7 @@ REM Enable only if value equals "true" (case-insensitive) AND BC-FIPS JAR is pre
 if /I "%OPENSEARCH_FIPS_MODE%"=="true" (
     if "%FOUND_BC_FIPS%"=="true" (
         echo FIPS mode enabled, setting JVM options.
-        set "OPENSEARCH_JAVA_OPTS=-Dorg.bouncycastle.fips.approved_only=true -Djava.security.properties=""%OPENSEARCH_PATH_CONF%\fips_java.security"" %OPENSEARCH_JAVA_OPTS%"
+        set "OPENSEARCH_JAVA_OPTS=-Dorg.bouncycastle.fips.approved_only=true -Djava.security.properties=""%OPENSEARCH_PATH_CONF%\fips_java.security"" --enable-native-access=ALL-UNNAMED %OPENSEARCH_JAVA_OPTS%"
     )
 )
 


### PR DESCRIPTION
### Description
Adds `--enable-native-access=ALL-UNNAMED` when OpenSearch starts in FIPS mode with `bc-fips` present. This matches the JVM guidance emitted by Java when Bouncy Castle FIPS loads native code and prevents restricted native access warnings from the keystore and other launcher-based CLI paths.

The flag is scoped to the existing FIPS launcher branch, alongside `fips_java.security` and `org.bouncycastle.fips.approved_only=true`, rather than being enabled globally.

Fixes #21640.

### Validation
- `bash -n distribution/src/bin/opensearch-env`
- `java --enable-native-access=ALL-UNNAMED -version` with Java 21
- bundled Java 25 accepts `--enable-native-access=ALL-UNNAMED`
- `./gradlew :distribution:archives:linux-tar:assemble :distribution:archives:windows-zip:assemble`
- verified generated Linux tar and Windows zip launcher scripts include the new flag