### PR TITLE
Fix NodeResourceUsageStats constructor to include nativeMemoryUtilizationPercent param

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/storage/tiering/HotToWarmTieringServiceIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/storage/tiering/HotToWarmTieringServiceIT.java
@@ -1045,7 +1045,7 @@ public class HotToWarmTieringServiceIT extends RemoteStoreBaseIntegTestCase {
         );
         clusterInfoService.setShardSizeFunctionAndRefresh(shardRouting -> 230L);
         clusterInfoService.setNodeResourceUsageFunctionAndRefresh(
-            nodeId -> new NodeResourceUsageStats(nodeId, System.currentTimeMillis(), 99, 20, null)
+            nodeId -> new NodeResourceUsageStats(nodeId, System.currentTimeMillis(), 99, 20, null, 0.0)
         );
 
         verifyMigrationError(INDEX_NAME, "Rejecting tiering request as JVM Utilization is high on all [WARM] nodes");

--- a/server/src/internalClusterTest/java/org/opensearch/storage/tiering/WarmToHotTieringServiceIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/storage/tiering/WarmToHotTieringServiceIT.java
@@ -1343,7 +1343,7 @@ public class WarmToHotTieringServiceIT extends RemoteStoreBaseIntegTestCase {
         migrateToWarm(INDEX_NAME);
 
         clusterInfoService.setNodeResourceUsageFunctionAndRefresh(
-            (nodeId -> new NodeResourceUsageStats(nodeId, System.currentTimeMillis(), 99, 20, null))
+            (nodeId -> new NodeResourceUsageStats(nodeId, System.currentTimeMillis(), 99, 20, null, 0.0))
         );
 
         // Try migrating again and verify error


### PR DESCRIPTION


<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Fixes compilation error in tiered storage integration tests caused by PR #21191 which added a 6th parameter (`nativeMemoryUtilizationPercent`) to the `NodeResourceUsageStats` constructor. Updated the constructor calls in    `HotToWarmTieringServiceIT` and `WarmToHotTieringServiceIT` to pass `0.0` for the new parameter.

### Related Issues
Fixes compilation failure introduced by #21191

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
