### PR TITLE
Wire coordinator queries into Rust query-tracking + cancellation

### DIFF
--- a/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/ExchangeSinkContext.java
+++ b/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/ExchangeSinkContext.java
@@ -23,6 +23,10 @@ import java.util.List;
  * <ul>
  *   <li>{@code queryId} / {@code stageId} — correlation ids for backend logs
  *       and metrics.</li>
+ *   <li>{@code taskId} — the parent {@code AnalyticsQueryTask} id. Backends
+ *       forward this to the native runtime as the query-tracking context id so
+ *       one cancellation call from Java cascades to every native query scope
+ *       (shard scans + coord reduce) registered under the same task.</li>
  *   <li>{@code fragmentBytes} — backend-specific serialized plan (e.g.
  *       Substrait) the backend will execute over the fed batches.</li>
  *   <li>{@code allocator} — the parent buffer allocator the backend should
@@ -42,7 +46,7 @@ import java.util.List;
  *
  * @opensearch.internal
  */
-public record ExchangeSinkContext(String queryId, int stageId, byte[] fragmentBytes, BufferAllocator allocator, List<
+public record ExchangeSinkContext(String queryId, int stageId, long taskId, byte[] fragmentBytes, BufferAllocator allocator, List<
     ChildInput> childInputs, ExchangeSink downstream) implements CommonExecutionContext {
 
     /**

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/api.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/api.rs
@@ -821,14 +821,65 @@ pub async unsafe fn execute_local_plan(
     let session = &*(session_ptr as *const LocalSession);
 
     // Per-query memory tracking — wraps the session's global pool. A
-    // `context_id` of 0 disables tracking (pool is not consulted).
+    // `context_id` of 0 disables tracking (pool is not consulted) and no
+    // cancellation token is registered in the global QUERY_REGISTRY.
     let query_context = QueryTrackingContext::new(context_id, session.memory_pool());
+    let token = query_tracker::get_cancellation_token(context_id);
 
-    let df_stream = session.execute_substrait(substrait_bytes).await?;
+    // Race substrait planning + execution against the cancellation token so
+    // a `cancel_query(context_id)` call from Java interrupts even before the
+    // first batch is produced (planning, from_substrait_plan, repartition
+    // setup, etc. can all take non-trivial time on a wide reduce).
+    let df_stream = cancellation::cancellable(
+        token.as_ref(),
+        context_id,
+        session.execute_substrait(substrait_bytes),
+    )
+    .await
+    .map_err(DataFusionError::Execution)?;
 
     // Wrap the output in the same CrossRtStream + RecordBatchStreamAdapter
     // shape as `execute_query`, so existing `stream_next` / `stream_close`
     // drain this handle unchanged.
+    let cross_rt_stream =
+        CrossRtStream::new_with_df_error_stream(df_stream, manager.cpu_executor());
+    let wrapped = RecordBatchStreamAdapter::new(cross_rt_stream.schema(), cross_rt_stream);
+
+    let handle = QueryStreamHandle::new(wrapped, query_context);
+    Ok(Box::into_raw(Box::new(handle)) as i64)
+}
+
+/// Executes the previously prepared final-aggregate plan on a local session.
+/// Mirrors [`execute_local_plan`] for the prepared-plan path: registers a
+/// query-tracking context + cancellation token under `context_id` so the
+/// parent `AnalyticsQueryTask` cancel propagates here, and wraps the native
+/// output in the same `CrossRtStream` + `RecordBatchStreamAdapter` + handle
+/// shape as the streaming path.
+///
+/// # Safety
+/// `session_ptr` must be a valid, non-zero pointer returned by
+/// `create_local_session` with a plan already prepared via
+/// [`LocalSession::prepare_final_plan`].
+pub unsafe fn execute_local_prepared_plan(
+    session_ptr: i64,
+    manager: &RuntimeManager,
+    context_id: i64,
+) -> Result<i64, DataFusionError> {
+    let session = &*(session_ptr as *const LocalSession);
+
+    // Registers the tracker + cancellation token under context_id in the
+    // shared QUERY_REGISTRY — parity with execute_query + execute_local_plan,
+    // so a `cancel_query(context_id)` call fires the token here too.
+    // The token is held via the QueryStreamHandle's context and consulted by
+    // stream_next on each batch pull.
+    let query_context = QueryTrackingContext::new(context_id, session.memory_pool());
+
+    // DataFusion's execute_stream is sync, but kicks off RepartitionExec /
+    // stream channels that require a Tokio reactor. Enter the IO runtime's
+    // context so those operators can register with the reactor.
+    let _guard = manager.io_runtime.enter();
+    let df_stream = session.execute_prepared()?;
+
     let cross_rt_stream =
         CrossRtStream::new_with_df_error_stream(df_stream, manager.cpu_executor());
     let wrapped = RecordBatchStreamAdapter::new(cross_rt_stream.schema(), cross_rt_stream);

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/ffm.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/ffm.rs
@@ -323,6 +323,7 @@ pub unsafe extern "C" fn df_execute_local_plan(
     session_ptr: i64,
     substrait_ptr: *const u8,
     substrait_len: i64,
+    context_id: i64,
 ) -> i64 {
     let mgr = get_rt_manager()?;
     // Copy substrait bytes into an owned Vec so the spawned future can move them
@@ -340,7 +341,10 @@ pub unsafe extern "C" fn df_execute_local_plan(
     mgr.io_runtime
         .block_on(crate::task_monitors::coordinator_reduce_monitor().instrument(async move {
             let inner_fut = async move {
-                unsafe { api::execute_local_plan(session_ptr, &bytes_vec, &mgr_for_inner, 0).await }
+                unsafe {
+                    api::execute_local_plan(session_ptr, &bytes_vec, &mgr_for_inner, context_id)
+                        .await
+                }
             };
             match mgr_for_spawn.cpu_executor().spawn(inner_fut).await {
                 Ok(inner_result) => inner_result,
@@ -866,21 +870,10 @@ pub unsafe extern "C" fn df_prepare_final_plan(
 /// with a plan already prepared via `df_prepare_final_plan`.
 #[ffm_safe]
 #[no_mangle]
-pub unsafe extern "C" fn df_execute_local_prepared_plan(session_ptr: i64) -> i64 {
-    let session = &*(session_ptr as *const crate::local_executor::LocalSession);
+pub unsafe extern "C" fn df_execute_local_prepared_plan(
+    session_ptr: i64,
+    context_id: i64,
+) -> i64 {
     let mgr = get_rt_manager()?;
-    // DataFusion's execute_stream is sync, but kicks off RepartitionExec / stream
-    // channels that require a Tokio reactor. Enter the IO runtime's context so those
-    // operators can register with the reactor.
-    let _guard = mgr.io_runtime.enter();
-    let df_stream = session.execute_prepared().map_err(|e| e.to_string())?;
-    let cross_rt_stream =
-        crate::cross_rt_stream::CrossRtStream::new_with_df_error_stream(df_stream, mgr.cpu_executor());
-    let wrapped = datafusion::physical_plan::stream::RecordBatchStreamAdapter::new(
-        cross_rt_stream.schema(),
-        cross_rt_stream,
-    );
-    let query_context = crate::query_tracker::QueryTrackingContext::new(0, session.memory_pool());
-    let handle = crate::api::QueryStreamHandle::new(wrapped, query_context);
-    Ok(Box::into_raw(Box::new(handle)) as i64)
+    api::execute_local_prepared_plan(session_ptr, &mgr, context_id).map_err(|e| e.to_string())
 }

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/local_executor.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/local_executor.rs
@@ -407,4 +407,58 @@ mod tests {
             .expect("prepare_final_plan succeeds");
         assert!(session.prepared_plan.is_some());
     }
+
+    /// Coordinator-side task cancellation wiring: once Java calls
+    /// `execute_local_plan(session, plan, context_id)` the context is
+    /// registered in [`query_tracker::QUERY_REGISTRY`], and a
+    /// [`cancel_query(context_id)`] cascade resolves the racing execute
+    /// future through the [`cancellation::cancellable`] branch.
+    ///
+    /// Mirrors the `execute_query` cancel path for the coordinator entry so
+    /// a parent `AnalyticsQueryTask.cancel()` interrupts the reduce even
+    /// before the first batch is produced.
+    #[tokio::test]
+    async fn cancel_query_fires_token_registered_from_reduce_path() {
+        use crate::cancellation;
+        use crate::query_tracker::{self, QueryTrackingContext};
+        use datafusion::execution::memory_pool::GreedyMemoryPool;
+        use std::sync::Arc;
+        use std::time::Duration;
+
+        let ctx_id = 98_765;
+        let pool: Arc<dyn datafusion::execution::memory_pool::MemoryPool> =
+            Arc::new(GreedyMemoryPool::new(10_000));
+        let _tracking = QueryTrackingContext::new(ctx_id, pool);
+
+        // A future that would block indefinitely — `cancel_query` is the
+        // only way out. Mirrors a coord reduce stalled on an input partition
+        // that never receives batches.
+        let blocked = async {
+            tokio::time::sleep(Duration::from_secs(60)).await;
+            Ok::<(), String>(())
+        };
+
+        let token = query_tracker::get_cancellation_token(ctx_id);
+        assert!(
+            token.is_some(),
+            "QueryTrackingContext::new must register a cancellation token"
+        );
+
+        let runner = tokio::spawn(async move {
+            cancellation::cancellable(token.as_ref(), ctx_id, blocked).await
+        });
+
+        // Brief yield so the runner parks on the sleep before we cancel.
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        query_tracker::cancel_query(ctx_id);
+
+        let result = runner.await.expect("spawn");
+        assert!(result.is_err(), "cancel_query must surface as an error");
+        let msg = result.err().unwrap();
+        assert!(
+            msg.contains(&ctx_id.to_string()) && msg.to_lowercase().contains("cancelled"),
+            "error must name the cancelled context: got [{}]",
+            msg
+        );
+    }
 }

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionMemtableReduceSink.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionMemtableReduceSink.java
@@ -130,7 +130,7 @@ public final class DatafusionMemtableReduceSink extends AbstractDatafusionReduce
             );
             childSchemas.put(singleChildStageId, ArrowSchemaIpc.fromBytes(registered.schemaIpc()));
 
-            streamPtr = NativeBridge.executeLocalPlan(session.getPointer(), ctx.fragmentBytes());
+            streamPtr = NativeBridge.executeLocalPlan(session.getPointer(), ctx.fragmentBytes(), ctx.taskId());
             try (StreamHandle outStream = new StreamHandle(streamPtr, runtimeHandle)) {
                 streamPtr = 0;
                 drainOutputIntoDownstream(outStream);

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionReduceSink.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionReduceSink.java
@@ -103,7 +103,7 @@ public final class DatafusionReduceSink extends AbstractDatafusionReduceSink imp
                     childSchemas.put(child.getKey(), preparedState.inputSchemas().get(i));
                     i++;
                 }
-                streamPtr = NativeBridge.executeLocalPreparedPlan(session.getPointer());
+                streamPtr = NativeBridge.executeLocalPreparedPlan(session.getPointer(), ctx.taskId());
             } else {
                 // Legacy path (non-aggregate reduce): register partitions and execute the
                 // fragment bytes directly. Used when no prior instruction prepared a plan.
@@ -121,7 +121,7 @@ public final class DatafusionReduceSink extends AbstractDatafusionReduceSink imp
                     senders.put(childStageId, new DatafusionPartitionSender(registered.pointer()));
                     childSchemas.put(childStageId, ArrowSchemaIpc.fromBytes(registered.schemaIpc()));
                 }
-                streamPtr = NativeBridge.executeLocalPlan(session.getPointer(), ctx.fragmentBytes());
+                streamPtr = NativeBridge.executeLocalPlan(session.getPointer(), ctx.fragmentBytes(), ctx.taskId());
             }
             outStreamLocal = new StreamHandle(streamPtr, runtimeHandle);
             success = true;

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/nativelib/NativeBridge.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/nativelib/NativeBridge.java
@@ -225,10 +225,16 @@ public final class NativeBridge {
             )
         );
 
-        // i64 df_execute_local_plan(session_ptr, substrait_ptr, substrait_len)
+        // i64 df_execute_local_plan(session_ptr, substrait_ptr, substrait_len, context_id)
         EXECUTE_LOCAL_PLAN = linker.downcallHandle(
             lib.find("df_execute_local_plan").orElseThrow(),
-            FunctionDescriptor.of(ValueLayout.JAVA_LONG, ValueLayout.JAVA_LONG, ValueLayout.ADDRESS, ValueLayout.JAVA_LONG)
+            FunctionDescriptor.of(
+                ValueLayout.JAVA_LONG,
+                ValueLayout.JAVA_LONG,
+                ValueLayout.ADDRESS,
+                ValueLayout.JAVA_LONG,
+                ValueLayout.JAVA_LONG
+            )
         );
 
         // i64 df_sender_send(sender_ptr, array_ptr, schema_ptr)
@@ -420,10 +426,10 @@ public final class NativeBridge {
             FunctionDescriptor.of(ValueLayout.JAVA_LONG, ValueLayout.JAVA_LONG, ValueLayout.ADDRESS, ValueLayout.JAVA_LONG)
         );
 
-        // i64 df_execute_local_prepared_plan(session_ptr)
+        // i64 df_execute_local_prepared_plan(session_ptr, context_id)
         EXECUTE_LOCAL_PREPARED_PLAN = linker.downcallHandle(
             lib.find("df_execute_local_prepared_plan").orElseThrow(),
-            FunctionDescriptor.of(ValueLayout.JAVA_LONG, ValueLayout.JAVA_LONG)
+            FunctionDescriptor.of(ValueLayout.JAVA_LONG, ValueLayout.JAVA_LONG, ValueLayout.JAVA_LONG)
         );
     }
 
@@ -791,11 +797,17 @@ public final class NativeBridge {
     /**
      * Executes a Substrait plan on the session, returning an opaque stream pointer. The stream is
      * drained via {@link #streamNext} and freed by {@link #streamClose}.
+     *
+     * @param sessionPtr pointer returned by {@link #createLocalSession}
+     * @param substrait  Substrait plan bytes
+     * @param contextId  the parent {@code AnalyticsQueryTask.getId()}; registers the reduce in the
+     *                   native {@code QUERY_REGISTRY} under this id so {@link #cancelQuery} fires
+     *                   the attached cancellation token. Pass {@code 0} to disable tracking.
      */
-    public static long executeLocalPlan(long sessionPtr, byte[] substrait) {
+    public static long executeLocalPlan(long sessionPtr, byte[] substrait, long contextId) {
         NativeHandle.validatePointer(sessionPtr, "session");
         try (var call = new NativeCall()) {
-            return call.invoke(EXECUTE_LOCAL_PLAN, sessionPtr, call.bytes(substrait), (long) substrait.length);
+            return call.invoke(EXECUTE_LOCAL_PLAN, sessionPtr, call.bytes(substrait), (long) substrait.length, contextId);
         }
     }
 
@@ -1020,12 +1032,14 @@ public final class NativeBridge {
      *
      * @param sessionPtr pointer returned by {@link #createLocalSession} with a plan
      *                   already prepared via {@link #prepareFinalPlan}
+     * @param contextId  the parent {@code AnalyticsQueryTask.getId()}; see
+     *                   {@link #executeLocalPlan(long, byte[], long)} for semantics
      * @return opaque stream pointer
      */
-    public static long executeLocalPreparedPlan(long sessionPtr) {
+    public static long executeLocalPreparedPlan(long sessionPtr, long contextId) {
         NativeHandle.validatePointer(sessionPtr, "session");
         try (var call = new NativeCall()) {
-            return call.invoke(EXECUTE_LOCAL_PREPARED_PLAN, sessionPtr);
+            return call.invoke(EXECUTE_LOCAL_PREPARED_PLAN, sessionPtr, contextId);
         }
     }
 

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionMemtableReduceSinkTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionMemtableReduceSinkTests.java
@@ -66,6 +66,7 @@ public class DatafusionMemtableReduceSinkTests extends OpenSearchTestCase {
             ExchangeSinkContext ctx = new ExchangeSinkContext(
                 "q-1",
                 0,
+                0L,
                 substrait,
                 alloc,
                 List.of(new ExchangeSinkContext.ChildInput(0, buildPassthroughSubstraitBytes(DatafusionMemtableReduceSink.INPUT_ID))),

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionReduceSinkTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionReduceSinkTests.java
@@ -99,6 +99,7 @@ public class DatafusionReduceSinkTests extends OpenSearchTestCase {
             ExchangeSinkContext ctx = new ExchangeSinkContext(
                 "q-1",
                 0,
+                0L,
                 substrait,
                 alloc,
                 List.of(new ExchangeSinkContext.ChildInput(0, buildPassthroughSubstraitBytes(DatafusionReduceSink.INPUT_ID))),
@@ -145,6 +146,7 @@ public class DatafusionReduceSinkTests extends OpenSearchTestCase {
             ExchangeSinkContext ctx = new ExchangeSinkContext(
                 "q-drain",
                 0,
+                0L,
                 substrait,
                 alloc,
                 List.of(new ExchangeSinkContext.ChildInput(0, buildPassthroughSubstraitBytes(DatafusionReduceSink.INPUT_ID))),
@@ -199,6 +201,7 @@ public class DatafusionReduceSinkTests extends OpenSearchTestCase {
             ExchangeSinkContext ctx = new ExchangeSinkContext(
                 "q-pipelined",
                 0,
+                0L,
                 reduceSubstrait,
                 alloc,
                 List.of(new ExchangeSinkContext.ChildInput(0, childSubstrait)),

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/NativeBridgePreparedPlanTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/NativeBridgePreparedPlanTests.java
@@ -31,7 +31,7 @@ public class NativeBridgePreparedPlanTests extends OpenSearchTestCase {
     }
 
     public void testExecuteLocalPreparedPlanRejectsNullPointer() {
-        expectThrows(IllegalArgumentException.class, () -> NativeBridge.executeLocalPreparedPlan(0L));
+        expectThrows(IllegalArgumentException.class, () -> NativeBridge.executeLocalPreparedPlan(0L, 0L));
     }
 
     /**

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stage/LocalComputeStageExecutionFactory.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stage/LocalComputeStageExecutionFactory.java
@@ -44,6 +44,7 @@ final class LocalComputeStageExecutionFactory implements StageExecutionFactory {
         ExchangeSinkContext context = new ExchangeSinkContext(
             config.queryId(),
             stage.getStageId(),
+            config.parentTask() != null ? config.parentTask().getId() : 0L,
             chosenBytes(stage),
             config.bufferAllocator(),
             List.of(),

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stage/LocalStageExecutionFactory.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stage/LocalStageExecutionFactory.java
@@ -46,6 +46,7 @@ final class LocalStageExecutionFactory implements StageExecutionFactory {
         ExchangeSinkContext context = new ExchangeSinkContext(
             config.queryId(),
             stage.getStageId(),
+            config.parentTask() != null ? config.parentTask().getId() : 0L,
             chosenBytes(stage),
             config.bufferAllocator(),
             buildChildInputs(stage),

--- a/sandbox/qa/analytics-engine-coordinator/src/internalClusterTest/java/org/opensearch/be/datafusion/CoordinatorReduceStressIT.java
+++ b/sandbox/qa/analytics-engine-coordinator/src/internalClusterTest/java/org/opensearch/be/datafusion/CoordinatorReduceStressIT.java
@@ -154,6 +154,7 @@ public class CoordinatorReduceStressIT extends OpenSearchTestCase {
         ExchangeSinkContext ctx = new ExchangeSinkContext(
             "q-r1",
             0,
+            0L,
             substrait,
             alloc,
             List.of(new ExchangeSinkContext.ChildInput(0, buildPassthroughSubstrait(INPUT_ID))),
@@ -192,6 +193,7 @@ public class CoordinatorReduceStressIT extends OpenSearchTestCase {
         ExchangeSinkContext ctx = new ExchangeSinkContext(
             "q-r2",
             0,
+            0L,
             substrait,
             alloc,
             List.of(new ExchangeSinkContext.ChildInput(0, buildPassthroughSubstrait(INPUT_ID))),
@@ -272,6 +274,7 @@ public class CoordinatorReduceStressIT extends OpenSearchTestCase {
         ExchangeSinkContext ctx = new ExchangeSinkContext(
             "q-r3",
             0,
+            0L,
             substrait,
             alloc,
             List.of(new ExchangeSinkContext.ChildInput(0, buildPassthroughSubstrait(INPUT_ID))),
@@ -373,6 +376,7 @@ public class CoordinatorReduceStressIT extends OpenSearchTestCase {
         ExchangeSinkContext ctx = new ExchangeSinkContext(
             "q-r3-bug",
             0,
+            0L,
             substrait,
             alloc,
             List.of(new ExchangeSinkContext.ChildInput(0, buildPassthroughSubstrait(INPUT_ID))),
@@ -468,6 +472,7 @@ public class CoordinatorReduceStressIT extends OpenSearchTestCase {
                         ExchangeSinkContext ctx = new ExchangeSinkContext(
                             "q-r4-" + idx,
                             0,
+                            0L,
                             substrait,
                             alloc,
                             List.of(new ExchangeSinkContext.ChildInput(0, buildPassthroughSubstrait(INPUT_ID))),
@@ -561,6 +566,7 @@ public class CoordinatorReduceStressIT extends OpenSearchTestCase {
         ExchangeSinkContext ctx = new ExchangeSinkContext(
             queryId,
             0,
+            0L,
             substrait,
             alloc,
             List.of(new ExchangeSinkContext.ChildInput(0, buildPassthroughSubstrait(INPUT_ID))),
@@ -598,6 +604,7 @@ public class CoordinatorReduceStressIT extends OpenSearchTestCase {
         ExchangeSinkContext ctx = new ExchangeSinkContext(
             "q-m1",
             0,
+            0L,
             substrait,
             alloc,
             List.of(new ExchangeSinkContext.ChildInput(0, buildPassthroughSubstrait(INPUT_ID))),
@@ -637,6 +644,7 @@ public class CoordinatorReduceStressIT extends OpenSearchTestCase {
             ExchangeSinkContext ctx = new ExchangeSinkContext(
                 "q-m2-" + run,
                 0,
+                0L,
                 substrait,
                 alloc,
                 List.of(new ExchangeSinkContext.ChildInput(0, buildPassthroughSubstrait(INPUT_ID))),
@@ -672,6 +680,7 @@ public class CoordinatorReduceStressIT extends OpenSearchTestCase {
         ExchangeSinkContext ctx = new ExchangeSinkContext(
             "q-m3",
             0,
+            0L,
             buildSumSubstrait(),
             alloc,
             List.of(
@@ -708,6 +717,7 @@ public class CoordinatorReduceStressIT extends OpenSearchTestCase {
         ExchangeSinkContext ctx = new ExchangeSinkContext(
             "q-f1",
             0,
+            0L,
             substrait,
             alloc,
             List.of(
@@ -767,6 +777,7 @@ public class CoordinatorReduceStressIT extends OpenSearchTestCase {
         ExchangeSinkContext ctx = new ExchangeSinkContext(
             "q-f2",
             0,
+            0L,
             substrait,
             alloc,
             List.of(


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Mirrors the data-node scan path (execute_query) for the coordinator reduce path so one AnalyticsQueryTask cancel call cascades to both stages.

Rust:
- df_execute_local_plan / df_execute_local_prepared_plan gain a trailing context_id parameter. api::execute_local_plan wraps session.execute_substrait in cancellation::cancellable so the parent AnalyticsQueryTask.cancel interrupts reduce planning + execution even before the first batch, via the QueryTrackingContext token that new() auto-registers in the shared QUERY_REGISTRY. execute_local_prepared_plan is similarly registered (the token is held via the returned QueryStreamHandle's context and consulted by stream_next).
- Single shared QUERY_REGISTRY for both stages, keyed by AnalyticsQueryTask.getId() — per the Slack discussion, SBP / task cancellation pick the heaviest global query regardless of stage.

Java:
- ExchangeSinkContext record gains a `long taskId` field. LocalStageScheduler threads config.parentTask().getId() into it; DatafusionReduceSink, DatafusionMemtableReduceSink, and the prepared-plan path forward it to NativeBridge.executeLocalPlan / executeLocalPreparedPlan.
- NativeBridge FFI descriptors + Java method signatures updated.

Tests:
- local_executor::tests::cancel_query_fires_token_registered_from_reduce_path asserts registry wiring: QueryTrackingContext::new(ctx_id, ..) registers a token, cancel_query(ctx_id) fires it, cancellable() surfaces the cancelled error mentioning the context id. End-to-end IT coverage comes from CoordinatorResilienceIT.testTaskCancellationAtCoordinator in PR #21626, which this branch rebases onto.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
