### PR TITLE
Changing RowIDMapping from multi-generation one to single generation with memory improvements

### DIFF
--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/index/LuceneWriter.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/index/LuceneWriter.java
@@ -665,7 +665,7 @@ public class LuceneWriter implements Writer<LuceneDocumentInput> {
                     if (docID == rowIdToPurge) {
                         return rowIdToPurge;
                     }
-                    return (int) mapping.getNewRowId(docID, RowIdMapping.SINGLE_GEN);
+                    return (int) mapping.getNewRowId(docID);
                 }
 
                 @Override

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/merge/LuceneMergeStrategy.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/merge/LuceneMergeStrategy.java
@@ -16,16 +16,17 @@ import org.opensearch.index.engine.dataformat.RowIdMapping;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Strategy interface for Lucene merge behavior based on whether Lucene is the
  * primary or secondary data format in a composite index.
  *
  * <p>When Lucene is the <b>primary</b> format, it performs a standard merge and
- * produces a {@link RowIdMapping} that secondary formats use to align their
+ * produces per-generation {@link RowIdMapping}s that secondary formats use to align their
  * document order.
  *
- * <p>When Lucene is a <b>secondary</b> format, it receives a {@link RowIdMapping}
+ * <p>When Lucene is a <b>secondary</b> format, it receives per-generation {@link RowIdMapping}s
  * from the primary format and remaps its row ID doc values + reorders documents
  * to match the primary's merged output.
  *
@@ -42,26 +43,27 @@ public interface LuceneMergeStrategy {
      * with {@link RowIdRemappingCodecReader} for row ID remapping.
      *
      * @param segments the segments to merge
-     * @param rowIdMapping the row ID mapping from the primary format, or null if this is the primary
-     * @param outputWriterGeneration the writer generation to assign to the merged output segment;
-     *                               strategies that produce a {@link RowIdRemappingOneMerge} use this
-     *                               to stamp the {@code writer_generation} attribute onto the merged
-     *                               {@code .si} file via {@code setMergeInfo}
+     * @param rowIdMappings per-generation row ID mappings from the primary format, or empty if this is the primary
+     * @param outputWriterGeneration the writer generation to assign to the merged output segment
      * @return the configured OneMerge for execution
      */
-    MergePolicy.OneMerge createOneMerge(List<SegmentCommitInfo> segments, RowIdMapping rowIdMapping, long outputWriterGeneration);
+    MergePolicy.OneMerge createOneMerge(
+        List<SegmentCommitInfo> segments,
+        Map<Long, RowIdMapping> rowIdMappings,
+        long outputWriterGeneration
+    );
 
     /**
-     * Builds or resolves the {@link RowIdMapping} after the merge completes.
+     * Builds or resolves the per-generation {@link RowIdMapping}s after the merge completes.
      *
-     * <p>Primary strategy: builds a new mapping by reading the merged segment to determine
+     * <p>Primary strategy: builds new mappings by reading the merged segment to determine
      * how old row IDs map to new positions in the merged output.
-     * <p>Secondary strategy: passes through the input mapping (already provided by the primary).
+     * <p>Secondary strategy: passes through the input mappings (already provided by the primary).
      *
      * @param completedMerge the merge that was executed (contains merged segment info)
-     * @param mergeInput the original merge input (contains input row ID mapping and segment list)
-     * @return the row ID mapping for the merge result, or null if not applicable
+     * @param mergeInput the original merge input (contains input row ID mappings and segment list)
+     * @return the per-generation row ID mappings for the merge result, or null if not applicable
      * @throws IOException if reading the merged segment fails
      */
-    RowIdMapping buildRowIdMapping(MergePolicy.OneMerge completedMerge, MergeInput mergeInput) throws IOException;
+    Map<Long, RowIdMapping> buildRowIdMappings(MergePolicy.OneMerge completedMerge, MergeInput mergeInput) throws IOException;
 }

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/merge/LuceneMerger.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/merge/LuceneMerger.java
@@ -99,7 +99,7 @@ public class LuceneMerger implements Merger {
     public MergeResult merge(MergeInput mergeInput) throws IOException {
         long start = System.nanoTime();
         try {
-            RowIdMapping rowIdMapping = mergeInput.rowIdMapping();
+            Map<Long, RowIdMapping> rowIdMappings = mergeInput.rowIdMappings();
             List<Segment> segments = mergeInput.segments();
 
             if (segments.isEmpty()) {
@@ -163,7 +163,7 @@ public class LuceneMerger implements Merger {
             // writer_generation attribute onto the merged SegmentInfo via setMergeInfo, which
             // Lucene invokes immediately before codec.segmentInfoFormat().write(...) — so the
             // attribute is persisted to the .si file and survives a writer reopen.
-            MergePolicy.OneMerge oneMerge = strategy.createOneMerge(matchingSegments, rowIdMapping, mergeInput.newWriterGeneration());
+            MergePolicy.OneMerge oneMerge = strategy.createOneMerge(matchingSegments, rowIdMappings, mergeInput.newWriterGeneration());
             indexWriter.executeMerge(oneMerge, mergeInput.newWriterGeneration());
 
             // Build the merged WriterFileSet from the output segment info
@@ -171,7 +171,7 @@ public class LuceneMerger implements Merger {
             WriterFileSet mergedFileSet = buildMergedFileSet(mergedInfo, mergeInput.newWriterGeneration());
 
             // Delegate RowIdMapping production to the strategy
-            RowIdMapping outputMapping = strategy.buildRowIdMapping(oneMerge, mergeInput);
+            Map<Long, RowIdMapping> outputMappings = strategy.buildRowIdMappings(oneMerge, mergeInput);
 
             logger.debug(
                 "LuceneMerger: completed merge of {} segments at generation {} ({} docs, {} files)",
@@ -182,7 +182,7 @@ public class LuceneMerger implements Merger {
             );
 
             stats.incMergeTotal();
-            return new MergeResult(Map.of(dataFormat, mergedFileSet), outputMapping);
+            return new MergeResult(Map.of(dataFormat, mergedFileSet), outputMappings);
         } catch (IOException e) {
             stats.incMergeFailures();
             throw e;

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/merge/PrimaryLuceneMergeStrategy.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/merge/PrimaryLuceneMergeStrategy.java
@@ -15,15 +15,16 @@ import org.opensearch.index.engine.dataformat.MergeInput;
 import org.opensearch.index.engine.dataformat.RowIdMapping;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * Merge strategy for when Lucene is the <b>primary</b> data format in a composite index.
  *
  * <p>As the primary format, Lucene performs a standard merge (no row ID remapping on input)
- * and produces a {@link RowIdMapping} that secondary formats use to align their document
- * order with the merged output.
+ * and produces per-generation {@link RowIdMapping}s that secondary formats use to align their
+ * document order with the merged output.
  *
- * <p>The mapping is built after the merge completes by reading the merged segment to
+ * <p>The mappings are built after the merge completes by reading the merged segment to
  * determine how documents from each source generation were reordered.
  *
  * @opensearch.experimental
@@ -32,12 +33,16 @@ import java.util.List;
 public class PrimaryLuceneMergeStrategy implements LuceneMergeStrategy {
 
     @Override
-    public MergePolicy.OneMerge createOneMerge(List<SegmentCommitInfo> segments, RowIdMapping rowIdMapping, long outputWriterGeneration) {
+    public MergePolicy.OneMerge createOneMerge(
+        List<SegmentCommitInfo> segments,
+        Map<Long, RowIdMapping> rowIdMappings,
+        long outputWriterGeneration
+    ) {
         throw new UnsupportedOperationException("Primary Lucene merge strategy is not yet implemented");
     }
 
     @Override
-    public RowIdMapping buildRowIdMapping(MergePolicy.OneMerge completedMerge, MergeInput mergeInput) {
+    public Map<Long, RowIdMapping> buildRowIdMappings(MergePolicy.OneMerge completedMerge, MergeInput mergeInput) {
         throw new UnsupportedOperationException("Primary Lucene merge strategy is not yet implemented");
     }
 }

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/merge/RowIdRemappingCodecReader.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/merge/RowIdRemappingCodecReader.java
@@ -20,8 +20,8 @@ import org.opensearch.index.engine.dataformat.RowIdMapping;
  * <p>This ensures the merged segment's {@code ___row_id} field stores the new global row IDs
  * from the {@link RowIdMapping}, not the original per-segment local values.
  *
- * <p>The IndexSort on the writer handles document <em>ordering</em> during merge.
- * This reader handles the <em>values</em> written to the merged segment.
+ * <p>Each instance holds the {@link RowIdMapping} for its specific generation — the generation
+ * resolution has already been performed upstream by {@link RowIdRemappingOneMerge}.
  *
  * @opensearch.experimental
  */
@@ -29,19 +29,16 @@ import org.opensearch.index.engine.dataformat.RowIdMapping;
 class RowIdRemappingCodecReader extends FilterCodecReader {
 
     private final RowIdMapping rowIdMapping;
-    private final long generation;
     private final int rowIdOffset;
 
     /**
      * @param in           the source codec reader to wrap
-     * @param rowIdMapping the mapping from old to new row IDs, or null for sequential assignment
-     * @param generation   the writer generation of this segment
+     * @param rowIdMapping the mapping from old to new row IDs for this segment's generation, or null for sequential assignment
      * @param rowIdOffset  the starting row ID offset for sequential assignment
      */
-    RowIdRemappingCodecReader(CodecReader in, RowIdMapping rowIdMapping, long generation, int rowIdOffset) {
+    RowIdRemappingCodecReader(CodecReader in, RowIdMapping rowIdMapping, int rowIdOffset) {
         super(in);
         this.rowIdMapping = rowIdMapping;
-        this.generation = generation;
         this.rowIdOffset = rowIdOffset;
     }
 
@@ -51,7 +48,7 @@ class RowIdRemappingCodecReader extends FilterCodecReader {
         if (delegate == null) {
             return null;
         }
-        return new RowIdRemappingDocValuesProducer(delegate, rowIdMapping, generation, in.maxDoc(), rowIdOffset);
+        return new RowIdRemappingDocValuesProducer(delegate, rowIdMapping, in.maxDoc(), rowIdOffset);
     }
 
     @Override

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/merge/RowIdRemappingDocValuesProducer.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/merge/RowIdRemappingDocValuesProducer.java
@@ -27,6 +27,9 @@ import java.io.IOException;
  * remapped row ID values from a {@link RowIdMapping}. All other fields are delegated
  * unchanged to the wrapped producer.
  *
+ * <p>Each instance holds the {@link RowIdMapping} for its specific generation — the generation
+ * resolution has already been performed upstream by {@link RowIdRemappingOneMerge}.
+ *
  * <p>This ensures the merged segment's {@code ___row_id} doc values contain the new
  * global row IDs (0..n-1) rather than the original per-segment local values.
  *
@@ -37,21 +40,18 @@ class RowIdRemappingDocValuesProducer extends DocValuesProducer {
 
     private final DocValuesProducer delegate;
     private final RowIdMapping rowIdMapping;
-    private final long generation;
     private final int maxDoc;
     private final int rowIdOffset;
 
     /**
      * @param delegate     the original doc values producer
-     * @param rowIdMapping the mapping from old to new row IDs, or null for sequential assignment
-     * @param generation   the writer generation of the source segment
+     * @param rowIdMapping the mapping from old to new row IDs for this segment's generation, or null for sequential assignment
      * @param maxDoc       the maximum document count in the source segment
      * @param rowIdOffset  the starting row ID offset for sequential assignment (used when rowIdMapping is null)
      */
-    RowIdRemappingDocValuesProducer(DocValuesProducer delegate, RowIdMapping rowIdMapping, long generation, int maxDoc, int rowIdOffset) {
+    RowIdRemappingDocValuesProducer(DocValuesProducer delegate, RowIdMapping rowIdMapping, int maxDoc, int rowIdOffset) {
         this.delegate = delegate;
         this.rowIdMapping = rowIdMapping;
-        this.generation = generation;
         this.maxDoc = maxDoc;
         this.rowIdOffset = rowIdOffset;
     }
@@ -65,7 +65,7 @@ class RowIdRemappingDocValuesProducer extends DocValuesProducer {
     public SortedNumericDocValues getSortedNumeric(FieldInfo field) throws IOException {
         if (DocumentInput.ROW_ID_FIELD.equals(field.name)) {
             if (rowIdMapping != null) {
-                return new MappedRowIdDocValues(delegate.getSortedNumeric(field), rowIdMapping, generation);
+                return new MappedRowIdDocValues(delegate.getSortedNumeric(field), rowIdMapping);
             } else {
                 // https://github.com/opensearch-project/OpenSearch/issues/21508
                 // TODO check how this will work for primary engine when rowIdMapping will be null.
@@ -112,18 +112,16 @@ class RowIdRemappingDocValuesProducer extends DocValuesProducer {
 
         private final SortedNumericDocValues delegate;
         private final RowIdMapping rowIdMapping;
-        private final long generation;
 
-        MappedRowIdDocValues(SortedNumericDocValues delegate, RowIdMapping rowIdMapping, long generation) {
+        MappedRowIdDocValues(SortedNumericDocValues delegate, RowIdMapping rowIdMapping) {
             this.delegate = delegate;
             this.rowIdMapping = rowIdMapping;
-            this.generation = generation;
         }
 
         @Override
         public long nextValue() throws IOException {
             long oldRowId = delegate.nextValue();
-            return rowIdMapping.getNewRowId(oldRowId, generation);
+            return rowIdMapping.getNewRowId(oldRowId);
         }
 
         @Override

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/merge/RowIdRemappingOneMerge.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/merge/RowIdRemappingOneMerge.java
@@ -17,6 +17,7 @@ import org.opensearch.index.engine.dataformat.RowIdMapping;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 
 import static org.opensearch.be.lucene.index.LuceneWriter.WRITER_GENERATION_ATTRIBUTE;
 
@@ -29,25 +30,27 @@ import static org.opensearch.be.lucene.index.LuceneWriter.WRITER_GENERATION_ATTR
  * {@code SortedNumericSortField} on the row ID field) — {@code MultiSorter} reads the
  * already-remapped values and builds DocMaps for reordering.
  *
+ * <p>This class resolves the writer generation for each segment and looks up the
+ * corresponding per-generation {@link RowIdMapping} from the provided map. Each
+ * {@link RowIdRemappingCodecReader} receives only the single mapping for its generation,
+ * eliminating the need to carry generation information further downstream.
+ *
  * <p>This class also stamps the {@link org.opensearch.be.lucene.index.LuceneWriter#WRITER_GENERATION_ATTRIBUTE}
  * onto the merged segment's {@link org.apache.lucene.index.SegmentInfo} via
- * {@link #setMergeInfo(SegmentCommitInfo)}. Lucene's {@code IndexWriter.mergeMiddle} invokes
- * this hook immediately before calling {@code codec.segmentInfoFormat().write(...)} on the
- * merged segment, so the attribute is persisted to the {@code .si} file and survives a
- * writer reopen. No codec, thread-local, or commit-data plumbing is needed.
+ * {@link #setMergeInfo(SegmentCommitInfo)}.
  *
  * @opensearch.experimental
  */
 @ExperimentalApi
 class RowIdRemappingOneMerge extends MergePolicy.OneMerge {
 
-    private final RowIdMapping rowIdMapping;
+    private final Map<Long, RowIdMapping> rowIdMappings;
     private final long outputWriterGeneration;
     private int nextRowIdOffset;
 
-    RowIdRemappingOneMerge(List<SegmentCommitInfo> segments, RowIdMapping rowIdMapping, long outputWriterGeneration) {
+    RowIdRemappingOneMerge(List<SegmentCommitInfo> segments, Map<Long, RowIdMapping> rowIdMappings, long outputWriterGeneration) {
         super(segments);
-        this.rowIdMapping = rowIdMapping;
+        this.rowIdMappings = rowIdMappings;
         this.outputWriterGeneration = outputWriterGeneration;
         this.nextRowIdOffset = 0;
     }
@@ -56,21 +59,15 @@ class RowIdRemappingOneMerge extends MergePolicy.OneMerge {
     public CodecReader wrapForMerge(CodecReader reader) throws IOException {
         CodecReader wrapped = super.wrapForMerge(reader);
         long generation = resolveGeneration(wrapped);
+        RowIdMapping mapping = rowIdMappings.get(generation);
         int offset = nextRowIdOffset;
         nextRowIdOffset += wrapped.maxDoc();
-        return new RowIdRemappingCodecReader(wrapped, rowIdMapping, generation, offset);
+        return new RowIdRemappingCodecReader(wrapped, mapping, offset);
     }
 
     /**
      * Stamps the writer generation attribute on the merged segment so it is persisted when
      * Lucene writes the {@code .si} file.
-     *
-     * <p>Lucene's {@code IndexWriter} calls this hook twice during a merge: once in
-     * {@code _mergeInit} right after the output {@link SegmentCommitInfo} is created, and a
-     * second time in {@code mergeMiddle} immediately before
-     * {@code codec.segmentInfoFormat().write(...)} persists the {@code .si}. The second call
-     * is the one that causes the attribute to land on disk. Stamping is idempotent, so the
-     * double-invocation is harmless.
      */
     @Override
     public void setMergeInfo(SegmentCommitInfo info) {

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/merge/SecondaryLuceneMergeStrategy.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/merge/SecondaryLuceneMergeStrategy.java
@@ -15,12 +15,13 @@ import org.opensearch.index.engine.dataformat.MergeInput;
 import org.opensearch.index.engine.dataformat.RowIdMapping;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * Merge strategy for when Lucene is a <b>secondary</b> data format in a composite index.
  *
- * <p>As a secondary format, Lucene receives a {@link RowIdMapping} from the primary format
- * and must:
+ * <p>As a secondary format, Lucene receives per-generation {@link RowIdMapping}s from the
+ * primary format and must:
  * <ol>
  *   <li>Remap row ID doc values to the new global IDs (via {@link RowIdRemappingCodecReader})</li>
  *   <li>Reorder documents to match the primary format's merged output (via IndexSort on the
@@ -29,7 +30,7 @@ import java.util.List;
  *
  * <p>This strategy creates a {@link RowIdRemappingOneMerge} that wraps each segment's
  * {@link org.apache.lucene.index.CodecReader} during the merge process. The
- * {@code buildRowIdMapping} method passes through the input mapping since the primary
+ * {@code buildRowIdMappings} method passes through the input mappings since the primary
  * format is the authority on document ordering.
  *
  * @opensearch.experimental
@@ -38,13 +39,17 @@ import java.util.List;
 public class SecondaryLuceneMergeStrategy implements LuceneMergeStrategy {
 
     @Override
-    public MergePolicy.OneMerge createOneMerge(List<SegmentCommitInfo> segments, RowIdMapping rowIdMapping, long outputWriterGeneration) {
-        return new RowIdRemappingOneMerge(segments, rowIdMapping, outputWriterGeneration);
+    public MergePolicy.OneMerge createOneMerge(
+        List<SegmentCommitInfo> segments,
+        Map<Long, RowIdMapping> rowIdMappings,
+        long outputWriterGeneration
+    ) {
+        return new RowIdRemappingOneMerge(segments, rowIdMappings, outputWriterGeneration);
     }
 
     @Override
-    public RowIdMapping buildRowIdMapping(MergePolicy.OneMerge completedMerge, MergeInput mergeInput) {
-        // Secondary format passes through the mapping from the primary — it does not produce its own.
-        return mergeInput.rowIdMapping();
+    public Map<Long, RowIdMapping> buildRowIdMappings(MergePolicy.OneMerge completedMerge, MergeInput mergeInput) {
+        // Secondary format passes through the mappings from the primary — it does not produce its own.
+        return mergeInput.rowIdMappings();
     }
 }

--- a/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/LuceneMergerTests.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/LuceneMergerTests.java
@@ -135,8 +135,10 @@ public class LuceneMergerTests extends OpenSearchTestCase {
         long[] gen1Mapping = new long[] { 0, 2, 4 };
         long[] gen2Mapping = new long[] { 1, 3 };
         Map<Long, RowIdMapping> rowIdMappings = Map.of(
-            1L, new PackedRowIdMapping(gen1Mapping, false),
-            2L, new PackedRowIdMapping(gen2Mapping, false)
+            1L,
+            new PackedRowIdMapping(gen1Mapping, false),
+            2L,
+            new PackedRowIdMapping(gen2Mapping, false)
         );
 
         LuceneMerger merger = new LuceneMerger(writer, new LuceneDataFormat(), dataPath, new LuceneShardStatsTracker());
@@ -204,8 +206,10 @@ public class LuceneMergerTests extends OpenSearchTestCase {
         long[] gen1Identity = new long[] { 0, 1, 2 };
         long[] gen2Identity = new long[] { 3, 4 };
         Map<Long, RowIdMapping> identityMappings = Map.of(
-            1L, new PackedRowIdMapping(gen1Identity, false),
-            2L, new PackedRowIdMapping(gen2Identity, false)
+            1L,
+            new PackedRowIdMapping(gen1Identity, false),
+            2L,
+            new PackedRowIdMapping(gen2Identity, false)
         );
 
         MergeInput input = MergeInput.builder().segments(segments).rowIdMappings(identityMappings).newWriterGeneration(10L).build();

--- a/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/LuceneMergerTests.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/LuceneMergerTests.java
@@ -129,27 +129,25 @@ public class LuceneMergerTests extends OpenSearchTestCase {
         // position 1: rowId=1 → doc_3 (gen=2, original rowId=0)
         // position 2: rowId=2 → doc_1 (gen=1, original rowId=1)
         // position 3: rowId=3 → doc_4 (gen=2, original rowId=1)
-        // Build a PackedRowIdMapping for the interleaved merge:
-        // gen=1 has 3 rows (offsets 0,1,2), gen=2 has 2 rows (offsets 3,4)
-        // position 0: rowId=0 → doc_0 (gen=1, original rowId=0)
-        // position 1: rowId=1 → doc_a (gen=2, original rowId=0)
-        // position 2: rowId=2 → doc_1 (gen=1, original rowId=1)
-        // position 3: rowId=3 → doc_b (gen=2, original rowId=1)
-        // position 4: rowId=4 → doc_2 (gen=1, original rowId=2)
-        long[] mappingArray = new long[] { 0, 2, 4, 1, 3 };
-        Map<Long, Integer> genOffsets = Map.of(1L, 0, 2L, 3);
-        Map<Long, Integer> genSizes = Map.of(1L, 3, 2L, 2);
-        RowIdMapping rowIdMapping = new PackedRowIdMapping(mappingArray, genOffsets, genSizes);
+        // Build per-generation PackedRowIdMappings for the interleaved merge:
+        // gen=1 has 3 rows: 0→0, 1→2, 2→4
+        // gen=2 has 2 rows: 0→1, 1→3
+        long[] gen1Mapping = new long[] { 0, 2, 4 };
+        long[] gen2Mapping = new long[] { 1, 3 };
+        Map<Long, RowIdMapping> rowIdMappings = Map.of(
+            1L, new PackedRowIdMapping(gen1Mapping, false),
+            2L, new PackedRowIdMapping(gen2Mapping, false)
+        );
 
         LuceneMerger merger = new LuceneMerger(writer, new LuceneDataFormat(), dataPath, new LuceneShardStatsTracker());
         SegmentInfos infos = getSegmentInfos(writer);
         List<Segment> segments = buildSegments(infos);
 
-        MergeInput input = MergeInput.builder().segments(segments).rowIdMapping(rowIdMapping).newWriterGeneration(10L).build();
+        MergeInput input = MergeInput.builder().segments(segments).rowIdMappings(rowIdMappings).newWriterGeneration(10L).build();
 
         MergeResult result = merger.merge(input);
         assertNotNull(result);
-        assertTrue(result.rowIdMapping().isPresent());
+        assertTrue(result.rowIdMappings().isPresent());
 
         writer.commit();
 
@@ -203,12 +201,14 @@ public class LuceneMergerTests extends OpenSearchTestCase {
 
         // Identity mapping — writeSegmentWithRichFields already writes globally-unique row IDs
         // (0,1,2 in gen=1 and 3,4 in gen=2), so returning the original row ID is well-formed.
-        long[] identityArray = new long[] { 0, 1, 2, 3, 4 };
-        Map<Long, Integer> identityOffsets = Map.of(1L, 0, 2L, 3);
-        Map<Long, Integer> identitySizes = Map.of(1L, 3, 2L, 2);
-        RowIdMapping identityMapping = new PackedRowIdMapping(identityArray, identityOffsets, identitySizes);
+        long[] gen1Identity = new long[] { 0, 1, 2 };
+        long[] gen2Identity = new long[] { 3, 4 };
+        Map<Long, RowIdMapping> identityMappings = Map.of(
+            1L, new PackedRowIdMapping(gen1Identity, false),
+            2L, new PackedRowIdMapping(gen2Identity, false)
+        );
 
-        MergeInput input = MergeInput.builder().segments(segments).rowIdMapping(identityMapping).newWriterGeneration(10L).build();
+        MergeInput input = MergeInput.builder().segments(segments).rowIdMappings(identityMappings).newWriterGeneration(10L).build();
         merger.merge(input);
         writer.commit();
 
@@ -265,7 +265,7 @@ public class LuceneMergerTests extends OpenSearchTestCase {
 
         RowIdMapping identity = new RowIdMapping() {
             @Override
-            public long getNewRowId(long oldId, long oldGeneration) {
+            public long getNewRowId(long oldId) {
                 return oldId;
             }
 
@@ -276,15 +276,16 @@ public class LuceneMergerTests extends OpenSearchTestCase {
 
             @Override
             public boolean isNewToOldSupported() {
-                return true;
+                return false;
             }
 
             @Override
             public int size() {
-                return 0;
+                return Integer.MAX_VALUE;
             }
         };
-        MergeInput input = MergeInput.builder().segments(segments).rowIdMapping(identity).newWriterGeneration(newGeneration).build();
+        Map<Long, RowIdMapping> mappings = Map.of(1L, identity, 2L, identity);
+        MergeInput input = MergeInput.builder().segments(segments).rowIdMappings(mappings).newWriterGeneration(newGeneration).build();
 
         merger.merge(input);
 

--- a/sandbox/plugins/composite-engine/src/main/java/org/opensearch/composite/merge/CompositeMergeExecutor.java
+++ b/sandbox/plugins/composite-engine/src/main/java/org/opensearch/composite/merge/CompositeMergeExecutor.java
@@ -52,13 +52,13 @@ public class CompositeMergeExecutor {
             FormatMergeResult primaryResult = mergeFormat(plan, plan.primaryFormat(), null);
             completed.add(primaryResult);
 
-            RowIdMapping mapping = plan.hasSecondaries()
-                ? primaryResult.rowIdMappingOpt()
-                    .orElseThrow(() -> new IllegalStateException("Primary merge did not produce row-ID mapping required by secondaries"))
+            Map<Long, RowIdMapping> mappings = plan.hasSecondaries()
+                ? primaryResult.rowIdMappingsOpt()
+                    .orElseThrow(() -> new IllegalStateException("Primary merge did not produce row-ID mappings required by secondaries"))
                 : null;
 
             for (DataFormat secondary : plan.secondaryFormats()) {
-                FormatMergeResult secondaryResult = mergeFormat(plan, secondary, mapping);
+                FormatMergeResult secondaryResult = mergeFormat(plan, secondary, mappings);
                 // Verify secondary produced output when primary did
                 if (primaryResult.mergedFiles() != null && secondaryResult.mergedFiles() == null) {
                     throw new IllegalStateException(
@@ -90,7 +90,7 @@ public class CompositeMergeExecutor {
                 completed.add(secondaryResult);
             }
 
-            return toMergeResult(completed, mapping);
+            return toMergeResult(completed, mappings);
         } catch (Exception e) {
             completed.forEach(FormatMergeResult::cleanup);
             if (e instanceof RuntimeException re) throw re;
@@ -98,22 +98,22 @@ public class CompositeMergeExecutor {
         }
     }
 
-    private FormatMergeResult mergeFormat(MergePlan plan, DataFormat format, RowIdMapping mapping) throws IOException {
+    private FormatMergeResult mergeFormat(MergePlan plan, DataFormat format, Map<Long, RowIdMapping> mappings) throws IOException {
         Merger merger = mergers.get(format);
         List<WriterFileSet> files = plan.filesFor(format);
         List<Segment> segments = new ArrayList<>();
         for (WriterFileSet wfs : files) {
             segments.add(Segment.builder(wfs.writerGeneration()).addSearchableFiles(format, wfs).build());
         }
-        MergeResult result = merger.merge(new MergeInput(segments, mapping, plan.mergedWriterGeneration()));
-        return new FormatMergeResult(format, result.getMergedWriterFileSetForDataformat(format), result.rowIdMapping().orElse(null));
+        MergeResult result = merger.merge(new MergeInput(segments, mappings, plan.mergedWriterGeneration()));
+        return new FormatMergeResult(format, result.getMergedWriterFileSetForDataformat(format), result.rowIdMappings().orElse(null));
     }
 
-    private static MergeResult toMergeResult(List<FormatMergeResult> results, RowIdMapping mapping) {
+    private static MergeResult toMergeResult(List<FormatMergeResult> results, Map<Long, RowIdMapping> mappings) {
         Map<DataFormat, WriterFileSet> merged = new HashMap<>();
         for (FormatMergeResult r : results) {
             merged.put(r.format(), r.mergedFiles());
         }
-        return new MergeResult(merged, mapping);
+        return new MergeResult(merged, mappings);
     }
 }

--- a/sandbox/plugins/composite-engine/src/main/java/org/opensearch/composite/merge/FormatMergeResult.java
+++ b/sandbox/plugins/composite-engine/src/main/java/org/opensearch/composite/merge/FormatMergeResult.java
@@ -16,16 +16,17 @@ import org.opensearch.index.engine.exec.WriterFileSet;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Map;
 import java.util.Optional;
 
 /**
  * Result of merging a single data format's files.
  */
 @ExperimentalApi
-public record FormatMergeResult(DataFormat format, WriterFileSet mergedFiles, RowIdMapping rowIdMapping) {
+public record FormatMergeResult(DataFormat format, WriterFileSet mergedFiles, Map<Long, RowIdMapping> rowIdMappings) {
 
-    public Optional<RowIdMapping> rowIdMappingOpt() {
-        return Optional.ofNullable(rowIdMapping);
+    public Optional<Map<Long, RowIdMapping>> rowIdMappingsOpt() {
+        return Optional.ofNullable(rowIdMappings);
     }
 
     /**

--- a/sandbox/plugins/composite-engine/src/test/java/org/opensearch/composite/CompositeWriterSortPropagationTests.java
+++ b/sandbox/plugins/composite-engine/src/test/java/org/opensearch/composite/CompositeWriterSortPropagationTests.java
@@ -62,9 +62,9 @@ public class CompositeWriterSortPropagationTests extends OpenSearchTestCase {
         assertNotNull(receivedMapping);
         assertEquals(3, receivedMapping.size());
         // permutation is {0,1,2} -> {2,0,1}: old pos 0 maps to new pos 2
-        assertEquals(2L, receivedMapping.getNewRowId(0, RowIdMapping.SINGLE_GEN));
-        assertEquals(0L, receivedMapping.getNewRowId(1, RowIdMapping.SINGLE_GEN));
-        assertEquals(1L, receivedMapping.getNewRowId(2, RowIdMapping.SINGLE_GEN));
+        assertEquals(2L, receivedMapping.getNewRowId(0));
+        assertEquals(0L, receivedMapping.getNewRowId(1));
+        assertEquals(1L, receivedMapping.getNewRowId(2));
 
         // The composite FileInfos should also carry the sort permutation
         assertNotNull(result.rowIdMapping());

--- a/sandbox/plugins/composite-engine/src/test/java/org/opensearch/composite/PackedRowIdMappingTests.java
+++ b/sandbox/plugins/composite-engine/src/test/java/org/opensearch/composite/PackedRowIdMappingTests.java
@@ -12,6 +12,7 @@ import org.opensearch.index.engine.dataformat.PackedRowIdMapping;
 import org.opensearch.index.engine.dataformat.RowIdMapping;
 import org.opensearch.test.OpenSearchTestCase;
 
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -20,25 +21,17 @@ import java.util.Map;
 public class PackedRowIdMappingTests extends OpenSearchTestCase {
 
     /**
-     * Basic lookup: two generations with known mappings.
-     * gen=1 (3 rows): 0→4, 1→3, 2→2
-     * gen=2 (2 rows): 0→1, 1→0
+     * Basic forward lookup with a simple permutation.
      */
-    public void testBasicLookup() {
+    public void testBasicForwardLookup() {
         long[] mappingArray = { 4, 3, 2, 1, 0 };
-        Map<Long, Integer> offsets = Map.of(1L, 0, 2L, 3);
-        Map<Long, Integer> sizes = Map.of(1L, 3, 2L, 2);
+        PackedRowIdMapping mapping = new PackedRowIdMapping(mappingArray, false);
 
-        PackedRowIdMapping mapping = new PackedRowIdMapping(mappingArray, offsets, sizes);
-
-        // gen=1 lookups
-        assertEquals(4L, mapping.getNewRowId(0, 1L));
-        assertEquals(3L, mapping.getNewRowId(1, 1L));
-        assertEquals(2L, mapping.getNewRowId(2, 1L));
-
-        // gen=2 lookups
-        assertEquals(1L, mapping.getNewRowId(0, 2L));
-        assertEquals(0L, mapping.getNewRowId(1, 2L));
+        assertEquals(4L, mapping.getNewRowId(0));
+        assertEquals(3L, mapping.getNewRowId(1));
+        assertEquals(2L, mapping.getNewRowId(2));
+        assertEquals(1L, mapping.getNewRowId(3));
+        assertEquals(0L, mapping.getNewRowId(4));
     }
 
     /**
@@ -46,24 +39,9 @@ public class PackedRowIdMappingTests extends OpenSearchTestCase {
      */
     public void testImplementsInterface() {
         long[] mappingArray = { 10, 20 };
-        Map<Long, Integer> offsets = Map.of(5L, 0);
-        Map<Long, Integer> sizes = Map.of(5L, 2);
-
-        RowIdMapping mapping = new PackedRowIdMapping(mappingArray, offsets, sizes);
-        assertEquals(10L, mapping.getNewRowId(0, 5L));
-        assertEquals(20L, mapping.getNewRowId(1, 5L));
-    }
-
-    /**
-     * Unknown generation returns -1.
-     */
-    public void testUnknownGenerationReturnsNegativeOne() {
-        long[] mappingArray = { 0 };
-        Map<Long, Integer> offsets = Map.of(1L, 0);
-        Map<Long, Integer> sizes = Map.of(1L, 1);
-
-        PackedRowIdMapping mapping = new PackedRowIdMapping(mappingArray, offsets, sizes);
-        assertEquals(-1L, mapping.getNewRowId(0, 99L));
+        RowIdMapping mapping = new PackedRowIdMapping(mappingArray, false);
+        assertEquals(10L, mapping.getNewRowId(0));
+        assertEquals(20L, mapping.getNewRowId(1));
     }
 
     /**
@@ -71,12 +49,9 @@ public class PackedRowIdMappingTests extends OpenSearchTestCase {
      */
     public void testOutOfBoundsRowIdReturnsNegativeOne() {
         long[] mappingArray = { 5, 6 };
-        Map<Long, Integer> offsets = Map.of(1L, 0);
-        Map<Long, Integer> sizes = Map.of(1L, 2);
-
-        PackedRowIdMapping mapping = new PackedRowIdMapping(mappingArray, offsets, sizes);
-        assertEquals(-1L, mapping.getNewRowId(2, 1L));
-        assertEquals(-1L, mapping.getNewRowId(-1, 1L));
+        PackedRowIdMapping mapping = new PackedRowIdMapping(mappingArray, false);
+        assertEquals(-1L, mapping.getNewRowId(2));
+        assertEquals(-1L, mapping.getNewRowId(-1));
     }
 
     /**
@@ -84,25 +59,8 @@ public class PackedRowIdMappingTests extends OpenSearchTestCase {
      */
     public void testSize() {
         long[] mappingArray = { 0, 1, 2, 3, 4 };
-        Map<Long, Integer> offsets = Map.of(1L, 0, 2L, 3);
-        Map<Long, Integer> sizes = Map.of(1L, 3, 2L, 2);
-
-        PackedRowIdMapping mapping = new PackedRowIdMapping(mappingArray, offsets, sizes);
+        PackedRowIdMapping mapping = new PackedRowIdMapping(mappingArray, false);
         assertEquals(5, mapping.size());
-    }
-
-    /**
-     * Generation size returns correct count per generation.
-     */
-    public void testGenerationSize() {
-        long[] mappingArray = { 0, 1, 2, 3, 4 };
-        Map<Long, Integer> offsets = Map.of(1L, 0, 2L, 3);
-        Map<Long, Integer> sizes = Map.of(1L, 3, 2L, 2);
-
-        PackedRowIdMapping mapping = new PackedRowIdMapping(mappingArray, offsets, sizes);
-        assertEquals(3, mapping.getGenerationSize(1L));
-        assertEquals(2, mapping.getGenerationSize(2L));
-        assertEquals(0, mapping.getGenerationSize(99L));
     }
 
     /**
@@ -113,10 +71,7 @@ public class PackedRowIdMappingTests extends OpenSearchTestCase {
         for (int i = 0; i < 1000; i++) {
             mappingArray[i] = i;
         }
-        Map<Long, Integer> offsets = Map.of(1L, 0);
-        Map<Long, Integer> sizes = Map.of(1L, 1000);
-
-        PackedRowIdMapping mapping = new PackedRowIdMapping(mappingArray, offsets, sizes);
+        PackedRowIdMapping mapping = new PackedRowIdMapping(mappingArray, false);
         assertTrue("RAM bytes used should be positive", mapping.ramBytesUsed() > 0);
     }
 
@@ -125,58 +80,78 @@ public class PackedRowIdMappingTests extends OpenSearchTestCase {
      */
     public void testEmptyMapping() {
         long[] mappingArray = {};
-        Map<Long, Integer> offsets = Map.of();
-        Map<Long, Integer> sizes = Map.of();
-
-        PackedRowIdMapping mapping = new PackedRowIdMapping(mappingArray, offsets, sizes);
+        PackedRowIdMapping mapping = new PackedRowIdMapping(mappingArray, false);
         assertEquals(0, mapping.size());
-        assertEquals(-1L, mapping.getNewRowId(0, 1L));
+        assertEquals(-1L, mapping.getNewRowId(0));
     }
 
     /**
-     * Null arguments throw NullPointerException.
+     * Null mapping array throws NullPointerException.
      */
     public void testNullArgumentsThrow() {
-        expectThrows(NullPointerException.class, () -> new PackedRowIdMapping(null, Map.of(), Map.of()));
-        expectThrows(NullPointerException.class, () -> new PackedRowIdMapping(new long[0], null, Map.of()));
-        expectThrows(NullPointerException.class, () -> new PackedRowIdMapping(new long[0], Map.of(), null));
+        expectThrows(NullPointerException.class, () -> new PackedRowIdMapping(null, false));
     }
 
     /**
-     * Generation offsets and sizes maps are unmodifiable.
+     * Reverse lookup works when reverseSupported=true.
      */
-    public void testMapsAreUnmodifiable() {
-        long[] mappingArray = { 0 };
-        Map<Long, Integer> offsets = Map.of(1L, 0);
-        Map<Long, Integer> sizes = Map.of(1L, 1);
+    public void testReverseLookup() {
+        // Permutation: 0→2, 1→0, 2→1
+        long[] mappingArray = { 2, 0, 1 };
+        PackedRowIdMapping mapping = new PackedRowIdMapping(mappingArray, true);
 
-        PackedRowIdMapping mapping = new PackedRowIdMapping(mappingArray, offsets, sizes);
-        expectThrows(UnsupportedOperationException.class, () -> mapping.getGenerationOffsets().put(2L, 1));
-        expectThrows(UnsupportedOperationException.class, () -> mapping.getGenerationSizes().put(2L, 1));
+        assertTrue(mapping.isNewToOldSupported());
+        // Forward: old→new
+        assertEquals(2L, mapping.getNewRowId(0));
+        assertEquals(0L, mapping.getNewRowId(1));
+        assertEquals(1L, mapping.getNewRowId(2));
+        // Reverse: new→old
+        assertEquals(1L, mapping.getOldRowId(0));
+        assertEquals(2L, mapping.getOldRowId(1));
+        assertEquals(0L, mapping.getOldRowId(2));
     }
 
     /**
-     * Three generations with non-sequential offsets (simulating real merge order).
+     * Reverse lookup throws when reverseSupported=false.
      */
-    public void testThreeGenerationsNonSequentialOrder() {
-        // Merge processes generations in order [5, 0, 3]
-        // gen=5 (2 rows): offset=0, mapping[0]=2, mapping[1]=3
-        // gen=0 (3 rows): offset=2, mapping[2]=0, mapping[3]=4, mapping[4]=1
-        // gen=3 (1 row): offset=5, mapping[5]=5
-        long[] mappingArray = { 2, 3, 0, 4, 1, 5 };
-        Map<Long, Integer> offsets = Map.of(5L, 0, 0L, 2, 3L, 5);
-        Map<Long, Integer> sizes = Map.of(5L, 2, 0L, 3, 3L, 1);
+    public void testReverseUnsupportedThrows() {
+        long[] mappingArray = { 0, 1, 2 };
+        PackedRowIdMapping mapping = new PackedRowIdMapping(mappingArray, false);
+        assertFalse(mapping.isNewToOldSupported());
+        expectThrows(UnsupportedOperationException.class, () -> mapping.getOldRowId(0));
+    }
 
-        PackedRowIdMapping mapping = new PackedRowIdMapping(mappingArray, offsets, sizes);
+    /**
+     * Reverse lookup with out-of-bounds returns -1.
+     */
+    public void testReverseOutOfBoundsReturnsNegativeOne() {
+        long[] mappingArray = { 1, 0 };
+        PackedRowIdMapping mapping = new PackedRowIdMapping(mappingArray, true);
+        assertEquals(-1L, mapping.getOldRowId(5));
+        assertEquals(-1L, mapping.getOldRowId(-1));
+    }
 
-        assertEquals(2L, mapping.getNewRowId(0, 5L));
-        assertEquals(3L, mapping.getNewRowId(1, 5L));
-        assertEquals(0L, mapping.getNewRowId(0, 0L));
-        assertEquals(4L, mapping.getNewRowId(1, 0L));
-        assertEquals(1L, mapping.getNewRowId(2, 0L));
-        assertEquals(5L, mapping.getNewRowId(0, 3L));
+    /**
+     * Per-generation mappings can be stored in a Map for merge use cases.
+     */
+    public void testMultiGenerationViaMap() {
+        // gen=1: 3 rows, permutation 0→4, 1→3, 2→2
+        long[] gen1Array = { 4, 3, 2 };
+        // gen=2: 2 rows, permutation 0→1, 1→0
+        long[] gen2Array = { 1, 0 };
 
-        assertEquals(6, mapping.size());
+        Map<Long, RowIdMapping> mappings = new HashMap<>();
+        mappings.put(1L, new PackedRowIdMapping(gen1Array, false));
+        mappings.put(2L, new PackedRowIdMapping(gen2Array, false));
+
+        RowIdMapping gen1 = mappings.get(1L);
+        assertEquals(4L, gen1.getNewRowId(0));
+        assertEquals(3L, gen1.getNewRowId(1));
+        assertEquals(2L, gen1.getNewRowId(2));
+
+        RowIdMapping gen2 = mappings.get(2L);
+        assertEquals(1L, gen2.getNewRowId(0));
+        assertEquals(0L, gen2.getNewRowId(1));
     }
 
     /**
@@ -184,13 +159,8 @@ public class PackedRowIdMappingTests extends OpenSearchTestCase {
      */
     public void testToString() {
         long[] mappingArray = { 0, 1, 2 };
-        Map<Long, Integer> offsets = Map.of(1L, 0);
-        Map<Long, Integer> sizes = Map.of(1L, 3);
-
-        PackedRowIdMapping mapping = new PackedRowIdMapping(mappingArray, offsets, sizes);
+        PackedRowIdMapping mapping = new PackedRowIdMapping(mappingArray, false);
         String str = mapping.toString();
         assertTrue(str.contains("size=3"));
-        assertTrue(str.contains("generations=1"));
-        assertTrue(str.contains("estimatedMemoryBytes="));
     }
 }

--- a/sandbox/plugins/composite-engine/src/test/java/org/opensearch/composite/merge/CompositeMergerTests.java
+++ b/sandbox/plugins/composite-engine/src/test/java/org/opensearch/composite/merge/CompositeMergerTests.java
@@ -58,9 +58,7 @@ import static org.mockito.Mockito.when;
 public class CompositeMergerTests extends OpenSearchTestCase {
 
     private static final ShardId SHARD_ID = new ShardId(new Index("test-index", "uuid"), 0);
-    private static final Map<Long, RowIdMapping> STUB_ROW_ID_MAPPINGS = Map.of(
-        0L, new PackedRowIdMapping(new long[] { 0 }, false)
-    );
+    private static final Map<Long, RowIdMapping> STUB_ROW_ID_MAPPINGS = Map.of(0L, new PackedRowIdMapping(new long[] { 0 }, false));
 
     private DataFormat primaryFormat;
     private DataFormat secondaryFormat;
@@ -662,7 +660,7 @@ public class CompositeMergerTests extends OpenSearchTestCase {
         RowIdMapping mapping = mock(RowIdMapping.class);
         when(mapping.size()).thenReturn(100);
 
-        when(primaryMerger.merge(any(MergeInput.class))).thenReturn(new MergeResult(Map.of(primary, primaryFiles), mapping));
+        when(primaryMerger.merge(any(MergeInput.class))).thenReturn(new MergeResult(Map.of(primary, primaryFiles), Map.of(10L, mapping)));
         when(secondaryMerger.merge(any(MergeInput.class))).thenReturn(new MergeResult(Map.of()));
 
         CompositeMergeExecutor executor = new CompositeMergeExecutor(Map.of(primary, primaryMerger, secondary, secondaryMerger));
@@ -689,7 +687,7 @@ public class CompositeMergerTests extends OpenSearchTestCase {
         RowIdMapping mapping = mock(RowIdMapping.class);
         when(mapping.size()).thenReturn(100);
 
-        when(primaryMerger.merge(any(MergeInput.class))).thenReturn(new MergeResult(Map.of(primary, primaryFiles), mapping));
+        when(primaryMerger.merge(any(MergeInput.class))).thenReturn(new MergeResult(Map.of(primary, primaryFiles), Map.of(10L, mapping)));
         when(secondaryMerger.merge(any(MergeInput.class))).thenReturn(new MergeResult(Map.of(secondary, secondaryFiles)));
 
         CompositeMergeExecutor executor = new CompositeMergeExecutor(Map.of(primary, primaryMerger, secondary, secondaryMerger));

--- a/sandbox/plugins/composite-engine/src/test/java/org/opensearch/composite/merge/CompositeMergerTests.java
+++ b/sandbox/plugins/composite-engine/src/test/java/org/opensearch/composite/merge/CompositeMergerTests.java
@@ -58,7 +58,9 @@ import static org.mockito.Mockito.when;
 public class CompositeMergerTests extends OpenSearchTestCase {
 
     private static final ShardId SHARD_ID = new ShardId(new Index("test-index", "uuid"), 0);
-    private static final RowIdMapping STUB_ROW_ID_MAPPING = new PackedRowIdMapping(new long[] { 0 }, false);
+    private static final Map<Long, RowIdMapping> STUB_ROW_ID_MAPPINGS = Map.of(
+        0L, new PackedRowIdMapping(new long[] { 0 }, false)
+    );
 
     private DataFormat primaryFormat;
     private DataFormat secondaryFormat;
@@ -102,7 +104,7 @@ public class CompositeMergerTests extends OpenSearchTestCase {
         WriterFileSet mergedPrimaryWfs = wfs(tempDir, 99L, Set.of("mp.dat"), 10);
         WriterFileSet mergedSecondaryWfs = wfs(tempDir, 99L, Set.of("ms.dat"), 10);
 
-        MergeResult primaryResult = new MergeResult(Map.of(primaryFormat, mergedPrimaryWfs), STUB_ROW_ID_MAPPING);
+        MergeResult primaryResult = new MergeResult(Map.of(primaryFormat, mergedPrimaryWfs), STUB_ROW_ID_MAPPINGS);
         MergeResult secondaryResult = new MergeResult(Map.of(secondaryFormat, mergedSecondaryWfs));
 
         when(primaryMerger.merge(any())).thenReturn(primaryResult);
@@ -180,7 +182,7 @@ public class CompositeMergerTests extends OpenSearchTestCase {
         OneMerge oneMerge = new OneMerge(List.of(segment));
 
         WriterFileSet mergedPrimaryWfs = wfs(tempDir, 99L, Set.of("mp.dat"), 5);
-        MergeResult primaryResult = new MergeResult(Map.of(primaryFormat, mergedPrimaryWfs), STUB_ROW_ID_MAPPING);
+        MergeResult primaryResult = new MergeResult(Map.of(primaryFormat, mergedPrimaryWfs), STUB_ROW_ID_MAPPINGS);
         when(primaryMerger.merge(any())).thenReturn(primaryResult);
         when(secondaryMerger.merge(any())).thenThrow(new IOException("secondary disk error"));
 
@@ -218,7 +220,7 @@ public class CompositeMergerTests extends OpenSearchTestCase {
         OneMerge oneMerge = new OneMerge(List.of(segment));
 
         WriterFileSet mergedPWfs = wfs(tempDir, 99L, Set.of("mp.dat"), 5);
-        MergeResult primaryResult = new MergeResult(Map.of(primaryFormat, mergedPWfs), STUB_ROW_ID_MAPPING);
+        MergeResult primaryResult = new MergeResult(Map.of(primaryFormat, mergedPWfs), STUB_ROW_ID_MAPPINGS);
         when(primaryMerger.merge(any())).thenReturn(primaryResult);
         when(secondaryMerger.merge(any())).thenThrow(new IOException("parquet error"));
         when(secondaryMerger2.merge(any())).thenThrow(new IOException("arrow error"));
@@ -273,7 +275,7 @@ public class CompositeMergerTests extends OpenSearchTestCase {
         OneMerge oneMerge = new OneMerge(List.of(segment));
 
         WriterFileSet mergedPrimaryWfs = wfs(tempDir, 99L, Set.of("mp.dat"), 5);
-        MergeResult primaryResult = new MergeResult(Map.of(primaryFormat, mergedPrimaryWfs), STUB_ROW_ID_MAPPING);
+        MergeResult primaryResult = new MergeResult(Map.of(primaryFormat, mergedPrimaryWfs), STUB_ROW_ID_MAPPINGS);
         when(primaryMerger.merge(any())).thenReturn(primaryResult);
         when(secondaryMerger.merge(any())).thenThrow(new IOException("secondary fail"));
 
@@ -294,7 +296,7 @@ public class CompositeMergerTests extends OpenSearchTestCase {
         OneMerge oneMerge = new OneMerge(List.of(segment));
 
         WriterFileSet mergedPrimaryWfs = wfs(tempDir, 99L, Set.of("nonexistent.dat"), 5);
-        MergeResult primaryResult = new MergeResult(Map.of(primaryFormat, mergedPrimaryWfs), STUB_ROW_ID_MAPPING);
+        MergeResult primaryResult = new MergeResult(Map.of(primaryFormat, mergedPrimaryWfs), STUB_ROW_ID_MAPPINGS);
         when(primaryMerger.merge(any())).thenReturn(primaryResult);
         when(secondaryMerger.merge(any())).thenThrow(new IOException("fail"));
 
@@ -334,7 +336,7 @@ public class CompositeMergerTests extends OpenSearchTestCase {
 
         WriterFileSet mergedPWfs = wfs(tempDir, 99L, Set.of("mp.dat"), 10);
         WriterFileSet mergedSWfs = wfs(tempDir, 99L, Set.of("ms.dat"), 10);
-        MergeResult primaryResult = new MergeResult(Map.of(primaryFormat, mergedPWfs), STUB_ROW_ID_MAPPING);
+        MergeResult primaryResult = new MergeResult(Map.of(primaryFormat, mergedPWfs), STUB_ROW_ID_MAPPINGS);
         MergeResult secondaryResult = new MergeResult(Map.of(secondaryFormat, mergedSWfs));
 
         when(primaryMerger.merge(any())).thenReturn(primaryResult);
@@ -372,7 +374,7 @@ public class CompositeMergerTests extends OpenSearchTestCase {
         OneMerge oneMerge = new OneMerge(List.of(segment));
 
         WriterFileSet mergedWfs = wfs(tempDir, 99L, Set.of("mp.dat"), 5);
-        MergeResult primaryResult = new MergeResult(Map.of(primaryFormat, mergedWfs), STUB_ROW_ID_MAPPING);
+        MergeResult primaryResult = new MergeResult(Map.of(primaryFormat, mergedWfs), STUB_ROW_ID_MAPPINGS);
         when(primaryMerger.merge(any())).thenReturn(primaryResult);
 
         MergeHandler handler = new MergeHandler(
@@ -555,7 +557,7 @@ public class CompositeMergerTests extends OpenSearchTestCase {
 
         // mergedPrimaryWfs points to "mp.dat" which is a non-empty directory
         WriterFileSet mergedPrimaryWfs = wfs(tempDir, 99L, Set.of("mp.dat"), 5);
-        MergeResult primaryResult = new MergeResult(Map.of(primaryFormat, mergedPrimaryWfs), STUB_ROW_ID_MAPPING);
+        MergeResult primaryResult = new MergeResult(Map.of(primaryFormat, mergedPrimaryWfs), STUB_ROW_ID_MAPPINGS);
         when(primaryMerger.merge(any())).thenReturn(primaryResult);
         when(secondaryMerger.merge(any())).thenThrow(new IOException("secondary fail"));
 

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/bridge/MergeFilesResult.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/bridge/MergeFilesResult.java
@@ -10,18 +10,20 @@ package org.opensearch.parquet.bridge;
 
 import org.opensearch.index.engine.dataformat.RowIdMapping;
 
+import java.util.Map;
+
 /**
- * Result of a native Parquet merge. Bundles the row-ID mapping used to
+ * Result of a native Parquet merge. Bundles the per-generation row-ID mappings used to
  * remap row IDs in secondary data formats with the Parquet file metadata
  * (version, row count, {@code created_by}, CRC32) of the merged output file,
  * plus per-merge stats forwarded to the per-shard tracker.
  *
- * @param rowIdMapping            row-ID remapping table for secondary data formats
+ * @param rowIdMappings           per-generation row-ID remapping tables for secondary data formats
  * @param metadata                Parquet file metadata + CRC32 of the merged output
  * @param flushAndSortChunkCount  count of flush+sort+chunk passes that ran during this merge
  * @param flushAndSortChunkTimeMs cumulative wall-clock millis spent in flush+sort+chunk passes
  * @param rowIdMappingMax         highest row_id assigned during this merge (= rows written)
  */
-public record MergeFilesResult(RowIdMapping rowIdMapping, ParquetFileMetadata metadata, long flushAndSortChunkCount,
+public record MergeFilesResult(Map<Long, RowIdMapping> rowIdMappings, ParquetFileMetadata metadata, long flushAndSortChunkCount,
     long flushAndSortChunkTimeMs, long rowIdMappingMax) {
 }

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/bridge/NativePackedRowIdMapping.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/bridge/NativePackedRowIdMapping.java
@@ -1,0 +1,203 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.parquet.bridge;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.index.engine.dataformat.RowIdMapping;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.lang.ref.Cleaner;
+import java.nio.ByteOrder;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Zero-copy {@link RowIdMapping} over a bit-packed buffer allocated by the native
+ * (Rust) writer during sort-on-close.
+ *
+ * <h2>Buffer layout (cross-language contract with {@code packed_mapping.rs})</h2>
+ * The native buffer holds two equally-sized sections, each storing {@code count}
+ * values at {@code bpv} bits per value, packed back-to-back in little-endian order
+ * (value {@code i} occupies bits {@code [i*bpv, (i+1)*bpv)} of its section):
+ * <pre>
+ *   [ forward: fwd[oldId] = newId | reverse: rev[newId] = oldId ]
+ * </pre>
+ * Each section is followed by 7 zero pad bytes so the unaligned 8-byte window read
+ * used for decoding never runs past the section. Total native footprint is
+ * {@code 2 * (ceil(count*bpv/8) + 7)} bytes — roughly {@code 2 * 3N} for 10M rows
+ * (24 bpv) instead of the {@code 2 * 8N} of raw longs, with zero Java heap usage.
+ *
+ * <h2>Ownership and cleanup</h2>
+ * This object owns the native buffer. Cleanup follows the standard layered scheme:
+ * <ul>
+ *   <li><b>Deterministic:</b> {@link #close()} frees the buffer via
+ *       {@code parquet_free_row_id_mapping}. Idempotent and thread-safe. Any access
+ *       after close throws {@link IllegalStateException} (enforced by the shared
+ *       {@link Arena}) rather than reading freed memory.</li>
+ *   <li><b>Backstop:</b> a {@link Cleaner} frees the buffer when this object becomes
+ *       unreachable without being closed, logging a leak warning. GC timing is not a
+ *       memory-pressure mechanism for native bytes — the backstop exists to bound
+ *       leaks, not replace close().</li>
+ * </ul>
+ * Outstanding native bytes across all live mappings are tracked in
+ * {@link #outstandingNativeBytes()} for observability.
+ */
+public final class NativePackedRowIdMapping implements RowIdMapping, AutoCloseable {
+
+    private static final Logger logger = LogManager.getLogger(NativePackedRowIdMapping.class);
+    private static final Cleaner CLEANER = Cleaner.create();
+    private static final AtomicLong OUTSTANDING_NATIVE_BYTES = new AtomicLong();
+
+    private static final ValueLayout.OfLong LE_LONG_UNALIGNED = ValueLayout.JAVA_LONG_UNALIGNED.withOrder(ByteOrder.LITTLE_ENDIAN);
+
+    private final MemorySegment segment;
+    private final int count;
+    private final int bpv;
+    private final long valueMask;
+    private final long reverseSectionOffset;
+    private final long nativeByteLen;
+    private final Arena arena;
+    private final NativeBufferState state;
+    private final Cleaner.Cleanable cleanable;
+
+    /**
+     * Wraps a native bit-packed mapping buffer produced by {@code parquet_finalize_writer}.
+     * Takes ownership: the buffer is freed on {@link #close()} (or by the Cleaner backstop).
+     *
+     * @param addr    native address of the packed buffer
+     * @param byteLen total buffer length in bytes (both sections including padding)
+     * @param count   number of row IDs per direction
+     * @param bpv     bits per value, in [1, 57]
+     */
+    NativePackedRowIdMapping(long addr, long byteLen, int count, int bpv) {
+        if (addr == 0 || byteLen <= 0 || count <= 0) {
+            throw new IllegalArgumentException("Invalid native mapping: addr=" + addr + " byteLen=" + byteLen + " count=" + count);
+        }
+        if (bpv < 1 || bpv > 57) {
+            throw new IllegalArgumentException("bpv must be in [1, 57], got " + bpv);
+        }
+        this.count = count;
+        this.bpv = bpv;
+        this.valueMask = (1L << bpv) - 1;
+        this.reverseSectionOffset = byteLen / 2;
+        this.nativeByteLen = byteLen;
+        this.state = new NativeBufferState(addr, byteLen);
+        // Shared arena: mappings are produced on the flush thread and consumed on merge
+        // threads. Closing the arena invalidates all access atomically across threads.
+        this.arena = Arena.ofShared();
+        this.segment = MemorySegment.ofAddress(addr).reinterpret(byteLen, arena, null);
+        this.state.arena = arena;
+        OUTSTANDING_NATIVE_BYTES.addAndGet(byteLen);
+        // Backstop: frees native memory if the owner never calls close(). Must not
+        // capture 'this' (state is a static class) or the mapping would never be collected.
+        this.cleanable = CLEANER.register(this, state);
+    }
+
+    @Override
+    public long getNewRowId(long oldId) {
+        if (oldId < 0 || oldId >= count) {
+            return -1L;
+        }
+        return unpack(0, oldId);
+    }
+
+    @Override
+    public long getOldRowId(long newId) {
+        if (newId < 0 || newId >= count) {
+            return -1L;
+        }
+        return unpack(reverseSectionOffset, newId);
+    }
+
+    @Override
+    public boolean isNewToOldSupported() {
+        return true;
+    }
+
+    @Override
+    public int size() {
+        return count;
+    }
+
+    /**
+     * Decodes value {@code index} from the section starting at {@code sectionBase}.
+     * Single unaligned little-endian 8-byte read + shift/mask; bpv &lt;= 57 guarantees
+     * the value fits inside the window, and the 7-byte section padding guarantees
+     * the read stays in bounds.
+     */
+    private long unpack(long sectionBase, long index) {
+        long bitPos = index * bpv;
+        long bytePos = sectionBase + (bitPos >>> 3);
+        int shift = (int) (bitPos & 7);
+        long window = segment.get(LE_LONG_UNALIGNED, bytePos);
+        return (window >>> shift) & valueMask;
+    }
+
+    /** Native bytes held by this mapping (both directions including padding). */
+    public long nativeBytesUsed() {
+        return nativeByteLen;
+    }
+
+    /** Total native bytes currently held by all live {@code NativePackedRowIdMapping} instances. */
+    public static long outstandingNativeBytes() {
+        return OUTSTANDING_NATIVE_BYTES.get();
+    }
+
+    /**
+     * Frees the native buffer. Idempotent. After close, any lookup throws
+     * {@link IllegalStateException} instead of touching freed memory.
+     */
+    @Override
+    public void close() {
+        state.explicitClose = true;
+        cleanable.clean(); // runs NativeBufferState.run() at most once
+    }
+
+    @Override
+    public String toString() {
+        return "NativePackedRowIdMapping{size=" + count + ", bpv=" + bpv + ", nativeBytes=" + nativeByteLen + '}';
+    }
+
+    /**
+     * Cleanup action shared between {@link #close()} and the Cleaner backstop.
+     * Static class holding no reference to the mapping object itself, so the Cleaner
+     * can fire when the mapping becomes unreachable.
+     */
+    private static final class NativeBufferState implements Runnable {
+        private final long addr;
+        private final long byteLen;
+        private final AtomicBoolean freed = new AtomicBoolean();
+        private volatile Arena arena;
+        private volatile boolean explicitClose;
+
+        NativeBufferState(long addr, long byteLen) {
+            this.addr = addr;
+            this.byteLen = byteLen;
+        }
+
+        @Override
+        public void run() {
+            if (freed.compareAndSet(false, true)) {
+                if (explicitClose == false) {
+                    logger.warn("NativePackedRowIdMapping leaked (never closed); freeing {} native bytes via Cleaner backstop", byteLen);
+                }
+                try {
+                    // Invalidate all Java-side access before freeing the memory.
+                    arena.close();
+                } finally {
+                    RustBridge.freeRowIdMapping(addr, byteLen);
+                    OUTSTANDING_NATIVE_BYTES.addAndGet(-byteLen);
+                }
+            }
+        }
+    }
+}

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/bridge/NativeParquetWriter.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/bridge/NativeParquetWriter.java
@@ -176,4 +176,21 @@ public class NativeParquetWriter {
         }
     }
 
+    /**
+     * Releases the native memory backing the row ID mapping, if any. Called when the
+     * owning writer closes — after the flush lifecycle that consumes the mapping has
+     * completed. Idempotent. Any access to the mapping after release throws
+     * {@link IllegalStateException} rather than reading freed memory.
+     */
+    public void releaseRowIdMapping() {
+        RowIdMapping mapping = rowIdMapping.get();
+        if (mapping instanceof AutoCloseable closeable) {
+            try {
+                closeable.close();
+            } catch (Exception e) {
+                throw new RuntimeException("Failed to release native row ID mapping for " + filePath, e);
+            }
+        }
+    }
+
 }

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/bridge/RustBridge.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/bridge/RustBridge.java
@@ -8,6 +8,8 @@
 
 package org.opensearch.parquet.bridge;
 
+import org.apache.lucene.util.packed.PackedInts;
+import org.apache.lucene.util.packed.PackedLongValues;
 import org.opensearch.index.engine.dataformat.PackedRowIdMapping;
 import org.opensearch.index.engine.dataformat.RowIdMapping;
 import org.opensearch.nativebridge.spi.NativeCall;
@@ -374,10 +376,21 @@ public class RustBridge {
             RowIdMapping rowIdMapping = null;
             if (permAddr != 0 && permLen > 0) {
                 try {
-                    long[] mappingArray = MemorySegment.ofAddress(permAddr)
-                        .reinterpret(permLen * ValueLayout.JAVA_LONG.byteSize())
-                        .toArray(ValueLayout.JAVA_LONG);
-                    rowIdMapping = new PackedRowIdMapping(mappingArray, true);
+                    // Read element-by-element from native memory, building both forward and reverse
+                    MemorySegment permSegment = MemorySegment.ofAddress(permAddr).reinterpret(permLen * ValueLayout.JAVA_LONG.byteSize());
+                    int size = (int) permLen;
+                    PackedLongValues.Builder forwardBuilder = PackedLongValues.packedBuilder(PackedInts.DEFAULT);
+                    long[] reverseArray = new long[size];
+                    for (int i = 0; i < size; i++) {
+                        long newId = permSegment.getAtIndex(ValueLayout.JAVA_LONG, i);
+                        forwardBuilder.add(newId);
+                        reverseArray[(int) newId] = i;
+                    }
+                    PackedLongValues.Builder reverseBuilder = PackedLongValues.packedBuilder(PackedInts.DEFAULT);
+                    for (long val : reverseArray) {
+                        reverseBuilder.add(val);
+                    }
+                    rowIdMapping = new PackedRowIdMapping(forwardBuilder.build(), reverseBuilder.build());
                 } finally {
                     NativeCall.invokeVoid(FREE_ROW_ID_MAPPING, permAddr, permLen);
                 }
@@ -644,12 +657,10 @@ public class RustBridge {
         long genCount = outGenCount.get(ValueLayout.JAVA_LONG, 0);
 
         try {
-            // Read mapping array (i64[])
-            long[] mappingArray = MemorySegment.ofAddress(mappingAddr)
-                .reinterpret(mappingLen * ValueLayout.JAVA_LONG.byteSize())
-                .toArray(ValueLayout.JAVA_LONG);
+            // Create a view over the native mapping array — no bulk copy
+            MemorySegment fullSegment = MemorySegment.ofAddress(mappingAddr).reinterpret(mappingLen * ValueLayout.JAVA_LONG.byteSize());
 
-            // Read generation keys (i64[]), offsets (i32[]), sizes (i32[])
+            // Read generation metadata (small arrays, OK to copy)
             long[] genKeys = MemorySegment.ofAddress(genKeysAddr)
                 .reinterpret(genCount * ValueLayout.JAVA_LONG.byteSize())
                 .toArray(ValueLayout.JAVA_LONG);
@@ -660,14 +671,17 @@ public class RustBridge {
                 .reinterpret(genCount * ValueLayout.JAVA_INT.byteSize())
                 .toArray(ValueLayout.JAVA_INT);
 
-            // Build one PackedRowIdMapping per generation by slicing the flat array
+            // Build one PackedRowIdMapping per generation by reading element-by-element
+            // directly from native memory into PackedLongValues — no intermediate long[] allocation
             Map<Long, RowIdMapping> result = new HashMap<>((int) genCount);
             for (int i = 0; i < (int) genCount; i++) {
                 int offset = genOffsets[i];
                 int size = genSizes[i];
-                long[] genMappingArray = new long[size];
-                System.arraycopy(mappingArray, offset, genMappingArray, 0, size);
-                result.put(genKeys[i], new PackedRowIdMapping(genMappingArray, false));
+                PackedLongValues.Builder builder = PackedLongValues.packedBuilder(PackedInts.DEFAULT);
+                for (int j = 0; j < size; j++) {
+                    builder.add(fullSegment.getAtIndex(ValueLayout.JAVA_LONG, offset + j));
+                }
+                result.put(genKeys[i], new PackedRowIdMapping(builder.build(), null));
             }
 
             return result;

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/bridge/RustBridge.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/bridge/RustBridge.java
@@ -609,7 +609,7 @@ public class RustBridge {
                 0
             );
 
-            RowIdMapping rowIdMapping = readAndFreeMergeResult(
+            Map<Long, RowIdMapping> rowIdMappings = readAndFreeMergeResult(
                 outMappingPtr,
                 outMappingLen,
                 outGenKeysPtr,
@@ -622,13 +622,13 @@ public class RustBridge {
             long flushChunkTimeMillis = outFlushChunkTimeMillis.get(ValueLayout.JAVA_LONG, 0);
             long rowIdMappingMax = outRowIdMappingMax.get(ValueLayout.JAVA_LONG, 0);
 
-            return new MergeFilesResult(rowIdMapping, metadata, flushChunkCount, flushChunkTimeMillis, rowIdMappingMax);
+            return new MergeFilesResult(rowIdMappings, metadata, flushChunkCount, flushChunkTimeMillis, rowIdMappingMax);
         } catch (IOException e) {
             throw new UncheckedIOException("Native merge failed", e);
         }
     }
 
-    private static RowIdMapping readAndFreeMergeResult(
+    private static Map<Long, RowIdMapping> readAndFreeMergeResult(
         MemorySegment outMappingPtr,
         MemorySegment outMappingLen,
         MemorySegment outGenKeysPtr,
@@ -660,14 +660,17 @@ public class RustBridge {
                 .reinterpret(genCount * ValueLayout.JAVA_INT.byteSize())
                 .toArray(ValueLayout.JAVA_INT);
 
-            Map<Long, Integer> offsetMap = new HashMap<>((int) genCount);
-            Map<Long, Integer> sizeMap = new HashMap<>((int) genCount);
+            // Build one PackedRowIdMapping per generation by slicing the flat array
+            Map<Long, RowIdMapping> result = new HashMap<>((int) genCount);
             for (int i = 0; i < (int) genCount; i++) {
-                offsetMap.put(genKeys[i], genOffsets[i]);
-                sizeMap.put(genKeys[i], genSizes[i]);
+                int offset = genOffsets[i];
+                int size = genSizes[i];
+                long[] genMappingArray = new long[size];
+                System.arraycopy(mappingArray, offset, genMappingArray, 0, size);
+                result.put(genKeys[i], new PackedRowIdMapping(genMappingArray, false));
             }
 
-            return new PackedRowIdMapping(mappingArray, offsetMap, sizeMap);
+            return result;
         } finally {
             NativeCall.invokeVoid(FREE_MERGE_RESULT, mappingAddr, mappingLen, genKeysAddr, genOffsetsAddr, genSizesAddr, genCount);
         }

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/bridge/RustBridge.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/bridge/RustBridge.java
@@ -110,7 +110,9 @@ public class RustBridge {
                 ValueLayout.ADDRESS,
                 ValueLayout.ADDRESS,                           // num_row_groups_out
                 ValueLayout.ADDRESS,                           // sort_perm_ptr_out
-                ValueLayout.ADDRESS                            // sort_perm_len_out
+                ValueLayout.ADDRESS,                           // sort_perm_byte_len_out
+                ValueLayout.ADDRESS,                           // sort_perm_count_out
+                ValueLayout.ADDRESS                            // sort_perm_bpv_out
             )
         );
         GET_FILE_METADATA = linker.downcallHandle(
@@ -264,7 +266,7 @@ public class RustBridge {
             lib.find("parquet_free_row_id_mapping").orElseThrow(),
             FunctionDescriptor.ofVoid(
                 ValueLayout.JAVA_LONG,                         // mapping_ptr
-                ValueLayout.JAVA_LONG                          // mapping_len
+                ValueLayout.JAVA_LONG                          // byte_len
             )
         );
         COLLECT_RUNTIME_METRICS = linker.downcallHandle(
@@ -360,7 +362,9 @@ public class RustBridge {
             var numRowGroupsOut = call.longOut();
             var out = call.outBuffer(1024);
             var sortPermPtrOut = call.longOut();
-            var sortPermLenOut = call.longOut();
+            var sortPermByteLenOut = call.longOut();
+            var sortPermCountOut = call.longOut();
+            var sortPermBpvOut = call.longOut();
             long rc = call.invokeIO(
                 FINALIZE_WRITER,
                 f.segment(),
@@ -373,7 +377,9 @@ public class RustBridge {
                 crc32Out,
                 numRowGroupsOut,
                 sortPermPtrOut,
-                sortPermLenOut
+                sortPermByteLenOut,
+                sortPermCountOut,
+                sortPermBpvOut
             );
             if (rc == 1) return null;
             int createdByLen = out.actualLength();
@@ -387,34 +393,35 @@ public class RustBridge {
                 (int) numRowGroupsOut.get(ValueLayout.JAVA_LONG, 0)
             );
 
-            // Read sort permutation if present
+            // Wrap the bit-packed permutation buffer (forward + reverse, ~bpv/8 bytes per
+            // value per direction) zero-copy. The mapping takes ownership of the native
+            // buffer and frees it via parquet_free_row_id_mapping on close(); no Java heap
+            // allocation is made for the mapping data.
             long permAddr = sortPermPtrOut.get(ValueLayout.JAVA_LONG, 0);
-            long permLen = sortPermLenOut.get(ValueLayout.JAVA_LONG, 0);
+            long permByteLen = sortPermByteLenOut.get(ValueLayout.JAVA_LONG, 0);
+            long permCount = sortPermCountOut.get(ValueLayout.JAVA_LONG, 0);
+            long permBpv = sortPermBpvOut.get(ValueLayout.JAVA_LONG, 0);
             RowIdMapping rowIdMapping = null;
-            if (permAddr != 0 && permLen > 0) {
+            if (permAddr != 0 && permByteLen > 0 && permCount > 0) {
                 try {
-                    // Read element-by-element from native memory, building both forward and reverse
-                    MemorySegment permSegment = MemorySegment.ofAddress(permAddr).reinterpret(permLen * ValueLayout.JAVA_LONG.byteSize());
-                    int size = (int) permLen;
-                    PackedLongValues.Builder forwardBuilder = PackedLongValues.packedBuilder(PackedInts.DEFAULT);
-                    long[] reverseArray = new long[size];
-                    for (int i = 0; i < size; i++) {
-                        long newId = permSegment.getAtIndex(ValueLayout.JAVA_LONG, i);
-                        forwardBuilder.add(newId);
-                        reverseArray[(int) newId] = i;
-                    }
-                    PackedLongValues.Builder reverseBuilder = PackedLongValues.packedBuilder(PackedInts.DEFAULT);
-                    for (long val : reverseArray) {
-                        reverseBuilder.add(val);
-                    }
-                    rowIdMapping = new PackedRowIdMapping(forwardBuilder.build(), reverseBuilder.build());
-                } finally {
-                    NativeCall.invokeVoid(FREE_ROW_ID_MAPPING, permAddr, permLen);
+                    rowIdMapping = new NativePackedRowIdMapping(permAddr, permByteLen, (int) permCount, (int) permBpv);
+                } catch (RuntimeException e) {
+                    // Wrapper construction failed — free the native buffer to avoid a leak.
+                    NativeCall.invokeVoid(FREE_ROW_ID_MAPPING, permAddr, permByteLen);
+                    throw e;
                 }
             }
 
             return new WriterFinalizeResult(metadata, rowIdMapping);
         }
+    }
+
+    /**
+     * Frees a bit-packed row ID mapping buffer previously returned by the finalize call.
+     * Invoked by {@link NativePackedRowIdMapping} on close (or its Cleaner backstop).
+     */
+    static void freeRowIdMapping(long addr, long byteLen) {
+        NativeCall.invokeVoid(FREE_ROW_ID_MAPPING, addr, byteLen);
     }
 
     public static ParquetFileMetadata getFileMetadata(String file) throws IOException {

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/bridge/RustBridge.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/bridge/RustBridge.java
@@ -626,7 +626,7 @@ public class RustBridge {
                 0
             );
 
-            RowIdMapping rowIdMapping = readAndFreeMergeResult(
+            Map<Long, RowIdMapping> rowIdMappings = readAndFreeMergeResult(
                 outMappingPtr,
                 outMappingLen,
                 outGenKeysPtr,
@@ -639,13 +639,13 @@ public class RustBridge {
             long flushChunkTimeMillis = outFlushChunkTimeMillis.get(ValueLayout.JAVA_LONG, 0);
             long rowIdMappingMax = outRowIdMappingMax.get(ValueLayout.JAVA_LONG, 0);
 
-            return new MergeFilesResult(rowIdMapping, metadata, flushChunkCount, flushChunkTimeMillis, rowIdMappingMax);
+            return new MergeFilesResult(rowIdMappings, metadata, flushChunkCount, flushChunkTimeMillis, rowIdMappingMax);
         } catch (IOException e) {
             throw new UncheckedIOException("Native merge failed", e);
         }
     }
 
-    private static RowIdMapping readAndFreeMergeResult(
+    private static Map<Long, RowIdMapping> readAndFreeMergeResult(
         MemorySegment outMappingPtr,
         MemorySegment outMappingLen,
         MemorySegment outGenKeysPtr,
@@ -677,14 +677,17 @@ public class RustBridge {
                 .reinterpret(genCount * ValueLayout.JAVA_INT.byteSize())
                 .toArray(ValueLayout.JAVA_INT);
 
-            Map<Long, Integer> offsetMap = new HashMap<>((int) genCount);
-            Map<Long, Integer> sizeMap = new HashMap<>((int) genCount);
+            // Build one PackedRowIdMapping per generation by slicing the flat array
+            Map<Long, RowIdMapping> result = new HashMap<>((int) genCount);
             for (int i = 0; i < (int) genCount; i++) {
-                offsetMap.put(genKeys[i], genOffsets[i]);
-                sizeMap.put(genKeys[i], genSizes[i]);
+                int offset = genOffsets[i];
+                int size = genSizes[i];
+                long[] genMappingArray = new long[size];
+                System.arraycopy(mappingArray, offset, genMappingArray, 0, size);
+                result.put(genKeys[i], new PackedRowIdMapping(genMappingArray, false));
             }
 
-            return new PackedRowIdMapping(mappingArray, offsetMap, sizeMap);
+            return result;
         } finally {
             NativeCall.invokeVoid(FREE_MERGE_RESULT, mappingAddr, mappingLen, genKeysAddr, genOffsetsAddr, genSizesAddr, genCount);
         }

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/bridge/RustBridge.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/bridge/RustBridge.java
@@ -8,6 +8,8 @@
 
 package org.opensearch.parquet.bridge;
 
+import org.apache.lucene.util.packed.PackedInts;
+import org.apache.lucene.util.packed.PackedLongValues;
 import org.opensearch.index.engine.dataformat.PackedRowIdMapping;
 import org.opensearch.index.engine.dataformat.RowIdMapping;
 import org.opensearch.nativebridge.spi.NativeCall;
@@ -391,10 +393,21 @@ public class RustBridge {
             RowIdMapping rowIdMapping = null;
             if (permAddr != 0 && permLen > 0) {
                 try {
-                    long[] mappingArray = MemorySegment.ofAddress(permAddr)
-                        .reinterpret(permLen * ValueLayout.JAVA_LONG.byteSize())
-                        .toArray(ValueLayout.JAVA_LONG);
-                    rowIdMapping = new PackedRowIdMapping(mappingArray, true);
+                    // Read element-by-element from native memory, building both forward and reverse
+                    MemorySegment permSegment = MemorySegment.ofAddress(permAddr).reinterpret(permLen * ValueLayout.JAVA_LONG.byteSize());
+                    int size = (int) permLen;
+                    PackedLongValues.Builder forwardBuilder = PackedLongValues.packedBuilder(PackedInts.DEFAULT);
+                    long[] reverseArray = new long[size];
+                    for (int i = 0; i < size; i++) {
+                        long newId = permSegment.getAtIndex(ValueLayout.JAVA_LONG, i);
+                        forwardBuilder.add(newId);
+                        reverseArray[(int) newId] = i;
+                    }
+                    PackedLongValues.Builder reverseBuilder = PackedLongValues.packedBuilder(PackedInts.DEFAULT);
+                    for (long val : reverseArray) {
+                        reverseBuilder.add(val);
+                    }
+                    rowIdMapping = new PackedRowIdMapping(forwardBuilder.build(), reverseBuilder.build());
                 } finally {
                     NativeCall.invokeVoid(FREE_ROW_ID_MAPPING, permAddr, permLen);
                 }
@@ -661,12 +674,10 @@ public class RustBridge {
         long genCount = outGenCount.get(ValueLayout.JAVA_LONG, 0);
 
         try {
-            // Read mapping array (i64[])
-            long[] mappingArray = MemorySegment.ofAddress(mappingAddr)
-                .reinterpret(mappingLen * ValueLayout.JAVA_LONG.byteSize())
-                .toArray(ValueLayout.JAVA_LONG);
+            // Create a view over the native mapping array — no bulk copy
+            MemorySegment fullSegment = MemorySegment.ofAddress(mappingAddr).reinterpret(mappingLen * ValueLayout.JAVA_LONG.byteSize());
 
-            // Read generation keys (i64[]), offsets (i32[]), sizes (i32[])
+            // Read generation metadata (small arrays, OK to copy)
             long[] genKeys = MemorySegment.ofAddress(genKeysAddr)
                 .reinterpret(genCount * ValueLayout.JAVA_LONG.byteSize())
                 .toArray(ValueLayout.JAVA_LONG);
@@ -677,14 +688,17 @@ public class RustBridge {
                 .reinterpret(genCount * ValueLayout.JAVA_INT.byteSize())
                 .toArray(ValueLayout.JAVA_INT);
 
-            // Build one PackedRowIdMapping per generation by slicing the flat array
+            // Build one PackedRowIdMapping per generation by reading element-by-element
+            // directly from native memory into PackedLongValues — no intermediate long[] allocation
             Map<Long, RowIdMapping> result = new HashMap<>((int) genCount);
             for (int i = 0; i < (int) genCount; i++) {
                 int offset = genOffsets[i];
                 int size = genSizes[i];
-                long[] genMappingArray = new long[size];
-                System.arraycopy(mappingArray, offset, genMappingArray, 0, size);
-                result.put(genKeys[i], new PackedRowIdMapping(genMappingArray, false));
+                PackedLongValues.Builder builder = PackedLongValues.packedBuilder(PackedInts.DEFAULT);
+                for (int j = 0; j < size; j++) {
+                    builder.add(fullSegment.getAtIndex(ValueLayout.JAVA_LONG, offset + j));
+                }
+                result.put(genKeys[i], new PackedRowIdMapping(builder.build(), null));
             }
 
             return result;

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/merge/NativeParquetMergeStrategy.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/merge/NativeParquetMergeStrategy.java
@@ -88,7 +88,7 @@ public class NativeParquetMergeStrategy implements ParquetMergeStrategy {
             // Merge files in Rust
             MergeFilesResult merged = RustBridge.mergeParquetFilesInRust(filePaths, mergedFilePath.toString(), indexName, writerGeneration);
             ParquetFileMetadata mergeMetadata = merged.metadata();
-            RowIdMapping rowIdMapping = merged.rowIdMapping();
+            Map<Long, RowIdMapping> rowIdMappings = merged.rowIdMappings();
 
             assert mergeMetadata.numRows() > 0 : "Merged file should contain at least one row";
 
@@ -123,7 +123,7 @@ public class NativeParquetMergeStrategy implements ParquetMergeStrategy {
             stats.addFlushAndSortChunkTimeMillis(merged.flushAndSortChunkTimeMs());
             stats.updateRowIdMappingMax(merged.rowIdMappingMax());
 
-            return new MergeResult(mergedWriterFileSetMap, rowIdMapping);
+            return new MergeResult(mergedWriterFileSetMap, rowIdMappings);
 
         } catch (Exception exception) {
             stats.incMergeFailures();

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/vsr/VSRManager.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/vsr/VSRManager.java
@@ -482,6 +482,16 @@ public class VSRManager implements AutoCloseable {
             if (writer != null) {
                 writer.cleanup();
             }
+            try {
+                // Free the native memory backing the sort row ID mapping. By close time the
+                // flush lifecycle that consumes the mapping (secondary-format reordering)
+                // has completed. Idempotent; a leak is caught by the Cleaner backstop.
+                if (writer != null) {
+                    writer.releaseRowIdMapping();
+                }
+            } catch (Exception e) {
+                logger.error("Error releasing row ID mapping during close for {}: {}", fileName, e.getMessage());
+            }
             managedVSR.set(null);
         }
     }

--- a/sandbox/plugins/parquet-data-format/src/main/rust/src/ffm.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/src/ffm.rs
@@ -153,7 +153,9 @@ pub unsafe extern "C" fn parquet_finalize_writer(
     crc32_out: *mut i64,
     num_row_groups_out: *mut i64,
     sort_perm_ptr_out: *mut i64,
-    sort_perm_len_out: *mut i64,
+    sort_perm_byte_len_out: *mut i64,
+    sort_perm_count_out: *mut i64,
+    sort_perm_bpv_out: *mut i64,
 ) -> i64 {
     let filename = str_from_raw(file_ptr, file_len)
         .map_err(|e| format!("parquet_finalize_writer: {}", e))?
@@ -186,19 +188,45 @@ pub unsafe extern "C" fn parquet_finalize_writer(
                 *num_row_groups_out = result.metadata.num_row_groups() as i64;
             }
 
-            // Return sort permutation if present
-            if !sort_perm_ptr_out.is_null() && !sort_perm_len_out.is_null() {
+            // Return the sort permutation, if present, as a single bit-packed buffer:
+            // [forward packed | reverse packed]. Each direction stores `count` values at
+            // `bpv = bits_per_value(count)` bits (~3 bytes/value for 10M rows instead of 8).
+            // Java wraps this buffer zero-copy in NativePackedRowIdMapping and frees it via
+            // parquet_free_row_id_mapping when the mapping is closed.
+            if !sort_perm_ptr_out.is_null()
+                && !sort_perm_byte_len_out.is_null()
+                && !sort_perm_count_out.is_null()
+                && !sort_perm_bpv_out.is_null()
+            {
                 if let Some(perm) = result.row_id_mapping {
-                    let len = perm.len();
-                    let mapping_bytes = len * std::mem::size_of::<i64>();
+                    let count = perm.len();
+                    let bpv = crate::packed_mapping::bits_per_value(count);
+                    let section_len = crate::packed_mapping::packed_byte_len(count, bpv);
+                    let total_len = section_len * 2;
+
+                    let mut buf = vec![0u8; total_len];
+                    let (fwd, rev) = buf.split_at_mut(section_len);
+                    // Forward: fwd[oldId] = newId (sequential pack).
+                    // Reverse: rev[newId] = oldId (scatter pack into the zeroed section) —
+                    // built directly from the permutation, no intermediate 8N reverse array.
+                    for (old_id, &new_id) in perm.iter().enumerate() {
+                        crate::packed_mapping::pack_one(fwd, bpv, old_id, new_id as u64);
+                        crate::packed_mapping::pack_one(rev, bpv, new_id as usize, old_id as u64);
+                    }
+                    drop(perm); // release the raw 8N permutation before handing off
+
                     // Track mapping handoff to Java — Java holds until parquet_free_row_id_mapping
-                    crate::memory::write_pool().grow(mapping_bytes);
-                    let boxed = perm.into_boxed_slice();
-                    *sort_perm_len_out = len as i64;
-                    *sort_perm_ptr_out = Box::into_raw(boxed) as *mut i64 as i64;
+                    crate::memory::write_pool().grow(total_len);
+                    let boxed = buf.into_boxed_slice();
+                    *sort_perm_byte_len_out = total_len as i64;
+                    *sort_perm_count_out = count as i64;
+                    *sort_perm_bpv_out = bpv as i64;
+                    *sort_perm_ptr_out = Box::into_raw(boxed) as *mut u8 as i64;
                 } else {
-                    *sort_perm_len_out = 0;
                     *sort_perm_ptr_out = 0;
+                    *sort_perm_byte_len_out = 0;
+                    *sort_perm_count_out = 0;
+                    *sort_perm_bpv_out = 0;
                 }
             }
             Ok(0)
@@ -915,16 +943,16 @@ pub unsafe extern "C" fn parquet_read_as_json(
 // Sort permutation memory management
 // ---------------------------------------------------------------------------
 
-/// Frees the heap-allocated row ID mapping array returned as part of `parquet_finalize_writer`.
+/// Frees the bit-packed row ID mapping buffer returned as part of `parquet_finalize_writer`.
+/// `byte_len` must be the exact `sort_perm_byte_len_out` value from the finalize call.
 #[no_mangle]
-pub unsafe extern "C" fn parquet_free_row_id_mapping(mapping_ptr: i64, mapping_len: i64) {
-    if mapping_ptr != 0 && mapping_len > 0 {
-        let mapping_bytes = mapping_len as usize * std::mem::size_of::<i64>();
+pub unsafe extern "C" fn parquet_free_row_id_mapping(mapping_ptr: i64, byte_len: i64) {
+    if mapping_ptr != 0 && byte_len > 0 {
         // Java released write mapping — free from pool
-        crate::memory::write_pool().shrink(mapping_bytes);
+        crate::memory::write_pool().shrink(byte_len as usize);
         let _ = Box::from_raw(slice::from_raw_parts_mut(
-            mapping_ptr as *mut i64,
-            mapping_len as usize,
+            mapping_ptr as *mut u8,
+            byte_len as usize,
         ));
     }
 }

--- a/sandbox/plugins/parquet-data-format/src/main/rust/src/lib.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/src/lib.rs
@@ -18,6 +18,7 @@ pub mod field_config;
 pub mod memory;
 pub mod merge;
 pub mod native_settings;
+pub mod packed_mapping;
 pub mod rate_limited_writer;
 pub mod writer;
 pub mod writer_properties_builder;

--- a/sandbox/plugins/parquet-data-format/src/main/rust/src/packed_mapping.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/src/packed_mapping.rs
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The OpenSearch Contributors require contributions made to
+// this file be licensed under the Apache-2.0 license or a
+// compatible open source license.
+
+//! Fixed-width bit packing for row ID mappings handed to Java.
+//!
+//! Both the forward permutation (`perm[oldId] = newId`) and its reverse are
+//! permutations of `[0, count)`, so every value fits in
+//! `bpv = 64 - leading_zeros(count - 1)` bits. Values are packed back-to-back
+//! in little-endian order: value `i` occupies bits `[i*bpv, (i+1)*bpv)` of the
+//! buffer. The Java reader (`NativePackedRowIdMapping`) decodes a value with a
+//! single unaligned little-endian 8-byte read plus shift/mask, so this layout
+//! is a cross-language serialization contract — do not change one side without
+//! the other.
+//!
+//! The buffer is padded with [`TAIL_PAD`] extra zero bytes so the reader's
+//! 8-byte window read at the last value never runs past the allocation.
+
+/// Extra zero bytes appended so an unaligned 8-byte read at the final value
+/// stays in bounds.
+pub const TAIL_PAD: usize = 7;
+
+/// Number of bits needed to represent any value in `[0, count)`.
+/// Returns 1 for `count <= 1` so the packed buffer is never zero-width.
+pub fn bits_per_value(count: usize) -> u32 {
+    if count <= 1 {
+        1
+    } else {
+        64 - ((count - 1) as u64).leading_zeros()
+    }
+}
+
+/// Total byte length of a packed buffer for `count` values at `bpv` bits each,
+/// including tail padding.
+pub fn packed_byte_len(count: usize, bpv: u32) -> usize {
+    (count * bpv as usize).div_ceil(8) + TAIL_PAD
+}
+
+/// Writes a single value at `index` into an already-zeroed packed buffer.
+///
+/// Safe to call in any index order (scatter) because each value's bits are
+/// disjoint and the write is a read-OR-write of an 8-byte window. The buffer
+/// must have been allocated with [`packed_byte_len`] and each index written
+/// at most once.
+///
+/// Requires `bpv <= 57` so that any value plus the maximum intra-byte shift (7)
+/// fits within one 8-byte window — guaranteed for row counts below 2^57.
+pub fn pack_one(buf: &mut [u8], bpv: u32, index: usize, value: u64) {
+    debug_assert!(bpv >= 1 && bpv <= 57, "bpv must be in [1, 57], got {}", bpv);
+    debug_assert!(value < (1u64 << bpv), "value {} does not fit in {} bits", value, bpv);
+    let bit_pos = index * bpv as usize;
+    let byte_pos = bit_pos >> 3;
+    let shift = (bit_pos & 7) as u32;
+    let window: &mut [u8] = &mut buf[byte_pos..byte_pos + 8];
+    let mut w = u64::from_le_bytes(window.try_into().unwrap());
+    w |= value << shift;
+    window.copy_from_slice(&w.to_le_bytes());
+}
+
+/// Bit-packs `values` at `bpv` bits per value into a little-endian buffer.
+pub fn pack(values: &[i64], bpv: u32) -> Vec<u8> {
+    let mut buf = vec![0u8; packed_byte_len(values.len(), bpv)];
+    for (i, &v) in values.iter().enumerate() {
+        pack_one(&mut buf, bpv, i, v as u64);
+    }
+    buf
+}
+
+/// Decodes value `i` from a packed buffer. Mirror of the Java reader; used in tests.
+#[cfg(test)]
+pub fn unpack(buf: &[u8], bpv: u32, i: usize) -> i64 {
+    let bit_pos = i * bpv as usize;
+    let byte_pos = bit_pos >> 3;
+    let shift = (bit_pos & 7) as u32;
+    let w = u64::from_le_bytes(buf[byte_pos..byte_pos + 8].try_into().unwrap());
+    ((w >> shift) & ((1u64 << bpv) - 1)) as i64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_bits_per_value() {
+        assert_eq!(bits_per_value(0), 1);
+        assert_eq!(bits_per_value(1), 1);
+        assert_eq!(bits_per_value(2), 1);
+        assert_eq!(bits_per_value(3), 2);
+        assert_eq!(bits_per_value(256), 8);
+        assert_eq!(bits_per_value(257), 9);
+        assert_eq!(bits_per_value(10_000_000), 24);
+    }
+
+    #[test]
+    fn test_pack_unpack_round_trip() {
+        // pseudo-random permutation of [0, n)
+        let n = 4099usize; // non-multiple of 8 to exercise straddling reads
+        let mut values: Vec<i64> = (0..n as i64).collect();
+        // simple deterministic shuffle
+        let mut seed = 0x9E3779B97F4A7C15u64;
+        for i in (1..n).rev() {
+            seed = seed.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+            let j = (seed % (i as u64 + 1)) as usize;
+            values.swap(i, j);
+        }
+        let bpv = bits_per_value(n);
+        let buf = pack(&values, bpv);
+        assert_eq!(buf.len(), packed_byte_len(n, bpv));
+        for (i, &v) in values.iter().enumerate() {
+            assert_eq!(unpack(&buf, bpv, i), v, "mismatch at index {}", i);
+        }
+    }
+
+    #[test]
+    fn test_pack_single_value() {
+        let buf = pack(&[0], bits_per_value(1));
+        assert_eq!(unpack(&buf, 1, 0), 0);
+    }
+
+    #[test]
+    fn test_packed_size_is_compact() {
+        // 10M rows at 24 bpv should be ~3 bytes per value, not 8
+        let n = 10_000_000usize;
+        let bpv = bits_per_value(n);
+        let len = packed_byte_len(n, bpv);
+        assert!(len < n * 4, "packed len {} should be well under 4 bytes/value", len);
+        assert!(len >= n * 3, "packed len {} should be at least 3 bytes/value for 24 bpv", len);
+    }
+}

--- a/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/bridge/NativePackedRowIdMappingTests.java
+++ b/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/bridge/NativePackedRowIdMappingTests.java
@@ -1,0 +1,200 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.parquet.bridge;
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+
+import org.apache.arrow.c.ArrowArray;
+import org.apache.arrow.c.ArrowSchema;
+import org.apache.arrow.c.Data;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.BigIntVector;
+import org.apache.arrow.vector.VarCharVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.opensearch.index.engine.dataformat.RowIdMapping;
+import org.opensearch.nativebridge.spi.ArrowExport;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+/**
+ * End-to-end tests of the native bit-packed row ID mapping produced by sort-on-close:
+ * Rust packs forward+reverse at bpv bits/value, Java reads it zero-copy through
+ * {@link NativePackedRowIdMapping}, and close() releases the native buffer exactly once.
+ */
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
+public class NativePackedRowIdMappingTests extends OpenSearchTestCase {
+
+    private static final String INDEX_NAME = "native-mapping-test-index";
+    private BufferAllocator allocator;
+    private Schema schema;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        RustBridge.initLogger();
+        allocator = new RootAllocator();
+        schema = new Schema(
+            List.of(
+                new Field("timestamp", FieldType.nullable(new ArrowType.Int(64, true)), null),
+                new Field("message", FieldType.nullable(new ArrowType.Utf8()), null),
+                new Field("__row_id__", FieldType.nullable(new ArrowType.Int(64, true)), null)
+            )
+        );
+        NativeSettings settings = NativeSettings.builder().indexName(INDEX_NAME).compressionType("LZ4_RAW").build();
+        RustBridge.onSettingsUpdate(settings);
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        RustBridge.removeSettings(INDEX_NAME);
+        allocator.close();
+        super.tearDown();
+    }
+
+    public void testSortedFlushProducesValidNativeMapping() throws Exception {
+        // Unsorted input: sorting by timestamp yields a non-identity permutation.
+        long[] timestamps = { 500, 100, 400, 200, 300 };
+        String[] messages = { "e", "a", "d", "b", "c" };
+
+        NativeParquetWriter writer = writeSortedFile("sorted.parquet", timestamps, messages);
+        RowIdMapping mapping = writer.getRowIdMapping();
+
+        assertNotNull("Sorted flush must produce a row ID mapping", mapping);
+        assertTrue("Mapping must be native-packed", mapping instanceof NativePackedRowIdMapping);
+        assertEquals(5, mapping.size());
+        assertTrue(mapping.isNewToOldSupported());
+
+        // Sorted order by timestamp: 100,200,300,400,500 → oldId 1,3,4,2,0.
+        // Forward: mapping[oldId] = position of that row in sorted output.
+        long[] expectedNewIds = { 4, 0, 3, 1, 2 };
+        for (int oldId = 0; oldId < 5; oldId++) {
+            assertEquals("forward mapping for oldId " + oldId, expectedNewIds[oldId], mapping.getNewRowId(oldId));
+            // Reverse must invert forward exactly.
+            assertEquals("reverse of forward for oldId " + oldId, oldId, mapping.getOldRowId(mapping.getNewRowId(oldId)));
+        }
+
+        // Out-of-range lookups return -1, matching PackedRowIdMapping semantics.
+        assertEquals(-1L, mapping.getNewRowId(-1));
+        assertEquals(-1L, mapping.getNewRowId(5));
+        assertEquals(-1L, mapping.getOldRowId(-1));
+        assertEquals(-1L, mapping.getOldRowId(5));
+
+        writer.releaseRowIdMapping();
+    }
+
+    public void testCloseFreesNativeMemoryAndInvalidatesAccess() throws Exception {
+        long before = NativePackedRowIdMapping.outstandingNativeBytes();
+
+        NativeParquetWriter writer = writeSortedFile("close.parquet", new long[] { 300, 100, 200 }, new String[] { "c", "a", "b" });
+        NativePackedRowIdMapping mapping = (NativePackedRowIdMapping) writer.getRowIdMapping();
+        assertNotNull(mapping);
+
+        assertTrue("mapping must hold native bytes", mapping.nativeBytesUsed() > 0);
+        assertEquals(before + mapping.nativeBytesUsed(), NativePackedRowIdMapping.outstandingNativeBytes());
+
+        mapping.close();
+        assertEquals("native bytes must return to baseline after close", before, NativePackedRowIdMapping.outstandingNativeBytes());
+
+        // Use-after-close must fail loudly, never read freed memory.
+        expectThrows(IllegalStateException.class, () -> mapping.getNewRowId(0));
+        expectThrows(IllegalStateException.class, () -> mapping.getOldRowId(0));
+
+        // close() is idempotent.
+        mapping.close();
+        assertEquals(before, NativePackedRowIdMapping.outstandingNativeBytes());
+    }
+
+    public void testReleaseRowIdMappingIsIdempotentAndSafeWithoutMapping() throws Exception {
+        // Writer that was never initialized has no mapping — release must be a no-op.
+        NativeParquetWriter writer = new NativeParquetWriter(createTempDir().resolve("none.parquet").toString());
+        writer.releaseRowIdMapping();
+
+        // Writer with a mapping: double release must be safe.
+        NativeParquetWriter sortedWriter = writeSortedFile("release.parquet", new long[] { 200, 100 }, new String[] { "b", "a" });
+        assertNotNull(sortedWriter.getRowIdMapping());
+        sortedWriter.releaseRowIdMapping();
+        sortedWriter.releaseRowIdMapping();
+    }
+
+    public void testLargerPermutationRoundTrip() throws Exception {
+        // Enough rows to exercise bpv > 8 and bit-boundary straddling within packed bytes.
+        int n = 1000;
+        long[] timestamps = new long[n];
+        String[] messages = new String[n];
+        // Descending timestamps → sort fully reverses the order.
+        for (int i = 0; i < n; i++) {
+            timestamps[i] = n - i;
+            messages[i] = "m" + i;
+        }
+
+        NativeParquetWriter writer = writeSortedFile("large.parquet", timestamps, messages);
+        RowIdMapping mapping = writer.getRowIdMapping();
+        assertNotNull(mapping);
+        assertEquals(n, mapping.size());
+
+        // Full reversal: oldId i lands at newId n-1-i.
+        for (int i = 0; i < n; i++) {
+            assertEquals(n - 1 - i, mapping.getNewRowId(i));
+            assertEquals(i, mapping.getOldRowId(n - 1 - i));
+        }
+
+        writer.releaseRowIdMapping();
+    }
+
+    /**
+     * Writes a file with a __row_id__ column and a timestamp sort config through the
+     * full native pipeline (createWriter → write → finalize) and returns the writer.
+     */
+    private NativeParquetWriter writeSortedFile(String name, long[] timestamps, String[] messages) throws Exception {
+        String filePath = createTempDir().resolve(name).toString();
+        ParquetSortConfig sortConfig = new ParquetSortConfig(List.of("timestamp"), List.of(false), List.of(false));
+
+        try (ArrowExport schemaExport = exportSchema()) {
+            NativeParquetWriter writer = new NativeParquetWriter(filePath);
+            writer.initialize(INDEX_NAME, schemaExport.getSchemaAddress(), sortConfig, 0L);
+            try (ArrowExport dataExport = exportData(timestamps, messages)) {
+                writer.write(dataExport.getArrayAddress(), dataExport.getSchemaAddress());
+            }
+            writer.flush();
+            return writer;
+        }
+    }
+
+    private ArrowExport exportSchema() {
+        ArrowSchema arrowSchema = ArrowSchema.allocateNew(allocator);
+        Data.exportSchema(allocator, schema, null, arrowSchema);
+        return new ArrowExport(null, arrowSchema);
+    }
+
+    private ArrowExport exportData(long[] timestamps, String[] messages) {
+        try (VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator)) {
+            BigIntVector tsVec = (BigIntVector) root.getVector("timestamp");
+            VarCharVector msgVec = (VarCharVector) root.getVector("message");
+            BigIntVector rowIdVec = (BigIntVector) root.getVector("__row_id__");
+            for (int i = 0; i < timestamps.length; i++) {
+                tsVec.setSafe(i, timestamps[i]);
+                msgVec.setSafe(i, messages[i].getBytes(StandardCharsets.UTF_8));
+                rowIdVec.setSafe(i, i);
+            }
+            root.setRowCount(timestamps.length);
+
+            ArrowArray array = ArrowArray.allocateNew(allocator);
+            ArrowSchema arrowSchema = ArrowSchema.allocateNew(allocator);
+            Data.exportVectorSchemaRoot(allocator, root, null, array, arrowSchema);
+            return new ArrowExport(array, arrowSchema);
+        }
+    }
+}

--- a/server/src/main/java/org/opensearch/index/engine/dataformat/MergeInput.java
+++ b/server/src/main/java/org/opensearch/index/engine/dataformat/MergeInput.java
@@ -14,6 +14,7 @@ import org.opensearch.index.engine.exec.WriterFileSet;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -23,14 +24,34 @@ import java.util.Objects;
  * @opensearch.experimental
  */
 @ExperimentalApi
-public record MergeInput(List<Segment> segments, RowIdMapping rowIdMapping, long newWriterGeneration) {
+public record MergeInput(List<Segment> segments, Map<Long, RowIdMapping> rowIdMappings, long newWriterGeneration) {
 
     public MergeInput {
         segments = List.copyOf(segments);
+        rowIdMappings = rowIdMappings != null ? Map.copyOf(rowIdMappings) : Map.of();
     }
 
     private MergeInput(Builder builder) {
-        this(new ArrayList<>(builder.segments), builder.rowIdMapping, builder.newWriterGeneration);
+        this(new ArrayList<>(builder.segments), builder.rowIdMappings, builder.newWriterGeneration);
+    }
+
+    /**
+     * Returns the {@link RowIdMapping} for a specific writer generation, or null if not present.
+     *
+     * @param generation the writer generation
+     * @return the row ID mapping for that generation, or null
+     */
+    public RowIdMapping getRowIdMapping(long generation) {
+        return rowIdMappings.get(generation);
+    }
+
+    /**
+     * Returns whether any row ID mappings are available.
+     *
+     * @return true if at least one generation mapping exists
+     */
+    public boolean hasRowIdMappings() {
+        return rowIdMappings != null && !rowIdMappings.isEmpty();
     }
 
     /**
@@ -58,7 +79,7 @@ public record MergeInput(List<Segment> segments, RowIdMapping rowIdMapping, long
     @ExperimentalApi
     public static class Builder {
         private List<Segment> segments = new ArrayList<>();
-        private RowIdMapping rowIdMapping;
+        private Map<Long, RowIdMapping> rowIdMappings;
         private long newWriterGeneration;
 
         private Builder() {}
@@ -86,13 +107,13 @@ public record MergeInput(List<Segment> segments, RowIdMapping rowIdMapping, long
         }
 
         /**
-         * Sets the row ID mapping for secondary data format merges.
+         * Sets the row ID mappings keyed by writer generation for secondary data format merges.
          *
-         * @param rowIdMapping the row ID mapping
+         * @param rowIdMappings map of writer generation to row ID mapping
          * @return this builder
          */
-        public Builder rowIdMapping(RowIdMapping rowIdMapping) {
-            this.rowIdMapping = rowIdMapping;
+        public Builder rowIdMappings(Map<Long, RowIdMapping> rowIdMappings) {
+            this.rowIdMappings = rowIdMappings;
             return this;
         }
 

--- a/server/src/main/java/org/opensearch/index/engine/dataformat/MergeResult.java
+++ b/server/src/main/java/org/opensearch/index/engine/dataformat/MergeResult.java
@@ -23,7 +23,7 @@ import java.util.Optional;
 public class MergeResult {
 
     private final Map<DataFormat, WriterFileSet> mergedWriterFileSet;
-    private final RowIdMapping rowIdMapping;
+    private final Map<Long, RowIdMapping> rowIdMappings;
 
     /**
      * Constructs a merge result with the given merged writer file sets.
@@ -32,18 +32,18 @@ public class MergeResult {
      */
     public MergeResult(Map<DataFormat, WriterFileSet> mergedWriterFileSet) {
         this.mergedWriterFileSet = mergedWriterFileSet;
-        this.rowIdMapping = null;
+        this.rowIdMappings = null;
     }
 
     /**
-     * Constructs a merge result with the given merged writer file sets and row ID mapping.
+     * Constructs a merge result with the given merged writer file sets and row ID mappings.
      *
      * @param mergedWriterFileSet map of data formats to merged writer file sets
-     * @param rowIdMapping the row ID mapping produced during the merge
+     * @param rowIdMappings the row ID mappings keyed by writer generation produced during the merge
      */
-    public MergeResult(Map<DataFormat, WriterFileSet> mergedWriterFileSet, RowIdMapping rowIdMapping) {
+    public MergeResult(Map<DataFormat, WriterFileSet> mergedWriterFileSet, Map<Long, RowIdMapping> rowIdMappings) {
         this.mergedWriterFileSet = mergedWriterFileSet;
-        this.rowIdMapping = rowIdMapping;
+        this.rowIdMappings = rowIdMappings;
     }
 
     /**
@@ -66,11 +66,11 @@ public class MergeResult {
     }
 
     /**
-     * Gets the row id mapping.
+     * Gets the row ID mappings keyed by writer generation.
      *
-     * @return the row id mapping
+     * @return optional containing the mappings, or empty if none produced
      */
-    public Optional<RowIdMapping> rowIdMapping() {
-        return Optional.ofNullable(rowIdMapping);
+    public Optional<Map<Long, RowIdMapping>> rowIdMappings() {
+        return Optional.ofNullable(rowIdMappings);
     }
 }

--- a/server/src/main/java/org/opensearch/index/engine/dataformat/PackedRowIdMapping.java
+++ b/server/src/main/java/org/opensearch/index/engine/dataformat/PackedRowIdMapping.java
@@ -12,33 +12,11 @@ import org.apache.lucene.util.packed.PackedInts;
 import org.apache.lucene.util.packed.PackedLongValues;
 import org.opensearch.common.annotation.ExperimentalApi;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Objects;
 
 /**
  * Compact implementation of {@link RowIdMapping} using Lucene's PackedLongValues for memory-efficient
- * storage of row ID mappings produced during merge operations.
- *
- * <p>Structure:
- * <ul>
- *   <li>A single flat packed array where {@code mapping[position] = newRowId}</li>
- *   <li>{@code generationOffsets} maps writer generation to starting offset in the array</li>
- *   <li>{@code generationSizes} maps writer generation to number of rows in that generation</li>
- * </ul>
- *
- * <p>Offsets are assigned in the order generations are processed during the primary format's merge,
- * not sorted. This ensures the mapping is independent of generation ordering.
- *
- * <p>Example: merge processes generations in order [5, 0, 3]:
- * <pre>
- *   generation 5 (2 rows): offset=0, mapping[0]=2, mapping[1]=3
- *   generation 0 (3 rows): offset=2, mapping[2]=0, mapping[3]=4, mapping[4]=1
- *   generation 3 (1 row):  offset=5, mapping[5]=5
- *
- *   Lookup: newRowId = mapping.get(generationOffsets.get(generation) + oldRowId)
- * </pre>
+ * storage of row ID mappings for a single generation.
  *
  * @opensearch.experimental
  */
@@ -47,45 +25,16 @@ public final class PackedRowIdMapping implements RowIdMapping {
 
     private final PackedLongValues mapping;
     private final PackedLongValues reverseMapping;
-    private final Map<Long, Integer> generationOffsets;
-    private final Map<Long, Integer> generationSizes;
     private final boolean reverseSupported;
 
     /**
-     * Creates a PackedRowIdMapping for a single-generation flush sort permutation.
-     *
-     * <p>Sets generationOffsets to {SINGLE_GEN: 0} and generationSizes to {SINGLE_GEN: mappingArray.length}.
-     * If reverseSupported is true, builds the reverse (newToOld) mapping by inverting the permutation.
+     * Creates a PackedRowIdMapping for a single generation.
      *
      * @param mappingArray array where {@code mappingArray[oldRowId] = newRowId}
      * @param reverseSupported whether to build the reverse mapping for newToOld lookups
      */
     public PackedRowIdMapping(long[] mappingArray, boolean reverseSupported) {
-        this(mappingArray, Map.of(RowIdMapping.SINGLE_GEN, 0), Map.of(RowIdMapping.SINGLE_GEN, mappingArray.length), reverseSupported);
-    }
-
-    /**
-     * Creates a PackedRowIdMapping from a mapping array, generation offsets, and generation sizes.
-     *
-     * <p>This constructor is used for multi-generation merge mappings. Reverse lookup is not supported.
-     *
-     * @param mappingArray array where index=position, value=newRowId
-     * @param generationOffsets map of writer generation to starting offset in the mapping array
-     * @param generationSizes map of writer generation to number of rows in that generation
-     */
-    public PackedRowIdMapping(long[] mappingArray, Map<Long, Integer> generationOffsets, Map<Long, Integer> generationSizes) {
-        this(mappingArray, generationOffsets, generationSizes, false);
-    }
-
-    private PackedRowIdMapping(
-        long[] mappingArray,
-        Map<Long, Integer> generationOffsets,
-        Map<Long, Integer> generationSizes,
-        boolean reverseSupported
-    ) {
         Objects.requireNonNull(mappingArray, "mappingArray cannot be null");
-        Objects.requireNonNull(generationOffsets, "generationOffsets cannot be null");
-        Objects.requireNonNull(generationSizes, "generationSizes cannot be null");
 
         this.reverseSupported = reverseSupported;
 
@@ -94,9 +43,6 @@ public final class PackedRowIdMapping implements RowIdMapping {
             forwardBuilder.add(value);
         }
         this.mapping = forwardBuilder.build();
-
-        this.generationOffsets = Collections.unmodifiableMap(new HashMap<>(generationOffsets));
-        this.generationSizes = Collections.unmodifiableMap(new HashMap<>(generationSizes));
 
         if (reverseSupported) {
             long[] reverseArray = new long[mappingArray.length];
@@ -114,37 +60,30 @@ public final class PackedRowIdMapping implements RowIdMapping {
     }
 
     /**
-     * Returns the new row ID for the given old row ID and writer generation.
-     * O(1) lookup via offset calculation.
+     * Creates a PackedRowIdMapping from pre-built forward and reverse mappings.
      *
-     * @param oldId the original row ID within the generation
-     * @param oldGeneration the writer generation of the source segment
-     * @return the new row ID, or -1 if the generation or row ID is not found
+     * @param forwardMapping pre-built packed values where {@code get(oldRowId) = newRowId}
+     * @param reverseMapping pre-built packed values where {@code get(newRowId) = oldRowId}, or null
      */
-    @Override
-    public long getNewRowId(long oldId, long oldGeneration) {
-        Integer offset = generationOffsets.get(oldGeneration);
-        if (offset == null) {
-            return -1L;
-        }
-        Integer size = generationSizes.get(oldGeneration);
-        if (size == null || oldId < 0 || oldId >= size) {
-            return -1L;
-        }
-        return mapping.get(offset + (int) oldId);
+    public PackedRowIdMapping(PackedLongValues forwardMapping, PackedLongValues reverseMapping) {
+        Objects.requireNonNull(forwardMapping, "forwardMapping cannot be null");
+        this.mapping = forwardMapping;
+        this.reverseMapping = reverseMapping;
+        this.reverseSupported = reverseMapping != null;
     }
 
-    /**
-     * Returns the old row ID for the given new row ID via reverse lookup.
-     *
-     * @param newId the new row ID
-     * @return the original row ID, or -1 if out of bounds
-     * @throws UnsupportedOperationException if reverse lookup is not supported
-     */
+    @Override
+    public long getNewRowId(long oldId) {
+        if (oldId < 0 || oldId >= mapping.size()) {
+            return -1L;
+        }
+        return mapping.get((int) oldId);
+    }
+
     @Override
     public long getOldRowId(long newId) {
         if (reverseSupported == false) {
-            throw new UnsupportedOperationException("Reverse lookup (newToOld) is not supported by this mapping");
+            throw new UnsupportedOperationException("Reverse lookup is not supported by this mapping");
         }
         if (newId < 0 || newId >= mapping.size()) {
             return -1L;
@@ -152,42 +91,16 @@ public final class PackedRowIdMapping implements RowIdMapping {
         return reverseMapping.get((int) newId);
     }
 
-    /**
-     * Returns whether reverse lookup (getOldRowId / newToOld) is supported by this mapping.
-     *
-     * @return true if reverse lookup is supported, false otherwise
-     */
     @Override
     public boolean isNewToOldSupported() {
         return reverseSupported;
     }
 
-    /**
-     * Returns the number of rows for a specific writer generation.
-     *
-     * @param generation the writer generation
-     * @return the number of rows, or 0 if the generation is not found
-     */
-    public int getGenerationSize(long generation) {
-        Integer size = generationSizes.get(generation);
-        return size != null ? size : 0;
-    }
-
-    /**
-     * Returns the total number of entries in the mapping.
-     *
-     * @return the total mapping size
-     */
     @Override
     public int size() {
         return (int) mapping.size();
     }
 
-    /**
-     * Returns the estimated memory usage of this mapping in bytes.
-     *
-     * @return estimated memory in bytes
-     */
     public long ramBytesUsed() {
         long bytes = mapping.ramBytesUsed();
         if (reverseMapping != null) {
@@ -196,33 +109,8 @@ public final class PackedRowIdMapping implements RowIdMapping {
         return bytes;
     }
 
-    /**
-     * Returns an unmodifiable view of the generation offsets.
-     *
-     * @return map of writer generation to starting offset
-     */
-    public Map<Long, Integer> getGenerationOffsets() {
-        return generationOffsets;
-    }
-
-    /**
-     * Returns an unmodifiable view of the generation sizes.
-     *
-     * @return map of writer generation to row count
-     */
-    public Map<Long, Integer> getGenerationSizes() {
-        return generationSizes;
-    }
-
     @Override
     public String toString() {
-        return "PackedRowIdMapping{"
-            + "size="
-            + mapping.size()
-            + ", generations="
-            + generationOffsets.size()
-            + ", estimatedMemoryBytes="
-            + mapping.ramBytesUsed()
-            + '}';
+        return "PackedRowIdMapping{size=" + mapping.size() + ", reverseSupported=" + reverseSupported + '}';
     }
 }

--- a/server/src/main/java/org/opensearch/index/engine/dataformat/PackedRowIdMapping.java
+++ b/server/src/main/java/org/opensearch/index/engine/dataformat/PackedRowIdMapping.java
@@ -62,8 +62,8 @@ public final class PackedRowIdMapping implements RowIdMapping {
     /**
      * Creates a PackedRowIdMapping from pre-built forward and reverse mappings.
      *
-     * @param forwardMapping pre-built packed values where {@code get(oldRowId) = newRowId}
-     * @param reverseMapping pre-built packed values where {@code get(newRowId) = oldRowId}, or null
+     * @param forwardMapping pre-built packed values where get(oldRowId) returns newRowId
+     * @param reverseMapping pre-built packed values where get(newRowId) returns oldRowId, or null
      */
     public PackedRowIdMapping(PackedLongValues forwardMapping, PackedLongValues reverseMapping) {
         Objects.requireNonNull(forwardMapping, "forwardMapping cannot be null");

--- a/server/src/main/java/org/opensearch/index/engine/dataformat/RowIdMapping.java
+++ b/server/src/main/java/org/opensearch/index/engine/dataformat/RowIdMapping.java
@@ -13,22 +13,23 @@ import org.opensearch.common.annotation.ExperimentalApi;
 /**
  * Mapping interface for translating old row IDs to new row IDs after a merge or sort operation.
  *
+ * <p>Each {@code RowIdMapping} instance represents the mapping for a <b>single generation</b>.
+ * For merge operations involving multiple generations, callers maintain a
+ * {@code Map<Long, RowIdMapping>} keyed by writer generation and pass the appropriate
+ * per-generation mapping to each consumer.
+ *
  * @opensearch.experimental
  */
 @ExperimentalApi
 public interface RowIdMapping {
 
-    /** Sentinel generation for single-gen flush sort scenarios. */
-    long SINGLE_GEN = -1L;
-
     /**
-     * Returns the new row ID corresponding to the given old row ID and generation.
+     * Returns the new row ID corresponding to the given old row ID within this generation.
      *
      * @param oldId the original row ID
-     * @param oldGeneration the original writer generation
      * @return the new row ID, or -1 if not found
      */
-    long getNewRowId(long oldId, long oldGeneration);
+    long getNewRowId(long oldId);
 
     /**
      * Reverse lookup: returns the old row ID corresponding to the given new row ID.

--- a/server/src/test/java/org/opensearch/index/engine/dataformat/DataFormatPluginTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/dataformat/DataFormatPluginTests.java
@@ -140,18 +140,22 @@ public class DataFormatPluginTests extends OpenSearchTestCase {
         WriterFileSet merged = mergeResult.getMergedWriterFileSetForDataformat(format);
         assertNotNull(merged);
         assertEquals(3L, merged.writerGeneration());
-        assertTrue(mergeResult.rowIdMapping().isPresent());
+        assertTrue(mergeResult.rowIdMappings().isPresent());
 
-        // Verify row ID mapping
-        RowIdMapping mapping = mergeResult.rowIdMapping().get();
-        assertEquals(0L, mapping.getNewRowId(0, 1L));
-        assertEquals(1L, mapping.getNewRowId(1, 1L));
-        assertEquals(2L, mapping.getNewRowId(0, 2L));
+        // Verify row ID mappings (per-generation)
+        Map<Long, RowIdMapping> mappings = mergeResult.rowIdMappings().get();
+        RowIdMapping gen1Mapping = mappings.get(1L);
+        RowIdMapping gen2Mapping = mappings.get(2L);
+        assertNotNull(gen1Mapping);
+        assertNotNull(gen2Mapping);
+        assertEquals(0L, gen1Mapping.getNewRowId(0));
+        assertEquals(1L, gen1Mapping.getNewRowId(1));
+        assertEquals(2L, gen2Mapping.getNewRowId(0));
 
-        // 6. Merge with an existing RowIdMapping (secondary data format merge)
+        // 6. Merge with existing RowIdMappings (secondary data format merge)
         MergeInput secondaryMergeInput = MergeInput.builder()
             .segments(List.of(seg1, seg2))
-            .rowIdMapping(mapping)
+            .rowIdMappings(mappings)
             .newWriterGeneration(4L)
             .build();
         MergeResult secondaryMerge = merger.merge(secondaryMergeInput);
@@ -224,12 +228,12 @@ public class DataFormatPluginTests extends OpenSearchTestCase {
         WriterFileSet fileSet = WriterFileSet.builder().directory(dir).writerGeneration(1L).addNumRows(5).addFile("merged.parquet").build();
 
         MergeResult withoutMapping = new MergeResult(Map.of(format, fileSet));
-        assertFalse(withoutMapping.rowIdMapping().isPresent());
+        assertFalse(withoutMapping.rowIdMappings().isPresent());
         assertEquals(fileSet, withoutMapping.getMergedWriterFileSetForDataformat(format));
 
-        RowIdMapping mapping = new PackedRowIdMapping(new long[] { 0 }, false);
-        MergeResult withMapping = new MergeResult(Map.of(format, fileSet), mapping);
-        assertTrue(withMapping.rowIdMapping().isPresent());
+        Map<Long, RowIdMapping> mappings = Map.of(1L, new PackedRowIdMapping(new long[] { 0 }, false));
+        MergeResult withMapping = new MergeResult(Map.of(format, fileSet), mappings);
+        assertTrue(withMapping.rowIdMappings().isPresent());
     }
 
     /**

--- a/server/src/test/java/org/opensearch/index/engine/dataformat/FileInfosTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/dataformat/FileInfosTests.java
@@ -65,7 +65,7 @@ public class FileInfosTests extends OpenSearchTestCase {
 
         assertNotNull(infos.rowIdMapping());
         assertEquals(3, infos.rowIdMapping().size());
-        assertEquals(2L, infos.rowIdMapping().getNewRowId(0, RowIdMapping.SINGLE_GEN));
+        assertEquals(2L, infos.rowIdMapping().getNewRowId(0));
     }
 
     public void testConstructorWithoutMapping() {

--- a/server/src/test/java/org/opensearch/index/engine/dataformat/FlushInputTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/dataformat/FlushInputTests.java
@@ -32,8 +32,8 @@ public class FlushInputTests extends OpenSearchTestCase {
         assertTrue(input.hasRowIdMapping());
         assertNotNull(input.rowIdMapping());
         assertEquals(3, input.rowIdMapping().size());
-        assertEquals(2L, input.rowIdMapping().getNewRowId(0, RowIdMapping.SINGLE_GEN));
-        assertEquals(0L, input.rowIdMapping().getNewRowId(1, RowIdMapping.SINGLE_GEN));
-        assertEquals(1L, input.rowIdMapping().getNewRowId(2, RowIdMapping.SINGLE_GEN));
+        assertEquals(2L, input.rowIdMapping().getNewRowId(0));
+        assertEquals(0L, input.rowIdMapping().getNewRowId(1));
+        assertEquals(1L, input.rowIdMapping().getNewRowId(2));
     }
 }

--- a/server/src/test/java/org/opensearch/index/engine/dataformat/PackedRowIdMappingTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/dataformat/PackedRowIdMappingTests.java
@@ -8,151 +8,104 @@
 
 package org.opensearch.index.engine.dataformat;
 
+import org.apache.lucene.util.packed.PackedInts;
+import org.apache.lucene.util.packed.PackedLongValues;
 import org.opensearch.test.OpenSearchTestCase;
-
-import java.util.Map;
 
 /**
  * Tests for {@link PackedRowIdMapping}.
  */
 public class PackedRowIdMappingTests extends OpenSearchTestCase {
 
-    public void testSingleGenConstructorForwardLookup() {
+    public void testForwardLookup() {
         long[] mapping = { 2, 0, 1 };
         PackedRowIdMapping m = new PackedRowIdMapping(mapping, false);
-
-        assertEquals(2L, m.getNewRowId(0, RowIdMapping.SINGLE_GEN));
-        assertEquals(0L, m.getNewRowId(1, RowIdMapping.SINGLE_GEN));
-        assertEquals(1L, m.getNewRowId(2, RowIdMapping.SINGLE_GEN));
+        assertEquals(2L, m.getNewRowId(0));
+        assertEquals(0L, m.getNewRowId(1));
+        assertEquals(1L, m.getNewRowId(2));
         assertEquals(3, m.size());
     }
 
-    public void testSingleGenWithReverseSupport() {
+    public void testWithReverseSupport() {
         long[] mapping = { 2, 0, 1 };
         PackedRowIdMapping m = new PackedRowIdMapping(mapping, true);
-
         assertTrue(m.isNewToOldSupported());
-        // forward: old 0 -> new 2, old 1 -> new 0, old 2 -> new 1
-        assertEquals(2L, m.getNewRowId(0, RowIdMapping.SINGLE_GEN));
-        assertEquals(0L, m.getNewRowId(1, RowIdMapping.SINGLE_GEN));
-        assertEquals(1L, m.getNewRowId(2, RowIdMapping.SINGLE_GEN));
-
-        // reverse: new 0 -> old 1, new 1 -> old 2, new 2 -> old 0
+        assertEquals(2L, m.getNewRowId(0));
+        assertEquals(0L, m.getNewRowId(1));
+        assertEquals(1L, m.getNewRowId(2));
         assertEquals(1L, m.getOldRowId(0));
         assertEquals(2L, m.getOldRowId(1));
         assertEquals(0L, m.getOldRowId(2));
     }
 
     public void testReverseUnsupportedThrows() {
-        long[] mapping = { 0, 1 };
-        PackedRowIdMapping m = new PackedRowIdMapping(mapping, false);
-
+        PackedRowIdMapping m = new PackedRowIdMapping(new long[] { 0, 1 }, false);
         assertFalse(m.isNewToOldSupported());
         expectThrows(UnsupportedOperationException.class, () -> m.getOldRowId(0));
     }
 
-    public void testMultiGenerationLookup() {
-        // gen=1 (3 rows at offset 0): 0->4, 1->3, 2->2
-        // gen=2 (2 rows at offset 3): 0->1, 1->0
-        long[] mappingArray = { 4, 3, 2, 1, 0 };
-        Map<Long, Integer> offsets = Map.of(1L, 0, 2L, 3);
-        Map<Long, Integer> sizes = Map.of(1L, 3, 2L, 2);
-
-        PackedRowIdMapping m = new PackedRowIdMapping(mappingArray, offsets, sizes);
-
-        assertEquals(4L, m.getNewRowId(0, 1L));
-        assertEquals(3L, m.getNewRowId(1, 1L));
-        assertEquals(2L, m.getNewRowId(2, 1L));
-        assertEquals(1L, m.getNewRowId(0, 2L));
-        assertEquals(0L, m.getNewRowId(1, 2L));
-        assertEquals(5, m.size());
-    }
-
-    public void testUnknownGenerationReturnsNegativeOne() {
-        long[] mappingArray = { 0 };
-        PackedRowIdMapping m = new PackedRowIdMapping(mappingArray, Map.of(1L, 0), Map.of(1L, 1));
-        assertEquals(-1L, m.getNewRowId(0, 99L));
-    }
-
-    public void testOutOfBoundsRowIdReturnsNegativeOne() {
-        long[] mappingArray = { 5, 6 };
-        PackedRowIdMapping m = new PackedRowIdMapping(mappingArray, Map.of(1L, 0), Map.of(1L, 2));
-        assertEquals(-1L, m.getNewRowId(2, 1L));
-        assertEquals(-1L, m.getNewRowId(-1, 1L));
+    public void testOutOfBoundsReturnsNegativeOne() {
+        PackedRowIdMapping m = new PackedRowIdMapping(new long[] { 5, 6 }, false);
+        assertEquals(-1L, m.getNewRowId(2));
+        assertEquals(-1L, m.getNewRowId(-1));
     }
 
     public void testReverseOutOfBoundsReturnsNegativeOne() {
-        long[] mapping = { 1, 0 };
-        PackedRowIdMapping m = new PackedRowIdMapping(mapping, true);
+        PackedRowIdMapping m = new PackedRowIdMapping(new long[] { 1, 0 }, true);
         assertEquals(-1L, m.getOldRowId(-1));
         assertEquals(-1L, m.getOldRowId(2));
     }
 
-    public void testGenerationSize() {
-        long[] mappingArray = { 0, 1, 2, 3, 4 };
-        Map<Long, Integer> offsets = Map.of(1L, 0, 2L, 3);
-        Map<Long, Integer> sizes = Map.of(1L, 3, 2L, 2);
-
-        PackedRowIdMapping m = new PackedRowIdMapping(mappingArray, offsets, sizes);
-        assertEquals(3, m.getGenerationSize(1L));
-        assertEquals(2, m.getGenerationSize(2L));
-        assertEquals(0, m.getGenerationSize(99L));
-    }
-
     public void testRamBytesUsedPositive() {
-        long[] mappingArray = new long[100];
-        for (int i = 0; i < 100; i++) {
-            mappingArray[i] = i;
-        }
-        PackedRowIdMapping m = new PackedRowIdMapping(mappingArray, false);
+        long[] arr = new long[100];
+        for (int i = 0; i < 100; i++) arr[i] = i;
+        PackedRowIdMapping m = new PackedRowIdMapping(arr, false);
         assertTrue(m.ramBytesUsed() > 0);
     }
 
     public void testRamBytesUsedWithReverse() {
-        long[] mappingArray = { 1, 0 };
-        PackedRowIdMapping withReverse = new PackedRowIdMapping(mappingArray, true);
-        PackedRowIdMapping withoutReverse = new PackedRowIdMapping(mappingArray, false);
+        PackedRowIdMapping withReverse = new PackedRowIdMapping(new long[] { 1, 0 }, true);
+        PackedRowIdMapping withoutReverse = new PackedRowIdMapping(new long[] { 1, 0 }, false);
         assertTrue(withReverse.ramBytesUsed() > withoutReverse.ramBytesUsed());
     }
 
     public void testEmptyMapping() {
-        long[] mappingArray = {};
-        PackedRowIdMapping m = new PackedRowIdMapping(mappingArray, Map.of(), Map.of());
+        PackedRowIdMapping m = new PackedRowIdMapping(new long[] {}, false);
         assertEquals(0, m.size());
-        assertEquals(-1L, m.getNewRowId(0, 1L));
+        assertEquals(-1L, m.getNewRowId(0));
     }
 
-    public void testNullArgumentsThrow() {
-        expectThrows(NullPointerException.class, () -> new PackedRowIdMapping(null, Map.of(), Map.of()));
-        expectThrows(NullPointerException.class, () -> new PackedRowIdMapping(new long[0], null, Map.of()));
-        expectThrows(NullPointerException.class, () -> new PackedRowIdMapping(new long[0], Map.of(), null));
+    public void testNullForwardThrows() {
+        expectThrows(NullPointerException.class, () -> new PackedRowIdMapping(null, false));
     }
 
-    public void testGetGenerationOffsets() {
-        long[] mappingArray = { 0, 1 };
-        Map<Long, Integer> offsets = Map.of(1L, 0);
-        Map<Long, Integer> sizes = Map.of(1L, 2);
-        PackedRowIdMapping m = new PackedRowIdMapping(mappingArray, offsets, sizes);
-
-        assertEquals(Map.of(1L, 0), m.getGenerationOffsets());
-        expectThrows(UnsupportedOperationException.class, () -> m.getGenerationOffsets().put(2L, 1));
+    public void testPackedLongValuesConstructorWithReverse() {
+        PackedLongValues.Builder fwd = PackedLongValues.packedBuilder(PackedInts.DEFAULT);
+        fwd.add(2); fwd.add(0); fwd.add(1);
+        PackedLongValues.Builder rev = PackedLongValues.packedBuilder(PackedInts.DEFAULT);
+        rev.add(1); rev.add(2); rev.add(0);
+        PackedRowIdMapping m = new PackedRowIdMapping(fwd.build(), rev.build());
+        assertTrue(m.isNewToOldSupported());
+        assertEquals(3, m.size());
+        assertEquals(2L, m.getNewRowId(0));
+        assertEquals(1L, m.getOldRowId(0));
     }
 
-    public void testGetGenerationSizes() {
-        long[] mappingArray = { 0, 1 };
-        Map<Long, Integer> offsets = Map.of(1L, 0);
-        Map<Long, Integer> sizes = Map.of(1L, 2);
-        PackedRowIdMapping m = new PackedRowIdMapping(mappingArray, offsets, sizes);
-
-        assertEquals(Map.of(1L, 2), m.getGenerationSizes());
-        expectThrows(UnsupportedOperationException.class, () -> m.getGenerationSizes().put(2L, 1));
+    public void testPackedLongValuesConstructorForwardOnly() {
+        PackedLongValues.Builder fwd = PackedLongValues.packedBuilder(PackedInts.DEFAULT);
+        fwd.add(4); fwd.add(3); fwd.add(2);
+        PackedRowIdMapping m = new PackedRowIdMapping(fwd.build(), null);
+        assertFalse(m.isNewToOldSupported());
+        assertEquals(4L, m.getNewRowId(0));
+        expectThrows(UnsupportedOperationException.class, () -> m.getOldRowId(0));
     }
 
-    public void testToStringContainsInfo() {
-        long[] mappingArray = { 0, 1, 2 };
-        PackedRowIdMapping m = new PackedRowIdMapping(mappingArray, Map.of(1L, 0), Map.of(1L, 3));
-        String str = m.toString();
-        assertTrue(str.contains("size=3"));
-        assertTrue(str.contains("generations=1"));
+    public void testNullPackedLongValuesForwardThrows() {
+        expectThrows(NullPointerException.class, () -> new PackedRowIdMapping((PackedLongValues) null, null));
+    }
+
+    public void testToString() {
+        PackedRowIdMapping m = new PackedRowIdMapping(new long[] { 0, 1, 2 }, false);
+        assertTrue(m.toString().contains("size=3"));
     }
 }

--- a/server/src/test/java/org/opensearch/index/engine/dataformat/PackedRowIdMappingTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/dataformat/PackedRowIdMappingTests.java
@@ -12,14 +12,10 @@ import org.apache.lucene.util.packed.PackedInts;
 import org.apache.lucene.util.packed.PackedLongValues;
 import org.opensearch.test.OpenSearchTestCase;
 
-/**
- * Tests for {@link PackedRowIdMapping}.
- */
 public class PackedRowIdMappingTests extends OpenSearchTestCase {
 
     public void testForwardLookup() {
-        long[] mapping = { 2, 0, 1 };
-        PackedRowIdMapping m = new PackedRowIdMapping(mapping, false);
+        PackedRowIdMapping m = new PackedRowIdMapping(new long[] { 2, 0, 1 }, false);
         assertEquals(2L, m.getNewRowId(0));
         assertEquals(0L, m.getNewRowId(1));
         assertEquals(1L, m.getNewRowId(2));
@@ -27,12 +23,9 @@ public class PackedRowIdMappingTests extends OpenSearchTestCase {
     }
 
     public void testWithReverseSupport() {
-        long[] mapping = { 2, 0, 1 };
-        PackedRowIdMapping m = new PackedRowIdMapping(mapping, true);
+        PackedRowIdMapping m = new PackedRowIdMapping(new long[] { 2, 0, 1 }, true);
         assertTrue(m.isNewToOldSupported());
         assertEquals(2L, m.getNewRowId(0));
-        assertEquals(0L, m.getNewRowId(1));
-        assertEquals(1L, m.getNewRowId(2));
         assertEquals(1L, m.getOldRowId(0));
         assertEquals(2L, m.getOldRowId(1));
         assertEquals(0L, m.getOldRowId(2));
@@ -44,68 +37,54 @@ public class PackedRowIdMappingTests extends OpenSearchTestCase {
         expectThrows(UnsupportedOperationException.class, () -> m.getOldRowId(0));
     }
 
-    public void testOutOfBoundsReturnsNegativeOne() {
+    public void testOutOfBounds() {
         PackedRowIdMapping m = new PackedRowIdMapping(new long[] { 5, 6 }, false);
         assertEquals(-1L, m.getNewRowId(2));
         assertEquals(-1L, m.getNewRowId(-1));
     }
 
-    public void testReverseOutOfBoundsReturnsNegativeOne() {
+    public void testReverseOutOfBounds() {
         PackedRowIdMapping m = new PackedRowIdMapping(new long[] { 1, 0 }, true);
         assertEquals(-1L, m.getOldRowId(-1));
         assertEquals(-1L, m.getOldRowId(2));
     }
 
-    public void testRamBytesUsedPositive() {
-        long[] arr = new long[100];
-        for (int i = 0; i < 100; i++) arr[i] = i;
-        PackedRowIdMapping m = new PackedRowIdMapping(arr, false);
-        assertTrue(m.ramBytesUsed() > 0);
-    }
-
-    public void testRamBytesUsedWithReverse() {
-        PackedRowIdMapping withReverse = new PackedRowIdMapping(new long[] { 1, 0 }, true);
-        PackedRowIdMapping withoutReverse = new PackedRowIdMapping(new long[] { 1, 0 }, false);
-        assertTrue(withReverse.ramBytesUsed() > withoutReverse.ramBytesUsed());
-    }
-
-    public void testEmptyMapping() {
+    public void testEmpty() {
         PackedRowIdMapping m = new PackedRowIdMapping(new long[] {}, false);
         assertEquals(0, m.size());
         assertEquals(-1L, m.getNewRowId(0));
     }
 
-    public void testNullForwardThrows() {
+    public void testNullThrows() {
         expectThrows(NullPointerException.class, () -> new PackedRowIdMapping(null, false));
     }
 
-    public void testPackedLongValuesConstructorWithReverse() {
+    public void testPackedLongValuesConstructor() {
         PackedLongValues.Builder fwd = PackedLongValues.packedBuilder(PackedInts.DEFAULT);
-        fwd.add(2); fwd.add(0); fwd.add(1);
+        fwd.add(2);
+        fwd.add(0);
+        fwd.add(1);
         PackedLongValues.Builder rev = PackedLongValues.packedBuilder(PackedInts.DEFAULT);
-        rev.add(1); rev.add(2); rev.add(0);
+        rev.add(1);
+        rev.add(2);
+        rev.add(0);
         PackedRowIdMapping m = new PackedRowIdMapping(fwd.build(), rev.build());
         assertTrue(m.isNewToOldSupported());
-        assertEquals(3, m.size());
         assertEquals(2L, m.getNewRowId(0));
         assertEquals(1L, m.getOldRowId(0));
     }
 
-    public void testPackedLongValuesConstructorForwardOnly() {
+    public void testPackedLongValuesForwardOnly() {
         PackedLongValues.Builder fwd = PackedLongValues.packedBuilder(PackedInts.DEFAULT);
-        fwd.add(4); fwd.add(3); fwd.add(2);
+        fwd.add(4);
+        fwd.add(3);
         PackedRowIdMapping m = new PackedRowIdMapping(fwd.build(), null);
         assertFalse(m.isNewToOldSupported());
         assertEquals(4L, m.getNewRowId(0));
-        expectThrows(UnsupportedOperationException.class, () -> m.getOldRowId(0));
     }
 
-    public void testNullPackedLongValuesForwardThrows() {
-        expectThrows(NullPointerException.class, () -> new PackedRowIdMapping((PackedLongValues) null, null));
-    }
-
-    public void testToString() {
-        PackedRowIdMapping m = new PackedRowIdMapping(new long[] { 0, 1, 2 }, false);
-        assertTrue(m.toString().contains("size=3"));
+    public void testRamBytesUsed() {
+        PackedRowIdMapping m = new PackedRowIdMapping(new long[] { 1, 0 }, true);
+        assertTrue(m.ramBytesUsed() > 0);
     }
 }

--- a/test/framework/src/main/java/org/opensearch/index/engine/dataformat/stub/MockMerger.java
+++ b/test/framework/src/main/java/org/opensearch/index/engine/dataformat/stub/MockMerger.java
@@ -42,9 +42,9 @@ public class MockMerger implements Merger {
             fileMetadataList.addAll(segment.dfGroupedSearchableFiles().values());
         }
         long newWriterGeneration = mergeInput.newWriterGeneration();
-        RowIdMapping existingMapping = mergeInput.rowIdMapping();
+        Map<Long, RowIdMapping> existingMappings = mergeInput.rowIdMappings();
 
-        String prefix = existingMapping != null ? "secondary_merged_gen" : "merged_gen";
+        String prefix = (existingMappings != null && !existingMappings.isEmpty()) ? "secondary_merged_gen" : "merged_gen";
         WriterFileSet merged = WriterFileSet.builder()
             .directory(directory)
             .writerGeneration(newWriterGeneration)
@@ -52,26 +52,23 @@ public class MockMerger implements Merger {
             .addNumRows(fileMetadataList.stream().mapToLong(WriterFileSet::numRows).sum())
             .build();
 
-        if (existingMapping != null) {
-            return new MergeResult(Map.of(dataFormat, merged), existingMapping);
+        if (existingMappings != null && !existingMappings.isEmpty()) {
+            return new MergeResult(Map.of(dataFormat, merged), existingMappings);
         }
 
-        Map<Long, Long> genOffsets = new HashMap<>();
-        Map<Long, Integer> genOffsetsInt = new HashMap<>();
-        Map<Long, Integer> genSizesInt = new HashMap<>();
-        int offset = 0;
+        // Build one PackedRowIdMapping per generation with global row ID assignment
+        Map<Long, RowIdMapping> mappings = new HashMap<>();
+        int globalOffset = 0;
         for (WriterFileSet fs : fileMetadataList) {
-            genOffsets.put(fs.writerGeneration(), (long) offset);
-            genOffsetsInt.put(fs.writerGeneration(), offset);
-            genSizesInt.put(fs.writerGeneration(), (int) fs.numRows());
-            offset += (int) fs.numRows();
+            int size = (int) fs.numRows();
+            long[] mappingArray = new long[size];
+            for (int i = 0; i < size; i++) {
+                mappingArray[i] = globalOffset + i;
+            }
+            mappings.put(fs.writerGeneration(), new PackedRowIdMapping(mappingArray, false));
+            globalOffset += size;
         }
-        long[] mappingArray = new long[offset];
-        for (int i = 0; i < offset; i++) {
-            mappingArray[i] = i;
-        }
-        RowIdMapping mapping = new PackedRowIdMapping(mappingArray, genOffsetsInt, genSizesInt);
 
-        return new MergeResult(Map.of(dataFormat, merged), mapping);
+        return new MergeResult(Map.of(dataFormat, merged), mappings);
     }
 }


### PR DESCRIPTION
<h3>Description</h3>
<p>This PR simplifies the <code>RowIdMapping</code> abstraction from a multi-generation monolith to a per-generation model, and eliminates unnecessary heap allocations when constructing mappings from native memory.</p>
<h4>Commit 1: Single-generation RowIdMapping</h4>
<p>Previously, <code>PackedRowIdMapping</code> stored mappings for <em>all</em> generations in a single flat array with <code>Map&lt;Long, Integer&gt;</code> offset/size lookups per generation. This made the class complex, harder to reason about, and coupled the mapping lifecycle to the merge coordinator.</p>
<p>Now, each <code>PackedRowIdMapping</code> represents exactly one generation. Callers maintain a <code>Map&lt;Long, RowIdMapping&gt;</code> externally. This:</p>
<ul>
<li>Removes <code>generationOffsets</code>, <code>generationSizes</code>, and the multi-gen constructor</li>
<li>Simplifies <code>getNewRowId(oldId, generation)</code> → <code>getNewRowId(oldId)</code> (no offset arithmetic)</li>
<li>Makes each mapping independently GC-able when its generation is no longer needed</li>
<li>Aligns <code>MergeInput</code> and <code>MergeResult</code> to use <code>Map&lt;Long, RowIdMapping&gt;</code> instead of a single monolithic mapping</li>
</ul>
<pre><code>

┌────────────────────────────────────────────────────────────┐
│                    BEFORE: Monolithic mapping              │
├────────────────────────────────────────────────────────────┤
│                                                            │
│  PackedRowIdMapping                                        │
│  ┌────────────────────────────────────────────────────────┐│
│  │ flat array: [gen5_row0, gen5_row1, gen0_row0, ... ]    ││
│  │ generationOffsets: {5→0, 0→2, 3→5}                     ││
│  │ generationSizes:   {5→2, 0→3, 3→1}                     ││
│  └────────────────────────────────────────────────────────┘│
│                                                            │
│  Lookup: mapping.get(offsets.get(gen) + oldRowId)          │
│  Problem: all generations coupled, can't GC individually   │
│                                                            │
└────────────────────────────────────────────────────────────
┌────────────────────────────────────────────────────────────┐
│                    AFTER: Per-generation mapping           │
├────────────────────────────────────────────────────────────┤
│                                                            │
│  Map<Long, RowIdMapping>                                   │
│  ┌──────────┐  ┌──────────┐  ┌──────────┐                  │
│  │ gen=5    │  │ gen=0    │  │ gen=3    │                  │
│  │ [0→2,    │  │ [0→0,    │  │ [0→5]    │                  │
│  │  1→3]    │  │  1→4,    │  └──────────┘                  │
│  └──────────┘  │  2→1]    │                                │
│                └──────────┘                                │
│                                                            │
│  Lookup: mappings.get(gen).getNewRowId(oldRowId)           │
│  Benefit: simple, independently GC-able, no offset math    │
│                                                            │
└────────────────────────────────────────────────────────────┘



</code></pre>
<h4>Commit 2: Avoid intermediate long[] allocation in RustBridge</h4>
<p>With the single-generation model in place, the RustBridge code that reads permutation arrays from native memory was further optimized:</p>

### Constraints

These are the constraints we are observing while considering this approach. Even though better alternates are there, we are considering this as this approach is meeting all these constraints. 

1. **Placement**: `MemorySegment`/`Arena` (FFM API) lives in `sandbox/libs/dataformat-native` and `sandbox/plugins/parquet-data-format`. The `server` module cannot use these APIs.
2. **Java 21 in server**: `java.lang.foreign.*` is a preview API in Java 21. The server module compiles without `--enable-preview`. Only sandbox modules can use FFM.
3. **Lifecycle**: We don't want to hold native memory for extended periods. The ideal is: cross the boundary, consume the data, release immediately.
4. **Compression**: Uncompressed `long[]` in native memory is 8 bytes/entry. `PackedLongValues` can compress to 2-4 bytes/entry for typical permutation values. For a 10M-row mapping, that's 80MB vs 20-40MB.

### Approach: 

<p><strong>Before:</strong> <code>MemorySegment.toArray(JAVA_LONG)</code> bulk-copied the entire native permutation into a heap <code>long[]</code>, which was then passed to <code>PackedRowIdMapping(long[], true)</code> — the constructor iterated it <em>again</em> to build <code>PackedLongValues</code>.</p>
<p><strong>After:</strong> Reads element-by-element from the native <code>MemorySegment</code> directly into <code>PackedLongValues.Builder</code>. A new constructor <code>PackedRowIdMapping(PackedLongValues, PackedLongValues)</code> accepts pre-built packed values, eliminating the intermediate <code>long[]</code>.</p>
<pre><code>
┌──────────────────────────────────────────────────────────────────┐
│                    BEFORE: Bulk copy path                        │
├──────────────────────────────────────────────────────────────────┤
│                                                                  │
│  Native Memory              Java Heap                            │
│  ┌──────────┐    toArray    ┌─────────────┐                      │
│  │ Rust     │ ────────────► │ long[N]     │  (8N bytes)          │
│  │ permut.  │               └──────┬──────┘                      │
│  └──────────┘                      │                             │
│                                    ▼                             │
│                     PackedRowIdMapping(long[], true)             │
│                                    │                             │
│                           ┌────────┴────────┐                    │
│                           ▼                 ▼                    │
│                    ┌────────────┐    ┌────────────┐              │
│                    │ long[N]    │    │ PackedLong │              │
│                    │ (reverse)  │    │ Values     │              │
│                    │ 8N bytes   │    │ ~3N bytes  │              │
│                    └─────┬─────-┘    └────────────┘              │
│                          ▼                                       │
│                    ┌────────────┐                                │
│                    │ PackedLong │                                │
│                    │ Values     │                                │
│                    │ ~3N bytes  │                                │
│                    └────────────┘                                │
│                                                                  │
│  Peak heap: 8N + 8N + ~3N + ~3N ≈ 22N bytes                      │
└──────────────────────────────────────────────────────────────────┘

┌──────────────────────────────────────────────────────────────────┐
│                    AFTER: Element-wise path                      │
├──────────────────────────────────────────────────────────────────┤
│                                                                  │
│  Native Memory              Java Heap                            │
│  ┌──────────┐    get(i)     ┌─────────────┐                      │
│  │ Rust     │ ────────────► │ PackedLong  │  (~3N bytes)         │
│  │ permut.  │               │ Values.Bldr │                      │
│  └──────────┘               └─────────────┘                      │
│       │                                                          │
│       │         get(i)      ┌─────────────┐                      │
│       └────────────────────►│ long[N]     │  (8N bytes, reverse) │
│                             └──────┬──────┘                      │
│                                    ▼                             │
│                             ┌─────────────┐                      │
│                             │ PackedLong  │  (~3N bytes)         │
│                             │ Values.Bldr │                      │
│                             └─────────────┘                      │
│                                                                  │
│  Peak heap: 8N + ~3N + ~3N ≈ 14N bytes                           │
└──────────────────────────────────────────────────────────────────┘

</code></pre>
<h3>JMH Benchmark Results (<code>-prof gc</code>)</h3>

Size | Old Alloc (B/op) | New Alloc (B/op) | Reduction
-- | -- | -- | --
100K | 2,103,893 | 1,303,822 | 38%
1M | 21,781,148 | 13,780,248 | 37%
5M | 112,532,336 | 72,525,763 | 36%


<p>At 5M entries, this saves ~38 MB of heap per flush and reduces GC events from 543 → 197.</p>
</body></html>


### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
