### PR TITLE
Drop unused/mis-scoped deps in sandbox plugins

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/build.gradle
+++ b/sandbox/plugins/analytics-backend-datafusion/build.gradle
@@ -50,7 +50,6 @@ dependencies {
   compileOnly project(':sandbox:plugins:analytics-engine')
 
   compileOnly "org.apache.logging.log4j:log4j-api:${versions.log4j}"
-  compileOnly "org.apache.logging.log4j:log4j-core:${versions.log4j}"
 
   // Apache Arrow dependencies.
   // arrow-vector + arrow-memory-core + arrow-format + flatbuffers are provided at runtime
@@ -58,7 +57,9 @@ dependencies {
   // and license files.
   compileOnly "org.apache.arrow:arrow-vector:${versions.arrow}"
   compileOnly "org.apache.arrow:arrow-memory-core:${versions.arrow}"
-  compileOnly "org.apache.arrow:arrow-memory-unsafe:${versions.arrow}"
+  // Unit tests run on a flat classpath, so arrow-memory-core needs an AllocationManager
+  // available via ServiceLoader. Pull arrow-memory-unsafe back in at test runtime.
+  testRuntimeOnly "org.apache.arrow:arrow-memory-unsafe:${versions.arrow}"
   implementation "org.apache.arrow:arrow-c-data:${versions.arrow}"
   compileOnly "org.apache.arrow:arrow-format:${versions.arrow}"
   compileOnly "com.google.flatbuffers:flatbuffers-java:${versions.flatbuffers}"
@@ -75,6 +76,7 @@ dependencies {
   // avatica ByteString is needed at compile time for IpBinaryFunctionAdapter's VARBINARY
   // literal construction; runtime is provided by analytics-framework's runtimeOnly avatica.
   compileOnly "org.apache.calcite.avatica:avatica-core:1.27.0"
+  // substrait-core's DefaultExtensionCatalog <clinit> registers jackson's Jdk8Module via ObjectMapper.
   implementation "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:${versions.jackson}"
   // jackson-datatype-jsr310 — added to arrow-flight-rpc (the parent plugin that bundles
   // arrow-vector). arrow-vector's JsonStringArrayList eagerly registers JavaTimeModule on

--- a/sandbox/plugins/analytics-backend-lucene/build.gradle
+++ b/sandbox/plugins/analytics-backend-lucene/build.gradle
@@ -37,11 +37,6 @@ dependencies {
 
     // Guava for test compilation — Calcite API exposes guava types
     calciteTestCompile "com.google.guava:guava:${versions.guava}"
-    testRuntimeOnly "com.google.guava:guava:${versions.guava}"
-    testRuntimeOnly 'com.google.guava:failureaccess:1.0.2'
-
-    // Calcite annotation compatibility
-    testCompileOnly 'org.immutables:value-annotations:2.8.8'
 }
 
 test {


### PR DESCRIPTION
## Summary

Dependency audit of sandbox plugins — remove unused declarations and fix mis-scoped ones.

- **analytics-backend-datafusion**: Drop redundant `log4j-core compileOnly` (PluginBuildPlugin already provides it). Rescope `arrow-memory-unsafe` from `compileOnly` to `testRuntimeOnly` (needed by ServiceLoader under flat test classpath, not used in main code). Add WHY comment on `jackson-datatype-jdk8` (substrait-core `<clinit>` loads `Jdk8Module`).
- **analytics-backend-lucene**: Drop `testRuntimeOnly guava + failureaccess` (already on `testRuntimeClasspath` via `testImplementation analytics-engine` → `api analytics-framework` → `runtimeOnly guava`). Drop `testCompileOnly immutables value-annotations` (zero test usage, stale comment).

## Test plan

- [x] `./gradlew :sandbox:plugins:analytics-backend-datafusion:precommit` — PASS
- [x] `./gradlew :sandbox:plugins:analytics-backend-datafusion:test` — PASS (all 200+ tests)
- [x] `./gradlew :sandbox:plugins:analytics-backend-lucene:precommit` — PASS
- [x] `./gradlew :sandbox:plugins:analytics-backend-lucene:test` — PASS
- [x] `dependencyInsight` confirms arrow-memory-unsafe and guava reach `testRuntimeClasspath` via correct paths
- [x] Plugin zip contents unchanged (no accidental bundling)