### PR TITLE
Fix for converting SQL wildcard to Lucene syntax

### DIFF
--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/WildcardQuerySerializer.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/WildcardQuerySerializer.java
@@ -33,7 +33,8 @@ public class WildcardQuerySerializer extends AbstractRelevanceSerializer {
 
     /**
      * Converts SQL wildcard characters (% and _) to Lucene wildcard characters (* and ?).
-     * Escaped wildcards (\\% and \\_) are treated as literal characters.
+     * Escaped wildcards (\% and \_) are treated as literal characters.
+     * A backslash escaping another backslash (\\) produces a literal backslash.
      */
     private static String convertSqlWildcardToLucene(String text) {
         final char ESCAPE = '\\';
@@ -41,33 +42,36 @@ public class WildcardQuerySerializer extends AbstractRelevanceSerializer {
         boolean escaped = false;
 
         for (char c : text.toCharArray()) {
-            switch (c) {
-                case ESCAPE:
-                    escaped = true;
-                    result.append(c);
-                    break;
-                case '%':
-                    if (escaped) {
-                        result.deleteCharAt(result.length() - 1);
+            if (escaped) {
+                switch (c) {
+                    case '%':
                         result.append('%');
-                    } else {
-                        result.append('*');
-                    }
-                    escaped = false;
-                    break;
-                case '_':
-                    if (escaped) {
-                        result.deleteCharAt(result.length() - 1);
+                        break;
+                    case '_':
                         result.append('_');
-                    } else {
-                        result.append('?');
-                    }
-                    escaped = false;
-                    break;
-                default:
-                    result.append(c);
-                    escaped = false;
+                        break;
+                    case ESCAPE:
+                        result.append(ESCAPE);
+                        break;
+                    default:
+                        result.append(ESCAPE);
+                        result.append(c);
+                        break;
+                }
+                escaped = false;
+            } else if (c == ESCAPE) {
+                escaped = true;
+            } else if (c == '%') {
+                result.append('*');
+            } else if (c == '_') {
+                result.append('?');
+            } else {
+                result.append(c);
             }
+        }
+        // Trailing backslash with nothing to escape — preserve it
+        if (escaped) {
+            result.append(ESCAPE);
         }
         return result.toString();
     }

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/WildcardQuerySerializer.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/WildcardQuerySerializer.java
@@ -27,7 +27,49 @@ public class WildcardQuerySerializer extends AbstractRelevanceSerializer {
 
     @Override
     protected QueryBuilder createQueryBuilder(ConversionUtils.RelevanceOperands operands) {
-        return new WildcardQueryBuilder(operands.fieldName(), operands.query());
+        String convertedPattern = convertSqlWildcardToLucene(operands.query());
+        return new WildcardQueryBuilder(operands.fieldName(), convertedPattern);
+    }
+
+    /**
+     * Converts SQL wildcard characters (% and _) to Lucene wildcard characters (* and ?).
+     * Escaped wildcards (\\% and \\_) are treated as literal characters.
+     */
+    private static String convertSqlWildcardToLucene(String text) {
+        final char ESCAPE = '\\';
+        StringBuilder result = new StringBuilder(text.length());
+        boolean escaped = false;
+
+        for (char c : text.toCharArray()) {
+            switch (c) {
+                case ESCAPE:
+                    escaped = true;
+                    result.append(c);
+                    break;
+                case '%':
+                    if (escaped) {
+                        result.deleteCharAt(result.length() - 1);
+                        result.append('%');
+                    } else {
+                        result.append('*');
+                    }
+                    escaped = false;
+                    break;
+                case '_':
+                    if (escaped) {
+                        result.deleteCharAt(result.length() - 1);
+                        result.append('_');
+                    } else {
+                        result.append('?');
+                    }
+                    escaped = false;
+                    break;
+                default:
+                    result.append(c);
+                    escaped = false;
+            }
+        }
+        return result.toString();
     }
 
     @Override

--- a/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/QuerySerializerRegistryTests.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/QuerySerializerRegistryTests.java
@@ -483,6 +483,65 @@ public class QuerySerializerRegistryTests extends OpenSearchTestCase {
         }
     }
 
+    /**
+     * Tests that an escaped backslash (\\) followed by a wildcard correctly produces
+     * a literal backslash plus the converted wildcard.
+     */
+    public void testWildcardQueryEscapedBackslashFollowedByWildcard() throws IOException {
+        DelegatedPredicateSerializer serializer = serializers.get(ScalarFunction.WILDCARD_QUERY);
+        // Java string "\\\\%" is runtime chars: \, \, %
+        // Expected: first \ escapes second \ → literal \, then % is unescaped → *
+        RexCall call = buildSingleFieldRexCallWithParams("title", "\\\\%", "WILDCARD_QUERY", Map.of());
+        List<FieldStorageInfo> fieldStorage = List.of(
+            new FieldStorageInfo("title", "text", FieldType.TEXT, List.of(), List.of("lucene"), List.of(), false)
+        );
+
+        byte[] serialized = serializer.serialize(call, fieldStorage);
+
+        try (StreamInput input = new NamedWriteableAwareStreamInput(StreamInput.wrap(serialized), WRITEABLE_REGISTRY)) {
+            WildcardQueryBuilder wildcardQb = (WildcardQueryBuilder) input.readNamedWriteable(QueryBuilder.class);
+            assertEquals("\\*", wildcardQb.value());
+        }
+    }
+
+    /**
+     * Tests that a backslash before a non-wildcard character preserves both characters.
+     */
+    public void testWildcardQueryBackslashBeforeNonWildcard() throws IOException {
+        DelegatedPredicateSerializer serializer = serializers.get(ScalarFunction.WILDCARD_QUERY);
+        // Java string "\\n" is runtime chars: \, n
+        RexCall call = buildSingleFieldRexCallWithParams("title", "test\\n", "WILDCARD_QUERY", Map.of());
+        List<FieldStorageInfo> fieldStorage = List.of(
+            new FieldStorageInfo("title", "text", FieldType.TEXT, List.of(), List.of("lucene"), List.of(), false)
+        );
+
+        byte[] serialized = serializer.serialize(call, fieldStorage);
+
+        try (StreamInput input = new NamedWriteableAwareStreamInput(StreamInput.wrap(serialized), WRITEABLE_REGISTRY)) {
+            WildcardQueryBuilder wildcardQb = (WildcardQueryBuilder) input.readNamedWriteable(QueryBuilder.class);
+            assertEquals("test\\n", wildcardQb.value());
+        }
+    }
+
+    /**
+     * Tests that a trailing backslash is preserved in the output.
+     */
+    public void testWildcardQueryTrailingBackslash() throws IOException {
+        DelegatedPredicateSerializer serializer = serializers.get(ScalarFunction.WILDCARD_QUERY);
+        // Java string "test\\" is runtime chars: t, e, s, t, \
+        RexCall call = buildSingleFieldRexCallWithParams("title", "test\\", "WILDCARD_QUERY", Map.of());
+        List<FieldStorageInfo> fieldStorage = List.of(
+            new FieldStorageInfo("title", "text", FieldType.TEXT, List.of(), List.of("lucene"), List.of(), false)
+        );
+
+        byte[] serialized = serializer.serialize(call, fieldStorage);
+
+        try (StreamInput input = new NamedWriteableAwareStreamInput(StreamInput.wrap(serialized), WRITEABLE_REGISTRY)) {
+            WildcardQueryBuilder wildcardQb = (WildcardQueryBuilder) input.readNamedWriteable(QueryBuilder.class);
+            assertEquals("test\\", wildcardQb.value());
+        }
+    }
+
     // --- QuerySerializer (no-field) tests ---
 
     /**

--- a/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/QuerySerializerRegistryTests.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/QuerySerializerRegistryTests.java
@@ -391,6 +391,98 @@ public class QuerySerializerRegistryTests extends OpenSearchTestCase {
         }
     }
 
+    // --- SQL-to-Lucene wildcard conversion tests ---
+
+    /**
+     * Tests that SQL '%' wildcard is converted to Lucene '*'.
+     */
+    public void testWildcardQueryConvertsPercentToStar() throws IOException {
+        DelegatedPredicateSerializer serializer = serializers.get(ScalarFunction.WILDCARD_QUERY);
+        RexCall call = buildSingleFieldRexCallWithParams("title", "test%", "WILDCARD_QUERY", Map.of());
+        List<FieldStorageInfo> fieldStorage = List.of(
+            new FieldStorageInfo("title", "text", FieldType.TEXT, List.of(), List.of("lucene"), List.of(), false)
+        );
+
+        byte[] serialized = serializer.serialize(call, fieldStorage);
+
+        try (StreamInput input = new NamedWriteableAwareStreamInput(StreamInput.wrap(serialized), WRITEABLE_REGISTRY)) {
+            WildcardQueryBuilder wildcardQb = (WildcardQueryBuilder) input.readNamedWriteable(QueryBuilder.class);
+            assertEquals("test*", wildcardQb.value());
+        }
+    }
+
+    /**
+     * Tests that SQL '_' wildcard is converted to Lucene '?'.
+     */
+    public void testWildcardQueryConvertsUnderscoreToQuestionMark() throws IOException {
+        DelegatedPredicateSerializer serializer = serializers.get(ScalarFunction.WILDCARD_QUERY);
+        RexCall call = buildSingleFieldRexCallWithParams("title", "te_t", "WILDCARD_QUERY", Map.of());
+        List<FieldStorageInfo> fieldStorage = List.of(
+            new FieldStorageInfo("title", "text", FieldType.TEXT, List.of(), List.of("lucene"), List.of(), false)
+        );
+
+        byte[] serialized = serializer.serialize(call, fieldStorage);
+
+        try (StreamInput input = new NamedWriteableAwareStreamInput(StreamInput.wrap(serialized), WRITEABLE_REGISTRY)) {
+            WildcardQueryBuilder wildcardQb = (WildcardQueryBuilder) input.readNamedWriteable(QueryBuilder.class);
+            assertEquals("te?t", wildcardQb.value());
+        }
+    }
+
+    /**
+     * Tests that escaped SQL wildcards (\% and \_) are treated as literal characters.
+     */
+    public void testWildcardQueryEscapedWildcardsRemainLiteral() throws IOException {
+        DelegatedPredicateSerializer serializer = serializers.get(ScalarFunction.WILDCARD_QUERY);
+        RexCall call = buildSingleFieldRexCallWithParams("title", "100\\%\\_done", "WILDCARD_QUERY", Map.of());
+        List<FieldStorageInfo> fieldStorage = List.of(
+            new FieldStorageInfo("title", "text", FieldType.TEXT, List.of(), List.of("lucene"), List.of(), false)
+        );
+
+        byte[] serialized = serializer.serialize(call, fieldStorage);
+
+        try (StreamInput input = new NamedWriteableAwareStreamInput(StreamInput.wrap(serialized), WRITEABLE_REGISTRY)) {
+            WildcardQueryBuilder wildcardQb = (WildcardQueryBuilder) input.readNamedWriteable(QueryBuilder.class);
+            assertEquals("100%_done", wildcardQb.value());
+        }
+    }
+
+    /**
+     * Tests mixed SQL wildcards and escaped wildcards in a single pattern.
+     */
+    public void testWildcardQueryMixedEscapedAndUnescaped() throws IOException {
+        DelegatedPredicateSerializer serializer = serializers.get(ScalarFunction.WILDCARD_QUERY);
+        RexCall call = buildSingleFieldRexCallWithParams("title", "%foo\\_bar_", "WILDCARD_QUERY", Map.of());
+        List<FieldStorageInfo> fieldStorage = List.of(
+            new FieldStorageInfo("title", "text", FieldType.TEXT, List.of(), List.of("lucene"), List.of(), false)
+        );
+
+        byte[] serialized = serializer.serialize(call, fieldStorage);
+
+        try (StreamInput input = new NamedWriteableAwareStreamInput(StreamInput.wrap(serialized), WRITEABLE_REGISTRY)) {
+            WildcardQueryBuilder wildcardQb = (WildcardQueryBuilder) input.readNamedWriteable(QueryBuilder.class);
+            assertEquals("*foo_bar?", wildcardQb.value());
+        }
+    }
+
+    /**
+     * Tests that a pattern with no SQL wildcards passes through unchanged.
+     */
+    public void testWildcardQueryNoSqlWildcardsPassesThrough() throws IOException {
+        DelegatedPredicateSerializer serializer = serializers.get(ScalarFunction.WILDCARD_QUERY);
+        RexCall call = buildSingleFieldRexCallWithParams("title", "hello*world?", "WILDCARD_QUERY", Map.of());
+        List<FieldStorageInfo> fieldStorage = List.of(
+            new FieldStorageInfo("title", "text", FieldType.TEXT, List.of(), List.of("lucene"), List.of(), false)
+        );
+
+        byte[] serialized = serializer.serialize(call, fieldStorage);
+
+        try (StreamInput input = new NamedWriteableAwareStreamInput(StreamInput.wrap(serialized), WRITEABLE_REGISTRY)) {
+            WildcardQueryBuilder wildcardQb = (WildcardQueryBuilder) input.readNamedWriteable(QueryBuilder.class);
+            assertEquals("hello*world?", wildcardQb.value());
+        }
+    }
+
     // --- QuerySerializer (no-field) tests ---
 
     /**


### PR DESCRIPTION
Fix: SQL wildcard characters not converted to Lucene wildcards in WildcardQuerySerializer
  
#### Problem:
  
The WildcardQuerySerializer was passing SQL wildcard patterns directly to Lucene's WildcardQueryBuilder without conversion. SQL uses % (match any sequence) and _ (match
single character), but Lucene expects * and ? respectively. This caused the following integration tests to fail:

- test_escaping_wildcard_percent_in_text
- test_wildcard_query_sql_wildcard_underscore_conversion
- test_wildcard_query_sql_wildcard_percent_conversion
  
#### Root Cause:
  
createQueryBuilder() passed the raw query pattern to WildcardQueryBuilder without translating SQL wildcard syntax to Lucene wildcard syntax.
  
#### Fix:

Added convertSqlWildcardToLucene() which translates the pattern before query construction:
  
- % → *
- _ → ?
- \% → literal % (escaped, not a wildcard)
- \_ → literal _ (escaped, not a wildcard)
  
#### Testing:

Added 5 unit tests covering basic conversion, escape handling, mixed escaped/unescaped patterns, and passthrough of native Lucene wildcards.

### Related Issues
Resolves #21738

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
