### PR TITLE
Fix - Request-level slow logs and shard-level slow logs are now written to the same file

### DIFF
--- a/distribution/src/config/log4j2.properties
+++ b/distribution/src/config/log4j2.properties
@@ -117,14 +117,14 @@ logger.deprecation.additivity = false
 appender.search_request_slowlog_json_appender.type = RollingFile
 appender.search_request_slowlog_json_appender.name = search_request_slowlog_json_appender
 appender.search_request_slowlog_json_appender.fileName = ${sys:opensearch.logs.base_path}${sys:file.separator}${sys:opensearch.logs\
-  .cluster_name}_index_search_slowlog.json
+  .cluster_name}_search_request_slowlog.json
 appender.search_request_slowlog_json_appender.filePermissions = rw-r-----
 appender.search_request_slowlog_json_appender.layout.type = OpenSearchJsonLayout
 appender.search_request_slowlog_json_appender.layout.type_name = search_request_slowlog
 appender.search_request_slowlog_json_appender.layout.opensearchmessagefields=message,took,took_millis,phase_took,total_hits,search_type,shards,source,id
 
 appender.search_request_slowlog_json_appender.filePattern = ${sys:opensearch.logs.base_path}${sys:file.separator}${sys:opensearch.logs\
-  .cluster_name}_index_search_slowlog-%i.json.gz
+  .cluster_name}_search_request_slowlog-%i.json.gz
 appender.search_request_slowlog_json_appender.policies.type = Policies
 appender.search_request_slowlog_json_appender.policies.size.type = SizeBasedTriggeringPolicy
 appender.search_request_slowlog_json_appender.policies.size.size = 1GB
@@ -135,13 +135,13 @@ appender.search_request_slowlog_json_appender.strategy.max = 4
 appender.search_request_slowlog_log_appender.type = RollingFile
 appender.search_request_slowlog_log_appender.name = search_request_slowlog_log_appender
 appender.search_request_slowlog_log_appender.fileName = ${sys:opensearch.logs.base_path}${sys:file.separator}${sys:opensearch.logs.cluster_name}\
-  _index_search_slowlog.log
+  _search_request_slowlog.log
 appender.search_request_slowlog_log_appender.filePermissions = rw-r-----
 appender.search_request_slowlog_log_appender.layout.type = PatternLayout
 appender.search_request_slowlog_log_appender.layout.pattern = [%d{ISO8601}][%-5p][%c{1.}] [%node_name]%marker %m%n
 
 appender.search_request_slowlog_log_appender.filePattern = ${sys:opensearch.logs.base_path}${sys:file.separator}${sys:opensearch.logs.cluster_name}\
-  _index_search_slowlog-%i.log.gz
+  _search_request_slowlog-%i.log.gz
 appender.search_request_slowlog_log_appender.policies.type = Policies
 appender.search_request_slowlog_log_appender.policies.size.type = SizeBasedTriggeringPolicy
 appender.search_request_slowlog_log_appender.policies.size.size = 1GB


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Problem : The default distribution of log4j files config makes request-level slow logs and shard-level slow logs are written to the same file, named opensearch_index_search_slowlog.log
This makes request level slow logs hard to read.
Fix: Separate the log file names

### Related Issues
Resolves #21679
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
