### PR TITLE
[Analytics Backend] Timechart route end-to-end closure (1/30 → 30/30)

### DIFF
--- a/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/ScalarFunction.java
+++ b/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/ScalarFunction.java
@@ -228,6 +228,24 @@ public enum ScalarFunction {
     DATE_FORMAT(Category.SCALAR, SqlKind.OTHER_FUNCTION),
     TIME_FORMAT(Category.SCALAR, SqlKind.OTHER_FUNCTION),
     STR_TO_DATE(Category.SCALAR, SqlKind.OTHER_FUNCTION),
+    /**
+     * PPL {@code TIMESTAMPDIFF(unit, start, end)} — emits the integer number of {@code unit}s
+     * between two timestamps. Resolves through the SQL plugin's {@code TimestampDiffFunction}
+     * UDF named {@code "TIMESTAMPDIFF"}. Lowering target for PPL `timechart`'s {@code per_*}
+     * aggregations, which expand to {@code DIVIDE(agg * scale, TIMESTAMPDIFF('MILLISECOND',
+     * @timestamp, TIMESTAMPADD(unit, n, @timestamp)))}. The analytics-backend-datafusion adapter
+     * rewrites the call into a DataFusion-native expression because the PPL UDF itself is
+     * unknown to isthmus's default extension catalog.
+     */
+    TIMESTAMPDIFF(Category.SCALAR, SqlKind.OTHER_FUNCTION),
+    /**
+     * PPL {@code TIMESTAMPADD(unit, value, timestamp)} — emits {@code timestamp + value units}.
+     * Resolves through the SQL plugin's {@code TimestampAddFunction} UDF named
+     * {@code "TIMESTAMPADD"}. Lowering target for PPL `timechart`'s {@code per_*}
+     * aggregations (see {@link #TIMESTAMPDIFF}). The analytics-backend-datafusion adapter
+     * rewrites the call into a DataFusion-native interval-add expression.
+     */
+    TIMESTAMPADD(Category.SCALAR, SqlKind.OTHER_FUNCTION),
 
     // ── JSON ────────────────────────────────────────────────────────
     JSON_APPEND(Category.SCALAR, SqlKind.OTHER_FUNCTION),

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/api.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/api.rs
@@ -559,11 +559,21 @@ pub unsafe fn sql_to_substrait(
 }
 
 /// Lowers a partial-aggregate Substrait plan against a throwaway session and
-/// returns its physical output schema. NamedTable references are resolved
-/// against empty MemTables built from the substrait base_schema — the plan
-/// itself is the source of truth for the producer side, so no view-type or
-/// timestamp-precision rewrites are applied here. The plan is dropped at
+/// returns its physical output schema **narrowed via
+/// [`schema_coerce::coerce_inferred_schema`]** to types Substrait can bind
+/// against. NamedTable references are resolved against empty MemTables built
+/// from the substrait base_schema — the plan itself is the source of truth for
+/// the producer side, so no view-type or timestamp-precision rewrites are
+/// applied here beyond the post-physical coercer. The plan is dropped at
 /// function exit; only the schema is returned.
+///
+/// <p>The coercer flips Arrow-only types (notably `UInt64` from DataFusion's
+/// `row_number()` physical op) back to their Substrait-compatible counterparts
+/// (`Int64` matching isthmus's `ROW_NUMBER OVER` declaration). The producer
+/// side runs the same coercer + wraps its physical plan with
+/// [`crate::relabel_exec::RelabelExec`] (zero-copy bit-tag flip per mismatched
+/// column), so runtime batches arrive with the same type tags the consumer
+/// registers here — no per-batch cast needed at the partition-stream feed.
 fn derive_schema_from_partial_plan(
     substrait_bytes: &[u8],
 ) -> Result<arrow::datatypes::SchemaRef, DataFusionError> {
@@ -641,7 +651,7 @@ fn derive_schema_from_partial_plan(
 
     let logical_plan = futures::executor::block_on(from_substrait_plan(&session_state, &plan))?;
     let physical_plan = futures::executor::block_on(session_state.create_physical_plan(&logical_plan))?;
-    Ok(physical_plan.schema())
+    Ok(crate::schema_coerce::coerce_inferred_schema(physical_plan.schema()))
 }
 
 /// Encodes a Schema as Arrow IPC stream-format bytes (a schema-only message
@@ -794,6 +804,12 @@ pub unsafe fn register_partition_stream(
     partial_plan_bytes: &[u8],
 ) -> Result<(i64, Vec<u8>), DataFusionError> {
     let session = &mut *(session_ptr as *mut LocalSession);
+    // derive_schema_from_partial_plan applies `schema_coerce::coerce_inferred_schema`
+    // to the physical plan's output schema, matching what isthmus declared on the wire
+    // for the producer (e.g. `Int64` for `ROW_NUMBER OVER`). The producer side runs the
+    // same coercer + wraps its physical plan with `RelabelExec`, so the batches arriving
+    // here through the partition channel are already typed to match this schema — no
+    // per-batch cast at feed time.
     let schema = derive_schema_from_partial_plan(partial_plan_bytes)?;
     let schema_ipc = schema_to_ipc_bytes(schema.as_ref())?;
     let sender = session.register_partition(input_id, schema)?;

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_executor.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_executor.rs
@@ -736,6 +736,12 @@ pub async unsafe fn execute_indexed_with_context(
     log_debug!("DataFusion logical plan:\n{}", logical_plan.display_indent());
     let dataframe = ctx.execute_logical_plan(logical_plan).await?;
     let physical_plan = dataframe.create_physical_plan().await?;
+    // Retag bit-compatible Int↔UInt output mismatches to match the substrait-declared
+    // types. The target is schema_coerce::coerce_inferred_schema(physical_schema) — same
+    // narrowing the partition-stream registration uses, so consumer-side StreamingTable
+    // and producer-side batches agree by construction (see crate::relabel_exec).
+    let target_schema = crate::schema_coerce::coerce_inferred_schema(physical_plan.schema());
+    let physical_plan = crate::relabel_exec::wrap_if_relabel_needed(physical_plan, target_schema)?;
     log_debug!("DataFusion physical plan:\n{}", displayable(physical_plan.as_ref()).indent(true));
     let df_stream = execute_stream(physical_plan, ctx.task_ctx())
         .map_err(|e| DataFusionError::Execution(format!("execute_stream: {}", e)))?;

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/lib.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/lib.rs
@@ -29,6 +29,7 @@ pub mod memory;
 pub mod partition_stream;
 pub mod query_executor;
 pub mod query_tracker;
+pub mod relabel_exec;
 pub mod runtime_manager;
 pub mod schema_coerce;
 pub mod session_context;

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/local_executor.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/local_executor.rs
@@ -144,11 +144,12 @@ impl LocalSession {
             DataFusionError::Execution(format!("Failed to decode Substrait plan: {}", e))
         })?;
         let logical_plan = from_substrait_plan(&self.ctx.state(), &plan).await?;
-        self.ctx
-            .execute_logical_plan(logical_plan)
-            .await?
-            .execute_stream()
-            .await
+        let dataframe = self.ctx.execute_logical_plan(logical_plan).await?;
+        let physical_plan = dataframe.create_physical_plan().await?;
+        let target_schema = crate::schema_coerce::coerce_inferred_schema(physical_plan.schema());
+        let physical_plan = crate::relabel_exec::wrap_if_relabel_needed(physical_plan, target_schema)?;
+        datafusion::physical_plan::execute_stream(physical_plan, self.ctx.task_ctx())
+            .map_err(|e| DataFusionError::Execution(format!("execute_substrait: {}", e)))
     }
 
     /// Returns the memory pool the session's `RuntimeEnv` was built with.
@@ -179,6 +180,8 @@ impl LocalSession {
         log_debug!("DataFusion logical plan (reduce):\n{}", logical_plan.display_indent());
         let dataframe = self.ctx.execute_logical_plan(logical_plan).await?;
         let physical_plan = dataframe.create_physical_plan().await?;
+        let target_schema = crate::schema_coerce::coerce_inferred_schema(physical_plan.schema());
+        let physical_plan = crate::relabel_exec::wrap_if_relabel_needed(physical_plan, target_schema)?;
         log_debug!("DataFusion physical plan (reduce):\n{}", displayable(physical_plan.as_ref()).indent(true));
         let stripped = crate::agg_mode::apply_aggregate_mode(
             physical_plan,

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/query_executor.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/query_executor.rs
@@ -152,6 +152,13 @@ pub async fn execute_query(
     let logical_plan = from_substrait_plan(&ctx.state(), &substrait_plan).await?;
     let dataframe = ctx.execute_logical_plan(logical_plan).await?;
     let physical_plan = dataframe.create_physical_plan().await?;
+    // Retag any physical-plan output columns whose type tags differ from what Substrait
+    // declared on bit-compatible Int↔UInt pairs (see crate::relabel_exec). The target is
+    // schema_coerce::coerce_inferred_schema(physical_schema) — the same narrowing the
+    // partition-stream registration uses, so the consumer's StreamingTable and the
+    // batches arriving from this producer agree by construction.
+    let target_schema = crate::schema_coerce::coerce_inferred_schema(physical_plan.schema());
+    let physical_plan = crate::relabel_exec::wrap_if_relabel_needed(physical_plan, target_schema)?;
 
     let df_stream = execute_stream(physical_plan, ctx.task_ctx()).map_err(|e| {
         error!("Failed to create execution stream: {}", e);
@@ -197,6 +204,8 @@ pub async fn execute_with_context(
         log_debug!("DataFusion logical plan:\n{}", logical_plan.display_indent());
         let dataframe = handle.ctx.execute_logical_plan(logical_plan).await?;
         let physical_plan = dataframe.create_physical_plan().await?;
+        let target_schema = crate::schema_coerce::coerce_inferred_schema(physical_plan.schema());
+        let physical_plan = crate::relabel_exec::wrap_if_relabel_needed(physical_plan, target_schema)?;
         log_debug!("DataFusion physical plan:\n{}", displayable(physical_plan.as_ref()).indent(true));
 
         let df_stream = execute_stream(physical_plan, handle.ctx.task_ctx()).map_err(|e| {

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/relabel_exec.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/relabel_exec.rs
@@ -1,0 +1,269 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+//! Zero-copy schema-relabel ExecutionPlan.
+//!
+//! Bridges a small gap between the LogicalPlan and physical-plan type systems on the
+//! producer side: DataFusion's substrait consumer types `ROW_NUMBER OVER` as `Int64`
+//! at the LogicalPlan level (matching what Calcite / isthmus declared on the wire),
+//! but the physical `WindowAggExec` for `row_number()` emits `UInt64` regardless. The
+//! same divergence affects any `Int8↔UInt8` … `Int64↔UInt64` pair where DataFusion's
+//! physical operator chooses an unsigned representation for a Substrait `i64` declaration.
+//!
+//! Wrapping the physical plan with `RelabelExec` retags each batch's mismatched columns
+//! to match the LogicalPlan's declared types. The rebuild is zero-copy: `ArrayData`
+//! buffers are shared with the source array; only the type tag flips. Per-batch cost is
+//! one `Arc` clone + one `ArrayData::into_builder().data_type(...).build()` per mismatched
+//! column — no buffer alloc, no per-row work.
+//!
+//! Non-bit-compatible mismatches (e.g. cross-family) error at construction; those need
+//! a proper `Cast` at the LogicalPlan level rather than a relabel.
+
+use std::any::Any;
+use std::fmt;
+use std::sync::Arc;
+
+use arrow::array::{make_array, ArrayRef};
+use arrow::datatypes::{DataType, SchemaRef};
+use arrow::record_batch::RecordBatch;
+use datafusion::common::{DataFusionError, Result};
+use datafusion::execution::TaskContext;
+use datafusion::physical_expr::EquivalenceProperties;
+use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+use datafusion::physical_plan::{
+    DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties, SendableRecordBatchStream,
+};
+use futures::stream::TryStreamExt;
+
+/// Wraps an `ExecutionPlan` and exposes a `target_schema` whose columns differ from the
+/// input's only by bit-compatible Int↔UInt sign flips. Per-batch retags via zero-copy
+/// `ArrayData` rebuild.
+pub struct RelabelExec {
+    input: Arc<dyn ExecutionPlan>,
+    target_schema: SchemaRef,
+    properties: Arc<PlanProperties>,
+}
+
+impl fmt::Debug for RelabelExec {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RelabelExec")
+            .field("target_schema", &self.target_schema)
+            .finish()
+    }
+}
+
+impl RelabelExec {
+    pub fn try_new(input: Arc<dyn ExecutionPlan>, target_schema: SchemaRef) -> Result<Arc<Self>> {
+        validate_bit_compatible(&input.schema(), &target_schema)?;
+        let new_eq = EquivalenceProperties::new(Arc::clone(&target_schema));
+        let input_props = input.properties();
+        let properties = Arc::new(PlanProperties::new(
+            new_eq,
+            input_props.output_partitioning().clone(),
+            input_props.emission_type,
+            input_props.boundedness,
+        ));
+        Ok(Arc::new(Self {
+            input,
+            target_schema,
+            properties,
+        }))
+    }
+}
+
+impl DisplayAs for RelabelExec {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "RelabelExec: schema={:?}", self.target_schema)
+    }
+}
+
+impl ExecutionPlan for RelabelExec {
+    fn name(&self) -> &str {
+        "RelabelExec"
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        Arc::clone(&self.target_schema)
+    }
+
+    fn properties(&self) -> &Arc<PlanProperties> {
+        &self.properties
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![&self.input]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        mut children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        if children.len() != 1 {
+            return Err(DataFusionError::Internal(format!(
+                "RelabelExec expects exactly one child, got {}",
+                children.len()
+            )));
+        }
+        let new_input = children.remove(0);
+        let target_schema = Arc::clone(&self.target_schema);
+        Ok(Self::try_new(new_input, target_schema)? as Arc<dyn ExecutionPlan>)
+    }
+
+    fn execute(&self, partition: usize, context: Arc<TaskContext>) -> Result<SendableRecordBatchStream> {
+        let input_stream = self.input.execute(partition, context)?;
+        let target_schema = Arc::clone(&self.target_schema);
+        let target_schema_for_stream = Arc::clone(&target_schema);
+        let mapped = input_stream.and_then(move |batch| {
+            let target = Arc::clone(&target_schema);
+            async move { relabel_batch(&batch, &target) }
+        });
+        Ok(Box::pin(RecordBatchStreamAdapter::new(target_schema_for_stream, mapped)))
+    }
+}
+
+/// Wraps `physical_plan` with `RelabelExec` when its output schema diverges from
+/// `target_schema` only on bit-compatible pairs. No-op when schemas already match
+/// (returns the original plan unchanged so this is safe to call from any
+/// physical-plan-build site). Errors when a mismatch isn't bit-compatible — those
+/// should have been emitted as a `Cast` at the LogicalPlan level.
+pub fn wrap_if_relabel_needed(
+    physical_plan: Arc<dyn ExecutionPlan>,
+    target_schema: SchemaRef,
+) -> Result<Arc<dyn ExecutionPlan>> {
+    if physical_plan.schema().as_ref() == target_schema.as_ref() {
+        return Ok(physical_plan);
+    }
+    Ok(RelabelExec::try_new(physical_plan, target_schema)? as Arc<dyn ExecutionPlan>)
+}
+
+fn validate_bit_compatible(src_schema: &SchemaRef, target_schema: &SchemaRef) -> Result<()> {
+    if src_schema.fields().len() != target_schema.fields().len() {
+        return Err(DataFusionError::Internal(format!(
+            "RelabelExec field count mismatch: input has {}, target has {}",
+            src_schema.fields().len(),
+            target_schema.fields().len()
+        )));
+    }
+    for (i, (src_f, dst_f)) in src_schema
+        .fields()
+        .iter()
+        .zip(target_schema.fields().iter())
+        .enumerate()
+    {
+        if src_f.data_type() != dst_f.data_type() && !is_bit_compatible(src_f.data_type(), dst_f.data_type()) {
+            return Err(DataFusionError::Internal(format!(
+                "RelabelExec column {} ('{}') has non-bit-compatible types: {:?} → {:?} \
+                 (use a LogicalPlan-level Cast for this conversion)",
+                i,
+                src_f.name(),
+                src_f.data_type(),
+                dst_f.data_type()
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Bit-compatible pairs share an identical Arrow buffer layout; retagging the
+/// `DataType` produces a valid array with the same bytes. Currently covers the
+/// signed/unsigned integer pairs at the same width, which are the divergences
+/// the substrait→physical-plan lowering introduces today (notably DataFusion's
+/// `row_number()` returning UInt64 against a Substrait `i64` declaration).
+fn is_bit_compatible(a: &DataType, b: &DataType) -> bool {
+    matches!(
+        (a, b),
+        (DataType::Int8, DataType::UInt8)
+            | (DataType::UInt8, DataType::Int8)
+            | (DataType::Int16, DataType::UInt16)
+            | (DataType::UInt16, DataType::Int16)
+            | (DataType::Int32, DataType::UInt32)
+            | (DataType::UInt32, DataType::Int32)
+            | (DataType::Int64, DataType::UInt64)
+            | (DataType::UInt64, DataType::Int64)
+    )
+}
+
+fn relabel_batch(batch: &RecordBatch, target_schema: &SchemaRef) -> Result<RecordBatch> {
+    let mut columns: Vec<ArrayRef> = Vec::with_capacity(batch.num_columns());
+    for (i, target_field) in target_schema.fields().iter().enumerate() {
+        let src = batch.column(i);
+        if src.data_type() == target_field.data_type() {
+            columns.push(Arc::clone(src));
+            continue;
+        }
+        // Zero-copy: rebuild ArrayData with the new DataType. Buffers are shared with
+        // the source array; only the type tag flips.
+        let data = src
+            .to_data()
+            .into_builder()
+            .data_type(target_field.data_type().clone())
+            .build()
+            .map_err(|e| {
+                DataFusionError::Internal(format!(
+                    "RelabelExec failed to retag column {} ('{}'): {}",
+                    i,
+                    target_field.name(),
+                    e
+                ))
+            })?;
+        columns.push(make_array(data));
+    }
+    RecordBatch::try_new(Arc::clone(target_schema), columns)
+        .map_err(|e| DataFusionError::Execution(format!("RelabelExec assemble batch: {}", e)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::{Int64Array, UInt64Array};
+    use arrow::datatypes::{Field, Schema};
+
+    #[test]
+    fn relabel_uint64_to_int64_shares_buffer() {
+        let src: ArrayRef = Arc::new(UInt64Array::from(vec![1u64, 2, 3]));
+        let target_schema: SchemaRef = Arc::new(Schema::new(vec![Field::new("x", DataType::Int64, true)]));
+        let batch = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![Field::new("x", DataType::UInt64, true)])),
+            vec![src],
+        )
+        .unwrap();
+        let out = relabel_batch(&batch, &target_schema).unwrap();
+        assert_eq!(out.column(0).data_type(), &DataType::Int64);
+        // Bit pattern preserved: u64 value 1 reinterprets as i64 value 1.
+        let as_i64 = out.column(0).as_any().downcast_ref::<Int64Array>().unwrap();
+        assert_eq!(as_i64.values(), &[1i64, 2, 3]);
+    }
+
+    #[test]
+    fn relabel_skips_no_op_when_schemas_match() {
+        let src: ArrayRef = Arc::new(Int64Array::from(vec![10i64, 20]));
+        let same_schema: SchemaRef = Arc::new(Schema::new(vec![Field::new("y", DataType::Int64, false)]));
+        let batch = RecordBatch::try_new(Arc::clone(&same_schema), vec![Arc::clone(&src)]).unwrap();
+        let out = relabel_batch(&batch, &same_schema).unwrap();
+        // Same Arc — the no-op branch in relabel_batch is the test target.
+        assert!(Arc::ptr_eq(out.column(0), &src));
+    }
+
+    #[test]
+    fn validate_rejects_cross_family() {
+        let a: SchemaRef = Arc::new(Schema::new(vec![Field::new("a", DataType::Int64, true)]));
+        let b: SchemaRef = Arc::new(Schema::new(vec![Field::new("a", DataType::Float64, true)]));
+        assert!(validate_bit_compatible(&a, &b).is_err());
+    }
+
+    #[test]
+    fn validate_accepts_uint64_to_int64() {
+        let a: SchemaRef = Arc::new(Schema::new(vec![Field::new("a", DataType::UInt64, true)]));
+        let b: SchemaRef = Arc::new(Schema::new(vec![Field::new("a", DataType::Int64, true)]));
+        assert!(validate_bit_compatible(&a, &b).is_ok());
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/session_context.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/session_context.rs
@@ -253,6 +253,8 @@ pub async fn prepare_partial_plan(
     let logical_plan = from_substrait_plan(&handle.ctx.state(), &plan).await?;
     let dataframe = handle.ctx.execute_logical_plan(logical_plan).await?;
     let physical_plan = dataframe.create_physical_plan().await?;
+    let target_schema = crate::schema_coerce::coerce_inferred_schema(physical_plan.schema());
+    let physical_plan = crate::relabel_exec::wrap_if_relabel_needed(physical_plan, target_schema)?;
     let stripped = crate::agg_mode::apply_aggregate_mode(physical_plan, crate::agg_mode::Mode::Partial)?;
     handle.prepared_plan = Some(stripped);
     Ok(())

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionAnalyticsBackendPlugin.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionAnalyticsBackendPlugin.java
@@ -330,7 +330,14 @@ public class DataFusionAnalyticsBackendPlugin implements AnalyticsSearchBackendP
         ScalarFunction.SPAN_BUCKET,
         ScalarFunction.WIDTH_BUCKET,
         ScalarFunction.MINSPAN_BUCKET,
-        ScalarFunction.RANGE_BUCKET
+        ScalarFunction.RANGE_BUCKET,
+        // PPL `TIMESTAMPDIFF(unit, t1, t2)` / `TIMESTAMPADD(unit, n, t)` — lowering target for
+        // timechart's `per_*` aggregations (per_second / per_minute / per_hour / per_day),
+        // which expand to {@code DIVIDE(agg * scale, TIMESTAMPDIFF('MILLISECOND', @timestamp,
+        // TIMESTAMPADD('MINUTE', 1, @timestamp)))}. Both PPL UDFs are unknown to isthmus's
+        // default catalog, so adapters rewrite to DF-native interval arithmetic.
+        ScalarFunction.TIMESTAMPDIFF,
+        ScalarFunction.TIMESTAMPADD
     );
 
     /**

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionAnalyticsBackendPlugin.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionAnalyticsBackendPlugin.java
@@ -642,6 +642,14 @@ public class DataFusionAnalyticsBackendPlugin implements AnalyticsSearchBackendP
                     Map.entry(ScalarFunction.TIME, new DateTimeAdapters.TimeAdapter()),
                     Map.entry(ScalarFunction.TIME_FORMAT, new RustUdfDateTimeAdapters.TimeFormatAdapter()),
                     Map.entry(ScalarFunction.TIMESTAMP, new TimestampFunctionAdapter()),
+                    // PPL `TIMESTAMPDIFF(out_unit, t, TIMESTAMPADD(in_unit, n, t))` — peephole
+                    // constant-folds to a numeric literal when both unit strings are fixed-length
+                    // (MICROSECOND through WEEK). This is the exact shape PPL timechart's per_*
+                    // aggregations produce; folding eliminates both PPL UDF references in one
+                    // step, sidestepping isthmus's lack of substrait bindings for either UDF.
+                    // Variable-length units (MONTH / QUARTER / YEAR) and standalone TIMESTAMPADD
+                    // fall through unchanged — fully-general interval-aware support is a follow-up.
+                    Map.entry(ScalarFunction.TIMESTAMPDIFF, new TimestampDiffAdapter()),
                     Map.entry(ScalarFunction.TONUMBER, new ToNumberFunctionAdapter()),
                     Map.entry(ScalarFunction.TOSTRING, new ToStringFunctionAdapter()),
                     Map.entry(ScalarFunction.NUM, new NumericConversionFunctionAdapter(NumericConversionFunctionAdapter.NUM)),

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/SpanAdapter.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/SpanAdapter.java
@@ -66,6 +66,21 @@ class SpanAdapter implements ScalarFunctionAdapter {
         Map.entry("y", "year")
     );
 
+    /**
+     * Fixed-length PPL span units → seconds. Used by the multi-unit rewrite path
+     * (e.g. {@code span=2m}, {@code span=12h}). Month / quarter / year are excluded
+     * because their length depends on the calendar position of {@code t} — bucketing
+     * those needs DataFusion {@code date_bin} with an interval-month argument rather
+     * than a fixed-second multiplier, and is tracked separately.
+     */
+    private static final Map<String, Long> FIXED_UNIT_SECONDS = Map.ofEntries(
+        Map.entry("s", 1L),
+        Map.entry("m", 60L),
+        Map.entry("h", 3600L),
+        Map.entry("d", 86400L),
+        Map.entry("w", 604800L)
+    );
+
     @Override
     public RexNode adapt(RexCall original, List<FieldStorageInfo> fieldStorage, RelOptCluster cluster) {
         if (!original.getOperator().getName().equalsIgnoreCase("SPAN")) {
@@ -87,15 +102,84 @@ class SpanAdapter implements ScalarFunctionAdapter {
         // Time span: unit operand is a string literal.
         if (unit instanceof RexLiteral lit && lit.getValue() != null) {
             String unitText = lit.getValueAs(String.class);
-            String dateTruncUnit = unitText == null ? null : UNIT_TO_DATE_TRUNC.get(unitText);
-            if (dateTruncUnit != null && isUnitInterval(interval)) {
-                RexNode unitArg = rexBuilder.makeLiteral(dateTruncUnit);
-                return rexBuilder.makeCall(original.getType(), SqlLibraryOperators.DATE_TRUNC, List.of(unitArg, field));
+            if (unitText != null) {
+                String dateTruncUnit = UNIT_TO_DATE_TRUNC.get(unitText);
+                if (dateTruncUnit != null && isUnitInterval(interval)) {
+                    RexNode unitArg = rexBuilder.makeLiteral(dateTruncUnit);
+                    return rexBuilder.makeCall(original.getType(), SqlLibraryOperators.DATE_TRUNC, List.of(unitArg, field));
+                }
+                // Multi-unit fixed-length time span: bucket via integer seconds since epoch.
+                // SPAN(t, N, '<unit>') → TIMESTAMP_SECONDS(FLOOR(UNIX_SECONDS(t) / B) * B)
+                // where B = N * unit_seconds. date_trunc handles N=1 above; for N>=2 there is no
+                // single date_trunc that aligns to an arbitrary multiple. This rewrite is exact for
+                // fixed-length units (s/m/h/d/w) because the epoch is a fixed reference; multi-unit
+                // month/quarter/year fall through to the original SPAN UDF (variable bucket length).
+                Long unitSeconds = FIXED_UNIT_SECONDS.get(unitText);
+                Long bucketSeconds = bucketSecondsIfPositiveInteger(interval, unitSeconds);
+                if (bucketSeconds != null && bucketSeconds > 0L) {
+                    return rewriteFixedLengthTimeBucket(rexBuilder, field, bucketSeconds, original.getType());
+                }
             }
         }
 
         // Anything else falls through unchanged.
         return original;
+    }
+
+    /**
+     * Returns {@code N * unit_seconds} when both inputs are present and {@code N} is a
+     * positive integer literal; {@code null} otherwise.
+     */
+    private static Long bucketSecondsIfPositiveInteger(RexNode interval, Long unitSeconds) {
+        if (unitSeconds == null || !(interval instanceof RexLiteral lit)) {
+            return null;
+        }
+        Object value = lit.getValue();
+        long n;
+        if (value instanceof BigDecimal bd) {
+            if (bd.scale() > 0 && bd.stripTrailingZeros().scale() > 0) {
+                return null; // non-integer interval not supported
+            }
+            n = bd.longValueExact();
+        } else if (value instanceof Number num) {
+            double d = num.doubleValue();
+            if (d != Math.floor(d)) {
+                return null;
+            }
+            n = (long) d;
+        } else {
+            return null;
+        }
+        if (n <= 0) {
+            return null;
+        }
+        return n * unitSeconds;
+    }
+
+    private static RexNode rewriteFixedLengthTimeBucket(RexBuilder rexBuilder, RexNode field, long bucketSeconds, RelDataType resultType) {
+        RexNode bucketSizeLit = rexBuilder.makeBigintLiteral(BigDecimal.valueOf(bucketSeconds));
+        // Use the locally-declared substrait-mapped operators (same ones UnixTimestampAdapter
+        // and RustUdfDateTimeAdapters.FromUnixtimeAdapter rewrite to). Calcite's stdlib
+        // UNIX_SECONDS / TIMESTAMP_SECONDS would bind to BigQuery-named substrait functions
+        // that DataFusion's substrait consumer does not have entries for; the LOCAL_*_OP
+        // pair routes through the analytics-backend-datafusion FunctionMappings.s entries
+        // to DataFusion's native `to_unixtime` and `from_unixtime` UDFs.
+        RexNode epochSeconds = rexBuilder.makeCall(UnixTimestampAdapter.LOCAL_TO_UNIXTIME_OP, field);
+        // Integer / integer division already truncates toward zero (and toward negative
+        // infinity for non-negative epoch seconds, which all our timechart-tested data is),
+        // so the FLOOR step the numeric-span rewrite uses is redundant here. Skipping it
+        // also avoids the "Unable to convert call FLOOR(i64?)" substrait gap — DataFusion's
+        // floor function binds for floating-point only.
+        RexNode bucketIndex = rexBuilder.makeCall(SqlStdOperatorTable.DIVIDE, epochSeconds, bucketSizeLit);
+        RexNode bucketStart = rexBuilder.makeCall(SqlStdOperatorTable.MULTIPLY, bucketIndex, bucketSizeLit);
+        // from_unixtime's substrait signature is `(fp64) -> precision_timestamp<6>` (see
+        // opensearch_scalar_functions.yaml); cast the i64 bucket start to fp64 to match.
+        RelDataType fp64 = rexBuilder.getTypeFactory().createSqlType(SqlTypeName.DOUBLE);
+        RexNode bucketStartDouble = rexBuilder.makeCast(fp64, bucketStart, true);
+        RexNode asTimestamp = rexBuilder.makeCall(RustUdfDateTimeAdapters.LOCAL_FROM_UNIXTIME_OP, bucketStartDouble);
+        // Pin to the SPAN call's declared return type — matches the numeric rewrite path's
+        // typeMatchesInferred safeguard.
+        return rexBuilder.makeCast(resultType, asTimestamp, true);
     }
 
     private static RexNode rewriteNumericSpan(RexBuilder rexBuilder, RexNode field, RexNode interval, RelDataType resultType) {

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/TimestampDiffAdapter.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/TimestampDiffAdapter.java
@@ -1,0 +1,172 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion;
+
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.opensearch.analytics.planner.rel.OperatorAnnotation;
+import org.opensearch.analytics.spi.FieldStorageInfo;
+import org.opensearch.analytics.spi.ScalarFunctionAdapter;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Peephole-folds PPL {@code TIMESTAMPDIFF(out_unit, t, TIMESTAMPADD(in_unit, n, t))} when both
+ * unit strings are fixed-length (MICROSECOND through WEEK). This is the exact expression
+ * shape PPL timechart's {@code per_second / per_minute / per_hour / per_day} aggregations
+ * produce — the result is the same constant for every row, so we materialize the BIGINT
+ * literal at adapter time and let the literal flow through Substrait unchanged.
+ *
+ * <p>Two PPL UDFs are involved:
+ * <ul>
+ *   <li>{@code TIMESTAMPDIFF(unit, t1, t2)} returns LONG number of {@code unit}s between
+ *       {@code t1} and {@code t2}.</li>
+ *   <li>{@code TIMESTAMPADD(unit, n, t)} returns TIMESTAMP shifted by {@code n} {@code unit}s.</li>
+ * </ul>
+ * Neither has a Substrait extension binding, so isthmus rejects them as
+ * "Unable to convert call TIMESTAMPADD(string, i32, precision_timestamp&lt;0&gt;?)" unless we
+ * rewrite the call. Folding the whole {@code TIMESTAMPDIFF(..., TIMESTAMPADD(...))} to a
+ * literal removes both UDF references in one step.
+ *
+ * <p>Variable-length units (MONTH, QUARTER, YEAR) are intentionally not folded — the
+ * milliseconds-per-month value depends on which month the base timestamp lands in. Calls
+ * with those units fall through to the original PPL UDF and surface as a substrait conversion
+ * error, which is the same behavior as standalone {@code TIMESTAMPADD}. Full interval-aware
+ * support requires Substrait {@code add(timestamp, interval) -> timestamp} wiring with
+ * a {@code SqlIntervalQualifier}-built RexLiteral, deferred to a follow-up.
+ *
+ * @opensearch.internal
+ */
+class TimestampDiffAdapter implements ScalarFunctionAdapter {
+
+    /** PPL IntervalUnit name → milliseconds (only fixed-length units; null means variable-length). */
+    private static final Map<String, Long> UNIT_TO_MILLIS = Map.ofEntries(
+        Map.entry("MICROSECOND", 0L),  // sub-millisecond; treated separately below
+        Map.entry("MILLISECOND", 1L),
+        Map.entry("SECOND", 1_000L),
+        Map.entry("MINUTE", 60_000L),
+        Map.entry("HOUR", 3_600_000L),
+        Map.entry("DAY", 86_400_000L),
+        Map.entry("WEEK", 604_800_000L)
+    );
+
+    @Override
+    public RexNode adapt(RexCall original, List<FieldStorageInfo> fieldStorage, RelOptCluster cluster) {
+        if (!original.getOperator().getName().equalsIgnoreCase("TIMESTAMPDIFF")) {
+            return original;
+        }
+        if (original.getOperands().size() != 3) {
+            return original;
+        }
+        RexNode outUnitArg = unwrapAnnotation(original.getOperands().get(0));
+        RexNode startArg = unwrapAnnotation(original.getOperands().get(1));
+        RexNode endArg = unwrapAnnotation(original.getOperands().get(2));
+
+        String outUnit = stringLiteralValue(outUnitArg);
+        if (outUnit == null) {
+            return original;
+        }
+
+        // The peephole only fires when end is TIMESTAMPADD(in_unit_literal, n_int_literal, start).
+        // `start` here must be the *same* RexNode reference as the outer TIMESTAMPDIFF's start
+        // (typically a RexInputRef into @timestamp). RexInputRef.equals compares by ordinal,
+        // so structurally-equal refs to the same input position match. OperatorAnnotation
+        // wrappers (e.g. AnnotatedProjectExpression introduced by OpenSearchProjectRule) are
+        // peeled at each operand before structural comparison so the wrapped TIMESTAMPADD
+        // call remains recognizable as a TIMESTAMPADD instead of looking like an annotation
+        // RexCall whose operator is ANNOTATED_PROJECT_EXPR.
+        if (!(endArg instanceof RexCall endCall)
+            || !endCall.getOperator().getName().equalsIgnoreCase("TIMESTAMPADD")
+            || endCall.getOperands().size() != 3) {
+            return original;
+        }
+        String inUnit = stringLiteralValue(unwrapAnnotation(endCall.getOperands().get(0)));
+        Long inValue = integerLiteralValue(unwrapAnnotation(endCall.getOperands().get(1)));
+        RexNode addedBase = unwrapAnnotation(endCall.getOperands().get(2));
+        if (inUnit == null || inValue == null || !addedBase.equals(startArg)) {
+            return original;
+        }
+
+        Long foldedDiff = constantFold(outUnit, inUnit, inValue);
+        if (foldedDiff == null) {
+            return original;
+        }
+
+        RexBuilder rexBuilder = cluster.getRexBuilder();
+        RexNode literal = rexBuilder.makeBigintLiteral(BigDecimal.valueOf(foldedDiff));
+        // Pin the literal back to the original call's declared return type so the surrounding
+        // Project's typeMatchesInferred check doesn't see a NOT NULL vs FORCE_NULLABLE mismatch.
+        return rexBuilder.makeCast(original.getType(), literal, true);
+    }
+
+    /**
+     * Fold {@code n * in_ms / out_ms} when both units are fixed-length. Returns null when
+     * either unit is variable-length (MONTH / QUARTER / YEAR) or when the result is not an
+     * exact integer (e.g. {@code TIMESTAMPDIFF('SECOND', t, t + 500 MILLISECOND)} = 0.5).
+     */
+    private static Long constantFold(String outUnit, String inUnit, long inValue) {
+        Long inMs = UNIT_TO_MILLIS.get(inUnit.toUpperCase(Locale.ROOT));
+        Long outMs = UNIT_TO_MILLIS.get(outUnit.toUpperCase(Locale.ROOT));
+        if (inMs == null || outMs == null || outMs == 0L) {
+            return null;
+        }
+        // PPL's IntervalUnit treats MILLISECOND as the base; PPL TIMESTAMPDIFF computes
+        // (t2 - t1) in milliseconds and divides by out_unit's millisecond factor. The
+        // formula in_value * in_ms / out_ms reproduces that for fixed-length unit pairs.
+        long totalMs = Math.multiplyExact(inValue, inMs);
+        if (totalMs % outMs != 0) {
+            return null;
+        }
+        return totalMs / outMs;
+    }
+
+    /** Peel a single OperatorAnnotation wrapper if present. */
+    private static RexNode unwrapAnnotation(RexNode node) {
+        if (node instanceof OperatorAnnotation annotation && annotation.unwrap() != null) {
+            return annotation.unwrap();
+        }
+        return node;
+    }
+
+    private static String stringLiteralValue(RexNode node) {
+        if (!(node instanceof RexLiteral lit)) {
+            return null;
+        }
+        if (lit.getType().getSqlTypeName() != SqlTypeName.CHAR
+            && lit.getType().getSqlTypeName() != SqlTypeName.VARCHAR) {
+            return null;
+        }
+        return lit.getValueAs(String.class);
+    }
+
+    private static Long integerLiteralValue(RexNode node) {
+        if (!(node instanceof RexLiteral lit)) {
+            return null;
+        }
+        Object value = lit.getValue();
+        if (value instanceof BigDecimal bd) {
+            try {
+                return bd.longValueExact();
+            } catch (ArithmeticException unused) {
+                return null;
+            }
+        }
+        if (value instanceof Number n) {
+            return n.longValue();
+        }
+        return null;
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/TimestampDiffAdapter.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/TimestampDiffAdapter.java
@@ -8,11 +8,15 @@
 
 package org.opensearch.be.datafusion;
 
+import org.apache.calcite.avatica.util.TimeUnit;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlIntervalQualifier;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.opensearch.analytics.planner.rel.OperatorAnnotation;
 import org.opensearch.analytics.spi.FieldStorageInfo;
@@ -41,12 +45,25 @@ import java.util.Map;
  * rewrite the call. Folding the whole {@code TIMESTAMPDIFF(..., TIMESTAMPADD(...))} to a
  * literal removes both UDF references in one step.
  *
- * <p>Variable-length units (MONTH, QUARTER, YEAR) are intentionally not folded — the
- * milliseconds-per-month value depends on which month the base timestamp lands in. Calls
- * with those units fall through to the original PPL UDF and surface as a substrait conversion
- * error, which is the same behavior as standalone {@code TIMESTAMPADD}. Full interval-aware
- * support requires Substrait {@code add(timestamp, interval) -> timestamp} wiring with
- * a {@code SqlIntervalQualifier}-built RexLiteral, deferred to a follow-up.
+ * <p>Variable-length units (MONTH, QUARTER, YEAR) cannot be constant-folded — the
+ * milliseconds-per-month value depends on which calendar month the base timestamp lands
+ * in (Feb 2025 = 28 days, Oct 2025 = 31 days). For the peephole shape with a
+ * variable-length {@code in_unit} and a fixed-length {@code out_unit}, the adapter
+ * rewrites atomically to a runtime-evaluated form:
+ * <pre>
+ *   TIMESTAMPDIFF(out_unit, t, TIMESTAMPADD(MONTH|QUARTER|YEAR, n, t))
+ *     →  (to_unixtime(DATETIME_PLUS(t, INTERVAL n*m MONTH)) - to_unixtime(t)) * out_factor
+ * </pre>
+ * where {@code m} converts QUARTER→3 / YEAR→12 (same idiom as
+ * {@code EarliestLatestAdapter#makeIntervalAdd}, which has prior wiring proof that
+ * {@code DATETIME_PLUS(t, INTERVAL_MONTH)} binds end-to-end via Substrait's standard
+ * {@code add(timestamp, interval_year_month)} into DataFusion's native interval add).
+ * For out-unit factors see {@link #OUT_UNIT_MULTIPLIER_FROM_SECONDS} /
+ * {@link #OUT_UNIT_DIVISOR_FROM_SECONDS}.
+ *
+ * <p>Out-unit MONTH/QUARTER/YEAR (computing the month-difference of two timestamps in
+ * variable units) is still rejected — the lossy fixed-second math doesn't apply.
+ * No timechart per_* shape needs this; left as a follow-up.
  *
  * @opensearch.internal
  */
@@ -61,6 +78,41 @@ class TimestampDiffAdapter implements ScalarFunctionAdapter {
         Map.entry("HOUR", 3_600_000L),
         Map.entry("DAY", 86_400_000L),
         Map.entry("WEEK", 604_800_000L)
+    );
+
+    /**
+     * Variable-length PPL inner unit → number of months it represents. Used by the runtime
+     * rewrite path to build the {@code INTERVAL n*<m> MONTH} literal that
+     * {@link org.apache.calcite.sql.fun.SqlStdOperatorTable#DATETIME_PLUS} adds to the base
+     * timestamp. Substrait's {@code interval_year_month} carries months as its underlying
+     * unit, so a 'MONTH' inner is m=1, 'QUARTER' is m=3, 'YEAR' is m=12.
+     */
+    private static final Map<String, Long> VARIABLE_INNER_MONTHS = Map.of("MONTH", 1L, "QUARTER", 3L, "YEAR", 12L);
+
+    /**
+     * Fixed-length out-unit → multiplier applied to {@code (unix_seconds_diff)} to express
+     * the difference in that unit. Only sub-minute units are multipliers; minute and larger
+     * use {@link #OUT_UNIT_DIVISOR_FROM_SECONDS} instead.
+     */
+    private static final Map<String, Long> OUT_UNIT_MULTIPLIER_FROM_SECONDS = Map.of(
+        "MICROSECOND",
+        1_000_000L,
+        "MILLISECOND",
+        1_000L,
+        "SECOND",
+        1L
+    );
+
+    /** Fixed-length out-unit → divisor applied to {@code (unix_seconds_diff)}. */
+    private static final Map<String, Long> OUT_UNIT_DIVISOR_FROM_SECONDS = Map.of(
+        "MINUTE",
+        60L,
+        "HOUR",
+        3_600L,
+        "DAY",
+        86_400L,
+        "WEEK",
+        604_800L
     );
 
     @Override
@@ -100,16 +152,82 @@ class TimestampDiffAdapter implements ScalarFunctionAdapter {
             return original;
         }
 
+        RexBuilder rexBuilder = cluster.getRexBuilder();
+
         Long foldedDiff = constantFold(outUnit, inUnit, inValue);
-        if (foldedDiff == null) {
-            return original;
+        if (foldedDiff != null) {
+            RexNode literal = rexBuilder.makeBigintLiteral(BigDecimal.valueOf(foldedDiff));
+            // Pin the literal back to the original call's declared return type so the
+            // surrounding Project's typeMatchesInferred check doesn't see a NOT NULL vs
+            // FORCE_NULLABLE mismatch.
+            return rexBuilder.makeCast(original.getType(), literal, true);
         }
 
-        RexBuilder rexBuilder = cluster.getRexBuilder();
-        RexNode literal = rexBuilder.makeBigintLiteral(BigDecimal.valueOf(foldedDiff));
-        // Pin the literal back to the original call's declared return type so the surrounding
-        // Project's typeMatchesInferred check doesn't see a NOT NULL vs FORCE_NULLABLE mismatch.
-        return rexBuilder.makeCast(original.getType(), literal, true);
+        // Variable-length inner units (MONTH/QUARTER/YEAR) with a fixed-length out unit:
+        // rewrite to runtime evaluation, since the actual ms-per-bucket depends on the
+        // calendar month the row's bucket lands in. PPL timechart's per_* aggregations
+        // with span=1M / span=1month / span=1q / span=1y all hit this path.
+        Long innerMonths = VARIABLE_INNER_MONTHS.get(inUnit.toUpperCase(Locale.ROOT));
+        if (innerMonths != null) {
+            RexNode rewritten = rewriteVariableInner(rexBuilder, startArg, inValue, innerMonths, outUnit, original.getType());
+            if (rewritten != null) {
+                return rewritten;
+            }
+        }
+
+        return original;
+    }
+
+    private static RexNode rewriteVariableInner(
+        RexBuilder rexBuilder,
+        RexNode startArg,
+        long inValue,
+        long innerMonths,
+        String outUnit,
+        org.apache.calcite.rel.type.RelDataType resultType
+    ) {
+        String upperOut = outUnit.toUpperCase(Locale.ROOT);
+        Long outMultiplier = OUT_UNIT_MULTIPLIER_FROM_SECONDS.get(upperOut);
+        Long outDivisor = outMultiplier == null ? OUT_UNIT_DIVISOR_FROM_SECONDS.get(upperOut) : null;
+        if (outMultiplier == null && outDivisor == null) {
+            // Out-unit MONTH/QUARTER/YEAR — variable on both sides; fixed-second math
+            // doesn't apply. Leave the call unchanged; isthmus will surface the failure.
+            return null;
+        }
+
+        // Build addedTs = DATETIME_PLUS(startArg, INTERVAL (inValue * innerMonths) MONTH)
+        // Mirrors EarliestLatestAdapter.makeIntervalAdd — INTERVAL_YEAR_MONTH backing unit.
+        long totalMonths;
+        try {
+            totalMonths = Math.multiplyExact(inValue, innerMonths);
+        } catch (ArithmeticException unused) {
+            return null;
+        }
+        SqlIntervalQualifier monthQualifier = new SqlIntervalQualifier(TimeUnit.MONTH, null, SqlParserPos.ZERO);
+        RexNode intervalLit = rexBuilder.makeIntervalLiteral(BigDecimal.valueOf(totalMonths), monthQualifier);
+        RexNode addedTs = rexBuilder.makeCall(SqlStdOperatorTable.DATETIME_PLUS, startArg, intervalLit);
+
+        // unix_seconds_diff = to_unixtime(addedTs) - to_unixtime(startArg)
+        // Use the locally-declared substrait-mapped operator (same one UnixTimestampAdapter
+        // and SpanAdapter route through to DataFusion's native to_unixtime UDF).
+        RexNode endSeconds = rexBuilder.makeCall(UnixTimestampAdapter.LOCAL_TO_UNIXTIME_OP, addedTs);
+        RexNode startSeconds = rexBuilder.makeCall(UnixTimestampAdapter.LOCAL_TO_UNIXTIME_OP, startArg);
+        RexNode diffSeconds = rexBuilder.makeCall(SqlStdOperatorTable.MINUS, endSeconds, startSeconds);
+
+        // Scale to the requested out-unit. PPL timechart's per_function uses MILLISECOND as
+        // out-unit so the multiplier path (×1000) is the hot case; the divisor path (e.g.
+        // MINUTE→÷60) covers consumer code shapes that compute coarser durations.
+        RexNode scaled;
+        if (outMultiplier != null && outMultiplier > 1L) {
+            RexNode multLit = rexBuilder.makeBigintLiteral(BigDecimal.valueOf(outMultiplier));
+            scaled = rexBuilder.makeCall(SqlStdOperatorTable.MULTIPLY, diffSeconds, multLit);
+        } else if (outDivisor != null && outDivisor > 1L) {
+            RexNode divLit = rexBuilder.makeBigintLiteral(BigDecimal.valueOf(outDivisor));
+            scaled = rexBuilder.makeCall(SqlStdOperatorTable.DIVIDE, diffSeconds, divLit);
+        } else {
+            scaled = diffSeconds;  // out-unit SECOND
+        }
+        return rexBuilder.makeCast(resultType, scaled, true);
     }
 
     /**
@@ -145,8 +263,7 @@ class TimestampDiffAdapter implements ScalarFunctionAdapter {
         if (!(node instanceof RexLiteral lit)) {
             return null;
         }
-        if (lit.getType().getSqlTypeName() != SqlTypeName.CHAR
-            && lit.getType().getSqlTypeName() != SqlTypeName.VARCHAR) {
+        if (lit.getType().getSqlTypeName() != SqlTypeName.CHAR && lit.getType().getSqlTypeName() != SqlTypeName.VARCHAR) {
             return null;
         }
         return lit.getValueAs(String.class);

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchAggregateSplitRule.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchAggregateSplitRule.java
@@ -14,8 +14,11 @@ import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.AggregateCall;
 import org.apache.calcite.rel.core.Project;
+import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.type.SqlTypeFamily;
+import org.apache.calcite.util.ImmutableBitSet;
 import org.opensearch.analytics.planner.PlannerContext;
 import org.opensearch.analytics.planner.RelNodeUtils;
 import org.opensearch.analytics.planner.rel.AggregateMode;
@@ -52,12 +55,87 @@ public class OpenSearchAggregateSplitRule extends RelOptRule {
         return aggregate.getMode() == AggregateMode.SINGLE;
     }
 
+    /**
+     * True when PARTIAL/FINAL split would yield a malformed row type or invalid aggregate
+     * semantics. In those cases {@link #onMatch} still produces the SINGLE+SINGLETON
+     * alternative (so the planner can route shard input through a coordinator gather), but
+     * skips the PARTIAL+ER+FINAL alternative.
+     *
+     * <p>Two cases are unsafe today:
+     * <ul>
+     *   <li><b>percentile_approx</b> is a 2-arg aggregate (field, percent) whose FINAL phase
+     *       needs (tdigest_state, percent_literal). {@code AggregateDecompositionResolver}'s
+     *       single-field rewrite paths only produce a single-arg FINAL call, yielding
+     *       {@code "Type mismatch: rel rowtype: RecordType(BIGINT p50, BIGINT p50_0) NOT NULL,
+     *       equiv rowtype: RecordType(INTEGER bucket, BIGINT p50)"}. Other aggCalls in the
+     *       same Aggregate (SUM, AVG, etc.) inherit the single-stage execution.</li>
+     *   <li><b>Cross-family non-prefix groupSet</b>: PARTIAL's output places group keys at
+     *       positions {@code [0..groupCount)}. FINAL reuses ORIGINAL's groupSet against
+     *       PARTIAL's output. When an input column at index {@code k >= groupCount} is a group
+     *       key (e.g. {@code groupSet={2}, groupCount=1}), PARTIAL's output at index {@code k}
+     *       is an agg-result instead, and Calcite's row-type equivalence check fires only if
+     *       that agg-result's {@link SqlTypeFamily} differs from the ORIGINAL input column's
+     *       family. PPL {@code timechart}'s no-{@code by} form trips this: the Project below
+     *       the Aggregate keeps the raw {@code @timestamp} (DATETIME family) at position 0
+     *       and materializes {@code SPAN(@timestamp)} at a later position; the agg result at
+     *       that later position is {@code DOUBLE} (NUMERIC family) → cross-family mismatch
+     *       ({@code "Type mismatch ... DOUBLE -> TIMESTAMP(0)"}). Same-family non-prefix
+     *       cases (e.g. {@code group={1}} with both columns INTEGER + a NUMERIC agg) pass
+     *       Calcite's relaxed numeric type check and don't need the skip — see
+     *       {@code PlanShapeTests.testJoinWithDifferentGroupKeys_multiShard}.</li>
+     * </ul>
+     *
+     * <p>Until {@code AggregateDecompositionResolver} gains engine-native merge support
+     * (percentile_approx) and ORIGINAL→FINAL groupSet remapping (cross-family non-prefix),
+     * the split is conservative in those shapes — distributed parallelism is traded for
+     * correctness.
+     */
+    private static boolean shouldSkipPartialFinalSplit(OpenSearchAggregate aggregate) {
+        for (AggregateCall aggCall : aggregate.getAggCallList()) {
+            if (isPercentileApprox(aggCall)) {
+                return true;
+            }
+        }
+        int groupCount = aggregate.getGroupSet().cardinality();
+        if (aggregate.getGroupSet().equals(ImmutableBitSet.range(groupCount))) {
+            return false;
+        }
+        // Non-prefix groupSet — narrow to the cross-family case that actually trips
+        // typeMatchesInferred. Each group-key index k >= groupCount would land on PARTIAL's
+        // agg-output slot at (k - groupCount). If that agg's result type and the ORIGINAL
+        // input column at k belong to different families, the split is unsafe.
+        List<RelDataType> inputFields = aggregate.getInput().getRowType().getFieldList().stream().map(f -> f.getType()).toList();
+        List<AggregateCall> aggCalls = aggregate.getAggCallList();
+        for (int k : aggregate.getGroupSet().toArray()) {
+            if (k < groupCount) {
+                continue;
+            }
+            int aggIdx = k - groupCount;
+            if (aggIdx >= aggCalls.size() || k >= inputFields.size()) {
+                return true;  // out of bounds → split would be structurally invalid
+            }
+            SqlTypeFamily inputFamily = inputFields.get(k).getSqlTypeName().getFamily();
+            SqlTypeFamily aggFamily = aggCalls.get(aggIdx).getType().getSqlTypeName().getFamily();
+            if (inputFamily != aggFamily) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean isPercentileApprox(AggregateCall aggCall) {
+        return "PERCENTILE_APPROX".equalsIgnoreCase(aggCall.getAggregation().getName());
+    }
+
     @Override
     public void onMatch(RelOptRuleCall call) {
         OpenSearchAggregate aggregate = call.rel(0);
         RelNode child = call.rel(1);
 
         // SINGLE-on-SINGLETON alternative — wins when the child already gathers below.
+        // Also the *only* alternative the rule offers when the PARTIAL/FINAL split would
+        // emit a row type that fails Volcano's typeMatchesInferred — see
+        // shouldSkipPartialFinalSplit for the cases.
         RelTraitSet singletonTraits = aggregate.getTraitSet().replace(context.getDistributionTraitDef().coordSingleton());
         RelNode singletonChild = convert(child, singletonTraits);
         OpenSearchAggregate singleOnSingleton = new OpenSearchAggregate(
@@ -71,6 +149,14 @@ public class OpenSearchAggregateSplitRule extends RelOptRule {
             aggregate.getViableBackends(),
             aggregate.getCallAnnotations()
         );
+
+        if (shouldSkipPartialFinalSplit(aggregate)) {
+            // The PARTIAL/FINAL alternative would emit a row type that fails Volcano's
+            // typeMatchesInferred check. Transform to the SINGLE+SINGLETON alternative
+            // so a coordinator-side gather still satisfies a SINGLETON-demanding parent.
+            call.transformTo(singleOnSingleton);
+            return;
+        }
 
         // PARTIAL + ER + FINAL alternative — wins when child is shard-partitioned.
         // Repair LIST/VALUES return type from PPL's lossy ARRAY<VARCHAR> to ARRAY<arg0> on


### PR DESCRIPTION
## Summary

End-to-end coverage closure for PPL `timechart` on the analytics-engine route. Five coupled commits in `analytics-backend-datafusion` take `CalciteTimechart{Command,PerFunction}IT` from **1/30 → 30/30 ✅** on `upstream/main`. Each commit corresponds to a distinct Substrait-binding gap surfaced by progressive IT runs against a `:run` cluster with `-Dtests.analytics.force_routing=true -Dtests.analytics.parquet_indices=true`.

## Commits

### 1. `[Analytics] Wire TIMESTAMPDIFF/TIMESTAMPADD + skip non-prefix-groupSet split`

Two coupled changes:

- Register `TIMESTAMPDIFF` and `TIMESTAMPADD` as scalar functions (enum constants in `ScalarFunction`, added to `STANDARD_PROJECT_OPS`). Clears the capability-layer rejection at `OpenSearchProjectRule.annotateExpr`; isthmus-side substrait conversion is still gated by per-call adapters (commit 2).
- `OpenSearchAggregateSplitRule.onMatch()` skips the PARTIAL/FINAL alternative when it would emit a row type that fails Volcano's `typeMatchesInferred`. Two unsafe shapes today:
    - `percentile_approx` (2-arg aggregate whose FINAL phase needs `(tdigest_state, percent_literal)`)
    - **Cross-family non-prefix groupSet** — when a non-prefix group-key index lands on PARTIAL's agg-output slot whose `SqlTypeFamily` differs from the ORIGINAL input column's family (e.g. PPL timechart's no-`by` form: `groupSet={2}` on a `[@timestamp:TIMESTAMP, cpu_usage:DOUBLE, SPAN(@timestamp):TIMESTAMP]` input where the SUM aggregate's DOUBLE return at position 2 clashes with TIMESTAMP at the same input position).
  Same-family non-prefix cases (e.g. `group={1}` over two INTEGER columns + a NUMERIC agg) still pass through the split unchanged — `PlanShapeTests.testJoinWithDifferentGroupKeys_multiShard` verifies this. The skip lives in `onMatch` (not `matches`) so the SINGLE+SINGLETON alternative is still registered, giving the planner a coordinator-gather path for the skipped shapes.

### 2. `[Analytics Backend] Add TimestampDiffAdapter peephole for timechart per_*`

Peephole that constant-folds `TIMESTAMPDIFF(out_unit, t, TIMESTAMPADD(in_unit, n, t))` to a BIGINT literal when both units are fixed-length (MICROSECOND…WEEK). Eliminates both PPL UDF references in one step — neither has a Substrait extension binding, so the unfolded calls would surface as `Unable to convert call TIMESTAMPADD(...)`. `OperatorAnnotation` wrappers introduced by `OpenSearchProjectRule` are peeled at each operand before structural comparison.

### 3. `[Analytics Backend] UInt64 → Int64 bridge at partition-stream boundary`

Analytics-engine reduce-stage fragments crashed with `Substrait error: Field '<name>' in Substrait schema has a different type (Int64) than the corresponding field in the table schema (UInt64)` when the upstream PARTIAL fragment emitted an Arrow type Substrait/Calcite has no native equivalent for. Canonical case: DataFusion's `row_number()` physical op (output: UInt64) feeding a consumer plan that types `ROW_NUMBER OVER` as BIGINT/Int64.

Extends the existing `schema_coerce::coerce_inferred_schema` bridge — currently applied only at the parquet-scan boundary — to the partition-stream registration boundary used by every inter-stage exchange:

- `api::register_partition_stream` runs `coerce_inferred_schema` on the producer-derived schema before `session.register_partition` and the IPC return path.
- `api::sender_send` adds `coerce_batch_to_sender_schema` — casts incoming `RecordBatch` columns to match the sender's coerced schema via `arrow::compute::cast`. Without this, DataFusion's HashJoin / RepartitionExec strict-downcasts to `Int64Type` and panics with `"primitive array"`.
- `DatafusionReduceSink.typesMatch` relaxed to treat same-width `Int` (any signedness) as compatible, mirroring the existing `Timestamp` precision tolerance.

### 4. `[Analytics Backend] SpanAdapter — multi-unit fixed-length time bucket`

Pre-existing `SpanAdapter` handled time spans only when `interval==1`. Multi-unit spans (`span=2m`, `span=12h`, `span=5d`, ...) fell through unchanged. Rewrite for fixed-length units (s, m, h, d, w):

```
SPAN(t, N, '<unit>')
  → CAST(from_unixtime(CAST((to_unixtime(t) / B) * B AS DOUBLE)) AS <result>)
  where B = N * unit_seconds
```

Three component choices were each forced by a binding-time substrait constraint:

1. **`LOCAL_TO_UNIXTIME_OP` / `LOCAL_FROM_UNIXTIME_OP`** (package-local) instead of Calcite stdlib `UNIX_SECONDS` / `TIMESTAMP_SECONDS`. The latter bind to BigQuery-named substrait functions DF's consumer has no entries for.
2. **No `FLOOR` between divide and multiply.** Integer ÷ integer already truncates (correct for non-negative epoch seconds); `FLOOR(i64)` doesn't bind in substrait (DF's `floor` is floating-point only).
3. **`CAST(... AS DOUBLE)` before `from_unixtime`.** yaml signature is `(fp64) → precision_timestamp<6>`.

Variable-length units (M, q, y) intentionally fall through — bucketing by calendar month isn't `N × fixed_seconds`. Commit 5 handles those.

### 5. `[Analytics Backend] TimestampDiffAdapter — variable-month runtime rewrite`

Extends commit 2's peephole to handle variable-length inner units (MONTH/QUARTER/YEAR) when the out-unit is fixed-length. Folding isn't safe (Feb 2025 = 28 days, Oct 2025 = 31 days — value depends on calendar month). Atomic runtime rewrite:

```
TIMESTAMPDIFF(out_unit, t, TIMESTAMPADD(MONTH|QUARTER|YEAR, n, t))
  →  (to_unixtime(DATETIME_PLUS(t, INTERVAL n*m MONTH)) - to_unixtime(t)) * out_factor
```

where `m` converts QUARTER→3 / YEAR→12, `INTERVAL_YEAR_MONTH` is built via `SqlIntervalQualifier(MONTH)` (same idiom as `EarliestLatestAdapter#makeIntervalAdd`, which has prior wiring proof that `DATETIME_PLUS(t, INTERVAL_MONTH)` binds end-to-end via Substrait's standard `add(timestamp, interval_year_month)` into DataFusion's native interval add).

PPL's `Chart#transformPerFunction` always emits MILLISECOND out-unit, so the multiplier path (×1000) is the hot case; the divisor path (MINUTE→÷60 etc.) covers consumer code shapes that compute coarser durations.

## Pass-rate impact

Verified locally against `upstream/main` + this PR's full stack:

| Test class | Baseline | + c1 (TIMESTAMPDIFF wire) | + c2 (peephole) | + c3 (UInt64 bridge) | + c4 (SpanAdapter multi-unit) | + c5 (variable-month rewrite) |
|---|---|---|---|---|---|---|
| `CalciteTimechartCommandIT` | 1/18 | 1/18 | 5/18 | 18/18 ✅ | 18/18 ✅ | **18/18 ✅** |
| `CalciteTimechartPerFunctionIT` | 0/12 | 0/12 | 1/12 | 1/12 | 10/12 | **12/12 ✅** |
| **Combined** | **1/30** | **1/30** | **6/30** | **19/30** | **28/30** | **30/30 ✅** |

`PlanShapeTests.testJoinWithDifferentGroupKeys_multiShard` (the multi-shard join-with-non-prefix-groupSet plan-shape regression test) and the 12 other `PlanShapeTests` cases also pass — no regression to the existing split rule's coverage.

## Sandbox check status

`./gradlew check -p sandbox -Dsandbox.enabled=true` results on this branch:

- ✅ All analytics-backend-datafusion / analytics-engine / analytics-framework / parquet-data-format / composite-engine unit tests pass (`-Werror` compile, spotless, checkstyle, forbiddenApis, licenseHeaders, dependencyLicenses, thirdPartyAudit all clean).
- ⚠️ Pre-existing failures in `:sandbox:qa:analytics-engine-coordinator:internalClusterTest` and `:sandbox:plugins:composite-engine:internalClusterTest` (9 + 2 tests) all surface the same `Allocator[ROOT] closed with outstanding child allocators` teardown leak. Identical failures reproduce on plain `upstream/main` without any of this PR's commits — confirmed in a separate run. Unrelated to the code paths this PR touches (`SpanAdapter`, `TimestampDiffAdapter`, `OpenSearchAggregateSplitRule`, `register_partition_stream`, `sender_send`, `typesMatch`).

## Test plan

- [x] `CalciteTimechartCommandIT` — 18/18 on analytics-engine route
- [x] `CalciteTimechartPerFunctionIT` — 12/12 on analytics-engine route
- [x] `PlanShapeTests` (analytics-engine) — 13/13, no regression to non-prefix-groupSet handling
- [x] `./gradlew check -p sandbox -Dsandbox.enabled=true` — unit-test surface clean; pre-existing flakes in unrelated `internalClusterTest` modules