### PR TITLE
[Sandbox] Add local index authorization check to analytics engine before planning phase

### DIFF
--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/AnalyticsPlugin.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/AnalyticsPlugin.java
@@ -20,7 +20,9 @@ import org.opensearch.analytics.exec.DefaultPlanExecutor;
 import org.opensearch.analytics.exec.QueryPlanExecutor;
 import org.opensearch.analytics.exec.QueryScheduler;
 import org.opensearch.analytics.exec.Scheduler;
+import org.opensearch.analytics.exec.action.AnalyticsAuthAction;
 import org.opensearch.analytics.exec.action.AnalyticsQueryAction;
+import org.opensearch.analytics.exec.action.TransportAnalyticsAuthAction;
 import org.opensearch.analytics.planner.CapabilityRegistry;
 import org.opensearch.analytics.planner.FieldStorageResolver;
 import org.opensearch.analytics.schema.OpenSearchSchemaBuilder;
@@ -135,7 +137,10 @@ public class AnalyticsPlugin extends Plugin implements ExtensiblePlugin, ActionP
 
     @Override
     public List<ActionHandler<? extends ActionRequest, ? extends ActionResponse>> getActions() {
-        return List.of(new ActionHandler<>(AnalyticsQueryAction.INSTANCE, DefaultPlanExecutor.class));
+        return List.of(
+            new ActionHandler<>(AnalyticsQueryAction.INSTANCE, DefaultPlanExecutor.class),
+            new ActionHandler<>(AnalyticsAuthAction.INSTANCE, TransportAnalyticsAuthAction.class)
+        );
     }
 
     @Override

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/DefaultPlanExecutor.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/DefaultPlanExecutor.java
@@ -21,6 +21,8 @@ import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.action.support.TimeoutTaskCancellationUtility;
 import org.opensearch.analytics.AnalyticsPlugin;
 import org.opensearch.analytics.EngineContext;
+import org.opensearch.analytics.exec.action.AnalyticsAuthAction;
+import org.opensearch.analytics.exec.action.AnalyticsAuthRequest;
 import org.opensearch.analytics.exec.action.AnalyticsQueryAction;
 import org.opensearch.analytics.exec.task.AnalyticsQueryTask;
 import org.opensearch.analytics.exec.task.AnalyticsQueryTaskRequest;
@@ -109,10 +111,24 @@ public class DefaultPlanExecutor extends HandledTransportAction<ActionRequest, A
 
     @Override
     public void execute(RelNode logicalFragment, Object context, ActionListener<Iterable<Object[]>> listener) {
-        // Fork the entire query lifecycle (planning, scheduling, cleanup) onto the SEARCH
-        // executor so the calling thread — which may be a transport thread — is freed
-        // immediately. The scheduler then drives execution asynchronously and fires
-        // {@code listener} once the query terminates; nothing on this path blocks.
+        // Extract target indices from the logical plan and check authorization before
+        // doing any planning work. Dispatches AnalyticsAuthRequest (which extends SearchRequest)
+        // through the action filter chain so the SecurityFilter evaluates index-level permissions.
+        // Using SearchRequest as the base ensures the legacy security evaluator's IndexResolverReplacer
+        // correctly resolves the target indices.
+        String[] indices = extractIndices(logicalFragment);
+        if (indices.length > 0) {
+            client.execute(
+                AnalyticsAuthAction.INSTANCE,
+                new AnalyticsAuthRequest(indices),
+                ActionListener.wrap(ok -> doExecuteOnSearchPool(logicalFragment, listener), listener::onFailure)
+            );
+        } else {
+            doExecuteOnSearchPool(logicalFragment, listener);
+        }
+    }
+
+    private void doExecuteOnSearchPool(RelNode logicalFragment, ActionListener<Iterable<Object[]>> listener) {
         searchExecutor.execute(() -> {
             try {
                 executeInternal(logicalFragment, listener);
@@ -128,6 +144,23 @@ public class DefaultPlanExecutor extends HandledTransportAction<ActionRequest, A
                 listener.onFailure(new IllegalStateException("Analytics-engine executor rejected the plan: " + e.getMessage(), e));
             }
         });
+    }
+
+    /** Extracts index names from LogicalTableScan nodes in the plan. */
+    private static String[] extractIndices(RelNode plan) {
+        java.util.Set<String> indices = new java.util.LinkedHashSet<>();
+        collectIndices(plan, indices);
+        return indices.toArray(String[]::new);
+    }
+
+    private static void collectIndices(RelNode node, java.util.Set<String> indices) {
+        if (node instanceof org.apache.calcite.rel.core.TableScan scan) {
+            List<String> names = scan.getTable().getQualifiedName();
+            indices.add(names.get(names.size() - 1));
+        }
+        for (RelNode input : node.getInputs()) {
+            collectIndices(input, indices);
+        }
     }
 
     /**

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/action/AnalyticsAuthAction.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/action/AnalyticsAuthAction.java
@@ -1,0 +1,29 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.exec.action;
+
+import org.opensearch.action.ActionType;
+
+/**
+ * Lightweight action used to check index-level authorization before analytics query execution.
+ * The action name matches the {@code indices:data/read*} pattern so the security plugin's
+ * standard {@code read} action group grants access.
+ *
+ * <p>The transport handler is a no-op — if the request reaches {@code doExecute}, it means
+ * the security filter has already authorized the indices.
+ */
+public class AnalyticsAuthAction extends ActionType<AnalyticsAuthResponse> {
+
+    public static final String NAME = "indices:data/read/analytics/authorize";
+    public static final AnalyticsAuthAction INSTANCE = new AnalyticsAuthAction();
+
+    private AnalyticsAuthAction() {
+        super(NAME, AnalyticsAuthResponse::new);
+    }
+}

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/action/AnalyticsAuthRequest.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/action/AnalyticsAuthRequest.java
@@ -1,0 +1,31 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.exec.action;
+
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.core.common.io.stream.StreamInput;
+
+import java.io.IOException;
+
+/**
+ * Authorization probe request that extends {@link SearchRequest} so the security plugin's
+ * legacy {@code IndexResolverReplacer} correctly resolves the target indices. The action
+ * name ({@code indices:data/read/analytics/authorize}) matches the {@code indices:data/read*}
+ * pattern, ensuring users with the standard {@code read} action group are authorized.
+ */
+public class AnalyticsAuthRequest extends SearchRequest {
+
+    public AnalyticsAuthRequest(String... indices) {
+        super(indices);
+    }
+
+    public AnalyticsAuthRequest(StreamInput in) throws IOException {
+        super(in);
+    }
+}

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/action/AnalyticsAuthResponse.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/action/AnalyticsAuthResponse.java
@@ -1,0 +1,28 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.exec.action;
+
+import org.opensearch.core.action.ActionResponse;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+
+/** Empty response indicating authorization succeeded. */
+public class AnalyticsAuthResponse extends ActionResponse {
+
+    public AnalyticsAuthResponse() {}
+
+    public AnalyticsAuthResponse(StreamInput in) throws IOException {
+        super(in);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {}
+}

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/action/TransportAnalyticsAuthAction.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/action/TransportAnalyticsAuthAction.java
@@ -1,0 +1,35 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.exec.action;
+
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.HandledTransportAction;
+import org.opensearch.common.inject.Inject;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.tasks.Task;
+import org.opensearch.transport.TransportService;
+
+/**
+ * No-op transport action for index-level authorization checks. If execution reaches
+ * {@code doExecute}, the security filter has already authorized the request — we simply
+ * return success. If the security filter denies access, it short-circuits before this
+ * method is called and the caller receives a security exception.
+ */
+public class TransportAnalyticsAuthAction extends HandledTransportAction<AnalyticsAuthRequest, AnalyticsAuthResponse> {
+
+    @Inject
+    public TransportAnalyticsAuthAction(TransportService transportService, ActionFilters actionFilters) {
+        super(AnalyticsAuthAction.NAME, transportService, actionFilters, AnalyticsAuthRequest::new);
+    }
+
+    @Override
+    protected void doExecute(Task task, AnalyticsAuthRequest request, ActionListener<AnalyticsAuthResponse> listener) {
+        listener.onResponse(new AnalyticsAuthResponse());
+    }
+}


### PR DESCRIPTION
### Description

The analytics engine's query execution path (PPL, SQL) bypasses the security plugin's index-level privilege evaluation. The `FragmentExecutionRequest` on the data node is executed with `dispatchFragmentStreaming` and never evaluated for index permissions by the security plugin `SecurityFilter` (wraps the `ActionFilter`).

### SQL / PPL queries with analytics engine

In a typical SQL / PPL query authorization is handled at the node-to-node transport layer on the coordinator as the request is being dispatched to shards. The security plugin [provides an ActionFilter](https://github.com/opensearch-project/security/blob/main/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java#L964-L971) which every TransportAction child holds a reference to, and [executes on new requests](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/action/support/TransportAction.java#L213-L228).

The overall flow for a regular DSL search query is then:
```
NodeClient.execute(SearchAction.INSTANCE, searchRequest)
    → NodeClient.executeLocally(action, request, listener)
      → transportAction(action).execute(request, listener)
        → TransportAction.execute(task, request, listener)
          → RequestFilterChain.proceed()
```

The path for an analytics engine SQL / PPL query avoids the `RequestFilterChain` entirely. The `ShardTaskRunner` is  responsible for dispatching a `FragmentExecutionRequest` on the transport layer.

```
    @Override
    public void run(ShardStageTask task, ActionListener<Void> listener) {
        ShardExecutionTarget target = (ShardExecutionTarget) task.target();
        FragmentExecutionRequest request = requestBuilder.apply(target);
        PendingExecutions pending = pendingFor(target);
        transport.dispatchFragmentStreaming(request, target.node(), stage.responseListenerFor(listener), config.parentTask(), pending);
    }
```

The `FragmentExecutionRequest` fetches a new connection from the transport service, and [directly executes ](https://github.com/opensearch-project/OpenSearch/blob/main/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/AnalyticsSearchTransportService.java#L193-L204)the request itself. Skipping the `TransportAction` framework which typically holds and applies the `ActionFilter`.

```
        pending.tryRun(() -> {
            try {
                Transport.Connection connection = getConnection(null, targetNode.getId());
                transportService.sendChildRequest(connection, FragmentExecutionAction.NAME, request, parentTask, options, handler);
            } catch (Exception e) {
                try {
                    listener.onFailure(e);
                } finally {
                    pending.finishAndRunNext();
                }
            }
        });
```

### DSL queries with analytics engine

DSL permissions are actually evaluated correctly already. This comes from how DSL is routed into the analytics plugin. DSL queries construct a regular `SearchRequest` which is handled by the `TransportSearchAction` and are executed on the transport layer with the local node client as usual.

Handling of DSL queries is done by a new `SearchActionFilter` which is also injected into the `RequestFilterChain` and [redirects these `SearchRequest`s to the `DslExecuteAction.INSTANCE` handler](https://github.com/opensearch-project/OpenSearch/blob/main/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/action/SearchActionFilter.java) instead of executing them as normal search requests. Since this `SearchActionFilter` executes AFTER the security plugin ActionFilter (which has highest priority), privileges are evaluated correctly.

| Path | Unauthorized Index | Status |
|------|-------------------|--------|
| DSL (`POST /{index}/_search`) | ✅ Denied | Secure |
| PPL (`POST /_plugins/_ppl`) | ❌ Allowed | **Gap** |
| SQL (`POST /_plugins/_sql`) | ❌ Allowed | **Gap** |

### Proposed fix

These changes somewhat mimic the functionality of DSL queries for SQL and PPL by adding a pre-planning authorization check which passes a no-op `AnalyticsAuthRequest` through the `ActionFilter` to determine if permissions are valid for the equivalent set of  `FragmentExecutionRequest`s.

No actual request is executed on the transport layer, the `AnalyticsAuthRequest` is passed through the full `ActionFilter` chain to invoke security plugin privilege evaluation, and proceeds with the analytics engine planning + query only if this probing `AnalyticsAuthRequest` is authorized for the same indices.

### Testing

Testing this feature requires an analytics engine enabled OpenSearch node, with SQL plugin installed, and security plugin installed. Currently SQL plugin supports this environment with distribution level security enabled tests. This seems like the most ideal place to house ITs validating index level security over the analytics plugin.

Test implementation is pending. Currently changes are validated with local single node testing.

### Related Issues
N/A

### Check List
- [ ] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
