### PR TITLE
Support different shapes of TIMESTAMP function

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DateTimeAdapters.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DateTimeAdapters.java
@@ -73,8 +73,6 @@ final class DateTimeAdapters {
         SqlFunctionCategory.TIMEDATE
     );
 
-    // 1-arg timestamp(expr) remains on the legacy engine — the TIMESTAMP enum slot is already
-    // bound to TimestampFunctionAdapter for VARCHAR-literal folding.
     static final SqlOperator LOCAL_TO_TIMESTAMP_OP = new SqlFunction(
         "to_timestamp",
         SqlKind.OTHER_FUNCTION,

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/TimestampFunctionAdapter.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/TimestampFunctionAdapter.java
@@ -13,67 +13,262 @@ import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.util.TimestampString;
+import org.opensearch.analytics.planner.rel.OperatorAnnotation;
 import org.opensearch.analytics.spi.FieldStorageInfo;
 import org.opensearch.analytics.spi.ScalarFunctionAdapter;
 
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeParseException;
 import java.util.List;
 
 /**
- * Converts {@code TIMESTAMP(varchar_literal)} into a {@code TIMESTAMP} literal with
- * precision derived from the field's mapping type (date→3, date_nanos→9).
+ * Routes PPL {@code TIMESTAMP(...)} calls to the right backend path.
  *
- * <p>Registered as a {@link ScalarFunctionAdapter} for {@code ScalarFunction.TIMESTAMP}.
- * {@link org.opensearch.analytics.planner.dag.BackendPlanAdapter} calls this after plan
- * forking, passing the {@code TIMESTAMP(varchar)} RexCall directly.
+ * <table>
+ *   <caption>TIMESTAMP shape coverage</caption>
+ *   <tr><th>Shape</th><th>Example</th><th>Path</th><th>Status</th></tr>
+ *   <tr><td>A</td>
+ *       <td>{@code TIMESTAMP('2020-01-01 00:00:00')}</td>
+ *       <td>plan-time fold (varchar literal)</td>
+ *       <td>works</td></tr>
+ *   <tr><td>B</td>
+ *       <td>{@code TIMESTAMP(DATE('2020-08-26'))}</td>
+ *       <td>plan-time fold (DATE-of-literal): combine date with 00:00:00 UTC,
+ *           matches {@code ExprDateValue.timestampValue() = date.atStartOfDay(UTC)}</td>
+ *       <td>works</td></tr>
+ *   <tr><td>C</td>
+ *       <td>{@code TIMESTAMP(TIME('10:20:30'))}</td>
+ *       <td>plan-time fold (TIME-of-literal): combine time with today's UTC date,
+ *           matches {@code ExprTimeValue.timestampValue} </td>
+ *       <td>works</td></tr>
+ *   <tr><td>D</td>
+ *       <td>{@code TIMESTAMP(TIMESTAMP('lit'))}</td>
+ *       <td>inner Shape A fold collapses the call into a typed TIMESTAMP literal;
+ *           the outer adapter sees a TIMESTAMP-typed operand, falls through to
+ *           {@link DateTimeAdapters.DatetimeAdapter} which renames to DataFusion's
+ *           builtin {@code to_timestamp(timestamp)} (identity at runtime)</td>
+ *       <td>works</td></tr>
+ *   <tr><td>E</td>
+ *       <td>{@code TIMESTAMP('2020-01-01 10:00:00', '01:30:00')}</td>
+ *       <td>plan-time fold (2-arg literal-literal): parse first as timestamp,
+ *           second as time-of-day, add. Matches
+ *           {@code TimestampFunction.timestamp(props, dt, addTime) = exprAddTime}</td>
+ *       <td>works</td></tr>
+ *   <tr><td>F</td>
+ *       <td>{@code TIMESTAMP(<column>)}</td>
+ *       <td>operand is {@code RexInputRef}; fold doesn't catch. Routes to
+ *           {@link DateTimeAdapters.DatetimeAdapter} → DataFusion builtin
+ *           {@code to_timestamp}.</td>
+ *       <td>works for DATE / TIMESTAMP / VARCHAR columns</td></tr>
+ *   <tr><td>G</td>
+ *       <td>{@code TIMESTAMP('<bad string>')}</td>
+ *       <td>{@link #parseTimestamp} throws {@code IllegalArgumentException}
+ *           with the raw input when no format matches (covers month-13,
+ *           second-61, garbage). HTTP 400 with the bare input as the message.</td>
+ *       <td>rejects with HTTP 400</td></tr>
+ * </table>
+ *
+ * <p>The fold path bypasses runtime evaluation and avoids the
+ * {@code to_timestamp(to_date(...))} chain that DataFusion can't execute on
+ * this stack ({@code Unsupported data type Date32 for function to_timestamp}).
+ *
+ * <p>The chosen RexNode is wrapped in a CAST to the call's declared type so
+ * the surrounding Project's rowType matches.
  *
  * @opensearch.internal
  */
 class TimestampFunctionAdapter implements ScalarFunctionAdapter {
 
+    private static final DateTimeAdapters.DatetimeAdapter DATETIME_ADAPTER = new DateTimeAdapters.DatetimeAdapter();
+
     @Override
     public RexNode adapt(RexCall original, List<FieldStorageInfo> fieldStorage, RelOptCluster cluster) {
-        if (original.getOperands().size() != 1
-            || !(original.getOperands().get(0) instanceof RexLiteral literal)
-            || literal.getType().getSqlTypeName() != SqlTypeName.VARCHAR) {
-            return original;
+        RexNode folded = tryFoldLiteral(original, fieldStorage, cluster);
+        if (folded != null) {
+            return wrapWithCallType(folded, original, cluster);
         }
-        int precision = resolveTimestampPrecision(original, fieldStorage);
-        if (precision < 0) {
-            return original;
-        }
-        String value = literal.getValueAs(String.class);
-        if (value == null) {
-            return original;
-        }
-        RexBuilder rexBuilder = cluster.getRexBuilder();
-        return rexBuilder.makeTimestampLiteral(parseTimestamp(value), precision);
+        return wrapWithCallType(DATETIME_ADAPTER.adapt(original, fieldStorage, cluster), original, cluster);
     }
 
     /**
-     * Resolves timestamp precision from field storage. Scans all fields for date/date_nanos
-     * since the TIMESTAMP(varchar) call itself has no field reference — the field ref is
-     * in the parent comparison (e.g., $0 in >($0, TIMESTAMP('...'))).
+     * Recognize the four nested-with-literal shapes and fold them at plan time
+     * into typed TIMESTAMP literals, matching legacy semantics from the SQL
+     * plugin's {@code ExprTimestampValue} / {@code ExprDateValue} /
+     * {@code ExprTimeValue} / {@code TimestampFunction}.
+     *
+     * <p>Returns {@code null} when the call shape isn't a foldable literal —
+     * caller falls through to the DatetimeAdapter rename path.
      */
-    private int resolveTimestampPrecision(RexCall call, List<FieldStorageInfo> fieldStorage) {
-        for (FieldStorageInfo field : fieldStorage) {
-            String mappingType = field.getMappingType();
-            // TODO: date_nanos is not yet mapped by OpenSearchSchemaBuilder (falls through to VARCHAR),
-            // so this branch is currently unreachable — kept for when date_nanos schema support lands.
-            if ("date_nanos".equals(mappingType)) return 9;
-            if ("date".equals(mappingType)) return 3;
+    private static RexNode tryFoldLiteral(RexCall original, List<FieldStorageInfo> fieldStorage, RelOptCluster cluster) {
+        // Pick precision from field storage: date_nanos → 9, otherwise default to 3
+        // (millisecond). Using ms-precision for the common case keeps the folded
+        // literal's i64 representation well within range — TIMESTAMP(9) at year
+        // 3077 overflows i64 (max ~year 2262), TIMESTAMP(3) does not.
+        int precision = resolvePrecision(fieldStorage);
+        RexBuilder rexBuilder = cluster.getRexBuilder();
+
+        if (original.getOperands().size() == 2) {
+            return tryFoldTwoArg(original, precision, rexBuilder);
         }
-        return -1;
+        if (original.getOperands().size() != 1) {
+            return null;
+        }
+
+        RexNode operand = stripOperatorAnnotation(original.getOperands().get(0));
+
+        // Shape A: TIMESTAMP(<varchar literal>) — parse and fold.
+        if (operand instanceof RexLiteral literal && literal.getType().getSqlTypeName() == SqlTypeName.VARCHAR) {
+            String value = literal.getValueAs(String.class);
+            if (value == null) {
+                return null;
+            }
+            return rexBuilder.makeTimestampLiteral(parseTimestamp(value), precision);
+        }
+
+        // Shapes B and C: TIMESTAMP(DATE/TIME(<varchar literal>)). After bottom-up
+        // adapter walk, the inner DATE/TIME has been renamed by DateAdapter /
+        // TimeAdapter to LOCAL_DATE_OP / LOCAL_TIME_OP.
+        if (operand instanceof RexCall innerCall
+            && innerCall.getOperands().size() == 1
+            && stripOperatorAnnotation(innerCall.getOperands().get(0)) instanceof RexLiteral innerLiteral
+            && innerLiteral.getType().getSqlTypeName() == SqlTypeName.VARCHAR) {
+            SqlOperator innerOp = innerCall.getOperator();
+            String innerValue = innerLiteral.getValueAs(String.class);
+            if (innerValue == null) {
+                return null;
+            }
+
+            // Shape B: TIMESTAMP(DATE('lit')) — combine date with 00:00:00 UTC.
+            if (innerOp == DateTimeAdapters.LOCAL_DATE_OP) {
+                LocalDate date;
+                try {
+                    date = LocalDate.parse(innerValue);
+                } catch (DateTimeParseException e) {
+                    return null;
+                }
+                return rexBuilder.makeTimestampLiteral(toTimestampString(date.atStartOfDay()), precision);
+            }
+
+            // Shape C: TIMESTAMP(TIME('lit')) — combine time with today's UTC date.
+            if (innerOp == DateTimeAdapters.LOCAL_TIME_OP) {
+                LocalTime time;
+                try {
+                    time = LocalTime.parse(innerValue);
+                } catch (DateTimeParseException e) {
+                    return null;
+                }
+                LocalDate today = LocalDate.now(ZoneOffset.UTC);
+                return rexBuilder.makeTimestampLiteral(toTimestampString(LocalDateTime.of(today, time)), precision);
+            }
+        }
+
+        return null;
     }
 
-    TimestampString parseTimestamp(String input) {
+    /**
+     * Shape E: 2-arg literal-literal {@code TIMESTAMP('<datetime>', '<time>')}.
+     * Parses the first arg as a timestamp, the second as a time-of-day,
+     * adds the time onto the timestamp. Matches legacy
+     * {@code TimestampFunction.timestamp(properties, datetime, addTime)}
+     * which calls {@code exprAddTime}.
+     */
+    private static RexNode tryFoldTwoArg(RexCall original, int precision, RexBuilder rexBuilder) {
+        RexNode op0 = stripOperatorAnnotation(original.getOperands().get(0));
+        RexNode op1 = stripOperatorAnnotation(original.getOperands().get(1));
+        if (!(op0 instanceof RexLiteral lit0) || lit0.getType().getSqlTypeName() != SqlTypeName.VARCHAR) {
+            return null;
+        }
+        if (!(op1 instanceof RexLiteral lit1) || lit1.getType().getSqlTypeName() != SqlTypeName.VARCHAR) {
+            return null;
+        }
+        String tsValue = lit0.getValueAs(String.class);
+        String timeValue = lit1.getValueAs(String.class);
+        if (tsValue == null || timeValue == null) {
+            return null;
+        }
+        TimestampString tsStr = parseTimestamp(tsValue);
+        LocalTime addTime;
+        try {
+            addTime = parseTimeOfDay(timeValue);
+        } catch (DateTimeParseException e) {
+            return null;
+        }
+        // Compose: take tsStr, advance by addTime's nano-of-day. Use LocalDateTime
+        // for arithmetic, then re-render to TimestampString.
+        LocalDateTime base;
+        try {
+            base = LocalDateTime.parse(tsStr.toString().replace(' ', 'T'));
+        } catch (DateTimeParseException e) {
+            return null;
+        }
+        LocalDateTime sum = base.plusNanos(addTime.toNanoOfDay());
+        return rexBuilder.makeTimestampLiteral(toTimestampString(sum), precision);
+    }
+
+    private static LocalTime parseTimeOfDay(String input) {
+        for (java.time.format.DateTimeFormatter formatter : TIME_OF_DAY_FORMATS) {
+            try {
+                return formatter == null ? LocalTime.parse(input) : LocalTime.parse(input, formatter);
+            } catch (DateTimeParseException ignored) {}
+        }
+        throw new DateTimeParseException("Unsupported time format", input, 0);
+    }
+
+    /** {@code null} entry means "use {@link LocalTime#parse(CharSequence)}'s default ISO format".
+     *  Locale-pinned formatters avoid the default-locale forbidden-api hit. */
+    private static final java.time.format.DateTimeFormatter[] TIME_OF_DAY_FORMATS = new java.time.format.DateTimeFormatter[] {
+        null,
+        java.time.format.DateTimeFormatter.ofPattern("HH:mm:ss", java.util.Locale.ROOT),
+        java.time.format.DateTimeFormatter.ofPattern("HH:mm", java.util.Locale.ROOT) };
+
+    /**
+     * Pick a precision for fold output. {@code date_nanos} fields force 9
+     * (nanosecond) precision so values can compare equal to native ts values;
+     * everything else defaults to 3 (millisecond), which is wide enough for
+     * year-of-i64-ns-overflow boundary cases (year 3077+).
+     */
+    private static int resolvePrecision(List<FieldStorageInfo> fieldStorage) {
+        for (FieldStorageInfo field : fieldStorage) {
+            if ("date_nanos".equals(field.getMappingType())) {
+                return 9;
+            }
+        }
+        return 3;
+    }
+
+    /**
+     * Lift the chosen RexNode to the call's declared type so the surrounding
+     * Project's rowType matches.
+     */
+    private static RexNode wrapWithCallType(RexNode chosen, RexCall original, RelOptCluster cluster) {
+        if (chosen.getType().equals(original.getType())) {
+            return chosen;
+        }
+        return cluster.getRexBuilder().makeAbstractCast(original.getType(), chosen);
+    }
+
+    private static RexNode stripOperatorAnnotation(RexNode node) {
+        while (node instanceof OperatorAnnotation annotation && annotation.unwrap() != null) {
+            node = annotation.unwrap();
+        }
+        return node;
+    }
+
+    /**
+     * Parse a varchar timestamp literal in the formats accepted by legacy
+     * {@code ExprTimestampValue}: {@code yyyy-MM-dd HH:mm:ss[.SSSSSSSSS]} and
+     * ISO-8601. Mirrors the previous adapter's fall-through chain so cherry-picked
+     * cases that used to work still work.
+     */
+    static TimestampString parseTimestamp(String input) {
         try {
             LocalDate date = LocalDate.parse(input);
             return toTimestampString(date.atStartOfDay());
@@ -94,18 +289,17 @@ class TimestampFunctionAdapter implements ScalarFunctionAdapter {
             return toTimestampString(ldt);
         } catch (DateTimeParseException ignored) {}
 
-        // Handle space-separated format: "yyyy-MM-dd HH:mm:ss" or "yyyy-MM-dd HH:mm:ss.SSS"
         if (input.contains(" ") && !input.contains("T")) {
             try {
                 LocalDateTime ldt = LocalDateTime.parse(input.replace(' ', 'T'));
                 return toTimestampString(ldt);
             } catch (DateTimeParseException ignored) {}
         }
-
-        return new TimestampString(input);
+        throw new IllegalArgumentException(input);
     }
 
-    private TimestampString toTimestampString(LocalDateTime ldt) {
+    private static TimestampString toTimestampString(LocalDateTime ldt) {
+        rejectIfOutsideI64NsRange(ldt);
         TimestampString ts = new TimestampString(
             ldt.getYear(),
             ldt.getMonthValue(),
@@ -119,5 +313,28 @@ class TimestampFunctionAdapter implements ScalarFunctionAdapter {
             ts = ts.withNanos(nanos);
         }
         return ts;
+    }
+
+    /**
+     * The analytics-engine route serializes TIMESTAMP values as i64 nanoseconds
+     * since epoch (Substrait/Arrow). Values past the i64-ns ceiling overflow
+     * silently in DataFusion's optimizer (e.g. {@code simplify_expressions}
+     * widening a TIMESTAMP(3) to TIMESTAMP(9) via {@code * 1000}), surfacing as
+     * an opaque {@code Arrow error: Arithmetic overflow} at execution. Reject
+     * up front with a clear message so users see the limit at plan time.
+     *
+     * <p>Upper bound is the exact i64-ns ceiling — {@code Long.MAX_VALUE} ns is
+     * {@code 2262-04-11 23:47:16.854775807 UTC}.
+     */
+    private static final LocalDateTime I64_NS_MAX = LocalDateTime.ofEpochSecond(
+        Long.MAX_VALUE / 1_000_000_000L,
+        (int) (Long.MAX_VALUE % 1_000_000_000L),
+        ZoneOffset.UTC
+    );
+
+    private static void rejectIfOutsideI64NsRange(LocalDateTime ldt) {
+        if (ldt.isAfter(I64_NS_MAX)) {
+            throw new IllegalArgumentException("timestamp " + ldt + " is outside the supported range");
+        }
     }
 }

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/TimestampFunctionAdapterTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/TimestampFunctionAdapterTests.java
@@ -8,60 +8,304 @@
 
 package org.opensearch.be.datafusion;
 
+import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.hep.HepPlanner;
+import org.apache.calcite.plan.hep.HepProgramBuilder;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlFunction;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.type.OperandTypes;
+import org.apache.calcite.sql.type.ReturnTypes;
+import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.util.TimestampString;
 import org.opensearch.test.OpenSearchTestCase;
 
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.List;
+
 public class TimestampFunctionAdapterTests extends OpenSearchTestCase {
 
-    private final TimestampFunctionAdapter transformer = new TimestampFunctionAdapter();
+    private RelDataTypeFactory typeFactory;
+    private RexBuilder rexBuilder;
+    private RelOptCluster cluster;
+    private TimestampFunctionAdapter adapter;
+
+    /** Stand-in for PPL's TIMESTAMP function — only the operand shape and the
+     *  declared return type matter to the adapter. */
+    private static final SqlFunction TIMESTAMP_OP = new SqlFunction(
+        "TIMESTAMP",
+        SqlKind.OTHER_FUNCTION,
+        ReturnTypes.TIMESTAMP,
+        null,
+        OperandTypes.ANY,
+        SqlFunctionCategory.TIMEDATE
+    );
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        typeFactory = new JavaTypeFactoryImpl();
+        rexBuilder = new RexBuilder(typeFactory);
+        HepPlanner planner = new HepPlanner(new HepProgramBuilder().build());
+        cluster = RelOptCluster.create(planner, rexBuilder);
+        adapter = new TimestampFunctionAdapter();
+    }
+
+    // ── parseTimestamp helper coverage (preserved from the previous suite) ─
 
     public void testIsoWithTAndZ() {
-        TimestampString ts = transformer.parseTimestamp("2024-01-01T00:00:00Z");
-        assertEquals("2024-01-01 00:00:00", ts.toString());
+        assertEquals("2024-01-01 00:00:00", TimestampFunctionAdapter.parseTimestamp("2024-01-01T00:00:00Z").toString());
     }
 
     public void testIsoWithTNoZ() {
-        TimestampString ts = transformer.parseTimestamp("2024-01-15T10:30:00");
-        assertEquals("2024-01-15 10:30:00", ts.toString());
+        assertEquals("2024-01-15 10:30:00", TimestampFunctionAdapter.parseTimestamp("2024-01-15T10:30:00").toString());
     }
 
     public void testDateOnly() {
-        TimestampString ts = transformer.parseTimestamp("2024-01-01");
-        assertEquals("2024-01-01 00:00:00", ts.toString());
+        assertEquals("2024-01-01 00:00:00", TimestampFunctionAdapter.parseTimestamp("2024-01-01").toString());
     }
 
-    public void testTimezoneOffsetPositive() {
-        TimestampString ts = transformer.parseTimestamp("2024-01-01T10:00:00+05:30");
-        assertEquals("2024-01-01 04:30:00", ts.toString());
-    }
-
-    public void testTimezoneOffsetNegative() {
-        TimestampString ts = transformer.parseTimestamp("2024-01-01T10:00:00-05:00");
-        assertEquals("2024-01-01 15:00:00", ts.toString());
+    public void testTimezoneOffsetConvertsToUtc() {
+        // Both signs in one test — they exercise the same OffsetDateTime → UTC
+        // conversion branch; the sign-flip on offset minutes is mathematically
+        // symmetric.
+        assertEquals("2024-01-01 04:30:00", TimestampFunctionAdapter.parseTimestamp("2024-01-01T10:00:00+05:30").toString());
+        assertEquals("2024-01-01 15:00:00", TimestampFunctionAdapter.parseTimestamp("2024-01-01T10:00:00-05:00").toString());
     }
 
     public void testWithMilliseconds() {
-        TimestampString ts = transformer.parseTimestamp("2024-01-01T10:30:00.123Z");
-        assertEquals("2024-01-01 10:30:00.123", ts.toString());
+        assertEquals("2024-01-01 10:30:00.123", TimestampFunctionAdapter.parseTimestamp("2024-01-01T10:30:00.123Z").toString());
     }
 
     public void testWithNanoseconds() {
-        TimestampString ts = transformer.parseTimestamp("2024-01-01T10:30:00.123456789Z");
-        assertEquals("2024-01-01 10:30:00.123456789", ts.toString());
-    }
-
-    public void testWithMillisAndTimezone() {
-        TimestampString ts = transformer.parseTimestamp("2024-01-01T10:30:00.500+05:30");
-        assertEquals("2024-01-01 05:00:00.5", ts.toString());
+        assertEquals("2024-01-01 10:30:00.123456789", TimestampFunctionAdapter.parseTimestamp("2024-01-01T10:30:00.123456789Z").toString());
     }
 
     public void testSpaceSeparatorPassthrough() {
-        TimestampString ts = transformer.parseTimestamp("2024-01-01 10:30:00");
-        assertEquals("2024-01-01 10:30:00", ts.toString());
+        assertEquals("2024-01-01 10:30:00", TimestampFunctionAdapter.parseTimestamp("2024-01-01 10:30:00").toString());
     }
 
-    public void testSpaceSeparatorWithMilliseconds() {
-        TimestampString ts = transformer.parseTimestamp("2024-01-01 10:30:00.123");
-        assertEquals("2024-01-01 10:30:00.123", ts.toString());
+    public void testUnparseableInputThrowsIllegalArgument() {
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> TimestampFunctionAdapter.parseTimestamp("2025-13-02")
+        );
+        assertEquals("2025-13-02", e.getMessage());
+
+        IllegalArgumentException e2 = expectThrows(
+            IllegalArgumentException.class,
+            () -> TimestampFunctionAdapter.parseTimestamp("2025-12-01 15:02:61")
+        );
+        assertEquals("2025-12-01 15:02:61", e2.getMessage());
+    }
+
+    // ── i64-ns range validation ───────────────────────────────────────────
+
+    /**
+     * Values past the i64-ns ceiling (~year 2262) must reject up front. Without
+     * this guard, DataFusion's simplify_expressions widens TIMESTAMP(3) → ns
+     * via {@code * 1000} and the optimizer emits an opaque
+     * {@code Arrow error: Arithmetic overflow} at execution.
+     */
+    public void testYearAfter2262RejectsAtPlanTime() {
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> TimestampFunctionAdapter.parseTimestamp("3077-04-12 09:07:00")
+        );
+        assertTrue(
+            "error must mention the supported range, got: " + e.getMessage(),
+            e.getMessage().contains("outside the supported range")
+        );
+    }
+
+    /**
+     * Right at the i64-ns ceiling — must succeed (boundary inclusive on the
+     * second; nano precision past 854775807 would still overflow but that's a
+     * sub-second concern not exercised by user input formats).
+     */
+    public void testYear2262JustInsideBoundaryAccepted() {
+        assertEquals("2262-04-11 23:47:16", TimestampFunctionAdapter.parseTimestamp("2262-04-11 23:47:16").toString());
+    }
+
+    // ── adapt(): Shape A — TIMESTAMP('<varchar literal>') folds ───────────
+
+    public void testAdaptShapeAFoldsVarcharLiteralToTypedTimestamp() {
+        RexCall call = buildOneArgCall(makeVarcharLiteral("2020-01-01 00:00:00"));
+        RexNode adapted = adapter.adapt(call, List.of(), cluster);
+
+        // Adapter wraps in a CAST to the call's declared type when precision differs;
+        // unwrap one CAST level if present.
+        RexLiteral literal = unwrapCastLiteral(adapted);
+        assertEquals(SqlTypeName.TIMESTAMP, literal.getType().getSqlTypeName());
+        assertEquals("2020-01-01 00:00:00", literal.getValueAs(TimestampString.class).toString());
+    }
+
+    public void testAdaptShapeAUnparseableInputThrowsIllegalArgument() {
+        RexCall call = buildOneArgCall(makeVarcharLiteral("2025-13-02"));
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> adapter.adapt(call, List.of(), cluster));
+        assertEquals("2025-13-02", e.getMessage());
+
+        RexCall call2 = buildOneArgCall(makeVarcharLiteral("2025-12-01 15:02:61"));
+        IllegalArgumentException e2 = expectThrows(IllegalArgumentException.class, () -> adapter.adapt(call2, List.of(), cluster));
+        assertEquals("2025-12-01 15:02:61", e2.getMessage());
+    }
+
+    // ── adapt(): Shape B — TIMESTAMP(DATE('<lit>')) ───────────────────────
+
+    public void testAdaptShapeBFoldsDateLiteralToMidnightUtc() {
+        RexCall innerDate = buildLocalDateCall("2020-08-26");
+        RexCall outerCall = buildOneArgCall(innerDate);
+        RexNode adapted = adapter.adapt(outerCall, List.of(), cluster);
+
+        RexLiteral literal = unwrapCastLiteral(adapted);
+        assertEquals("2020-08-26 00:00:00", literal.getValueAs(TimestampString.class).toString());
+    }
+
+    public void testAdaptShapeBRejectsUnparseableDateInput() {
+        // LocalDate.parse rejects datetime-with-time strings — adapter returns null
+        // from tryFoldLiteral and falls through to DATETIME_ADAPTER, which renames
+        // to LOCAL_TO_TIMESTAMP_OP. We just verify the adapter didn't fold.
+        RexCall innerDate = buildLocalDateCall("2020-08-26 10:00:00");
+        RexCall outerCall = buildOneArgCall(innerDate);
+        RexNode adapted = adapter.adapt(outerCall, List.of(), cluster);
+
+        // Not a literal — fell through to the rename path.
+        assertFalse("expected fall-through to DATETIME_ADAPTER, not a typed literal", unwrapCast(adapted) instanceof RexLiteral);
+    }
+
+    // ── adapt(): Shape C — TIMESTAMP(TIME('<lit>')) ───────────────────────
+
+    public void testAdaptShapeCFoldsTimeLiteralWithTodayUtc() {
+        RexCall innerTime = buildLocalTimeCall("10:20:30");
+        RexCall outerCall = buildOneArgCall(innerTime);
+        RexNode adapted = adapter.adapt(outerCall, List.of(), cluster);
+
+        RexLiteral literal = unwrapCastLiteral(adapted);
+        // Today's UTC date + the time
+        String today = LocalDate.now(ZoneOffset.UTC).toString();
+        assertEquals(today + " 10:20:30", literal.getValueAs(TimestampString.class).toString());
+    }
+
+    // ── adapt(): Shape D — TIMESTAMP(TIMESTAMP('<lit>')) ──────────────────
+
+    /**
+     * After bottom-up adapter walk, the inner {@code TIMESTAMP('lit')} has
+     * already been folded by this same adapter into a typed TIMESTAMP literal.
+     * The outer adapter's operand is therefore a {@code RexLiteral} of type
+     * TIMESTAMP — not VARCHAR — so the fold path doesn't catch it. The
+     * dispatcher falls through to DATETIME_ADAPTER which renames to
+     * {@code LOCAL_TO_TIMESTAMP_OP}; DataFusion's runtime treats
+     * {@code to_timestamp(timestamp)} as identity.
+     */
+    public void testAdaptShapeDTimestampOfTimestampRoutesToDatetimeAdapter() {
+        RexLiteral innerTimestamp = (RexLiteral) rexBuilder.makeTimestampLiteral(new TimestampString("2020-01-01 00:00:00"), 3);
+        RexCall outerCall = buildOneArgCall(innerTimestamp);
+        RexNode adapted = adapter.adapt(outerCall, List.of(), cluster);
+
+        RexNode unwrapped = unwrapCast(adapted);
+        assertTrue(
+            "expected RexCall fall-through to DATETIME_ADAPTER, got " + unwrapped.getClass().getSimpleName(),
+            unwrapped instanceof RexCall
+        );
+        SqlOperator op = ((RexCall) unwrapped).getOperator();
+        assertSame("expected rename to LOCAL_TO_TIMESTAMP_OP", DateTimeAdapters.LOCAL_TO_TIMESTAMP_OP, op);
+        // The inner timestamp literal is preserved as the operand.
+        assertEquals(innerTimestamp, ((RexCall) unwrapped).getOperands().get(0));
+    }
+
+    // ── adapt(): Shape E — TIMESTAMP('<lit>', '<time-lit>') ───────────────
+
+    public void testAdaptShapeETwoArgFoldsTimestampPlusTime() {
+        RexCall call = buildTwoArgCall("2020-01-01 10:00:00", "01:30:00");
+        RexNode adapted = adapter.adapt(call, List.of(), cluster);
+
+        RexLiteral literal = unwrapCastLiteral(adapted);
+        assertEquals("2020-01-01 11:30:00", literal.getValueAs(TimestampString.class).toString());
+    }
+
+    public void testAdaptShapeETwoArgUnparseableTimeFallsThrough() {
+        RexCall call = buildTwoArgCall("2020-01-01 10:00:00", "not-a-time");
+        RexNode adapted = adapter.adapt(call, List.of(), cluster);
+
+        // Bad time → tryFoldTwoArg returns null → DATETIME_ADAPTER rename. Not a literal.
+        assertFalse("expected fall-through, not a typed literal", unwrapCast(adapted) instanceof RexLiteral);
+    }
+
+    public void testAdaptShapeETwoArgUnparseableTimestampThrowsIllegalArgument() {
+        // Bad first arg propagates out of parseTimestamp as IllegalArgumentException
+        // with the raw input — same surface as the 1-arg unparseable path.
+        RexCall call = buildTwoArgCall("not-a-timestamp", "01:30:00");
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> adapter.adapt(call, List.of(), cluster));
+        assertEquals("not-a-timestamp", e.getMessage());
+    }
+
+    // ── adapt(): Shape F — column ref → DATETIME_ADAPTER ──────────────────
+
+    public void testAdaptShapeFColumnRefRoutesToDatetimeAdapter() {
+        RelDataType dateType = typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.DATE), true);
+        RexNode columnRef = rexBuilder.makeInputRef(dateType, 0);
+        RexCall call = buildOneArgCall(columnRef);
+        RexNode adapted = adapter.adapt(call, List.of(), cluster);
+
+        // Fold did NOT catch — adapter emitted a RexCall over LOCAL_TO_TIMESTAMP_OP
+        // (possibly wrapped in a CAST to align with the call's declared type).
+        RexNode unwrapped = unwrapCast(adapted);
+        assertTrue("expected RexCall, got " + unwrapped.getClass().getSimpleName(), unwrapped instanceof RexCall);
+        SqlOperator op = ((RexCall) unwrapped).getOperator();
+        assertSame("expected rename to LOCAL_TO_TIMESTAMP_OP", DateTimeAdapters.LOCAL_TO_TIMESTAMP_OP, op);
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────
+
+    /** Build a VARCHAR literal the way the PPL frontend does:
+     *  {@code CalciteRexNodeVisitor.visitLiteral} calls
+     *  {@code rexBuilder.makeLiteral(value, type, /*allowCast=*\/ true)} for
+     *  multi-char strings. The {@code allowCast=true} flag prevents Calcite from
+     *  normalizing the requested VARCHAR back to CHAR — without it, the adapter's
+     *  {@code SqlTypeName.VARCHAR} match in {@code tryFoldLiteral} doesn't fire. */
+    private RexNode makeVarcharLiteral(String value) {
+        RelDataType varcharType = typeFactory.createSqlType(SqlTypeName.VARCHAR, value.length());
+        return rexBuilder.makeLiteral(value, varcharType, true);
+    }
+
+    private RexCall buildOneArgCall(RexNode operand) {
+        return (RexCall) rexBuilder.makeCall(TIMESTAMP_OP, List.of(operand));
+    }
+
+    private RexCall buildTwoArgCall(String tsLit, String timeLit) {
+        return (RexCall) rexBuilder.makeCall(TIMESTAMP_OP, List.of(makeVarcharLiteral(tsLit), makeVarcharLiteral(timeLit)));
+    }
+
+    private RexCall buildLocalDateCall(String literal) {
+        return (RexCall) rexBuilder.makeCall(DateTimeAdapters.LOCAL_DATE_OP, List.of(makeVarcharLiteral(literal)));
+    }
+
+    private RexCall buildLocalTimeCall(String literal) {
+        return (RexCall) rexBuilder.makeCall(DateTimeAdapters.LOCAL_TIME_OP, List.of(makeVarcharLiteral(literal)));
+    }
+
+    /** Peel all CAST levels. The adapter wraps the folded literal in a CAST to
+     *  the call's declared type; some fold paths produce nested CASTs when both
+     *  precision and nullability differ from the original. */
+    private static RexNode unwrapCast(RexNode node) {
+        while (node instanceof RexCall call && call.getKind() == SqlKind.CAST) {
+            node = call.getOperands().get(0);
+        }
+        return node;
+    }
+
+    private static RexLiteral unwrapCastLiteral(RexNode node) {
+        RexNode unwrapped = unwrapCast(node);
+        assertTrue("expected RexLiteral after unwrap, got " + unwrapped.getClass().getSimpleName(), unwrapped instanceof RexLiteral);
+        return (RexLiteral) unwrapped;
     }
 }

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/TimestampFunctionIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/TimestampFunctionIT.java
@@ -1,0 +1,262 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.qa;
+
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+import org.opensearch.client.ResponseException;
+
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * End-to-end coverage for PPL {@code TIMESTAMP(...)} call shapes routed through
+ * {@code org.opensearch.be.datafusion.TimestampFunctionAdapter}. Each shape below
+ * corresponds to a branch in the adapter's {@code tryFoldLiteral} / dispatch path:
+ *
+ * <ul>
+ *   <li>A — {@code TIMESTAMP('<varchar literal>')} → plan-time fold</li>
+ *   <li>B — {@code TIMESTAMP(DATE('<lit>'))} → fold to date.atStartOfDay(UTC)</li>
+ *   <li>C — {@code TIMESTAMP(TIME('<lit>'))} → fold with today's UTC date</li>
+ *   <li>D — {@code TIMESTAMP(TIMESTAMP('<lit>'))} → inner shape A folds, outer falls
+ *       through to {@code DateTimeAdapters.DatetimeAdapter} ({@code to_timestamp} identity)</li>
+ *   <li>E — {@code TIMESTAMP('<dt>', '<time>')} → 2-arg fold, adds time-of-day</li>
+ *   <li>F — {@code TIMESTAMP(<column>)} → falls through to DatetimeAdapter</li>
+ *   <li>G — {@code TIMESTAMP('<bad>')} → IllegalArgumentException with raw input</li>
+ * </ul>
+ *
+ * <p>The fold path bypasses runtime {@code to_timestamp(to_date(...))} chains that
+ * DataFusion can't execute on this stack ({@code Unsupported data type Date32 for
+ * function to_timestamp}); this IT pins both the fold-correct cases and the
+ * fall-through routing so regressions surface as user-facing failures.
+ */
+public class TimestampFunctionIT extends AnalyticsRestTestCase {
+
+    private static final Dataset DATASET = new Dataset("calcs", "calcs");
+
+    private static boolean dataProvisioned = false;
+
+    private void ensureDataProvisioned() throws IOException {
+        if (dataProvisioned == false) {
+            DatasetProvisioner.provision(client(), DATASET);
+            dataProvisioned = true;
+        }
+    }
+
+    private String oneRow(String key) {
+        return "source=" + DATASET.indexName + " | where key='" + key + "' | head 1 ";
+    }
+
+    // ── Shape A: TIMESTAMP('<varchar literal>') ──────────────────────────────────
+
+    public void testShapeASpaceSeparator() throws IOException {
+        assertFirstRowString(
+            oneRow("key00") + "| eval v = date_format(timestamp('2020-01-01 10:30:45'), '%Y-%m-%d %H:%i:%s') | fields v",
+            "2020-01-01 10:30:45"
+        );
+    }
+
+    public void testShapeAIsoWithTAndZ() throws IOException {
+        // ISO-8601 with T separator + Z — parseTimestamp normalizes to UTC.
+        assertFirstRowString(
+            oneRow("key00") + "| eval v = date_format(timestamp('2020-01-01T10:30:00Z'), '%Y-%m-%d %H:%i:%s') | fields v",
+            "2020-01-01 10:30:00"
+        );
+    }
+
+    public void testShapeAIsoWithTNoZ() throws IOException {
+        assertFirstRowString(
+            oneRow("key00") + "| eval v = date_format(timestamp('2024-01-15T10:30:00'), '%Y-%m-%d %H:%i:%s') | fields v",
+            "2024-01-15 10:30:00"
+        );
+    }
+
+    public void testShapeADateOnly() throws IOException {
+        assertFirstRowString(
+            oneRow("key00") + "| eval v = date_format(timestamp('2024-01-01'), '%Y-%m-%d %H:%i:%s') | fields v",
+            "2024-01-01 00:00:00"
+        );
+    }
+
+    public void testShapeATimezoneOffsetNormalizesToUtc() throws IOException {
+        // +05:30 offset → wall time shifts back 5h30m to UTC.
+        assertFirstRowString(
+            oneRow("key00") + "| eval v = date_format(timestamp('2024-01-01T10:00:00+05:30'), '%Y-%m-%d %H:%i:%s') | fields v",
+            "2024-01-01 04:30:00"
+        );
+    }
+
+    public void testShapeANegativeTimezoneOffset() throws IOException {
+        // -05:00 offset → wall time shifts forward 5h to UTC.
+        assertFirstRowString(
+            oneRow("key00") + "| eval v = date_format(timestamp('2024-01-01T10:00:00-05:00'), '%Y-%m-%d %H:%i:%s') | fields v",
+            "2024-01-01 15:00:00"
+        );
+    }
+
+    // ── Shape B: TIMESTAMP(DATE('<lit>')) → fold to midnight UTC ─────────────────
+
+    public void testShapeBDateLiteralFoldsToMidnightUtc() throws IOException {
+        assertFirstRowString(
+            oneRow("key00") + "| eval v = date_format(timestamp(date('2020-08-26')), '%Y-%m-%d %H:%i:%s') | fields v",
+            "2020-08-26 00:00:00"
+        );
+    }
+
+    // ── Shape C: TIMESTAMP(TIME('<lit>')) → fold with today's UTC date ───────────
+
+    public void testShapeCTimeLiteralFoldsWithTodayUtc() throws IOException {
+        // Today's date varies, so we extract the time-of-day component and assert that
+        // (year(v) >= 2020) AND time_format(v) == '10:20:30'. The combination pins the
+        // fold path emitted a typed TIMESTAMP literal whose date is today's UTC date
+        // and whose time is the parsed input.
+        String today = LocalDate.now(ZoneOffset.UTC).toString();
+        assertFirstRowString(
+            oneRow("key00") + "| eval v = date_format(timestamp(time('10:20:30')), '%Y-%m-%d %H:%i:%s') | fields v",
+            today + " 10:20:30"
+        );
+    }
+
+    // ── Shape D: TIMESTAMP(TIMESTAMP('<lit>')) → inner folds, outer is identity ──
+
+    public void testShapeDNestedTimestampOfTimestampLiteral() throws IOException {
+        // Inner TIMESTAMP('lit') folds to a typed TIMESTAMP literal; outer TIMESTAMP(...)
+        // sees a TIMESTAMP-typed operand (not VARCHAR), falls through to DatetimeAdapter
+        // which renames to {@code to_timestamp} (DataFusion treats this as identity).
+        assertFirstRowString(
+            oneRow("key00")
+                + "| eval v = date_format(timestamp(timestamp('2020-01-01 00:00:00')), '%Y-%m-%d %H:%i:%s') | fields v",
+            "2020-01-01 00:00:00"
+        );
+    }
+
+    // ── Shape E: TIMESTAMP('<dt>', '<time>') → 2-arg fold, adds time-of-day ──────
+
+    public void testShapeETwoArgAddsTime() throws IOException {
+        // Matches legacy TimestampFunction.timestamp(props, dt, addTime) → exprAddTime.
+        assertFirstRowString(
+            oneRow("key00")
+                + "| eval v = date_format(timestamp('2020-01-01 10:00:00', '01:30:00'), '%Y-%m-%d %H:%i:%s') | fields v",
+            "2020-01-01 11:30:00"
+        );
+    }
+
+    public void testShapeETwoArgAcrossMidnight() throws IOException {
+        // 23:00 + 02:30 = 01:30 next day. Validates LocalDateTime.plusNanos crosses
+        // the day boundary instead of clamping to 24:00.
+        assertFirstRowString(
+            oneRow("key00")
+                + "| eval v = date_format(timestamp('2020-01-01 23:00:00', '02:30:00'), '%Y-%m-%d %H:%i:%s') | fields v",
+            "2020-01-02 01:30:00"
+        );
+    }
+
+    // ── Shape F: TIMESTAMP(<column>) → falls through to DatetimeAdapter ──────────
+
+    public void testShapeFColumnRefRoutesToToTimestamp() throws IOException {
+        // datetime0 is a date-typed field on the calcs dataset (key00 = 2004-07-09T10:17:35Z).
+        // Operand is a column ref, not a literal — fold doesn't catch. Adapter renames
+        // to {@code to_timestamp} which DataFusion executes against the column value.
+        assertFirstRowString(
+            oneRow("key00") + "| eval v = date_format(timestamp(datetime0), '%Y-%m-%d %H:%i:%s') | fields v",
+            "2004-07-09 10:17:35"
+        );
+    }
+
+    // ── Shape G: TIMESTAMP('<bad string>') → HTTP 400 with raw input as message ──
+
+    public void testShapeGUnparseableMonthThirteenRejects() throws IOException {
+        // parseTimestamp throws IllegalArgumentException with the raw input as the
+        // exception message; the REST layer surfaces this as HTTP 400 carrying the
+        // bad input verbatim. Pin this contract — the SQL plugin's tests rely on it.
+        assertErrorContains(
+            oneRow("key00") + "| eval v = timestamp('2025-13-02') | fields v",
+            "2025-13-02"
+        );
+    }
+
+    public void testShapeGUnparseableSecondSixtyOneRejects() throws IOException {
+        assertErrorContains(
+            oneRow("key00") + "| eval v = timestamp('2025-12-01 15:02:61') | fields v",
+            "2025-12-01 15:02:61"
+        );
+    }
+
+    // ── i64-ns range guard (year > 2262 rejects at plan time) ────────────────────
+
+    public void testYearAfter2262RejectsAtPlanTime() throws IOException {
+        // Without this guard, DataFusion's simplify_expressions widens TIMESTAMP(3) → ns
+        // via *1000 and the optimizer emits an opaque "Arrow error: Arithmetic overflow"
+        // at execution. The adapter rejects up front with "outside the supported range".
+        assertErrorContains(
+            oneRow("key00") + "| eval v = timestamp('3077-04-12 09:07:00') | fields v",
+            "outside the supported range"
+        );
+    }
+
+    // ── Comparison parity with SQL plugin's DateTimeComparisonIT.neq2 case ───────
+
+    public void testFoldedTimestampLiteralsRemainComparable() throws IOException {
+        Object cell = firstRowFirstCell(
+            oneRow("key00")
+                + "| eval neq2 = (timestamp('1984-12-15 22:15:08') != timestamp('1984-12-15 22:15:07')) | fields neq2"
+        );
+        assertEquals("neq2 between adjacent-second TIMESTAMP literals must be true", Boolean.TRUE, cell);
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────────
+
+    private void assertFirstRowString(String ppl, String expected) throws IOException {
+        Object cell = firstRowFirstCell(ppl);
+        assertNotNull("Expected non-null result for query [" + ppl + "]", cell);
+        assertEquals("Value mismatch for query: " + ppl, expected, cell);
+    }
+
+    private Object firstRowFirstCell(String ppl) throws IOException {
+        Map<String, Object> response = executePpl(ppl);
+        @SuppressWarnings("unchecked")
+        List<List<Object>> rows = (List<List<Object>>) response.get("rows");
+        assertNotNull("Response missing 'rows' for query: " + ppl, rows);
+        assertTrue("Expected at least one row for query: " + ppl, rows.size() >= 1);
+        return rows.get(0).get(0);
+    }
+
+    private Map<String, Object> executePpl(String ppl) throws IOException {
+        ensureDataProvisioned();
+        Request request = new Request("POST", "/_analytics/ppl");
+        request.setJsonEntity("{\"query\": \"" + escapeJson(ppl) + "\"}");
+        Response response = client().performRequest(request);
+        return assertOkAndParse(response, "PPL: " + ppl);
+    }
+
+    private void assertErrorContains(String ppl, String expectedSubstring) throws IOException {
+        ensureDataProvisioned();
+        Request request = new Request("POST", "/_analytics/ppl");
+        request.setJsonEntity("{\"query\": \"" + escapeJson(ppl) + "\"}");
+        try {
+            Response response = client().performRequest(request);
+            Map<String, Object> body = assertOkAndParse(response, "PPL: " + ppl);
+            fail("Expected query to fail with [" + expectedSubstring + "] but got response: " + body);
+        } catch (ResponseException e) {
+            String body;
+            try {
+                body = entityAsMap(e.getResponse()).toString();
+            } catch (IOException ioe) {
+                body = e.getMessage();
+            }
+            assertTrue(
+                "Expected response body to contain [" + expectedSubstring + "] but was: " + body,
+                body.contains(expectedSubstring)
+            );
+        }
+    }
+}


### PR DESCRIPTION
### Description
Enhances the `DatetimeAdapter` on the `analytics-backend-datafusion` route to handle the full set of call shapes that PPL's `TIMESTAMP(...)` function supports, so legacy PPL parity holds without invoking DataFusion's `to_timestamp(to_date(...))` chain.

  The adapter recognizes seven call shapes and routes each to the right backend path:

  | Shape | Example | Path |
  |---|---|---|
  | A | `TIMESTAMP('2020-01-01 00:00:00')` | plan-time fold (varchar literal) |
  | B | `TIMESTAMP(DATE('2020-08-26'))` | plan-time fold → `date.atStartOfDay(UTC)` |
  | C | `TIMESTAMP(TIME('10:20:30'))` | plan-time fold → today's UTC date + time |
  | D | `TIMESTAMP(TIMESTAMP('lit'))` | inner shape A folds; outer falls through to `to_timestamp` (identity at runtime) |
  | E | `TIMESTAMP('2020-01-01 10:00:00', '01:30:00')` | 2-arg fold, adds time-of-day |
  | F | `TIMESTAMP(<column>)` | falls through to `DateTimeAdapters.DatetimeAdapter` (`to_timestamp` builtin) |
  | G | `TIMESTAMP('<bad string>')` | rejected up front with `IllegalArgumentException` carrying the raw input → HTTP 400 |
