### PR TITLE
Fix StringView buffer bloat in stream_next FFI export

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/api.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/api.rs
@@ -35,6 +35,8 @@ use std::num::NonZeroUsize;
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use arrow_schema::DataType;
+
 use arrow_array::ffi::FFI_ArrowArray;
 use arrow_array::RecordBatch;
 use arrow_array::{Array, StructArray};
@@ -454,6 +456,7 @@ pub async unsafe fn stream_next(stream_ptr: i64) -> Result<i64, DataFusionError>
 
     match result {
         Some(batch) => {
+            let batch = compact_string_view_columns(batch);
             let struct_array: StructArray = batch.into();
             let array_data = struct_array.into_data();
             let ffi_array = FFI_ArrowArray::new(&array_data);
@@ -461,6 +464,36 @@ pub async unsafe fn stream_next(stream_ptr: i64) -> Result<i64, DataFusionError>
         }
         None => Ok(0),
     }
+}
+
+/// Compacts StringView/BinaryView columns in a RecordBatch by calling `gc()`.
+/// This eliminates shared backing buffers that inflate batch size when sliced
+/// from a larger array (e.g., hash aggregate EmitTo::All + slice()).
+fn compact_string_view_columns(batch: RecordBatch) -> RecordBatch {
+    let schema = batch.schema();
+    let has_views = schema.fields().iter().any(|f| {
+        matches!(f.data_type(), DataType::Utf8View | DataType::BinaryView)
+    });
+    if !has_views {
+        return batch;
+    }
+    let columns: Vec<Arc<dyn Array>> = batch
+        .columns()
+        .iter()
+        .zip(schema.fields().iter())
+        .map(|(col, field)| match field.data_type() {
+            DataType::Utf8View => {
+                let view: &arrow_array::StringViewArray = col.as_any().downcast_ref().unwrap();
+                Arc::new(view.gc()) as Arc<dyn Array>
+            }
+            DataType::BinaryView => {
+                let view: &arrow_array::BinaryViewArray = col.as_any().downcast_ref().unwrap();
+                Arc::new(view.gc()) as Arc<dyn Array>
+            }
+            _ => Arc::clone(col),
+        })
+        .collect();
+    RecordBatch::try_new(schema, columns).unwrap_or(batch)
 }
 
 /// Closes a result stream. Safe to call with 0 (no-op).

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/api.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/api.rs
@@ -1171,22 +1171,20 @@ mod tests {
         let strings: Vec<String> = (0..1000)
             .map(|i| format!("long_string_value_{:06}_padding", i))
             .collect();
-        let string_view_array =
-            StringViewArray::from_iter_values(strings.iter().map(|s| s.as_str()));
+        let string_view_array: Arc<dyn Array> =
+            Arc::new(StringViewArray::from_iter_values(strings.iter().map(|s| s.as_str())));
 
         let schema = Arc::new(Schema::new(vec![
             Field::new("str_col", DataType::Utf8View, false),
         ]));
         let batch =
-            RecordBatch::try_new(schema, vec![Arc::new(string_view_array)]).unwrap();
+            RecordBatch::try_new(schema, vec![Arc::clone(&string_view_array)]).unwrap();
 
-        let before_size = batch.column(0).get_array_memory_size();
         let compacted = compact_string_view_columns(batch);
-        let after_size = compacted.column(0).get_array_memory_size();
 
-        assert_eq!(
-            before_size, after_size,
-            "Non-sliced batch should pass through unchanged (no copy needed)"
+        assert!(
+            Arc::ptr_eq(&string_view_array, compacted.column(0)),
+            "Non-sliced batch must return the original column Arc (no copy)"
         );
     }
 

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/api.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/api.rs
@@ -74,17 +74,26 @@ pub struct QueryStreamHandle {
     /// The physical plan may reference state (e.g. RuntimeEnv, caches) owned
     /// by the session; dropping it prematurely causes use-after-free.
     _session_ctx: Option<datafusion::prelude::SessionContext>,
+    has_views: bool,
 }
 
 impl QueryStreamHandle {
+    fn schema_has_views(schema: &arrow_schema::SchemaRef) -> bool {
+        schema.fields().iter().any(|f| {
+            matches!(f.data_type(), DataType::Utf8View | DataType::BinaryView)
+        })
+    }
+
     pub fn new(
         stream: RecordBatchStreamAdapter<CrossRtStream>,
         query_context: QueryTrackingContext,
     ) -> Self {
+        let has_views = Self::schema_has_views(&stream.schema());
         Self {
             stream,
             _query_tracking_context: query_context,
             _session_ctx: None,
+            has_views,
         }
     }
 
@@ -93,10 +102,12 @@ impl QueryStreamHandle {
         query_context: QueryTrackingContext,
         ctx: datafusion::prelude::SessionContext,
     ) -> Self {
+        let has_views = Self::schema_has_views(&stream.schema());
         Self {
             stream,
             _query_tracking_context: query_context,
             _session_ctx: Some(ctx),
+            has_views,
         }
     }
 }
@@ -456,7 +467,11 @@ pub async unsafe fn stream_next(stream_ptr: i64) -> Result<i64, DataFusionError>
 
     match result {
         Some(batch) => {
-            let batch = compact_string_view_columns(batch);
+            let batch = if handle.has_views {
+                compact_string_view_columns(batch)
+            } else {
+                batch
+            };
             let struct_array: StructArray = batch.into();
             let array_data = struct_array.into_data();
             let ffi_array = FFI_ArrowArray::new(&array_data);
@@ -466,15 +481,27 @@ pub async unsafe fn stream_next(stream_ptr: i64) -> Result<i64, DataFusionError>
     }
 }
 
-/// Compacts StringView/BinaryView columns in a RecordBatch by calling `gc()`.
-/// This eliminates shared backing buffers that inflate batch size when sliced
-/// from a larger array (e.g., hash aggregate EmitTo::All + slice()).
+/// Prevents sliced StringView batches from carrying full backing buffers across FFI.
 fn compact_string_view_columns(batch: RecordBatch) -> RecordBatch {
     let schema = batch.schema();
-    let has_views = schema.fields().iter().any(|f| {
-        matches!(f.data_type(), DataType::Utf8View | DataType::BinaryView)
-    });
-    if !has_views {
+    let needs_compaction = batch
+        .columns()
+        .iter()
+        .zip(schema.fields().iter())
+        .any(|(col, field)| match field.data_type() {
+            DataType::Utf8View => {
+                let view: &arrow_array::StringViewArray = col.as_any().downcast_ref()
+                    .expect("column must be StringViewArray when schema declares Utf8View");
+                view_needs_gc(view.data_buffers(), view.total_buffer_bytes_used())
+            }
+            DataType::BinaryView => {
+                let view: &arrow_array::BinaryViewArray = col.as_any().downcast_ref()
+                    .expect("column must be BinaryViewArray when schema declares BinaryView");
+                view_needs_gc(view.data_buffers(), view.total_buffer_bytes_used())
+            }
+            _ => false,
+        });
+    if !needs_compaction {
         return batch;
     }
     let columns: Vec<Arc<dyn Array>> = batch
@@ -483,17 +510,30 @@ fn compact_string_view_columns(batch: RecordBatch) -> RecordBatch {
         .zip(schema.fields().iter())
         .map(|(col, field)| match field.data_type() {
             DataType::Utf8View => {
-                let view: &arrow_array::StringViewArray = col.as_any().downcast_ref().unwrap();
+                let view: &arrow_array::StringViewArray = col.as_any().downcast_ref()
+                    .expect("column must be StringViewArray when schema declares Utf8View");
                 Arc::new(view.gc()) as Arc<dyn Array>
             }
             DataType::BinaryView => {
-                let view: &arrow_array::BinaryViewArray = col.as_any().downcast_ref().unwrap();
+                let view: &arrow_array::BinaryViewArray = col.as_any().downcast_ref()
+                    .expect("column must be BinaryViewArray when schema declares BinaryView");
                 Arc::new(view.gc()) as Arc<dyn Array>
             }
             _ => Arc::clone(col),
         })
         .collect();
-    RecordBatch::try_new(schema, columns).unwrap_or(batch)
+    RecordBatch::try_new(schema, columns).expect("gc'd columns must match schema")
+}
+
+// 10KB: below this, the gc() copy cost outweighs the transfer savings.
+const GC_MIN_WASTE_BYTES: usize = 10_240;
+
+#[inline]
+fn view_needs_gc(buffers: &[arrow::buffer::Buffer], bytes_used: usize) -> bool {
+    let bytes_allocated: usize = buffers.iter().map(|b| b.len()).sum();
+    let waste = bytes_allocated.saturating_sub(bytes_used);
+    let is_significantly_bloated = bytes_allocated > 2 * bytes_used;
+    is_significantly_bloated && waste > GC_MIN_WASTE_BYTES
 }
 
 /// Closes a result stream. Safe to call with 0 (no-op).
@@ -1123,6 +1163,51 @@ mod tests {
         assert_eq!(
             batch.columns()[0].get_array_memory_size(),
             compacted.columns()[0].get_array_memory_size()
+        );
+    }
+
+    #[test]
+    fn non_sliced_batch_skips_gc() {
+        let strings: Vec<String> = (0..1000)
+            .map(|i| format!("long_string_value_{:06}_padding", i))
+            .collect();
+        let string_view_array =
+            StringViewArray::from_iter_values(strings.iter().map(|s| s.as_str()));
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("str_col", DataType::Utf8View, false),
+        ]));
+        let batch =
+            RecordBatch::try_new(schema, vec![Arc::new(string_view_array)]).unwrap();
+
+        let before_size = batch.column(0).get_array_memory_size();
+        let compacted = compact_string_view_columns(batch);
+        let after_size = compacted.column(0).get_array_memory_size();
+
+        assert_eq!(
+            before_size, after_size,
+            "Non-sliced batch should pass through unchanged (no copy needed)"
+        );
+    }
+
+    #[test]
+    fn view_needs_gc_detects_bloat() {
+        let strings: Vec<String> = (0..10_000)
+            .map(|i| format!("long_string_value_{:06}_padding", i))
+            .collect();
+        let full_array =
+            StringViewArray::from_iter_values(strings.iter().map(|s| s.as_str()));
+
+        let sliced = full_array.slice(0, 100);
+        let sliced_view: &StringViewArray = sliced.as_any().downcast_ref().unwrap();
+        assert!(
+            view_needs_gc(sliced_view.data_buffers(), sliced_view.total_buffer_bytes_used()),
+            "Sliced array must be detected as needing gc"
+        );
+
+        assert!(
+            !view_needs_gc(full_array.data_buffers(), full_array.total_buffer_bytes_used()),
+            "Non-sliced array must NOT need gc"
         );
     }
 }

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/api.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/api.rs
@@ -1003,6 +1003,130 @@ pub unsafe fn sender_close(sender_ptr: i64) {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow_array::{BinaryViewArray, Int64Array, StringViewArray};
+    use arrow_schema::{Field, Schema};
+
+    #[test]
+    fn stringview_gc_compacts_sliced_buffers() {
+        let total_rows = 100_000usize;
+        let slice_rows = 100usize;
+
+        let strings: Vec<String> = (0..total_rows)
+            .map(|i| format!("long_string_value_{:06}_padding", i))
+            .collect();
+        let string_view_array = StringViewArray::from_iter_values(strings.iter().map(|s| s.as_str()));
+        let int_array = Int64Array::from_iter_values(0..total_rows as i64);
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("str_col", DataType::Utf8View, false),
+            Field::new("int_col", DataType::Int64, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![Arc::new(string_view_array), Arc::new(int_array)],
+        )
+        .unwrap();
+
+        let sliced = batch.slice(0, slice_rows);
+
+        let before_size = sliced.column(0).get_array_memory_size();
+
+        let compacted = compact_string_view_columns(sliced);
+
+        let after_size = compacted.column(0).get_array_memory_size();
+
+        assert!(
+            before_size > after_size * 100,
+            "Expected >100x reduction on StringView column, got before={} after={} ratio={}",
+            before_size,
+            after_size,
+            before_size / after_size
+        );
+    }
+
+    #[test]
+    fn stringview_gc_inline_strings_no_change() {
+        let strings: Vec<&str> = (0..100).map(|_| "short").collect();
+        let string_view_array = StringViewArray::from_iter_values(strings.into_iter());
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("str_col", DataType::Utf8View, false),
+        ]));
+        let batch =
+            RecordBatch::try_new(schema, vec![Arc::new(string_view_array.clone())]).unwrap();
+
+        let compacted = compact_string_view_columns(batch.clone());
+        let before_size = batch.columns()[0].get_array_memory_size();
+        let after_size = compacted.columns()[0].get_array_memory_size();
+        assert_eq!(before_size, after_size);
+    }
+
+    #[test]
+    fn stringview_gc_empty_array() {
+        let string_view_array = StringViewArray::from_iter_values(std::iter::empty::<&str>());
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("str_col", DataType::Utf8View, false),
+        ]));
+        let batch = RecordBatch::try_new(schema, vec![Arc::new(string_view_array)]).unwrap();
+        let compacted = compact_string_view_columns(batch);
+        assert_eq!(compacted.num_rows(), 0);
+    }
+
+    #[test]
+    fn binaryview_gc_compacts_sliced_buffers() {
+        let total_rows = 10_000usize;
+        let slice_rows = 10usize;
+
+        let values: Vec<Vec<u8>> = (0..total_rows)
+            .map(|i| format!("binary_payload_{:08}_extra_bytes", i).into_bytes())
+            .collect();
+        let binary_view_array =
+            BinaryViewArray::from_iter_values(values.iter().map(|v| v.as_slice()));
+        let int_array = Int64Array::from_iter_values(0..total_rows as i64);
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("bin_col", DataType::BinaryView, false),
+            Field::new("int_col", DataType::Int64, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![Arc::new(binary_view_array), Arc::new(int_array)],
+        )
+        .unwrap();
+
+        let sliced = batch.slice(0, slice_rows);
+        let before_size = sliced.columns()[0].get_array_memory_size();
+
+        let compacted = compact_string_view_columns(sliced);
+        let after_size = compacted.columns()[0].get_array_memory_size();
+
+        assert!(
+            before_size > after_size * 100,
+            "Expected large reduction for BinaryView, got before={} after={} ratio={}",
+            before_size,
+            after_size,
+            before_size / after_size
+        );
+    }
+
+    #[test]
+    fn no_view_columns_passthrough() {
+        let int_array = Int64Array::from_iter_values(0..1000);
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("int_col", DataType::Int64, false),
+        ]));
+        let batch = RecordBatch::try_new(schema, vec![Arc::new(int_array)]).unwrap();
+        let compacted = compact_string_view_columns(batch.clone());
+        assert_eq!(
+            batch.columns()[0].get_array_memory_size(),
+            compacted.columns()[0].get_array_memory_size()
+        );
+    }
+}
+
 /// Imports a batch of Arrow C Data structures into a [`Vec<RecordBatch>`] and
 /// registers them as an in-memory table on the given session under `input_id`.
 ///

--- a/sandbox/plugins/analytics-backend-datafusion/rust/tests/stringview_gc_test.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/tests/stringview_gc_test.rs
@@ -1,0 +1,276 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+//! Regression test for `compact_string_view_columns` (api.rs line 459).
+//!
+//! Exercises `df_stream_next` end-to-end with a sliced StringView batch.
+//! When compaction is active, the output batch's backing buffers should be
+//! right-sized (~3KB for 100 strings) rather than carrying the full 10K-element
+//! buffer (~300KB).
+
+use std::sync::{Arc, OnceLock};
+use std::thread;
+
+use arrow_array::ffi::{FFI_ArrowArray, FFI_ArrowSchema};
+use arrow_array::{Array, RecordBatch, StringViewArray, StructArray};
+use arrow_schema::{DataType, Field, Schema, SchemaRef};
+use datafusion::datasource::MemTable;
+use datafusion::prelude::SessionContext;
+use datafusion_substrait::logical_plan::producer::to_substrait_plan;
+use prost::Message;
+use tempfile::TempDir;
+
+use opensearch_datafusion::ffm::{
+    df_close_global_runtime, df_close_local_session, df_create_global_runtime,
+    df_create_local_session, df_execute_local_plan, df_init_runtime_manager,
+    df_register_partition_stream, df_sender_close, df_sender_send, df_stream_close, df_stream_next,
+};
+
+// ---------------------------------------------------------------------------
+// One-time setup (same OnceLock pattern as local_exec_test.rs)
+// ---------------------------------------------------------------------------
+
+static RT_INIT: OnceLock<()> = OnceLock::new();
+
+fn ensure_runtime_manager() {
+    RT_INIT.get_or_init(|| {
+        df_init_runtime_manager(1);
+    });
+}
+
+struct RuntimeGuard {
+    ptr: i64,
+    _spill_dir: TempDir,
+}
+
+impl RuntimeGuard {
+    fn new() -> Self {
+        ensure_runtime_manager();
+        let spill_dir = TempDir::new().expect("tempdir");
+        let spill_path = spill_dir
+            .path()
+            .to_str()
+            .expect("utf-8 spill path")
+            .to_string();
+        let spill_bytes = spill_path.as_bytes();
+        let rc = unsafe {
+            df_create_global_runtime(
+                128 * 1024 * 1024,
+                0,
+                spill_bytes.as_ptr(),
+                spill_bytes.len() as i64,
+                64 * 1024 * 1024,
+            )
+        };
+        assert!(rc > 0, "df_create_global_runtime returned {}", rc);
+        Self {
+            ptr: rc,
+            _spill_dir: spill_dir,
+        }
+    }
+}
+
+impl Drop for RuntimeGuard {
+    fn drop(&mut self) {
+        unsafe { df_close_global_runtime(self.ptr) };
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn utf8view_schema() -> SchemaRef {
+    Arc::new(Schema::new(vec![Field::new("s", DataType::Utf8View, false)]))
+}
+
+/// Build a substrait plan for `SELECT * FROM "input-0"` with the given schema.
+async fn build_passthrough_substrait(schema: SchemaRef) -> Vec<u8> {
+    let ctx = SessionContext::new();
+    let empty = MemTable::try_new(Arc::clone(&schema), vec![vec![]]).expect("mem table");
+    ctx.register_table("input-0", Arc::new(empty))
+        .expect("register input-0");
+    let plan = ctx
+        .sql("SELECT * FROM \"input-0\"")
+        .await
+        .expect("sql parses")
+        .logical_plan()
+        .clone();
+    let substrait = to_substrait_plan(&plan, &ctx.state()).expect("to_substrait");
+    let mut buf = Vec::new();
+    substrait.encode(&mut buf).expect("encode");
+    buf
+}
+
+fn register_input(session_ptr: i64, input_id: &str, schema: &Schema) -> i64 {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("build tokio rt");
+    let plan_bytes = rt.block_on(build_passthrough_substrait(Arc::new(schema.clone())));
+    let id_bytes = input_id.as_bytes();
+    let mut out_buf = vec![0u8; 64 * 1024];
+    let mut out_len: i64 = 0;
+    let rc = unsafe {
+        df_register_partition_stream(
+            session_ptr,
+            id_bytes.as_ptr(),
+            id_bytes.len() as i64,
+            plan_bytes.as_ptr(),
+            plan_bytes.len() as i64,
+            out_buf.as_mut_ptr(),
+            out_buf.len() as i64,
+            &mut out_len as *mut i64,
+        )
+    };
+    assert!(rc > 0, "df_register_partition_stream rc={}", rc);
+    rc
+}
+
+fn export_batch_ptrs(batch: RecordBatch) -> (i64, i64) {
+    let schema = batch.schema();
+    let ffi_schema = FFI_ArrowSchema::try_from(schema.as_ref()).expect("schema export");
+
+    let struct_array: StructArray = batch.into();
+    let array_data = struct_array.into_data();
+    let ffi_array = FFI_ArrowArray::new(&array_data);
+
+    let array_ptr = Box::into_raw(Box::new(ffi_array)) as i64;
+    let schema_ptr = Box::into_raw(Box::new(ffi_schema)) as i64;
+    (array_ptr, schema_ptr)
+}
+
+// ---------------------------------------------------------------------------
+// Test
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_stringview_gc_on_sliced_batch() {
+    let runtime = RuntimeGuard::new();
+    let session_ptr = unsafe { df_create_local_session(runtime.ptr) };
+    assert!(session_ptr > 0);
+
+    let schema = utf8view_schema();
+    let sender_ptr = register_input(session_ptr, "input-0", schema.as_ref());
+
+    // Build a substrait plan for passthrough SELECT
+    let substrait_bytes = {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("build tokio rt");
+        rt.block_on(build_passthrough_substrait(Arc::clone(&schema)))
+    };
+
+    // Create a 10K-element StringViewArray, then slice to 100 rows.
+    // Each string is ~30 bytes so the full array backing is ~300KB.
+    // The sliced batch only references 100 strings (~3KB of actual data).
+    let producer = thread::spawn(move || {
+        let full_strings: Vec<String> = (0..10_000)
+            .map(|i| format!("string-value-padding-{:010}", i))
+            .collect();
+        let full_array = StringViewArray::from_iter_values(full_strings.iter().map(|s| s.as_str()));
+
+        // Verify the full array has substantial backing buffers
+        let full_buffer_size: usize = full_array.data_buffers().iter().map(|b| b.len()).sum();
+        assert!(
+            full_buffer_size > 200_000,
+            "full array buffer size should be >200KB, got {}",
+            full_buffer_size
+        );
+
+        // Slice to rows [100..200] — only 100 elements
+        let sliced = full_array.slice(100, 100);
+        let sliced_view = sliced
+            .as_any()
+            .downcast_ref::<StringViewArray>()
+            .expect("still a StringViewArray");
+
+        // The sliced array still references the full backing buffers
+        let sliced_buffer_size: usize = sliced_view.data_buffers().iter().map(|b| b.len()).sum();
+        assert!(
+            sliced_buffer_size > 200_000,
+            "sliced array should still carry full buffers before GC, got {}",
+            sliced_buffer_size
+        );
+
+        let batch = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![Field::new("s", DataType::Utf8View, false)])),
+            vec![Arc::new(sliced)],
+        )
+        .expect("batch from sliced array");
+
+        let (arr_ptr, sch_ptr) = export_batch_ptrs(batch);
+        let rc = unsafe { df_sender_send(sender_ptr, arr_ptr, sch_ptr) };
+        assert_eq!(rc, 0, "df_sender_send rc={}", rc);
+
+        unsafe { df_sender_close(sender_ptr) };
+    });
+
+    let stream_ptr = unsafe {
+        df_execute_local_plan(
+            session_ptr,
+            substrait_bytes.as_ptr(),
+            substrait_bytes.len() as i64,
+            0, // context_id
+        )
+    };
+    assert!(stream_ptr > 0, "df_execute_local_plan rc={}", stream_ptr);
+
+    // Drain the output and check buffer sizes
+    let mut output_batches: Vec<RecordBatch> = Vec::new();
+    loop {
+        let rc = unsafe { df_stream_next(stream_ptr) };
+        assert!(rc >= 0, "df_stream_next rc={}", rc);
+        if rc == 0 {
+            break;
+        }
+        let ffi_array = unsafe { Box::from_raw(rc as *mut FFI_ArrowArray) };
+        let result_schema = Arc::new(Schema::new(vec![Field::new(
+            "s",
+            DataType::Utf8View,
+            false,
+        )]));
+        let ffi_schema =
+            FFI_ArrowSchema::try_from(result_schema.as_ref()).expect("result schema export");
+        let array_data =
+            unsafe { arrow_array::ffi::from_ffi(*ffi_array, &ffi_schema).expect("import") };
+        let struct_array = StructArray::from(array_data);
+        let batch = RecordBatch::from(struct_array);
+        output_batches.push(batch);
+    }
+
+    unsafe { df_stream_close(stream_ptr) };
+    unsafe { df_close_local_session(session_ptr) };
+    producer.join().expect("producer thread");
+
+    // Validate: we got exactly 100 rows and the buffers are compact
+    let total_rows: usize = output_batches.iter().map(|b| b.num_rows()).sum();
+    assert_eq!(total_rows, 100, "expected 100 rows, got {}", total_rows);
+
+    let mut total_buffer_bytes: usize = 0;
+    for batch in &output_batches {
+        let col = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringViewArray>()
+            .expect("Utf8View column");
+        let buf_size: usize = col.data_buffers().iter().map(|b| b.len()).sum();
+        total_buffer_bytes += buf_size;
+    }
+
+    // 100 strings of ~30 bytes each = ~3KB of actual data.
+    // With compaction (line 459 active): buffers should be <= 10KB (generous margin).
+    // Without compaction: buffers would be >200KB (full 10K-element backing).
+    assert!(
+        total_buffer_bytes < 10_000,
+        "StringView buffers should be compacted to ~3KB, but got {} bytes. \
+         This indicates compact_string_view_columns is not working.",
+        total_buffer_bytes
+    );
+}

--- a/server/src/test/java/org/opensearch/cluster/DiskUsageTests.java
+++ b/server/src/test/java/org/opensearch/cluster/DiskUsageTests.java
@@ -500,6 +500,7 @@ public class DiskUsageTests extends OpenSearchTestCase {
             null,
             null,
             null,
+            null,
             null
         );
     }


### PR DESCRIPTION
### Description

`StringViewArray::slice()` shares ALL backing buffers via Arc. When DataFusion's hash aggregate emits via `EmitTo::All` and slices the result into per-batch chunks, each batch carries the full backing buffer pool — not just the strings it references. This caused up to 435x data amplification on multi-shard aggregate queries with many distinct string values.

**Root cause:** Arrow IPC and C Data Interface intentionally do not compact StringView backing buffers during serialization ([arrow-rs #5513](https://github.com/apache/arrow-rs/issues/5513)). Compaction is the caller's responsibility at the serialization boundary.

**Fix:** Add `compact_string_view_columns()` in `stream_next()` before FFI export. Calls `gc()` on StringView/BinaryView columns only when backing buffers are significantly over-allocated. Three-level precondition avoids unnecessary work:

```
stream_next() per batch:
  1. has_views flag?         → No: skip (O(1), set once at stream creation)
  2. view_needs_gc()?        → No: buffers compact (O(n) scan, 2x + 10KB threshold)
  3. gc()                    → compact the bloated columns (O(n) copy)
```

### Performance

| Query type | Cost per batch |
|---|---|
| No StringView columns (numeric agg, scan) | Zero — O(1) bool check |
| StringView but not sliced (scan, filter) | O(n) view scan, no allocation |
| Sliced StringView (hash aggregate emit) | O(n) scan + copy into compact buffer |

Validated on 4-shard ClickBench q19 (14M groups, SearchPhrase):
- Before: 9748 batches × 174MB = 1.7TB transferred, 12 minutes
- After: 9748 batches × 0.4MB = 4GB transferred, 11 seconds

### Testing

```bash
# Unit tests (function correctness + optimization)
cargo test -p opensearch-datafusion --lib -- api::tests

# Integration test (regression guard for stream_next call site)
cargo test -p opensearch-datafusion --test stringview_gc_test
```

The integration test feeds a sliced 10K→100 StringView batch through `df_stream_next` and asserts output buffers are compact (<10KB). **Fails immediately if the gc() call is removed** (gets 310KB instead).

### Check List
- [x] New functionality includes testing
- [x] New functionality has been documented
- [x] Commits are signed off