### PR TITLE
Analytics-engine: Update coordinator reduce to use search threadpool

### DIFF
--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stage/coordinator/LocalTaskRunner.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stage/coordinator/LocalTaskRunner.java
@@ -9,16 +9,16 @@
 package org.opensearch.analytics.exec.stage.coordinator;
 
 import org.opensearch.analytics.exec.task.TaskRunner;
+import org.opensearch.common.util.concurrent.AbstractRunnable;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.action.NotifyOnceListener;
 
 import java.util.concurrent.Executor;
 
 /**
- * LOCAL-kind task runner: submits the {@link LocalStageTask#body()} to a per-query
- * virtual-thread executor. The body owns the listener — wrapped in a
+ * LOCAL-kind task runner: submits the {@link LocalStageTask} to the search
+ * executor. The body owns the listener — wrapped in a
  * {@link NotifyOnceListener} so a body that both fires and throws can't double-notify.
- * Virtual threads keep blocking reduce drains off SEARCH workers.
  *
  * @opensearch.internal
  */
@@ -43,10 +43,21 @@ public final class LocalTaskRunner implements TaskRunner<LocalStageTask> {
                 listener.onFailure(cause);
             }
         };
-        executor.execute(() -> {
-            try {
+        executor.execute(new AbstractRunnable() {
+            @Override
+            protected void doRun() {
                 task.body().accept(once);
-            } catch (Exception e) {
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                once.onFailure(e);
+            }
+
+            @Override
+            public void onRejection(Exception e) {
+                // Bounded pool queue full — fail the query gracefully instead of letting the
+                // rejection escape run() and hang the query with no terminal callback.
                 once.onFailure(e);
             }
         });

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stage/coordinator/PassThroughStageExecution.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stage/coordinator/PassThroughStageExecution.java
@@ -37,7 +37,7 @@ public final class PassThroughStageExecution extends AbstractStageExecution impl
             throw new IllegalArgumentException("PassThroughStageExecution requires a RowProducingSink");
         }
         this.ownedSink = (RowProducingSink) sink;
-        this.runner = new LocalTaskRunner(config.localTaskExecutor());
+        this.runner = new LocalTaskRunner(config.searchExecutor());
     }
 
     @Override

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stage/coordinator/ReduceStageExecution.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stage/coordinator/ReduceStageExecution.java
@@ -38,7 +38,7 @@ public final class ReduceStageExecution extends AbstractStageExecution implement
         super(stage, config.queryId(), config.operationListeners(), config.parentTask());
         this.backendSink = backendSink;
         this.downstream = downstream;
-        this.runner = new LocalTaskRunner(config.localTaskExecutor());
+        this.runner = new LocalTaskRunner(config.searchExecutor());
     }
 
     @Override

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/stage/LocalTaskRunnerTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/stage/LocalTaskRunnerTests.java
@@ -10,9 +10,12 @@ package org.opensearch.analytics.exec.stage;
 
 import org.opensearch.analytics.exec.stage.coordinator.LocalStageTask;
 import org.opensearch.analytics.exec.stage.coordinator.LocalTaskRunner;
+import org.opensearch.common.util.concurrent.AbstractRunnable;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.concurrency.OpenSearchRejectedExecutionException;
 import org.opensearch.test.OpenSearchTestCase;
 
+import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -72,6 +75,29 @@ public class LocalTaskRunnerTests extends OpenSearchTestCase {
 
         submitted.get().run();
         assertTrue("onCompleted fires once the executor runs the body", completed.get());
+    }
+
+    public void testRejectionSignalsFailedGracefully() {
+        // A bounded pool rejects when its queue is full. OpenSearchThreadPoolExecutor invokes
+        // onRejection on an AbstractRunnable rather than rethrowing — the runner must route that
+        // to the listener so the query fails gracefully instead of hanging with no callback.
+        OpenSearchRejectedExecutionException rejected = new OpenSearchRejectedExecutionException("queue full");
+        AtomicBoolean ran = new AtomicBoolean();
+        AtomicBoolean completed = new AtomicBoolean();
+        AtomicReference<Exception> failure = new AtomicReference<>();
+
+        Executor rejectingExecutor = r -> ((AbstractRunnable) r).onRejection(rejected);
+        LocalTaskRunner dispatcher = new LocalTaskRunner(rejectingExecutor);
+        LocalStageTask task = new LocalStageTask(new StageTaskId(0, 0), listener -> {
+            ran.set(true);
+            listener.onResponse(null);
+        });
+
+        dispatcher.run(task, handle(completed, failure));
+
+        assertFalse("body must not run when the task is rejected", ran.get());
+        assertFalse("onCompleted must not fire when rejected", completed.get());
+        assertSame("rejection is routed to listener.onFailure", rejected, failure.get());
     }
 
     private static ActionListener<Void> handle(AtomicBoolean completed, AtomicReference<Exception> failure) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Run the coordinator reduce on the SEARCH pool instead of a virtual thread

This also properly wires up AbstractRunnable to handle rejection.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
