### PR TITLE
Add interceptCheckpointUpdates to TieringStatusIT and TierCancelIT

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/storage/tiering/TierCancelIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/storage/tiering/TierCancelIT.java
@@ -26,9 +26,13 @@ import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.core.common.unit.ByteSizeUnit;
 import org.opensearch.core.common.unit.ByteSizeValue;
 import org.opensearch.index.IndexModule;
+import org.opensearch.indices.replication.SegmentReplicationSourceService;
 import org.opensearch.node.Node;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.remotestore.RemoteStoreBaseIntegTestCase;
+import org.opensearch.core.transport.TransportResponse;
+import org.opensearch.test.transport.MockTransportService;
+import org.opensearch.transport.TransportService;
 import org.opensearch.storage.action.tiering.CancelTieringAction;
 import org.opensearch.storage.action.tiering.CancelTieringRequest;
 import org.opensearch.storage.action.tiering.HotToWarmTierAction;
@@ -36,7 +40,9 @@ import org.opensearch.storage.action.tiering.IndexTieringRequest;
 import org.opensearch.storage.action.tiering.WarmToHotTierAction;
 import org.opensearch.test.OpenSearchIntegTestCase;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -75,7 +81,9 @@ public class TierCancelIT extends RemoteStoreBaseIntegTestCase {
 
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {
-        return super.nodePlugins().stream().collect(Collectors.toList());
+        List<Class<? extends Plugin>> plugins = new ArrayList<>(super.nodePlugins());
+        plugins.add(MockTransportService.TestPlugin.class);
+        return plugins;
     }
 
     @Override
@@ -311,6 +319,26 @@ public class TierCancelIT extends RemoteStoreBaseIntegTestCase {
         internalCluster().startClusterManagerOnlyNode(settingsBuilder.build());
         internalCluster().startDataOnlyNodes(numberOfReplicas + 1, settingsBuilder.build());
         internalCluster().startWarmOnlyNodes(2, settingsBuilder.build());
+        interceptCheckpointUpdates();
+    }
+
+    protected void interceptCheckpointUpdates() {
+        for (String nodeName : internalCluster().getNodeNames()) {
+            MockTransportService mockTransportService = (MockTransportService) internalCluster().getInstance(
+                TransportService.class,
+                nodeName
+            );
+            mockTransportService.addRequestHandlingBehavior(
+                SegmentReplicationSourceService.Actions.UPDATE_VISIBLE_CHECKPOINT,
+                (handler, request, channel, task) -> {
+                    try {
+                        handler.messageReceived(request, channel, task);
+                    } catch (AssertionError e) {
+                        channel.sendResponse(TransportResponse.Empty.INSTANCE);
+                    }
+                }
+            );
+        }
     }
 
     protected void createTestIndex(String indexName, int numberOfShards, int numberOfReplicas) {

--- a/server/src/internalClusterTest/java/org/opensearch/storage/tiering/TieringStatusIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/storage/tiering/TieringStatusIT.java
@@ -16,6 +16,10 @@ import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.ClusterStateListener;
 import org.opensearch.cluster.MockInternalClusterInfoService;
 import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.core.transport.TransportResponse;
+import org.opensearch.indices.replication.SegmentReplicationSourceService;
+import org.opensearch.test.transport.MockTransportService;
+import org.opensearch.transport.TransportService;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.node.DiscoveryNodeRole;
 import org.opensearch.cluster.routing.IndexRoutingTable;
@@ -75,7 +79,7 @@ public class TieringStatusIT extends RemoteStoreBaseIntegTestCase {
 
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {
-        return Stream.concat(super.nodePlugins().stream(), Stream.of(MockInternalClusterInfoService.TestPlugin.class))
+        return Stream.concat(super.nodePlugins().stream(), Stream.of(MockInternalClusterInfoService.TestPlugin.class, MockTransportService.TestPlugin.class))
             .collect(Collectors.toList());
     }
 
@@ -97,6 +101,26 @@ public class TieringStatusIT extends RemoteStoreBaseIntegTestCase {
         internalCluster().startClusterManagerOnlyNode();
         internalCluster().startDataOnlyNodes(numberOfReplicas + 1);
         internalCluster().startWarmOnlyNodes(2);
+        interceptCheckpointUpdates();
+    }
+
+    protected void interceptCheckpointUpdates() {
+        for (String nodeName : internalCluster().getNodeNames()) {
+            MockTransportService mockTransportService = (MockTransportService) internalCluster().getInstance(
+                TransportService.class,
+                nodeName
+            );
+            mockTransportService.addRequestHandlingBehavior(
+                SegmentReplicationSourceService.Actions.UPDATE_VISIBLE_CHECKPOINT,
+                (handler, request, channel, task) -> {
+                    try {
+                        handler.messageReceived(request, channel, task);
+                    } catch (AssertionError e) {
+                        channel.sendResponse(TransportResponse.Empty.INSTANCE);
+                    }
+                }
+            );
+        }
     }
 
     protected void createTestIndex(String indexName, int numberOfShards, int numberOfReplicas) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Adds `interceptCheckpointUpdates` fix to `TieringStatusIT` and `TierCancelIT` to resolve the`ReplicationTracker` assertion race condition (GitHub #3923).

During tiering operations with segment replication, a checkpoint update can arrive after relocation handoff begins, triggering an assertion in `ReplicationTracker.updateVisibleCheckpointForShard`. The fix intercepts the `UPDATE_VISIBLE_CHECKPOINT` transport action and gracefully handles the`AssertionError` — the same approach already applied to `HotToWarmTieringServiceIT` and`WarmToHotTieringServiceIT`.

This PR is intended to be merged into #21749.

### Related Issues
Resolves the flaky `TieringStatusIT.testTieringStatus` failure (muted via `@AwaitsFix` in #21749 commit 7).

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
