### PR TITLE
[BUG] Fix for intermediate field name handling

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionFragmentConvertor.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionFragmentConvertor.java
@@ -22,11 +22,15 @@ import org.apache.calcite.rel.RelReferentialConstraint;
 import org.apache.calcite.rel.RelRoot;
 import org.apache.calcite.rel.core.AggregateCall;
 import org.apache.calcite.rel.core.TableScan;
+import org.apache.calcite.rel.logical.LogicalFilter;
+import org.apache.calcite.rel.logical.LogicalProject;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.rex.RexInputRef;
 import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexShuttle;
 import org.apache.calcite.schema.ColumnStrategy;
 import org.apache.calcite.sql.SqlAggFunction;
 import org.apache.calcite.sql.SqlFunctionCategory;
@@ -621,6 +625,49 @@ public class DataFusionFragmentConvertor implements FragmentConvertor {
             newMeasures.add(Aggregate.Measure.builder().from(m).function(rephased).build());
         }
         return Aggregate.builder().from(agg).measures(newMeasures).build();
+    }
+
+    /**
+     * Eliminates intermediate project nodes that introduce derived fields referenced by
+     * a filter above them. Inlines the project's expressions into the filter condition
+     * and moves the project above the filter.
+     *
+     * <p>This works around a Substrait/DataFusion limitation: Substrait does not carry
+     * intermediate field names, so DataFusion's Substrait consumer derives them from
+     * expression strings. DataFusion's optimizer then pushes filters past projections
+     * using those synthetic names, which fail schema resolution against the raw table.
+     */
+    private static RelNode eliminateIntermediateRelNodes(RelNode node) {
+        // Recurse into children first (bottom-up)
+        List<RelNode> newInputs = new ArrayList<>(node.getInputs().size());
+        boolean childrenChanged = false;
+        for (RelNode input : node.getInputs()) {
+            RelNode rewritten = eliminateIntermediateRelNodes(input);
+            newInputs.add(rewritten);
+            if (rewritten != input) {
+                childrenChanged = true;
+            }
+        }
+        RelNode current = childrenChanged ? node.copy(node.getTraitSet(), newInputs) : node;
+
+        // Check if this is a Filter whose input is a Project
+        if (current instanceof org.apache.calcite.rel.core.Filter filter
+            && filter.getInput() instanceof org.apache.calcite.rel.core.Project project) {
+            List<RexNode> projectExprs = project.getProjects();
+            // Inline: replace each RexInputRef in the filter condition with the
+            // corresponding project expression
+            RexNode inlinedCondition = filter.getCondition().accept(new RexShuttle() {
+                @Override
+                public RexNode visitInputRef(RexInputRef inputRef) {
+                    return projectExprs.get(inputRef.getIndex());
+                }
+            });
+            // Rebuild: Project(Filter(Project.input)) with the inlined condition
+            RelNode projectInput = project.getInput();
+            RelNode newFilter = LogicalFilter.create(projectInput, inlinedCondition);
+            return LogicalProject.create(newFilter, List.of(), projectExprs, project.getRowType());
+        }
+        return current;
     }
 
     /**

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionFragmentConvertor.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionFragmentConvertor.java
@@ -458,6 +458,29 @@ public class DataFusionFragmentConvertor implements FragmentConvertor {
         // LOCAL_*_OP stubs so isthmus's AggregateFunctionConverter binds them by
         // operator identity through ADDITIONAL_AGGREGATE_SIGS.
         preprocessed = PplAggregateCallRewriter.rewrite(preprocessed);
+
+        // Substrait does not name intermediate fields in a plan — all references are
+        // positional ordinals (see https://substrait.io/faq/#where-are-field-names-represented).
+        // When DataFusion's Substrait consumer (datafusion-substrait crate) deserializes a
+        // ProjectRel, it invents names for expression-derived output fields using the expression
+        // string (e.g. "table.col + Int32(1)") per DataFusion's output field name semantics.
+        // If a FilterRel above the ProjectRel references such a derived field, DataFusion's
+        // optimizer (FilterProjectTransposeRule) pushes the filter below the projection. The
+        // filter then references the expression-derived column name against the raw table schema,
+        // causing "Schema error: No field named ...".
+        //
+        // Input (problematic — filter references derived column from intermediate project):
+        //   Filter(condition: >($19, 200))
+        //     Project(..., answerId=[+($0, 1)])
+        //       TableScan(opensearch-sql_test_index_beer)
+        //
+        // Output (safe — filter inlined, references raw table columns only):
+        //   Project(..., answerId=[+($0, 1)])
+        //     Filter(condition: >(+($0, 1), 200))
+        //       TableScan(opensearch-sql_test_index_beer)
+        //
+        preprocessed = eliminateIntermediateRelNodes(preprocessed);
+
         RelRoot root = RelRoot.of(preprocessed, SqlKind.SELECT);
         SubstraitRelVisitor visitor = createVisitor(preprocessed);
         Rel substraitRel;

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionFragmentConvertorTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionFragmentConvertorTests.java
@@ -698,4 +698,90 @@ public class DataFusionFragmentConvertorTests extends OpenSearchTestCase {
         assertTrue("lower's input must be the rewired stage-scan", innerOfLower.hasRead());
     }
 
+    // ── eliminateIntermediateRelNodes tests ────────────────────────────────────
+
+    /**
+     * A {@code Filter(Project(Scan))} is rewritten to {@code Project(Filter(Scan))}
+     * with the filter condition inlined to reference raw table columns.
+     * This prevents DataFusion's optimizer from failing on synthetic field names.
+     */
+    public void testFilterOverProjectOverScan_RewrittenToProjectOverFilterOverScan() throws Exception {
+        RelNode scan = buildTableScan("test_index", "A", "B");
+        // Project: [A + 1, B]
+        RexNode exprA = rexBuilder.makeCall(
+            SqlStdOperatorTable.PLUS,
+            rexBuilder.makeInputRef(scan, 0),
+            rexBuilder.makeLiteral(1, typeFactory.createSqlType(SqlTypeName.INTEGER), true)
+        );
+        RexNode exprB = rexBuilder.makeInputRef(scan, 1);
+        RelNode project = LogicalProject.create(scan, List.of(), List.of(exprA, exprB), List.of("derived_a", "B"), java.util.Set.of());
+
+        // Filter on derived_a > 200 (references project output column 0)
+        RexNode filterCond = rexBuilder.makeCall(
+            SqlStdOperatorTable.GREATER_THAN,
+            rexBuilder.makeInputRef(project, 0),
+            rexBuilder.makeLiteral(200, typeFactory.createSqlType(SqlTypeName.INTEGER), true)
+        );
+        RelNode filter = LogicalFilter.create(project, filterCond);
+
+        byte[] bytes = newConvertor().convertFragment(filter);
+        Plan plan = decodeSubstrait(bytes);
+        Rel root = rootRel(plan);
+
+        // After rewrite: root should be ProjectRel(FilterRel(ReadRel))
+        assertTrue("root must be a ProjectRel after rewrite", root.hasProject());
+        ProjectRel projectRel = root.getProject();
+        Rel projectInput = projectRel.getInput();
+        assertTrue("Project input must be a FilterRel", projectInput.hasFilter());
+        FilterRel filterRel = projectInput.getFilter();
+        assertTrue("Filter must have a condition", filterRel.hasCondition());
+        Rel filterInput = filterRel.getInput();
+        assertTrue("Filter input must be a ReadRel (table scan)", filterInput.hasRead());
+        assertEquals(List.of("test_index"), filterInput.getRead().getNamedTable().getNamesList());
+    }
+
+    /**
+     * A bare {@code Project(Scan)} without a filter above it passes through unchanged —
+     * the rewrite only triggers for Filter-over-Project patterns.
+     */
+    public void testProjectOverScan_NoFilter_PassesThroughUnchanged() throws Exception {
+        RelNode scan = buildTableScan("test_index", "A", "B");
+        RexNode exprA = rexBuilder.makeCall(
+            SqlStdOperatorTable.PLUS,
+            rexBuilder.makeInputRef(scan, 0),
+            rexBuilder.makeLiteral(1, typeFactory.createSqlType(SqlTypeName.INTEGER), true)
+        );
+        RelNode project = LogicalProject.create(scan, List.of(), List.of(exprA), List.of("derived_a"), java.util.Set.of());
+
+        byte[] bytes = newConvertor().convertFragment(project);
+        Plan plan = decodeSubstrait(bytes);
+        Rel root = rootRel(plan);
+
+        // Should remain ProjectRel(ReadRel) — no filter inserted
+        assertTrue("root must be a ProjectRel", root.hasProject());
+        Rel projectInput = root.getProject().getInput();
+        assertTrue("Project input must be a ReadRel", projectInput.hasRead());
+    }
+
+    /**
+     * A {@code Filter(Scan)} without an intermediate project passes through unchanged.
+     */
+    public void testFilterOverScan_NoProject_PassesThroughUnchanged() throws Exception {
+        RelNode scan = buildTableScan("test_index", "A", "B");
+        RexNode predicate = rexBuilder.makeCall(
+            SqlStdOperatorTable.GREATER_THAN,
+            rexBuilder.makeInputRef(scan, 0),
+            rexBuilder.makeLiteral(5, typeFactory.createSqlType(SqlTypeName.INTEGER), true)
+        );
+        RelNode filter = LogicalFilter.create(scan, predicate);
+
+        byte[] bytes = newConvertor().convertFragment(filter);
+        Plan plan = decodeSubstrait(bytes);
+        Rel root = rootRel(plan);
+
+        // Should remain FilterRel(ReadRel)
+        assertTrue("root must be a FilterRel", root.hasFilter());
+        assertTrue("Filter input must be a ReadRel", root.getFilter().getInput().hasRead());
+    }
+
 }


### PR DESCRIPTION
#### Description

Fixes a plan conversion failure when a PPL query uses EVAL (project) followed by WHERE (filter) on the derived column — e.g.:
```
SOURCE=index | EVAL answerId = AcceptedAnswerId + 1 | WHERE answerId > 200
```

#### Problem

Substrait does not carry intermediate field names — all references are positional ordinals. When DataFusion's Substrait consumer deserializes a ProjectRel, it invents
names for expression-derived output fields using the expression string (e.g. "table.col + Int32(1)"). If a FilterRel above the ProjectRel references such a derived
field, DataFusion's optimizer (FilterProjectTransposeRule) pushes the filter below the projection. The filter then references the expression-derived column name against
the raw table schema, causing:

`Schema error: No field named "table.col + Int32(1)"`

#### Fix

Added eliminateIntermediateRelNodes() which rewrites Filter(Project(Scan)) into Project(Filter(Scan)) before Substrait conversion. The filter condition is inlined with
the project's expressions so it references raw table columns directly:

Before (problematic):

```
Filter(condition: >(answerId, 200))
  Project(..., answerId=[+($0, 1)])
    TableScan(index)
```
After (safe):
```
Project(..., answerId=[+($0, 1)])
  Filter(condition: >(+($0, 1), 200))
    TableScan(index)
```
This ensures the Substrait plan never contains a filter referencing synthetic intermediate field names.

#### Testing

Added 3 unit tests in DataFusionFragmentConvertorTests:

- testFilterOverProjectOverScan_RewrittenToProjectOverFilterOverScan — verifies the rewrite produces ProjectRel(FilterRel(ReadRel))
- testProjectOverScan_NoFilter_PassesThroughUnchanged — no false triggering
- testFilterOverScan_NoProject_PassesThroughUnchanged — no false triggering

Manually verified with PPL query on a local cluster:
```
SOURCE=parquet_test | EVAL newScore = score + 1 | WHERE newScore > 5
```

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
