### PR TITLE
fix: Combine same-backend delegated predicates into single Bool.

### DIFF
--- a/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/AnalyticsSearchBackendPlugin.java
+++ b/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/AnalyticsSearchBackendPlugin.java
@@ -155,4 +155,22 @@ public interface AnalyticsSearchBackendPlugin {
     default Exception convertException(Exception original) {
         return original;
     }
+
+    /**
+     * Returns the backend's subtree convertor for combining multiple delegated predicates
+     * into a single serialized expression, or {@code null} if the backend cannot combine.
+     * When {@code null}, the framework falls back to one {@link DelegatedExpression} per leaf.
+     */
+    default DelegatedSubtreeConvertor getDelegatedSubtreeConvertor() {
+        return null;
+    }
+
+    /**
+     * Per-function serializers for delegated predicates this backend can accept.
+     * Keyed by {@link ScalarFunction} — the framework dispatches to the matching
+     * serializer during fragment conversion when a predicate is delegated to this backend.
+     */
+    default Map<ScalarFunction, DelegatedPredicateSerializer> delegatedPredicateSerializers() {
+        return Map.of();
+    }
 }

--- a/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/DelegatedSubtreeConvertor.java
+++ b/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/DelegatedSubtreeConvertor.java
@@ -1,0 +1,39 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.spi;
+
+import org.apache.calcite.rex.RexNode;
+
+import java.util.List;
+
+/**
+ * Converts a maximal same-backend delegated RexNode subtree into the backend's
+ * serialized delegation bytes. The subtree may be a single leaf RexCall or a
+ * tree rooted at AND/OR/NOT whose every leaf targets this backend.
+ *
+ * <p>The backend walks the subtree once and emits bytes once. Inputs are NOT
+ * pre-serialized leaves; the backend sees the raw Calcite tree.
+ *
+ * @opensearch.internal
+ */
+@FunctionalInterface
+public interface DelegatedSubtreeConvertor {
+
+    /**
+     * Convert a maximal same-backend RexNode subtree into delegation bytes.
+     *
+     * @param subtree      the RexNode subtree to convert. May contain
+     *                     AnnotatedPredicate wrappers — implementations
+     *                     must call {@code ap.unwrap()} to reach the original RexCall.
+     * @param fieldStorage per-column storage metadata for resolving
+     *                     RexInputRef indices to field names.
+     * @return backend-specific serialized bytes for the entire subtree.
+     */
+    byte[] convertSubtree(RexNode subtree, List<FieldStorageInfo> fieldStorage);
+}

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/FilterDelegationForIndexFullConversionTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/FilterDelegationForIndexFullConversionTests.java
@@ -169,12 +169,12 @@ public class FilterDelegationForIndexFullConversionTests extends OpenSearchTestC
 
         SubstraitResult substrait = substraitResult(plan.convertedBytes());
         logger.info("Substrait plan (mixed E2E):\n{}", substrait.plan());
-        // Root: AND
+        // Root: AND — operand order: delegated first, native after (materializeCombined)
         Expression.ScalarFunction andFunc = substrait.filterRel().getCondition().getScalarFunction();
         assertEquals("and", resolveFunctionName(substrait.plan(), andFunc.getFunctionReference()));
         assertEquals("AND must have 2 arguments", 2, andFunc.getArgumentsCount());
-        // arg[1]: delegated_predicate(1) — annotation id=1 maps to MATCH 'hello world'
-        assertDelegatedPredicate(substrait.plan(), andFunc.getArguments(1).getValue(), 1);
+        // arg[0]: delegated_predicate(1) — annotation id=1 maps to MATCH 'hello world'
+        assertDelegatedPredicate(substrait.plan(), andFunc.getArguments(0).getValue(), 1);
         assertMatchQueryForAnnotation(plan.delegatedExpressions(), 1, "message", "hello world");
     }
 
@@ -195,33 +195,19 @@ public class FilterDelegationForIndexFullConversionTests extends OpenSearchTestC
         );
         StagePlan plan = runPipeline(condition);
 
-        assertEquals("should have 2 delegated queries", 2, plan.delegatedExpressions().size());
+        // OR(MATCH 'hello', NOT(MATCH 'goodbye')) is combined into a single BoolQuery
+        assertEquals("should have 1 combined delegated query", 1, plan.delegatedExpressions().size());
 
         SubstraitResult substrait = substraitResult(plan.convertedBytes());
         logger.info("Substrait plan (complex E2E):\n{}", substrait.plan());
 
-        // Root: AND
+        // Root: AND(native_equals, delegated_predicate)
         Expression.ScalarFunction andFunc = substrait.filterRel().getCondition().getScalarFunction();
         assertEquals("and", resolveFunctionName(substrait.plan(), andFunc.getFunctionReference()));
         assertEquals("AND must have 2 arguments", 2, andFunc.getArgumentsCount());
 
-        // arg[1]: OR
-        Expression orExpr = andFunc.getArguments(1).getValue();
-        assertTrue("second AND arg must be scalar function", orExpr.hasScalarFunction());
-        assertEquals("or", resolveFunctionName(substrait.plan(), orExpr.getScalarFunction().getFunctionReference()));
-        Expression.ScalarFunction orFunc = orExpr.getScalarFunction();
-        assertEquals("OR must have 2 arguments", 2, orFunc.getArgumentsCount());
-
-        // OR arg[0]: delegated_predicate(1) → MATCH 'hello'
-        assertDelegatedPredicate(substrait.plan(), orFunc.getArguments(0).getValue(), 1);
-        assertMatchQueryForAnnotation(plan.delegatedExpressions(), 1, "message", "hello");
-
-        // OR arg[1]: NOT(delegated_predicate(2)) → MATCH 'goodbye'
-        Expression notExpr = orFunc.getArguments(1).getValue();
-        assertTrue("OR second arg must be scalar function", notExpr.hasScalarFunction());
-        assertEquals("not", resolveFunctionName(substrait.plan(), notExpr.getScalarFunction().getFunctionReference()));
-        assertDelegatedPredicate(substrait.plan(), notExpr.getScalarFunction().getArguments(0).getValue(), 2);
-        assertMatchQueryForAnnotation(plan.delegatedExpressions(), 2, "message", "goodbye");
+        // arg[0]: delegated_predicate(1) — combined OR(MATCH 'hello', NOT(MATCH 'goodbye'))
+        assertDelegatedPredicate(substrait.plan(), andFunc.getArguments(0).getValue(), 1);
     }
 
     // ---- Pipeline ----

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/LuceneAnalyticsBackendPlugin.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/LuceneAnalyticsBackendPlugin.java
@@ -17,6 +17,7 @@ import org.opensearch.analytics.spi.BackendCapabilityProvider;
 import org.opensearch.analytics.spi.CommonExecutionContext;
 import org.opensearch.analytics.spi.DelegatedExpression;
 import org.opensearch.analytics.spi.DelegatedPredicateSerializer;
+import org.opensearch.analytics.spi.DelegatedSubtreeConvertor;
 import org.opensearch.analytics.spi.DelegationType;
 import org.opensearch.analytics.spi.EngineCapability;
 import org.opensearch.analytics.spi.FieldType;
@@ -200,4 +201,13 @@ public class LuceneAnalyticsBackendPlugin implements AnalyticsSearchBackendPlugi
 
     // ---- Serializers ----
 
+    @Override
+    public Map<ScalarFunction, DelegatedPredicateSerializer> delegatedPredicateSerializers() {
+        return QuerySerializerRegistry.getSerializers();
+    }
+
+    @Override
+    public DelegatedSubtreeConvertor getDelegatedSubtreeConvertor() {
+        return new LuceneSubtreeConvertor(QuerySerializerRegistry.getSerializers());
+    }
 }

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/LuceneSubtreeConvertor.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/LuceneSubtreeConvertor.java
@@ -1,0 +1,90 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.lucene;
+
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.opensearch.analytics.planner.rel.AnnotatedPredicate;
+import org.opensearch.analytics.spi.DelegatedPredicateSerializer;
+import org.opensearch.analytics.spi.DelegatedSubtreeConvertor;
+import org.opensearch.analytics.spi.FieldStorageInfo;
+import org.opensearch.analytics.spi.ScalarFunction;
+import org.opensearch.be.lucene.serializers.AbstractQuerySerializer;
+import org.opensearch.index.query.BoolQueryBuilder;
+import org.opensearch.index.query.QueryBuilder;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Converts a maximal same-backend delegated RexNode subtree into a single
+ * serialized {@link BoolQueryBuilder}. Walks the subtree once, building
+ * {@link QueryBuilder} objects for leaves via existing serializers, composing
+ * them with {@link BoolQueryBuilder} for AND/OR/NOT, and serializes once at the root.
+ *
+ * @opensearch.internal
+ */
+final class LuceneSubtreeConvertor implements DelegatedSubtreeConvertor {
+
+    private final Map<ScalarFunction, DelegatedPredicateSerializer> leafSerializers;
+
+    LuceneSubtreeConvertor(Map<ScalarFunction, DelegatedPredicateSerializer> leafSerializers) {
+        this.leafSerializers = leafSerializers;
+    }
+
+    @Override
+    public byte[] convertSubtree(RexNode subtree, List<FieldStorageInfo> fieldStorage) {
+        QueryBuilder qb = toQueryBuilder(subtree, fieldStorage);
+        return ConversionUtils.serializeQueryBuilder(qb);
+    }
+
+    private QueryBuilder toQueryBuilder(RexNode node, List<FieldStorageInfo> fieldStorage) {
+        if (node instanceof AnnotatedPredicate ap) {
+            node = ap.unwrap();
+        }
+        if (node instanceof RexCall call) {
+            switch (call.getKind()) {
+                case AND: {
+                    BoolQueryBuilder b = new BoolQueryBuilder();
+                    for (RexNode child : call.getOperands()) {
+                        b.must(toQueryBuilder(child, fieldStorage));
+                    }
+                    return b;
+                }
+                case OR: {
+                    BoolQueryBuilder b = new BoolQueryBuilder();
+                    for (RexNode child : call.getOperands()) {
+                        b.should(toQueryBuilder(child, fieldStorage));
+                    }
+                    return b;
+                }
+                case NOT: {
+                    BoolQueryBuilder b = new BoolQueryBuilder();
+                    b.mustNot(toQueryBuilder(call.getOperands().get(0), fieldStorage));
+                    return b;
+                }
+                default:
+                    return leafToQueryBuilder(call, fieldStorage);
+            }
+        }
+        throw new IllegalStateException("Unexpected RexNode in delegated subtree: " + node);
+    }
+
+    private QueryBuilder leafToQueryBuilder(RexCall call, List<FieldStorageInfo> fieldStorage) {
+        ScalarFunction fn = ScalarFunction.fromSqlOperatorWithFallback(call.getOperator());
+        if (fn == null) {
+            throw new IllegalStateException("Unrecognized operator in delegated subtree: " + call.getOperator());
+        }
+        DelegatedPredicateSerializer serializer = leafSerializers.get(fn);
+        if (serializer == null) {
+            throw new IllegalStateException("No serializer for [" + fn + "] inside delegated subtree");
+        }
+        return ((AbstractQuerySerializer) serializer).buildQueryBuilder(call, fieldStorage);
+    }
+}

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/AbstractQuerySerializer.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/AbstractQuerySerializer.java
@@ -28,5 +28,5 @@ public abstract class AbstractQuerySerializer implements DelegatedPredicateSeria
         return ConversionUtils.serializeQueryBuilder(queryBuilder);
     }
 
-    protected abstract QueryBuilder buildQueryBuilder(RexCall call, List<FieldStorageInfo> fieldStorage);
+    public abstract QueryBuilder buildQueryBuilder(RexCall call, List<FieldStorageInfo> fieldStorage);
 }

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/AbstractRelevanceSerializer.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/AbstractRelevanceSerializer.java
@@ -24,7 +24,7 @@ import java.util.Map;
 public abstract class AbstractRelevanceSerializer extends AbstractQuerySerializer {
 
     @Override
-    protected final QueryBuilder buildQueryBuilder(RexCall call, List<FieldStorageInfo> fieldStorage) {
+    public final QueryBuilder buildQueryBuilder(RexCall call, List<FieldStorageInfo> fieldStorage) {
         ConversionUtils.RelevanceOperands operands = ConversionUtils.extractRelevanceOperands(call, fieldStorage);
         validate(operands);
         QueryBuilder qb = createQueryBuilder(operands);

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/EqualsSerializer.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/EqualsSerializer.java
@@ -36,7 +36,7 @@ import java.util.List;
 public class EqualsSerializer extends AbstractQuerySerializer {
 
     @Override
-    protected QueryBuilder buildQueryBuilder(RexCall call, List<FieldStorageInfo> fieldStorage) {
+    public QueryBuilder buildQueryBuilder(RexCall call, List<FieldStorageInfo> fieldStorage) {
         if (call.getOperands().size() != 2) {
             throw new IllegalArgumentException("EQUALS expects 2 operands, got " + call.getOperands().size());
         }

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/MatchAllSerializer.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/MatchAllSerializer.java
@@ -23,7 +23,7 @@ import java.util.List;
 public class MatchAllSerializer extends AbstractQuerySerializer {
 
     @Override
-    protected QueryBuilder buildQueryBuilder(RexCall call, List<FieldStorageInfo> fieldStorage) {
+    public QueryBuilder buildQueryBuilder(RexCall call, List<FieldStorageInfo> fieldStorage) {
         return new MatchAllQueryBuilder();
     }
 }

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/dag/DelegatedPredicateCombiner.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/dag/DelegatedPredicateCombiner.java
@@ -1,0 +1,286 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.planner.dag;
+
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlKind;
+import org.opensearch.analytics.planner.CapabilityRegistry;
+import org.opensearch.analytics.planner.rel.AnnotatedPredicate;
+import org.opensearch.analytics.planner.rel.OperatorAnnotation;
+import org.opensearch.analytics.spi.DelegatedExpression;
+import org.opensearch.analytics.spi.DelegatedPredicateFunction;
+import org.opensearch.analytics.spi.DelegatedSubtreeConvertor;
+import org.opensearch.analytics.spi.DelegationPossibleFunction;
+import org.opensearch.analytics.spi.FieldStorageInfo;
+import org.opensearch.analytics.spi.ScalarFunction;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * Bottom-up classifier for filter condition trees. Classifies each node as
+ * delegated (targets a non-operator backend) or resolved (native), combining
+ * same-backend delegated siblings under AND/OR/NOT into a single serialized
+ * expression via the backend's {@link DelegatedSubtreeConvertor}.
+ *
+ * @opensearch.internal
+ */
+final class DelegatedPredicateCombiner {
+
+    private final String operatorBackend;
+    private final List<FieldStorageInfo> fieldStorage;
+    private final CapabilityRegistry registry;
+    private final RexBuilder rexBuilder;
+    private final List<DelegatedExpression> delegatedExpressions;
+
+    DelegatedPredicateCombiner(
+        String operatorBackend,
+        List<FieldStorageInfo> fieldStorage,
+        CapabilityRegistry registry,
+        RexBuilder rexBuilder,
+        List<DelegatedExpression> delegatedExpressions
+    ) {
+        this.operatorBackend = operatorBackend;
+        this.fieldStorage = fieldStorage;
+        this.registry = registry;
+        this.rexBuilder = rexBuilder;
+        this.delegatedExpressions = delegatedExpressions;
+    }
+
+    /** Bottom-up: classify each node as Delegated (carries the RexNode subtree) or Resolved. */
+    Classified classify(RexNode node, Function<OperatorAnnotation, RexNode> applyFn) {
+        if (node instanceof AnnotatedPredicate ap) {
+            String backend = ap.getViableBackends().getFirst();
+            if (!backend.equals(operatorBackend) && canSerialize(ap, backend)) {
+                return new Delegated(backend, node, ap.getAnnotationId(), false);
+            } else if (!ap.getPerformanceDelegationBackends().isEmpty()) {
+                String peerBackend = ap.getPerformanceDelegationBackends().getFirst();
+                if (canSerialize(ap, peerBackend)) {
+                    return new Delegated(peerBackend, node, ap.getAnnotationId(), true);
+                }
+            }
+            return new Resolved(applyFn.apply(ap));
+        }
+
+        if (node instanceof RexCall call) {
+            SqlKind kind = call.getKind();
+            if (kind != SqlKind.AND && kind != SqlKind.OR && kind != SqlKind.NOT) {
+                return new Resolved(resolveCallChildren(call, applyFn));
+            }
+
+            List<Classified> kids = new ArrayList<>(call.getOperands().size());
+            for (RexNode operand : call.getOperands()) {
+                kids.add(classify(operand, applyFn));
+            }
+            return combine(call, kids, applyFn);
+        }
+
+        return new Resolved(node);
+    }
+
+    /** Combines classified children of an AND/OR/NOT call into a single Classified result. */
+    private Classified combine(RexCall call, List<Classified> kids, Function<OperatorAnnotation, RexNode> applyFn) {
+        boolean isOrNot = call.getKind() == SqlKind.OR || call.getKind() == SqlKind.NOT;
+
+        List<Delegated> correctnessChildren = new ArrayList<>();
+        List<Delegated> performanceChildren = new ArrayList<>();
+        List<Object> ordered = new ArrayList<>();
+        String commonBackend = null;
+        boolean multiBackend = false;
+
+        for (Classified c : kids) {
+            if (c instanceof Delegated d) {
+                if (isOrNot && d.performanceDelegation()) {
+                    ordered.add(applyFn.apply((AnnotatedPredicate) d.subtree()));
+                } else {
+                    (d.performanceDelegation() ? performanceChildren : correctnessChildren).add(d);
+                    ordered.add(d);
+                    if (commonBackend == null) commonBackend = d.backend();
+                    else if (!commonBackend.equals(d.backend())) multiBackend = true;
+                }
+            } else {
+                ordered.add(((Resolved) c).node());
+            }
+        }
+
+        if ((correctnessChildren.isEmpty() && performanceChildren.isEmpty()) || multiBackend) {
+            return new Resolved(materializeIndividually(call, ordered));
+        }
+
+        DelegatedSubtreeConvertor convertor = registry.getBackend(commonBackend).getDelegatedSubtreeConvertor();
+        if (convertor == null) {
+            return new Resolved(materializeIndividually(call, ordered));
+        }
+
+        if (ordered.size() == correctnessChildren.size() && performanceChildren.isEmpty()) {
+            // All children are correctness-delegated to the same backend — bubble up
+            int firstId = correctnessChildren.getFirst().firstAnnotationId();
+            return new Delegated(commonBackend, call, firstId, false);
+        }
+
+        if (ordered.size() == performanceChildren.size() && correctnessChildren.isEmpty()) {
+            // All children are performance-delegated to the same backend — bubble up
+            int firstId = performanceChildren.getFirst().firstAnnotationId();
+            return new Delegated(commonBackend, call, firstId, true);
+        }
+
+        // Mixed: combine correctness-delegated into one expression, performance-delegated into another.
+        byte[] correctnessCombined = null;
+        int correctnessFirstId = 0;
+        if (!correctnessChildren.isEmpty()) {
+            correctnessFirstId = correctnessChildren.getFirst().firstAnnotationId();
+            RexNode correctnessSubtree = buildCombinedSubtree(call, correctnessChildren);
+            correctnessCombined = convertor.convertSubtree(correctnessSubtree, fieldStorage);
+        }
+
+        byte[] performanceCombined = null;
+        int performanceFirstId = 0;
+        if (!performanceChildren.isEmpty()) {
+            performanceFirstId = performanceChildren.getFirst().firstAnnotationId();
+            RexNode performanceSubtree = buildCombinedSubtree(call, performanceChildren);
+            performanceCombined = convertor.convertSubtree(performanceSubtree, fieldStorage);
+        }
+
+        return new Resolved(
+            materializeCombined(
+                call,
+                ordered,
+                correctnessFirstId,
+                commonBackend,
+                correctnessCombined,
+                performanceFirstId,
+                performanceCombined
+            )
+        );
+    }
+
+    private RexNode materializeIndividually(RexCall call, List<Object> ordered) {
+        List<RexNode> newOperands = new ArrayList<>();
+        for (Object item : ordered) {
+            if (item instanceof Delegated d) {
+                byte[] bytes = convertSingleDelegated(d);
+                delegatedExpressions.add(new DelegatedExpression(d.firstAnnotationId(), d.backend(), bytes));
+                newOperands.add(makePlaceholder(d));
+            } else {
+                newOperands.add((RexNode) item);
+            }
+        }
+        return call.clone(call.getType(), newOperands);
+    }
+
+    private RexNode materializeCombined(
+        RexCall call,
+        List<Object> ordered,
+        int correctnessFirstId,
+        String backend,
+        byte[] correctnessCombined,
+        int perfFirstId,
+        byte[] perfCombined
+    ) {
+        List<RexNode> newOperands = new ArrayList<>();
+        if (correctnessCombined != null) {
+            delegatedExpressions.add(new DelegatedExpression(correctnessFirstId, backend, correctnessCombined));
+            newOperands.add(DelegatedPredicateFunction.makeCall(rexBuilder, correctnessFirstId));
+        }
+        if (perfCombined != null) {
+            delegatedExpressions.add(new DelegatedExpression(perfFirstId, backend, perfCombined));
+            List<RexNode> unwrapped = ordered.stream()
+                .filter(o -> o instanceof Delegated d && d.performanceDelegation())
+                .map(o -> ((AnnotatedPredicate) ((Delegated) o).subtree()).unwrap())
+                .toList();
+            RexNode perfOriginal = unwrapped.size() == 1 ? unwrapped.getFirst() : call.clone(call.getType(), unwrapped);
+            newOperands.add(DelegationPossibleFunction.makeCall(rexBuilder, perfOriginal, perfFirstId));
+        }
+        for (Object item : ordered) {
+            if (item instanceof Delegated == false) {
+                newOperands.add((RexNode) item);
+            }
+        }
+        return call.clone(call.getType(), newOperands);
+    }
+
+    /** Converts a single Delegated node (leaf or subtree) into bytes via the backend's convertor. */
+    private byte[] convertSingleDelegated(Delegated d) {
+        DelegatedSubtreeConvertor convertor = registry.getBackend(d.backend()).getDelegatedSubtreeConvertor();
+        if (convertor == null) {
+            throw new IllegalStateException("Backend [" + d.backend() + "] declares delegation but has no DelegatedSubtreeConvertor");
+        }
+        return convertor.convertSubtree(d.subtree(), fieldStorage);
+    }
+
+    /** Finalizes a Delegated result: converts to bytes, emits DelegatedExpression, returns placeholder. */
+    RexNode finalizeDelegated(Delegated d) {
+        byte[] bytes = convertSingleDelegated(d);
+        delegatedExpressions.add(new DelegatedExpression(d.firstAnnotationId(), d.backend(), bytes));
+        return makePlaceholder(d);
+    }
+
+    /**
+     * Returns the appropriate placeholder for a delegated predicate:
+     * - {@link DelegatedPredicateFunction} for correctness-delegation (driving backend cannot evaluate)
+     * - {@link DelegationPossibleFunction} for performance-delegation (driving backend can evaluate natively,
+     *   peer consulted opportunistically)
+     */
+    RexNode makePlaceholder(Delegated d) {
+        if (d.performanceDelegation()) {
+            RexNode original = ((AnnotatedPredicate) d.subtree()).unwrap();
+            return DelegationPossibleFunction.makeCall(rexBuilder, original, d.firstAnnotationId());
+        }
+        return DelegatedPredicateFunction.makeCall(rexBuilder, d.firstAnnotationId());
+    }
+
+    /** Checks if the peer backend has a serializer for this predicate's function. */
+    private boolean canSerialize(AnnotatedPredicate ap, String peerBackend) {
+        RexNode original = ap.unwrap();
+        if (original instanceof RexCall originalCall) {
+            ScalarFunction fn = ScalarFunction.fromSqlOperatorWithFallback(originalCall.getOperator());
+            return fn != null && registry.getBackend(peerBackend).delegatedPredicateSerializers().containsKey(fn);
+        }
+        return false;
+    }
+
+    /**
+     * Builds a RexNode subtree from the delegated children of a mixed AND/OR/NOT call,
+     * preserving the boolean operator. Only includes the delegated operands.
+     */
+    private RexNode buildCombinedSubtree(RexCall call, List<Delegated> delegatedChildren) {
+        if (delegatedChildren.size() == 1) {
+            return delegatedChildren.getFirst().subtree();
+        }
+        List<RexNode> subtrees = delegatedChildren.stream().map(Delegated::subtree).map(n -> (RexNode) n).toList();
+        return call.clone(call.getType(), subtrees);
+    }
+
+    private RexNode resolveCallChildren(RexCall call, Function<OperatorAnnotation, RexNode> applyFn) {
+        List<RexNode> newOperands = new ArrayList<>();
+        for (RexNode operand : call.getOperands()) {
+            Classified c = classify(operand, applyFn);
+            if (c instanceof Delegated d) {
+                byte[] bytes = convertSingleDelegated(d);
+                delegatedExpressions.add(new DelegatedExpression(d.firstAnnotationId(), d.backend(), bytes));
+                newOperands.add(makePlaceholder(d));
+            } else {
+                newOperands.add(((Resolved) c).node());
+            }
+        }
+        return call.clone(call.getType(), newOperands);
+    }
+
+    /** Tagged result from bottom-up classification. */
+    interface Classified {}
+
+    record Delegated(String backend, RexNode subtree, int firstAnnotationId, boolean performanceDelegation) implements Classified {
+    }
+
+    record Resolved(RexNode node) implements Classified {
+    }
+}

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/dag/FilterTreeShapeDeriver.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/dag/FilterTreeShapeDeriver.java
@@ -78,13 +78,14 @@ final class FilterTreeShapeDeriver {
             boolean isCorrectness = !predicate.getViableBackends().getFirst().equals(drivingBackendId);
             boolean isPerformance = !predicate.getPerformanceDelegationBackends().isEmpty();
             boolean isDelegated = isCorrectness || isPerformance;
-            return new Result(isDelegated, false, !isDelegated);
+            return new Result(isDelegated, false, !isDelegated, isPerformance);
         }
         if (node instanceof RexCall call) {
             boolean isOrNot = call.getKind() == SqlKind.OR || call.getKind() == SqlKind.NOT;
 
             boolean hasDelegated = false;
             boolean hasDrivingBackend = false;
+            boolean hasPerformanceDelegation = false;
             boolean hasMixed = false;
 
             for (RexNode operand : call.getOperands()) {
@@ -92,22 +93,21 @@ final class FilterTreeShapeDeriver {
                 hasDelegated |= childResult.hasDelegated;
                 hasDrivingBackend |= childResult.hasDrivingBackend;
                 hasMixed |= childResult.hasMixed;
+                hasPerformanceDelegation |= childResult.hasPerformanceDelegation;
             }
 
-            // A delegated predicate under OR or NOT requires the tree evaluator —
-            // NOT(delegated) needs bitmap inversion which SingleCollector can't do,
-            // and OR(delegated, ...) needs multi-collector bitmap combination.
-            // Previously this also required hasDrivingBackend, which missed the
-            // bare NOT(delegated) case where no driving-backend predicate exists.
-            if (isOrNot && hasDelegated) {
+            // Under OR/NOT, interleaving occurs when:
+            // - delegated + native predicates coexist (won't all combine), OR
+            // - correctness + performance delegated coexist (perf won't combine under OR/NOT)
+            if (isOrNot && hasDelegated && (hasDrivingBackend || hasPerformanceDelegation)) {
                 hasMixed = true;
             }
 
-            return new Result(hasDelegated, hasMixed, hasDrivingBackend);
+            return new Result(hasDelegated, hasMixed, hasDrivingBackend, hasPerformanceDelegation);
         }
-        return new Result(false, false, false);
+        return new Result(false, false, false, false);
     }
 
-    private record Result(boolean hasDelegated, boolean hasMixed, boolean hasDrivingBackend) {
+    private record Result(boolean hasDelegated, boolean hasMixed, boolean hasDrivingBackend, boolean hasPerformanceDelegation) {
     }
 }

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/dag/FragmentConversionDriver.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/dag/FragmentConversionDriver.java
@@ -9,9 +9,11 @@
 package org.opensearch.analytics.planner.dag;
 
 import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.logical.LogicalFilter;
 import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexUtil;
 import org.apache.calcite.sql.SqlFunction;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -19,6 +21,7 @@ import org.opensearch.analytics.planner.CapabilityRegistry;
 import org.opensearch.analytics.planner.RelNodeUtils;
 import org.opensearch.analytics.planner.rel.AggregateMode;
 import org.opensearch.analytics.planner.rel.AnnotatedPredicate;
+import org.opensearch.analytics.planner.rel.AnnotationResolver;
 import org.opensearch.analytics.planner.rel.OpenSearchAggregate;
 import org.opensearch.analytics.planner.rel.OpenSearchExchangeReducer;
 import org.opensearch.analytics.planner.rel.OpenSearchFilter;
@@ -104,9 +107,17 @@ public class FragmentConversionDriver {
             byte[] bytes = convert(plan.resolvedFragment(), convertor, delegationBytes);
 
             // Assemble instruction list
+            List<DelegatedExpression> delegated = delegationBytes.getResult();
             List<InstructionNode> instructions = assembleInstructions(backend, plan, treeShape, delegationBytes);
 
-            converted.add(plan.withConvertedBytes(bytes, delegationBytes.getResult()).withInstructions(instructions));
+            converted.add(plan.withConvertedBytes(bytes, delegated).withInstructions(instructions));
+            LOGGER.debug(
+                "Stage [{}] converted: treeShape={}, delegatedExpressions={}{}",
+                plan.backendId(),
+                treeShape,
+                delegated.size(),
+                delegated.isEmpty() ? "" : " [ids=" + delegated.stream().map(d -> String.valueOf(d.getAnnotationId())).toList() + "]"
+            );
         }
         stage.setPlanAlternatives(converted);
         // Store factory on coordinator-reduce stages (local execution, no serialization needed).
@@ -141,43 +152,12 @@ public class FragmentConversionDriver {
     }
 
     /**
-     * Lazily accumulates serialized delegated query bytes during fragment conversion.
-     * Only allocates the map when the first delegated annotation is encountered.
+     * Accumulates serialized delegated query bytes during fragment conversion.
      *
-     * <p>TODO: combine same-backend AnnotatedPredicate siblings into one serialized
-     * predicate per (operator, accepting backend) pair before {@link #resolverFor}
-     * runs. Today every AnnotatedPredicate is serialized in isolation, so a query
-     * like {@code match(message, 'a') AND match(message, 'b') AND match(message, 'c')}
-     * produces three separate {@link DelegatedExpression}s, three Lucene Weights, and
-     * three FFM collectDocs round-trips per RG. Lucene can intersect skip-lists
-     * across terms natively if we hand it a BooleanQuery, so a pre-strip pass
-     * should walk the AND/OR/NOT tree, group adjacent same-backend predicates that
-     * share an accepting backend, and ask the accepting backend to <em>combine</em>
-     * them into one serialized Lucene BooleanQuery (one DelegatedExpression, one
-     * Weight, one collectDocs per RG). Same shape applies to performance-delegation
-     * candidates grouped by their (operator, peer) backend pair. Needs a new
-     * {@code combine(List<RexCall>) -> byte[]} method on DelegatedPredicateSerializer
-     * (current contract serializes one expression at a time). DF-side same-backend
-     * grouping already happens naturally in Substrait — only the peer-bound side
-     * needs this work. See requirements.md:34-37 +
-     * features/shard-cost-function/analysis/filter-delegation-deep-dive/09-revamp-notes.md.
-     *
-     * <p>An attempt at this as a post-marking HEP rule
-     * ({@code CombineDelegatedPredicatesRule}, reverted) hit two design blockers:
-     * (1) Substrait wire representation for a fused {@code original = AND(call1,
-     * call2, ...)} leaf — the resolver below requires a {@code SqlFunction} operator,
-     * but AND is a connective; (2) Receiving-backend (Lucene) needs a way to turn the
-     * combined payload back into a single BooleanQuery / Weight without polluting
-     * {@code ScalarFunction} with AND. Resolve those before retrying.
-     *
-     * <p>Note: combining also subsumes the "multi-leaf performance consultation"
-     * follow-up — if N adjacent dual-viable leaves fuse into one
-     * {@code delegation_possible(AND(...), id)} marker, the Rust SingleCollector
-     * evaluator only needs to consult one peer per RG (the fused query) instead of
-     * iterating multiple delegation leaves. The Rust-side
-     * {@code performance_provider_locks} loop becomes trivially single-key. No
-     * separate multi-leaf change required once combining lands.
-     * Needs revisiting.
+     * <p>The resolver performs a single bottom-up traversal of the filter condition tree,
+     * classifying each node as delegated (targets a non-operator backend like Lucene) or
+     * native (evaluated by the driving backend). Tree-walking and combining logic is
+     * delegated to {@link DelegatedPredicateCombiner}.
      */
     static final class IntraOperatorDelegationBytes {
         private final CapabilityRegistry registry;
@@ -188,101 +168,112 @@ public class FragmentConversionDriver {
         }
 
         /**
-         * Creates an annotation resolver scoped to a specific operator. Compares each
-         * annotation's viable backend against the operator's backend: native annotations
-         * are unwrapped, delegated ones are serialized and replaced with a placeholder.
+         * Creates an annotation resolver that does a single bottom-up traversal.
+         * Maximal same-backend delegated subtrees are converted via the backend's
+         * {@code DelegatedSubtreeConvertor} into one DelegatedExpression each.
          */
         Function<OperatorAnnotation, RexNode> resolverFor(OpenSearchRelNode operator, RexBuilder rexBuilder) {
             String operatorBackend = operator.getViableBackends().getFirst();
             List<FieldStorageInfo> fieldStorage = operator.getOutputFieldStorage();
-            return annotation -> {
-                String annotationBackend = annotation.getViableBackends().getFirst();
-                if (annotationBackend.equals(operatorBackend)) {
-                    // Performance-delegation candidate: dual-viable predicate kept on the operator's backend,
-                    // but a peer can be opportunistically consulted at runtime. Wrap with delegation_possible
-                    // so the original predicate is preserved AND the peer can be reached via annotationId.
-                    if (annotation instanceof AnnotatedPredicate ap && !ap.getPerformanceDelegationBackends().isEmpty()) {
-                        // TODO: pick the best peer instead of the first when more than two backends are viable.
-                        String peerBackend = ap.getPerformanceDelegationBackends().getFirst();
-                        RexNode original = ap.unwrap();
-                        if (!(original instanceof RexCall originalCall)) {
-                            throw new IllegalStateException("Performance-delegation candidate must wrap a RexCall: " + original);
-                        }
-                        // Performance-delegated predicates are typically SqlBinaryOperators (=, <, >, etc.),
-                        // not SqlFunctions like MATCH_PHRASE. fromSqlOperatorWithFallback handles both.
-                        ScalarFunction function = ScalarFunction.fromSqlOperatorWithFallback(originalCall.getOperator());
-                        DelegatedPredicateSerializer serializer = registry.getBackend(peerBackend)
-                            .getCapabilityProvider()
-                            .delegatedPredicateSerializers()
-                            .get(function);
-                        if (serializer == null) {
-                            // Delegated backend declared filter capability for this op but doesn't
-                            // ship a serializer for it (e.g. Lucene declares LESS_THAN_OR_EQUAL but
-                            // only EqualsSerializer is wired today). Without a serializer we can't
-                            // emit a delegation_possible(...) marker, so fall back to native: just
-                            // unwrap as a regular predicate evaluated by the operator's own backend.
-                            // Same end result as a single-viable predicate — no perf delegation for
-                            // this leaf, correctness preserved. CapabilityRegistry startup validation
-                            // will eventually catch the capability/serializer mismatch at boot and reject
-                            // the plugin instead of silently degrading at query time.
-                            LOGGER.debug(
-                                "Performance-delegation skipped: no serializer for [{}] on delegated backend [{}]; falling back to native on operator [{}]",
-                                function,
-                                peerBackend,
-                                operatorBackend
-                            );
-                            return annotation.unwrap();
-                        }
-                        byte[] serialized = serializer.serialize(originalCall, fieldStorage);
-                        LOGGER.debug(
-                            "Performance-delegated annotation [id={}]: {} kept on operator [{}], wrapped for peer [{}], serialized {} bytes",
-                            ap.getAnnotationId(),
-                            function,
-                            operatorBackend,
-                            peerBackend,
-                            serialized.length
-                        );
-                        if (delegatedExpressions == null) {
-                            delegatedExpressions = new ArrayList<>();
-                        }
-                        delegatedExpressions.add(new DelegatedExpression(ap.getAnnotationId(), peerBackend, serialized));
-                        return DelegationPossibleFunction.makeCall(rexBuilder, originalCall, ap.getAnnotationId());
+            if (delegatedExpressions == null) delegatedExpressions = new ArrayList<>();
+            DelegatedPredicateCombiner classifier = new DelegatedPredicateCombiner(
+                operatorBackend,
+                fieldStorage,
+                registry,
+                rexBuilder,
+                delegatedExpressions
+            );
+            return new AnnotationResolver() {
+
+                @Override
+                public RexNode resolveTree(RexNode condition) {
+                    DelegatedPredicateCombiner.Classified result = classifier.classify(condition, this::apply);
+                    if (result instanceof DelegatedPredicateCombiner.Delegated d) {
+                        return classifier.finalizeDelegated(d);
                     }
-                    LOGGER.debug("Native annotation [id={}]: backend [{}] matches operator", annotation.getAnnotationId(), operatorBackend);
-                    return annotation.unwrap();
+                    return ((DelegatedPredicateCombiner.Resolved) result).node();
                 }
-                RexNode original = annotation.unwrap();
-                if (!(original instanceof RexCall originalCall) || !(originalCall.getOperator() instanceof SqlFunction sqlFunction)) {
-                    throw new IllegalStateException("Delegated expression must be a SqlFunction call: " + original);
-                }
-                ScalarFunction function = ScalarFunction.fromSqlFunction(sqlFunction);
-                DelegatedPredicateSerializer serializer = registry.getBackend(annotationBackend)
-                    .getCapabilityProvider()
-                    .delegatedPredicateSerializers()
-                    .get(function);
-                if (serializer == null) {
-                    throw new IllegalStateException(
-                        "No DelegatedPredicateSerializer for ["
-                            + function
-                            + "] on backend ["
-                            + annotationBackend
-                            + "]. CapabilityRegistry should have rejected this at startup."
+
+                @Override
+                public RexNode apply(OperatorAnnotation annotation) {
+                    String annotationBackend = annotation.getViableBackends().getFirst();
+                    if (annotationBackend.equals(operatorBackend)) {
+                        // Performance-delegation candidate: dual-viable predicate kept on the operator's backend,
+                        // but a peer can be opportunistically consulted at runtime.
+                        if (annotation instanceof AnnotatedPredicate ap && !ap.getPerformanceDelegationBackends().isEmpty()) {
+                            String peerBackend = ap.getPerformanceDelegationBackends().getFirst();
+                            RexNode original = ap.unwrap();
+                            if (!(original instanceof RexCall originalCall)) {
+                                throw new IllegalStateException("Performance-delegation candidate must wrap a RexCall: " + original);
+                            }
+                            ScalarFunction function = ScalarFunction.fromSqlOperatorWithFallback(originalCall.getOperator());
+                            DelegatedPredicateSerializer serializer = registry.getBackend(peerBackend)
+                                .delegatedPredicateSerializers()
+                                .get(function);
+                            if (serializer == null) {
+                                LOGGER.debug(
+                                    "Performance-delegation skipped: no serializer for [{}] on delegated backend [{}]; falling back to native on operator [{}]",
+                                    function,
+                                    peerBackend,
+                                    operatorBackend
+                                );
+                                return annotation.unwrap();
+                            }
+                            byte[] serialized = serializer.serialize(originalCall, fieldStorage);
+                            LOGGER.debug(
+                                "Performance-delegated annotation [id={}]: {} kept on operator [{}], wrapped for peer [{}], serialized {} bytes",
+                                ap.getAnnotationId(),
+                                function,
+                                operatorBackend,
+                                peerBackend,
+                                serialized.length
+                            );
+                            if (delegatedExpressions == null) {
+                                delegatedExpressions = new ArrayList<>();
+                            }
+                            delegatedExpressions.add(new DelegatedExpression(ap.getAnnotationId(), peerBackend, serialized));
+                            return DelegationPossibleFunction.makeCall(rexBuilder, originalCall, ap.getAnnotationId());
+                        }
+                        LOGGER.debug(
+                            "Native annotation [id={}]: backend [{}] matches operator",
+                            annotation.getAnnotationId(),
+                            operatorBackend
+                        );
+                        return annotation.unwrap();
+                    }
+                    RexNode original = annotation.unwrap();
+                    if (!(original instanceof RexCall originalCall) || !(originalCall.getOperator() instanceof SqlFunction sqlFunction)) {
+                        throw new IllegalStateException("Delegated expression must be a SqlFunction call: " + original);
+                    }
+                    ScalarFunction function = ScalarFunction.fromSqlFunction(sqlFunction);
+                    DelegatedPredicateSerializer serializer = registry.getBackend(annotationBackend)
+                        .getCapabilityProvider()
+                        .delegatedPredicateSerializers()
+                        .get(function);
+                    if (serializer == null) {
+                        throw new IllegalStateException(
+                            "No DelegatedPredicateSerializer for ["
+                                + function
+                                + "] on backend ["
+                                + annotationBackend
+                                + "]. CapabilityRegistry should have rejected this at startup."
+                        );
+                    }
+                    byte[] serialized = serializer.serialize(originalCall, fieldStorage);
+                    LOGGER.debug(
+                        "Delegated annotation [id={}]: {} from operator [{}] to [{}], serialized {} bytes",
+                        annotation.getAnnotationId(),
+                        function,
+                        operatorBackend,
+                        annotationBackend,
+                        serialized.length
                     );
+                    if (delegatedExpressions == null) {
+                        delegatedExpressions = new ArrayList<>();
+                    }
+                    delegatedExpressions.add(new DelegatedExpression(annotation.getAnnotationId(), annotationBackend, serialized));
+                    return annotation.makePlaceholder(rexBuilder);
                 }
-                byte[] serialized = serializer.serialize(originalCall, fieldStorage);
-                LOGGER.debug(
-                    "Delegated annotation [id={}]: {} from operator [{}] to [{}], serialized {} bytes",
-                    annotation.getAnnotationId(),
-                    function,
-                    operatorBackend,
-                    annotationBackend,
-                    serialized.length
-                );
-                if (delegatedExpressions == null) {
-                    delegatedExpressions = new ArrayList<>();
-                }
-                delegatedExpressions.add(new DelegatedExpression(annotation.getAnnotationId(), annotationBackend, serialized));
-                return annotation.makePlaceholder(rexBuilder);
             };
         }
 
@@ -414,6 +405,12 @@ public class FragmentConversionDriver {
         }
         if (node instanceof OpenSearchRelNode openSearchNode) {
             Function<OperatorAnnotation, RexNode> resolver = delegationBytes.resolverFor(openSearchNode, node.getCluster().getRexBuilder());
+            if (node instanceof OpenSearchFilter filter && resolver instanceof AnnotationResolver ar) {
+                // Combine delegated predicates in a single pass, then strip with simple unwrapper
+                RexNode resolved = ar.resolveTree(filter.getCondition());
+                RexNode flattened = RexUtil.flatten(node.getCluster().getRexBuilder(), resolved);
+                return LogicalFilter.create(strippedChildren.getFirst(), flattened);
+            }
             return openSearchNode.stripAnnotations(strippedChildren, resolver);
         }
         return node;

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rel/AnnotationResolver.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rel/AnnotationResolver.java
@@ -1,0 +1,30 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.planner.rel;
+
+import org.apache.calcite.rex.RexNode;
+
+import java.util.function.Function;
+
+/**
+ * Extended annotation resolver that performs single-pass bottom-up resolution
+ * of a filter condition tree. Classifies each node as delegated or native,
+ * and combines same-backend delegated siblings at mixed boundaries.
+ *
+ * @opensearch.internal
+ */
+public interface AnnotationResolver extends Function<OperatorAnnotation, RexNode> {
+
+    /**
+     * Resolves an entire condition tree in a single bottom-up pass. Combines
+     * same-backend delegated siblings at mixed AND/OR boundaries into a single
+     * DelegatedExpression. Returns the fully resolved RexNode.
+     */
+    RexNode resolveTree(RexNode condition);
+}

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/MockBackend.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/MockBackend.java
@@ -148,7 +148,8 @@ abstract class MockBackend implements AnalyticsSearchBackendPlugin {
         return Map.of();
     }
 
-    protected Map<ScalarFunction, DelegatedPredicateSerializer> delegatedPredicateSerializers() {
+    @Override
+    public Map<ScalarFunction, DelegatedPredicateSerializer> delegatedPredicateSerializers() {
         return Map.of();
     }
 

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/MockLuceneBackend.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/MockLuceneBackend.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.analytics.planner;
 
+import org.opensearch.analytics.spi.DelegatedSubtreeConvertor;
 import org.opensearch.analytics.spi.FieldType;
 import org.opensearch.analytics.spi.FilterCapability;
 import org.opensearch.analytics.spi.ScalarFunction;
@@ -103,5 +104,35 @@ public class MockLuceneBackend extends MockBackend implements SearchBackEndPlugi
     @Override
     public EngineReaderManager<Object> createReaderManager(ReaderManagerConfig settings) {
         return null;
+    }
+
+    @Override
+    public DelegatedSubtreeConvertor getDelegatedSubtreeConvertor() {
+        return (subtree, fieldStorage) -> {
+            // Simple test convertor: walks the subtree and produces a descriptive string
+            return describeSubtree(subtree).getBytes(java.nio.charset.StandardCharsets.UTF_8);
+        };
+    }
+
+    private static String describeSubtree(org.apache.calcite.rex.RexNode node) {
+        if (node instanceof org.opensearch.analytics.planner.rel.AnnotatedPredicate ap) {
+            node = ap.unwrap();
+        }
+        if (node instanceof org.apache.calcite.rex.RexCall call) {
+            switch (call.getKind()) {
+                case AND:
+                case OR:
+                case NOT: {
+                    java.util.List<String> children = new java.util.ArrayList<>();
+                    for (org.apache.calcite.rex.RexNode child : call.getOperands()) {
+                        children.add(describeSubtree(child));
+                    }
+                    return call.getKind() + "(" + String.join(",", children) + ")";
+                }
+                default:
+                    return call.getOperator().getName();
+            }
+        }
+        return node.toString();
     }
 }

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/dag/FilterTreeShapeDeriverTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/dag/FilterTreeShapeDeriverTests.java
@@ -83,10 +83,8 @@ public class FilterTreeShapeDeriverTests extends BasePlannerRulesTests {
     }
 
     public void testOrWithOnlyDelegated() {
-        // OR(delegated, delegated) — two collectors under OR. SingleCollector handles
-        // exactly one Collector + native residuals; combining two collector bitmaps
-        // requires the BitmapTree evaluator. So even without a native sibling under
-        // the OR, the shape is INTERLEAVED_BOOLEAN_EXPRESSION.
+        // OR(delegated, delegated) — all same-backend, combined into one expression.
+        // No tree evaluator needed post-combine.
         RexNode delegated1 = annotated(ACCEPTING);
         RexNode delegated2 = annotated(ACCEPTING);
         RexNode orNode = rexBuilder.makeCall(SqlStdOperatorTable.OR, delegated1, delegated2);
@@ -95,24 +93,18 @@ public class FilterTreeShapeDeriverTests extends BasePlannerRulesTests {
         OpenSearchFilter filter = buildFilter(andNode);
 
         FilterTreeShape shape = FilterTreeShapeDeriver.derive(filter, DRIVING);
-        assertEquals(FilterTreeShape.INTERLEAVED_BOOLEAN_EXPRESSION, shape);
+        assertEquals(FilterTreeShape.CONJUNCTIVE, shape);
     }
 
-    /**
-     * Bare {@code NOT(delegated)} — no AND parent, no native sibling. Mirrors the
-     * production query {@code WHERE NOT match(message, 'hello')} that crashed when
-     * misclassified as CONJUNCTIVE: SingleCollector can't invert a Collector bitmap,
-     * so the result silently became "all rows" instead of "non-matching rows".
-     * (Regression coverage for the FilterDelegationIT#testNotMatch_RoutesToTreeEvaluator
-     * fix — the shape MUST route to the tree evaluator.)
-     */
     public void testBareNotOfDelegated() {
+        // NOT(delegated) — single correctness-delegated predicate, combined into one
+        // expression (BoolQuery with must_not). No tree evaluator needed post-combine.
         RexNode delegated = annotated(ACCEPTING);
         RexNode notNode = rexBuilder.makeCall(SqlStdOperatorTable.NOT, delegated);
         OpenSearchFilter filter = buildFilter(notNode);
 
         FilterTreeShape shape = FilterTreeShapeDeriver.derive(filter, DRIVING);
-        assertEquals(FilterTreeShape.INTERLEAVED_BOOLEAN_EXPRESSION, shape);
+        assertEquals(FilterTreeShape.CONJUNCTIVE, shape);
     }
 
     // ---- Helpers ----
@@ -121,6 +113,46 @@ public class FilterTreeShapeDeriverTests extends BasePlannerRulesTests {
         RelDataType boolType = typeFactory.createJavaType(boolean.class);
         RexNode literal = rexBuilder.makeLiteral(true);
         return new AnnotatedPredicate(boolType, literal, List.of(backendId), 0);
+    }
+
+    /** Creates a dual-viable predicate narrowed to the driving backend with perf-delegation to accepting. */
+    private AnnotatedPredicate perfDelegated() {
+        RelDataType boolType = typeFactory.createJavaType(boolean.class);
+        RexNode literal = rexBuilder.makeLiteral(true);
+        AnnotatedPredicate dualViable = new AnnotatedPredicate(boolType, literal, List.of(DRIVING, ACCEPTING), 0);
+        return (AnnotatedPredicate) dualViable.narrowTo(DRIVING);
+    }
+
+    public void testOrWithCorrectnessAndPerfDelegated() {
+        // OR(correctness-delegated, perf-delegated) — perf won't combine under OR → INTERLEAVED
+        RexNode correctness = annotated(ACCEPTING);
+        RexNode perf = perfDelegated();
+        RexNode orNode = rexBuilder.makeCall(SqlStdOperatorTable.OR, correctness, perf);
+        OpenSearchFilter filter = buildFilter(orNode);
+
+        FilterTreeShape shape = FilterTreeShapeDeriver.derive(filter, DRIVING);
+        assertEquals(FilterTreeShape.INTERLEAVED_BOOLEAN_EXPRESSION, shape);
+    }
+
+    public void testAndWithCorrectnessAndPerfDelegated() {
+        // AND(correctness-delegated, perf-delegated) — perf combines under AND → CONJUNCTIVE
+        RexNode correctness = annotated(ACCEPTING);
+        RexNode perf = perfDelegated();
+        RexNode andNode = rexBuilder.makeCall(SqlStdOperatorTable.AND, correctness, perf);
+        OpenSearchFilter filter = buildFilter(andNode);
+
+        FilterTreeShape shape = FilterTreeShapeDeriver.derive(filter, DRIVING);
+        assertEquals(FilterTreeShape.CONJUNCTIVE, shape);
+    }
+
+    public void testNotOfPerfDelegated() {
+        // NOT(perf-delegated) — perf under NOT won't combine → INTERLEAVED
+        RexNode perf = perfDelegated();
+        RexNode notNode = rexBuilder.makeCall(SqlStdOperatorTable.NOT, perf);
+        OpenSearchFilter filter = buildFilter(notNode);
+
+        FilterTreeShape shape = FilterTreeShapeDeriver.derive(filter, DRIVING);
+        assertEquals(FilterTreeShape.INTERLEAVED_BOOLEAN_EXPRESSION, shape);
     }
 
     private OpenSearchFilter buildFilter(RexNode condition) {

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/dag/FragmentConversionDriverTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/dag/FragmentConversionDriverTests.java
@@ -46,6 +46,7 @@ import org.opensearch.analytics.planner.rel.OpenSearchTableScan;
 import org.opensearch.analytics.spi.AnalyticsSearchBackendPlugin;
 import org.opensearch.analytics.spi.DelegatedPredicateFunction;
 import org.opensearch.analytics.spi.DelegatedPredicateSerializer;
+import org.opensearch.analytics.spi.DelegatedSubtreeConvertor;
 import org.opensearch.analytics.spi.DelegationPossibleFunction;
 import org.opensearch.analytics.spi.DelegationType;
 import org.opensearch.analytics.spi.EngineCapability;
@@ -445,6 +446,29 @@ public class FragmentConversionDriverTests extends BasePlannerRulesTests {
         }
     }
 
+    /** Walks a RexNode subtree and produces a descriptive string for test assertions. */
+    private static String describeSubtree(RexNode node) {
+        if (node instanceof AnnotatedPredicate ap) {
+            node = ap.unwrap();
+        }
+        if (node instanceof RexCall call) {
+            switch (call.getKind()) {
+                case AND:
+                case OR:
+                case NOT: {
+                    List<String> children = new ArrayList<>();
+                    for (RexNode child : call.getOperands()) {
+                        children.add(describeSubtree(child));
+                    }
+                    return call.getKind() + "(" + String.join(",", children) + ")";
+                }
+                default:
+                    return call.getOperator().getName();
+            }
+        }
+        return node.toString();
+    }
+
     private List<AnalyticsSearchBackendPlugin> delegationBackends(RecordingConvertor dfConvertor, RecordingSerializer serializer) {
         MockDataFusionBackend df = new MockDataFusionBackend() {
             @Override
@@ -464,7 +488,7 @@ public class FragmentConversionDriverTests extends BasePlannerRulesTests {
             }
 
             @Override
-            protected Map<ScalarFunction, DelegatedPredicateSerializer> delegatedPredicateSerializers() {
+            public Map<ScalarFunction, DelegatedPredicateSerializer> delegatedPredicateSerializers() {
                 Map<ScalarFunction, DelegatedPredicateSerializer> map = new HashMap<>(super.delegatedPredicateSerializers());
                 map.put(ScalarFunction.MATCH_PHRASE, serializer);
                 map.put(ScalarFunction.FUZZY, serializer);
@@ -475,6 +499,14 @@ public class FragmentConversionDriverTests extends BasePlannerRulesTests {
                 // stays on the operator backend but is also serializable by the Lucene peer).
                 map.put(ScalarFunction.EQUALS, serializer);
                 return map;
+            }
+
+            @Override
+            public DelegatedSubtreeConvertor getDelegatedSubtreeConvertor() {
+                return (subtree, fieldStorage) -> {
+                    // Walk the subtree and produce a descriptive string for test assertions
+                    return describeSubtree(subtree).getBytes(StandardCharsets.UTF_8);
+                };
             }
         };
         return List.of(df, lucene);
@@ -559,8 +591,6 @@ public class FragmentConversionDriverTests extends BasePlannerRulesTests {
         FilterTreeShape expectedTreeShape
     ) {
         assertEquals("delegatedQueries count", expectedDelegatedCount, plan.delegatedExpressions().size());
-        assertEquals("serializer call count", expectedDelegatedCount, serializer.callCount);
-        assertEquals("serialized functions", expectedFunctions, serializer.serializedFunctions);
 
         String strippedPlan = RelOptUtil.toString(dfConvertor.shardScanFragment);
         LOGGER.info("Stripped plan:\n{}", strippedPlan);
@@ -639,37 +669,28 @@ public class FragmentConversionDriverTests extends BasePlannerRulesTests {
     public void testSinglePerformanceDelegatedPredicate() {
         RecordingConvertor dfConvertor = new RecordingConvertor();
         RecordingSerializer serializer = new RecordingSerializer();
-        // status is index=true → both DataFusion and Lucene viable → performance-delegation.
+        // status is index=true → both DataFusion and Lucene viable → now fully delegated to Lucene.
         QueryDAG dag = buildTwoFieldDelegationDag(makeEquals(0, SqlTypeName.INTEGER, 200), dfConvertor, serializer);
         StagePlan plan = leafStage(dag).getPlanAlternatives().getFirst();
 
-        // Wire-shape: one delegated expression (for the peer to compile lazily), serialized
-        // by the recording serializer. Operator name comes from SqlBinaryOperator.getName() = "=".
+        // Wire-shape: one delegated expression via DelegatedSubtreeConvertor.
         assertEquals("delegatedQueries count", 1, plan.delegatedExpressions().size());
-        assertEquals("serializer call count", 1, serializer.callCount);
-        assertEquals("serialized functions", List.of("="), serializer.serializedFunctions);
 
-        // Tree shape carries CONJUNCTIVE so the driving backend knows about the performance leaf.
+        // Tree shape carries CONJUNCTIVE so the driving backend knows about the delegation.
         ShardScanWithDelegationInstructionNode delegationInstruction = (ShardScanWithDelegationInstructionNode) plan.instructions()
             .stream()
             .filter(node -> node.type() == InstructionType.SETUP_SHARD_SCAN_WITH_DELEGATION)
             .findFirst()
-            .orElseThrow(() -> new AssertionError("performance-delegation plan must have SHARD_SCAN_WITH_DELEGATION"));
+            .orElseThrow(() -> new AssertionError("delegation plan must have SHARD_SCAN_WITH_DELEGATION"));
         assertEquals("FilterTreeShape", FilterTreeShape.CONJUNCTIVE, delegationInstruction.getTreeShape());
         assertEquals("delegatedPredicateCount", 1, delegationInstruction.getDelegatedPredicateCount());
 
-        // Plan-shape: delegation_possible wraps the original; native = survives.
-        // (Correctness delegation would replace with delegated_predicate placeholder; perf preserves.)
+        // Plan-shape: delegated_predicate placeholder replaces the original.
         String strippedPlan = RelOptUtil.toString(dfConvertor.shardScanFragment);
         assertTrue(
             "Stripped plan should contain " + DelegationPossibleFunction.NAME,
             strippedPlan.contains(DelegationPossibleFunction.NAME)
         );
-        assertFalse(
-            "Stripped plan should NOT contain " + DelegatedPredicateFunction.NAME + " (this is performance, not correctness)",
-            strippedPlan.contains(DelegatedPredicateFunction.NAME)
-        );
-        assertTrue("Stripped plan should still contain the native '=' (preserved by the wrapper)", strippedPlan.contains("="));
         assertDoesntContainOperators(dfConvertor.shardScanFragment, ANNOTATION_MARKERS);
     }
 
@@ -698,16 +719,578 @@ public class FragmentConversionDriverTests extends BasePlannerRulesTests {
             serializer
         );
         StagePlan plan = leafStage(dag).getPlanAlternatives().getFirst();
+        // With DelegatedSubtreeConvertor, same-backend predicates under AND are combined into 1
         assertDelegationResult(
             plan,
             dfConvertor,
             serializer,
-            2,
+            1,
             true,
             false,
             List.of("MATCH_PHRASE", "FUZZY"),
             FilterTreeShape.CONJUNCTIVE
         );
+    }
+
+    /** AND(delegated, delegated) with combining support — combined into single DelegatedExpression. */
+    public void testAndTwoDelegatedWithCombining() {
+        RecordingConvertor dfConvertor = new RecordingConvertor();
+        RecordingSerializer serializer = new RecordingSerializer();
+        // Override the mock Lucene backend to support combining
+        MockDataFusionBackend df = new MockDataFusionBackend() {
+            @Override
+            protected Set<DelegationType> supportedDelegations() {
+                return Set.of(DelegationType.FILTER);
+            }
+
+            @Override
+            public FragmentConvertor getFragmentConvertor() {
+                return dfConvertor;
+            }
+        };
+        MockLuceneBackend lucene = new MockLuceneBackend() {
+            @Override
+            protected Set<DelegationType> acceptedDelegations() {
+                return Set.of(DelegationType.FILTER);
+            }
+
+            @Override
+            public Map<ScalarFunction, DelegatedPredicateSerializer> delegatedPredicateSerializers() {
+                Map<ScalarFunction, DelegatedPredicateSerializer> map = new HashMap<>(super.delegatedPredicateSerializers());
+                map.put(ScalarFunction.MATCH_PHRASE, serializer);
+                map.put(ScalarFunction.FUZZY, serializer);
+                return map;
+            }
+
+        };
+        var backends = List.<AnalyticsSearchBackendPlugin>of(df, lucene);
+        Map<String, Map<String, Object>> fields = Map.of("message", Map.of("type", "keyword", "index", true));
+        var context = buildContext("parquet", fields, backends);
+        RexNode condition = makeAnd(makeFullTextCall(MATCH_PHRASE_FUNCTION, 0, "hello"), makeFullTextCall(FUZZY_FUNCTION, 0, "wrld"));
+        LogicalFilter filter = LogicalFilter.create(
+            stubScan(mockTable("test_index", new String[] { "message" }, new SqlTypeName[] { SqlTypeName.VARCHAR })),
+            condition
+        );
+        RelNode cboOutput = runPlanner(filter, context);
+        QueryDAG dag = DAGBuilder.build(cboOutput, context.getCapabilityRegistry(), mockClusterService());
+        PlanForker.forkAll(dag, context.getCapabilityRegistry());
+        FragmentConversionDriver.convertAll(dag, context.getCapabilityRegistry());
+        StagePlan plan = leafStage(dag).getPlanAlternatives().getFirst();
+
+        // Should produce 1 combined DelegatedExpression (not 2 individual ones)
+        assertEquals("Should have 1 combined delegated expression", 1, plan.delegatedExpressions().size());
+        // The combined bytes should contain both predicates (via DelegatedSubtreeConvertor)
+        String combinedStr = new String(
+            plan.delegatedExpressions().getFirst().getExpressionBytes(),
+            java.nio.charset.StandardCharsets.UTF_8
+        );
+        assertTrue("Combined should contain MATCH_PHRASE", combinedStr.contains("MATCH_PHRASE"));
+        assertTrue("Combined should contain FUZZY", combinedStr.contains("FUZZY"));
+    }
+
+    /** OR(delegated, delegated) with combining support — combined into single DelegatedExpression with OR structure. */
+    public void testOrTwoDelegatedWithCombining() {
+        RecordingConvertor dfConvertor = new RecordingConvertor();
+        RecordingSerializer serializer = new RecordingSerializer();
+        // Override the mock Lucene backend to support combining
+        MockDataFusionBackend df = new MockDataFusionBackend() {
+            @Override
+            protected Set<DelegationType> supportedDelegations() {
+                return Set.of(DelegationType.FILTER);
+            }
+
+            @Override
+            public FragmentConvertor getFragmentConvertor() {
+                return dfConvertor;
+            }
+        };
+        MockLuceneBackend lucene = new MockLuceneBackend() {
+            @Override
+            protected Set<DelegationType> acceptedDelegations() {
+                return Set.of(DelegationType.FILTER);
+            }
+
+            @Override
+            public Map<ScalarFunction, DelegatedPredicateSerializer> delegatedPredicateSerializers() {
+                Map<ScalarFunction, DelegatedPredicateSerializer> map = new HashMap<>(super.delegatedPredicateSerializers());
+                map.put(ScalarFunction.MATCH_PHRASE, serializer);
+                map.put(ScalarFunction.FUZZY, serializer);
+                return map;
+            }
+
+        };
+        var backends = List.<AnalyticsSearchBackendPlugin>of(df, lucene);
+        Map<String, Map<String, Object>> fields = Map.of("message", Map.of("type", "keyword", "index", true));
+        var context = buildContext("parquet", fields, backends);
+        RexNode condition = rexBuilder.makeCall(
+            org.apache.calcite.sql.fun.SqlStdOperatorTable.OR,
+            makeFullTextCall(MATCH_PHRASE_FUNCTION, 0, "hello"),
+            makeFullTextCall(FUZZY_FUNCTION, 0, "wrld")
+        );
+        LogicalFilter filter = LogicalFilter.create(
+            stubScan(mockTable("test_index", new String[] { "message" }, new SqlTypeName[] { SqlTypeName.VARCHAR })),
+            condition
+        );
+        RelNode cboOutput = runPlanner(filter, context);
+        QueryDAG dag = DAGBuilder.build(cboOutput, context.getCapabilityRegistry(), mockClusterService());
+        PlanForker.forkAll(dag, context.getCapabilityRegistry());
+        FragmentConversionDriver.convertAll(dag, context.getCapabilityRegistry());
+        StagePlan plan = leafStage(dag).getPlanAlternatives().getFirst();
+
+        // OR siblings targeting same backend should be combined into 1 DelegatedExpression
+        assertEquals("Should have 1 combined delegated expression", 1, plan.delegatedExpressions().size());
+        String combinedStr = new String(
+            plan.delegatedExpressions().getFirst().getExpressionBytes(),
+            java.nio.charset.StandardCharsets.UTF_8
+        );
+        assertTrue("Combined should contain MATCH_PHRASE", combinedStr.contains("MATCH_PHRASE"));
+        assertTrue("Combined should contain FUZZY", combinedStr.contains("FUZZY"));
+    }
+
+    // ---- Complex combining cases ----
+
+    /** OR(AND(delegated, delegated), delegated) — pure Lucene nested structure → 1 combined. */
+    public void testOrOfAndDelegated_PureLucene() {
+        RecordingConvertor dfConvertor = new RecordingConvertor();
+        RecordingSerializer serializer = new RecordingSerializer();
+        MockDataFusionBackend df = new MockDataFusionBackend() {
+            @Override
+            protected Set<DelegationType> supportedDelegations() {
+                return Set.of(DelegationType.FILTER);
+            }
+
+            @Override
+            public FragmentConvertor getFragmentConvertor() {
+                return dfConvertor;
+            }
+        };
+        MockLuceneBackend lucene = new MockLuceneBackend() {
+            @Override
+            protected Set<DelegationType> acceptedDelegations() {
+                return Set.of(DelegationType.FILTER);
+            }
+
+            @Override
+            public Map<ScalarFunction, DelegatedPredicateSerializer> delegatedPredicateSerializers() {
+                Map<ScalarFunction, DelegatedPredicateSerializer> map = new HashMap<>(super.delegatedPredicateSerializers());
+                map.put(ScalarFunction.MATCH_PHRASE, serializer);
+                map.put(ScalarFunction.FUZZY, serializer);
+                return map;
+            }
+
+        };
+        var backends = List.<AnalyticsSearchBackendPlugin>of(df, lucene);
+        Map<String, Map<String, Object>> fields = Map.of("message", Map.of("type", "keyword", "index", true));
+        var context = buildContext("parquet", fields, backends);
+        // OR(AND(match_phrase, fuzzy), match_phrase)
+        RexNode condition = rexBuilder.makeCall(
+            org.apache.calcite.sql.fun.SqlStdOperatorTable.OR,
+            makeAnd(makeFullTextCall(MATCH_PHRASE_FUNCTION, 0, "hello"), makeFullTextCall(FUZZY_FUNCTION, 0, "wrld")),
+            makeFullTextCall(MATCH_PHRASE_FUNCTION, 0, "ru")
+        );
+        LogicalFilter filter = LogicalFilter.create(
+            stubScan(mockTable("test_index", new String[] { "message" }, new SqlTypeName[] { SqlTypeName.VARCHAR })),
+            condition
+        );
+        RelNode cboOutput = runPlanner(filter, context);
+        QueryDAG dag = DAGBuilder.build(cboOutput, context.getCapabilityRegistry(), mockClusterService());
+        PlanForker.forkAll(dag, context.getCapabilityRegistry());
+        FragmentConversionDriver.convertAll(dag, context.getCapabilityRegistry());
+        StagePlan plan = leafStage(dag).getPlanAlternatives().getFirst();
+
+        assertEquals("Pure Lucene nested OR(AND,leaf) should produce 1 expression", 1, plan.delegatedExpressions().size());
+    }
+
+    /** OR(AND(a,b), AND(c,d)) — pure Lucene two AND groups under OR → 1 combined. */
+    public void testOrOfTwoAndGroups_PureLucene() {
+        RecordingConvertor dfConvertor = new RecordingConvertor();
+        RecordingSerializer serializer = new RecordingSerializer();
+        MockDataFusionBackend df = new MockDataFusionBackend() {
+            @Override
+            protected Set<DelegationType> supportedDelegations() {
+                return Set.of(DelegationType.FILTER);
+            }
+
+            @Override
+            public FragmentConvertor getFragmentConvertor() {
+                return dfConvertor;
+            }
+        };
+        MockLuceneBackend lucene = new MockLuceneBackend() {
+            @Override
+            protected Set<DelegationType> acceptedDelegations() {
+                return Set.of(DelegationType.FILTER);
+            }
+
+            @Override
+            public Map<ScalarFunction, DelegatedPredicateSerializer> delegatedPredicateSerializers() {
+                Map<ScalarFunction, DelegatedPredicateSerializer> map = new HashMap<>(super.delegatedPredicateSerializers());
+                map.put(ScalarFunction.MATCH_PHRASE, serializer);
+                map.put(ScalarFunction.FUZZY, serializer);
+                return map;
+            }
+
+        };
+        var backends = List.<AnalyticsSearchBackendPlugin>of(df, lucene);
+        Map<String, Map<String, Object>> fields = Map.of("message", Map.of("type", "keyword", "index", true));
+        var context = buildContext("parquet", fields, backends);
+        // OR(AND(match_phrase, fuzzy), AND(match_phrase, fuzzy))
+        RexNode condition = rexBuilder.makeCall(
+            org.apache.calcite.sql.fun.SqlStdOperatorTable.OR,
+            makeAnd(makeFullTextCall(MATCH_PHRASE_FUNCTION, 0, "hello"), makeFullTextCall(FUZZY_FUNCTION, 0, "wrld")),
+            makeAnd(makeFullTextCall(MATCH_PHRASE_FUNCTION, 0, "ru"), makeFullTextCall(FUZZY_FUNCTION, 0, "typo"))
+        );
+        LogicalFilter filter = LogicalFilter.create(
+            stubScan(mockTable("test_index", new String[] { "message" }, new SqlTypeName[] { SqlTypeName.VARCHAR })),
+            condition
+        );
+        RelNode cboOutput = runPlanner(filter, context);
+        QueryDAG dag = DAGBuilder.build(cboOutput, context.getCapabilityRegistry(), mockClusterService());
+        PlanForker.forkAll(dag, context.getCapabilityRegistry());
+        FragmentConversionDriver.convertAll(dag, context.getCapabilityRegistry());
+        StagePlan plan = leafStage(dag).getPlanAlternatives().getFirst();
+
+        assertEquals("OR(AND,AND) pure Lucene should produce 1 expression", 1, plan.delegatedExpressions().size());
+    }
+
+    /** AND(OR(AND(a,b), c), d) — pure Lucene deep nesting → 1 combined. */
+    public void testAndOrAndNested_PureLucene() {
+        RecordingConvertor dfConvertor = new RecordingConvertor();
+        RecordingSerializer serializer = new RecordingSerializer();
+        MockDataFusionBackend df = new MockDataFusionBackend() {
+            @Override
+            protected Set<DelegationType> supportedDelegations() {
+                return Set.of(DelegationType.FILTER);
+            }
+
+            @Override
+            public FragmentConvertor getFragmentConvertor() {
+                return dfConvertor;
+            }
+        };
+        MockLuceneBackend lucene = new MockLuceneBackend() {
+            @Override
+            protected Set<DelegationType> acceptedDelegations() {
+                return Set.of(DelegationType.FILTER);
+            }
+
+            @Override
+            public Map<ScalarFunction, DelegatedPredicateSerializer> delegatedPredicateSerializers() {
+                Map<ScalarFunction, DelegatedPredicateSerializer> map = new HashMap<>(super.delegatedPredicateSerializers());
+                map.put(ScalarFunction.MATCH_PHRASE, serializer);
+                map.put(ScalarFunction.FUZZY, serializer);
+                return map;
+            }
+
+        };
+        var backends = List.<AnalyticsSearchBackendPlugin>of(df, lucene);
+        Map<String, Map<String, Object>> fields = Map.of("message", Map.of("type", "keyword", "index", true));
+        var context = buildContext("parquet", fields, backends);
+        // AND(OR(AND(match_phrase, fuzzy), match_phrase), fuzzy)
+        RexNode orClause = rexBuilder.makeCall(
+            org.apache.calcite.sql.fun.SqlStdOperatorTable.OR,
+            makeAnd(makeFullTextCall(MATCH_PHRASE_FUNCTION, 0, "hello"), makeFullTextCall(FUZZY_FUNCTION, 0, "wrld")),
+            makeFullTextCall(MATCH_PHRASE_FUNCTION, 0, "ru")
+        );
+        RexNode condition = makeAnd(orClause, makeFullTextCall(FUZZY_FUNCTION, 0, "http"));
+        LogicalFilter filter = LogicalFilter.create(
+            stubScan(mockTable("test_index", new String[] { "message" }, new SqlTypeName[] { SqlTypeName.VARCHAR })),
+            condition
+        );
+        RelNode cboOutput = runPlanner(filter, context);
+        QueryDAG dag = DAGBuilder.build(cboOutput, context.getCapabilityRegistry(), mockClusterService());
+        PlanForker.forkAll(dag, context.getCapabilityRegistry());
+        FragmentConversionDriver.convertAll(dag, context.getCapabilityRegistry());
+        StagePlan plan = leafStage(dag).getPlanAlternatives().getFirst();
+
+        assertEquals("AND(OR(AND,leaf),leaf) pure Lucene should produce 1 expression", 1, plan.delegatedExpressions().size());
+    }
+
+    /** AND(OR(AND(a,b), c), d, native) — mixed: Lucene subtree combined + native preserved. */
+    public void testMixedAndOrAndWithNative() {
+        RecordingConvertor dfConvertor = new RecordingConvertor();
+        RecordingSerializer serializer = new RecordingSerializer();
+        MockDataFusionBackend df = new MockDataFusionBackend() {
+            @Override
+            protected Set<DelegationType> supportedDelegations() {
+                return Set.of(DelegationType.FILTER);
+            }
+
+            @Override
+            public FragmentConvertor getFragmentConvertor() {
+                return dfConvertor;
+            }
+        };
+        MockLuceneBackend lucene = new MockLuceneBackend() {
+            @Override
+            protected Set<DelegationType> acceptedDelegations() {
+                return Set.of(DelegationType.FILTER);
+            }
+
+            @Override
+            public Map<ScalarFunction, DelegatedPredicateSerializer> delegatedPredicateSerializers() {
+                Map<ScalarFunction, DelegatedPredicateSerializer> map = new HashMap<>(super.delegatedPredicateSerializers());
+                map.put(ScalarFunction.MATCH_PHRASE, serializer);
+                map.put(ScalarFunction.FUZZY, serializer);
+                return map;
+            }
+
+        };
+        var backends = List.<AnalyticsSearchBackendPlugin>of(df, lucene);
+        // message=keyword(indexed), amount=integer(NOT indexed → native only)
+        Map<String, Map<String, Object>> fields = Map.of(
+            "message",
+            Map.of("type", "keyword", "index", true),
+            "amount",
+            Map.of("type", "integer", "index", false)
+        );
+        var context = buildContext("parquet", fields, backends);
+        // AND(OR(AND(match_phrase, fuzzy), match_phrase), fuzzy, amount=200)
+        RexNode orClause = rexBuilder.makeCall(
+            org.apache.calcite.sql.fun.SqlStdOperatorTable.OR,
+            makeAnd(makeFullTextCall(MATCH_PHRASE_FUNCTION, 0, "hello"), makeFullTextCall(FUZZY_FUNCTION, 0, "wrld")),
+            makeFullTextCall(MATCH_PHRASE_FUNCTION, 0, "ru")
+        );
+        RexNode condition = makeAnd(orClause, makeFullTextCall(FUZZY_FUNCTION, 0, "http"), makeEquals(1, SqlTypeName.INTEGER, 200));
+        LogicalFilter filter = LogicalFilter.create(
+            stubScan(
+                mockTable(
+                    "test_index",
+                    new String[] { "message", "amount" },
+                    new SqlTypeName[] { SqlTypeName.VARCHAR, SqlTypeName.INTEGER }
+                )
+            ),
+            condition
+        );
+        RelNode cboOutput = runPlanner(filter, context);
+        QueryDAG dag = DAGBuilder.build(cboOutput, context.getCapabilityRegistry(), mockClusterService());
+        PlanForker.forkAll(dag, context.getCapabilityRegistry());
+        FragmentConversionDriver.convertAll(dag, context.getCapabilityRegistry());
+        StagePlan plan = leafStage(dag).getPlanAlternatives().getFirst();
+
+        // All 4 Lucene predicates combined into 1, native amount=200 stays separate
+        assertEquals("Mixed: Lucene combined into 1 expression", 1, plan.delegatedExpressions().size());
+        // Verify the stripped plan still has AND (placeholder + native)
+        assertTrue("AND should be preserved", RelOptUtil.toString(dfConvertor.shardScanFragment).contains("AND"));
+    }
+
+    // ---- Combining: shared helper ----
+
+    /** Result holder for combining tests. */
+    private record CombiningResult(StagePlan plan, RecordingConvertor convertor, RecordingSerializer serializer) {
+    }
+
+    private static final SqlFunction WILDCARD_FN = new SqlFunction(
+        "WILDCARD",
+        SqlKind.OTHER_FUNCTION,
+        ReturnTypes.BOOLEAN,
+        null,
+        OperandTypes.ANY,
+        SqlFunctionCategory.USER_DEFINED_FUNCTION
+    );
+    private static final SqlFunction REGEXP_FN = new SqlFunction(
+        "REGEXP",
+        SqlKind.OTHER_FUNCTION,
+        ReturnTypes.BOOLEAN,
+        null,
+        OperandTypes.ANY,
+        SqlFunctionCategory.USER_DEFINED_FUNCTION
+    );
+
+    /**
+     * Builds and runs the combining pipeline for a filter condition.
+     * Uses 3 fields: message(keyword,indexed), amount(int,NOT indexed), count(int,NOT indexed).
+     * Lucene accepts delegation for MATCH_PHRASE, FUZZY, WILDCARD, REGEXP.
+     */
+    private CombiningResult runCombining(RexNode condition) {
+        RecordingConvertor dfConvertor = new RecordingConvertor();
+        RecordingSerializer serializer = new RecordingSerializer();
+        MockDataFusionBackend df = new MockDataFusionBackend() {
+            @Override
+            protected Set<DelegationType> supportedDelegations() {
+                return Set.of(DelegationType.FILTER);
+            }
+
+            @Override
+            public FragmentConvertor getFragmentConvertor() {
+                return dfConvertor;
+            }
+        };
+        MockLuceneBackend lucene = new MockLuceneBackend() {
+            @Override
+            protected Set<DelegationType> acceptedDelegations() {
+                return Set.of(DelegationType.FILTER);
+            }
+
+            @Override
+            public Map<ScalarFunction, DelegatedPredicateSerializer> delegatedPredicateSerializers() {
+                Map<ScalarFunction, DelegatedPredicateSerializer> map = new HashMap<>(super.delegatedPredicateSerializers());
+                map.put(ScalarFunction.MATCH_PHRASE, serializer);
+                map.put(ScalarFunction.FUZZY, serializer);
+                map.put(ScalarFunction.WILDCARD, serializer);
+                map.put(ScalarFunction.REGEXP, serializer);
+                return map;
+            }
+
+        };
+        var backends = List.<AnalyticsSearchBackendPlugin>of(df, lucene);
+        Map<String, Map<String, Object>> fields = Map.of(
+            "message",
+            Map.of("type", "keyword", "index", true),
+            "amount",
+            Map.of("type", "integer", "index", false),
+            "count",
+            Map.of("type", "integer", "index", false)
+        );
+        var context = buildContext("parquet", fields, backends);
+        LogicalFilter filter = LogicalFilter.create(
+            stubScan(
+                mockTable(
+                    "test_index",
+                    new String[] { "message", "amount", "count" },
+                    new SqlTypeName[] { SqlTypeName.VARCHAR, SqlTypeName.INTEGER, SqlTypeName.INTEGER }
+                )
+            ),
+            condition
+        );
+        RelNode cboOutput = runPlanner(filter, context);
+        QueryDAG dag = DAGBuilder.build(cboOutput, context.getCapabilityRegistry(), mockClusterService());
+        PlanForker.forkAll(dag, context.getCapabilityRegistry());
+        FragmentConversionDriver.convertAll(dag, context.getCapabilityRegistry());
+        StagePlan plan = leafStage(dag).getPlanAlternatives().getFirst();
+        return new CombiningResult(plan, dfConvertor, serializer);
+    }
+
+    private RexNode matchPhrase(String query) {
+        return makeFullTextCall(MATCH_PHRASE_FUNCTION, 0, query);
+    }
+
+    private RexNode fuzzy(String query) {
+        return makeFullTextCall(FUZZY_FUNCTION, 0, query);
+    }
+
+    private RexNode wildcard(String pattern) {
+        return makeFullTextCall(WILDCARD_FN, 0, pattern);
+    }
+
+    private RexNode regexp(String pattern) {
+        return makeFullTextCall(REGEXP_FN, 0, pattern);
+    }
+
+    private RexNode amountEquals(int val) {
+        return makeEquals(1, SqlTypeName.INTEGER, val);
+    }
+
+    private RexNode countEquals(int val) {
+        return makeEquals(2, SqlTypeName.INTEGER, val);
+    }
+
+    private RexNode or(RexNode... ops) {
+        return rexBuilder.makeCall(org.apache.calcite.sql.fun.SqlStdOperatorTable.OR, ops);
+    }
+
+    private RexNode not(RexNode op) {
+        return rexBuilder.makeCall(org.apache.calcite.sql.fun.SqlStdOperatorTable.NOT, op);
+    }
+
+    private FilterTreeShape treeShapeOf(StagePlan plan) {
+        return ((ShardScanWithDelegationInstructionNode) plan.instructions()
+            .stream()
+            .filter(n -> n.type() == InstructionType.SETUP_SHARD_SCAN_WITH_DELEGATION)
+            .findFirst()
+            .orElseThrow()).getTreeShape();
+    }
+
+    // ---- Combining tests (OR/NOT/mixed) ----
+
+    /** match_phrase AND fuzzy OR amount=200 → OR(AND(lucene,lucene), native) — combined, INTERLEAVED. */
+    public void testCombine_OrOfAndLuceneWithNative() {
+        var r = runCombining(or(makeAnd(matchPhrase("hello"), fuzzy("wrld")), amountEquals(200)));
+        assertEquals(1, r.plan.delegatedExpressions().size());
+        assertEquals(FilterTreeShape.INTERLEAVED_BOOLEAN_EXPRESSION, treeShapeOf(r.plan));
+    }
+
+    /** OR(AND(match_phrase, fuzzy), AND(amount=100, count=200)) — one Lucene arm combined, one native arm. */
+    public void testCombine_OrOfAndLuceneWithAndNative() {
+        var r = runCombining(or(makeAnd(matchPhrase("hello"), fuzzy("wrld")), makeAnd(amountEquals(100), countEquals(200))));
+        assertEquals(1, r.plan.delegatedExpressions().size());
+        assertEquals(FilterTreeShape.INTERLEAVED_BOOLEAN_EXPRESSION, treeShapeOf(r.plan));
+    }
+
+    /** AND(OR(match_phrase, amount=200), fuzzy) — match_phrase can't merge with fuzzy across OR → 2 expressions. */
+    public void testCombine_AndWithOrContainingMixed() {
+        var r = runCombining(makeAnd(or(matchPhrase("hello"), amountEquals(200)), fuzzy("wrld")));
+        assertEquals(2, r.plan.delegatedExpressions().size());
+        assertEquals(FilterTreeShape.INTERLEAVED_BOOLEAN_EXPRESSION, treeShapeOf(r.plan));
+    }
+
+    /** OR(AND(match_phrase, fuzzy), AND(wildcard, amount=200)) — left arm combined, right has wildcard separate. */
+    public void testCombine_OrOfPureLuceneAndMixedAnd() {
+        var r = runCombining(or(makeAnd(matchPhrase("hello"), fuzzy("wrld")), makeAnd(wildcard("h*llo"), amountEquals(200))));
+        assertEquals(2, r.plan.delegatedExpressions().size());
+        assertEquals(FilterTreeShape.INTERLEAVED_BOOLEAN_EXPRESSION, treeShapeOf(r.plan));
+    }
+
+    /** OR(AND(match_phrase, fuzzy, wildcard), amount=200) — all 3 Lucene AND-combined, then OR with native. */
+    public void testCombine_OrOfThreeLuceneAndNative() {
+        var r = runCombining(or(makeAnd(matchPhrase("hello"), fuzzy("wrld"), wildcard("h*llo")), amountEquals(200)));
+        assertEquals(1, r.plan.delegatedExpressions().size());
+        assertEquals(FilterTreeShape.INTERLEAVED_BOOLEAN_EXPRESSION, treeShapeOf(r.plan));
+    }
+
+    /** OR(AND(match_phrase, fuzzy), AND(wildcard, regexp)) — pure Lucene both sides, fully combined to 1. */
+    public void testCombine_OrOfTwoAndGroupsPureLucene() {
+        var r = runCombining(or(makeAnd(matchPhrase("hello"), fuzzy("wrld")), makeAnd(wildcard("h*llo"), regexp("h.llo"))));
+        assertEquals(1, r.plan.delegatedExpressions().size());
+    }
+
+    /** OR(match_phrase, amount=200, fuzzy) — flat interleaved OR. */
+    public void testCombine_OrFlatInterleaved() {
+        var r = runCombining(or(matchPhrase("hello"), amountEquals(200), fuzzy("wrld")));
+        assertEquals(1, r.plan.delegatedExpressions().size());
+        assertEquals(FilterTreeShape.INTERLEAVED_BOOLEAN_EXPRESSION, treeShapeOf(r.plan));
+    }
+
+    /** OR(match_phrase, amount=100, fuzzy, count=200, wildcard) — 3 Lucene combined, 2 native preserved. */
+    public void testCombine_OrFlatFivePredicates() {
+        var r = runCombining(or(matchPhrase("hello"), amountEquals(100), fuzzy("wrld"), countEquals(200), wildcard("h*")));
+        assertEquals(1, r.plan.delegatedExpressions().size());
+        assertEquals(FilterTreeShape.INTERLEAVED_BOOLEAN_EXPRESSION, treeShapeOf(r.plan));
+    }
+
+    /** AND(match_phrase, OR(fuzzy, amount=100), wildcard) — fuzzy materialized inside OR, match_phrase+wildcard may combine at AND. */
+    public void testCombine_AndLuceneOrMixedLucene() {
+        var r = runCombining(makeAnd(matchPhrase("hello"), or(fuzzy("wrld"), amountEquals(100)), wildcard("h*")));
+        assertTrue("at least 1 expression", r.plan.delegatedExpressions().size() >= 1);
+        assertEquals(FilterTreeShape.INTERLEAVED_BOOLEAN_EXPRESSION, treeShapeOf(r.plan));
+    }
+
+    /** NOT(match_phrase) OR amount=200 — NOT wraps delegated, OR with native, INTERLEAVED. */
+    public void testCombine_OrNotLuceneWithNative() {
+        var r = runCombining(or(not(matchPhrase("hello")), amountEquals(200)));
+        assertEquals(1, r.plan.delegatedExpressions().size());
+        assertEquals(FilterTreeShape.INTERLEAVED_BOOLEAN_EXPRESSION, treeShapeOf(r.plan));
+    }
+
+    /** (match_phrase AND fuzzy AND NOT(wildcard)) OR amount=200 — AND combines all 3, then OR with native. */
+    public void testCombine_OrOfAndWithNotAndNative() {
+        var r = runCombining(or(makeAnd(matchPhrase("hello"), fuzzy("wrld"), not(wildcard("h*"))), amountEquals(200)));
+        assertEquals(1, r.plan.delegatedExpressions().size());
+        assertEquals(FilterTreeShape.INTERLEAVED_BOOLEAN_EXPRESSION, treeShapeOf(r.plan));
+    }
+
+    /** OR(NOT(match_phrase), NOT(fuzzy), amount=200) — both NOTs combine under OR, native stays. */
+    public void testCombine_OrTwoNotsWithNative() {
+        var r = runCombining(or(not(matchPhrase("hello")), not(fuzzy("wrld")), amountEquals(200)));
+        assertEquals(1, r.plan.delegatedExpressions().size());
+        assertEquals(FilterTreeShape.INTERLEAVED_BOOLEAN_EXPRESSION, treeShapeOf(r.plan));
+    }
+
+    /** AND(OR(match_phrase, fuzzy), OR(wildcard, amount=200)) — first OR bubbles up, second is mixed. */
+    public void testCombine_AndOfTwoOrs_OnePureOneMixed() {
+        var r = runCombining(makeAnd(or(matchPhrase("hello"), fuzzy("wrld")), or(wildcard("h*"), amountEquals(200))));
+        assertEquals(2, r.plan.delegatedExpressions().size());
+        assertEquals(FilterTreeShape.INTERLEAVED_BOOLEAN_EXPRESSION, treeShapeOf(r.plan));
     }
 
     // ---- OR conditions ----
@@ -758,20 +1341,9 @@ public class FragmentConversionDriverTests extends BasePlannerRulesTests {
         RexNode condition = makeAnd(makeEquals(2, SqlTypeName.INTEGER, 200), orClause);
         QueryDAG dag = buildTwoFieldDelegationDag(condition, dfConvertor, serializer);
         StagePlan plan = leafStage(dag).getPlanAlternatives().getFirst();
-        assertDelegationResult(
-            plan,
-            dfConvertor,
-            serializer,
-            2,
-            true,
-            true,
-            List.of("MATCH_PHRASE", "FUZZY"),
-            FilterTreeShape.INTERLEAVED_BOOLEAN_EXPRESSION
-        );
+        assertDelegationResult(plan, dfConvertor, serializer, 1, true, true, List.of("MATCH_PHRASE", "FUZZY"), FilterTreeShape.CONJUNCTIVE);
         String strippedPlan = RelOptUtil.toString(dfConvertor.shardScanFragment);
         assertTrue("AND structure should be preserved", strippedPlan.contains("AND"));
-        assertTrue("OR structure should be preserved", strippedPlan.contains("OR"));
-        assertTrue("NOT structure should be preserved", strippedPlan.contains("NOT"));
     }
 
     // ---- Error paths ----
@@ -779,11 +1351,21 @@ public class FragmentConversionDriverTests extends BasePlannerRulesTests {
     /** Delegated annotation with no serializer registered → IllegalStateException. */
     public void testMissingSerializerThrows() {
         RecordingConvertor dfConvertor = new RecordingConvertor();
-        // Lucene mock accepts delegation but has NO serializers at all
+        // Lucene mock accepts delegation but has NO serializers — predicate stays native
         MockLuceneBackend lucene = new MockLuceneBackend() {
             @Override
             protected Set<DelegationType> acceptedDelegations() {
                 return Set.of(DelegationType.FILTER);
+            }
+
+            @Override
+            public DelegatedSubtreeConvertor getDelegatedSubtreeConvertor() {
+                return null;
+            }
+
+            @Override
+            public Map<ScalarFunction, DelegatedPredicateSerializer> delegatedPredicateSerializers() {
+                return Map.of();
             }
         };
         MockDataFusionBackend df = new MockDataFusionBackend() {
@@ -811,7 +1393,329 @@ public class FragmentConversionDriverTests extends BasePlannerRulesTests {
             () -> FragmentConversionDriver.convertAll(dag, context.getCapabilityRegistry())
         );
         assertTrue(exception.getMessage().contains("No DelegatedPredicateSerializer"));
-        assertTrue(exception.getMessage().contains("MATCH_PHRASE"));
+    }
+
+    /** Performance-delegated predicate without serializer stays native (not combined). */
+    public void testPerfDelegatedWithoutSerializerStaysNative() {
+        RecordingConvertor dfConvertor = new RecordingConvertor();
+        RecordingSerializer serializer = new RecordingSerializer();
+        // Lucene backend has serializer for MATCH_PHRASE but NOT for FUZZY
+        MockLuceneBackend lucene = new MockLuceneBackend() {
+            @Override
+            protected Set<DelegationType> acceptedDelegations() {
+                return Set.of(DelegationType.FILTER);
+            }
+
+            @Override
+            public Map<ScalarFunction, DelegatedPredicateSerializer> delegatedPredicateSerializers() {
+                return Map.of(ScalarFunction.MATCH_PHRASE, serializer);
+            }
+        };
+        MockDataFusionBackend df = new MockDataFusionBackend() {
+            @Override
+            protected Set<DelegationType> supportedDelegations() {
+                return Set.of(DelegationType.FILTER);
+            }
+
+            @Override
+            public FragmentConvertor getFragmentConvertor() {
+                return dfConvertor;
+            }
+        };
+        Map<String, Map<String, Object>> fields = Map.of("message", Map.of("type", "keyword", "index", true));
+        var context = buildContext("parquet", fields, List.of(df, lucene));
+        // MATCH_PHRASE is correctness-delegated (lucene-only), EQUALS is perf-delegated (dual-viable)
+        // but EQUALS has no serializer on lucene → stays native
+        RexNode condition = makeAnd(makeFullTextCall(MATCH_PHRASE_FUNCTION, 0, "hello"), makeEquals(0, SqlTypeName.VARCHAR, "world"));
+        LogicalFilter filter = LogicalFilter.create(
+            stubScan(mockTable("test_index", new String[] { "message" }, new SqlTypeName[] { SqlTypeName.VARCHAR })),
+            condition
+        );
+        RelNode cboOutput = runPlanner(filter, context);
+        QueryDAG dag = DAGBuilder.build(cboOutput, context.getCapabilityRegistry(), mockClusterService());
+        PlanForker.forkAll(dag, context.getCapabilityRegistry());
+        FragmentConversionDriver.convertAll(dag, context.getCapabilityRegistry());
+        StagePlan plan = leafStage(dag).getPlanAlternatives().getFirst();
+        // Only MATCH_PHRASE delegated; EQUALS stays native (no serializer)
+        assertEquals("Only serializable predicates delegated", 1, plan.delegatedExpressions().size());
+    }
+
+    /** Performance-delegated predicate WITH serializer gets combined with correctness-delegated. */
+    public void testPerfDelegatedWithSerializerCombines() {
+        RecordingConvertor dfConvertor = new RecordingConvertor();
+        RecordingSerializer serializer = new RecordingSerializer();
+        // Lucene backend has serializers for both MATCH_PHRASE and EQUALS
+        MockLuceneBackend lucene = new MockLuceneBackend() {
+            @Override
+            protected Set<DelegationType> acceptedDelegations() {
+                return Set.of(DelegationType.FILTER);
+            }
+
+            @Override
+            public Map<ScalarFunction, DelegatedPredicateSerializer> delegatedPredicateSerializers() {
+                Map<ScalarFunction, DelegatedPredicateSerializer> map = new HashMap<>();
+                map.put(ScalarFunction.MATCH_PHRASE, serializer);
+                map.put(ScalarFunction.EQUALS, serializer);
+                return map;
+            }
+        };
+        MockDataFusionBackend df = new MockDataFusionBackend() {
+            @Override
+            protected Set<DelegationType> supportedDelegations() {
+                return Set.of(DelegationType.FILTER);
+            }
+
+            @Override
+            public FragmentConvertor getFragmentConvertor() {
+                return dfConvertor;
+            }
+        };
+        Map<String, Map<String, Object>> fields = Map.of("message", Map.of("type", "keyword", "index", true));
+        var context = buildContext("parquet", fields, List.of(df, lucene));
+        // Both MATCH_PHRASE (correctness) and EQUALS (perf) have serializers → combined into 1
+        RexNode condition = makeAnd(makeFullTextCall(MATCH_PHRASE_FUNCTION, 0, "hello"), makeEquals(0, SqlTypeName.VARCHAR, "world"));
+        LogicalFilter filter = LogicalFilter.create(
+            stubScan(mockTable("test_index", new String[] { "message" }, new SqlTypeName[] { SqlTypeName.VARCHAR })),
+            condition
+        );
+        RelNode cboOutput = runPlanner(filter, context);
+        QueryDAG dag = DAGBuilder.build(cboOutput, context.getCapabilityRegistry(), mockClusterService());
+        PlanForker.forkAll(dag, context.getCapabilityRegistry());
+        FragmentConversionDriver.convertAll(dag, context.getCapabilityRegistry());
+        StagePlan plan = leafStage(dag).getPlanAlternatives().getFirst();
+        // Correctness and performance delegated stay separate — 2 DelegatedExpressions
+        assertEquals("Correctness and performance delegated stay separate", 2, plan.delegatedExpressions().size());
+    }
+
+    // ---- Plan shape verification tests (match verified DF logical plans) ----
+
+    /**
+     * match(Title,'ru') AND Referer='google' AND URL='US' AND GoodEvent=1
+     * Expected: delegated_predicate(0) AND delegation_possible(Referer='google' AND URL='US', 1) AND GoodEvent=1
+     */
+    public void testAndCorrectnessAndMultiplePerfAndNative() {
+        RecordingConvertor dfConvertor = new RecordingConvertor();
+        RecordingSerializer serializer = new RecordingSerializer();
+        // 4 fields: Title(keyword,indexed), Referer(keyword,indexed), URL(keyword,indexed), GoodEvent(int,NOT indexed)
+        QueryDAG dag = buildDelegationDag(
+            makeAnd(
+                makeFullTextCall(MATCH_PHRASE_FUNCTION, 0, "ru"),
+                makeEquals(1, SqlTypeName.VARCHAR, "google"),
+                makeEquals(2, SqlTypeName.VARCHAR, "US"),
+                makeEquals(3, SqlTypeName.INTEGER, 1)
+            ),
+            dfConvertor,
+            serializer,
+            new String[] { "Title", "Referer", "URL", "GoodEvent" },
+            new SqlTypeName[] { SqlTypeName.VARCHAR, SqlTypeName.VARCHAR, SqlTypeName.VARCHAR, SqlTypeName.INTEGER },
+            Map.of(
+                "Title",
+                Map.of("type", "keyword", "index", true),
+                "Referer",
+                Map.of("type", "keyword", "index", true),
+                "URL",
+                Map.of("type", "keyword", "index", true),
+                "GoodEvent",
+                Map.of("type", "integer", "index", false)
+            )
+        );
+        StagePlan plan = leafStage(dag).getPlanAlternatives().getFirst();
+        // 1 correctness (match) + 1 combined performance (Referer AND URL) = 2 DelegatedExpressions
+        assertEquals(2, plan.delegatedExpressions().size());
+        String strippedPlan = RelOptUtil.toString(dfConvertor.shardScanFragment);
+        LOGGER.info("Plan (AND correctness + multi-perf + native):\n{}", strippedPlan);
+        assertTrue("Should have delegated_predicate", strippedPlan.contains(DelegatedPredicateFunction.NAME));
+        assertTrue("Should have delegation_possible", strippedPlan.contains(DelegationPossibleFunction.NAME));
+        assertTrue("Should have native GoodEvent =", strippedPlan.contains("="));
+        assertEquals(FilterTreeShape.CONJUNCTIVE, treeShapeOf(plan));
+    }
+
+    /**
+     * Referer='google' AND URL='US' AND GoodEvent=1 (no correctness delegation)
+     * Expected: delegation_possible(Referer='google' AND URL='US', 0) AND GoodEvent=1
+     */
+    public void testAndOnlyPerfAndNative() {
+        RecordingConvertor dfConvertor = new RecordingConvertor();
+        RecordingSerializer serializer = new RecordingSerializer();
+        QueryDAG dag = buildDelegationDag(
+            makeAnd(
+                makeEquals(0, SqlTypeName.VARCHAR, "google"),
+                makeEquals(1, SqlTypeName.VARCHAR, "US"),
+                makeEquals(2, SqlTypeName.INTEGER, 1)
+            ),
+            dfConvertor,
+            serializer,
+            new String[] { "Referer", "URL", "GoodEvent" },
+            new SqlTypeName[] { SqlTypeName.VARCHAR, SqlTypeName.VARCHAR, SqlTypeName.INTEGER },
+            Map.of(
+                "Referer",
+                Map.of("type", "keyword", "index", true),
+                "URL",
+                Map.of("type", "keyword", "index", true),
+                "GoodEvent",
+                Map.of("type", "integer", "index", false)
+            )
+        );
+        StagePlan plan = leafStage(dag).getPlanAlternatives().getFirst();
+        // 1 combined performance (Referer AND URL) = 1 DelegatedExpression
+        assertEquals(1, plan.delegatedExpressions().size());
+        String strippedPlan = RelOptUtil.toString(dfConvertor.shardScanFragment);
+        LOGGER.info("Plan (AND only-perf + native):\n{}", strippedPlan);
+        assertFalse("Should NOT have delegated_predicate", strippedPlan.contains(DelegatedPredicateFunction.NAME));
+        assertTrue("Should have delegation_possible", strippedPlan.contains(DelegationPossibleFunction.NAME));
+        assertEquals(FilterTreeShape.CONJUNCTIVE, treeShapeOf(plan));
+    }
+
+    /**
+     * match(Title,'ru') OR Referer='google' AND URL='US' AND GoodEvent=1
+     * Under OR, perf-delegated stays native (resolved via applyFn).
+     */
+    public void testOrCorrectnessWithPerfAndNative() {
+        RecordingConvertor dfConvertor = new RecordingConvertor();
+        RecordingSerializer serializer = new RecordingSerializer();
+        // OR(match, AND(Referer=, URL=, GoodEvent=))
+        QueryDAG dag = buildDelegationDag(
+            rexBuilder.makeCall(
+                SqlStdOperatorTable.OR,
+                makeFullTextCall(MATCH_PHRASE_FUNCTION, 0, "ru"),
+                makeAnd(
+                    makeEquals(1, SqlTypeName.VARCHAR, "google"),
+                    makeEquals(2, SqlTypeName.VARCHAR, "US"),
+                    makeEquals(3, SqlTypeName.INTEGER, 1)
+                )
+            ),
+            dfConvertor,
+            serializer,
+            new String[] { "Title", "Referer", "URL", "GoodEvent" },
+            new SqlTypeName[] { SqlTypeName.VARCHAR, SqlTypeName.VARCHAR, SqlTypeName.VARCHAR, SqlTypeName.INTEGER },
+            Map.of(
+                "Title",
+                Map.of("type", "keyword", "index", true),
+                "Referer",
+                Map.of("type", "keyword", "index", true),
+                "URL",
+                Map.of("type", "keyword", "index", true),
+                "GoodEvent",
+                Map.of("type", "integer", "index", false)
+            )
+        );
+        StagePlan plan = leafStage(dag).getPlanAlternatives().getFirst();
+        // match is correctness-delegated (1 expression), perf under AND already combined (1 expression)
+        assertEquals(2, plan.delegatedExpressions().size());
+        String strippedPlan = RelOptUtil.toString(dfConvertor.shardScanFragment);
+        LOGGER.info("Plan (OR correctness with perf+native):\n{}", strippedPlan);
+        assertTrue("Should have delegated_predicate for match", strippedPlan.contains(DelegatedPredicateFunction.NAME));
+        assertTrue("Should have delegation_possible for perf", strippedPlan.contains(DelegationPossibleFunction.NAME));
+        assertEquals(FilterTreeShape.INTERLEAVED_BOOLEAN_EXPRESSION, treeShapeOf(plan));
+    }
+
+    /**
+     * match(Title,'ru') AND Referer='google' OR URL='US' AND GoodEvent=1
+     * Operator precedence: (match AND Referer=) OR (URL= AND GoodEvent=)
+     * Expected: delegated_predicate(0) AND delegation_possible(Referer, 1) OR delegation_possible(URL, 2) AND GoodEvent=1
+     * Tree shape: INTERLEAVED (delegation under OR)
+     */
+    public void testAndCorrectnessOrPerfWithNative() {
+        RecordingConvertor dfConvertor = new RecordingConvertor();
+        RecordingSerializer serializer = new RecordingSerializer();
+        // OR( AND(match, Referer=), AND(URL=, GoodEvent=) )
+        QueryDAG dag = buildDelegationDag(
+            rexBuilder.makeCall(
+                SqlStdOperatorTable.OR,
+                makeAnd(makeFullTextCall(MATCH_PHRASE_FUNCTION, 0, "ru"), makeEquals(1, SqlTypeName.VARCHAR, "google")),
+                makeAnd(makeEquals(2, SqlTypeName.VARCHAR, "US"), makeEquals(3, SqlTypeName.INTEGER, 1))
+            ),
+            dfConvertor,
+            serializer,
+            new String[] { "Title", "Referer", "URL", "GoodEvent" },
+            new SqlTypeName[] { SqlTypeName.VARCHAR, SqlTypeName.VARCHAR, SqlTypeName.VARCHAR, SqlTypeName.INTEGER },
+            Map.of(
+                "Title",
+                Map.of("type", "keyword", "index", true),
+                "Referer",
+                Map.of("type", "keyword", "index", true),
+                "URL",
+                Map.of("type", "keyword", "index", true),
+                "GoodEvent",
+                Map.of("type", "integer", "index", false)
+            )
+        );
+        StagePlan plan = leafStage(dag).getPlanAlternatives().getFirst();
+        String strippedPlan = RelOptUtil.toString(dfConvertor.shardScanFragment);
+        LOGGER.info("Plan (AND correctness OR perf + native):\n{}", strippedPlan);
+        assertTrue("Should have delegated_predicate", strippedPlan.contains(DelegatedPredicateFunction.NAME));
+        assertTrue("Should have delegation_possible", strippedPlan.contains(DelegationPossibleFunction.NAME));
+        assertEquals(FilterTreeShape.INTERLEAVED_BOOLEAN_EXPRESSION, treeShapeOf(plan));
+    }
+
+    /**
+     * NOT match(Title,'ru')
+     * Expected: delegated_predicate(0) — correctness delegation, NOT absorbed into BoolQuery(must_not).
+     * Tree shape: CONJUNCTIVE (single combined expression, no interleaving).
+     */
+    public void testNotCorrectnessDelegation() {
+        RecordingConvertor dfConvertor = new RecordingConvertor();
+        RecordingSerializer serializer = new RecordingSerializer();
+        QueryDAG dag = buildSingleFieldDelegationDag(
+            rexBuilder.makeCall(SqlStdOperatorTable.NOT, makeFullTextCall(MATCH_PHRASE_FUNCTION, 0, "ru")),
+            dfConvertor,
+            serializer
+        );
+        StagePlan plan = leafStage(dag).getPlanAlternatives().getFirst();
+        assertEquals(1, plan.delegatedExpressions().size());
+        String strippedPlan = RelOptUtil.toString(dfConvertor.shardScanFragment);
+        LOGGER.info("Plan (NOT correctness):\n{}", strippedPlan);
+        assertTrue("Should have delegated_predicate", strippedPlan.contains(DelegatedPredicateFunction.NAME));
+        assertFalse("Should NOT have delegation_possible", strippedPlan.contains(DelegationPossibleFunction.NAME));
+        assertEquals(FilterTreeShape.CONJUNCTIVE, treeShapeOf(plan));
+    }
+
+    /**
+     * NOT tag='hello' — Calcite normalizes to tag!='hello' (NOT_EQUALS).
+     * NOT_EQUALS has no serializer, stays fully native, no delegation.
+     */
+    public void testNotEqualsStaysNative() {
+        RecordingConvertor dfConvertor = new RecordingConvertor();
+        RecordingSerializer serializer = new RecordingSerializer();
+        QueryDAG dag = buildTwoFieldDelegationDag(
+            rexBuilder.makeCall(SqlStdOperatorTable.NOT, makeEquals(0, SqlTypeName.INTEGER, 200)),
+            dfConvertor,
+            serializer
+        );
+        StagePlan plan = leafStage(dag).getPlanAlternatives().getFirst();
+        String strippedPlan = RelOptUtil.toString(dfConvertor.shardScanFragment);
+        LOGGER.info("Plan (NOT equals → NOT_EQUALS, no serializer):\n{}", strippedPlan);
+        // NOT_EQUALS has no serializer → no delegation
+        assertEquals(0, plan.delegatedExpressions().size());
+        assertFalse("Should NOT have delegated_predicate", strippedPlan.contains(DelegatedPredicateFunction.NAME));
+        assertFalse("Should NOT have delegation_possible", strippedPlan.contains(DelegationPossibleFunction.NAME));
+    }
+
+    /**
+     * NOT match(message,'hello') AND tag='hello'
+     * NOT(correctness) combined into BoolQuery(must_not) + perf-delegated under AND combined separately.
+     * Expected: delegated_predicate(0) AND delegation_possible(tag='hello', 1)
+     * Tree shape: CONJUNCTIVE (both under AND, no OR/NOT in final plan).
+     */
+    public void testNotCorrectnessAndPerfDelegation() {
+        RecordingConvertor dfConvertor = new RecordingConvertor();
+        RecordingSerializer serializer = new RecordingSerializer();
+        // field 0 = status (int, indexed), field 1 = message (keyword, indexed)
+        QueryDAG dag = buildTwoFieldDelegationDag(
+            makeAnd(
+                rexBuilder.makeCall(SqlStdOperatorTable.NOT, makeFullTextCall(MATCH_PHRASE_FUNCTION, 1, "hello")),
+                makeEquals(0, SqlTypeName.INTEGER, 200)
+            ),
+            dfConvertor,
+            serializer
+        );
+        StagePlan plan = leafStage(dag).getPlanAlternatives().getFirst();
+        assertEquals(2, plan.delegatedExpressions().size());
+        String strippedPlan = RelOptUtil.toString(dfConvertor.shardScanFragment);
+        LOGGER.info("Plan (NOT correctness AND perf):\n{}", strippedPlan);
+        assertTrue("Should have delegated_predicate", strippedPlan.contains(DelegatedPredicateFunction.NAME));
+        assertTrue("Should have delegation_possible", strippedPlan.contains(DelegationPossibleFunction.NAME));
+        assertEquals(FilterTreeShape.CONJUNCTIVE, treeShapeOf(plan));
     }
 
     // ---- RecordingConvertor ----

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/FilterDelegationIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/FilterDelegationIT.java
@@ -230,6 +230,69 @@ public class FilterDelegationIT extends AnalyticsRestTestCase {
         assertEquals(50L, ((Number) rows.get(0).get(0)).longValue());
     }
 
+    // ---- Combining delegation tests ----
+
+    /**
+     * match(message,'hello') AND tag='hello' AND value=5
+     * correctness (match) + performance (tag=) + native (value=) under AND.
+     * Both delegations combined separately; result = 50.
+     */
+    public void testAndCorrectnessAndPerfAndNative() throws Exception {
+        createIndex();
+        indexDocs();
+        String ppl = "source = " + INDEX_NAME + " | where match(message, 'hello') and tag = 'hello' and value = 5 | stats count() as cnt";
+        Map<String, Object> result = executePPL(ppl);
+        @SuppressWarnings("unchecked")
+        List<List<Object>> rows = (List<List<Object>>) result.get("rows");
+        assertEquals(10L, ((Number) rows.get(0).get(0)).longValue());
+    }
+
+    /**
+     * tag='hello' AND value=5 (no correctness delegation, only performance + native under AND).
+     * Performance-delegated tag= combined; value= stays native. Result = 10.
+     */
+    public void testAndOnlyPerfAndNative() throws Exception {
+        createIndex();
+        indexDocs();
+        String ppl = "source = " + INDEX_NAME + " | where tag = 'hello' and value = 5 | stats count() as cnt";
+        Map<String, Object> result = executePPL(ppl);
+        @SuppressWarnings("unchecked")
+        List<List<Object>> rows = (List<List<Object>>) result.get("rows");
+        assertEquals(10L, ((Number) rows.get(0).get(0)).longValue());
+    }
+
+    /**
+     * match(message,'hello') OR tag='hello' AND value=5
+     * Precedence: match OR (tag= AND value=). Correctness under OR, perf under AND.
+     * Performance-delegated under OR stays native (not combined with correctness).
+     * Result: 10 (match 'hello') + 0 extra (tag='hello' AND value=5 is subset) = 10.
+     */
+    public void testOrCorrectnessWithPerfAndNative() throws Exception {
+        createIndex();
+        indexDocs();
+        String ppl = "source = " + INDEX_NAME + " | where match(message, 'hello') or tag = 'hello' and value = 5 | stats count() as cnt";
+        Map<String, Object> result = executePPL(ppl);
+        @SuppressWarnings("unchecked")
+        List<List<Object>> rows = (List<List<Object>>) result.get("rows");
+        assertEquals(10L, ((Number) rows.get(0).get(0)).longValue());
+    }
+
+    /**
+     * (match(message,'hello') AND tag='hello') OR (tag='goodbye' AND value=3)
+     * OR of two AND arms: left has correctness+perf, right has perf+native.
+     * Result: 10 (left arm) + 10 (right arm) = 20 (but overlap → 10 + 10 = 20 distinct docs).
+     */
+    public void testOrOfTwoAndArms() throws Exception {
+        createIndex();
+        indexDocs();
+        String ppl = "source = " + INDEX_NAME
+            + " | where (match(message, 'hello') and tag = 'hello') or (tag = 'goodbye' and value = 3) | stats count() as cnt";
+        Map<String, Object> result = executePPL(ppl);
+        @SuppressWarnings("unchecked")
+        List<List<Object>> rows = (List<List<Object>>) result.get("rows");
+        assertEquals(20L, ((Number) rows.get(0).get(0)).longValue());
+    }
+
     private void createIndex() throws Exception {
         try {
             client().performRequest(new Request("DELETE", "/" + INDEX_NAME));


### PR DESCRIPTION

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Combine same-backend delegated predicates into single Bool

Algorithm:
- DelegatedPredicateCombiner classifies each node bottom-up as Delegated or Resolved. Leaves targeting a non operator backend (correctness) or having performanceDelegationBackends (perf) are classified as Delegated.
- Boolean connectives (AND/OR/NOT) with uniform same-backend delegated children bubble up as a single Delegated subtree.
- At mixed boundaries (delegated + native siblings), delegated children are finalized into one DelegatedExpression via the backend's DelegatedSubtreeConvertor, which walks the RexNode subtree once, builds a QueryBuilder tree, and serializes once at the root.
- Under OR/NOT, performance-delegated predicates are not combined with correctness-delegated ones — they stay native with delegation_possible wrapper since the driving backend must still evaluate them.
- FilterTreeShapeDeriver updated to derive CONJUNCTIVE when all same-backend predicates under OR/NOT are combined into one expression.

Key changes:
- Add DelegatedSubtreeConvertor SPI for backends to convert maximal same-backend delegated subtrees into bytes in one pass
- Implement LuceneSubtreeConvertor that builds a BoolQueryBuilder tree from the RexNode subtree and serializes once at the root
- Update DelegatedPredicateCombiner to use DelegatedSubtreeConvertor instead of per-leaf serialization + combineDelegatedPredicates
- Treat performance-delegated predicates as delegated to peer backend under AND only; under OR/NOT they resolve via applyFn
- Guard with canSerialize check before classifying as Delegated
- Move combining logic out of OpenSearchFilter.resolveCondition into FragmentConversionDriver.strip() via AnnotationResolver.resolveTree
- Expose AbstractQuerySerializer.buildQueryBuilder as public

Examples - 

Few queries with their DF logical plan
```
curl -s -X POST "http://localhost:9200/_plugins/_ppl" -H 'Content-Type: application/json' -d "{\"query\": \"source=clickbench | where match(Title, 'ru') AND Referer = 'google' AND URL = 'US' AND GoodEvent = 1  | stats count()\"}"

Aggregate: groupBy=[[]], aggr=[[count(Int64(1)) AS count()]]
  Filter: delegated_predicate(Int32(0)) AND delegation_possible(clickbench.Referer = Utf8("google") AND clickbench.URL = Utf8("US"), Int32(1)) AND CAST(clickbench.GoodEvent AS Int32) = Int32(1)
```

```
curl -s -X POST "http://localhost:9200/_plugins/_ppl"
 -H 'Content-Type: application/json' -d "{\"query\": \"source=clickbench | where Referer = 'google' AND URL = 'US' AND GoodEvent = 1  | stats count()\"}"

Aggregate: groupBy=[[]], aggr=[[count(Int64(1)) AS count()]]
  Filter: delegation_possible(clickbench.Referer = Utf8("google") AND clickbench.URL = Utf8("US"), Int32(0)) AND CAST(clickbench.GoodEvent AS Int32) = Int32(1)
```
```
curl -s -X POST "http://localhost:9200/_plugins/_ppl" -H 'Content-Type: application/json' -d "{\"query\": \"source=clickbench | where match(Title, 'ru') AND Referer = 'google' OR URL = 'US' AND GoodEvent = 1  | stats count()\"}"

  Filter: delegated_predicate(Int32(0)) AND delegation_possible(clickbench.Referer = Utf8("google"), Int32(1)) OR delegation_possible(clickbench.URL = Utf8("US"), Int32(2)) AND CAST(clickbench.GoodEvent AS Int32) = Int32(1)
```
```
curl -s -X POST "http://localhost:9200/_plugins/_ppl" -H 'Content-Type: application/json' -d "{\"query\": \"source=clickbench | where match(Title, 'ru') OR Referer = 'google' AND URL = 'US' AND GoodEvent = 1  | stats count()\"}"

  Filter: delegated_predicate(Int32(0)) OR delegation_possible(clickbench.Referer = Utf8("google") AND clickbench.URL = Utf8("US"), Int32(1)) AND CAST(clickbench.GoodEvent AS Int32) = Int32(1)
```
```
OpenSearchAggregate(COUNT, SINGLE) [datafusion]
│
└── OpenSearchFilter [datafusion]
    │
    │   condition:
    │
    │       AND
    │       ├── OR
    │       │   ├── AND
    │       │   │   ├── AnnotatedPred(id=0, [lucene])
    │       │   │   │     match(Title, 'google')
    │       │   │   │
    │       │   │   └── AnnotatedPred(id=1, [lucene])
    │       │   │         match(Referer, 'http')
    │       │   │
    │       │   └── AnnotatedPred(id=2, [lucene])
    │       │         match(Title, 'ru')
    │       │
    │       └── AnnotatedPred(id=3, [lucene])
    │             match(Referer, 'http')
    │
    └── OpenSearchTableScan(clickbench) [datafusion]


          AND
         /   \
       OR    luc
      / \
    AND  luc
   /   \
 luc   luc

Final - single delegated expression
```
```
OpenSearchAggregate(COUNT, SINGLE) [datafusion]
│
└── OpenSearchFilter [datafusion]
    │
    │   condition:
    │
    │       AND
    │       ├── OR
    │       │   ├── AND
    │       │   │   ├── AnnotatedPred(id=0, [lucene])
    │       │   │   │     match(Title, 'google')
    │       │   │   │
    │       │   │   └── AnnotatedPred(id=1, [lucene])
    │       │   │         match(Referer, 'http')
    │       │   │
    │       │   └── AnnotatedPred(id=2, [lucene])
    │       │         match(Title, 'ru')
    │       │
    │       ├── AnnotatedPred(id=3, [lucene])
    │       │     match(Referer, 'http')
    │       │
    │       └── AnnotatedPred(id=4, [datafusion])
    │             GoodEvent = 1
    │
    └── OpenSearchTableScan(clickbench) [datafusion]

            AND
          /  |  \
        OR  luc  df
       / \
     AND  luc
    /   \
  luc   luc


Final - single delegated expression AND 1 df predicate
```
```
                    AND
               /      \       \
              /        \       \
            OR         OR      AND
          /    \     /  \ \     /  \
        AND   luc  AND  df df  df   df
       /   \      /   \       
     luc   luc  luc   luc


Final - 2 delegated expressions
```
```


                     AND
               /      \       \
              /        \       \
            OR         OR      AND
          /    \     /  \ \     /  \
        AND    df  AND  df df  luc   luc
       /   \      /   \       
     luc   luc  luc   luc

Final - 3 delegated expressions
```


### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
