### PR TITLE
[Analytics Backend / DataFusion] Wire sub-second multi-unit span() via date_bin

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionFragmentConvertor.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionFragmentConvertor.java
@@ -164,6 +164,8 @@ public class DataFusionFragmentConvertor implements FragmentConvertor {
         // documented space-separator timestamp output is preserved on the AE path.
         FunctionMappings.s(SqlLibraryOperators.TO_CHAR, "to_char"),
         FunctionMappings.s(SqlLibraryOperators.DATE_TRUNC, "date_trunc"),
+        // PPL span(field, N<us|ms>) with N > 1 → DataFusion `date_bin`. See SpanAdapter.
+        FunctionMappings.s(SpanAdapter.LOCAL_DATE_BIN_OP, "date_bin"),
         FunctionMappings.s(ConvertTzAdapter.LOCAL_CONVERT_TZ_OP, "convert_tz"),
         FunctionMappings.s(UnixTimestampAdapter.LOCAL_TO_UNIXTIME_OP, "to_unixtime"),
         // Niladic ops from DateTimeAdapters — each maps 1:1 to a DF builtin.

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/SpanAdapter.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/SpanAdapter.java
@@ -14,8 +14,14 @@ import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlFunction;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.fun.SqlLibraryOperators;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.type.OperandTypes;
+import org.apache.calcite.sql.type.ReturnTypes;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.opensearch.analytics.spi.FieldStorageInfo;
 import org.opensearch.analytics.spi.ScalarFunctionAdapter;
@@ -35,11 +41,25 @@ import java.util.Map;
  *       {@code (field / interval) * interval} for integer types (where Calcite's
  *       integer division already truncates).</li>
  *   <li><b>Time span</b> ({@code unit} is a single-letter unit string like
- *       {@code "y"}, {@code "M"}, {@code "d"}, etc.): rewritten to
- *       {@code DATE_TRUNC(<unit>, field)} when {@code interval == 1}. Multi-unit
- *       intervals like {@code 12h} aren't expressible as {@code date_trunc} and
- *       fall through to the original UDF, which surfaces as a normal substrait
- *       binding error rather than a silent wrong-result.</li>
+ *       {@code "y"}, {@code "M"}, {@code "d"}, etc.) lowers through three paths,
+ *       checked in order:
+ *       <ul>
+ *         <li><b>{@code interval == 1}, any unit:</b> rewritten to
+ *             {@code DATE_TRUNC(<unit>, field)} — the cheapest DataFusion path.</li>
+ *         <li><b>Fixed-length unit (s/m/h/d/w) with {@code interval > 1}:</b> bucketed
+ *             via integer-seconds arithmetic ({@code TIMESTAMP_SECONDS(FLOOR(UNIX_SECONDS(t) / B) * B)}).
+ *             Exact because the epoch is a fixed reference for these units.</li>
+ *         <li><b>Sub-second unit (us/ms) with {@code interval > 1}:</b> rewritten to
+ *             DataFusion's native {@code date_bin("<N> <unit>", field)}. The arithmetic
+ *             path can't be used here because {@code to_unixtime} returns BIGINT seconds
+ *             and loses sub-second precision. Emitting the stride as a plain string
+ *             literal (e.g. {@code "40 milliseconds"}) avoids substrait interval-type
+ *             plumbing and matches how DataFusion's native parser accepts strides.</li>
+ *       </ul>
+ *       Multi-unit month / quarter / year intervals (e.g. {@code 12M}) still fall through
+ *       to the original UDF — their bucket length is calendar-dependent, requiring a
+ *       {@code date_bin} with an interval-month stride; tracked separately.
+ *   </li>
  * </ul>
  *
  * <p>The unit-letter mapping mirrors PPL's {@code SpanUnit} enum (defined in the SQL
@@ -81,6 +101,36 @@ class SpanAdapter implements ScalarFunctionAdapter {
         Map.entry("w", 604800L)
     );
 
+    /**
+     * Sub-second PPL span units → DataFusion {@code date_bin} stride suffix. Only used
+     * for the multi-unit {@code date_bin} rewrite path (N &gt; 1); N == 1 cases use the
+     * cheaper {@code date_trunc} path above. The fixed-second arithmetic path can't be
+     * used here because {@code to_unixtime} returns BIGINT seconds, losing sub-second
+     * precision; emitting a string-form stride to DataFusion's native {@code date_bin}
+     * preserves the millisecond / microsecond resolution.
+     */
+    private static final Map<String, String> SUB_SECOND_UNIT_TO_DATE_BIN_STRIDE = Map.of(
+        "us", "microseconds",
+        "ms", "milliseconds"
+    );
+
+    /**
+     * Locally-declared target operator for the sub-second {@code date_bin} path. Name
+     * matches DataFusion's native {@code date_bin}; the operand checker is informational
+     * (the adapter constructs the call directly and isthmus resolves the substrait
+     * function by name). Return type is pinned to ARG1 (the source-timestamp operand)
+     * so the rewritten call's declared type matches the original SPAN call (and thus
+     * the enclosing Project's cached rowType).
+     */
+    static final SqlOperator LOCAL_DATE_BIN_OP = new SqlFunction(
+        "date_bin",
+        SqlKind.OTHER_FUNCTION,
+        ReturnTypes.ARG1_NULLABLE,
+        null,
+        OperandTypes.ANY_ANY,
+        SqlFunctionCategory.TIMEDATE
+    );
+
     @Override
     public RexNode adapt(RexCall original, List<FieldStorageInfo> fieldStorage, RelOptCluster cluster) {
         if (!original.getOperator().getName().equalsIgnoreCase("SPAN")) {
@@ -119,11 +169,58 @@ class SpanAdapter implements ScalarFunctionAdapter {
                 if (bucketSeconds != null && bucketSeconds > 0L) {
                     return rewriteFixedLengthTimeBucket(rexBuilder, field, bucketSeconds, original.getType());
                 }
+                // Sub-second multi-unit time span: bucket via DataFusion's native date_bin.
+                // SPAN(t, N, 'us'|'ms') → date_bin("<N> microseconds"|"<N> milliseconds", t).
+                // The arithmetic path above can't be used because to_unixtime returns BIGINT
+                // seconds and would truncate sub-second precision. date_bin accepts the
+                // stride as a plain string literal natively in DataFusion's SQL parser,
+                // which sidesteps the substrait interval-type plumbing.
+                String dateBinStrideUnit = SUB_SECOND_UNIT_TO_DATE_BIN_STRIDE.get(unitText);
+                if (dateBinStrideUnit != null) {
+                    Long n = extractPositiveInteger(interval);
+                    if (n != null) {
+                        RexNode stride = rexBuilder.makeLiteral(n + " " + dateBinStrideUnit);
+                        return rexBuilder.makeCall(original.getType(), LOCAL_DATE_BIN_OP, List.of(stride, field));
+                    }
+                }
             }
         }
 
         // Anything else falls through unchanged.
         return original;
+    }
+
+    /**
+     * Returns the interval as a positive whole-number {@code Long} if it is a numeric
+     * literal whose value is a positive integer; {@code null} otherwise. Sibling of
+     * {@link #bucketSecondsIfPositiveInteger} without the unit-seconds multiplier — the
+     * sub-second date_bin path bakes the unit into the stride string instead.
+     */
+    private static Long extractPositiveInteger(RexNode interval) {
+        if (!(interval instanceof RexLiteral lit)) {
+            return null;
+        }
+        Object value = lit.getValue();
+        long n;
+        if (value instanceof BigDecimal bd) {
+            if (bd.scale() > 0 && bd.stripTrailingZeros().scale() > 0) {
+                return null;
+            }
+            try {
+                n = bd.longValueExact();
+            } catch (ArithmeticException e) {
+                return null;
+            }
+        } else if (value instanceof Number num) {
+            double d = num.doubleValue();
+            if (d != Math.floor(d)) {
+                return null;
+            }
+            n = (long) d;
+        } else {
+            return null;
+        }
+        return n > 0 ? n : null;
     }
 
     /**

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/SpanAdapter.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/SpanAdapter.java
@@ -109,10 +109,7 @@ class SpanAdapter implements ScalarFunctionAdapter {
      * precision; emitting a string-form stride to DataFusion's native {@code date_bin}
      * preserves the millisecond / microsecond resolution.
      */
-    private static final Map<String, String> SUB_SECOND_UNIT_TO_DATE_BIN_STRIDE = Map.of(
-        "us", "microseconds",
-        "ms", "milliseconds"
-    );
+    private static final Map<String, String> SUB_SECOND_UNIT_TO_DATE_BIN_STRIDE = Map.of("us", "microseconds", "ms", "milliseconds");
 
     /**
      * Locally-declared target operator for the sub-second {@code date_bin} path. Name
@@ -131,6 +128,11 @@ class SpanAdapter implements ScalarFunctionAdapter {
         SqlFunctionCategory.TIMEDATE
     );
 
+    // TODO: SPAN is a PPL-shaped UDF; matching by operator name and decomposing its operands here
+    // couples this backend adapter to the SQL/PPL plugin's frontend representation. Long term,
+    // Analytics-Engine should hand the backend a backend-neutral bucketing primitive (e.g. a typed
+    // DATE_BIN / FLOOR-divide expression already lowered upstream) so this adapter can disappear
+    // and we stop replicating SPAN's semantics per-backend.
     @Override
     public RexNode adapt(RexCall original, List<FieldStorageInfo> fieldStorage, RelOptCluster cluster) {
         if (!original.getOperator().getName().equalsIgnoreCase("SPAN")) {
@@ -203,7 +205,9 @@ class SpanAdapter implements ScalarFunctionAdapter {
         Object value = lit.getValue();
         long n;
         if (value instanceof BigDecimal bd) {
-            if (bd.scale() > 0 && bd.stripTrailingZeros().scale() > 0) {
+            // stripTrailingZeros canonicalises both forms — `1`, `1.0`, `1E2` all collapse
+            // to scale ≤ 0; any fractional component leaves scale > 0.
+            if (bd.stripTrailingZeros().scale() > 0) {
                 return null;
             }
             try {
@@ -212,11 +216,10 @@ class SpanAdapter implements ScalarFunctionAdapter {
                 return null;
             }
         } else if (value instanceof Number num) {
-            double d = num.doubleValue();
-            if (d != Math.floor(d)) {
+            if (!isIntegralDouble(num.doubleValue())) {
                 return null;
             }
-            n = (long) d;
+            n = (long) num.doubleValue();
         } else {
             return null;
         }
@@ -228,29 +231,20 @@ class SpanAdapter implements ScalarFunctionAdapter {
      * positive integer literal; {@code null} otherwise.
      */
     private static Long bucketSecondsIfPositiveInteger(RexNode interval, Long unitSeconds) {
-        if (unitSeconds == null || !(interval instanceof RexLiteral lit)) {
+        if (unitSeconds == null) {
             return null;
         }
-        Object value = lit.getValue();
-        long n;
-        if (value instanceof BigDecimal bd) {
-            if (bd.scale() > 0 && bd.stripTrailingZeros().scale() > 0) {
-                return null; // non-integer interval not supported
-            }
-            n = bd.longValueExact();
-        } else if (value instanceof Number num) {
-            double d = num.doubleValue();
-            if (d != Math.floor(d)) {
-                return null;
-            }
-            n = (long) d;
-        } else {
-            return null;
-        }
-        if (n <= 0) {
-            return null;
-        }
-        return n * unitSeconds;
+        Long n = extractPositiveInteger(interval);
+        return n == null ? null : n * unitSeconds;
+    }
+
+    /**
+     * True when {@code d} is finite and equal to its floor — i.e. a whole-number double
+     * with no fractional part. Centralises the rounding check used by the literal
+     * extractors above.
+     */
+    private static boolean isIntegralDouble(double d) {
+        return Double.isFinite(d) && d == Math.floor(d);
     }
 
     private static RexNode rewriteFixedLengthTimeBucket(RexBuilder rexBuilder, RexNode field, long bucketSeconds, RelDataType resultType) {

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/resources/opensearch_scalar_functions.yaml
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/resources/opensearch_scalar_functions.yaml
@@ -64,6 +64,21 @@ scalar_functions:
           - { value: string, name: "unit" }
           - { value: "date", name: "value" }
         return: date
+  - name: "date_bin"
+    description: >-
+      Bucket a timestamp into fixed-width windows of size `stride` (a string-form
+      interval like `"40 milliseconds"`) starting from the Unix epoch. Lowering
+      target for PPL's sub-second multi-unit time span — `span(field, N us)` and
+      `span(field, N ms)` with `N > 1` — rewritten by `SpanAdapter`. Larger
+      fixed-length units (`s`, `m`, `h`, `d`, `w`) take the cheaper integer-seconds
+      arithmetic path in the same adapter and don't reach this signature. The
+      arg shape mirrors `date_trunc`: string stride then precision_timestamp,
+      so isthmus matchKeys binds it the same way.
+    impls:
+      - args:
+          - { value: string, name: "stride" }
+          - { value: "precision_timestamp<P>", name: "source" }
+        return: precision_timestamp<P>
   - name: "convert_tz"
     description: >-
       Shift a timestamp from one timezone to another. IANA names and +/-HH:MM

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/SpanAdapterSubSecondTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/SpanAdapterSubSecondTests.java
@@ -1,0 +1,173 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion;
+
+import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.hep.HepPlanner;
+import org.apache.calcite.plan.hep.HepProgramBuilder;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlFunction;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.type.OperandTypes;
+import org.apache.calcite.sql.type.ReturnTypes;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+/**
+ * Unit tests for the sub-second multi-unit lowering path in {@link SpanAdapter}.
+ *
+ * <p>The fixed-second arithmetic path (s/m/h/d/w) is covered by the timechart-route
+ * end-to-end suite. This class targets the gap that the timechart PR explicitly left
+ * out — {@code us} and {@code ms} with {@code N > 1} — which is what dashboard logs-tab
+ * histogram queries hit when bucket width is sub-second (e.g.
+ * {@code span(@timestamp, 40ms)}).
+ */
+public class SpanAdapterSubSecondTests extends OpenSearchTestCase {
+
+    private static RexCall makeSpanCall(RexBuilder rexBuilder, RelDataType tsType, BigDecimal interval, String unit) {
+        RelDataTypeFactory typeFactory = rexBuilder.getTypeFactory();
+        RelDataType intType = typeFactory.createSqlType(SqlTypeName.INTEGER);
+        SqlFunction spanOp = new SqlFunction(
+            "SPAN",
+            SqlKind.OTHER_FUNCTION,
+            ReturnTypes.explicit(tsType),
+            null,
+            OperandTypes.VARIADIC,
+            SqlFunctionCategory.USER_DEFINED_FUNCTION
+        );
+        RexNode fieldRef = rexBuilder.makeInputRef(tsType, 0);
+        RexNode intervalLit = rexBuilder.makeLiteral(interval, intType);
+        RexNode unitLit = rexBuilder.makeLiteral(unit);
+        return (RexCall) rexBuilder.makeCall(spanOp, List.of(fieldRef, intervalLit, unitLit));
+    }
+
+    private static RelOptCluster newCluster() {
+        RelDataTypeFactory typeFactory = new JavaTypeFactoryImpl();
+        RexBuilder rexBuilder = new RexBuilder(typeFactory);
+        return RelOptCluster.create(new HepPlanner(new HepProgramBuilder().build()), rexBuilder);
+    }
+
+    /** The dashboard-trigger case: {@code span(@timestamp, 40ms)} lowers to
+     *  {@code date_bin("40 milliseconds", @timestamp)}. */
+    public void testMillisecondMultiUnitRewritesToDateBin() {
+        RelOptCluster cluster = newCluster();
+        RexBuilder rexBuilder = cluster.getRexBuilder();
+        RelDataType tsType = rexBuilder.getTypeFactory()
+            .createTypeWithNullability(rexBuilder.getTypeFactory().createSqlType(SqlTypeName.TIMESTAMP, 0), true);
+
+        RexCall original = makeSpanCall(rexBuilder, tsType, BigDecimal.valueOf(40), "ms");
+        RexNode adapted = new SpanAdapter().adapt(original, List.of(), cluster);
+
+        assertTrue("adapted node must be a RexCall, got " + adapted.getClass(), adapted instanceof RexCall);
+        RexCall call = (RexCall) adapted;
+        assertSame("sub-second multi-unit must lower to LOCAL_DATE_BIN_OP", SpanAdapter.LOCAL_DATE_BIN_OP, call.getOperator());
+        assertEquals("date_bin takes (stride, source)", 2, call.getOperands().size());
+        assertEquals(
+            "stride must be DataFusion's string-form interval with the count",
+            "40 milliseconds",
+            ((RexLiteral) call.getOperands().get(0)).getValueAs(String.class)
+        );
+    }
+
+    public void testMicrosecondMultiUnitRewritesToDateBin() {
+        RelOptCluster cluster = newCluster();
+        RexBuilder rexBuilder = cluster.getRexBuilder();
+        RelDataType tsType = rexBuilder.getTypeFactory()
+            .createTypeWithNullability(rexBuilder.getTypeFactory().createSqlType(SqlTypeName.TIMESTAMP, 0), true);
+
+        RexCall original = makeSpanCall(rexBuilder, tsType, BigDecimal.valueOf(250), "us");
+        RexCall adapted = (RexCall) new SpanAdapter().adapt(original, List.of(), cluster);
+
+        assertSame(SpanAdapter.LOCAL_DATE_BIN_OP, adapted.getOperator());
+        assertEquals(
+            "250 microseconds",
+            ((RexLiteral) adapted.getOperands().get(0)).getValueAs(String.class)
+        );
+    }
+
+    /** N == 1 for sub-second units must NOT take the date_bin path — date_trunc handles it. */
+    public void testSubSecondUnitOneStaysOnDateTruncPath() {
+        RelOptCluster cluster = newCluster();
+        RexBuilder rexBuilder = cluster.getRexBuilder();
+        RelDataType tsType = rexBuilder.getTypeFactory()
+            .createTypeWithNullability(rexBuilder.getTypeFactory().createSqlType(SqlTypeName.TIMESTAMP, 0), true);
+
+        RexCall original = makeSpanCall(rexBuilder, tsType, BigDecimal.ONE, "ms");
+        RexCall adapted = (RexCall) new SpanAdapter().adapt(original, List.of(), cluster);
+
+        assertEquals(
+            "N==1 ms stays on date_trunc (the cheaper path), NOT date_bin",
+            "DATE_TRUNC",
+            adapted.getOperator().getName()
+        );
+    }
+
+    /** Non-integer interval for sub-second units must fall through unchanged. The interval
+     *  needs a DECIMAL literal type so the fractional value survives; INTEGER would coerce
+     *  to 1 and accidentally hit the date_trunc path. */
+    public void testFractionalIntervalForSubSecondFallsThrough() {
+        RelDataTypeFactory typeFactory = new JavaTypeFactoryImpl();
+        RexBuilder rexBuilder = new RexBuilder(typeFactory);
+        RelOptCluster cluster = RelOptCluster.create(new HepPlanner(new HepProgramBuilder().build()), rexBuilder);
+        RelDataType tsType = typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.TIMESTAMP, 0), true);
+        RelDataType decType = typeFactory.createSqlType(SqlTypeName.DECIMAL, 5, 2);
+
+        SqlFunction spanOp = new SqlFunction(
+            "SPAN",
+            SqlKind.OTHER_FUNCTION,
+            ReturnTypes.explicit(tsType),
+            null,
+            OperandTypes.VARIADIC,
+            SqlFunctionCategory.USER_DEFINED_FUNCTION
+        );
+        RexNode fieldRef = rexBuilder.makeInputRef(tsType, 0);
+        RexNode fractionalInterval = rexBuilder.makeLiteral(new BigDecimal("2.5"), decType);
+        RexNode unitLit = rexBuilder.makeLiteral("ms");
+        RexCall original = (RexCall) rexBuilder.makeCall(spanOp, List.of(fieldRef, fractionalInterval, unitLit));
+
+        RexNode adapted = new SpanAdapter().adapt(original, List.of(), cluster);
+        assertSame("fractional interval must fall through unchanged", original, adapted);
+    }
+
+    /**
+     * The adapted call MUST preserve the original SPAN call's {@link RelDataType}. The
+     * enclosing Project caches its rowType from the pre-adaptation expression; any
+     * Calcite-inferred-type drift breaks {@code Project.isValid}'s compatibleTypes
+     * assertion during fragment conversion. Regression guard mirroring the same check
+     * on {@link SpanBucketAdapterTests#testAdaptedCallPreservesOriginalReturnType}.
+     */
+    public void testAdaptedDateBinCallPreservesOriginalReturnType() {
+        RelOptCluster cluster = newCluster();
+        RexBuilder rexBuilder = cluster.getRexBuilder();
+        // Use precision-3 nullable timestamp — distinct from LOCAL_DATE_BIN_OP's
+        // ARG1_NULLABLE inferred type if the operand was a different type.
+        RelDataType tsType = rexBuilder.getTypeFactory()
+            .createTypeWithNullability(rexBuilder.getTypeFactory().createSqlType(SqlTypeName.TIMESTAMP, 3), true);
+
+        RexCall original = makeSpanCall(rexBuilder, tsType, BigDecimal.valueOf(40), "ms");
+        assertEquals(tsType, original.getType());
+
+        RexNode adapted = new SpanAdapter().adapt(original, List.of(), cluster);
+        assertEquals(
+            "adapted date_bin call must declare the same type as the original SPAN call",
+            original.getType(),
+            adapted.getType()
+        );
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/SpanAdapterSubSecondTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/SpanAdapterSubSecondTests.java
@@ -95,10 +95,7 @@ public class SpanAdapterSubSecondTests extends OpenSearchTestCase {
         RexCall adapted = (RexCall) new SpanAdapter().adapt(original, List.of(), cluster);
 
         assertSame(SpanAdapter.LOCAL_DATE_BIN_OP, adapted.getOperator());
-        assertEquals(
-            "250 microseconds",
-            ((RexLiteral) adapted.getOperands().get(0)).getValueAs(String.class)
-        );
+        assertEquals("250 microseconds", ((RexLiteral) adapted.getOperands().get(0)).getValueAs(String.class));
     }
 
     /** N == 1 for sub-second units must NOT take the date_bin path — date_trunc handles it. */
@@ -111,11 +108,7 @@ public class SpanAdapterSubSecondTests extends OpenSearchTestCase {
         RexCall original = makeSpanCall(rexBuilder, tsType, BigDecimal.ONE, "ms");
         RexCall adapted = (RexCall) new SpanAdapter().adapt(original, List.of(), cluster);
 
-        assertEquals(
-            "N==1 ms stays on date_trunc (the cheaper path), NOT date_bin",
-            "DATE_TRUNC",
-            adapted.getOperator().getName()
-        );
+        assertEquals("N==1 ms stays on date_trunc (the cheaper path), NOT date_bin", "DATE_TRUNC", adapted.getOperator().getName());
     }
 
     /** Non-integer interval for sub-second units must fall through unchanged. The interval
@@ -164,10 +157,6 @@ public class SpanAdapterSubSecondTests extends OpenSearchTestCase {
         assertEquals(tsType, original.getType());
 
         RexNode adapted = new SpanAdapter().adapt(original, List.of(), cluster);
-        assertEquals(
-            "adapted date_bin call must declare the same type as the original SPAN call",
-            original.getType(),
-            adapted.getType()
-        );
+        assertEquals("adapted date_bin call must declare the same type as the original SPAN call", original.getType(), adapted.getType());
     }
 }

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/SpanTimeCommandIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/SpanTimeCommandIT.java
@@ -1,0 +1,182 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.qa;
+
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Self-contained integration test for PPL's time-mode {@code span} on the
+ * analytics-engine route. Sister to {@link SpanCommandIT}, which covers the
+ * numeric-span Rust kernel and explicitly scopes out date/time.
+ *
+ * <p>Exercises all three lowering paths in
+ * {@code org.opensearch.be.datafusion.SpanAdapter}:
+ *
+ * <ul>
+ *   <li><b>{@code interval == 1}, any unit:</b> rewritten to
+ *       {@code date_trunc(<unit>, field)}.</li>
+ *   <li><b>Fixed-length unit ({@code s}/{@code m}/{@code h}/{@code d}/{@code w})
+ *       with {@code interval > 1}:</b> bucketed via integer-seconds arithmetic
+ *       through {@code to_unixtime} / {@code from_unixtime}.</li>
+ *   <li><b>Sub-second unit ({@code us}/{@code ms}) with {@code interval > 1}:</b>
+ *       rewritten to DataFusion's native {@code date_bin("<N> <unit>", field)}.
+ *       The arithmetic path can't preserve sub-second precision because
+ *       {@code to_unixtime} returns BIGINT seconds.</li>
+ * </ul>
+ *
+ * <p>The sub-second multi-unit path is the dashboard-trigger case: the logs-tab
+ * histogram emits {@code span(@timestamp, 40ms)} and previously surfaced
+ * {@code Unable to convert call SPAN(precision_timestamp<0>?, i32, char<1>)}.
+ *
+ * <p>Uses a focused {@code span_time} dataset (5 rows with explicit sub-second
+ * timestamps) rather than the {@code calcs} dataset because {@code calcs}'s
+ * {@code datetime0} field has whole-second values and can't exercise 40ms
+ * bucketing meaningfully.
+ */
+public class SpanTimeCommandIT extends AnalyticsRestTestCase {
+
+    private static final Dataset DATASET = new Dataset("span_time", "span_time");
+
+    private static boolean dataProvisioned = false;
+
+    private void ensureDataProvisioned() throws IOException {
+        if (dataProvisioned == false) {
+            DatasetProvisioner.provision(client(), DATASET);
+            dataProvisioned = true;
+        }
+    }
+
+    /**
+     * Sample data summary (5 rows in {@code datasets/span_time/bulk.json}):
+     * <pre>
+     * 2026-05-20T00:07:56.114Z   INFO
+     * 2026-05-20T00:07:56.500Z   INFO
+     * 2026-05-20T00:07:57.200Z   WARN
+     * 2026-05-20T00:07:58.000Z   WARN
+     * 2026-05-20T00:08:00.000Z   INFO
+     * </pre>
+     */
+
+    // ── date_trunc path: N == 1 ───────────────────────────────────────────────
+
+    /** {@code span(@timestamp, 1h)} — all 5 rows fall in a single hour bucket. */
+    public void testSpanUnitOneHourLowersToDateTrunc() throws IOException {
+        long total = assertSingleHourBucketTotal();
+        assertEquals("all 5 rows fall in the 00:00 hour bucket", 5L, total);
+    }
+
+    private long assertSingleHourBucketTotal() throws IOException {
+        Map<String, Object> response = executePpl(
+            "source=" + DATASET.indexName + " | stats count() as c by span(`@timestamp`, 1h) as s"
+        );
+        @SuppressWarnings("unchecked")
+        List<List<Object>> rows = (List<List<Object>>) response.get("rows");
+        assertNotNull("rows missing", rows);
+        assertEquals("1h bucketing must collapse to a single bucket", 1, rows.size());
+        return ((Number) rows.get(0).get(0)).longValue();
+    }
+
+    // ── fixed-second arithmetic path: N > 1, unit in {s, m, h, d, w} ──────────
+
+    /** {@code span(@timestamp, 2h)} — all 5 rows fall in a single 2-hour bucket. */
+    public void testSpanMultiUnitHoursLowersToArithmetic() throws IOException {
+        Map<String, Object> response = executePpl(
+            "source=" + DATASET.indexName + " | stats count() as c by span(`@timestamp`, 2h) as s"
+        );
+        @SuppressWarnings("unchecked")
+        List<List<Object>> rows = (List<List<Object>>) response.get("rows");
+        assertNotNull("rows missing", rows);
+        assertEquals("2h bucketing must collapse to a single bucket", 1, rows.size());
+        assertEquals("all 5 rows fall in the 00:00 2h bucket", 5L, ((Number) rows.get(0).get(0)).longValue());
+    }
+
+    // ── date_bin path (new): N > 1, sub-second unit ───────────────────────────
+
+    /**
+     * {@code span(@timestamp, 40ms)} — the dashboard-trigger case. The 5 rows are spaced
+     * far enough apart that each lands in a distinct 40ms bucket. Previously failed with
+     * {@code Unable to convert call SPAN(...)} on the analytics-engine route.
+     */
+    public void testSpanFortyMillisecondsBucketsEachRowDistinctly() throws IOException {
+        Map<String, Object> response = executePpl(
+            "source=" + DATASET.indexName + " | stats count() as c by span(`@timestamp`, 40ms) as s"
+        );
+        @SuppressWarnings("unchecked")
+        List<List<Object>> rows = (List<List<Object>>) response.get("rows");
+        assertNotNull("rows missing", rows);
+        assertEquals("each of 5 rows must fall in a distinct 40ms bucket", 5, rows.size());
+
+        long total = 0;
+        Set<Object> distinctBuckets = new HashSet<>();
+        for (List<Object> r : rows) {
+            total += ((Number) r.get(0)).longValue();
+            distinctBuckets.add(r.get(1));
+            assertEquals("each 40ms bucket must contain exactly 1 row", 1L, ((Number) r.get(0)).longValue());
+        }
+        assertEquals("row total must equal the 5 source rows", 5L, total);
+        assertEquals("bucket labels must be distinct", 5, distinctBuckets.size());
+    }
+
+    /**
+     * {@code span(@timestamp, 250us)} — sub-second microsecond bucket. With 5 rows spaced
+     * milliseconds apart, each must land in its own 250us bucket. Exercises the same
+     * date_bin path as ms, but with the second sub-second unit.
+     */
+    public void testSpanMicrosecondsBucketsEachRowDistinctly() throws IOException {
+        Map<String, Object> response = executePpl(
+            "source=" + DATASET.indexName + " | stats count() as c by span(`@timestamp`, 250us) as s"
+        );
+        @SuppressWarnings("unchecked")
+        List<List<Object>> rows = (List<List<Object>>) response.get("rows");
+        assertNotNull("rows missing", rows);
+        assertEquals("each of 5 rows must fall in a distinct 250us bucket", 5, rows.size());
+    }
+
+    /**
+     * Regression guard: {@code span(@timestamp, 1ms)} must stay on the cheaper
+     * {@code date_trunc} path (N == 1, any unit) rather than the new
+     * {@code date_bin} sub-second path. The unit is "ms" but N is 1, so the
+     * adapter must check {@code isUnitInterval} before falling through to
+     * sub-second handling.
+     */
+    public void testSpanOneMillisecondStaysOnDateTruncPath() throws IOException {
+        Map<String, Object> response = executePpl(
+            "source=" + DATASET.indexName + " | stats count() as c by span(`@timestamp`, 1ms) as s"
+        );
+        @SuppressWarnings("unchecked")
+        List<List<Object>> rows = (List<List<Object>>) response.get("rows");
+        assertNotNull("rows missing", rows);
+        // All source @timestamp values have distinct millisecond values, so 1ms truncation
+        // produces 5 buckets, one per row. The point of this assertion is that the query
+        // executes successfully — the precise bucket layout is the same as 250us in this
+        // dataset, just resolved through a different lowering path.
+        long total = 0;
+        for (List<Object> r : rows) {
+            total += ((Number) r.get(0)).longValue();
+        }
+        assertEquals("row total must equal the 5 source rows", 5L, total);
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────────
+
+    private Map<String, Object> executePpl(String ppl) throws IOException {
+        ensureDataProvisioned();
+        Request request = new Request("POST", "/_analytics/ppl");
+        request.setJsonEntity("{\"query\": \"" + escapeJson(ppl) + "\"}");
+        Response response = client().performRequest(request);
+        return assertOkAndParse(response, "PPL: " + ppl);
+    }
+}

--- a/sandbox/qa/analytics-engine-rest/src/test/resources/datasets/span_time/bulk.json
+++ b/sandbox/qa/analytics-engine-rest/src/test/resources/datasets/span_time/bulk.json
@@ -1,0 +1,11 @@
+{"index":{}}
+{"@timestamp":"2026-05-20T00:07:56.114Z","level":"INFO"}
+{"index":{}}
+{"@timestamp":"2026-05-20T00:07:56.500Z","level":"INFO"}
+{"index":{}}
+{"@timestamp":"2026-05-20T00:07:57.200Z","level":"WARN"}
+{"index":{}}
+{"@timestamp":"2026-05-20T00:07:58.000Z","level":"WARN"}
+{"index":{}}
+{"@timestamp":"2026-05-20T00:08:00.000Z","level":"INFO"}
+

--- a/sandbox/qa/analytics-engine-rest/src/test/resources/datasets/span_time/mapping.json
+++ b/sandbox/qa/analytics-engine-rest/src/test/resources/datasets/span_time/mapping.json
@@ -1,0 +1,16 @@
+{
+    "settings": {
+        "number_of_shards": 1,
+        "number_of_replicas": 0
+    },
+    "mappings" : {
+        "properties" : {
+            "@timestamp" : {
+                "type" : "date"
+            },
+            "level" : {
+                "type" : "keyword"
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What this fixes

Dashboard logs-tab histogram queries that bucket timestamps into
**sub-second** widths (e.g. `span(@timestamp, 40ms)`,
`span(@timestamp, 250us)`) fail on the analytics-engine route against
parquet-backed indices with:

```
Unable to convert call SPAN(precision_timestamp<0>?, i32, char<1>)
```

## Why it happens

`SpanAdapter` already had two lowering paths for time-mode SPAN:

1. `interval == 1`, any unit → `date_trunc(<unit>, field)` (predates this PR)
2. fixed-second unit (`s`, `m`, `h`, `d`, `w`) with `interval > 1` →
   integer-seconds arithmetic via `to_unixtime / from_unixtime` (added by
   #21747)

Sub-second units (`us`, `ms`) with `interval > 1` are in the gap between
those two paths. The arithmetic approach can't be reused because
`to_unixtime` returns BIGINT seconds and would truncate sub-second
precision. So `SPAN(t, 40, 'ms')` falls through unchanged and isthmus
then fails to bind the PPL SPAN UDF.

## What this PR changes

Adds a third lowering path checked after the existing two:

- `interval == 1`, any unit       → `date_trunc(<unit>, field)`             *(unchanged)*
- fixed-second + `interval > 1`   → integer-seconds arithmetic              *(#21747, unchanged)*
- **sub-second + `interval > 1`   → `date_bin("<N> <unit>", field)`**         *(new)*

DataFusion's `date_bin(stride, source)` accepts a string-form interval
stride like `"40 milliseconds"` or `"250 microseconds"` natively. Emitting
the stride as a plain string literal avoids substrait interval-type
plumbing that would otherwise be needed for sub-second precision, and
matches how DataFusion's native parser accepts strides at the SQL
surface.

Multi-unit month/quarter/year still fall through unchanged — calendar-
dependent bucket length needs `date_bin` with an interval-month stride;
tracked separately.

### Wiring

1. **`opensearch_scalar_functions.yaml`** — new `date_bin` entry with
   signature `(stride: string, source: precision_timestamp<P>) -> precision_timestamp<P>`.
2. **`SpanAdapter.java`** — `SUB_SECOND_UNIT_TO_DATE_BIN_STRIDE` map plus a
   `LOCAL_DATE_BIN_OP` Calcite `SqlFunction`, used by the new branch in
   `adapt()`.
3. **`DataFusionFragmentConvertor.java`** —
   `FunctionMappings.s(SpanAdapter.LOCAL_DATE_BIN_OP, "date_bin")`.

## Test plan

### Unit (`SpanAdapterSubSecondTests`, 5/5 pass)

- `testMillisecondMultiUnitRewritesToDateBin` — `40ms` lowers to
  `date_bin("40 milliseconds", field)`.
- `testMicrosecondMultiUnitRewritesToDateBin` — `250us` lowers to
  `date_bin("250 microseconds", field)`.
- `testSubSecondUnitOneStaysOnDateTruncPath` — `N == 1` for `us`/`ms`
  keeps using the cheaper `date_trunc` path (regression guard).
- `testFractionalIntervalForSubSecondFallsThrough` — non-integer
  intervals are not rewritten.
- `testAdaptedDateBinCallPreservesOriginalReturnType` — Project rowType
  invariant.

Full `:sandbox:plugins:analytics-backend-datafusion:test` suite passes
(no regression of the timechart fixed-second arithmetic path).

### QA integration (`SpanTimeCommandIT`, 5/5 pass)

Self-contained REST test in `sandbox/qa/analytics-engine-rest` against
a parquet-backed cluster, exercising the full PPL → CalciteRelNodeVisitor
→ SpanAdapter → Substrait → DataFusion pipeline. Uses a focused 5-row
`span_time` dataset with explicit sub-second timestamps (the existing
`calcs` dataset is whole-second only).

| Test | Path | Result |
|---|---|---|
| `testSpanUnitOneHourLowersToDateTrunc` | date_trunc | 5 rows in one 1h bucket |
| `testSpanMultiUnitHoursLowersToArithmetic` | arithmetic (#21747) | 5 rows in one 2h bucket |
| `testSpanFortyMillisecondsBucketsEachRowDistinctly` | **date_bin (new)** | 5 distinct 40ms buckets |
| `testSpanMicrosecondsBucketsEachRowDistinctly` | **date_bin (new)** | 5 distinct 250us buckets |
| `testSpanOneMillisecondStaysOnDateTruncPath` | date_trunc | regression guard: `N == 1 ms` stays on cheaper path |

Run via:

```bash
./gradlew :sandbox:qa:analytics-engine-rest:integTest \
  -Dsandbox.enabled=true --tests "*SpanTimeCommandIT"
```