### PR TITLE
[analytics-engine] DatePartAdapters: coerce VARCHAR operand to TIMESTAMP and validate string literals

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatePartAdapters.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatePartAdapters.java
@@ -8,21 +8,84 @@
 
 package org.opensearch.be.datafusion;
 
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.fun.SqlLibraryOperators;
+import org.apache.calcite.sql.type.SqlTypeFamily;
+import org.apache.calcite.sql.type.SqlTypeName;
 import org.opensearch.analytics.spi.AbstractNameMappingAdapter;
+import org.opensearch.analytics.spi.FieldStorageInfo;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
  * Date-part extractor adapters — rewrite {@code FN(ts)} to {@code date_part('<unit>', ts)}.
  * Alias pairs (e.g. MONTH_OF_YEAR → MONTH) share an adapter instance at registration.
  *
+ * <p>Operand coercion: PPL allows bare string-literal datetime arguments
+ * (e.g. {@code DAY('2020-09-16')}). Calcite types those operands as
+ * {@code VARCHAR}, but {@code opensearch_scalar_functions.yaml} declares
+ * {@code date_part} only for {@code (string, precision_timestamp<P>)} and
+ * {@code (string, date)}. Without coercion, isthmus' signature matcher fails
+ * with {@code "Unable to convert call DATE_PART(string, string)"}. This adapter
+ * wraps any character-family operand in {@code CAST(operand AS TIMESTAMP)} so
+ * the call resolves to the precision_timestamp impl. DataFusion's CAST kernel
+ * parses ISO-8601 datetime strings; malformed inputs surface as a runtime
+ * Arrow cast error from the engine.
+ *
  * @opensearch.internal
  */
 final class DatePartAdapters extends AbstractNameMappingAdapter {
 
+    private final String unit;
+
     DatePartAdapters(String unit) {
         super(SqlLibraryOperators.DATE_PART, List.of(unit), List.of());
+        this.unit = unit;
+    }
+
+    @Override
+    public RexNode adapt(RexCall original, List<FieldStorageInfo> fieldStorage, RelOptCluster cluster) {
+        if (original.getOperands().stream().noneMatch(DatePartAdapters::isCharacterOperand)) {
+            return super.adapt(original, fieldStorage, cluster);
+        }
+        RexBuilder rexBuilder = cluster.getRexBuilder();
+        List<RexNode> coerced = new ArrayList<>(original.getOperands().size());
+        for (RexNode operand : original.getOperands()) {
+            coerced.add(isCharacterOperand(operand) ? castToTimestamp(operand, cluster) : operand);
+        }
+        RelDataType unitType = rexBuilder.getTypeFactory().createSqlType(SqlTypeName.VARCHAR);
+        List<RexNode> args = new ArrayList<>(coerced.size() + 1);
+        args.add(rexBuilder.makeLiteral(unit, unitType, true));
+        args.addAll(coerced);
+        return rexBuilder.makeCall(original.getType(), SqlLibraryOperators.DATE_PART, args);
+    }
+
+    private static boolean isCharacterOperand(RexNode operand) {
+        return SqlTypeFamily.CHARACTER.contains(operand.getType());
+    }
+
+    private static RexNode castToTimestamp(RexNode operand, RelOptCluster cluster) {
+        RelDataTypeFactory factory = cluster.getTypeFactory();
+        RelDataType timestampType = factory.createTypeWithNullability(
+            factory.createSqlType(SqlTypeName.TIMESTAMP),
+            operand.getType().isNullable()
+        );
+        return cluster.getRexBuilder().makeCast(timestampType, operand);
+    }
+
+    /**
+     * Shared coercion helper for sibling adapters ({@link DayOfWeekAdapter}, {@link SecondAdapter})
+     * that build {@code date_part('<unit>', operand)} calls directly. Wraps a character-family
+     * operand in {@code CAST(_ AS TIMESTAMP)}; non-character operands are returned unchanged.
+     */
+    static RexNode coerceCharacterOperandToTimestamp(RexNode operand, RelOptCluster cluster) {
+        return isCharacterOperand(operand) ? castToTimestamp(operand, cluster) : operand;
     }
 
     static DatePartAdapters year() {

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatePartAdapters.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatePartAdapters.java
@@ -13,6 +13,7 @@ import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.fun.SqlLibraryOperators;
 import org.apache.calcite.sql.type.SqlTypeFamily;
@@ -20,8 +21,13 @@ import org.apache.calcite.sql.type.SqlTypeName;
 import org.opensearch.analytics.spi.AbstractNameMappingAdapter;
 import org.opensearch.analytics.spi.FieldStorageInfo;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 /**
  * Date-part extractor adapters — rewrite {@code FN(ts)} to {@code date_part('<unit>', ts)}.
@@ -57,7 +63,12 @@ final class DatePartAdapters extends AbstractNameMappingAdapter {
         RexBuilder rexBuilder = cluster.getRexBuilder();
         List<RexNode> coerced = new ArrayList<>(original.getOperands().size());
         for (RexNode operand : original.getOperands()) {
-            coerced.add(isCharacterOperand(operand) ? castToTimestamp(operand, cluster) : operand);
+            if (isCharacterOperand(operand)) {
+                validateDatetimeLiteral(operand);
+                coerced.add(castToTimestamp(operand, cluster));
+            } else {
+                coerced.add(operand);
+            }
         }
         RelDataType unitType = rexBuilder.getTypeFactory().createSqlType(SqlTypeName.VARCHAR);
         List<RexNode> args = new ArrayList<>(coerced.size() + 1);
@@ -83,9 +94,63 @@ final class DatePartAdapters extends AbstractNameMappingAdapter {
      * Shared coercion helper for sibling adapters ({@link DayOfWeekAdapter}, {@link SecondAdapter})
      * that build {@code date_part('<unit>', operand)} calls directly. Wraps a character-family
      * operand in {@code CAST(_ AS TIMESTAMP)}; non-character operands are returned unchanged.
+     * String {@link RexLiteral} operands are eagerly validated to surface the legacy
+     * {@code "unsupported format"} error at plan time (see {@link #validateDatetimeLiteral}).
      */
     static RexNode coerceCharacterOperandToTimestamp(RexNode operand, RelOptCluster cluster) {
-        return isCharacterOperand(operand) ? castToTimestamp(operand, cluster) : operand;
+        if (!isCharacterOperand(operand)) {
+            return operand;
+        }
+        validateDatetimeLiteral(operand);
+        return castToTimestamp(operand, cluster);
+    }
+
+    /**
+     * Eagerly parses string {@link RexLiteral} operands so an invalid literal surfaces as a
+     * coordinator-side {@link IllegalArgumentException} during planning, before the value reaches
+     * DataFusion's CAST kernel. The native error message ({@code "Arrow error: Parser error: ..."})
+     * is dropped by Flight RPC serialization on the worker→coordinator hop, so without this check
+     * users see {@code "Failed to start streaming fragment on ..."} instead of the legacy
+     * {@code "timestamp:<v> in unsupported format"} wording.
+     *
+     * <p>Non-literal operands (column refs, expressions) and NULL literals pass through — column
+     * value validation is a separate concern (Arrow CAST per-row error handling, tracked
+     * separately).
+     *
+     * <p>Accept-set mirrors legacy {@code DateTimeParser.parse}: try {@link LocalDateTime} (date+time
+     * with optional nanos), {@link LocalDate} (bare date), {@link LocalTime} (bare time), throw on
+     * all-failed. Same try/catch-fall-through shape used by
+     * {@link TimestampFunctionAdapter#parseTimestamp}.
+     */
+    static void validateDatetimeLiteral(RexNode operand) {
+        if (!(operand instanceof RexLiteral literal)) {
+            return;
+        }
+        String value = literal.getValueAs(String.class);
+        if (value == null) {
+            return;
+        }
+        try {
+            LocalDateTime.parse(value.replace(' ', 'T'));
+            return;
+        } catch (DateTimeParseException ignored) {}
+
+        try {
+            LocalDate.parse(value);
+            return;
+        } catch (DateTimeParseException ignored) {}
+
+        try {
+            LocalTime.parse(value);
+            return;
+        } catch (DateTimeParseException ignored) {
+            // SQL plugin's ErrorMessageFactory.unwrapCause walks to the deepest cause for the response
+            // type/details, so attaching DateTimeParseException as cause would surface its stock JDK
+            // message instead of this one. Mirrors legacy DateTimeParser.parse, which throws causeless.
+            throw new IllegalArgumentException(
+                String.format(Locale.ROOT, "timestamp:%s in unsupported format, please use 'yyyy-MM-dd HH:mm:ss[.SSSSSSSSS]'", value)
+            );
+        }
     }
 
     static DatePartAdapters year() {

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DayOfWeekAdapter.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DayOfWeekAdapter.java
@@ -27,6 +27,10 @@ import java.util.List;
  * MySQL/PPL uses 1=Sun..7=Sat but DataFusion/Postgres {@code date_part('dow')} returns 0..6, so we
  * add 1 and cast back to the original call's return type.
  *
+ * <p>VARCHAR operands (bare PPL string literals like {@code DAYOFWEEK('2020-09-16')}) are coerced
+ * to TIMESTAMP so the {@code (string, precision_timestamp<P>)} signature resolves — same rationale
+ * as {@link DatePartAdapters}.
+ *
  * @opensearch.internal
  */
 class DayOfWeekAdapter implements ScalarFunctionAdapter {
@@ -39,7 +43,8 @@ class DayOfWeekAdapter implements ScalarFunctionAdapter {
         RexBuilder rexBuilder = cluster.getRexBuilder();
         RelDataType varchar = cluster.getTypeFactory().createSqlType(SqlTypeName.VARCHAR);
         RexNode partLiteral = rexBuilder.makeLiteral("dow", varchar, true);
-        RexNode datePart = rexBuilder.makeCall(SqlLibraryOperators.DATE_PART, partLiteral, original.getOperands().get(0));
+        RexNode operand = DatePartAdapters.coerceCharacterOperandToTimestamp(original.getOperands().get(0), cluster);
+        RexNode datePart = rexBuilder.makeCall(SqlLibraryOperators.DATE_PART, partLiteral, operand);
         RexNode sum = rexBuilder.makeCall(SqlStdOperatorTable.PLUS, datePart, rexBuilder.makeExactLiteral(BigDecimal.ONE));
         return rexBuilder.makeCast(original.getType(), sum);
     }

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/SecondAdapter.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/SecondAdapter.java
@@ -27,6 +27,10 @@ import java.util.List;
  * intermediate CAST to DOUBLE is needed because our substrait YAML declares date_part/floor as
  * fp64-only while Calcite's inference returns BIGINT for {@code part='second'}.
  *
+ * <p>VARCHAR operands (bare PPL string literals like {@code SECOND('2020-09-16 17:30:45')}) are
+ * coerced to TIMESTAMP so the {@code (string, precision_timestamp<P>)} signature resolves — same
+ * rationale as {@link DatePartAdapters}.
+ *
  * @opensearch.internal
  */
 class SecondAdapter implements ScalarFunctionAdapter {
@@ -39,7 +43,8 @@ class SecondAdapter implements ScalarFunctionAdapter {
         RexBuilder rexBuilder = cluster.getRexBuilder();
         RelDataType varchar = cluster.getTypeFactory().createSqlType(SqlTypeName.VARCHAR);
         RexNode partLiteral = rexBuilder.makeLiteral("second", varchar, true);
-        RexNode datePart = rexBuilder.makeCall(SqlLibraryOperators.DATE_PART, partLiteral, original.getOperands().get(0));
+        RexNode operand = DatePartAdapters.coerceCharacterOperandToTimestamp(original.getOperands().get(0), cluster);
+        RexNode datePart = rexBuilder.makeCall(SqlLibraryOperators.DATE_PART, partLiteral, operand);
         RelDataType doubleType = cluster.getTypeFactory()
             .createTypeWithNullability(cluster.getTypeFactory().createSqlType(SqlTypeName.DOUBLE), datePart.getType().isNullable());
         RexNode datePartDouble = rexBuilder.makeCast(doubleType, datePart);

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatePartAdaptersTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatePartAdaptersTests.java
@@ -1,0 +1,144 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion;
+
+import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.volcano.VolcanoPlanner;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlFunction;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.fun.SqlLibraryOperators;
+import org.apache.calcite.sql.type.OperandTypes;
+import org.apache.calcite.sql.type.ReturnTypes;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.List;
+
+/**
+ * Unit tests for {@link DatePartAdapters}. Covers the VARCHAR-operand coercion
+ * that wraps bare-string PPL call shapes (e.g. {@code DAY('2020-09-16')}) so
+ * the rewritten {@code date_part('day', CAST(_ AS TIMESTAMP))} resolves against
+ * the {@code (string, precision_timestamp<P>)} signature in
+ * {@code opensearch_scalar_functions.yaml}.
+ */
+public class DatePartAdaptersTests extends OpenSearchTestCase {
+
+    private final RelDataTypeFactory typeFactory = new JavaTypeFactoryImpl();
+    private final RexBuilder rexBuilder = new RexBuilder(typeFactory);
+    private final RelOptCluster cluster = RelOptCluster.create(new VolcanoPlanner(), rexBuilder);
+
+    /** PPL-style nullary-arg DAY operator stand-in; the adapter only inspects the operand types. */
+    private SqlFunction pplDay() {
+        return new SqlFunction(
+            "DAY",
+            SqlKind.OTHER_FUNCTION,
+            ReturnTypes.INTEGER_NULLABLE,
+            null,
+            OperandTypes.ANY,
+            SqlFunctionCategory.TIMEDATE
+        );
+    }
+
+    /** TIMESTAMP operand passes through unchanged — the original two-arg shape from the parent. */
+    public void testTimestampOperandPassesThrough() {
+        RexNode ts = rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.TIMESTAMP), 0);
+        RexCall original = (RexCall) rexBuilder.makeCall(pplDay(), List.of(ts));
+
+        RexCall adapted = (RexCall) DatePartAdapters.day().adapt(original, List.of(), cluster);
+
+        assertSame(SqlLibraryOperators.DATE_PART, adapted.getOperator());
+        assertEquals(2, adapted.getOperands().size());
+        assertEquals("day", ((RexLiteral) adapted.getOperands().get(0)).getValueAs(String.class));
+        assertSame("TIMESTAMP operand must not be wrapped in CAST", ts, adapted.getOperands().get(1));
+    }
+
+    /** DATE operand passes through unchanged — the {@code (string, date)} impl handles it. */
+    public void testDateOperandPassesThrough() {
+        RexNode date = rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.DATE), 0);
+        RexCall original = (RexCall) rexBuilder.makeCall(pplDay(), List.of(date));
+
+        RexCall adapted = (RexCall) DatePartAdapters.day().adapt(original, List.of(), cluster);
+
+        assertSame(date, adapted.getOperands().get(1));
+    }
+
+    /** VARCHAR operand is wrapped in {@code CAST(_ AS TIMESTAMP)}. */
+    public void testVarcharLiteralOperandIsCastToTimestamp() {
+        RelDataType varcharType = typeFactory.createSqlType(SqlTypeName.VARCHAR);
+        RexNode literal = rexBuilder.makeLiteral("2020-09-16", varcharType, true);
+        RexCall original = (RexCall) rexBuilder.makeCall(pplDay(), List.of(literal));
+
+        RexCall adapted = (RexCall) DatePartAdapters.day().adapt(original, List.of(), cluster);
+
+        RexNode wrapped = adapted.getOperands().get(1);
+        assertTrue("VARCHAR operand must be wrapped", wrapped instanceof RexCall);
+        RexCall cast = (RexCall) wrapped;
+        assertEquals("rewrite must use CAST", SqlKind.CAST, cast.getKind());
+        assertSame(SqlTypeName.TIMESTAMP, cast.getType().getSqlTypeName());
+        assertSame("inner operand of CAST must be the original literal", literal, cast.getOperands().get(0));
+    }
+
+    /** CHAR (fixed-width) operand is also coerced — both are SqlTypeFamily.CHARACTER. */
+    public void testCharOperandIsCastToTimestamp() {
+        RelDataType charType = typeFactory.createSqlType(SqlTypeName.CHAR, 10);
+        RexNode field = rexBuilder.makeInputRef(charType, 0);
+        RexCall original = (RexCall) rexBuilder.makeCall(pplDay(), List.of(field));
+
+        RexCall adapted = (RexCall) DatePartAdapters.day().adapt(original, List.of(), cluster);
+
+        RexNode wrapped = adapted.getOperands().get(1);
+        assertEquals(SqlKind.CAST, ((RexCall) wrapped).getKind());
+        assertSame(SqlTypeName.TIMESTAMP, wrapped.getType().getSqlTypeName());
+    }
+
+    /** Coerced CAST preserves operand nullability so the outer call's nullable return type stays consistent. */
+    public void testCastPreservesNullability() {
+        RelDataType nullableVarchar = typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.VARCHAR), true);
+        RexNode field = rexBuilder.makeInputRef(nullableVarchar, 0);
+        RexCall original = (RexCall) rexBuilder.makeCall(pplDay(), List.of(field));
+
+        RexCall adapted = (RexCall) DatePartAdapters.day().adapt(original, List.of(), cluster);
+
+        assertTrue("CAST output must remain nullable", adapted.getOperands().get(1).getType().isNullable());
+    }
+
+    /** Each unit factory threads through its own prepended literal. */
+    public void testUnitLiteralPropagatedFromFactory() {
+        RexNode ts = rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.TIMESTAMP), 0);
+        RexCall original = (RexCall) rexBuilder.makeCall(pplDay(), List.of(ts));
+
+        RexCall adaptedYear = (RexCall) DatePartAdapters.year().adapt(original, List.of(), cluster);
+        RexCall adaptedQuarter = (RexCall) DatePartAdapters.quarter().adapt(original, List.of(), cluster);
+        RexCall adaptedDoy = (RexCall) DatePartAdapters.dayOfYear().adapt(original, List.of(), cluster);
+
+        assertEquals("year", ((RexLiteral) adaptedYear.getOperands().get(0)).getValueAs(String.class));
+        assertEquals("quarter", ((RexLiteral) adaptedQuarter.getOperands().get(0)).getValueAs(String.class));
+        assertEquals("doy", ((RexLiteral) adaptedDoy.getOperands().get(0)).getValueAs(String.class));
+    }
+
+    /** Coercion path also works when invoked through the unit factory for a non-default unit. */
+    public void testVarcharCoercionWithHourUnit() {
+        RelDataType varcharType = typeFactory.createSqlType(SqlTypeName.VARCHAR);
+        RexNode literal = rexBuilder.makeLiteral("2020-09-16 17:30:00", varcharType, true);
+        RexCall original = (RexCall) rexBuilder.makeCall(pplDay(), List.of(literal));
+
+        RexCall adapted = (RexCall) DatePartAdapters.hour().adapt(original, List.of(), cluster);
+
+        assertEquals("hour", ((RexLiteral) adapted.getOperands().get(0)).getValueAs(String.class));
+        assertEquals(SqlKind.CAST, ((RexCall) adapted.getOperands().get(1)).getKind());
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatePartAdaptersTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatePartAdaptersTests.java
@@ -141,4 +141,55 @@ public class DatePartAdaptersTests extends OpenSearchTestCase {
         assertEquals("hour", ((RexLiteral) adapted.getOperands().get(0)).getValueAs(String.class));
         assertEquals(SqlKind.CAST, ((RexCall) adapted.getOperands().get(1)).getKind());
     }
+
+    /**
+     * Invalid string literals (month 13, second 61, garbage) must throw at plan time so the
+     * legacy "unsupported format" wording reaches the HTTP body. The Arrow CAST kernel error
+     * does not survive Flight RPC serialization on the worker→coordinator hop.
+     */
+    public void testInvalidDateLiteralRejectedAtPlanTime() {
+        assertInvalidLiteralRejected("2025-13-02"); // month out of range
+        assertInvalidLiteralRejected("2025-12-01 15:02:61"); // second out of range
+        assertInvalidLiteralRejected("16:00:61"); // bare time, second out of range
+        assertInvalidLiteralRejected("not-a-date");
+    }
+
+    /** NULL literal passes through — column-value semantics handle null at runtime. */
+    public void testNullVarcharLiteralPassesThrough() {
+        RelDataType nullableVarchar = typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.VARCHAR), true);
+        RexNode nullLit = rexBuilder.makeNullLiteral(nullableVarchar);
+        RexCall original = (RexCall) rexBuilder.makeCall(pplDay(), List.of(nullLit));
+
+        RexCall adapted = (RexCall) DatePartAdapters.day().adapt(original, List.of(), cluster);
+
+        assertSame(SqlLibraryOperators.DATE_PART, adapted.getOperator());
+    }
+
+    /** Non-literal VARCHAR (column ref) is not eagerly validated — only literals are. */
+    public void testVarcharColumnRefNotValidated() {
+        RelDataType varcharType = typeFactory.createSqlType(SqlTypeName.VARCHAR);
+        RexNode columnRef = rexBuilder.makeInputRef(varcharType, 0);
+        RexCall original = (RexCall) rexBuilder.makeCall(pplDay(), List.of(columnRef));
+
+        // Must not throw despite the value being unknown at plan time.
+        RexCall adapted = (RexCall) DatePartAdapters.day().adapt(original, List.of(), cluster);
+
+        assertEquals(SqlKind.CAST, ((RexCall) adapted.getOperands().get(1)).getKind());
+    }
+
+    private void assertInvalidLiteralRejected(String value) {
+        RelDataType varcharType = typeFactory.createSqlType(SqlTypeName.VARCHAR);
+        RexNode literal = rexBuilder.makeLiteral(value, varcharType, true);
+        RexCall original = (RexCall) rexBuilder.makeCall(pplDay(), List.of(literal));
+
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> DatePartAdapters.day().adapt(original, List.of(), cluster)
+        );
+        assertTrue(
+            "message must contain 'unsupported format' for input [" + value + "], got: " + e.getMessage(),
+            e.getMessage().contains("unsupported format")
+        );
+        assertTrue("message must echo the offending input [" + value + "]", e.getMessage().contains(value));
+    }
 }

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DayOfWeekAdapterTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DayOfWeekAdapterTests.java
@@ -1,0 +1,86 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion;
+
+import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.volcano.VolcanoPlanner;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlFunction;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.fun.SqlLibraryOperators;
+import org.apache.calcite.sql.type.OperandTypes;
+import org.apache.calcite.sql.type.ReturnTypes;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.List;
+
+/**
+ * VARCHAR-coercion coverage for {@link DayOfWeekAdapter}. Pre-fix this adapter
+ * built {@code date_part('dow', <varchar>)} which the substrait matcher rejected
+ * as {@code DATE_PART(string, string)}.
+ */
+public class DayOfWeekAdapterTests extends OpenSearchTestCase {
+
+    private final RelDataTypeFactory typeFactory = new JavaTypeFactoryImpl();
+    private final RexBuilder rexBuilder = new RexBuilder(typeFactory);
+    private final RelOptCluster cluster = RelOptCluster.create(new VolcanoPlanner(), rexBuilder);
+
+    private SqlFunction pplDayOfWeek() {
+        return new SqlFunction(
+            "DAYOFWEEK",
+            SqlKind.OTHER_FUNCTION,
+            ReturnTypes.INTEGER_NULLABLE,
+            null,
+            OperandTypes.ANY,
+            SqlFunctionCategory.TIMEDATE
+        );
+    }
+
+    private RexCall innerDatePart(RexCall adapted) {
+        // adapted shape: CAST(PLUS(date_part('dow', _), 1) AS retType)
+        RexCall outerCast = adapted;
+        assertEquals(SqlKind.CAST, outerCast.getKind());
+        RexCall plus = (RexCall) outerCast.getOperands().get(0);
+        assertEquals(SqlKind.PLUS, plus.getKind());
+        RexCall datePart = (RexCall) plus.getOperands().get(0);
+        assertSame(SqlLibraryOperators.DATE_PART, datePart.getOperator());
+        return datePart;
+    }
+
+    public void testTimestampOperandPassesThrough() {
+        RexNode ts = rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.TIMESTAMP), 0);
+        RexCall original = (RexCall) rexBuilder.makeCall(pplDayOfWeek(), List.of(ts));
+
+        RexCall adapted = (RexCall) new DayOfWeekAdapter().adapt(original, List.of(), cluster);
+
+        assertSame("TIMESTAMP operand must not be wrapped in CAST", ts, innerDatePart(adapted).getOperands().get(1));
+    }
+
+    public void testVarcharOperandIsCastToTimestamp() {
+        RelDataType varcharType = typeFactory.createSqlType(SqlTypeName.VARCHAR);
+        RexNode literal = rexBuilder.makeLiteral("2020-09-16", varcharType, true);
+        RexCall original = (RexCall) rexBuilder.makeCall(pplDayOfWeek(), List.of(literal));
+
+        RexCall adapted = (RexCall) new DayOfWeekAdapter().adapt(original, List.of(), cluster);
+
+        RexNode operand = innerDatePart(adapted).getOperands().get(1);
+        assertTrue("VARCHAR operand must be wrapped", operand instanceof RexCall);
+        RexCall cast = (RexCall) operand;
+        assertEquals(SqlKind.CAST, cast.getKind());
+        assertSame(SqlTypeName.TIMESTAMP, cast.getType().getSqlTypeName());
+        assertSame(literal, cast.getOperands().get(0));
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DayOfWeekAdapterTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DayOfWeekAdapterTests.java
@@ -83,4 +83,17 @@ public class DayOfWeekAdapterTests extends OpenSearchTestCase {
         assertSame(SqlTypeName.TIMESTAMP, cast.getType().getSqlTypeName());
         assertSame(literal, cast.getOperands().get(0));
     }
+
+    public void testInvalidLiteralRejectedAtPlanTime() {
+        RelDataType varcharType = typeFactory.createSqlType(SqlTypeName.VARCHAR);
+        RexNode literal = rexBuilder.makeLiteral("2025-13-02", varcharType, true);
+        RexCall original = (RexCall) rexBuilder.makeCall(pplDayOfWeek(), List.of(literal));
+
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> new DayOfWeekAdapter().adapt(original, List.of(), cluster)
+        );
+        assertTrue(e.getMessage().contains("unsupported format"));
+        assertTrue(e.getMessage().contains("2025-13-02"));
+    }
 }

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/SecondAdapterTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/SecondAdapterTests.java
@@ -1,0 +1,88 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion;
+
+import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.volcano.VolcanoPlanner;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlFunction;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.fun.SqlLibraryOperators;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.type.OperandTypes;
+import org.apache.calcite.sql.type.ReturnTypes;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.List;
+
+/**
+ * VARCHAR-coercion coverage for {@link SecondAdapter}. Pre-fix this adapter
+ * built {@code date_part('second', <varchar>)} which the substrait matcher
+ * rejected as {@code DATE_PART(string, string)}.
+ */
+public class SecondAdapterTests extends OpenSearchTestCase {
+
+    private final RelDataTypeFactory typeFactory = new JavaTypeFactoryImpl();
+    private final RexBuilder rexBuilder = new RexBuilder(typeFactory);
+    private final RelOptCluster cluster = RelOptCluster.create(new VolcanoPlanner(), rexBuilder);
+
+    private SqlFunction pplSecond() {
+        return new SqlFunction(
+            "SECOND",
+            SqlKind.OTHER_FUNCTION,
+            ReturnTypes.INTEGER_NULLABLE,
+            null,
+            OperandTypes.ANY,
+            SqlFunctionCategory.TIMEDATE
+        );
+    }
+
+    private RexCall innerDatePart(RexCall adapted) {
+        // adapted shape: CAST(FLOOR(CAST(date_part('second', _) AS DOUBLE)) AS retType)
+        assertEquals(SqlKind.CAST, adapted.getKind());
+        RexCall floor = (RexCall) adapted.getOperands().get(0);
+        assertSame(SqlStdOperatorTable.FLOOR, floor.getOperator());
+        RexCall innerCast = (RexCall) floor.getOperands().get(0);
+        assertEquals(SqlKind.CAST, innerCast.getKind());
+        RexCall datePart = (RexCall) innerCast.getOperands().get(0);
+        assertSame(SqlLibraryOperators.DATE_PART, datePart.getOperator());
+        return datePart;
+    }
+
+    public void testTimestampOperandPassesThrough() {
+        RexNode ts = rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.TIMESTAMP), 0);
+        RexCall original = (RexCall) rexBuilder.makeCall(pplSecond(), List.of(ts));
+
+        RexCall adapted = (RexCall) new SecondAdapter().adapt(original, List.of(), cluster);
+
+        assertSame("TIMESTAMP operand must not be wrapped in CAST", ts, innerDatePart(adapted).getOperands().get(1));
+    }
+
+    public void testVarcharOperandIsCastToTimestamp() {
+        RelDataType varcharType = typeFactory.createSqlType(SqlTypeName.VARCHAR);
+        RexNode literal = rexBuilder.makeLiteral("2020-09-16 17:30:45", varcharType, true);
+        RexCall original = (RexCall) rexBuilder.makeCall(pplSecond(), List.of(literal));
+
+        RexCall adapted = (RexCall) new SecondAdapter().adapt(original, List.of(), cluster);
+
+        RexNode operand = innerDatePart(adapted).getOperands().get(1);
+        assertTrue("VARCHAR operand must be wrapped", operand instanceof RexCall);
+        RexCall cast = (RexCall) operand;
+        assertEquals(SqlKind.CAST, cast.getKind());
+        assertSame(SqlTypeName.TIMESTAMP, cast.getType().getSqlTypeName());
+        assertSame(literal, cast.getOperands().get(0));
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/SecondAdapterTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/SecondAdapterTests.java
@@ -85,4 +85,17 @@ public class SecondAdapterTests extends OpenSearchTestCase {
         assertSame(SqlTypeName.TIMESTAMP, cast.getType().getSqlTypeName());
         assertSame(literal, cast.getOperands().get(0));
     }
+
+    public void testInvalidLiteralRejectedAtPlanTime() {
+        RelDataType varcharType = typeFactory.createSqlType(SqlTypeName.VARCHAR);
+        RexNode literal = rexBuilder.makeLiteral("2025-12-01 15:02:61", varcharType, true);
+        RexCall original = (RexCall) rexBuilder.makeCall(pplSecond(), List.of(literal));
+
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> new SecondAdapter().adapt(original, List.of(), cluster)
+        );
+        assertTrue(e.getMessage().contains("unsupported format"));
+        assertTrue(e.getMessage().contains("2025-12-01 15:02:61"));
+    }
 }


### PR DESCRIPTION
### Problem

PPL allows bare string-literal datetime arguments like `DAY('2020-09-16')`. Calcite types those operands as `VARCHAR`, so `DatePartAdapters` (and the siblings `DayOfWeekAdapter` / `SecondAdapter`) produced `DATE_PART('<unit>', <varchar>)`. `opensearch_scalar_functions.yaml` only declares `date_part` for `(string, precision_timestamp<P>)` and `(string, date)`, so isthmus' substrait matcher rejected the call with:

```
IllegalArgumentException: Unable to convert call DATE_PART(string, string)
```

This blocked **31 PPL date-part tests** across `CalcitePPLBuiltinDatetimeFunctionInvalidIT` (18), `CalciteDateTimeFunctionIT` (11), and `CalcitePPLBuiltinFunctionsNullIT` (2).

Two follow-on issues uncovered while iterating:
- `DayOfWeekAdapter` / `SecondAdapter` build their `date_part` calls directly, so they didn't pick up the original `DatePartAdapters` fix.
- Invalid literals (e.g. `'2025-13-02'`) failed inside DataFusion's CAST kernel; the Arrow error text is dropped by Flight RPC on the worker→coordinator hop, so the legacy `"unsupported format"` wording the IT assertions expect never reached the user.

### Solution

Engine-side only — all changes under `sandbox/plugins/analytics-backend-datafusion/`.

1. **VARCHAR→TIMESTAMP coercion** in `DatePartAdapters.adapt`; `TIMESTAMP` / `DATE` operands pass through.
2. **Shared helper** `coerceCharacterOperandToTimestamp` so `DayOfWeekAdapter` / `SecondAdapter` (which build `date_part` directly) get the same wrapping.
3. **Plan-time literal validation** mirroring legacy `DateTimeParser.parse` — flat try-chain (`LocalDateTime` with space→T, then `LocalDate`, then `LocalTime`) that throws `IllegalArgumentException("timestamp:<v> in unsupported format, ...")` without attaching the cause (SQL plugin's `unwrapCause` would otherwise surface the inner JDK message instead of the legacy wording).

### Testing

#### Unit tests
`:sandbox:plugins:analytics-backend-datafusion:check` — **BUILD SUCCESSFUL** locally under JDK 25. Covers TIMESTAMP / DATE pass-through, VARCHAR + CHAR coercion, nullability preservation, unit-literal propagation, NULL-literal pass-through, column-ref-not-eagerly-validated, and 4 invalid-literal rejection cases (month-13, second-61, bare-time-second-61, garbage) across all three adapter test classes.

#### End-to-end ITs (force-routed AE cluster, `:integ-test:integTestRemote -Dtests.analytics.parquet=true`)
- **6 originally-tracked failing tests now pass**: `testDAYOFWEEKInvalid`, `testDAY_OF_WEEKInvalid`, `testSECONDInvalid`, `testSECOND_OF_MINUTEInvalid` in `CalcitePPLBuiltinDatetimeFunctionInvalidIT`; `testDayOfWeek`, `testDay_of_week` in `CalciteDateTimeFunctionIT`.
- **Full 31-test set verified** by running the 3 affected IT classes end-to-end and grepping the test-result XML directory for any lingering `DATE_PART(string, string)` mention:

before

```
31 test methods across 3 classes fail with Unable to convert call DATE_PART(string, string).

  ┌───────┬────────────────────────────────────────────┬────────────────────────────────────────────────────────────────┐
  │ Tests │                   Class                    │                        Outer exception                         │
  ├───────┼────────────────────────────────────────────┼────────────────────────────────────────────────────────────────┤
  │    18 │ CalcitePPLBuiltinDatetimeFunctionInvalidIT │ AssertionError (test-side — they assert on the error response) │
  ├───────┼────────────────────────────────────────────┼────────────────────────────────────────────────────────────────┤
  │    11 │ CalciteDateTimeFunctionIT                  │ ResponseException (server-side — query returns HTTP 500)       │
  ├───────┼────────────────────────────────────────────┼────────────────────────────────────────────────────────────────┤
  │     2 │ CalcitePPLBuiltinFunctionsNullIT           │ AssertionError (test-side)
```

after

| Class | Total tests | `DATE_PART(string, string)` matches |
|---|---|---|
| CalcitePPLBuiltinDatetimeFunctionInvalidIT | 45 | **0** |
| CalciteDateTimeFunctionIT | 65 | **0** |
| CalcitePPLBuiltinFunctionsNullIT | 71 | **0** |

The error mode is fully eliminated across the 3 affected classes. Residual failures in those classes are unrelated error types (other engine gaps), not the DATE_PART signature mismatch this PR targets.

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request created, if applicable. *(N/A — internal adapter behavior, engine-side only.)*
- [ ] Public documentation issue/PR created, if applicable. *(N/A — bug fix, no PPL-visible behavior change.)*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
