### PR TITLE
Fix DiskUsageTests NodeStats constructor call

### DIFF
--- a/server/src/test/java/org/opensearch/cluster/DiskUsageTests.java
+++ b/server/src/test/java/org/opensearch/cluster/DiskUsageTests.java
@@ -500,6 +500,7 @@ public class DiskUsageTests extends OpenSearchTestCase {
             null,
             null,
             null,
+            null,
             null
         );
     }


### PR DESCRIPTION
### Description

Fixes a compile failure in `DiskUsageTests` caused by the test helper using an outdated `NodeStats` constructor argument list.

Breaking change was https://github.com/opensearch-project/OpenSearch/pull/21637

Break can be seen in https://github.com/opensearch-project/OpenSearch/actions/runs/26195056157/job/77072446112

`NodeStats` now accepts `AnalyticsBackendNativeMemoryStats` as the final constructor argument. The `makeNodeStatsWithResourceUsage` helper in `DiskUsageTests` was missing that trailing argument, which caused CodeQL autobuild to fail during test compilation.

This change adds the missing `null` argument so the helper matches the current constructor signature.

### Related Issues

Fixes

```
  [2026-05-20 23:15:14] [autobuild] > Task :server:compileTestJava
  [2026-05-20 23:15:14] [autobuild] /home/runner/work/OpenSearch/OpenSearch/server/src/test/java/org/opensearch/cluster/DiskUsageTests.java:473: error: no suitable constructor found for NodeStats(DiscoveryNode,int,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,NodesResourceUsageStats,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>)
  [2026-05-20 23:15:14] [autobuild]         return new NodeStats(
  [2026-05-20 23:15:14] [autobuild]                ^
  [2026-05-20 23:15:14] [autobuild]     constructor NodeStats.NodeStats(StreamInput) is not applicable
  [2026-05-20 23:15:14] [autobuild]       (actual and formal argument lists differ in length)
  [2026-05-20 23:15:14] [autobuild]     constructor NodeStats.NodeStats(DiscoveryNode,long,NodeIndicesStats,OsStats,ProcessStats,JvmStats,ThreadPoolStats,FsInfo,TransportStats,HttpStats,AllCircuitBreakerStats,ScriptStats,DiscoveryStats,IngestStats,AdaptiveSelectionStats,NodesResourceUsageStats,ScriptCacheStats,IndexingPressureStats,ShardIndexingPressureStats,SearchBackpressureStats,ClusterManagerThrottlingStats,WeightedRoutingStats,AggregateFileCacheStats,TaskCancellationStats,SearchPipelineStats,SegmentReplicationRejectionStats,RepositoriesStats,AdmissionControlStats,NodeCacheStats,RemoteStoreNodeStats,AnalyticsBackendNativeMemoryStats) is not applicable
  [2026-05-20 23:15:14] [autobuild]       (actual and formal argument lists differ in length
```

### Check List

- [x] New functionality includes testing.
- [x] All tests pass.
- [x] New functionality has been documented.

### Testing

- `./gradlew :server:compileTestJava`
- `./gradlew :server:test --tests org.opensearch.cluster.DiskUsageTests`
- `./gradlew :server:spotlessJavaCheck`
