### PR TITLE
Add STATS bundle aggregate decomposition

### DIFF
--- a/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/AggregateFunction.java
+++ b/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/AggregateFunction.java
@@ -39,6 +39,14 @@ public enum AggregateFunction {
     // a Project wrapper before the resolver sees the plan.
     AVG(Type.SIMPLE, SqlKind.AVG),
 
+    // STATS bundle aggregate. Decomposition (STATS(x) → struct of COUNT/MIN/MAX/SUM/AVG) is
+    // handled by OpenSearchStatsReduceRule during HEP, before the resolver and Volcano split
+    // run, so this enum entry exists only to satisfy backend-capability and SqlAggFunction
+    // mapping plumbing — no intermediateFields are needed because the rule rewrites STATS
+    // into primitives before the partial/final split. SqlKind is OTHER (custom function),
+    // so resolution goes via name lookup in fromNameOrError.
+    STATS(Type.STATE_EXPANDING, SqlKind.OTHER),
+
     // Statistical — fixed-size state, multi-pass or running stats. Handled by
     // OpenSearchAggregateReduceRule (once FUNCTIONS_TO_REDUCE is extended to include them)
     // — no intermediateFields here either.
@@ -202,6 +210,7 @@ public enum AggregateFunction {
             case COUNT -> SqlStdOperatorTable.COUNT;
             case AVG -> SqlStdOperatorTable.AVG;
             case APPROX_COUNT_DISTINCT -> SqlStdOperatorTable.APPROX_COUNT_DISTINCT;
+            case STATS -> OpenSearchAggregateOperators.STATS;
             default -> throw new IllegalStateException("No SqlAggFunction mapping for: " + this);
         };
     }

--- a/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/OpenSearchAggregateOperators.java
+++ b/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/OpenSearchAggregateOperators.java
@@ -1,0 +1,106 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.spi;
+
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.sql.SqlAggFunction;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlOperatorBinding;
+import org.apache.calcite.sql.type.OperandTypes;
+import org.apache.calcite.sql.type.ReturnTypes;
+import org.apache.calcite.sql.type.SqlReturnTypeInference;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.util.Optionality;
+
+/**
+ * Custom Calcite {@link SqlAggFunction} singletons defined by the OpenSearch analytics
+ * engine but referenced by frontends (the SQL/PPL parser library, planner-side rules) —
+ * kept in the SPI module so any party can import the same singleton.
+ *
+ * <p>Currently defines:
+ * <ul>
+ *   <li>{@link #STATS} — bundle aggregate returning {@code STRUCT(count, min, max, avg, sum)}.
+ *       Decomposed at HEP planning time by
+ *       {@code OpenSearchStatsReduceRule} into primitive COUNT/MIN/MAX/SUM aggregate calls
+ *       plus a Project that builds the struct, so no executor ever sees STATS.</li>
+ * </ul>
+ *
+ * @opensearch.internal
+ */
+public final class OpenSearchAggregateOperators {
+
+    private OpenSearchAggregateOperators() {}
+
+    /**
+     * Field names of the struct returned by {@link #STATS}. Public so the planner-side rule
+     * (which builds the Project that re-assembles the struct) and any test fixture can use
+     * the same names without re-declaring constants.
+     */
+    public static final String STATS_FIELD_COUNT = "count";
+    public static final String STATS_FIELD_MIN = "min";
+    public static final String STATS_FIELD_MAX = "max";
+    public static final String STATS_FIELD_SUM = "sum";
+    public static final String STATS_FIELD_AVG = "avg";
+
+    /**
+     * Return-type inference for {@link #STATS}. Produces a struct whose component types match
+     * what Calcite's built-in COUNT/MIN/MAX/SUM aggregates would produce for the same operand,
+     * with AVG fixed to DOUBLE. Matching matters because the Project the decomposition rule
+     * emits must produce the same row type the original STATS aggregate declared.
+     */
+    private static final SqlReturnTypeInference STATS_RETURN_TYPE_INFERENCE = OpenSearchAggregateOperators::inferStatsReturnType;
+
+    /**
+     * STATS bundle aggregate. Decomposed at HEP planning time — never reaches the executor.
+     */
+    public static final SqlAggFunction STATS = new SqlAggFunction(
+        "STATS",
+        null,
+        SqlKind.OTHER,
+        STATS_RETURN_TYPE_INFERENCE,
+        null,
+        OperandTypes.NUMERIC,
+        SqlFunctionCategory.USER_DEFINED_FUNCTION,
+        false,
+        false,
+        Optionality.FORBIDDEN
+    ) {
+    };
+
+    private static RelDataType inferStatsReturnType(SqlOperatorBinding opBinding) {
+        RelDataTypeFactory typeFactory = opBinding.getTypeFactory();
+        RelDataType inputType = opBinding.getOperandType(0);
+
+        RelDataType countType = typeFactory.createSqlType(SqlTypeName.BIGINT);
+
+        RelDataType nullableInput = typeFactory.createTypeWithNullability(inputType, true);
+
+        // Delegate to Calcite's SUM type inference. AGG_SUM widens INTEGER → BIGINT,
+        // BIGINT → DECIMAL, DOUBLE → DOUBLE, etc. Falls back to the input type if the
+        // inference returns null (shouldn't happen for numeric-validated operands).
+        RelDataType sumType = ReturnTypes.AGG_SUM.inferReturnType(opBinding);
+        if (sumType == null) {
+            sumType = nullableInput;
+        } else {
+            sumType = typeFactory.createTypeWithNullability(sumType, true);
+        }
+
+        RelDataType avgType = typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.DOUBLE), true);
+
+        return typeFactory.builder()
+            .add(STATS_FIELD_COUNT, countType)
+            .add(STATS_FIELD_MIN, nullableInput)
+            .add(STATS_FIELD_MAX, nullableInput)
+            .add(STATS_FIELD_AVG, avgType)
+            .add(STATS_FIELD_SUM, sumType)
+            .build();
+    }
+}

--- a/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/ScalarFunction.java
+++ b/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/ScalarFunction.java
@@ -51,6 +51,14 @@ public enum ScalarFunction {
     /** Calcite's Sarg fold for IN / NOT IN / BETWEEN / range-union. Backends expand it before substrait. */
     SARG_PREDICATE(Category.SCALAR, SqlKind.SEARCH),
 
+    /**
+     * Struct constructor — Calcite's {@code SqlStdOperatorTable.ROW}, used in Project to
+     * assemble named-field structs from scalar inputs. Result type is always a struct, so
+     * capability resolution in {@code OpenSearchProjectRule} falls back to the first
+     * operand's type (no {@code FieldType.STRUCT} exists).
+     */
+    ROW(Category.SCALAR, SqlKind.ROW),
+
     // ── Full-text search ─────────────────────────────────────────────
     MATCH(Category.FULL_TEXT, SqlKind.OTHER_FUNCTION),
     MATCH_PHRASE(Category.FULL_TEXT, SqlKind.OTHER_FUNCTION),

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/PlannerImpl.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/PlannerImpl.java
@@ -29,6 +29,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.analytics.planner.rel.OpenSearchDistributionTraitDef;
 import org.opensearch.analytics.planner.rules.OpenSearchAggregateReduceRule;
+import org.opensearch.analytics.planner.rules.OpenSearchStatsReduceRule;
 import org.opensearch.analytics.planner.rules.OpenSearchAggregateRule;
 import org.opensearch.analytics.planner.rules.OpenSearchAggregateSplitRule;
 import org.opensearch.analytics.planner.rules.OpenSearchDistributionDeriveRule;
@@ -180,6 +181,12 @@ public class PlannerImpl {
     private static RelNode decomposeAggregates(RelNode input, RuleProfilingListener listener) {
         HepProgramBuilder builder = new HepProgramBuilder();
         builder.addMatchOrder(HepMatchOrder.BOTTOM_UP);
+        // STATS reduction must run before the standard AVG/STDDEV/VAR reduction. Both rules
+        // operate on plain LogicalAggregate; ordering matters because the STATS rule emits
+        // primitive SUM/COUNT/MIN/MAX and a Project that derives AVG inline (no AVG aggCall),
+        // so the AVG decomposition rule does not see — and does not need to see — STATS' avg
+        // path. Other AVG/STDDEV/VAR aggCalls in the same Aggregate are still picked up.
+        builder.addRuleInstance(OpenSearchStatsReduceRule.INSTANCE);
         builder.addRuleInstance(new OpenSearchAggregateReduceRule());
         HepPlanner planner = new HepPlanner(builder.build());
         if (listener != null) {

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchStatsReduceRule.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchStatsReduceRule.java
@@ -1,0 +1,289 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.planner.rules;
+
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.rel.RelCollations;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.AggregateCall;
+import org.apache.calcite.rel.logical.LogicalAggregate;
+import org.apache.calcite.rel.logical.LogicalProject;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlAggFunction;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.sql.type.SqlTypeUtil;
+import org.opensearch.analytics.spi.OpenSearchAggregateOperators;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * HEP rule that decomposes the {@link OpenSearchAggregateOperators#STATS STATS} bundle aggregate
+ * into the four primitive aggregates ({@code COUNT}, {@code MIN}, {@code MAX}, {@code SUM})
+ * plus a {@link LogicalProject} that re-assembles them — together with a derived {@code AVG}
+ * — into the struct shape the original {@code STATS} call declared.
+ *
+ * <p><b>Why decompose at HEP time?</b> {@code STATS} has no executor implementation in this
+ * codebase and isn't a Calcite standard {@link org.apache.calcite.sql.SqlKind} that
+ * Calcite's stock {@link org.apache.calcite.rel.rules.AggregateReduceFunctionsRule} knows
+ * how to reduce. Doing the rewrite during HEP keeps the rest of the planner — marking,
+ * Volcano split, partial/final resolver, fragment conversion, DataFusion execution —
+ * unaware of {@code STATS}; everything downstream sees only primitives that already have
+ * full support.
+ *
+ * <p><b>Output shape preserved.</b> The original {@code STATS(x)} column has type
+ * {@code STRUCT(count, min, max, avg, sum)}. The {@link LogicalProject} on top of the
+ * rebuilt {@link LogicalAggregate} reassembles the struct so the row-type contract holds.
+ *
+ * @opensearch.internal
+ */
+public final class OpenSearchStatsReduceRule extends RelOptRule {
+
+    public static final OpenSearchStatsReduceRule INSTANCE = new OpenSearchStatsReduceRule();
+
+    private OpenSearchStatsReduceRule() {
+        super(operand(LogicalAggregate.class, any()), "OpenSearchStatsReduceRule");
+    }
+
+    @Override
+    public boolean matches(RelOptRuleCall call) {
+        LogicalAggregate aggregate = call.rel(0);
+        for (AggregateCall aggCall : aggregate.getAggCallList()) {
+            if (isStats(aggCall.getAggregation())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public void onMatch(RelOptRuleCall call) {
+        LogicalAggregate aggregate = call.rel(0);
+        RexBuilder rexBuilder = aggregate.getCluster().getRexBuilder();
+        RelDataTypeFactory typeFactory = aggregate.getCluster().getTypeFactory();
+
+        int groupCount = aggregate.getGroupCount();
+        boolean hasEmptyGroup = aggregate.getGroupSet().isEmpty();
+
+        Expansion expansion = expandAggCalls(aggregate, hasEmptyGroup, groupCount);
+
+        LogicalAggregate newAgg = LogicalAggregate.create(
+            aggregate.getInput(),
+            aggregate.getHints(),
+            aggregate.getGroupSet(),
+            aggregate.getGroupSets(),
+            expansion.newCalls
+        );
+
+        RelNode project = buildAssemblyProject(aggregate, newAgg, expansion.originalToNew, groupCount, rexBuilder, typeFactory);
+        call.transformTo(project);
+    }
+
+    /**
+     * Expands each STATS aggregate call into four primitives ({@code SUM}, {@code MIN},
+     * {@code MAX}, {@code COUNT}, in that emission order); leaves non-STATS calls untouched.
+     *
+     * <p><b>Emission order matters for distributed correctness.</b> Calcite's
+     * {@code Aggregate.typeMatchesInferred} assertion fires during the split rule's FINAL
+     * aggregate construction. The FINAL keeps the original aggCall list with original
+     * {@code argList} (e.g. {@code [1]}) but its input is the PARTIAL's output, where
+     * column 1 is the first aggregate's output column. Putting {@code SUM} first means
+     * column 1 of PARTIAL is {@code sum_p} — same Calcite type as the source field — so
+     * when FINAL re-infers MIN/MAX/SUM/COUNT against it, the inferred types match the
+     * stored types from when this rule created the calls. {@code DistributedAggregateRewriter}
+     * corrects the semantically-incorrect argList post-Volcano. Putting {@code COUNT}
+     * first would force column 1 of PARTIAL to be {@code BIGINT}, breaking FINAL's
+     * MIN/MAX/SUM type assertions.
+     *
+     * <p>The returned mapping per original call is {@code [countIdx, minIdx, maxIdx, sumIdx]}
+     * regardless of emission order — assembly looks up by role, not position.
+     */
+    private static Expansion expandAggCalls(LogicalAggregate aggregate, boolean hasEmptyGroup, int groupCount) {
+        RelNode input = aggregate.getInput();
+        List<AggregateCall> newCalls = new ArrayList<>();
+        List<int[]> originalToNew = new ArrayList<>(aggregate.getAggCallList().size());
+        for (AggregateCall original : aggregate.getAggCallList()) {
+            if (isStats(original.getAggregation())) {
+                int sumIdx = newCalls.size();
+                newCalls.add(makePrimitive(SqlStdOperatorTable.SUM, original, input, hasEmptyGroup, groupCount));
+                int minIdx = newCalls.size();
+                newCalls.add(makePrimitive(SqlStdOperatorTable.MIN, original, input, hasEmptyGroup, groupCount));
+                int maxIdx = newCalls.size();
+                newCalls.add(makePrimitive(SqlStdOperatorTable.MAX, original, input, hasEmptyGroup, groupCount));
+                int countIdx = newCalls.size();
+                newCalls.add(makePrimitive(SqlStdOperatorTable.COUNT, original, input, hasEmptyGroup, groupCount));
+                originalToNew.add(new int[] { countIdx, minIdx, maxIdx, sumIdx });
+            } else {
+                originalToNew.add(new int[] { newCalls.size() });
+                newCalls.add(original);
+            }
+        }
+        return new Expansion(newCalls, originalToNew);
+    }
+
+    /**
+     * Result of {@link #expandAggCalls}: the new aggCall list and a per-original-call mapping
+     * to indices in the new list ([countIdx, minIdx, maxIdx, sumIdx] for STATS, single-element
+     * for everything else).
+     */
+    private record Expansion(List<AggregateCall> newCalls, List<int[]> originalToNew) {
+    }
+
+    /**
+     * Builds the Project on top of {@code newAgg} that produces the original aggregate's row
+     * type: group-by columns pass through unchanged; non-STATS aggregate columns are identity
+     * refs into {@code newAgg}'s output; STATS aggregate columns are reassembled struct
+     * expressions via {@link #buildStatsStruct}.
+     */
+    private static RelNode buildAssemblyProject(
+        LogicalAggregate originalAgg,
+        LogicalAggregate newAgg,
+        List<int[]> originalToNew,
+        int groupCount,
+        RexBuilder rexBuilder,
+        RelDataTypeFactory typeFactory
+    ) {
+        List<RelDataTypeField> originalFields = originalAgg.getRowType().getFieldList();
+        List<RelDataTypeField> newAggFields = newAgg.getRowType().getFieldList();
+        List<RexNode> projects = new ArrayList<>(originalFields.size());
+        List<String> fieldNames = new ArrayList<>(originalFields.size());
+
+        for (int i = 0; i < groupCount; i++) {
+            projects.add(rexBuilder.makeInputRef(newAggFields.get(i).getType(), i));
+            fieldNames.add(originalFields.get(i).getName());
+        }
+
+        for (int origIdx = 0; origIdx < originalAgg.getAggCallList().size(); origIdx++) {
+            AggregateCall original = originalAgg.getAggCallList().get(origIdx);
+            int[] mapping = originalToNew.get(origIdx);
+            fieldNames.add(originalFields.get(groupCount + origIdx).getName());
+
+            if (isStats(original.getAggregation())) {
+                projects.add(buildStatsStruct(original, mapping, newAggFields, groupCount, rexBuilder, typeFactory));
+            } else {
+                int newColPos = groupCount + mapping[0];
+                projects.add(rexBuilder.makeInputRef(newAggFields.get(newColPos).getType(), newColPos));
+            }
+        }
+
+        return LogicalProject.create(newAgg, originalAgg.getHints(), projects, fieldNames);
+    }
+
+    /**
+     * Builds a {@code ROW(count, min, max, avg, sum)} expression matching the original
+     * STATS call's declared struct type. Field order matches legacy OpenSearch
+     * {@code InternalStats}: count, min, max, avg, sum — so {@code statsFields.get(3)} is
+     * the avg field type and {@code statsFields.get(4)} is the sum field type.
+     */
+    private static RexNode buildStatsStruct(
+        AggregateCall originalStats,
+        int[] mapping,
+        List<RelDataTypeField> newAggFields,
+        int groupCount,
+        RexBuilder rexBuilder,
+        RelDataTypeFactory typeFactory
+    ) {
+        RelDataType statsType = originalStats.getType();
+        List<RelDataTypeField> statsFields = statsType.getFieldList();
+        if (statsFields.size() != 5) {
+            throw new IllegalStateException(
+                "STATS return type must declare 5 fields (count, min, max, avg, sum), got: " + statsType
+            );
+        }
+
+        int newCountPos = groupCount + mapping[0];
+        int newMinPos = groupCount + mapping[1];
+        int newMaxPos = groupCount + mapping[2];
+        int newSumPos = groupCount + mapping[3];
+
+        RexNode countRef = ensureType(rexBuilder, newAggFields.get(newCountPos).getType(), newCountPos, statsFields.get(0).getType());
+        RexNode minRef = ensureType(rexBuilder, newAggFields.get(newMinPos).getType(), newMinPos, statsFields.get(1).getType());
+        RexNode maxRef = ensureType(rexBuilder, newAggFields.get(newMaxPos).getType(), newMaxPos, statsFields.get(2).getType());
+        RexNode sumRef = ensureType(rexBuilder, newAggFields.get(newSumPos).getType(), newSumPos, statsFields.get(4).getType());
+        RexNode avgRef = buildAvgExpression(newSumPos, newCountPos, statsFields.get(3).getType(), newAggFields, rexBuilder, typeFactory);
+
+        return rexBuilder.makeCall(statsType, SqlStdOperatorTable.ROW, List.of(countRef, minRef, maxRef, avgRef, sumRef));
+    }
+
+    /**
+     * Computes {@code CAST(sum AS DOUBLE) / CAST(count AS DOUBLE)} cast back to
+     * {@code targetAvgType}. Computing through DOUBLE casts gives a stable DOUBLE result
+     * regardless of the input numeric type. The final cast is defensive — guards against
+     * future drift between the divide result type and the AVG field type declared by STATS.
+     */
+    private static RexNode buildAvgExpression(
+        int sumPos,
+        int countPos,
+        RelDataType targetAvgType,
+        List<RelDataTypeField> newAggFields,
+        RexBuilder rexBuilder,
+        RelDataTypeFactory typeFactory
+    ) {
+        RelDataType doubleNullable = typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.DOUBLE), true);
+        RexNode rawSum = rexBuilder.makeInputRef(newAggFields.get(sumPos).getType(), sumPos);
+        RexNode rawCount = rexBuilder.makeInputRef(newAggFields.get(countPos).getType(), countPos);
+        RexNode sumAsDouble = rexBuilder.makeCast(doubleNullable, rawSum);
+        RexNode countAsDouble = rexBuilder.makeCast(doubleNullable, rawCount);
+        RexNode avgExpr = rexBuilder.makeCall(SqlStdOperatorTable.DIVIDE, sumAsDouble, countAsDouble);
+        return rexBuilder.makeCast(targetAvgType, avgExpr);
+    }
+
+    /**
+     * Builds a primitive aggregate call (COUNT/MIN/MAX/SUM) over the same operand and filter
+     * as the original {@code STATS} call. Empty {@code rexList} because primitive aggregates
+     * have no per-call expressions; {@code null} for type and name lets Calcite infer them
+     * from the operator and input.
+     */
+    private static AggregateCall makePrimitive(
+        SqlAggFunction op,
+        AggregateCall original,
+        RelNode input,
+        boolean hasEmptyGroup,
+        int groupCount
+    ) {
+        return AggregateCall.create(
+            op,
+            original.isDistinct(),
+            original.isApproximate(),
+            original.ignoreNulls(),
+            List.of(),
+            original.getArgList(),
+            original.filterArg,
+            null,
+            RelCollations.EMPTY,
+            groupCount,
+            input,
+            null,
+            null
+        );
+    }
+
+    /**
+     * Returns a {@link RexNode} of {@code targetType}: an input ref at {@code pos}, optionally
+     * wrapped in a CAST when source and target differ modulo nullability. Used to coerce
+     * primitive aggregate outputs into the field types declared by the STATS struct.
+     */
+    private static RexNode ensureType(RexBuilder rexBuilder, RelDataType sourceType, int pos, RelDataType targetType) {
+        RexNode ref = rexBuilder.makeInputRef(sourceType, pos);
+        if (SqlTypeUtil.equalSansNullability(rexBuilder.getTypeFactory(), sourceType, targetType)) {
+            return ref;
+        }
+        return rexBuilder.makeCast(targetType, ref);
+    }
+
+    private static boolean isStats(SqlAggFunction op) {
+        return op == OpenSearchAggregateOperators.STATS;
+    }
+}

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/MockDataFusionBackend.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/MockDataFusionBackend.java
@@ -184,7 +184,10 @@ public class MockDataFusionBackend extends MockBackend implements SearchBackEndP
         // Logical connectives (projection-side composition: `case(a and b, …)`)
         ScalarFunction.AND,
         ScalarFunction.OR,
-        ScalarFunction.NOT
+        ScalarFunction.NOT,
+        // Struct constructor — emitted by OpenSearchStatsReduceRule's Project to assemble
+        // STRUCT(count, min, max, avg, sum) from the primitive aggregate output columns.
+        ScalarFunction.ROW
     );
 
     private static final Set<ProjectCapability> PROJECT_CAPS;

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/StatsAggregatePlanShapeTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/StatsAggregatePlanShapeTests.java
@@ -1,0 +1,147 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.planner;
+
+import org.apache.calcite.rel.RelCollations;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.AggregateCall;
+import org.apache.calcite.rel.logical.LogicalAggregate;
+import org.apache.calcite.util.ImmutableBitSet;
+import org.opensearch.analytics.planner.rel.OpenSearchAggregate;
+import org.opensearch.analytics.planner.rel.OpenSearchExchangeReducer;
+import org.opensearch.analytics.planner.rel.OpenSearchProject;
+import org.opensearch.analytics.spi.OpenSearchAggregateOperators;
+
+import java.util.List;
+
+/**
+ * Plan-shape tests for the STATS aggregate after the full {@code PlannerImpl} pipeline
+ * (HEP decompose → marking → CBO).
+ *
+ * <p>By the time these assertions run, {@code OpenSearchStatsReduceRule} has expanded
+ * STATS into the four primitive aggregate calls plus a Project that builds the
+ * {@code STRUCT(count, min, max, avg, sum)} result. Subsequent phases (marking, Volcano
+ * split, distribute) operate on that primitive plan exactly the way they operate on any
+ * other AVG/SUM/COUNT aggregate. The assertion shape is therefore the same as
+ * {@link AggregatePlanShapeTests}'s — the structure proves STATS routes through every
+ * phase correctly.
+ */
+public class StatsAggregatePlanShapeTests extends PlanShapeTestBase {
+
+    public void testStatsSingleField_1shard_yieldsProjectOverSingleAggregate() {
+        RelNode scan = stubScan(mockTable("test_index", "status", "size"));
+        AggregateCall stats = makeStatsCall(scan, 1, "stats_size");
+        RelNode plan = LogicalAggregate.create(scan, List.of(), ImmutableBitSet.of(), null, List.of(stats));
+
+        RelNode result = runPlanner(plan, singleShardContext());
+
+        // Top-level: ExchangeReducer wrapping a Project that builds the struct from a
+        // single-mode Aggregate's primitives. Peel the ER to inspect Project + Aggregate.
+        RelNode top = unwrapRootReducer(result);
+        assertTrue("Top must be OpenSearchProject", top instanceof OpenSearchProject);
+        OpenSearchProject project = (OpenSearchProject) top;
+        assertEquals(1, project.getProjects().size());
+
+        RelNode child = unwrapExchange(project.getInput());
+        assertTrue("Project input must be OpenSearchAggregate", child instanceof OpenSearchAggregate);
+        OpenSearchAggregate agg = (OpenSearchAggregate) child;
+        assertEquals("Decomposed to 4 primitive calls", 4, agg.getAggCallList().size());
+    }
+
+    public void testStatsSingleField_2shard_splitsIntoPartialFinalAroundProject() {
+        RelNode scan = stubScan(mockTable("test_index", "status", "size"));
+        AggregateCall stats = makeStatsCall(scan, 1, "stats_size");
+        RelNode plan = LogicalAggregate.create(scan, List.of(), ImmutableBitSet.of(), null, List.of(stats));
+
+        RelNode result = runPlanner(plan, multiShardContext());
+
+        // Plan shape after the multi-shard split:
+        //   Project [stats = STRUCT(count, min, max, avg, sum)]
+        //     └── Aggregate(FINAL) [SUM, MIN, MAX, COUNT]
+        //          └── ExchangeReducer
+        //               └── Aggregate(PARTIAL) [SUM, MIN, MAX, COUNT]
+        //                    └── Scan
+        RelNode top = unwrapRootReducer(result);
+        assertTrue("Top must be OpenSearchProject", top instanceof OpenSearchProject);
+        OpenSearchProject project = (OpenSearchProject) top;
+
+        RelNode finalAgg = unwrapExchange(project.getInput());
+        assertTrue("Below project must be Aggregate(FINAL)", finalAgg instanceof OpenSearchAggregate);
+        assertEquals(4, ((OpenSearchAggregate) finalAgg).getAggCallList().size());
+
+        RelNode reducer = finalAgg.getInputs().get(0);
+        assertTrue("Below FINAL must be ExchangeReducer", reducer instanceof OpenSearchExchangeReducer);
+    }
+
+    public void testStatsWithGroupBy_2shard() {
+        RelNode scan = stubScan(mockTable("test_index", "status", "size"));
+        AggregateCall stats = makeStatsCall(scan, 1, "stats_size");
+        RelNode plan = LogicalAggregate.create(scan, List.of(), ImmutableBitSet.of(0), null, List.of(stats));
+
+        RelNode result = runPlanner(plan, multiShardContext());
+
+        RelNode top = unwrapRootReducer(result);
+        assertTrue("Top must be OpenSearchProject", top instanceof OpenSearchProject);
+        OpenSearchProject project = (OpenSearchProject) top;
+        assertEquals(2, project.getProjects().size());
+        assertEquals("status", project.getRowType().getFieldList().get(0).getName());
+        assertEquals("stats_size", project.getRowType().getFieldList().get(1).getName());
+    }
+
+    public void testStatsMixedWithCount_2shard_bothFlowThroughSamePartialFinal() {
+        RelNode scan = stubScan(mockTable("test_index", "status", "size"));
+        AggregateCall stats = makeStatsCall(scan, 1, "stats_size");
+        AggregateCall countStar = AggregateCall.create(
+            org.apache.calcite.sql.fun.SqlStdOperatorTable.COUNT,
+            false,
+            false,
+            false,
+            List.of(),
+            List.of(),
+            -1,
+            null,
+            RelCollations.EMPTY,
+            0,
+            scan,
+            null,
+            "cnt_all"
+        );
+        RelNode plan = LogicalAggregate.create(scan, List.of(), ImmutableBitSet.of(0), null, List.of(stats, countStar));
+
+        RelNode result = runPlanner(plan, multiShardContext());
+
+        RelNode top = unwrapRootReducer(result);
+        assertTrue("Top must be OpenSearchProject", top instanceof OpenSearchProject);
+        OpenSearchProject project = (OpenSearchProject) top;
+        assertEquals(3, project.getProjects().size());
+
+        RelNode finalAgg = unwrapExchange(project.getInput());
+        assertTrue("Below project must be Aggregate(FINAL)", finalAgg instanceof OpenSearchAggregate);
+        // 4 primitives for STATS + 1 for cnt_all = 5.
+        assertEquals(5, ((OpenSearchAggregate) finalAgg).getAggCallList().size());
+    }
+
+    private AggregateCall makeStatsCall(RelNode input, int colIdx, String name) {
+        return AggregateCall.create(
+            OpenSearchAggregateOperators.STATS,
+            false,
+            false,
+            false,
+            List.of(),
+            List.of(colIdx),
+            -1,
+            null,
+            RelCollations.EMPTY,
+            0,
+            input,
+            null,
+            name
+        );
+    }
+}

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/rules/OpenSearchStatsReduceRuleTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/rules/OpenSearchStatsReduceRuleTests.java
@@ -1,0 +1,328 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.planner.rules;
+
+import org.apache.calcite.plan.hep.HepMatchOrder;
+import org.apache.calcite.plan.hep.HepPlanner;
+import org.apache.calcite.plan.hep.HepProgramBuilder;
+import org.apache.calcite.rel.RelCollations;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.Aggregate;
+import org.apache.calcite.rel.core.AggregateCall;
+import org.apache.calcite.rel.core.Project;
+import org.apache.calcite.rel.logical.LogicalAggregate;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.util.ImmutableBitSet;
+import org.opensearch.analytics.planner.BasePlannerRulesTests;
+import org.opensearch.analytics.spi.OpenSearchAggregateOperators;
+
+import java.util.List;
+
+/**
+ * Unit tests for {@link OpenSearchStatsReduceRule}. Each test builds a
+ * {@link LogicalAggregate} containing one or more aggregate calls, applies <i>only</i>
+ * the STATS reduction rule via a minimal {@link HepPlanner}, and asserts the resulting
+ * tree's structure: a {@link Project} on top of a {@link LogicalAggregate} whose
+ * {@code AggregateCall}s are the expected primitive set.
+ *
+ * <p>Tests are intentionally rule-scoped — they do not exercise {@code PlannerImpl}
+ * marking, CBO, or fragment conversion. End-to-end planner integration is covered by
+ * {@code StatsAggregatePlanShapeTests}.
+ */
+public class OpenSearchStatsReduceRuleTests extends BasePlannerRulesTests {
+
+    public void testSingleStatsCall_noGroupBy_decomposesIntoFourPrimitivesPlusProject() {
+        StubTableScan scan = (StubTableScan) stubScan(mockTable("orders", "price"));
+        AggregateCall statsCall = makeStatsCall(scan, 0, "stats_price");
+        LogicalAggregate aggregate = LogicalAggregate.create(scan, List.of(), ImmutableBitSet.of(), null, List.of(statsCall));
+
+        RelNode rewritten = applyRule(aggregate);
+
+        assertProjectOverAggregateWithFourPrimitives(rewritten, 0);
+    }
+
+    public void testSingleStatsCall_withGroupBy_preservesGroupSetAndPassesThroughGroupColumn() {
+        StubTableScan scan = (StubTableScan) stubScan(mockTable("orders", "city", "price"));
+        AggregateCall statsCall = makeStatsCall(scan, 1, "stats_price");
+        LogicalAggregate aggregate = LogicalAggregate.create(scan, List.of(), ImmutableBitSet.of(0), null, List.of(statsCall));
+
+        RelNode rewritten = applyRule(aggregate);
+
+        assertTrue("Top must be a Project", rewritten instanceof Project);
+        Project project = (Project) rewritten;
+        assertEquals(2, project.getProjects().size());
+        assertEquals("city", project.getRowType().getFieldList().get(0).getName());
+        assertEquals("stats_price", project.getRowType().getFieldList().get(1).getName());
+
+        Aggregate inner = (Aggregate) project.getInput();
+        assertEquals(ImmutableBitSet.of(0), inner.getGroupSet());
+        // Order matters — SUM-first emission preserves typeMatchesInferred after Volcano split.
+        assertEquals(4, inner.getAggCallList().size());
+        assertAggCallKinds(inner, SqlKind.SUM, SqlKind.MIN, SqlKind.MAX, SqlKind.COUNT);
+    }
+
+    public void testStatsMixedWithOtherAggregate_decomposesOnlyStats() {
+        StubTableScan scan = (StubTableScan) stubScan(mockTable("orders", "price", "quantity"));
+        AggregateCall statsCall = makeStatsCall(scan, 0, "stats_price");
+        // Pre-existing AVG over quantity — must survive untouched.
+        AggregateCall avgCall = AggregateCall.create(
+            SqlStdOperatorTable.AVG,
+            false,
+            false,
+            false,
+            List.of(),
+            List.of(1),
+            -1,
+            null,
+            RelCollations.EMPTY,
+            0,
+            scan,
+            null,
+            "avg_qty"
+        );
+        LogicalAggregate aggregate = LogicalAggregate.create(scan, List.of(), ImmutableBitSet.of(), null, List.of(statsCall, avgCall));
+
+        RelNode rewritten = applyRule(aggregate);
+
+        Project project = (Project) rewritten;
+        assertEquals(2, project.getProjects().size());
+
+        Aggregate inner = (Aggregate) project.getInput();
+        // 4 primitives for STATS + 1 surviving AVG = 5.
+        assertEquals(5, inner.getAggCallList().size());
+        assertAggCallKinds(inner, SqlKind.SUM, SqlKind.MIN, SqlKind.MAX, SqlKind.COUNT, SqlKind.AVG);
+        assertSame(SqlStdOperatorTable.AVG, inner.getAggCallList().get(4).getAggregation());
+    }
+
+    public void testMultipleStatsCalls_eachExpandsIntoFourPrimitives() {
+        StubTableScan scan = (StubTableScan) stubScan(mockTable("orders", "price", "quantity"));
+        AggregateCall stats1 = makeStatsCall(scan, 0, "stats_price");
+        AggregateCall stats2 = makeStatsCall(scan, 1, "stats_qty");
+        LogicalAggregate aggregate = LogicalAggregate.create(scan, List.of(), ImmutableBitSet.of(), null, List.of(stats1, stats2));
+
+        RelNode rewritten = applyRule(aggregate);
+
+        Project project = (Project) rewritten;
+        assertEquals(2, project.getProjects().size());
+
+        Aggregate inner = (Aggregate) project.getInput();
+        // 4 primitives per STATS × 2 STATS = 8.
+        assertEquals(8, inner.getAggCallList().size());
+        assertAggCallKinds(
+            inner,
+            SqlKind.SUM,
+            SqlKind.MIN,
+            SqlKind.MAX,
+            SqlKind.COUNT,
+            SqlKind.SUM,
+            SqlKind.MIN,
+            SqlKind.MAX,
+            SqlKind.COUNT
+        );
+        assertTrue(project.getProjects().get(0) instanceof RexCall);
+        assertEquals(SqlKind.ROW, ((RexCall) project.getProjects().get(0)).getOperator().getKind());
+        assertTrue(project.getProjects().get(1) instanceof RexCall);
+        assertEquals(SqlKind.ROW, ((RexCall) project.getProjects().get(1)).getOperator().getKind());
+    }
+
+    public void testStatsCall_filterArgIsPropagatedToAllPrimitives() {
+        // mockTable's default schema is single-column INTEGER, but FILTER needs a BOOLEAN
+        // NOT NULL column — build a 2-col table where col 1 is BOOLEAN.
+        StubTableScan scan2 = (StubTableScan) stubScan(
+            mockTable("orders2", new String[] { "price", "in_scope" }, new SqlTypeName[] { SqlTypeName.INTEGER, SqlTypeName.BOOLEAN })
+        );
+        AggregateCall statsCall = AggregateCall.create(
+            OpenSearchAggregateOperators.STATS,
+            false,
+            false,
+            false,
+            List.of(),
+            List.of(0),
+            1,
+            null,
+            RelCollations.EMPTY,
+            0,
+            scan2,
+            null,
+            "stats_price"
+        );
+        LogicalAggregate aggregate = LogicalAggregate.create(scan2, List.of(), ImmutableBitSet.of(), null, List.of(statsCall));
+
+        RelNode rewritten = applyRule(aggregate);
+
+        Aggregate inner = (Aggregate) ((Project) rewritten).getInput();
+        for (AggregateCall call : inner.getAggCallList()) {
+            assertEquals("filterArg must propagate to " + call.getAggregation().getName(), 1, call.filterArg);
+        }
+    }
+
+    public void testRuleNoOpWhenNoStatsCallPresent() {
+        StubTableScan scan = (StubTableScan) stubScan(mockTable("orders", "price"));
+        AggregateCall sumCall = AggregateCall.create(
+            SqlStdOperatorTable.SUM,
+            false,
+            false,
+            false,
+            List.of(),
+            List.of(0),
+            -1,
+            null,
+            RelCollations.EMPTY,
+            0,
+            scan,
+            null,
+            "sum_price"
+        );
+        LogicalAggregate aggregate = LogicalAggregate.create(scan, List.of(), ImmutableBitSet.of(), null, List.of(sumCall));
+
+        RelNode rewritten = applyRule(aggregate);
+
+        // No STATS → rule does not fire → HEP returns the input unchanged.
+        assertTrue("Plan must remain a LogicalAggregate when no STATS present", rewritten instanceof LogicalAggregate);
+        assertEquals(1, ((LogicalAggregate) rewritten).getAggCallList().size());
+        assertSame(SqlStdOperatorTable.SUM, ((LogicalAggregate) rewritten).getAggCallList().get(0).getAggregation());
+    }
+
+    public void testStatsStructFieldNamesMatchSpec() {
+        StubTableScan scan = (StubTableScan) stubScan(mockTable("orders", "price"));
+        AggregateCall statsCall = makeStatsCall(scan, 0, "stats_price");
+        LogicalAggregate aggregate = LogicalAggregate.create(scan, List.of(), ImmutableBitSet.of(), null, List.of(statsCall));
+
+        RelNode rewritten = applyRule(aggregate);
+
+        // Legacy OpenSearch InternalStats field order: count, min, max, avg, sum.
+        Project project = (Project) rewritten;
+        RelDataType statsType = project.getRowType().getFieldList().get(0).getType();
+        assertTrue("STATS column must be a struct/row type", statsType.isStruct());
+        assertEquals(5, statsType.getFieldList().size());
+        assertEquals(OpenSearchAggregateOperators.STATS_FIELD_COUNT, statsType.getFieldList().get(0).getName());
+        assertEquals(OpenSearchAggregateOperators.STATS_FIELD_MIN, statsType.getFieldList().get(1).getName());
+        assertEquals(OpenSearchAggregateOperators.STATS_FIELD_MAX, statsType.getFieldList().get(2).getName());
+        assertEquals(OpenSearchAggregateOperators.STATS_FIELD_AVG, statsType.getFieldList().get(3).getName());
+        assertEquals(OpenSearchAggregateOperators.STATS_FIELD_SUM, statsType.getFieldList().get(4).getName());
+    }
+
+    public void testStatsStructFieldTypesForIntegerInput() {
+        StubTableScan scan = (StubTableScan) stubScan(mockTable("orders", "price"));
+        AggregateCall statsCall = makeStatsCall(scan, 0, "stats_price");
+        LogicalAggregate aggregate = LogicalAggregate.create(scan, List.of(), ImmutableBitSet.of(), null, List.of(statsCall));
+
+        RelNode rewritten = applyRule(aggregate);
+
+        Project project = (Project) rewritten;
+        RelDataType statsType = project.getRowType().getFieldList().get(0).getType();
+        assertEquals(SqlTypeName.BIGINT, statsType.getFieldList().get(0).getType().getSqlTypeName());
+        assertEquals(SqlTypeName.INTEGER, statsType.getFieldList().get(1).getType().getSqlTypeName());
+        assertEquals(SqlTypeName.INTEGER, statsType.getFieldList().get(2).getType().getSqlTypeName());
+        assertEquals(SqlTypeName.DOUBLE, statsType.getFieldList().get(3).getType().getSqlTypeName());
+        // Calcite's AGG_SUM preserves operand type (INTEGER → INTEGER); distributed SUM
+        // widening to BIGINT happens later in the planner, not in return-type inference.
+        assertEquals(SqlTypeName.INTEGER, statsType.getFieldList().get(4).getType().getSqlTypeName());
+    }
+
+    public void testStatsCall_distinctIsPropagatedWhereMeaningful() {
+        StubTableScan scan = (StubTableScan) stubScan(mockTable("orders", "price"));
+        AggregateCall statsCall = AggregateCall.create(
+            OpenSearchAggregateOperators.STATS,
+            true,
+            false,
+            false,
+            List.of(),
+            List.of(0),
+            -1,
+            null,
+            RelCollations.EMPTY,
+            0,
+            scan,
+            null,
+            "stats_price"
+        );
+        LogicalAggregate aggregate = LogicalAggregate.create(scan, List.of(), ImmutableBitSet.of(), null, List.of(statsCall));
+
+        RelNode rewritten = applyRule(aggregate);
+
+        Aggregate inner = (Aggregate) ((Project) rewritten).getInput();
+        // Calcite normalizes DISTINCT for idempotent aggregates: MIN/MAX silently strip it
+        // (since MIN(DISTINCT x) == MIN(x)). SUM and COUNT preserve DISTINCT because it
+        // changes their result. The rule's job is to propagate the flag at construction time;
+        // Calcite then applies its normalization. Both outcomes are correct.
+        for (AggregateCall call : inner.getAggCallList()) {
+            SqlKind kind = call.getAggregation().getKind();
+            if (kind == SqlKind.SUM || kind == SqlKind.COUNT) {
+                assertTrue("DISTINCT must propagate to " + kind, call.isDistinct());
+            } else {
+                assertFalse("Calcite normalizes DISTINCT off " + kind + " (idempotent)", call.isDistinct());
+            }
+        }
+    }
+
+    private AggregateCall makeStatsCall(RelNode input, int colIdx, String name) {
+        return AggregateCall.create(
+            OpenSearchAggregateOperators.STATS,
+            false,
+            false,
+            false,
+            List.of(),
+            List.of(colIdx),
+            -1,
+            null,
+            RelCollations.EMPTY,
+            0,
+            input,
+            null,
+            name
+        );
+    }
+
+    /**
+     * Applies only {@link OpenSearchStatsReduceRule} to {@code root} via a minimal HEP
+     * planner and returns the post-rule plan. Mirrors what {@code PlannerImpl}'s
+     * {@code decomposeAggregates} phase does, scoped to a single rule for unit-level
+     * isolation.
+     */
+    private RelNode applyRule(RelNode root) {
+        HepProgramBuilder builder = new HepProgramBuilder();
+        builder.addMatchOrder(HepMatchOrder.BOTTOM_UP);
+        builder.addRuleInstance(OpenSearchStatsReduceRule.INSTANCE);
+        HepPlanner planner = new HepPlanner(builder.build());
+        planner.setRoot(root);
+        return planner.findBestExp();
+    }
+
+    /**
+     * Asserts the rewritten plan is a {@code Project(LogicalAggregate(input))} where the
+     * inner aggregate has exactly four primitive calls in the canonical SUM/MIN/MAX/COUNT
+     * order and the project's stats column at {@code statsColIdx} is a struct.
+     */
+    private static void assertProjectOverAggregateWithFourPrimitives(RelNode rewritten, int statsColIdx) {
+        assertTrue("Top must be a Project", rewritten instanceof Project);
+        Project project = (Project) rewritten;
+        assertTrue("Project's input must be a LogicalAggregate", project.getInput() instanceof LogicalAggregate);
+        LogicalAggregate inner = (LogicalAggregate) project.getInput();
+        assertEquals(4, inner.getAggCallList().size());
+        assertAggCallKinds(inner, SqlKind.SUM, SqlKind.MIN, SqlKind.MAX, SqlKind.COUNT);
+        RelDataType statsType = project.getRowType().getFieldList().get(statsColIdx).getType();
+        assertTrue("STATS column must be a struct type", statsType.isStruct());
+    }
+
+    private static void assertAggCallKinds(Aggregate aggregate, SqlKind... expectedKinds) {
+        assertEquals("aggCall count mismatch", expectedKinds.length, aggregate.getAggCallList().size());
+        for (int i = 0; i < expectedKinds.length; i++) {
+            assertEquals(
+                "aggCall " + i + " kind mismatch",
+                expectedKinds[i],
+                aggregate.getAggCallList().get(i).getAggregation().getKind()
+            );
+        }
+    }
+}


### PR DESCRIPTION
  ### Description
  
  Adds support for the SQL `STATS(field)` bundle aggregate function in the analytics engine sandbox. `STATS` returns a struct of `{count, min, max, avg, sum}` — same shape and field order as legacy OpenSearch's `InternalStats` aggregation.
  
  #### Approach: HEP-time decomposition into primitives
  
  A new HEP rule, `OpenSearchStatsReduceRule`, runs in `PlannerImpl.decomposeAggregates` (alongside the existing `OpenSearchAggregateReduceRule` that handles AVG/STDDEV/VAR). When the rule sees a `LogicalAggregate` containing a `STATS` aggregate call, it rewrites the plan into:
  
  Project [stats = STRUCT(count, min, max, avg, sum)]
    └── LogicalAggregate [SUM(x), MIN(x), MAX(x), COUNT(x)]
         └── (input)
  
  The Project assembles the result struct using Calcite's `ROW` operator. `avg` is computed inline as `CAST(sum AS DOUBLE) / CAST(count AS DOUBLE)`. Subsequent planner phases (marking, Volcano CBO, partial/final split, fragment conversion, DataFusion execution) see only standard primitive aggregates,
  which already have full backend support.
  
  #### Why HEP-time decomposition
  
  `STATS` has no executor implementation in this codebase and isn't a Calcite standard `SqlKind` that the stock `AggregateReduceFunctionsRule` knows how to reduce. Rewriting at HEP keeps `STATS` invisible to downstream phases while reusing battle-tested primitives.
  
  #### SPI additions
  
  - `OpenSearchAggregateOperators.STATS` — custom `SqlAggFunction` singleton with the struct return type. Public so frontends can emit calls to it.
  - `AggregateFunction.STATS` — registers the function category and `SqlKind.OTHER`.
  - `ScalarFunction.ROW` — registers Calcite's struct constructor used by the assembly Project.
  
  #### Notable design choices
  
  - **Emission order `[SUM, MIN, MAX, COUNT]`** (not `[COUNT, MIN, MAX, SUM]`). After Volcano split, FINAL's aggregate calls reuse the original `argList` against PARTIAL's output. Putting `SUM` first means `PARTIAL.col[1]` has the same Calcite type as the source field, so FINAL's `typeMatchesInferred`
  assertion passes for MIN/MAX/SUM. `DistributedAggregateRewriter` corrects argList semantics post-Volcano.
  - **Struct field order `count, min, max, avg, sum`** — matches `InternalStats.doXContentBody` for backward compatibility with any client tooling that consumes results positionally.
  
  #### Tests
  
  - `OpenSearchStatsReduceRuleTests` — 9 unit tests covering single STATS, multiple STATS, STATS mixed with other aggregates, STATS with GROUP BY, FILTER and DISTINCT propagation, struct field names/types, and the no-op case.
  - `StatsAggregatePlanShapeTests` — 4 integration tests through the full `PlannerImpl.runAllOptimizations` covering 1-shard, 2-shard, GROUP BY, and STATS-mixed-with-COUNT scenarios.