### PR TITLE
Fix safe-commit info and replication checksum for DFA shards

### DIFF
--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/index/LuceneCommitter.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/index/LuceneCommitter.java
@@ -31,7 +31,6 @@ import org.opensearch.be.lucene.LuceneReader;
 import org.opensearch.common.annotation.ExperimentalApi;
 import org.opensearch.index.engine.CommitStats;
 import org.opensearch.index.engine.EngineConfig;
-import org.opensearch.index.engine.SafeCommitInfo;
 import org.opensearch.index.engine.dataformat.DocumentInput;
 import org.opensearch.index.engine.exec.CombinedCatalogSnapshotDeletionPolicy;
 import org.opensearch.index.engine.exec.commit.Committer;
@@ -203,17 +202,6 @@ public class LuceneCommitter extends SafeBootstrapCommitter {
             logger.warn("Failed to read segment infos for commit stats", e);
             return null;
         }
-    }
-
-    /**
-     * Not yet implemented. Will return safe commit info once the index deleter is wired in.
-     *
-     * @return never returns normally
-     * @throws UnsupportedOperationException always
-     */
-    @Override
-    public SafeCommitInfo getSafeCommitInfo() {
-        throw new UnsupportedOperationException("TODO:: with index deleter");
     }
 
     @Override

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/index/LuceneReplicaCommitter.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/index/LuceneReplicaCommitter.java
@@ -12,7 +12,6 @@ import org.apache.lucene.index.IndexFileNames;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.SegmentInfos;
 import org.opensearch.index.engine.CommitStats;
-import org.opensearch.index.engine.SafeCommitInfo;
 import org.opensearch.index.engine.exec.commit.Committer;
 import org.opensearch.index.engine.exec.commit.CommitterConfig;
 import org.opensearch.index.engine.exec.coord.CatalogSnapshot;
@@ -110,11 +109,6 @@ public class LuceneReplicaCommitter implements Committer {
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
-    }
-
-    @Override
-    public SafeCommitInfo getSafeCommitInfo() {
-        return null;
     }
 
     @Override

--- a/sandbox/plugins/composite-engine/src/test/java/org/opensearch/composite/CompositeIndexingExecutionEngineTests.java
+++ b/sandbox/plugins/composite-engine/src/test/java/org/opensearch/composite/CompositeIndexingExecutionEngineTests.java
@@ -13,7 +13,6 @@ import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.index.engine.CommitStats;
-import org.opensearch.index.engine.SafeCommitInfo;
 import org.opensearch.index.engine.dataformat.DataFormat;
 import org.opensearch.index.engine.dataformat.DataFormatPlugin;
 import org.opensearch.index.engine.dataformat.DataFormatRegistry;
@@ -271,11 +270,6 @@ public class CompositeIndexingExecutionEngineTests extends OpenSearchTestCase {
         @Override
         public CommitStats getCommitStats() {
             return null;
-        }
-
-        @Override
-        public SafeCommitInfo getSafeCommitInfo() {
-            return SafeCommitInfo.EMPTY;
         }
 
         @Override

--- a/sandbox/plugins/composite-engine/src/test/java/org/opensearch/composite/CompositeTestHelper.java
+++ b/sandbox/plugins/composite-engine/src/test/java/org/opensearch/composite/CompositeTestHelper.java
@@ -13,7 +13,6 @@ import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.index.engine.CommitStats;
-import org.opensearch.index.engine.SafeCommitInfo;
 import org.opensearch.index.engine.dataformat.DataFormat;
 import org.opensearch.index.engine.dataformat.DataFormatPlugin;
 import org.opensearch.index.engine.dataformat.DataFormatRegistry;
@@ -369,11 +368,6 @@ final class CompositeTestHelper {
         @Override
         public CommitStats getCommitStats() {
             return null;
-        }
-
-        @Override
-        public SafeCommitInfo getSafeCommitInfo() {
-            return SafeCommitInfo.EMPTY;
         }
 
         @Override

--- a/server/src/main/java/org/opensearch/index/engine/DataFormatAwareEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/DataFormatAwareEngine.java
@@ -1378,7 +1378,7 @@ public class DataFormatAwareEngine implements Indexer {
 
     @Override
     public SafeCommitInfo getSafeCommitInfo() {
-        return committer.getSafeCommitInfo();
+        return catalogSnapshotManager.getSafeCommitInfo();
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/index/engine/DataFormatAwareNRTReplicationEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/DataFormatAwareNRTReplicationEngine.java
@@ -529,7 +529,7 @@ public class DataFormatAwareNRTReplicationEngine implements Indexer {
     @Override
     public GatedCloseable<CatalogSnapshot> acquireSafeCatalogSnapshot() throws EngineException {
         ensureOpen();
-        return catalogSnapshotManager.acquireSnapshot();
+        return acquireLastCommittedSnapshot(false);
     }
 
     @Override
@@ -544,7 +544,7 @@ public class DataFormatAwareNRTReplicationEngine implements Indexer {
     @Override
     public SafeCommitInfo getSafeCommitInfo() {
         ensureOpen();
-        try (GatedCloseable<CatalogSnapshot> snapshot = catalogSnapshotManager.acquireSnapshot()) {
+        try (GatedCloseable<CatalogSnapshot> snapshot = catalogSnapshotManager.acquireCommittedSnapshot(true)) {
             return new SafeCommitInfo(localCheckpointTracker.getProcessedCheckpoint(), (int) snapshot.get().getNumDocs());
         } catch (IOException e) {
             throw new UncheckedIOException(e);
@@ -991,6 +991,13 @@ public class DataFormatAwareNRTReplicationEngine implements Indexer {
             final CatalogSnapshot snapshot = lastSnapshot;
             acquiredSnapshots.add(snapshot);
             return new GatedCloseable<>(snapshot, () -> { acquiredSnapshots.remove(snapshot); });
+        }
+
+        @Override
+        public SafeCommitInfo getSafeCommitInfo() {
+            // Replicas track safe commit info on the engine itself (see DataFormatAwareNRTReplicationEngine#getSafeCommitInfo);
+            // this policy is not used to compute it.
+            return SafeCommitInfo.EMPTY;
         }
 
         /**

--- a/server/src/main/java/org/opensearch/index/engine/DataFormatAwareNRTReplicationEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/DataFormatAwareNRTReplicationEngine.java
@@ -545,7 +545,10 @@ public class DataFormatAwareNRTReplicationEngine implements Indexer {
     public SafeCommitInfo getSafeCommitInfo() {
         ensureOpen();
         try (GatedCloseable<CatalogSnapshot> snapshot = catalogSnapshotManager.acquireCommittedSnapshot(true)) {
-            return new SafeCommitInfo(localCheckpointTracker.getProcessedCheckpoint(), (int) snapshot.get().getNumDocs());
+            CatalogSnapshot cs = snapshot.get();
+            String lcp = cs.getUserData().get(SequenceNumbers.LOCAL_CHECKPOINT_KEY);
+            long localCheckpoint = lcp != null ? Long.parseLong(lcp) : SequenceNumbers.NO_OPS_PERFORMED;
+            return new SafeCommitInfo(localCheckpoint, (int) cs.getNumDocs());
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/server/src/main/java/org/opensearch/index/engine/DataFormatAwareReadOnlyEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/DataFormatAwareReadOnlyEngine.java
@@ -720,6 +720,11 @@ public class DataFormatAwareReadOnlyEngine implements Indexer {
         public List<CatalogSnapshot> onCommit(List<CatalogSnapshot> commits) {
             return Collections.emptyList();
         }
+
+        @Override
+        public SafeCommitInfo getSafeCommitInfo() {
+            return SafeCommitInfo.EMPTY;
+        }
     }
 
     CatalogSnapshotManager getCatalogSnapshotManager() {

--- a/server/src/main/java/org/opensearch/index/engine/NRTReplicationEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/NRTReplicationEngine.java
@@ -410,7 +410,7 @@ public class NRTReplicationEngine extends Engine {
     @ExperimentalApi
     @Override
     public GatedCloseable<CatalogSnapshot> acquireSafeCatalogSnapshot() throws EngineException {
-        return acquireLastCatalogSnapshot(false);
+        return acquireLastCommitedCatalogSnapshot(false);
     }
 
     /**
@@ -418,7 +418,7 @@ public class NRTReplicationEngine extends Engine {
      * in-memory {@code lastCommittedSegmentInfos} as a {@link SegmentInfosCatalogSnapshot} while
      * pinning the referenced files via {@code replicaFileTracker}. Avoids re-reading {@code segments_N}.
      */
-    private GatedCloseable<CatalogSnapshot> acquireLastCatalogSnapshot(boolean flushFirst) throws EngineException {
+    private GatedCloseable<CatalogSnapshot> acquireLastCommitedCatalogSnapshot(boolean flushFirst) throws EngineException {
         if (flushFirst) {
             flush(false, true);
         }

--- a/server/src/main/java/org/opensearch/index/engine/exec/CatalogSnapshotDeletionPolicy.java
+++ b/server/src/main/java/org/opensearch/index/engine/exec/CatalogSnapshotDeletionPolicy.java
@@ -10,6 +10,7 @@ package org.opensearch.index.engine.exec;
 
 import org.opensearch.common.annotation.ExperimentalApi;
 import org.opensearch.common.concurrent.GatedCloseable;
+import org.opensearch.index.engine.SafeCommitInfo;
 import org.opensearch.index.engine.exec.coord.CatalogSnapshot;
 
 import java.io.IOException;
@@ -42,6 +43,11 @@ public interface CatalogSnapshotDeletionPolicy {
                 return Collections.emptyList();
             }
             return new ArrayList<>(commits.subList(0, commits.size() - 1));
+        }
+
+        @Override
+        public SafeCommitInfo getSafeCommitInfo() {
+            return SafeCommitInfo.EMPTY;
         }
     };
 
@@ -81,4 +87,9 @@ public interface CatalogSnapshotDeletionPolicy {
     default CatalogSnapshot findSafeCommit(List<CatalogSnapshot> commits) throws IOException {
         throw new UnsupportedOperationException("findSafeCommit not supported by this policy");
     }
+
+    /**
+     * Returns information about the safe commit, for making decisions about recoveries.
+     */
+    SafeCommitInfo getSafeCommitInfo();
 }

--- a/server/src/main/java/org/opensearch/index/engine/exec/CombinedCatalogSnapshotDeletionPolicy.java
+++ b/server/src/main/java/org/opensearch/index/engine/exec/CombinedCatalogSnapshotDeletionPolicy.java
@@ -211,6 +211,7 @@ public class CombinedCatalogSnapshotDeletionPolicy implements CatalogSnapshotDel
     /**
      * Returns information about the safe commit, for making decisions about recoveries.
      */
+    @Override
     public SafeCommitInfo getSafeCommitInfo() {
         return safeCommitInfo;
     }

--- a/server/src/main/java/org/opensearch/index/engine/exec/commit/Committer.java
+++ b/server/src/main/java/org/opensearch/index/engine/exec/commit/Committer.java
@@ -10,7 +10,6 @@ package org.opensearch.index.engine.exec.commit;
 
 import org.opensearch.common.annotation.ExperimentalApi;
 import org.opensearch.index.engine.CommitStats;
-import org.opensearch.index.engine.SafeCommitInfo;
 import org.opensearch.index.engine.exec.CommitFileManager;
 import org.opensearch.index.engine.exec.coord.CatalogSnapshot;
 
@@ -88,13 +87,6 @@ public interface Committer extends CommitFileManager, Closeable {
      * @return the commit stats, or null if no commit has occurred
      */
     CommitStats getCommitStats();
-
-    /**
-     * Returns information about the safe commit point for recovery decisions.
-     *
-     * @return the safe commit info
-     */
-    SafeCommitInfo getSafeCommitInfo();
 
     /**
      * Discovers all persisted committed catalog snapshots from the backing store.

--- a/server/src/main/java/org/opensearch/index/engine/exec/coord/CatalogSnapshotManager.java
+++ b/server/src/main/java/org/opensearch/index/engine/exec/coord/CatalogSnapshotManager.java
@@ -14,6 +14,7 @@ import org.opensearch.common.CheckedFunction;
 import org.opensearch.common.annotation.ExperimentalApi;
 import org.opensearch.common.concurrent.GatedCloseable;
 import org.opensearch.common.concurrent.GatedConditionalCloseable;
+import org.opensearch.index.engine.SafeCommitInfo;
 import org.opensearch.index.engine.dataformat.DataFormat;
 import org.opensearch.index.engine.dataformat.MergeResult;
 import org.opensearch.index.engine.dataformat.merge.OneMerge;
@@ -509,6 +510,13 @@ public class CatalogSnapshotManager implements Closeable {
                 throw new RuntimeException("Failed to release committed snapshot [gen=" + policyRef.get().getGeneration() + "]", e);
             }
         });
+    }
+
+    /**
+     * Returns information about the safe commit from the underlying deletion policy.
+     */
+    public SafeCommitInfo getSafeCommitInfo() {
+        return deletionPolicy.getSafeCommitInfo();
     }
 
     // ---- Internal ----

--- a/server/src/main/java/org/opensearch/index/shard/RemoteStoreRefreshListener.java
+++ b/server/src/main/java/org/opensearch/index/shard/RemoteStoreRefreshListener.java
@@ -255,7 +255,13 @@ public final class RemoteStoreRefreshListener extends ReleasableRetryableRefresh
                 }
 
                 try (GatedCloseable<CatalogSnapshot> catalogSnapshotRef = indexShard.getCatalogSnapshot()) {
-                    CatalogSnapshot catalogSnapshot = catalogSnapshotRef.get();
+                    // Clone to freeze lastCommitGeneration and other mutable state for the
+                    // duration of this upload cycle. Without cloning, a concurrent flush can
+                    // call CatalogSnapshotManager.updateLastCommitInfo which mutates the live
+                    // snapshot's lastCommitGeneration — causing the retry path (which runs
+                    // asynchronously) to serialize segment metadata with a different generation
+                    // than the one used for the initial segment file upload.
+                    CatalogSnapshot catalogSnapshot = catalogSnapshotRef.get().clone();
                     final ReplicationCheckpoint checkpoint = indexShard.computeReplicationCheckpoint(catalogSnapshot);
                     if (checkpoint.getPrimaryTerm() != indexShard.getOperationPrimaryTerm()) {
                         throw new IllegalStateException(

--- a/server/src/main/java/org/opensearch/index/store/Store.java
+++ b/server/src/main/java/org/opensearch/index/store/Store.java
@@ -116,7 +116,6 @@ import java.io.UncheckedIOException;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -496,36 +495,6 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
             markStoreCorrupted(ex);
             throw ex;
         }
-    }
-
-    /**
-     * Computes {@link StoreFileMetadata} for a specific set of files. Unlike
-     * {@link #getSegmentMetadataMap(CatalogSnapshot)} which processes all files in a snapshot,
-     * this method only reads checksums for the requested files — suitable for merged segment
-     * checkpoint computation where only one segment's files are needed.
-     *
-     * @param files collection of file names to compute metadata for (may be format-aware names)
-     * @return map of filename to {@link StoreFileMetadata}
-     * @throws IOException on I/O error during checksum computation
-     */
-    @ExperimentalApi
-    public Map<String, StoreFileMetadata> getFileMetadata(Collection<String> files) throws IOException {
-        failIfCorrupted();
-        Map<String, StoreFileMetadata> result = new HashMap<>();
-        for (String file : files) {
-            final long length = directory.fileLength(file);
-            final String checksum;
-            final DataFormatAwareStoreDirectory dfasd = DataFormatAwareStoreDirectory.unwrap(directory);
-            if (dfasd != null && DataFormatAwareStoreDirectory.isDefaultFormat(FileMetadata.parseDataFormat(file)) == false) {
-                checksum = dfasd.calculateUploadChecksum(file);
-            } else {
-                try (IndexInput in = directory.openInput(file, IOContext.READONCE)) {
-                    checksum = Store.digestToString(CodecUtil.retrieveChecksum(in));
-                }
-            }
-            result.put(file, new StoreFileMetadata(file, length, checksum, org.opensearch.Version.CURRENT.luceneVersion));
-        }
-        return result;
     }
 
     /**
@@ -1782,6 +1751,29 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
      */
     public static String digestToString(long digest) {
         return Long.toString(digest, Character.MAX_RADIX);
+    }
+
+    /**
+     * Computes the checksum of a local file in this store using the same strategy as
+     * {@link MetadataSnapshot#checksumFromFile}: when the directory unwraps to a
+     * {@link DataFormatAwareStoreDirectory}, the format-aware
+     * {@link DataFormatAwareStoreDirectory#calculateUploadChecksum} is used so that
+     * non-Lucene files (e.g. parquet) produce a checksum comparable to the one stored
+     * in {@link StoreFileMetadata#checksum()}. Otherwise the Lucene codec footer is read
+     * via {@link CodecUtil#retrieveChecksum}.
+     *
+     * @param fileName the file name to checksum, relative to this store's directory
+     * @return checksum string in the same format as {@link StoreFileMetadata#checksum()}
+     */
+    public String checksumLocalFile(String fileName) throws IOException {
+        ensureOpen();
+        final DataFormatAwareStoreDirectory dfasd = DataFormatAwareStoreDirectory.unwrap(directory());
+        if (dfasd != null) {
+            return digestToString(Long.parseLong(dfasd.calculateUploadChecksum(fileName)));
+        }
+        try (IndexInput input = directory().openInput(fileName, IOContext.READONCE)) {
+            return digestToString(CodecUtil.retrieveChecksum(input));
+        }
     }
 
     /**

--- a/server/src/main/java/org/opensearch/indices/replication/AbstractSegmentReplicationTarget.java
+++ b/server/src/main/java/org/opensearch/indices/replication/AbstractSegmentReplicationTarget.java
@@ -9,9 +9,6 @@
 package org.opensearch.indices.replication;
 
 import org.apache.logging.log4j.message.ParameterizedMessage;
-import org.apache.lucene.codecs.CodecUtil;
-import org.apache.lucene.store.IOContext;
-import org.apache.lucene.store.IndexInput;
 import org.opensearch.OpenSearchCorruptionException;
 import org.opensearch.action.StepListener;
 import org.opensearch.common.util.CancellableThreads;
@@ -271,8 +268,8 @@ public abstract class AbstractSegmentReplicationTarget extends ReplicationTarget
 
     // pkg private for tests
     private boolean validateLocalChecksum(StoreFileMetadata file) {
-        try (IndexInput indexInput = indexShard.store().directory().openInput(file.name(), IOContext.READONCE)) {
-            String checksum = Store.digestToString(CodecUtil.retrieveChecksum(indexInput));
+        try {
+            final String checksum = indexShard.store().checksumLocalFile(file.name());
             if (file.checksum().equals(checksum)) {
                 return true;
             } else {

--- a/server/src/main/java/org/opensearch/indices/replication/RemoteStoreReplicationSource.java
+++ b/server/src/main/java/org/opensearch/indices/replication/RemoteStoreReplicationSource.java
@@ -72,7 +72,7 @@ public class RemoteStoreReplicationSource implements SegmentReplicationSource {
     ) {
         Map<String, StoreFileMetadata> metadataMap;
         // TODO: Need to figure out a way to pass this information for segment metadata via remote store.
-        try (GatedCloseable<CatalogSnapshot> catalogSnapshotRef = indexShard.getCatalogSnapshot()){
+        try (GatedCloseable<CatalogSnapshot> catalogSnapshotRef = indexShard.getCatalogSnapshot()) {
 
             final Version version = LuceneVersionConverter.toLuceneOrLatest(catalogSnapshotRef.get().getCommitDataFormatVersion());
             final RemoteSegmentMetadata mdFile = getRemoteSegmentMetadata();

--- a/server/src/main/java/org/opensearch/indices/replication/RemoteStoreReplicationSource.java
+++ b/server/src/main/java/org/opensearch/indices/replication/RemoteStoreReplicationSource.java
@@ -72,11 +72,9 @@ public class RemoteStoreReplicationSource implements SegmentReplicationSource {
     ) {
         Map<String, StoreFileMetadata> metadataMap;
         // TODO: Need to figure out a way to pass this information for segment metadata via remote store.
-        try {
-            final Version version;
-            try (GatedCloseable<CatalogSnapshot> catalogSnapshotRef = indexShard.getCatalogSnapshot()) {
-                version = LuceneVersionConverter.toLuceneOrLatest(catalogSnapshotRef.get().getCommitDataFormatVersion());
-            }
+        try (GatedCloseable<CatalogSnapshot> catalogSnapshotRef = indexShard.getCatalogSnapshot()){
+
+            final Version version = LuceneVersionConverter.toLuceneOrLatest(catalogSnapshotRef.get().getCommitDataFormatVersion());
             final RemoteSegmentMetadata mdFile = getRemoteSegmentMetadata();
 
             // Handle null metadata file case

--- a/server/src/test/java/org/opensearch/index/engine/DataFormatAwareEngineRecoveryTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/DataFormatAwareEngineRecoveryTests.java
@@ -197,11 +197,6 @@ public class DataFormatAwareEngineRecoveryTests extends OpenSearchTestCase {
         }
 
         @Override
-        public SafeCommitInfo getSafeCommitInfo() {
-            return SafeCommitInfo.EMPTY;
-        }
-
-        @Override
         public List<CatalogSnapshot> listCommittedSnapshots() {
             if (lastCommittedSnapshot != null) {
                 return List.of(lastCommittedSnapshot);

--- a/server/src/test/java/org/opensearch/index/engine/exec/commit/CommitterTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/exec/commit/CommitterTests.java
@@ -9,7 +9,6 @@
 package org.opensearch.index.engine.exec.commit;
 
 import org.opensearch.index.engine.CommitStats;
-import org.opensearch.index.engine.SafeCommitInfo;
 import org.opensearch.index.engine.exec.commit.Committer.CommitInput;
 import org.opensearch.test.OpenSearchTestCase;
 
@@ -40,11 +39,6 @@ public class CommitterTests extends OpenSearchTestCase {
             @Override
             public CommitStats getCommitStats() {
                 return null;
-            }
-
-            @Override
-            public SafeCommitInfo getSafeCommitInfo() {
-                return SafeCommitInfo.EMPTY;
             }
 
             @Override
@@ -95,11 +89,6 @@ public class CommitterTests extends OpenSearchTestCase {
             }
 
             @Override
-            public SafeCommitInfo getSafeCommitInfo() {
-                return SafeCommitInfo.EMPTY;
-            }
-
-            @Override
             public java.util.List<org.opensearch.index.engine.exec.coord.CatalogSnapshot> listCommittedSnapshots() {
                 return java.util.List.of();
             }
@@ -141,11 +130,6 @@ public class CommitterTests extends OpenSearchTestCase {
             @Override
             public CommitStats getCommitStats() {
                 return null;
-            }
-
-            @Override
-            public SafeCommitInfo getSafeCommitInfo() {
-                return SafeCommitInfo.EMPTY;
             }
 
             @Override

--- a/server/src/test/java/org/opensearch/index/engine/exec/coord/CatalogSnapshotManagerTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/exec/coord/CatalogSnapshotManagerTests.java
@@ -12,6 +12,7 @@ import org.opensearch.common.concurrent.GatedCloseable;
 import org.opensearch.common.concurrent.GatedConditionalCloseable;
 import org.opensearch.core.index.Index;
 import org.opensearch.core.index.shard.ShardId;
+import org.opensearch.index.engine.SafeCommitInfo;
 import org.opensearch.index.engine.dataformat.DataFormat;
 import org.opensearch.index.engine.dataformat.MergeResult;
 import org.opensearch.index.engine.dataformat.merge.OneMerge;
@@ -922,6 +923,44 @@ public class CatalogSnapshotManagerTests extends OpenSearchTestCase {
             }
             assertTrue("pre-existing files must not be touched by empty-initial bootstrap", Files.exists(leftover));
         }
+    }
+
+    public void testGetSafeCommitInfoDelegatesToPolicy() throws IOException {
+        AtomicLong globalCP = new AtomicLong(100);
+        CombinedCatalogSnapshotDeletionPolicy policy = new CombinedCatalogSnapshotDeletionPolicy(
+            logger,
+            new DefaultTranslogDeletionPolicy(-1, -1, 0),
+            globalCP::get
+        );
+        DataformatAwareCatalogSnapshot snapshot = new DataformatAwareCatalogSnapshot(
+            1L,
+            1L,
+            0L,
+            List.of(),
+            1L,
+            Map.of("local_checkpoint", "50", "max_seq_no", "100", "translog_uuid", "test-uuid")
+        );
+        snapshot.setLastCommitInfo("segments_1", 1L, 0L);
+        CatalogSnapshotManager manager = new CatalogSnapshotManager(
+            List.of(snapshot),
+            policy,
+            files -> Map.of(),
+            Map.of(),
+            List.of(),
+            null,
+            mock(CommitFileManager.class)
+        );
+        SafeCommitInfo info = manager.getSafeCommitInfo();
+        assertEquals(50L, info.localCheckpoint);
+        assertEquals(0, info.docCount);
+        manager.close();
+    }
+
+    public void testGetSafeCommitInfoWithKeepLatestOnlyReturnsEmpty() throws IOException {
+        CatalogSnapshotManager manager = createRandomManager();
+        SafeCommitInfo info = manager.getSafeCommitInfo();
+        assertEquals(SafeCommitInfo.EMPTY, info);
+        manager.close();
     }
 
     private CatalogSnapshotManager createRandomManager() {

--- a/server/src/test/java/org/opensearch/index/engine/exec/coord/SafeBootstrapCommitterTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/exec/coord/SafeBootstrapCommitterTests.java
@@ -15,7 +15,6 @@ import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.index.engine.CommitStats;
 import org.opensearch.index.engine.EngineConfig;
-import org.opensearch.index.engine.SafeCommitInfo;
 import org.opensearch.index.engine.exec.commit.CommitterConfig;
 import org.opensearch.index.engine.exec.commit.SafeBootstrapCommitter;
 import org.opensearch.index.seqno.RetentionLeases;
@@ -69,11 +68,6 @@ public class SafeBootstrapCommitterTests extends OpenSearchTestCase {
         @Override
         public CommitStats getCommitStats() {
             return null;
-        }
-
-        @Override
-        public SafeCommitInfo getSafeCommitInfo() {
-            return SafeCommitInfo.EMPTY;
         }
 
         @Override

--- a/server/src/test/java/org/opensearch/index/store/StoreTests.java
+++ b/server/src/test/java/org/opensearch/index/store/StoreTests.java
@@ -51,6 +51,7 @@ import org.apache.lucene.index.NoMergePolicy;
 import org.apache.lucene.index.SegmentInfos;
 import org.apache.lucene.index.SnapshotDeletionPolicy;
 import org.apache.lucene.index.Term;
+import org.apache.lucene.store.AlreadyClosedException;
 import org.apache.lucene.store.ByteBuffersDirectory;
 import org.apache.lucene.store.ChecksumIndexInput;
 import org.apache.lucene.store.Directory;
@@ -86,6 +87,7 @@ import org.opensearch.index.seqno.ReplicationTracker;
 import org.opensearch.index.seqno.RetentionLease;
 import org.opensearch.index.seqno.SequenceNumbers;
 import org.opensearch.index.shard.ShardPath;
+import org.opensearch.index.store.checksum.GenericCRC32ChecksumHandler;
 import org.opensearch.index.translog.Translog;
 import org.opensearch.indices.replication.common.ReplicationType;
 import org.opensearch.indices.store.TransportNodesListShardStoreMetadataHelper.StoreFilesMetadata;
@@ -1463,6 +1465,79 @@ public class StoreTests extends OpenSearchTestCase {
         assertEquals("numDocs must be 0 for DFA", 0L, loaded.numDocs);
 
         IOUtils.close(store);
+    }
+
+    public void testChecksumLocalFileWithLuceneCodecFooter() throws IOException {
+        final ShardId shardId = new ShardId("index", "_na_", 1);
+        Store store = new Store(shardId, INDEX_SETTINGS, StoreTests.newDirectory(random()), new DummyShardLock(shardId));
+        // Write a .si file with a valid Lucene codec footer
+        try (IndexOutput output = store.directory().createOutput("_0.si", IOContext.DEFAULT)) {
+            output.writeBytes(new byte[] { 1, 2, 3, 4, 5 }, 5);
+            CodecUtil.writeFooter(output);
+        }
+        String checksum = store.checksumLocalFile("_0.si");
+        assertNotNull(checksum);
+        // Verify it matches what CodecUtil.retrieveChecksum returns
+        try (IndexInput input = store.directory().openInput("_0.si", IOContext.DEFAULT)) {
+            String expected = Store.digestToString(CodecUtil.retrieveChecksum(input));
+            assertEquals(expected, checksum);
+        }
+        IOUtils.close(store);
+    }
+
+    public void testChecksumLocalFileWithDataFormatAwareDirectory() throws IOException {
+        final ShardId shardId = new ShardId("index", "_na_", 1);
+        final Path tempDir = createTempDir();
+        final Path shardDir = tempDir.resolve(shardId.getIndex().getUUID()).resolve(String.valueOf(shardId.id()));
+        final ShardPath shardPath = new ShardPath(false, shardDir, shardDir, shardId);
+        // Create a DataFormatAwareStoreDirectory with a "parquet" checksum strategy (CRC32)
+        Directory fsDir = newFSDirectory(shardPath.resolveIndex());
+        DataFormatAwareStoreDirectory dfaDir = new DataFormatAwareStoreDirectory(
+            fsDir,
+            shardPath,
+            Map.of("parquet", new GenericCRC32ChecksumHandler())
+        );
+        Store store = new Store(shardId, INDEX_SETTINGS, dfaDir, new DummyShardLock(shardId), Store.OnClose.EMPTY, shardPath, null);
+
+        // Write a parquet file (non-Lucene format — full-file CRC32)
+        byte[] parquetContent = new byte[] { 10, 20, 30, 40, 50, 60 };
+        try (IndexOutput output = dfaDir.createOutput("parquet/_0.parquet", IOContext.DEFAULT)) {
+            output.writeBytes(parquetContent, parquetContent.length);
+        }
+        // Write a Lucene .si file with codec footer
+        try (IndexOutput output = dfaDir.createOutput("_0.si", IOContext.DEFAULT)) {
+            output.writeBytes(new byte[] { 1, 2, 3 }, 3);
+            CodecUtil.writeFooter(output);
+        }
+
+        // Verify parquet file uses CRC32 checksum (not codec footer)
+        String parquetChecksum = store.checksumLocalFile("parquet/_0.parquet");
+        assertNotNull(parquetChecksum);
+        java.util.zip.CRC32 crc32 = new java.util.zip.CRC32();
+        crc32.update(parquetContent);
+        String expectedParquet = Store.digestToString(crc32.getValue());
+        assertEquals("parquet file should use full-file CRC32", expectedParquet, parquetChecksum);
+
+        // Verify .si file uses Lucene codec footer checksum
+        String siChecksum = store.checksumLocalFile("_0.si");
+        assertNotNull(siChecksum);
+        try (IndexInput input = dfaDir.openInput("_0.si", IOContext.DEFAULT)) {
+            String expectedSi = Store.digestToString(CodecUtil.retrieveChecksum(input));
+            assertEquals("Lucene file should use codec footer", expectedSi, siChecksum);
+        }
+
+        IOUtils.close(store);
+    }
+
+    public void testChecksumLocalFileThrowsOnClosedStore() throws IOException {
+        final ShardId shardId = new ShardId("index", "_na_", 1);
+        Store store = new Store(shardId, INDEX_SETTINGS, StoreTests.newDirectory(random()), new DummyShardLock(shardId));
+        try (IndexOutput output = store.directory().createOutput("_0.si", IOContext.DEFAULT)) {
+            output.writeBytes(new byte[] { 1, 2, 3 }, 3);
+            CodecUtil.writeFooter(output);
+        }
+        store.close();
+        expectThrows(AlreadyClosedException.class, () -> store.checksumLocalFile("_0.si"));
     }
 
     public void testShardFormatDirectoryResolverRoutesByFormat() throws IOException {

--- a/test/framework/src/main/java/org/opensearch/index/engine/dataformat/stub/InMemoryCommitter.java
+++ b/test/framework/src/main/java/org/opensearch/index/engine/dataformat/stub/InMemoryCommitter.java
@@ -10,7 +10,6 @@ package org.opensearch.index.engine.dataformat.stub;
 
 import org.apache.lucene.index.SegmentInfos;
 import org.opensearch.index.engine.CommitStats;
-import org.opensearch.index.engine.SafeCommitInfo;
 import org.opensearch.index.engine.exec.commit.Committer;
 import org.opensearch.index.engine.exec.coord.CatalogSnapshot;
 import org.opensearch.index.engine.exec.coord.CatalogSnapshotManager;
@@ -67,11 +66,6 @@ public class InMemoryCommitter implements Committer {
         } catch (IOException e) {
             return null;
         }
-    }
-
-    @Override
-    public SafeCommitInfo getSafeCommitInfo() {
-        return SafeCommitInfo.EMPTY;
     }
 
     @Override


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Two bug fixes in the DataFormat-Aware (DFA) replication path, surfaced by DataFormatAwareReplicationIT.
  
  1. Move getSafeCommitInfo to CatalogSnapshotManager / deletion policy
  
  DataFormatAwareEngine.getSafeCommitInfo() delegated to committer.getSafeCommitInfo(), where the only implementation threw UnsupportedOperationException("TODO:: with index deleter").
  Any caller of IndexShard.getSafeCommitInfo() therefore crashed — most visibly the periodic retention-lease sync, which calls it via
  ReplicationTracker.getMinimumReasonableRetainedSeqNo() whenever a replica is missing. Stale peer-recovery leases consequently never expired.
  
  Fix: move getSafeCommitInfo() from the Committer SPI to CatalogSnapshotDeletionPolicy / CatalogSnapshotManager, where CombinedCatalogSnapshotDeletionPolicy already maintains a cached
  volatile SafeCommitInfo updated in synchronized onCommit. New chain mirrors InternalEngine → CombinedDeletionPolicy.getSafeCommitInfo() exactly:
  
  IndexShard → DataFormatAwareEngine → CatalogSnapshotManager → CatalogSnapshotDeletionPolicy
  
  Replica path (DataFormatAwareNRTReplicationEngine.getSafeCommitInfo) is unchanged. getSafeCommitInfo is dropped from the Committer interface (only one caller existed) and from the
  corresponding stubs.
  
  2. Fix validateLocalChecksum to use format-aware checksum for DFA shards
  
  AbstractSegmentReplicationTarget.validateLocalChecksum unconditionally called CodecUtil.retrieveChecksum on all files, which fails on non-Lucene formats (e.g. parquet) with
  CorruptIndexException: codec footer mismatch. This caused segment replication on DFA shards to unnecessarily delete and re-download valid local files after a crash recovery.
  
  The fix mirrors the primary-side logic in Store.checksumFromFile: unwrap the directory, and if it's a DataFormatAwareStoreDirectory, delegate to calculateUploadChecksum (which
  dispatches per format). Otherwise fall back to the existing Lucene CodecUtil path.
  
  Also removes the unused Store.getFileMetadata(Collection<String>) method and its orphaned java.util.Collection import (dead code from a prior iteration).
  


### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
