### PR TITLE
[analytics engine] Execute analytics engine plan as a local transport action to provide ActionFilter authorization

### DIFF
--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/DefaultPlanExecutor.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/DefaultPlanExecutor.java
@@ -15,13 +15,14 @@ import org.apache.calcite.rel.metadata.JaninoRelMetadataProvider;
 import org.apache.calcite.rel.metadata.RelMetadataQueryBase;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.opensearch.action.ActionRequest;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.action.support.TimeoutTaskCancellationUtility;
 import org.opensearch.analytics.AnalyticsPlugin;
 import org.opensearch.analytics.EngineContext;
 import org.opensearch.analytics.exec.action.AnalyticsQueryAction;
+import org.opensearch.analytics.exec.action.AnalyticsQueryRequest;
+import org.opensearch.analytics.exec.action.AnalyticsQueryResponse;
 import org.opensearch.analytics.exec.profile.ProfiledResult;
 import org.opensearch.analytics.exec.profile.QueryProfile;
 import org.opensearch.analytics.exec.profile.QueryProfileBuilder;
@@ -30,6 +31,7 @@ import org.opensearch.analytics.exec.task.AnalyticsQueryTaskRequest;
 import org.opensearch.analytics.planner.CapabilityRegistry;
 import org.opensearch.analytics.planner.PlannerContext;
 import org.opensearch.analytics.planner.PlannerImpl;
+import org.opensearch.analytics.planner.RelNodeUtils;
 import org.opensearch.analytics.planner.dag.BackendPlanAdapter;
 import org.opensearch.analytics.planner.dag.DAGBuilder;
 import org.opensearch.analytics.planner.dag.FragmentConversionDriver;
@@ -40,7 +42,6 @@ import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.action.ActionListener;
-import org.opensearch.core.action.ActionResponse;
 import org.opensearch.search.SearchService;
 import org.opensearch.tasks.Task;
 import org.opensearch.tasks.TaskManager;
@@ -67,7 +68,7 @@ import static org.opensearch.action.search.TransportSearchAction.SEARCH_CANCEL_A
  *
  * @opensearch.internal
  */
-public class DefaultPlanExecutor extends HandledTransportAction<ActionRequest, ActionResponse>
+public class DefaultPlanExecutor extends HandledTransportAction<AnalyticsQueryRequest, AnalyticsQueryResponse>
     implements
         QueryPlanExecutor<RelNode, Iterable<Object[]>> {
 
@@ -98,9 +99,7 @@ public class DefaultPlanExecutor extends HandledTransportAction<ActionRequest, A
         Scheduler scheduler,
         ArrowAllocatorService allocatorService
     ) {
-        super(AnalyticsQueryAction.NAME, transportService, actionFilters, in -> {
-            throw new UnsupportedOperationException("Transport path not implemented yet");
-        });
+        super(AnalyticsQueryAction.NAME, transportService, actionFilters, AnalyticsQueryRequest::new);
         this.capabilityRegistry = capabilityRegistry;
         this.clusterService = clusterService;
         this.searchExecutor = threadPool.executor(ThreadPool.Names.SEARCH);
@@ -117,24 +116,17 @@ public class DefaultPlanExecutor extends HandledTransportAction<ActionRequest, A
 
     @Override
     public void execute(RelNode logicalFragment, Object context, ActionListener<Iterable<Object[]>> listener) {
-        // Wrap listener to convert backend-specific exceptions (e.g., native memory errors
-        // arriving as StreamException from gRPC) into proper OpenSearch exception types.
-        ActionListener<Iterable<Object[]>> convertingListener = ActionListener.wrap(
-            listener::onResponse,
-            e -> listener.onFailure(e instanceof Exception ex ? engineContext.convertException(ex) : e)
+        // Dispatch through ActionModule so the SecurityFilter evaluates index-level
+        // permissions before any planning work begins. The AnalyticsQueryRequest
+        // implements IndicesRequest.Replaceable, exposing target indices extracted
+        // from the RelNode's TableScan nodes.
+        String[] indices = RelNodeUtils.extractIndices(logicalFragment);
+        AnalyticsQueryRequest request = new AnalyticsQueryRequest(logicalFragment, context, indices);
+        client.execute(
+            AnalyticsQueryAction.INSTANCE,
+            request,
+            ActionListener.wrap(resp -> listener.onResponse(resp.getRows()), listener::onFailure)
         );
-        searchExecutor.execute(() -> {
-            try {
-                // Non-profile path: unwrap rows from ProfiledResult (profile is null)
-                executeInternal(
-                    logicalFragment,
-                    false,
-                    ActionListener.wrap(result -> convertingListener.onResponse(result.rows()), convertingListener::onFailure)
-                );
-            } catch (Exception e) {
-                convertingListener.onFailure(e);
-            }
-        });
     }
 
     @Override
@@ -246,10 +238,33 @@ public class DefaultPlanExecutor extends HandledTransportAction<ActionRequest, A
     }
 
     @Override
-    protected void doExecute(Task task, ActionRequest request, ActionListener<ActionResponse> listener) {
-        // Transport path — reserved for future remote query invocation.
-        // Currently, front-ends invoke execute(RelNode, Object, ActionListener) directly.
-        listener.onFailure(new UnsupportedOperationException("Direct invocation only — use execute(RelNode, Object, ActionListener)"));
+    protected void doExecute(Task task, AnalyticsQueryRequest request, ActionListener<AnalyticsQueryResponse> listener) {
+        // Runs after SecurityFilter has authorized the request.
+        // Fork the entire query lifecycle (planning, scheduling, cleanup) onto the SEARCH
+        // executor so the calling thread — which may be a transport thread — is freed
+        // immediately. The listener is wrapped to convert backend-specific exceptions.
+        ActionListener<AnalyticsQueryResponse> convertingListener = ActionListener.wrap(
+            listener::onResponse,
+            e -> listener.onFailure(e instanceof Exception ex ? engineContext.convertException(ex) : e)
+        );
+        searchExecutor.execute(() -> {
+            try {
+                executeInternal(
+                    request.getPlan(),
+                    false,
+                    ActionListener.wrap(
+                        result -> convertingListener.onResponse(new AnalyticsQueryResponse(result.rows())),
+                        convertingListener::onFailure
+                    )
+                );
+            } catch (Exception e) {
+                convertingListener.onFailure(e);
+            } catch (AssertionError e) {
+                convertingListener.onFailure(
+                    new IllegalStateException("Analytics-engine executor rejected the plan: " + e.getMessage(), e)
+                );
+            }
+        });
     }
 
     /**

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/action/AnalyticsQueryAction.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/action/AnalyticsQueryAction.java
@@ -10,29 +10,25 @@ package org.opensearch.analytics.exec.action;
 
 import org.opensearch.action.ActionType;
 import org.opensearch.analytics.exec.DefaultPlanExecutor;
-import org.opensearch.analytics.exec.QueryPlanExecutor;
-import org.opensearch.core.action.ActionResponse;
 
 /**
- * Coordinator-level action for executing analytics queries.
+ * Coordinator-level action for executing analytics queries. Registered in
+ * {@link org.opensearch.analytics.AnalyticsPlugin#getActions()} with
+ * {@link DefaultPlanExecutor} as the handler.
  *
- * <p>Currently used as a Guice injection vehicle for {@link DefaultPlanExecutor}
- * — the transport action registration lets Guice construct the executor with all
- * its dependencies ({@code TransportService}, {@code ClusterService}, etc.).
- * Front-end plugins invoke the executor directly via
- * {@link QueryPlanExecutor#execute}, not through transport.
- *
- * <p>Future: the transport path ({@code doExecute}) will accept query strings
- * for remote invocation.
+ * <p>The action name {@code indices:data/read/analytics/query} is index-level,
+ * matching the standard {@code read} action group pattern ({@code indices:data/read*}).
+ * This ensures the security plugin's {@code SecurityFilter} evaluates index-level
+ * permissions when the request is dispatched through {@code NodeClient.execute()}.
  *
  * @opensearch.internal
  */
-public class AnalyticsQueryAction extends ActionType<ActionResponse> {
+public class AnalyticsQueryAction extends ActionType<AnalyticsQueryResponse> {
 
     public static final String NAME = "indices:data/read/analytics/query";
     public static final AnalyticsQueryAction INSTANCE = new AnalyticsQueryAction();
 
     private AnalyticsQueryAction() {
-        super(NAME, in -> { throw new UnsupportedOperationException("Transport path not implemented yet"); });
+        super(NAME, AnalyticsQueryResponse::new);
     }
 }

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/action/AnalyticsQueryRequest.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/action/AnalyticsQueryRequest.java
@@ -1,0 +1,80 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.exec.action;
+
+import org.apache.calcite.rel.RelNode;
+import org.opensearch.action.ActionRequest;
+import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.action.IndicesRequest;
+import org.opensearch.action.support.IndicesOptions;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+
+/**
+ * Request carrying a logical query plan for analytics engine execution.
+ * Implements {@link IndicesRequest.Replaceable} so the security plugin's
+ * {@code IndexResolverReplacer} can resolve and optionally narrow the
+ * target indices for permission evaluation.
+ *
+ * <p>This request is local-dispatch only (same JVM via {@code NodeClient.execute()}).
+ * The {@link RelNode} is transient and not wire-serializable.
+ */
+public class AnalyticsQueryRequest extends ActionRequest implements IndicesRequest.Replaceable {
+
+    private final transient RelNode plan;
+    private final transient Object context;
+    private String[] indices;
+
+    public AnalyticsQueryRequest(RelNode plan, Object context, String[] indices) {
+        this.plan = plan;
+        this.context = context;
+        this.indices = indices;
+    }
+
+    public AnalyticsQueryRequest(StreamInput in) throws IOException {
+        super(in);
+        throw new UnsupportedOperationException("AnalyticsQueryRequest is local-dispatch only");
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        throw new UnsupportedOperationException("AnalyticsQueryRequest is local-dispatch only");
+    }
+
+    public RelNode getPlan() {
+        return plan;
+    }
+
+    public Object getContext() {
+        return context;
+    }
+
+    @Override
+    public String[] indices() {
+        return indices;
+    }
+
+    @Override
+    public IndicesRequest indices(String... indices) {
+        this.indices = indices;
+        return this;
+    }
+
+    @Override
+    public IndicesOptions indicesOptions() {
+        return IndicesOptions.strictExpandOpen();
+    }
+
+    @Override
+    public ActionRequestValidationException validate() {
+        return null;
+    }
+}

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/action/AnalyticsQueryResponse.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/action/AnalyticsQueryResponse.java
@@ -1,0 +1,42 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.exec.action;
+
+import org.opensearch.core.action.ActionResponse;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+
+/**
+ * Response carrying materialized query results from the analytics engine.
+ * Local-dispatch only — the rows are held in-memory and not wire-serializable.
+ */
+public class AnalyticsQueryResponse extends ActionResponse {
+
+    private final transient Iterable<Object[]> rows;
+
+    public AnalyticsQueryResponse(Iterable<Object[]> rows) {
+        this.rows = rows;
+    }
+
+    public AnalyticsQueryResponse(StreamInput in) throws IOException {
+        super(in);
+        throw new UnsupportedOperationException("AnalyticsQueryResponse is local-dispatch only");
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        throw new UnsupportedOperationException("AnalyticsQueryResponse is local-dispatch only");
+    }
+
+    public Iterable<Object[]> getRows() {
+        return rows;
+    }
+}

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/RelNodeUtils.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/RelNodeUtils.java
@@ -150,4 +150,40 @@ public class RelNodeUtils {
         return null;
     }
 
+    /** Maximum recursion depth when walking a RelNode tree to extract indices. */
+    static final int MAX_EXTRACT_INDICES_DEPTH = 15;
+
+    /**
+     * Extracts all index names referenced by {@link org.apache.calcite.rel.core.TableScan}
+     * nodes in the plan. Walks the tree up to {@link #MAX_EXTRACT_INDICES_DEPTH} levels to
+     * guard against pathologically deep plans constructed from complex user queries.
+     *
+     * @param plan the root of the RelNode tree
+     * @return array of distinct index names in encounter order
+     * @throws IllegalStateException if the plan exceeds the maximum depth
+     */
+    public static String[] extractIndices(RelNode plan) {
+        java.util.Set<String> indices = new java.util.LinkedHashSet<>();
+        if (!collectIndices(plan, indices, 0)) {
+            throw new IllegalStateException("Query plan exceeds maximum depth (" + MAX_EXTRACT_INDICES_DEPTH + ") for index extraction");
+        }
+        return indices.toArray(String[]::new);
+    }
+
+    private static boolean collectIndices(RelNode node, java.util.Set<String> indices, int depth) {
+        if (depth >= MAX_EXTRACT_INDICES_DEPTH) {
+            return false;
+        }
+        if (node instanceof org.apache.calcite.rel.core.TableScan scan) {
+            java.util.List<String> names = scan.getTable().getQualifiedName();
+            indices.add(names.get(names.size() - 1));
+        }
+        for (RelNode input : node.getInputs()) {
+            if (!collectIndices(input, indices, depth + 1)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
 }

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/RelNodeUtilsTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/RelNodeUtilsTests.java
@@ -1,0 +1,138 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.planner;
+
+import org.apache.calcite.jdbc.CalciteSchema;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.JoinRelType;
+import org.apache.calcite.rel.logical.LogicalFilter;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.schema.SchemaPlus;
+import org.apache.calcite.schema.impl.AbstractTable;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.tools.Frameworks;
+import org.apache.calcite.tools.RelBuilder;
+import org.opensearch.test.OpenSearchTestCase;
+
+import static org.opensearch.analytics.planner.RelNodeUtils.MAX_EXTRACT_INDICES_DEPTH;
+
+/**
+ * Unit tests for {@link RelNodeUtils#extractIndices(RelNode)}.
+ */
+public class RelNodeUtilsTests extends OpenSearchTestCase {
+
+    private RelBuilder builder() {
+        SchemaPlus schema = CalciteSchema.createRootSchema(true).plus();
+        schema.add("my_index", new MockTable());
+        schema.add("orders", new MockTable());
+        schema.add("customers", new MockTable());
+        schema.add("events", new MockTable());
+        schema.add("metrics", new MockTable());
+        schema.add("logs_2023", new MockTable());
+        schema.add("logs_2024", new MockTable());
+        schema.add("index_a", new MockTable());
+        schema.add("index_b", new MockTable());
+        schema.add("deep_index", new MockTable());
+        return RelBuilder.create(Frameworks.newConfigBuilder().defaultSchema(schema).build());
+    }
+
+    public void testSingleTableScan() {
+        RelBuilder b = builder();
+        RelNode plan = b.scan("my_index").build();
+        assertArrayEquals(new String[] { "my_index" }, RelNodeUtils.extractIndices(plan));
+    }
+
+    public void testProjectOverScan() {
+        RelBuilder b = builder();
+        RelNode plan = b.scan("orders").project(b.field("id")).build();
+        assertArrayEquals(new String[] { "orders" }, RelNodeUtils.extractIndices(plan));
+    }
+
+    public void testSortOverFilterOverScan() {
+        RelBuilder b = builder();
+        RelNode plan = b.scan("events").filter(b.literal(true)).sort(b.field("id")).build();
+        assertArrayEquals(new String[] { "events" }, RelNodeUtils.extractIndices(plan));
+    }
+
+    public void testAggregateOverScan() {
+        RelBuilder b = builder();
+        RelNode plan = b.scan("metrics").aggregate(b.groupKey("id"), b.count(false, "cnt")).build();
+        assertArrayEquals(new String[] { "metrics" }, RelNodeUtils.extractIndices(plan));
+    }
+
+    public void testJoinExtractsBothIndices() {
+        RelBuilder b = builder();
+        RelNode plan = b.scan("customers").scan("orders").join(JoinRelType.INNER, b.literal(true)).build();
+        assertArrayEquals(new String[] { "customers", "orders" }, RelNodeUtils.extractIndices(plan));
+    }
+
+    public void testUnionExtractsBothIndices() {
+        RelBuilder b = builder();
+        RelNode plan = b.scan("logs_2023")
+            .project(b.field("id"), b.field("name"))
+            .scan("logs_2024")
+            .project(b.field("id"), b.field("name"))
+            .union(true)
+            .build();
+        assertArrayEquals(new String[] { "logs_2023", "logs_2024" }, RelNodeUtils.extractIndices(plan));
+    }
+
+    public void testDeduplicatesRepeatedIndex() {
+        RelBuilder b = builder();
+        RelNode plan = b.scan("my_index")
+            .project(b.field("id"), b.field("name"))
+            .scan("my_index")
+            .project(b.field("id"), b.field("name"))
+            .union(true)
+            .build();
+        assertArrayEquals(new String[] { "my_index" }, RelNodeUtils.extractIndices(plan));
+    }
+
+    public void testComplexJoinWithAggregate() {
+        RelBuilder b = builder();
+        RelNode plan = b.scan("index_a")
+            .scan("index_b")
+            .join(JoinRelType.LEFT, b.literal(true))
+            .aggregate(b.groupKey(0), b.count(false, "cnt"))
+            .sort(b.field(0))
+            .build();
+        assertArrayEquals(new String[] { "index_a", "index_b" }, RelNodeUtils.extractIndices(plan));
+    }
+
+    public void testDepthGuardThrowsOnExcessiveDepth() {
+        RelBuilder b = builder();
+        RelNode node = b.scan("deep_index").build();
+        // Wrap in LogicalFilter nodes directly to avoid RelBuilder optimizations.
+        for (int i = 0; i < MAX_EXTRACT_INDICES_DEPTH + 5; i++) {
+            RexBuilder rex = node.getCluster().getRexBuilder();
+            RexNode condition = rex.makeCall(
+                SqlStdOperatorTable.GREATER_THAN,
+                rex.makeInputRef(node.getRowType().getFieldList().get(0).getType(), 0),
+                rex.makeZeroLiteral(node.getRowType().getFieldList().get(0).getType())
+            );
+            node = LogicalFilter.create(node, condition);
+        }
+        // The plan exceeds MAX_EXTRACT_INDICES_DEPTH — should throw rather than silently skip
+        RelNode deepPlan = node;
+        IllegalStateException e = expectThrows(IllegalStateException.class, () -> RelNodeUtils.extractIndices(deepPlan));
+        assertTrue(e.getMessage().contains("maximum depth"));
+    }
+
+    /** Minimal table implementation for RelBuilder schema registration. */
+    private static class MockTable extends AbstractTable {
+        @Override
+        public RelDataType getRowType(RelDataTypeFactory typeFactory) {
+            return typeFactory.builder().add("id", SqlTypeName.INTEGER).add("name", SqlTypeName.VARCHAR).build();
+        }
+    }
+}


### PR DESCRIPTION
### Description

The analytics engine's query execution path (PPL, SQL) bypasses the security plugin's index-level privilege evaluation. The `FragmentExecutionRequest` on the data node is executed with `dispatchFragmentStreaming` and never evaluated for index permissions by the security plugin `SecurityFilter` (wraps the `ActionFilter`).

### SQL / PPL queries with analytics engine

In a typical SQL / PPL query authorization is handled at the node-to-node transport layer on the coordinator as the request is being dispatched to shards. The security plugin [provides an ActionFilter](https://github.com/opensearch-project/security/blob/main/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java#L964-L971) which every TransportAction child holds a reference to, and [executes on new requests](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/action/support/TransportAction.java#L213-L228).

The overall flow for a regular DSL search query is then:
```
NodeClient.execute(SearchAction.INSTANCE, searchRequest)
    → NodeClient.executeLocally(action, request, listener)
      → transportAction(action).execute(request, listener)
        → TransportAction.execute(task, request, listener)
          → RequestFilterChain.proceed()
```

The path for an analytics engine SQL / PPL query avoids the `RequestFilterChain` entirely. The `ShardTaskRunner` is  responsible for dispatching a `FragmentExecutionRequest` on the transport layer.

```
    @Override
    public void run(ShardStageTask task, ActionListener<Void> listener) {
        ShardExecutionTarget target = (ShardExecutionTarget) task.target();
        FragmentExecutionRequest request = requestBuilder.apply(target);
        PendingExecutions pending = pendingFor(target);
        transport.dispatchFragmentStreaming(request, target.node(), stage.responseListenerFor(listener), config.parentTask(), pending);
    }
```

The `FragmentExecutionRequest` fetches a new connection from the transport service, and [directly executes ](https://github.com/opensearch-project/OpenSearch/blob/main/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/AnalyticsSearchTransportService.java#L193-L204)the request itself. Skipping the `TransportAction` framework which typically holds and applies the `ActionFilter`.

```
        pending.tryRun(() -> {
            try {
                Transport.Connection connection = getConnection(null, targetNode.getId());
                transportService.sendChildRequest(connection, FragmentExecutionAction.NAME, request, parentTask, options, handler);
            } catch (Exception e) {
                try {
                    listener.onFailure(e);
                } finally {
                    pending.finishAndRunNext();
                }
            }
        });
```

### DSL queries with analytics engine

DSL permissions are actually evaluated correctly already. This comes from how DSL is routed into the analytics plugin. DSL queries construct a regular `SearchRequest` which is handled by the `TransportSearchAction` and are executed on the transport layer with the local node client as usual.

Handling of DSL queries is done by a new `SearchActionFilter` which is also injected into the `RequestFilterChain` and [redirects these `SearchRequest`s to the `DslExecuteAction.INSTANCE` handler](https://github.com/opensearch-project/OpenSearch/blob/main/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/action/SearchActionFilter.java) instead of executing them as normal search requests. Since this `SearchActionFilter` executes AFTER the security plugin ActionFilter (which has highest priority), privileges are evaluated correctly.

| Path | Unauthorized Index | Status |
|------|-------------------|--------|
| DSL (`POST /{index}/_search`) | ✅ Denied | Secure |
| PPL (`POST /_plugins/_ppl`) | ❌ Allowed | **Gap** |
| SQL (`POST /_plugins/_sql`) | ❌ Allowed | **Gap** |

### Proposed fix

These changes somewhat mimic the functionality of DSL queries for SQL and PPL by adding a pre-planning authorization check which passes a no-op `AnalyticsAuthRequest` through the `ActionFilter` to determine if permissions are valid for the equivalent set of  `FragmentExecutionRequest`s.

No actual request is executed on the transport layer, the `AnalyticsAuthRequest` is passed through the full `ActionFilter` chain to invoke security plugin privilege evaluation, and proceeds with the analytics engine planning + query only if this probing `AnalyticsAuthRequest` is authorized for the same indices.

### Testing

These changes route all analytics engine query execution through the existing `AnalyticsQueryAction` and `TransportAction` via `NodeClient.execute()` during `DefaultPlanExecutor.execute()`. This triggers the `ActionFilter` chain (including SecurityFilter) before even planning begins.

Test implementation is pending. Currently changes are validated with local single node testing.

### Related Issues
N/A

### Check List
- [ ] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
