### PR TITLE
[Backport 3.6] Update pull-based ingestion multi-threaded writer flow batchStartPointer computation

### DIFF
--- a/plugins/ingestion-kafka/src/main/java/org/opensearch/plugin/kafka/KafkaPartitionConsumer.java
+++ b/plugins/ingestion-kafka/src/main/java/org/opensearch/plugin/kafka/KafkaPartitionConsumer.java
@@ -142,7 +142,7 @@ public class KafkaPartitionConsumer implements IngestionShardConsumer<KafkaOffse
      * @throws TimeoutException
      */
     @Override
-    public List<ReadResult<KafkaOffset, KafkaMessage>> readNext(
+    public synchronized List<ReadResult<KafkaOffset, KafkaMessage>> readNext(
         KafkaOffset offset,
         boolean includeStart,
         long maxMessages,
@@ -162,7 +162,7 @@ public class KafkaPartitionConsumer implements IngestionShardConsumer<KafkaOffse
      * @throws TimeoutException
      */
     @Override
-    public List<ReadResult<KafkaOffset, KafkaMessage>> readNext(long maxMessages, int timeoutMillis) throws TimeoutException {
+    public synchronized List<ReadResult<KafkaOffset, KafkaMessage>> readNext(long maxMessages, int timeoutMillis) throws TimeoutException {
         List<ReadResult<KafkaOffset, KafkaMessage>> records = AccessController.doPrivileged(
             (PrivilegedAction<List<ReadResult<KafkaOffset, KafkaMessage>>>) () -> fetch(lastFetchedOffset, false, timeoutMillis)
         );
@@ -170,7 +170,7 @@ public class KafkaPartitionConsumer implements IngestionShardConsumer<KafkaOffse
     }
 
     @Override
-    public IngestionShardPointer earliestPointer() {
+    public synchronized IngestionShardPointer earliestPointer() {
         long startOffset = AccessController.doPrivileged(
             (PrivilegedAction<Long>) () -> consumer.beginningOffsets(Collections.singletonList(topicPartition))
                 .getOrDefault(topicPartition, 0L)
@@ -179,7 +179,7 @@ public class KafkaPartitionConsumer implements IngestionShardConsumer<KafkaOffse
     }
 
     @Override
-    public IngestionShardPointer latestPointer() {
+    public synchronized IngestionShardPointer latestPointer() {
         long endOffset = AccessController.doPrivileged(
             (PrivilegedAction<Long>) () -> consumer.endOffsets(Collections.singletonList(topicPartition)).getOrDefault(topicPartition, 0L)
         );
@@ -187,7 +187,7 @@ public class KafkaPartitionConsumer implements IngestionShardConsumer<KafkaOffse
     }
 
     @Override
-    public IngestionShardPointer pointerFromTimestampMillis(long timestampMillis) {
+    public synchronized IngestionShardPointer pointerFromTimestampMillis(long timestampMillis) {
         long offset = AccessController.doPrivileged((PrivilegedAction<Long>) () -> {
             Map<TopicPartition, OffsetAndTimestamp> position = consumer.offsetsForTimes(
                 Collections.singletonMap(topicPartition, timestampMillis)
@@ -257,14 +257,12 @@ public class KafkaPartitionConsumer implements IngestionShardConsumer<KafkaOffse
 
     /**
      * Compute Kafka offset based lag as the difference between latest available offset and last consumed offset.
-     * Note: This method is not thread-safe and should only be called from the poller thread to avoid multi-threaded
-     * access to KafkaConsumer.
      *
      * @param expectedStartPointer the pointer where ingestion would start if no messages have been consumed yet
      * @return offset based lag. -1 is returned if errors are encountered.
      */
     @Override
-    public long getPointerBasedLag(IngestionShardPointer expectedStartPointer) {
+    public synchronized long getPointerBasedLag(IngestionShardPointer expectedStartPointer) {
         try {
             // Get the end offset for the partition
             long endOffset = consumer.endOffsets(Collections.singletonList(topicPartition)).getOrDefault(topicPartition, 0L);
@@ -285,7 +283,7 @@ public class KafkaPartitionConsumer implements IngestionShardConsumer<KafkaOffse
     }
 
     @Override
-    public void close() throws IOException {
+    public synchronized void close() throws IOException {
         consumer.close();
     }
 

--- a/server/src/main/java/org/opensearch/indices/pollingingest/DefaultStreamPoller.java
+++ b/server/src/main/java/org/opensearch/indices/pollingingest/DefaultStreamPoller.java
@@ -294,6 +294,8 @@ public class DefaultStreamPoller implements StreamPoller {
 
     /**
      * Process records and write to the blocking queue. In case of error, return the shard pointer of the failed message.
+     * Messages must be written to the blocking queue in the same order in which they were received from the consumer to
+     * ensure ordering guarantees.
      */
     private IngestionShardPointer processRecords(
         List<IngestionShardConsumer.ReadResult<? extends IngestionShardPointer, ? extends Message>> results
@@ -564,7 +566,6 @@ public class DefaultStreamPoller implements StreamPoller {
 
     /**
      * Update the cached pointer-based lag if enough time has elapsed since the last update.
-     * {@code consumer.getPointerBasedLag()} is called from the poller thread, so it's safe to access the consumer.
      * If pointerBasedLagUpdateIntervalMs is 0, pointer-based lag calculation is disabled.
      */
     private void updatePointerBasedLagIfNeeded() {
@@ -690,6 +691,8 @@ public class DefaultStreamPoller implements StreamPoller {
      * batchStartPointer if first time initialization, or from the latest available batchStartPointer on reinitialization.
      */
     private void handleConsumerInitialization() {
+        // retrieve batchStartPointer before clearing the partition blocking queues
+        IngestionShardPointer restartPointer = getBatchStartPointer();
         closeConsumer();
         blockingQueueContainer.clearAllQueues();
         initializeConsumer();
@@ -698,11 +701,12 @@ public class DefaultStreamPoller implements StreamPoller {
         IngestionShardPointer resetShardPointer = getResetShardPointer();
         if (resetShardPointer != null) {
             initialBatchStartPointer = resetShardPointer;
+            restartPointer = resetShardPointer;
         }
 
         // Force the consumer to start from the batchStartPointer. This will be the initialBatchStartPointer for first
         // time initialization, or the latest batchStartPointer based on processed messages.
-        forcedShardPointer = getBatchStartPointer();
+        forcedShardPointer = restartPointer;
     }
 
     /**

--- a/server/src/main/java/org/opensearch/indices/pollingingest/PartitionedBlockingQueueContainer.java
+++ b/server/src/main/java/org/opensearch/indices/pollingingest/PartitionedBlockingQueueContainer.java
@@ -40,6 +40,7 @@ public class PartitionedBlockingQueueContainer {
     private final Map<Integer, BlockingQueue<ShardUpdateMessage<? extends IngestionShardPointer, ? extends Message>>> partitionToQueueMap;
     private final Map<Integer, MessageProcessorRunnable> partitionToMessageProcessorMap;
     private final Map<Integer, ExecutorService> partitionToProcessorExecutorMap;
+    private final Map<Integer, IngestionShardPointer> partitionToFirstQueuedPointerMap;
 
     /**
      * Initialize partitions and processor threads for given number of partitions.
@@ -55,6 +56,7 @@ public class PartitionedBlockingQueueContainer {
         partitionToQueueMap = new ConcurrentHashMap<>();
         partitionToMessageProcessorMap = new ConcurrentHashMap<>();
         partitionToProcessorExecutorMap = new ConcurrentHashMap<>();
+        partitionToFirstQueuedPointerMap = new ConcurrentHashMap<>();
         this.numPartitions = numPartitions;
 
         logger.info("Initializing processors for shard {} using {} partitions", shardId, numPartitions);
@@ -89,6 +91,7 @@ public class PartitionedBlockingQueueContainer {
         partitionToQueueMap = new ConcurrentHashMap<>();
         partitionToMessageProcessorMap = new ConcurrentHashMap<>();
         partitionToProcessorExecutorMap = new ConcurrentHashMap<>();
+        partitionToFirstQueuedPointerMap = new ConcurrentHashMap<>();
         this.numPartitions = 1;
 
         partitionToQueueMap.put(0, messageProcessorRunnable.getBlockingQueue());
@@ -124,7 +127,18 @@ public class PartitionedBlockingQueueContainer {
         String id = (String) payloadMap.get(IdFieldMapper.NAME);
 
         int partition = getPartitionFromID(id);
-        partitionToQueueMap.get(partition).put(shardUpdateMessage);
+        IngestionShardPointer previousFirstQueuedPointer = partitionToFirstQueuedPointerMap.putIfAbsent(
+            partition,
+            shardUpdateMessage.pointer()
+        );
+        try {
+            partitionToQueueMap.get(partition).put(shardUpdateMessage);
+        } catch (InterruptedException | RuntimeException e) {
+            if (previousFirstQueuedPointer == null) {
+                partitionToFirstQueuedPointerMap.remove(partition, shardUpdateMessage.pointer());
+            }
+            throw e;
+        }
     }
 
     /**
@@ -136,6 +150,7 @@ public class PartitionedBlockingQueueContainer {
         partitionToQueueMap.clear();
         partitionToMessageProcessorMap.clear();
         partitionToProcessorExecutorMap.clear();
+        partitionToFirstQueuedPointerMap.clear();
     }
 
     /**
@@ -145,6 +160,7 @@ public class PartitionedBlockingQueueContainer {
         for (BlockingQueue<ShardUpdateMessage<? extends IngestionShardPointer, ? extends Message>> queue : partitionToQueueMap.values()) {
             queue.clear();
         }
+        partitionToFirstQueuedPointerMap.clear();
         logger.debug("Cleared all blocking queues across {} partitions", numPartitions);
     }
 
@@ -167,10 +183,20 @@ public class PartitionedBlockingQueueContainer {
     }
 
     /**
-     * Returns the current shard pointers from each message processor thread.
+     * Returns the list of lowest/first shard pointer per partition that is in-flight or already processed.
+     * If the processor thread is yet to process the very first message, the first queued pointer for the partition is considered.
+     * The fallback to first queued partition ensures that the correct pointer is considered before the very first message is processed
+     * by the processor thread. Note that this fallback works because messages are written to the blocking queue sequentially
+     * in the same order in which they are received from the consumer.
      */
     public List<IngestionShardPointer> getCurrentShardPointers() {
-        return partitionToMessageProcessorMap.values().stream().map(MessageProcessorRunnable::getCurrentShardPointer).toList();
+        return partitionToMessageProcessorMap.entrySet().stream().map(entry -> {
+            IngestionShardPointer currentShardPointer = entry.getValue().getCurrentShardPointer();
+            if (currentShardPointer != null) {
+                return currentShardPointer;
+            }
+            return partitionToFirstQueuedPointerMap.get(entry.getKey());
+        }).toList();
     }
 
     private int getPartitionFromID(String id) {

--- a/server/src/test/java/org/opensearch/indices/pollingingest/DefaultStreamPollerTests.java
+++ b/server/src/test/java/org/opensearch/indices/pollingingest/DefaultStreamPollerTests.java
@@ -35,6 +35,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -539,6 +540,116 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
         Thread.sleep(sleepTime);
 
         assertEquals(new FakeIngestionSource.FakeIngestionShardPointer(0), poller.getBatchStartPointer());
+        blockingQueueContainer.close();
+    }
+
+    public void testBatchStartPointerUsesFirstQueuedPointerWhenProcessorPointerIsNull() throws InterruptedException {
+        MessageProcessorRunnable processorRunnable = new MessageProcessorRunnable(
+            new ArrayBlockingQueue<>(5),
+            processor,
+            errorStrategy,
+            "test_index",
+            0
+        );
+        PartitionedBlockingQueueContainer blockingQueueContainer = new PartitionedBlockingQueueContainer(processorRunnable, 0);
+        DefaultStreamPoller poller = new DefaultStreamPoller(
+            new FakeIngestionSource.FakeIngestionShardPointer(0),
+            fakeConsumerFactory,
+            "",
+            0,
+            blockingQueueContainer,
+            StreamPoller.ResetState.NONE,
+            "",
+            errorStrategy,
+            StreamPoller.State.NONE,
+            1000,
+            1000,
+            10000,
+            indexSettings,
+            new DefaultIngestionMessageMapper(),
+            new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(-1), 0),
+            new IngestionSource.Builder("FAKE").build()
+        );
+
+        blockingQueueContainer.add(createShardUpdateMessage(5, "1"));
+
+        assertNull(processorRunnable.getCurrentShardPointer());
+        assertEquals(new FakeIngestionSource.FakeIngestionShardPointer(5), poller.getBatchStartPointer());
+        blockingQueueContainer.close();
+        poller.close();
+    }
+
+    public void testFirstQueuedPointerIsClearedWhenQueuePutFails() throws InterruptedException {
+        ArrayBlockingQueue mockQueue = mock(ArrayBlockingQueue.class);
+        doThrow(new RuntimeException("put failed")).when(mockQueue).put(any());
+        MessageProcessorRunnable processorRunnable = new MessageProcessorRunnable(mockQueue, processor, errorStrategy, "test_index", 0);
+        PartitionedBlockingQueueContainer blockingQueueContainer = new PartitionedBlockingQueueContainer(processorRunnable, 0);
+
+        RuntimeException exception = expectThrows(
+            RuntimeException.class,
+            () -> blockingQueueContainer.add(createShardUpdateMessage(5, "1"))
+        );
+        assertEquals("put failed", exception.getMessage());
+        assertEquals(Collections.singletonList(null), blockingQueueContainer.getCurrentShardPointers());
+        blockingQueueContainer.close();
+    }
+
+    public void testConsumerReinitializationUsesRestartPointerCapturedBeforeClearingQueues() throws Exception {
+        ArrayBlockingQueue mockQueue = mock(ArrayBlockingQueue.class);
+        processorRunnable = new MessageProcessorRunnable(mockQueue, processor, errorStrategy, "test_index", 0);
+        PartitionedBlockingQueueContainer blockingQueueContainer = new PartitionedBlockingQueueContainer(processorRunnable, 0);
+
+        IngestionShardConsumer initialConsumer = mock(IngestionShardConsumer.class);
+        IngestionShardConsumer reinitializedConsumer = mock(IngestionShardConsumer.class);
+        when(initialConsumer.getShardId()).thenReturn(0);
+        when(reinitializedConsumer.getShardId()).thenReturn(0);
+
+        FakeIngestionSource.FakeIngestionShardPointer initialPointer = new FakeIngestionSource.FakeIngestionShardPointer(3);
+        FakeIngestionSource.FakeIngestionShardPointer queuedPointer = new FakeIngestionSource.FakeIngestionShardPointer(7);
+        FakeIngestionSource.FakeIngestionMessage message = new FakeIngestionSource.FakeIngestionMessage(
+            "{\"_id\":\"1\",\"_source\":{\"name\":\"bob\", \"age\": 24}}".getBytes(StandardCharsets.UTF_8)
+        );
+        List<
+            IngestionShardConsumer.ReadResult<
+                FakeIngestionSource.FakeIngestionShardPointer,
+                FakeIngestionSource.FakeIngestionMessage>> results = Collections.singletonList(
+                    new IngestionShardConsumer.ReadResult<>(queuedPointer, message)
+                );
+
+        when(initialConsumer.readNext(eq(initialPointer), eq(true), anyLong(), anyInt())).thenReturn(results);
+        when(initialConsumer.readNext(anyLong(), anyInt())).thenReturn(Collections.emptyList());
+        when(reinitializedConsumer.readNext(eq(queuedPointer), eq(true), anyLong(), anyInt())).thenReturn(Collections.emptyList());
+        when(reinitializedConsumer.readNext(anyLong(), anyInt())).thenReturn(Collections.emptyList());
+
+        IngestionConsumerFactory mockConsumerFactory = mock(IngestionConsumerFactory.class);
+        when(mockConsumerFactory.createShardConsumer(anyString(), anyInt(), any())).thenReturn(initialConsumer)
+            .thenReturn(reinitializedConsumer);
+
+        poller = new DefaultStreamPoller(
+            initialPointer,
+            mockConsumerFactory,
+            "",
+            0,
+            blockingQueueContainer,
+            StreamPoller.ResetState.NONE,
+            "",
+            errorStrategy,
+            StreamPoller.State.NONE,
+            1000,
+            1000,
+            10000,
+            indexSettings,
+            new DefaultIngestionMessageMapper(),
+            new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(-1), 0),
+            new IngestionSource.Builder("FAKE").build()
+        );
+
+        poller.start();
+        assertBusy(() -> assertEquals(queuedPointer, poller.getBatchStartPointer()), 30, TimeUnit.SECONDS);
+
+        poller.requestConsumerReinitialization(new IngestionSource.Builder("FAKE").build());
+
+        assertBusy(() -> verify(reinitializedConsumer).readNext(eq(queuedPointer), eq(true), anyLong(), anyInt()), 30, TimeUnit.SECONDS);
         blockingQueueContainer.close();
     }
 
@@ -1199,5 +1310,18 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
         assertTrue(warmupPoller.isWarmupComplete());
 
         warmupPoller.close();
+    }
+
+    private
+        ShardUpdateMessage<FakeIngestionSource.FakeIngestionShardPointer, FakeIngestionSource.FakeIngestionMessage>
+        createShardUpdateMessage(long pointer, String id) {
+        byte[] payload = ("{\"_id\":\"" + id + "\",\"_source\":{\"name\":\"bob\", \"age\": 24}}").getBytes(StandardCharsets.UTF_8);
+        Map<String, Object> payloadMap = IngestionUtils.getParsedPayloadMap(payload);
+        return new ShardUpdateMessage<>(
+            new FakeIngestionSource.FakeIngestionShardPointer(pointer),
+            new FakeIngestionSource.FakeIngestionMessage(payload),
+            payloadMap,
+            -1
+        );
     }
 }


### PR DESCRIPTION
### Description
Backport #21697 from 3.7 to 3.6.

1. Update the pull-based ingestion multi-threaded write flow to handle the rare race scenario where a flush is called before the very first message is read by a processor thread, but another processor thread has read a message. In this case, use the first queued message pointer for determining batchStartPointer. This can only happen during uneven hash distribution on docID partitioning which is rare.
2. Update Kafka consumer to be synchronized to avoid concurrent access when reset API is called.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
