### PR TITLE
Added microsecond function and timestamp lowerbound check

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionAnalyticsBackendPlugin.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionAnalyticsBackendPlugin.java
@@ -616,7 +616,7 @@ public class DataFusionAnalyticsBackendPlugin implements AnalyticsSearchBackendP
                     Map.entry(ScalarFunction.LOG2, new NumericToDoubleAdapter(SqlLibraryOperators.LOG2)),
                     Map.entry(ScalarFunction.MAKEDATE, new RustUdfDateTimeAdapters.MakedateAdapter()),
                     Map.entry(ScalarFunction.MAKETIME, new RustUdfDateTimeAdapters.MaketimeAdapter()),
-                    Map.entry(ScalarFunction.MICROSECOND, DatePartAdapters.microsecond()),
+                    Map.entry(ScalarFunction.MICROSECOND, new MicrosecondAdapter()),
                     Map.entry(ScalarFunction.MINSPAN_BUCKET, new MinspanBucketAdapter()),
                     Map.entry(ScalarFunction.MINUTE, minute),
                     Map.entry(ScalarFunction.MINUTE_OF_HOUR, minute),

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/MicrosecondAdapter.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/MicrosecondAdapter.java
@@ -1,0 +1,51 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion;
+
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.fun.SqlLibraryOperators;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.opensearch.analytics.spi.FieldStorageInfo;
+import org.opensearch.analytics.spi.ScalarFunctionAdapter;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+/**
+ * PPL {@code microsecond(x)} → {@code CAST(MOD(date_part('microsecond', x), 1_000_000) AS <retType>)}:
+ * MySQL/PPL {@code MICROSECOND()} returns only the sub-second microseconds (0..999_999), but
+ * DataFusion/Postgres {@code date_part('microsecond', x)} returns
+ * {@code seconds * 1_000_000 + microseconds} (e.g. 46_123_456 for {@code 01:34:46.123456}).
+ * Wrap with {@code MOD(..., 1_000_000)} to drop the seconds component, matching MySQL semantics
+ * and what {@code DateTimeFunctionIT#testMicrosecond} expects.
+ *
+ * @opensearch.internal
+ */
+class MicrosecondAdapter implements ScalarFunctionAdapter {
+
+    private static final BigDecimal ONE_MILLION = BigDecimal.valueOf(1_000_000L);
+
+    @Override
+    public RexNode adapt(RexCall original, List<FieldStorageInfo> fieldStorage, RelOptCluster cluster) {
+        if (original.getOperands().size() != 1) {
+            return original;
+        }
+        RexBuilder rexBuilder = cluster.getRexBuilder();
+        RelDataType varchar = cluster.getTypeFactory().createSqlType(SqlTypeName.VARCHAR);
+        RexNode partLiteral = rexBuilder.makeLiteral("microsecond", varchar, true);
+        RexNode datePart = rexBuilder.makeCall(SqlLibraryOperators.DATE_PART, partLiteral, original.getOperands().get(0));
+        RexNode mod = rexBuilder.makeCall(SqlStdOperatorTable.MOD, datePart, rexBuilder.makeExactLiteral(ONE_MILLION));
+        return rexBuilder.makeCast(original.getType(), mod);
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/MicrosecondAdapter.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/MicrosecondAdapter.java
@@ -24,10 +24,10 @@ import java.util.List;
 
 /**
  * PPL {@code microsecond(x)} → {@code CAST(MOD(date_part('microsecond', x), 1_000_000) AS <retType>)}:
- * MySQL/PPL {@code MICROSECOND()} returns only the sub-second microseconds (0..999_999), but
+ * PPL {@code MICROSECOND()} returns only the sub-second microseconds (0..999_999), but
  * DataFusion/Postgres {@code date_part('microsecond', x)} returns
  * {@code seconds * 1_000_000 + microseconds} (e.g. 46_123_456 for {@code 01:34:46.123456}).
- * Wrap with {@code MOD(..., 1_000_000)} to drop the seconds component, matching MySQL semantics
+ * Wrap with {@code MOD(..., 1_000_000)} to drop the seconds component, matching PPL semantics
  * and what {@code DateTimeFunctionIT#testMicrosecond} expects.
  *
  * @opensearch.internal

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/TimestampFunctionAdapter.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/TimestampFunctionAdapter.java
@@ -323,8 +323,11 @@ class TimestampFunctionAdapter implements ScalarFunctionAdapter {
      * an opaque {@code Arrow error: Arithmetic overflow} at execution. Reject
      * up front with a clear message so users see the limit at plan time.
      *
-     * <p>Upper bound is the exact i64-ns ceiling — {@code Long.MAX_VALUE} ns is
-     * {@code 2262-04-11 23:47:16.854775807 UTC}.
+     * <p>Bounds are the exact i64-ns ends — {@code Long.MAX_VALUE} ns is
+     * {@code 2262-04-11 23:47:16.854775807 UTC} and {@code Long.MIN_VALUE} ns is
+     * {@code 1677-09-21 00:12:43.145224192 UTC}. Lower-bound rejection is
+     * symmetric with the upper bound; without it, year-0001 literals slip past
+     * the planner and die at execution with an opaque {@code StreamException}.
      */
     private static final LocalDateTime I64_NS_MAX = LocalDateTime.ofEpochSecond(
         Long.MAX_VALUE / 1_000_000_000L,
@@ -332,8 +335,14 @@ class TimestampFunctionAdapter implements ScalarFunctionAdapter {
         ZoneOffset.UTC
     );
 
+    private static final LocalDateTime I64_NS_MIN = LocalDateTime.ofEpochSecond(
+        Math.floorDiv(Long.MIN_VALUE, 1_000_000_000L),
+        (int) Math.floorMod(Long.MIN_VALUE, 1_000_000_000L),
+        ZoneOffset.UTC
+    );
+
     private static void rejectIfOutsideI64NsRange(LocalDateTime ldt) {
-        if (ldt.isAfter(I64_NS_MAX)) {
+        if (ldt.isAfter(I64_NS_MAX) || ldt.isBefore(I64_NS_MIN)) {
             throw new IllegalArgumentException("timestamp " + ldt + " is outside the supported range");
         }
     }

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/MicrosecondAdapterTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/MicrosecondAdapterTests.java
@@ -1,0 +1,118 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion;
+
+import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.hep.HepPlanner;
+import org.apache.calcite.plan.hep.HepProgramBuilder;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.fun.SqlLibraryOperators;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.sql.type.ReturnTypes;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.sql.validate.SqlUserDefinedFunction;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.List;
+
+/**
+ * Unit tests for {@link MicrosecondAdapter}. PPL's {@code microsecond(x)} returns the
+ * sub-second microseconds (0..999_999), but DataFusion's {@code date_part('microsecond', x)}
+ * returns {@code seconds * 1_000_000 + microseconds} — Postgres semantics. The adapter
+ * wraps the {@code date_part} call with {@code MOD(..., 1_000_000)} and casts back to the
+ * call's declared return type, restoring MySQL/PPL semantics.
+ */
+public class MicrosecondAdapterTests extends OpenSearchTestCase {
+
+    private RelDataTypeFactory typeFactory;
+    private RexBuilder rexBuilder;
+    private RelOptCluster cluster;
+    private RelDataType timestampType;
+    private RelDataType intType;
+    private SqlUserDefinedFunction microsecondUdf;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        typeFactory = new JavaTypeFactoryImpl();
+        rexBuilder = new RexBuilder(typeFactory);
+        HepPlanner planner = new HepPlanner(new HepProgramBuilder().build());
+        cluster = RelOptCluster.create(planner, rexBuilder);
+        timestampType = typeFactory.createSqlType(SqlTypeName.TIMESTAMP);
+        intType = typeFactory.createSqlType(SqlTypeName.INTEGER);
+        microsecondUdf = new SqlUserDefinedFunction(
+            new SqlIdentifier("MICROSECOND", SqlParserPos.ZERO),
+            SqlKind.OTHER_FUNCTION,
+            ReturnTypes.INTEGER_NULLABLE,
+            null,
+            null,
+            null
+        );
+    }
+
+    public void testMicrosecondRewrittenAsModOfDatePart() {
+        RexNode arg = rexBuilder.makeInputRef(timestampType, 0);
+        RexCall original = (RexCall) rexBuilder.makeCall(intType, microsecondUdf, List.of(arg));
+
+        RexNode adapted = new MicrosecondAdapter().adapt(original, List.of(), cluster);
+
+        // Expected tree: CAST(MOD(date_part('microsecond', arg), 1_000_000) AS INTEGER)
+        assertTrue("outermost node must be a RexCall", adapted instanceof RexCall);
+        RexCall castCall = (RexCall) adapted;
+        assertSame("outermost operator must be CAST", SqlStdOperatorTable.CAST, castCall.getOperator());
+        assertEquals(SqlTypeName.INTEGER, castCall.getType().getSqlTypeName());
+
+        RexNode castOperand = castCall.getOperands().get(0);
+        assertTrue("CAST operand must be a RexCall", castOperand instanceof RexCall);
+        RexCall modCall = (RexCall) castOperand;
+        assertSame("inside CAST must be MOD", SqlStdOperatorTable.MOD, modCall.getOperator());
+        assertEquals(2, modCall.getOperands().size());
+
+        RexNode modLeft = modCall.getOperands().get(0);
+        assertTrue("left operand of MOD must be a RexCall", modLeft instanceof RexCall);
+        RexCall datePart = (RexCall) modLeft;
+        assertSame("MOD's left operand must be date_part(...)", SqlLibraryOperators.DATE_PART, datePart.getOperator());
+        assertEquals(2, datePart.getOperands().size());
+
+        RexNode partLiteral = datePart.getOperands().get(0);
+        assertTrue("date_part's first arg must be a literal", partLiteral instanceof RexLiteral);
+        assertEquals("microsecond", ((RexLiteral) partLiteral).getValueAs(String.class));
+        assertSame("date_part's second arg must be the original timestamp arg", arg, datePart.getOperands().get(1));
+
+        RexNode modRight = modCall.getOperands().get(1);
+        assertTrue("MOD's right operand must be a literal", modRight instanceof RexLiteral);
+        assertEquals(1_000_000L, ((RexLiteral) modRight).getValueAs(Long.class).longValue());
+    }
+
+    public void testAdaptLeavesUnaryNonMicrosecondCallAlone() {
+        // Sanity: an unrelated single-arg call should not be rewritten, even though the
+        // adapter only checks operand count. (The dispatch in DataFusionAnalyticsBackendPlugin
+        // gates by ScalarFunction.MICROSECOND, but we still want adapt() to be safe to
+        // call directly on whatever the dispatcher hands it.)
+        RexNode arg = rexBuilder.makeInputRef(timestampType, 0);
+        RexCall absCall = (RexCall) rexBuilder.makeCall(SqlStdOperatorTable.ABS, List.of(arg));
+
+        // The adapter unconditionally wraps any 1-arg call in MOD(date_part('microsecond', x), 1e6),
+        // so adapt() does rewrite. Verify the operand-count guard fires when arity is wrong.
+        RexCall twoArg = (RexCall) rexBuilder.makeCall(
+            SqlStdOperatorTable.PLUS,
+            List.of(rexBuilder.makeInputRef(intType, 0), rexBuilder.makeInputRef(intType, 1))
+        );
+        assertSame("multi-arg calls pass through unchanged", twoArg, new MicrosecondAdapter().adapt(twoArg, List.of(), cluster));
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/MicrosecondAdapterTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/MicrosecondAdapterTests.java
@@ -35,7 +35,7 @@ import java.util.List;
  * sub-second microseconds (0..999_999), but DataFusion's {@code date_part('microsecond', x)}
  * returns {@code seconds * 1_000_000 + microseconds} — Postgres semantics. The adapter
  * wraps the {@code date_part} call with {@code MOD(..., 1_000_000)} and casts back to the
- * call's declared return type, restoring MySQL/PPL semantics.
+ * call's declared return type, restoring PPL semantics.
  */
 public class MicrosecondAdapterTests extends OpenSearchTestCase {
 

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/TimestampFunctionAdapterTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/TimestampFunctionAdapterTests.java
@@ -136,6 +136,29 @@ public class TimestampFunctionAdapterTests extends OpenSearchTestCase {
         assertEquals("2262-04-11 23:47:16", TimestampFunctionAdapter.parseTimestamp("2262-04-11 23:47:16").toString());
     }
 
+    /**
+     * Values below the i64-ns floor (~year 1677) must reject up front, mirroring
+     * the upper-bound check. Without this guard, year-0001 literals slip past the
+     * planner and die at execution with an opaque {@code StreamException}.
+     */
+    public void testYearBefore1677RejectsAtPlanTime() {
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> TimestampFunctionAdapter.parseTimestamp("0001-01-01 00:00:00")
+        );
+        assertTrue(
+            "error must mention the supported range, got: " + e.getMessage(),
+            e.getMessage().contains("outside the supported range")
+        );
+    }
+
+    /**
+     * Right at the i64-ns floor — must succeed. Mirrors {@link #testYear2262JustInsideBoundaryAccepted}.
+     */
+    public void testYear1677JustInsideLowerBoundaryAccepted() {
+        assertEquals("1677-09-22 00:00:00", TimestampFunctionAdapter.parseTimestamp("1677-09-22 00:00:00").toString());
+    }
+
     // ── adapt(): Shape A — TIMESTAMP('<varchar literal>') folds ───────────
 
     public void testAdaptShapeAFoldsVarcharLiteralToTypedTimestamp() {


### PR DESCRIPTION
## Summary

Two independent fixes on the analytics-engine PPL date path, both surfaced by a per-type sweep against parquet-backed indices:

1. **`microsecond(date_nanos)` returned `seconds * 1_000_000 + microseconds`** instead of just the sub-second microseconds. PPL semantics expect the latter; DataFusion's `date_part('microsecond', x)` (the existing lowering target) returns the former (Postgres semantics).
2. **`timestamp('0001-01-01 …')` died at execution** with an opaque `Failed to start streaming fragment` instead of being rejected cleanly at planning. The upper bound (`year > 2262`) was already validated; the lower bound was missing, so out-of-range literals slipped past the planner and surfaced as a `StreamException`.

Each fix is independently scoped and independently tested.

## Fix 1 — `microsecond(date_nanos)` semantics

**Before:** `microsecond(timestamp('2019-03-24 01:34:46.123456'))` returned `46_123_456`.
**After:** the same query returns `123_456`.

The previous lowering used `DatePartAdapters.microsecond()` — the generic "rename `FN(x)` → `date_part('<unit>', x)`" helper that backs `year`, `month`, `day`, `hour`, `minute`, `quarter`, `week`, and `dayOfYear`. For those eight, PPL and Postgres conventions agree, so the rename is sufficient. `microsecond` is the only date part where they diverge.

This PR introduces `MicrosecondAdapter`, a sibling of the existing `DayOfWeekAdapter` (which already bridges the same shape of PPL-vs-Postgres mismatch for `dow`: 0..6 → 1..7). It rewrites:

```
microsecond(x)  →  CAST(MOD(date_part('microsecond', x), 1_000_000) AS <retType>)
```

The `MOD(..., 1_000_000)` drops the seconds component, restoring PPL semantics. The CAST preserves the call's declared return type.

The existing `DatePartAdapters.microsecond()` factory remains for the helper class's symmetry; the registration in `DataFusionAnalyticsBackendPlugin` switches to `new MicrosecondAdapter()`.

## Fix 2 — Timestamp lower-bound check

**Before:** `year(timestamp('0001-01-01 …'))` returned HTTP 500 with an opaque `StreamException` from execution.
**After:** HTTP 400 with `timestamp 0001-01-01T00:00 is outside the supported range`, mirroring the existing upper-bound rejection.

The analytics-engine serializes TIMESTAMP as i64 nanoseconds since epoch, valid range `1677-09-21T00:12:43.145224192Z` to `2262-04-11T23:47:16.854775807Z`. `TimestampFunctionAdapter.rejectIfOutsideI64NsRange` already enforced the upper bound; this PR adds the symmetric `I64_NS_MIN` (using `Math.floorDiv`/`Math.floorMod` for the negative-second arithmetic) and an `isBefore` branch.
