### PR TITLE
[analytics engine] Add `/_plugins/_analytics/stats` endpoint

### DIFF
--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/AnalyticsPlugin.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/AnalyticsPlugin.java
@@ -27,6 +27,7 @@ import org.opensearch.analytics.planner.CapabilityRegistry;
 import org.opensearch.analytics.planner.FieldStorageResolver;
 import org.opensearch.analytics.schema.OpenSearchSchemaBuilder;
 import org.opensearch.analytics.spi.AnalyticsSearchBackendPlugin;
+import org.opensearch.analytics.stats.AnalyticsStats;
 import org.opensearch.analytics.stats.AnalyticsStatsCollector;
 import org.opensearch.analytics.stats.RestAnalyticsStatsAction;
 import org.opensearch.arrow.allocator.ArrowNativeAllocator;
@@ -47,10 +48,12 @@ import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.env.Environment;
 import org.opensearch.env.NodeEnvironment;
+import org.opensearch.index.search.stats.SearchStats;
 import org.opensearch.plugins.ActionPlugin;
 import org.opensearch.plugins.ExtensiblePlugin;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.plugins.PluginComponentRegistry;
+import org.opensearch.plugins.SearchStatsContributor;
 import org.opensearch.repositories.RepositoriesService;
 import org.opensearch.rest.RestController;
 import org.opensearch.rest.RestHandler;
@@ -74,7 +77,7 @@ import java.util.function.Supplier;
  *
  * @opensearch.internal
  */
-public class AnalyticsPlugin extends Plugin implements ExtensiblePlugin, ActionPlugin {
+public class AnalyticsPlugin extends Plugin implements ExtensiblePlugin, ActionPlugin, SearchStatsContributor {
 
     private static final Logger logger = LogManager.getLogger(AnalyticsPlugin.class);
 
@@ -211,6 +214,16 @@ public class AnalyticsPlugin extends Plugin implements ExtensiblePlugin, ActionP
 
     static int schedulerPoolSize() {
         return Math.max(2, Runtime.getRuntime().availableProcessors() / 2);
+    }
+
+    @Override
+    public SearchStats contributeSearchStats() {
+        AnalyticsStats.LatencyStats elapsed = statsCollector.snapshot().queries().elapsedMs();
+        if (elapsed.count() == 0) {
+            return null;
+        }
+        SearchStats.Stats stats = new SearchStats.Stats.Builder().queryCount(elapsed.count()).queryTimeInMillis(elapsed.sumMs()).build();
+        return new SearchStats(stats, 0, null);
     }
 
     @Override

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/AnalyticsPlugin.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/AnalyticsPlugin.java
@@ -27,15 +27,21 @@ import org.opensearch.analytics.planner.CapabilityRegistry;
 import org.opensearch.analytics.planner.FieldStorageResolver;
 import org.opensearch.analytics.schema.OpenSearchSchemaBuilder;
 import org.opensearch.analytics.spi.AnalyticsSearchBackendPlugin;
+import org.opensearch.analytics.stats.AnalyticsStatsCollector;
+import org.opensearch.analytics.stats.RestAnalyticsStatsAction;
 import org.opensearch.arrow.allocator.ArrowNativeAllocator;
 import org.opensearch.arrow.spi.NativeAllocatorPoolConfig;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
+import org.opensearch.cluster.node.DiscoveryNodes;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Module;
 import org.opensearch.common.inject.TypeLiteral;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.IndexScopedSettings;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.settings.SettingsFilter;
 import org.opensearch.core.action.ActionResponse;
 import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
@@ -46,6 +52,8 @@ import org.opensearch.plugins.ExtensiblePlugin;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.plugins.PluginComponentRegistry;
 import org.opensearch.repositories.RepositoriesService;
+import org.opensearch.rest.RestController;
+import org.opensearch.rest.RestHandler;
 import org.opensearch.script.ScriptService;
 import org.opensearch.threadpool.ExecutorBuilder;
 import org.opensearch.threadpool.FixedExecutorBuilder;
@@ -101,6 +109,7 @@ public class AnalyticsPlugin extends Plugin implements ExtensiblePlugin, ActionP
     private AnalyticsSearchService searchService;
     private CoordinatorAllocatorHandle coordinatorAllocatorHandle;
     private ReaderContextStore readerContextStore;
+    private final AnalyticsStatsCollector statsCollector = new AnalyticsStatsCollector();
 
     @SuppressWarnings("rawtypes")
     @Override
@@ -145,7 +154,20 @@ public class AnalyticsPlugin extends Plugin implements ExtensiblePlugin, ActionP
             nativeAllocator.getPoolAllocator(NativeAllocatorPoolConfig.POOL_QUERY).newChildAllocator("coordinator", 0, Long.MAX_VALUE)
         );
 
-        return List.of(searchService, ctx, capabilityRegistry, coordinatorAllocatorHandle);
+        return List.of(searchService, ctx, capabilityRegistry, coordinatorAllocatorHandle, statsCollector);
+    }
+
+    @Override
+    public List<RestHandler> getRestHandlers(
+        Settings settings,
+        RestController restController,
+        ClusterSettings clusterSettings,
+        IndexScopedSettings indexScopedSettings,
+        SettingsFilter settingsFilter,
+        IndexNameExpressionResolver indexNameExpressionResolver,
+        Supplier<DiscoveryNodes> nodesInCluster
+    ) {
+        return List.of(new RestAnalyticsStatsAction(statsCollector));
     }
 
     @Override

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/DefaultPlanExecutor.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/DefaultPlanExecutor.java
@@ -38,6 +38,7 @@ import org.opensearch.analytics.planner.dag.DAGBuilder;
 import org.opensearch.analytics.planner.dag.FragmentConversionDriver;
 import org.opensearch.analytics.planner.dag.PlanForker;
 import org.opensearch.analytics.planner.dag.QueryDAG;
+import org.opensearch.analytics.stats.AnalyticsStatsCollector;
 import org.opensearch.arrow.allocator.AllocationRejection;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
@@ -83,6 +84,7 @@ public class DefaultPlanExecutor extends HandledTransportAction<AnalyticsQueryRe
     private final ThreadPool threadPool;
     private final NodeClient client;
     private final EngineContextProvider contextProvider;
+    private final AnalyticsStatsCollector statsCollector;
     // Owned and closed by AnalyticsPlugin via the injected CoordinatorAllocatorHandle so that
     // shutdown closes this child of POOL_QUERY before arrow-base closes the root allocator.
     private final BufferAllocator coordinatorAllocator;
@@ -100,7 +102,8 @@ public class DefaultPlanExecutor extends HandledTransportAction<AnalyticsQueryRe
         NodeClient client,
         Scheduler scheduler,
         CoordinatorAllocatorHandle coordinatorAllocatorHandle,
-        IndexNameExpressionResolver indexNameExpressionResolver
+        IndexNameExpressionResolver indexNameExpressionResolver,
+        AnalyticsStatsCollector statsCollector
     ) {
         super(AnalyticsQueryAction.NAME, transportService, actionFilters, AnalyticsQueryRequest::new);
         this.capabilityRegistry = capabilityRegistry;
@@ -110,6 +113,7 @@ public class DefaultPlanExecutor extends HandledTransportAction<AnalyticsQueryRe
         this.client = client;
         this.scheduler = scheduler;
         this.contextProvider = contextProvider;
+        this.statsCollector = statsCollector;
         // Use the plugin-owned coordinator allocator (a child of POOL_QUERY). The plugin
         // closes the underlying allocator on Plugin.close() via the handle, so coordinator-
         // side allocations are released deterministically before arrow-base tears down the
@@ -171,7 +175,11 @@ public class DefaultPlanExecutor extends HandledTransportAction<AnalyticsQueryRe
         RelMetadataQueryBase.THREAD_PROVIDERS.set(JaninoRelMetadataProvider.of(logicalFragment.getCluster().getMetadataProvider()));
         logicalFragment.getCluster().invalidateMetadataQuery();
 
-        final long planStartNanos = profile ? System.nanoTime() : 0;
+        // Always time planning and capture the full plan: every query produces a QueryProfile
+        // that's fed into AnalyticsStatsCollector for the _plugins/_analytics/stats endpoint.
+        // The non-explain path drops the profile from the response after recording it; the
+        // explain path returns it inline.
+        final long planStartNanos = System.nanoTime();
         // Reuse the snapshot captured at REST entry when present; this is the same ClusterState
         // OpenSearchSchemaBuilder used to build the SchemaPlus, so planner and schema agree.
         // TODO: remove the null fallback once every front-end (test-ppl-frontend,
@@ -186,7 +194,7 @@ public class DefaultPlanExecutor extends HandledTransportAction<AnalyticsQueryRe
         PlanForker.forkAll(dag, capabilityRegistry);
         BackendPlanAdapter.adaptAll(dag, capabilityRegistry);
         FragmentConversionDriver.convertAll(dag, capabilityRegistry);
-        final long planningTimeMs = profile ? java.util.concurrent.TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - planStartNanos) : 0;
+        final long planningTimeMs = java.util.concurrent.TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - planStartNanos);
         logger.debug("[DefaultPlanExecutor] QueryDAG:\n{}", dag);
 
         // The task is the framework-provided task from doExecute (registered by
@@ -225,9 +233,18 @@ public class DefaultPlanExecutor extends HandledTransportAction<AnalyticsQueryRe
          */
         final AtomicReference<QueryExecution> execRef = new AtomicReference<>();
 
-        ActionListener<Iterable<Object[]>> rowsListener = profile
-            ? buildProfilingRowsListener(execRef, context, fullPlan, planningTimeMs, listener)
-            : ActionListener.wrap(rows -> listener.onResponse(new ProfiledResult(rows, null, null)), listener::onFailure);
+        // Build the profile on every terminal — both for the _explain payload (when profile=true)
+        // and for the stats collector (always). When profile=false the resulting profile is
+        // recorded into the collector and dropped from the response.
+        ActionListener<Iterable<Object[]>> rowsListener = buildProfilingRowsListener(
+            execRef,
+            context,
+            fullPlan,
+            planningTimeMs,
+            statsCollector,
+            profile,
+            listener
+        );
 
         final List<String> outputColumnOrder = logicalFragment.getRowType().getFieldNames();
         // No taskManager.unregister here: the framework (HandledTransportAction) unregisters the
@@ -254,23 +271,34 @@ public class DefaultPlanExecutor extends HandledTransportAction<AnalyticsQueryRe
     }
 
     /**
-     * Builds a rows listener that snapshots the {@link ExecutionGraph} into a {@link QueryProfile}
-     * at terminal, delivering a {@link ProfiledResult} on both success and failure paths.
+     * Builds a rows listener that, on every terminal, feeds the {@link ExecutionGraph} into the
+     * stats collector via {@link AnalyticsStatsCollector#recordExecution} — no allocation, no
+     * plan stringification. The full {@link QueryProfile} is only built when
+     * {@code includeProfileInResponse} is true (i.e. for the {@code _explain} response).
      */
     private static ActionListener<Iterable<Object[]>> buildProfilingRowsListener(
         AtomicReference<QueryExecution> execRef,
         QueryContext context,
         String fullPlan,
         long planningTimeMs,
+        AnalyticsStatsCollector statsCollector,
+        boolean includeProfileInResponse,
         ActionListener<ProfiledResult> listener
     ) {
         return ActionListener.wrap(rows -> {
-            QueryProfile qp = QueryProfileBuilder.snapshot(execRef.get().getGraph(), context, fullPlan, planningTimeMs);
+            ExecutionGraph graph = execRef.get().getGraph();
+            statsCollector.recordExecution(graph, context.dag(), planningTimeMs);
+            QueryProfile qp = includeProfileInResponse ? QueryProfileBuilder.snapshot(graph, context, fullPlan, planningTimeMs) : null;
             listener.onResponse(new ProfiledResult(rows, null, qp));
         }, e -> {
-            QueryProfile qp = execRef.get() != null && execRef.get().getGraph() != null
-                ? QueryProfileBuilder.snapshot(execRef.get().getGraph(), context, fullPlan, planningTimeMs)
-                : new QueryProfile(context.queryId(), java.util.List.of(), planningTimeMs, 0L, java.util.List.of());
+            QueryExecution exec = execRef.get();
+            ExecutionGraph graph = exec != null ? exec.getGraph() : null;
+            statsCollector.recordExecution(graph, context.dag(), planningTimeMs);
+            QueryProfile qp = includeProfileInResponse
+                ? (graph != null
+                    ? QueryProfileBuilder.snapshot(graph, context, fullPlan, planningTimeMs)
+                    : new QueryProfile(context.queryId(), java.util.List.of(), planningTimeMs, 0L, java.util.List.of()))
+                : null;
             listener.onResponse(new ProfiledResult(null, e, qp));
         });
     }
@@ -292,12 +320,20 @@ public class DefaultPlanExecutor extends HandledTransportAction<AnalyticsQueryRe
                     request.getPlan(),
                     request.getQueryCtx(),
                     request.isProfile(),
-                    ActionListener.wrap(
-                        result -> convertingListener.onResponse(
-                            request.isProfile() ? new AnalyticsQueryResponse(result) : new AnalyticsQueryResponse(result.rows())
-                        ),
-                        convertingListener::onFailure
-                    )
+                    ActionListener.wrap(result -> {
+                        if (result.isSuccess()) {
+                            convertingListener.onResponse(
+                                request.isProfile() ? new AnalyticsQueryResponse(result) : new AnalyticsQueryResponse(result.rows())
+                            );
+                        } else {
+                            // executeWithProfile delivers failures via onResponse with a populated
+                            // ProfiledResult.failure so the profile is always recorded; surface it
+                            // here as a true onFailure so the caller doesn't see a null-rows response.
+                            convertingListener.onFailure(
+                                result.failure() instanceof Exception ex ? ex : new RuntimeException(result.failure())
+                            );
+                        }
+                    }, convertingListener::onFailure)
                 );
             } catch (Exception e) {
                 convertingListener.onFailure(e);

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/stats/AnalyticsStats.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/stats/AnalyticsStats.java
@@ -1,0 +1,147 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.stats;
+
+import org.opensearch.common.annotation.ExperimentalApi;
+import org.opensearch.core.xcontent.ToXContentFragment;
+import org.opensearch.core.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * Snapshot of node-local analytics-engine counters and timers. Built by
+ * {@link AnalyticsStatsCollector#snapshot()} and rendered as a JSON fragment
+ * by the stats REST handler.
+ *
+ * <p>Field naming aligns with PR #21660's {@code StageProfile} ({@code elapsed_ms},
+ * {@code rows_processed}, {@code tasks_completed}) so dashboards can ingest
+ * either API without translating field names.
+ *
+ * <p>Latency buckets carry only raw cumulative {@code count} and {@code sum_ms}
+ * — mirroring the analytics DataFusion backend's stats contract. Averages,
+ * percentiles, and rates are derived by the metrics backend (Tumbler /
+ * Prometheus / etc.) from interval diffs.
+ *
+ * <p>Marked {@link ExperimentalApi} — field shapes and the bucket layout may
+ * change in subsequent revisions.
+ */
+@ExperimentalApi
+public final class AnalyticsStats implements ToXContentFragment {
+
+    private final Queries queries;
+    private final Map<String, StageBucket> stagesByType;
+    private final Fragments fragments;
+
+    public AnalyticsStats(Queries queries, Map<String, StageBucket> stagesByType, Fragments fragments) {
+        this.queries = queries;
+        this.stagesByType = stagesByType;
+        this.fragments = fragments;
+    }
+
+    public Queries queries() {
+        return queries;
+    }
+
+    public Map<String, StageBucket> stagesByType() {
+        return stagesByType;
+    }
+
+    public Fragments fragments() {
+        return fragments;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject("analytics");
+        queries.toXContent(builder, params);
+        builder.startObject("stages_by_type");
+        for (Map.Entry<String, StageBucket> e : stagesByType.entrySet()) {
+            builder.field(e.getKey());
+            e.getValue().toXContent(builder, params);
+        }
+        builder.endObject();
+        fragments.toXContent(builder, params);
+        builder.endObject();
+        return builder;
+    }
+
+    /**
+     * Cumulative latency totals: {@code count} of recordings and {@code sum_ms}
+     * of their elapsed times. Both monotonically increasing since node start.
+     */
+    public record LatencyStats(long count, long sumMs) implements ToXContentFragment {
+
+        public static final LatencyStats EMPTY = new LatencyStats(0, 0);
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            builder.startObject();
+            builder.field("count", count);
+            builder.field("sum_ms", sumMs);
+            builder.endObject();
+            return builder;
+        }
+    }
+
+    /**
+     * Per-query latency rollup. Counters like total / succeeded / failed are
+     * intentionally <strong>not</strong> exposed here — those are covered by
+     * analytics-engine integration with the existing {@code _nodes/stats}
+     * extension point. This bucket carries analytics-engine-specific timing
+     * totals that don't have a home in core node stats: end-to-end query
+     * elapsed and Calcite planning time.
+     */
+    public record Queries(LatencyStats elapsedMs, LatencyStats planningMs) implements ToXContentFragment {
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            builder.startObject("queries");
+            builder.field("elapsed_ms");
+            elapsedMs.toXContent(builder, params);
+            builder.field("planning_ms");
+            planningMs.toXContent(builder, params);
+            builder.endObject();
+            return builder;
+        }
+    }
+
+    /** Per-stage-type rollup, keyed by {@link org.opensearch.analytics.planner.dag.StageExecutionType} name. */
+    public record StageBucket(long started, long succeeded, long failed, long cancelled, long rowsProcessedTotal, LatencyStats elapsedMs)
+        implements
+            ToXContentFragment {
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            builder.startObject();
+            builder.field("started", started);
+            builder.field("succeeded", succeeded);
+            builder.field("failed", failed);
+            builder.field("cancelled", cancelled);
+            builder.field("rows_processed_total", rowsProcessedTotal);
+            builder.field("elapsed_ms");
+            elapsedMs.toXContent(builder, params);
+            builder.endObject();
+            return builder;
+        }
+    }
+
+    /** Per-fragment (task) rollup. */
+    public record Fragments(long total, long succeeded, long failed, LatencyStats elapsedMs) implements ToXContentFragment {
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            builder.startObject("fragments");
+            builder.field("total", total);
+            builder.field("succeeded", succeeded);
+            builder.field("failed", failed);
+            builder.field("elapsed_ms");
+            elapsedMs.toXContent(builder, params);
+            builder.endObject();
+            return builder;
+        }
+    }
+}

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/stats/AnalyticsStatsCollector.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/stats/AnalyticsStatsCollector.java
@@ -1,0 +1,209 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.stats;
+
+import org.opensearch.analytics.exec.ExecutionGraph;
+import org.opensearch.analytics.exec.stage.StageExecution;
+import org.opensearch.analytics.exec.stage.StageMetrics;
+import org.opensearch.analytics.exec.stage.StageTask;
+import org.opensearch.analytics.planner.dag.QueryDAG;
+import org.opensearch.analytics.planner.dag.Stage;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.LongAdder;
+
+/**
+ * Node-local rollup of analytics-engine query, stage, and fragment timings.
+ * {@code DefaultPlanExecutor} calls {@link #recordExecution} once per query
+ * terminal — feeding the raw counters straight off the {@link ExecutionGraph}
+ * without allocating an intermediate
+ * {@link org.opensearch.analytics.exec.profile.QueryProfile}. The {@code _explain}
+ * payload still uses {@code QueryProfileBuilder.snapshot()}; the stats path
+ * intentionally avoids it so the hot path stays allocation-free.
+ *
+ * <p>{@link #snapshot()} returns an immutable {@link AnalyticsStats} for the
+ * REST endpoint to render. Recording is wait-free: counters and latency totals
+ * are {@link LongAdder}s, the per-stage-type bucket map is a
+ * {@link ConcurrentHashMap}.
+ *
+ * <p>We intentionally don't compute averages, percentiles, or histograms here
+ * — the metrics backend derives those from interval diffs of the cumulative
+ * {@code count} / {@code sum_ms} totals. Mirrors the contract of the
+ * analytics DataFusion backend's stats endpoint.
+ */
+public final class AnalyticsStatsCollector {
+
+    private final LatencyTotals queriesElapsed = new LatencyTotals();
+    private final LatencyTotals queriesPlanning = new LatencyTotals();
+
+    private final ConcurrentMap<String, StageCounters> byStageType = new ConcurrentHashMap<>();
+
+    private final LongAdder fragmentsTotal = new LongAdder();
+    private final LongAdder fragmentsSucceeded = new LongAdder();
+    private final LongAdder fragmentsFailed = new LongAdder();
+    private final LatencyTotals fragmentsElapsed = new LatencyTotals();
+
+    /**
+     * Folds a completed query's execution into the rollup. Called once per query
+     * from {@code DefaultPlanExecutor} at terminal — success, failure, or cancellation.
+     * Walks the {@link ExecutionGraph} directly and feeds {@link LongAdder}s; no
+     * intermediate {@code QueryProfile}, no plan stringification, no per-stage
+     * stream filters.
+     *
+     * <p>Tolerates a null graph (e.g. failures upstream of execution) by
+     * recording only the planning time.
+     *
+     * @param graph the post-execution graph; may be {@code null} if the query
+     *              failed before execution started
+     * @param dag   the DAG that produced the graph; used to resolve each
+     *              {@link StageExecution} to its {@link Stage#getExecutionType()}
+     *              for per-stage-type bucketing. May be {@code null} when graph is null.
+     * @param planningTimeMs Calcite planning duration in ms
+     */
+    public void recordExecution(ExecutionGraph graph, QueryDAG dag, long planningTimeMs) {
+        if (planningTimeMs > 0) {
+            queriesPlanning.record(planningTimeMs);
+        }
+        if (graph == null) return;
+
+        // Build a stageId -> executionType lookup once. The DAG is small (handful of stages)
+        // so a flat HashMap is faster than the recursive findStageById walk QueryProfileBuilder
+        // does per-stage.
+        Map<Integer, String> stageTypeById = dag != null ? buildStageTypeIndex(dag) : Map.of();
+
+        // Track the earliest start / latest end across all stages to derive end-to-end
+        // execution wall time without a second pass over the graph.
+        long earliestStart = Long.MAX_VALUE;
+        long latestEnd = 0L;
+
+        for (StageExecution exec : graph.allExecutions()) {
+            StageMetrics m = exec.getMetrics();
+            long start = m.getStartTimeMs();
+            long end = m.getEndTimeMs();
+            long elapsed = (start > 0 && end > 0) ? end - start : 0L;
+            if (start > 0) earliestStart = Math.min(earliestStart, start);
+            if (end > 0) latestEnd = Math.max(latestEnd, end);
+
+            String execType = stageTypeById.getOrDefault(exec.getStageId(), exec.getClass().getSimpleName());
+            StageCounters c = bucket(execType);
+            switch (exec.getState()) {
+                case SUCCEEDED -> c.succeeded.increment();
+                case FAILED -> c.failed.increment();
+                case CANCELLED -> c.cancelled.increment();
+                default -> {
+                    // CREATED / RUNNING — stage didn't reach terminal; don't count toward terminal buckets.
+                }
+            }
+            c.started.increment();
+            c.rowsProcessedTotal.add(m.getRowsProcessed());
+            if (elapsed > 0) {
+                c.elapsed.record(elapsed);
+            }
+
+            for (StageTask task : exec.tasks()) {
+                fragmentsTotal.increment();
+                switch (task.state()) {
+                    case FINISHED -> fragmentsSucceeded.increment();
+                    case FAILED -> fragmentsFailed.increment();
+                    default -> {
+                        // CREATED / RUNNING / CANCELLED — counted in total only.
+                    }
+                }
+                long taskStart = task.startedAtMs();
+                long taskEnd = task.finishedAtMs();
+                long taskElapsed = (taskStart > 0 && taskEnd > 0) ? taskEnd - taskStart : 0L;
+                if (taskElapsed > 0) {
+                    fragmentsElapsed.record(taskElapsed);
+                }
+            }
+        }
+
+        long executionTimeMs = (earliestStart != Long.MAX_VALUE && latestEnd > 0) ? latestEnd - earliestStart : 0L;
+        if (executionTimeMs > 0) {
+            queriesElapsed.record(executionTimeMs);
+        }
+    }
+
+    /** Builds an immutable snapshot of all counters at this instant. */
+    public AnalyticsStats snapshot() {
+        AnalyticsStats.Queries queries = new AnalyticsStats.Queries(queriesElapsed.snapshot(), queriesPlanning.snapshot());
+        Map<String, AnalyticsStats.StageBucket> stageMap = new TreeMap<>();
+        for (Map.Entry<String, StageCounters> e : byStageType.entrySet()) {
+            StageCounters c = e.getValue();
+            stageMap.put(
+                e.getKey(),
+                new AnalyticsStats.StageBucket(
+                    c.started.sum(),
+                    c.succeeded.sum(),
+                    c.failed.sum(),
+                    c.cancelled.sum(),
+                    c.rowsProcessedTotal.sum(),
+                    c.elapsed.snapshot()
+                )
+            );
+        }
+        AnalyticsStats.Fragments fragments = new AnalyticsStats.Fragments(
+            fragmentsTotal.sum(),
+            fragmentsSucceeded.sum(),
+            fragmentsFailed.sum(),
+            fragmentsElapsed.snapshot()
+        );
+        return new AnalyticsStats(queries, stageMap, fragments);
+    }
+
+    private StageCounters bucket(String stageType) {
+        return byStageType.computeIfAbsent(stageType != null ? stageType : "unknown", k -> new StageCounters());
+    }
+
+    private static Map<Integer, String> buildStageTypeIndex(QueryDAG dag) {
+        Map<Integer, String> out = new HashMap<>();
+        addStage(out, dag.rootStage());
+        return out;
+    }
+
+    private static void addStage(Map<Integer, String> out, Stage stage) {
+        out.put(stage.getStageId(), stage.getExecutionType().name());
+        for (Stage child : stage.getChildStages()) {
+            addStage(out, child);
+        }
+    }
+
+    /**
+     * Wait-free count + sum of millisecond elapsed times. Negative recordings
+     * are dropped. Mirrors the cumulative {@code total_*_duration_ms} /
+     * {@code total_*_count} pattern used by the DataFusion backend's stats.
+     */
+    private static final class LatencyTotals {
+        private final LongAdder count = new LongAdder();
+        private final LongAdder sumMs = new LongAdder();
+
+        void record(long valueMs) {
+            if (valueMs < 0) return;
+            count.increment();
+            sumMs.add(valueMs);
+        }
+
+        AnalyticsStats.LatencyStats snapshot() {
+            return new AnalyticsStats.LatencyStats(count.sum(), sumMs.sum());
+        }
+    }
+
+    private static final class StageCounters {
+        final LongAdder started = new LongAdder();
+        final LongAdder succeeded = new LongAdder();
+        final LongAdder failed = new LongAdder();
+        final LongAdder cancelled = new LongAdder();
+        final LongAdder rowsProcessedTotal = new LongAdder();
+        final LatencyTotals elapsed = new LatencyTotals();
+    }
+}

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/stats/RestAnalyticsStatsAction.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/stats/RestAnalyticsStatsAction.java
@@ -1,0 +1,66 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.stats;
+
+import org.opensearch.common.annotation.ExperimentalApi;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.rest.BaseRestHandler;
+import org.opensearch.rest.BytesRestResponse;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.transport.client.node.NodeClient;
+
+import java.util.List;
+
+/**
+ * REST handler for {@code GET _plugins/_analytics/stats}. Returns a snapshot of
+ * node-local query / stage / fragment counters from {@link AnalyticsStatsCollector}.
+ *
+ * <p>Per-node only for v1 — broadcast via {@code TransportNodesAction} is a
+ * follow-up. Mirrors the simple {@code BaseRestHandler} pattern used by
+ * {@code DataFusionStatsAction}.
+ *
+ * <p>Marked {@link ExperimentalApi} — route, response shape, and aggregation
+ * scope (per-node vs. cluster-wide) may evolve.
+ */
+@ExperimentalApi
+public class RestAnalyticsStatsAction extends BaseRestHandler {
+
+    private final AnalyticsStatsCollector collector;
+
+    public RestAnalyticsStatsAction(AnalyticsStatsCollector collector) {
+        this.collector = collector;
+    }
+
+    @Override
+    public String getName() {
+        return "analytics_stats_action";
+    }
+
+    @Override
+    public List<Route> routes() {
+        return List.of(new Route(RestRequest.Method.GET, "_plugins/_analytics/stats"));
+    }
+
+    @Override
+    protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) {
+        return channel -> {
+            try {
+                AnalyticsStats stats = collector.snapshot();
+                XContentBuilder builder = channel.newBuilder();
+                builder.startObject();
+                stats.toXContent(builder, request);
+                builder.endObject();
+                channel.sendResponse(new BytesRestResponse(RestStatus.OK, builder));
+            } catch (Exception e) {
+                channel.sendResponse(new BytesRestResponse(channel, e));
+            }
+        };
+    }
+}

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/stats/package-info.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/stats/package-info.java
@@ -1,0 +1,16 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/**
+ * Node-local stats rollup for the analytics engine.
+ * {@link org.opensearch.analytics.stats.AnalyticsStatsCollector} accumulates
+ * lifecycle events from the {@link org.opensearch.analytics.backend.AnalyticsOperationListener}
+ * firing sites; {@link org.opensearch.analytics.stats.RestAnalyticsStatsAction}
+ * exposes a snapshot at {@code GET _plugins/_analytics/stats}.
+ */
+package org.opensearch.analytics.stats;

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/stats/AnalyticsStatsCollectorTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/stats/AnalyticsStatsCollectorTests.java
@@ -1,0 +1,216 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.stats;
+
+import org.opensearch.analytics.exec.ExecutionGraph;
+import org.opensearch.analytics.exec.stage.StageExecution;
+import org.opensearch.analytics.exec.stage.StageMetrics;
+import org.opensearch.analytics.exec.stage.StageTask;
+import org.opensearch.analytics.exec.stage.StageTaskState;
+import org.opensearch.analytics.planner.dag.QueryDAG;
+import org.opensearch.analytics.planner.dag.Stage;
+import org.opensearch.analytics.planner.dag.StageExecutionType;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link AnalyticsStatsCollector}. Feeds synthetic
+ * {@link ExecutionGraph}s into {@link AnalyticsStatsCollector#recordExecution} and
+ * asserts the rollup at {@link AnalyticsStatsCollector#snapshot} reflects them.
+ */
+public class AnalyticsStatsCollectorTests extends OpenSearchTestCase {
+
+    public void testRecordsQueryAndPlanningElapsed() {
+        AnalyticsStatsCollector c = new AnalyticsStatsCollector();
+        QueryDAG dag = dag(stageOf(0, StageExecutionType.SHARD_FRAGMENT, List.of()));
+
+        c.recordExecution(graphOf(execOf(0, StageExecution.State.SUCCEEDED, 100L, 130L, 0L, List.of())), dag, 15L);
+        c.recordExecution(graphOf(execOf(0, StageExecution.State.SUCCEEDED, 200L, 260L, 0L, List.of())), dag, 45L);
+
+        AnalyticsStats.LatencyStats elapsed = c.snapshot().queries().elapsedMs();
+        assertEquals(2, elapsed.count());
+        assertEquals(90, elapsed.sumMs());
+
+        AnalyticsStats.LatencyStats planning = c.snapshot().queries().planningMs();
+        assertEquals(2, planning.count());
+        assertEquals(60, planning.sumMs());
+    }
+
+    public void testStageBucketsKeyedByExecutionType() {
+        AnalyticsStatsCollector c = new AnalyticsStatsCollector();
+        QueryDAG dag = dag(
+            stageOf(0, StageExecutionType.COORDINATOR_REDUCE, List.of(stageOf(1, StageExecutionType.SHARD_FRAGMENT, List.of())))
+        );
+        c.recordExecution(
+            graphOf(
+                execOf(0, StageExecution.State.SUCCEEDED, 100L, 103L, 50L, List.of()),
+                execOf(1, StageExecution.State.SUCCEEDED, 100L, 108L, 200L, List.of())
+            ),
+            dag,
+            10L
+        );
+
+        AnalyticsStats.StageBucket shard = c.snapshot().stagesByType().get("SHARD_FRAGMENT");
+        assertNotNull(shard);
+        assertEquals(1, shard.started());
+        assertEquals(1, shard.succeeded());
+        assertEquals(0, shard.failed());
+        assertEquals(200, shard.rowsProcessedTotal());
+        assertEquals(8, shard.elapsedMs().sumMs());
+
+        AnalyticsStats.StageBucket reduce = c.snapshot().stagesByType().get("COORDINATOR_REDUCE");
+        assertNotNull(reduce);
+        assertEquals(1, reduce.started());
+        assertEquals(50, reduce.rowsProcessedTotal());
+        assertEquals(3, reduce.elapsedMs().sumMs());
+    }
+
+    public void testStageStatesRouteToCorrectCounter() {
+        AnalyticsStatsCollector c = new AnalyticsStatsCollector();
+        QueryDAG dag = dag(stageOf(0, StageExecutionType.SHARD_FRAGMENT, List.of()));
+        c.recordExecution(
+            graphOf(
+                execOf(0, StageExecution.State.SUCCEEDED, 100L, 101L, 0L, List.of()),
+                execOf(0, StageExecution.State.FAILED, 100L, 101L, 0L, List.of()),
+                execOf(0, StageExecution.State.CANCELLED, 100L, 101L, 0L, List.of())
+            ),
+            dag,
+            1L
+        );
+
+        AnalyticsStats.StageBucket shard = c.snapshot().stagesByType().get("SHARD_FRAGMENT");
+        assertEquals(3, shard.started());
+        assertEquals(1, shard.succeeded());
+        assertEquals(1, shard.failed());
+        assertEquals(1, shard.cancelled());
+    }
+
+    public void testFragmentCountersFromTasks() {
+        AnalyticsStatsCollector c = new AnalyticsStatsCollector();
+        QueryDAG dag = dag(stageOf(0, StageExecutionType.SHARD_FRAGMENT, List.of()));
+        c.recordExecution(
+            graphOf(
+                execOf(
+                    0,
+                    StageExecution.State.SUCCEEDED,
+                    100L,
+                    110L,
+                    5L,
+                    List.of(
+                        taskOf(StageTaskState.FINISHED, 100L, 106L),
+                        taskOf(StageTaskState.FINISHED, 100L, 104L),
+                        taskOf(StageTaskState.FAILED, 100L, 102L)
+                    )
+                )
+            ),
+            dag,
+            1L
+        );
+
+        AnalyticsStats.Fragments f = c.snapshot().fragments();
+        assertEquals(3, f.total());
+        assertEquals(2, f.succeeded());
+        assertEquals(1, f.failed());
+        assertEquals(3, f.elapsedMs().count());
+        assertEquals(12, f.elapsedMs().sumMs());
+    }
+
+    public void testSnapshotIsCumulative() {
+        AnalyticsStatsCollector c = new AnalyticsStatsCollector();
+        QueryDAG dag = dag(stageOf(0, StageExecutionType.SHARD_FRAGMENT, List.of()));
+
+        c.recordExecution(graphOf(execOf(0, StageExecution.State.SUCCEEDED, 100L, 110L, 0L, List.of())), dag, 1L);
+        AnalyticsStats first = c.snapshot();
+        assertEquals(1, first.queries().elapsedMs().count());
+
+        c.recordExecution(graphOf(execOf(0, StageExecution.State.SUCCEEDED, 200L, 230L, 0L, List.of())), dag, 1L);
+        AnalyticsStats second = c.snapshot();
+        assertEquals("count cumulative across snapshots", 2, second.queries().elapsedMs().count());
+        assertEquals("sum cumulative across snapshots", 40, second.queries().elapsedMs().sumMs());
+    }
+
+    public void testNullGraphRecordsOnlyPlanning() {
+        AnalyticsStatsCollector c = new AnalyticsStatsCollector();
+        c.recordExecution(null, null, 5L);
+
+        AnalyticsStats stats = c.snapshot();
+        assertEquals(1, stats.queries().planningMs().count());
+        assertEquals(5, stats.queries().planningMs().sumMs());
+        assertEquals(0, stats.queries().elapsedMs().count());
+        assertTrue(stats.stagesByType().isEmpty());
+        assertEquals(0, stats.fragments().total());
+    }
+
+    public void testStageWithUnknownTypeIdRoutesToFallback() {
+        // Graph has a stage with id=99 that the DAG doesn't know about — fall back to the
+        // StageExecution implementation class name rather than dropping the record.
+        AnalyticsStatsCollector c = new AnalyticsStatsCollector();
+        QueryDAG dag = dag(stageOf(0, StageExecutionType.SHARD_FRAGMENT, List.of()));
+        StageExecution exec = execOf(99, StageExecution.State.SUCCEEDED, 100L, 105L, 0L, List.of());
+        c.recordExecution(graphOf(exec), dag, 1L);
+
+        // The default exec mock's getClass().getSimpleName() is the Mockito-generated proxy name;
+        // we just assert the bucket is populated rather than asserting on the specific key.
+        assertEquals(1, c.snapshot().stagesByType().size());
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private static Stage stageOf(int id, StageExecutionType type, List<Stage> children) {
+        Stage stage = mock(Stage.class);
+        when(stage.getStageId()).thenReturn(id);
+        when(stage.getExecutionType()).thenReturn(type);
+        when(stage.getChildStages()).thenReturn(children);
+        return stage;
+    }
+
+    private static QueryDAG dag(Stage rootStage) {
+        return new QueryDAG("q-test", rootStage);
+    }
+
+    private static StageExecution execOf(
+        int stageId,
+        StageExecution.State state,
+        long startMs,
+        long endMs,
+        long rows,
+        List<StageTask> tasks
+    ) {
+        StageExecution exec = mock(StageExecution.class);
+        when(exec.getStageId()).thenReturn(stageId);
+        when(exec.getState()).thenReturn(state);
+        // StageMetrics records nanoTime internally; mock it so tests can drive exact ms values.
+        StageMetrics m = mock(StageMetrics.class);
+        when(m.getStartTimeMs()).thenReturn(startMs);
+        when(m.getEndTimeMs()).thenReturn(endMs);
+        when(m.getRowsProcessed()).thenReturn(rows);
+        when(exec.getMetrics()).thenReturn(m);
+        when(exec.tasks()).thenReturn(tasks);
+        return exec;
+    }
+
+    private static StageTask taskOf(StageTaskState state, long startMs, long endMs) {
+        StageTask t = mock(StageTask.class);
+        when(t.state()).thenReturn(state);
+        when(t.startedAtMs()).thenReturn(startMs);
+        when(t.finishedAtMs()).thenReturn(endMs);
+        return t;
+    }
+
+    private static ExecutionGraph graphOf(StageExecution... execs) {
+        ExecutionGraph graph = mock(ExecutionGraph.class);
+        when(graph.allExecutions()).thenReturn(List.of(execs));
+        when(graph.queryId()).thenReturn("q-test");
+        return graph;
+    }
+}

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/AnalyticsStatsApiIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/AnalyticsStatsApiIT.java
@@ -1,0 +1,135 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.qa;
+
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * Integration test for {@code GET /_plugins/_analytics/stats}. Fires a few
+ * PPL queries via {@code POST /_analytics/ppl} and verifies the stats endpoint
+ * reflects the activity in its query / stage / fragment counters.
+ */
+public class AnalyticsStatsApiIT extends AnalyticsRestTestCase {
+
+    private static final Dataset DATASET = new Dataset("calcs", "calcs");
+    private static boolean dataProvisioned = false;
+
+    private void ensureDataProvisioned() throws IOException {
+        if (dataProvisioned == false) {
+            DatasetProvisioner.provision(client(), DATASET);
+            dataProvisioned = true;
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testStatsEndpointReflectsExecutedQueries() throws IOException {
+        ensureDataProvisioned();
+
+        // Fire a handful of queries. The test cluster has multiple nodes and the REST client
+        // round-robins, so a single GET /_plugins/_analytics/stats only sees one node's slice
+        // of the activity. We poll until at least one query is reflected somewhere — proving
+        // the listener fired and the rollup serialized — without depending on which node
+        // happened to coordinate.
+        // Mix of queries — a few shapes so the per-stage-type buckets see varied work
+        // and the histograms have enough samples for percentile spread.
+        for (int i = 0; i < 30; i++) {
+            executePpl("source=" + DATASET.indexName + " | fields str0");
+            executePpl("source=" + DATASET.indexName + " | where num0 > 0 | fields str0, num0");
+            executePpl("source=" + DATASET.indexName + " | stats avg(num0)");
+        }
+
+        // Hit every node so the snapshot reflects both coordinator-side (queries, stages)
+        // and data-node-side (fragments) activity. Pick whichever node returned the most.
+        Map<String, Object> stats = fetchBusiestNodeStats();
+        Map<String, Object> analytics = (Map<String, Object>) stats.get("analytics");
+        assertNotNull("analytics present", analytics);
+
+        // queries bucket carries only the latency distributions — query counters
+        // (total/succeeded/failed) live in _nodes/stats, not here.
+        Map<String, Object> queries = (Map<String, Object>) analytics.get("queries");
+        assertNotNull("queries present", queries);
+        Map<String, Object> elapsed = (Map<String, Object>) queries.get("elapsed_ms");
+        assertLatencyStatsShape("queries.elapsed_ms", elapsed);
+        Map<String, Object> planning = (Map<String, Object>) queries.get("planning_ms");
+        assertLatencyStatsShape("queries.planning_ms", planning);
+        // At least one query should have been recorded somewhere on the busiest node.
+        long elapsedCount = ((Number) elapsed.get("count")).longValue();
+        assertTrue("queries.elapsed_ms.count >= 1, got " + elapsedCount, elapsedCount >= 1);
+
+        Map<String, Object> stagesByType = (Map<String, Object>) analytics.get("stages_by_type");
+        assertNotNull("stages_by_type present", stagesByType);
+        assertFalse("at least one stage type recorded", stagesByType.isEmpty());
+        for (Map.Entry<String, Object> entry : stagesByType.entrySet()) {
+            Map<String, Object> bucket = (Map<String, Object>) entry.getValue();
+            assertNotNull(entry.getKey() + ".started", bucket.get("started"));
+            assertNotNull(entry.getKey() + ".succeeded", bucket.get("succeeded"));
+            assertLatencyStatsShape(entry.getKey() + ".elapsed_ms", (Map<String, Object>) bucket.get("elapsed_ms"));
+            long started = ((Number) bucket.get("started")).longValue();
+            assertTrue(entry.getKey() + ".started > 0", started > 0);
+        }
+
+        Map<String, Object> fragments = (Map<String, Object>) analytics.get("fragments");
+        assertNotNull("fragments present", fragments);
+        assertNotNull("fragments.total", fragments.get("total"));
+        Map<String, Object> fragElapsed = (Map<String, Object>) fragments.get("elapsed_ms");
+        assertLatencyStatsShape("fragments.elapsed_ms", fragElapsed);
+        long fragTotal = ((Number) fragments.get("total")).longValue();
+        long fragSucceeded = ((Number) fragments.get("succeeded")).longValue();
+        if (fragTotal > 0) {
+            // If this node ran any fragments, at least some should have completed and reported success.
+            assertTrue("fragments.succeeded > 0 when total > 0, total=" + fragTotal + " succeeded=" + fragSucceeded, fragSucceeded > 0);
+            long fragSum = ((Number) fragElapsed.get("sum_ms")).longValue();
+            assertTrue("fragments.elapsed_ms.sum_ms > 0 when fragments succeeded", fragSum > 0);
+        }
+    }
+
+    private static void assertLatencyStatsShape(String label, Map<String, Object> latency) {
+        assertNotNull(label + " object present", latency);
+        for (String field : new String[] { "count", "sum_ms" }) {
+            assertNotNull(label + "." + field, latency.get(field));
+            long v = ((Number) latency.get(field)).longValue();
+            assertTrue(label + "." + field + " non-negative, got " + v, v >= 0);
+        }
+    }
+
+    private Map<String, Object> fetchStats() throws IOException {
+        Request request = new Request("GET", "/_plugins/_analytics/stats");
+        Response response = client().performRequest(request);
+        return assertOkAndParse(response, "STATS GET");
+    }
+
+    /**
+     * Per-node round-robin makes a single GET land on whichever node the client picks.
+     * For the example/visualisation test we want the busiest snapshot — the node that
+     * did the most work — so percentile spread and all three buckets show meaningful
+     * data.
+     */
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> fetchBusiestNodeStats() throws IOException {
+        Map<String, Object> best = null;
+        long bestSignal = -1;
+        for (int i = 0; i < 12; i++) {
+            Map<String, Object> stats = fetchStats();
+            Map<String, Object> analytics = (Map<String, Object>) stats.get("analytics");
+            Map<String, Object> elapsed = (Map<String, Object>) ((Map<String, Object>) analytics.get("queries")).get("elapsed_ms");
+            Map<String, Object> fragments = (Map<String, Object>) analytics.get("fragments");
+            long signal = ((Number) elapsed.get("count")).longValue() + ((Number) fragments.get("total")).longValue();
+            if (signal > bestSignal) {
+                bestSignal = signal;
+                best = stats;
+            }
+        }
+        return best;
+    }
+
+}

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/SearchStatsContributorIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/SearchStatsContributorIT.java
@@ -1,0 +1,95 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.qa;
+
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * Integration test verifying that analytics-engine queries surface in the standard
+ * {@code search.query_total} / {@code search.query_time_in_millis} counters under
+ * {@code GET /_nodes/stats} via the {@link org.opensearch.plugins.SearchStatsContributor}
+ * extension point. Existing tooling (e.g. Tumbler) polls these fields, so wiring the
+ * analytics counters there means no tooling changes are required to observe analytics
+ * traffic.
+ */
+public class SearchStatsContributorIT extends AnalyticsRestTestCase {
+
+    private static final Dataset DATASET = new Dataset("calcs", "calcs");
+    private static boolean dataProvisioned = false;
+
+    private void ensureDataProvisioned() throws IOException {
+        if (dataProvisioned == false) {
+            DatasetProvisioner.provision(client(), DATASET);
+            dataProvisioned = true;
+        }
+    }
+
+    public void testQueryTotalIncrementsAfterAnalyticsQueries() throws IOException {
+        ensureDataProvisioned();
+
+        long baselineQueryTotal = getQueryTotalAcrossNodes();
+        long baselineQueryTimeMs = getQueryTimeAcrossNodes();
+
+        // Fire a handful of analytics-engine PPL queries — varied shapes so the contributor
+        // sees both real elapsed time and a non-trivial count.
+        for (int i = 0; i < 5; i++) {
+            executePpl("source=" + DATASET.indexName + " | fields str0");
+            executePpl("source=" + DATASET.indexName + " | where num0 > 0 | fields str0, num0");
+            executePpl("source=" + DATASET.indexName + " | stats avg(num0)");
+        }
+
+        long afterQueryTotal = getQueryTotalAcrossNodes();
+        long afterQueryTimeMs = getQueryTimeAcrossNodes();
+
+        long countDelta = afterQueryTotal - baselineQueryTotal;
+        assertTrue(
+            "search.query_total must increment by at least 1 after analytics queries, delta=" + countDelta,
+            countDelta >= 1
+        );
+        // query_time_in_millis is a sum so it should grow strictly monotonically with count;
+        // any single query that took 0ms is unlikely with non-trivial work, but the contract
+        // we care about is "the field is being populated", so >= 0 is enough.
+        long timeDelta = afterQueryTimeMs - baselineQueryTimeMs;
+        assertTrue("search.query_time_in_millis must not regress, delta=" + timeDelta, timeDelta >= 0);
+    }
+
+    private long getQueryTotalAcrossNodes() throws IOException {
+        return sumSearchField("query_total");
+    }
+
+    private long getQueryTimeAcrossNodes() throws IOException {
+        return sumSearchField("query_time_in_millis");
+    }
+
+    @SuppressWarnings("unchecked")
+    private long sumSearchField(String field) throws IOException {
+        Request request = new Request("GET", "/_nodes/stats/indices/search");
+        Response response = client().performRequest(request);
+        Map<String, Object> body = entityAsMap(response);
+        Map<String, Object> nodes = (Map<String, Object>) body.get("nodes");
+        long total = 0;
+        for (Object nodeValue : nodes.values()) {
+            Map<String, Object> nodeStats = (Map<String, Object>) nodeValue;
+            Map<String, Object> indices = (Map<String, Object>) nodeStats.get("indices");
+            if (indices == null) continue;
+            Map<String, Object> search = (Map<String, Object>) indices.get("search");
+            if (search == null) continue;
+            Number value = (Number) search.get(field);
+            if (value != null) {
+                total += value.longValue();
+            }
+        }
+        return total;
+    }
+
+}

--- a/server/src/main/java/org/opensearch/indices/IndicesService.java
+++ b/server/src/main/java/org/opensearch/indices/IndicesService.java
@@ -174,6 +174,7 @@ import org.opensearch.node.Node;
 import org.opensearch.node.remotestore.RemoteStoreNodeAttribute;
 import org.opensearch.plugins.IndexStorePlugin;
 import org.opensearch.plugins.PluginsService;
+import org.opensearch.plugins.SearchStatsContributor;
 import org.opensearch.repositories.RepositoriesService;
 import org.opensearch.script.ScriptService;
 import org.opensearch.search.aggregations.support.ValuesSourceRegistry;
@@ -481,6 +482,7 @@ public class IndicesService extends AbstractLifecycleComponent
     private volatile int maxSizeInRequestCache;
     private volatile int defaultMaxMergeAtOnce;
     private final StatusCounterStats statusCounterStats;
+    private volatile List<SearchStatsContributor> searchStatsContributors = Collections.emptyList();
     private final ClusterMergeSchedulerConfig clusterMergeSchedulerConfig;
     private final DataFormatRegistry dataFormatRegistry;
     private final Map<String, org.opensearch.index.store.DataFormatAwareStoreDirectoryFactory> dataFormatAwareStoreDirectoryFactories;
@@ -896,6 +898,12 @@ public class IndicesService extends AbstractLifecycleComponent
                     break;
                 case Search:
                     commonStats.search.add(oldShardsStats.searchStats);
+                    for (SearchStatsContributor contributor : searchStatsContributors) {
+                        SearchStats contributed = contributor.contributeSearchStats();
+                        if (contributed != null) {
+                            commonStats.search.add(contributed);
+                        }
+                    }
                     break;
                 case Merge:
                     commonStats.merge.add(oldShardsStats.mergeStats);
@@ -2469,6 +2477,13 @@ public class IndicesService extends AbstractLifecycleComponent
 
     public void setFixedRefreshIntervalSchedulingEnabled(boolean fixedRefreshIntervalSchedulingEnabled) {
         this.fixedRefreshIntervalSchedulingEnabled = fixedRefreshIntervalSchedulingEnabled;
+    }
+
+    /**
+     * Sets the list of search stats contributors. Called by {@code Node} after plugin discovery.
+     */
+    public void setSearchStatsContributors(List<SearchStatsContributor> contributors) {
+        this.searchStatsContributors = contributors;
     }
 
     private boolean isFixedRefreshIntervalSchedulingEnabled() {

--- a/server/src/main/java/org/opensearch/node/Node.java
+++ b/server/src/main/java/org/opensearch/node/Node.java
@@ -244,6 +244,7 @@ import org.opensearch.plugins.ScriptPlugin;
 import org.opensearch.plugins.SearchBackEndPlugin;
 import org.opensearch.plugins.SearchPipelinePlugin;
 import org.opensearch.plugins.SearchPlugin;
+import org.opensearch.plugins.SearchStatsContributor;
 import org.opensearch.plugins.SecureSettingsFactory;
 import org.opensearch.plugins.SystemIndexPlugin;
 import org.opensearch.plugins.TaskManagerClientPlugin;
@@ -1232,6 +1233,11 @@ public class Node implements Closeable {
                 .filter(Objects::nonNull)
                 .findFirst()
                 .ifPresent(supplier -> monitorService.memoryReportingService().setNativeStatsSupplier(supplier));
+
+            List<SearchStatsContributor> searchStatsContributors = pluginsService.filterPlugins(SearchStatsContributor.class);
+            if (searchStatsContributors.isEmpty() == false) {
+                indicesService.setSearchStatsContributors(searchStatsContributors);
+            }
 
             if (nodeCacheService != null) {
                 nodeCacheService.registerProviders(blockCacheProviders);

--- a/server/src/main/java/org/opensearch/plugins/SearchStatsContributor.java
+++ b/server/src/main/java/org/opensearch/plugins/SearchStatsContributor.java
@@ -1,0 +1,36 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugins;
+
+import org.opensearch.common.annotation.ExperimentalApi;
+import org.opensearch.index.search.stats.SearchStats;
+
+/**
+ * Extension point for plugins that execute searches outside the standard Lucene path
+ * (e.g. analytics engine) to contribute their query metrics into the node-level
+ * {@link SearchStats} reported by {@code GET /_nodes/stats}.
+ * <p>
+ * The returned {@link SearchStats} is merged additively into the node's total search
+ * stats before serialization, so existing tooling sees the counters in the standard
+ * location without modification.
+ *
+ * @opensearch.experimental
+ */
+@ExperimentalApi
+public interface SearchStatsContributor {
+
+    /**
+     * Returns search stats to be merged into the node's aggregate search stats.
+     * Called on each {@code _nodes/stats} request. Implementations should return
+     * a snapshot of current counters; the caller handles null gracefully.
+     *
+     * @return search stats to contribute, or null if nothing to report
+     */
+    SearchStats contributeSearchStats();
+}

--- a/server/src/test/java/org/opensearch/indices/IndicesServiceTests.java
+++ b/server/src/test/java/org/opensearch/indices/IndicesServiceTests.java
@@ -38,6 +38,7 @@ import org.apache.lucene.search.similarities.Similarity;
 import org.apache.lucene.store.AlreadyClosedException;
 import org.opensearch.Version;
 import org.opensearch.action.admin.indices.stats.CommonStatsFlags;
+import org.opensearch.action.admin.indices.stats.CommonStatsFlags.Flag;
 import org.opensearch.action.admin.indices.stats.IndexShardStats;
 import org.opensearch.action.search.SearchType;
 import org.opensearch.cluster.ClusterName;
@@ -72,6 +73,7 @@ import org.opensearch.index.engine.exec.EngineBackedIndexerFactory;
 import org.opensearch.index.mapper.KeywordFieldMapper;
 import org.opensearch.index.mapper.Mapper;
 import org.opensearch.index.mapper.MapperService;
+import org.opensearch.index.search.stats.SearchStats;
 import org.opensearch.index.shard.IllegalIndexShardStateException;
 import org.opensearch.index.shard.IndexShard;
 import org.opensearch.index.shard.IndexShardState;
@@ -81,6 +83,7 @@ import org.opensearch.indices.IndicesService.ShardDeletionCheckResult;
 import org.opensearch.plugins.EnginePlugin;
 import org.opensearch.plugins.MapperPlugin;
 import org.opensearch.plugins.Plugin;
+import org.opensearch.plugins.SearchStatsContributor;
 import org.opensearch.search.internal.ContextIndexSearcher;
 import org.opensearch.search.internal.ShardSearchRequest;
 import org.opensearch.test.IndexSettingsModule;
@@ -714,5 +717,38 @@ public class IndicesServiceTests extends OpenSearchSingleNodeTestCase {
                 return size;
             }
         };
+    }
+
+    public void testStatsMergesSearchStatsContributors() {
+        IndicesService indicesService = getIndicesService();
+
+        // Baseline: no contributors registered. The Search block reflects only the node's own
+        // shard stats, which are zero on this single-node test fixture with no queries fired.
+        SearchStats baseline = indicesService.stats(new CommonStatsFlags(Flag.Search)).getSearch();
+        assertNotNull(baseline);
+        long baselineQueryCount = baseline.getTotal().getQueryCount();
+        long baselineQueryTime = baseline.getTotal().getQueryTimeInMillis();
+
+        // Two contributors: one returning real numbers, one returning null. Both must be invoked.
+        SearchStatsContributor populated = () -> new SearchStats(
+            new SearchStats.Stats.Builder().queryCount(7).queryTimeInMillis(123).build(),
+            0,
+            null
+        );
+        SearchStatsContributor empty = () -> null;
+        indicesService.setSearchStatsContributors(List.of(populated, empty));
+        try {
+            SearchStats merged = indicesService.stats(new CommonStatsFlags(Flag.Search)).getSearch();
+            assertNotNull(merged);
+            assertEquals(baselineQueryCount + 7, merged.getTotal().getQueryCount());
+            assertEquals(baselineQueryTime + 123, merged.getTotal().getQueryTimeInMillis());
+
+            // Non-Search flags must not invoke the contributors. Asking for Indexing only should
+            // leave the search block null in the response — the populated contributor's numbers
+            // would surface here if the case Search: branch wasn't gated by the flag.
+            assertNull(indicesService.stats(new CommonStatsFlags(Flag.Indexing)).getSearch());
+        } finally {
+            indicesService.setSearchStatsContributors(Collections.emptyList());
+        }
     }
 }


### PR DESCRIPTION
### Description
Builds ontop of #21660 and adds per stage timing but rolled up so users won't need to hit `_explain` for every request

Example:
```
$ curl -s 'http://localhost:9200/_plugins/_analytics/stats' | jq
{
  "analytics": {
    "queries": {
      "elapsed_ms":  { "count": 46, "sum_ms": 615 },
      "planning_ms": { "count": 46, "sum_ms": 504 }
    },
    "stages_by_type": {
      "SHARD_FRAGMENT": {
        "started": 46, "succeeded": 46, "failed": 0, "cancelled": 0,
        "rows_processed_total": 334,
        "elapsed_ms": { "count": 46, "sum_ms": 615 }
      }
    },
    "fragments": {
      "total": 46, "succeeded": 46, "failed": 0,
      "elapsed_ms": { "count": 46, "sum_ms": 613 }
    }
  }
}
```

Some follow ups that can be added:
- `TransportNodesAction` to broadcast/merge results, since right now this API is per-node only
- Planning-time failures don't increment `queries.failed` — query lifecycle events fire from `QueryScheduler.execute()`, but parse / table-resolution / planning failures fail upstream of that

Also separately adds a `SearchStatsContributor` so analytics-engine queries surface in `_nodes/stats` `search.query_total` / `query_time_in_millis`. This means existing tooling can see Mustang traffic without changes.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
