### PR TITLE
Fix flaky testContextHeaderPropagatedToResponseHeaders

### DIFF
--- a/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/FlightOutboundHandlerContextPropagationTests.java
+++ b/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/FlightOutboundHandlerContextPropagationTests.java
@@ -185,6 +185,8 @@ public class FlightOutboundHandlerContextPropagationTests extends FlightTranspor
     public void testContextHeaderPropagatedToResponseHeaders() throws InterruptedException {
         String action = "internal:test/context-header-in-response";
         CountDownLatch handlerLatch = new CountDownLatch(1);
+        // 2 batches + 1 completeStream = 3 message sent events
+        CountDownLatch messageSentLatch = new CountDownLatch(3);
         AtomicInteger responseCount = new AtomicInteger(0);
         AtomicReference<Exception> handlerException = new AtomicReference<>();
         AtomicInteger messageSentCount = new AtomicInteger(0);
@@ -193,6 +195,7 @@ public class FlightOutboundHandlerContextPropagationTests extends FlightTranspor
             @Override
             public void onResponseSent(long requestId, String action, TransportResponse response) {
                 messageSentCount.incrementAndGet();
+                messageSentLatch.countDown();
             }
 
         };
@@ -252,7 +255,8 @@ public class FlightOutboundHandlerContextPropagationTests extends FlightTranspor
         assertTrue(handlerLatch.await(TIMEOUT_SEC, TimeUnit.SECONDS));
         assertEquals(2, responseCount.get());
         assertNull(handlerException.get());
-        // 2 batches + 1 completeStream = 3 message sent events
+        // Wait for all async onResponseSent callbacks to complete before asserting count
+        assertTrue("All message sent events should complete", messageSentLatch.await(TIMEOUT_SEC, TimeUnit.SECONDS));
         assertEquals(3, messageSentCount.get());
     }
 }


### PR DESCRIPTION
### Description

Fix race condition in `testContextHeaderPropagatedToResponseHeaders` that causes intermittent `expected:<3> but was:<2>` assertion failure.

**Root cause:** `onResponseSent` callbacks are invoked asynchronously via `flightChannel.getExecutor()`. The client-side `handlerLatch` releases before the server-side `completeStream` callback fires under CPU pressure.

**Fix:** Add a dedicated `CountDownLatch(3)` for `onResponseSent` events and await it before asserting the count.

**Verification:** Reproduced locally under CPU stress (failed at run 4/14 before fix). After fix, 30 consecutive runs under same stress all pass.

### Related Issues
Resolves #21333

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).