### PR TITLE
analytics-engine: dedicated reduce thread pool

### DIFF
--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/AnalyticsPlugin.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/AnalyticsPlugin.java
@@ -69,6 +69,17 @@ public class AnalyticsPlugin extends Plugin implements ExtensiblePlugin, ActionP
     public static final String SCHEDULER_THREAD_POOL_NAME = "analytics_scheduler";
     private static final int SCHEDULER_QUEUE_SIZE = 200;
 
+    public static final String REDUCE_THREAD_POOL_NAME = "analytics_reduce";
+
+    // The reduce pool exists to isolate coordinator-reduce drains from the SEARCH
+    // pool, preventing deadlock when reduces and local shard fragments compete for
+    // the same threads. Each reduce thread blocks on a synchronous FFM call
+    // (streamNext) with negligible CPU usage — memory is the real constraint,
+    // bounded by the DataFusion pool and phantom reservations. Size is generous
+    // so the thread pool isn't the throughput bottleneck.
+    private static final int REDUCE_POOL_SIZE = Math.max(8, Runtime.getRuntime().availableProcessors() * 4);
+    private static final int REDUCE_QUEUE_SIZE = 200;
+
     public static final Setting<Long> COORDINATOR_BUFFER_LIMIT = Setting.longSetting(
         "analytics.coordinator.buffer_limit",
         256L * 1024 * 1024,
@@ -152,7 +163,10 @@ public class AnalyticsPlugin extends Plugin implements ExtensiblePlugin, ActionP
     @Override
     public List<ExecutorBuilder<?>> getExecutorBuilders(Settings settings) {
         int poolSize = schedulerPoolSize();
-        return List.of(new FixedExecutorBuilder(settings, SCHEDULER_THREAD_POOL_NAME, poolSize, SCHEDULER_QUEUE_SIZE, "analytics"));
+        return List.of(
+            new FixedExecutorBuilder(settings, SCHEDULER_THREAD_POOL_NAME, poolSize, SCHEDULER_QUEUE_SIZE, "analytics"),
+            new FixedExecutorBuilder(settings, REDUCE_THREAD_POOL_NAME, REDUCE_POOL_SIZE, REDUCE_QUEUE_SIZE, "analytics_reduce")
+        );
     }
 
     static int schedulerPoolSize() {

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/QueryContext.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/QueryContext.java
@@ -83,6 +83,10 @@ public class QueryContext {
         return threadPool != null ? threadPool.executor(AnalyticsPlugin.SCHEDULER_THREAD_POOL_NAME) : Runnable::run;
     }
 
+    public Executor reduceExecutor() {
+        return threadPool != null ? threadPool.executor(AnalyticsPlugin.REDUCE_THREAD_POOL_NAME) : Runnable::run;
+    }
+
     public AnalyticsQueryTask parentTask() {
         return parentTask;
     }

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stage/coordinator/ReduceStageExecution.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stage/coordinator/ReduceStageExecution.java
@@ -38,13 +38,13 @@ public final class ReduceStageExecution extends AbstractStageExecution implement
 
     private final ReducingExchangeSink backendSink;
     private final ExchangeSink downstream;
-    private final Executor searchExecutor;
+    private final Executor reduceExecutor;
 
     public ReduceStageExecution(Stage stage, QueryContext config, ReducingExchangeSink backendSink, ExchangeSink downstream) {
         super(stage, config.queryId(), config.operationListeners(), config.parentTask());
         this.backendSink = backendSink;
         this.downstream = downstream;
-        this.searchExecutor = config.searchExecutor();
+        this.reduceExecutor = config.reduceExecutor();
         this.runner = new LocalTaskRunner(config.schedulerExecutor());
     }
 
@@ -81,7 +81,7 @@ public final class ReduceStageExecution extends AbstractStageExecution implement
     @Override
     protected List<StageTask> materializeTasks() {
         return List.of(new LocalStageTask(new StageTaskId(getStageId(), 0), listener -> {
-            searchExecutor.execute(() -> {
+            reduceExecutor.execute(() -> {
                 try {
                     backendSink.reduce(listener);
                 } catch (Exception e) {

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/stage/ReduceStageExecutionTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/stage/ReduceStageExecutionTests.java
@@ -257,7 +257,7 @@ public class ReduceStageExecutionTests extends OpenSearchTestCase {
 
     private static QueryContext mockContext() {
         QueryContext ctx = mock(QueryContext.class);
-        when(ctx.searchExecutor()).thenReturn(inlineExecutor());
+        when(ctx.reduceExecutor()).thenReturn(inlineExecutor());
         when(ctx.schedulerExecutor()).thenReturn(inlineExecutor());
         when(ctx.parentTask()).thenReturn(mock(AnalyticsQueryTask.class));
         return ctx;


### PR DESCRIPTION
Add a fixed analytics_reduce pool for coordinator reduce drains. The reduce blocks for the entire query duration via a synchronous FFM call (streamNext), so sharing the SEARCH pool causes deadlock: concurrent reduces occupy all search threads, preventing local shard fragments from executing and feeding the reduce.

The reduce pool is separate from both SEARCH (which runs shard fragments) and analytics_scheduler (which orchestrates stage lifecycle). Pool size is adjustable via thread_pool.analytics_reduce.size cluster setting, with a generous default as its not actually doing any real work.

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
