### PR TITLE
Add analytics query stats via PluginNodeStats extension point

### DIFF
--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/AnalyticsPlugin.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/AnalyticsPlugin.java
@@ -22,6 +22,8 @@ import org.opensearch.analytics.exec.QueryPlanExecutor;
 import org.opensearch.analytics.exec.QueryScheduler;
 import org.opensearch.analytics.exec.Scheduler;
 import org.opensearch.analytics.exec.action.AnalyticsQueryAction;
+import org.opensearch.analytics.exec.stats.AnalyticsQueryNodeStats;
+import org.opensearch.analytics.exec.stats.QueryStatsService;
 import org.opensearch.analytics.planner.CapabilityRegistry;
 import org.opensearch.analytics.planner.FieldStorageResolver;
 import org.opensearch.analytics.schema.OpenSearchSchemaBuilder;
@@ -43,6 +45,7 @@ import org.opensearch.plugins.ActionPlugin;
 import org.opensearch.plugins.ExtensiblePlugin;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.plugins.PluginComponentRegistry;
+import org.opensearch.plugins.PluginNodeStats;
 import org.opensearch.repositories.RepositoriesService;
 import org.opensearch.script.ScriptService;
 import org.opensearch.threadpool.ExecutorBuilder;
@@ -99,6 +102,7 @@ public class AnalyticsPlugin extends Plugin implements ExtensiblePlugin, ActionP
     private SqlOperatorTable operatorTable;
     private AnalyticsSearchService searchService;
     private CoordinatorAllocatorHandle coordinatorAllocatorHandle;
+    private final QueryStatsService queryStatsService = new QueryStatsService();
 
     @SuppressWarnings("rawtypes")
     @Override
@@ -151,6 +155,7 @@ public class AnalyticsPlugin extends Plugin implements ExtensiblePlugin, ActionP
             b.bind(new TypeLiteral<QueryPlanExecutor<RelNode, Iterable<Object[]>>>() {
             }).to(DefaultPlanExecutor.class);
             b.bind(EngineContext.class).to(DefaultEngineContext.class);
+            b.bind(QueryStatsService.class).toInstance(queryStatsService);
             // Singleton bind on the concrete class so node-injector lookups for
             // QueryScheduler.class don't fall back to a JIT binding (which would
             // re-instantiate AnalyticsSearchTransportService, whose ctor registers
@@ -181,6 +186,18 @@ public class AnalyticsPlugin extends Plugin implements ExtensiblePlugin, ActionP
 
     static int schedulerPoolSize() {
         return Math.max(2, Runtime.getRuntime().availableProcessors() / 2);
+    }
+
+    @Override
+    public List<PluginNodeStats> nodeStats() {
+        return List.of(queryStatsService.snapshot());
+    }
+
+    @Override
+    public List<NamedWriteableRegistry.Entry> getNamedWriteables() {
+        return List.of(
+            new NamedWriteableRegistry.Entry(PluginNodeStats.class, AnalyticsQueryNodeStats.NAME, AnalyticsQueryNodeStats::new)
+        );
     }
 
     @Override

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/DefaultPlanExecutor.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/DefaultPlanExecutor.java
@@ -26,6 +26,7 @@ import org.opensearch.analytics.exec.action.AnalyticsQueryResponse;
 import org.opensearch.analytics.exec.profile.ProfiledResult;
 import org.opensearch.analytics.exec.profile.QueryProfile;
 import org.opensearch.analytics.exec.profile.QueryProfileBuilder;
+import org.opensearch.analytics.exec.stats.QueryStatsService;
 import org.opensearch.analytics.exec.task.AnalyticsQueryTask;
 import org.opensearch.analytics.exec.task.AnalyticsQueryTaskRequest;
 import org.opensearch.analytics.planner.CapabilityRegistry;
@@ -82,6 +83,7 @@ public class DefaultPlanExecutor extends HandledTransportAction<AnalyticsQueryRe
     private final TaskManager taskManager;
     private final NodeClient client;
     private final EngineContext engineContext;
+    private final QueryStatsService queryStatsService;
     // Owned and closed by AnalyticsPlugin via the injected CoordinatorAllocatorHandle so that
     // shutdown closes this child of POOL_QUERY before arrow-base closes the root allocator.
     private final BufferAllocator coordinatorAllocator;
@@ -97,7 +99,8 @@ public class DefaultPlanExecutor extends HandledTransportAction<AnalyticsQueryRe
         EngineContext engineContext,
         NodeClient client,
         Scheduler scheduler,
-        CoordinatorAllocatorHandle coordinatorAllocatorHandle
+        CoordinatorAllocatorHandle coordinatorAllocatorHandle,
+        QueryStatsService queryStatsService
     ) {
         super(AnalyticsQueryAction.NAME, transportService, actionFilters, AnalyticsQueryRequest::new);
         this.capabilityRegistry = capabilityRegistry;
@@ -108,6 +111,7 @@ public class DefaultPlanExecutor extends HandledTransportAction<AnalyticsQueryRe
         this.client = client;
         this.scheduler = scheduler;
         this.engineContext = engineContext;
+        this.queryStatsService = queryStatsService;
         // Use the plugin-owned coordinator allocator (a child of POOL_QUERY). The plugin
         // closes the underlying allocator on Plugin.close() via the handle, so coordinator-
         // side allocations are released deterministically before arrow-base tears down the
@@ -157,14 +161,14 @@ public class DefaultPlanExecutor extends HandledTransportAction<AnalyticsQueryRe
         RelMetadataQueryBase.THREAD_PROVIDERS.set(JaninoRelMetadataProvider.of(logicalFragment.getCluster().getMetadataProvider()));
         logicalFragment.getCluster().invalidateMetadataQuery();
 
-        final long planStartNanos = profile ? System.nanoTime() : 0;
+        final long planStartNanos = System.nanoTime();
         RelNode plan = PlannerImpl.createPlan(logicalFragment, new PlannerContext(capabilityRegistry, clusterService.state()));
         final String fullPlan = profile ? org.apache.calcite.plan.RelOptUtil.toString(plan) : null;
         QueryDAG dag = DAGBuilder.build(plan, capabilityRegistry, clusterService);
         PlanForker.forkAll(dag, capabilityRegistry);
         BackendPlanAdapter.adaptAll(dag, capabilityRegistry);
         FragmentConversionDriver.convertAll(dag, capabilityRegistry);
-        final long planningTimeMs = profile ? java.util.concurrent.TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - planStartNanos) : 0;
+        final long planningTimeMs = java.util.concurrent.TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - planStartNanos);
         logger.debug("[DefaultPlanExecutor] QueryDAG:\n{}", dag);
 
         final AnalyticsQueryTask queryTask = (AnalyticsQueryTask) taskManager.register(
@@ -206,7 +210,7 @@ public class DefaultPlanExecutor extends HandledTransportAction<AnalyticsQueryRe
 
         ActionListener<Iterable<Object[]>> rowsListener = profile
             ? buildProfilingRowsListener(execRef, context, fullPlan, planningTimeMs, listener)
-            : ActionListener.wrap(rows -> listener.onResponse(new ProfiledResult(rows, null, null)), listener::onFailure);
+            : buildStatsOnlyRowsListener(execRef, context, planningTimeMs, listener);
 
         ActionListener<Iterable<VectorSchemaRoot>> batchesListener = ActionListener.runAfter(
             ActionListener.wrap(batches -> rowsListener.onResponse(batchesToRows(batches)), rowsListener::onFailure),
@@ -231,8 +235,9 @@ public class DefaultPlanExecutor extends HandledTransportAction<AnalyticsQueryRe
     /**
      * Builds a rows listener that snapshots the {@link ExecutionGraph} into a {@link QueryProfile}
      * at terminal, delivering a {@link ProfiledResult} on both success and failure paths.
+     * Also records the profile into the node-level stats service.
      */
-    private static ActionListener<Iterable<Object[]>> buildProfilingRowsListener(
+    private ActionListener<Iterable<Object[]>> buildProfilingRowsListener(
         AtomicReference<QueryExecution> execRef,
         QueryContext context,
         String fullPlan,
@@ -241,12 +246,37 @@ public class DefaultPlanExecutor extends HandledTransportAction<AnalyticsQueryRe
     ) {
         return ActionListener.wrap(rows -> {
             QueryProfile qp = QueryProfileBuilder.snapshot(execRef.get().getGraph(), context, fullPlan, planningTimeMs);
+            queryStatsService.recordQuery(qp, false);
             listener.onResponse(new ProfiledResult(rows, null, qp));
         }, e -> {
             QueryProfile qp = execRef.get() != null && execRef.get().getGraph() != null
                 ? QueryProfileBuilder.snapshot(execRef.get().getGraph(), context, fullPlan, planningTimeMs)
                 : new QueryProfile(context.queryId(), java.util.List.of(), planningTimeMs, 0L, java.util.List.of());
+            queryStatsService.recordQuery(qp, true);
             listener.onResponse(new ProfiledResult(null, e, qp));
+        });
+    }
+
+    /**
+     * Non-profile path: snapshots the graph for stats recording only, does not include
+     * the profile in the response.
+     */
+    private ActionListener<Iterable<Object[]>> buildStatsOnlyRowsListener(
+        AtomicReference<QueryExecution> execRef,
+        QueryContext context,
+        long planningTimeMs,
+        ActionListener<ProfiledResult> listener
+    ) {
+        return ActionListener.wrap(rows -> {
+            QueryProfile qp = QueryProfileBuilder.snapshot(execRef.get().getGraph(), context, null, planningTimeMs);
+            queryStatsService.recordQuery(qp, false);
+            listener.onResponse(new ProfiledResult(rows, null, null));
+        }, e -> {
+            QueryProfile qp = execRef.get() != null && execRef.get().getGraph() != null
+                ? QueryProfileBuilder.snapshot(execRef.get().getGraph(), context, null, planningTimeMs)
+                : new QueryProfile(context.queryId(), java.util.List.of(), planningTimeMs, 0L, java.util.List.of());
+            queryStatsService.recordQuery(qp, true);
+            listener.onFailure(e);
         });
     }
 

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stats/AnalyticsQueryNodeStats.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stats/AnalyticsQueryNodeStats.java
@@ -1,0 +1,158 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.exec.stats;
+
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.plugins.PluginNodeStats;
+
+import java.io.IOException;
+
+/**
+ * Node-level analytics query stats exposed via {@code GET /_nodes/stats/plugin_stats}.
+ * Appears under {@code nodes.<id>.analytics_query_stats} in the response.
+ *
+ * @opensearch.internal
+ */
+public class AnalyticsQueryNodeStats implements PluginNodeStats {
+
+    public static final String NAME = "analytics_query_stats";
+
+    private final long totalQueries;
+    private final long failedQueries;
+    private final long cancelledQueries;
+    private final long planningP50Ms;
+    private final long planningP95Ms;
+    private final long planningP99Ms;
+    private final long executionP50Ms;
+    private final long executionP95Ms;
+    private final long executionP99Ms;
+    private final long coordinatorRowsP50;
+    private final long coordinatorRowsP95;
+    private final long shardFragmentStageCount;
+    private final long shardFragmentStageTotalMs;
+    private final long coordinatorReduceStageCount;
+    private final long coordinatorReduceStageTotalMs;
+
+    public AnalyticsQueryNodeStats(
+        long totalQueries,
+        long failedQueries,
+        long cancelledQueries,
+        long planningP50Ms,
+        long planningP95Ms,
+        long planningP99Ms,
+        long executionP50Ms,
+        long executionP95Ms,
+        long executionP99Ms,
+        long coordinatorRowsP50,
+        long coordinatorRowsP95,
+        long shardFragmentStageCount,
+        long shardFragmentStageTotalMs,
+        long coordinatorReduceStageCount,
+        long coordinatorReduceStageTotalMs
+    ) {
+        this.totalQueries = totalQueries;
+        this.failedQueries = failedQueries;
+        this.cancelledQueries = cancelledQueries;
+        this.planningP50Ms = planningP50Ms;
+        this.planningP95Ms = planningP95Ms;
+        this.planningP99Ms = planningP99Ms;
+        this.executionP50Ms = executionP50Ms;
+        this.executionP95Ms = executionP95Ms;
+        this.executionP99Ms = executionP99Ms;
+        this.coordinatorRowsP50 = coordinatorRowsP50;
+        this.coordinatorRowsP95 = coordinatorRowsP95;
+        this.shardFragmentStageCount = shardFragmentStageCount;
+        this.shardFragmentStageTotalMs = shardFragmentStageTotalMs;
+        this.coordinatorReduceStageCount = coordinatorReduceStageCount;
+        this.coordinatorReduceStageTotalMs = coordinatorReduceStageTotalMs;
+    }
+
+    public AnalyticsQueryNodeStats(StreamInput in) throws IOException {
+        this.totalQueries = in.readVLong();
+        this.failedQueries = in.readVLong();
+        this.cancelledQueries = in.readVLong();
+        this.planningP50Ms = in.readVLong();
+        this.planningP95Ms = in.readVLong();
+        this.planningP99Ms = in.readVLong();
+        this.executionP50Ms = in.readVLong();
+        this.executionP95Ms = in.readVLong();
+        this.executionP99Ms = in.readVLong();
+        this.coordinatorRowsP50 = in.readVLong();
+        this.coordinatorRowsP95 = in.readVLong();
+        this.shardFragmentStageCount = in.readVLong();
+        this.shardFragmentStageTotalMs = in.readVLong();
+        this.coordinatorReduceStageCount = in.readVLong();
+        this.coordinatorReduceStageTotalMs = in.readVLong();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeVLong(totalQueries);
+        out.writeVLong(failedQueries);
+        out.writeVLong(cancelledQueries);
+        out.writeVLong(planningP50Ms);
+        out.writeVLong(planningP95Ms);
+        out.writeVLong(planningP99Ms);
+        out.writeVLong(executionP50Ms);
+        out.writeVLong(executionP95Ms);
+        out.writeVLong(executionP99Ms);
+        out.writeVLong(coordinatorRowsP50);
+        out.writeVLong(coordinatorRowsP95);
+        out.writeVLong(shardFragmentStageCount);
+        out.writeVLong(shardFragmentStageTotalMs);
+        out.writeVLong(coordinatorReduceStageCount);
+        out.writeVLong(coordinatorReduceStageTotalMs);
+    }
+
+    @Override
+    public String getWriteableName() {
+        return NAME;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject("query_counts");
+        builder.field("total", totalQueries);
+        builder.field("failed", failedQueries);
+        builder.field("cancelled", cancelledQueries);
+        builder.endObject();
+
+        builder.startObject("planning_time_ms");
+        builder.field("p50", planningP50Ms);
+        builder.field("p95", planningP95Ms);
+        builder.field("p99", planningP99Ms);
+        builder.endObject();
+
+        builder.startObject("execution_time_ms");
+        builder.field("p50", executionP50Ms);
+        builder.field("p95", executionP95Ms);
+        builder.field("p99", executionP99Ms);
+        builder.endObject();
+
+        builder.startObject("coordinator_rows");
+        builder.field("p50", coordinatorRowsP50);
+        builder.field("p95", coordinatorRowsP95);
+        builder.endObject();
+
+        builder.startObject("stages");
+        builder.startObject("shard_fragment");
+        builder.field("count", shardFragmentStageCount);
+        builder.field("total_ms", shardFragmentStageTotalMs);
+        builder.endObject();
+        builder.startObject("coordinator_reduce");
+        builder.field("count", coordinatorReduceStageCount);
+        builder.field("total_ms", coordinatorReduceStageTotalMs);
+        builder.endObject();
+        builder.endObject();
+
+        return builder;
+    }
+}

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stats/QueryStatsService.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stats/QueryStatsService.java
@@ -1,0 +1,138 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.exec.stats;
+
+import org.opensearch.analytics.exec.profile.QueryProfile;
+import org.opensearch.analytics.exec.profile.StageProfile;
+
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicLongArray;
+
+/**
+ * Node-level aggregation of per-query analytics engine metrics.
+ * Thread-safe — called from the search executor pool on every query completion.
+ *
+ * <p>Maintains rolling histograms (fixed-size circular buffers) for latency
+ * percentiles and simple atomic counters for totals.
+ *
+ * @opensearch.internal
+ */
+public class QueryStatsService {
+
+    private static final int HISTOGRAM_SIZE = 1024;
+
+    // --- Counters ---
+    private final AtomicLong totalQueries = new AtomicLong();
+    private final AtomicLong failedQueries = new AtomicLong();
+    private final AtomicLong cancelledQueries = new AtomicLong();
+
+    // --- Stage counters by type ---
+    private final AtomicLong shardFragmentStageCount = new AtomicLong();
+    private final AtomicLong shardFragmentStageTotalMs = new AtomicLong();
+    private final AtomicLong coordinatorReduceStageCount = new AtomicLong();
+    private final AtomicLong coordinatorReduceStageTotalMs = new AtomicLong();
+
+    // --- Rolling histograms for percentiles ---
+    private final RollingHistogram planningTimeMs = new RollingHistogram(HISTOGRAM_SIZE);
+    private final RollingHistogram executionTimeMs = new RollingHistogram(HISTOGRAM_SIZE);
+    private final RollingHistogram coordinatorRows = new RollingHistogram(HISTOGRAM_SIZE);
+
+    /**
+     * Records a completed query's profile into the aggregate stats.
+     *
+     * @param profile the query profile snapshot (never null)
+     * @param failed  true if the query failed
+     */
+    public void recordQuery(QueryProfile profile, boolean failed) {
+        totalQueries.incrementAndGet();
+        if (failed) {
+            failedQueries.incrementAndGet();
+        }
+
+        planningTimeMs.record(profile.planningTimeMs());
+        executionTimeMs.record(profile.executionTimeMs());
+
+        long totalRows = 0;
+        for (StageProfile stage : profile.stages()) {
+            String type = stage.executionType();
+            if ("SHARD_FRAGMENT".equals(type)) {
+                shardFragmentStageCount.incrementAndGet();
+                shardFragmentStageTotalMs.addAndGet(stage.elapsedMs());
+            } else if ("COORDINATOR_REDUCE".equals(type)) {
+                coordinatorReduceStageCount.incrementAndGet();
+                coordinatorReduceStageTotalMs.addAndGet(stage.elapsedMs());
+                totalRows += stage.rowsProcessed();
+            }
+        }
+        coordinatorRows.record(totalRows);
+    }
+
+    /** Records a cancelled query (no profile available). */
+    public void recordCancelled() {
+        totalQueries.incrementAndGet();
+        cancelledQueries.incrementAndGet();
+    }
+
+    /** Snapshots the current aggregate stats into an immutable POJO. */
+    public AnalyticsQueryNodeStats snapshot() {
+        return new AnalyticsQueryNodeStats(
+            totalQueries.get(),
+            failedQueries.get(),
+            cancelledQueries.get(),
+            planningTimeMs.percentile(50),
+            planningTimeMs.percentile(95),
+            planningTimeMs.percentile(99),
+            executionTimeMs.percentile(50),
+            executionTimeMs.percentile(95),
+            executionTimeMs.percentile(99),
+            coordinatorRows.percentile(50),
+            coordinatorRows.percentile(95),
+            shardFragmentStageCount.get(),
+            shardFragmentStageTotalMs.get(),
+            coordinatorReduceStageCount.get(),
+            coordinatorReduceStageTotalMs.get()
+        );
+    }
+
+    /**
+     * Fixed-size circular buffer for approximate percentile computation.
+     * Not perfectly accurate under high concurrency (racy index increment)
+     * but good enough for operational metrics.
+     */
+    static final class RollingHistogram {
+        private final AtomicLongArray values;
+        private final AtomicLong writeIndex = new AtomicLong();
+        private final int capacity;
+
+        RollingHistogram(int capacity) {
+            this.capacity = capacity;
+            this.values = new AtomicLongArray(capacity);
+        }
+
+        void record(long value) {
+            int idx = (int) (writeIndex.getAndIncrement() % capacity);
+            values.set(idx, value);
+        }
+
+        long percentile(int p) {
+            long count = writeIndex.get();
+            int size = (int) Math.min(count, capacity);
+            if (size == 0) return 0;
+
+            long[] sorted = new long[size];
+            for (int i = 0; i < size; i++) {
+                sorted[i] = values.get(i);
+            }
+            Arrays.sort(sorted);
+            int idx = Math.min((int) Math.ceil(p / 100.0 * size) - 1, size - 1);
+            return sorted[Math.max(0, idx)];
+        }
+    }
+}

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/AnalyticsQueryStatsIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/AnalyticsQueryStatsIT.java
@@ -1,0 +1,152 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.qa;
+
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+
+import java.util.Map;
+
+/**
+ * Integration test validating that analytics query stats are reported through
+ * the {@code GET /_nodes/stats/plugin_stats} API after executing queries.
+ */
+public class AnalyticsQueryStatsIT extends AnalyticsRestTestCase {
+
+    private static final String INDEX = "query_stats_test";
+
+    public void testStatsAppearAfterQueryExecution() throws Exception {
+        createIndex();
+        indexData();
+
+        // Execute multiple queries to generate stats
+        executePPL("source = " + INDEX + " | stats avg(score) by name");
+        executePPL("source = " + INDEX + " | where score > 80");
+        executePPL("source = " + INDEX + " | fields name, score");
+
+        // Fetch plugin stats
+        Map<String, Object> stats = getAnalyticsQueryStats();
+
+        // Verify structure
+        assertNotNull("analytics_query_stats must be present", stats);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> queryCounts = (Map<String, Object>) stats.get("query_counts");
+        assertNotNull("query_counts must be present", queryCounts);
+        assertTrue("total queries must be >= 1", ((Number) queryCounts.get("total")).longValue() >= 1);
+        assertTrue("failed queries must be 0", ((Number) queryCounts.get("failed")).longValue() == 0);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> planningTime = (Map<String, Object>) stats.get("planning_time_ms");
+        assertNotNull("planning_time_ms must be present", planningTime);
+        assertNotNull("planning_time_ms.p50 must be present", planningTime.get("p50"));
+        assertNotNull("planning_time_ms.p95 must be present", planningTime.get("p95"));
+        assertNotNull("planning_time_ms.p99 must be present", planningTime.get("p99"));
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> executionTime = (Map<String, Object>) stats.get("execution_time_ms");
+        assertNotNull("execution_time_ms must be present", executionTime);
+        assertNotNull("execution_time_ms.p50 must be present", executionTime.get("p50"));
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> coordinatorRows = (Map<String, Object>) stats.get("coordinator_rows");
+        assertNotNull("coordinator_rows must be present", coordinatorRows);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> stages = (Map<String, Object>) stats.get("stages");
+        assertNotNull("stages must be present", stages);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> shardFragment = (Map<String, Object>) stages.get("shard_fragment");
+        assertNotNull("stages.shard_fragment must be present", shardFragment);
+        assertTrue("shard_fragment count must be >= 1", ((Number) shardFragment.get("count")).longValue() >= 1);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> coordinatorReduce = (Map<String, Object>) stages.get("coordinator_reduce");
+        assertNotNull("stages.coordinator_reduce must be present", coordinatorReduce);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> getAnalyticsQueryStats() throws Exception {
+        Request request = new Request("GET", "/_nodes/stats/plugin_stats");
+        Response response = client().performRequest(request);
+        Map<String, Object> body = entityAsMap(response);
+
+        Map<String, Object> nodes = (Map<String, Object>) body.get("nodes");
+        assertNotNull("nodes must be present in _nodes/stats response", nodes);
+        assertFalse("nodes must not be empty", nodes.isEmpty());
+
+        // Find the node that has analytics_query_stats (the coordinator node)
+        for (Object nodeValue : nodes.values()) {
+            Map<String, Object> nodeStats = (Map<String, Object>) nodeValue;
+            Map<String, Object> stats = (Map<String, Object>) nodeStats.get("analytics_query_stats");
+            if (stats != null) {
+                Map<String, Object> counts = (Map<String, Object>) stats.get("query_counts");
+                if (counts != null && ((Number) counts.get("total")).longValue() > 0) {
+                    return stats;
+                }
+            }
+        }
+        // Fall back to first node's stats (may be empty)
+        Map<String, Object> nodeStats = (Map<String, Object>) nodes.values().iterator().next();
+        return (Map<String, Object>) nodeStats.get("analytics_query_stats");
+    }
+
+    private void executePPL(String ppl) throws Exception {
+        Request request = new Request("POST", "/_analytics/ppl");
+        request.setJsonEntity("{\"query\": \"" + ppl + "\"}");
+        Response response = client().performRequest(request);
+        assertEquals("PPL query must succeed", 200, response.getStatusLine().getStatusCode());
+    }
+
+    private void createIndex() throws Exception {
+        try {
+            client().performRequest(new Request("DELETE", "/" + INDEX));
+        } catch (Exception ignored) {}
+
+        Request create = new Request("PUT", "/" + INDEX);
+        create.setJsonEntity("{"
+            + "\"settings\": {"
+            + "  \"index.number_of_shards\": 2,"
+            + "  \"index.number_of_replicas\": 0,"
+            + "  \"index.pluggable.dataformat.enabled\": true,"
+            + "  \"index.pluggable.dataformat\": \"composite\""
+            + "},"
+            + "\"mappings\": {"
+            + "  \"properties\": {"
+            + "    \"name\": {\"type\": \"keyword\"},"
+            + "    \"score\": {\"type\": \"double\"}"
+            + "  }"
+            + "}"
+            + "}");
+        client().performRequest(create);
+    }
+
+    private void indexData() throws Exception {
+        Request bulk = new Request("POST", "/" + INDEX + "/_bulk");
+        bulk.addParameter("refresh", "true");
+        bulk.setJsonEntity(
+            "{\"index\":{}}\n{\"name\":\"alice\",\"score\":95.5}\n"
+                + "{\"index\":{}}\n{\"name\":\"bob\",\"score\":87.3}\n"
+                + "{\"index\":{}}\n{\"name\":\"carol\",\"score\":91.0}\n"
+        );
+        client().performRequest(bulk);
+
+        // Flush to commit parquet files to disk
+        Request flush = new Request("POST", "/" + INDEX + "/_flush");
+        flush.addParameter("force", "true");
+        client().performRequest(flush);
+
+        // Wait for index health
+        Request health = new Request("GET", "/_cluster/health/" + INDEX);
+        health.addParameter("wait_for_status", "yellow");
+        health.addParameter("timeout", "30s");
+        client().performRequest(health);
+    }
+}


### PR DESCRIPTION
### Description

Exposes node-level analytics engine query metrics through the existing `_nodes/stats/plugin_stats` API. Aggregates per-query profile data into rolling percentile histograms and atomic counters.

Example output:
```
  {
    "nodes": {
      "<node-id>": {
        "analytics_query_stats": {
          "query_counts": { "total": 5, "failed": 0, "cancelled": 0 },
          "planning_time_ms": { "p50": 12, "p95": 45, "p99": 67 },
          "execution_time_ms": { "p50": 30, "p95": 120, "p99": 250 },
          "coordinator_rows": { "p50": 100, "p95": 5000 },
          "stages": {
            "shard_fragment": { "count": 10, "total_ms": 450 },
            "coordinator_reduce": { "count": 5, "total_ms": 60 }
          }
        }
      }
    }
  }
```

### Related Issues
N/A

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
