### PR TITLE
Tighten memory guard to prevent OOM

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/ffm.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/ffm.rs
@@ -92,6 +92,7 @@ pub unsafe extern "C" fn df_create_global_runtime(
     spill_dir_len: i64,
     spill_limit: i64,
 ) -> i64 {
+    crate::memory_guard::set_pool_limit_for_guard(memory_pool_limit);
     let spill_dir = str_from_raw(spill_dir_ptr, spill_dir_len)
         .map_err(|e| format!("df_create_global_runtime: {}", e))?;
     api::create_global_runtime(memory_pool_limit, cache_manager_ptr, spill_dir, spill_limit)
@@ -146,6 +147,7 @@ pub unsafe extern "C" fn df_set_memory_pool_limit(runtime_ptr: i64, new_limit: i
     if runtime_ptr == 0 {
         return Err("null runtime pointer".to_string());
     }
+    crate::memory_guard::set_pool_limit_for_guard(new_limit);
     api::set_memory_pool_limit(runtime_ptr, new_limit)?;
     Ok(0)
 }
@@ -155,13 +157,15 @@ pub extern "C" fn df_set_min_target_partitions(value: i64) {
     api::set_min_target_partitions(value);
 }
 
-/// Sets memory guard thresholds. admission_x1000 and operator_x1000 are
-/// the thresholds multiplied by 1000 (e.g., 700 = 0.70, 850 = 0.85).
+/// Sets memory guard thresholds. Values are thresholds multiplied by 1000
+/// (e.g., 700 = 0.70, 850 = 0.85, 950 = 0.95).
 #[no_mangle]
-pub extern "C" fn df_set_memory_guard_thresholds(admission_x1000: i64, operator_x1000: i64) {
+pub extern "C" fn df_set_memory_guard_thresholds(admission_throttle_x1000: i64, admission_reject_x1000: i64, execution_spill_x1000: i64, execution_critical_x1000: i64) {
     crate::memory_guard::set_thresholds(crate::memory_guard::MemoryThresholds {
-        admission: admission_x1000 as f64 / 1000.0,
-        operator: operator_x1000 as f64 / 1000.0,
+        admission_throttle: admission_throttle_x1000 as f64 / 1000.0,
+        admission_reject: admission_reject_x1000 as f64 / 1000.0,
+        execution_spill: execution_spill_x1000 as f64 / 1000.0,
+        execution_critical: execution_critical_x1000 as f64 / 1000.0,
     });
 }
 

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/memory.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/memory.rs
@@ -112,6 +112,58 @@ impl MemoryPool for DynamicLimitPool {
         reservation: &MemoryReservation,
         additional: usize,
     ) -> Result<(), DataFusionError> {
+        // Two-tier RSS guard for in-flight queries:
+        //
+        // - operator (85%): reject to trigger spill. The operator will flush its hash
+        //   table to disk and retry. This is recoverable — the query continues.
+        // - critical (95%): hard reject to prevent OOM. Last resort — even spill can't
+        //   save the node at this pressure level.
+        //
+        // Between 85-95%, the override (below) ensures spill sort buffers can still
+        // allocate: when the CAS fails and RSS has dropped below operator threshold
+        // (because the hash table was freed during spill), the override fires and
+        // allows the sort allocation through.
+        //
+        // The adaptive cache (cached_resident_bytes) bypasses the 100ms cache when
+        // the last value was above operator threshold — so the override sees the
+        // fresh (lower) RSS after spill frees memory, not a stale peak.
+        let limit = self.dynamic_limit.load(Ordering::Acquire);
+        let resident = crate::memory_guard::cached_resident_bytes();
+        if resident > 0 && limit >= 16 * 1024 * 1024 {
+            let thresholds = crate::memory_guard::get_thresholds();
+            let critical_bytes = (limit as f64 * thresholds.execution_critical) as usize;
+            let spill_bytes = (limit as f64 * thresholds.execution_spill) as usize;
+            let resident_usize = resident as usize;
+
+            // Critical (95%): hard reject — OOM imminent, protect the node.
+            if resident_usize > critical_bytes {
+                self.tripped_count.fetch_add(1, Ordering::Relaxed);
+                let used = self.used.load(Ordering::Relaxed);
+                return Err(crate::native_error::pool_limit_error(
+                    additional,
+                    reservation.consumer().name(),
+                    reservation.size(),
+                    0,
+                    limit,
+                ));
+            }
+
+            // Operator (85%): soft reject — triggers spill. The operator will
+            // flush to disk, free memory, then retry. Spill sort buffers will
+            // succeed on retry because RSS drops and the override allows them.
+            if resident_usize > spill_bytes {
+                self.tripped_count.fetch_add(1, Ordering::Relaxed);
+                let used = self.used.load(Ordering::Relaxed);
+                return Err(crate::native_error::pool_limit_error(
+                    additional,
+                    reservation.consumer().name(),
+                    reservation.size(),
+                    0,
+                    limit,
+                ));
+            }
+        }
+
         let dynamic_limit = &self.dynamic_limit;
 
         // Fast path: try the normal CAS against the pool limit.
@@ -138,7 +190,7 @@ impl MemoryPool for DynamicLimitPool {
         let used = self.used.load(Ordering::Relaxed);
         // Only attempt override if the allocation is plausible (won't overflow).
         if used.checked_add(additional).is_some() {
-            if crate::memory_guard::should_override(limit, crate::memory_guard::OverrideContext::Operator) {
+            if crate::memory_guard::should_override(limit, crate::memory_guard::OverrideContext::Execution) {
                 // jemalloc confirms headroom — allow the grow
                 let _ = self.used.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |u| {
                     u.checked_add(additional)
@@ -147,7 +199,22 @@ impl MemoryPool for DynamicLimitPool {
             }
         }
 
-        // Both pool and jemalloc confirm pressure — reject (operator will spill)
+        // Both pool and jemalloc confirm pressure. Check if RSS is critical —
+        // if so, cancel the query rather than spilling (spill can't help at 95%+).
+        if crate::memory_guard::should_cancel_query(limit) {
+            native_bridge_common::log_info!(
+                "Memory CANCEL: RSS exceeds critical threshold for consumer [{}]. Cancelling query to protect node.",
+                reservation.consumer().name()
+            );
+            return Err(DataFusionError::ResourcesExhausted(format!(
+                "Query cancelled: native memory RSS exceeds critical threshold ({}% of pool limit {}B). \
+                 Reduce query concurrency or increase datafusion.memory_pool_limit_bytes.",
+                (crate::memory_guard::get_thresholds().execution_critical * 100.0) as u32,
+                limit
+            )));
+        }
+
+        // RSS between operator (85%) and critical (95%) — reject (operator will spill)
         self.tripped_count.fetch_add(1, Ordering::Relaxed);
         let used = self.used.load(Ordering::Relaxed);
         Err(crate::native_error::pool_limit_error(
@@ -393,5 +460,62 @@ mod tests {
         }
         assert_eq!(handle.tripped_count(), 0);
         assert_eq!(pool.reserved(), 100_000);
+    }
+
+    #[test]
+    fn test_hard_guard_rejects_when_rss_exceeds_critical() {
+        // Create a pool with a limit smaller than the current process RSS.
+        // A Rust test process typically uses 50-200MB RSS, so 20MB should
+        // always trigger the hard guard (RSS > 95% of 20MB = 19MB).
+        let (pool, handle) = new_pool(20 * 1024 * 1024); // 20MB
+
+        let resident = crate::memory_guard::cached_resident_bytes();
+        if resident <= 0 {
+            return; // jemalloc not available in this test env
+        }
+
+        let critical_bytes = (20.0 * 1024.0 * 1024.0 * 0.95) as i64;
+        if resident < critical_bytes {
+            return; // RSS unexpectedly low — skip rather than false-fail
+        }
+
+        let consumer = MemoryConsumer::new("hard_guard_test");
+        let mut reservation = consumer.register(&pool);
+
+        // The hard guard fires before the CAS — even a tiny grow should be rejected
+        let result = reservation.try_grow(1024);
+        assert!(
+            result.is_err(),
+            "try_grow should fail when RSS ({}) exceeds critical threshold (95% of 20MB)",
+            resident
+        );
+        assert!(
+            handle.tripped_count() >= 1,
+            "tripped_count should increment on hard guard rejection"
+        );
+    }
+
+    #[test]
+    fn test_hard_guard_passes_when_rss_below_critical() {
+        // Create a pool with a huge limit (1TB). The test process RSS is well
+        // below 95% of 1TB, so the hard guard should NOT fire.
+        let limit = 1024 * 1024 * 1024 * 1024_usize; // 1TB
+        let (pool, handle) = new_pool(limit);
+
+        let consumer = MemoryConsumer::new("large_pool_test");
+        let mut reservation = consumer.register(&pool);
+
+        // A small allocation should succeed — RSS is far below 95% of 1TB
+        let result = reservation.try_grow(4096);
+        assert!(
+            result.is_ok(),
+            "try_grow should succeed when RSS is well below 95% of 1TB pool limit"
+        );
+        assert_eq!(
+            handle.tripped_count(),
+            0,
+            "tripped_count should remain 0 when hard guard does not fire"
+        );
+        assert_eq!(pool.reserved(), 4096);
     }
 }

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/memory_guard.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/memory_guard.rs
@@ -8,13 +8,79 @@
 
 //! Unified jemalloc-based memory guard for pool override decisions.
 //!
-//! Provides a single entry point (`should_override`) that both the admission
-//! layer (`query_budget.rs`) and the operator layer (`memory.rs`) call before
-//! reducing partitions or triggering spill respectively.
+//! All RSS checks go through [`cached_resident_bytes()`] — a single source of
+//! truth refreshed at most once per 100ms. This avoids expensive jemalloc
+//! `epoch.advance()` calls on the hot path while keeping the memory picture
+//! consistent across all decision layers (hard guard, override, cancel, admission).
 //!
 //! Thresholds are configurable at runtime via `set_thresholds`.
 
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
+use std::time::Instant;
+
+// --- Cached RSS ---
+
+const RESIDENT_CACHE_INTERVAL_MS: u64 = 100;
+static CACHED_RESIDENT: AtomicI64 = AtomicI64::new(0);
+// Initialized to u64::MAX so the first call always refreshes (any now_ms - MAX wraps to > 100).
+static LAST_CHECK_MS: AtomicU64 = AtomicU64::new(u64::MAX);
+static EPOCH_BASE: std::sync::OnceLock<Instant> = std::sync::OnceLock::new();
+
+/// Returns jemalloc resident bytes, cached for up to 100ms on the happy path.
+///
+/// When the cached value is above the spill threshold, bypasses the cache and
+/// reads fresh — because a stale-high value can incorrectly block the override
+/// (which allows spill sort buffers to allocate). The cost of a fresh read (~1-5µs)
+/// is acceptable under pressure since it only fires when memory is elevated.
+///
+/// On the happy path (RSS below threshold), only one thread per 100ms interval pays
+/// the epoch.advance() cost; all others get the cached value in <1ns.
+pub fn cached_resident_bytes() -> i64 {
+    let cached = CACHED_RESIDENT.load(Ordering::Relaxed);
+
+    // If last known value was above spill threshold, bypass cache and read fresh.
+    // A stale-high value would block the override and prevent spill from completing.
+    if cached > 0 {
+        let spill_x1000 = EXECUTION_SPILL_X1000.load(Ordering::Relaxed);
+        let limit = pool_limit_for_guard();
+        if limit > 0 {
+            let threshold = (limit as u64 * spill_x1000 / 1000) as i64;
+            if cached >= threshold {
+                let fresh = native_bridge_common::allocator::resident_bytes();
+                CACHED_RESIDENT.store(fresh, Ordering::Relaxed);
+                return fresh;
+            }
+        }
+    }
+
+    // Happy path: return cached value, refresh if interval elapsed.
+    let base = EPOCH_BASE.get_or_init(Instant::now);
+    let now_ms = base.elapsed().as_millis() as u64;
+    let last = LAST_CHECK_MS.load(Ordering::Relaxed);
+    if now_ms.wrapping_sub(last) >= RESIDENT_CACHE_INTERVAL_MS {
+        if LAST_CHECK_MS.compare_exchange(last, now_ms, Ordering::Relaxed, Ordering::Relaxed).is_ok() {
+            let r = native_bridge_common::allocator::resident_bytes();
+            CACHED_RESIDENT.store(r, Ordering::Relaxed);
+            return r;
+        }
+    }
+    CACHED_RESIDENT.load(Ordering::Relaxed)
+}
+
+// Pool limit stored for the guard's threshold check. Set once from create_global_runtime.
+static POOL_LIMIT_FOR_GUARD: AtomicI64 = AtomicI64::new(0);
+
+/// Set the pool limit used by the cached RSS pressure check.
+/// Called once at runtime creation.
+pub fn set_pool_limit_for_guard(limit: i64) {
+    POOL_LIMIT_FOR_GUARD.store(limit, Ordering::Release);
+}
+
+fn pool_limit_for_guard() -> i64 {
+    POOL_LIMIT_FOR_GUARD.load(Ordering::Relaxed)
+}
+
+// --- Thresholds ---
 
 /// Minimum pool size (bytes) for jemalloc override to activate.
 /// Below this, the pool is assumed to be a unit test / benchmark with
@@ -22,39 +88,43 @@ use std::sync::atomic::{AtomicU64, Ordering};
 const MIN_POOL_FOR_OVERRIDE: usize = 16 * 1024 * 1024; // 16MB
 
 // Configurable thresholds stored as fixed-point (×1000) in atomics.
-// Defaults: admission=70%, operator=85%.
-static ADMISSION_THRESHOLD_X1000: AtomicU64 = AtomicU64::new(700);
-static OPERATOR_THRESHOLD_X1000: AtomicU64 = AtomicU64::new(850);
+static ADMISSION_THROTTLE_X1000: AtomicU64 = AtomicU64::new(750);
+static ADMISSION_REJECT_X1000: AtomicU64 = AtomicU64::new(850);
+static EXECUTION_SPILL_X1000: AtomicU64 = AtomicU64::new(850);
+static EXECUTION_CRITICAL_X1000: AtomicU64 = AtomicU64::new(950);
 
 /// Which layer is asking for the override check.
 #[derive(Debug, Clone, Copy)]
 pub enum OverrideContext {
     /// Admission-time: deciding whether to reduce target_partitions.
-    /// More conservative (lower threshold) — committing to resource usage.
     Admission,
-    /// Operator try_grow: deciding whether to trigger spill.
-    /// More aggressive (higher threshold) — avoiding expensive disk I/O.
-    Operator,
+    /// Execution try_grow: deciding whether to allow despite pool rejection.
+    Execution,
 }
 
-/// Configurable memory thresholds for jemalloc override decisions.
+/// Configurable memory thresholds.
 ///
-/// Both values are fractions (0.0–1.0) of the pool limit:
-/// - If `jemalloc_allocated < threshold × pool_limit`, the pool's rejection
-///   is considered a false positive and the operation proceeds.
+/// Admission thresholds control who gets in.
+/// Execution thresholds control what happens during the query.
 #[derive(Debug, Clone, Copy)]
 pub struct MemoryThresholds {
-    /// Threshold for admission decisions (reduce partitions). Default: 0.70
-    pub admission: f64,
-    /// Threshold for operator decisions (trigger spill). Default: 0.85
-    pub operator: f64,
+    /// RSS above this → reduce parallelism for new queries. Default: 0.75
+    pub admission_throttle: f64,
+    /// RSS above this → reject new queries (429). Default: 0.85
+    pub admission_reject: f64,
+    /// RSS above this → force spill + disable override in try_grow. Default: 0.85
+    pub execution_spill: f64,
+    /// RSS above this → hard guard rejects (pre-CAS) + cancel (post-CAS). Default: 0.95
+    pub execution_critical: f64,
 }
 
 impl Default for MemoryThresholds {
     fn default() -> Self {
         Self {
-            admission: 0.70,
-            operator: 0.85,
+            admission_throttle: 0.75,
+            admission_reject: 0.85,
+            execution_spill: 0.85,
+            execution_critical: 0.95,
         }
     }
 }
@@ -62,12 +132,20 @@ impl Default for MemoryThresholds {
 /// Set the memory thresholds at runtime. Called from Java when cluster
 /// settings change. Thread-safe (atomic stores).
 pub fn set_thresholds(thresholds: MemoryThresholds) {
-    ADMISSION_THRESHOLD_X1000.store(
-        (thresholds.admission * 1000.0) as u64,
+    ADMISSION_THROTTLE_X1000.store(
+        (thresholds.admission_throttle * 1000.0) as u64,
         Ordering::Release,
     );
-    OPERATOR_THRESHOLD_X1000.store(
-        (thresholds.operator * 1000.0) as u64,
+    ADMISSION_REJECT_X1000.store(
+        (thresholds.admission_reject * 1000.0) as u64,
+        Ordering::Release,
+    );
+    EXECUTION_SPILL_X1000.store(
+        (thresholds.execution_spill * 1000.0) as u64,
+        Ordering::Release,
+    );
+    EXECUTION_CRITICAL_X1000.store(
+        (thresholds.execution_critical * 1000.0) as u64,
         Ordering::Release,
     );
 }
@@ -75,13 +153,41 @@ pub fn set_thresholds(thresholds: MemoryThresholds) {
 /// Read current thresholds.
 pub fn get_thresholds() -> MemoryThresholds {
     MemoryThresholds {
-        admission: ADMISSION_THRESHOLD_X1000.load(Ordering::Acquire) as f64 / 1000.0,
-        operator: OPERATOR_THRESHOLD_X1000.load(Ordering::Acquire) as f64 / 1000.0,
+        admission_throttle: ADMISSION_THROTTLE_X1000.load(Ordering::Acquire) as f64 / 1000.0,
+        admission_reject: ADMISSION_REJECT_X1000.load(Ordering::Acquire) as f64 / 1000.0,
+        execution_spill: EXECUTION_SPILL_X1000.load(Ordering::Acquire) as f64 / 1000.0,
+        execution_critical: EXECUTION_CRITICAL_X1000.load(Ordering::Acquire) as f64 / 1000.0,
     }
+}
+
+/// Returns `true` if RSS exceeds the critical threshold — the query should be
+/// cancelled. This is the last-resort path (post-CAS-fail, post-override-denied):
+/// the pool rejected, jemalloc confirms pressure, and spill alone can't recover
+/// fast enough. Cancel the query to protect the node.
+///
+/// The same critical threshold is used by the hard guard (pre-CAS) to force spill
+/// earlier — that path is recoverable. This path fires only when spill was already
+/// attempted or cannot help.
+pub fn should_cancel_query(pool_limit_bytes: usize) -> bool {
+    if pool_limit_bytes < MIN_POOL_FOR_OVERRIDE {
+        return false;
+    }
+    let resident = cached_resident_bytes();
+    if resident <= 0 {
+        return false;
+    }
+    let critical_bytes = (pool_limit_bytes as u64).saturating_mul(EXECUTION_CRITICAL_X1000.load(Ordering::Acquire)) / 1000;
+    resident >= critical_bytes as i64
 }
 
 /// Check whether jemalloc says physical memory has headroom, meaning the
 /// pool's rejection is a false positive (stale accounting).
+///
+/// Uses `resident_bytes` (physical RSS) instead of `allocated_bytes` (live objects).
+/// `allocated_bytes` undercounts true memory pressure because jemalloc retains
+/// freed pages in thread caches and arenas (dirty/muzzy decay). Under concurrent
+/// workloads, the gap between allocated and resident can be 10-20GB, causing the
+/// override to fire when the system is actually near OOM.
 ///
 /// Returns `true` if the override should fire (proceed despite pool rejection).
 /// Returns `false` if pressure is real or stats are unavailable.
@@ -90,23 +196,46 @@ pub fn get_thresholds() -> MemoryThresholds {
 /// - `pool_limit_bytes`: the pool's configured limit
 /// - `context`: which layer is asking (determines threshold)
 pub fn should_override(pool_limit_bytes: usize, context: OverrideContext) -> bool {
-    // Skip for tiny pools (unit tests, benchmarks with artificial limits)
     if pool_limit_bytes < MIN_POOL_FOR_OVERRIDE {
         return false;
     }
 
-    let allocated = native_bridge_common::allocator::allocated_bytes();
-    if allocated <= 0 {
+    let resident = cached_resident_bytes();
+    if resident <= 0 {
         return false;
     }
 
     let threshold_x1000 = match context {
-        OverrideContext::Admission => ADMISSION_THRESHOLD_X1000.load(Ordering::Acquire),
-        OverrideContext::Operator => OPERATOR_THRESHOLD_X1000.load(Ordering::Acquire),
+        OverrideContext::Admission => ADMISSION_REJECT_X1000.load(Ordering::Acquire),
+        OverrideContext::Execution => EXECUTION_SPILL_X1000.load(Ordering::Acquire),
     };
 
-    let threshold_bytes = (pool_limit_bytes as u64 * threshold_x1000 / 1000) as i64;
-    allocated < threshold_bytes
+    let threshold_bytes = (pool_limit_bytes as u64).saturating_mul(threshold_x1000) / 1000;
+    resident < threshold_bytes as i64
+}
+
+/// Proactive admission check: returns `true` if jemalloc resident memory
+/// already exceeds the admission threshold (70% of pool limit by default).
+///
+/// Called BEFORE query execution (at budget acquisition) to reject or reduce
+/// concurrency early — before any hash table allocation occurs. This prevents
+/// the "20 queries all pass admission simultaneously" burst that causes OOM.
+///
+/// Cost: one `epoch.advance` + stat read (~1-5µs). Called once per query at
+/// admission, not per-batch.
+pub fn is_memory_pressured(pool_limit_bytes: usize) -> bool {
+    if pool_limit_bytes < MIN_POOL_FOR_OVERRIDE {
+        return false;
+    }
+
+    let resident = cached_resident_bytes();
+    if resident <= 0 {
+        return false;
+    }
+
+    let threshold_x1000 = ADMISSION_THROTTLE_X1000.load(Ordering::Acquire);
+    let threshold_bytes = (pool_limit_bytes as u64).saturating_mul(threshold_x1000) / 1000;
+    resident >= threshold_bytes as i64
 }
 
 // ---------------------------------------------------------------------------
@@ -180,19 +309,22 @@ mod tests {
     #[test]
     fn default_thresholds() {
         let t = MemoryThresholds::default();
-        assert!((t.admission - 0.70).abs() < 0.001);
-        assert!((t.operator - 0.85).abs() < 0.001);
+        assert!((t.admission_throttle - 0.75).abs() < 0.001);
+        assert!((t.execution_spill - 0.85).abs() < 0.001);
+        assert!((t.execution_critical - 0.95).abs() < 0.001);
     }
 
     #[test]
     fn set_and_get_thresholds() {
         set_thresholds(MemoryThresholds {
-            admission: 0.60,
-            operator: 0.90,
+            admission_throttle: 0.60, admission_reject: 0.80,
+            execution_spill: 0.90,
+            execution_critical: 0.97,
         });
         let t = get_thresholds();
-        assert!((t.admission - 0.60).abs() < 0.001);
-        assert!((t.operator - 0.90).abs() < 0.001);
+        assert!((t.admission_throttle - 0.60).abs() < 0.001);
+        assert!((t.execution_spill - 0.90).abs() < 0.001);
+        assert!((t.execution_critical - 0.97).abs() < 0.001);
         // Restore defaults
         set_thresholds(MemoryThresholds::default());
     }
@@ -201,6 +333,129 @@ mod tests {
     fn skip_for_small_pools() {
         // Pool below 16MB → always returns false (no override)
         assert!(!should_override(1_000_000, OverrideContext::Admission));
-        assert!(!should_override(1_000_000, OverrideContext::Operator));
+        assert!(!should_override(1_000_000, OverrideContext::Execution));
+    }
+
+    #[test]
+    fn should_override_uses_resident_not_allocated() {
+        // With a large pool (1TB), resident will always be below threshold
+        // so override should fire (resident < threshold = "headroom available")
+        let large_pool = 1024 * 1024 * 1024 * 1024; // 1TB
+        let resident = cached_resident_bytes();
+        if resident <= 0 {
+            return; // jemalloc not active in this test env (CI)
+        }
+        let result = should_override(large_pool, OverrideContext::Execution);
+        assert!(result, "With 1TB pool limit, resident should be well below threshold — override should fire");
+    }
+
+    #[test]
+    fn is_memory_pressured_false_for_large_pool() {
+        // With a 1TB pool, current process RSS is far below 70% → not pressured
+        let large_pool = 1024 * 1024 * 1024 * 1024; // 1TB
+        assert!(!is_memory_pressured(large_pool));
+    }
+
+    #[test]
+    fn is_memory_pressured_true_when_rss_exceeds_limit() {
+        // Set pool limit to something well below current process RSS.
+        // A Rust test process typically uses 50-200MB RSS, so a 20MB limit
+        // should always be exceeded.
+        let small_pool = 20 * 1024 * 1024; // 20MB — above MIN_POOL_FOR_OVERRIDE
+        let resident = native_bridge_common::allocator::resident_bytes();
+        if resident <= 0 {
+            return; // jemalloc not available
+        }
+        // Only assert if RSS is actually above 70% of 20MB = 14MB (which it will be)
+        if resident as usize > small_pool * 70 / 100 {
+            assert!(is_memory_pressured(small_pool));
+        }
+    }
+
+    #[test]
+    fn is_memory_pressured_skips_small_pools() {
+        assert!(!is_memory_pressured(1_000_000)); // 1MB — below MIN_POOL_FOR_OVERRIDE
+    }
+
+    #[test]
+    fn cached_resident_bytes_returns_non_negative() {
+        // Returns > 0 when jemalloc is active, 0 when not (CI may not link jemalloc)
+        let resident = cached_resident_bytes();
+        assert!(resident >= 0, "cached_resident_bytes() should never return negative, got {}", resident);
+    }
+
+    #[test]
+    fn cached_resident_bytes_is_stable_within_interval() {
+        // Two calls within <100ms should return the same cached value
+        // (only one thread per interval refreshes the cache).
+        let first = cached_resident_bytes();
+        let second = cached_resident_bytes();
+        assert_eq!(
+            first, second,
+            "Two immediate calls should return the same cached value"
+        );
+    }
+
+    #[test]
+    fn should_cancel_query_false_for_small_pools() {
+        // Pools below MIN_POOL_FOR_OVERRIDE (16MB) always return false
+        assert!(!should_cancel_query(1_000_000)); // 1MB
+        assert!(!should_cancel_query(8 * 1024 * 1024)); // 8MB
+        assert!(!should_cancel_query(15 * 1024 * 1024)); // 15MB
+    }
+
+    #[test]
+    fn should_cancel_query_true_when_rss_exceeds_limit() {
+        // With a 20MB pool limit (above MIN_POOL_FOR_OVERRIDE), the current test
+        // process RSS should exceed 95% of 20MB = 19MB. A Rust test process
+        // typically uses 50-200MB RSS.
+        let small_pool = 20 * 1024 * 1024; // 20MB
+        let resident = native_bridge_common::allocator::resident_bytes();
+        if resident <= 0 {
+            return; // jemalloc not available in this test env
+        }
+        // Only assert if RSS actually exceeds the critical threshold
+        let critical_bytes = (small_pool as f64 * 0.95) as i64;
+        if resident >= critical_bytes {
+            assert!(
+                should_cancel_query(small_pool),
+                "should_cancel_query should return true when RSS ({}) exceeds 95% of pool ({})",
+                resident,
+                small_pool
+            );
+        }
+    }
+
+    #[test]
+    fn override_respects_spill_vs_admission_threshold() {
+        // Operator threshold (85%) is more permissive than admission (75%).
+        // For a pool where RSS is between 70% and 85%:
+        // - Admission override should NOT fire (RSS >= 70% threshold)
+        // - Operator override SHOULD fire (RSS < 85% threshold)
+        //
+        // We can't precisely control RSS in a unit test, but we can verify
+        // that the thresholds are read correctly by setting them and checking
+        // behavior with known pool sizes.
+        let resident = native_bridge_common::allocator::resident_bytes();
+        if resident <= 0 {
+            return; // jemalloc not available in this test env
+        }
+        let resident = resident as usize;
+
+        // Set pool limit so that resident is exactly between 70% and 85%
+        // pool = resident / 0.77 (midpoint) → resident/pool ≈ 77%
+        let pool_at_midpoint = (resident as f64 / 0.77) as usize;
+        if pool_at_midpoint < MIN_POOL_FOR_OVERRIDE {
+            return;
+        }
+
+        // At 77% utilization: admission (75%) should NOT override, operator (85%) SHOULD override
+        let admission_result = should_override(pool_at_midpoint, OverrideContext::Admission);
+        let spill_result = should_override(pool_at_midpoint, OverrideContext::Execution);
+
+        // admission: resident (77%) >= threshold (70%) → NOT below → override = false
+        assert!(!admission_result, "At 77% RSS, admission override should NOT fire (threshold 70%)");
+        // operator: resident (77%) < threshold (85%) → below → override = true
+        assert!(spill_result, "At 77% RSS, spill override SHOULD fire (threshold 85%)");
     }
 }

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/query_budget.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/query_budget.rs
@@ -191,6 +191,13 @@ pub fn acquire_budget_with_projection(
 ///
 /// Tries to reserve a phantom at the configured parallelism. If the pool
 /// rejects it, iteratively halves target_partitions until it fits.
+///
+/// **Proactive RSS check**: before attempting pool reservation, consults
+/// jemalloc's resident bytes. If physical memory already exceeds the admission
+/// threshold (default 70% of pool limit), immediately reduces partitions to
+/// the minimum. This prevents the "20 queries all pass admission simultaneously"
+/// burst — each new query arriving when RSS is elevated starts at minimum
+/// parallelism, limiting its hash table growth and total memory footprint.
 fn acquire_budget_inner(
     pool: &Arc<dyn MemoryPool>,
     avg_row_bytes: usize,
@@ -201,6 +208,45 @@ fn acquire_budget_inner(
     let min_partitions = get_min_target_partitions();
     let mut target_partitions = configured_target_partitions.max(min_partitions);
     let mut batch_size = configured_batch_size.max(MIN_BATCH_SIZE);
+
+    // Proactive admission guard: only consult jemalloc RSS when the pool's own
+    // reservation accounting already shows pressure (>= admission threshold).
+    // This avoids the ~5µs jemalloc epoch.advance cost on the happy path.
+    if let Some(limit) = pool_limit(pool) {
+        let reserved = pool.reserved();
+        let thresholds = crate::memory_guard::get_thresholds();
+        let admission_bytes = (limit as f64 * thresholds.admission_throttle) as usize;
+        if reserved >= admission_bytes {
+            let resident = native_bridge_common::allocator::resident_bytes();
+            if resident > 0 {
+                let spill_bytes = (limit as f64 * thresholds.admission_reject) as i64;
+                if resident >= spill_bytes {
+                    // RSS at spill threshold (85%) — reject immediately.
+                    // Even at min partitions this query will hit spill on first batch.
+                    // Better to reject with clear backpressure than admit and fail slowly.
+                    native_bridge_common::log_info!(
+                        "Admission REJECTED: pool reserved={}B, RSS={}B >= spill threshold ({:.0}% of {}B). Node under memory pressure.",
+                        reserved, resident, thresholds.admission_reject * 100.0, limit
+                    );
+                    return Err(crate::native_error::admission_rejected_error(
+                        compute_untracked_bytes_with_columns(min_partitions, MIN_BATCH_SIZE, avg_row_bytes, num_columns),
+                        min_partitions,
+                        MIN_BATCH_SIZE,
+                        avg_row_bytes,
+                    ));
+                }
+                // RSS between admission (70%) and operator (85%) — reduce partitions
+                let admission_threshold_bytes = (limit as f64 * thresholds.admission_throttle) as i64;
+                if resident >= admission_threshold_bytes {
+                    native_bridge_common::log_info!(
+                        "Admission: pool reserved={}B, RSS={}B >= admission threshold ({:.0}%) — reducing to min partitions={}",
+                        reserved, resident, thresholds.admission_throttle * 100.0, min_partitions
+                    );
+                    target_partitions = min_partitions;
+                }
+            }
+        }
+    }
 
     loop {
         let phantom_bytes = compute_untracked_bytes_with_columns(

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionPlugin.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionPlugin.java
@@ -201,11 +201,11 @@ public class DataFusionPlugin extends Plugin
      * When pool accounting rejects a phantom reservation but jemalloc reports
      * actual RSS below this fraction of the pool limit, the reservation proceeds
      * at full parallelism (false-positive override). Lower = more conservative.
-     * Default: 0.70.
+     * Default: 0.75.
      */
-    public static final Setting<Double> DATAFUSION_MEMORY_GUARD_ADMISSION_THRESHOLD = Setting.doubleSetting(
-        "datafusion.memory_guard.admission_threshold",
-        0.70,
+    public static final Setting<Double> DATAFUSION_MEMORY_GUARD_ADMISSION_THROTTLE_THRESHOLD = Setting.doubleSetting(
+        "datafusion.memory_guard.admission_throttle_threshold",
+        0.75,
         0.0,
         1.0,
         Setting.Property.NodeScope,
@@ -213,15 +213,42 @@ public class DataFusionPlugin extends Plugin
     );
 
     /**
-     * Operator threshold for the jemalloc memory guard (0.0–1.0).
-     * When an operator's try_grow is rejected by the pool but jemalloc reports
-     * actual RSS below this fraction of the pool limit, the grow proceeds
-     * (avoiding unnecessary spill). Higher = more aggressive (fewer spills).
+     * RSS fraction above which new queries are rejected (429 backpressure).
+     * Protects running queries from new arrivals when memory is elevated.
      * Default: 0.85.
      */
-    public static final Setting<Double> DATAFUSION_MEMORY_GUARD_OPERATOR_THRESHOLD = Setting.doubleSetting(
-        "datafusion.memory_guard.operator_threshold",
+    public static final Setting<Double> DATAFUSION_MEMORY_GUARD_ADMISSION_REJECT_THRESHOLD = Setting.doubleSetting(
+        "datafusion.memory_guard.admission_reject_threshold",
         0.85,
+        0.0,
+        1.0,
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
+    );
+
+    /**
+     * RSS fraction above which the execution hard guard forces spill and the
+     * override (which allows allocations despite pool rejection) is disabled.
+     * Default: 0.85.
+     */
+    public static final Setting<Double> DATAFUSION_MEMORY_GUARD_EXECUTION_SPILL_THRESHOLD = Setting.doubleSetting(
+        "datafusion.memory_guard.execution.spill_threshold",
+        0.85,
+        0.0,
+        1.0,
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
+    );
+
+    /**
+     * RSS fraction at which memory is considered critical. Serves dual purpose:
+     * - Hard guard (pre-CAS): forces spill when pool accounting lags jemalloc (recoverable)
+     * - Cancel path (post-CAS-fail): terminates query when spill can't help (last resort)
+     * Default: 0.95.
+     */
+    public static final Setting<Double> DATAFUSION_MEMORY_GUARD_EXECUTION_CRITICAL_THRESHOLD = Setting.doubleSetting(
+        "datafusion.memory_guard.execution.critical_threshold",
+        0.95,
         0.0,
         1.0,
         Setting.Property.NodeScope,
@@ -305,15 +332,21 @@ public class DataFusionPlugin extends Plugin
         clusterService.getClusterSettings().addSettingsUpdateConsumer(DATAFUSION_SPILL_MEMORY_LIMIT, this::updateSpillMemoryLimit);
         clusterService.getClusterSettings().addSettingsUpdateConsumer(DATAFUSION_MIN_TARGET_PARTITIONS, this::updateMinTargetPartitions);
         clusterService.getClusterSettings()
-            .addSettingsUpdateConsumer(DATAFUSION_MEMORY_GUARD_ADMISSION_THRESHOLD, v -> updateMemoryGuardThresholds());
+            .addSettingsUpdateConsumer(DATAFUSION_MEMORY_GUARD_ADMISSION_THROTTLE_THRESHOLD, v -> updateMemoryGuardThresholds());
         clusterService.getClusterSettings()
-            .addSettingsUpdateConsumer(DATAFUSION_MEMORY_GUARD_OPERATOR_THRESHOLD, v -> updateMemoryGuardThresholds());
+            .addSettingsUpdateConsumer(DATAFUSION_MEMORY_GUARD_ADMISSION_REJECT_THRESHOLD, v -> updateMemoryGuardThresholds());
+        clusterService.getClusterSettings()
+            .addSettingsUpdateConsumer(DATAFUSION_MEMORY_GUARD_EXECUTION_SPILL_THRESHOLD, v -> updateMemoryGuardThresholds());
+        clusterService.getClusterSettings()
+            .addSettingsUpdateConsumer(DATAFUSION_MEMORY_GUARD_EXECUTION_CRITICAL_THRESHOLD, v -> updateMemoryGuardThresholds());
 
         // Apply initial values
         NativeBridge.setMinTargetPartitions(DATAFUSION_MIN_TARGET_PARTITIONS.get(settings));
         NativeBridge.setMemoryGuardThresholds(
-            DATAFUSION_MEMORY_GUARD_ADMISSION_THRESHOLD.get(settings),
-            DATAFUSION_MEMORY_GUARD_OPERATOR_THRESHOLD.get(settings)
+            DATAFUSION_MEMORY_GUARD_ADMISSION_THROTTLE_THRESHOLD.get(settings),
+            DATAFUSION_MEMORY_GUARD_ADMISSION_REJECT_THRESHOLD.get(settings),
+            DATAFUSION_MEMORY_GUARD_EXECUTION_SPILL_THRESHOLD.get(settings),
+            DATAFUSION_MEMORY_GUARD_EXECUTION_CRITICAL_THRESHOLD.get(settings)
         );
 
         this.datafusionSettings = new DatafusionSettings(clusterService);
@@ -449,10 +482,18 @@ public class DataFusionPlugin extends Plugin
     }
 
     private void updateMemoryGuardThresholds() {
-        double admission = clusterService.getClusterSettings().get(DATAFUSION_MEMORY_GUARD_ADMISSION_THRESHOLD);
-        double operator = clusterService.getClusterSettings().get(DATAFUSION_MEMORY_GUARD_OPERATOR_THRESHOLD);
-        NativeBridge.setMemoryGuardThresholds(admission, operator);
-        logger.info("Updated DataFusion memory guard thresholds: admission={}, operator={}", admission, operator);
+        double admissionThrottle = clusterService.getClusterSettings().get(DATAFUSION_MEMORY_GUARD_ADMISSION_THROTTLE_THRESHOLD);
+        double admissionReject = clusterService.getClusterSettings().get(DATAFUSION_MEMORY_GUARD_ADMISSION_REJECT_THRESHOLD);
+        double executionSpill = clusterService.getClusterSettings().get(DATAFUSION_MEMORY_GUARD_EXECUTION_SPILL_THRESHOLD);
+        double executionCritical = clusterService.getClusterSettings().get(DATAFUSION_MEMORY_GUARD_EXECUTION_CRITICAL_THRESHOLD);
+        NativeBridge.setMemoryGuardThresholds(admissionThrottle, admissionReject, executionSpill, executionCritical);
+        logger.info(
+            "Updated DataFusion memory guard thresholds: admission_throttle={}, admission_reject={}, execution_spill={}, execution_critical={}",
+            admissionThrottle,
+            admissionReject,
+            executionSpill,
+            executionCritical
+        );
     }
 
     @Override

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionSettings.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionSettings.java
@@ -171,8 +171,10 @@ public final class DatafusionSettings {
         DataFusionPlugin.DATAFUSION_SPILL_MEMORY_LIMIT,
         DataFusionPlugin.DATAFUSION_REDUCE_INPUT_MODE,
         DataFusionPlugin.DATAFUSION_MIN_TARGET_PARTITIONS,
-        DataFusionPlugin.DATAFUSION_MEMORY_GUARD_ADMISSION_THRESHOLD,
-        DataFusionPlugin.DATAFUSION_MEMORY_GUARD_OPERATOR_THRESHOLD,
+        DataFusionPlugin.DATAFUSION_MEMORY_GUARD_ADMISSION_THROTTLE_THRESHOLD,
+        DataFusionPlugin.DATAFUSION_MEMORY_GUARD_ADMISSION_REJECT_THRESHOLD,
+        DataFusionPlugin.DATAFUSION_MEMORY_GUARD_EXECUTION_SPILL_THRESHOLD,
+        DataFusionPlugin.DATAFUSION_MEMORY_GUARD_EXECUTION_CRITICAL_THRESHOLD,
 
         // Cache settings — metadata and statistics cache configuration
         CacheSettings.METADATA_CACHE_SIZE_LIMIT,

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/nativelib/NativeBridge.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/nativelib/NativeBridge.java
@@ -180,7 +180,7 @@ public final class NativeBridge {
 
         SET_MEMORY_GUARD_THRESHOLDS = linker.downcallHandle(
             lib.find("df_set_memory_guard_thresholds").orElseThrow(),
-            FunctionDescriptor.ofVoid(ValueLayout.JAVA_LONG, ValueLayout.JAVA_LONG)
+            FunctionDescriptor.ofVoid(ValueLayout.JAVA_LONG, ValueLayout.JAVA_LONG, ValueLayout.JAVA_LONG, ValueLayout.JAVA_LONG)
         );
 
         CREATE_READER = linker.downcallHandle(
@@ -680,10 +680,20 @@ public final class NativeBridge {
         }
     }
 
-    /** Sets the memory guard admission and operator thresholds (0.0–1.0). */
-    public static void setMemoryGuardThresholds(double admission, double operator) {
+    /** Sets the memory guard thresholds (0.0–1.0): admission throttle, admission reject, execution spill, execution critical. */
+    public static void setMemoryGuardThresholds(
+        double admissionThrottle,
+        double admissionReject,
+        double executionSpill,
+        double executionCritical
+    ) {
         try {
-            SET_MEMORY_GUARD_THRESHOLDS.invokeExact((long) (admission * 1000), (long) (operator * 1000));
+            SET_MEMORY_GUARD_THRESHOLDS.invokeExact(
+                (long) (admissionThrottle * 1000),
+                (long) (admissionReject * 1000),
+                (long) (executionSpill * 1000),
+                (long) (executionCritical * 1000)
+            );
         } catch (Throwable t) {
             logger.debug("Failed to set memory guard thresholds", t);
         }

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionPluginSettingsTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionPluginSettingsTests.java
@@ -110,7 +110,7 @@ public class DataFusionPluginSettingsTests extends OpenSearchTestCase {
     public void testGetSettingsReturnsTotalExpectedCount() {
         try (DataFusionPlugin plugin = new DataFusionPlugin()) {
             List<Setting<?>> settings = plugin.getSettings();
-            assertEquals(19, settings.size());
+            assertEquals(23, settings.size());
         } catch (Exception e) {
             throw new AssertionError(e);
         }

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionSettingsTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionSettingsTests.java
@@ -69,7 +69,7 @@ public class DatafusionSettingsTests extends OpenSearchTestCase {
     }
 
     public void testAllSettingsContainsAllExpectedSettings() {
-        assertEquals(19, DatafusionSettings.ALL_SETTINGS.size());
+        assertEquals(23, DatafusionSettings.ALL_SETTINGS.size());
         assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DatafusionSettings.INDEXED_BATCH_SIZE));
         assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DatafusionSettings.INDEXED_PARQUET_PUSHDOWN_FILTERS));
         assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DatafusionSettings.INDEXED_MIN_SKIP_RUN_DEFAULT));


### PR DESCRIPTION
---
   DataFusion's hash aggregation allocates via jemalloc before consulting the memory pool (hashbrown::reserve() → malloc → then try_grow()). Under concurrent load, 20 queries burst past the 30.9GB pool limit simultaneously → OOM kills the node.

  The Solution: Layered Defense

```
  Query arrives
        │
        ▼
  ┌─────────────────────────────────────────────────────────────────────┐
  │  ADMISSION (query_budget.rs) — once per query, before execution     │
  │                                                                     │
  │  cached_resident_bytes() vs pool_limit:                             │
  │    RSS < 70%  → admit at full parallelism                           │
  │    RSS 70-85% → admit at reduced parallelism (fewer partitions)     │
  │    RSS > 85%  → reject query (429 backpressure)                     │
  │                                                                     │
  │  Also reserves a "phantom" for untracked memory (in-flight batches, │
  │  decode buffers) so the pool accurately reflects true usage.         │
  └─────────────────────────────────────────────────────────────────────┘
        │
        ▼  query admitted, operators start processing batches
        │
  ┌─────────────────────────────────────────────────────────────────────┐
  │  try_grow() — called per batch per operator (hot path)              │
  │                                                                     │
  │  ┌─ HARD GUARD (pre-CAS) ────────────────────────────────────────┐  │
  │  │  cached_resident_bytes() > 95% of pool_limit?                 │  │
  │  │    YES → reject → triggers spill (operator flushes to disk)   │  │
  │  │    NO  → continue to CAS                                      │  │
  │  └───────────────────────────────────────────────────────────────┘  │
  │                                                                     │
  │  ┌─ POOL CAS ────────────────────────────────────────────────────┐  │
  │  │  pool_used + additional <= pool_limit?                        │  │
  │  │    YES → allow (fast path, no jemalloc call)                  │  │
  │  │    NO  → CAS fails, check override                           │  │
  │  └───────────────────────────────────────────────────────────────┘  │
  │                                                                     │
  │  ┌─ OPERATOR OVERRIDE (post-CAS-fail) ──────────────────────────┐  │
  │  │  cached_resident_bytes() < 85% of pool_limit?                 │  │
  │  │    YES → pool is lying (stale phantoms) → allow allocation    │  │
  │  │    NO  → pressure is real, continue to cancel check           │  │
  │  │                                                               │  │
  │  │  This is how spill sort buffers succeed: after the hash table │  │
  │  │  is freed during spill, RSS drops below 85%, override fires,  │  │
  │  │  and the sort allocation goes through.                        │  │
  │  └───────────────────────────────────────────────────────────────┘  │
  │                                                                     │
  │  ┌─ CANCEL (post-CAS-fail, post-override-denied) ───────────────┐  │
  │  │  cached_resident_bytes() > 95% of pool_limit?                 │  │
  │  │    YES → cancel query (ResourcesExhausted, protect node)      │  │
  │  │    NO  → reject → triggers spill                              │  │
  │  └───────────────────────────────────────────────────────────────┘  │
  └─────────────────────────────────────────────────────────────────────┘

  Thresholds (configurable at runtime via cluster settings)

  ┌─────────────────────────────────────────────┬─────────┬───────────────────────────────────────────────────────────┐
  │                   Setting                   │ Default │                           Role                            │
  ├─────────────────────────────────────────────┼─────────┼───────────────────────────────────────────────────────────┤
  │ datafusion.memory_guard.admission_threshold │ 0.70    │ Reduce/reject new queries                                 │
  ├─────────────────────────────────────────────┼─────────┼───────────────────────────────────────────────────────────┤
  │ datafusion.memory_guard.operator_threshold  │ 0.85    │ Override: allow if RSS below (spill buffers succeed here) │
  ├─────────────────────────────────────────────┼─────────┼───────────────────────────────────────────────────────────┤
  │ datafusion.memory_guard.critical_threshold  │ 0.95    │ Hard guard + cancel: protect node from OOM                │
  └─────────────────────────────────────────────┴─────────┴───────────────────────────────────────────────────────────┘
```
  The Adaptive Cache

  cached_resident_bytes() avoids calling jemalloc epoch.advance() (~1-5µs) on every try_grow:

  - Happy path (RSS < 85%): returns cached value, refreshed every 100ms. Cost: one atomic load (<1ns).
  - Under pressure (cached ≥ 85%): bypasses cache, reads fresh. This prevents a stale-high value from blocking the override when RSS has actually dropped (e.g., after spill frees memory).

  How Spill Works End-to-End

  1. Batch processes → hash table grows via hashbrown::reserve() (outside pool)
  2. try_grow() called → hard guard or CAS rejects
  3. DataFusion catches ResourcesExhausted → calls spill()
  4. spill() emits hash table into a RecordBatch
  5. spill() calls clear_shrink(0) → frees hash table memory → RSS drops
  6. spill() calls try_grow(sort_memory) for sort buffer
  7. CAS fails (pool accounting still high from phantoms)
  8. Override: cached_resident (now fresh, RSS dropped) < 85% → ALLOWS ✓
  9. Sort buffer allocated → data sorted → written to disk
  10. Query continues with next batch (hash table rebuilt incrementally)

  What's NOT fixed (separate issue)

  18 high-cardinality queries (17M-100M groups) fail at the Arrow C Data import layer — when Rust exports partial aggregation results to Java, the Arrow flight allocator (~1.8GB) is exhausted. This is upstream of the memory pool, in the transport layer.
   Needs backpressure at the Rust→Java boundary or a larger flight allocator budget.

  Test Results

  ```
  ┌─────────────────────────────────────┬────────────────────────┬──────────────────────────────────────────────────┐
  │                                     │       Unpatched        │            Patched (commit faa08e2c)             │
  ├─────────────────────────────────────┼────────────────────────┼──────────────────────────────────────────────────┤
  │ OOM trigger (25 concurrent queries) │ OOM at 60.7GB in 8s    │ Survived at 46.5GB, all complete in 19s          │
  ├─────────────────────────────────────┼────────────────────────┼──────────────────────────────────────────────────┤
  │ Full ClickBench (42 queries)        │ OOM kills node         │ 23/41 pass, 18 fail at Arrow import (node alive) │
  ├─────────────────────────────────────┼────────────────────────┼──────────────────────────────────────────────────┤
  │ Peak native RSS                     │ 50.7 GB (uncontrolled) │ 27.9 GB (with spill)                             │
  ├─────────────────────────────────────┼────────────────────────┼──────────────────────────────────────────────────┤
  │ Spill                               │ Never triggered        │ 1.4 GB peak                                      │
  └─────────────────────────────────────┴────────────────────────┴──────────────────────────────────────────────────┘
  ```

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
