### PR TITLE
Add backpressure to Arrow Flight stream producer

### DIFF
--- a/plugins/arrow-flight-rpc/src/main/java/org/apache/arrow/flight/DemandDrivenFlightStream.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/apache/arrow/flight/DemandDrivenFlightStream.java
@@ -201,9 +201,7 @@ public class DemandDrivenFlightStream implements AutoCloseable {
                         root = VectorSchemaRoot.create(schema, allocator);
                         loader = new VectorLoader(root);
                     }
-                    // Schema message processed, request next (will be data or dictionary)
                     if (!completed) requestStream.request(1);
-                    // Recurse to get the actual data batch
                     Object next = queue.poll(60, TimeUnit.SECONDS);
                     if (next != null && next != DONE) {
                         processMessage((ArrowMessage) next);
@@ -222,7 +220,6 @@ public class DemandDrivenFlightStream implements AutoCloseable {
                     break;
 
                 case DICTIONARY_BATCH:
-                    // Process dictionary, then request and process next message
                     if (!completed) requestStream.request(1);
                     Object dictNext = queue.poll(60, TimeUnit.SECONDS);
                     if (dictNext != null && dictNext != DONE) {
@@ -235,8 +232,14 @@ public class DemandDrivenFlightStream implements AutoCloseable {
             }
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
+        } catch (Exception e) {
+            throw new RuntimeException("Error processing Arrow Flight message", e);
         } finally {
-            message.close();
+            try {
+                message.close();
+            } catch (Exception e) {
+                // best-effort close
+            }
         }
     }
 

--- a/plugins/arrow-flight-rpc/src/main/java/org/apache/arrow/flight/DemandDrivenFlightStream.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/apache/arrow/flight/DemandDrivenFlightStream.java
@@ -1,0 +1,298 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.apache.arrow.flight;
+
+import io.grpc.ClientCall;
+import io.grpc.MethodDescriptor;
+import io.grpc.protobuf.ProtoUtils;
+import io.grpc.stub.ClientCallStreamObserver;
+import io.grpc.stub.ClientCalls;
+import io.grpc.stub.ClientResponseObserver;
+import org.apache.arrow.memory.ArrowBuf;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.vector.VectorLoader;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.ipc.message.ArrowRecordBatch;
+import org.apache.arrow.vector.types.pojo.Schema;
+
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A demand-driven replacement for {@link FlightStream} that uses
+ * {@code disableAutoInboundFlowControl()} to prevent gRPC from eagerly
+ * deserializing messages into the Arrow allocator.
+ *
+ * <p>Standard FlightStream allows gRPC to deliver and deserialize messages as fast
+ * as bytes arrive on the wire. Each deserialization allocates Arrow buffers from the
+ * bounded flight allocator pool. Under high-cardinality workloads, this exhausts the pool.
+ *
+ * <p>This implementation requests exactly 1 message at a time via {@code request(1)}.
+ * The gRPC Netty layer only reads and deserializes ONE message from the socket before
+ * waiting for the next explicit request. This gives true demand-driven streaming:
+ * at most 1 deserialized message in the allocator at any time.
+ *
+ * <p>This achieves InfluxDB-style lazy streaming within Java gRPC:
+ * <ul>
+ *   <li>Consumer calls {@link #next()} → triggers {@code request(1)}</li>
+ *   <li>gRPC reads and deserializes exactly 1 message</li>
+ *   <li>Consumer processes and frees the batch</li>
+ *   <li>Next {@code next()} call triggers the next {@code request(1)}</li>
+ * </ul>
+ */
+public class DemandDrivenFlightStream implements AutoCloseable {
+
+    private final BufferAllocator allocator;
+    private final LinkedBlockingQueue<Object> queue = new LinkedBlockingQueue<>(2);
+    private volatile ClientCallStreamObserver<?> requestStream;
+    private volatile VectorSchemaRoot root;
+    private volatile VectorLoader loader;
+    private volatile Schema schema;
+    private volatile boolean completed = false;
+    private volatile Throwable error;
+    private volatile ArrowBuf applicationMetadata;
+
+    private static final Object DONE = new Object();
+
+    DemandDrivenFlightStream(BufferAllocator allocator) {
+        this.allocator = allocator;
+    }
+
+    /**
+     * The DoGet method descriptor — constructed once, reused for all streams.
+     * Matches arrow.flight.protocol.FlightService/DoGet exactly.
+     */
+    private static io.grpc.MethodDescriptor<Flight.Ticket, ArrowMessage> doGetDescriptor(BufferAllocator allocator) {
+        return io.grpc.MethodDescriptor.<Flight.Ticket, ArrowMessage>newBuilder()
+            .setType(io.grpc.MethodDescriptor.MethodType.SERVER_STREAMING)
+            .setFullMethodName("arrow.flight.protocol.FlightService/DoGet")
+            .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(Flight.Ticket.getDefaultInstance()))
+            .setResponseMarshaller(ArrowMessage.createMarshaller(allocator))
+            .build();
+    }
+
+    /**
+     * Opens a demand-driven stream using the gRPC channel directly.
+     * No reflection — constructs the MethodDescriptor and ClientCall explicitly.
+     *
+     * @param channel     the gRPC ManagedChannel (from FlightTransport)
+     * @param allocator   the Arrow BufferAllocator for deserialization
+     * @param ticket      the Flight ticket identifying the stream
+     * @param options     call options (headers, deadlines, etc.)
+     */
+    public static DemandDrivenFlightStream openFromChannel(
+        io.grpc.Channel channel,
+        BufferAllocator allocator,
+        Ticket ticket,
+        CallOption... options
+    ) {
+        var descriptor = doGetDescriptor(allocator);
+        io.grpc.CallOptions callOpts = io.grpc.CallOptions.DEFAULT;
+        for (CallOption opt : options) {
+            callOpts = opt.wrapCallOption(callOpts);
+        }
+        ClientCall<Flight.Ticket, ArrowMessage> call = channel.newCall(descriptor, callOpts);
+        return open(allocator, call, ticket.toProtocol());
+    }
+
+    /**
+     * Creates a demand-driven stream for the given gRPC call.
+     * Disables auto inbound flow control and requests messages one at a time.
+     */
+    static DemandDrivenFlightStream open(
+        BufferAllocator allocator,
+        ClientCall<Flight.Ticket, ArrowMessage> call,
+        Flight.Ticket ticket
+    ) {
+        DemandDrivenFlightStream stream = new DemandDrivenFlightStream(allocator);
+
+        ClientResponseObserver<Flight.Ticket, ArrowMessage> observer =
+            new ClientResponseObserver<>() {
+                @Override
+                public void beforeStart(ClientCallStreamObserver<Flight.Ticket> reqStream) {
+                    stream.requestStream = reqStream;
+                    reqStream.disableAutoInboundFlowControl();
+                }
+
+                @Override
+                public void onNext(ArrowMessage message) {
+                    try {
+                        stream.queue.put(message);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                }
+
+                @Override
+                public void onError(Throwable t) {
+                    stream.error = t;
+                    stream.completed = true;
+                    try {
+                        stream.queue.put(DONE);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                }
+
+                @Override
+                public void onCompleted() {
+                    stream.completed = true;
+                    try {
+                        stream.queue.put(DONE);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                }
+            };
+
+        // Start the streaming call with our demand-driven observer
+        ClientCalls.asyncServerStreamingCall(call, ticket, observer);
+
+        // Request the first message (schema)
+        stream.requestStream.request(1);
+
+        return stream;
+    }
+
+    /**
+     * Advances to the next record batch. Returns false when stream is exhausted.
+     * Each call requests exactly 1 message from gRPC → exactly 1 deserialization.
+     */
+    public boolean next() {
+        if (completed && queue.isEmpty()) return false;
+
+        try {
+            Object item = queue.poll(60, TimeUnit.SECONDS);
+            if (item == null) {
+                throw new RuntimeException("Timeout waiting for Flight message");
+            }
+            if (item == DONE) {
+                if (error != null) {
+                    if (error instanceof RuntimeException re) throw re;
+                    throw new RuntimeException(error);
+                }
+                return false;
+            }
+
+            ArrowMessage message = (ArrowMessage) item;
+            processMessage(message);
+
+            // Request the next message AFTER processing the current one.
+            // This is the demand-driven signal: gRPC only reads/deserializes
+            // the next message when we explicitly ask for it.
+            if (!completed) {
+                requestStream.request(1);
+            }
+
+            return true;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return false;
+        }
+    }
+
+    private void processMessage(ArrowMessage message) {
+        try {
+            switch (message.getMessageType()) {
+                case SCHEMA:
+                    schema = message.asSchemaMessage() != null
+                        ? org.apache.arrow.vector.ipc.message.MessageSerializer.deserializeSchema(message.asSchemaMessage())
+                        : null;
+                    if (schema != null && root == null) {
+                        root = VectorSchemaRoot.create(schema, allocator);
+                        loader = new VectorLoader(root);
+                    }
+                    // Schema message processed, request next (will be data or dictionary)
+                    if (!completed) requestStream.request(1);
+                    // Recurse to get the actual data batch
+                    Object next = queue.poll(60, TimeUnit.SECONDS);
+                    if (next != null && next != DONE) {
+                        processMessage((ArrowMessage) next);
+                    }
+                    break;
+
+                case RECORD_BATCH:
+                    if (root != null) root.clear();
+                    ArrowRecordBatch batch = message.asRecordBatch();
+                    try {
+                        loader.load(batch);
+                    } finally {
+                        batch.close();
+                    }
+                    updateMetadata(message);
+                    break;
+
+                case DICTIONARY_BATCH:
+                    // Process dictionary, then request and process next message
+                    if (!completed) requestStream.request(1);
+                    Object dictNext = queue.poll(60, TimeUnit.SECONDS);
+                    if (dictNext != null && dictNext != DONE) {
+                        processMessage((ArrowMessage) dictNext);
+                    }
+                    break;
+
+                default:
+                    break;
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        } finally {
+            message.close();
+        }
+    }
+
+    private void updateMetadata(ArrowMessage message) {
+        if (applicationMetadata != null) {
+            applicationMetadata.close();
+        }
+        applicationMetadata = message.getApplicationMetadata();
+        if (applicationMetadata != null) {
+            applicationMetadata.getReferenceManager().retain();
+        }
+    }
+
+    /** Returns the current VectorSchemaRoot (reused across batches). */
+    public VectorSchemaRoot getRoot() {
+        return root;
+    }
+
+    /** Returns the schema. */
+    public Schema getSchema() {
+        return schema;
+    }
+
+    /** Returns application metadata from the last batch. */
+    public ArrowBuf getLatestMetadata() {
+        return applicationMetadata;
+    }
+
+    /** Cancel the stream. */
+    public void cancel(String reason, Throwable cause) {
+        if (requestStream != null) {
+            requestStream.cancel(reason, cause);
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        if (root != null) {
+            root.close();
+        }
+        if (applicationMetadata != null) {
+            applicationMetadata.close();
+        }
+        // Drain remaining messages
+        Object remaining;
+        while ((remaining = queue.poll()) != null) {
+            if (remaining instanceof ArrowMessage msg) {
+                msg.close();
+            }
+        }
+    }
+}

--- a/plugins/arrow-flight-rpc/src/main/java/org/apache/arrow/flight/DemandDrivenFlightStream.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/apache/arrow/flight/DemandDrivenFlightStream.java
@@ -9,8 +9,6 @@
 package org.apache.arrow.flight;
 
 import io.grpc.ClientCall;
-
-
 import io.grpc.stub.ClientCallStreamObserver;
 import io.grpc.stub.ClientCalls;
 import io.grpc.stub.ClientResponseObserver;
@@ -79,20 +77,20 @@ public class DemandDrivenFlightStream implements AutoCloseable {
      * @param channel     the gRPC ManagedChannel (from FlightTransport)
      * @param allocator   the Arrow BufferAllocator for deserialization
      * @param ticket      the Flight ticket identifying the stream
-     * @param options     call options (headers, deadlines, etc.)
+     * @param headers     gRPC metadata headers (e.g. correlation ID)
      */
     public static DemandDrivenFlightStream openFromChannel(
         io.grpc.Channel channel,
         BufferAllocator allocator,
         Ticket ticket,
-        CallOption... options
+        io.grpc.Metadata headers
     ) {
         var descriptor = doGetDescriptor(allocator);
-        io.grpc.CallOptions callOpts = io.grpc.CallOptions.DEFAULT;
-        for (CallOption opt : options) {
-            callOpts = opt.wrapCallOption(callOpts);
-        }
-        ClientCall<org.apache.arrow.flight.impl.Flight.Ticket, ArrowMessage> call = channel.newCall(descriptor, callOpts);
+        io.grpc.Channel interceptedChannel = io.grpc.ClientInterceptors.intercept(
+            channel, io.grpc.stub.MetadataUtils.newAttachHeadersInterceptor(headers)
+        );
+        ClientCall<org.apache.arrow.flight.impl.Flight.Ticket, ArrowMessage> call =
+            interceptedChannel.newCall(descriptor, io.grpc.CallOptions.DEFAULT);
         return open(allocator, call, ticket.toProtocol());
     }
 

--- a/plugins/arrow-flight-rpc/src/main/java/org/apache/arrow/flight/DemandDrivenFlightStream.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/apache/arrow/flight/DemandDrivenFlightStream.java
@@ -74,21 +74,24 @@ public class DemandDrivenFlightStream implements AutoCloseable {
      * Opens a demand-driven stream using the gRPC channel directly.
      * No reflection — constructs the MethodDescriptor and ClientCall explicitly.
      *
-     * @param channel     the gRPC ManagedChannel (from FlightTransport)
-     * @param allocator   the Arrow BufferAllocator for deserialization
-     * @param ticket      the Flight ticket identifying the stream
-     * @param headers     gRPC metadata headers (e.g. correlation ID)
+     * @param channel      the gRPC ManagedChannel (from FlightTransport)
+     * @param allocator    the Arrow BufferAllocator for deserialization
+     * @param ticket       the Flight ticket identifying the stream
+     * @param headers      gRPC metadata headers (e.g. correlation ID)
+     * @param interceptors additional client interceptors (e.g. response header capture)
      */
     public static DemandDrivenFlightStream openFromChannel(
         io.grpc.Channel channel,
         BufferAllocator allocator,
         Ticket ticket,
-        io.grpc.Metadata headers
+        io.grpc.Metadata headers,
+        io.grpc.ClientInterceptor... interceptors
     ) {
         var descriptor = doGetDescriptor(allocator);
-        io.grpc.Channel interceptedChannel = io.grpc.ClientInterceptors.intercept(
-            channel, io.grpc.stub.MetadataUtils.newAttachHeadersInterceptor(headers)
-        );
+        java.util.List<io.grpc.ClientInterceptor> allInterceptors = new java.util.ArrayList<>();
+        allInterceptors.add(io.grpc.stub.MetadataUtils.newAttachHeadersInterceptor(headers));
+        allInterceptors.addAll(java.util.Arrays.asList(interceptors));
+        io.grpc.Channel interceptedChannel = io.grpc.ClientInterceptors.intercept(channel, allInterceptors);
         ClientCall<org.apache.arrow.flight.impl.Flight.Ticket, ArrowMessage> call =
             interceptedChannel.newCall(descriptor, io.grpc.CallOptions.DEFAULT);
         return open(allocator, call, ticket.toProtocol());

--- a/plugins/arrow-flight-rpc/src/main/java/org/apache/arrow/flight/DemandDrivenFlightStream.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/apache/arrow/flight/DemandDrivenFlightStream.java
@@ -9,8 +9,8 @@
 package org.apache.arrow.flight;
 
 import io.grpc.ClientCall;
-import io.grpc.MethodDescriptor;
-import io.grpc.protobuf.ProtoUtils;
+
+
 import io.grpc.stub.ClientCallStreamObserver;
 import io.grpc.stub.ClientCalls;
 import io.grpc.stub.ClientResponseObserver;
@@ -65,16 +65,11 @@ public class DemandDrivenFlightStream implements AutoCloseable {
     }
 
     /**
-     * The DoGet method descriptor — constructed once, reused for all streams.
-     * Matches arrow.flight.protocol.FlightService/DoGet exactly.
+     * Gets the DoGet method descriptor from Arrow Flight's binding service.
+     * Same package access — no reflection needed.
      */
-    private static io.grpc.MethodDescriptor<Flight.Ticket, ArrowMessage> doGetDescriptor(BufferAllocator allocator) {
-        return io.grpc.MethodDescriptor.<Flight.Ticket, ArrowMessage>newBuilder()
-            .setType(io.grpc.MethodDescriptor.MethodType.SERVER_STREAMING)
-            .setFullMethodName("arrow.flight.protocol.FlightService/DoGet")
-            .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(Flight.Ticket.getDefaultInstance()))
-            .setResponseMarshaller(ArrowMessage.createMarshaller(allocator))
-            .build();
+    private static io.grpc.MethodDescriptor<org.apache.arrow.flight.impl.Flight.Ticket, ArrowMessage> doGetDescriptor(BufferAllocator allocator) {
+        return FlightBindingService.getDoGetDescriptor(allocator);
     }
 
     /**
@@ -97,7 +92,7 @@ public class DemandDrivenFlightStream implements AutoCloseable {
         for (CallOption opt : options) {
             callOpts = opt.wrapCallOption(callOpts);
         }
-        ClientCall<Flight.Ticket, ArrowMessage> call = channel.newCall(descriptor, callOpts);
+        ClientCall<org.apache.arrow.flight.impl.Flight.Ticket, ArrowMessage> call = channel.newCall(descriptor, callOpts);
         return open(allocator, call, ticket.toProtocol());
     }
 
@@ -107,15 +102,15 @@ public class DemandDrivenFlightStream implements AutoCloseable {
      */
     static DemandDrivenFlightStream open(
         BufferAllocator allocator,
-        ClientCall<Flight.Ticket, ArrowMessage> call,
-        Flight.Ticket ticket
+        ClientCall<org.apache.arrow.flight.impl.Flight.Ticket, ArrowMessage> call,
+        org.apache.arrow.flight.impl.Flight.Ticket ticket
     ) {
         DemandDrivenFlightStream stream = new DemandDrivenFlightStream(allocator);
 
-        ClientResponseObserver<Flight.Ticket, ArrowMessage> observer =
+        ClientResponseObserver<org.apache.arrow.flight.impl.Flight.Ticket, ArrowMessage> observer =
             new ClientResponseObserver<>() {
                 @Override
-                public void beforeStart(ClientCallStreamObserver<Flight.Ticket> reqStream) {
+                public void beforeStart(ClientCallStreamObserver<org.apache.arrow.flight.impl.Flight.Ticket> reqStream) {
                     stream.requestStream = reqStream;
                     reqStream.disableAutoInboundFlowControl();
                 }

--- a/plugins/arrow-flight-rpc/src/main/java/org/apache/arrow/flight/FlightClientWithChannel.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/apache/arrow/flight/FlightClientWithChannel.java
@@ -1,0 +1,41 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.apache.arrow.flight;
+
+import io.grpc.ManagedChannel;
+import org.apache.arrow.memory.BufferAllocator;
+
+import java.util.List;
+
+/**
+ * Extends FlightClient to expose the underlying ManagedChannel.
+ * This allows DemandDrivenFlightStream to create ClientCalls directly
+ * without reflection, enabling disableAutoInboundFlowControl().
+ */
+public class FlightClientWithChannel extends FlightClient {
+
+    private final ManagedChannel channel;
+    private final BufferAllocator allocator;
+
+    FlightClientWithChannel(BufferAllocator allocator, ManagedChannel channel, List<FlightClientMiddleware.Factory> middleware) {
+        super(allocator, channel, middleware);
+        this.channel = channel;
+        this.allocator = allocator;
+    }
+
+    /** Returns the underlying gRPC channel for demand-driven stream creation. */
+    public ManagedChannel getChannel() {
+        return channel;
+    }
+
+    /** Returns the allocator used for Arrow deserialization. */
+    public BufferAllocator getAllocator() {
+        return allocator;
+    }
+}

--- a/plugins/arrow-flight-rpc/src/main/java/org/apache/arrow/flight/OSFlightClient.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/apache/arrow/flight/OSFlightClient.java
@@ -109,6 +109,7 @@ public class OSFlightClient {
             return this;
         }
 
+
         /** Create the client from this builder. */
         public FlightClient build() {
             final NettyChannelBuilder builder;
@@ -220,7 +221,8 @@ public class OSFlightClient {
                 builder.eventLoopGroup(workerELG);
             }
  
-            return new FlightClient(allocator, builder.build(), middleware);
+            io.grpc.ManagedChannel channel = builder.build();
+            return new FlightClientWithChannel(allocator, channel, middleware);
         }
 
         public Builder executor(ExecutorService executorService) {

--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightOutboundHandler.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightOutboundHandler.java
@@ -131,13 +131,14 @@ class FlightOutboundHandler extends ProtocolOutboundHandler {
             return;
         }
 
-        flightChannel.getExecutor().execute(threadPool.getThreadContext().preserveContext(() -> {
-            try (BatchTask ignored = task) {
-                processBatchTask(task);
-            } catch (Exception e) {
-                messageListener.onResponseSent(requestId, action, e);
-            }
-        }));
+        // Execute synchronously on the caller's thread to apply backpressure:
+        // the producer blocks here until gRPC is ready for the next batch,
+        // preventing unbounded batch accumulation in the Arrow allocator.
+        try (BatchTask ignored = task) {
+            processBatchTask(task);
+        } catch (Exception e) {
+            messageListener.onResponseSent(requestId, action, e);
+        }
     }
 
     private void processBatchTask(BatchTask task) {

--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightServerChannel.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightServerChannel.java
@@ -69,7 +69,7 @@ class FlightServerChannel implements TcpChannel, ArrowFlightChannel {
         this.correlationId = Long.parseLong(middleware.getCorrelationId());
         logger.debug("Creating FlightServerChannel for correlation ID: {}", correlationId);
         this.serverStreamListener = serverStreamListener;
-        this.serverStreamListener.setUseZeroCopy(false);
+        this.serverStreamListener.setUseZeroCopy(true);
         this.serverStreamListener.setOnCancelHandler(() -> {
             cancelled = true;
             callTracker.recordCallEnd(StreamErrorCode.CANCELLED.name());

--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightServerChannel.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightServerChannel.java
@@ -69,7 +69,7 @@ class FlightServerChannel implements TcpChannel, ArrowFlightChannel {
         this.correlationId = Long.parseLong(middleware.getCorrelationId());
         logger.debug("Creating FlightServerChannel for correlation ID: {}", correlationId);
         this.serverStreamListener = serverStreamListener;
-        this.serverStreamListener.setUseZeroCopy(true);
+        this.serverStreamListener.setUseZeroCopy(false);
         this.serverStreamListener.setOnCancelHandler(() -> {
             cancelled = true;
             callTracker.recordCallEnd(StreamErrorCode.CANCELLED.name());

--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightServerChannel.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightServerChannel.java
@@ -56,6 +56,8 @@ class FlightServerChannel implements TcpChannel, ArrowFlightChannel {
     private final ExecutorService executor;
     private final long correlationId;
     private final AtomicInteger batchNumber = new AtomicInteger(0);
+    private final Object readyLock = new Object();
+    private static final long ALLOCATOR_PRESSURE_PERCENT = 85;
 
     public FlightServerChannel(
         ServerStreamListener serverStreamListener,
@@ -72,6 +74,11 @@ class FlightServerChannel implements TcpChannel, ArrowFlightChannel {
             cancelled = true;
             callTracker.recordCallEnd(StreamErrorCode.CANCELLED.name());
             close();
+        });
+        this.serverStreamListener.setOnReadyHandler(() -> {
+            synchronized (readyLock) {
+                readyLock.notifyAll();
+            }
         });
         this.allocator = allocator;
         this.middleware = middleware;
@@ -120,8 +127,7 @@ class FlightServerChannel implements TcpChannel, ArrowFlightChannel {
             // placeholder to clear and fill the root with data for the next batch
         }
         logger.debug("Sending batch #{} for correlation ID: {}", batchNumber, correlationId);
-        // we do not want to close the root right after putNext() call as we do not know the status of it whether
-        // its transmitted at transport; we close them all at complete stream. TODO: optimize this behaviour
+        waitForReady();
         serverStreamListener.putNext();
         long putNextTime = (System.nanoTime() - batchStartTime) / 1_000_000;
         if (callTracker != null) {
@@ -137,6 +143,33 @@ class FlightServerChannel implements TcpChannel, ArrowFlightChannel {
         } else {
             logger.debug("Batch #{} sent for correlation ID: {}, putNext: {}ms", batchNumber, correlationId, putNextTime);
         }
+    }
+
+    /**
+     * Blocks until the gRPC transport is ready AND the Arrow allocator has headroom.
+     * On the fast path (both ready), returns immediately with one branch check.
+     * Under pressure, waits for the onReadyHandler callback (gRPC buffers drained)
+     * or polls allocator usage every 100ms (Arrow buffers freed after transmission).
+     */
+    private void waitForReady() {
+        if (serverStreamListener.isReady() && !isAllocatorPressured()) {
+            return;
+        }
+        synchronized (readyLock) {
+            while ((!serverStreamListener.isReady() || isAllocatorPressured()) && !cancelled && open.get()) {
+                try {
+                    readyLock.wait(100);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
+            }
+        }
+    }
+
+    private boolean isAllocatorPressured() {
+        long limit = allocator.getLimit();
+        return limit != Long.MAX_VALUE && allocator.getAllocatedMemory() >= limit * ALLOCATOR_PRESSURE_PERCENT / 100;
     }
 
     /**

--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightTransportResponse.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightTransportResponse.java
@@ -103,10 +103,31 @@ class FlightTransportResponse<T extends TransportResponse> implements StreamTran
                                 callHeaders.get(key)
                             );
                         }
+                        io.grpc.ClientInterceptor responseHeaderInterceptor = new io.grpc.ClientInterceptor() {
+                            @Override
+                            public <ReqT, RespT> io.grpc.ClientCall<ReqT, RespT> interceptCall(
+                                io.grpc.MethodDescriptor<ReqT, RespT> method,
+                                io.grpc.CallOptions callOptions,
+                                io.grpc.Channel next
+                            ) {
+                                return new io.grpc.ForwardingClientCall.SimpleForwardingClientCall<>(next.newCall(method, callOptions)) {
+                                    @Override
+                                    public void start(io.grpc.ClientCall.Listener<RespT> responseListener, io.grpc.Metadata requestHeaders) {
+                                        super.start(new io.grpc.ForwardingClientCallListener.SimpleForwardingClientCallListener<>(responseListener) {
+                                            @Override
+                                            public void onHeaders(io.grpc.Metadata responseHeaders) {
+                                                processResponseHeaders(responseHeaders);
+                                                super.onHeaders(responseHeaders);
+                                            }
+                                        }, requestHeaders);
+                                    }
+                                };
+                            }
+                        };
                         demandStream = org.apache.arrow.flight.DemandDrivenFlightStream.openFromChannel(
                             clientWithChannel.getChannel(),
                             clientWithChannel.getAllocator(),
-                            ticket, headers
+                            ticket, headers, responseHeaderInterceptor
                         );
                     } else {
                         // Fallback: use standard FlightStream (no demand control)
@@ -181,6 +202,28 @@ class FlightTransportResponse<T extends TransportResponse> implements StreamTran
             : VectorStreamInput.forByteSerialized(streamRoot, namedWriteableRegistry);
     }
 
+
+    private void processResponseHeaders(io.grpc.Metadata responseHeaders) {
+        try {
+            String encodedHeader = responseHeaders.get(
+                io.grpc.Metadata.Key.of(ClientHeaderMiddleware.RAW_HEADER_KEY, io.grpc.Metadata.ASCII_STRING_MARSHALLER)
+            );
+            String corrId = responseHeaders.get(
+                io.grpc.Metadata.Key.of(CORRELATION_ID_KEY, io.grpc.Metadata.ASCII_STRING_MARSHALLER)
+            );
+            if (encodedHeader == null || corrId == null) return;
+
+            byte[] headerBuffer = java.util.Base64.getDecoder().decode(encodedHeader);
+            org.opensearch.core.common.bytes.BytesReference headerRef =
+                new org.opensearch.core.common.bytes.BytesArray(headerBuffer);
+            Header header = org.opensearch.transport.InboundDecoder.readHeader(
+                org.opensearch.Version.CURRENT, headerRef.length(), headerRef
+            );
+            headerContext.setHeader(Long.parseLong(corrId), header);
+        } catch (Exception e) {
+            logger.warn("Failed to process response headers for demand-driven stream", e);
+        }
+    }
 
     @Override
     public void cancel(String reason, Throwable cause) {

--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightTransportResponse.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightTransportResponse.java
@@ -96,10 +96,17 @@ class FlightTransportResponse<T extends TransportResponse> implements StreamTran
                     // This prevents gRPC from eagerly deserializing messages into the
                     // bounded Arrow allocator. At most 1 message is deserialized at a time.
                     if (flightClient instanceof org.apache.arrow.flight.FlightClientWithChannel clientWithChannel) {
+                        io.grpc.Metadata headers = new io.grpc.Metadata();
+                        for (String key : callHeaders.keys()) {
+                            headers.put(
+                                io.grpc.Metadata.Key.of(key, io.grpc.Metadata.ASCII_STRING_MARSHALLER),
+                                callHeaders.get(key)
+                            );
+                        }
                         demandStream = org.apache.arrow.flight.DemandDrivenFlightStream.openFromChannel(
                             clientWithChannel.getChannel(),
                             clientWithChannel.getAllocator(),
-                            ticket, new HeaderCallOption(callHeaders)
+                            ticket, headers
                         );
                     } else {
                         // Fallback: use standard FlightStream (no demand control)

--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightTransportResponse.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightTransportResponse.java
@@ -49,6 +49,7 @@ class FlightTransportResponse<T extends TransportResponse> implements StreamTran
     private final long correlationId;
 
     private volatile FlightStream flightStream;
+    private volatile org.apache.arrow.flight.DemandDrivenFlightStream demandStream;
     private volatile long currentBatchSize;
     private volatile boolean firstBatchConsumed;
     private volatile boolean closed;
@@ -91,14 +92,32 @@ class FlightTransportResponse<T extends TransportResponse> implements StreamTran
             Thread.ofVirtual().start(() -> {
                 try {
                     long start = System.nanoTime();
-                    flightStream = flightClient.getStream(ticket, new HeaderCallOption(callHeaders));
+                    // Use demand-driven FlightStream with disableAutoInboundFlowControl().
+                    // This prevents gRPC from eagerly deserializing messages into the
+                    // bounded Arrow allocator. At most 1 message is deserialized at a time.
+                    if (flightClient instanceof org.apache.arrow.flight.FlightClientWithChannel clientWithChannel) {
+                        demandStream = org.apache.arrow.flight.DemandDrivenFlightStream.openFromChannel(
+                            clientWithChannel.getChannel(),
+                            clientWithChannel.getAllocator(),
+                            ticket, new HeaderCallOption(callHeaders)
+                        );
+                    } else {
+                        // Fallback: use standard FlightStream (no demand control)
+                        flightStream = flightClient.getStream(ticket, new HeaderCallOption(callHeaders));
+                        flightStream.next();
+                        initialHeader = headerContext.getHeader(correlationId);
+                        future.complete(initialHeader);
+                        return;
+                    }
                     long elapsedMs = (System.nanoTime() - start) / 1_000_000;
-                    logger.debug("FlightClient.getStream() for correlationId: {} took {}ms", correlationId, elapsedMs);
+                    logger.debug("DemandDrivenFlightStream opened for correlationId: {} took {}ms", correlationId, elapsedMs);
                     start = System.nanoTime();
-                    flightStream.next();
+                    demandStream.next();
                     elapsedMs = (System.nanoTime() - start) / 1_000_000;
-                    logger.debug("First FlightClient.next() for correlationId: {} took {}ms", correlationId, elapsedMs);
+                    logger.debug("First DemandDrivenFlightStream.next() for correlationId: {} took {}ms", correlationId, elapsedMs);
                     initialHeader = headerContext.getHeader(correlationId);
+                    // Also set flightStream for compatibility with existing close/cancel logic
+                    flightStream = null;
                     future.complete(initialHeader);
                 } catch (FlightRuntimeException e) {
                     future.completeExceptionally(FlightErrorMapper.fromFlightException(e));
@@ -113,17 +132,20 @@ class FlightTransportResponse<T extends TransportResponse> implements StreamTran
         return handler;
     }
 
+
     @Override
     public T nextResponse() {
         if (closed) throw new StreamException(StreamErrorCode.UNAVAILABLE, "Stream is closed");
-        if (flightStream == null) throw new IllegalStateException("openAndPrefetch() must be called first");
+        if (demandStream == null) throw new IllegalStateException("openAndPrefetch() must be called first");
 
         long startTime = System.currentTimeMillis();
         try {
-            boolean hasNext = firstBatchConsumed ? flightStream.next() : (firstBatchConsumed = true);
+            // Demand-driven: next() calls request(1) internally AFTER processing.
+            // At most 1 message deserialized in the Arrow allocator at any time.
+            boolean hasNext = firstBatchConsumed ? demandStream.next() : (firstBatchConsumed = true);
             if (!hasNext) return null;
 
-            VectorSchemaRoot streamRoot = flightStream.getRoot();
+            VectorSchemaRoot streamRoot = demandStream.getRoot();
             currentBatchSize = FlightUtils.calculateVectorSchemaRootSize(streamRoot);
             try (VectorStreamInput input = newStreamInput(streamRoot)) {
                 input.setVersion(initialHeader.getVersion());
@@ -152,10 +174,12 @@ class FlightTransportResponse<T extends TransportResponse> implements StreamTran
             : VectorStreamInput.forByteSerialized(streamRoot, namedWriteableRegistry);
     }
 
+
     @Override
     public void cancel(String reason, Throwable cause) {
         if (closed) return;
         try {
+            if (demandStream != null) demandStream.cancel(reason, cause);
             if (flightStream != null) flightStream.cancel(reason, cause);
         } catch (Exception e) {
             logger.warn("Error cancelling flight stream", e);
@@ -169,6 +193,13 @@ class FlightTransportResponse<T extends TransportResponse> implements StreamTran
         if (closed) return;
         closed = true;
 
+        if (demandStream != null) {
+            try {
+                demandStream.close();
+            } catch (Exception e) {
+                logger.debug("Error closing demand-driven stream", e);
+            }
+        }
         if (flightStream != null) {
             try {
                 flightStream.close();

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/api.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/api.rs
@@ -586,13 +586,37 @@ fn try_acquire_budget_from_cache(
 }
 
 /// Returns the Arrow schema for the given stream as a heap-allocated FFI_ArrowSchema pointer.
+/// If the stream contains Utf8View/BinaryView columns, the schema reflects the converted
+/// LargeUtf8/LargeBinary types that `compact_string_view_columns` will produce in the data.
 ///
 /// # Safety
 /// `stream_ptr` must be a valid, non-zero pointer to a QueryStreamHandle.
 pub unsafe fn stream_get_schema(stream_ptr: i64) -> Result<i64, DataFusionError> {
     let handle = &mut *(stream_ptr as *mut QueryStreamHandle);
     let schema = handle.stream.schema();
-    let ffi_schema = FFI_ArrowSchema::try_from(schema.as_ref())
+    let export_schema = if handle.has_views {
+        let new_fields: Vec<arrow_schema::FieldRef> = schema
+            .fields()
+            .iter()
+            .map(|f| match f.data_type() {
+                DataType::Utf8View => Arc::new(arrow_schema::Field::new(
+                    f.name(),
+                    DataType::LargeUtf8,
+                    f.is_nullable(),
+                )),
+                DataType::BinaryView => Arc::new(arrow_schema::Field::new(
+                    f.name(),
+                    DataType::LargeBinary,
+                    f.is_nullable(),
+                )),
+                _ => Arc::clone(f),
+            })
+            .collect();
+        Arc::new(arrow_schema::Schema::new_with_metadata(new_fields, schema.metadata().clone()))
+    } else {
+        schema
+    };
+    let ffi_schema = FFI_ArrowSchema::try_from(export_schema.as_ref())
         .map_err(|e| DataFusionError::Execution(format!("Schema conversion failed: {}", e)))?;
     Ok(Box::into_raw(Box::new(ffi_schema)) as i64)
 }
@@ -643,59 +667,66 @@ pub async unsafe fn stream_next(
     }
 }
 
-/// Prevents sliced StringView batches from carrying full backing buffers across FFI.
+/// Converts Utf8View/BinaryView columns to Utf8/Binary before FFI export.
+///
+/// Utf8View uses variadic backing buffers that share a single ReferenceCountedArrowArray
+/// in Java's C Data import. With gRPC zero-copy, these buffers stay tracked in the Java
+/// allocator until the wire write completes — causing accumulation across batches.
+/// Converting to contiguous Utf8/LargeUtf8 produces a single owned buffer per column
+/// that Java can release independently per batch.
 fn compact_string_view_columns(batch: RecordBatch) -> RecordBatch {
     let schema = batch.schema();
-    let needs_compaction = batch
-        .columns()
+    let new_fields: Vec<arrow_schema::FieldRef> = schema
+        .fields()
         .iter()
-        .zip(schema.fields().iter())
-        .any(|(col, field)| match field.data_type() {
-            DataType::Utf8View => {
-                let view: &arrow_array::StringViewArray = col.as_any().downcast_ref()
-                    .expect("column must be StringViewArray when schema declares Utf8View");
-                view_needs_gc(view.data_buffers(), view.total_buffer_bytes_used())
-            }
-            DataType::BinaryView => {
-                let view: &arrow_array::BinaryViewArray = col.as_any().downcast_ref()
-                    .expect("column must be BinaryViewArray when schema declares BinaryView");
-                view_needs_gc(view.data_buffers(), view.total_buffer_bytes_used())
-            }
-            _ => false,
-        });
-    if !needs_compaction {
-        return batch;
-    }
+        .map(|f| match f.data_type() {
+            DataType::Utf8View => Arc::new(arrow_schema::Field::new(
+                f.name(),
+                DataType::LargeUtf8,
+                f.is_nullable(),
+            )),
+            DataType::BinaryView => Arc::new(arrow_schema::Field::new(
+                f.name(),
+                DataType::LargeBinary,
+                f.is_nullable(),
+            )),
+            _ => Arc::clone(f),
+        })
+        .collect();
+    let new_schema = Arc::new(arrow_schema::Schema::new_with_metadata(
+        new_fields,
+        schema.metadata().clone(),
+    ));
+
     let columns: Vec<Arc<dyn Array>> = batch
         .columns()
         .iter()
         .zip(schema.fields().iter())
         .map(|(col, field)| match field.data_type() {
             DataType::Utf8View => {
-                let view: &arrow_array::StringViewArray = col.as_any().downcast_ref()
-                    .expect("column must be StringViewArray when schema declares Utf8View");
-                Arc::new(view.gc()) as Arc<dyn Array>
+                let view: &arrow_array::StringViewArray = col
+                    .as_any()
+                    .downcast_ref()
+                    .expect("column must be StringViewArray");
+                let large: arrow_array::LargeStringArray = view
+                    .iter()
+                    .collect();
+                Arc::new(large) as Arc<dyn Array>
             }
             DataType::BinaryView => {
-                let view: &arrow_array::BinaryViewArray = col.as_any().downcast_ref()
-                    .expect("column must be BinaryViewArray when schema declares BinaryView");
-                Arc::new(view.gc()) as Arc<dyn Array>
+                let view: &arrow_array::BinaryViewArray = col
+                    .as_any()
+                    .downcast_ref()
+                    .expect("column must be BinaryViewArray");
+                let large: arrow_array::LargeBinaryArray = view
+                    .iter()
+                    .collect();
+                Arc::new(large) as Arc<dyn Array>
             }
             _ => Arc::clone(col),
         })
         .collect();
-    RecordBatch::try_new(schema, columns).expect("gc'd columns must match schema")
-}
-
-// 10KB: below this, the gc() copy cost outweighs the transfer savings.
-const GC_MIN_WASTE_BYTES: usize = 10_240;
-
-#[inline]
-fn view_needs_gc(buffers: &[arrow::buffer::Buffer], bytes_used: usize) -> bool {
-    let bytes_allocated: usize = buffers.iter().map(|b| b.len()).sum();
-    let waste = bytes_allocated.saturating_sub(bytes_used);
-    let is_significantly_bloated = bytes_allocated > 2 * bytes_used;
-    is_significantly_bloated && waste > GC_MIN_WASTE_BYTES
+    RecordBatch::try_new(new_schema, columns).expect("converted columns must match schema")
 }
 
 /// Closes a result stream. Safe to call with 0 (no-op).

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/api.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/api.rs
@@ -643,29 +643,16 @@ pub async unsafe fn stream_next(
     }
 }
 
-/// Prevents sliced StringView batches from carrying full backing buffers across FFI.
+/// Compacts StringView/BinaryView columns before FFI export via gc().
+///
+/// gc() rebuilds variadic backing buffers so each batch owns exactly the
+/// bytes it references — no shared parent buffers carried across FFI.
+/// This is critical for the Java C Data import path: wrapForeignAllocation
+/// tracks the full backing buffer size against a bounded allocator pool.
+/// Without gc(), multiple batches share large Rust-managed buffers whose
+/// foreign allocations accumulate and exhaust the pool.
 fn compact_string_view_columns(batch: RecordBatch) -> RecordBatch {
     let schema = batch.schema();
-    let needs_compaction = batch
-        .columns()
-        .iter()
-        .zip(schema.fields().iter())
-        .any(|(col, field)| match field.data_type() {
-            DataType::Utf8View => {
-                let view: &arrow_array::StringViewArray = col.as_any().downcast_ref()
-                    .expect("column must be StringViewArray when schema declares Utf8View");
-                view_needs_gc(view.data_buffers(), view.total_buffer_bytes_used())
-            }
-            DataType::BinaryView => {
-                let view: &arrow_array::BinaryViewArray = col.as_any().downcast_ref()
-                    .expect("column must be BinaryViewArray when schema declares BinaryView");
-                view_needs_gc(view.data_buffers(), view.total_buffer_bytes_used())
-            }
-            _ => false,
-        });
-    if !needs_compaction {
-        return batch;
-    }
     let columns: Vec<Arc<dyn Array>> = batch
         .columns()
         .iter()
@@ -685,17 +672,6 @@ fn compact_string_view_columns(batch: RecordBatch) -> RecordBatch {
         })
         .collect();
     RecordBatch::try_new(schema, columns).expect("gc'd columns must match schema")
-}
-
-// 10KB: below this, the gc() copy cost outweighs the transfer savings.
-const GC_MIN_WASTE_BYTES: usize = 10_240;
-
-#[inline]
-fn view_needs_gc(buffers: &[arrow::buffer::Buffer], bytes_used: usize) -> bool {
-    let bytes_allocated: usize = buffers.iter().map(|b| b.len()).sum();
-    let waste = bytes_allocated.saturating_sub(bytes_used);
-    let is_significantly_bloated = bytes_allocated > 2 * bytes_used;
-    is_significantly_bloated && waste > GC_MIN_WASTE_BYTES
 }
 
 /// Closes a result stream. Safe to call with 0 (no-op).

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/api.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/api.rs
@@ -634,6 +634,15 @@ pub async unsafe fn stream_next(
             } else {
                 batch
             };
+            // Compact sliced batches before FFI export. When DataFusion emits a
+            // large hash table via EmitTo::All, it slices into batch_size chunks.
+            // Rust's RecordBatch::slice() is zero-copy — each slice references the
+            // full parent buffers. Without compaction, C Data export transfers the
+            // ENTIRE parent buffer (~GB) even for an 8192-row slice. The Java
+            // receiver then allocates the full buffer size in its Arrow allocator,
+            // exhausting the flight pool. Compaction copies only the visible data
+            // into tight buffers, reducing FFI transfer to actual batch size.
+            let batch = compact_sliced_batch(batch);
             let struct_array: StructArray = batch.into();
             let array_data = struct_array.into_data();
             let ffi_array = FFI_ArrowArray::new(&array_data);
@@ -685,6 +694,111 @@ fn compact_string_view_columns(batch: RecordBatch) -> RecordBatch {
         })
         .collect();
     RecordBatch::try_new(schema, columns).expect("gc'd columns must match schema")
+}
+
+/// Compacts variable-length columns in a sliced RecordBatch before FFI export.
+///
+/// When DataFusion slices a large batch (e.g., 23M-row hash table output into
+/// 8192-row chunks), fixed-width columns get their own buffer but variable-length
+/// columns (Utf8, Binary) share the parent's data buffer. The offsets are copied
+/// but the data buffer pointer still references the full parent allocation (~GB).
+///
+/// Without compaction, FFI export transfers the full shared data buffer. The Java
+/// receiver allocates the full buffer size in the flight pool allocator → OOM.
+///
+/// This function rebuilds only the affected columns (Utf8, LargeUtf8, Binary,
+/// LargeBinary) by iterating their values into a fresh array with tight buffers.
+/// Fixed-width columns are passed through unchanged (they already have compact buffers).
+///
+/// Cost: ~10-100µs per 8192-row batch (128KB of string data). Negligible compared
+/// to the query execution time and always cheaper than the OOM alternative.
+fn compact_sliced_batch(batch: RecordBatch) -> RecordBatch {
+    if batch.num_rows() == 0 {
+        return batch;
+    }
+    let schema = batch.schema();
+
+    // Check if any variable-length column has a bloated data buffer
+    let needs_compact = batch
+        .columns()
+        .iter()
+        .zip(schema.fields().iter())
+        .any(|(col, field)| {
+            matches!(
+                field.data_type(),
+                DataType::Utf8 | DataType::LargeUtf8 | DataType::Binary | DataType::LargeBinary
+            ) && varlen_data_buffer_is_bloated(col)
+        });
+
+    if !needs_compact {
+        return batch;
+    }
+
+    // Rebuild only the bloated variable-length columns
+    let columns: Vec<Arc<dyn Array>> = batch
+        .columns()
+        .iter()
+        .zip(schema.fields().iter())
+        .map(|(col, field)| match field.data_type() {
+            DataType::Utf8 => {
+                if varlen_data_buffer_is_bloated(col) {
+                    let arr: &arrow_array::StringArray = col.as_any().downcast_ref().unwrap();
+                    let compacted: arrow_array::StringArray = arr.iter().collect();
+                    Arc::new(compacted) as Arc<dyn Array>
+                } else {
+                    Arc::clone(col)
+                }
+            }
+            DataType::LargeUtf8 => {
+                if varlen_data_buffer_is_bloated(col) {
+                    let arr: &arrow_array::LargeStringArray = col.as_any().downcast_ref().unwrap();
+                    let compacted: arrow_array::LargeStringArray = arr.iter().collect();
+                    Arc::new(compacted) as Arc<dyn Array>
+                } else {
+                    Arc::clone(col)
+                }
+            }
+            DataType::Binary => {
+                if varlen_data_buffer_is_bloated(col) {
+                    let arr: &arrow_array::BinaryArray = col.as_any().downcast_ref().unwrap();
+                    let compacted: arrow_array::BinaryArray = arr.iter().collect();
+                    Arc::new(compacted) as Arc<dyn Array>
+                } else {
+                    Arc::clone(col)
+                }
+            }
+            DataType::LargeBinary => {
+                if varlen_data_buffer_is_bloated(col) {
+                    let arr: &arrow_array::LargeBinaryArray = col.as_any().downcast_ref().unwrap();
+                    let compacted: arrow_array::LargeBinaryArray = arr.iter().collect();
+                    Arc::new(compacted) as Arc<dyn Array>
+                } else {
+                    Arc::clone(col)
+                }
+            }
+            _ => Arc::clone(col),
+        })
+        .collect();
+
+    RecordBatch::try_new(schema, columns).unwrap_or(batch)
+}
+
+/// Returns true if a variable-length column's data buffer is significantly larger
+/// than the visible data (indicating a shared parent buffer from slicing).
+/// Threshold: data buffer > 2× the actual string/binary bytes used by this slice.
+fn varlen_data_buffer_is_bloated(col: &Arc<dyn Array>) -> bool {
+    let data = col.to_data();
+    // Variable-length arrays have 2 buffers: [offsets, data]
+    if data.buffers().len() < 2 {
+        return false;
+    }
+    let data_buf_len = data.buffers()[1].len();
+    // Estimate actual data usage from the array's logical size minus the offsets
+    let total_size = col.get_array_memory_size();
+    let offsets_size = data.buffers()[0].len();
+    let estimated_data_used = total_size.saturating_sub(offsets_size);
+    // Bloated if data buffer is more than 2× what the slice actually uses
+    data_buf_len > 2 * estimated_data_used.max(1) && data_buf_len > GC_MIN_WASTE_BYTES
 }
 
 // 10KB: below this, the gc() copy cost outweighs the transfer savings.

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/api.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/api.rs
@@ -586,37 +586,13 @@ fn try_acquire_budget_from_cache(
 }
 
 /// Returns the Arrow schema for the given stream as a heap-allocated FFI_ArrowSchema pointer.
-/// If the stream contains Utf8View/BinaryView columns, the schema reflects the converted
-/// LargeUtf8/LargeBinary types that `compact_string_view_columns` will produce in the data.
 ///
 /// # Safety
 /// `stream_ptr` must be a valid, non-zero pointer to a QueryStreamHandle.
 pub unsafe fn stream_get_schema(stream_ptr: i64) -> Result<i64, DataFusionError> {
     let handle = &mut *(stream_ptr as *mut QueryStreamHandle);
     let schema = handle.stream.schema();
-    let export_schema = if handle.has_views {
-        let new_fields: Vec<arrow_schema::FieldRef> = schema
-            .fields()
-            .iter()
-            .map(|f| match f.data_type() {
-                DataType::Utf8View => Arc::new(arrow_schema::Field::new(
-                    f.name(),
-                    DataType::LargeUtf8,
-                    f.is_nullable(),
-                )),
-                DataType::BinaryView => Arc::new(arrow_schema::Field::new(
-                    f.name(),
-                    DataType::LargeBinary,
-                    f.is_nullable(),
-                )),
-                _ => Arc::clone(f),
-            })
-            .collect();
-        Arc::new(arrow_schema::Schema::new_with_metadata(new_fields, schema.metadata().clone()))
-    } else {
-        schema
-    };
-    let ffi_schema = FFI_ArrowSchema::try_from(export_schema.as_ref())
+    let ffi_schema = FFI_ArrowSchema::try_from(schema.as_ref())
         .map_err(|e| DataFusionError::Execution(format!("Schema conversion failed: {}", e)))?;
     Ok(Box::into_raw(Box::new(ffi_schema)) as i64)
 }
@@ -667,66 +643,59 @@ pub async unsafe fn stream_next(
     }
 }
 
-/// Converts Utf8View/BinaryView columns to Utf8/Binary before FFI export.
-///
-/// Utf8View uses variadic backing buffers that share a single ReferenceCountedArrowArray
-/// in Java's C Data import. With gRPC zero-copy, these buffers stay tracked in the Java
-/// allocator until the wire write completes — causing accumulation across batches.
-/// Converting to contiguous Utf8/LargeUtf8 produces a single owned buffer per column
-/// that Java can release independently per batch.
+/// Prevents sliced StringView batches from carrying full backing buffers across FFI.
 fn compact_string_view_columns(batch: RecordBatch) -> RecordBatch {
     let schema = batch.schema();
-    let new_fields: Vec<arrow_schema::FieldRef> = schema
-        .fields()
+    let needs_compaction = batch
+        .columns()
         .iter()
-        .map(|f| match f.data_type() {
-            DataType::Utf8View => Arc::new(arrow_schema::Field::new(
-                f.name(),
-                DataType::LargeUtf8,
-                f.is_nullable(),
-            )),
-            DataType::BinaryView => Arc::new(arrow_schema::Field::new(
-                f.name(),
-                DataType::LargeBinary,
-                f.is_nullable(),
-            )),
-            _ => Arc::clone(f),
-        })
-        .collect();
-    let new_schema = Arc::new(arrow_schema::Schema::new_with_metadata(
-        new_fields,
-        schema.metadata().clone(),
-    ));
-
+        .zip(schema.fields().iter())
+        .any(|(col, field)| match field.data_type() {
+            DataType::Utf8View => {
+                let view: &arrow_array::StringViewArray = col.as_any().downcast_ref()
+                    .expect("column must be StringViewArray when schema declares Utf8View");
+                view_needs_gc(view.data_buffers(), view.total_buffer_bytes_used())
+            }
+            DataType::BinaryView => {
+                let view: &arrow_array::BinaryViewArray = col.as_any().downcast_ref()
+                    .expect("column must be BinaryViewArray when schema declares BinaryView");
+                view_needs_gc(view.data_buffers(), view.total_buffer_bytes_used())
+            }
+            _ => false,
+        });
+    if !needs_compaction {
+        return batch;
+    }
     let columns: Vec<Arc<dyn Array>> = batch
         .columns()
         .iter()
         .zip(schema.fields().iter())
         .map(|(col, field)| match field.data_type() {
             DataType::Utf8View => {
-                let view: &arrow_array::StringViewArray = col
-                    .as_any()
-                    .downcast_ref()
-                    .expect("column must be StringViewArray");
-                let large: arrow_array::LargeStringArray = view
-                    .iter()
-                    .collect();
-                Arc::new(large) as Arc<dyn Array>
+                let view: &arrow_array::StringViewArray = col.as_any().downcast_ref()
+                    .expect("column must be StringViewArray when schema declares Utf8View");
+                Arc::new(view.gc()) as Arc<dyn Array>
             }
             DataType::BinaryView => {
-                let view: &arrow_array::BinaryViewArray = col
-                    .as_any()
-                    .downcast_ref()
-                    .expect("column must be BinaryViewArray");
-                let large: arrow_array::LargeBinaryArray = view
-                    .iter()
-                    .collect();
-                Arc::new(large) as Arc<dyn Array>
+                let view: &arrow_array::BinaryViewArray = col.as_any().downcast_ref()
+                    .expect("column must be BinaryViewArray when schema declares BinaryView");
+                Arc::new(view.gc()) as Arc<dyn Array>
             }
             _ => Arc::clone(col),
         })
         .collect();
-    RecordBatch::try_new(new_schema, columns).expect("converted columns must match schema")
+    RecordBatch::try_new(schema, columns).expect("gc'd columns must match schema")
+}
+
+// 10KB: below this, the gc() copy cost outweighs the transfer savings.
+const GC_MIN_WASTE_BYTES: usize = 10_240;
+
+#[inline]
+fn view_needs_gc(buffers: &[arrow::buffer::Buffer], bytes_used: usize) -> bool {
+    let bytes_allocated: usize = buffers.iter().map(|b| b.len()).sum();
+    let waste = bytes_allocated.saturating_sub(bytes_used);
+    let is_significantly_bloated = bytes_allocated > 2 * bytes_used;
+    is_significantly_bloated && waste > GC_MIN_WASTE_BYTES
 }
 
 /// Closes a result stream. Safe to call with 0 (no-op).

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/api.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/api.rs
@@ -634,15 +634,6 @@ pub async unsafe fn stream_next(
             } else {
                 batch
             };
-            // Compact sliced batches before FFI export. When DataFusion emits a
-            // large hash table via EmitTo::All, it slices into batch_size chunks.
-            // Rust's RecordBatch::slice() is zero-copy — each slice references the
-            // full parent buffers. Without compaction, C Data export transfers the
-            // ENTIRE parent buffer (~GB) even for an 8192-row slice. The Java
-            // receiver then allocates the full buffer size in its Arrow allocator,
-            // exhausting the flight pool. Compaction copies only the visible data
-            // into tight buffers, reducing FFI transfer to actual batch size.
-            let batch = compact_sliced_batch(batch);
             let struct_array: StructArray = batch.into();
             let array_data = struct_array.into_data();
             let ffi_array = FFI_ArrowArray::new(&array_data);
@@ -694,111 +685,6 @@ fn compact_string_view_columns(batch: RecordBatch) -> RecordBatch {
         })
         .collect();
     RecordBatch::try_new(schema, columns).expect("gc'd columns must match schema")
-}
-
-/// Compacts variable-length columns in a sliced RecordBatch before FFI export.
-///
-/// When DataFusion slices a large batch (e.g., 23M-row hash table output into
-/// 8192-row chunks), fixed-width columns get their own buffer but variable-length
-/// columns (Utf8, Binary) share the parent's data buffer. The offsets are copied
-/// but the data buffer pointer still references the full parent allocation (~GB).
-///
-/// Without compaction, FFI export transfers the full shared data buffer. The Java
-/// receiver allocates the full buffer size in the flight pool allocator → OOM.
-///
-/// This function rebuilds only the affected columns (Utf8, LargeUtf8, Binary,
-/// LargeBinary) by iterating their values into a fresh array with tight buffers.
-/// Fixed-width columns are passed through unchanged (they already have compact buffers).
-///
-/// Cost: ~10-100µs per 8192-row batch (128KB of string data). Negligible compared
-/// to the query execution time and always cheaper than the OOM alternative.
-fn compact_sliced_batch(batch: RecordBatch) -> RecordBatch {
-    if batch.num_rows() == 0 {
-        return batch;
-    }
-    let schema = batch.schema();
-
-    // Check if any variable-length column has a bloated data buffer
-    let needs_compact = batch
-        .columns()
-        .iter()
-        .zip(schema.fields().iter())
-        .any(|(col, field)| {
-            matches!(
-                field.data_type(),
-                DataType::Utf8 | DataType::LargeUtf8 | DataType::Binary | DataType::LargeBinary
-            ) && varlen_data_buffer_is_bloated(col)
-        });
-
-    if !needs_compact {
-        return batch;
-    }
-
-    // Rebuild only the bloated variable-length columns
-    let columns: Vec<Arc<dyn Array>> = batch
-        .columns()
-        .iter()
-        .zip(schema.fields().iter())
-        .map(|(col, field)| match field.data_type() {
-            DataType::Utf8 => {
-                if varlen_data_buffer_is_bloated(col) {
-                    let arr: &arrow_array::StringArray = col.as_any().downcast_ref().unwrap();
-                    let compacted: arrow_array::StringArray = arr.iter().collect();
-                    Arc::new(compacted) as Arc<dyn Array>
-                } else {
-                    Arc::clone(col)
-                }
-            }
-            DataType::LargeUtf8 => {
-                if varlen_data_buffer_is_bloated(col) {
-                    let arr: &arrow_array::LargeStringArray = col.as_any().downcast_ref().unwrap();
-                    let compacted: arrow_array::LargeStringArray = arr.iter().collect();
-                    Arc::new(compacted) as Arc<dyn Array>
-                } else {
-                    Arc::clone(col)
-                }
-            }
-            DataType::Binary => {
-                if varlen_data_buffer_is_bloated(col) {
-                    let arr: &arrow_array::BinaryArray = col.as_any().downcast_ref().unwrap();
-                    let compacted: arrow_array::BinaryArray = arr.iter().collect();
-                    Arc::new(compacted) as Arc<dyn Array>
-                } else {
-                    Arc::clone(col)
-                }
-            }
-            DataType::LargeBinary => {
-                if varlen_data_buffer_is_bloated(col) {
-                    let arr: &arrow_array::LargeBinaryArray = col.as_any().downcast_ref().unwrap();
-                    let compacted: arrow_array::LargeBinaryArray = arr.iter().collect();
-                    Arc::new(compacted) as Arc<dyn Array>
-                } else {
-                    Arc::clone(col)
-                }
-            }
-            _ => Arc::clone(col),
-        })
-        .collect();
-
-    RecordBatch::try_new(schema, columns).unwrap_or(batch)
-}
-
-/// Returns true if a variable-length column's data buffer is significantly larger
-/// than the visible data (indicating a shared parent buffer from slicing).
-/// Threshold: data buffer > 2× the actual string/binary bytes used by this slice.
-fn varlen_data_buffer_is_bloated(col: &Arc<dyn Array>) -> bool {
-    let data = col.to_data();
-    // Variable-length arrays have 2 buffers: [offsets, data]
-    if data.buffers().len() < 2 {
-        return false;
-    }
-    let data_buf_len = data.buffers()[1].len();
-    // Estimate actual data usage from the array's logical size minus the offsets
-    let total_size = col.get_array_memory_size();
-    let offsets_size = data.buffers()[0].len();
-    let estimated_data_used = total_size.saturating_sub(offsets_size);
-    // Bloated if data buffer is more than 2× what the slice actually uses
-    data_buf_len > 2 * estimated_data_used.max(1) && data_buf_len > GC_MIN_WASTE_BYTES
 }
 
 // 10KB: below this, the gc() copy cost outweighs the transfer savings.

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionResultStream.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionResultStream.java
@@ -110,16 +110,19 @@ public class DatafusionResultStream implements EngineResultStream {
             }
         }
 
+        private static final long ALLOCATOR_PRESSURE_PERCENT = 85;
+        private static final long PRESSURE_BACKOFF_MS = 50;
+        private static final int MAX_PRESSURE_WAITS = 200;
+
         private boolean loadNextBatch() {
             ensureSchema();
             if (nativeStreamExhausted) return false;
+            waitForAllocatorHeadroom();
             long arrayAddr = callNativeFn(
                 listener -> NativeBridge.streamNext(streamHandle.getRuntimeHandle().get(), streamHandle.getPointer(), listener)
             );
             if (arrayAddr == 0) {
                 nativeStreamExhausted = true;
-                // Streaming Flight requires ≥1 schema-bearing frame before completeStream;
-                // synthesise a zero-row batch carrying the schema for empty native streams.
                 if (!batchEmitted) {
                     nextBatch = VectorSchemaRoot.create(schema, allocator);
                     nextBatch.setRowCount(0);
@@ -135,6 +138,26 @@ public class DatafusionResultStream implements EngineResultStream {
             nextBatch = freshRoot;
             batchEmitted = true;
             return true;
+        }
+
+        private void waitForAllocatorHeadroom() {
+            org.apache.arrow.memory.BufferAllocator parent = allocator;
+            while (parent.getParentAllocator() != null) {
+                parent = parent.getParentAllocator();
+            }
+            long limit = parent.getLimit();
+            if (limit == Long.MAX_VALUE) return;
+            for (int i = 0; i < MAX_PRESSURE_WAITS; i++) {
+                if (parent.getAllocatedMemory() < limit * ALLOCATOR_PRESSURE_PERCENT / 100) {
+                    return;
+                }
+                try {
+                    Thread.sleep(PRESSURE_BACKOFF_MS);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
+            }
         }
 
         @Override

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/AnalyticsSearchTransportService.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/AnalyticsSearchTransportService.java
@@ -178,8 +178,6 @@ public class AnalyticsSearchTransportService {
                         receiverError.set(e);
                     } finally {
                         poisonPill.set(true);
-                        // Unblock consumer if waiting
-                        queue.offer(null);
                     }
                 });
 

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/AnalyticsSearchTransportService.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/AnalyticsSearchTransportService.java
@@ -48,6 +48,17 @@ import java.io.IOException;
  */
 @Singleton
 public class AnalyticsSearchTransportService {
+
+    /**
+     * Bounded queue depth between the Flight receiver (deserializer) and the consumer
+     * (DataFusion reduce sink). Limits how many deserialized Arrow batches can accumulate
+     * in the flight allocator before the receiver pauses pulling from gRPC.
+     *
+     * Sized for multi-node pipelining: 8 batches hides up to ~8ms of network latency
+     * while keeping allocator pressure bounded (8 × batch_size × num_streams).
+     */
+    private static final int RECEIVER_QUEUE_DEPTH = 8;
+
     private final StreamTransportService transportService;
     private final ClusterService clusterService;
 
@@ -148,18 +159,54 @@ public class AnalyticsSearchTransportService {
 
             @Override
             public void handleStreamResponse(StreamTransportResponse<FragmentExecutionArrowResponse> stream) {
+                var queue = new java.util.concurrent.ArrayBlockingQueue<FragmentExecutionArrowResponse>(RECEIVER_QUEUE_DEPTH);
+                var poisonPill = new java.util.concurrent.atomic.AtomicBoolean(false);
+                var receiverError = new java.util.concurrent.atomic.AtomicReference<Exception>(null);
+
+                // Receiver thread: deserializes from gRPC into bounded queue.
+                // Blocks at queue.put() when consumer is slow → stops flightStream.next()
+                // → stops gRPC request(1) → backpressure propagates to sender.
+                Thread.ofVirtual().name("flight-receiver-" + pending.hashCode()).start(() -> {
+                    try {
+                        FragmentExecutionArrowResponse current;
+                        while ((current = stream.nextResponse()) != null) {
+                            queue.put(current);
+                        }
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    } catch (Exception e) {
+                        receiverError.set(e);
+                    } finally {
+                        poisonPill.set(true);
+                        // Unblock consumer if waiting
+                        queue.offer(null);
+                    }
+                });
+
+                // Consumer: pulls from queue on demand, feeds to sink.
+                // This thread already exists (the handler executor thread).
                 try {
-                    FragmentExecutionArrowResponse current;
                     FragmentExecutionArrowResponse last = null;
-                    while ((current = stream.nextResponse()) != null) {
+                    while (true) {
+                        FragmentExecutionArrowResponse batch = queue.poll(100, java.util.concurrent.TimeUnit.MILLISECONDS);
+                        if (batch == null) {
+                            if (poisonPill.get() && queue.isEmpty()) break;
+                            continue;
+                        }
                         if (last != null) {
                             listener.onStreamResponse(last, false);
                         }
-                        last = current;
+                        last = batch;
                     }
                     if (last != null) {
                         listener.onStreamResponse(last, true);
                     }
+                    if (receiverError.get() != null) {
+                        throw receiverError.get();
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    listener.onFailure(new RuntimeException("Stream consumption interrupted", e));
                 } catch (Exception e) {
                     listener.onFailure(e);
                 } finally {


### PR DESCRIPTION
FlightServerChannel.sendBatch() calls putNext() without checking transport readiness or allocator pressure. When the receiver can't drain fast enough, Arrow buffers accumulate and the allocator OOMs.

Add waitForReady() before putNext() with two guards:
- isReady(): gRPC transport-level flow control (Netty write buffer)
- isAllocatorPressured(): Arrow allocator at 95% of pool limit

Fast path: both checks pass → one branch, no synchronization. Slow path: blocks on readyLock, woken by onReadyHandler callback. Polls allocator pressure every 100ms as fallback.

Note: This alone doesn't fix the 18 high-cardinality query failures. Those fail because DataFusion's hash aggregation emits all groups via EmitTo::All into a single RecordBatch, which is then sliced by batch_size (8192) for the output stream. However, the Rust RecordBatch.slice() is zero-copy — the full underlying buffer is exported via C Data Interface, and the Java receiver allocates the FULL buffer size in the flight allocator. The proper fix requires compacting sliced batches before C Data export on the Rust side.

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
