### PR TITLE
Fix SSE blob store reload during repository metadata update

### DIFF
--- a/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3Repository.java
+++ b/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3Repository.java
@@ -596,8 +596,9 @@ class S3Repository extends MeteredBlobStoreRepository {
         s3AsyncService.releaseCachedClients();
 
         // Reload configs for S3BlobStore
-        BlobStore blobStore = getBlobStore();
-        blobStore.reload(metadata);
+        if (blobStoreProvider.get() != null) {
+            blobStoreProvider.get().reloadBlobStore(newRepositoryMetadata);
+        }
     }
 
     /**

--- a/server/src/main/java/org/opensearch/index/store/SubdirectoryAwareDirectory.java
+++ b/server/src/main/java/org/opensearch/index/store/SubdirectoryAwareDirectory.java
@@ -39,7 +39,7 @@ import java.util.stream.Collectors;
  */
 public class SubdirectoryAwareDirectory extends FilterDirectory {
     private static final Logger logger = LogManager.getLogger(SubdirectoryAwareDirectory.class);
-    private static final Set<String> EXCLUDED_SUBDIRECTORIES = Set.of("index/", "translog/", "_state/");
+    private static final Set<String> EXCLUDED_SUBDIRECTORIES = Set.of("index/", "translog/", "_state/", "lucene/");
     private final ShardPath shardPath;
 
     /**

--- a/server/src/main/java/org/opensearch/repositories/blobstore/BlobStoreProvider.java
+++ b/server/src/main/java/org/opensearch/repositories/blobstore/BlobStoreProvider.java
@@ -17,6 +17,8 @@ import org.opensearch.common.blobstore.EncryptedBlobStore;
 import org.opensearch.common.lifecycle.Lifecycle;
 import org.opensearch.repositories.RepositoryException;
 
+import java.util.Objects;
+
 /**
  * Provide for the BlobStore class
  *
@@ -81,6 +83,17 @@ public class BlobStoreProvider {
             throw e;
         } catch (Exception e) {
             throw new RepositoryException(metadata.name(), "cannot create blob store", e);
+        }
+    }
+
+    public void reloadBlobStore(RepositoryMetadata metadata) {
+        if (serverSideEncryptedBlobStore.get() != null) {
+            logger.info("Reloading repository metadata for SSE blob store");
+            Objects.requireNonNull(serverSideEncryptedBlobStore.get()).reload(metadata);
+        }
+        if (blobStore.get() != null) {
+            logger.info("Reloading repository metadata for non SSE blob store");
+            Objects.requireNonNull(blobStore.get()).reload(metadata);
         }
     }
 

--- a/server/src/main/java/org/opensearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/opensearch/repositories/blobstore/BlobStoreRepository.java
@@ -567,7 +567,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
 
     private final SetOnce<BlobContainer> snapshotShardPathBlobContainer = new SetOnce<>();
 
-    private final SetOnce<BlobStoreProvider> blobStoreProvider = new SetOnce<>();
+    protected final SetOnce<BlobStoreProvider> blobStoreProvider = new SetOnce<>();
 
     protected final ClusterService clusterService;
 

--- a/server/src/test/java/org/opensearch/repositories/blobstore/BlobStoreProviderTests.java
+++ b/server/src/test/java/org/opensearch/repositories/blobstore/BlobStoreProviderTests.java
@@ -18,6 +18,9 @@ import org.junit.Before;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -121,5 +124,90 @@ public class BlobStoreProviderTests extends OpenSearchTestCase {
 
         // Test - should throw RepositoryException
         expectThrows(RepositoryException.class, () -> provider.initBlobStore());
+    }
+
+    /**
+     * Verifies that {@link BlobStoreProvider#reloadBlobStore(RepositoryMetadata)} reloads BOTH the
+     * non-SSE and SSE blob stores when both have been initialized. This is the regression test for
+     * the bug where SSE-enabled repositories did not pick up updated metadata because only the
+     * non-SSE store was reloaded.
+     */
+    public void testReloadBlobStoreReloadsBothStoresWhenBothInitialized() throws Exception {
+        // Setup: initialize both non-SSE and SSE blob stores
+        when(mockLifecycle.started()).thenReturn(true);
+        when(mockRepository.createBlobStore()).thenReturn(mockBlobStore).thenReturn(mockServerSideEncryptionBlobStore);
+
+        provider.blobStore(false); // initializes non-SSE store
+        provider.blobStore(true);  // initializes SSE store
+
+        RepositoryMetadata newMetadata = mock(RepositoryMetadata.class);
+        when(newMetadata.name()).thenReturn("test-repository");
+
+        // Test
+        provider.reloadBlobStore(newMetadata);
+
+        // Verify both stores were reloaded with the new metadata
+        verify(mockBlobStore, times(1)).reload(newMetadata);
+        verify(mockServerSideEncryptionBlobStore, times(1)).reload(newMetadata);
+    }
+
+    /**
+     * Verifies that only the non-SSE blob store is reloaded when only it has been initialized.
+     * The SSE blob store should not be reloaded because it has never been created.
+     */
+    public void testReloadBlobStoreOnlyReloadsNonSseStoreWhenOnlyNonSseInitialized() throws Exception {
+        // Setup: initialize only the non-SSE blob store
+        when(mockLifecycle.started()).thenReturn(true);
+        when(mockRepository.createBlobStore()).thenReturn(mockBlobStore);
+
+        provider.blobStore(false);
+
+        RepositoryMetadata newMetadata = mock(RepositoryMetadata.class);
+        when(newMetadata.name()).thenReturn("test-repository");
+
+        // Test
+        provider.reloadBlobStore(newMetadata);
+
+        // Verify: only the non-SSE store was reloaded; SSE store was never touched
+        verify(mockBlobStore, times(1)).reload(newMetadata);
+        verify(mockServerSideEncryptionBlobStore, never()).reload(any());
+    }
+
+    /**
+     * Verifies that only the SSE blob store is reloaded when only it has been initialized.
+     * The non-SSE blob store should not be reloaded because it has never been created.
+     */
+    public void testReloadBlobStoreOnlyReloadsSseStoreWhenOnlySseInitialized() throws Exception {
+        // Setup: initialize only the SSE blob store
+        when(mockLifecycle.started()).thenReturn(true);
+        when(mockRepository.createBlobStore()).thenReturn(mockServerSideEncryptionBlobStore);
+
+        provider.blobStore(true);
+
+        RepositoryMetadata newMetadata = mock(RepositoryMetadata.class);
+        when(newMetadata.name()).thenReturn("test-repository");
+
+        // Test
+        provider.reloadBlobStore(newMetadata);
+
+        // Verify: only the SSE store was reloaded; non-SSE store was never touched
+        verify(mockServerSideEncryptionBlobStore, times(1)).reload(newMetadata);
+        verify(mockBlobStore, never()).reload(any());
+    }
+
+    /**
+     * Verifies that {@link BlobStoreProvider#reloadBlobStore(RepositoryMetadata)} is a safe no-op
+     * when neither blob store has been initialized yet. This guards against NPEs when reload is
+     * triggered before any blob store has been lazily created.
+     */
+    public void testReloadBlobStoreNoOpWhenNeitherStoreInitialized() {
+        RepositoryMetadata newMetadata = mock(RepositoryMetadata.class);
+
+        // Test - should not throw
+        provider.reloadBlobStore(newMetadata);
+
+        // Verify: neither store had reload invoked on it
+        verify(mockBlobStore, never()).reload(any());
+        verify(mockServerSideEncryptionBlobStore, never()).reload(any());
     }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
#### Summary
  
1. When repository metadata was updated on an SSE-enabled S3 repository (e.g., rotating credentials, changing endpoint), S3Repository.reload() only invoked reload() on the result of getBlobStore(), which returned only the non-SSE blob store.
  The serverSideEncryptedBlobStore was silently skipped, leaving SSE-enabled repositories using stale config until node restart.

2. Added "lucene/" in `EXCLUDED_SUBDIRECTORIES` so that the files in this directory doesn't come in the file list of `SubdirectoryAwareDirectory`.
  
  #### Bug
  
  When repository metadata was updated on an SSE-enabled S3 repository (e.g., rotating credentials, changing endpoint), S3Repository.reload() only invoked reload() on the result of getBlobStore(), which returned only the non-SSE blob store.
  The serverSideEncryptedBlobStore was silently skipped, leaving SSE-enabled repositories using stale config until node restart.
  
  #### Changes
  
  - BlobStoreProvider.reloadBlobStore(RepositoryMetadata) — new method that reloads both the non-SSE and SSE blob stores when initialized.
  - S3Repository.reload() — now delegates to blobStoreProvider.reloadBlobStore() instead of reloading only one store.
  - BlobStoreRepository.blobStoreProvider — visibility relaxed from private to protected so subclasses can invoke the provider.
  

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
