### PR TITLE
Fix Utf8View/Utf8 schema mismatch panic in indexed parquet path

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/segment_info.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/segment_info.rs
@@ -121,7 +121,10 @@ pub async fn build_segments(
     //      primitives (recursively merged for Struct/List/Union).
     //   5. Apply `binary_as_string` and `force_view_types` transforms
     //      if configured.
-    let format = ParquetFormat::default();
+    // Disable Utf8View: the indexed path uses the file's physical schema for
+    // ParquetSource (to avoid column reordering issues), so the inferred table
+    // schema must also use Utf8 (not Utf8View) to stay consistent.
+    let format = ParquetFormat::default().with_force_view_types(false);
     let schema = FileFormat::infer_schema(&format, state, &store, object_metas)
         .await
         .map_err(|e| format!("infer_schema union: {}", e))?;

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/stream.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/stream.rs
@@ -597,9 +597,13 @@ impl IndexedStream {
             }
         };
 
-        // Strip extra predicate columns to match output schema
+        // Reorder/strip columns to match output schema. The parquet reader
+        // delivers columns in the file's physical order which may differ from
+        // the table schema order (e.g. when infer_schema sorted alphabetically).
         let t_proj = Instant::now();
-        let output = if output.num_columns() > self.schema.fields().len() {
+        let output = if output.schema().as_ref() == self.schema.as_ref() {
+            output
+        } else {
             let n = self.schema.fields().len();
             if n == 0 {
                 RecordBatch::try_new_with_options(
@@ -617,8 +621,6 @@ impl IndexedStream {
                     .collect();
                 output.project(&indices)?
             }
-        } else {
-            output
         };
         if let Some(ref t) = self.metrics.projection_fixup_time {
             t.add_duration(t_proj.elapsed());

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/fuzz/config.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/fuzz/config.rs
@@ -660,6 +660,35 @@ impl FixtureConfig {
             min_skip_run_override: Some(4),
         }
     }
+
+    /// Shuffled columns: same as `small` but columns are in reversed
+    /// order. Exercises the stream.rs reprojection-by-name path .
+    pub fn shuffled_columns(seed: u64) -> Self {
+        let mut cols = default_columns();
+        cols.reverse();
+        Self {
+            seed,
+            num_rows: 10_000,
+            num_segments: 1,
+            target_partitions: 1,
+            rows_per_row_group: 2_048,
+            rows_per_page: 512,
+            columns: cols,
+            null_pct: 0.1,
+            num_collector_leaves: 3,
+            collector_density: 0.05,
+            tree_max_depth: 5,
+            tree_max_fanout: 5,
+            batch_size: None,
+            max_collector_parallelism: None,
+            null_pct_overrides: std::collections::HashMap::new(),
+            force_misaligned_pages: false,
+            null_strategy: NullStrategy::Uniform,
+            phantom_columns: Vec::new(),
+            multi_column_or_pct: 0.0,
+            min_skip_run_override: None,
+        }
+    }
 }
 
 /// Default column mix — covers every Predicate code path our evaluator

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/fuzz/tests.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/fuzz/tests.rs
@@ -156,7 +156,12 @@ async fn fuzz_single_row_group() {
 /// regardless of seed.
 #[tokio::test(flavor = "multi_thread")]
 async fn fuzz_parallel_collectors() {
-    run_fuzz("fuzz_parallel_collectors", 50, FixtureConfig::parallel_collectors).await;
+    run_fuzz(
+        "fuzz_parallel_collectors",
+        50,
+        FixtureConfig::parallel_collectors,
+    )
+    .await;
 }
 
 /// AND(Predicate, Collector) focused: shallow depth-2 trees with 4
@@ -280,4 +285,13 @@ async fn fuzz_delegation_sloppy() {
         2,
     )
     .await;
+}
+
+/// Shuffled column order: parquet file columns are in reversed order
+/// compared to the table schema. Exercises the stream.rs
+/// reprojection-by-name fix that fires when schemas have the same
+/// columns but in different order.
+#[tokio::test(flavor = "multi_thread")]
+async fn fuzz_shuffled_columns() {
+    run_fuzz("fuzz_shuffled_columns", 50, FixtureConfig::shuffled_columns).await;
 }

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/schema_drift.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/schema_drift.rs
@@ -359,3 +359,167 @@ fn page_pruner_prunes_existing_column_despite_missing_column() {
         }
     }
 }
+// ══════════════════════════════════════════════════════════════════════
+
+/// Generic helper: write a parquet file, register with a (possibly different)
+/// table schema, run `SELECT * FROM t`, return row count.
+async fn query_with_mismatched_schema(
+    file_schema: SchemaRef,
+    table_schema: SchemaRef,
+    batch: &RecordBatch,
+    tree_bool: BoolNode,
+) -> usize {
+    let tmp = NamedTempFile::new().unwrap();
+    let (file, path) = tmp.keep().unwrap();
+    let props = datafusion::parquet::file::properties::WriterProperties::builder()
+        .set_max_row_group_size(256)
+        .build();
+    let mut w = ArrowWriter::try_new(file, file_schema, Some(props)).unwrap();
+    w.write(batch).unwrap();
+    w.close().unwrap();
+
+    let size = std::fs::metadata(&path).unwrap().len();
+    let rfile = std::fs::File::open(&path).unwrap();
+    let meta =
+        ArrowReaderMetadata::load(&rfile, ArrowReaderOptions::new().with_page_index(true)).unwrap();
+    let parquet_meta = meta.metadata().clone();
+    let mut rgs = Vec::new();
+    let mut offset = 0i64;
+    for i in 0..parquet_meta.num_row_groups() {
+        let n = parquet_meta.row_group(i).num_rows();
+        rgs.push(RowGroupInfo {
+            index: i,
+            first_row: offset,
+            num_rows: n,
+        });
+        offset += n;
+    }
+    let segment = SegmentFileInfo {
+        writer_generation: 0,
+        max_doc: batch.num_rows() as i64,
+        object_path: object_store::path::Path::from(path.to_string_lossy().as_ref()),
+        parquet_size: size,
+        row_groups: rgs,
+        metadata: Arc::clone(&parquet_meta),
+    };
+    let tree = Arc::new(tree_bool);
+    let factory: super::super::table_provider::EvaluatorFactory = {
+        let tree = Arc::clone(&tree);
+        let schema = table_schema.clone();
+        Arc::new(move |segment, _chunk, _stream_metrics| {
+            let resolved = tree.resolve(&[])?;
+            let pruner = Arc::new(PagePruner::new(&schema, Arc::clone(&segment.metadata)));
+            let eval: Arc<dyn RowGroupBitsetSource> = Arc::new(TreeBitsetSource {
+                tree: Arc::new(resolved),
+                evaluator: Arc::new(BitmapTreeEvaluator),
+                leaves: Arc::new(CollectorLeafBitmaps::without_metrics()),
+                page_pruner: pruner,
+                cost_predicate: 1,
+                cost_collector: 10,
+                max_collector_parallelism: 1,
+                pruning_predicates: std::sync::Arc::new(std::collections::HashMap::new()),
+                page_prune_metrics: None,
+                collector_strategy:
+                    crate::indexed_table::eval::CollectorCallStrategy::TightenOuterBounds,
+            });
+            Ok(eval)
+        })
+    };
+    let qc = crate::datafusion_query_config::DatafusionQueryConfig::builder()
+        .target_partitions(1)
+        .force_strategy(Some(FilterStrategy::BooleanMask))
+        .force_pushdown(Some(false))
+        .build();
+    let provider = Arc::new(IndexedTableProvider::new(IndexedTableConfig {
+        schema: table_schema,
+        segments: vec![segment],
+        store: Arc::new(object_store::local::LocalFileSystem::new())
+            as Arc<dyn object_store::ObjectStore>,
+        store_url: datafusion::execution::object_store::ObjectStoreUrl::local_filesystem(),
+        evaluator_factory: factory,
+        pushdown_predicate: None,
+        query_config: std::sync::Arc::new(qc),
+        predicate_columns: vec![],
+    }));
+    let ctx = SessionContext::new();
+    ctx.register_table("t", provider).unwrap();
+    let df = ctx.sql("SELECT * FROM t").await.unwrap();
+    let mut stream = df.execute_stream().await.unwrap();
+    let mut count = 0;
+    while let Some(b) = stream.next().await {
+        let b = b.unwrap();
+        count += b.num_rows();
+    }
+    count
+}
+
+/// Build a tautology predicate: `col >= 0` (always true for non-negative int columns).
+/// `col_idx` is the column's position in the table schema.
+fn tautology_int(col: &str, col_idx: usize) -> BoolNode {
+    let left: Arc<dyn datafusion::physical_expr::PhysicalExpr> = Arc::new(
+        datafusion::physical_expr::expressions::Column::new(col, col_idx),
+    );
+    let right: Arc<dyn datafusion::physical_expr::PhysicalExpr> = Arc::new(
+        datafusion::physical_expr::expressions::Literal::new(ScalarValue::Int32(Some(0))),
+    );
+    BoolNode::Predicate(Arc::new(
+        datafusion::physical_expr::expressions::BinaryExpr::new(left, Operator::GtEq, right),
+    ))
+}
+
+// File has (name, score, brand); table schema is (brand, name, score).
+// Without the stream.rs reprojection fix, columns would be swapped.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn reorder_columns_aligned_and_filtered() {
+    let file_schema = Arc::new(Schema::new(vec![
+        Field::new("name", DataType::Utf8, false),
+        Field::new("score", DataType::Int32, false),
+        Field::new("brand", DataType::Utf8, false),
+    ]));
+    let table_schema = Arc::new(Schema::new(vec![
+        Field::new("brand", DataType::Utf8, false),
+        Field::new("name", DataType::Utf8, false),
+        Field::new("score", DataType::Int32, false),
+    ]));
+    let batch = RecordBatch::try_new(
+        file_schema.clone(),
+        vec![
+            Arc::new(StringArray::from(vec!["alice", "bob", "alice", "bob"])),
+            Arc::new(Int32Array::from(vec![10, 20, 30, 40])),
+            Arc::new(StringArray::from(vec!["acme", "globex", "acme", "globex"])),
+        ],
+    )
+    .unwrap();
+    let count =
+        query_with_mismatched_schema(file_schema, table_schema, &batch, tautology_int("score", 2))
+            .await;
+    assert_eq!(count, 4);
+}
+
+// File has Utf8 columns; table schema declares Utf8View.
+// Without force_view_types(false), panics with "byte view array".
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn utf8view_schema_with_utf8_file_does_not_panic() {
+    let file_schema = Arc::new(Schema::new(vec![
+        Field::new("city", DataType::Utf8, false),
+        Field::new("pop", DataType::Int32, false),
+    ]));
+    let table_schema = Arc::new(Schema::new(vec![
+        Field::new("city", DataType::Utf8View, false),
+        Field::new("pop", DataType::Int32, false),
+    ]));
+    let batch = RecordBatch::try_new(
+        file_schema.clone(),
+        vec![
+            Arc::new(StringArray::from(vec![
+                "seattle", "portland", "denver", "austin",
+            ])),
+            Arc::new(Int32Array::from(vec![750_000, 650_000, 700_000, 980_000])),
+        ],
+    )
+    .unwrap();
+    let count =
+        query_with_mismatched_schema(file_schema, table_schema, &batch, tautology_int("pop", 1))
+            .await;
+    assert_eq!(count, 4);
+}


### PR DESCRIPTION
DataFusion's ParquetFormat::default() promotes Utf8 to Utf8View in inferred schemas (force_view_types=true), but the parquet reader delivers Utf8 arrays. This type mismatch causes a native panic ("Panic: byte view array") when downstream operators encounter Utf8View schema with Utf8 data.

Additionally, when the inferred table schema has columns in a different order than the file's physical layout, the stream's projection step was only firing when column counts differed, silently passing misaligned batches through.

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
