### PR TITLE
[Backport] [3.6] Memory leak upon installing transport-reactor-netty4 plugin (#21788)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Handle dependencies between analyzers ([#19248](https://github.com/opensearch-project/OpenSearch/pull/19248))
 - Fix `_field_caps` returning empty results and corrupted field names for `disable_objects: true` mappings ([#20800](https://github.com/opensearch-project/OpenSearch/pull/20800))
 - Make sure Netty4Http3ServerTransport uses configured HeaderVerifier and Decompressor instances ([#21293](https://github.com/opensearch-project/OpenSearch/pull/21293))
+- Fix memory leak upon installing transport-reactor-netty4 plugin ([#21788](https://github.com/opensearch-project/OpenSearch/pull/21788))
 
 ### Dependencies
 - Bump shadow-gradle-plugin from 8.3.9 to 9.3.1 ([#20569](https://github.com/opensearch-project/OpenSearch/pull/20569))

--- a/plugins/transport-reactor-netty4/src/internalClusterTest/java/org/opensearch/http/reactor/netty4/ReactorNetty4HttpChannelsReleaseIntegTests.java
+++ b/plugins/transport-reactor-netty4/src/internalClusterTest/java/org/opensearch/http/reactor/netty4/ReactorNetty4HttpChannelsReleaseIntegTests.java
@@ -30,7 +30,6 @@ import java.util.concurrent.TimeUnit;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 
 @ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, supportsDedicatedMasters = false, numDataNodes = 1)
 public class ReactorNetty4HttpChannelsReleaseIntegTests extends OpenSearchReactorNetty4IntegTestCase {
@@ -67,17 +66,9 @@ public class ReactorNetty4HttpChannelsReleaseIntegTests extends OpenSearchReacto
         }
         countDownLatch.await();
 
-        // no channels get closed in this test, hence we expect as many channels as we created in the map at most
-        // it is difficult to match the exact number of HTTP channels since:
-        // - there is 10 connections per route default setting (RestClient)
-        // - there are at least 2 nodes in the cluster (master + data)
-        // - if additional plugins are used (like telemetry), the same HTTP channel may
-        // be wrapped around, inflating the number of HTTP channels being tracked
-        assertThat(
-            "All channels remain open",
-            RestCancellableNodeClient.getNumChannels(),
-            greaterThanOrEqualTo(initialHttpChannels + 10 /* default connections per route */)
-        );
+        // The Project Reactor creates an ephemeral connection over Netty channel all the time and run request / response conversation over
+        // it. The underlying HttpChannel / RestChannel instances are always closed once the response is delivered.
+        assertThat("All channels are closed", RestCancellableNodeClient.getNumChannels(), equalTo(initialHttpChannels));
     }
 
     /**

--- a/plugins/transport-reactor-netty4/src/main/java/org/opensearch/http/reactor/netty4/ReactorNetty4HttpServerTransport.java
+++ b/plugins/transport-reactor-netty4/src/main/java/org/opensearch/http/reactor/netty4/ReactorNetty4HttpServerTransport.java
@@ -8,9 +8,13 @@
 
 package org.opensearch.http.reactor.netty4;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.opensearch.OpenSearchException;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.Randomness;
+import org.opensearch.common.concurrent.CompletableContext;
+import org.opensearch.common.network.CloseableChannel;
 import org.opensearch.common.network.NetworkService;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Setting;
@@ -20,6 +24,7 @@ import org.opensearch.common.util.BigArrays;
 import org.opensearch.common.util.concurrent.OpenSearchExecutors;
 import org.opensearch.common.util.io.IOUtils;
 import org.opensearch.common.util.net.NetUtils;
+import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.unit.ByteSizeUnit;
 import org.opensearch.core.common.unit.ByteSizeValue;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
@@ -44,8 +49,13 @@ import javax.net.ssl.KeyManagerFactory;
 import java.net.InetSocketAddress;
 import java.net.SocketOption;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
@@ -64,9 +74,11 @@ import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SupportedCipherSuiteFilter;
 import io.netty.handler.timeout.ReadTimeoutException;
 import org.reactivestreams.Publisher;
+import reactor.core.publisher.FluxSink;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
+import reactor.netty.Connection;
 import reactor.netty.DisposableChannel;
 import reactor.netty.DisposableServer;
 import reactor.netty.http.HttpProtocol;
@@ -94,6 +106,8 @@ import static org.opensearch.http.HttpTransportSettings.SETTING_HTTP_TCP_SEND_BU
  * The HTTP transport implementations based on Reactor Netty (see please {@link HttpServer}).
  */
 public class ReactorNetty4HttpServerTransport extends AbstractHttpServerTransport {
+    private static final Logger logger = LogManager.getLogger(ReactorNetty4HttpServerTransport.class);
+
     private static final String SETTING_KEY_HTTP_NETTY_MAX_COMPOSITE_BUFFER_COMPONENTS = "http.netty.max_composite_buffer_components";
     private static final ByteSizeValue MTU = new ByteSizeValue(Long.parseLong(System.getProperty("opensearch.net.mtu", "1500")));
 
@@ -188,6 +202,7 @@ public class ReactorNetty4HttpServerTransport extends AbstractHttpServerTranspor
     private volatile SharedGroupFactory.SharedGroup sharedGroup;
     private volatile DisposableServer disposableServer;
     private volatile Scheduler scheduler;
+    private final Map<Channel, HostChannel> hostChannels = new ConcurrentHashMap<>();
 
     /**
      * Creates new HTTP transport implementations based on Reactor Netty (see please {@link HttpServer}).
@@ -537,6 +552,13 @@ public class ReactorNetty4HttpServerTransport extends AbstractHttpServerTranspor
      */
     @Override
     protected void stopInternal() {
+        try {
+            CloseableChannel.closeChannels(new ArrayList<>(hostChannels.values()), true);
+        } catch (Exception e) {
+            logger.warn("unexpected exception while closing http channels", e);
+        }
+        hostChannels.clear();
+
         if (sharedGroup != null) {
             sharedGroup.shutdown();
             sharedGroup = null;
@@ -600,5 +622,105 @@ public class ReactorNetty4HttpServerTransport extends AbstractHttpServerTranspor
         } catch (final RuntimeException ex) {
             // Do nothing
         }
+    }
+
+    /**
+     * The {@link HostChannel} abstraction binds {@link HttpChannel} instance to a single Netty channel and
+     * separate the lifecycle of those: {@link HttpChannel} is closed upon every response delivered whereas {@link HostChannel}
+     * is closed only when the Netty channel it is attached to is closed.
+     */
+    static final class HostChannel implements CloseableChannel {
+        private final Channel channel;
+        private final CompletableContext<Void> closeContext = new CompletableContext<>();
+        private final Set<HttpChannel> httpChannels = Collections.newSetFromMap(new ConcurrentHashMap<>());
+
+        HostChannel(Channel channel) {
+            this.channel = channel;
+            Netty4Utils.addListener(channel.closeFuture(), closeContext);
+            closeContext.addListener((v, ex) -> { httpChannels.forEach(HttpChannel::close); });
+        }
+
+        @Override
+        public void addCloseListener(ActionListener<Void> listener) {
+            closeContext.addListener(ActionListener.toBiConsumer(listener));
+        }
+
+        /**
+         * Checks if underlying Netty channel is open
+         * @return "true" if underlying Netty channel is open, "false" otherwise
+         */
+        @Override
+        public boolean isOpen() {
+            return channel.isOpen();
+        }
+
+        /**
+         * Unbinds {@link HttpChannel} instance
+         * @param httpChannel {@link HttpChannel} instance
+         */
+        void close(HttpChannel httpChannel) {
+            httpChannels.remove(httpChannel);
+        }
+
+        /**
+         * Closes this channel group
+         */
+        @Override
+        public void close() {
+            if (closeContext.isDone() == false) {
+                Netty4Utils.addListener(channel.close(), closeContext);
+            } else {
+                channel.close();
+            }
+        }
+
+        /**
+         * Creates and binds new {@link HttpChannel} instance to this channel group
+        * @param request HTTP request
+        * @param response HTTP response
+        * @param emitter {@link HttpContent} emitter
+        * @return new {@link HttpChannel} instance
+         */
+        HttpChannel newHttpChannel(HttpServerRequest request, HttpServerResponse response, FluxSink<HttpContent> emitter) {
+            final ReactorNetty4NonStreamingHttpChannel httpChannel = new ReactorNetty4NonStreamingHttpChannel(
+                this,
+                request,
+                response,
+                emitter
+            );
+            httpChannels.add(httpChannel);
+            return httpChannel;
+        }
+
+    }
+
+    /**
+     * Creates a new non-streaming {@link HttpChannel} instance. The Project Reactor creates an ephemeral connection
+     * over Netty channel all the time and runs request / response conversation over it. It does not work well with persistent
+     * connections as it leads to explosion of {@link HttpChannel} instances that are tracked by {@link AbstractHttpServerTransport}
+     * and eventually could cause out of memory.
+     *
+     * To mitigate that, the {@link HostChannel} abstraction binds {@link HttpChannel} instance to a single Netty channel and
+     * separate the lifecycle of those: {@link HttpChannel} is closed upon every response delivered whereas {@link HostChannel}
+     * is closed only when the Netty channel it is attached to is closed.
+     *
+     * @param request HTTP request
+     * @param response HTTP response
+     * @param emitter {@link HttpContent} emitter
+     * @return new {@link HttpChannel} instance
+     */
+    HttpChannel newNonStreamingHttpChannel(HttpServerRequest request, HttpServerResponse response, FluxSink<HttpContent> emitter) {
+        final Connection[] connection = new Connection[1];
+        request.withConnection(c -> connection[0] = c);
+
+        if (connection[0] == null) {
+            throw new IllegalStateException("Failed to obtain connection from HttpServerRequest");
+        }
+
+        final Channel channel = connection[0].channel();
+        final HostChannel hostChannel = hostChannels.computeIfAbsent(channel, key -> new HostChannel(key));
+        hostChannel.addCloseListener(ActionListener.wrap(() -> hostChannels.remove(channel)));
+
+        return hostChannel.newHttpChannel(request, response, emitter);
     }
 }

--- a/plugins/transport-reactor-netty4/src/main/java/org/opensearch/http/reactor/netty4/ReactorNetty4NonStreamingHttpChannel.java
+++ b/plugins/transport-reactor-netty4/src/main/java/org/opensearch/http/reactor/netty4/ReactorNetty4NonStreamingHttpChannel.java
@@ -12,11 +12,10 @@ import org.opensearch.common.concurrent.CompletableContext;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.http.HttpChannel;
 import org.opensearch.http.HttpResponse;
-import org.opensearch.transport.netty4.Netty4Utils;
+import org.opensearch.http.reactor.netty4.ReactorNetty4HttpServerTransport.HostChannel;
 
 import java.net.InetSocketAddress;
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpContent;
@@ -27,32 +26,33 @@ import reactor.netty.http.server.HttpServerResponse;
 class ReactorNetty4NonStreamingHttpChannel implements HttpChannel {
     private final HttpServerRequest request;
     private final HttpServerResponse response;
-    private final CompletableContext<Void> closeContext = new CompletableContext<>();
     private final FluxSink<HttpContent> emitter;
+    private final HostChannel hostChannel;
+    private final CompletableContext<Void> closeContext = new CompletableContext<>();
 
-    ReactorNetty4NonStreamingHttpChannel(HttpServerRequest request, HttpServerResponse response, FluxSink<HttpContent> emitter) {
+    ReactorNetty4NonStreamingHttpChannel(
+        HostChannel hostChannel,
+        HttpServerRequest request,
+        HttpServerResponse response,
+        FluxSink<HttpContent> emitter
+    ) {
+        this.hostChannel = hostChannel;
         this.request = request;
         this.response = response;
         this.emitter = emitter;
-        this.request.withConnection(connection -> Netty4Utils.addListener(connection.channel().closeFuture(), closeContext));
     }
 
     @Override
     public boolean isOpen() {
-        final AtomicBoolean isOpen = new AtomicBoolean();
-        request.withConnection(connection -> isOpen.set(connection.channel().isOpen()));
-        return isOpen.get();
+        return hostChannel.isOpen();
     }
 
     @Override
     public void close() {
-        request.withConnection(connection -> {
-            if (closeContext.isDone() == false) {
-                Netty4Utils.addListener(connection.channel().close(), closeContext);
-            } else {
-                connection.channel().close();
-            }
-        });
+        if (closeContext.isDone() == false) {
+            closeContext.complete(null);
+            hostChannel.close(this);
+        }
     }
 
     @Override

--- a/plugins/transport-reactor-netty4/src/main/java/org/opensearch/http/reactor/netty4/ReactorNetty4NonStreamingRequestConsumer.java
+++ b/plugins/transport-reactor-netty4/src/main/java/org/opensearch/http/reactor/netty4/ReactorNetty4NonStreamingRequestConsumer.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.http.reactor.netty4;
 
+import org.opensearch.http.HttpChannel;
 import org.opensearch.http.HttpRequest;
 
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -34,6 +35,7 @@ class ReactorNetty4NonStreamingRequestConsumer<T extends HttpContent> implements
     private final AtomicBoolean disposed = new AtomicBoolean(false);
     private volatile FluxSink<HttpContent> emitter;
     private volatile boolean lastHttpContentEmitted = false;
+    private volatile HttpChannel channel;
 
     ReactorNetty4NonStreamingRequestConsumer(
         ReactorNetty4HttpServerTransport transport,
@@ -84,7 +86,7 @@ class ReactorNetty4NonStreamingRequestConsumer<T extends HttpContent> implements
         if (in instanceof LastHttpContent) {
             lastHttpContentEmitted = true;
 
-            final ReactorNetty4NonStreamingHttpChannel channel = new ReactorNetty4NonStreamingHttpChannel(request, response, emitter);
+            channel = transport.newNonStreamingHttpChannel(request, response, emitter);
             final HttpRequest r = createRequest(request, content);
 
             try {
@@ -113,6 +115,13 @@ class ReactorNetty4NonStreamingRequestConsumer<T extends HttpContent> implements
 
     @Override
     public void dispose() {
+        // Always close the HttpChannel instance here since the underlying publisher is disposed.
+        final HttpChannel httpChannel = channel;
+        if (httpChannel != null) {
+            httpChannel.close();
+            channel = null;
+        }
+
         if (disposed.compareAndSet(false, true)) {
             this.content.release();
         }


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/OpenSearch/pull/21788 to 3.6