### PR TITLE
Revert NonClosingReaderWrapper cache (#20921)

### DIFF
--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -252,7 +252,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletionService;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorCompletionService;
@@ -333,8 +332,6 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
 
     private final IndexingOperationListener indexingOperationListeners;
     private final Runnable globalCheckpointSyncer;
-    private final ConcurrentHashMap<DirectoryReader, NonClosingReaderWrapper> nonClosingReaderWrapperCache = new ConcurrentHashMap<>();
-    private final Function<DirectoryReader, DirectoryReader> nonClosingReaderWrapperSupplier;
 
     Runnable getGlobalCheckpointSyncer() {
         return globalCheckpointSyncer;
@@ -559,34 +556,6 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         } else {
             readerWrapper = indexReaderWrapper;
         }
-
-        nonClosingReaderWrapperSupplier = directoryReader -> {
-            int[] fromCache = new int[] { 0 };
-            try {
-                // To prevent instantiating a new NonClosingReaderWrapper per query/get/update request,
-                // the wrapper can be shared across all uses of the same NonClosingReaderWrapper.
-                return nonClosingReaderWrapperCache.computeIfAbsent(directoryReader, key -> {
-                    try {
-                        NonClosingReaderWrapper closingReaderWrapper = new NonClosingReaderWrapper(key);
-                        fromCache[0] = 1;
-                        return closingReaderWrapper;
-                    } catch (IOException e) {
-                        fromCache[0] = 2;
-                        throw new OpenSearchException("failed to wrap searcher", e);
-                    }
-                });
-            } finally {
-                if (fromCache[0] == 1) {
-                    OpenSearchDirectoryReader.addReaderCloseListener(
-                        directoryReader,
-                        cacheKey -> nonClosingReaderWrapperCache.remove(directoryReader)
-                    );
-                } else if (fromCache[0] == 2) {
-                    nonClosingReaderWrapperCache.remove(directoryReader);
-                }
-            }
-        };
-
         refreshListeners = buildRefreshListeners();
         lastSearcherAccess.set(threadPool.relativeTimeInMillis());
         persistMetadata(path, indexSettings, shardRouting, null, logger);
@@ -2448,9 +2417,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
             : "DirectoryReader must be an instance or OpenSearchDirectoryReader";
         boolean success = false;
         try {
-            final Engine.Searcher newSearcher = readerWrapper == null
-                ? searcher
-                : wrapSearcher(searcher, readerWrapper, nonClosingReaderWrapperSupplier);
+            final Engine.Searcher newSearcher = readerWrapper == null ? searcher : wrapSearcher(searcher, readerWrapper);
             assert newSearcher != null;
             success = true;
             return newSearcher;
@@ -2470,28 +2437,14 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         Engine.Searcher engineSearcher,
         CheckedFunction<DirectoryReader, DirectoryReader, IOException> readerWrapper
     ) throws IOException {
-        return wrapSearcher(engineSearcher, readerWrapper, null);
-    }
-
-    public static Engine.Searcher wrapSearcher(
-        Engine.Searcher engineSearcher,
-        CheckedFunction<DirectoryReader, DirectoryReader, IOException> readerWrapper,
-        Function<DirectoryReader, DirectoryReader> nonClosingReaderWrapperSupplier
-    ) throws IOException {
         assert readerWrapper != null;
-        DirectoryReader directoryReader = engineSearcher.getDirectoryReader();
-        final OpenSearchDirectoryReader openSearchDirectoryReader = OpenSearchDirectoryReader.getOpenSearchDirectoryReader(directoryReader);
+        final OpenSearchDirectoryReader openSearchDirectoryReader = OpenSearchDirectoryReader.getOpenSearchDirectoryReader(
+            engineSearcher.getDirectoryReader()
+        );
         if (openSearchDirectoryReader == null) {
             throw new IllegalStateException("Can't wrap non opensearch directory reader");
         }
-
-        DirectoryReader nonClosingReaderWrapper;
-        if (nonClosingReaderWrapperSupplier == null) {
-            nonClosingReaderWrapper = new NonClosingReaderWrapper(directoryReader);
-        } else {
-            nonClosingReaderWrapper = nonClosingReaderWrapperSupplier.apply(directoryReader);
-            assert nonClosingReaderWrapper instanceof NonClosingReaderWrapper;
-        }
+        NonClosingReaderWrapper nonClosingReaderWrapper = new NonClosingReaderWrapper(engineSearcher.getDirectoryReader());
         DirectoryReader reader = readerWrapper.apply(nonClosingReaderWrapper);
         if (reader != nonClosingReaderWrapper) {
             if (reader.getReaderCacheHelper() != openSearchDirectoryReader.getReaderCacheHelper()) {
@@ -2588,7 +2541,6 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
                     changeState(IndexShardState.CLOSED, reason);
                 }
             } finally {
-                nonClosingReaderWrapperCache.clear();
                 final Indexer engine = this.currentEngineReference.getAndSet(null);
                 try {
                     if (engine != null && flushEngine) {
@@ -4595,9 +4547,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
                 public void afterRefresh(boolean didRefresh) {
                     if (!didRefresh) return;
                     // Use the engine directly (not IndexShard.acquireSearcher) so that we do NOT
-                    // go through IndexShard.wrapSearcher / nonClosingReaderWrapperSupplier.
-                    // Going through the shard-level wrapper would create entries in the
-                    // nonClosingReaderWrapperCache that callers do not expect.
+                    // go through IndexShard.wrapSearcher.
                     try (
                         Engine.Searcher searcher = applyOnEngine(
                             getIndexer(),
@@ -6367,16 +6317,6 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         } else {
             throw new IllegalStateException("Cannot apply function on indexer " + indexer.getClass() + " directly on IndexShard");
         }
-    }
-
-    // Visible for testing
-    Function<DirectoryReader, DirectoryReader> nonClosingReaderWrapperSupplier() {
-        return nonClosingReaderWrapperSupplier;
-    }
-
-    // Visible for testing
-    ConcurrentHashMap<DirectoryReader, NonClosingReaderWrapper> nonClosingReaderWrapperCache() {
-        return nonClosingReaderWrapperCache;
     }
 
     // Visible for testing

--- a/server/src/test/java/org/opensearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/IndexShardTests.java
@@ -5514,54 +5514,6 @@ public class IndexShardTests extends IndexShardTestCase {
         closeShards(primary);
     }
 
-    public void testCacheWrapperReader() throws IOException {
-        Settings settings = Settings.builder()
-            .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
-            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
-            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
-            .put(IndexSettings.INDEX_PERIODIC_FLUSH_INTERVAL_SETTING.getKey(), "1s")
-            .build();
-
-        IndexMetadata metadata = IndexMetadata.builder("test")
-            .putMapping("{ \"properties\": { \"foo\":  { \"type\": \"text\"}}}")
-            .settings(settings)
-            .primaryTerm(0, 1)
-            .build();
-
-        CheckedFunction<DirectoryReader, DirectoryReader, IOException> wrapper = reader -> reader;
-
-        IndexShard primary = newShard(new ShardId(metadata.getIndex(), 0), true, "n1", metadata, wrapper);
-        recoverShardFromStore(primary);
-        indexDoc(primary, "_doc", "0", "{\"foo\" : \"bar\"}");
-        primary.flush(new FlushRequest());
-
-        try (
-            Engine.SearcherSupplier searcherSupplier = primary.acquireSearcherSupplier();
-            Engine.Searcher searcher = searcherSupplier.acquireSearcher("foo")
-        ) {
-            DirectoryReader directoryReader = searcher.getDirectoryReader();
-            Engine.Searcher wrap = IndexShard.wrapSearcher(searcher, wrapper, primary.nonClosingReaderWrapperSupplier());
-            wrap.close();
-            assertEquals(1, primary.nonClosingReaderWrapperCache().size());
-            DirectoryReader nonClosingReaderWrapper = primary.nonClosingReaderWrapperCache().get(directoryReader);
-            assertNotNull(nonClosingReaderWrapper);
-
-            // use the cache
-            wrap = IndexShard.wrapSearcher(searcher, wrapper, primary.nonClosingReaderWrapperSupplier());
-            wrap.close();
-            assertEquals(1, primary.nonClosingReaderWrapperCache().size());
-            DirectoryReader newNonClosingReaderWrapper = primary.nonClosingReaderWrapperCache().get(directoryReader);
-            assertEquals(nonClosingReaderWrapper, newNonClosingReaderWrapper);
-
-            // not use the cache
-            wrap = IndexShard.wrapSearcher(searcher, wrapper, null);
-            assertNotEquals(wrap, newNonClosingReaderWrapper);
-            wrap.close();
-        }
-        closeShards(primary);
-        assertTrue(primary.nonClosingReaderWrapperCache().isEmpty());
-    }
-
     /**
      * Verifies that {@code isRemoteSegmentStoreInSync} uses {@code getCatalogSnapshot()} (the unified
      * catalog API) rather than the legacy {@code getSegmentInfosSnapshot()}. After indexing and refreshing,


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This reverts the NonClosingReaderWrapper cache introduced in #20921.

NonClosingReaderWrapper only prevents close() from propagating to the underlying DirectoryReader. The wrapper itself is still a normal IndexReader with its own closed state. Once a wrapped searcher closes the cached NonClosingReaderWrapper, that wrapper becomes closed even though the underlying reader remains open.

If the cache later returns the same NonClosingReaderWrapper for another wrapped searcher, the caller may operate on an already-closed wrapper and hit AlreadyClosedException, for example when accessing leaves(). Therefore the wrapper should remain scoped to a single wrapped searcher instead of being shared from a cache.


### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
