### PR TITLE
Enable native access for FIPS launchers

### DIFF
--- a/distribution/src/bin/opensearch-env
+++ b/distribution/src/bin/opensearch-env
@@ -114,17 +114,19 @@ OPENSEARCH_PATH_CONF=`cd "$OPENSEARCH_PATH_CONF"; pwd`
 
 # FIPS mode is runtime-configured via env var (default: false)
 OPENSEARCH_FIPS_MODE="${OPENSEARCH_FIPS_MODE:-false}"
-
-# Normalize to lowercase for common inputs: TRUE/True/true
-OPENSEARCH_FIPS_MODE="${OPENSEARCH_FIPS_MODE:-false}"
 OPENSEARCH_FIPS_MODE="$(echo "$OPENSEARCH_FIPS_MODE" | tr '[:upper:]' '[:lower:]')"
 
-if [[ "$OPENSEARCH_FIPS_MODE" == "true" ]] && ls "$OPENSEARCH_HOME/lib" | grep -E -q "bc-fips.*\.jar"; then
-  echo "FIPS mode enabled, setting JVM options."
-  export OPENSEARCH_JAVA_OPTS="-Djava.security.properties=${OPENSEARCH_PATH_CONF}/fips_java.security ${OPENSEARCH_JAVA_OPTS}"
+# BC-FIPS triggers a native load on init, so JDK 24+ requires
+# --enable-native-access=ALL-UNNAMED whenever the jar is on the classpath,
+# regardless of whether FIPS mode itself is enabled.
+if ls "$OPENSEARCH_HOME/lib" 2>/dev/null | grep -E -q "bc-fips.*\.jar"; then
+  export OPENSEARCH_JAVA_OPTS="--enable-native-access=ALL-UNNAMED ${OPENSEARCH_JAVA_OPTS}"
 
-  # Ensure BC-FIPS "approved only" mode is on when FIPS mode is enabled
-  export OPENSEARCH_JAVA_OPTS="-Dorg.bouncycastle.fips.approved_only=true ${OPENSEARCH_JAVA_OPTS}"
+  if [[ "$OPENSEARCH_FIPS_MODE" == "true" ]]; then
+    echo "FIPS mode enabled, setting JVM options."
+    export OPENSEARCH_JAVA_OPTS="-Djava.security.properties=${OPENSEARCH_PATH_CONF}/fips_java.security ${OPENSEARCH_JAVA_OPTS}"
+    export OPENSEARCH_JAVA_OPTS="-Dorg.bouncycastle.fips.approved_only=true ${OPENSEARCH_JAVA_OPTS}"
+  fi
 fi
 
 OPENSEARCH_DISTRIBUTION_TYPE=${opensearch.distribution.type}

--- a/distribution/src/bin/opensearch-env.bat
+++ b/distribution/src/bin/opensearch-env.bat
@@ -40,9 +40,13 @@ if exist "%OPENSEARCH_HOME%\lib\bc-fips*.jar" (
     set "FOUND_BC_FIPS=true"
 )
 
-REM Enable only if value equals "true" (case-insensitive) AND BC-FIPS JAR is present
-if /I "%OPENSEARCH_FIPS_MODE%"=="true" (
-    if "%FOUND_BC_FIPS%"=="true" (
+REM BC-FIPS triggers a native load on init, so JDK 24+ requires
+REM --enable-native-access=ALL-UNNAMED whenever the jar is on the classpath,
+REM regardless of whether FIPS mode itself is enabled.
+if "%FOUND_BC_FIPS%"=="true" (
+    set "OPENSEARCH_JAVA_OPTS=--enable-native-access=ALL-UNNAMED %OPENSEARCH_JAVA_OPTS%"
+
+    if /I "%OPENSEARCH_FIPS_MODE%"=="true" (
         echo FIPS mode enabled, setting JVM options.
         set "OPENSEARCH_JAVA_OPTS=-Dorg.bouncycastle.fips.approved_only=true -Djava.security.properties=""%OPENSEARCH_PATH_CONF%\fips_java.security"" %OPENSEARCH_JAVA_OPTS%"
     )


### PR DESCRIPTION
### Description


Iteration of https://github.com/opensearch-project/OpenSearch/pull/21710

**Validation**

Before:

```console
root@default:/home/vagrant# sudo -u opensearch /usr/share/opensearch/bin/opensearch-keystore add opensearch.notifications.core.email.smtp.username
Enter value for opensearch.notifications.core.email.smtp.username: 
WARNING: A restricted method in java.lang.System has been called
WARNING: java.lang.System::load has been called by org.bouncycastle.crypto.fips.NativeLoader$1 in an unnamed module (file:/usr/share/wazuh-indexer/lib/bc-fips-2.1.2.jar)
WARNING: Use --enable-native-access=ALL-UNNAMED to avoid a warning for callers in this module
WARNING: Restricted methods will be blocked in a future release unless native access is enabled
root@default:/home/vagrant#
```

After:

```console
root@default:/home/vagrant# sudo -u opensearch /usr/share/opensearch/bin/opensearch-keystore add opensearch.notifications.core.email.smtp.username
Setting opensearch.notifications.core.email.smtp.username already exists. Overwrite? [y/N]y
Enter value for opensearch.notifications.core.email.smtp.username: 
root@default:/home/vagrant#
```


### Related Issues
Resolves #21640 

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
