### PR TITLE
Fix VSR Rotation verification for failures

### DIFF
--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/engine/ParquetIndexingEngine.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/engine/ParquetIndexingEngine.java
@@ -254,15 +254,15 @@ public class ParquetIndexingEngine implements IndexingExecutionEngine<ParquetDat
     @Override
     public Writer<ParquetDocumentInput> createWriter(WriterConfig config) {
         long mappingVersion = mappingVersionSupplier.get();
-        Schema schema = getOrBuildSchema(mappingVersion);
+        Schema schema = getOrBuildSchema();
         Path filePath = buildParquetFilePath(shardPath, config.writerGeneration(), null);
         return new ParquetWriter(
             filePath.toString(),
             config.writerGeneration(),
-            mappingVersion,
+            0L,
             dataFormat,
             schema,
-            () -> getOrBuildSchema(mappingVersionSupplier.get()),
+            this::getOrBuildSchema,
             bufferPool,
             indexSettings,
             threadPool,
@@ -330,13 +330,8 @@ public class ParquetIndexingEngine implements IndexingExecutionEngine<ParquetDat
         return null;
     }
 
-    private Schema getOrBuildSchema(long mappingVersion) {
-        if (cachedSchemaVersion == mappingVersion && cachedSchema != null) {
-            return cachedSchema;
-        }
-        cachedSchema = schemaSupplier.get();
-        cachedSchemaVersion = mappingVersion;
-        return cachedSchema;
+    private Schema getOrBuildSchema() {
+        return schemaSupplier.get();
     }
 
     @Override

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/ArrowSchemaBuilder.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/ArrowSchemaBuilder.java
@@ -41,10 +41,11 @@ public final class ArrowSchemaBuilder {
      * TODO - Get the mapping version while creating the schema
      */
     public static Schema getSchema(MapperService mapperService) {
+
         Objects.requireNonNull(mapperService, "MapperService cannot be null");
         List<Field> fields = new ArrayList<>();
         if (mapperService.documentMapper() != null) {
-            for (Mapper mapper : mapperService.documentMapper().mappers()) {
+            for (Mapper mapper : mapperService.documentMapperWithAutoCreate().getDocumentMapper().mappers()) {
                 if (isUnsupportedMetadataField(mapper)) {
                     logger.debug("Skipping unsupported metadata field: [{}] of type [{}]", mapper.name(), mapper.typeName());
                     continue;

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/vsr/VSRManager.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/vsr/VSRManager.java
@@ -9,6 +9,7 @@
 package org.opensearch.parquet.vsr;
 
 import org.apache.arrow.c.ArrowSchema;
+import java.util.stream.Collectors;
 import org.apache.arrow.vector.BigIntVector;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.Schema;
@@ -161,6 +162,14 @@ public class VSRManager implements AutoCloseable {
                 );
             }
             if (activeVSR.getVector(fieldType.name()) == null) {
+                logger.error(
+                    "[Gen: {}] VSR schema mismatch: field [{}] not in active VSR. VSR schema fields: {}",
+                    writerGeneration,
+                    fieldType.name(),
+                    activeVSR.getSchema().getFields().stream()
+                        .map(f -> f.getName())
+                        .collect(java.util.stream.Collectors.joining(", "))
+                );
                 throw new MismatchedInputException(
                     "Active VSR has no vector for field ["
                         + fieldType.name()
@@ -193,7 +202,7 @@ public class VSRManager implements AutoCloseable {
      *
      * @param newSchema the schema to reconcile against
      */
-    public void reconcileSchema(Schema newSchema) {
+    public boolean reconcileSchema(Schema newSchema) {
         ManagedVSR activeVSR = managedVSR.get();
         boolean changed = false;
         for (Field schemaField : newSchema.getFields()) {
@@ -205,7 +214,10 @@ public class VSRManager implements AutoCloseable {
         }
         if (changed) {
             vsrPool.updateSchema(activeVSR.getSchema());
+        } else {
+            logger.info("no changes in schema despite change in mapping version");
         }
+        return changed;
     }
 
     /**

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/vsr/VSRManager.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/vsr/VSRManager.java
@@ -70,7 +70,7 @@ public class VSRManager implements AutoCloseable {
     private final String vsrRotationThread;
     private final long writerGeneration;
     private volatile Future<?> pendingWrite;
-    private NativeParquetWriter writer;
+    private final NativeParquetWriter writer;
     private final int ROTATION_TIMEOUT = 120;
     private LongAdder rowCount = new LongAdder();
     private long acceptedRows = 0L;
@@ -131,8 +131,13 @@ public class VSRManager implements AutoCloseable {
      * @param doc the document input containing field-value pairs
      */
     public void addDocument(ParquetDocumentInput doc) throws IOException {
-        if (pendingWrite != null && pendingWrite.isDone() && pendingWrite.exceptionNow() != null) {
-            throw new IllegalStateException(pendingWrite.exceptionNow());
+        if (pendingWrite != null && pendingWrite.isDone()) {
+            Future.State state = pendingWrite.state();
+            if (state == Future.State.FAILED) {
+                throw new IllegalStateException(pendingWrite.exceptionNow());
+            } else if (state == Future.State.CANCELLED) {
+                throw new IllegalStateException("Background write was cancelled");
+            }
         }
         maybeRotateActiveVSR();
         // Re-check the rowId invariant so a single-format Parquet path is protected too.
@@ -375,5 +380,10 @@ public class VSRManager implements AutoCloseable {
      */
     public RowIdMapping getRowIdMapping() {
         return writer.getRowIdMapping();
+    }
+
+    /** Visible for testing — returns the pending background write future, or null. */
+    Future<?> getPendingWrite() {
+        return pendingWrite;
     }
 }

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/writer/ParquetWriter.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/writer/ParquetWriter.java
@@ -9,6 +9,9 @@
 package org.opensearch.parquet.writer;
 
 import org.apache.arrow.vector.types.pojo.Schema;
+import java.util.stream.Collectors;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.index.engine.dataformat.FileInfos;
 import org.opensearch.index.engine.dataformat.FlushInput;
@@ -45,13 +48,15 @@ import java.util.function.Supplier;
  */
 public class ParquetWriter implements Writer<ParquetDocumentInput> {
 
+    private static final Logger logger = LogManager.getLogger(ParquetWriter.class);
+
     private final String file;
     private final long writerGeneration;
     private final ParquetDataFormat dataFormat;
     private final VSRManager vsrManager;
     private final FormatChecksumStrategy checksumStrategy;
     private final Supplier<Schema> schemaSupplier;
-    private long mappingVersion;
+    private volatile long mappingVersion;
     private volatile WriterState state = WriterState.ACTIVE;
     private long acceptedRows = 0L;
 
@@ -190,10 +195,29 @@ public class ParquetWriter implements Writer<ParquetDocumentInput> {
     @Override
     public void updateMappingVersion(long newVersion) {
         if (newVersion > this.mappingVersion) {
+            logger.info(
+                "[Gen: {}] updateMappingVersion: advancing from {} to {}, will reconcile schema",
+                writerGeneration,
+                this.mappingVersion,
+                newVersion
+            );
             this.mappingVersion = newVersion;
-            // Reconcile the active VSR with the new mapping's schema so addDoc never has
-            // to add field vectors itself.
-            vsrManager.reconcileSchema(schemaSupplier.get());
+            Schema schema = schemaSupplier.get();
+            logger.info(
+                "[Gen: {}] updateMappingVersion: schema from supplier has {} fields: {}",
+                writerGeneration,
+                schema.getFields().size(),
+                schema.getFields().stream().map(f -> f.getName()).collect(java.util.stream.Collectors.joining(", "))
+            );
+            boolean updated = vsrManager.reconcileSchema(schema);
+            logger.info("updateMappingVersion: reconcileSchema returned updated={}", updated);
+        } else {
+            logger.info(
+                "[Gen: {}] updateMappingVersion: no-op, newVersion={} <= current mappingVersion={}",
+                writerGeneration,
+                newVersion,
+                this.mappingVersion
+            );
         }
     }
 

--- a/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/vsr/VSRManagerTests.java
+++ b/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/vsr/VSRManagerTests.java
@@ -32,6 +32,7 @@ import org.opensearch.threadpool.ThreadPool;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.Future;
 
 import static org.opensearch.parquet.engine.ParquetIndexingEngineTests.metadataFields;
 import static org.opensearch.parquet.engine.ParquetIndexingEngineTests.populateMetadataFields;
@@ -359,23 +360,35 @@ public class VSRManagerTests extends OpenSearchTestCase {
         // Reconcile once before any docs — the tag vector must persist across the VSR
         // rotation triggered by maxRowsPerVSR=1.
         manager.reconcileSchema(schemaWith("tag", new ArrowType.Utf8()));
+        {
+            ParquetDocumentInput doc1 = new ParquetDocumentInput();
+            populateMetadataFields(doc1);
+            doc1.setRowId(DocumentInput.ROW_ID_FIELD, 0L);
+            doc1.addField(valField, 1);
+            doc1.addField(tagField, "a");
+            manager.addDocument(doc1);
+        }
 
-        ParquetDocumentInput doc1 = new ParquetDocumentInput();
-        populateMetadataFields(doc1);
-        doc1.setRowId(DocumentInput.ROW_ID_FIELD, 0L);
-        doc1.addField(valField, 1);
-        doc1.addField(tagField, "a");
-        manager.addDocument(doc1);
+        {
+            ParquetDocumentInput doc2 = new ParquetDocumentInput();
+            populateMetadataFields(doc2);
+            doc2.setRowId(DocumentInput.ROW_ID_FIELD, 1L);
+            doc2.addField(valField, 2);
+            doc2.addField(tagField, "b");
+            manager.addDocument(doc2); // this would've triggerer the rotation
+        }
 
-        ParquetDocumentInput doc2 = new ParquetDocumentInput();
-        populateMetadataFields(doc2);
-        doc2.setRowId(DocumentInput.ROW_ID_FIELD, 1L);
-        doc2.addField(valField, 2);
-        doc2.addField(tagField, "b");
-        manager.addDocument(doc2);
+        {
+            ParquetDocumentInput doc3 = new ParquetDocumentInput();
+            populateMetadataFields(doc3);
+            doc3.setRowId(DocumentInput.ROW_ID_FIELD, 2L);
+            doc3.addField(valField, 3);
+            doc3.addField(tagField, "c");
+            manager.addDocument(doc3); // this would've triggerer the rotation
+        }
 
         ParquetFileMetadata metadata = manager.flush();
-        assertEquals(2, metadata.numRows());
+        assertEquals(3, metadata.numRows());
     }
 
     public void testReconcileSchemaAddsMultipleVectorsAtOnce() throws Exception {
@@ -497,4 +510,81 @@ public class VSRManagerTests extends OpenSearchTestCase {
         fields.addAll(metadataFields());
         manager.reconcileSchema(new Schema(fields));
     }
+
+    public void testAddDocumentAfterSuccessfulBackgroundWriteDoesNotThrow() throws Exception {
+        // Use a very low rotation threshold to trigger background writes frequently
+        List<Field> fields = new ArrayList<>();
+        fields.addAll(metadataFields());
+        fields.add(new Field("val", FieldType.nullable(new ArrowType.Int(32, true)), null));
+        schema = new Schema(fields);
+
+        String filePath = createTempDir().resolve("bg-write-success.parquet").toString();
+        int lowThreshold = randomIntBetween(2, 5);
+        VSRManager manager = new VSRManager(filePath, indexSettings, schema, bufferPool, lowThreshold, threadPool, 0L);
+
+        NumberFieldMapper.NumberFieldType valField = new NumberFieldMapper.NumberFieldType("val", NumberFieldMapper.NumberType.INTEGER);
+
+        // Run multiple rotation cycles — each cycle fills the VSR to threshold,
+        // triggers background write, waits for completion, then verifies next addDocument works
+        int cycles = randomIntBetween(3, 8);
+        int rowId = 0;
+        for (int cycle = 0; cycle < cycles; cycle++) {
+            for (int i = 0; i < lowThreshold; i++) {
+                ParquetDocumentInput doc = new ParquetDocumentInput();
+                populateMetadataFields(doc);
+                doc.addField(valField, rowId);
+                doc.setRowId(DocumentInput.ROW_ID_FIELD, rowId);
+                manager.addDocument(doc);
+                rowId++;
+            }
+
+            // Wait for background write to complete using assertBusy
+            assertBusy(() -> {
+                Future<?> f = manager.getPendingWrite();
+                assertTrue("Background write should complete", f == null || f.isDone());
+            });
+
+            // This addDocument must NOT throw — verifies the fix for the
+            // exceptionNow() bug on successfully completed futures
+            ParquetDocumentInput nextDoc = new ParquetDocumentInput();
+            populateMetadataFields(nextDoc);
+            nextDoc.addField(valField, rowId);
+            nextDoc.setRowId(DocumentInput.ROW_ID_FIELD, rowId);
+            manager.addDocument(nextDoc);
+            rowId++;
+        }
+
+        manager.flush();
+    }
+
+    public void testContinuousAddDocumentAcrossMultipleRotationsWithoutWaiting() throws Exception {
+        // Continuously add documents across many rotations without ever waiting for
+        // background writes — verifies no error when future is still running or not yet done
+        List<Field> fields = new ArrayList<>();
+        fields.addAll(metadataFields());
+        fields.add(new Field("val", FieldType.nullable(new ArrowType.Int(32, true)), null));
+        schema = new Schema(fields);
+
+        String filePath = createTempDir().resolve("continuous-add.parquet").toString();
+        int lowThreshold = randomIntBetween(2, 4);
+        int totalDocs = lowThreshold * randomIntBetween(5, 12);
+        VSRManager manager = new VSRManager(filePath, indexSettings, schema, bufferPool, lowThreshold, threadPool, 0L);
+
+        NumberFieldMapper.NumberFieldType valField = new NumberFieldMapper.NumberFieldType("val", NumberFieldMapper.NumberType.INTEGER);
+
+        // Add all docs in a tight loop — no waiting between rotations
+        for (int i = 0; i < totalDocs; i++) {
+            ParquetDocumentInput doc = new ParquetDocumentInput();
+            populateMetadataFields(doc);
+            doc.addField(valField, i);
+            doc.setRowId(DocumentInput.ROW_ID_FIELD, i);
+            manager.addDocument(doc);
+        }
+
+        // Flush at the end — must succeed regardless of pending write state
+        ParquetFileMetadata metadata = manager.flush();
+        assertNotNull(metadata);
+        assertEquals(totalDocs, metadata.numRows());
+    }
+
 }

--- a/server/src/main/java/org/opensearch/index/engine/DataFormatAwareEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/DataFormatAwareEngine.java
@@ -14,6 +14,7 @@ import org.apache.lucene.index.IndexCommit;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.ReferenceManager;
 import org.apache.lucene.store.AlreadyClosedException;
+import org.opensearch.cluster.ClusterStateListener;
 import org.opensearch.common.Booleans;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.SetOnce;
@@ -1810,6 +1811,7 @@ public class DataFormatAwareEngine implements Indexer {
                 }
                 IOUtils.close(indexingExecutionEngine, committer, translogManager);
                 closeReaders();
+
             } catch (Exception e) {
                 logger.warn("failed to close engine resources", e);
             } finally {
@@ -1850,7 +1852,7 @@ public class DataFormatAwareEngine implements Indexer {
     }
 
     private long currentMappingVersion() {
-        return engineConfig.getMapperService().getIndexSettings().getIndexMetadata().getMappingVersion();
+        return engineConfig.getMapperService().documentMapper().getVersion();
     }
 
     /**

--- a/server/src/main/java/org/opensearch/index/mapper/DocumentMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/DocumentMapper.java
@@ -90,12 +90,16 @@ public class DocumentMapper implements ToXContentFragment {
 
         private final Mapper.BuilderContext builderContext;
 
+        private final long newVersion;
+
         public Builder(RootObjectMapper.Builder builder, MapperService mapperService) {
             final Settings indexSettings = mapperService.getIndexSettings().getSettings();
             this.builderContext = new Mapper.BuilderContext(indexSettings, new ContentPath(1));
             this.rootObjectMapper = builder.build(builderContext);
 
             final DocumentMapper existingMapper = mapperService.documentMapper();
+            this.newVersion = existingMapper == null ? 1L : existingMapper.getVersion() + 1L;
+
             final Map<String, TypeParser> metadataMapperParsers = mapperService.mapperRegistry.getMetadataMapperParsers();
             for (Map.Entry<String, MetadataFieldMapper.TypeParser> entry : metadataMapperParsers.entrySet()) {
                 final String name = entry.getKey();
@@ -132,7 +136,7 @@ public class DocumentMapper implements ToXContentFragment {
                 metadataMappers.values().toArray(new MetadataFieldMapper[0]),
                 meta
             );
-            return new DocumentMapper(mapperService, mapping);
+            return new DocumentMapper(mapperService, mapping, newVersion);
         }
     }
 
@@ -152,7 +156,13 @@ public class DocumentMapper implements ToXContentFragment {
     private final MetadataFieldMapper[] deleteTombstoneMetadataFieldMappers;
     private final MetadataFieldMapper[] noopTombstoneMetadataFieldMappers;
 
+    private final long version;
+
     public DocumentMapper(MapperService mapperService, Mapping mapping) {
+        this(mapperService, mapping, 0L);
+    }
+
+    public DocumentMapper(MapperService mapperService, Mapping mapping, long version) {
         this.mapperService = mapperService;
         this.type = mapping.root().name();
         this.typeText = new Text(this.type);
@@ -192,6 +202,7 @@ public class DocumentMapper implements ToXContentFragment {
         this.noopTombstoneMetadataFieldMappers = Stream.of(mapping.metadataMappers)
             .filter(field -> noopTombstoneMetadataFields.contains(field.name()))
             .toArray(MetadataFieldMapper[]::new);
+        this.version = version;
     }
 
     public Mapping mapping() {
@@ -212,6 +223,10 @@ public class DocumentMapper implements ToXContentFragment {
 
     public CompressedXContent mappingSource() {
         return this.mappingSource;
+    }
+
+    public long getVersion() {
+        return this.version;
     }
 
     public RootObjectMapper root() {
@@ -323,7 +338,7 @@ public class DocumentMapper implements ToXContentFragment {
 
     public DocumentMapper merge(Mapping mapping, MergeReason reason) {
         Mapping merged = this.mapping.merge(mapping, reason);
-        return new DocumentMapper(mapperService, merged);
+        return new DocumentMapper(mapperService, merged, this.version + 1L);
     }
 
     public void validate(IndexSettings settings, boolean checkLimits) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Fix VSR Rotation verification for failures

### Related Issues
Resolves issue where for high doc ingestion, the vsr rotation fails due to exceptionNow returning an exception for even successfully completed future
Fixes past tests which didn't catch this due to moving the rotation on next doc rather than current doc

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
