### PR TITLE
Add search support for handling deleted documents

### DIFF
--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/LuceneFilterDelegationHandle.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/LuceneFilterDelegationHandle.java
@@ -21,6 +21,7 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.Weight;
+import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.FixedBitSet;
 import org.opensearch.analytics.spi.DelegatedExpression;
 import org.opensearch.analytics.spi.FilterDelegationHandle;
@@ -184,7 +185,8 @@ final class LuceneFilterDelegationHandle implements FilterDelegationHandle {
         try {
             Scorer scorer = weight.scorer(leaf);
             int collectorKey = nextCollectorKey.getAndIncrement();
-            scorersByCollectorKey.put(collectorKey, new ScorerHandle(scorer, minDoc, maxDoc));
+            Bits liveDocs = leaf.reader().getLiveDocs();
+            scorersByCollectorKey.put(collectorKey, new ScorerHandle(scorer, liveDocs, minDoc, maxDoc));
             LOGGER.debug(
                 "[scf] createCollector providerKey={} writerGeneration={} range=[{},{}) → collectorKey={}",
                 providerKey,
@@ -232,8 +234,13 @@ final class LuceneFilterDelegationHandle implements FilterDelegationHandle {
                         if (docId < scanFrom) {
                             docId = iterator.advance(scanFrom);
                         }
+
+                        Bits liveDocs = handle.liveDocs;
                         while (docId != DocIdSetIterator.NO_MORE_DOCS && docId < scanTo) {
-                            bits.set(docId - minDoc);
+                            if (liveDocs == null || liveDocs.get(docId) == true) {
+                                bits.set(docId - minDoc);
+                            }
+
                             docId = iterator.nextDoc();
                         }
                         handle.currentDoc = docId;
@@ -286,12 +293,14 @@ final class LuceneFilterDelegationHandle implements FilterDelegationHandle {
 
     private static final class ScorerHandle {
         final Scorer scorer;
+        final Bits liveDocs;
         final int partitionMinDoc;
         final int partitionMaxDoc;
         int currentDoc = -1;
 
-        ScorerHandle(Scorer scorer, int partitionMinDoc, int partitionMaxDoc) {
+        ScorerHandle(Scorer scorer, Bits liveDocs, int partitionMinDoc, int partitionMaxDoc) {
             this.scorer = scorer;
+            this.liveDocs = liveDocs;
             this.partitionMinDoc = partitionMinDoc;
             this.partitionMaxDoc = partitionMaxDoc;
         }

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchFilterRule.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchFilterRule.java
@@ -16,7 +16,11 @@ import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexInputRef;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexUtil;
+import org.apache.calcite.sql.SqlFunction;
+import org.apache.calcite.sql.SqlFunctionCategory;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.type.OperandTypes;
+import org.apache.calcite.sql.type.ReturnTypes;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.analytics.planner.CapabilityRegistry;
@@ -35,6 +39,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import static org.apache.calcite.sql.type.SqlTypeName.BOOLEAN;
+
 /**
  * Converts {@link Filter} → {@link OpenSearchFilter}.
  *
@@ -52,6 +58,27 @@ import java.util.Set;
 public class OpenSearchFilterRule extends RelOptRule {
 
     private static final Logger LOGGER = LogManager.getLogger(OpenSearchFilterRule.class);
+
+    private static final String LUCENE_BACKEND_NAME = "lucene";
+    private static final String LUCENE_DATA_FORMAT = "lucene";
+
+    /**
+     * SqlFunction whose getName() upper-cases to {@link ScalarFunction#MATCHALL}.
+     * Constructed inline at the only call site that materializes a synthetic
+     * match-all RexCall ({@link #injectLuceneLiveDocsClauseIfNeeded}). The Lucene-side
+     * {@code MatchAllSerializer} produces a {@code MatchAllQueryBuilder} from
+     * this RexCall; at execution time, that query's {@code Weight.scorer} iterator
+     * filters out soft-deleted documents — guaranteeing live-docs filtering even
+     * when no user predicate naturally targets Lucene.
+     */
+    private static final SqlFunction MATCH_ALL_OPERATOR = new SqlFunction(
+        "MATCHALL",
+        SqlKind.OTHER_FUNCTION,
+        ReturnTypes.BOOLEAN,
+        null,
+        OperandTypes.NILADIC,
+        SqlFunctionCategory.USER_DEFINED_FUNCTION
+    );
 
     private final PlannerContext context;
 
@@ -81,7 +108,19 @@ public class OpenSearchFilterRule extends RelOptRule {
         List<FieldStorageInfo> childFieldStorage = openSearchInput.getOutputFieldStorage();
 
         // Annotate every leaf predicate with viable backends.
-        RexNode annotatedCondition = annotateCondition(filter.getCondition(), childFieldStorage, childViableBackends);
+        RexNode annotatedUserCondition = annotateCondition(filter.getCondition(), childFieldStorage, childViableBackends);
+
+        // Inject a synthetic MATCHALL() leaf for hybrid Lucene+Parquet shards that have
+        // no naturally-Lucene predicate, so live-docs filtering still happens via
+        // Lucene's Weight.scorer iterator. Prepended before annotateCondition so the
+        // existing FULL_TEXT field-less path resolves it to viableBackends=["lucene"]
+        // without code duplication.
+        RexNode annotatedCondition = injectLuceneLiveDocsClauseIfNeeded(
+            annotatedUserCondition,
+            childViableBackends,
+            childFieldStorage,
+            filter.getCluster().getRexBuilder()
+        );
 
         // Compute operator-level viable backends: must be viable for child AND handle predicates
         List<String> viableBackends = computeFilterViableBackends(annotatedCondition, childViableBackends);
@@ -105,6 +144,66 @@ public class OpenSearchFilterRule extends RelOptRule {
                 viableBackends
             )
         );
+    }
+
+    // ---- Predicate annotation ----
+    private RexNode injectLuceneLiveDocsClauseIfNeeded(
+        RexNode annotatedCondition,
+        List<String> childViableBackends,
+        List<FieldStorageInfo> childFieldStorage,
+        org.apache.calcite.rex.RexBuilder rexBuilder
+    ) {
+        // Lucene Backend can be lucene or mock-lucene, so better get the name from registry for Match_ALL.
+        List<String> luceneBackends = getLuceneBackendName();
+        if (luceneBackends.isEmpty() == true) {
+            return annotatedCondition;
+        }
+
+        assert luceneBackends.size() == 1;
+        String luceneBackEndName = luceneBackends.get(0);
+
+        // Guard 1: Lucene is one of the configured data formats on this shard
+        // (i.e., at least one non-derived field carries Lucene as a storage format).
+        boolean luceneConfigured = false;
+        for (FieldStorageInfo info : childFieldStorage) {
+            if (info.isDerived()) continue;
+            if (info.getIndexFormats().contains(LUCENE_DATA_FORMAT) || info.getDocValueFormats().contains(LUCENE_DATA_FORMAT)) {
+                luceneConfigured = true;
+                break;
+            }
+        }
+        if (luceneConfigured == false) {
+            return annotatedCondition;
+        }
+
+        // Guard 2: every annotated leaf in the user's condition has viableBackends == [datafusion]
+        // (exactly DataFusion, no other backend). If any leaf includes Lucene (or anything else),
+        // skip — that leaf is already Lucene-eligible (or unrelated to the live-docs concern).
+        List<AnnotatedPredicate> leaves = new ArrayList<>();
+        collectAnnotatedPredicates(annotatedCondition, leaves);
+        if (leaves.isEmpty()) {
+            return annotatedCondition;
+        }
+        for (AnnotatedPredicate leaf : leaves) {
+            List<String> viable = leaf.getViableBackends();
+            if (viable.size() == 1 && luceneBackEndName.equals(viable.get(0))) {
+                return annotatedCondition;
+            }
+        }
+
+        // All guards passed — build the synthetic, pre-annotated MATCHALL leaf and AND-attach it.
+        RexNode matchAllCall = rexBuilder.makeCall(rexBuilder.getTypeFactory().createSqlType(BOOLEAN), MATCH_ALL_OPERATOR, List.of());
+        AnnotatedPredicate annotatedMatchAll = new AnnotatedPredicate(
+            matchAllCall.getType(),
+            matchAllCall,
+            List.of(luceneBackEndName),
+            context.nextAnnotationId()
+        );
+        return RexUtil.composeConjunction(rexBuilder, List.of(annotatedCondition, annotatedMatchAll));
+    }
+
+    private List<String> getLuceneBackendName() {
+        return context.getCapabilityRegistry().filterBackends(ScalarFunction.MATCHALL, FieldType.TEXT, LUCENE_BACKEND_NAME);
     }
 
     // ---- Predicate annotation ----

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/FilterRuleTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/FilterRuleTests.java
@@ -31,7 +31,11 @@ import org.opensearch.analytics.spi.AnalyticsSearchBackendPlugin;
 import org.opensearch.analytics.spi.BackendCapabilityProvider;
 import org.opensearch.analytics.spi.DelegationType;
 import org.opensearch.analytics.spi.EngineCapability;
+import org.opensearch.analytics.spi.FieldType;
+import org.opensearch.analytics.spi.FilterCapability;
+import org.opensearch.analytics.spi.ScalarFunction;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -387,6 +391,172 @@ public class FilterRuleTests extends BasePlannerRulesTests {
             }
         };
         return List.of(df, lucene);
+    }
+
+    // ---- Live-docs MATCHALL injection tests ----
+
+    /**
+     * Builds backends with delegation + MATCHALL registered on Lucene.
+     * Simulates composite (Parquet + Lucene) production configuration.
+     */
+    private List<AnalyticsSearchBackendPlugin> compositeDelegationBackends() {
+        MockDataFusionBackend df = new MockDataFusionBackend() {
+            @Override
+            protected Set<DelegationType> supportedDelegations() {
+                return Set.of(DelegationType.FILTER);
+            }
+        };
+        MockLuceneBackend lucene = new MockLuceneBackend() {
+            @Override
+            protected Set<DelegationType> acceptedDelegations() {
+                return Set.of(DelegationType.FILTER);
+            }
+
+            @Override
+            protected Set<FilterCapability> filterCapabilities() {
+                Set<FilterCapability> caps = new HashSet<>(super.filterCapabilities());
+                caps.add(
+                    new FilterCapability.FullText(
+                        ScalarFunction.MATCHALL,
+                        FieldType.TEXT,
+                        Set.of(MockLuceneBackend.LUCENE_DATA_FORMAT),
+                        Set.of()
+                    )
+                );
+                caps.add(
+                    new FilterCapability.FullText(
+                        ScalarFunction.MATCHALL,
+                        FieldType.KEYWORD,
+                        Set.of(MockLuceneBackend.LUCENE_DATA_FORMAT),
+                        Set.of()
+                    )
+                );
+                return caps;
+            }
+        };
+        return List.of(df, lucene);
+    }
+
+    // -- Composite format: Parquet + Lucene --
+
+    /**
+     * Composite shard with only Parquet-eligible predicates: MATCHALL should be injected
+     * so Lucene's scorer filters soft-deleted documents.
+     */
+    public void testCompositeFormat_parquetOnlyFilter_matchAllInjected() {
+        PlannerContext context = buildContext(
+            "parquet",
+            Map.of("status", Map.of("type", "integer", "index", true)),
+            compositeDelegationBackends()
+        );
+        RelOptTable table = mockTable("test_index", new String[] { "status" }, new SqlTypeName[] { SqlTypeName.INTEGER });
+        LogicalFilter filter = LogicalFilter.create(stubScan(table), makeEquals(0, SqlTypeName.INTEGER, 200));
+        RelNode result = unwrapExchange(runPlanner(filter, context));
+
+        assertTrue(result instanceof OpenSearchFilter);
+        RexNode condition = ((OpenSearchFilter) result).getCondition();
+        assertTrue("Expected AND with injected MATCHALL", condition instanceof RexCall);
+        assertEquals(SqlKind.AND, ((RexCall) condition).getKind());
+
+        boolean hasMatchAll = false;
+        for (RexNode operand : ((RexCall) condition).getOperands()) {
+            if (operand instanceof AnnotatedPredicate ap && ap.getOriginal().toString().contains("MATCHALL")) {
+                hasMatchAll = true;
+                assertEquals(List.of(MockLuceneBackend.NAME), ap.getViableBackends());
+            }
+        }
+        assertTrue("Synthetic MATCHALL should be present", hasMatchAll);
+    }
+
+    /**
+     * Composite shard with a Lucene-only predicate (full-text MATCH_PHRASE):
+     * no MATCHALL injection needed — the existing predicate's scorer already filters live docs.
+     */
+    public void testCompositeFormat_luceneOnlyFilter_noMatchAllInjected() {
+        PlannerContext context = buildContext(
+            "parquet",
+            Map.of("message", Map.of("type", "keyword", "index", true)),
+            compositeDelegationBackends()
+        );
+        RelOptTable table = mockTable("test_index", new String[] { "message" }, new SqlTypeName[] { SqlTypeName.VARCHAR });
+        LogicalFilter filter = LogicalFilter.create(
+            stubScan(table),
+            makeFullTextCall(fullTextSqlFunction("MATCH_PHRASE"), 0, "hello world")
+        );
+        RelNode result = unwrapExchange(runPlanner(filter, context));
+
+        assertTrue(result instanceof OpenSearchFilter);
+        RexNode condition = ((OpenSearchFilter) result).getCondition();
+        assertFalse("Should not inject MATCHALL when Lucene predicate already present", condition.toString().contains("MATCHALL"));
+    }
+
+    /**
+     * Composite shard with mixed predicates (Parquet integer filter AND Lucene full-text):
+     * no MATCHALL injection — the full-text predicate already ensures live-docs filtering.
+     */
+    public void testCompositeFormat_parquetAndLuceneFilter_noMatchAllInjected() {
+        PlannerContext context = buildContext(
+            "parquet",
+            Map.of("status", Map.of("type", "integer", "index", true), "message", Map.of("type", "keyword", "index", true)),
+            compositeDelegationBackends()
+        );
+        RelOptTable table = mockTable(
+            "test_index",
+            new String[] { "status", "message" },
+            new SqlTypeName[] { SqlTypeName.INTEGER, SqlTypeName.VARCHAR }
+        );
+        LogicalFilter filter = LogicalFilter.create(
+            stubScan(table),
+            makeAnd(makeEquals(0, SqlTypeName.INTEGER, 200), makeFullTextCall(fullTextSqlFunction("MATCH_PHRASE"), 1, "timeout error"))
+        );
+        RelNode result = unwrapExchange(runPlanner(filter, context));
+
+        assertTrue(result instanceof OpenSearchFilter);
+        RexNode condition = ((OpenSearchFilter) result).getCondition();
+        assertFalse("Should not inject MATCHALL when AND already contains Lucene predicate", condition.toString().contains("MATCHALL"));
+    }
+
+    // -- Parquet-only format --
+
+    /**
+     * Parquet-only shard (no Lucene index format on any field): no MATCHALL injection.
+     * Guard 1 prevents injection since no field has Lucene storage.
+     */
+    public void testParquetOnlyFormat_noMatchAllInjected() {
+        OpenSearchFilter result = runFilter(
+            "parquet",
+            Map.of("status", Map.of("type", "integer", "index", false, "doc_values", true)),
+            new String[] { "status" },
+            new SqlTypeName[] { SqlTypeName.INTEGER },
+            makeEquals(0, SqlTypeName.INTEGER, 200),
+            List.of(DATAFUSION),
+            Set.of(MockDataFusionBackend.NAME)
+        );
+
+        assertFalse("Parquet-only shard should not have MATCHALL", result.getCondition().toString().contains("MATCHALL"));
+    }
+
+    // -- Lucene-only format --
+
+    /**
+     * Lucene-only shard where the predicate is already Lucene-eligible:
+     * no MATCHALL needed since the predicate's scorer naturally handles live docs.
+     */
+    public void testLuceneOnlyFormat_noMatchAllInjected() {
+        PlannerContext context = buildContext(
+            "parquet",
+            Map.of("tag", Map.of("type", "keyword", "index", true)),
+            compositeDelegationBackends()
+        );
+        RelOptTable table = mockTable("test_index", new String[] { "tag" }, new SqlTypeName[] { SqlTypeName.VARCHAR });
+        LogicalFilter filter = LogicalFilter.create(stubScan(table), makeFullTextCall(fullTextSqlFunction("MATCH"), 0, "hello"));
+        RelNode result = unwrapExchange(runPlanner(filter, context));
+
+        assertTrue(result instanceof OpenSearchFilter);
+        assertFalse(
+            "Lucene-only predicate should not trigger MATCHALL",
+            ((OpenSearchFilter) result).getCondition().toString().contains("MATCHALL")
+        );
     }
 
     public void testBackendWithFilterDelegationButNoFactory_throws() {


### PR DESCRIPTION
### Description
For a Composite format where one of the format is Lucene (or lucene only format), deleted documents are tracked by Lucene's `liveDocs` bitmap. When a query's filter contains at least one predicate naturally served by Lucene, that predicate's `Weight.scorer(...).iterator()` already excludes deletes — so deleted docs are filtered out.

When **every** predicate is Parquet-native (DataFusion drives the scan, no Lucene delegation occurs), there is no Lucene-produced bitset to AND with the row-group survivor mask. Parquet has no concept of soft-delete, so deleted documents leak into query results.

**The fix**: inject a synthetic Lucene-bound `MATCHALL()` annotation under a top-level AND so at least one Lucene `Weight.scorer` runs per row group, producing a live-docs bitset that gets ANDed into the survivor mask.
