### PR TITLE
[pull-based-ingestion] Pass IndexMetadata instead of only IngestionSource when initiating the shardConsumer

### DIFF
--- a/plugins/ingestion-fs/src/main/java/org/opensearch/plugin/ingestion/fs/FileConsumerFactory.java
+++ b/plugins/ingestion-fs/src/main/java/org/opensearch/plugin/ingestion/fs/FileConsumerFactory.java
@@ -8,7 +8,7 @@
 
 package org.opensearch.plugin.ingestion.fs;
 
-import org.opensearch.cluster.metadata.IngestionSource;
+import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.index.IngestionConsumerFactory;
 
 /**
@@ -22,8 +22,8 @@ public class FileConsumerFactory implements IngestionConsumerFactory<FilePartiti
     public FileConsumerFactory() {}
 
     @Override
-    public FilePartitionConsumer createShardConsumer(String clientId, int shardId, IngestionSource ingestionSource) {
-        FileSourceConfig localConfig = new FileSourceConfig(ingestionSource.params());
+    public FilePartitionConsumer createShardConsumer(String clientId, int shardId, IndexMetadata indexMetadata) {
+        FileSourceConfig localConfig = new FileSourceConfig(indexMetadata.getIngestionSource().params());
         return new FilePartitionConsumer(localConfig, shardId);
     }
 

--- a/plugins/ingestion-kafka/src/main/java/org/opensearch/plugin/kafka/KafkaConsumerFactory.java
+++ b/plugins/ingestion-kafka/src/main/java/org/opensearch/plugin/kafka/KafkaConsumerFactory.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.plugin.kafka;
 
+import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.metadata.IngestionSource;
 import org.opensearch.index.IngestionConsumerFactory;
 
@@ -22,7 +23,8 @@ public class KafkaConsumerFactory implements IngestionConsumerFactory<KafkaParti
     public KafkaConsumerFactory() {}
 
     @Override
-    public KafkaPartitionConsumer createShardConsumer(String clientId, int shardId, IngestionSource ingestionSource) {
+    public KafkaPartitionConsumer createShardConsumer(String clientId, int shardId, IndexMetadata indexMetadata) {
+        IngestionSource ingestionSource = indexMetadata.getIngestionSource();
         KafkaSourceConfig localConfig = new KafkaSourceConfig((int) ingestionSource.getMaxPollSize(), ingestionSource.params());
         return new KafkaPartitionConsumer(clientId, localConfig, shardId);
     }

--- a/plugins/ingestion-kafka/src/test/java/org/opensearch/plugin/kafka/KafkaConsumerFactoryTests.java
+++ b/plugins/ingestion-kafka/src/test/java/org/opensearch/plugin/kafka/KafkaConsumerFactoryTests.java
@@ -8,13 +8,14 @@
 
 package org.opensearch.plugin.kafka;
 
+import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.test.OpenSearchTestCase;
 import org.junit.Assert;
 
 public class KafkaConsumerFactoryTests extends OpenSearchTestCase {
     public void testCreateShardConsumerWithNullSource() {
         KafkaConsumerFactory factory = new KafkaConsumerFactory();
-        expectThrows(NullPointerException.class, () -> factory.createShardConsumer("test-client", 0, null));
+        expectThrows(NullPointerException.class, () -> factory.createShardConsumer("test-client", 0, (IndexMetadata) null));
     }
 
     public void testParsePointerFromString() {

--- a/plugins/ingestion-kafka/src/test/java/org/opensearch/plugin/kafka/KafkaConsumerFactoryTests.java
+++ b/plugins/ingestion-kafka/src/test/java/org/opensearch/plugin/kafka/KafkaConsumerFactoryTests.java
@@ -13,7 +13,7 @@ import org.opensearch.test.OpenSearchTestCase;
 import org.junit.Assert;
 
 public class KafkaConsumerFactoryTests extends OpenSearchTestCase {
-    public void testCreateShardConsumerWithNullSource() {
+    public void testCreateShardConsumerWithNullMetadata() {
         KafkaConsumerFactory factory = new KafkaConsumerFactory();
         expectThrows(NullPointerException.class, () -> factory.createShardConsumer("test-client", 0, (IndexMetadata) null));
     }

--- a/plugins/ingestion-kinesis/src/main/java/org/opensearch/plugin/kinesis/KinesisConsumerFactory.java
+++ b/plugins/ingestion-kinesis/src/main/java/org/opensearch/plugin/kinesis/KinesisConsumerFactory.java
@@ -8,7 +8,7 @@
 
 package org.opensearch.plugin.kinesis;
 
-import org.opensearch.cluster.metadata.IngestionSource;
+import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.index.IngestionConsumerFactory;
 
 /**
@@ -22,8 +22,8 @@ public class KinesisConsumerFactory implements IngestionConsumerFactory<KinesisS
     public KinesisConsumerFactory() {}
 
     @Override
-    public KinesisShardConsumer createShardConsumer(String clientId, int shardId, IngestionSource ingestionSource) {
-        KinesisSourceConfig localConfig = new KinesisSourceConfig(ingestionSource.params());
+    public KinesisShardConsumer createShardConsumer(String clientId, int shardId, IndexMetadata indexMetadata) {
+        KinesisSourceConfig localConfig = new KinesisSourceConfig(indexMetadata.getIngestionSource().params());
         return new KinesisShardConsumer(clientId, localConfig, shardId);
     }
 

--- a/plugins/ingestion-kinesis/src/test/java/org/opensearch/plugin/kinesis/KinesisConsumerFactoryTests.java
+++ b/plugins/ingestion-kinesis/src/test/java/org/opensearch/plugin/kinesis/KinesisConsumerFactoryTests.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.plugin.kinesis;
 
+import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.test.OpenSearchTestCase;
 import org.junit.Assert;
 
@@ -19,7 +20,7 @@ public class KinesisConsumerFactoryTests extends OpenSearchTestCase {
 
     public void testCreateShardConsumerWithNullSource() {
         KinesisConsumerFactory factory = new KinesisConsumerFactory();
-        expectThrows(NullPointerException.class, () -> factory.createShardConsumer("test-client", 0, null));
+        expectThrows(NullPointerException.class, () -> factory.createShardConsumer("test-client", 0, (IndexMetadata) null));
     }
 
     public void testParsePointerFromString() {

--- a/plugins/ingestion-kinesis/src/test/java/org/opensearch/plugin/kinesis/KinesisConsumerFactoryTests.java
+++ b/plugins/ingestion-kinesis/src/test/java/org/opensearch/plugin/kinesis/KinesisConsumerFactoryTests.java
@@ -18,7 +18,7 @@ public class KinesisConsumerFactoryTests extends OpenSearchTestCase {
         Assert.assertNotNull("Factory should be created", factory);
     }
 
-    public void testCreateShardConsumerWithNullSource() {
+    public void testCreateShardConsumerWithNullMetadata() {
         KinesisConsumerFactory factory = new KinesisConsumerFactory();
         expectThrows(NullPointerException.class, () -> factory.createShardConsumer("test-client", 0, (IndexMetadata) null));
     }

--- a/server/src/main/java/org/opensearch/index/IngestionConsumerFactory.java
+++ b/server/src/main/java/org/opensearch/index/IngestionConsumerFactory.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.index;
 
+import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.metadata.IngestionSource;
 import org.opensearch.common.annotation.PublicApi;
 
@@ -23,12 +24,12 @@ public interface IngestionConsumerFactory<T extends IngestionShardConsumer, P ex
      * Initialize the factory with the configuration parameters.
      *
      * @param ingestionSource the ingestion source with configuration parameters to initialize the factory
-     * @deprecated Implement {@link #createShardConsumer(String, int, IngestionSource)} instead, which receives
-     * the ingestion source directly and requires no separate initialization step.
+     * @deprecated Implement {@link #createShardConsumer(String, int, IndexMetadata)} instead, which receives
+     * the index metadata directly and requires no separate initialization step.
      */
     @Deprecated(forRemoval = true)
     default void initialize(IngestionSource ingestionSource) {
-        // no-op: implementations should override createShardConsumer(String, int, IngestionSource) instead
+        // no-op: implementations should override createShardConsumer(String, int, IndexMetadata) instead
     }
 
     /**
@@ -37,12 +38,12 @@ public interface IngestionConsumerFactory<T extends IngestionShardConsumer, P ex
      * @param clientId the client id assigned to the consumer
      * @param shardId the id of the shard
      * @return the created consumer
-     * @deprecated Use {@link #createShardConsumer(String, int, IngestionSource)} instead.
+     * @deprecated Use {@link #createShardConsumer(String, int, IndexMetadata)} instead.
      */
     @Deprecated(forRemoval = true)
     default T createShardConsumer(String clientId, int shardId) {
         throw new UnsupportedOperationException(
-            "Implement createShardConsumer(String, int, IngestionSource) instead of the deprecated two-step API."
+            "Implement createShardConsumer(String, int, IndexMetadata) instead of the deprecated two-step API."
         );
     }
 
@@ -55,21 +56,21 @@ public interface IngestionConsumerFactory<T extends IngestionShardConsumer, P ex
     P parsePointerFromString(String pointer);
 
     /**
-     * Create a consumer to ingest messages from a shard of the streams, using the provided ingestion source directly.
+     * Create a consumer to ingest messages from a shard of the streams, using the provided index metadata directly.
      * Implementations should override this method rather than the deprecated
      * {@link #initialize(IngestionSource)} and {@link #createShardConsumer(String, int)} pair.
      * <p>
      * The default implementation delegates to the deprecated two-step pair for backward compatibility
      * with existing implementations that override {@link #initialize(IngestionSource)}.
      *
-     * @param clientId        the client id assigned to the consumer
-     * @param shardId         the id of the shard
-     * @param ingestionSource the ingestion source configuration
+     * @param clientId      the client id assigned to the consumer
+     * @param shardId       the id of the shard
+     * @param indexMetadata the index metadata containing the ingestion source configuration
      * @return the created consumer
      */
     @SuppressWarnings("deprecation")
-    default T createShardConsumer(String clientId, int shardId, IngestionSource ingestionSource) {
-        initialize(ingestionSource);
+    default T createShardConsumer(String clientId, int shardId, IndexMetadata indexMetadata) {
+        initialize(indexMetadata.getIngestionSource());
         return createShardConsumer(clientId, shardId);
     }
 }

--- a/server/src/main/java/org/opensearch/index/IngestionConsumerFactory.java
+++ b/server/src/main/java/org/opensearch/index/IngestionConsumerFactory.java
@@ -56,6 +56,25 @@ public interface IngestionConsumerFactory<T extends IngestionShardConsumer, P ex
     P parsePointerFromString(String pointer);
 
     /**
+     * Create a consumer to ingest messages from a shard of the streams, using the provided ingestion source directly.
+     * Implementations should override this method rather than the deprecated
+     * {@link #initialize(IngestionSource)} and {@link #createShardConsumer(String, int)} pair.
+     * <p>
+     * The default implementation delegates to the deprecated two-step pair for backward compatibility
+     * with existing implementations that override {@link #initialize(IngestionSource)}.
+     *
+     * @param clientId        the client id assigned to the consumer
+     * @param shardId         the id of the shard
+     * @param ingestionSource the ingestion source configuration
+     * @return the created consumer
+     */
+    @Deprecated(forRemoval = true)
+    default T createShardConsumer(String clientId, int shardId, IngestionSource ingestionSource) {
+        initialize(ingestionSource);
+        return createShardConsumer(clientId, shardId);
+    }
+
+    /**
      * Create a consumer to ingest messages from a shard of the streams, using the provided index metadata directly.
      * Implementations should override this method rather than the deprecated
      * {@link #initialize(IngestionSource)} and {@link #createShardConsumer(String, int)} pair.

--- a/server/src/main/java/org/opensearch/index/IngestionConsumerFactory.java
+++ b/server/src/main/java/org/opensearch/index/IngestionConsumerFactory.java
@@ -89,7 +89,6 @@ public interface IngestionConsumerFactory<T extends IngestionShardConsumer, P ex
      */
     @SuppressWarnings("deprecation")
     default T createShardConsumer(String clientId, int shardId, IndexMetadata indexMetadata) {
-        initialize(indexMetadata.getIngestionSource());
-        return createShardConsumer(clientId, shardId);
+        return createShardConsumer(clientId, shardId, indexMetadata.getIngestionSource());
     }
 }

--- a/server/src/main/java/org/opensearch/index/engine/IngestionEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/IngestionEngine.java
@@ -158,7 +158,7 @@ public class IngestionEngine extends InternalEngine {
             .mapperSettings(ingestionSource.getMapperSettings())
             .pipelineExecutor(pipelineExecutor)
             .warmupConfig(ingestionSource.getWarmupConfig())
-            .ingestionSource(ingestionSource)
+            .indexMetadata(indexMetadata)
             .build();
         registerStreamPollerListener();
 
@@ -570,13 +570,13 @@ public class IngestionEngine extends InternalEngine {
 
         logger.info("Ingestion source params updated, reinitializing consumer");
 
-        // Get current ingestion source with updated params from index metadata
+        // Get current index metadata with updated ingestion source params
         IndexMetadata indexMetadata = engineConfig.getIndexSettings().getIndexMetadata();
         assert indexMetadata != null;
-        IngestionSource updatedIngestionSource = Objects.requireNonNull(indexMetadata.getIngestionSource());
+        assert indexMetadata.getIngestionSource() != null;
 
         // Request consumer reinitialization in the poller
-        streamPoller.requestConsumerReinitialization(updatedIngestionSource);
+        streamPoller.requestConsumerReinitialization(indexMetadata);
         logger.info("Successfully processed ingestion source params update");
     }
 

--- a/server/src/main/java/org/opensearch/indices/pollingingest/DefaultStreamPoller.java
+++ b/server/src/main/java/org/opensearch/indices/pollingingest/DefaultStreamPoller.java
@@ -13,6 +13,7 @@ import org.apache.logging.log4j.Logger;
 import org.opensearch.cluster.ClusterChangedEvent;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.block.ClusterBlockLevel;
+import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.metadata.IngestionSource;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.metrics.CounterMetric;
@@ -58,8 +59,8 @@ public class DefaultStreamPoller implements StreamPoller {
     // flag to indicate if consumer needs to be reinitialized
     private volatile boolean reinitializeConsumer;
 
-    // the ingestion source used to create the consumer; updated on settings changes
-    private volatile IngestionSource currentIngestionSource;
+    // the index metadata used to create the consumer; updated on settings changes
+    private volatile IndexMetadata currentIndexMetadata;
 
     private volatile long lastPolledMessageTimestamp = 0;
     private volatile long cachedPointerBasedLag = -1; // -1 indicates poller has not consumed any message yet
@@ -122,7 +123,7 @@ public class DefaultStreamPoller implements StreamPoller {
         Map<String, Object> mapperSettings,
         IngestPipelineExecutor pipelineExecutor,
         IngestionSource.WarmupConfig warmupConfig,
-        IngestionSource ingestionSource
+        IndexMetadata indexMetadata
     ) {
         this(
             startPointer,
@@ -147,7 +148,7 @@ public class DefaultStreamPoller implements StreamPoller {
             ingestionEngine.config().getIndexSettings(),
             IngestionMessageMapper.create(mapperType.getName(), shardId, mapperSettings),
             warmupConfig,
-            ingestionSource
+            indexMetadata
         );
     }
 
@@ -170,7 +171,7 @@ public class DefaultStreamPoller implements StreamPoller {
         IndexSettings indexSettings,
         IngestionMessageMapper messageMapper,
         IngestionSource.WarmupConfig warmupConfig,
-        IngestionSource ingestionSource
+        IndexMetadata indexMetadata
     ) {
         this.consumerFactory = Objects.requireNonNull(consumerFactory);
         this.consumerClientId = Objects.requireNonNull(consumerClientId);
@@ -190,7 +191,7 @@ public class DefaultStreamPoller implements StreamPoller {
         this.indexName = indexSettings.getIndex().getName();
         this.messageMapper = Objects.requireNonNull(messageMapper);
         this.warmupConfig = Objects.requireNonNull(warmupConfig);
-        this.currentIngestionSource = Objects.requireNonNull(ingestionSource);
+        this.currentIndexMetadata = Objects.requireNonNull(indexMetadata);
 
         // handle initial poller states
         this.paused = initialState == State.PAUSED;
@@ -627,17 +628,17 @@ public class DefaultStreamPoller implements StreamPoller {
 
     /**
      * Mark the poller's consumer for reinitialization. A new consumer will be initialized and start consuming from the
-     * latest batchStartPointer using the updated ingestion source.
-     * @param updatedIngestionSource the updated ingestion source with new configuration parameters
+     * latest batchStartPointer using the updated index metadata.
+     * @param updatedIndexMetadata the updated index metadata with new configuration parameters
      */
     @Override
-    public synchronized void requestConsumerReinitialization(IngestionSource updatedIngestionSource) {
+    public synchronized void requestConsumerReinitialization(IndexMetadata updatedIndexMetadata) {
         if (closed) {
             logger.warn("Cannot reinitialize consumer for closed poller of shard {}", shardId);
             return;
         }
 
-        this.currentIngestionSource = updatedIngestionSource;
+        this.currentIndexMetadata = updatedIndexMetadata;
         logger.info("Configuration parameters updated for index {} shard {}, requesting consumer reinitialization", indexName, shardId);
         reinitializeConsumer = true;
     }
@@ -728,7 +729,7 @@ public class DefaultStreamPoller implements StreamPoller {
     private synchronized void initializeConsumer() {
         try {
             reinitializeConsumer = false;
-            this.consumer = consumerFactory.createShardConsumer(consumerClientId, shardId, currentIngestionSource);
+            this.consumer = consumerFactory.createShardConsumer(consumerClientId, shardId, currentIndexMetadata);
             logger.info("Successfully initialized consumer for shard {}", shardId);
         } catch (Exception e) {
             logger.warn("Failed to create consumer for shard {}: {}", shardId, e.getMessage());
@@ -779,7 +780,7 @@ public class DefaultStreamPoller implements StreamPoller {
         private IngestPipelineExecutor pipelineExecutor;
         // Warmup configuration - default matches IndexMetadata settings
         private IngestionSource.WarmupConfig warmupConfig = new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(-1), 100L);
-        private IngestionSource ingestionSource;
+        private IndexMetadata indexMetadata;
 
         /**
          * Initialize the builder with mandatory parameters
@@ -904,10 +905,10 @@ public class DefaultStreamPoller implements StreamPoller {
         }
 
         /**
-         * Set the ingestion source used to create the consumer.
+         * Set the index metadata used to create the consumer.
          */
-        public Builder ingestionSource(IngestionSource ingestionSource) {
-            this.ingestionSource = Objects.requireNonNull(ingestionSource);
+        public Builder indexMetadata(IndexMetadata indexMetadata) {
+            this.indexMetadata = Objects.requireNonNull(indexMetadata);
             return this;
         }
 
@@ -934,7 +935,7 @@ public class DefaultStreamPoller implements StreamPoller {
                 mapperSettings,
                 pipelineExecutor,
                 warmupConfig,
-                ingestionSource
+                indexMetadata
             );
         }
     }

--- a/server/src/main/java/org/opensearch/indices/pollingingest/StreamPoller.java
+++ b/server/src/main/java/org/opensearch/indices/pollingingest/StreamPoller.java
@@ -9,6 +9,7 @@
 package org.opensearch.indices.pollingingest;
 
 import org.opensearch.cluster.ClusterStateListener;
+import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.metadata.IngestionSource;
 import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.index.IngestionShardConsumer;
@@ -77,11 +78,11 @@ public interface StreamPoller extends Closeable, ClusterStateListener {
     IngestionShardConsumer getConsumer();
 
     /**
-     * Requests the poller to reinitialize the consumer with updated ingestion source configuration.
+     * Requests the poller to reinitialize the consumer with updated index metadata.
      * This is called when ingestion source params are dynamically updated.
-     * @param updatedIngestionSource the updated ingestion source with new configuration parameters
+     * @param updatedIndexMetadata the updated index metadata with new configuration parameters
      */
-    void requestConsumerReinitialization(IngestionSource updatedIngestionSource);
+    void requestConsumerReinitialization(IndexMetadata updatedIndexMetadata);
 
     /**
      * Updates the warmup configuration dynamically.

--- a/server/src/test/java/org/opensearch/index/engine/FakeIngestionSource.java
+++ b/server/src/test/java/org/opensearch/index/engine/FakeIngestionSource.java
@@ -11,7 +11,7 @@ package org.opensearch.index.engine;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.LongPoint;
 import org.apache.lucene.search.Query;
-import org.opensearch.cluster.metadata.IngestionSource;
+import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.index.IngestionConsumerFactory;
 import org.opensearch.index.IngestionShardConsumer;
 import org.opensearch.index.IngestionShardPointer;
@@ -37,7 +37,7 @@ public class FakeIngestionSource {
         }
 
         @Override
-        public FakeIngestionConsumer createShardConsumer(String clientId, int shardId, IngestionSource ingestionSource) {
+        public FakeIngestionConsumer createShardConsumer(String clientId, int shardId, IndexMetadata indexMetadata) {
             return new FakeIngestionConsumer(messages, shardId);
         }
 

--- a/server/src/test/java/org/opensearch/indices/pollingingest/DefaultStreamPollerTests.java
+++ b/server/src/test/java/org/opensearch/indices/pollingingest/DefaultStreamPollerTests.java
@@ -14,6 +14,7 @@ import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.block.ClusterBlock;
 import org.opensearch.cluster.block.ClusterBlockLevel;
 import org.opensearch.cluster.block.ClusterBlocks;
+import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.metadata.IngestionSource;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
@@ -69,6 +70,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
     private PartitionedBlockingQueueContainer partitionedBlockingQueueContainer;
     private IngestionEngine engine;
     private IndexSettings indexSettings;
+    private IndexMetadata indexMetadata;
 
     @Before
     public void setUp() throws Exception {
@@ -83,6 +85,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
         partitionedBlockingQueueContainer = new PartitionedBlockingQueueContainer(processorRunnable, 0);
         engine = mock(IngestionEngine.class);
         indexSettings = IndexSettingsModule.newIndexSettings("index", Settings.EMPTY);
+        indexMetadata = indexSettings.getIndexMetadata();
         poller = new DefaultStreamPoller(
             new FakeIngestionSource.FakeIngestionShardPointer(0),
             fakeConsumerFactory,
@@ -99,7 +102,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             indexSettings,
             new DefaultIngestionMessageMapper(),
             new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(-1), 0),
-            new IngestionSource.Builder("FAKE").build()
+            indexMetadata
         );
         partitionedBlockingQueueContainer.startProcessorThreads();
     }
@@ -175,7 +178,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             indexSettings,
             new DefaultIngestionMessageMapper(),
             new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(-1), 0),
-            new IngestionSource.Builder("FAKE").build()
+            indexMetadata
         );
         CountDownLatch latch = new CountDownLatch(2);
         doAnswer(invocation -> {
@@ -211,7 +214,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             indexSettings,
             new DefaultIngestionMessageMapper(),
             new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(-1), 0),
-            new IngestionSource.Builder("FAKE").build()
+            indexMetadata
         );
 
         // Set up latch to wait for 2 messages to be processed
@@ -255,7 +258,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             indexSettings,
             new DefaultIngestionMessageMapper(),
             new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(-1), 0),
-            new IngestionSource.Builder("FAKE").build()
+            indexMetadata
         );
         CountDownLatch latch = new CountDownLatch(1);
         doAnswer(invocation -> {
@@ -293,11 +296,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
     public void testDropErrorIngestionStrategy() throws TimeoutException, InterruptedException {
         messages.add("{\"_id\":\"3\",\"_source\":{\"name\":\"bob\", \"age\": 24}}".getBytes(StandardCharsets.UTF_8));
         messages.add("{\"_id\":\"4\",\"_source\":{\"name\":\"alice\", \"age\": 21}}".getBytes(StandardCharsets.UTF_8));
-        FakeIngestionSource.FakeIngestionConsumer fakeConsumer = fakeConsumerFactory.createShardConsumer(
-            "",
-            0,
-            new IngestionSource.Builder("FAKE").build()
-        );
+        FakeIngestionSource.FakeIngestionConsumer fakeConsumer = fakeConsumerFactory.createShardConsumer("", 0, indexMetadata);
         List<
             IngestionShardConsumer.ReadResult<
                 FakeIngestionSource.FakeIngestionShardPointer,
@@ -347,7 +346,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             indexSettings,
             new DefaultIngestionMessageMapper(),
             new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(-1), 0),
-            new IngestionSource.Builder("FAKE").build()
+            indexMetadata
         );
         poller.start();
         Thread.sleep(sleepTime);
@@ -363,11 +362,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
     public void testBlockErrorIngestionStrategy() throws TimeoutException, InterruptedException {
         messages.add("{\"_id\":\"3\",\"_source\":{\"name\":\"bob\", \"age\": 24}}".getBytes(StandardCharsets.UTF_8));
         messages.add("{\"_id\":\"4\",\"_source\":{\"name\":\"alice\", \"age\": 21}}".getBytes(StandardCharsets.UTF_8));
-        FakeIngestionSource.FakeIngestionConsumer fakeConsumer = fakeConsumerFactory.createShardConsumer(
-            "",
-            0,
-            new IngestionSource.Builder("FAKE").build()
-        );
+        FakeIngestionSource.FakeIngestionConsumer fakeConsumer = fakeConsumerFactory.createShardConsumer("", 0, indexMetadata);
         List<
             IngestionShardConsumer.ReadResult<
                 FakeIngestionSource.FakeIngestionShardPointer,
@@ -416,7 +411,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             indexSettings,
             new DefaultIngestionMessageMapper(),
             new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(-1), 0),
-            new IngestionSource.Builder("FAKE").build()
+            indexMetadata
         );
         poller.start();
         Thread.sleep(sleepTime);
@@ -455,7 +450,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             indexSettings,
             new DefaultIngestionMessageMapper(),
             new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(-1), 0),
-            new IngestionSource.Builder("FAKE").build()
+            indexMetadata
         );
         poller.start();
         Thread.sleep(sleepTime);
@@ -479,11 +474,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
     public void testPersistedBatchStartPointer() throws TimeoutException, InterruptedException {
         messages.add("{\"_id\":\"3\",\"_source\":{\"name\":\"bob\", \"age\": 24}}".getBytes(StandardCharsets.UTF_8));
         messages.add("{\"_id\":\"4\",\"_source\":{\"name\":\"alice\", \"age\": 21}}".getBytes(StandardCharsets.UTF_8));
-        FakeIngestionSource.FakeIngestionConsumer fakeConsumer = fakeConsumerFactory.createShardConsumer(
-            "",
-            0,
-            new IngestionSource.Builder("FAKE").build()
-        );
+        FakeIngestionSource.FakeIngestionConsumer fakeConsumer = fakeConsumerFactory.createShardConsumer("", 0, indexMetadata);
         List<
             IngestionShardConsumer.ReadResult<
                 FakeIngestionSource.FakeIngestionShardPointer,
@@ -534,7 +525,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             indexSettings,
             new DefaultIngestionMessageMapper(),
             new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(-1), 0),
-            new IngestionSource.Builder("FAKE").build()
+            indexMetadata
         );
         poller.start();
         Thread.sleep(sleepTime);
@@ -568,7 +559,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             indexSettings,
             new DefaultIngestionMessageMapper(),
             new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(-1), 0),
-            new IngestionSource.Builder("FAKE").build()
+            indexMetadata
         );
 
         blockingQueueContainer.add(createShardUpdateMessage(5, "1"));
@@ -641,13 +632,13 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             indexSettings,
             new DefaultIngestionMessageMapper(),
             new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(-1), 0),
-            new IngestionSource.Builder("FAKE").build()
+            indexMetadata
         );
 
         poller.start();
         assertBusy(() -> assertEquals(queuedPointer, poller.getBatchStartPointer()), 30, TimeUnit.SECONDS);
 
-        poller.requestConsumerReinitialization(new IngestionSource.Builder("FAKE").build());
+        poller.requestConsumerReinitialization(indexMetadata);
 
         assertBusy(() -> verify(reinitializedConsumer).readNext(eq(queuedPointer), eq(true), anyLong(), anyInt()), 30, TimeUnit.SECONDS);
         blockingQueueContainer.close();
@@ -716,7 +707,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             indexSettings,
             new DefaultIngestionMessageMapper(),
             new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(-1), 0),
-            new IngestionSource.Builder("FAKE").build()
+            indexMetadata
         );
 
         poller.start();
@@ -761,7 +752,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             indexSettings,
             new DefaultIngestionMessageMapper(),
             new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(-1), 0),
-            new IngestionSource.Builder("FAKE").build()
+            indexMetadata
         );
 
         // Start and wait for 2 messages to be processed
@@ -776,9 +767,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             return null;
         }).when(processor).process(any(), any());
 
-        // Create a mock ingestion source for reinitialization
-        IngestionSource mockIngestionSource = new IngestionSource.Builder("test").build();
-        poller.requestConsumerReinitialization(mockIngestionSource);
+        poller.requestConsumerReinitialization(indexMetadata);
 
         // Add a 3rd message
         messages.add("{\"_id\":\"3\",\"_source\":{\"name\":\"charlie\", \"age\": 30}}".getBytes(StandardCharsets.UTF_8));
@@ -819,7 +808,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             indexSettings,
             new DefaultIngestionMessageMapper(),
             new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(-1), 0),
-            new IngestionSource.Builder("FAKE").build()
+            indexMetadata
         );
 
         // Start poller
@@ -831,8 +820,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
 
         // Request consumer reinitialization and wait for it to complete before adding messages
         IngestionShardConsumer oldConsumer = poller.getConsumer();
-        IngestionSource mockIngestionSource = new IngestionSource.Builder("test").build();
-        poller.requestConsumerReinitialization(mockIngestionSource);
+        poller.requestConsumerReinitialization(indexMetadata);
 
         assertBusy(() -> {
             IngestionShardConsumer currentConsumer = poller.getConsumer();
@@ -872,7 +860,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             indexSettings,
             new DefaultIngestionMessageMapper(),
             new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(-1), 0),
-            new IngestionSource.Builder("FAKE").build()
+            indexMetadata
         );
 
         // When all queues return null and initialBatchStartPointer is null, getBatchStartPointer should return null
@@ -903,7 +891,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             indexSettings,
             new DefaultIngestionMessageMapper(),
             new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(-1), 0),
-            new IngestionSource.Builder("FAKE").build()
+            indexMetadata
         );
 
         // Warmup should be considered complete when disabled
@@ -930,7 +918,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             indexSettings,
             new DefaultIngestionMessageMapper(),
             new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(300000), 0),
-            new IngestionSource.Builder("FAKE").build()
+            indexMetadata
         );
 
         // Initially warmup is not complete
@@ -971,7 +959,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             indexSettings,
             new DefaultIngestionMessageMapper(),
             new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(500), 0),
-            new IngestionSource.Builder("FAKE").build()
+            indexMetadata
         );
 
         warmupPoller.start();
@@ -1001,7 +989,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             indexSettings,
             new DefaultIngestionMessageMapper(),
             new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(300000), 0),
-            new IngestionSource.Builder("FAKE").build()
+            indexMetadata
         );
 
         // Initial state should be NONE
@@ -1044,7 +1032,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             indexSettings,
             new DefaultIngestionMessageMapper(),
             new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(500), 0),
-            new IngestionSource.Builder("FAKE").build()
+            indexMetadata
         );
 
         warmupPoller.start();
@@ -1081,7 +1069,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             indexSettings,
             new DefaultIngestionMessageMapper(),
             new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(30000), 100),
-            new IngestionSource.Builder("FAKE").build()
+            indexMetadata
         );
 
         warmupPoller.start();
@@ -1112,7 +1100,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             indexSettings,
             new DefaultIngestionMessageMapper(),
             new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(-1), 0),
-            new IngestionSource.Builder("FAKE").build()
+            indexMetadata
         );
 
         // Should return immediately without blocking since warmup is disabled
@@ -1150,7 +1138,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             indexSettings,
             new DefaultIngestionMessageMapper(),
             new IngestionSource.WarmupConfig(TimeValue.timeValueMinutes(5), 100L),
-            new IngestionSource.Builder("FAKE").build()
+            indexMetadata
         );
 
         // Start the poller - it will be paused, so warmup should be skipped
@@ -1185,7 +1173,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             indexSettings,
             new DefaultIngestionMessageMapper(),
             enabledConfig,
-            new IngestionSource.Builder("FAKE").build()
+            indexMetadata
         );
 
         // Warmup should not be complete yet
@@ -1225,7 +1213,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             indexSettings,
             new DefaultIngestionMessageMapper(),
             new IngestionSource.WarmupConfig(TimeValue.timeValueMinutes(10), 100L),
-            new IngestionSource.Builder("FAKE").build()
+            indexMetadata
         );
 
         // Start the poller
@@ -1261,7 +1249,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             indexSettings,
             new DefaultIngestionMessageMapper(),
             initialConfig,
-            new IngestionSource.Builder("FAKE").build()
+            indexMetadata
         );
 
         // Warmup should not be complete yet
@@ -1296,7 +1284,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             indexSettings,
             new DefaultIngestionMessageMapper(),
             disabledConfig,
-            new IngestionSource.Builder("FAKE").build()
+            indexMetadata
         );
 
         // Warmup should be complete since it was disabled

--- a/server/src/test/java/org/opensearch/indices/pollingingest/DefaultStreamPollerTests.java
+++ b/server/src/test/java/org/opensearch/indices/pollingingest/DefaultStreamPollerTests.java
@@ -328,7 +328,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
         blockingQueueContainer.startProcessorThreads();
 
         IngestionConsumerFactory mockConsumerFactory = mock(IngestionConsumerFactory.class);
-        when(mockConsumerFactory.createShardConsumer(anyString(), anyInt(), any())).thenReturn(mockConsumer);
+        when(mockConsumerFactory.createShardConsumer(anyString(), anyInt(), (IndexMetadata) any())).thenReturn(mockConsumer);
 
         poller = new DefaultStreamPoller(
             new FakeIngestionSource.FakeIngestionShardPointer(0),
@@ -393,7 +393,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
         PartitionedBlockingQueueContainer blockingQueueContainer = new PartitionedBlockingQueueContainer(processorRunnable, 0);
         blockingQueueContainer.startProcessorThreads();
         IngestionConsumerFactory mockConsumerFactory = mock(IngestionConsumerFactory.class);
-        when(mockConsumerFactory.createShardConsumer(anyString(), anyInt(), any())).thenReturn(mockConsumer);
+        when(mockConsumerFactory.createShardConsumer(anyString(), anyInt(), (IndexMetadata) any())).thenReturn(mockConsumer);
 
         poller = new DefaultStreamPoller(
             new FakeIngestionSource.FakeIngestionShardPointer(0),
@@ -507,7 +507,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
 
         when(mockConsumer.readNext(anyLong(), anyInt())).thenReturn(readResultsBatch2).thenReturn(Collections.emptyList());
         IngestionConsumerFactory mockConsumerFactory = mock(IngestionConsumerFactory.class);
-        when(mockConsumerFactory.createShardConsumer(anyString(), anyInt(), any())).thenReturn(mockConsumer);
+        when(mockConsumerFactory.createShardConsumer(anyString(), anyInt(), (IndexMetadata) any())).thenReturn(mockConsumer);
 
         poller = new DefaultStreamPoller(
             new FakeIngestionSource.FakeIngestionShardPointer(0),
@@ -613,7 +613,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
         when(reinitializedConsumer.readNext(anyLong(), anyInt())).thenReturn(Collections.emptyList());
 
         IngestionConsumerFactory mockConsumerFactory = mock(IngestionConsumerFactory.class);
-        when(mockConsumerFactory.createShardConsumer(anyString(), anyInt(), any())).thenReturn(initialConsumer)
+        when(mockConsumerFactory.createShardConsumer(anyString(), anyInt(), (IndexMetadata) any())).thenReturn(initialConsumer)
             .thenReturn(reinitializedConsumer);
 
         poller = new DefaultStreamPoller(
@@ -686,7 +686,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
 
         // Create a mock consumer factory that fails on first call but succeeds on second call
         IngestionConsumerFactory mockConsumerFactory = mock(IngestionConsumerFactory.class);
-        when(mockConsumerFactory.createShardConsumer(anyString(), anyInt(), any())).thenThrow(
+        when(mockConsumerFactory.createShardConsumer(anyString(), anyInt(), (IndexMetadata) any())).thenThrow(
             new RuntimeException("Simulated consumer initialization failure")
         ).thenReturn(mockConsumer);
 
@@ -718,7 +718,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
         }, 30, TimeUnit.SECONDS);
 
         // Verify the consumer factory was called twice (once for failure, once for success)
-        verify(mockConsumerFactory, times(2)).createShardConsumer(anyString(), anyInt(), any());
+        verify(mockConsumerFactory, times(2)).createShardConsumer(anyString(), anyInt(), (IndexMetadata) any());
         assertNotNull(poller.getConsumer());
     }
 
@@ -939,7 +939,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
         // Create a mock consumer factory that always reports high lag
         IngestionConsumerFactory mockFactory = mock(IngestionConsumerFactory.class);
         IngestionShardConsumer mockConsumer = mock(IngestionShardConsumer.class);
-        when(mockFactory.createShardConsumer(anyString(), anyInt(), any())).thenReturn(mockConsumer);
+        when(mockFactory.createShardConsumer(anyString(), anyInt(), (IndexMetadata) any())).thenReturn(mockConsumer);
         when(mockConsumer.getPointerBasedLag(any())).thenReturn(1000L); // High lag
         when(mockConsumer.readNext(anyLong(), anyInt())).thenReturn(Collections.emptyList());
 
@@ -1012,7 +1012,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
         // Create a mock consumer factory that returns negative pointer-based lag (unsupported)
         IngestionConsumerFactory mockFactory = mock(IngestionConsumerFactory.class);
         IngestionShardConsumer mockConsumer = mock(IngestionShardConsumer.class);
-        when(mockFactory.createShardConsumer(anyString(), anyInt(), any())).thenReturn(mockConsumer);
+        when(mockFactory.createShardConsumer(anyString(), anyInt(), (IndexMetadata) any())).thenReturn(mockConsumer);
         when(mockConsumer.getPointerBasedLag(any())).thenReturn(-1L); // Negative means unsupported
         when(mockConsumer.readNext(anyLong(), anyInt())).thenReturn(Collections.emptyList());
 
@@ -1048,7 +1048,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
         // Create a mock consumer factory that reports lag slightly above threshold then drops to threshold
         IngestionConsumerFactory mockFactory = mock(IngestionConsumerFactory.class);
         IngestionShardConsumer mockConsumer = mock(IngestionShardConsumer.class);
-        when(mockFactory.createShardConsumer(anyString(), anyInt(), any())).thenReturn(mockConsumer);
+        when(mockFactory.createShardConsumer(anyString(), anyInt(), (IndexMetadata) any())).thenReturn(mockConsumer);
         // Return lag of 50 which is below threshold of 100
         when(mockConsumer.getPointerBasedLag(any())).thenReturn(50L);
         when(mockConsumer.readNext(anyLong(), anyInt())).thenReturn(Collections.emptyList());
@@ -1118,7 +1118,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
         // Create a poller with warmup enabled but starting in PAUSED state
         IngestionConsumerFactory mockFactory = mock(IngestionConsumerFactory.class);
         IngestionShardConsumer mockConsumer = mock(IngestionShardConsumer.class);
-        when(mockFactory.createShardConsumer(anyString(), anyInt(), any())).thenReturn(mockConsumer);
+        when(mockFactory.createShardConsumer(anyString(), anyInt(), (IndexMetadata) any())).thenReturn(mockConsumer);
         when(mockConsumer.getPointerBasedLag(any())).thenReturn(1000L);
         when(mockConsumer.readNext(anyLong(), anyInt())).thenReturn(Collections.emptyList());
 
@@ -1193,7 +1193,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
         // Create a mock consumer that always reports high lag so warmup never completes on its own
         IngestionConsumerFactory mockFactory = mock(IngestionConsumerFactory.class);
         IngestionShardConsumer mockConsumer = mock(IngestionShardConsumer.class);
-        when(mockFactory.createShardConsumer(anyString(), anyInt(), any())).thenReturn(mockConsumer);
+        when(mockFactory.createShardConsumer(anyString(), anyInt(), (IndexMetadata) any())).thenReturn(mockConsumer);
         when(mockConsumer.getPointerBasedLag(any())).thenReturn(1000L);
         when(mockConsumer.readNext(anyLong(), anyInt())).thenReturn(Collections.emptyList());
 


### PR DESCRIPTION


<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
IngestionSource only exposes a very limited set of index settings and sometimes the plugin might want to see more, for example:
1. We only pass in the current shardId but don't know the total number of shards, this requires plugin must have some pre-existing knowledge about sharding (like, kafka is sharded the same way as OS index)
2. The plugin might want to have access to the index mapping to apply correct transformation or filtering, when the input schema and index schema is not exactly aligned.


### Check List
- [x] Functionality includes testing.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
