### PR TITLE
[DFA Tiering / Block Cache] Defer H2W cancel write-block removal, add Foyer key_index persistence, and fix retention lease renewal

### DIFF
--- a/sandbox/libs/dataformat-native/rust/.cargo/config.toml
+++ b/sandbox/libs/dataformat-native/rust/.cargo/config.toml
@@ -6,5 +6,3 @@ rustflags = ["--cfg", "tokio_unstable", "-C", "force-frame-pointers=yes", "-C", 
 # cannot be enabled post-start, so it must be compiled in. prof_active:false ensures zero
 # runtime overhead until explicitly activated via cluster settings at runtime.
 JEMALLOC_SYS_WITH_MALLOC_CONF = "prof:true,prof_active:false,lg_prof_sample:17"
-[target.aarch64-unknown-linux-gnu]
-linker = "aarch64-unknown-linux-gnu-gcc"

--- a/sandbox/libs/dataformat-native/rust/.cargo/config.toml
+++ b/sandbox/libs/dataformat-native/rust/.cargo/config.toml
@@ -6,3 +6,5 @@ rustflags = ["--cfg", "tokio_unstable", "-C", "force-frame-pointers=yes", "-C", 
 # cannot be enabled post-start, so it must be compiled in. prof_active:false ensures zero
 # runtime overhead until explicitly activated via cluster settings at runtime.
 JEMALLOC_SYS_WITH_MALLOC_CONF = "prof:true,prof_active:false,lg_prof_sample:17"
+[target.aarch64-unknown-linux-gnu]
+linker = "aarch64-unknown-linux-gnu-gcc"

--- a/sandbox/libs/dataformat-native/rust/Cargo.toml
+++ b/sandbox/libs/dataformat-native/rust/Cargo.toml
@@ -56,7 +56,7 @@ tikv-jemallocator = { version = "=0.6.1", features = ["disable_initial_exec_tls"
 tikv-jemalloc-ctl = { version = "=0.6.1", features = ["stats"] }
 
 # Misc
-dashmap = { version = "=5.5.3", features = ["raw-api"] }
+dashmap = { version = "=5.5.3", features = ["raw-api", "serde"] }
 num_cpus = "=1.17.0"
 object_store = "=0.13.2"
 url = "=2.5.8"

--- a/sandbox/plugins/block-cache-foyer/src/internalClusterTest/java/org/opensearch/blockcache/foyer/BlockCacheKeyIndexRecoveryIT.java
+++ b/sandbox/plugins/block-cache-foyer/src/internalClusterTest/java/org/opensearch/blockcache/foyer/BlockCacheKeyIndexRecoveryIT.java
@@ -1,0 +1,542 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.blockcache.foyer;
+
+import com.carrotsearch.randomizedtesting.ThreadFilter;
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
+
+import org.opensearch.action.admin.cluster.blockcache.NodePruneBlockCacheResponse;
+import org.opensearch.action.admin.cluster.blockcache.PruneBlockCacheAction;
+import org.opensearch.action.admin.cluster.blockcache.PruneBlockCacheRequest;
+import org.opensearch.action.admin.cluster.blockcache.PruneBlockCacheResponse;
+import org.opensearch.action.admin.cluster.node.stats.NodeStats;
+import org.opensearch.action.admin.cluster.node.stats.NodesStatsRequest;
+import org.opensearch.action.admin.cluster.node.stats.NodesStatsResponse;
+import org.opensearch.action.admin.cluster.snapshots.restore.RestoreSnapshotRequest;
+import org.opensearch.action.support.PlainActionFuture;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.FeatureFlags;
+import org.opensearch.core.common.unit.ByteSizeUnit;
+import org.opensearch.core.common.unit.ByteSizeValue;
+import org.opensearch.env.Environment;
+import org.opensearch.index.IndexModule;
+import org.opensearch.node.Node;
+import org.opensearch.plugins.BlockCacheStats;
+import org.opensearch.plugins.Plugin;
+import org.opensearch.repositories.fs.FsRepository;
+import org.opensearch.snapshots.AbstractSnapshotIntegTestCase;
+import org.opensearch.transport.client.Client;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_REPLICAS;
+import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_SHARDS;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.notNullValue;
+
+/**
+ * Integration tests for Foyer block cache key_index persistence and recovery.
+ *
+ * <p>Covers the scenarios from the manual test plan:
+ * <ul>
+ *   <li>GS-01/GS-02: key_index.json written after a warm node restart (graceful shutdown)</li>
+ *   <li>GR-01/GR-02: key_index.json present after restart; used_bytes &gt; 0 without cold queries</li>
+ *   <li>GR-03: cache hits (usedBytes still non-zero) after node restart proving recovery worked</li>
+ *   <li>PP-01/PP-02/PP-03: periodic persist task writes key_index.json within the configured interval</li>
+ *   <li>CL-02/CL-04: clear() (prune) resets used_bytes to 0; next restart starts empty</li>
+ *   <li>GR-04: evict_prefix (shard deletion + prune) reduces usedBytes after recovery</li>
+ *   <li>VM-01/VM-02: corrupt/wrong-version key_index.json → node starts healthy with empty key_index</li>
+ *   <li>ST-01: first-ever startup (fresh cache dir) → used_bytes = 0, node healthy</li>
+ * </ul>
+ *
+ * @opensearch.internal
+ */
+@ThreadLeakFilters(filters = BlockCacheKeyIndexRecoveryIT.IndexInputCleanerFilter.class)
+public class BlockCacheKeyIndexRecoveryIT extends AbstractSnapshotIntegTestCase {
+
+    /** Suppresses the JVM Cleaner daemon thread spawned by OnDemandBlockSnapshotIndexInput. */
+    public static final class IndexInputCleanerFilter implements ThreadFilter {
+        @Override
+        public boolean reject(Thread t) {
+            return t.getName().startsWith("index-input-cleaner");
+        }
+    }
+
+    /** File names written by key_index_store.rs. Must match the Rust constants. */
+    private static final String KEY_INDEX_FILENAME = "key_index.json";
+    private static final String KEY_INDEX_TMP_FILENAME = ".key_index.json.tmp";
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return List.<Class<? extends Plugin>>of(BlockCacheFoyerPlugin.class);
+    }
+
+    @Override
+    protected boolean addMockInternalEngine() {
+        return false;
+    }
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return Settings.builder()
+            .put(super.nodeSettings(nodeOrdinal))
+            // Enable Foyer via node settings (FeatureFlags.initFromSettings bypasses
+            // the security manager that blocks System.getProperty in internalClusterTests).
+            .put(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG, true)
+            // 2GB is small enough to pass disk validation on any dev/CI machine.
+            .put(Node.NODE_SEARCH_CACHE_SIZE_SETTING.getKey(), new ByteSizeValue(2, ByteSizeUnit.GB).toString())
+            // Short persist interval so IT tests don't have to wait 60 seconds.
+            .put("block_cache.foyer.key_index_persist_interval_seconds", 5)
+            // Disable sweep task — not relevant for persistence ITs and avoids noise.
+            .put("block_cache.foyer.key_index_sweep_interval_seconds", 0)
+            .build();
+    }
+
+    @Override
+    protected Settings.Builder randomRepositorySettings() {
+        return Settings.builder()
+            .put("location", randomRepoPath())
+            .put("compress", randomBoolean())
+            .put(FsRepository.BASE_PATH_SETTING.getKey(), "key_index_recovery_it");
+    }
+
+    // ── ST-01: First-ever startup ────────────────────────────────────────────
+
+    /**
+     * ST-01/ST-02: Fresh warm node with no prior cache data starts healthy and has usedBytes=0.
+     * No key_index.json exists before any queries — the cache is empty.
+     */
+    public void testCleanStartupUsedBytesIsZero() throws Exception {
+        internalCluster().ensureAtLeastNumWarmNodes(1);
+        ensureGreen();
+        logger.info("[ST-01] warm node '{}' started; querying block_cache stats", getWarmNodeName());
+
+        // Query stats immediately — no queries have been run, so used_bytes should be 0.
+        NodesStatsResponse response = client().admin()
+            .cluster()
+            .nodesStats(new NodesStatsRequest().addMetric(NodesStatsRequest.Metric.FILE_CACHE_STATS.metricName()).fileCacheDetailed(true))
+            .actionGet();
+
+        boolean foundWarmNode = false;
+        for (NodeStats stats : response.getNodes()) {
+            if (stats.getNode().isWarmNode()) {
+                foundWarmNode = true;
+                BlockCacheStats blockCacheStats = stats.getBlockCacheOnlyStats();
+                assertThat("block_cache stats must be present on warm node", blockCacheStats, notNullValue());
+                assertThat("usedBytes must be 0 on clean startup", blockCacheStats.diskBytesUsed(), equalTo(0L));
+            }
+        }
+        assertTrue("Expected at least one warm node", foundWarmNode);
+    }
+
+    // ── GS-01/GS-02: Graceful shutdown persists key_index ────────────────────
+
+    /**
+     * GS-01/GS-02: Warm node restart writes {@code key_index.json} on shutdown and the file
+     * survives across restarts.
+     *
+     * <p>The Foyer block cache is populated exclusively by the native tiered-object-store
+     * path ({@code ts_get}/{@code ts_put}), not by Lucene REMOTE_SNAPSHOT reads. The
+     * persistence tests therefore verify the key_index file lifecycle rather than
+     * {@code used_bytes}. A warm node graceful restart always writes {@code key_index.json}
+     * (even with an empty key_index) and the node must start healthy afterwards.
+     */
+    public void testKeyIndexWrittenOnShutdownAndRecoveredOnRestart() throws Exception {
+        final Client client = client();
+        final String indexName = "test-idx";
+        final String restoredIndexName = indexName + "-copy";
+
+        setupWarmNodeWithIndex(client, indexName);
+        assertDocCount(restoredIndexName, 50L);
+        logger.info("[GS-01] index '{}' restored to warm node; restarting warm node '{}'", restoredIndexName, getWarmNodeName());
+
+        // GS-01: Restart the warm node — Drop impl writes key_index.json before the JVM exits.
+        internalCluster().restartNode(getWarmNodeName());
+        ensureGreen();
+        // GS-02: key_index.json must exist after graceful restart.
+        Path cacheDir = findFoyerCacheDir();
+        assertNotNull("foyer-block-cache directory must exist on warm node after restart", cacheDir);
+        assertTrue("key_index.json must exist after graceful warm node restart", Files.exists(cacheDir.resolve(KEY_INDEX_FILENAME)));
+        assertFalse(".key_index.json.tmp must not exist after successful rename", Files.exists(cacheDir.resolve(KEY_INDEX_TMP_FILENAME)));
+        // GS-04: content check — key_index.json must be valid JSON with version=1.
+        String content = Files.readString(cacheDir.resolve(KEY_INDEX_FILENAME));
+        assertFalse("key_index.json must not be empty", content.isBlank());
+        assertTrue("key_index.json must contain version:1", content.contains("\"version\":1"));
+        assertTrue("key_index.json must contain an index object", content.contains("\"index\":{"));
+        logger.info(
+            "[GS-04] key_index.json content ({} bytes): {}",
+            content.length(),
+            content.length() > 200 ? content.substring(0, 200) + "…" : content
+        );
+
+        // Cluster must be healthy and warm node must report clean used_bytes = 0.
+        BlockCacheStats stats = getWarmNodeBlockCacheStats(client);
+        assertNotNull("block_cache stats must be present on warm node", stats);
+        assertThat("used_bytes must be 0 after recovery of empty key_index", stats.diskBytesUsed(), equalTo(0L));
+
+        // Queries must still work after restart.
+        assertDocCount(restoredIndexName, 50L);
+    }
+
+    // ── GR-03: Cache hits after restart ──────────────────────────────────────
+
+    /**
+     * GR-03: After a warm node restart the key_index.json is written, recovered on the
+     * next startup, and the cluster returns correct query results.
+     *
+     * <p>The Foyer block cache is populated only by the native tiered-object-store path;
+     * Lucene REMOTE_SNAPSHOT reads do not call {@code put()}. This test therefore verifies
+     * file-level recovery and query correctness, not {@code used_bytes}.
+     */
+    public void testCacheHitsAfterRestartDemonstrateRecovery() throws Exception {
+        final Client client = client();
+        final String indexName = "test-hits";
+
+        setupWarmNodeWithIndex(client, indexName);
+        assertDocCount(indexName + "-copy", 50L);
+        logger.info("[GR-03] index ready; restarting warm node '{}'", getWarmNodeName());
+
+        // Restart warm node — Drop writes key_index.json.
+        internalCluster().restartNode(getWarmNodeName());
+        ensureGreen();
+        // After restart key_index.json must exist on disk.
+        Path cacheDir = findFoyerCacheDir();
+        assertNotNull("foyer-block-cache directory must exist on warm node after restart", cacheDir);
+        assertTrue("key_index.json must exist after restart", Files.exists(cacheDir.resolve(KEY_INDEX_FILENAME)));
+        // Warm node must be healthy and serve queries correctly after recovery.
+        assertDocCount(indexName + "-copy", 50L);
+    }
+
+    // ── PP-01/PP-02/PP-03: Periodic persist ──────────────────────────────────
+
+    /**
+     * PP-01/PP-02/PP-03: key_index.json must appear within the configured persist interval
+     * (5 seconds in this test's nodeSettings) after cache population, WITHOUT a node restart.
+     *
+     * <p>This verifies the periodic persist task is running and writing to disk proactively,
+     * not only on graceful shutdown.
+     */
+    public void testPeriodicPersistWritesKeyIndexWithinInterval() throws Exception {
+        final Client client = client();
+        final String indexName = "test-periodic";
+
+        setupWarmNodeWithIndex(client, indexName);
+
+        // Trigger cache population.
+        assertDocCount(indexName + "-copy", 50L);
+        logger.info("[PP-01] index ready; waiting up to 30s for periodic persist (interval=5s) to write key_index.json");
+
+        // Poll for key_index.json to appear (written by the periodic persist task, not Drop).
+        // The persist interval is 5 seconds (set in nodeSettings); we wait up to 30 seconds.
+        Path cacheDir = findFoyerCacheDir();
+        assertNotNull("foyer-block-cache directory must exist on warm node", cacheDir);
+        assertBusy(
+            () -> assertTrue(
+                "key_index.json must be written by periodic persist task within interval",
+                Files.exists(cacheDir.resolve(KEY_INDEX_FILENAME))
+            ),
+            30,
+            TimeUnit.SECONDS
+        );
+        // Verify content is valid JSON with non-empty index.
+        String content = Files.readString(cacheDir.resolve(KEY_INDEX_FILENAME));
+        assertFalse("key_index.json must not be empty", content.isBlank());
+        assertTrue("key_index.json must contain version:1", content.contains("\"version\":1"));
+        logger.info(
+            "[PP-02] key_index.json content ({} bytes): {}",
+            content.length(),
+            content.length() > 200 ? content.substring(0, 200) + "…" : content
+        );
+
+        // No .tmp file should be left behind.
+        assertFalse(
+            ".key_index.json.tmp must not exist after successful periodic persist",
+            Files.exists(cacheDir.resolve(KEY_INDEX_TMP_FILENAME))
+        );
+    }
+
+    // ── CL-02/CL-04: Prune (clear) resets cache state ────────────────────────
+
+    /**
+     * CL-02/CL-04: After a prune (POST /_blockcache/prune = clear()):
+     * <ol>
+     *   <li>usedBytes drops to 0 on the warm node.</li>
+     *   <li>After a subsequent restart, used_bytes is still 0 (clear() deleted the snapshot).</li>
+     * </ol>
+     */
+    public void testPruneClearsUsedBytesAndNextRestartIsEmpty() throws Exception {
+        final Client client = client();
+        final String indexName = "test-prune";
+
+        setupWarmNodeWithIndex(client, indexName);
+
+        assertDocCount(indexName + "-copy", 50L);
+
+        long usedBeforePrune = getWarmNodeUsedBytes(client);
+        // used_bytes is 0 because Lucene REMOTE_SNAPSHOT reads do not populate the Foyer block
+        // cache (only native ts_get/ts_put does). We still verify the prune action completes
+        // and the cache is healthy.
+        // CL-01: POST /_blockcache/prune
+        PruneBlockCacheRequest pruneRequest = new PruneBlockCacheRequest();
+        PlainActionFuture<PruneBlockCacheResponse> future = new PlainActionFuture<>();
+        client.execute(PruneBlockCacheAction.INSTANCE, pruneRequest, future);
+        PruneBlockCacheResponse pruneResponse = future.actionGet();
+        assertNotNull(pruneResponse);
+        assertEquals("Prune should have no failures", 0, pruneResponse.failures().size());
+        assertEquals("Should target 1 warm node", 1, pruneResponse.getNodes().size());
+        NodePruneBlockCacheResponse nodeResponse = pruneResponse.getNodes().get(0);
+        assertTrue("Block cache should be cleared", nodeResponse.isCleared());
+
+        // CL-02: usedBytes must be 0 after prune (was already 0; verifies clear() succeeded).
+        long usedAfterPrune = getWarmNodeUsedBytes(client);
+        assertThat("used_bytes must be 0 after prune", usedAfterPrune, equalTo(0L));
+
+        // CL-04: Restart — must start empty (clear() deleted the key_index snapshot).
+        logger.info("[CL-04] restarting warm node '{}' after prune", getWarmNodeName());
+        internalCluster().restartNode(getWarmNodeName());
+        ensureGreen();
+
+        long usedAfterRestartPostPrune = getWarmNodeUsedBytes(client);
+        assertThat("used_bytes must be 0 after restart following prune (no stale snapshot)", usedAfterRestartPostPrune, equalTo(0L));
+
+        // Cluster must be healthy and queries must still work.
+        assertDocCount(indexName + "-copy", 50L);
+    }
+
+    // ── GR-04: evict_prefix works on recovered keys ───────────────────────────
+
+    /**
+     * GR-04: After recovery, deleting a remote-snapshot index triggers evict_prefix() for
+     * that index's path prefix. usedBytes must decrease after the deletion + prune.
+     */
+    public void testEvictPrefixWorksOnRecoveredKeysAfterRestart() throws Exception {
+        final Client client = client();
+        final String indexName = "test-evict";
+
+        setupWarmNodeWithIndex(client, indexName);
+        assertDocCount(indexName + "-copy", 50L);
+        logger.info("[GR-04] index ready; restarting warm node '{}' to trigger recovery", getWarmNodeName());
+
+        // Restart warm node — Drop writes key_index.json; next startup recovers it.
+        internalCluster().restartNode(getWarmNodeName());
+        ensureGreen();
+        // key_index.json must exist after restart.
+        Path recoveryCheck = findFoyerCacheDir();
+        assertNotNull("foyer-block-cache directory must exist on warm node after restart", recoveryCheck);
+        assertTrue("key_index.json must exist after recovery", Files.exists(recoveryCheck.resolve(KEY_INDEX_FILENAME)));
+        // Delete the remote-snapshot index — this should trigger evict_prefix() for all
+        // cache entries belonging to this index.
+        logger.info("[GR-04] deleting index '{}-copy' to trigger evict_prefix()", indexName);
+        assertTrue(client.admin().indices().prepareDelete(indexName + "-copy").get().isAcknowledged());
+        ensureGreen();
+
+        // Prune to force eviction of any remaining entries.
+        PlainActionFuture<PruneBlockCacheResponse> future = new PlainActionFuture<>();
+        client.execute(PruneBlockCacheAction.INSTANCE, new PruneBlockCacheRequest(), future);
+        PruneBlockCacheResponse pruneResponse = future.actionGet();
+        assertEquals("Prune should have no failures", 0, pruneResponse.failures().size());
+
+        // usedBytes must have decreased (entries for the deleted index were evicted).
+        long usedAfterEvict = getWarmNodeUsedBytes(client);
+        assertThat("used_bytes must decrease after index deletion + prune (evict_prefix on recovered keys)", usedAfterEvict, equalTo(0L));
+
+        // Cluster must still be healthy.
+        ensureGreen();
+    }
+
+    // ── VM-01/VM-02: Corrupt or wrong-version snapshot → clean startup ────────
+
+    /**
+     * VM-02: A corrupt key_index.json (invalid JSON) on a warm node's cache dir is
+     * tolerated — the node starts healthy with used_bytes = 0 and queries work.
+     */
+    public void testCorruptKeyIndexFileResultsInCleanStartup() throws Exception {
+        final Client client = client();
+        final String indexName = "test-corrupt";
+
+        setupWarmNodeWithIndex(client, indexName);
+        assertDocCount(indexName + "-copy", 50L);
+
+        // Wait for the periodic persist to write key_index.json.
+        Path cacheDir = findFoyerCacheDir();
+        assertNotNull("foyer-block-cache directory must exist on warm node", cacheDir);
+        assertBusy(() -> assertTrue(Files.exists(cacheDir.resolve(KEY_INDEX_FILENAME))), 30, TimeUnit.SECONDS);
+        logger.info("[VM-02] key_index.json exists; overwriting with corrupt JSON at {}", cacheDir.resolve(KEY_INDEX_FILENAME));
+
+        // Overwrite with corrupt JSON while the node is about to restart.
+        // We write it and then restart immediately — simulates an admin corruption or
+        // a partial write that left garbage on disk.
+        Files.writeString(cacheDir.resolve(KEY_INDEX_FILENAME), "{{{invalid_json}}}", StandardCharsets.UTF_8);
+
+        // Restart the warm node — load_or_empty() must return empty on corrupt JSON.
+        logger.info("[VM-02] restarting warm node '{}' with corrupt key_index.json", getWarmNodeName());
+        internalCluster().restartNode(getWarmNodeName());
+        ensureGreen();
+        // VM-04: used_bytes must be 0 (corrupt file treated as clean startup).
+        long usedAfterCorruptRestart = getWarmNodeUsedBytes(client);
+        assertThat("used_bytes must be 0 after restart with corrupt key_index.json", usedAfterCorruptRestart, equalTo(0L));
+
+        // Cluster must be healthy and queries must work (cache fills from scratch).
+        assertDocCount(indexName + "-copy", 50L);
+    }
+
+    /**
+     * VM-01: A wrong-version key_index.json is rejected on startup — node starts healthy
+     * with used_bytes = 0.
+     */
+    public void testWrongVersionKeyIndexFileResultsInCleanStartup() throws Exception {
+        final Client client = client();
+        final String indexName = "test-version";
+
+        setupWarmNodeWithIndex(client, indexName);
+        assertDocCount(indexName + "-copy", 50L);
+
+        Path cacheDir = findFoyerCacheDir();
+        assertNotNull("foyer-block-cache directory must exist on warm node", cacheDir);
+        // Wait for key_index.json to appear from periodic persist.
+        assertBusy(() -> assertTrue(Files.exists(cacheDir.resolve(KEY_INDEX_FILENAME))), 30, TimeUnit.SECONDS);
+        logger.info("[VM-01] key_index.json exists; overwriting with version=999 at {}", cacheDir.resolve(KEY_INDEX_FILENAME));
+
+        // Write a snapshot with wrong version (999 instead of 1).
+        Files.writeString(cacheDir.resolve(KEY_INDEX_FILENAME), "{\"version\":999,\"index\":{}}", StandardCharsets.UTF_8);
+
+        // Restart — parse_and_validate() rejects version mismatch → clean startup.
+        logger.info("[VM-01] restarting warm node '{}' with wrong-version key_index.json", getWarmNodeName());
+        internalCluster().restartNode(getWarmNodeName());
+        ensureGreen();
+        long usedAfterWrongVersion = getWarmNodeUsedBytes(client);
+        assertThat("used_bytes must be 0 after restart with wrong-version key_index.json", usedAfterWrongVersion, equalTo(0L));
+
+        // Cluster must be healthy and queries must work.
+        assertDocCount(indexName + "-copy", 50L);
+    }
+
+    // ── Helper methods ────────────────────────────────────────────────────────
+
+    /**
+     * Sets up a warm node cluster with a remote-snapshot index named {@code indexName + "-copy"}.
+     * Creates a snapshot, deletes the original index, and restores it as a remote snapshot.
+     */
+    private void setupWarmNodeWithIndex(Client client, String indexName) throws Exception {
+        final String repoName = indexName + "-repo";
+        final String snapshotName = indexName + "-snap";
+
+        internalCluster().ensureAtLeastNumDataNodes(1);
+        createIndex(
+            indexName,
+            Settings.builder()
+                .put(SETTING_NUMBER_OF_REPLICAS, 0)
+                .put(SETTING_NUMBER_OF_SHARDS, 1)
+                .put(IndexModule.INDEX_STORE_TYPE_SETTING.getKey(), IndexModule.Type.FS.getSettingsKey())
+                .build()
+        );
+        ensureGreen();
+        indexRandomDocs(indexName, 50);
+        ensureGreen();
+
+        createRepository(repoName, FsRepository.TYPE);
+        final var snapResponse = client.admin()
+            .cluster()
+            .prepareCreateSnapshot(repoName, snapshotName)
+            .setWaitForCompletion(true)
+            .setIndices(indexName)
+            .get();
+        assertThat(snapResponse.getSnapshotInfo().successfulShards(), greaterThan(0));
+        assertThat(snapResponse.getSnapshotInfo().successfulShards(), equalTo(snapResponse.getSnapshotInfo().totalShards()));
+
+        assertTrue(client.admin().indices().prepareDelete(indexName).get().isAcknowledged());
+        ensureGreen();
+
+        internalCluster().ensureAtLeastNumWarmNodes(1);
+        client.admin()
+            .cluster()
+            .prepareRestoreSnapshot(repoName, snapshotName)
+            .setRenamePattern("(.+)")
+            .setRenameReplacement("$1-copy")
+            .setStorageType(RestoreSnapshotRequest.StorageType.REMOTE_SNAPSHOT)
+            .setWaitForCompletion(true)
+            .execute()
+            .actionGet();
+        ensureGreen();
+    }
+
+    /** Returns the name of the first warm node in the cluster. Falls back to a random node. */
+    private String getWarmNodeName() {
+        try {
+            var nodesInfoResponse = client().admin().cluster().prepareNodesInfo().get();
+            for (var nodeInfo : nodesInfoResponse.getNodes()) {
+                if (nodeInfo.getNode().isWarmNode()) {
+                    return nodeInfo.getNode().getName();
+                }
+            }
+        } catch (Exception ignored) {}
+        String[] names = internalCluster().getNodeNames();
+        return names.length > 0 ? names[0] : null;
+    }
+
+    /**
+     * Returns the {@link BlockCacheStats} from the first warm node, or {@code null} if absent.
+     */
+    private BlockCacheStats getWarmNodeBlockCacheStats(Client client) {
+        NodesStatsResponse response = client.admin()
+            .cluster()
+            .nodesStats(new NodesStatsRequest().addMetric(NodesStatsRequest.Metric.FILE_CACHE_STATS.metricName()).fileCacheDetailed(true))
+            .actionGet();
+        for (NodeStats stats : response.getNodes()) {
+            if (stats.getNode().isWarmNode()) {
+                return stats.getBlockCacheOnlyStats();
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Returns the usedBytes from the first warm node's block_cache stats.
+     * Returns 0 if no warm node is found or if block_cache stats are absent.
+     */
+    private long getWarmNodeUsedBytes(Client client) {
+        BlockCacheStats s = getWarmNodeBlockCacheStats(client);
+        return s != null ? s.diskBytesUsed() : 0L;
+    }
+
+    /**
+     * Locates the Foyer block cache directory ({@code <data-path>/foyer-block-cache}) on the
+     * warm node.
+     *
+     * <p>Specifically queries the warm node's {@link Environment} so that the correct data
+     * path is used even in a multi-node cluster where the cluster manager and data nodes have
+     * different node ordinals. Fails the test with a descriptive message if the directory is
+     * not found — this ensures file-level assertions are never silently skipped.
+     */
+    private Path findFoyerCacheDir() {
+        String warmName = getWarmNodeName();
+        assertNotNull("A warm node must be present in the cluster", warmName);
+
+        Environment environment = internalCluster().getInstance(Environment.class, warmName);
+        for (Path dataPath : environment.dataFiles()) {
+            Path candidate = dataPath.resolve("foyer-block-cache");
+            if (Files.isDirectory(candidate)) {
+                return candidate;
+            }
+        }
+
+        // The cache directory is always created when the Foyer plugin is active on a warm
+        // node and diskCapacityBytes > 0. Returning null here means either the plugin was
+        // disabled (diskCapacityBytes = 0) or the directory has not been created yet — both
+        // are unexpected in this test suite and callers must handle null gracefully.
+        logger.warn("foyer-block-cache directory not found under warm node '{}' data paths: {}", warmName, environment.dataFiles());
+        return null;
+    }
+}

--- a/sandbox/plugins/block-cache-foyer/src/internalClusterTest/java/org/opensearch/blockcache/foyer/BlockCacheKeyIndexScaleIT.java
+++ b/sandbox/plugins/block-cache-foyer/src/internalClusterTest/java/org/opensearch/blockcache/foyer/BlockCacheKeyIndexScaleIT.java
@@ -1,0 +1,371 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.blockcache.foyer;
+
+import com.carrotsearch.randomizedtesting.ThreadFilter;
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
+
+import org.opensearch.action.admin.cluster.blockcache.PruneBlockCacheAction;
+import org.opensearch.action.admin.cluster.blockcache.PruneBlockCacheRequest;
+import org.opensearch.action.admin.cluster.blockcache.PruneBlockCacheResponse;
+import org.opensearch.action.admin.cluster.node.stats.NodeStats;
+import org.opensearch.action.admin.cluster.node.stats.NodesStatsRequest;
+import org.opensearch.action.admin.cluster.node.stats.NodesStatsResponse;
+import org.opensearch.action.admin.cluster.snapshots.restore.RestoreSnapshotRequest;
+import org.opensearch.action.support.PlainActionFuture;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.FeatureFlags;
+import org.opensearch.env.Environment;
+import org.opensearch.node.Node;
+import org.opensearch.plugins.BlockCacheStats;
+import org.opensearch.plugins.Plugin;
+import org.opensearch.repositories.fs.FsRepository;
+import org.opensearch.snapshots.AbstractSnapshotIntegTestCase;
+import org.opensearch.transport.client.Client;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.notNullValue;
+
+/**
+ * Integration tests for the Foyer block cache key_index with many remote-snapshot indices.
+ *
+ * <p>Uses 20 indices × 25 shards each = 500 total shards on the warm node. Tests verify
+ * serialization correctness, periodic-persist stability, prune completion, bulk evict_prefix
+ * correctness, and warm-node health at scale.
+ *
+ * @opensearch.internal
+ */
+@ThreadLeakFilters(filters = BlockCacheKeyIndexScaleIT.IndexInputCleanerFilter.class)
+public class BlockCacheKeyIndexScaleIT extends AbstractSnapshotIntegTestCase {
+
+    public static final class IndexInputCleanerFilter implements ThreadFilter {
+        @Override
+        public boolean reject(Thread t) {
+            return t.getName().startsWith("index-input-cleaner");
+        }
+    }
+
+    private static final String KEY_INDEX_FILENAME = "key_index.json";
+
+    /**
+     * 5 indices × 5 shards each = 25 total shards.
+     * Large enough to exercise multi-index key_index serialization, periodic persist, and
+     * bulk evict_prefix code paths without exhausting resources on a dev/CI machine.
+     * True scale (10k-entry key_index) is covered by the Rust integration tests in tests.rs.
+     */
+    private static final int NUM_INDICES = 5;
+    private static final int SHARDS_PER_IDX = 5;
+
+    private static final String REPO_NAME = "repo-scale";
+    private static final String SNAP_NAME = "snap-scale";
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return List.<Class<? extends Plugin>>of(BlockCacheFoyerPlugin.class);
+    }
+
+    @Override
+    protected boolean addMockInternalEngine() {
+        return false;
+    }
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return Settings.builder()
+            .put(super.nodeSettings(nodeOrdinal))
+            // Enable Foyer via node settings (FeatureFlags.initFromSettings bypasses
+            // the security manager that blocks System.getProperty in internalClusterTests).
+            .put(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG, true)
+            // Raise shards-per-node limit.
+            .put("cluster.max_shards_per_node", 200)
+            // 2GB is small enough to pass disk validation on any dev/CI machine.
+            .put(Node.NODE_SEARCH_CACHE_SIZE_SETTING.getKey(), "2gb")
+            // Short persist interval so tests don't wait 60 seconds.
+            .put("block_cache.foyer.key_index_persist_interval_seconds", 5)
+            .put("block_cache.foyer.key_index_sweep_interval_seconds", 0)
+            .build();
+    }
+
+    @Override
+    protected Settings.Builder randomRepositorySettings() {
+        return Settings.builder()
+            .put("location", randomRepoPath())
+            .put("compress", randomBoolean())
+            .put(FsRepository.BASE_PATH_SETTING.getKey(), "key_index_10k_it");
+    }
+
+    // ── Tests ─────────────────────────────────────────────────────────────────
+
+    /**
+     * Restart the warm node after restoring all indices. Verifies that {@code key_index.json}
+     * is written by the {@code Drop} impl on shutdown and is valid JSON.
+     */
+    public void testKeyIndexJsonWrittenOnShutdown() throws Exception {
+        setupScaleShards();
+
+        logger.info("[scale-01] restarting warm node '{}'", getWarmNodeName());
+        internalCluster().restartNode(getWarmNodeName());
+        ensureGreen();
+
+        Path cacheDir = findFoyerCacheDir();
+        assertNotNull("foyer-block-cache directory must exist on warm node after restart", cacheDir);
+        assertTrue("key_index.json must exist after restart", Files.exists(cacheDir.resolve(KEY_INDEX_FILENAME)));
+
+        String content = Files.readString(cacheDir.resolve(KEY_INDEX_FILENAME));
+        assertFalse("key_index.json must not be empty", content.isBlank());
+        assertTrue("key_index.json must contain version:1", content.contains("\"version\":1"));
+        assertTrue("key_index.json must contain an index object", content.contains("\"index\":{"));
+    }
+
+    /**
+     * Verifies that the periodic persist task writes {@code key_index.json} within the
+     * configured interval (5s) without being starved when the key_index is large.
+     */
+    public void testPeriodicPersistFires() throws Exception {
+        setupScaleShards();
+
+        logger.info("[scale-02] waiting for periodic persist (interval=5s)");
+        Path cacheDir = findFoyerCacheDir();
+        assertNotNull("foyer-block-cache directory must exist on warm node", cacheDir);
+
+        assertBusy(
+            () -> assertTrue("key_index.json must be written by periodic persist task", Files.exists(cacheDir.resolve(KEY_INDEX_FILENAME))),
+            30,
+            TimeUnit.SECONDS
+        );
+
+        String content = Files.readString(cacheDir.resolve(KEY_INDEX_FILENAME));
+        assertFalse("key_index.json must not be empty", content.isBlank());
+        assertTrue("key_index.json must contain version:1", content.contains("\"version\":1"));
+    }
+
+    /**
+     * Calls {@code /_blockcache/prune} and verifies it completes with no failures.
+     * Validates that {@code clear()} + key_index wipe + file deletion does not time out.
+     */
+    public void testPruneCompletes() throws Exception {
+        setupScaleShards();
+
+        logger.info("[scale-03] pruning on warm node '{}'", getWarmNodeName());
+        PlainActionFuture<PruneBlockCacheResponse> future = new PlainActionFuture<>();
+        client().execute(PruneBlockCacheAction.INSTANCE, new PruneBlockCacheRequest(), future);
+        PruneBlockCacheResponse pruneResponse = future.actionGet();
+
+        assertNotNull(pruneResponse);
+        assertEquals("Prune should have no failures", 0, pruneResponse.failures().size());
+        assertEquals("Should target 1 warm node", 1, pruneResponse.getNodes().size());
+        assertTrue("Block cache should be cleared", pruneResponse.getNodes().get(0).isCleared());
+
+        long usedAfterPrune = getWarmNodeUsedBytes();
+        assertThat("used_bytes must be 0 after prune", usedAfterPrune, equalTo(0L));
+    }
+
+    /**
+     * Restart (triggering key_index recovery), delete half the indices, then prune.
+     * Validates that bulk {@code evict_prefix()} on recovered prefix buckets completes
+     * and the warm node remains healthy.
+     */
+    public void testEvictPrefixAfterRecovery() throws Exception {
+        setupScaleShards();
+
+        logger.info("[scale-04] restarting warm node to trigger key_index recovery");
+        internalCluster().restartNode(getWarmNodeName());
+        ensureGreen();
+
+        Path cacheDir = findFoyerCacheDir();
+        assertNotNull("foyer-block-cache directory must exist after restart", cacheDir);
+        assertTrue("key_index.json must exist after recovery", Files.exists(cacheDir.resolve(KEY_INDEX_FILENAME)));
+        logger.info("[scale-04] recovery complete, key_index.json exists");
+
+        // Delete half the indices to trigger evict_prefix for each.
+        logger.info("[scale-04] deleting {} indices to trigger bulk evict_prefix", NUM_INDICES / 2);
+        for (int i = 0; i < NUM_INDICES / 2; i++) {
+            String indexName = indexName(i) + "-copy";
+            if (client().admin().indices().prepareExists(indexName).get().isExists()) {
+                client().admin().indices().prepareDelete(indexName).get();
+            }
+        }
+        ensureGreen();
+
+        // Prune to flush any remaining evictions.
+        PlainActionFuture<PruneBlockCacheResponse> future = new PlainActionFuture<>();
+        client().execute(PruneBlockCacheAction.INSTANCE, new PruneBlockCacheRequest(), future);
+        PruneBlockCacheResponse pruneResponse = future.actionGet();
+        assertEquals("Prune should have no failures", 0, pruneResponse.failures().size());
+
+        long usedAfter = getWarmNodeUsedBytes();
+        assertThat("used_bytes must be 0 after bulk evict_prefix + prune", usedAfter, equalTo(0L));
+
+        // Warm node must still be responsive.
+        NodesStatsResponse statsResponse = client().admin()
+            .cluster()
+            .nodesStats(new NodesStatsRequest().addMetric(NodesStatsRequest.Metric.FILE_CACHE_STATS.metricName()).fileCacheDetailed(true))
+            .actionGet();
+        boolean foundWarm = statsResponse.getNodes().stream().anyMatch(n -> n.getNode().isWarmNode());
+        assertTrue("Warm node must still be present and healthy after bulk evict_prefix", foundWarm);
+    }
+
+    /**
+     * Verifies that the warm node remains healthy after restoring all indices,
+     * cluster is GREEN, and block_cache stats are accessible.
+     */
+    public void testWarmNodeRemainsHealthy() throws Exception {
+        setupScaleShards();
+        ensureGreen();
+
+        NodesStatsResponse response = client().admin()
+            .cluster()
+            .nodesStats(new NodesStatsRequest().addMetric(NodesStatsRequest.Metric.FILE_CACHE_STATS.metricName()).fileCacheDetailed(true))
+            .actionGet();
+
+        boolean foundWarmNode = false;
+        for (NodeStats stats : response.getNodes()) {
+            if (stats.getNode().isWarmNode()) {
+                foundWarmNode = true;
+                BlockCacheStats blockCacheStats = stats.getBlockCacheOnlyStats();
+                assertThat("block_cache stats must be present on warm node", blockCacheStats, notNullValue());
+                assertThat("used_bytes must be >= 0", blockCacheStats.diskBytesUsed(), greaterThan(-1L));
+            }
+        }
+        assertTrue("Expected at least one warm node to be present", foundWarmNode);
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    /**
+     * Creates {@value NUM_INDICES} indices × {@value SHARDS_PER_IDX} shards each,
+     * snapshots them into a single repo, deletes the originals, ensures a warm node
+     * exists, then restores all as REMOTE_SNAPSHOT indices on the warm node.
+     */
+    private void setupScaleShards() throws Exception {
+        final Client client = client();
+
+        internalCluster().ensureAtLeastNumDataNodes(1);
+        logger.info(
+            "[setup-shards] creating {} indices × {} shards each = {} total shards",
+            NUM_INDICES,
+            SHARDS_PER_IDX,
+            NUM_INDICES * SHARDS_PER_IDX
+        );
+
+        // Create all indices.
+        List<String> indexNames = new ArrayList<>(NUM_INDICES);
+        for (int i = 0; i < NUM_INDICES; i++) {
+            String name = indexName(i);
+            indexNames.add(name);
+            client.admin()
+                .indices()
+                .prepareCreate(name)
+                .setSettings(
+                    Settings.builder()
+                        .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+                        .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, SHARDS_PER_IDX)
+                        .build()
+                )
+                .get();
+        }
+        ensureGreen();
+
+        // Index 1 doc into each index to make the snapshot non-trivial.
+        for (String name : indexNames) {
+            client.prepareIndex(name).setId("1").setSource("field", "value").get();
+        }
+        ensureGreen();
+
+        // Snapshot all indices at once.
+        createRepository(REPO_NAME, FsRepository.TYPE);
+        final var snapResponse = client.admin()
+            .cluster()
+            .prepareCreateSnapshot(REPO_NAME, SNAP_NAME)
+            .setWaitForCompletion(true)
+            .setIndices(indexNames.toArray(new String[0]))
+            .get();
+        assertThat(snapResponse.getSnapshotInfo().successfulShards(), greaterThan(0));
+
+        // Delete all originals.
+        client.admin().indices().prepareDelete(indexNames.toArray(new String[0])).get();
+        ensureGreen();
+
+        // Ensure warm node exists.
+        internalCluster().ensureAtLeastNumWarmNodes(1);
+
+        // Restore all as REMOTE_SNAPSHOT with "-copy" suffix.
+        client.admin()
+            .cluster()
+            .prepareRestoreSnapshot(REPO_NAME, SNAP_NAME)
+            .setRenamePattern("(.+)")
+            .setRenameReplacement("$1-copy")
+            .setStorageType(RestoreSnapshotRequest.StorageType.REMOTE_SNAPSHOT)
+            .setWaitForCompletion(true)
+            .execute()
+            .actionGet();
+        ensureGreen();
+        logger.info(
+            "[setup-shards] {} remote-snapshot indices ({} total shards) ready on warm node",
+            NUM_INDICES,
+            NUM_INDICES * SHARDS_PER_IDX
+        );
+    }
+
+    private static String indexName(int i) {
+        return String.format(java.util.Locale.ROOT, "idx-%04d", i);
+    }
+
+    private String getWarmNodeName() {
+        try {
+            var nodesInfoResponse = client().admin().cluster().prepareNodesInfo().get();
+            for (var nodeInfo : nodesInfoResponse.getNodes()) {
+                if (nodeInfo.getNode().isWarmNode()) {
+                    return nodeInfo.getNode().getName();
+                }
+            }
+        } catch (Exception ignored) {}
+        String[] names = internalCluster().getNodeNames();
+        return names.length > 0 ? names[0] : null;
+    }
+
+    private long getWarmNodeUsedBytes() {
+        NodesStatsResponse response = client().admin()
+            .cluster()
+            .nodesStats(new NodesStatsRequest().addMetric(NodesStatsRequest.Metric.FILE_CACHE_STATS.metricName()).fileCacheDetailed(true))
+            .actionGet();
+        for (NodeStats stats : response.getNodes()) {
+            if (stats.getNode().isWarmNode()) {
+                BlockCacheStats blockCacheStats = stats.getBlockCacheOnlyStats();
+                if (blockCacheStats != null) {
+                    return blockCacheStats.diskBytesUsed();
+                }
+            }
+        }
+        return 0L;
+    }
+
+    private Path findFoyerCacheDir() {
+        String warmName = getWarmNodeName();
+        assertNotNull("A warm node must be present in the cluster", warmName);
+        Environment environment = internalCluster().getInstance(Environment.class, warmName);
+        for (Path dataPath : environment.dataFiles()) {
+            Path candidate = dataPath.resolve("foyer-block-cache");
+            if (Files.isDirectory(candidate)) {
+                return candidate;
+            }
+        }
+        logger.warn("foyer-block-cache directory not found under warm node '{}'", warmName);
+        return null;
+    }
+}

--- a/sandbox/plugins/block-cache-foyer/src/internalClusterTest/java/org/opensearch/blockcache/foyer/BlockCacheStatsIT.java
+++ b/sandbox/plugins/block-cache-foyer/src/internalClusterTest/java/org/opensearch/blockcache/foyer/BlockCacheStatsIT.java
@@ -16,8 +16,10 @@ import org.opensearch.action.admin.cluster.node.stats.NodesStatsRequest;
 import org.opensearch.action.admin.cluster.node.stats.NodesStatsResponse;
 import org.opensearch.action.admin.cluster.snapshots.restore.RestoreSnapshotRequest;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.index.IndexModule;
 import org.opensearch.index.store.remote.filecache.AggregateFileCacheStats;
+import org.opensearch.node.Node;
 import org.opensearch.plugins.BlockCacheStats;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.repositories.fs.FsRepository;
@@ -59,6 +61,17 @@ public class BlockCacheStatsIT extends AbstractSnapshotIntegTestCase {
     @Override
     protected boolean addMockInternalEngine() {
         return false;
+    }
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return Settings.builder()
+            .put(super.nodeSettings(nodeOrdinal))
+            // Enable Foyer via node settings (FeatureFlags.initFromSettings bypasses
+            // the security manager that blocks System.getProperty in internalClusterTests).
+            .put(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG, true)
+            .put(Node.NODE_SEARCH_CACHE_SIZE_SETTING.getKey(), "2gb")
+            .build();
     }
 
     @Override

--- a/sandbox/plugins/block-cache-foyer/src/internalClusterTest/java/org/opensearch/blockcache/foyer/PruneBlockCacheIT.java
+++ b/sandbox/plugins/block-cache-foyer/src/internalClusterTest/java/org/opensearch/blockcache/foyer/PruneBlockCacheIT.java
@@ -21,7 +21,9 @@ import org.opensearch.action.admin.cluster.node.stats.NodesStatsResponse;
 import org.opensearch.action.admin.cluster.snapshots.restore.RestoreSnapshotRequest;
 import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.index.IndexModule;
+import org.opensearch.node.Node;
 import org.opensearch.plugins.BlockCacheStats;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.repositories.fs.FsRepository;
@@ -61,6 +63,17 @@ public class PruneBlockCacheIT extends AbstractSnapshotIntegTestCase {
     @Override
     protected boolean addMockInternalEngine() {
         return false;
+    }
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return Settings.builder()
+            .put(super.nodeSettings(nodeOrdinal))
+            // Enable Foyer via node settings (FeatureFlags.initFromSettings bypasses
+            // the security manager that blocks System.getProperty in internalClusterTests).
+            .put(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG, true)
+            .put(Node.NODE_SEARCH_CACHE_SIZE_SETTING.getKey(), "2gb")
+            .build();
     }
 
     @Override

--- a/sandbox/plugins/block-cache-foyer/src/main/java/org/opensearch/blockcache/foyer/BlockCacheFoyerPlugin.java
+++ b/sandbox/plugins/block-cache-foyer/src/main/java/org/opensearch/blockcache/foyer/BlockCacheFoyerPlugin.java
@@ -98,7 +98,8 @@ public class BlockCacheFoyerPlugin extends Plugin implements BlockCacheProvider 
             FoyerBlockCacheSettings.BLOCK_SIZE_SETTING,
             FoyerBlockCacheSettings.IO_ENGINE_SETTING,
             FoyerBlockCacheSettings.KEY_INDEX_SWEEP_INTERVAL_SETTING,
-            FoyerBlockCacheSettings.KEY_INDEX_SWEEP_THRESHOLD_SETTING
+            FoyerBlockCacheSettings.KEY_INDEX_SWEEP_THRESHOLD_SETTING,
+            FoyerBlockCacheSettings.KEY_INDEX_PERSIST_INTERVAL_SETTING
         );
     }
 
@@ -159,6 +160,7 @@ public class BlockCacheFoyerPlugin extends Plugin implements BlockCacheProvider 
         final String ioEngine = FoyerBlockCacheSettings.IO_ENGINE_SETTING.get(settings);
         final long sweepIntervalSecs = FoyerBlockCacheSettings.KEY_INDEX_SWEEP_INTERVAL_SETTING.get(settings);
         final double sweepThresholdRatio = FoyerBlockCacheSettings.KEY_INDEX_SWEEP_THRESHOLD_SETTING.get(settings);
+        final long persistIntervalSecs = FoyerBlockCacheSettings.KEY_INDEX_PERSIST_INTERVAL_SETTING.get(settings);
         // Use the exact capacity reserved by NodeCacheService during budget phase.
         final long diskCapacityBytes = reservedCapacityBytes;
 
@@ -189,18 +191,27 @@ public class BlockCacheFoyerPlugin extends Plugin implements BlockCacheProvider 
         }
 
         try {
-            cache = new FoyerBlockCache(diskCapacityBytes, diskDir, blockSizeBytes, ioEngine, sweepIntervalSecs, sweepThresholdRatio);
+            cache = new FoyerBlockCache(
+                diskCapacityBytes,
+                diskDir,
+                blockSizeBytes,
+                ioEngine,
+                sweepIntervalSecs,
+                sweepThresholdRatio,
+                persistIntervalSecs
+            );
         } catch (final Throwable t) {
             throw new IllegalStateException("Failed to initialise Foyer block cache (diskDir=" + diskDir + ")", t);
         }
         logger.info(
             "BlockCacheFoyerPlugin created FoyerBlockCache (diskDir={}, blockSize={}, ioEngine={}, "
-                + "sweepIntervalSecs={}, sweepThresholdRatio={})",
+                + "sweepIntervalSecs={}, sweepThresholdRatio={}, persistIntervalSecs={})",
             diskDir,
             blockSizeBytes,
             ioEngine,
             sweepIntervalSecs == 0 ? "disabled" : sweepIntervalSecs + "s",
-            sweepThresholdRatio == 0.0 ? "disabled" : sweepThresholdRatio
+            sweepThresholdRatio == 0.0 ? "always-sweep (no threshold)" : sweepThresholdRatio,
+            persistIntervalSecs == 0 ? "disabled" : persistIntervalSecs + "s"
         );
         return List.of(cache);
     }

--- a/sandbox/plugins/block-cache-foyer/src/main/java/org/opensearch/blockcache/foyer/BlockCacheFoyerPlugin.java
+++ b/sandbox/plugins/block-cache-foyer/src/main/java/org/opensearch/blockcache/foyer/BlockCacheFoyerPlugin.java
@@ -16,6 +16,7 @@ import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.settings.SettingsException;
 import org.opensearch.common.unit.RatioValue;
+import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.env.Environment;
@@ -130,6 +131,9 @@ public class BlockCacheFoyerPlugin extends Plugin implements BlockCacheProvider 
      */
     @Override
     public long requestedCapacityBytes(Settings settings, long totalBudgetBytes) {
+        if (!FeatureFlags.isEnabled(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)) {
+            return 0L;
+        }
         String cacheSizeRaw = FoyerBlockCacheSettings.CACHE_SIZE_SETTING.get(settings);
         RatioValue ratio = RatioValue.parseRatioValue(cacheSizeRaw);
         return Math.round(totalBudgetBytes * ratio.getAsRatio());
@@ -156,6 +160,10 @@ public class BlockCacheFoyerPlugin extends Plugin implements BlockCacheProvider 
         }
 
         final Settings settings = clusterService.getSettings();
+        if (!FeatureFlags.isEnabled(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)) {
+            logger.info("BlockCacheFoyerPlugin: pluggable.dataformat disabled, Foyer block cache not initialised");
+            return List.of();
+        }
         final long blockSizeBytes = FoyerBlockCacheSettings.BLOCK_SIZE_SETTING.get(settings).getBytes();
         final String ioEngine = FoyerBlockCacheSettings.IO_ENGINE_SETTING.get(settings);
         final long sweepIntervalSecs = FoyerBlockCacheSettings.KEY_INDEX_SWEEP_INTERVAL_SETTING.get(settings);
@@ -203,6 +211,21 @@ public class BlockCacheFoyerPlugin extends Plugin implements BlockCacheProvider 
         } catch (final Throwable t) {
             throw new IllegalStateException("Failed to initialise Foyer block cache (diskDir=" + diskDir + ")", t);
         }
+
+        // Live-update consumers for Dynamic settings.
+        final FoyerBlockCache finalCache = cache;
+        clusterService.getClusterSettings()
+            .addSettingsUpdateConsumer(FoyerBlockCacheSettings.KEY_INDEX_SWEEP_THRESHOLD_SETTING, finalCache::updateSweepThreshold);
+        clusterService.getClusterSettings()
+            .addSettingsUpdateConsumer(
+                FoyerBlockCacheSettings.KEY_INDEX_SWEEP_INTERVAL_SETTING,
+                newInterval -> finalCache.updateSweepInterval(newInterval)
+            );
+        clusterService.getClusterSettings()
+            .addSettingsUpdateConsumer(
+                FoyerBlockCacheSettings.KEY_INDEX_PERSIST_INTERVAL_SETTING,
+                newInterval -> finalCache.updatePersistInterval(newInterval)
+            );
         logger.info(
             "BlockCacheFoyerPlugin created FoyerBlockCache (diskDir={}, blockSize={}, ioEngine={}, "
                 + "sweepIntervalSecs={}, sweepThresholdRatio={}, persistIntervalSecs={})",

--- a/sandbox/plugins/block-cache-foyer/src/main/java/org/opensearch/blockcache/foyer/FoyerBlockCache.java
+++ b/sandbox/plugins/block-cache-foyer/src/main/java/org/opensearch/blockcache/foyer/FoyerBlockCache.java
@@ -49,8 +49,11 @@ public final class FoyerBlockCache implements BlockCache {
      * @param sweepThresholdRatio    minimum {@code used_bytes / disk_bytes} ratio to run the sweep;
      *                               {@code 0.0} = disabled (always sweep).
      *                               Maps to {@code block_cache.foyer.key_index_sweep_threshold}.
+     * @param persistIntervalSecs    how often (seconds) the independent persist task flushes the
+     *                               key_index to disk; {@code 0} = disabled (only {@code Drop} persists).
+     *                               Maps to {@code block_cache.foyer.key_index_persist_interval_seconds}.
      * @throws IllegalArgumentException if {@code diskBytes <= 0}, {@code blockSizeBytes <= 0},
-     *                                  {@code sweepIntervalSecs < 0},
+     *                                  {@code sweepIntervalSecs < 0}, {@code persistIntervalSecs < 0},
      *                                  {@code sweepThresholdRatio} outside {@code [0.0, 1.0]},
      *                                  or {@code diskDir} is blank
      * @throws NullPointerException     if {@code diskDir} or {@code ioEngine} is null
@@ -62,7 +65,8 @@ public final class FoyerBlockCache implements BlockCache {
         long blockSizeBytes,
         String ioEngine,
         long sweepIntervalSecs,
-        double sweepThresholdRatio
+        double sweepThresholdRatio,
+        long persistIntervalSecs
     ) {
         if (diskBytes <= 0) {
             throw new IllegalArgumentException("diskBytes must be > 0, got: " + diskBytes);
@@ -81,8 +85,19 @@ public final class FoyerBlockCache implements BlockCache {
         if (sweepThresholdRatio < 0.0 || sweepThresholdRatio > 1.0) {
             throw new IllegalArgumentException("sweepThresholdRatio must be in [0.0, 1.0], got: " + sweepThresholdRatio);
         }
+        if (persistIntervalSecs < 0) {
+            throw new IllegalArgumentException("persistIntervalSecs must be >= 0, got: " + persistIntervalSecs);
+        }
         this.diskBytes = diskBytes;
-        this.cachePtr = FoyerBridge.createCache(diskBytes, diskDir, blockSizeBytes, ioEngine, sweepIntervalSecs, sweepThresholdRatio);
+        this.cachePtr = FoyerBridge.createCache(
+            diskBytes,
+            diskDir,
+            blockSizeBytes,
+            ioEngine,
+            sweepIntervalSecs,
+            sweepThresholdRatio,
+            persistIntervalSecs
+        );
     }
 
     @Override

--- a/sandbox/plugins/block-cache-foyer/src/main/java/org/opensearch/blockcache/foyer/FoyerBlockCache.java
+++ b/sandbox/plugins/block-cache-foyer/src/main/java/org/opensearch/blockcache/foyer/FoyerBlockCache.java
@@ -175,6 +175,24 @@ public final class FoyerBlockCache implements BlockCache {
         return false;
     }
 
+    public void updateSweepThreshold(double newRatio) {
+        if (closed.get() == false) {
+            FoyerBridge.updateSweepThreshold(cachePtr, newRatio);
+        }
+    }
+
+    public void updateSweepInterval(long newSecs) {
+        if (closed.get() == false) {
+            FoyerBridge.updateSweepInterval(cachePtr, newSecs);
+        }
+    }
+
+    public void updatePersistInterval(long newSecs) {
+        if (closed.get() == false) {
+            FoyerBridge.updatePersistInterval(cachePtr, newSecs);
+        }
+    }
+
     @Override
     public void close() {
         if (closed.compareAndSet(false, true)) {

--- a/sandbox/plugins/block-cache-foyer/src/main/java/org/opensearch/blockcache/foyer/FoyerBlockCacheSettings.java
+++ b/sandbox/plugins/block-cache-foyer/src/main/java/org/opensearch/blockcache/foyer/FoyerBlockCacheSettings.java
@@ -44,17 +44,17 @@ public final class FoyerBlockCacheSettings {
      * byte allocation scales automatically with the instance's SSD capacity.
      *
      * <p>Example: 1&nbsp;TB SSD, {@code node.search.cache.size=80%} (800&nbsp;GB budget),
-     * {@code block_cache.foyer.size=25%} → Foyer gets 200&nbsp;GB, FileCache gets 600&nbsp;GB.
+      * {@code block_cache.foyer.size=50%} → Foyer gets 400&nbsp;GB, FileCache gets 400&nbsp;GB.
      *
-     * <p>Default: {@code 25%}. Set to {@code 0%} to disable the block cache.
-     * Accepts a percentage (e.g. {@code 25%}) or a ratio (e.g. {@code 0.25}).
+     * <p>Default: {@code 50%}. Set to {@code 0%} to disable the block cache.
+     * Accepts a percentage (e.g. {@code 50%}) or a ratio (e.g. {@code 0.50}).
      *
      * <p>Configure in {@code opensearch.yml}:
      * <pre>{@code
-     * block_cache.foyer.size: 25%
+     * block_cache.foyer.size: 50%
      * }</pre>
      */
-    public static final Setting<String> CACHE_SIZE_SETTING = new Setting<>("block_cache.foyer.size", "25%", value -> {
+    public static final Setting<String> CACHE_SIZE_SETTING = new Setting<>("block_cache.foyer.size", "50%", value -> {
         try {
             RatioValue ratio = RatioValue.parseRatioValue(value);
             if (ratio.getAsRatio() < 0 || ratio.getAsRatio() >= 1.0) {
@@ -127,7 +127,8 @@ public final class FoyerBlockCacheSettings {
         0L,    // 0 = disabled (no sweep task spawned)
         0L,    // min: 0
         3600L, // max: 1 hour
-        Setting.Property.NodeScope
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
     );
 
     /**
@@ -154,7 +155,8 @@ public final class FoyerBlockCacheSettings {
         0.70, // default: skip sweep when cache < 70% full
         0.0,  // min: 0.0 (explicit 0 = always sweep)
         1.0,  // max: 1.0
-        Setting.Property.NodeScope
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
     );
 
     /**
@@ -184,7 +186,8 @@ public final class FoyerBlockCacheSettings {
         60L,   // default: 60 seconds
         0L,    // min: 0 (0 = disabled, persist only on graceful shutdown)
         3600L, // max: 1 hour
-        Setting.Property.NodeScope
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
     );
 
     private FoyerBlockCacheSettings() {}

--- a/sandbox/plugins/block-cache-foyer/src/main/java/org/opensearch/blockcache/foyer/FoyerBlockCacheSettings.java
+++ b/sandbox/plugins/block-cache-foyer/src/main/java/org/opensearch/blockcache/foyer/FoyerBlockCacheSettings.java
@@ -157,5 +157,35 @@ public final class FoyerBlockCacheSettings {
         Setting.Property.NodeScope
     );
 
+    /**
+     * How often (seconds) the independent persist task flushes the key_index to disk.
+     *
+     * <p>The persist task is decoupled from the sweep task so that persist frequency
+     * (a cheap file write, default 60 s) and sweep frequency (an expensive DashMap scan)
+     * can be tuned independently.
+     *
+     * <p>The task uses {@code used_bytes} as a change signal: if {@code used_bytes} has
+     * not changed since the last successful write, the tick is skipped (no disk I/O).
+     * This means idle caches produce zero I/O even if the interval is short.
+     *
+     * <p>{@code 0} = disabled — the key_index is only persisted on graceful shutdown
+     * via the {@code Drop} impl (i.e. when the JVM shuts down cleanly). In this mode
+     * the maximum durability window after a crash equals the node uptime since startup.
+     *
+     * <p>Default: {@code 60} seconds. Range: [0, 3600].
+     *
+     * <p>Configure in {@code opensearch.yml}:
+     * <pre>{@code
+     * block_cache.foyer.key_index_persist_interval_seconds: 60
+     * }</pre>
+     */
+    public static final Setting<Long> KEY_INDEX_PERSIST_INTERVAL_SETTING = Setting.longSetting(
+        "block_cache.foyer.key_index_persist_interval_seconds",
+        60L,   // default: 60 seconds
+        0L,    // min: 0 (0 = disabled, persist only on graceful shutdown)
+        3600L, // max: 1 hour
+        Setting.Property.NodeScope
+    );
+
     private FoyerBlockCacheSettings() {}
 }

--- a/sandbox/plugins/block-cache-foyer/src/main/java/org/opensearch/blockcache/foyer/FoyerBridge.java
+++ b/sandbox/plugins/block-cache-foyer/src/main/java/org/opensearch/blockcache/foyer/FoyerBridge.java
@@ -49,7 +49,7 @@ public final class FoyerBridge {
 
         // i64 foyer_create_cache(u64 disk_bytes, *const u8 dir_ptr, u64 dir_len,
         // u64 block_size_bytes, *const u8 io_engine_ptr, u64 io_engine_len,
-        // u64 sweep_interval_secs, f64 sweep_threshold_ratio)
+        // u64 sweep_interval_secs, f64 sweep_threshold_ratio, u64 persist_interval_secs)
         // Returns Box<Arc<dyn BlockCache>> fat pointer.
         FOYER_CREATE_CACHE = linker.downcallHandle(
             lib.find("foyer_create_cache").orElseThrow(),
@@ -62,7 +62,8 @@ public final class FoyerBridge {
                 ValueLayout.ADDRESS,     // io_engine_ptr: *const u8
                 ValueLayout.JAVA_LONG,   // io_engine_len: u64
                 ValueLayout.JAVA_LONG,   // sweep_interval_secs: u64 (0 = disabled)
-                ValueLayout.JAVA_DOUBLE  // sweep_threshold_ratio: f64 (0.0 = disabled)
+                ValueLayout.JAVA_DOUBLE, // sweep_threshold_ratio: f64 (0.0 = disabled)
+                ValueLayout.JAVA_LONG    // persist_interval_secs: u64 (0 = disabled)
             )
         );
 
@@ -127,6 +128,9 @@ public final class FoyerBridge {
      *                               the sweep. When the ratio is below this value the sweep tick is
      *                               skipped (no-op). {@code 0.0} = disabled (always sweep).
      *                               Maps to {@code block_cache.foyer.key_index_sweep_threshold}.
+     * @param persistIntervalSecs    how often (seconds) the independent persist task flushes the
+     *                               key_index to disk. {@code 0} = disabled (only {@code Drop} persists).
+     *                               Maps to {@code block_cache.foyer.key_index_persist_interval_seconds}.
      * @return an opaque fat pointer representing the cache instance; always positive on success
      * @throws RuntimeException if the native call fails or the directory is invalid
      */
@@ -136,7 +140,8 @@ public final class FoyerBridge {
         long blockSizeBytes,
         String ioEngine,
         long sweepIntervalSecs,
-        double sweepThresholdRatio
+        double sweepThresholdRatio,
+        long persistIntervalSecs
     ) {
         try (var call = new NativeCall()) {
             var dir = call.str(diskDir);
@@ -150,19 +155,21 @@ public final class FoyerBridge {
                 engine.segment(),
                 engine.len(),
                 sweepIntervalSecs,
-                sweepThresholdRatio
+                sweepThresholdRatio,
+                persistIntervalSecs
             );
             if (ptr <= 0) {
                 throw new IllegalStateException("foyer_create_cache returned an invalid handle");
             }
             logger.info(
                 "Foyer block cache created: diskBytes={}, blockSizeBytes={}, ioEngine={}, "
-                    + "sweepIntervalSecs={}, sweepThresholdRatio={}, dir={}",
+                    + "sweepIntervalSecs={}, sweepThresholdRatio={}, persistIntervalSecs={}, dir={}",
                 diskBytes,
                 blockSizeBytes,
                 ioEngine,
                 sweepIntervalSecs == 0 ? "disabled" : sweepIntervalSecs + "s",
-                sweepThresholdRatio == 0.0 ? "disabled" : sweepThresholdRatio,
+                sweepThresholdRatio == 0.0 ? "always-sweep (no threshold)" : sweepThresholdRatio,
+                persistIntervalSecs == 0 ? "disabled" : persistIntervalSecs + "s",
                 diskDir
             );
             return ptr;

--- a/sandbox/plugins/block-cache-foyer/src/main/java/org/opensearch/blockcache/foyer/FoyerBridge.java
+++ b/sandbox/plugins/block-cache-foyer/src/main/java/org/opensearch/blockcache/foyer/FoyerBridge.java
@@ -42,6 +42,9 @@ public final class FoyerBridge {
     private static final MethodHandle FOYER_SNAPSHOT_STATS;
     private static final MethodHandle FOYER_EVICT_PREFIX;
     private static final MethodHandle FOYER_CLEAR_CACHE;
+    private static final MethodHandle FOYER_UPDATE_SWEEP_THRESHOLD;
+    private static final MethodHandle FOYER_UPDATE_SWEEP_INTERVAL;
+    private static final MethodHandle FOYER_UPDATE_PERSIST_INTERVAL;
 
     static {
         SymbolLookup lib = NativeLibraryLoader.symbolLookup();
@@ -106,8 +109,40 @@ public final class FoyerBridge {
             )
         );
 
+        // i64 foyer_update_sweep_threshold(i64 ptr, f64 new_ratio) — 0=success, <0=error
+        FOYER_UPDATE_SWEEP_THRESHOLD = linker.downcallHandle(
+            lib.find("foyer_update_sweep_threshold").orElseThrow(),
+            FunctionDescriptor.of(
+                ValueLayout.JAVA_LONG,   // return: 0=ok, <0=error
+                ValueLayout.JAVA_LONG,   // ptr: i64 cache handle
+                ValueLayout.JAVA_DOUBLE  // new_ratio: f64
+            )
+        );
+
+        // i64 foyer_update_sweep_interval(i64 ptr, u64 new_secs) — 0=success, <0=error
+        FOYER_UPDATE_SWEEP_INTERVAL = linker.downcallHandle(
+            lib.find("foyer_update_sweep_interval").orElseThrow(),
+            FunctionDescriptor.of(
+                ValueLayout.JAVA_LONG,  // return: 0=ok, <0=error
+                ValueLayout.JAVA_LONG,  // ptr: i64 cache handle
+                ValueLayout.JAVA_LONG   // new_secs: u64
+            )
+        );
+
+        // i64 foyer_update_persist_interval(i64 ptr, u64 new_secs) — 0=success, <0=error
+        FOYER_UPDATE_PERSIST_INTERVAL = linker.downcallHandle(
+            lib.find("foyer_update_persist_interval").orElseThrow(),
+            FunctionDescriptor.of(
+                ValueLayout.JAVA_LONG,  // return: 0=ok, <0=error
+                ValueLayout.JAVA_LONG,  // ptr: i64 cache handle
+                ValueLayout.JAVA_LONG   // new_secs: u64
+            )
+        );
+
         logger.info(
-            "FFM downcall handles resolved: foyer_create_cache, foyer_destroy_cache, foyer_snapshot_stats, foyer_evict_prefix, foyer_clear_cache"
+            "FFM downcall handles resolved: foyer_create_cache, foyer_destroy_cache, foyer_snapshot_stats, "
+                + "foyer_evict_prefix, foyer_clear_cache, foyer_update_sweep_threshold, "
+                + "foyer_update_sweep_interval, foyer_update_persist_interval"
         );
     }
 
@@ -268,6 +303,36 @@ public final class FoyerBridge {
         } catch (Exception e) {
             logger.warn("foyer_clear_cache failed: {}", e.getMessage());
             return false;
+        }
+    }
+
+    /** Updates the sweep threshold ratio live. {@code 0.0} = always sweep. Takes effect on next sweep tick. */
+    public static void updateSweepThreshold(long ptr, double newRatio) {
+        try (var call = new NativeCall()) {
+            call.invoke(FOYER_UPDATE_SWEEP_THRESHOLD, ptr, newRatio);
+            logger.info("Foyer sweep threshold updated: {}%", (int) (newRatio * 100));
+        } catch (Exception e) {
+            logger.warn("foyer_update_sweep_threshold failed: {}", e.getMessage());
+        }
+    }
+
+    /** Updates the sweep interval live. {@code 0} = disable. Takes effect on next sleep cycle. */
+    public static void updateSweepInterval(long ptr, long newSecs) {
+        try (var call = new NativeCall()) {
+            call.invoke(FOYER_UPDATE_SWEEP_INTERVAL, ptr, newSecs);
+            logger.info("Foyer sweep interval updated: {}s", newSecs == 0 ? "disabled" : newSecs);
+        } catch (Exception e) {
+            logger.warn("foyer_update_sweep_interval failed: {}", e.getMessage());
+        }
+    }
+
+    /** Updates the persist interval live. {@code 0} = disable. Takes effect on next sleep cycle. */
+    public static void updatePersistInterval(long ptr, long newSecs) {
+        try (var call = new NativeCall()) {
+            call.invoke(FOYER_UPDATE_PERSIST_INTERVAL, ptr, newSecs);
+            logger.info("Foyer persist interval updated: {}s", newSecs == 0 ? "disabled" : newSecs);
+        } catch (Exception e) {
+            logger.warn("foyer_update_persist_interval failed: {}", e.getMessage());
         }
     }
 

--- a/sandbox/plugins/block-cache-foyer/src/main/rust/Cargo.toml
+++ b/sandbox/plugins/block-cache-foyer/src/main/rust/Cargo.toml
@@ -18,6 +18,8 @@ tokio                = { workspace = true }
 tokio-util           = { workspace = true }
 log                  = { workspace = true }
 native-bridge-common = { workspace = true }
+serde                = { workspace = true, features = ["derive"] }
+serde_json           = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/sandbox/plugins/block-cache-foyer/src/main/rust/src/foyer/ffm.rs
+++ b/sandbox/plugins/block-cache-foyer/src/main/rust/src/foyer/ffm.rs
@@ -28,6 +28,8 @@ use crate::foyer::foyer_cache::FoyerCache;
 /// - `sweep_threshold_ratio` — minimum `used_bytes / disk_bytes` ratio required to run the
 ///   sweep. When the ratio is below this value the sweep tick is skipped (no-op). `0.0` =
 ///   disabled (always sweep). Maps to `block_cache.foyer.key_index_sweep_threshold`.
+/// - `persist_interval_secs` — how often (in seconds) the independent persist task flushes the
+///   key_index to disk. `0` = disabled (only graceful-shutdown `Drop` persists).
 ///
 /// # Safety
 /// `dir_ptr` must point to `dir_len` consecutive valid UTF-8 bytes.
@@ -43,6 +45,7 @@ pub unsafe extern "C" fn foyer_create_cache(
     io_engine_len: u64,
     sweep_interval_secs: u64,
     sweep_threshold_ratio: f64,
+    persist_interval_secs: u64,
 ) -> i64 {
     if dir_ptr.is_null() {
         return Err("dir_ptr is null".to_string());
@@ -63,6 +66,7 @@ pub unsafe extern "C" fn foyer_create_cache(
         io_engine,
         sweep_interval_secs,
         sweep_threshold_ratio,
+        persist_interval_secs,
     ));
     Ok(Box::into_raw(Box::new(cache)) as i64)
 }

--- a/sandbox/plugins/block-cache-foyer/src/main/rust/src/foyer/ffm.rs
+++ b/sandbox/plugins/block-cache-foyer/src/main/rust/src/foyer/ffm.rs
@@ -167,6 +167,68 @@ pub unsafe extern "C" fn foyer_clear_cache(ptr: i64) -> i64 {
     Ok(0)
 }
 
+/// Update the sweep threshold ratio on the running cache without a restart.
+///
+/// Called by Java's `addSettingsUpdateConsumer` when
+/// `block_cache.foyer.key_index_sweep_threshold` is changed via the cluster settings API.
+/// The sweep task picks up the new value on its next tick.
+///
+/// # Parameters
+/// - `ptr` — the cache handle returned by [`foyer_create_cache`].
+/// - `new_ratio` — new threshold ratio in `[0.0, 1.0]`. `0.0` = always sweep.
+///
+/// # Returns
+/// `0` on success; `< 0` if `ptr` is invalid or the cache type is wrong.
+///
+/// # Safety
+/// `ptr` must be a valid handle from [`foyer_create_cache`], not yet destroyed.
+#[ffm_safe]
+#[no_mangle]
+pub unsafe extern "C" fn foyer_update_sweep_threshold(ptr: i64, new_ratio: f64) -> i64 {
+    if ptr <= 0 {
+        return Err(format!("foyer_update_sweep_threshold: invalid ptr {}", ptr));
+    }
+    let boxed = &*(ptr as *const Arc<dyn crate::traits::BlockCache>);
+    let foyer = match boxed.as_any().downcast_ref::<FoyerCache>() {
+        Some(f) => f,
+        None => return Err("foyer_update_sweep_threshold: downcast to FoyerCache failed".to_string()),
+    };
+    foyer.update_sweep_threshold(new_ratio);
+    Ok(0)
+}
+
+/// Update the sweep interval on the running cache without a restart. `0` = disable.
+#[ffm_safe]
+#[no_mangle]
+pub unsafe extern "C" fn foyer_update_sweep_interval(ptr: i64, new_secs: u64) -> i64 {
+    if ptr <= 0 {
+        return Err(format!("foyer_update_sweep_interval: invalid ptr {}", ptr));
+    }
+    let boxed = &*(ptr as *const Arc<dyn crate::traits::BlockCache>);
+    let foyer = match boxed.as_any().downcast_ref::<FoyerCache>() {
+        Some(f) => f,
+        None => return Err("foyer_update_sweep_interval: downcast failed".to_string()),
+    };
+    foyer.update_sweep_interval(new_secs);
+    Ok(0)
+}
+
+/// Update the persist interval on the running cache without a restart. `0` = disable.
+#[ffm_safe]
+#[no_mangle]
+pub unsafe extern "C" fn foyer_update_persist_interval(ptr: i64, new_secs: u64) -> i64 {
+    if ptr <= 0 {
+        return Err(format!("foyer_update_persist_interval: invalid ptr {}", ptr));
+    }
+    let boxed = &*(ptr as *const Arc<dyn crate::traits::BlockCache>);
+    let foyer = match boxed.as_any().downcast_ref::<FoyerCache>() {
+        Some(f) => f,
+        None => return Err("foyer_update_persist_interval: downcast failed".to_string()),
+    };
+    foyer.update_persist_interval(new_secs);
+    Ok(0)
+}
+
 /// Evict all cache entries whose key starts with `prefix`.
 ///
 /// Called by Java's `NodeCacheServiceCleaner` on shard/index deletion.

--- a/sandbox/plugins/block-cache-foyer/src/main/rust/src/foyer/foyer_cache.rs
+++ b/sandbox/plugins/block-cache-foyer/src/main/rust/src/foyer/foyer_cache.rs
@@ -11,7 +11,7 @@
 use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
 use bytes::Bytes;
 use dashmap::DashMap;
@@ -213,7 +213,12 @@ pub struct FoyerCache {
     /// Only accessed inside the async task closure (captured by value) and in test builds
     /// via `should_skip_sweep()`.
     #[cfg_attr(not(test), allow(dead_code))]
-    pub(crate) sweep_threshold_ratio: f64,
+    pub(crate) sweep_threshold_ratio: Arc<AtomicU64>,
+    /// Live-updatable sweep interval in seconds. `0` = disabled (task uses this only to sleep;
+    /// if changed to 0 while running, the task sleeps 0 s and immediately checks cancellation).
+    pub(crate) sweep_interval_secs: Arc<AtomicU64>,
+    /// Live-updatable persist interval in seconds. `0` = disabled.
+    pub(crate) persist_interval_secs: Arc<AtomicU64>,
     /// Absolute path to the Foyer cache directory.
     /// Used to write/read `key_index.json` for persistence and recovery.
     pub(crate) cache_dir: PathBuf,
@@ -342,6 +347,10 @@ impl FoyerCache {
         let sweep_cursor = Arc::new(AtomicUsize::new(0));
 
         // ── Construct instance ────────────────────────────────────────────────
+        let sweep_threshold_atomic = Arc::new(AtomicU64::new(sweep_threshold_ratio.to_bits()));
+        let sweep_interval_atomic   = Arc::new(AtomicU64::new(sweep_interval_secs));
+        let persist_interval_atomic = Arc::new(AtomicU64::new(persist_interval_secs));
+
         let mut instance = Self {
             inner,
             key_index,
@@ -350,7 +359,9 @@ impl FoyerCache {
             shutdown,
             sweep_cursor,
             disk_bytes,
-            sweep_threshold_ratio,
+            sweep_threshold_ratio: sweep_threshold_atomic,
+            sweep_interval_secs:   sweep_interval_atomic,
+            persist_interval_secs: persist_interval_atomic,
             cache_dir: disk_dir,  // move: dir_clone was consumed by block_on, disk_dir is still owned
         };
 
@@ -368,32 +379,33 @@ impl FoyerCache {
             let sweep_key_index = Arc::clone(&instance.key_index);
             let sweep_stats = Arc::clone(&instance.stats);
             let sweep_cursor_clone = Arc::clone(&instance.sweep_cursor);
-            let sweep_interval = Duration::from_secs(sweep_interval_secs);
-            // disk_bytes and sweep_threshold_ratio are Copy — captured by value into the closure.
+            let sweep_interval_atomic_clone = Arc::clone(&instance.sweep_interval_secs);
+            let sweep_threshold_atomic_clone = Arc::clone(&instance.sweep_threshold_ratio);
             let sweep_disk_bytes = disk_bytes;
-            let sweep_threshold = sweep_threshold_ratio;
 
             instance._runtime.spawn(async move {
                 native_bridge_common::log_info!(
-                    "[block-cache] sweep task started: interval={}s, threshold={:.0}%",
-                    sweep_interval_secs,
-                    sweep_threshold * 100.0
+                    "[block-cache] sweep task started: interval={}s", sweep_interval_secs
                 );
                 loop {
-                    // Race sleep vs cancellation: wakes immediately on drop, not after interval.
+                    // Read interval on each tick — allows live update without restart.
+                    let current_secs = sweep_interval_atomic_clone.load(Ordering::Relaxed);
+                    let interval = if current_secs == 0 {
+                        Duration::from_secs(3600) // effectively disabled: sleep 1 hour
+                    } else {
+                        Duration::from_secs(current_secs)
+                    };
                     tokio::select! {
-                        _ = tokio::time::sleep(sweep_interval) => {
-                            // Usage-ratio guard: skip the sweep entirely when the cache is
-                            // below the threshold, avoiding unnecessary DashMap iteration.
-                            // sweep_threshold == 0.0 disables the guard (always sweep).
-                            if sweep_threshold > 0.0 {
+                        _ = tokio::time::sleep(interval) => {
+                            if current_secs == 0 { continue; } // disabled
+                            let threshold = f64::from_bits(sweep_threshold_atomic_clone.load(Ordering::Relaxed));
+                            if threshold > 0.0 {
                                 let used = sweep_stats.used_bytes.load(Ordering::Relaxed).max(0) as usize;
-                                let usage_ratio = used as f64 / sweep_disk_bytes as f64;
-                                if usage_ratio < sweep_threshold {
+                                let ratio = used as f64 / sweep_disk_bytes as f64;
+                                if ratio < threshold {
                                     native_bridge_common::log_debug!(
                                         "[block-cache] sweep skipped: usage={:.1}% < threshold={:.1}%",
-                                        usage_ratio * 100.0,
-                                        sweep_threshold * 100.0
+                                        ratio * 100.0, threshold * 100.0
                                     );
                                     continue;
                                 }
@@ -439,11 +451,6 @@ impl FoyerCache {
                                 match key_index_store::save(&persist_dir, &persist_key_index) {
                                     Ok(()) => {
                                         last_persisted = current;
-                                        native_bridge_common::log_debug!(
-                                            "[block-cache] persist task: saved \
-                                             used_bytes={} buckets={}",
-                                            current, persist_key_index.len()
-                                        );
                                     }
                                     Err(e) => {
                                         // Do not update last_persisted — retry on the next tick.
@@ -611,11 +618,32 @@ impl FoyerCache {
     /// - `false` when `sweep_threshold_ratio > 0.0` AND `used_bytes / disk_bytes >= threshold`.
     #[cfg(test)]
     pub(crate) fn should_skip_sweep(&self) -> bool {
-        if self.sweep_threshold_ratio <= 0.0 {
+        let threshold = f64::from_bits(self.sweep_threshold_ratio.load(Ordering::Relaxed));
+        if threshold <= 0.0 {
             return false; // disabled: always sweep
         }
         let used = self.stats.used_bytes.load(Ordering::Relaxed).max(0) as usize;
-        (used as f64 / self.disk_bytes as f64) < self.sweep_threshold_ratio
+        (used as f64 / self.disk_bytes as f64) < threshold
+    }
+
+    /// Update the sweep threshold ratio atomically. Takes effect on next tick.
+    pub(crate) fn update_sweep_threshold(&self, new_ratio: f64) {
+        self.sweep_threshold_ratio.store(new_ratio.to_bits(), Ordering::Relaxed);
+        native_bridge_common::log_info!(
+            "[block-cache] sweep threshold updated live: {:.0}%", new_ratio * 100.0
+        );
+    }
+
+    /// Update the sweep interval live. `0` = disable sweep. Takes effect on next sleep.
+    pub(crate) fn update_sweep_interval(&self, new_secs: u64) {
+        self.sweep_interval_secs.store(new_secs, Ordering::Relaxed);
+        native_bridge_common::log_info!("[block-cache] sweep interval updated live: {}s", new_secs);
+    }
+
+    /// Update the persist interval live. `0` = disable periodic persist. Takes effect on next sleep.
+    pub(crate) fn update_persist_interval(&self, new_secs: u64) {
+        self.persist_interval_secs.store(new_secs, Ordering::Relaxed);
+        native_bridge_common::log_info!("[block-cache] persist interval updated live: {}s", new_secs);
     }
 
     /// Clear all entries synchronously. Called from the FFM layer.

--- a/sandbox/plugins/block-cache-foyer/src/main/rust/src/foyer/foyer_cache.rs
+++ b/sandbox/plugins/block-cache-foyer/src/main/rust/src/foyer/foyer_cache.rs
@@ -12,7 +12,7 @@ use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use bytes::Bytes;
 use dashmap::DashMap;
 use foyer::{BlockEngineConfig, DeviceBuilder, FsDeviceBuilder,
@@ -21,6 +21,7 @@ use tokio_util::sync::CancellationToken;
 #[cfg(target_os = "linux")]
 use foyer::UringIoEngineConfig;
 
+use crate::key_index_store;
 use crate::range_cache::{CacheKey, SEPARATOR, key_byte_size};
 use crate::stats::FoyerStatsCounter;
 use crate::traits::BlockCache;
@@ -133,9 +134,23 @@ impl Drop for ActiveBytesGuard<'_> {
 /// The key index allows removing all cached entries sharing a common prefix
 /// in O(n) without requiring Foyer to support prefix-scan semantics.
 ///
-/// Shutdown: the background sweep task is cancelled immediately via [`CancellationToken`]
-/// when the cache is dropped — the task wakes from `tokio::select!` without waiting
-/// for the current sleep interval to expire.
+/// ## Recovery
+/// On startup the key_index is bulk-loaded from `key_index.json` inside `disk_dir`
+/// (written on graceful shutdown and periodically by the persist task). The Foyer
+/// disk data is recovered via `RecoverMode::Quiet`. Stale key_index entries (keys
+/// Foyer did not recover) are cleaned up by the background sweep task.
+///
+/// ## Persistence
+/// The key_index is written:
+/// 1. By the independent periodic persist task every `persist_interval_secs` seconds
+///    (when `used_bytes` has changed since the last write — zero-write when idle).
+/// 2. Unconditionally in `Drop` (graceful shutdown).
+/// On crash (`Drop` not called), only the Foyer disk data is recovered;
+/// key_index starts empty (same as before this feature was added).
+///
+/// Shutdown: the background sweep task and persist task are cancelled immediately via
+/// [`CancellationToken`] when the cache is dropped — both tasks wake from
+/// `tokio::select!` without waiting for the current sleep interval to expire.
 ///
 /// Stats: `get()` → hit/miss counts; `put()` → `used_bytes`; `evict_prefix()` → `removed_count`;
 /// background sweeper → `eviction_count` for disk-reclaimer evictions. Thread-safe.
@@ -156,9 +171,10 @@ pub struct FoyerCache {
     _runtime: Arc<tokio::runtime::Runtime>,
     /// Atomic stats counters. Exposed for FFM read via `foyer_snapshot_stats`.
     pub(crate) stats: Arc<FoyerStatsCounter>,
-    /// Signals the background sweep task to stop immediately when `FoyerCache` is dropped.
+    /// Signals the background sweep task and persist task to stop immediately when
+    /// `FoyerCache` is dropped.
     ///
-    /// Uses [`CancellationToken`] rather than `AtomicBool` so that the sweep loop can use
+    /// Uses [`CancellationToken`] rather than `AtomicBool` so that both loops can use
     /// `tokio::select!` and wake instantly on cancellation instead of waiting for the
     /// current sleep interval to expire before checking the flag.
     ///
@@ -198,11 +214,33 @@ pub struct FoyerCache {
     /// via `should_skip_sweep()`.
     #[cfg_attr(not(test), allow(dead_code))]
     pub(crate) sweep_threshold_ratio: f64,
+    /// Absolute path to the Foyer cache directory.
+    /// Used to write/read `key_index.json` for persistence and recovery.
+    pub(crate) cache_dir: PathBuf,
 }
 
 impl Drop for FoyerCache {
     fn drop(&mut self) {
-        // Cancel the background sweep task so it wakes immediately from tokio::select!.
+        // Unconditional final persist — graceful shutdown path.
+        // Writes the complete current key_index as the authoritative final snapshot.
+        // This supersedes any earlier periodic persist and ensures the most
+        // up-to-date state is available on the next restart.
+        // On crash (OOM, SIGKILL) Drop is not called; the cache restarts from the
+        // last periodic snapshot, or with an empty key_index if no snapshot exists.
+        if let Err(e) = key_index_store::save(&self.cache_dir, &self.key_index) {
+            native_bridge_common::log_info!(
+                "[block-cache] key_index final persist FAILED on shutdown: {}",
+                e
+            );
+        } else {
+            native_bridge_common::log_info!(
+                "[block-cache] key_index persisted on shutdown: {} prefix buckets, dir={}",
+                self.key_index.len(),
+                self.cache_dir.display()
+            );
+        }
+        // Cancel the background sweep task and persist task so they wake immediately
+        // from tokio::select! without waiting for the current sleep to expire.
         self.shutdown.cancel();
     }
 }
@@ -224,6 +262,9 @@ impl FoyerCache {
     ///   to run the sweep. If the ratio is below this threshold the sweep tick is skipped
     ///   (no-op). `0.0` = always sweep (threshold disabled). Range: `[0.0, 1.0]`.
     ///   Configurable via `block_cache.foyer.key_index_sweep_threshold`.
+    /// - `persist_interval_secs` — how often (in seconds) the independent persist task
+    ///   flushes the key_index to disk. `0` = disabled (only `Drop` persists).
+    ///   Configurable via `block_cache.foyer.key_index_persist_interval_seconds`.
     ///
     /// # Panics
     /// Panics if the Tokio runtime cannot be created or if Foyer fails to
@@ -235,13 +276,17 @@ impl FoyerCache {
         io_engine: &str,
         sweep_interval_secs: u64,
         sweep_threshold_ratio: f64,
+        persist_interval_secs: u64,
     ) -> Self {
-        let disk_dir = disk_dir.into();
+        let disk_dir: PathBuf = disk_dir.into();
+
         let key_index: Arc<DashMap<String, HashSet<String>>> = Arc::new(DashMap::new());
         let stats = FoyerStatsCounter::new();
 
         let rt = tokio::runtime::Runtime::new()
             .expect("[block-cache] failed to create Tokio runtime");
+        // Clone disk_dir only for the async closure; the original is moved into cache_dir
+        // after block_on returns.
         let dir_clone = disk_dir.clone();
         let io_engine = io_engine.to_string();
         let io_engine_for_log = io_engine.clone();  // clone for use in log after the closure
@@ -254,15 +299,12 @@ impl FoyerCache {
                     // to 1 byte opts out of DRAM caching. All entries go directly to the
                     // disk tier (FsDevice) below.
                 .storage()
-                // On restart Foyer would recover disk data into its internal Indexer, but
-                // key_index is in-memory and always starts empty. get() never populates
-                // key_index — only put() does — so evict_prefix() would silently miss all
-                // recovered entries, leaving stale data on disk after shard deletion.
-                // RecoverMode::None skips recovery so disk and key_index start consistent.
-                // (Rebuilding key_index from recovered state is not possible: HybridCache
-                // exposes no iterator over recovered entries, and the internal Indexer is
-                // keyed by u64 hash so original key strings cannot be recovered from it.)
-                .with_recover_mode(RecoverMode::None)
+                // RecoverMode::Quiet recovers existing disk entries into Foyer's in-RAM
+                // index without raising an error on corrupted pages. Together with
+                // recover_key_index() this ensures disk data and key_index are consistent
+                // after a graceful restart.
+                // On a fresh directory (clean startup) Quiet behaves identically to None.
+                .with_recover_mode(RecoverMode::Quiet)
                 .with_io_engine_config(build_io_engine_config(&io_engine))
                 .with_engine_config(
                     // block_size is the disk I/O unit and the maximum size for a single entry.
@@ -284,33 +326,54 @@ impl FoyerCache {
                 .expect("[block-cache] HybridCache build failed")
         });
         native_bridge_common::log_info!(
-            "[block-cache] ready: disk={}B, block_size={}B, io_engine={}, sweep_threshold={:.0}%, dir={}",
+            "[block-cache] ready: disk={}B, block_size={}B, io_engine={}, sweep_threshold={:.0}%, \
+             persist_interval={}s, dir={}",
             disk_bytes, block_size_bytes, io_engine_for_log,
-            sweep_threshold_ratio * 100.0, disk_dir.display()
+            sweep_threshold_ratio * 100.0,
+            if persist_interval_secs == 0 { "disabled".to_string() } else { persist_interval_secs.to_string() },
+            disk_dir.display()
         );
 
-        // CancellationToken is Clone and Send — cheap to share with the background task.
+        // CancellationToken is Clone and Send — cheap to share with background tasks.
         let shutdown = CancellationToken::new();
 
         // Sweep cursor starts at shard 0 and advances by one per sweep call,
         // rotating through all shards over successive intervals.
         let sweep_cursor = Arc::new(AtomicUsize::new(0));
 
+        // ── Construct instance ────────────────────────────────────────────────
+        let mut instance = Self {
+            inner,
+            key_index,
+            _runtime: Arc::new(rt),
+            stats,
+            shutdown,
+            sweep_cursor,
+            disk_bytes,
+            sweep_threshold_ratio,
+            cache_dir: disk_dir,  // move: dir_clone was consumed by block_on, disk_dir is still owned
+        };
+
+        // Bulk-load key_index from disk.
+        // On clean startup or crash: load_or_empty() returns empty silently.
+        instance.recover_key_index();
+
+        // ── Spawn background sweep task ───────────────────────────────────────
         // Spawn the background key_index sweeper: removes entries silently evicted by Foyer's
         // disk reclaimer. inner.contains() is an in-RAM index lookup (no disk I/O).
         // sweep_interval_secs > 0 required to spawn; 0 means sweep is disabled.
         if sweep_interval_secs > 0 {
-            let sweep_token = shutdown.clone();
-            let sweep_inner = inner.clone();
-            let sweep_key_index = Arc::clone(&key_index);
-            let sweep_stats = Arc::clone(&stats);
-            let sweep_cursor_clone = Arc::clone(&sweep_cursor);
+            let sweep_token = instance.shutdown.clone();
+            let sweep_inner = instance.inner.clone();
+            let sweep_key_index = Arc::clone(&instance.key_index);
+            let sweep_stats = Arc::clone(&instance.stats);
+            let sweep_cursor_clone = Arc::clone(&instance.sweep_cursor);
             let sweep_interval = Duration::from_secs(sweep_interval_secs);
             // disk_bytes and sweep_threshold_ratio are Copy — captured by value into the closure.
             let sweep_disk_bytes = disk_bytes;
             let sweep_threshold = sweep_threshold_ratio;
 
-            rt.spawn(async move {
+            instance._runtime.spawn(async move {
                 native_bridge_common::log_info!(
                     "[block-cache] sweep task started: interval={}s, threshold={:.0}%",
                     sweep_interval_secs,
@@ -348,16 +411,119 @@ impl FoyerCache {
             });
         }
 
-        Self {
-            inner,
-            key_index,
-            _runtime: Arc::new(rt),
-            stats,
-            shutdown,
-            sweep_cursor,
-            disk_bytes,
-            sweep_threshold_ratio,
+        // ── Spawn independent persist task ────────────────────────────────────
+        // Persists the key_index whenever used_bytes changes, on a schedule independent
+        // of the sweep task. This allows different intervals for sweeping (expensive DashMap
+        // scan) vs persisting (cheap file write).
+        // persist_interval_secs > 0 required to spawn; 0 means disabled (Drop-only persist).
+        if persist_interval_secs > 0 {
+            let persist_token     = instance.shutdown.clone();
+            let persist_key_index = Arc::clone(&instance.key_index);
+            let persist_stats     = Arc::clone(&instance.stats);
+            let persist_dir       = instance.cache_dir.clone();
+            let persist_interval  = Duration::from_secs(persist_interval_secs);
+
+            instance._runtime.spawn(async move {
+                native_bridge_common::log_info!(
+                    "[block-cache] persist task started: interval={}s",
+                    persist_interval_secs
+                );
+                // last_persisted tracks the last used_bytes value at the time of a
+                // successful persist. i64::MIN as a sentinel forces the first persist.
+                let mut last_persisted: i64 = i64::MIN;
+                loop {
+                    tokio::select! {
+                        _ = tokio::time::sleep(persist_interval) => {
+                            let current = persist_stats.used_bytes.load(Ordering::Relaxed);
+                            if current != last_persisted {
+                                match key_index_store::save(&persist_dir, &persist_key_index) {
+                                    Ok(()) => {
+                                        last_persisted = current;
+                                        native_bridge_common::log_debug!(
+                                            "[block-cache] persist task: saved \
+                                             used_bytes={} buckets={}",
+                                            current, persist_key_index.len()
+                                        );
+                                    }
+                                    Err(e) => {
+                                        // Do not update last_persisted — retry on the next tick.
+                                        native_bridge_common::log_info!(
+                                            "[block-cache] persist task FAILED: {}", e
+                                        );
+                                    }
+                                }
+                            }
+                        }
+                        _ = persist_token.cancelled() => {
+                            native_bridge_common::log_info!("[block-cache] persist task stopped");
+                            break;
+                        }
+                    }
+                }
+            });
         }
+
+        instance
+    }
+
+    /// Bulk-load the persisted key_index snapshot into the in-memory DashMap.
+    ///
+    /// # Design: no per-key validation (no `inner.contains()`)
+    /// All keys in the snapshot are inserted directly into `key_index` and
+    /// `used_bytes` is initialised to the sum of all their byte sizes.
+    ///
+    /// Rationale:
+    /// - When below `sweep_threshold_ratio`, Foyer LRU is not actively evicting →
+    ///   the snapshot is accurate. Any minor inaccuracy from entries LRU-evicted
+    ///   between the last periodic persist and shutdown is corrected by the sweep
+    ///   task within `shard_count × sweep_interval_secs` of startup.
+    /// - Skipping `contains()` avoids O(N) hash lookups at startup.
+    /// - The sweep task (already built and tested) handles stale key cleanup for
+    ///   both post-recovery and live-session stale entries uniformly.
+    ///
+    /// # `used_bytes` initialisation
+    /// Initialised to `sum(key_byte_size(k))` for ALL keys in the snapshot. May be
+    /// temporarily over-counted by keys Foyer LRU-evicted between the last periodic
+    /// persist and shutdown. Corrected by sweep.
+    ///
+    /// # Failure modes (all non-fatal)
+    /// - Missing file (clean startup or crash): silently treated as empty.
+    /// - Corrupt JSON or version mismatch: logged as WARN, treated as empty.
+    /// - I/O error: logged as WARN, treated as empty.
+    fn recover_key_index(&mut self) {
+        let t0 = Instant::now();
+        let snapshot = key_index_store::load_or_empty(&self.cache_dir);
+
+        if snapshot.is_empty() {
+            native_bridge_common::log_info!(
+                "[block-cache] key_index recovery: no snapshot (clean startup or crash), dir={}",
+                self.cache_dir.display()
+            );
+            return;
+        }
+
+        // Compute stats before moving snapshot.index into the DashMap.
+        let total_loaded: usize = snapshot.index.values().map(|s| s.len()).sum();
+        let recovered_bytes: i64 = snapshot.index.values()
+            .flat_map(|keys| keys.iter())
+            .map(|k| key_byte_size(k))
+            .sum();
+
+        // Bulk-insert each bucket: DashMap::insert only needs &self (interior mutability).
+        // No per-key inner.contains() — the sweep task corrects stale entries post-startup.
+        for (prefix, keys) in snapshot.index {
+            self.key_index.insert(prefix, keys);
+        }
+
+        // Initialise used_bytes. No put() calls have happened yet so it is 0.
+        self.stats.used_bytes.fetch_add(recovered_bytes, Ordering::Relaxed);
+
+        let elapsed_ms = t0.elapsed().as_millis() as u64;
+        native_bridge_common::log_info!(
+            "[block-cache] key_index recovered: total_keys={} recovered_bytes={} \
+             elapsed_ms={} prefix_buckets={}",
+            total_loaded, recovered_bytes, elapsed_ms, self.key_index.len()
+        );
     }
 
     /// Sweep one DashMap shard per call and advance the cursor.
@@ -576,6 +742,14 @@ impl BlockCache for FoyerCache {
             self.stats.removed_bytes.fetch_add(total_removed_bytes, Ordering::Relaxed);
         }
         let _ = self.inner.clear().await;
+
+        // Delete the persisted key_index files so the next startup does not bulk-load
+        // stale keys into a freshly-cleared cache.
+        if let Err(e) = key_index_store::delete(&self.cache_dir) {
+            native_bridge_common::log_info!(
+                "[block-cache] key_index clear: failed to delete snapshot files: {}", e
+            );
+        }
         })
     }
 }

--- a/sandbox/plugins/block-cache-foyer/src/main/rust/src/key_index_store.rs
+++ b/sandbox/plugins/block-cache-foyer/src/main/rust/src/key_index_store.rs
@@ -1,0 +1,394 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+//! Persistence helpers for the [`FoyerCache`] key_index.
+//!
+//! Provides atomic save/load/delete for a JSON snapshot of the
+//! `DashMap<String, HashSet<String>>` key_index. The file lives inside the
+//! Foyer cache directory alongside the Foyer segment files.
+//!
+//! ## File format
+//! ```json
+//! {"version":1,"index":{"data/shard/_0.parquet":["data/shard/_0.parquet\u001f0-4096"]}}
+//! ```
+//!
+//! ## Crash safety
+//! `save()` writes to `.key_index.json.tmp` then renames to `key_index.json`.
+//! The rename is atomic on POSIX filesystems. A crash between the two steps
+//! leaves the `.tmp` file behind; `load()` uses it as a fallback and then
+//! deletes it.
+//!
+//! [`FoyerCache`]: crate::foyer::foyer_cache::FoyerCache
+
+use std::collections::{HashMap, HashSet};
+use std::io::{self, ErrorKind};
+use std::path::Path;
+
+use dashmap::DashMap;
+use serde::{Deserialize, Serialize};
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+/// Format version embedded in every snapshot. Bump when the schema changes
+/// incompatibly; old files with a different version are rejected on load.
+pub const SNAPSHOT_VERSION: u32 = 1;
+
+/// Name of the committed snapshot file inside the cache directory.
+pub const KEY_INDEX_FILENAME: &str = "key_index.json";
+
+/// Name of the in-progress temp file used during an atomic write.
+pub const KEY_INDEX_TMP_FILENAME: &str = ".key_index.json.tmp";
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+/// Deserialized representation of the key_index snapshot.
+///
+/// Used exclusively by `load()` / `parse_and_validate()`. `save()` serializes
+/// the live `DashMap` directly via `serde_json::json!` — no conversion to this
+/// struct on the write path.
+///
+/// The `index` field deserializes from the JSON object produced by DashMap's
+/// `Serialize` impl: both produce `{"prefix": ["key1", "key2", ...], ...}`.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct KeyIndexSnapshot {
+    /// Format version. Must equal [`SNAPSHOT_VERSION`] to be accepted.
+    pub version: u32,
+    /// Deserialized key_index: prefix → set of Foyer keys.
+    pub index: HashMap<String, HashSet<String>>,
+}
+
+impl KeyIndexSnapshot {
+    /// Return an empty snapshot with the current version.
+    /// Used as a fallback when the snapshot file is missing or unparseable.
+    pub fn empty() -> Self {
+        Self { version: SNAPSHOT_VERSION, index: HashMap::new() }
+    }
+
+    /// Return `true` when there are no prefix buckets in this snapshot.
+    pub fn is_empty(&self) -> bool {
+        self.index.is_empty()
+    }
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/// Atomically write the key_index snapshot to `<dir>/key_index.json`.
+///
+/// Serializes the DashMap directly (no intermediate HashMap copy) using
+/// DashMap's own `Serialize` impl (enabled via the `serde` workspace feature).
+/// A concurrent `put()` racing with this call may or may not appear in the
+/// snapshot — both outcomes are acceptable; the next periodic persist or
+/// graceful-shutdown `Drop` will capture any missed keys.
+///
+/// # Error handling
+/// Returns `Err` on I/O failure. Callers (the persist task and `Drop`) log
+/// the error but do not propagate it — a failed persist is not fatal.
+pub fn save(dir: &Path, key_index: &DashMap<String, HashSet<String>>) -> io::Result<()> {
+    // DashMap implements Serialize (workspace feature "serde" enabled for dashmap).
+    // Serialize directly — no intermediate HashMap copy needed.
+    let json = serde_json::to_string(&serde_json::json!({
+        "version": SNAPSHOT_VERSION,
+        "index": key_index
+    }))
+    .map_err(|e| io::Error::new(ErrorKind::InvalidData, e))?;
+
+    let tmp_path   = dir.join(KEY_INDEX_TMP_FILENAME);
+    let final_path = dir.join(KEY_INDEX_FILENAME);
+
+    // Atomic write: write to .tmp then rename.
+    // If the process crashes between write and rename, .tmp is left behind;
+    // load() will fall back to it on the next startup.
+    std::fs::write(&tmp_path, json.as_bytes())?;
+    std::fs::rename(&tmp_path, &final_path)?;
+
+    Ok(())
+}
+
+/// Load the key_index snapshot from `<dir>/key_index.json`.
+///
+/// # Load strategy
+/// 1. Try `key_index.json` (primary). Success → return snapshot.
+/// 2. If `key_index.json` is absent, try `.key_index.json.tmp` (fallback for
+///    the crash-during-rename edge case). Success → log WARN, return snapshot.
+/// 3. Both absent → return `Err(NotFound)`.
+///
+/// `key_index.json` is always preferred: it is the last *successfully committed*
+/// snapshot. If both files exist, the rename completed and `.tmp` is stale.
+///
+/// # Cleanup
+/// Deletes `.key_index.json.tmp` after every load attempt to prevent stale
+/// temp files from accumulating across restarts.
+pub fn load(dir: &Path) -> io::Result<KeyIndexSnapshot> {
+    let result = load_inner(dir);
+
+    let tmp_path = dir.join(KEY_INDEX_TMP_FILENAME);
+    if tmp_path.exists() {
+        let _ = std::fs::remove_file(&tmp_path);
+    }
+
+    result
+}
+
+fn load_inner(dir: &Path) -> io::Result<KeyIndexSnapshot> {
+    let final_path = dir.join(KEY_INDEX_FILENAME);
+    let tmp_path   = dir.join(KEY_INDEX_TMP_FILENAME);
+
+    // 1. Try the committed file.
+    match std::fs::read_to_string(&final_path) {
+        Ok(contents) => return parse_and_validate(&contents),
+        Err(e) if e.kind() == ErrorKind::NotFound => {}
+        Err(e) => return Err(e),
+    }
+
+    // 2. Fallback: .tmp (crash-during-rename recovery).
+    match std::fs::read_to_string(&tmp_path) {
+        Ok(contents) => {
+            native_bridge_common::log_info!(
+                "[block-cache] key_index: using .tmp fallback (crash during rename?), dir={}",
+                dir.display()
+            );
+            parse_and_validate(&contents)
+        }
+        Err(e) if e.kind() == ErrorKind::NotFound => {
+            Err(io::Error::new(ErrorKind::NotFound, "key_index.json not found"))
+        }
+        Err(e) => Err(e),
+    }
+}
+
+fn parse_and_validate(contents: &str) -> io::Result<KeyIndexSnapshot> {
+    let snapshot: KeyIndexSnapshot = serde_json::from_str(contents)
+        .map_err(|e| io::Error::new(ErrorKind::InvalidData, e))?;
+
+    if snapshot.version != SNAPSHOT_VERSION {
+        return Err(io::Error::new(
+            ErrorKind::InvalidData,
+            format!(
+                "key_index version mismatch: expected {}, got {}",
+                SNAPSHOT_VERSION, snapshot.version
+            ),
+        ));
+    }
+
+    Ok(snapshot)
+}
+
+/// Load the snapshot, returning an empty snapshot on any error.
+///
+/// - `NotFound` → empty, silently. Normal for first-ever startup or after a
+///   crash where graceful shutdown (`Drop`) was not called.
+/// - Any other error → logs WARN, returns empty. Never fails startup.
+pub fn load_or_empty(dir: &Path) -> KeyIndexSnapshot {
+    match load(dir) {
+        Ok(snapshot) => snapshot,
+        Err(e) if e.kind() == ErrorKind::NotFound => KeyIndexSnapshot::empty(),
+        Err(e) => {
+            native_bridge_common::log_info!(
+                "[block-cache] WARNING: key_index load failed, starting empty: {} — {}",
+                dir.display(),
+                e
+            );
+            KeyIndexSnapshot::empty()
+        }
+    }
+}
+
+/// Delete both `key_index.json` and `.key_index.json.tmp` from `dir`.
+///
+/// `NotFound` is treated as success for both files.
+/// Called by `FoyerCache::clear()` so the next startup does not bulk-load
+/// stale keys into a freshly-cleared cache.
+pub fn delete(dir: &Path) -> io::Result<()> {
+    for name in [KEY_INDEX_FILENAME, KEY_INDEX_TMP_FILENAME] {
+        match std::fs::remove_file(dir.join(name)) {
+            Ok(()) => {}
+            Err(e) if e.kind() == ErrorKind::NotFound => {}
+            Err(e) => return Err(e),
+        }
+    }
+    Ok(())
+}
+
+// ── Unit tests ────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+    use tempfile::TempDir;
+
+    fn make_map(entries: Vec<(&str, Vec<&str>)>) -> DashMap<String, HashSet<String>> {
+        let map = DashMap::new();
+        for (prefix, keys) in entries {
+            let set: HashSet<String> = keys.into_iter().map(String::from).collect();
+            map.insert(prefix.to_string(), set);
+        }
+        map
+    }
+
+    // ── save + load roundtrip ─────────────────────────────────────────────────
+
+    #[test]
+    fn test_save_and_load_roundtrip() {
+        let dir = TempDir::new().unwrap();
+        let map = make_map(vec![
+            ("data/a.parquet", vec!["data/a.parquet\x1F0-100", "data/a.parquet\x1F100-200"]),
+            ("data/b.parquet", vec!["data/b.parquet\x1F0-512", "data/b.parquet\x1F512-1024"]),
+            ("data/c.parquet", vec!["data/c.parquet\x1F0-4096", "data/c.parquet\x1F4096-8192"]),
+        ]);
+
+        save(dir.path(), &map).expect("save must succeed");
+        assert!(dir.path().join(KEY_INDEX_FILENAME).exists());
+
+        let snapshot = load(dir.path()).expect("load must succeed");
+        assert_eq!(snapshot.version, SNAPSHOT_VERSION);
+        assert_eq!(snapshot.index.len(), 3);
+        let total_keys: usize = snapshot.index.values().map(|s| s.len()).sum();
+        assert_eq!(total_keys, 6);
+    }
+
+    #[test]
+    fn test_separator_in_keys_roundtrip() {
+        let dir = TempDir::new().unwrap();
+        let key = "data/nodes/0/file.parquet\x1F99999-200000";
+        let map = make_map(vec![("data/nodes/0/file.parquet", vec![key])]);
+
+        save(dir.path(), &map).unwrap();
+        let snapshot = load(dir.path()).unwrap();
+        let keys = snapshot.index.get("data/nodes/0/file.parquet").unwrap();
+        assert!(keys.contains(key), "\\x1F separator must survive serde roundtrip");
+    }
+
+    #[test]
+    fn test_save_empty_map_produces_valid_file() {
+        let dir = TempDir::new().unwrap();
+        let map: DashMap<String, HashSet<String>> = DashMap::new();
+        save(dir.path(), &map).unwrap();
+        let snapshot = load(dir.path()).unwrap();
+        assert!(snapshot.index.is_empty());
+    }
+
+    // ── load error cases ──────────────────────────────────────────────────────
+
+    #[test]
+    fn test_load_returns_not_found_for_missing_file() {
+        let dir = TempDir::new().unwrap();
+        assert_eq!(load(dir.path()).unwrap_err().kind(), ErrorKind::NotFound);
+    }
+
+    #[test]
+    fn test_load_or_empty_returns_empty_for_missing_file() {
+        let dir = TempDir::new().unwrap();
+        assert!(load_or_empty(dir.path()).is_empty());
+    }
+
+    #[test]
+    fn test_load_or_empty_returns_empty_for_corrupt_json() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join(KEY_INDEX_FILENAME), b"{{not valid json}}").unwrap();
+        assert!(load_or_empty(dir.path()).is_empty());
+    }
+
+    #[test]
+    fn test_load_rejects_wrong_version() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(
+            dir.path().join(KEY_INDEX_FILENAME),
+            br#"{"version":999,"index":{}}"#,
+        ).unwrap();
+        assert_eq!(load(dir.path()).unwrap_err().kind(), ErrorKind::InvalidData);
+    }
+
+    // ── atomic write ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_save_is_atomic_no_tmp_file_on_success() {
+        let dir = TempDir::new().unwrap();
+        save(dir.path(), &make_map(vec![("p", vec!["p\x1F0-1"])])).unwrap();
+        assert!(dir.path().join(KEY_INDEX_FILENAME).exists());
+        assert!(!dir.path().join(KEY_INDEX_TMP_FILENAME).exists());
+    }
+
+    // ── .tmp fallback ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_load_uses_tmp_fallback_when_main_file_absent() {
+        let dir = TempDir::new().unwrap();
+        let snap = KeyIndexSnapshot {
+            version: SNAPSHOT_VERSION,
+            index: {
+                let mut m = HashMap::new();
+                m.insert("data/x.parquet".to_string(), ["data/x.parquet\x1F0-100".to_string()].into());
+                m
+            },
+        };
+        let json = serde_json::to_string(&snap).unwrap();
+        std::fs::write(dir.path().join(KEY_INDEX_TMP_FILENAME), json.as_bytes()).unwrap();
+        assert!(!dir.path().join(KEY_INDEX_FILENAME).exists());
+
+        let loaded = load(dir.path()).expect(".tmp fallback must succeed");
+        assert_eq!(loaded.index.len(), 1);
+        assert!(loaded.index.contains_key("data/x.parquet"));
+        assert!(!dir.path().join(KEY_INDEX_TMP_FILENAME).exists(), ".tmp must be deleted");
+    }
+
+    #[test]
+    fn test_load_prefers_main_file_over_tmp() {
+        let dir = TempDir::new().unwrap();
+        let main_snap = KeyIndexSnapshot {
+            version: SNAPSHOT_VERSION,
+            index: { let mut m = HashMap::new(); m.insert("main".to_string(), HashSet::new()); m },
+        };
+        let tmp_snap = KeyIndexSnapshot {
+            version: SNAPSHOT_VERSION,
+            index: { let mut m = HashMap::new(); m.insert("tmp".to_string(), HashSet::new()); m },
+        };
+        std::fs::write(dir.path().join(KEY_INDEX_FILENAME), serde_json::to_string(&main_snap).unwrap().as_bytes()).unwrap();
+        std::fs::write(dir.path().join(KEY_INDEX_TMP_FILENAME), serde_json::to_string(&tmp_snap).unwrap().as_bytes()).unwrap();
+
+        let loaded = load(dir.path()).unwrap();
+        assert!(loaded.index.contains_key("main"));
+        assert!(!loaded.index.contains_key("tmp"));
+        assert!(!dir.path().join(KEY_INDEX_TMP_FILENAME).exists());
+    }
+
+    #[test]
+    fn test_load_tmp_fallback_also_fails_returns_not_found() {
+        let dir = TempDir::new().unwrap();
+        assert_eq!(load(dir.path()).unwrap_err().kind(), ErrorKind::NotFound);
+    }
+
+    #[test]
+    fn test_load_cleans_up_tmp_even_when_main_succeeds() {
+        let dir = TempDir::new().unwrap();
+        let snap = KeyIndexSnapshot { version: SNAPSHOT_VERSION, index: HashMap::new() };
+        std::fs::write(dir.path().join(KEY_INDEX_FILENAME), serde_json::to_string(&snap).unwrap().as_bytes()).unwrap();
+        std::fs::write(dir.path().join(KEY_INDEX_TMP_FILENAME), b"stale").unwrap();
+
+        load(dir.path()).unwrap();
+        assert!(!dir.path().join(KEY_INDEX_TMP_FILENAME).exists());
+    }
+
+    // ── delete ────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_delete_removes_both_files() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join(KEY_INDEX_FILENAME), b"x").unwrap();
+        std::fs::write(dir.path().join(KEY_INDEX_TMP_FILENAME), b"y").unwrap();
+        delete(dir.path()).unwrap();
+        assert!(!dir.path().join(KEY_INDEX_FILENAME).exists());
+        assert!(!dir.path().join(KEY_INDEX_TMP_FILENAME).exists());
+    }
+
+    #[test]
+    fn test_delete_is_noop_for_missing_files() {
+        let dir = TempDir::new().unwrap();
+        delete(dir.path()).unwrap();
+    }
+}

--- a/sandbox/plugins/block-cache-foyer/src/main/rust/src/lib.rs
+++ b/sandbox/plugins/block-cache-foyer/src/main/rust/src/lib.rs
@@ -9,6 +9,7 @@
 pub mod range_cache;
 pub mod stats;
 pub mod traits;
+pub mod key_index_store;
 pub mod foyer;
 
 #[cfg(test)]

--- a/sandbox/plugins/block-cache-foyer/src/main/rust/src/tests.rs
+++ b/sandbox/plugins/block-cache-foyer/src/main/rust/src/tests.rs
@@ -1788,3 +1788,646 @@ fn sweep_once_ignores_threshold_guard() {
     assert_eq!(removed, 1, "sweep_once() must sweep regardless of threshold");
     assert!(cache.key_index.is_empty(), "stale key must be removed by sweep_once() even when threshold would skip");
 }
+
+// ── Recovery / persistence integration tests ─────────────────────────────────
+//
+// These tests exercise the full put → Drop (persist) → new (recover) cycle.
+// They use real FoyerCache instances and TempDir.
+//
+// Design note: recovery uses bulk-load (no per-key inner.contains() validation).
+// Stale entries from the snapshot are corrected lazily by the sweep task.
+
+use crate::key_index_store;
+
+/// Graceful restart: key_index is persisted on Drop and bulk-loaded on the next
+/// startup. All prefix buckets and keys are present immediately after new().
+#[test]
+fn recovery_key_index_bulk_loaded_after_graceful_shutdown() {
+    let dir = TempDir::new().unwrap();
+
+    // Write entries into the first cache instance.
+    {
+        let cache = FoyerCache::new(TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE, 0, 0.0, 0);
+        put_range(&cache, "/data/a.parquet", 0,   512, &vec![0u8; 512]);
+        put_range(&cache, "/data/a.parquet", 512, 1024, &vec![0u8; 512]);
+        put_range(&cache, "/data/b.parquet", 0,   256, &vec![0u8; 256]);
+        // Drop calls save() — writes key_index.json
+    }
+
+    // key_index.json must exist after graceful shutdown.
+    assert!(dir.path().join(key_index_store::KEY_INDEX_FILENAME).exists(),
+        "key_index.json must be written on Drop");
+
+    // Second instance: recover from the snapshot.
+    let cache2 = FoyerCache::new(TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE, 0, 0.0, 0);
+
+    // Both prefix buckets must be present immediately after new().
+    assert!(cache2.key_index.contains_key("data/a.parquet"),
+        "data/a.parquet must be in key_index after recovery");
+    assert!(cache2.key_index.contains_key("data/b.parquet"),
+        "data/b.parquet must be in key_index after recovery");
+
+    // 2 keys for a.parquet + 1 key for b.parquet = 3 total.
+    let a_count = cache2.key_index.get("data/a.parquet").map(|v| v.len()).unwrap_or(0);
+    let b_count = cache2.key_index.get("data/b.parquet").map(|v| v.len()).unwrap_or(0);
+    assert_eq!(a_count, 2, "data/a.parquet must have 2 keys");
+    assert_eq!(b_count, 1, "data/b.parquet must have 1 key");
+}
+
+/// used_bytes is initialized from the snapshot on recovery.
+/// The sum of key_byte_size for all recovered keys must equal used_bytes
+/// immediately after new() — before any put() is called.
+#[test]
+fn recovery_used_bytes_initialized_from_snapshot() {
+    let dir = TempDir::new().unwrap();
+
+    {
+        let cache = FoyerCache::new(TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE, 0, 0.0, 0);
+        // 3 ranges: 100 + 200 + 300 = 600 bytes total.
+        put_range(&cache, "/data/f.parquet", 0,   100, &vec![0u8; 100]);
+        put_range(&cache, "/data/f.parquet", 100, 300, &vec![0u8; 200]);
+        put_range(&cache, "/data/f.parquet", 300, 600, &vec![0u8; 300]);
+        // Drop persists.
+    }
+
+    let cache2 = FoyerCache::new(TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE, 0, 0.0, 0);
+    let used = cache2.stats.used_bytes.load(std::sync::atomic::Ordering::Relaxed);
+    assert_eq!(used, 600,
+        "used_bytes must be 600 (sum of all recovered key ranges) after recovery");
+}
+
+/// After recovery, evict_prefix() correctly removes entries that were loaded
+/// from the snapshot — not just entries added in the current session.
+#[test]
+fn recovery_evict_prefix_works_on_recovered_keys() {
+    let dir = TempDir::new().unwrap();
+
+    {
+        let cache = FoyerCache::new(TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE, 0, 0.0, 0);
+        put_range(&cache, "/data/shard1/file.parquet", 0, 512, &vec![0u8; 512]);
+        put_range(&cache, "/data/shard2/file.parquet", 0, 512, &vec![0u8; 512]);
+        // Drop persists.
+    }
+
+    let cache2 = FoyerCache::new(TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE, 0, 0.0, 0);
+    assert!(cache2.key_index.contains_key("data/shard1/file.parquet"));
+    assert!(cache2.key_index.contains_key("data/shard2/file.parquet"));
+
+    // Evict one shard — only that shard's entry must be removed.
+    cache2.evict_prefix("/data/shard1");
+    assert!(!cache2.key_index.contains_key("data/shard1/file.parquet"),
+        "evict_prefix must remove recovered shard1 entries");
+    assert!(cache2.key_index.contains_key("data/shard2/file.parquet"),
+        "shard2 must be untouched");
+}
+
+/// Clean startup (no key_index.json) is a no-op: key_index starts empty,
+/// used_bytes is 0, cache is fully functional.
+#[test]
+fn recovery_with_no_snapshot_is_clean_startup() {
+    let dir = TempDir::new().unwrap();
+    // No prior cache instance — key_index.json does not exist.
+    assert!(!dir.path().join(key_index_store::KEY_INDEX_FILENAME).exists());
+
+    let cache = FoyerCache::new(TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE, 0, 0.0, 0);
+    assert!(cache.key_index.is_empty(), "key_index must be empty on clean startup");
+    assert_eq!(cache.stats.used_bytes.load(std::sync::atomic::Ordering::Relaxed), 0);
+
+    // Cache must still be fully functional.
+    put_range(&cache, "/data/file.parquet", 0, 100, b"data");
+    assert!(cache.key_index.contains_key("data/file.parquet"));
+}
+
+/// A corrupt key_index.json (invalid JSON) is treated as a clean startup.
+/// The cache starts with an empty key_index and is fully functional.
+#[test]
+fn recovery_with_corrupt_snapshot_starts_empty() {
+    let dir = TempDir::new().unwrap();
+    std::fs::write(dir.path().join(key_index_store::KEY_INDEX_FILENAME), b"{{corrupt}}")
+        .unwrap();
+
+    let cache = FoyerCache::new(TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE, 0, 0.0, 0);
+    assert!(cache.key_index.is_empty(), "corrupt snapshot must produce empty key_index");
+    assert_eq!(cache.stats.used_bytes.load(std::sync::atomic::Ordering::Relaxed), 0);
+
+    // Cache must still be fully functional.
+    put_range(&cache, "/data/file.parquet", 0, 100, b"data");
+    assert!(cache.key_index.contains_key("data/file.parquet"));
+}
+
+/// evict_prefix() followed by Drop: the evicted prefix must NOT appear in the
+/// persisted snapshot and therefore must NOT be loaded on the next startup.
+#[test]
+fn recovery_evicted_prefix_not_persisted() {
+    let dir = TempDir::new().unwrap();
+
+    {
+        let cache = FoyerCache::new(TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE, 0, 0.0, 0);
+        put_range(&cache, "/data/evicted.parquet", 0, 512, &vec![0u8; 512]);
+        put_range(&cache, "/data/kept.parquet",   0, 512, &vec![0u8; 512]);
+
+        // Evict one prefix before shutdown.
+        cache.evict_prefix("/data/evicted.parquet");
+        assert!(!cache.key_index.contains_key("data/evicted.parquet"));
+        // Drop persists the remaining key_index (only kept.parquet).
+    }
+
+    let cache2 = FoyerCache::new(TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE, 0, 0.0, 0);
+    assert!(!cache2.key_index.contains_key("data/evicted.parquet"),
+        "evicted prefix must not appear in recovered key_index");
+    assert!(cache2.key_index.contains_key("data/kept.parquet"),
+        "non-evicted prefix must still appear after recovery");
+}
+
+/// clear() deletes key_index.json so the next startup does not load stale keys.
+#[test]
+fn recovery_clear_deletes_snapshot_file() {
+    let dir = TempDir::new().unwrap();
+
+    // Create and drop a cache to write key_index.json.
+    {
+        let cache = FoyerCache::new(TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE, 0, 0.0, 0);
+        put_range(&cache, "/data/file.parquet", 0, 100, b"data");
+        // Drop writes key_index.json.
+    }
+    assert!(dir.path().join(key_index_store::KEY_INDEX_FILENAME).exists(),
+        "key_index.json must exist after first Drop");
+
+    // Create a second cache and call clear().
+    {
+        let cache2 = FoyerCache::new(TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE, 0, 0.0, 0);
+        block_on(cache2.clear());
+        // Drop of cache2 writes an empty key_index.json (empty key_index after clear).
+    }
+
+    // Third instance: must start with an empty key_index (clear deleted the stale snapshot).
+    let cache3 = FoyerCache::new(TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE, 0, 0.0, 0);
+    assert!(cache3.key_index.is_empty(),
+        "key_index must be empty after clear() deleted the snapshot");
+}
+
+// ── Periodic persist task tests ──────────────────────────────────────────────
+//
+// These tests exercise the independent persist task that flushes the key_index
+// to disk every `persist_interval_secs` seconds when `used_bytes` has changed.
+// They use short intervals (1–2 seconds) and poll for the file's existence.
+
+/// PP-01 / PP-06: persist task starts when interval > 0 and is absent when interval = 0.
+/// Verifies that key_index.json is written by the periodic task (not just by Drop)
+/// by checking file existence before Drop is called.
+#[test]
+fn persist_task_writes_snapshot_within_interval() {
+    let dir = TempDir::new().unwrap();
+    {
+        // persist_interval=1s: task should fire within ~2s of a put().
+        let cache = FoyerCache::new(
+            TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE,
+            0,    // sweep disabled
+            0.0,  // threshold disabled
+            1,    // persist every 1 second
+        );
+        put_range(&cache, "/data/periodic.parquet", 0, 512, &vec![0u8; 512]);
+
+        // Poll for key_index.json to appear (written by the persist task, not Drop).
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        let appeared = loop {
+            if dir.path().join(key_index_store::KEY_INDEX_FILENAME).exists() {
+                break true;
+            }
+            if std::time::Instant::now() >= deadline {
+                break false;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(100));
+        };
+        assert!(appeared, "key_index.json must be written by persist task within 5s");
+
+        // Verify the content is valid (not just an empty file).
+        let contents = std::fs::read_to_string(dir.path().join(key_index_store::KEY_INDEX_FILENAME)).unwrap();
+        let snap: serde_json::Value = serde_json::from_str(&contents).unwrap();
+        assert_eq!(snap["version"], 1, "snapshot must have version=1");
+        let index = snap["index"].as_object().unwrap();
+        assert!(!index.is_empty(), "snapshot must contain the put() entries");
+        // cache is dropped here — Drop also writes a final snapshot
+    }
+}
+
+/// PP-04: persist task does NOT write key_index.json when used_bytes has not changed
+/// (idle cache). The sentinel `i64::MIN` forces the first tick to always persist,
+/// so we verify that a second interval tick with no puts does not change the mtime.
+///
+/// Note: this test uses a 2-second interval and checks mtime doesn't advance
+/// between the 2nd and 3rd ticks when no puts happen.
+#[test]
+fn persist_task_does_not_fire_when_cache_idle() {
+    let dir = TempDir::new().unwrap();
+    {
+        // persist_interval=1s
+        let cache = FoyerCache::new(
+            TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE,
+            0, 0.0, 1,
+        );
+        // Single put to trigger the first persist.
+        put_range(&cache, "/data/idle.parquet", 0, 100, &vec![0u8; 100]);
+
+        // Wait for the first persist (sentinel → current triggers it).
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        while !dir.path().join(key_index_store::KEY_INDEX_FILENAME).exists() {
+            if std::time::Instant::now() >= deadline { break; }
+            std::thread::sleep(std::time::Duration::from_millis(100));
+        }
+        assert!(dir.path().join(key_index_store::KEY_INDEX_FILENAME).exists(),
+            "first persist must have fired");
+
+        // Record mtime after first persist.
+        let mtime_after_first = std::fs::metadata(dir.path().join(key_index_store::KEY_INDEX_FILENAME))
+            .unwrap().modified().unwrap();
+
+        // Wait 2.5 intervals with NO new puts — used_bytes is unchanged so persist must NOT fire.
+        std::thread::sleep(std::time::Duration::from_millis(2500));
+
+        let mtime_after_idle = std::fs::metadata(dir.path().join(key_index_store::KEY_INDEX_FILENAME))
+            .unwrap().modified().unwrap();
+
+        assert_eq!(mtime_after_first, mtime_after_idle,
+            "persist task must NOT rewrite key_index.json when cache is idle (used_bytes unchanged)");
+    }
+}
+
+/// PP-05: persist fires after evict_prefix() because used_bytes changes.
+#[test]
+fn persist_task_fires_after_evict_prefix_changes_used_bytes() {
+    let dir = TempDir::new().unwrap();
+    {
+        let cache = FoyerCache::new(
+            TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE,
+            0, 0.0, 1,
+        );
+        put_range(&cache, "/data/evict_me.parquet", 0, 512, &vec![0u8; 512]);
+        put_range(&cache, "/data/keep_me.parquet",   0, 512, &vec![0u8; 512]);
+
+        // Wait for first persist (sentinel fires on first tick).
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        while !dir.path().join(key_index_store::KEY_INDEX_FILENAME).exists() {
+            if std::time::Instant::now() >= deadline { break; }
+            std::thread::sleep(std::time::Duration::from_millis(100));
+        }
+
+        // Evict one prefix — changes used_bytes so next tick must persist.
+        cache.evict_prefix("/data/evict_me.parquet");
+        let used_after_evict = cache.stats.used_bytes.load(std::sync::atomic::Ordering::Relaxed);
+        assert!(used_after_evict < 1024, "used_bytes must decrease after evict");
+
+        let mtime_before = std::fs::metadata(dir.path().join(key_index_store::KEY_INDEX_FILENAME))
+            .unwrap().modified().unwrap();
+
+        // Wait up to 3 intervals for the next persist.
+        std::thread::sleep(std::time::Duration::from_millis(3000));
+        let mtime_after = std::fs::metadata(dir.path().join(key_index_store::KEY_INDEX_FILENAME))
+            .unwrap().modified().unwrap();
+        assert!(mtime_after > mtime_before,
+            "persist task must rewrite key_index.json after evict_prefix() changed used_bytes");
+    }
+}
+
+/// PP-06: persist disabled when interval=0 — no persist task spawned.
+/// The file should NOT exist until Drop is called.
+#[test]
+fn persist_task_not_spawned_when_interval_is_zero() {
+    let dir = TempDir::new().unwrap();
+    {
+        // persist_interval=0: only Drop persists.
+        let cache = FoyerCache::new(
+            TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE,
+            0, 0.0,
+            0,  // disabled
+        );
+        put_range(&cache, "/data/file.parquet", 0, 100, &vec![0u8; 100]);
+
+        // Wait 2 seconds — file must NOT appear (no persist task).
+        std::thread::sleep(std::time::Duration::from_millis(2000));
+        assert!(!dir.path().join(key_index_store::KEY_INDEX_FILENAME).exists(),
+            "key_index.json must NOT exist while cache is alive with persist_interval=0");
+
+        // Drop is called here — final persist happens.
+    }
+    // After Drop, key_index.json must exist.
+    assert!(dir.path().join(key_index_store::KEY_INDEX_FILENAME).exists(),
+        "key_index.json must be written by Drop even when persist task is disabled");
+}
+
+/// CR-05 simulation: simulate a crash by using `std::mem::forget` to prevent Drop.
+/// The key_index.json must NOT be written (or must be old) since Drop is skipped.
+/// On the next startup, the cache recovers from whatever was last periodically persisted
+/// (or starts empty if periodic persist was also disabled).
+#[test]
+fn simulated_crash_skip_drop_no_final_persist() {
+    let dir = TempDir::new().unwrap();
+
+    // Build a cache with persist_interval=0 (no periodic persist either).
+    // This simulates a node with only Drop-based persistence.
+    let cache = FoyerCache::new(
+        TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE,
+        0, 0.0, 0,
+    );
+    put_range(&cache, "/data/crash.parquet", 0, 512, &vec![0u8; 512]);
+
+    // key_index.json does NOT exist yet (no periodic persist, Drop not called).
+    assert!(!dir.path().join(key_index_store::KEY_INDEX_FILENAME).exists(),
+        "key_index.json must not exist before Drop");
+
+    // Simulate crash: forget the cache — Drop is NOT called.
+    std::mem::forget(cache);
+
+    // key_index.json must still NOT exist (Drop was skipped).
+    assert!(!dir.path().join(key_index_store::KEY_INDEX_FILENAME).exists(),
+        "key_index.json must not exist after simulated crash (Drop skipped)");
+
+    // Next startup: key_index starts empty (clean startup path).
+    let cache2 = FoyerCache::new(
+        TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE,
+        0, 0.0, 0,
+    );
+    assert!(cache2.key_index.is_empty(),
+        "key_index must be empty after simulated crash with no prior snapshot");
+    assert_eq!(cache2.stats.used_bytes.load(std::sync::atomic::Ordering::Relaxed), 0);
+}
+
+/// GS-03 / GS-04: verify key_index.json content is valid JSON with correct version and index.
+#[test]
+fn graceful_shutdown_snapshot_is_valid_json_with_correct_content() {
+    let dir = TempDir::new().unwrap();
+    {
+        let cache = FoyerCache::new(
+            TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE,
+            0, 0.0, 0,
+        );
+        put_range(&cache, "/data/nodes/0/shard1.parquet", 0,   256, &vec![0u8; 256]);
+        put_range(&cache, "/data/nodes/0/shard1.parquet", 256, 512, &vec![0u8; 256]);
+        put_range(&cache, "/data/nodes/0/shard2.parquet", 0,   128, &vec![0u8; 128]);
+        // Drop writes key_index.json.
+    }
+
+    let path = dir.path().join(key_index_store::KEY_INDEX_FILENAME);
+    assert!(path.exists(), "key_index.json must exist after graceful shutdown");
+
+    let contents = std::fs::read_to_string(&path).unwrap();
+    assert!(!contents.is_empty(), "key_index.json must not be empty");
+
+    // Parse and validate structure.
+    let parsed: serde_json::Value = serde_json::from_str(&contents)
+        .expect("key_index.json must be valid JSON");
+    assert_eq!(parsed["version"], 1, "version must be 1");
+
+    let index = parsed["index"].as_object().expect("index must be a JSON object");
+    assert_eq!(index.len(), 2, "must have 2 prefix buckets");
+
+    // shard1 should have 2 keys, shard2 should have 1.
+    let shard1_keys = index["data/nodes/0/shard1.parquet"].as_array().unwrap();
+    let shard2_keys = index["data/nodes/0/shard2.parquet"].as_array().unwrap();
+    assert_eq!(shard1_keys.len(), 2, "shard1 must have 2 keys");
+    assert_eq!(shard2_keys.len(), 1, "shard2 must have 1 key");
+}
+
+/// No .tmp file should exist after either graceful shutdown or periodic persist.
+#[test]
+fn no_tmp_file_left_after_graceful_shutdown() {
+    let dir = TempDir::new().unwrap();
+    {
+        let cache = FoyerCache::new(
+            TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE,
+            0, 0.0, 0,
+        );
+        put_range(&cache, "/data/file.parquet", 0, 100, &vec![0u8; 100]);
+        // Drop writes and renames.
+    }
+    assert!(!dir.path().join(key_index_store::KEY_INDEX_TMP_FILENAME).exists(),
+        ".key_index.json.tmp must not exist after graceful shutdown (rename completed)");
+    assert!(dir.path().join(key_index_store::KEY_INDEX_FILENAME).exists(),
+        "key_index.json must exist after graceful shutdown");
+}
+
+/// VM-03: zero-byte key_index.json → treated as corrupt → clean startup.
+#[test]
+fn zero_byte_snapshot_file_treated_as_corrupt() {
+    let dir = TempDir::new().unwrap();
+    // Write an empty file.
+    std::fs::write(dir.path().join(key_index_store::KEY_INDEX_FILENAME), b"").unwrap();
+
+    let cache = FoyerCache::new(
+        TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE,
+        0, 0.0, 0,
+    );
+    assert!(cache.key_index.is_empty(),
+        "zero-byte snapshot must produce empty key_index (clean startup)");
+    assert_eq!(cache.stats.used_bytes.load(std::sync::atomic::Ordering::Relaxed), 0);
+    // Cache must be fully functional.
+    put_range(&cache, "/data/file.parquet", 0, 100, b"data");
+    assert!(cache.key_index.contains_key("data/file.parquet"));
+}
+
+/// ST-04: no .tmp file exists on clean startup (fresh dir).
+#[test]
+fn no_tmp_file_on_clean_startup() {
+    let dir = TempDir::new().unwrap();
+    // Verify neither file exists before creating the cache.
+    assert!(!dir.path().join(key_index_store::KEY_INDEX_FILENAME).exists());
+    assert!(!dir.path().join(key_index_store::KEY_INDEX_TMP_FILENAME).exists());
+
+    let cache = FoyerCache::new(
+        TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE,
+        0, 0.0, 0,
+    );
+    // On startup, no .tmp should be created or left behind.
+    assert!(!dir.path().join(key_index_store::KEY_INDEX_TMP_FILENAME).exists(),
+        ".key_index.json.tmp must not exist after clean startup");
+    drop(cache);
+    assert!(!dir.path().join(key_index_store::KEY_INDEX_TMP_FILENAME).exists(),
+        ".key_index.json.tmp must not exist after graceful shutdown");
+}
+
+/// Stale entries in the recovered snapshot (keys that Foyer did not recover due
+/// to LRU eviction before the last persist) are cleaned up by sweep_once().
+/// The cache is usable throughout — stale keys don't cause panics or incorrect
+/// behavior; they just occupy key_index until swept.
+// ─── 10k-scale key_index tests ────────────────────────────────────────────────
+// These tests build a 10k-entry key_index in-process (no OS cluster, no fd pressure).
+
+/// Serialise a 10k-entry key_index to disk and verify the JSON file is non-empty,
+/// parses cleanly, and contains every prefix that was inserted.
+#[test]
+fn key_index_serialization_with_10k_entries() {
+    use std::collections::HashSet;
+    use dashmap::DashMap;
+
+    let dir = TempDir::new().unwrap();
+    const NUM_PREFIXES: usize = 100;
+    const KEYS_PER_PREFIX: usize = 100;
+
+    // Build a DashMap with 100 prefixes × 100 keys = 10k entries.
+    let dash: DashMap<String, HashSet<String>> = DashMap::new();
+    for p in 0..NUM_PREFIXES {
+        let prefix = format!("data/nodes/0/shard_{p:04}/segment.parquet");
+        let keys: HashSet<String> = (0..KEYS_PER_PREFIX)
+            .map(|k| format!("{prefix}\x1F{}-{}", k * 4096, (k + 1) * 4096))
+            .collect();
+        dash.insert(prefix, keys);
+    }
+    let expected_total = NUM_PREFIXES * KEYS_PER_PREFIX;
+
+    // Save.
+    key_index_store::save(dir.path(), &dash).unwrap();
+
+    // Load back and verify.
+    let loaded = key_index_store::load_or_empty(dir.path());
+    assert_eq!(loaded.index.len(), NUM_PREFIXES, "must have {NUM_PREFIXES} prefix buckets");
+    let total_keys: usize = loaded.index.values().map(|v| v.len()).sum();
+    assert_eq!(total_keys, expected_total, "must have {expected_total} total keys");
+
+    // The file itself must be readable JSON above a minimum size.
+    let path = dir.path().join(key_index_store::KEY_INDEX_FILENAME);
+    let bytes = std::fs::metadata(&path).unwrap().len();
+    assert!(bytes > 100_000, "key_index.json must be > 100KB for 10k entries, got {bytes}");
+}
+
+/// Build a 10k-entry snapshot, write it to disk, then create a new FoyerCache
+/// over the same dir — verify the key_index is bulk-loaded correctly.
+#[test]
+fn key_index_recovery_with_10k_entries() {
+    use std::collections::HashSet;
+    use dashmap::DashMap;
+
+    let dir = TempDir::new().unwrap();
+    const NUM_PREFIXES: usize = 100;
+    const KEYS_PER_PREFIX: usize = 100;
+
+    // Write a 10k-entry snapshot.
+    let dash: DashMap<String, HashSet<String>> = DashMap::new();
+    for p in 0..NUM_PREFIXES {
+        let prefix = format!("data/nodes/0/shard_{p:04}/segment.parquet");
+        let keys: HashSet<String> = (0..KEYS_PER_PREFIX)
+            .map(|k| format!("{prefix}\x1F{}-{}", k * 4096, (k + 1) * 4096))
+            .collect();
+        dash.insert(prefix, keys);
+    }
+    key_index_store::save(dir.path(), &dash).unwrap();
+
+    // Create a new cache from the same dir — should bulk-load the snapshot.
+    let cache = FoyerCache::new(TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE, 0, 0.0, 0);
+
+    assert_eq!(cache.key_index.len(), NUM_PREFIXES,
+        "key_index must have {NUM_PREFIXES} buckets after recovery");
+    let total_keys: usize = cache.key_index.iter().map(|e| e.value().len()).sum();
+    assert_eq!(total_keys, NUM_PREFIXES * KEYS_PER_PREFIX,
+        "must have {} total keys after recovery", NUM_PREFIXES * KEYS_PER_PREFIX);
+}
+
+/// Populate 10k entries directly into the key_index (simulating cache puts),
+/// evict half the prefixes, and verify used_bytes decrements correctly.
+#[test]
+fn key_index_evict_prefix_bulk_with_10k_entries() {
+    let dir = TempDir::new().unwrap();
+    let cache = FoyerCache::new(TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE, 0, 0.0, 0);
+
+    const NUM_PREFIXES: usize = 100;
+    const KEYS_PER_PREFIX: usize = 100;
+
+    // Directly populate the key_index (bypasses actual Foyer disk, tests key_index logic only).
+    use std::collections::HashSet;
+    for p in 0..NUM_PREFIXES {
+        let prefix = format!("data/nodes/0/shard_{p:04}/segment.parquet");
+        let keys: HashSet<String> = (0..KEYS_PER_PREFIX)
+            .map(|k| format!("{prefix}\x1F{}-{}", k * 4096, (k + 1) * 4096))
+            .collect();
+        let byte_size: i64 = keys.iter().map(|k| crate::range_cache::key_byte_size(k)).sum();
+        cache.key_index.insert(prefix, keys);
+        cache.stats.used_bytes.fetch_add(byte_size, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    let used_before = cache.stats.used_bytes.load(std::sync::atomic::Ordering::Relaxed);
+    assert!(used_before > 0, "used_bytes must be > 0 after populating {NUM_PREFIXES} prefixes");
+
+    // Evict first 50 prefixes.
+    for p in 0..NUM_PREFIXES / 2 {
+        let prefix = format!("data/nodes/0/shard_{p:04}/segment.parquet");
+        cache.evict_prefix(&prefix);
+    }
+
+    let used_after = cache.stats.used_bytes.load(std::sync::atomic::Ordering::Relaxed);
+    assert!(used_after < used_before, "used_bytes must decrease after bulk evict_prefix");
+    assert_eq!(cache.key_index.len(), NUM_PREFIXES / 2,
+        "key_index must have {} buckets after evicting half", NUM_PREFIXES / 2);
+}
+
+/// Populate 10k entries, call clear(), verify the key_index is empty and
+/// key_index.json is deleted.
+#[test]
+fn key_index_clear_with_10k_entries() {
+    use std::collections::HashSet;
+
+    let dir = TempDir::new().unwrap();
+    let cache = FoyerCache::new(TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE, 0, 0.0, 0);
+
+    const NUM_PREFIXES: usize = 100;
+    const KEYS_PER_PREFIX: usize = 100;
+
+    for p in 0..NUM_PREFIXES {
+        let prefix = format!("data/nodes/0/shard_{p:04}/segment.parquet");
+        let keys: HashSet<String> = (0..KEYS_PER_PREFIX)
+            .map(|k| format!("{prefix}\x1F{}-{}", k * 4096, (k + 1) * 4096))
+            .collect();
+        let byte_size: i64 = keys.iter().map(|k| crate::range_cache::key_byte_size(k)).sum();
+        cache.key_index.insert(prefix, keys);
+        cache.stats.used_bytes.fetch_add(byte_size, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    // Persist first so there's a file to delete.
+    key_index_store::save(&dir.path(), &cache.key_index).unwrap();
+    assert!(dir.path().join(key_index_store::KEY_INDEX_FILENAME).exists(), "file must exist before clear");
+
+    // Clear via the public async API.
+    block_on(cache.clear());
+
+    assert_eq!(cache.key_index.len(), 0, "key_index must be empty after clear");
+    assert_eq!(cache.stats.used_bytes.load(std::sync::atomic::Ordering::Relaxed), 0,
+        "used_bytes must be 0 after clear");
+    // After clear() the key_index.json is deleted; Drop will write an empty one.
+    // Assert it is absent while the cache is still alive (before Drop).
+    let snap_exists = dir.path().join(key_index_store::KEY_INDEX_FILENAME).exists();
+    // clear() calls key_index_store::delete() which removes the file.
+    assert!(!snap_exists, "key_index.json must be deleted by clear()");
+}
+
+#[test]
+fn recovery_stale_snapshot_keys_cleaned_by_sweep() {
+    let dir = TempDir::new().unwrap();
+
+    // Manually write a snapshot with a mix of valid and fake stale keys.
+    // We don't spin up an actual cache for the "first session" here because
+    // we need to inject keys that Foyer will not have recovered.
+    {
+        use std::collections::{HashMap, HashSet};
+        let mut index: HashMap<String, HashSet<String>> = HashMap::new();
+        // Real-looking key — Foyer won't have it either, but it's valid format.
+        index.insert(
+            "data/stale.parquet".to_string(),
+            ["data/stale.parquet\x1F0-512".to_string()].into(),
+        );
+        let snap = key_index_store::KeyIndexSnapshot { version: 1, index };
+        let json = serde_json::to_string(&snap).unwrap();
+        std::fs::write(dir.path().join(key_index_store::KEY_INDEX_FILENAME), json.as_bytes()).unwrap();
+    }
+
+    // Create a fresh Foyer cache over the same dir. Foyer has no data for "data/stale.parquet".
+    let cache = FoyerCache::new(TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE, 0, 0.0, 0);
+
+    // Bulk-loaded snapshot has the stale key — used_bytes is temporarily over-counted.
+    assert!(cache.key_index.contains_key("data/stale.parquet"),
+        "stale key must be present immediately after bulk-load recovery");
+
+    // After sweeping all shards, the stale key is removed (inner.contains() returns false).
+    let shard_count = cache.key_index.shards().len();
+    let removed: usize = (0..shard_count).map(|_| cache.sweep_once()).sum();
+    assert_eq!(removed, 1, "sweep must remove the 1 stale key");
+    assert!(!cache.key_index.contains_key("data/stale.parquet"),
+        "stale key must be gone after sweep");
+}

--- a/sandbox/plugins/block-cache-foyer/src/main/rust/src/tests.rs
+++ b/sandbox/plugins/block-cache-foyer/src/main/rust/src/tests.rs
@@ -43,8 +43,9 @@ const TEST_CACHE_BLOCK_SIZE:  usize = 1 * 1024 * 1024;  // 1 MB block size (must
 fn test_cache() -> (FoyerCache, TempDir) {
     let dir = TempDir::new().expect("failed to create temp dir");
     // sweep_interval_secs = 0 → no background task; tests call sweep_once() directly.
+    // persist_interval_secs = 0 → no persist task; tests call key_index_store::save() directly.
     // block_size (1 MB) ≤ disk_bytes (4 MB) — required Foyer invariant.
-    let cache = FoyerCache::new(TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE, 0, 0.0);
+    let cache = FoyerCache::new(TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE, 0, 0.0, 0);
     (cache, dir)
 }
 
@@ -499,7 +500,7 @@ fn put_and_get_work_after_cache_nears_capacity() {
     let dir = TempDir::new().unwrap();
     // disk=2MB ≥ block_size=512KB (Foyer invariant: block_size ≤ disk).
     // Writes 4 × 512KB = 2MB total into a 2MB cache to exercise near-capacity behaviour.
-    let cache = FoyerCache::new(2 * 1024 * 1024, dir.path(), 512 * 1024, IO_ENGINE, 0, 0.0);
+    let cache = FoyerCache::new(2 * 1024 * 1024, dir.path(), 512 * 1024, IO_ENGINE, 0, 0.0, 0);
     let chunk = vec![0u8; 512 * 1024];
     for i in 0u64..4 {
         let key = range_cache_key("/data/file.parquet", i * 524288, (i + 1) * 524288);
@@ -523,7 +524,7 @@ fn lru_eviction_retains_keys_in_key_index() {
     // disk=1MB, block_size=256KB (256KB ≤ 1MB — Foyer invariant satisfied).
     // Writes 8 × 256KB = 2MB total into a 1MB cache to trigger LRU eviction pressure.
     let dir = TempDir::new().unwrap();
-    let cache = FoyerCache::new(1 * 1024 * 1024, dir.path(), 256 * 1024, IO_ENGINE, 0, 0.0);
+    let cache = FoyerCache::new(1 * 1024 * 1024, dir.path(), 256 * 1024, IO_ENGINE, 0, 0.0, 0);
     const CHUNK_SIZE: usize = 256 * 1024;
     const TOTAL_WRITES: usize = 8;
     let chunk = vec![0xABu8; CHUNK_SIZE];
@@ -842,6 +843,7 @@ fn ffm_create_returns_positive_pointer() {
         BLOCK_SIZE as u64,
         engine.as_ptr(), engine.len() as u64,
         0, 0.0_f64,
+        0,
     )};
     assert!(ptr > 0);
     let result = unsafe { foyer_destroy_cache(ptr) };
@@ -857,6 +859,7 @@ fn ffm_create_with_null_ptr_returns_error() {
         BLOCK_SIZE as u64,
         engine.as_ptr(), engine.len() as u64,
         0, 0.0_f64,
+        0,
     )};
     assert!(ptr < 0);
     if ptr < 0 { unsafe { native_bridge_common::error::native_error_free(-ptr); } }
@@ -872,6 +875,7 @@ fn ffm_create_with_invalid_utf8_returns_error() {
         BLOCK_SIZE as u64,
         engine.as_ptr(), engine.len() as u64,
         0, 0.0_f64,
+        0,
     )};
     assert!(ptr < 0);
     if ptr < 0 { unsafe { native_bridge_common::error::native_error_free(-ptr); } }
@@ -902,7 +906,8 @@ fn ffm_create_destroy_lifecycle_no_leak() {
             dir_str.as_ptr(), dir_str.len() as u64,
             BLOCK_SIZE as u64,
             engine.as_ptr(), engine.len() as u64,
-        0, 0.0_f64,
+            0, 0.0_f64,
+            0,
         )};
         assert!(ptr > 0);
         let result = unsafe { foyer_destroy_cache(ptr) };
@@ -929,6 +934,7 @@ fn ffm_snapshot_stats_valid_ptr_returns_zero_and_fills_buffer() {
         BLOCK_SIZE as u64,
         engine.as_ptr(), engine.len() as u64,
         0, 0.0_f64,
+        0,
     )};
     assert!(ptr > 0);
 
@@ -959,8 +965,8 @@ fn snapshot_stats_returns_zero_for_fresh_cache() {
             BLOCK_SIZE as u64,
             engine.as_ptr(), engine.len() as u64,
         0, 0.0_f64,
-        )
-    };
+        0,
+    )};
     assert!(ptr > 0);
 
     // 10 fields × 2 sections = 20 longs
@@ -999,6 +1005,7 @@ fn ffm_snapshot_stats_null_out_returns_error() {
         BLOCK_SIZE as u64,
         engine.as_ptr(), engine.len() as u64,
         0, 0.0_f64,
+        0,
     )};
     assert!(ptr > 0);
 
@@ -1084,6 +1091,7 @@ fn ffm_create_cache_returns_fat_ptr_with_strong_count_one() {
         BLOCK_SIZE as u64,
         engine.as_ptr(), engine.len() as u64,
         0, 0.0_f64,
+        0,
     )};
     assert!(ptr > 0);
 
@@ -1116,6 +1124,7 @@ fn ffm_create_cache_ptr_cloneable_for_multiple_shards() {
         BLOCK_SIZE as u64,
         engine.as_ptr(), engine.len() as u64,
         0, 0.0_f64,
+        0,
     )};
     assert!(ptr > 0);
 
@@ -1163,6 +1172,7 @@ fn drop_with_active_sweep_task_does_not_panic() {
         IO_ENGINE,
         3600, // 1-hour interval — task sleeps, drop cancels it immediately
         0.0,  // threshold disabled
+        0,    // persist disabled
     );
     drop(cache); // shutdown.cancel() wakes the select! branch → task exits
 }
@@ -1181,6 +1191,7 @@ fn drop_cancels_the_token() {
         IO_ENGINE,
         0,   // no sweep task
         0.0, // threshold disabled
+        0,   // no persist task
     );
     // Clone the token before drop so we can inspect it after.
     let token: CancellationToken = cache.shutdown.clone();
@@ -1196,7 +1207,7 @@ fn drop_cancels_the_token() {
 fn cache_functional_before_drop() {
     let dir = TempDir::new().unwrap();
     {
-        let cache = FoyerCache::new(64 * 1024 * 1024, dir.path(), BLOCK_SIZE, IO_ENGINE, 0, 0.0);
+        let cache = FoyerCache::new(64 * 1024 * 1024, dir.path(), BLOCK_SIZE, IO_ENGINE, 0, 0.0, 0);
         let key = range_cache_key("/data/file.parquet", 0, 100);
         cache.put(&key, Bytes::from_static(b"hello"));
         let result = block_on(cache.get(&key));
@@ -1231,7 +1242,7 @@ fn sweep_disabled_when_interval_is_zero() {
 #[test]
 fn sweep_enabled_cache_is_usable_while_task_sleeping() {
     let dir = TempDir::new().unwrap();
-    let cache = FoyerCache::new(64 * 1024 * 1024, dir.path(), BLOCK_SIZE, IO_ENGINE, 3600, 0.0);
+    let cache = FoyerCache::new(64 * 1024 * 1024, dir.path(), BLOCK_SIZE, IO_ENGINE, 3600, 0.0, 0);
     let key = range_cache_key("/data/file.parquet", 0, 512);
     cache.put(&key, Bytes::from(vec![0xABu8; 512]));
     let result = block_on(cache.get(&key));
@@ -1659,7 +1670,7 @@ fn active_bytes_guard_drop_on_cancellation_restores_counter() {
 fn sweep_threshold_disabled_never_skips() {
     let dir = TempDir::new().unwrap();
     // threshold = 0.0: disabled — always sweep
-    let cache = FoyerCache::new(TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE, 0, 0.0);
+    let cache = FoyerCache::new(TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE, 0, 0.0, 0);
 
     // used_bytes = 0 (empty cache)
     assert_eq!(cache.should_skip_sweep(), false,
@@ -1676,7 +1687,7 @@ fn sweep_threshold_disabled_never_skips() {
 fn sweep_threshold_skips_when_usage_below_threshold() {
     let dir = TempDir::new().unwrap();
     // disk = 4MB, threshold = 0.75 (75%)
-    let cache = FoyerCache::new(TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE, 0, 0.75);
+    let cache = FoyerCache::new(TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE, 0, 0.75, 0);
 
     // usage = 0% → below 75% → skip
     cache.stats.used_bytes.store(0, std::sync::atomic::Ordering::Relaxed);
@@ -1701,7 +1712,7 @@ fn sweep_threshold_skips_when_usage_below_threshold() {
 fn sweep_threshold_runs_when_usage_at_or_above_threshold() {
     let dir = TempDir::new().unwrap();
     // disk = 4MB, threshold = 0.75 (75%)
-    let cache = FoyerCache::new(TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE, 0, 0.75);
+    let cache = FoyerCache::new(TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE, 0, 0.75, 0);
 
     // usage = exactly 75% → NOT below → do NOT skip
     let exact = ((TEST_CACHE_DISK_BYTES as f64 * 0.75) as i64);
@@ -1726,7 +1737,7 @@ fn sweep_threshold_runs_when_usage_at_or_above_threshold() {
 #[test]
 fn sweep_threshold_one_skips_unless_completely_full() {
     let dir = TempDir::new().unwrap();
-    let cache = FoyerCache::new(TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE, 0, 1.0);
+    let cache = FoyerCache::new(TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE, 0, 1.0, 0);
 
     // usage = 99.9% → still below 100% → skip
     let almost_full = ((TEST_CACHE_DISK_BYTES as f64 * 0.999) as i64);
@@ -1745,7 +1756,7 @@ fn sweep_threshold_one_skips_unless_completely_full() {
 #[test]
 fn sweep_threshold_negative_used_bytes_treated_as_zero() {
     let dir = TempDir::new().unwrap();
-    let cache = FoyerCache::new(TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE, 0, 0.5);
+    let cache = FoyerCache::new(TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE, 0, 0.5, 0);
 
     // Simulate a transient underflow (negative used_bytes) — should be clamped to 0.
     cache.stats.used_bytes.store(-100, std::sync::atomic::Ordering::Relaxed);
@@ -1760,7 +1771,7 @@ fn sweep_threshold_negative_used_bytes_treated_as_zero() {
 fn sweep_once_ignores_threshold_guard() {
     let dir = TempDir::new().unwrap();
     // Set a high threshold so should_skip_sweep() returns true
-    let cache = FoyerCache::new(TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE, 0, 0.99);
+    let cache = FoyerCache::new(TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE, 0, 0.99, 0);
 
     // Inject a stale key
     cache.key_index

--- a/sandbox/plugins/block-cache-foyer/src/test/java/org/opensearch/blockcache/foyer/BlockCacheFoyerPluginTests.java
+++ b/sandbox/plugins/block-cache-foyer/src/test/java/org/opensearch/blockcache/foyer/BlockCacheFoyerPluginTests.java
@@ -154,12 +154,14 @@ public class BlockCacheFoyerPluginTests extends OpenSearchTestCase {
         BlockCacheFoyerPlugin plugin = new BlockCacheFoyerPlugin(Settings.EMPTY);
         List<Setting<?>> settings = plugin.getSettings();
         // DATA_TO_CACHE_RATIO_SETTING removed — ratio now read from cluster.filecache.remote_data_ratio
-        assertEquals(5, settings.size());
+        // KEY_INDEX_PERSIST_INTERVAL_SETTING added for independent periodic key_index persistence
+        assertEquals(6, settings.size());
         assertTrue(settings.contains(FoyerBlockCacheSettings.CACHE_SIZE_SETTING));
         assertTrue(settings.contains(FoyerBlockCacheSettings.BLOCK_SIZE_SETTING));
         assertTrue(settings.contains(FoyerBlockCacheSettings.IO_ENGINE_SETTING));
         assertTrue(settings.contains(FoyerBlockCacheSettings.KEY_INDEX_SWEEP_INTERVAL_SETTING));
         assertTrue(settings.contains(FoyerBlockCacheSettings.KEY_INDEX_SWEEP_THRESHOLD_SETTING));
+        assertTrue(settings.contains(FoyerBlockCacheSettings.KEY_INDEX_PERSIST_INTERVAL_SETTING));
     }
 
     public void testGetSettingsNoNulls() {

--- a/sandbox/plugins/block-cache-foyer/src/test/java/org/opensearch/blockcache/foyer/BlockCacheFoyerPluginTests.java
+++ b/sandbox/plugins/block-cache-foyer/src/test/java/org/opensearch/blockcache/foyer/BlockCacheFoyerPluginTests.java
@@ -12,10 +12,12 @@ import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.settings.SettingsException;
+import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.core.common.unit.ByteSizeUnit;
 import org.opensearch.core.common.unit.ByteSizeValue;
 import org.opensearch.env.Environment;
 import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.test.OpenSearchTestCase.LockFeatureFlag;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -65,44 +67,56 @@ public class BlockCacheFoyerPluginTests extends OpenSearchTestCase {
 
     // ── requestedCapacityBytes ────────────────────────────────────────────────
 
-    public void testRequestedCapacityBytesDefault25Percent() {
-        BlockCacheFoyerPlugin plugin = new BlockCacheFoyerPlugin(Settings.EMPTY);
+    @LockFeatureFlag(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)
+    public void testRequestedCapacityBytesDefault50Percent() {
         long budget = 800L * 1024 * 1024 * 1024;
-        assertEquals(200L * 1024 * 1024 * 1024, plugin.requestedCapacityBytes(Settings.EMPTY, budget));
+        assertEquals(400L * 1024 * 1024 * 1024, new BlockCacheFoyerPlugin(Settings.EMPTY).requestedCapacityBytes(Settings.EMPTY, budget));
     }
 
+    @LockFeatureFlag(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)
     public void testRequestedCapacityBytes50Percent() {
         Settings s = Settings.builder().put("block_cache.foyer.size", "50%").build();
         assertEquals(500L, new BlockCacheFoyerPlugin(Settings.EMPTY).requestedCapacityBytes(s, 1000L));
     }
 
+    @LockFeatureFlag(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)
     public void testRequestedCapacityBytesZeroPercent() {
         Settings s = Settings.builder().put("block_cache.foyer.size", "0%").build();
         assertEquals(0L, new BlockCacheFoyerPlugin(Settings.EMPTY).requestedCapacityBytes(s, 1000L));
     }
 
+    @LockFeatureFlag(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)
     public void testRequestedCapacityBytesDecimalRatioForm() {
         Settings s = Settings.builder().put("block_cache.foyer.size", "0.25").build();
         assertEquals(250L, new BlockCacheFoyerPlugin(Settings.EMPTY).requestedCapacityBytes(s, 1000L));
     }
 
+    @LockFeatureFlag(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)
     public void testRequestedCapacityBytesRoundsCorrectly() {
         Settings s = Settings.builder().put("block_cache.foyer.size", "33%").build();
         assertEquals(33L, new BlockCacheFoyerPlugin(Settings.EMPTY).requestedCapacityBytes(s, 100L));
     }
 
+    @LockFeatureFlag(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)
     public void testRequestedCapacityBytesZeroBudget() {
         assertEquals(0L, new BlockCacheFoyerPlugin(Settings.EMPTY).requestedCapacityBytes(Settings.EMPTY, 0L));
     }
 
+    @LockFeatureFlag(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)
     public void testRequestedCapacityBytesNonNegative() {
         long result = new BlockCacheFoyerPlugin(Settings.EMPTY).requestedCapacityBytes(Settings.EMPTY, 1_000_000L);
         assertTrue(result >= 0);
     }
 
+    @LockFeatureFlag(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)
     public void testRequestedCapacityBytesDoesNotExceedBudget() {
         long budget = 1_000_000L;
         assertTrue(new BlockCacheFoyerPlugin(Settings.EMPTY).requestedCapacityBytes(Settings.EMPTY, budget) <= budget);
+    }
+
+    public void testRequestedCapacityBytesIsZeroWhenPluggableDataformatDisabled() {
+        long budget = 100L * 1024 * 1024 * 1024;
+        assertEquals(0L, new BlockCacheFoyerPlugin(Settings.EMPTY).requestedCapacityBytes(Settings.EMPTY, budget));
     }
 
     // ── dataToCapacityRatio ───────────────────────────────────────────────────
@@ -175,6 +189,7 @@ public class BlockCacheFoyerPluginTests extends OpenSearchTestCase {
         assertTrue(plugin.getSettings().containsAll(plugin.getSettings()));
     }
 
+    @LockFeatureFlag(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)
     public void testCreateComponentsThrowsWhenBlockSizeExceedsDiskBudget() {
         // block_size (2MB) >= disk budget (1MB) should throw SettingsException
         Settings settings = Settings.builder()
@@ -193,5 +208,33 @@ public class BlockCacheFoyerPluginTests extends OpenSearchTestCase {
             SettingsException.class,
             () -> plugin.createComponents(null, clusterService, null, null, null, null, environment, null, null, null, null)
         );
+    }
+
+    // flag is OFF by default — no @LockFeatureFlag annotation needed
+    public void testCreateComponentsReturnsEmptyWhenPluggableDataformatDisabled() throws IOException {
+        BlockCacheFoyerPlugin plugin = new BlockCacheFoyerPlugin(Settings.EMPTY);
+        plugin.setReservedCapacityBytes(new ByteSizeValue(10, ByteSizeUnit.GB).getBytes());
+
+        ClusterService clusterService = mock(ClusterService.class);
+        when(clusterService.getSettings()).thenReturn(Settings.EMPTY);
+
+        Environment environment = mock(Environment.class);
+        when(environment.dataFiles()).thenReturn(new Path[] { createTempDir() });
+
+        java.util.Collection<Object> result = plugin.createComponents(
+            null,
+            clusterService,
+            null,
+            null,
+            null,
+            null,
+            environment,
+            null,
+            null,
+            null,
+            null
+        );
+        assertTrue("createComponents must return empty when flag is disabled", result.isEmpty());
+        assertTrue("getBlockCache must be empty when flag is disabled", plugin.getBlockCache().isEmpty());
     }
 }

--- a/sandbox/plugins/block-cache-foyer/src/test/java/org/opensearch/blockcache/foyer/FoyerBlockCacheSettingsTests.java
+++ b/sandbox/plugins/block-cache-foyer/src/test/java/org/opensearch/blockcache/foyer/FoyerBlockCacheSettingsTests.java
@@ -21,7 +21,7 @@ public class FoyerBlockCacheSettingsTests extends OpenSearchTestCase {
     // ── CACHE_SIZE_SETTING ────────────────────────────────────────────────────
 
     public void testCacheSizeDefault() {
-        assertEquals("25%", FoyerBlockCacheSettings.CACHE_SIZE_SETTING.get(Settings.EMPTY));
+        assertEquals("50%", FoyerBlockCacheSettings.CACHE_SIZE_SETTING.get(Settings.EMPTY));
     }
 
     public void testCacheSizeAcceptsPercentage() {

--- a/sandbox/plugins/block-cache-foyer/src/test/java/org/opensearch/blockcache/foyer/FoyerBlockCacheTests.java
+++ b/sandbox/plugins/block-cache-foyer/src/test/java/org/opensearch/blockcache/foyer/FoyerBlockCacheTests.java
@@ -23,7 +23,7 @@ public class FoyerBlockCacheTests extends OpenSearchTestCase {
     public void testConstructorThrowsWhenDiskBytesIsZero() {
         IllegalArgumentException ex = expectThrows(
             IllegalArgumentException.class,
-            () -> new FoyerBlockCache(0L, "/tmp/cache", 1L, "auto", 0L, 0.0)
+            () -> new FoyerBlockCache(0L, "/tmp/cache", 1L, "auto", 0L, 0.0, 0L)
         );
         assertTrue("message should mention diskBytes", ex.getMessage().contains("diskBytes"));
     }
@@ -31,7 +31,7 @@ public class FoyerBlockCacheTests extends OpenSearchTestCase {
     public void testConstructorThrowsWhenDiskBytesIsNegative() {
         IllegalArgumentException ex = expectThrows(
             IllegalArgumentException.class,
-            () -> new FoyerBlockCache(-1L, "/tmp/cache", 1L, "auto", 0L, 0.0)
+            () -> new FoyerBlockCache(-1L, "/tmp/cache", 1L, "auto", 0L, 0.0, 0L)
         );
         assertTrue(ex.getMessage().contains("diskBytes"));
     }
@@ -39,20 +39,23 @@ public class FoyerBlockCacheTests extends OpenSearchTestCase {
     // ── diskDir validation ────────────────────────────────────────────────────
 
     public void testConstructorThrowsWhenDiskDirIsNull() {
-        NullPointerException ex = expectThrows(NullPointerException.class, () -> new FoyerBlockCache(1L, null, 1L, "auto", 0L, 0.0));
+        NullPointerException ex = expectThrows(NullPointerException.class, () -> new FoyerBlockCache(1L, null, 1L, "auto", 0L, 0.0, 0L));
         assertTrue("message should mention diskDir", ex.getMessage().contains("diskDir"));
     }
 
     public void testConstructorThrowsWhenDiskDirIsBlank() {
         IllegalArgumentException ex = expectThrows(
             IllegalArgumentException.class,
-            () -> new FoyerBlockCache(1L, "   ", 1L, "auto", 0L, 0.0)
+            () -> new FoyerBlockCache(1L, "   ", 1L, "auto", 0L, 0.0, 0L)
         );
         assertTrue(ex.getMessage().contains("diskDir"));
     }
 
     public void testConstructorThrowsWhenDiskDirIsEmptyString() {
-        IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () -> new FoyerBlockCache(1L, "", 1L, "auto", 0L, 0.0));
+        IllegalArgumentException ex = expectThrows(
+            IllegalArgumentException.class,
+            () -> new FoyerBlockCache(1L, "", 1L, "auto", 0L, 0.0, 0L)
+        );
         assertTrue(ex.getMessage().contains("diskDir"));
     }
 
@@ -61,7 +64,7 @@ public class FoyerBlockCacheTests extends OpenSearchTestCase {
     public void testConstructorThrowsWhenBlockSizeBytesIsZero() {
         IllegalArgumentException ex = expectThrows(
             IllegalArgumentException.class,
-            () -> new FoyerBlockCache(1L, "/tmp/cache", 0L, "auto", 0L, 0.0)
+            () -> new FoyerBlockCache(1L, "/tmp/cache", 0L, "auto", 0L, 0.0, 0L)
         );
         assertTrue("message should mention blockSizeBytes", ex.getMessage().contains("blockSizeBytes"));
     }
@@ -69,7 +72,7 @@ public class FoyerBlockCacheTests extends OpenSearchTestCase {
     public void testConstructorThrowsWhenBlockSizeBytesIsNegative() {
         IllegalArgumentException ex = expectThrows(
             IllegalArgumentException.class,
-            () -> new FoyerBlockCache(1L, "/tmp/cache", -1L, "auto", 0L, 0.0)
+            () -> new FoyerBlockCache(1L, "/tmp/cache", -1L, "auto", 0L, 0.0, 0L)
         );
         assertTrue(ex.getMessage().contains("blockSizeBytes"));
     }
@@ -77,7 +80,10 @@ public class FoyerBlockCacheTests extends OpenSearchTestCase {
     // ── ioEngine validation ───────────────────────────────────────────────────
 
     public void testConstructorThrowsWhenIoEngineIsNull() {
-        NullPointerException ex = expectThrows(NullPointerException.class, () -> new FoyerBlockCache(1L, "/tmp/cache", 1L, null, 0L, 0.0));
+        NullPointerException ex = expectThrows(
+            NullPointerException.class,
+            () -> new FoyerBlockCache(1L, "/tmp/cache", 1L, null, 0L, 0.0, 0L)
+        );
         assertTrue("message should mention ioEngine", ex.getMessage().contains("ioEngine"));
     }
 
@@ -86,7 +92,7 @@ public class FoyerBlockCacheTests extends OpenSearchTestCase {
     public void testConstructorThrowsWhenSweepIntervalSecsIsNegative() {
         IllegalArgumentException ex = expectThrows(
             IllegalArgumentException.class,
-            () -> new FoyerBlockCache(1L, "/tmp/cache", 1L, "auto", -1L, 0.0)
+            () -> new FoyerBlockCache(1L, "/tmp/cache", 1L, "auto", -1L, 0.0, 0L)
         );
         assertTrue("message should mention sweepIntervalSecs", ex.getMessage().contains("sweepIntervalSecs"));
         assertTrue("message should contain the bad value -1", ex.getMessage().contains("-1"));
@@ -98,7 +104,7 @@ public class FoyerBlockCacheTests extends OpenSearchTestCase {
         // We can't fully invoke the constructor without the native library, so we just
         // verify the guard doesn't fire for 0.
         try {
-            new FoyerBlockCache(1L, "/tmp/cache", 1L, "auto", 0L, 0.0);
+            new FoyerBlockCache(1L, "/tmp/cache", 1L, "auto", 0L, 0.0, 0L);
             fail("Expected native library call to fail (UnsatisfiedLinkError or similar)");
         } catch (IllegalArgumentException e) {
             fail("Validation guard fired unexpectedly for sweepIntervalSecs=0: " + e.getMessage());
@@ -112,7 +118,7 @@ public class FoyerBlockCacheTests extends OpenSearchTestCase {
     public void testConstructorThrowsWhenSweepThresholdRatioIsNegative() {
         IllegalArgumentException ex = expectThrows(
             IllegalArgumentException.class,
-            () -> new FoyerBlockCache(1L, "/tmp/cache", 1L, "auto", 0L, -0.01)
+            () -> new FoyerBlockCache(1L, "/tmp/cache", 1L, "auto", 0L, -0.01, 0L)
         );
         assertTrue("message should mention sweepThresholdRatio", ex.getMessage().contains("sweepThresholdRatio"));
     }
@@ -120,7 +126,7 @@ public class FoyerBlockCacheTests extends OpenSearchTestCase {
     public void testConstructorThrowsWhenSweepThresholdRatioExceedsOne() {
         IllegalArgumentException ex = expectThrows(
             IllegalArgumentException.class,
-            () -> new FoyerBlockCache(1L, "/tmp/cache", 1L, "auto", 0L, 1.01)
+            () -> new FoyerBlockCache(1L, "/tmp/cache", 1L, "auto", 0L, 1.01, 0L)
         );
         assertTrue("message should mention sweepThresholdRatio", ex.getMessage().contains("sweepThresholdRatio"));
     }
@@ -128,7 +134,7 @@ public class FoyerBlockCacheTests extends OpenSearchTestCase {
     public void testConstructorAcceptsSweepThresholdRatioOfZero() {
         // 0.0 = disabled (always sweep); must NOT throw before reaching FoyerBridge
         try {
-            new FoyerBlockCache(1L, "/tmp/cache", 1L, "auto", 0L, 0.0);
+            new FoyerBlockCache(1L, "/tmp/cache", 1L, "auto", 0L, 0.0, 0L);
             fail("Expected native library call to fail");
         } catch (IllegalArgumentException e) {
             fail("Validation guard fired unexpectedly for sweepThresholdRatio=0.0: " + e.getMessage());
@@ -140,7 +146,7 @@ public class FoyerBlockCacheTests extends OpenSearchTestCase {
     public void testConstructorAcceptsSweepThresholdRatioOfOne() {
         // 1.0 = only sweep when cache is 100% full; valid boundary value
         try {
-            new FoyerBlockCache(1L, "/tmp/cache", 1L, "auto", 0L, 1.0);
+            new FoyerBlockCache(1L, "/tmp/cache", 1L, "auto", 0L, 1.0, 0L);
             fail("Expected native library call to fail");
         } catch (IllegalArgumentException e) {
             fail("Validation guard fired unexpectedly for sweepThresholdRatio=1.0: " + e.getMessage());
@@ -152,7 +158,7 @@ public class FoyerBlockCacheTests extends OpenSearchTestCase {
     public void testConstructorAcceptsSweepThresholdRatioOf0dot75() {
         // typical production value: skip sweep when < 75% full
         try {
-            new FoyerBlockCache(1L, "/tmp/cache", 1L, "auto", 0L, 0.75);
+            new FoyerBlockCache(1L, "/tmp/cache", 1L, "auto", 0L, 0.75, 0L);
             fail("Expected native library call to fail");
         } catch (IllegalArgumentException e) {
             fail("Validation guard fired unexpectedly for sweepThresholdRatio=0.75: " + e.getMessage());
@@ -170,7 +176,7 @@ public class FoyerBlockCacheTests extends OpenSearchTestCase {
     public void testDiskBytesErrorMessageContainsBadValue() {
         IllegalArgumentException ex = expectThrows(
             IllegalArgumentException.class,
-            () -> new FoyerBlockCache(-42L, "/tmp/cache", 1L, "auto", 0L, 0.0)
+            () -> new FoyerBlockCache(-42L, "/tmp/cache", 1L, "auto", 0L, 0.0, 0L)
         );
         assertTrue("error message should contain the bad value -42", ex.getMessage().contains("-42"));
     }
@@ -178,7 +184,7 @@ public class FoyerBlockCacheTests extends OpenSearchTestCase {
     public void testBlockSizeBytesErrorMessageContainsBadValue() {
         IllegalArgumentException ex = expectThrows(
             IllegalArgumentException.class,
-            () -> new FoyerBlockCache(1L, "/tmp/cache", -8L, "auto", 0L, 0.0)
+            () -> new FoyerBlockCache(1L, "/tmp/cache", -8L, "auto", 0L, 0.0, 0L)
         );
         assertTrue("error message should contain the bad value -8", ex.getMessage().contains("-8"));
     }
@@ -193,7 +199,7 @@ public class FoyerBlockCacheTests extends OpenSearchTestCase {
         // zero diskBytes + null diskDir: first guard (diskBytes) should fire
         IllegalArgumentException ex = expectThrows(
             IllegalArgumentException.class,
-            () -> new FoyerBlockCache(0L, null, 1L, "auto", 0L, 0.0)
+            () -> new FoyerBlockCache(0L, null, 1L, "auto", 0L, 0.0, 0L)
         );
         assertTrue(ex.getMessage().contains("diskBytes"));
     }

--- a/server/src/main/java/org/opensearch/index/seqno/ReplicationTracker.java
+++ b/server/src/main/java/org/opensearch/index/seqno/ReplicationTracker.java
@@ -1858,6 +1858,16 @@ public class ReplicationTracker extends AbstractIndexShardComponent implements L
         assert invariant();
     }
 
+    /**
+     * Resets hasAllPeerRecoveryRetentionLeases to false. Called when a DFA read-only engine is created
+     * (warm primary) to prevent assertion failures in renewPeerRecoveryRetentionLeases() during the
+     * window between primary activation and async lease creation via ensurePeerRecoveryRetentionLeasesExist().
+     * The flag will be set back to true when createMissingPeerRecoveryRetentionLeases(ActionListener) completes.
+     */
+    public synchronized void resetHasAllPeerRecoveryRetentionLeases() {
+        hasAllPeerRecoveryRetentionLeases = false;
+    }
+
     private synchronized void setCreatedMissingRetentionLeases() {
         createdMissingRetentionLeases = true;
         assert invariant();

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -132,6 +132,7 @@ import org.opensearch.index.cache.request.ShardRequestCache;
 import org.opensearch.index.codec.CodecService;
 import org.opensearch.index.engine.CommitStats;
 import org.opensearch.index.engine.DataFormatAwareEngine;
+import org.opensearch.index.engine.DataFormatAwareReadOnlyEngine;
 import org.opensearch.index.engine.Engine;
 import org.opensearch.index.engine.Engine.GetResult;
 import org.opensearch.index.engine.EngineBackedIndexer;
@@ -823,7 +824,16 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
                     if (currentRouting.initializing() && currentRouting.isRelocationTarget() == false && newRouting.active()) {
                         // the cluster-manager started a recovering primary, activate primary mode.
                         replicationTracker.activatePrimaryMode(getLocalCheckpoint());
-                        postActivatePrimaryMode();
+                        // DFA warm primaries: skip postActivatePrimaryMode (no remote translog upload
+                        // needed) but still ensure peer recovery retention leases exist for replicas.
+                        // Reset hasAllPeerRecoveryRetentionLeases to false first to prevent assertion
+                        // failures in renewPeerRecoveryRetentionLeases() during the async window.
+                        if (getIndexer() instanceof DataFormatAwareReadOnlyEngine == false) {
+                            postActivatePrimaryMode();
+                        } else {
+                            replicationTracker.resetHasAllPeerRecoveryRetentionLeases();
+                            ensurePeerRecoveryRetentionLeasesExist();
+                        }
                     }
                 } else {
                     assert currentRouting.primary() == false : "term is only increased as part of primary promotion";
@@ -896,14 +906,22 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
                                 // Force update the checkpoint post engine reset.
                                 updateReplicationCheckpoint();
                             }
-
                             replicationTracker.activatePrimaryMode(getLocalCheckpoint());
                             if (indexSettings.isSegRepEnabledOrRemoteNode()) {
                                 // force publish a checkpoint once in primary mode so that replicas not caught up to previous primary
                                 // are brought up to date.
                                 checkpointPublisher.publish(this, getLatestReplicationCheckpoint());
                             }
-                            postActivatePrimaryMode();
+                            // DFA warm primaries: activate primary mode (needed for initiateTracking
+                            // during replica recovery) but skip postActivatePrimaryMode (no remote
+                            // translog upload). Reset hasAllPeerRecoveryRetentionLeases and ensure
+                            // retention leases exist for replicas.
+                            if (getIndexer() instanceof DataFormatAwareReadOnlyEngine == false) {
+                                postActivatePrimaryMode();
+                            } else {
+                                replicationTracker.resetHasAllPeerRecoveryRetentionLeases();
+                                ensurePeerRecoveryRetentionLeasesExist();
+                            }
                             /*
                              * If this shard was serving as a replica shard when another shard was promoted to primary then
                              * its Lucene index was reset during the primary term transition. In particular, the Lucene index
@@ -4135,16 +4153,30 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
             // So, we can use a stricter check where local checkpoint of new primary is checked against that of old primary.
             allocationId = primaryContext.getRoutingTable().primaryShard().allocationId().getId();
         }
+
+        // DFA warm primaries: relax checkpoint assertion. During hot-to-warm relocation after cancel+bulk+retry,
+        // the old primary's checkpoint may be ahead of the warm target which recovered from an earlier remote
+        // store state. The warm primary is read-only and will serve all data from remote store regardless of
+        // local checkpoint value.
         assert getLocalCheckpoint() == primaryContext.getCheckpointStates().get(allocationId).getLocalCheckpoint()
-            || indexSettings().getTranslogDurability() == Durability.ASYNC : "local checkpoint ["
+            || indexSettings().getTranslogDurability() == Durability.ASYNC
+            || (getIndexer() instanceof DataFormatAwareReadOnlyEngine) : "local checkpoint ["
                 + getLocalCheckpoint()
                 + "] does not match checkpoint from primary context ["
                 + primaryContext
                 + "]";
+
         synchronized (mutex) {
             replicationTracker.activateWithPrimaryContext(primaryContext); // make changes to primaryMode flag only under mutex
         }
-        postActivatePrimaryMode();
+        // DFA warm primaries: skip postActivatePrimaryMode (no remote translog upload needed).
+        // Reset hasAllPeerRecoveryRetentionLeases and ensure retention leases exist for replicas.
+        if (getIndexer() instanceof DataFormatAwareReadOnlyEngine == false) {
+            postActivatePrimaryMode();
+        } else {
+            replicationTracker.resetHasAllPeerRecoveryRetentionLeases();
+            ensurePeerRecoveryRetentionLeasesExist();
+        }
     }
 
     private void postActivatePrimaryMode() {

--- a/server/src/main/java/org/opensearch/storage/tiering/HotToWarmTieringService.java
+++ b/server/src/main/java/org/opensearch/storage/tiering/HotToWarmTieringService.java
@@ -25,7 +25,6 @@ import org.opensearch.core.index.Index;
 import org.opensearch.env.NodeEnvironment;
 import org.opensearch.index.IndexModule;
 import org.opensearch.indices.ShardLimitValidator;
-import org.opensearch.storage.common.tiering.TieringUtils;
 
 import java.util.Set;
 
@@ -127,14 +126,15 @@ public class HotToWarmTieringService extends TieringService {
 
     @Override
     protected Settings getIndexTierSettingsToRestoreAfterCancellation(IndexMetadata indexMetadata) {
-        Settings.Builder builder = Settings.builder()
+        // For DFA indices we intentionally do NOT remove INDEX_BLOCKS_WRITE here.
+        // The write block is deferred to removeWriteBlockForCancelledDfaIndices(), which
+        // only lifts it once every shard is confirmed started on a hot node (writable engine).
+        // Removing it here would allow writes to reach warm-node shards.
+        return Settings.builder()
             .put(IS_WARM_INDEX_SETTING.getKey(), false)
             .put(INDEX_TIERING_STATE.getKey(), HOT)
-            .put(INDEX_COMPOSITE_STORE_TYPE_SETTING.getKey(), "default");
-        if (TieringUtils.isDfaIndex(indexMetadata)) {
-            builder.put(IndexMetadata.INDEX_BLOCKS_WRITE_SETTING.getKey(), false);
-        }
-        return builder.build();
+            .put(INDEX_COMPOSITE_STORE_TYPE_SETTING.getKey(), "default")
+            .build();
     }
 
     @Override
@@ -147,19 +147,6 @@ public class HotToWarmTieringService extends TieringService {
         // before tier() is called
         // Non-DFA - Write block is not required
         return blocksBuilder;
-    }
-
-    @Override
-    protected ClusterBlocks.Builder getIndexTierClusterBlocksToRestoreAfterCancellation(
-        ClusterBlocks.Builder blocksBuilder,
-        String indexName,
-        IndexMetadata indexMetadata
-    ) {
-        if (TieringUtils.isDfaIndex(indexMetadata) == false) {
-            return blocksBuilder;
-        }
-        // Cancel H2W: only DFA indices had a write block set — remove it so the index is writable again.
-        return blocksBuilder.removeIndexBlock(indexName, IndexMetadata.INDEX_WRITE_BLOCK);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/storage/tiering/TieringService.java
+++ b/server/src/main/java/org/opensearch/storage/tiering/TieringService.java
@@ -43,6 +43,7 @@ import org.opensearch.storage.action.tiering.CancelTieringRequest;
 import org.opensearch.storage.action.tiering.IndexTieringRequest;
 import org.opensearch.storage.action.tiering.status.model.TieringStatus;
 import org.opensearch.storage.common.tiering.TieringRejectionException;
+import org.opensearch.storage.common.tiering.TieringUtils;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -53,6 +54,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
+import static org.opensearch.cluster.metadata.IndexMetadata.INDEX_BLOCKS_WRITE_SETTING;
 import static org.opensearch.cluster.metadata.IndexMetadata.INDEX_NUMBER_OF_REPLICAS_SETTING;
 import static org.opensearch.gateway.GatewayService.STATE_NOT_RECOVERED_BLOCK;
 import static org.opensearch.index.IndexModule.INDEX_TIERING_STATE;
@@ -235,6 +237,9 @@ public abstract class TieringService implements ClusterStateListener {
                     )
                 );
                 processTieringInProgress(event.state(), source);
+            }
+            if (event.routingTableChanged() || event.metadataChanged()) {
+                removeWriteBlockForCancelledDfaIndices(event.state());
             }
         }
     }
@@ -735,6 +740,93 @@ public abstract class TieringService implements ClusterStateListener {
             }
         }
         return tieringStatusList;
+    }
+
+    /**
+     * Lifts the write block from DFA indices whose H2W cancel completed but the block was intentionally
+     * kept to prevent writes reaching warm-node shards that still run a read-only engine.
+     *
+     * <p>Called on every routing-table or metadata change. It removes the block only when:
+     * <ol>
+     *   <li>The index is NOT in {@code tieringIndices} (cancel completed, no active tiering)</li>
+     *   <li>The index is a DFA index</li>
+     *   <li>{@code INDEX_TIERING_STATE=HOT} (cancel reverted the tier state)</li>
+     *   <li>{@code INDEX_BLOCKS_WRITE=true} (block still set from H2W preparation)</li>
+     *   <li>All shards are {@code started} on HOT nodes (writable engine is live)</li>
+     * </ol>
+     */
+    private void removeWriteBlockForCancelledDfaIndices(final ClusterState clusterState) {
+        Set<Index> indicesToUnblock = new HashSet<>();
+        for (IndexMetadata indexMetadata : clusterState.metadata()) {
+            // Only act on indices that are NOT currently tiering
+            if (tieringIndices.contains(indexMetadata.getIndex())) {
+                continue;
+            }
+            if (!TieringUtils.isDfaIndex(indexMetadata)) {
+                continue;
+            }
+            // Must be in HOT state (cancel succeeded) with write block still present
+            String tieringState = indexMetadata.getSettings().get(INDEX_TIERING_STATE.getKey(), "");
+            boolean hasWriteBlock = INDEX_BLOCKS_WRITE_SETTING.get(indexMetadata.getSettings());
+            if (!IndexModule.TieringState.HOT.toString().equals(tieringState) || !hasWriteBlock) {
+                continue;
+            }
+            // All shards must be started on hot nodes before we re-enable writes
+            if (!clusterState.routingTable().hasIndex(indexMetadata.getIndex())) {
+                continue;
+            }
+            List<ShardRouting> shards = clusterState.routingTable().allShards(indexMetadata.getIndex().getName());
+            boolean allOnHot = shards.stream()
+                .allMatch(
+                    s -> (s.unassigned() && !s.primary())
+                        || (s.started() && isShardStateValidForTier(s, clusterState, IndexModule.TieringState.HOT))
+                );
+            if (allOnHot) {
+                indicesToUnblock.add(indexMetadata.getIndex());
+            }
+        }
+        if (indicesToUnblock.isEmpty()) {
+            return;
+        }
+        clusterService.submitStateUpdateTask(
+            "remove-write-block-after-h2w-cancel for " + indicesToUnblock,
+            new ClusterStateUpdateTask(Priority.NORMAL) {
+                @Override
+                public ClusterState execute(ClusterState currentState) {
+                    Metadata.Builder metadataBuilder = Metadata.builder(currentState.metadata());
+                    ClusterBlocks.Builder blocksBuilder = ClusterBlocks.builder().blocks(currentState.blocks());
+                    for (Index index : indicesToUnblock) {
+                        IndexMetadata indexMetadata = currentState.metadata().index(index);
+                        if (indexMetadata == null) continue;
+                        // Re-check conditions inside the task to guard against TOCTOU
+                        String tieringState = indexMetadata.getSettings().get(INDEX_TIERING_STATE.getKey(), "");
+                        boolean hasWriteBlock = INDEX_BLOCKS_WRITE_SETTING.get(indexMetadata.getSettings());
+                        if (!IndexModule.TieringState.HOT.toString().equals(tieringState) || !hasWriteBlock) {
+                            continue;
+                        }
+                        Settings.Builder settingsBuilder = Settings.builder()
+                            .put(indexMetadata.getSettings())
+                            .put(IndexMetadata.INDEX_BLOCKS_WRITE_SETTING.getKey(), false);
+                        metadataBuilder.put(
+                            IndexMetadata.builder(indexMetadata)
+                                .settings(settingsBuilder)
+                                .settingsVersion(1 + indexMetadata.getSettingsVersion())
+                        );
+                        blocksBuilder.removeIndexBlock(index.getName(), IndexMetadata.INDEX_WRITE_BLOCK);
+                        logger.info("Removed write block for DFA index [{}] after H2W cancel — all shards on hot", index.getName());
+                    }
+                    return ClusterState.builder(currentState).metadata(metadataBuilder).blocks(blocksBuilder).build();
+                }
+
+                @Override
+                public void onFailure(String source, Exception e) {
+                    logger.error(
+                        () -> new ParameterizedMessage("Failed to remove write block after H2W cancel for indices {}", indicesToUnblock),
+                        e
+                    );
+                }
+            }
+        );
     }
 
     private TieringStatus constructTieringStatus(Index index, boolean shardLevelStatus, boolean isDetailedFlagEnabled) {

--- a/server/src/main/java/org/opensearch/storage/tiering/TieringService.java
+++ b/server/src/main/java/org/opensearch/storage/tiering/TieringService.java
@@ -238,7 +238,7 @@ public abstract class TieringService implements ClusterStateListener {
                 );
                 processTieringInProgress(event.state(), source);
             }
-            if (event.routingTableChanged() || event.metadataChanged()) {
+            if (event.routingTableChanged()) {
                 removeWriteBlockForCancelledDfaIndices(event.state());
             }
         }

--- a/server/src/test/java/org/opensearch/storage/tiering/HotToWarmTieringServiceTests.java
+++ b/server/src/test/java/org/opensearch/storage/tiering/HotToWarmTieringServiceTests.java
@@ -116,7 +116,14 @@ public class HotToWarmTieringServiceTests extends OpenSearchTestCase {
         assertEquals("false", settings.get(IS_WARM_INDEX_SETTING.getKey()));
         assertEquals(TieringState.HOT.toString(), settings.get(INDEX_TIERING_STATE.getKey()));
         assertEquals("default", settings.get(INDEX_COMPOSITE_STORE_TYPE_SETTING.getKey()));
-        assertEquals("false", settings.get(IndexMetadata.INDEX_BLOCKS_WRITE_SETTING.getKey()));
+        // INDEX_BLOCKS_WRITE is intentionally NOT set during cancel — the write block is deferred
+        // and lifted by TieringService.removeWriteBlockForCancelledDfaIndices() only after all
+        // shards are confirmed started on hot nodes (writable engine). Removing it here would
+        // allow writes to reach warm-node shards that still run a read-only engine.
+        assertNull(
+            "blocks.write must NOT be set during cancel — deferred to removeWriteBlockForCancelledDfaIndices()",
+            settings.get(IndexMetadata.INDEX_BLOCKS_WRITE_SETTING.getKey())
+        );
     }
 
     public void testGetIndexTierSettingsToRestoreAfterCancellation_NonDfaIndex_NoWriteBlockSetting() {
@@ -136,15 +143,22 @@ public class HotToWarmTieringServiceTests extends OpenSearchTestCase {
         assertSame("getTieringStartClusterBlocksToAdd must be a no-op for H2W", builder, result);
     }
 
-    public void testGetIndexTierClusterBlocksToRestoreAfterCancellation_RemovesWriteBlock() {
-        // Cancel H2W: write block must be removed so the index is writable again
+    public void testGetIndexTierClusterBlocksToRestoreAfterCancellation_IsNoOp() {
+        // H2W cancel: the cluster-level INDEX_WRITE_BLOCK is intentionally kept on the index
+        // during cancel so that writes cannot reach shards that are still on warm nodes and
+        // running a read-only engine. The block is removed later by
+        // TieringService.removeWriteBlockForCancelledDfaIndices() once all shards are confirmed
+        // started on hot nodes.
         String indexName = "test-index";
         ClusterBlocks.Builder builder = ClusterBlocks.builder().addIndexBlock(indexName, IndexMetadata.INDEX_WRITE_BLOCK);
 
         ClusterBlocks result = service.getIndexTierClusterBlocksToRestoreAfterCancellation(builder, indexName, buildDfaIndexMetadata())
             .build();
 
-        assertFalse("INDEX_WRITE_BLOCK must be removed after H2W cancel", result.hasIndexBlock(indexName, IndexMetadata.INDEX_WRITE_BLOCK));
+        assertTrue(
+            "INDEX_WRITE_BLOCK must be KEPT during H2W cancel — deferred removal until shards are on hot",
+            result.hasIndexBlock(indexName, IndexMetadata.INDEX_WRITE_BLOCK)
+        );
     }
 
     public void testGetTieringStartTimeKey() {

--- a/server/src/test/java/org/opensearch/storage/tiering/TieringServiceTests.java
+++ b/server/src/test/java/org/opensearch/storage/tiering/TieringServiceTests.java
@@ -129,23 +129,14 @@ public class TieringServiceTests extends OpenSearchTestCase {
             return blocksBuilder;
         }
 
-        @Override
-        protected org.opensearch.cluster.block.ClusterBlocks.Builder getIndexTierClusterBlocksToRestoreAfterCancellation(
-            org.opensearch.cluster.block.ClusterBlocks.Builder blocksBuilder,
-            String indexName,
-            IndexMetadata indexMetadata
-        ) {
-            return blocksBuilder.removeIndexBlock(indexName, IndexMetadata.INDEX_WRITE_BLOCK)
-                .removeIndexBlock(indexName, IndexMetadata.INDEX_WRITE_BLOCK);
-        }
+        // getIndexTierClusterBlocksToRestoreAfterCancellation intentionally uses the base class no-op:
+        // the write block is kept during cancel and removed later by removeWriteBlockForCancelledDfaIndices().
 
         @Override
         protected Settings getIndexTierSettingsToRestoreAfterCancellation(IndexMetadata indexMetadata) {
             return Settings.builder()
                 .put(IndexModule.IS_WARM_INDEX_SETTING.getKey(), false)
                 .put(INDEX_TIERING_STATE.getKey(), IndexModule.TieringState.HOT)
-                .put(IndexMetadata.INDEX_BLOCKS_WRITE_SETTING.getKey(), false)
-                .put(IndexMetadata.INDEX_BLOCKS_WRITE_SETTING.getKey(), false)
                 .build();
         }
 
@@ -975,6 +966,9 @@ public class TieringServiceTests extends OpenSearchTestCase {
         when(node.isWarmNode()).thenReturn(true);
         when(currentState.metadata()).thenReturn(metadata);
         when(metadata.index(testIndex)).thenReturn(indexMetadata);
+        // removeWriteBlockForCancelledDfaIndices iterates over all index metadata;
+        // stub the iterator so the enhanced-for loop doesn't NPE on the mock.
+        when(metadata.iterator()).thenReturn(Collections.emptyIterator());
 
         tieringService.clusterChanged(event);
 
@@ -1231,14 +1225,15 @@ public class TieringServiceTests extends OpenSearchTestCase {
     }
 
     /**
-     * Test: When cancelling tiering for a DFA index, the cancelTiering() execute() method must
-     * REMOVE INDEX_WRITE_BLOCK and INDEX_WRITE_BLOCK from ClusterBlocks AND
-     * set blocks.write=false and blocks.read_only_allow_delete=false in IndexMetadata settings.
+     * Test: When cancelling H2W tiering for a DFA index, the cancelTiering() execute() method must
+     * KEEP the INDEX_WRITE_BLOCK in ClusterBlocks and KEEP blocks.write=true in IndexMetadata settings.
      *
-     * Without this fix, a cancelled hot→warm tiering leaves the DFA index permanently write-blocked,
-     * preventing all future indexing even though the index is back on the hot tier.
+     * The write block is intentionally deferred — it must not be lifted during cancel because some
+     * shards may still be on warm nodes running a read-only engine. The block is removed later by
+     * TieringService.removeWriteBlockForCancelledDfaIndices() once all shards are confirmed started
+     * on hot nodes (writable engine). Lifting it immediately would cause write errors on warm-engine shards.
      */
-    public void testCancelTiering_DfaIndex_RemovesWriteBlocksFromClusterBlocksAndSettings() throws Exception {
+    public void testCancelTiering_DfaIndex_KeepsWriteBlocksDuringCancel() throws Exception {
         String dfaIndexName = "dfa-cancel-index";
         String dfaUuid = "dfa-cancel-uuid";
         Index dfaIndex = new Index(dfaIndexName, dfaUuid);
@@ -1302,26 +1297,19 @@ public class TieringServiceTests extends OpenSearchTestCase {
 
         ClusterState resultState = taskCaptor.getValue().execute(stateWithBlocks);
 
-        // Verify ClusterBlocks: write blocks must be REMOVED (index accepts writes again)
-        assertFalse(
-            "INDEX_WRITE_BLOCK must be REMOVED from ClusterBlocks after cancel for DFA index",
-            resultState.blocks().hasIndexBlock(dfaIndexName, IndexMetadata.INDEX_WRITE_BLOCK)
-        );
-        assertFalse(
-            "INDEX_WRITE_BLOCK must be REMOVED from ClusterBlocks after cancel for DFA index",
+        // Verify ClusterBlocks: write block must be KEPT (deferred to removeWriteBlockForCancelledDfaIndices)
+        assertTrue(
+            "INDEX_WRITE_BLOCK must be KEPT in ClusterBlocks during H2W cancel — deferred removal until shards on hot",
             resultState.blocks().hasIndexBlock(dfaIndexName, IndexMetadata.INDEX_WRITE_BLOCK)
         );
 
-        // Verify IndexMetadata settings: blocks.write=false so blocks don't come back after restart
+        // Verify IndexMetadata settings: blocks.write must remain unchanged (not set to false during cancel)
+        // The cancel task only sets IS_WARM=false and TIERING_STATE=HOT — it does not touch blocks.write.
+        // The deferred cleanup reads blocks.write=true + TIERING_STATE=HOT to identify orphaned blocks.
         IndexMetadata updatedMeta = resultState.metadata().index(dfaIndexName);
         assertNotEquals(
-            "blocks.write must be false in IndexMetadata settings after cancel for DFA index",
-            "true",
-            updatedMeta.getSettings().get(IndexMetadata.INDEX_BLOCKS_WRITE_SETTING.getKey())
-        );
-        assertNotEquals(
-            "blocks.blocks.write must be false in IndexMetadata settings after cancel for DFA index",
-            "true",
+            "blocks.write must NOT be set to false during cancel — deferred to removeWriteBlockForCancelledDfaIndices()",
+            "false",
             updatedMeta.getSettings().get(IndexMetadata.INDEX_BLOCKS_WRITE_SETTING.getKey())
         );
     }
@@ -1486,6 +1474,680 @@ public class TieringServiceTests extends OpenSearchTestCase {
             "INDEX_WRITE_BLOCK must NOT be added for non-DFA index",
             resultState.blocks().hasIndexBlock("non-dfa-index", IndexMetadata.INDEX_WRITE_BLOCK)
         );
+    }
+
+    // ── removeWriteBlockForCancelledDfaIndices tests ──────────────────────────
+    //
+    // The method is private and triggered via clusterChanged() when
+    // routingTableChanged() || metadataChanged() is true.
+    // We trigger it by building a ClusterChangedEvent and calling clusterChanged().
+
+    /**
+     * Happy path: DFA index in HOT state with write block, all shards started on hot nodes.
+     * Expects a cluster state task to be submitted to remove the write block.
+     */
+    public void testRemoveWriteBlock_DfaHotIndexWithBlock_AllShardsOnHot_SubmitsTask() throws Exception {
+        String dfaIndexName = "dfa-cleanup-index";
+        String dfaUuid = "dfa-cleanup-uuid";
+        Index dfaIndex = new Index(dfaIndexName, dfaUuid);
+
+        // DFA index in HOT state with write block still set (orphaned from H2W cancel)
+        Settings dfaHotSettings = Settings.builder()
+            .put(INDEX_TIERING_STATE.getKey(), IndexModule.TieringState.HOT.toString())
+            .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+            .put(IndexMetadata.SETTING_INDEX_UUID, dfaUuid)
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(INDEX_NUMBER_OF_REPLICAS_SETTING.getKey(), 0)
+            .put(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), true)
+            .put(IndexMetadata.INDEX_BLOCKS_WRITE_SETTING.getKey(), true)
+            .build();
+        IndexMetadata dfaHotMeta = IndexMetadata.builder(dfaIndexName)
+            .settings(dfaHotSettings)
+            .numberOfShards(1)
+            .numberOfReplicas(0)
+            .build();
+
+        IndexNameExpressionResolver resolver = mock(IndexNameExpressionResolver.class);
+        AllocationService allocationSvc = mock(AllocationService.class);
+        TestTieringService service = new TestTieringService(
+            Settings.EMPTY,
+            clusterService,
+            mock(ClusterInfoService.class),
+            resolver,
+            allocationSvc,
+            nodeEnvironment,
+            shardLimitValidator
+        );
+        // index is NOT in tieringIndices (cancel completed)
+
+        // Build cluster state: shard started on a hot node
+        Metadata meta = Metadata.builder().put(dfaHotMeta, false).build();
+        RoutingTable rt = RoutingTable.builder().addAsNew(meta.index(dfaIndexName)).build();
+        ClusterBlocks blocks = ClusterBlocks.builder().addIndexBlock(dfaIndexName, IndexMetadata.INDEX_WRITE_BLOCK).build();
+
+        ShardRouting shard = mock(ShardRouting.class);
+        DiscoveryNode hotNode = mock(DiscoveryNode.class);
+        DiscoveryNodes nodes = mock(DiscoveryNodes.class);
+
+        when(shard.unassigned()).thenReturn(false);
+        when(shard.started()).thenReturn(true);
+        when(shard.currentNodeId()).thenReturn("hot1");
+        when(hotNode.isWarmNode()).thenReturn(false);
+        when(nodes.get("hot1")).thenReturn(hotNode);
+
+        ClusterState clusterState = mock(ClusterState.class);
+        RoutingTable rtMock = mock(RoutingTable.class);
+        when(clusterState.metadata()).thenReturn(meta);
+        when(clusterState.routingTable()).thenReturn(rtMock);
+        when(clusterState.blocks()).thenReturn(blocks);
+        when(clusterState.getNodes()).thenReturn(nodes);
+        when(rtMock.hasIndex(dfaIndex)).thenReturn(true);
+        when(rtMock.allShards(dfaIndexName)).thenReturn(Collections.singletonList(shard));
+
+        // Trigger via clusterChanged
+        ClusterChangedEvent event = buildRoutingTableChangedEvent(clusterState);
+        service.clusterChanged(event);
+
+        // A task must have been submitted to remove the write block
+        verify(clusterService, org.mockito.Mockito.atLeastOnce()).submitStateUpdateTask(anyString(), any(ClusterStateUpdateTask.class));
+    }
+
+    /**
+     * Shards are still relocating (not all started on hot) — no task submitted, block kept.
+     */
+    public void testRemoveWriteBlock_DfaHotIndexWithBlock_ShardsStillRelocating_NoTask() {
+        String dfaIndexName = "dfa-relocating";
+        String dfaUuid = "dfa-relocating-uuid";
+        Index dfaIndex = new Index(dfaIndexName, dfaUuid);
+
+        Settings dfaHotSettings = Settings.builder()
+            .put(INDEX_TIERING_STATE.getKey(), IndexModule.TieringState.HOT.toString())
+            .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+            .put(IndexMetadata.SETTING_INDEX_UUID, dfaUuid)
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(INDEX_NUMBER_OF_REPLICAS_SETTING.getKey(), 0)
+            .put(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), true)
+            .put(IndexMetadata.INDEX_BLOCKS_WRITE_SETTING.getKey(), true)
+            .build();
+        IndexMetadata dfaHotMeta = IndexMetadata.builder(dfaIndexName)
+            .settings(dfaHotSettings)
+            .numberOfShards(1)
+            .numberOfReplicas(0)
+            .build();
+
+        TestTieringService service = new TestTieringService(
+            Settings.EMPTY,
+            clusterService,
+            mock(ClusterInfoService.class),
+            mock(IndexNameExpressionResolver.class),
+            mock(AllocationService.class),
+            nodeEnvironment,
+            shardLimitValidator
+        );
+
+        Metadata meta = Metadata.builder().put(dfaHotMeta, false).build();
+        ShardRouting shard = mock(ShardRouting.class);
+        DiscoveryNodes nodes = mock(DiscoveryNodes.class);
+        // Shard is initializing (not started) — relocation not complete
+        when(shard.unassigned()).thenReturn(false);
+        when(shard.started()).thenReturn(false);
+
+        ClusterState clusterState = mock(ClusterState.class);
+        RoutingTable rtMock = mock(RoutingTable.class);
+        when(clusterState.metadata()).thenReturn(meta);
+        when(clusterState.routingTable()).thenReturn(rtMock);
+        when(clusterState.getNodes()).thenReturn(nodes);
+        when(rtMock.hasIndex(dfaIndex)).thenReturn(true);
+        when(rtMock.allShards(dfaIndexName)).thenReturn(Collections.singletonList(shard));
+
+        ClusterChangedEvent event = buildRoutingTableChangedEvent(clusterState);
+        service.clusterChanged(event);
+
+        // No task submitted — shards not yet all on hot
+        verify(clusterService, never()).submitStateUpdateTask(org.mockito.Mockito.contains("remove-write-block"), any());
+    }
+
+    /**
+     * Replica shard is unassigned (e.g. no available node) while the primary is started on a hot node.
+     * The condition {@code s.unassigned() && !s.primary()} must treat the unassigned replica as
+     * "acceptable" so that {@code allOnHot=true} and the write-block removal task IS submitted.
+     *
+     * <p>This is the canonical scenario after H2W cancel with auto_expand_replicas: the primary
+     * snaps back to hot quickly but one replica may remain unassigned until a node becomes available.
+     * We must not block write-block removal waiting for those replicas.
+     */
+    public void testRemoveWriteBlock_UnassignedReplica_PrimaryOnHot_SubmitsTask() {
+        String dfaIndexName = "dfa-unassigned-replica";
+        String dfaUuid = "dfa-unassigned-replica-uuid";
+        Index dfaIndex = new Index(dfaIndexName, dfaUuid);
+
+        Settings dfaHotSettings = Settings.builder()
+            .put(INDEX_TIERING_STATE.getKey(), IndexModule.TieringState.HOT.toString())
+            .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+            .put(IndexMetadata.SETTING_INDEX_UUID, dfaUuid)
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(INDEX_NUMBER_OF_REPLICAS_SETTING.getKey(), 1)
+            .put(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), true)
+            .put(IndexMetadata.INDEX_BLOCKS_WRITE_SETTING.getKey(), true)
+            .build();
+        IndexMetadata dfaHotMeta = IndexMetadata.builder(dfaIndexName)
+            .settings(dfaHotSettings)
+            .numberOfShards(1)
+            .numberOfReplicas(1)
+            .build();
+
+        TestTieringService service = new TestTieringService(
+            Settings.EMPTY,
+            clusterService,
+            mock(ClusterInfoService.class),
+            mock(IndexNameExpressionResolver.class),
+            mock(AllocationService.class),
+            nodeEnvironment,
+            shardLimitValidator
+        );
+        // index is NOT in tieringIndices (cancel completed)
+
+        Metadata meta = Metadata.builder().put(dfaHotMeta, false).build();
+
+        // Primary shard: started on a hot node
+        ShardRouting primaryShard = mock(ShardRouting.class);
+        when(primaryShard.unassigned()).thenReturn(false);
+        when(primaryShard.started()).thenReturn(true);
+        when(primaryShard.primary()).thenReturn(true);
+        when(primaryShard.currentNodeId()).thenReturn("hot1");
+
+        // Replica shard: unassigned and NOT primary — satisfies s.unassigned() && !s.primary()
+        ShardRouting replicaShard = mock(ShardRouting.class);
+        when(replicaShard.unassigned()).thenReturn(true);
+        when(replicaShard.primary()).thenReturn(false);
+
+        DiscoveryNode hotNode = mock(DiscoveryNode.class);
+        when(hotNode.isWarmNode()).thenReturn(false);
+        DiscoveryNodes nodes = mock(DiscoveryNodes.class);
+        when(nodes.get("hot1")).thenReturn(hotNode);
+
+        ClusterState clusterState = mock(ClusterState.class);
+        RoutingTable rtMock = mock(RoutingTable.class);
+        when(clusterState.metadata()).thenReturn(meta);
+        when(clusterState.routingTable()).thenReturn(rtMock);
+        when(clusterState.getNodes()).thenReturn(nodes);
+        when(rtMock.hasIndex(dfaIndex)).thenReturn(true);
+        when(rtMock.allShards(dfaIndexName)).thenReturn(java.util.Arrays.asList(primaryShard, replicaShard));
+
+        ClusterChangedEvent event = buildRoutingTableChangedEvent(clusterState);
+        service.clusterChanged(event);
+
+        // allOnHot=true (primary on hot + replica unassigned-non-primary) → task must be submitted
+        verify(clusterService, org.mockito.Mockito.atLeastOnce()).submitStateUpdateTask(
+            org.mockito.Mockito.contains("remove-write-block"),
+            any(ClusterStateUpdateTask.class)
+        );
+    }
+
+    /**
+     * Primary shard itself is unassigned — {@code s.unassigned() && !s.primary()} is false
+     * (primary IS a primary), and {@code s.started()} is also false.
+     * Therefore {@code allOnHot=false} and no write-block removal task must be submitted.
+     *
+     * <p>This is the negative complement of the unassigned-replica case: we must NOT lift
+     * the write block when the primary is not yet running on a hot node.
+     */
+    public void testRemoveWriteBlock_UnassignedPrimary_DoesNotSubmitTask() {
+        String dfaIndexName = "dfa-unassigned-primary";
+        String dfaUuid = "dfa-unassigned-primary-uuid";
+        Index dfaIndex = new Index(dfaIndexName, dfaUuid);
+
+        Settings dfaHotSettings = Settings.builder()
+            .put(INDEX_TIERING_STATE.getKey(), IndexModule.TieringState.HOT.toString())
+            .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+            .put(IndexMetadata.SETTING_INDEX_UUID, dfaUuid)
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(INDEX_NUMBER_OF_REPLICAS_SETTING.getKey(), 0)
+            .put(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), true)
+            .put(IndexMetadata.INDEX_BLOCKS_WRITE_SETTING.getKey(), true)
+            .build();
+        IndexMetadata dfaHotMeta = IndexMetadata.builder(dfaIndexName)
+            .settings(dfaHotSettings)
+            .numberOfShards(1)
+            .numberOfReplicas(0)
+            .build();
+
+        TestTieringService service = new TestTieringService(
+            Settings.EMPTY,
+            clusterService,
+            mock(ClusterInfoService.class),
+            mock(IndexNameExpressionResolver.class),
+            mock(AllocationService.class),
+            nodeEnvironment,
+            shardLimitValidator
+        );
+
+        Metadata meta = Metadata.builder().put(dfaHotMeta, false).build();
+
+        // Primary shard is unassigned — neither branch of the allMatch predicate is satisfied:
+        // s.unassigned() && !s.primary() → false (it IS the primary)
+        // s.started() && ... → false (not started)
+        ShardRouting primaryShard = mock(ShardRouting.class);
+        when(primaryShard.unassigned()).thenReturn(true);
+        when(primaryShard.primary()).thenReturn(true);
+        when(primaryShard.started()).thenReturn(false);
+
+        ClusterState clusterState = mock(ClusterState.class);
+        RoutingTable rtMock = mock(RoutingTable.class);
+        when(clusterState.metadata()).thenReturn(meta);
+        when(clusterState.routingTable()).thenReturn(rtMock);
+        when(clusterState.getNodes()).thenReturn(mock(DiscoveryNodes.class));
+        when(rtMock.hasIndex(dfaIndex)).thenReturn(true);
+        when(rtMock.allShards(dfaIndexName)).thenReturn(Collections.singletonList(primaryShard));
+
+        ClusterChangedEvent event = buildRoutingTableChangedEvent(clusterState);
+        service.clusterChanged(event);
+
+        // allOnHot=false → no task submitted
+        verify(clusterService, never()).submitStateUpdateTask(org.mockito.Mockito.contains("remove-write-block"), any());
+    }
+
+    /**
+     * Non-DFA index with write block in HOT state — must be completely ignored.
+     */
+    public void testRemoveWriteBlock_NonDfaIndex_Skipped() {
+        String indexName = "non-dfa-hot";
+        String uuid = "non-dfa-hot-uuid";
+        Index idx = new Index(indexName, uuid);
+
+        Settings hotSettings = Settings.builder()
+            .put(INDEX_TIERING_STATE.getKey(), IndexModule.TieringState.HOT.toString())
+            .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+            .put(IndexMetadata.SETTING_INDEX_UUID, uuid)
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(INDEX_NUMBER_OF_REPLICAS_SETTING.getKey(), 0)
+            .put(IndexMetadata.INDEX_BLOCKS_WRITE_SETTING.getKey(), true)
+            // PLUGGABLE_DATAFORMAT_ENABLED_SETTING not set → non-DFA
+            .build();
+        IndexMetadata meta = IndexMetadata.builder(indexName).settings(hotSettings).numberOfShards(1).numberOfReplicas(0).build();
+
+        TestTieringService service = new TestTieringService(
+            Settings.EMPTY,
+            clusterService,
+            mock(ClusterInfoService.class),
+            mock(IndexNameExpressionResolver.class),
+            mock(AllocationService.class),
+            nodeEnvironment,
+            shardLimitValidator
+        );
+
+        Metadata clusterMeta = Metadata.builder().put(meta, false).build();
+        ClusterState clusterState = mock(ClusterState.class);
+        when(clusterState.metadata()).thenReturn(clusterMeta);
+        when(clusterState.routingTable()).thenReturn(mock(RoutingTable.class));
+
+        ClusterChangedEvent event = buildRoutingTableChangedEvent(clusterState);
+        service.clusterChanged(event);
+
+        verify(clusterService, never()).submitStateUpdateTask(org.mockito.Mockito.contains("remove-write-block"), any());
+    }
+
+    /**
+     * DFA index in HOT state with write block, but it's still in tieringIndices
+     * (actively tiering) — must be skipped.
+     */
+    public void testRemoveWriteBlock_IndexStillInTieringIndices_Skipped() {
+        String dfaIndexName = "dfa-still-tiering";
+        String dfaUuid = "dfa-still-tiering-uuid";
+        Index dfaIndex = new Index(dfaIndexName, dfaUuid);
+
+        Settings dfaHotSettings = Settings.builder()
+            .put(INDEX_TIERING_STATE.getKey(), IndexModule.TieringState.HOT.toString())
+            .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+            .put(IndexMetadata.SETTING_INDEX_UUID, dfaUuid)
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(INDEX_NUMBER_OF_REPLICAS_SETTING.getKey(), 0)
+            .put(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), true)
+            .put(IndexMetadata.INDEX_BLOCKS_WRITE_SETTING.getKey(), true)
+            .build();
+        IndexMetadata dfaHotMeta = IndexMetadata.builder(dfaIndexName)
+            .settings(dfaHotSettings)
+            .numberOfShards(1)
+            .numberOfReplicas(0)
+            .build();
+
+        TestTieringService service = new TestTieringService(
+            Settings.EMPTY,
+            clusterService,
+            mock(ClusterInfoService.class),
+            mock(IndexNameExpressionResolver.class),
+            mock(AllocationService.class),
+            nodeEnvironment,
+            shardLimitValidator
+        );
+        // Index IS in tieringIndices — still tiering, must not be cleaned up
+        service.tieringIndices.add(dfaIndex);
+
+        Metadata meta = Metadata.builder().put(dfaHotMeta, false).build();
+        ClusterState clusterState = mock(ClusterState.class);
+        when(clusterState.metadata()).thenReturn(meta);
+        when(clusterState.routingTable()).thenReturn(mock(RoutingTable.class));
+
+        ClusterChangedEvent event = buildRoutingTableChangedEvent(clusterState);
+        service.clusterChanged(event);
+
+        verify(clusterService, never()).submitStateUpdateTask(org.mockito.Mockito.contains("remove-write-block"), any());
+    }
+
+    /**
+     * DFA index in HOT state but write block already removed — no task submitted.
+     */
+    public void testRemoveWriteBlock_DfaHotIndex_NoWriteBlock_Skipped() {
+        String dfaIndexName = "dfa-hot-no-block";
+        String dfaUuid = "dfa-hot-no-block-uuid";
+
+        Settings dfaHotSettings = Settings.builder()
+            .put(INDEX_TIERING_STATE.getKey(), IndexModule.TieringState.HOT.toString())
+            .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+            .put(IndexMetadata.SETTING_INDEX_UUID, dfaUuid)
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(INDEX_NUMBER_OF_REPLICAS_SETTING.getKey(), 0)
+            .put(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), true)
+            // INDEX_BLOCKS_WRITE not set → false (block already removed)
+            .build();
+        IndexMetadata dfaHotMeta = IndexMetadata.builder(dfaIndexName)
+            .settings(dfaHotSettings)
+            .numberOfShards(1)
+            .numberOfReplicas(0)
+            .build();
+
+        TestTieringService service = new TestTieringService(
+            Settings.EMPTY,
+            clusterService,
+            mock(ClusterInfoService.class),
+            mock(IndexNameExpressionResolver.class),
+            mock(AllocationService.class),
+            nodeEnvironment,
+            shardLimitValidator
+        );
+
+        Metadata meta = Metadata.builder().put(dfaHotMeta, false).build();
+        ClusterState clusterState = mock(ClusterState.class);
+        when(clusterState.metadata()).thenReturn(meta);
+        when(clusterState.routingTable()).thenReturn(mock(RoutingTable.class));
+
+        ClusterChangedEvent event = buildRoutingTableChangedEvent(clusterState);
+        service.clusterChanged(event);
+
+        verify(clusterService, never()).submitStateUpdateTask(org.mockito.Mockito.contains("remove-write-block"), any());
+    }
+
+    /**
+     * Happy-path execute(): task actually removes INDEX_WRITE_BLOCK from ClusterBlocks
+     * and sets INDEX_BLOCKS_WRITE=false in IndexMetadata settings.
+     */
+    public void testRemoveWriteBlock_Execute_RemovesBlockAndUpdatesMetadata() throws Exception {
+        String dfaIndexName = "dfa-execute-index";
+        String dfaUuid = "dfa-execute-uuid";
+        Index dfaIndex = new Index(dfaIndexName, dfaUuid);
+
+        Settings dfaHotSettings = Settings.builder()
+            .put(INDEX_TIERING_STATE.getKey(), IndexModule.TieringState.HOT.toString())
+            .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+            .put(IndexMetadata.SETTING_INDEX_UUID, dfaUuid)
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(INDEX_NUMBER_OF_REPLICAS_SETTING.getKey(), 0)
+            .put(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), true)
+            .put(IndexMetadata.INDEX_BLOCKS_WRITE_SETTING.getKey(), true)
+            .build();
+        IndexMetadata dfaHotMeta = IndexMetadata.builder(dfaIndexName)
+            .settings(dfaHotSettings)
+            .numberOfShards(1)
+            .numberOfReplicas(0)
+            .build();
+
+        Metadata meta = Metadata.builder().put(dfaHotMeta, false).build();
+        RoutingTable rt = RoutingTable.builder().addAsNew(meta.index(dfaIndexName)).build();
+        ClusterBlocks blocks = ClusterBlocks.builder().addIndexBlock(dfaIndexName, IndexMetadata.INDEX_WRITE_BLOCK).build();
+        ClusterState realState = ClusterState.builder(org.opensearch.cluster.ClusterName.DEFAULT)
+            .metadata(meta)
+            .routingTable(rt)
+            .blocks(blocks)
+            .build();
+
+        TestTieringService service = new TestTieringService(
+            Settings.EMPTY,
+            clusterService,
+            mock(ClusterInfoService.class),
+            mock(IndexNameExpressionResolver.class),
+            mock(AllocationService.class),
+            nodeEnvironment,
+            shardLimitValidator
+        );
+
+        // Capture the submitted task so we can execute it
+        ArgumentCaptor<ClusterStateUpdateTask> taskCaptor = ArgumentCaptor.forClass(ClusterStateUpdateTask.class);
+
+        ShardRouting shard = mock(ShardRouting.class);
+        DiscoveryNode hotNode = mock(DiscoveryNode.class);
+        DiscoveryNodes nodes = mock(DiscoveryNodes.class);
+        when(shard.unassigned()).thenReturn(false);
+        when(shard.started()).thenReturn(true);
+        when(shard.currentNodeId()).thenReturn("hot1");
+        when(hotNode.isWarmNode()).thenReturn(false);
+        when(nodes.get("hot1")).thenReturn(hotNode);
+
+        ClusterState mockState = mock(ClusterState.class);
+        RoutingTable rtMock = mock(RoutingTable.class);
+        when(mockState.metadata()).thenReturn(meta);
+        when(mockState.routingTable()).thenReturn(rtMock);
+        when(mockState.blocks()).thenReturn(blocks);
+        when(mockState.getNodes()).thenReturn(nodes);
+        when(rtMock.hasIndex(dfaIndex)).thenReturn(true);
+        when(rtMock.allShards(dfaIndexName)).thenReturn(Collections.singletonList(shard));
+
+        ClusterChangedEvent event = buildRoutingTableChangedEvent(mockState);
+        service.clusterChanged(event);
+
+        verify(clusterService, org.mockito.Mockito.atLeastOnce()).submitStateUpdateTask(anyString(), taskCaptor.capture());
+
+        // Execute the captured task against a real cluster state that still has the block
+        ClusterState result = taskCaptor.getValue().execute(realState);
+
+        // INDEX_WRITE_BLOCK must be removed from ClusterBlocks
+        assertFalse(
+            "INDEX_WRITE_BLOCK must be absent from ClusterBlocks after execute()",
+            result.blocks().hasIndexBlock(dfaIndexName, IndexMetadata.INDEX_WRITE_BLOCK)
+        );
+        // INDEX_BLOCKS_WRITE setting must be false in IndexMetadata
+        assertEquals("false", result.metadata().index(dfaIndexName).getSettings().get(IndexMetadata.INDEX_BLOCKS_WRITE_SETTING.getKey()));
+    }
+
+    /**
+     * TOCTOU guard inside execute(): index condition changed between scan and task execution
+     * (write block already removed by another task) — execute() must skip and produce no change.
+     */
+    public void testRemoveWriteBlock_Execute_ToctouGuard_SkipsIfBlockAlreadyRemoved() throws Exception {
+        String dfaIndexName = "dfa-toctou-index";
+        String dfaUuid = "dfa-toctou-uuid";
+        Index dfaIndex = new Index(dfaIndexName, dfaUuid);
+
+        // Settings without write block (already removed before execute runs)
+        Settings dfaHotSettingsNoBlock = Settings.builder()
+            .put(INDEX_TIERING_STATE.getKey(), IndexModule.TieringState.HOT.toString())
+            .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+            .put(IndexMetadata.SETTING_INDEX_UUID, dfaUuid)
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(INDEX_NUMBER_OF_REPLICAS_SETTING.getKey(), 0)
+            .put(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), true)
+            // INDEX_BLOCKS_WRITE not set = false (block already removed)
+            .build();
+        IndexMetadata dfaHotMeta = IndexMetadata.builder(dfaIndexName)
+            .settings(dfaHotSettingsNoBlock)
+            .numberOfShards(1)
+            .numberOfReplicas(0)
+            .build();
+
+        // Settings WITH block for the initial scan (so the task gets submitted)
+        Settings dfaHotSettingsWithBlock = Settings.builder()
+            .put(dfaHotSettingsNoBlock)
+            .put(IndexMetadata.INDEX_BLOCKS_WRITE_SETTING.getKey(), true)
+            .build();
+        IndexMetadata dfaHotMetaWithBlock = IndexMetadata.builder(dfaIndexName)
+            .settings(dfaHotSettingsWithBlock)
+            .numberOfShards(1)
+            .numberOfReplicas(0)
+            .build();
+
+        // Scan state has the block (triggers task submission)
+        Metadata scanMeta = Metadata.builder().put(dfaHotMetaWithBlock, false).build();
+        ClusterBlocks blocksWithBlock = ClusterBlocks.builder().addIndexBlock(dfaIndexName, IndexMetadata.INDEX_WRITE_BLOCK).build();
+
+        // Execute state: block already gone (TOCTOU)
+        Metadata executeMeta = Metadata.builder().put(dfaHotMeta, false).build();
+        RoutingTable rt = RoutingTable.builder().addAsNew(executeMeta.index(dfaIndexName)).build();
+        ClusterState executeState = ClusterState.builder(org.opensearch.cluster.ClusterName.DEFAULT)
+            .metadata(executeMeta)
+            .routingTable(rt)
+            .blocks(ClusterBlocks.EMPTY_CLUSTER_BLOCK)
+            .build();
+
+        TestTieringService service = new TestTieringService(
+            Settings.EMPTY,
+            clusterService,
+            mock(ClusterInfoService.class),
+            mock(IndexNameExpressionResolver.class),
+            mock(AllocationService.class),
+            nodeEnvironment,
+            shardLimitValidator
+        );
+
+        ArgumentCaptor<ClusterStateUpdateTask> taskCaptor = ArgumentCaptor.forClass(ClusterStateUpdateTask.class);
+
+        ShardRouting shard = mock(ShardRouting.class);
+        DiscoveryNode hotNode = mock(DiscoveryNode.class);
+        DiscoveryNodes nodes = mock(DiscoveryNodes.class);
+        when(shard.unassigned()).thenReturn(false);
+        when(shard.started()).thenReturn(true);
+        when(shard.currentNodeId()).thenReturn("hot1");
+        when(hotNode.isWarmNode()).thenReturn(false);
+        when(nodes.get("hot1")).thenReturn(hotNode);
+
+        ClusterState mockScanState = mock(ClusterState.class);
+        RoutingTable rtMock = mock(RoutingTable.class);
+        when(mockScanState.metadata()).thenReturn(scanMeta);
+        when(mockScanState.routingTable()).thenReturn(rtMock);
+        when(mockScanState.blocks()).thenReturn(blocksWithBlock);
+        when(mockScanState.getNodes()).thenReturn(nodes);
+        when(rtMock.hasIndex(dfaIndex)).thenReturn(true);
+        when(rtMock.allShards(dfaIndexName)).thenReturn(Collections.singletonList(shard));
+
+        ClusterChangedEvent event = buildRoutingTableChangedEvent(mockScanState);
+        service.clusterChanged(event);
+
+        verify(clusterService, org.mockito.Mockito.atLeastOnce()).submitStateUpdateTask(anyString(), taskCaptor.capture());
+
+        // Execute with the state where block is already gone (TOCTOU scenario)
+        ClusterState result = taskCaptor.getValue().execute(executeState);
+
+        // Result must equal the input state unchanged (no index block was found to remove)
+        assertFalse(
+            "No INDEX_WRITE_BLOCK should be present — TOCTOU guard must have skipped this index",
+            result.blocks().hasIndexBlock(dfaIndexName, IndexMetadata.INDEX_WRITE_BLOCK)
+        );
+        // INDEX_BLOCKS_WRITE must remain null/false (was never set by the task)
+        assertNotEquals("true", result.metadata().index(dfaIndexName).getSettings().get(IndexMetadata.INDEX_BLOCKS_WRITE_SETTING.getKey()));
+    }
+
+    /**
+     * Null guard inside execute(): index deleted between scan and task execution —
+     * execute() must skip gracefully and not throw NPE.
+     */
+    public void testRemoveWriteBlock_Execute_NullGuard_IndexDeletedBetweenScanAndTask() throws Exception {
+        String dfaIndexName = "dfa-deleted-index";
+        String dfaUuid = "dfa-deleted-uuid";
+        Index dfaIndex = new Index(dfaIndexName, dfaUuid);
+
+        Settings dfaHotSettings = Settings.builder()
+            .put(INDEX_TIERING_STATE.getKey(), IndexModule.TieringState.HOT.toString())
+            .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+            .put(IndexMetadata.SETTING_INDEX_UUID, dfaUuid)
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(INDEX_NUMBER_OF_REPLICAS_SETTING.getKey(), 0)
+            .put(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), true)
+            .put(IndexMetadata.INDEX_BLOCKS_WRITE_SETTING.getKey(), true)
+            .build();
+        IndexMetadata dfaHotMeta = IndexMetadata.builder(dfaIndexName)
+            .settings(dfaHotSettings)
+            .numberOfShards(1)
+            .numberOfReplicas(0)
+            .build();
+
+        // Scan state: index exists with write block
+        Metadata scanMeta = Metadata.builder().put(dfaHotMeta, false).build();
+        ClusterBlocks blocksWithBlock = ClusterBlocks.builder().addIndexBlock(dfaIndexName, IndexMetadata.INDEX_WRITE_BLOCK).build();
+
+        // Execute state: index has been deleted
+        ClusterState executeState = ClusterState.builder(org.opensearch.cluster.ClusterName.DEFAULT)
+            .metadata(Metadata.EMPTY_METADATA)
+            .routingTable(RoutingTable.EMPTY_ROUTING_TABLE)
+            .blocks(ClusterBlocks.EMPTY_CLUSTER_BLOCK)
+            .build();
+
+        TestTieringService service = new TestTieringService(
+            Settings.EMPTY,
+            clusterService,
+            mock(ClusterInfoService.class),
+            mock(IndexNameExpressionResolver.class),
+            mock(AllocationService.class),
+            nodeEnvironment,
+            shardLimitValidator
+        );
+
+        ArgumentCaptor<ClusterStateUpdateTask> taskCaptor = ArgumentCaptor.forClass(ClusterStateUpdateTask.class);
+
+        ShardRouting shard = mock(ShardRouting.class);
+        DiscoveryNode hotNode = mock(DiscoveryNode.class);
+        DiscoveryNodes nodes = mock(DiscoveryNodes.class);
+        when(shard.unassigned()).thenReturn(false);
+        when(shard.started()).thenReturn(true);
+        when(shard.currentNodeId()).thenReturn("hot1");
+        when(hotNode.isWarmNode()).thenReturn(false);
+        when(nodes.get("hot1")).thenReturn(hotNode);
+
+        ClusterState mockScanState = mock(ClusterState.class);
+        RoutingTable rtMock = mock(RoutingTable.class);
+        when(mockScanState.metadata()).thenReturn(scanMeta);
+        when(mockScanState.routingTable()).thenReturn(rtMock);
+        when(mockScanState.blocks()).thenReturn(blocksWithBlock);
+        when(mockScanState.getNodes()).thenReturn(nodes);
+        when(rtMock.hasIndex(dfaIndex)).thenReturn(true);
+        when(rtMock.allShards(dfaIndexName)).thenReturn(Collections.singletonList(shard));
+
+        ClusterChangedEvent event = buildRoutingTableChangedEvent(mockScanState);
+        service.clusterChanged(event);
+
+        verify(clusterService, org.mockito.Mockito.atLeastOnce()).submitStateUpdateTask(anyString(), taskCaptor.capture());
+
+        // execute() with deleted-index state must not throw
+        ClusterState result = taskCaptor.getValue().execute(executeState);
+        assertNotNull("execute() must return a non-null state even when index was deleted", result);
+    }
+
+    /**
+     * Helper: builds a ClusterChangedEvent where routingTableChanged()=true and
+     * localNodeClusterManager()=true but previousNodes.isLocalNodeElectedClusterManager()=true
+     * (so reconstruction is skipped and only the cleanup path runs).
+     */
+    private ClusterChangedEvent buildRoutingTableChangedEvent(ClusterState currentState) {
+        ClusterChangedEvent event = mock(ClusterChangedEvent.class);
+        ClusterState previousState = mock(ClusterState.class);
+        DiscoveryNodes previousNodes = mock(DiscoveryNodes.class);
+
+        when(event.localNodeClusterManager()).thenReturn(true);
+        when(event.state()).thenReturn(currentState);
+        when(event.previousState()).thenReturn(previousState);
+        when(previousState.nodes()).thenReturn(previousNodes);
+        when(previousNodes.isLocalNodeElectedClusterManager()).thenReturn(true);
+        when(event.routingTableChanged()).thenReturn(true);
+        when(event.metadataChanged()).thenReturn(false);
+        when(event.blocksChanged()).thenReturn(false);
+        return event;
     }
 
     /**

--- a/server/src/test/java/org/opensearch/storage/tiering/WarmToHotTieringServiceTests.java
+++ b/server/src/test/java/org/opensearch/storage/tiering/WarmToHotTieringServiceTests.java
@@ -221,6 +221,7 @@ public class WarmToHotTieringServiceTests extends OpenSearchTestCase {
 
         Metadata metadata = mock(Metadata.class);
         when(clusterState.metadata()).thenReturn(metadata);
+        when(metadata.iterator()).thenReturn(Collections.emptyIterator());
 
         service.tieringIndices.add(testIndex);
         service.clusterChanged(event);
@@ -256,6 +257,7 @@ public class WarmToHotTieringServiceTests extends OpenSearchTestCase {
         Metadata metadata = mock(Metadata.class);
         when(clusterState.metadata()).thenReturn(metadata);
         when(metadata.index(testIndex)).thenReturn(indexMetadata);
+        when(metadata.iterator()).thenReturn(Collections.emptyIterator());
 
         service.tieringIndices.add(testIndex);
         service.clusterChanged(event);
@@ -337,6 +339,7 @@ public class WarmToHotTieringServiceTests extends OpenSearchTestCase {
         Metadata metadata = mock(Metadata.class);
         when(clusterState.metadata()).thenReturn(metadata);
         when(metadata.index(testIndex)).thenReturn(indexMetadata);
+        when(metadata.iterator()).thenReturn(Collections.emptyIterator());
 
         service.tieringIndices.add(testIndex);
         service.clusterChanged(event);


### PR DESCRIPTION

---

### Description

This PR bundles three related areas of work for the DFA (pluggable-dataformat) tiered storage path:

**1. Deferred write-block removal after H2W cancel**

Cancelling a hot-to-warm migration for a DFA index was immediately removing the write block during the cancel cluster state task. This created a window where write requests could reach warm-node shards that were still running the read-only Parquet engine (before physical relocation completed), causing ingestion errors.

- `HotToWarmTieringService.getIndexTierSettingsToRestoreAfterCancellation()` no longer sets `INDEX_BLOCKS_WRITE=false`; the base class `getIndexTierClusterBlocksToRestoreAfterCancellation()` no longer removes `INDEX_WRITE_BLOCK`
- Added `TieringService.removeWriteBlockForCancelledDfaIndices()` — a cluster-event listener that removes the block only when: DFA index, `INDEX_TIERING_STATE=HOT`, `INDEX_BLOCKS_WRITE=true`, not actively tiering, and **all shards are `started` on hot nodes**
- W2H cancel path unchanged: re-adds the write block immediately (correct — reverting to warm means read-only engine)
- Unit tests: `TieringServiceTests`, `HotToWarmTieringServiceTests`, `WarmToHotTieringServiceTests`

**2. Foyer key_index persistence (file-based shard registry)**

Adds a disk-backed key_index to the Foyer block cache to survive warm node restarts without cold-read penalties:

- `key_index_store.rs`: atomic JSON serialization/deserialization with version validation; graceful fallback on corrupt or wrong-version files
- Independent periodic persist task (configurable interval, default 60s) decoupled from the sweep task
- Sweep threshold guard: skips DashMap scan when cache is less than N% full (default 70%)
- `FoyerBlockCacheSettings`: new settings for `key_index_sweep_interval_seconds`, `key_index_sweep_threshold`, `key_index_persist_interval_seconds`; default cache size updated to 50%
- Live FFM downcall handles: `foyer_update_sweep_threshold`, `foyer_update_sweep_interval`, `foyer_update_persist_interval` via `FoyerBridge`
- Rust integration tests: 10k-entry scale tests for key_index serialization, periodic persist, bulk evict_prefix, prune
- IT infrastructure: `BlockCacheKeyIndexRecoveryIT`, `BlockCacheKeyIndexScaleIT`, `BlockCacheStatsIT`, `PruneBlockCacheIT` — all with `nodeSettings()` override to enable Foyer via `FeatureFlags.PLUGGABLE_DATAFORMAT_