### PR TITLE
[Sandbox] feat(datafusion): expose parquet metadata / statistics cache stats and search stats on the analytics backend stats endpoint

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/cache.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/cache.rs
@@ -6,6 +6,7 @@
  * compatible open source license.
  */
 
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
 use datafusion::execution::cache::cache_manager::{
@@ -28,13 +29,30 @@ fn log_cache_error(operation: &str, error: &str) {
 // Wrapper to make Mutex<DefaultFilesMetadataCache> implement FileMetadataCache
 pub struct MutexFileMetadataCache {
     pub inner: Mutex<DefaultFilesMetadataCache>,
+    hit_count: AtomicUsize,
+    miss_count: AtomicUsize,
 }
 
 impl MutexFileMetadataCache {
     pub fn new(cache: DefaultFilesMetadataCache) -> Self {
         Self {
             inner: Mutex::new(cache),
+            hit_count: AtomicUsize::new(0),
+            miss_count: AtomicUsize::new(0),
         }
+    }
+
+    pub fn hit_count(&self) -> usize {
+        self.hit_count.load(Ordering::Relaxed)
+    }
+
+    pub fn miss_count(&self) -> usize {
+        self.miss_count.load(Ordering::Relaxed)
+    }
+
+    pub fn reset_stats(&self) {
+        self.hit_count.store(0, Ordering::Relaxed);
+        self.miss_count.store(0, Ordering::Relaxed);
     }
 
     pub fn clear_cache(&self) {
@@ -61,7 +79,15 @@ impl MutexFileMetadataCache {
 impl CacheAccessor<Path, CachedFileMetadataEntry> for MutexFileMetadataCache {
     fn get(&self, k: &Path) -> Option<CachedFileMetadataEntry> {
         match self.inner.lock() {
-            Ok(cache) => cache.get(k),
+            Ok(cache) => {
+                let result = cache.get(k);
+                if result.is_some() {
+                    self.hit_count.fetch_add(1, Ordering::Relaxed);
+                } else {
+                    self.miss_count.fetch_add(1, Ordering::Relaxed);
+                }
+                result
+            }
             Err(e) => {
                 log_cache_error("get", &e.to_string());
                 None

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/custom_cache_manager.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/custom_cache_manager.rs
@@ -504,9 +504,58 @@ impl CustomCacheManager {
             .unwrap_or(0.0)
     }
 
+    /// Get statistics cache entry count
+    pub fn statistics_cache_entry_count(&self) -> usize {
+        self.statistics_cache.as_ref()
+            .map(|cache| <CustomStatisticsCache as CacheAccessor<_, _>>::len(cache))
+            .unwrap_or(0)
+    }
+
+    /// Get statistics cache size limit in bytes
+    pub fn statistics_cache_size_limit(&self) -> usize {
+        self.statistics_cache.as_ref()
+            .map(|cache| cache.current_size_limit())
+            .unwrap_or(0)
+    }
+
     /// Reset statistics cache stats
     pub fn statistics_cache_reset_stats(&self) {
         if let Some(cache) = &self.statistics_cache {
+            cache.reset_stats();
+        }
+    }
+
+    /// Get metadata cache hit count
+    pub fn metadata_cache_hit_count(&self) -> usize {
+        self.file_metadata_cache.as_ref()
+            .map(|cache| cache.hit_count())
+            .unwrap_or(0)
+    }
+
+    /// Get metadata cache miss count
+    pub fn metadata_cache_miss_count(&self) -> usize {
+        self.file_metadata_cache.as_ref()
+            .map(|cache| cache.miss_count())
+            .unwrap_or(0)
+    }
+
+    /// Get metadata cache entry count
+    pub fn metadata_cache_entry_count(&self) -> usize {
+        self.file_metadata_cache.as_ref()
+            .map(|cache| <MutexFileMetadataCache as CacheAccessor<_, _>>::len(cache))
+            .unwrap_or(0)
+    }
+
+    /// Get metadata cache size limit in bytes
+    pub fn metadata_cache_size_limit(&self) -> usize {
+        self.file_metadata_cache.as_ref()
+            .map(|cache| cache.get_cache_limit())
+            .unwrap_or(0)
+    }
+
+    /// Reset metadata cache stats
+    pub fn metadata_cache_reset_stats(&self) {
+        if let Some(cache) = &self.file_metadata_cache {
             cache.reset_stats();
         }
     }

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/ffm.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/ffm.rs
@@ -1165,7 +1165,7 @@ pub unsafe extern "C" fn df_execute_with_context(
 /// `runtime_ptr` may be `0` to skip cache-stats collection. When non-zero it
 /// must be a valid pointer returned by [`df_create_global_runtime`].
 ///
-/// The buffer must have capacity for at least `size_of::<DfStatsBuffer>()` bytes (536).
+/// The buffer must have capacity for at least `size_of::<DfStatsBuffer>()` bytes (544).
 /// Returns 0 on success.
 #[ffm_safe]
 #[no_mangle]

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/ffm.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/ffm.rs
@@ -854,6 +854,7 @@ pub unsafe extern "C" fn df_create_session_context(
     plan_ptr: *const u8,
     plan_len: i64,
 ) -> i64 {
+    crate::search_stats::inc_listing_table_scan();
     let table_name = str_from_raw(table_name_ptr, table_name_len)
         .map_err(|e| format!("df_create_session_context: {}", e))?;
     let query_config =
@@ -893,6 +894,11 @@ pub unsafe extern "C" fn df_create_session_context_indexed(
     plan_ptr: *const u8,
     plan_len: i64,
 ) -> i64 {
+    match tree_shape {
+        1 => crate::search_stats::inc_single_collector_scan(),
+        2 => crate::search_stats::inc_bitmap_tree_scan(),
+        _ => {}
+    }
     let table_name = str_from_raw(table_name_ptr, table_name_len)
         .map_err(|e| format!("df_create_session_context_indexed: {}", e))?;
     let query_config =
@@ -1156,12 +1162,18 @@ pub unsafe extern "C" fn df_execute_with_context(
 
 /// Collects all native executor metrics into a caller-provided byte buffer.
 ///
-/// The buffer must have capacity for at least `size_of::<DfStatsBuffer>()` bytes (344).
+/// `runtime_ptr` may be `0` to skip cache-stats collection. When non-zero it
+/// must be a valid pointer returned by [`df_create_global_runtime`].
+///
+/// The buffer must have capacity for at least `size_of::<DfStatsBuffer>()` bytes (536).
 /// Returns 0 on success.
 #[ffm_safe]
 #[no_mangle]
-pub unsafe extern "C" fn df_stats(out_ptr: *mut u8, out_cap: i64) -> i64 {
-    use crate::stats::{layout, pack_runtime_metrics, pack_task_monitor, pack_partition_gate, DfStatsBuffer, RuntimeMetricsRepr};
+pub unsafe extern "C" fn df_stats(runtime_ptr: i64, out_ptr: *mut u8, out_cap: i64) -> i64 {
+    use crate::stats::{
+        layout, pack_cache_stats, pack_partition_gate, pack_runtime_metrics, pack_task_monitor,
+        CacheStatsRepr, DfStatsBuffer, RuntimeMetricsRepr,
+    };
     use crate::task_monitors::{
         coordinator_reduce_monitor, query_execution_monitor,
         stream_next_monitor, plan_setup_monitor,
@@ -1190,6 +1202,18 @@ pub unsafe extern "C" fn df_stats(out_ptr: *mut u8, out_cap: i64) -> i64 {
         RuntimeMetricsRepr::zeroed()
     };
 
+    // Cache stats (zeroed when no runtime pointer or no cache manager)
+    let cache_stats = if runtime_ptr != 0 {
+        let runtime = &*(runtime_ptr as *const DataFusionRuntime);
+        runtime
+            .custom_cache_manager
+            .as_ref()
+            .map(pack_cache_stats)
+            .unwrap_or_else(CacheStatsRepr::zeroed)
+    } else {
+        CacheStatsRepr::zeroed()
+    };
+
     let buf = DfStatsBuffer {
         io_runtime,
         cpu_runtime,
@@ -1199,6 +1223,8 @@ pub unsafe extern "C" fn df_stats(out_ptr: *mut u8, out_cap: i64) -> i64 {
         plan_setup: pack_task_monitor(plan_setup_monitor()),
         fragment_executor_gate: pack_partition_gate(mgr.cpu_executor.concurrency_gate()),
         reduce_executor_gate: pack_partition_gate(mgr.coordinator_gate()),
+        cache_stats,
+        search_stats: crate::search_stats::snapshot(),
     };
 
     // Copy struct bytes to caller buffer

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/ffm.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/ffm.rs
@@ -1165,7 +1165,7 @@ pub unsafe extern "C" fn df_execute_with_context(
 /// `runtime_ptr` may be `0` to skip cache-stats collection. When non-zero it
 /// must be a valid pointer returned by [`df_create_global_runtime`].
 ///
-/// The buffer must have capacity for at least `size_of::<DfStatsBuffer>()` bytes (544).
+/// The buffer must have capacity for at least `size_of::<DfStatsBuffer>()` bytes (552).
 /// Returns 0 on success.
 #[ffm_safe]
 #[no_mangle]
@@ -1209,9 +1209,9 @@ pub unsafe extern "C" fn df_stats(runtime_ptr: i64, out_ptr: *mut u8, out_cap: i
             .custom_cache_manager
             .as_ref()
             .map(pack_cache_stats)
-            .unwrap_or_else(CacheStatsRepr::zeroed)
+            .unwrap_or_else(CacheStatsRepr::default)
     } else {
-        CacheStatsRepr::zeroed()
+        CacheStatsRepr::default()
     };
 
     let buf = DfStatsBuffer {

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/metrics.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/metrics.rs
@@ -18,6 +18,8 @@ use datafusion::physical_plan::metrics::{
     Count, ExecutionPlanMetricsSet, MetricBuilder, MetricsSet, Time,
 };
 
+use crate::indexed_table::parquet_bridge::ReadIoStats;
+
 /// Lightweight metric handles passed from `IndexedExec` to the streaming loop.
 ///
 /// All fields are `Option` because standalone uses of `IndexedExec` (i.e. not
@@ -117,6 +119,9 @@ pub struct StreamMetrics {
     /// RGs that became prunable only after the filter tightened further between
     /// prefetch (which runs ~1 RG ahead) and processing.
     pub dynamic_filter_rg_pruned_at_poll: Option<Count>,
+    /// Object-store read wall-time accumulator, shared across all RG readers
+    /// within this partition.
+    pub io_stats: Option<Arc<ReadIoStats>>,
     /// Inner `DataSourceExec` parquet metrics for this partition: one
     /// `MetricsSet` per chunk (row-group set) the partition scans.
     pub inner_parquet_metrics: Option<Arc<std::sync::Mutex<Vec<MetricsSet>>>>,
@@ -162,6 +167,7 @@ impl StreamMetrics {
             init_prefetch_time: None,
             dynamic_filter_rg_pruned_at_prefetch: None,
             dynamic_filter_rg_pruned_at_poll: None,
+            io_stats: None,
             inner_parquet_metrics: None,
         }
     }
@@ -299,6 +305,7 @@ impl PartitionMetrics {
             init_prefetch_time: Some(self.init_prefetch_time),
             dynamic_filter_rg_pruned_at_prefetch: Some(self.dynamic_filter_rg_pruned_at_prefetch),
             dynamic_filter_rg_pruned_at_poll: Some(self.dynamic_filter_rg_pruned_at_poll),
+            io_stats: Some(Arc::new(ReadIoStats::default())),
             inner_parquet_metrics,
         }
     }

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/metrics.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/metrics.rs
@@ -100,6 +100,14 @@ pub struct StreamMetrics {
     /// Time spent polling the inner parquet stream (pull decoded
     /// batch), isolating decode from our own processing.
     pub parquet_poll_time: Option<Time>,
+    /// Cumulative wall-clock spent parked between consecutive `poll_next` calls.
+    /// The task returned `Poll::Pending` or was not re-polled immediately;
+    /// accumulated into this metric at the start of each poll.
+    pub inter_poll_gap: Option<Time>,
+    /// Cumulative count of `poll_next` invocations across all chunk streams.
+    pub poll_count: Option<Count>,
+    /// Time spent in the initial `init_prefetch()` call (first poll only).
+    pub init_prefetch_time: Option<Time>,
     /// Count of row groups skipped by the runtime dynamic-filter pruner at the
     /// PREFETCH phase — before the Lucene/FFM eval ran. This saves both the
     /// index eval and the parquet decode. Zero when no dynamic filter was pushed.
@@ -109,7 +117,8 @@ pub struct StreamMetrics {
     /// RGs that became prunable only after the filter tightened further between
     /// prefetch (which runs ~1 RG ahead) and processing.
     pub dynamic_filter_rg_pruned_at_poll: Option<Count>,
-    /// Accumulated inner `DataSourceExec` parquet metrics (shared across partitions).
+    /// Inner `DataSourceExec` parquet metrics for this partition: one
+    /// `MetricsSet` per chunk (row-group set) the partition scans.
     pub inner_parquet_metrics: Option<Arc<std::sync::Mutex<Vec<MetricsSet>>>>,
 }
 
@@ -148,6 +157,9 @@ impl StreamMetrics {
             mask_slice_time: None,
             projection_fixup_time: None,
             parquet_poll_time: None,
+            inter_poll_gap: None,
+            poll_count: None,
+            init_prefetch_time: None,
             dynamic_filter_rg_pruned_at_prefetch: None,
             dynamic_filter_rg_pruned_at_poll: None,
             inner_parquet_metrics: None,
@@ -188,6 +200,9 @@ pub struct PartitionMetrics {
     pub mask_slice_time: Time,
     pub projection_fixup_time: Time,
     pub parquet_poll_time: Time,
+    pub inter_poll_gap: Time,
+    pub poll_count: Count,
+    pub init_prefetch_time: Time,
     pub dynamic_filter_rg_pruned_at_prefetch: Count,
     pub dynamic_filter_rg_pruned_at_poll: Count,
 }
@@ -232,6 +247,11 @@ impl PartitionMetrics {
                 .subset_time("projection_fixup_time", partition),
             parquet_poll_time: MetricBuilder::new(metrics)
                 .subset_time("parquet_poll_time", partition),
+            inter_poll_gap: MetricBuilder::new(metrics)
+                .subset_time("inter_poll_gap", partition),
+            poll_count: counter("poll_count"),
+            init_prefetch_time: MetricBuilder::new(metrics)
+                .subset_time("init_prefetch_time", partition),
             dynamic_filter_rg_pruned_at_prefetch: counter("dynamic_filter_rg_pruned_at_prefetch"),
             dynamic_filter_rg_pruned_at_poll: counter("dynamic_filter_rg_pruned_at_poll"),
         }
@@ -274,6 +294,9 @@ impl PartitionMetrics {
             mask_slice_time: Some(self.mask_slice_time),
             projection_fixup_time: Some(self.projection_fixup_time),
             parquet_poll_time: Some(self.parquet_poll_time),
+            inter_poll_gap: Some(self.inter_poll_gap),
+            poll_count: Some(self.poll_count),
+            init_prefetch_time: Some(self.init_prefetch_time),
             dynamic_filter_rg_pruned_at_prefetch: Some(self.dynamic_filter_rg_pruned_at_prefetch),
             dynamic_filter_rg_pruned_at_poll: Some(self.dynamic_filter_rg_pruned_at_poll),
             inner_parquet_metrics,

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/parquet_bridge.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/parquet_bridge.rs
@@ -20,6 +20,7 @@
 
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::common::Result;
@@ -80,7 +81,7 @@ pub struct ReadIoStats {
     pub count: AtomicU64,
 }
 
-fn record_io(stats: &ReadIoStats, dur: std::time::Duration) {
+fn record_io(stats: &ReadIoStats, dur: Duration) {
     let ns = dur.as_nanos() as u64;
     stats.total_ns.fetch_add(ns, Ordering::Relaxed);
     stats.count.fetch_add(1, Ordering::Relaxed);
@@ -158,7 +159,7 @@ fn create_stream_with_access_plan(
     let partitioned_file = PartitionedFile::new(config.file_path.clone(), config.file_size)
         .with_extensions(Arc::new(access_plan));
 
-    let reader_factory = Arc::new(CachedMetadataReaderFactory::with_io_stats(
+    let reader_factory = Arc::new(CachedMetadataReaderFactory::new(
         Arc::clone(&config.store),
         Arc::clone(&config.metadata),
         Arc::clone(&config.io_stats),
@@ -207,11 +208,7 @@ pub struct CachedMetadataReaderFactory {
 }
 
 impl CachedMetadataReaderFactory {
-    pub fn new(store: Arc<dyn ObjectStore>, metadata: Arc<ParquetMetaData>) -> Self {
-        Self::with_io_stats(store, metadata, Arc::new(ReadIoStats::default()))
-    }
-
-    pub fn with_io_stats(
+    pub fn new(
         store: Arc<dyn ObjectStore>,
         metadata: Arc<ParquetMetaData>,
         io_stats: Arc<ReadIoStats>,
@@ -260,7 +257,7 @@ impl AsyncFileReader for CachedMetadataReader {
         let location = self.location.clone();
         let io_stats = Arc::clone(&self.io_stats);
         async move {
-            let t0 = std::time::Instant::now();
+            let t0 = Instant::now();
             let r = store
                 .get_range(&location, range)
                 .await
@@ -281,7 +278,7 @@ impl AsyncFileReader for CachedMetadataReader {
         let location = self.location.clone();
         let io_stats = Arc::clone(&self.io_stats);
         async move {
-            let t0 = std::time::Instant::now();
+            let t0 = Instant::now();
             let r = store
                 .get_ranges(&location, &ranges)
                 .await

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/parquet_bridge.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/parquet_bridge.rs
@@ -18,6 +18,7 @@
 //! design and it was reworked here so the indexed path respects the same store
 //! the vanilla path uses (file://, s3://, etc.).
 
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
 use datafusion::arrow::datatypes::SchemaRef;
@@ -72,6 +73,19 @@ pub async fn load_parquet_metadata(
     Ok((Arc::new(schema), size, pq_meta))
 }
 
+/// Shared accumulator for object-store read wall-time.
+#[derive(Debug, Default)]
+pub struct ReadIoStats {
+    pub total_ns: AtomicU64,
+    pub count: AtomicU64,
+}
+
+fn record_io(stats: &ReadIoStats, dur: std::time::Duration) {
+    let ns = dur.as_nanos() as u64;
+    stats.total_ns.fetch_add(ns, Ordering::Relaxed);
+    stats.count.fetch_add(1, Ordering::Relaxed);
+}
+
 /// Configuration for creating a per-row-group parquet stream.
 pub struct RowGroupStreamConfig {
     /// Object-store-relative path to the parquet file.
@@ -85,6 +99,7 @@ pub struct RowGroupStreamConfig {
     pub metadata: Arc<ParquetMetaData>,
     pub projection: Option<Vec<usize>>,
     pub predicate: Option<Arc<dyn datafusion::physical_expr::PhysicalExpr>>,
+    pub io_stats: Arc<ReadIoStats>,
 }
 
 /// Create a stream that reads a single row group using `RowSelection`.
@@ -143,9 +158,10 @@ fn create_stream_with_access_plan(
     let partitioned_file = PartitionedFile::new(config.file_path.clone(), config.file_size)
         .with_extensions(Arc::new(access_plan));
 
-    let reader_factory = Arc::new(CachedMetadataReaderFactory::new(
+    let reader_factory = Arc::new(CachedMetadataReaderFactory::with_io_stats(
         Arc::clone(&config.store),
         Arc::clone(&config.metadata),
+        Arc::clone(&config.io_stats),
     )) as Arc<dyn ParquetFileReaderFactory>;
 
     let mut parquet_source = ParquetSource::new(config.full_schema.clone())
@@ -187,11 +203,20 @@ fn create_stream_with_access_plan(
 pub struct CachedMetadataReaderFactory {
     store: Arc<dyn ObjectStore>,
     metadata: Arc<ParquetMetaData>,
+    io_stats: Arc<ReadIoStats>,
 }
 
 impl CachedMetadataReaderFactory {
     pub fn new(store: Arc<dyn ObjectStore>, metadata: Arc<ParquetMetaData>) -> Self {
-        Self { store, metadata }
+        Self::with_io_stats(store, metadata, Arc::new(ReadIoStats::default()))
+    }
+
+    pub fn with_io_stats(
+        store: Arc<dyn ObjectStore>,
+        metadata: Arc<ParquetMetaData>,
+        io_stats: Arc<ReadIoStats>,
+    ) -> Self {
+        Self { store, metadata, io_stats }
     }
 }
 
@@ -210,6 +235,7 @@ impl ParquetFileReaderFactory for CachedMetadataReaderFactory {
             location: file.object_meta.location.clone(),
             metadata: Arc::clone(&self.metadata),
             metrics: file_metrics,
+            io_stats: Arc::clone(&self.io_stats),
         }))
     }
 }
@@ -219,6 +245,7 @@ struct CachedMetadataReader {
     location: object_store::path::Path,
     metadata: Arc<ParquetMetaData>,
     metrics: ParquetFileMetrics,
+    io_stats: Arc<ReadIoStats>,
 }
 
 impl AsyncFileReader for CachedMetadataReader {
@@ -231,11 +258,15 @@ impl AsyncFileReader for CachedMetadataReader {
             .add((range.end - range.start) as usize);
         let store = Arc::clone(&self.store);
         let location = self.location.clone();
+        let io_stats = Arc::clone(&self.io_stats);
         async move {
-            store
+            let t0 = std::time::Instant::now();
+            let r = store
                 .get_range(&location, range)
                 .await
-                .map_err(|e| datafusion::parquet::errors::ParquetError::External(Box::new(e)))
+                .map_err(|e| datafusion::parquet::errors::ParquetError::External(Box::new(e)));
+            record_io(&io_stats, t0.elapsed());
+            r
         }
         .boxed()
     }
@@ -248,11 +279,15 @@ impl AsyncFileReader for CachedMetadataReader {
         self.metrics.bytes_scanned.add(total as usize);
         let store = Arc::clone(&self.store);
         let location = self.location.clone();
+        let io_stats = Arc::clone(&self.io_stats);
         async move {
-            store
+            let t0 = std::time::Instant::now();
+            let r = store
                 .get_ranges(&location, &ranges)
                 .await
-                .map_err(|e| datafusion::parquet::errors::ParquetError::External(Box::new(e)))
+                .map_err(|e| datafusion::parquet::errors::ParquetError::External(Box::new(e)));
+            record_io(&io_stats, t0.elapsed());
+            r
         }
         .boxed()
     }

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/stream.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/stream.rs
@@ -808,11 +808,11 @@ impl Stream for IndexedStream {
 
         let result = self.as_mut().poll_inner(cx);
 
-        let now = Instant::now();
+        let t0 = Instant::now();
         if let Some(ref t) = self.metrics.elapsed_compute {
-            t.add_duration(now.saturating_duration_since(poll_start));
+            t.add_duration(t0.saturating_duration_since(poll_start));
         }
-        self.last_poll_end = Some(now);
+        self.last_poll_end = Some(t0);
         result
     }
 }

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/stream.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/stream.rs
@@ -483,8 +483,8 @@ struct IndexedStream {
     mask_offset: usize,
     batch_offset: usize,
     finished: bool,
-    /// Wall-clock start time for per-segment timing. Set on first poll.
     stream_start: Option<std::time::Instant>,
+    last_poll_end: Option<Instant>,
     metadata: Arc<ParquetMetaData>,
     predicate: Option<Arc<dyn datafusion::physical_expr::PhysicalExpr>>,
     initialized: bool,
@@ -579,6 +579,7 @@ impl IndexedStream {
             batch_offset: 0,
             finished: false,
             stream_start: None,
+            last_poll_end: None,
             metadata,
             predicate,
             initialized: false,
@@ -780,17 +781,33 @@ impl Stream for IndexedStream {
         // time downstream work.
         let poll_start = Instant::now();
 
+        if let Some(prev_end) = self.last_poll_end {
+            let gap = poll_start.saturating_duration_since(prev_end);
+            if let Some(ref t) = self.metrics.inter_poll_gap {
+                t.add_duration(gap);
+            }
+        }
+        if let Some(ref c) = self.metrics.poll_count {
+            c.add(1);
+        }
+
         if !self.initialized {
             self.stream_start = Some(Instant::now());
+            let t0 = Instant::now();
             self.index_reader.init_prefetch();
+            if let Some(ref t) = self.metrics.init_prefetch_time {
+                t.add_duration(t0.elapsed());
+            }
             self.initialized = true;
         }
 
         let result = self.as_mut().poll_inner(cx);
 
+        let now = Instant::now();
         if let Some(ref t) = self.metrics.elapsed_compute {
-            t.add_duration(poll_start.elapsed());
+            t.add_duration(now.saturating_duration_since(poll_start));
         }
+        self.last_poll_end = Some(now);
         result
     }
 }

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/stream.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/stream.rs
@@ -610,6 +610,11 @@ impl IndexedStream {
             metadata: Arc::clone(&self.metadata),
             projection: self.projection.clone(),
             predicate: self.predicate.clone(),
+            io_stats: self
+                .metrics
+                .io_stats
+                .clone()
+                .unwrap_or_else(|| Arc::new(super::parquet_bridge::ReadIoStats::default())),
         }
     }
 

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/table_provider.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/table_provider.rs
@@ -54,6 +54,12 @@ use crate::datafusion_query_config::DatafusionQueryConfig;
 use crate::indexed_table::metrics::StreamMetrics;
 use crate::indexed_table::page_pruner::StatsPruneTree;
 use std::collections::HashSet;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::physical_plan::RecordBatchStream;
+use futures::Stream;
 
 /// Info about a segment and its corresponding parquet file.
 #[derive(Debug, Clone)]
@@ -467,8 +473,10 @@ impl ExecutionPlan for QueryShardExec {
         })?;
 
         let pmetrics = PartitionMetrics::new(&self.metrics, partition);
+        let partition_inner_parquet_metrics = Arc::new(std::sync::Mutex::new(Vec::new()));
         let stream_metrics =
-            pmetrics.into_stream_metrics(Some(Arc::clone(&self.inner_parquet_metrics)));
+            pmetrics.into_stream_metrics(Some(Arc::clone(&partition_inner_parquet_metrics)));
+        let stream_metrics_for_drop = stream_metrics.clone();
 
         // Conjoin any accepted runtime dynamic filters into one predicate,
         // shared (by Arc) across every chunk's IndexedExec. The inner
@@ -556,18 +564,58 @@ impl ExecutionPlan for QueryShardExec {
             streams.push(exec.execute(0, Arc::clone(&context))?);
         }
 
-        match streams.len() {
+        // Chain the per-chunk streams into one stream for this partition,
+        // then wrap so the Drop impl flushes search_stats for this query.
+        let inner: SendableRecordBatchStream = match streams.len() {
             0 => {
                 let empty = datafusion::physical_plan::empty::EmptyExec::new(
                     self.projected_schema.clone(),
                 );
-                empty.execute(0, context)
+                empty.execute(0, context)?
             }
-            1 => Ok(streams.into_iter().next().unwrap()),
+            1 => streams.into_iter().next().unwrap(),
             _ => {
                 let schema = self.projected_schema.clone();
                 let chained = futures::stream::iter(streams).flatten();
-                Ok(Box::pin(RecordBatchStreamAdapter::new(schema, chained)))
+                Box::pin(RecordBatchStreamAdapter::new(schema, chained))
+            }
+        };
+        Ok(Box::pin(AccumulatingStream {
+            inner,
+            stream_metrics: stream_metrics_for_drop,
+            shared_inner_parquet_metrics: Arc::clone(&self.inner_parquet_metrics),
+        }))
+    }
+}
+
+struct AccumulatingStream {
+    inner: SendableRecordBatchStream,
+    stream_metrics: StreamMetrics,
+    shared_inner_parquet_metrics: Arc<std::sync::Mutex<Vec<MetricsSet>>>,
+}
+
+impl Stream for AccumulatingStream {
+    type Item = Result<RecordBatch>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        Pin::new(&mut self.inner).poll_next(cx)
+    }
+}
+
+impl RecordBatchStream for AccumulatingStream {
+    fn schema(&self) -> SchemaRef {
+        self.inner.schema()
+    }
+}
+
+impl Drop for AccumulatingStream {
+    fn drop(&mut self) {
+        crate::search_stats::accumulate(&self.stream_metrics);
+        if let Some(ref per) = self.stream_metrics.inner_parquet_metrics {
+            if let (Ok(mut src), Ok(mut dst)) =
+                (per.lock(), self.shared_inner_parquet_metrics.lock())
+            {
+                dst.append(&mut src);
             }
         }
     }

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/table_provider.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/table_provider.rs
@@ -48,18 +48,14 @@ use futures::StreamExt;
 use super::bool_tree::BoolNode;
 use super::eval::RowGroupBitsetSource;
 use super::metrics::PartitionMetrics;
+use super::parquet_bridge::ReadIoStats;
 use super::partitioning::{compute_assignments, PartitionAssignment, SegmentChunk, SegmentLayout};
-use super::stream::{FilterStrategy, IndexedExec, RowGroupInfo};
+use super::stream::{IndexedExec, RowGroupInfo};
 use crate::datafusion_query_config::DatafusionQueryConfig;
 use crate::indexed_table::metrics::StreamMetrics;
 use crate::indexed_table::page_pruner::StatsPruneTree;
+use crate::search_stats::accumulate_from_exec;
 use std::collections::HashSet;
-use std::pin::Pin;
-use std::task::{Context, Poll};
-
-use datafusion::arrow::record_batch::RecordBatch;
-use datafusion::physical_plan::RecordBatchStream;
-use futures::Stream;
 
 /// Info about a segment and its corresponding parquet file.
 #[derive(Debug, Clone)]
@@ -309,6 +305,7 @@ impl TableProvider for IndexedTableProvider {
             predicate,
             metrics: ExecutionPlanMetricsSet::new(),
             inner_parquet_metrics: Arc::new(std::sync::Mutex::new(Vec::new())),
+            io_stats: Arc::new(ReadIoStats::default()),
             row_id_output_index,
             dynamic_filters: Vec::new(),
         }))
@@ -336,6 +333,7 @@ pub struct QueryShardExec {
     predicate: Option<Arc<dyn datafusion::physical_expr::PhysicalExpr>>,
     metrics: ExecutionPlanMetricsSet,
     inner_parquet_metrics: Arc<std::sync::Mutex<Vec<MetricsSet>>>,
+    io_stats: Arc<ReadIoStats>,
     /// Column index in the OUTPUT schema where computed `___row_id` should be
     /// injected. `None` means no row ID computation (normal data path).
     row_id_output_index: Option<usize>,
@@ -473,25 +471,14 @@ impl ExecutionPlan for QueryShardExec {
         })?;
 
         let pmetrics = PartitionMetrics::new(&self.metrics, partition);
-        let partition_inner_parquet_metrics = Arc::new(std::sync::Mutex::new(Vec::new()));
-        let stream_metrics =
-            pmetrics.into_stream_metrics(Some(Arc::clone(&partition_inner_parquet_metrics)));
-        let stream_metrics_for_drop = stream_metrics.clone();
+        let mut stream_metrics =
+            pmetrics.into_stream_metrics(Some(Arc::clone(&self.inner_parquet_metrics)));
+        stream_metrics.io_stats = Some(Arc::clone(&self.io_stats));
 
-        // Conjoin any accepted runtime dynamic filters into one predicate,
-        // shared (by Arc) across every chunk's IndexedExec. The inner
-        // DynamicFilterPhysicalExpr state is shared with the producing TopK, so
-        // all streams observe the same runtime tightening.
         let dynamic_filter: Option<Arc<dyn datafusion::physical_expr::PhysicalExpr>> =
             (!self.dynamic_filters.is_empty())
                 .then(|| datafusion::physical_expr::utils::conjunction(self.dynamic_filters.clone()));
 
-        // Build one IndexedExec per SegmentChunk and execute it immediately,
-        // collecting per-chunk streams. We then chain them sequentially into
-        // a single stream for this partition. This avoids the
-        // UnionExec + CoalescePartitionsExec wrapping (which would re-shape
-        // partitioning and add an extra coalesce hop) — chunks here are
-        // already serialized within one partition assignment.
         let mut streams: Vec<SendableRecordBatchStream> =
             Vec::with_capacity(assignment.chunks.len());
         for chunk in &assignment.chunks {
@@ -499,7 +486,6 @@ impl ExecutionPlan for QueryShardExec {
                 DataFusionError::Internal(format!("segment_idx {} out of range", chunk.segment_idx))
             })?;
 
-            // Subset the segment's row groups to just this chunk's.
             let rg_set: HashSet<usize> = chunk.row_group_indices.iter().copied().collect();
             let row_groups: Vec<RowGroupInfo> = segment
                 .row_groups
@@ -528,7 +514,6 @@ impl ExecutionPlan for QueryShardExec {
                 }
             }
 
-            // Build evaluator for this chunk.
             let evaluator = (self.config.evaluator_factory)(segment, chunk, &stream_metrics, stats_prune_tree.as_ref())
                 .map_err(|e| DataFusionError::External(e.into()))?;
 
@@ -564,9 +549,7 @@ impl ExecutionPlan for QueryShardExec {
             streams.push(exec.execute(0, Arc::clone(&context))?);
         }
 
-        // Chain the per-chunk streams into one stream for this partition,
-        // then wrap so the Drop impl flushes search_stats for this query.
-        let inner: SendableRecordBatchStream = match streams.len() {
+        let stream: SendableRecordBatchStream = match streams.len() {
             0 => {
                 let empty = datafusion::physical_plan::empty::EmptyExec::new(
                     self.projected_schema.clone(),
@@ -580,44 +563,17 @@ impl ExecutionPlan for QueryShardExec {
                 Box::pin(RecordBatchStreamAdapter::new(schema, chained))
             }
         };
-        Ok(Box::pin(AccumulatingStream {
-            inner,
-            stream_metrics: stream_metrics_for_drop,
-            shared_inner_parquet_metrics: Arc::clone(&self.inner_parquet_metrics),
-        }))
+        Ok(stream)
     }
 }
 
-struct AccumulatingStream {
-    inner: SendableRecordBatchStream,
-    stream_metrics: StreamMetrics,
-    shared_inner_parquet_metrics: Arc<std::sync::Mutex<Vec<MetricsSet>>>,
-}
-
-impl Stream for AccumulatingStream {
-    type Item = Result<RecordBatch>;
-
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        Pin::new(&mut self.inner).poll_next(cx)
-    }
-}
-
-impl RecordBatchStream for AccumulatingStream {
-    fn schema(&self) -> SchemaRef {
-        self.inner.schema()
-    }
-}
-
-impl Drop for AccumulatingStream {
+impl Drop for QueryShardExec {
     fn drop(&mut self) {
-        crate::search_stats::accumulate(&self.stream_metrics);
-        if let Some(ref per) = self.stream_metrics.inner_parquet_metrics {
-            if let (Ok(mut src), Ok(mut dst)) =
-                (per.lock(), self.shared_inner_parquet_metrics.lock())
-            {
-                dst.append(&mut src);
-            }
-        }
+        accumulate_from_exec(
+            &self.metrics,
+            &self.inner_parquet_metrics,
+            &self.io_stats,
+        );
     }
 }
 
@@ -671,6 +627,7 @@ impl QueryShardExec {
             predicate: self.predicate.clone(),
             metrics: ExecutionPlanMetricsSet::new(),
             inner_parquet_metrics: Arc::clone(&self.inner_parquet_metrics),
+            io_stats: Arc::clone(&self.io_stats),
             row_id_output_index: self.row_id_output_index,
             dynamic_filters,
         }

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/lib.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/lib.rs
@@ -55,5 +55,6 @@ pub mod udaf;
 pub mod udf;
 pub mod udwf;
 pub mod native_node_stats;
+pub mod search_stats;
 pub mod stats;
 pub mod task_monitors;

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/search_stats.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/search_stats.rs
@@ -1,0 +1,175 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+//! Cumulative search execution counters exposed via `df_stats()`.
+
+use std::sync::atomic::{AtomicI64, Ordering};
+
+use datafusion::physical_plan::metrics::MetricsSet;
+
+use crate::indexed_table::metrics::StreamMetrics;
+use crate::stats::SearchStatsRepr;
+
+static LISTING_TABLE_SCAN: AtomicI64 = AtomicI64::new(0);
+static SINGLE_COLLECTOR_SCAN: AtomicI64 = AtomicI64::new(0);
+static BITMAP_TREE_SCAN: AtomicI64 = AtomicI64::new(0);
+static DELEGATION_CALLS: AtomicI64 = AtomicI64::new(0);
+static RG_PROCESSED: AtomicI64 = AtomicI64::new(0);
+static RG_SKIPPED: AtomicI64 = AtomicI64::new(0);
+static PARQUET_SCAN_TOTAL_TIME_MS: AtomicI64 = AtomicI64::new(0);
+static PARQUET_SCAN_UNTIL_DATA_TIME_MS: AtomicI64 = AtomicI64::new(0);
+static PARQUET_PROCESSING_TIME_MS: AtomicI64 = AtomicI64::new(0);
+static PREFETCH_WAIT_TIME_MS: AtomicI64 = AtomicI64::new(0);
+static PREFETCH_WAIT_COUNT: AtomicI64 = AtomicI64::new(0);
+static ELAPSED_COMPUTE_MS: AtomicI64 = AtomicI64::new(0);
+static BUILD_MASK_TIME_MS: AtomicI64 = AtomicI64::new(0);
+static ON_BATCH_MASK_TIME_MS: AtomicI64 = AtomicI64::new(0);
+static FILTER_RECORD_BATCH_TIME_MS: AtomicI64 = AtomicI64::new(0);
+
+pub fn inc_listing_table_scan() {
+    LISTING_TABLE_SCAN.fetch_add(1, Ordering::Relaxed);
+}
+
+pub fn inc_single_collector_scan() {
+    SINGLE_COLLECTOR_SCAN.fetch_add(1, Ordering::Relaxed);
+}
+
+pub fn inc_bitmap_tree_scan() {
+    BITMAP_TREE_SCAN.fetch_add(1, Ordering::Relaxed);
+}
+
+pub fn sum_inner_metric_ns(sets: &[MetricsSet], name: &str) -> u64 {
+    let mut total = 0u64;
+    for set in sets {
+        let mut best = 0usize;
+        for metric in set.iter() {
+            if metric.value().name() == name {
+                best = best.max(metric.value().as_usize());
+            }
+        }
+        total += best as u64;
+    }
+    total
+}
+
+pub fn accumulate(m: &StreamMetrics) {
+    if let Some(ref c) = m.ffm_collector_calls {
+        DELEGATION_CALLS.fetch_add(c.value() as i64, Ordering::Relaxed);
+    }
+    if let Some(ref c) = m.rg_processed {
+        RG_PROCESSED.fetch_add(c.value() as i64, Ordering::Relaxed);
+    }
+    if let Some(ref c) = m.rg_skipped {
+        RG_SKIPPED.fetch_add(c.value() as i64, Ordering::Relaxed);
+    }
+    if let Some(ref acc) = m.inner_parquet_metrics {
+        if let Ok(sets) = acc.lock() {
+            PARQUET_SCAN_TOTAL_TIME_MS.fetch_add(
+                (sum_inner_metric_ns(&sets, "time_elapsed_scanning_total") / 1_000_000) as i64,
+                Ordering::Relaxed,
+            );
+            PARQUET_SCAN_UNTIL_DATA_TIME_MS.fetch_add(
+                (sum_inner_metric_ns(&sets, "time_elapsed_scanning_until_data") / 1_000_000) as i64,
+                Ordering::Relaxed,
+            );
+            PARQUET_PROCESSING_TIME_MS.fetch_add(
+                (sum_inner_metric_ns(&sets, "time_elapsed_processing") / 1_000_000) as i64,
+                Ordering::Relaxed,
+            );
+        }
+    }
+    if let Some(ref t) = m.prefetch_wait_time {
+        PREFETCH_WAIT_TIME_MS.fetch_add((t.value() / 1_000_000) as i64, Ordering::Relaxed);
+    }
+    if let Some(ref c) = m.prefetch_wait_count {
+        PREFETCH_WAIT_COUNT.fetch_add(c.value() as i64, Ordering::Relaxed);
+    }
+    if let Some(ref t) = m.elapsed_compute {
+        ELAPSED_COMPUTE_MS.fetch_add((t.value() / 1_000_000) as i64, Ordering::Relaxed);
+    }
+    if let Some(ref t) = m.build_mask_time {
+        BUILD_MASK_TIME_MS.fetch_add((t.value() / 1_000_000) as i64, Ordering::Relaxed);
+    }
+    if let Some(ref t) = m.on_batch_mask_time {
+        ON_BATCH_MASK_TIME_MS.fetch_add((t.value() / 1_000_000) as i64, Ordering::Relaxed);
+    }
+    if let Some(ref t) = m.filter_record_batch_time {
+        FILTER_RECORD_BATCH_TIME_MS.fetch_add((t.value() / 1_000_000) as i64, Ordering::Relaxed);
+    }
+}
+
+pub fn snapshot() -> SearchStatsRepr {
+    SearchStatsRepr {
+        listing_table_scan: LISTING_TABLE_SCAN.load(Ordering::Relaxed),
+        single_collector_scan: SINGLE_COLLECTOR_SCAN.load(Ordering::Relaxed),
+        bitmap_tree_scan: BITMAP_TREE_SCAN.load(Ordering::Relaxed),
+        delegation_calls: DELEGATION_CALLS.load(Ordering::Relaxed),
+        rg_processed: RG_PROCESSED.load(Ordering::Relaxed),
+        rg_skipped: RG_SKIPPED.load(Ordering::Relaxed),
+        parquet_scan_total_time_ms: PARQUET_SCAN_TOTAL_TIME_MS.load(Ordering::Relaxed),
+        parquet_scan_until_data_time_ms: PARQUET_SCAN_UNTIL_DATA_TIME_MS.load(Ordering::Relaxed),
+        parquet_processing_time_ms: PARQUET_PROCESSING_TIME_MS.load(Ordering::Relaxed),
+        prefetch_wait_time_ms: PREFETCH_WAIT_TIME_MS.load(Ordering::Relaxed),
+        prefetch_wait_count: PREFETCH_WAIT_COUNT.load(Ordering::Relaxed),
+        elapsed_compute_ms: ELAPSED_COMPUTE_MS.load(Ordering::Relaxed),
+        build_mask_time_ms: BUILD_MASK_TIME_MS.load(Ordering::Relaxed),
+        on_batch_mask_time_ms: ON_BATCH_MASK_TIME_MS.load(Ordering::Relaxed),
+        filter_record_batch_time_ms: FILTER_RECORD_BATCH_TIME_MS.load(Ordering::Relaxed),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::indexed_table::metrics::PartitionMetrics;
+    use datafusion::physical_plan::metrics::ExecutionPlanMetricsSet;
+
+    #[test]
+    fn path_counters_increment() {
+        let before = snapshot();
+        inc_listing_table_scan();
+        inc_single_collector_scan();
+        inc_single_collector_scan();
+        inc_bitmap_tree_scan();
+        let after = snapshot();
+        assert_eq!(after.listing_table_scan - before.listing_table_scan, 1);
+        assert_eq!(after.single_collector_scan - before.single_collector_scan, 2);
+        assert_eq!(after.bitmap_tree_scan - before.bitmap_tree_scan, 1);
+    }
+
+    #[test]
+    fn accumulate_folds_partition_metrics() {
+        let before = snapshot();
+        let metrics_set = ExecutionPlanMetricsSet::new();
+        let pm = PartitionMetrics::new(&metrics_set, 0);
+
+        pm.elapsed_compute.add_duration(std::time::Duration::from_millis(50));
+        pm.ffm_collector_calls.add(3);
+        pm.row_groups_processed.add(2);
+        pm.row_groups_skipped.add(1);
+        pm.prefetch_wait_time.add_duration(std::time::Duration::from_millis(10));
+        pm.prefetch_wait_count.add(2);
+
+        accumulate(&pm.into_stream_metrics(None));
+        let after = snapshot();
+
+        assert_eq!(after.delegation_calls - before.delegation_calls, 3);
+        assert_eq!(after.rg_processed - before.rg_processed, 2);
+        assert_eq!(after.rg_skipped - before.rg_skipped, 1);
+        assert!(after.prefetch_wait_time_ms - before.prefetch_wait_time_ms >= 10);
+        assert_eq!(after.prefetch_wait_count - before.prefetch_wait_count, 2);
+    }
+
+    #[test]
+    fn empty_stream_metrics_is_safe() {
+        let before = snapshot();
+        accumulate(&StreamMetrics::empty());
+        let after = snapshot();
+        assert_eq!(after.delegation_calls, before.delegation_calls);
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/search_stats.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/search_stats.rs
@@ -9,10 +9,12 @@
 //! Cumulative search execution counters exposed via `df_stats()`.
 
 use std::sync::atomic::{AtomicI64, Ordering};
+use std::sync::{Arc, Mutex};
 
-use datafusion::physical_plan::metrics::MetricsSet;
+use datafusion::physical_plan::metrics::{ExecutionPlanMetricsSet, MetricsSet};
 
 use crate::indexed_table::metrics::StreamMetrics;
+use crate::indexed_table::parquet_bridge::ReadIoStats;
 use crate::stats::SearchStatsRepr;
 
 static LISTING_TABLE_SCAN: AtomicI64 = AtomicI64::new(0);
@@ -24,6 +26,7 @@ static RG_SKIPPED: AtomicI64 = AtomicI64::new(0);
 static PARQUET_SCAN_TOTAL_TIME_MS: AtomicI64 = AtomicI64::new(0);
 static PARQUET_SCAN_UNTIL_DATA_TIME_MS: AtomicI64 = AtomicI64::new(0);
 static PARQUET_PROCESSING_TIME_MS: AtomicI64 = AtomicI64::new(0);
+static PARQUET_BYTES_SCANNED: AtomicI64 = AtomicI64::new(0);
 static PREFETCH_WAIT_TIME_MS: AtomicI64 = AtomicI64::new(0);
 static PREFETCH_WAIT_COUNT: AtomicI64 = AtomicI64::new(0);
 static ELAPSED_COMPUTE_MS: AtomicI64 = AtomicI64::new(0);
@@ -82,6 +85,10 @@ pub fn accumulate(m: &StreamMetrics) {
                 (sum_inner_metric_ns(&sets, "time_elapsed_processing") / 1_000_000) as i64,
                 Ordering::Relaxed,
             );
+            PARQUET_BYTES_SCANNED.fetch_add(
+                sum_inner_metric_ns(&sets, "bytes_scanned") as i64,
+                Ordering::Relaxed,
+            );
         }
     }
     if let Some(ref t) = m.prefetch_wait_time {
@@ -110,6 +117,64 @@ pub fn accumulate(m: &StreamMetrics) {
     }
 }
 
+/// Accumulate from a `QueryShardExec`'s aggregated metrics at query completion.
+pub fn accumulate_from_exec(
+    metrics: &ExecutionPlanMetricsSet,
+    inner_parquet_metrics: &Arc<Mutex<Vec<MetricsSet>>>,
+    io_stats: &ReadIoStats,
+) {
+    let aggregated = metrics.clone_inner().aggregate_by_name();
+
+    let count = |name: &str| -> i64 {
+        aggregated
+            .iter()
+            .find(|m| m.value().name() == name)
+            .map(|m| m.value().as_usize() as i64)
+            .unwrap_or(0)
+    };
+    let time_ms = |name: &str| -> i64 {
+        aggregated
+            .iter()
+            .find(|m| m.value().name() == name)
+            .map(|m| (m.value().as_usize() / 1_000_000) as i64)
+            .unwrap_or(0)
+    };
+
+    DELEGATION_CALLS.fetch_add(count("ffm_collector_calls"), Ordering::Relaxed);
+    RG_PROCESSED.fetch_add(count("row_groups_processed"), Ordering::Relaxed);
+    RG_SKIPPED.fetch_add(count("row_groups_skipped"), Ordering::Relaxed);
+    PREFETCH_WAIT_TIME_MS.fetch_add(time_ms("prefetch_wait_time"), Ordering::Relaxed);
+    PREFETCH_WAIT_COUNT.fetch_add(count("prefetch_wait_count"), Ordering::Relaxed);
+    ELAPSED_COMPUTE_MS.fetch_add(time_ms("elapsed_compute"), Ordering::Relaxed);
+    BUILD_MASK_TIME_MS.fetch_add(time_ms("build_mask_time"), Ordering::Relaxed);
+    ON_BATCH_MASK_TIME_MS.fetch_add(time_ms("on_batch_mask_time"), Ordering::Relaxed);
+    FILTER_RECORD_BATCH_TIME_MS.fetch_add(time_ms("filter_record_batch_time"), Ordering::Relaxed);
+
+    if let Ok(sets) = inner_parquet_metrics.lock() {
+        PARQUET_SCAN_TOTAL_TIME_MS.fetch_add(
+            (sum_inner_metric_ns(&sets, "time_elapsed_scanning_total") / 1_000_000) as i64,
+            Ordering::Relaxed,
+        );
+        PARQUET_SCAN_UNTIL_DATA_TIME_MS.fetch_add(
+            (sum_inner_metric_ns(&sets, "time_elapsed_scanning_until_data") / 1_000_000) as i64,
+            Ordering::Relaxed,
+        );
+        PARQUET_PROCESSING_TIME_MS.fetch_add(
+            (sum_inner_metric_ns(&sets, "time_elapsed_processing") / 1_000_000) as i64,
+            Ordering::Relaxed,
+        );
+        PARQUET_BYTES_SCANNED.fetch_add(
+            sum_inner_metric_ns(&sets, "bytes_scanned") as i64,
+            Ordering::Relaxed,
+        );
+    }
+
+    OBJECT_STORE_READ_TIME_MS.fetch_add(
+        (io_stats.total_ns.load(Ordering::Relaxed) / 1_000_000) as i64,
+        Ordering::Relaxed,
+    );
+}
+
 pub fn snapshot() -> SearchStatsRepr {
     SearchStatsRepr {
         listing_table_scan: LISTING_TABLE_SCAN.load(Ordering::Relaxed),
@@ -121,6 +186,7 @@ pub fn snapshot() -> SearchStatsRepr {
         parquet_scan_total_time_ms: PARQUET_SCAN_TOTAL_TIME_MS.load(Ordering::Relaxed),
         parquet_scan_until_data_time_ms: PARQUET_SCAN_UNTIL_DATA_TIME_MS.load(Ordering::Relaxed),
         parquet_processing_time_ms: PARQUET_PROCESSING_TIME_MS.load(Ordering::Relaxed),
+        parquet_bytes_scanned: PARQUET_BYTES_SCANNED.load(Ordering::Relaxed),
         prefetch_wait_time_ms: PREFETCH_WAIT_TIME_MS.load(Ordering::Relaxed),
         prefetch_wait_count: PREFETCH_WAIT_COUNT.load(Ordering::Relaxed),
         elapsed_compute_ms: ELAPSED_COMPUTE_MS.load(Ordering::Relaxed),

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/search_stats.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/search_stats.rs
@@ -30,6 +30,7 @@ static ELAPSED_COMPUTE_MS: AtomicI64 = AtomicI64::new(0);
 static BUILD_MASK_TIME_MS: AtomicI64 = AtomicI64::new(0);
 static ON_BATCH_MASK_TIME_MS: AtomicI64 = AtomicI64::new(0);
 static FILTER_RECORD_BATCH_TIME_MS: AtomicI64 = AtomicI64::new(0);
+static OBJECT_STORE_READ_TIME_MS: AtomicI64 = AtomicI64::new(0);
 
 pub fn inc_listing_table_scan() {
     LISTING_TABLE_SCAN.fetch_add(1, Ordering::Relaxed);
@@ -101,6 +102,12 @@ pub fn accumulate(m: &StreamMetrics) {
     if let Some(ref t) = m.filter_record_batch_time {
         FILTER_RECORD_BATCH_TIME_MS.fetch_add((t.value() / 1_000_000) as i64, Ordering::Relaxed);
     }
+    if let Some(ref stats) = m.io_stats {
+        OBJECT_STORE_READ_TIME_MS.fetch_add(
+            (stats.total_ns.load(Ordering::Relaxed) / 1_000_000) as i64,
+            Ordering::Relaxed,
+        );
+    }
 }
 
 pub fn snapshot() -> SearchStatsRepr {
@@ -120,6 +127,7 @@ pub fn snapshot() -> SearchStatsRepr {
         build_mask_time_ms: BUILD_MASK_TIME_MS.load(Ordering::Relaxed),
         on_batch_mask_time_ms: ON_BATCH_MASK_TIME_MS.load(Ordering::Relaxed),
         filter_record_batch_time_ms: FILTER_RECORD_BATCH_TIME_MS.load(Ordering::Relaxed),
+        object_store_read_time_ms: OBJECT_STORE_READ_TIME_MS.load(Ordering::Relaxed),
     }
 }
 

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/statistics_cache.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/statistics_cache.rs
@@ -134,9 +134,9 @@ pub struct CustomStatisticsCache {
     /// Combined memory tracking state
     memory_state: Arc<Mutex<MemoryState>>,
     /// Cache hit count (thread-safe)
-    hit_count: Arc<Mutex<usize>>,
+    hit_count: AtomicUsize,
     /// Cache miss count (thread-safe)
-    miss_count: Arc<Mutex<usize>>,
+    miss_count: AtomicUsize,
 }
 
 impl CustomStatisticsCache {
@@ -151,8 +151,8 @@ impl CustomStatisticsCache {
                 tracker: HashMap::new(),
                 total: 0,
             })),
-            hit_count: Arc::new(Mutex::new(0)),
-            miss_count: Arc::new(Mutex::new(0)),
+            hit_count: AtomicUsize::new(0),
+            miss_count: AtomicUsize::new(0),
         }
     }
 
@@ -173,12 +173,12 @@ impl CustomStatisticsCache {
 
     /// Get cache hit count
     pub fn hit_count(&self) -> usize {
-        self.hit_count.lock().map(|guard| *guard).unwrap_or(0)
+        self.hit_count.load(Ordering::Relaxed)
     }
 
     /// Get cache miss count
     pub fn miss_count(&self) -> usize {
-        self.miss_count.lock().map(|guard| *guard).unwrap_or(0)
+        self.miss_count.load(Ordering::Relaxed)
     }
 
     /// Get cache hit rate (returns value between 0.0 and 1.0)
@@ -191,8 +191,8 @@ impl CustomStatisticsCache {
 
     /// Reset hit and miss counters
     pub fn reset_stats(&self) {
-        if let Ok(mut hits) = self.hit_count.lock() { *hits = 0; }
-        if let Ok(mut misses) = self.miss_count.lock() { *misses = 0; }
+        self.hit_count.store(0, Ordering::Relaxed);
+        self.miss_count.store(0, Ordering::Relaxed);
     }
 
     /// Update the cache size limit
@@ -245,6 +245,11 @@ impl CustomStatisticsCache {
     /// Get current cache size according to policy (uses actual memory consumption)
     pub fn current_size(&self) -> CacheResult<usize> {
         Ok(self.memory_consumed())
+    }
+
+    /// Get current size limit in bytes (configured cap, not utilization)
+    pub fn current_size_limit(&self) -> usize {
+        self.size_limit.load(Ordering::Relaxed)
     }
 
     /// Manually trigger eviction (requires &mut self)
@@ -336,7 +341,7 @@ impl CustomStatisticsCache {
         let result = self.inner_cache.get(k);
 
         if result.is_some() {
-            if let Ok(mut hits) = self.hit_count.lock() { *hits += 1; }
+            self.hit_count.fetch_add(1, Ordering::Relaxed);
             let key = k.to_string();
             let memory_size = {
                 let state = self.memory_state.lock();
@@ -346,7 +351,7 @@ impl CustomStatisticsCache {
                 policy_guard.on_access(&key, memory_size);
             }
         } else {
-            if let Ok(mut misses) = self.miss_count.lock() { *misses += 1; }
+            self.miss_count.fetch_add(1, Ordering::Relaxed);
         }
 
         result.map(|s| s.value().clone())

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/stats.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/stats.rs
@@ -5,7 +5,7 @@
 //! Stats packing helpers for the FFM `df_stats()` function.
 //!
 //! Packs Tokio runtime metrics and per-operation task monitor metrics
-//! into a `#[repr(C)]` `DfStatsBuffer` struct (536 bytes) for efficient
+//! into a `#[repr(C)]` `DfStatsBuffer` struct (544 bytes) for efficient
 //! transfer across the FFM boundary.
 //!
 //! ## Struct layout
@@ -21,7 +21,7 @@
 //! | `fragment_executor_gate` | `PartitionGateRepr`  | 6 × i64 |
 //! | `reduce_executor_gate`   | `PartitionGateRepr`  | 6 × i64 |
 //! | `cache_stats`        | `CacheStatsRepr`     | 10 × i64 (2 × 5: metadata + statistics caches) |
-//! | `search_stats`       | `SearchStatsRepr`    | 15 × i64 |
+//! | `search_stats`       | `SearchStatsRepr`    | 16 × i64 |
 
 use tokio::runtime::Handle;
 use tokio_metrics::{RuntimeMonitor, TaskMonitor};
@@ -128,6 +128,7 @@ pub struct SearchStatsRepr {
     pub build_mask_time_ms: i64,
     pub on_batch_mask_time_ms: i64,
     pub filter_record_batch_time_ms: i64,
+    pub object_store_read_time_ms: i64,
 }
 
 #[repr(C)]
@@ -149,13 +150,13 @@ const _: () = assert!(std::mem::size_of::<TaskMonitorRepr>() == 3 * 8);
 const _: () = assert!(std::mem::size_of::<PartitionGateRepr>() == 6 * 8);
 const _: () = assert!(std::mem::size_of::<CacheGroupRepr>() == 5 * 8);
 const _: () = assert!(std::mem::size_of::<CacheStatsRepr>() == 10 * 8);
-const _: () = assert!(std::mem::size_of::<SearchStatsRepr>() == 15 * 8);
-const _: () = assert!(std::mem::size_of::<DfStatsBuffer>() == 67 * 8);
+const _: () = assert!(std::mem::size_of::<SearchStatsRepr>() == 16 * 8);
+const _: () = assert!(std::mem::size_of::<DfStatsBuffer>() == 68 * 8);
 
 pub mod layout {
     use super::*;
     pub const BUFFER_BYTE_SIZE: usize = std::mem::size_of::<DfStatsBuffer>();
-    const _: () = assert!(BUFFER_BYTE_SIZE == 536);
+    const _: () = assert!(BUFFER_BYTE_SIZE == 544);
 }
 
 /// Snapshot a `RuntimeMonitor` and return a populated `RuntimeMetricsRepr`.
@@ -365,7 +366,7 @@ mod tests {
             search_stats: crate::search_stats::snapshot(),
         };
 
-        assert_eq!(layout::BUFFER_BYTE_SIZE, 536);
+        assert_eq!(layout::BUFFER_BYTE_SIZE, 544);
         assert!(buf.io_runtime.workers_count > 0, "IO runtime workers_count should be > 0, got {}", buf.io_runtime.workers_count);
         assert!(buf.fragment_executor_gate.max_permits > 0, "fragment_executor_gate max_permits should be > 0, got {}", buf.fragment_executor_gate.max_permits);
         assert!(buf.reduce_executor_gate.max_permits > 0, "reduce_executor_gate max_permits should be > 0, got {}", buf.reduce_executor_gate.max_permits);
@@ -381,9 +382,9 @@ mod tests {
     #[test]
     fn test_df_stats_buffer_too_small() {
         // Verify that the buffer size assertion holds
-        assert_eq!(std::mem::size_of::<DfStatsBuffer>(), 536);
-        assert_eq!(layout::BUFFER_BYTE_SIZE, 536);
-        // A buffer smaller than 536 bytes should be rejected by df_stats.
+        assert_eq!(std::mem::size_of::<DfStatsBuffer>(), 544);
+        assert_eq!(layout::BUFFER_BYTE_SIZE, 544);
+        // A buffer smaller than 544 bytes should be rejected by df_stats.
         // We can't call df_stats directly without a runtime manager,
         // but we verify the constant is correct.
         assert!(layout::BUFFER_BYTE_SIZE > 0);
@@ -407,7 +408,7 @@ mod tests {
     fn test_pack_cache_stats_reflects_underlying_counters() {
         use std::sync::Arc;
 
-        use datafusion::execution::cache::cache_unit::DefaultFilesMetadataCache;
+        use datafusion::execution::cache::DefaultFilesMetadataCache;
         use datafusion::execution::cache::CacheAccessor;
         use object_store::path::Path;
 

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/stats.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/stats.rs
@@ -5,7 +5,7 @@
 //! Stats packing helpers for the FFM `df_stats()` function.
 //!
 //! Packs Tokio runtime metrics and per-operation task monitor metrics
-//! into a `#[repr(C)]` `DfStatsBuffer` struct (544 bytes) for efficient
+//! into a `#[repr(C)]` `DfStatsBuffer` struct (552 bytes) for efficient
 //! transfer across the FFM boundary.
 //!
 //! ## Struct layout
@@ -21,7 +21,7 @@
 //! | `fragment_executor_gate` | `PartitionGateRepr`  | 6 × i64 |
 //! | `reduce_executor_gate`   | `PartitionGateRepr`  | 6 × i64 |
 //! | `cache_stats`        | `CacheStatsRepr`     | 10 × i64 (2 × 5: metadata + statistics caches) |
-//! | `search_stats`       | `SearchStatsRepr`    | 16 × i64 |
+//! | `search_stats`       | `SearchStatsRepr`    | 17 × i64 |
 
 use tokio::runtime::Handle;
 use tokio_metrics::{RuntimeMonitor, TaskMonitor};
@@ -90,8 +90,8 @@ pub struct CacheStatsRepr {
     pub statistics_cache: CacheGroupRepr,
 }
 
-impl CacheGroupRepr {
-    pub fn zeroed() -> Self {
+impl Default for CacheGroupRepr {
+    fn default() -> Self {
         Self {
             hit_count: 0,
             miss_count: 0,
@@ -102,11 +102,11 @@ impl CacheGroupRepr {
     }
 }
 
-impl CacheStatsRepr {
-    pub fn zeroed() -> Self {
+impl Default for CacheStatsRepr {
+    fn default() -> Self {
         Self {
-            metadata_cache: CacheGroupRepr::zeroed(),
-            statistics_cache: CacheGroupRepr::zeroed(),
+            metadata_cache: CacheGroupRepr::default(),
+            statistics_cache: CacheGroupRepr::default(),
         }
     }
 }
@@ -122,6 +122,7 @@ pub struct SearchStatsRepr {
     pub parquet_scan_total_time_ms: i64,
     pub parquet_scan_until_data_time_ms: i64,
     pub parquet_processing_time_ms: i64,
+    pub parquet_bytes_scanned: i64,
     pub prefetch_wait_time_ms: i64,
     pub prefetch_wait_count: i64,
     pub elapsed_compute_ms: i64,
@@ -150,13 +151,13 @@ const _: () = assert!(std::mem::size_of::<TaskMonitorRepr>() == 3 * 8);
 const _: () = assert!(std::mem::size_of::<PartitionGateRepr>() == 6 * 8);
 const _: () = assert!(std::mem::size_of::<CacheGroupRepr>() == 5 * 8);
 const _: () = assert!(std::mem::size_of::<CacheStatsRepr>() == 10 * 8);
-const _: () = assert!(std::mem::size_of::<SearchStatsRepr>() == 16 * 8);
-const _: () = assert!(std::mem::size_of::<DfStatsBuffer>() == 68 * 8);
+const _: () = assert!(std::mem::size_of::<SearchStatsRepr>() == 17 * 8);
+const _: () = assert!(std::mem::size_of::<DfStatsBuffer>() == 69 * 8);
 
 pub mod layout {
     use super::*;
     pub const BUFFER_BYTE_SIZE: usize = std::mem::size_of::<DfStatsBuffer>();
-    const _: () = assert!(BUFFER_BYTE_SIZE == 544);
+    const _: () = assert!(BUFFER_BYTE_SIZE == 552);
 }
 
 /// Snapshot a `RuntimeMonitor` and return a populated `RuntimeMetricsRepr`.
@@ -362,11 +363,11 @@ mod tests {
             plan_setup: pack_task_monitor(plan_setup_monitor()),
             fragment_executor_gate: pack_partition_gate(mgr.cpu_executor.concurrency_gate()),
             reduce_executor_gate: pack_partition_gate(mgr.coordinator_gate()),
-            cache_stats: CacheStatsRepr::zeroed(),
+            cache_stats: CacheStatsRepr::default(),
             search_stats: crate::search_stats::snapshot(),
         };
 
-        assert_eq!(layout::BUFFER_BYTE_SIZE, 544);
+        assert_eq!(layout::BUFFER_BYTE_SIZE, 552);
         assert!(buf.io_runtime.workers_count > 0, "IO runtime workers_count should be > 0, got {}", buf.io_runtime.workers_count);
         assert!(buf.fragment_executor_gate.max_permits > 0, "fragment_executor_gate max_permits should be > 0, got {}", buf.fragment_executor_gate.max_permits);
         assert!(buf.reduce_executor_gate.max_permits > 0, "reduce_executor_gate max_permits should be > 0, got {}", buf.reduce_executor_gate.max_permits);
@@ -382,9 +383,9 @@ mod tests {
     #[test]
     fn test_df_stats_buffer_too_small() {
         // Verify that the buffer size assertion holds
-        assert_eq!(std::mem::size_of::<DfStatsBuffer>(), 544);
-        assert_eq!(layout::BUFFER_BYTE_SIZE, 544);
-        // A buffer smaller than 544 bytes should be rejected by df_stats.
+        assert_eq!(std::mem::size_of::<DfStatsBuffer>(), 552);
+        assert_eq!(layout::BUFFER_BYTE_SIZE, 552);
+        // A buffer smaller than 552 bytes should be rejected by df_stats.
         // We can't call df_stats directly without a runtime manager,
         // but we verify the constant is correct.
         assert!(layout::BUFFER_BYTE_SIZE > 0);

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/stats.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/stats.rs
@@ -5,7 +5,7 @@
 //! Stats packing helpers for the FFM `df_stats()` function.
 //!
 //! Packs Tokio runtime metrics and per-operation task monitor metrics
-//! into a `#[repr(C)]` `DfStatsBuffer` struct (336 bytes) for efficient
+//! into a `#[repr(C)]` `DfStatsBuffer` struct (536 bytes) for efficient
 //! transfer across the FFM boundary.
 //!
 //! ## Struct layout
@@ -19,11 +19,14 @@
 //! | `stream_next`        | `TaskMonitorRepr`    | 3 × i64 |
 //! | `plan_setup`         | `TaskMonitorRepr`    | 3 × i64 |
 //! | `fragment_executor_gate` | `PartitionGateRepr`  | 6 × i64 |
-//! | `reduce_executor_gate`            | `PartitionGateRepr`  | 6 × i64 |
+//! | `reduce_executor_gate`   | `PartitionGateRepr`  | 6 × i64 |
+//! | `cache_stats`        | `CacheStatsRepr`     | 10 × i64 (2 × 5: metadata + statistics caches) |
+//! | `search_stats`       | `SearchStatsRepr`    | 15 × i64 |
 
 use tokio::runtime::Handle;
 use tokio_metrics::{RuntimeMonitor, TaskMonitor};
 
+use crate::custom_cache_manager::CustomCacheManager;
 use crate::executor::ConcurrencyGate;
 
 #[repr(C)]
@@ -73,6 +76,61 @@ pub struct PartitionGateRepr {
 }
 
 #[repr(C)]
+pub struct CacheGroupRepr {
+    pub hit_count: i64,
+    pub miss_count: i64,
+    pub entry_count: i64,
+    pub memory_bytes: i64,
+    pub size_limit_bytes: i64,
+}
+
+#[repr(C)]
+pub struct CacheStatsRepr {
+    pub metadata_cache: CacheGroupRepr,
+    pub statistics_cache: CacheGroupRepr,
+}
+
+impl CacheGroupRepr {
+    pub fn zeroed() -> Self {
+        Self {
+            hit_count: 0,
+            miss_count: 0,
+            entry_count: 0,
+            memory_bytes: 0,
+            size_limit_bytes: 0,
+        }
+    }
+}
+
+impl CacheStatsRepr {
+    pub fn zeroed() -> Self {
+        Self {
+            metadata_cache: CacheGroupRepr::zeroed(),
+            statistics_cache: CacheGroupRepr::zeroed(),
+        }
+    }
+}
+
+#[repr(C)]
+pub struct SearchStatsRepr {
+    pub listing_table_scan: i64,
+    pub single_collector_scan: i64,
+    pub bitmap_tree_scan: i64,
+    pub delegation_calls: i64,
+    pub rg_processed: i64,
+    pub rg_skipped: i64,
+    pub parquet_scan_total_time_ms: i64,
+    pub parquet_scan_until_data_time_ms: i64,
+    pub parquet_processing_time_ms: i64,
+    pub prefetch_wait_time_ms: i64,
+    pub prefetch_wait_count: i64,
+    pub elapsed_compute_ms: i64,
+    pub build_mask_time_ms: i64,
+    pub on_batch_mask_time_ms: i64,
+    pub filter_record_batch_time_ms: i64,
+}
+
+#[repr(C)]
 pub struct DfStatsBuffer {
     pub io_runtime: RuntimeMetricsRepr,
     pub cpu_runtime: RuntimeMetricsRepr,
@@ -82,17 +140,22 @@ pub struct DfStatsBuffer {
     pub plan_setup: TaskMonitorRepr,
     pub fragment_executor_gate: PartitionGateRepr,
     pub reduce_executor_gate: PartitionGateRepr,
+    pub cache_stats: CacheStatsRepr,
+    pub search_stats: SearchStatsRepr,
 }
 
 const _: () = assert!(std::mem::size_of::<RuntimeMetricsRepr>() == 9 * 8);
 const _: () = assert!(std::mem::size_of::<TaskMonitorRepr>() == 3 * 8);
 const _: () = assert!(std::mem::size_of::<PartitionGateRepr>() == 6 * 8);
-const _: () = assert!(std::mem::size_of::<DfStatsBuffer>() == 42 * 8);
+const _: () = assert!(std::mem::size_of::<CacheGroupRepr>() == 5 * 8);
+const _: () = assert!(std::mem::size_of::<CacheStatsRepr>() == 10 * 8);
+const _: () = assert!(std::mem::size_of::<SearchStatsRepr>() == 15 * 8);
+const _: () = assert!(std::mem::size_of::<DfStatsBuffer>() == 67 * 8);
 
 pub mod layout {
     use super::*;
     pub const BUFFER_BYTE_SIZE: usize = std::mem::size_of::<DfStatsBuffer>();
-    const _: () = assert!(BUFFER_BYTE_SIZE == 336);
+    const _: () = assert!(BUFFER_BYTE_SIZE == 536);
 }
 
 /// Snapshot a `RuntimeMonitor` and return a populated `RuntimeMetricsRepr`.
@@ -175,6 +238,43 @@ pub fn pack_partition_gate(gate: &ConcurrencyGate) -> PartitionGateRepr {
         total_batches_started: gate.total_queries_admitted() as i64,
         poison_permits: gate.poison_permits_held() as i64,
         target_max_permits: gate.target_max_permits() as i64,
+    }
+}
+
+/// Snapshot the [`CustomCacheManager`] caches and return a populated
+/// [`CacheStatsRepr`]. Disabled caches return all-zeros via the manager's
+/// `unwrap_or(0)` accessor fallbacks.
+///
+/// | Field            | Source                                              |
+/// |------------------|-----------------------------------------------------|
+/// | hit_count        | `mgr.{metadata,statistics}_cache_hit_count()`       |
+/// | miss_count       | `mgr.{metadata,statistics}_cache_miss_count()`      |
+/// | entry_count      | `mgr.{metadata,statistics}_cache_entry_count()`     |
+/// | memory_bytes     | `mgr.get_memory_consumed_by_type({METADATA,STATS})` |
+/// | size_limit_bytes | `mgr.{metadata,statistics}_cache_size_limit()`      |
+pub fn pack_cache_stats(mgr: &CustomCacheManager) -> CacheStatsRepr {
+    let metadata_memory = mgr
+        .get_memory_consumed_by_type(crate::cache::CACHE_TYPE_METADATA)
+        .unwrap_or(0) as i64;
+    let statistics_memory = mgr
+        .get_memory_consumed_by_type(crate::cache::CACHE_TYPE_STATS)
+        .unwrap_or(0) as i64;
+
+    CacheStatsRepr {
+        metadata_cache: CacheGroupRepr {
+            hit_count: mgr.metadata_cache_hit_count() as i64,
+            miss_count: mgr.metadata_cache_miss_count() as i64,
+            entry_count: mgr.metadata_cache_entry_count() as i64,
+            memory_bytes: metadata_memory,
+            size_limit_bytes: mgr.metadata_cache_size_limit() as i64,
+        },
+        statistics_cache: CacheGroupRepr {
+            hit_count: mgr.statistics_cache_hit_count() as i64,
+            miss_count: mgr.statistics_cache_miss_count() as i64,
+            entry_count: mgr.statistics_cache_entry_count() as i64,
+            memory_bytes: statistics_memory,
+            size_limit_bytes: mgr.statistics_cache_size_limit() as i64,
+        },
     }
 }
 
@@ -261,9 +361,11 @@ mod tests {
             plan_setup: pack_task_monitor(plan_setup_monitor()),
             fragment_executor_gate: pack_partition_gate(mgr.cpu_executor.concurrency_gate()),
             reduce_executor_gate: pack_partition_gate(mgr.coordinator_gate()),
+            cache_stats: CacheStatsRepr::zeroed(),
+            search_stats: crate::search_stats::snapshot(),
         };
 
-        assert_eq!(layout::BUFFER_BYTE_SIZE, 336);
+        assert_eq!(layout::BUFFER_BYTE_SIZE, 536);
         assert!(buf.io_runtime.workers_count > 0, "IO runtime workers_count should be > 0, got {}", buf.io_runtime.workers_count);
         assert!(buf.fragment_executor_gate.max_permits > 0, "fragment_executor_gate max_permits should be > 0, got {}", buf.fragment_executor_gate.max_permits);
         assert!(buf.reduce_executor_gate.max_permits > 0, "reduce_executor_gate max_permits should be > 0, got {}", buf.reduce_executor_gate.max_permits);
@@ -279,11 +381,73 @@ mod tests {
     #[test]
     fn test_df_stats_buffer_too_small() {
         // Verify that the buffer size assertion holds
-        assert_eq!(std::mem::size_of::<DfStatsBuffer>(), 336);
-        assert_eq!(layout::BUFFER_BYTE_SIZE, 336);
-        // A buffer smaller than 336 bytes should be rejected by df_stats.
+        assert_eq!(std::mem::size_of::<DfStatsBuffer>(), 536);
+        assert_eq!(layout::BUFFER_BYTE_SIZE, 536);
+        // A buffer smaller than 536 bytes should be rejected by df_stats.
         // We can't call df_stats directly without a runtime manager,
         // but we verify the constant is correct.
         assert!(layout::BUFFER_BYTE_SIZE > 0);
+    }
+
+    #[test]
+    fn test_pack_cache_stats_empty_manager_zeroed() {
+        use crate::custom_cache_manager::CustomCacheManager;
+        let mgr = CustomCacheManager::new();
+        let repr = pack_cache_stats(&mgr);
+        for g in [&repr.metadata_cache, &repr.statistics_cache] {
+            assert_eq!(g.hit_count, 0);
+            assert_eq!(g.miss_count, 0);
+            assert_eq!(g.entry_count, 0);
+            assert_eq!(g.memory_bytes, 0);
+            assert_eq!(g.size_limit_bytes, 0);
+        }
+    }
+
+    #[test]
+    fn test_pack_cache_stats_reflects_underlying_counters() {
+        use std::sync::Arc;
+
+        use datafusion::execution::cache::cache_unit::DefaultFilesMetadataCache;
+        use datafusion::execution::cache::CacheAccessor;
+        use object_store::path::Path;
+
+        use crate::cache::MutexFileMetadataCache;
+        use crate::custom_cache_manager::CustomCacheManager;
+        use crate::eviction_policy::PolicyType;
+        use crate::statistics_cache::CustomStatisticsCache;
+
+        let metadata_cache = Arc::new(MutexFileMetadataCache::new(
+            DefaultFilesMetadataCache::new(50 * 1024 * 1024),
+        ));
+        let stats_cache = Arc::new(CustomStatisticsCache::new(
+            PolicyType::Lru,
+            10 * 1024 * 1024,
+            0.8,
+        ));
+
+        // Drive 3 misses on each cache and one extra miss on metadata.
+        for i in 0..3 {
+            let p = Path::from(format!("/test/missing/{i}.parquet"));
+            assert!(metadata_cache.get(&p).is_none());
+            assert!(stats_cache.get(&p).is_none());
+        }
+        assert!(metadata_cache.get(&Path::from("/test/missing/extra.parquet")).is_none());
+
+        let mut mgr = CustomCacheManager::new();
+        mgr.set_file_metadata_cache(metadata_cache);
+        mgr.set_statistics_cache(stats_cache);
+
+        let repr = pack_cache_stats(&mgr);
+
+        assert_eq!(repr.metadata_cache.hit_count, 0);
+        assert_eq!(repr.metadata_cache.miss_count, 4);
+        assert_eq!(repr.statistics_cache.hit_count, 0);
+        assert_eq!(repr.statistics_cache.miss_count, 3);
+
+        assert_eq!(repr.metadata_cache.size_limit_bytes, 50 * 1024 * 1024);
+        assert_eq!(repr.statistics_cache.size_limit_bytes, 10 * 1024 * 1024);
+
+        assert_eq!(repr.metadata_cache.entry_count, 0);
+        assert_eq!(repr.statistics_cache.entry_count, 0);
     }
 }

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionService.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionService.java
@@ -224,13 +224,15 @@ public class DataFusionService extends AbstractLifecycleComponent {
         if (runtimeHandle == null) {
             throw new IllegalStateException("DataFusionService has not been started");
         }
-        DataFusionStats nativeStats = NativeBridge.stats();
+        DataFusionStats nativeStats = NativeBridge.stats(runtimeHandle.get());
         SpillStats spill = buildSpillStats();
         return new DataFusionStats(
             nativeStats.getNativeExecutorsStats(),
             nativeStats.getDatanodeGateStats(),
             nativeStats.getCoordinatorGateStats(),
-            spill
+            spill,
+            nativeStats.getCacheStats(),
+            nativeStats.getSearchStats()
         );
     }
 

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/nativelib/NativeBridge.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/nativelib/NativeBridge.java
@@ -497,10 +497,10 @@ public final class NativeBridge {
             FunctionDescriptor.of(ValueLayout.JAVA_LONG, ValueLayout.JAVA_LONG, ValueLayout.ADDRESS, ValueLayout.JAVA_LONG)
         );
 
-        // i64 df_stats(out_ptr, out_cap)
+        // i64 df_stats(runtime_ptr, out_ptr, out_cap)
         STATS = linker.downcallHandle(
             lib.find("df_stats").orElseThrow(),
-            FunctionDescriptor.of(ValueLayout.JAVA_LONG, ValueLayout.ADDRESS, ValueLayout.JAVA_LONG)
+            FunctionDescriptor.of(ValueLayout.JAVA_LONG, ValueLayout.JAVA_LONG, ValueLayout.ADDRESS, ValueLayout.JAVA_LONG)
         );
 
         // i64 df_query_registry_top_n_by_current(out_ptr, cap_entries)
@@ -985,10 +985,10 @@ public final class NativeBridge {
      * @return a fully constructed {@link DataFusionStats}
      * @throws IllegalStateException if the runtime manager is not initialized
      */
-    public static DataFusionStats stats() {
+    public static DataFusionStats stats(long runtimePtr) {
         try (var call = new NativeCall()) {
             var seg = call.buf((int) StatsLayout.LAYOUT.byteSize());
-            call.invoke(STATS, seg, StatsLayout.LAYOUT.byteSize());
+            call.invoke(STATS, runtimePtr, seg, StatsLayout.LAYOUT.byteSize());
 
             // IO runtime (always present — zeroed if not yet initialized)
             var ioRuntime = StatsLayout.readRuntimeMetrics(seg, "io_runtime");
@@ -1006,7 +1006,20 @@ public final class NativeBridge {
             var datanodeGate = StatsLayout.readPartitionGate(seg, "fragment_executor_gate", "datanode_gate");
             var coordinatorGate = StatsLayout.readPartitionGate(seg, "reduce_executor_gate", "coordinator_gate");
 
-            return new DataFusionStats(new NativeExecutorsStats(ioRuntime, cpuRuntime, taskMonitors), datanodeGate, coordinatorGate, null);
+            // Cache stats (zeroed in native when caches are disabled)
+            var cacheStats = StatsLayout.readCacheStats(seg);
+
+            // Search stats
+            var searchStats = StatsLayout.readSearchStats(seg);
+
+            return new DataFusionStats(
+                new NativeExecutorsStats(ioRuntime, cpuRuntime, taskMonitors),
+                datanodeGate,
+                coordinatorGate,
+                null,
+                cacheStats,
+                searchStats
+            );
         }
     }
 
@@ -1021,7 +1034,7 @@ public final class NativeBridge {
      * zero-byte trackers are filtered on the Rust side. Order within the
      * buffer is unspecified.
      *
-     * <p>Mirrors the {@link #stats()} pattern: the layout class decodes
+     * <p>Mirrors the {@link #stats(long)} pattern: the layout class decodes
      * directly into the caller's final type ({@link QueryExecutionMetrics})
      * with no transport-only intermediate.
      *
@@ -1061,7 +1074,7 @@ public final class NativeBridge {
 
     /**
      * Reads native task cancellation counters via {@code df_native_node_stats} FFM call.
-     * Independent of {@link #stats()} which calls {@code df_stats} for plugin stats.
+     * Independent of {@link #stats(long)} which calls {@code df_stats} for plugin stats.
      *
      * @return a populated {@link AnalyticsBackendTaskCancellationStats}
      * @throws IllegalStateException if the FFM function returns a non-zero error code

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/nativelib/StatsLayout.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/nativelib/StatsLayout.java
@@ -27,8 +27,8 @@ import java.lang.invoke.VarHandle;
  * and provides {@link VarHandle} accessors for each field via layout path navigation.
  *
  * <p>The layout contains 10 named groups (2 runtime × 9 fields + 4 task monitor × 3 fields
- * + 2 partition gate × 6 fields + 1 cache stats × 10 fields + 1 search stats × 16 fields
- * = 68 longs = 544 bytes).
+ * + 2 partition gate × 6 fields + 1 cache stats × 10 fields + 1 search stats × 17 fields
+ * = 69 longs = 552 bytes).
  */
 public final class StatsLayout {
 
@@ -68,6 +68,7 @@ public final class StatsLayout {
         "parquet_scan_total_time_ms",
         "parquet_scan_until_data_time_ms",
         "parquet_processing_time_ms",
+        "parquet_bytes_scanned",
         "prefetch_wait_time_ms",
         "prefetch_wait_count",
         "elapsed_compute_ms",
@@ -91,8 +92,8 @@ public final class StatsLayout {
     );
 
     static {
-        if (LAYOUT.byteSize() != 68 * Long.BYTES) {
-            throw new AssertionError("StatsLayout size mismatch: expected " + (68 * Long.BYTES) + " but got " + LAYOUT.byteSize());
+        if (LAYOUT.byteSize() != 69 * Long.BYTES) {
+            throw new AssertionError("StatsLayout size mismatch: expected " + (69 * Long.BYTES) + " but got " + LAYOUT.byteSize());
         }
     }
 
@@ -178,6 +179,7 @@ public final class StatsLayout {
     private static final VarHandle SS_PARQUET_SCAN_TOTAL_TIME_MS = handle("search_stats", "parquet_scan_total_time_ms");
     private static final VarHandle SS_PARQUET_SCAN_UNTIL_DATA_TIME_MS = handle("search_stats", "parquet_scan_until_data_time_ms");
     private static final VarHandle SS_PARQUET_PROCESSING_TIME_MS = handle("search_stats", "parquet_processing_time_ms");
+    private static final VarHandle SS_PARQUET_BYTES_SCANNED = handle("search_stats", "parquet_bytes_scanned");
     private static final VarHandle SS_PREFETCH_WAIT_TIME_MS = handle("search_stats", "prefetch_wait_time_ms");
     private static final VarHandle SS_PREFETCH_WAIT_COUNT = handle("search_stats", "prefetch_wait_count");
     private static final VarHandle SS_ELAPSED_COMPUTE_MS = handle("search_stats", "elapsed_compute_ms");
@@ -291,7 +293,7 @@ public final class StatsLayout {
     }
 
     /**
-     * Read the search_stats group (16 fields) from the segment.
+     * Read the search_stats group (17 fields) from the segment.
      *
      * @param seg the memory segment containing the DfStatsBuffer
      * @return a populated SearchStats instance
@@ -307,6 +309,7 @@ public final class StatsLayout {
             (long) SS_PARQUET_SCAN_TOTAL_TIME_MS.get(seg, 0L),
             (long) SS_PARQUET_SCAN_UNTIL_DATA_TIME_MS.get(seg, 0L),
             (long) SS_PARQUET_PROCESSING_TIME_MS.get(seg, 0L),
+            (long) SS_PARQUET_BYTES_SCANNED.get(seg, 0L),
             (long) SS_PREFETCH_WAIT_TIME_MS.get(seg, 0L),
             (long) SS_PREFETCH_WAIT_COUNT.get(seg, 0L),
             (long) SS_ELAPSED_COMPUTE_MS.get(seg, 0L),
@@ -377,6 +380,7 @@ public final class StatsLayout {
             ValueLayout.JAVA_LONG.withName("parquet_scan_total_time_ms"),
             ValueLayout.JAVA_LONG.withName("parquet_scan_until_data_time_ms"),
             ValueLayout.JAVA_LONG.withName("parquet_processing_time_ms"),
+            ValueLayout.JAVA_LONG.withName("parquet_bytes_scanned"),
             ValueLayout.JAVA_LONG.withName("prefetch_wait_time_ms"),
             ValueLayout.JAVA_LONG.withName("prefetch_wait_count"),
             ValueLayout.JAVA_LONG.withName("elapsed_compute_ms"),

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/nativelib/StatsLayout.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/nativelib/StatsLayout.java
@@ -27,8 +27,8 @@ import java.lang.invoke.VarHandle;
  * and provides {@link VarHandle} accessors for each field via layout path navigation.
  *
  * <p>The layout contains 10 named groups (2 runtime × 9 fields + 4 task monitor × 3 fields
- * + 2 partition gate × 6 fields + 1 cache stats × 10 fields + 1 search stats × 15 fields
- * = 67 longs = 536 bytes).
+ * + 2 partition gate × 6 fields + 1 cache stats × 10 fields + 1 search stats × 16 fields
+ * = 68 longs = 544 bytes).
  */
 public final class StatsLayout {
 
@@ -73,7 +73,8 @@ public final class StatsLayout {
         "elapsed_compute_ms",
         "build_mask_time_ms",
         "on_batch_mask_time_ms",
-        "filter_record_batch_time_ms" };
+        "filter_record_batch_time_ms",
+        "object_store_read_time_ms" };
 
     /** The struct layout mirroring Rust's {@code DfStatsBuffer}. */
     public static final StructLayout LAYOUT = MemoryLayout.structLayout(
@@ -90,8 +91,8 @@ public final class StatsLayout {
     );
 
     static {
-        if (LAYOUT.byteSize() != 67 * Long.BYTES) {
-            throw new AssertionError("StatsLayout size mismatch: expected " + (67 * Long.BYTES) + " but got " + LAYOUT.byteSize());
+        if (LAYOUT.byteSize() != 68 * Long.BYTES) {
+            throw new AssertionError("StatsLayout size mismatch: expected " + (68 * Long.BYTES) + " but got " + LAYOUT.byteSize());
         }
     }
 
@@ -183,6 +184,7 @@ public final class StatsLayout {
     private static final VarHandle SS_BUILD_MASK_TIME_MS = handle("search_stats", "build_mask_time_ms");
     private static final VarHandle SS_ON_BATCH_MASK_TIME_MS = handle("search_stats", "on_batch_mask_time_ms");
     private static final VarHandle SS_FILTER_RECORD_BATCH_TIME_MS = handle("search_stats", "filter_record_batch_time_ms");
+    private static final VarHandle SS_OBJECT_STORE_READ_TIME_MS = handle("search_stats", "object_store_read_time_ms");
 
     private StatsLayout() {}
 
@@ -289,7 +291,7 @@ public final class StatsLayout {
     }
 
     /**
-     * Read the search_stats group (15 fields) from the segment.
+     * Read the search_stats group (16 fields) from the segment.
      *
      * @param seg the memory segment containing the DfStatsBuffer
      * @return a populated SearchStats instance
@@ -310,7 +312,8 @@ public final class StatsLayout {
             (long) SS_ELAPSED_COMPUTE_MS.get(seg, 0L),
             (long) SS_BUILD_MASK_TIME_MS.get(seg, 0L),
             (long) SS_ON_BATCH_MASK_TIME_MS.get(seg, 0L),
-            (long) SS_FILTER_RECORD_BATCH_TIME_MS.get(seg, 0L)
+            (long) SS_FILTER_RECORD_BATCH_TIME_MS.get(seg, 0L),
+            (long) SS_OBJECT_STORE_READ_TIME_MS.get(seg, 0L)
         );
     }
 
@@ -379,7 +382,8 @@ public final class StatsLayout {
             ValueLayout.JAVA_LONG.withName("elapsed_compute_ms"),
             ValueLayout.JAVA_LONG.withName("build_mask_time_ms"),
             ValueLayout.JAVA_LONG.withName("on_batch_mask_time_ms"),
-            ValueLayout.JAVA_LONG.withName("filter_record_batch_time_ms")
+            ValueLayout.JAVA_LONG.withName("filter_record_batch_time_ms"),
+            ValueLayout.JAVA_LONG.withName("object_store_read_time_ms")
         ).withName(name);
     }
 

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/nativelib/StatsLayout.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/nativelib/StatsLayout.java
@@ -8,8 +8,11 @@
 
 package org.opensearch.be.datafusion.nativelib;
 
+import org.opensearch.be.datafusion.stats.CacheGroupStats;
+import org.opensearch.be.datafusion.stats.CacheStats;
 import org.opensearch.be.datafusion.stats.PartitionGateStats;
 import org.opensearch.be.datafusion.stats.RuntimeMetrics;
+import org.opensearch.be.datafusion.stats.SearchStats;
 import org.opensearch.be.datafusion.stats.TaskMonitorStats;
 
 import java.lang.foreign.MemoryLayout;
@@ -23,7 +26,9 @@ import java.lang.invoke.VarHandle;
  * Defines the {@code MemoryLayout.structLayout} mirroring the Rust {@code DfStatsBuffer}
  * and provides {@link VarHandle} accessors for each field via layout path navigation.
  *
- * <p>The layout contains 8 named groups (2 runtime × 9 fields + 4 task monitor × 3 fields + 2 partition gate × 6 fields = 42 longs = 336 bytes).
+ * <p>The layout contains 10 named groups (2 runtime × 9 fields + 4 task monitor × 3 fields
+ * + 2 partition gate × 6 fields + 1 cache stats × 10 fields + 1 search stats × 15 fields
+ * = 67 longs = 536 bytes).
  */
 public final class StatsLayout {
 
@@ -51,6 +56,25 @@ public final class StatsLayout {
         "poison_permits",
         "target_max_permits" };
 
+    private static final String[] CACHE_GROUP_FIELDS = { "hit_count", "miss_count", "entry_count", "memory_bytes", "size_limit_bytes" };
+
+    private static final String[] SEARCH_STATS_FIELDS = {
+        "listing_table_scan",
+        "single_collector_scan",
+        "bitmap_tree_scan",
+        "delegation_calls",
+        "rg_processed",
+        "rg_skipped",
+        "parquet_scan_total_time_ms",
+        "parquet_scan_until_data_time_ms",
+        "parquet_processing_time_ms",
+        "prefetch_wait_time_ms",
+        "prefetch_wait_count",
+        "elapsed_compute_ms",
+        "build_mask_time_ms",
+        "on_batch_mask_time_ms",
+        "filter_record_batch_time_ms" };
+
     /** The struct layout mirroring Rust's {@code DfStatsBuffer}. */
     public static final StructLayout LAYOUT = MemoryLayout.structLayout(
         runtimeGroup("io_runtime"),
@@ -60,12 +84,14 @@ public final class StatsLayout {
         taskMonitorGroup("stream_next"),
         taskMonitorGroup("plan_setup"),
         partitionGateGroup("fragment_executor_gate"),
-        partitionGateGroup("reduce_executor_gate")
+        partitionGateGroup("reduce_executor_gate"),
+        cacheStatsGroup("cache_stats"),
+        searchStatsGroup("search_stats")
     );
 
     static {
-        if (LAYOUT.byteSize() != 42 * Long.BYTES) {
-            throw new AssertionError("StatsLayout size mismatch: expected " + (42 * Long.BYTES) + " but got " + LAYOUT.byteSize());
+        if (LAYOUT.byteSize() != 67 * Long.BYTES) {
+            throw new AssertionError("StatsLayout size mismatch: expected " + (67 * Long.BYTES) + " but got " + LAYOUT.byteSize());
         }
     }
 
@@ -126,6 +152,37 @@ public final class StatsLayout {
     private static final VarHandle CG_TOTAL_BATCHES_STARTED = handle("reduce_executor_gate", "total_batches_started");
     private static final VarHandle CG_POISON_PERMITS = handle("reduce_executor_gate", "poison_permits");
     private static final VarHandle CG_TARGET_MAX_PERMITS = handle("reduce_executor_gate", "target_max_permits");
+
+    // ---- VarHandles for cache_stats.metadata_cache fields ----
+    private static final VarHandle CACHE_META_HIT_COUNT = cacheHandle("metadata_cache", "hit_count");
+    private static final VarHandle CACHE_META_MISS_COUNT = cacheHandle("metadata_cache", "miss_count");
+    private static final VarHandle CACHE_META_ENTRY_COUNT = cacheHandle("metadata_cache", "entry_count");
+    private static final VarHandle CACHE_META_MEMORY_BYTES = cacheHandle("metadata_cache", "memory_bytes");
+    private static final VarHandle CACHE_META_SIZE_LIMIT_BYTES = cacheHandle("metadata_cache", "size_limit_bytes");
+
+    // ---- VarHandles for cache_stats.statistics_cache fields ----
+    private static final VarHandle CACHE_STATS_HIT_COUNT = cacheHandle("statistics_cache", "hit_count");
+    private static final VarHandle CACHE_STATS_MISS_COUNT = cacheHandle("statistics_cache", "miss_count");
+    private static final VarHandle CACHE_STATS_ENTRY_COUNT = cacheHandle("statistics_cache", "entry_count");
+    private static final VarHandle CACHE_STATS_MEMORY_BYTES = cacheHandle("statistics_cache", "memory_bytes");
+    private static final VarHandle CACHE_STATS_SIZE_LIMIT_BYTES = cacheHandle("statistics_cache", "size_limit_bytes");
+
+    // ---- VarHandles for search_stats fields ----
+    private static final VarHandle SS_LISTING_TABLE_SCAN = handle("search_stats", "listing_table_scan");
+    private static final VarHandle SS_SINGLE_COLLECTOR_SCAN = handle("search_stats", "single_collector_scan");
+    private static final VarHandle SS_BITMAP_TREE_SCAN = handle("search_stats", "bitmap_tree_scan");
+    private static final VarHandle SS_DELEGATION_CALLS = handle("search_stats", "delegation_calls");
+    private static final VarHandle SS_RG_PROCESSED = handle("search_stats", "rg_processed");
+    private static final VarHandle SS_RG_SKIPPED = handle("search_stats", "rg_skipped");
+    private static final VarHandle SS_PARQUET_SCAN_TOTAL_TIME_MS = handle("search_stats", "parquet_scan_total_time_ms");
+    private static final VarHandle SS_PARQUET_SCAN_UNTIL_DATA_TIME_MS = handle("search_stats", "parquet_scan_until_data_time_ms");
+    private static final VarHandle SS_PARQUET_PROCESSING_TIME_MS = handle("search_stats", "parquet_processing_time_ms");
+    private static final VarHandle SS_PREFETCH_WAIT_TIME_MS = handle("search_stats", "prefetch_wait_time_ms");
+    private static final VarHandle SS_PREFETCH_WAIT_COUNT = handle("search_stats", "prefetch_wait_count");
+    private static final VarHandle SS_ELAPSED_COMPUTE_MS = handle("search_stats", "elapsed_compute_ms");
+    private static final VarHandle SS_BUILD_MASK_TIME_MS = handle("search_stats", "build_mask_time_ms");
+    private static final VarHandle SS_ON_BATCH_MASK_TIME_MS = handle("search_stats", "on_batch_mask_time_ms");
+    private static final VarHandle SS_FILTER_RECORD_BATCH_TIME_MS = handle("search_stats", "filter_record_batch_time_ms");
 
     private StatsLayout() {}
 
@@ -207,6 +264,56 @@ public final class StatsLayout {
         );
     }
 
+    /**
+     * Read the cache_stats group (10 fields, 2 sub-caches × 5 fields each).
+     *
+     * @param seg the memory segment containing the DfStatsBuffer
+     * @return a populated CacheStats instance with metadata + statistics sub-groups
+     */
+    public static CacheStats readCacheStats(MemorySegment seg) {
+        CacheGroupStats metadata = new CacheGroupStats(
+            (long) CACHE_META_HIT_COUNT.get(seg, 0L),
+            (long) CACHE_META_MISS_COUNT.get(seg, 0L),
+            (long) CACHE_META_ENTRY_COUNT.get(seg, 0L),
+            (long) CACHE_META_MEMORY_BYTES.get(seg, 0L),
+            (long) CACHE_META_SIZE_LIMIT_BYTES.get(seg, 0L)
+        );
+        CacheGroupStats statistics = new CacheGroupStats(
+            (long) CACHE_STATS_HIT_COUNT.get(seg, 0L),
+            (long) CACHE_STATS_MISS_COUNT.get(seg, 0L),
+            (long) CACHE_STATS_ENTRY_COUNT.get(seg, 0L),
+            (long) CACHE_STATS_MEMORY_BYTES.get(seg, 0L),
+            (long) CACHE_STATS_SIZE_LIMIT_BYTES.get(seg, 0L)
+        );
+        return new CacheStats(metadata, statistics);
+    }
+
+    /**
+     * Read the search_stats group (15 fields) from the segment.
+     *
+     * @param seg the memory segment containing the DfStatsBuffer
+     * @return a populated SearchStats instance
+     */
+    public static SearchStats readSearchStats(MemorySegment seg) {
+        return new SearchStats(
+            (long) SS_LISTING_TABLE_SCAN.get(seg, 0L),
+            (long) SS_SINGLE_COLLECTOR_SCAN.get(seg, 0L),
+            (long) SS_BITMAP_TREE_SCAN.get(seg, 0L),
+            (long) SS_DELEGATION_CALLS.get(seg, 0L),
+            (long) SS_RG_PROCESSED.get(seg, 0L),
+            (long) SS_RG_SKIPPED.get(seg, 0L),
+            (long) SS_PARQUET_SCAN_TOTAL_TIME_MS.get(seg, 0L),
+            (long) SS_PARQUET_SCAN_UNTIL_DATA_TIME_MS.get(seg, 0L),
+            (long) SS_PARQUET_PROCESSING_TIME_MS.get(seg, 0L),
+            (long) SS_PREFETCH_WAIT_TIME_MS.get(seg, 0L),
+            (long) SS_PREFETCH_WAIT_COUNT.get(seg, 0L),
+            (long) SS_ELAPSED_COMPUTE_MS.get(seg, 0L),
+            (long) SS_BUILD_MASK_TIME_MS.get(seg, 0L),
+            (long) SS_ON_BATCH_MASK_TIME_MS.get(seg, 0L),
+            (long) SS_FILTER_RECORD_BATCH_TIME_MS.get(seg, 0L)
+        );
+    }
+
     // ---- Private helpers ----
 
     private static StructLayout runtimeGroup(String name) {
@@ -242,8 +349,50 @@ public final class StatsLayout {
         ).withName(name);
     }
 
+    private static StructLayout cacheGroup(String name) {
+        return MemoryLayout.structLayout(
+            ValueLayout.JAVA_LONG.withName("hit_count"),
+            ValueLayout.JAVA_LONG.withName("miss_count"),
+            ValueLayout.JAVA_LONG.withName("entry_count"),
+            ValueLayout.JAVA_LONG.withName("memory_bytes"),
+            ValueLayout.JAVA_LONG.withName("size_limit_bytes")
+        ).withName(name);
+    }
+
+    private static StructLayout cacheStatsGroup(String name) {
+        return MemoryLayout.structLayout(cacheGroup("metadata_cache"), cacheGroup("statistics_cache")).withName(name);
+    }
+
+    private static StructLayout searchStatsGroup(String name) {
+        return MemoryLayout.structLayout(
+            ValueLayout.JAVA_LONG.withName("listing_table_scan"),
+            ValueLayout.JAVA_LONG.withName("single_collector_scan"),
+            ValueLayout.JAVA_LONG.withName("bitmap_tree_scan"),
+            ValueLayout.JAVA_LONG.withName("delegation_calls"),
+            ValueLayout.JAVA_LONG.withName("rg_processed"),
+            ValueLayout.JAVA_LONG.withName("rg_skipped"),
+            ValueLayout.JAVA_LONG.withName("parquet_scan_total_time_ms"),
+            ValueLayout.JAVA_LONG.withName("parquet_scan_until_data_time_ms"),
+            ValueLayout.JAVA_LONG.withName("parquet_processing_time_ms"),
+            ValueLayout.JAVA_LONG.withName("prefetch_wait_time_ms"),
+            ValueLayout.JAVA_LONG.withName("prefetch_wait_count"),
+            ValueLayout.JAVA_LONG.withName("elapsed_compute_ms"),
+            ValueLayout.JAVA_LONG.withName("build_mask_time_ms"),
+            ValueLayout.JAVA_LONG.withName("on_batch_mask_time_ms"),
+            ValueLayout.JAVA_LONG.withName("filter_record_batch_time_ms")
+        ).withName(name);
+    }
+
     private static VarHandle handle(String group, String field) {
         return LAYOUT.varHandle(PathElement.groupElement(group), PathElement.groupElement(field));
+    }
+
+    private static VarHandle cacheHandle(String subGroup, String field) {
+        return LAYOUT.varHandle(
+            PathElement.groupElement("cache_stats"),
+            PathElement.groupElement(subGroup),
+            PathElement.groupElement(field)
+        );
     }
 
     private static VarHandle[] runtimeHandles(String group) {

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/stats/CacheGroupStats.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/stats/CacheGroupStats.java
@@ -1,0 +1,118 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion.stats;
+
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.common.io.stream.Writeable;
+import org.opensearch.core.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * Per-cache observability counters: cumulative hit/miss totals plus
+ * point-in-time entry count, memory consumption, and configured size limit.
+ *
+ * <p>An "all zero" instance (in particular {@code size_limit_bytes == 0}) means
+ * the corresponding cache is disabled rather than merely idle.
+ *
+ * <p>{@code hit_rate} is computed at render time and is not part of the wire layout.
+ */
+public class CacheGroupStats implements Writeable {
+
+    /** Cumulative successful {@code get()} calls. */
+    public final long hitCount;
+    /** Cumulative {@code get()} calls that returned no entry. */
+    public final long missCount;
+    /** Number of entries currently held (point-in-time). */
+    public final long entryCount;
+    /** Bytes currently held by the cache (point-in-time). */
+    public final long memoryBytes;
+    /** Configured byte cap. Zero means the cache is disabled. */
+    public final long sizeLimitBytes;
+
+    /**
+     * Construct from explicit field values.
+     *
+     * @param hitCount       cumulative successful gets
+     * @param missCount      cumulative gets that returned no entry
+     * @param entryCount     entries currently held
+     * @param memoryBytes    bytes currently held
+     * @param sizeLimitBytes configured byte cap (0 means disabled)
+     */
+    public CacheGroupStats(long hitCount, long missCount, long entryCount, long memoryBytes, long sizeLimitBytes) {
+        this.hitCount = hitCount;
+        this.missCount = missCount;
+        this.entryCount = entryCount;
+        this.memoryBytes = memoryBytes;
+        this.sizeLimitBytes = sizeLimitBytes;
+    }
+
+    /**
+     * Deserialize from stream.
+     *
+     * @param in the stream input
+     * @throws IOException if deserialization fails
+     */
+    public CacheGroupStats(StreamInput in) throws IOException {
+        this.hitCount = in.readVLong();
+        this.missCount = in.readVLong();
+        this.entryCount = in.readVLong();
+        this.memoryBytes = in.readVLong();
+        this.sizeLimitBytes = in.readVLong();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeVLong(hitCount);
+        out.writeVLong(missCount);
+        out.writeVLong(entryCount);
+        out.writeVLong(memoryBytes);
+        out.writeVLong(sizeLimitBytes);
+    }
+
+    /**
+     * Render the 5 wire fields plus the derived {@code hit_rate} as snake_case JSON fields.
+     *
+     * @param builder the XContent builder to write to
+     * @throws IOException if writing fails
+     */
+    public void toXContent(XContentBuilder builder) throws IOException {
+        builder.field("hit_count", hitCount);
+        builder.field("miss_count", missCount);
+        builder.field("hit_rate", hitRate());
+        builder.field("entry_count", entryCount);
+        builder.field("memory_bytes", memoryBytes);
+        builder.field("size_limit_bytes", sizeLimitBytes);
+    }
+
+    /** Returns {@code hits / (hits + misses)}; {@code 0.0} when the cache has had no traffic. */
+    public double hitRate() {
+        long total = hitCount + missCount;
+        return total == 0 ? 0.0 : (double) hitCount / (double) total;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CacheGroupStats that = (CacheGroupStats) o;
+        return hitCount == that.hitCount
+            && missCount == that.missCount
+            && entryCount == that.entryCount
+            && memoryBytes == that.memoryBytes
+            && sizeLimitBytes == that.sizeLimitBytes;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(hitCount, missCount, entryCount, memoryBytes, sizeLimitBytes);
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/stats/CacheStats.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/stats/CacheStats.java
@@ -1,0 +1,96 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion.stats;
+
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.common.io.stream.Writeable;
+import org.opensearch.core.xcontent.ToXContentFragment;
+import org.opensearch.core.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * Stats for the two parquet caches owned by {@code CustomCacheManager}:
+ * the parquet metadata (footer) cache and the column-statistics cache.
+ *
+ * <p>Each sub-group reports five fields. Disabled caches surface as all-zero
+ * groups (in particular {@code size_limit_bytes == 0}); the JSON shape stays
+ * symmetric so clients can render the response uniformly.
+ */
+public class CacheStats implements Writeable, ToXContentFragment {
+
+    private final CacheGroupStats metadataCache;
+    private final CacheGroupStats statisticsCache;
+
+    /**
+     * Construct from individual sub-group stats.
+     *
+     * @param metadataCache   metadata cache counters (must not be null)
+     * @param statisticsCache statistics cache counters (must not be null)
+     */
+    public CacheStats(CacheGroupStats metadataCache, CacheGroupStats statisticsCache) {
+        this.metadataCache = Objects.requireNonNull(metadataCache);
+        this.statisticsCache = Objects.requireNonNull(statisticsCache);
+    }
+
+    /**
+     * Deserialize from stream.
+     *
+     * @param in the stream input
+     * @throws IOException if deserialization fails
+     */
+    public CacheStats(StreamInput in) throws IOException {
+        this.metadataCache = new CacheGroupStats(in);
+        this.statisticsCache = new CacheGroupStats(in);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        metadataCache.writeTo(out);
+        statisticsCache.writeTo(out);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject("cache_stats");
+        builder.startObject("metadata_cache");
+        metadataCache.toXContent(builder);
+        builder.endObject();
+        builder.startObject("statistics_cache");
+        statisticsCache.toXContent(builder);
+        builder.endObject();
+        builder.endObject();
+        return builder;
+    }
+
+    /** Returns the metadata cache counters. */
+    public CacheGroupStats getMetadataCache() {
+        return metadataCache;
+    }
+
+    /** Returns the statistics cache counters. */
+    public CacheGroupStats getStatisticsCache() {
+        return statisticsCache;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CacheStats that = (CacheStats) o;
+        return Objects.equals(metadataCache, that.metadataCache) && Objects.equals(statisticsCache, that.statisticsCache);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(metadataCache, statisticsCache);
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/stats/DataFusionStats.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/stats/DataFusionStats.java
@@ -20,8 +20,7 @@ import java.util.Objects;
 /**
  * Top-level stats container for the DataFusion backend.
  *
- * <p>Implements {@link Writeable} for transport serialization,
- * {@link Writeable} for transport serialization, and {@link ToXContentFragment}
+ * <p>Implements {@link Writeable} for transport serialization and {@link ToXContentFragment}
  * for JSON rendering.
  *
  * <p>Composes {@link NativeExecutorsStats} rather than duplicating its fields,
@@ -35,14 +34,42 @@ public class DataFusionStats implements Writeable, ToXContentFragment {
     private final PartitionGateStats datanodeGateStats; // nullable
     private final PartitionGateStats coordinatorGateStats; // nullable
     private final SpillStats spillStats; // nullable
+    private final CacheStats cacheStats; // nullable
+    private final SearchStats searchStats; // nullable
 
     /**
-     * Construct from components.
+     * Construct from all components.
      *
      * @param nativeExecutorsStats  the native executor metrics (nullable)
      * @param datanodeGateStats     the datanode partition gate metrics (nullable)
      * @param coordinatorGateStats  the coordinator partition gate metrics (nullable)
-     * @param spillStats            the spill directory stats
+     * @param spillStats            the spill directory stats (nullable)
+     * @param cacheStats            the parquet metadata + statistics cache metrics (nullable)
+     * @param searchStats           the search execution metrics (nullable)
+     */
+    public DataFusionStats(
+        NativeExecutorsStats nativeExecutorsStats,
+        PartitionGateStats datanodeGateStats,
+        PartitionGateStats coordinatorGateStats,
+        SpillStats spillStats,
+        CacheStats cacheStats,
+        SearchStats searchStats
+    ) {
+        this.nativeExecutorsStats = nativeExecutorsStats;
+        this.datanodeGateStats = datanodeGateStats;
+        this.coordinatorGateStats = coordinatorGateStats;
+        this.spillStats = spillStats;
+        this.cacheStats = cacheStats;
+        this.searchStats = searchStats;
+    }
+
+    /**
+     * Construct without cache or search stats. Equivalent to passing {@code null} for both.
+     *
+     * @param nativeExecutorsStats  the native executor metrics (nullable)
+     * @param datanodeGateStats     the datanode partition gate metrics (nullable)
+     * @param coordinatorGateStats  the coordinator partition gate metrics (nullable)
+     * @param spillStats            the spill directory stats (nullable)
      */
     public DataFusionStats(
         NativeExecutorsStats nativeExecutorsStats,
@@ -50,10 +77,7 @@ public class DataFusionStats implements Writeable, ToXContentFragment {
         PartitionGateStats coordinatorGateStats,
         SpillStats spillStats
     ) {
-        this.nativeExecutorsStats = nativeExecutorsStats;
-        this.datanodeGateStats = datanodeGateStats;
-        this.coordinatorGateStats = coordinatorGateStats;
-        this.spillStats = spillStats;
+        this(nativeExecutorsStats, datanodeGateStats, coordinatorGateStats, spillStats, null, null);
     }
 
     /**
@@ -67,6 +91,8 @@ public class DataFusionStats implements Writeable, ToXContentFragment {
         this.datanodeGateStats = in.readOptionalWriteable(PartitionGateStats::new);
         this.coordinatorGateStats = in.readOptionalWriteable(PartitionGateStats::new);
         this.spillStats = in.readOptionalWriteable(SpillStats::new);
+        this.cacheStats = in.readOptionalWriteable(CacheStats::new);
+        this.searchStats = in.readOptionalWriteable(SearchStats::new);
     }
 
     @Override
@@ -75,6 +101,8 @@ public class DataFusionStats implements Writeable, ToXContentFragment {
         out.writeOptionalWriteable(datanodeGateStats);
         out.writeOptionalWriteable(coordinatorGateStats);
         out.writeOptionalWriteable(spillStats);
+        out.writeOptionalWriteable(cacheStats);
+        out.writeOptionalWriteable(searchStats);
     }
 
     @Override
@@ -90,6 +118,12 @@ public class DataFusionStats implements Writeable, ToXContentFragment {
         }
         if (spillStats != null) {
             spillStats.toXContent(builder, params);
+        }
+        if (cacheStats != null) {
+            cacheStats.toXContent(builder, params);
+        }
+        if (searchStats != null) {
+            searchStats.toXContent(builder, params);
         }
         return builder;
     }
@@ -122,6 +156,20 @@ public class DataFusionStats implements Writeable, ToXContentFragment {
         return spillStats;
     }
 
+    /**
+     * Returns the parquet cache metrics, or {@code null} if absent.
+     */
+    public CacheStats getCacheStats() {
+        return cacheStats;
+    }
+
+    /**
+     * Returns the search execution metrics, or {@code null} if absent.
+     */
+    public SearchStats getSearchStats() {
+        return searchStats;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -130,11 +178,13 @@ public class DataFusionStats implements Writeable, ToXContentFragment {
         return Objects.equals(nativeExecutorsStats, that.nativeExecutorsStats)
             && Objects.equals(datanodeGateStats, that.datanodeGateStats)
             && Objects.equals(coordinatorGateStats, that.coordinatorGateStats)
-            && Objects.equals(spillStats, that.spillStats);
+            && Objects.equals(spillStats, that.spillStats)
+            && Objects.equals(cacheStats, that.cacheStats)
+            && Objects.equals(searchStats, that.searchStats);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(nativeExecutorsStats, datanodeGateStats, coordinatorGateStats, spillStats);
+        return Objects.hash(nativeExecutorsStats, datanodeGateStats, coordinatorGateStats, spillStats, cacheStats, searchStats);
     }
 }

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/stats/SearchStats.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/stats/SearchStats.java
@@ -40,6 +40,7 @@ public class SearchStats implements Writeable, ToXContentFragment {
     public final long buildMaskTimeMs;
     public final long onBatchMaskTimeMs;
     public final long filterRecordBatchTimeMs;
+    public final long objectStoreReadTimeMs;
 
     public SearchStats(
         long listingTableScan,
@@ -56,7 +57,8 @@ public class SearchStats implements Writeable, ToXContentFragment {
         long elapsedComputeMs,
         long buildMaskTimeMs,
         long onBatchMaskTimeMs,
-        long filterRecordBatchTimeMs
+        long filterRecordBatchTimeMs,
+        long objectStoreReadTimeMs
     ) {
         this.listingTableScan = listingTableScan;
         this.singleCollectorScan = singleCollectorScan;
@@ -73,6 +75,7 @@ public class SearchStats implements Writeable, ToXContentFragment {
         this.buildMaskTimeMs = buildMaskTimeMs;
         this.onBatchMaskTimeMs = onBatchMaskTimeMs;
         this.filterRecordBatchTimeMs = filterRecordBatchTimeMs;
+        this.objectStoreReadTimeMs = objectStoreReadTimeMs;
     }
 
     public SearchStats(StreamInput in) throws IOException {
@@ -91,6 +94,7 @@ public class SearchStats implements Writeable, ToXContentFragment {
         this.buildMaskTimeMs = in.readVLong();
         this.onBatchMaskTimeMs = in.readVLong();
         this.filterRecordBatchTimeMs = in.readVLong();
+        this.objectStoreReadTimeMs = in.readVLong();
     }
 
     @Override
@@ -110,6 +114,7 @@ public class SearchStats implements Writeable, ToXContentFragment {
         out.writeVLong(buildMaskTimeMs);
         out.writeVLong(onBatchMaskTimeMs);
         out.writeVLong(filterRecordBatchTimeMs);
+        out.writeVLong(objectStoreReadTimeMs);
     }
 
     @Override
@@ -130,6 +135,7 @@ public class SearchStats implements Writeable, ToXContentFragment {
         builder.field("build_mask_time_ms", buildMaskTimeMs);
         builder.field("on_batch_mask_time_ms", onBatchMaskTimeMs);
         builder.field("filter_record_batch_time_ms", filterRecordBatchTimeMs);
+        builder.field("object_store_read_time_ms", objectStoreReadTimeMs);
         builder.endObject();
         return builder;
     }
@@ -153,7 +159,8 @@ public class SearchStats implements Writeable, ToXContentFragment {
             && elapsedComputeMs == that.elapsedComputeMs
             && buildMaskTimeMs == that.buildMaskTimeMs
             && onBatchMaskTimeMs == that.onBatchMaskTimeMs
-            && filterRecordBatchTimeMs == that.filterRecordBatchTimeMs;
+            && filterRecordBatchTimeMs == that.filterRecordBatchTimeMs
+            && objectStoreReadTimeMs == that.objectStoreReadTimeMs;
     }
 
     @Override
@@ -173,7 +180,8 @@ public class SearchStats implements Writeable, ToXContentFragment {
             elapsedComputeMs,
             buildMaskTimeMs,
             onBatchMaskTimeMs,
-            filterRecordBatchTimeMs
+            filterRecordBatchTimeMs,
+            objectStoreReadTimeMs
         );
     }
 }

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/stats/SearchStats.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/stats/SearchStats.java
@@ -1,0 +1,179 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion.stats;
+
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.common.io.stream.Writeable;
+import org.opensearch.core.xcontent.ToXContentFragment;
+import org.opensearch.core.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * Node-level cumulative search execution counters exposed under the
+ * {@code search_stats} key. Each field is a process-global running total
+ * summed across all partitions and queries since startup; values are never
+ * reset between calls.
+ */
+public class SearchStats implements Writeable, ToXContentFragment {
+
+    public final long listingTableScan;
+    public final long singleCollectorScan;
+    public final long bitmapTreeScan;
+    public final long delegationCalls;
+    public final long rgProcessed;
+    public final long rgSkipped;
+    public final long parquetScanTotalTimeMs;
+    public final long parquetScanUntilDataTimeMs;
+    public final long parquetProcessingTimeMs;
+    public final long prefetchWaitTimeMs;
+    public final long prefetchWaitCount;
+    public final long elapsedComputeMs;
+    public final long buildMaskTimeMs;
+    public final long onBatchMaskTimeMs;
+    public final long filterRecordBatchTimeMs;
+
+    public SearchStats(
+        long listingTableScan,
+        long singleCollectorScan,
+        long bitmapTreeScan,
+        long delegationCalls,
+        long rgProcessed,
+        long rgSkipped,
+        long parquetScanTotalTimeMs,
+        long parquetScanUntilDataTimeMs,
+        long parquetProcessingTimeMs,
+        long prefetchWaitTimeMs,
+        long prefetchWaitCount,
+        long elapsedComputeMs,
+        long buildMaskTimeMs,
+        long onBatchMaskTimeMs,
+        long filterRecordBatchTimeMs
+    ) {
+        this.listingTableScan = listingTableScan;
+        this.singleCollectorScan = singleCollectorScan;
+        this.bitmapTreeScan = bitmapTreeScan;
+        this.delegationCalls = delegationCalls;
+        this.rgProcessed = rgProcessed;
+        this.rgSkipped = rgSkipped;
+        this.parquetScanTotalTimeMs = parquetScanTotalTimeMs;
+        this.parquetScanUntilDataTimeMs = parquetScanUntilDataTimeMs;
+        this.parquetProcessingTimeMs = parquetProcessingTimeMs;
+        this.prefetchWaitTimeMs = prefetchWaitTimeMs;
+        this.prefetchWaitCount = prefetchWaitCount;
+        this.elapsedComputeMs = elapsedComputeMs;
+        this.buildMaskTimeMs = buildMaskTimeMs;
+        this.onBatchMaskTimeMs = onBatchMaskTimeMs;
+        this.filterRecordBatchTimeMs = filterRecordBatchTimeMs;
+    }
+
+    public SearchStats(StreamInput in) throws IOException {
+        this.listingTableScan = in.readVLong();
+        this.singleCollectorScan = in.readVLong();
+        this.bitmapTreeScan = in.readVLong();
+        this.delegationCalls = in.readVLong();
+        this.rgProcessed = in.readVLong();
+        this.rgSkipped = in.readVLong();
+        this.parquetScanTotalTimeMs = in.readVLong();
+        this.parquetScanUntilDataTimeMs = in.readVLong();
+        this.parquetProcessingTimeMs = in.readVLong();
+        this.prefetchWaitTimeMs = in.readVLong();
+        this.prefetchWaitCount = in.readVLong();
+        this.elapsedComputeMs = in.readVLong();
+        this.buildMaskTimeMs = in.readVLong();
+        this.onBatchMaskTimeMs = in.readVLong();
+        this.filterRecordBatchTimeMs = in.readVLong();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeVLong(listingTableScan);
+        out.writeVLong(singleCollectorScan);
+        out.writeVLong(bitmapTreeScan);
+        out.writeVLong(delegationCalls);
+        out.writeVLong(rgProcessed);
+        out.writeVLong(rgSkipped);
+        out.writeVLong(parquetScanTotalTimeMs);
+        out.writeVLong(parquetScanUntilDataTimeMs);
+        out.writeVLong(parquetProcessingTimeMs);
+        out.writeVLong(prefetchWaitTimeMs);
+        out.writeVLong(prefetchWaitCount);
+        out.writeVLong(elapsedComputeMs);
+        out.writeVLong(buildMaskTimeMs);
+        out.writeVLong(onBatchMaskTimeMs);
+        out.writeVLong(filterRecordBatchTimeMs);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject("search_stats");
+        builder.field("listing_table_scan", listingTableScan);
+        builder.field("single_collector_scan", singleCollectorScan);
+        builder.field("bitmap_tree_scan", bitmapTreeScan);
+        builder.field("delegation_calls", delegationCalls);
+        builder.field("rg_processed", rgProcessed);
+        builder.field("rg_skipped", rgSkipped);
+        builder.field("parquet_scan_total_time_ms", parquetScanTotalTimeMs);
+        builder.field("parquet_scan_until_data_time_ms", parquetScanUntilDataTimeMs);
+        builder.field("parquet_processing_time_ms", parquetProcessingTimeMs);
+        builder.field("prefetch_wait_time_ms", prefetchWaitTimeMs);
+        builder.field("prefetch_wait_count", prefetchWaitCount);
+        builder.field("elapsed_compute_ms", elapsedComputeMs);
+        builder.field("build_mask_time_ms", buildMaskTimeMs);
+        builder.field("on_batch_mask_time_ms", onBatchMaskTimeMs);
+        builder.field("filter_record_batch_time_ms", filterRecordBatchTimeMs);
+        builder.endObject();
+        return builder;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SearchStats that = (SearchStats) o;
+        return listingTableScan == that.listingTableScan
+            && singleCollectorScan == that.singleCollectorScan
+            && bitmapTreeScan == that.bitmapTreeScan
+            && delegationCalls == that.delegationCalls
+            && rgProcessed == that.rgProcessed
+            && rgSkipped == that.rgSkipped
+            && parquetScanTotalTimeMs == that.parquetScanTotalTimeMs
+            && parquetScanUntilDataTimeMs == that.parquetScanUntilDataTimeMs
+            && parquetProcessingTimeMs == that.parquetProcessingTimeMs
+            && prefetchWaitTimeMs == that.prefetchWaitTimeMs
+            && prefetchWaitCount == that.prefetchWaitCount
+            && elapsedComputeMs == that.elapsedComputeMs
+            && buildMaskTimeMs == that.buildMaskTimeMs
+            && onBatchMaskTimeMs == that.onBatchMaskTimeMs
+            && filterRecordBatchTimeMs == that.filterRecordBatchTimeMs;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+            listingTableScan,
+            singleCollectorScan,
+            bitmapTreeScan,
+            delegationCalls,
+            rgProcessed,
+            rgSkipped,
+            parquetScanTotalTimeMs,
+            parquetScanUntilDataTimeMs,
+            parquetProcessingTimeMs,
+            prefetchWaitTimeMs,
+            prefetchWaitCount,
+            elapsedComputeMs,
+            buildMaskTimeMs,
+            onBatchMaskTimeMs,
+            filterRecordBatchTimeMs
+        );
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/stats/SearchStats.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/stats/SearchStats.java
@@ -34,6 +34,7 @@ public class SearchStats implements Writeable, ToXContentFragment {
     public final long parquetScanTotalTimeMs;
     public final long parquetScanUntilDataTimeMs;
     public final long parquetProcessingTimeMs;
+    public final long parquetBytesScanned;
     public final long prefetchWaitTimeMs;
     public final long prefetchWaitCount;
     public final long elapsedComputeMs;
@@ -52,6 +53,7 @@ public class SearchStats implements Writeable, ToXContentFragment {
         long parquetScanTotalTimeMs,
         long parquetScanUntilDataTimeMs,
         long parquetProcessingTimeMs,
+        long parquetBytesScanned,
         long prefetchWaitTimeMs,
         long prefetchWaitCount,
         long elapsedComputeMs,
@@ -69,6 +71,7 @@ public class SearchStats implements Writeable, ToXContentFragment {
         this.parquetScanTotalTimeMs = parquetScanTotalTimeMs;
         this.parquetScanUntilDataTimeMs = parquetScanUntilDataTimeMs;
         this.parquetProcessingTimeMs = parquetProcessingTimeMs;
+        this.parquetBytesScanned = parquetBytesScanned;
         this.prefetchWaitTimeMs = prefetchWaitTimeMs;
         this.prefetchWaitCount = prefetchWaitCount;
         this.elapsedComputeMs = elapsedComputeMs;
@@ -88,6 +91,7 @@ public class SearchStats implements Writeable, ToXContentFragment {
         this.parquetScanTotalTimeMs = in.readVLong();
         this.parquetScanUntilDataTimeMs = in.readVLong();
         this.parquetProcessingTimeMs = in.readVLong();
+        this.parquetBytesScanned = in.readVLong();
         this.prefetchWaitTimeMs = in.readVLong();
         this.prefetchWaitCount = in.readVLong();
         this.elapsedComputeMs = in.readVLong();
@@ -108,6 +112,7 @@ public class SearchStats implements Writeable, ToXContentFragment {
         out.writeVLong(parquetScanTotalTimeMs);
         out.writeVLong(parquetScanUntilDataTimeMs);
         out.writeVLong(parquetProcessingTimeMs);
+        out.writeVLong(parquetBytesScanned);
         out.writeVLong(prefetchWaitTimeMs);
         out.writeVLong(prefetchWaitCount);
         out.writeVLong(elapsedComputeMs);
@@ -129,6 +134,7 @@ public class SearchStats implements Writeable, ToXContentFragment {
         builder.field("parquet_scan_total_time_ms", parquetScanTotalTimeMs);
         builder.field("parquet_scan_until_data_time_ms", parquetScanUntilDataTimeMs);
         builder.field("parquet_processing_time_ms", parquetProcessingTimeMs);
+        builder.field("parquet_bytes_scanned", parquetBytesScanned);
         builder.field("prefetch_wait_time_ms", prefetchWaitTimeMs);
         builder.field("prefetch_wait_count", prefetchWaitCount);
         builder.field("elapsed_compute_ms", elapsedComputeMs);
@@ -154,6 +160,7 @@ public class SearchStats implements Writeable, ToXContentFragment {
             && parquetScanTotalTimeMs == that.parquetScanTotalTimeMs
             && parquetScanUntilDataTimeMs == that.parquetScanUntilDataTimeMs
             && parquetProcessingTimeMs == that.parquetProcessingTimeMs
+            && parquetBytesScanned == that.parquetBytesScanned
             && prefetchWaitTimeMs == that.prefetchWaitTimeMs
             && prefetchWaitCount == that.prefetchWaitCount
             && elapsedComputeMs == that.elapsedComputeMs
@@ -175,6 +182,7 @@ public class SearchStats implements Writeable, ToXContentFragment {
             parquetScanTotalTimeMs,
             parquetScanUntilDataTimeMs,
             parquetProcessingTimeMs,
+            parquetBytesScanned,
             prefetchWaitTimeMs,
             prefetchWaitCount,
             elapsedComputeMs,

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/nativelib/StatsLayoutPropertyTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/nativelib/StatsLayoutPropertyTests.java
@@ -35,7 +35,7 @@ public class StatsLayoutPropertyTests extends OpenSearchTestCase {
 
     private static final int TRIES = 100;
 
-    private static final int FIELD_COUNT = 67;
+    private static final int FIELD_COUNT = 68;
 
     // ---- Generators ----
 
@@ -187,7 +187,7 @@ public class StatsLayoutPropertyTests extends OpenSearchTestCase {
                 assertEquals(values[50], cs.getStatisticsCache().memoryBytes);
                 assertEquals(values[51], cs.getStatisticsCache().sizeLimitBytes);
 
-                // Search stats (offsets 52-66)
+                // Search stats (offsets 52-67)
                 var ss = StatsLayout.readSearchStats(seg);
                 assertEquals(values[52], ss.listingTableScan);
                 assertEquals(values[53], ss.singleCollectorScan);
@@ -204,6 +204,7 @@ public class StatsLayoutPropertyTests extends OpenSearchTestCase {
                 assertEquals(values[64], ss.buildMaskTimeMs);
                 assertEquals(values[65], ss.onBatchMaskTimeMs);
                 assertEquals(values[66], ss.filterRecordBatchTimeMs);
+                assertEquals(values[67], ss.objectStoreReadTimeMs);
             }
         }
     }
@@ -323,7 +324,8 @@ public class StatsLayoutPropertyTests extends OpenSearchTestCase {
                     ss.elapsedComputeMs,
                     ss.buildMaskTimeMs,
                     ss.onBatchMaskTimeMs,
-                    ss.filterRecordBatchTimeMs };
+                    ss.filterRecordBatchTimeMs,
+                    ss.objectStoreReadTimeMs };
                 for (int i = 0; i < FIELD_COUNT; i++) {
                     reencoded.setAtIndex(ValueLayout.JAVA_LONG, i, decoded[i]);
                 }

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/nativelib/StatsLayoutPropertyTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/nativelib/StatsLayoutPropertyTests.java
@@ -35,7 +35,7 @@ public class StatsLayoutPropertyTests extends OpenSearchTestCase {
 
     private static final int TRIES = 100;
 
-    private static final int FIELD_COUNT = 38;
+    private static final int FIELD_COUNT = 67;
 
     // ---- Generators ----
 
@@ -156,6 +156,54 @@ public class StatsLayoutPropertyTests extends OpenSearchTestCase {
                     assertEquals(tmGroups[g] + ".total_scheduled_duration_ms", values[base + 1], tm.totalScheduledDurationMs);
                     assertEquals(tmGroups[g] + ".total_idle_duration_ms", values[base + 2], tm.totalIdleDurationMs);
                 }
+
+                // Partition gates (offsets 30-41)
+                var dg = StatsLayout.readPartitionGate(seg, "fragment_executor_gate");
+                assertEquals(values[30], dg.maxPermits);
+                assertEquals(values[31], dg.activePermits);
+                assertEquals(values[32], dg.totalWaitDurationMs);
+                assertEquals(values[33], dg.totalBatchesStarted);
+                assertEquals(values[34], dg.poisonPermits);
+                assertEquals(values[35], dg.targetMaxPermits);
+
+                var cg = StatsLayout.readPartitionGate(seg, "reduce_executor_gate");
+                assertEquals(values[36], cg.maxPermits);
+                assertEquals(values[37], cg.activePermits);
+                assertEquals(values[38], cg.totalWaitDurationMs);
+                assertEquals(values[39], cg.totalBatchesStarted);
+                assertEquals(values[40], cg.poisonPermits);
+                assertEquals(values[41], cg.targetMaxPermits);
+
+                // Cache stats (offsets 42-51)
+                var cs = StatsLayout.readCacheStats(seg);
+                assertEquals(values[42], cs.getMetadataCache().hitCount);
+                assertEquals(values[43], cs.getMetadataCache().missCount);
+                assertEquals(values[44], cs.getMetadataCache().entryCount);
+                assertEquals(values[45], cs.getMetadataCache().memoryBytes);
+                assertEquals(values[46], cs.getMetadataCache().sizeLimitBytes);
+                assertEquals(values[47], cs.getStatisticsCache().hitCount);
+                assertEquals(values[48], cs.getStatisticsCache().missCount);
+                assertEquals(values[49], cs.getStatisticsCache().entryCount);
+                assertEquals(values[50], cs.getStatisticsCache().memoryBytes);
+                assertEquals(values[51], cs.getStatisticsCache().sizeLimitBytes);
+
+                // Search stats (offsets 52-66)
+                var ss = StatsLayout.readSearchStats(seg);
+                assertEquals(values[52], ss.listingTableScan);
+                assertEquals(values[53], ss.singleCollectorScan);
+                assertEquals(values[54], ss.bitmapTreeScan);
+                assertEquals(values[55], ss.delegationCalls);
+                assertEquals(values[56], ss.rgProcessed);
+                assertEquals(values[57], ss.rgSkipped);
+                assertEquals(values[58], ss.parquetScanTotalTimeMs);
+                assertEquals(values[59], ss.parquetScanUntilDataTimeMs);
+                assertEquals(values[60], ss.parquetProcessingTimeMs);
+                assertEquals(values[61], ss.prefetchWaitTimeMs);
+                assertEquals(values[62], ss.prefetchWaitCount);
+                assertEquals(values[63], ss.elapsedComputeMs);
+                assertEquals(values[64], ss.buildMaskTimeMs);
+                assertEquals(values[65], ss.onBatchMaskTimeMs);
+                assertEquals(values[66], ss.filterRecordBatchTimeMs);
             }
         }
     }
@@ -201,6 +249,10 @@ public class StatsLayoutPropertyTests extends OpenSearchTestCase {
                 var qe = StatsLayout.readTaskMonitor(original, "query_execution");
                 var sn = StatsLayout.readTaskMonitor(original, "stream_next");
                 var ps = StatsLayout.readTaskMonitor(original, "plan_setup");
+                var dg = StatsLayout.readPartitionGate(original, "fragment_executor_gate");
+                var cg = StatsLayout.readPartitionGate(original, "reduce_executor_gate");
+                var cs = StatsLayout.readCacheStats(original);
+                var ss = StatsLayout.readSearchStats(original);
 
                 // Re-encode into new buffer
                 var reencoded = arena.allocate(StatsLayout.LAYOUT);
@@ -234,14 +286,51 @@ public class StatsLayoutPropertyTests extends OpenSearchTestCase {
                     sn.totalIdleDurationMs,
                     ps.totalPollDurationMs,
                     ps.totalScheduledDurationMs,
-                    ps.totalIdleDurationMs };
-                for (int i = 0; i < decoded.length; i++) {
+                    ps.totalIdleDurationMs,
+                    dg.maxPermits,
+                    dg.activePermits,
+                    dg.totalWaitDurationMs,
+                    dg.totalBatchesStarted,
+                    dg.poisonPermits,
+                    dg.targetMaxPermits,
+                    cg.maxPermits,
+                    cg.activePermits,
+                    cg.totalWaitDurationMs,
+                    cg.totalBatchesStarted,
+                    cg.poisonPermits,
+                    cg.targetMaxPermits,
+                    cs.getMetadataCache().hitCount,
+                    cs.getMetadataCache().missCount,
+                    cs.getMetadataCache().entryCount,
+                    cs.getMetadataCache().memoryBytes,
+                    cs.getMetadataCache().sizeLimitBytes,
+                    cs.getStatisticsCache().hitCount,
+                    cs.getStatisticsCache().missCount,
+                    cs.getStatisticsCache().entryCount,
+                    cs.getStatisticsCache().memoryBytes,
+                    cs.getStatisticsCache().sizeLimitBytes,
+                    ss.listingTableScan,
+                    ss.singleCollectorScan,
+                    ss.bitmapTreeScan,
+                    ss.delegationCalls,
+                    ss.rgProcessed,
+                    ss.rgSkipped,
+                    ss.parquetScanTotalTimeMs,
+                    ss.parquetScanUntilDataTimeMs,
+                    ss.parquetProcessingTimeMs,
+                    ss.prefetchWaitTimeMs,
+                    ss.prefetchWaitCount,
+                    ss.elapsedComputeMs,
+                    ss.buildMaskTimeMs,
+                    ss.onBatchMaskTimeMs,
+                    ss.filterRecordBatchTimeMs };
+                for (int i = 0; i < FIELD_COUNT; i++) {
                     reencoded.setAtIndex(ValueLayout.JAVA_LONG, i, decoded[i]);
                 }
 
-                // Compare byte-for-byte over the decoded prefix
-                byte[] originalBytes = original.asSlice(0, (long) decoded.length * Long.BYTES).toArray(ValueLayout.JAVA_BYTE);
-                byte[] reencodedBytes = reencoded.asSlice(0, (long) decoded.length * Long.BYTES).toArray(ValueLayout.JAVA_BYTE);
+                // Compare byte-for-byte
+                byte[] originalBytes = original.toArray(ValueLayout.JAVA_BYTE);
+                byte[] reencodedBytes = reencoded.toArray(ValueLayout.JAVA_BYTE);
                 assertArrayEquals("Decode-then-reencode must produce byte-identical buffer", originalBytes, reencodedBytes);
             }
         }

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/nativelib/StatsLayoutPropertyTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/nativelib/StatsLayoutPropertyTests.java
@@ -35,7 +35,7 @@ public class StatsLayoutPropertyTests extends OpenSearchTestCase {
 
     private static final int TRIES = 100;
 
-    private static final int FIELD_COUNT = 68;
+    private static final int FIELD_COUNT = 69;
 
     // ---- Generators ----
 
@@ -187,7 +187,7 @@ public class StatsLayoutPropertyTests extends OpenSearchTestCase {
                 assertEquals(values[50], cs.getStatisticsCache().memoryBytes);
                 assertEquals(values[51], cs.getStatisticsCache().sizeLimitBytes);
 
-                // Search stats (offsets 52-67)
+                // Search stats (offsets 52-68)
                 var ss = StatsLayout.readSearchStats(seg);
                 assertEquals(values[52], ss.listingTableScan);
                 assertEquals(values[53], ss.singleCollectorScan);
@@ -198,13 +198,14 @@ public class StatsLayoutPropertyTests extends OpenSearchTestCase {
                 assertEquals(values[58], ss.parquetScanTotalTimeMs);
                 assertEquals(values[59], ss.parquetScanUntilDataTimeMs);
                 assertEquals(values[60], ss.parquetProcessingTimeMs);
-                assertEquals(values[61], ss.prefetchWaitTimeMs);
-                assertEquals(values[62], ss.prefetchWaitCount);
-                assertEquals(values[63], ss.elapsedComputeMs);
-                assertEquals(values[64], ss.buildMaskTimeMs);
-                assertEquals(values[65], ss.onBatchMaskTimeMs);
-                assertEquals(values[66], ss.filterRecordBatchTimeMs);
-                assertEquals(values[67], ss.objectStoreReadTimeMs);
+                assertEquals(values[61], ss.parquetBytesScanned);
+                assertEquals(values[62], ss.prefetchWaitTimeMs);
+                assertEquals(values[63], ss.prefetchWaitCount);
+                assertEquals(values[64], ss.elapsedComputeMs);
+                assertEquals(values[65], ss.buildMaskTimeMs);
+                assertEquals(values[66], ss.onBatchMaskTimeMs);
+                assertEquals(values[67], ss.filterRecordBatchTimeMs);
+                assertEquals(values[68], ss.objectStoreReadTimeMs);
             }
         }
     }
@@ -319,6 +320,7 @@ public class StatsLayoutPropertyTests extends OpenSearchTestCase {
                     ss.parquetScanTotalTimeMs,
                     ss.parquetScanUntilDataTimeMs,
                     ss.parquetProcessingTimeMs,
+                    ss.parquetBytesScanned,
                     ss.prefetchWaitTimeMs,
                     ss.prefetchWaitCount,
                     ss.elapsedComputeMs,

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/nativelib/StatsLayoutTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/nativelib/StatsLayoutTests.java
@@ -20,10 +20,10 @@ import java.lang.foreign.ValueLayout;
  */
 public class StatsLayoutTests extends OpenSearchTestCase {
 
-    /** 7.1: Layout byte size must be 544 (68 × 8). */
+    /** 7.1: Layout byte size must be 552 (69 × 8). */
     public void testLayoutByteSize() {
-        assertEquals(544L, StatsLayout.LAYOUT.byteSize());
-        assertEquals(68 * Long.BYTES, (int) StatsLayout.LAYOUT.byteSize());
+        assertEquals(552L, StatsLayout.LAYOUT.byteSize());
+        assertEquals(69 * Long.BYTES, (int) StatsLayout.LAYOUT.byteSize());
     }
 
     /** 7.2: readRuntimeMetrics decodes 9 known values from io_runtime group. */

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/nativelib/StatsLayoutTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/nativelib/StatsLayoutTests.java
@@ -20,10 +20,10 @@ import java.lang.foreign.ValueLayout;
  */
 public class StatsLayoutTests extends OpenSearchTestCase {
 
-    /** 7.1: Layout byte size must be 336 (42 × 8). */
+    /** 7.1: Layout byte size must be 536 (67 × 8). */
     public void testLayoutByteSize() {
-        assertEquals(336L, StatsLayout.LAYOUT.byteSize());
-        assertEquals(42 * Long.BYTES, (int) StatsLayout.LAYOUT.byteSize());
+        assertEquals(536L, StatsLayout.LAYOUT.byteSize());
+        assertEquals(67 * Long.BYTES, (int) StatsLayout.LAYOUT.byteSize());
     }
 
     /** 7.2: readRuntimeMetrics decodes 9 known values from io_runtime group. */

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/nativelib/StatsLayoutTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/nativelib/StatsLayoutTests.java
@@ -20,10 +20,10 @@ import java.lang.foreign.ValueLayout;
  */
 public class StatsLayoutTests extends OpenSearchTestCase {
 
-    /** 7.1: Layout byte size must be 536 (67 × 8). */
+    /** 7.1: Layout byte size must be 544 (68 × 8). */
     public void testLayoutByteSize() {
-        assertEquals(536L, StatsLayout.LAYOUT.byteSize());
-        assertEquals(67 * Long.BYTES, (int) StatsLayout.LAYOUT.byteSize());
+        assertEquals(544L, StatsLayout.LAYOUT.byteSize());
+        assertEquals(68 * Long.BYTES, (int) StatsLayout.LAYOUT.byteSize());
     }
 
     /** 7.2: readRuntimeMetrics decodes 9 known values from io_runtime group. */

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/stats/CacheStatsTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/stats/CacheStatsTests.java
@@ -1,0 +1,161 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion.stats;
+
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+
+/**
+ * Unit tests for {@link CacheStats} and {@link CacheGroupStats}.
+ *
+ * <p>Covers transport serialization round-trip, JSON rendering shape,
+ * the derived {@code hit_rate}, and equality semantics.
+ */
+public class CacheStatsTests extends OpenSearchTestCase {
+
+    // ---- CacheGroupStats ----
+
+    public void testCacheGroupStatsFieldsArePopulated() {
+        CacheGroupStats g = new CacheGroupStats(10, 2, 5, 4096, 100_000_000);
+        assertEquals(10L, g.hitCount);
+        assertEquals(2L, g.missCount);
+        assertEquals(5L, g.entryCount);
+        assertEquals(4096L, g.memoryBytes);
+        assertEquals(100_000_000L, g.sizeLimitBytes);
+    }
+
+    public void testCacheGroupStatsHitRate() {
+        CacheGroupStats hits = new CacheGroupStats(10, 2, 0, 0, 0);
+        assertEquals(10.0 / 12.0, hits.hitRate(), 1e-9);
+
+        // No traffic must yield 0.0, not NaN
+        CacheGroupStats empty = new CacheGroupStats(0, 0, 0, 0, 0);
+        assertEquals(0.0, empty.hitRate(), 0.0);
+
+        CacheGroupStats pure = new CacheGroupStats(7, 0, 0, 0, 0);
+        assertEquals(1.0, pure.hitRate(), 0.0);
+
+        CacheGroupStats miss = new CacheGroupStats(0, 5, 0, 0, 0);
+        assertEquals(0.0, miss.hitRate(), 0.0);
+    }
+
+    public void testCacheGroupStatsWriteableRoundTrip() throws IOException {
+        CacheGroupStats original = new CacheGroupStats(123, 45, 67, 89_012, 250_000_000);
+        BytesStreamOutput out = new BytesStreamOutput();
+        original.writeTo(out);
+        StreamInput in = out.bytes().streamInput();
+        CacheGroupStats decoded = new CacheGroupStats(in);
+        assertEquals(original, decoded);
+    }
+
+    public void testCacheGroupStatsToXContent() throws IOException {
+        CacheGroupStats g = new CacheGroupStats(10, 2, 5, 4096, 100_000_000);
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        builder.startObject();
+        g.toXContent(builder);
+        builder.endObject();
+        String json = builder.toString();
+
+        assertTrue(json.contains("\"hit_count\":10"));
+        assertTrue(json.contains("\"miss_count\":2"));
+        // Match hit_rate by prefix since the JSON formatting of doubles is not pinned
+        assertTrue("expected hit_rate ≈ 10/12, got: " + json, json.contains("\"hit_rate\":0.833"));
+        assertTrue(json.contains("\"entry_count\":5"));
+        assertTrue(json.contains("\"memory_bytes\":4096"));
+        assertTrue(json.contains("\"size_limit_bytes\":100000000"));
+    }
+
+    public void testCacheGroupStatsEqualsAndHashCode() {
+        CacheGroupStats a = new CacheGroupStats(1, 2, 3, 4, 5);
+        CacheGroupStats b = new CacheGroupStats(1, 2, 3, 4, 5);
+        CacheGroupStats c = new CacheGroupStats(1, 2, 3, 4, 6);
+
+        assertEquals(a, b);
+        assertEquals(a.hashCode(), b.hashCode());
+        assertNotEquals(a, c);
+    }
+
+    // ---- CacheStats ----
+
+    public void testCacheStatsConstructorRejectsNullSubGroups() {
+        expectThrows(NullPointerException.class, () -> new CacheStats(null, new CacheGroupStats(0, 0, 0, 0, 0)));
+        expectThrows(NullPointerException.class, () -> new CacheStats(new CacheGroupStats(0, 0, 0, 0, 0), null));
+    }
+
+    public void testCacheStatsAccessors() {
+        CacheGroupStats meta = new CacheGroupStats(1, 2, 3, 4, 5);
+        CacheGroupStats stats = new CacheGroupStats(6, 7, 8, 9, 10);
+        CacheStats c = new CacheStats(meta, stats);
+
+        assertSame(meta, c.getMetadataCache());
+        assertSame(stats, c.getStatisticsCache());
+    }
+
+    public void testCacheStatsWriteableRoundTrip() throws IOException {
+        CacheStats original = new CacheStats(new CacheGroupStats(11, 12, 13, 14, 15), new CacheGroupStats(21, 22, 23, 24, 25));
+        BytesStreamOutput out = new BytesStreamOutput();
+        original.writeTo(out);
+        StreamInput in = out.bytes().streamInput();
+        CacheStats decoded = new CacheStats(in);
+        assertEquals(original, decoded);
+    }
+
+    public void testCacheStatsToXContentShape() throws IOException {
+        CacheStats c = new CacheStats(new CacheGroupStats(11, 0, 3, 1024, 250_000_000), new CacheGroupStats(0, 7, 0, 0, 100_000_000));
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        builder.startObject();
+        c.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        builder.endObject();
+        String json = builder.toString();
+
+        // Top-level wrapper
+        assertTrue("expected cache_stats wrapper, got: " + json, json.contains("\"cache_stats\""));
+        // Both sub-groups present
+        assertTrue(json.contains("\"metadata_cache\""));
+        assertTrue(json.contains("\"statistics_cache\""));
+        // Per-group fields
+        assertTrue(json.contains("\"hit_count\":11"));
+        assertTrue(json.contains("\"miss_count\":7"));
+        assertTrue(json.contains("\"entry_count\":3"));
+        assertTrue(json.contains("\"memory_bytes\":1024"));
+        assertTrue(json.contains("\"size_limit_bytes\":250000000"));
+        assertTrue(json.contains("\"size_limit_bytes\":100000000"));
+    }
+
+    public void testCacheStatsZeroedRendersAllZeros() throws IOException {
+        CacheStats zero = new CacheStats(new CacheGroupStats(0, 0, 0, 0, 0), new CacheGroupStats(0, 0, 0, 0, 0));
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        builder.startObject();
+        zero.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        builder.endObject();
+        String json = builder.toString();
+
+        // Disabled-cache sentinel: both size_limit_bytes are 0
+        long sizeLimitOccurrences = json.split("\"size_limit_bytes\":0", -1).length - 1;
+        assertEquals("expected size_limit_bytes:0 to appear twice (one per sub-cache)", 2, sizeLimitOccurrences);
+        // hit_rate must not be NaN
+        assertFalse("hit_rate must not be NaN: " + json, json.contains("NaN"));
+    }
+
+    public void testCacheStatsEqualsAndHashCode() {
+        CacheStats a = new CacheStats(new CacheGroupStats(1, 2, 3, 4, 5), new CacheGroupStats(6, 7, 8, 9, 10));
+        CacheStats b = new CacheStats(new CacheGroupStats(1, 2, 3, 4, 5), new CacheGroupStats(6, 7, 8, 9, 10));
+        CacheStats c = new CacheStats(new CacheGroupStats(1, 2, 3, 4, 5), new CacheGroupStats(6, 7, 8, 9, 99));
+
+        assertEquals(a, b);
+        assertEquals(a.hashCode(), b.hashCode());
+        assertNotEquals(a, c);
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/stats/DataFusionStatsPropertyTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/stats/DataFusionStatsPropertyTests.java
@@ -123,6 +123,7 @@ public class DataFusionStatsPropertyTests extends OpenSearchTestCase {
             nonNegLong(),
             nonNegLong(),
             nonNegLong(),
+            nonNegLong(),
             nonNegLong()
         );
     }

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/stats/DataFusionStatsPropertyTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/stats/DataFusionStatsPropertyTests.java
@@ -122,6 +122,7 @@ public class DataFusionStatsPropertyTests extends OpenSearchTestCase {
             nonNegLong(),
             nonNegLong(),
             nonNegLong(),
+            nonNegLong(),
             nonNegLong()
         );
     }

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/stats/DataFusionStatsPropertyTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/stats/DataFusionStatsPropertyTests.java
@@ -98,26 +98,58 @@ public class DataFusionStatsPropertyTests extends OpenSearchTestCase {
         return monitors;
     }
 
+    private CacheGroupStats randomCacheGroupStats() {
+        return new CacheGroupStats(nonNegLong(), nonNegLong(), nonNegLong(), nonNegLong(), nonNegLong());
+    }
+
+    private CacheStats randomCacheStats() {
+        return new CacheStats(randomCacheGroupStats(), randomCacheGroupStats());
+    }
+
+    private SearchStats randomSearchStats() {
+        return new SearchStats(
+            nonNegLong(),
+            nonNegLong(),
+            nonNegLong(),
+            nonNegLong(),
+            nonNegLong(),
+            nonNegLong(),
+            nonNegLong(),
+            nonNegLong(),
+            nonNegLong(),
+            nonNegLong(),
+            nonNegLong(),
+            nonNegLong(),
+            nonNegLong(),
+            nonNegLong(),
+            nonNegLong()
+        );
+    }
+
     private DataFusionStats randomDataFusionStatsCpuPresent() {
         return new DataFusionStats(
             new NativeExecutorsStats(randomRuntimeMetrics(), randomRuntimeMetricsWithPositiveWorkers(), randomTaskMonitors()),
-            new PartitionGateStats("datanode_gate", 12, 0, 0, 0, 0, 12),
-            new PartitionGateStats("coordinator_gate", 12, 0, 0, 0, 0, 12),
-            null
+            new PartitionGateStats("datanode_gate", nonNegLong(), nonNegLong(), nonNegLong(), nonNegLong(), nonNegLong(), nonNegLong()),
+            new PartitionGateStats("coordinator_gate", nonNegLong(), nonNegLong(), nonNegLong(), nonNegLong(), nonNegLong(), nonNegLong()),
+            null,
+            randomCacheStats(),
+            randomSearchStats()
         );
     }
 
     private DataFusionStats randomDataFusionStatsCpuAbsent() {
         return new DataFusionStats(
             new NativeExecutorsStats(randomRuntimeMetrics(), null, randomTaskMonitors()),
-            new PartitionGateStats("datanode_gate", 12, 0, 0, 0, 0, 12),
-            new PartitionGateStats("coordinator_gate", 12, 0, 0, 0, 0, 12),
-            null
+            new PartitionGateStats("datanode_gate", nonNegLong(), nonNegLong(), nonNegLong(), nonNegLong(), nonNegLong(), nonNegLong()),
+            new PartitionGateStats("coordinator_gate", nonNegLong(), nonNegLong(), nonNegLong(), nonNegLong(), nonNegLong(), nonNegLong()),
+            null,
+            randomCacheStats(),
+            randomSearchStats()
         );
     }
 
     private DataFusionStats dataFusionStatsNullExecutors() {
-        return new DataFusionStats(null, null, null, null);
+        return new DataFusionStats(null, null, null, null, null, null);
     }
 
     // ---- Property 1: Writeable round-trip preserves all field values ----
@@ -175,6 +207,28 @@ public class DataFusionStatsPropertyTests extends OpenSearchTestCase {
                 assertEquals(3, monitor.size());
                 verifyTaskMonitorFields(nes.getTaskMonitors().get(opType.key()), monitor, opType.key());
             }
+
+            // Cache stats
+            CacheStats cs = stats.getCacheStats();
+            assertNotNull(cs);
+            Map<String, Object> cacheNode = asMap(root.get("cache_stats"));
+            assertNotNull("cache_stats must be present", cacheNode);
+            Map<String, Object> metaNode = asMap(cacheNode.get("metadata_cache"));
+            assertNotNull(metaNode);
+            assertEquals(cs.getMetadataCache().hitCount, ((Number) metaNode.get("hit_count")).longValue());
+            assertEquals(cs.getMetadataCache().missCount, ((Number) metaNode.get("miss_count")).longValue());
+            Map<String, Object> statsNode = asMap(cacheNode.get("statistics_cache"));
+            assertNotNull(statsNode);
+            assertEquals(cs.getStatisticsCache().hitCount, ((Number) statsNode.get("hit_count")).longValue());
+
+            // Search stats
+            SearchStats ss = stats.getSearchStats();
+            assertNotNull(ss);
+            Map<String, Object> searchNode = asMap(root.get("search_stats"));
+            assertNotNull("search_stats must be present", searchNode);
+            assertEquals(ss.delegationCalls, ((Number) searchNode.get("delegation_calls")).longValue());
+            assertEquals(ss.rgProcessed, ((Number) searchNode.get("rg_processed")).longValue());
+            assertEquals(ss.bitmapTreeScan, ((Number) searchNode.get("bitmap_tree_scan")).longValue());
         }
     }
 

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/stats/DataFusionStatsTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/stats/DataFusionStatsTests.java
@@ -253,4 +253,49 @@ public class DataFusionStatsTests extends OpenSearchTestCase {
             assertEquals(original.getSpillStats(), roundTripped.getSpillStats());
         }
     }
+
+    // ---- Test: cacheStats omitted by default (no cache stats provided → null) ----
+
+    public void testCacheStatsAbsentWhenNotProvided() throws IOException {
+        DataFusionStats stats = sequentialStats();
+        assertNull(stats.getCacheStats());
+
+        String json = toJsonString(stats);
+        assertFalse("cache_stats should be omitted when null", json.contains("cache_stats"));
+    }
+
+    // ---- Test: cacheStats present → renders into JSON ----
+
+    public void testCacheStatsPresentRendersIntoJson() throws IOException {
+        RuntimeMetrics io = new RuntimeMetrics(1, 2, 3, 4, 5, 6, 7, 8, 0);
+        Map<String, TaskMonitorStats> taskMonitors = new LinkedHashMap<>();
+        taskMonitors.put("coordinator_reduce", new TaskMonitorStats(0, 0, 0));
+        taskMonitors.put("query_execution", new TaskMonitorStats(0, 0, 0));
+        taskMonitors.put("stream_next", new TaskMonitorStats(0, 0, 0));
+        taskMonitors.put("plan_setup", new TaskMonitorStats(0, 0, 0));
+
+        CacheStats cache = new CacheStats(
+            new CacheGroupStats(100, 5, 25, 4096, 250_000_000),
+            new CacheGroupStats(50, 0, 25, 2048, 100_000_000)
+        );
+        DataFusionStats stats = new DataFusionStats(
+            new NativeExecutorsStats(io, null, taskMonitors),
+            new PartitionGateStats("datanode_gate", 12, 0, 0, 0, 0, 12),
+            new PartitionGateStats("coordinator_gate", 12, 0, 0, 0, 0, 12),
+            null,
+            cache,
+            null
+        );
+
+        assertSame(cache, stats.getCacheStats());
+
+        String json = toJsonString(stats);
+        assertTrue("cache_stats wrapper expected", json.contains("\"cache_stats\""));
+        assertTrue(json.contains("\"metadata_cache\""));
+        assertTrue(json.contains("\"statistics_cache\""));
+        assertTrue(json.contains("\"hit_count\":100"));
+        assertTrue(json.contains("\"hit_count\":50"));
+        assertTrue(json.contains("\"size_limit_bytes\":250000000"));
+        assertTrue(json.contains("\"size_limit_bytes\":100000000"));
+    }
 }


### PR DESCRIPTION
### Description

Adds `cache_stats` and `search_stats` to `GET _plugins/_analytics_backend_datafusion/stats`.

```json
"cache_stats": {
  "metadata_cache": {
    "hit_count": 0,
    "miss_count": 0,
    "hit_rate": 0.0,
    "entry_count": 0,
    "memory_bytes": 0,
    "size_limit_bytes": 262144000
  },
  "statistics_cache": {
    "hit_count": 0,
    "miss_count": 0,
    "hit_rate": 0.0,
    "entry_count": 0,
    "memory_bytes": 0,
    "size_limit_bytes": 104857600
  }
},
"search_stats": {
  "listing_table_scan": 0,
  "single_collector_scan": 0,
  "bitmap_tree_scan": 0,
  "delegation_calls": 0,
  "rg_processed": 0,
  "rg_skipped": 0,
  "parquet_scan_total_time_ms": 0,
  "parquet_scan_until_data_time_ms": 0,
  "parquet_processing_time_ms": 0,
  "parquet_bytes_scanned": 0,
  "prefetch_wait_time_ms": 0,
  "prefetch_wait_count": 0,
  "elapsed_compute_ms": 0,
  "build_mask_time_ms": 0,
  "on_batch_mask_time_ms": 0,
  "filter_record_batch_time_ms": 0,
  "object_store_read_time_ms": 0
}
```

`size_limit_bytes == 0` means the cache is disabled. All `search_stats` values are cumulative since node start.

#### cache_stats

| Field | Description |
|-------|-------------|
| `hit_count` | Cache lookups that returned a cached entry |
| `miss_count` | Cache lookups that did not find a cached entry |
| `hit_rate` | `hit_count / (hit_count + miss_count)`, 0.0 when no lookups |
| `entry_count` | Current number of entries in the cache |
| `memory_bytes` | Current memory consumed by cached entries |
| `size_limit_bytes` | Configured max memory for this cache (0 = disabled) |

#### search_stats

| Field | Description |
|-------|-------------|
| `listing_table_scan` | Queries routed through the parquet-only scan path |
| `single_collector_scan` | Queries routed through the indexed single-collector path |
| `bitmap_tree_scan` | Queries routed through the indexed bitmap-tree path |
| `delegation_calls` | Total Rust→Java FFM calls to the Lucene collector |
| `rg_processed` | Total row groups scanned |
| `rg_skipped` | Total row groups skipped (zero matching docs) |
| `parquet_scan_total_time_ms` | Inner parquet `time_elapsed_scanning_total`: total wall-clock summed across all record batches, measured from each data request until a batch is produced (scanning + decompression/decoding); per DataFusion this also includes the parent operator's execution time |
| `parquet_scan_until_data_time_ms` | Inner parquet `time_elapsed_scanning_until_data`: wall-clock from when data is first requested until the first record batch is produced (file scanning + first-batch decompression/decoding) |
| `parquet_processing_time_ms` | Inner parquet `time_elapsed_processing`: wall-clock for record batch decompression/decoding (time spent waiting on the FileStream's input) |
| `parquet_bytes_scanned` | Inner parquet `bytes_scanned`: total compressed bytes read from the object store across all row groups |
| `prefetch_wait_time_ms` | Total time the poll thread blocked waiting for Lucene prefetch |
| `prefetch_wait_count` | Total times the poll thread parked for prefetch |
| `elapsed_compute_ms` | Total wall-clock time inside indexed stream `poll_next` |
| `build_mask_time_ms` | Time building BooleanArray mask from candidate RoaringBitmap |
| `on_batch_mask_time_ms` | Time in evaluator bitmap logic per batch (`on_batch_mask`) |
| `filter_record_batch_time_ms` | Time applying Arrow filter to keep matching rows |
| `object_store_read_time_ms` | Cumulative wall-clock spent in object-store reads (`get_range`/`get_ranges`) on the indexed scan path |

#### Additional registered metrics (not exposed via the stats API)

These are registered in the `ExecutionPlanMetricsSet` for richer per-plan observability. They are not surfaced in the stats endpoint response.

| Field | Description |
|-------|-------------|
| `inter_poll_gap` | Cumulative wall-clock time parked between consecutive `poll_next` calls |
| `poll_count` | Total number of `poll_next` invocations |
| `init_prefetch_time` | Time spent in the initial prefetch setup (first poll only) |

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request created, if applicable.
- [ ] Public documentation issue/PR created, if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
