### PR TITLE
[2.19] Add CI mirror and JDK group excludes to avoid Maven Central throttling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -214,7 +214,7 @@ tasks.register("verifyVersions") {
     // Read the list from maven central.
     // Fetch the metadata and parse the xml into Version instances because it's more straight forward here
     // rather than bwcVersion ( VersionCollection ).
-    new URL('https://repo1.maven.org/maven2/org/opensearch/opensearch/maven-metadata.xml').openStream().withStream { s ->
+    new URL('https://ci.opensearch.org/maven2/org/opensearch/opensearch/maven-metadata.xml').openStream().withStream { s ->
       BuildParams.bwcVersions.compareToAuthoritative(
         new XmlParser().parse(s)
           .versioning.versions.version

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -94,8 +94,22 @@ tasks.withType(JavaCompile).configureEach {
  *****************************************************************************/
 
 repositories {
-  mavenCentral()
-  gradlePluginPortal()
+  maven {
+    url = uri("https://ci.opensearch.org/maven2/")
+    content {
+      excludeGroupByRegex "adoptium.*|adoptopenjdk.*|openjdk.*"
+    }
+  }
+  mavenCentral {
+    content {
+      excludeGroupByRegex "adoptium.*|adoptopenjdk.*|openjdk.*"
+    }
+  }
+  gradlePluginPortal {
+    content {
+      excludeGroupByRegex "adoptium.*|adoptopenjdk.*|openjdk.*"
+    }
+  }
 }
 
 dependencies {

--- a/buildSrc/src/integTest/groovy/org/opensearch/gradle/OpenSearchTestBasePluginFuncTest.groovy
+++ b/buildSrc/src/integTest/groovy/org/opensearch/gradle/OpenSearchTestBasePluginFuncTest.groovy
@@ -53,6 +53,7 @@ class OpenSearchTestBasePluginFuncTest extends AbstractGradleFuncTest {
             }
 
             repositories {
+                maven { url = uri("https://ci.opensearch.org/maven2/") }
                 mavenCentral()
             }
 

--- a/buildSrc/src/main/java/org/opensearch/gradle/RepositoriesSetupPlugin.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/RepositoriesSetupPlugin.java
@@ -82,7 +82,14 @@ public class RepositoriesSetupPlugin implements Plugin<Project> {
             // such that we don't have to pass hardcoded files to gradle
             repos.mavenLocal();
         }
-        repos.mavenCentral();
+        repos.maven(repo -> {
+            repo.setName("Maven Cache");
+            repo.setUrl("https://ci.opensearch.org/maven2/");
+            repo.content(descriptor -> descriptor.excludeGroupByRegex("adoptium.*|adoptopenjdk.*|openjdk.*"));
+        });
+        repos.mavenCentral(repo -> {
+            repo.content(descriptor -> descriptor.excludeGroupByRegex("adoptium.*|adoptopenjdk.*|openjdk.*"));
+        });
 
         String luceneVersion = VersionProperties.getLucene();
         if (luceneVersion.contains("-snapshot")) {

--- a/buildSrc/src/main/java/org/opensearch/gradle/RepositoriesSetupPlugin.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/RepositoriesSetupPlugin.java
@@ -87,9 +87,7 @@ public class RepositoriesSetupPlugin implements Plugin<Project> {
             repo.setUrl("https://ci.opensearch.org/maven2/");
             repo.content(descriptor -> descriptor.excludeGroupByRegex("adoptium.*|adoptopenjdk.*|openjdk.*"));
         });
-        repos.mavenCentral(repo -> {
-            repo.content(descriptor -> descriptor.excludeGroupByRegex("adoptium.*|adoptopenjdk.*|openjdk.*"));
-        });
+        repos.mavenCentral(repo -> { repo.content(descriptor -> descriptor.excludeGroupByRegex("adoptium.*|adoptopenjdk.*|openjdk.*")); });
 
         String luceneVersion = VersionProperties.getLucene();
         if (luceneVersion.contains("-snapshot")) {

--- a/buildSrc/src/test/resources/plugin/optional-dependencies.gradle
+++ b/buildSrc/src/test/resources/plugin/optional-dependencies.gradle
@@ -18,6 +18,7 @@ group = "org.custom.group"
 version = '1.0.0'
 
 repositories {
+  maven { url = uri("https://ci.opensearch.org/maven2/") }
   mavenCentral()
 }
 

--- a/buildSrc/src/testKit/opensearch.build/build.gradle
+++ b/buildSrc/src/testKit/opensearch.build/build.gradle
@@ -39,6 +39,7 @@ repositories {
       artifact()
     }
   }
+  maven { url = uri("https://ci.opensearch.org/maven2/") }
   mavenCentral()
 }
 
@@ -53,6 +54,7 @@ repositories {
       artifact()
     }
   }
+  maven { url = uri("https://ci.opensearch.org/maven2/") }
   mavenCentral()
 }
 

--- a/buildSrc/src/testKit/testingConventions/build.gradle
+++ b/buildSrc/src/testKit/testingConventions/build.gradle
@@ -18,6 +18,7 @@ allprojects {
   apply plugin: 'opensearch.build'
 
   repositories {
+    maven { url = uri("https://ci.opensearch.org/maven2/") }
     mavenCentral()
   }
   dependencies {

--- a/buildSrc/src/testKit/thirdPartyAudit/build.gradle
+++ b/buildSrc/src/testKit/thirdPartyAudit/build.gradle
@@ -36,6 +36,7 @@ repositories {
       artifact()
     }
   }
+  maven { url = uri("https://ci.opensearch.org/maven2/") }
   mavenCentral()
 }
 

--- a/buildSrc/src/testKit/thirdPartyAudit/sample_jars/build.gradle
+++ b/buildSrc/src/testKit/thirdPartyAudit/sample_jars/build.gradle
@@ -13,6 +13,7 @@ plugins {
   id 'java'
 }
 repositories {
+  maven { url = uri("https://ci.opensearch.org/maven2/") }
   mavenCentral()
 }
 

--- a/doc-tools/build.gradle
+++ b/doc-tools/build.gradle
@@ -8,5 +8,15 @@ base {
 }
 
 repositories {
-    mavenCentral()
+    maven {
+        url = uri("https://ci.opensearch.org/maven2/")
+        content {
+            excludeGroupByRegex "adoptium.*|adoptopenjdk.*|openjdk.*"
+        }
+    }
+    mavenCentral {
+        content {
+            excludeGroupByRegex "adoptium.*|adoptopenjdk.*|openjdk.*"
+        }
+    }
 }

--- a/gradle/code-coverage.gradle
+++ b/gradle/code-coverage.gradle
@@ -9,8 +9,22 @@
 apply plugin: 'jacoco'
 
 repositories {
-  mavenCentral()
-  gradlePluginPortal()
+  maven {
+    url = "https://ci.opensearch.org/maven2/"
+    content {
+      excludeGroupByRegex "adoptium.*|adoptopenjdk.*|openjdk.*"
+    }
+  }
+  mavenCentral {
+    content {
+      excludeGroupByRegex "adoptium.*|adoptopenjdk.*|openjdk.*"
+    }
+  }
+  gradlePluginPortal {
+    content {
+      excludeGroupByRegex "adoptium.*|adoptopenjdk.*|openjdk.*"
+    }
+  }
   // TODO: Find the way to use the repositories from RepositoriesSetupPlugin
   maven {
     url = "https://ci.opensearch.org/ci/dbc/snapshots/lucene/"

--- a/gradle/ide.gradle
+++ b/gradle/ide.gradle
@@ -16,6 +16,9 @@ import org.jetbrains.gradle.ext.JUnit
 buildscript {
   repositories {
     maven {
+      url = "https://ci.opensearch.org/maven2/"
+    }
+    maven {
       url = "https://plugins.gradle.org/m2/"
     }
   }

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -171,7 +171,7 @@ def japicmpCompareTarget = System.getProperty("japicmp.compare.version")
 if (japicmpCompareTarget == null) { /* use latest released version */
     // Read the list from maven central.
     // Fetch the metadata and parse the xml into Version instances, pick the latest one
-    japicmpCompareTarget = new URL('https://repo1.maven.org/maven2/org/opensearch/opensearch/maven-metadata.xml').openStream().withStream { s ->
+    japicmpCompareTarget = new URL('https://ci.opensearch.org/maven2/org/opensearch/opensearch/maven-metadata.xml').openStream().withStream { s ->
         new XmlParser().parse(s)
            .versioning.versions.version
            .collect { it.text() }.findAll { it ==~ /\d+\.\d+\.\d+/ }

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,6 +9,27 @@
  * GitHub history for details.
  */
 
+pluginManagement {
+  repositories {
+    maven {
+      url = uri("https://ci.opensearch.org/maven2/")
+      content {
+        excludeGroupByRegex "adoptium.*|adoptopenjdk.*|openjdk.*"
+      }
+    }
+    gradlePluginPortal {
+      content {
+        excludeGroupByRegex "adoptium.*|adoptopenjdk.*|openjdk.*"
+      }
+    }
+    mavenCentral {
+      content {
+        excludeGroupByRegex "adoptium.*|adoptopenjdk.*|openjdk.*"
+      }
+    }
+  }
+}
+
 plugins {
   id "com.gradle.develocity" version "3.19"
 }


### PR DESCRIPTION
### Description

Backport of #21853 to the 2.19 branch. Adds CI mirror and JDK/JRE group excludes to avoid Maven Central 429 throttling during builds.

### Changes
- `settings.gradle` — Add `pluginManagement` block with CI mirror and JDK group excludes
- `buildSrc/build.gradle` — Add CI mirror, add excludes to mavenCentral and gradlePluginPortal
- `RepositoriesSetupPlugin.java` — Add Maven Cache repo before mavenCentral, exclude JDK groups from both
- `gradle/ide.gradle` — Add CI mirror to buildscript repositories
- `gradle/code-coverage.gradle` — Add CI mirror + excludes
- `server/build.gradle` — CI mirror for japicmp metadata
- `build.gradle` — CI mirror for version metadata
- `doc-tools/build.gradle` — CI mirror + excludes
- Test/testKit files — Add CI mirror before mavenCentral

### Motivation

BWC builds of 2.19 are failing with HTTP 429 from Maven Central during gradle-check on main.