### PR TITLE
Fix two replication races in DataFormatAwareEngine flush

### DIFF
--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/index/LuceneCommitter.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/index/LuceneCommitter.java
@@ -99,6 +99,9 @@ public class LuceneCommitter extends SafeBootstrapCommitter {
     private final MergeIndexWriter indexWriter;
     private final LuceneCommitDeletionPolicy deletionPolicy;
     private final AtomicBoolean isClosed = new AtomicBoolean();
+
+    /** Cached latest committed {@link SegmentInfos}; refreshed inside {@link #commit}, read by {@link #getCommitStats}. */
+    private volatile SegmentInfos lastCommittedSegmentInfos;
     // Keyed by catalog snapshot generation — survives snapshot cloning at the upload boundary.
     private final Map<Long, LuceneReader> readers = new ConcurrentHashMap<>();
 
@@ -118,6 +121,7 @@ public class LuceneCommitter extends SafeBootstrapCommitter {
             this.deletionPolicy = new LuceneCommitDeletionPolicy();
             IndexWriterConfig iwc = createIndexWriterConfig(committerConfig);
             this.indexWriter = new MergeIndexWriter(store.directory(), iwc);
+            this.lastCommittedSegmentInfos = SegmentInfos.readLatestCommit(indexWriter.getDirectory());
         } catch (Exception e) {
             store.decRef();
             throw e;
@@ -140,6 +144,7 @@ public class LuceneCommitter extends SafeBootstrapCommitter {
         indexWriter.setLiveCommitData(commitData.userData());
         indexWriter.commit();
         SegmentInfos committed = SegmentInfos.readLatestCommit(indexWriter.getDirectory());
+        this.lastCommittedSegmentInfos = committed;
 
         // Encode writer's Lucene version as a long — keeps CatalogSnapshot Lucene-type-agnostic.
         long version = LuceneVersionConverter.encode(committed.getCommitLuceneVersion());
@@ -189,20 +194,13 @@ public class LuceneCommitter extends SafeBootstrapCommitter {
     }
 
     /**
-     * Returns commit statistics derived from the latest committed segment infos.
-     *
-     * @return the commit stats, or {@code null} if segment infos cannot be read
+     * Returns commit stats from the cached {@link SegmentInfos} to avoid a per-call disk read
+     * (which validates referenced files and races with concurrent merges).
      */
     @Override
     public CommitStats getCommitStats() {
         ensureOpen();
-        try {
-            SegmentInfos segmentInfos = SegmentInfos.readLatestCommit(indexWriter.getDirectory());
-            return new CommitStats(segmentInfos);
-        } catch (IOException e) {
-            logger.warn("Failed to read segment infos for commit stats", e);
-            return null;
-        }
+        return new CommitStats(lastCommittedSegmentInfos);
     }
 
     @Override

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/index/LuceneReplicaCommitter.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/index/LuceneReplicaCommitter.java
@@ -20,7 +20,6 @@ import org.opensearch.index.engine.exec.coord.LuceneVersionConverter;
 import org.opensearch.index.store.Store;
 
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.io.UnsupportedEncodingException;
 import java.util.HashMap;
 import java.util.List;
@@ -102,13 +101,13 @@ public class LuceneReplicaCommitter implements Committer {
         return lastCommittedSegmentInfos.getUserData();
     }
 
+    /**
+     * Returns commit stats from the cached {@link SegmentInfos} to avoid a per-call disk read
+     * (which races with concurrent segment replication and surfaces as Store corruption).
+     */
     @Override
     public CommitStats getCommitStats() {
-        try {
-            return new CommitStats(store.readLastCommittedSegmentsInfo());
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
+        return new CommitStats(lastCommittedSegmentInfos);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/index/engine/DataFormatAwareEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/DataFormatAwareEngine.java
@@ -1001,69 +1001,80 @@ public class DataFormatAwareEngine implements Indexer {
                 flushLock.lock();
             }
             try {
-                // Refresh first to flush buffered data to segments
-                refresh("flush");
-                translogManager.rollTranslogGeneration();
-                // Persist the latest catalog snapshot so it survives restart
-                try (GatedConditionalCloseable<CatalogSnapshot> snapshotRef = catalogSnapshotManager.acquireSnapshotForCommit()) {
-                    CatalogSnapshot snapshot = snapshotRef.get();
-                    Map<String, String> lastCommitData = committer.getLastCommittedData();
-                    String lastCommittedSnapshotId = lastCommitData.get(CatalogSnapshot.CATALOG_SNAPSHOT_ID);
-                    // commit only if last committed CS id is different from the one we are about to commit or if force param is true
-                    if (force || lastCommittedSnapshotId == null || snapshot.getId() != Long.parseLong(lastCommittedSnapshotId)) {
-                        // Sync translog before commit so the global checkpoint is persisted
-                        // and available to the deletion policy when onCommit is triggered.
-                        translogManager.ensureCanFlush();
-                        translogManager.syncTranslog();
-                        Map<String, String> commitData = new HashMap<>();
-                        commitData.put(CatalogSnapshot.LAST_COMPOSITE_WRITER_GEN_KEY, Long.toString(snapshot.getLastWriterGeneration()));
-                        commitData.put(CatalogSnapshot.CATALOG_SNAPSHOT_ID, Long.toString(snapshot.getId()));
-                        commitData.put(Translog.TRANSLOG_UUID_KEY, translogManager.getTranslogUUID());
-                        commitData.put(
-                            SequenceNumbers.LOCAL_CHECKPOINT_KEY,
-                            Long.toString(localCheckpointTracker.getProcessedCheckpoint())
-                        );
-                        commitData.put(SequenceNumbers.MAX_SEQ_NO, Long.toString(localCheckpointTracker.getMaxSeqNo()));
-                        commitData.put(MAX_UNSAFE_AUTO_ID_TIMESTAMP_COMMIT_ID, Long.toString(maxUnsafeAutoIdTimestamp.get()));
-                        commitData.put(Engine.HISTORY_UUID_KEY, historyUUID);
+                // Hold refreshLock across the whole flush so a concurrent refresh cannot advance
+                // latestCatalogSnapshot between commit() and updateLastCommitInfo(). Reentrant.
+                refreshLock.lock();
+                try {
+                    // Refresh first to flush buffered data to segments
+                    refresh("flush");
+                    translogManager.rollTranslogGeneration();
+                    // Persist the latest catalog snapshot so it survives restart
+                    try (GatedConditionalCloseable<CatalogSnapshot> snapshotRef = catalogSnapshotManager.acquireSnapshotForCommit()) {
+                        CatalogSnapshot snapshot = snapshotRef.get();
+                        Map<String, String> lastCommitData = committer.getLastCommittedData();
+                        String lastCommittedSnapshotId = lastCommitData.get(CatalogSnapshot.CATALOG_SNAPSHOT_ID);
+                        // commit only if last committed CS id is different from the one we are about to commit or if force param is true
+                        if (force || lastCommittedSnapshotId == null || snapshot.getId() != Long.parseLong(lastCommittedSnapshotId)) {
+                            // Sync translog before commit so the global checkpoint is persisted
+                            // and available to the deletion policy when onCommit is triggered.
+                            translogManager.ensureCanFlush();
+                            translogManager.syncTranslog();
+                            Map<String, String> commitData = new HashMap<>();
+                            commitData.put(
+                                CatalogSnapshot.LAST_COMPOSITE_WRITER_GEN_KEY,
+                                Long.toString(snapshot.getLastWriterGeneration())
+                            );
+                            commitData.put(CatalogSnapshot.CATALOG_SNAPSHOT_ID, Long.toString(snapshot.getId()));
+                            commitData.put(Translog.TRANSLOG_UUID_KEY, translogManager.getTranslogUUID());
+                            commitData.put(
+                                SequenceNumbers.LOCAL_CHECKPOINT_KEY,
+                                Long.toString(localCheckpointTracker.getProcessedCheckpoint())
+                            );
+                            commitData.put(SequenceNumbers.MAX_SEQ_NO, Long.toString(localCheckpointTracker.getMaxSeqNo()));
+                            commitData.put(MAX_UNSAFE_AUTO_ID_TIMESTAMP_COMMIT_ID, Long.toString(maxUnsafeAutoIdTimestamp.get()));
+                            commitData.put(Engine.HISTORY_UUID_KEY, historyUUID);
 
-                        // Update snapshot userData so deletion policy can read max_seq_no
-                        snapshot.setUserData(commitData, true);
+                            // Update snapshot userData so deletion policy can read max_seq_no
+                            snapshot.setUserData(commitData, true);
 
-                        // Now add snapshot to commit data so it has latest snapshot
-                        commitData.put(CatalogSnapshot.CATALOG_SNAPSHOT_KEY, snapshot.serializeToString());
+                            // Now add snapshot to commit data so it has latest snapshot
+                            commitData.put(CatalogSnapshot.CATALOG_SNAPSHOT_KEY, snapshot.serializeToString());
 
-                        // Commit data must contain all keys required for recovery
-                        assert commitData.containsKey(CatalogSnapshot.CATALOG_SNAPSHOT_KEY) : "commit data missing catalog snapshot";
-                        assert commitData.containsKey(Translog.TRANSLOG_UUID_KEY) : "commit data missing translog UUID";
-                        assert commitData.containsKey(SequenceNumbers.LOCAL_CHECKPOINT_KEY) : "commit data missing local checkpoint";
-                        assert commitData.containsKey(SequenceNumbers.MAX_SEQ_NO) : "commit data missing max seq no";
-                        assert commitData.containsKey(Engine.HISTORY_UUID_KEY) : "commit data missing history UUID";
-                        assert snapshot.getId() >= 0 : "snapshot ID must be non-negative but was: " + snapshot.getId();
-                        assert Long.parseLong(commitData.get(SequenceNumbers.LOCAL_CHECKPOINT_KEY)) >= -1
-                            : "local checkpoint in commit data must be >= -1";
-                        assert Long.parseLong(commitData.get(SequenceNumbers.MAX_SEQ_NO)) >= -1 : "max seq no in commit data must be >= -1";
+                            // Commit data must contain all keys required for recovery
+                            assert commitData.containsKey(CatalogSnapshot.CATALOG_SNAPSHOT_KEY) : "commit data missing catalog snapshot";
+                            assert commitData.containsKey(Translog.TRANSLOG_UUID_KEY) : "commit data missing translog UUID";
+                            assert commitData.containsKey(SequenceNumbers.LOCAL_CHECKPOINT_KEY) : "commit data missing local checkpoint";
+                            assert commitData.containsKey(SequenceNumbers.MAX_SEQ_NO) : "commit data missing max seq no";
+                            assert commitData.containsKey(Engine.HISTORY_UUID_KEY) : "commit data missing history UUID";
+                            assert snapshot.getId() >= 0 : "snapshot ID must be non-negative but was: " + snapshot.getId();
+                            assert Long.parseLong(commitData.get(SequenceNumbers.LOCAL_CHECKPOINT_KEY)) >= -1
+                                : "local checkpoint in commit data must be >= -1";
+                            assert Long.parseLong(commitData.get(SequenceNumbers.MAX_SEQ_NO)) >= -1
+                                : "max seq no in commit data must be >= -1";
 
-                        // We do an additional commit on engine start due to no catalog snapshot present in earlier commit during empty
-                        // recovery
-                        Committer.CommitResult commitResult = committer.commit(
-                            new Committer.CommitInput(commitData.entrySet(), snapshot, 0)
-                        );
+                            // We do an additional commit on engine start due to no catalog snapshot present in earlier commit during empty
+                            // recovery
+                            Committer.CommitResult commitResult = committer.commit(
+                                new Committer.CommitInput(commitData.entrySet(), snapshot, 0)
+                            );
 
-                        if (commitResult != null && snapshot instanceof DataformatAwareCatalogSnapshot dfaSnapshot) {
-                            // If the catalog snapshot changed during the flush, this will ensure the latest one
-                            // has the commit format.
-                            // Any new snapshots created post this should track this commit info.
-                            catalogSnapshotManager.updateLastCommitInfo(commitResult);
+                            if (commitResult != null && snapshot instanceof DataformatAwareCatalogSnapshot dfaSnapshot) {
+                                // If the catalog snapshot changed during the flush, this will ensure the latest one
+                                // has the commit format.
+                                // Any new snapshots created post this should track this commit info.
+                                catalogSnapshotManager.updateLastCommitInfo(commitResult);
+                            }
+                            snapshotRef.markSuccess();
+                            translogManager.trimUnreferencedReaders();
                         }
-                        snapshotRef.markSuccess();
-                        translogManager.trimUnreferencedReaders();
                     }
-                }
-                logger.trace("flush completed");
+                    logger.trace("flush completed");
 
-                // Notify stats cache that flush completed to refresh committed state
-                statsCache.onFlushCompleted();
+                    // Notify stats cache that flush completed to refresh committed state
+                    statsCache.onFlushCompleted();
+                } finally {
+                    refreshLock.unlock();
+                }
             } catch (AlreadyClosedException e) {
                 failOnTragicEvent(e);
                 throw e;


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
## Bugs
  
  Under heavy ingestion + primary kill, two races in `DataFormatAwareEngine` cause replication failures:
  
  ### Bug 1 — Store corruption from `getCommitStats()`
  
  ReplicationFailedException[Store corruption during replication]
    → CorruptIndexException → NoSuchFileException [_X.si]
      at LuceneReplicaCommitter.getCommitStats / LuceneCommitter.getCommitStats
  
  `getCommitStats()` calls `SegmentInfos.readLatestCommit(directory)` on every invocation. `readCommit` validates referenced segment files; under concurrent merges they can be
  transiently missing, failing the engine.
  
  ### Bug 2 — Stale `lastCommitFileName` on the just-committed snapshot
  
  RecoveryFailedException → Phase[1] sendFileStep failed
    → NoSuchFileException [.../indices/<UUID>/0/index/segments_<N>]
  
  A concurrent refresh between `committer.commit()` and `updateLastCommitInfo()` advances `latestCatalogSnapshot`. `updateLastCommitInfo` then writes to the new snapshot, while the
  snapshot we just committed enters `committedSnapshots` with its inherited (stale) `lastCommitFileName`. Peer-recovery later reads that stale name and hits a deleted `segments_<N>`.
  
  ## Fixes
  
  1. **Cache `SegmentInfos`** in `LuceneCommitter` and `LuceneReplicaCommitter`. Populated in the constructor, refreshed inside `synchronized commit()`. `getCommitStats()` reads from
  cache — no disk validation, no race. Mirrors vanilla `InternalEngine.lastCommittedSegmentInfos`.
  
  2. **Hold `refreshLock` across the entire `flush()` body** in `DataFormatAwareEngine`. Refresh acquires this lock too, so concurrent `commitNewSnapshot` is serialized with flush.
  `refreshLock` is reentrant, so the inner `refresh("flush")` re-acquires safely.
  
  ## Validation
  
  5x `test3-v3` runs (kill primary mid-ingestion, 50 bulk clients, 20% ClickBench):
  
  | Metric | Pre-fix | This PR |
  |---|---|---|
  | Hard failures (cluster RED) | 2 of 6 (33%) | **0 of 5** |
  | `Store corruption` | 1+ per run | **0** |
  | `NoSuchFileException [segments_<N>]` | observed | **0** |
### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
