### PR TITLE
Add data-format-aware stats APIs (Plugin.nodeStats + dataformat_stats endpoint)

### DIFF
--- a/sandbox/libs/plugin-stats-spi/build.gradle
+++ b/sandbox/libs/plugin-stats-spi/build.gradle
@@ -1,0 +1,22 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * SPI interfaces for plugin-level statistics.
+ * Provides DataFormatShardStats and DataFormatShardStatsTracker contracts
+ * that data format plugins (Lucene, Parquet, etc.) implement.
+ */
+
+java { sourceCompatibility = JavaVersion.toVersion(25); targetCompatibility = JavaVersion.toVersion(25) }
+
+// no tests for now
+testingConventions.enabled = false
+
+dependencies {
+    compileOnly project(':server')
+}

--- a/sandbox/libs/plugin-stats-spi/src/main/java/org/opensearch/plugin/stats/DataFormatShardStats.java
+++ b/sandbox/libs/plugin-stats-spi/src/main/java/org/opensearch/plugin/stats/DataFormatShardStats.java
@@ -1,0 +1,43 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.stats;
+
+import org.opensearch.common.annotation.ExperimentalApi;
+import org.opensearch.core.common.io.stream.Writeable;
+import org.opensearch.core.xcontent.ToXContentFragment;
+
+/**
+ * Marker interface for shard-level statistics emitted by a {@link DataFormatStatsProvider}.
+ *
+ * <p>Implementations supply both wire-format serialization ({@link Writeable}) and REST
+ * rendering ({@link ToXContentFragment}). The single behavioral method is {@link #add},
+ * which lets each format define its own per-counter aggregation rules (e.g., sum for
+ * monotonic counters, max for high-water marks, last-write-wins for gauges).
+ *
+ * <p>The recursive type bound {@code T extends DataFormatShardStats<T>} lets the coordinator
+ * merge typed snapshots without casting and without relying on generic JSON re-parsing.
+ *
+ * @param <T> concrete implementing class (e.g., {@code ParquetShardStats})
+ *
+ * @opensearch.experimental
+ */
+@ExperimentalApi
+public interface DataFormatShardStats<T extends DataFormatShardStats<T>> extends Writeable, ToXContentFragment {
+
+    /**
+     * Merge this snapshot with another and return the combined result.
+     *
+     * <p>Each implementation chooses the per-counter rule (sum, max, min, last). Counters
+     * that monotonically grow (e.g., {@code docs_indexed_total}) are typically summed;
+     * gauges and high-water marks (e.g., {@code current_generation}) are typically maxed.
+     *
+     * <p>Implementations should be pure (no mutation of {@code this} or {@code other}).
+     */
+    T add(T other);
+}

--- a/sandbox/libs/plugin-stats-spi/src/main/java/org/opensearch/plugin/stats/DataFormatStatsProvider.java
+++ b/sandbox/libs/plugin-stats-spi/src/main/java/org/opensearch/plugin/stats/DataFormatStatsProvider.java
@@ -1,0 +1,74 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.stats;
+
+import org.opensearch.common.annotation.ExperimentalApi;
+import org.opensearch.core.common.io.stream.Writeable;
+import org.opensearch.core.index.shard.ShardId;
+
+import java.util.Optional;
+
+/**
+ * SPI implemented by each data-format plugin to expose its stats via the per-format
+ * REST endpoints:
+ * <ul>
+ *   <li>{@code GET /_plugins/{formatName}/{index}/_stats}</li>
+ *   <li>{@code GET /_plugins/{formatName}/_nodes/[{nodeId}/]_stats}</li>
+ * </ul>
+ *
+ * <p>Each plugin owns its endpoints — the plugin registers REST handlers and transport
+ * actions itself in its {@code getRestHandlers()} / {@code getActions()}. Composite-engine
+ * has no role in stats endpoint registration.
+ *
+ * <p>Adding a new data format:
+ * <ol>
+ *   <li>Implement this interface in the new format's plugin</li>
+ *   <li>Register it via {@code new MyStatsProvider()} in the plugin's
+ *       {@code createGuiceModules()} so the registry is populated</li>
+ *   <li>Subclass the SPI's transport bases and register them via
+ *       {@code ActionPlugin.getActions()} / {@code getRestHandlers()}</li>
+ * </ol>
+ *
+ * @param <T> concrete shard-stats type (e.g., {@code ParquetShardStats})
+ *
+ * @opensearch.experimental
+ */
+@ExperimentalApi
+public interface DataFormatStatsProvider<T extends DataFormatShardStats<T>> {
+
+    /**
+     * Identifier for this data format. Used as the URL path component
+     * (e.g., {@code "parquet"} maps to {@code /_plugins/parquet/...}).
+     * Must be unique across all data format plugins loaded.
+     */
+    String formatName();
+
+    /**
+     * Returns shard-level stats for the given shard, or empty if this format
+     * has no engine for that shard (e.g., the format is not configured on the index).
+     *
+     * <p>Called on the data node that hosts the shard, by the per-index transport.
+     */
+    Optional<T> shardStats(ShardId shardId);
+
+    /**
+     * Returns aggregate stats summed across all shards of this format on the
+     * local node, or empty if no shards of this format are present on this node.
+     *
+     * <p>Called on each target node by the per-node transport.
+     */
+    Optional<T> aggregateNodeStats();
+
+    /**
+     * Reader for deserializing wire-encoded stats from another node. Used by
+     * the transport to reconstruct {@link DataFormatShardStats} sent across
+     * the cluster.
+     */
+    Writeable.Reader<T> shardStatsReader();
+}

--- a/sandbox/libs/plugin-stats-spi/src/main/java/org/opensearch/plugin/stats/DataFormatStatsProviderRegistry.java
+++ b/sandbox/libs/plugin-stats-spi/src/main/java/org/opensearch/plugin/stats/DataFormatStatsProviderRegistry.java
@@ -1,0 +1,54 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.stats;
+
+import org.opensearch.common.annotation.ExperimentalApi;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * JVM-wide registry of {@link DataFormatStatsProvider} instances.
+ *
+ * <p>Each data-format plugin registers its provider here on construction. The registry
+ * acts as a thin shared lookup so engines can self-register their per-shard trackers
+ * with the right provider via {@link #get(String)}.
+ *
+ * <p>The SPI library is loaded by composite-engine's classloader and shared with
+ * dependent plugins via {@code extendedPlugins}, so a single registry instance is
+ * shared across all plugins in a node JVM.
+ *
+ * @opensearch.experimental
+ */
+@ExperimentalApi
+public final class DataFormatStatsProviderRegistry {
+
+    public static final DataFormatStatsProviderRegistry INSTANCE = new DataFormatStatsProviderRegistry();
+
+    private final ConcurrentMap<String, DataFormatStatsProvider<?>> providers = new ConcurrentHashMap<>();
+
+    private DataFormatStatsProviderRegistry() {}
+
+    /** Registers a provider. First writer wins for a given format name. */
+    public void register(DataFormatStatsProvider<?> provider) {
+        providers.putIfAbsent(provider.formatName(), provider);
+    }
+
+    /** Returns the provider for a format, or {@code null} if no plugin has registered it. */
+    public DataFormatStatsProvider<?> get(String formatName) {
+        return providers.get(formatName);
+    }
+
+    /** Returns an unmodifiable snapshot of all registered providers. */
+    public Collection<DataFormatStatsProvider<?>> all() {
+        return Collections.unmodifiableCollection(providers.values());
+    }
+}

--- a/sandbox/libs/plugin-stats-spi/src/main/java/org/opensearch/plugin/stats/StatsRecorder.java
+++ b/sandbox/libs/plugin-stats-spi/src/main/java/org/opensearch/plugin/stats/StatsRecorder.java
@@ -1,0 +1,116 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.stats;
+
+import java.io.IOException;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.function.LongConsumer;
+
+/**
+ * Common utility for recording wall-clock elapsed time around stat-emitting callables.
+ * Eliminates the repeated boilerplate of:
+ *
+ * <pre>{@code
+ *     long start = System.nanoTime();
+ *     try { work(); }
+ *     finally { tracker.addXxxTimeMillis(TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start)); }
+ * }</pre>
+ *
+ * <p>Usage examples:
+ * <pre>{@code
+ *     // Time-only (no success/failure counters):
+ *     recordTimeMillis(() -> indexWriter.forceMerge(1, true), stats::addFlushForceMergeTimeMillis);
+ *
+ *     // Time + outcome (success counter on clean return, failure counter on throw):
+ *     recordOutcome(
+ *         () -> { doWork(); return result; },
+ *         tracker::addCommitTimeMillis,
+ *         tracker::incCommitTotal,
+ *         tracker::incCommitFailures
+ *     );
+ * }</pre>
+ *
+ * <p>All variants record elapsed time even when the wrapped work throws.
+ *
+ * @opensearch.experimental
+ */
+public final class StatsRecorder {
+
+    private StatsRecorder() {}
+
+    /** Closure that may throw {@link IOException}. */
+    @FunctionalInterface
+    public interface IORunnable {
+        void run() throws IOException;
+    }
+
+    /** Closure with a return value that may throw {@link IOException}. */
+    @FunctionalInterface
+    public interface IOSupplier<T> {
+        T get() throws IOException;
+    }
+
+    /**
+     * Runs {@code work} and reports elapsed wall-clock millis to {@code timeRecorder}.
+     * Time is reported even if {@code work} throws.
+     */
+    public static void recordTimeMillis(IORunnable work, LongConsumer timeRecorder) throws IOException {
+        Objects.requireNonNull(work, "work");
+        Objects.requireNonNull(timeRecorder, "timeRecorder");
+        long start = System.nanoTime();
+        try {
+            work.run();
+        } finally {
+            timeRecorder.accept(TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start));
+        }
+    }
+
+    /**
+     * Runs {@code work} and reports time + outcome:
+     * <ul>
+     *   <li>{@code timeRecorder} always fires (in {@code finally})</li>
+     *   <li>{@code onSuccess} fires only on a clean return</li>
+     *   <li>{@code onFailure} fires only when {@code work} throws</li>
+     * </ul>
+     */
+    public static <T> T recordOutcome(IOSupplier<T> work, LongConsumer timeRecorder, Runnable onSuccess, Runnable onFailure)
+        throws IOException {
+        Objects.requireNonNull(work, "work");
+        Objects.requireNonNull(timeRecorder, "timeRecorder");
+        Objects.requireNonNull(onSuccess, "onSuccess");
+        Objects.requireNonNull(onFailure, "onFailure");
+        long start = System.nanoTime();
+        boolean threw = false;
+        try {
+            return work.get();
+        } catch (Throwable t) {
+            threw = true;
+            onFailure.run();
+            throw t;
+        } finally {
+            timeRecorder.accept(TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start));
+            if (threw == false) {
+                onSuccess.run();
+            }
+        }
+    }
+
+    /**
+     * Void-returning variant of {@link #recordOutcome(IOSupplier, LongConsumer, Runnable, Runnable)}.
+     */
+    public static void recordOutcome(IORunnable work, LongConsumer timeRecorder, Runnable onSuccess, Runnable onFailure)
+        throws IOException {
+        Objects.requireNonNull(work, "work");
+        recordOutcome(() -> {
+            work.run();
+            return null;
+        }, timeRecorder, onSuccess, onFailure);
+    }
+}

--- a/sandbox/libs/plugin-stats-spi/src/main/java/org/opensearch/plugin/stats/package-info.java
+++ b/sandbox/libs/plugin-stats-spi/src/main/java/org/opensearch/plugin/stats/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/**
+ * SPI for plugin-level data-format statistics.
+ *
+ * <p>Defines the {@link org.opensearch.plugin.stats.DataFormatStatsProvider} contract,
+ * the {@link org.opensearch.plugin.stats.DataFormatShardStats} typed shard-stats marker,
+ * and the JVM-wide {@link org.opensearch.plugin.stats.DataFormatStatsProviderRegistry}
+ * registry. Per-format plugins (Lucene, Parquet, etc.) implement these interfaces to
+ * surface their counters via the per-format REST endpoints in the
+ * {@code transport} sub-package.
+ *
+ * @opensearch.experimental
+ */
+@ExperimentalApi
+package org.opensearch.plugin.stats;
+
+import org.opensearch.common.annotation.ExperimentalApi;

--- a/sandbox/libs/plugin-stats-spi/src/main/java/org/opensearch/plugin/stats/transport/BaseFormatNodeStatsRestAction.java
+++ b/sandbox/libs/plugin-stats-spi/src/main/java/org/opensearch/plugin/stats/transport/BaseFormatNodeStatsRestAction.java
@@ -1,0 +1,53 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.stats.transport;
+
+import org.opensearch.action.ActionType;
+import org.opensearch.common.annotation.ExperimentalApi;
+import org.opensearch.core.common.Strings;
+import org.opensearch.rest.BaseRestHandler;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.rest.action.RestToXContentListener;
+import org.opensearch.transport.client.node.NodeClient;
+
+import java.util.List;
+
+/**
+ * Abstract REST handler for per-format node-level stats.
+ *
+ * @opensearch.experimental
+ */
+@ExperimentalApi
+public abstract class BaseFormatNodeStatsRestAction extends BaseRestHandler {
+
+    protected abstract String formatName();
+
+    protected abstract ActionType<? extends FormatNodeStatsResponse<?>> actionType();
+
+    @Override
+    public String getName() {
+        return formatName() + "_node_stats_action";
+    }
+
+    @Override
+    public List<Route> routes() {
+        return List.of(
+            new Route(RestRequest.Method.GET, "/_plugins/" + formatName() + "/_nodes/_stats"),
+            new Route(RestRequest.Method.GET, "/_plugins/" + formatName() + "/_nodes/{nodeId}/_stats")
+        );
+    }
+
+    @Override
+    protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) {
+        String nodeId = request.param("nodeId");
+        String[] nodeIds = nodeId != null ? Strings.splitStringByCommaToArray(nodeId) : new String[0];
+        FormatNodeStatsRequest statsRequest = new FormatNodeStatsRequest(formatName(), nodeIds);
+        return channel -> client.execute(actionType(), statsRequest, new RestToXContentListener<>(channel));
+    }
+}

--- a/sandbox/libs/plugin-stats-spi/src/main/java/org/opensearch/plugin/stats/transport/BaseFormatStatsRestAction.java
+++ b/sandbox/libs/plugin-stats-spi/src/main/java/org/opensearch/plugin/stats/transport/BaseFormatStatsRestAction.java
@@ -9,6 +9,7 @@
 package org.opensearch.plugin.stats.transport;
 
 import org.opensearch.action.ActionType;
+import org.opensearch.action.support.IndicesOptions;
 import org.opensearch.common.annotation.ExperimentalApi;
 import org.opensearch.core.common.Strings;
 import org.opensearch.rest.BaseRestHandler;
@@ -48,11 +49,27 @@ public abstract class BaseFormatStatsRestAction extends BaseRestHandler {
             throw new IllegalArgumentException("level must be 'index' or 'shards' but was [" + level + "]");
         }
         boolean shardLevel = "shards".equals(level);
-        String shardParam = request.param("shard");
-        Integer shardFilter = shardParam != null ? Integer.parseInt(shardParam) : null;
-        String nodeFilter = request.param("node");
+
+        String shardsParam = request.param("shards");
+        int[] shardFilter = null;
+        if (shardsParam != null) {
+            String[] parts = Strings.splitStringByCommaToArray(shardsParam);
+            shardFilter = new int[parts.length];
+            for (int i = 0; i < parts.length; i++) {
+                try {
+                    shardFilter[i] = Integer.parseInt(parts[i].trim());
+                } catch (NumberFormatException e) {
+                    throw new IllegalArgumentException("shards parameter must be a comma-separated list of integers, got: " + shardsParam);
+                }
+            }
+        }
+        String nodesParam = request.param("nodes");
+        String[] nodeFilter = nodesParam != null ? Strings.splitStringByCommaToArray(nodesParam) : null;
+
+        IndicesOptions indicesOptions = IndicesOptions.fromRequest(request, IndicesOptions.strictExpandOpen());
 
         FormatStatsRequest statsRequest = new FormatStatsRequest(formatName(), indices, shardLevel, shardFilter, nodeFilter);
+        statsRequest.indicesOptions(indicesOptions);
         return channel -> client.execute(actionType(), statsRequest, new RestToXContentListener<>(channel));
     }
 }

--- a/sandbox/libs/plugin-stats-spi/src/main/java/org/opensearch/plugin/stats/transport/BaseFormatStatsRestAction.java
+++ b/sandbox/libs/plugin-stats-spi/src/main/java/org/opensearch/plugin/stats/transport/BaseFormatStatsRestAction.java
@@ -1,0 +1,58 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.stats.transport;
+
+import org.opensearch.action.ActionType;
+import org.opensearch.common.annotation.ExperimentalApi;
+import org.opensearch.core.common.Strings;
+import org.opensearch.rest.BaseRestHandler;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.rest.action.RestToXContentListener;
+import org.opensearch.transport.client.node.NodeClient;
+
+import java.util.List;
+
+/**
+ * Abstract REST handler for per-format index-level stats.
+ *
+ * @opensearch.experimental
+ */
+@ExperimentalApi
+public abstract class BaseFormatStatsRestAction extends BaseRestHandler {
+
+    protected abstract String formatName();
+
+    protected abstract ActionType<? extends FormatStatsResponse<?>> actionType();
+
+    @Override
+    public String getName() {
+        return formatName() + "_stats_action";
+    }
+
+    @Override
+    public List<Route> routes() {
+        return List.of(new Route(RestRequest.Method.GET, "/_plugins/" + formatName() + "/{index}/_stats"));
+    }
+
+    @Override
+    protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) {
+        String[] indices = Strings.splitStringByCommaToArray(request.param("index"));
+        String level = request.param("level");
+        if (level != null && !"index".equals(level) && !"shards".equals(level)) {
+            throw new IllegalArgumentException("level must be 'index' or 'shards' but was [" + level + "]");
+        }
+        boolean shardLevel = "shards".equals(level);
+        String shardParam = request.param("shard");
+        Integer shardFilter = shardParam != null ? Integer.parseInt(shardParam) : null;
+        String nodeFilter = request.param("node");
+
+        FormatStatsRequest statsRequest = new FormatStatsRequest(formatName(), indices, shardLevel, shardFilter, nodeFilter);
+        return channel -> client.execute(actionType(), statsRequest, new RestToXContentListener<>(channel));
+    }
+}

--- a/sandbox/libs/plugin-stats-spi/src/main/java/org/opensearch/plugin/stats/transport/BaseTransportFormatNodeStatsAction.java
+++ b/sandbox/libs/plugin-stats-spi/src/main/java/org/opensearch/plugin/stats/transport/BaseTransportFormatNodeStatsAction.java
@@ -1,0 +1,99 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.stats.transport;
+
+import org.opensearch.action.FailedNodeException;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.nodes.TransportNodesAction;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.annotation.ExperimentalApi;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.Writeable;
+import org.opensearch.plugin.stats.DataFormatShardStats;
+import org.opensearch.plugin.stats.DataFormatStatsProvider;
+import org.opensearch.plugin.stats.DataFormatStatsProviderRegistry;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportService;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Abstract transport action that collects per-format aggregate node stats.
+ * Each data-format plugin subclasses this to register its own node-stats action.
+ *
+ * @param <T> concrete shard-stats type
+ *
+ * @opensearch.experimental
+ */
+@ExperimentalApi
+public abstract class BaseTransportFormatNodeStatsAction<T extends DataFormatShardStats<T>> extends TransportNodesAction<
+    FormatNodeStatsRequest,
+    FormatNodeStatsResponse<T>,
+    FormatNodeStatsRequest,
+    NodeFormatStats<T>> {
+
+    private final String formatName;
+    private final Writeable.Reader<T> reader;
+
+    @SuppressWarnings("unchecked")
+    protected BaseTransportFormatNodeStatsAction(
+        String actionName,
+        String formatName,
+        Writeable.Reader<T> reader,
+        ThreadPool threadPool,
+        ClusterService clusterService,
+        TransportService transportService,
+        ActionFilters actionFilters
+    ) {
+        super(
+            actionName,
+            threadPool,
+            clusterService,
+            transportService,
+            actionFilters,
+            FormatNodeStatsRequest::new,
+            FormatNodeStatsRequest::new,
+            ThreadPool.Names.MANAGEMENT,
+            (Class<NodeFormatStats<T>>) (Class<?>) NodeFormatStats.class
+        );
+        this.formatName = formatName;
+        this.reader = reader;
+    }
+
+    @Override
+    protected FormatNodeStatsResponse<T> newResponse(
+        FormatNodeStatsRequest request,
+        List<NodeFormatStats<T>> nodeStats,
+        List<FailedNodeException> failures
+    ) {
+        return new FormatNodeStatsResponse<>(clusterService.getClusterName(), nodeStats, failures);
+    }
+
+    @Override
+    protected FormatNodeStatsRequest newNodeRequest(FormatNodeStatsRequest request) {
+        return request;
+    }
+
+    @Override
+    protected NodeFormatStats<T> newNodeResponse(StreamInput in) throws IOException {
+        return new NodeFormatStats<>(in, reader);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected NodeFormatStats<T> nodeOperation(FormatNodeStatsRequest request) {
+        DataFormatStatsProvider<T> provider = (DataFormatStatsProvider<T>) DataFormatStatsProviderRegistry.INSTANCE.get(formatName);
+        if (provider == null) {
+            throw new IllegalArgumentException("unknown format: " + formatName);
+        }
+        T stats = provider.aggregateNodeStats().orElse(null);
+        return new NodeFormatStats<>(transportService.getLocalNode(), formatName, stats);
+    }
+}

--- a/sandbox/libs/plugin-stats-spi/src/main/java/org/opensearch/plugin/stats/transport/BaseTransportFormatStatsAction.java
+++ b/sandbox/libs/plugin-stats-spi/src/main/java/org/opensearch/plugin/stats/transport/BaseTransportFormatStatsAction.java
@@ -1,0 +1,173 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.stats.transport;
+
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.broadcast.node.TransportBroadcastByNodeAction;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.block.ClusterBlockException;
+import org.opensearch.cluster.block.ClusterBlockLevel;
+import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
+import org.opensearch.cluster.routing.PlainShardsIterator;
+import org.opensearch.cluster.routing.ShardRouting;
+import org.opensearch.cluster.routing.ShardsIterator;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.annotation.ExperimentalApi;
+import org.opensearch.core.action.support.DefaultShardOperationFailedException;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.Writeable;
+import org.opensearch.plugin.stats.DataFormatShardStats;
+import org.opensearch.plugin.stats.DataFormatStatsProvider;
+import org.opensearch.plugin.stats.DataFormatStatsProviderRegistry;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportService;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Abstract transport action that collects per-format stats using broadcast-by-node routing.
+ * Each data-format plugin subclasses this to register its own action.
+ *
+ * @param <T> concrete shard-stats type
+ *
+ * @opensearch.experimental
+ */
+@ExperimentalApi
+public abstract class BaseTransportFormatStatsAction<T extends DataFormatShardStats<T>> extends TransportBroadcastByNodeAction<
+    FormatStatsRequest,
+    FormatStatsResponse<T>,
+    FormatStatsShardResult<T>> {
+
+    private final String formatName;
+    private final Writeable.Reader<T> reader;
+
+    protected BaseTransportFormatStatsAction(
+        String actionName,
+        String formatName,
+        Writeable.Reader<T> reader,
+        ClusterService clusterService,
+        TransportService transportService,
+        ActionFilters actionFilters,
+        IndexNameExpressionResolver indexNameExpressionResolver
+    ) {
+        super(
+            actionName,
+            clusterService,
+            transportService,
+            actionFilters,
+            indexNameExpressionResolver,
+            FormatStatsRequest::new,
+            ThreadPool.Names.MANAGEMENT
+        );
+        this.formatName = formatName;
+        this.reader = reader;
+    }
+
+    @Override
+    protected FormatStatsShardResult<T> readShardResult(StreamInput in) throws IOException {
+        return new FormatStatsShardResult<>(in, reader);
+    }
+
+    @Override
+    protected FormatStatsResponse<T> newResponse(
+        FormatStatsRequest request,
+        int totalShards,
+        int successfulShards,
+        int failedShards,
+        List<FormatStatsShardResult<T>> results,
+        List<DefaultShardOperationFailedException> shardFailures,
+        ClusterState clusterState
+    ) {
+        return new FormatStatsResponse<>(
+            request.formatName(),
+            request.isShardLevel(),
+            results,
+            totalShards,
+            successfulShards,
+            failedShards,
+            shardFailures
+        );
+    }
+
+    @Override
+    protected FormatStatsRequest readRequestFrom(StreamInput in) throws IOException {
+        return new FormatStatsRequest(in);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected FormatStatsShardResult<T> shardOperation(FormatStatsRequest request, ShardRouting shardRouting) {
+        DataFormatStatsProvider<T> provider = (DataFormatStatsProvider<T>) DataFormatStatsProviderRegistry.INSTANCE.get(formatName);
+        if (provider == null) return new FormatStatsShardResult<>(shardRouting, null);
+        return new FormatStatsShardResult<>(shardRouting, provider.shardStats(shardRouting.shardId()).orElse(null));
+    }
+
+    @Override
+    protected ShardsIterator shards(ClusterState clusterState, FormatStatsRequest request, String[] concreteIndices) {
+        List<ShardRouting> shards = clusterState.routingTable().allShards(concreteIndices).getShardRoutings();
+        String nodeFilter = request.getNodeFilter();
+        Integer shardFilter = request.getShardFilter();
+
+        if (shardFilter != null) {
+            for (String index : concreteIndices) {
+                int numShards = clusterState.routingTable().index(index).getShards().size();
+                if (shardFilter < 0 || shardFilter >= numShards) {
+                    throw new IllegalArgumentException(
+                        "shard [" + shardFilter + "] is out of range for index [" + index + "] which has [" + numShards + "] shard(s)"
+                    );
+                }
+            }
+        }
+
+        String resolvedNodeFilter = null;
+        if (nodeFilter != null) {
+            if ("_local".equals(nodeFilter)) {
+                resolvedNodeFilter = clusterState.getNodes().getLocalNodeId();
+            } else {
+                if (clusterState.getNodes().get(nodeFilter) == null) {
+                    throw new IllegalArgumentException("node [" + nodeFilter + "] not found in cluster");
+                }
+                resolvedNodeFilter = nodeFilter;
+            }
+        }
+
+        final String finalNodeFilter = resolvedNodeFilter;
+        List<ShardRouting> filtered = shards.stream().filter(sr -> {
+            // DFA replicas use segment replication from remote store and don't run an indexing
+            // engine, so they have no per-format tracker registered. Always restrict to primaries
+            // — the broadcast then has exactly one copy per logical shard, which makes
+            // `_shards.total` match the user's `index.number_of_shards` setting and prevents
+            // empty `{ primary: false }` noise in `level=shards` output.
+            if (sr.primary() == false) {
+                return false;
+            }
+            if (shardFilter != null && sr.shardId().id() != shardFilter) {
+                return false;
+            }
+            if (finalNodeFilter != null && !finalNodeFilter.equals(sr.currentNodeId())) {
+                return false;
+            }
+            return true;
+        }).collect(Collectors.toList());
+
+        return new PlainShardsIterator(filtered);
+    }
+
+    @Override
+    protected ClusterBlockException checkGlobalBlock(ClusterState state, FormatStatsRequest request) {
+        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_READ);
+    }
+
+    @Override
+    protected ClusterBlockException checkRequestBlock(ClusterState state, FormatStatsRequest request, String[] concreteIndices) {
+        return state.blocks().indicesBlockedException(ClusterBlockLevel.METADATA_READ, concreteIndices);
+    }
+}

--- a/sandbox/libs/plugin-stats-spi/src/main/java/org/opensearch/plugin/stats/transport/BaseTransportFormatStatsAction.java
+++ b/sandbox/libs/plugin-stats-spi/src/main/java/org/opensearch/plugin/stats/transport/BaseTransportFormatStatsAction.java
@@ -29,7 +29,9 @@ import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
 
 import java.io.IOException;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -113,33 +115,45 @@ public abstract class BaseTransportFormatStatsAction<T extends DataFormatShardSt
     @Override
     protected ShardsIterator shards(ClusterState clusterState, FormatStatsRequest request, String[] concreteIndices) {
         List<ShardRouting> shards = clusterState.routingTable().allShards(concreteIndices).getShardRoutings();
-        String nodeFilter = request.getNodeFilter();
-        Integer shardFilter = request.getShardFilter();
+        int[] shardFilter = request.getShardFilter();
+        String[] nodeFilter = request.getNodeFilter();
 
-        if (shardFilter != null) {
+        if (shardFilter != null && shardFilter.length > 0) {
             for (String index : concreteIndices) {
                 int numShards = clusterState.routingTable().index(index).getShards().size();
-                if (shardFilter < 0 || shardFilter >= numShards) {
-                    throw new IllegalArgumentException(
-                        "shard [" + shardFilter + "] is out of range for index [" + index + "] which has [" + numShards + "] shard(s)"
-                    );
+                for (int sid : shardFilter) {
+                    if (sid < 0 || sid >= numShards) {
+                        throw new IllegalArgumentException(
+                            "shard [" + sid + "] is out of range for index [" + index + "] which has [" + numShards + "] shard(s)"
+                        );
+                    }
                 }
             }
         }
 
-        String resolvedNodeFilter = null;
+        final Set<String> resolvedNodeFilter = new HashSet<>();
         if (nodeFilter != null) {
-            if ("_local".equals(nodeFilter)) {
-                resolvedNodeFilter = clusterState.getNodes().getLocalNodeId();
-            } else {
-                if (clusterState.getNodes().get(nodeFilter) == null) {
-                    throw new IllegalArgumentException("node [" + nodeFilter + "] not found in cluster");
+            for (String nf : nodeFilter) {
+                if ("_local".equals(nf)) {
+                    resolvedNodeFilter.add(clusterState.getNodes().getLocalNodeId());
+                } else {
+                    if (clusterState.getNodes().get(nf) == null) {
+                        throw new IllegalArgumentException("node [" + nf + "] not found in cluster");
+                    }
+                    resolvedNodeFilter.add(nf);
                 }
-                resolvedNodeFilter = nodeFilter;
             }
         }
+        final boolean nodeFilterActive = nodeFilter != null && nodeFilter.length > 0;
 
-        final String finalNodeFilter = resolvedNodeFilter;
+        final Set<Integer> shardFilterSet = new HashSet<>();
+        if (shardFilter != null) {
+            for (int sid : shardFilter) {
+                shardFilterSet.add(sid);
+            }
+        }
+        final boolean shardFilterActive = shardFilter != null && shardFilter.length > 0;
+
         List<ShardRouting> filtered = shards.stream().filter(sr -> {
             // DFA replicas use segment replication from remote store and don't run an indexing
             // engine, so they have no per-format tracker registered. Always restrict to primaries
@@ -149,10 +163,10 @@ public abstract class BaseTransportFormatStatsAction<T extends DataFormatShardSt
             if (sr.primary() == false) {
                 return false;
             }
-            if (shardFilter != null && sr.shardId().id() != shardFilter) {
+            if (shardFilterActive && !shardFilterSet.contains(sr.shardId().id())) {
                 return false;
             }
-            if (finalNodeFilter != null && !finalNodeFilter.equals(sr.currentNodeId())) {
+            if (nodeFilterActive && !resolvedNodeFilter.contains(sr.currentNodeId())) {
                 return false;
             }
             return true;

--- a/sandbox/libs/plugin-stats-spi/src/main/java/org/opensearch/plugin/stats/transport/FormatNodeStatsActionType.java
+++ b/sandbox/libs/plugin-stats-spi/src/main/java/org/opensearch/plugin/stats/transport/FormatNodeStatsActionType.java
@@ -1,0 +1,27 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.stats.transport;
+
+import org.opensearch.action.ActionType;
+import org.opensearch.common.annotation.ExperimentalApi;
+import org.opensearch.core.common.io.stream.Writeable;
+import org.opensearch.plugin.stats.DataFormatShardStats;
+
+/**
+ * ActionType for per-format node-level stats, parameterised by the format's stats type.
+ *
+ * @opensearch.experimental
+ */
+@ExperimentalApi
+public class FormatNodeStatsActionType<T extends DataFormatShardStats<T>> extends ActionType<FormatNodeStatsResponse<T>> {
+
+    public FormatNodeStatsActionType(String formatName, Writeable.Reader<T> reader) {
+        super("cluster:monitor/dfa/" + formatName + "/nodes/stats", in -> new FormatNodeStatsResponse<>(in, reader));
+    }
+}

--- a/sandbox/libs/plugin-stats-spi/src/main/java/org/opensearch/plugin/stats/transport/FormatNodeStatsRequest.java
+++ b/sandbox/libs/plugin-stats-spi/src/main/java/org/opensearch/plugin/stats/transport/FormatNodeStatsRequest.java
@@ -1,0 +1,47 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.stats.transport;
+
+import org.opensearch.action.support.nodes.BaseNodesRequest;
+import org.opensearch.common.annotation.ExperimentalApi;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+
+/**
+ * Request for per-format node-level stats.
+ *
+ * @opensearch.experimental
+ */
+@ExperimentalApi
+public class FormatNodeStatsRequest extends BaseNodesRequest<FormatNodeStatsRequest> {
+
+    private final String formatName;
+
+    public FormatNodeStatsRequest(String formatName, String... nodeIds) {
+        super(nodeIds);
+        this.formatName = formatName;
+    }
+
+    public FormatNodeStatsRequest(StreamInput in) throws IOException {
+        super(in);
+        this.formatName = in.readString();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeString(formatName);
+    }
+
+    public String formatName() {
+        return formatName;
+    }
+}

--- a/sandbox/libs/plugin-stats-spi/src/main/java/org/opensearch/plugin/stats/transport/FormatNodeStatsResponse.java
+++ b/sandbox/libs/plugin-stats-spi/src/main/java/org/opensearch/plugin/stats/transport/FormatNodeStatsResponse.java
@@ -1,0 +1,82 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.stats.transport;
+
+import org.opensearch.action.FailedNodeException;
+import org.opensearch.action.support.nodes.BaseNodesResponse;
+import org.opensearch.cluster.ClusterName;
+import org.opensearch.common.annotation.ExperimentalApi;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.common.io.stream.Writeable;
+import org.opensearch.core.xcontent.ToXContentObject;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.plugin.stats.DataFormatShardStats;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Response for per-format node-level stats.
+ *
+ * @param <T> concrete shard-stats type
+ *
+ * @opensearch.experimental
+ */
+@ExperimentalApi
+public class FormatNodeStatsResponse<T extends DataFormatShardStats<T>> extends BaseNodesResponse<NodeFormatStats<T>>
+    implements
+        ToXContentObject {
+
+    private final Writeable.Reader<T> reader;
+
+    public FormatNodeStatsResponse(ClusterName clusterName, List<NodeFormatStats<T>> nodes, List<FailedNodeException> failures) {
+        super(clusterName, nodes, failures);
+        this.reader = null;
+    }
+
+    public FormatNodeStatsResponse(StreamInput in, Writeable.Reader<T> reader) throws IOException {
+        super(in);
+        this.reader = reader;
+    }
+
+    @Override
+    protected List<NodeFormatStats<T>> readNodesFrom(StreamInput in) throws IOException {
+        int size = in.readVInt();
+        List<NodeFormatStats<T>> nodes = new ArrayList<>(size);
+        for (int i = 0; i < size; i++) {
+            nodes.add(new NodeFormatStats<>(in, reader));
+        }
+        return nodes;
+    }
+
+    @Override
+    protected void writeNodesTo(StreamOutput out, List<NodeFormatStats<T>> nodes) throws IOException {
+        out.writeVInt(nodes.size());
+        for (NodeFormatStats<T> node : nodes) {
+            node.writeTo(out);
+        }
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.startObject("nodes");
+        for (NodeFormatStats<T> nodeStats : getNodes()) {
+            builder.startObject(nodeStats.getNode().getId());
+            builder.field("name", nodeStats.getNode().getName());
+            nodeStats.toXContent(builder, params);
+            builder.endObject();
+        }
+        builder.endObject();
+        builder.endObject();
+        return builder;
+    }
+}

--- a/sandbox/libs/plugin-stats-spi/src/main/java/org/opensearch/plugin/stats/transport/FormatStatsActionType.java
+++ b/sandbox/libs/plugin-stats-spi/src/main/java/org/opensearch/plugin/stats/transport/FormatStatsActionType.java
@@ -1,0 +1,27 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.stats.transport;
+
+import org.opensearch.action.ActionType;
+import org.opensearch.common.annotation.ExperimentalApi;
+import org.opensearch.core.common.io.stream.Writeable;
+import org.opensearch.plugin.stats.DataFormatShardStats;
+
+/**
+ * ActionType for per-format index-level stats, parameterised by the format's stats type.
+ *
+ * @opensearch.experimental
+ */
+@ExperimentalApi
+public class FormatStatsActionType<T extends DataFormatShardStats<T>> extends ActionType<FormatStatsResponse<T>> {
+
+    public FormatStatsActionType(String formatName, Writeable.Reader<T> reader) {
+        super("cluster:monitor/dfa/" + formatName + "/index/stats", in -> new FormatStatsResponse<>(in, reader));
+    }
+}

--- a/sandbox/libs/plugin-stats-spi/src/main/java/org/opensearch/plugin/stats/transport/FormatStatsRequest.java
+++ b/sandbox/libs/plugin-stats-spi/src/main/java/org/opensearch/plugin/stats/transport/FormatStatsRequest.java
@@ -25,10 +25,10 @@ public class FormatStatsRequest extends BroadcastRequest<FormatStatsRequest> {
 
     private final String formatName;
     private final boolean shardLevel;
-    private final Integer shardFilter;
-    private final String nodeFilter;
+    private final int[] shardFilter;
+    private final String[] nodeFilter;
 
-    public FormatStatsRequest(String formatName, String[] indices, boolean shardLevel, Integer shardFilter, String nodeFilter) {
+    public FormatStatsRequest(String formatName, String[] indices, boolean shardLevel, int[] shardFilter, String[] nodeFilter) {
         super(indices);
         this.formatName = formatName;
         this.shardLevel = shardLevel;
@@ -40,8 +40,8 @@ public class FormatStatsRequest extends BroadcastRequest<FormatStatsRequest> {
         super(in);
         this.formatName = in.readString();
         this.shardLevel = in.readBoolean();
-        this.shardFilter = in.readOptionalVInt();
-        this.nodeFilter = in.readOptionalString();
+        this.shardFilter = in.readBoolean() ? in.readVIntArray() : null;
+        this.nodeFilter = in.readBoolean() ? in.readStringArray() : null;
     }
 
     @Override
@@ -49,8 +49,18 @@ public class FormatStatsRequest extends BroadcastRequest<FormatStatsRequest> {
         super.writeTo(out);
         out.writeString(formatName);
         out.writeBoolean(shardLevel);
-        out.writeOptionalVInt(shardFilter);
-        out.writeOptionalString(nodeFilter);
+        if (shardFilter == null) {
+            out.writeBoolean(false);
+        } else {
+            out.writeBoolean(true);
+            out.writeVIntArray(shardFilter);
+        }
+        if (nodeFilter == null) {
+            out.writeBoolean(false);
+        } else {
+            out.writeBoolean(true);
+            out.writeStringArray(nodeFilter);
+        }
     }
 
     public String formatName() {
@@ -61,11 +71,11 @@ public class FormatStatsRequest extends BroadcastRequest<FormatStatsRequest> {
         return shardLevel;
     }
 
-    public Integer getShardFilter() {
+    public int[] getShardFilter() {
         return shardFilter;
     }
 
-    public String getNodeFilter() {
+    public String[] getNodeFilter() {
         return nodeFilter;
     }
 }

--- a/sandbox/libs/plugin-stats-spi/src/main/java/org/opensearch/plugin/stats/transport/FormatStatsRequest.java
+++ b/sandbox/libs/plugin-stats-spi/src/main/java/org/opensearch/plugin/stats/transport/FormatStatsRequest.java
@@ -1,0 +1,71 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.stats.transport;
+
+import org.opensearch.action.support.broadcast.BroadcastRequest;
+import org.opensearch.common.annotation.ExperimentalApi;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+
+/**
+ * Broadcast request for per-format index-level stats.
+ *
+ * @opensearch.experimental
+ */
+@ExperimentalApi
+public class FormatStatsRequest extends BroadcastRequest<FormatStatsRequest> {
+
+    private final String formatName;
+    private final boolean shardLevel;
+    private final Integer shardFilter;
+    private final String nodeFilter;
+
+    public FormatStatsRequest(String formatName, String[] indices, boolean shardLevel, Integer shardFilter, String nodeFilter) {
+        super(indices);
+        this.formatName = formatName;
+        this.shardLevel = shardLevel;
+        this.shardFilter = shardFilter;
+        this.nodeFilter = nodeFilter;
+    }
+
+    public FormatStatsRequest(StreamInput in) throws IOException {
+        super(in);
+        this.formatName = in.readString();
+        this.shardLevel = in.readBoolean();
+        this.shardFilter = in.readOptionalVInt();
+        this.nodeFilter = in.readOptionalString();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeString(formatName);
+        out.writeBoolean(shardLevel);
+        out.writeOptionalVInt(shardFilter);
+        out.writeOptionalString(nodeFilter);
+    }
+
+    public String formatName() {
+        return formatName;
+    }
+
+    public boolean isShardLevel() {
+        return shardLevel;
+    }
+
+    public Integer getShardFilter() {
+        return shardFilter;
+    }
+
+    public String getNodeFilter() {
+        return nodeFilter;
+    }
+}

--- a/sandbox/libs/plugin-stats-spi/src/main/java/org/opensearch/plugin/stats/transport/FormatStatsResponse.java
+++ b/sandbox/libs/plugin-stats-spi/src/main/java/org/opensearch/plugin/stats/transport/FormatStatsResponse.java
@@ -105,7 +105,12 @@ public class FormatStatsResponse<T extends DataFormatShardStats<T>> extends Broa
                     b.startArray(String.valueOf(s.getKey()));
                     for (var r : s.getValue()) {
                         b.startObject();
+                        b.startObject("routing");
+                        b.field("state", r.shardRouting().state().toString());
                         b.field("primary", r.shardRouting().primary());
+                        b.field("node", r.shardRouting().currentNodeId());
+                        b.field("relocating_node", r.shardRouting().relocatingNodeId());
+                        b.endObject();
                         if (r.stats() != null) r.stats().toXContent(b, p);
                         b.endObject();
                     }

--- a/sandbox/libs/plugin-stats-spi/src/main/java/org/opensearch/plugin/stats/transport/FormatStatsResponse.java
+++ b/sandbox/libs/plugin-stats-spi/src/main/java/org/opensearch/plugin/stats/transport/FormatStatsResponse.java
@@ -1,0 +1,120 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.stats.transport;
+
+import org.opensearch.action.support.broadcast.BroadcastResponse;
+import org.opensearch.common.annotation.ExperimentalApi;
+import org.opensearch.core.action.support.DefaultShardOperationFailedException;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.common.io.stream.Writeable;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.plugin.stats.DataFormatShardStats;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * Response for per-format index-level stats with format-owned aggregation.
+ *
+ * @param <T> concrete shard-stats type
+ *
+ * @opensearch.experimental
+ */
+@ExperimentalApi
+public class FormatStatsResponse<T extends DataFormatShardStats<T>> extends BroadcastResponse {
+
+    private final List<FormatStatsShardResult<T>> shardResults;
+    private final String formatName;
+    private final boolean shardLevel;
+    private final Writeable.Reader<T> reader;
+
+    public FormatStatsResponse(
+        String formatName,
+        boolean shardLevel,
+        List<FormatStatsShardResult<T>> shardResults,
+        int totalShards,
+        int successfulShards,
+        int failedShards,
+        List<DefaultShardOperationFailedException> shardFailures
+    ) {
+        super(totalShards, successfulShards, failedShards, shardFailures);
+        this.formatName = formatName;
+        this.shardLevel = shardLevel;
+        this.shardResults = shardResults;
+        this.reader = null;
+    }
+
+    public FormatStatsResponse(StreamInput in, Writeable.Reader<T> reader) throws IOException {
+        super(in);
+        this.reader = reader;
+        this.formatName = in.readString();
+        this.shardLevel = in.readBoolean();
+        int size = in.readVInt();
+        this.shardResults = new ArrayList<>(size);
+        for (int i = 0; i < size; i++) {
+            shardResults.add(new FormatStatsShardResult<>(in, reader));
+        }
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeString(formatName);
+        out.writeBoolean(shardLevel);
+        out.writeVInt(shardResults.size());
+        for (FormatStatsShardResult<T> result : shardResults) {
+            result.writeTo(out);
+        }
+    }
+
+    @Override
+    protected void addCustomXContentFields(XContentBuilder b, Params p) throws IOException {
+        b.field("format", formatName);
+        Map<String, List<FormatStatsShardResult<T>>> byIndex = new HashMap<>();
+        for (var r : shardResults) {
+            byIndex.computeIfAbsent(r.shardRouting().getIndexName(), k -> new ArrayList<>()).add(r);
+        }
+        b.startObject("indices");
+        for (var entry : byIndex.entrySet()) {
+            b.startObject(entry.getKey());
+            // format-owned aggregation via T.add()
+            T agg = null;
+            for (var r : entry.getValue()) {
+                if (r.stats() == null) continue;
+                agg = (agg == null) ? r.stats() : agg.add(r.stats());
+            }
+            if (agg != null) agg.toXContent(b, p);
+            if (shardLevel) {
+                b.startObject("shards");
+                Map<Integer, List<FormatStatsShardResult<T>>> byShard = new TreeMap<>();
+                for (var r : entry.getValue()) {
+                    byShard.computeIfAbsent(r.shardRouting().shardId().id(), k -> new ArrayList<>()).add(r);
+                }
+                for (var s : byShard.entrySet()) {
+                    b.startArray(String.valueOf(s.getKey()));
+                    for (var r : s.getValue()) {
+                        b.startObject();
+                        b.field("primary", r.shardRouting().primary());
+                        if (r.stats() != null) r.stats().toXContent(b, p);
+                        b.endObject();
+                    }
+                    b.endArray();
+                }
+                b.endObject();
+            }
+            b.endObject();
+        }
+        b.endObject();
+    }
+}

--- a/sandbox/libs/plugin-stats-spi/src/main/java/org/opensearch/plugin/stats/transport/FormatStatsShardResult.java
+++ b/sandbox/libs/plugin-stats-spi/src/main/java/org/opensearch/plugin/stats/transport/FormatStatsShardResult.java
@@ -1,0 +1,65 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.stats.transport;
+
+import org.opensearch.cluster.routing.ShardRouting;
+import org.opensearch.common.annotation.ExperimentalApi;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.common.io.stream.Writeable;
+import org.opensearch.plugin.stats.DataFormatShardStats;
+
+import java.io.IOException;
+
+/**
+ * Per-shard result holding typed stats produced by the format's provider.
+ *
+ * @param <T> concrete shard-stats type
+ *
+ * @opensearch.experimental
+ */
+@ExperimentalApi
+public class FormatStatsShardResult<T extends DataFormatShardStats<T>> implements Writeable {
+
+    private final ShardRouting shardRouting;
+    private final T stats;
+
+    public FormatStatsShardResult(ShardRouting shardRouting, T stats) {
+        this.shardRouting = shardRouting;
+        this.stats = stats;
+    }
+
+    public FormatStatsShardResult(StreamInput in, Writeable.Reader<T> reader) throws IOException {
+        this.shardRouting = new ShardRouting(in);
+        if (in.readBoolean()) {
+            this.stats = reader.read(in);
+        } else {
+            this.stats = null;
+        }
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        shardRouting.writeTo(out);
+        if (stats != null) {
+            out.writeBoolean(true);
+            stats.writeTo(out);
+        } else {
+            out.writeBoolean(false);
+        }
+    }
+
+    public ShardRouting shardRouting() {
+        return shardRouting;
+    }
+
+    public T stats() {
+        return stats;
+    }
+}

--- a/sandbox/libs/plugin-stats-spi/src/main/java/org/opensearch/plugin/stats/transport/NodeFormatStats.java
+++ b/sandbox/libs/plugin-stats-spi/src/main/java/org/opensearch/plugin/stats/transport/NodeFormatStats.java
@@ -1,0 +1,79 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.stats.transport;
+
+import org.opensearch.action.support.nodes.BaseNodeResponse;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.common.annotation.ExperimentalApi;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.common.io.stream.Writeable;
+import org.opensearch.core.xcontent.ToXContentFragment;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.plugin.stats.DataFormatShardStats;
+
+import java.io.IOException;
+
+/**
+ * Per-node response holding typed format stats.
+ *
+ * @param <T> concrete shard-stats type
+ *
+ * @opensearch.experimental
+ */
+@ExperimentalApi
+public class NodeFormatStats<T extends DataFormatShardStats<T>> extends BaseNodeResponse implements ToXContentFragment {
+
+    private final String formatName;
+    private final T stats;
+
+    public NodeFormatStats(DiscoveryNode node, String formatName, T stats) {
+        super(node);
+        this.formatName = formatName;
+        this.stats = stats;
+    }
+
+    public NodeFormatStats(StreamInput in, Writeable.Reader<T> reader) throws IOException {
+        super(in);
+        this.formatName = in.readString();
+        if (in.readBoolean()) {
+            this.stats = reader.read(in);
+        } else {
+            this.stats = null;
+        }
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeString(formatName);
+        if (stats != null) {
+            out.writeBoolean(true);
+            stats.writeTo(out);
+        } else {
+            out.writeBoolean(false);
+        }
+    }
+
+    public String formatName() {
+        return formatName;
+    }
+
+    public T stats() {
+        return stats;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        if (stats != null) {
+            stats.toXContent(builder, params);
+        }
+        return builder;
+    }
+}

--- a/sandbox/libs/plugin-stats-spi/src/main/java/org/opensearch/plugin/stats/transport/package-info.java
+++ b/sandbox/libs/plugin-stats-spi/src/main/java/org/opensearch/plugin/stats/transport/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/**
+ * Transport and REST action base classes for per-format statistics endpoints.
+ *
+ * <p>Data-format plugins subclass the abstract bases in this package to register
+ * their own index-level and node-level stats actions without duplicating routing,
+ * serialization, or aggregation logic.
+ *
+ * @opensearch.experimental
+ */
+@ExperimentalApi
+package org.opensearch.plugin.stats.transport;
+
+import org.opensearch.common.annotation.ExperimentalApi;

--- a/sandbox/plugins/analytics-backend-lucene/build.gradle
+++ b/sandbox/plugins/analytics-backend-lucene/build.gradle
@@ -11,7 +11,7 @@ apply plugin: 'opensearch.internal-cluster-test'
 opensearchplugin {
     description = 'OpenSearch plugin providing Lucene-based search execution engine'
     classname = 'org.opensearch.be.lucene.LucenePlugin'
-    extendedPlugins = ['analytics-engine']
+    extendedPlugins = ['analytics-engine', 'composite-engine']
 }
 
 java { sourceCompatibility = JavaVersion.toVersion(25); targetCompatibility = JavaVersion.toVersion(25) }
@@ -38,6 +38,7 @@ dependencies {
     // Shared types and SPI interfaces — provided at runtime by the parent analytics-engine plugin (extendedPlugins above).
     compileOnly project(':sandbox:libs:analytics-framework')
     compileOnly project(':sandbox:plugins:analytics-engine')
+    compileOnly project(":sandbox:libs:plugin-stats-spi")
 
     // Arrow vector + memory — needed by the Lucene-as-driver count fast path to emit
     // Arrow batches as the engine's result. Provided at runtime via the analytics-engine

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/LucenePlugin.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/LucenePlugin.java
@@ -12,7 +12,21 @@ import org.opensearch.be.lucene.index.LuceneCommitter;
 import org.opensearch.be.lucene.index.LuceneCommitterFactory;
 import org.opensearch.be.lucene.index.LuceneDeleteExecutionEngine;
 import org.opensearch.be.lucene.index.LuceneIndexingExecutionEngine;
+import org.opensearch.be.lucene.stats.LuceneStatsProvider;
+import org.opensearch.be.lucene.stats.transport.LuceneNodeStatsActionType;
+import org.opensearch.be.lucene.stats.transport.LuceneNodeStatsRestAction;
+import org.opensearch.be.lucene.stats.transport.LuceneNodeStatsTransportAction;
+import org.opensearch.be.lucene.stats.transport.LuceneStatsActionType;
+import org.opensearch.be.lucene.stats.transport.LuceneStatsRestAction;
+import org.opensearch.be.lucene.stats.transport.LuceneStatsTransportAction;
+import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
+import org.opensearch.cluster.node.DiscoveryNodes;
 import org.opensearch.common.annotation.ExperimentalApi;
+import org.opensearch.common.inject.Module;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.IndexScopedSettings;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.settings.SettingsFilter;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.index.engine.dataformat.DataFormat;
 import org.opensearch.index.engine.dataformat.DataFormatDescriptor;
@@ -26,11 +40,15 @@ import org.opensearch.index.engine.exec.EngineReaderManager;
 import org.opensearch.index.engine.exec.commit.Committer;
 import org.opensearch.index.engine.exec.commit.CommitterFactory;
 import org.opensearch.index.store.checksum.LuceneChecksumHandler;
+import org.opensearch.plugins.ActionPlugin;
 import org.opensearch.plugins.EnginePlugin;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.plugins.SearchBackEndPlugin;
+import org.opensearch.rest.RestController;
+import org.opensearch.rest.RestHandler;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -51,7 +69,7 @@ import java.util.function.Supplier;
  * @opensearch.experimental
  */
 @ExperimentalApi
-public class LucenePlugin extends Plugin implements DataFormatPlugin, SearchBackEndPlugin<LuceneReader>, EnginePlugin {
+public class LucenePlugin extends Plugin implements DataFormatPlugin, SearchBackEndPlugin<LuceneReader>, EnginePlugin, ActionPlugin {
 
     public static final LuceneDataFormat DATA_FORMAT = new LuceneDataFormat();
 
@@ -142,5 +160,39 @@ public class LucenePlugin extends Plugin implements DataFormatPlugin, SearchBack
     @Override
     public DeleteExecutionEngine<?> getDeleteExecutionEngine(Committer committer) {
         return new LuceneDeleteExecutionEngine(DATA_FORMAT, committer);
+    }
+
+    /**
+     * Constructs the {@link LuceneStatsProvider} eagerly so engines can self-register their
+     * trackers via the static {@code getInstance()} accessor at construction time.
+     */
+    @Override
+    public Collection<Module> createGuiceModules() {
+        // Eagerly construct the singleton so LuceneIndexingExecutionEngine can register on creation.
+        new LuceneStatsProvider();
+        return List.of();
+    }
+
+    @Override
+    public
+        List<ActionPlugin.ActionHandler<? extends org.opensearch.action.ActionRequest, ? extends org.opensearch.core.action.ActionResponse>>
+        getActions() {
+        return List.of(
+            new ActionPlugin.ActionHandler<>(LuceneStatsActionType.INSTANCE, LuceneStatsTransportAction.class),
+            new ActionPlugin.ActionHandler<>(LuceneNodeStatsActionType.INSTANCE, LuceneNodeStatsTransportAction.class)
+        );
+    }
+
+    @Override
+    public List<RestHandler> getRestHandlers(
+        Settings settings,
+        RestController restController,
+        ClusterSettings clusterSettings,
+        IndexScopedSettings indexScopedSettings,
+        SettingsFilter settingsFilter,
+        IndexNameExpressionResolver indexNameExpressionResolver,
+        Supplier<DiscoveryNodes> nodesInCluster
+    ) {
+        return List.of(new LuceneStatsRestAction(), new LuceneNodeStatsRestAction());
     }
 }

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/index/LuceneCommitter.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/index/LuceneCommitter.java
@@ -140,6 +140,11 @@ public class LuceneCommitter extends SafeBootstrapCommitter {
      * all referenced data files are fsync'd before the commit point to ensure crash
      * consistency (write-ahead ordering).
      *
+     * <p>Stats: {@code commit_time_millis} accumulates wall time for every attempt
+     * (success or failure). {@code commit_total} increments only on successful return.
+     * {@code commit_failures} increments only on a thrown exception. Therefore
+     * {@code commit_total + commit_failures = total attempts}.
+     *
      * @param commitData the key-value pairs to store as live commit data
      * @throws IOException if the commit fails
      * @throws IllegalStateException if this committer is closed
@@ -148,6 +153,7 @@ public class LuceneCommitter extends SafeBootstrapCommitter {
     public synchronized CommitResult commit(CommitInput commitData) throws IOException {
         ensureOpen();
         long start = System.nanoTime();
+        boolean threw = false;
         try {
             indexWriter.setLiveCommitData(commitData.userData());
             // Write-ahead fsync: data files durable before the commit point that references them.
@@ -159,10 +165,12 @@ public class LuceneCommitter extends SafeBootstrapCommitter {
             indexWriter.commit();
             SegmentInfos committed = SegmentInfos.readLatestCommit(indexWriter.getDirectory());
             this.lastCommittedSegmentInfos = committed;
-
             // Encode writer's Lucene version as a long — keeps CatalogSnapshot Lucene-type-agnostic.
             long version = LuceneVersionConverter.encode(committed.getCommitLuceneVersion());
             return new CommitResult(committed.getSegmentsFileName(), committed.getGeneration(), version);
+        } catch (Throwable t) {
+            threw = true;
+            throw t;
         } finally {
             LuceneStatsProvider provider = (LuceneStatsProvider) DataFormatStatsProviderRegistry.INSTANCE.get(
                 LuceneStatsProvider.FORMAT_NAME
@@ -170,8 +178,12 @@ public class LuceneCommitter extends SafeBootstrapCommitter {
             if (provider != null) {
                 LuceneShardStatsTracker tracker = provider.getTracker(store.shardId());
                 if (tracker != null) {
-                    tracker.incCommitTotal();
                     tracker.addCommitTimeMillis(TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start));
+                    if (threw) {
+                        tracker.incCommitFailures();
+                    } else {
+                        tracker.incCommitTotal();
+                    }
                 }
             }
         }

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/index/LuceneCommitter.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/index/LuceneCommitter.java
@@ -29,6 +29,8 @@ import org.apache.lucene.store.ByteBuffersIndexOutput;
 import org.apache.lucene.util.Version;
 import org.opensearch.be.lucene.LuceneDataFormat;
 import org.opensearch.be.lucene.LuceneReader;
+import org.opensearch.be.lucene.stats.LuceneShardStatsTracker;
+import org.opensearch.be.lucene.stats.LuceneStatsProvider;
 import org.opensearch.common.annotation.ExperimentalApi;
 import org.opensearch.index.engine.CommitStats;
 import org.opensearch.index.engine.EngineConfig;
@@ -43,6 +45,7 @@ import org.opensearch.index.engine.exec.coord.DataformatAwareCatalogSnapshot;
 import org.opensearch.index.engine.exec.coord.LuceneVersionConverter;
 import org.opensearch.index.store.Store;
 import org.opensearch.index.translog.Translog;
+import org.opensearch.plugin.stats.DataFormatStatsProviderRegistry;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -52,6 +55,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -143,20 +147,34 @@ public class LuceneCommitter extends SafeBootstrapCommitter {
     @Override
     public synchronized CommitResult commit(CommitInput commitData) throws IOException {
         ensureOpen();
-        indexWriter.setLiveCommitData(commitData.userData());
-        // Write-ahead fsync: data files durable before the commit point that references them.
-        // getFiles(false) excludes segments_N — IndexWriter.commit() handles that via rename + syncMetaData.
-        if (commitData.catalogSnapshot() != null) {
-            store.directory().sync(commitData.catalogSnapshot().getFiles(false));
-            store.directory().syncMetaData();
-        }
-        indexWriter.commit();
-        SegmentInfos committed = SegmentInfos.readLatestCommit(indexWriter.getDirectory());
-        this.lastCommittedSegmentInfos = committed;
+        long start = System.nanoTime();
+        try {
+            indexWriter.setLiveCommitData(commitData.userData());
+            // Write-ahead fsync: data files durable before the commit point that references them.
+            // getFiles(false) excludes segments_N — IndexWriter.commit() handles that via rename + syncMetaData.
+            if (commitData.catalogSnapshot() != null) {
+                store.directory().sync(commitData.catalogSnapshot().getFiles(false));
+                store.directory().syncMetaData();
+            }
+            indexWriter.commit();
+            SegmentInfos committed = SegmentInfos.readLatestCommit(indexWriter.getDirectory());
+            this.lastCommittedSegmentInfos = committed;
 
-        // Encode writer's Lucene version as a long — keeps CatalogSnapshot Lucene-type-agnostic.
-        long version = LuceneVersionConverter.encode(committed.getCommitLuceneVersion());
-        return new CommitResult(committed.getSegmentsFileName(), committed.getGeneration(), version);
+            // Encode writer's Lucene version as a long — keeps CatalogSnapshot Lucene-type-agnostic.
+            long version = LuceneVersionConverter.encode(committed.getCommitLuceneVersion());
+            return new CommitResult(committed.getSegmentsFileName(), committed.getGeneration(), version);
+        } finally {
+            LuceneStatsProvider provider = (LuceneStatsProvider) DataFormatStatsProviderRegistry.INSTANCE.get(
+                LuceneStatsProvider.FORMAT_NAME
+            );
+            if (provider != null) {
+                LuceneShardStatsTracker tracker = provider.getTracker(store.shardId());
+                if (tracker != null) {
+                    tracker.incCommitTotal();
+                    tracker.addCommitTimeMillis(TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start));
+                }
+            }
+        }
     }
 
     /**
@@ -298,6 +316,11 @@ public class LuceneCommitter extends SafeBootstrapCommitter {
     Sort getUserProvidedSort() {
         ensureOpen();
         return userProvidedSort;
+    }
+
+    /** Returns the store reference. Package-private for sibling classes (e.g., LuceneDeleteExecutionEngine). */
+    Store getStore() {
+        return store;
     }
 
     /** Returns the version-keyed reader map used by {@link #serializeToCommitFormat}. */

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/index/LuceneCommitter.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/index/LuceneCommitter.java
@@ -153,14 +153,17 @@ public class LuceneCommitter extends SafeBootstrapCommitter {
     public synchronized CommitResult commit(CommitInput commitData) throws IOException {
         ensureOpen();
         long start = System.nanoTime();
+        long syncMillis = 0;
         boolean threw = false;
         try {
             indexWriter.setLiveCommitData(commitData.userData());
             // Write-ahead fsync: data files durable before the commit point that references them.
             // getFiles(false) excludes segments_N — IndexWriter.commit() handles that via rename + syncMetaData.
             if (commitData.catalogSnapshot() != null) {
+                long syncStart = System.nanoTime();
                 store.directory().sync(commitData.catalogSnapshot().getFiles(false));
                 store.directory().syncMetaData();
+                syncMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - syncStart);
             }
             indexWriter.commit();
             SegmentInfos committed = SegmentInfos.readLatestCommit(indexWriter.getDirectory());
@@ -179,6 +182,7 @@ public class LuceneCommitter extends SafeBootstrapCommitter {
                 LuceneShardStatsTracker tracker = provider.getTracker(store.shardId());
                 if (tracker != null) {
                     tracker.addCommitTimeMillis(TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start));
+                    tracker.addCommitSyncTimeMillis(syncMillis);
                     if (threw) {
                         tracker.incCommitFailures();
                     } else {

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/index/LuceneDeleteExecutionEngine.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/index/LuceneDeleteExecutionEngine.java
@@ -13,6 +13,8 @@ import org.apache.logging.log4j.Logger;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.Term;
 import org.opensearch.be.lucene.LuceneDataFormat;
+import org.opensearch.be.lucene.stats.LuceneShardStatsTracker;
+import org.opensearch.be.lucene.stats.LuceneStatsProvider;
 import org.opensearch.index.engine.dataformat.DataFormat;
 import org.opensearch.index.engine.dataformat.DeleteExecutionEngine;
 import org.opensearch.index.engine.dataformat.DeleteInput;
@@ -25,6 +27,8 @@ import org.opensearch.index.engine.dataformat.Writer;
 import org.opensearch.index.engine.exec.commit.Committer;
 import org.opensearch.index.mapper.IdFieldMapper;
 import org.opensearch.index.mapper.Uid;
+import org.opensearch.index.store.Store;
+import org.opensearch.plugin.stats.DataFormatStatsProviderRegistry;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -32,6 +36,7 @@ import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
 import java.util.function.LongFunction;
 
 /**
@@ -49,12 +54,15 @@ public class LuceneDeleteExecutionEngine implements DeleteExecutionEngine<DataFo
     private final DataFormat dataFormat;
     private final IndexWriter parentWriter;
     private final ConcurrentMap<String, Long> idToGen;
+    private final Store store;
 
     public LuceneDeleteExecutionEngine(DataFormat dataFormat, Committer committer) {
         this.generationToDeleterMap = new ConcurrentHashMap<>();
         this.idToGen = new ConcurrentHashMap<>();
         this.dataFormat = dataFormat;
-        this.parentWriter = ((LuceneCommitter) committer).getIndexWriter();
+        LuceneCommitter luceneCommitter = (LuceneCommitter) committer;
+        this.parentWriter = luceneCommitter.getIndexWriter();
+        this.store = luceneCommitter.getStore();
     }
 
     @Override
@@ -76,27 +84,41 @@ public class LuceneDeleteExecutionEngine implements DeleteExecutionEngine<DataFo
 
     @Override
     public DeleteResult deleteDocument(DeleteInput deleteInput, LongFunction<Closeable> writerByGenSupplier) throws IOException {
-        Deleter currentDeleter = generationToDeleterMap.get(deleteInput.generation());
-        assert currentDeleter != null && currentDeleter.isActive()
-            : "current-gen deleter must exist and be active while caller holds the writer lock; gen=" + deleteInput.generation();
+        long start = System.nanoTime();
+        try {
+            Deleter currentDeleter = generationToDeleterMap.get(deleteInput.generation());
+            assert currentDeleter != null && currentDeleter.isActive()
+                : "current-gen deleter must exist and be active while caller holds the writer lock; gen=" + deleteInput.generation();
 
-        // TODO: If not present then record buffered deletes.
-        currentDeleter.recordBufferedDeletes(deleteInput.id());
-        Long previousGen = lookupGen(deleteInput.id());
-        if (previousGen != null) {
-            Closeable previousWriterLock = writerByGenSupplier.apply(previousGen);
-            if (previousWriterLock != null) {
-                // It means previous writer is active here.
-                try {
-                    Deleter deleter = generationToDeleterMap.get(previousGen);
-                    return deleter.deleteDoc(deleteInput);
-                } finally {
-                    previousWriterLock.close();
+            // TODO: If not present then record buffered deletes.
+            currentDeleter.recordBufferedDeletes(deleteInput.id());
+            Long previousGen = lookupGen(deleteInput.id());
+            if (previousGen != null) {
+                Closeable previousWriterLock = writerByGenSupplier.apply(previousGen);
+                if (previousWriterLock != null) {
+                    // It means previous writer is active here.
+                    try {
+                        Deleter deleter = generationToDeleterMap.get(previousGen);
+                        return deleter.deleteDoc(deleteInput);
+                    } finally {
+                        previousWriterLock.close();
+                    }
+                }
+            }
+
+            return new DeleteResult.Success(1L, 1L, 1L);
+        } finally {
+            LuceneStatsProvider provider = (LuceneStatsProvider) DataFormatStatsProviderRegistry.INSTANCE.get(
+                LuceneStatsProvider.FORMAT_NAME
+            );
+            if (provider != null) {
+                LuceneShardStatsTracker tracker = provider.getTracker(store.shardId());
+                if (tracker != null) {
+                    tracker.incDeleteTotal();
+                    tracker.addDeleteTimeMillis(TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start));
                 }
             }
         }
-
-        return new DeleteResult.Success(1L, 1L, 1L);
     }
 
     @Override

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/index/LuceneIndexingExecutionEngine.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/index/LuceneIndexingExecutionEngine.java
@@ -27,6 +27,8 @@ import org.opensearch.be.lucene.LuceneDataFormat;
 import org.opensearch.be.lucene.LuceneFieldFactoryRegistry;
 import org.opensearch.be.lucene.LuceneReader;
 import org.opensearch.be.lucene.merge.LuceneMerger;
+import org.opensearch.be.lucene.stats.LuceneShardStatsTracker;
+import org.opensearch.be.lucene.stats.LuceneStatsProvider;
 import org.opensearch.common.annotation.ExperimentalApi;
 import org.opensearch.common.util.io.IOUtils;
 import org.opensearch.index.engine.dataformat.DataFormat;
@@ -42,6 +44,7 @@ import org.opensearch.index.engine.exec.WriterFileSet;
 import org.opensearch.index.engine.exec.commit.IndexStoreProvider;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.store.Store;
+import org.opensearch.plugin.stats.DataFormatStatsProviderRegistry;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -53,6 +56,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Lucene-specific {@link IndexingExecutionEngine} that manages per-writer Lucene segments
@@ -79,6 +83,7 @@ public class LuceneIndexingExecutionEngine implements IndexingExecutionEngine<Lu
 
     private static final Logger logger = LogManager.getLogger(LuceneIndexingExecutionEngine.class);
 
+    private final LuceneShardStatsTracker stats = new LuceneShardStatsTracker();
     private final LuceneDataFormat dataFormat;
     private final MergeIndexWriter sharedWriter;
     private final MapperService mapperService;
@@ -120,7 +125,7 @@ public class LuceneIndexingExecutionEngine implements IndexingExecutionEngine<Lu
         this.codec = sharedWriter.getConfig().getCodec();
         this.fieldFactoryRegistry = new LuceneFieldFactoryRegistry();
 
-        this.luceneMerger = new LuceneMerger(sharedWriter, dataFormat, store.shardPath().resolveIndex());
+        this.luceneMerger = new LuceneMerger(sharedWriter, dataFormat, store.shardPath().resolveIndex(), stats);
 
         // Create the lucene subdirectory if it doesn't exist, or clear stale contents
         // from a prior engine lifecycle. Any data here is either already hardlinked into
@@ -132,6 +137,13 @@ public class LuceneIndexingExecutionEngine implements IndexingExecutionEngine<Lu
             Files.createDirectories(baseDirectory);
         } catch (IOException e) {
             throw new RuntimeException("Failed to create lucene base directory: " + baseDirectory, e);
+        }
+        // Register this shard's tracker with the format-wide stats provider so the
+        // /_plugins/lucene/{index}/_stats and /_plugins/lucene/_nodes/{nodeId}/_stats
+        // REST endpoints can read live counters. Unregistered in close().
+        LuceneStatsProvider provider = (LuceneStatsProvider) DataFormatStatsProviderRegistry.INSTANCE.get(LuceneStatsProvider.FORMAT_NAME);
+        if (provider != null) {
+            provider.register(store.shardId(), stats);
         }
     }
 
@@ -182,7 +194,8 @@ public class LuceneIndexingExecutionEngine implements IndexingExecutionEngine<Lu
                 analyzer,
                 codec,
                 getChildWriterSortConfiguration(),
-                activeWriters
+                activeWriters,
+                stats
             );
             pendingCleanup.put(config.writerGeneration(), writer);
             return writer;
@@ -205,9 +218,10 @@ public class LuceneIndexingExecutionEngine implements IndexingExecutionEngine<Lu
         Analyzer analyzer,
         Codec codec,
         Sort indexSort,
-        Set<LuceneWriter> registry
+        Set<LuceneWriter> registry,
+        LuceneShardStatsTracker stats
     ) throws IOException {
-        return new LuceneWriter(writerGeneration, mappingVersion, dataFormat, baseDirectory, analyzer, codec, indexSort, registry);
+        return new LuceneWriter(writerGeneration, mappingVersion, dataFormat, baseDirectory, analyzer, codec, indexSort, registry, stats);
     }
 
     private Sort getChildWriterSortConfiguration() {
@@ -274,80 +288,90 @@ public class LuceneIndexingExecutionEngine implements IndexingExecutionEngine<Lu
             return new RefreshResult(List.of());
         }
 
-        List<Segment> resultSegments = new ArrayList<>(refreshInput.existingSegments());
+        long refreshStart = System.nanoTime();
+        try {
+            List<Segment> resultSegments = new ArrayList<>(refreshInput.existingSegments());
 
-        // Collect all source directories and their paths for a single batched addIndexes call
-        List<Directory> sourceDirectories = new ArrayList<>();
-        Set<Long> writerGenerations = new HashSet<>();
+            // Collect all source directories and their paths for a single batched addIndexes call
+            List<Directory> sourceDirectories = new ArrayList<>();
+            Set<Long> writerGenerations = new HashSet<>();
 
-        for (Segment segment : refreshInput.writerFiles()) {
-            WriterFileSet wfs = segment.dfGroupedSearchableFiles().get(LuceneDataFormat.LUCENE_FORMAT_NAME);
-            if (wfs == null) {
-                continue;
+            for (Segment segment : refreshInput.writerFiles()) {
+                WriterFileSet wfs = segment.dfGroupedSearchableFiles().get(LuceneDataFormat.LUCENE_FORMAT_NAME);
+                if (wfs == null) {
+                    continue;
+                }
+
+                Path dirPath = Path.of(wfs.directory());
+                if (Files.isDirectory(dirPath) == false) {
+                    logger.warn("Lucene writer directory does not exist: {}", dirPath);
+                    continue;
+                }
+
+                sourceDirectories.add(new HardlinkCopyDirectoryWrapper(new MMapDirectory(dirPath)));
+                writerGenerations.add(wfs.writerGeneration());
             }
 
-            Path dirPath = Path.of(wfs.directory());
-            if (Files.isDirectory(dirPath) == false) {
-                logger.warn("Lucene writer directory does not exist: {}", dirPath);
-                continue;
-            }
-
-            sourceDirectories.add(new HardlinkCopyDirectoryWrapper(new MMapDirectory(dirPath)));
-            writerGenerations.add(wfs.writerGeneration());
-        }
-
-        // Single batched addIndexes call for all source directories
-        if (sourceDirectories.isEmpty() == false) {
-            try {
-                sharedWriter.addIndexes(sourceDirectories.toArray(new Directory[0]));
-                logger.debug("Incorporated {} Lucene segments into shared writer in a single addIndexes call", sourceDirectories.size());
-            } finally {
-                // Close all source directories
-                for (Directory dir : sourceDirectories) {
-                    try {
-                        dir.close();
-                    } catch (IOException e) {
-                        logger.warn("Failed to close source directory after addIndexes", e);
+            // Single batched addIndexes call for all source directories
+            if (sourceDirectories.isEmpty() == false) {
+                long addIndexesStart = System.nanoTime();
+                try {
+                    sharedWriter.addIndexes(sourceDirectories.toArray(new Directory[0]));
+                    logger.debug(
+                        "Incorporated {} Lucene segments into shared writer in a single addIndexes call",
+                        sourceDirectories.size()
+                    );
+                } finally {
+                    stats.addRefreshAddIndexesTimeMillis(TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - addIndexesStart));
+                    // Close all source directories
+                    for (Directory dir : sourceDirectories) {
+                        try {
+                            dir.close();
+                        } catch (IOException e) {
+                            logger.warn("Failed to close source directory after addIndexes", e);
+                        }
                     }
                 }
-            }
 
-            // After addIndexes, open an NRT reader to discover the actual file names
-            // for the newly added segments. Lucene renames files during addIndexes,
-            // so the original temp directory file names are no longer valid.
-            Path sharedDir = store.shardPath().resolveIndex();
+                // After addIndexes, open an NRT reader to discover the actual file names
+                // for the newly added segments. Lucene renames files during addIndexes,
+                // so the original temp directory file names are no longer valid.
+                Path sharedDir = store.shardPath().resolveIndex();
 
-            try (DirectoryReader reader = DirectoryReader.open(sharedWriter)) {
-                List<LeafReaderContext> leaves = reader.leaves();
+                try (DirectoryReader reader = DirectoryReader.open(sharedWriter)) {
+                    List<LeafReaderContext> leaves = reader.leaves();
 
-                for (int i = 0; i < leaves.size(); i++) {
-                    LeafReaderContext ctx = leaves.get(i);
-                    if (ctx.reader() instanceof SegmentReader segReader) {
-                        SegmentCommitInfo segInfo = segReader.getSegmentInfo();
-                        String genAttr = segInfo.info.getAttribute(LuceneWriter.WRITER_GENERATION_ATTRIBUTE);
-                        if (genAttr == null) {
-                            continue;
+                    for (int i = 0; i < leaves.size(); i++) {
+                        LeafReaderContext ctx = leaves.get(i);
+                        if (ctx.reader() instanceof SegmentReader segReader) {
+                            SegmentCommitInfo segInfo = segReader.getSegmentInfo();
+                            String genAttr = segInfo.info.getAttribute(LuceneWriter.WRITER_GENERATION_ATTRIBUTE);
+                            if (genAttr == null) {
+                                continue;
+                            }
+
+                            long writerGen = Long.parseLong(genAttr);
+                            if (!writerGenerations.contains(writerGen)) {
+                                continue;
+                            }
+                            long numDocs = segReader.maxDoc();
+
+                            WriterFileSet.Builder wfsBuilder = WriterFileSet.builder()
+                                .directory(sharedDir)
+                                .writerGeneration(writerGen)
+                                .addNumRows(numDocs);
+
+                            for (String file : segInfo.files()) {
+                                wfsBuilder.addFile(file);
+                            }
+
+                            resultSegments.add(Segment.builder(writerGen).addSearchableFiles(dataFormat, wfsBuilder.build()).build());
+                            writerGenerations.remove(writerGen);
+                            stats.incRefreshSegmentsIncorporatedTotal();
                         }
-
-                        long writerGen = Long.parseLong(genAttr);
-                        if (!writerGenerations.contains(writerGen)) {
-                            continue;
-                        }
-                        long numDocs = segReader.maxDoc();
-
-                        WriterFileSet.Builder wfsBuilder = WriterFileSet.builder()
-                            .directory(sharedDir)
-                            .writerGeneration(writerGen)
-                            .addNumRows(numDocs);
-
-                        for (String file : segInfo.files()) {
-                            wfsBuilder.addFile(file);
-                        }
-
-                        resultSegments.add(Segment.builder(writerGen).addSearchableFiles(dataFormat, wfsBuilder.build()).build());
-                        writerGenerations.remove(writerGen);
                     }
                 }
+                assert writerGenerations.isEmpty() : "Could not get segments from all writers";
             }
             assert writerGenerations.isEmpty() : "Could not get segments from all writers";
 
@@ -362,9 +386,12 @@ public class LuceneIndexingExecutionEngine implements IndexingExecutionEngine<Lu
                     }
                 }
             }
-        }
 
-        return new RefreshResult(List.copyOf(resultSegments));
+            return new RefreshResult(List.copyOf(resultSegments));
+        } finally {
+            stats.incRefreshTotal();
+            stats.addRefreshTimeMillis(TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - refreshStart));
+        }
     }
 
     @Override
@@ -406,6 +433,11 @@ public class LuceneIndexingExecutionEngine implements IndexingExecutionEngine<Lu
     /** No-op — the {@link LuceneCommitter} owns the shared IndexWriter lifecycle. */
     @Override
     public void close() throws IOException {
+        // Unregister this shard's tracker from the stats provider before tearing down.
+        LuceneStatsProvider provider = (LuceneStatsProvider) DataFormatStatsProviderRegistry.INSTANCE.get(LuceneStatsProvider.FORMAT_NAME);
+        if (provider != null) {
+            provider.unregister(store.shardId());
+        }
         // LuceneCommitter owns the shared IndexWriter lifecycle
     }
 

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/index/LuceneIndexingExecutionEngine.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/index/LuceneIndexingExecutionEngine.java
@@ -130,20 +130,34 @@ public class LuceneIndexingExecutionEngine implements IndexingExecutionEngine<Lu
         // Create the lucene subdirectory if it doesn't exist, or clear stale contents
         // from a prior engine lifecycle. Any data here is either already hardlinked into
         // index/ (via addIndexes) or will be replayed from the translog on recovery.
-        if (Files.isDirectory(baseDirectory)) {
-            tryDeleteDirectory(baseDirectory);
-        }
+        boolean registered = false;
+        LuceneStatsProvider provider = null;
         try {
-            Files.createDirectories(baseDirectory);
-        } catch (IOException e) {
-            throw new RuntimeException("Failed to create lucene base directory: " + baseDirectory, e);
-        }
-        // Register this shard's tracker with the format-wide stats provider so the
-        // /_plugins/lucene/{index}/_stats and /_plugins/lucene/_nodes/{nodeId}/_stats
-        // REST endpoints can read live counters. Unregistered in close().
-        LuceneStatsProvider provider = (LuceneStatsProvider) DataFormatStatsProviderRegistry.INSTANCE.get(LuceneStatsProvider.FORMAT_NAME);
-        if (provider != null) {
-            provider.register(store.shardId(), stats);
+            if (Files.isDirectory(baseDirectory)) {
+                tryDeleteDirectory(baseDirectory);
+            }
+            try {
+                Files.createDirectories(baseDirectory);
+            } catch (IOException e) {
+                throw new RuntimeException("Failed to create lucene base directory: " + baseDirectory, e);
+            }
+            // Register this shard's tracker with the format-wide stats provider so the
+            // /_plugins/lucene/{index}/_stats and /_plugins/lucene/_nodes/{nodeId}/_stats
+            // REST endpoints can read live counters. Unregistered in close().
+            provider = (LuceneStatsProvider) DataFormatStatsProviderRegistry.INSTANCE.get(LuceneStatsProvider.FORMAT_NAME);
+            if (provider != null) {
+                provider.register(store.shardId(), stats);
+                registered = true;
+            }
+        } catch (Throwable t) {
+            if (registered && provider != null) {
+                try {
+                    provider.unregister(store.shardId());
+                } catch (Throwable rollbackErr) {
+                    logger.warn("Failed to unregister lucene stats tracker during constructor rollback", rollbackErr);
+                }
+            }
+            throw t;
         }
     }
 

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/index/LuceneWriter.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/index/LuceneWriter.java
@@ -51,6 +51,7 @@ import org.opensearch.index.engine.dataformat.Writer;
 import org.opensearch.index.engine.dataformat.WriterState;
 import org.opensearch.index.engine.exec.WriterFileSet;
 import org.opensearch.index.mapper.Uid;
+import org.opensearch.plugin.stats.StatsRecorder;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -356,11 +357,7 @@ public class LuceneWriter implements Writer<LuceneDocumentInput> {
 
             // Common path: forceMerge to 1 segment, commit, build FileInfos
             long forceMergeStartNanos = System.nanoTime();
-            try {
-                indexWriter.forceMerge(1, true);
-            } finally {
-                stats.addFlushForceMergeTimeMillis(TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - forceMergeStartNanos));
-            }
+            StatsRecorder.recordTimeMillis(() -> indexWriter.forceMerge(1, true), stats::addFlushForceMergeTimeMillis);
             long forceMergeDurationMs = TimeValue.nsecToMSec(System.nanoTime() - forceMergeStartNanos);
             logger.info(
                 "flush: forceMerge complete: generation={}, docCount={}, duration={}ms",

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/index/LuceneWriter.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/index/LuceneWriter.java
@@ -36,6 +36,7 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.MMapDirectory;
 import org.opensearch.be.lucene.LuceneDataFormat;
+import org.opensearch.be.lucene.stats.LuceneShardStatsTracker;
 import org.opensearch.common.annotation.ExperimentalApi;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.io.IOUtils;
@@ -60,6 +61,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Per-generation Lucene writer that creates segments in an isolated temporary directory.
@@ -97,6 +99,7 @@ public class LuceneWriter implements Writer<LuceneDocumentInput> {
 
     private final long writerGeneration;
     private final LuceneDataFormat dataFormat;
+    private final LuceneShardStatsTracker stats;
     private final Path tempDirectory;
     private final Directory directory;
     private final IndexWriter indexWriter;
@@ -116,6 +119,7 @@ public class LuceneWriter implements Writer<LuceneDocumentInput> {
      * @param analyzer         the analyzer to use for tokenized fields, or null for default
      * @param codec            the codec to use, or null for default
      * @param indexSort        the index sort to apply (null when Lucene is secondary format)
+     * @param stats            the shard-level stats collector
      * @throws IOException if directory creation or IndexWriter opening fails
      */
     public LuceneWriter(
@@ -126,11 +130,13 @@ public class LuceneWriter implements Writer<LuceneDocumentInput> {
         Analyzer analyzer,
         Codec codec,
         Sort indexSort,
-        Set<LuceneWriter> registry
+        Set<LuceneWriter> registry,
+        LuceneShardStatsTracker stats
     ) throws IOException {
         this.writerGeneration = writerGeneration;
         this.mappingVersion = mappingVersion;
         this.dataFormat = dataFormat;
+        this.stats = stats;
         this.docCount = 0;
         this.registry = registry;
 
@@ -218,27 +224,34 @@ public class LuceneWriter implements Writer<LuceneDocumentInput> {
      */
     @Override
     public WriteResult addDoc(LuceneDocumentInput input) throws IOException {
-        if (state != WriterState.ACTIVE) {
-            throw new IllegalStateException("addDoc requires ACTIVE state but was " + state);
-        }
-        // Defense-in-depth: CompositeWriter enforces rowId == docCount at the multiplexer
-        // layer, but we re-check here so a single-format Lucene path is also protected.
-        if (input.getRowId() != docCount) {
-            throw new IllegalStateException("rowId [" + input.getRowId() + "] does not match doc count [" + docCount + "]");
-        }
+        long start = System.nanoTime();
         try {
-            indexWriter.addDocument(input.getFinalInput());
-        } catch (IOException | IllegalArgumentException e) {
-            // Lucene's IndexWriter may have consumed a docId before throwing; advance our
-            // counter to match so rollbackTo can tombstone the partial slot, and
-            // retire to preserve the docId == rowId invariant for subsequent writes.
+            if (state != WriterState.ACTIVE) {
+                throw new IllegalStateException("addDoc requires ACTIVE state but was " + state);
+            }
+            // Defense-in-depth: CompositeWriter enforces rowId == docCount at the multiplexer
+            // layer, but we re-check here so a single-format Lucene path is also protected.
+            if (input.getRowId() != docCount) {
+                throw new IllegalStateException("rowId [" + input.getRowId() + "] does not match doc count [" + docCount + "]");
+            }
+            try {
+                indexWriter.addDocument(input.getFinalInput());
+            } catch (IOException | IllegalArgumentException e) {
+                // Lucene's IndexWriter may have consumed a docId before throwing; advance our
+                // counter to match so rollbackTo can tombstone the partial slot, and
+                // retire to preserve the docId == rowId invariant for subsequent writes.
+                docCount++;
+                state = WriterState.PENDING_ROLLBACK;
+                stats.incDocsIndexedFailures();
+                return new WriteResult.Failure(e, -1L, -1L, -1L);
+            }
+            long currentDocId = docCount;
             docCount++;
-            state = WriterState.PENDING_ROLLBACK;
-            return new WriteResult.Failure(e, -1L, -1L, -1L);
+            stats.addDocsIndexed(1);
+            return new WriteResult.Success(1L, 1L, currentDocId);
+        } finally {
+            stats.addIndexTimeMillis(TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start));
         }
-        long currentDocId = docCount;
-        docCount++;
-        return new WriteResult.Success(1L, 1L, currentDocId);
     }
 
     @Override
@@ -292,135 +305,145 @@ public class LuceneWriter implements Writer<LuceneDocumentInput> {
             return FileInfos.empty();
         }
 
-        long flushStartNanos = System.nanoTime();
-        logger.info(
-            "flush: START generation={}, docCount={}, hasRowIdMapping={}",
-            writerGeneration,
-            docCount,
-            flushInput.hasRowIdMapping()
-        );
-        indexWriter.flush();
+        long flushStart = System.nanoTime();
+        try {
+            long flushStartNanos = System.nanoTime();
+            logger.info(
+                "flush: START generation={}, docCount={}, hasRowIdMapping={}",
+                writerGeneration,
+                docCount,
+                flushInput.hasRowIdMapping()
+            );
+            indexWriter.flush();
 
-        // If sort permutation is provided, configure the reorder merge policy
-        if (flushInput.hasRowIdMapping()) {
-            // RowIdMapping shouldn't be available if index has sort configurations.
-            Sort configuredIndexSort = indexWriter.getConfig().getIndexSort();
-            if (configuredIndexSort != null) {
-                throw new IllegalStateException(
-                    "RowIdMapping should not be available when child IndexWriter is configured with IndexSort ["
-                        + configuredIndexSort
-                        + "] for writer generation ["
-                        + writerGeneration
-                        + "]"
-                );
-            }
-            RowIdMapping mapping = flushInput.rowIdMapping();
-            if (mapping.size() != docCount) {
-                throw new IllegalStateException(
-                    "RowIdMapping size ["
-                        + mapping.size()
-                        + "] does not match document count ["
-                        + docCount
-                        + "] for writer generation ["
-                        + writerGeneration
-                        + "]"
-                );
-            }
-            configureSortedMerge(mapping, state == WriterState.RETIRED_FLUSHABLE);
-        } else if (indexWriter.getConfig().getIndexSort() != null) {
-            // Lucene is primary with IndexSort: Lucene natively reorders docs during
-            // forceMerge, but __row_id__ values were assigned at insertion time and will
-            // be scrambled after sort. Force a merge so the codec rewrites row IDs to
-            // sequential 0..N-1 in the final doc order.
+            // If sort permutation is provided, configure the reorder merge policy
             if (flushInput.hasRowIdMapping()) {
-                throw new IllegalStateException(
-                    "RowIdMapping must not be provided when IndexSort is configured for writer generation [" + writerGeneration + "]"
-                );
+                // RowIdMapping shouldn't be available if index has sort configurations.
+                Sort configuredIndexSort = indexWriter.getConfig().getIndexSort();
+                if (configuredIndexSort != null) {
+                    throw new IllegalStateException(
+                        "RowIdMapping should not be available when child IndexWriter is configured with IndexSort ["
+                            + configuredIndexSort
+                            + "] for writer generation ["
+                            + writerGeneration
+                            + "]"
+                    );
+                }
+                RowIdMapping mapping = flushInput.rowIdMapping();
+                if (mapping.size() != docCount) {
+                    throw new IllegalStateException(
+                        "RowIdMapping size ["
+                            + mapping.size()
+                            + "] does not match document count ["
+                            + docCount
+                            + "] for writer generation ["
+                            + writerGeneration
+                            + "]"
+                    );
+                }
+                configureSortedMerge(mapping, state == WriterState.RETIRED_FLUSHABLE);
+            } else if (indexWriter.getConfig().getIndexSort() != null) {
+                // Lucene is primary with IndexSort: Lucene natively reorders docs during
+                // forceMerge, but __row_id__ values were assigned at insertion time and will
+                // be scrambled after sort. Force a merge so the codec rewrites row IDs to
+                // sequential 0..N-1 in the final doc order.
+                if (flushInput.hasRowIdMapping()) {
+                    throw new IllegalStateException(
+                        "RowIdMapping must not be provided when IndexSort is configured for writer generation [" + writerGeneration + "]"
+                    );
+                }
             }
-        }
 
-        // Common path: forceMerge to 1 segment, commit, build FileInfos
-        long forceMergeStartNanos = System.nanoTime();
-        indexWriter.forceMerge(1, true);
-        long forceMergeDurationMs = TimeValue.nsecToMSec(System.nanoTime() - forceMergeStartNanos);
-        logger.info(
-            "flush: forceMerge complete: generation={}, docCount={}, duration={}ms",
-            writerGeneration,
-            docCount,
-            forceMergeDurationMs
-        );
-
-        long commitStartNanos = System.nanoTime();
-        indexWriter.commit();
-        long commitDurationMs = TimeValue.nsecToMSec(System.nanoTime() - commitStartNanos);
-        logger.info("flush: commit complete: generation={}, duration={}ms", writerGeneration, commitDurationMs);
-
-        // Close the IndexWriter before rewriting segment metadata.
-        // This prevents IndexFileDeleter from removing our rewritten segments_N
-        // file (which it wouldn't recognize as its own commit).
-        indexWriter.close();
-
-        // Verify the invariant: exactly 1 segment with docCount documents
-        SegmentInfos segmentInfos = SegmentInfos.readLatestCommit(directory);
-        assert segmentInfos.size() == 1 : "Expected exactly 1 segment after force merge, got " + segmentInfos.size();
-
-        SegmentCommitInfo segmentInfo = segmentInfos.info(0);
-        // After flush the segment must contain exactly docCount live docs. Any tombstones
-        // from rollbackTo are expunged by the reordering forceMerge (secondary path)
-        // or by LogByteSizeMergePolicy's forceMerge (primary-with-indexSort path).
-        // TODO: this assertion will trip if Lucene is configured as the primary format
-        // without an IndexSort and a rollbackTo has run — the no-sort/no-mapping
-        // branch uses NoMergePolicy, so forceMerge is a no-op and the tombstone remains.
-        // Production never wires Lucene as primary without IndexSort, but tests that do
-        // need to either configure index.sort.field or avoid the rollback path.
-        assert segmentInfo.info.maxDoc() == docCount : "Expected " + docCount + " docs in segment, got " + segmentInfo.info.maxDoc();
-
-        // Invariant: ___row_id__ doc values must be sequential 0..maxDoc-1 after forceMerge.
-        // This holds in all cases:
-        // - Lucene secondary: docs reordered via OneMerge.reorder() + row ID rewrite
-        // - Lucene primary with IndexSort: Lucene sorts natively + row ID rewrite
-        // - No sort: docs added sequentially, row IDs naturally sequential
-        // Wrapped in `assert` so the I/O cost is paid only when assertions are enabled.
-        assert assertRowIdsSequential(directory) : "___row_id__ doc values not sequential after forceMerge for writer generation ["
-            + writerGeneration
-            + "]";
-
-        // Stamp the IndexSort on the segment metadata post-commit so that
-        // addIndexes(Directory...) on the shared writer sees matching sort.
-        // The segment is always sorted by __row_id__ — either naturally (docs
-        // written sequentially) or via OneMerge.reorder() + row ID rewrite.
-        if (flushInput.hasRowIdMapping()) {
-            logger.debug("Overriding segment info manually");
-            rewriteSegmentInfoWithSort(segmentInfos, segmentInfo);
-        }
-
-        // Build the WriterFileSet pointing to the temp directory
-        WriterFileSet.Builder wfsBuilder = WriterFileSet.builder()
-            .directory(tempDirectory)
-            .writerGeneration(writerGeneration)
-            .addNumRows(docCount);
-
-        // Add all files in the segment
-        for (String file : directory.listAll()) {
-            if (file.startsWith("segments") == false && file.equals("write.lock") == false) {
-                wfsBuilder.addFile(file);
+            // Common path: forceMerge to 1 segment, commit, build FileInfos
+            long forceMergeStartNanos = System.nanoTime();
+            try {
+                indexWriter.forceMerge(1, true);
+            } finally {
+                stats.addFlushForceMergeTimeMillis(TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - forceMergeStartNanos));
             }
+            long forceMergeDurationMs = TimeValue.nsecToMSec(System.nanoTime() - forceMergeStartNanos);
+            logger.info(
+                "flush: forceMerge complete: generation={}, docCount={}, duration={}ms",
+                writerGeneration,
+                docCount,
+                forceMergeDurationMs
+            );
+
+            long commitStartNanos = System.nanoTime();
+            indexWriter.commit();
+            long commitDurationMs = TimeValue.nsecToMSec(System.nanoTime() - commitStartNanos);
+            logger.info("flush: commit complete: generation={}, duration={}ms", writerGeneration, commitDurationMs);
+
+            // Close the IndexWriter before rewriting segment metadata.
+            // This prevents IndexFileDeleter from removing our rewritten segments_N
+            // file (which it wouldn't recognize as its own commit).
+            indexWriter.close();
+
+            // Verify the invariant: exactly 1 segment with docCount documents
+            SegmentInfos segmentInfos = SegmentInfos.readLatestCommit(directory);
+            assert segmentInfos.size() == 1 : "Expected exactly 1 segment after force merge, got " + segmentInfos.size();
+
+            SegmentCommitInfo segmentInfo = segmentInfos.info(0);
+            // After flush the segment must contain exactly docCount live docs. Any tombstones
+            // from rollbackTo are expunged by the reordering forceMerge (secondary path)
+            // or by LogByteSizeMergePolicy's forceMerge (primary-with-indexSort path).
+            // TODO: this assertion will trip if Lucene is configured as the primary format
+            // without an IndexSort and a rollbackTo has run — the no-sort/no-mapping
+            // branch uses NoMergePolicy, so forceMerge is a no-op and the tombstone remains.
+            // Production never wires Lucene as primary without IndexSort, but tests that do
+            // need to either configure index.sort.field or avoid the rollback path.
+            assert segmentInfo.info.maxDoc() == docCount : "Expected " + docCount + " docs in segment, got " + segmentInfo.info.maxDoc();
+
+            // Invariant: ___row_id__ doc values must be sequential 0..maxDoc-1 after forceMerge.
+            // This holds in all cases:
+            // - Lucene secondary: docs reordered via OneMerge.reorder() + row ID rewrite
+            // - Lucene primary with IndexSort: Lucene sorts natively + row ID rewrite
+            // - No sort: docs added sequentially, row IDs naturally sequential
+            // Wrapped in `assert` so the I/O cost is paid only when assertions are enabled.
+            assert assertRowIdsSequential(directory) : "___row_id__ doc values not sequential after forceMerge for writer generation ["
+                + writerGeneration
+                + "]";
+
+            // Stamp the IndexSort on the segment metadata post-commit so that
+            // addIndexes(Directory...) on the shared writer sees matching sort.
+            // The segment is always sorted by __row_id__ — either naturally (docs
+            // written sequentially) or via OneMerge.reorder() + row ID rewrite.
+            if (flushInput.hasRowIdMapping()) {
+                logger.debug("Overriding segment info manually");
+                rewriteSegmentInfoWithSort(segmentInfos, segmentInfo);
+            }
+
+            // Build the WriterFileSet pointing to the temp directory
+            WriterFileSet.Builder wfsBuilder = WriterFileSet.builder()
+                .directory(tempDirectory)
+                .writerGeneration(writerGeneration)
+                .addNumRows(docCount);
+
+            // Add all files in the segment
+            for (String file : directory.listAll()) {
+                if (file.startsWith("segments") == false && file.equals("write.lock") == false) {
+                    wfsBuilder.addFile(file);
+                }
+            }
+
+            directory.close();
+            flushed = true;
+
+            long totalFlushDurationMs = TimeValue.nsecToMSec(System.nanoTime() - flushStartNanos);
+            logger.info(
+                "flush: DONE generation={}, totalRows={}, forceMerge={}ms, commit={}ms, total={}ms",
+                writerGeneration,
+                docCount,
+                forceMergeDurationMs,
+                commitDurationMs,
+                totalFlushDurationMs
+            );
+
+            return FileInfos.builder().putWriterFileSet(dataFormat, wfsBuilder.build()).build();
+        } finally {
+            stats.incFlushTotal();
+            stats.addFlushTimeMillis(TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - flushStart));
         }
-
-        directory.close();
-        flushed = true;
-
-        long totalFlushDurationMs = TimeValue.nsecToMSec(System.nanoTime() - flushStartNanos);
-        logger.info(
-            "flush: DONE generation={}, totalRows={}, forceMerge={}ms, commit={}ms, total={}ms",
-            writerGeneration,
-            docCount,
-            forceMergeDurationMs,
-            commitDurationMs,
-            totalFlushDurationMs
-        );
-
-        return FileInfos.builder().putWriterFileSet(dataFormat, wfsBuilder.build()).build();
     }
 
     /**

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/merge/LuceneMerger.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/merge/LuceneMerger.java
@@ -15,6 +15,7 @@ import org.apache.lucene.index.MergeIndexWriter;
 import org.apache.lucene.index.MergePolicy;
 import org.apache.lucene.index.SegmentCommitInfo;
 import org.apache.lucene.index.SegmentInfos;
+import org.opensearch.be.lucene.stats.LuceneShardStatsTracker;
 import org.opensearch.common.SuppressForbidden;
 import org.opensearch.common.annotation.ExperimentalApi;
 import org.opensearch.index.engine.dataformat.DataFormat;
@@ -33,6 +34,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import static org.opensearch.be.lucene.index.LuceneWriter.WRITER_GENERATION_ATTRIBUTE;
 
@@ -79,84 +81,95 @@ public class LuceneMerger implements Merger {
     private final DataFormat dataFormat;
     private final Path storeDirectory;
     private final LuceneMergeStrategy strategy;
+    private final LuceneShardStatsTracker stats;
 
-    public LuceneMerger(MergeIndexWriter indexWriter, DataFormat dataFormat, Path storeDirectory) {
+    public LuceneMerger(MergeIndexWriter indexWriter, DataFormat dataFormat, Path storeDirectory, LuceneShardStatsTracker stats) {
         if (indexWriter == null) {
             throw new IllegalArgumentException("IndexWriter must not be null");
         }
         this.indexWriter = indexWriter;
         this.dataFormat = dataFormat;
         this.storeDirectory = storeDirectory;
+        this.stats = stats;
         // TODO implement primary and integrate the same here
         this.strategy = new SecondaryLuceneMergeStrategy();
     }
 
     @Override
     public MergeResult merge(MergeInput mergeInput) throws IOException {
-        RowIdMapping rowIdMapping = mergeInput.rowIdMapping();
-        List<Segment> segments = mergeInput.segments();
-
-        if (segments.isEmpty()) {
-            return new MergeResult(Map.of());
-        }
-
-        Set<Long> generationsToMerge = new HashSet<>();
-        for (Segment segment : segments) {
-            generationsToMerge.add(segment.generation());
-        }
-
-        SegmentInfos segmentInfos;
+        long start = System.nanoTime();
         try {
-            segmentInfos = (SegmentInfos) SEGMENT_INFOS_FIELD.get(indexWriter);
-        } catch (IllegalAccessException e) {
-            throw new IOException("Failed to access IndexWriter segmentInfos via reflection", e);
-        }
+            RowIdMapping rowIdMapping = mergeInput.rowIdMapping();
+            List<Segment> segments = mergeInput.segments();
 
-        if (segmentInfos.size() == 0) {
-            logger.warn("No segments in IndexWriter — skipping merge");
-            return new MergeResult(Map.of());
-        }
+            if (segments.isEmpty()) {
+                return new MergeResult(Map.of());
+            }
 
-        List<SegmentCommitInfo> matchingSegments = findMatchingSegments(segmentInfos, generationsToMerge);
+            Set<Long> generationsToMerge = new HashSet<>();
+            for (Segment segment : segments) {
+                generationsToMerge.add(segment.generation());
+            }
 
-        if (matchingSegments.isEmpty()) {
-            throw new IOException(
-                "No Lucene segments found matching writer generations "
-                    + generationsToMerge
-                    + " — segments may have been consumed by a concurrent merge"
+            SegmentInfos segmentInfos;
+            try {
+                segmentInfos = (SegmentInfos) SEGMENT_INFOS_FIELD.get(indexWriter);
+            } catch (IllegalAccessException e) {
+                throw new IOException("Failed to access IndexWriter segmentInfos via reflection", e);
+            }
+
+            if (segmentInfos.size() == 0) {
+                logger.warn("No segments in IndexWriter — skipping merge");
+                return new MergeResult(Map.of());
+            }
+
+            List<SegmentCommitInfo> matchingSegments = findMatchingSegments(segmentInfos, generationsToMerge);
+
+            if (matchingSegments.isEmpty()) {
+                throw new IOException(
+                    "No Lucene segments found matching writer generations "
+                        + generationsToMerge
+                        + " — segments may have been consumed by a concurrent merge"
+                );
+            }
+
+            logger.debug(
+                "LuceneMerger: merging {} segments (generations {}) using merge(OneMerge) + IndexSort",
+                matchingSegments.size(),
+                generationsToMerge
             );
+
+            // Delegate OneMerge creation to the strategy (primary vs secondary behavior).
+            // For the secondary path, the returned RowIdRemappingOneMerge stamps the
+            // writer_generation attribute onto the merged SegmentInfo via setMergeInfo, which
+            // Lucene invokes immediately before codec.segmentInfoFormat().write(...) — so the
+            // attribute is persisted to the .si file and survives a writer reopen.
+            MergePolicy.OneMerge oneMerge = strategy.createOneMerge(matchingSegments, rowIdMapping, mergeInput.newWriterGeneration());
+            indexWriter.executeMerge(oneMerge, mergeInput.newWriterGeneration());
+
+            // Build the merged WriterFileSet from the output segment info
+            SegmentCommitInfo mergedInfo = oneMerge.getMergeInfo();
+            WriterFileSet mergedFileSet = buildMergedFileSet(mergedInfo, mergeInput.newWriterGeneration());
+
+            // Delegate RowIdMapping production to the strategy
+            RowIdMapping outputMapping = strategy.buildRowIdMapping(oneMerge, mergeInput);
+
+            logger.debug(
+                "LuceneMerger: completed merge of {} segments at generation {} ({} docs, {} files)",
+                matchingSegments.size(),
+                mergeInput.newWriterGeneration(),
+                oneMerge.getMergeInfo().info.maxDoc(),
+                oneMerge.getMergeInfo().files().size()
+            );
+
+            stats.incMergeTotal();
+            return new MergeResult(Map.of(dataFormat, mergedFileSet), outputMapping);
+        } catch (IOException e) {
+            stats.incMergeFailures();
+            throw e;
+        } finally {
+            stats.addMergeTimeMillis(TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start));
         }
-
-        logger.debug(
-            "LuceneMerger: merging {} segments (generations {}) using merge(OneMerge) + IndexSort",
-            matchingSegments.size(),
-            generationsToMerge
-        );
-
-        // Delegate OneMerge creation to the strategy (primary vs secondary behavior).
-        // For the secondary path, the returned RowIdRemappingOneMerge stamps the
-        // writer_generation attribute onto the merged SegmentInfo via setMergeInfo, which
-        // Lucene invokes immediately before codec.segmentInfoFormat().write(...) — so the
-        // attribute is persisted to the .si file and survives a writer reopen.
-        MergePolicy.OneMerge oneMerge = strategy.createOneMerge(matchingSegments, rowIdMapping, mergeInput.newWriterGeneration());
-        indexWriter.executeMerge(oneMerge, mergeInput.newWriterGeneration());
-
-        // Build the merged WriterFileSet from the output segment info
-        SegmentCommitInfo mergedInfo = oneMerge.getMergeInfo();
-        WriterFileSet mergedFileSet = buildMergedFileSet(mergedInfo, mergeInput.newWriterGeneration());
-
-        // Delegate RowIdMapping production to the strategy
-        RowIdMapping outputMapping = strategy.buildRowIdMapping(oneMerge, mergeInput);
-
-        logger.debug(
-            "LuceneMerger: completed merge of {} segments at generation {} ({} docs, {} files)",
-            matchingSegments.size(),
-            mergeInput.newWriterGeneration(),
-            oneMerge.getMergeInfo().info.maxDoc(),
-            oneMerge.getMergeInfo().files().size()
-        );
-
-        return new MergeResult(Map.of(dataFormat, mergedFileSet), outputMapping);
     }
 
     /**

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/stats/LuceneShardStats.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/stats/LuceneShardStats.java
@@ -49,6 +49,7 @@ public class LuceneShardStats implements DataFormatShardStats<LuceneShardStats> 
     // Commit
     private final long commitTotal;
     private final long commitTimeMillis;
+    private final long commitFailures;
 
     // Delete
     private final long deleteTotal;
@@ -59,7 +60,7 @@ public class LuceneShardStats implements DataFormatShardStats<LuceneShardStats> 
      * Used by transport actions when a shard does not have a Lucene secondary delegate.
      */
     public static LuceneShardStats empty() {
-        return new LuceneShardStats(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+        return new LuceneShardStats(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
     }
 
     /**
@@ -81,6 +82,7 @@ public class LuceneShardStats implements DataFormatShardStats<LuceneShardStats> 
         long mergeFailures,
         long commitTotal,
         long commitTimeMillis,
+        long commitFailures,
         long deleteTotal,
         long deleteTimeMillis
     ) {
@@ -99,6 +101,7 @@ public class LuceneShardStats implements DataFormatShardStats<LuceneShardStats> 
         this.mergeFailures = mergeFailures;
         this.commitTotal = commitTotal;
         this.commitTimeMillis = commitTimeMillis;
+        this.commitFailures = commitFailures;
         this.deleteTotal = deleteTotal;
         this.deleteTimeMillis = deleteTimeMillis;
     }
@@ -128,6 +131,7 @@ public class LuceneShardStats implements DataFormatShardStats<LuceneShardStats> 
         // Commit
         this.commitTotal = in.readVLong();
         this.commitTimeMillis = in.readVLong();
+        this.commitFailures = in.readVLong();
 
         // Delete
         this.deleteTotal = in.readVLong();
@@ -160,6 +164,7 @@ public class LuceneShardStats implements DataFormatShardStats<LuceneShardStats> 
         // Commit
         out.writeVLong(commitTotal);
         out.writeVLong(commitTimeMillis);
+        out.writeVLong(commitFailures);
 
         // Delete
         out.writeVLong(deleteTotal);
@@ -201,6 +206,7 @@ public class LuceneShardStats implements DataFormatShardStats<LuceneShardStats> 
         builder.startObject("commit");
         builder.field("commit_total", commitTotal);
         builder.field("commit_time_millis", commitTimeMillis);
+        builder.field("commit_failures", commitFailures);
         builder.endObject();
 
         // Delete
@@ -234,6 +240,7 @@ public class LuceneShardStats implements DataFormatShardStats<LuceneShardStats> 
             this.mergeFailures + other.mergeFailures,
             this.commitTotal + other.commitTotal,
             this.commitTimeMillis + other.commitTimeMillis,
+            this.commitFailures + other.commitFailures,
             this.deleteTotal + other.deleteTotal,
             this.deleteTimeMillis + other.deleteTimeMillis
         );

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/stats/LuceneShardStats.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/stats/LuceneShardStats.java
@@ -1,0 +1,241 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.lucene.stats;
+
+import org.opensearch.common.annotation.ExperimentalApi;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.plugin.stats.DataFormatShardStats;
+
+import java.io.IOException;
+
+/**
+ * Immutable point-in-time snapshot of shard-level Lucene statistics.
+ * Produced by {@link LuceneShardStatsTracker#stats()}.
+ *
+ * @opensearch.experimental
+ */
+@ExperimentalApi
+public class LuceneShardStats implements DataFormatShardStats<LuceneShardStats> {
+
+    // Indexing
+    private final long docsIndexedTotal;
+    private final long docsIndexedFailures;
+    private final long indexTimeMillis;
+
+    // Flush
+    private final long flushTotal;
+    private final long flushTimeMillis;
+    private final long flushForceMergeTimeMillis;
+
+    // Refresh
+    private final long refreshTotal;
+    private final long refreshTimeMillis;
+    private final long refreshAddIndexesTimeMillis;
+    private final long refreshSegmentsIncorporatedTotal;
+
+    // Merge
+    private final long mergeTotal;
+    private final long mergeTimeMillis;
+    private final long mergeFailures;
+
+    // Commit
+    private final long commitTotal;
+    private final long commitTimeMillis;
+
+    // Delete
+    private final long deleteTotal;
+    private final long deleteTimeMillis;
+
+    /**
+     * Returns an empty LuceneShardStats snapshot with all zero counters.
+     * Used by transport actions when a shard does not have a Lucene secondary delegate.
+     */
+    public static LuceneShardStats empty() {
+        return new LuceneShardStats(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+    }
+
+    /**
+     * Constructs a snapshot with all values.
+     */
+    public LuceneShardStats(
+        long docsIndexedTotal,
+        long docsIndexedFailures,
+        long indexTimeMillis,
+        long flushTotal,
+        long flushTimeMillis,
+        long flushForceMergeTimeMillis,
+        long refreshTotal,
+        long refreshTimeMillis,
+        long refreshAddIndexesTimeMillis,
+        long refreshSegmentsIncorporatedTotal,
+        long mergeTotal,
+        long mergeTimeMillis,
+        long mergeFailures,
+        long commitTotal,
+        long commitTimeMillis,
+        long deleteTotal,
+        long deleteTimeMillis
+    ) {
+        this.docsIndexedTotal = docsIndexedTotal;
+        this.docsIndexedFailures = docsIndexedFailures;
+        this.indexTimeMillis = indexTimeMillis;
+        this.flushTotal = flushTotal;
+        this.flushTimeMillis = flushTimeMillis;
+        this.flushForceMergeTimeMillis = flushForceMergeTimeMillis;
+        this.refreshTotal = refreshTotal;
+        this.refreshTimeMillis = refreshTimeMillis;
+        this.refreshAddIndexesTimeMillis = refreshAddIndexesTimeMillis;
+        this.refreshSegmentsIncorporatedTotal = refreshSegmentsIncorporatedTotal;
+        this.mergeTotal = mergeTotal;
+        this.mergeTimeMillis = mergeTimeMillis;
+        this.mergeFailures = mergeFailures;
+        this.commitTotal = commitTotal;
+        this.commitTimeMillis = commitTimeMillis;
+        this.deleteTotal = deleteTotal;
+        this.deleteTimeMillis = deleteTimeMillis;
+    }
+
+    public LuceneShardStats(StreamInput in) throws IOException {
+        // Indexing
+        this.docsIndexedTotal = in.readVLong();
+        this.docsIndexedFailures = in.readVLong();
+        this.indexTimeMillis = in.readVLong();
+
+        // Flush
+        this.flushTotal = in.readVLong();
+        this.flushTimeMillis = in.readVLong();
+        this.flushForceMergeTimeMillis = in.readVLong();
+
+        // Refresh
+        this.refreshTotal = in.readVLong();
+        this.refreshTimeMillis = in.readVLong();
+        this.refreshAddIndexesTimeMillis = in.readVLong();
+        this.refreshSegmentsIncorporatedTotal = in.readVLong();
+
+        // Merge
+        this.mergeTotal = in.readVLong();
+        this.mergeTimeMillis = in.readVLong();
+        this.mergeFailures = in.readVLong();
+
+        // Commit
+        this.commitTotal = in.readVLong();
+        this.commitTimeMillis = in.readVLong();
+
+        // Delete
+        this.deleteTotal = in.readVLong();
+        this.deleteTimeMillis = in.readVLong();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        // Indexing
+        out.writeVLong(docsIndexedTotal);
+        out.writeVLong(docsIndexedFailures);
+        out.writeVLong(indexTimeMillis);
+
+        // Flush
+        out.writeVLong(flushTotal);
+        out.writeVLong(flushTimeMillis);
+        out.writeVLong(flushForceMergeTimeMillis);
+
+        // Refresh
+        out.writeVLong(refreshTotal);
+        out.writeVLong(refreshTimeMillis);
+        out.writeVLong(refreshAddIndexesTimeMillis);
+        out.writeVLong(refreshSegmentsIncorporatedTotal);
+
+        // Merge
+        out.writeVLong(mergeTotal);
+        out.writeVLong(mergeTimeMillis);
+        out.writeVLong(mergeFailures);
+
+        // Commit
+        out.writeVLong(commitTotal);
+        out.writeVLong(commitTimeMillis);
+
+        // Delete
+        out.writeVLong(deleteTotal);
+        out.writeVLong(deleteTimeMillis);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        // Indexing
+        builder.startObject("indexing");
+        builder.field("docs_indexed_total", docsIndexedTotal);
+        builder.field("docs_indexed_failures", docsIndexedFailures);
+        builder.field("index_time_millis", indexTimeMillis);
+        builder.endObject();
+
+        // Flush
+        builder.startObject("flush");
+        builder.field("flush_total", flushTotal);
+        builder.field("flush_time_millis", flushTimeMillis);
+        builder.field("flush_force_merge_time_millis", flushForceMergeTimeMillis);
+        builder.endObject();
+
+        // Refresh
+        builder.startObject("refresh");
+        builder.field("refresh_total", refreshTotal);
+        builder.field("refresh_time_millis", refreshTimeMillis);
+        builder.field("refresh_add_indexes_time_millis", refreshAddIndexesTimeMillis);
+        builder.field("refresh_segments_incorporated_total", refreshSegmentsIncorporatedTotal);
+        builder.endObject();
+
+        // Merge
+        builder.startObject("merge");
+        builder.field("merge_total", mergeTotal);
+        builder.field("merge_time_millis", mergeTimeMillis);
+        builder.field("merge_failures", mergeFailures);
+        builder.endObject();
+
+        // Commit
+        builder.startObject("commit");
+        builder.field("commit_total", commitTotal);
+        builder.field("commit_time_millis", commitTimeMillis);
+        builder.endObject();
+
+        // Delete
+        builder.startObject("delete");
+        builder.field("delete_total", deleteTotal);
+        builder.field("delete_time_millis", deleteTimeMillis);
+        builder.endObject();
+
+        return builder;
+    }
+
+    /**
+     * Returns a new snapshot that is the sum of this snapshot and another.
+     * Used for aggregation across shards.
+     */
+    @Override
+    public LuceneShardStats add(LuceneShardStats other) {
+        return new LuceneShardStats(
+            this.docsIndexedTotal + other.docsIndexedTotal,
+            this.docsIndexedFailures + other.docsIndexedFailures,
+            this.indexTimeMillis + other.indexTimeMillis,
+            this.flushTotal + other.flushTotal,
+            this.flushTimeMillis + other.flushTimeMillis,
+            this.flushForceMergeTimeMillis + other.flushForceMergeTimeMillis,
+            this.refreshTotal + other.refreshTotal,
+            this.refreshTimeMillis + other.refreshTimeMillis,
+            this.refreshAddIndexesTimeMillis + other.refreshAddIndexesTimeMillis,
+            this.refreshSegmentsIncorporatedTotal + other.refreshSegmentsIncorporatedTotal,
+            this.mergeTotal + other.mergeTotal,
+            this.mergeTimeMillis + other.mergeTimeMillis,
+            this.mergeFailures + other.mergeFailures,
+            this.commitTotal + other.commitTotal,
+            this.commitTimeMillis + other.commitTimeMillis,
+            this.deleteTotal + other.deleteTotal,
+            this.deleteTimeMillis + other.deleteTimeMillis
+        );
+    }
+}

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/stats/LuceneShardStats.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/stats/LuceneShardStats.java
@@ -50,6 +50,7 @@ public class LuceneShardStats implements DataFormatShardStats<LuceneShardStats> 
     private final long commitTotal;
     private final long commitTimeMillis;
     private final long commitFailures;
+    private final long commitSyncTimeMillis;
 
     // Delete
     private final long deleteTotal;
@@ -60,7 +61,7 @@ public class LuceneShardStats implements DataFormatShardStats<LuceneShardStats> 
      * Used by transport actions when a shard does not have a Lucene secondary delegate.
      */
     public static LuceneShardStats empty() {
-        return new LuceneShardStats(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+        return new LuceneShardStats(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
     }
 
     /**
@@ -83,6 +84,7 @@ public class LuceneShardStats implements DataFormatShardStats<LuceneShardStats> 
         long commitTotal,
         long commitTimeMillis,
         long commitFailures,
+        long commitSyncTimeMillis,
         long deleteTotal,
         long deleteTimeMillis
     ) {
@@ -102,6 +104,7 @@ public class LuceneShardStats implements DataFormatShardStats<LuceneShardStats> 
         this.commitTotal = commitTotal;
         this.commitTimeMillis = commitTimeMillis;
         this.commitFailures = commitFailures;
+        this.commitSyncTimeMillis = commitSyncTimeMillis;
         this.deleteTotal = deleteTotal;
         this.deleteTimeMillis = deleteTimeMillis;
     }
@@ -132,6 +135,7 @@ public class LuceneShardStats implements DataFormatShardStats<LuceneShardStats> 
         this.commitTotal = in.readVLong();
         this.commitTimeMillis = in.readVLong();
         this.commitFailures = in.readVLong();
+        this.commitSyncTimeMillis = in.readVLong();
 
         // Delete
         this.deleteTotal = in.readVLong();
@@ -165,6 +169,7 @@ public class LuceneShardStats implements DataFormatShardStats<LuceneShardStats> 
         out.writeVLong(commitTotal);
         out.writeVLong(commitTimeMillis);
         out.writeVLong(commitFailures);
+        out.writeVLong(commitSyncTimeMillis);
 
         // Delete
         out.writeVLong(deleteTotal);
@@ -207,6 +212,7 @@ public class LuceneShardStats implements DataFormatShardStats<LuceneShardStats> 
         builder.field("commit_total", commitTotal);
         builder.field("commit_time_millis", commitTimeMillis);
         builder.field("commit_failures", commitFailures);
+        builder.field("commit_sync_time_millis", commitSyncTimeMillis);
         builder.endObject();
 
         // Delete
@@ -241,6 +247,7 @@ public class LuceneShardStats implements DataFormatShardStats<LuceneShardStats> 
             this.commitTotal + other.commitTotal,
             this.commitTimeMillis + other.commitTimeMillis,
             this.commitFailures + other.commitFailures,
+            this.commitSyncTimeMillis + other.commitSyncTimeMillis,
             this.deleteTotal + other.deleteTotal,
             this.deleteTimeMillis + other.deleteTimeMillis
         );

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/stats/LuceneShardStatsTracker.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/stats/LuceneShardStatsTracker.java
@@ -47,6 +47,7 @@ public class LuceneShardStatsTracker {
     private final LongAdder commitTotal = new LongAdder();
     private final LongAdder commitTimeMillis = new LongAdder();
     private final LongAdder commitFailures = new LongAdder();
+    private final LongAdder commitSyncTimeMillis = new LongAdder();
 
     // Delete counters
     private final LongAdder deleteTotal = new LongAdder();
@@ -73,6 +74,7 @@ public class LuceneShardStatsTracker {
             commitTotal.sum(),
             commitTimeMillis.sum(),
             commitFailures.sum(),
+            commitSyncTimeMillis.sum(),
             deleteTotal.sum(),
             deleteTimeMillis.sum()
         );
@@ -150,6 +152,10 @@ public class LuceneShardStatsTracker {
 
     public void incCommitFailures() {
         commitFailures.increment();
+    }
+
+    public void addCommitSyncTimeMillis(long ms) {
+        commitSyncTimeMillis.add(ms);
     }
 
     // --- Delete methods ---

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/stats/LuceneShardStatsTracker.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/stats/LuceneShardStatsTracker.java
@@ -1,0 +1,158 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.lucene.stats;
+
+import org.opensearch.common.annotation.ExperimentalApi;
+
+import java.util.concurrent.atomic.LongAdder;
+
+/**
+ * Mutable, thread-safe shard-level statistics tracker for the Lucene data format plugin.
+ * Uses LongAdder for high-throughput counters.
+ * Call {@link #stats()} to obtain an immutable {@link LuceneShardStats} snapshot.
+ *
+ * @opensearch.experimental
+ */
+@ExperimentalApi
+public class LuceneShardStatsTracker {
+
+    // Indexing counters
+    private final LongAdder docsIndexedTotal = new LongAdder();
+    private final LongAdder docsIndexedFailures = new LongAdder();
+    private final LongAdder indexTimeMillis = new LongAdder();
+
+    // Flush counters
+    private final LongAdder flushTotal = new LongAdder();
+    private final LongAdder flushTimeMillis = new LongAdder();
+    private final LongAdder flushForceMergeTimeMillis = new LongAdder();
+
+    // Refresh counters
+    private final LongAdder refreshTotal = new LongAdder();
+    private final LongAdder refreshTimeMillis = new LongAdder();
+    private final LongAdder refreshAddIndexesTimeMillis = new LongAdder();
+    private final LongAdder refreshSegmentsIncorporatedTotal = new LongAdder();
+
+    // Merge counters
+    private final LongAdder mergeTotal = new LongAdder();
+    private final LongAdder mergeTimeMillis = new LongAdder();
+    private final LongAdder mergeFailures = new LongAdder();
+
+    // Commit counters
+    private final LongAdder commitTotal = new LongAdder();
+    private final LongAdder commitTimeMillis = new LongAdder();
+
+    // Delete counters
+    private final LongAdder deleteTotal = new LongAdder();
+    private final LongAdder deleteTimeMillis = new LongAdder();
+
+    /**
+     * Returns an immutable point-in-time snapshot of all tracked statistics.
+     */
+    public LuceneShardStats stats() {
+        return new LuceneShardStats(
+            docsIndexedTotal.sum(),
+            docsIndexedFailures.sum(),
+            indexTimeMillis.sum(),
+            flushTotal.sum(),
+            flushTimeMillis.sum(),
+            flushForceMergeTimeMillis.sum(),
+            refreshTotal.sum(),
+            refreshTimeMillis.sum(),
+            refreshAddIndexesTimeMillis.sum(),
+            refreshSegmentsIncorporatedTotal.sum(),
+            mergeTotal.sum(),
+            mergeTimeMillis.sum(),
+            mergeFailures.sum(),
+            commitTotal.sum(),
+            commitTimeMillis.sum(),
+            deleteTotal.sum(),
+            deleteTimeMillis.sum()
+        );
+    }
+
+    // --- Indexing methods ---
+
+    public void addDocsIndexed(long n) {
+        docsIndexedTotal.add(n);
+    }
+
+    public void incDocsIndexedFailures() {
+        docsIndexedFailures.increment();
+    }
+
+    public void addIndexTimeMillis(long ms) {
+        indexTimeMillis.add(ms);
+    }
+
+    // --- Flush methods ---
+
+    public void incFlushTotal() {
+        flushTotal.increment();
+    }
+
+    public void addFlushTimeMillis(long ms) {
+        flushTimeMillis.add(ms);
+    }
+
+    public void addFlushForceMergeTimeMillis(long ms) {
+        flushForceMergeTimeMillis.add(ms);
+    }
+
+    // --- Refresh methods ---
+
+    public void incRefreshTotal() {
+        refreshTotal.increment();
+    }
+
+    public void addRefreshTimeMillis(long ms) {
+        refreshTimeMillis.add(ms);
+    }
+
+    public void addRefreshAddIndexesTimeMillis(long ms) {
+        refreshAddIndexesTimeMillis.add(ms);
+    }
+
+    public void incRefreshSegmentsIncorporatedTotal() {
+        refreshSegmentsIncorporatedTotal.increment();
+    }
+
+    // --- Merge methods ---
+
+    public void incMergeTotal() {
+        mergeTotal.increment();
+    }
+
+    public void addMergeTimeMillis(long ms) {
+        mergeTimeMillis.add(ms);
+    }
+
+    public void incMergeFailures() {
+        mergeFailures.increment();
+    }
+
+    // --- Commit methods ---
+
+    public void incCommitTotal() {
+        commitTotal.increment();
+    }
+
+    public void addCommitTimeMillis(long ms) {
+        commitTimeMillis.add(ms);
+    }
+
+    // --- Delete methods ---
+
+    public void incDeleteTotal() {
+        deleteTotal.increment();
+    }
+
+    public void addDeleteTimeMillis(long ms) {
+        deleteTimeMillis.add(ms);
+    }
+}

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/stats/LuceneShardStatsTracker.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/stats/LuceneShardStatsTracker.java
@@ -46,6 +46,7 @@ public class LuceneShardStatsTracker {
     // Commit counters
     private final LongAdder commitTotal = new LongAdder();
     private final LongAdder commitTimeMillis = new LongAdder();
+    private final LongAdder commitFailures = new LongAdder();
 
     // Delete counters
     private final LongAdder deleteTotal = new LongAdder();
@@ -71,6 +72,7 @@ public class LuceneShardStatsTracker {
             mergeFailures.sum(),
             commitTotal.sum(),
             commitTimeMillis.sum(),
+            commitFailures.sum(),
             deleteTotal.sum(),
             deleteTimeMillis.sum()
         );
@@ -144,6 +146,10 @@ public class LuceneShardStatsTracker {
 
     public void addCommitTimeMillis(long ms) {
         commitTimeMillis.add(ms);
+    }
+
+    public void incCommitFailures() {
+        commitFailures.increment();
     }
 
     // --- Delete methods ---

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/stats/LuceneStatsProvider.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/stats/LuceneStatsProvider.java
@@ -1,0 +1,107 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.lucene.stats;
+
+import org.opensearch.common.annotation.ExperimentalApi;
+import org.opensearch.core.common.io.stream.Writeable;
+import org.opensearch.core.index.shard.ShardId;
+import org.opensearch.plugin.stats.DataFormatStatsProvider;
+import org.opensearch.plugin.stats.DataFormatStatsProviderRegistry;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Lucene implementation of {@link DataFormatStatsProvider}.
+ *
+ * <p>Maintains a per-shard registry of {@link LuceneShardStatsTracker} instances.
+ * {@code LuceneIndexingExecutionEngine} self-registers on construction and
+ * unregisters on close. The composite-engine plugin reads stats from this
+ * provider via the {@link DataFormatStatsProvider} interface — no direct
+ * dependency on lucene's concrete classes.
+ *
+ * <p>Singleton pattern: a static {@code INSTANCE} field is set during plugin
+ * construction so the engine layer can register its tracker without DI plumbing.
+ *
+ * @opensearch.experimental
+ */
+@ExperimentalApi
+public final class LuceneStatsProvider implements DataFormatStatsProvider<LuceneShardStats> {
+
+    public static final String FORMAT_NAME = "lucene";
+
+    private static volatile LuceneStatsProvider INSTANCE;
+
+    private final Map<ShardId, LuceneShardStatsTracker> trackers = new ConcurrentHashMap<>();
+
+    public LuceneStatsProvider() {
+        if (INSTANCE == null) {
+            INSTANCE = this;
+        }
+        DataFormatStatsProviderRegistry.INSTANCE.register(this);
+    }
+
+    /** Returns the singleton instance, or {@code null} if the plugin has not been constructed yet. */
+    public static LuceneStatsProvider getInstance() {
+        return INSTANCE;
+    }
+
+    /** Registers a tracker for a shard. Called from {@code LuceneIndexingExecutionEngine}'s constructor. */
+    public void register(ShardId shardId, LuceneShardStatsTracker tracker) {
+        trackers.put(shardId, tracker);
+    }
+
+    /** Unregisters a tracker. Called from the engine's {@code close()} method. */
+    public void unregister(ShardId shardId) {
+        trackers.remove(shardId);
+    }
+
+    /**
+     * Returns the registered tracker for a shard, or null if none.
+     * Used by {@code LuceneCommitter} and {@code LuceneDeleteExecutionEngine} to increment
+     * their counters into the same tracker the engine registered.
+     */
+    public LuceneShardStatsTracker getTracker(ShardId shardId) {
+        return trackers.get(shardId);
+    }
+
+    // --- DataFormatStatsProvider ---
+
+    @Override
+    public String formatName() {
+        return FORMAT_NAME;
+    }
+
+    @Override
+    public Optional<LuceneShardStats> shardStats(ShardId shardId) {
+        LuceneShardStatsTracker tracker = trackers.get(shardId);
+        if (tracker == null) {
+            return Optional.empty();
+        }
+        return Optional.of(tracker.stats());
+    }
+
+    @Override
+    public Optional<LuceneShardStats> aggregateNodeStats() {
+        if (trackers.isEmpty()) {
+            return Optional.empty();
+        }
+        LuceneShardStats agg = LuceneShardStats.empty();
+        for (LuceneShardStatsTracker t : trackers.values()) {
+            agg = agg.add(t.stats());
+        }
+        return Optional.of(agg);
+    }
+
+    @Override
+    public Writeable.Reader<LuceneShardStats> shardStatsReader() {
+        return LuceneShardStats::new;
+    }
+}

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/stats/package-info.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/stats/package-info.java
@@ -1,0 +1,14 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/**
+ * Statistics collection for the Lucene data format backend.
+ *
+ * @opensearch.experimental
+ */
+package org.opensearch.be.lucene.stats;

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/stats/transport/LuceneNodeStatsActionType.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/stats/transport/LuceneNodeStatsActionType.java
@@ -1,0 +1,30 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.lucene.stats.transport;
+
+import org.opensearch.be.lucene.stats.LuceneShardStats;
+import org.opensearch.be.lucene.stats.LuceneStatsProvider;
+import org.opensearch.common.annotation.ExperimentalApi;
+import org.opensearch.plugin.stats.transport.FormatNodeStatsActionType;
+
+/**
+ * Action type for the lucene per-node stats endpoint
+ * ({@code GET /_plugins/lucene/_nodes/[{nodeId}/]_stats}).
+ *
+ * @opensearch.experimental
+ */
+@ExperimentalApi
+public final class LuceneNodeStatsActionType extends FormatNodeStatsActionType<LuceneShardStats> {
+
+    public static final LuceneNodeStatsActionType INSTANCE = new LuceneNodeStatsActionType();
+
+    private LuceneNodeStatsActionType() {
+        super(LuceneStatsProvider.FORMAT_NAME, LuceneShardStats::new);
+    }
+}

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/stats/transport/LuceneNodeStatsRestAction.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/stats/transport/LuceneNodeStatsRestAction.java
@@ -1,0 +1,34 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.lucene.stats.transport;
+
+import org.opensearch.action.ActionType;
+import org.opensearch.be.lucene.stats.LuceneStatsProvider;
+import org.opensearch.common.annotation.ExperimentalApi;
+import org.opensearch.plugin.stats.transport.BaseFormatNodeStatsRestAction;
+import org.opensearch.plugin.stats.transport.FormatNodeStatsResponse;
+
+/**
+ * REST handler for {@code GET /_plugins/lucene/_nodes/[{nodeId}/]_stats}.
+ *
+ * @opensearch.experimental
+ */
+@ExperimentalApi
+public final class LuceneNodeStatsRestAction extends BaseFormatNodeStatsRestAction {
+
+    @Override
+    protected String formatName() {
+        return LuceneStatsProvider.FORMAT_NAME;
+    }
+
+    @Override
+    protected ActionType<? extends FormatNodeStatsResponse<?>> actionType() {
+        return LuceneNodeStatsActionType.INSTANCE;
+    }
+}

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/stats/transport/LuceneNodeStatsTransportAction.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/stats/transport/LuceneNodeStatsTransportAction.java
@@ -1,0 +1,46 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.lucene.stats.transport;
+
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.be.lucene.stats.LuceneShardStats;
+import org.opensearch.be.lucene.stats.LuceneStatsProvider;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.annotation.ExperimentalApi;
+import org.opensearch.common.inject.Inject;
+import org.opensearch.plugin.stats.transport.BaseTransportFormatNodeStatsAction;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportService;
+
+/**
+ * Per-node stats transport action for lucene.
+ *
+ * @opensearch.experimental
+ */
+@ExperimentalApi
+public final class LuceneNodeStatsTransportAction extends BaseTransportFormatNodeStatsAction<LuceneShardStats> {
+
+    @Inject
+    public LuceneNodeStatsTransportAction(
+        ThreadPool threadPool,
+        ClusterService clusterService,
+        TransportService transportService,
+        ActionFilters actionFilters
+    ) {
+        super(
+            LuceneNodeStatsActionType.INSTANCE.name(),
+            LuceneStatsProvider.FORMAT_NAME,
+            LuceneShardStats::new,
+            threadPool,
+            clusterService,
+            transportService,
+            actionFilters
+        );
+    }
+}

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/stats/transport/LuceneStatsActionType.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/stats/transport/LuceneStatsActionType.java
@@ -1,0 +1,30 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.lucene.stats.transport;
+
+import org.opensearch.be.lucene.stats.LuceneShardStats;
+import org.opensearch.be.lucene.stats.LuceneStatsProvider;
+import org.opensearch.common.annotation.ExperimentalApi;
+import org.opensearch.plugin.stats.transport.FormatStatsActionType;
+
+/**
+ * Action type for the lucene per-index stats endpoint
+ * ({@code GET /_plugins/lucene/{index}/_stats}).
+ *
+ * @opensearch.experimental
+ */
+@ExperimentalApi
+public final class LuceneStatsActionType extends FormatStatsActionType<LuceneShardStats> {
+
+    public static final LuceneStatsActionType INSTANCE = new LuceneStatsActionType();
+
+    private LuceneStatsActionType() {
+        super(LuceneStatsProvider.FORMAT_NAME, LuceneShardStats::new);
+    }
+}

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/stats/transport/LuceneStatsRestAction.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/stats/transport/LuceneStatsRestAction.java
@@ -1,0 +1,34 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.lucene.stats.transport;
+
+import org.opensearch.action.ActionType;
+import org.opensearch.be.lucene.stats.LuceneStatsProvider;
+import org.opensearch.common.annotation.ExperimentalApi;
+import org.opensearch.plugin.stats.transport.BaseFormatStatsRestAction;
+import org.opensearch.plugin.stats.transport.FormatStatsResponse;
+
+/**
+ * REST handler for {@code GET /_plugins/lucene/{index}/_stats}.
+ *
+ * @opensearch.experimental
+ */
+@ExperimentalApi
+public final class LuceneStatsRestAction extends BaseFormatStatsRestAction {
+
+    @Override
+    protected String formatName() {
+        return LuceneStatsProvider.FORMAT_NAME;
+    }
+
+    @Override
+    protected ActionType<? extends FormatStatsResponse<?>> actionType() {
+        return LuceneStatsActionType.INSTANCE;
+    }
+}

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/stats/transport/LuceneStatsTransportAction.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/stats/transport/LuceneStatsTransportAction.java
@@ -1,0 +1,46 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.lucene.stats.transport;
+
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.be.lucene.stats.LuceneShardStats;
+import org.opensearch.be.lucene.stats.LuceneStatsProvider;
+import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.annotation.ExperimentalApi;
+import org.opensearch.common.inject.Inject;
+import org.opensearch.plugin.stats.transport.BaseTransportFormatStatsAction;
+import org.opensearch.transport.TransportService;
+
+/**
+ * Per-index stats transport action for lucene.
+ *
+ * @opensearch.experimental
+ */
+@ExperimentalApi
+public final class LuceneStatsTransportAction extends BaseTransportFormatStatsAction<LuceneShardStats> {
+
+    @Inject
+    public LuceneStatsTransportAction(
+        ClusterService clusterService,
+        TransportService transportService,
+        ActionFilters actionFilters,
+        IndexNameExpressionResolver indexNameExpressionResolver
+    ) {
+        super(
+            LuceneStatsActionType.INSTANCE.name(),
+            LuceneStatsProvider.FORMAT_NAME,
+            LuceneShardStats::new,
+            clusterService,
+            transportService,
+            actionFilters,
+            indexNameExpressionResolver
+        );
+    }
+}

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/stats/transport/package-info.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/stats/transport/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/**
+ * Transport and REST actions for the lucene per-format statistics endpoints.
+ *
+ * <p>Wires {@link org.opensearch.be.lucene.stats.LuceneStatsProvider} into the
+ * {@code /_plugins/lucene/{index}/_stats} and {@code /_plugins/lucene/_nodes/_stats}
+ * REST + transport surfaces by extending the abstract bases in
+ * {@link org.opensearch.plugin.stats.transport}.
+ *
+ * @opensearch.experimental
+ */
+@ExperimentalApi
+package org.opensearch.be.lucene.stats.transport;
+
+import org.opensearch.common.annotation.ExperimentalApi;

--- a/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/LuceneMergerTests.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/LuceneMergerTests.java
@@ -30,6 +30,7 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.NIOFSDirectory;
 import org.apache.lucene.tests.analysis.MockAnalyzer;
 import org.opensearch.be.lucene.merge.LuceneMerger;
+import org.opensearch.be.lucene.stats.LuceneShardStatsTracker;
 import org.opensearch.common.SuppressForbidden;
 import org.opensearch.index.engine.dataformat.DocumentInput;
 import org.opensearch.index.engine.dataformat.MergeInput;
@@ -90,7 +91,7 @@ public class LuceneMergerTests extends OpenSearchTestCase {
      * Merge with empty input returns empty result without error.
      */
     public void testMergeWithEmptyInput() throws IOException {
-        LuceneMerger merger = new LuceneMerger(writer, new LuceneDataFormat(), dataPath);
+        LuceneMerger merger = new LuceneMerger(writer, new LuceneDataFormat(), dataPath, new LuceneShardStatsTracker());
         MergeInput input = MergeInput.builder().segments(List.of()).newWriterGeneration(99L).build();
 
         MergeResult result = merger.merge(input);
@@ -140,7 +141,7 @@ public class LuceneMergerTests extends OpenSearchTestCase {
         Map<Long, Integer> genSizes = Map.of(1L, 3, 2L, 2);
         RowIdMapping rowIdMapping = new PackedRowIdMapping(mappingArray, genOffsets, genSizes);
 
-        LuceneMerger merger = new LuceneMerger(writer, new LuceneDataFormat(), dataPath);
+        LuceneMerger merger = new LuceneMerger(writer, new LuceneDataFormat(), dataPath, new LuceneShardStatsTracker());
         SegmentInfos infos = getSegmentInfos(writer);
         List<Segment> segments = buildSegments(infos);
 
@@ -196,7 +197,7 @@ public class LuceneMergerTests extends OpenSearchTestCase {
         writeSegmentWithRichFields(writer, 2L, 3, 2);
         writer.commit();
 
-        LuceneMerger merger = new LuceneMerger(writer, new LuceneDataFormat(), dataPath);
+        LuceneMerger merger = new LuceneMerger(writer, new LuceneDataFormat(), dataPath, new LuceneShardStatsTracker());
         SegmentInfos infos = getSegmentInfos(writer);
         List<Segment> segments = buildSegments(infos);
 
@@ -232,7 +233,10 @@ public class LuceneMergerTests extends OpenSearchTestCase {
      * Constructor with null IndexWriter throws IllegalArgumentException.
      */
     public void testConstructorWithNullIndexWriterThrows() {
-        expectThrows(IllegalArgumentException.class, () -> new LuceneMerger(null, new LuceneDataFormat(), Path.of(".")));
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> new LuceneMerger(null, new LuceneDataFormat(), Path.of("."), new LuceneShardStatsTracker())
+        );
     }
 
     /**
@@ -255,7 +259,7 @@ public class LuceneMergerTests extends OpenSearchTestCase {
         writeSegment(writer, 2L, 3, 2);
         writer.commit();
 
-        LuceneMerger merger = new LuceneMerger(writer, new LuceneDataFormat(), dataPath);
+        LuceneMerger merger = new LuceneMerger(writer, new LuceneDataFormat(), dataPath, new LuceneShardStatsTracker());
         SegmentInfos infos = getSegmentInfos(writer);
         List<Segment> segments = buildSegments(infos);
 

--- a/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/index/LuceneCommitterTests.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/index/LuceneCommitterTests.java
@@ -14,6 +14,8 @@ import org.apache.lucene.store.NIOFSDirectory;
 import org.apache.lucene.tests.analysis.MockAnalyzer;
 import org.apache.lucene.util.Version;
 import org.opensearch.be.lucene.LucenePlugin;
+import org.opensearch.be.lucene.stats.LuceneShardStatsTracker;
+import org.opensearch.be.lucene.stats.LuceneStatsProvider;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.BigArrays;
@@ -31,6 +33,7 @@ import org.opensearch.index.store.Store;
 import org.opensearch.index.translog.InternalTranslogFactory;
 import org.opensearch.index.translog.Translog;
 import org.opensearch.index.translog.TranslogConfig;
+import org.opensearch.plugin.stats.DataFormatStatsProviderRegistry;
 import org.opensearch.plugins.EnginePlugin;
 import org.opensearch.plugins.PluginsService;
 import org.opensearch.test.DummyShardLock;
@@ -172,5 +175,76 @@ public class LuceneCommitterTests extends OpenSearchTestCase {
             () -> committer.commit(new Committer.CommitInput(Map.of("key", "value").entrySet(), null))
         );
         config.engineConfig().getStore().close();
+    }
+
+    /**
+     * Verifies that {@code lucene.commit.commit_failures} increments when {@code commit()}
+     * throws, and {@code commit_total} does NOT increment for the failed attempt.
+     *
+     * <p>Setup: register a {@link LuceneStatsProvider} + tracker against the shard's id
+     * so {@link LuceneCommitter#commit} can reach them via the global registry. Close the
+     * underlying {@link IndexWriter} directly (without going through {@code committer.close()})
+     * — this leaves {@code LuceneCommitter.isClosed=false} so {@code ensureOpen()} still
+     * passes, but the next {@code indexWriter.commit()} throws {@code AlreadyClosedException}.
+     * That {@code Throwable} lands in our catch block, which sets {@code threw=true} and
+     * (in the finally) increments {@code commit_failures} instead of {@code commit_total}.
+     *
+     * <p>We read counter values by rendering {@code LuceneShardStats#toXContent} to JSON
+     * (the class doesn't expose getters; this is the same surface end users observe).
+     */
+    public void testCommitFailureIncrementsCommitFailuresCounter() throws IOException {
+        LuceneStatsProvider provider = new LuceneStatsProvider();
+        DataFormatStatsProviderRegistry.INSTANCE.register(provider);
+
+        CommitterConfig config = createCommitterConfig();
+        ShardId shardId = config.engineConfig().getShardId();
+        LuceneShardStatsTracker tracker = new LuceneShardStatsTracker();
+        provider.register(shardId, tracker);
+
+        LuceneCommitter committer = new LuceneCommitter(config);
+        try {
+            // Sanity baseline: both counters at zero before the failure.
+            assertEquals("baseline commit_total", 0L, readCounter(tracker, "commit_total"));
+            assertEquals("baseline commit_failures", 0L, readCounter(tracker, "commit_failures"));
+
+            // Force the IndexWriter into a closed state. The committer's own isClosed flag
+            // remains false (we did NOT call committer.close()) so ensureOpen() inside
+            // commit() will pass; but indexWriter.commit() will throw AlreadyClosedException.
+            committer.getIndexWriter().close();
+
+            expectThrows(Throwable.class, () -> committer.commit(new Committer.CommitInput(Map.<String, String>of().entrySet(), null)));
+
+            // Contract: commit_failures incremented by exactly 1, commit_total still 0.
+            assertEquals("commit_failures must be 1 after one failed commit", 1L, readCounter(tracker, "commit_failures"));
+            assertEquals("commit_total must still be 0 (failed attempt does not count)", 0L, readCounter(tracker, "commit_total"));
+        } finally {
+            provider.unregister(shardId);
+            try {
+                committer.close();
+            } catch (Throwable ignored) {
+                // committer.close() may complain because IndexWriter is already closed
+            }
+            config.engineConfig().getStore().close();
+        }
+    }
+
+    /** Reads a single counter from a tracker by rendering its snapshot to JSON. */
+    @SuppressWarnings("unchecked")
+    private static long readCounter(LuceneShardStatsTracker tracker, String fieldName) throws IOException {
+        var builder = org.opensearch.common.xcontent.XContentFactory.jsonBuilder().startObject();
+        tracker.stats().toXContent(builder, org.opensearch.core.xcontent.ToXContent.EMPTY_PARAMS);
+        builder.endObject();
+        Map<String, Object> parsed = org.opensearch.common.xcontent.XContentHelper.convertToMap(
+            org.opensearch.common.xcontent.json.JsonXContent.jsonXContent,
+            builder.toString(),
+            true
+        );
+        // The field lives one level deep (e.g., parsed.commit.commit_failures).
+        for (Object section : parsed.values()) {
+            if (section instanceof Map<?, ?> map && map.containsKey(fieldName)) {
+                return ((Number) map.get(fieldName)).longValue();
+            }
+        }
+        throw new AssertionError("field not found: " + fieldName);
     }
 }

--- a/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/index/LuceneDeleteExecutionEngineTests.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/index/LuceneDeleteExecutionEngineTests.java
@@ -15,6 +15,7 @@ import org.apache.lucene.index.Term;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.MMapDirectory;
 import org.opensearch.be.lucene.LuceneDataFormat;
+import org.opensearch.be.lucene.stats.LuceneShardStatsTracker;
 import org.opensearch.common.queue.Lockable;
 import org.opensearch.common.queue.LockablePool;
 import org.opensearch.index.engine.dataformat.DataFormat;
@@ -1389,7 +1390,8 @@ public class LuceneDeleteExecutionEngineTests extends OpenSearchTestCase {
             null,
             Codec.getDefault(),
             null,
-            ConcurrentHashMap.newKeySet()
+            ConcurrentHashMap.newKeySet(),
+            new LuceneShardStatsTracker()
         );
         LuceneWriter writer2 = new LuceneWriter(
             2L,
@@ -1399,7 +1401,8 @@ public class LuceneDeleteExecutionEngineTests extends OpenSearchTestCase {
             null,
             Codec.getDefault(),
             null,
-            ConcurrentHashMap.newKeySet()
+            ConcurrentHashMap.newKeySet(),
+            new LuceneShardStatsTracker()
         );
 
         LockablePool<WriterHolder> writerPool = buildWriterPool(deleteEngine, writer1, writer2);
@@ -1456,7 +1459,8 @@ public class LuceneDeleteExecutionEngineTests extends OpenSearchTestCase {
             null,
             Codec.getDefault(),
             null,
-            ConcurrentHashMap.newKeySet()
+            ConcurrentHashMap.newKeySet(),
+            new LuceneShardStatsTracker()
         );
         LockablePool<WriterHolder> writerPool = buildWriterPool(deleteEngine, writer1);
 
@@ -1519,7 +1523,8 @@ public class LuceneDeleteExecutionEngineTests extends OpenSearchTestCase {
             null,
             Codec.getDefault(),
             null,
-            ConcurrentHashMap.newKeySet()
+            ConcurrentHashMap.newKeySet(),
+            new LuceneShardStatsTracker()
         );
         LuceneWriter writer2 = new LuceneWriter(
             2L,
@@ -1529,7 +1534,8 @@ public class LuceneDeleteExecutionEngineTests extends OpenSearchTestCase {
             null,
             Codec.getDefault(),
             null,
-            ConcurrentHashMap.newKeySet()
+            ConcurrentHashMap.newKeySet(),
+            new LuceneShardStatsTracker()
         );
         LockablePool<WriterHolder> writerPool = buildWriterPool(deleteEngine, writer1, writer2);
 
@@ -1615,7 +1621,8 @@ public class LuceneDeleteExecutionEngineTests extends OpenSearchTestCase {
             null,
             Codec.getDefault(),
             null,
-            ConcurrentHashMap.newKeySet()
+            ConcurrentHashMap.newKeySet(),
+            new LuceneShardStatsTracker()
         );
         LuceneWriter writer2 = new LuceneWriter(
             2L,
@@ -1625,7 +1632,8 @@ public class LuceneDeleteExecutionEngineTests extends OpenSearchTestCase {
             null,
             Codec.getDefault(),
             null,
-            ConcurrentHashMap.newKeySet()
+            ConcurrentHashMap.newKeySet(),
+            new LuceneShardStatsTracker()
         );
         LuceneWriter writer3 = new LuceneWriter(
             3L,
@@ -1635,7 +1643,8 @@ public class LuceneDeleteExecutionEngineTests extends OpenSearchTestCase {
             null,
             Codec.getDefault(),
             null,
-            ConcurrentHashMap.newKeySet()
+            ConcurrentHashMap.newKeySet(),
+            new LuceneShardStatsTracker()
         );
         LockablePool<WriterHolder> writerPool = buildWriterPool(deleteEngine, writer1, writer2, writer3);
 
@@ -1747,7 +1756,8 @@ public class LuceneDeleteExecutionEngineTests extends OpenSearchTestCase {
             null,
             Codec.getDefault(),
             null,
-            ConcurrentHashMap.newKeySet()
+            ConcurrentHashMap.newKeySet(),
+            new LuceneShardStatsTracker()
         );
         LuceneWriter writer2 = new LuceneWriter(
             2L,
@@ -1757,7 +1767,8 @@ public class LuceneDeleteExecutionEngineTests extends OpenSearchTestCase {
             null,
             Codec.getDefault(),
             null,
-            ConcurrentHashMap.newKeySet()
+            ConcurrentHashMap.newKeySet(),
+            new LuceneShardStatsTracker()
         );
         LuceneWriter writer3 = new LuceneWriter(
             3L,
@@ -1767,7 +1778,8 @@ public class LuceneDeleteExecutionEngineTests extends OpenSearchTestCase {
             null,
             Codec.getDefault(),
             null,
-            ConcurrentHashMap.newKeySet()
+            ConcurrentHashMap.newKeySet(),
+            new LuceneShardStatsTracker()
         );
         LockablePool<WriterHolder> writerPool = buildWriterPool(deleteEngine, writer1, writer2, writer3);
 
@@ -1842,7 +1854,8 @@ public class LuceneDeleteExecutionEngineTests extends OpenSearchTestCase {
             null,
             Codec.getDefault(),
             null,
-            ConcurrentHashMap.newKeySet()
+            ConcurrentHashMap.newKeySet(),
+            new LuceneShardStatsTracker()
         );
         LuceneWriter writer2 = new LuceneWriter(
             2L,
@@ -1852,7 +1865,8 @@ public class LuceneDeleteExecutionEngineTests extends OpenSearchTestCase {
             null,
             Codec.getDefault(),
             null,
-            ConcurrentHashMap.newKeySet()
+            ConcurrentHashMap.newKeySet(),
+            new LuceneShardStatsTracker()
         );
         LuceneWriter writer3 = new LuceneWriter(
             3L,
@@ -1862,7 +1876,8 @@ public class LuceneDeleteExecutionEngineTests extends OpenSearchTestCase {
             null,
             Codec.getDefault(),
             null,
-            ConcurrentHashMap.newKeySet()
+            ConcurrentHashMap.newKeySet(),
+            new LuceneShardStatsTracker()
         );
         LockablePool<WriterHolder> writerPool = buildWriterPool(deleteEngine, writer1, writer2, writer3);
 

--- a/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/index/LuceneIndexingExecutionEngineTests.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/index/LuceneIndexingExecutionEngineTests.java
@@ -15,6 +15,7 @@ import org.apache.lucene.store.NIOFSDirectory;
 import org.apache.lucene.tests.analysis.MockAnalyzer;
 import org.opensearch.be.lucene.LuceneDataFormat;
 import org.opensearch.be.lucene.LucenePlugin;
+import org.opensearch.be.lucene.stats.LuceneShardStatsTracker;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.BigArrays;
@@ -179,7 +180,8 @@ public class LuceneIndexingExecutionEngineTests extends LucenePluginBaseTests {
                 null,
                 Codec.getDefault(),
                 null,
-                ConcurrentHashMap.newKeySet()
+                ConcurrentHashMap.newKeySet(),
+                new LuceneShardStatsTracker()
             )
         ) {
             for (int i = 0; i < numDocs; i++) {

--- a/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/index/LuceneWriterSortedFlushTests.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/index/LuceneWriterSortedFlushTests.java
@@ -19,6 +19,7 @@ import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.SortedNumericSortField;
 import org.apache.lucene.store.NIOFSDirectory;
 import org.opensearch.be.lucene.LuceneDataFormat;
+import org.opensearch.be.lucene.stats.LuceneShardStatsTracker;
 import org.opensearch.index.engine.dataformat.FileInfos;
 import org.opensearch.index.engine.dataformat.FlushInput;
 import org.opensearch.index.engine.dataformat.PackedRowIdMapping;
@@ -73,7 +74,8 @@ public class LuceneWriterSortedFlushTests extends LucenePluginBaseTests {
                 null,
                 Codec.getDefault(),
                 null,
-                ConcurrentHashMap.newKeySet()
+                ConcurrentHashMap.newKeySet(),
+                new LuceneShardStatsTracker()
             )
         ) {
             for (int i = 0; i < numDocs; i++) {
@@ -138,7 +140,8 @@ public class LuceneWriterSortedFlushTests extends LucenePluginBaseTests {
                 null,
                 Codec.getDefault(),
                 null,
-                ConcurrentHashMap.newKeySet()
+                ConcurrentHashMap.newKeySet(),
+                new LuceneShardStatsTracker()
             )
         ) {
             for (int i = 0; i < numDocs; i++) {
@@ -185,7 +188,8 @@ public class LuceneWriterSortedFlushTests extends LucenePluginBaseTests {
                 null,
                 Codec.getDefault(),
                 null,
-                ConcurrentHashMap.newKeySet()
+                ConcurrentHashMap.newKeySet(),
+                new LuceneShardStatsTracker()
             )
         ) {
             FileInfos fileInfos = writer.flush(sortedFlushInput);
@@ -215,7 +219,8 @@ public class LuceneWriterSortedFlushTests extends LucenePluginBaseTests {
                 null,
                 Codec.getDefault(),
                 null,
-                ConcurrentHashMap.newKeySet()
+                ConcurrentHashMap.newKeySet(),
+                new LuceneShardStatsTracker()
             )
         ) {
             for (int i = 0; i < 3; i++) {
@@ -257,7 +262,8 @@ public class LuceneWriterSortedFlushTests extends LucenePluginBaseTests {
                 null,
                 Codec.getDefault(),
                 null,
-                ConcurrentHashMap.newKeySet()
+                ConcurrentHashMap.newKeySet(),
+                new LuceneShardStatsTracker()
             )
         ) {
             for (int i = 0; i < numDocs; i++) {
@@ -302,7 +308,8 @@ public class LuceneWriterSortedFlushTests extends LucenePluginBaseTests {
                 null,
                 Codec.getDefault(),
                 rowIdSort,
-                ConcurrentHashMap.newKeySet()
+                ConcurrentHashMap.newKeySet(),
+                new LuceneShardStatsTracker()
             )
         ) {
             for (int i = 0; i < numDocs; i++) {
@@ -366,7 +373,8 @@ public class LuceneWriterSortedFlushTests extends LucenePluginBaseTests {
                 null,
                 Codec.getDefault(),
                 indexSort,
-                ConcurrentHashMap.newKeySet()
+                ConcurrentHashMap.newKeySet(),
+                new LuceneShardStatsTracker()
             )
         ) {
             for (int i = 0; i < numDocs; i++) {
@@ -421,7 +429,8 @@ public class LuceneWriterSortedFlushTests extends LucenePluginBaseTests {
                 null,
                 Codec.getDefault(),
                 indexSort,
-                ConcurrentHashMap.newKeySet()
+                ConcurrentHashMap.newKeySet(),
+                new LuceneShardStatsTracker()
             )
         ) {
             for (int i = 0; i < oldRowIds.length; i++) {
@@ -482,7 +491,8 @@ public class LuceneWriterSortedFlushTests extends LucenePluginBaseTests {
                 null,
                 Codec.getDefault(),
                 null,
-                ConcurrentHashMap.newKeySet()
+                ConcurrentHashMap.newKeySet(),
+                new LuceneShardStatsTracker()
             )
         ) {
             for (int i = 0; i < numDocs; i++) {
@@ -628,10 +638,30 @@ public class LuceneWriterSortedFlushTests extends LucenePluginBaseTests {
      */
     private LuceneWriter newWriterWithMaxBufferedDocs(Path baseDir, Integer maxBufferedDocsOverride) throws IOException {
         if (maxBufferedDocsOverride == null) {
-            return new LuceneWriter(1L, 0L, dataFormat, baseDir, null, Codec.getDefault(), null, ConcurrentHashMap.newKeySet());
+            return new LuceneWriter(
+                1L,
+                0L,
+                dataFormat,
+                baseDir,
+                null,
+                Codec.getDefault(),
+                null,
+                ConcurrentHashMap.newKeySet(),
+                new LuceneShardStatsTracker()
+            );
         }
         final int override = maxBufferedDocsOverride;
-        return new LuceneWriter(1L, 0L, dataFormat, baseDir, null, Codec.getDefault(), null, ConcurrentHashMap.newKeySet()) {
+        return new LuceneWriter(
+            1L,
+            0L,
+            dataFormat,
+            baseDir,
+            null,
+            Codec.getDefault(),
+            null,
+            ConcurrentHashMap.newKeySet(),
+            new LuceneShardStatsTracker()
+        ) {
             @Override
             protected double ramBufferSizeMB() {
                 return 1024.0;

--- a/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/index/LuceneWriterTests.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/index/LuceneWriterTests.java
@@ -272,7 +272,8 @@ public class LuceneWriterTests extends LucenePluginBaseTests {
                 null,
                 Codec.getDefault(),
                 null,
-                ConcurrentHashMap.newKeySet()
+                ConcurrentHashMap.newKeySet(),
+                new LuceneShardStatsTracker()
             )
         ) {
             LuceneDocumentInput input = new LuceneDocumentInput();

--- a/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/index/LuceneWriterTests.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/index/LuceneWriterTests.java
@@ -23,6 +23,7 @@ import org.apache.lucene.search.SortedNumericSortField;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.store.NIOFSDirectory;
 import org.opensearch.be.lucene.LuceneDataFormat;
+import org.opensearch.be.lucene.stats.LuceneShardStatsTracker;
 import org.opensearch.index.engine.dataformat.DataFormat;
 import org.opensearch.index.engine.dataformat.DeleteInput;
 import org.opensearch.index.engine.dataformat.FileInfos;
@@ -66,7 +67,8 @@ public class LuceneWriterTests extends LucenePluginBaseTests {
                 null,
                 Codec.getDefault(),
                 null,
-                ConcurrentHashMap.newKeySet()
+                ConcurrentHashMap.newKeySet(),
+                new LuceneShardStatsTracker()
             )
         ) {
             int numDocs = randomIntBetween(5, 20);
@@ -108,7 +110,8 @@ public class LuceneWriterTests extends LucenePluginBaseTests {
                 null,
                 Codec.getDefault(),
                 null,
-                ConcurrentHashMap.newKeySet()
+                ConcurrentHashMap.newKeySet(),
+                new LuceneShardStatsTracker()
             )
         ) {
             for (int i = 0; i < numDocs; i++) {
@@ -146,7 +149,8 @@ public class LuceneWriterTests extends LucenePluginBaseTests {
                 null,
                 Codec.getDefault(),
                 null,
-                ConcurrentHashMap.newKeySet()
+                ConcurrentHashMap.newKeySet(),
+                new LuceneShardStatsTracker()
             )
         ) {
             FileInfos fileInfos = writer.flush(FlushInput.EMPTY);
@@ -167,7 +171,8 @@ public class LuceneWriterTests extends LucenePluginBaseTests {
                 null,
                 Codec.getDefault(),
                 null,
-                ConcurrentHashMap.newKeySet()
+                ConcurrentHashMap.newKeySet(),
+                new LuceneShardStatsTracker()
             )
         ) {
             assertThat(writer.generation(), equalTo(gen));
@@ -195,7 +200,8 @@ public class LuceneWriterTests extends LucenePluginBaseTests {
                 null,
                 Codec.getDefault(),
                 null,
-                ConcurrentHashMap.newKeySet()
+                ConcurrentHashMap.newKeySet(),
+                new LuceneShardStatsTracker()
             )
         ) {
             LuceneDocumentInput input = new LuceneDocumentInput();
@@ -230,7 +236,8 @@ public class LuceneWriterTests extends LucenePluginBaseTests {
                 null,
                 Codec.getDefault(),
                 null,
-                ConcurrentHashMap.newKeySet()
+                ConcurrentHashMap.newKeySet(),
+                new LuceneShardStatsTracker()
             )
         ) {
             LuceneDocumentInput input = new LuceneDocumentInput();
@@ -288,7 +295,8 @@ public class LuceneWriterTests extends LucenePluginBaseTests {
                 null,
                 Codec.getDefault(),
                 null,
-                ConcurrentHashMap.newKeySet()
+                ConcurrentHashMap.newKeySet(),
+                new LuceneShardStatsTracker()
             )
         ) {
             int numDocs = randomIntBetween(5, 15);
@@ -326,7 +334,8 @@ public class LuceneWriterTests extends LucenePluginBaseTests {
                 null,
                 Codec.getDefault(),
                 null,
-                ConcurrentHashMap.newKeySet()
+                ConcurrentHashMap.newKeySet(),
+                new LuceneShardStatsTracker()
             )
         ) {
             for (int i = 0; i < numDocs; i++) {
@@ -387,7 +396,8 @@ public class LuceneWriterTests extends LucenePluginBaseTests {
             null,
             Codec.getDefault(),
             null,
-            ConcurrentHashMap.newKeySet()
+            ConcurrentHashMap.newKeySet(),
+            new LuceneShardStatsTracker()
         );
         LuceneWriter writer2 = new LuceneWriter(
             gen2,
@@ -397,7 +407,8 @@ public class LuceneWriterTests extends LucenePluginBaseTests {
             null,
             Codec.getDefault(),
             null,
-            ConcurrentHashMap.newKeySet()
+            ConcurrentHashMap.newKeySet(),
+            new LuceneShardStatsTracker()
         );
         try {
             for (int i = 0; i < numDocs1; i++) {
@@ -458,7 +469,8 @@ public class LuceneWriterTests extends LucenePluginBaseTests {
                 null,
                 Codec.getDefault(),
                 null,
-                ConcurrentHashMap.newKeySet()
+                ConcurrentHashMap.newKeySet(),
+                new LuceneShardStatsTracker()
             )
         ) {
             Optional<Writer<?>> result = writer.getWriterForFormat("lucene");
@@ -479,7 +491,8 @@ public class LuceneWriterTests extends LucenePluginBaseTests {
                 null,
                 Codec.getDefault(),
                 null,
-                ConcurrentHashMap.newKeySet()
+                ConcurrentHashMap.newKeySet(),
+                new LuceneShardStatsTracker()
             )
         ) {
             Optional<Writer<?>> parquetResult = writer.getWriterForFormat("parquet");
@@ -522,7 +535,8 @@ public class LuceneWriterTests extends LucenePluginBaseTests {
                 null,
                 Codec.getDefault(),
                 indexSort,
-                ConcurrentHashMap.newKeySet()
+                ConcurrentHashMap.newKeySet(),
+                new LuceneShardStatsTracker()
             )
         ) {
             MappedFieldType textField = mockTextField("content");
@@ -570,7 +584,8 @@ public class LuceneWriterTests extends LucenePluginBaseTests {
                     null,
                     Codec.getDefault(),
                     sort,
-                    ConcurrentHashMap.newKeySet()
+                    ConcurrentHashMap.newKeySet(),
+                    new LuceneShardStatsTracker()
                 )
             ) {
                 MappedFieldType textField = mockTextField("content");
@@ -602,7 +617,8 @@ public class LuceneWriterTests extends LucenePluginBaseTests {
                 null,
                 Codec.getDefault(),
                 null,
-                ConcurrentHashMap.newKeySet()
+                ConcurrentHashMap.newKeySet(),
+                new LuceneShardStatsTracker()
             )
         ) {
             LuceneDocumentInput input = new LuceneDocumentInput();
@@ -620,7 +636,17 @@ public class LuceneWriterTests extends LucenePluginBaseTests {
     public void testGetHeapBytesUsedZeroAfterCloseWithoutFlush() throws IOException {
         Path baseDir = createTempDir();
         MappedFieldType textField = mockTextField("content");
-        LuceneWriter writer = new LuceneWriter(1L, 0L, dataFormat, baseDir, null, Codec.getDefault(), null, ConcurrentHashMap.newKeySet());
+        LuceneWriter writer = new LuceneWriter(
+            1L,
+            0L,
+            dataFormat,
+            baseDir,
+            null,
+            Codec.getDefault(),
+            null,
+            ConcurrentHashMap.newKeySet(),
+            new LuceneShardStatsTracker()
+        );
         LuceneDocumentInput input = new LuceneDocumentInput();
         input.addField(textField, "hello world");
         input.setRowId(LuceneDocumentInput.ROW_ID_FIELD, 0);

--- a/sandbox/plugins/composite-engine/build.gradle
+++ b/sandbox/plugins/composite-engine/build.gradle
@@ -13,6 +13,8 @@ opensearchplugin {
 
 apply plugin: 'opensearch.internal-cluster-test'
 
+java { sourceCompatibility = JavaVersion.toVersion(25); targetCompatibility = JavaVersion.toVersion(25) }
+
 // Test compilation needs JDK 25 to consume parquet-data-format (which targets JDK 25)
 tasks.named('compileTestJava').configure {
   sourceCompatibility = JavaVersion.toVersion(25)
@@ -37,12 +39,17 @@ internalClusterTest {
   systemProperty 'io.netty.noUnsafe', 'false'
   systemProperty 'io.netty.tryUnsafe', 'true'
   systemProperty 'io.netty.tryReflectionSetAccessible', 'true'
+  // Disable OpenSearch's Netty4Utils.setAvailableProcessors() so randomized node.processors values
+  // across test methods do not collide on Netty's process-wide NettyRuntime static.
+  // See Netty4Utils.java: opensearch.set.netty.runtime.available.processors flag.
+  systemProperty 'opensearch.set.netty.runtime.available.processors', 'false'
   systemProperty 'native.lib.path', project(':sandbox:libs:dataformat-native').ext.nativeLibPath.absolutePath
   dependsOn ':sandbox:libs:dataformat-native:buildRustLibrary'
 }
 
 dependencies {
   api project(':libs:opensearch-concurrent-queue')
+  implementation project(':sandbox:libs:plugin-stats-spi')
   compileOnly project(':server')
   testImplementation project(':test:framework')
   testImplementation project(':sandbox:plugins:parquet-data-format')
@@ -54,4 +61,6 @@ dependencies {
   internalClusterTestImplementation project(':sandbox:plugins:analytics-backend-datafusion')
   internalClusterTestImplementation project(':sandbox:libs:analytics-framework')
   internalClusterTestImplementation project(':sandbox:plugins:native-repository-fs')
+  // Netty4 HTTP transport for ITs that use the low-level RestClient (e.g., DataFormatStatsIT, *DataFormatApi*IT).
+  internalClusterTestImplementation project(':modules:transport-netty4')
 }

--- a/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/AbstractCompositeEngineIT.java
+++ b/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/AbstractCompositeEngineIT.java
@@ -8,6 +8,9 @@
 
 package org.opensearch.composite;
 
+import com.carrotsearch.randomizedtesting.ThreadFilter;
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
+
 import org.opensearch.action.admin.indices.flush.FlushResponse;
 import org.opensearch.action.admin.indices.stats.IndicesStatsResponse;
 import org.opensearch.action.admin.indices.stats.ShardStats;
@@ -16,8 +19,10 @@ import org.opensearch.be.datafusion.DataFusionPlugin;
 import org.opensearch.be.lucene.LucenePlugin;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.concurrent.GatedCloseable;
+import org.opensearch.common.network.NetworkModule;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.FeatureFlags;
+import org.opensearch.common.util.concurrent.OpenSearchExecutors;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.index.IndexService;
 import org.opensearch.index.engine.CommitStats;
@@ -30,11 +35,13 @@ import org.opensearch.indices.IndicesService;
 import org.opensearch.parquet.ParquetDataFormatPlugin;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.test.OpenSearchIntegTestCase;
+import org.opensearch.transport.Netty4ModulePlugin;
 
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.function.Function;
+import java.util.regex.Pattern;
 
 /**
  * Base class for composite engine integration tests.
@@ -43,7 +50,22 @@ import java.util.function.Function;
  * parquet primary + lucene secondary data formats. Subclasses inherit plugin
  * wiring, index creation helpers, and utility methods to access engine internals.
  */
+@ThreadLeakFilters(filters = AbstractCompositeEngineIT.ParquetNativeThreadFilter.class)
 public abstract class AbstractCompositeEngineIT extends OpenSearchIntegTestCase {
+
+    /**
+     * Suppresses generic "Thread-N" worker threads spawned by parquet's native (Rust) merge path.
+     * These JNI threads have empty Java stack traces; the JVM's randomized testing framework
+     * cannot identify their origin so they appear as leaks at suite teardown.
+     */
+    public static class ParquetNativeThreadFilter implements ThreadFilter {
+        private static final Pattern GENERIC_THREAD_NAME = Pattern.compile("^Thread-\\d+$");
+
+        @Override
+        public boolean reject(Thread t) {
+            return GENERIC_THREAD_NAME.matcher(t.getName()).matches();
+        }
+    }
 
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {
@@ -52,7 +74,10 @@ public abstract class AbstractCompositeEngineIT extends OpenSearchIntegTestCase 
             ParquetDataFormatPlugin.class,
             CompositeDataFormatPlugin.class,
             LucenePlugin.class,
-            DataFusionPlugin.class
+            DataFusionPlugin.class,
+            // Netty4ModulePlugin provides the real HTTP server transport. Subclasses that override
+            // addMockHttpTransport() to return false rely on this plugin for the REST endpoints.
+            Netty4ModulePlugin.class
         );
     }
 
@@ -61,6 +86,11 @@ public abstract class AbstractCompositeEngineIT extends OpenSearchIntegTestCase 
         return Settings.builder()
             .put(super.nodeSettings(nodeOrdinal))
             .put(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG, true)
+            // Use Netty4 as the HTTP transport so getRestClient() ITs can hit /_plugins/* endpoints.
+            .put(NetworkModule.HTTP_TYPE_KEY, Netty4ModulePlugin.NETTY_HTTP_TRANSPORT_NAME)
+            // Pin processors to a fixed value. InternalTestCluster otherwise randomizes node.processors per-test
+            // which conflicts with Netty's process-wide NettyRuntime.availableProcessors static across test methods.
+            .put(OpenSearchExecutors.NODE_PROCESSORS_SETTING.getKey(), 1)
             .build();
     }
 

--- a/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/BaseStatsIT.java
+++ b/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/BaseStatsIT.java
@@ -1,0 +1,77 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.composite;
+
+import org.opensearch.client.Response;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * Abstract base class for stats API integration tests.
+ * Provides helper methods for querying parquet and lucene stats endpoints
+ * and asserting on JSON response fields.
+ *
+ * @opensearch.experimental
+ */
+public abstract class BaseStatsIT extends AbstractCompositeEngineIT {
+
+    @Override
+    protected boolean addMockHttpTransport() {
+        return false;
+    }
+
+    protected Map<String, Object> parquetIndexStats(String index, String... queryParams) throws IOException {
+        return StatsITHelpers.parquetIndexStats(getRestClient(), index, queryParams);
+    }
+
+    protected Map<String, Object> luceneIndexStats(String index, String... queryParams) throws IOException {
+        return StatsITHelpers.luceneIndexStats(getRestClient(), index, queryParams);
+    }
+
+    protected Map<String, Object> parquetNodeStats(String nodeIdOrEmpty, String... queryParams) throws IOException {
+        return StatsITHelpers.parquetNodeStats(getRestClient(), nodeIdOrEmpty, queryParams);
+    }
+
+    protected Map<String, Object> luceneNodeStats(String nodeIdOrEmpty, String... queryParams) throws IOException {
+        return StatsITHelpers.luceneNodeStats(getRestClient(), nodeIdOrEmpty, queryParams);
+    }
+
+    protected int getStatusCode(Map<String, Object> response) {
+        return StatsITHelpers.getStatusCode(response);
+    }
+
+    protected long getCounter(Map<String, Object> response, String dottedPath) {
+        return StatsITHelpers.getCounter(response, dottedPath);
+    }
+
+    protected boolean hasPath(Map<String, Object> response, String dottedPath) {
+        return StatsITHelpers.hasPath(response, dottedPath);
+    }
+
+    protected void assertCounter(String message, Map<String, Object> response, String path, long expected) {
+        StatsITHelpers.assertCounter(message, response, path, expected);
+    }
+
+    protected void assertCounterAtLeast(String message, Map<String, Object> response, String path, long min) {
+        StatsITHelpers.assertCounterAtLeast(message, response, path, min);
+    }
+
+    protected void assertCounterPresent(String message, Map<String, Object> response, String path) {
+        StatsITHelpers.assertCounterPresent(message, response, path);
+    }
+
+    protected void forceMerge(String index, int maxSegments) {
+        StatsITHelpers.forceMerge(client(), index, maxSegments);
+    }
+
+    protected Response getRaw(String path) throws IOException {
+        return StatsITHelpers.getRaw(getRestClient(), path);
+    }
+}

--- a/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/FailableLuceneDataFormatPlugin.java
+++ b/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/FailableLuceneDataFormatPlugin.java
@@ -21,6 +21,7 @@ import org.opensearch.be.lucene.LucenePlugin;
 import org.opensearch.be.lucene.index.LuceneCommitter;
 import org.opensearch.be.lucene.index.LuceneIndexingExecutionEngine;
 import org.opensearch.be.lucene.index.LuceneWriter;
+import org.opensearch.be.lucene.stats.LuceneShardStatsTracker;
 import org.opensearch.index.engine.dataformat.IndexingEngineConfig;
 import org.opensearch.index.engine.dataformat.IndexingExecutionEngine;
 import org.opensearch.index.engine.exec.commit.Committer;
@@ -112,7 +113,8 @@ public class FailableLuceneDataFormatPlugin extends LucenePlugin {
             Analyzer analyzer,
             Codec codec,
             Sort indexSort,
-            Set<LuceneWriter> registry
+            Set<LuceneWriter> registry,
+            LuceneShardStatsTracker stats
         ) throws IOException {
             return new FaultInjectingLuceneWriter(
                 writerGeneration,
@@ -122,7 +124,8 @@ public class FailableLuceneDataFormatPlugin extends LucenePlugin {
                 analyzer,
                 codec,
                 indexSort,
-                registry
+                registry,
+                stats
             );
         }
     }
@@ -142,9 +145,10 @@ public class FailableLuceneDataFormatPlugin extends LucenePlugin {
             Analyzer analyzer,
             Codec codec,
             Sort indexSort,
-            Set<LuceneWriter> registry
+            Set<LuceneWriter> registry,
+            LuceneShardStatsTracker stats
         ) throws IOException {
-            super(writerGeneration, mappingVersion, dataFormat, baseDirectory, analyzer, codec, indexSort, registry);
+            super(writerGeneration, mappingVersion, dataFormat, baseDirectory, analyzer, codec, indexSort, registry, stats);
         }
 
         @Override

--- a/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/LuceneStatsIT.java
+++ b/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/LuceneStatsIT.java
@@ -1,0 +1,78 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.composite;
+
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+import org.opensearch.common.xcontent.XContentHelper;
+import org.opensearch.common.xcontent.json.JsonXContent;
+import org.opensearch.test.OpenSearchIntegTestCase.ClusterScope;
+import org.opensearch.test.OpenSearchIntegTestCase.Scope;
+
+import java.util.Map;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.notNullValue;
+
+/**
+ * Integration tests for {@code GET /_plugins/lucene/{index}/_stats} and
+ * {@code GET /_plugins/lucene/_nodes/{nodeId}/_stats}.
+ *
+ * @opensearch.experimental
+ */
+@ClusterScope(scope = Scope.SUITE, numDataNodes = 1)
+public class LuceneStatsIT extends AbstractCompositeEngineIT {
+
+    @Override
+    protected boolean addMockHttpTransport() {
+        return false;
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testLuceneIndexStats() throws Exception {
+        String idx = "lucene-stats-1";
+        createCompositeIndex(idx, true);
+        indexDocs(idx, 50, 0);
+        flushIndex(idx);
+
+        Response response = getRestClient().performRequest(new Request("GET", "/_plugins/lucene/" + idx + "/_stats"));
+        assertThat(response.getStatusLine().getStatusCode(), equalTo(200));
+        Map<String, Object> body = XContentHelper.convertToMap(JsonXContent.jsonXContent, response.getEntity().getContent(), true);
+
+        Map<String, Object> indexStats = (Map<String, Object>) ((Map<String, Object>) body.get("indices")).get(idx);
+        Map<String, Object> indexing = (Map<String, Object>) indexStats.get("indexing");
+        assertThat(indexing, notNullValue());
+        assertThat(((Number) indexing.get("docs_indexed_total")).longValue(), equalTo(50L));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testLuceneNodeStats() throws Exception {
+        String idx = "lucene-node-stats";
+        createCompositeIndex(idx, true);
+        indexDocs(idx, 25, 0);
+        flushIndex(idx);
+
+        Response response = getRestClient().performRequest(new Request("GET", "/_plugins/lucene/_nodes/_stats"));
+        assertThat(response.getStatusLine().getStatusCode(), equalTo(200));
+        Map<String, Object> body = XContentHelper.convertToMap(JsonXContent.jsonXContent, response.getEntity().getContent(), true);
+        assertThat(body, hasKey("nodes"));
+        assertThat(((Map<?, ?>) body.get("nodes")).size(), greaterThanOrEqualTo(1));
+    }
+
+    public void testUnknownFormatReturns404() {
+        try {
+            getRestClient().performRequest(new Request("GET", "/_plugins/no-such-format/myindex/_stats"));
+            fail("expected error for unknown format");
+        } catch (Exception e) {
+            assertThat(e, notNullValue());
+        }
+    }
+}

--- a/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/ParquetStatsIT.java
+++ b/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/ParquetStatsIT.java
@@ -1,0 +1,109 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.composite;
+
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+import org.opensearch.client.ResponseException;
+import org.opensearch.common.xcontent.XContentHelper;
+import org.opensearch.common.xcontent.json.JsonXContent;
+import org.opensearch.test.OpenSearchIntegTestCase.ClusterScope;
+import org.opensearch.test.OpenSearchIntegTestCase.Scope;
+
+import java.util.Map;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.notNullValue;
+
+/**
+ * Integration tests for {@code GET /_plugins/parquet/{index}/_stats} and
+ * {@code GET /_plugins/parquet/_nodes/{nodeId}/_stats}.
+ *
+ * @opensearch.experimental
+ */
+@ClusterScope(scope = Scope.SUITE, numDataNodes = 1)
+public class ParquetStatsIT extends AbstractCompositeEngineIT {
+
+    @Override
+    protected boolean addMockHttpTransport() {
+        return false; // need real Netty4 HTTP transport for the REST client
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testParquetIndexStats() throws Exception {
+        String idx = "parquet-stats-1";
+        createCompositeIndex(idx, true);
+        indexDocs(idx, 50, 0);
+        flushIndex(idx);
+
+        Response response = getRestClient().performRequest(new Request("GET", "/_plugins/parquet/" + idx + "/_stats"));
+        assertThat(response.getStatusLine().getStatusCode(), equalTo(200));
+        Map<String, Object> body = XContentHelper.convertToMap(JsonXContent.jsonXContent, response.getEntity().getContent(), true);
+
+        assertThat(body, hasKey("indices"));
+        Map<String, Object> indices = (Map<String, Object>) body.get("indices");
+        assertThat(indices, hasKey(idx));
+        Map<String, Object> indexStats = (Map<String, Object>) indices.get(idx);
+        Map<String, Object> indexing = (Map<String, Object>) indexStats.get("indexing");
+        assertThat(indexing, notNullValue());
+        assertThat(((Number) indexing.get("docs_indexed_total")).longValue(), equalTo(50L));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testParquetIndexStatsShardLevel() throws Exception {
+        String idx = "parquet-stats-shards";
+        createCompositeIndex(idx, true);
+        indexDocs(idx, 30, 0);
+        flushIndex(idx);
+
+        Response response = getRestClient().performRequest(new Request("GET", "/_plugins/parquet/" + idx + "/_stats?level=shards"));
+        assertThat(response.getStatusLine().getStatusCode(), equalTo(200));
+        Map<String, Object> body = XContentHelper.convertToMap(JsonXContent.jsonXContent, response.getEntity().getContent(), true);
+        Map<String, Object> indexStats = (Map<String, Object>) ((Map<String, Object>) body.get("indices")).get(idx);
+        assertThat(indexStats, hasKey("shards"));
+    }
+
+    public void testParquetIndexStatsNonExistent() {
+        try {
+            getRestClient().performRequest(new Request("GET", "/_plugins/parquet/no-such-index/_stats"));
+            fail("expected 404");
+        } catch (Exception e) {
+            assertThat(e, notNullValue());
+        }
+    }
+
+    public void testParquetInvalidShard() throws Exception {
+        String idx = "parquet-invalid-shard";
+        createCompositeIndex(idx, true);
+        try {
+            getRestClient().performRequest(new Request("GET", "/_plugins/parquet/" + idx + "/_stats?shard=99"));
+            fail("expected 400");
+        } catch (ResponseException e) {
+            assertThat(e.getResponse().getStatusLine().getStatusCode(), equalTo(400));
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testParquetNodeStats() throws Exception {
+        String idx = "parquet-node-stats";
+        createCompositeIndex(idx, true);
+        indexDocs(idx, 25, 0);
+        flushIndex(idx);
+
+        Response response = getRestClient().performRequest(new Request("GET", "/_plugins/parquet/_nodes/_stats"));
+        assertThat(response.getStatusLine().getStatusCode(), equalTo(200));
+        Map<String, Object> body = XContentHelper.convertToMap(JsonXContent.jsonXContent, response.getEntity().getContent(), true);
+
+        assertThat(body, hasKey("nodes"));
+        Map<String, Object> nodes = (Map<String, Object>) body.get("nodes");
+        assertThat("at least one node returns parquet stats", nodes.size(), greaterThanOrEqualTo(1));
+    }
+}

--- a/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/StatsExtendedMetricsIT.java
+++ b/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/StatsExtendedMetricsIT.java
@@ -1,0 +1,342 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.composite;
+
+import org.opensearch.test.OpenSearchIntegTestCase.ClusterScope;
+import org.opensearch.test.OpenSearchIntegTestCase.Scope;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Integration tests for stats counters added on top of the baseline set: Validates the new counters
+ * behave correctly at shard, index, and node-aggregate scopes:
+ *
+ * <ul>
+ *   <li>lucene {@code commit.commit_failures}</li>
+ *   <li>parquet {@code merge.flush_and_sort_chunk_total} / {@code _time_millis}</li>
+ *   <li>parquet {@code merge.row_id_mapping_max} (max-of-maxes when aggregated)</li>
+ *   <li>parquet {@code native_runtime.parquet_merge.merge_tasks_started / merge_tasks_failed}</li>
+ *   <li>parquet {@code native_runtime.parquet_merge.merge_tasks_queue_depth / merge_tasks_in_flight} (derived)</li>
+ *   <li>parquet {@code native_runtime.parquet_io.blocking_queue_depth / local_queue_depth_total}</li>
+ *   <li>parquet {@code native_runtime.parquet_io.polls_count_total / overflow_count_total}</li>
+ * </ul>
+ *
+ * @opensearch.experimental
+ */
+@ClusterScope(scope = Scope.SUITE, numDataNodes = 1)
+public class StatsExtendedMetricsIT extends BaseStatsIT {
+
+    // ===================================================================
+    // Lucene commit_failures — always 0 in happy path
+    // ===================================================================
+
+    public void testLuceneCommitFailuresIsZeroInHappyPath() throws Exception {
+        String idx = "pr2-commit-failures-idx";
+        createCompositeIndex(idx, true);
+        indexDocs(idx, 50, 0);
+        refreshIndex(idx);
+        forceMerge(idx, 1);
+
+        assertBusy(() -> {
+            // Index level
+            Map<String, Object> resp = luceneIndexStats(idx);
+            assertCounterPresent("lucene commit_failures field must be present", resp, "indices." + idx + ".commit.commit_failures");
+            assertCounter("lucene commit_failures should be 0 in happy path", resp, "indices." + idx + ".commit.commit_failures", 0L);
+            assertCounterAtLeast(
+                "lucene commit_total should be >= 1 after force_merge",
+                resp,
+                "indices." + idx + ".commit.commit_total",
+                1L
+            );
+        }, 30, TimeUnit.SECONDS);
+    }
+
+    // ===================================================================
+    // Parquet flush_and_sort_chunk + row_id_mapping_max — per-shard
+    // ===================================================================
+
+    @SuppressWarnings("unchecked")
+    public void testFlushAndSortChunkAndRowIdMappingMaxAtShardLevel() throws Exception {
+        String idx = "pr2-fchunk-shard-idx";
+        createCompositeIndex(idx, true);
+
+        // Multiple refreshes → multiple parquet files → force_merge has real work to do.
+        int totalDocs = 0;
+        for (int batch = 0; batch < 4; batch++) {
+            indexDocs(idx, 50, batch * 50);
+            refreshIndex(idx);
+            totalDocs += 50;
+        }
+        forceMerge(idx, 1);
+        final int expectedRows = totalDocs;
+
+        assertBusy(() -> {
+            // Shard level — counters live on the actual primary shard
+            Map<String, Object> shardResp = parquetIndexStats(idx, "level", "shards");
+            Map<String, Object> indices = (Map<String, Object>) shardResp.get("indices");
+            Map<String, Object> indexBlock = (Map<String, Object>) indices.get(idx);
+            Map<String, Object> shards = (Map<String, Object>) indexBlock.get("shards");
+            assertFalse("shards block must not be empty", shards.isEmpty());
+
+            for (Map.Entry<String, Object> entry : shards.entrySet()) {
+                List<Map<String, Object>> copies = (List<Map<String, Object>>) entry.getValue();
+                Map<String, Object> primary = null;
+                for (Map<String, Object> copy : copies) {
+                    Map<String, Object> routing = (Map<String, Object>) copy.get("routing");
+                    if (routing != null && Boolean.TRUE.equals(routing.get("primary"))) {
+                        primary = copy;
+                        break;
+                    }
+                }
+                assertNotNull("each shard entry must have a primary copy", primary);
+
+                Map<String, Object> merge = (Map<String, Object>) primary.get("merge");
+                assertNotNull("primary shard must have merge block", merge);
+
+                long chunkTotal = ((Number) merge.get("flush_and_sort_chunk_total")).longValue();
+                long chunkTime = ((Number) merge.get("flush_and_sort_chunk_time_millis")).longValue();
+                long rowIdMax = ((Number) merge.get("row_id_mapping_max")).longValue();
+
+                assertTrue("flush_and_sort_chunk_total must be >= 1 after force_merge: " + chunkTotal, chunkTotal >= 1);
+                assertTrue("flush_and_sort_chunk_time_millis must be >= 0: " + chunkTime, chunkTime >= 0);
+                // row_id_mapping_max equals the row count of the largest merge output for this shard.
+                // After a force-merge to 1 segment, that's at most the shard's total rows.
+                assertTrue("row_id_mapping_max must be > 0 after force_merge: " + rowIdMax, rowIdMax > 0);
+                assertTrue(
+                    "row_id_mapping_max [" + rowIdMax + "] must not exceed total rows [" + expectedRows + "]",
+                    rowIdMax <= expectedRows
+                );
+            }
+        }, 30, TimeUnit.SECONDS);
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testFlushAndSortChunkAggregatesAtIndexLevel() throws Exception {
+        String idx = "pr2-fchunk-idx-agg";
+        createCompositeIndex(idx, true);
+
+        for (int batch = 0; batch < 3; batch++) {
+            indexDocs(idx, 40, batch * 40);
+            refreshIndex(idx);
+        }
+        forceMerge(idx, 1);
+
+        assertBusy(() -> {
+            // Sum of per-shard chunk_total values (level=shards)
+            Map<String, Object> shardResp = parquetIndexStats(idx, "level", "shards");
+            Map<String, Object> shards = (Map<String, Object>) ((Map<String, Object>) ((Map<String, Object>) shardResp.get("indices")).get(
+                idx
+            )).get("shards");
+            long chunkTotalSum = 0;
+            long chunkTimeSum = 0;
+            long rowIdMaxAcross = 0;
+            for (Map.Entry<String, Object> entry : shards.entrySet()) {
+                List<Map<String, Object>> copies = (List<Map<String, Object>>) entry.getValue();
+                for (Map<String, Object> copy : copies) {
+                    Map<String, Object> routing = (Map<String, Object>) copy.get("routing");
+                    if (routing == null || !Boolean.TRUE.equals(routing.get("primary"))) continue;
+                    Map<String, Object> merge = (Map<String, Object>) copy.get("merge");
+                    chunkTotalSum += ((Number) merge.get("flush_and_sort_chunk_total")).longValue();
+                    chunkTimeSum += ((Number) merge.get("flush_and_sort_chunk_time_millis")).longValue();
+                    rowIdMaxAcross = Math.max(rowIdMaxAcross, ((Number) merge.get("row_id_mapping_max")).longValue());
+                }
+            }
+
+            // Index-level aggregate (default: no level=shards)
+            Map<String, Object> idxResp = parquetIndexStats(idx);
+            assertCounter(
+                "index-level flush_and_sort_chunk_total = sum of primary shards",
+                idxResp,
+                "indices." + idx + ".merge.flush_and_sort_chunk_total",
+                chunkTotalSum
+            );
+            assertCounter(
+                "index-level flush_and_sort_chunk_time_millis = sum of primary shards",
+                idxResp,
+                "indices." + idx + ".merge.flush_and_sort_chunk_time_millis",
+                chunkTimeSum
+            );
+            assertCounter(
+                "index-level row_id_mapping_max = max-of-maxes (NOT sum)",
+                idxResp,
+                "indices." + idx + ".merge.row_id_mapping_max",
+                rowIdMaxAcross
+            );
+        }, 30, TimeUnit.SECONDS);
+    }
+
+    // ===================================================================
+    // Rayon native_runtime — node-level only
+    // ===================================================================
+
+    @SuppressWarnings("unchecked")
+    public void testParquetMergeRayonStatsAfterMerge() throws Exception {
+        String idx = "pr2-rayon-idx";
+        createCompositeIndex(idx, true);
+
+        for (int batch = 0; batch < 4; batch++) {
+            indexDocs(idx, 40, batch * 40);
+            refreshIndex(idx);
+        }
+        forceMerge(idx, 1);
+
+        assertBusy(() -> {
+            Map<String, Object> resp = parquetNodeStats("");
+            Map<String, Object> nodes = (Map<String, Object>) resp.get("nodes");
+            assertFalse("nodes block must not be empty", nodes.isEmpty());
+
+            Map<String, Object> nodeStats = (Map<String, Object>) nodes.values().iterator().next();
+            Map<String, Object> nativeRuntime = (Map<String, Object>) nodeStats.get("native_runtime");
+            assertNotNull("native_runtime block must be present", nativeRuntime);
+
+            Map<String, Object> rayon = (Map<String, Object>) nativeRuntime.get("parquet_merge");
+            assertNotNull("parquet_merge block must be present", rayon);
+
+            long submitted = ((Number) rayon.get("merge_tasks_submitted")).longValue();
+            long started = ((Number) rayon.get("merge_tasks_started")).longValue();
+            long completed = ((Number) rayon.get("merge_tasks_completed")).longValue();
+            long failed = ((Number) rayon.get("merge_tasks_failed")).longValue();
+            long panicked = ((Number) rayon.get("merge_tasks_panicked")).longValue();
+            long queueDepth = ((Number) rayon.get("merge_tasks_queue_depth")).longValue();
+            long inFlight = ((Number) rayon.get("merge_tasks_in_flight")).longValue();
+
+            assertTrue("merge_tasks_submitted must be >= 1: " + submitted, submitted >= 1);
+            assertTrue("merge_tasks_started must be >= 1: " + started, started >= 1);
+            assertTrue("merge_tasks_completed must be >= 1: " + completed, completed >= 1);
+            assertEquals("merge_tasks_failed must be 0 in happy path", 0L, failed);
+            assertEquals("merge_tasks_panicked must be 0 in happy path", 0L, panicked);
+
+            // Derived: queue_depth = max(0, submitted - started). After merges complete, should be 0.
+            assertEquals("queue_depth derivation: max(0, submitted - started)", Math.max(0L, submitted - started), queueDepth);
+            assertEquals(
+                "in_flight derivation: max(0, started - completed - failed - panicked)",
+                Math.max(0L, started - completed - failed - panicked),
+                inFlight
+            );
+            // After force_merge has settled, no merges in flight.
+            assertEquals("in_flight should be 0 after merges complete", 0L, inFlight);
+        }, 30, TimeUnit.SECONDS);
+    }
+
+    // ===================================================================
+    // Tokio parquet_io — new fields present + non-negative
+    // ===================================================================
+
+    @SuppressWarnings("unchecked")
+    public void testParquetIoNewTokioFieldsPresent() throws Exception {
+        String idx = "pr2-tokio-idx";
+        createCompositeIndex(idx, true);
+        for (int batch = 0; batch < 3; batch++) {
+            indexDocs(idx, 30, batch * 30);
+            refreshIndex(idx);
+        }
+        forceMerge(idx, 1);
+
+        assertBusy(() -> {
+            Map<String, Object> resp = parquetNodeStats("");
+            Map<String, Object> nodes = (Map<String, Object>) resp.get("nodes");
+            Map<String, Object> nodeStats = (Map<String, Object>) nodes.values().iterator().next();
+            Map<String, Object> tokio = (Map<String, Object>) ((Map<String, Object>) nodeStats.get("native_runtime")).get("parquet_io");
+            assertNotNull("parquet_io block must be present", tokio);
+
+            // All fields present (existing + new from Task 5).
+            for (String field : new String[] {
+                "num_workers",
+                "num_blocking_threads",
+                "active_tasks",
+                "global_queue_depth",
+                "blocking_queue_depth",
+                "local_queue_depth_total",
+                "polls_count_total",
+                "overflow_count_total",
+                "spawned_tasks_total",
+                "workers_busy_millis_total" }) {
+                assertNotNull("parquet_io must contain field: " + field, tokio.get(field));
+            }
+
+            long workers = ((Number) tokio.get("num_workers")).longValue();
+            long polls = ((Number) tokio.get("polls_count_total")).longValue();
+            long busyMillis = ((Number) tokio.get("workers_busy_millis_total")).longValue();
+
+            assertTrue("num_workers must be > 0 once tokio runtime is initialized: " + workers, workers > 0);
+            // After IO activity (merge writes via spawn_blocking), the runtime polls tasks.
+            assertTrue("polls_count_total must be > 0 after merge IO: " + polls, polls > 0);
+            assertTrue("workers_busy_millis_total must be >= 0: " + busyMillis, busyMillis >= 0);
+
+            // Snapshot fields must be >= 0 (current depth, not cumulative).
+            assertTrue("blocking_queue_depth must be >= 0", ((Number) tokio.get("blocking_queue_depth")).longValue() >= 0);
+            assertTrue("local_queue_depth_total must be >= 0", ((Number) tokio.get("local_queue_depth_total")).longValue() >= 0);
+            assertTrue("overflow_count_total must be >= 0", ((Number) tokio.get("overflow_count_total")).longValue() >= 0);
+        }, 30, TimeUnit.SECONDS);
+    }
+
+    // ===================================================================
+    // Negative tests — fields gated correctly
+    // ===================================================================
+
+    @SuppressWarnings("unchecked")
+    public void testFlushAndSortChunkPresentAtAllShardIndexLevels() throws Exception {
+        // Sanity: per-shard fields must appear at every level (shard / index / node-aggregate).
+        // Distinct from row_id_mapping_max which uses max-of-maxes aggregation.
+        String idx = "pr2-fields-everywhere-idx";
+        createCompositeIndex(idx, true);
+        for (int batch = 0; batch < 2; batch++) {
+            indexDocs(idx, 30, batch * 30);
+            refreshIndex(idx);
+        }
+        forceMerge(idx, 1);
+
+        assertBusy(() -> {
+            // Index-level aggregate
+            Map<String, Object> idxResp = parquetIndexStats(idx);
+            assertCounterPresent(
+                "flush_and_sort_chunk_total at index level",
+                idxResp,
+                "indices." + idx + ".merge.flush_and_sort_chunk_total"
+            );
+            assertCounterPresent(
+                "flush_and_sort_chunk_time_millis at index level",
+                idxResp,
+                "indices." + idx + ".merge.flush_and_sort_chunk_time_millis"
+            );
+            assertCounterPresent("row_id_mapping_max at index level", idxResp, "indices." + idx + ".merge.row_id_mapping_max");
+
+            // Shard level
+            Map<String, Object> shardResp = parquetIndexStats(idx, "level", "shards");
+            Map<String, Object> shards = (Map<String, Object>) ((Map<String, Object>) ((Map<String, Object>) shardResp.get("indices")).get(
+                idx
+            )).get("shards");
+            for (Map.Entry<String, Object> entry : shards.entrySet()) {
+                List<Map<String, Object>> copies = (List<Map<String, Object>>) entry.getValue();
+                for (Map<String, Object> copy : copies) {
+                    Map<String, Object> merge = (Map<String, Object>) copy.get("merge");
+                    assertNotNull("merge block exists on shard copy", merge);
+                    assertNotNull("flush_and_sort_chunk_total exists on shard", merge.get("flush_and_sort_chunk_total"));
+                    assertNotNull("flush_and_sort_chunk_time_millis exists on shard", merge.get("flush_and_sort_chunk_time_millis"));
+                    assertNotNull("row_id_mapping_max exists on shard", merge.get("row_id_mapping_max"));
+                }
+            }
+
+            // Node level — also has these per-shard counters summed
+            Map<String, Object> nodeResp = parquetNodeStats("");
+            Map<String, Object> nodes = (Map<String, Object>) nodeResp.get("nodes");
+            for (Object n : nodes.values()) {
+                Map<String, Object> nodeStats = (Map<String, Object>) n;
+                Map<String, Object> merge = (Map<String, Object>) nodeStats.get("merge");
+                if (merge != null) {
+                    assertNotNull("flush_and_sort_chunk_total on node", merge.get("flush_and_sort_chunk_total"));
+                    assertNotNull("flush_and_sort_chunk_time_millis on node", merge.get("flush_and_sort_chunk_time_millis"));
+                    assertNotNull("row_id_mapping_max on node", merge.get("row_id_mapping_max"));
+                }
+            }
+        }, 30, TimeUnit.SECONDS);
+    }
+}

--- a/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/StatsFailureIT.java
+++ b/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/StatsFailureIT.java
@@ -1,0 +1,162 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.composite;
+
+import org.opensearch.arrow.allocator.ArrowBasePlugin;
+import org.opensearch.be.datafusion.DataFusionPlugin;
+import org.opensearch.parquet.ParquetDataFormatPlugin;
+import org.opensearch.plugins.Plugin;
+import org.opensearch.test.OpenSearchIntegTestCase.ClusterScope;
+import org.opensearch.test.OpenSearchIntegTestCase.Scope;
+import org.opensearch.transport.Netty4ModulePlugin;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Integration tests for stats tracker lifecycle around DFA engine failure.
+ *
+ * <p>Uses {@link FailableLuceneDataFormatPlugin} to inject a Directory-level fault that makes
+ * the IndexWriter tragic, fails the engine, and forces a shard recovery. The test then verifies
+ * that the per-format provider registry properly unregisters the dead tracker and registers a
+ * fresh one for the new engine, with all failure counters at zero on the recovered tracker and
+ * subsequent indexing tracked correctly.
+ *
+ * <p>Note: this test does NOT assert that {@code docs_indexed_failures} ticks during the failed
+ * indexing operations. The Directory-level fault makes the engine tragic before all per-doc
+ * failures necessarily flow through the {@code LuceneWriter.addDoc()} catch block, so a
+ * deterministic assertion on the failure-counter increment is racy. The lifecycle invariants
+ * tested here are the higher-value safety net: orphan trackers and double-counting bugs would
+ * surface as non-zero counters on the post-recovery tracker.
+ *
+ * @opensearch.experimental
+ */
+@ClusterScope(scope = Scope.TEST, numDataNodes = 0)
+public class StatsFailureIT extends AbstractCompositeEngineIT {
+
+    @Override
+    protected boolean addMockHttpTransport() {
+        return false;
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        // Swap LucenePlugin out for FailableLuceneDataFormatPlugin so we can inject failures.
+        return Arrays.asList(
+            ArrowBasePlugin.class,
+            ParquetDataFormatPlugin.class,
+            CompositeDataFormatPlugin.class,
+            FailableLuceneDataFormatPlugin.class,
+            DataFusionPlugin.class,
+            Netty4ModulePlugin.class
+        );
+    }
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        FailableLuceneDataFormatPlugin.clearFailure();
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        FailableLuceneDataFormatPlugin.clearFailure();
+        super.tearDown();
+    }
+
+    /**
+     * Verifies stats tracker lifecycle around engine failure and recovery:
+     * 1. Happy path: all *_failures counters are 0 after successful indexing.
+     * 2. Inject a Directory-level fault that causes the engine to fail.
+     * 3. After shard recovery, stats endpoint is functional and failure counters are 0
+     *    (proving the old tracker was properly unregistered and a fresh one registered).
+     * 4. New indexing after recovery is tracked correctly.
+     */
+    public void testTrackerLifecycleAroundEngineFailure() throws Exception {
+        // Start a single node to minimize interference with the JVM-wide failure countdown.
+        internalCluster().startNode();
+        String idx = "failure-idx";
+        createCompositeIndex(idx, true);
+
+        // Stage 1 — happy path: index 50 docs, refresh, assert all *_failures == 0.
+        indexDocs(idx, 50, 0);
+        refreshIndex(idx);
+        Map<String, Object> happyP = StatsITHelpers.parquetIndexStats(getRestClient(), idx);
+        Map<String, Object> happyL = StatsITHelpers.luceneIndexStats(getRestClient(), idx);
+        StatsITHelpers.assertCounter(
+            "happy parquet native_write_failures",
+            happyP,
+            "indices." + idx + ".native_write.native_write_failures",
+            0L
+        );
+        StatsITHelpers.assertCounter("happy parquet merge_failures", happyP, "indices." + idx + ".merge.merge_failures", 0L);
+        StatsITHelpers.assertCounter(
+            "happy lucene docs_indexed_failures",
+            happyL,
+            "indices." + idx + ".indexing.docs_indexed_failures",
+            0L
+        );
+        StatsITHelpers.assertCounter("happy lucene merge_failures", happyL, "indices." + idx + ".merge.merge_failures", 0L);
+
+        // Stage 2 — inject a Directory-level fault. The IOException during flush makes the
+        // IndexWriter tragic, which fails the engine. The shard is then reallocated and
+        // recovered on the same node.
+        FailableLuceneDataFormatPlugin.failOnNthWrite(3);
+        for (int i = 50; i < 70; i++) {
+            try {
+                client().prepareIndex(idx).setId(String.valueOf(i)).setSource("name", "injection_" + i, "value", i).get();
+            } catch (Exception expected) {
+                // Engine failure causes indexing exceptions — expected.
+                break;
+            }
+        }
+        FailableLuceneDataFormatPlugin.clearFailure();
+
+        // Stage 3 — wait for shard recovery. After the engine fails, the shard is reallocated.
+        // A new engine is created with a fresh stats tracker.
+        assertBusy(() -> ensureGreen(idx), 30, TimeUnit.SECONDS);
+
+        // Stage 4 — after recovery, stats endpoint must be functional with clean counters.
+        // The old tracker (which may have seen the failure) was unregistered on engine close;
+        // the new tracker starts fresh.
+        Map<String, Object> postRecoveryL = StatsITHelpers.luceneIndexStats(getRestClient(), idx);
+        StatsITHelpers.assertCounter(
+            "post-recovery lucene docs_indexed_failures must be 0",
+            postRecoveryL,
+            "indices." + idx + ".indexing.docs_indexed_failures",
+            0L
+        );
+        StatsITHelpers.assertCounter(
+            "post-recovery lucene merge_failures must be 0",
+            postRecoveryL,
+            "indices." + idx + ".merge.merge_failures",
+            0L
+        );
+
+        // Stage 5 — new indexing after recovery is tracked correctly.
+        indexDocs(idx, 20, 100);
+        refreshIndex(idx);
+        Map<String, Object> postIndexL = StatsITHelpers.luceneIndexStats(getRestClient(), idx);
+        StatsITHelpers.assertCounterAtLeast(
+            "post-recovery new docs tracked",
+            postIndexL,
+            "indices." + idx + ".indexing.docs_indexed_total",
+            20L
+        );
+        Map<String, Object> postIndexP = StatsITHelpers.parquetIndexStats(getRestClient(), idx);
+        StatsITHelpers.assertCounterAtLeast(
+            "post-recovery parquet new docs tracked",
+            postIndexP,
+            "indices." + idx + ".indexing.docs_indexed_total",
+            20L
+        );
+    }
+}

--- a/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/StatsITHelpers.java
+++ b/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/StatsITHelpers.java
@@ -1,0 +1,124 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.composite;
+
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+import org.opensearch.client.RestClient;
+import org.opensearch.common.xcontent.XContentHelper;
+import org.opensearch.common.xcontent.json.JsonXContent;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Static utility methods shared across stats integration tests. Extracted from
+ * {@link BaseStatsIT} so that test classes extending different base hierarchies
+ * (e.g. {@link DataFormatAwareReplicationBaseIT}) can reuse the same helpers.
+ *
+ * @opensearch.experimental
+ */
+final class StatsITHelpers {
+
+    private StatsITHelpers() {}
+
+    // ---- REST helpers ----
+
+    static Map<String, Object> parquetIndexStats(RestClient rest, String index, String... queryParams) throws IOException {
+        return fetchStats(rest, "/_plugins/parquet/" + index + "/_stats", queryParams);
+    }
+
+    static Map<String, Object> luceneIndexStats(RestClient rest, String index, String... queryParams) throws IOException {
+        return fetchStats(rest, "/_plugins/lucene/" + index + "/_stats", queryParams);
+    }
+
+    static Map<String, Object> parquetNodeStats(RestClient rest, String nodeIdOrEmpty, String... queryParams) throws IOException {
+        String path = nodeIdOrEmpty.isEmpty() ? "/_plugins/parquet/_nodes/_stats" : "/_plugins/parquet/_nodes/" + nodeIdOrEmpty + "/_stats";
+        return fetchStats(rest, path, queryParams);
+    }
+
+    static Map<String, Object> luceneNodeStats(RestClient rest, String nodeIdOrEmpty, String... queryParams) throws IOException {
+        String path = nodeIdOrEmpty.isEmpty() ? "/_plugins/lucene/_nodes/_stats" : "/_plugins/lucene/_nodes/" + nodeIdOrEmpty + "/_stats";
+        return fetchStats(rest, path, queryParams);
+    }
+
+    static Map<String, Object> fetchStats(RestClient rest, String path, String... queryParams) throws IOException {
+        if (queryParams.length % 2 != 0) {
+            throw new AssertionError("queryParams must be key-value pairs, got odd count: " + queryParams.length);
+        }
+        StringBuilder uri = new StringBuilder(path);
+        for (int i = 0; i < queryParams.length; i += 2) {
+            uri.append(i == 0 ? '?' : '&').append(queryParams[i]).append('=').append(queryParams[i + 1]);
+        }
+        Response response = rest.performRequest(new Request("GET", uri.toString()));
+        return XContentHelper.convertToMap(JsonXContent.jsonXContent, response.getEntity().getContent(), true);
+    }
+
+    static Response getRaw(RestClient rest, String path) throws IOException {
+        return rest.performRequest(new Request("GET", path));
+    }
+
+    // ---- Pure parsers ----
+
+    static int getStatusCode(Map<String, Object> response) {
+        Number status = (Number) response.get("status");
+        return status != null ? status.intValue() : -1;
+    }
+
+    @SuppressWarnings("unchecked")
+    static long getCounter(Map<String, Object> response, String dottedPath) {
+        String[] segments = dottedPath.split("\\.");
+        Object current = response;
+        for (String segment : segments) {
+            if (!(current instanceof Map)) return -1L;
+            current = ((Map<String, Object>) current).get(segment);
+            if (current == null) return -1L;
+        }
+        if (current instanceof Number) return ((Number) current).longValue();
+        return -1L;
+    }
+
+    @SuppressWarnings("unchecked")
+    static boolean hasPath(Map<String, Object> response, String dottedPath) {
+        String[] segments = dottedPath.split("\\.");
+        Object current = response;
+        for (String segment : segments) {
+            if (!(current instanceof Map)) return false;
+            current = ((Map<String, Object>) current).get(segment);
+            if (current == null) return false;
+        }
+        return true;
+    }
+
+    // ---- Assertion helpers ----
+
+    static void assertCounter(String message, Map<String, Object> response, String path, long expected) {
+        long actual = getCounter(response, path);
+        assertEquals(message + " [path=" + path + "]", expected, actual);
+    }
+
+    static void assertCounterAtLeast(String message, Map<String, Object> response, String path, long min) {
+        long actual = getCounter(response, path);
+        assertTrue(message + " [path=" + path + ", actual=" + actual + ", min=" + min + "]", actual >= min);
+    }
+
+    static void assertCounterPresent(String message, Map<String, Object> response, String path) {
+        long actual = getCounter(response, path);
+        assertTrue(message + " [path=" + path + " must exist, got -1]", actual != -1L);
+    }
+
+    // ---- Action helpers ----
+
+    static void forceMerge(org.opensearch.transport.client.Client client, String index, int maxSegments) {
+        client.admin().indices().prepareForceMerge(index).setMaxNumSegments(maxSegments).get();
+    }
+}

--- a/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/StatsLifecycleIT.java
+++ b/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/StatsLifecycleIT.java
@@ -119,9 +119,17 @@ public class StatsLifecycleIT extends BaseStatsIT {
                 260L
             );
             Map<String, Object> l5 = luceneIndexStats("lifecycle-idx");
-            // Note: lucene.merge.merge_total stays 0 in the composite-engine flow because the
-            // lucene secondary uses flush+addIndexes (not standalone IndexWriter.maybeMerge()).
-            // The force-merge work is recorded under flush.flush_force_merge_time_millis instead.
+            // Lucene merger fires per shard during composite force_merge — CompositeMerger
+            // dispatches to both the primary (parquet) and secondary (lucene) mergers. We
+            // expect merge_total >= number_of_primary_shards (1 here, single-shard test).
+            // flush.flush_force_merge_time_millis also records time spent in the internal
+            // force-merge during flush.
+            assertCounterAtLeast(
+                "stage 5 lucene merge_total >= 1 (composite force_merge dispatches to lucene merger too)",
+                l5,
+                "indices.lifecycle-idx.merge.merge_total",
+                1L
+            );
             assertCounterAtLeast(
                 "stage 5 lucene flush_force_merge_time_millis",
                 l5,

--- a/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/StatsLifecycleIT.java
+++ b/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/StatsLifecycleIT.java
@@ -73,6 +73,8 @@ public class StatsLifecycleIT extends BaseStatsIT {
         Map<String, Object> l3 = luceneIndexStats("lifecycle-idx");
         assertCounterAtLeast("stage 3 lucene flush", l3, "indices.lifecycle-idx.flush.flush_total", 1L);
         assertCounterAtLeast("stage 3 lucene commit", l3, "indices.lifecycle-idx.commit.commit_total", 1L);
+        // commit_failures must stay 0 in the happy path.
+        assertCounter("stage 3 lucene commit_failures", l3, "indices.lifecycle-idx.commit.commit_failures", 0L);
 
         // Stage 4 — index 4 more batches with refresh between each, to produce 5 parquet files total.
         // Multiple parquet files are needed for force_merge to actually invoke a parquet merge:
@@ -95,6 +97,27 @@ public class StatsLifecycleIT extends BaseStatsIT {
             assertCounterAtLeast("stage 5 parquet merge_total", r5, "indices.lifecycle-idx.merge.merge_total", 1L);
             assertCounterAtLeast("stage 5 parquet merge_input_files", r5, "indices.lifecycle-idx.merge.merge_input_files_total", 2L);
             assertCounter("stage 5 parquet merge_failures", r5, "indices.lifecycle-idx.merge.merge_failures", 0L);
+            // per-shard merge metrics — must populate after force_merge runs at least one merge.
+            assertCounterAtLeast(
+                "stage 5 parquet flush_and_sort_chunk_total",
+                r5,
+                "indices.lifecycle-idx.merge.flush_and_sort_chunk_total",
+                1L
+            );
+            assertCounterAtLeast(
+                "stage 5 parquet flush_and_sort_chunk_time_millis",
+                r5,
+                "indices.lifecycle-idx.merge.flush_and_sort_chunk_time_millis",
+                0L
+            );
+            // row_id_mapping_max equals the largest merge output's row count for this shard;
+            // after merging 5 batches of 40 docs (=260 total) on a single-shard index, max is 260.
+            assertCounter(
+                "stage 5 parquet row_id_mapping_max equals merged row count",
+                r5,
+                "indices.lifecycle-idx.merge.row_id_mapping_max",
+                260L
+            );
             Map<String, Object> l5 = luceneIndexStats("lifecycle-idx");
             // Note: lucene.merge.merge_total stays 0 in the composite-engine flow because the
             // lucene secondary uses flush+addIndexes (not standalone IndexWriter.maybeMerge()).

--- a/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/StatsLifecycleIT.java
+++ b/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/StatsLifecycleIT.java
@@ -1,0 +1,439 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.composite;
+
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+import org.opensearch.client.ResponseException;
+import org.opensearch.test.OpenSearchIntegTestCase.ClusterScope;
+import org.opensearch.test.OpenSearchIntegTestCase.Scope;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Integration tests for stats API lifecycle behavior on a single-node, single-shard topology.
+ * Tests counter accuracy across indexing, refresh, flush, merge stages and REST contract negatives.
+ *
+ * @opensearch.experimental
+ */
+@ClusterScope(scope = Scope.SUITE, numDataNodes = 1)
+public class StatsLifecycleIT extends BaseStatsIT {
+
+    /**
+     * Flagship accuracy test: walks through 7 stages of index lifecycle and asserts
+     * counters increment correctly for both parquet and lucene formats.
+     */
+    public void testStatsLifecycle_SingleShard() throws Exception {
+        createCompositeIndex("lifecycle-idx", true);
+
+        // Stage 0 — fresh index
+        Map<String, Object> r0 = parquetIndexStats("lifecycle-idx");
+        assertCounter("stage 0 docs", r0, "indices.lifecycle-idx.indexing.docs_indexed_total", 0L);
+        assertCounter("stage 0 native_write", r0, "indices.lifecycle-idx.native_write.native_write_total", 0L);
+        Map<String, Object> l0 = luceneIndexStats("lifecycle-idx");
+        assertCounter("stage 0 lucene refresh", l0, "indices.lifecycle-idx.refresh.refresh_total", 0L);
+
+        // Stage 1 — index 100 docs (no refresh yet)
+        indexDocs("lifecycle-idx", 100, 0);
+        Map<String, Object> r1 = parquetIndexStats("lifecycle-idx");
+        assertCounter("stage 1 parquet docs", r1, "indices.lifecycle-idx.indexing.docs_indexed_total", 100L);
+        assertCounterAtLeast("stage 1 parquet index_time", r1, "indices.lifecycle-idx.indexing.index_time_millis", 0L);
+        // Note: ParquetShardStats does NOT have docs_indexed_failures — only lucene does
+        Map<String, Object> l1 = luceneIndexStats("lifecycle-idx");
+        assertCounter("stage 1 lucene docs", l1, "indices.lifecycle-idx.indexing.docs_indexed_total", 100L);
+        assertCounter("stage 1 lucene refresh_total", l1, "indices.lifecycle-idx.refresh.refresh_total", 0L);
+
+        // Stage 2 — refresh
+        refreshIndex("lifecycle-idx");
+        Map<String, Object> r2 = parquetIndexStats("lifecycle-idx");
+        assertCounterAtLeast("stage 2 native_write", r2, "indices.lifecycle-idx.native_write.native_write_total", 1L);
+        assertCounterAtLeast("stage 2 native_finalize", r2, "indices.lifecycle-idx.native_write.native_finalize_total", 1L);
+        Map<String, Object> l2 = luceneIndexStats("lifecycle-idx");
+        assertCounterAtLeast("stage 2 lucene refresh_total", l2, "indices.lifecycle-idx.refresh.refresh_total", 1L);
+        assertCounterAtLeast("stage 2 lucene refresh_time", l2, "indices.lifecycle-idx.refresh.refresh_time_millis", 0L);
+
+        // Stage 3 — flush
+        flushIndex("lifecycle-idx");
+        Map<String, Object> l3 = luceneIndexStats("lifecycle-idx");
+        assertCounterAtLeast("stage 3 lucene flush", l3, "indices.lifecycle-idx.flush.flush_total", 1L);
+        assertCounterAtLeast("stage 3 lucene commit", l3, "indices.lifecycle-idx.commit.commit_total", 1L);
+
+        // Stage 4 — index 4 more batches with refresh between each, to produce 5 parquet files total.
+        // Multiple parquet files are needed for force_merge to actually invoke a parquet merge:
+        // policy doesn't merge fewer than 2 files, and we want headroom above the threshold.
+        for (int batch = 1; batch <= 4; batch++) {
+            indexDocs("lifecycle-idx", 40, 100 + (batch - 1) * 40);
+            refreshIndex("lifecycle-idx");
+        }
+        Map<String, Object> r4 = parquetIndexStats("lifecycle-idx");
+        assertCounter("stage 4 parquet docs accumulate", r4, "indices.lifecycle-idx.indexing.docs_indexed_total", 260L);
+        Map<String, Object> l4 = luceneIndexStats("lifecycle-idx");
+        assertCounter("stage 4 lucene docs accumulate", l4, "indices.lifecycle-idx.indexing.docs_indexed_total", 260L);
+        assertCounterAtLeast("stage 4 lucene refresh count", l4, "indices.lifecycle-idx.refresh.refresh_total", 5L);
+
+        // Stage 5 — force_merge to 1 segment. Parquet merges asynchronously off the force_merge call,
+        // so wrap merge-counter assertions in assertBusy to wait for the native merge to finalize.
+        forceMerge("lifecycle-idx", 1);
+        assertBusy(() -> {
+            Map<String, Object> r5 = parquetIndexStats("lifecycle-idx");
+            assertCounterAtLeast("stage 5 parquet merge_total", r5, "indices.lifecycle-idx.merge.merge_total", 1L);
+            assertCounterAtLeast("stage 5 parquet merge_input_files", r5, "indices.lifecycle-idx.merge.merge_input_files_total", 2L);
+            assertCounter("stage 5 parquet merge_failures", r5, "indices.lifecycle-idx.merge.merge_failures", 0L);
+            Map<String, Object> l5 = luceneIndexStats("lifecycle-idx");
+            assertCounterAtLeast("stage 5 lucene merge_total", l5, "indices.lifecycle-idx.merge.merge_total", 1L);
+            assertCounter("stage 5 lucene merge_failures", l5, "indices.lifecycle-idx.merge.merge_failures", 0L);
+        }, 30, java.util.concurrent.TimeUnit.SECONDS);
+
+        // Stage 6 — final cross-format consistency
+        Map<String, Object> rf = parquetIndexStats("lifecycle-idx");
+        Map<String, Object> lf = luceneIndexStats("lifecycle-idx");
+        long parquetDocs = getCounter(rf, "indices.lifecycle-idx.indexing.docs_indexed_total");
+        long luceneDocs = getCounter(lf, "indices.lifecycle-idx.indexing.docs_indexed_total");
+        assertEquals("cross-format doc count must match", parquetDocs, luceneDocs);
+        assertEquals(260L, parquetDocs);
+        // All failure counters zero in happy path
+        assertCounter("happy parquet native_write_failures", rf, "indices.lifecycle-idx.native_write.native_write_failures", 0L);
+        assertCounter("happy parquet merge_failures", rf, "indices.lifecycle-idx.merge.merge_failures", 0L);
+        assertCounter("happy lucene merge_failures", lf, "indices.lifecycle-idx.merge.merge_failures", 0L);
+    }
+
+    /**
+     * Verifies that stats for multiple indices are isolated — querying one index
+     * returns only that index's counters.
+     */
+    public void testMultipleIndicesIsolation() throws Exception {
+        createCompositeIndex("idx1", true);
+        createCompositeIndex("idx2", true);
+        createCompositeIndex("idx3", true);
+
+        indexDocs("idx1", 10, 0);
+        indexDocs("idx2", 20, 0);
+        indexDocs("idx3", 30, 0);
+        refreshIndex("idx1");
+        refreshIndex("idx2");
+        refreshIndex("idx3");
+
+        assertCounter("parquet idx1", parquetIndexStats("idx1"), "indices.idx1.indexing.docs_indexed_total", 10L);
+        assertCounter("parquet idx2", parquetIndexStats("idx2"), "indices.idx2.indexing.docs_indexed_total", 20L);
+        assertCounter("parquet idx3", parquetIndexStats("idx3"), "indices.idx3.indexing.docs_indexed_total", 30L);
+        assertCounter("lucene idx1", luceneIndexStats("idx1"), "indices.idx1.indexing.docs_indexed_total", 10L);
+        assertCounter("lucene idx2", luceneIndexStats("idx2"), "indices.idx2.indexing.docs_indexed_total", 20L);
+        assertCounter("lucene idx3", luceneIndexStats("idx3"), "indices.idx3.indexing.docs_indexed_total", 30L);
+    }
+
+    /**
+     * Tests REST contract negative cases: unknown format, wrong HTTP method,
+     * nonexistent index, response shape, and content-type.
+     */
+    public void testRESTContractNegatives() throws Exception {
+        createCompositeIndex("contract-idx", true);
+        indexDocs("contract-idx", 5, 0);
+        refreshIndex("contract-idx");
+
+        // 1. Unknown format -> 400
+        try {
+            getRestClient().performRequest(new Request("GET", "/_plugins/orc/contract-idx/_stats"));
+            fail("expected 400 for unknown format");
+        } catch (ResponseException e) {
+            assertEquals(400, e.getResponse().getStatusLine().getStatusCode());
+        }
+
+        // 2. Wrong method POST -> 405
+        try {
+            getRestClient().performRequest(new Request("POST", "/_plugins/parquet/contract-idx/_stats"));
+            fail("expected 405 for POST");
+        } catch (ResponseException e) {
+            assertEquals(405, e.getResponse().getStatusLine().getStatusCode());
+        }
+
+        // 3. Nonexistent index -> 4xx
+        try {
+            getRestClient().performRequest(new Request("GET", "/_plugins/parquet/no-such-idx/_stats"));
+            fail("expected 4xx for nonexistent index");
+        } catch (ResponseException e) {
+            int code = e.getResponse().getStatusLine().getStatusCode();
+            assertTrue("expected 4xx, got " + code, code >= 400 && code < 500);
+        }
+
+        // 4. Verify a successful all-shards query returns proper structure.
+        // (We use a wildcard pattern; bare /_plugins/parquet/_stats is not a registered route.)
+        Response wildcardResponse = getRaw("/_plugins/parquet/*/_stats");
+        Map<String, Object> wildcardBody = org.opensearch.common.xcontent.XContentHelper.convertToMap(
+            org.opensearch.common.xcontent.json.JsonXContent.jsonXContent,
+            wildcardResponse.getEntity().getContent(),
+            true
+        );
+        assertTrue("response must have 'indices' key", wildcardBody.containsKey("indices"));
+
+        // 5. Content-Type assertion
+        Response successResponse = getRaw("/_plugins/parquet/contract-idx/_stats");
+        String contentType = successResponse.getEntity().getContentType();
+        assertTrue("Content-Type must be application/json, got: " + contentType, contentType.startsWith("application/json"));
+    }
+
+    /**
+     * Verifies that parquet primary and lucene secondary see the same operations.
+     */
+    public void testCrossFormatConsistency() throws Exception {
+        createCompositeIndex("cross-format-idx", true);
+        indexDocs("cross-format-idx", 50, 0);
+        refreshIndex("cross-format-idx");
+        flushIndex("cross-format-idx");
+
+        Map<String, Object> p = parquetIndexStats("cross-format-idx");
+        Map<String, Object> l = luceneIndexStats("cross-format-idx");
+
+        long parquetDocs = getCounter(p, "indices.cross-format-idx.indexing.docs_indexed_total");
+        long luceneDocs = getCounter(l, "indices.cross-format-idx.indexing.docs_indexed_total");
+        assertEquals("both formats must observe identical doc count", parquetDocs, luceneDocs);
+        assertEquals(50L, parquetDocs);
+
+        // Refresh fires native_finalize on parquet AND refresh_total on lucene.
+        assertCounterAtLeast("parquet finalize after refresh", p, "indices.cross-format-idx.native_write.native_finalize_total", 1L);
+        assertCounterAtLeast("lucene refresh after refresh", l, "indices.cross-format-idx.refresh.refresh_total", 1L);
+
+        // Flush fires lucene flush+commit; parquet does not have a flush counter (it finalizes per refresh).
+        assertCounterAtLeast("lucene flush after flush", l, "indices.cross-format-idx.flush.flush_total", 1L);
+        assertCounterAtLeast("lucene commit after flush", l, "indices.cross-format-idx.commit.commit_total", 1L);
+    }
+
+    /**
+     * Verifies counters increment correctly across multiple write batches — no resets, no drift.
+     */
+    public void testCountersAccumulateAcrossOperations() throws Exception {
+        createCompositeIndex("accumulate-idx", true);
+
+        // Batch 1: 30 docs, refresh, capture v1
+        indexDocs("accumulate-idx", 30, 0);
+        refreshIndex("accumulate-idx");
+        long v1Parquet = getCounter(parquetIndexStats("accumulate-idx"), "indices.accumulate-idx.indexing.docs_indexed_total");
+        long v1Lucene = getCounter(luceneIndexStats("accumulate-idx"), "indices.accumulate-idx.indexing.docs_indexed_total");
+        long v1Refresh = getCounter(luceneIndexStats("accumulate-idx"), "indices.accumulate-idx.refresh.refresh_total");
+        assertEquals(30L, v1Parquet);
+        assertEquals(30L, v1Lucene);
+        assertTrue("refresh_total must be at least 1 after batch 1", v1Refresh >= 1L);
+
+        // Batch 2: 70 more docs, refresh, capture v2
+        indexDocs("accumulate-idx", 70, 30);
+        refreshIndex("accumulate-idx");
+        long v2Parquet = getCounter(parquetIndexStats("accumulate-idx"), "indices.accumulate-idx.indexing.docs_indexed_total");
+        long v2Lucene = getCounter(luceneIndexStats("accumulate-idx"), "indices.accumulate-idx.indexing.docs_indexed_total");
+        long v2Refresh = getCounter(luceneIndexStats("accumulate-idx"), "indices.accumulate-idx.refresh.refresh_total");
+
+        // Doc counters must be exactly v1 + 70.
+        assertEquals("parquet docs accumulate exactly", v1Parquet + 70L, v2Parquet);
+        assertEquals("lucene docs accumulate exactly", v1Lucene + 70L, v2Lucene);
+        // Refresh count must increase strictly (we issued at least one more refresh).
+        assertTrue("refresh count must strictly increase: v1=" + v1Refresh + ", v2=" + v2Refresh, v2Refresh > v1Refresh);
+    }
+
+    /**
+     * Verifies a freshly-created index with no operations has all counters at zero.
+     */
+    public void testEmptyIndexAllCountersZero() throws Exception {
+        createCompositeIndex("empty-idx", true);
+
+        Map<String, Object> p = parquetIndexStats("empty-idx");
+        Map<String, Object> l = luceneIndexStats("empty-idx");
+
+        // Every parquet counter that's been wired must be zero, not absent (catches tracker-not-registered bugs).
+        assertCounter("parquet docs zero", p, "indices.empty-idx.indexing.docs_indexed_total", 0L);
+        assertCounter("parquet index_time zero", p, "indices.empty-idx.indexing.index_time_millis", 0L);
+        assertCounter("parquet native_write_total zero", p, "indices.empty-idx.native_write.native_write_total", 0L);
+        assertCounter("parquet native_finalize_total zero", p, "indices.empty-idx.native_write.native_finalize_total", 0L);
+        assertCounter("parquet merge_total zero", p, "indices.empty-idx.merge.merge_total", 0L);
+        assertCounter("parquet vsr_rotations_total zero", p, "indices.empty-idx.vsr.vsr_rotations_total", 0L);
+
+        // Same for lucene. Note: index creation may trigger an initial commit, so commit_total may be 0 or 1.
+        assertCounter("lucene docs zero", l, "indices.empty-idx.indexing.docs_indexed_total", 0L);
+        assertCounter("lucene refresh_total zero", l, "indices.empty-idx.refresh.refresh_total", 0L);
+        assertCounter("lucene flush_total zero", l, "indices.empty-idx.flush.flush_total", 0L);
+        assertCounter("lucene merge_total zero", l, "indices.empty-idx.merge.merge_total", 0L);
+        // commit_total may be 0 or 1 — index creation can trigger an initial Lucene commit.
+        long commitTotal = getCounter(l, "indices.empty-idx.commit.commit_total");
+        assertTrue("lucene commit_total must be 0 or 1 for empty index, got " + commitTotal, commitTotal >= 0L && commitTotal <= 1L);
+    }
+
+    /**
+     * Verifies that stats counters reset to 0 when an index is deleted and recreated with the
+     * same name. Catches tracker leaks in the per-format provider registry.
+     */
+    public void testCountersResetOnIndexDelete() throws Exception {
+        String idx = "reset-on-delete-idx";
+        createCompositeIndex(idx, true);
+        indexDocs(idx, 100, 0);
+        refreshIndex(idx);
+
+        // Pre-condition: counters reflect the indexed docs.
+        assertCounter("pre-delete parquet docs", parquetIndexStats(idx), "indices." + idx + ".indexing.docs_indexed_total", 100L);
+        assertCounter("pre-delete lucene docs", luceneIndexStats(idx), "indices." + idx + ".indexing.docs_indexed_total", 100L);
+
+        // Delete and recreate same name.
+        client().admin().indices().prepareDelete(idx).get();
+        createCompositeIndex(idx, true);
+
+        // Post-condition: counters must be 0 — no carryover from the deleted index's tracker.
+        assertCounter("post-recreate parquet docs zero", parquetIndexStats(idx), "indices." + idx + ".indexing.docs_indexed_total", 0L);
+        assertCounter("post-recreate lucene docs zero", luceneIndexStats(idx), "indices." + idx + ".indexing.docs_indexed_total", 0L);
+        assertCounter(
+            "post-recreate parquet native_write zero",
+            parquetIndexStats(idx),
+            "indices." + idx + ".native_write.native_write_total",
+            0L
+        );
+        assertCounter("post-recreate lucene refresh zero", luceneIndexStats(idx), "indices." + idx + ".refresh.refresh_total", 0L);
+    }
+
+    /**
+     * Race-condition safety: 4 threads index 250 docs each concurrently. After all threads
+     * complete, docs_indexed_total must be exactly 1000.
+     *
+     * <p>A separate querier thread polls the stats endpoint at ~1ms intervals while indexing
+     * is in flight and asserts the docs_indexed_total counter never goes backwards. This is a
+     * best-effort check: a transient backwards-jump that resolves within a poll window could
+     * still slip through. The primary correctness invariant is the final-count assertion at
+     * the end of the test.
+     */
+    public void testConcurrentIndexingAccuracy() throws Exception {
+        String idx = "concurrent-idx";
+        createCompositeIndex(idx, true);
+
+        final int threadCount = 4;
+        final int docsPerThread = 250;
+        final int totalDocs = threadCount * docsPerThread;
+        ExecutorService pool = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch start = new CountDownLatch(1);
+        List<Future<?>> futures = new ArrayList<>();
+
+        for (int t = 0; t < threadCount; t++) {
+            final int threadId = t;
+            futures.add(pool.submit(() -> {
+                try {
+                    start.await();
+                    for (int i = 0; i < docsPerThread; i++) {
+                        int docId = threadId * docsPerThread + i;
+                        client().prepareIndex(idx).setId(String.valueOf(docId)).setSource("name", "doc_" + docId, "value", docId).get();
+                    }
+                } catch (Exception e) {
+                    throw new RuntimeException("thread " + threadId + " failed", e);
+                }
+                return null;
+            }));
+        }
+
+        // Concurrent stats queries while indexing — best-effort monotonicity check at ~1ms cadence.
+        // Single querier thread: read-then-update of `lastSeen` is safe without compare-and-swap
+        // because there is no other writer.
+        AtomicLong lastSeen = new AtomicLong(0);
+        AtomicBoolean keepQuerying = new AtomicBoolean(true);
+        AtomicReference<Throwable> queryError = new AtomicReference<>();
+        Thread querier = new Thread(() -> {
+            while (keepQuerying.get()) {
+                try {
+                    Map<String, Object> r = parquetIndexStats(idx);
+                    long current = getCounter(r, "indices." + idx + ".indexing.docs_indexed_total");
+                    long prev = lastSeen.get();
+                    if (current < prev) {
+                        throw new AssertionError("counter went backwards: prev=" + prev + ", current=" + current);
+                    }
+                    lastSeen.set(Math.max(prev, current));
+                    Thread.sleep(1);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    return;
+                } catch (Throwable t) {
+                    queryError.set(t);
+                    return;
+                }
+            }
+        });
+        querier.start();
+
+        // Release indexer threads.
+        start.countDown();
+        for (Future<?> f : futures) {
+            f.get(90, TimeUnit.SECONDS);
+        }
+        pool.shutdown();
+        keepQuerying.set(false);
+        querier.join(5000);
+
+        // Verify no querier errors.
+        if (queryError.get() != null) {
+            throw new AssertionError("querier thread saw an error", queryError.get());
+        }
+
+        // Final accuracy check.
+        refreshIndex(idx);
+        assertCounter(
+            "final docs_indexed_total must be exactly " + totalDocs,
+            parquetIndexStats(idx),
+            "indices." + idx + ".indexing.docs_indexed_total",
+            (long) totalDocs
+        );
+        assertCounter(
+            "lucene final must match",
+            luceneIndexStats(idx),
+            "indices." + idx + ".indexing.docs_indexed_total",
+            (long) totalDocs
+        );
+    }
+
+    /**
+     * Verifies that a plain Lucene index (no composite engine) returns 200 with effectively-empty stats.
+     */
+    public void testNonCompositeIndexReturnsEmpty() throws Exception {
+        // Create index WITHOUT composite engine — plain Lucene only.
+        client().admin()
+            .indices()
+            .prepareCreate("plain-idx")
+            .setSettings(
+                org.opensearch.common.settings.Settings.builder()
+                    .put(org.opensearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+                    .put(org.opensearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+            )
+            .setMapping("name", "type=keyword")
+            .get();
+        ensureGreen("plain-idx");
+
+        // Index some docs — these go to plain Lucene, not DFA.
+        for (int i = 0; i < 5; i++) {
+            client().prepareIndex("plain-idx").setId(String.valueOf(i)).setSource("name", "doc_" + i).get();
+        }
+        refreshIndex("plain-idx");
+
+        // Both stats endpoints must return HTTP 200 with no parquet/lucene tracker data for this index.
+        Map<String, Object> p = parquetIndexStats("plain-idx");
+        Map<String, Object> l = luceneIndexStats("plain-idx");
+
+        // Response must contain the indices block. The plain-idx entry must NOT have any DFA
+        // counters: with no tracker registered, FormatStatsResponse aggregation produces an
+        // empty object for the index, so docs_indexed_total is absent (getCounter returns -1L).
+        // Accepting -1 OR 0 makes the assertion robust to future shape changes (e.g., emitting
+        // explicit zeros rather than omitting fields).
+        long parquetDocs = getCounter(p, "indices.plain-idx.indexing.docs_indexed_total");
+        long luceneDocs = getCounter(l, "indices.plain-idx.indexing.docs_indexed_total");
+        assertTrue("parquet docs must be absent (-1) or 0 for non-composite index, got " + parquetDocs, parquetDocs <= 0L);
+        assertTrue("lucene docs must be absent (-1) or 0 for non-composite index, got " + luceneDocs, luceneDocs <= 0L);
+
+        // The response must NOT have a server error.
+        assertTrue("response must contain 'indices' key", p.containsKey("indices"));
+        assertTrue("response must contain 'indices' key", l.containsKey("indices"));
+    }
+}

--- a/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/StatsLifecycleIT.java
+++ b/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/StatsLifecycleIT.java
@@ -96,7 +96,15 @@ public class StatsLifecycleIT extends BaseStatsIT {
             assertCounterAtLeast("stage 5 parquet merge_input_files", r5, "indices.lifecycle-idx.merge.merge_input_files_total", 2L);
             assertCounter("stage 5 parquet merge_failures", r5, "indices.lifecycle-idx.merge.merge_failures", 0L);
             Map<String, Object> l5 = luceneIndexStats("lifecycle-idx");
-            assertCounterAtLeast("stage 5 lucene merge_total", l5, "indices.lifecycle-idx.merge.merge_total", 1L);
+            // Note: lucene.merge.merge_total stays 0 in the composite-engine flow because the
+            // lucene secondary uses flush+addIndexes (not standalone IndexWriter.maybeMerge()).
+            // The force-merge work is recorded under flush.flush_force_merge_time_millis instead.
+            assertCounterAtLeast(
+                "stage 5 lucene flush_force_merge_time_millis",
+                l5,
+                "indices.lifecycle-idx.flush.flush_force_merge_time_millis",
+                1L
+            );
             assertCounter("stage 5 lucene merge_failures", l5, "indices.lifecycle-idx.merge.merge_failures", 0L);
         }, 30, java.util.concurrent.TimeUnit.SECONDS);
 

--- a/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/StatsManualValidationIT.java
+++ b/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/StatsManualValidationIT.java
@@ -148,6 +148,17 @@ public class StatsManualValidationIT extends BaseStatsIT {
             "parquet.merge.merge_output_rows_total == 260",
             getCounter(p5, "indices." + idx + ".merge.merge_output_rows_total") == 260L
         );
+        // — per-shard flush_and_sort_chunk and row_id_mapping_max
+        printAssertion(
+            "parquet.merge.flush_and_sort_chunk_total >= 1",
+            getCounter(p5, "indices." + idx + ".merge.flush_and_sort_chunk_total") >= 1L
+        );
+        printAssertion(
+            "parquet.merge.flush_and_sort_chunk_time_millis >= 0",
+            getCounter(p5, "indices." + idx + ".merge.flush_and_sort_chunk_time_millis") >= 0L
+        );
+        printAssertion("parquet.merge.row_id_mapping_max == 260", getCounter(p5, "indices." + idx + ".merge.row_id_mapping_max") == 260L);
+        printAssertion("lucene.commit.commit_failures == 0", getCounter(l5, "indices." + idx + ".commit.commit_failures") == 0L);
         printAssertion("parquet.merge.merge_failures == 0", getCounter(p5, "indices." + idx + ".merge.merge_failures") == 0L);
         // Note: lucene.merge.merge_total stays 0 in composite-engine flow because the
         // lucene secondary uses flush+addIndexes (not standalone IndexWriter.maybeMerge).
@@ -168,8 +179,8 @@ public class StatsManualValidationIT extends BaseStatsIT {
         Map<String, Object> firstNode = (Map<String, Object>) nodes.values().iterator().next();
         printAssertion("native_runtime block present at node level", firstNode.containsKey("native_runtime"));
         Map<String, Object> nativeRuntime = (Map<String, Object>) firstNode.get("native_runtime");
-        Map<String, Object> rayon = (Map<String, Object>) nativeRuntime.get("rayon");
-        Map<String, Object> tokio = (Map<String, Object>) nativeRuntime.get("tokio");
+        Map<String, Object> rayon = (Map<String, Object>) nativeRuntime.get("parquet_merge");
+        Map<String, Object> tokio = (Map<String, Object>) nativeRuntime.get("parquet_io");
         printAssertion("rayon.configured_threads > 0", ((Number) rayon.get("configured_threads")).longValue() > 0);
         printAssertion("rayon.merge_tasks_submitted >= 1", ((Number) rayon.get("merge_tasks_submitted")).longValue() >= 1);
         printAssertion("rayon.merge_tasks_completed >= 1", ((Number) rayon.get("merge_tasks_completed")).longValue() >= 1);

--- a/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/StatsManualValidationIT.java
+++ b/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/StatsManualValidationIT.java
@@ -8,6 +8,8 @@
 
 package org.opensearch.composite;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.opensearch.common.xcontent.json.JsonXContent;
 import org.opensearch.test.OpenSearchIntegTestCase.ClusterScope;
 import org.opensearch.test.OpenSearchIntegTestCase.Scope;
@@ -36,6 +38,8 @@ import java.util.concurrent.TimeUnit;
  */
 @ClusterScope(scope = Scope.SUITE, numDataNodes = 1)
 public class StatsManualValidationIT extends BaseStatsIT {
+
+    private static final Logger LOGGER = LogManager.getLogger(StatsManualValidationIT.class);
 
     @SuppressWarnings("unchecked")
     public void testFullManualValidation() throws Exception {
@@ -233,31 +237,32 @@ public class StatsManualValidationIT extends BaseStatsIT {
     }
 
     // ─────────────────────────────────────────────────────────────────────────────
-    // Output helpers — write to stdout via System.out so they're visible in test logs
+    // Output helpers — emit via Log4j so they appear in test logs
+    // (forbidden-apis disallows direct System.out usage).
     // ─────────────────────────────────────────────────────────────────────────────
 
     private static void printSection(String title) {
-        System.out.println();
-        System.out.println("════════════════════════════════════════════════════════════════════════");
-        System.out.println("  " + title);
-        System.out.println("════════════════════════════════════════════════════════════════════════");
+        LOGGER.info("");
+        LOGGER.info("════════════════════════════════════════════════════════════════════════");
+        LOGGER.info("  {}", title);
+        LOGGER.info("════════════════════════════════════════════════════════════════════════");
     }
 
     private static void printResponse(String label, Map<String, Object> body) {
-        System.out.println();
-        System.out.println("    >>> " + label);
+        LOGGER.info("");
+        LOGGER.info("    >>> {}", label);
         try {
             String json = JsonXContent.contentBuilder().map(body == null ? new LinkedHashMap<>() : body).toString();
             for (String line : json.split("\n")) {
-                System.out.println("    " + line);
+                LOGGER.info("    {}", line);
             }
         } catch (IOException e) {
-            System.out.println("    [error rendering body: " + e.getMessage() + "]");
+            LOGGER.info("    [error rendering body: {}]", e.getMessage());
         }
     }
 
     private static void printAssertion(String label, boolean ok) {
-        System.out.println("    " + (ok ? "✅" : "❌") + "  " + label);
+        LOGGER.info("    {}  {}", ok ? "✅" : "❌", label);
         if (!ok) {
             throw new AssertionError("assertion failed: " + label);
         }

--- a/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/StatsManualValidationIT.java
+++ b/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/StatsManualValidationIT.java
@@ -1,0 +1,254 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.composite;
+
+import org.opensearch.common.xcontent.json.JsonXContent;
+import org.opensearch.test.OpenSearchIntegTestCase.ClusterScope;
+import org.opensearch.test.OpenSearchIntegTestCase.Scope;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Manual-validation IT — drives the full stats API surface end-to-end and prints
+ * the actual JSON responses to stdout for human verification. Logs a structured
+ * report covering: all old per-shard/per-index/per-node counters, the new
+ * routing sub-object, rayon/tokio native runtime stats, and filter behavior.
+ *
+ * <p>Not part of the standard test suite; runs only when explicitly requested:
+ * <pre>
+ *   ./gradlew :sandbox:plugins:composite-engine:internalClusterTest \
+ *       --tests "org.opensearch.composite.StatsManualValidationIT" \
+ *       -Dtests.verbose=true --info
+ * </pre>
+ *
+ * Each println uses a stable header so the output is easy to grep through.
+ *
+ * @opensearch.experimental
+ */
+@ClusterScope(scope = Scope.SUITE, numDataNodes = 1)
+public class StatsManualValidationIT extends BaseStatsIT {
+
+    @SuppressWarnings("unchecked")
+    public void testFullManualValidation() throws Exception {
+        String idx = "manual-idx";
+        createCompositeIndex(idx, true);
+
+        // ─────────────────────────────────────────────────────────────────────────
+        // Stage 0 — empty index
+        // ─────────────────────────────────────────────────────────────────────────
+        printSection("STAGE 0: Empty index — all counters should be 0");
+        printResponse("GET /_plugins/parquet/" + idx + "/_stats", parquetIndexStats(idx));
+        printResponse("GET /_plugins/lucene/" + idx + "/_stats", luceneIndexStats(idx));
+
+        // ─────────────────────────────────────────────────────────────────────────
+        // Stage 1 — index 100 docs (no refresh)
+        // ─────────────────────────────────────────────────────────────────────────
+        printSection("STAGE 1: Indexed 100 docs (no refresh) — docs_indexed_total=100, refresh_total=0");
+        indexDocs(idx, 100, 0);
+        Map<String, Object> p1 = parquetIndexStats(idx);
+        Map<String, Object> l1 = luceneIndexStats(idx);
+        printResponse("parquet", p1);
+        printResponse("lucene", l1);
+        printAssertion(
+            "parquet.indexing.docs_indexed_total == 100",
+            getCounter(p1, "indices." + idx + ".indexing.docs_indexed_total") == 100L
+        );
+        printAssertion(
+            "lucene.indexing.docs_indexed_total == 100",
+            getCounter(l1, "indices." + idx + ".indexing.docs_indexed_total") == 100L
+        );
+        printAssertion("lucene.refresh.refresh_total == 0", getCounter(l1, "indices." + idx + ".refresh.refresh_total") == 0L);
+
+        // ─────────────────────────────────────────────────────────────────────────
+        // Stage 2 — refresh
+        // ─────────────────────────────────────────────────────────────────────────
+        printSection("STAGE 2: Refresh — refresh_total=1, native_finalize_total>=1");
+        refreshIndex(idx);
+        Map<String, Object> p2 = parquetIndexStats(idx);
+        Map<String, Object> l2 = luceneIndexStats(idx);
+        printResponse("parquet", p2);
+        printResponse("lucene", l2);
+        printAssertion(
+            "parquet.native_write.native_write_total >= 1",
+            getCounter(p2, "indices." + idx + ".native_write.native_write_total") >= 1L
+        );
+        printAssertion(
+            "parquet.native_write.native_finalize_total >= 1",
+            getCounter(p2, "indices." + idx + ".native_write.native_finalize_total") >= 1L
+        );
+        printAssertion("lucene.refresh.refresh_total >= 1", getCounter(l2, "indices." + idx + ".refresh.refresh_total") >= 1L);
+
+        // ─────────────────────────────────────────────────────────────────────────
+        // Stage 3 — flush
+        // ─────────────────────────────────────────────────────────────────────────
+        printSection("STAGE 3: Flush — flush_total>=1, commit_total>=1");
+        flushIndex(idx);
+        Map<String, Object> l3 = luceneIndexStats(idx);
+        printResponse("lucene", l3);
+        printAssertion("lucene.flush.flush_total >= 1", getCounter(l3, "indices." + idx + ".flush.flush_total") >= 1L);
+        printAssertion("lucene.commit.commit_total >= 1", getCounter(l3, "indices." + idx + ".commit.commit_total") >= 1L);
+
+        // ─────────────────────────────────────────────────────────────────────────
+        // Stage 4 — index more in 4 batches with refreshes (5 segments total)
+        // ─────────────────────────────────────────────────────────────────────────
+        printSection("STAGE 4: 4 more batches × 40 docs = 160 more (total=260)");
+        for (int batch = 0; batch < 4; batch++) {
+            indexDocs(idx, 40, 100 + batch * 40);
+            refreshIndex(idx);
+        }
+        Map<String, Object> p4 = parquetIndexStats(idx);
+        Map<String, Object> l4 = luceneIndexStats(idx);
+        printResponse("parquet", p4);
+        printResponse("lucene", l4);
+        printAssertion(
+            "parquet.indexing.docs_indexed_total == 260",
+            getCounter(p4, "indices." + idx + ".indexing.docs_indexed_total") == 260L
+        );
+        printAssertion(
+            "lucene.indexing.docs_indexed_total == 260",
+            getCounter(l4, "indices." + idx + ".indexing.docs_indexed_total") == 260L
+        );
+        printAssertion(
+            "cross-format consistency: parquet == lucene",
+            getCounter(p4, "indices." + idx + ".indexing.docs_indexed_total") == getCounter(
+                l4,
+                "indices." + idx + ".indexing.docs_indexed_total"
+            )
+        );
+
+        // ─────────────────────────────────────────────────────────────────────────
+        // Stage 5 — force_merge to 1 (triggers rayon/tokio paths)
+        // ─────────────────────────────────────────────────────────────────────────
+        printSection("STAGE 5: force_merge to 1 segment — rayon/tokio counters should engage");
+        forceMerge(idx, 1);
+        // Parquet merge is async; wait for counters to populate
+        assertBusy(() -> {
+            Map<String, Object> r = parquetIndexStats(idx);
+            assertCounterAtLeast("parquet.merge.merge_total >= 1", r, "indices." + idx + ".merge.merge_total", 1L);
+        }, 30, TimeUnit.SECONDS);
+        Map<String, Object> p5 = parquetIndexStats(idx);
+        Map<String, Object> l5 = luceneIndexStats(idx);
+        printResponse("parquet (post-merge)", p5);
+        printResponse("lucene (post-merge)", l5);
+        printAssertion("parquet.merge.merge_total >= 1", getCounter(p5, "indices." + idx + ".merge.merge_total") >= 1L);
+        printAssertion(
+            "parquet.merge.merge_input_files_total > 1",
+            getCounter(p5, "indices." + idx + ".merge.merge_input_files_total") > 1L
+        );
+        printAssertion(
+            "parquet.merge.merge_output_rows_total == 260",
+            getCounter(p5, "indices." + idx + ".merge.merge_output_rows_total") == 260L
+        );
+        printAssertion("parquet.merge.merge_failures == 0", getCounter(p5, "indices." + idx + ".merge.merge_failures") == 0L);
+        // Note: lucene.merge.merge_total stays 0 in composite-engine flow because the
+        // lucene secondary uses flush+addIndexes (not standalone IndexWriter.maybeMerge).
+        // The lucene-side force-merge work is captured in flush.flush_force_merge_time_millis.
+        printAssertion(
+            "lucene.flush.flush_force_merge_time_millis > 0 (force-merge ran via flush path)",
+            getCounter(l5, "indices." + idx + ".flush.flush_force_merge_time_millis") > 0L
+        );
+        printAssertion("lucene.merge.merge_failures == 0", getCounter(l5, "indices." + idx + ".merge.merge_failures") == 0L);
+
+        // ─────────────────────────────────────────────────────────────────────────
+        // Stage 6 — node-stats: native_runtime block must appear
+        // ─────────────────────────────────────────────────────────────────────────
+        printSection("STAGE 6: /_nodes/_stats — native_runtime (rayon + tokio) must populate");
+        Map<String, Object> nodeStats = parquetNodeStats("");
+        printResponse("GET /_plugins/parquet/_nodes/_stats", nodeStats);
+        Map<String, Object> nodes = (Map<String, Object>) nodeStats.get("nodes");
+        Map<String, Object> firstNode = (Map<String, Object>) nodes.values().iterator().next();
+        printAssertion("native_runtime block present at node level", firstNode.containsKey("native_runtime"));
+        Map<String, Object> nativeRuntime = (Map<String, Object>) firstNode.get("native_runtime");
+        Map<String, Object> rayon = (Map<String, Object>) nativeRuntime.get("rayon");
+        Map<String, Object> tokio = (Map<String, Object>) nativeRuntime.get("tokio");
+        printAssertion("rayon.configured_threads > 0", ((Number) rayon.get("configured_threads")).longValue() > 0);
+        printAssertion("rayon.merge_tasks_submitted >= 1", ((Number) rayon.get("merge_tasks_submitted")).longValue() >= 1);
+        printAssertion("rayon.merge_tasks_completed >= 1", ((Number) rayon.get("merge_tasks_completed")).longValue() >= 1);
+        printAssertion("rayon.merge_tasks_panicked == 0", ((Number) rayon.get("merge_tasks_panicked")).longValue() == 0);
+        printAssertion("tokio.num_workers > 0", ((Number) tokio.get("num_workers")).longValue() > 0);
+        printAssertion("tokio.spawned_tasks_total > 0", ((Number) tokio.get("spawned_tasks_total")).longValue() > 0);
+
+        // ─────────────────────────────────────────────────────────────────────────
+        // Stage 7 — index-level response must NOT have native_runtime
+        // ─────────────────────────────────────────────────────────────────────────
+        printSection("STAGE 7: Index-level /{idx}/_stats must NOT contain native_runtime");
+        Map<String, Object> indices = (Map<String, Object>) p5.get("indices");
+        Map<String, Object> indexBlock = (Map<String, Object>) indices.get(idx);
+        printAssertion("index-level response does NOT have native_runtime", !indexBlock.containsKey("native_runtime"));
+
+        // ─────────────────────────────────────────────────────────────────────────
+        // Stage 8 — shard-level routing sub-object
+        // ─────────────────────────────────────────────────────────────────────────
+        printSection("STAGE 8: ?level=shards — verify routing sub-object");
+        Map<String, Object> shardLevel = parquetIndexStats(idx, "level", "shards");
+        printResponse("parquet ?level=shards", shardLevel);
+        Map<String, Object> shards = (Map<String, Object>) ((Map<String, Object>) ((Map<String, Object>) shardLevel.get("indices")).get(
+            idx
+        )).get("shards");
+        Map<String, Object> shard0 = (Map<String, Object>) ((java.util.List<?>) shards.get("0")).get(0);
+        Map<String, Object> routing = (Map<String, Object>) shard0.get("routing");
+        printAssertion("shards.0[0] has routing sub-object", routing != null);
+        printAssertion("routing.primary == true", Boolean.TRUE.equals(routing.get("primary")));
+        printAssertion("routing.node is non-null", routing.get("node") != null);
+        printAssertion("routing.state is non-null", routing.get("state") != null);
+
+        // ─────────────────────────────────────────────────────────────────────────
+        // Stage 9 — filter params
+        // ─────────────────────────────────────────────────────────────────────────
+        printSection("STAGE 9: ?ignore_unavailable=true with mixed missing/available indices");
+        try {
+            Map<String, Object> ignoreResp = parquetIndexStats(idx + ",no-such-idx", "ignore_unavailable", "true");
+            Map<String, Object> ignoreIdx = (Map<String, Object>) ignoreResp.get("indices");
+            printAssertion("ignore_unavailable=true returns 200 with available index", ignoreIdx.containsKey(idx));
+            printAssertion("ignore_unavailable=true does NOT include missing index", !ignoreIdx.containsKey("no-such-idx"));
+        } catch (Exception e) {
+            printAssertion("ignore_unavailable=true did NOT throw", false);
+            logger.error("ignore_unavailable threw", e);
+        }
+
+        // ─────────────────────────────────────────────────────────────────────────
+        // Stage 10 — final summary
+        // ─────────────────────────────────────────────────────────────────────────
+        printSection("MANUAL VALIDATION COMPLETE — all assertions verified");
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // Output helpers — write to stdout via System.out so they're visible in test logs
+    // ─────────────────────────────────────────────────────────────────────────────
+
+    private static void printSection(String title) {
+        System.out.println();
+        System.out.println("════════════════════════════════════════════════════════════════════════");
+        System.out.println("  " + title);
+        System.out.println("════════════════════════════════════════════════════════════════════════");
+    }
+
+    private static void printResponse(String label, Map<String, Object> body) {
+        System.out.println();
+        System.out.println("    >>> " + label);
+        try {
+            String json = JsonXContent.contentBuilder().map(body == null ? new LinkedHashMap<>() : body).toString();
+            for (String line : json.split("\n")) {
+                System.out.println("    " + line);
+            }
+        } catch (IOException e) {
+            System.out.println("    [error rendering body: " + e.getMessage() + "]");
+        }
+    }
+
+    private static void printAssertion(String label, boolean ok) {
+        System.out.println("    " + (ok ? "✅" : "❌") + "  " + label);
+        if (!ok) {
+            throw new AssertionError("assertion failed: " + label);
+        }
+    }
+}

--- a/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/StatsNativeRuntimeIT.java
+++ b/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/StatsNativeRuntimeIT.java
@@ -49,10 +49,10 @@ public class StatsNativeRuntimeIT extends BaseStatsIT {
             assertTrue("node entry must contain native_runtime block", nodeStats.containsKey("native_runtime"));
 
             Map<String, Object> nativeRuntime = (Map<String, Object>) nodeStats.get("native_runtime");
-            assertTrue("native_runtime must contain rayon block", nativeRuntime.containsKey("rayon"));
-            assertTrue("native_runtime must contain tokio block", nativeRuntime.containsKey("tokio"));
+            assertTrue("native_runtime must contain parquet_merge block", nativeRuntime.containsKey("parquet_merge"));
+            assertTrue("native_runtime must contain parquet_io block", nativeRuntime.containsKey("parquet_io"));
 
-            Map<String, Object> rayon = (Map<String, Object>) nativeRuntime.get("rayon");
+            Map<String, Object> rayon = (Map<String, Object>) nativeRuntime.get("parquet_merge");
             assertTrue("rayon configured_threads must be > 0 after merge", ((Number) rayon.get("configured_threads")).longValue() > 0);
             assertTrue(
                 "rayon merge_tasks_submitted must be >= 1 after force_merge",
@@ -67,12 +67,29 @@ public class StatsNativeRuntimeIT extends BaseStatsIT {
                 0L,
                 ((Number) rayon.get("merge_tasks_panicked")).longValue()
             );
+            // — new rayon counters + derived fields
+            assertTrue("rayon merge_tasks_started must be >= 1", ((Number) rayon.get("merge_tasks_started")).longValue() >= 1);
+            assertEquals("rayon merge_tasks_failed must be 0 in happy path", 0L, ((Number) rayon.get("merge_tasks_failed")).longValue());
+            assertNotNull("rayon merge_tasks_queue_depth derived field present", rayon.get("merge_tasks_queue_depth"));
+            assertNotNull("rayon merge_tasks_in_flight derived field present", rayon.get("merge_tasks_in_flight"));
+            assertTrue("rayon merge_tasks_queue_depth must be >= 0", ((Number) rayon.get("merge_tasks_queue_depth")).longValue() >= 0);
+            assertEquals(
+                "rayon merge_tasks_in_flight must be 0 after merges complete",
+                0L,
+                ((Number) rayon.get("merge_tasks_in_flight")).longValue()
+            );
 
-            Map<String, Object> tokio = (Map<String, Object>) nativeRuntime.get("tokio");
+            Map<String, Object> tokio = (Map<String, Object>) nativeRuntime.get("parquet_io");
             assertTrue(
                 "tokio num_workers must be > 0 after IO runtime is initialized",
                 ((Number) tokio.get("num_workers")).longValue() > 0
             );
+            // — new tokio fields
+            assertNotNull("tokio blocking_queue_depth field present", tokio.get("blocking_queue_depth"));
+            assertNotNull("tokio local_queue_depth_total field present", tokio.get("local_queue_depth_total"));
+            assertNotNull("tokio polls_count_total field present", tokio.get("polls_count_total"));
+            assertNotNull("tokio overflow_count_total field present", tokio.get("overflow_count_total"));
+            assertTrue("tokio polls_count_total must be > 0 after merge IO", ((Number) tokio.get("polls_count_total")).longValue() > 0);
         }, 30, TimeUnit.SECONDS);
     }
 

--- a/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/StatsNativeRuntimeIT.java
+++ b/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/StatsNativeRuntimeIT.java
@@ -1,0 +1,127 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.composite;
+
+import org.opensearch.test.OpenSearchIntegTestCase.ClusterScope;
+import org.opensearch.test.OpenSearchIntegTestCase.Scope;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Integration tests for the parquet native_runtime stats block at the node-level endpoint.
+ * Verifies that rayon + tokio runtime metrics are collected and surfaced after a merge
+ * operation runs, but never appear at shard level or in cluster-aggregate /{idx}/_stats.
+ *
+ * @opensearch.experimental
+ */
+@ClusterScope(scope = Scope.SUITE, numDataNodes = 1)
+public class StatsNativeRuntimeIT extends BaseStatsIT {
+
+    /**
+     * After a force_merge runs, the parquet node-stats endpoint must include a
+     * non-empty native_runtime block with rayon + tokio metrics.
+     */
+    @SuppressWarnings("unchecked")
+    public void testNativeRuntimeStatsAppearAtNodeLevel() throws Exception {
+        String idx = "native-runtime-idx";
+        createCompositeIndex(idx, true);
+
+        for (int batch = 0; batch < 5; batch++) {
+            indexDocs(idx, 40, batch * 40);
+            refreshIndex(idx);
+        }
+        forceMerge(idx, 1);
+
+        assertBusy(() -> {
+            Map<String, Object> resp = parquetNodeStats("");
+            assertTrue("response must have nodes block", resp.containsKey("nodes"));
+            Map<String, Object> nodes = (Map<String, Object>) resp.get("nodes");
+            assertFalse("nodes block must not be empty", nodes.isEmpty());
+
+            Map<String, Object> nodeStats = (Map<String, Object>) nodes.values().iterator().next();
+            assertTrue("node entry must contain native_runtime block", nodeStats.containsKey("native_runtime"));
+
+            Map<String, Object> nativeRuntime = (Map<String, Object>) nodeStats.get("native_runtime");
+            assertTrue("native_runtime must contain rayon block", nativeRuntime.containsKey("rayon"));
+            assertTrue("native_runtime must contain tokio block", nativeRuntime.containsKey("tokio"));
+
+            Map<String, Object> rayon = (Map<String, Object>) nativeRuntime.get("rayon");
+            assertTrue("rayon configured_threads must be > 0 after merge", ((Number) rayon.get("configured_threads")).longValue() > 0);
+            assertTrue(
+                "rayon merge_tasks_submitted must be >= 1 after force_merge",
+                ((Number) rayon.get("merge_tasks_submitted")).longValue() >= 1
+            );
+            assertTrue(
+                "rayon merge_tasks_completed must be >= 1 after successful merge",
+                ((Number) rayon.get("merge_tasks_completed")).longValue() >= 1
+            );
+            assertEquals(
+                "rayon merge_tasks_panicked must be 0 in happy path",
+                0L,
+                ((Number) rayon.get("merge_tasks_panicked")).longValue()
+            );
+
+            Map<String, Object> tokio = (Map<String, Object>) nativeRuntime.get("tokio");
+            assertTrue(
+                "tokio num_workers must be > 0 after IO runtime is initialized",
+                ((Number) tokio.get("num_workers")).longValue() > 0
+            );
+        }, 30, TimeUnit.SECONDS);
+    }
+
+    /**
+     * The native_runtime block must NOT appear in the cluster-aggregate /{idx}/_stats response.
+     */
+    @SuppressWarnings("unchecked")
+    public void testNativeRuntimeAbsentAtIndexLevel() throws Exception {
+        String idx = "native-runtime-absent-idx";
+        createCompositeIndex(idx, true);
+        for (int batch = 0; batch < 3; batch++) {
+            indexDocs(idx, 30, batch * 30);
+            refreshIndex(idx);
+        }
+        forceMerge(idx, 1);
+
+        assertBusy(() -> {
+            Map<String, Object> idxResp = parquetIndexStats(idx);
+            Map<String, Object> indices = (Map<String, Object>) idxResp.get("indices");
+            Map<String, Object> indexBlock = (Map<String, Object>) indices.get(idx);
+            assertFalse("index-level response must NOT have native_runtime block", indexBlock.containsKey("native_runtime"));
+        }, 10, TimeUnit.SECONDS);
+    }
+
+    /**
+     * The native_runtime block must NOT appear in shard-level entries either.
+     */
+    @SuppressWarnings("unchecked")
+    public void testNativeRuntimeAbsentAtShardLevel() throws Exception {
+        String idx = "native-runtime-shard-idx";
+        createCompositeIndex(idx, true);
+        for (int batch = 0; batch < 3; batch++) {
+            indexDocs(idx, 30, batch * 30);
+            refreshIndex(idx);
+        }
+        forceMerge(idx, 1);
+
+        assertBusy(() -> {
+            Map<String, Object> shardResp = parquetIndexStats(idx, "level", "shards");
+            Map<String, Object> indices = (Map<String, Object>) shardResp.get("indices");
+            Map<String, Object> indexBlock = (Map<String, Object>) indices.get(idx);
+            assertTrue("index block must contain shards", indexBlock.containsKey("shards"));
+            Map<String, Object> shards = (Map<String, Object>) indexBlock.get("shards");
+            for (Map.Entry<String, Object> e : shards.entrySet()) {
+                java.util.List<Map<String, Object>> copies = (java.util.List<Map<String, Object>>) e.getValue();
+                for (Map<String, Object> copy : copies) {
+                    assertFalse("shard-level entry must NOT have native_runtime block", copy.containsKey("native_runtime"));
+                }
+            }
+        }, 10, TimeUnit.SECONDS);
+    }
+}

--- a/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/StatsReplicaIT.java
+++ b/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/StatsReplicaIT.java
@@ -1,0 +1,93 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.composite;
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+
+import org.opensearch.common.network.NetworkModule;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.concurrent.OpenSearchExecutors;
+import org.opensearch.plugins.Plugin;
+import org.opensearch.test.OpenSearchIntegTestCase;
+import org.opensearch.transport.Netty4ModulePlugin;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Integration test for stats API behavior with replica shards. Uses the DFA replication
+ * pattern (remote store + segment replication) since DFA does not support plain peer
+ * recovery to non-remote-store replicas.
+ *
+ * @opensearch.experimental
+ */
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
+@ThreadLeakFilters(filters = AbstractCompositeEngineIT.ParquetNativeThreadFilter.class)
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 0)
+public class StatsReplicaIT extends DataFormatAwareReplicationBaseIT {
+
+    @Override
+    protected boolean addMockHttpTransport() {
+        return false;
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        // Add Netty4ModulePlugin to the parent's list so getRestClient() works for /_plugins/* endpoints.
+        return Stream.concat(super.nodePlugins().stream(), Stream.of(Netty4ModulePlugin.class)).collect(Collectors.toList());
+    }
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return Settings.builder()
+            .put(super.nodeSettings(nodeOrdinal))
+            .put(NetworkModule.HTTP_TYPE_KEY, Netty4ModulePlugin.NETTY_HTTP_TRANSPORT_NAME)
+            // Pin processors to a fixed value (matches AbstractCompositeEngineIT). Required to
+            // avoid Netty NettyRuntime.availableProcessors static collision across nodes in a
+            // multi-node IT cluster running in a single JVM.
+            .put(OpenSearchExecutors.NODE_PROCESSORS_SETTING.getKey(), 1)
+            .build();
+    }
+
+    /**
+     * Verifies that replica shards are excluded from stats aggregation — only primary
+     * shard stats are counted. Uses createDfaIndex(1) which gives 1 primary + 1 replica
+     * via remote-store-backed segment replication.
+     *
+     * <p>The index name is {@link DataFormatAwareReplicationBaseIT#INDEX_NAME} = "dfa-replication-base-idx".
+     */
+    public void testReplicasExcludedFromAggregation() throws Exception {
+        // Sets up cluster manager + 2 data nodes + 1 shard with 1 replica via remote store.
+        createDfaIndex(1);
+
+        // Index 100 docs (refresh policy NONE — inherited from base class indexDocs())
+        indexDocs(100);
+
+        // Refresh so the docs land in a refreshable segment and primary's tracker counts them
+        client().admin().indices().prepareRefresh(INDEX_NAME).get();
+
+        // Hit the parquet stats endpoint via REST
+        Map<String, Object> r = StatsITHelpers.parquetIndexStats(getRestClient(), INDEX_NAME);
+
+        // Replica copy exists but only the primary's tracker contributes to the count.
+        StatsITHelpers.assertCounter(
+            "primary-only count for index with 1 replica must equal 100 (NOT 200 — replicas excluded)",
+            r,
+            "indices." + INDEX_NAME + ".indexing.docs_indexed_total",
+            100L
+        );
+        // _shards header reports primaries only — 1 shard, 1 successful, 0 failed.
+        StatsITHelpers.assertCounter("_shards.total counts primaries only", r, "_shards.total", 1L);
+        StatsITHelpers.assertCounter("_shards.successful", r, "_shards.successful", 1L);
+        StatsITHelpers.assertCounter("_shards.failed", r, "_shards.failed", 0L);
+    }
+}

--- a/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/StatsTopologyIT.java
+++ b/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/StatsTopologyIT.java
@@ -1,0 +1,496 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.composite;
+
+import org.opensearch.client.Request;
+import org.opensearch.client.ResponseException;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.test.OpenSearchIntegTestCase.ClusterScope;
+import org.opensearch.test.OpenSearchIntegTestCase.Scope;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Integration tests for stats API behavior across different cluster topologies.
+ * Each test starts its own cluster nodes since Scope.TEST destroys between tests.
+ *
+ * @opensearch.experimental
+ */
+@ClusterScope(scope = Scope.TEST, numDataNodes = 0)
+public class StatsTopologyIT extends BaseStatsIT {
+
+    protected void createIndexWithShards(String name, int numShards, int numReplicas, boolean withLuceneSecondary) {
+        Settings.Builder s = Settings.builder()
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, numShards)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, numReplicas)
+            .put("index.pluggable.dataformat.enabled", true)
+            .put("index.pluggable.dataformat", "composite")
+            .put("index.composite.primary_data_format", "parquet");
+        if (withLuceneSecondary) {
+            s.putList("index.composite.secondary_data_formats", "lucene");
+        } else {
+            s.putList("index.composite.secondary_data_formats");
+        }
+        client().admin().indices().prepareCreate(name).setSettings(s).setMapping("name", "type=keyword", "value", "type=integer").get();
+        ensureGreen(name);
+    }
+
+    /**
+     * Verifies that index-level doc total equals the sum of per-shard doc totals
+     * when queried with level=shards.
+     */
+    @SuppressWarnings("unchecked")
+    public void testIndexLevelEqualsShardSum() throws Exception {
+        internalCluster().startNodes(1);
+        createIndexWithShards("shard-sum-idx", 3, 0, true);
+        indexDocs("shard-sum-idx", 300, 0);
+        refreshIndex("shard-sum-idx");
+
+        // Query default level
+        Map<String, Object> r = parquetIndexStats("shard-sum-idx");
+        assertCounter("index-level total", r, "indices.shard-sum-idx.indexing.docs_indexed_total", 300L);
+
+        // Query level=shards
+        Map<String, Object> rs = parquetIndexStats("shard-sum-idx", "level", "shards");
+        assertTrue("shards block must exist for level=shards", hasPath(rs, "indices.shard-sum-idx.shards"));
+
+        long sum = computeShardSum(rs, "shard-sum-idx", "indexing.docs_indexed_total");
+        assertEquals("shard sum must equal index total", 300L, sum);
+    }
+
+    /**
+     * Verifies that stats aggregate correctly across a 3-node cluster with 6 shards.
+     * Cluster-aggregate via /{idx}/_stats is the authoritative aggregation path.
+     *
+     * <p>Note: per-node breakdown via /_nodes/_stats is NOT asserted with a sum here because
+     * {@code internalCluster()} runs all "nodes" in a single JVM, where the
+     * {@code DataFormatStatsProviderRegistry} is JVM-wide. Each node's local registry sees
+     * trackers from every node, so summing per-node values triple-counts. In production
+     * each node has its own JVM, so per-node values are correctly partitioned by shard ownership.
+     */
+    @SuppressWarnings("unchecked")
+    public void testMultiNodeClusterAggregation() throws Exception {
+        internalCluster().startNodes(3);
+        createIndexWithShards("cluster-agg-idx", 6, 0, true);
+        indexDocs("cluster-agg-idx", 600, 0);
+        refreshIndex("cluster-agg-idx");
+
+        Map<String, Object> r = parquetIndexStats("cluster-agg-idx");
+        assertCounter("cluster-aggregate doc total", r, "indices.cluster-agg-idx.indexing.docs_indexed_total", 600L);
+        // Verify _shards header
+        assertCounter("_shards.total", r, "_shards.total", 6L);
+        assertCounter("_shards.successful", r, "_shards.successful", 6L);
+        assertCounter("_shards.failed", r, "_shards.failed", 0L);
+
+        // Per-node endpoint: assert response structure (3 nodes present, each has indexing block).
+        // Do NOT sum per-node — see javadoc above for why.
+        Map<String, Object> nr = parquetNodeStats("");
+        assertTrue("nodes key present", nr.containsKey("nodes"));
+        Map<String, Object> nodes = (Map<String, Object>) nr.get("nodes");
+        assertEquals("expected 3 node entries", 3, nodes.size());
+        for (Map.Entry<String, Object> e : nodes.entrySet()) {
+            Map<String, Object> nodeStats = (Map<String, Object>) e.getValue();
+            assertTrue("node entry must have indexing block", hasPath(nodeStats, "indexing.docs_indexed_total"));
+        }
+    }
+
+    /**
+     * Verifies that node-stats endpoint with a specific nodeId returns only that node.
+     */
+    @SuppressWarnings("unchecked")
+    public void testNodeStatsSpecificNodeFilter() throws Exception {
+        internalCluster().startNodes(3);
+        createIndexWithShards("node-filter-idx", 3, 0, true);
+        indexDocs("node-filter-idx", 90, 0);
+        refreshIndex("node-filter-idx");
+
+        // Get one node's id
+        Map<String, Object> all = parquetNodeStats("");
+        Map<String, Object> nodes = (Map<String, Object>) all.get("nodes");
+        String firstNodeId = nodes.keySet().iterator().next();
+
+        // Query for just that node
+        Map<String, Object> single = parquetNodeStats(firstNodeId);
+        Map<String, Object> singleNodes = (Map<String, Object>) single.get("nodes");
+        assertEquals("node-id-filter response must have exactly 1 node", 1, singleNodes.size());
+        assertTrue("response must contain the requested node", singleNodes.containsKey(firstNodeId));
+    }
+
+    /**
+     * Verifies that stats survive a data node restart and continue accumulating correctly.
+     * In the single-JVM test framework, the JVM-wide {@code DataFormatStatsProviderRegistry}
+     * retains trackers across node restarts, so counters persist. This test verifies the
+     * stats endpoint remains functional after restart and new indexing is tracked.
+     */
+    @SuppressWarnings("unchecked")
+    public void testStatsAccumulateAfterNodeRestart() throws Exception {
+        // Start a dedicated cluster manager (keeps REST client alive) + 1 data node.
+        internalCluster().startClusterManagerOnlyNode();
+        String dataNode = internalCluster().startDataOnlyNode();
+        String idx = "restart-idx";
+        createIndexWithShards(idx, 1, 0, true);
+        indexDocs(idx, 50, 0);
+        refreshIndex(idx);
+
+        // Pre-restart: counters reflect the 50 docs.
+        long preRestartDocs = getCounter(parquetIndexStats(idx), "indices." + idx + ".indexing.docs_indexed_total");
+        assertEquals("pre-restart parquet docs", 50L, preRestartDocs);
+
+        // Restart the data node.
+        internalCluster().restartNode(dataNode);
+        ensureGreen(idx);
+
+        // Post-restart: stats endpoint must still be functional.
+        Map<String, Object> postRestart = parquetIndexStats(idx);
+        assertTrue("response must have indices key after restart", postRestart.containsKey("indices"));
+
+        // Index more docs — counters must accumulate from wherever they were.
+        long postRestartBefore = getCounter(parquetIndexStats(idx), "indices." + idx + ".indexing.docs_indexed_total");
+        indexDocs(idx, 30, 50);
+        refreshIndex(idx);
+        long postRestartAfter = getCounter(parquetIndexStats(idx), "indices." + idx + ".indexing.docs_indexed_total");
+        assertEquals("new docs must be tracked after restart", postRestartBefore + 30L, postRestartAfter);
+
+        // Lucene secondary must also track the new docs.
+        long luceneAfter = getCounter(luceneIndexStats(idx), "indices." + idx + ".indexing.docs_indexed_total");
+        assertEquals("lucene must match parquet after restart", postRestartAfter, luceneAfter);
+    }
+
+    // testReplicasExcludedFromAggregation: deferred. DFA replicas in current upstream require
+    // a remote-store-backed cluster (RemoteStoreBaseIntegTestCase). Plain peer recovery to a
+    // non-remote replica fails with TranslogCorruptedException at recovery time. To test
+    // primary-only aggregation we'd need to extend RemoteStoreBaseIntegTestCase and configure
+    // segment replication via remote store. This is moved to Wave 3 / a follow-up PR.
+
+    /**
+     * Verifies that the {@code shards=} param accepts a comma-separated list and filters
+     * shard-level results to exactly those shard IDs.
+     */
+    @SuppressWarnings("unchecked")
+    public void testMultiValueShardFilter() throws Exception {
+        internalCluster().startNodes(2);
+        createIndexWithShards("multi-shard-filter-idx", 4, 0, true);
+        indexDocs("multi-shard-filter-idx", 80, 0);
+        refreshIndex("multi-shard-filter-idx");
+
+        // shards=0,2 — exactly 2 entries.
+        Map<String, Object> r2 = parquetIndexStats("multi-shard-filter-idx", "level", "shards", "shards", "0,2");
+        Map<String, Object> shards2 = (Map<String, Object>) ((Map<String, Object>) ((Map<String, Object>) r2.get("indices")).get(
+            "multi-shard-filter-idx"
+        )).get("shards");
+        assertEquals("shards=0,2 must return exactly 2 entries", 2, shards2.size());
+        assertTrue("must include shard 0", shards2.containsKey("0"));
+        assertTrue("must include shard 2", shards2.containsKey("2"));
+        assertFalse("must NOT include shard 1", shards2.containsKey("1"));
+        assertFalse("must NOT include shard 3", shards2.containsKey("3"));
+
+        // shards=0,1,3 — exactly 3 entries.
+        Map<String, Object> r3 = parquetIndexStats("multi-shard-filter-idx", "level", "shards", "shards", "0,1,3");
+        Map<String, Object> shards3 = (Map<String, Object>) ((Map<String, Object>) ((Map<String, Object>) r3.get("indices")).get(
+            "multi-shard-filter-idx"
+        )).get("shards");
+        assertEquals("shards=0,1,3 must return exactly 3 entries", 3, shards3.size());
+        assertTrue(shards3.containsKey("0"));
+        assertTrue(shards3.containsKey("1"));
+        assertTrue(shards3.containsKey("3"));
+        assertFalse("must NOT include shard 2", shards3.containsKey("2"));
+    }
+
+    /**
+     * Verifies that the {@code nodes=} param accepts a comma-separated list and that the
+     * special token {@code _local} resolves to the coordinating node.
+     */
+    @SuppressWarnings("unchecked")
+    public void testMultiValueNodeFilter() throws Exception {
+        internalCluster().startNodes(2);
+        createIndexWithShards("multi-node-filter-idx", 4, 0, true);
+        indexDocs("multi-node-filter-idx", 40, 0);
+        refreshIndex("multi-node-filter-idx");
+
+        // Get both node IDs.
+        var nodeInfos = client().admin().cluster().prepareNodesInfo().get().getNodes();
+        String nodeA = nodeInfos.get(0).getNode().getId();
+        String nodeB = nodeInfos.get(1).getNode().getId();
+
+        // nodes=A,B — should return ALL 4 shards (across both nodes).
+        Map<String, Object> rBoth = parquetIndexStats("multi-node-filter-idx", "level", "shards", "nodes", nodeA + "," + nodeB);
+        Map<String, Object> shardsBoth = (Map<String, Object>) ((Map<String, Object>) ((Map<String, Object>) rBoth.get("indices")).get(
+            "multi-node-filter-idx"
+        )).get("shards");
+        assertEquals("nodes=A,B (all nodes) must return all 4 shards", 4, shardsBoth.size());
+
+        // nodes=A — only shards on node A. Each shard's routing.node must match nodeA.
+        Map<String, Object> rA = parquetIndexStats("multi-node-filter-idx", "level", "shards", "nodes", nodeA);
+        Map<String, Object> shardsA = (Map<String, Object>) ((Map<String, Object>) ((Map<String, Object>) rA.get("indices")).get(
+            "multi-node-filter-idx"
+        )).get("shards");
+        assertTrue("nodes=A must return at least 1 shard", shardsA.size() >= 1);
+        for (Map.Entry<String, Object> e : shardsA.entrySet()) {
+            List<Map<String, Object>> copies = (List<Map<String, Object>>) e.getValue();
+            for (Map<String, Object> copy : copies) {
+                Map<String, Object> routing = (Map<String, Object>) copy.get("routing");
+                assertEquals("every entry must be on node A", nodeA, routing.get("node"));
+            }
+        }
+
+        // nodes=_local must succeed and return shards on the coordinating node.
+        Map<String, Object> rLocal = parquetIndexStats("multi-node-filter-idx", "level", "shards", "nodes", "_local");
+        Map<String, Object> shardsLocal = (Map<String, Object>) ((Map<String, Object>) ((Map<String, Object>) rLocal.get("indices")).get(
+            "multi-node-filter-idx"
+        )).get("shards");
+        assertTrue("_local must return at least 1 shard", shardsLocal.size() >= 1);
+    }
+
+    /**
+     * Verifies that the {@code expand_wildcards} param controls wildcard expansion semantics.
+     * Default {@code open} excludes closed indices; {@code all} with {@code ignore_unavailable=true}
+     * includes both open and closed indices in the resolution (though closed indices may have empty stats).
+     */
+    @SuppressWarnings("unchecked")
+    public void testExpandWildcardsHonored() throws Exception {
+        internalCluster().startNodes(1);
+        createIndexWithShards("wildcard-open-idx", 1, 0, true);
+        createIndexWithShards("wildcard-closed-idx", 1, 0, true);
+        indexDocs("wildcard-open-idx", 10, 0);
+        indexDocs("wildcard-closed-idx", 20, 0);
+        refreshIndex("wildcard-open-idx");
+        refreshIndex("wildcard-closed-idx");
+
+        // Close one of the indices.
+        client().admin().indices().prepareClose("wildcard-closed-idx").get();
+
+        // Default (no expand_wildcards) — wildcard matches only the open index.
+        Map<String, Object> rDefault = parquetIndexStats("wildcard-*");
+        Map<String, Object> indicesDefault = (Map<String, Object>) rDefault.get("indices");
+        assertTrue("default expand must include open index", indicesDefault.containsKey("wildcard-open-idx"));
+        assertFalse("default expand must NOT include closed index", indicesDefault.containsKey("wildcard-closed-idx"));
+
+        // expand_wildcards=open — same as default.
+        Map<String, Object> rOpen = parquetIndexStats("wildcard-*", "expand_wildcards", "open");
+        Map<String, Object> indicesOpen = (Map<String, Object>) rOpen.get("indices");
+        assertTrue(indicesOpen.containsKey("wildcard-open-idx"));
+        assertFalse(indicesOpen.containsKey("wildcard-closed-idx"));
+
+        // expand_wildcards=all with ignore_unavailable=true — the open index must still appear.
+        // The closed index may or may not appear depending on whether the broadcast action can
+        // iterate closed shards. We verify the open index is present and that the response
+        // includes MORE indices than expand_wildcards=open (or at minimum the same set).
+        Map<String, Object> rAll = parquetIndexStats("wildcard-*", "expand_wildcards", "all", "ignore_unavailable", "true");
+        Map<String, Object> indicesAll = (Map<String, Object>) rAll.get("indices");
+        assertTrue("expand=all must include open", indicesAll.containsKey("wildcard-open-idx"));
+        // expand_wildcards=all resolves the closed index in the pattern, but the broadcast
+        // action cannot execute on closed shards so the response may omit it. Assert that
+        // the response size is >= the open-only response (no regression).
+        assertTrue("expand=all must return at least as many indices as expand=open", indicesAll.size() >= indicesOpen.size());
+    }
+
+    /**
+     * Verifies the {@code allow_no_indices} param controls whether a wildcard pattern matching
+     * zero indices returns 200 with empty results or 404.
+     */
+    @SuppressWarnings("unchecked")
+    public void testAllowNoIndices() throws Exception {
+        internalCluster().startNodes(1);
+        // Create an index to ensure cluster is green, then use a non-matching wildcard.
+        createIndexWithShards("allow-no-anchor-idx", 1, 0, true);
+
+        // allow_no_indices=true — must succeed with empty indices block.
+        Map<String, Object> rOk = parquetIndexStats("no-match-*", "allow_no_indices", "true");
+        Map<String, Object> indicesOk = (Map<String, Object>) rOk.get("indices");
+        assertNotNull("response must have indices key", indicesOk);
+        assertTrue("indices block must be empty for no-match wildcard", indicesOk.isEmpty());
+
+        // allow_no_indices=false — must fail with 4xx.
+        try {
+            getRestClient().performRequest(new Request("GET", "/_plugins/parquet/no-match-*/_stats?allow_no_indices=false"));
+            fail("expected 4xx for allow_no_indices=false on no-match wildcard");
+        } catch (ResponseException e) {
+            int code = e.getResponse().getStatusLine().getStatusCode();
+            assertTrue("expected 4xx, got " + code, code >= 400 && code < 500);
+        }
+    }
+
+    /**
+     * Verifies that an out-of-range shard ID in the {@code shards=} param returns a clear 400.
+     */
+    public void testInvalidShardIdReturnsBadRequest() throws Exception {
+        internalCluster().startNodes(1);
+        createIndexWithShards("bad-shard-idx", 3, 0, true);
+        indexDocs("bad-shard-idx", 30, 0);
+        refreshIndex("bad-shard-idx");
+
+        // shards=99 — out of range for a 3-shard index.
+        try {
+            getRestClient().performRequest(new Request("GET", "/_plugins/parquet/bad-shard-idx/_stats?level=shards&shards=99"));
+            fail("expected 400 for out-of-range shard id");
+        } catch (ResponseException e) {
+            int code = e.getResponse().getStatusLine().getStatusCode();
+            assertEquals("expected exactly 400 for out-of-range shard", 400, code);
+        }
+
+        // shards=foo — non-integer must also return 400.
+        try {
+            getRestClient().performRequest(new Request("GET", "/_plugins/parquet/bad-shard-idx/_stats?level=shards&shards=foo"));
+            fail("expected 400 for non-integer shard id");
+        } catch (ResponseException e) {
+            int code = e.getResponse().getStatusLine().getStatusCode();
+            assertEquals("expected exactly 400 for non-integer shard", 400, code);
+        }
+    }
+
+    /**
+     * Computes the sum of a counter across all shards in the shard-level response.
+     * Response shape: indices.{idx}.shards."{shardId}".[{routing: {primary: bool, ...}, indexing: {...}, ...}]
+     *
+     * <p>Treats both 0 and absent (-1L from {@code getCounter}) as no-contribution; only
+     * positive values are added. Negative values from missing paths are ignored rather
+     * than throwing — callers that need strict path validation should use {@code hasPath}.
+     */
+    @SuppressWarnings("unchecked")
+    private long computeShardSum(Map<String, Object> response, String indexName, String counterPath) {
+        Map<String, Object> indices = (Map<String, Object>) response.get("indices");
+        Map<String, Object> indexStats = (Map<String, Object>) indices.get(indexName);
+        Map<String, Object> shards = (Map<String, Object>) indexStats.get("shards");
+        long sum = 0L;
+        for (Map.Entry<String, Object> shardEntry : shards.entrySet()) {
+            List<Map<String, Object>> copies = (List<Map<String, Object>>) shardEntry.getValue();
+            for (Map<String, Object> copy : copies) {
+                long val = getCounter(copy, counterPath);
+                if (val >= 0) sum += val;
+            }
+        }
+        return sum;
+    }
+
+    /**
+     * 3 shards, query level=shards, verify each shard entry has primary field and stats.
+     */
+    @SuppressWarnings("unchecked")
+    public void testShardLevelRoutingMetadata() throws Exception {
+        internalCluster().startNodes(1);
+        createIndexWithShards("routing-idx", 3, 0, true);
+        indexDocs("routing-idx", 60, 0);
+        refreshIndex("routing-idx");
+
+        Map<String, Object> rs = parquetIndexStats("routing-idx", "level", "shards");
+        assertTrue("shards block must exist", hasPath(rs, "indices.routing-idx.shards"));
+
+        Map<String, Object> indices = (Map<String, Object>) rs.get("indices");
+        Map<String, Object> indexBlock = (Map<String, Object>) indices.get("routing-idx");
+        Map<String, Object> shards = (Map<String, Object>) indexBlock.get("shards");
+        assertEquals("expected 3 shard entries (one per primary)", 3, shards.size());
+
+        for (Map.Entry<String, Object> shardEntry : shards.entrySet()) {
+            List<Map<String, Object>> copies = (List<Map<String, Object>>) shardEntry.getValue();
+            assertEquals("each shard list must have exactly 1 entry (primary only)", 1, copies.size());
+            Map<String, Object> copy = copies.get(0);
+            // routing sub-object must be present with expected fields.
+            Map<String, Object> routing = (Map<String, Object>) copy.get("routing");
+            assertNotNull("each shard copy must have a routing block", routing);
+            assertEquals("copy must be primary", Boolean.TRUE, routing.get("primary"));
+            assertNotNull("routing.node must be set", routing.get("node"));
+            assertNotNull("routing.state must be set", routing.get("state"));
+            assertNull("routing.relocating_node must be null for stable shards", routing.get("relocating_node"));
+            // Stats fields must be present in the copy.
+            assertTrue("copy must have indexing block", copy.containsKey("indexing"));
+        }
+    }
+
+    /**
+     * With no level param, response must NOT include shards block.
+     */
+    @SuppressWarnings("unchecked")
+    public void testDefaultLevelExcludesShardsBlock() throws Exception {
+        internalCluster().startNodes(1);
+        createIndexWithShards("default-level-idx", 3, 0, true);
+        indexDocs("default-level-idx", 30, 0);
+        refreshIndex("default-level-idx");
+
+        // Default — no level param.
+        Map<String, Object> r = parquetIndexStats("default-level-idx");
+        Map<String, Object> indices = (Map<String, Object>) r.get("indices");
+        Map<String, Object> indexBlock = (Map<String, Object>) indices.get("default-level-idx");
+        assertFalse("default level response must NOT have a shards block", indexBlock.containsKey("shards"));
+        assertCounter("index-level total still present", r, "indices.default-level-idx.indexing.docs_indexed_total", 30L);
+
+        // Explicit level=index — also excludes shards.
+        Map<String, Object> rIndex = parquetIndexStats("default-level-idx", "level", "index");
+        Map<String, Object> indicesIdx = (Map<String, Object>) rIndex.get("indices");
+        Map<String, Object> indexBlockIdx = (Map<String, Object>) indicesIdx.get("default-level-idx");
+        assertFalse("explicit level=index must NOT have a shards block", indexBlockIdx.containsKey("shards"));
+    }
+
+    /**
+     * Multiple indices, test wildcard, comma-separated, and ignore_unavailable resolution.
+     */
+    @SuppressWarnings("unchecked")
+    public void testIndexPatternResolution() throws Exception {
+        internalCluster().startNodes(1);
+        createIndexWithShards("pat-idx-a", 1, 0, true);
+        createIndexWithShards("pat-idx-b", 1, 0, true);
+        createIndexWithShards("other-idx", 1, 0, true);
+        indexDocs("pat-idx-a", 10, 0);
+        indexDocs("pat-idx-b", 20, 0);
+        indexDocs("other-idx", 30, 0);
+        refreshIndex("pat-idx-a");
+        refreshIndex("pat-idx-b");
+        refreshIndex("other-idx");
+
+        // Wildcard pat-idx-* must match a + b but NOT other-idx.
+        Map<String, Object> wildResp = parquetIndexStats("pat-idx-*");
+        Map<String, Object> wildIndices = (Map<String, Object>) wildResp.get("indices");
+        assertTrue("wildcard must match pat-idx-a", wildIndices.containsKey("pat-idx-a"));
+        assertTrue("wildcard must match pat-idx-b", wildIndices.containsKey("pat-idx-b"));
+        assertFalse("wildcard must NOT match other-idx", wildIndices.containsKey("other-idx"));
+
+        // Comma-separated must match both (use a and other).
+        Map<String, Object> commaResp = parquetIndexStats("pat-idx-a,other-idx");
+        Map<String, Object> commaIndices = (Map<String, Object>) commaResp.get("indices");
+        assertTrue(commaIndices.containsKey("pat-idx-a"));
+        assertTrue(commaIndices.containsKey("other-idx"));
+        assertFalse("comma list must NOT match unspecified pat-idx-b", commaIndices.containsKey("pat-idx-b"));
+
+        // ignore_unavailable=true with one missing must succeed and return only the existing one.
+        Map<String, Object> mixResp = parquetIndexStats("pat-idx-a,no-such-idx", "ignore_unavailable", "true");
+        Map<String, Object> mixIndices = (Map<String, Object>) mixResp.get("indices");
+        assertTrue("existing index pat-idx-a must appear in response", mixIndices.containsKey("pat-idx-a"));
+        assertFalse("missing index must not appear in response", mixIndices.containsKey("no-such-idx"));
+    }
+
+    /**
+     * Test the shard= and node= query parameters for filtering shard-level results.
+     */
+    @SuppressWarnings("unchecked")
+    public void testShardAndNodeFilters() throws Exception {
+        internalCluster().startNodes(2);
+        createIndexWithShards("filter-idx", 4, 0, true);
+        indexDocs("filter-idx", 80, 0);
+        refreshIndex("filter-idx");
+
+        // shards=2 — only that shard in shard-level response.
+        Map<String, Object> sf = parquetIndexStats("filter-idx", "level", "shards", "shards", "2");
+        Map<String, Object> indices = (Map<String, Object>) sf.get("indices");
+        Map<String, Object> indexBlock = (Map<String, Object>) indices.get("filter-idx");
+        Map<String, Object> shards = (Map<String, Object>) indexBlock.get("shards");
+        assertEquals("shard filter must restrict to 1 entry", 1, shards.size());
+        assertTrue("must include shard 2", shards.containsKey("2"));
+
+        // node filter — pick a real node id from the cluster, query restricting to that node.
+        String someNodeId = client().admin().cluster().prepareNodesInfo().get().getNodes().get(0).getNode().getId();
+        Map<String, Object> nf = parquetIndexStats("filter-idx", "level", "shards", "nodes", someNodeId);
+        Map<String, Object> nfIndices = (Map<String, Object>) nf.get("indices");
+        Map<String, Object> nfIndex = (Map<String, Object>) nfIndices.get("filter-idx");
+        Map<String, Object> nfShards = (Map<String, Object>) nfIndex.get("shards");
+        // Must have at most as many entries as shards on that node (4 shards across 2 nodes).
+        assertTrue("node filter must return at least 1 shard", nfShards.size() >= 1);
+        assertTrue("node filter must return at most 4 shards", nfShards.size() <= 4);
+    }
+}

--- a/sandbox/plugins/composite-engine/src/main/java/org/opensearch/composite/CompositeDataFormatPlugin.java
+++ b/sandbox/plugins/composite-engine/src/main/java/org/opensearch/composite/CompositeDataFormatPlugin.java
@@ -37,6 +37,7 @@ import org.opensearch.index.mapper.MapperParsingException;
 import org.opensearch.index.shard.IndexSettingProvider;
 import org.opensearch.indices.IndexCreationException;
 import org.opensearch.indices.IndicesService;
+import org.opensearch.plugin.stats.DataFormatStatsProviderRegistry;
 import org.opensearch.plugins.ExtensiblePlugin;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.repositories.RepositoriesService;
@@ -85,10 +86,15 @@ import java.util.stream.Collectors;
  * {@code extendedPlugins = ['composite-engine']} in their {@code build.gradle}
  * and implementing {@link DataFormatPlugin}.
  *
+ * <p>Implements {@link ExtensiblePlugin} so that other data-format plugins (parquet, lucene)
+ * can declare {@code extendedPlugins=['composite-engine']} in their plugin descriptors. This
+ * makes composite-engine's bundled {@code plugin-stats-spi} classes available to those plugins'
+ * classloaders — ensuring all formats share the same {@link DataFormatStatsProviderRegistry}.
+ *
  * @opensearch.experimental
  */
 @ExperimentalApi
-public class CompositeDataFormatPlugin extends Plugin implements DataFormatPlugin {
+public class CompositeDataFormatPlugin extends Plugin implements DataFormatPlugin, ExtensiblePlugin {
 
     private static final Logger logger = LogManager.getLogger(CompositeDataFormatPlugin.class);
 
@@ -433,4 +439,5 @@ public class CompositeDataFormatPlugin extends Plugin implements DataFormatPlugi
         }
         return Map.copyOf(strategies);
     }
+
 }

--- a/sandbox/plugins/composite-engine/src/test/java/org/opensearch/composite/CompositeWriterFailureTests.java
+++ b/sandbox/plugins/composite-engine/src/test/java/org/opensearch/composite/CompositeWriterFailureTests.java
@@ -12,6 +12,7 @@ import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.store.LockObtainFailedException;
 import org.opensearch.be.lucene.LuceneDataFormat;
 import org.opensearch.be.lucene.index.LuceneWriter;
+import org.opensearch.be.lucene.stats.LuceneShardStatsTracker;
 import org.opensearch.index.engine.dataformat.DataFormat;
 import org.opensearch.index.engine.dataformat.DocumentInput;
 import org.opensearch.index.engine.dataformat.IndexingExecutionEngine;
@@ -218,10 +219,30 @@ public class CompositeWriterFailureTests extends OpenSearchTestCase {
         LuceneDataFormat luceneFormat = new LuceneDataFormat();
 
         // First, prove the failure mode
-        LuceneWriter leakedWriter = new LuceneWriter(generation, 0L, luceneFormat, baseDir, null, Codec.getDefault(), null, registry);
+        LuceneWriter leakedWriter = new LuceneWriter(
+            generation,
+            0L,
+            luceneFormat,
+            baseDir,
+            null,
+            Codec.getDefault(),
+            null,
+            registry,
+            new LuceneShardStatsTracker()
+        );
         LockObtainFailedException lockError = expectThrows(
             LockObtainFailedException.class,
-            () -> new LuceneWriter(generation, 0L, luceneFormat, baseDir, null, Codec.getDefault(), null, registry)
+            () -> new LuceneWriter(
+                generation,
+                0L,
+                luceneFormat,
+                baseDir,
+                null,
+                Codec.getDefault(),
+                null,
+                registry,
+                new LuceneShardStatsTracker()
+            )
         );
         assertThat(lockError.getMessage(), org.hamcrest.Matchers.containsString("Lock held by this virtual machine"));
         leakedWriter.close();
@@ -253,7 +274,8 @@ public class CompositeWriterFailureTests extends OpenSearchTestCase {
                         null,
                         Codec.getDefault(),
                         null,
-                        registry
+                        registry,
+                        new LuceneShardStatsTracker()
                     );
                 } catch (IOException e) {
                     throw new RuntimeException(e);
@@ -272,7 +294,17 @@ public class CompositeWriterFailureTests extends OpenSearchTestCase {
 
         // Simulate engine restart reusing same generation.
         // Without the fix, this throws LockObtainFailedException.
-        LuceneWriter retryWriter = new LuceneWriter(generation, 0L, luceneFormat, baseDir, null, Codec.getDefault(), null, registry);
+        LuceneWriter retryWriter = new LuceneWriter(
+            generation,
+            0L,
+            luceneFormat,
+            baseDir,
+            null,
+            Codec.getDefault(),
+            null,
+            registry,
+            new LuceneShardStatsTracker()
+        );
         retryWriter.close();
     }
 

--- a/sandbox/plugins/parquet-data-format/build.gradle
+++ b/sandbox/plugins/parquet-data-format/build.gradle
@@ -9,7 +9,7 @@
 opensearchplugin {
   description = 'Parquet data format plugin for OpenSearch.'
   classname = 'org.opensearch.parquet.ParquetDataFormatPlugin'
-  extendedPlugins = ['arrow-base']
+  extendedPlugins = ['arrow-base', 'composite-engine']
 }
 
 java { sourceCompatibility = JavaVersion.toVersion(25); targetCompatibility = JavaVersion.toVersion(25) }
@@ -18,6 +18,9 @@ dependencies {
   // arrow-base provides ArrowNativeAllocator at runtime (shared classloader)
   compileOnly project(':plugins:arrow-base')
   testImplementation project(':plugins:arrow-base')
+
+  // Plugin stats SPI interfaces
+  compileOnly project(":sandbox:libs:plugin-stats-spi")
 
   // Shared native bridge lib (provides the unified .so and FFM SymbolLookup)
   implementation project(':sandbox:libs:dataformat-native')

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/ParquetDataFormatPlugin.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/ParquetDataFormatPlugin.java
@@ -8,12 +8,19 @@
 
 package org.opensearch.parquet;
 
+import org.opensearch.action.ActionRequest;
 import org.opensearch.arrow.allocator.ArrowNativeAllocator;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
+import org.opensearch.cluster.node.DiscoveryNodes;
 import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.inject.Module;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.IndexScopedSettings;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.settings.SettingsFilter;
 import org.opensearch.common.util.concurrent.OpenSearchExecutors;
+import org.opensearch.core.action.ActionResponse;
 import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.env.Environment;
@@ -31,10 +38,21 @@ import org.opensearch.index.store.PrecomputedChecksumStrategy;
 import org.opensearch.parquet.engine.ParquetDataFormat;
 import org.opensearch.parquet.engine.ParquetIndexingEngine;
 import org.opensearch.parquet.fields.ArrowSchemaBuilder;
+import org.opensearch.parquet.stats.ParquetStatsProvider;
+import org.opensearch.parquet.stats.transport.ParquetNodeStatsActionType;
+import org.opensearch.parquet.stats.transport.ParquetNodeStatsRestAction;
+import org.opensearch.parquet.stats.transport.ParquetNodeStatsTransportAction;
+import org.opensearch.parquet.stats.transport.ParquetStatsActionType;
+import org.opensearch.parquet.stats.transport.ParquetStatsRestAction;
+import org.opensearch.parquet.stats.transport.ParquetStatsTransportAction;
 import org.opensearch.parquet.store.ParquetStoreStrategy;
+import org.opensearch.plugins.ActionPlugin;
+import org.opensearch.plugins.ActionPlugin.ActionHandler;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.plugins.PluginComponentRegistry;
 import org.opensearch.repositories.RepositoriesService;
+import org.opensearch.rest.RestController;
+import org.opensearch.rest.RestHandler;
 import org.opensearch.script.ScriptService;
 import org.opensearch.threadpool.ExecutorBuilder;
 import org.opensearch.threadpool.FixedExecutorBuilder;
@@ -62,7 +80,7 @@ import java.util.function.Supplier;
  * routing directory events, and closing native resources are all handled
  * there. The plugin stays purely declarative.
  */
-public class ParquetDataFormatPlugin extends Plugin implements DataFormatPlugin {
+public class ParquetDataFormatPlugin extends Plugin implements DataFormatPlugin, ActionPlugin {
 
     /**
      * Current parquet writer format version, long-encoded (plugin-defined namespace; the
@@ -163,5 +181,40 @@ public class ParquetDataFormatPlugin extends Plugin implements DataFormatPlugin 
                 "thread_pool." + PARQUET_THREAD_POOL_NAME
             )
         );
+    }
+
+    /**
+     * Constructs the {@link ParquetStatsProvider} eagerly so engines can self-register their
+     * trackers via the static {@code getInstance()} accessor at construction time. Also adds
+     * a multibinding entry so the composite-engine plugin can discover this provider via
+     * {@code Set<DataFormatStatsProvider>} injection without naming parquet directly.
+     */
+    @Override
+    public Collection<Module> createGuiceModules() {
+        // Eagerly construct the provider so the registry is populated before the engine
+        // and transport-action layers attempt lookups.
+        new ParquetStatsProvider();
+        return List.of();
+    }
+
+    @Override
+    public List<ActionHandler<? extends ActionRequest, ? extends ActionResponse>> getActions() {
+        return List.of(
+            new ActionHandler<>(ParquetStatsActionType.INSTANCE, ParquetStatsTransportAction.class),
+            new ActionHandler<>(ParquetNodeStatsActionType.INSTANCE, ParquetNodeStatsTransportAction.class)
+        );
+    }
+
+    @Override
+    public List<RestHandler> getRestHandlers(
+        Settings settings,
+        RestController restController,
+        ClusterSettings clusterSettings,
+        IndexScopedSettings indexScopedSettings,
+        SettingsFilter settingsFilter,
+        IndexNameExpressionResolver indexNameExpressionResolver,
+        Supplier<DiscoveryNodes> nodesInCluster
+    ) {
+        return List.of(new ParquetStatsRestAction(), new ParquetNodeStatsRestAction());
     }
 }

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/bridge/MergeFilesResult.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/bridge/MergeFilesResult.java
@@ -13,7 +13,15 @@ import org.opensearch.index.engine.dataformat.RowIdMapping;
 /**
  * Result of a native Parquet merge. Bundles the row-ID mapping used to
  * remap row IDs in secondary data formats with the Parquet file metadata
- * (version, row count, {@code created_by}, CRC32) of the merged output file.
+ * (version, row count, {@code created_by}, CRC32) of the merged output file,
+ * plus per-merge stats forwarded to the per-shard tracker.
+ *
+ * @param rowIdMapping            row-ID remapping table for secondary data formats
+ * @param metadata                Parquet file metadata + CRC32 of the merged output
+ * @param flushAndSortChunkCount  count of flush+sort+chunk passes that ran during this merge
+ * @param flushAndSortChunkTimeMs cumulative wall-clock millis spent in flush+sort+chunk passes
+ * @param rowIdMappingMax         highest row_id assigned during this merge (= rows written)
  */
-public record MergeFilesResult(RowIdMapping rowIdMapping, ParquetFileMetadata metadata) {
+public record MergeFilesResult(RowIdMapping rowIdMapping, ParquetFileMetadata metadata, long flushAndSortChunkCount,
+    long flushAndSortChunkTimeMs, long rowIdMappingMax) {
 }

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/bridge/NativeParquetWriter.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/bridge/NativeParquetWriter.java
@@ -11,6 +11,7 @@ package org.opensearch.parquet.bridge;
 import org.opensearch.common.SetOnce;
 import org.opensearch.index.engine.dataformat.RowIdMapping;
 import org.opensearch.parquet.stats.ParquetShardStatsTracker;
+import org.opensearch.plugin.stats.StatsRecorder;
 
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
@@ -103,17 +104,12 @@ public class NativeParquetWriter {
         if (initialized == false) {
             throw new IllegalStateException("Writer not initialized: " + filePath);
         }
-        long startNanos = System.nanoTime();
-        try {
-            RustBridge.write(filePath, arrayAddress, schemaAddress);
-            stats.incNativeWriteTotal();
-        } catch (IOException e) {
-            stats.incNativeWriteFailures();
-            throw e;
-        } finally {
-            long elapsed = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
-            stats.addNativeWriteTimeMillis(elapsed);
-        }
+        StatsRecorder.recordOutcome(
+            () -> RustBridge.write(filePath, arrayAddress, schemaAddress),
+            stats::addNativeWriteTimeMillis,
+            stats::incNativeWriteTotal,
+            stats::incNativeWriteFailures
+        );
     }
 
     /**

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/bridge/NativeParquetWriter.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/bridge/NativeParquetWriter.java
@@ -10,8 +10,10 @@ package org.opensearch.parquet.bridge;
 
 import org.opensearch.common.SetOnce;
 import org.opensearch.index.engine.dataformat.RowIdMapping;
+import org.opensearch.parquet.stats.ParquetShardStatsTracker;
 
 import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
@@ -34,6 +36,7 @@ public class NativeParquetWriter {
     private final String filePath;
     private final SetOnce<ParquetFileMetadata> metadata = new SetOnce<>();
     private final SetOnce<RowIdMapping> rowIdMapping = new SetOnce<>();
+    private final ParquetShardStatsTracker stats;
     private volatile boolean initialized = false;
 
     /**
@@ -41,9 +44,20 @@ public class NativeParquetWriter {
      * call {@link #initialize(String, long, ParquetSortConfig, long)} before the first write.
      *
      * @param filePath the path to the Parquet file to write
+     * @param stats shard-level stats tracker
+     */
+    public NativeParquetWriter(String filePath, ParquetShardStatsTracker stats) {
+        this.filePath = filePath;
+        this.stats = stats;
+    }
+
+    /**
+     * Creates a new NativeParquetWriter handle without stats collection.
+     *
+     * @param filePath the path to the Parquet file to write
      */
     public NativeParquetWriter(String filePath) {
-        this.filePath = filePath;
+        this(filePath, new ParquetShardStatsTracker());
     }
 
     /**
@@ -89,7 +103,17 @@ public class NativeParquetWriter {
         if (initialized == false) {
             throw new IllegalStateException("Writer not initialized: " + filePath);
         }
-        RustBridge.write(filePath, arrayAddress, schemaAddress);
+        long startNanos = System.nanoTime();
+        try {
+            RustBridge.write(filePath, arrayAddress, schemaAddress);
+            stats.incNativeWriteTotal();
+        } catch (IOException e) {
+            stats.incNativeWriteFailures();
+            throw e;
+        } finally {
+            long elapsed = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
+            stats.addNativeWriteTimeMillis(elapsed);
+        }
     }
 
     /**
@@ -103,12 +127,22 @@ public class NativeParquetWriter {
     public ParquetFileMetadata flush() throws IOException {
         if (writerFlushed.compareAndSet(false, true)) {
             if (initialized) {
-                RustBridge.WriterFinalizeResult result = RustBridge.finalizeWriter(filePath);
-                if (result != null) {
-                    metadata.set(result.metadata());
-                    if (result.rowIdMapping() != null) {
-                        rowIdMapping.set(result.rowIdMapping());
+                long startNanos = System.nanoTime();
+                try {
+                    RustBridge.WriterFinalizeResult result = RustBridge.finalizeWriter(filePath);
+                    if (result != null) {
+                        metadata.set(result.metadata());
+                        if (result.rowIdMapping() != null) {
+                            rowIdMapping.set(result.rowIdMapping());
+                        }
                     }
+                    stats.incNativeFinalizeTotal();
+                } catch (IOException e) {
+                    stats.incNativeFinalizeFailures();
+                    throw e;
+                } finally {
+                    long elapsed = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
+                    stats.addNativeFinalizeTimeMillis(elapsed);
                 }
             }
         }

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/bridge/RustBridge.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/bridge/RustBridge.java
@@ -12,6 +12,7 @@ import org.opensearch.index.engine.dataformat.PackedRowIdMapping;
 import org.opensearch.index.engine.dataformat.RowIdMapping;
 import org.opensearch.nativebridge.spi.NativeCall;
 import org.opensearch.nativebridge.spi.NativeLibraryLoader;
+import org.opensearch.parquet.stats.ParquetNativeRuntimeStats;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -44,6 +45,7 @@ public class RustBridge {
     private static final MethodHandle FREE_MERGE_RESULT;
     private static final MethodHandle READ_AS_JSON;
     private static final MethodHandle FREE_ROW_ID_MAPPING;
+    private static final MethodHandle COLLECT_RUNTIME_METRICS;
 
     static {
         SymbolLookup lib = NativeLibraryLoader.symbolLookup();
@@ -244,6 +246,14 @@ public class RustBridge {
             FunctionDescriptor.ofVoid(
                 ValueLayout.JAVA_LONG,                         // mapping_ptr
                 ValueLayout.JAVA_LONG                          // mapping_len
+            )
+        );
+        COLLECT_RUNTIME_METRICS = linker.downcallHandle(
+            lib.find("parquet_collect_runtime_metrics").orElseThrow(),
+            FunctionDescriptor.of(
+                ValueLayout.JAVA_LONG,    // return value
+                ValueLayout.ADDRESS,      // out_buf
+                ValueLayout.JAVA_LONG     // out_len
             )
         );
     }
@@ -478,6 +488,25 @@ public class RustBridge {
         try (var call = new NativeCall()) {
             var idx = call.str(indexName);
             call.invoke(REMOVE_SETTINGS, idx.segment(), idx.len());
+        }
+    }
+
+    /**
+     * Collects a snapshot of native runtime metrics for the parquet merge path.
+     * Returns a long array of {@link ParquetNativeRuntimeStats#FIELD_COUNT} elements in the
+     * order documented in {@link org.opensearch.parquet.stats.ParquetNativeRuntimeStats#fromArray}.
+     */
+    public static long[] collectRuntimeMetrics() {
+        try (var call = new NativeCall()) {
+            var buf = call.buf(ParquetNativeRuntimeStats.FIELD_COUNT * 8);
+            call.invokeIO(COLLECT_RUNTIME_METRICS, buf, (long) ParquetNativeRuntimeStats.FIELD_COUNT);
+            long[] out = new long[ParquetNativeRuntimeStats.FIELD_COUNT];
+            for (int i = 0; i < ParquetNativeRuntimeStats.FIELD_COUNT; i++) {
+                out[i] = buf.getAtIndex(ValueLayout.JAVA_LONG, i);
+            }
+            return out;
+        } catch (IOException e) {
+            throw new java.io.UncheckedIOException("collectRuntimeMetrics failed", e);
         }
     }
 

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/bridge/RustBridge.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/bridge/RustBridge.java
@@ -216,7 +216,10 @@ public class RustBridge {
                 ValueLayout.ADDRESS,    // out_gen_keys_ptr
                 ValueLayout.ADDRESS,    // out_gen_offsets_ptr
                 ValueLayout.ADDRESS,    // out_gen_sizes_ptr
-                ValueLayout.ADDRESS     // out_gen_count
+                ValueLayout.ADDRESS,    // out_gen_count
+                ValueLayout.ADDRESS,    // out_flush_and_sort_chunk_count
+                ValueLayout.ADDRESS,    // out_flush_and_sort_chunk_time_millis
+                ValueLayout.ADDRESS     // out_row_id_mapping_max
             )
         );
         FREE_MERGE_RESULT = linker.downcallHandle(
@@ -535,6 +538,10 @@ public class RustBridge {
             var outGenOffsetsPtr = call.longOut();
             var outGenSizesPtr = call.longOut();
             var outGenCount = call.longOut();
+            // Out-pointers for per-merge stats forwarded to the per-shard tracker.
+            var outFlushChunkCount = call.longOut();
+            var outFlushChunkTimeMillis = call.longOut();
+            var outRowIdMappingMax = call.longOut();
 
             call.invokeIO(
                 MERGE_FILES,
@@ -557,7 +564,10 @@ public class RustBridge {
                 outGenKeysPtr,
                 outGenOffsetsPtr,
                 outGenSizesPtr,
-                outGenCount
+                outGenCount,
+                outFlushChunkCount,
+                outFlushChunkTimeMillis,
+                outRowIdMappingMax
             );
 
             int createdByLen = (int) createdByOut.lenOut().get(ValueLayout.JAVA_LONG, 0);
@@ -580,7 +590,11 @@ public class RustBridge {
                 outGenCount
             );
 
-            return new MergeFilesResult(rowIdMapping, metadata);
+            long flushChunkCount = outFlushChunkCount.get(ValueLayout.JAVA_LONG, 0);
+            long flushChunkTimeMillis = outFlushChunkTimeMillis.get(ValueLayout.JAVA_LONG, 0);
+            long rowIdMappingMax = outRowIdMappingMax.get(ValueLayout.JAVA_LONG, 0);
+
+            return new MergeFilesResult(rowIdMapping, metadata, flushChunkCount, flushChunkTimeMillis, rowIdMappingMax);
         } catch (IOException e) {
             throw new UncheckedIOException("Native merge failed", e);
         }

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/engine/ParquetIndexingEngine.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/engine/ParquetIndexingEngine.java
@@ -172,15 +172,27 @@ public class ParquetIndexingEngine implements IndexingExecutionEngine<ParquetDat
                 statsTracker
             )
         );
-        pushSettingsToRust();
-        // Register this shard's tracker with the format-wide stats provider so the
-        // /_plugins/parquet/{index}/_stats and /_plugins/parquet/_nodes/{nodeId}/_stats
-        // REST endpoints can read live counters. Unregistered in close().
-        ParquetStatsProvider provider = (ParquetStatsProvider) DataFormatStatsProviderRegistry.INSTANCE.get(
-            ParquetStatsProvider.FORMAT_NAME
-        );
-        if (provider != null) {
-            provider.register(shardPath.getShardId(), statsTracker);
+        boolean registered = false;
+        ParquetStatsProvider provider = null;
+        try {
+            pushSettingsToRust();
+            // Register this shard's tracker with the format-wide stats provider so the
+            // /_plugins/parquet/{index}/_stats and /_plugins/parquet/_nodes/{nodeId}/_stats
+            // REST endpoints can read live counters. Unregistered in close().
+            provider = (ParquetStatsProvider) DataFormatStatsProviderRegistry.INSTANCE.get(ParquetStatsProvider.FORMAT_NAME);
+            if (provider != null) {
+                provider.register(shardPath.getShardId(), statsTracker);
+                registered = true;
+            }
+        } catch (Throwable t) {
+            if (registered && provider != null) {
+                try {
+                    provider.unregister(shardPath.getShardId());
+                } catch (Throwable rollbackErr) {
+                    logger.warn("Failed to unregister parquet stats tracker during constructor rollback", rollbackErr);
+                }
+            }
+            throw t;
         }
     }
 

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/engine/ParquetIndexingEngine.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/engine/ParquetIndexingEngine.java
@@ -31,8 +31,11 @@ import org.opensearch.parquet.bridge.RustBridge;
 import org.opensearch.parquet.memory.ArrowBufferPool;
 import org.opensearch.parquet.merge.NativeParquetMergeStrategy;
 import org.opensearch.parquet.merge.ParquetMergeExecutor;
+import org.opensearch.parquet.stats.ParquetShardStatsTracker;
+import org.opensearch.parquet.stats.ParquetStatsProvider;
 import org.opensearch.parquet.writer.ParquetDocumentInput;
 import org.opensearch.parquet.writer.ParquetWriter;
+import org.opensearch.plugin.stats.DataFormatStatsProviderRegistry;
 import org.opensearch.threadpool.ThreadPool;
 
 import java.io.IOException;
@@ -84,6 +87,7 @@ public class ParquetIndexingEngine implements IndexingExecutionEngine<ParquetDat
     private final ThreadPool threadPool;
     private final FormatChecksumStrategy checksumStrategy;
     private final Merger parquetMerger;
+    private final ParquetShardStatsTracker statsTracker = new ParquetShardStatsTracker();
 
     /**
      * Creates a new ParquetIndexingEngine.
@@ -160,9 +164,24 @@ public class ParquetIndexingEngine implements IndexingExecutionEngine<ParquetDat
             throw new RuntimeException(e);
         }
         this.parquetMerger = new ParquetMergeExecutor(
-            new NativeParquetMergeStrategy(dataFormat, indexSettings.getIndex().getName(), shardPath, checksumStrategy::registerChecksum)
+            new NativeParquetMergeStrategy(
+                dataFormat,
+                indexSettings.getIndex().getName(),
+                shardPath,
+                checksumStrategy::registerChecksum,
+                statsTracker
+            )
         );
         pushSettingsToRust();
+        // Register this shard's tracker with the format-wide stats provider so the
+        // /_plugins/parquet/{index}/_stats and /_plugins/parquet/_nodes/{nodeId}/_stats
+        // REST endpoints can read live counters. Unregistered in close().
+        ParquetStatsProvider provider = (ParquetStatsProvider) DataFormatStatsProviderRegistry.INSTANCE.get(
+            ParquetStatsProvider.FORMAT_NAME
+        );
+        if (provider != null) {
+            provider.register(shardPath.getShardId(), statsTracker);
+        }
     }
 
     /**
@@ -224,7 +243,8 @@ public class ParquetIndexingEngine implements IndexingExecutionEngine<ParquetDat
             bufferPool,
             indexSettings,
             threadPool,
-            checksumStrategy
+            checksumStrategy,
+            statsTracker
         );
     }
 
@@ -300,6 +320,13 @@ public class ParquetIndexingEngine implements IndexingExecutionEngine<ParquetDat
 
     @Override
     public void close() throws IOException {
+        // Unregister this shard's tracker from the stats provider before tearing down.
+        ParquetStatsProvider provider = (ParquetStatsProvider) DataFormatStatsProviderRegistry.INSTANCE.get(
+            ParquetStatsProvider.FORMAT_NAME
+        );
+        if (provider != null) {
+            provider.unregister(shardPath.getShardId());
+        }
         try {
             RustBridge.removeSettings(indexSettings.getIndex().getName());
         } catch (Exception e) {

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/merge/NativeParquetMergeStrategy.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/merge/NativeParquetMergeStrategy.java
@@ -24,6 +24,7 @@ import org.opensearch.parquet.bridge.MergeFilesResult;
 import org.opensearch.parquet.bridge.ParquetFileMetadata;
 import org.opensearch.parquet.bridge.RustBridge;
 import org.opensearch.parquet.engine.ParquetIndexingEngine;
+import org.opensearch.parquet.stats.ParquetShardStatsTracker;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -31,6 +32,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Implements merging of Parquet files.
@@ -43,17 +45,20 @@ public class NativeParquetMergeStrategy implements ParquetMergeStrategy {
     private final String indexName;
     private final ShardPath shardPath;
     private final TriConsumer<FileMetadata, Long, Long> checksumUpdater;
+    private final ParquetShardStatsTracker stats;
 
     public NativeParquetMergeStrategy(
         DataFormat dataFormat,
         String indexName,
         ShardPath shardPath,
-        TriConsumer<FileMetadata, Long, Long> checksumUpdater
+        TriConsumer<FileMetadata, Long, Long> checksumUpdater,
+        ParquetShardStatsTracker stats
     ) {
         this.dataFormat = dataFormat;
         this.indexName = indexName;
         this.shardPath = shardPath;
         this.checksumUpdater = checksumUpdater;
+        this.stats = stats;
     }
 
     @Override
@@ -78,6 +83,7 @@ public class NativeParquetMergeStrategy implements ParquetMergeStrategy {
         Path mergedFilePath = ParquetIndexingEngine.buildParquetFilePath(shardPath, writerGeneration, "merged");
         String mergedFileName = mergedFilePath.getFileName().toString();
 
+        long startNanos = System.nanoTime();
         try {
             // Merge files in Rust
             MergeFilesResult merged = RustBridge.mergeParquetFilesInRust(filePaths, mergedFilePath.toString(), indexName, writerGeneration);
@@ -107,9 +113,18 @@ public class NativeParquetMergeStrategy implements ParquetMergeStrategy {
             );
             Map<DataFormat, WriterFileSet> mergedWriterFileSetMap = Collections.singletonMap(dataFormat, mergedWriterFileSet);
 
+            long elapsed = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
+            stats.incMergeTotal();
+            stats.addMergeTimeMillis(elapsed);
+            stats.addMergeInputFilesTotal(filePaths.size());
+            stats.addMergeOutputRowsTotal(mergeMetadata.numRows());
+
             return new MergeResult(mergedWriterFileSetMap, rowIdMapping);
 
         } catch (Exception exception) {
+            stats.incMergeFailures();
+            long elapsed = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
+            stats.addMergeTimeMillis(elapsed);
             logger.error(() -> new ParameterizedMessage("Merge failed while creating merged file [{}]", mergedFilePath), exception);
             try {
                 Files.deleteIfExists(mergedFilePath);

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/merge/NativeParquetMergeStrategy.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/merge/NativeParquetMergeStrategy.java
@@ -118,6 +118,10 @@ public class NativeParquetMergeStrategy implements ParquetMergeStrategy {
             stats.addMergeTimeMillis(elapsed);
             stats.addMergeInputFilesTotal(filePaths.size());
             stats.addMergeOutputRowsTotal(mergeMetadata.numRows());
+            // Per-shard merge metrics forwarded from native: chunk count + time + row_id max.
+            stats.addFlushAndSortChunkTotal(merged.flushAndSortChunkCount());
+            stats.addFlushAndSortChunkTimeMillis(merged.flushAndSortChunkTimeMs());
+            stats.updateRowIdMappingMax(merged.rowIdMappingMax());
 
             return new MergeResult(mergedWriterFileSetMap, rowIdMapping);
 

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/stats/ParquetNativeRuntimeStats.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/stats/ParquetNativeRuntimeStats.java
@@ -33,12 +33,14 @@ import java.io.IOException;
 public final class ParquetNativeRuntimeStats implements Writeable, ToXContentFragment {
 
     /** Number of long values in the FFM array returned by {@code RustBridge.collectRuntimeMetrics()}. */
-    public static final int FIELD_COUNT = 11;
+    public static final int FIELD_COUNT = 17;
 
     // Rayon merge pool state
     private final long rayonConfiguredThreads;
     private final long rayonMergeTasksSubmitted;
+    private final long rayonMergeTasksStarted;
     private final long rayonMergeTasksCompleted;
+    private final long rayonMergeTasksFailed;
     private final long rayonMergeTasksPanicked;
     private final long rayonMergeWallMillis;
 
@@ -47,31 +49,47 @@ public final class ParquetNativeRuntimeStats implements Writeable, ToXContentFra
     private final long tokioNumBlockingThreads;
     private final long tokioActiveTasks;
     private final long tokioGlobalQueueDepth;
+    private final long tokioBlockingQueueDepth;
+    private final long tokioLocalQueueDepthTotal;
+    private final long tokioPollsCountTotal;
+    private final long tokioOverflowCountTotal;
     private final long tokioSpawnedTasksTotal;
     private final long tokioWorkersBusyMillisTotal;
 
     public ParquetNativeRuntimeStats(
         long rayonConfiguredThreads,
         long rayonMergeTasksSubmitted,
+        long rayonMergeTasksStarted,
         long rayonMergeTasksCompleted,
+        long rayonMergeTasksFailed,
         long rayonMergeTasksPanicked,
         long rayonMergeWallMillis,
         long tokioNumWorkers,
         long tokioNumBlockingThreads,
         long tokioActiveTasks,
         long tokioGlobalQueueDepth,
+        long tokioBlockingQueueDepth,
+        long tokioLocalQueueDepthTotal,
+        long tokioPollsCountTotal,
+        long tokioOverflowCountTotal,
         long tokioSpawnedTasksTotal,
         long tokioWorkersBusyMillisTotal
     ) {
         this.rayonConfiguredThreads = rayonConfiguredThreads;
         this.rayonMergeTasksSubmitted = rayonMergeTasksSubmitted;
+        this.rayonMergeTasksStarted = rayonMergeTasksStarted;
         this.rayonMergeTasksCompleted = rayonMergeTasksCompleted;
+        this.rayonMergeTasksFailed = rayonMergeTasksFailed;
         this.rayonMergeTasksPanicked = rayonMergeTasksPanicked;
         this.rayonMergeWallMillis = rayonMergeWallMillis;
         this.tokioNumWorkers = tokioNumWorkers;
         this.tokioNumBlockingThreads = tokioNumBlockingThreads;
         this.tokioActiveTasks = tokioActiveTasks;
         this.tokioGlobalQueueDepth = tokioGlobalQueueDepth;
+        this.tokioBlockingQueueDepth = tokioBlockingQueueDepth;
+        this.tokioLocalQueueDepthTotal = tokioLocalQueueDepthTotal;
+        this.tokioPollsCountTotal = tokioPollsCountTotal;
+        this.tokioOverflowCountTotal = tokioOverflowCountTotal;
         this.tokioSpawnedTasksTotal = tokioSpawnedTasksTotal;
         this.tokioWorkersBusyMillisTotal = tokioWorkersBusyMillisTotal;
     }
@@ -79,13 +97,19 @@ public final class ParquetNativeRuntimeStats implements Writeable, ToXContentFra
     public ParquetNativeRuntimeStats(StreamInput in) throws IOException {
         this.rayonConfiguredThreads = in.readVLong();
         this.rayonMergeTasksSubmitted = in.readVLong();
+        this.rayonMergeTasksStarted = in.readVLong();
         this.rayonMergeTasksCompleted = in.readVLong();
+        this.rayonMergeTasksFailed = in.readVLong();
         this.rayonMergeTasksPanicked = in.readVLong();
         this.rayonMergeWallMillis = in.readVLong();
         this.tokioNumWorkers = in.readVLong();
         this.tokioNumBlockingThreads = in.readVLong();
         this.tokioActiveTasks = in.readVLong();
         this.tokioGlobalQueueDepth = in.readVLong();
+        this.tokioBlockingQueueDepth = in.readVLong();
+        this.tokioLocalQueueDepthTotal = in.readVLong();
+        this.tokioPollsCountTotal = in.readVLong();
+        this.tokioOverflowCountTotal = in.readVLong();
         this.tokioSpawnedTasksTotal = in.readVLong();
         this.tokioWorkersBusyMillisTotal = in.readVLong();
     }
@@ -94,13 +118,19 @@ public final class ParquetNativeRuntimeStats implements Writeable, ToXContentFra
     public void writeTo(StreamOutput out) throws IOException {
         out.writeVLong(rayonConfiguredThreads);
         out.writeVLong(rayonMergeTasksSubmitted);
+        out.writeVLong(rayonMergeTasksStarted);
         out.writeVLong(rayonMergeTasksCompleted);
+        out.writeVLong(rayonMergeTasksFailed);
         out.writeVLong(rayonMergeTasksPanicked);
         out.writeVLong(rayonMergeWallMillis);
         out.writeVLong(tokioNumWorkers);
         out.writeVLong(tokioNumBlockingThreads);
         out.writeVLong(tokioActiveTasks);
         out.writeVLong(tokioGlobalQueueDepth);
+        out.writeVLong(tokioBlockingQueueDepth);
+        out.writeVLong(tokioLocalQueueDepthTotal);
+        out.writeVLong(tokioPollsCountTotal);
+        out.writeVLong(tokioOverflowCountTotal);
         out.writeVLong(tokioSpawnedTasksTotal);
         out.writeVLong(tokioWorkersBusyMillisTotal);
     }
@@ -108,18 +138,32 @@ public final class ParquetNativeRuntimeStats implements Writeable, ToXContentFra
     @Override
     public XContentBuilder toXContent(XContentBuilder b, Params p) throws IOException {
         b.startObject("native_runtime");
-        b.startObject("rayon");
+        b.startObject("parquet_merge");
         b.field("configured_threads", rayonConfiguredThreads);
         b.field("merge_tasks_submitted", rayonMergeTasksSubmitted);
+        b.field("merge_tasks_started", rayonMergeTasksStarted);
         b.field("merge_tasks_completed", rayonMergeTasksCompleted);
+        b.field("merge_tasks_failed", rayonMergeTasksFailed);
         b.field("merge_tasks_panicked", rayonMergeTasksPanicked);
         b.field("merge_wall_millis", rayonMergeWallMillis);
+        // Derived: tasks queued but not yet picked up by a worker.
+        // Clamped to 0 to handle racy reads where started briefly exceeds submitted.
+        b.field("merge_tasks_queue_depth", Math.max(0L, rayonMergeTasksSubmitted - rayonMergeTasksStarted));
+        // Derived: tasks currently executing (started but not yet completed/failed/panicked).
+        b.field(
+            "merge_tasks_in_flight",
+            Math.max(0L, rayonMergeTasksStarted - rayonMergeTasksCompleted - rayonMergeTasksFailed - rayonMergeTasksPanicked)
+        );
         b.endObject();
-        b.startObject("tokio");
+        b.startObject("parquet_io");
         b.field("num_workers", tokioNumWorkers);
         b.field("num_blocking_threads", tokioNumBlockingThreads);
         b.field("active_tasks", tokioActiveTasks);
         b.field("global_queue_depth", tokioGlobalQueueDepth);
+        b.field("blocking_queue_depth", tokioBlockingQueueDepth);
+        b.field("local_queue_depth_total", tokioLocalQueueDepthTotal);
+        b.field("polls_count_total", tokioPollsCountTotal);
+        b.field("overflow_count_total", tokioOverflowCountTotal);
         b.field("spawned_tasks_total", tokioSpawnedTasksTotal);
         b.field("workers_busy_millis_total", tokioWorkersBusyMillisTotal);
         b.endObject();
@@ -133,15 +177,21 @@ public final class ParquetNativeRuntimeStats implements Writeable, ToXContentFra
      * <pre>
      *   [0]  rayon_configured_threads
      *   [1]  rayon_merge_tasks_submitted
-     *   [2]  rayon_merge_tasks_completed
-     *   [3]  rayon_merge_tasks_panicked
-     *   [4]  rayon_merge_wall_millis
-     *   [5]  tokio_num_workers
-     *   [6]  tokio_num_blocking_threads
-     *   [7]  tokio_active_tasks
-     *   [8]  tokio_global_queue_depth
-     *   [9]  tokio_spawned_tasks_total
-     *   [10] tokio_workers_busy_millis_total
+     *   [2]  rayon_merge_tasks_started
+     *   [3]  rayon_merge_tasks_completed
+     *   [4]  rayon_merge_tasks_failed
+     *   [5]  rayon_merge_tasks_panicked
+     *   [6]  rayon_merge_wall_millis
+     *   [7]  tokio_num_workers
+     *   [8]  tokio_num_blocking_threads
+     *   [9]  tokio_active_tasks
+     *   [10] tokio_global_queue_depth
+     *   [11] tokio_blocking_queue_depth
+     *   [12] tokio_local_queue_depth_total
+     *   [13] tokio_polls_count_total
+     *   [14] tokio_overflow_count_total
+     *   [15] tokio_spawned_tasks_total
+     *   [16] tokio_workers_busy_millis_total
      * </pre>
      */
     public static ParquetNativeRuntimeStats fromArray(long[] arr) {
@@ -153,7 +203,25 @@ public final class ParquetNativeRuntimeStats implements Writeable, ToXContentFra
                     + (arr == null ? "null" : Integer.toString(arr.length))
             );
         }
-        return new ParquetNativeRuntimeStats(arr[0], arr[1], arr[2], arr[3], arr[4], arr[5], arr[6], arr[7], arr[8], arr[9], arr[10]);
+        return new ParquetNativeRuntimeStats(
+            arr[0],
+            arr[1],
+            arr[2],
+            arr[3],
+            arr[4],
+            arr[5],
+            arr[6],
+            arr[7],
+            arr[8],
+            arr[9],
+            arr[10],
+            arr[11],
+            arr[12],
+            arr[13],
+            arr[14],
+            arr[15],
+            arr[16]
+        );
     }
 
 }

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/stats/ParquetNativeRuntimeStats.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/stats/ParquetNativeRuntimeStats.java
@@ -23,9 +23,16 @@ import java.io.IOException;
  * (never on individual shard trackers) and dropped during cross-node aggregation
  * so it never appears in cluster-wide /{idx}/_stats responses.
  *
- * <p>The wire format encodes 11 values via {@link #FIELD_COUNT}; the JNI bridge in
+ * <p>The wire format encodes {@value #FIELD_COUNT} values; the JNI bridge in
  * {@link org.opensearch.parquet.bridge.RustBridge#collectRuntimeMetrics()} returns
  * an array of the same length in the order documented in {@link #fromArray}.
+ *
+ * <p><b>parquet_merge.merge_tasks_failed</b> counts logical errors that occur INSIDE
+ * the rayon-wrapped column-encoding pass only. Logical errors that occur before this
+ * wrapper runs (FFM bridge throws, Java-side validation fails, IO task panics, etc.)
+ * increment the per-shard {@code parquet.merge.merge_failures} counter but NOT
+ * {@code merge_tasks_failed}. The two populations overlap but intentionally measure
+ * different scopes — they are not expected to be equal.
  *
  * @opensearch.experimental
  */

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/stats/ParquetNativeRuntimeStats.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/stats/ParquetNativeRuntimeStats.java
@@ -1,0 +1,159 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.parquet.stats;
+
+import org.opensearch.common.annotation.ExperimentalApi;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.common.io.stream.Writeable;
+import org.opensearch.core.xcontent.ToXContentFragment;
+import org.opensearch.core.xcontent.XContentBuilder;
+
+import java.io.IOException;
+
+/**
+ * Process-wide native runtime metrics for the parquet merge path: rayon thread pool
+ * usage and tokio IO runtime state. Populated only at the per-node aggregate scope
+ * (never on individual shard trackers) and dropped during cross-node aggregation
+ * so it never appears in cluster-wide /{idx}/_stats responses.
+ *
+ * <p>The wire format encodes 11 values via {@link #FIELD_COUNT}; the JNI bridge in
+ * {@link org.opensearch.parquet.bridge.RustBridge#collectRuntimeMetrics()} returns
+ * an array of the same length in the order documented in {@link #fromArray}.
+ *
+ * @opensearch.experimental
+ */
+@ExperimentalApi
+public final class ParquetNativeRuntimeStats implements Writeable, ToXContentFragment {
+
+    /** Number of long values in the FFM array returned by {@code RustBridge.collectRuntimeMetrics()}. */
+    public static final int FIELD_COUNT = 11;
+
+    // Rayon merge pool state
+    private final long rayonConfiguredThreads;
+    private final long rayonMergeTasksSubmitted;
+    private final long rayonMergeTasksCompleted;
+    private final long rayonMergeTasksPanicked;
+    private final long rayonMergeWallMillis;
+
+    // Tokio IO runtime state
+    private final long tokioNumWorkers;
+    private final long tokioNumBlockingThreads;
+    private final long tokioActiveTasks;
+    private final long tokioGlobalQueueDepth;
+    private final long tokioSpawnedTasksTotal;
+    private final long tokioWorkersBusyMillisTotal;
+
+    public ParquetNativeRuntimeStats(
+        long rayonConfiguredThreads,
+        long rayonMergeTasksSubmitted,
+        long rayonMergeTasksCompleted,
+        long rayonMergeTasksPanicked,
+        long rayonMergeWallMillis,
+        long tokioNumWorkers,
+        long tokioNumBlockingThreads,
+        long tokioActiveTasks,
+        long tokioGlobalQueueDepth,
+        long tokioSpawnedTasksTotal,
+        long tokioWorkersBusyMillisTotal
+    ) {
+        this.rayonConfiguredThreads = rayonConfiguredThreads;
+        this.rayonMergeTasksSubmitted = rayonMergeTasksSubmitted;
+        this.rayonMergeTasksCompleted = rayonMergeTasksCompleted;
+        this.rayonMergeTasksPanicked = rayonMergeTasksPanicked;
+        this.rayonMergeWallMillis = rayonMergeWallMillis;
+        this.tokioNumWorkers = tokioNumWorkers;
+        this.tokioNumBlockingThreads = tokioNumBlockingThreads;
+        this.tokioActiveTasks = tokioActiveTasks;
+        this.tokioGlobalQueueDepth = tokioGlobalQueueDepth;
+        this.tokioSpawnedTasksTotal = tokioSpawnedTasksTotal;
+        this.tokioWorkersBusyMillisTotal = tokioWorkersBusyMillisTotal;
+    }
+
+    public ParquetNativeRuntimeStats(StreamInput in) throws IOException {
+        this.rayonConfiguredThreads = in.readVLong();
+        this.rayonMergeTasksSubmitted = in.readVLong();
+        this.rayonMergeTasksCompleted = in.readVLong();
+        this.rayonMergeTasksPanicked = in.readVLong();
+        this.rayonMergeWallMillis = in.readVLong();
+        this.tokioNumWorkers = in.readVLong();
+        this.tokioNumBlockingThreads = in.readVLong();
+        this.tokioActiveTasks = in.readVLong();
+        this.tokioGlobalQueueDepth = in.readVLong();
+        this.tokioSpawnedTasksTotal = in.readVLong();
+        this.tokioWorkersBusyMillisTotal = in.readVLong();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeVLong(rayonConfiguredThreads);
+        out.writeVLong(rayonMergeTasksSubmitted);
+        out.writeVLong(rayonMergeTasksCompleted);
+        out.writeVLong(rayonMergeTasksPanicked);
+        out.writeVLong(rayonMergeWallMillis);
+        out.writeVLong(tokioNumWorkers);
+        out.writeVLong(tokioNumBlockingThreads);
+        out.writeVLong(tokioActiveTasks);
+        out.writeVLong(tokioGlobalQueueDepth);
+        out.writeVLong(tokioSpawnedTasksTotal);
+        out.writeVLong(tokioWorkersBusyMillisTotal);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder b, Params p) throws IOException {
+        b.startObject("native_runtime");
+        b.startObject("rayon");
+        b.field("configured_threads", rayonConfiguredThreads);
+        b.field("merge_tasks_submitted", rayonMergeTasksSubmitted);
+        b.field("merge_tasks_completed", rayonMergeTasksCompleted);
+        b.field("merge_tasks_panicked", rayonMergeTasksPanicked);
+        b.field("merge_wall_millis", rayonMergeWallMillis);
+        b.endObject();
+        b.startObject("tokio");
+        b.field("num_workers", tokioNumWorkers);
+        b.field("num_blocking_threads", tokioNumBlockingThreads);
+        b.field("active_tasks", tokioActiveTasks);
+        b.field("global_queue_depth", tokioGlobalQueueDepth);
+        b.field("spawned_tasks_total", tokioSpawnedTasksTotal);
+        b.field("workers_busy_millis_total", tokioWorkersBusyMillisTotal);
+        b.endObject();
+        b.endObject();
+        return b;
+    }
+
+    /**
+     * Builds an instance from the {@link #FIELD_COUNT}-element long array returned by
+     * {@code RustBridge.collectRuntimeMetrics()}, in order:
+     * <pre>
+     *   [0]  rayon_configured_threads
+     *   [1]  rayon_merge_tasks_submitted
+     *   [2]  rayon_merge_tasks_completed
+     *   [3]  rayon_merge_tasks_panicked
+     *   [4]  rayon_merge_wall_millis
+     *   [5]  tokio_num_workers
+     *   [6]  tokio_num_blocking_threads
+     *   [7]  tokio_active_tasks
+     *   [8]  tokio_global_queue_depth
+     *   [9]  tokio_spawned_tasks_total
+     *   [10] tokio_workers_busy_millis_total
+     * </pre>
+     */
+    public static ParquetNativeRuntimeStats fromArray(long[] arr) {
+        if (arr == null || arr.length < FIELD_COUNT) {
+            throw new IllegalArgumentException(
+                "native runtime stats array must have at least "
+                    + FIELD_COUNT
+                    + " elements, got: "
+                    + (arr == null ? "null" : Integer.toString(arr.length))
+            );
+        }
+        return new ParquetNativeRuntimeStats(arr[0], arr[1], arr[2], arr[3], arr[4], arr[5], arr[6], arr[7], arr[8], arr[9], arr[10]);
+    }
+
+}

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/stats/ParquetShardStats.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/stats/ParquetShardStats.java
@@ -53,6 +53,11 @@ public class ParquetShardStats implements DataFormatShardStats<ParquetShardStats
     private final long mergeFailures;
     private final long mergeInputFilesTotal;
     private final long mergeOutputRowsTotal;
+    // Per-merge: cumulative count + millis for the flush+sort+chunk pass that runs inside each merge.
+    private final long flushAndSortChunkTotal;
+    private final long flushAndSortChunkTimeMillis;
+    // Highest row_id assigned during any merge of this shard (max-of-maxes when cross-aggregated).
+    private final long rowIdMappingMax;
 
     // Background Write
     private final long backgroundWriteTotal;
@@ -69,7 +74,7 @@ public class ParquetShardStats implements DataFormatShardStats<ParquetShardStats
      * Used by transport actions when a shard does not have a Parquet primary delegate.
      */
     public static ParquetShardStats empty() {
-        return new ParquetShardStats(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+        return new ParquetShardStats(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
     }
 
     /**
@@ -93,6 +98,9 @@ public class ParquetShardStats implements DataFormatShardStats<ParquetShardStats
         long mergeFailures,
         long mergeInputFilesTotal,
         long mergeOutputRowsTotal,
+        long flushAndSortChunkTotal,
+        long flushAndSortChunkTimeMillis,
+        long rowIdMappingMax,
         long backgroundWriteTotal,
         long backgroundWriteWaitMillis,
         long backgroundWriteTimeouts,
@@ -116,6 +124,9 @@ public class ParquetShardStats implements DataFormatShardStats<ParquetShardStats
             mergeFailures,
             mergeInputFilesTotal,
             mergeOutputRowsTotal,
+            flushAndSortChunkTotal,
+            flushAndSortChunkTimeMillis,
+            rowIdMappingMax,
             backgroundWriteTotal,
             backgroundWriteWaitMillis,
             backgroundWriteTimeouts,
@@ -145,6 +156,9 @@ public class ParquetShardStats implements DataFormatShardStats<ParquetShardStats
         long mergeFailures,
         long mergeInputFilesTotal,
         long mergeOutputRowsTotal,
+        long flushAndSortChunkTotal,
+        long flushAndSortChunkTimeMillis,
+        long rowIdMappingMax,
         long backgroundWriteTotal,
         long backgroundWriteWaitMillis,
         long backgroundWriteTimeouts,
@@ -168,6 +182,9 @@ public class ParquetShardStats implements DataFormatShardStats<ParquetShardStats
         this.mergeFailures = mergeFailures;
         this.mergeInputFilesTotal = mergeInputFilesTotal;
         this.mergeOutputRowsTotal = mergeOutputRowsTotal;
+        this.flushAndSortChunkTotal = flushAndSortChunkTotal;
+        this.flushAndSortChunkTimeMillis = flushAndSortChunkTimeMillis;
+        this.rowIdMappingMax = rowIdMappingMax;
         this.backgroundWriteTotal = backgroundWriteTotal;
         this.backgroundWriteWaitMillis = backgroundWriteWaitMillis;
         this.backgroundWriteTimeouts = backgroundWriteTimeouts;
@@ -200,6 +217,9 @@ public class ParquetShardStats implements DataFormatShardStats<ParquetShardStats
         this.mergeFailures = in.readVLong();
         this.mergeInputFilesTotal = in.readVLong();
         this.mergeOutputRowsTotal = in.readVLong();
+        this.flushAndSortChunkTotal = in.readVLong();
+        this.flushAndSortChunkTimeMillis = in.readVLong();
+        this.rowIdMappingMax = in.readVLong();
 
         // Background Write
         this.backgroundWriteTotal = in.readVLong();
@@ -237,6 +257,9 @@ public class ParquetShardStats implements DataFormatShardStats<ParquetShardStats
         out.writeVLong(mergeFailures);
         out.writeVLong(mergeInputFilesTotal);
         out.writeVLong(mergeOutputRowsTotal);
+        out.writeVLong(flushAndSortChunkTotal);
+        out.writeVLong(flushAndSortChunkTimeMillis);
+        out.writeVLong(rowIdMappingMax);
 
         // Background Write
         out.writeVLong(backgroundWriteTotal);
@@ -281,6 +304,9 @@ public class ParquetShardStats implements DataFormatShardStats<ParquetShardStats
         builder.field("merge_failures", mergeFailures);
         builder.field("merge_input_files_total", mergeInputFilesTotal);
         builder.field("merge_output_rows_total", mergeOutputRowsTotal);
+        builder.field("flush_and_sort_chunk_total", flushAndSortChunkTotal);
+        builder.field("flush_and_sort_chunk_time_millis", flushAndSortChunkTimeMillis);
+        builder.field("row_id_mapping_max", rowIdMappingMax);
         builder.endObject();
 
         // Background Write
@@ -323,6 +349,10 @@ public class ParquetShardStats implements DataFormatShardStats<ParquetShardStats
             this.mergeFailures + other.mergeFailures,
             this.mergeInputFilesTotal + other.mergeInputFilesTotal,
             this.mergeOutputRowsTotal + other.mergeOutputRowsTotal,
+            this.flushAndSortChunkTotal + other.flushAndSortChunkTotal,
+            this.flushAndSortChunkTimeMillis + other.flushAndSortChunkTimeMillis,
+            // row_id_mapping_max composes as max-of-maxes (sum is meaningless for a max).
+            Math.max(this.rowIdMappingMax, other.rowIdMappingMax),
             this.backgroundWriteTotal + other.backgroundWriteTotal,
             this.backgroundWriteWaitMillis + other.backgroundWriteWaitMillis,
             this.backgroundWriteTimeouts + other.backgroundWriteTimeouts,
@@ -354,6 +384,9 @@ public class ParquetShardStats implements DataFormatShardStats<ParquetShardStats
             mergeFailures,
             mergeInputFilesTotal,
             mergeOutputRowsTotal,
+            flushAndSortChunkTotal,
+            flushAndSortChunkTimeMillis,
+            rowIdMappingMax,
             backgroundWriteTotal,
             backgroundWriteWaitMillis,
             backgroundWriteTimeouts,

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/stats/ParquetShardStats.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/stats/ParquetShardStats.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.parquet.stats;
 
+import org.opensearch.common.Nullable;
 import org.opensearch.common.annotation.ExperimentalApi;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
@@ -59,6 +60,10 @@ public class ParquetShardStats implements DataFormatShardStats<ParquetShardStats
     private final long backgroundWriteTimeouts;
     private final long backgroundWriteFailures;
 
+    // Native Runtime (node-level only, null on shard trackers and cross-node aggregation)
+    @Nullable
+    private final ParquetNativeRuntimeStats nativeRuntime;
+
     /**
      * Returns an empty ParquetShardStats snapshot with all zero counters.
      * Used by transport actions when a shard does not have a Parquet primary delegate.
@@ -93,6 +98,59 @@ public class ParquetShardStats implements DataFormatShardStats<ParquetShardStats
         long backgroundWriteTimeouts,
         long backgroundWriteFailures
     ) {
+        this(
+            docsIndexedTotal,
+            indexTimeMillis,
+            vsrRotationsTotal,
+            nativeWriteTotal,
+            nativeWriteTimeMillis,
+            nativeWriteFailures,
+            nativeFinalizeTotal,
+            nativeFinalizeTimeMillis,
+            nativeFinalizeFailures,
+            nativeSyncTotal,
+            nativeSyncTimeMillis,
+            nativeSyncFailures,
+            mergeTotal,
+            mergeTimeMillis,
+            mergeFailures,
+            mergeInputFilesTotal,
+            mergeOutputRowsTotal,
+            backgroundWriteTotal,
+            backgroundWriteWaitMillis,
+            backgroundWriteTimeouts,
+            backgroundWriteFailures,
+            null
+        );
+    }
+
+    /**
+     * Constructs a snapshot with all values including optional native runtime stats.
+     */
+    public ParquetShardStats(
+        long docsIndexedTotal,
+        long indexTimeMillis,
+        long vsrRotationsTotal,
+        long nativeWriteTotal,
+        long nativeWriteTimeMillis,
+        long nativeWriteFailures,
+        long nativeFinalizeTotal,
+        long nativeFinalizeTimeMillis,
+        long nativeFinalizeFailures,
+        long nativeSyncTotal,
+        long nativeSyncTimeMillis,
+        long nativeSyncFailures,
+        long mergeTotal,
+        long mergeTimeMillis,
+        long mergeFailures,
+        long mergeInputFilesTotal,
+        long mergeOutputRowsTotal,
+        long backgroundWriteTotal,
+        long backgroundWriteWaitMillis,
+        long backgroundWriteTimeouts,
+        long backgroundWriteFailures,
+        @Nullable ParquetNativeRuntimeStats nativeRuntime
+    ) {
         this.docsIndexedTotal = docsIndexedTotal;
         this.indexTimeMillis = indexTimeMillis;
         this.vsrRotationsTotal = vsrRotationsTotal;
@@ -114,6 +172,7 @@ public class ParquetShardStats implements DataFormatShardStats<ParquetShardStats
         this.backgroundWriteWaitMillis = backgroundWriteWaitMillis;
         this.backgroundWriteTimeouts = backgroundWriteTimeouts;
         this.backgroundWriteFailures = backgroundWriteFailures;
+        this.nativeRuntime = nativeRuntime;
     }
 
     public ParquetShardStats(StreamInput in) throws IOException {
@@ -147,6 +206,9 @@ public class ParquetShardStats implements DataFormatShardStats<ParquetShardStats
         this.backgroundWriteWaitMillis = in.readVLong();
         this.backgroundWriteTimeouts = in.readVLong();
         this.backgroundWriteFailures = in.readVLong();
+
+        // Native Runtime
+        this.nativeRuntime = in.readOptionalWriteable(ParquetNativeRuntimeStats::new);
     }
 
     @Override
@@ -181,6 +243,9 @@ public class ParquetShardStats implements DataFormatShardStats<ParquetShardStats
         out.writeVLong(backgroundWriteWaitMillis);
         out.writeVLong(backgroundWriteTimeouts);
         out.writeVLong(backgroundWriteFailures);
+
+        // Native Runtime
+        out.writeOptionalWriteable(nativeRuntime);
     }
 
     @Override
@@ -226,6 +291,11 @@ public class ParquetShardStats implements DataFormatShardStats<ParquetShardStats
         builder.field("background_write_failures", backgroundWriteFailures);
         builder.endObject();
 
+        // Native Runtime (only present at node-level aggregate)
+        if (nativeRuntime != null) {
+            nativeRuntime.toXContent(builder, params);
+        }
+
         return builder;
     }
 
@@ -256,7 +326,39 @@ public class ParquetShardStats implements DataFormatShardStats<ParquetShardStats
             this.backgroundWriteTotal + other.backgroundWriteTotal,
             this.backgroundWriteWaitMillis + other.backgroundWriteWaitMillis,
             this.backgroundWriteTimeouts + other.backgroundWriteTimeouts,
-            this.backgroundWriteFailures + other.backgroundWriteFailures
+            this.backgroundWriteFailures + other.backgroundWriteFailures,
+            null  // drop nativeRuntime on cross-node aggregation
+        );
+    }
+
+    /**
+     * Returns a copy of this with the given native runtime stats attached. Used by
+     * {@link ParquetStatsProvider} to attach per-node runtime stats to the aggregated value.
+     */
+    public ParquetShardStats withNativeRuntime(ParquetNativeRuntimeStats runtime) {
+        return new ParquetShardStats(
+            docsIndexedTotal,
+            indexTimeMillis,
+            vsrRotationsTotal,
+            nativeWriteTotal,
+            nativeWriteTimeMillis,
+            nativeWriteFailures,
+            nativeFinalizeTotal,
+            nativeFinalizeTimeMillis,
+            nativeFinalizeFailures,
+            nativeSyncTotal,
+            nativeSyncTimeMillis,
+            nativeSyncFailures,
+            mergeTotal,
+            mergeTimeMillis,
+            mergeFailures,
+            mergeInputFilesTotal,
+            mergeOutputRowsTotal,
+            backgroundWriteTotal,
+            backgroundWriteWaitMillis,
+            backgroundWriteTimeouts,
+            backgroundWriteFailures,
+            runtime
         );
     }
 }

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/stats/ParquetShardStats.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/stats/ParquetShardStats.java
@@ -1,0 +1,262 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.parquet.stats;
+
+import org.opensearch.common.annotation.ExperimentalApi;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.common.io.stream.Writeable;
+import org.opensearch.core.xcontent.ToXContentFragment;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.plugin.stats.DataFormatShardStats;
+
+import java.io.IOException;
+
+/**
+ * Immutable point-in-time snapshot of shard-level Parquet statistics.
+ * Produced by {@link ParquetShardStatsTracker#stats()}.
+ * Supports serialization via {@link Writeable} and REST rendering via {@link ToXContentFragment}.
+ *
+ * @opensearch.experimental
+ */
+@ExperimentalApi
+public class ParquetShardStats implements DataFormatShardStats<ParquetShardStats> {
+
+    // Indexing
+    private final long docsIndexedTotal;
+    private final long indexTimeMillis;
+
+    // VSR Pipeline
+    private final long vsrRotationsTotal;
+
+    // Native Write
+    private final long nativeWriteTotal;
+    private final long nativeWriteTimeMillis;
+    private final long nativeWriteFailures;
+    private final long nativeFinalizeTotal;
+    private final long nativeFinalizeTimeMillis;
+    private final long nativeFinalizeFailures;
+    private final long nativeSyncTotal;
+    private final long nativeSyncTimeMillis;
+    private final long nativeSyncFailures;
+
+    // Merge
+    private final long mergeTotal;
+    private final long mergeTimeMillis;
+    private final long mergeFailures;
+    private final long mergeInputFilesTotal;
+    private final long mergeOutputRowsTotal;
+
+    // Background Write
+    private final long backgroundWriteTotal;
+    private final long backgroundWriteWaitMillis;
+    private final long backgroundWriteTimeouts;
+    private final long backgroundWriteFailures;
+
+    /**
+     * Returns an empty ParquetShardStats snapshot with all zero counters.
+     * Used by transport actions when a shard does not have a Parquet primary delegate.
+     */
+    public static ParquetShardStats empty() {
+        return new ParquetShardStats(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+    }
+
+    /**
+     * Constructs a snapshot with all values.
+     */
+    public ParquetShardStats(
+        long docsIndexedTotal,
+        long indexTimeMillis,
+        long vsrRotationsTotal,
+        long nativeWriteTotal,
+        long nativeWriteTimeMillis,
+        long nativeWriteFailures,
+        long nativeFinalizeTotal,
+        long nativeFinalizeTimeMillis,
+        long nativeFinalizeFailures,
+        long nativeSyncTotal,
+        long nativeSyncTimeMillis,
+        long nativeSyncFailures,
+        long mergeTotal,
+        long mergeTimeMillis,
+        long mergeFailures,
+        long mergeInputFilesTotal,
+        long mergeOutputRowsTotal,
+        long backgroundWriteTotal,
+        long backgroundWriteWaitMillis,
+        long backgroundWriteTimeouts,
+        long backgroundWriteFailures
+    ) {
+        this.docsIndexedTotal = docsIndexedTotal;
+        this.indexTimeMillis = indexTimeMillis;
+        this.vsrRotationsTotal = vsrRotationsTotal;
+        this.nativeWriteTotal = nativeWriteTotal;
+        this.nativeWriteTimeMillis = nativeWriteTimeMillis;
+        this.nativeWriteFailures = nativeWriteFailures;
+        this.nativeFinalizeTotal = nativeFinalizeTotal;
+        this.nativeFinalizeTimeMillis = nativeFinalizeTimeMillis;
+        this.nativeFinalizeFailures = nativeFinalizeFailures;
+        this.nativeSyncTotal = nativeSyncTotal;
+        this.nativeSyncTimeMillis = nativeSyncTimeMillis;
+        this.nativeSyncFailures = nativeSyncFailures;
+        this.mergeTotal = mergeTotal;
+        this.mergeTimeMillis = mergeTimeMillis;
+        this.mergeFailures = mergeFailures;
+        this.mergeInputFilesTotal = mergeInputFilesTotal;
+        this.mergeOutputRowsTotal = mergeOutputRowsTotal;
+        this.backgroundWriteTotal = backgroundWriteTotal;
+        this.backgroundWriteWaitMillis = backgroundWriteWaitMillis;
+        this.backgroundWriteTimeouts = backgroundWriteTimeouts;
+        this.backgroundWriteFailures = backgroundWriteFailures;
+    }
+
+    public ParquetShardStats(StreamInput in) throws IOException {
+        // Indexing
+        this.docsIndexedTotal = in.readVLong();
+        this.indexTimeMillis = in.readVLong();
+
+        // VSR
+        this.vsrRotationsTotal = in.readVLong();
+
+        // Native Write
+        this.nativeWriteTotal = in.readVLong();
+        this.nativeWriteTimeMillis = in.readVLong();
+        this.nativeWriteFailures = in.readVLong();
+        this.nativeFinalizeTotal = in.readVLong();
+        this.nativeFinalizeTimeMillis = in.readVLong();
+        this.nativeFinalizeFailures = in.readVLong();
+        this.nativeSyncTotal = in.readVLong();
+        this.nativeSyncTimeMillis = in.readVLong();
+        this.nativeSyncFailures = in.readVLong();
+
+        // Merge
+        this.mergeTotal = in.readVLong();
+        this.mergeTimeMillis = in.readVLong();
+        this.mergeFailures = in.readVLong();
+        this.mergeInputFilesTotal = in.readVLong();
+        this.mergeOutputRowsTotal = in.readVLong();
+
+        // Background Write
+        this.backgroundWriteTotal = in.readVLong();
+        this.backgroundWriteWaitMillis = in.readVLong();
+        this.backgroundWriteTimeouts = in.readVLong();
+        this.backgroundWriteFailures = in.readVLong();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        // Indexing
+        out.writeVLong(docsIndexedTotal);
+        out.writeVLong(indexTimeMillis);
+
+        // VSR
+        out.writeVLong(vsrRotationsTotal);
+
+        // Native Write
+        out.writeVLong(nativeWriteTotal);
+        out.writeVLong(nativeWriteTimeMillis);
+        out.writeVLong(nativeWriteFailures);
+        out.writeVLong(nativeFinalizeTotal);
+        out.writeVLong(nativeFinalizeTimeMillis);
+        out.writeVLong(nativeFinalizeFailures);
+        out.writeVLong(nativeSyncTotal);
+        out.writeVLong(nativeSyncTimeMillis);
+        out.writeVLong(nativeSyncFailures);
+
+        // Merge
+        out.writeVLong(mergeTotal);
+        out.writeVLong(mergeTimeMillis);
+        out.writeVLong(mergeFailures);
+        out.writeVLong(mergeInputFilesTotal);
+        out.writeVLong(mergeOutputRowsTotal);
+
+        // Background Write
+        out.writeVLong(backgroundWriteTotal);
+        out.writeVLong(backgroundWriteWaitMillis);
+        out.writeVLong(backgroundWriteTimeouts);
+        out.writeVLong(backgroundWriteFailures);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        // Indexing
+        builder.startObject("indexing");
+        builder.field("docs_indexed_total", docsIndexedTotal);
+        builder.field("index_time_millis", indexTimeMillis);
+        builder.endObject();
+
+        // VSR
+        builder.startObject("vsr");
+        builder.field("vsr_rotations_total", vsrRotationsTotal);
+        builder.endObject();
+
+        // Native Write
+        builder.startObject("native_write");
+        builder.field("native_write_total", nativeWriteTotal);
+        builder.field("native_write_time_millis", nativeWriteTimeMillis);
+        builder.field("native_write_failures", nativeWriteFailures);
+        builder.field("native_finalize_total", nativeFinalizeTotal);
+        builder.field("native_finalize_time_millis", nativeFinalizeTimeMillis);
+        builder.field("native_finalize_failures", nativeFinalizeFailures);
+        builder.field("native_sync_total", nativeSyncTotal);
+        builder.field("native_sync_time_millis", nativeSyncTimeMillis);
+        builder.field("native_sync_failures", nativeSyncFailures);
+        builder.endObject();
+
+        // Merge
+        builder.startObject("merge");
+        builder.field("merge_total", mergeTotal);
+        builder.field("merge_time_millis", mergeTimeMillis);
+        builder.field("merge_failures", mergeFailures);
+        builder.field("merge_input_files_total", mergeInputFilesTotal);
+        builder.field("merge_output_rows_total", mergeOutputRowsTotal);
+        builder.endObject();
+
+        // Background Write
+        builder.startObject("background_write");
+        builder.field("background_write_total", backgroundWriteTotal);
+        builder.field("background_write_wait_millis", backgroundWriteWaitMillis);
+        builder.field("background_write_timeouts", backgroundWriteTimeouts);
+        builder.field("background_write_failures", backgroundWriteFailures);
+        builder.endObject();
+
+        return builder;
+    }
+
+    /**
+     * Returns a new snapshot that is the sum of this snapshot and another.
+     * Used for aggregation across shards.
+     */
+    @Override
+    public ParquetShardStats add(ParquetShardStats other) {
+        return new ParquetShardStats(
+            this.docsIndexedTotal + other.docsIndexedTotal,
+            this.indexTimeMillis + other.indexTimeMillis,
+            this.vsrRotationsTotal + other.vsrRotationsTotal,
+            this.nativeWriteTotal + other.nativeWriteTotal,
+            this.nativeWriteTimeMillis + other.nativeWriteTimeMillis,
+            this.nativeWriteFailures + other.nativeWriteFailures,
+            this.nativeFinalizeTotal + other.nativeFinalizeTotal,
+            this.nativeFinalizeTimeMillis + other.nativeFinalizeTimeMillis,
+            this.nativeFinalizeFailures + other.nativeFinalizeFailures,
+            this.nativeSyncTotal + other.nativeSyncTotal,
+            this.nativeSyncTimeMillis + other.nativeSyncTimeMillis,
+            this.nativeSyncFailures + other.nativeSyncFailures,
+            this.mergeTotal + other.mergeTotal,
+            this.mergeTimeMillis + other.mergeTimeMillis,
+            this.mergeFailures + other.mergeFailures,
+            this.mergeInputFilesTotal + other.mergeInputFilesTotal,
+            this.mergeOutputRowsTotal + other.mergeOutputRowsTotal,
+            this.backgroundWriteTotal + other.backgroundWriteTotal,
+            this.backgroundWriteWaitMillis + other.backgroundWriteWaitMillis,
+            this.backgroundWriteTimeouts + other.backgroundWriteTimeouts,
+            this.backgroundWriteFailures + other.backgroundWriteFailures
+        );
+    }
+}

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/stats/ParquetShardStats.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/stats/ParquetShardStats.java
@@ -43,9 +43,6 @@ public class ParquetShardStats implements DataFormatShardStats<ParquetShardStats
     private final long nativeFinalizeTotal;
     private final long nativeFinalizeTimeMillis;
     private final long nativeFinalizeFailures;
-    private final long nativeSyncTotal;
-    private final long nativeSyncTimeMillis;
-    private final long nativeSyncFailures;
 
     // Merge
     private final long mergeTotal;
@@ -74,7 +71,7 @@ public class ParquetShardStats implements DataFormatShardStats<ParquetShardStats
      * Used by transport actions when a shard does not have a Parquet primary delegate.
      */
     public static ParquetShardStats empty() {
-        return new ParquetShardStats(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+        return new ParquetShardStats(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
     }
 
     /**
@@ -90,9 +87,6 @@ public class ParquetShardStats implements DataFormatShardStats<ParquetShardStats
         long nativeFinalizeTotal,
         long nativeFinalizeTimeMillis,
         long nativeFinalizeFailures,
-        long nativeSyncTotal,
-        long nativeSyncTimeMillis,
-        long nativeSyncFailures,
         long mergeTotal,
         long mergeTimeMillis,
         long mergeFailures,
@@ -116,9 +110,6 @@ public class ParquetShardStats implements DataFormatShardStats<ParquetShardStats
             nativeFinalizeTotal,
             nativeFinalizeTimeMillis,
             nativeFinalizeFailures,
-            nativeSyncTotal,
-            nativeSyncTimeMillis,
-            nativeSyncFailures,
             mergeTotal,
             mergeTimeMillis,
             mergeFailures,
@@ -148,9 +139,6 @@ public class ParquetShardStats implements DataFormatShardStats<ParquetShardStats
         long nativeFinalizeTotal,
         long nativeFinalizeTimeMillis,
         long nativeFinalizeFailures,
-        long nativeSyncTotal,
-        long nativeSyncTimeMillis,
-        long nativeSyncFailures,
         long mergeTotal,
         long mergeTimeMillis,
         long mergeFailures,
@@ -174,9 +162,6 @@ public class ParquetShardStats implements DataFormatShardStats<ParquetShardStats
         this.nativeFinalizeTotal = nativeFinalizeTotal;
         this.nativeFinalizeTimeMillis = nativeFinalizeTimeMillis;
         this.nativeFinalizeFailures = nativeFinalizeFailures;
-        this.nativeSyncTotal = nativeSyncTotal;
-        this.nativeSyncTimeMillis = nativeSyncTimeMillis;
-        this.nativeSyncFailures = nativeSyncFailures;
         this.mergeTotal = mergeTotal;
         this.mergeTimeMillis = mergeTimeMillis;
         this.mergeFailures = mergeFailures;
@@ -207,9 +192,6 @@ public class ParquetShardStats implements DataFormatShardStats<ParquetShardStats
         this.nativeFinalizeTotal = in.readVLong();
         this.nativeFinalizeTimeMillis = in.readVLong();
         this.nativeFinalizeFailures = in.readVLong();
-        this.nativeSyncTotal = in.readVLong();
-        this.nativeSyncTimeMillis = in.readVLong();
-        this.nativeSyncFailures = in.readVLong();
 
         // Merge
         this.mergeTotal = in.readVLong();
@@ -247,9 +229,6 @@ public class ParquetShardStats implements DataFormatShardStats<ParquetShardStats
         out.writeVLong(nativeFinalizeTotal);
         out.writeVLong(nativeFinalizeTimeMillis);
         out.writeVLong(nativeFinalizeFailures);
-        out.writeVLong(nativeSyncTotal);
-        out.writeVLong(nativeSyncTimeMillis);
-        out.writeVLong(nativeSyncFailures);
 
         // Merge
         out.writeVLong(mergeTotal);
@@ -292,9 +271,6 @@ public class ParquetShardStats implements DataFormatShardStats<ParquetShardStats
         builder.field("native_finalize_total", nativeFinalizeTotal);
         builder.field("native_finalize_time_millis", nativeFinalizeTimeMillis);
         builder.field("native_finalize_failures", nativeFinalizeFailures);
-        builder.field("native_sync_total", nativeSyncTotal);
-        builder.field("native_sync_time_millis", nativeSyncTimeMillis);
-        builder.field("native_sync_failures", nativeSyncFailures);
         builder.endObject();
 
         // Merge
@@ -341,9 +317,6 @@ public class ParquetShardStats implements DataFormatShardStats<ParquetShardStats
             this.nativeFinalizeTotal + other.nativeFinalizeTotal,
             this.nativeFinalizeTimeMillis + other.nativeFinalizeTimeMillis,
             this.nativeFinalizeFailures + other.nativeFinalizeFailures,
-            this.nativeSyncTotal + other.nativeSyncTotal,
-            this.nativeSyncTimeMillis + other.nativeSyncTimeMillis,
-            this.nativeSyncFailures + other.nativeSyncFailures,
             this.mergeTotal + other.mergeTotal,
             this.mergeTimeMillis + other.mergeTimeMillis,
             this.mergeFailures + other.mergeFailures,
@@ -376,9 +349,6 @@ public class ParquetShardStats implements DataFormatShardStats<ParquetShardStats
             nativeFinalizeTotal,
             nativeFinalizeTimeMillis,
             nativeFinalizeFailures,
-            nativeSyncTotal,
-            nativeSyncTimeMillis,
-            nativeSyncFailures,
             mergeTotal,
             mergeTimeMillis,
             mergeFailures,

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/stats/ParquetShardStatsTracker.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/stats/ParquetShardStatsTracker.java
@@ -10,6 +10,7 @@ package org.opensearch.parquet.stats;
 
 import org.opensearch.common.annotation.ExperimentalApi;
 
+import java.util.concurrent.atomic.LongAccumulator;
 import java.util.concurrent.atomic.LongAdder;
 
 /**
@@ -46,6 +47,11 @@ public class ParquetShardStatsTracker {
     private final LongAdder mergeFailures = new LongAdder();
     private final LongAdder mergeInputFilesTotal = new LongAdder();
     private final LongAdder mergeOutputRowsTotal = new LongAdder();
+    // Per-merge: cumulative count + millis for the flush+sort+chunk pass that runs inside each merge.
+    private final LongAdder flushAndSortChunkTotal = new LongAdder();
+    private final LongAdder flushAndSortChunkTimeMillis = new LongAdder();
+    // Highest row_id assigned across all merges of this shard.
+    private final LongAccumulator rowIdMappingMax = new LongAccumulator(Long::max, 0L);
 
     // Background Write counters
     private final LongAdder backgroundWriteTotal = new LongAdder();
@@ -75,6 +81,9 @@ public class ParquetShardStatsTracker {
             mergeFailures.sum(),
             mergeInputFilesTotal.sum(),
             mergeOutputRowsTotal.sum(),
+            flushAndSortChunkTotal.sum(),
+            flushAndSortChunkTimeMillis.sum(),
+            rowIdMappingMax.get(),
             backgroundWriteTotal.sum(),
             backgroundWriteWaitMillis.sum(),
             backgroundWriteTimeouts.sum(),
@@ -156,6 +165,18 @@ public class ParquetShardStatsTracker {
 
     public void addMergeOutputRowsTotal(long n) {
         mergeOutputRowsTotal.add(n);
+    }
+
+    public void addFlushAndSortChunkTotal(long n) {
+        flushAndSortChunkTotal.add(n);
+    }
+
+    public void addFlushAndSortChunkTimeMillis(long ms) {
+        flushAndSortChunkTimeMillis.add(ms);
+    }
+
+    public void updateRowIdMappingMax(long value) {
+        rowIdMappingMax.accumulate(value);
     }
 
     // --- Background Write methods ---

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/stats/ParquetShardStatsTracker.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/stats/ParquetShardStatsTracker.java
@@ -37,9 +37,6 @@ public class ParquetShardStatsTracker {
     private final LongAdder nativeFinalizeTotal = new LongAdder();
     private final LongAdder nativeFinalizeTimeMillis = new LongAdder();
     private final LongAdder nativeFinalizeFailures = new LongAdder();
-    private final LongAdder nativeSyncTotal = new LongAdder();
-    private final LongAdder nativeSyncTimeMillis = new LongAdder();
-    private final LongAdder nativeSyncFailures = new LongAdder();
 
     // Merge counters
     private final LongAdder mergeTotal = new LongAdder();
@@ -73,9 +70,6 @@ public class ParquetShardStatsTracker {
             nativeFinalizeTotal.sum(),
             nativeFinalizeTimeMillis.sum(),
             nativeFinalizeFailures.sum(),
-            nativeSyncTotal.sum(),
-            nativeSyncTimeMillis.sum(),
-            nativeSyncFailures.sum(),
             mergeTotal.sum(),
             mergeTimeMillis.sum(),
             mergeFailures.sum(),
@@ -131,18 +125,6 @@ public class ParquetShardStatsTracker {
 
     public void incNativeFinalizeFailures() {
         nativeFinalizeFailures.increment();
-    }
-
-    public void incNativeSyncTotal() {
-        nativeSyncTotal.increment();
-    }
-
-    public void addNativeSyncTimeMillis(long ms) {
-        nativeSyncTimeMillis.add(ms);
-    }
-
-    public void incNativeSyncFailures() {
-        nativeSyncFailures.increment();
     }
 
     // --- Merge methods ---

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/stats/ParquetShardStatsTracker.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/stats/ParquetShardStatsTracker.java
@@ -1,0 +1,178 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.parquet.stats;
+
+import org.opensearch.common.annotation.ExperimentalApi;
+
+import java.util.concurrent.atomic.LongAdder;
+
+/**
+ * Mutable, thread-safe shard-level statistics tracker for the Parquet data format plugin.
+ * Uses LongAdder for high-throughput counters.
+ * Call {@link #stats()} to obtain an immutable {@link ParquetShardStats} snapshot.
+ *
+ * @opensearch.experimental
+ */
+@ExperimentalApi
+public class ParquetShardStatsTracker {
+
+    // Indexing counters
+    private final LongAdder docsIndexedTotal = new LongAdder();
+    private final LongAdder indexTimeMillis = new LongAdder();
+
+    // VSR Pipeline counters
+    private final LongAdder vsrRotationsTotal = new LongAdder();
+
+    // Native Write counters
+    private final LongAdder nativeWriteTotal = new LongAdder();
+    private final LongAdder nativeWriteTimeMillis = new LongAdder();
+    private final LongAdder nativeWriteFailures = new LongAdder();
+    private final LongAdder nativeFinalizeTotal = new LongAdder();
+    private final LongAdder nativeFinalizeTimeMillis = new LongAdder();
+    private final LongAdder nativeFinalizeFailures = new LongAdder();
+    private final LongAdder nativeSyncTotal = new LongAdder();
+    private final LongAdder nativeSyncTimeMillis = new LongAdder();
+    private final LongAdder nativeSyncFailures = new LongAdder();
+
+    // Merge counters
+    private final LongAdder mergeTotal = new LongAdder();
+    private final LongAdder mergeTimeMillis = new LongAdder();
+    private final LongAdder mergeFailures = new LongAdder();
+    private final LongAdder mergeInputFilesTotal = new LongAdder();
+    private final LongAdder mergeOutputRowsTotal = new LongAdder();
+
+    // Background Write counters
+    private final LongAdder backgroundWriteTotal = new LongAdder();
+    private final LongAdder backgroundWriteWaitMillis = new LongAdder();
+    private final LongAdder backgroundWriteTimeouts = new LongAdder();
+    private final LongAdder backgroundWriteFailures = new LongAdder();
+
+    /**
+     * Returns an immutable point-in-time snapshot of all tracked statistics.
+     */
+    public ParquetShardStats stats() {
+        return new ParquetShardStats(
+            docsIndexedTotal.sum(),
+            indexTimeMillis.sum(),
+            vsrRotationsTotal.sum(),
+            nativeWriteTotal.sum(),
+            nativeWriteTimeMillis.sum(),
+            nativeWriteFailures.sum(),
+            nativeFinalizeTotal.sum(),
+            nativeFinalizeTimeMillis.sum(),
+            nativeFinalizeFailures.sum(),
+            nativeSyncTotal.sum(),
+            nativeSyncTimeMillis.sum(),
+            nativeSyncFailures.sum(),
+            mergeTotal.sum(),
+            mergeTimeMillis.sum(),
+            mergeFailures.sum(),
+            mergeInputFilesTotal.sum(),
+            mergeOutputRowsTotal.sum(),
+            backgroundWriteTotal.sum(),
+            backgroundWriteWaitMillis.sum(),
+            backgroundWriteTimeouts.sum(),
+            backgroundWriteFailures.sum()
+        );
+    }
+
+    // --- Indexing methods ---
+
+    public void addDocsIndexed(long n) {
+        docsIndexedTotal.add(n);
+    }
+
+    public void addIndexTimeMillis(long ms) {
+        indexTimeMillis.add(ms);
+    }
+
+    // --- VSR Pipeline methods ---
+
+    public void incVsrRotations() {
+        vsrRotationsTotal.increment();
+    }
+
+    // --- Native Write methods ---
+
+    public void incNativeWriteTotal() {
+        nativeWriteTotal.increment();
+    }
+
+    public void addNativeWriteTimeMillis(long ms) {
+        nativeWriteTimeMillis.add(ms);
+    }
+
+    public void incNativeWriteFailures() {
+        nativeWriteFailures.increment();
+    }
+
+    public void incNativeFinalizeTotal() {
+        nativeFinalizeTotal.increment();
+    }
+
+    public void addNativeFinalizeTimeMillis(long ms) {
+        nativeFinalizeTimeMillis.add(ms);
+    }
+
+    public void incNativeFinalizeFailures() {
+        nativeFinalizeFailures.increment();
+    }
+
+    public void incNativeSyncTotal() {
+        nativeSyncTotal.increment();
+    }
+
+    public void addNativeSyncTimeMillis(long ms) {
+        nativeSyncTimeMillis.add(ms);
+    }
+
+    public void incNativeSyncFailures() {
+        nativeSyncFailures.increment();
+    }
+
+    // --- Merge methods ---
+
+    public void incMergeTotal() {
+        mergeTotal.increment();
+    }
+
+    public void addMergeTimeMillis(long ms) {
+        mergeTimeMillis.add(ms);
+    }
+
+    public void incMergeFailures() {
+        mergeFailures.increment();
+    }
+
+    public void addMergeInputFilesTotal(long n) {
+        mergeInputFilesTotal.add(n);
+    }
+
+    public void addMergeOutputRowsTotal(long n) {
+        mergeOutputRowsTotal.add(n);
+    }
+
+    // --- Background Write methods ---
+
+    public void incBackgroundWriteTotal() {
+        backgroundWriteTotal.increment();
+    }
+
+    public void addBackgroundWriteWaitMillis(long ms) {
+        backgroundWriteWaitMillis.add(ms);
+    }
+
+    public void incBackgroundWriteTimeouts() {
+        backgroundWriteTimeouts.increment();
+    }
+
+    public void incBackgroundWriteFailures() {
+        backgroundWriteFailures.increment();
+    }
+}

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/stats/ParquetStatsProvider.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/stats/ParquetStatsProvider.java
@@ -1,0 +1,106 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.parquet.stats;
+
+import org.opensearch.common.annotation.ExperimentalApi;
+import org.opensearch.core.common.io.stream.Writeable;
+import org.opensearch.core.index.shard.ShardId;
+import org.opensearch.plugin.stats.DataFormatStatsProvider;
+import org.opensearch.plugin.stats.DataFormatStatsProviderRegistry;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Parquet implementation of {@link DataFormatStatsProvider}.
+ *
+ * <p>Maintains a per-shard registry of {@link ParquetShardStatsTracker} instances.
+ * {@code ParquetIndexingEngine} self-registers on construction and unregisters
+ * on close. The plugin's REST + transport classes read stats from this provider
+ * via the {@link DataFormatStatsProvider} interface.
+ *
+ * <p>Singleton pattern: a static {@code INSTANCE} field is set during plugin
+ * construction so the engine layer (which doesn't have easy Guice injection
+ * hooks) can register its tracker without DI plumbing.
+ *
+ * @opensearch.experimental
+ */
+@ExperimentalApi
+public final class ParquetStatsProvider implements DataFormatStatsProvider<ParquetShardStats> {
+
+    public static final String FORMAT_NAME = "parquet";
+
+    private static volatile ParquetStatsProvider INSTANCE;
+
+    private final Map<ShardId, ParquetShardStatsTracker> trackers = new ConcurrentHashMap<>();
+
+    public ParquetStatsProvider() {
+        // First instance wins. Subsequent constructions are no-ops on the singleton slot.
+        if (INSTANCE == null) {
+            INSTANCE = this;
+        }
+        // Register with the cross-plugin registry so REST handlers and transports can find us.
+        DataFormatStatsProviderRegistry.INSTANCE.register(this);
+    }
+
+    /** Returns the singleton instance, or {@code null} if the plugin has not been constructed yet. */
+    public static ParquetStatsProvider getInstance() {
+        return INSTANCE;
+    }
+
+    /** Registers a tracker for a shard. Called from {@code ParquetIndexingEngine}'s constructor. */
+    public void register(ShardId shardId, ParquetShardStatsTracker tracker) {
+        trackers.put(shardId, tracker);
+    }
+
+    /** Unregisters a tracker. Called from the engine's {@code close()} method. */
+    public void unregister(ShardId shardId) {
+        trackers.remove(shardId);
+    }
+
+    /**
+     * Returns the registered tracker for a shard, or {@code null} if none.
+     * Used by sibling components (e.g., merger, writer) to increment counters
+     * directly on the same tracker the engine registered.
+     */
+    public ParquetShardStatsTracker getTracker(ShardId shardId) {
+        return trackers.get(shardId);
+    }
+
+    // --- DataFormatStatsProvider ---
+
+    @Override
+    public String formatName() {
+        return FORMAT_NAME;
+    }
+
+    @Override
+    public Optional<ParquetShardStats> shardStats(ShardId shardId) {
+        ParquetShardStatsTracker tracker = trackers.get(shardId);
+        return tracker == null ? Optional.empty() : Optional.of(tracker.stats());
+    }
+
+    @Override
+    public Optional<ParquetShardStats> aggregateNodeStats() {
+        if (trackers.isEmpty()) {
+            return Optional.empty();
+        }
+        ParquetShardStats agg = ParquetShardStats.empty();
+        for (ParquetShardStatsTracker t : trackers.values()) {
+            agg = agg.add(t.stats());
+        }
+        return Optional.of(agg);
+    }
+
+    @Override
+    public Writeable.Reader<ParquetShardStats> shardStatsReader() {
+        return ParquetShardStats::new;
+    }
+}

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/stats/ParquetStatsProvider.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/stats/ParquetStatsProvider.java
@@ -8,6 +8,8 @@
 
 package org.opensearch.parquet.stats;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.opensearch.common.annotation.ExperimentalApi;
 import org.opensearch.core.common.io.stream.Writeable;
 import org.opensearch.core.index.shard.ShardId;
@@ -36,6 +38,8 @@ import java.util.concurrent.ConcurrentHashMap;
 public final class ParquetStatsProvider implements DataFormatStatsProvider<ParquetShardStats> {
 
     public static final String FORMAT_NAME = "parquet";
+
+    private static final Logger logger = LogManager.getLogger(ParquetStatsProvider.class);
 
     private static volatile ParquetStatsProvider INSTANCE;
 
@@ -96,7 +100,19 @@ public final class ParquetStatsProvider implements DataFormatStatsProvider<Parqu
         for (ParquetShardStatsTracker t : trackers.values()) {
             agg = agg.add(t.stats());
         }
-        return Optional.of(agg);
+        // Attach native runtime metrics — only at node level. If the FFM/JNI bridge is
+        // unavailable (e.g., test infra without lib loaded) we still return the per-shard
+        // aggregate; missing runtime metrics shouldn't break the whole stats request.
+        // Catching Exception (not Throwable) so we still propagate JVM-fatal Errors.
+        try {
+            ParquetNativeRuntimeStats runtime = ParquetNativeRuntimeStats.fromArray(
+                org.opensearch.parquet.bridge.RustBridge.collectRuntimeMetrics()
+            );
+            return Optional.of(agg.withNativeRuntime(runtime));
+        } catch (Exception e) {
+            logger.warn("Failed to collect native runtime metrics; returning per-shard aggregate without runtime block", e);
+            return Optional.of(agg);
+        }
     }
 
     @Override

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/stats/package-info.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/stats/package-info.java
@@ -1,0 +1,14 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/**
+ * Statistics collection for the Parquet data format plugin.
+ *
+ * @opensearch.experimental
+ */
+package org.opensearch.parquet.stats;

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/stats/transport/ParquetNodeStatsActionType.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/stats/transport/ParquetNodeStatsActionType.java
@@ -1,0 +1,30 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.parquet.stats.transport;
+
+import org.opensearch.common.annotation.ExperimentalApi;
+import org.opensearch.parquet.stats.ParquetShardStats;
+import org.opensearch.parquet.stats.ParquetStatsProvider;
+import org.opensearch.plugin.stats.transport.FormatNodeStatsActionType;
+
+/**
+ * Action type for the parquet per-node stats endpoint
+ * ({@code GET /_plugins/parquet/_nodes/[{nodeId}/]_stats}).
+ *
+ * @opensearch.experimental
+ */
+@ExperimentalApi
+public final class ParquetNodeStatsActionType extends FormatNodeStatsActionType<ParquetShardStats> {
+
+    public static final ParquetNodeStatsActionType INSTANCE = new ParquetNodeStatsActionType();
+
+    private ParquetNodeStatsActionType() {
+        super(ParquetStatsProvider.FORMAT_NAME, ParquetShardStats::new);
+    }
+}

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/stats/transport/ParquetNodeStatsRestAction.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/stats/transport/ParquetNodeStatsRestAction.java
@@ -1,0 +1,34 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.parquet.stats.transport;
+
+import org.opensearch.action.ActionType;
+import org.opensearch.common.annotation.ExperimentalApi;
+import org.opensearch.parquet.stats.ParquetStatsProvider;
+import org.opensearch.plugin.stats.transport.BaseFormatNodeStatsRestAction;
+import org.opensearch.plugin.stats.transport.FormatNodeStatsResponse;
+
+/**
+ * REST handler for {@code GET /_plugins/parquet/_nodes/[{nodeId}/]_stats}.
+ *
+ * @opensearch.experimental
+ */
+@ExperimentalApi
+public final class ParquetNodeStatsRestAction extends BaseFormatNodeStatsRestAction {
+
+    @Override
+    protected String formatName() {
+        return ParquetStatsProvider.FORMAT_NAME;
+    }
+
+    @Override
+    protected ActionType<? extends FormatNodeStatsResponse<?>> actionType() {
+        return ParquetNodeStatsActionType.INSTANCE;
+    }
+}

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/stats/transport/ParquetNodeStatsTransportAction.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/stats/transport/ParquetNodeStatsTransportAction.java
@@ -1,0 +1,46 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.parquet.stats.transport;
+
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.annotation.ExperimentalApi;
+import org.opensearch.common.inject.Inject;
+import org.opensearch.parquet.stats.ParquetShardStats;
+import org.opensearch.parquet.stats.ParquetStatsProvider;
+import org.opensearch.plugin.stats.transport.BaseTransportFormatNodeStatsAction;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportService;
+
+/**
+ * Per-node stats transport action for parquet.
+ *
+ * @opensearch.experimental
+ */
+@ExperimentalApi
+public final class ParquetNodeStatsTransportAction extends BaseTransportFormatNodeStatsAction<ParquetShardStats> {
+
+    @Inject
+    public ParquetNodeStatsTransportAction(
+        ThreadPool threadPool,
+        ClusterService clusterService,
+        TransportService transportService,
+        ActionFilters actionFilters
+    ) {
+        super(
+            ParquetNodeStatsActionType.INSTANCE.name(),
+            ParquetStatsProvider.FORMAT_NAME,
+            ParquetShardStats::new,
+            threadPool,
+            clusterService,
+            transportService,
+            actionFilters
+        );
+    }
+}

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/stats/transport/ParquetStatsActionType.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/stats/transport/ParquetStatsActionType.java
@@ -1,0 +1,30 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.parquet.stats.transport;
+
+import org.opensearch.common.annotation.ExperimentalApi;
+import org.opensearch.parquet.stats.ParquetShardStats;
+import org.opensearch.parquet.stats.ParquetStatsProvider;
+import org.opensearch.plugin.stats.transport.FormatStatsActionType;
+
+/**
+ * Action type for the parquet per-index stats endpoint
+ * ({@code GET /_plugins/parquet/{index}/_stats}).
+ *
+ * @opensearch.experimental
+ */
+@ExperimentalApi
+public final class ParquetStatsActionType extends FormatStatsActionType<ParquetShardStats> {
+
+    public static final ParquetStatsActionType INSTANCE = new ParquetStatsActionType();
+
+    private ParquetStatsActionType() {
+        super(ParquetStatsProvider.FORMAT_NAME, ParquetShardStats::new);
+    }
+}

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/stats/transport/ParquetStatsRestAction.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/stats/transport/ParquetStatsRestAction.java
@@ -1,0 +1,34 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.parquet.stats.transport;
+
+import org.opensearch.action.ActionType;
+import org.opensearch.common.annotation.ExperimentalApi;
+import org.opensearch.parquet.stats.ParquetStatsProvider;
+import org.opensearch.plugin.stats.transport.BaseFormatStatsRestAction;
+import org.opensearch.plugin.stats.transport.FormatStatsResponse;
+
+/**
+ * REST handler for {@code GET /_plugins/parquet/{index}/_stats}.
+ *
+ * @opensearch.experimental
+ */
+@ExperimentalApi
+public final class ParquetStatsRestAction extends BaseFormatStatsRestAction {
+
+    @Override
+    protected String formatName() {
+        return ParquetStatsProvider.FORMAT_NAME;
+    }
+
+    @Override
+    protected ActionType<? extends FormatStatsResponse<?>> actionType() {
+        return ParquetStatsActionType.INSTANCE;
+    }
+}

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/stats/transport/ParquetStatsTransportAction.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/stats/transport/ParquetStatsTransportAction.java
@@ -1,0 +1,50 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.parquet.stats.transport;
+
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.annotation.ExperimentalApi;
+import org.opensearch.common.inject.Inject;
+import org.opensearch.parquet.stats.ParquetShardStats;
+import org.opensearch.parquet.stats.ParquetStatsProvider;
+import org.opensearch.plugin.stats.transport.BaseTransportFormatStatsAction;
+import org.opensearch.transport.TransportService;
+
+/**
+ * Per-index stats transport action for parquet.
+ *
+ * <p>All broadcast/aggregation logic lives in {@link BaseTransportFormatStatsAction};
+ * this class just supplies the action name, format name, and the {@link ParquetShardStats}
+ * stream reader so the transport can deserialize per-shard payloads.
+ *
+ * @opensearch.experimental
+ */
+@ExperimentalApi
+public final class ParquetStatsTransportAction extends BaseTransportFormatStatsAction<ParquetShardStats> {
+
+    @Inject
+    public ParquetStatsTransportAction(
+        ClusterService clusterService,
+        TransportService transportService,
+        ActionFilters actionFilters,
+        IndexNameExpressionResolver indexNameExpressionResolver
+    ) {
+        super(
+            ParquetStatsActionType.INSTANCE.name(),
+            ParquetStatsProvider.FORMAT_NAME,
+            ParquetShardStats::new,
+            clusterService,
+            transportService,
+            actionFilters,
+            indexNameExpressionResolver
+        );
+    }
+}

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/stats/transport/package-info.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/stats/transport/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/**
+ * Transport and REST actions for the parquet per-format statistics endpoints.
+ *
+ * <p>Wires {@link org.opensearch.parquet.stats.ParquetStatsProvider} into the
+ * {@code /_plugins/parquet/{index}/_stats} and {@code /_plugins/parquet/_nodes/_stats}
+ * REST + transport surfaces by extending the abstract bases in
+ * {@link org.opensearch.plugin.stats.transport}.
+ *
+ * @opensearch.experimental
+ */
+@ExperimentalApi
+package org.opensearch.parquet.stats.transport;
+
+import org.opensearch.common.annotation.ExperimentalApi;

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/vsr/VSRManager.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/vsr/VSRManager.java
@@ -26,6 +26,7 @@ import org.opensearch.parquet.bridge.ParquetSortConfig;
 import org.opensearch.parquet.fields.ArrowFieldRegistry;
 import org.opensearch.parquet.fields.ParquetField;
 import org.opensearch.parquet.memory.ArrowBufferPool;
+import org.opensearch.parquet.stats.ParquetShardStatsTracker;
 import org.opensearch.parquet.writer.FieldValuePair;
 import org.opensearch.parquet.writer.MismatchedInputException;
 import org.opensearch.parquet.writer.ParquetDocumentInput;
@@ -68,6 +69,7 @@ public class VSRManager implements AutoCloseable {
     private final ThreadPool threadPool;
     private final String vsrRotationThread;
     private final long writerGeneration;
+    private final ParquetShardStatsTracker stats;
     private volatile Future<?> pendingWrite;
     private final NativeParquetWriter writer;
     private final int ROTATION_TIMEOUT = 120;
@@ -84,9 +86,61 @@ public class VSRManager implements AutoCloseable {
         ArrowBufferPool bufferPool,
         int maxRowsPerVSR,
         ThreadPool threadPool,
+        long writerGeneration,
+        ParquetShardStatsTracker stats
+    ) {
+        this(fileName, indexSettings, schema, bufferPool, maxRowsPerVSR, threadPool, true, writerGeneration, stats);
+    }
+
+    /**
+     * Creates a new VSRManager with asynchronous background writes and no stats collection.
+     */
+    public VSRManager(
+        String fileName,
+        IndexSettings indexSettings,
+        Schema schema,
+        ArrowBufferPool bufferPool,
+        int maxRowsPerVSR,
+        ThreadPool threadPool,
         long writerGeneration
     ) {
-        this(fileName, indexSettings, schema, bufferPool, maxRowsPerVSR, threadPool, true, writerGeneration);
+        this(
+            fileName,
+            indexSettings,
+            schema,
+            bufferPool,
+            maxRowsPerVSR,
+            threadPool,
+            true,
+            writerGeneration,
+            new ParquetShardStatsTracker()
+        );
+    }
+
+    /**
+     * Creates a new VSRManager without stats collection.
+     */
+    public VSRManager(
+        String fileName,
+        IndexSettings indexSettings,
+        Schema schema,
+        ArrowBufferPool bufferPool,
+        int maxRowsPerVSR,
+        ThreadPool threadPool,
+        boolean runAsync,
+        long writerGeneration
+    ) {
+        this(
+            fileName,
+            indexSettings,
+            schema,
+            bufferPool,
+            maxRowsPerVSR,
+            threadPool,
+            runAsync,
+            writerGeneration,
+            new ParquetShardStatsTracker()
+        );
     }
 
     /**
@@ -101,6 +155,7 @@ public class VSRManager implements AutoCloseable {
      * @param runAsync if true, frozen VSR writes run on the background thread pool;
      *                 if false, they run on the calling thread (for benchmarks/tests)
      * @param writerGeneration the writer generation to store in file metadata
+     * @param stats shard-level stats tracker
      */
     public VSRManager(
         String fileName,
@@ -110,16 +165,18 @@ public class VSRManager implements AutoCloseable {
         int maxRowsPerVSR,
         ThreadPool threadPool,
         boolean runAsync,
-        long writerGeneration
+        long writerGeneration,
+        ParquetShardStatsTracker stats
     ) {
         this.fileName = fileName;
         this.indexSettings = indexSettings;
         this.writerGeneration = writerGeneration;
+        this.stats = stats;
         this.vsrPool = new VSRPool("pool-" + fileName, schema, bufferPool, maxRowsPerVSR);
         this.threadPool = threadPool;
         this.vsrRotationThread = runAsync ? ParquetDataFormatPlugin.PARQUET_THREAD_POOL_NAME : ThreadPool.Names.SAME;
         this.managedVSR.set(vsrPool.getActiveVSR());
-        this.writer = new NativeParquetWriter(fileName);
+        this.writer = new NativeParquetWriter(fileName, stats);
     }
 
     /**
@@ -133,6 +190,7 @@ public class VSRManager implements AutoCloseable {
         if (pendingWrite != null && pendingWrite.isDone()) {
             Future.State state = pendingWrite.state();
             if (state == Future.State.FAILED) {
+                stats.incBackgroundWriteFailures();
                 throw new IllegalStateException(pendingWrite.exceptionNow());
             } else if (state == Future.State.CANCELLED) {
                 throw new IllegalStateException("Background write was cancelled");
@@ -227,6 +285,7 @@ public class VSRManager implements AutoCloseable {
         if (rotated == false) {
             return;
         }
+        stats.incVsrRotations();
         logger.debug("VSR rotation occurred for {}", fileName);
         ManagedVSR frozenVSR = vsrPool.getFrozenVSR();
         if (frozenVSR != null) {
@@ -321,21 +380,27 @@ public class VSRManager implements AutoCloseable {
         if (pendingWrite == null) {
             return;
         }
+        long startNanos = System.nanoTime();
         try {
             if (timeoutSeconds > 0) {
                 pendingWrite.get(timeoutSeconds, TimeUnit.SECONDS);
             } else {
                 pendingWrite.get();
             }
+            stats.incBackgroundWriteTotal();
         } catch (TimeoutException e) {
+            stats.incBackgroundWriteTimeouts();
             if (ignoreTimeout) {
                 logger.warn("Timed out waiting for background VSR write for {}", fileName);
             } else {
                 throw new IOException("Timed out waiting for background VSR write for " + fileName, e);
             }
         } catch (Exception e) {
+            stats.incBackgroundWriteFailures();
             throw new IOException("Background VSR write failed for " + fileName, e.getCause());
         } finally {
+            long elapsed = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
+            stats.addBackgroundWriteWaitMillis(elapsed);
             pendingWrite = null;
         }
     }

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/writer/ParquetWriter.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/writer/ParquetWriter.java
@@ -25,11 +25,13 @@ import org.opensearch.parquet.ParquetSettings;
 import org.opensearch.parquet.bridge.ParquetFileMetadata;
 import org.opensearch.parquet.engine.ParquetDataFormat;
 import org.opensearch.parquet.memory.ArrowBufferPool;
+import org.opensearch.parquet.stats.ParquetShardStatsTracker;
 import org.opensearch.parquet.vsr.VSRManager;
 import org.opensearch.threadpool.ThreadPool;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
 /**
@@ -55,6 +57,7 @@ public class ParquetWriter implements Writer<ParquetDocumentInput> {
     private final VSRManager vsrManager;
     private final FormatChecksumStrategy checksumStrategy;
     private final Supplier<Schema> schemaSupplier;
+    private final ParquetShardStatsTracker stats;
     private volatile long mappingVersion;
     private volatile WriterState state = WriterState.ACTIVE;
     private long acceptedRows = 0L;
@@ -74,6 +77,42 @@ public class ParquetWriter implements Writer<ParquetDocumentInput> {
      * @param indexSettings index settings for writer configuration
      * @param threadPool the thread pool for background native writes
      * @param checksumStrategy strategy to register pre-computed checksums on
+     * @param stats shard-level stats tracker
+     */
+    public ParquetWriter(
+        String file,
+        long writerGeneration,
+        long mappingVersion,
+        ParquetDataFormat dataFormat,
+        Schema schema,
+        Supplier<Schema> schemaSupplier,
+        ArrowBufferPool bufferPool,
+        IndexSettings indexSettings,
+        ThreadPool threadPool,
+        FormatChecksumStrategy checksumStrategy,
+        ParquetShardStatsTracker stats
+    ) {
+        this.file = file;
+        this.writerGeneration = writerGeneration;
+        this.mappingVersion = mappingVersion;
+        this.dataFormat = dataFormat;
+        this.checksumStrategy = checksumStrategy;
+        this.schemaSupplier = schemaSupplier;
+        this.stats = stats;
+        this.vsrManager = new VSRManager(
+            file,
+            indexSettings,
+            schema,
+            bufferPool,
+            ParquetSettings.MAX_ROWS_PER_VSR.get(indexSettings.getSettings()),
+            threadPool,
+            writerGeneration,
+            stats
+        );
+    }
+
+    /**
+     * Creates a new ParquetWriter without stats collection.
      */
     public ParquetWriter(
         String file,
@@ -87,20 +126,18 @@ public class ParquetWriter implements Writer<ParquetDocumentInput> {
         ThreadPool threadPool,
         FormatChecksumStrategy checksumStrategy
     ) {
-        this.file = file;
-        this.writerGeneration = writerGeneration;
-        this.mappingVersion = mappingVersion;
-        this.dataFormat = dataFormat;
-        this.checksumStrategy = checksumStrategy;
-        this.schemaSupplier = schemaSupplier;
-        this.vsrManager = new VSRManager(
+        this(
             file,
-            indexSettings,
+            writerGeneration,
+            mappingVersion,
+            dataFormat,
             schema,
+            schemaSupplier,
             bufferPool,
-            ParquetSettings.MAX_ROWS_PER_VSR.get(indexSettings.getSettings()),
+            indexSettings,
             threadPool,
-            writerGeneration
+            checksumStrategy,
+            new ParquetShardStatsTracker()
         );
     }
 
@@ -109,16 +146,23 @@ public class ParquetWriter implements Writer<ParquetDocumentInput> {
         if (state != WriterState.ACTIVE) {
             throw new IllegalStateException("Writer is not active, state=" + state);
         }
-        // Schema mismatch is recoverable: the VSR rejected the doc pre-admission, so the
-        // caller-driven rollback no-ops in the VSR and restores ACTIVE.
+        long startNanos = System.nanoTime();
         try {
-            vsrManager.addDocument(d);
-        } catch (MismatchedInputException e) {
-            state = WriterState.PENDING_ROLLBACK;
-            return new WriteResult.Failure(e, -1, -1, -1);
+            // Schema mismatch is recoverable: the VSR rejected the doc pre-admission, so the
+            // caller-driven rollback no-ops in the VSR and restores ACTIVE.
+            try {
+                vsrManager.addDocument(d);
+            } catch (MismatchedInputException e) {
+                state = WriterState.PENDING_ROLLBACK;
+                return new WriteResult.Failure(e, -1, -1, -1);
+            }
+            acceptedRows++;
+            stats.addDocsIndexed(1);
+            return new WriteResult.Success(1L, 1L, 1L);
+        } finally {
+            long elapsed = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
+            stats.addIndexTimeMillis(elapsed);
         }
-        acceptedRows++;
-        return new WriteResult.Success(1L, 1L, 1L);
     }
 
     @Override

--- a/sandbox/plugins/parquet-data-format/src/main/rust/src/ffm.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/src/ffm.rs
@@ -487,6 +487,10 @@ pub unsafe extern "C" fn parquet_merge_files(
     out_gen_offsets_ptr: *mut i64,
     out_gen_sizes_ptr: *mut i64,
     out_gen_count: *mut i64,
+    // Per-merge stats forwarded to the per-shard ParquetShardStatsTracker on the Java side.
+    out_flush_and_sort_chunk_count: *mut i64,
+    out_flush_and_sort_chunk_time_millis: *mut i64,
+    out_row_id_mapping_max: *mut i64,
 ) -> i64 {
     let input_files = str_array_from_raw(input_ptrs, input_lens, input_count)
         .map_err(|e| format!("parquet_merge_files inputs: {}", e))?;
@@ -559,6 +563,11 @@ pub unsafe extern "C" fn parquet_merge_files(
     *out_gen_keys_ptr = Box::into_raw(keys) as *mut i64 as i64;
     *out_gen_offsets_ptr = Box::into_raw(offsets) as *mut i32 as i64;
     *out_gen_sizes_ptr = Box::into_raw(sizes) as *mut i32 as i64;
+
+    // Per-merge stats out-pointers — callers always pass valid pointers (matches existing convention).
+    *out_flush_and_sort_chunk_count = result.flush_and_sort_chunk_count;
+    *out_flush_and_sort_chunk_time_millis = result.flush_and_sort_chunk_time_millis;
+    *out_row_id_mapping_max = result.row_id_mapping_max;
 
     Ok(0)
 }
@@ -703,26 +712,32 @@ pub unsafe extern "C" fn parquet_collect_runtime_metrics(
     if out_buf.is_null() {
         return Err("parquet_collect_runtime_metrics: null out_buf".to_string());
     }
-    if out_len < 11 {
+    if out_len < 17 {
         return Err(format!(
-            "parquet_collect_runtime_metrics: out_len {} < 11",
+            "parquet_collect_runtime_metrics: out_len {} < 17",
             out_len
         ));
     }
     let s = crate::merge::metrics::collect();
-    let arr: [i64; 11] = [
+    let arr: [i64; 17] = [
         s.rayon_configured_threads,
         s.rayon_merge_tasks_submitted,
+        s.rayon_merge_tasks_started,
         s.rayon_merge_tasks_completed,
+        s.rayon_merge_tasks_failed,
         s.rayon_merge_tasks_panicked,
         s.rayon_merge_wall_millis,
         s.tokio_num_workers,
         s.tokio_num_blocking_threads,
         s.tokio_active_tasks,
         s.tokio_global_queue_depth,
+        s.tokio_blocking_queue_depth,
+        s.tokio_local_queue_depth_total,
+        s.tokio_polls_count_total,
+        s.tokio_overflow_count_total,
         s.tokio_spawned_tasks_total,
         s.tokio_workers_busy_millis_total,
     ];
-    std::ptr::copy_nonoverlapping(arr.as_ptr(), out_buf, 11);
+    std::ptr::copy_nonoverlapping(arr.as_ptr(), out_buf, 17);
     Ok(0)
 }

--- a/sandbox/plugins/parquet-data-format/src/main/rust/src/ffm.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/src/ffm.rs
@@ -683,3 +683,46 @@ pub unsafe extern "C" fn parquet_free_row_id_mapping(
         let _ = Box::from_raw(slice::from_raw_parts_mut(mapping_ptr as *mut i64, mapping_len as usize));
     }
 }
+
+// ---------------------------------------------------------------------------
+// Native runtime metrics
+// ---------------------------------------------------------------------------
+
+/// Collect a snapshot of native runtime stats for the parquet merge path.
+///
+/// The caller passes a buffer of 11 i64s. On success, writes the 11-stat snapshot in the order
+/// documented in `ParquetNativeRuntimeStats.fromArray`. Returns 0 on success, or a negative
+/// error pointer on failure (per FFM convention).
+/// Returns 0 on success, negative error pointer on failure (per FFM convention).
+#[ffm_safe]
+#[no_mangle]
+pub unsafe extern "C" fn parquet_collect_runtime_metrics(
+    out_buf: *mut i64,
+    out_len: i64,
+) -> i64 {
+    if out_buf.is_null() {
+        return Err("parquet_collect_runtime_metrics: null out_buf".to_string());
+    }
+    if out_len < 11 {
+        return Err(format!(
+            "parquet_collect_runtime_metrics: out_len {} < 11",
+            out_len
+        ));
+    }
+    let s = crate::merge::metrics::collect();
+    let arr: [i64; 11] = [
+        s.rayon_configured_threads,
+        s.rayon_merge_tasks_submitted,
+        s.rayon_merge_tasks_completed,
+        s.rayon_merge_tasks_panicked,
+        s.rayon_merge_wall_millis,
+        s.tokio_num_workers,
+        s.tokio_num_blocking_threads,
+        s.tokio_active_tasks,
+        s.tokio_global_queue_depth,
+        s.tokio_spawned_tasks_total,
+        s.tokio_workers_busy_millis_total,
+    ];
+    std::ptr::copy_nonoverlapping(arr.as_ptr(), out_buf, 11);
+    Ok(0)
+}

--- a/sandbox/plugins/parquet-data-format/src/main/rust/src/merge/context.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/src/merge/context.rs
@@ -147,12 +147,25 @@ impl MergeContext {
 
     /// Concat buffered batches, append row IDs, encode columns in parallel,
     /// and send the encoded row group to the IO task.
+    ///
+    /// `flush_and_sort_chunk_count` and `flush_and_sort_chunk_time_millis` are
+    /// always recorded — including on failure paths — to keep this counter
+    /// symmetric with rayon's `merge_wall_millis`. The empty-chunks early-return
+    /// is the only path that doesn't count as an attempt.
     pub fn flush(&mut self) -> MergeResult<()> {
         if self.output_chunks.is_empty() {
             return Ok(());
         }
         let flush_start = std::time::Instant::now();
+        self.flush_and_sort_chunk_count += 1;
 
+        let result = self.do_flush();
+
+        self.flush_and_sort_chunk_time_millis += flush_start.elapsed().as_millis() as i64;
+        result
+    }
+
+    fn do_flush(&mut self) -> MergeResult<()> {
         let merged = if self.output_chunks.len() == 1 {
             self.output_chunks.pop().unwrap()
         } else {
@@ -215,8 +228,6 @@ impl MergeContext {
             self.total_rows_written
         );
 
-        self.flush_and_sort_chunk_count += 1;
-        self.flush_and_sort_chunk_time_millis += flush_start.elapsed().as_millis() as i64;
         Ok(())
     }
 

--- a/sandbox/plugins/parquet-data-format/src/main/rust/src/merge/context.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/src/merge/context.rs
@@ -45,6 +45,10 @@ pub struct MergeContext {
     next_row_id: i64,
     total_rows_written: usize,
     rayon_threads: Option<usize>,
+    // Per-merge counters returned via `finish()` and forwarded to the per-shard tracker on the
+    // Java side (see NativeParquetMergeStrategy + ParquetShardStatsTracker).
+    flush_and_sort_chunk_count: i64,
+    flush_and_sort_chunk_time_millis: i64,
 }
 
 impl MergeContext {
@@ -121,6 +125,8 @@ impl MergeContext {
             next_row_id: 0,
             total_rows_written: 0,
             rayon_threads,
+            flush_and_sort_chunk_count: 0,
+            flush_and_sort_chunk_time_millis: 0,
         })
     }
 
@@ -145,6 +151,7 @@ impl MergeContext {
         if self.output_chunks.is_empty() {
             return Ok(());
         }
+        let flush_start = std::time::Instant::now();
 
         let merged = if self.output_chunks.len() == 1 {
             self.output_chunks.pop().unwrap()
@@ -208,6 +215,8 @@ impl MergeContext {
             self.total_rows_written
         );
 
+        self.flush_and_sort_chunk_count += 1;
+        self.flush_and_sort_chunk_time_millis += flush_start.elapsed().as_millis() as i64;
         Ok(())
     }
 
@@ -243,9 +252,14 @@ impl MergeContext {
         Ok(paired)
     }
 
-    /// Final flush + close the IO task. Returns Parquet metadata and CRC32.
-    pub fn finish(mut self) -> MergeResult<(parquet::file::metadata::ParquetMetaData, u32)> {
+    /// Final flush + close the IO task. Returns Parquet metadata, CRC32, and per-merge stats
+    /// to be forwarded to the per-shard tracker on the Java side.
+    pub fn finish(mut self) -> MergeResult<MergeFinishStats> {
         self.flush()?;
+        // Capture the per-merge counters BEFORE moving `self` into the IO send below.
+        let final_row_id_max = self.next_row_id;
+        let flush_count = self.flush_and_sort_chunk_count;
+        let flush_time_millis = self.flush_and_sort_chunk_time_millis;
 
         let (reply_tx, reply_rx) =
             oneshot::channel::<MergeResult<(parquet::file::metadata::ParquetMetaData, u32)>>();
@@ -256,8 +270,27 @@ impl MergeContext {
 
         drop(self.io_tx);
 
-        reply_rx
+        let (metadata, crc32) = reply_rx
             .blocking_recv()
-            .map_err(|_| MergeError::Logic("IO task terminated during close".into()))?
+            .map_err(|_| MergeError::Logic("IO task terminated during close".into()))??;
+
+        Ok(MergeFinishStats {
+            metadata,
+            crc32,
+            flush_and_sort_chunk_count: flush_count,
+            flush_and_sort_chunk_time_millis: flush_time_millis,
+            row_id_mapping_max: final_row_id_max,
+        })
     }
+}
+
+/// Result returned from `MergeContext::finish()`.
+/// Carries the parquet metadata + CRC plus per-merge stat counters that the caller
+/// forwards to the per-shard `ParquetShardStatsTracker`.
+pub struct MergeFinishStats {
+    pub metadata: parquet::file::metadata::ParquetMetaData,
+    pub crc32: u32,
+    pub flush_and_sort_chunk_count: i64,
+    pub flush_and_sort_chunk_time_millis: i64,
+    pub row_id_mapping_max: i64,
 }

--- a/sandbox/plugins/parquet-data-format/src/main/rust/src/merge/context.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/src/merge/context.rs
@@ -174,15 +174,18 @@ impl MergeContext {
 
         let chunk_results: Vec<
             Result<parquet::arrow::arrow_writer::ArrowColumnChunk, parquet::errors::ParquetError>,
-        > = get_merge_pool(self.rayon_threads).install(|| {
-            leaves_and_writers
-                .into_par_iter()
-                .map(|(leaf, mut col_writer)| {
-                    col_writer.write(&leaf)?;
-                    col_writer.close()
-                })
-                .collect()
-        });
+        > = super::metrics::record_merge(|| {
+            let results: Vec<_> = get_merge_pool(self.rayon_threads).install(|| {
+                leaves_and_writers
+                    .into_par_iter()
+                    .map(|(leaf, mut col_writer)| {
+                        col_writer.write(&leaf)?;
+                        col_writer.close()
+                    })
+                    .collect()
+            });
+            Ok(results)
+        })?;
 
         let mut encoded_chunks = Vec::with_capacity(chunk_results.len());
         for r in chunk_results {

--- a/sandbox/plugins/parquet-data-format/src/main/rust/src/merge/io_task.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/src/merge/io_task.rs
@@ -45,7 +45,7 @@ const IO_CHANNEL_BUFFER: usize = 2;
 // Process-wide shared Rayon thread pool
 // =============================================================================
 
-static MERGE_POOL: OnceLock<ThreadPool> = OnceLock::new();
+pub(crate) static MERGE_POOL: OnceLock<ThreadPool> = OnceLock::new();
 
 pub fn get_merge_pool(num_threads: Option<usize>) -> &'static ThreadPool {
     MERGE_POOL.get_or_init(|| {
@@ -62,7 +62,7 @@ pub fn get_merge_pool(num_threads: Option<usize>) -> &'static ThreadPool {
 // Process-wide shared Tokio runtime for async IO
 // =============================================================================
 
-static IO_RUNTIME: OnceLock<Runtime> = OnceLock::new();
+pub(crate) static IO_RUNTIME: OnceLock<Runtime> = OnceLock::new();
 
 fn get_io_runtime(num_threads: Option<usize>) -> &'static Runtime {
     IO_RUNTIME.get_or_init(|| {

--- a/sandbox/plugins/parquet-data-format/src/main/rust/src/merge/metrics.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/src/merge/metrics.rs
@@ -30,7 +30,9 @@ use super::error::MergeError;
 // =============================================================================
 
 static RAYON_SUBMITTED: AtomicU64 = AtomicU64::new(0);
+static RAYON_STARTED: AtomicU64 = AtomicU64::new(0);
 static RAYON_COMPLETED: AtomicU64 = AtomicU64::new(0);
+static RAYON_FAILED: AtomicU64 = AtomicU64::new(0);
 static RAYON_PANICKED: AtomicU64 = AtomicU64::new(0);
 static RAYON_MERGE_WALL_MILLIS: AtomicU64 = AtomicU64::new(0);
 
@@ -42,13 +44,19 @@ static RAYON_MERGE_WALL_MILLIS: AtomicU64 = AtomicU64::new(0);
 pub struct NativeRuntimeStats {
     pub rayon_configured_threads: i64,
     pub rayon_merge_tasks_submitted: i64,
+    pub rayon_merge_tasks_started: i64,
     pub rayon_merge_tasks_completed: i64,
+    pub rayon_merge_tasks_failed: i64,
     pub rayon_merge_tasks_panicked: i64,
     pub rayon_merge_wall_millis: i64,
     pub tokio_num_workers: i64,
     pub tokio_num_blocking_threads: i64,
     pub tokio_active_tasks: i64,
     pub tokio_global_queue_depth: i64,
+    pub tokio_blocking_queue_depth: i64,
+    pub tokio_local_queue_depth_total: i64,
+    pub tokio_polls_count_total: i64,
+    pub tokio_overflow_count_total: i64,
     pub tokio_spawned_tasks_total: i64,
     pub tokio_workers_busy_millis_total: i64,
 }
@@ -62,7 +70,9 @@ pub fn collect() -> NativeRuntimeStats {
     if let Some(pool) = super::io_task::MERGE_POOL.get() {
         s.rayon_configured_threads = pool.current_num_threads() as i64;
         s.rayon_merge_tasks_submitted = RAYON_SUBMITTED.load(Ordering::Relaxed) as i64;
+        s.rayon_merge_tasks_started = RAYON_STARTED.load(Ordering::Relaxed) as i64;
         s.rayon_merge_tasks_completed = RAYON_COMPLETED.load(Ordering::Relaxed) as i64;
+        s.rayon_merge_tasks_failed = RAYON_FAILED.load(Ordering::Relaxed) as i64;
         s.rayon_merge_tasks_panicked = RAYON_PANICKED.load(Ordering::Relaxed) as i64;
         s.rayon_merge_wall_millis = RAYON_MERGE_WALL_MILLIS.load(Ordering::Relaxed) as i64;
     }
@@ -74,11 +84,24 @@ pub fn collect() -> NativeRuntimeStats {
         s.tokio_num_blocking_threads = m.num_blocking_threads() as i64;
         s.tokio_active_tasks = m.num_alive_tasks() as i64;
         s.tokio_global_queue_depth = m.global_queue_depth() as i64;
+        s.tokio_blocking_queue_depth = m.blocking_queue_depth() as i64;
         s.tokio_spawned_tasks_total = m.spawned_tasks_count() as i64;
-        let busy_millis: i64 = (0..m.num_workers())
-            .map(|i| m.worker_total_busy_duration(i).as_millis() as i64)
-            .sum();
+        // Per-worker fan-out: sum across all workers for runtime-wide totals.
+        let n = m.num_workers();
+        let mut busy_millis: i64 = 0;
+        let mut local_queue_depth_total: i64 = 0;
+        let mut polls_count_total: i64 = 0;
+        let mut overflow_count_total: i64 = 0;
+        for i in 0..n {
+            busy_millis += m.worker_total_busy_duration(i).as_millis() as i64;
+            local_queue_depth_total += m.worker_local_queue_depth(i) as i64;
+            polls_count_total += m.worker_poll_count(i) as i64;
+            overflow_count_total += m.worker_overflow_count(i) as i64;
+        }
         s.tokio_workers_busy_millis_total = busy_millis;
+        s.tokio_local_queue_depth_total = local_queue_depth_total;
+        s.tokio_polls_count_total = polls_count_total;
+        s.tokio_overflow_count_total = overflow_count_total;
     }
 
     s
@@ -102,7 +125,12 @@ where
     let start = Instant::now();
     // catch_unwind so a panic increments RAYON_PANICKED before being re-raised. AssertUnwindSafe
     // is acceptable here because the only state we touch in the closure is local to it.
-    let result = catch_unwind(AssertUnwindSafe(f));
+    // RAYON_STARTED is bumped inside the closure so it reflects when rayon actually picked up
+    // the work — `submitted - started` ≈ queued tasks waiting for a worker.
+    let result = catch_unwind(AssertUnwindSafe(|| {
+        RAYON_STARTED.fetch_add(1, Ordering::Relaxed);
+        f()
+    }));
     let elapsed_ms = start.elapsed().as_millis() as u64;
     RAYON_MERGE_WALL_MILLIS.fetch_add(elapsed_ms, Ordering::Relaxed);
 
@@ -111,7 +139,10 @@ where
             RAYON_COMPLETED.fetch_add(1, Ordering::Relaxed);
             Ok(r)
         }
-        Ok(Err(e)) => Err(e),
+        Ok(Err(e)) => {
+            RAYON_FAILED.fetch_add(1, Ordering::Relaxed);
+            Err(e)
+        }
         Err(panic_payload) => {
             RAYON_PANICKED.fetch_add(1, Ordering::Relaxed);
             std::panic::resume_unwind(panic_payload);

--- a/sandbox/plugins/parquet-data-format/src/main/rust/src/merge/metrics.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/src/merge/metrics.rs
@@ -111,10 +111,15 @@ pub fn collect() -> NativeRuntimeStats {
 ///
 /// Counter semantics:
 /// - `submitted` = number of times this wrapper was entered.
+/// - `started`   = number of times the closure actually began executing on a rayon worker.
 /// - `completed` = number of times the closure returned `Ok(_)`.
+/// - `failed`    = number of times the closure returned `Err(_)` — i.e. logical errors that
+///   happened INSIDE the rayon-wrapped column-encoding pass. Logical errors that occur
+///   BEFORE this wrapper runs (FFM bridge throws, Java-side validation fails, IO task
+///   panics, etc.) increment the per-shard `parquet.merge.merge_failures` counter but
+///   NOT this one. As a result, `merge_tasks_failed` and `merge_failures` populations
+///   overlap but are not identical — they intentionally measure different things.
 /// - `panicked`  = number of times the closure unwound (panicked); the panic is then re-raised.
-/// - On `Err(_)`, neither `completed` nor `panicked` is incremented; `submitted - completed - panicked`
-///   is the count of merges that terminated with a logical error.
 /// - `merge_wall_millis` accumulates total wall-clock duration of every wrapped call (the work
 ///   itself, plus any rayon-pool install overhead, plus errored and panicked invocations).
 pub fn record_merge<F, R>(f: F) -> Result<R, MergeError>

--- a/sandbox/plugins/parquet-data-format/src/main/rust/src/merge/metrics.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/src/merge/metrics.rs
@@ -1,0 +1,120 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+//! Process-wide native runtime metrics for the parquet merge path.
+//!
+//! Exposes counters around the rayon merge pool and a snapshot of the tokio IO runtime metrics.
+//! All atomics use Relaxed ordering — values are monotonic-counter or last-write-wins; readers
+//! may see slightly stale values but never corrupt state.
+
+use std::panic::{catch_unwind, AssertUnwindSafe};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Instant;
+
+use super::error::MergeError;
+
+// =============================================================================
+// Atomic counters around the rayon merge pool
+// =============================================================================
+// Atomic counters around the rayon merge pool
+//
+// Note: `RAYON_MERGE_WALL_MILLIS` is the cumulative wall-clock duration of every wrapped
+// merge operation, including the parallel column-encoding work itself — NOT just the time
+// spent waiting to install work on the rayon pool. The previous name `*_install_wait_millis`
+// was misleading; saturation is better inferred from the ratio of wall time to thread count.
+// =============================================================================
+
+static RAYON_SUBMITTED: AtomicU64 = AtomicU64::new(0);
+static RAYON_COMPLETED: AtomicU64 = AtomicU64::new(0);
+static RAYON_PANICKED: AtomicU64 = AtomicU64::new(0);
+static RAYON_MERGE_WALL_MILLIS: AtomicU64 = AtomicU64::new(0);
+
+// =============================================================================
+// Snapshot collected on every stats request
+// =============================================================================
+
+#[derive(Default, Debug, Clone, Copy)]
+pub struct NativeRuntimeStats {
+    pub rayon_configured_threads: i64,
+    pub rayon_merge_tasks_submitted: i64,
+    pub rayon_merge_tasks_completed: i64,
+    pub rayon_merge_tasks_panicked: i64,
+    pub rayon_merge_wall_millis: i64,
+    pub tokio_num_workers: i64,
+    pub tokio_num_blocking_threads: i64,
+    pub tokio_active_tasks: i64,
+    pub tokio_global_queue_depth: i64,
+    pub tokio_spawned_tasks_total: i64,
+    pub tokio_workers_busy_millis_total: i64,
+}
+
+/// Snapshot the current state of the rayon merge pool and tokio IO runtime.
+/// Returns all-zeros if neither pool has been initialized yet (no merge has run).
+pub fn collect() -> NativeRuntimeStats {
+    let mut s = NativeRuntimeStats::default();
+
+    // Rayon — only if MERGE_POOL has been initialized
+    if let Some(pool) = super::io_task::MERGE_POOL.get() {
+        s.rayon_configured_threads = pool.current_num_threads() as i64;
+        s.rayon_merge_tasks_submitted = RAYON_SUBMITTED.load(Ordering::Relaxed) as i64;
+        s.rayon_merge_tasks_completed = RAYON_COMPLETED.load(Ordering::Relaxed) as i64;
+        s.rayon_merge_tasks_panicked = RAYON_PANICKED.load(Ordering::Relaxed) as i64;
+        s.rayon_merge_wall_millis = RAYON_MERGE_WALL_MILLIS.load(Ordering::Relaxed) as i64;
+    }
+
+    // Tokio — only if IO_RUNTIME has been initialized
+    if let Some(rt) = super::io_task::IO_RUNTIME.get() {
+        let m = rt.metrics();
+        s.tokio_num_workers = m.num_workers() as i64;
+        s.tokio_num_blocking_threads = m.num_blocking_threads() as i64;
+        s.tokio_active_tasks = m.num_alive_tasks() as i64;
+        s.tokio_global_queue_depth = m.global_queue_depth() as i64;
+        s.tokio_spawned_tasks_total = m.spawned_tasks_count() as i64;
+        let busy_millis: i64 = (0..m.num_workers())
+            .map(|i| m.worker_total_busy_duration(i).as_millis() as i64)
+            .sum();
+        s.tokio_workers_busy_millis_total = busy_millis;
+    }
+
+    s
+}
+
+/// Wraps a rayon-pool-using closure to record submission/completion/panic + wait time.
+///
+/// Counter semantics:
+/// - `submitted` = number of times this wrapper was entered.
+/// - `completed` = number of times the closure returned `Ok(_)`.
+/// - `panicked`  = number of times the closure unwound (panicked); the panic is then re-raised.
+/// - On `Err(_)`, neither `completed` nor `panicked` is incremented; `submitted - completed - panicked`
+///   is the count of merges that terminated with a logical error.
+/// - `merge_wall_millis` accumulates total wall-clock duration of every wrapped call (the work
+///   itself, plus any rayon-pool install overhead, plus errored and panicked invocations).
+pub fn record_merge<F, R>(f: F) -> Result<R, MergeError>
+where
+    F: FnOnce() -> Result<R, MergeError>,
+{
+    RAYON_SUBMITTED.fetch_add(1, Ordering::Relaxed);
+    let start = Instant::now();
+    // catch_unwind so a panic increments RAYON_PANICKED before being re-raised. AssertUnwindSafe
+    // is acceptable here because the only state we touch in the closure is local to it.
+    let result = catch_unwind(AssertUnwindSafe(f));
+    let elapsed_ms = start.elapsed().as_millis() as u64;
+    RAYON_MERGE_WALL_MILLIS.fetch_add(elapsed_ms, Ordering::Relaxed);
+
+    match result {
+        Ok(Ok(r)) => {
+            RAYON_COMPLETED.fetch_add(1, Ordering::Relaxed);
+            Ok(r)
+        }
+        Ok(Err(e)) => Err(e),
+        Err(panic_payload) => {
+            RAYON_PANICKED.fetch_add(1, Ordering::Relaxed);
+            std::panic::resume_unwind(panic_payload);
+        }
+    }
+}

--- a/sandbox/plugins/parquet-data-format/src/main/rust/src/merge/mod.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/src/merge/mod.rs
@@ -11,6 +11,7 @@ mod cursor;
 pub mod error;
 pub mod heap;
 pub mod io_task;
+pub mod metrics;
 pub mod schema;
 mod sorted;
 mod unsorted;

--- a/sandbox/plugins/parquet-data-format/src/main/rust/src/merge/mod.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/src/merge/mod.rs
@@ -36,4 +36,10 @@ pub struct MergeOutput {
     pub metadata: parquet::file::metadata::ParquetMetaData,
     /// Whole-file CRC32 of the merged output file
     pub crc32: u32,
+    /// Per-merge: number of flush+sort+chunk passes that ran inside this merge.
+    pub flush_and_sort_chunk_count: i64,
+    /// Per-merge: cumulative wall-clock millis spent in flush+sort+chunk passes.
+    pub flush_and_sort_chunk_time_millis: i64,
+    /// Per-merge: highest row_id assigned (= total rows written by this merge).
+    pub row_id_mapping_max: i64,
 }

--- a/sandbox/plugins/parquet-data-format/src/main/rust/src/merge/sorted.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/src/merge/sorted.rs
@@ -266,15 +266,15 @@ pub fn merge_sorted(
     }
 
     // ── Phase 5: Close ──────────────────────────────────────────────────
-    let (metadata, crc32) = ctx.finish()?;
+    let stats = ctx.finish()?;
 
     log_debug!(
         "[RUST] Merge complete ({}): {} total rows written to '{}' in {} row groups, crc32={:#010x}",
         direction_label,
-        metadata.file_metadata().num_rows(),
+        stats.metadata.file_metadata().num_rows(),
         output_path,
-        metadata.num_row_groups(),
-        crc32
+        stats.metadata.num_row_groups(),
+        stats.crc32
     );
 
     Ok(super::MergeOutput {
@@ -282,7 +282,10 @@ pub fn merge_sorted(
         gen_keys,
         gen_offsets,
         gen_sizes,
-        metadata,
-        crc32,
+        metadata: stats.metadata,
+        crc32: stats.crc32,
+        flush_and_sort_chunk_count: stats.flush_and_sort_chunk_count,
+        flush_and_sort_chunk_time_millis: stats.flush_and_sort_chunk_time_millis,
+        row_id_mapping_max: stats.row_id_mapping_max,
     })
 }

--- a/sandbox/plugins/parquet-data-format/src/main/rust/src/merge/unsorted.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/src/merge/unsorted.rs
@@ -124,14 +124,14 @@ pub fn merge_unsorted(
         gen_sizes.push(file_rows);
     }
 
-    let (metadata, crc32) = ctx.finish()?;
+    let stats = ctx.finish()?;
 
     log_debug!(
         "[RUST] Unsorted merge complete: {} total rows written to '{}' within {} row groups, crc32={:#010x}",
-        metadata.file_metadata().num_rows(),
+        stats.metadata.file_metadata().num_rows(),
         output_path,
-        metadata.num_row_groups(),
-        crc32
+        stats.metadata.num_row_groups(),
+        stats.crc32
     );
 
     Ok(super::MergeOutput {
@@ -139,7 +139,10 @@ pub fn merge_unsorted(
         gen_keys,
         gen_offsets,
         gen_sizes,
-        metadata,
-        crc32,
+        metadata: stats.metadata,
+        crc32: stats.crc32,
+        flush_and_sort_chunk_count: stats.flush_and_sort_chunk_count,
+        flush_and_sort_chunk_time_millis: stats.flush_and_sort_chunk_time_millis,
+        row_id_mapping_max: stats.row_id_mapping_max,
     })
 }

--- a/sandbox/qa/analytics-engine-rest/build.gradle
+++ b/sandbox/qa/analytics-engine-rest/build.gradle
@@ -62,9 +62,9 @@ def configureAnalyticsCluster = { cluster ->
     cluster.plugin ':plugins:arrow-flight-rpc'
     cluster.plugin ':sandbox:plugins:analytics-engine'
     cluster.plugin ':sandbox:plugins:analytics-backend-datafusion'
+    cluster.plugin ':sandbox:plugins:composite-engine'
     cluster.plugin ':sandbox:plugins:analytics-backend-lucene'
     cluster.plugin ':sandbox:plugins:dsl-query-executor'
-    cluster.plugin ':sandbox:plugins:composite-engine'
     cluster.plugin ':sandbox:plugins:parquet-data-format'
     // Shim — keeps /_analytics/ppl/_explain available for ExplainApiIT, which asserts on
     // the shim's profile/stage-timing output that the real plugin doesn't emit.


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description

  
  ## Summary
  
  Adds runtime visibility into the composite data-format engine via per-format stats APIs. Each registered data format exposes its own pair of REST endpoints, discovered automatically
  via a small SPI. Open for extension (new format = new provider), closed for modification (composite-engine never references concrete formats).
  
  API mirrors OpenSearch's standard `_stats` conventions — same parameter names, same JSON shape, same `IndicesOptions` semantics — so existing tooling works unchanged.
  
  ## API surface
  
  | Endpoint | Purpose |
  |---|---|
  | `GET /_plugins/{format}/{index}/_stats` | Per-index stats (use `?level=shards` for per-shard breakdown) |
  | `GET /_plugins/{format}/_nodes/_stats` | Aggregate across all nodes |
  | `GET /_plugins/{format}/_nodes/{nodeId}/_stats` | Aggregate for a specific node |
  
  `{format}` is `parquet` or `lucene` today.
  
  **Query params:** `level=index|shards`, `shards=0,2,5`, `nodes=node1,node2` or `_local`, `ignore_unavailable`, `allow_no_indices`, `expand_wildcards`. Standard `?filter_path` works on
  all responses.
  
  ### Sample — parquet
  
  ```bash
  GET /_plugins/parquet/myindex/_stats
  
  {
    "_shards": { "total": 1, "successful": 1, "failed": 0 },
    "format": "parquet",
    "indices": {
      "myindex": {
        "indexing":     { "docs_indexed_total": 12345, "index_time_millis": 234 },
        "vsr":          { "vsr_rotations_total": 4 },
        "native_write": { "native_write_total": 4, "native_finalize_total": 4, "native_write_failures": 0 },
        "merge":        { "merge_total": 1, "merge_input_files_total": 4, "merge_output_rows_total": 12345, "merge_failures": 0 }
      }
    }
  }
  ```
  Sample — lucene
  ```
  GET /_plugins/lucene/myindex/_stats
  
  {
    "_shards": { "total": 1, "successful": 1, "failed": 0 },
    "format": "lucene",
    "indices": {
      "myindex": {
        "indexing": { "docs_indexed_total": 12345, "docs_indexed_failures": 0, "index_time_millis": 198 },
        "refresh":  { "refresh_total": 8, "refresh_segments_incorporated_total": 12 },
        "flush":    { "flush_total": 3, "flush_time_millis": 510 },
        "commit":   { "commit_total": 3, "commit_time_millis": 412 },
        "merge":    { "merge_total": 2, "merge_failures": 0 }
      }
    }
  }
```
  
  Shard-level (?level=shards) wraps per-shard routing in a routing sub-object (state, primary, node, relocating_node) matching the standard _stats shape.
  
  Architecture
  
  - plugin-stats-spi (sandbox/libs/plugin-stats-spi/) — defines DataFormatStatsProvider<T> and a JVM-wide DataFormatStatsProviderRegistry. Generic over each format's typed shard-stats
  class so aggregation is type-safe end-to-end.
  - Per-format providers — ParquetStatsProvider, LuceneStatsProvider register with the SPI on construction. Engines self-register per-shard LongAdder-backed trackers; the registry is the
  single source of truth.
  - Auto-discovery — CompositeDataFormatPlugin.getRestHandlers() iterates registry.all() and registers REST + transport actions per provider. Zero hardcoded format names.
  - Format-owned aggregation — coordinator merges via T.add(other); each format defines per-counter merge rules (sum vs. max vs. min) instead of blind JSON deep-merge.
  - Primary-only filter — DFA replicas have no indexing engine; broadcast restricts to primaries so _shards.total matches index.number_of_shards.
 
  
  GET /_plugins/orc/{index}/_stats and GET /_plugins/orc/_nodes/_stats work automatically — no edits to composite-engine.

```
  All stats exposed by our PR — Parquet + Lucene
  
  Parquet — 24 per-shard counters + 17 native runtime fields (incl. 2 derived)
  
  Per-shard / per-index counters (visible at /_plugins/parquet/{index}/_stats)
  
  "indexing": {
    "docs_indexed_total": 0,        // count of docs successfully added
    "index_time_millis": 0          // cumulative time spent in addDoc
  },
  "vsr": {
    "vsr_rotations_total": 0        // count of VSR buffer rotations (fires under heavy load)
  },
  "native_write": {
    "native_write_total": 0,         // count of batches written to disk
    "native_write_time_millis": 0,
    "native_write_failures": 0,
    "native_finalize_total": 0,      // count of parquet files sealed (one per refresh)
    "native_finalize_time_millis": 0,
    "native_finalize_failures": 0,
    "native_sync_total": 0,          // count of explicit sync() calls (rare path)
    "native_sync_time_millis": 0,
    "native_sync_failures": 0
  },
  "merge": {
    "merge_total": 0,                          // count of parquet merges
    "merge_time_millis": 0,
    "merge_failures": 0,
    "merge_input_files_total": 0,              // sum of input file counts across merges
    "merge_output_rows_total": 0,              // sum of output row counts across merges
    "flush_and_sort_chunk_total": 0,           // count of flush+sort+chunk passes inside merges
    "flush_and_sort_chunk_time_millis": 0,     // cumulative wall time in flush+sort+chunk passes
    "row_id_mapping_max": 0                    // max row_id assigned across this shard's merges (max-of-maxes when aggregated)
  },
  "background_write": {
    "background_write_total": 0,         // count of completed async VSR writes
    "background_write_wait_millis": 0,   // cumulative wait time
    "background_write_timeouts": 0,
    "background_write_failures": 0
  }
  
  Node-level only — native_runtime block at /_plugins/parquet/_nodes/_stats
  
  "native_runtime": {
    "parquet_merge": {                        // rayon merge pool — process-wide singleton on this node
      "configured_threads": 0,                // merge pool size
      "merge_tasks_submitted": 0,             // cumulative merges entered the wrapper
      "merge_tasks_started": 0,               // cumulative merges actually picked up by a rayon worker
      "merge_tasks_completed": 0,             // cumulative merges finished OK
      "merge_tasks_failed": 0,                // cumulative merges that returned a logical error
      "merge_tasks_panicked": 0,              // cumulative panics caught (re-raised after counter bump)
      "merge_wall_millis": 0,                 // cumulative wall time inside record_merge
      "merge_tasks_queue_depth": 0,           // derived: max(0, submitted - started)
      "merge_tasks_in_flight": 0              // derived: max(0, started - completed - failed - panicked)
    },
    "parquet_io": {                           // tokio IO runtime — process-wide singleton on this node
      "num_workers": 0,                       // tokio runtime worker count
      "num_blocking_threads": 0,              // blocking-pool size
      "active_tasks": 0,                      // tasks currently in flight
      "global_queue_depth": 0,                // tasks queued in the global injector / backpressure indicator
      "blocking_queue_depth": 0,              // tasks queued in the blocking-thread-pool injector
      "local_queue_depth_total": 0,           // sum of per-worker local queue depths
      "polls_count_total": 0,                 // cumulative task polls across all workers
      "overflow_count_total": 0,              // cumulative local-queue overflow events into the global queue
      "spawned_tasks_total": 0,               // lifetime tasks spawned
      "workers_busy_millis_total": 0          // sum of per-worker busy duration
    }
  }
  
  24 per-shard + 17 native runtime (15 stored + 2 derived) = 41 parquet stats total.
  
  ────────────────────────────────────────────────────────────────────────────────
  
  Lucene — 18 per-shard counters
  
  (Visible at /_plugins/lucene/{index}/_stats. No native runtime block — lucene has no native pools.)
  
  "indexing": {
    "docs_indexed_total": 0,
    "docs_indexed_failures": 0,
    "index_time_millis": 0
  },
  "flush": {
    "flush_total": 0,                       // count of flushes (each refresh triggers a flush in composite)
    "flush_time_millis": 0,
    "flush_force_merge_time_millis": 0      // time spent in flush's internal force-merge to 1 segment
  },
  "refresh": {
    "refresh_total": 0,
    "refresh_time_millis": 0,
    "refresh_add_indexes_time_millis": 0,   // time inside sharedWriter.addIndexes()
    "refresh_segments_incorporated_total": 0  // count of source segments merged into shared writer
  },
  "merge": {
    "merge_total": 0,                       // standalone IndexWriter merges (always 0 in composite flow)
    "merge_time_millis": 0,
    "merge_failures": 0
  },
  "commit": {
    "commit_total": 0,                      // count of successful commits (index creation = 1; each flush adds another)
    "commit_time_millis": 0,                // wall time across all attempts (success + failure)
    "commit_failures": 0                    // count of commits that threw — total + failures = total attempts
  },
  "delete": {
    "delete_total": 0,                      // always 0 today — composite engine rejects deletes
    "delete_time_millis": 0
  }
  

```

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
