### PR TITLE
Adding grpc interceptor to help with clearing up arrow buffer messages in queue that are cancelled

### DIFF
--- a/plugins/arrow-flight-rpc/src/main/java/org/apache/arrow/flight/OSFlightClient.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/apache/arrow/flight/OSFlightClient.java
@@ -8,6 +8,7 @@
 
 package org.apache.arrow.flight;
 
+import io.grpc.ClientInterceptor;
 import io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.NettyChannelBuilder;
 import io.netty.channel.EventLoopGroup;
@@ -41,6 +42,7 @@ public class OSFlightClient {
         private InputStream clientKey = null;
         private String overrideHostname = null;
         private List<FlightClientMiddleware.Factory> middleware = new ArrayList<>();
+        private List<ClientInterceptor> grpcInterceptors = new ArrayList<>();
         private boolean verifyServer = true;
 
         private EventLoopGroup workerELG;
@@ -101,6 +103,12 @@ public class OSFlightClient {
 
         public Builder intercept(FlightClientMiddleware.Factory factory) {
             middleware.add(factory);
+            return this;
+        }
+
+        /** Register a gRPC {@link ClientInterceptor} on the underlying channel. */
+        public Builder grpcIntercept(ClientInterceptor interceptor) {
+            grpcInterceptors.add(Preconditions.checkNotNull(interceptor));
             return this;
         }
 
@@ -219,7 +227,11 @@ public class OSFlightClient {
             if (workerELG != null) {
                 builder.eventLoopGroup(workerELG);
             }
- 
+
+            if (!grpcInterceptors.isEmpty()) {
+                builder.intercept(grpcInterceptors);
+            }
+
             return new FlightClient(allocator, builder.build(), middleware);
         }
 

--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/BufferReleasingClientInterceptor.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/BufferReleasingClientInterceptor.java
@@ -1,0 +1,119 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.arrow.flight.transport;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.InputStream;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.ForwardingClientCall.SimpleForwardingClientCall;
+import io.grpc.ForwardingClientCallListener.SimpleForwardingClientCallListener;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.MethodDescriptor.Marshaller;
+import io.grpc.Status;
+
+/**
+ * gRPC {@link ClientInterceptor} that closes Arrow Flight response messages whose buffers
+ * were parsed off the wire but never delivered to the application.
+ *
+ * <p>The Flight {@code DoGet}/{@code DoExchange} response marshaller allocates {@code ArrowBuf}s
+ * the moment a frame arrives. The parsed message sits in gRPC's per-call {@code MessagesAvailable}
+ * queue until the application calls {@code FlightStream.next()}. If the stream is cancelled
+ * (server-side error, client cancel, deadline) before that happens, gRPC drops the queued
+ * messages without invoking {@link AutoCloseable#close()} on them, so the buffers stay accounted
+ * against the flight allocator forever.
+ *
+ * <p>This interceptor wraps the response marshaller, tracks every parsed message that is
+ * {@link AutoCloseable}, removes entries when {@code Listener.onMessage} hands the message off
+ * to the application, and closes anything still in the queue when {@code Listener.onClose} fires.
+ *
+ * @opensearch.internal
+ */
+final class BufferReleasingClientInterceptor implements ClientInterceptor {
+
+    private static final Logger logger = LogManager.getLogger(BufferReleasingClientInterceptor.class);
+
+    @Override
+    public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+        MethodDescriptor<ReqT, RespT> method,
+        CallOptions callOptions,
+        Channel next
+    ) {
+        TrackingMarshaller<RespT> tracking = new TrackingMarshaller<>(method.getResponseMarshaller());
+        MethodDescriptor<ReqT, RespT> wrapped = method.toBuilder(method.getRequestMarshaller(), tracking).build();
+        return new SimpleForwardingClientCall<ReqT, RespT>(next.newCall(wrapped, callOptions)) {
+            @Override
+            public void start(Listener<RespT> responseListener, Metadata headers) {
+                super.start(new SimpleForwardingClientCallListener<RespT>(responseListener) {
+                    @Override
+                    public void onMessage(RespT message) {
+                        super.onMessage(message);
+                        tracking.markDelivered(message);
+                    }
+
+                    @Override
+                    public void onClose(Status status, Metadata trailers) {
+                        try {
+                            super.onClose(status, trailers);
+                        } finally {
+                            tracking.releaseUndelivered();
+                        }
+                    }
+                }, headers);
+            }
+        };
+    }
+
+    private static final class TrackingMarshaller<T> implements Marshaller<T> {
+        private final Marshaller<T> delegate;
+        private final ConcurrentLinkedQueue<T> outstanding = new ConcurrentLinkedQueue<>();
+
+        TrackingMarshaller(Marshaller<T> delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public InputStream stream(T value) {
+            return delegate.stream(value);
+        }
+
+        @Override
+        public T parse(InputStream stream) {
+            T value = delegate.parse(stream);
+            if (value instanceof AutoCloseable) {
+                outstanding.add(value);
+            }
+            return value;
+        }
+
+        void markDelivered(T value) {
+            outstanding.remove(value);
+        }
+
+        void releaseUndelivered() {
+            T value;
+            while ((value = outstanding.poll()) != null) {
+                if (value instanceof AutoCloseable c) {
+                    try {
+                        c.close();
+                    } catch (Exception e) {
+                        logger.warn("failed to release Arrow Flight message buffer on stream termination", e);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightTransport.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightTransport.java
@@ -330,6 +330,7 @@ class FlightTransport extends TcpTransport {
             .sslContext(sslContextProvider != null ? sslContextProvider.getClientSslContext() : null)
             .executor(clientExecutor)
             .intercept(factory)
+            .grpcIntercept(new BufferReleasingClientInterceptor())
             .build();
 
         try {

--- a/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/BufferReleasingClientInterceptorTests.java
+++ b/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/BufferReleasingClientInterceptorTests.java
@@ -1,0 +1,259 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.arrow.flight.transport;
+
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.MethodDescriptor.Marshaller;
+import io.grpc.MethodDescriptor.MethodType;
+import io.grpc.Status;
+
+public class BufferReleasingClientInterceptorTests extends OpenSearchTestCase {
+
+    /**
+     * Closeable stand-in for an ArrowMessage. Increments a counter on each close().
+     */
+    private static final class CountingCloseable implements AutoCloseable {
+        private final AtomicInteger closeCount;
+
+        CountingCloseable(AtomicInteger closeCount) {
+            this.closeCount = closeCount;
+        }
+
+        @Override
+        public void close() {
+            closeCount.incrementAndGet();
+        }
+    }
+
+    /**
+     * Captures the wrapped MethodDescriptor and the listener so the test can drive the
+     * call as if it were gRPC.
+     */
+    private static final class CapturingChannel extends Channel {
+        MethodDescriptor<byte[], CountingCloseable> capturedMethod;
+        ClientCall.Listener<CountingCloseable> capturedListener;
+
+        @Override
+        public <ReqT, RespT> ClientCall<ReqT, RespT> newCall(MethodDescriptor<ReqT, RespT> methodDescriptor, CallOptions callOptions) {
+            @SuppressWarnings("unchecked")
+            MethodDescriptor<byte[], CountingCloseable> typed = (MethodDescriptor<byte[], CountingCloseable>) methodDescriptor;
+            capturedMethod = typed;
+            return new ClientCall<ReqT, RespT>() {
+                @Override
+                public void start(Listener<RespT> responseListener, Metadata headers) {
+                    @SuppressWarnings("unchecked")
+                    ClientCall.Listener<CountingCloseable> typedListener = (ClientCall.Listener<CountingCloseable>) responseListener;
+                    capturedListener = typedListener;
+                }
+
+                @Override
+                public void request(int numMessages) {}
+
+                @Override
+                public void cancel(String message, Throwable cause) {}
+
+                @Override
+                public void halfClose() {}
+
+                @Override
+                public void sendMessage(ReqT message) {}
+            };
+        }
+
+        @Override
+        public String authority() {
+            return "test";
+        }
+    }
+
+    private MethodDescriptor<byte[], CountingCloseable> buildMethod(AtomicInteger closeCount, List<CountingCloseable> parsed) {
+        Marshaller<byte[]> requestMarshaller = new Marshaller<>() {
+            @Override
+            public InputStream stream(byte[] value) {
+                return new ByteArrayInputStream(value);
+            }
+
+            @Override
+            public byte[] parse(InputStream stream) {
+                return new byte[0];
+            }
+        };
+        Marshaller<CountingCloseable> responseMarshaller = new Marshaller<>() {
+            @Override
+            public InputStream stream(CountingCloseable value) {
+                return new ByteArrayInputStream(new byte[0]);
+            }
+
+            @Override
+            public CountingCloseable parse(InputStream stream) {
+                CountingCloseable c = new CountingCloseable(closeCount);
+                parsed.add(c);
+                return c;
+            }
+        };
+        return MethodDescriptor.<byte[], CountingCloseable>newBuilder()
+            .setType(MethodType.SERVER_STREAMING)
+            .setFullMethodName("test/Stream")
+            .setRequestMarshaller(requestMarshaller)
+            .setResponseMarshaller(responseMarshaller)
+            .build();
+    }
+
+    public void testUndeliveredMessagesClosedOnTermination() {
+        AtomicInteger closeCount = new AtomicInteger();
+        List<CountingCloseable> parsed = new ArrayList<>();
+        MethodDescriptor<byte[], CountingCloseable> method = buildMethod(closeCount, parsed);
+
+        BufferReleasingClientInterceptor interceptor = new BufferReleasingClientInterceptor();
+        CapturingChannel channel = new CapturingChannel();
+
+        ClientCall<byte[], CountingCloseable> wrappedCall = interceptor.interceptCall(method, CallOptions.DEFAULT, channel);
+        AtomicReference<Status> closeStatus = new AtomicReference<>();
+        wrappedCall.start(new ClientCall.Listener<>() {
+            @Override
+            public void onClose(Status status, Metadata trailers) {
+                closeStatus.set(status);
+            }
+        }, new Metadata());
+
+        // Simulate gRPC parsing 3 messages off the wire via the (now-tracking) marshaller.
+        Marshaller<CountingCloseable> tracking = channel.capturedMethod.getResponseMarshaller();
+        CountingCloseable m0 = tracking.parse(new ByteArrayInputStream(new byte[0]));
+        CountingCloseable m1 = tracking.parse(new ByteArrayInputStream(new byte[0]));
+        CountingCloseable m2 = tracking.parse(new ByteArrayInputStream(new byte[0]));
+
+        // Application consumes m0 only; m1 and m2 stay queued.
+        channel.capturedListener.onMessage(m0);
+
+        // Stream cancelled (server error / client cancel / deadline — all flow through onClose).
+        channel.capturedListener.onClose(Status.CANCELLED, new Metadata());
+
+        assertSame(Status.CANCELLED, closeStatus.get());
+        // Interceptor closed the two undelivered messages; the delivered one is the application's responsibility.
+        assertEquals("expected interceptor to close 2 undelivered messages", 2, closeCount.get());
+        assertEquals(3, parsed.size());
+        assertSame(parsed.get(0), m0);
+    }
+
+    public void testNoDoubleCloseWhenAllMessagesDelivered() {
+        AtomicInteger closeCount = new AtomicInteger();
+        List<CountingCloseable> parsed = new ArrayList<>();
+        MethodDescriptor<byte[], CountingCloseable> method = buildMethod(closeCount, parsed);
+
+        BufferReleasingClientInterceptor interceptor = new BufferReleasingClientInterceptor();
+        CapturingChannel channel = new CapturingChannel();
+
+        ClientCall<byte[], CountingCloseable> wrappedCall = interceptor.interceptCall(method, CallOptions.DEFAULT, channel);
+        wrappedCall.start(new ClientCall.Listener<>() {
+        }, new Metadata());
+
+        Marshaller<CountingCloseable> tracking = channel.capturedMethod.getResponseMarshaller();
+        CountingCloseable m0 = tracking.parse(new ByteArrayInputStream(new byte[0]));
+        CountingCloseable m1 = tracking.parse(new ByteArrayInputStream(new byte[0]));
+
+        channel.capturedListener.onMessage(m0);
+        channel.capturedListener.onMessage(m1);
+        channel.capturedListener.onClose(Status.OK, new Metadata());
+
+        assertEquals("interceptor must not close messages already delivered to the application", 0, closeCount.get());
+    }
+
+    public void testNonCloseableResponsesPassThrough() {
+        AtomicInteger closeCount = new AtomicInteger();
+        // String responses — not AutoCloseable, must not be tracked.
+        Marshaller<byte[]> requestMarshaller = new Marshaller<>() {
+            @Override
+            public InputStream stream(byte[] value) {
+                return new ByteArrayInputStream(value);
+            }
+
+            @Override
+            public byte[] parse(InputStream stream) {
+                return new byte[0];
+            }
+        };
+        Marshaller<String> responseMarshaller = new Marshaller<>() {
+            @Override
+            public InputStream stream(String value) {
+                return new ByteArrayInputStream(value.getBytes());
+            }
+
+            @Override
+            public String parse(InputStream stream) {
+                return "hello";
+            }
+        };
+        MethodDescriptor<byte[], String> method = MethodDescriptor.<byte[], String>newBuilder()
+            .setType(MethodType.UNARY)
+            .setFullMethodName("test/Unary")
+            .setRequestMarshaller(requestMarshaller)
+            .setResponseMarshaller(responseMarshaller)
+            .build();
+
+        BufferReleasingClientInterceptor interceptor = new BufferReleasingClientInterceptor();
+        AtomicReference<MethodDescriptor<byte[], String>> captured = new AtomicReference<>();
+        AtomicReference<ClientCall.Listener<String>> capturedListener = new AtomicReference<>();
+        Channel channel = new Channel() {
+            @Override
+            public <ReqT, RespT> ClientCall<ReqT, RespT> newCall(MethodDescriptor<ReqT, RespT> m, CallOptions callOptions) {
+                @SuppressWarnings("unchecked")
+                MethodDescriptor<byte[], String> typed = (MethodDescriptor<byte[], String>) m;
+                captured.set(typed);
+                return new ClientCall<ReqT, RespT>() {
+                    @Override
+                    public void start(Listener<RespT> l, Metadata h) {
+                        @SuppressWarnings("unchecked")
+                        ClientCall.Listener<String> typedListener = (ClientCall.Listener<String>) l;
+                        capturedListener.set(typedListener);
+                    }
+
+                    @Override
+                    public void request(int numMessages) {}
+
+                    @Override
+                    public void cancel(String msg, Throwable c) {}
+
+                    @Override
+                    public void halfClose() {}
+
+                    @Override
+                    public void sendMessage(ReqT msg) {}
+                };
+            }
+
+            @Override
+            public String authority() {
+                return "test";
+            }
+        };
+
+        ClientCall<byte[], String> wrappedCall = interceptor.interceptCall(method, CallOptions.DEFAULT, channel);
+        wrappedCall.start(new ClientCall.Listener<>() {
+        }, new Metadata());
+
+        // Parse a non-AutoCloseable response — must not blow up; nothing to close.
+        String parsed = captured.get().getResponseMarshaller().parse(new ByteArrayInputStream(new byte[0]));
+        assertEquals("hello", parsed);
+        capturedListener.get().onClose(Status.CANCELLED, new Metadata());
+        assertEquals(0, closeCount.get());
+    }
+}

--- a/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/BufferReleasingClientInterceptorTests.java
+++ b/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/BufferReleasingClientInterceptorTests.java
@@ -12,6 +12,7 @@ import org.opensearch.test.OpenSearchTestCase;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -194,7 +195,7 @@ public class BufferReleasingClientInterceptorTests extends OpenSearchTestCase {
         Marshaller<String> responseMarshaller = new Marshaller<>() {
             @Override
             public InputStream stream(String value) {
-                return new ByteArrayInputStream(value.getBytes());
+                return new ByteArrayInputStream(value.getBytes(StandardCharsets.UTF_8));
             }
 
             @Override


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Fix Arrow flight client allocator leak on cancelled gRPC streams

When a Flight stream is cancelled (admission control/rejection etc), gRPC's per-call MessagesAvailable queue drops ArrowMessages that were parsed off the wire but never delivered to the application. Their backing ArrowBufs stay accounted against the flight native allocator forever. Every subsequent query fails with OutOfMemoryException: Unable to allocate buffer ... Current allocation: 2147483648. Recovery requires JVM restart.

Fix

A new gRPC ClientInterceptor (BufferReleasingClientInterceptor) wraps the response marshaller for each Flight RPC, tracks every parsed AutoCloseable message in a per-call ConcurrentLinkedQueue, removes entries when Listener.onMessage delivers them to the application, and drains+closes anything still queued from Listener.onClose (which gRPC guarantees fires exactly once on every termination path). OSFlightClient.Builder gets a small additive grpcIntercept(ClientInterceptor) method to register it on the underlying NettyChannelBuilder.

<img width="731" height="864" alt="image" src="https://github.com/user-attachments/assets/5f980e48-649d-4b3f-ae5a-8c8e0c27bf70" />


Verification

- New unit test BufferReleasingClientInterceptorTests covers: undelivered messages closed on cancel, no double-close on success, non-AutoCloseable pass-through.
- End-to-end on a single-node cluster running ClickBench datafusion-queries with search_clients=10: unpatched build wedges the allocator before q09 and every subsequent query fails. Patched build progresses past q09 with the allocator oscillating 116–688 MB instead of pinning at 2 GiB.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
Resolves #21861 

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
