### PR TITLE
Add CodeQL workflow permissions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -24,6 +24,10 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
### Description
Adds explicit permissions to the CodeQL workflow so the CodeQL action can complete result publication after analysis.

The failing run shows CodeQL was able to proceed through setup/build, but failed while uploading code scanning results with `Resource not accessible by integration`:

https://github.com/opensearch-project/OpenSearch/actions/runs/26542305341/job/78186384890

### Why this permission is needed
`github/codeql-action/analyze` uploads SARIF results to GitHub code scanning. That upload uses the security events/code scanning API, which requires `security-events: write` for the workflow token. Without that scope, CodeQL can still run analysis, but the final upload step fails and marks the job as a configuration error.

GitHub documents this in:

- [CodeQL Action workflow permissions](https://github.com/github/codeql-action?tab=readme-ov-file#workflow-permissions)
- [Uploading a SARIF file to GitHub](https://docs.github.com/en/code-security/how-tos/find-and-fix-code-vulnerabilities/integrate-with-existing-tools/uploading-a-sarif-file-to-github)

SARIF, or Static Analysis Results Interchange Format, is the JSON-based report format that CodeQL and other static analysis tools use to describe findings. GitHub code scanning consumes SARIF uploads and turns those results into code scanning alerts on pull requests and in the repository Security tab.

This also sets the other needed scopes explicitly:

- `contents: read` for repository checkout/source access
- `actions: read` for CodeQL workflow/action API access
- `security-events: write` for publishing code scanning results

### Validation
- Inspected the failing CodeQL job log
- Ran `git diff --check`
