### PR TITLE
IT: assert lastCommitFileName invariant under concurrent flush/refresh

### DIFF
--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/index/LuceneCommitter.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/index/LuceneCommitter.java
@@ -379,10 +379,15 @@ public class LuceneCommitter extends SafeBootstrapCommitter {
         }
         // Open a temp IndexWriter at the target commit and re-commit. The default deletion policy
         // (KeepOnlyLastCommitDeletionPolicy) discards all other segments_N files, cleaning up
-        // both unsafe commits and orphan non-CatalogSnapshot commits as well, if any
+        // both unsafe commits and orphan non-CatalogSnapshot commits as well, if any.
+        // Pin the merge policy to NoMergePolicy: this writer's only job is to re-anchor the
+        // commit point. The default TieredMergePolicy would otherwise merge segments without
+        // honoring the engine's index sort, producing an unsorted merged segment that the
+        // subsequent (sorted) MergeIndexWriter cannot open.
         IndexWriterConfig iwc = new IndexWriterConfig().setOpenMode(IndexWriterConfig.OpenMode.APPEND)
             .setCommitOnClose(false)
-            .setIndexCommit(targetCommit);
+            .setIndexCommit(targetCommit)
+            .setMergePolicy(NoMergePolicy.INSTANCE);
         try (IndexWriter tempWriter = new IndexWriter(store.directory(), iwc)) {
             tempWriter.setLiveCommitData(targetCommit.getUserData().entrySet());
             tempWriter.commit();

--- a/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/CompositeConcurrentIndexingIT.java
+++ b/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/CompositeConcurrentIndexingIT.java
@@ -17,13 +17,17 @@ import org.opensearch.arrow.allocator.ArrowBasePlugin;
 import org.opensearch.be.datafusion.DataFusionPlugin;
 import org.opensearch.be.lucene.LucenePlugin;
 import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.concurrent.GatedCloseable;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.FeatureFlags;
+import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.index.engine.CommitStats;
 import org.opensearch.index.engine.exec.Segment;
 import org.opensearch.index.engine.exec.WriterFileSet;
+import org.opensearch.index.engine.exec.coord.CatalogSnapshot;
 import org.opensearch.index.engine.exec.coord.DataformatAwareCatalogSnapshot;
+import org.opensearch.index.shard.IndexShard;
 import org.opensearch.parquet.ParquetDataFormatPlugin;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.test.OpenSearchIntegTestCase;
@@ -257,6 +261,147 @@ public class CompositeConcurrentIndexingIT extends OpenSearchIntegTestCase {
         assertEquals("No threads should have failed", 0, failures.get());
 
         // Final refresh + flush
+        client().admin().indices().prepareRefresh(indexName).get();
+        client().admin().indices().prepareFlush(indexName).setForce(true).setWaitIfOngoing(true).get();
+
+        verifyIndex(indexName, numShards, indexedCount.get());
+    }
+
+    /**
+     * Stress test for the flush/refresh interleaving fixed by holding {@code refreshLock}
+     * across the entire {@code DataFormatAwareEngine.flush()} body. Without that lock, a
+     * refresh that fires between {@code committer.commit()} and {@code updateLastCommitInfo()}
+     * advances {@code latestCatalogSnapshot}, leaving the just-committed snapshot with a stale
+     * {@code lastCommitFileName} that may point to a {@code segments_<N>} the deletion sweep
+     * has already removed — surfacing later as peer-recovery {@code NoSuchFileException}.
+     *
+     * <p>The test pushes high contention with multiple parallel indexer + flusher + refresher
+     * threads. After every flush, each flusher reads back the just-committed snapshot's
+     * {@code lastCommitFileName} and asserts it (a) is non-null and (b) references a Lucene
+     * commit file that actually exists on disk — the direct invariant the {@code refreshLock}
+     * fix protects.
+     */
+    public void testConcurrentFlushAndRefreshHoldsRefreshLock() throws Exception {
+        String indexName = INDEX_NAMES[0];
+        int numShards = 1;
+        int docsPerIndexer = 50;
+        int numIndexers = 4;
+        int numFlushers = 3;
+        int numRefreshers = 3;
+        int flushesPerThread = 8;
+        int refreshesPerThread = 8;
+
+        client().admin().indices().prepareCreate(indexName).setSettings(indexSettings(numShards)).get();
+        ensureGreen(indexName);
+
+        // Resolve the primary shard once — used by flushers to read back commit-state invariant
+        ShardId shardId = new ShardId(resolveIndex(indexName), 0);
+        IndexShard primaryShard = null;
+        for (String node : internalCluster().getDataNodeNames()) {
+            try {
+                IndexShard s = getIndexShard(node, shardId, indexName);
+                if (s != null && s.routingEntry().primary()) {
+                    primaryShard = s;
+                    break;
+                }
+            } catch (Exception ignore) {}
+        }
+        assertNotNull("primary shard for [" + indexName + "][0] must be available", primaryShard);
+        final IndexShard primary = primaryShard;
+
+        AtomicInteger failures = new AtomicInteger(0);
+        AtomicInteger raceDetected = new AtomicInteger(0);
+        AtomicInteger indexedCount = new AtomicInteger(0);
+        CyclicBarrier barrier = new CyclicBarrier(numIndexers + numFlushers + numRefreshers);
+
+        Thread[] indexers = new Thread[numIndexers];
+        for (int t = 0; t < numIndexers; t++) {
+            final int threadId = t;
+            indexers[t] = new Thread(() -> {
+                try {
+                    barrier.await();
+                    for (int i = 0; i < docsPerIndexer; i++) {
+                        client().prepareIndex()
+                            .setIndex(indexName)
+                            .setSource("name", "t" + threadId + "_d" + i, "value", threadId * 1000 + i)
+                            .get();
+                        indexedCount.incrementAndGet();
+                    }
+                } catch (Exception e) {
+                    failures.incrementAndGet();
+                }
+            }, "race-indexer-" + t);
+        }
+
+        Thread[] flushers = new Thread[numFlushers];
+        for (int t = 0; t < numFlushers; t++) {
+            flushers[t] = new Thread(() -> {
+                try {
+                    barrier.await();
+                    for (int i = 0; i < flushesPerThread; i++) {
+                        Thread.sleep(randomIntBetween(20, 80));
+                        client().admin().indices().prepareFlush(indexName).setForce(false).setWaitIfOngoing(true).get();
+
+                        // Direct invariant: the just-committed snapshot's lastCommitFileName
+                        // must (a) be non-null and (b) reference a segments_<N> that is still
+                        // on disk. A refresh racing inside flush() leaves the committed snapshot
+                        // with a stale name; once the next deletion sweep runs that file is gone.
+                        try (GatedCloseable<CatalogSnapshot> ref = primary.acquireSafeCatalogSnapshot()) {
+                            String reported = ref.get().getLastCommitFileName();
+                            if (reported == null || !reported.startsWith("segments_")) {
+                                raceDetected.incrementAndGet();
+                                continue;
+                            }
+                            primary.store().incRef();
+                            try {
+                                Set<String> diskFiles = new HashSet<>(Arrays.asList(primary.store().directory().listAll()));
+                                if (!diskFiles.contains(reported)) {
+                                    raceDetected.incrementAndGet();
+                                }
+                            } finally {
+                                primary.store().decRef();
+                            }
+                        }
+                    }
+                } catch (Exception e) {
+                    failures.incrementAndGet();
+                }
+            }, "race-flusher-" + t);
+        }
+
+        Thread[] refreshers = new Thread[numRefreshers];
+        for (int t = 0; t < numRefreshers; t++) {
+            refreshers[t] = new Thread(() -> {
+                try {
+                    barrier.await();
+                    for (int i = 0; i < refreshesPerThread; i++) {
+                        Thread.sleep(randomIntBetween(10, 40));
+                        client().admin().indices().prepareRefresh(indexName).get();
+                    }
+                } catch (Exception e) {
+                    failures.incrementAndGet();
+                }
+            }, "race-refresher-" + t);
+        }
+
+        for (Thread t : indexers)
+            t.start();
+        for (Thread t : flushers)
+            t.start();
+        for (Thread t : refreshers)
+            t.start();
+
+        for (Thread t : indexers)
+            t.join(60_000);
+        for (Thread t : flushers)
+            t.join(60_000);
+        for (Thread t : refreshers)
+            t.join(60_000);
+
+        assertEquals("No worker thread should have failed under concurrent flush/refresh", 0, failures.get());
+        assertEquals("Committed snapshot's lastCommitFileName must always match an existing segments_<N> on disk", 0, raceDetected.get());
+
+        // Final flush so committed snapshot reflects all indexed docs
         client().admin().indices().prepareRefresh(indexName).get();
         client().admin().indices().prepareFlush(indexName).setForce(true).setWaitIfOngoing(true).get();
 

--- a/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/DataFormatAwareReplicaResilienceIT.java
+++ b/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/DataFormatAwareReplicaResilienceIT.java
@@ -8,8 +8,13 @@
 
 package org.opensearch.composite;
 
+import org.opensearch.cluster.health.ClusterHealthStatus;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
 import org.opensearch.index.shard.IndexShard;
 
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
@@ -101,5 +106,79 @@ public class DataFormatAwareReplicaResilienceIT extends DataFormatAwareReplicati
             Set<String> recoveredFiles = DataFormatAwareITUtils.catalogFilesExcludingSegments(recoveredReplica);
             assertEquals("Recovered replica should have same catalog files as primary", primaryCatalogFiles, recoveredFiles);
         }, 60, TimeUnit.SECONDS);
+    }
+
+    /**
+     * Reproduces the indexSort mismatch fired when {@code LuceneCommitter.discoverAndTrimUnsafeCommits}
+     * runs at engine reinit with many Lucene segments at the safe-commit point.
+     *
+     * <p>Without the fix, {@code discoverAndTrimUnsafeCommits} opens a temp {@code IndexWriter}
+     * with default {@code TieredMergePolicy} and no {@code setIndexSort}. If the safe commit
+     * has {@code >= ~10} segments, the temp writer fires a merge during its open/close cycle
+     * that produces a segment with {@code source=merge} and {@code indexSort=null}. The
+     * subsequent (sorted) {@code MergeIndexWriter} cannot open at that polluted commit and
+     * throws {@code IllegalArgumentException: cannot change previous indexSort=null ...},
+     * leaving the shard unable to start.
+     *
+     * <p>The fix pins {@code NoMergePolicy.INSTANCE} on that temp writer.
+     */
+    public void testEngineReinitDoesNotFailWithIndexSortMismatch() throws Exception {
+        internalCluster().startClusterManagerOnlyNode();
+        internalCluster().startDataOnlyNodes(2);
+
+        // Lucene-secondary index with merges suppressed so refreshes accumulate as separate
+        // segments. The safe commit must reference >= TieredMergePolicy.DEFAULT_SEGMENTS_PER_TIER
+        // (~10) Lucene segments to trigger the buggy temp-writer merge during engine reinit.
+        Settings indexSettings = Settings.builder()
+            .put(dfaIndexSettings(0))
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+            .putList("index.composite.secondary_data_formats", List.of("lucene"))
+            .put("index.composite.merge_on_refresh_max_size", "0")
+            .put("index.merge.policy.max_merge_at_once", 2)
+            .put("index.merge.policy.segments_per_tier", 100)
+            .put("index.merge.policy.floor_segment", "1gb")
+            .build();
+        client().admin().indices().prepareCreate(INDEX_NAME).setSettings(indexSettings).get();
+        ensureGreen(INDEX_NAME);
+
+        // 15 batches × 5 docs with explicit refresh between → ~13 distinct Lucene segments,
+        // well above the TieredMergePolicy default segments_per_tier threshold.
+        int numBatches = 15;
+        int docsPerBatch = 5;
+        for (int b = 0; b < numBatches; b++) {
+            for (int d = 0; d < docsPerBatch; d++) {
+                client().prepareIndex(INDEX_NAME).setSource("name", "b" + b + "_d" + d, "value", b * 100 + d).get();
+            }
+            client().admin().indices().prepareRefresh(INDEX_NAME).get();
+        }
+
+        // Flush so segments are persisted in a real Lucene commit (segments_<N>).
+        client().admin().indices().prepareFlush(INDEX_NAME).setForce(true).setWaitIfOngoing(true).get();
+
+        // Restart the data node holding the primary — forces engine teardown and reinit
+        // through LuceneCommitter.<init> → SafeBootstrapCommitter ctor →
+        // discoverAndTrimUnsafeCommits, which is where the bug fires.
+        String primaryNode = primaryNodeName();
+        internalCluster().restartNode(primaryNode);
+
+        // Without the fix, the new MergeIndexWriter cannot open at the (now polluted)
+        // commit and the shard fails to start, so the cluster never reaches GREEN.
+        // Bound the wait so a buggy build fails fast rather than silently retrying for
+        // the default ensureGreen window.
+        ClusterHealthStatus status = client().admin()
+            .cluster()
+            .prepareHealth(INDEX_NAME)
+            .setWaitForGreenStatus()
+            .setTimeout(TimeValue.timeValueSeconds(60))
+            .get()
+            .getStatus();
+        assertEquals(
+            "Index ["
+                + INDEX_NAME
+                + "] must reach GREEN after engine reinit; the indexSort bug in "
+                + "discoverAndTrimUnsafeCommits prevents this when the safe commit has many segments.",
+            ClusterHealthStatus.GREEN,
+            status
+        );
     }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
### What
  
  This PR adds two changes:
  
  1. A regression IT (`CompositeConcurrentIndexingIT#testConcurrentFlushAndRefreshHoldsRefreshLock`) for the `refreshLock` fix in `DataFormatAwareEngine.flush()`.
  2. A bug fix + regression IT for an `indexSort` mismatch in `LuceneCommitter.discoverAndTrimUnsafeCommits` that prevents engine reinit when the safe commit has many Lucene segments.
  
  ---
  
  ### Change 1 — IT for `refreshLock` fix in `DataFormatAwareEngine.flush()`
  
 #### Why
  
  Without holding `refreshLock` across the full flush body, a refresh that fires between `committer.commit()` and `updateLastCommitInfo()` advances `latestCatalogSnapshot` so the
  just-committed snapshot keeps a stale `lastCommitFileName`. The stale name eventually points to a `segments_<N>` the deletion sweep has already removed, and surfaces as peer-recovery
  `NoSuchFileException`.
  
  The existing IT covered concurrent index/refresh/flush correctness but did not assert the on-disk invariant that the fix protects.
  
  #### What the test does
  
  - 4 indexer + 3 flusher + 3 refresher threads, started in lockstep via a `CyclicBarrier`
  - After every flush, the flusher reads back the safe catalog snapshot and asserts
      - `getLastCommitFileName()` is non-null and starts with `segments_`
      - the referenced file is still listed in `store().directory().listAll()`
  - Final `verifyIndex` confirms doc counts and segment-generation invariants
  
  #### Validation
  
  | Configuration | Result |
  |---|---|
  | With `refreshLock` fix | PASS in ~15s |
  | `refreshLock` removed | FAIL: `Committed snapshot's lastCommitFileName must always match an existing segments_<N> on disk` (also surfaces `afterRefresh called but not beforeRefresh`)
  |
  
  Test fails deterministically without the fix and passes with it.
  
  ---
  
  ### Change 2 — Fix `indexSort` mismatch in `LuceneCommitter.discoverAndTrimUnsafeCommits`
  
  #### Why
  
  `LuceneCommitter.discoverAndTrimUnsafeCommits` opens a temp `IndexWriter` in `APPEND` mode at the safe-commit point with no `setMergePolicy` (defaults to `TieredMergePolicy`) and no
  `setIndexSort`. When the safe commit references ≥ ~10 Lucene segments, the temp writer fires a merge during open/close and produces a segment with `source=merge` and `indexSort=null`.
  The new (sorted) `MergeIndexWriter` then fails to open at the polluted commit:
  
  IllegalArgumentException: cannot change previous indexSort=null
      (from segment=_X(...source=merge,...))
      to new indexSort=<sortednumeric: "__row_id__"> ...
      at IndexWriter.validateIndexSort:1225
      at LuceneCommitter.<init>:126
  
  The shard cannot start; the index goes RED.
  
  #### Fix
  
  Pin `NoMergePolicy.INSTANCE` on the temp writer — matches the existing guard vanilla `Store.trimUnsafeCommits` uses (`Store.java:2255`). The temp writer's job is to re-anchor the
  commit point; it must never merge.
  
  #### Test
  
  `DataFormatAwareReplicaResilienceIT#testEngineReinitDoesNotFailWithIndexSortMismatch` fails deterministically without the fix (RED) and passes with it (~60s GREEN).
  ````

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
