### PR TITLE
Bind arrow-flight-rpc tests to a port range, not a single port

### DIFF
--- a/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/FlightTransportTestBase.java
+++ b/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/FlightTransportTestBase.java
@@ -42,7 +42,6 @@ import org.junit.Before;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.util.Collections;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -50,8 +49,6 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 public abstract class FlightTransportTestBase extends OpenSearchTestCase {
-
-    private static final AtomicInteger portCounter = new AtomicInteger(0);
 
     protected DiscoveryNode remoteNode;
     protected Location serverLocation;
@@ -69,20 +66,17 @@ public abstract class FlightTransportTestBase extends OpenSearchTestCase {
     public void setUp() throws Exception {
         super.setUp();
 
+        // Configure FlightTransport with a port range rather than a single hardcoded port. The
+        // transport iterates the range via PortsRange.iterate() and binds the first available
+        // port. Using a single port made tests fail with BindTransportException whenever the
+        // chosen port was held in TIME_WAIT or contended by another process on the CI runner.
+        // The actual bound port is read from FlightTransport.boundAddress() after start() below.
         int basePort = getBasePort(9500);
-        int streamPort = basePort + portCounter.incrementAndGet();
-        int transportPort = basePort + portCounter.incrementAndGet();
-
-        TransportAddress streamAddress = new TransportAddress(InetAddress.getLoopbackAddress(), streamPort);
-        TransportAddress transportAddress = new TransportAddress(InetAddress.getLoopbackAddress(), transportPort);
-        remoteNode = new DiscoveryNode(new DiscoveryNode("test-node-id", transportAddress, Version.CURRENT), streamAddress);
-        boundAddress = new BoundTransportAddress(new TransportAddress[] { transportAddress }, transportAddress);
-        serverLocation = Location.forGrpcInsecure("localhost", streamPort);
-        headerContext = new HeaderContext();
+        String portRange = basePort + "-" + (basePort + 99);
 
         Settings settings = Settings.builder()
             .put("node.name", getTestName())
-            .put("aux.transport.transport-flight.port", streamPort)
+            .put("aux.transport.transport-flight.port", portRange)
             .build();
         ServerConfig.init(settings);
         threadPool = new ThreadPool(
@@ -93,6 +87,7 @@ public abstract class FlightTransportTestBase extends OpenSearchTestCase {
         );
         namedWriteableRegistry = new NamedWriteableRegistry(Collections.emptyList());
         statsCollector = new FlightStatsCollector();
+        headerContext = new HeaderContext();
 
         // FlightTransport sources its allocator from the framework's FLIGHT pool. Construct one
         // here so the test has a usable allocator; tearDown closes it.
@@ -113,6 +108,17 @@ public abstract class FlightTransportTestBase extends OpenSearchTestCase {
             nativeAllocator
         );
         flightTransport.start();
+
+        // Resolve the actual bound stream port (chosen by PortsRange.iterate()) and derive the
+        // remote node's transport/stream addresses from it. The transport address is never
+        // bound by this test, so any distinct port suffices.
+        int streamPort = flightTransport.boundAddress().publishAddress().address().getPort();
+        TransportAddress streamAddress = new TransportAddress(InetAddress.getLoopbackAddress(), streamPort);
+        TransportAddress transportAddress = new TransportAddress(InetAddress.getLoopbackAddress(), streamPort + 1);
+        remoteNode = new DiscoveryNode(new DiscoveryNode("test-node-id", transportAddress, Version.CURRENT), streamAddress);
+        boundAddress = new BoundTransportAddress(new TransportAddress[] { transportAddress }, transportAddress);
+        serverLocation = Location.forGrpcInsecure("localhost", streamPort);
+
         TransportService transportService = mock(TransportService.class);
         TaskManager taskManager = mock(TaskManager.class);
         when(taskManager.taskExecutionStarted(any())).thenReturn(mock(ThreadContext.StoredContext.class));


### PR DESCRIPTION
FlightTransportTestBase was assigning a single deterministic port per test via getBasePort(9500) + portCounter. When that port was held in TIME_WAIT or otherwise contended on a CI runner, the FlightTransport bind failed with BindTransportException, causing flakes in FlightOutboundHandlerContextPropagationTests, FlightClientChannelTests, and FlightMetricsTests.

Pass a 100-port range to the aux.transport.transport-flight.port setting so PortsRange.iterate() finds the first free port, and read the actual bound port back from FlightTransport.boundAddress() to construct the test's stream and transport addresses. This matches the pattern used by AbstractSimpleTransportTestCase, MockTransportService, and OpenSearchSingleNodeTestCase.

### Related Issues
Resolves #18938 #18947

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
