### PR TITLE
Set X-Opaque-Id in Log4j2 MDC for analytics engine request tracing

### DIFF
--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/AnalyticsSearchService.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/AnalyticsSearchService.java
@@ -148,6 +148,7 @@ public class AnalyticsSearchService implements AutoCloseable {
     ) {
         try {
             executor.execute(() -> {
+                LOGGER.debug("[FragmentExecution] shard={} task={}", shard.shardId(), task.getId());
                 try (FragmentResources ctx = executeFragmentStreaming(request, shard, task)) {
                     Iterator<EngineResultBatch> it = ctx.stream().iterator();
                     while (it.hasNext()) {

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/AnalyticsSearchTransportService.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/AnalyticsSearchTransportService.java
@@ -95,7 +95,10 @@ public class AnalyticsSearchTransportService {
                     shard,
                     (AnalyticsShardTask) task,
                     channelResponseHandler(channel),
-                    transportService.getThreadPool().executor(ThreadPool.Names.SEARCH)
+                    ContextAwareExecutor.wrap(
+                        transportService.getThreadPool().executor(ThreadPool.Names.SEARCH),
+                        transportService.getThreadPool()
+                    )
                 );
             }
         );
@@ -127,7 +130,10 @@ public class AnalyticsSearchTransportService {
                     shard,
                     (AnalyticsShardTask) task,
                     channelResponseHandler(channel),
-                    transportService.getThreadPool().executor(ThreadPool.Names.SEARCH)
+                    ContextAwareExecutor.wrap(
+                        transportService.getThreadPool().executor(ThreadPool.Names.SEARCH),
+                        transportService.getThreadPool()
+                    )
                 );
             }
         );

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/ContextAwareExecutor.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/ContextAwareExecutor.java
@@ -1,0 +1,50 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.exec;
+
+import org.opensearch.tasks.Task;
+import org.opensearch.threadpool.ThreadPool;
+
+import java.util.concurrent.Executor;
+
+/**
+ * Wraps an {@link Executor} to propagate the {@code X-Opaque-Id} request header from
+ * OpenSearch's {@link org.opensearch.common.util.concurrent.ThreadContext} into Log4j2's
+ * MDC ({@link org.apache.logging.log4j.ThreadContext}) on the executing thread.
+ *
+ * <p>Use this for any analytics engine executor that dispatches work to a thread pool,
+ * so that all downstream loggers automatically include the opaque ID without explicit
+ * parameter passing.
+ *
+ * @opensearch.internal
+ */
+public final class ContextAwareExecutor {
+
+    private ContextAwareExecutor() {}
+
+    /**
+     * Wraps the given executor so that tasks run with the {@code opaque_id} MDC key set
+     * from the current thread's {@code X-Opaque-Id} header.
+     */
+    public static Executor wrap(Executor delegate, ThreadPool threadPool) {
+        return cmd -> {
+            String opaqueId = threadPool.getThreadContext().getHeader(Task.X_OPAQUE_ID);
+            delegate.execute(() -> {
+                if (opaqueId != null) {
+                    org.apache.logging.log4j.ThreadContext.put("opaque_id", opaqueId);
+                }
+                try {
+                    cmd.run();
+                } finally {
+                    org.apache.logging.log4j.ThreadContext.remove("opaque_id");
+                }
+            });
+        };
+    }
+}

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/DefaultPlanExecutor.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/DefaultPlanExecutor.java
@@ -285,7 +285,7 @@ public class DefaultPlanExecutor extends HandledTransportAction<AnalyticsQueryRe
             listener::onResponse,
             e -> listener.onFailure(e instanceof Exception ex ? contextProvider.convertException(ex) : e)
         );
-        searchExecutor.execute(() -> {
+        ContextAwareExecutor.wrap(searchExecutor, threadPool).execute(() -> {
             try {
                 executeInternal(
                     request.getPlan(),


### PR DESCRIPTION
### Description

Populates the Log4j2 ThreadContext (MDC) with the X-Opaque-Id header value on both the coordinator and data node execution threads. This allows operators to trace analytics engine queries through planning, scheduling, and execution logs by adding `%X{opaque_id}` to their log4j2.properties pattern.

Coordinator: MDC is set on the SEARCH thread in DefaultPlanExecutor before planning/execution begins, and cleared in finally.

Data node: MDC is set on the SEARCH thread inside the wrapped executor in AnalyticsSearchTransportService's fragment execution handler.

### Testing

Start single node 
```
./gradlew run -Dsandbox.enabled=true \
  -PinstalledPlugins="['opensearch-job-scheduler:3.7.0.0-SNAPSHOT', 'arrow-base', 'arrow-flight-rpc', 'analytics-engine', 'parquet-data-format', 'analytics-backend-datafusion', 'analytics-backend-lucene', 'composite-engine', 'opensearch-sql-plugin:3.7.0.0-SNAPSHOT']" \
  -Dtests.jvm.argline="-Dopensearch.experimental.feature.pluggable.dataformat.enabled=true -Dopensearch.experimental.feature.transport.stream.enabled=true"
```

Debug logging
```
curl -X PUT "localhost:9200/_cluster/settings" -H 'Content-Type: application/json' -d'
  {"transient": {"logger.org.opensearch.analytics.exec": "DEBUG"}}'
```

Create parquet index
```
curl -X PUT "localhost:9200/test_parquet" -H 'Content-Type: application/json' -d'
{
  "settings": {
    "index.number_of_shards": 2,
    "index.number_of_replicas": 0,
    "index.pluggable.dataformat.enabled": true,
    "index.pluggable.dataformat": "composite"
  },
  "mappings": {
    "properties": {
      "name": {"type": "keyword"},
      "age": {"type": "integer"},
      "score": {"type": "double"}
    }
  }
}'
```

```
curl -X POST "localhost:9200/test_parquet/_bulk?refresh=true" -H 'Content-Type: application/x-ndjson' -d'
{"index":{}}
{"name":"alice","age":30,"score":95.5}
{"index":{}}
{"name":"bob","age":25,"score":87.3}
{"index":{}}
{"name":"carol","age":35,"score":91.0}
```

### Test Query with X-Opaque-Id header

```
curl -X POST "localhost:9200/_plugins/_ppl" \
  -H 'Content-Type: application/json' \
  -H 'X-Opaque-Id: MY-TRACE-XYZ-999' \
  -d '{"query": "source = test_parquet | fields name, score"}'
```

Logger output (planning phase)
```
[2026-05-28T10:54:05,744][INFO ][o.o.a.p.PlannerImpl      ] [runTask-0] [MY-TRACE-XYZ-999] Input RelNode:
LogicalSystemLimit(fetch=[10000], type=[QUERY_SIZE_LIMIT])
  LogicalProject(name=[$1], score=[$2])
    LogicalTableScan(table=[[opensearch, test_parquet]])

[2026-05-28T10:54:05,793][INFO ][o.o.a.p.PlannerImpl      ] [runTask-0] [MY-TRACE-XYZ-999] After marking:
OpenSearchSort(fetch=[10000], viableBackends=[[datafusion]])
  OpenSearchProject(name=[$1], score=[$2], viableBackends=[[datafusion]])
    OpenSearchTableScan(table=[[test_parquet]], viableBackends=[[datafusion]])

[2026-05-28T10:54:05,819][INFO ][o.o.a.p.r.OpenSearchDistributionTraitDef] [runTask-0] [MY-TRACE-XYZ-999] convert(): rel=RelSubset#48, fromTrait=RANDOM(SHARD:t=-2080058522:s=2), toTrait=SINGLETON, backend=datafusion
[2026-05-28T10:54:05,835][INFO ][o.o.a.p.r.OpenSearchDistributionTraitDef] [runTask-0] [MY-TRACE-XYZ-999] convert(): rel=RelSubset#44, fromTrait=RANDOM(SHARD:t=-2080058522:s=2), toTrait=SINGLETON(COORDINATOR), backend=datafusion
```

Logger output (shard level)

```
  [DEBUG][o.o.a.e.AnalyticsSearchService] [runTask-0] [SHARD-PROOF-123] [FragmentExecution] shard=[test_parquet][1] opaque_id_in_mdc=SHARD-PROOF-123
  [DEBUG][o.o.a.e.AnalyticsSearchService] [runTask-0] [SHARD-PROOF-123] [FragmentExecution] shard=[test_parquet][0] opaque_id_in_mdc=SHARD-PROOF-123
```



### Related Issues
N/A

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
