### PR TITLE
Refactor distributed-aggregate rewriter

### DIFF
--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/RelNodeUtils.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/RelNodeUtils.java
@@ -82,7 +82,8 @@ public class RelNodeUtils {
                 aggregate.getMode(),
                 aggregate.getViableBackends(),
                 aggregate.getCallAnnotations(),
-                aggregate.getFinalExtraLiteralArgs()
+                aggregate.getFinalExtraLiteralArgs(),
+                aggregate.getIntermediateFields()
             );
         } else if (node instanceof OpenSearchSort sort) {
             return new OpenSearchSort(

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/dag/DistributedAggregateRewriter.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/dag/DistributedAggregateRewriter.java
@@ -31,21 +31,14 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Post-Volcano orchestrator: adapts a FINAL {@link OpenSearchAggregate}'s input chain (re-types
- * the StageInputScan when a typeResolver dictates a different shape, inserts a literal-Project
- * for STATE_EXPANDING aggregates) and rebinds its aggCalls via the nested
- * {@link FinalAggCallBuilder} when anything changed.
+ * Adapts a FINAL {@link OpenSearchAggregate}'s input chain after the DAG is fragmented:
+ * re-types the StageInputScan, inserts a literal-Project for STATE_EXPANDING aggregates, and
+ * rebinds aggCalls via {@link FinalAggCallBuilder} when anything changed. Called from
+ * {@code BackendPlanAdapter.adaptNode}.
  *
- * <p>Runs after Volcano CBO and DAG fragmentation, called from
- * {@code BackendPlanAdapter.adaptNode} once per FINAL aggregate per backend. At that point
- * FINAL's input chain ends at an {@link OpenSearchStageInputScan} placeholder — PARTIAL lives
- * in a sibling stage.
- *
- * <p>TODO: {@link FinalAggCallBuilder} also runs at split-rule time (called from
- * {@code OpenSearchAggregateSplitRule} in {@code planner.rules}), so its current home here
- * means {@code planner.rules} reaches into {@code planner.dag} — backwards from the usual
- * layered direction. Move it to a top-level class in {@code planner.rel} once a third
- * construction-time consumer appears.
+ * <p>TODO: {@link FinalAggCallBuilder} is also used by the split rule, so {@code planner.rules}
+ * reaches into {@code planner.dag} — backwards from the usual layering. Move it to
+ * {@code planner.rel} once a third construction-time consumer appears.
  *
  * @opensearch.internal
  */
@@ -56,8 +49,6 @@ public final class DistributedAggregateRewriter {
     static RelNode rewrite(OpenSearchAggregate finalAgg) {
         assert finalAgg.getMode() == AggregateMode.FINAL : "rewrite is only called on FINAL aggregates";
         RelNode exchange = finalAgg.getInput();
-        // Skip degenerate trees where the exchange has no child or the leaf below it isn't
-        // a StageInputScan — transformers target the StageInputScan layer.
         if (exchange.getInputs().isEmpty()) return finalAgg;
         if (!(exchange.getInputs().get(0) instanceof OpenSearchStageInputScan)) return finalAgg;
 

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/dag/DistributedAggregateRewriter.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/dag/DistributedAggregateRewriter.java
@@ -25,192 +25,302 @@ import org.opensearch.analytics.spi.AggregateFunction;
 import org.opensearch.analytics.spi.AggregateFunction.IntermediateField;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
 /**
- * Post-Volcano distributed-aggregate decomposition for FINAL aggregate calls. Classifies
- * each call via {@link AggregateFunction#intermediateFields} into pass-through,
- * function-swap (e.g. COUNT→SUM), or engine-native merge (reducer == self), and rebuilds
- * its argList, function, and return type accordingly. Sole owner of
- * {@link AggregateCall#create} on the FINAL side.
+ * Post-Volcano orchestrator: adapts a FINAL {@link OpenSearchAggregate}'s input chain (re-types
+ * the StageInputScan when a typeResolver dictates a different shape, inserts a literal-Project
+ * for STATE_EXPANDING aggregates) and rebinds its aggCalls via the nested
+ * {@link FinalAggCallBuilder} when anything changed.
+ *
+ * <p>Runs after Volcano CBO and DAG fragmentation, called from
+ * {@code BackendPlanAdapter.adaptNode} once per FINAL aggregate per backend. At that point
+ * FINAL's input chain ends at an {@link OpenSearchStageInputScan} placeholder — PARTIAL lives
+ * in a sibling stage.
+ *
+ * <p>TODO: {@link FinalAggCallBuilder} also runs at split-rule time (called from
+ * {@code OpenSearchAggregateSplitRule} in {@code planner.rules}), so its current home here
+ * means {@code planner.rules} reaches into {@code planner.dag} — backwards from the usual
+ * layered direction. Move it to a top-level class in {@code planner.rel} once a third
+ * construction-time consumer appears.
  *
  * @opensearch.internal
  */
-final class DistributedAggregateRewriter {
+public final class DistributedAggregateRewriter {
 
     private DistributedAggregateRewriter() {}
 
     static RelNode rewrite(OpenSearchAggregate finalAgg) {
+        assert finalAgg.getMode() == AggregateMode.FINAL : "rewrite is only called on FINAL aggregates";
         RelNode exchange = finalAgg.getInput();
+        // Skip degenerate trees where the exchange has no child or the leaf below it isn't
+        // a StageInputScan — transformers target the StageInputScan layer.
         if (exchange.getInputs().isEmpty()) return finalAgg;
-        if (!(exchange.getInputs().get(0) instanceof OpenSearchStageInputScan stageInput)) return finalAgg;
+        if (!(exchange.getInputs().get(0) instanceof OpenSearchStageInputScan)) return finalAgg;
 
-        RelDataTypeFactory tf = finalAgg.getCluster().getTypeFactory();
-        int groupCount = finalAgg.getGroupSet().cardinality();
-        boolean hasEmptyGroup = finalAgg.getGroupSet().isEmpty();
+        TransformResult result = TransformResult.initial(exchange);
+        result = overrideExchangeType(finalAgg, result);
+        result = insertLiteralProject(finalAgg, result);
+        if (!result.changed(exchange)) return finalAgg;
 
-        RelDataType originalExchangeType = stageInput.getRowType();
-        List<RelDataType> exchangeTypes = new ArrayList<>(originalExchangeType.getFieldCount());
-        List<String> exchangeNames = new ArrayList<>(originalExchangeType.getFieldCount());
-        for (RelDataTypeField f : originalExchangeType.getFieldList()) {
-            exchangeTypes.add(f.getType());
-            exchangeNames.add(f.getName());
-        }
-
-        List<IntermediateField> perCallField = new ArrayList<>(finalAgg.getAggCallList().size());
-        for (int i = 0; i < finalAgg.getAggCallList().size(); i++) {
-            AggregateCall call = finalAgg.getAggCallList().get(i);
-            List<IntermediateField> fields = AggregateFunction.fromSqlAggFunction(call.getAggregation()).intermediateFields();
-            IntermediateField field;
-            if (fields == null) {
-                field = null;
-            } else if (fields.size() == 1) {
-                field = fields.get(0);
-                RelDataType partialOutputType = originalExchangeType.getFieldList().get(groupCount + i).getType();
-                exchangeTypes.set(groupCount + i, field.typeResolver().resolve(List.of(partialOutputType), tf));
-            } else {
-                throw new IllegalStateException(
-                    "Multi-field decomposition for ["
-                        + call.getAggregation().getName()
-                        + "] should have been reduced by OpenSearchAggregateReduceRule during HEP marking"
-                );
-            }
-            perCallField.add(field);
-        }
-
-        RelDataType overriddenExchangeType = tf.createStructType(exchangeTypes, exchangeNames);
-        RelNode newFinalInput;
-        if (overriddenExchangeType.equals(originalExchangeType)) {
-            newFinalInput = exchange;
-        } else {
-            OpenSearchStageInputScan newStageInput = new OpenSearchStageInputScan(
-                stageInput.getCluster(),
-                stageInput.getTraitSet(),
-                stageInput.getChildStageId(),
-                overriddenExchangeType,
-                stageInput.getViableBackends(),
-                stageInput.getOutputFieldStorage()
-            );
-            newFinalInput = exchange.copy(exchange.getTraitSet(), List.of(newStageInput));
-        }
-
-        // Re-create captured literal aggregate-args (e.g. TAKE's N) as constant Project
-        // columns. SubstraitPlanRewriter.visit(Aggregate) inlines them into the substrait.
-        Map<Integer, List<RexLiteral>> extraLiterals = finalAgg.getFinalExtraLiteralArgs();
-        Map<Integer, List<Integer>> extraLiteralColIdxByCallIdx;
-        if (extraLiterals.isEmpty()) {
-            extraLiteralColIdxByCallIdx = Map.of();
-        } else {
-            int origColCount = newFinalInput.getRowType().getFieldCount();
-            List<RexNode> projectExprs = new ArrayList<>(origColCount);
-            List<String> projectNames = new ArrayList<>(origColCount);
-            for (int idx = 0; idx < origColCount; idx++) {
-                RelDataType fieldType = newFinalInput.getRowType().getFieldList().get(idx).getType();
-                projectExprs.add(new RexInputRef(idx, fieldType));
-                projectNames.add(newFinalInput.getRowType().getFieldList().get(idx).getName());
-            }
-            java.util.LinkedHashMap<Integer, List<Integer>> idxMap = new java.util.LinkedHashMap<>();
-            for (Map.Entry<Integer, List<RexLiteral>> entry : extraLiterals.entrySet()) {
-                List<Integer> colIdxs = new ArrayList<>(entry.getValue().size());
-                for (int litI = 0; litI < entry.getValue().size(); litI++) {
-                    RexLiteral lit = entry.getValue().get(litI);
-                    int colIdx = projectExprs.size();
-                    projectExprs.add(lit);
-                    projectNames.add("$lit_call" + entry.getKey() + "_" + litI);
-                    colIdxs.add(colIdx);
-                }
-                idxMap.put(entry.getKey(), List.copyOf(colIdxs));
-            }
-            RelDataTypeFactory.Builder rowTypeBuilder = tf.builder();
-            for (int idx = 0; idx < projectExprs.size(); idx++) {
-                rowTypeBuilder.add(projectNames.get(idx), projectExprs.get(idx).getType());
-            }
-            newFinalInput = new OpenSearchProject(
-                newFinalInput.getCluster(),
-                newFinalInput.getTraitSet(),
-                newFinalInput,
-                projectExprs,
-                rowTypeBuilder.build(),
-                finalAgg.getViableBackends()
-            );
-            extraLiteralColIdxByCallIdx = idxMap;
-        }
-
-        List<AggregateCall> rebuiltCalls = new ArrayList<>(finalAgg.getAggCallList().size());
-        for (int i = 0; i < finalAgg.getAggCallList().size(); i++) {
-            AggregateCall call = finalAgg.getAggCallList().get(i);
-            IntermediateField field = perCallField.get(i);
-            int stateColIdx = groupCount + i;
-            String name = overriddenExchangeType.getFieldList().get(stateColIdx).getName();
-            List<Integer> extraColIdxs = extraLiteralColIdxByCallIdx.getOrDefault(i, List.of());
-            rebuiltCalls.add(buildFinalCall(call, field, stateColIdx, extraColIdxs, name, newFinalInput, hasEmptyGroup));
-        }
-
-        return new OpenSearchAggregate(
-            finalAgg.getCluster(),
-            finalAgg.getTraitSet(),
-            newFinalInput,
-            finalAgg.getGroupSet(),
-            finalAgg.getGroupSets(),
-            rebuiltCalls,
-            AggregateMode.FINAL,
-            finalAgg.getViableBackends(),
-            finalAgg.getCallAnnotations(),
-            // Cleared so a later copy doesn't re-inject the literal Project.
-            Map.of()
+        List<AggregateCall> rebuiltCalls = FinalAggCallBuilder.buildFinalCalls(
+            finalAgg.getAggCallList(),
+            finalAgg.getIntermediateFields(),
+            finalAgg.getGroupSet().cardinality(),
+            result.finalInput(),
+            finalAgg.getGroupSet().isEmpty(),
+            result.extraLiteralColIdxByCallIdx()
         );
+        return OpenSearchAggregate.finalAfterRewrite(finalAgg, result.finalInput(), rebuiltCalls);
     }
 
-    private static AggregateCall buildFinalCall(
-        AggregateCall call,
-        IntermediateField field,
-        int finalArgIdx,
-        List<Integer> extraColIdxs,
-        String name,
-        RelNode newFinalInput,
-        boolean hasEmptyGroup
-    ) {
-        SqlAggFunction aggFunc;
-        RelDataType explicitType;
-        if (field == null) {
-            aggFunc = call.getAggregation();
-            explicitType = null;
-        } else if (field.reducer() == AggregateFunction.fromSqlAggFunction(call.getAggregation())) {
-            // Engine-native merge: keep function identity, pin return type. STATE_EXPANDING
-            // pins to the StageInputScan column (PARTIAL's output shape); APPROXIMATE keeps
-            // the user-facing return type (e.g. HLL FINAL → BIGINT).
-            aggFunc = call.getAggregation();
-            AggregateFunction enumFn = AggregateFunction.fromSqlAggFunction(call.getAggregation());
-            if (enumFn.getType() == AggregateFunction.Type.STATE_EXPANDING) {
-                explicitType = newFinalInput.getRowType().getFieldList().get(finalArgIdx).getType();
-            } else {
-                explicitType = call.getType();
-            }
-        } else {
-            aggFunc = field.reducer().toSqlAggFunction();
-            explicitType = null;
+    /** Carries the running input chain plus the per-call indexes of any literal columns added. */
+    private record TransformResult(RelNode finalInput, Map<Integer, List<Integer>> extraLiteralColIdxByCallIdx) {
+
+        static TransformResult initial(RelNode finalInput) {
+            return new TransformResult(finalInput, Map.of());
         }
 
-        // State column followed by any forwarded literal-arg columns.
-        List<Integer> argList = new ArrayList<>(1 + extraColIdxs.size());
-        argList.add(finalArgIdx);
-        argList.addAll(extraColIdxs);
+        boolean changed(RelNode original) {
+            return finalInput != original || !extraLiteralColIdxByCallIdx.isEmpty();
+        }
+    }
 
-        return AggregateCall.create(
-            aggFunc,
-            call.isDistinct(),
-            call.isApproximate(),
-            call.ignoreNulls(),
-            call.rexList,
-            List.copyOf(argList),
-            call.filterArg,
-            call.distinctKeys,
-            call.collation,
-            hasEmptyGroup,
-            newFinalInput,
-            explicitType,
-            name
+    // ── Transformer 1: StageInputScan re-typing ─────────────────────────────
+
+    /**
+     * Re-types the StageInputScan when an aggregate's intermediate state has a different shape
+     * than PARTIAL's declared output (e.g. APPROX_COUNT_DISTINCT emits a {@code VARBINARY} HLL
+     * sketch). Reads the per-call classification stored on FINAL — never re-classifies.
+     */
+    private static TransformResult overrideExchangeType(OpenSearchAggregate finalAgg, TransformResult current) {
+        RelNode exchange = current.finalInput();
+        if (exchange.getInputs().isEmpty()) return current;
+        if (!(exchange.getInputs().get(0) instanceof OpenSearchStageInputScan stageInput)) return current;
+
+        List<IntermediateField> intermediateFields = finalAgg.getIntermediateFields();
+        if (intermediateFields.isEmpty()) return current;
+
+        RelDataTypeFactory typeFactory = finalAgg.getCluster().getTypeFactory();
+        RelDataType stageInputType = stageInput.getRowType();
+        int groupCount = finalAgg.getGroupSet().cardinality();
+
+        RelDataTypeFactory.Builder rebuiltType = typeFactory.builder();
+        boolean changed = false;
+        for (int idx = 0; idx < stageInputType.getFieldCount(); idx++) {
+            RelDataTypeField column = stageInputType.getFieldList().get(idx);
+            // Group keys (idx < groupCount) keep their type; agg columns resolve through the SPI.
+            RelDataType resolvedType = resolveColumnType(column, idx - groupCount, intermediateFields, typeFactory);
+            if (!resolvedType.equals(column.getType())) changed = true;
+            rebuiltType.add(column.getName(), resolvedType);
+        }
+        if (!changed) return current;
+
+        OpenSearchStageInputScan rebuiltStageInput = new OpenSearchStageInputScan(
+            stageInput.getCluster(),
+            stageInput.getTraitSet(),
+            stageInput.getChildStageId(),
+            rebuiltType.build(),
+            stageInput.getViableBackends(),
+            stageInput.getOutputFieldStorage()
         );
+        RelNode rebuiltExchange = exchange.copy(exchange.getTraitSet(), List.of(rebuiltStageInput));
+        return new TransformResult(rebuiltExchange, current.extraLiteralColIdxByCallIdx());
+    }
+
+    private static RelDataType resolveColumnType(
+        RelDataTypeField column,
+        int callIdx,
+        List<IntermediateField> intermediateFields,
+        RelDataTypeFactory typeFactory
+    ) {
+        if (callIdx < 0 || callIdx >= intermediateFields.size()) return column.getType();
+        IntermediateField field = intermediateFields.get(callIdx);
+        if (field == null) return column.getType();
+        return field.typeResolver().resolve(List.of(column.getType()), typeFactory);
+    }
+
+    // ── Transformer 2: literal-Project insertion ────────────────────────────
+
+    private static final String LITERAL_COL_PREFIX = "$lit_call";
+
+    /**
+     * Re-introduces a STATE_EXPANDING aggregate's literal config args (e.g. {@code take(field, 10)}'s
+     * {@code 10}) as constant columns above the StageInputScan. PARTIAL emits only state, so FINAL
+     * needs the literals projected back in to reference them by index.
+     */
+    private static TransformResult insertLiteralProject(OpenSearchAggregate finalAgg, TransformResult current) {
+        Map<Integer, List<RexLiteral>> literalsByCall = finalAgg.getFinalExtraLiteralArgs();
+        if (literalsByCall.isEmpty()) return current;
+
+        RelNode input = current.finalInput();
+        RelDataType inputType = input.getRowType();
+        RelDataTypeFactory.Builder projectType = finalAgg.getCluster().getTypeFactory().builder();
+        List<RexNode> projectExpressions = new ArrayList<>(inputType.getFieldCount() + literalsByCall.size());
+
+        // Forward existing input columns unchanged.
+        for (int idx = 0; idx < inputType.getFieldCount(); idx++) {
+            RelDataType columnType = inputType.getFieldList().get(idx).getType();
+            String columnName = inputType.getFieldList().get(idx).getName();
+            projectExpressions.add(new RexInputRef(idx, columnType));
+            projectType.add(columnName, columnType);
+        }
+
+        // Append one column per captured literal; record where each call's literals landed.
+        Map<Integer, List<Integer>> literalColumnsByCall = new LinkedHashMap<>();
+        for (Map.Entry<Integer, List<RexLiteral>> entry : literalsByCall.entrySet()) {
+            int callIdx = entry.getKey();
+            List<RexLiteral> literals = entry.getValue();
+            List<Integer> columnIdxs = new ArrayList<>(literals.size());
+            for (int litIdx = 0; litIdx < literals.size(); litIdx++) {
+                RexLiteral literal = literals.get(litIdx);
+                columnIdxs.add(projectExpressions.size()); // capture index BEFORE adding
+                projectExpressions.add(literal);
+                projectType.add(LITERAL_COL_PREFIX + callIdx + "_" + litIdx, literal.getType());
+            }
+            literalColumnsByCall.put(callIdx, List.copyOf(columnIdxs));
+        }
+
+        OpenSearchProject project = new OpenSearchProject(
+            input.getCluster(),
+            input.getTraitSet(),
+            input,
+            projectExpressions,
+            projectType.build(),
+            finalAgg.getViableBackends()
+        );
+        return new TransformResult(project, Map.copyOf(literalColumnsByCall));
+    }
+
+    // ── FinalAggCallBuilder: construction-time aggCall factory ──────────────
+
+    /**
+     * Construction-time factory for FINAL aggCalls. Owns argList rebase to {@code groupCount + i},
+     * function swap (e.g. COUNT→SUM), and return-type pinning. Pure: no rel-tree walking.
+     *
+     * <p>Called by the split rule (so Volcano's {@code typeMatchesInferred} passes) and again by
+     * {@link #rewrite} when an input adapter changed the chain — idempotent given the same
+     * {@code intermediateFields} list.
+     */
+    public static final class FinalAggCallBuilder {
+
+        private FinalAggCallBuilder() {}
+
+        /**
+         * Returns the {@link IntermediateField} per call (parallel to {@code originalCalls}).
+         * Run on the ORIGINAL aggCalls — classifying a post-swap call could pick the wrong
+         * reducer. A {@code null} entry means the aggregate has no SPI decomposition; FINAL
+         * passes such a call through unchanged.
+         */
+        public static List<IntermediateField> classify(List<AggregateCall> originalCalls) {
+            List<IntermediateField> result = new ArrayList<>(originalCalls.size());
+            for (AggregateCall call : originalCalls) {
+                List<IntermediateField> fields = AggregateFunction.fromSqlAggFunction(call.getAggregation()).intermediateFields();
+                if (fields == null) {
+                    result.add(null);
+                } else if (fields.size() == 1) {
+                    result.add(fields.get(0));
+                } else {
+                    // Multi-field decompositions (AVG, STDDEV, ...) must be reduced upstream.
+                    throw new IllegalStateException(
+                        "Aggregate [" + call.getAggregation().getName() + "] has multiple intermediate fields; expected at most one"
+                    );
+                }
+            }
+            // List.copyOf would NPE on the null pass-through entries.
+            return Collections.unmodifiableList(result);
+        }
+
+        /** Overload for callers without literal-arg columns to forward (the common case). */
+        public static List<AggregateCall> buildFinalCalls(
+            List<AggregateCall> calls,
+            List<IntermediateField> intermediateFields,
+            int groupCount,
+            RelNode finalInput,
+            boolean hasEmptyGroup
+        ) {
+            return buildFinalCalls(calls, intermediateFields, groupCount, finalInput, hasEmptyGroup, Map.of());
+        }
+
+        /**
+         * Rebuilds FINAL aggCalls bound against {@code finalInput}. Each call's argList becomes
+         * {@code [groupCount + i, ...extras]}; the function is swapped per its
+         * {@link IntermediateField#reducer}; the return type is re-inferred or pinned per the
+         * engine-native-merge rules.
+         */
+        public static List<AggregateCall> buildFinalCalls(
+            List<AggregateCall> calls,
+            List<IntermediateField> intermediateFields,
+            int groupCount,
+            RelNode finalInput,
+            boolean hasEmptyGroup,
+            Map<Integer, List<Integer>> extraLiteralColIdxByCallIdx
+        ) {
+            List<AggregateCall> rebuilt = new ArrayList<>(calls.size());
+            for (int i = 0; i < calls.size(); i++) {
+                AggregateCall call = calls.get(i);
+                int stateColIdx = groupCount + i;
+                String name = finalInput.getRowType().getFieldList().get(stateColIdx).getName();
+                List<Integer> extraColIdxs = extraLiteralColIdxByCallIdx.getOrDefault(i, List.of());
+                rebuilt.add(buildOne(call, intermediateFields.get(i), stateColIdx, extraColIdxs, name, finalInput, hasEmptyGroup));
+            }
+            return rebuilt;
+        }
+
+        private static AggregateCall buildOne(
+            AggregateCall call,
+            IntermediateField field,
+            int finalArgIdx,
+            List<Integer> extraColIdxs,
+            String name,
+            RelNode finalInput,
+            boolean hasEmptyGroup
+        ) {
+            SqlAggFunction aggFunc;
+            RelDataType explicitType;
+            if (field == null) {
+                // No decomposition — pass through, let Calcite re-infer.
+                aggFunc = call.getAggregation();
+                explicitType = null;
+            } else {
+                AggregateFunction enumFn = AggregateFunction.fromSqlAggFunction(call.getAggregation());
+                boolean isEngineNativeMerge = field.reducer() == enumFn;
+                if (isEngineNativeMerge) {
+                    // Same function on FINAL: STATE_EXPANDING pins to the state column type;
+                    // others keep the user-facing return type.
+                    aggFunc = call.getAggregation();
+                    explicitType = enumFn.getType() == AggregateFunction.Type.STATE_EXPANDING
+                        ? finalInput.getRowType().getFieldList().get(finalArgIdx).getType()
+                        : call.getType();
+                } else {
+                    // Function swap (COUNT → SUM, etc.). Let Calcite re-infer.
+                    aggFunc = field.reducer().toSqlAggFunction();
+                    explicitType = null;
+                }
+            }
+
+            List<Integer> argList = new ArrayList<>(1 + extraColIdxs.size());
+            argList.add(finalArgIdx);
+            argList.addAll(extraColIdxs);
+
+            return AggregateCall.create(
+                aggFunc,
+                call.isDistinct(),
+                call.isApproximate(),
+                call.ignoreNulls(),
+                call.rexList,
+                List.copyOf(argList),
+                call.filterArg,
+                call.distinctKeys,
+                call.collation,
+                hasEmptyGroup,
+                finalInput,
+                explicitType,
+                name
+            );
+        }
     }
 }

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rel/OpenSearchAggregate.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rel/OpenSearchAggregate.java
@@ -63,11 +63,7 @@ public class OpenSearchAggregate extends Aggregate implements OpenSearchRelNode 
      * constant columns below FINAL, since the StageInputScan only carries the state.
      */
     private final Map<Integer, List<RexLiteral>> finalExtraLiteralArgs;
-    /**
-     * Per-call {@link IntermediateField} classification, parallel to {@link #getAggCallList()};
-     * stored on FINAL so post-Volcano transformers don't re-classify post-swap calls. A
-     * {@code null} entry means no SPI decomposition for that slot. Empty for SINGLE / PARTIAL.
-     */
+    /** Per-call {@link IntermediateField} classification, parallel to {@link #getAggCallList()}; null entry = no SPI decomposition; empty for SINGLE/PARTIAL. */
     private final List<IntermediateField> perCallIntermediateField;
 
     public OpenSearchAggregate(
@@ -133,12 +129,7 @@ public class OpenSearchAggregate extends Aggregate implements OpenSearchRelNode 
         this.perCallIntermediateField = Collections.unmodifiableList(new ArrayList<>(perCallIntermediateField));
     }
 
-    /**
-     * Builds a FINAL aggregate after {@code DistributedAggregateRewriter} has consumed the
-     * post-Volcano scratch state — the captured literals are now real columns in
-     * {@code newInput}, and the per-call classification is no longer needed downstream. Both
-     * stashes are cleared so a later {@code copy()} can't replay them.
-     */
+    /** Builds a FINAL aggregate post-rewrite; clears both stashes so a later {@code copy()} can't replay them. */
     public static OpenSearchAggregate finalAfterRewrite(OpenSearchAggregate prior, RelNode newInput, List<AggregateCall> rebuiltCalls) {
         return new OpenSearchAggregate(
             prior.getCluster(),

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rel/OpenSearchAggregate.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rel/OpenSearchAggregate.java
@@ -24,9 +24,11 @@ import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.util.ImmutableBitSet;
 import org.opensearch.analytics.planner.RelNodeUtils;
+import org.opensearch.analytics.spi.AggregateFunction.IntermediateField;
 import org.opensearch.analytics.spi.FieldStorageInfo;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -61,6 +63,12 @@ public class OpenSearchAggregate extends Aggregate implements OpenSearchRelNode 
      * constant columns below FINAL, since the StageInputScan only carries the state.
      */
     private final Map<Integer, List<RexLiteral>> finalExtraLiteralArgs;
+    /**
+     * Per-call {@link IntermediateField} classification, parallel to {@link #getAggCallList()};
+     * stored on FINAL so post-Volcano transformers don't re-classify post-swap calls. A
+     * {@code null} entry means no SPI decomposition for that slot. Empty for SINGLE / PARTIAL.
+     */
+    private final List<IntermediateField> perCallIntermediateField;
 
     public OpenSearchAggregate(
         RelOptCluster cluster,
@@ -73,7 +81,7 @@ public class OpenSearchAggregate extends Aggregate implements OpenSearchRelNode 
         List<String> viableBackends,
         Map<Integer, AggregateCallAnnotation> callAnnotations
     ) {
-        this(cluster, traitSet, input, groupSet, groupSets, aggCalls, mode, viableBackends, callAnnotations, Map.of());
+        this(cluster, traitSet, input, groupSet, groupSets, aggCalls, mode, viableBackends, callAnnotations, Map.of(), List.of());
     }
 
     public OpenSearchAggregate(
@@ -88,11 +96,63 @@ public class OpenSearchAggregate extends Aggregate implements OpenSearchRelNode 
         Map<Integer, AggregateCallAnnotation> callAnnotations,
         Map<Integer, List<RexLiteral>> finalExtraLiteralArgs
     ) {
+        this(
+            cluster,
+            traitSet,
+            input,
+            groupSet,
+            groupSets,
+            aggCalls,
+            mode,
+            viableBackends,
+            callAnnotations,
+            finalExtraLiteralArgs,
+            List.of()
+        );
+    }
+
+    public OpenSearchAggregate(
+        RelOptCluster cluster,
+        RelTraitSet traitSet,
+        RelNode input,
+        ImmutableBitSet groupSet,
+        List<ImmutableBitSet> groupSets,
+        List<AggregateCall> aggCalls,
+        AggregateMode mode,
+        List<String> viableBackends,
+        Map<Integer, AggregateCallAnnotation> callAnnotations,
+        Map<Integer, List<RexLiteral>> finalExtraLiteralArgs,
+        List<IntermediateField> perCallIntermediateField
+    ) {
         super(cluster, traitSet, List.of(), input, groupSet, groupSets, aggCalls);
         this.mode = mode;
         this.viableBackends = viableBackends;
         this.callAnnotations = Map.copyOf(callAnnotations);
         this.finalExtraLiteralArgs = Map.copyOf(finalExtraLiteralArgs);
+        // Collections.unmodifiableList — List.copyOf would NPE on the null pass-through entries.
+        this.perCallIntermediateField = Collections.unmodifiableList(new ArrayList<>(perCallIntermediateField));
+    }
+
+    /**
+     * Builds a FINAL aggregate after {@code DistributedAggregateRewriter} has consumed the
+     * post-Volcano scratch state — the captured literals are now real columns in
+     * {@code newInput}, and the per-call classification is no longer needed downstream. Both
+     * stashes are cleared so a later {@code copy()} can't replay them.
+     */
+    public static OpenSearchAggregate finalAfterRewrite(OpenSearchAggregate prior, RelNode newInput, List<AggregateCall> rebuiltCalls) {
+        return new OpenSearchAggregate(
+            prior.getCluster(),
+            prior.getTraitSet(),
+            newInput,
+            prior.getGroupSet(),
+            prior.getGroupSets(),
+            rebuiltCalls,
+            AggregateMode.FINAL,
+            prior.viableBackends,
+            prior.callAnnotations,
+            Map.of(),
+            List.of()
+        );
     }
 
     public AggregateMode getMode() {
@@ -106,6 +166,11 @@ public class OpenSearchAggregate extends Aggregate implements OpenSearchRelNode 
 
     public Map<Integer, List<RexLiteral>> getFinalExtraLiteralArgs() {
         return finalExtraLiteralArgs;
+    }
+
+    /** See {@link #perCallIntermediateField}. */
+    public List<IntermediateField> getIntermediateFields() {
+        return perCallIntermediateField;
     }
 
     @Override
@@ -182,7 +247,8 @@ public class OpenSearchAggregate extends Aggregate implements OpenSearchRelNode 
             mode,
             viableBackends,
             callAnnotations,
-            finalExtraLiteralArgs
+            finalExtraLiteralArgs,
+            perCallIntermediateField
         );
     }
 
@@ -250,7 +316,8 @@ public class OpenSearchAggregate extends Aggregate implements OpenSearchRelNode 
             mode,
             List.of(backend),
             rebuilt,
-            finalExtraLiteralArgs
+            finalExtraLiteralArgs,
+            perCallIntermediateField
         );
     }
 

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchAggregateSplitRule.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchAggregateSplitRule.java
@@ -15,6 +15,8 @@ import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.AggregateCall;
 import org.apache.calcite.rel.core.Project;
 import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexInputRef;
 import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlAggFunction;
@@ -22,10 +24,13 @@ import org.apache.calcite.sql.type.SqlTypeFamily;
 import org.apache.calcite.util.ImmutableBitSet;
 import org.opensearch.analytics.planner.PlannerContext;
 import org.opensearch.analytics.planner.RelNodeUtils;
+import org.opensearch.analytics.planner.dag.DistributedAggregateRewriter.FinalAggCallBuilder;
 import org.opensearch.analytics.planner.rel.AggregateMode;
 import org.opensearch.analytics.planner.rel.OpenSearchAggregate;
 import org.opensearch.analytics.planner.rel.OpenSearchConvention;
+import org.opensearch.analytics.planner.rel.OpenSearchProject;
 import org.opensearch.analytics.spi.AggregateFunction;
+import org.opensearch.analytics.spi.AggregateFunction.IntermediateField;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -128,21 +133,68 @@ public class OpenSearchAggregateSplitRule extends RelOptRule {
         RelNode gathered = convert(partial, finalTraits);
         Map<Integer, List<RexLiteral>> finalExtraLiterals = captureLiteralArgsForFinal(aggregate.getAggCallList(), child);
 
+        // Classify ORIGINAL aggCalls once and stash on FINAL for post-Volcano transformers.
+        List<IntermediateField> intermediateFields = FinalAggCallBuilder.classify(aggregate.getAggCallList());
+
+        // Build FINAL's aggCalls against gathered's row type so typeMatchesInferred passes.
+        List<AggregateCall> finalAggCalls = FinalAggCallBuilder.buildFinalCalls(
+            aggregate.getAggCallList(),
+            intermediateFields,
+            aggregate.getGroupSet().cardinality(),
+            gathered,
+            aggregate.getGroupSet().isEmpty()
+        );
+
         OpenSearchAggregate finalAggregate = new OpenSearchAggregate(
             aggregate.getCluster(),
             finalTraits,
             gathered,
             aggregate.getGroupSet(),
             aggregate.getGroupSets(),
-            aggregate.getAggCallList(),
+            finalAggCalls,
             AggregateMode.FINAL,
             aggregate.getViableBackends(),
             aggregate.getCallAnnotations(),
-            finalExtraLiterals
+            finalExtraLiterals,
+            intermediateFields
         );
 
+        // Empty-group nullability gap (COUNT→SUM swap): wrap FINAL so its row type matches SINGLE's.
+        RelNode finalAlternative = wrapWithCastIfNeeded(finalAggregate, aggregate);
+
         call.getPlanner().ensureRegistered(singleOnSingleton, aggregate);
-        call.transformTo(finalAggregate);
+        call.transformTo(finalAlternative);
+    }
+
+    /** Wraps FINAL in a CAST-projection when any column type drifts from {@code expected}'s row type; type-only check, name differences pass through. */
+    private static RelNode wrapWithCastIfNeeded(OpenSearchAggregate finalAggregate, OpenSearchAggregate expected) {
+        RelDataType actualType = finalAggregate.getRowType();
+        RelDataType expectedType = expected.getRowType();
+        RexBuilder rexBuilder = finalAggregate.getCluster().getRexBuilder();
+
+        List<RexNode> projects = new ArrayList<>(actualType.getFieldCount());
+        boolean anyTypeDiffers = false;
+        for (int idx = 0; idx < actualType.getFieldCount(); idx++) {
+            RelDataType columnType = actualType.getFieldList().get(idx).getType();
+            RelDataType targetType = expectedType.getFieldList().get(idx).getType();
+            RexNode ref = new RexInputRef(idx, columnType);
+            if (columnType.equals(targetType)) {
+                projects.add(ref);
+            } else {
+                projects.add(rexBuilder.makeCast(targetType, ref));
+                anyTypeDiffers = true;
+            }
+        }
+        if (!anyTypeDiffers) return finalAggregate;
+
+        return new OpenSearchProject(
+            finalAggregate.getCluster(),
+            finalAggregate.getTraitSet(),
+            finalAggregate,
+            projects,
+            expectedType,
+            finalAggregate.getViableBackends()
+        );
     }
 
     /** Re-declare LIST/VALUES return type as {@code ARRAY<arg0>} (PPL lowers it to {@code ARRAY<VARCHAR>}). */

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/AggregatePlanShapeTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/AggregatePlanShapeTests.java
@@ -9,13 +9,7 @@
 package org.opensearch.analytics.planner;
 
 import org.apache.calcite.rel.RelNode;
-import org.apache.calcite.rel.core.AggregateCall;
-import org.apache.calcite.rel.logical.LogicalAggregate;
-import org.apache.calcite.sql.fun.SqlStdOperatorTable;
-import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.util.ImmutableBitSet;
-
-import java.util.List;
 
 /**
  * Plan-shape tests for {@link org.opensearch.analytics.planner.rel.OpenSearchAggregate}.
@@ -26,8 +20,9 @@ import java.util.List;
  */
 public class AggregatePlanShapeTests extends PlanShapeTestBase {
 
-    public void testStatsCountStar_1shard() {
-        RelNode plan = makeAggregate(stubScan(mockTable("test_index", "status", "size")), countStarCall());
+    public void testStatsCountStarByKey_1shard() {
+        RelNode scan = stubScan(mockTable("test_index", "status", "size"));
+        RelNode plan = makeAggregate(scan, countStarCall(scan));
         RelNode result = runPlanner(plan, singleShardContext());
         assertPlanShape("""
             OpenSearchAggregate(group=[{0}], cnt=[COUNT()], mode=[SINGLE], viableBackends=[[mock-parquet]])
@@ -35,12 +30,14 @@ public class AggregatePlanShapeTests extends PlanShapeTestBase {
             """, result);
     }
 
-    public void testStatsCountStar_2shard() {
-        RelNode plan = makeAggregate(stubScan(mockTable("test_index", "status", "size")), countStarCall());
+    public void testStatsCountStarByKey_2shard() {
+        // FINAL's COUNT is rebuilt as SUM($1) by the COUNT→SUM swap in FinalAggCallBuilder.
+        RelNode scan = stubScan(mockTable("test_index", "status", "size"));
+        RelNode plan = makeAggregate(scan, countStarCall(scan));
         RelNode result = runPlanner(plan, multiShardContext());
         assertPlanShape(
             """
-                OpenSearchAggregate(group=[{0}], cnt=[COUNT()], mode=[FINAL], viableBackends=[[mock-parquet]])
+                OpenSearchAggregate(group=[{0}], cnt=[SUM($1)], mode=[FINAL], viableBackends=[[mock-parquet]])
                   OpenSearchExchangeReducer(viableBackends=[[mock-parquet]], exchange=[ExchangeInfo[distributionType=SINGLETON, partitionKeyIndices=[]]])
                     OpenSearchAggregate(group=[{0}], cnt=[COUNT()], mode=[PARTIAL], viableBackends=[[mock-parquet]])
                       OpenSearchTableScan(table=[[test_index]], viableBackends=[[mock-parquet]])
@@ -50,7 +47,8 @@ public class AggregatePlanShapeTests extends PlanShapeTestBase {
     }
 
     public void testStatsSumByKey_1shard() {
-        RelNode plan = makeAggregate(stubScan(mockTable("test_index", "status", "size")), sumCall());
+        RelNode scan = stubScan(mockTable("test_index", "status", "size"));
+        RelNode plan = makeAggregate(scan, sumCall(scan));
         RelNode result = runPlanner(plan, singleShardContext());
         assertPlanShape("""
             OpenSearchAggregate(group=[{0}], total_size=[SUM($1)], mode=[SINGLE], viableBackends=[[mock-parquet]])
@@ -59,7 +57,8 @@ public class AggregatePlanShapeTests extends PlanShapeTestBase {
     }
 
     public void testStatsSumByKey_2shard() {
-        RelNode plan = makeAggregate(stubScan(mockTable("test_index", "status", "size")), sumCall());
+        RelNode scan = stubScan(mockTable("test_index", "status", "size"));
+        RelNode plan = makeAggregate(scan, sumCall(scan));
         RelNode result = runPlanner(plan, multiShardContext());
         assertPlanShape(
             """
@@ -72,37 +71,30 @@ public class AggregatePlanShapeTests extends PlanShapeTestBase {
         );
     }
 
-    public void testStatsAvgByKey_2shard() {
-        // AVG is decomposed during the reduce phase into SUM/COUNT plus a Project
-        // computing the quotient. After split, FINAL receives reduced primitive aggs.
-        // Use AggregateCall.create with null type so Calcite infers AVG's canonical
-        // return type — passing an explicit type can drift from typeMatchesInferred.
+    public void testStatsAvgByKey_1shard() {
+        // AVG → SUM/COUNT primitives plus a Project for the quotient; SINGLE only.
         RelNode scan = stubScan(mockTable("test_index", "status", "size"));
-        AggregateCall avg = AggregateCall.create(
-            SqlStdOperatorTable.AVG,
-            false,
-            false,
-            false,
-            List.of(),
-            List.of(1),
-            -1,
-            null,
-            org.apache.calcite.rel.RelCollations.EMPTY,
-            1,
-            scan,
-            null,
-            "avg_size"
-        );
-        RelNode plan = LogicalAggregate.create(scan, List.of(), ImmutableBitSet.of(0), null, List.of(avg));
-        RelNode result = runPlanner(plan, multiShardContext());
-        // Project on top performs CAST(SUM(x) / COUNT()) back to AVG's declared return type.
-        // COUNT here has no field operand because the inferred AVG decomposition produces a
-        // bare COUNT (counts all rows in the group, equivalent to COUNT(x) when x is not nullable).
-        // Skeleton: Project ← FINAL(SUM,COUNT) ← ER ← PARTIAL(SUM,COUNT) ← Scan.
+        RelNode plan = makeAggregate(scan, ImmutableBitSet.of(0), avgCall(scan));
+        RelNode result = runPlanner(plan, singleShardContext());
         assertPlanShape(
             """
                 OpenSearchProject(status=[$0], avg_size=[ANNOTATED_PROJECT_EXPR(id=3, backends=[mock-parquet], CAST(ANNOTATED_PROJECT_EXPR(id=2, backends=[mock-parquet], /($1, $2))):INTEGER NOT NULL)], viableBackends=[[mock-parquet]])
-                  OpenSearchAggregate(group=[{0}], agg#0=[SUM($1)], agg#1=[COUNT()], mode=[FINAL], viableBackends=[[mock-parquet]])
+                  OpenSearchAggregate(group=[{0}], agg#0=[SUM($1)], agg#1=[COUNT()], mode=[SINGLE], viableBackends=[[mock-parquet]])
+                    OpenSearchTableScan(table=[[test_index]], viableBackends=[[mock-parquet]])
+                """,
+            result
+        );
+    }
+
+    public void testStatsAvgByKey_2shard() {
+        // AVG decomposes pre-split; FINAL receives the reduced primitives.
+        RelNode scan = stubScan(mockTable("test_index", "status", "size"));
+        RelNode plan = makeAggregate(scan, ImmutableBitSet.of(0), avgCall(scan));
+        RelNode result = runPlanner(plan, multiShardContext());
+        assertPlanShape(
+            """
+                OpenSearchProject(status=[$0], avg_size=[ANNOTATED_PROJECT_EXPR(id=3, backends=[mock-parquet], CAST(ANNOTATED_PROJECT_EXPR(id=2, backends=[mock-parquet], /($1, $2))):INTEGER NOT NULL)], viableBackends=[[mock-parquet]])
+                  OpenSearchAggregate(group=[{0}], $f1=[SUM($1)], $f2=[SUM($2)], mode=[FINAL], viableBackends=[[mock-parquet]])
                     OpenSearchExchangeReducer(viableBackends=[[mock-parquet]], exchange=[ExchangeInfo[distributionType=SINGLETON, partitionKeyIndices=[]]])
                       OpenSearchAggregate(group=[{0}], agg#0=[SUM($1)], agg#1=[COUNT()], mode=[PARTIAL], viableBackends=[[mock-parquet]])
                         OpenSearchTableScan(table=[[test_index]], viableBackends=[[mock-parquet]])
@@ -111,36 +103,60 @@ public class AggregatePlanShapeTests extends PlanShapeTestBase {
         );
     }
 
-    public void testStatsMultiCall_2shard() {
-        // sum + count_star, both grouped by status. Single PARTIAL/FINAL pair carries
-        // both calls.
+    public void testStatsSumCountByKey_1shard() {
+        // SINGLE aggregate carries both calls; no split, no rebase.
         RelNode scan = stubScan(mockTable("test_index", "status", "size"));
-        AggregateCall sum = AggregateCall.create(
-            SqlStdOperatorTable.SUM,
-            false,
-            List.of(1),
-            -1,
-            scan,
-            typeFactory.createSqlType(SqlTypeName.INTEGER),
-            "sum_size"
-        );
-        AggregateCall cnt = AggregateCall.create(
-            SqlStdOperatorTable.COUNT,
-            false,
-            List.of(),
-            -1,
-            scan,
-            typeFactory.createSqlType(SqlTypeName.BIGINT),
-            "cnt"
-        );
-        RelNode plan = LogicalAggregate.create(scan, List.of(), ImmutableBitSet.of(0), null, List.of(sum, cnt));
+        RelNode plan = makeAggregate(scan, ImmutableBitSet.of(0), sumCall(scan), countStarCall(scan));
+        RelNode result = runPlanner(plan, singleShardContext());
+        assertPlanShape("""
+            OpenSearchAggregate(group=[{0}], total_size=[SUM($1)], cnt=[COUNT()], mode=[SINGLE], viableBackends=[[mock-parquet]])
+              OpenSearchTableScan(table=[[test_index]], viableBackends=[[mock-parquet]])
+            """, result);
+    }
+
+    public void testStatsSumCountByKey_2shard() {
+        // FINAL: SUM stays (engine-native merge), COUNT→SUM($2) via FinalAggCallBuilder.
+        RelNode scan = stubScan(mockTable("test_index", "status", "size"));
+        RelNode plan = makeAggregate(scan, ImmutableBitSet.of(0), sumCall(scan), countStarCall(scan));
         RelNode result = runPlanner(plan, multiShardContext());
         assertPlanShape(
             """
-                OpenSearchAggregate(group=[{0}], sum_size=[SUM($1)], cnt=[COUNT()], mode=[FINAL], viableBackends=[[mock-parquet]])
+                OpenSearchAggregate(group=[{0}], total_size=[SUM($1)], cnt=[SUM($2)], mode=[FINAL], viableBackends=[[mock-parquet]])
                   OpenSearchExchangeReducer(viableBackends=[[mock-parquet]], exchange=[ExchangeInfo[distributionType=SINGLETON, partitionKeyIndices=[]]])
-                    OpenSearchAggregate(group=[{0}], sum_size=[SUM($1)], cnt=[COUNT()], mode=[PARTIAL], viableBackends=[[mock-parquet]])
+                    OpenSearchAggregate(group=[{0}], total_size=[SUM($1)], cnt=[COUNT()], mode=[PARTIAL], viableBackends=[[mock-parquet]])
                       OpenSearchTableScan(table=[[test_index]], viableBackends=[[mock-parquet]])
+                """,
+            result
+        );
+    }
+
+    /** Empty-group count(), single-shard. SINGLE alternative; no split, no wrap. */
+    public void testStatsCountStar_emptyGroup_1shard() {
+        RelNode scan = stubScan(mockTable("test_index", "status", "size"));
+        RelNode plan = makeAggregate(scan, ImmutableBitSet.of(), countStarCall(scan));
+        RelNode result = runPlanner(plan, singleShardContext());
+        assertPlanShape("""
+            OpenSearchAggregate(group=[{}], cnt=[COUNT()], mode=[SINGLE], viableBackends=[[mock-parquet]])
+              OpenSearchTableScan(table=[[test_index]], viableBackends=[[mock-parquet]])
+            """, result);
+    }
+
+    /**
+     * Empty-group count(), multi-shard. The Project on top is the CAST-wrap from
+     * {@code OpenSearchAggregateSplitRule.wrapWithCastIfNeeded} — without it, Volcano rejects
+     * FINAL's nullable BIGINT against SINGLE's BIGINT NOT NULL.
+     */
+    public void testStatsCountStar_emptyGroup_2shard() {
+        RelNode scan = stubScan(mockTable("test_index", "status", "size"));
+        RelNode plan = makeAggregate(scan, ImmutableBitSet.of(), countStarCall(scan));
+        RelNode result = runPlanner(plan, multiShardContext());
+        assertPlanShape(
+            """
+                OpenSearchProject(cnt=[CAST($0):BIGINT NOT NULL], viableBackends=[[mock-parquet]])
+                  OpenSearchAggregate(group=[{}], cnt=[SUM($0)], mode=[FINAL], viableBackends=[[mock-parquet]])
+                    OpenSearchExchangeReducer(viableBackends=[[mock-parquet]], exchange=[ExchangeInfo[distributionType=SINGLETON, partitionKeyIndices=[]]])
+                      OpenSearchAggregate(group=[{}], cnt=[COUNT()], mode=[PARTIAL], viableBackends=[[mock-parquet]])
+                        OpenSearchTableScan(table=[[test_index]], viableBackends=[[mock-parquet]])
                 """,
             result
         );

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/BasePlannerRulesTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/BasePlannerRulesTests.java
@@ -461,27 +461,58 @@ public abstract class BasePlannerRulesTests extends OpenSearchTestCase {
     // TODO: AggregateRuleTests has private copies of these — replace with these shared versions.
 
     protected AggregateCall sumCall() {
+        return sumCall(stubScan(mockTable("test_index", "status", "size")));
+    }
+
+    protected AggregateCall sumCall(RelNode input) {
         return AggregateCall.create(
             SqlStdOperatorTable.SUM,
             false,
             List.of(1),
             -1,
-            stubScan(mockTable("test_index", "status", "size")),
+            input,
             typeFactory.createSqlType(SqlTypeName.INTEGER),
             "total_size"
         );
     }
 
     protected AggregateCall countStarCall() {
+        return countStarCall(stubScan(mockTable("test_index", "status", "size")));
+    }
+
+    protected AggregateCall countStarCall(RelNode input) {
         // COUNT(*) — no field arguments, always gets annotated with aggregateCapableBackends
         return AggregateCall.create(
             SqlStdOperatorTable.COUNT,
             false,
             List.of(),
             -1,
-            stubScan(mockTable("test_index", "status", "size")),
+            input,
             typeFactory.createSqlType(SqlTypeName.BIGINT),
             "cnt"
+        );
+    }
+
+    /**
+     * AVG over the second column. Uses the long-form {@link AggregateCall#create} with a
+     * {@code null} return type so Calcite infers AVG's canonical type; the short-form
+     * overload passes an explicit type and would trip {@code Aggregate.typeMatchesInferred}.
+     */
+    protected AggregateCall avgCall(RelNode input) {
+        return AggregateCall.create(
+            SqlStdOperatorTable.AVG,
+            false,
+            false,
+            false,
+            List.of(),
+            List.of(1),
+            -1,
+            null,
+            org.apache.calcite.rel.RelCollations.EMPTY,
+            1,
+            input,
+            null,
+            "avg_size"
         );
     }
 
@@ -515,7 +546,11 @@ public abstract class BasePlannerRulesTests extends OpenSearchTestCase {
     }
 
     protected LogicalAggregate makeAggregate(RelNode input, AggregateCall... aggCalls) {
-        return LogicalAggregate.create(input, List.of(), ImmutableBitSet.of(0), null, List.of(aggCalls));
+        return makeAggregate(input, ImmutableBitSet.of(0), aggCalls);
+    }
+
+    protected LogicalAggregate makeAggregate(RelNode input, ImmutableBitSet groupSet, AggregateCall... aggCalls) {
+        return LogicalAggregate.create(input, List.of(), groupSet, null, List.of(aggCalls));
     }
 
     protected LogicalAggregate makeMultiCallAggregate(RelNode input, AggregateCall... aggCalls) {

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/PlanShapeTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/PlanShapeTests.java
@@ -61,7 +61,7 @@ public class PlanShapeTests extends PlanShapeTestBase {
         assertPlanShape(
             """
                 OpenSearchSort(sort0=[$1], dir0=[ASC], fetch=[2], viableBackends=[[mock-parquet]])
-                  OpenSearchAggregate(group=[{0}], cnt=[COUNT()], mode=[FINAL], viableBackends=[[mock-parquet]])
+                  OpenSearchAggregate(group=[{0}], cnt=[SUM($1)], mode=[FINAL], viableBackends=[[mock-parquet]])
                     OpenSearchExchangeReducer(viableBackends=[[mock-parquet]], exchange=[ExchangeInfo[distributionType=SINGLETON, partitionKeyIndices=[]]])
                       OpenSearchAggregate(group=[{0}], cnt=[COUNT()], mode=[PARTIAL], viableBackends=[[mock-parquet]])
                         OpenSearchTableScan(table=[[test_index]], viableBackends=[[mock-parquet]])
@@ -82,7 +82,7 @@ public class PlanShapeTests extends PlanShapeTestBase {
         assertPlanShape(
             """
                 OpenSearchSort(sort0=[$1], dir0=[ASC], fetch=[2], viableBackends=[[mock-parquet]])
-                  OpenSearchAggregate(group=[{0}], cnt=[COUNT()], mode=[FINAL], viableBackends=[[mock-parquet]])
+                  OpenSearchAggregate(group=[{0}], cnt=[SUM($1)], mode=[FINAL], viableBackends=[[mock-parquet]])
                     OpenSearchExchangeReducer(viableBackends=[[mock-parquet]], exchange=[ExchangeInfo[distributionType=SINGLETON, partitionKeyIndices=[]]])
                       OpenSearchAggregate(group=[{0}], cnt=[COUNT()], mode=[PARTIAL], viableBackends=[[mock-parquet]])
                         OpenSearchTableScan(table=[[test_index]], viableBackends=[[mock-parquet]])
@@ -106,7 +106,7 @@ public class PlanShapeTests extends PlanShapeTestBase {
             """
                 OpenSearchSort(sort0=[$0], dir0=[ASC], viableBackends=[[mock-parquet]])
                   OpenSearchSort(sort0=[$1], dir0=[ASC], fetch=[2], viableBackends=[[mock-parquet]])
-                    OpenSearchAggregate(group=[{0}], cnt=[COUNT()], mode=[FINAL], viableBackends=[[mock-parquet]])
+                    OpenSearchAggregate(group=[{0}], cnt=[SUM($1)], mode=[FINAL], viableBackends=[[mock-parquet]])
                       OpenSearchExchangeReducer(viableBackends=[[mock-parquet]], exchange=[ExchangeInfo[distributionType=SINGLETON, partitionKeyIndices=[]]])
                         OpenSearchAggregate(group=[{0}], cnt=[COUNT()], mode=[PARTIAL], viableBackends=[[mock-parquet]])
                           OpenSearchTableScan(table=[[test_index]], viableBackends=[[mock-parquet]])
@@ -156,11 +156,11 @@ public class PlanShapeTests extends PlanShapeTestBase {
         assertPlanShape(
             """
                 OpenSearchJoin(condition=[=($0, $2)], joinType=[inner], viableBackends=[[mock-parquet]])
-                  OpenSearchAggregate(group=[{0}], cnt=[COUNT()], mode=[FINAL], viableBackends=[[mock-parquet]])
+                  OpenSearchAggregate(group=[{0}], cnt=[SUM($1)], mode=[FINAL], viableBackends=[[mock-parquet]])
                     OpenSearchExchangeReducer(viableBackends=[[mock-parquet]], exchange=[ExchangeInfo[distributionType=SINGLETON, partitionKeyIndices=[]]])
                       OpenSearchAggregate(group=[{0}], cnt=[COUNT()], mode=[PARTIAL], viableBackends=[[mock-parquet]])
                         OpenSearchTableScan(table=[[test_index]], viableBackends=[[mock-parquet]])
-                  OpenSearchAggregate(group=[{0}], cnt=[COUNT()], mode=[FINAL], viableBackends=[[mock-parquet]])
+                  OpenSearchAggregate(group=[{0}], cnt=[SUM($1)], mode=[FINAL], viableBackends=[[mock-parquet]])
                     OpenSearchExchangeReducer(viableBackends=[[mock-parquet]], exchange=[ExchangeInfo[distributionType=SINGLETON, partitionKeyIndices=[]]])
                       OpenSearchAggregate(group=[{0}], cnt=[COUNT()], mode=[PARTIAL], viableBackends=[[mock-parquet]])
                         OpenSearchTableScan(table=[[test_index]], viableBackends=[[mock-parquet]])
@@ -325,7 +325,7 @@ public class PlanShapeTests extends PlanShapeTestBase {
                     OpenSearchExchangeReducer(viableBackends=[[mock-parquet]], exchange=[ExchangeInfo[distributionType=SINGLETON, partitionKeyIndices=[]]])
                       OpenSearchAggregate(group=[{0}], s=[SUM($1)], mode=[PARTIAL], viableBackends=[[mock-parquet]])
                         OpenSearchTableScan(table=[[test_index]], viableBackends=[[mock-parquet]])
-                  OpenSearchAggregate(group=[{1}], s=[SUM($0)], mode=[FINAL], viableBackends=[[mock-parquet]])
+                  OpenSearchAggregate(group=[{1}], s=[SUM($1)], mode=[FINAL], viableBackends=[[mock-parquet]])
                     OpenSearchExchangeReducer(viableBackends=[[mock-parquet]], exchange=[ExchangeInfo[distributionType=SINGLETON, partitionKeyIndices=[]]])
                       OpenSearchAggregate(group=[{1}], s=[SUM($0)], mode=[PARTIAL], viableBackends=[[mock-parquet]])
                         OpenSearchTableScan(table=[[test_index]], viableBackends=[[mock-parquet]])
@@ -368,11 +368,11 @@ public class PlanShapeTests extends PlanShapeTestBase {
         assertPlanShape(
             """
                 OpenSearchUnion(all=[true], viableBackends=[[mock-parquet]])
-                  OpenSearchAggregate(group=[{0}], cnt=[COUNT()], mode=[FINAL], viableBackends=[[mock-parquet]])
+                  OpenSearchAggregate(group=[{0}], cnt=[SUM($1)], mode=[FINAL], viableBackends=[[mock-parquet]])
                     OpenSearchExchangeReducer(viableBackends=[[mock-parquet]], exchange=[ExchangeInfo[distributionType=SINGLETON, partitionKeyIndices=[]]])
                       OpenSearchAggregate(group=[{0}], cnt=[COUNT()], mode=[PARTIAL], viableBackends=[[mock-parquet]])
                         OpenSearchTableScan(table=[[test_index]], viableBackends=[[mock-parquet]])
-                  OpenSearchAggregate(group=[{0}], cnt=[COUNT()], mode=[FINAL], viableBackends=[[mock-parquet]])
+                  OpenSearchAggregate(group=[{0}], cnt=[SUM($1)], mode=[FINAL], viableBackends=[[mock-parquet]])
                     OpenSearchExchangeReducer(viableBackends=[[mock-parquet]], exchange=[ExchangeInfo[distributionType=SINGLETON, partitionKeyIndices=[]]])
                       OpenSearchAggregate(group=[{0}], cnt=[COUNT()], mode=[PARTIAL], viableBackends=[[mock-parquet]])
                         OpenSearchTableScan(table=[[test_index]], viableBackends=[[mock-parquet]])

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/dag/DAGShapeTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/dag/DAGShapeTests.java
@@ -202,7 +202,7 @@ public class DAGShapeTests extends BasePlannerRulesTests {
                 QueryDAG(queryId=<random>)
                 Stage 1
                   OpenSearchSort(sort0=[$1], dir0=[ASC], fetch=[2], viableBackends=[[mock-parquet]])
-                    OpenSearchAggregate(group=[{0}], cnt=[COUNT()], mode=[FINAL], viableBackends=[[mock-parquet]])
+                    OpenSearchAggregate(group=[{0}], cnt=[SUM($1)], mode=[FINAL], viableBackends=[[mock-parquet]])
                       OpenSearchExchangeReducer(viableBackends=[[mock-parquet]], exchange=[ExchangeInfo[distributionType=SINGLETON, partitionKeyIndices=[]]])
                         OpenSearchStageInputScan(childStageId=[0], viableBackends=[[mock-parquet]])
                   Stage 0 exchange=SINGLETON

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/dag/DistributedAggregateRewriterTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/dag/DistributedAggregateRewriterTests.java
@@ -1,0 +1,212 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.planner.dag;
+
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.AggregateCall;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.sql.SqlAggFunction;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.util.ImmutableBitSet;
+import org.opensearch.analytics.planner.BasePlannerRulesTests;
+import org.opensearch.analytics.planner.rel.AggregateMode;
+import org.opensearch.analytics.planner.rel.OpenSearchAggregate;
+import org.opensearch.analytics.planner.rel.OpenSearchExchangeReducer;
+import org.opensearch.analytics.planner.rel.OpenSearchProject;
+import org.opensearch.analytics.planner.rel.OpenSearchStageInputScan;
+import org.opensearch.analytics.spi.AggregateFunction;
+import org.opensearch.analytics.spi.AggregateFunction.IntermediateField;
+
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Direct-call unit tests for the post-Volcano rewrite path. Constructs FINAL
+ * {@link OpenSearchAggregate} trees by hand and asserts how
+ * {@link DistributedAggregateRewriter#rewrite} (and its transformer chain) reshape them.
+ */
+public class DistributedAggregateRewriterTests extends BasePlannerRulesTests {
+
+    /**
+     * No StageInputScan, no decompositions, no literals → rewriter returns the same instance.
+     * Verifies the orchestrator's fast-path early return.
+     */
+    public void testRewriteNoOpWhenNothingToAdapt() {
+        OpenSearchAggregate finalAgg = buildFinalAggregateOverScan();
+        // Wrap an exchange reducer over a plain scan so the orchestrator's prefix check
+        // (must have a StageInputScan beneath the reducer) fails — early exit, no work done.
+        RelNode result = DistributedAggregateRewriter.rewrite(finalAgg);
+        assertSame("rewrite must return finalAgg unchanged when input chain isn't a StageInputScan", finalAgg, result);
+    }
+
+    /**
+     * APPROX_COUNT_DISTINCT's intermediate field is VARBINARY (sketch), but the StageInputScan
+     * was constructed declaring BIGINT (the user-facing return type). The transformer should
+     * re-type the StageInputScan column to VARBINARY.
+     */
+    public void testExchangeTypeOverrideRetypesApproxCountDistinctSketch() {
+        // PARTIAL output schema as declared (BIGINT for the agg column).
+        RelDataType groupKeyType = typeFactory.createSqlType(SqlTypeName.INTEGER);
+        RelDataType declaredAggType = typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.BIGINT), false);
+        RelDataType stageInputType = typeFactory.builder().add("k", groupKeyType).add("dc", declaredAggType).build();
+
+        OpenSearchStageInputScan stageInput = new OpenSearchStageInputScan(
+            cluster,
+            cluster.traitSet(),
+            0,
+            stageInputType,
+            List.of("mock-parquet"),
+            List.of()
+        );
+        OpenSearchExchangeReducer reducer = new OpenSearchExchangeReducer(cluster, cluster.traitSet(), stageInput, List.of("mock-parquet"));
+
+        // FINAL aggregate sitting on top of the exchange. APPROX_COUNT_DISTINCT keeps function
+        // identity (engine-native merge) — its declared return type is BIGINT (user-facing).
+        AggregateCall dcCall = AggregateCall.create(
+            SqlStdOperatorTable.APPROX_COUNT_DISTINCT,
+            false,
+            List.of(1),
+            -1,
+            reducer,
+            declaredAggType,
+            "dc"
+        );
+        // intermediateFields is parallel to aggCallList (one entry per agg call, not per row column).
+        List<IntermediateField> intermediateFields = List.of(classify(SqlStdOperatorTable.APPROX_COUNT_DISTINCT));
+        OpenSearchAggregate finalAgg = new OpenSearchAggregate(
+            cluster,
+            cluster.traitSet(),
+            reducer,
+            ImmutableBitSet.of(0),
+            null,
+            List.of(dcCall),
+            AggregateMode.FINAL,
+            List.of("mock-parquet"),
+            Map.of(),
+            Map.of(),
+            intermediateFields
+        );
+
+        RelNode result = DistributedAggregateRewriter.rewrite(finalAgg);
+
+        // The exchange below FINAL must now wrap a StageInputScan whose 'dc' column is VARBINARY.
+        assertNotSame("rewrite should return a new FINAL when the exchange type was overridden", finalAgg, result);
+        OpenSearchExchangeReducer newReducer = (OpenSearchExchangeReducer) result.getInput(0);
+        OpenSearchStageInputScan newStageInput = (OpenSearchStageInputScan) newReducer.getInput(0);
+        RelDataType retypedDc = newStageInput.getRowType().getFieldList().get(1).getType();
+        assertEquals(SqlTypeName.VARBINARY, retypedDc.getSqlTypeName());
+    }
+
+    /**
+     * STATE_EXPANDING aggregates carry literal config args (e.g. {@code take(field, 10)}'s
+     * {@code 10}) on FINAL's {@code finalExtraLiteralArgs} stash. The transformer should
+     * insert an {@link OpenSearchProject} that re-introduces those literals as columns.
+     */
+    public void testLiteralProjectInsertsCapturedLiterals() {
+        RelDataType stateType = typeFactory.createSqlType(SqlTypeName.BIGINT);
+        RelDataType stageInputType = typeFactory.builder().add("take_state", stateType).build();
+        OpenSearchStageInputScan stageInput = new OpenSearchStageInputScan(
+            cluster,
+            cluster.traitSet(),
+            0,
+            stageInputType,
+            List.of("mock-parquet"),
+            List.of()
+        );
+        OpenSearchExchangeReducer reducer = new OpenSearchExchangeReducer(cluster, cluster.traitSet(), stageInput, List.of("mock-parquet"));
+
+        // We don't need a real TAKE SqlAggFunction for this check — a SUM call will do, since
+        // the transformer only reads finalExtraLiteralArgs and projects the literals; FINAL's
+        // own aggCall list isn't introspected by the transformer itself. Use the long-form
+        // create with null return type so Calcite infers (avoids typeMatchesInferred drift on
+        // empty group).
+        AggregateCall sumCall = AggregateCall.create(
+            SqlStdOperatorTable.SUM,
+            false,
+            false,
+            false,
+            List.of(),
+            List.of(0),
+            -1,
+            null,
+            org.apache.calcite.rel.RelCollations.EMPTY,
+            0,
+            reducer,
+            null,
+            "take_state"
+        );
+
+        // One captured literal for call 0: integer 10.
+        RexLiteral ten = (RexLiteral) rexBuilder.makeLiteral(BigDecimal.valueOf(10), typeFactory.createSqlType(SqlTypeName.INTEGER), true);
+        Map<Integer, List<RexLiteral>> extras = Map.of(0, List.of(ten));
+
+        OpenSearchAggregate finalAgg = new OpenSearchAggregate(
+            cluster,
+            cluster.traitSet(),
+            reducer,
+            ImmutableBitSet.of(),
+            null,
+            List.of(sumCall),
+            AggregateMode.FINAL,
+            List.of("mock-parquet"),
+            Map.of(),
+            extras,
+            Collections.singletonList(null)
+        );
+
+        RelNode result = DistributedAggregateRewriter.rewrite(finalAgg);
+
+        // FINAL's input should now be an OpenSearchProject (inserted by insertLiteralProject).
+        assertNotSame("rewrite should return a new FINAL when literals were re-introduced", finalAgg, result);
+        OpenSearchProject project = (OpenSearchProject) result.getInput(0);
+        // Project has the original column plus the appended literal column.
+        assertEquals(2, project.getRowType().getFieldCount());
+        assertEquals("take_state", project.getRowType().getFieldList().get(0).getName());
+        assertTrue(
+            "literal column name should follow the $lit_call prefix",
+            project.getRowType().getFieldList().get(1).getName().startsWith("$lit_call")
+        );
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    /** Small helper: classify a single SqlAggFunction via the SPI; null when no decomposition. */
+    private static IntermediateField classify(SqlAggFunction sqlFn) {
+        AggregateFunction enumFn = AggregateFunction.fromSqlAggFunction(sqlFn);
+        List<IntermediateField> fields = enumFn.intermediateFields();
+        if (fields == null) return null;
+        return fields.get(0);
+    }
+
+    /**
+     * Builds a FINAL aggregate over a plain scan (no exchange reducer). Used as a degenerate
+     * input shape — the orchestrator's StageInputScan check should reject it and return the
+     * input unchanged.
+     */
+    private OpenSearchAggregate buildFinalAggregateOverScan() {
+        RelNode scan = stubScan(mockTable("test_index", "status", "size"));
+        return new OpenSearchAggregate(
+            cluster,
+            cluster.traitSet(),
+            scan,
+            ImmutableBitSet.of(0),
+            null,
+            List.of(sumCall(scan)),
+            AggregateMode.FINAL,
+            List.of("mock-parquet"),
+            Map.of(),
+            Map.of(),
+            Collections.singletonList(null)
+        );
+    }
+}


### PR DESCRIPTION
### Description

Refactors `DistributedAggregateRewriter` into a transformer pipeline and fixes aggCall slot adjustment in `OpenSearchAggregateSplitRule` when the input schema changes during the aggregate split.

`DistributedAggregateRewriter` was originally introduced in #21645 and #21731 to handle post-Volcano FINAL-aggregate rewrites. As it grew, three loosely-related concerns ended up under a single `rewrite()` method, with construction-time aggCall building reaching across packages.

#21848 took an initial pass at the empty-group failures by skipping the PARTIAL/FINAL split when the aggregate has no `by` clause. As discussed in that PR's comments, the skip was a workaround rather than a fix — distributed parallelism was traded for correctness on every empty-group query, and the underlying row-type-drift issue between SINGLE and FINAL went unaddressed.

This PR separates the two timings (construction-time vs. post-Volcano), introduces a single source of truth for per-call classification, and fixes the row-type drift directly so empty-group queries can use the parallel PARTIAL/FINAL alternative without the skip.

### Changes

**Refactor**
- Consolidate the post-Volcano transformer pipeline (interface + two implementations) and `FinalAggCallBuilder` into `DistributedAggregateRewriter` as nested types and private static methods.
- Move construction-time aggCall building (slot rebase, COUNT→SUM swap, type pinning) into `FinalAggCallBuilder`.
-  Introduce per-call `IntermediateField` classification stored on `OpenSearchAggregate`. Classifying once on the ORIGINAL aggCalls avoids picking the wrong reducer when post-swap calls are re-classified later.
- Add `OpenSearchAggregate.finalAfterRewrite` static factory so the rewriter's return path doesn't repeat the constructor argument list.

**Fix**
- `OpenSearchAggregateSplitRule` now builds FINAL via `FinalAggCallBuilder` with the stashed classification, fixing aggCall slot adjustment when the input schema changes during the aggregate split.
- For empty-group `count()`, FINAL's COUNT→SUM swap returns nullable `BIGINT` while SINGLE keeps `BIGINT NOT NULL` — Volcano rejects the mismatch. Wrap FINAL in a CAST-projection back to SINGLE's row type. Restores PARTIAL/FINAL parallelism for no `group by` queries.

### Tests

- `AggregatePlanShapeTests` — 10 plan-shape assertions across count / sum / avg / sum+count with `by`, plus count empty-group, at 1-shard and 2-shard.
- `DistributedAggregateRewriterTests` 
- End-to-end verified against ClickBench at 1n/1sh, 1n/4sh, and 4n/4sh: 43/43 PPL queries pass; the 5 originally-failing queries (Q10, Q29, Q31, Q32, Q33) green; new empty-group `count()`, `count(), sum(x)`, `count(), avg(x)`, `count(), min(string)` shapes all pass.
- The original failing reproducer and its swap-control both return identical row counts:
  ```
  source = clickbench | stats count(), sum(AdvEngineID) by RegionID   (was failing pre-fix)
  source = clickbench | stats sum(AdvEngineID), count() by RegionID   (was passing; control)
  ```