### PR TITLE
Stats api transport for `/_plugins/_analytics/stats` endpoint

### DIFF
--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/AnalyticsPlugin.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/AnalyticsPlugin.java
@@ -32,6 +32,8 @@ import org.opensearch.analytics.spi.AnalyticsSearchBackendPlugin;
 import org.opensearch.analytics.stats.AnalyticsStats;
 import org.opensearch.analytics.stats.AnalyticsStatsCollector;
 import org.opensearch.analytics.stats.RestAnalyticsStatsAction;
+import org.opensearch.analytics.stats.transport.AnalyticsStatsAction;
+import org.opensearch.analytics.stats.transport.TransportAnalyticsStatsAction;
 import org.opensearch.arrow.allocator.ArrowNativeAllocator;
 import org.opensearch.arrow.spi.NativeAllocatorPoolConfig;
 import org.opensearch.cluster.ClusterState;
@@ -222,7 +224,7 @@ public class AnalyticsPlugin extends Plugin implements ExtensiblePlugin, ActionP
         IndexNameExpressionResolver indexNameExpressionResolver,
         Supplier<DiscoveryNodes> nodesInCluster
     ) {
-        return List.of(new RestAnalyticsStatsAction(statsCollector));
+        return List.of(new RestAnalyticsStatsAction());
     }
 
     @Override
@@ -243,7 +245,10 @@ public class AnalyticsPlugin extends Plugin implements ExtensiblePlugin, ActionP
 
     @Override
     public List<ActionHandler<? extends ActionRequest, ? extends ActionResponse>> getActions() {
-        return List.of(new ActionHandler<>(AnalyticsQueryAction.INSTANCE, DefaultPlanExecutor.class));
+        return List.of(
+            new ActionHandler<>(AnalyticsQueryAction.INSTANCE, DefaultPlanExecutor.class),
+            new ActionHandler<>(AnalyticsStatsAction.INSTANCE, TransportAnalyticsStatsAction.class)
+        );
     }
 
     @Override

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/stats/AnalyticsStats.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/stats/AnalyticsStats.java
@@ -9,11 +9,15 @@
 package org.opensearch.analytics.stats;
 
 import org.opensearch.common.annotation.ExperimentalApi;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.common.io.stream.Writeable;
 import org.opensearch.core.xcontent.ToXContentFragment;
 import org.opensearch.core.xcontent.XContentBuilder;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.TreeMap;
 
 /**
  * Snapshot of node-local analytics-engine counters and timers. Built by
@@ -33,7 +37,7 @@ import java.util.Map;
  * change in subsequent revisions.
  */
 @ExperimentalApi
-public final class AnalyticsStats implements ToXContentFragment {
+public final class AnalyticsStats implements ToXContentFragment, Writeable {
 
     private final Queries queries;
     private final Map<String, StageBucket> stagesByType;
@@ -43,6 +47,30 @@ public final class AnalyticsStats implements ToXContentFragment {
         this.queries = queries;
         this.stagesByType = stagesByType;
         this.fragments = fragments;
+    }
+
+    public AnalyticsStats(StreamInput in) throws IOException {
+        this.queries = new Queries(in);
+        int size = in.readVInt();
+        // TreeMap preserves the deterministic alphabetical ordering used by snapshot().
+        Map<String, StageBucket> map = new TreeMap<>();
+        for (int i = 0; i < size; i++) {
+            String key = in.readString();
+            map.put(key, new StageBucket(in));
+        }
+        this.stagesByType = map;
+        this.fragments = new Fragments(in);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        queries.writeTo(out);
+        out.writeVInt(stagesByType.size());
+        for (Map.Entry<String, StageBucket> e : stagesByType.entrySet()) {
+            out.writeString(e.getKey());
+            e.getValue().writeTo(out);
+        }
+        fragments.writeTo(out);
     }
 
     public Queries queries() {
@@ -76,9 +104,19 @@ public final class AnalyticsStats implements ToXContentFragment {
      * Cumulative latency totals: {@code count} of recordings and {@code sum_ms}
      * of their elapsed times. Both monotonically increasing since node start.
      */
-    public record LatencyStats(long count, long sumMs) implements ToXContentFragment {
+    public record LatencyStats(long count, long sumMs) implements ToXContentFragment, Writeable {
 
         public static final LatencyStats EMPTY = new LatencyStats(0, 0);
+
+        public LatencyStats(StreamInput in) throws IOException {
+            this(in.readVLong(), in.readVLong());
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeVLong(count);
+            out.writeVLong(sumMs);
+        }
 
         @Override
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
@@ -98,7 +136,18 @@ public final class AnalyticsStats implements ToXContentFragment {
      * totals that don't have a home in core node stats: end-to-end query
      * elapsed and Calcite planning time.
      */
-    public record Queries(LatencyStats elapsedMs, LatencyStats planningMs) implements ToXContentFragment {
+    public record Queries(LatencyStats elapsedMs, LatencyStats planningMs) implements ToXContentFragment, Writeable {
+
+        public Queries(StreamInput in) throws IOException {
+            this(new LatencyStats(in), new LatencyStats(in));
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            elapsedMs.writeTo(out);
+            planningMs.writeTo(out);
+        }
+
         @Override
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
             builder.startObject("queries");
@@ -114,7 +163,23 @@ public final class AnalyticsStats implements ToXContentFragment {
     /** Per-stage-type rollup, keyed by {@link org.opensearch.analytics.planner.dag.StageExecutionType} name. */
     public record StageBucket(long started, long succeeded, long failed, long cancelled, long rowsProcessedTotal, LatencyStats elapsedMs)
         implements
-            ToXContentFragment {
+            ToXContentFragment,
+            Writeable {
+
+        public StageBucket(StreamInput in) throws IOException {
+            this(in.readVLong(), in.readVLong(), in.readVLong(), in.readVLong(), in.readVLong(), new LatencyStats(in));
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeVLong(started);
+            out.writeVLong(succeeded);
+            out.writeVLong(failed);
+            out.writeVLong(cancelled);
+            out.writeVLong(rowsProcessedTotal);
+            elapsedMs.writeTo(out);
+        }
+
         @Override
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
             builder.startObject();
@@ -131,7 +196,20 @@ public final class AnalyticsStats implements ToXContentFragment {
     }
 
     /** Per-fragment (task) rollup. */
-    public record Fragments(long total, long succeeded, long failed, LatencyStats elapsedMs) implements ToXContentFragment {
+    public record Fragments(long total, long succeeded, long failed, LatencyStats elapsedMs) implements ToXContentFragment, Writeable {
+
+        public Fragments(StreamInput in) throws IOException {
+            this(in.readVLong(), in.readVLong(), in.readVLong(), new LatencyStats(in));
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeVLong(total);
+            out.writeVLong(succeeded);
+            out.writeVLong(failed);
+            elapsedMs.writeTo(out);
+        }
+
         @Override
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
             builder.startObject("fragments");

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/stats/RestAnalyticsStatsAction.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/stats/RestAnalyticsStatsAction.java
@@ -8,35 +8,29 @@
 
 package org.opensearch.analytics.stats;
 
+import org.opensearch.analytics.stats.transport.AnalyticsStatsAction;
+import org.opensearch.analytics.stats.transport.AnalyticsStatsRequest;
 import org.opensearch.common.annotation.ExperimentalApi;
-import org.opensearch.core.rest.RestStatus;
-import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.common.Strings;
 import org.opensearch.rest.BaseRestHandler;
-import org.opensearch.rest.BytesRestResponse;
 import org.opensearch.rest.RestRequest;
+import org.opensearch.rest.action.RestActions.NodesResponseRestListener;
 import org.opensearch.transport.client.node.NodeClient;
 
 import java.util.List;
 
 /**
- * REST handler for {@code GET _plugins/_analytics/stats}. Returns a snapshot of
- * node-local query / stage / fragment counters from {@link AnalyticsStatsCollector}.
- *
- * <p>Per-node only for v1 — broadcast via {@code TransportNodesAction} is a
- * follow-up. Mirrors the simple {@code BaseRestHandler} pattern used by
- * {@code DataFusionStatsAction}.
+ * REST handler for {@code GET _plugins/_analytics/stats} (and the per-node
+ * variant {@code GET _plugins/_analytics/{nodeId}/stats}). Fans out to the
+ * matching nodes via {@link AnalyticsStatsAction} and renders one
+ * {@link AnalyticsStats} block per node, mirroring {@code _nodes/stats}'s
+ * path scoping.
  *
  * <p>Marked {@link ExperimentalApi} — route, response shape, and aggregation
- * scope (per-node vs. cluster-wide) may evolve.
+ * scope may evolve.
  */
 @ExperimentalApi
 public class RestAnalyticsStatsAction extends BaseRestHandler {
-
-    private final AnalyticsStatsCollector collector;
-
-    public RestAnalyticsStatsAction(AnalyticsStatsCollector collector) {
-        this.collector = collector;
-    }
 
     @Override
     public String getName() {
@@ -45,22 +39,19 @@ public class RestAnalyticsStatsAction extends BaseRestHandler {
 
     @Override
     public List<Route> routes() {
-        return List.of(new Route(RestRequest.Method.GET, "_plugins/_analytics/stats"));
+        return List.of(
+            new Route(RestRequest.Method.GET, "_plugins/_analytics/stats"),
+            new Route(RestRequest.Method.GET, "_plugins/_analytics/{nodeId}/stats")
+        );
     }
 
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) {
-        return channel -> {
-            try {
-                AnalyticsStats stats = collector.snapshot();
-                XContentBuilder builder = channel.newBuilder();
-                builder.startObject();
-                stats.toXContent(builder, request);
-                builder.endObject();
-                channel.sendResponse(new BytesRestResponse(RestStatus.OK, builder));
-            } catch (Exception e) {
-                channel.sendResponse(new BytesRestResponse(channel, e));
-            }
-        };
+        // Empty array means "all nodes" — BaseNodesRequest's contract. nodeId can be a
+        // single id, a comma-separated list, or a node selector like "master:true" / "_local"
+        // (same vocabulary as /_nodes/stats path scoping).
+        String[] nodeIds = Strings.splitStringByCommaToArray(request.param("nodeId"));
+        AnalyticsStatsRequest req = new AnalyticsStatsRequest(nodeIds);
+        return channel -> client.execute(AnalyticsStatsAction.INSTANCE, req, new NodesResponseRestListener<>(channel));
     }
 }

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/stats/package-info.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/stats/package-info.java
@@ -7,10 +7,12 @@
  */
 
 /**
- * Node-local stats rollup for the analytics engine.
- * {@link org.opensearch.analytics.stats.AnalyticsStatsCollector} accumulates
- * lifecycle events from the {@link org.opensearch.analytics.backend.AnalyticsOperationListener}
- * firing sites; {@link org.opensearch.analytics.stats.RestAnalyticsStatsAction}
- * exposes a snapshot at {@code GET _plugins/_analytics/stats}.
+ * Cluster-wide stats rollup for the analytics engine.
+ * {@link org.opensearch.analytics.stats.AnalyticsStatsCollector} folds each
+ * completed {@link org.opensearch.analytics.exec.profile.QueryProfile} into
+ * cumulative counters and HdrHistogram-backed latency buckets.
+ * {@link org.opensearch.analytics.stats.RestAnalyticsStatsAction} exposes a
+ * fan-out snapshot at {@code GET _plugins/_analytics/stats} via
+ * {@link org.opensearch.analytics.stats.transport.AnalyticsStatsAction}.
  */
 package org.opensearch.analytics.stats;

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/stats/transport/AnalyticsStatsAction.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/stats/transport/AnalyticsStatsAction.java
@@ -1,0 +1,32 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.stats.transport;
+
+import org.opensearch.action.ActionType;
+import org.opensearch.common.annotation.ExperimentalApi;
+
+/**
+ * Transport action for the cluster-wide analytics-engine stats rollup. Backs
+ * {@code GET _plugins/_analytics/stats} via {@link TransportAnalyticsStatsAction}.
+ *
+ * <p>Cluster-monitor scope so the action goes through the standard nodes-stats
+ * authorization path.
+ *
+ * @opensearch.experimental
+ */
+@ExperimentalApi
+public class AnalyticsStatsAction extends ActionType<AnalyticsStatsResponse> {
+
+    public static final AnalyticsStatsAction INSTANCE = new AnalyticsStatsAction();
+    public static final String NAME = "cluster:monitor/analytics/stats";
+
+    private AnalyticsStatsAction() {
+        super(NAME, AnalyticsStatsResponse::new);
+    }
+}

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/stats/transport/AnalyticsStatsNodeRequest.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/stats/transport/AnalyticsStatsNodeRequest.java
@@ -1,0 +1,34 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.stats.transport;
+
+import org.opensearch.common.annotation.ExperimentalApi;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.transport.TransportRequest;
+
+import java.io.IOException;
+
+/**
+ * Per-node request emitted by the coordinator to each fan-out target. The
+ * outer {@link AnalyticsStatsRequest} carries no filters today, so this
+ * request is empty too — it exists to satisfy
+ * {@link org.opensearch.action.support.nodes.TransportNodesAction}'s
+ * generic contract.
+ *
+ * @opensearch.experimental
+ */
+@ExperimentalApi
+public class AnalyticsStatsNodeRequest extends TransportRequest {
+
+    public AnalyticsStatsNodeRequest() {}
+
+    public AnalyticsStatsNodeRequest(StreamInput in) throws IOException {
+        super(in);
+    }
+}

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/stats/transport/AnalyticsStatsNodeResponse.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/stats/transport/AnalyticsStatsNodeResponse.java
@@ -1,0 +1,51 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.stats.transport;
+
+import org.opensearch.action.support.nodes.BaseNodeResponse;
+import org.opensearch.analytics.stats.AnalyticsStats;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.common.annotation.ExperimentalApi;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+
+/**
+ * Per-node payload of {@link AnalyticsStatsResponse}: the local
+ * {@link AnalyticsStats} snapshot from this node's
+ * {@link org.opensearch.analytics.stats.AnalyticsStatsCollector}.
+ *
+ * @opensearch.experimental
+ */
+@ExperimentalApi
+public class AnalyticsStatsNodeResponse extends BaseNodeResponse {
+
+    private final AnalyticsStats stats;
+
+    public AnalyticsStatsNodeResponse(DiscoveryNode node, AnalyticsStats stats) {
+        super(node);
+        this.stats = stats;
+    }
+
+    public AnalyticsStatsNodeResponse(StreamInput in) throws IOException {
+        super(in);
+        this.stats = new AnalyticsStats(in);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        stats.writeTo(out);
+    }
+
+    public AnalyticsStats getStats() {
+        return stats;
+    }
+}

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/stats/transport/AnalyticsStatsRequest.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/stats/transport/AnalyticsStatsRequest.java
@@ -1,0 +1,39 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.stats.transport;
+
+import org.opensearch.action.support.nodes.BaseNodesRequest;
+import org.opensearch.common.annotation.ExperimentalApi;
+import org.opensearch.core.common.io.stream.StreamInput;
+
+import java.io.IOException;
+
+/**
+ * Request for {@link AnalyticsStatsAction}. No payload — the response is the
+ * full per-node analytics stats rollup. Inherits {@code nodesIds()} filtering
+ * from {@link BaseNodesRequest} (not exposed via REST, but available
+ * programmatically and supported by the transport-action fan-out).
+ *
+ * @opensearch.experimental
+ */
+@ExperimentalApi
+public class AnalyticsStatsRequest extends BaseNodesRequest<AnalyticsStatsRequest> {
+
+    public AnalyticsStatsRequest() {
+        super((String[]) null);
+    }
+
+    public AnalyticsStatsRequest(String... nodesIds) {
+        super(nodesIds);
+    }
+
+    public AnalyticsStatsRequest(StreamInput in) throws IOException {
+        super(in);
+    }
+}

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/stats/transport/AnalyticsStatsResponse.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/stats/transport/AnalyticsStatsResponse.java
@@ -1,0 +1,64 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.stats.transport;
+
+import org.opensearch.action.FailedNodeException;
+import org.opensearch.action.support.nodes.BaseNodesResponse;
+import org.opensearch.cluster.ClusterName;
+import org.opensearch.common.annotation.ExperimentalApi;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.xcontent.ToXContentObject;
+import org.opensearch.core.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Cluster-wide response for {@code GET _plugins/_analytics/stats}. Mirrors
+ * {@code _nodes/stats} layout: each contacted node's analytics rollup is
+ * rendered under its node id. The {@code _nodes} header (total/successful/failed)
+ * and the {@code cluster_name} are emitted by the REST handler via
+ * {@link org.opensearch.rest.action.RestActions#nodesResponse}.
+ *
+ * @opensearch.experimental
+ */
+@ExperimentalApi
+public class AnalyticsStatsResponse extends BaseNodesResponse<AnalyticsStatsNodeResponse> implements ToXContentObject {
+
+    public AnalyticsStatsResponse(StreamInput in) throws IOException {
+        super(in);
+    }
+
+    public AnalyticsStatsResponse(ClusterName clusterName, List<AnalyticsStatsNodeResponse> nodes, List<FailedNodeException> failures) {
+        super(clusterName, nodes, failures);
+    }
+
+    @Override
+    protected List<AnalyticsStatsNodeResponse> readNodesFrom(StreamInput in) throws IOException {
+        return in.readList(AnalyticsStatsNodeResponse::new);
+    }
+
+    @Override
+    protected void writeNodesTo(StreamOutput out, List<AnalyticsStatsNodeResponse> nodes) throws IOException {
+        out.writeList(nodes);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject("nodes");
+        for (AnalyticsStatsNodeResponse node : getNodes()) {
+            builder.startObject(node.getNode().getId());
+            node.getStats().toXContent(builder, params);
+            builder.endObject();
+        }
+        builder.endObject();
+        return builder;
+    }
+}

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/stats/transport/TransportAnalyticsStatsAction.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/stats/transport/TransportAnalyticsStatsAction.java
@@ -1,0 +1,93 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.stats.transport;
+
+import org.opensearch.action.FailedNodeException;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.nodes.TransportNodesAction;
+import org.opensearch.analytics.stats.AnalyticsStats;
+import org.opensearch.analytics.stats.AnalyticsStatsCollector;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.annotation.ExperimentalApi;
+import org.opensearch.common.inject.Inject;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportService;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Coordinator-level fan-out for {@link AnalyticsStatsAction}. Each contacted
+ * node runs {@link #nodeOperation} which returns a fresh snapshot of the
+ * local {@link AnalyticsStatsCollector}; the coordinator collects all the
+ * responses into an {@link AnalyticsStatsResponse} for rendering.
+ *
+ * <p>The node-level work is a single {@code snapshot()} call — cheap,
+ * lock-free, and bounded — so it runs on the {@code MANAGEMENT} threadpool
+ * mirroring {@code TransportNodesStatsAction}.
+ *
+ * @opensearch.experimental
+ */
+@ExperimentalApi
+public class TransportAnalyticsStatsAction extends TransportNodesAction<
+    AnalyticsStatsRequest,
+    AnalyticsStatsResponse,
+    AnalyticsStatsNodeRequest,
+    AnalyticsStatsNodeResponse> {
+
+    private final AnalyticsStatsCollector collector;
+
+    @Inject
+    public TransportAnalyticsStatsAction(
+        ThreadPool threadPool,
+        ClusterService clusterService,
+        TransportService transportService,
+        ActionFilters actionFilters,
+        AnalyticsStatsCollector collector
+    ) {
+        super(
+            AnalyticsStatsAction.NAME,
+            threadPool,
+            clusterService,
+            transportService,
+            actionFilters,
+            AnalyticsStatsRequest::new,
+            AnalyticsStatsNodeRequest::new,
+            ThreadPool.Names.MANAGEMENT,
+            AnalyticsStatsNodeResponse.class
+        );
+        this.collector = collector;
+    }
+
+    @Override
+    protected AnalyticsStatsResponse newResponse(
+        AnalyticsStatsRequest request,
+        List<AnalyticsStatsNodeResponse> responses,
+        List<FailedNodeException> failures
+    ) {
+        return new AnalyticsStatsResponse(clusterService.getClusterName(), responses, failures);
+    }
+
+    @Override
+    protected AnalyticsStatsNodeRequest newNodeRequest(AnalyticsStatsRequest request) {
+        return new AnalyticsStatsNodeRequest();
+    }
+
+    @Override
+    protected AnalyticsStatsNodeResponse newNodeResponse(StreamInput in) throws IOException {
+        return new AnalyticsStatsNodeResponse(in);
+    }
+
+    @Override
+    protected AnalyticsStatsNodeResponse nodeOperation(AnalyticsStatsNodeRequest request) {
+        AnalyticsStats stats = collector.snapshot();
+        return new AnalyticsStatsNodeResponse(clusterService.localNode(), stats);
+    }
+}

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/stats/transport/package-info.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/stats/transport/package-info.java
@@ -1,0 +1,16 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/**
+ * Transport plumbing for {@code GET _plugins/_analytics/stats}: a
+ * {@link org.opensearch.action.support.nodes.TransportNodesAction} that fans
+ * out from the coordinator to each cluster node, collects the local
+ * {@link org.opensearch.analytics.stats.AnalyticsStats} snapshot, and
+ * renders one entry per node — mirroring {@code _nodes/stats}'s shape.
+ */
+package org.opensearch.analytics.stats.transport;

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/stats/AnalyticsStatsTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/stats/AnalyticsStatsTests.java
@@ -1,0 +1,98 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.stats;
+
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * Wire-format round-trip tests for {@link AnalyticsStats} and its nested
+ * records. Required because {@link AnalyticsStats} is shipped from each node
+ * to the coordinator inside an
+ * {@link org.opensearch.analytics.stats.transport.AnalyticsStatsNodeResponse}
+ * via {@link org.opensearch.action.support.nodes.TransportNodesAction}.
+ */
+public class AnalyticsStatsTests extends OpenSearchTestCase {
+
+    public void testLatencyStatsRoundTrip() throws IOException {
+        AnalyticsStats.LatencyStats original = new AnalyticsStats.LatencyStats(100, 12345);
+        AnalyticsStats.LatencyStats copy = roundTrip(original, AnalyticsStats.LatencyStats::new);
+        assertEquals(original, copy);
+    }
+
+    public void testQueriesRoundTrip() throws IOException {
+        AnalyticsStats.Queries original = new AnalyticsStats.Queries(
+            new AnalyticsStats.LatencyStats(50, 5000),
+            new AnalyticsStats.LatencyStats(50, 1500)
+        );
+        AnalyticsStats.Queries copy = roundTrip(original, AnalyticsStats.Queries::new);
+        assertEquals(original, copy);
+    }
+
+    public void testStageBucketRoundTrip() throws IOException {
+        AnalyticsStats.StageBucket original = new AnalyticsStats.StageBucket(10, 8, 1, 1, 12345, new AnalyticsStats.LatencyStats(10, 500));
+        AnalyticsStats.StageBucket copy = roundTrip(original, AnalyticsStats.StageBucket::new);
+        assertEquals(original, copy);
+    }
+
+    public void testFragmentsRoundTrip() throws IOException {
+        AnalyticsStats.Fragments original = new AnalyticsStats.Fragments(42, 40, 2, new AnalyticsStats.LatencyStats(42, 800));
+        AnalyticsStats.Fragments copy = roundTrip(original, AnalyticsStats.Fragments::new);
+        assertEquals(original, copy);
+    }
+
+    public void testAnalyticsStatsRoundTrip() throws IOException {
+        Map<String, AnalyticsStats.StageBucket> stages = new TreeMap<>();
+        stages.put("SHARD_FRAGMENT", new AnalyticsStats.StageBucket(20, 18, 1, 1, 99999, new AnalyticsStats.LatencyStats(20, 400)));
+        stages.put("COORDINATOR_REDUCE", new AnalyticsStats.StageBucket(5, 5, 0, 0, 0, new AnalyticsStats.LatencyStats(5, 50)));
+
+        AnalyticsStats original = new AnalyticsStats(
+            new AnalyticsStats.Queries(new AnalyticsStats.LatencyStats(25, 600), new AnalyticsStats.LatencyStats(25, 100)),
+            stages,
+            new AnalyticsStats.Fragments(40, 38, 2, new AnalyticsStats.LatencyStats(40, 750))
+        );
+
+        AnalyticsStats copy = roundTrip(original, AnalyticsStats::new);
+        assertEquals(original.queries(), copy.queries());
+        assertEquals(original.fragments(), copy.fragments());
+        assertEquals(original.stagesByType(), copy.stagesByType());
+    }
+
+    public void testEmptyAnalyticsStatsRoundTrip() throws IOException {
+        AnalyticsStats original = new AnalyticsStats(
+            new AnalyticsStats.Queries(AnalyticsStats.LatencyStats.EMPTY, AnalyticsStats.LatencyStats.EMPTY),
+            new TreeMap<>(),
+            new AnalyticsStats.Fragments(0, 0, 0, AnalyticsStats.LatencyStats.EMPTY)
+        );
+        AnalyticsStats copy = roundTrip(original, AnalyticsStats::new);
+        assertEquals(original.queries(), copy.queries());
+        assertEquals(original.fragments(), copy.fragments());
+        assertTrue("empty stages map round-trips empty", copy.stagesByType().isEmpty());
+    }
+
+    @FunctionalInterface
+    private interface IOFunction<T, R> {
+        R apply(T t) throws IOException;
+    }
+
+    private static <T extends org.opensearch.core.common.io.stream.Writeable> T roundTrip(T original, IOFunction<StreamInput, T> reader)
+        throws IOException {
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            original.writeTo(out);
+            try (StreamInput in = out.bytes().streamInput()) {
+                return reader.apply(in);
+            }
+        }
+    }
+}

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/AnalyticsStatsApiIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/AnalyticsStatsApiIT.java
@@ -17,7 +17,20 @@ import java.util.Map;
 /**
  * Integration test for {@code GET /_plugins/_analytics/stats}. Fires a few
  * PPL queries via {@code POST /_analytics/ppl} and verifies the stats endpoint
- * reflects the activity in its query / stage / fragment counters.
+ * returns a cluster-wide response with one entry per node, each carrying the
+ * full analytics rollup.
+ *
+ * <p>The endpoint mirrors {@code _nodes/stats}'s shape:
+ * <pre>
+ * {
+ *   "_nodes": {...},
+ *   "cluster_name": "...",
+ *   "nodes": {
+ *     "&lt;node-id&gt;": { "analytics": { "queries": {...}, "stages_by_type": {...}, "fragments": {...} } },
+ *     ...
+ *   }
+ * }
+ * </pre>
  */
 public class AnalyticsStatsApiIT extends AnalyticsRestTestCase {
 
@@ -35,62 +48,105 @@ public class AnalyticsStatsApiIT extends AnalyticsRestTestCase {
     public void testStatsEndpointReflectsExecutedQueries() throws IOException {
         ensureDataProvisioned();
 
-        // Fire a handful of queries. The test cluster has multiple nodes and the REST client
-        // round-robins, so a single GET /_plugins/_analytics/stats only sees one node's slice
-        // of the activity. We poll until at least one query is reflected somewhere — proving
-        // the listener fired and the rollup serialized — without depending on which node
-        // happened to coordinate.
-        // Mix of queries — a few shapes so the per-stage-type buckets see varied work
-        // and the histograms have enough samples for percentile spread.
+        // Fire a mix of query shapes so the per-stage-type buckets see varied work and the
+        // histograms have enough samples for percentile spread. The REST client round-robins
+        // the coordinator across nodes, so different queries land on different coordinators.
         for (int i = 0; i < 30; i++) {
             executePpl("source=" + DATASET.indexName + " | fields str0");
             executePpl("source=" + DATASET.indexName + " | where num0 > 0 | fields str0, num0");
             executePpl("source=" + DATASET.indexName + " | stats avg(num0)");
         }
 
-        // Hit every node so the snapshot reflects both coordinator-side (queries, stages)
-        // and data-node-side (fragments) activity. Pick whichever node returned the most.
-        Map<String, Object> stats = fetchBusiestNodeStats();
-        Map<String, Object> analytics = (Map<String, Object>) stats.get("analytics");
-        assertNotNull("analytics present", analytics);
+        Map<String, Object> body = fetchStats();
+        Map<String, Object> nodesHeader = (Map<String, Object>) body.get("_nodes");
+        assertNotNull("_nodes header present", nodesHeader);
+        assertNotNull("cluster_name present", body.get("cluster_name"));
 
-        // queries bucket carries only the latency distributions — query counters
-        // (total/succeeded/failed) live in _nodes/stats, not here.
-        Map<String, Object> queries = (Map<String, Object>) analytics.get("queries");
-        assertNotNull("queries present", queries);
-        Map<String, Object> elapsed = (Map<String, Object>) queries.get("elapsed_ms");
-        assertLatencyStatsShape("queries.elapsed_ms", elapsed);
-        Map<String, Object> planning = (Map<String, Object>) queries.get("planning_ms");
-        assertLatencyStatsShape("queries.planning_ms", planning);
-        // At least one query should have been recorded somewhere on the busiest node.
-        long elapsedCount = ((Number) elapsed.get("count")).longValue();
-        assertTrue("queries.elapsed_ms.count >= 1, got " + elapsedCount, elapsedCount >= 1);
+        Map<String, Object> nodes = (Map<String, Object>) body.get("nodes");
+        assertNotNull("nodes block present", nodes);
+        assertFalse("at least one node in response", nodes.isEmpty());
 
-        Map<String, Object> stagesByType = (Map<String, Object>) analytics.get("stages_by_type");
-        assertNotNull("stages_by_type present", stagesByType);
-        assertFalse("at least one stage type recorded", stagesByType.isEmpty());
-        for (Map.Entry<String, Object> entry : stagesByType.entrySet()) {
-            Map<String, Object> bucket = (Map<String, Object>) entry.getValue();
-            assertNotNull(entry.getKey() + ".started", bucket.get("started"));
-            assertNotNull(entry.getKey() + ".succeeded", bucket.get("succeeded"));
-            assertLatencyStatsShape(entry.getKey() + ".elapsed_ms", (Map<String, Object>) bucket.get("elapsed_ms"));
-            long started = ((Number) bucket.get("started")).longValue();
-            assertTrue(entry.getKey() + ".started > 0", started > 0);
+        // At least one node must have recorded work — every query was coordinated by some
+        // node in this cluster. Walk all nodes, validate each one's shape, and track which
+        // saw the most activity.
+        boolean sawAnyQuery = false;
+        boolean sawAnyStage = false;
+        boolean sawAnyFragment = false;
+        for (Map.Entry<String, Object> nodeEntry : nodes.entrySet()) {
+            String nodeId = nodeEntry.getKey();
+            Map<String, Object> nodeBody = (Map<String, Object>) nodeEntry.getValue();
+            Map<String, Object> analytics = (Map<String, Object>) nodeBody.get("analytics");
+            assertNotNull(nodeId + ".analytics present", analytics);
+
+            // queries bucket carries only the latency distributions — query counters
+            // (total/succeeded/failed) live in _nodes/stats, not here.
+            Map<String, Object> queries = (Map<String, Object>) analytics.get("queries");
+            assertNotNull(nodeId + ".queries present", queries);
+            Map<String, Object> elapsed = (Map<String, Object>) queries.get("elapsed_ms");
+            assertLatencyStatsShape(nodeId + ".queries.elapsed_ms", elapsed);
+            assertLatencyStatsShape(nodeId + ".queries.planning_ms", (Map<String, Object>) queries.get("planning_ms"));
+            if (((Number) elapsed.get("count")).longValue() > 0) {
+                sawAnyQuery = true;
+            }
+
+            Map<String, Object> stagesByType = (Map<String, Object>) analytics.get("stages_by_type");
+            assertNotNull(nodeId + ".stages_by_type present", stagesByType);
+            for (Map.Entry<String, Object> stageEntry : stagesByType.entrySet()) {
+                Map<String, Object> bucket = (Map<String, Object>) stageEntry.getValue();
+                String label = nodeId + ".stages_by_type." + stageEntry.getKey();
+                assertNotNull(label + ".started", bucket.get("started"));
+                assertNotNull(label + ".succeeded", bucket.get("succeeded"));
+                assertLatencyStatsShape(label + ".elapsed_ms", (Map<String, Object>) bucket.get("elapsed_ms"));
+                if (((Number) bucket.get("started")).longValue() > 0) {
+                    sawAnyStage = true;
+                }
+            }
+
+            Map<String, Object> fragments = (Map<String, Object>) analytics.get("fragments");
+            assertNotNull(nodeId + ".fragments present", fragments);
+            assertNotNull(nodeId + ".fragments.total", fragments.get("total"));
+            Map<String, Object> fragElapsed = (Map<String, Object>) fragments.get("elapsed_ms");
+            assertLatencyStatsShape(nodeId + ".fragments.elapsed_ms", fragElapsed);
+            long fragTotal = ((Number) fragments.get("total")).longValue();
+            long fragSucceeded = ((Number) fragments.get("succeeded")).longValue();
+            if (fragTotal > 0) {
+                sawAnyFragment = true;
+                assertTrue(
+                    nodeId + ".fragments.succeeded > 0 when total > 0, total=" + fragTotal + " succeeded=" + fragSucceeded,
+                    fragSucceeded > 0
+                );
+                long fragSum = ((Number) fragElapsed.get("sum_ms")).longValue();
+                assertTrue(nodeId + ".fragments.elapsed_ms.sum_ms > 0 when fragments succeeded", fragSum > 0);
+            }
         }
 
-        Map<String, Object> fragments = (Map<String, Object>) analytics.get("fragments");
-        assertNotNull("fragments present", fragments);
-        assertNotNull("fragments.total", fragments.get("total"));
-        Map<String, Object> fragElapsed = (Map<String, Object>) fragments.get("elapsed_ms");
-        assertLatencyStatsShape("fragments.elapsed_ms", fragElapsed);
-        long fragTotal = ((Number) fragments.get("total")).longValue();
-        long fragSucceeded = ((Number) fragments.get("succeeded")).longValue();
-        if (fragTotal > 0) {
-            // If this node ran any fragments, at least some should have completed and reported success.
-            assertTrue("fragments.succeeded > 0 when total > 0, total=" + fragTotal + " succeeded=" + fragSucceeded, fragSucceeded > 0);
-            long fragSum = ((Number) fragElapsed.get("sum_ms")).longValue();
-            assertTrue("fragments.elapsed_ms.sum_ms > 0 when fragments succeeded", fragSum > 0);
-        }
+        assertTrue("at least one node recorded a query", sawAnyQuery);
+        assertTrue("at least one node recorded a stage", sawAnyStage);
+        assertTrue("at least one node recorded a fragment", sawAnyFragment);
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testStatsEndpointScopedToSingleNode() throws IOException {
+        ensureDataProvisioned();
+
+        // Pick an arbitrary node id from a cluster-wide call, then re-query scoped to that id.
+        Map<String, Object> all = fetchStats();
+        Map<String, Object> nodes = (Map<String, Object>) all.get("nodes");
+        assertNotNull("nodes block present", nodes);
+        assertFalse("at least one node in cluster", nodes.isEmpty());
+        String nodeId = nodes.keySet().iterator().next();
+
+        Request request = new Request("GET", "/_plugins/_analytics/" + nodeId + "/stats");
+        Map<String, Object> body = assertOkAndParse(client().performRequest(request), "STATS GET (single node)");
+
+        Map<String, Object> nodesHeader = (Map<String, Object>) body.get("_nodes");
+        assertNotNull("_nodes header present", nodesHeader);
+        assertEquals("path scope contacts exactly one node", 1, ((Number) nodesHeader.get("total")).intValue());
+
+        Map<String, Object> scopedNodes = (Map<String, Object>) body.get("nodes");
+        assertEquals("response carries exactly one node entry", 1, scopedNodes.size());
+        assertTrue(nodeId + " is the only entry", scopedNodes.containsKey(nodeId));
+        assertNotNull(nodeId + ".analytics present", ((Map<String, Object>) scopedNodes.get(nodeId)).get("analytics"));
     }
 
     private static void assertLatencyStatsShape(String label, Map<String, Object> latency) {
@@ -106,30 +162,6 @@ public class AnalyticsStatsApiIT extends AnalyticsRestTestCase {
         Request request = new Request("GET", "/_plugins/_analytics/stats");
         Response response = client().performRequest(request);
         return assertOkAndParse(response, "STATS GET");
-    }
-
-    /**
-     * Per-node round-robin makes a single GET land on whichever node the client picks.
-     * For the example/visualisation test we want the busiest snapshot — the node that
-     * did the most work — so percentile spread and all three buckets show meaningful
-     * data.
-     */
-    @SuppressWarnings("unchecked")
-    private Map<String, Object> fetchBusiestNodeStats() throws IOException {
-        Map<String, Object> best = null;
-        long bestSignal = -1;
-        for (int i = 0; i < 12; i++) {
-            Map<String, Object> stats = fetchStats();
-            Map<String, Object> analytics = (Map<String, Object>) stats.get("analytics");
-            Map<String, Object> elapsed = (Map<String, Object>) ((Map<String, Object>) analytics.get("queries")).get("elapsed_ms");
-            Map<String, Object> fragments = (Map<String, Object>) analytics.get("fragments");
-            long signal = ((Number) elapsed.get("count")).longValue() + ((Number) fragments.get("total")).longValue();
-            if (signal > bestSignal) {
-                bestSignal = signal;
-                best = stats;
-            }
-        }
-        return best;
     }
 
 }


### PR DESCRIPTION
### Description
Based on #21796 , adds `TransportNodesAction` to broadcast/merge results, since right now this API is per-node only. 

Example:
```
$ curl -s 'http://localhost:9200/_plugins/_analytics/stats' | jq
{
  "_nodes": { "total": 2, "successful": 2, "failed": 0 },
  "cluster_name": "integTest",
  "nodes": {
    "rAuqJRf8R-qDhOoVeOEB-g": {
      "analytics": {
        "queries": {
          "elapsed_ms":  { "count": 46, "sum_ms": 747 },
          "planning_ms": { "count": 46, "sum_ms": 437 }
        },
        "stages_by_type": {
          "SHARD_FRAGMENT": {
            "started": 46, "succeeded": 46, "failed": 0, "cancelled": 0,
            "rows_processed_total": 334,
            "elapsed_ms": { "count": 46, "sum_ms": 747 }
          }
        },
        "fragments": {
          "total": 46, "succeeded": 46, "failed": 0,
          "elapsed_ms": { "count": 46, "sum_ms": 747 }
        }
      }
    },
    "P42d3WKTQvquaLpsqxHINA": {
      "analytics": {
        "queries": {
          "elapsed_ms":  { "count": 44, "sum_ms": 254 },
          "planning_ms": { "count": 44, "sum_ms": 458 }
        },
        "stages_by_type": {
          "SHARD_FRAGMENT": {
            "started": 44, "succeeded": 44, "failed": 0, "cancelled": 0,
            "rows_processed_total": 326,
            "elapsed_ms": { "count": 44, "sum_ms": 254 }
          }
        },
        "fragments": {
          "total": 44, "succeeded": 44, "failed": 0,
          "elapsed_ms": { "count": 44, "sum_ms": 254 }
        }
      }
    }
  }
}
```

And to curl a specific node:
```
$ curl -s 'http://localhost:9200/_plugins/_analytics/<node-id>/stats' | jq
{
  "_nodes": { "total": 1, "successful": 1, "failed": 0 },
  "cluster_name": "integTest",
  "nodes": {
    "<node-id>": {
      "analytics": {
        "queries": {
          "elapsed_ms":  { "count": 46, "sum_ms": 531 },
          "planning_ms": { "count": 46, "sum_ms": 450 }
        },
        "stages_by_type": {
          "SHARD_FRAGMENT": {
            "started": 46, "succeeded": 46, "failed": 0, "cancelled": 0,
            "rows_processed_total": 334,
            "elapsed_ms": { "count": 46, "sum_ms": 531 }
          }
        },
        "fragments": {
          "total": 46, "succeeded": 46, "failed": 0,
          "elapsed_ms": { "count": 46, "sum_ms": 531 }
        }
      }
    }
  }
}
```

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
