### PR TITLE
[Analytics Engine] Make PPL chart work on the analytics-engine route (partition-boundary coercion + non-prefix agg-split type fix)

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/local_executor.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/local_executor.rs
@@ -43,7 +43,9 @@ use datafusion_substrait::logical_plan::consumer::from_substrait_plan;
 use prost::Message;
 use substrait::proto::Plan;
 
-use crate::partition_stream::{channel, PartitionStreamSender, SingleReceiverPartition};
+use crate::partition_stream::{
+    channel, CoercingReceiverPartition, PartitionStreamSender, SingleReceiverPartition,
+};
 
 /// Coordinator-reduce DataFusion session.
 ///
@@ -133,8 +135,21 @@ impl LocalSession {
         schema: SchemaRef,
     ) -> Result<PartitionStreamSender, DataFusionError> {
         let (sender, receiver) = channel(Arc::clone(&schema));
-        let partition: Arc<dyn PartitionStream> = Arc::new(SingleReceiverPartition::new(receiver));
-        let table = StreamingTable::try_new(schema, vec![partition])?;
+        // The producer fragment feeds batches in DataFusion's raw physical types, but the
+        // consumer fragment's Substrait plan declares the coerced forms (UInt64→Int64,
+        // BinaryView→Binary, Float16→Float32 — see crate::schema_coerce). Register the
+        // StreamingTable under the coerced schema so the consumer plan binds against it, and
+        // coerce each batch on the way out. The channel + returned sender keep the un-coerced
+        // schema so the Java-side tripwire still validates producer batches against what the
+        // producer actually emits. coerce_inferred_schema returns the same Arc when nothing
+        // needs rewriting, so the common case keeps the cheaper passthrough partition.
+        let coerced = crate::schema_coerce::coerce_inferred_schema(Arc::clone(&schema));
+        let partition: Arc<dyn PartitionStream> = if Arc::ptr_eq(&coerced, &schema) {
+            Arc::new(SingleReceiverPartition::new(receiver))
+        } else {
+            Arc::new(CoercingReceiverPartition::new(receiver, Arc::clone(&coerced)))
+        };
+        let table = StreamingTable::try_new(coerced, vec![partition])?;
         self.ctx
             .register_table(name, Arc::new(table))
             .map_err(|e| {

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/partition_stream.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/partition_stream.rs
@@ -42,9 +42,11 @@ use datafusion::execution::{RecordBatchStream, TaskContext};
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::physical_plan::streaming::PartitionStream;
 use datafusion::physical_plan::SendableRecordBatchStream;
-use futures::{stream, Stream};
+use futures::{stream, Stream, StreamExt};
 use tokio::runtime::Handle;
 use tokio::sync::mpsc;
+
+use crate::schema_coerce::coerce_record_batch;
 
 /// Bounded channel capacity. Small by design — producers back-pressure when the
 /// DataFusion execute side falls behind.
@@ -192,6 +194,67 @@ impl PartitionStream for SingleReceiverPartition {
                     stream::empty(),
                 ))
             }
+        }
+    }
+}
+
+/// Like [`SingleReceiverPartition`], but coerces every batch to `target` before
+/// handing it to DataFusion.
+///
+/// Registered by [`crate::local_executor::LocalSession::register_partition`] when
+/// the producer fragment's physical schema carries types the consumer fragment's
+/// Substrait plan does not (e.g. `row_number()` emits `UInt64` while the plan
+/// declares `Int64`). The channel still carries the producer's raw batches — the
+/// Java tripwire validates them against the un-coerced schema — and the coercion
+/// happens here, on the consumer side of the channel, so the `StreamingTable`'s
+/// declared schema (`target`) matches what flows out of it.
+pub(crate) struct CoercingReceiverPartition {
+    target: SchemaRef,
+    receiver: Mutex<Option<PartitionStreamReceiver>>,
+}
+
+impl CoercingReceiverPartition {
+    pub(crate) fn new(receiver: PartitionStreamReceiver, target: SchemaRef) -> Self {
+        Self {
+            target,
+            receiver: Mutex::new(Some(receiver)),
+        }
+    }
+}
+
+impl fmt::Debug for CoercingReceiverPartition {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CoercingReceiverPartition")
+            .field("target", &self.target)
+            .finish()
+    }
+}
+
+impl PartitionStream for CoercingReceiverPartition {
+    fn schema(&self) -> &SchemaRef {
+        &self.target
+    }
+
+    fn execute(&self, _ctx: Arc<TaskContext>) -> SendableRecordBatchStream {
+        let taken = self
+            .receiver
+            .lock()
+            .expect("partition mutex poisoned")
+            .take();
+        match taken {
+            Some(receiver) => {
+                let target = Arc::clone(&self.target);
+                let coerced = receiver
+                    .map(move |item| item.and_then(|batch| coerce_record_batch(batch, &target)));
+                Box::pin(RecordBatchStreamAdapter::new(
+                    Arc::clone(&self.target),
+                    coerced,
+                ))
+            }
+            None => Box::pin(RecordBatchStreamAdapter::new(
+                Arc::clone(&self.target),
+                stream::empty(),
+            )),
         }
     }
 }

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/schema_coerce.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/schema_coerce.rs
@@ -87,7 +87,10 @@
 
 use std::sync::Arc;
 
+use datafusion::arrow::compute::cast;
 use datafusion::arrow::datatypes::{DataType, Field, Fields, Schema, SchemaRef};
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::common::DataFusionError;
 
 /// Rewrite the schema to forms Substrait can bind against:
 ///   - `BinaryView` → `Binary`
@@ -111,6 +114,50 @@ pub fn coerce_inferred_schema(schema: SchemaRef) -> SchemaRef {
         rewritten_fields,
         schema.metadata().clone(),
     ))
+}
+
+/// Casts every column of `batch` to the corresponding field type in `target`,
+/// returning a batch whose schema is exactly `target`.
+///
+/// Used at the streaming-partition boundary: a producer fragment emits batches
+/// in DataFusion's raw physical types (`UInt64` for `row_number()`, `BinaryView`
+/// for view-typed columns, `Float16`), but the consumer fragment's Substrait
+/// plan declares the coerced forms (`Int64` / `Binary` / `Float32`) — the same
+/// rewrite [`coerce_inferred_schema`] applies to scan schemas. Without this the
+/// registered `StreamingTable` schema diverges from the consumer plan and
+/// DataFusion rejects the wire with "Substrait schema has a different type than
+/// the corresponding field in the table schema".
+///
+/// Columns already matching their target type are reused without a copy; only
+/// divergent columns go through [`arrow::compute::cast`] (e.g. the cheap
+/// `UInt64 → Int64` reinterpret). Returns the input unchanged when its schema
+/// already equals `target`.
+pub fn coerce_record_batch(
+    batch: RecordBatch,
+    target: &SchemaRef,
+) -> Result<RecordBatch, DataFusionError> {
+    if &batch.schema() == target {
+        return Ok(batch);
+    }
+    let mut columns = Vec::with_capacity(batch.num_columns());
+    for (i, column) in batch.columns().iter().enumerate() {
+        let want = target.field(i).data_type();
+        if column.data_type() == want {
+            columns.push(Arc::clone(column));
+        } else {
+            columns.push(cast(column, want).map_err(|e| {
+                DataFusionError::Execution(format!(
+                    "coerce_record_batch: cast of column '{}' from {:?} to {:?} failed: {}",
+                    target.field(i).name(),
+                    column.data_type(),
+                    want,
+                    e
+                ))
+            })?);
+        }
+    }
+    RecordBatch::try_new(Arc::clone(target), columns)
+        .map_err(|e| DataFusionError::Execution(format!("coerce_record_batch: {}", e)))
 }
 
 fn schema_needs_coerce(schema: &Schema) -> bool {
@@ -184,6 +231,48 @@ pub fn append_missing_nullable(registered: &Schema, expected: &Schema) -> Option
 #[cfg(test)]
 mod tests {
     use super::*;
+    use arrow_array::{Int64Array, UInt64Array};
+
+    #[test]
+    fn coerce_record_batch_rewrites_uint64_column() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("rn", DataType::UInt64, false),
+            Field::new("v", DataType::Int64, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(UInt64Array::from(vec![1u64, 2, 3])),
+                Arc::new(Int64Array::from(vec![10i64, 20, 30])),
+            ],
+        )
+        .unwrap();
+        let target = coerce_inferred_schema(Arc::clone(&schema));
+        assert_eq!(target.field(0).data_type(), &DataType::Int64);
+
+        let out = coerce_record_batch(batch, &target).unwrap();
+        assert_eq!(out.schema(), target);
+        assert_eq!(out.column(0).data_type(), &DataType::Int64);
+        let rn = out
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .expect("coerced to Int64");
+        assert_eq!(rn.values(), &[1i64, 2, 3]);
+    }
+
+    #[test]
+    fn coerce_record_batch_passthrough_when_already_matching() {
+        let schema = Arc::new(Schema::new(vec![Field::new("v", DataType::Int64, false)]));
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(Int64Array::from(vec![7i64, 8]))],
+        )
+        .unwrap();
+        let out = coerce_record_batch(batch, &schema).unwrap();
+        assert_eq!(out.schema(), schema);
+        assert_eq!(out.num_rows(), 2);
+    }
 
     #[test]
     fn append_missing_adds_absent_columns_as_nullable() {

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchAggregateSplitRule.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchAggregateSplitRule.java
@@ -20,7 +20,7 @@ import org.apache.calcite.rex.RexInputRef;
 import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlAggFunction;
-import org.apache.calcite.sql.type.SqlTypeFamily;
+import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.util.ImmutableBitSet;
 import org.opensearch.analytics.planner.PlannerContext;
 import org.opensearch.analytics.planner.RelNodeUtils;
@@ -75,9 +75,18 @@ public class OpenSearchAggregateSplitRule extends RelOptRule {
             if (aggIdx >= aggCalls.size() || k >= inputFields.size()) {
                 return true;
             }
-            SqlTypeFamily inputFamily = inputFields.get(k).getSqlTypeName().getFamily();
-            SqlTypeFamily aggFamily = aggCalls.get(aggIdx).getType().getSqlTypeName().getFamily();
-            if (inputFamily != aggFamily) {
+            // Compare the exact SqlTypeName, not just the type family. The FINAL reuses this
+            // group-key ordinal over the PARTIAL output, where ordinal k (>= groupCount) now
+            // holds an agg output, so the FINAL's group-key column takes the agg-output type
+            // (aggCalls.get(aggIdx)). That must equal the original input field type
+            // (inputFields.get(k)) for the FINAL row type to stay equivalent to the original
+            // aggregate's — otherwise Volcano's typeMatchesInferred / rowtype-equivalence check
+            // throws. A family match is too coarse: BIGINT and INTEGER share the NUMERIC family
+            // yet fail that check (PPL chart / stats `... by <field> span=...` over an INTEGER
+            // measure declares the agg as BIGINT while the span key is INTEGER).
+            SqlTypeName inputType = inputFields.get(k).getSqlTypeName();
+            SqlTypeName aggType = aggCalls.get(aggIdx).getType().getSqlTypeName();
+            if (inputType != aggType) {
                 return true;
             }
         }


### PR DESCRIPTION
### Description

Two type-handling fixes on the analytics-engine route, both surfaced by PPL `chart` (force-routed through the analytics-engine path). No SQL-plugin change — chart's lowering is already merged and unchanged.

#### 1. Coerce streaming-partition schema & batches at the reduce-stage boundary (DataFusion backend)

A producer fragment emits batches in DataFusion's raw physical Arrow types — `UInt64` (e.g. `row_number()`), `BinaryView` (view-typed columns), `Float16` (`half_float`) — but the consumer fragment's Substrait plan declares the coerced forms (`Int64` / `Binary` / `Float32`) that `coerce_inferred_schema` already applies to scan-inferred schemas. `LocalSession::register_partition` registered the reduce-stage `StreamingTable` under the **raw** producer schema, so when a column of one of those types crosses the reduce exchange the consumer plan can fail to bind:

```
Substrait error: Field 'X' in Substrait schema has a different type (Int64) than the corresponding field in the table schema (UInt64).
```

Register the `StreamingTable` under the coerced schema and coerce each incoming batch (new `coerce_record_batch` + `CoercingReceiverPartition`). The channel/sender keep the un-coerced schema so the Java-side tripwire still validates producer batches; `coerce_inferred_schema` returns the same `Arc` when nothing needs rewriting, so plans without these types keep the cheaper passthrough partition (no behavior change).

#### 2. Skip partial/final split on non-prefix groupSet type mismatch — exact `SqlTypeName` (analytics-engine planner)

`OpenSearchAggregateSplitRule.shouldSkipPartialFinalSplit()` skips the split for non-prefix group sets, where a group-key ordinal `k >= groupCount` lands on a PARTIAL agg-output slot — the structural FINAL reuses original ordinals over the keys-first PARTIAL output, so the group key takes the agg-output type, which must equal the original input-field type or Volcano's `typeMatchesInferred` / row-type-equivalence check throws. The collision check compared `SqlTypeFamily`, which is too coarse: `BIGINT` and `INTEGER` share the `NUMERIC` family, so a span group key (`INTEGER`) over a measure declared `BIGINT` could slip through and planning crash with:

```
AssertionError: type mismatch: aggCall type: BIGINT inferred type: INTEGER
IllegalArgumentException: Type mismatch: rel rowtype ... $f2: BIGINT -> INTEGER
```

Compare the exact `SqlTypeName`, so such cases fall back to a SINGLE coordinator aggregate (always correct). Prefix group sets (the common case) are unaffected — they early-return before this check.

Both are surfaced by `chart ... by <field> span=...` over an `INTEGER` measure and by chart's ranked `ROW_NUMBER() OVER (...)` subplan crossing a join exchange; the equivalent `stats ... by <field> span=...` and any `unsigned_long` / `binary` / `float16` column crossing a reduce stage hit the same paths.

### Tests

New Rust unit tests: `coerce_record_batch_rewrites_uint64_column`, `coerce_record_batch_passthrough_when_already_matching`.

### Check List
- [x] New functionality includes testing.
- [x] Commits are signed per the DCO using `--signoff`.
