### PR TITLE
[Sandbox] feat(datafusion): expose cumulative indexed-search execution stats on the analytics backend stats endpoint

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/ffm.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/ffm.rs
@@ -1013,11 +1013,12 @@ pub unsafe extern "C" fn df_execute_with_context(
 
 /// Collects all native executor metrics into a caller-provided byte buffer.
 ///
-/// The buffer must have capacity for at least `size_of::<DfStatsBuffer>()` bytes (344).
+/// The buffer must have capacity for at least `size_of::<DfStatsBuffer>()` bytes (544).
 /// Returns 0 on success.
 #[ffm_safe]
 #[no_mangle]
 pub unsafe extern "C" fn df_stats(out_ptr: *mut u8, out_cap: i64) -> i64 {
+    use crate::search_stats::pack_search_stats;
     use crate::stats::{layout, pack_runtime_metrics, pack_task_monitor, pack_partition_gate, DfStatsBuffer, RuntimeMetricsRepr};
     use crate::task_monitors::{
         coordinator_reduce_monitor, query_execution_monitor,
@@ -1056,6 +1057,7 @@ pub unsafe extern "C" fn df_stats(out_ptr: *mut u8, out_cap: i64) -> i64 {
         plan_setup: pack_task_monitor(plan_setup_monitor()),
         datanode_gate: pack_partition_gate(mgr.cpu_executor.concurrency_gate()),
         coordinator_gate: pack_partition_gate(mgr.coordinator_gate()),
+        search_stats: pack_search_stats(),
     };
 
     // Copy struct bytes to caller buffer

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/table_provider.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/table_provider.rs
@@ -48,7 +48,14 @@ use super::partitioning::{compute_assignments, PartitionAssignment, SegmentChunk
 use super::stream::{FilterStrategy, IndexedExec, RowGroupInfo};
 use crate::datafusion_query_config::DatafusionQueryConfig;
 use crate::indexed_table::metrics::StreamMetrics;
+use crate::search_stats::SEARCH_STATS;
 use std::collections::HashSet;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::physical_plan::RecordBatchStream;
+use futures::Stream;
 
 /// Info about a segment and its corresponding parquet file.
 #[derive(Debug, Clone)]
@@ -394,6 +401,10 @@ impl ExecutionPlan for QueryShardExec {
         let pmetrics = PartitionMetrics::new(&self.metrics, partition);
         let stream_metrics =
             pmetrics.into_stream_metrics(Some(Arc::clone(&self.inner_parquet_metrics)));
+        // Cloned handles for accumulation when the partition stream is dropped.
+        // `StreamMetrics` shares its `Count`/`Time` `Arc`s with the live stream,
+        // so by drop time these reflect the final per-partition totals.
+        let stream_metrics_for_accum = stream_metrics.clone();
 
         // Build one IndexedExec per SegmentChunk, chain via UnionExec-style concatenation.
         let mut execs: Vec<Arc<dyn ExecutionPlan>> = Vec::with_capacity(assignment.chunks.len());
@@ -454,11 +465,13 @@ impl ExecutionPlan for QueryShardExec {
             // No work — empty stream
             let empty =
                 datafusion::physical_plan::empty::EmptyExec::new(self.projected_schema.clone());
-            return empty.execute(0, context);
+            let inner = empty.execute(0, context)?;
+            return Ok(Box::pin(AccumulatingStream::new(inner, stream_metrics_for_accum)));
         }
 
         if execs.len() == 1 {
-            return execs.remove(0).execute(0, context);
+            let inner = execs.remove(0).execute(0, context)?;
+            return Ok(Box::pin(AccumulatingStream::new(inner, stream_metrics_for_accum)));
         }
 
         // Multiple chunks in one partition — concatenate via UnionExec
@@ -468,7 +481,8 @@ impl ExecutionPlan for QueryShardExec {
         // so wrap in CoalescePartitionsExec.
         let coalesced =
             datafusion::physical_plan::coalesce_partitions::CoalescePartitionsExec::new(union);
-        coalesced.execute(0, context)
+        let inner = coalesced.execute(0, context)?;
+        Ok(Box::pin(AccumulatingStream::new(inner, stream_metrics_for_accum)))
     }
 }
 
@@ -480,6 +494,39 @@ impl QueryShardExec {
         &self,
     ) -> Option<&Arc<dyn datafusion::physical_expr::PhysicalExpr>> {
         self.predicate.as_ref()
+    }
+}
+
+/// Wraps a partition stream so that final per-partition `Count`/`Time`
+/// values are folded into [`SEARCH_STATS`] when the stream is dropped.
+struct AccumulatingStream {
+    inner: SendableRecordBatchStream,
+    stream_metrics: StreamMetrics,
+}
+
+impl AccumulatingStream {
+    fn new(inner: SendableRecordBatchStream, stream_metrics: StreamMetrics) -> Self {
+        Self { inner, stream_metrics }
+    }
+}
+
+impl Stream for AccumulatingStream {
+    type Item = Result<RecordBatch>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        Pin::new(&mut self.inner).poll_next(cx)
+    }
+}
+
+impl RecordBatchStream for AccumulatingStream {
+    fn schema(&self) -> SchemaRef {
+        self.inner.schema()
+    }
+}
+
+impl Drop for AccumulatingStream {
+    fn drop(&mut self) {
+        SEARCH_STATS.accumulate(&self.stream_metrics);
     }
 }
 

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/lib.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/lib.rs
@@ -55,5 +55,6 @@ pub mod udaf;
 pub mod udf;
 pub mod udwf;
 pub mod native_node_stats;
+pub mod search_stats;
 pub mod stats;
 pub mod task_monitors;

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/search_stats.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/search_stats.rs
@@ -1,0 +1,331 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+//! Process-global accumulator for indexed-path search execution metrics.
+//!
+//! [`SEARCH_STATS`] is updated once per partition stream lifetime from the
+//! `Drop` impl of the partition stream wrapper in
+//! [`crate::indexed_table::table_provider`]; values are read by
+//! [`crate::stats::pack_search_stats`] when the FFM stats endpoint runs.
+
+use std::sync::atomic::{AtomicI64, Ordering};
+
+use once_cell::sync::Lazy;
+
+use crate::indexed_table::metrics::StreamMetrics;
+use crate::stats::SearchStatsRepr;
+
+/// Cumulative indexed-search execution metrics. Field names match
+/// [`SearchStatsRepr`] / `PartitionMetrics`.
+pub struct SearchStatsAccumulator {
+    pub queries_completed: AtomicI64,
+
+    pub output_rows: AtomicI64,
+    pub rows_matched: AtomicI64,
+    pub rows_pruned_by_page_index: AtomicI64,
+    pub row_groups_processed: AtomicI64,
+    pub row_groups_skipped: AtomicI64,
+    pub pages_pruned: AtomicI64,
+    pub pages_total: AtomicI64,
+    pub page_pruning_unavailable: AtomicI64,
+    pub ffm_collector_calls: AtomicI64,
+    pub batches_produced: AtomicI64,
+    pub parquet_batches_received: AtomicI64,
+    pub position_map_identity: AtomicI64,
+    pub position_map_bitmap: AtomicI64,
+    pub position_map_runs: AtomicI64,
+    pub min_skip_run_row_granular: AtomicI64,
+    pub min_skip_run_block_granular: AtomicI64,
+    pub prefetch_wait_count: AtomicI64,
+    pub batches_pre_coalesce: AtomicI64,
+
+    pub elapsed_compute_ms: AtomicI64,
+    pub index_time_ms: AtomicI64,
+    pub parquet_time_ms: AtomicI64,
+    pub prefetch_wait_time_ms: AtomicI64,
+    pub coalesce_time_ms: AtomicI64,
+    pub build_mask_time_ms: AtomicI64,
+    pub filter_record_batch_time_ms: AtomicI64,
+    pub on_batch_mask_time_ms: AtomicI64,
+    pub mask_slice_time_ms: AtomicI64,
+    pub projection_fixup_time_ms: AtomicI64,
+    pub parquet_poll_time_ms: AtomicI64,
+}
+
+impl SearchStatsAccumulator {
+    const fn new() -> Self {
+        Self {
+            queries_completed: AtomicI64::new(0),
+            output_rows: AtomicI64::new(0),
+            rows_matched: AtomicI64::new(0),
+            rows_pruned_by_page_index: AtomicI64::new(0),
+            row_groups_processed: AtomicI64::new(0),
+            row_groups_skipped: AtomicI64::new(0),
+            pages_pruned: AtomicI64::new(0),
+            pages_total: AtomicI64::new(0),
+            page_pruning_unavailable: AtomicI64::new(0),
+            ffm_collector_calls: AtomicI64::new(0),
+            batches_produced: AtomicI64::new(0),
+            parquet_batches_received: AtomicI64::new(0),
+            position_map_identity: AtomicI64::new(0),
+            position_map_bitmap: AtomicI64::new(0),
+            position_map_runs: AtomicI64::new(0),
+            min_skip_run_row_granular: AtomicI64::new(0),
+            min_skip_run_block_granular: AtomicI64::new(0),
+            prefetch_wait_count: AtomicI64::new(0),
+            batches_pre_coalesce: AtomicI64::new(0),
+            elapsed_compute_ms: AtomicI64::new(0),
+            index_time_ms: AtomicI64::new(0),
+            parquet_time_ms: AtomicI64::new(0),
+            prefetch_wait_time_ms: AtomicI64::new(0),
+            coalesce_time_ms: AtomicI64::new(0),
+            build_mask_time_ms: AtomicI64::new(0),
+            filter_record_batch_time_ms: AtomicI64::new(0),
+            on_batch_mask_time_ms: AtomicI64::new(0),
+            mask_slice_time_ms: AtomicI64::new(0),
+            projection_fixup_time_ms: AtomicI64::new(0),
+            parquet_poll_time_ms: AtomicI64::new(0),
+        }
+    }
+
+    /// Fold a completed partition stream's final `Count`/`Time` values into
+    /// the cumulative counters. `Option` fields are skipped when `None`
+    /// (standalone test paths with [`StreamMetrics::empty`]).
+    pub fn accumulate(&self, m: &StreamMetrics) {
+        self.queries_completed.fetch_add(1, Ordering::Relaxed);
+
+        if let Some(ref c) = m.output_rows {
+            self.output_rows.fetch_add(c.value() as i64, Ordering::Relaxed);
+        }
+        if let Some(ref c) = m.rows_matched {
+            self.rows_matched.fetch_add(c.value() as i64, Ordering::Relaxed);
+        }
+        if let Some(ref c) = m.rows_pruned {
+            self.rows_pruned_by_page_index
+                .fetch_add(c.value() as i64, Ordering::Relaxed);
+        }
+        if let Some(ref c) = m.rg_processed {
+            self.row_groups_processed
+                .fetch_add(c.value() as i64, Ordering::Relaxed);
+        }
+        if let Some(ref c) = m.rg_skipped {
+            self.row_groups_skipped
+                .fetch_add(c.value() as i64, Ordering::Relaxed);
+        }
+        if let Some(ref c) = m.pages_pruned {
+            self.pages_pruned.fetch_add(c.value() as i64, Ordering::Relaxed);
+        }
+        if let Some(ref c) = m.pages_total {
+            self.pages_total.fetch_add(c.value() as i64, Ordering::Relaxed);
+        }
+        if let Some(ref c) = m.page_pruning_unavailable {
+            self.page_pruning_unavailable
+                .fetch_add(c.value() as i64, Ordering::Relaxed);
+        }
+        if let Some(ref c) = m.ffm_collector_calls {
+            self.ffm_collector_calls
+                .fetch_add(c.value() as i64, Ordering::Relaxed);
+        }
+        if let Some(ref c) = m.batches_produced {
+            self.batches_produced
+                .fetch_add(c.value() as i64, Ordering::Relaxed);
+        }
+        if let Some(ref c) = m.parquet_batches_received {
+            self.parquet_batches_received
+                .fetch_add(c.value() as i64, Ordering::Relaxed);
+        }
+        if let Some(ref c) = m.position_map_identity {
+            self.position_map_identity
+                .fetch_add(c.value() as i64, Ordering::Relaxed);
+        }
+        if let Some(ref c) = m.position_map_bitmap {
+            self.position_map_bitmap
+                .fetch_add(c.value() as i64, Ordering::Relaxed);
+        }
+        if let Some(ref c) = m.position_map_runs {
+            self.position_map_runs
+                .fetch_add(c.value() as i64, Ordering::Relaxed);
+        }
+        if let Some(ref c) = m.min_skip_run_row_granular {
+            self.min_skip_run_row_granular
+                .fetch_add(c.value() as i64, Ordering::Relaxed);
+        }
+        if let Some(ref c) = m.min_skip_run_block_granular {
+            self.min_skip_run_block_granular
+                .fetch_add(c.value() as i64, Ordering::Relaxed);
+        }
+        if let Some(ref c) = m.prefetch_wait_count {
+            self.prefetch_wait_count
+                .fetch_add(c.value() as i64, Ordering::Relaxed);
+        }
+        if let Some(ref c) = m.batches_pre_coalesce {
+            self.batches_pre_coalesce
+                .fetch_add(c.value() as i64, Ordering::Relaxed);
+        }
+
+        if let Some(ref t) = m.elapsed_compute {
+            self.elapsed_compute_ms
+                .fetch_add(ns_to_ms(t.value()), Ordering::Relaxed);
+        }
+        if let Some(ref t) = m.index_time {
+            self.index_time_ms
+                .fetch_add(ns_to_ms(t.value()), Ordering::Relaxed);
+        }
+        if let Some(ref t) = m.parquet_time {
+            self.parquet_time_ms
+                .fetch_add(ns_to_ms(t.value()), Ordering::Relaxed);
+        }
+        if let Some(ref t) = m.prefetch_wait_time {
+            self.prefetch_wait_time_ms
+                .fetch_add(ns_to_ms(t.value()), Ordering::Relaxed);
+        }
+        if let Some(ref t) = m.coalesce_time {
+            self.coalesce_time_ms
+                .fetch_add(ns_to_ms(t.value()), Ordering::Relaxed);
+        }
+        if let Some(ref t) = m.build_mask_time {
+            self.build_mask_time_ms
+                .fetch_add(ns_to_ms(t.value()), Ordering::Relaxed);
+        }
+        if let Some(ref t) = m.filter_record_batch_time {
+            self.filter_record_batch_time_ms
+                .fetch_add(ns_to_ms(t.value()), Ordering::Relaxed);
+        }
+        if let Some(ref t) = m.on_batch_mask_time {
+            self.on_batch_mask_time_ms
+                .fetch_add(ns_to_ms(t.value()), Ordering::Relaxed);
+        }
+        if let Some(ref t) = m.mask_slice_time {
+            self.mask_slice_time_ms
+                .fetch_add(ns_to_ms(t.value()), Ordering::Relaxed);
+        }
+        if let Some(ref t) = m.projection_fixup_time {
+            self.projection_fixup_time_ms
+                .fetch_add(ns_to_ms(t.value()), Ordering::Relaxed);
+        }
+        if let Some(ref t) = m.parquet_poll_time {
+            self.parquet_poll_time_ms
+                .fetch_add(ns_to_ms(t.value()), Ordering::Relaxed);
+        }
+    }
+
+    /// Snapshot the cumulative counters into a [`SearchStatsRepr`] for FFM transport.
+    pub fn snapshot(&self) -> SearchStatsRepr {
+        SearchStatsRepr {
+            queries_completed: self.queries_completed.load(Ordering::Relaxed),
+            output_rows: self.output_rows.load(Ordering::Relaxed),
+            rows_matched: self.rows_matched.load(Ordering::Relaxed),
+            rows_pruned_by_page_index: self.rows_pruned_by_page_index.load(Ordering::Relaxed),
+            row_groups_processed: self.row_groups_processed.load(Ordering::Relaxed),
+            row_groups_skipped: self.row_groups_skipped.load(Ordering::Relaxed),
+            pages_pruned: self.pages_pruned.load(Ordering::Relaxed),
+            pages_total: self.pages_total.load(Ordering::Relaxed),
+            page_pruning_unavailable: self.page_pruning_unavailable.load(Ordering::Relaxed),
+            ffm_collector_calls: self.ffm_collector_calls.load(Ordering::Relaxed),
+            batches_produced: self.batches_produced.load(Ordering::Relaxed),
+            parquet_batches_received: self.parquet_batches_received.load(Ordering::Relaxed),
+            position_map_identity: self.position_map_identity.load(Ordering::Relaxed),
+            position_map_bitmap: self.position_map_bitmap.load(Ordering::Relaxed),
+            position_map_runs: self.position_map_runs.load(Ordering::Relaxed),
+            min_skip_run_row_granular: self.min_skip_run_row_granular.load(Ordering::Relaxed),
+            min_skip_run_block_granular: self.min_skip_run_block_granular.load(Ordering::Relaxed),
+            prefetch_wait_count: self.prefetch_wait_count.load(Ordering::Relaxed),
+            batches_pre_coalesce: self.batches_pre_coalesce.load(Ordering::Relaxed),
+            elapsed_compute_ms: self.elapsed_compute_ms.load(Ordering::Relaxed),
+            index_time_ms: self.index_time_ms.load(Ordering::Relaxed),
+            parquet_time_ms: self.parquet_time_ms.load(Ordering::Relaxed),
+            prefetch_wait_time_ms: self.prefetch_wait_time_ms.load(Ordering::Relaxed),
+            coalesce_time_ms: self.coalesce_time_ms.load(Ordering::Relaxed),
+            build_mask_time_ms: self.build_mask_time_ms.load(Ordering::Relaxed),
+            filter_record_batch_time_ms: self.filter_record_batch_time_ms.load(Ordering::Relaxed),
+            on_batch_mask_time_ms: self.on_batch_mask_time_ms.load(Ordering::Relaxed),
+            mask_slice_time_ms: self.mask_slice_time_ms.load(Ordering::Relaxed),
+            projection_fixup_time_ms: self.projection_fixup_time_ms.load(Ordering::Relaxed),
+            parquet_poll_time_ms: self.parquet_poll_time_ms.load(Ordering::Relaxed),
+        }
+    }
+}
+
+#[inline]
+fn ns_to_ms(ns: usize) -> i64 {
+    (ns / 1_000_000) as i64
+}
+
+/// Process-global accumulator. Read at FFM stats time, written from the
+/// partition stream's `Drop` impl.
+pub static SEARCH_STATS: Lazy<SearchStatsAccumulator> =
+    Lazy::new(SearchStatsAccumulator::new);
+
+/// Snapshot the global accumulator into the FFM wire format.
+pub fn pack_search_stats() -> SearchStatsRepr {
+    SEARCH_STATS.snapshot()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::indexed_table::metrics::PartitionMetrics;
+    use datafusion::physical_plan::metrics::ExecutionPlanMetricsSet;
+
+    #[test]
+    fn accumulate_empty_stream_metrics_only_bumps_queries_completed() {
+        let acc = SearchStatsAccumulator::new();
+        acc.accumulate(&StreamMetrics::empty());
+        assert_eq!(acc.queries_completed.load(Ordering::Relaxed), 1);
+        assert_eq!(acc.output_rows.load(Ordering::Relaxed), 0);
+        assert_eq!(acc.parquet_time_ms.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn accumulate_reads_count_and_time_values() {
+        let acc = SearchStatsAccumulator::new();
+        let metrics_set = ExecutionPlanMetricsSet::new();
+        let pm = PartitionMetrics::new(&metrics_set, 0);
+
+        pm.output_rows.add(100);
+        pm.rows_matched.add(80);
+        pm.row_groups_processed.add(2);
+        pm.ffm_collector_calls.add(5);
+        pm.parquet_time
+            .add_duration(std::time::Duration::from_millis(250));
+        pm.elapsed_compute
+            .add_duration(std::time::Duration::from_millis(500));
+
+        let stream_metrics = pm.into_stream_metrics(None);
+        acc.accumulate(&stream_metrics);
+
+        assert_eq!(acc.queries_completed.load(Ordering::Relaxed), 1);
+        assert_eq!(acc.output_rows.load(Ordering::Relaxed), 100);
+        assert_eq!(acc.rows_matched.load(Ordering::Relaxed), 80);
+        assert_eq!(acc.row_groups_processed.load(Ordering::Relaxed), 2);
+        assert_eq!(acc.ffm_collector_calls.load(Ordering::Relaxed), 5);
+        assert_eq!(acc.parquet_time_ms.load(Ordering::Relaxed), 250);
+        assert_eq!(acc.elapsed_compute_ms.load(Ordering::Relaxed), 500);
+
+        let pm2 = PartitionMetrics::new(&metrics_set, 1);
+        pm2.output_rows.add(50);
+        let sm2 = pm2.into_stream_metrics(None);
+        acc.accumulate(&sm2);
+        assert_eq!(acc.queries_completed.load(Ordering::Relaxed), 2);
+        assert_eq!(acc.output_rows.load(Ordering::Relaxed), 150);
+    }
+
+    #[test]
+    fn snapshot_returns_repr_with_all_fields() {
+        let acc = SearchStatsAccumulator::new();
+        acc.queries_completed.store(7, Ordering::Relaxed);
+        acc.output_rows.store(1234, Ordering::Relaxed);
+        acc.parquet_time_ms.store(99, Ordering::Relaxed);
+
+        let repr = acc.snapshot();
+        assert_eq!(repr.queries_completed, 7);
+        assert_eq!(repr.output_rows, 1234);
+        assert_eq!(repr.parquet_time_ms, 99);
+        assert_eq!(repr.rows_matched, 0);
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/stats.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/stats.rs
@@ -4,9 +4,9 @@
 
 //! Stats packing helpers for the FFM `df_stats()` function.
 //!
-//! Packs Tokio runtime metrics and per-operation task monitor metrics
-//! into a `#[repr(C)]` `DfStatsBuffer` struct (304 bytes) for efficient
-//! transfer across the FFM boundary.
+//! Packs Tokio runtime metrics, per-operation task monitor metrics, and
+//! cumulative indexed-search metrics into a `#[repr(C)]` `DfStatsBuffer`
+//! struct (544 bytes) for efficient transfer across the FFM boundary.
 //!
 //! ## Struct layout
 //!
@@ -20,6 +20,7 @@
 //! | `plan_setup`         | `TaskMonitorRepr`    | 3 × i64 |
 //! | `datanode_gate`      | `PartitionGateRepr`  | 4 × i64 |
 //! | `coordinator_gate`   | `PartitionGateRepr`  | 4 × i64 |
+//! | `search_stats`       | `SearchStatsRepr`    | 30 × i64 (1 lifecycle + 18 counts + 11 times) |
 
 use tokio::runtime::Handle;
 use tokio_metrics::{RuntimeMonitor, TaskMonitor};
@@ -71,6 +72,77 @@ pub struct PartitionGateRepr {
 }
 
 #[repr(C)]
+pub struct SearchStatsRepr {
+    pub queries_completed: i64,
+    pub output_rows: i64,
+    pub rows_matched: i64,
+    pub rows_pruned_by_page_index: i64,
+    pub row_groups_processed: i64,
+    pub row_groups_skipped: i64,
+    pub pages_pruned: i64,
+    pub pages_total: i64,
+    pub page_pruning_unavailable: i64,
+    pub ffm_collector_calls: i64,
+    pub batches_produced: i64,
+    pub parquet_batches_received: i64,
+    pub position_map_identity: i64,
+    pub position_map_bitmap: i64,
+    pub position_map_runs: i64,
+    pub min_skip_run_row_granular: i64,
+    pub min_skip_run_block_granular: i64,
+    pub prefetch_wait_count: i64,
+    pub batches_pre_coalesce: i64,
+    pub elapsed_compute_ms: i64,
+    pub index_time_ms: i64,
+    pub parquet_time_ms: i64,
+    pub prefetch_wait_time_ms: i64,
+    pub coalesce_time_ms: i64,
+    pub build_mask_time_ms: i64,
+    pub filter_record_batch_time_ms: i64,
+    pub on_batch_mask_time_ms: i64,
+    pub mask_slice_time_ms: i64,
+    pub projection_fixup_time_ms: i64,
+    pub parquet_poll_time_ms: i64,
+}
+
+impl SearchStatsRepr {
+    pub fn zeroed() -> Self {
+        Self {
+            queries_completed: 0,
+            output_rows: 0,
+            rows_matched: 0,
+            rows_pruned_by_page_index: 0,
+            row_groups_processed: 0,
+            row_groups_skipped: 0,
+            pages_pruned: 0,
+            pages_total: 0,
+            page_pruning_unavailable: 0,
+            ffm_collector_calls: 0,
+            batches_produced: 0,
+            parquet_batches_received: 0,
+            position_map_identity: 0,
+            position_map_bitmap: 0,
+            position_map_runs: 0,
+            min_skip_run_row_granular: 0,
+            min_skip_run_block_granular: 0,
+            prefetch_wait_count: 0,
+            batches_pre_coalesce: 0,
+            elapsed_compute_ms: 0,
+            index_time_ms: 0,
+            parquet_time_ms: 0,
+            prefetch_wait_time_ms: 0,
+            coalesce_time_ms: 0,
+            build_mask_time_ms: 0,
+            filter_record_batch_time_ms: 0,
+            on_batch_mask_time_ms: 0,
+            mask_slice_time_ms: 0,
+            projection_fixup_time_ms: 0,
+            parquet_poll_time_ms: 0,
+        }
+    }
+}
+
+#[repr(C)]
 pub struct DfStatsBuffer {
     pub io_runtime: RuntimeMetricsRepr,
     pub cpu_runtime: RuntimeMetricsRepr,
@@ -80,17 +152,19 @@ pub struct DfStatsBuffer {
     pub plan_setup: TaskMonitorRepr,
     pub datanode_gate: PartitionGateRepr,
     pub coordinator_gate: PartitionGateRepr,
+    pub search_stats: SearchStatsRepr,
 }
 
 const _: () = assert!(std::mem::size_of::<RuntimeMetricsRepr>() == 9 * 8);
 const _: () = assert!(std::mem::size_of::<TaskMonitorRepr>() == 3 * 8);
 const _: () = assert!(std::mem::size_of::<PartitionGateRepr>() == 4 * 8);
-const _: () = assert!(std::mem::size_of::<DfStatsBuffer>() == 38 * 8);
+const _: () = assert!(std::mem::size_of::<SearchStatsRepr>() == 30 * 8);
+const _: () = assert!(std::mem::size_of::<DfStatsBuffer>() == 68 * 8);
 
 pub mod layout {
     use super::*;
     pub const BUFFER_BYTE_SIZE: usize = std::mem::size_of::<DfStatsBuffer>();
-    const _: () = assert!(BUFFER_BYTE_SIZE == 304);
+    const _: () = assert!(BUFFER_BYTE_SIZE == 544);
 }
 
 /// Snapshot a `RuntimeMonitor` and return a populated `RuntimeMetricsRepr`.
@@ -255,9 +329,10 @@ mod tests {
             plan_setup: pack_task_monitor(plan_setup_monitor()),
             datanode_gate: pack_partition_gate(mgr.cpu_executor.concurrency_gate()),
             coordinator_gate: pack_partition_gate(mgr.coordinator_gate()),
+            search_stats: SearchStatsRepr::zeroed(),
         };
 
-        assert_eq!(layout::BUFFER_BYTE_SIZE, 304);
+        assert_eq!(layout::BUFFER_BYTE_SIZE, 544);
         assert!(buf.io_runtime.workers_count > 0, "IO runtime workers_count should be > 0, got {}", buf.io_runtime.workers_count);
         assert!(buf.datanode_gate.max_permits > 0, "datanode_gate max_permits should be > 0, got {}", buf.datanode_gate.max_permits);
         assert!(buf.coordinator_gate.max_permits > 0, "coordinator_gate max_permits should be > 0, got {}", buf.coordinator_gate.max_permits);
@@ -273,11 +348,39 @@ mod tests {
     #[test]
     fn test_df_stats_buffer_too_small() {
         // Verify that the buffer size assertion holds
-        assert_eq!(std::mem::size_of::<DfStatsBuffer>(), 304);
-        assert_eq!(layout::BUFFER_BYTE_SIZE, 304);
-        // A buffer smaller than 304 bytes should be rejected by df_stats.
+        assert_eq!(std::mem::size_of::<DfStatsBuffer>(), 544);
+        assert_eq!(layout::BUFFER_BYTE_SIZE, 544);
+        // A buffer smaller than 544 bytes should be rejected by df_stats.
         // We can't call df_stats directly without a runtime manager,
         // but we verify the constant is correct.
         assert!(layout::BUFFER_BYTE_SIZE > 0);
+    }
+
+    #[test]
+    fn test_search_stats_repr_zeroed() {
+        let r = SearchStatsRepr::zeroed();
+        assert_eq!(r.queries_completed, 0);
+        assert_eq!(r.output_rows, 0);
+        assert_eq!(r.parquet_time_ms, 0);
+        assert_eq!(r.parquet_poll_time_ms, 0);
+    }
+
+    #[test]
+    fn test_pack_search_stats_reflects_global_accumulator() {
+        use crate::search_stats::{pack_search_stats, SEARCH_STATS};
+        use std::sync::atomic::Ordering;
+
+        // Static fixture: snapshot before, mutate, snapshot after, compare deltas.
+        // Reset is not exposed (cumulative-only by design); we rely on deltas so
+        // we don't depend on whether other tests ran first.
+        let before = pack_search_stats();
+        SEARCH_STATS.queries_completed.fetch_add(3, Ordering::Relaxed);
+        SEARCH_STATS.output_rows.fetch_add(42, Ordering::Relaxed);
+        SEARCH_STATS.parquet_time_ms.fetch_add(7, Ordering::Relaxed);
+        let after = pack_search_stats();
+
+        assert_eq!(after.queries_completed - before.queries_completed, 3);
+        assert_eq!(after.output_rows - before.output_rows, 42);
+        assert_eq!(after.parquet_time_ms - before.parquet_time_ms, 7);
     }
 }

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/nativelib/NativeBridge.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/nativelib/NativeBridge.java
@@ -875,8 +875,14 @@ public final class NativeBridge {
             // Partition gates
             var datanodeGate = StatsLayout.readPartitionGate(seg, "datanode_gate");
             var coordinatorGate = StatsLayout.readPartitionGate(seg, "coordinator_gate");
+            var searchStats = StatsLayout.readSearchStats(seg);
 
-            return new DataFusionStats(new NativeExecutorsStats(ioRuntime, cpuRuntime, taskMonitors), datanodeGate, coordinatorGate);
+            return new DataFusionStats(
+                new NativeExecutorsStats(ioRuntime, cpuRuntime, taskMonitors),
+                datanodeGate,
+                coordinatorGate,
+                searchStats
+            );
         }
     }
 

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/nativelib/StatsLayout.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/nativelib/StatsLayout.java
@@ -10,6 +10,7 @@ package org.opensearch.be.datafusion.nativelib;
 
 import org.opensearch.be.datafusion.stats.PartitionGateStats;
 import org.opensearch.be.datafusion.stats.RuntimeMetrics;
+import org.opensearch.be.datafusion.stats.SearchStats;
 import org.opensearch.be.datafusion.stats.TaskMonitorStats;
 
 import java.lang.foreign.MemoryLayout;
@@ -23,7 +24,8 @@ import java.lang.invoke.VarHandle;
  * Defines the {@code MemoryLayout.structLayout} mirroring the Rust {@code DfStatsBuffer}
  * and provides {@link VarHandle} accessors for each field via layout path navigation.
  *
- * <p>The layout contains 8 named groups (2 runtime × 9 fields + 4 task monitor × 3 fields + 2 partition gate × 4 fields = 38 longs = 304 bytes).
+ * <p>The layout contains 9 named groups
+ * (2 runtime × 9 + 4 task monitor × 3 + 2 partition gate × 4 + 1 search_stats × 30 = 68 longs = 544 bytes).
  */
 public final class StatsLayout {
 
@@ -49,6 +51,38 @@ public final class StatsLayout {
         "total_wait_duration_ms",
         "total_batches_started" };
 
+    private static final String[] SEARCH_STATS_FIELDS = {
+        "queries_completed",
+        "output_rows",
+        "rows_matched",
+        "rows_pruned_by_page_index",
+        "row_groups_processed",
+        "row_groups_skipped",
+        "pages_pruned",
+        "pages_total",
+        "page_pruning_unavailable",
+        "ffm_collector_calls",
+        "batches_produced",
+        "parquet_batches_received",
+        "position_map_identity",
+        "position_map_bitmap",
+        "position_map_runs",
+        "min_skip_run_row_granular",
+        "min_skip_run_block_granular",
+        "prefetch_wait_count",
+        "batches_pre_coalesce",
+        "elapsed_compute_ms",
+        "index_time_ms",
+        "parquet_time_ms",
+        "prefetch_wait_time_ms",
+        "coalesce_time_ms",
+        "build_mask_time_ms",
+        "filter_record_batch_time_ms",
+        "on_batch_mask_time_ms",
+        "mask_slice_time_ms",
+        "projection_fixup_time_ms",
+        "parquet_poll_time_ms" };
+
     /** The struct layout mirroring Rust's {@code DfStatsBuffer}. */
     public static final StructLayout LAYOUT = MemoryLayout.structLayout(
         runtimeGroup("io_runtime"),
@@ -58,12 +92,13 @@ public final class StatsLayout {
         taskMonitorGroup("stream_next"),
         taskMonitorGroup("plan_setup"),
         partitionGateGroup("datanode_gate"),
-        partitionGateGroup("coordinator_gate")
+        partitionGateGroup("coordinator_gate"),
+        searchStatsGroup("search_stats")
     );
 
     static {
-        if (LAYOUT.byteSize() != 38 * Long.BYTES) {
-            throw new AssertionError("StatsLayout size mismatch: expected " + (38 * Long.BYTES) + " but got " + LAYOUT.byteSize());
+        if (LAYOUT.byteSize() != 68 * Long.BYTES) {
+            throw new AssertionError("StatsLayout size mismatch: expected " + (68 * Long.BYTES) + " but got " + LAYOUT.byteSize());
         }
     }
 
@@ -120,6 +155,17 @@ public final class StatsLayout {
     private static final VarHandle CG_ACTIVE_PERMITS = handle("coordinator_gate", "active_permits");
     private static final VarHandle CG_TOTAL_WAIT_DURATION_MS = handle("coordinator_gate", "total_wait_duration_ms");
     private static final VarHandle CG_TOTAL_BATCHES_STARTED = handle("coordinator_gate", "total_batches_started");
+
+    // ---- VarHandles for search_stats fields ----
+    private static final VarHandle[] SEARCH_STATS_HANDLES = buildSearchStatsHandles();
+
+    private static VarHandle[] buildSearchStatsHandles() {
+        VarHandle[] hs = new VarHandle[SEARCH_STATS_FIELDS.length];
+        for (int i = 0; i < SEARCH_STATS_FIELDS.length; i++) {
+            hs[i] = handle("search_stats", SEARCH_STATS_FIELDS[i]);
+        }
+        return hs;
+    }
 
     private StatsLayout() {}
 
@@ -187,6 +233,27 @@ public final class StatsLayout {
         );
     }
 
+    /**
+     * Read the {@code search_stats} group (30 fields) from the segment.
+     *
+     * @param seg the memory segment containing the DfStatsBuffer
+     * @return a populated {@link SearchStats} instance
+     */
+    public static SearchStats readSearchStats(MemorySegment seg) {
+        long[] v = new long[SEARCH_STATS_HANDLES.length];
+        for (int i = 0; i < SEARCH_STATS_HANDLES.length; i++) {
+            v[i] = (long) SEARCH_STATS_HANDLES[i].get(seg, 0L);
+        }
+        int i = 0;
+        return new SearchStats(
+            v[i++],
+            v[i++], v[i++], v[i++], v[i++], v[i++], v[i++], v[i++], v[i++], v[i++],
+            v[i++], v[i++], v[i++], v[i++], v[i++], v[i++], v[i++], v[i++], v[i++],
+            v[i++], v[i++], v[i++], v[i++], v[i++], v[i++], v[i++], v[i++], v[i++],
+            v[i++], v[i++]
+        );
+    }
+
     // ---- Private helpers ----
 
     private static StructLayout runtimeGroup(String name) {
@@ -218,6 +285,14 @@ public final class StatsLayout {
             ValueLayout.JAVA_LONG.withName("total_wait_duration_ms"),
             ValueLayout.JAVA_LONG.withName("total_batches_started")
         ).withName(name);
+    }
+
+    private static StructLayout searchStatsGroup(String name) {
+        MemoryLayout[] fields = new MemoryLayout[SEARCH_STATS_FIELDS.length];
+        for (int i = 0; i < SEARCH_STATS_FIELDS.length; i++) {
+            fields[i] = ValueLayout.JAVA_LONG.withName(SEARCH_STATS_FIELDS[i]);
+        }
+        return MemoryLayout.structLayout(fields).withName(name);
     }
 
     private static VarHandle handle(String group, String field) {

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/stats/DataFusionStats.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/stats/DataFusionStats.java
@@ -34,6 +34,7 @@ public class DataFusionStats implements Writeable, ToXContentFragment {
     private final NativeExecutorsStats nativeExecutorsStats; // nullable
     private final PartitionGateStats datanodeGateStats; // nullable
     private final PartitionGateStats coordinatorGateStats; // nullable
+    private final SearchStats searchStats; // nullable
 
     /**
      * Construct from components.
@@ -47,9 +48,27 @@ public class DataFusionStats implements Writeable, ToXContentFragment {
         PartitionGateStats datanodeGateStats,
         PartitionGateStats coordinatorGateStats
     ) {
+        this(nativeExecutorsStats, datanodeGateStats, coordinatorGateStats, null);
+    }
+
+    /**
+     * Construct from components, including search stats.
+     *
+     * @param nativeExecutorsStats  the native executor metrics (nullable)
+     * @param datanodeGateStats     the datanode partition gate metrics (nullable)
+     * @param coordinatorGateStats  the coordinator partition gate metrics (nullable)
+     * @param searchStats           cumulative indexed-search metrics (nullable)
+     */
+    public DataFusionStats(
+        NativeExecutorsStats nativeExecutorsStats,
+        PartitionGateStats datanodeGateStats,
+        PartitionGateStats coordinatorGateStats,
+        SearchStats searchStats
+    ) {
         this.nativeExecutorsStats = nativeExecutorsStats;
         this.datanodeGateStats = datanodeGateStats;
         this.coordinatorGateStats = coordinatorGateStats;
+        this.searchStats = searchStats;
     }
 
     /**
@@ -62,6 +81,7 @@ public class DataFusionStats implements Writeable, ToXContentFragment {
         this.nativeExecutorsStats = in.readOptionalWriteable(NativeExecutorsStats::new);
         this.datanodeGateStats = in.readOptionalWriteable(PartitionGateStats::new);
         this.coordinatorGateStats = in.readOptionalWriteable(PartitionGateStats::new);
+        this.searchStats = in.readOptionalWriteable(SearchStats::new);
     }
 
     @Override
@@ -69,6 +89,7 @@ public class DataFusionStats implements Writeable, ToXContentFragment {
         out.writeOptionalWriteable(nativeExecutorsStats);
         out.writeOptionalWriteable(datanodeGateStats);
         out.writeOptionalWriteable(coordinatorGateStats);
+        out.writeOptionalWriteable(searchStats);
     }
 
     @Override
@@ -81,6 +102,9 @@ public class DataFusionStats implements Writeable, ToXContentFragment {
         }
         if (coordinatorGateStats != null) {
             coordinatorGateStats.toXContent(builder, params);
+        }
+        if (searchStats != null) {
+            searchStats.toXContent(builder, params);
         }
         return builder;
     }
@@ -106,6 +130,13 @@ public class DataFusionStats implements Writeable, ToXContentFragment {
         return coordinatorGateStats;
     }
 
+    /**
+     * Returns the cumulative indexed-search metrics, or {@code null} if absent.
+     */
+    public SearchStats getSearchStats() {
+        return searchStats;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -113,11 +144,12 @@ public class DataFusionStats implements Writeable, ToXContentFragment {
         DataFusionStats that = (DataFusionStats) o;
         return Objects.equals(nativeExecutorsStats, that.nativeExecutorsStats)
             && Objects.equals(datanodeGateStats, that.datanodeGateStats)
-            && Objects.equals(coordinatorGateStats, that.coordinatorGateStats);
+            && Objects.equals(coordinatorGateStats, that.coordinatorGateStats)
+            && Objects.equals(searchStats, that.searchStats);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(nativeExecutorsStats, datanodeGateStats, coordinatorGateStats);
+        return Objects.hash(nativeExecutorsStats, datanodeGateStats, coordinatorGateStats, searchStats);
     }
 }

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/stats/SearchStats.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/stats/SearchStats.java
@@ -1,0 +1,301 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion.stats;
+
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.common.io.stream.Writeable;
+import org.opensearch.core.xcontent.ToXContentFragment;
+import org.opensearch.core.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * Cumulative indexed-search execution metrics, accumulated by the native
+ * {@code SEARCH_STATS} static across all partition stream lifetimes since
+ * process start.
+ *
+ * <p>Mirrors Rust's {@code SearchStatsRepr}: one lifecycle counter,
+ * 18 raw counts and 11 elapsed times in milliseconds.
+ */
+public class SearchStats implements Writeable, ToXContentFragment {
+
+    /** Number of partition streams that have completed. */
+    public final long queriesCompleted;
+
+    /** Cumulative rows emitted from {@code IndexedExec::poll_next}. */
+    public final long outputRows;
+    /** Cumulative rows that matched the indexed predicate (pre-residual). */
+    public final long rowsMatched;
+    /** Cumulative rows pruned by parquet page-index pruning. */
+    public final long rowsPrunedByPageIndex;
+    /** Cumulative row groups processed. */
+    public final long rowGroupsProcessed;
+    /** Cumulative row groups skipped via row-group pruning. */
+    public final long rowGroupsSkipped;
+    /** Cumulative parquet pages eliminated by the page-level pruner. */
+    public final long pagesPruned;
+    /** Cumulative parquet pages considered by the page-level pruner. */
+    public final long pagesTotal;
+    /** Cumulative {@code prune_rg} calls that could not apply page-level pruning. */
+    public final long pagePruningUnavailable;
+    /** Cumulative FFM round-trips into the Java backend collector. */
+    public final long ffmCollectorCalls;
+    /** Cumulative output {@code RecordBatch}es produced. */
+    public final long batchesProduced;
+    /** Cumulative input {@code RecordBatch}es received from the parquet stream. */
+    public final long parquetBatchesReceived;
+    /** Cumulative row groups whose {@code PositionMap} was {@code Identity}. */
+    public final long positionMapIdentity;
+    /** Cumulative row groups whose {@code PositionMap} was {@code Bitmap}. */
+    public final long positionMapBitmap;
+    /** Cumulative row groups whose {@code PositionMap} was {@code Runs}. */
+    public final long positionMapRuns;
+    /** Cumulative row groups built with row-granular {@code RowSelection}. */
+    public final long minSkipRunRowGranular;
+    /** Cumulative row groups built with block-granular {@code RowSelection}. */
+    public final long minSkipRunBlockGranular;
+    /** Cumulative {@code Poll::Pending} returns from the prefetch receiver. */
+    public final long prefetchWaitCount;
+    /** Cumulative batches fed into the output coalescer. */
+    public final long batchesPreCoalesce;
+
+    /** Cumulative wall-clock time spent in {@code poll_next}, in milliseconds. */
+    public final long elapsedComputeMs;
+    /** Cumulative time spent inside the index search, in milliseconds. */
+    public final long indexTimeMs;
+    /** Cumulative time spent reading parquet, in milliseconds. */
+    public final long parquetTimeMs;
+    /** Cumulative time the poll thread blocked on prefetch, in milliseconds. */
+    public final long prefetchWaitTimeMs;
+    /** Cumulative time spent in the output coalescer, in milliseconds. */
+    public final long coalesceTimeMs;
+    /** Cumulative time spent in {@code build_mask}, in milliseconds. */
+    public final long buildMaskTimeMs;
+    /** Cumulative time spent in {@code filter_record_batch}, in milliseconds. */
+    public final long filterRecordBatchTimeMs;
+    /** Cumulative time spent in evaluator {@code on_batch_mask}, in milliseconds. */
+    public final long onBatchMaskTimeMs;
+    /** Cumulative time spent slicing and downcasting the current mask, in milliseconds. */
+    public final long maskSliceTimeMs;
+    /** Cumulative time spent in {@code finalize_batch} projection fix-up, in milliseconds. */
+    public final long projectionFixupTimeMs;
+    /** Cumulative time spent polling the inner parquet stream, in milliseconds. */
+    public final long parquetPollTimeMs;
+
+    /**
+     * Construct from explicit field values. Argument order matches the Rust
+     * {@code SearchStatsRepr} layout: lifecycle, then 18 counts, then 11 times.
+     */
+    public SearchStats(
+        long queriesCompleted,
+        long outputRows,
+        long rowsMatched,
+        long rowsPrunedByPageIndex,
+        long rowGroupsProcessed,
+        long rowGroupsSkipped,
+        long pagesPruned,
+        long pagesTotal,
+        long pagePruningUnavailable,
+        long ffmCollectorCalls,
+        long batchesProduced,
+        long parquetBatchesReceived,
+        long positionMapIdentity,
+        long positionMapBitmap,
+        long positionMapRuns,
+        long minSkipRunRowGranular,
+        long minSkipRunBlockGranular,
+        long prefetchWaitCount,
+        long batchesPreCoalesce,
+        long elapsedComputeMs,
+        long indexTimeMs,
+        long parquetTimeMs,
+        long prefetchWaitTimeMs,
+        long coalesceTimeMs,
+        long buildMaskTimeMs,
+        long filterRecordBatchTimeMs,
+        long onBatchMaskTimeMs,
+        long maskSliceTimeMs,
+        long projectionFixupTimeMs,
+        long parquetPollTimeMs
+    ) {
+        this.queriesCompleted = queriesCompleted;
+        this.outputRows = outputRows;
+        this.rowsMatched = rowsMatched;
+        this.rowsPrunedByPageIndex = rowsPrunedByPageIndex;
+        this.rowGroupsProcessed = rowGroupsProcessed;
+        this.rowGroupsSkipped = rowGroupsSkipped;
+        this.pagesPruned = pagesPruned;
+        this.pagesTotal = pagesTotal;
+        this.pagePruningUnavailable = pagePruningUnavailable;
+        this.ffmCollectorCalls = ffmCollectorCalls;
+        this.batchesProduced = batchesProduced;
+        this.parquetBatchesReceived = parquetBatchesReceived;
+        this.positionMapIdentity = positionMapIdentity;
+        this.positionMapBitmap = positionMapBitmap;
+        this.positionMapRuns = positionMapRuns;
+        this.minSkipRunRowGranular = minSkipRunRowGranular;
+        this.minSkipRunBlockGranular = minSkipRunBlockGranular;
+        this.prefetchWaitCount = prefetchWaitCount;
+        this.batchesPreCoalesce = batchesPreCoalesce;
+        this.elapsedComputeMs = elapsedComputeMs;
+        this.indexTimeMs = indexTimeMs;
+        this.parquetTimeMs = parquetTimeMs;
+        this.prefetchWaitTimeMs = prefetchWaitTimeMs;
+        this.coalesceTimeMs = coalesceTimeMs;
+        this.buildMaskTimeMs = buildMaskTimeMs;
+        this.filterRecordBatchTimeMs = filterRecordBatchTimeMs;
+        this.onBatchMaskTimeMs = onBatchMaskTimeMs;
+        this.maskSliceTimeMs = maskSliceTimeMs;
+        this.projectionFixupTimeMs = projectionFixupTimeMs;
+        this.parquetPollTimeMs = parquetPollTimeMs;
+    }
+
+    /**
+     * Deserialize from stream.
+     *
+     * @param in the stream input
+     * @throws IOException if deserialization fails
+     */
+    public SearchStats(StreamInput in) throws IOException {
+        this(
+            in.readVLong(),
+            in.readVLong(), in.readVLong(), in.readVLong(), in.readVLong(), in.readVLong(),
+            in.readVLong(), in.readVLong(), in.readVLong(), in.readVLong(), in.readVLong(),
+            in.readVLong(), in.readVLong(), in.readVLong(), in.readVLong(), in.readVLong(),
+            in.readVLong(), in.readVLong(), in.readVLong(),
+            in.readVLong(), in.readVLong(), in.readVLong(), in.readVLong(), in.readVLong(),
+            in.readVLong(), in.readVLong(), in.readVLong(), in.readVLong(), in.readVLong(),
+            in.readVLong()
+        );
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeVLong(queriesCompleted);
+        out.writeVLong(outputRows);
+        out.writeVLong(rowsMatched);
+        out.writeVLong(rowsPrunedByPageIndex);
+        out.writeVLong(rowGroupsProcessed);
+        out.writeVLong(rowGroupsSkipped);
+        out.writeVLong(pagesPruned);
+        out.writeVLong(pagesTotal);
+        out.writeVLong(pagePruningUnavailable);
+        out.writeVLong(ffmCollectorCalls);
+        out.writeVLong(batchesProduced);
+        out.writeVLong(parquetBatchesReceived);
+        out.writeVLong(positionMapIdentity);
+        out.writeVLong(positionMapBitmap);
+        out.writeVLong(positionMapRuns);
+        out.writeVLong(minSkipRunRowGranular);
+        out.writeVLong(minSkipRunBlockGranular);
+        out.writeVLong(prefetchWaitCount);
+        out.writeVLong(batchesPreCoalesce);
+        out.writeVLong(elapsedComputeMs);
+        out.writeVLong(indexTimeMs);
+        out.writeVLong(parquetTimeMs);
+        out.writeVLong(prefetchWaitTimeMs);
+        out.writeVLong(coalesceTimeMs);
+        out.writeVLong(buildMaskTimeMs);
+        out.writeVLong(filterRecordBatchTimeMs);
+        out.writeVLong(onBatchMaskTimeMs);
+        out.writeVLong(maskSliceTimeMs);
+        out.writeVLong(projectionFixupTimeMs);
+        out.writeVLong(parquetPollTimeMs);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject("search_stats");
+        builder.field("queries_completed", queriesCompleted);
+        builder.field("output_rows", outputRows);
+        builder.field("rows_matched", rowsMatched);
+        builder.field("rows_pruned_by_page_index", rowsPrunedByPageIndex);
+        builder.field("row_groups_processed", rowGroupsProcessed);
+        builder.field("row_groups_skipped", rowGroupsSkipped);
+        builder.field("pages_pruned", pagesPruned);
+        builder.field("pages_total", pagesTotal);
+        builder.field("page_pruning_unavailable", pagePruningUnavailable);
+        builder.field("ffm_collector_calls", ffmCollectorCalls);
+        builder.field("batches_produced", batchesProduced);
+        builder.field("parquet_batches_received", parquetBatchesReceived);
+        builder.field("position_map_identity", positionMapIdentity);
+        builder.field("position_map_bitmap", positionMapBitmap);
+        builder.field("position_map_runs", positionMapRuns);
+        builder.field("min_skip_run_row_granular", minSkipRunRowGranular);
+        builder.field("min_skip_run_block_granular", minSkipRunBlockGranular);
+        builder.field("prefetch_wait_count", prefetchWaitCount);
+        builder.field("batches_pre_coalesce", batchesPreCoalesce);
+        builder.field("elapsed_compute_ms", elapsedComputeMs);
+        builder.field("index_time_ms", indexTimeMs);
+        builder.field("parquet_time_ms", parquetTimeMs);
+        builder.field("prefetch_wait_time_ms", prefetchWaitTimeMs);
+        builder.field("coalesce_time_ms", coalesceTimeMs);
+        builder.field("build_mask_time_ms", buildMaskTimeMs);
+        builder.field("filter_record_batch_time_ms", filterRecordBatchTimeMs);
+        builder.field("on_batch_mask_time_ms", onBatchMaskTimeMs);
+        builder.field("mask_slice_time_ms", maskSliceTimeMs);
+        builder.field("projection_fixup_time_ms", projectionFixupTimeMs);
+        builder.field("parquet_poll_time_ms", parquetPollTimeMs);
+        builder.endObject();
+        return builder;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SearchStats that = (SearchStats) o;
+        return queriesCompleted == that.queriesCompleted
+            && outputRows == that.outputRows
+            && rowsMatched == that.rowsMatched
+            && rowsPrunedByPageIndex == that.rowsPrunedByPageIndex
+            && rowGroupsProcessed == that.rowGroupsProcessed
+            && rowGroupsSkipped == that.rowGroupsSkipped
+            && pagesPruned == that.pagesPruned
+            && pagesTotal == that.pagesTotal
+            && pagePruningUnavailable == that.pagePruningUnavailable
+            && ffmCollectorCalls == that.ffmCollectorCalls
+            && batchesProduced == that.batchesProduced
+            && parquetBatchesReceived == that.parquetBatchesReceived
+            && positionMapIdentity == that.positionMapIdentity
+            && positionMapBitmap == that.positionMapBitmap
+            && positionMapRuns == that.positionMapRuns
+            && minSkipRunRowGranular == that.minSkipRunRowGranular
+            && minSkipRunBlockGranular == that.minSkipRunBlockGranular
+            && prefetchWaitCount == that.prefetchWaitCount
+            && batchesPreCoalesce == that.batchesPreCoalesce
+            && elapsedComputeMs == that.elapsedComputeMs
+            && indexTimeMs == that.indexTimeMs
+            && parquetTimeMs == that.parquetTimeMs
+            && prefetchWaitTimeMs == that.prefetchWaitTimeMs
+            && coalesceTimeMs == that.coalesceTimeMs
+            && buildMaskTimeMs == that.buildMaskTimeMs
+            && filterRecordBatchTimeMs == that.filterRecordBatchTimeMs
+            && onBatchMaskTimeMs == that.onBatchMaskTimeMs
+            && maskSliceTimeMs == that.maskSliceTimeMs
+            && projectionFixupTimeMs == that.projectionFixupTimeMs
+            && parquetPollTimeMs == that.parquetPollTimeMs;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+            queriesCompleted,
+            outputRows, rowsMatched, rowsPrunedByPageIndex, rowGroupsProcessed, rowGroupsSkipped,
+            pagesPruned, pagesTotal, pagePruningUnavailable, ffmCollectorCalls, batchesProduced,
+            parquetBatchesReceived, positionMapIdentity, positionMapBitmap, positionMapRuns,
+            minSkipRunRowGranular, minSkipRunBlockGranular, prefetchWaitCount, batchesPreCoalesce,
+            elapsedComputeMs, indexTimeMs, parquetTimeMs, prefetchWaitTimeMs, coalesceTimeMs,
+            buildMaskTimeMs, filterRecordBatchTimeMs, onBatchMaskTimeMs, maskSliceTimeMs,
+            projectionFixupTimeMs, parquetPollTimeMs
+        );
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/src/propertyTest/java/org/opensearch/be/datafusion/nativelib/StatsLayoutPropertyTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/propertyTest/java/org/opensearch/be/datafusion/nativelib/StatsLayoutPropertyTests.java
@@ -45,7 +45,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
  */
 public class StatsLayoutPropertyTests {
 
-    private static final int FIELD_COUNT = 38;
+    private static final int FIELD_COUNT = 68;
     private static final int BUFFER_SIZE = FIELD_COUNT * Long.BYTES;
 
     // ---- Generators ----
@@ -236,6 +236,9 @@ public class StatsLayoutPropertyTests {
             var qe = StatsLayout.readTaskMonitor(original, "query_execution");
             var sn = StatsLayout.readTaskMonitor(original, "stream_next");
             var ps = StatsLayout.readTaskMonitor(original, "plan_setup");
+            var dg = StatsLayout.readPartitionGate(original, "datanode_gate");
+            var cg = StatsLayout.readPartitionGate(original, "coordinator_gate");
+            var ss = StatsLayout.readSearchStats(original);
 
             // Re-encode into new buffer
             var reencoded = arena.allocate(StatsLayout.LAYOUT);
@@ -269,7 +272,45 @@ public class StatsLayoutPropertyTests {
                 sn.totalIdleDurationMs,
                 ps.totalPollDurationMs,
                 ps.totalScheduledDurationMs,
-                ps.totalIdleDurationMs };
+                ps.totalIdleDurationMs,
+                dg.maxPermits,
+                dg.activePermits,
+                dg.totalWaitDurationMs,
+                dg.totalBatchesStarted,
+                cg.maxPermits,
+                cg.activePermits,
+                cg.totalWaitDurationMs,
+                cg.totalBatchesStarted,
+                ss.queriesCompleted,
+                ss.outputRows,
+                ss.rowsMatched,
+                ss.rowsPrunedByPageIndex,
+                ss.rowGroupsProcessed,
+                ss.rowGroupsSkipped,
+                ss.pagesPruned,
+                ss.pagesTotal,
+                ss.pagePruningUnavailable,
+                ss.ffmCollectorCalls,
+                ss.batchesProduced,
+                ss.parquetBatchesReceived,
+                ss.positionMapIdentity,
+                ss.positionMapBitmap,
+                ss.positionMapRuns,
+                ss.minSkipRunRowGranular,
+                ss.minSkipRunBlockGranular,
+                ss.prefetchWaitCount,
+                ss.batchesPreCoalesce,
+                ss.elapsedComputeMs,
+                ss.indexTimeMs,
+                ss.parquetTimeMs,
+                ss.prefetchWaitTimeMs,
+                ss.coalesceTimeMs,
+                ss.buildMaskTimeMs,
+                ss.filterRecordBatchTimeMs,
+                ss.onBatchMaskTimeMs,
+                ss.maskSliceTimeMs,
+                ss.projectionFixupTimeMs,
+                ss.parquetPollTimeMs };
             for (int i = 0; i < FIELD_COUNT; i++) {
                 reencoded.setAtIndex(ValueLayout.JAVA_LONG, i, decoded[i]);
             }

--- a/sandbox/plugins/analytics-backend-datafusion/src/propertyTest/java/org/opensearch/be/datafusion/stats/DataFusionStatsPropertyTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/propertyTest/java/org/opensearch/be/datafusion/stats/DataFusionStatsPropertyTests.java
@@ -134,6 +134,31 @@ public class DataFusionStatsPropertyTests {
         return Arbitraries.just(new DataFusionStats(null, null, null));
     }
 
+    @Provide
+    Arbitrary<SearchStats> searchStatsArbitrary() {
+        Arbitrary<Long> nonNeg = Arbitraries.longs().between(0, Long.MAX_VALUE / 2);
+        return nonNeg.array(Long[].class).ofSize(30).map(arr -> new SearchStats(
+            arr[0],
+            arr[1], arr[2], arr[3], arr[4], arr[5], arr[6], arr[7], arr[8], arr[9],
+            arr[10], arr[11], arr[12], arr[13], arr[14], arr[15], arr[16], arr[17], arr[18],
+            arr[19], arr[20], arr[21], arr[22], arr[23], arr[24], arr[25], arr[26], arr[27],
+            arr[28], arr[29]
+        ));
+    }
+
+    /** DataFusionStats including search stats. */
+    @Provide
+    Arbitrary<DataFusionStats> dataFusionStatsWithSearchStats() {
+        return Combinators.combine(dataFusionStatsCpuPresent(), searchStatsArbitrary()).as((stats, search) ->
+            new DataFusionStats(
+                stats.getNativeExecutorsStats(),
+                stats.getDatanodeGateStats(),
+                stats.getCoordinatorGateStats(),
+                search
+            )
+        );
+    }
+
     // ---- Property 1: Writeable round-trip preserves all field values ----
 
     /**
@@ -268,6 +293,25 @@ public class DataFusionStatsPropertyTests {
         byte[] first = renderJsonBytes(stats);
         byte[] second = renderJsonBytes(stats);
         assertTrue(Arrays.equals(first, second), "toXContent must produce byte-for-byte identical JSON on repeated calls (null executors)");
+    }
+
+    /**
+     * Feature: stats-spi-refactor, Property: DataFusionStats Writeable round-trip with search stats.
+     */
+    @Property(tries = 100)
+    void writeableRoundTripWithSearchStats(@ForAll("dataFusionStatsWithSearchStats") DataFusionStats original) throws IOException {
+        DataFusionStats deserialized = writeableRoundTrip(original);
+        assertNotNull(deserialized.getSearchStats());
+        assertEquals(original, deserialized, "Writeable round-trip must preserve search stats");
+    }
+
+    /**
+     * Feature: stats-spi-refactor, Property: DataFusionStats JSON contains search_stats key.
+     */
+    @Property(tries = 50)
+    void jsonContainsSearchStatsKey(@ForAll("dataFusionStatsWithSearchStats") DataFusionStats stats) throws IOException {
+        String json = renderJson(stats);
+        assertTrue(json.contains("\"search_stats\""), "JSON must contain search_stats key when present");
     }
 
     /** Renders a {@link DataFusionStats} to JSON bytes via {@code toXContent}. */

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/nativelib/StatsLayoutTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/nativelib/StatsLayoutTests.java
@@ -20,10 +20,10 @@ import java.lang.foreign.ValueLayout;
  */
 public class StatsLayoutTests extends OpenSearchTestCase {
 
-    /** 7.1: Layout byte size must be 304 (38 × 8). */
+    /** 7.1: Layout byte size must be 544 (68 × 8). */
     public void testLayoutByteSize() {
-        assertEquals(304L, StatsLayout.LAYOUT.byteSize());
-        assertEquals(38 * Long.BYTES, (int) StatsLayout.LAYOUT.byteSize());
+        assertEquals(544L, StatsLayout.LAYOUT.byteSize());
+        assertEquals(68 * Long.BYTES, (int) StatsLayout.LAYOUT.byteSize());
     }
 
     /** 7.2: readRuntimeMetrics decodes 9 known values from io_runtime group. */

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/stats/DataFusionStatsTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/stats/DataFusionStatsTests.java
@@ -225,4 +225,36 @@ public class DataFusionStatsTests extends OpenSearchTestCase {
         assertTrue(monitors.containsKey("stream_next"));
         assertTrue(monitors.containsKey("plan_setup"));
     }
+
+    // ---- Test: search_stats integrates into composition ----
+
+    public void testSearchStatsAbsentWhenNull() throws IOException {
+        DataFusionStats stats = sequentialStats();
+        assertNull(stats.getSearchStats());
+        String json = toJsonString(stats);
+        assertFalse("search_stats should not appear when null", json.contains("\"search_stats\""));
+    }
+
+    public void testSearchStatsPresentWhenNonNull() throws IOException {
+        SearchStats search = new SearchStats(
+            7,
+            100, 80, 0, 5, 10, 0, 0, 0, 5,
+            5, 5, 0, 5, 0, 5, 0, 0, 5,
+            500, 50, 250, 0, 10, 5, 5, 5, 5,
+            5, 200
+        );
+        DataFusionStats stats = new DataFusionStats(
+            sequentialStats().getNativeExecutorsStats(),
+            sequentialStats().getDatanodeGateStats(),
+            sequentialStats().getCoordinatorGateStats(),
+            search
+        );
+        assertSame(search, stats.getSearchStats());
+
+        String json = toJsonString(stats);
+        assertTrue(json.contains("\"search_stats\""));
+        assertTrue(json.contains("\"queries_completed\":7"));
+        assertTrue(json.contains("\"output_rows\":100"));
+        assertTrue(json.contains("\"parquet_time_ms\":250"));
+    }
 }

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/stats/SearchStatsTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/stats/SearchStatsTests.java
@@ -1,0 +1,154 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion.stats;
+
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+
+/**
+ * Unit tests for {@link SearchStats}.
+ *
+ * <p>Covers transport serialization round-trip, JSON rendering shape, and
+ * equality semantics.
+ */
+public class SearchStatsTests extends OpenSearchTestCase {
+
+    /** Build a SearchStats with sequential values 1..30 for deterministic field verification. */
+    private static SearchStats sequentialStats() {
+        return new SearchStats(
+            1,
+            2, 3, 4, 5, 6, 7, 8, 9, 10,
+            11, 12, 13, 14, 15, 16, 17, 18, 19,
+            20, 21, 22, 23, 24, 25, 26, 27, 28,
+            29, 30
+        );
+    }
+
+    public void testFieldsArePopulated() {
+        SearchStats s = sequentialStats();
+        assertEquals(1L, s.queriesCompleted);
+        assertEquals(2L, s.outputRows);
+        assertEquals(3L, s.rowsMatched);
+        assertEquals(4L, s.rowsPrunedByPageIndex);
+        assertEquals(5L, s.rowGroupsProcessed);
+        assertEquals(6L, s.rowGroupsSkipped);
+        assertEquals(10L, s.ffmCollectorCalls);
+        assertEquals(20L, s.elapsedComputeMs);
+        assertEquals(22L, s.parquetTimeMs);
+        assertEquals(30L, s.parquetPollTimeMs);
+    }
+
+    public void testWriteableRoundTrip() throws IOException {
+        SearchStats original = sequentialStats();
+        BytesStreamOutput out = new BytesStreamOutput();
+        original.writeTo(out);
+        StreamInput in = out.bytes().streamInput();
+        SearchStats decoded = new SearchStats(in);
+        assertEquals(original, decoded);
+    }
+
+    public void testToXContentShape() throws IOException {
+        SearchStats s = sequentialStats();
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        builder.startObject();
+        s.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        builder.endObject();
+        String json = builder.toString();
+
+        assertTrue(json.contains("\"search_stats\""));
+        assertTrue(json.contains("\"queries_completed\":1"));
+        assertTrue(json.contains("\"output_rows\":2"));
+        assertTrue(json.contains("\"rows_matched\":3"));
+        assertTrue(json.contains("\"row_groups_processed\":5"));
+        assertTrue(json.contains("\"ffm_collector_calls\":10"));
+        assertTrue(json.contains("\"elapsed_compute_ms\":20"));
+        assertTrue(json.contains("\"parquet_time_ms\":22"));
+        assertTrue(json.contains("\"parquet_poll_time_ms\":30"));
+    }
+
+    public void testToXContentRendersAllThirtyFields() throws IOException {
+        SearchStats s = sequentialStats();
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        builder.startObject();
+        s.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        builder.endObject();
+        String json = builder.toString();
+
+        String[] keys = {
+            "queries_completed",
+            "output_rows",
+            "rows_matched",
+            "rows_pruned_by_page_index",
+            "row_groups_processed",
+            "row_groups_skipped",
+            "pages_pruned",
+            "pages_total",
+            "page_pruning_unavailable",
+            "ffm_collector_calls",
+            "batches_produced",
+            "parquet_batches_received",
+            "position_map_identity",
+            "position_map_bitmap",
+            "position_map_runs",
+            "min_skip_run_row_granular",
+            "min_skip_run_block_granular",
+            "prefetch_wait_count",
+            "batches_pre_coalesce",
+            "elapsed_compute_ms",
+            "index_time_ms",
+            "parquet_time_ms",
+            "prefetch_wait_time_ms",
+            "coalesce_time_ms",
+            "build_mask_time_ms",
+            "filter_record_batch_time_ms",
+            "on_batch_mask_time_ms",
+            "mask_slice_time_ms",
+            "projection_fixup_time_ms",
+            "parquet_poll_time_ms" };
+        for (String k : keys) {
+            assertTrue("expected JSON to contain field: " + k, json.contains("\"" + k + "\""));
+        }
+    }
+
+    public void testEqualsAndHashCode() {
+        SearchStats a = sequentialStats();
+        SearchStats b = sequentialStats();
+        SearchStats c = new SearchStats(
+            999,
+            2, 3, 4, 5, 6, 7, 8, 9, 10,
+            11, 12, 13, 14, 15, 16, 17, 18, 19,
+            20, 21, 22, 23, 24, 25, 26, 27, 28,
+            29, 30
+        );
+
+        assertEquals(a, b);
+        assertEquals(a.hashCode(), b.hashCode());
+        assertNotEquals(a, c);
+    }
+
+    public void testZeroValuesRoundTrip() throws IOException {
+        SearchStats zero = new SearchStats(
+            0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0
+        );
+        BytesStreamOutput out = new BytesStreamOutput();
+        zero.writeTo(out);
+        SearchStats decoded = new SearchStats(out.bytes().streamInput());
+        assertEquals(zero, decoded);
+    }
+}


### PR DESCRIPTION
### Description

Adds `search_stats` to `GET _plugins/analytics_backend_datafusion/stats` for the indexed-path search executor.

```json
"search_stats": {
  "queries_completed": 42,
  "output_rows": 1234567,
  "rows_matched": 890123,
  "rows_pruned_by_page_index": 344444,
  "row_groups_processed": 4200,
  "row_groups_skipped": 800,
  "pages_pruned": 12000,
  "pages_total": 50000,
  "page_pruning_unavailable": 5,
  "ffm_collector_calls": 4200,
  "batches_produced": 420,
  "parquet_batches_received": 4200,
  "position_map_identity": 100,
  "position_map_bitmap": 3500,
  "position_map_runs": 600,
  "min_skip_run_row_granular": 3500,
  "min_skip_run_block_granular": 600,
  "prefetch_wait_count": 200,
  "batches_pre_coalesce": 4200,
  "elapsed_compute_ms": 5000,
  "index_time_ms": 1500,
  "parquet_time_ms": 3200,
  "prefetch_wait_time_ms": 200,
  "coalesce_time_ms": 50,
  "build_mask_time_ms": 100,
  "filter_record_batch_time_ms": 300,
  "on_batch_mask_time_ms": 80,
  "mask_slice_time_ms": 20,
  "projection_fixup_time_ms": 10,
  "parquet_poll_time_ms": 2800
}
```

All values are cumulative since node start. `queries_completed == 0` means no indexed-path queries have run yet.

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
