### PR TITLE
Add slow log support for analytics engine indexing and search paths

### DIFF
--- a/sandbox/libs/analytics-api/src/main/java/org/opensearch/analytics/QueryRequestContext.java
+++ b/sandbox/libs/analytics-api/src/main/java/org/opensearch/analytics/QueryRequestContext.java
@@ -24,5 +24,9 @@ import org.opensearch.cluster.ClusterState;
  *
  * @opensearch.internal
  */
-public record QueryRequestContext(ClusterState clusterState, SchemaPlus schema) {
+public record QueryRequestContext(ClusterState clusterState, SchemaPlus schema, String querySource) {
+
+    public QueryRequestContext(ClusterState clusterState, SchemaPlus schema) {
+        this(clusterState, schema, null);
+    }
 }

--- a/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/backend/AnalyticsOperationListener.java
+++ b/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/backend/AnalyticsOperationListener.java
@@ -140,6 +140,7 @@ public interface AnalyticsOperationListener {
      * @param tookInNanos wall-clock time for the fragment execution
      * @param rowsProduced number of rows produced by this fragment
      * @param indexSettings the index settings for per-index slow log threshold lookup
+     * @param stats quantitative execution stats (rows scanned, bytes read, etc.)
      */
     default void onFragmentSuccess(
         String queryId,
@@ -147,7 +148,8 @@ public interface AnalyticsOperationListener {
         String shardId,
         long tookInNanos,
         long rowsProduced,
-        IndexSettings indexSettings
+        IndexSettings indexSettings,
+        FragmentExecutionStats stats
     ) {}
 
     /**
@@ -291,11 +293,12 @@ public interface AnalyticsOperationListener {
             String shardId,
             long tookInNanos,
             long rowsProduced,
-            IndexSettings indexSettings
+            IndexSettings indexSettings,
+            FragmentExecutionStats stats
         ) {
             for (AnalyticsOperationListener l : delegates) {
                 try {
-                    l.onFragmentSuccess(queryId, stageId, shardId, tookInNanos, rowsProduced, indexSettings);
+                    l.onFragmentSuccess(queryId, stageId, shardId, tookInNanos, rowsProduced, indexSettings, stats);
                 } catch (Exception e) {
                     warn("onFragmentSuccess", e);
                 }

--- a/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/backend/AnalyticsOperationListener.java
+++ b/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/backend/AnalyticsOperationListener.java
@@ -10,6 +10,7 @@ package org.opensearch.analytics.backend;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.opensearch.index.IndexSettings;
 
 import java.util.List;
 
@@ -60,6 +61,26 @@ public interface AnalyticsOperationListener {
      */
     default void onQueryFailure(String queryId, Exception cause) {}
 
+    /**
+     * Called when query planning completes on the coordinator (Calcite CBO, DAG build,
+     * fragment conversion). Fired before execution stages begin.
+     *
+     * @param queryId the unique query identifier
+     * @param tookInNanos wall-clock time for the planning phase
+     */
+    default void onPlanningComplete(String queryId, long tookInNanos) {}
+
+    /**
+     * Called when the entire query request completes, including result materialization.
+     * This is the terminal event for the full request lifecycle — analogous to
+     * {@code SearchRequestOperationsListener.onRequestEnd()} in the default search path.
+     *
+     * @param queryId the unique query identifier
+     * @param totalTookInNanos wall-clock time from query submission to completion (includes planning + execution + materialization)
+     * @param totalRows total rows in the materialized result set
+     */
+    default void onQueryComplete(String queryId, long totalTookInNanos, long totalRows) {}
+
     // ─── Coordinator-side: stage lifecycle ──────────────────────────────
 
     /**
@@ -79,7 +100,7 @@ public interface AnalyticsOperationListener {
      * @param tookInNanos wall-clock time from stage start to completion
      * @param rowsProcessed number of rows processed by this stage
      */
-    default void onStageSuccess(String queryId, int stageId, long tookInNanos, long rowsProcessed) {}
+    default void onStageSuccess(String queryId, int stageId, String stageType, long tookInNanos, long rowsProcessed) {}
 
     /**
      * Called when a stage transitions to FAILED.
@@ -118,8 +139,16 @@ public interface AnalyticsOperationListener {
      * @param shardId the shard that was queried
      * @param tookInNanos wall-clock time for the fragment execution
      * @param rowsProduced number of rows produced by this fragment
+     * @param indexSettings the index settings for per-index slow log threshold lookup
      */
-    default void onFragmentSuccess(String queryId, int stageId, String shardId, long tookInNanos, long rowsProduced) {}
+    default void onFragmentSuccess(
+        String queryId,
+        int stageId,
+        String shardId,
+        long tookInNanos,
+        long rowsProduced,
+        IndexSettings indexSettings
+    ) {}
 
     /**
      * Called when a plan fragment fails on a data node.
@@ -152,6 +181,28 @@ public interface AnalyticsOperationListener {
                     l.onQueryStart(queryId, stageCount);
                 } catch (Exception e) {
                     warn("onQueryStart", e);
+                }
+            }
+        }
+
+        @Override
+        public void onPlanningComplete(String queryId, long tookInNanos) {
+            for (AnalyticsOperationListener l : delegates) {
+                try {
+                    l.onPlanningComplete(queryId, tookInNanos);
+                } catch (Exception e) {
+                    warn("onPlanningComplete", e);
+                }
+            }
+        }
+
+        @Override
+        public void onQueryComplete(String queryId, long totalTookInNanos, long totalRows) {
+            for (AnalyticsOperationListener l : delegates) {
+                try {
+                    l.onQueryComplete(queryId, totalTookInNanos, totalRows);
+                } catch (Exception e) {
+                    warn("onQueryComplete", e);
                 }
             }
         }
@@ -190,10 +241,10 @@ public interface AnalyticsOperationListener {
         }
 
         @Override
-        public void onStageSuccess(String queryId, int stageId, long tookInNanos, long rowsProcessed) {
+        public void onStageSuccess(String queryId, int stageId, String stageType, long tookInNanos, long rowsProcessed) {
             for (AnalyticsOperationListener l : delegates) {
                 try {
-                    l.onStageSuccess(queryId, stageId, tookInNanos, rowsProcessed);
+                    l.onStageSuccess(queryId, stageId, stageType, tookInNanos, rowsProcessed);
                 } catch (Exception e) {
                     warn("onStageSuccess", e);
                 }
@@ -234,10 +285,17 @@ public interface AnalyticsOperationListener {
         }
 
         @Override
-        public void onFragmentSuccess(String queryId, int stageId, String shardId, long tookInNanos, long rowsProduced) {
+        public void onFragmentSuccess(
+            String queryId,
+            int stageId,
+            String shardId,
+            long tookInNanos,
+            long rowsProduced,
+            IndexSettings indexSettings
+        ) {
             for (AnalyticsOperationListener l : delegates) {
                 try {
-                    l.onFragmentSuccess(queryId, stageId, shardId, tookInNanos, rowsProduced);
+                    l.onFragmentSuccess(queryId, stageId, shardId, tookInNanos, rowsProduced, indexSettings);
                 } catch (Exception e) {
                     warn("onFragmentSuccess", e);
                 }

--- a/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/backend/AnalyticsOperationListener.java
+++ b/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/backend/AnalyticsOperationListener.java
@@ -138,16 +138,14 @@ public interface AnalyticsOperationListener {
      * @param stageId the stage this fragment belongs to
      * @param shardId the shard that was queried
      * @param tookInNanos wall-clock time for the fragment execution
-     * @param rowsProduced number of rows produced by this fragment
      * @param indexSettings the index settings for per-index slow log threshold lookup
-     * @param stats quantitative execution stats (rows scanned, bytes read, etc.)
+     * @param stats execution stats including rows produced, delegation info, and task headers
      */
     default void onFragmentSuccess(
         String queryId,
         int stageId,
         String shardId,
         long tookInNanos,
-        long rowsProduced,
         IndexSettings indexSettings,
         FragmentExecutionStats stats
     ) {}
@@ -292,13 +290,12 @@ public interface AnalyticsOperationListener {
             int stageId,
             String shardId,
             long tookInNanos,
-            long rowsProduced,
             IndexSettings indexSettings,
             FragmentExecutionStats stats
         ) {
             for (AnalyticsOperationListener l : delegates) {
                 try {
-                    l.onFragmentSuccess(queryId, stageId, shardId, tookInNanos, rowsProduced, indexSettings, stats);
+                    l.onFragmentSuccess(queryId, stageId, shardId, tookInNanos, indexSettings, stats);
                 } catch (Exception e) {
                     warn("onFragmentSuccess", e);
                 }

--- a/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/backend/FragmentExecutionStats.java
+++ b/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/backend/FragmentExecutionStats.java
@@ -22,15 +22,8 @@ package org.opensearch.analytics.backend;
  *
  * @opensearch.internal
  */
-public record FragmentExecutionStats(
-    long rowsProduced,
-    boolean usedSecondaryIndex,
-    int delegatedPredicateCount,
-    String filterTreeShape,
-    boolean hasPartialAggregate,
-    long taskId,
-    String opaqueId
-) {
+public record FragmentExecutionStats(long rowsProduced, boolean usedSecondaryIndex, int delegatedPredicateCount, String filterTreeShape,
+    boolean hasPartialAggregate, long taskId, String opaqueId) {
 
     public static final FragmentExecutionStats EMPTY = new FragmentExecutionStats(0, false, 0, null, false, -1, null);
 }

--- a/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/backend/FragmentExecutionStats.java
+++ b/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/backend/FragmentExecutionStats.java
@@ -1,0 +1,36 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.backend;
+
+/**
+ * Execution stats for a completed fragment, carried alongside the slow log
+ * callback to provide insight into the work performed.
+ *
+ * @param rowsProduced             rows returned by this fragment
+ * @param usedSecondaryIndex       whether a secondary/inverted index was consulted for filtering
+ * @param delegatedPredicateCount  number of predicates delegated to the secondary index (0 if none)
+ * @param filterTreeShape          boolean tree shape for delegation (null if no delegation)
+ * @param hasPartialAggregate      whether this fragment performs partial aggregation
+ * @param taskId                   the task ID for correlation with _tasks API
+ * @param opaqueId                 the X-Opaque-Id header for correlation with the client request (nullable)
+ *
+ * @opensearch.internal
+ */
+public record FragmentExecutionStats(
+    long rowsProduced,
+    boolean usedSecondaryIndex,
+    int delegatedPredicateCount,
+    String filterTreeShape,
+    boolean hasPartialAggregate,
+    long taskId,
+    String opaqueId
+) {
+
+    public static final FragmentExecutionStats EMPTY = new FragmentExecutionStats(0, false, 0, null, false, -1, null);
+}

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/AnalyticsPlugin.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/AnalyticsPlugin.java
@@ -15,7 +15,9 @@ import org.apache.calcite.sql.util.SqlOperatorTables;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.action.ActionRequest;
+import org.opensearch.analytics.exec.AnalyticsFragmentSlowLog;
 import org.opensearch.analytics.exec.AnalyticsSearchService;
+import org.opensearch.analytics.exec.AnalyticsSearchSlowLog;
 import org.opensearch.analytics.exec.CoordinatorAllocatorHandle;
 import org.opensearch.analytics.exec.DefaultPlanExecutor;
 import org.opensearch.analytics.exec.QueryPlanExecutor;
@@ -110,6 +112,8 @@ public class AnalyticsPlugin extends Plugin implements ExtensiblePlugin, ActionP
 
     private final List<AnalyticsSearchBackendPlugin> backEnds = new ArrayList<>();
     private AnalyticsSearchService searchService;
+    private AnalyticsSearchSlowLog analyticsSearchSlowLog;
+    private AnalyticsFragmentSlowLog analyticsFragmentSlowLog;
     private CoordinatorAllocatorHandle coordinatorAllocatorHandle;
     private ReaderContextStore readerContextStore;
     private final AnalyticsStatsCollector statsCollector = new AnalyticsStatsCollector();
@@ -147,7 +151,15 @@ public class AnalyticsPlugin extends Plugin implements ExtensiblePlugin, ActionP
         readerContextStore = new ReaderContextStore(threadPool);
         clusterService.getClusterSettings()
             .addSettingsUpdateConsumer(ReaderContextStore.READER_CONTEXT_KEEP_ALIVE, readerContextStore::setKeepAlive);
-        searchService = new AnalyticsSearchService(backEndsByName, nativeAllocator, namedWriteableRegistry, readerContextStore);
+        analyticsSearchSlowLog = new AnalyticsSearchSlowLog(clusterService);
+        analyticsFragmentSlowLog = new AnalyticsFragmentSlowLog();
+        searchService = new AnalyticsSearchService(
+            backEndsByName,
+            List.of(analyticsFragmentSlowLog),
+            nativeAllocator,
+            namedWriteableRegistry,
+            readerContextStore
+        );
         DefaultEngineContextProvider ctx = new DefaultEngineContextProvider(clusterService, indexNameExpressionResolver, backEndsByName);
         // Build the coordinator allocator under POOL_QUERY here, in the plugin, so that the
         // plugin's lifecycle owns its lifetime. The Guice-bound DefaultPlanExecutor consumes
@@ -157,7 +169,7 @@ public class AnalyticsPlugin extends Plugin implements ExtensiblePlugin, ActionP
             nativeAllocator.getPoolAllocator(NativeAllocatorPoolConfig.POOL_QUERY).newChildAllocator("coordinator", 0, Long.MAX_VALUE)
         );
 
-        return List.of(searchService, ctx, capabilityRegistry, coordinatorAllocatorHandle, statsCollector);
+        return List.of(searchService, ctx, capabilityRegistry, coordinatorAllocatorHandle, analyticsSearchSlowLog, statsCollector);
     }
 
     @Override

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/AnalyticsFragmentSlowLog.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/AnalyticsFragmentSlowLog.java
@@ -1,0 +1,81 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.exec;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.analytics.backend.AnalyticsOperationListener;
+import org.opensearch.common.logging.Loggers;
+import org.opensearch.common.logging.SlowLogLevel;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.index.IndexSettings;
+import org.opensearch.index.SearchSlowLog;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Data-node-level slow log for analytics engine fragment executions.
+ * Reads per-index thresholds from {@link IndexSettings} passed at call time,
+ * mirroring how {@link SearchSlowLog} uses per-index settings for shard-level
+ * query timing in the standard search path.
+ */
+public class AnalyticsFragmentSlowLog implements AnalyticsOperationListener {
+
+    private final Logger logger;
+
+    public static final String LOGGER_NAME = "index.search.slowlog";
+
+    public AnalyticsFragmentSlowLog() {
+        this.logger = LogManager.getLogger(LOGGER_NAME);
+        Loggers.setLevel(logger, SlowLogLevel.TRACE.name());
+    }
+
+    @Override
+    public void onFragmentSuccess(
+        String queryId,
+        int stageId,
+        String shardId,
+        long tookInNanos,
+        long rowsProduced,
+        IndexSettings indexSettings
+    ) {
+        long warnThreshold = indexSettings.getValue(SearchSlowLog.INDEX_SEARCH_SLOWLOG_THRESHOLD_QUERY_WARN_SETTING).nanos();
+        long infoThreshold = indexSettings.getValue(SearchSlowLog.INDEX_SEARCH_SLOWLOG_THRESHOLD_QUERY_INFO_SETTING).nanos();
+        long debugThreshold = indexSettings.getValue(SearchSlowLog.INDEX_SEARCH_SLOWLOG_THRESHOLD_QUERY_DEBUG_SETTING).nanos();
+        long traceThreshold = indexSettings.getValue(SearchSlowLog.INDEX_SEARCH_SLOWLOG_THRESHOLD_QUERY_TRACE_SETTING).nanos();
+        SlowLogLevel level = indexSettings.getValue(SearchSlowLog.INDEX_SEARCH_SLOWLOG_LEVEL);
+
+        String message = formatMessage(queryId, stageId, shardId, tookInNanos, rowsProduced);
+        if (warnThreshold >= 0 && tookInNanos > warnThreshold && level.isLevelEnabledFor(SlowLogLevel.WARN)) {
+            logger.warn(message);
+        } else if (infoThreshold >= 0 && tookInNanos > infoThreshold && level.isLevelEnabledFor(SlowLogLevel.INFO)) {
+            logger.info(message);
+        } else if (debugThreshold >= 0 && tookInNanos > debugThreshold && level.isLevelEnabledFor(SlowLogLevel.DEBUG)) {
+            logger.debug(message);
+        } else if (traceThreshold >= 0 && tookInNanos > traceThreshold && level.isLevelEnabledFor(SlowLogLevel.TRACE)) {
+            logger.trace(message);
+        }
+    }
+
+    private static String formatMessage(String queryId, int stageId, String shardId, long tookInNanos, long rowsProduced) {
+        return "took["
+            + TimeValue.timeValueNanos(tookInNanos)
+            + "], took_millis["
+            + TimeUnit.NANOSECONDS.toMillis(tookInNanos)
+            + "], query_id["
+            + queryId
+            + "], stage_id["
+            + stageId
+            + "], shard["
+            + shardId
+            + "], rows_produced["
+            + rowsProduced
+            + "]";
+    }
+}

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/AnalyticsFragmentSlowLog.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/AnalyticsFragmentSlowLog.java
@@ -11,6 +11,7 @@ package org.opensearch.analytics.exec;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.analytics.backend.AnalyticsOperationListener;
+import org.opensearch.analytics.backend.FragmentExecutionStats;
 import org.opensearch.common.logging.Loggers;
 import org.opensearch.common.logging.SlowLogLevel;
 import org.opensearch.common.unit.TimeValue;
@@ -43,7 +44,8 @@ public class AnalyticsFragmentSlowLog implements AnalyticsOperationListener {
         String shardId,
         long tookInNanos,
         long rowsProduced,
-        IndexSettings indexSettings
+        IndexSettings indexSettings,
+        FragmentExecutionStats stats
     ) {
         long warnThreshold = indexSettings.getValue(SearchSlowLog.INDEX_SEARCH_SLOWLOG_THRESHOLD_QUERY_WARN_SETTING).nanos();
         long infoThreshold = indexSettings.getValue(SearchSlowLog.INDEX_SEARCH_SLOWLOG_THRESHOLD_QUERY_INFO_SETTING).nanos();
@@ -51,7 +53,7 @@ public class AnalyticsFragmentSlowLog implements AnalyticsOperationListener {
         long traceThreshold = indexSettings.getValue(SearchSlowLog.INDEX_SEARCH_SLOWLOG_THRESHOLD_QUERY_TRACE_SETTING).nanos();
         SlowLogLevel level = indexSettings.getValue(SearchSlowLog.INDEX_SEARCH_SLOWLOG_LEVEL);
 
-        String message = formatMessage(queryId, stageId, shardId, tookInNanos, rowsProduced);
+        String message = formatMessage(queryId, stageId, shardId, tookInNanos, rowsProduced, stats);
         if (warnThreshold >= 0 && tookInNanos > warnThreshold && level.isLevelEnabledFor(SlowLogLevel.WARN)) {
             logger.warn(message);
         } else if (infoThreshold >= 0 && tookInNanos > infoThreshold && level.isLevelEnabledFor(SlowLogLevel.INFO)) {
@@ -63,19 +65,30 @@ public class AnalyticsFragmentSlowLog implements AnalyticsOperationListener {
         }
     }
 
-    private static String formatMessage(String queryId, int stageId, String shardId, long tookInNanos, long rowsProduced) {
-        return "took["
-            + TimeValue.timeValueNanos(tookInNanos)
-            + "], took_millis["
-            + TimeUnit.NANOSECONDS.toMillis(tookInNanos)
-            + "], query_id["
-            + queryId
-            + "], stage_id["
-            + stageId
-            + "], shard["
-            + shardId
-            + "], rows_produced["
-            + rowsProduced
-            + "]";
+    private static String formatMessage(
+        String queryId,
+        int stageId,
+        String shardId,
+        long tookInNanos,
+        long rowsProduced,
+        FragmentExecutionStats stats
+    ) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("took[").append(TimeValue.timeValueNanos(tookInNanos));
+        sb.append("], took_millis[").append(TimeUnit.NANOSECONDS.toMillis(tookInNanos));
+        sb.append("], query_id[").append(queryId);
+        sb.append("], stage_id[").append(stageId);
+        sb.append("], shard[").append(shardId);
+        sb.append("], rows_produced[").append(rowsProduced);
+        sb.append("], used_secondary_index[").append(stats.usedSecondaryIndex());
+        if (stats.usedSecondaryIndex()) {
+            sb.append("], delegated_predicates[").append(stats.delegatedPredicateCount());
+            sb.append("], filter_tree_shape[").append(stats.filterTreeShape());
+        }
+        sb.append("], partial_aggregate[").append(stats.hasPartialAggregate());
+        sb.append("], task_id[").append(stats.taskId());
+        sb.append("], id[").append(stats.opaqueId() != null ? stats.opaqueId() : "");
+        sb.append("]");
+        return sb.toString();
     }
 }

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/AnalyticsFragmentSlowLog.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/AnalyticsFragmentSlowLog.java
@@ -43,7 +43,6 @@ public class AnalyticsFragmentSlowLog implements AnalyticsOperationListener {
         int stageId,
         String shardId,
         long tookInNanos,
-        long rowsProduced,
         IndexSettings indexSettings,
         FragmentExecutionStats stats
     ) {
@@ -53,7 +52,7 @@ public class AnalyticsFragmentSlowLog implements AnalyticsOperationListener {
         long traceThreshold = indexSettings.getValue(SearchSlowLog.INDEX_SEARCH_SLOWLOG_THRESHOLD_QUERY_TRACE_SETTING).nanos();
         SlowLogLevel level = indexSettings.getValue(SearchSlowLog.INDEX_SEARCH_SLOWLOG_LEVEL);
 
-        String message = formatMessage(queryId, stageId, shardId, tookInNanos, rowsProduced, stats);
+        String message = formatMessage(queryId, stageId, shardId, tookInNanos, stats);
         if (warnThreshold >= 0 && tookInNanos > warnThreshold && level.isLevelEnabledFor(SlowLogLevel.WARN)) {
             logger.warn(message);
         } else if (infoThreshold >= 0 && tookInNanos > infoThreshold && level.isLevelEnabledFor(SlowLogLevel.INFO)) {
@@ -65,21 +64,14 @@ public class AnalyticsFragmentSlowLog implements AnalyticsOperationListener {
         }
     }
 
-    private static String formatMessage(
-        String queryId,
-        int stageId,
-        String shardId,
-        long tookInNanos,
-        long rowsProduced,
-        FragmentExecutionStats stats
-    ) {
+    private static String formatMessage(String queryId, int stageId, String shardId, long tookInNanos, FragmentExecutionStats stats) {
         StringBuilder sb = new StringBuilder();
         sb.append("took[").append(TimeValue.timeValueNanos(tookInNanos));
         sb.append("], took_millis[").append(TimeUnit.NANOSECONDS.toMillis(tookInNanos));
         sb.append("], query_id[").append(queryId);
         sb.append("], stage_id[").append(stageId);
         sb.append("], shard[").append(shardId);
-        sb.append("], rows_produced[").append(rowsProduced);
+        sb.append("], rows_produced[").append(stats.rowsProduced());
         sb.append("], used_secondary_index[").append(stats.usedSecondaryIndex());
         if (stats.usedSecondaryIndex()) {
             sb.append("], delegated_predicates[").append(stats.delegatedPredicateCount());

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/AnalyticsSearchService.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/AnalyticsSearchService.java
@@ -149,12 +149,25 @@ public class AnalyticsSearchService implements AutoCloseable {
         try {
             executor.execute(() -> {
                 LOGGER.debug("[FragmentExecution] shard={} task={}", shard.shardId(), task.getId());
+                final long startNanos = System.nanoTime();
+                long rowsProduced = 0;
                 try (FragmentResources ctx = executeFragmentStreaming(request, shard, task)) {
                     Iterator<EngineResultBatch> it = ctx.stream().iterator();
                     while (it.hasNext()) {
-                        responseHandler.onBatch(it.next());
+                        EngineResultBatch batch = it.next();
+                        rowsProduced += batch.getRowCount();
+                        responseHandler.onBatch(batch);
                     }
+                    long fragmentTookNanos = System.nanoTime() - startNanos;
                     responseHandler.onComplete();
+                    listener.onFragmentSuccess(
+                        request.getQueryId(),
+                        request.getStageId(),
+                        shard.shardId().toString(),
+                        fragmentTookNanos,
+                        rowsProduced,
+                        shard.indexSettings()
+                    );
                 } catch (Exception e) {
                     responseHandler.onFailure(e);
                 }

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/AnalyticsSearchService.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/AnalyticsSearchService.java
@@ -15,6 +15,7 @@ import org.apache.logging.log4j.Logger;
 import org.opensearch.analytics.backend.AnalyticsOperationListener;
 import org.opensearch.analytics.backend.EngineResultBatch;
 import org.opensearch.analytics.backend.EngineResultStream;
+import org.opensearch.analytics.backend.FragmentExecutionStats;
 import org.opensearch.analytics.backend.SearchExecEngine;
 import org.opensearch.analytics.backend.ShardScanExecutionContext;
 import org.opensearch.analytics.exec.action.FetchByRowIdsRequest;
@@ -123,15 +124,31 @@ public class AnalyticsSearchService implements AutoCloseable {
     }
 
     public FragmentResources executeFragmentStreaming(FragmentExecutionRequest request, IndexShard shard, AnalyticsShardTask task) {
+        return executeFragmentStreamingResolved(request, shard, task).resources;
+    }
+
+    private ResolvedExecution executeFragmentStreamingResolved(
+        FragmentExecutionRequest request,
+        IndexShard shard,
+        AnalyticsShardTask task
+    ) {
         ResolvedFragment resolved = resolveFragment(request, shard);
         try {
-            return startFragment(request, resolved, shard, task);
+            FragmentResources resources = startFragment(request, resolved, shard, task);
+            return new ResolvedExecution(resources, resolved);
         } catch (TaskCancelledException | IllegalStateException | IllegalArgumentException e) {
             listener.onFragmentFailure(resolved.queryId, resolved.stageId, resolved.shardIdStr, e);
             throw e;
         } catch (Exception e) {
             listener.onFragmentFailure(resolved.queryId, resolved.stageId, resolved.shardIdStr, e);
             throw new RuntimeException("Failed to start streaming fragment on " + shard.shardId(), e);
+        }
+    }
+
+    private record ResolvedExecution(FragmentResources resources, ResolvedFragment resolved) implements AutoCloseable {
+        @Override
+        public void close() throws Exception {
+            resources.close();
         }
     }
 
@@ -151,8 +168,8 @@ public class AnalyticsSearchService implements AutoCloseable {
                 LOGGER.debug("[FragmentExecution] shard={} task={}", shard.shardId(), task.getId());
                 final long startNanos = System.nanoTime();
                 long rowsProduced = 0;
-                try (FragmentResources ctx = executeFragmentStreaming(request, shard, task)) {
-                    Iterator<EngineResultBatch> it = ctx.stream().iterator();
+                try (ResolvedExecution exec = executeFragmentStreamingResolved(request, shard, task)) {
+                    Iterator<EngineResultBatch> it = exec.resources().stream().iterator();
                     while (it.hasNext()) {
                         EngineResultBatch batch = it.next();
                         rowsProduced += batch.getRowCount();
@@ -160,13 +177,30 @@ public class AnalyticsSearchService implements AutoCloseable {
                     }
                     long fragmentTookNanos = System.nanoTime() - startNanos;
                     responseHandler.onComplete();
+                    ResolvedFragment resolved = exec.resolved();
+                    DelegationDescriptor delegation = resolved.plan().getDelegationDescriptor();
+                    boolean usedSecondaryIndex = delegation != null;
+                    int delegatedPredicateCount = delegation != null ? delegation.delegatedPredicateCount() : 0;
+                    String filterTreeShape = delegation != null ? delegation.treeShape().name() : null;
+                    boolean hasPartialAggregate = resolved.plan().getInstructions().stream()
+                        .anyMatch(n -> n.type() == org.opensearch.analytics.spi.InstructionType.SETUP_PARTIAL_AGGREGATE);
+                    FragmentExecutionStats stats = new FragmentExecutionStats(
+                        rowsProduced,
+                        usedSecondaryIndex,
+                        delegatedPredicateCount,
+                        filterTreeShape,
+                        hasPartialAggregate,
+                        task.getId(),
+                        task.getHeader(Task.X_OPAQUE_ID)
+                    );
                     listener.onFragmentSuccess(
                         request.getQueryId(),
                         request.getStageId(),
                         shard.shardId().toString(),
                         fragmentTookNanos,
                         rowsProduced,
-                        shard.indexSettings()
+                        shard.indexSettings(),
+                        stats
                     );
                 } catch (Exception e) {
                     responseHandler.onFailure(e);

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/AnalyticsSearchService.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/AnalyticsSearchService.java
@@ -182,7 +182,9 @@ public class AnalyticsSearchService implements AutoCloseable {
                     boolean usedSecondaryIndex = delegation != null;
                     int delegatedPredicateCount = delegation != null ? delegation.delegatedPredicateCount() : 0;
                     String filterTreeShape = delegation != null ? delegation.treeShape().name() : null;
-                    boolean hasPartialAggregate = resolved.plan().getInstructions().stream()
+                    boolean hasPartialAggregate = resolved.plan()
+                        .getInstructions()
+                        .stream()
                         .anyMatch(n -> n.type() == org.opensearch.analytics.spi.InstructionType.SETUP_PARTIAL_AGGREGATE);
                     FragmentExecutionStats stats = new FragmentExecutionStats(
                         rowsProduced,
@@ -198,7 +200,6 @@ public class AnalyticsSearchService implements AutoCloseable {
                         request.getStageId(),
                         shard.shardId().toString(),
                         fragmentTookNanos,
-                        rowsProduced,
                         shard.indexSettings(),
                         stats
                     );

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/AnalyticsSearchSlowLog.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/AnalyticsSearchSlowLog.java
@@ -1,0 +1,156 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.exec;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.action.search.SearchRequestSlowLog;
+import org.opensearch.analytics.backend.AnalyticsOperationListener;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.logging.Loggers;
+import org.opensearch.common.logging.SlowLogLevel;
+import org.opensearch.common.unit.TimeValue;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Coordinator-level slow log for analytics engine queries. Logs at {@code onQueryComplete}
+ * — the terminal event fired after planning, execution, and materialization are all done.
+ *
+ * <p>Reuses the existing {@code cluster.search.request.slowlog.*} settings so operators
+ * have a single configuration surface for both standard and analytics search paths.
+ *
+ * <p>{@link #createQueryListener(String)} creates a per-query listener that observes the
+ * full query lifecycle — planning, stage execution, and completion — accumulating timing
+ * data and emitting the slow log entry at {@code onQueryComplete}.
+ */
+public class AnalyticsSearchSlowLog implements AnalyticsOperationListener {
+
+    private volatile long warnThreshold;
+    private volatile long infoThreshold;
+    private volatile long debugThreshold;
+    private volatile long traceThreshold;
+    private volatile SlowLogLevel level;
+
+    private final Logger queryLogger;
+
+    public static final String QUERY_LOGGER_NAME = "cluster.search.request.slowlog";
+
+    public AnalyticsSearchSlowLog(ClusterService clusterService) {
+        this.queryLogger = LogManager.getLogger(QUERY_LOGGER_NAME);
+        Loggers.setLevel(queryLogger, SlowLogLevel.TRACE.name());
+
+        this.warnThreshold = clusterService.getClusterSettings()
+            .get(SearchRequestSlowLog.CLUSTER_SEARCH_REQUEST_SLOWLOG_THRESHOLD_WARN_SETTING)
+            .nanos();
+        this.infoThreshold = clusterService.getClusterSettings()
+            .get(SearchRequestSlowLog.CLUSTER_SEARCH_REQUEST_SLOWLOG_THRESHOLD_INFO_SETTING)
+            .nanos();
+        this.debugThreshold = clusterService.getClusterSettings()
+            .get(SearchRequestSlowLog.CLUSTER_SEARCH_REQUEST_SLOWLOG_THRESHOLD_DEBUG_SETTING)
+            .nanos();
+        this.traceThreshold = clusterService.getClusterSettings()
+            .get(SearchRequestSlowLog.CLUSTER_SEARCH_REQUEST_SLOWLOG_THRESHOLD_TRACE_SETTING)
+            .nanos();
+        this.level = clusterService.getClusterSettings().get(SearchRequestSlowLog.CLUSTER_SEARCH_REQUEST_SLOWLOG_LEVEL);
+
+        clusterService.getClusterSettings()
+            .addSettingsUpdateConsumer(
+                SearchRequestSlowLog.CLUSTER_SEARCH_REQUEST_SLOWLOG_THRESHOLD_WARN_SETTING,
+                t -> warnThreshold = t.nanos()
+            );
+        clusterService.getClusterSettings()
+            .addSettingsUpdateConsumer(
+                SearchRequestSlowLog.CLUSTER_SEARCH_REQUEST_SLOWLOG_THRESHOLD_INFO_SETTING,
+                t -> infoThreshold = t.nanos()
+            );
+        clusterService.getClusterSettings()
+            .addSettingsUpdateConsumer(
+                SearchRequestSlowLog.CLUSTER_SEARCH_REQUEST_SLOWLOG_THRESHOLD_DEBUG_SETTING,
+                t -> debugThreshold = t.nanos()
+            );
+        clusterService.getClusterSettings()
+            .addSettingsUpdateConsumer(
+                SearchRequestSlowLog.CLUSTER_SEARCH_REQUEST_SLOWLOG_THRESHOLD_TRACE_SETTING,
+                t -> traceThreshold = t.nanos()
+            );
+        clusterService.getClusterSettings().addSettingsUpdateConsumer(SearchRequestSlowLog.CLUSTER_SEARCH_REQUEST_SLOWLOG_LEVEL, l -> {
+            this.level = l;
+            Loggers.setLevel(queryLogger, l.name());
+        });
+    }
+
+    /**
+     * Creates a per-query listener that observes the full query lifecycle. Must be created
+     * before planning starts so it can capture planning time, stage timing, and emit the
+     * slow log at query completion. Task headers are set later via {@link QuerySlowLogListener#setHeaders}.
+     */
+    public QuerySlowLogListener createQueryListener(String querySource) {
+        return new QuerySlowLogListener(querySource);
+    }
+
+    private void logAtLevel(String message, long tookInNanos) {
+        if (warnThreshold >= 0 && tookInNanos > warnThreshold && level.isLevelEnabledFor(SlowLogLevel.WARN)) {
+            queryLogger.warn(message);
+        } else if (infoThreshold >= 0 && tookInNanos > infoThreshold && level.isLevelEnabledFor(SlowLogLevel.INFO)) {
+            queryLogger.info(message);
+        } else if (debugThreshold >= 0 && tookInNanos > debugThreshold && level.isLevelEnabledFor(SlowLogLevel.DEBUG)) {
+            queryLogger.debug(message);
+        } else if (traceThreshold >= 0 && tookInNanos > traceThreshold && level.isLevelEnabledFor(SlowLogLevel.TRACE)) {
+            queryLogger.trace(message);
+        }
+    }
+
+    /**
+     * Per-query listener that accumulates planning time, stage timing, and task headers,
+     * then emits the complete slow log entry at {@code onQueryComplete}.
+     */
+    class QuerySlowLogListener implements AnalyticsOperationListener {
+        private final String querySource;
+        private volatile String opaqueId;
+        private volatile String requestId;
+        private long planningTimeMs;
+        private final StringBuilder stageTook = new StringBuilder();
+
+        QuerySlowLogListener(String querySource) {
+            this.querySource = querySource;
+        }
+
+        void setHeaders(String opaqueId, String requestId) {
+            this.opaqueId = opaqueId;
+            this.requestId = requestId;
+        }
+
+        @Override
+        public void onPlanningComplete(String queryId, long tookInNanos) {
+            this.planningTimeMs = TimeUnit.NANOSECONDS.toMillis(tookInNanos);
+        }
+
+        @Override
+        public void onStageSuccess(String queryId, int stageId, String stageType, long tookInNanos, long rowsProcessed) {
+            if (stageTook.length() > 0) stageTook.append(", ");
+            stageTook.append(stageType).append("=").append(TimeUnit.NANOSECONDS.toMillis(tookInNanos));
+        }
+
+        @Override
+        public void onQueryComplete(String queryId, long totalTookInNanos, long totalRows) {
+            StringBuilder sb = new StringBuilder();
+            sb.append("took[").append(TimeValue.timeValueNanos(totalTookInNanos)).append("], ");
+            sb.append("took_millis[").append(TimeUnit.NANOSECONDS.toMillis(totalTookInNanos)).append("], ");
+            sb.append("planning_time_millis[").append(planningTimeMs).append("], ");
+            sb.append("stage_took_millis[{").append(stageTook).append("}], ");
+            sb.append("query_id[").append(queryId).append("], ");
+            sb.append("total_rows[").append(totalRows).append("], ");
+            sb.append("source[").append(querySource != null ? querySource : "").append("], ");
+            sb.append("id[").append(opaqueId != null ? opaqueId : "").append("], ");
+            sb.append("request_id[").append(requestId != null ? requestId : "").append("]");
+            logAtLevel(sb.toString(), totalTookInNanos);
+        }
+    }
+}

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/DefaultPlanExecutor.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/DefaultPlanExecutor.java
@@ -90,6 +90,7 @@ public class DefaultPlanExecutor extends HandledTransportAction<AnalyticsQueryRe
     private final BufferAllocator coordinatorAllocator;
     private volatile long perQueryBufferLimit;
     private final IndexNameExpressionResolver indexNameExpressionResolver;
+    private final AnalyticsSearchSlowLog analyticsSearchSlowLog;
 
     @Inject
     public DefaultPlanExecutor(
@@ -103,6 +104,7 @@ public class DefaultPlanExecutor extends HandledTransportAction<AnalyticsQueryRe
         Scheduler scheduler,
         CoordinatorAllocatorHandle coordinatorAllocatorHandle,
         IndexNameExpressionResolver indexNameExpressionResolver,
+        AnalyticsSearchSlowLog analyticsSearchSlowLog,
         AnalyticsStatsCollector statsCollector
     ) {
         super(AnalyticsQueryAction.NAME, transportService, actionFilters, AnalyticsQueryRequest::new);
@@ -125,6 +127,7 @@ public class DefaultPlanExecutor extends HandledTransportAction<AnalyticsQueryRe
         clusterService.getClusterSettings()
             .addSettingsUpdateConsumer(AnalyticsPlugin.COORDINATOR_BUFFER_LIMIT, v -> perQueryBufferLimit = v);
         this.indexNameExpressionResolver = indexNameExpressionResolver;
+        this.analyticsSearchSlowLog = analyticsSearchSlowLog;
     }
 
     @Override
@@ -175,6 +178,11 @@ public class DefaultPlanExecutor extends HandledTransportAction<AnalyticsQueryRe
         RelMetadataQueryBase.THREAD_PROVIDERS.set(JaninoRelMetadataProvider.of(logicalFragment.getCluster().getMetadataProvider()));
         logicalFragment.getCluster().invalidateMetadataQuery();
 
+        // Create the slow log wrapper at the start so it observes the full query lifecycle.
+        final String querySource = queryCtx != null ? queryCtx.querySource() : null;
+        final AnalyticsSearchSlowLog.QuerySlowLogListener queryListener = analyticsSearchSlowLog.createQueryListener(querySource);
+        final long queryStartNanos = System.nanoTime();
+
         // Always time planning and capture the full plan: every query produces a QueryProfile
         // that's fed into AnalyticsStatsCollector for the _plugins/_analytics/stats endpoint.
         // The non-explain path drops the profile from the response after recording it; the
@@ -194,13 +202,17 @@ public class DefaultPlanExecutor extends HandledTransportAction<AnalyticsQueryRe
         PlanForker.forkAll(dag, capabilityRegistry);
         BackendPlanAdapter.adaptAll(dag, capabilityRegistry);
         FragmentConversionDriver.convertAll(dag, capabilityRegistry);
-        final long planningTimeMs = java.util.concurrent.TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - planStartNanos);
+        final long planningTimeNanos = System.nanoTime() - planStartNanos;
+        final long planningTimeMs = java.util.concurrent.TimeUnit.NANOSECONDS.toMillis(planningTimeNanos);
         logger.debug("[DefaultPlanExecutor] QueryDAG:\n{}", dag);
+
+        queryListener.onPlanningComplete(dag.queryId(), planningTimeNanos);
 
         // The task is the framework-provided task from doExecute (registered by
         // HandledTransportAction before doExecute, unregistered when the listener completes).
         // Using it — rather than self-registering a detached task — is what lets a client
         // disconnect / explicit task cancel propagate into the running query.
+        queryListener.setHeaders(queryTask.getHeader(Task.X_OPAQUE_ID), queryTask.getHeader(Task.X_REQUEST_ID));
         final BufferAllocator queryAllocator;
         final boolean ownsAllocator;
         if (perQueryBufferLimit <= 0) {
@@ -218,14 +230,17 @@ public class DefaultPlanExecutor extends HandledTransportAction<AnalyticsQueryRe
             ownsAllocator = true;
         }
         logger.debug("[query-{}] Arrow allocator created, limit={}B", dag.queryId(), perQueryBufferLimit);
+
+        // ─── Build query context ──────────────────────────────────────────
         final QueryContext context;
         try {
-            context = new QueryContext(dag, threadPool, queryTask, queryAllocator, ownsAllocator);
+            context = new QueryContext(dag, threadPool, queryTask, queryAllocator, ownsAllocator, List.of(queryListener));
         } catch (Exception e) {
             if (ownsAllocator) queryAllocator.close();
             throw e;
         }
 
+        // ─── Execution + materialization ──────────────────────────────────
         /*
         Profile and explain are captured within the QueryExecution, however QueryExecution requires the complete
         batchesListener to construct the ExecutionGraph. To get around this circular dependency we build a profiling
@@ -250,10 +265,12 @@ public class DefaultPlanExecutor extends HandledTransportAction<AnalyticsQueryRe
         // No taskManager.unregister here: the framework (HandledTransportAction) unregisters the
         // task it created for doExecute once this listener settles. Unregistering it ourselves
         // would double-free a task we no longer own.
-        ActionListener<Iterable<VectorSchemaRoot>> batchesListener = ActionListener.wrap(
-            batches -> rowsListener.onResponse(batchesToRows(batches, outputColumnOrder)),
-            rowsListener::onFailure
-        );
+        ActionListener<Iterable<VectorSchemaRoot>> batchesListener = ActionListener.wrap(batches -> {
+            Iterable<Object[]> rows = batchesToRows(batches, outputColumnOrder);
+            long totalRows = rows instanceof List ? ((List<?>) rows).size() : 0;
+            queryListener.onQueryComplete(dag.queryId(), System.nanoTime() - queryStartNanos, totalRows);
+            rowsListener.onResponse(rows);
+        }, rowsListener::onFailure);
 
         TimeValue taskTimeout = queryTask.getCancelAfterTimeInterval();
         TimeValue clusterTimeout = clusterService.getClusterSettings().get(SEARCH_CANCEL_AFTER_TIME_INTERVAL_SETTING);

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/QueryContext.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/QueryContext.java
@@ -71,6 +71,17 @@ public class QueryContext {
         this(dag, threadPool, parentTask, DEFAULT_MAX_CONCURRENT_SHARD_REQUESTS, List.of(), allocator, ownsAllocator);
     }
 
+    public QueryContext(
+        QueryDAG dag,
+        ThreadPool threadPool,
+        AnalyticsQueryTask parentTask,
+        BufferAllocator allocator,
+        boolean ownsAllocator,
+        List<AnalyticsOperationListener> operationListeners
+    ) {
+        this(dag, threadPool, parentTask, DEFAULT_MAX_CONCURRENT_SHARD_REQUESTS, operationListeners, allocator, ownsAllocator);
+    }
+
     /** Full-parameter constructor. Private; tests use {@link #forTest} factories. */
     private QueryContext(
         QueryDAG dag,

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stage/AbstractStageExecution.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stage/AbstractStageExecution.java
@@ -251,6 +251,7 @@ public abstract class AbstractStageExecution implements StageExecution {
                 l -> l.onStageSuccess(
                     queryId,
                     sid,
+                    stageType,
                     metrics.getEndTimeMs() > 0 && metrics.getStartTimeMs() > 0
                         ? (metrics.getEndTimeMs() - metrics.getStartTimeMs()) * 1_000_000L
                         : 0,

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/AnalyticsFragmentSlowLogTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/AnalyticsFragmentSlowLogTests.java
@@ -12,6 +12,7 @@ import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.Version;
+import org.opensearch.analytics.backend.FragmentExecutionStats;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.logging.Loggers;
 import org.opensearch.common.settings.Settings;
@@ -52,7 +53,8 @@ public class AnalyticsFragmentSlowLogTests extends OpenSearchTestCase {
                 )
             );
 
-            fragmentSlowLog.onFragmentSuccess("q1", 0, "test-shard", TimeValue.timeValueMillis(5).nanos(), 42, indexSettings);
+            fragmentSlowLog.onFragmentSuccess("q1", 0, "test-shard", TimeValue.timeValueMillis(5).nanos(), 42, indexSettings,
+                new FragmentExecutionStats(42, true, 2, "CONJUNCTIVE", false, 99, "opaque-1"));
             appender.assertAllExpectationsMatched();
         }
     }
@@ -74,7 +76,8 @@ public class AnalyticsFragmentSlowLogTests extends OpenSearchTestCase {
                 )
             );
 
-            fragmentSlowLog.onFragmentSuccess("q1", 0, "test-shard", TimeValue.timeValueMillis(5).nanos(), 42, indexSettings);
+            fragmentSlowLog.onFragmentSuccess("q1", 0, "test-shard", TimeValue.timeValueMillis(5).nanos(), 42, indexSettings,
+                new FragmentExecutionStats(42, true, 2, "CONJUNCTIVE", false, 99, "opaque-1"));
             appender.assertAllExpectationsMatched();
         }
     }
@@ -92,11 +95,12 @@ public class AnalyticsFragmentSlowLogTests extends OpenSearchTestCase {
                     "all fields present",
                     AnalyticsFragmentSlowLog.LOGGER_NAME,
                     Level.WARN,
-                    ".*took\\[.*\\].*took_millis\\[\\d+\\].*query_id\\[q-fields\\].*stage_id\\[2\\].*shard\\[\\[my-idx\\]\\[0\\]\\].*rows_produced\\[100\\].*"
+                    ".*took\\[.*\\].*took_millis\\[\\d+\\].*query_id\\[q-fields\\].*stage_id\\[2\\].*shard\\[\\[my-idx\\]\\[0\\]\\].*rows_produced\\[100\\].*used_secondary_index\\[false\\].*partial_aggregate\\[true\\].*task_id\\[101\\].*id\\[opaque-2\\].*"
                 )
             );
 
-            fragmentSlowLog.onFragmentSuccess("q-fields", 2, "[my-idx][0]", TimeValue.timeValueMillis(50).nanos(), 100, indexSettings);
+            fragmentSlowLog.onFragmentSuccess("q-fields", 2, "[my-idx][0]", TimeValue.timeValueMillis(50).nanos(), 100, indexSettings,
+                new FragmentExecutionStats(100, false, 0, null, true, 101, "opaque-2"));
             appender.assertAllExpectationsMatched();
         }
     }

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/AnalyticsFragmentSlowLogTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/AnalyticsFragmentSlowLogTests.java
@@ -53,8 +53,14 @@ public class AnalyticsFragmentSlowLogTests extends OpenSearchTestCase {
                 )
             );
 
-            fragmentSlowLog.onFragmentSuccess("q1", 0, "test-shard", TimeValue.timeValueMillis(5).nanos(), 42, indexSettings,
-                new FragmentExecutionStats(42, true, 2, "CONJUNCTIVE", false, 99, "opaque-1"));
+            fragmentSlowLog.onFragmentSuccess(
+                "q1",
+                0,
+                "test-shard",
+                TimeValue.timeValueMillis(5).nanos(),
+                indexSettings,
+                new FragmentExecutionStats(42, true, 2, "CONJUNCTIVE", false, 99, "opaque-1")
+            );
             appender.assertAllExpectationsMatched();
         }
     }
@@ -76,8 +82,14 @@ public class AnalyticsFragmentSlowLogTests extends OpenSearchTestCase {
                 )
             );
 
-            fragmentSlowLog.onFragmentSuccess("q1", 0, "test-shard", TimeValue.timeValueMillis(5).nanos(), 42, indexSettings,
-                new FragmentExecutionStats(42, true, 2, "CONJUNCTIVE", false, 99, "opaque-1"));
+            fragmentSlowLog.onFragmentSuccess(
+                "q1",
+                0,
+                "test-shard",
+                TimeValue.timeValueMillis(5).nanos(),
+                indexSettings,
+                new FragmentExecutionStats(42, true, 2, "CONJUNCTIVE", false, 99, "opaque-1")
+            );
             appender.assertAllExpectationsMatched();
         }
     }
@@ -99,8 +111,80 @@ public class AnalyticsFragmentSlowLogTests extends OpenSearchTestCase {
                 )
             );
 
-            fragmentSlowLog.onFragmentSuccess("q-fields", 2, "[my-idx][0]", TimeValue.timeValueMillis(50).nanos(), 100, indexSettings,
-                new FragmentExecutionStats(100, false, 0, null, true, 101, "opaque-2"));
+            fragmentSlowLog.onFragmentSuccess(
+                "q-fields",
+                2,
+                "[my-idx][0]",
+                TimeValue.timeValueMillis(50).nanos(),
+                indexSettings,
+                new FragmentExecutionStats(100, false, 0, null, true, 101, "opaque-2")
+            );
+            appender.assertAllExpectationsMatched();
+        }
+    }
+
+    public void testFragmentSlowLogWithSecondaryIndexShowsDelegationFields() throws Exception {
+        AnalyticsFragmentSlowLog fragmentSlowLog = new AnalyticsFragmentSlowLog();
+        Logger logger = LogManager.getLogger(AnalyticsFragmentSlowLog.LOGGER_NAME);
+        Loggers.setLevel(logger, Level.WARN);
+
+        IndexSettings indexSettings = createIndexSettings(TimeValue.timeValueMillis(0));
+
+        try (MockLogAppender appender = MockLogAppender.createForLoggers(logger)) {
+            appender.addExpectation(
+                new MockLogAppender.PatternSeenWithLoggerPrefixExpectation(
+                    "delegation fields present when secondary index used",
+                    AnalyticsFragmentSlowLog.LOGGER_NAME,
+                    Level.WARN,
+                    ".*used_secondary_index\\[true\\].*delegated_predicates\\[3\\].*filter_tree_shape\\[CONJUNCTIVE\\].*"
+                )
+            );
+
+            fragmentSlowLog.onFragmentSuccess(
+                "q-sec",
+                0,
+                "[idx][0]",
+                TimeValue.timeValueMillis(10).nanos(),
+                indexSettings,
+                new FragmentExecutionStats(50, true, 3, "CONJUNCTIVE", false, 200, null)
+            );
+            appender.assertAllExpectationsMatched();
+        }
+    }
+
+    public void testFragmentSlowLogWithoutSecondaryIndexOmitsDelegationFields() throws Exception {
+        AnalyticsFragmentSlowLog fragmentSlowLog = new AnalyticsFragmentSlowLog();
+        Logger logger = LogManager.getLogger(AnalyticsFragmentSlowLog.LOGGER_NAME);
+        Loggers.setLevel(logger, Level.WARN);
+
+        IndexSettings indexSettings = createIndexSettings(TimeValue.timeValueMillis(0));
+
+        try (MockLogAppender appender = MockLogAppender.createForLoggers(logger)) {
+            appender.addExpectation(
+                new MockLogAppender.PatternSeenWithLoggerPrefixExpectation(
+                    "no delegation fields when secondary index not used",
+                    AnalyticsFragmentSlowLog.LOGGER_NAME,
+                    Level.WARN,
+                    ".*used_secondary_index\\[false\\].*partial_aggregate\\[.*"
+                )
+            );
+            appender.addExpectation(
+                new MockLogAppender.UnseenEventExpectation(
+                    "delegated_predicates absent",
+                    AnalyticsFragmentSlowLog.LOGGER_NAME,
+                    Level.WARN,
+                    "*delegated_predicates*"
+                )
+            );
+
+            fragmentSlowLog.onFragmentSuccess(
+                "q-nosec",
+                0,
+                "[idx][0]",
+                TimeValue.timeValueMillis(10).nanos(),
+                indexSettings,
+                new FragmentExecutionStats(50, false, 0, null, false, 201, "op-1")
+            );
             appender.assertAllExpectationsMatched();
         }
     }

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/AnalyticsFragmentSlowLogTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/AnalyticsFragmentSlowLogTests.java
@@ -1,0 +1,103 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.exec;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.Version;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.logging.Loggers;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.index.IndexSettings;
+import org.opensearch.index.SearchSlowLog;
+import org.opensearch.test.MockLogAppender;
+import org.opensearch.test.OpenSearchTestCase;
+
+public class AnalyticsFragmentSlowLogTests extends OpenSearchTestCase {
+
+    private IndexSettings createIndexSettings(TimeValue warnThreshold) {
+        Settings settings = Settings.builder()
+            .put(IndexMetadata.SETTING_INDEX_UUID, "test-uuid")
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+            .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+            .put(SearchSlowLog.INDEX_SEARCH_SLOWLOG_THRESHOLD_QUERY_WARN_SETTING.getKey(), warnThreshold)
+            .build();
+        IndexMetadata metadata = IndexMetadata.builder("test-index").settings(settings).build();
+        return new IndexSettings(metadata, Settings.EMPTY);
+    }
+
+    public void testFragmentSlowLogFiresWhenAboveThreshold() throws Exception {
+        AnalyticsFragmentSlowLog fragmentSlowLog = new AnalyticsFragmentSlowLog();
+        Logger logger = LogManager.getLogger(AnalyticsFragmentSlowLog.LOGGER_NAME);
+        Loggers.setLevel(logger, Level.WARN);
+
+        IndexSettings indexSettings = createIndexSettings(TimeValue.timeValueMillis(0));
+
+        try (MockLogAppender appender = MockLogAppender.createForLoggers(logger)) {
+            appender.addExpectation(
+                new MockLogAppender.PatternSeenWithLoggerPrefixExpectation(
+                    "fragment log fires",
+                    AnalyticsFragmentSlowLog.LOGGER_NAME,
+                    Level.WARN,
+                    ".*shard\\[test-shard\\].*rows_produced\\[42\\].*"
+                )
+            );
+
+            fragmentSlowLog.onFragmentSuccess("q1", 0, "test-shard", TimeValue.timeValueMillis(5).nanos(), 42, indexSettings);
+            appender.assertAllExpectationsMatched();
+        }
+    }
+
+    public void testFragmentSlowLogDoesNotFireWhenBelowThreshold() throws Exception {
+        AnalyticsFragmentSlowLog fragmentSlowLog = new AnalyticsFragmentSlowLog();
+        Logger logger = LogManager.getLogger(AnalyticsFragmentSlowLog.LOGGER_NAME);
+        Loggers.setLevel(logger, Level.WARN);
+
+        IndexSettings indexSettings = createIndexSettings(TimeValue.timeValueMinutes(10));
+
+        try (MockLogAppender appender = MockLogAppender.createForLoggers(logger)) {
+            appender.addExpectation(
+                new MockLogAppender.UnseenEventExpectation(
+                    "no fragment log below threshold",
+                    AnalyticsFragmentSlowLog.LOGGER_NAME,
+                    Level.WARN,
+                    "*"
+                )
+            );
+
+            fragmentSlowLog.onFragmentSuccess("q1", 0, "test-shard", TimeValue.timeValueMillis(5).nanos(), 42, indexSettings);
+            appender.assertAllExpectationsMatched();
+        }
+    }
+
+    public void testFragmentSlowLogContainsAllExpectedFields() throws Exception {
+        AnalyticsFragmentSlowLog fragmentSlowLog = new AnalyticsFragmentSlowLog();
+        Logger logger = LogManager.getLogger(AnalyticsFragmentSlowLog.LOGGER_NAME);
+        Loggers.setLevel(logger, Level.WARN);
+
+        IndexSettings indexSettings = createIndexSettings(TimeValue.timeValueMillis(0));
+
+        try (MockLogAppender appender = MockLogAppender.createForLoggers(logger)) {
+            appender.addExpectation(
+                new MockLogAppender.PatternSeenWithLoggerPrefixExpectation(
+                    "all fields present",
+                    AnalyticsFragmentSlowLog.LOGGER_NAME,
+                    Level.WARN,
+                    ".*took\\[.*\\].*took_millis\\[\\d+\\].*query_id\\[q-fields\\].*stage_id\\[2\\].*shard\\[\\[my-idx\\]\\[0\\]\\].*rows_produced\\[100\\].*"
+                )
+            );
+
+            fragmentSlowLog.onFragmentSuccess("q-fields", 2, "[my-idx][0]", TimeValue.timeValueMillis(50).nanos(), 100, indexSettings);
+            appender.assertAllExpectationsMatched();
+        }
+    }
+}

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/AnalyticsSearchSlowLogTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/AnalyticsSearchSlowLogTests.java
@@ -1,0 +1,165 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.exec;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.action.search.SearchRequestSlowLog;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.logging.Loggers;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.test.MockLogAppender;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.Set;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class AnalyticsSearchSlowLogTests extends OpenSearchTestCase {
+
+    private AnalyticsSearchSlowLog createSlowLog(TimeValue warnThreshold) {
+        Settings settings = Settings.builder()
+            .put(SearchRequestSlowLog.CLUSTER_SEARCH_REQUEST_SLOWLOG_THRESHOLD_WARN_SETTING.getKey(), warnThreshold)
+            .build();
+        ClusterSettings clusterSettings = new ClusterSettings(
+            settings,
+            Set.of(
+                SearchRequestSlowLog.CLUSTER_SEARCH_REQUEST_SLOWLOG_THRESHOLD_WARN_SETTING,
+                SearchRequestSlowLog.CLUSTER_SEARCH_REQUEST_SLOWLOG_THRESHOLD_INFO_SETTING,
+                SearchRequestSlowLog.CLUSTER_SEARCH_REQUEST_SLOWLOG_THRESHOLD_DEBUG_SETTING,
+                SearchRequestSlowLog.CLUSTER_SEARCH_REQUEST_SLOWLOG_THRESHOLD_TRACE_SETTING,
+                SearchRequestSlowLog.CLUSTER_SEARCH_REQUEST_SLOWLOG_LEVEL
+            )
+        );
+        ClusterService clusterService = mock(ClusterService.class);
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
+        when(clusterService.getSettings()).thenReturn(settings);
+        return new AnalyticsSearchSlowLog(clusterService);
+    }
+
+    public void testSlowLogFiresAtOnQueryComplete() throws Exception {
+        AnalyticsSearchSlowLog slowLog = createSlowLog(TimeValue.timeValueMillis(0));
+        Logger logger = LogManager.getLogger(AnalyticsSearchSlowLog.QUERY_LOGGER_NAME);
+        Loggers.setLevel(logger, Level.WARN);
+
+        var wrapped = slowLog.createQueryListener("SELECT * FROM idx");
+        wrapped.setHeaders("opaque-1", "req-1");
+
+        try (MockLogAppender appender = MockLogAppender.createForLoggers(logger)) {
+            appender.addExpectation(
+                new MockLogAppender.PatternSeenWithLoggerPrefixExpectation(
+                    "slow log fires at query complete",
+                    AnalyticsSearchSlowLog.QUERY_LOGGER_NAME,
+                    Level.WARN,
+                    ".*took\\[.*\\].*query_id\\[q1\\].*total_rows\\[50\\].*"
+                )
+            );
+
+            wrapped.onQueryComplete("q1", TimeValue.timeValueMillis(10).nanos(), 50);
+            appender.assertAllExpectationsMatched();
+        }
+    }
+
+    public void testSlowLogDoesNotFireWhenBelowThreshold() throws Exception {
+        AnalyticsSearchSlowLog slowLog = createSlowLog(TimeValue.timeValueSeconds(10));
+        Logger logger = LogManager.getLogger(AnalyticsSearchSlowLog.QUERY_LOGGER_NAME);
+        Loggers.setLevel(logger, Level.WARN);
+
+        var wrapped = slowLog.createQueryListener("SELECT 1");
+
+        try (MockLogAppender appender = MockLogAppender.createForLoggers(logger)) {
+            appender.addExpectation(
+                new MockLogAppender.UnseenEventExpectation(
+                    "no log below threshold",
+                    AnalyticsSearchSlowLog.QUERY_LOGGER_NAME,
+                    Level.WARN,
+                    "*"
+                )
+            );
+
+            wrapped.onQueryComplete("q2", TimeValue.timeValueMillis(5).nanos(), 10);
+            appender.assertAllExpectationsMatched();
+        }
+    }
+
+    public void testSlowLogIncludesPlanningAndStageTiming() throws Exception {
+        AnalyticsSearchSlowLog slowLog = createSlowLog(TimeValue.timeValueMillis(0));
+        Logger logger = LogManager.getLogger(AnalyticsSearchSlowLog.QUERY_LOGGER_NAME);
+        Loggers.setLevel(logger, Level.WARN);
+
+        var wrapped = slowLog.createQueryListener("SELECT val FROM idx");
+
+        try (MockLogAppender appender = MockLogAppender.createForLoggers(logger)) {
+            appender.addExpectation(
+                new MockLogAppender.PatternSeenWithLoggerPrefixExpectation(
+                    "planning and stage timing present",
+                    AnalyticsSearchSlowLog.QUERY_LOGGER_NAME,
+                    Level.WARN,
+                    ".*planning_time_millis\\[2\\].*stage_took_millis\\[\\{ShardFragmentStageExecution=8, ReduceStageExecution=3\\}\\].*"
+                )
+            );
+
+            wrapped.onPlanningComplete("q3", TimeValue.timeValueMillis(2).nanos());
+            wrapped.onStageSuccess("q3", 0, "ShardFragmentStageExecution", TimeValue.timeValueMillis(8).nanos(), 100);
+            wrapped.onStageSuccess("q3", 1, "ReduceStageExecution", TimeValue.timeValueMillis(3).nanos(), 100);
+            wrapped.onQueryComplete("q3", TimeValue.timeValueMillis(14).nanos(), 100);
+
+            appender.assertAllExpectationsMatched();
+        }
+    }
+
+    public void testSlowLogIncludesSourceAndHeaders() throws Exception {
+        AnalyticsSearchSlowLog slowLog = createSlowLog(TimeValue.timeValueMillis(0));
+        Logger logger = LogManager.getLogger(AnalyticsSearchSlowLog.QUERY_LOGGER_NAME);
+        Loggers.setLevel(logger, Level.WARN);
+
+        var wrapped = slowLog.createQueryListener("source = my_index | stats count()");
+        wrapped.setHeaders("user-opaque-123", "req-456");
+
+        try (MockLogAppender appender = MockLogAppender.createForLoggers(logger)) {
+            appender.addExpectation(
+                new MockLogAppender.PatternSeenWithLoggerPrefixExpectation(
+                    "source in log",
+                    AnalyticsSearchSlowLog.QUERY_LOGGER_NAME,
+                    Level.WARN,
+                    ".*source\\[source = my_index \\| stats count\\(\\)\\].*id\\[user-opaque-123\\].*request_id\\[req-456\\].*"
+                )
+            );
+
+            wrapped.onQueryComplete("q4", TimeValue.timeValueMillis(10).nanos(), 1);
+            appender.assertAllExpectationsMatched();
+        }
+    }
+
+    public void testSlowLogWithNullMetadata() throws Exception {
+        AnalyticsSearchSlowLog slowLog = createSlowLog(TimeValue.timeValueMillis(0));
+        Logger logger = LogManager.getLogger(AnalyticsSearchSlowLog.QUERY_LOGGER_NAME);
+        Loggers.setLevel(logger, Level.WARN);
+
+        var wrapped = slowLog.createQueryListener(null);
+
+        try (MockLogAppender appender = MockLogAppender.createForLoggers(logger)) {
+            appender.addExpectation(
+                new MockLogAppender.PatternSeenWithLoggerPrefixExpectation(
+                    "empty fields present",
+                    AnalyticsSearchSlowLog.QUERY_LOGGER_NAME,
+                    Level.WARN,
+                    ".*source\\[\\].*id\\[\\].*request_id\\[\\].*"
+                )
+            );
+
+            wrapped.onQueryComplete("q5", TimeValue.timeValueMillis(1).nanos(), 0);
+            appender.assertAllExpectationsMatched();
+        }
+    }
+}

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/stage/OperationListenerCoverageTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/stage/OperationListenerCoverageTests.java
@@ -200,7 +200,7 @@ public class OperationListenerCoverageTests extends OpenSearchTestCase {
         }
 
         @Override
-        public void onStageSuccess(String queryId, int stageId, long tookInNanos, long rowsProcessed) {
+        public void onStageSuccess(String queryId, int stageId, String stageType, long tookInNanos, long rowsProcessed) {
             events.add("onStageSuccess:" + stageId);
         }
 

--- a/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/CompositeIndexingSlowLogIT.java
+++ b/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/CompositeIndexingSlowLogIT.java
@@ -1,0 +1,97 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.composite;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.common.logging.Loggers;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.index.IndexingSlowLog;
+import org.opensearch.test.MockLogAppender;
+import org.opensearch.test.OpenSearchIntegTestCase;
+
+/**
+ * Verifies that the indexing slow log fires with full fidelity when documents
+ * are indexed through the DataFormatAware (Parquet) engine.
+ */
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 1)
+public class CompositeIndexingSlowLogIT extends AbstractCompositeEngineIT {
+
+    private static final String INDEX_NAME = "slowlog-test-idx";
+    private static final String SLOW_LOG_LOGGER = IndexingSlowLog.INDEX_INDEXING_SLOWLOG_PREFIX + ".index";
+
+    public void testSlowLogEmitsAllFieldsForDFAEngine() throws Exception {
+        createIndexWithSlowLogThreshold(TimeValue.timeValueMillis(0));
+
+        try (MockLogAppender appender = newSlowLogAppender()) {
+            appender.addExpectation(expectSeen("contains index name", ".*slowlog-test-idx.*"));
+            appender.addExpectation(expectSeen("contains took", ".*took\\[.*\\].*"));
+            appender.addExpectation(expectSeen("contains took_millis", ".*took_millis\\[\\d+\\].*"));
+            appender.addExpectation(expectSeen("contains document id", ".*id\\[1\\].*"));
+            appender.addExpectation(expectSeen("contains routing field", ".*routing\\[.*\\].*"));
+            appender.addExpectation(expectSeen("contains document source", ".*source\\[.*test_value.*\\].*"));
+
+            assertEquals(
+                RestStatus.CREATED,
+                client().prepareIndex().setIndex(INDEX_NAME).setId("1").setSource("name", "test_value", "value", 42).get().status()
+            );
+
+            appender.assertAllExpectationsMatched();
+        }
+    }
+
+    public void testSlowLogDoesNotFireWhenBelowThreshold() throws Exception {
+        createIndexWithSlowLogThreshold(TimeValue.timeValueMinutes(10));
+
+        try (MockLogAppender appender = newSlowLogAppender()) {
+            appender.addExpectation(
+                new MockLogAppender.UnseenEventExpectation("no slow log below threshold", SLOW_LOG_LOGGER, Level.WARN, "*")
+            );
+
+            assertEquals(
+                RestStatus.CREATED,
+                client().prepareIndex().setIndex(INDEX_NAME).setId("1").setSource("name", "fast_doc", "value", 1).get().status()
+            );
+
+            appender.assertAllExpectationsMatched();
+        }
+    }
+
+    private void createIndexWithSlowLogThreshold(TimeValue threshold) {
+        client().admin()
+            .indices()
+            .prepareCreate(INDEX_NAME)
+            .setSettings(
+                Settings.builder()
+                    .put("index.number_of_shards", 1)
+                    .put("index.number_of_replicas", 0)
+                    .put("index.pluggable.dataformat.enabled", true)
+                    .put("index.pluggable.dataformat", "composite")
+                    .put("index.composite.primary_data_format", "parquet")
+                    .putList("index.composite.secondary_data_formats", "lucene")
+                    .put(IndexingSlowLog.INDEX_INDEXING_SLOWLOG_THRESHOLD_INDEX_WARN_SETTING.getKey(), threshold)
+            )
+            .setMapping("name", "type=keyword", "value", "type=integer")
+            .get();
+        ensureGreen(INDEX_NAME);
+    }
+
+    private MockLogAppender newSlowLogAppender() throws IllegalAccessException {
+        Logger logger = LogManager.getLogger(SLOW_LOG_LOGGER);
+        Loggers.setLevel(logger, Level.WARN);
+        return MockLogAppender.createForLoggers(logger);
+    }
+
+    private static MockLogAppender.PatternSeenWithLoggerPrefixExpectation expectSeen(String name, String regex) {
+        return new MockLogAppender.PatternSeenWithLoggerPrefixExpectation(name, SLOW_LOG_LOGGER, Level.WARN, regex);
+    }
+}

--- a/sandbox/plugins/test-ppl-frontend/src/main/java/org/opensearch/ppl/action/UnifiedQueryService.java
+++ b/sandbox/plugins/test-ppl-frontend/src/main/java/org/opensearch/ppl/action/UnifiedQueryService.java
@@ -17,6 +17,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.analytics.EngineContextProvider;
+import org.opensearch.analytics.QueryRequestContext;
 import org.opensearch.analytics.exec.QueryPlanExecutor;
 import org.opensearch.analytics.exec.profile.ProfiledResult;
 import org.opensearch.sql.api.UnifiedQueryContext;
@@ -124,9 +125,12 @@ public class UnifiedQueryService {
                 columns.add(field.getName());
             }
 
+            QueryRequestContext baseCtx = contextProvider.getContext();
+            QueryRequestContext queryCtx = new QueryRequestContext(baseCtx.clusterState(), baseCtx.schema(), pplText);
+
             if (profile) {
                 PlainActionFuture<ProfiledResult> future = new PlainActionFuture<>();
-                planExecutor.executeWithProfile(logicalPlan, null, future);
+                planExecutor.executeWithProfile(logicalPlan, queryCtx, future);
                 ProfiledResult result = future.actionGet();
 
                 if (result.isSuccess() == false) {
@@ -146,7 +150,7 @@ public class UnifiedQueryService {
             // (e.g. CircuitBreakingException) is handled by DefaultPlanExecutor's
             // convertingListener without being wrapped in ProfiledResult.
             PlainActionFuture<Iterable<Object[]>> future = new PlainActionFuture<>();
-            planExecutor.execute(logicalPlan, null, future);
+            planExecutor.execute(logicalPlan, queryCtx, future);
             Iterable<Object[]> results = future.actionGet();
 
             List<Object[]> rows = new ArrayList<>();

--- a/sandbox/qa/analytics-engine-coordinator/src/internalClusterTest/java/org/opensearch/analytics/sql/AnalyticsSearchSlowLogIT.java
+++ b/sandbox/qa/analytics-engine-coordinator/src/internalClusterTest/java/org/opensearch/analytics/sql/AnalyticsSearchSlowLogIT.java
@@ -1,0 +1,261 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.sql;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.Version;
+import org.opensearch.action.admin.indices.create.CreateIndexResponse;
+import org.opensearch.action.search.SearchRequestSlowLog;
+import org.opensearch.analytics.AnalyticsPlugin;
+import org.opensearch.analytics.exec.AnalyticsFragmentSlowLog;
+import org.opensearch.analytics.exec.AnalyticsSearchSlowLog;
+import org.opensearch.index.SearchSlowLog;
+import org.opensearch.analytics.exec.DefaultPlanExecutor;
+import org.opensearch.arrow.allocator.ArrowBasePlugin;
+import org.opensearch.arrow.flight.transport.FlightStreamPlugin;
+import org.opensearch.be.datafusion.DataFusionPlugin;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.logging.Loggers;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.common.util.FeatureFlags;
+import org.opensearch.composite.CompositeDataFormatPlugin;
+import org.opensearch.index.engine.dataformat.stub.MockCommitterEnginePlugin;
+import org.opensearch.parquet.ParquetDataFormatPlugin;
+import org.opensearch.plugins.Plugin;
+import org.opensearch.plugins.PluginInfo;
+import org.opensearch.ppl.TestPPLPlugin;
+import org.opensearch.ppl.action.PPLRequest;
+import org.opensearch.ppl.action.PPLResponse;
+import org.opensearch.ppl.action.UnifiedPPLExecuteAction;
+import org.opensearch.test.MockLogAppender;
+import org.opensearch.test.OpenSearchIntegTestCase;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Verifies that the analytics engine search slow log fires for queries
+ * executed through the DataFusion backend on the coordinator path.
+ */
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 2, numClientNodes = 0)
+public class AnalyticsSearchSlowLogIT extends OpenSearchIntegTestCase {
+
+    private static final String INDEX = "slowlog_search_idx";
+    private static final int TOTAL_DOCS = 10;
+    private static final String QUERY_LOGGER = AnalyticsSearchSlowLog.QUERY_LOGGER_NAME;
+    private static final String FRAGMENT_LOGGER = AnalyticsFragmentSlowLog.LOGGER_NAME;
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return List.of(ArrowBasePlugin.class, TestPPLPlugin.class, CompositeDataFormatPlugin.class, MockCommitterEnginePlugin.class);
+    }
+
+    @Override
+    protected Collection<PluginInfo> additionalNodePlugins() {
+        return List.of(
+            classpathPlugin(FlightStreamPlugin.class, List.of(ArrowBasePlugin.class.getName())),
+            classpathPlugin(AnalyticsPlugin.class, Collections.emptyList()),
+            classpathPlugin(ParquetDataFormatPlugin.class, Collections.emptyList()),
+            classpathPlugin(DataFusionPlugin.class, List.of(AnalyticsPlugin.class.getName()))
+        );
+    }
+
+    private static PluginInfo classpathPlugin(Class<? extends Plugin> pluginClass, List<String> extendedPlugins) {
+        return new PluginInfo(
+            pluginClass.getName(),
+            "classpath plugin",
+            "NA",
+            Version.CURRENT,
+            "1.8",
+            pluginClass.getName(),
+            null,
+            extendedPlugins,
+            false
+        );
+    }
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return Settings.builder()
+            .put(super.nodeSettings(nodeOrdinal))
+            .put(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG, true)
+            .put(FeatureFlags.STREAM_TRANSPORT, true)
+            .build();
+    }
+
+    @Override
+    protected Settings featureFlagSettings() {
+        return Settings.builder()
+            .put(super.featureFlagSettings())
+            .put(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG, true)
+            .put(FeatureFlags.STREAM_TRANSPORT, true)
+            .build();
+    }
+
+    public void testQuerySlowLogEmitsAllFieldsOnCoordinatorPath() throws Exception {
+        setSlowLogThreshold(TimeValue.timeValueMillis(0));
+        createAndSeedIndex();
+        SqlPlanRunner runner = sqlPlanRunner();
+
+        Logger queryLogger = LogManager.getLogger(QUERY_LOGGER);
+        Loggers.setLevel(queryLogger, Level.WARN);
+
+        try (MockLogAppender appender = MockLogAppender.createForLoggers(queryLogger)) {
+            appender.addExpectation(expectQuery("has took", ".*took\\[.*\\].*took_millis\\[\\d+\\].*"));
+            appender.addExpectation(expectQuery("has planning_time_millis", ".*planning_time_millis\\[\\d+\\].*"));
+            appender.addExpectation(expectQuery("has stage_took_millis", ".*stage_took_millis\\[\\{.*StageExecution.*\\}\\].*"));
+            appender.addExpectation(expectQuery("has query_id", ".*query_id\\[[a-f0-9-]+\\].*"));
+            appender.addExpectation(expectQuery("has total_rows > 0", ".*total_rows\\[(?!0\\])\\d+\\].*"));
+            appender.addExpectation(expectQuery("has source field", ".*source\\[.*\\].*"));
+            appender.addExpectation(expectQuery("has id field", ".*id\\[.*\\].*"));
+            appender.addExpectation(expectQuery("has request_id field", ".*request_id\\[.*\\].*"));
+
+            List<Object[]> rows = runner.executeSql("SELECT val FROM " + INDEX);
+            assertFalse("query must return rows", rows.isEmpty());
+
+            appender.assertAllExpectationsMatched();
+        }
+    }
+
+    public void testFragmentSlowLogEmitsAllFieldsOnDataNodePath() throws Exception {
+        setSlowLogThreshold(TimeValue.timeValueMillis(0));
+        createAndSeedIndex();
+        setIndexSlowLogThreshold(TimeValue.timeValueMillis(0));
+        SqlPlanRunner runner = sqlPlanRunner();
+
+        Logger fragmentLogger = LogManager.getLogger(FRAGMENT_LOGGER);
+        Loggers.setLevel(fragmentLogger, Level.WARN);
+
+        try (MockLogAppender appender = MockLogAppender.createForLoggers(fragmentLogger)) {
+            appender.addExpectation(expectFragment("has took", ".*took\\[.*\\].*took_millis\\[\\d+\\].*"));
+            appender.addExpectation(expectFragment("has query_id", ".*query_id\\[[a-f0-9-]+\\].*"));
+            appender.addExpectation(expectFragment("has stage_id", ".*stage_id\\[\\d+\\].*"));
+            appender.addExpectation(expectFragment("has shard", ".*shard\\[\\[" + INDEX + "\\]\\[\\d+\\]\\].*"));
+            appender.addExpectation(expectFragment("has rows_produced > 0", ".*rows_produced\\[(?!0\\])\\d+\\].*"));
+
+            List<Object[]> rows = runner.executeSql("SELECT val FROM " + INDEX);
+            assertFalse("query must return rows", rows.isEmpty());
+
+            appender.assertAllExpectationsMatched();
+        }
+    }
+
+    public void testSlowLogDoesNotFireWhenBelowThreshold() throws Exception {
+        setSlowLogThreshold(TimeValue.timeValueMinutes(10));
+        createAndSeedIndex();
+        SqlPlanRunner runner = sqlPlanRunner();
+
+        Logger queryLogger = LogManager.getLogger(QUERY_LOGGER);
+        Loggers.setLevel(queryLogger, Level.WARN);
+
+        try (MockLogAppender appender = MockLogAppender.createForLoggers(queryLogger)) {
+            appender.addExpectation(
+                new MockLogAppender.UnseenEventExpectation("no slow log below threshold", QUERY_LOGGER, Level.WARN, "*")
+            );
+
+            List<Object[]> rows = runner.executeSql("SELECT val FROM " + INDEX);
+            assertFalse("query must return rows", rows.isEmpty());
+
+            appender.assertAllExpectationsMatched();
+        }
+    }
+
+    public void testSlowLogContainsQuerySourceViaPPLFrontend() throws Exception {
+        setSlowLogThreshold(TimeValue.timeValueMillis(0));
+        createAndSeedIndex();
+
+        Logger queryLogger = LogManager.getLogger(QUERY_LOGGER);
+        Loggers.setLevel(queryLogger, Level.WARN);
+
+        try (MockLogAppender appender = MockLogAppender.createForLoggers(queryLogger)) {
+            appender.addExpectation(
+                new MockLogAppender.PatternSeenWithLoggerPrefixExpectation(
+                    "source field contains PPL text",
+                    QUERY_LOGGER,
+                    Level.WARN,
+                    ".*source\\[source = " + INDEX + ".*\\].*"
+                )
+            );
+
+            PPLResponse response = client().execute(
+                UnifiedPPLExecuteAction.INSTANCE,
+                new PPLRequest("source = " + INDEX + " | fields val")
+            ).actionGet();
+            assertFalse("PPL query must return rows", response.getRows().isEmpty());
+
+            appender.assertAllExpectationsMatched();
+        }
+    }
+
+    private void setSlowLogThreshold(TimeValue threshold) {
+        client().admin()
+            .cluster()
+            .prepareUpdateSettings()
+            .setPersistentSettings(
+                Settings.builder().put(SearchRequestSlowLog.CLUSTER_SEARCH_REQUEST_SLOWLOG_THRESHOLD_WARN_SETTING.getKey(), threshold)
+            )
+            .get();
+    }
+
+    private void setIndexSlowLogThreshold(TimeValue threshold) {
+        client().admin()
+            .indices()
+            .prepareUpdateSettings(INDEX)
+            .setSettings(
+                Settings.builder().put(SearchSlowLog.INDEX_SEARCH_SLOWLOG_THRESHOLD_QUERY_WARN_SETTING.getKey(), threshold)
+            )
+            .get();
+    }
+
+    private void createAndSeedIndex() {
+        Settings indexSettings = Settings.builder()
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 2)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+            .put("index.pluggable.dataformat.enabled", true)
+            .put("index.pluggable.dataformat", "composite")
+            .put("index.composite.primary_data_format", "parquet")
+            .putList("index.composite.secondary_data_formats")
+            .build();
+
+        CreateIndexResponse response = client().admin()
+            .indices()
+            .prepareCreate(INDEX)
+            .setSettings(indexSettings)
+            .setMapping("val", "type=integer")
+            .get();
+        assertTrue("index creation must be acknowledged", response.isAcknowledged());
+        ensureGreen(INDEX);
+
+        for (int i = 0; i < TOTAL_DOCS; i++) {
+            client().prepareIndex(INDEX).setId(String.valueOf(i)).setSource("val", i + 1).get();
+        }
+        client().admin().indices().prepareRefresh(INDEX).get();
+        client().admin().indices().prepareFlush(INDEX).get();
+    }
+
+    private SqlPlanRunner sqlPlanRunner() {
+        String node = internalCluster().getNodeNames()[0];
+        ClusterService clusterService = internalCluster().getInstance(ClusterService.class, node);
+        DefaultPlanExecutor executor = internalCluster().getInstance(DefaultPlanExecutor.class, node);
+        return new SqlPlanRunner(clusterService, executor);
+    }
+
+    private static MockLogAppender.PatternSeenWithLoggerPrefixExpectation expectQuery(String name, String regex) {
+        return new MockLogAppender.PatternSeenWithLoggerPrefixExpectation(name, QUERY_LOGGER, Level.WARN, regex);
+    }
+
+    private static MockLogAppender.PatternSeenWithLoggerPrefixExpectation expectFragment(String name, String regex) {
+        return new MockLogAppender.PatternSeenWithLoggerPrefixExpectation(name, FRAGMENT_LOGGER, Level.WARN, regex);
+    }
+}

--- a/sandbox/qa/analytics-engine-coordinator/src/internalClusterTest/java/org/opensearch/analytics/sql/AnalyticsSearchSlowLogIT.java
+++ b/sandbox/qa/analytics-engine-coordinator/src/internalClusterTest/java/org/opensearch/analytics/sql/AnalyticsSearchSlowLogIT.java
@@ -43,6 +43,7 @@ import org.opensearch.test.OpenSearchIntegTestCase;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Verifies that the analytics engine search slow log fires for queries
@@ -143,6 +144,10 @@ public class AnalyticsSearchSlowLogIT extends OpenSearchIntegTestCase {
             appender.addExpectation(expectFragment("has stage_id", ".*stage_id\\[\\d+\\].*"));
             appender.addExpectation(expectFragment("has shard", ".*shard\\[\\[" + INDEX + "\\]\\[\\d+\\]\\].*"));
             appender.addExpectation(expectFragment("has rows_produced > 0", ".*rows_produced\\[(?!0\\])\\d+\\].*"));
+            appender.addExpectation(expectFragment("has used_secondary_index", ".*used_secondary_index\\[.*\\].*"));
+            appender.addExpectation(expectFragment("has partial_aggregate", ".*partial_aggregate\\[.*\\].*"));
+            appender.addExpectation(expectFragment("has task_id", ".*task_id\\[\\d+\\].*"));
+            appender.addExpectation(expectFragment("has id field", ".*id\\[.*\\].*"));
 
             List<Object[]> rows = runner.executeSql("SELECT val FROM " + INDEX);
             assertFalse("query must return rows", rows.isEmpty());
@@ -171,7 +176,7 @@ public class AnalyticsSearchSlowLogIT extends OpenSearchIntegTestCase {
         }
     }
 
-    public void testSlowLogContainsQuerySourceViaPPLFrontend() throws Exception {
+    public void testSlowLogContainsQuerySourceAndOpaqueIdViaPPLFrontend() throws Exception {
         setSlowLogThreshold(TimeValue.timeValueMillis(0));
         createAndSeedIndex();
 
@@ -179,19 +184,12 @@ public class AnalyticsSearchSlowLogIT extends OpenSearchIntegTestCase {
         Loggers.setLevel(queryLogger, Level.WARN);
 
         try (MockLogAppender appender = MockLogAppender.createForLoggers(queryLogger)) {
-            appender.addExpectation(
-                new MockLogAppender.PatternSeenWithLoggerPrefixExpectation(
-                    "source field contains PPL text",
-                    QUERY_LOGGER,
-                    Level.WARN,
-                    ".*source\\[source = " + INDEX + ".*\\].*"
-                )
-            );
+            appender.addExpectation(expectQuery("source field contains PPL text", ".*source\\[source = " + INDEX + ".*\\].*"));
+            appender.addExpectation(expectQuery("id field contains opaque id", ".*id\\[slow-log-test-id\\].*"));
 
-            PPLResponse response = client().execute(
-                UnifiedPPLExecuteAction.INSTANCE,
-                new PPLRequest("source = " + INDEX + " | fields val")
-            ).actionGet();
+            PPLResponse response = client().filterWithHeader(Map.of("X-Opaque-Id", "slow-log-test-id"))
+                .execute(UnifiedPPLExecuteAction.INSTANCE, new PPLRequest("source = " + INDEX + " | fields val"))
+                .actionGet();
             assertFalse("PPL query must return rows", response.getRows().isEmpty());
 
             appender.assertAllExpectationsMatched();


### PR DESCRIPTION
### Description
Wire up slow logs for the DataFusion/Parquet engine so operators can identify slow operations through the analytics path, matching the observability available on the standard Lucene search/indexing path.

Indexing path: verified that the existing IndexingSlowLog fires correctly for DFA-backed indices 
Search path (:
  - AnalyticsSearchSlowLog (coordinator): logs query completions exceeding `cluster.search.request.slowlog.*` thresholds. Captures query source (PPL/SQL text), X-Opaque-ID,
   and request ID via a per-query wrapper closure.
  - AnalyticsFragmentSlowLog (data node): logs fragment executions exceeding `index.search.slowlog.threshold.query.*` per-index thresholds, reading IndexSettings at call
  time -- same settings as SearchSlowLog. 
 




### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
