### PR TITLE
[Analytics Engine] Skip partial/final split on non-prefix groupSet type mismatch (exact SqlTypeName)

### DIFF
--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchAggregateSplitRule.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchAggregateSplitRule.java
@@ -20,7 +20,7 @@ import org.apache.calcite.rex.RexInputRef;
 import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlAggFunction;
-import org.apache.calcite.sql.type.SqlTypeFamily;
+import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.util.ImmutableBitSet;
 import org.opensearch.analytics.planner.PlannerContext;
 import org.opensearch.analytics.planner.RelNodeUtils;
@@ -75,9 +75,18 @@ public class OpenSearchAggregateSplitRule extends RelOptRule {
             if (aggIdx >= aggCalls.size() || k >= inputFields.size()) {
                 return true;
             }
-            SqlTypeFamily inputFamily = inputFields.get(k).getSqlTypeName().getFamily();
-            SqlTypeFamily aggFamily = aggCalls.get(aggIdx).getType().getSqlTypeName().getFamily();
-            if (inputFamily != aggFamily) {
+            // Compare the exact SqlTypeName, not just the type family. The FINAL reuses this
+            // group-key ordinal over the PARTIAL output, where ordinal k (>= groupCount) now
+            // holds an agg output, so the FINAL's group-key column takes the agg-output type
+            // (aggCalls.get(aggIdx)). That must equal the original input field type
+            // (inputFields.get(k)) for the FINAL row type to stay equivalent to the original
+            // aggregate's — otherwise Volcano's typeMatchesInferred / rowtype-equivalence check
+            // throws. A family match is too coarse: BIGINT and INTEGER share the NUMERIC family
+            // yet fail that check (PPL chart / stats `... by <field> span=...` over an INTEGER
+            // measure declares the agg as BIGINT while the span key is INTEGER).
+            SqlTypeName inputType = inputFields.get(k).getSqlTypeName();
+            SqlTypeName aggType = aggCalls.get(aggIdx).getType().getSqlTypeName();
+            if (inputType != aggType) {
                 return true;
             }
         }


### PR DESCRIPTION
### Description

`OpenSearchAggregateSplitRule.shouldSkipPartialFinalSplit()` skips the PARTIAL/FINAL split for **non-prefix** group sets — those where a group-key ordinal `k >= groupCount` lands on a PARTIAL agg-output slot. The structural FINAL reuses the original ordinals over the keys-first PARTIAL output, so such a group key would take the **agg-output column's type**, which must equal the original input-field type or Volcano's `Aggregate.typeMatchesInferred` / row-type-equivalence check throws.

The collision check compared `SqlTypeFamily`, which is too coarse: `BIGINT` and `INTEGER` both belong to the `NUMERIC` family, so a span group key (`INTEGER`) paired with a measure declared `BIGINT` slipped through, the split was attempted, and planning crashed with either:

```
AssertionError: type mismatch: aggCall type: BIGINT inferred type: INTEGER
```
or
```
IllegalArgumentException: Type mismatch: rel rowtype ... $f2: BIGINT -> INTEGER
```

### Fix

Compare the exact `SqlTypeName` instead of the type family, so these cases fall back to a SINGLE coordinator aggregate (always correct) rather than an unsound partial/final split. One-line semantics change; no behavior change for prefix group sets (handled by the earlier early-return) or for non-prefix sets whose collision-slot types already match.

### How it surfaced / verification

Surfaced by PPL `chart ... by <field> span=...` over an `INTEGER` measure on the analytics-engine route (e.g. `chart max(balance) by age span=10`, `chart usenull=... avg(balance) over gender by age span=10`). The equivalent `stats ... by <field> span=...` shape hits the same path.

Verified against `CalciteChartCommandIT` (opensearch-project/sql) force-routed through the analytics-engine path. The two span tests that crashed on planning go red → green:

| Test (`CalciteChartCommandIT`) | Before | After |
|---|---|---|
| `testChartMaxBalanceByAgeSpan` | ❌ `aggCall type: BIGINT inferred type: INTEGER` | ✅ |
| `testChartUseNullTrueWithNullStr` | ❌ `Type mismatch … $f2: BIGINT -> INTEGER` | ✅ |

Combined with the partition-boundary coercion fix (#21878), chart on the analytics-engine route goes from 8/15 → 10/15; the remaining 5 are out of scope here (datetime wire-format sql#5420 ×2, and the `attributes.client.ip` Binary/BinaryView scan mismatch ×3).

### Follow-up

A self-contained QA IT under `sandbox/qa/analytics-engine-rest` exercising `stats max(<int>) by <field> span=N` would regression-cover this in OpenSearch CI (no existing Span/Stats QA IT covers the `stats max(int-measure) by … span` non-prefix shape). Not included here.

### Check List
- [x] Commits are signed per the DCO using `--signoff`.
