### PR TITLE
Fix: Downgrade optional plugin dependency warning to a single info log (#21322)

### DIFF
--- a/server/src/main/java/org/opensearch/plugins/PluginsService.java
+++ b/server/src/main/java/org/opensearch/plugins/PluginsService.java
@@ -625,7 +625,8 @@ public class PluginsService implements ReportingService<PluginsAndModules> {
             Bundle depBundle = bundles.get(dependency);
             if (depBundle == null) {
                 if (bundle.plugin.isExtendedPluginOptional(dependency)) {
-                    logger.info("Missing optional plugin [" + dependency + "], dependency of [" + name + "]. Some features of this plugin may not function without the dependencies being installed.");
+                    logger.info("Missing optional plugin [" + dependency + "], dependency of [" + name + "]. " +
+                                "Some features of this plugin may not function without the dependencies being installed.");
                     continue;
                 } else {
                     throw new IllegalArgumentException("Missing plugin [" + dependency + "], dependency of [" + name + "]");

--- a/server/src/main/java/org/opensearch/plugins/PluginsService.java
+++ b/server/src/main/java/org/opensearch/plugins/PluginsService.java
@@ -625,8 +625,7 @@ public class PluginsService implements ReportingService<PluginsAndModules> {
             Bundle depBundle = bundles.get(dependency);
             if (depBundle == null) {
                 if (bundle.plugin.isExtendedPluginOptional(dependency)) {
-                    logger.warn("Missing plugin [" + dependency + "], dependency of [" + name + "]");
-                    logger.warn("Some features of this plugin may not function without the dependencies being installed.\n");
+                    logger.info("Missing optional plugin [" + dependency + "], dependency of [" + name + "]. Some features of this plugin may not function without the dependencies being installed.");
                     continue;
                 } else {
                     throw new IllegalArgumentException("Missing plugin [" + dependency + "], dependency of [" + name + "]");

--- a/server/src/main/java/org/opensearch/plugins/PluginsService.java
+++ b/server/src/main/java/org/opensearch/plugins/PluginsService.java
@@ -625,8 +625,12 @@ public class PluginsService implements ReportingService<PluginsAndModules> {
             Bundle depBundle = bundles.get(dependency);
             if (depBundle == null) {
                 if (bundle.plugin.isExtendedPluginOptional(dependency)) {
-                    logger.info("Missing optional plugin [" + dependency + "], dependency of [" + name + "]. " +
-                                "Some features of this plugin may not function without the dependencies being installed.");
+                    logger.info(
+                        "Missing optional plugin [{}], dependency of [{}]. "
+                            + "Some features of this plugin may not function without the dependencies being installed.",
+                        dependency,
+                        name
+                    );
                     continue;
                 } else {
                     throw new IllegalArgumentException("Missing plugin [" + dependency + "], dependency of [" + name + "]");

--- a/server/src/test/java/org/opensearch/plugins/PluginsServiceTests.java
+++ b/server/src/test/java/org/opensearch/plugins/PluginsServiceTests.java
@@ -369,10 +369,10 @@ public class PluginsServiceTests extends OpenSearchTestCase {
         try (MockLogAppender mockLogAppender = MockLogAppender.createForLoggers(LogManager.getLogger(PluginsService.class))) {
             mockLogAppender.addExpectation(
                 new MockLogAppender.SeenEventExpectation(
-                    "[.test] warning",
+                    "[.test] info",
                     "org.opensearch.plugins.PluginsService",
-                    Level.WARN,
-                    "Missing plugin [dne], dependency of [foo]"
+                    Level.INFO,
+                    "Missing optional plugin [dne], dependency of [foo]. Some features of this plugin may not function without the dependencies being installed."
                 )
             );
             Path pluginDir = createTempDir();


### PR DESCRIPTION
### Description
Changed a multi-line `WARN` log to a single `INFO` log when an optional plugin is missing during startup. This prevents confusing, fragmented output and explicitly identifies the dependency as "optional", as requested by the maintainers. 

Taking this over with permission from @dzane17.

### Related Issues
Resolves #21322

### Check List
- [x] Functionality includes testing. *(Note: Trivial logging string change, no new tests required).*
- [ ] API changes companion pull request created, if applicable.
- [ ] Public documentation issue/PR created, if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).