### PR TITLE
[Arrow Flight RPC] Producer-side back-pressure under slow consumers

### DIFF
--- a/plugins/arrow-flight-rpc/README.md
+++ b/plugins/arrow-flight-rpc/README.md
@@ -46,6 +46,7 @@ For detailed usage and architecture information, see the [docs](docs/) folder:
 - [Server-side Streaming Guide](docs/server-side-streaming-guide.md) - How to implement server-side streaming
 - [Transport Client Streaming Flow](docs/transport-client-streaming-flow.md) - Client-side streaming implementation
 - [Flight Client Channel Flow](docs/flight-client-channel-flow.md) - Client channel flow details
+- [Producer Back-Pressure](docs/backpressure.md) - Producer-side back-pressure: settings, behaviour, sizing
 - [Metrics](docs/metrics.md) - Monitoring and performance metrics
 - [Error Handling](docs/error-handling.md) - Error handling patterns
 - [Security Integration](docs/security-integration.md) - Security plugin integration and TLS setup

--- a/plugins/arrow-flight-rpc/docs/backpressure.md
+++ b/plugins/arrow-flight-rpc/docs/backpressure.md
@@ -1,0 +1,133 @@
+# Producer Back-Pressure
+
+`FlightServerChannel.sendResponseBatch` honours gRPC's `isReady()` contract: the
+producer thread parks on `BackpressureStrategy.waitForListener` before each batch
+is queued, and resumes only once gRPC reports the per-stream outbound buffer has
+drained below `setOnReadyThreshold`. Slow consumers throttle producer wall-clock
+rather than allowing buffers to accumulate to the point of allocator OOM.
+
+## Why the eventloop queue exists
+
+Multiple producer threads may call `channel.sendResponseBatch(...)` concurrently
+on the same stream (concurrent segment search, parallel batch generation). Arrow
+Flight's `ServerStreamListener.putNext` is **not** safe for concurrent calls and
+the contract requires `start → putNext × N → completed` in strict order on a
+single thread; out-of-order or interleaved calls corrupt the stream.
+
+Each `FlightServerChannel` therefore funnels submissions through a per-channel
+single-threaded executor (the "eventloop"). Producer threads enqueue
+`BatchTask`s; the eventloop dequeues them and performs the actual zero-copy
+transfer plus `putNext`. This serialises ordering without making producer threads
+contend on a per-channel mutex.
+
+The back-pressure gate runs on the producer thread *before* the eventloop
+submission, so a slow consumer throttles allocation rather than letting the
+queue grow.
+
+## Settings
+
+| Setting | Default | Property |
+|---|---|---|
+| `arrow.flight.channel.ready_timeout` | `60s` | node-scope |
+| `arrow.flight.channel.outbound_buffer_threshold` | `64mb` | node-scope |
+
+- `ready_timeout` caps how long the producer thread parks before failing the
+  batch with `StreamErrorCode.TIMED_OUT`. `100ms` minimum.
+- `outbound_buffer_threshold` is the per-stream gRPC buffered-bytes watermark.
+  `isReady()` flips false once the per-stream outbound queue crosses this size.
+  **Must be strictly smaller than `native.allocator.pool.flight.max`** so the
+  gate engages before the allocator runs out (typical headroom: ~16 MiB).
+
+## Operator-facing behaviour
+
+### Fast consumer (steady state)
+The readiness check is essentially free: the producer's call to
+`awaitReadyOrThrow` returns immediately because gRPC's outbound buffer stays
+below threshold.
+
+### Slow consumer
+- `isReady()` flips false once gRPC's per-stream outbound buffered-bytes crosses
+  the threshold. The producer's next `sendResponseBatch` parks.
+- gRPC fires `OnReadyHandler` after the consumer drains some bytes from the wire
+  (HTTP/2 `WINDOW_UPDATE` arriving). The producer wakes and resumes.
+- Sustained slowness for longer than `ready_timeout` causes the batch to fail
+  with `TIMED_OUT`; the producer thread is freed and the stream terminates.
+
+### Cancellation
+Client-cancel propagates via gRPC's `OnCancelHandler` into the strategy's cancel
+callback. Any thread parked on `waitForListener` wakes promptly with
+`StreamErrorCode.CANCELLED`.
+
+## Tuning and operational concerns
+
+### Sizing the flight pool
+
+`native.allocator.pool.flight.max` is **per node**, shared across all active
+streams. `outbound_buffer_threshold` is **per stream**. Rule of thumb:
+
+```
+flight pool max  >=  N concurrent streams × (threshold + ~16 MiB headroom)
+```
+
+For N=10 concurrent streams at the default 64 MiB threshold, that's roughly
+800 MiB. The threshold itself is a watermark, not a max-message-size — a single
+batch larger than the threshold ships in one shot, with the producer parking on
+the next `sendResponseBatch`. The hard constraint on per-batch size is the pool
+cap (allocation must fit).
+
+### Thread-pool exhaustion under slow consumers
+
+The producer thread parks while waiting for the consumer. The action handler
+runs on whichever thread pool it was registered against (typically `SEARCH` or
+`GENERIC`); under N concurrent slow streams, N threads from that pool are
+parked simultaneously. Once the pool is exhausted, new requests targeting it
+queue up or are rejected.
+
+Mitigations:
+- Size `ready_timeout` to fail unresponsive streams within an acceptable window.
+- Register stream actions on a pool sized for streaming workloads (not on
+  shared CPU-bound pools): a pool of K threads both bounds concurrent streams
+  to K and isolates the parking from unrelated traffic. A dedicated
+  admission-control layer is a more flexible alternative, out of scope here.
+
+### ⚠️ Known limitation: unbounded eventloop queue
+
+`awaitReadyOrThrow` checks `listener.isReady()`, which reflects only gRPC's
+per-stream outbound buffer. The actual push to gRPC happens later, on the
+per-channel eventloop, when the eventloop dequeues a `BatchTask` and calls
+`putNext`. Between enqueue and `putNext`, the in-flight batch sits in our own
+queue — invisible to gRPC, so `isReady()` doesn't account for it.
+
+Implication: a producer that allocates batches significantly faster than the
+eventloop drains can pile up retained batches in the queue *before* gRPC's
+outbound crosses the threshold and `isReady()` flips false. The flight pool
+allocator can be pushed past `outbound_buffer_threshold` by roughly the size
+of the queued-but-not-yet-pushed batches. The current `flight pool max` sizing
+guidance (threshold + ~16 MiB headroom per stream) absorbs typical bursts but
+doesn't formally bound this.
+
+A byte-aware bounded queue at the eventloop entry — that parks (or rejects)
+the producer when the sum of queued batch sizes crosses a per-channel cap —
+would close the gap. Open design questions:
+
+- **Cap dimension**: byte-aware (sum of retained sizes) vs depth-aware (count).
+  Bytes is correct for OOM protection.
+- **Mechanism**: park the producer at enqueue (mirrors `awaitReadyOrThrow`'s
+  shape; same thread-pool-exhaustion caveat applies) vs reject with
+  `RESOURCE_EXHAUSTED`.
+- **Sizing**: per-channel cap (independent) vs carve from a shared per-node
+  budget tied to `flight pool max`.
+
+Tracked separately; not addressed in this change.
+
+### ⚠️ Virtual threads for park-bound producers
+
+> **For workloads where the producer is mostly bottlenecked on
+> `awaitReadyOrThrow` (lots of parking, little compute per batch), the code
+> that registers the stream action can dispatch its handler on a virtual-thread
+> executor it owns.** Park time then doesn't consume a platform thread.
+> CPU-bound work (e.g. building each batch) should still run on a sized
+> platform-thread pool to avoid pinning the carrier — typically by submitting
+> that work to a separate executor and awaiting the result from the virtual
+> thread. The framework itself does not assume virtual threads; this is a
+> decision for the action's registrant.

--- a/plugins/arrow-flight-rpc/docs/server-side-streaming-guide.md
+++ b/plugins/arrow-flight-rpc/docs/server-side-streaming-guide.md
@@ -82,6 +82,7 @@ flowchart TD
 ### Blocking
 - `sendResponseBatch()` may block if transport buffers are full
 - Server will pause until client consumes data and frees buffer space
+- See [backpressure.md](backpressure.md) for behaviour, settings, and sizing.
 
 ### Cancellation
 - `sendResponseBatch()` throws `StreamException` with `StreamErrorCode.CANCELLED` when client cancels

--- a/plugins/arrow-flight-rpc/src/internalClusterTest/java/org/opensearch/arrow/flight/BackpressureProducerIT.java
+++ b/plugins/arrow-flight-rpc/src/internalClusterTest/java/org/opensearch/arrow/flight/BackpressureProducerIT.java
@@ -1,0 +1,337 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.arrow.flight;
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.vector.IntVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.opensearch.Version;
+import org.opensearch.action.ActionRequest;
+import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.action.ActionType;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.TransportAction;
+import org.opensearch.arrow.allocator.ArrowBasePlugin;
+import org.opensearch.arrow.allocator.ArrowNativeAllocator;
+import org.opensearch.arrow.flight.bootstrap.ServerConfig;
+import org.opensearch.arrow.flight.transport.FlightStreamPlugin;
+import org.opensearch.arrow.spi.NativeAllocatorPoolConfig;
+import org.opensearch.arrow.transport.ArrowBatchResponse;
+import org.opensearch.arrow.transport.ArrowBatchResponseHandler;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.common.inject.Inject;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.action.ActionResponse;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.common.unit.ByteSizeUnit;
+import org.opensearch.core.common.unit.ByteSizeValue;
+import org.opensearch.plugins.ActionPlugin;
+import org.opensearch.plugins.Plugin;
+import org.opensearch.plugins.PluginInfo;
+import org.opensearch.tasks.Task;
+import org.opensearch.test.OpenSearchIntegTestCase;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.StreamTransportService;
+import org.opensearch.transport.TransportChannel;
+import org.opensearch.transport.TransportException;
+import org.opensearch.transport.TransportRequestOptions;
+import org.opensearch.transport.stream.StreamTransportResponse;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.opensearch.common.util.FeatureFlags.STREAM_TRANSPORT;
+
+/**
+ * Verifies producer-side back-pressure under a slow consumer. The producer parks on
+ * gRPC's {@code isReady()} once the per-stream outbound buffer crosses
+ * {@code arrow.flight.channel.outbound_buffer_threshold} so the flight pool stays
+ * within bounds and the stream completes cleanly. Producer wall-clock must reflect
+ * the consumer's pacing, evidence that the producer was throttled rather than
+ * racing ahead.
+ */
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, minNumDataNodes = 2, maxNumDataNodes = 2)
+public class BackpressureProducerIT extends OpenSearchIntegTestCase {
+
+    private static final long MB = 1024L * 1024L;
+
+    /** 8× the gRPC threshold — comfortable headroom for any in-flight queue overshoot
+     *  between when {@code isReady()} flips false and when the producer next observes it. */
+    private static final long FLIGHT_POOL_CAP_BYTES = 64 * MB;
+
+    /** Set well below the pool cap so {@code isReady()} flips before the allocator runs out. */
+    private static final long GRPC_THRESHOLD_BYTES = 8 * MB;
+
+    private static final int BATCH_COUNT = 64;
+    private static final int ROWS_PER_BATCH = 256 * 1024; // ~1 MiB per batch
+    private static final long CONSUMER_SLEEP_MS = 200;
+    /** Per-batch producer compute paces allocation comfortably below gRPC's drain rate
+     *  so the eventloop's queue never grows beyond a handful of batches between gate checks. */
+    private static final long PRODUCER_SLEEP_MS = 50;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        internalCluster().ensureAtLeastNumDataNodes(2);
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return List.of(BackpressureTestPlugin.class, ArrowBasePlugin.class);
+    }
+
+    @Override
+    protected Collection<PluginInfo> additionalNodePlugins() {
+        return List.of(
+            new PluginInfo(
+                FlightStreamPlugin.class.getName(),
+                "classpath plugin",
+                "NA",
+                Version.CURRENT,
+                "1.8",
+                FlightStreamPlugin.class.getName(),
+                null,
+                List.of(ArrowBasePlugin.class.getName()),
+                false
+            )
+        );
+    }
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return Settings.builder()
+            .put(super.nodeSettings(nodeOrdinal))
+            .put("node.native_memory.limit", "512mb")
+            .put(NativeAllocatorPoolConfig.SETTING_ROOT_LIMIT, 256 * MB)
+            .put(NativeAllocatorPoolConfig.SETTING_FLIGHT_MAX, FLIGHT_POOL_CAP_BYTES)
+            .put(NativeAllocatorPoolConfig.SETTING_INGEST_MAX, 16 * MB)
+            .put(NativeAllocatorPoolConfig.SETTING_QUERY_MAX, 16 * MB)
+            .put(ServerConfig.FLIGHT_OUTBOUND_BUFFER_THRESHOLD.getKey(), new ByteSizeValue(GRPC_THRESHOLD_BYTES, ByteSizeUnit.BYTES))
+            .build();
+    }
+
+    @LockFeatureFlag(STREAM_TRANSPORT)
+    public void testSlowConsumerStreamCompletesUnderBackpressure() throws Exception {
+        DiscoveryNode targetNode = pickRemoteDataNode();
+        StreamTransportService sts = internalCluster().getInstance(StreamTransportService.class);
+
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        AtomicInteger batchesReceived = new AtomicInteger(0);
+
+        long startNanos = System.nanoTime();
+        sts.sendRequest(
+            targetNode,
+            BackpressureTestAction.NAME,
+            new BackpressureTestRequest(BATCH_COUNT, ROWS_PER_BATCH, PRODUCER_SLEEP_MS),
+            TransportRequestOptions.builder().withType(TransportRequestOptions.Type.STREAM).build(),
+            new ArrowBatchResponseHandler<BackpressureTestResponse>() {
+                @Override
+                public void handleStreamResponse(StreamTransportResponse<BackpressureTestResponse> stream) {
+                    try {
+                        BackpressureTestResponse response;
+                        while ((response = stream.nextResponse()) != null) {
+                            try (VectorSchemaRoot root = response.getRoot()) {
+                                batchesReceived.incrementAndGet();
+                            }
+                            // Slow consumer drives gRPC's outbound past the threshold so
+                            // the producer must park rather than race ahead.
+                            Thread.sleep(CONSUMER_SLEEP_MS);
+                        }
+                        stream.close();
+                    } catch (Exception e) {
+                        failure.compareAndSet(null, e);
+                        stream.cancel("consumer error", e);
+                    } finally {
+                        latch.countDown();
+                    }
+                }
+
+                @Override
+                public void handleException(TransportException exp) {
+                    failure.compareAndSet(null, exp);
+                    latch.countDown();
+                }
+
+                @Override
+                public String executor() {
+                    return ThreadPool.Names.GENERIC;
+                }
+
+                @Override
+                public BackpressureTestResponse read(StreamInput in) throws IOException {
+                    return new BackpressureTestResponse(in);
+                }
+            }
+        );
+
+        assertTrue("Stream should finish within 90s", latch.await(90, TimeUnit.SECONDS));
+        assertNull("Producer must not surface any failure under back-pressure: " + failure.get(), failure.get());
+
+        long elapsedMillis = (System.nanoTime() - startNanos) / 1_000_000;
+        assertEquals("All batches must arrive successfully under back-pressure", BATCH_COUNT, batchesReceived.get());
+
+        // Wall-clock must reflect consumer pacing — without back-pressure the producer
+        // would race ahead and finish near-instantly relative to the consumer's sleep
+        // budget. 0.4x absorbs startup jitter and CI variance without false negatives.
+        long minExpectedMillis = (long) ((BATCH_COUNT * CONSUMER_SLEEP_MS) * 0.4);
+        assertTrue(
+            "Wall-clock " + elapsedMillis + "ms must reflect consumer pacing (>=" + minExpectedMillis + "ms)",
+            elapsedMillis >= minExpectedMillis
+        );
+    }
+
+    private DiscoveryNode pickRemoteDataNode() {
+        String localName = internalCluster().getInstance(StreamTransportService.class).getLocalNode().getName();
+        for (DiscoveryNode node : getClusterState().nodes()) {
+            if (!node.getName().equals(localName) && node.isDataNode()) {
+                return node;
+            }
+        }
+        throw new AssertionError("No remote data node found");
+    }
+
+    // ── action / request / response / plugin ──
+
+    public static final Schema SCHEMA = new Schema(List.of(new Field("value", FieldType.nullable(new ArrowType.Int(32, true)), null)));
+
+    public static class BackpressureTestResponse extends ArrowBatchResponse {
+        public BackpressureTestResponse(VectorSchemaRoot root) {
+            super(root);
+        }
+
+        public BackpressureTestResponse(StreamInput in) throws IOException {
+            super(in);
+        }
+    }
+
+    public static class BackpressureTestRequest extends ActionRequest {
+        private final int batchCount;
+        private final int rowsPerBatch;
+        private final long perBatchSleepMillis;
+
+        public BackpressureTestRequest(int batchCount, int rowsPerBatch, long perBatchSleepMillis) {
+            this.batchCount = batchCount;
+            this.rowsPerBatch = rowsPerBatch;
+            this.perBatchSleepMillis = perBatchSleepMillis;
+        }
+
+        public BackpressureTestRequest(StreamInput in) throws IOException {
+            super(in);
+            this.batchCount = in.readInt();
+            this.rowsPerBatch = in.readInt();
+            this.perBatchSleepMillis = in.readLong();
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            out.writeInt(batchCount);
+            out.writeInt(rowsPerBatch);
+            out.writeLong(perBatchSleepMillis);
+        }
+
+        @Override
+        public ActionRequestValidationException validate() {
+            return null;
+        }
+    }
+
+    public static class BackpressureTestAction extends ActionType<BackpressureTestResponse> {
+        public static final BackpressureTestAction INSTANCE = new BackpressureTestAction();
+        public static final String NAME = "cluster:internal/test/backpressure_producer";
+
+        private BackpressureTestAction() {
+            super(NAME, BackpressureTestResponse::new);
+        }
+    }
+
+    public static class TransportBackpressureTestAction extends TransportAction<BackpressureTestRequest, BackpressureTestResponse> {
+        private final BufferAllocator allocator;
+
+        @Inject
+        public TransportBackpressureTestAction(
+            StreamTransportService streamTransportService,
+            ActionFilters actionFilters,
+            ArrowNativeAllocator nativeAllocator
+        ) {
+            super(BackpressureTestAction.NAME, actionFilters, streamTransportService.getTaskManager());
+            this.allocator = nativeAllocator.getPoolAllocator(NativeAllocatorPoolConfig.POOL_FLIGHT)
+                .newChildAllocator("backpressure-it", 0, Long.MAX_VALUE);
+            streamTransportService.registerRequestHandler(
+                BackpressureTestAction.NAME,
+                ThreadPool.Names.GENERIC,
+                BackpressureTestRequest::new,
+                this::handleStreamRequest
+            );
+        }
+
+        @Override
+        protected void doExecute(Task task, BackpressureTestRequest request, ActionListener<BackpressureTestResponse> listener) {
+            listener.onFailure(new UnsupportedOperationException("Use StreamTransportService"));
+        }
+
+        private void handleStreamRequest(BackpressureTestRequest request, TransportChannel channel, Task task) throws IOException {
+            try {
+                for (int b = 0; b < request.batchCount; b++) {
+                    if (request.perBatchSleepMillis > 0) {
+                        try {
+                            Thread.sleep(request.perBatchSleepMillis);
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                            throw new IOException("interrupted", e);
+                        }
+                    }
+                    VectorSchemaRoot root = VectorSchemaRoot.create(SCHEMA, allocator);
+                    boolean transferred = false;
+                    try {
+                        IntVector v = (IntVector) root.getVector("value");
+                        v.allocateNew(request.rowsPerBatch);
+                        for (int i = 0; i < request.rowsPerBatch; i++) {
+                            v.setSafe(i, i);
+                        }
+                        root.setRowCount(request.rowsPerBatch);
+                        channel.sendResponseBatch(new BackpressureTestResponse(root));
+                        transferred = true;
+                    } finally {
+                        if (!transferred) {
+                            root.close();
+                        }
+                    }
+                }
+                channel.completeStream();
+            } catch (Exception e) {
+                channel.sendResponse(e);
+            }
+        }
+    }
+
+    public static class BackpressureTestPlugin extends Plugin implements ActionPlugin {
+        public BackpressureTestPlugin() {}
+
+        @Override
+        public List<ActionHandler<? extends ActionRequest, ? extends ActionResponse>> getActions() {
+            return List.of(new ActionHandler<>(BackpressureTestAction.INSTANCE, TransportBackpressureTestAction.class));
+        }
+    }
+}

--- a/plugins/arrow-flight-rpc/src/main/java/org/apache/arrow/flight/OSFlightServer.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/apache/arrow/flight/OSFlightServer.java
@@ -57,8 +57,10 @@ import org.apache.arrow.util.Preconditions;
 public class OSFlightServer {
     /** The maximum size of an individual gRPC message. This effectively disables the limit. */
     static final int MAX_GRPC_MESSAGE_SIZE = Integer.MAX_VALUE;
-    /** The default number of bytes that can be queued on an output stream before blocking. */
-    static final int DEFAULT_BACKPRESSURE_THRESHOLD = 10 * 1024 * 1024; // 10MB
+    /** Default per-stream outbound buffered-bytes threshold; can be overridden via
+     *  {@code arrow.flight.channel.outbound_buffer_threshold}. See
+     *  {@code docs/backpressure.md} for sizing guidance. */
+    static final int DEFAULT_BACKPRESSURE_THRESHOLD = 64 * 1024 * 1024; // 64MB
 
     private static final MethodHandle FLIGHT_SERVER_CTOR_MH;
 

--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/bootstrap/ServerConfig.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/bootstrap/ServerConfig.java
@@ -14,6 +14,8 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.transport.PortsRange;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.concurrent.OpenSearchExecutors;
+import org.opensearch.core.common.unit.ByteSizeUnit;
+import org.opensearch.core.common.unit.ByteSizeValue;
 import org.opensearch.threadpool.ScalingExecutorBuilder;
 
 import java.security.AccessController;
@@ -145,6 +147,33 @@ public class ServerConfig {
         Setting.Property.NodeScope
     );
 
+    /**
+     * Maximum time the producer thread parks in {@code FlightServerChannel.awaitReadyOrThrow}
+     * before failing the batch with
+     * {@link org.opensearch.transport.stream.StreamErrorCode#TIMED_OUT}.
+     */
+    public static final Setting<TimeValue> FLIGHT_READY_TIMEOUT = Setting.timeSetting(
+        "arrow.flight.channel.ready_timeout",
+        TimeValue.timeValueSeconds(60),
+        TimeValue.timeValueMillis(100),
+        Setting.Property.NodeScope
+    );
+
+    /**
+     * Per-stream outbound buffered-bytes threshold passed to gRPC's
+     * {@code setOnReadyThreshold}. {@code isReady()} flips false once the per-stream
+     * outbound buffer crosses this size; the producer parks on that signal. Set this
+     * strictly below {@code native.allocator.pool.flight.max} so the gate engages
+     * before the allocator runs out.
+     */
+    public static final Setting<ByteSizeValue> FLIGHT_OUTBOUND_BUFFER_THRESHOLD = Setting.byteSizeSetting(
+        "arrow.flight.channel.outbound_buffer_threshold",
+        new ByteSizeValue(64, ByteSizeUnit.MB),
+        new ByteSizeValue(1, ByteSizeUnit.MB),
+        new ByteSizeValue(2, ByteSizeUnit.GB),
+        Setting.Property.NodeScope
+    );
+
     static final Setting<Integer> FLIGHT_EVENT_LOOP_THREADS = Setting.intSetting(
         "flight.event_loop.threads",
         Math.max(1, NettyRuntime.availableProcessors() * 2),
@@ -262,7 +291,9 @@ public class ServerConfig {
                 ARROW_ENABLE_UNSAFE_MEMORY_ACCESS,
                 ARROW_SSL_ENABLE,
                 FLIGHT_EVENT_LOOP_THREADS,
-                FLIGHT_THREAD_POOL_MIN_SIZE
+                FLIGHT_THREAD_POOL_MIN_SIZE,
+                FLIGHT_READY_TIMEOUT,
+                FLIGHT_OUTBOUND_BUFFER_THRESHOLD
             )
         );
     }

--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/ArrowFlightProducer.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/ArrowFlightProducer.java
@@ -28,6 +28,9 @@ import java.util.concurrent.ExecutorService;
 
 /**
  * FlightProducer implementation for handling Arrow Flight requests.
+ *
+ * <p>Each call constructs a {@link FlightServerChannel} that gates batch submission on
+ * gRPC's {@code isReady()} via the channel's {@link FlightServerChannel#awaitReadyOrThrow()}.
  */
 class ArrowFlightProducer extends NoOpFlightProducer {
     private final BufferAllocator allocator;
@@ -37,12 +40,14 @@ class ArrowFlightProducer extends NoOpFlightProducer {
     private final FlightServerMiddleware.Key<ServerHeaderMiddleware> middlewareKey;
     private final FlightStatsCollector statsCollector;
     private final ExecutorService executor;
+    private final long readyTimeoutMillis;
 
     public ArrowFlightProducer(
         FlightTransport flightTransport,
         BufferAllocator allocator,
         FlightServerMiddleware.Key<ServerHeaderMiddleware> middlewareKey,
-        FlightStatsCollector statsCollector
+        FlightStatsCollector statsCollector,
+        long readyTimeoutMillis
     ) {
         this.threadPool = flightTransport.getThreadPool();
         this.requestHandlers = flightTransport.getRequestHandlers();
@@ -51,6 +56,7 @@ class ArrowFlightProducer extends NoOpFlightProducer {
         this.allocator = allocator;
         this.statsCollector = statsCollector;
         this.executor = threadPool.executor(ServerConfig.FLIGHT_SERVER_THREAD_POOL_NAME);
+        this.readyTimeoutMillis = readyTimeoutMillis;
     }
 
     @Override
@@ -66,7 +72,8 @@ class ArrowFlightProducer extends NoOpFlightProducer {
                 allocator,
                 middleware,
                 callTracker,
-                flightTransport.getNextFlightExecutor()
+                flightTransport.getNextFlightExecutor(),
+                readyTimeoutMillis
             );
             try {
                 BytesArray buf = new BytesArray(ticket.getBytes());

--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/CompositeBackpressureStrategy.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/CompositeBackpressureStrategy.java
@@ -1,0 +1,87 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.arrow.flight.transport;
+
+import org.apache.arrow.flight.BackpressureStrategy;
+import org.apache.arrow.flight.FlightProducer.ServerStreamListener;
+
+/**
+ * {@link BackpressureStrategy} that fixes a known race in Arrow's
+ * {@code CallbackBackpressureStrategy} (apache/arrow-java#346): that strategy reads
+ * {@code listener.isReady()} twice — once as the wait-loop predicate, then again
+ * post-loop to decide which {@code WaitResult} to return. gRPC mutates
+ * {@code isReady()} from Netty event-loop threads outside the strategy's lock, so
+ * the two reads can disagree (e.g. predicate sees {@code true} and exits, post-loop
+ * sees {@code false} after another producer's write re-filled the outbound buffer),
+ * producing {@code "Invalid state when waiting for listener"} runtime exceptions.
+ *
+ * <p>This implementation reads {@code listener.isReady()} and
+ * {@code listener.isCancelled()} once per loop iteration inside the lock and commits
+ * to those values — there is no second read to disagree with. The handlers'
+ * {@code notifyAll()} simply wakes the waiter so the next iteration reads fresh.
+ *
+ * <p>Composes channel-level cancel cleanup: the cancel callback runs the channel's
+ * cleanup (e.g. marking cancelled, releasing resources) before notifying parked
+ * waiters, so a thread waking from {@code waitForListener} always observes the
+ * channel in cancelled state.
+ */
+final class CompositeBackpressureStrategy implements BackpressureStrategy {
+
+    private final Object lock = new Object();
+    private final Runnable channelCancelCleanup;
+    private ServerStreamListener listener;
+
+    CompositeBackpressureStrategy(Runnable channelCancelCleanup) {
+        this.channelCancelCleanup = channelCancelCleanup;
+    }
+
+    @Override
+    public void register(ServerStreamListener listener) {
+        this.listener = listener;
+        listener.setOnReadyHandler(() -> {
+            synchronized (lock) {
+                lock.notifyAll();
+            }
+        });
+        listener.setOnCancelHandler(() -> {
+            try {
+                channelCancelCleanup.run();
+            } finally {
+                synchronized (lock) {
+                    lock.notifyAll();
+                }
+            }
+        });
+    }
+
+    @Override
+    public WaitResult waitForListener(long timeoutMillis) {
+        long deadline = System.currentTimeMillis() + timeoutMillis;
+        synchronized (lock) {
+            while (true) {
+                if (listener.isCancelled()) {
+                    return WaitResult.CANCELLED;
+                }
+                if (listener.isReady()) {
+                    return WaitResult.READY;
+                }
+                long remaining = deadline - System.currentTimeMillis();
+                if (remaining <= 0) {
+                    return WaitResult.TIMEOUT;
+                }
+                try {
+                    lock.wait(remaining);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    return WaitResult.OTHER;
+                }
+            }
+        }
+    }
+}

--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightOutboundHandler.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightOutboundHandler.java
@@ -131,6 +131,12 @@ class FlightOutboundHandler extends ProtocolOutboundHandler {
             return;
         }
 
+        // Block the producer thread before queuing the batch so a slow consumer throttles
+        // allocation rather than letting the eventloop's queue grow. Note: isReady()
+        // reflects only gRPC's outbound buffer, not our own queue depth — see
+        // docs/backpressure.md "Known limitation: unbounded eventloop queue".
+        flightChannel.awaitReadyOrThrow();
+
         flightChannel.getExecutor().execute(threadPool.getThreadContext().preserveContext(() -> {
             try (BatchTask ignored = task) {
                 processBatchTask(task);

--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightServerChannel.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightServerChannel.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.arrow.flight.transport;
 
+import org.apache.arrow.flight.BackpressureStrategy;
 import org.apache.arrow.flight.CallStatus;
 import org.apache.arrow.flight.FlightProducer.ServerStreamListener;
 import org.apache.arrow.flight.FlightRuntimeException;
@@ -36,8 +37,14 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static org.opensearch.arrow.flight.transport.FlightErrorMapper.mapFromCallStatus;
 
 /**
- * TcpChannel implementation for Arrow Flight. It is created per call in ArrowFlightProducer.
- * This implementation is not thread safe; consumer must ensure to invoke sendBatch serially and call completeStream() at the end
+ * TcpChannel implementation for Arrow Flight. Created per call in {@link ArrowFlightProducer}.
+ *
+ * <p>Honours gRPC's {@code isReady()} contract via {@link CompositeBackpressureStrategy}:
+ * producer threads call {@link #awaitReadyOrThrow()} before {@code sendBatch} is queued
+ * and park until gRPC's outbound buffer drains below {@code setOnReadyThreshold}.
+ *
+ * <p>This implementation is not thread safe; the producer must invoke {@code sendBatch}
+ * serially and call {@code completeStream()} at the end.
  */
 class FlightServerChannel implements TcpChannel, ArrowFlightChannel {
     private static final String PROFILE_NAME = "flight";
@@ -56,29 +63,74 @@ class FlightServerChannel implements TcpChannel, ArrowFlightChannel {
     private final ExecutorService executor;
     private final long correlationId;
     private final AtomicInteger batchNumber = new AtomicInteger(0);
+    private final CompositeBackpressureStrategy bp;
+    private final long readyTimeoutMillis;
 
     public FlightServerChannel(
         ServerStreamListener serverStreamListener,
         BufferAllocator allocator,
         ServerHeaderMiddleware middleware,
         FlightCallTracker callTracker,
-        ExecutorService executor
+        ExecutorService executor,
+        long readyTimeoutMillis
     ) {
         this.correlationId = Long.parseLong(middleware.getCorrelationId());
         logger.debug("Creating FlightServerChannel for correlation ID: {}", correlationId);
         this.serverStreamListener = serverStreamListener;
         this.serverStreamListener.setUseZeroCopy(true);
-        this.serverStreamListener.setOnCancelHandler(() -> {
-            cancelled = true;
-            callTracker.recordCallEnd(StreamErrorCode.CANCELLED.name());
-            close();
-        });
         this.allocator = allocator;
         this.middleware = middleware;
         this.callTracker = callTracker;
         this.executor = executor;
+        this.readyTimeoutMillis = readyTimeoutMillis;
         this.localAddress = new InetSocketAddress(InetAddress.getLoopbackAddress(), 0);
         this.remoteAddress = new InetSocketAddress(InetAddress.getLoopbackAddress(), 0);
+        // CompositeBackpressureStrategy.register installs both setOnReadyHandler and
+        // setOnCancelHandler; the cancel callback runs onChannelCancelled before
+        // notifying parked threads so the cancelled state is visible on wake.
+        this.bp = new CompositeBackpressureStrategy(this::onChannelCancelled);
+        this.bp.register(serverStreamListener);
+    }
+
+    /**
+     * Parks the calling thread until gRPC signals it can accept another batch. Called
+     * from the producer thread before the batch is submitted to the channel's executor.
+     *
+     * <p><b>Warning:</b> the calling thread may park for up to {@code readyTimeoutMillis}
+     * under a slow consumer. If the action handler is registered on a bounded thread
+     * pool (e.g. {@code SEARCH}), N concurrent slow streams will hold N threads parked
+     * simultaneously and can starve the pool. Operators should size the action's thread
+     * pool — or limit concurrent streams via admission control — accordingly.
+     *
+     * @throws StreamException with {@link StreamErrorCode#TIMED_OUT} if the consumer
+     *         remains not-ready longer than {@code readyTimeoutMillis}, or
+     *         {@link StreamErrorCode#CANCELLED} if the client cancelled.
+     */
+    public void awaitReadyOrThrow() {
+        if (cancelled) {
+            throw StreamException.cancelled("stream cancelled before back-pressure wait");
+        }
+        BackpressureStrategy.WaitResult result = bp.waitForListener(readyTimeoutMillis);
+        switch (result) {
+            case READY:
+                return;
+            case CANCELLED:
+                throw StreamException.cancelled("stream cancelled while waiting for consumer");
+            case TIMEOUT:
+                throw new StreamException(StreamErrorCode.TIMED_OUT, "consumer not ready after " + readyTimeoutMillis + "ms");
+            default:
+                logger.warn("unexpected back-pressure wait result: {}", result);
+                throw new StreamException(StreamErrorCode.INTERNAL, "unexpected back-pressure wait result: " + result);
+        }
+    }
+
+    /** Idempotent cleanup invoked from the strategy when gRPC fires {@code OnCancelHandler}. */
+    private void onChannelCancelled() {
+        if (!cancelled) {
+            cancelled = true;
+            callTracker.recordCallEnd(StreamErrorCode.CANCELLED.name());
+            close();
+        }
     }
 
     public BufferAllocator getAllocator() {

--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightTransport.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightTransport.java
@@ -163,7 +163,13 @@ class FlightTransport extends TcpTransport {
                 statsCollector.setBufferAllocator(flightPool);
                 statsCollector.setThreadPool(threadPool);
             }
-            flightProducer = new ArrowFlightProducer(this, flightPool, SERVER_HEADER_KEY, statsCollector);
+            flightProducer = new ArrowFlightProducer(
+                this,
+                flightPool,
+                SERVER_HEADER_KEY,
+                statsCollector,
+                ServerConfig.FLIGHT_READY_TIMEOUT.get(settings).millis()
+            );
             bindServer();
             success = true;
             if (statsCollector != null) {
@@ -242,6 +248,7 @@ class FlightTransport extends TcpTransport {
                     .bossEventLoopGroup(bossEventLoopGroup)
                     .workerEventLoopGroup(workerEventLoopGroup)
                     .executor(serverExecutor)
+                    .backpressureThreshold((int) ServerConfig.FLIGHT_OUTBOUND_BUFFER_THRESHOLD.get(settings).getBytes())
                     .middleware(SERVER_HEADER_KEY, factory);
 
                 builder.location(locations.get(0));

--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightTransportChannel.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightTransportChannel.java
@@ -104,14 +104,15 @@ class FlightTransportChannel extends TcpTransportChannel implements ArrowFlightC
                 isHandshake
             );
         } catch (StreamException e) {
+            // Cancelled: consumer is gone, release ends the call cleanly. For other
+            // failures (e.g. TIMED_OUT from the back-pressure gate) leave the channel
+            // open so the handler can call channel.sendResponse(e) to relay the error
+            // to the consumer; sendResponse releases on its own.
             if (e.getErrorCode() == StreamErrorCode.CANCELLED) {
                 release(true);
-                throw e;
             }
-            release(true);
             throw e;
         } catch (Exception e) {
-            release(true);
             throw new StreamException(StreamErrorCode.INTERNAL, "Error sending response batch", e);
         }
     }

--- a/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/bootstrap/ServerConfigTests.java
+++ b/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/bootstrap/ServerConfigTests.java
@@ -9,6 +9,8 @@ package org.opensearch.arrow.flight.bootstrap;
 
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
+import org.opensearch.core.common.unit.ByteSizeUnit;
+import org.opensearch.core.common.unit.ByteSizeValue;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.ScalingExecutorBuilder;
 
@@ -67,6 +69,8 @@ public class ServerConfigTests extends OpenSearchTestCase {
         assertTrue(settings.contains(ServerConfig.ARROW_ENABLE_UNSAFE_MEMORY_ACCESS));
         assertTrue(settings.contains(ServerConfig.ARROW_ENABLE_DEBUG_ALLOCATOR));
         assertTrue(settings.contains(ServerConfig.ARROW_SSL_ENABLE));
+        assertTrue(settings.contains(ServerConfig.FLIGHT_READY_TIMEOUT));
+        assertTrue(settings.contains(ServerConfig.FLIGHT_OUTBOUND_BUFFER_THRESHOLD));
     }
 
     public void testDefaultSettings() {
@@ -80,5 +84,34 @@ public class ServerConfigTests extends OpenSearchTestCase {
         assertTrue(ServerConfig.ARROW_ENABLE_UNSAFE_MEMORY_ACCESS.get(defaultSettings));
         assertFalse(ServerConfig.ARROW_ENABLE_DEBUG_ALLOCATOR.get(defaultSettings));
         assertFalse(ServerConfig.ARROW_SSL_ENABLE.get(defaultSettings));
+        assertEquals(TimeValue.timeValueSeconds(60), ServerConfig.FLIGHT_READY_TIMEOUT.get(defaultSettings));
+        assertEquals(64L * 1024 * 1024, ServerConfig.FLIGHT_OUTBOUND_BUFFER_THRESHOLD.get(defaultSettings).getBytes());
+    }
+
+    public void testBackpressureSettingsParse() {
+        Settings overridden = Settings.builder()
+            .put(ServerConfig.FLIGHT_READY_TIMEOUT.getKey(), TimeValue.timeValueSeconds(5))
+            .put(ServerConfig.FLIGHT_OUTBOUND_BUFFER_THRESHOLD.getKey(), new ByteSizeValue(16, ByteSizeUnit.MB))
+            .build();
+        assertEquals(TimeValue.timeValueSeconds(5), ServerConfig.FLIGHT_READY_TIMEOUT.get(overridden));
+        assertEquals(16L * 1024 * 1024, ServerConfig.FLIGHT_OUTBOUND_BUFFER_THRESHOLD.get(overridden).getBytes());
+    }
+
+    public void testReadyTimeoutMinimum() {
+        // 100ms minimum is enforced; lower values must be rejected at parse.
+        Settings tooLow = Settings.builder().put(ServerConfig.FLIGHT_READY_TIMEOUT.getKey(), TimeValue.timeValueMillis(50)).build();
+        expectThrows(IllegalArgumentException.class, () -> ServerConfig.FLIGHT_READY_TIMEOUT.get(tooLow));
+    }
+
+    public void testOutboundBufferThresholdBounds() {
+        Settings tooLow = Settings.builder()
+            .put(ServerConfig.FLIGHT_OUTBOUND_BUFFER_THRESHOLD.getKey(), new ByteSizeValue(512, ByteSizeUnit.KB))
+            .build();
+        expectThrows(IllegalArgumentException.class, () -> ServerConfig.FLIGHT_OUTBOUND_BUFFER_THRESHOLD.get(tooLow));
+
+        Settings tooHigh = Settings.builder()
+            .put(ServerConfig.FLIGHT_OUTBOUND_BUFFER_THRESHOLD.getKey(), new ByteSizeValue(3, ByteSizeUnit.GB))
+            .build();
+        expectThrows(IllegalArgumentException.class, () -> ServerConfig.FLIGHT_OUTBOUND_BUFFER_THRESHOLD.get(tooHigh));
     }
 }

--- a/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/CompositeBackpressureStrategyTests.java
+++ b/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/CompositeBackpressureStrategyTests.java
@@ -1,0 +1,195 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.arrow.flight.transport;
+
+import org.apache.arrow.flight.BackpressureStrategy;
+import org.apache.arrow.flight.FlightProducer.ServerStreamListener;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class CompositeBackpressureStrategyTests extends OpenSearchTestCase {
+
+    /**
+     * register(listener) must install both onReady and onCancel handlers on the listener.
+     * The channel's own setOnCancelHandler is intentionally NOT called by the channel —
+     * the strategy owns it, and channel cleanup runs via the composed cancelCallback.
+     */
+    public void testRegisterInstallsBothHandlers() {
+        ServerStreamListener listener = mock(ServerStreamListener.class);
+        AtomicReference<Runnable> capturedReadyHandler = new AtomicReference<>();
+        AtomicReference<Runnable> capturedCancelHandler = new AtomicReference<>();
+
+        doAnswer(inv -> {
+            capturedReadyHandler.set(inv.getArgument(0));
+            return null;
+        }).when(listener).setOnReadyHandler(any(Runnable.class));
+
+        doAnswer(inv -> {
+            capturedCancelHandler.set(inv.getArgument(0));
+            return null;
+        }).when(listener).setOnCancelHandler(any(Runnable.class));
+
+        CompositeBackpressureStrategy bp = new CompositeBackpressureStrategy(() -> {});
+        bp.register(listener);
+
+        assertNotNull("onReadyHandler must be installed", capturedReadyHandler.get());
+        assertNotNull("onCancelHandler must be installed", capturedCancelHandler.get());
+    }
+
+    /**
+     * waitForListener must return READY immediately when the listener is already ready.
+     */
+    public void testWaitForListenerReadyFastPath() {
+        ServerStreamListener listener = mock(ServerStreamListener.class);
+        when(listener.isReady()).thenReturn(true);
+        when(listener.isCancelled()).thenReturn(false);
+
+        CompositeBackpressureStrategy bp = new CompositeBackpressureStrategy(() -> {});
+        bp.register(listener);
+
+        long start = System.nanoTime();
+        BackpressureStrategy.WaitResult result = bp.waitForListener(5_000);
+        long elapsedMillis = (System.nanoTime() - start) / 1_000_000;
+
+        assertEquals(BackpressureStrategy.WaitResult.READY, result);
+        assertTrue("Fast path must not park (elapsed=" + elapsedMillis + "ms)", elapsedMillis < 100);
+    }
+
+    /**
+     * Firing the captured onReadyHandler must wake a thread parked in waitForListener.
+     * Simulates gRPC's OnReadyHandler firing while the eventloop is parked.
+     */
+    public void testReadyHandlerWakesWaiter() throws Exception {
+        ServerStreamListener listener = mock(ServerStreamListener.class);
+        AtomicBoolean ready = new AtomicBoolean(false);
+        when(listener.isReady()).thenAnswer(inv -> ready.get());
+        when(listener.isCancelled()).thenReturn(false);
+
+        AtomicReference<Runnable> readyHandler = new AtomicReference<>();
+        doAnswer(inv -> {
+            readyHandler.set(inv.getArgument(0));
+            return null;
+        }).when(listener).setOnReadyHandler(any(Runnable.class));
+
+        CompositeBackpressureStrategy bp = new CompositeBackpressureStrategy(() -> {});
+        bp.register(listener);
+
+        CountDownLatch waiterEntered = new CountDownLatch(1);
+        AtomicReference<BackpressureStrategy.WaitResult> result = new AtomicReference<>();
+        Thread waiter = new Thread(() -> {
+            waiterEntered.countDown();
+            result.set(bp.waitForListener(30_000));
+        }, "waiter");
+        waiter.start();
+        assertTrue(waiterEntered.await(2, TimeUnit.SECONDS));
+        assertBusy(() -> assertEquals(Thread.State.TIMED_WAITING, waiter.getState()), 2, TimeUnit.SECONDS);
+
+        ready.set(true);
+        readyHandler.get().run();
+
+        waiter.join(2_000);
+        assertFalse("Waiter must have exited", waiter.isAlive());
+        assertEquals(BackpressureStrategy.WaitResult.READY, result.get());
+    }
+
+    /**
+     * The composed cancel callback must run channel cleanup BEFORE notifying waiters,
+     * so any thread that wakes observes the channel in its cancelled state.
+     * Also verifies cleanup runs exactly once per cancel.
+     */
+    public void testCancelCallbackRunsCleanupBeforeNotify() throws Exception {
+        ServerStreamListener listener = mock(ServerStreamListener.class);
+        AtomicBoolean cancelled = new AtomicBoolean(false);
+        when(listener.isReady()).thenReturn(false);
+        when(listener.isCancelled()).thenAnswer(inv -> cancelled.get());
+
+        AtomicReference<Runnable> cancelHandler = new AtomicReference<>();
+        doAnswer(inv -> {
+            cancelHandler.set(inv.getArgument(0));
+            return null;
+        }).when(listener).setOnCancelHandler(any(Runnable.class));
+
+        AtomicInteger cleanupCount = new AtomicInteger();
+        AtomicBoolean cleanupRanWhileWaiterStillSleeping = new AtomicBoolean(false);
+
+        CompositeBackpressureStrategy bp = new CompositeBackpressureStrategy(() -> {
+            cleanupCount.incrementAndGet();
+            // Channel cleanup flips the cancelled flag the strategy will observe on wake.
+            cancelled.set(true);
+            cleanupRanWhileWaiterStillSleeping.set(true);
+        });
+        bp.register(listener);
+
+        CountDownLatch waiterEntered = new CountDownLatch(1);
+        AtomicReference<BackpressureStrategy.WaitResult> result = new AtomicReference<>();
+        Thread waiter = new Thread(() -> {
+            waiterEntered.countDown();
+            result.set(bp.waitForListener(30_000));
+        }, "waiter");
+        waiter.start();
+        assertTrue(waiterEntered.await(2, TimeUnit.SECONDS));
+        assertBusy(() -> assertEquals(Thread.State.TIMED_WAITING, waiter.getState()), 2, TimeUnit.SECONDS);
+
+        // Fire the cancel handler — this is what gRPC would do on client cancel.
+        cancelHandler.get().run();
+
+        waiter.join(2_000);
+        assertFalse("Waiter must have exited", waiter.isAlive());
+        assertEquals(BackpressureStrategy.WaitResult.CANCELLED, result.get());
+        assertEquals("cleanup must run exactly once", 1, cleanupCount.get());
+        assertTrue("cleanup must have run before notify woke the waiter", cleanupRanWhileWaiterStillSleeping.get());
+    }
+
+    /**
+     * gRPC's OnReadyHandler fires only on transitions (not-ready → ready), not on every
+     * isReady()==true state. Once the listener is ready, multiple successive
+     * waitForListener calls must all see READY without waiting for a fresh handler firing.
+     */
+    public void testRepeatedWaitsReturnReadyWithoutRehandler() {
+        ServerStreamListener listener = mock(ServerStreamListener.class);
+        when(listener.isReady()).thenReturn(true);
+        when(listener.isCancelled()).thenReturn(false);
+
+        CompositeBackpressureStrategy bp = new CompositeBackpressureStrategy(() -> {});
+        bp.register(listener);
+
+        for (int i = 0; i < 5; i++) {
+            assertEquals("call #" + i, BackpressureStrategy.WaitResult.READY, bp.waitForListener(5_000));
+        }
+    }
+
+    /**
+     * waitForListener must return TIMEOUT when neither ready nor cancelled fires within the timeout.
+     */
+    public void testWaitForListenerTimeout() {
+        ServerStreamListener listener = mock(ServerStreamListener.class);
+        when(listener.isReady()).thenReturn(false);
+        when(listener.isCancelled()).thenReturn(false);
+
+        CompositeBackpressureStrategy bp = new CompositeBackpressureStrategy(() -> {});
+        bp.register(listener);
+
+        long start = System.nanoTime();
+        BackpressureStrategy.WaitResult result = bp.waitForListener(100);
+        long elapsedMillis = (System.nanoTime() - start) / 1_000_000;
+
+        assertEquals(BackpressureStrategy.WaitResult.TIMEOUT, result);
+        assertTrue("Should wait approximately the timeout (elapsed=" + elapsedMillis + "ms)", elapsedMillis >= 90);
+    }
+}

--- a/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/FlightOutboundHandlerTests.java
+++ b/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/FlightOutboundHandlerTests.java
@@ -344,6 +344,78 @@ public class FlightOutboundHandlerTests extends OpenSearchTestCase {
         assertSame("Error should be passed to listener", completeError, capturedError.get());
     }
 
+    // --- Back-pressure path: gating on the producer thread before executor submit ---
+
+    /**
+     * sendResponseBatch must call {@code awaitReadyOrThrow} on the producer thread
+     * BEFORE submitting the BatchTask to the executor — that is what throttles
+     * allocation under a slow consumer.
+     */
+    public void testSendResponseBatchGatesBeforeExecutor() throws Exception {
+        java.util.concurrent.atomic.AtomicBoolean awaitCalled = new java.util.concurrent.atomic.AtomicBoolean(false);
+        doAnswer(inv -> {
+            awaitCalled.set(true);
+            return null;
+        }).when(mockFlightChannel).awaitReadyOrThrow();
+
+        CountDownLatch executorRan = new CountDownLatch(1);
+        doAnswer(invocation -> {
+            executorRan.countDown();
+            return null;
+        }).when(mockListener).onResponseSent(anyLong(), anyString(), any(TransportResponse.class));
+
+        handler.sendResponseBatch(
+            Version.CURRENT,
+            Collections.emptySet(),
+            mockFlightChannel,
+            mock(FlightTransportChannel.class),
+            1L,
+            "test-action",
+            mock(TransportResponse.class),
+            false,
+            false
+        );
+
+        // sendResponseBatch returns only after the gate has run.
+        assertTrue("awaitReadyOrThrow must run before sendResponseBatch returns", awaitCalled.get());
+        assertTrue("Executor task should complete", executorRan.await(5, TimeUnit.SECONDS));
+        verify(mockFlightChannel).awaitReadyOrThrow();
+    }
+
+    /**
+     * If awaitReadyOrThrow throws (timeout / cancellation), the StreamException must
+     * propagate to the caller — sendResponseBatch must NOT submit the BatchTask, and
+     * NOT silently swallow the failure.
+     */
+    public void testSendResponseBatchPropagatesAwaitReadyException() {
+        ExecutorService submitTrap = mock(ExecutorService.class);
+        when(mockFlightChannel.getExecutor()).thenReturn(submitTrap);
+
+        org.opensearch.transport.stream.StreamException timeoutEx = new org.opensearch.transport.stream.StreamException(
+            org.opensearch.transport.stream.StreamErrorCode.TIMED_OUT,
+            "consumer not ready"
+        );
+        doThrow(timeoutEx).when(mockFlightChannel).awaitReadyOrThrow();
+
+        org.opensearch.transport.stream.StreamException thrown = expectThrows(
+            org.opensearch.transport.stream.StreamException.class,
+            () -> handler.sendResponseBatch(
+                Version.CURRENT,
+                Collections.emptySet(),
+                mockFlightChannel,
+                mock(FlightTransportChannel.class),
+                1L,
+                "test-action",
+                mock(TransportResponse.class),
+                false,
+                false
+            )
+        );
+        assertSame(timeoutEx, thrown);
+        // Crucially: we must not have submitted the BatchTask after the gate failed.
+        verify(submitTrap, org.mockito.Mockito.never()).execute(any());
+    }
+
     public void testBatchTaskCloseWithIsErrorCallsReleaseChannelWithTrue() {
         FlightTransportChannel mockTransportChannel = mock(FlightTransportChannel.class);
 

--- a/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/FlightServerChannelTests.java
+++ b/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/FlightServerChannelTests.java
@@ -1,0 +1,252 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.arrow.flight.transport;
+
+import org.apache.arrow.flight.FlightProducer.ServerStreamListener;
+import org.apache.arrow.memory.BufferAllocator;
+import org.opensearch.arrow.flight.stats.FlightCallTracker;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.transport.stream.StreamErrorCode;
+import org.opensearch.transport.stream.StreamException;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class FlightServerChannelTests extends OpenSearchTestCase {
+
+    private ServerStreamListener listener;
+    private BufferAllocator allocator;
+    private ServerHeaderMiddleware middleware;
+    private FlightCallTracker callTracker;
+    private ExecutorService executor;
+    private AtomicBoolean ready;
+    private AtomicBoolean listenerCancelled;
+    private AtomicReference<Runnable> capturedReadyHandler;
+    private AtomicReference<Runnable> capturedCancelHandler;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        listener = mock(ServerStreamListener.class);
+        allocator = mock(BufferAllocator.class);
+        middleware = mock(ServerHeaderMiddleware.class);
+        when(middleware.getCorrelationId()).thenReturn("42");
+        callTracker = mock(FlightCallTracker.class);
+        executor = Executors.newSingleThreadExecutor();
+
+        ready = new AtomicBoolean(false);
+        listenerCancelled = new AtomicBoolean(false);
+        when(listener.isReady()).thenAnswer(inv -> ready.get());
+        when(listener.isCancelled()).thenAnswer(inv -> listenerCancelled.get());
+
+        capturedReadyHandler = new AtomicReference<>();
+        capturedCancelHandler = new AtomicReference<>();
+        doAnswer(inv -> {
+            capturedReadyHandler.set(inv.getArgument(0));
+            return null;
+        }).when(listener).setOnReadyHandler(any(Runnable.class));
+        doAnswer(inv -> {
+            capturedCancelHandler.set(inv.getArgument(0));
+            return null;
+        }).when(listener).setOnCancelHandler(any(Runnable.class));
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        executor.shutdownNow();
+        executor.awaitTermination(5, TimeUnit.SECONDS);
+        super.tearDown();
+    }
+
+    private FlightServerChannel newChannel(long readyTimeoutMillis) {
+        return new FlightServerChannel(listener, allocator, middleware, callTracker, executor, readyTimeoutMillis);
+    }
+
+    public void testAwaitReadyFastPath() {
+        ready.set(true);
+        FlightServerChannel ch = newChannel(5_000);
+
+        long start = System.nanoTime();
+        ch.awaitReadyOrThrow();
+        long elapsedMs = (System.nanoTime() - start) / 1_000_000;
+
+        assertTrue("Fast path must not park (elapsed=" + elapsedMs + "ms)", elapsedMs < 100);
+    }
+
+    public void testAwaitReadyParksUntilOnReadyFires() throws Exception {
+        ready.set(false);
+        FlightServerChannel ch = newChannel(30_000);
+
+        CountDownLatch waiterEntered = new CountDownLatch(1);
+        AtomicReference<Throwable> waiterError = new AtomicReference<>();
+        Thread waiter = new Thread(() -> {
+            waiterEntered.countDown();
+            try {
+                ch.awaitReadyOrThrow();
+            } catch (Throwable t) {
+                waiterError.set(t);
+            }
+        }, "producer-waiter");
+        waiter.start();
+        assertTrue(waiterEntered.await(2, TimeUnit.SECONDS));
+        assertBusy(() -> assertEquals(Thread.State.TIMED_WAITING, waiter.getState()), 2, TimeUnit.SECONDS);
+
+        ready.set(true);
+        capturedReadyHandler.get().run();
+
+        waiter.join(2_000);
+        assertFalse("Waiter must have exited", waiter.isAlive());
+        assertNull("awaitReadyOrThrow must return normally on READY", waiterError.get());
+    }
+
+    public void testAwaitReadyTimeoutThrowsTimedOut() {
+        ready.set(false);
+        FlightServerChannel ch = newChannel(100);
+
+        StreamException ex = expectThrows(StreamException.class, ch::awaitReadyOrThrow);
+        assertEquals(StreamErrorCode.TIMED_OUT, ex.getErrorCode());
+        assertTrue("Message should reference the timeout", ex.getMessage().contains("100ms"));
+
+        // TIMED_OUT does not run channel cleanup. The handler is expected to relay the
+        // exception via channel.sendResponse(e), and FlightServerChannel.sendError records
+        // the call end. Without that relay, no recordCallEnd would happen here — that is
+        // the contract, and is verified end-to-end via the handler/transport-channel paths.
+        verify(callTracker, org.mockito.Mockito.never()).recordCallEnd(any());
+        assertTrue("channel must remain open after timeout — handler may still relay", ch.isOpen());
+    }
+
+    /**
+     * Cancellation while a producer thread is parked must wake it with a CANCELLED
+     * StreamException AND run the channel's onChannelCancelled cleanup (recordCallEnd, close).
+     */
+    public void testCancelWhileWaitingThrowsAndRunsChannelCleanup() throws Exception {
+        ready.set(false);
+        FlightServerChannel ch = newChannel(30_000);
+
+        CountDownLatch waiterEntered = new CountDownLatch(1);
+        AtomicReference<Throwable> waiterError = new AtomicReference<>();
+        Thread waiter = new Thread(() -> {
+            waiterEntered.countDown();
+            try {
+                ch.awaitReadyOrThrow();
+            } catch (Throwable t) {
+                waiterError.set(t);
+            }
+        }, "producer-waiter");
+        waiter.start();
+        assertTrue(waiterEntered.await(2, TimeUnit.SECONDS));
+        assertBusy(() -> assertEquals(Thread.State.TIMED_WAITING, waiter.getState()), 2, TimeUnit.SECONDS);
+
+        listenerCancelled.set(true);
+        capturedCancelHandler.get().run();
+
+        waiter.join(2_000);
+        assertFalse("Waiter must have exited", waiter.isAlive());
+
+        Throwable t = waiterError.get();
+        assertNotNull("waiter must have thrown", t);
+        assertTrue("must be StreamException, got " + t, t instanceof StreamException);
+        assertEquals(StreamErrorCode.CANCELLED, ((StreamException) t).getErrorCode());
+
+        verify(callTracker).recordCallEnd(StreamErrorCode.CANCELLED.name());
+        assertFalse("channel must be closed after cancel", ch.isOpen());
+    }
+
+    public void testAwaitReadyOnAlreadyCancelledChannelThrows() {
+        ready.set(false);
+        FlightServerChannel ch = newChannel(30_000);
+
+        listenerCancelled.set(true);
+        capturedCancelHandler.get().run();
+
+        long start = System.nanoTime();
+        StreamException ex = expectThrows(StreamException.class, ch::awaitReadyOrThrow);
+        long elapsedMs = (System.nanoTime() - start) / 1_000_000;
+
+        assertEquals(StreamErrorCode.CANCELLED, ex.getErrorCode());
+        assertTrue("Already-cancelled path must not park (elapsed=" + elapsedMs + "ms)", elapsedMs < 100);
+    }
+
+    /**
+     * All concurrent producer threads parked in {@code awaitReadyOrThrow} must wake on a
+     * single cancel — none should be left hanging until {@code readyTimeoutMillis}.
+     * The channel cleanup ({@code recordCallEnd}, close) must run exactly once.
+     */
+    public void testCancelWakesAllParkedProducers() throws Exception {
+        ready.set(false);
+        FlightServerChannel ch = newChannel(30_000);
+
+        int n = 4;
+        CountDownLatch entered = new CountDownLatch(n);
+        List<AtomicReference<Throwable>> errors = new ArrayList<>(n);
+        List<Thread> waiters = new ArrayList<>(n);
+        for (int i = 0; i < n; i++) {
+            AtomicReference<Throwable> err = new AtomicReference<>();
+            errors.add(err);
+            Thread w = new Thread(() -> {
+                entered.countDown();
+                try {
+                    ch.awaitReadyOrThrow();
+                } catch (Throwable t) {
+                    err.set(t);
+                }
+            }, "producer-waiter-" + i);
+            waiters.add(w);
+            w.start();
+        }
+        assertTrue(entered.await(2, TimeUnit.SECONDS));
+        for (Thread w : waiters) {
+            assertBusy(() -> assertEquals(Thread.State.TIMED_WAITING, w.getState()), 2, TimeUnit.SECONDS);
+        }
+
+        listenerCancelled.set(true);
+        capturedCancelHandler.get().run();
+
+        for (Thread w : waiters) {
+            w.join(2_000);
+            assertFalse("Waiter " + w.getName() + " must have exited", w.isAlive());
+        }
+        for (AtomicReference<Throwable> err : errors) {
+            Throwable t = err.get();
+            assertNotNull("each waiter must have thrown", t);
+            assertTrue("must be StreamException, got " + t, t instanceof StreamException);
+            assertEquals(StreamErrorCode.CANCELLED, ((StreamException) t).getErrorCode());
+        }
+        // Channel cleanup must be invoked exactly once even though N threads observed cancel.
+        verify(callTracker, org.mockito.Mockito.times(1)).recordCallEnd(StreamErrorCode.CANCELLED.name());
+    }
+
+    /**
+     * After a cancel, subsequent {@code awaitReadyOrThrow} calls must throw immediately
+     * — even if the underlying listener somehow reports {@code isReady()==true}. The
+     * channel's own cancelled flag short-circuits before we consult the strategy.
+     */
+    public void testAwaitReadyAfterCancelStaysCancelled() {
+        ready.set(true); // intentionally true to ensure the channel-level guard wins
+        FlightServerChannel ch = newChannel(30_000);
+
+        listenerCancelled.set(true);
+        capturedCancelHandler.get().run();
+
+        StreamException ex = expectThrows(StreamException.class, ch::awaitReadyOrThrow);
+        assertEquals(StreamErrorCode.CANCELLED, ex.getErrorCode());
+    }
+}

--- a/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/FlightTransportChannelTests.java
+++ b/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/FlightTransportChannelTests.java
@@ -131,6 +131,10 @@ public class FlightTransportChannelTests extends OpenSearchTestCase {
     }
 
     public void testSendResponseBatchWithGenericException() throws IOException {
+        // Non-cancel exceptions must NOT release the channel here — the handler is
+        // expected to call channel.sendResponse(e) to relay the failure to the consumer,
+        // and that path releases on its own. Releasing prematurely would close the
+        // underlying TcpChannel and break the relay.
         TransportResponse response = mock(TransportResponse.class);
         RuntimeException genericException = new RuntimeException("generic error");
 
@@ -141,8 +145,23 @@ public class FlightTransportChannelTests extends OpenSearchTestCase {
         assertEquals(StreamErrorCode.INTERNAL, thrown.getErrorCode());
         assertEquals("Error sending response batch", thrown.getMessage());
         assertEquals(genericException, thrown.getCause());
-        verify(mockTcpChannel).close();
-        verify(mockReleasable).close();
+        verify(mockTcpChannel, org.mockito.Mockito.never()).close();
+        verify(mockReleasable, org.mockito.Mockito.never()).close();
+    }
+
+    public void testSendResponseBatchWithNonCancelStreamExceptionDoesNotRelease() throws IOException {
+        // Same contract for non-cancel StreamException (e.g. TIMED_OUT from awaitReadyOrThrow):
+        // the channel stays open so the handler's sendResponse(e) can relay to the consumer.
+        TransportResponse response = mock(TransportResponse.class);
+        StreamException timedOut = new StreamException(StreamErrorCode.TIMED_OUT, "consumer not ready");
+
+        doThrow(timedOut).when(mockOutboundHandler)
+            .sendResponseBatch(any(), any(), any(), any(), anyLong(), any(), any(), anyBoolean(), anyBoolean());
+
+        StreamException thrown = assertThrows(StreamException.class, () -> channel.sendResponseBatch(response));
+        assertSame(timedOut, thrown);
+        verify(mockTcpChannel, org.mockito.Mockito.never()).close();
+        verify(mockReleasable, org.mockito.Mockito.never()).close();
     }
 
     public void testCompleteStreamSuccess() {


### PR DESCRIPTION
## Summary

`FlightServerChannel.sendResponseBatch` now honours gRPC's `isReady()` contract: the producer thread parks on `BackpressureStrategy.waitForListener` before each batch is queued, and resumes only after gRPC reports the per-stream outbound buffer has drained below `setOnReadyThreshold`. Slow consumers throttle producer wall-clock instead of OOMing the flight pool.

## Context

3.1 used `BaseFlightProducer` with a synchronous `BackpressureStrategy.waitForListener` gate before every `putNext`. When we moved to the async/queue model (`flight-eventloop-N` + `FlightOutboundHandler.BatchTask`), the goal was to match the existing OpenSearch transport's fire-and-forget shape — producer enqueues quickly and returns, ordering is enforced by a single-threaded eventloop. That solved the concurrent-segment-search contention problem (multiple producer threads writing to one channel without serialising on a per-channel mutex), but in doing so we dropped the `isReady()` gate. Without it, the unguarded path ignored gRPC's flow-control signal and let buffers accumulate until the flight pool allocator threw `OutOfMemoryException`.

This PR restores the gate without giving up the async fire-and-forget shape. `awaitReadyOrThrow` runs **on the producer thread before** the `BatchTask` is submitted to the eventloop. The eventloop and its single-threaded ordering guarantees are unchanged.

## What changed

- `FlightServerChannel` registers a `CompositeBackpressureStrategy` and exposes `awaitReadyOrThrow()`. The strategy's cancel callback runs the channel's existing `onChannelCancelled` cleanup before notifying parked threads, so a thread waking from `waitForListener` always observes the cancelled state.
- `FlightOutboundHandler.sendResponseBatch` calls `awaitReadyOrThrow()` before `getExecutor().execute(...)`.
- `CompositeBackpressureStrategy` implements `BackpressureStrategy` directly rather than extending Arrow's `CallbackBackpressureStrategy`, which has a known race ([apache/arrow-java#346](https://github.com/apache/arrow-java/issues/346)): it reads `listener.isReady()` twice — once as the wait-loop predicate, then again post-loop to decide which `WaitResult` to return — and gRPC mutates that flag from Netty event-loop threads outside the strategy's lock, so the two reads can disagree (`"Invalid state when waiting for listener"`). This implementation reads `listener.isReady()` and `listener.isCancelled()` once per loop iteration inside the lock; the handlers' `notifyAll()` simply wakes the waiter so the next iteration reads fresh.
- New settings `arrow.flight.channel.outbound_buffer_threshold` (default 64 MiB) and `arrow.flight.channel.ready_timeout` (default 60s, 100ms minimum). The threshold is wired through to `OSFlightServer.Builder.backpressureThreshold`.

## Settings

| Setting | Default | Behaviour |
|---|---|---|
| `arrow.flight.channel.ready_timeout` | `60s` | Maximum time the producer parks before failing the batch with `StreamErrorCode.TIMED_OUT`. |
| `arrow.flight.channel.outbound_buffer_threshold` | `64mb` | Per-stream gRPC watermark. **Must be strictly smaller than `native.allocator.pool.flight.max`.** |

## Tuning and operational concerns

### Sizing the flight pool

`outbound_buffer_threshold` is **per stream**; `native.allocator.pool.flight.max` is **per node**, shared across all streams.

```
flight pool max  >=  N concurrent streams × (threshold + ~16 MiB headroom)
```

The threshold is a watermark, not a max-message-size — a single batch larger than the threshold ships in one shot, with the producer parking on the next `sendResponseBatch`. See [docs/backpressure.md](plugins/arrow-flight-rpc/docs/backpressure.md) for full sizing guidance.

### Thread-pool exhaustion under slow consumers

The producer thread **parks** under a slow consumer (up to `ready_timeout`). The action handler runs on whichever thread pool it was registered against; N concurrent slow streams hold N threads parked simultaneously, which can starve the pool.

Mitigations:
- Size `ready_timeout` to fail unresponsive streams within an acceptable window.
- Register stream actions on a pool sized for streaming workloads (not on shared CPU-bound pools): a pool of K threads both bounds concurrent streams to K and isolates the parking from unrelated traffic. A dedicated admission-control layer is a more flexible alternative, out of scope here.

### ⚠️ Virtual threads for park-bound producers

> **For workloads where the producer is mostly bottlenecked on `awaitReadyOrThrow` (lots of parking, little compute per batch), the code that registers the stream action can dispatch its handler on a virtual-thread executor it owns.** Park time then doesn't consume a platform thread. CPU-bound work (e.g. building each batch) should still run on a sized platform-thread pool to avoid pinning the carrier — typically by submitting that work to a separate executor and awaiting the result from the virtual thread. The framework itself does not assume virtual threads; this is a decision for the action's registrant.

## Tests

- `CompositeBackpressureStrategyTests` covers handler installation, fast path, ready-handler wakes a parked waiter, cancel-callback runs cleanup before notify, repeated waits return `READY` without a fresh handler firing (gRPC's `OnReadyHandler` is edge-triggered), and timeout.
- `FlightServerChannelTests` covers `awaitReadyOrThrow` fast path, parks-until-OnReady-fires, timeout, cancel-while-waiting + channel cleanup, already-cancelled, cancel-wakes-all-parked-producers (cleanup runs exactly once), post-cancel guard.
- `FlightOutboundHandlerTests` covers the `awaitReadyOrThrow` gating path.
- `ServerConfigTests` covers the new settings' parsing and bounds.
- `BackpressureProducerIT` exercises a slow consumer end-to-end; asserts the stream completes cleanly, all batches arrive, and producer wall-clock reflects consumer pacing (proves the producer was actually throttled).
- Concurrency-sensitive unit tests use `assertBusy` on `Thread.State.TIMED_WAITING` rather than fixed sleeps to avoid flakiness. Stable across multiple reruns.

Coverage on touched code: `CompositeBackpressureStrategy` 100%, `FlightServerChannel` 82%, `ArrowFlightProducer` 77%, `FlightOutboundHandler` 70%. Uncovered lines are pre-existing defensive paths.

## Test plan

- [x] `./gradlew :plugins:arrow-flight-rpc:test`
- [x] `./gradlew :plugins:arrow-flight-rpc:check -x internalClusterTest`
- [x] `./gradlew :plugins:arrow-flight-rpc:internalClusterTest --tests "*BackpressureProducerIT"` (stable across reruns)
- [x] `./gradlew :plugins:arrow-flight-rpc:jacocoTestReport`