### PR TITLE
Unmute CoordinatorReduceIT TAKE/LIST/VALUES tests

### DIFF
--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/CoordinatorReduceIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/CoordinatorReduceIT.java
@@ -8,7 +8,6 @@
 
 package org.opensearch.analytics.qa;
 
-import org.apache.lucene.tests.util.LuceneTestCase;
 import org.opensearch.client.Request;
 import org.opensearch.client.Response;
 
@@ -129,7 +128,6 @@ public class CoordinatorReduceIT extends AnalyticsRestTestCase {
     }
 
     /** Single-shard {@code take(value, 3)} — bounded array of up to 3 values. */
-    @LuceneTestCase.AwaitsFix(bugUrl = "broken")
     public void testTakeSingleShard() throws Exception {
         String index = "coord_reduce_take_single";
         createSingleShardParquetBackedIndex(index);
@@ -162,7 +160,6 @@ public class CoordinatorReduceIT extends AnalyticsRestTestCase {
     }
 
     /** Cross-shard {@code take(value, 5)} — coordinator unions per-shard arrays and truncates to 5. */
-    @LuceneTestCase.AwaitsFix(bugUrl = "broken")
     public void testTakeAcrossShards() throws Exception {
         String index = "coord_reduce_take_multi";
         createParquetBackedIndex(index);
@@ -303,7 +300,6 @@ public class CoordinatorReduceIT extends AnalyticsRestTestCase {
     }
 
     /** Cross-shard {@code list(value)} — coordinator concatenates per-shard lists via list_merge UDAF. */
-    @LuceneTestCase.AwaitsFix(bugUrl = "broken")
     public void testListAcrossShards() throws Exception {
         String index = "coord_reduce_list_multi";
         createParquetBackedIndex(index);
@@ -381,7 +377,6 @@ public class CoordinatorReduceIT extends AnalyticsRestTestCase {
     }
 
     /** Cross-shard {@code values(value)} — coordinator concatenates and re-deduplicates via list_merge_distinct UDAF. */
-    @LuceneTestCase.AwaitsFix(bugUrl = "broken")
     public void testValuesAcrossShards() throws Exception {
         String index = "coord_reduce_values_multi";
         createParquetBackedIndex(index);


### PR DESCRIPTION
These four tests were muted by #21774 right after #21731 added them. The aggCall slot / IntermediateField re-classification bug was fixed by #21875 (refactor distributed-aggregate rewriter); verified locally with -Dtests.iters=3 (12/12 pass).


### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
