### PR TITLE
analytics-engine: register delegation markers on all DataFusion sessions

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/session_context.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/session_context.rs
@@ -339,10 +339,10 @@ pub async unsafe fn create_session_context_indexed(
 ) -> Result<i64, DataFusionError> {
     let ptr = create_session_context(runtime_ptr, shard_view_ptr, table_name, context_id, query_config, plan_bytes).await?;
 
-    // Augment with indexed config and UDF registration
+    // Augment with indexed config. The delegation marker UDFs (index_filter, delegation_possible)
+    // are now registered for every session by udf::register_all (via create_session_context above);
+    // the indexed path additionally UNWRAPS them before execution.
     let handle = &mut *(ptr as *mut SessionContextHandle);
-    handle.ctx.register_udf(crate::indexed_table::substrait_to_tree::create_index_filter_udf());
-    handle.ctx.register_udf(crate::indexed_table::substrait_to_tree::create_delegation_possible_udf());
     handle.indexed_config = Some(IndexedExecutionConfig {
         tree_shape,
         delegated_predicate_count,

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/mod.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/mod.rs
@@ -205,6 +205,15 @@ pub fn register_all(ctx: &SessionContext) {
     time_format::register_all(ctx);
     width_bucket::register_all(ctx);
     reduce_eval::register_all(ctx);
+    // Delegation markers (index_filter = correctness-delegation, delegation_possible =
+    // performance-delegation). Calcite emits these into a shard filter's substrait; they are
+    // unwrapped/executed ONLY on the data-node indexed path. But every session must be able to
+    // PARSE them: a coordinator-reduce session derives the producer (shard) plan's output schema
+    // via derive_schema_from_partial_plan, which builds the producer's physical plan and fails on
+    // an unregistered function. Register here so all sessions can parse; the bodies still error if
+    // ever actually invoked (they never are off the indexed path).
+    ctx.register_udf(crate::indexed_table::substrait_to_tree::create_index_filter_udf());
+    ctx.register_udf(crate::indexed_table::substrait_to_tree::create_delegation_possible_udf());
     log::info!(
         "OpenSearch UDF register_all: convert_tz, conversion(numeric_conversion: num/auto/memk/rmcomma/rmunit/dur2sec/mstime, time_conversion: ctime/mktime), crc32, date_format, extract, from_unixtime, item, json_append, json_array_length, json_delete, json_extend, json_extract, json_extract_all, json_keys, json_set, makedate, maketime, minspan_bucket, mvappend, mvfind, mvzip, parse, range_bucket, rex_extract, rex_extract_multi, rex_offset, sha1, span_bucket, str_to_date, strftime, time_format, width_bucket registered"
     );

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/JoinCommandIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/JoinCommandIT.java
@@ -84,7 +84,6 @@ public class JoinCommandIT extends AnalyticsRestTestCase {
      * Left outer join. Drops one str0 value from the right side via a filter so
      * a subset of left rows have no match and appear with nulls on the right.
      */
-    @AwaitsFix(bugUrl = "Real opensearch-sql plugin: DataFusion fails with \"Not implemented: function delegation_possible\" - the opportunistic row-group-pruning marker UDF is not registered in the Rust context. Needs delegation_possible identity-UDF registration (rust fix, separate PR).")
     public void testLeftOuterJoin() throws IOException {
         final String ppl = "source="
             + CALCS.indexName
@@ -101,7 +100,6 @@ public class JoinCommandIT extends AnalyticsRestTestCase {
      * Right outer join — mirror of left outer. Drops a value from the LEFT side via a
      * filter so some right rows have no match and appear with nulls on the left.
      */
-    @AwaitsFix(bugUrl = "Real opensearch-sql plugin: DataFusion fails with \"Not implemented: function delegation_possible\" - the opportunistic row-group-pruning marker UDF is not registered in the Rust context. Needs delegation_possible identity-UDF registration (rust fix, separate PR).")
     public void testRightOuterJoin() throws IOException {
         final String ppl = "source="
             + CALCS.indexName
@@ -128,7 +126,6 @@ public class JoinCommandIT extends AnalyticsRestTestCase {
     }
 
     /** Left anti join — returns left rows with NO match on the right. */
-    @AwaitsFix(bugUrl = "Real opensearch-sql plugin: DataFusion fails with \"Not implemented: function delegation_possible\" - the opportunistic row-group-pruning marker UDF is not registered in the Rust context. Needs delegation_possible identity-UDF registration (rust fix, separate PR).")
     public void testLeftAntiJoin() throws IOException {
         final String ppl = "source="
             + CALCS.indexName

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/MultisearchCommandIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/MultisearchCommandIT.java
@@ -77,7 +77,7 @@ public class MultisearchCommandIT extends AnalyticsRestTestCase {
 
     // ── 3-way multisearch — the shape that triggered the substrait names bug ───
 
-    @AwaitsFix(bugUrl = "Real opensearch-sql plugin: DataFusion fails with \"Not implemented: function delegation_possible\" - the opportunistic row-group-pruning marker UDF is not registered in the Rust context. Needs delegation_possible identity-UDF registration (rust fix, separate PR).")
+    @AwaitsFix(bugUrl = "Real opensearch-sql plugin: multisearch 3-branch union | stats count by bucket returns wrong counts (expected 6, got 2) - union branch results are under-aggregated. Separate correctness bug; delegation_possible (the prior failure) is fixed.")
     public void testMultisearchThreeBranchesByStr0() throws IOException {
         // Three string-equality branches over the calcs str0 column. `str0` distribution is
         // FURNITURE=2, OFFICE SUPPLIES=6, TECHNOLOGY=9. The 3-way Union(ER, ER, ER) is the


### PR DESCRIPTION


<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
The delegation_possible / index_filter marker UDFs were registered only on shard scans. A coordinator-reduce session has a step to parse a producer (shard) plan to derive its output schema and failed with "Unsupported function name: delegation_possible". Register both markers in udf::register_all so every session can parse them; only the indexed data-node path ever unwraps/executes them.

Un-mutes JoinCommandIT left/right-outer + left-anti join tests.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
