### PR TITLE
Filter rule: respect nested scalar-function capabilities when computing viable backends

### DIFF
--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchFilterRule.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchFilterRule.java
@@ -148,11 +148,11 @@ public class OpenSearchFilterRule extends RelOptRule {
         List<FieldStorageInfo> fieldStorageInfos,
         List<String> childViableBackends
     ) {
-        PredicateAnalysis analysis = new PredicateAnalysis(new HashSet<>(), new ArrayList<>());
+        PredicateContents contents = new PredicateContents(new HashSet<>(), new ArrayList<>());
         for (RexNode operand : predicate.getOperands()) {
-            analyze(operand, analysis);
+            collect(operand, contents);
         }
-        Set<Integer> fieldIndices = analysis.fieldIndices();
+        Set<Integer> fieldIndices = contents.fieldIndices();
 
         CapabilityRegistry registry = context.getCapabilityRegistry();
 
@@ -213,7 +213,7 @@ public class OpenSearchFilterRule extends RelOptRule {
         }
 
         // Every nested scalar function in the predicate must also be evaluable by a candidate backend
-        for (RexCall scalarFunctionCall : analysis.scalarFunctionCalls()) {
+        for (RexCall scalarFunctionCall : contents.scalarFunctionCalls()) {
             // Calcite-internal value constructors (named-parameter MAP/ARRAY/ROW used by full-text
             // operators like match() to pass `field`, `query`, etc.) aren't real scalar functions
             // they're parameter-passing scaffolding. Skip them
@@ -282,18 +282,25 @@ public class OpenSearchFilterRule extends RelOptRule {
      *
      * <p>{@code fieldIndices} — RexInputRef indices feeding the field-storage intersection.
      * <p>{@code scalarFunctionCalls} — nested RexCalls feeding the scalar-function capability intersection.
+     *
+     * <p>TODO: refactor as part of a wider {@link #resolveViableBackends} cleanup. Today the method
+     * juggles four concerns (operand walk, no-field branching, per-field intersection, scalar-function
+     * intersection); the unknown-operator throws at the outer comparator and the nested scalar function
+     * duplicate the same lookup-and-throw shape, and the walker here mirrors {@code OpenSearchProjectRule}'s
+     * operand traversal. A unified visitor over the predicate tree, shared between filter and project
+     * rules, would consolidate all of this.
      */
-    private record PredicateAnalysis(Set<Integer> fieldIndices, List<RexCall> scalarFunctionCalls) {
+    private record PredicateContents(Set<Integer> fieldIndices, List<RexCall> scalarFunctionCalls) {
     }
 
-    /** Recurses the operand subtree, populating {@code analysis} in-place. */
-    private void analyze(RexNode node, PredicateAnalysis analysis) {
+    /** Recurses the operand subtree, populating {@code contents} in-place. */
+    private void collect(RexNode node, PredicateContents contents) {
         if (node instanceof RexInputRef inputRef) {
-            analysis.fieldIndices().add(inputRef.getIndex());
+            contents.fieldIndices().add(inputRef.getIndex());
         } else if (node instanceof RexCall rexCall) {
-            analysis.scalarFunctionCalls().add(rexCall);
+            contents.scalarFunctionCalls().add(rexCall);
             for (RexNode operand : rexCall.getOperands()) {
-                analyze(operand, analysis);
+                collect(operand, contents);
             }
         }
     }

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchFilterRule.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchFilterRule.java
@@ -283,12 +283,9 @@ public class OpenSearchFilterRule extends RelOptRule {
      * <p>{@code fieldIndices} — RexInputRef indices feeding the field-storage intersection.
      * <p>{@code scalarFunctionCalls} — nested RexCalls feeding the scalar-function capability intersection.
      *
-     * <p>TODO: refactor as part of a wider {@link #resolveViableBackends} cleanup. Today the method
-     * juggles four concerns (operand walk, no-field branching, per-field intersection, scalar-function
-     * intersection); the unknown-operator throws at the outer comparator and the nested scalar function
-     * duplicate the same lookup-and-throw shape, and the walker here mirrors {@code OpenSearchProjectRule}'s
-     * operand traversal. A unified visitor over the predicate tree, shared between filter and project
-     * rules, would consolidate all of this.
+     * <p>TODO: ensure that the code for tagging and checking the scalar function of a predicate
+     * remains the same as the code for tagging and checking its nested inner expressions as much
+     * as possible.
      */
     private record PredicateContents(Set<Integer> fieldIndices, List<RexCall> scalarFunctionCalls) {
     }

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchFilterRule.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchFilterRule.java
@@ -214,6 +214,13 @@ public class OpenSearchFilterRule extends RelOptRule {
 
         // Every nested scalar function in the predicate must also be evaluable by a candidate backend
         for (RexCall scalarFunctionCall : analysis.scalarFunctionCalls()) {
+            // Calcite-internal value constructors (named-parameter MAP/ARRAY/ROW used by full-text
+            // operators like match() to pass `field`, `query`, etc.) aren't real scalar functions
+            // they're parameter-passing scaffolding. Skip them
+            SqlKind kind = scalarFunctionCall.getKind();
+            if (kind == SqlKind.MAP_VALUE_CONSTRUCTOR || kind == SqlKind.ARRAY_VALUE_CONSTRUCTOR || kind == SqlKind.ROW) {
+                continue;
+            }
             ScalarFunction scalarFunc = ScalarFunction.fromSqlOperatorWithFallback(scalarFunctionCall.getOperator());
             if (scalarFunc == null) {
                 throw new IllegalStateException(

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchFilterRule.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchFilterRule.java
@@ -148,8 +148,11 @@ public class OpenSearchFilterRule extends RelOptRule {
         List<FieldStorageInfo> fieldStorageInfos,
         List<String> childViableBackends
     ) {
-        Set<Integer> fieldIndices = new HashSet<>();
-        collectFieldIndices(predicate, fieldIndices);
+        PredicateAnalysis analysis = new PredicateAnalysis(new HashSet<>(), new ArrayList<>());
+        for (RexNode operand : predicate.getOperands()) {
+            analyze(operand, analysis);
+        }
+        Set<Integer> fieldIndices = analysis.fieldIndices();
 
         CapabilityRegistry registry = context.getCapabilityRegistry();
 
@@ -209,6 +212,50 @@ public class OpenSearchFilterRule extends RelOptRule {
             viableSet.retainAll(fieldViable);
         }
 
+        // Every nested scalar function in the predicate must also be evaluable by a candidate backend
+        for (RexCall scalarFunctionCall : analysis.scalarFunctionCalls()) {
+            ScalarFunction scalarFunc = ScalarFunction.fromSqlOperatorWithFallback(scalarFunctionCall.getOperator());
+            if (scalarFunc == null) {
+                throw new IllegalStateException(
+                    "Unrecognized scalar function ["
+                        + scalarFunctionCall.getOperator().getName()
+                        + "] in call ["
+                        + scalarFunctionCall
+                        + "] within filter predicate ["
+                        + predicate
+                        + "]"
+                );
+            }
+            FieldType returnType = FieldType.fromSqlTypeName(scalarFunctionCall.getType().getSqlTypeName());
+            // Polymorphic UDF fallback (e.g. SCALAR_MAX/MIN return SqlTypeName.ANY): infer
+            // FieldType from the first concrete operand. Backend capabilities for these UDFs
+            // are declared over operand types, so this preserves correct dispatch — see
+            // OpenSearchProjectRule.resolveScalarViableBackends for the parallel fallback.
+            if (returnType == null) {
+                for (RexNode operand : scalarFunctionCall.getOperands()) {
+                    FieldType operandType = FieldType.fromSqlTypeName(operand.getType().getSqlTypeName());
+                    if (operandType != null) {
+                        returnType = operandType;
+                        break;
+                    }
+                }
+                if (returnType == null) {
+                    throw new IllegalStateException(
+                        "Unmapped return type ["
+                            + scalarFunctionCall.getType().getSqlTypeName()
+                            + "] for scalar function ["
+                            + scalarFunc
+                            + "] in call ["
+                            + scalarFunctionCall
+                            + "] within filter predicate ["
+                            + predicate
+                            + "]"
+                    );
+                }
+            }
+            viableSet.retainAll(registry.scalarBackendsAnyFormat(scalarFunc, returnType));
+        }
+
         if (viableSet.isEmpty()) {
             throw new IllegalStateException(
                 "No backend can evaluate filter predicate ["
@@ -223,13 +270,23 @@ public class OpenSearchFilterRule extends RelOptRule {
         return new ArrayList<>(viableSet);
     }
 
-    /** Extracts all field indices referenced by RexInputRef nodes in the expression. */
-    private void collectFieldIndices(RexNode node, Set<Integer> result) {
+    /**
+     * Result of a single walk over a predicate's operand subtree.
+     *
+     * <p>{@code fieldIndices} — RexInputRef indices feeding the field-storage intersection.
+     * <p>{@code scalarFunctionCalls} — nested RexCalls feeding the scalar-function capability intersection.
+     */
+    private record PredicateAnalysis(Set<Integer> fieldIndices, List<RexCall> scalarFunctionCalls) {
+    }
+
+    /** Recurses the operand subtree, populating {@code analysis} in-place. */
+    private void analyze(RexNode node, PredicateAnalysis analysis) {
         if (node instanceof RexInputRef inputRef) {
-            result.add(inputRef.getIndex());
+            analysis.fieldIndices().add(inputRef.getIndex());
         } else if (node instanceof RexCall rexCall) {
+            analysis.scalarFunctionCalls().add(rexCall);
             for (RexNode operand : rexCall.getOperands()) {
-                collectFieldIndices(operand, result);
+                analyze(operand, analysis);
             }
         }
     }

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/FilterRuleTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/FilterRuleTests.java
@@ -364,6 +364,39 @@ public class FilterRuleTests extends BasePlannerRulesTests {
     }
 
     /**
+     * Four-level nesting: {@code UPPER(CONCAT(UPPER(CONCAT(name, '_a')), '_b')) = 'FOO'}.
+     * Confirms the walk recurses through arbitrary depth; Lucene drops at any level it can't evaluate.
+     */
+    public void testDeeplyNestedScalarFunctionsDropLucene() {
+        RelDataType varchar = typeFactory.createSqlType(SqlTypeName.VARCHAR);
+        RexNode level4 = rexBuilder.makeCall(
+            SqlStdOperatorTable.CONCAT,
+            rexBuilder.makeInputRef(varchar, 0),
+            rexBuilder.makeLiteral("_a")
+        );
+        RexNode level3 = rexBuilder.makeCall(SqlStdOperatorTable.UPPER, level4);
+        RexNode level2 = rexBuilder.makeCall(SqlStdOperatorTable.CONCAT, level3, rexBuilder.makeLiteral("_b"));
+        RexNode level1 = rexBuilder.makeCall(SqlStdOperatorTable.UPPER, level2);
+        RexNode predicate = rexBuilder.makeCall(SqlStdOperatorTable.EQUALS, level1, rexBuilder.makeLiteral("FOO"));
+
+        OpenSearchFilter result = runFilter(
+            "parquet",
+            Map.of("name", Map.of("type", "keyword", "index", true)),
+            new String[] { "name" },
+            new SqlTypeName[] { SqlTypeName.VARCHAR },
+            predicate
+        );
+
+        AnnotatedPredicate annotated = (AnnotatedPredicate) result.getCondition();
+        assertEquals("Only DataFusion remains viable", 1, annotated.getViableBackends().size());
+        assertTrue(annotated.getViableBackends().contains(MockDataFusionBackend.NAME));
+        assertFalse(
+            "Lucene must be excluded across deeply nested scalar-function calls",
+            annotated.getViableBackends().contains(MockLuceneBackend.NAME)
+        );
+    }
+
+    /**
      * AND of {@code status = 200} (no nested function) and {@code UPPER(country) = 'US'}
      * (nested UPPER). Each leaf is annotated independently: Lucene stays on the first
      * leaf and drops only on the second.

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/FilterRuleTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/FilterRuleTests.java
@@ -14,6 +14,7 @@ import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.AggregateCall;
 import org.apache.calcite.rel.logical.LogicalAggregate;
 import org.apache.calcite.rel.logical.LogicalFilter;
+import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlFunction;
@@ -283,6 +284,144 @@ public class FilterRuleTests extends BasePlannerRulesTests {
 
         RelNode result = runPlanner(having, context);
         assertNotNull("Planner must produce a plan for HAVING on derived column", result);
+    }
+
+    // ---- Scalar-function capability narrowing ----
+
+    /**
+     * Baseline: {@code country = 'US'} has no nested scalar function, so both backends
+     * stay viable. Sets the expected shape that the next four tests narrow against.
+     */
+    public void testNoScalarFunctionsKeepsLuceneViable() {
+        OpenSearchFilter result = runFilter(
+            "parquet",
+            Map.of("country_name", Map.of("type", "keyword", "index", true)),
+            new String[] { "country_name" },
+            new SqlTypeName[] { SqlTypeName.VARCHAR },
+            makeEquals(0, SqlTypeName.VARCHAR, "US")
+        );
+
+        AnnotatedPredicate annotated = (AnnotatedPredicate) result.getCondition();
+        assertPredicateAnnotation(annotated, MockDataFusionBackend.NAME, MockLuceneBackend.NAME);
+    }
+
+    /**
+     * {@code UPPER(country) = 'US'}: Lucene supports EQUALS on KEYWORD but does not
+     * support UPPER, so the predicate is no longer viable for Lucene.
+     */
+    public void testNestedScalarFunctionDropsLuceneFromPredicateAnnotation() {
+        RelDataType varchar = typeFactory.createSqlType(SqlTypeName.VARCHAR);
+        RexNode upperCall = rexBuilder.makeCall(SqlStdOperatorTable.UPPER, rexBuilder.makeInputRef(varchar, 0));
+        RexNode predicate = rexBuilder.makeCall(SqlStdOperatorTable.EQUALS, upperCall, rexBuilder.makeLiteral("US"));
+
+        OpenSearchFilter result = runFilter(
+            "parquet",
+            Map.of("country_name", Map.of("type", "keyword", "index", true)),
+            new String[] { "country_name" },
+            new SqlTypeName[] { SqlTypeName.VARCHAR },
+            predicate
+        );
+
+        AnnotatedPredicate annotated = (AnnotatedPredicate) result.getCondition();
+        assertEquals("Only DataFusion remains viable", 1, annotated.getViableBackends().size());
+        assertTrue(annotated.getViableBackends().contains(MockDataFusionBackend.NAME));
+        assertFalse(
+            "Lucene must be excluded — no scalar capability for UPPER",
+            annotated.getViableBackends().contains(MockLuceneBackend.NAME)
+        );
+    }
+
+    /**
+     * Two-level nesting: {@code UPPER(CONCAT(name, '_x')) = 'FOO'}. Confirms the walk
+     * looks past the outer scalar function into its operands; Lucene supports neither
+     * UPPER nor CONCAT, so it drops out either way.
+     */
+    public void testNestedScalarFunctionsDropLucene() {
+        RelDataType varchar = typeFactory.createSqlType(SqlTypeName.VARCHAR);
+        RexNode concatCall = rexBuilder.makeCall(
+            SqlStdOperatorTable.CONCAT,
+            rexBuilder.makeInputRef(varchar, 0),
+            rexBuilder.makeLiteral("_x")
+        );
+        RexNode upperCall = rexBuilder.makeCall(SqlStdOperatorTable.UPPER, concatCall);
+        RexNode predicate = rexBuilder.makeCall(SqlStdOperatorTable.EQUALS, upperCall, rexBuilder.makeLiteral("FOO"));
+
+        OpenSearchFilter result = runFilter(
+            "parquet",
+            Map.of("name", Map.of("type", "keyword", "index", true)),
+            new String[] { "name" },
+            new SqlTypeName[] { SqlTypeName.VARCHAR },
+            predicate
+        );
+
+        AnnotatedPredicate annotated = (AnnotatedPredicate) result.getCondition();
+        assertEquals("Only DataFusion remains viable", 1, annotated.getViableBackends().size());
+        assertTrue(annotated.getViableBackends().contains(MockDataFusionBackend.NAME));
+        assertFalse(
+            "Lucene must be excluded across nested scalar-function calls",
+            annotated.getViableBackends().contains(MockLuceneBackend.NAME)
+        );
+    }
+
+    /**
+     * AND of {@code status = 200} (no nested function) and {@code UPPER(country) = 'US'}
+     * (nested UPPER). Each leaf is annotated independently: Lucene stays on the first
+     * leaf and drops only on the second.
+     */
+    public void testScalarFunctionNarrowingIsPerLeaf() {
+        RelDataType varchar = typeFactory.createSqlType(SqlTypeName.VARCHAR);
+        RexNode upperCall = rexBuilder.makeCall(SqlStdOperatorTable.UPPER, rexBuilder.makeInputRef(varchar, 1));
+        RexNode upperEq = rexBuilder.makeCall(SqlStdOperatorTable.EQUALS, upperCall, rexBuilder.makeLiteral("US"));
+
+        OpenSearchFilter result = runFilter(
+            "parquet",
+            Map.of("status", Map.of("type", "integer", "index", true), "country_name", Map.of("type", "keyword", "index", true)),
+            new String[] { "status", "country_name" },
+            new SqlTypeName[] { SqlTypeName.INTEGER, SqlTypeName.VARCHAR },
+            makeAnd(makeEquals(0, SqlTypeName.INTEGER, 200), upperEq)
+        );
+
+        RexCall andCondition = (RexCall) result.getCondition();
+        AnnotatedPredicate plainEq = (AnnotatedPredicate) andCondition.getOperands().get(0);
+        AnnotatedPredicate upperEqAnnotated = (AnnotatedPredicate) andCondition.getOperands().get(1);
+
+        assertPredicateAnnotation(plainEq, MockDataFusionBackend.NAME, MockLuceneBackend.NAME);
+        assertEquals("Only DataFusion remains viable for the scalar-function leaf", 1, upperEqAnnotated.getViableBackends().size());
+        assertTrue(upperEqAnnotated.getViableBackends().contains(MockDataFusionBackend.NAME));
+        assertFalse(
+            "Lucene must be excluded only on the scalar-function leaf",
+            upperEqAnnotated.getViableBackends().contains(MockLuceneBackend.NAME)
+        );
+    }
+
+    /**
+     * A nested scalar function that the framework doesn't know about (no entry in the
+     * {@link org.opensearch.analytics.spi.ScalarFunction} enum) makes the predicate
+     * unevaluable on every backend. Marking should fail fast and the error should name
+     * the unrecognized function.
+     */
+    public void testUnrecognizedScalarFunctionThrows() {
+        SqlFunction unknown = new SqlFunction(
+            "FAKE_UDF",
+            SqlKind.OTHER_FUNCTION,
+            ReturnTypes.VARCHAR_2000,
+            null,
+            OperandTypes.ANY,
+            SqlFunctionCategory.USER_DEFINED_FUNCTION
+        );
+        RelDataType varchar = typeFactory.createSqlType(SqlTypeName.VARCHAR);
+        RexNode unknownCall = rexBuilder.makeCall(unknown, rexBuilder.makeInputRef(varchar, 0));
+        RexNode predicate = rexBuilder.makeCall(SqlStdOperatorTable.EQUALS, unknownCall, rexBuilder.makeLiteral("X"));
+
+        RelOptTable table = mockTable("test_index", new String[] { "name" }, new SqlTypeName[] { SqlTypeName.VARCHAR });
+        LogicalFilter filter = LogicalFilter.create(stubScan(table), predicate);
+        PlannerContext context = buildContext("parquet", Map.of("name", Map.of("type", "keyword", "index", true)));
+
+        IllegalStateException exception = expectThrows(IllegalStateException.class, () -> runPlanner(filter, context));
+        assertTrue(
+            "Message must name the unrecognized scalar function",
+            exception.getMessage().contains("Unrecognized scalar function [FAKE_UDF]")
+        );
     }
 
     // ---- Helpers ----

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/FilterRuleTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/FilterRuleTests.java
@@ -332,48 +332,12 @@ public class FilterRuleTests extends BasePlannerRulesTests {
     }
 
     /**
-     * Two-level nesting: {@code UPPER(CONCAT(name, '_x')) = 'FOO'}. Confirms the walk
-     * looks past the outer scalar function into its operands; Lucene supports neither
-     * UPPER nor CONCAT, so it drops out either way.
-     */
-    public void testNestedScalarFunctionsDropLucene() {
-        RelDataType varchar = typeFactory.createSqlType(SqlTypeName.VARCHAR);
-        RexNode concatCall = rexBuilder.makeCall(
-            SqlStdOperatorTable.CONCAT,
-            rexBuilder.makeInputRef(varchar, 0),
-            rexBuilder.makeLiteral("_x")
-        );
-        RexNode upperCall = rexBuilder.makeCall(SqlStdOperatorTable.UPPER, concatCall);
-        RexNode predicate = rexBuilder.makeCall(SqlStdOperatorTable.EQUALS, upperCall, rexBuilder.makeLiteral("FOO"));
-
-        OpenSearchFilter result = runFilter(
-            "parquet",
-            Map.of("name", Map.of("type", "keyword", "index", true)),
-            new String[] { "name" },
-            new SqlTypeName[] { SqlTypeName.VARCHAR },
-            predicate
-        );
-
-        AnnotatedPredicate annotated = (AnnotatedPredicate) result.getCondition();
-        assertEquals("Only DataFusion remains viable", 1, annotated.getViableBackends().size());
-        assertTrue(annotated.getViableBackends().contains(MockDataFusionBackend.NAME));
-        assertFalse(
-            "Lucene must be excluded across nested scalar-function calls",
-            annotated.getViableBackends().contains(MockLuceneBackend.NAME)
-        );
-    }
-
-    /**
      * Four-level nesting: {@code UPPER(CONCAT(UPPER(CONCAT(name, '_a')), '_b')) = 'FOO'}.
      * Confirms the walk recurses through arbitrary depth; Lucene drops at any level it can't evaluate.
      */
     public void testDeeplyNestedScalarFunctionsDropLucene() {
         RelDataType varchar = typeFactory.createSqlType(SqlTypeName.VARCHAR);
-        RexNode level4 = rexBuilder.makeCall(
-            SqlStdOperatorTable.CONCAT,
-            rexBuilder.makeInputRef(varchar, 0),
-            rexBuilder.makeLiteral("_a")
-        );
+        RexNode level4 = rexBuilder.makeCall(SqlStdOperatorTable.CONCAT, rexBuilder.makeInputRef(varchar, 0), rexBuilder.makeLiteral("_a"));
         RexNode level3 = rexBuilder.makeCall(SqlStdOperatorTable.UPPER, level4);
         RexNode level2 = rexBuilder.makeCall(SqlStdOperatorTable.CONCAT, level3, rexBuilder.makeLiteral("_b"));
         RexNode level1 = rexBuilder.makeCall(SqlStdOperatorTable.UPPER, level2);
@@ -394,6 +358,204 @@ public class FilterRuleTests extends BasePlannerRulesTests {
             "Lucene must be excluded across deeply nested scalar-function calls",
             annotated.getViableBackends().contains(MockLuceneBackend.NAME)
         );
+    }
+
+    /**
+     * Predicate with a nested scalar function ({@code EXP}) that NO mock backend declares
+     * scalar capability for: viableSet collapses to empty after the inner-call intersection,
+     * and the existing "no backend can evaluate filter predicate" throw fires. Verifies the
+     * error message names the outer comparator's SqlKind and the field, so the failure is
+     * pin-pointable from logs.
+     */
+    public void testInnerScalarWithNoBackendSupportThrows() {
+        SqlFunction expFn = SqlStdOperatorTable.EXP;
+        RexNode innerCall = rexBuilder.makeCall(expFn, rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.INTEGER), 0));
+        RexNode predicate = rexBuilder.makeCall(
+            SqlStdOperatorTable.GREATER_THAN,
+            innerCall,
+            rexBuilder.makeLiteral(1.0, typeFactory.createSqlType(SqlTypeName.DOUBLE), true)
+        );
+
+        RelOptTable table = mockTable("test_index", new String[] { "n" }, new SqlTypeName[] { SqlTypeName.INTEGER });
+        LogicalFilter filter = LogicalFilter.create(stubScan(table), predicate);
+        PlannerContext context = buildContext("parquet", Map.of("n", Map.of("type", "integer", "index", true)));
+
+        IllegalStateException exception = expectThrows(IllegalStateException.class, () -> runPlanner(filter, context));
+        assertTrue(
+            "Message must indicate no backend can evaluate the predicate, got: " + exception.getMessage(),
+            exception.getMessage().contains("No backend can evaluate filter predicate")
+        );
+        assertTrue("Message must name the outer comparator's kind", exception.getMessage().contains("GREATER_THAN"));
+        assertTrue("Message must name the field", exception.getMessage().contains("n:integer"));
+    }
+
+    /**
+     * Nested boolean tree {@code AND( $0 = 200 , OR( UPPER($s) = 'X' , >(EXP($num), 1.0) ) )}.
+     * The deepest leaf has an inner {@code EXP} no backend declares; the throw fires from
+     * that leaf and propagates up through OR and AND. Verifies (a) sibling leaves don't
+     * suppress the un-evaluable leaf's failure and (b) the error message stays per-leaf
+     * (names {@code GREATER_THAN} on {@code num:integer}, not the surrounding shape).
+     */
+    public void testNestedAndOrWithUnevaluableLeafThrows() {
+        RelDataType integer = typeFactory.createSqlType(SqlTypeName.INTEGER);
+        RelDataType varchar = typeFactory.createSqlType(SqlTypeName.VARCHAR);
+        RelDataType doubleType = typeFactory.createSqlType(SqlTypeName.DOUBLE);
+
+        // status = 200
+        RexNode goodLeaf = makeEquals(0, SqlTypeName.INTEGER, 200);
+
+        // UPPER(s) = 'X'
+        RexNode upperCall = rexBuilder.makeCall(SqlStdOperatorTable.UPPER, rexBuilder.makeInputRef(varchar, 1));
+        RexNode upperLeaf = rexBuilder.makeCall(SqlStdOperatorTable.EQUALS, upperCall, rexBuilder.makeLiteral("X"));
+
+        // EXP(num) > 1.0 (no backend declares EXP)
+        RexNode expCall = rexBuilder.makeCall(SqlStdOperatorTable.EXP, rexBuilder.makeInputRef(integer, 2));
+        RexNode badLeaf = rexBuilder.makeCall(SqlStdOperatorTable.GREATER_THAN, expCall, rexBuilder.makeLiteral(1.0, doubleType, true));
+
+        RexNode condition = makeCall(SqlStdOperatorTable.AND, goodLeaf, makeCall(SqlStdOperatorTable.OR, upperLeaf, badLeaf));
+
+        RelOptTable table = mockTable(
+            "test_index",
+            new String[] { "status", "s", "num" },
+            new SqlTypeName[] { SqlTypeName.INTEGER, SqlTypeName.VARCHAR, SqlTypeName.INTEGER }
+        );
+        LogicalFilter filter = LogicalFilter.create(stubScan(table), condition);
+        PlannerContext context = buildContext(
+            "parquet",
+            Map.of(
+                "status",
+                Map.of("type", "integer", "index", true),
+                "s",
+                Map.of("type", "keyword", "index", true),
+                "num",
+                Map.of("type", "integer", "index", true)
+            )
+        );
+
+        IllegalStateException exception = expectThrows(IllegalStateException.class, () -> runPlanner(filter, context));
+        assertTrue(
+            "Message must indicate no backend can evaluate the predicate, got: " + exception.getMessage(),
+            exception.getMessage().contains("No backend can evaluate filter predicate")
+        );
+        assertTrue("Message must name the offending leaf's comparator", exception.getMessage().contains("GREATER_THAN"));
+        assertTrue("Message must name the offending leaf's field", exception.getMessage().contains("num:integer"));
+        assertFalse(
+            "Message must not conflate sibling leaves' fields",
+            exception.getMessage().contains("status:") || exception.getMessage().contains("s:keyword")
+        );
+    }
+
+    /**
+     * Inter-leaf "same backend" check: {@code (MATCH(s, 'foo') OR status = 200) AND >(SIN(num), 0.5)}.
+     * Each leaf is individually viable on different single backends — P1 (MATCH) is Lucene-only,
+     * P3 (SIN inner call) is DataFusion-only — and no FILTER delegation is registered. The
+     * operator-level intersection at {@code computeFilterViableBackends} finds no backend that
+     * can evaluate every leaf, throwing the "No backend can execute filter" error. This pins
+     * the cross-leaf constraint distinct from the per-leaf throw above.
+     */
+    public void testFilterWithMixedBackendLeavesAndNoDelegationThrows() {
+        RelDataType integer = typeFactory.createSqlType(SqlTypeName.INTEGER);
+        RelDataType doubleType = typeFactory.createSqlType(SqlTypeName.DOUBLE);
+
+        // P1: MATCH(s, 'foo') — full-text predicate, Lucene-only (DataFusion declares no FULL_TEXT caps).
+        RexNode p1 = makeFullTextCall(fullTextSqlFunction("MATCH"), 1, "foo");
+
+        // P2: status = 200 — dual-viable on its own, doesn't help bridge P1 and P3.
+        RexNode p2 = makeEquals(0, SqlTypeName.INTEGER, 200);
+
+        // P3: SIN(num) > 0.5 — inner SIN is DataFusion-only (Lucene declares no ProjectCapability),
+        // so the leaf narrows to [datafusion] via the new inner-call walk.
+        RexNode sinCall = rexBuilder.makeCall(SqlStdOperatorTable.SIN, rexBuilder.makeInputRef(integer, 2));
+        RexNode p3 = rexBuilder.makeCall(SqlStdOperatorTable.GREATER_THAN, sinCall, rexBuilder.makeLiteral(0.5, doubleType, true));
+
+        RexNode condition = makeCall(SqlStdOperatorTable.AND, makeCall(SqlStdOperatorTable.OR, p1, p2), p3);
+
+        RelOptTable table = mockTable(
+            "test_index",
+            new String[] { "status", "s", "num" },
+            new SqlTypeName[] { SqlTypeName.INTEGER, SqlTypeName.VARCHAR, SqlTypeName.INTEGER }
+        );
+        LogicalFilter filter = LogicalFilter.create(stubScan(table), condition);
+        PlannerContext context = buildContext(
+            "parquet",
+            Map.of(
+                "status",
+                Map.of("type", "integer", "index", true),
+                "s",
+                Map.of("type", "keyword", "index", true),
+                "num",
+                Map.of("type", "integer", "index", true)
+            )
+        );
+
+        IllegalStateException exception = expectThrows(IllegalStateException.class, () -> runPlanner(filter, context));
+        assertTrue(
+            "Message must indicate the operator-level mismatch, got: " + exception.getMessage(),
+            exception.getMessage().contains("No backend can execute filter")
+        );
+        assertTrue("Message must mention the missing delegation path", exception.getMessage().contains("no delegation path exists"));
+    }
+
+    /**
+     * Symmetric happy path: same {@code (MATCH(s, 'foo') OR status = 200) AND >(SIN(num), 0.5)}
+     * shape, but with FILTER delegation registered (DataFusion drives, Lucene accepts).
+     * The operator-level intersection finds DataFusion as a viable driver — it evaluates
+     * P2 and P3 natively and delegates the MATCH leaf (P1) to Lucene. No throw; the filter
+     * marks {@code [datafusion]} at the operator level and P1's annotation lists Lucene as
+     * the delegation target.
+     */
+    public void testFilterWithMixedBackendLeavesAndDelegationSucceeds() {
+        RelDataType integer = typeFactory.createSqlType(SqlTypeName.INTEGER);
+        RelDataType doubleType = typeFactory.createSqlType(SqlTypeName.DOUBLE);
+
+        RexNode p1 = makeFullTextCall(fullTextSqlFunction("MATCH"), 1, "foo");
+        RexNode p2 = makeEquals(0, SqlTypeName.INTEGER, 200);
+        RexNode sinCall = rexBuilder.makeCall(SqlStdOperatorTable.SIN, rexBuilder.makeInputRef(integer, 2));
+        RexNode p3 = rexBuilder.makeCall(SqlStdOperatorTable.GREATER_THAN, sinCall, rexBuilder.makeLiteral(0.5, doubleType, true));
+        RexNode condition = makeCall(SqlStdOperatorTable.AND, makeCall(SqlStdOperatorTable.OR, p1, p2), p3);
+
+        OpenSearchFilter result = runFilterWithDelegation(
+            "parquet",
+            Map.of(
+                "status",
+                Map.of("type", "integer", "index", true),
+                "s",
+                Map.of("type", "keyword", "index", true),
+                "num",
+                Map.of("type", "integer", "index", true)
+            ),
+            new String[] { "status", "s", "num" },
+            new SqlTypeName[] { SqlTypeName.INTEGER, SqlTypeName.VARCHAR, SqlTypeName.INTEGER },
+            condition
+        );
+
+        // Operator-level: DataFusion drives. Lucene is a delegation target only, never the driver.
+        assertEquals("Operator-level viable backends must be exactly [datafusion]", 1, result.getViableBackends().size());
+        assertTrue(result.getViableBackends().contains(MockDataFusionBackend.NAME));
+        assertFalse(
+            "Lucene must not appear at the operator level — it accepts delegated leaves but doesn't drive",
+            result.getViableBackends().contains(MockLuceneBackend.NAME)
+        );
+
+        RexCall andCondition = (RexCall) result.getCondition();
+        RexCall orBranch = (RexCall) andCondition.getOperands().get(0);
+        AnnotatedPredicate matchPred = (AnnotatedPredicate) orBranch.getOperands().get(0);
+        AnnotatedPredicate equalsPred = (AnnotatedPredicate) orBranch.getOperands().get(1);
+        AnnotatedPredicate sinPred = (AnnotatedPredicate) andCondition.getOperands().get(1);
+
+        // P1 (MATCH) — exactly Lucene; DataFusion will delegate it.
+        assertEquals("P1 (MATCH) viable backends must be exactly [lucene]", 1, matchPred.getViableBackends().size());
+        assertTrue(matchPred.getViableBackends().contains(MockLuceneBackend.NAME));
+
+        // P2 (EQUALS on integer) — exactly both backends, dual-viable.
+        assertEquals("P2 (EQUALS) viable backends must be exactly [datafusion, lucene]", 2, equalsPred.getViableBackends().size());
+        assertTrue(equalsPred.getViableBackends().contains(MockDataFusionBackend.NAME));
+        assertTrue(equalsPred.getViableBackends().contains(MockLuceneBackend.NAME));
+
+        // P3 (SIN > 0.5) — exactly DataFusion; Lucene declares no scalar capability for SIN
+        // so the inner-call walk drops it.
+        assertEquals("P3 (SIN) viable backends must be exactly [datafusion]", 1, sinPred.getViableBackends().size());
+        assertTrue(sinPred.getViableBackends().contains(MockDataFusionBackend.NAME));
     }
 
     /**

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/MockDataFusionBackend.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/MockDataFusionBackend.java
@@ -187,7 +187,9 @@ public class MockDataFusionBackend extends MockBackend implements SearchBackEndP
         ScalarFunction.NOT,
         // String — used by QTF plan-shape tests covering composite expressions / dedup.
         ScalarFunction.CONCAT,
-        ScalarFunction.UPPER
+        ScalarFunction.UPPER,
+        ScalarFunction.SIN,
+        ScalarFunction.ABS
     );
 
     private static final Set<ProjectCapability> PROJECT_CAPS;

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/ReplaceCommandIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/ReplaceCommandIT.java
@@ -8,7 +8,6 @@
 
 package org.opensearch.analytics.qa;
 
-import org.apache.lucene.tests.util.LuceneTestCase.AwaitsFix;
 
 import org.opensearch.client.Request;
 import org.opensearch.client.Response;
@@ -63,7 +62,6 @@ public class ReplaceCommandIT extends AnalyticsRestTestCase {
 
     // ── command form: literal pattern (SqlStdOperatorTable.REPLACE) ─────────────
 
-    @AwaitsFix(bugUrl = "Real opensearch-sql plugin: a filter whose shape is not (field, literal) (REPLACE/REGEXP_REPLACE/CHAR_LENGTH/array_element(...) = literal) is marked dual-viable for performance-delegation, but Lucene's DelegatedPredicateSerializer only handles (RexInputRef, RexLiteral) and throws IllegalArgumentException at fragment conversion. Needs the marking-time canSerialize prune in OpenSearchFilterRule (engine fix, separate PR).")
     public void testReplaceLiteralSinglePair() throws IOException {
         // FURNITURE → FURN in str0; 2 rows affected, others unchanged.
         // assertContainsRow uses substring/contains — order-independent.
@@ -73,7 +71,6 @@ public class ReplaceCommandIT extends AnalyticsRestTestCase {
         );
     }
 
-    @AwaitsFix(bugUrl = "Real opensearch-sql plugin: a filter whose shape is not (field, literal) (REPLACE/REGEXP_REPLACE/CHAR_LENGTH/array_element(...) = literal) is marked dual-viable for performance-delegation, but Lucene's DelegatedPredicateSerializer only handles (RexInputRef, RexLiteral) and throws IllegalArgumentException at fragment conversion. Needs the marking-time canSerialize prune in OpenSearchFilterRule (engine fix, separate PR).")
     public void testReplaceLiteralMultiplePairs() throws IOException {
         // Nested REPLACE in projection: REPLACE(REPLACE(str0, 'FURNITURE', 'F'), 'TECHNOLOGY', 'T').
         // FURNITURE (×2) → 'F', TECHNOLOGY (×9) → 'T', OFFICE SUPPLIES (×6) → unchanged.
@@ -95,7 +92,6 @@ public class ReplaceCommandIT extends AnalyticsRestTestCase {
         );
     }
 
-    @AwaitsFix(bugUrl = "Real opensearch-sql plugin: a filter whose shape is not (field, literal) (REPLACE/REGEXP_REPLACE/CHAR_LENGTH/array_element(...) = literal) is marked dual-viable for performance-delegation, but Lucene's DelegatedPredicateSerializer only handles (RexInputRef, RexLiteral) and throws IllegalArgumentException at fragment conversion. Needs the marking-time canSerialize prune in OpenSearchFilterRule (engine fix, separate PR).")
     public void testReplaceLiteralExpectedRows() throws IOException {
         // Verify the actual replaced values (not just counts) for the FURNITURE rows.
         assertRows(
@@ -105,7 +101,6 @@ public class ReplaceCommandIT extends AnalyticsRestTestCase {
         );
     }
 
-    @AwaitsFix(bugUrl = "Real opensearch-sql plugin: a filter whose shape is not (field, literal) (REPLACE/REGEXP_REPLACE/CHAR_LENGTH/array_element(...) = literal) is marked dual-viable for performance-delegation, but Lucene's DelegatedPredicateSerializer only handles (RexInputRef, RexLiteral) and throws IllegalArgumentException at fragment conversion. Needs the marking-time canSerialize prune in OpenSearchFilterRule (engine fix, separate PR).")
     public void testReplaceLiteralAcrossMultipleFields() throws IOException {
         // Replace value 'FURNITURE' in BOTH str0 and str1. str1 has no FURNITURE → unaffected.
         // str0 has 2 → renamed to FURN.
@@ -123,7 +118,6 @@ public class ReplaceCommandIT extends AnalyticsRestTestCase {
     // parse. RegexpReplaceAdapter (in DataFusionAnalyticsBackendPlugin.scalarFunctionAdapters)
     // rewrites `\Q…\E` blocks to per-char-escaped literals before substrait serialization.
 
-    @AwaitsFix(bugUrl = "Real opensearch-sql plugin: a filter whose shape is not (field, literal) (REPLACE/REGEXP_REPLACE/CHAR_LENGTH/array_element(...) = literal) is marked dual-viable for performance-delegation, but Lucene's DelegatedPredicateSerializer only handles (RexInputRef, RexLiteral) and throws IllegalArgumentException at fragment conversion. Needs the marking-time canSerialize prune in OpenSearchFilterRule (engine fix, separate PR).")
     public void testReplaceWildcardSuffix() throws IOException {
         // '*BOARDS' matches strings ending in BOARDS — CORDED KEYBOARDS, CORDLESS KEYBOARDS (×2).
         // Whole-string replacement: matched values become 'KBD'.
@@ -133,7 +127,6 @@ public class ReplaceCommandIT extends AnalyticsRestTestCase {
         );
     }
 
-    @AwaitsFix(bugUrl = "Real opensearch-sql plugin: a filter whose shape is not (field, literal) (REPLACE/REGEXP_REPLACE/CHAR_LENGTH/array_element(...) = literal) is marked dual-viable for performance-delegation, but Lucene's DelegatedPredicateSerializer only handles (RexInputRef, RexLiteral) and throws IllegalArgumentException at fragment conversion. Needs the marking-time canSerialize prune in OpenSearchFilterRule (engine fix, separate PR).")
     public void testReplaceWildcardPrefix() throws IOException {
         // 'BUSINESS*' matches BUSINESS ENVELOPES, BUSINESS COPIERS (×2).
         assertRowCount(
@@ -144,7 +137,6 @@ public class ReplaceCommandIT extends AnalyticsRestTestCase {
 
     // ── function form: regexp_replace() in eval projection ─────────────────────
 
-    @AwaitsFix(bugUrl = "Real opensearch-sql plugin: a filter whose shape is not (field, literal) (REPLACE/REGEXP_REPLACE/CHAR_LENGTH/array_element(...) = literal) is marked dual-viable for performance-delegation, but Lucene's DelegatedPredicateSerializer only handles (RexInputRef, RexLiteral) and throws IllegalArgumentException at fragment conversion. Needs the marking-time canSerialize prune in OpenSearchFilterRule (engine fix, separate PR).")
     public void testRegexpReplaceInEval() throws IOException {
         // eval-side regexp_replace lowers to REGEXP_REPLACE_3. Replace any digit run in str0 with
         // empty — no-op for these string values, exercises the function-form code path.
@@ -155,7 +147,6 @@ public class ReplaceCommandIT extends AnalyticsRestTestCase {
         );
     }
 
-    @AwaitsFix(bugUrl = "Real opensearch-sql plugin: a filter whose shape is not (field, literal) (REPLACE/REGEXP_REPLACE/CHAR_LENGTH/array_element(...) = literal) is marked dual-viable for performance-delegation, but Lucene's DelegatedPredicateSerializer only handles (RexInputRef, RexLiteral) and throws IllegalArgumentException at fragment conversion. Needs the marking-time canSerialize prune in OpenSearchFilterRule (engine fix, separate PR).")
     public void testReplaceFunctionInEval() throws IOException {
         // PPL replace() function in eval also lowers to REGEXP_REPLACE_3 (per
         // PPLFuncImpTable.register for BuiltinFunctionName.REPLACE).

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/RexCommandIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/RexCommandIT.java
@@ -8,7 +8,6 @@
 
 package org.opensearch.analytics.qa;
 
-import org.apache.lucene.tests.util.LuceneTestCase.AwaitsFix;
 
 import org.opensearch.client.Request;
 import org.opensearch.client.Response;
@@ -69,7 +68,6 @@ public class RexCommandIT extends AnalyticsRestTestCase {
 
     // ── sed mode without flags (REGEXP_REPLACE_3, already wired by replace) ────
 
-    @AwaitsFix(bugUrl = "Real opensearch-sql plugin: a filter whose shape is not (field, literal) (REPLACE/REGEXP_REPLACE/CHAR_LENGTH/array_element(...) = literal) is marked dual-viable for performance-delegation, but Lucene's DelegatedPredicateSerializer only handles (RexInputRef, RexLiteral) and throws IllegalArgumentException at fragment conversion. Needs the marking-time canSerialize prune in OpenSearchFilterRule (engine fix, separate PR).")
     public void testRexSedReplaceLiteral() throws IOException {
         // Replace literal "SUPPLIES" → "STUFF" in str0. 6 rows have "OFFICE SUPPLIES"; each
         // becomes "OFFICE STUFF". No-flags sed lowers to 3-arg regexp_replace which the
@@ -114,7 +112,6 @@ public class RexCommandIT extends AnalyticsRestTestCase {
 
     // ── sed mode with /i flag (REGEXP_REPLACE_PG_4 — case-insensitive) ─────────
 
-    @AwaitsFix(bugUrl = "Real opensearch-sql plugin: a filter whose shape is not (field, literal) (REPLACE/REGEXP_REPLACE/CHAR_LENGTH/array_element(...) = literal) is marked dual-viable for performance-delegation, but Lucene's DelegatedPredicateSerializer only handles (RexInputRef, RexLiteral) and throws IllegalArgumentException at fragment conversion. Needs the marking-time canSerialize prune in OpenSearchFilterRule (engine fix, separate PR).")
     public void testRexSedReplaceCaseInsensitive() throws IOException {
         // Pattern is lowercase but field values are uppercase — /i makes it match.
         // 2 FURNITURE rows in str0 → "FURN".
@@ -144,7 +141,6 @@ public class RexCommandIT extends AnalyticsRestTestCase {
 
     // ── sed mode with backreference (4-arg with flags + $N braces test) ───────
 
-    @AwaitsFix(bugUrl = "Real opensearch-sql plugin: a filter whose shape is not (field, literal) (REPLACE/REGEXP_REPLACE/CHAR_LENGTH/array_element(...) = literal) is marked dual-viable for performance-delegation, but Lucene's DelegatedPredicateSerializer only handles (RexInputRef, RexLiteral) and throws IllegalArgumentException at fragment conversion. Needs the marking-time canSerialize prune in OpenSearchFilterRule (engine fix, separate PR).")
     public void testRexSedReplaceWithBackreference() throws IOException {
         // Swap first two whitespace-separated tokens. Exercises both pattern unquoting
         // (none needed here — user-typed regex) AND replacement-side $N → ${N} brace

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/SpathCommandIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/SpathCommandIT.java
@@ -8,7 +8,6 @@
 
 package org.opensearch.analytics.qa;
 
-import org.apache.lucene.tests.util.LuceneTestCase.AwaitsFix;
 
 import org.opensearch.client.Request;
 import org.opensearch.client.Response;
@@ -174,7 +173,6 @@ public class SpathCommandIT extends AnalyticsRestTestCase {
         );
     }
 
-    @AwaitsFix(bugUrl = "Real opensearch-sql plugin: a filter whose shape is not (field, literal) (REPLACE/REGEXP_REPLACE/CHAR_LENGTH/array_element(...) = literal) is marked dual-viable for performance-delegation, but Lucene's DelegatedPredicateSerializer only handles (RexInputRef, RexLiteral) and throws IllegalArgumentException at fragment conversion. Needs the marking-time canSerialize prune in OpenSearchFilterRule (engine fix, separate PR).")
     public void testSpathAutoExtractWithWhere() throws IOException {
         // EQUALS on a MAP-column expression goes through the FieldType.MAP filter
         // capability registered for the analytics-engine route.

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/WhereCommandIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/WhereCommandIT.java
@@ -8,7 +8,6 @@
 
 package org.opensearch.analytics.qa;
 
-import org.apache.lucene.tests.util.LuceneTestCase.AwaitsFix;
 
 import org.opensearch.client.Request;
 import org.opensearch.client.Response;
@@ -245,7 +244,6 @@ public class WhereCommandIT extends AnalyticsRestTestCase {
 
     // ── Sub-expression scalar calls (pass through to DataFusion) ────────────
 
-    @AwaitsFix(bugUrl = "Real opensearch-sql plugin: a filter whose shape is not (field, literal) (REPLACE/REGEXP_REPLACE/CHAR_LENGTH/array_element(...) = literal) is marked dual-viable for performance-delegation, but Lucene's DelegatedPredicateSerializer only handles (RexInputRef, RexLiteral) and throws IllegalArgumentException at fragment conversion. Needs the marking-time canSerialize prune in OpenSearchFilterRule (engine fix, separate PR).")
     public void testWhereInnerLength() throws IOException {
         // length('FURNITURE') = 9 → 2 rows.
         assertRowCount(


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description

#### What this PR does

Updated `OpenSearchFilterRule` to look **inside** predicates when computing per-predicate viable backends. Previously it only checked the outer comparator (`EQUALS`, `>`, `IN`, …) against backend capabilities; nested scalar functions like `CHAR_LENGTH(str)`, `JSON_EXTRACT_ALL(doc)`, `ITEM(map, key)` were ignored. Now every nested `RexCall` is intersected against `scalarBackendsAnyFormat(fn, returnType)` so a backend stays viable only if it can evaluate the **whole predicate**, not just its outer operator.

#### Why

A predicate like:

```
=(ITEM(JSON_EXTRACT_ALL($0), 'user.name'), 'John')
```

would survive marking with `backends=[lucene, datafusion]` because Lucene legitimately declares `EQUALS` on `KEYWORD`. But Lucene has no scalar capability for `JSON_EXTRACT_ALL` or `ITEM-on-MAP` — so when CBO records Lucene as a perf-delegation peer and fragment conversion later calls `EqualsSerializer.buildQueryBuilder` on the original `RexCall`, it finds `(RexCall, RexLiteral)` instead of the expected `(RexInputRef, RexLiteral)` and throws:

```
java.lang.IllegalArgumentException:
  EQUALS performance-delegation requires (RexInputRef, RexLiteral);
  got array_element(map_extract(json_extract_all($0), 'user.name'), 1) = 'John'
```

The bug only surfaces on dual-format indices (parquet primary + lucene secondary). With this fix Lucene drops out at marking time for any predicate whose nested calls it can't evaluate, the perf-delegation arm never invokes the per-function serializer with an unsupported shape, and the runtime IAE becomes unreachable.

#### How

In `OpenSearchFilterRule.resolveViableBackends`:

1. **One tree walk** instead of two — collects field indices and nested scalar-function calls in a single pass into a `PredicateAnalysis` record.
2. **Field-storage intersection** (existing) — narrows on the outer comparator and each field's storage formats. Unchanged.
3. **Scalar-function intersection** (new) — for each nested call, narrows on `scalarBackendsAnyFormat(fn, returnType)`. A backend stays viable only if it can evaluate every nested function.
4. **Polymorphic-UDF fallback** — when a call's return type is `SqlTypeName.ANY` (e.g. `SCALAR_MAX`), infer the type from the first concrete operand. Mirrors `OpenSearchProjectRule`. Throws if even that fails.
5. **Better error messages** — both throw paths name the offending nested call and the enclosing predicate. A TODO marks the next granular-message improvement on the existing empty-set throw.

#### Tests

**Unit tests** — 5 new tests in `FilterRuleTests`:

- `testNoScalarFunctionsKeepsLuceneViable` — baseline; no nested RexCall ⇒ both backends survive.
- `testNestedScalarFunctionDropsLuceneFromPredicateAnnotation` — `UPPER(country) = 'US'` ⇒ Lucene drops.
- `testNestedScalarFunctionsDropLucene` — two-level nesting `UPPER(CONCAT(name, '_x')) = 'FOO'` ⇒ walk recurses.
- `testScalarFunctionNarrowingIsPerLeaf` — AND of two leaves; narrowing is leaf-local.
- `testUnrecognizedScalarFunctionThrows` — unknown operator throws with the function name.

**Integration tests** — removed 13 `@AwaitsFix` annotations across four classes that were skipped specifically for this gap. All previously-skipped tests now run and pass:

| File | Tests un-skipped |
|---|---|
| `WhereCommandIT.java` | 1 (`testWhereInnerLength`) |
| `ReplaceCommandIT.java` | 8 (literal/multi-pair/no-match/expected-rows/multi-field + 2 wildcard + 2 function-form) |
| `RexCommandIT.java` | 3 (sed literal, sed `/i`, sed backreference) |
| `SpathCommandIT.java` | 1 (`testSpathAutoExtractWithWhere`) |

The unused `LuceneTestCase.AwaitsFix` imports are dropped from each.



### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
