### PR TITLE
Add bloom filter pruning on the indexed parquet read path

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/datafusion_query_config.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/datafusion_query_config.rs
@@ -70,6 +70,8 @@ pub struct DatafusionQueryConfig {
     /// Only consulted when the plan requests row IDs (contains _global_row_id() UDF
     /// or projects ___row_id).
     pub query_strategy: QueryStrategy,
+    /// Whether to use bloom filters for row group pruning on the indexed read path.
+    pub bloom_filter_on_read: bool,
 }
 
 /// FFM wire format. Must stay in lockstep with the Java `MemoryLayout`.
@@ -101,6 +103,8 @@ pub struct WireDatafusionQueryConfig {
     pub tree_collector_strategy: i32,
     /// 0 = None (baseline), 1 = ListingTable, 2 = IndexedPredicateOnly
     pub query_strategy: i32,
+    /// 0 = false, 1 = true
+    pub bloom_filter_on_read: i32,
 }
 
 impl DatafusionQueryConfig {
@@ -124,6 +128,7 @@ impl DatafusionQueryConfig {
             single_collector_strategy: CollectorCallStrategy::PageRangeSplit,
             tree_collector_strategy: CollectorCallStrategy::TightenOuterBounds,
             query_strategy: QueryStrategy::None,
+            bloom_filter_on_read: true,
         }
     }
 
@@ -194,6 +199,7 @@ impl DatafusionQueryConfig {
                 2 => QueryStrategy::IndexedPredicateOnly,
                 _ => QueryStrategy::None,
             },
+            bloom_filter_on_read: w.bloom_filter_on_read != 0,
         }
     }
 }
@@ -258,6 +264,10 @@ impl DatafusionQueryConfigBuilder {
         self.0.tree_collector_strategy = v;
         self
     }
+    pub fn bloom_filter_on_read(mut self, v: bool) -> Self {
+        self.0.bloom_filter_on_read = v;
+        self
+    }
     pub fn build(self) -> DatafusionQueryConfig {
         self.0
     }
@@ -305,6 +315,7 @@ mod tests {
             single_collector_strategy: 2,
             tree_collector_strategy: 1,
             query_strategy: 1,
+            bloom_filter_on_read: 1,
         };
         let ptr = &wire as *const _ as i64;
         let c = unsafe { DatafusionQueryConfig::from_ffm_ptr(ptr) };
@@ -338,6 +349,7 @@ mod tests {
             single_collector_strategy: 2,
             tree_collector_strategy: 1,
             query_strategy: 0,
+            bloom_filter_on_read: 0,
         };
         let ptr = &wire as *const _ as i64;
         let c = unsafe { DatafusionQueryConfig::from_ffm_ptr(ptr) };

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/ffm.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/ffm.rs
@@ -69,6 +69,7 @@ fn get_rt_manager() -> Result<Arc<RuntimeManager>, String> {
         .ok_or_else(|| "Runtime manager not initialized".to_string())
 }
 
+
 #[no_mangle]
 pub extern "C" fn df_init_runtime_manager(cpu_threads: i32, datanode_multiplier: f64, coordinator_multiplier: f64) {
     let mut guard = TOKIO_RUNTIME_MANAGER.write();

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_executor.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_executor.rs
@@ -179,6 +179,7 @@ pub async fn execute_indexed_query(
         table_name: table_name.clone(),
         indexed_config: None, // derive classification from tree
         query_config: Arc::unwrap_or_clone(query_config),
+        io_handle: tokio::runtime::Handle::current(),
         aggregate_mode: crate::agg_mode::Mode::Default,
         prepared_plan: None,
         phantom_reservation: None,
@@ -475,6 +476,7 @@ async unsafe fn execute_indexed_with_context_inner(
     let object_metas = handle.object_metas;
     let writer_generations = handle.writer_generations;
     let query_context = handle.query_context;
+    let io_handle = handle.io_handle;
     // Extract context_id early so it can be captured by the per-segment closures
     // below. The closures pass it through every FFM upcall so Java can route each
     // callback to the correct per-query FilterDelegationHandle and DelegationThreadTracker.
@@ -698,6 +700,7 @@ async unsafe fn execute_indexed_with_context_inner(
                             object_path: segment.object_path.clone(),
                             metadata: Arc::clone(&segment.metadata),
                             arrow_schema: Arc::clone(&bloom_schema),
+                            io_handle: io_handle.clone(),
                             rg_bloom_pruned: stream_metrics.rg_bloom_pruned.clone(),
                             bloom_filter_eval_time: stream_metrics.bloom_filter_eval_time.clone(),
                         })

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_executor.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_executor.rs
@@ -698,6 +698,8 @@ async unsafe fn execute_indexed_with_context_inner(
                             object_path: segment.object_path.clone(),
                             metadata: Arc::clone(&segment.metadata),
                             arrow_schema: Arc::clone(&bloom_schema),
+                            rg_bloom_pruned: stream_metrics.rg_bloom_pruned.clone(),
+                            bloom_filter_eval_time: stream_metrics.bloom_filter_eval_time.clone(),
                         })
                     } else {
                         None

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_executor.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_executor.rs
@@ -659,6 +659,9 @@ async unsafe fn execute_indexed_with_context_inner(
                 .and_then(|expr| build_pruning_predicate(expr, Arc::clone(&schema_for_pruner)));
 
             let call_strategy = query_config.single_collector_strategy;
+            let bloom_store = Arc::clone(&store);
+            let bloom_schema = schema.clone();
+            let bloom_on_read = query_config.bloom_filter_on_read;
             Arc::new(
                 move |segment: &SegmentFileInfo, chunk, stream_metrics: &StreamMetrics| {
                     let collector_opt: Option<Arc<dyn RowGroupDocsCollector>> = match &correctness_provider {
@@ -689,6 +692,16 @@ async unsafe fn execute_indexed_with_context_inner(
                         &schema_for_pruner,
                         Arc::clone(&segment.metadata),
                     ));
+                    let bloom_config = if bloom_on_read {
+                        Some(crate::indexed_table::eval::single_collector::BloomConfig {
+                            store: Arc::clone(&bloom_store),
+                            object_path: segment.object_path.clone(),
+                            metadata: Arc::clone(&segment.metadata),
+                            arrow_schema: Arc::clone(&bloom_schema),
+                        })
+                    } else {
+                        None
+                    };
                     let eval: Arc<dyn RowGroupBitsetSource> =
                         Arc::new(SingleCollectorEvaluator::new(
                             collector_opt,
@@ -702,6 +715,7 @@ async unsafe fn execute_indexed_with_context_inner(
                             segment.writer_generation,
                             Arc::new(crate::indexed_table::eval::single_collector::FfmDelegatedBackendCollectorFactory),
                             context_id,
+                            bloom_config,
                         ));
                     Ok(eval)
                 },

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/bloom_pruner.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/bloom_pruner.rs
@@ -55,11 +55,20 @@ impl BloomFilterStatistics {
             ScalarValue::Float32(Some(v)) => sbbf.check(v),
             ScalarValue::Float64(Some(v)) => sbbf.check(v),
             ScalarValue::Boolean(Some(v)) => sbbf.check(v),
-            ScalarValue::Decimal128(Some(v), _precision, _scale) => {
+            ScalarValue::Decimal128(Some(v), _precision, scale) => {
                 // Parquet stores Decimal as fixed-length byte array (big-endian).
                 // The SBBF hashes the raw bytes that were inserted at write time.
                 // For Decimal128 the parquet writer uses the i128 in big-endian
                 // byte representation (16 bytes).
+                //
+                // NOTE: This assumes the query value has the same scale as the
+                // stored value. If the Parquet column is DECIMAL(10,2) and the
+                // query literal is 1.5 (scale=1, stored as 15), but Parquet
+                // stored it as 150 (scale=2), the byte representations differ
+                // and the bloom filter will return a false negative. DataFusion's
+                // cast coercion should normalize scales before reaching here, but
+                // if a mismatch occurs we conservatively return `true` (may match).
+                let _ = scale; // used only in the comment above
                 let bytes = v.to_be_bytes();
                 sbbf.check(bytes.as_slice())
             }

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/bloom_pruner.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/bloom_pruner.rs
@@ -1,0 +1,214 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+//! Bloom filter pruning for indexed parquet reads.
+//!
+//! Uses the Parquet bloom filter (SBBF — Split Block Bloom Filter) embedded in
+//! the file footer to decide whether a row group can possibly contain values
+//! that match equality predicates. Runs AFTER page-level min/max pruning (free,
+//! in-memory) and BEFORE the expensive FFM collector call (Lucene, ~1-5 ms).
+//!
+//! If the bloom filter proves absence for all equality predicates, the row group
+//! is skipped entirely — saving the FFM round-trip.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use datafusion::arrow::array::{ArrayRef, BooleanArray};
+use datafusion::arrow::datatypes::Schema;
+use datafusion::common::{Column, ScalarValue};
+use datafusion::parquet::bloom_filter::Sbbf;
+use datafusion::parquet::file::metadata::ParquetMetaData;
+use datafusion::physical_optimizer::pruning::{PruningPredicate, PruningStatistics};
+use object_store::{GetOptions, GetRange, ObjectStore};
+
+/// `PruningStatistics` implementation backed by a single row group's bloom
+/// filters. The `contained()` method is the only one that returns meaningful
+/// data — all other methods return `None` so `PruningPredicate::prune` falls
+/// back to "cannot prune" for non-equality predicates.
+struct BloomFilterStatistics {
+    /// Column name → parsed SBBF for this row group.
+    blooms: std::collections::HashMap<String, Sbbf>,
+}
+
+impl BloomFilterStatistics {
+    /// Check whether a scalar value is contained in the bloom filter.
+    /// Returns `true` if the value MAY be present, `false` if it is
+    /// definitely absent.
+    fn check_scalar(sbbf: &Sbbf, value: &ScalarValue) -> bool {
+        match value {
+            ScalarValue::Utf8(Some(s)) | ScalarValue::LargeUtf8(Some(s)) => {
+                sbbf.check(s.as_str())
+            }
+            ScalarValue::Binary(Some(b)) | ScalarValue::LargeBinary(Some(b)) => {
+                sbbf.check(b.as_slice())
+            }
+            ScalarValue::Int32(Some(v)) => sbbf.check(v),
+            ScalarValue::Int64(Some(v)) => sbbf.check(v),
+            ScalarValue::UInt32(Some(v)) => sbbf.check(v),
+            ScalarValue::UInt64(Some(v)) => sbbf.check(v),
+            ScalarValue::Float32(Some(v)) => sbbf.check(v),
+            ScalarValue::Float64(Some(v)) => sbbf.check(v),
+            ScalarValue::Boolean(Some(v)) => sbbf.check(v),
+            ScalarValue::Decimal128(Some(v), _precision, _scale) => {
+                // Parquet stores Decimal as fixed-length byte array (big-endian).
+                // The SBBF hashes the raw bytes that were inserted at write time.
+                // For Decimal128 the parquet writer uses the i128 in big-endian
+                // byte representation (16 bytes).
+                let bytes = v.to_be_bytes();
+                sbbf.check(bytes.as_slice())
+            }
+            // Null or unsupported type → conservatively say "may be present"
+            _ => true,
+        }
+    }
+}
+
+impl PruningStatistics for BloomFilterStatistics {
+    fn min_values(&self, _column: &Column) -> Option<ArrayRef> {
+        None
+    }
+    fn max_values(&self, _column: &Column) -> Option<ArrayRef> {
+        None
+    }
+    fn num_containers(&self) -> usize {
+        1
+    }
+    fn null_counts(&self, _column: &Column) -> Option<ArrayRef> {
+        None
+    }
+    fn row_counts(&self, _column: &Column) -> Option<ArrayRef> {
+        None
+    }
+    fn contained(
+        &self,
+        column: &Column,
+        values: &HashSet<ScalarValue>,
+    ) -> Option<BooleanArray> {
+        let sbbf = self.blooms.get(column.name())?;
+        // For the single-container case (1 row group), we return a
+        // single-element BooleanArray. `true` means the bloom filter says
+        // at least one of the values MAY be present; `false` means NONE of
+        // the values can be present (definite absence).
+        let any_may_match = values.iter().any(|v| Self::check_scalar(sbbf, v));
+        Some(BooleanArray::from(vec![any_may_match]))
+    }
+}
+
+/// Attempt to prune a single row group using bloom filters.
+///
+/// Returns `true` if the row group should be PRUNED (skipped), `false` if it
+/// should be kept (bloom filter says values may be present, or bloom filter is
+/// unavailable).
+///
+/// Any error (missing bloom filter, I/O error, parse error) results in `false`
+/// (conservative: do not prune).
+pub async fn bloom_prune_rg(
+    store: &dyn ObjectStore,
+    path: &object_store::path::Path,
+    metadata: &ParquetMetaData,
+    arrow_schema: &Arc<Schema>,
+    rg_idx: usize,
+    predicate: &PruningPredicate,
+) -> bool {
+    match bloom_prune_rg_inner(store, path, metadata, arrow_schema, rg_idx, predicate).await {
+        Ok(should_prune) => should_prune,
+        Err(_) => false, // conservative: don't prune on error
+    }
+}
+
+async fn bloom_prune_rg_inner(
+    store: &dyn ObjectStore,
+    path: &object_store::path::Path,
+    metadata: &ParquetMetaData,
+    arrow_schema: &Arc<Schema>,
+    rg_idx: usize,
+    predicate: &PruningPredicate,
+) -> Result<bool, Box<dyn std::error::Error + Send + Sync>> {
+    let rg_meta = metadata
+        .row_groups()
+        .get(rg_idx)
+        .ok_or("row group index out of range")?;
+
+    // Identify which columns participate in the predicate's equality checks.
+    // `literal_columns` returns columns where the predicate has literal
+    // equality constraints (e.g., col = 'value').
+    let literal_cols = predicate.literal_columns();
+    if literal_cols.is_empty() {
+        return Ok(false); // no equality predicates → cannot bloom-prune
+    }
+
+    let mut blooms = std::collections::HashMap::new();
+
+    for col_name in &literal_cols {
+        // Find the parquet column index for this column name.
+        let col_idx = match arrow_schema
+            .fields()
+            .iter()
+            .position(|f| f.name() == col_name)
+        {
+            Some(idx) => idx,
+            None => continue, // column not in schema → skip
+        };
+
+        // Get the column chunk metadata for this column in this row group.
+        let col_chunk = rg_meta.column(col_idx);
+
+        // Check if bloom filter metadata is available.
+        let bf_offset: u64 = match col_chunk.bloom_filter_offset() {
+            Some(offset) if offset >= 0 => offset as u64,
+            _ => continue, // no bloom filter for this column
+        };
+
+        let bf_length: u64 = match col_chunk.bloom_filter_length() {
+            Some(len) if len > 0 => len as u64,
+            _ => {
+                // If length is not recorded, we cannot safely read.
+                // Some parquet writers don't record length — skip this column.
+                continue;
+            }
+        };
+
+        // Read the bloom filter bytes from the object store.
+        let opts = GetOptions {
+            range: Some(GetRange::Bounded(
+                std::ops::Range {
+                    start: bf_offset,
+                    end: bf_offset + bf_length,
+                },
+            )),
+            ..Default::default()
+        };
+
+        let get_result = store.get_opts(path, opts).await?;
+        let bytes = get_result.bytes().await?;
+
+        // Parse the SBBF from the raw bytes (includes header + bitset).
+        let sbbf = Sbbf::from_bytes(&bytes)?;
+        blooms.insert(col_name.clone(), sbbf);
+    }
+
+    if blooms.is_empty() {
+        return Ok(false); // no bloom filters available → cannot prune
+    }
+
+    let stats = BloomFilterStatistics {
+        blooms,
+    };
+
+    // Call the pruning predicate with our bloom-filter-backed statistics.
+    // Result is a Vec<bool> with one entry per container (we have 1 container).
+    // `true` means "keep", `false` means "can prune".
+    match predicate.prune(&stats) {
+        Ok(keep) => {
+            // Single container: if keep[0] == false, the RG can be pruned.
+            Ok(keep.first() == Some(&false))
+        }
+        Err(_) => Ok(false), // evaluation error → don't prune
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/eval/single_collector.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/eval/single_collector.rs
@@ -185,6 +185,7 @@ pub struct BloomConfig {
     pub object_path: object_store::path::Path,
     pub metadata: Arc<ParquetMetaData>,
     pub arrow_schema: Arc<datafusion::arrow::datatypes::Schema>,
+    pub io_handle: tokio::runtime::Handle,
     pub rg_bloom_pruned: Option<datafusion::physical_plan::metrics::Count>,
     pub bloom_filter_eval_time: Option<datafusion::physical_plan::metrics::Time>,
 }
@@ -286,10 +287,11 @@ impl RowGroupBitsetSource for SingleCollectorEvaluator {
         }
 
         // Bloom filter pruning: runs after page pruning (free) but before
-        // the expensive FFM collector call.
+        // the expensive FFM collector call. Uses the IO runtime handle from
+        // the RuntimeManager to drive the async object-store read.
         if let (Some(bloom), Some(pp)) = (&self.bloom_config, &self.pruning_predicate) {
             let _timer = bloom.bloom_filter_eval_time.as_ref().map(|t| t.timer());
-            let pruned = futures::executor::block_on(
+            let pruned = bloom.io_handle.block_on(
                 crate::indexed_table::bloom_pruner::bloom_prune_rg(
                     &*bloom.store,
                     &bloom.object_path,

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/eval/single_collector.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/eval/single_collector.rs
@@ -37,6 +37,7 @@ use crate::indexed_table::page_pruner::{PagePruneMetrics, PagePruner};
 use crate::indexed_table::row_selection::{
     bitmap_to_packed_bits, packed_bits_to_boolean_array, row_selection_to_bitmap, PositionMap,
 };
+use datafusion::parquet::file::metadata::ParquetMetaData;
 use datafusion::physical_optimizer::pruning::PruningPredicate;
 use std::time::Instant;
 
@@ -174,6 +175,16 @@ pub struct SingleCollectorEvaluator {
     /// Per-query context identifier passed through every FFM upcall so Java can route
     /// each callback to the correct per-query `FilterDelegationHandle` and tracker.
     context_id: i64,
+    /// Bloom filter pruning config. None = disabled.
+    bloom_config: Option<BloomConfig>,
+}
+
+/// Resources needed for per-RG bloom filter pruning.
+pub struct BloomConfig {
+    pub store: Arc<dyn object_store::ObjectStore>,
+    pub object_path: object_store::path::Path,
+    pub metadata: Arc<ParquetMetaData>,
+    pub arrow_schema: Arc<datafusion::arrow::datatypes::Schema>,
 }
 
 impl SingleCollectorEvaluator {
@@ -189,6 +200,7 @@ impl SingleCollectorEvaluator {
         writer_generation: i64,
         delegated_backend_collector_factory: Arc<dyn DelegatedBackendCollectorFactory>,
         context_id: i64,
+        bloom_config: Option<BloomConfig>,
     ) -> Self {
         Self {
             collector,
@@ -202,6 +214,7 @@ impl SingleCollectorEvaluator {
             writer_generation,
             delegated_backend_collector_factory,
             context_id,
+            bloom_config,
         }
     }
 }
@@ -262,6 +275,31 @@ impl RowGroupBitsetSource for SingleCollectorEvaluator {
                     ranges
                 })
         });
+
+        // All pages pruned by stats → skip bloom + collector entirely.
+        if let Some(ref ranges) = page_ranges {
+            if ranges.is_empty() {
+                return Ok(None);
+            }
+        }
+
+        // Bloom filter pruning: runs after page pruning (free) but before
+        // the expensive FFM collector call.
+        if let (Some(bloom), Some(pp)) = (&self.bloom_config, &self.pruning_predicate) {
+            let pruned = futures::executor::block_on(
+                crate::indexed_table::bloom_pruner::bloom_prune_rg(
+                    &*bloom.store,
+                    &bloom.object_path,
+                    &bloom.metadata,
+                    &bloom.arrow_schema,
+                    rg.index,
+                    pp.as_ref(),
+                )
+            );
+            if pruned {
+                return Ok(None);
+            }
+        }
 
         // Build candidates either from the always-call correctness collector OR, when
         // the query is performance-only (no Collector leaves), from the page-pruned
@@ -644,7 +682,7 @@ mod tests {
             docs: vec![0, 3, 7],
         }) as Arc<dyn RowGroupDocsCollector>;
         let pruner = minimal_page_pruner();
-        let eval = SingleCollectorEvaluator::new(Some(collector), pruner, None, None, None, None, CollectorCallStrategy::FullRange, Arc::new(HashMap::new()), 0, Arc::new(FfmDelegatedBackendCollectorFactory), 0);
+        let eval = SingleCollectorEvaluator::new(Some(collector), pruner, None, None, None, None, CollectorCallStrategy::FullRange, Arc::new(HashMap::new()), 0, Arc::new(FfmDelegatedBackendCollectorFactory), 0, None);
 
         let rg = RowGroupInfo {
             index: 0,
@@ -660,7 +698,7 @@ mod tests {
     fn on_batch_mask_returns_none_for_path_b() {
         let collector = Arc::new(StubCollector { docs: vec![0] }) as Arc<dyn RowGroupDocsCollector>;
         let pruner = minimal_page_pruner();
-        let eval = SingleCollectorEvaluator::new(Some(collector), pruner, None, None, None, None, CollectorCallStrategy::FullRange, Arc::new(HashMap::new()), 0, Arc::new(FfmDelegatedBackendCollectorFactory), 0);
+        let eval = SingleCollectorEvaluator::new(Some(collector), pruner, None, None, None, None, CollectorCallStrategy::FullRange, Arc::new(HashMap::new()), 0, Arc::new(FfmDelegatedBackendCollectorFactory), 0, None);
         let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, false)]));
         let batch = datafusion::arrow::record_batch::RecordBatch::try_new(
             schema,
@@ -688,7 +726,7 @@ mod tests {
         // (it's the only post-decode filter we have on this path).
         let collector = Arc::new(StubCollector { docs: vec![0] }) as Arc<dyn RowGroupDocsCollector>;
         let pruner = minimal_page_pruner();
-        let eval = SingleCollectorEvaluator::new(Some(collector), pruner, None, None, None, None, CollectorCallStrategy::FullRange, Arc::new(HashMap::new()), 0, Arc::new(FfmDelegatedBackendCollectorFactory), 0);
+        let eval = SingleCollectorEvaluator::new(Some(collector), pruner, None, None, None, None, CollectorCallStrategy::FullRange, Arc::new(HashMap::new()), 0, Arc::new(FfmDelegatedBackendCollectorFactory), 0, None);
         assert!(eval.needs_row_mask());
     }
 
@@ -696,7 +734,7 @@ mod tests {
     fn empty_match_returns_none() {
         let collector = Arc::new(StubCollector { docs: vec![] }) as Arc<dyn RowGroupDocsCollector>;
         let pruner = minimal_page_pruner();
-        let eval = SingleCollectorEvaluator::new(Some(collector), pruner, None, None, None, None, CollectorCallStrategy::FullRange, Arc::new(HashMap::new()), 0, Arc::new(FfmDelegatedBackendCollectorFactory), 0);
+        let eval = SingleCollectorEvaluator::new(Some(collector), pruner, None, None, None, None, CollectorCallStrategy::FullRange, Arc::new(HashMap::new()), 0, Arc::new(FfmDelegatedBackendCollectorFactory), 0, None);
         let rg = RowGroupInfo {
             index: 0,
             first_row: 0,
@@ -716,7 +754,7 @@ mod tests {
             docs: vec![0, 3, 7],
         }) as Arc<dyn RowGroupDocsCollector>;
         let pruner = minimal_page_pruner();
-        let eval = SingleCollectorEvaluator::new(Some(collector), pruner, None, None, None, None, CollectorCallStrategy::FullRange, Arc::new(HashMap::new()), 0, Arc::new(FfmDelegatedBackendCollectorFactory), 0);
+        let eval = SingleCollectorEvaluator::new(Some(collector), pruner, None, None, None, None, CollectorCallStrategy::FullRange, Arc::new(HashMap::new()), 0, Arc::new(FfmDelegatedBackendCollectorFactory), 0, None);
 
         let rg = RowGroupInfo {
             index: 0,

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/eval/single_collector.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/eval/single_collector.rs
@@ -185,6 +185,8 @@ pub struct BloomConfig {
     pub object_path: object_store::path::Path,
     pub metadata: Arc<ParquetMetaData>,
     pub arrow_schema: Arc<datafusion::arrow::datatypes::Schema>,
+    pub rg_bloom_pruned: Option<datafusion::physical_plan::metrics::Count>,
+    pub bloom_filter_eval_time: Option<datafusion::physical_plan::metrics::Time>,
 }
 
 impl SingleCollectorEvaluator {
@@ -286,6 +288,7 @@ impl RowGroupBitsetSource for SingleCollectorEvaluator {
         // Bloom filter pruning: runs after page pruning (free) but before
         // the expensive FFM collector call.
         if let (Some(bloom), Some(pp)) = (&self.bloom_config, &self.pruning_predicate) {
+            let _timer = bloom.bloom_filter_eval_time.as_ref().map(|t| t.timer());
             let pruned = futures::executor::block_on(
                 crate::indexed_table::bloom_pruner::bloom_prune_rg(
                     &*bloom.store,
@@ -297,6 +300,9 @@ impl RowGroupBitsetSource for SingleCollectorEvaluator {
                 )
             );
             if pruned {
+                if let Some(ref c) = bloom.rg_bloom_pruned {
+                    c.add(1);
+                }
                 return Ok(None);
             }
         }

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/metrics.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/metrics.rs
@@ -36,6 +36,10 @@ pub struct StreamMetrics {
     pub min_skip_run_block_granular: Option<Count>,
     pub rg_processed: Option<Count>,
     pub rg_skipped: Option<Count>,
+    /// Row groups pruned by bloom filter (value proven absent).
+    pub rg_bloom_pruned: Option<Count>,
+    /// Time spent in bloom filter IO + evaluation across all RGs.
+    pub bloom_filter_eval_time: Option<Time>,
     /// Count of parquet pages the page-level pruner eliminated across
     /// all RGs in this partition.
     pub pages_pruned: Option<Count>,
@@ -114,6 +118,8 @@ impl StreamMetrics {
             min_skip_run_block_granular: None,
             rg_processed: None,
             rg_skipped: None,
+            rg_bloom_pruned: None,
+            bloom_filter_eval_time: None,
             pages_pruned: None,
             pages_total: None,
             page_pruning_unavailable: None,
@@ -150,6 +156,8 @@ pub struct PartitionMetrics {
     pub min_skip_run_block_granular: Count,
     pub row_groups_processed: Count,
     pub row_groups_skipped: Count,
+    pub rg_bloom_pruned: Count,
+    pub bloom_filter_eval_time: Time,
     pub pages_pruned: Count,
     pub pages_total: Count,
     pub page_pruning_unavailable: Count,
@@ -185,6 +193,8 @@ impl PartitionMetrics {
             min_skip_run_block_granular: counter("min_skip_run_block_granular"),
             row_groups_processed: counter("row_groups_processed"),
             row_groups_skipped: counter("row_groups_skipped"),
+            rg_bloom_pruned: counter("rg_bloom_pruned"),
+            bloom_filter_eval_time: MetricBuilder::new(metrics).subset_time("bloom_filter_eval_time", partition),
             pages_pruned: counter("pages_pruned"),
             pages_total: counter("pages_total"),
             page_pruning_unavailable: counter("page_pruning_unavailable"),
@@ -228,6 +238,8 @@ impl PartitionMetrics {
             min_skip_run_block_granular: Some(self.min_skip_run_block_granular),
             rg_processed: Some(self.row_groups_processed),
             rg_skipped: Some(self.row_groups_skipped),
+            rg_bloom_pruned: Some(self.rg_bloom_pruned),
+            bloom_filter_eval_time: Some(self.bloom_filter_eval_time),
             pages_pruned: Some(self.pages_pruned),
             pages_total: Some(self.pages_total),
             page_pruning_unavailable: Some(self.page_pruning_unavailable),

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/mod.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/mod.rs
@@ -54,6 +54,7 @@
 //!   into Java (provider/collector lifetime wrappers + registration)
 //! - `page_pruner`, `partitioning`, `parquet_bridge`, `metrics`, `segment_info` — support
 
+pub mod bloom_pruner;
 pub mod bool_tree;
 pub mod eval;
 pub mod row_id_injection;

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/fuzz/delegation.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/fuzz/delegation.rs
@@ -422,6 +422,7 @@ pub(in crate::indexed_table::tests_e2e) async fn execute_delegation_tree(
                 segment.writer_generation,
                 Arc::clone(&factory),
                 0,
+                None,
             ));
             Ok(eval)
         })

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/fuzz/harness.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/fuzz/harness.rs
@@ -402,6 +402,7 @@ pub(in crate::indexed_table::tests_e2e) async fn execute_tree_single_collector(
                 segment.writer_generation,
                 std::sync::Arc::new(crate::indexed_table::eval::single_collector::FfmDelegatedBackendCollectorFactory),
                 0,
+                None,
             ));
             let _ = segment;
             Ok(eval)

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/multi_segment.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/multi_segment.rs
@@ -160,6 +160,7 @@ async fn run_two_segment_query(
                     segment.writer_generation,
                     std::sync::Arc::new(crate::indexed_table::eval::single_collector::FfmDelegatedBackendCollectorFactory),
                     0,
+                    None,
                 ),
             );
                 Ok(eval)
@@ -364,6 +365,7 @@ async fn run_segments(specs: Vec<SegSpec>, num_partitions: usize) -> Vec<(i32, S
                     segment.writer_generation,
                     std::sync::Arc::new(crate::indexed_table::eval::single_collector::FfmDelegatedBackendCollectorFactory),
                     0,
+                    None,
                 ),
             );
                 Ok(eval)

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/page_pruning.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/page_pruning.rs
@@ -362,6 +362,7 @@ async fn run_single_collector(
                 segment.writer_generation,
                 std::sync::Arc::new(crate::indexed_table::eval::single_collector::FfmDelegatedBackendCollectorFactory),
                 0,
+                None,
             ));
             Ok(eval)
         })

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/session_context.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/session_context.rs
@@ -47,6 +47,9 @@ pub struct SessionContextHandle {
     pub indexed_config: Option<IndexedExecutionConfig>,
     /// Per-query tuning knobs (batch size, partitions, filter strategies, etc.)
     pub query_config: DatafusionQueryConfig,
+    /// IO runtime handle for bloom filter reads and other async I/O dispatched
+    /// from CPU executor threads (where the IO_RUNTIME thread-local may not be set).
+    pub io_handle: tokio::runtime::Handle,
     /// Aggregate execution mode for distributed partial/final stripping.
     pub(crate) aggregate_mode: crate::agg_mode::Mode,
     /// Pre-prepared physical plan (set by prepare_partial_plan / prepare_final_plan).
@@ -306,6 +309,7 @@ pub async unsafe fn create_session_context(
         table_name: table_name.to_string(),
         indexed_config: None,
         query_config,
+        io_handle: tokio::runtime::Handle::current(),
         aggregate_mode: crate::agg_mode::Mode::Default,
         prepared_plan: None,
         phantom_reservation: phantom,
@@ -517,6 +521,7 @@ mod tests {
             table_name: "t".to_string(),
             indexed_config: None,
             query_config: crate::datafusion_query_config::DatafusionQueryConfig::test_default(),
+            io_handle: tokio::runtime::Handle::current(),
             aggregate_mode: Mode::Default,
             prepared_plan: None,
             phantom_reservation: None,

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionSettings.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionSettings.java
@@ -61,6 +61,19 @@ public final class DatafusionSettings {
     );
 
     /**
+     * Whether to use parquet bloom filters for row-group pruning on the indexed read path.
+     * When true, equality predicates are checked against the SBBF (Split Block Bloom Filter)
+     * embedded in the parquet footer before invoking the expensive FFM collector call.
+     * If the bloom filter proves absence, the row group is skipped entirely.
+     */
+    public static final Setting<Boolean> INDEXED_BLOOM_FILTER_ON_READ = Setting.boolSetting(
+        "datafusion.indexed.bloom_filter_on_read",
+        true,
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
+    );
+
+    /**
      * Default minimum run length (in rows) below which the indexed stream skips
      * row-selection optimizations and falls back to sequential decode. Shorter runs
      * have higher per-row overhead from selection vector maintenance.
@@ -253,6 +266,7 @@ public final class DatafusionSettings {
         // Indexed query settings — per-query tuning knobs for the indexed execution path
         INDEXED_BATCH_SIZE,
         INDEXED_PARQUET_PUSHDOWN_FILTERS,
+        INDEXED_BLOOM_FILTER_ON_READ,
         INDEXED_MIN_SKIP_RUN_DEFAULT,
         INDEXED_MIN_SKIP_RUN_SELECTIVITY_THRESHOLD,
         INDEXED_SINGLE_COLLECTOR_STRATEGY,
@@ -294,6 +308,7 @@ public final class DatafusionSettings {
             .batchSize(INDEXED_BATCH_SIZE.get(settings))
             .targetPartitions(deriveTargetPartitions(this.concurrentSearchMode, this.maxSliceCount))
             .parquetPushdownFilters(INDEXED_PARQUET_PUSHDOWN_FILTERS.get(settings))
+            .bloomFilterOnRead(INDEXED_BLOOM_FILTER_ON_READ.get(settings))
             .minSkipRunDefault(INDEXED_MIN_SKIP_RUN_DEFAULT.get(settings))
             .minSkipRunSelectivityThreshold(INDEXED_MIN_SKIP_RUN_SELECTIVITY_THRESHOLD.get(settings))
             .singleCollectorStrategy(strategyToWireValue(INDEXED_SINGLE_COLLECTOR_STRATEGY.get(settings)))
@@ -317,6 +332,7 @@ public final class DatafusionSettings {
             .batchSize(INDEXED_BATCH_SIZE.get(settings))
             .targetPartitions(deriveTargetPartitions(this.concurrentSearchMode, this.maxSliceCount))
             .parquetPushdownFilters(INDEXED_PARQUET_PUSHDOWN_FILTERS.get(settings))
+            .bloomFilterOnRead(INDEXED_BLOOM_FILTER_ON_READ.get(settings))
             .minSkipRunDefault(INDEXED_MIN_SKIP_RUN_DEFAULT.get(settings))
             .minSkipRunSelectivityThreshold(INDEXED_MIN_SKIP_RUN_SELECTIVITY_THRESHOLD.get(settings))
             .singleCollectorStrategy(strategyToWireValue(INDEXED_SINGLE_COLLECTOR_STRATEGY.get(settings)))
@@ -333,6 +349,10 @@ public final class DatafusionSettings {
 
         clusterSettings.addSettingsUpdateConsumer(INDEXED_PARQUET_PUSHDOWN_FILTERS, newValue -> {
             snapshot = WireConfigSnapshot.builder(snapshot).parquetPushdownFilters(newValue).build();
+        });
+
+        clusterSettings.addSettingsUpdateConsumer(INDEXED_BLOOM_FILTER_ON_READ, newValue -> {
+            snapshot = WireConfigSnapshot.builder(snapshot).bloomFilterOnRead(newValue).build();
         });
 
         clusterSettings.addSettingsUpdateConsumer(INDEXED_MIN_SKIP_RUN_DEFAULT, newValue -> {

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/WireConfigSnapshot.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/WireConfigSnapshot.java
@@ -26,11 +26,12 @@ import java.lang.foreign.ValueLayout;
 public final class WireConfigSnapshot {
 
     /** Total byte size of the wire struct ({@code WireDatafusionQueryConfig}). */
-    public static final long BYTE_SIZE = 72;
+    public static final long BYTE_SIZE = 76;
 
     private final int batchSize;
     private final int targetPartitions;
     private final boolean parquetPushdownFilters;
+    private final boolean bloomFilterOnRead;
     private final int minSkipRunDefault;
     private final double minSkipRunSelectivityThreshold;
     private final int maxCollectorParallelism;
@@ -42,6 +43,7 @@ public final class WireConfigSnapshot {
         this.batchSize = builder.batchSize;
         this.targetPartitions = builder.targetPartitions;
         this.parquetPushdownFilters = builder.parquetPushdownFilters;
+        this.bloomFilterOnRead = builder.bloomFilterOnRead;
         this.minSkipRunDefault = builder.minSkipRunDefault;
         this.minSkipRunSelectivityThreshold = builder.minSkipRunSelectivityThreshold;
         this.maxCollectorParallelism = builder.maxCollectorParallelism;
@@ -62,6 +64,7 @@ public final class WireConfigSnapshot {
         return new Builder().batchSize(current.batchSize)
             .targetPartitions(current.targetPartitions)
             .parquetPushdownFilters(current.parquetPushdownFilters)
+            .bloomFilterOnRead(current.bloomFilterOnRead)
             .minSkipRunDefault(current.minSkipRunDefault)
             .minSkipRunSelectivityThreshold(current.minSkipRunSelectivityThreshold)
             .maxCollectorParallelism(current.maxCollectorParallelism)
@@ -80,6 +83,10 @@ public final class WireConfigSnapshot {
 
     public boolean parquetPushdownFilters() {
         return parquetPushdownFilters;
+    }
+
+    public boolean bloomFilterOnRead() {
+        return bloomFilterOnRead;
     }
 
     public int minSkipRunDefault() {
@@ -129,9 +136,10 @@ public final class WireConfigSnapshot {
      * 56      4     max_collector_parallelism            i32      from snapshot
      * 60      4     single_collector_strategy            i32      from snapshot
      * 64      4     tree_collector_strategy              i32      from snapshot
-     * 68      4     query_strategy                      i32      from snapshot (0/1/2)
+     * 68      4     query_strategy                       i32      from snapshot (0/1/2)
+     * 72      4     bloom_filter_on_read                 i32      from snapshot (0/1)
      * ──────  ────
-     * Total: 72 bytes
+     * Total: 76 bytes
      * </pre>
      *
      * @param segment the target memory segment (at least {@link #BYTE_SIZE} bytes)
@@ -165,6 +173,8 @@ public final class WireConfigSnapshot {
         segment.set(ValueLayout.JAVA_INT, 64, treeCollectorStrategy);
         // Offset 68: query_strategy (i32) — 0 = None, 1 = ListingTable, 2 = IndexedPredicateOnly
         segment.set(ValueLayout.JAVA_INT, 68, queryStrategy);
+        // Offset 72: bloom_filter_on_read (i32) — 0 = false, 1 = true
+        segment.set(ValueLayout.JAVA_INT, 72, bloomFilterOnRead ? 1 : 0);
     }
 
     /**
@@ -175,6 +185,7 @@ public final class WireConfigSnapshot {
         private int batchSize = 8192;
         private int targetPartitions = 4;
         private boolean parquetPushdownFilters = false;
+        private boolean bloomFilterOnRead = true;
         private int minSkipRunDefault = 1024;
         private double minSkipRunSelectivityThreshold = 0.03;
         private int maxCollectorParallelism = 1;
@@ -196,6 +207,11 @@ public final class WireConfigSnapshot {
 
         public Builder parquetPushdownFilters(boolean parquetPushdownFilters) {
             this.parquetPushdownFilters = parquetPushdownFilters;
+            return this;
+        }
+
+        public Builder bloomFilterOnRead(boolean bloomFilterOnRead) {
+            this.bloomFilterOnRead = bloomFilterOnRead;
             return this;
         }
 

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionPluginSettingsTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionPluginSettingsTests.java
@@ -97,6 +97,7 @@ public class DataFusionPluginSettingsTests extends OpenSearchTestCase {
 
             assertTrue(settingKeys.contains("datafusion.indexed.batch_size"));
             assertTrue(settingKeys.contains("datafusion.indexed.parquet_pushdown_filters"));
+            assertTrue(settingKeys.contains("datafusion.indexed.bloom_filter_on_read"));
             assertTrue(settingKeys.contains("datafusion.indexed.min_skip_run_default"));
             assertTrue(settingKeys.contains("datafusion.indexed.min_skip_run_selectivity_threshold"));
             assertTrue(settingKeys.contains("datafusion.indexed.single_collector_strategy"));
@@ -111,7 +112,7 @@ public class DataFusionPluginSettingsTests extends OpenSearchTestCase {
     public void testGetSettingsReturnsTotalExpectedCount() {
         try (DataFusionPlugin plugin = new DataFusionPlugin()) {
             List<Setting<?>> settings = plugin.getSettings();
-            assertEquals(25, settings.size());
+            assertEquals(26, settings.size());
         } catch (Exception e) {
             throw new AssertionError(e);
         }

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionSettingsTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionSettingsTests.java
@@ -69,10 +69,11 @@ public class DatafusionSettingsTests extends OpenSearchTestCase {
     }
 
     public void testAllSettingsContainsAllExpectedSettings() {
-        assertEquals(25, DatafusionSettings.ALL_SETTINGS.size());
+        assertEquals(26, DatafusionSettings.ALL_SETTINGS.size());
         assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DataFusionPlugin.DATAFUSION_REDUCE_TARGET_PARTITIONS));
         assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DatafusionSettings.INDEXED_BATCH_SIZE));
         assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DatafusionSettings.INDEXED_PARQUET_PUSHDOWN_FILTERS));
+        assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DatafusionSettings.INDEXED_BLOOM_FILTER_ON_READ));
         assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DatafusionSettings.INDEXED_MIN_SKIP_RUN_DEFAULT));
         assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DatafusionSettings.INDEXED_MIN_SKIP_RUN_SELECTIVITY_THRESHOLD));
         assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DatafusionSettings.INDEXED_SINGLE_COLLECTOR_STRATEGY));
@@ -87,6 +88,7 @@ public class DatafusionSettingsTests extends OpenSearchTestCase {
 
         assertEquals(8192, snapshot.batchSize());
         assertEquals(false, snapshot.parquetPushdownFilters());
+        assertEquals(true, snapshot.bloomFilterOnRead());
         assertEquals(1024, snapshot.minSkipRunDefault());
         assertEquals(0.03, snapshot.minSkipRunSelectivityThreshold(), 1e-15);
         assertEquals(2, snapshot.singleCollectorStrategy()); // page_range_split

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/WireConfigSnapshotTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/WireConfigSnapshotTests.java
@@ -17,7 +17,7 @@ import java.lang.foreign.ValueLayout;
 public class WireConfigSnapshotTests extends OpenSearchTestCase {
 
     public void testByteSize() {
-        assertEquals(72L, WireConfigSnapshot.BYTE_SIZE);
+        assertEquals(76L, WireConfigSnapshot.BYTE_SIZE);
     }
 
     public void testWriteToWritesCorrectValuesAtCorrectOffsets() {
@@ -81,6 +81,7 @@ public class WireConfigSnapshotTests extends OpenSearchTestCase {
         assertEquals(8192, snapshot.batchSize());
         assertEquals(4, snapshot.targetPartitions());
         assertEquals(false, snapshot.parquetPushdownFilters());
+        assertEquals(true, snapshot.bloomFilterOnRead());
         assertEquals(1024, snapshot.minSkipRunDefault());
         assertEquals(0.03, snapshot.minSkipRunSelectivityThreshold(), 1e-15);
         assertEquals(1, snapshot.maxCollectorParallelism());
@@ -94,6 +95,7 @@ public class WireConfigSnapshotTests extends OpenSearchTestCase {
             .batchSize(4096)
             .targetPartitions(16)
             .parquetPushdownFilters(true)
+            .bloomFilterOnRead(false)
             .minSkipRunDefault(512)
             .minSkipRunSelectivityThreshold(0.5)
             .maxCollectorParallelism(8)
@@ -107,6 +109,7 @@ public class WireConfigSnapshotTests extends OpenSearchTestCase {
         assertEquals(original.batchSize(), copy.batchSize());
         assertEquals(original.targetPartitions(), copy.targetPartitions());
         assertEquals(original.parquetPushdownFilters(), copy.parquetPushdownFilters());
+        assertEquals(original.bloomFilterOnRead(), copy.bloomFilterOnRead());
         assertEquals(original.minSkipRunDefault(), copy.minSkipRunDefault());
         assertEquals(original.minSkipRunSelectivityThreshold(), copy.minSkipRunSelectivityThreshold(), 0.0);
         assertEquals(original.maxCollectorParallelism(), copy.maxCollectorParallelism());


### PR DESCRIPTION
Integrate per-row-group bloom filter checks into the indexed execution prefetch phase. When enabled, equality predicates (=, IN) are checked against parquet bloom filters before invoking the Lucene collector FFM call. If the bloom filter proves the queried value is absent from a row group, the entire RG is skipped — saving the FFM round-trip, page pruning, and parquet decode.

Java:
- Add datafusion.indexed.bloom_filter_on_read (Dynamic, NodeScope, default true) to DatafusionSettings
- Wire through WireConfigSnapshot at offset 72 (i32, 0/1)

Rust:
- Add bloom_filter_on_read to WireDatafusionQueryConfig + DatafusionQueryConfig
- New module: indexed_table/bloom_pruner.rs
  - extract_equality_checks: walks PhysicalExpr tree for col=lit and IN
  - read_bloom_filter: fetches SBBF bytes from object store per RG/column
  - scalar_to_bloom_check: converts ScalarValue to Sbbf::check input
  - bloom_prune_rg: top-level entry — returns true if RG can be skipped
- SingleCollectorEvaluator: accepts store/path/metadata/schema; calls bloom_prune_rg at the top of prefetch_rg (before page pruning)
- indexed_executor: captures store + schema + bloom_filter_on_read in the evaluator factory closure

Design:
- AND semantics only: if any single column's equality proves absence, skip the RG. OR predicates are not extracted (future enhancement).
- Conservative: any IO error or unsupported type → do NOT prune.
- Runs synchronously via futures::executor::block_on since prefetch_rg is already on a worker thread; bloom filter reads are small (~8-32KB).

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
