### PR TITLE
[Feature Request] gRPC indexing: add support for ExtraFieldsValues

### DIFF
--- a/modules/transport-grpc/src/main/java/org/opensearch/transport/grpc/proto/request/document/bulk/BulkRequestParserProtoUtils.java
+++ b/modules/transport-grpc/src/main/java/org/opensearch/transport/grpc/proto/request/document/bulk/BulkRequestParserProtoUtils.java
@@ -23,6 +23,7 @@ import org.opensearch.core.xcontent.MediaType;
 import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.index.VersionType;
+import org.opensearch.index.mapper.extrasource.ExtraFieldValues;
 import org.opensearch.index.seqno.SequenceNumbers;
 import org.opensearch.protobufs.BulkRequest;
 import org.opensearch.protobufs.BulkRequestBody;
@@ -96,7 +97,7 @@ public class BulkRequestParserProtoUtils {
      * @param byteString The protobuf ByteString to convert
      * @return A BytesReference wrapping the ByteString data
      */
-    private static BytesReference byteStringToBytesReference(ByteString byteString) {
+    static BytesReference byteStringToBytesReference(ByteString byteString) {
         if (byteString == null || byteString.isEmpty()) {
             return BytesArray.EMPTY;
         }
@@ -162,12 +163,14 @@ public class BulkRequestParserProtoUtils {
             String pipeline = valueOrDefault(defaultPipeline, request.getPipeline());
             Boolean requireAlias = valueOrDefault(defaultRequireAlias, request.getRequireAlias());
 
+            ExtraFieldValues extraFieldValues = ExtraFieldValuesProtoUtils.fromProto(bulkRequestBodyEntry);
             OperationContainer operationContainer = bulkRequestBodyEntry.getOperationContainer();
             switch (operationContainer.getOperationContainerCase()) {
                 case CREATE:
                     docWriteRequest = buildCreateRequest(
                         operationContainer.getCreate(),
                         bulkRequestBodyEntry.getObject(),
+                        extraFieldValues,
                         index,
                         id,
                         routing,
@@ -183,6 +186,7 @@ public class BulkRequestParserProtoUtils {
                     docWriteRequest = buildIndexRequest(
                         operationContainer.getIndex(),
                         bulkRequestBodyEntry.getObject(),
+                        extraFieldValues,
                         opType,
                         index,
                         id,
@@ -209,6 +213,7 @@ public class BulkRequestParserProtoUtils {
                     docWriteRequest = buildUpdateRequest(
                         operationContainer.getUpdate(),
                         updateDocBytes,
+                        extraFieldValues,
                         bulkRequestBodyEntry,
                         index,
                         id,
@@ -222,6 +227,9 @@ public class BulkRequestParserProtoUtils {
                     );
                     break;
                 case DELETE:
+                    if (extraFieldValues.isEmpty() == false) {
+                        throw new IllegalArgumentException("extra_field_values are not supported for delete operations");
+                    }
                     docWriteRequest = buildDeleteRequest(
                         operationContainer.getDelete(),
                         index,
@@ -250,6 +258,7 @@ public class BulkRequestParserProtoUtils {
      *
      * @param createOperation The create operation protobuf message
      * @param documentBytes The document content as ByteString (zero-copy reference)
+     * @param extraFieldValues The extra field values to index outside {@code _source}
      * @param index The default index name
      * @param id The default document ID
      * @param routing The default routing value
@@ -264,6 +273,7 @@ public class BulkRequestParserProtoUtils {
     public static IndexRequest buildCreateRequest(
         WriteOperation createOperation,
         ByteString documentBytes,
+        ExtraFieldValues extraFieldValues,
         String index,
         String id,
         String routing,
@@ -294,6 +304,7 @@ public class BulkRequestParserProtoUtils {
             .setIfSeqNo(ifSeqNo)
             .setIfPrimaryTerm(ifPrimaryTerm)
             .source(documentRef, mediaType)
+            .extraFieldValues(extraFieldValues)
             .setRequireAlias(requireAlias);
         return indexRequest;
     }
@@ -303,6 +314,7 @@ public class BulkRequestParserProtoUtils {
      *
      * @param indexOperation The index operation protobuf message
      * @param documentBytes The document content as ByteString (zero-copy reference)
+     * @param extraFieldValues The extra field values to index outside {@code _source}
      * @param opType The default operation type
      * @param index The default index name
      * @param id The default document ID
@@ -318,6 +330,7 @@ public class BulkRequestParserProtoUtils {
     public static IndexRequest buildIndexRequest(
         IndexOperation indexOperation,
         ByteString documentBytes,
+        ExtraFieldValues extraFieldValues,
         OpType opType,
         String index,
         String id,
@@ -358,6 +371,7 @@ public class BulkRequestParserProtoUtils {
                 .setIfSeqNo(ifSeqNo)
                 .setIfPrimaryTerm(ifPrimaryTerm)
                 .source(documentRef, mediaType)
+                .extraFieldValues(extraFieldValues)
                 .setRequireAlias(requireAlias);
         } else {
             indexRequest = new IndexRequest(index).id(id)
@@ -369,6 +383,7 @@ public class BulkRequestParserProtoUtils {
                 .setIfSeqNo(ifSeqNo)
                 .setIfPrimaryTerm(ifPrimaryTerm)
                 .source(documentRef, mediaType)
+                .extraFieldValues(extraFieldValues)
                 .setRequireAlias(requireAlias);
         }
         return indexRequest;
@@ -379,6 +394,7 @@ public class BulkRequestParserProtoUtils {
      *
      * @param updateOperation The update operation protobuf message
      * @param documentBytes The document content as ByteString (zero-copy reference)
+     * @param extraFieldValues The extra field values to apply to update doc/upsert sources
      * @param bulkRequestBody The bulk request body containing additional update options
      * @param index The default index name
      * @param id The default document ID
@@ -394,6 +410,7 @@ public class BulkRequestParserProtoUtils {
     public static UpdateRequest buildUpdateRequest(
         UpdateOperation updateOperation,
         ByteString documentBytes,
+        ExtraFieldValues extraFieldValues,
         BulkRequestBody bulkRequestBody,
         String index,
         String id,
@@ -428,6 +445,7 @@ public class BulkRequestParserProtoUtils {
 
         // Populate all document-level fields
         updateRequest = fromProto(updateRequest, documentBytes, bulkRequestBody, ifSeqNo, ifPrimaryTerm);
+        applyUpdateExtraFieldValues(updateRequest, extraFieldValues);
 
         // Apply fetchSourceContext default
         if (fetchSourceContext != null) {
@@ -441,6 +459,27 @@ public class BulkRequestParserProtoUtils {
         }
 
         return updateRequest;
+    }
+
+    private static void applyUpdateExtraFieldValues(UpdateRequest updateRequest, ExtraFieldValues extraFieldValues) {
+        if (extraFieldValues == null || extraFieldValues.isEmpty()) {
+            return;
+        }
+
+        // Bulk gRPC has one extra_field_values map for the update item, so it applies to every concrete indexing path
+        // represented in the UpdateRequest. UpdateHelper later executes only the doc path or the upsert path.
+        boolean applied = false;
+        if (updateRequest.doc() != null) {
+            updateRequest.docExtraFieldValues(extraFieldValues);
+            applied = true;
+        }
+        if (updateRequest.upsertRequest() != null) {
+            updateRequest.upsertExtraFieldValues(extraFieldValues);
+            applied = true;
+        }
+        if (applied == false) {
+            throw new IllegalArgumentException("extra_field_values require an update doc or upsert document");
+        }
     }
 
     /**

--- a/modules/transport-grpc/src/main/java/org/opensearch/transport/grpc/proto/request/document/bulk/ExtraFieldValuesProtoUtils.java
+++ b/modules/transport-grpc/src/main/java/org/opensearch/transport/grpc/proto/request/document/bulk/ExtraFieldValuesProtoUtils.java
@@ -1,0 +1,112 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.transport.grpc.proto.request.document.bulk;
+
+import com.google.protobuf.ByteString;
+import org.opensearch.index.mapper.extrasource.BytesValue;
+import org.opensearch.index.mapper.extrasource.ExtraFieldValue;
+import org.opensearch.index.mapper.extrasource.ExtraFieldValues;
+import org.opensearch.index.mapper.extrasource.FloatArrayValue;
+import org.opensearch.protobufs.BinaryFieldValue;
+import org.opensearch.protobufs.BulkRequestBody;
+import org.opensearch.protobufs.FloatList;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Converts protobuf extra field values into OpenSearch extra source values.
+ */
+final class ExtraFieldValuesProtoUtils {
+
+    private ExtraFieldValuesProtoUtils() {}
+
+    static ExtraFieldValues fromProto(BulkRequestBody body) {
+        Map<String, BinaryFieldValue> m = body.getExtraFieldValuesMap();
+        if (m.isEmpty()) {
+            return ExtraFieldValues.EMPTY;
+        }
+
+        Map<String, ExtraFieldValue> out = new HashMap<>(Math.max(16, m.size() * 2));
+        for (Map.Entry<String, BinaryFieldValue> e : m.entrySet()) {
+            try {
+                out.put(e.getKey(), toExtraFieldValue(e.getValue()));
+            } catch (IllegalArgumentException ex) {
+                throw new IllegalArgumentException("Invalid extra_field_values entry [" + e.getKey() + "]: " + ex.getMessage(), ex);
+            }
+        }
+        return new ExtraFieldValues(out);
+    }
+
+    private static ExtraFieldValue toExtraFieldValue(BinaryFieldValue protoVal) {
+        switch (protoVal.getBinaryFieldValueCase()) {
+            case BYTES_VALUE: {
+                return new BytesValue(BulkRequestParserProtoUtils.byteStringToBytesReference(protoVal.getBytesValue().getBytes()));
+            }
+            case FLOAT_ARRAY_VALUE: {
+                return toInternalFloatArrayValue(protoVal.getFloatArrayValue());
+            }
+            case BINARYFIELDVALUE_NOT_SET:
+            default:
+                throw new IllegalArgumentException("Unsupported/empty BinaryFieldValue: " + protoVal.getBinaryFieldValueCase());
+        }
+    }
+
+    private static FloatArrayValue toInternalFloatArrayValue(org.opensearch.protobufs.FloatArrayValue fav) {
+        switch (fav.getEncodingCase()) {
+            case BINARY_LE: {
+                final ByteString bs = fav.getBinaryLe().getBytesLe();
+                int dim = resolvePackedDimension(bs, fav.getBinaryLe().getDimension(), Float.BYTES, "float");
+                return FloatArrayValue.fromPackedBytes(BulkRequestParserProtoUtils.byteStringToBytesReference(bs), dim);
+            }
+            case VALUES: {
+                final FloatList fl = fav.getValues();
+                final int count = fl.getValuesCount();
+                final float[] arr = new float[count];
+                // Important: Avoid boxing, protobuf uses primitive float list internally
+                for (int i = 0; i < count; i++) {
+                    arr[i] = fl.getValues(i);
+                }
+                return FloatArrayValue.fromFloatArray(arr);
+            }
+            case ENCODING_NOT_SET:
+            default:
+                throw new IllegalArgumentException("FloatArrayValue.repr is not set");
+        }
+    }
+
+    private static int resolvePackedDimension(ByteString bytes, int dimension, int bytesPerElement, String valueType) {
+        if (dimension < 0) {
+            throw new IllegalArgumentException(valueType + " dimension must be >= 0 but was " + dimension);
+        }
+
+        int byteLength = bytes.size();
+        if (dimension == 0) {
+            if (byteLength % bytesPerElement != 0) {
+                throw new IllegalArgumentException(
+                    valueType + " packed_le byte length must be multiple of " + bytesPerElement + " but was " + byteLength
+                );
+            }
+            return byteLength / bytesPerElement;
+        }
+
+        final int expectedByteLength;
+        try {
+            expectedByteLength = Math.multiplyExact(dimension, bytesPerElement);
+        } catch (ArithmeticException e) {
+            throw new IllegalArgumentException(valueType + " dimension too large: " + dimension, e);
+        }
+        if (byteLength != expectedByteLength) {
+            throw new IllegalArgumentException(
+                "Bad packed " + valueType + " length=" + byteLength + " expected=" + expectedByteLength + " (dim=" + dimension + ")"
+            );
+        }
+        return dimension;
+    }
+}

--- a/modules/transport-grpc/src/test/java/org/opensearch/transport/grpc/proto/request/document/bulk/BulkRequestParserProtoUtilsTests.java
+++ b/modules/transport-grpc/src/test/java/org/opensearch/transport/grpc/proto/request/document/bulk/BulkRequestParserProtoUtilsTests.java
@@ -19,10 +19,17 @@ import org.opensearch.core.common.bytes.BytesArray;
 import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.core.xcontent.MediaType;
 import org.opensearch.index.VersionType;
+import org.opensearch.index.mapper.extrasource.BytesValue;
+import org.opensearch.index.mapper.extrasource.ExtraFieldValue;
+import org.opensearch.index.mapper.extrasource.ExtraFieldValues;
+import org.opensearch.index.mapper.extrasource.FloatArrayValue;
 import org.opensearch.index.seqno.SequenceNumbers;
+import org.opensearch.protobufs.BinaryFieldValue;
 import org.opensearch.protobufs.BulkRequest;
 import org.opensearch.protobufs.BulkRequestBody;
 import org.opensearch.protobufs.DeleteOperation;
+import org.opensearch.protobufs.FloatBinaryLE;
+import org.opensearch.protobufs.FloatList;
 import org.opensearch.protobufs.IndexOperation;
 import org.opensearch.protobufs.OpType;
 import org.opensearch.protobufs.OperationContainer;
@@ -30,6 +37,8 @@ import org.opensearch.protobufs.UpdateOperation;
 import org.opensearch.protobufs.WriteOperation;
 import org.opensearch.test.OpenSearchTestCase;
 
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
 
 import static org.opensearch.index.seqno.SequenceNumbers.UNASSIGNED_PRIMARY_TERM;
@@ -49,6 +58,7 @@ public class BulkRequestParserProtoUtilsTests extends OpenSearchTestCase {
         IndexRequest indexRequest = BulkRequestParserProtoUtils.buildCreateRequest(
             writeOperation,
             UnsafeByteOperations.unsafeWrap(document),
+            ExtraFieldValues.EMPTY,
             "default-index",
             "default-id",
             "default-routing",
@@ -91,6 +101,7 @@ public class BulkRequestParserProtoUtilsTests extends OpenSearchTestCase {
         IndexRequest indexRequest = BulkRequestParserProtoUtils.buildIndexRequest(
             indexOperation,
             UnsafeByteOperations.unsafeWrap(document),
+            ExtraFieldValues.EMPTY,
             null,
             "default-index",
             "default-id",
@@ -126,6 +137,7 @@ public class BulkRequestParserProtoUtilsTests extends OpenSearchTestCase {
         IndexRequest indexRequest = BulkRequestParserProtoUtils.buildIndexRequest(
             indexOperation,
             UnsafeByteOperations.unsafeWrap(document),
+            ExtraFieldValues.EMPTY,
             opType,
             "default-index",
             "default-id",
@@ -198,6 +210,7 @@ public class BulkRequestParserProtoUtilsTests extends OpenSearchTestCase {
         UpdateRequest updateRequest = BulkRequestParserProtoUtils.buildUpdateRequest(
             updateOperation,
             UnsafeByteOperations.unsafeWrap(document),
+            ExtraFieldValues.EMPTY,
             bulkRequestBody,
             "default-index",
             "default-id",
@@ -317,6 +330,7 @@ public class BulkRequestParserProtoUtilsTests extends OpenSearchTestCase {
         IndexRequest indexRequest = BulkRequestParserProtoUtils.buildCreateRequest(
             writeOperation,
             UnsafeByteOperations.unsafeWrap(document),
+            ExtraFieldValues.EMPTY,
             "default-index",
             "default-id",
             "default-routing",
@@ -344,6 +358,7 @@ public class BulkRequestParserProtoUtilsTests extends OpenSearchTestCase {
         IndexRequest indexRequest = BulkRequestParserProtoUtils.buildCreateRequest(
             writeOperation,
             UnsafeByteOperations.unsafeWrap(document),
+            ExtraFieldValues.EMPTY,
             "default-index",
             "default-id",
             "default-routing",
@@ -376,6 +391,7 @@ public class BulkRequestParserProtoUtilsTests extends OpenSearchTestCase {
         IndexRequest indexRequest = BulkRequestParserProtoUtils.buildIndexRequest(
             indexOperation,
             UnsafeByteOperations.unsafeWrap(document),
+            ExtraFieldValues.EMPTY,
             OpType.OP_TYPE_INDEX,
             "default-index",
             "default-id",
@@ -409,6 +425,7 @@ public class BulkRequestParserProtoUtilsTests extends OpenSearchTestCase {
         IndexRequest indexRequest = BulkRequestParserProtoUtils.buildIndexRequest(
             indexOperation,
             UnsafeByteOperations.unsafeWrap(document),
+            ExtraFieldValues.EMPTY,
             null,
             "default-index",
             "default-id",
@@ -458,6 +475,7 @@ public class BulkRequestParserProtoUtilsTests extends OpenSearchTestCase {
         UpdateRequest updateRequest = BulkRequestParserProtoUtils.buildUpdateRequest(
             updateOperation,
             UnsafeByteOperations.unsafeWrap(document),
+            ExtraFieldValues.EMPTY,
             bulkRequestBody,
             "default-index",
             "default-id",
@@ -490,6 +508,7 @@ public class BulkRequestParserProtoUtilsTests extends OpenSearchTestCase {
         UpdateRequest updateRequest = BulkRequestParserProtoUtils.buildUpdateRequest(
             updateOperation,
             UnsafeByteOperations.unsafeWrap(document),
+            ExtraFieldValues.EMPTY,
             bulkRequestBody,
             "default-index",
             "default-id",
@@ -520,6 +539,7 @@ public class BulkRequestParserProtoUtilsTests extends OpenSearchTestCase {
         UpdateRequest updateRequest = BulkRequestParserProtoUtils.buildUpdateRequest(
             updateOperation,
             UnsafeByteOperations.unsafeWrap(document),
+            ExtraFieldValues.EMPTY,
             bulkRequestBody,
             "default-index",
             "default-id",
@@ -554,6 +574,7 @@ public class BulkRequestParserProtoUtilsTests extends OpenSearchTestCase {
         UpdateRequest updateRequest = BulkRequestParserProtoUtils.buildUpdateRequest(
             updateOperation,
             UnsafeByteOperations.unsafeWrap(document),
+            ExtraFieldValues.EMPTY,
             bulkRequestBody,
             "default-index",
             "default-id",
@@ -583,6 +604,7 @@ public class BulkRequestParserProtoUtilsTests extends OpenSearchTestCase {
         UpdateRequest updateRequest = BulkRequestParserProtoUtils.buildUpdateRequest(
             updateOperation,
             UnsafeByteOperations.unsafeWrap(document),
+            ExtraFieldValues.EMPTY,
             bulkRequestBody,
             "default-index",
             "default-id",
@@ -736,6 +758,7 @@ public class BulkRequestParserProtoUtilsTests extends OpenSearchTestCase {
         IndexRequest indexRequest = BulkRequestParserProtoUtils.buildCreateRequest(
             writeOperation,
             UnsafeByteOperations.unsafeWrap(smileDocument),
+            ExtraFieldValues.EMPTY,
             "default-index",
             "default-id",
             null,
@@ -764,6 +787,7 @@ public class BulkRequestParserProtoUtilsTests extends OpenSearchTestCase {
         IndexRequest indexRequest = BulkRequestParserProtoUtils.buildCreateRequest(
             writeOperation,
             UnsafeByteOperations.unsafeWrap(cborDocument),
+            ExtraFieldValues.EMPTY,
             "default-index",
             "default-id",
             null,
@@ -792,6 +816,7 @@ public class BulkRequestParserProtoUtilsTests extends OpenSearchTestCase {
         IndexRequest indexRequest = BulkRequestParserProtoUtils.buildIndexRequest(
             indexOperation,
             UnsafeByteOperations.unsafeWrap(smileDocument),
+            ExtraFieldValues.EMPTY,
             null,
             "default-index",
             "default-id",
@@ -820,6 +845,7 @@ public class BulkRequestParserProtoUtilsTests extends OpenSearchTestCase {
         IndexRequest indexRequest = BulkRequestParserProtoUtils.buildIndexRequest(
             indexOperation,
             UnsafeByteOperations.unsafeWrap(cborDocument),
+            ExtraFieldValues.EMPTY,
             null,
             "default-index",
             "default-id",
@@ -872,6 +898,7 @@ public class BulkRequestParserProtoUtilsTests extends OpenSearchTestCase {
         IndexRequest indexRequest = BulkRequestParserProtoUtils.buildCreateRequest(
             writeOperation,
             UnsafeByteOperations.unsafeWrap(emptyDocument),
+            ExtraFieldValues.EMPTY,
             "default-index",
             "default-id",
             null,
@@ -898,6 +925,7 @@ public class BulkRequestParserProtoUtilsTests extends OpenSearchTestCase {
         IndexRequest indexRequest = BulkRequestParserProtoUtils.buildCreateRequest(
             writeOperation,
             UnsafeByteOperations.unsafeWrap(jsonDocument),
+            ExtraFieldValues.EMPTY,
             "default-index",
             "default-id",
             null,
@@ -926,6 +954,7 @@ public class BulkRequestParserProtoUtilsTests extends OpenSearchTestCase {
         IndexRequest indexRequest = BulkRequestParserProtoUtils.buildCreateRequest(
             writeOperation,
             UnsafeByteOperations.unsafeWrap(yamlDocument),
+            ExtraFieldValues.EMPTY,
             "default-index",
             "default-id",
             null,
@@ -954,6 +983,7 @@ public class BulkRequestParserProtoUtilsTests extends OpenSearchTestCase {
         IndexRequest indexRequest = BulkRequestParserProtoUtils.buildIndexRequest(
             indexOperation,
             UnsafeByteOperations.unsafeWrap(jsonDocument),
+            ExtraFieldValues.EMPTY,
             null,
             "default-index",
             "default-id",
@@ -982,6 +1012,7 @@ public class BulkRequestParserProtoUtilsTests extends OpenSearchTestCase {
         IndexRequest indexRequest = BulkRequestParserProtoUtils.buildIndexRequest(
             indexOperation,
             UnsafeByteOperations.unsafeWrap(yamlDocument),
+            ExtraFieldValues.EMPTY,
             null,
             "default-index",
             "default-id",
@@ -1072,6 +1103,7 @@ public class BulkRequestParserProtoUtilsTests extends OpenSearchTestCase {
         UpdateRequest updateRequest = BulkRequestParserProtoUtils.buildUpdateRequest(
             updateOperation,
             UnsafeByteOperations.unsafeWrap(document),
+            ExtraFieldValues.EMPTY,
             bulkRequestBody,
             "default-index",
             "default-id",
@@ -1273,6 +1305,7 @@ public class BulkRequestParserProtoUtilsTests extends OpenSearchTestCase {
         IndexRequest indexRequest = BulkRequestParserProtoUtils.buildCreateRequest(
             createOp,
             byteString,
+            ExtraFieldValues.EMPTY,
             "default-index",
             "default-id",
             "default-routing",
@@ -1303,6 +1336,7 @@ public class BulkRequestParserProtoUtilsTests extends OpenSearchTestCase {
         IndexRequest indexRequest = BulkRequestParserProtoUtils.buildCreateRequest(
             createOp,
             byteString,
+            ExtraFieldValues.EMPTY,
             "default-index",
             "default-id",
             "default-routing",
@@ -1330,6 +1364,7 @@ public class BulkRequestParserProtoUtilsTests extends OpenSearchTestCase {
         IndexRequest indexRequest = BulkRequestParserProtoUtils.buildCreateRequest(
             createOp,
             byteString,
+            ExtraFieldValues.EMPTY,
             "default-index",
             "default-id",
             "default-routing",
@@ -1365,6 +1400,7 @@ public class BulkRequestParserProtoUtilsTests extends OpenSearchTestCase {
         UpdateRequest updateRequest = BulkRequestParserProtoUtils.buildUpdateRequest(
             updateOp,
             docBytes,
+            ExtraFieldValues.EMPTY,
             bulkRequestBody,
             "default-index",
             "default-id",
@@ -1404,6 +1440,7 @@ public class BulkRequestParserProtoUtilsTests extends OpenSearchTestCase {
         UpdateRequest updateRequest = BulkRequestParserProtoUtils.buildUpdateRequest(
             updateOp,
             UnsafeByteOperations.unsafeWrap(docBytes),
+            ExtraFieldValues.EMPTY,
             bulkRequestBody,
             "default-index",
             "default-id",
@@ -1447,6 +1484,7 @@ public class BulkRequestParserProtoUtilsTests extends OpenSearchTestCase {
         UpdateRequest updateRequest = BulkRequestParserProtoUtils.buildUpdateRequest(
             updateOp,
             ByteString.copyFrom(docBytes),
+            ExtraFieldValues.EMPTY,
             bulkRequestBody,
             "default-index",
             "default-id",
@@ -1487,6 +1525,7 @@ public class BulkRequestParserProtoUtilsTests extends OpenSearchTestCase {
         IndexRequest indexRequest = BulkRequestParserProtoUtils.buildIndexRequest(
             indexOp,
             UnsafeByteOperations.unsafeWrap(document),
+            ExtraFieldValues.EMPTY,
             null,
             "default-index",
             "default-id",
@@ -1517,6 +1556,7 @@ public class BulkRequestParserProtoUtilsTests extends OpenSearchTestCase {
         IndexRequest indexRequest = BulkRequestParserProtoUtils.buildCreateRequest(
             createOp,
             UnsafeByteOperations.unsafeWrap(document),
+            ExtraFieldValues.EMPTY,
             "default-index",
             "default-id",
             "default-routing",
@@ -1532,4 +1572,267 @@ public class BulkRequestParserProtoUtilsTests extends OpenSearchTestCase {
         assertNotNull("Source should not be null", indexRequest.source());
         assertEquals("Source content should match UTF-8", jsonWithUnicode, indexRequest.source().utf8ToString());
     }
+
+    public void testGetDocWriteRequestsWithExtraFieldValuesOnIndex() {
+        byte[] rawBytes = new byte[] { 0, 1, 2, 127, -128, -1 };
+        BulkRequestBody indexBody = indexBodyBuilder().putExtraFieldValues("raw_bytes", binaryBytesValue(rawBytes))
+            .putExtraFieldValues("vector_values", binaryFloatValues(1.5f, 2.5f))
+            .putExtraFieldValues("vector_packed", binaryPackedFloatValue(packFloatLE(3.5f, 4.5f), 2))
+            .build();
+
+        IndexRequest indexRequest = parseSingleIndexRequest(indexBody);
+
+        assertBytesValue(indexRequest.extraFieldValues().get("raw_bytes"), rawBytes);
+        assertFloatArrayValue(indexRequest.extraFieldValues().get("vector_values"), false, 1.5f, 2.5f);
+        assertFloatArrayValue(indexRequest.extraFieldValues().get("vector_packed"), true, 3.5f, 4.5f);
+    }
+
+    public void testGetDocWriteRequestsWithExtraFieldValuesOnCreate() {
+        BulkRequestBody createBody = createBodyBuilder().putExtraFieldValues("vector", binaryPackedFloatValue(packFloatLE(5.5f, 6.5f)))
+            .build();
+
+        IndexRequest createRequest = parseSingleIndexRequest(createBody);
+
+        assertEquals(DocWriteRequest.OpType.CREATE, createRequest.opType());
+        assertFloatArrayValue(createRequest.extraFieldValues().get("vector"), true, 5.5f, 6.5f);
+    }
+
+    public void testGetDocWriteRequestsWithExtraFieldValuesOnUpdateDocAndUpsert() {
+        org.opensearch.protobufs.UpdateAction updateAction = org.opensearch.protobufs.UpdateAction.newBuilder()
+            .setDoc(ByteString.copyFromUtf8("{\"field\":\"updated\"}"))
+            .setUpsert(ByteString.copyFromUtf8("{\"field\":\"created\"}"))
+            .build();
+
+        BulkRequestBody updateBody = updateBodyBuilder(updateAction).putExtraFieldValues("vector", binaryFloatValues(3.5f, 4.5f)).build();
+
+        UpdateRequest updateRequest = parseSingleUpdateRequest(updateBody);
+
+        assertNotNull(updateRequest.doc());
+        assertNotNull(updateRequest.upsertRequest());
+        assertFloatArrayValue(updateRequest.doc().extraFieldValues().get("vector"), false, 3.5f, 4.5f);
+        assertFloatArrayValue(updateRequest.upsertRequest().extraFieldValues().get("vector"), false, 3.5f, 4.5f);
+    }
+
+    public void testGetDocWriteRequestsWithUpdateDocOnlyExtraFieldValues() {
+        BulkRequestBody updateBody = updateBodyBuilder(
+            org.opensearch.protobufs.UpdateAction.newBuilder().setDoc(ByteString.copyFromUtf8("{\"field\":\"updated\"}")).build()
+        ).putExtraFieldValues("vector", binaryFloatValues(7.5f, 8.5f)).build();
+
+        UpdateRequest updateRequest = parseSingleUpdateRequest(updateBody);
+
+        assertNotNull(updateRequest.doc());
+        assertNull(updateRequest.upsertRequest());
+        assertFloatArrayValue(updateRequest.doc().extraFieldValues().get("vector"), false, 7.5f, 8.5f);
+    }
+
+    public void testGetDocWriteRequestsWithUpdateDocAsUpsertExtraFieldValues() {
+        org.opensearch.protobufs.UpdateAction updateAction = org.opensearch.protobufs.UpdateAction.newBuilder()
+            .setDoc(ByteString.copyFromUtf8("{\"field\":\"updated\"}"))
+            .setDocAsUpsert(true)
+            .build();
+
+        BulkRequestBody updateBody = updateBodyBuilder(updateAction).putExtraFieldValues("vector", binaryFloatValues(9.5f, 10.5f)).build();
+
+        UpdateRequest updateRequest = parseSingleUpdateRequest(updateBody);
+
+        assertTrue(updateRequest.docAsUpsert());
+        assertNotNull(updateRequest.doc());
+        assertNull(updateRequest.upsertRequest());
+        assertFloatArrayValue(updateRequest.doc().extraFieldValues().get("vector"), false, 9.5f, 10.5f);
+    }
+
+    public void testGetDocWriteRequestsWithEmptyBytesExtraFieldValue() {
+        IndexRequest indexRequest = parseSingleIndexRequest(indexBodyWithExtraField("raw_bytes", binaryBytesValue()));
+
+        assertBytesValue(indexRequest.extraFieldValues().get("raw_bytes"));
+    }
+
+    public void testGetDocWriteRequestsWithEmptyFloatValuesExtraFieldValue() {
+        IndexRequest indexRequest = parseSingleIndexRequest(indexBodyWithExtraField("vector", binaryFloatValues()));
+
+        assertFloatArrayValue(indexRequest.extraFieldValues().get("vector"), false);
+    }
+
+    public void testGetDocWriteRequestsWithEmptyPackedFloatExtraFieldValue() {
+        IndexRequest indexRequest = parseSingleIndexRequest(indexBodyWithExtraField("vector", binaryPackedFloatValue(new byte[0])));
+
+        assertFloatArrayValue(indexRequest.extraFieldValues().get("vector"), true);
+    }
+
+    public void testGetDocWriteRequestsRejectsPackedFloatBytesNotMultipleOfFour() {
+        assertRejectsIndexExtraFieldValue(binaryPackedFloatValue(new byte[] { 1, 2, 3 }));
+    }
+
+    public void testGetDocWriteRequestsRejectsInvalidExtraFieldValueWithFieldPath() {
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> parseSingleDocWriteRequest(indexBodyWithExtraField("bad_vector", binaryPackedFloatValue(new byte[] { 1, 2, 3 })))
+        );
+
+        assertTrue(e.getMessage(), e.getMessage().contains("Invalid extra_field_values entry [bad_vector]"));
+        assertTrue(e.getMessage(), e.getMessage().contains("packed_le byte length"));
+        assertNotNull(e.getCause());
+    }
+
+    public void testGetDocWriteRequestsRejectsPackedFloatDimensionMismatch() {
+        assertRejectsIndexExtraFieldValue(binaryPackedFloatValue(packFloatLE(1.5f, 2.5f), 3));
+    }
+
+    public void testGetDocWriteRequestsRejectsNegativePackedFloatDimension() {
+        assertRejectsIndexExtraFieldValue(binaryPackedFloatValue(packFloatLE(1.5f), -1));
+    }
+
+    public void testGetDocWriteRequestsRejectsEmptyBinaryFieldValue() {
+        assertRejectsIndexExtraFieldValue(BinaryFieldValue.newBuilder().build());
+    }
+
+    public void testGetDocWriteRequestsRejectsEmptyFloatArrayValue() {
+        BinaryFieldValue emptyFloatArray = BinaryFieldValue.newBuilder()
+            .setFloatArrayValue(org.opensearch.protobufs.FloatArrayValue.newBuilder().build())
+            .build();
+
+        assertRejectsIndexExtraFieldValue(emptyFloatArray);
+    }
+
+    public void testGetDocWriteRequestsRejectsExtraFieldValuesOnDelete() {
+        BulkRequestBody deleteBody = deleteBodyBuilder().putExtraFieldValues("raw_bytes", binaryBytesValue((byte) 1)).build();
+
+        expectThrows(IllegalArgumentException.class, () -> parseSingleDocWriteRequest(deleteBody));
+    }
+
+    public void testGetDocWriteRequestsRejectsUpdateExtraFieldValuesWithoutDocOrUpsert() {
+        BulkRequestBody updateBody = updateBodyBuilder(org.opensearch.protobufs.UpdateAction.newBuilder().setDetectNoop(false).build())
+            .putExtraFieldValues("vector", binaryFloatValues(1.5f))
+            .build();
+
+        expectThrows(IllegalArgumentException.class, () -> parseSingleDocWriteRequest(updateBody));
+    }
+
+    private void assertRejectsIndexExtraFieldValue(BinaryFieldValue value) {
+        expectThrows(IllegalArgumentException.class, () -> parseSingleDocWriteRequest(indexBodyWithExtraField("field", value)));
+    }
+
+    private IndexRequest parseSingleIndexRequest(BulkRequestBody body) {
+        DocWriteRequest<?> request = parseSingleDocWriteRequest(body);
+        assertTrue(request instanceof IndexRequest);
+        return (IndexRequest) request;
+    }
+
+    private UpdateRequest parseSingleUpdateRequest(BulkRequestBody body) {
+        DocWriteRequest<?> request = parseSingleDocWriteRequest(body);
+        assertTrue(request instanceof UpdateRequest);
+        return (UpdateRequest) request;
+    }
+
+    private DocWriteRequest<?> parseSingleDocWriteRequest(BulkRequestBody body) {
+        DocWriteRequest<?>[] requests = BulkRequestParserProtoUtils.getDocWriteRequests(
+            BulkRequest.newBuilder().addBulkRequestBody(body).build(),
+            "default-index",
+            null,
+            null,
+            null,
+            false
+        );
+        assertEquals(1, requests.length);
+        return requests[0];
+    }
+
+    private static BulkRequestBody indexBodyWithExtraField(String field, BinaryFieldValue value) {
+        return indexBodyBuilder().putExtraFieldValues(field, value).build();
+    }
+
+    private static BulkRequestBody.Builder indexBodyBuilder() {
+        return BulkRequestBody.newBuilder()
+            .setOperationContainer(
+                OperationContainer.newBuilder().setIndex(IndexOperation.newBuilder().setXIndex("test-index").build()).build()
+            )
+            .setObject(ByteString.copyFromUtf8("{\"field\":\"value\"}"));
+    }
+
+    private static BulkRequestBody.Builder createBodyBuilder() {
+        return BulkRequestBody.newBuilder()
+            .setOperationContainer(
+                OperationContainer.newBuilder()
+                    .setCreate(WriteOperation.newBuilder().setXIndex("test-index").setXId("test-id").build())
+                    .build()
+            )
+            .setObject(ByteString.copyFromUtf8("{\"field\":\"value\"}"));
+    }
+
+    private static BulkRequestBody.Builder updateBodyBuilder(org.opensearch.protobufs.UpdateAction updateAction) {
+        return BulkRequestBody.newBuilder()
+            .setOperationContainer(
+                OperationContainer.newBuilder()
+                    .setUpdate(UpdateOperation.newBuilder().setXIndex("test-index").setXId("test-id").build())
+                    .build()
+            )
+            .setUpdateAction(updateAction);
+    }
+
+    private static BulkRequestBody.Builder deleteBodyBuilder() {
+        return BulkRequestBody.newBuilder()
+            .setOperationContainer(
+                OperationContainer.newBuilder()
+                    .setDelete(DeleteOperation.newBuilder().setXIndex("test-index").setXId("test-id").build())
+                    .build()
+            );
+    }
+
+    private static BinaryFieldValue binaryBytesValue(byte... values) {
+        return BinaryFieldValue.newBuilder()
+            .setBytesValue(org.opensearch.protobufs.BytesValue.newBuilder().setBytes(ByteString.copyFrom(values)).build())
+            .build();
+    }
+
+    private static BinaryFieldValue binaryFloatValues(float... values) {
+        FloatList.Builder floatList = FloatList.newBuilder();
+        for (float value : values) {
+            floatList.addValues(value);
+        }
+        return BinaryFieldValue.newBuilder()
+            .setFloatArrayValue(org.opensearch.protobufs.FloatArrayValue.newBuilder().setValues(floatList.build()).build())
+            .build();
+    }
+
+    private static BinaryFieldValue binaryPackedFloatValue(byte[] bytes) {
+        return BinaryFieldValue.newBuilder()
+            .setFloatArrayValue(
+                org.opensearch.protobufs.FloatArrayValue.newBuilder()
+                    .setBinaryLe(FloatBinaryLE.newBuilder().setBytesLe(ByteString.copyFrom(bytes)).build())
+                    .build()
+            )
+            .build();
+    }
+
+    private static BinaryFieldValue binaryPackedFloatValue(byte[] bytes, int dimension) {
+        return BinaryFieldValue.newBuilder()
+            .setFloatArrayValue(
+                org.opensearch.protobufs.FloatArrayValue.newBuilder()
+                    .setBinaryLe(FloatBinaryLE.newBuilder().setBytesLe(ByteString.copyFrom(bytes)).setDimension(dimension).build())
+                    .build()
+            )
+            .build();
+    }
+
+    private static void assertBytesValue(ExtraFieldValue value, byte... expected) {
+        assertTrue(value instanceof BytesValue);
+        assertArrayEquals(expected, BytesReference.toBytes(((BytesValue) value).bytes()));
+    }
+
+    private static void assertFloatArrayValue(ExtraFieldValue value, boolean expectedPackedLE, float... expected) {
+        assertTrue(value instanceof FloatArrayValue);
+        FloatArrayValue floatArrayValue = (FloatArrayValue) value;
+        assertEquals(expectedPackedLE, floatArrayValue.isPackedLE());
+        assertEquals(expected.length, floatArrayValue.dimension());
+        assertArrayEquals(expected, floatArrayValue.asFloatArray(), 0.0f);
+    }
+
+    private static byte[] packFloatLE(float... values) {
+        ByteBuffer buffer = ByteBuffer.allocate(values.length * Float.BYTES).order(ByteOrder.LITTLE_ENDIAN);
+        for (float value : values) {
+            buffer.putFloat(value);
+        }
+        return buffer.array();
+    }
+
 }

--- a/modules/transport-grpc/src/test/java/org/opensearch/transport/grpc/proto/request/document/bulk/ExtraFieldValuesProtoUtilsTests.java
+++ b/modules/transport-grpc/src/test/java/org/opensearch/transport/grpc/proto/request/document/bulk/ExtraFieldValuesProtoUtilsTests.java
@@ -1,0 +1,116 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.transport.grpc.proto.request.document.bulk;
+
+import com.google.protobuf.ByteString;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.index.mapper.extrasource.BytesValue;
+import org.opensearch.index.mapper.extrasource.ExtraFieldValue;
+import org.opensearch.index.mapper.extrasource.ExtraFieldValues;
+import org.opensearch.index.mapper.extrasource.FloatArrayValue;
+import org.opensearch.protobufs.BinaryFieldValue;
+import org.opensearch.protobufs.BulkRequestBody;
+import org.opensearch.protobufs.FloatBinaryLE;
+import org.opensearch.protobufs.FloatList;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+public class ExtraFieldValuesProtoUtilsTests extends OpenSearchTestCase {
+
+    public void testFromProtoReturnsEmptyForNoExtraFieldValues() {
+        assertSame(ExtraFieldValues.EMPTY, ExtraFieldValuesProtoUtils.fromProto(BulkRequestBody.newBuilder().build()));
+    }
+
+    public void testFromProtoConvertsSupportedTypes() {
+        byte[] rawBytes = new byte[] { 0, 1, 2, 127, -128, -1 };
+        BulkRequestBody body = BulkRequestBody.newBuilder()
+            .putExtraFieldValues("raw_bytes", binaryBytesValue(rawBytes))
+            .putExtraFieldValues("vector_values", binaryFloatValues(1.5f, 2.5f))
+            .putExtraFieldValues("vector_packed", binaryPackedFloatValue(packFloatLE(3.5f, 4.5f), 2))
+            .build();
+
+        ExtraFieldValues extraFieldValues = ExtraFieldValuesProtoUtils.fromProto(body);
+
+        assertEquals(3, extraFieldValues.values().size());
+        assertBytesValue(extraFieldValues.get("raw_bytes"), rawBytes);
+        assertFloatArrayValue(extraFieldValues.get("vector_values"), false, 1.5f, 2.5f);
+        assertFloatArrayValue(extraFieldValues.get("vector_packed"), true, 3.5f, 4.5f);
+    }
+
+    public void testFromProtoRejectsInvalidEntryWithFieldPath() {
+        BulkRequestBody body = BulkRequestBody.newBuilder()
+            .putExtraFieldValues("bad_vector", binaryPackedFloatValue(new byte[] { 1, 2, 3 }))
+            .build();
+
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> ExtraFieldValuesProtoUtils.fromProto(body));
+
+        assertTrue(e.getMessage(), e.getMessage().contains("Invalid extra_field_values entry [bad_vector]"));
+        assertTrue(e.getMessage(), e.getMessage().contains("packed_le byte length"));
+        assertNotNull(e.getCause());
+    }
+
+    private static BinaryFieldValue binaryBytesValue(byte... values) {
+        return BinaryFieldValue.newBuilder()
+            .setBytesValue(org.opensearch.protobufs.BytesValue.newBuilder().setBytes(ByteString.copyFrom(values)).build())
+            .build();
+    }
+
+    private static BinaryFieldValue binaryFloatValues(float... values) {
+        FloatList.Builder floatList = FloatList.newBuilder();
+        for (float value : values) {
+            floatList.addValues(value);
+        }
+        return BinaryFieldValue.newBuilder()
+            .setFloatArrayValue(org.opensearch.protobufs.FloatArrayValue.newBuilder().setValues(floatList.build()).build())
+            .build();
+    }
+
+    private static BinaryFieldValue binaryPackedFloatValue(byte[] bytes) {
+        return BinaryFieldValue.newBuilder()
+            .setFloatArrayValue(
+                org.opensearch.protobufs.FloatArrayValue.newBuilder()
+                    .setBinaryLe(FloatBinaryLE.newBuilder().setBytesLe(ByteString.copyFrom(bytes)).build())
+                    .build()
+            )
+            .build();
+    }
+
+    private static BinaryFieldValue binaryPackedFloatValue(byte[] bytes, int dimension) {
+        return BinaryFieldValue.newBuilder()
+            .setFloatArrayValue(
+                org.opensearch.protobufs.FloatArrayValue.newBuilder()
+                    .setBinaryLe(FloatBinaryLE.newBuilder().setBytesLe(ByteString.copyFrom(bytes)).setDimension(dimension).build())
+                    .build()
+            )
+            .build();
+    }
+
+    private static void assertBytesValue(ExtraFieldValue value, byte... expected) {
+        assertTrue(value instanceof BytesValue);
+        assertArrayEquals(expected, BytesReference.toBytes(((BytesValue) value).bytes()));
+    }
+
+    private static void assertFloatArrayValue(ExtraFieldValue value, boolean expectedPackedLE, float... expected) {
+        assertTrue(value instanceof FloatArrayValue);
+        FloatArrayValue floatArrayValue = (FloatArrayValue) value;
+        assertEquals(expectedPackedLE, floatArrayValue.isPackedLE());
+        assertEquals(expected.length, floatArrayValue.dimension());
+        assertArrayEquals(expected, floatArrayValue.asFloatArray(), 0.0f);
+    }
+
+    private static byte[] packFloatLE(float... values) {
+        ByteBuffer buffer = ByteBuffer.allocate(values.length * Float.BYTES).order(ByteOrder.LITTLE_ENDIAN);
+        for (float value : values) {
+            buffer.putFloat(value);
+        }
+        return buffer.array();
+    }
+}


### PR DESCRIPTION
Resolves [#21892](https://github.com/opensearch-project/OpenSearch/issues/21892)


### Is your feature request related to a problem? Please describe

Adds support for extra_field_values in gRPC bulk API requests, enabling callers to attach binary or float array fields outside of _source for index, create, and update operations.  
 

### Related component

Indexing
Indexing:Performance
 

### Additional context

[Add support of "extra fields" outside _source indexing](https://github.com/opensearch-project/OpenSearch/issues/20765)
[[gRPC] Move primitive array types out of source
](https://github.com/opensearch-project/OpenSearch/issues/19638)

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
