### PR TITLE
analytics-engine: map SMALLINT/TINYINT in the QTF Arrow converter

### DIFF
--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/ArrowCalciteTypes.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/ArrowCalciteTypes.java
@@ -24,10 +24,10 @@ import org.apache.calcite.rel.type.RelDataType;
  * single authority for the Calcite→Arrow direction needed outside that resolver.
  *
  * <p>FIXME [FixBeforeMainMerge] coverage gaps: TIMESTAMP currently hardcodes MILLISECOND
- * (Calcite precision is ignored — see toArrow note), and several Calcite/Arrow types are
- * still unmapped (TIMESTAMP_WITH_LOCAL_TIME_ZONE, DATE, TIME, SMALLINT, TINYINT, DECIMAL,
- * Arrow Date/Time/Decimal/...). Audit and broaden before merge so the QTF path tolerates
- * non-keyword/non-date columns end-to-end.
+ * (Calcite precision is ignored — see toArrow note), so date_nanos is not yet distinguished,
+ * and several Calcite/Arrow types are still unmapped (TIMESTAMP_WITH_LOCAL_TIME_ZONE, DATE,
+ * TIME, DECIMAL, Arrow Date/Time/Decimal/...). Audit and broaden before merge so the QTF path
+ * tolerates non-keyword/non-date columns end-to-end.
  */
 public final class ArrowCalciteTypes {
 
@@ -40,6 +40,10 @@ public final class ArrowCalciteTypes {
         return switch (t.getSqlTypeName()) {
             case BIGINT -> new ArrowType.Int(64, true);
             case INTEGER -> new ArrowType.Int(32, true);
+            // Match the wire Arrow type the data node emits: ShortParquetField -> Int(16),
+            // ByteParquetField -> Int(8). Keeps the Stitcher's copyFromSafe types aligned.
+            case SMALLINT -> new ArrowType.Int(16, true);
+            case TINYINT -> new ArrowType.Int(8, true);
             case DOUBLE -> new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE);
             case REAL, FLOAT -> new ArrowType.FloatingPoint(FloatingPointPrecision.SINGLE);
             // Utf8View matches what the DataFusion/parquet path on the data node emits for
@@ -48,7 +52,7 @@ public final class ArrowCalciteTypes {
             case VARCHAR, CHAR -> ArrowType.Utf8View.INSTANCE;
             case VARBINARY, BINARY -> ArrowType.Binary.INSTANCE;
             case BOOLEAN -> ArrowType.Bool.INSTANCE;
-            // TODO: TIMESTAMP_WITH_LOCAL_TIME_ZONE, DATE, TIME, SMALLINT, TINYINT, DECIMAL still missing.
+            // TODO: TIMESTAMP_WITH_LOCAL_TIME_ZONE, DATE, TIME, DECIMAL still missing.
             // TODO: hardcoded MILLISECOND to match what DateParquetField emits on the data node;
             // Calcite's reported precision doesn't track the wire-level Arrow precision today, so
             // honouring t.getPrecision() here would break Stitcher copyFromSafe. Revisit when

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/ArrowCalciteTypesTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/ArrowCalciteTypesTests.java
@@ -1,0 +1,48 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.planner;
+
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeSystem;
+import org.apache.calcite.sql.type.SqlTypeFactoryImpl;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.opensearch.test.OpenSearchTestCase;
+
+/**
+ * Unit tests for {@link ArrowCalciteTypes} Calcite→Arrow mapping used by the QTF
+ * (late-materialization) stitch path.
+ */
+public class ArrowCalciteTypesTests extends OpenSearchTestCase {
+
+    private static final SqlTypeFactoryImpl TYPE_FACTORY = new SqlTypeFactoryImpl(RelDataTypeSystem.DEFAULT);
+
+    private static RelDataType type(SqlTypeName name) {
+        return TYPE_FACTORY.createSqlType(name);
+    }
+
+    /**
+     * SMALLINT (OpenSearch {@code short}) must map to the wire Arrow type the data node
+     * emits — {@code Int(16, true)} per {@code ShortParquetField} — so the Stitcher's
+     * copyFromSafe sees matching types. Previously threw "Unsupported Calcite type: SMALLINT".
+     */
+    public void testSmallintMapsToInt16() {
+        assertEquals(new ArrowType.Int(16, true), ArrowCalciteTypes.toArrow(type(SqlTypeName.SMALLINT)));
+    }
+
+    /** TINYINT (OpenSearch {@code byte}) -> Int(8, true) per ByteParquetField. */
+    public void testTinyintMapsToInt8() {
+        assertEquals(new ArrowType.Int(8, true), ArrowCalciteTypes.toArrow(type(SqlTypeName.TINYINT)));
+    }
+
+    public void testIntegerAndBigintUnchanged() {
+        assertEquals(new ArrowType.Int(32, true), ArrowCalciteTypes.toArrow(type(SqlTypeName.INTEGER)));
+        assertEquals(new ArrowType.Int(64, true), ArrowCalciteTypes.toArrow(type(SqlTypeName.BIGINT)));
+    }
+}

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/PplClickBenchIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/PplClickBenchIT.java
@@ -13,6 +13,7 @@ import org.opensearch.client.Request;
 import org.opensearch.client.Response;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -50,6 +51,36 @@ public class PplClickBenchIT extends AnalyticsRestTestCase {
         if (dataProvisioned == false) {
             DatasetProvisioner.provision(client(), ClickBenchTestHelper.DATASET);
             dataProvisioned = true;
+        }
+    }
+
+    /**
+     * Regression for the QTF Arrow type converter: a {@code sort … | head N} query goes through
+     * late-materialization (query-then-fetch), which fetches the above-anchor physical fields by
+     * row-id and builds their Arrow output schema via {@code ArrowCalciteTypes.toArrow}. Here
+     * {@code Age} is an OpenSearch {@code short} (Calcite SMALLINT); before SMALLINT/TINYINT were
+     * mapped, the stitch threw {@code "Unsupported Calcite type: SMALLINT"} and the whole query
+     * 500'd. Assert the short column materializes as numbers across the fetched rows.
+     *
+     * <p>Row <em>order</em> is intentionally not asserted — clickbench is provisioned at 2 shards
+     * and the QTF concat-gather does not globally merge-sort, so which 5 rows come back is not
+     * deterministic. This test only proves the SMALLINT above-anchor field round-trips.
+     */
+    public void testQtfFetchOfShortAboveAnchorField() throws IOException {
+        Map<String, Object> response = executePpl(
+            "source=" + ClickBenchTestHelper.DATASET.indexName + " | sort WatchID | head 5 | fields WatchID, Age"
+        );
+        @SuppressWarnings("unchecked")
+        List<List<Object>> rows = (List<List<Object>>) response.get("datarows");
+        assertNotNull("datarows missing — QTF stitch likely failed before returning", rows);
+        assertEquals("head 5 should return 5 rows", 5, rows.size());
+        for (List<Object> r : rows) {
+            assertEquals("row should have [WatchID, Age]", 2, r.size());
+            assertTrue(
+                "Age (short/SMALLINT) must materialize as a number, got " + r.get(1) + " of "
+                    + (r.get(1) == null ? "null" : r.get(1).getClass().getSimpleName()),
+                r.get(1) instanceof Number
+            );
         }
     }
 


### PR DESCRIPTION


<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
ArrowCalciteTypes.toArrow (used by the late-materialization stitch to build the fetch-stage output schema) had no case for SMALLINT/TINYINT, so a QTF query whose above-anchor fields include a short/byte column (e.g. clickbench Age under sort+head) threw "Unsupported Calcite type: SMALLINT" and the whole query 500'd.

Map SMALLINT -> Int(16,true) and TINYINT -> Int(8,true), matching the wire Arrow types the data node emits (ShortParquetField / ByteParquetField) so the Stitcher's copyFromSafe sees aligned types. Adds ArrowCalciteTypesTests plus PplClickBenchIT.testQtfFetchOfShortAboveAnchorField proving a short above-anchor field round-trips through the QTF stitch end-to-end.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
