### PR TITLE
Coerce MemTable schema to fix Binary/BinaryView mismatch on reduce sink

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/api.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/api.rs
@@ -1155,8 +1155,8 @@ fn derive_schema_from_partial_plan(
             arrow_schema
         };
         let arrow_schema = coerce_unsupported_timestamp_precision(&arrow_schema);
-
-        let table = MemTable::try_new(Arc::new(arrow_schema), vec![vec![]])?;
+        let arrow_schema = crate::schema_coerce::coerce_inferred_schema(Arc::new(arrow_schema));
+        let table = MemTable::try_new(arrow_schema, vec![vec![]])?;
         // Plan may scan the same table twice; the second register is a no-op.
         let _ = ctx.register_table(&table_name, Arc::new(table));
     }


### PR DESCRIPTION
### Description

Fixes a Substrait `Binary` vs MemTable `BinaryView` type-mismatch on the reduce-sink path. Cross-index queries (JOIN, IN-subquery) over parquet-backed indices with `ip` or `binary` fields fail at plan-binding time with:

```
Substrait error: Field '<x>' in Substrait schema has a different type (Binary)
than the corresponding field in the table schema (BinaryView).
```

#### Root cause

`derive_schema_from_partial_plan` (in `analytics-backend-datafusion/rust/src/api.rs`) builds a throwaway MemTable to bind named-table refs in the substrait wire plan. It applies `transform_schema_to_view` (flips `Binary` → `BinaryView`) but never applies `schema_coerce::coerce_inferred_schema` to the MemTable schema before `from_substrait_plan`. The substrait consumer then sees wire `Binary` against MemTable `BinaryView` and rejects the binding.

PR #21631 introduced the coercer for the table-scan path

#### Fix

One-line addition: apply `coerce_inferred_schema` to the MemTable schema after `transform_schema_to_view` and `coerce_unsupported_timestamp_precision`. The MemTable now lands in the same `Binary`/`Int64`/`Float32` shape as the wire.

#### Verification

Verified locally against mch2's 2-shard QA branch (cherry-picked `qa: default analytics-engine datasets to 2 shards` + un-mute commits). Across 5 suites named in mch2's failure report bucket #1 (Binary/IP, 170 units):

- Before fix: every Binary/BinaryView query 500s with the message above.
- After fix: 399 PPL queries executed across the suites, **0** Binary/BinaryView errors.

Residual failures all attributable to other report buckets (unimplemented scalar functions, RexCall casts, decimal divide, etc.) — none introduced by this change.

### Related Issues

- Builds on #21631 (scan support for \`ip\`/\`binary\` field types — introduced \`schema_coerce\`)

### Check List
- [x] Functionality includes testing — Rust unit tests in \`schema_coerce.rs\` cover the \`BinaryView → Binary\` rewrite; e2e verified via QA suite re-run
- [ ] API changes companion pull request — N/A
- [ ] Public documentation issue/PR — N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.