### PR TITLE
analytics-eng: preserve a Sort under a Fetch in substrait conversion

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionFragmentConvertor.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionFragmentConvertor.java
@@ -505,7 +505,12 @@ public class DataFusionFragmentConvertor implements FragmentConvertor {
             return Project.builder().from(project).input(newInput).build();
         }
         if (wrapper instanceof Fetch fetch) {
-            return Fetch.builder().from(fetch).input(newInput).build();
+            // A single Calcite LogicalSort carrying both a collation AND a fetch/offset lowers to
+            // Fetch(Sort(input)) — two Substrait rels from one node. Rewiring the Fetch's input
+            // directly would drop the Sort and lose global order before the limit. Descend into
+            // the Sort so the shape becomes Fetch(Sort(newInput)): gather, sort globally, then limit.
+            Rel rewiredInput = fetch.getInput() instanceof Sort ? replaceInput(fetch.getInput(), newInput) : newInput;
+            return Fetch.builder().from(fetch).input(rewiredInput).build();
         }
         throw new UnsupportedOperationException(
             "Cannot attach-on-top a Substrait Rel of type " + wrapper.getClass().getSimpleName() + " — no single-input rewire defined"

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionFragmentConvertorTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionFragmentConvertorTests.java
@@ -293,6 +293,54 @@ public class DataFusionFragmentConvertorTests extends OpenSearchTestCase {
     }
 
     /**
+     * Regression: a single Calcite {@link LogicalSort} carrying BOTH a collation and a {@code fetch}
+     * (PPL {@code sort x | head N}, which Calcite merges into one node) lowers via isthmus to
+     * {@code Fetch(Sort(input))} — two Substrait rels from one operator. {@code attachFragmentOnTop}
+     * must rewire the inner plan under the Sort, preserving {@code Fetch(Sort(inner))} so the global
+     * order is applied before the limit.
+     *
+     * <p>The earlier rewire replaced the Fetch's input directly, dropping the Sort and yielding
+     * {@code Fetch(inner)} — the limit then ran over an unordered concat-gather, so a multi-shard
+     * {@code sort | head N} returned the first N rows in arrival order instead of sorted order.
+     */
+    public void testAttachFragmentOnTop_SortWithFetch_PreservesSortUnderFetch() throws Exception {
+        DataFusionFragmentConvertor convertor = newConvertor();
+
+        // Inner: final-agg over stage-input (same shape as testAttachFragmentOnTop_Sort).
+        RelDataType stageRowType = rowType("A");
+        int childStageId = 3;
+        RelNode stageInput = new OpenSearchStageInputScan(
+            cluster,
+            cluster.traitSet(),
+            childStageId,
+            stageRowType,
+            List.of("datafusion"),
+            List.of()
+        );
+        LogicalAggregate finalAgg = buildSumAggregate(stageInput, 0);
+        byte[] innerBytes = convertor.convertFragment(finalAgg);
+
+        // Wrapper: ONE LogicalSort carrying a collation (order by col 0) AND a fetch (head 5).
+        // isthmus lowers this single node to Fetch(Sort(Read)); the rewire must keep the Sort.
+        RelNode placeholderInput = buildTableScan("__placeholder__", "sum_col");
+        RexNode fetchN = rexBuilder.makeLiteral(5, typeFactory.createSqlType(SqlTypeName.INTEGER), true);
+        LogicalSort sortLimit = LogicalSort.create(placeholderInput, RelCollations.of(0), null, fetchN);
+
+        byte[] combined = convertor.attachFragmentOnTop(sortLimit, innerBytes);
+
+        Plan plan = decodeSubstrait(combined);
+        Rel root = rootRel(plan);
+        assertTrue("root must be a FetchRel (the limit)", root.hasFetch());
+        Rel underFetch = root.getFetch().getInput();
+        assertTrue("Sort must be preserved under the Fetch (global order before the limit), not dropped", underFetch.hasSort());
+        Rel underSort = underFetch.getSort().getInput();
+        assertTrue("Sort input must be the rewired inner AggregateRel", underSort.hasAggregate());
+        Rel aggInput = underSort.getAggregate().getInput();
+        assertTrue("Agg input must be the inner ReadRel", aggInput.hasRead());
+        assertEquals(List.of("input-" + childStageId), aggInput.getRead().getNamedTable().getNamesList());
+    }
+
+    /**
      * Regression: {@code attachPartialAggOnTop} must populate {@code Plan.Root.names}
      * with the *wrapper aggregate's* output column names — not the inner scan's.
      * Using the inner's names causes DataFusion's substrait consumer to fail


### PR DESCRIPTION


<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
A single Calcite LogicalSort that carries both a collation and a fetch/offset (a PPL `sort x | head N`, which Calcite merges into one node) lowers via isthmus to Fetch(Sort(input)) — two Substrait rels from one operator. DataFusionFragmentConvertor.replaceInput rewired the Fetch's input directly, dropping the Sort and producing Fetch(input). The limit then ran over the unordered concat-gather, so a multi-shard `sort | head N` returned the first N rows in arrival order instead of sorted order.

Descend into the Sort when the Fetch's input is one, so the rewired shape is Fetch(Sort(newInput)): gather, sort globally, then limit.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
