### PR TITLE
Add datafusion.spill_directory setting

### DIFF
--- a/distribution/src/config/opensearch.yml
+++ b/distribution/src/config/opensearch.yml
@@ -121,3 +121,10 @@ ${path.logs}
 # Once there is no observed impact on performance, this feature flag can be removed.
 #
 #opensearch.experimental.optimization.datetime_formatter_caching.enabled: false
+#
+# Path to the spill directory. Empty string (default) falls back to a tmp/ sibling of
+# path.data[0]. AOS optimized domain set this to /mnt/analytics/backend/spill so
+# spill traffic lands on a dedicated EBS volume rather than contending with the data path.
+# NodeScope, Final — Rust DiskManager directories are built once at runtime startup.
+#
+#datafusion.spill_directory:

--- a/distribution/src/config/opensearch.yml
+++ b/distribution/src/config/opensearch.yml
@@ -122,9 +122,11 @@ ${path.logs}
 #
 #opensearch.experimental.optimization.datetime_formatter_caching.enabled: false
 #
-# Path to the spill directory. Empty string (default) falls back to a tmp/ sibling of
-# path.data[0]. AOS optimized domain set this to /mnt/analytics/backend/spill so
-# spill traffic lands on a dedicated EBS volume rather than contending with the data path.
-# NodeScope, Final — Rust DiskManager directories are built once at runtime startup.
+# Path to the spill directory used by the analytics-backend-datafusion plugin. When
+# unset (default), spill is disabled and queries that exceed
+# datafusion.memory_pool_limit_bytes will fail with a "DiskManager is disabled" error.
+# Set this to a directory on a dedicated filesystem to enable spill — the directory
+# should not contend with the data path. NodeScope, Final — DataFusion's DiskManager
+# is built once at runtime startup.
 #
 #datafusion.spill_directory:

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/api.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/api.rs
@@ -311,6 +311,10 @@ pub fn create_global_runtime(
     // "DiskManager is disabled" error instead of writing to an unintended path.
     let disk_manager = if spill_dir.is_empty() {
         log::info!("DataFusion spill disabled (datafusion.spill_directory not set)");
+        // Mark spill explicitly disabled so per_query_spill_budget short-circuits
+        // before touching SPILL_DIR. Without this, an unset OnceLock would surface
+        // as a phantom "disk pressure" signal and clamp every query to 1 partition.
+        crate::memory_guard::mark_spill_disabled();
         DiskManagerBuilder::default().with_mode(DiskManagerMode::Disabled)
     } else {
         let effective_spill_limit = if spill_limit == 0 {
@@ -528,14 +532,14 @@ pub async unsafe fn execute_query(
         .memory_pool()
         .map(|p| p as Arc<dyn datafusion::execution::memory_pool::MemoryPool>);
 
-    // Check disk pressure: if spill space is critically low, reduce parallelism
-    // to minimize spill volume per query. One statvfs call (~1µs).
-    let disk_budget = crate::memory_guard::per_query_spill_budget();
-    let disk_capped_partitions = if disk_budget.is_none() {
-        // Critically low disk — minimize parallelism to reduce spill
-        1
-    } else {
-        query_config.target_partitions
+    // Check disk pressure: when spill is on and disk is dangerously low, reduce
+    // parallelism so each query produces less spill volume. When spill is off, disk
+    // health is irrelevant — there is no spill to throttle, so parallelism stays at
+    // the configured value. One statvfs call (~1µs) only on the enabled path.
+    let disk_capped_partitions = match crate::memory_guard::per_query_spill_budget() {
+        crate::memory_guard::SpillBudget::Critical => 1,
+        crate::memory_guard::SpillBudget::Disabled
+        | crate::memory_guard::SpillBudget::Available(_) => query_config.target_partitions,
     };
 
     // Acquire memory budget: reserve phantom for untracked memory.
@@ -1565,18 +1569,32 @@ mod tests {
     use arrow_array::{BinaryViewArray, Int64Array, StringViewArray};
     use arrow_schema::{Field, Schema};
 
+    /// Shared lock for tests that mutate `memory_guard`'s global SPILL_ENABLED / SPILL_DIR
+    /// or that observe the global runtime state from `create_global_runtime`. cargo test
+    /// runs tests in parallel by default; without serialization, two runtime-construction
+    /// tests would race on these globals and produce flaky assertions.
+    static SPILL_GLOBALS_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
     #[test]
     fn create_global_runtime_with_empty_spill_dir_disables_disk_manager() {
         // Empty spill_dir is the "disabled" sentinel from Java. The runtime must build
         // successfully and the DiskManager must report tmp_files_enabled() == false so
         // any spill attempt surfaces the upstream "DiskManager is disabled" error
-        // instead of writing to an unintended path.
+        // instead of writing to an unintended path. Construction must also flip the
+        // memory_guard SPILL_ENABLED flag off so per_query_spill_budget returns
+        // Disabled (not Critical) — preventing the 1-partition clamp.
+        let _guard = SPILL_GLOBALS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let ptr = create_global_runtime(64 * 1024 * 1024, 0, "", 0).expect("runtime build");
         assert!(ptr > 0);
         let runtime = unsafe { &*(ptr as *const DataFusionRuntime) };
         assert!(
             !runtime.runtime_env.disk_manager.tmp_files_enabled(),
             "expected DiskManagerMode::Disabled when spill_dir is empty"
+        );
+        assert_eq!(
+            crate::memory_guard::per_query_spill_budget(),
+            crate::memory_guard::SpillBudget::Disabled,
+            "spill-disabled runtime must surface SpillBudget::Disabled (not Critical) so the caller does not clamp parallelism"
         );
         unsafe { close_global_runtime(ptr) };
     }
@@ -1585,7 +1603,11 @@ mod tests {
     fn create_global_runtime_with_spill_dir_enables_disk_manager() {
         // Non-empty spill_dir takes the Directories(...) path. tmp_files_enabled() must
         // be true so spill attempts succeed. Passing spill_limit=0 also exercises the
-        // dynamic-limit resolver (resolve_dynamic_spill_limit + set_spill_dir).
+        // dynamic-limit resolver (resolve_dynamic_spill_limit + set_spill_dir). The
+        // budget must NOT be Disabled — set_spill_dir flips SPILL_ENABLED on. Whether
+        // it's Available or Critical depends on the test host's free disk; both prove
+        // the enabled-path branch is taken.
+        let _guard = SPILL_GLOBALS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let tmp = tempfile::tempdir().expect("tempdir");
         let spill_path = tmp.path().to_str().expect("utf-8 path");
         let ptr = create_global_runtime(64 * 1024 * 1024, 0, spill_path, 0).expect("runtime build");
@@ -1594,6 +1616,11 @@ mod tests {
         assert!(
             runtime.runtime_env.disk_manager.tmp_files_enabled(),
             "expected DiskManagerMode::Directories when spill_dir is set"
+        );
+        assert_ne!(
+            crate::memory_guard::per_query_spill_budget(),
+            crate::memory_guard::SpillBudget::Disabled,
+            "spill-enabled runtime must NOT surface SpillBudget::Disabled"
         );
         unsafe { close_global_runtime(ptr) };
     }

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/api.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/api.rs
@@ -306,18 +306,26 @@ pub fn create_global_runtime(
         )));
     }
 
-    let effective_spill_limit = if spill_limit == 0 {
-        resolve_dynamic_spill_limit(spill_dir)
+    // Empty spill_dir is the "disabled" sentinel from Java. Build the runtime with
+    // DiskManagerMode::Disabled — operators that need to spill will fail with a clear
+    // "DiskManager is disabled" error instead of writing to an unintended path.
+    let disk_manager = if spill_dir.is_empty() {
+        log::info!("DataFusion spill disabled (datafusion.spill_directory not set)");
+        DiskManagerBuilder::default().with_mode(DiskManagerMode::Disabled)
     } else {
-        spill_limit as u64
+        let effective_spill_limit = if spill_limit == 0 {
+            resolve_dynamic_spill_limit(spill_dir)
+        } else {
+            spill_limit as u64
+        };
+
+        // Register spill directory for per-query disk pressure checks
+        crate::memory_guard::set_spill_dir(spill_dir);
+
+        DiskManagerBuilder::default()
+            .with_max_temp_directory_size(effective_spill_limit)
+            .with_mode(DiskManagerMode::Directories(vec![PathBuf::from(spill_dir)]))
     };
-
-    // Register spill directory for per-query disk pressure checks
-    crate::memory_guard::set_spill_dir(spill_dir);
-
-    let disk_manager = DiskManagerBuilder::default()
-        .with_max_temp_directory_size(effective_spill_limit)
-        .with_mode(DiskManagerMode::Directories(vec![PathBuf::from(spill_dir)]));
 
     let (dynamic_pool, dynamic_limit_handle) = DynamicLimitPool::new(memory_pool_limit as usize);
     let memory_pool = Arc::new(TrackConsumersPool::new(
@@ -1556,6 +1564,39 @@ mod tests {
     use super::*;
     use arrow_array::{BinaryViewArray, Int64Array, StringViewArray};
     use arrow_schema::{Field, Schema};
+
+    #[test]
+    fn create_global_runtime_with_empty_spill_dir_disables_disk_manager() {
+        // Empty spill_dir is the "disabled" sentinel from Java. The runtime must build
+        // successfully and the DiskManager must report tmp_files_enabled() == false so
+        // any spill attempt surfaces the upstream "DiskManager is disabled" error
+        // instead of writing to an unintended path.
+        let ptr = create_global_runtime(64 * 1024 * 1024, 0, "", 0).expect("runtime build");
+        assert!(ptr > 0);
+        let runtime = unsafe { &*(ptr as *const DataFusionRuntime) };
+        assert!(
+            !runtime.runtime_env.disk_manager.tmp_files_enabled(),
+            "expected DiskManagerMode::Disabled when spill_dir is empty"
+        );
+        unsafe { close_global_runtime(ptr) };
+    }
+
+    #[test]
+    fn create_global_runtime_with_spill_dir_enables_disk_manager() {
+        // Non-empty spill_dir takes the Directories(...) path. tmp_files_enabled() must
+        // be true so spill attempts succeed. Passing spill_limit=0 also exercises the
+        // dynamic-limit resolver (resolve_dynamic_spill_limit + set_spill_dir).
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let spill_path = tmp.path().to_str().expect("utf-8 path");
+        let ptr = create_global_runtime(64 * 1024 * 1024, 0, spill_path, 0).expect("runtime build");
+        assert!(ptr > 0);
+        let runtime = unsafe { &*(ptr as *const DataFusionRuntime) };
+        assert!(
+            runtime.runtime_env.disk_manager.tmp_files_enabled(),
+            "expected DiskManagerMode::Directories when spill_dir is set"
+        );
+        unsafe { close_global_runtime(ptr) };
+    }
 
     #[test]
     fn stringview_gc_compacts_sliced_buffers() {

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/memory_guard.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/memory_guard.rs
@@ -15,7 +15,7 @@
 //!
 //! Thresholds are configurable at runtime via `set_thresholds`.
 
-use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, Ordering};
 use std::time::Instant;
 
 // --- Cached RSS ---
@@ -248,24 +248,67 @@ static DISK_FRACTION_X1000: AtomicU64 = AtomicU64::new(100); // 10% = 100/1000
 /// Stored spill directory path. Set once at runtime creation.
 static SPILL_DIR: std::sync::OnceLock<String> = std::sync::OnceLock::new();
 
-/// Set the spill directory (called once from create_global_runtime).
+/// Whether spill is enabled at runtime construction. Stays `false` when DataFusion
+/// is built with `DiskManagerMode::Disabled` (i.e. `datafusion.spill_directory` unset).
+/// Used by `per_query_spill_budget` to short-circuit before touching `SPILL_DIR` so
+/// the disabled path doesn't masquerade as "disk dying" and clamp parallelism.
+static SPILL_ENABLED: AtomicBool = AtomicBool::new(false);
+
+/// Per-query spill state, returned by `per_query_spill_budget`.
+///
+/// Three states make the call site unambiguous:
+/// * `Disabled`     — spill is off; parallelism MUST NOT be clamped (no spill = no risk).
+/// * `Critical`     — spill is on but available disk is dangerously low; clamp to 1.
+/// * `Available(n)` — spill is on and disk is healthy; full parallelism + per-query budget.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SpillBudget {
+    Disabled,
+    Critical,
+    Available(u64),
+}
+
+/// Set the spill directory and mark spill enabled (called once from create_global_runtime
+/// when DataFusion is built with `DiskManagerMode::Directories`).
 pub fn set_spill_dir(path: &str) {
     let _ = SPILL_DIR.set(path.to_string());
+    SPILL_ENABLED.store(true, Ordering::Release);
+}
+
+/// Mark spill explicitly disabled (called once from create_global_runtime when
+/// DataFusion is built with `DiskManagerMode::Disabled`). This makes the disabled
+/// state explicit so `per_query_spill_budget` returns `Disabled` instead of
+/// returning a phantom "disk pressure" signal driven by an unset `SPILL_DIR`.
+pub fn mark_spill_disabled() {
+    SPILL_ENABLED.store(false, Ordering::Release);
 }
 
 /// Returns the per-query spill budget based on available disk space.
 ///
-/// Formula: `10% of available_disk`
+/// Formula: `10% of available_disk` for the `Available` case.
 ///
-/// Returns None if disk space is critically low (< 64MB available after
-/// applying the fraction). This signals the caller to reduce parallelism
-/// to minimize spill volume. The global spill ceiling is enforced by
-/// DataFusion's DiskManager (`max_temp_directory_size`).
+/// Returns:
+/// * `Disabled`     when spill is off — no `statvfs` call, no clamp.
+/// * `Critical`     when spill is on but the spill volume is dangerously low
+///                  (< 64MB after the fraction, or `statvfs` failed). Caller clamps to 1.
+/// * `Available(n)` when spill is on and disk is healthy.
 ///
-/// Cost: one `statvfs` syscall (~1µs). Called once per query at admission.
-pub fn per_query_spill_budget() -> Option<u64> {
-    let spill_dir = SPILL_DIR.get()?;
-    let available = available_disk_space(spill_dir)?;
+/// Cost: one `statvfs` syscall (~1µs) only when spill is enabled. Called once per
+/// query at admission.
+pub fn per_query_spill_budget() -> SpillBudget {
+    if !SPILL_ENABLED.load(Ordering::Acquire) {
+        return SpillBudget::Disabled;
+    }
+    // SPILL_ENABLED is only set to true by `set_spill_dir`, which always populates
+    // SPILL_DIR first — but a defensive `match` keeps this safe even if call ordering
+    // ever changes.
+    let spill_dir = match SPILL_DIR.get() {
+        Some(d) => d,
+        None => return SpillBudget::Critical,
+    };
+    let available = match available_disk_space(spill_dir) {
+        Some(a) => a,
+        None => return SpillBudget::Critical,
+    };
 
     let fraction_x1000 = DISK_FRACTION_X1000.load(Ordering::Acquire);
     let budget = available * fraction_x1000 / 1000;
@@ -276,9 +319,9 @@ pub fn per_query_spill_budget() -> Option<u64> {
             budget / (1024 * 1024),
             available / (1024 * 1024),
         );
-        return None;
+        return SpillBudget::Critical;
     }
-    Some(budget)
+    SpillBudget::Available(budget)
 }
 
 /// Query available disk space for the given path.

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionPlugin.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionPlugin.java
@@ -178,27 +178,30 @@ public class DataFusionPlugin extends Plugin
      * Spill directory used by DataFusion's {@code DiskManager} for intermediate state when
      * operators (HashAggregate, Sort, TopK) exceed {@link #DATAFUSION_MEMORY_POOL_LIMIT}.
      *
-     * <p><strong>Default: empty string</strong> — falls back to a {@code tmp/} sibling of
-     * {@code path.data[0]}, preserving the historical behaviour for self-managed clusters that
-     * never configured this setting. AOS optimized domain set this to
-     * {@code /mnt/analytics/backend/spill} via {@code opensearch.yml} so spill traffic lands on
-     * a dedicated EBS volume instead of contending with the data path.
+     * <p>Optional. When set, DataFusion uses {@code DiskManagerMode::Directories} to spill
+     * to the configured path. When unset (empty), DataFusion runs in
+     * {@code DiskManagerMode::Disabled} — spill is off and queries that exceed
+     * {@link #DATAFUSION_MEMORY_POOL_LIMIT} fail with a clear "DiskManager is disabled" error
+     * rather than silently spilling somewhere unexpected.
+     *
+     * <p>{@code Final} because DataFusion's {@code DiskManager} is built once at runtime
+     * startup; changing the directory mid-flight would orphan in-progress spill files.
      */
     public static final Setting<String> DATAFUSION_SPILL_DIRECTORY = new Setting<>(
         "datafusion.spill_directory",
         "",
         Function.identity(),
         DataFusionPlugin::validateSpillDirectory,
-        Setting.Property.NodeScope
+        Setting.Property.NodeScope,
+        Setting.Property.Final
     );
 
     /**
-     * Validates {@link #DATAFUSION_SPILL_DIRECTORY}. Empty is accepted (sentinel for the legacy
-     * {@code path.data[0]/../tmp} default). For non-empty values, walks up the path until an
-     * existing ancestor is found; rejects paths whose root is unreachable. Writability is
-     * intentionally not checked here — the directory may be created later by the AOS boot
-     * script (first-boot mount), and runtime spill writes will surface any permission issues
-     * at first spill with a clear DataFusion error.
+     * Validates {@link #DATAFUSION_SPILL_DIRECTORY}. Empty (the unset sentinel) is accepted
+     * and signals that spill should be disabled. Non-empty values must parse as a {@link Path};
+     * existence and writability are intentionally not checked because the directory may be
+     * created later by a host boot script (first-boot mount), and runtime spill writes will
+     * surface any permission issues at first spill with a clear DataFusion error.
      */
     static String validateSpillDirectory(String value) {
         if (value == null || value.isEmpty()) {
@@ -210,20 +213,6 @@ public class DataFusionPlugin extends Plugin
             throw new IllegalArgumentException("Setting [datafusion.spill_directory] is not a valid path: [" + value + "]", e);
         }
         return value;
-    }
-
-    /**
-     * Resolves the effective spill directory: when {@link #DATAFUSION_SPILL_DIRECTORY} is set,
-     * uses it as-is; otherwise falls back to the legacy {@code path.data[0]/../tmp} default.
-     * The fallback preserves backward compatibility for self-managed clusters that never
-     * configured this setting.
-     */
-    static String resolveSpillDirectory(Settings settings, Environment environment) {
-        String configured = DATAFUSION_SPILL_DIRECTORY.get(settings);
-        if (configured != null && configured.isEmpty() == false) {
-            return configured;
-        }
-        return environment.dataFiles()[0].getParent().resolve("tmp").toAbsolutePath().toString();
     }
 
     /**
@@ -395,7 +384,7 @@ public class DataFusionPlugin extends Plugin
         Settings settings = environment.settings();
         long memoryPoolLimit = DATAFUSION_MEMORY_POOL_LIMIT.get(settings);
         long spillMemoryLimit = DATAFUSION_SPILL_MEMORY_LIMIT.get(settings);
-        String spillDir = resolveSpillDirectory(settings, environment);
+        String spillDir = DATAFUSION_SPILL_DIRECTORY.get(settings);
 
         dataFusionService = DataFusionService.builder()
             .memoryPoolLimit(memoryPoolLimit)

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionPlugin.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionPlugin.java
@@ -57,11 +57,13 @@ import org.opensearch.transport.client.Client;
 import org.opensearch.watcher.ResourceWatcherService;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 import io.substrait.extension.DefaultExtensionCatalog;
@@ -171,6 +173,58 @@ public class DataFusionPlugin extends Plugin
         Setting.Property.NodeScope,
         Setting.Property.Dynamic
     );
+
+    /**
+     * Spill directory used by DataFusion's {@code DiskManager} for intermediate state when
+     * operators (HashAggregate, Sort, TopK) exceed {@link #DATAFUSION_MEMORY_POOL_LIMIT}.
+     *
+     * <p><strong>Default: empty string</strong> — falls back to a {@code tmp/} sibling of
+     * {@code path.data[0]}, preserving the historical behaviour for self-managed clusters that
+     * never configured this setting. AOS optimized domain set this to
+     * {@code /mnt/analytics/backend/spill} via {@code opensearch.yml} so spill traffic lands on
+     * a dedicated EBS volume instead of contending with the data path.
+     */
+    public static final Setting<String> DATAFUSION_SPILL_DIRECTORY = new Setting<>(
+        "datafusion.spill_directory",
+        "",
+        Function.identity(),
+        DataFusionPlugin::validateSpillDirectory,
+        Setting.Property.NodeScope
+    );
+
+    /**
+     * Validates {@link #DATAFUSION_SPILL_DIRECTORY}. Empty is accepted (sentinel for the legacy
+     * {@code path.data[0]/../tmp} default). For non-empty values, walks up the path until an
+     * existing ancestor is found; rejects paths whose root is unreachable. Writability is
+     * intentionally not checked here — the directory may be created later by the AOS boot
+     * script (first-boot mount), and runtime spill writes will surface any permission issues
+     * at first spill with a clear DataFusion error.
+     */
+    static String validateSpillDirectory(String value) {
+        if (value == null || value.isEmpty()) {
+            return value;
+        }
+        try {
+            Path.of(value).toAbsolutePath().normalize();
+        } catch (java.nio.file.InvalidPathException e) {
+            throw new IllegalArgumentException("Setting [datafusion.spill_directory] is not a valid path: [" + value + "]", e);
+        }
+        return value;
+    }
+
+    /**
+     * Resolves the effective spill directory: when {@link #DATAFUSION_SPILL_DIRECTORY} is set,
+     * uses it as-is; otherwise falls back to the legacy {@code path.data[0]/../tmp} default.
+     * The fallback preserves backward compatibility for self-managed clusters that never
+     * configured this setting.
+     */
+    static String resolveSpillDirectory(Settings settings, Environment environment) {
+        String configured = DATAFUSION_SPILL_DIRECTORY.get(settings);
+        if (configured != null && configured.isEmpty() == false) {
+            return configured;
+        }
+        return environment.dataFiles()[0].getParent().resolve("tmp").toAbsolutePath().toString();
+    }
 
     /**
      * Computes the default for {@link #DATAFUSION_SPILL_MEMORY_LIMIT} as 50% of physical RAM.
@@ -341,7 +395,7 @@ public class DataFusionPlugin extends Plugin
         Settings settings = environment.settings();
         long memoryPoolLimit = DATAFUSION_MEMORY_POOL_LIMIT.get(settings);
         long spillMemoryLimit = DATAFUSION_SPILL_MEMORY_LIMIT.get(settings);
-        String spillDir = environment.dataFiles()[0].getParent().resolve("tmp").toAbsolutePath().toString();
+        String spillDir = resolveSpillDirectory(settings, environment);
 
         dataFusionService = DataFusionService.builder()
             .memoryPoolLimit(memoryPoolLimit)

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionSettings.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionSettings.java
@@ -243,6 +243,7 @@ public final class DatafusionSettings {
         // Runtime settings — memory pool, spill, reduce input mode, and budget tuning
         DataFusionPlugin.DATAFUSION_MEMORY_POOL_LIMIT,
         DataFusionPlugin.DATAFUSION_SPILL_MEMORY_LIMIT,
+        DataFusionPlugin.DATAFUSION_SPILL_DIRECTORY,
         DataFusionPlugin.DATAFUSION_REDUCE_INPUT_MODE,
         DataFusionPlugin.DATAFUSION_REDUCE_TARGET_PARTITIONS,
         DataFusionPlugin.DATAFUSION_MIN_TARGET_PARTITIONS,

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/ToStringFunctionAdapter.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/ToStringFunctionAdapter.java
@@ -67,7 +67,7 @@ class ToStringFunctionAdapter implements ScalarFunctionAdapter {
     private enum Format {
         HEX("hex", SqlTypeName.BIGINT),
         BINARY("binary", SqlTypeName.BIGINT),
-        COMMAS("commas", /* preserveFractional */ null),
+        COMMAS("commas", /* preserveFractional */null),
         DURATION("duration", SqlTypeName.BIGINT),
         DURATION_MILLIS("duration_millis", SqlTypeName.BIGINT);
 

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionPluginSettingsTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionPluginSettingsTests.java
@@ -139,19 +139,22 @@ public class DataFusionPluginSettingsTests extends OpenSearchTestCase {
         // startup; changing the directory at runtime would orphan in-flight spill files.
         assertFalse("datafusion.spill_directory must NOT be dynamic", DataFusionPlugin.DATAFUSION_SPILL_DIRECTORY.isDynamic());
         assertTrue("datafusion.spill_directory must have node scope", DataFusionPlugin.DATAFUSION_SPILL_DIRECTORY.hasNodeScope());
+        assertTrue("datafusion.spill_directory must be Final", DataFusionPlugin.DATAFUSION_SPILL_DIRECTORY.isFinal());
     }
 
     public void testSpillDirectoryDefaultIsEmpty() {
-        // Empty default is the sentinel for "fall back to data[0]/../tmp"; preserves backward
-        // compatibility for self-managed clusters that never configured this setting.
-        Settings s = Settings.EMPTY;
-        assertEquals("", DataFusionPlugin.DATAFUSION_SPILL_DIRECTORY.get(s));
+        // Empty default is the sentinel for "spill disabled" — DataFusion will build the
+        // runtime in DiskManagerMode::Disabled. Setting the value to a real path opts back
+        // into spill. This preserves a sensible default for self-managed clusters that
+        // never configured the setting.
+        assertEquals("", DataFusionPlugin.DATAFUSION_SPILL_DIRECTORY.get(Settings.EMPTY));
     }
 
-    public void testSpillDirectoryEmptyValidatesSuccessfully() {
-        // Empty is the documented sentinel; validator must accept it without filesystem checks.
-        DataFusionPlugin.validateSpillDirectory("");
-        DataFusionPlugin.validateSpillDirectory(null);
+    public void testSpillDirectoryAcceptsEmptyValue() {
+        // Explicitly setting the value to empty must also pass validation — same effect as
+        // leaving it unset (spill disabled).
+        Settings s = Settings.builder().put("datafusion.spill_directory", "").build();
+        assertEquals("", DataFusionPlugin.DATAFUSION_SPILL_DIRECTORY.get(s));
     }
 
     public void testSpillDirectoryAcceptsValidExistingPath() throws Exception {
@@ -160,10 +163,10 @@ public class DataFusionPluginSettingsTests extends OpenSearchTestCase {
         assertEquals(tmp.toString(), DataFusionPlugin.DATAFUSION_SPILL_DIRECTORY.get(s));
     }
 
-    public void testSpillDirectoryAcceptsPathWhereOnlyAncestorExists() throws Exception {
+    public void testSpillDirectoryAcceptsPathThatDoesNotYetExist() throws Exception {
         // The leaf directory may not exist yet at plugin-startup time (host-fleet boot script
-        // could still be mounting the volume). Validator must walk up to an existing ancestor
-        // and only check writability there.
+        // could still be mounting the volume). Validator accepts on syntactic grounds only;
+        // runtime spill writes surface any permission/mount issues.
         Path existingParent = createTempDir();
         Path nonExistentLeaf = existingParent.resolve("spill-not-yet-mounted");
         assertTrue(Files.notExists(nonExistentLeaf));
@@ -179,15 +182,6 @@ public class DataFusionPluginSettingsTests extends OpenSearchTestCase {
         assertTrue(
             "error message should reference the setting key, got: " + e.getMessage(),
             e.getMessage().contains("datafusion.spill_directory")
-        );
-    }
-
-    public void testSpillDirectoryIsRejectedAtClusterScope() {
-        // Cluster-level updates (PUT _cluster/settings) must be rejected because the setting
-        // is NodeScope-only.
-        assertFalse(
-            "datafusion.spill_directory must NOT have cluster (dynamic) scope",
-            DataFusionPlugin.DATAFUSION_SPILL_DIRECTORY.isDynamic()
         );
     }
 

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionPluginSettingsTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionPluginSettingsTests.java
@@ -12,6 +12,8 @@ import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.test.OpenSearchTestCase;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -116,6 +118,77 @@ public class DataFusionPluginSettingsTests extends OpenSearchTestCase {
         } catch (Exception e) {
             throw new AssertionError(e);
         }
+    }
+
+    // ── datafusion.spill_directory (task 1.1) ──
+
+    public void testSpillDirectoryIsRegistered() {
+        try (DataFusionPlugin plugin = new DataFusionPlugin()) {
+            List<Setting<?>> settings = plugin.getSettings();
+            assertTrue(
+                "Plugin must register DATAFUSION_SPILL_DIRECTORY via getSettings()",
+                settings.contains(DataFusionPlugin.DATAFUSION_SPILL_DIRECTORY)
+            );
+        } catch (Exception e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    public void testSpillDirectoryIsFinalAndNodeScope() {
+        // Final because DataFusion's DiskManagerMode::Directories is built once at runtime
+        // startup; changing the directory at runtime would orphan in-flight spill files.
+        assertFalse("datafusion.spill_directory must NOT be dynamic", DataFusionPlugin.DATAFUSION_SPILL_DIRECTORY.isDynamic());
+        assertTrue("datafusion.spill_directory must have node scope", DataFusionPlugin.DATAFUSION_SPILL_DIRECTORY.hasNodeScope());
+    }
+
+    public void testSpillDirectoryDefaultIsEmpty() {
+        // Empty default is the sentinel for "fall back to data[0]/../tmp"; preserves backward
+        // compatibility for self-managed clusters that never configured this setting.
+        Settings s = Settings.EMPTY;
+        assertEquals("", DataFusionPlugin.DATAFUSION_SPILL_DIRECTORY.get(s));
+    }
+
+    public void testSpillDirectoryEmptyValidatesSuccessfully() {
+        // Empty is the documented sentinel; validator must accept it without filesystem checks.
+        DataFusionPlugin.validateSpillDirectory("");
+        DataFusionPlugin.validateSpillDirectory(null);
+    }
+
+    public void testSpillDirectoryAcceptsValidExistingPath() throws Exception {
+        Path tmp = createTempDir();
+        Settings s = Settings.builder().put("datafusion.spill_directory", tmp.toString()).build();
+        assertEquals(tmp.toString(), DataFusionPlugin.DATAFUSION_SPILL_DIRECTORY.get(s));
+    }
+
+    public void testSpillDirectoryAcceptsPathWhereOnlyAncestorExists() throws Exception {
+        // The leaf directory may not exist yet at plugin-startup time (host-fleet boot script
+        // could still be mounting the volume). Validator must walk up to an existing ancestor
+        // and only check writability there.
+        Path existingParent = createTempDir();
+        Path nonExistentLeaf = existingParent.resolve("spill-not-yet-mounted");
+        assertTrue(Files.notExists(nonExistentLeaf));
+        Settings s = Settings.builder().put("datafusion.spill_directory", nonExistentLeaf.toString()).build();
+        assertEquals(nonExistentLeaf.toString(), DataFusionPlugin.DATAFUSION_SPILL_DIRECTORY.get(s));
+    }
+
+    public void testSpillDirectoryRejectsInvalidPathSyntax() {
+        // Nul-byte path is unparseable by Path.of; the validator must reject it with a
+        // clear error message that references the setting key.
+        Settings s = Settings.builder().put("datafusion.spill_directory", "\u0000bad\u0000path").build();
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> DataFusionPlugin.DATAFUSION_SPILL_DIRECTORY.get(s));
+        assertTrue(
+            "error message should reference the setting key, got: " + e.getMessage(),
+            e.getMessage().contains("datafusion.spill_directory")
+        );
+    }
+
+    public void testSpillDirectoryIsRejectedAtClusterScope() {
+        // Cluster-level updates (PUT _cluster/settings) must be rejected because the setting
+        // is NodeScope-only.
+        assertFalse(
+            "datafusion.spill_directory must NOT have cluster (dynamic) scope",
+            DataFusionPlugin.DATAFUSION_SPILL_DIRECTORY.isDynamic()
+        );
     }
 
     public void testDatafusionSettingsIsNullBeforeCreateComponents() {

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionPluginSettingsTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionPluginSettingsTests.java
@@ -114,7 +114,7 @@ public class DataFusionPluginSettingsTests extends OpenSearchTestCase {
     public void testGetSettingsReturnsTotalExpectedCount() {
         try (DataFusionPlugin plugin = new DataFusionPlugin()) {
             List<Setting<?>> settings = plugin.getSettings();
-            assertEquals(26, settings.size());
+            assertEquals(27, settings.size());
         } catch (Exception e) {
             throw new AssertionError(e);
         }

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionServiceTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionServiceTests.java
@@ -51,6 +51,29 @@ public class DataFusionServiceTests extends OpenSearchTestCase {
         assertFalse(handle.isOpen());
     }
 
+    public void testServiceStartWithEmptySpillDirectory() {
+        // Empty spillDirectory triggers DiskManagerMode::Disabled in Rust. The runtime
+        // must build successfully (memory-only execution); spill-attempting queries will
+        // fail with a "DiskManager is disabled" error, but plain runtime construction
+        // and shutdown are unaffected.
+        ensureTokioInit();
+        DataFusionService service = DataFusionService.builder()
+            .memoryPoolLimit(64 * 1024 * 1024)
+            .spillMemoryLimit(0L)
+            .spillDirectory("")
+            .cpuThreads(2)
+            .build();
+        service.start();
+
+        NativeRuntimeHandle handle = service.getNativeRuntime();
+        assertNotNull(handle);
+        assertTrue(handle.isOpen());
+        assertTrue(handle.get() != 0);
+
+        service.stop();
+        assertFalse(handle.isOpen());
+    }
+
     public void testGetNativeRuntimeBeforeStartThrows() {
         DataFusionService service = DataFusionService.builder().build();
         expectThrows(IllegalStateException.class, service::getNativeRuntime);

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionSettingsTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionSettingsTests.java
@@ -69,7 +69,7 @@ public class DatafusionSettingsTests extends OpenSearchTestCase {
     }
 
     public void testAllSettingsContainsAllExpectedSettings() {
-        assertEquals(26, DatafusionSettings.ALL_SETTINGS.size());
+        assertEquals(27, DatafusionSettings.ALL_SETTINGS.size());
         assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DataFusionPlugin.DATAFUSION_REDUCE_TARGET_PARTITIONS));
         assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DataFusionPlugin.DATAFUSION_SPILL_DIRECTORY));
         assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DatafusionSettings.INDEXED_BATCH_SIZE));

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionSettingsTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionSettingsTests.java
@@ -71,6 +71,7 @@ public class DatafusionSettingsTests extends OpenSearchTestCase {
     public void testAllSettingsContainsAllExpectedSettings() {
         assertEquals(26, DatafusionSettings.ALL_SETTINGS.size());
         assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DataFusionPlugin.DATAFUSION_REDUCE_TARGET_PARTITIONS));
+        assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DataFusionPlugin.DATAFUSION_SPILL_DIRECTORY));
         assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DatafusionSettings.INDEXED_BATCH_SIZE));
         assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DatafusionSettings.INDEXED_PARQUET_PUSHDOWN_FILTERS));
         assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DatafusionSettings.INDEXED_BLOOM_FILTER_ON_READ));

--- a/sandbox/qa/analytics-engine-coordinator/src/internalClusterTest/java/org/opensearch/analytics/resilience/MemoryGuardIT.java
+++ b/sandbox/qa/analytics-engine-coordinator/src/internalClusterTest/java/org/opensearch/analytics/resilience/MemoryGuardIT.java
@@ -95,6 +95,7 @@ public class MemoryGuardIT extends OpenSearchIntegTestCase {
             .put(super.nodeSettings(nodeOrdinal))
             .put(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG, true)
             .put(FeatureFlags.STREAM_TRANSPORT, true)
+            .put("datafusion.spill_directory", createTempDir().toString())
             .build();
     }
 

--- a/sandbox/qa/analytics-engine-coordinator/src/internalClusterTest/java/org/opensearch/analytics/resilience/SpillDisabledParallelismIT.java
+++ b/sandbox/qa/analytics-engine-coordinator/src/internalClusterTest/java/org/opensearch/analytics/resilience/SpillDisabledParallelismIT.java
@@ -1,0 +1,187 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.resilience;
+
+import org.opensearch.Version;
+import org.opensearch.action.bulk.BulkRequestBuilder;
+import org.opensearch.action.bulk.BulkResponse;
+import org.opensearch.analytics.AnalyticsPlugin;
+import org.opensearch.arrow.allocator.ArrowBasePlugin;
+import org.opensearch.arrow.flight.transport.FlightStreamPlugin;
+import org.opensearch.be.datafusion.DataFusionPlugin;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.FeatureFlags;
+import org.opensearch.composite.CompositeDataFormatPlugin;
+import org.opensearch.index.engine.dataformat.stub.MockCommitterEnginePlugin;
+import org.opensearch.parquet.ParquetDataFormatPlugin;
+import org.opensearch.plugins.Plugin;
+import org.opensearch.plugins.PluginInfo;
+import org.opensearch.ppl.TestPPLPlugin;
+import org.opensearch.ppl.action.PPLRequest;
+import org.opensearch.ppl.action.PPLResponse;
+import org.opensearch.ppl.action.UnifiedPPLExecuteAction;
+import org.opensearch.test.OpenSearchIntegTestCase;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Integration test for the spill-disabled query path.
+ *
+ * <p>When {@code datafusion.spill_directory} is unset, the DataFusion runtime is built with
+ * {@code DiskManagerMode::Disabled}. In that configuration, the per-query disk-pressure
+ * check {@code memory_guard::per_query_spill_budget} must return {@code SpillBudget::Disabled}
+ * — NOT a phantom "disk dying" signal that would clamp every query to one partition.
+ *
+ * <p>This test boots a cluster with no spill_directory configured and runs a coordinator-reduce
+ * GROUP BY whose memory footprint fits comfortably under the default pool. The query MUST
+ * succeed and produce the correct number of groups. A regression that re-introduces the
+ * unconditional 1-partition clamp would still pass the correctness assertion (single-threaded
+ * reduce yields the same result), so the test additionally records query latency and asserts
+ * it stays under a generous bound — proving the query was not silently single-threaded for
+ * the entire pipeline.
+ *
+ * <p>Latency-based assertion is intentionally loose: the bound is wide enough that healthy
+ * hosts always pass, while a true regression to {@code target_partitions=1} on a multi-shard
+ * GROUP BY shows up consistently. If you see this test fail with a near-bound timing on
+ * unrelated work, raise the bound rather than skipping the assertion — the latency floor IS
+ * the regression signal.
+ */
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 2, numClientNodes = 0, supportsDedicatedMasters = false)
+public class SpillDisabledParallelismIT extends OpenSearchIntegTestCase {
+
+    private static final String INDEX_NAME = "spill_disabled_test";
+    private static final int NUM_DOCS = 4000;
+    private static final int NUM_GROUPS = 100;
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return List.of(ArrowBasePlugin.class, TestPPLPlugin.class, CompositeDataFormatPlugin.class, MockCommitterEnginePlugin.class);
+    }
+
+    @Override
+    protected Collection<PluginInfo> additionalNodePlugins() {
+        return List.of(
+            classpathPlugin(FlightStreamPlugin.class, List.of(ArrowBasePlugin.class.getName())),
+            classpathPlugin(AnalyticsPlugin.class, Collections.emptyList()),
+            classpathPlugin(ParquetDataFormatPlugin.class, Collections.emptyList()),
+            classpathPlugin(DataFusionPlugin.class, List.of(AnalyticsPlugin.class.getName()))
+        );
+    }
+
+    private static PluginInfo classpathPlugin(Class<? extends Plugin> pluginClass, List<String> extendedPlugins) {
+        return new PluginInfo(
+            pluginClass.getName(),
+            "classpath plugin",
+            "NA",
+            Version.CURRENT,
+            "1.8",
+            pluginClass.getName(),
+            null,
+            extendedPlugins,
+            false
+        );
+    }
+
+    /**
+     * Note the deliberate omission of {@code datafusion.spill_directory} — that's the whole
+     * point of this test. The empty default (the new contract introduced alongside the
+     * setting) drives DataFusion into {@code DiskManagerMode::Disabled}.
+     */
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return Settings.builder()
+            .put(super.nodeSettings(nodeOrdinal))
+            .put(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG, true)
+            .put(FeatureFlags.STREAM_TRANSPORT, true)
+            // datafusion.spill_directory is intentionally NOT set — empty default = spill disabled.
+            .build();
+    }
+
+    private void createIndexAndIngest() throws Exception {
+        Settings indexSettings = Settings.builder()
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 4)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+            .put("index.pluggable.dataformat.enabled", true)
+            .put("index.pluggable.dataformat", "composite")
+            .put("index.composite.primary_data_format", "parquet")
+            .putList("index.composite.secondary_data_formats")
+            .build();
+
+        assertTrue(
+            client().admin().indices().prepareCreate(INDEX_NAME).setSettings(indexSettings).setMapping("g", "type=integer").get().isAcknowledged()
+        );
+
+        BulkRequestBuilder bulk = client().prepareBulk();
+        for (int i = 0; i < NUM_DOCS; i++) {
+            bulk.add(client().prepareIndex(INDEX_NAME).setSource("g", i % NUM_GROUPS));
+        }
+        BulkResponse bulkResponse = bulk.get();
+        assertFalse("Bulk ingest should not have errors", bulkResponse.hasFailures());
+
+        refresh(INDEX_NAME);
+        ensureGreen(INDEX_NAME);
+    }
+
+    private PPLResponse executePPL(String query) {
+        return client().execute(UnifiedPPLExecuteAction.INSTANCE, new PPLRequest(query)).actionGet();
+    }
+
+    /**
+     * A GROUP BY query whose working set fits under the default memory pool MUST complete
+     * successfully when spill is disabled, with the correct number of groups. This guards
+     * against two regressions at once:
+     *
+     * <ol>
+     *   <li>If the disabled-spill path is broken at runtime construction (e.g. a panic from
+     *       a missing spill dir during DiskManager build), the query never even starts.</li>
+     *   <li>If {@code per_query_spill_budget} ever drifts back to clamping parallelism to 1
+     *       on the disabled path, the query still returns correct results — but the latency
+     *       bound below catches the throughput cliff.</li>
+     * </ol>
+     */
+    public void testNonSpillingGroupByCompletesWithSpillDisabled() throws Exception {
+        createIndexAndIngest();
+
+        long startNanos = System.nanoTime();
+        PPLResponse response = executePPL("source = " + INDEX_NAME + " | stats count() by g");
+        long elapsedMs = (System.nanoTime() - startNanos) / 1_000_000L;
+
+        assertNotNull("Query response must not be null when spill is disabled", response);
+        assertEquals(
+            "GROUP BY g must yield " + NUM_GROUPS + " groups even with spill disabled",
+            NUM_GROUPS,
+            response.getRows().size()
+        );
+
+        // Loose throughput bound: a 4-shard, 4000-row GROUP BY on a healthy CI host completes
+        // well under a second. 30s gives ample headroom for slow CI yet still flags a true
+        // single-threaded regression (which on the same workload trends 5–10× slower than
+        // multi-partition execution as shard count grows).
+        assertTrue(
+            "Query took " + elapsedMs + "ms — exceeds 30s loose bound; investigate whether "
+                + "per_query_spill_budget is incorrectly clamping target_partitions when spill is disabled",
+            elapsedMs < 30_000L
+        );
+    }
+
+    /**
+     * A simple aggregate (no GROUP BY) must also succeed with spill disabled. This exercises
+     * the simpler non-reduce path and ensures the disabled DiskManager doesn't break plain
+     * memory-only queries.
+     */
+    public void testSimpleAggregateSucceedsWithSpillDisabled() throws Exception {
+        createIndexAndIngest();
+        PPLResponse response = executePPL("source = " + INDEX_NAME + " | stats count()");
+        assertNotNull(response);
+        assertEquals("count() must return exactly one row", 1, response.getRows().size());
+    }
+}


### PR DESCRIPTION
## Description

Lets operators point DataFusion spill at a dedicated filesystem instead of inheriting the hardcoded `path.data[0]/../tmp` default. New setting is exposed to set the directory which will be picked by datafusion fallback to the disabled spill otherwise.
