### PR TITLE
Truncate analytics result set at 10k rows to prevent OOM

### DIFF
--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/RowProducingSink.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/RowProducingSink.java
@@ -12,7 +12,6 @@ import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.opensearch.analytics.backend.ExchangeSource;
 import org.opensearch.analytics.spi.ExchangeSink;
-import org.opensearch.core.concurrency.OpenSearchRejectedExecutionException;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -29,8 +28,8 @@ import java.util.List;
  *
  * <p>A configurable row count limit ({@link #maxRows}) acts as a guardrail
  * against unbounded result accumulation. When exceeded, {@link #feed}
- * throws {@link OpenSearchRejectedExecutionException} which propagates to the stage
- * execution and transitions it to FAILED.
+ * throws an exception which propagates to the stage
+ * the result set at the configured limit.
  *
  * <p><b>Thread safety:</b> {@link #feed} may be called concurrently from
  * multiple shard response handlers on the SEARCH thread pool. All mutating
@@ -49,7 +48,7 @@ public class RowProducingSink implements ExchangeSink, ExchangeSource {
      *
      * <p>TODO: make configurable via cluster setting.
      */
-    static final long DEFAULT_MAX_ROWS = 1_000_000L;
+    static final long DEFAULT_MAX_ROWS = 10_000L;
 
     private final List<VectorSchemaRoot> batches = new ArrayList<>();
     private final List<String> fieldNames = new ArrayList<>();
@@ -77,17 +76,11 @@ public class RowProducingSink implements ExchangeSink, ExchangeSource {
                 fieldNames.add(f.getName());
             }
         }
-        long incoming = batch.getRowCount();
-        if (totalRows + incoming > maxRows) {
+        if (totalRows >= maxRows) {
             batch.close();
-            throw new OpenSearchRejectedExecutionException(
-                "Analytics query result exceeded maximum row limit of "
-                    + maxRows
-                    + " rows. "
-                    + "Consider adding filters or aggregations to reduce the result set."
-            );
+            return;
         }
-        totalRows += incoming;
+        totalRows += batch.getRowCount();
         batches.add(batch);
     }
 

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/RowProducingSinkTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/RowProducingSinkTests.java
@@ -139,6 +139,70 @@ public class RowProducingSinkTests extends OpenSearchTestCase {
         sink.close();
     }
 
+    // ─── Row-limit truncation (PR 6) ─────────────────────────────────────
+
+    /**
+     * Once {@code totalRows} reaches {@code maxRows}, further batches are dropped (and closed)
+     * rather than rejected — the sink truncates the result set instead of throwing, so a query
+     * exceeding the limit returns a capped result rather than failing the whole request.
+     */
+    public void testFeedTruncatesAtMaxRowsInsteadOfThrowing() {
+        RowProducingSink sink = new RowProducingSink(2);
+
+        VectorSchemaRoot r1 = makeVsr(List.of("id"), new Object[][] { { "1" }, { "2" } });
+        VectorSchemaRoot r2 = makeVsr(List.of("id"), new Object[][] { { "3" } });
+        VectorSchemaRoot r3 = makeVsr(List.of("id"), new Object[][] { { "4" } });
+
+        sink.feed(r1); // totalRows = 2, reaches the limit
+        sink.feed(r2); // totalRows >= maxRows → dropped + closed, no throw
+        sink.feed(r3); // dropped + closed
+
+        assertEquals("result is capped at maxRows", 2, sink.getRowCount());
+        Iterator<VectorSchemaRoot> it = sink.readResult().iterator();
+        assertSame("only the pre-limit batch is retained", r1, it.next());
+        assertFalse("over-limit batches are not buffered", it.hasNext());
+
+        sink.close();
+    }
+
+    /**
+     * The accepting batch may overshoot {@code maxRows} (the check is "stop once at/over the
+     * limit", evaluated before each batch) — but the next batch is then dropped. This pins the
+     * exact boundary semantics so a future refactor can't silently change them.
+     */
+    public void testFeedAcceptsBatchThatCrossesLimitThenStops() {
+        RowProducingSink sink = new RowProducingSink(2);
+
+        VectorSchemaRoot r1 = makeVsr(List.of("id"), new Object[][] { { "1" }, { "2" }, { "3" } });
+        VectorSchemaRoot r2 = makeVsr(List.of("id"), new Object[][] { { "4" } });
+
+        sink.feed(r1); // totalRows was 0 (< 2) → accepted whole, totalRows = 3 (overshoots)
+        sink.feed(r2); // totalRows 3 >= 2 → dropped
+
+        assertEquals("the crossing batch is accepted in full", 3, sink.getRowCount());
+        Iterator<VectorSchemaRoot> it = sink.readResult().iterator();
+        assertSame(r1, it.next());
+        assertFalse(it.hasNext());
+
+        sink.close();
+    }
+
+    /**
+     * {@code maxRows = Long.MAX_VALUE} disables the cap — every batch is retained.
+     */
+    public void testUnlimitedSinkRetainsAllBatches() {
+        RowProducingSink sink = new RowProducingSink(Long.MAX_VALUE);
+
+        VectorSchemaRoot r1 = makeVsr(List.of("id"), new Object[][] { { "1" } });
+        VectorSchemaRoot r2 = makeVsr(List.of("id"), new Object[][] { { "2" } });
+
+        sink.feed(r1);
+        sink.feed(r2);
+
+        assertEquals(2, sink.getRowCount());
+        sink.close();
+    }
+
     // ─── Helpers ────────────────────────────────────────────────────────
 
     private VectorSchemaRoot makeVsr(List<String> fieldNames, Object[][] rows) {

--- a/sandbox/qa/analytics-engine-coordinator/src/internalClusterTest/java/org/opensearch/analytics/resilience/CoordinatorTransportStressIT.java
+++ b/sandbox/qa/analytics-engine-coordinator/src/internalClusterTest/java/org/opensearch/analytics/resilience/CoordinatorTransportStressIT.java
@@ -95,21 +95,31 @@ public class CoordinatorTransportStressIT extends OpenSearchIntegTestCase {
     private static final String INDEX_1 = "stress_idx_1";
     private static final String INDEX_3 = "stress_idx_3";
 
-    // ROWS_PER_BATCH: scaled down from a notional 50_000 to 5_000 because the
-    // coordinator's reduce-side RowProducingSink imposes a 1_000_000-row hard
-    // limit (RowProducingSink.DEFAULT_MAX_ROWS) for queries that do not push a
-    // backend-aggregating COORDINATOR_REDUCE stage. The synthetic batches we
-    // emit here come from a stub handler that bypasses the production
-    // partial-aggregation path — they arrive at the coordinator as raw
-    // Int32 row batches and feed the row-collecting sink directly. With
-    // ROWS_PER_BATCH=5_000 the heaviest test (S1: 100 batches) totals
-    // 500_000 rows, comfortably under that limit while still exercising
-    // 100 round-trip stream batches across the full streaming transport
-    // path. See "Coordinator finding" in the test report.
+    // ROWS_PER_BATCH: the coordinator's reduce-side RowProducingSink truncates
+    // buffered output at OUTPUT_ROW_CAP rows (RowProducingSink.DEFAULT_MAX_ROWS)
+    // for queries that do not push a backend-aggregating COORDINATOR_REDUCE
+    // stage. The synthetic batches we emit here come from a stub handler that
+    // bypasses the production partial-aggregation path — they arrive at the
+    // coordinator as raw Int32 row batches and feed the row-collecting sink
+    // directly, so the sink caps the result. These tests intentionally send far
+    // more than the cap to stress the streaming transport path (many round-trip
+    // stream batches, native mpsc backpressure, drain thread); the assertions
+    // therefore expect the capped output (min(sent, OUTPUT_ROW_CAP)) rather than
+    // every row sent. ROWS_PER_BATCH=5_000 divides the cap evenly so truncation
+    // (whole-batch) lands deterministically on the cap. See "Coordinator
+    // finding" in the test report.
     private static final int ROWS_PER_BATCH = 5_000;
     private static final int VALUE = 7;
     /** Per-batch native bytes ≈ 5_000 × 4 (Int32 data) + bitmap. */
     private static final long PER_BATCH_BYTES = ROWS_PER_BATCH * 4L + 8 * 1024L;
+    /**
+     * Coordinator output cap — mirrors the package-private
+     * {@code RowProducingSink.DEFAULT_MAX_ROWS}. The row-collecting sink truncates
+     * buffered output at this many rows (whole batches dropped once reached), so a
+     * raw (non-aggregating) stream of N rows yields {@code min(N, OUTPUT_ROW_CAP)}
+     * rows at the coordinator.
+     */
+    private static final long OUTPUT_ROW_CAP = 10_000L;
 
     private static final TimeValue STRESS_TIMEOUT = TimeValue.timeValueSeconds(60);
     private static final TimeValue CONCURRENT_TIMEOUT = TimeValue.timeValueSeconds(90);
@@ -280,6 +290,21 @@ public class CoordinatorTransportStressIT extends OpenSearchIntegTestCase {
         return total;
     }
 
+    /**
+     * Asserts a raw (non-aggregating) stress response reflects the coordinator's
+     * output truncation: the row count is {@code min(rowsSent, OUTPUT_ROW_CAP)},
+     * and the retained rows are intact — every kept row carries {@link #VALUE}, so
+     * the summed column equals {@code rowsKept × VALUE}. We deliberately do NOT
+     * assert all {@code rowsSent} rows survive: {@code RowProducingSink} caps
+     * buffered output, and these tests stress the transport path well past that cap.
+     */
+    private static void assertCappedResult(String tag, long rowsSent, PPLResponse response) {
+        long expectedRows = Math.min(rowsSent, OUTPUT_ROW_CAP);
+        long actualRows = response.getRows().size();
+        assertEquals(tag + " capped row-count mismatch (sent=" + rowsSent + ", cap=" + OUTPUT_ROW_CAP + ")", expectedRows, actualRows);
+        assertEquals(tag + " retained rows must be intact (sum == rowsKept × VALUE)", actualRows * VALUE, sumValueColumn(response));
+    }
+
     /** Build a fresh VSR with {@link #ROWS_PER_BATCH} rows of constant {@link #VALUE}. */
     private static VectorSchemaRoot buildBatch() {
         VectorSchemaRoot vsr = VectorSchemaRoot.create(BATCH_SCHEMA, producerAllocator);
@@ -319,15 +344,17 @@ public class CoordinatorTransportStressIT extends OpenSearchIntegTestCase {
     }
 
     /**
-     * S1 — 100 batches of 50k Int32 rows from a single shard. Verifies the
+     * S1 — 100 batches of 5k Int32 rows from a single shard. Verifies the
      * coordinator's reduce sink + native mpsc backpressure + drain-thread keep
-     * up under sustained per-shard load and the SUM is exact (50000 × 100 × 7).
+     * up under sustained per-shard load. The 500k rows sent far exceed the
+     * coordinator output cap, so the result is truncated to OUTPUT_ROW_CAP rows
+     * (with the retained rows intact); the stress value is the 100 streamed
+     * round-trips, not the final row count.
      */
     public void testCoordinatorHandlesHundredBatchesFromOneShard() throws Exception {
         createSingleShardIndex();
         final int batches = 100;
-        final long expectedRows = (long) ROWS_PER_BATCH * batches;
-        final long expectedSum = expectedRows * VALUE;
+        final long rowsSent = (long) ROWS_PER_BATCH * batches;
         String victim = pickShardHostingNode(INDEX_1);
         MockTransportService mts = (MockTransportService) internalCluster().getInstance(TransportService.class, victim);
         AtomicInteger sent = new AtomicInteger();
@@ -345,15 +372,17 @@ public class CoordinatorTransportStressIT extends OpenSearchIntegTestCase {
         });
         try {
             PPLResponse response = executePPL("source = " + INDEX_1, STRESS_TIMEOUT);
-            assertEquals("S1 row-count mismatch (sent=" + sent.get() + ")", expectedRows, response.getRows().size());
-            assertEquals("S1 sum mismatch", expectedSum, sumValueColumn(response));
+            assertCappedResult("S1 (sent=" + sent.get() + ")", rowsSent, response);
         } finally {
             mts.clearAllRules();
         }
     }
 
     /**
-     * S2 — 3-shard variant: 50 batches × 50k rows per shard.
+     * S2 — 3-shard variant: 50 batches × 5k rows per shard. The combined stream
+     * exceeds the coordinator output cap, so the result is truncated to
+     * OUTPUT_ROW_CAP rows (retained rows intact); the stress value is the
+     * concurrent 3-shard streaming fan-in, not the final row count.
      */
     public void testCoordinatorHandlesBatchesAcrossAllThreeShards() throws Exception {
         createThreeShardIndex();
@@ -365,8 +394,7 @@ public class CoordinatorTransportStressIT extends OpenSearchIntegTestCase {
         // on the same node, the stub fires once per FragmentExecutionAction
         // request (one per shard), still emitting batchesPerShard batches per
         // shard. Use shard-count for arithmetic, not host-node count.
-        long expectedRows = (long) ROWS_PER_BATCH * batchesPerShard * map.size();
-        long expectedSum = expectedRows * VALUE;
+        long rowsSent = (long) ROWS_PER_BATCH * batchesPerShard * map.size();
         Map<String, AtomicInteger> sentByNode = new HashMap<>();
         List<MockTransportService> stubbed = new ArrayList<>();
         for (String node : map.values()) {
@@ -396,8 +424,7 @@ public class CoordinatorTransportStressIT extends OpenSearchIntegTestCase {
                 .stream()
                 .map(e -> e.getKey() + ":" + e.getValue().get())
                 .collect(Collectors.joining(","));
-            assertEquals("S2 row-count mismatch (sent=" + sentReport + ")", expectedRows, response.getRows().size());
-            assertEquals("S2 sum mismatch (sent=" + sentReport + ")", expectedSum, sumValueColumn(response));
+            assertCappedResult("S2 (sent=" + sentReport + ")", rowsSent, response);
         } finally {
             for (MockTransportService mts : stubbed) {
                 mts.clearAllRules();
@@ -492,14 +519,16 @@ public class CoordinatorTransportStressIT extends OpenSearchIntegTestCase {
     }
 
     /**
-     * S4 — Backpressure: producer emits fast (no sleeps). Verifies sum is exact
-     * (no rows lost) and producer-side allocator high-water stays bounded.
+     * S4 — Backpressure: producer emits fast (no sleeps). The transport path must
+     * deliver every batch to the coordinator (no transport-level loss) and keep the
+     * producer-side allocator high-water bounded. The coordinator output sink then
+     * truncates the buffered rows at OUTPUT_ROW_CAP, so the response reflects the
+     * cap (retained rows intact), not all 250k rows sent.
      */
     public void testBackPressureDoesNotDropBatches() throws Exception {
         createSingleShardIndex();
         final int batches = 50;
-        final long expectedRows = (long) ROWS_PER_BATCH * batches;
-        final long expectedSum = expectedRows * VALUE;
+        final long rowsSent = (long) ROWS_PER_BATCH * batches;
         String victim = pickShardHostingNode(INDEX_1);
         MockTransportService mts = (MockTransportService) internalCluster().getInstance(TransportService.class, victim);
         AtomicInteger sent = new AtomicInteger();
@@ -523,8 +552,7 @@ public class CoordinatorTransportStressIT extends OpenSearchIntegTestCase {
         });
         try {
             PPLResponse response = executePPL("source = " + INDEX_1, STRESS_TIMEOUT);
-            assertEquals("S4 row-count mismatch (sent=" + sent.get() + ")", expectedRows, response.getRows().size());
-            assertEquals("S4 sum mismatch", expectedSum, sumValueColumn(response));
+            assertCappedResult("S4 (sent=" + sent.get() + ")", rowsSent, response);
             // The producer allocator high-water reflects how many in-flight
             // VSRs the producer holds at any one time. FlightTransportChannel
             // .sendResponseBatch enqueues to FlightOutboundHandler's executor
@@ -533,7 +561,8 @@ public class CoordinatorTransportStressIT extends OpenSearchIntegTestCase {
             // can allocate all N batches before the serializer drains the
             // first, so the bound here is loose: high-water ≤ (N+1) × per-
             // batch bytes for N enqueued batches. This is informational —
-            // the substantive check is row-count + sum (no batch dropped).
+            // the substantive check is the capped row-count + retained-row
+            // integrity asserted above.
             long ceiling = beforeProducer + (long) (batches + 2) * PER_BATCH_BYTES * 4L;
             assertTrue(
                 "Producer allocator high-water exceeded loose bound: high="
@@ -550,9 +579,10 @@ public class CoordinatorTransportStressIT extends OpenSearchIntegTestCase {
     }
 
     /**
-     * S5 — 4 concurrent stress queries against the same single-shard index.
-     * Each gets 30 batches × 50k × 7 rows. Independent client-side futures
-     * verify per-query correctness.
+     * S5 — concurrent stress queries against the same single-shard index. Each
+     * query streams 15 batches × 5k rows (75k sent), which exceeds the coordinator
+     * output cap, so each independent client-side future verifies the per-query
+     * result is truncated to OUTPUT_ROW_CAP rows with the retained rows intact.
      */
     public void testConcurrentStressRuns() throws Exception {
         createSingleShardIndex();
@@ -582,7 +612,9 @@ public class CoordinatorTransportStressIT extends OpenSearchIntegTestCase {
         // 2 (or higher) once the streaming-dispatch hazard is fixed.
         final int concurrency = 1;
         final int batchesPerQuery = 15;
-        final long expectedRowsPerQuery = (long) ROWS_PER_BATCH * batchesPerQuery;
+        final long rowsSentPerQuery = (long) ROWS_PER_BATCH * batchesPerQuery;
+        // Coordinator output cap truncates each query's buffered result.
+        final long expectedRowsPerQuery = Math.min(rowsSentPerQuery, OUTPUT_ROW_CAP);
         final long expectedSumPerQuery = expectedRowsPerQuery * VALUE;
         String victim = pickShardHostingNode(INDEX_1);
         MockTransportService mts = (MockTransportService) internalCluster().getInstance(TransportService.class, victim);


### PR DESCRIPTION


The drain loop continues to completion (all shard data is consumed and the native plan terminates normally) — only the buffered output is capped.

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
RowProducingSink now silently discards batches once the row count exceeds 10,000 rows (analogous to index.max_result_window in core search). Previously, unbounded GROUP BY queries without a LIMIT in the coordinator plan would accumulate millions of VSR rows and OOM the JVM during JSON serialization.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
