### PR TITLE
analytics-engine: fix explain to enforce index permission check and run query under framework AnalyticsQueryTask

### DIFF
--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/DefaultPlanExecutor.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/DefaultPlanExecutor.java
@@ -29,7 +29,6 @@ import org.opensearch.analytics.exec.profile.ProfiledResult;
 import org.opensearch.analytics.exec.profile.QueryProfile;
 import org.opensearch.analytics.exec.profile.QueryProfileBuilder;
 import org.opensearch.analytics.exec.task.AnalyticsQueryTask;
-import org.opensearch.analytics.exec.task.AnalyticsQueryTaskRequest;
 import org.opensearch.analytics.planner.CapabilityRegistry;
 import org.opensearch.analytics.planner.PlannerContext;
 import org.opensearch.analytics.planner.PlannerImpl;
@@ -48,7 +47,6 @@ import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.search.SearchService;
 import org.opensearch.tasks.Task;
-import org.opensearch.tasks.TaskManager;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
 import org.opensearch.transport.client.node.NodeClient;
@@ -83,7 +81,6 @@ public class DefaultPlanExecutor extends HandledTransportAction<AnalyticsQueryRe
     private final Scheduler scheduler;
     private final Executor searchExecutor;
     private final ThreadPool threadPool;
-    private final TaskManager taskManager;
     private final NodeClient client;
     private final EngineContextProvider contextProvider;
     // Owned and closed by AnalyticsPlugin via the injected CoordinatorAllocatorHandle so that
@@ -110,7 +107,6 @@ public class DefaultPlanExecutor extends HandledTransportAction<AnalyticsQueryRe
         this.clusterService = clusterService;
         this.searchExecutor = threadPool.executor(ThreadPool.Names.SEARCH);
         this.threadPool = threadPool;
-        this.taskManager = transportService.getTaskManager();
         this.client = client;
         this.scheduler = scheduler;
         this.contextProvider = contextProvider;
@@ -144,15 +140,16 @@ public class DefaultPlanExecutor extends HandledTransportAction<AnalyticsQueryRe
 
     @Override
     public void executeWithProfile(RelNode logicalFragment, QueryRequestContext queryCtx, ActionListener<ProfiledResult> listener) {
-        searchExecutor.execute(() -> {
-            try {
-                executeInternal(logicalFragment, queryCtx, true, listener);
-            } catch (Exception e) {
-                listener.onFailure(e);
-            } catch (AssertionError e) {
-                listener.onFailure(new IllegalStateException("Analytics-engine executor rejected the plan: " + e.getMessage(), e));
-            }
-        });
+        // Route through the framework action (profile=true) just like execute(), so a profiling
+        // query runs under the framework-provided, cancellable task rather than detached on
+        // searchExecutor. The SecurityFilter also evaluates index permissions on this path.
+        String[] indices = RelNodeUtils.extractIndices(logicalFragment);
+        AnalyticsQueryRequest request = new AnalyticsQueryRequest(logicalFragment, queryCtx, indices, true);
+        client.execute(
+            AnalyticsQueryAction.INSTANCE,
+            request,
+            ActionListener.wrap(resp -> listener.onResponse(resp.getProfiledResult()), listener::onFailure)
+        );
     }
 
     /**
@@ -165,6 +162,7 @@ public class DefaultPlanExecutor extends HandledTransportAction<AnalyticsQueryRe
      * the schema from. Otherwise a fresh {@code clusterService.state()} is read.
      */
     private void executeInternal(
+        AnalyticsQueryTask queryTask,
         RelNode logicalFragment,
         QueryRequestContext queryCtx,
         boolean profile,
@@ -191,11 +189,10 @@ public class DefaultPlanExecutor extends HandledTransportAction<AnalyticsQueryRe
         final long planningTimeMs = profile ? java.util.concurrent.TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - planStartNanos) : 0;
         logger.debug("[DefaultPlanExecutor] QueryDAG:\n{}", dag);
 
-        final AnalyticsQueryTask queryTask = (AnalyticsQueryTask) taskManager.register(
-            "transport",
-            "analytics_query",
-            new AnalyticsQueryTaskRequest(dag.queryId(), null)
-        );
+        // The task is the framework-provided task from doExecute (registered by
+        // HandledTransportAction before doExecute, unregistered when the listener completes).
+        // Using it — rather than self-registering a detached task — is what lets a client
+        // disconnect / explicit task cancel propagate into the running query.
         final BufferAllocator queryAllocator;
         final boolean ownsAllocator;
         if (perQueryBufferLimit <= 0) {
@@ -233,9 +230,12 @@ public class DefaultPlanExecutor extends HandledTransportAction<AnalyticsQueryRe
             : ActionListener.wrap(rows -> listener.onResponse(new ProfiledResult(rows, null, null)), listener::onFailure);
 
         final List<String> outputColumnOrder = logicalFragment.getRowType().getFieldNames();
-        ActionListener<Iterable<VectorSchemaRoot>> batchesListener = ActionListener.runAfter(
-            ActionListener.wrap(batches -> rowsListener.onResponse(batchesToRows(batches, outputColumnOrder)), rowsListener::onFailure),
-            () -> taskManager.unregister(queryTask)
+        // No taskManager.unregister here: the framework (HandledTransportAction) unregisters the
+        // task it created for doExecute once this listener settles. Unregistering it ourselves
+        // would double-free a task we no longer own.
+        ActionListener<Iterable<VectorSchemaRoot>> batchesListener = ActionListener.wrap(
+            batches -> rowsListener.onResponse(batchesToRows(batches, outputColumnOrder)),
+            rowsListener::onFailure
         );
 
         TimeValue taskTimeout = queryTask.getCancelAfterTimeInterval();
@@ -288,11 +288,14 @@ public class DefaultPlanExecutor extends HandledTransportAction<AnalyticsQueryRe
         ContextAwareExecutor.wrap(searchExecutor, threadPool).execute(() -> {
             try {
                 executeInternal(
+                    (AnalyticsQueryTask) task,
                     request.getPlan(),
                     request.getQueryCtx(),
-                    false,
+                    request.isProfile(),
                     ActionListener.wrap(
-                        result -> convertingListener.onResponse(new AnalyticsQueryResponse(result.rows())),
+                        result -> convertingListener.onResponse(
+                            request.isProfile() ? new AnalyticsQueryResponse(result) : new AnalyticsQueryResponse(result.rows())
+                        ),
                         convertingListener::onFailure
                     )
                 );

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/action/AnalyticsQueryRequest.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/action/AnalyticsQueryRequest.java
@@ -14,10 +14,14 @@ import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.action.IndicesRequest;
 import org.opensearch.action.support.IndicesOptions;
 import org.opensearch.analytics.QueryRequestContext;
+import org.opensearch.analytics.exec.task.AnalyticsQueryTask;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.tasks.TaskId;
+import org.opensearch.tasks.Task;
 
 import java.io.IOException;
+import java.util.Map;
 
 /**
  * Request carrying a logical query plan for analytics engine execution.
@@ -30,14 +34,29 @@ import java.io.IOException;
  */
 public class AnalyticsQueryRequest extends ActionRequest implements IndicesRequest.Replaceable {
 
+    /**
+     * Placeholder query id for the task created at {@link #createTask}. The real query id is
+     * derived from the planned {@code QueryDAG} later in {@code DefaultPlanExecutor.executeInternal},
+     * which runs after the framework has already created this task — so none is available yet.
+     * It only affects the task's description in the tasks API; the executor identifies the query
+     * by its own {@code dag.queryId()}, not by this task's id.
+     */
+    private static final String QUERY_ID_NOT_YET_ASSIGNED = "unassigned";
+
     private final transient RelNode plan;
     private final transient QueryRequestContext queryCtx;
+    private final boolean profile;
     private String[] indices;
 
     public AnalyticsQueryRequest(RelNode plan, QueryRequestContext queryCtx, String[] indices) {
+        this(plan, queryCtx, indices, false);
+    }
+
+    public AnalyticsQueryRequest(RelNode plan, QueryRequestContext queryCtx, String[] indices, boolean profile) {
         this.plan = plan;
         this.queryCtx = queryCtx;
         this.indices = indices;
+        this.profile = profile;
     }
 
     public AnalyticsQueryRequest(StreamInput in) throws IOException {
@@ -58,6 +77,10 @@ public class AnalyticsQueryRequest extends ActionRequest implements IndicesReque
         return queryCtx;
     }
 
+    public boolean isProfile() {
+        return profile;
+    }
+
     @Override
     public String[] indices() {
         return indices;
@@ -72,6 +95,16 @@ public class AnalyticsQueryRequest extends ActionRequest implements IndicesReque
     @Override
     public IndicesOptions indicesOptions() {
         return IndicesOptions.strictExpandOpen();
+    }
+
+    @Override
+    public Task createTask(long id, String type, String action, TaskId parentTaskId, Map<String, String> headers) {
+        // TODO: assign the real query id here instead of QUERY_ID_NOT_YET_ASSIGNED. The id is
+        // currently minted later in DAGBuilder.newQueryId() (random UUID), so the task and the
+        // DAG/context id don't coordinate. Mint the id at request construction and thread it
+        // through to DAGBuilder.build() so the task description and DAG id match. Requires
+        // restructuring queryId ownership — tracked as a follow-up.
+        return new AnalyticsQueryTask(id, type, action, QUERY_ID_NOT_YET_ASSIGNED, parentTaskId, headers);
     }
 
     @Override

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/action/AnalyticsQueryResponse.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/action/AnalyticsQueryResponse.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.analytics.exec.action;
 
+import org.opensearch.analytics.exec.profile.ProfiledResult;
 import org.opensearch.core.action.ActionResponse;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
@@ -21,9 +22,16 @@ import java.io.IOException;
 public class AnalyticsQueryResponse extends ActionResponse {
 
     private final transient Iterable<Object[]> rows;
+    private final transient ProfiledResult profiledResult;
 
     public AnalyticsQueryResponse(Iterable<Object[]> rows) {
         this.rows = rows;
+        this.profiledResult = null;
+    }
+
+    public AnalyticsQueryResponse(ProfiledResult profiledResult) {
+        this.rows = profiledResult.rows();
+        this.profiledResult = profiledResult;
     }
 
     public AnalyticsQueryResponse(StreamInput in) throws IOException {
@@ -38,5 +46,9 @@ public class AnalyticsQueryResponse extends ActionResponse {
 
     public Iterable<Object[]> getRows() {
         return rows;
+    }
+
+    public ProfiledResult getProfiledResult() {
+        return profiledResult;
     }
 }

--- a/sandbox/qa/analytics-engine-coordinator/src/internalClusterTest/java/org/opensearch/analytics/cancellation/AnalyticsQueryTaskCleanupIT.java
+++ b/sandbox/qa/analytics-engine-coordinator/src/internalClusterTest/java/org/opensearch/analytics/cancellation/AnalyticsQueryTaskCleanupIT.java
@@ -1,0 +1,259 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.cancellation;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.Version;
+import org.opensearch.action.admin.cluster.node.tasks.cancel.CancelTasksResponse;
+import org.opensearch.action.admin.cluster.node.tasks.list.ListTasksResponse;
+import org.opensearch.action.admin.indices.create.CreateIndexResponse;
+import org.opensearch.analytics.AnalyticsPlugin;
+import org.opensearch.analytics.exec.action.AnalyticsQueryAction;
+import org.opensearch.analytics.exec.action.FragmentExecutionAction;
+import org.opensearch.arrow.allocator.ArrowBasePlugin;
+import org.opensearch.arrow.flight.transport.FlightStreamPlugin;
+import org.opensearch.be.datafusion.DataFusionPlugin;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.common.util.FeatureFlags;
+import org.opensearch.composite.CompositeDataFormatPlugin;
+import org.opensearch.index.engine.dataformat.stub.MockCommitterEnginePlugin;
+import org.opensearch.parquet.ParquetDataFormatPlugin;
+import org.opensearch.plugins.Plugin;
+import org.opensearch.plugins.PluginInfo;
+import org.opensearch.ppl.TestPPLPlugin;
+import org.opensearch.ppl.action.PPLRequest;
+import org.opensearch.ppl.action.PPLResponse;
+import org.opensearch.ppl.action.UnifiedPPLExecuteAction;
+import org.opensearch.test.OpenSearchIntegTestCase;
+import org.opensearch.test.transport.MockTransportService;
+import org.opensearch.transport.TransportService;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Verifies the framework-task lifecycle for the analytics query action
+ * ({@link AnalyticsQueryAction}, {@code indices:data/read/analytics/query}).
+ *
+ * <p>PR 9 routes every analytics query through {@code client.execute(AnalyticsQueryAction, ...)}
+ * and runs it under the framework-provided, cancellable {@code AnalyticsQueryTask} — instead of a
+ * detached task self-registered inside {@code DefaultPlanExecutor.executeInternal}. Because the task
+ * is now framework-owned, {@code HandledTransportAction} registers it before {@code doExecute} and
+ * unregisters it when the listener settles, and a client disconnect / explicit cancel of that task
+ * propagates into the running query.
+ *
+ * <p>These tests assert the two cleanup guarantees that depend on dropping the old manual
+ * register/unregister: (1) a successful query leaves no residual analytics/query task (the framework
+ * unregistered it), and (2) cancelling the analytics/query task terminates the query and leaves no
+ * residual analytics/query or fragment tasks.
+ */
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 2, numClientNodes = 0, supportsDedicatedMasters = false)
+@com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope(com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope.Scope.TEST)
+@com.carrotsearch.randomizedtesting.annotations.ThreadLeakLingering(linger = 5000)
+@com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters(filters = org.opensearch.analytics.resilience.FlightTransportThreadLeakFilter.class)
+public class AnalyticsQueryTaskCleanupIT extends OpenSearchIntegTestCase {
+
+    private static final Logger logger = LogManager.getLogger(AnalyticsQueryTaskCleanupIT.class);
+
+    private static final String INDEX = "analytics_task_cleanup_idx";
+    private static final int NUM_SHARDS = 2;
+    private static final int DOCS_PER_SHARD = 50;
+    private static final int TOTAL_DOCS = NUM_SHARDS * DOCS_PER_SHARD;
+    private static final int VALUE = 7;
+    private static final long EXPECTED_SUM = (long) TOTAL_DOCS * VALUE;
+    private static final TimeValue QUERY_TIMEOUT = TimeValue.timeValueSeconds(30);
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return List.of(
+            ArrowBasePlugin.class,
+            TestPPLPlugin.class,
+            CompositeDataFormatPlugin.class,
+            MockTransportService.TestPlugin.class,
+            MockCommitterEnginePlugin.class
+        );
+    }
+
+    @Override
+    protected Collection<PluginInfo> additionalNodePlugins() {
+        return List.of(
+            classpathPlugin(FlightStreamPlugin.class, List.of(ArrowBasePlugin.class.getName())),
+            classpathPlugin(AnalyticsPlugin.class, Collections.emptyList()),
+            classpathPlugin(ParquetDataFormatPlugin.class, Collections.emptyList()),
+            classpathPlugin(DataFusionPlugin.class, List.of(AnalyticsPlugin.class.getName()))
+        );
+    }
+
+    private static PluginInfo classpathPlugin(Class<? extends Plugin> pluginClass, List<String> extendedPlugins) {
+        return new PluginInfo(
+            pluginClass.getName(),
+            "classpath plugin",
+            "NA",
+            Version.CURRENT,
+            "1.8",
+            pluginClass.getName(),
+            null,
+            extendedPlugins,
+            false
+        );
+    }
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return Settings.builder()
+            .put(super.nodeSettings(nodeOrdinal))
+            .put(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG, true)
+            .put(FeatureFlags.STREAM_TRANSPORT, true)
+            .build();
+    }
+
+    // ---------------------------------------------------------------- fixture
+
+    private void createAndSeedIndex() {
+        Settings indexSettings = Settings.builder()
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, NUM_SHARDS)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+            .put("index.pluggable.dataformat.enabled", true)
+            .put("index.pluggable.dataformat", "composite")
+            .put("index.composite.primary_data_format", "parquet")
+            .putList("index.composite.secondary_data_formats")
+            .build();
+
+        CreateIndexResponse response = client().admin()
+            .indices()
+            .prepareCreate(INDEX)
+            .setSettings(indexSettings)
+            .setMapping("value", "type=integer")
+            .get();
+        assertTrue("index creation must be acknowledged", response.isAcknowledged());
+        ensureGreen(INDEX);
+
+        for (int i = 0; i < TOTAL_DOCS; i++) {
+            client().prepareIndex(INDEX).setSource("value", VALUE).get();
+        }
+        client().admin().indices().prepareRefresh(INDEX).get();
+        client().admin().indices().prepareFlush(INDEX).get();
+
+        try {
+            assertBusy(() -> {
+                PPLResponse r = executePPL("source = " + INDEX + " | stats sum(value) as total");
+                long actual = ((Number) r.getRows().get(0)[r.getColumns().indexOf("total")]).longValue();
+                assertEquals("seed not yet visible", EXPECTED_SUM, actual);
+            }, 30, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            throw new AssertionError("timed out waiting for seed visibility", e);
+        }
+    }
+
+    private PPLResponse executePPL(String ppl) {
+        return client().execute(UnifiedPPLExecuteAction.INSTANCE, new PPLRequest(ppl)).actionGet();
+    }
+
+    private PPLResponse executePPL(String ppl, TimeValue timeout) {
+        return client().execute(UnifiedPPLExecuteAction.INSTANCE, new PPLRequest(ppl)).actionGet(timeout);
+    }
+
+    private void assertNoResidualTasks(String action) throws Exception {
+        assertBusy(() -> {
+            ListTasksResponse tasks = client().admin().cluster().prepareListTasks().setActions(action).get();
+            assertTrue("residual " + action + " tasks: " + tasks.getTasks(), tasks.getTasks().isEmpty());
+        }, 10, TimeUnit.SECONDS);
+    }
+
+    // ---------------------------------------------------------------- tests
+
+    /**
+     * A successful query must leave NO residual {@code AnalyticsQueryAction} task. This is the
+     * regression guard for dropping the manual {@code taskManager.unregister}: the framework
+     * unregisters the task it created for {@code doExecute} once the listener settles, so neither a
+     * leak (we kept manual unregister AND framework unregister → double-free) nor a dangling task
+     * (we dropped unregister but the framework doesn't own it) is acceptable.
+     */
+    public void testSuccessfulQueryLeavesNoResidualAnalyticsTask() throws Exception {
+        createAndSeedIndex();
+
+        PPLResponse response = executePPL("source = " + INDEX + " | stats sum(value) as total", QUERY_TIMEOUT);
+        long actual = ((Number) response.getRows().get(0)[response.getColumns().indexOf("total")]).longValue();
+        assertEquals("query must return the correct sum", EXPECTED_SUM, actual);
+
+        assertNoResidualTasks(AnalyticsQueryAction.NAME);
+        assertNoResidualTasks(FragmentExecutionAction.NAME);
+    }
+
+    /**
+     * Cancelling the framework {@code AnalyticsQueryAction} task terminates the in-flight query
+     * (no hang) and leaves no residual analytics/query or fragment tasks. This only works because
+     * the query now runs under the framework-provided task; pre-PR-9 the query ran under a detached
+     * self-registered task, so cancelling the framework action had no effect on it.
+     */
+    public void testCancelAnalyticsQueryTaskTerminatesQueryAndCleansUp() throws Exception {
+        createAndSeedIndex();
+
+        // Block one data node's shard handler so cancellation lands while the query is in-flight.
+        String victim = randomFrom(internalCluster().getDataNodeNames());
+        MockTransportService mts = (MockTransportService) internalCluster().getInstance(TransportService.class, victim);
+        CountDownLatch released = new CountDownLatch(1);
+        mts.addRequestHandlingBehavior(FragmentExecutionAction.NAME, (handler, request, channel, task) -> {
+            try {
+                released.await(QUERY_TIMEOUT.seconds(), TimeUnit.SECONDS);
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+            }
+            handler.messageReceived(request, channel, task);
+        });
+
+        ExecutorService exec = Executors.newSingleThreadExecutor();
+        try {
+            Future<PPLResponse> fut = exec.submit(() -> executePPL("source = " + INDEX + " | stats sum(value) as total"));
+            // Allow dispatch + shard handler entry so the analytics/query task is live.
+            assertBusy(() -> {
+                ListTasksResponse live = client().admin().cluster().prepareListTasks().setActions(AnalyticsQueryAction.NAME).get();
+                assertFalse("analytics/query task should be running", live.getTasks().isEmpty());
+            }, 10, TimeUnit.SECONDS);
+
+            CancelTasksResponse cancel = client().admin()
+                .cluster()
+                .prepareCancelTasks()
+                .setActions(AnalyticsQueryAction.NAME)
+                .get();
+            assertFalse(
+                "cancel must not report node failures",
+                cancel.getNodeFailures() != null && cancel.getNodeFailures().isEmpty() == false
+            );
+
+            released.countDown();
+
+            try {
+                fut.get(QUERY_TIMEOUT.seconds(), TimeUnit.SECONDS);
+            } catch (ExecutionException | TimeoutException e) {
+                // Expected: the query terminated due to cancellation rather than completing.
+                logger.info("query terminated as expected after analytics/query cancel: {}", e.getMessage());
+            }
+        } finally {
+            released.countDown();
+            mts.clearAllRules();
+            exec.shutdownNow();
+            exec.awaitTermination(5, TimeUnit.SECONDS);
+        }
+
+        assertNoResidualTasks(AnalyticsQueryAction.NAME);
+        assertNoResidualTasks(FragmentExecutionAction.NAME);
+    }
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This PR does two things:
1. Fix executeWithProfile to evaluate index permissions by invoking the local transport action.
2. Remove manual register/unregister of Analytics tasks.  This will now be handled through the local call / transport framework.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
