### PR TITLE
[analytics-engine] Wire PPL percentile_approx end-to-end

### DIFF
--- a/sandbox/libs/analytics-framework/src/test/java/org/opensearch/analytics/spi/AggregateFunctionTests.java
+++ b/sandbox/libs/analytics-framework/src/test/java/org/opensearch/analytics/spi/AggregateFunctionTests.java
@@ -164,6 +164,24 @@ public class AggregateFunctionTests extends OpenSearchTestCase {
         assertEquals(integer, resolve(fields.get(0), integer));
     }
 
+    // ── PERCENTILE_APPROX: state-bearing, no decomposition declared ──
+    //
+    // DataFusion's t-digest state is multi-field and doesn't fit the single-field
+    // IntermediateField shape. OpenSearchAggregateSplitRule skips the partial/final split
+    // for STATE_EXPANDING aggregates, so PERCENTILE_APPROX runs single-stage on the
+    // coordinator after a singleton gather.
+    public void testPercentileApproxHasNoDecomposition() {
+        assertFalse(AggregateFunction.PERCENTILE_APPROX.hasDecomposition());
+        assertNull(AggregateFunction.PERCENTILE_APPROX.intermediateFields());
+        assertEquals(AggregateFunction.Type.STATE_EXPANDING, AggregateFunction.PERCENTILE_APPROX.getType());
+        assertEquals(SqlKind.OTHER, AggregateFunction.PERCENTILE_APPROX.getSqlKind());
+    }
+
+    public void testPercentileApproxResolvesByName() {
+        assertSame(AggregateFunction.PERCENTILE_APPROX, AggregateFunction.fromNameOrError("percentile_approx"));
+        assertSame(AggregateFunction.PERCENTILE_APPROX, AggregateFunction.fromNameOrError("PERCENTILE_APPROX"));
+    }
+
     // ── fromSqlKind still works ──
 
     public void testFromSqlKindResolvesExistingEntries() {

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionAnalyticsBackendPlugin.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionAnalyticsBackendPlugin.java
@@ -408,6 +408,7 @@ public class DataFusionAnalyticsBackendPlugin implements AnalyticsSearchBackendP
         AggregateFunction.COUNT,
         AggregateFunction.AVG,
         AggregateFunction.APPROX_COUNT_DISTINCT,
+        AggregateFunction.PERCENTILE_APPROX,
         AggregateFunction.TAKE,
         AggregateFunction.FIRST,
         AggregateFunction.LAST,

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionFragmentConvertor.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionFragmentConvertor.java
@@ -25,6 +25,7 @@ import org.apache.calcite.rel.core.TableScan;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.schema.ColumnStrategy;
@@ -37,6 +38,7 @@ import org.apache.calcite.sql.fun.SqlLibraryOperators;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.type.OperandTypes;
 import org.apache.calcite.sql.type.ReturnTypes;
+import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.sql.type.SqlTypeTransforms;
 import org.apache.calcite.util.ImmutableBitSet;
 import org.apache.calcite.util.Optionality;
@@ -49,6 +51,8 @@ import org.opensearch.analytics.spi.FragmentConvertor;
 import org.opensearch.be.datafusion.planner.adapter.NumericConversionFunctionAdapter;
 import org.opensearch.be.datafusion.planner.adapter.TimeConversionFunctionAdapter;
 
+import java.math.BigDecimal;
+import java.math.MathContext;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -304,6 +308,30 @@ public class DataFusionFragmentConvertor implements FragmentConvertor {
     ) {
     };
 
+    /**
+     * PPL {@code percentile_approx(field, percentile)} → DataFusion's builtin
+     * {@code approx_percentile_cont(field, percentile)}. PPL's trailing field-type-flag
+     * arg is stripped by {@link PplAggregateCallRewriter} before binding; the percentile
+     * literal is rescaled from PPL's [0, 100] to DataFusion's [0, 1] convention via
+     * {@link LocalAggOp#normaliseLiteralArg} at substrait emission.
+     */
+    static final LocalAggOp LOCAL_PERCENTILE_APPROX_OP = new LocalAggOp(
+        "approx_percentile_cont",
+        SqlKind.OTHER_FUNCTION,
+        ReturnTypes.ARG0.andThen(SqlTypeTransforms.FORCE_NULLABLE),
+        OperandTypes.ANY_ANY
+    ) {
+        @Override
+        public RexNode normaliseLiteralArg(int argIndex, RexLiteral lit, RexBuilder rexBuilder, RelDataTypeFactory typeFactory) {
+            if (argIndex == 1 && lit.getValue() instanceof BigDecimal bd) {
+                BigDecimal scaled = bd.divide(BigDecimal.valueOf(100), MathContext.DECIMAL64);
+                RelDataType doubleType = typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.DOUBLE), true);
+                return rexBuilder.makeLiteral(scaled, doubleType);
+            }
+            return lit;
+        }
+    };
+
     /** BRAIN window stub for {@code patterns ... method=BRAIN mode=label}. */
     static final SqlAggFunction LOCAL_INTERNAL_PATTERN_WINDOW_OP = new SqlAggFunction(
         "internal_pattern",
@@ -342,6 +370,7 @@ public class DataFusionFragmentConvertor implements FragmentConvertor {
         FunctionMappings.s(LOCAL_ARRAY_AGG_OP, "array_agg"),
         FunctionMappings.s(LOCAL_LIST_MERGE_OP, "list_merge"),
         FunctionMappings.s(LOCAL_LIST_MERGE_DISTINCT_OP, "list_merge_distinct"),
+        FunctionMappings.s(LOCAL_PERCENTILE_APPROX_OP, "approx_percentile_cont"),
         FunctionMappings.s(LOCAL_INTERNAL_PATTERN_OP, "internal_pattern")
     );
 
@@ -602,6 +631,7 @@ public class DataFusionFragmentConvertor implements FragmentConvertor {
                 List<RexNode> projects = project.getProjects();
                 List<FunctionArg> args = fn.arguments();
                 List<FunctionArg> rewritten = null;
+                RexBuilder rexBuilder = project.getCluster().getRexBuilder();
                 for (int i = 0; i < args.size(); i++) {
                     FunctionArg arg = args.get(i);
                     if (!(arg instanceof io.substrait.expression.FieldReference fr)) continue;
@@ -609,7 +639,10 @@ public class DataFusionFragmentConvertor implements FragmentConvertor {
                     if (offset == null || offset < 0 || offset >= projects.size()) continue;
                     if (!(projects.get(offset) instanceof RexLiteral rexLit)) continue;
                     if (rewritten == null) rewritten = new ArrayList<>(args);
-                    rewritten.set(i, rexConverter.apply(rexLit));
+                    RexNode toConvert = call.getAggregation() instanceof LocalAggOp localOp
+                        ? localOp.normaliseLiteralArg(i, rexLit, rexBuilder, typeFactory)
+                        : rexLit;
+                    rewritten.set(i, rexConverter.apply(toConvert));
                 }
                 if (rewritten == null) return bound;
                 return Optional.of(ImmutableAggregateFunctionInvocation.builder().from(fn).arguments(rewritten).build());
@@ -640,6 +673,40 @@ public class DataFusionFragmentConvertor implements FragmentConvertor {
         io.substrait.expression.FieldReference.ReferenceSegment seg = fr.segments().get(0);
         if (!(seg instanceof io.substrait.expression.FieldReference.StructField sf)) return null;
         return sf.offset();
+    }
+
+    /**
+     * Local aggregate stub that may transform inlined literal args before substrait emission.
+     * Other local stubs without transformations stay as plain {@link SqlAggFunction}; the
+     * {@code convert()} override only invokes {@link #normaliseLiteralArg} when the call's
+     * operator is a {@code LocalAggOp}, so adding a new normalisation is purely a matter of
+     * subclassing here next to the op's declaration.
+     */
+    abstract static class LocalAggOp extends SqlAggFunction {
+        LocalAggOp(
+            String name,
+            SqlKind kind,
+            org.apache.calcite.sql.type.SqlReturnTypeInference returnTypeInference,
+            org.apache.calcite.sql.type.SqlOperandTypeChecker operandTypeChecker
+        ) {
+            super(
+                name,
+                null,
+                kind,
+                returnTypeInference,
+                null,
+                operandTypeChecker,
+                SqlFunctionCategory.USER_DEFINED_FUNCTION,
+                false,
+                false,
+                Optionality.FORBIDDEN
+            );
+        }
+
+        /** Identity by default; override to transform the {@code argIndex}-th inlined literal arg. */
+        public RexNode normaliseLiteralArg(int argIndex, RexLiteral lit, RexBuilder rexBuilder, RelDataTypeFactory typeFactory) {
+            return lit;
+        }
     }
 
     // ── Plan serde helpers ──────────────────────────────────────────────────────

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/PplAggregateCallRewriter.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/PplAggregateCallRewriter.java
@@ -12,8 +12,13 @@ import org.apache.calcite.rel.RelHomogeneousShuttle;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.Aggregate;
 import org.apache.calcite.rel.core.AggregateCall;
+import org.apache.calcite.rel.core.Project;
+import org.apache.calcite.rel.logical.LogicalProject;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlAggFunction;
 import org.apache.calcite.sql.type.SqlTypeName;
 
@@ -21,7 +26,14 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
-/** Rewrites PPL state-expanding aggregates (TAKE/FIRST/LAST/LIST/VALUES/PATTERN) onto local stubs. */
+/**
+ * Rewrites PPL state-expanding aggregates (TAKE / FIRST / LAST / LIST / VALUES / PATTERN /
+ * PERCENTILE_APPROX) onto local stubs the substrait emitter binds via
+ * {@link DataFusionFragmentConvertor}'s ADDITIONAL_AGGREGATE_SIGS. Also normalises any
+ * RexLiteral{SqlTypeName.SYMBOL} in upstream Projects to VARCHAR — isthmus's
+ * LiteralConverter rejects unregistered Enum classes, and PPL's percentile_approx /
+ * median emit a SymbolFlag arg purely for type inference.
+ */
 final class PplAggregateCallRewriter {
 
     private static final Set<SqlAggFunction> LOCAL_OPS = Set.of(
@@ -31,6 +43,7 @@ final class PplAggregateCallRewriter {
         DataFusionFragmentConvertor.LOCAL_ARRAY_AGG_OP,
         DataFusionFragmentConvertor.LOCAL_LIST_MERGE_OP,
         DataFusionFragmentConvertor.LOCAL_LIST_MERGE_DISTINCT_OP,
+        DataFusionFragmentConvertor.LOCAL_PERCENTILE_APPROX_OP,
         DataFusionFragmentConvertor.LOCAL_INTERNAL_PATTERN_OP
     );
 
@@ -41,27 +54,63 @@ final class PplAggregateCallRewriter {
             @Override
             public RelNode visit(RelNode other) {
                 RelNode visited = super.visit(other);
-                if (!(visited instanceof Aggregate agg)) {
-                    return visited;
+                if (visited instanceof Project p) {
+                    return normaliseSymbolFlagLiterals(p);
                 }
-                List<AggregateCall> oldCalls = agg.getAggCallList();
-                List<AggregateCall> newCalls = new ArrayList<>(oldCalls.size());
-                boolean changed = false;
-                for (AggregateCall call : oldCalls) {
-                    AggregateCall rewritten = rewriteCall(agg, call);
-                    if (rewritten == call) {
-                        newCalls.add(call);
-                    } else {
-                        newCalls.add(rewritten);
-                        changed = true;
-                    }
+                if (visited instanceof Aggregate agg) {
+                    return rewriteAggregate(agg);
                 }
-                if (!changed) {
-                    return visited;
-                }
-                return agg.copy(agg.getTraitSet(), agg.getInput(), agg.getGroupSet(), agg.getGroupSets(), newCalls);
+                return visited;
             }
         });
+    }
+
+    private static RelNode rewriteAggregate(Aggregate agg) {
+        List<AggregateCall> oldCalls = agg.getAggCallList();
+        List<AggregateCall> newCalls = new ArrayList<>(oldCalls.size());
+        boolean changed = false;
+        for (AggregateCall call : oldCalls) {
+            AggregateCall rewritten = rewriteCall(agg, call);
+            if (rewritten == call) {
+                newCalls.add(call);
+            } else {
+                newCalls.add(rewritten);
+                changed = true;
+            }
+        }
+        if (!changed) {
+            return agg;
+        }
+        return agg.copy(agg.getTraitSet(), agg.getInput(), agg.getGroupSet(), agg.getGroupSets(), newCalls);
+    }
+
+    /** Replace any RexLiteral{SymbolFlag} in {@code project}'s projection list with a VARCHAR literal of the symbol's name. */
+    private static RelNode normaliseSymbolFlagLiterals(Project project) {
+        List<RexNode> oldProjects = project.getProjects();
+        boolean hasSymbol = oldProjects.stream()
+            .anyMatch(p -> p instanceof RexLiteral lit && lit.getType().getSqlTypeName() == SqlTypeName.SYMBOL);
+        if (!hasSymbol) {
+            return project;
+        }
+        RelDataTypeFactory typeFactory = project.getCluster().getTypeFactory();
+        RexBuilder rexBuilder = project.getCluster().getRexBuilder();
+        RelDataType varcharType = typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.VARCHAR), true);
+        List<RexNode> newProjects = new ArrayList<>(oldProjects.size());
+        for (RexNode p : oldProjects) {
+            if (p instanceof RexLiteral lit && lit.getType().getSqlTypeName() == SqlTypeName.SYMBOL) {
+                String name = lit.getValue() == null ? "" : lit.getValue().toString();
+                newProjects.add(rexBuilder.makeLiteral(name, varcharType));
+            } else {
+                newProjects.add(p);
+            }
+        }
+        return LogicalProject.create(
+            project.getInput(),
+            project.getHints(),
+            newProjects,
+            project.getRowType().getFieldNames(),
+            project.getVariablesSet()
+        );
     }
 
     private static AggregateCall rewriteCall(Aggregate agg, AggregateCall call) {
@@ -100,6 +149,32 @@ final class PplAggregateCallRewriter {
                 // PPL declares ARRAY<MAP<VARCHAR, ANY>>; substrait can't carry ANY.
                 targetOp = DataFusionFragmentConvertor.LOCAL_INTERNAL_PATTERN_OP;
                 explicitReturnType = internalPatternReturnType(agg.getCluster().getTypeFactory());
+            }
+            case "PERCENTILE_APPROX" -> {
+                // Trim the PPL type-flag arg; the substrait emit-time literal-arg normaliser
+                // (DataFusionFragmentConvertor#normaliseLiteralArg) rescales the percentile.
+                if (call.getArgList().size() < 3) {
+                    return call;
+                }
+                targetOp = DataFusionFragmentConvertor.LOCAL_PERCENTILE_APPROX_OP;
+                List<Integer> trimmedArgList = new ArrayList<>(call.getArgList().subList(0, 2));
+                RelDataType arg0Type = agg.getInput().getRowType().getFieldList().get(call.getArgList().get(0)).getType();
+                RelDataType nullableArg0 = agg.getCluster().getTypeFactory().createTypeWithNullability(arg0Type, true);
+                return AggregateCall.create(
+                    targetOp,
+                    targetDistinct,
+                    call.isApproximate(),
+                    call.ignoreNulls(),
+                    call.rexList,
+                    trimmedArgList,
+                    call.filterArg,
+                    call.distinctKeys,
+                    call.collation,
+                    agg.getGroupCount(),
+                    agg.getInput(),
+                    nullableArg0,
+                    call.getName()
+                );
             }
             default -> {
                 return call;

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/resources/opensearch_aggregate_functions.yaml
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/resources/opensearch_aggregate_functions.yaml
@@ -92,6 +92,17 @@ aggregate_functions:
           - name: x
             value: any
         return: any
+  - name: approx_percentile_cont
+    description: >-
+      PPL `percentile_approx(field, percentile)` — t-digest based approximate
+      percentile. Maps to DataFusion's builtin `approx_percentile_cont`.
+    impls:
+      - args:
+          - name: x
+            value: any1
+          - name: percentile
+            value: any2
+        return: any1
   - name: internal_pattern
     description: >-
       PPL `patterns ... method=BRAIN` (aggregation mode). Custom Rust UDAF in

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchAggregateRule.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchAggregateRule.java
@@ -138,6 +138,15 @@ public class OpenSearchAggregateRule extends RelOptRule {
 
         List<String> callViable = null;
         for (int fieldIndex : aggCall.getArgList()) {
+            // Skip metadata-only literal arg columns whose FieldType is null (e.g. SYMBOL —
+            // PPL's percentile_approx / median type-flag). Only data-field args need a
+            // backend viability check.
+            if (fieldIndex < childFieldStorageInfos.size()) {
+                FieldStorageInfo peek = childFieldStorageInfos.get(fieldIndex);
+                if (peek.isDerived() && peek.getFieldType() == null) {
+                    continue;
+                }
+            }
             FieldStorageInfo storageInfo = FieldStorageInfo.resolve(childFieldStorageInfos, fieldIndex);
             FieldType fieldType = storageInfo.getFieldType();
 

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/CoordinatorReduceIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/CoordinatorReduceIT.java
@@ -127,6 +127,31 @@ public class CoordinatorReduceIT extends AnalyticsRestTestCase {
         );
     }
 
+    /**
+     * {@code stats percentile_approx(value, 50) as p} — t-digest approximate median.
+     * STATE_EXPANDING, so the split rule gathers to coordinator + single-stage. Maps to
+     * DataFusion's {@code approx_percentile_cont} via {@link
+     * org.opensearch.be.datafusion.PplAggregateCallRewriter}.
+     */
+    public void testPercentileApproxAcrossShards() throws Exception {
+        String index = "coord_reduce_percentile_approx";
+        createParquetBackedIndex(index);
+        indexVaryingValueDocs(index);
+
+        Map<String, Object> result = executePpl("source = " + index + " | stats percentile_approx(value, 50) as p");
+        List<List<Object>> rows = scalarRows(result, "p");
+
+        Object cell = rows.get(0).get(0);
+        assertNotNull("cell for 'p' must not be null — coordinator-reduce returned no value", cell);
+        double actual = ((Number) cell).doubleValue();
+        int totalDocs = NUM_SHARDS * DOCS_PER_SHARD;
+        double expected = (totalDocs + 1) / 2.0;
+        assertTrue(
+            "percentile_approx(value, 50) should be approximately " + expected + " (±2.0), got " + actual,
+            Math.abs(actual - expected) <= 2.0
+        );
+    }
+
     /** Single-shard {@code take(value, 3)} — bounded array of up to 3 values. */
     public void testTakeSingleShard() throws Exception {
         String index = "coord_reduce_take_single";


### PR DESCRIPTION
Routes PPL `percentile_approx(field, p)` through the analytics-engine to DataFusion's builtin `approx_percentile_cont` as a single-stage gather-on- coordinator aggregate. PplAggregateCallRewriter strips the PPL type-flag arg and normalises SymbolFlag literals to VARCHAR (isthmus's LiteralConverter rejects unregistered enum classes). DataFusionFragmentConvertor's literal-arg normaliser rescales the percentile from PPL's [0, 100] to DataFusion's [0, 1] convention at substrait emission. OpenSearchAggregateRule skips backend-viability checks on null-FieldType metadata arg columns. Adds CoordinatorReduceIT.testPercentileApproxAcrossShards.
 

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
