### PR TITLE
Bias cancellation select toward the token branch

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/cancellation.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/cancellation.rs
@@ -16,6 +16,12 @@ use tokio_util::sync::CancellationToken;
 
 /// Race a future against a cancellation token. Returns a cancellation error string
 /// if the token fires first. Pass `None` for non-cancellable queries.
+///
+/// The select is `biased` toward the token branch so that once cancellation is
+/// signalled the cancellation result wins even when the inner future is also
+/// ready (e.g. it produced an error from an aborted CPU task). Without this,
+/// `cancel_query` calls that abort a CPU task can race the resulting "Worker
+/// gone" error to the inner branch and surface it instead of the cancellation.
 pub async fn cancellable<F, T, E>(
     token: Option<&CancellationToken>,
     context_id: i64,
@@ -28,8 +34,9 @@ where
     match token {
         Some(token) => {
             tokio::select! {
-                result = fut => result.map_err(|e| e.to_string()),
+                biased;
                 _ = token.cancelled() => Err(format!("Query {} cancelled", context_id)),
+                result = fut => result.map_err(|e| e.to_string()),
             }
         }
         None => fut.await.map_err(|e| e.to_string()),
@@ -38,6 +45,8 @@ where
 
 /// Variant that returns a sentinel value on cancellation instead of an error.
 /// Used by `stream_next` where `None` signals cancellation/EOF.
+///
+/// `biased` toward the token branch — see [`cancellable`] for the rationale.
 pub async fn cancellable_or<F, T, E>(
     token: Option<&CancellationToken>,
     sentinel: T,
@@ -50,8 +59,9 @@ where
     match token {
         Some(token) => {
             tokio::select! {
-                result = fut => result.map_err(|e| e.to_string()),
+                biased;
                 _ = token.cancelled() => Ok(sentinel),
+                result = fut => result.map_err(|e| e.to_string()),
             }
         }
         None => fut.await.map_err(|e| e.to_string()),

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionReduceSinkTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionReduceSinkTests.java
@@ -29,7 +29,6 @@ import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.util.ImmutableBitSet;
-import org.apache.lucene.tests.util.LuceneTestCase;
 import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.analytics.spi.ExchangeSink;
 import org.opensearch.analytics.spi.ExchangeSinkContext;
@@ -61,7 +60,6 @@ import io.substrait.extension.SimpleExtension;
  *       reduced result.</li>
  * </ul>
  */
-@LuceneTestCase.AwaitsFix(bugUrl = "Flaky - muting until fixed")
 public class DatafusionReduceSinkTests extends OpenSearchTestCase {
 
     public void testArrowSchemaIpcEncodesSchema() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
`cancellable` / `cancellable_or` raced the cancellation token against the inner future with an unbiased `tokio::select!`. After `cancel_query` aborts the CPU task, the CrossRtStream driver pushes a "Worker gone" error into the channel — by the time `stream_next` re-enters `cancellable_or`, both branches can be ready and tokio picks randomly. When the inner branch wins, the surface error is "Worker gone" instead of a clean cancellation, which manifested as flaky `DatafusionReduceSinkTests.testCancelAfter…` runs (#21921).

Add `biased;` so the token branch always wins when both are ready, and unmute the test class.

Tested by running a failing seed on the entire test suite. It fails in main, but succeeds with these changes. Also ran the suite 10 times with random seed and observed no failure.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
