### PR TITLE
Fix Time32-vs-Arrow mismatch on PPL time queries

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/maketime.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/maketime.rs
@@ -6,15 +6,21 @@
  * compatible open source license.
  */
 
-//! `maketime(hour, minute, second)` → `Time64(us)`. Hour/minute rounded; second passes with fraction.
+//! `maketime(hour, minute, second)` → `Time64(ns)`. Hour/minute rounded; second passes with fraction.
 //! Negative / non-finite / out-of-range (after rounding) / null → NULL.
+//!
+//! Output is `Time64(Nanosecond)` (not `Time64(Microsecond)`) so that maketime's
+//! Arrow output type harmonises with `current_time` / `to_time` / `curtime`,
+//! which all emit `Time64(Nanosecond)`. The internal `micros_of_day` helper
+//! still computes a microsecond count; the call sites multiply by 1_000 at
+//! emission to widen losslessly to nanoseconds (max value 8.64e13 ≪ i64::MAX).
 
 use std::any::Any;
 use std::sync::Arc;
 
 use super::udf_identity;
 
-use datafusion::arrow::array::{Array, ArrayRef, AsArray, Time64MicrosecondBuilder};
+use datafusion::arrow::array::{Array, ArrayRef, AsArray, Time64NanosecondBuilder};
 use datafusion::arrow::datatypes::{DataType, Float64Type, TimeUnit};
 use datafusion::common::{exec_err, plan_err, Result, ScalarValue};
 use datafusion::execution::context::SessionContext;
@@ -60,7 +66,7 @@ impl ScalarUDFImpl for MaketimeUdf {
         if arg_types.len() != 3 {
             return plan_err!("maketime expects 3 arguments, got {}", arg_types.len());
         }
-        Ok(DataType::Time64(TimeUnit::Microsecond))
+        Ok(DataType::Time64(TimeUnit::Nanosecond))
     }
 
     fn coerce_types(&self, arg_types: &[DataType]) -> Result<Vec<DataType>> {
@@ -83,12 +89,14 @@ impl ScalarUDFImpl for MaketimeUdf {
             ColumnarValue::Scalar(ScalarValue::Float64(s)),
         ) = (&args.args[0], &args.args[1], &args.args[2])
         {
-            let micros = match (h, m, s) {
-                (Some(h), Some(m), Some(s)) => micros_of_day(*h, *m, *s),
+            let nanos = match (h, m, s) {
+                // micros_of_day is bounded by 24h*60m*60s*1e6 = 8.64e10 µs, so
+                // *1_000 to ns yields ≤ 8.64e13 — safely within i64::MAX (≈9.2e18).
+                (Some(h), Some(m), Some(s)) => micros_of_day(*h, *m, *s).map(|us| us * 1_000),
                 _ => None,
             };
-            return Ok(ColumnarValue::Scalar(ScalarValue::Time64Microsecond(
-                micros,
+            return Ok(ColumnarValue::Scalar(ScalarValue::Time64Nanosecond(
+                nanos,
             )));
         }
 
@@ -98,14 +106,15 @@ impl ScalarUDFImpl for MaketimeUdf {
         let h = h.as_primitive::<Float64Type>();
         let m = m.as_primitive::<Float64Type>();
         let s = s.as_primitive::<Float64Type>();
-        let mut builder = Time64MicrosecondBuilder::with_capacity(n);
+        let mut builder = Time64NanosecondBuilder::with_capacity(n);
         for i in 0..n {
             if h.is_null(i) || m.is_null(i) || s.is_null(i) {
                 builder.append_null();
                 continue;
             }
             match micros_of_day(h.value(i), m.value(i), s.value(i)) {
-                Some(us) => builder.append_value(us),
+                // Lossless µs → ns scale (×1_000); see invoke_with_args scalar branch.
+                Some(us) => builder.append_value(us * 1_000),
                 None => builder.append_null(),
             }
         }

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionFragmentConvertor.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionFragmentConvertor.java
@@ -412,7 +412,7 @@ public class DataFusionFragmentConvertor implements FragmentConvertor {
             withAggregationPhase(wrapper, Expression.AggregationPhase.INITIAL_TO_INTERMEDIATE),
             fieldNames(partialAggFragment)
         );
-        return serializePlan(SubstraitPlanRewriter.rewrite(rewired));
+        return serializePlan(SubstraitPlanPojoRewriter.rewrite(rewired));
     }
 
     /**
@@ -447,7 +447,7 @@ public class DataFusionFragmentConvertor implements FragmentConvertor {
             .setRoot(io.substrait.proto.RelRoot.newBuilder().setInput(inputRel).addAllNames(rowType.getFieldNames()).build())
             .build();
 
-        byte[] bytes = io.substrait.proto.Plan.newBuilder().addRelations(planRel).build().toByteArray();
+        byte[] bytes = SubstraitPlanProtoRewriter.rewrite(io.substrait.proto.Plan.newBuilder().addRelations(planRel).build()).toByteArray();
         LOGGER.debug("Schema-only Read for stage [{}]: {} bytes", childStageId, bytes.length);
         return bytes;
     }
@@ -459,7 +459,7 @@ public class DataFusionFragmentConvertor implements FragmentConvertor {
         RelNode rewritten = rewriteStageInputScans(fragment);
         Rel wrapper = convertStandalone(rewritten);
         // Rewriter must run on the assembled plan so wrapper literals get rewritten alongside the inner.
-        return serializePlan(SubstraitPlanRewriter.rewrite(rewire(inner, wrapper, fieldNames(fragment))));
+        return serializePlan(SubstraitPlanPojoRewriter.rewrite(rewire(inner, wrapper, fieldNames(fragment))));
     }
 
     private byte[] convertToSubstrait(RelNode fragment) {
@@ -483,9 +483,9 @@ public class DataFusionFragmentConvertor implements FragmentConvertor {
         Plan.Root substraitRoot = Plan.Root.builder().input(substraitRel).names(fieldNames).build();
         Plan plan = Plan.builder().addRoots(substraitRoot).build();
 
-        plan = SubstraitPlanRewriter.rewrite(plan);
+        plan = SubstraitPlanPojoRewriter.rewrite(plan);
 
-        io.substrait.proto.Plan protoPlan = new PlanProtoConverter().toProto(plan);
+        io.substrait.proto.Plan protoPlan = SubstraitPlanProtoRewriter.rewrite(new PlanProtoConverter().toProto(plan));
         byte[] bytes = protoPlan.toByteArray();
         LOGGER.debug("Substrait plan: {} bytes", bytes.length);
         return bytes;
@@ -733,7 +733,7 @@ public class DataFusionFragmentConvertor implements FragmentConvertor {
 
     /** Serializes a model-level {@link Plan} to proto bytes. */
     private static byte[] serializePlan(Plan plan) {
-        return new PlanProtoConverter().toProto(plan).toByteArray();
+        return SubstraitPlanProtoRewriter.rewrite(new PlanProtoConverter().toProto(plan)).toByteArray();
     }
 
     // ── Calcite TableScan wrappers for OpenSearchStageInputScan rewrite ─────────

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/SubstraitPlanPojoRewriter.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/SubstraitPlanPojoRewriter.java
@@ -23,22 +23,28 @@ import io.substrait.relation.RelCopyOnWriteVisitor;
 import io.substrait.util.EmptyVisitationContext;
 
 /**
- * Single-pass post-processor for Substrait plans before serialization to protobuf.
- *
- * <p>Applies two kinds of rewrites:
+ * POJO-layer Substrait plan rewriter. Runs before the plan is serialized to protobuf
+ * and patches expressions that isthmus emits incorrectly or that DataFusion's
+ * substrait consumer cannot handle. Today it covers two cases:
  * <ul>
- *   <li><b>Rel-level</b> — structural changes like table name stripping, handled by
- *       {@link RelCopyOnWriteVisitor} overrides.</li>
- *   <li><b>Expression-level</b> — literal/type fixes handled by
- *       {@link ExpressionCopyOnWriteVisitor} overrides. Adding a new expression rewrite
- *       only requires overriding the corresponding {@code visit} method.</li>
+ *   <li>{@code PrecisionTimestampLiteral} arrives at precision 6 (µs) regardless of
+ *       the source type; rescaled to precision 3 (ms) to match parquet storage.</li>
+ *   <li>{@code VarCharLiteral} → {@code StrLiteral} — DataFusion 53.1.0's consumer
+ *       has no VarCharLiteral arm; the two literal types are byte-identical.</li>
  * </ul>
+ *
+ * <p>Sibling {@link SubstraitPlanProtoRewriter} runs after this class on the proto layer
+ * for fixes that require setting fields the POJO API doesn't expose.
+ *
+ * <p>TODO: remove this class once both upstream gaps are closed — substrait-java
+ * isthmus inspects the source precision when lowering timestamp literals, and
+ * datafusion-substrait adds a VarCharLiteral arm to its consumer.
  *
  * @opensearch.internal
  */
-class SubstraitPlanRewriter {
+class SubstraitPlanPojoRewriter {
 
-    private SubstraitPlanRewriter() {}
+    private SubstraitPlanPojoRewriter() {}
 
     static Plan rewrite(Plan plan) {
         PlanRelVisitor visitor = new PlanRelVisitor();

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/SubstraitPlanProtoRewriter.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/SubstraitPlanProtoRewriter.java
@@ -1,0 +1,327 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion;
+
+import io.substrait.proto.CrossRel;
+import io.substrait.proto.ExtensionMultiRel;
+import io.substrait.proto.HashJoinRel;
+import io.substrait.proto.JoinRel;
+import io.substrait.proto.MergeJoinRel;
+import io.substrait.proto.NamedStruct;
+import io.substrait.proto.NestedLoopJoinRel;
+import io.substrait.proto.Plan;
+import io.substrait.proto.PlanRel;
+import io.substrait.proto.ReadRel;
+import io.substrait.proto.Rel;
+import io.substrait.proto.RelRoot;
+import io.substrait.proto.SetRel;
+import io.substrait.proto.Type;
+
+/**
+ * Proto-layer Substrait plan rewriter. Runs after {@code SubstraitPlanPojoRewriter} serializes
+ * the POJO so it can patch fields the POJO API doesn't expose. Today it covers a single case:
+ * {@code Type.PrecisionTime} arrives with {@code type_variation_reference = 0}
+ * (TIME_32) regardless of the precision, because substrait-java's POJO has no
+ * setter for that field. For {@code precision ∈ {6, 9}} that yields
+ * {@code Time32(µs|ns)} — an Arrow type that doesn't exist; the DataFusion consumer
+ * builds it anyway and rejects the schema match against the real {@code Time64}
+ * column. Promoting to variation 1 (TIME_64) is unconditionally correct: the
+ * Time32 form for those precisions has no valid representation, so there's nothing
+ * to lose.
+ *
+ * <p>Walks {@code Plan.relations} → every Rel variant's inputs →
+ * {@code ReadRel.base_schema} → nested Struct / List / Map element types.
+ *
+ * <p>TODO: remove this class once substrait-java exposes
+ * {@code typeVariationReference} on {@code Type.PrecisionTime}.
+ *
+ * @opensearch.internal
+ */
+final class SubstraitPlanProtoRewriter {
+
+    private static final int TIME_64_TYPE_VARIATION_REF = 1;
+
+    private SubstraitPlanProtoRewriter() {}
+
+    /**
+     * Walks {@code plan} and returns a copy with every offending
+     * {@code PrecisionTime} promoted to TIME_64. Returns the original instance
+     * unchanged if no rewrite was needed (so the common no-op case avoids an
+     * extra builder allocation).
+     */
+    static Plan rewrite(Plan plan) {
+        Plan.Builder builder = null;
+        for (int i = 0; i < plan.getRelationsCount(); i++) {
+            PlanRel original = plan.getRelations(i);
+            PlanRel rewritten = rewritePlanRel(original);
+            if (rewritten != original) {
+                if (builder == null) {
+                    builder = plan.toBuilder();
+                }
+                builder.setRelations(i, rewritten);
+            }
+        }
+        return builder != null ? builder.build() : plan;
+    }
+
+    private static PlanRel rewritePlanRel(PlanRel pr) {
+        switch (pr.getRelTypeCase()) {
+            case REL: {
+                Rel rewritten = rewriteRel(pr.getRel());
+                return rewritten != pr.getRel() ? pr.toBuilder().setRel(rewritten).build() : pr;
+            }
+            case ROOT: {
+                RelRoot root = pr.getRoot();
+                if (!root.hasInput()) {
+                    return pr;
+                }
+                Rel rewritten = rewriteRel(root.getInput());
+                if (rewritten == root.getInput()) {
+                    return pr;
+                }
+                return pr.toBuilder().setRoot(root.toBuilder().setInput(rewritten).build()).build();
+            }
+            case RELTYPE_NOT_SET:
+            default:
+                return pr;
+        }
+    }
+
+    private static Rel rewriteRel(Rel rel) {
+        switch (rel.getRelTypeCase()) {
+            case READ: {
+                ReadRel rewritten = rewriteRead(rel.getRead());
+                return rewritten != rel.getRead() ? rel.toBuilder().setRead(rewritten).build() : rel;
+            }
+            case FILTER: {
+                if (!rel.getFilter().hasInput()) return rel;
+                Rel inp = rewriteRel(rel.getFilter().getInput());
+                if (inp == rel.getFilter().getInput()) return rel;
+                return rel.toBuilder().setFilter(rel.getFilter().toBuilder().setInput(inp).build()).build();
+            }
+            case FETCH: {
+                if (!rel.getFetch().hasInput()) return rel;
+                Rel inp = rewriteRel(rel.getFetch().getInput());
+                if (inp == rel.getFetch().getInput()) return rel;
+                return rel.toBuilder().setFetch(rel.getFetch().toBuilder().setInput(inp).build()).build();
+            }
+            case AGGREGATE: {
+                if (!rel.getAggregate().hasInput()) return rel;
+                Rel inp = rewriteRel(rel.getAggregate().getInput());
+                if (inp == rel.getAggregate().getInput()) return rel;
+                return rel.toBuilder().setAggregate(rel.getAggregate().toBuilder().setInput(inp).build()).build();
+            }
+            case SORT: {
+                if (!rel.getSort().hasInput()) return rel;
+                Rel inp = rewriteRel(rel.getSort().getInput());
+                if (inp == rel.getSort().getInput()) return rel;
+                return rel.toBuilder().setSort(rel.getSort().toBuilder().setInput(inp).build()).build();
+            }
+            case JOIN: {
+                Rel l = rel.getJoin().hasLeft() ? rewriteRel(rel.getJoin().getLeft()) : null;
+                Rel r = rel.getJoin().hasRight() ? rewriteRel(rel.getJoin().getRight()) : null;
+                boolean lc = l != null && l != rel.getJoin().getLeft();
+                boolean rc = r != null && r != rel.getJoin().getRight();
+                if (!lc && !rc) return rel;
+                JoinRel.Builder jb = rel.getJoin().toBuilder();
+                if (lc) jb.setLeft(l);
+                if (rc) jb.setRight(r);
+                return rel.toBuilder().setJoin(jb.build()).build();
+            }
+            case PROJECT: {
+                if (!rel.getProject().hasInput()) return rel;
+                Rel inp = rewriteRel(rel.getProject().getInput());
+                if (inp == rel.getProject().getInput()) return rel;
+                return rel.toBuilder().setProject(rel.getProject().toBuilder().setInput(inp).build()).build();
+            }
+            case SET: {
+                SetRel set = rel.getSet();
+                SetRel.Builder sb = null;
+                for (int i = 0; i < set.getInputsCount(); i++) {
+                    Rel inp = rewriteRel(set.getInputs(i));
+                    if (inp != set.getInputs(i)) {
+                        if (sb == null) sb = set.toBuilder();
+                        sb.setInputs(i, inp);
+                    }
+                }
+                return sb != null ? rel.toBuilder().setSet(sb.build()).build() : rel;
+            }
+            case EXTENSION_SINGLE: {
+                if (!rel.getExtensionSingle().hasInput()) return rel;
+                Rel inp = rewriteRel(rel.getExtensionSingle().getInput());
+                if (inp == rel.getExtensionSingle().getInput()) return rel;
+                return rel.toBuilder().setExtensionSingle(rel.getExtensionSingle().toBuilder().setInput(inp).build()).build();
+            }
+            case EXTENSION_MULTI: {
+                ExtensionMultiRel em = rel.getExtensionMulti();
+                ExtensionMultiRel.Builder eb = null;
+                for (int i = 0; i < em.getInputsCount(); i++) {
+                    Rel inp = rewriteRel(em.getInputs(i));
+                    if (inp != em.getInputs(i)) {
+                        if (eb == null) eb = em.toBuilder();
+                        eb.setInputs(i, inp);
+                    }
+                }
+                return eb != null ? rel.toBuilder().setExtensionMulti(eb.build()).build() : rel;
+            }
+            case CROSS: {
+                Rel l = rel.getCross().hasLeft() ? rewriteRel(rel.getCross().getLeft()) : null;
+                Rel r = rel.getCross().hasRight() ? rewriteRel(rel.getCross().getRight()) : null;
+                boolean lc = l != null && l != rel.getCross().getLeft();
+                boolean rc = r != null && r != rel.getCross().getRight();
+                if (!lc && !rc) return rel;
+                CrossRel.Builder cb = rel.getCross().toBuilder();
+                if (lc) cb.setLeft(l);
+                if (rc) cb.setRight(r);
+                return rel.toBuilder().setCross(cb.build()).build();
+            }
+            case HASH_JOIN: {
+                Rel l = rel.getHashJoin().hasLeft() ? rewriteRel(rel.getHashJoin().getLeft()) : null;
+                Rel r = rel.getHashJoin().hasRight() ? rewriteRel(rel.getHashJoin().getRight()) : null;
+                boolean lc = l != null && l != rel.getHashJoin().getLeft();
+                boolean rc = r != null && r != rel.getHashJoin().getRight();
+                if (!lc && !rc) return rel;
+                HashJoinRel.Builder hb = rel.getHashJoin().toBuilder();
+                if (lc) hb.setLeft(l);
+                if (rc) hb.setRight(r);
+                return rel.toBuilder().setHashJoin(hb.build()).build();
+            }
+            case MERGE_JOIN: {
+                Rel l = rel.getMergeJoin().hasLeft() ? rewriteRel(rel.getMergeJoin().getLeft()) : null;
+                Rel r = rel.getMergeJoin().hasRight() ? rewriteRel(rel.getMergeJoin().getRight()) : null;
+                boolean lc = l != null && l != rel.getMergeJoin().getLeft();
+                boolean rc = r != null && r != rel.getMergeJoin().getRight();
+                if (!lc && !rc) return rel;
+                MergeJoinRel.Builder mb = rel.getMergeJoin().toBuilder();
+                if (lc) mb.setLeft(l);
+                if (rc) mb.setRight(r);
+                return rel.toBuilder().setMergeJoin(mb.build()).build();
+            }
+            case NESTED_LOOP_JOIN: {
+                Rel l = rel.getNestedLoopJoin().hasLeft() ? rewriteRel(rel.getNestedLoopJoin().getLeft()) : null;
+                Rel r = rel.getNestedLoopJoin().hasRight() ? rewriteRel(rel.getNestedLoopJoin().getRight()) : null;
+                boolean lc = l != null && l != rel.getNestedLoopJoin().getLeft();
+                boolean rc = r != null && r != rel.getNestedLoopJoin().getRight();
+                if (!lc && !rc) return rel;
+                NestedLoopJoinRel.Builder nb = rel.getNestedLoopJoin().toBuilder();
+                if (lc) nb.setLeft(l);
+                if (rc) nb.setRight(r);
+                return rel.toBuilder().setNestedLoopJoin(nb.build()).build();
+            }
+            case WINDOW: {
+                if (!rel.getWindow().hasInput()) return rel;
+                Rel inp = rewriteRel(rel.getWindow().getInput());
+                if (inp == rel.getWindow().getInput()) return rel;
+                return rel.toBuilder().setWindow(rel.getWindow().toBuilder().setInput(inp).build()).build();
+            }
+            case EXCHANGE: {
+                if (!rel.getExchange().hasInput()) return rel;
+                Rel inp = rewriteRel(rel.getExchange().getInput());
+                if (inp == rel.getExchange().getInput()) return rel;
+                return rel.toBuilder().setExchange(rel.getExchange().toBuilder().setInput(inp).build()).build();
+            }
+            case EXPAND: {
+                if (!rel.getExpand().hasInput()) return rel;
+                Rel inp = rewriteRel(rel.getExpand().getInput());
+                if (inp == rel.getExpand().getInput()) return rel;
+                return rel.toBuilder().setExpand(rel.getExpand().toBuilder().setInput(inp).build()).build();
+            }
+            case WRITE: {
+                if (!rel.getWrite().hasInput()) return rel;
+                Rel inp = rewriteRel(rel.getWrite().getInput());
+                if (inp == rel.getWrite().getInput()) return rel;
+                return rel.toBuilder().setWrite(rel.getWrite().toBuilder().setInput(inp).build()).build();
+            }
+            // Leaf rels — no inputs to recurse, no schema we rewrite here today.
+            case EXTENSION_LEAF:
+            case REFERENCE:
+            case DDL:
+            case UPDATE:
+            case RELTYPE_NOT_SET:
+            default:
+                return rel;
+        }
+    }
+
+    private static ReadRel rewriteRead(ReadRel read) {
+        if (!read.hasBaseSchema()) {
+            return read;
+        }
+        NamedStruct rewritten = rewriteNamedStruct(read.getBaseSchema());
+        return rewritten != read.getBaseSchema() ? read.toBuilder().setBaseSchema(rewritten).build() : read;
+    }
+
+    private static NamedStruct rewriteNamedStruct(NamedStruct ns) {
+        if (!ns.hasStruct()) {
+            return ns;
+        }
+        Type.Struct rewritten = rewriteStruct(ns.getStruct());
+        return rewritten != ns.getStruct() ? ns.toBuilder().setStruct(rewritten).build() : ns;
+    }
+
+    private static Type.Struct rewriteStruct(Type.Struct s) {
+        Type.Struct.Builder sb = null;
+        for (int i = 0; i < s.getTypesCount(); i++) {
+            Type rewritten = rewriteType(s.getTypes(i));
+            if (rewritten != s.getTypes(i)) {
+                if (sb == null) sb = s.toBuilder();
+                sb.setTypes(i, rewritten);
+            }
+        }
+        return sb != null ? sb.build() : s;
+    }
+
+    /**
+     * Visible for tests.
+     */
+    static Type rewriteType(Type t) {
+        switch (t.getKindCase()) {
+            case PRECISION_TIME: {
+                Type.PrecisionTime pt = t.getPrecisionTime();
+                if (pt.getTypeVariationReference() == 0 && (pt.getPrecision() == 6 || pt.getPrecision() == 9)) {
+                    return t.toBuilder()
+                        .setPrecisionTime(pt.toBuilder().setTypeVariationReference(TIME_64_TYPE_VARIATION_REF).build())
+                        .build();
+                }
+                return t;
+            }
+            case STRUCT: {
+                Type.Struct rewritten = rewriteStruct(t.getStruct());
+                return rewritten != t.getStruct() ? t.toBuilder().setStruct(rewritten).build() : t;
+            }
+            case LIST: {
+                if (!t.getList().hasType()) return t;
+                Type inner = rewriteType(t.getList().getType());
+                if (inner == t.getList().getType()) return t;
+                return t.toBuilder().setList(t.getList().toBuilder().setType(inner).build()).build();
+            }
+            case MAP: {
+                Type.Map.Builder mb = null;
+                Type.Map m = t.getMap();
+                if (m.hasKey()) {
+                    Type k = rewriteType(m.getKey());
+                    if (k != m.getKey()) {
+                        mb = m.toBuilder();
+                        mb.setKey(k);
+                    }
+                }
+                if (m.hasValue()) {
+                    Type v = rewriteType(m.getValue());
+                    if (v != m.getValue()) {
+                        if (mb == null) mb = m.toBuilder();
+                        mb.setValue(v);
+                    }
+                }
+                return mb != null ? t.toBuilder().setMap(mb.build()).build() : t;
+            }
+            default:
+                return t;
+        }
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/SubstraitPlanPojoRewriterTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/SubstraitPlanPojoRewriterTests.java
@@ -24,7 +24,7 @@ import io.substrait.relation.Project;
 import io.substrait.type.NamedStruct;
 import io.substrait.type.TypeCreator;
 
-public class SubstraitPlanRewriterTests extends OpenSearchTestCase {
+public class SubstraitPlanPojoRewriterTests extends OpenSearchTestCase {
 
     private static final TypeCreator R = TypeCreator.of(false);
 
@@ -39,7 +39,7 @@ public class SubstraitPlanRewriterTests extends OpenSearchTestCase {
             .build();
 
         Plan plan = buildFilterPlan(literal);
-        Plan rewritten = SubstraitPlanRewriter.rewrite(plan);
+        Plan rewritten = SubstraitPlanPojoRewriter.rewrite(plan);
 
         Expression condition = getFilterCondition(rewritten);
         assertTrue(condition instanceof Expression.PrecisionTimestampLiteral);
@@ -55,7 +55,7 @@ public class SubstraitPlanRewriterTests extends OpenSearchTestCase {
         Expression literal = ImmutableExpression.PrecisionTimestampLiteral.builder().value(epochNanos).precision(9).nullable(false).build();
 
         Plan plan = buildFilterPlan(literal);
-        Plan rewritten = SubstraitPlanRewriter.rewrite(plan);
+        Plan rewritten = SubstraitPlanPojoRewriter.rewrite(plan);
 
         Expression condition = getFilterCondition(rewritten);
         assertTrue(condition instanceof Expression.PrecisionTimestampLiteral);
@@ -74,7 +74,7 @@ public class SubstraitPlanRewriterTests extends OpenSearchTestCase {
             .build();
 
         Plan plan = buildFilterPlan(literal);
-        Plan rewritten = SubstraitPlanRewriter.rewrite(plan);
+        Plan rewritten = SubstraitPlanPojoRewriter.rewrite(plan);
 
         Expression condition = getFilterCondition(rewritten);
         assertTrue(condition instanceof Expression.PrecisionTimestampLiteral);
@@ -107,7 +107,7 @@ public class SubstraitPlanRewriterTests extends OpenSearchTestCase {
             .build();
 
         Plan plan = buildFilterPlan(gtCall);
-        Plan rewritten = SubstraitPlanRewriter.rewrite(plan);
+        Plan rewritten = SubstraitPlanPojoRewriter.rewrite(plan);
 
         Expression condition = getFilterCondition(rewritten);
         assertTrue(condition instanceof Expression.ScalarFunctionInvocation);
@@ -126,7 +126,7 @@ public class SubstraitPlanRewriterTests extends OpenSearchTestCase {
             .build();
 
         Plan plan = buildPlan(scan);
-        Plan rewritten = SubstraitPlanRewriter.rewrite(plan);
+        Plan rewritten = SubstraitPlanPojoRewriter.rewrite(plan);
 
         NamedScan rewrittenScan = (NamedScan) rewritten.getRoots().get(0).getInput();
         assertEquals(List.of("parquet_dates"), rewrittenScan.getNames());
@@ -136,7 +136,7 @@ public class SubstraitPlanRewriterTests extends OpenSearchTestCase {
         Expression literal = ImmutableExpression.PrecisionTimestampLiteral.builder().value(12345L).precision(4).nullable(false).build();
 
         Plan plan = buildFilterPlan(literal);
-        expectThrows(IllegalArgumentException.class, () -> SubstraitPlanRewriter.rewrite(plan));
+        expectThrows(IllegalArgumentException.class, () -> SubstraitPlanPojoRewriter.rewrite(plan));
     }
 
     // --- VarCharLiteral → StrLiteral tests ---
@@ -145,7 +145,7 @@ public class SubstraitPlanRewriterTests extends OpenSearchTestCase {
         Expression varcharLiteral = ImmutableExpression.VarCharLiteral.builder().value("Sum").length(3).nullable(false).build();
 
         Plan plan = buildFilterPlan(varcharLiteral);
-        Plan rewritten = SubstraitPlanRewriter.rewrite(plan);
+        Plan rewritten = SubstraitPlanPojoRewriter.rewrite(plan);
 
         Expression condition = getFilterCondition(rewritten);
         assertTrue("Expected StrLiteral, got " + condition.getClass(), condition instanceof Expression.StrLiteral);
@@ -166,7 +166,7 @@ public class SubstraitPlanRewriterTests extends OpenSearchTestCase {
         Project project = Project.builder().input(scan).addExpressions(varcharLiteral).build();
 
         Plan plan = buildPlan(project);
-        Plan rewritten = SubstraitPlanRewriter.rewrite(plan);
+        Plan rewritten = SubstraitPlanPojoRewriter.rewrite(plan);
 
         Project rewrittenProject = (Project) rewritten.getRoots().get(0).getInput();
         Expression expr = rewrittenProject.getExpressions().get(0);
@@ -180,7 +180,7 @@ public class SubstraitPlanRewriterTests extends OpenSearchTestCase {
         Expression varcharLiteral = ImmutableExpression.VarCharLiteral.builder().value("nullable_value").length(14).nullable(true).build();
 
         Plan plan = buildFilterPlan(varcharLiteral);
-        Plan rewritten = SubstraitPlanRewriter.rewrite(plan);
+        Plan rewritten = SubstraitPlanPojoRewriter.rewrite(plan);
 
         Expression condition = getFilterCondition(rewritten);
         assertTrue(condition instanceof Expression.StrLiteral);
@@ -207,7 +207,7 @@ public class SubstraitPlanRewriterTests extends OpenSearchTestCase {
             .build();
 
         Plan plan = buildFilterPlan(eqCall);
-        Plan rewritten = SubstraitPlanRewriter.rewrite(plan);
+        Plan rewritten = SubstraitPlanPojoRewriter.rewrite(plan);
 
         Expression condition = getFilterCondition(rewritten);
         assertTrue(condition instanceof Expression.ScalarFunctionInvocation);
@@ -232,7 +232,7 @@ public class SubstraitPlanRewriterTests extends OpenSearchTestCase {
         Project project = Project.builder().input(scan).addExpressions(varchar1, varchar2, varchar3).build();
 
         Plan plan = buildPlan(project);
-        Plan rewritten = SubstraitPlanRewriter.rewrite(plan);
+        Plan rewritten = SubstraitPlanPojoRewriter.rewrite(plan);
 
         Project rewrittenProject = (Project) rewritten.getRoots().get(0).getInput();
         List<Expression> expressions = rewrittenProject.getExpressions();
@@ -257,7 +257,7 @@ public class SubstraitPlanRewriterTests extends OpenSearchTestCase {
         Expression strLiteral = ImmutableExpression.StrLiteral.builder().value("already_string").nullable(false).build();
 
         Plan plan = buildFilterPlan(strLiteral);
-        Plan rewritten = SubstraitPlanRewriter.rewrite(plan);
+        Plan rewritten = SubstraitPlanPojoRewriter.rewrite(plan);
 
         Expression condition = getFilterCondition(rewritten);
         assertTrue(condition instanceof Expression.StrLiteral);

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/SubstraitPlanProtoRewriterTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/SubstraitPlanProtoRewriterTests.java
@@ -1,0 +1,138 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion;
+
+import org.opensearch.test.OpenSearchTestCase;
+
+import io.substrait.proto.NamedStruct;
+import io.substrait.proto.Plan;
+import io.substrait.proto.PlanRel;
+import io.substrait.proto.ReadRel;
+import io.substrait.proto.Rel;
+import io.substrait.proto.Type;
+
+/**
+ * Unit tests for {@link SubstraitPlanProtoRewriter} — verifies that PrecisionTime
+ * fields with {@code type_variation_reference == 0} and {@code precision in {6, 9}}
+ * are promoted to variation 1 (TIME_64), while other PrecisionTime values pass
+ * through unchanged.
+ */
+public class SubstraitPlanProtoRewriterTests extends OpenSearchTestCase {
+
+    private static Type makePrecisionTime(int precision, int variationReference) {
+        return Type.newBuilder()
+            .setPrecisionTime(Type.PrecisionTime.newBuilder().setPrecision(precision).setTypeVariationReference(variationReference).build())
+            .build();
+    }
+
+    public void testPromotesVariation0Precision9() {
+        Type before = makePrecisionTime(9, 0);
+        Type after = SubstraitPlanProtoRewriter.rewriteType(before);
+        assertTrue("Type should still be PrecisionTime", after.hasPrecisionTime());
+        assertEquals("Precision preserved", 9, after.getPrecisionTime().getPrecision());
+        assertEquals("Variation promoted to 1 (TIME_64)", 1, after.getPrecisionTime().getTypeVariationReference());
+    }
+
+    public void testPromotesVariation0Precision6() {
+        Type before = makePrecisionTime(6, 0);
+        Type after = SubstraitPlanProtoRewriter.rewriteType(before);
+        assertEquals(6, after.getPrecisionTime().getPrecision());
+        assertEquals("Variation promoted to 1", 1, after.getPrecisionTime().getTypeVariationReference());
+    }
+
+    public void testLeavesVariation0Precision3Alone() {
+        // Time32(Millisecond) is legal — must not be promoted.
+        Type before = makePrecisionTime(3, 0);
+        Type after = SubstraitPlanProtoRewriter.rewriteType(before);
+        assertSame("No-op when precision is legal for Time32", before, after);
+        assertEquals(0, after.getPrecisionTime().getTypeVariationReference());
+    }
+
+    public void testLeavesVariation0Precision0Alone() {
+        // Time32(Second) is legal — must not be promoted.
+        Type before = makePrecisionTime(0, 0);
+        Type after = SubstraitPlanProtoRewriter.rewriteType(before);
+        assertSame(before, after);
+        assertEquals(0, after.getPrecisionTime().getTypeVariationReference());
+    }
+
+    public void testLeavesVariation1Alone() {
+        // Already explicitly Time64 — must remain as authored.
+        Type before = makePrecisionTime(9, 1);
+        Type after = SubstraitPlanProtoRewriter.rewriteType(before);
+        assertSame(before, after);
+        assertEquals(1, after.getPrecisionTime().getTypeVariationReference());
+    }
+
+    public void testRecursesIntoStruct() {
+        Type structType = Type.newBuilder()
+            .setStruct(
+                Type.Struct.newBuilder()
+                    .addTypes(makePrecisionTime(9, 0)) // should be promoted
+                    .addTypes(makePrecisionTime(3, 0)) // should be left alone
+                    .build()
+            )
+            .build();
+        Type rewritten = SubstraitPlanProtoRewriter.rewriteType(structType);
+        assertNotSame("Struct rewritten because inner type changed", structType, rewritten);
+        assertEquals("First inner type promoted", 1, rewritten.getStruct().getTypes(0).getPrecisionTime().getTypeVariationReference());
+        assertEquals("Second inner type unchanged", 0, rewritten.getStruct().getTypes(1).getPrecisionTime().getTypeVariationReference());
+    }
+
+    public void testRecursesIntoList() {
+        Type listType = Type.newBuilder().setList(Type.List.newBuilder().setType(makePrecisionTime(9, 0)).build()).build();
+        Type rewritten = SubstraitPlanProtoRewriter.rewriteType(listType);
+        assertEquals("List element type promoted", 1, rewritten.getList().getType().getPrecisionTime().getTypeVariationReference());
+    }
+
+    public void testRecursesIntoMap() {
+        Type mapType = Type.newBuilder()
+            .setMap(Type.Map.newBuilder().setKey(makePrecisionTime(9, 0)).setValue(makePrecisionTime(6, 0)).build())
+            .build();
+        Type rewritten = SubstraitPlanProtoRewriter.rewriteType(mapType);
+        assertEquals("Map key promoted", 1, rewritten.getMap().getKey().getPrecisionTime().getTypeVariationReference());
+        assertEquals("Map value promoted", 1, rewritten.getMap().getValue().getPrecisionTime().getTypeVariationReference());
+    }
+
+    public void testFullPlanRewriteThroughReadRel() {
+        // Build a minimal Plan { relations: [Read { base_schema: Struct { types: [PrecisionTime(9, 0)] } }] }
+        // and confirm rewrite() promotes the PrecisionTime in the read's base schema.
+        ReadRel read = ReadRel.newBuilder()
+            .setBaseSchema(
+                NamedStruct.newBuilder()
+                    .addNames("tm")
+                    .setStruct(Type.Struct.newBuilder().addTypes(makePrecisionTime(9, 0)).build())
+                    .build()
+            )
+            .build();
+        Rel rel = Rel.newBuilder().setRead(read).build();
+        PlanRel planRel = PlanRel.newBuilder().setRel(rel).build();
+        Plan plan = Plan.newBuilder().addRelations(planRel).build();
+
+        Plan rewritten = SubstraitPlanProtoRewriter.rewrite(plan);
+        Type rewrittenType = rewritten.getRelations(0).getRel().getRead().getBaseSchema().getStruct().getTypes(0);
+        assertEquals("PrecisionTime in ReadRel.base_schema promoted", 1, rewrittenType.getPrecisionTime().getTypeVariationReference());
+        assertEquals("Precision still 9", 9, rewrittenType.getPrecisionTime().getPrecision());
+    }
+
+    public void testNoOpReturnsSameInstance() {
+        // A plan with no offending PrecisionTime should round-trip the same instance.
+        ReadRel read = ReadRel.newBuilder()
+            .setBaseSchema(
+                NamedStruct.newBuilder()
+                    .addNames("ms")
+                    .setStruct(Type.Struct.newBuilder().addTypes(makePrecisionTime(3, 0)).build())
+                    .build()
+            )
+            .build();
+        Plan plan = Plan.newBuilder().addRelations(PlanRel.newBuilder().setRel(Rel.newBuilder().setRead(read).build()).build()).build();
+        Plan rewritten = SubstraitPlanProtoRewriter.rewrite(plan);
+        assertSame("No-op rewrite returns same instance", plan, rewritten);
+    }
+}


### PR DESCRIPTION
### Problems

**1. Time32-vs-Time64 schema mismatch.** PPL time-of-day functions — `time(ts)`, `current_time()`, `curtime()`, `maketime(...)` — fail with:

```
Substrait error: Field has type Time32(Nanosecond), table column is Time64(Nanosecond)
```

`Time32(µs|ns)` isn't a real Arrow type — Arrow only allows `Time32(s|ms)` and `Time64(µs|ns)`. The plan describes something that can't round-trip cleanly to a real column, so all four functions are broken.

**2. `maketime` returns a different unit from its siblings.** `time(ts)`, `current_time()`, and `curtime()` return `Time64(Nanosecond)`; `maketime(...)` returns `Time64(Microsecond)`. Inconsistent and forces callers to special-case maketime when comparing or arithmetic-combining time values.

### Root cause (Problem 1)

substrait-java's `PrecisionTime` POJO is missing a setter for `typeVariationReference`, so high-precision time fields always serialize with that field at its proto default `0` (= Time32) regardless of precision. DataFusion's substrait consumer dutifully constructs `Time32(Nanosecond)` and the schema check rejects it against the real `Time64` column.

For low-precision values (seconds, ms) the default-0 encoding happens to coincide with Arrow's only legal Time32 layout — that's why `from_unixtime(...)` works and the bug only surfaces at µs/ns.

### Fix

* **`SubstraitPlanProtoRewriter`** — new proto-layer walker. Promotes `PrecisionTime` variation `0 → 1` (Time32 → Time64) for precision ∈ {6, 9}. Wired into both Substrait emit sites in `DataFusionFragmentConvertor` (`serializePlan` + the direct-proto schema-only path). Fixes Problem 1.
* **`maketime` UDF return type** — emit `Time64(Nanosecond)` instead of `Time64(Microsecond)`. Fixes Problem 2.
* **`SubstraitPlanRewriter` → `SubstraitPlanPojoRewriter`** — renamed.

Once substrait-java exposes `typeVariationReference` on `Type.PrecisionTime` (mirroring upstream PR [#794](https://github.com/substrait-io/substrait-java/pull/794) for `Type.UserDefined`), `SubstraitPlanProtoRewriter` can be deleted.

### Why two rewriters (POJO + proto), not one

**1. Why the new fix has to be at proto, not POJO** — substrait-java's POJO `io.substrait.plan.Plan` has no setter for `typeVariationReference` on `Type.PrecisionTime`. The field is only present on `io.substrait.proto.Type.PrecisionTime`, after `PlanProtoConverter` has serialized the POJO. So the only place to set it is post-serialization, on the proto.

**2. Why the existing POJO rewrites couldn't be moved into the proto rewriter** — `SubstraitPlanPojoRewriter` uses substrait-java's typed `RelCopyOnWriteVisitor` / `ExpressionCopyOnWriteVisitor`, which give recursion through every Rel variant (Filter, Project, Aggregate, Join, Sort, …) and every Expression case (function args, casts, if-then-else, scalar subqueries) for free. At the proto layer there's no equivalent typed visitor — you'd hand-roll all that recursion. A lot of code for no functional gain.

### Tests

* `SubstraitPlanProtoRewriterTests` — covers `PrecisionTime` precision 0/3/6/9 paths, nested `Struct/List/Map`, `ReadRel` base schema rewrite, no-op identity case.
* All four affected functions verified end-to-end on multi-shard PPL queries.

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.