### PR TITLE
Fix array_length return type mismatch

### DIFF
--- a/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/IntegerReturnWideningCastAdapter.java
+++ b/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/IntegerReturnWideningCastAdapter.java
@@ -1,0 +1,61 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.spi;
+
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.type.SqlTypeName;
+
+import java.util.List;
+
+/**
+ * Reconciles the i32-vs-i64 return-type disagreement between Calcite and DataFusion for
+ * functions like {@code ARRAY_LENGTH}.
+ *
+ * <p><b>Why:</b> Calcite types {@code array_length} as {@code INTEGER} (i32). DataFusion's
+ * UDF actually returns {@code BIGINT} (i64). On 1 shard nobody cross-checks; on 2 shards
+ * the cross-fragment schema check sees {@code Int32 ≠ Int64} and fails the query.
+ *
+ * <p><b>What:</b> rewrite {@code fn(...)} → {@code CAST(fn(...) AS INTEGER)}.
+ * <ul>
+ *   <li>The inner call's declared return type is forced to {@code BIGINT}, so it matches
+ *       what DataFusion actually produces.</li>
+ *   <li>The outer cast narrows the i64 result back to i32, so every operator above this
+ *       call in the plan still sees the {@code INTEGER}</li>
+ * </ul>
+ *
+ * <p>Applies to {@code INTEGER}/{@code SMALLINT}/{@code TINYINT} returns;
+ * {@code BIGINT} and non-integer returns pass through unchanged (re-running on the inner widened call is a safe no-op).
+ * @opensearch.internal
+ */
+public class IntegerReturnWideningCastAdapter implements ScalarFunctionAdapter {
+
+    @Override
+    public RexNode adapt(RexCall original, List<FieldStorageInfo> fieldStorage, RelOptCluster cluster) {
+        SqlTypeName originalReturn = original.getType().getSqlTypeName();
+        // Only widen integer returns narrower than BIGINT; BIGINT/non-integer returns don't exhibit the i32/i64 mismatch.
+        if (originalReturn != SqlTypeName.INTEGER && originalReturn != SqlTypeName.SMALLINT && originalReturn != SqlTypeName.TINYINT) {
+            return original;
+        }
+
+        RelDataTypeFactory factory = cluster.getTypeFactory();
+        RelDataType bigintType = factory.createTypeWithNullability(
+            factory.createSqlType(SqlTypeName.BIGINT),
+            original.getType().isNullable()
+        );
+
+        // Rebuild with BIGINT return so isthmus binds DataFusion's i64 impl; operands unchanged.
+        RexNode widenedCall = cluster.getRexBuilder().makeCall(bigintType, original.getOperator(), original.getOperands());
+        // Outer CAST restores the original return type so parent stages see the same schema; inner call produces i64 internally.
+        return cluster.getRexBuilder().makeCast(original.getType(), widenedCall);
+    }
+}

--- a/sandbox/libs/analytics-framework/src/test/java/org/opensearch/analytics/spi/IntegerReturnWideningCastAdapterTests.java
+++ b/sandbox/libs/analytics-framework/src/test/java/org/opensearch/analytics/spi/IntegerReturnWideningCastAdapterTests.java
@@ -1,0 +1,166 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.spi;
+
+import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.volcano.VolcanoPlanner;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.fun.SqlLibraryOperators;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.List;
+
+/**
+ * Unit tests for {@link IntegerReturnWideningCastAdapter} — verifies that an
+ * {@code INTEGER}-returning call (concrete example: {@code ARRAY_LENGTH(arr)}) is rewritten
+ * to {@code CAST(fn(...) AS INTEGER)} where the inner call has return type {@code BIGINT}
+ * (to match DataFusion's i64 physical), and that already-wide / non-integer returns pass
+ * through unchanged.
+ */
+public class IntegerReturnWideningCastAdapterTests extends OpenSearchTestCase {
+
+    private final RelDataTypeFactory typeFactory = new JavaTypeFactoryImpl();
+    private final RexBuilder rexBuilder = new RexBuilder(typeFactory);
+    private final RelOptCluster cluster = RelOptCluster.create(new VolcanoPlanner(), rexBuilder);
+
+    private RelDataType type(SqlTypeName name, boolean nullable) {
+        return typeFactory.createTypeWithNullability(typeFactory.createSqlType(name), nullable);
+    }
+
+    /** Builds an {@code ARRAY_LENGTH(arr)} {@link RexCall} whose return type Calcite resolves to
+     *  {@code INTEGER NULLABLE} (matching {@code ReturnTypes.INTEGER_NULLABLE}). */
+    private RexCall arrayLengthCall(RexNode arrOperand) {
+        RelDataType retType = type(SqlTypeName.INTEGER, true);
+        return (RexCall) rexBuilder.makeCall(retType, SqlLibraryOperators.ARRAY_LENGTH, List.of(arrOperand));
+    }
+
+    private RexNode arrayLiteral() {
+        RelDataType intType = type(SqlTypeName.INTEGER, false);
+        RelDataType arrType = typeFactory.createArrayType(intType, -1);
+        return rexBuilder.makeLiteral(List.of(1, 2, 3), arrType, false);
+    }
+
+    public void testArrayLengthIntegerReturnIsWrappedInCasts() {
+        // array_length(arr) — outer return must remain INTEGER, inner must be widened to BIGINT,
+        // operand passes through unchanged.
+        RexNode arr = arrayLiteral();
+        RexCall original = arrayLengthCall(arr);
+        assertEquals("preconditions: original return type INTEGER", SqlTypeName.INTEGER, original.getType().getSqlTypeName());
+
+        IntegerReturnWideningCastAdapter adapter = new IntegerReturnWideningCastAdapter();
+        RexNode adapted = adapter.adapt(original, List.of(), cluster);
+
+        assertTrue("Adapter must return a RexCall", adapted instanceof RexCall);
+        RexCall outerCast = (RexCall) adapted;
+        assertEquals("Outer node is a CAST", SqlKind.CAST, outerCast.getKind());
+        assertEquals("Outer return type INTEGER (matching original)", SqlTypeName.INTEGER, outerCast.getType().getSqlTypeName());
+
+        RexNode inner = outerCast.getOperands().get(0);
+        assertTrue("Inner node is a RexCall (the widened ARRAY_LENGTH)", inner instanceof RexCall);
+        RexCall innerCall = (RexCall) inner;
+        assertSame("Inner operator is the original ARRAY_LENGTH operator", original.getOperator(), innerCall.getOperator());
+        assertEquals("Inner return type widened to BIGINT", SqlTypeName.BIGINT, innerCall.getType().getSqlTypeName());
+        assertEquals("Inner call has the same number of operands", original.getOperands().size(), innerCall.getOperands().size());
+        assertSame("Operand passed through unchanged", arr, innerCall.getOperands().get(0));
+    }
+
+    public void testNullabilityIsPreservedOnInnerAndOuter() {
+        // Nullable INTEGER return — outer CAST must produce nullable INTEGER (matching original);
+        // the inner widened call must be nullable BIGINT.
+        RexCall original = arrayLengthCall(arrayLiteral());
+        assertTrue("Precondition: original is nullable", original.getType().isNullable());
+
+        IntegerReturnWideningCastAdapter adapter = new IntegerReturnWideningCastAdapter();
+        RexCall outerCast = (RexCall) adapter.adapt(original, List.of(), cluster);
+
+        assertEquals("Outer return type still INTEGER", SqlTypeName.INTEGER, outerCast.getType().getSqlTypeName());
+        assertTrue("Outer cast preserves nullability", outerCast.getType().isNullable());
+        RexCall innerCall = (RexCall) outerCast.getOperands().get(0);
+        assertTrue("Inner widened call preserves nullability", innerCall.getType().isNullable());
+    }
+
+    public void testNonNullableIntegerReturnProducesNonNullableOuterCast() {
+        // Forge a non-nullable INTEGER return on the synthetic call to verify nullability flows
+        // through both the inner widening and the outer cast unchanged.
+        RexNode arr = arrayLiteral();
+        RelDataType nonNullInt = type(SqlTypeName.INTEGER, false);
+        RexCall original = (RexCall) rexBuilder.makeCall(nonNullInt, SqlLibraryOperators.ARRAY_LENGTH, List.of(arr));
+        assertFalse("Precondition: original is non-nullable", original.getType().isNullable());
+
+        IntegerReturnWideningCastAdapter adapter = new IntegerReturnWideningCastAdapter();
+        RexCall outerCast = (RexCall) adapter.adapt(original, List.of(), cluster);
+
+        assertFalse("Outer cast preserves non-nullability", outerCast.getType().isNullable());
+        RexCall innerCall = (RexCall) outerCast.getOperands().get(0);
+        assertFalse("Inner widened call preserves non-nullability", innerCall.getType().isNullable());
+    }
+
+    public void testBigintReturnIsUnchanged() {
+        // If somehow Calcite already types the call as BIGINT (e.g. a future operator with a
+        // BIGINT return-type inference), there's nothing to widen — adapter must be a no-op.
+        RexNode arr = arrayLiteral();
+        RelDataType bigintRet = type(SqlTypeName.BIGINT, true);
+        RexCall original = (RexCall) rexBuilder.makeCall(bigintRet, SqlLibraryOperators.ARRAY_LENGTH, List.of(arr));
+
+        IntegerReturnWideningCastAdapter adapter = new IntegerReturnWideningCastAdapter();
+        RexNode adapted = adapter.adapt(original, List.of(), cluster);
+
+        assertSame("Already-BIGINT return passes through unchanged", original, adapted);
+    }
+
+    public void testReAdaptingInnerWidenedCallIsANoop() {
+        // The adapter rebuilds the call as cast(fn(...) [BIGINT], INTEGER). If BackendPlanAdapter
+        // recurses and re-visits the inner BIGINT-returning call, the return-type guard must skip
+        // the rewrite to avoid infinite expansion.
+        RexCall original = arrayLengthCall(arrayLiteral());
+
+        IntegerReturnWideningCastAdapter adapter = new IntegerReturnWideningCastAdapter();
+        RexCall outerCast = (RexCall) adapter.adapt(original, List.of(), cluster);
+        RexCall innerWidened = (RexCall) outerCast.getOperands().get(0);
+        assertEquals("Precondition: inner is BIGINT-returning", SqlTypeName.BIGINT, innerWidened.getType().getSqlTypeName());
+
+        RexNode reAdapted = adapter.adapt(innerWidened, List.of(), cluster);
+        assertSame("Re-adapting inner BIGINT-return call is a no-op", innerWidened, reAdapted);
+    }
+
+    public void testSmallintReturnIsAlsoWidened() {
+        // Defensive: if some other call surfaces with SMALLINT return (same family of i16<->i64
+        // mismatches in principle), the adapter must widen it just like INTEGER.
+        RexNode arr = arrayLiteral();
+        RelDataType smallintRet = type(SqlTypeName.SMALLINT, true);
+        RexCall original = (RexCall) rexBuilder.makeCall(smallintRet, SqlLibraryOperators.ARRAY_LENGTH, List.of(arr));
+
+        IntegerReturnWideningCastAdapter adapter = new IntegerReturnWideningCastAdapter();
+        RexCall outerCast = (RexCall) adapter.adapt(original, List.of(), cluster);
+
+        assertEquals("Outer return type SMALLINT (matching original)", SqlTypeName.SMALLINT, outerCast.getType().getSqlTypeName());
+        RexCall innerCall = (RexCall) outerCast.getOperands().get(0);
+        assertEquals("Inner return type widened to BIGINT", SqlTypeName.BIGINT, innerCall.getType().getSqlTypeName());
+    }
+
+    public void testNonIntegerReturnIsUnchanged() {
+        // A DOUBLE-returning call would not exhibit the i32/i64 schema disagreement and is out
+        // of scope for this adapter. Adapter must pass through unchanged.
+        RexNode arr = arrayLiteral();
+        RelDataType doubleRet = type(SqlTypeName.DOUBLE, true);
+        RexCall original = (RexCall) rexBuilder.makeCall(doubleRet, SqlLibraryOperators.ARRAY_LENGTH, List.of(arr));
+
+        IntegerReturnWideningCastAdapter adapter = new IntegerReturnWideningCastAdapter();
+        RexNode adapted = adapter.adapt(original, List.of(), cluster);
+
+        assertSame("DOUBLE-return call passes through unchanged", original, adapted);
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionAnalyticsBackendPlugin.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionAnalyticsBackendPlugin.java
@@ -599,6 +599,7 @@ public class DataFusionAnalyticsBackendPlugin implements AnalyticsSearchBackendP
                 return Map.ofEntries(
                     Map.entry(ScalarFunction.ARRAY, new MakeArrayAdapter()),
                     Map.entry(ScalarFunction.ARRAY_JOIN, new ArrayToStringAdapter()),
+                    Map.entry(ScalarFunction.ARRAY_LENGTH, new IntegerReturnWideningCastAdapter()),
                     Map.entry(ScalarFunction.ARRAY_SLICE, new ArraySliceAdapter()),
                     Map.entry(ScalarFunction.ITEM, new ArrayElementAdapter()),
                     Map.entry(ScalarFunction.MVFIND, new MvfindAdapter()),

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionAnalyticsBackendPlugin.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionAnalyticsBackendPlugin.java
@@ -34,6 +34,7 @@ import org.opensearch.analytics.spi.FilterCapability;
 import org.opensearch.analytics.spi.FilterDelegationHandle;
 import org.opensearch.analytics.spi.FragmentConvertor;
 import org.opensearch.analytics.spi.FragmentInstructionHandlerFactory;
+import org.opensearch.analytics.spi.IntegerReturnWideningCastAdapter;
 import org.opensearch.analytics.spi.IntegerRoundingCastAdapter;
 import org.opensearch.analytics.spi.JoinCapability;
 import org.opensearch.analytics.spi.NumericToDoubleAdapter;


### PR DESCRIPTION
## Description

Calcite types `array_length` as `INTEGER` (i32), but DataFusion's UDF returns `BIGINT` (i64). On a single shard the disagreement is invisible. On a multi-shard plan, the cross-fragment schema check sees `Int32 ≠ Int64` and fails the query with HTTP 500.

```
ArrayFunctionIT > testArrayLength FAILED
  Substrait error: Field 'len' has different type (Int32) than table schema (Int64)
```

## Fix

Mirror the `IntegerRoundingCastAdapter` pattern from #21914. New adapter `IntegerReturnWideningCastAdapter` rewrites:

```
array_length(arr) : INTEGER
```

into:

```
CAST( array_length(arr) : BIGINT  AS INTEGER )
```

- **Inner BIGINT** matches what DataFusion actually emits, so the cross-shard schema check passes.
- **Outer CAST back to INTEGER** preserves the original return type so parent operators see no change.

Registered against `ScalarFunction.ARRAY_LENGTH`. Generalised to `INTEGER`/`SMALLINT`/`TINYINT` returns, so future i32-vs-i64 mismatches are a one-line registration.

## Testing

- New unit tests in `IntegerReturnWideningCastAdapterTests` (wrap shape, nullability, no-op for BIGINT/non-integer, recursion safety).
- `ArrayFunctionIT.testArrayLength` passes on the 2-shard default tree.
- `MathFunctionIT.testFloorOnIntColumn` / `testCeilOnIntColumn` (the #21914 regression tests) still pass.