### PR TITLE
Add search support for handling deleted documents

### DIFF
--- a/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/backend/ShardScanExecutionContext.java
+++ b/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/backend/ShardScanExecutionContext.java
@@ -38,6 +38,7 @@ public class ShardScanExecutionContext implements CommonExecutionContext {
     private QueryCache queryCache;
     private QueryCachingPolicy queryCachingPolicy;
     private ShardId shardId;
+    private boolean hasDeletedDocs;
 
     /**
      * Constructs an execution context.
@@ -142,5 +143,19 @@ public class ShardScanExecutionContext implements CommonExecutionContext {
 
     public void setShardId(ShardId shardId) {
         this.shardId = shardId;
+    }
+
+    /**
+     * Returns whether this shard has soft-deleted documents that need filtering.
+     */
+    public boolean hasDeletedDocs() {
+        return hasDeletedDocs;
+    }
+
+    /**
+     * Sets whether this shard has soft-deleted documents.
+     */
+    public void setHasDeletedDocs(boolean hasDeletedDocs) {
+        this.hasDeletedDocs = hasDeletedDocs;
     }
 }

--- a/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/AnalyticsSearchBackendPlugin.java
+++ b/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/AnalyticsSearchBackendPlugin.java
@@ -192,4 +192,17 @@ public interface AnalyticsSearchBackendPlugin {
     default Map<ScalarFunction, DelegatedPredicateSerializer> delegatedPredicateSerializers() {
         return Map.of();
     }
+
+    /**
+     * Returns whether the shard has soft-deleted documents that need filtering.
+     *
+     * <p>Only the backend that owns the secondary index (typically Lucene) implements this.
+     * Other backends return {@code false} (default).
+     *
+     * @param reader the point-in-time reader for the current shard
+     * @return {@code true} if the shard has deletions
+     */
+    default boolean hasDeletedDocs(Reader reader) {
+        return false;
+    }
 }

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/ShardScanInstructionHandler.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/ShardScanInstructionHandler.java
@@ -58,28 +58,28 @@ public class ShardScanInstructionHandler implements FragmentInstructionHandler<S
         String tableName = context.getTableName();
 
         WireConfigSnapshot snapshot = plugin.getDatafusionSettings().getSnapshot();
+        boolean hasDeletedDocs = context.hasDeletedDocs();
         try (Arena arena = Arena.ofConfined()) {
             MemorySegment segment = arena.allocate(WireConfigSnapshot.BYTE_SIZE);
             snapshot.writeTo(segment);
             SessionContextHandle sessionCtxHandle;
-            if (node.requestsRowIds()) {
-                // QTF query phase — narrowed scan emits __row_id__. Use the indexed session
-                // context so the IndexedTableProvider injects shard-global row ids during scan.
-                // No delegated predicates here (delegation goes through ShardScanWithDelegationHandler),
-                // so treeShape=NO_DELEGATION and delegatedPredicateCount=0.
+            // Use IndexedTableProvider (segment-aware parquet scan with delegation callbacks)
+            // when the query needs shard-global __row_id__ for QTF fetch phase, or when the
+            // shard has deleted docs requiring liveDocs bitset filtering via Lucene delegation.
+            // Otherwise use plain ListingTable for a simpler, faster parquet-only scan.
+            if (node.requestsRowIds() || hasDeletedDocs) {
                 sessionCtxHandle = NativeBridge.createSessionContextForIndexedExecution(
                     readerPtr,
                     runtimePtr,
                     tableName,
                     contextId,
-                    FilterTreeShape.NO_DELEGATION.ordinal(),
-                    0,
-                    true,
+                    hasDeletedDocs ? FilterTreeShape.CONJUNCTIVE.ordinal() : FilterTreeShape.NO_DELEGATION.ordinal(),
+                    hasDeletedDocs ? 1 : 0,
+                    node.requestsRowIds(),
                     segment.address(),
                     context.getFragmentBytes()
                 );
             } else {
-                // Plan bytes let Rust widen the schema for multi-index queries (null-fill missing columns).
                 sessionCtxHandle = NativeBridge.createSessionContext(
                     readerPtr,
                     runtimePtr,

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/nativelib/NativeBridge.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/nativelib/NativeBridge.java
@@ -1237,7 +1237,6 @@ public final class NativeBridge {
             try {
                 result = call.invoke(EXECUTE_WITH_CONTEXT, sessionCtxPtr, plan, planLen);
             } finally {
-                // Rust took ownership via Box::from_raw; do not let doClose() double-free.
                 sessionContext.markConsumed();
             }
             listener.onResponse(result);

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/LuceneAnalyticsBackendPlugin.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/LuceneAnalyticsBackendPlugin.java
@@ -10,6 +10,7 @@ package org.opensearch.be.lucene;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.IndexSearcher;
 import org.opensearch.analytics.backend.ShardScanExecutionContext;
 import org.opensearch.analytics.spi.AnalyticsSearchBackendPlugin;
@@ -209,5 +210,19 @@ public class LuceneAnalyticsBackendPlugin implements AnalyticsSearchBackendPlugi
     @Override
     public DelegatedSubtreeConvertor getDelegatedSubtreeConvertor() {
         return new LuceneSubtreeConvertor(QuerySerializerRegistry.getSerializers());
+    }
+
+    @Override
+    public boolean hasDeletedDocs(IndexReaderProvider.Reader reader) {
+        LuceneReader luceneReader = reader.getReader(plugin.getDataFormat(), LuceneReader.class);
+        if (luceneReader == null) {
+            return false;
+        }
+        for (LeafReaderContext leaf : luceneReader.directoryReader().leaves()) {
+            if (leaf.reader().getLiveDocs() != null) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/LuceneFilterDelegationHandle.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/LuceneFilterDelegationHandle.java
@@ -21,6 +21,7 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.Weight;
+import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.FixedBitSet;
 import org.opensearch.analytics.spi.DelegatedExpression;
 import org.opensearch.analytics.spi.FilterDelegationHandle;
@@ -183,8 +184,9 @@ final class LuceneFilterDelegationHandle implements FilterDelegationHandle {
 
         try {
             Scorer scorer = weight.scorer(leaf);
+            Bits liveDocs = leaf.reader().getLiveDocs();
             int collectorKey = nextCollectorKey.getAndIncrement();
-            scorersByCollectorKey.put(collectorKey, new ScorerHandle(scorer, minDoc, maxDoc));
+            scorersByCollectorKey.put(collectorKey, new ScorerHandle(scorer, liveDocs, minDoc, maxDoc));
             LOGGER.debug(
                 "[scf] createCollector providerKey={} writerGeneration={} range=[{},{}) → collectorKey={}",
                 providerKey,
@@ -232,8 +234,11 @@ final class LuceneFilterDelegationHandle implements FilterDelegationHandle {
                         if (docId < scanFrom) {
                             docId = iterator.advance(scanFrom);
                         }
+                        Bits liveDocs = handle.liveDocs;
                         while (docId != DocIdSetIterator.NO_MORE_DOCS && docId < scanTo) {
-                            bits.set(docId - minDoc);
+                            if (liveDocs == null || liveDocs.get(docId)) {
+                                bits.set(docId - minDoc);
+                            }
                             docId = iterator.nextDoc();
                         }
                         handle.currentDoc = docId;
@@ -286,12 +291,14 @@ final class LuceneFilterDelegationHandle implements FilterDelegationHandle {
 
     private static final class ScorerHandle {
         final Scorer scorer;
+        final Bits liveDocs;
         final int partitionMinDoc;
         final int partitionMaxDoc;
         int currentDoc = -1;
 
-        ScorerHandle(Scorer scorer, int partitionMinDoc, int partitionMaxDoc) {
+        ScorerHandle(Scorer scorer, Bits liveDocs, int partitionMinDoc, int partitionMaxDoc) {
             this.scorer = scorer;
+            this.liveDocs = liveDocs;
             this.partitionMinDoc = partitionMinDoc;
             this.partitionMaxDoc = partitionMaxDoc;
         }

--- a/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/LuceneFilterDelegationHandleLiveDocsTests.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/LuceneFilterDelegationHandleLiveDocsTests.java
@@ -1,0 +1,572 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.lucene;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.MergePolicy;
+import org.apache.lucene.index.NoMergePolicy;
+import org.apache.lucene.index.SegmentReader;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.store.ByteBuffersDirectory;
+import org.apache.lucene.store.Directory;
+import org.opensearch.analytics.spi.DelegatedExpression;
+import org.opensearch.analytics.spi.FilterDelegationHandle;
+import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
+import org.opensearch.index.engine.exec.coord.CatalogSnapshot;
+import org.opensearch.index.mapper.MappedFieldType;
+import org.opensearch.index.query.MatchAllQueryBuilder;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.TermQueryBuilder;
+import org.opensearch.index.query.QueryShardContext;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for liveDocs filtering in {@link LuceneFilterDelegationHandle}.
+ *
+ * Validates three scenarios:
+ * 1. Parquet-only format with deletions: synthetic MATCHALL delegation filters deleted docs
+ *    via liveDocs in collectDocs().
+ * 2. Parquet + Lucene (composite): real delegated predicate (e.g., TermQuery) combined with
+ *    liveDocs filtering — deleted docs that match the predicate are excluded.
+ * 3. Lucene-only: delegation handle correctly reports liveDocs=null (no deletions) — all
+ *    matching docs pass through.
+ */
+public class LuceneFilterDelegationHandleLiveDocsTests extends OpenSearchTestCase {
+
+    private static final String LUCENE_BACKEND = "lucene";
+
+    private Directory directory;
+    private IndexWriter writer;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        directory = new ByteBuffersDirectory();
+        IndexWriterConfig config = new IndexWriterConfig();
+        // Disable merges so that deleted docs remain as liveDocs bitset
+        // rather than being physically removed by segment merging.
+        config.setMergePolicy(NoMergePolicy.INSTANCE);
+        writer = new IndexWriter(directory, config);
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        writer.close();
+        directory.close();
+        super.tearDown();
+    }
+
+    /**
+     * Parquet-only with deletions: synthetic MATCHALL delegation.
+     * All live docs should pass; deleted docs should be excluded.
+     *
+     * Simulates: index 10 docs, delete 3, use MATCHALL delegation → expect 7 bits set.
+     */
+    public void testParquetOnly_MatchAllDelegation_ExcludesDeletedDocs() throws Exception {
+        // Index 10 docs
+        for (int i = 0; i < 10; i++) {
+            Document doc = new Document();
+            doc.add(new StringField("_id", "doc" + i, Field.Store.NO));
+            doc.add(new StringField("status", String.valueOf(i % 3), Field.Store.NO));
+            writer.addDocument(doc);
+        }
+        writer.commit();
+
+        // Delete docs 2, 5, 8 (every third doc starting at 2)
+        writer.deleteDocuments(new Term("_id", "doc2"));
+        writer.deleteDocuments(new Term("_id", "doc5"));
+        writer.deleteDocuments(new Term("_id", "doc8"));
+        writer.commit();
+
+        DirectoryReader reader = DirectoryReader.open(writer);
+        try {
+            LuceneFilterDelegationHandle handle = createHandle(reader, serializeQuery(new MatchAllQueryBuilder()));
+
+            LeafReaderContext leaf = reader.leaves().get(0);
+            assertNotNull("Segment must have liveDocs after deletions", leaf.reader().getLiveDocs());
+
+            int providerKey = handle.createProvider(0);
+            assertTrue("Provider key must be valid", providerKey >= 0);
+
+            int collectorKey = handle.createCollector(providerKey, 1L, 0, leaf.reader().maxDoc());
+            assertTrue("Collector key must be valid", collectorKey >= 0);
+
+            long[] bitset = collectBitset(handle, collectorKey, 0, leaf.reader().maxDoc());
+
+            int liveCount = countBits(bitset, leaf.reader().maxDoc());
+            assertEquals("Should have 7 live docs (10 total - 3 deleted)", 7, liveCount);
+
+            // Verify specific deleted positions are NOT set
+            assertFalse("Doc 2 should be excluded (deleted)", isBitSet(bitset, 2));
+            assertFalse("Doc 5 should be excluded (deleted)", isBitSet(bitset, 5));
+            assertFalse("Doc 8 should be excluded (deleted)", isBitSet(bitset, 8));
+
+            // Verify some live positions ARE set
+            assertTrue("Doc 0 should be included (live)", isBitSet(bitset, 0));
+            assertTrue("Doc 1 should be included (live)", isBitSet(bitset, 1));
+            assertTrue("Doc 3 should be included (live)", isBitSet(bitset, 3));
+
+            handle.releaseCollector(collectorKey);
+            handle.releaseProvider(providerKey);
+            handle.close();
+        } finally {
+            reader.close();
+        }
+    }
+
+    /**
+     * Parquet + Lucene composite: real TermQuery delegation with deletions.
+     * Only live docs that ALSO match the delegated predicate should pass.
+     *
+     * Simulates: index 10 docs with status "match" or "nomatch", delete some matching docs,
+     * delegate a TermQuery for status=match → only live matching docs in bitset.
+     */
+    public void testParquetPlusLucene_TermQueryDelegation_ExcludesDeletedMatchingDocs() throws Exception {
+        // Index 10 docs: even-indexed have status=match, odd have status=nomatch
+        for (int i = 0; i < 10; i++) {
+            Document doc = new Document();
+            doc.add(new StringField("_id", "doc" + i, Field.Store.NO));
+            doc.add(new StringField("status", i % 2 == 0 ? "match" : "nomatch", Field.Store.NO));
+            writer.addDocument(doc);
+        }
+        writer.commit();
+
+        // Delete docs 0 and 4 (both have status=match)
+        writer.deleteDocuments(new Term("_id", "doc0"));
+        writer.deleteDocuments(new Term("_id", "doc4"));
+        writer.commit();
+
+        DirectoryReader reader = DirectoryReader.open(writer);
+        try {
+            // Use a raw Lucene TermQuery directly via a custom handle (bypass QueryBuilder serialization)
+            LuceneFilterDelegationHandle handle = createHandleWithRawQuery(
+                reader,
+                new org.apache.lucene.search.TermQuery(new Term("status", "match"))
+            );
+
+            LeafReaderContext leaf = reader.leaves().get(0);
+            assertNotNull("Segment must have liveDocs after deletions", leaf.reader().getLiveDocs());
+
+            int providerKey = handle.createProvider(0);
+            assertTrue("Provider key must be valid", providerKey >= 0);
+
+            int collectorKey = handle.createCollector(providerKey, 1L, 0, leaf.reader().maxDoc());
+            assertTrue("Collector key must be valid", collectorKey >= 0);
+
+            long[] bitset = collectBitset(handle, collectorKey, 0, leaf.reader().maxDoc());
+
+            int matchCount = countBits(bitset, leaf.reader().maxDoc());
+            // Originally 5 docs match (0,2,4,6,8), minus 2 deleted (0,4) = 3 live matches
+            assertEquals("Should have 3 live matching docs", 3, matchCount);
+
+            // Deleted matching docs should NOT be in bitset
+            assertFalse("Doc 0 should be excluded (deleted)", isBitSet(bitset, 0));
+            assertFalse("Doc 4 should be excluded (deleted)", isBitSet(bitset, 4));
+
+            // Live matching docs should be in bitset
+            assertTrue("Doc 2 should be included (live, matches)", isBitSet(bitset, 2));
+            assertTrue("Doc 6 should be included (live, matches)", isBitSet(bitset, 6));
+            assertTrue("Doc 8 should be included (live, matches)", isBitSet(bitset, 8));
+
+            // Non-matching docs should NOT be in bitset regardless of liveness
+            assertFalse("Doc 1 should be excluded (doesn't match)", isBitSet(bitset, 1));
+            assertFalse("Doc 3 should be excluded (doesn't match)", isBitSet(bitset, 3));
+
+            handle.releaseCollector(collectorKey);
+            handle.releaseProvider(providerKey);
+            handle.close();
+        } finally {
+            reader.close();
+        }
+    }
+
+    /**
+     * Lucene-only (no deletions): liveDocs is null, all matching docs pass.
+     * Verifies that collectDocs works correctly when there are no deleted docs.
+     */
+    public void testLuceneOnly_NoDeletions_AllMatchingDocsPass() throws Exception {
+        // Index 10 docs, NO deletions
+        for (int i = 0; i < 10; i++) {
+            Document doc = new Document();
+            doc.add(new StringField("_id", "doc" + i, Field.Store.NO));
+            doc.add(new StringField("status", i % 2 == 0 ? "match" : "nomatch", Field.Store.NO));
+            writer.addDocument(doc);
+        }
+        writer.commit();
+
+        DirectoryReader reader = DirectoryReader.open(writer);
+        try {
+            LuceneFilterDelegationHandle handle = createHandleWithRawQuery(
+                reader,
+                new org.apache.lucene.search.TermQuery(new Term("status", "match"))
+            );
+
+            LeafReaderContext leaf = reader.leaves().get(0);
+            assertNull("liveDocs should be null when no deletions exist", leaf.reader().getLiveDocs());
+
+            int providerKey = handle.createProvider(0);
+            assertTrue("Provider key must be valid", providerKey >= 0);
+
+            int collectorKey = handle.createCollector(providerKey, 1L, 0, leaf.reader().maxDoc());
+            assertTrue("Collector key must be valid", collectorKey >= 0);
+
+            long[] bitset = collectBitset(handle, collectorKey, 0, leaf.reader().maxDoc());
+
+            int matchCount = countBits(bitset, leaf.reader().maxDoc());
+            // 5 even-indexed docs match status=match, no deletions
+            assertEquals("Should have 5 matching docs (no deletions)", 5, matchCount);
+
+            // All even-indexed docs should be set
+            assertTrue("Doc 0 should match", isBitSet(bitset, 0));
+            assertTrue("Doc 2 should match", isBitSet(bitset, 2));
+            assertTrue("Doc 4 should match", isBitSet(bitset, 4));
+            assertTrue("Doc 6 should match", isBitSet(bitset, 6));
+            assertTrue("Doc 8 should match", isBitSet(bitset, 8));
+
+            handle.releaseCollector(collectorKey);
+            handle.releaseProvider(providerKey);
+            handle.close();
+        } finally {
+            reader.close();
+        }
+    }
+
+    /**
+     * MATCHALL with no deletions: all docs should be in the bitset.
+     * Baseline sanity check.
+     */
+    public void testMatchAll_NoDeletions_AllDocsPass() throws Exception {
+        for (int i = 0; i < 10; i++) {
+            Document doc = new Document();
+            doc.add(new StringField("_id", "doc" + i, Field.Store.NO));
+            writer.addDocument(doc);
+        }
+        writer.commit();
+
+        DirectoryReader reader = DirectoryReader.open(writer);
+        try {
+            LuceneFilterDelegationHandle handle = createHandle(reader, serializeQuery(new MatchAllQueryBuilder()));
+
+            LeafReaderContext leaf = reader.leaves().get(0);
+            assertNull("liveDocs should be null when no deletions", leaf.reader().getLiveDocs());
+
+            int providerKey = handle.createProvider(0);
+            int collectorKey = handle.createCollector(providerKey, 1L, 0, leaf.reader().maxDoc());
+
+            long[] bitset = collectBitset(handle, collectorKey, 0, leaf.reader().maxDoc());
+
+            int count = countBits(bitset, leaf.reader().maxDoc());
+            assertEquals("All 10 docs should pass", 10, count);
+
+            handle.releaseCollector(collectorKey);
+            handle.releaseProvider(providerKey);
+            handle.close();
+        } finally {
+            reader.close();
+        }
+    }
+
+    /**
+     * All docs deleted: MATCHALL delegation returns empty bitset.
+     */
+    public void testAllDocsDeleted_EmptyBitset() throws Exception {
+        for (int i = 0; i < 5; i++) {
+            Document doc = new Document();
+            doc.add(new StringField("_id", "doc" + i, Field.Store.NO));
+            writer.addDocument(doc);
+        }
+        writer.commit();
+
+        // Delete all
+        for (int i = 0; i < 5; i++) {
+            writer.deleteDocuments(new Term("_id", "doc" + i));
+        }
+        writer.commit();
+
+        DirectoryReader reader = DirectoryReader.open(writer);
+        try {
+            // After deleting all docs, the segment may be removed entirely
+            if (reader.leaves().isEmpty()) {
+                // Valid case: Lucene can drop segments with no live docs
+                reader.close();
+                return;
+            }
+
+            LuceneFilterDelegationHandle handle = createHandle(reader, serializeQuery(new MatchAllQueryBuilder()));
+
+            LeafReaderContext leaf = reader.leaves().get(0);
+            int providerKey = handle.createProvider(0);
+            int collectorKey = handle.createCollector(providerKey, 1L, 0, leaf.reader().maxDoc());
+
+            long[] bitset = collectBitset(handle, collectorKey, 0, leaf.reader().maxDoc());
+
+            int count = countBits(bitset, leaf.reader().maxDoc());
+            assertEquals("No live docs — bitset should be empty", 0, count);
+
+            handle.releaseCollector(collectorKey);
+            handle.releaseProvider(providerKey);
+            handle.close();
+        } finally {
+            reader.close();
+        }
+    }
+
+    /**
+     * Update scenario (delete + re-index same ID): only the new version should appear.
+     * Simulates what happens on an update: the old doc is soft-deleted, a new doc is added.
+     */
+    public void testUpdate_OldVersionExcluded_NewVersionIncluded() throws Exception {
+        // Index original doc
+        Document original = new Document();
+        original.add(new StringField("_id", "doc1", Field.Store.NO));
+        original.add(new StringField("version", "v1", Field.Store.NO));
+        writer.addDocument(original);
+        writer.commit();
+
+        // Update: delete old, add new (in same segment after commit)
+        writer.deleteDocuments(new Term("_id", "doc1"));
+        Document updated = new Document();
+        updated.add(new StringField("_id", "doc1", Field.Store.NO));
+        updated.add(new StringField("version", "v2", Field.Store.NO));
+        writer.addDocument(updated);
+        writer.commit();
+
+        DirectoryReader reader = DirectoryReader.open(writer);
+        try {
+            LuceneFilterDelegationHandle handle = createHandle(reader, serializeQuery(new MatchAllQueryBuilder()));
+
+            // There may be 1 or 2 segments depending on merge behavior
+            int totalLive = 0;
+            for (LeafReaderContext leaf : reader.leaves()) {
+                String segName = ((SegmentReader) leaf.reader()).getSegmentInfo().info.name;
+                long gen = getGenerationForSegment(reader, segName);
+
+                int providerKey = handle.createProvider(0);
+                int collectorKey = handle.createCollector(providerKey, gen, 0, leaf.reader().maxDoc());
+                if (collectorKey < 0) {
+                    handle.releaseProvider(providerKey);
+                    continue;
+                }
+
+                long[] bitset = collectBitset(handle, collectorKey, 0, leaf.reader().maxDoc());
+                totalLive += countBits(bitset, leaf.reader().maxDoc());
+
+                handle.releaseCollector(collectorKey);
+                handle.releaseProvider(providerKey);
+            }
+
+            // Only the new version should be live
+            assertEquals("Should have exactly 1 live doc (the updated version)", 1, totalLive);
+
+            handle.close();
+        } finally {
+            reader.close();
+        }
+    }
+
+    /**
+     * Partial range collectDocs: validates that liveDocs filtering works correctly
+     * when collecting a sub-range [minDoc, maxDoc) within a segment.
+     */
+    public void testPartialRange_LiveDocsFilteringCorrect() throws Exception {
+        // Index 20 docs
+        for (int i = 0; i < 20; i++) {
+            Document doc = new Document();
+            doc.add(new StringField("_id", "doc" + i, Field.Store.NO));
+            writer.addDocument(doc);
+        }
+        writer.commit();
+
+        // Delete docs 5, 10, 15
+        writer.deleteDocuments(new Term("_id", "doc5"));
+        writer.deleteDocuments(new Term("_id", "doc10"));
+        writer.deleteDocuments(new Term("_id", "doc15"));
+        writer.commit();
+
+        DirectoryReader reader = DirectoryReader.open(writer);
+        try {
+            LuceneFilterDelegationHandle handle = createHandle(reader, serializeQuery(new MatchAllQueryBuilder()));
+
+            LeafReaderContext leaf = reader.leaves().get(0);
+            int providerKey = handle.createProvider(0);
+
+            // Collect only range [4, 12) — should include docs 4,6,7,8,9,11 (exclude 5,10)
+            int collectorKey = handle.createCollector(providerKey, 1L, 4, 12);
+            assertTrue("Collector key must be valid", collectorKey >= 0);
+
+            long[] bitset = collectBitset(handle, collectorKey, 4, 12);
+
+            int count = countBits(bitset, 8); // range span = 12 - 4 = 8
+            // Docs in range [4,12): 4,5,6,7,8,9,10,11 → minus deleted 5,10 = 6 live
+            assertEquals("Should have 6 live docs in range [4,12)", 6, count);
+
+            // Doc at offset 1 in the range (absolute doc 5) should be excluded
+            assertFalse("Doc 5 (offset 1) should be excluded (deleted)", isBitSet(bitset, 1));
+            // Doc at offset 6 in the range (absolute doc 10) should be excluded
+            assertFalse("Doc 10 (offset 6) should be excluded (deleted)", isBitSet(bitset, 6));
+            // Doc at offset 0 (absolute doc 4) should be included
+            assertTrue("Doc 4 (offset 0) should be included (live)", isBitSet(bitset, 0));
+
+            handle.releaseCollector(collectorKey);
+            handle.releaseProvider(providerKey);
+            handle.close();
+        } finally {
+            reader.close();
+        }
+    }
+
+    // ─── Helper Methods ──────────────────────────────────────────────────────────
+
+    private LuceneFilterDelegationHandle createHandle(DirectoryReader reader, byte[] queryBytes) {
+        Map<Long, String> genMap = buildGenerationMap(reader);
+        LuceneReader luceneReader = new LuceneReader(reader, genMap);
+        IndexSearcher searcher = new IndexSearcher(reader);
+        QueryShardContext qsc = mockQueryShardContext(searcher);
+        CatalogSnapshot catalogSnapshot = mock(CatalogSnapshot.class);
+        NamedWriteableRegistry registry = new NamedWriteableRegistry(
+            List.of(
+                new NamedWriteableRegistry.Entry(QueryBuilder.class, MatchAllQueryBuilder.NAME, MatchAllQueryBuilder::new),
+                new NamedWriteableRegistry.Entry(QueryBuilder.class, TermQueryBuilder.NAME, TermQueryBuilder::new)
+            )
+        );
+        DelegatedExpression expr = new DelegatedExpression(0, LUCENE_BACKEND, queryBytes);
+        return new LuceneFilterDelegationHandle(List.of(expr), qsc, luceneReader, catalogSnapshot, registry, () -> false);
+    }
+
+    /**
+     * Creates a delegation handle that uses a raw Lucene Query directly,
+     * bypassing QueryBuilder serialization/deserialization. Useful when testing
+     * liveDocs filtering behavior without depending on QueryBuilder mocks.
+     */
+    private LuceneFilterDelegationHandle createHandleWithRawQuery(DirectoryReader reader, org.apache.lucene.search.Query rawQuery) {
+        Map<Long, String> genMap = buildGenerationMap(reader);
+        LuceneReader luceneReader = new LuceneReader(reader, genMap);
+        IndexSearcher searcher = new IndexSearcher(reader);
+        // Build a QueryShardContext whose searcher is wired and whose fieldMapper
+        // returns a MappedFieldType that produces the raw query when termQuery is called.
+        QueryShardContext qsc = mock(QueryShardContext.class);
+        when(qsc.searcher()).thenReturn(searcher);
+        MappedFieldType fieldType = mock(MappedFieldType.class);
+        when(fieldType.termQuery(any(), any())).thenReturn(rawQuery);
+        when(qsc.fieldMapper(any())).thenReturn(fieldType);
+
+        CatalogSnapshot catalogSnapshot = mock(CatalogSnapshot.class);
+        // Serialize a TermQueryBuilder with a dummy field — the mock intercepts toQuery
+        // and returns the raw query regardless of field name.
+        NamedWriteableRegistry registry = new NamedWriteableRegistry(
+            List.of(
+                new NamedWriteableRegistry.Entry(QueryBuilder.class, TermQueryBuilder.NAME, TermQueryBuilder::new)
+            )
+        );
+        byte[] queryBytes;
+        try {
+            queryBytes = serializeQuery(new TermQueryBuilder("_dummy", "_dummy"));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        DelegatedExpression expr = new DelegatedExpression(0, LUCENE_BACKEND, queryBytes);
+        return new LuceneFilterDelegationHandle(List.of(expr), qsc, luceneReader, catalogSnapshot, registry, () -> false);
+    }
+
+    private Map<Long, String> buildGenerationMap(DirectoryReader reader) {
+        Map<Long, String> genMap = new HashMap<>();
+        long gen = 1L;
+        for (LeafReaderContext leaf : reader.leaves()) {
+            SegmentReader sr = (SegmentReader) leaf.reader();
+            genMap.put(gen, sr.getSegmentInfo().info.name);
+            gen++;
+        }
+        return genMap;
+    }
+
+    private long getGenerationForSegment(DirectoryReader reader, String segName) {
+        Map<Long, String> genMap = buildGenerationMap(reader);
+        for (Map.Entry<Long, String> entry : genMap.entrySet()) {
+            if (entry.getValue().equals(segName)) {
+                return entry.getKey();
+            }
+        }
+        return -1;
+    }
+
+    private QueryShardContext mockQueryShardContext(IndexSearcher searcher) {
+        QueryShardContext qsc = mock(QueryShardContext.class);
+        when(qsc.searcher()).thenReturn(searcher);
+        MappedFieldType statusFieldType = mock(MappedFieldType.class);
+        when(statusFieldType.termQuery(any(), any())).thenAnswer(invocation -> {
+            Object value = invocation.getArgument(0);
+            return new org.apache.lucene.search.TermQuery(new Term("status", value.toString()));
+        });
+        when(qsc.fieldMapper(eq("status"))).thenReturn(statusFieldType);
+
+        MappedFieldType idFieldType = mock(MappedFieldType.class);
+        when(idFieldType.termQuery(any(), any())).thenAnswer(invocation -> {
+            Object value = invocation.getArgument(0);
+            return new org.apache.lucene.search.TermQuery(new Term("_id", value.toString()));
+        });
+        when(qsc.fieldMapper(eq("_id"))).thenReturn(idFieldType);
+        return qsc;
+    }
+
+    private byte[] serializeQuery(QueryBuilder qb) throws IOException {
+        org.opensearch.common.io.stream.BytesStreamOutput out = new org.opensearch.common.io.stream.BytesStreamOutput();
+        out.writeNamedWriteable(qb);
+        return org.opensearch.core.common.bytes.BytesReference.toBytes(out.bytes());
+    }
+
+    private long[] collectBitset(FilterDelegationHandle handle, int collectorKey, int minDoc, int maxDoc) {
+        int span = maxDoc - minDoc;
+        int wordCount = (span + 63) >>> 6;
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment out = arena.allocate((long) wordCount * Long.BYTES);
+            int written = handle.collectDocs(collectorKey, minDoc, maxDoc, out);
+            assertTrue("collectDocs should return non-negative word count", written >= 0);
+            long[] words = new long[wordCount];
+            for (int i = 0; i < written; i++) {
+                words[i] = out.getAtIndex(ValueLayout.JAVA_LONG, i);
+            }
+            return words;
+        }
+    }
+
+    private int countBits(long[] words, int maxBits) {
+        int count = 0;
+        for (int i = 0; i < maxBits; i++) {
+            if (isBitSet(words, i)) count++;
+        }
+        return count;
+    }
+
+    private boolean isBitSet(long[] words, int bit) {
+        int wordIndex = bit >>> 6;
+        int bitIndex = bit & 63;
+        if (wordIndex >= words.length) return false;
+        return (words[wordIndex] & (1L << bitIndex)) != 0;
+    }
+}

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/AnalyticsSearchService.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/AnalyticsSearchService.java
@@ -22,9 +22,11 @@ import org.opensearch.analytics.exec.action.FragmentExecutionRequest;
 import org.opensearch.analytics.exec.task.AnalyticsShardTask;
 import org.opensearch.analytics.spi.AnalyticsSearchBackendPlugin;
 import org.opensearch.analytics.spi.BackendExecutionContext;
+import org.opensearch.analytics.spi.DelegatedExpression;
 import org.opensearch.analytics.spi.DelegationDescriptor;
 import org.opensearch.analytics.spi.DelegationThreadTracker;
 import org.opensearch.analytics.spi.FilterDelegationHandle;
+import org.opensearch.analytics.spi.FilterTreeShape;
 import org.opensearch.analytics.spi.FragmentInstructionHandler;
 import org.opensearch.analytics.spi.FragmentInstructionHandlerFactory;
 import org.opensearch.analytics.spi.InstructionNode;
@@ -323,6 +325,12 @@ public class AnalyticsSearchService implements AutoCloseable {
             // TODO: currently assumes single accepting backend. When multiple accepting backends exist
             // (e.g., Lucene + Tantivy), group expressions by acceptingBackendId and create one handle per group.
             DelegationDescriptor delegation = resolved.plan.getDelegationDescriptor();
+            // Inject synthetic MATCHALL delegation when the shard has soft-deleted documents
+            // but no real delegation exists. The MATCHALL scorer iterates all docs and
+            // collectDocs() checks liveDocs — filtering deleted rows via the existing FFM path.
+            if (delegation == null && ctx.hasDeletedDocs()) {
+                delegation = buildLiveDocsDelegation(ctx);
+            }
             if (delegation != null) {
                 String acceptingBackendId = delegation.delegatedExpressions().getFirst().getAcceptingBackendId();
                 AnalyticsSearchBackendPlugin acceptingBackend = backends.get(acceptingBackendId);
@@ -434,7 +442,44 @@ public class AnalyticsSearchService implements AutoCloseable {
         ctx.setQueryCache(shard.getQueryCache());
         ctx.setQueryCachingPolicy(shard.getQueryCachingPolicy());
         ctx.setShardId(shard.shardId());
+
+        for (AnalyticsSearchBackendPlugin backend : backends.values()) {
+            if (backend.hasDeletedDocs(reader)) {
+                ctx.setHasDeletedDocs(true);
+                break;
+            }
+        }
         return ctx;
+    }
+
+    /**
+     * Builds a synthetic MATCHALL delegation descriptor for live-docs filtering.
+     * The MATCHALL scorer iterates all docs; collectDocs() checks liveDocs to exclude deleted ones.
+     */
+    private DelegationDescriptor buildLiveDocsDelegation(ShardScanExecutionContext ctx) {
+        String luceneBackendId = null;
+        for (Map.Entry<String, AnalyticsSearchBackendPlugin> entry : backends.entrySet()) {
+            if (entry.getValue().hasDeletedDocs(ctx.getReader())) {
+                luceneBackendId = entry.getKey();
+                break;
+            }
+        }
+
+        // In case registered format is parquet only format, return null.
+        if (luceneBackendId == null) {
+            return null;
+        }
+        try {
+            var matchAll = new org.opensearch.index.query.MatchAllQueryBuilder();
+            var out = new org.opensearch.common.io.stream.BytesStreamOutput();
+            out.writeNamedWriteable(matchAll);
+            byte[] expressionBytes = org.opensearch.core.common.bytes.BytesReference.toBytes(out.bytes());
+            DelegatedExpression expr = new DelegatedExpression(0, luceneBackendId, expressionBytes);
+            return new DelegationDescriptor(FilterTreeShape.CONJUNCTIVE, 1, List.of(expr));
+        } catch (IOException e) {
+            LOGGER.warn("Failed to build synthetic MATCHALL delegation for live-docs filtering", e);
+            return null;
+        }
     }
 
     // ── Assertion helpers (invoked only when -ea is enabled; bodies are dead in production) ──


### PR DESCRIPTION
### Description

For a Composite format where one of the format is Lucene (or lucene only format), deleted documents are tracked by Lucene's liveDocs bitmap. When a query's filter contains at least one predicate naturally served by Lucene, that predicate's Weight.scorer(...).iterator() already excludes deletes — so deleted docs are filtered out. Adding support for updates/deltes by attaching a live docs delegation when there are deletes.
