### PR TITLE
Add node-attr for different engine types

### DIFF
--- a/server/src/main/java/org/opensearch/node/EngineModeNodeAttribute.java
+++ b/server/src/main/java/org/opensearch/node/EngineModeNodeAttribute.java
@@ -1,0 +1,110 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.node;
+
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.common.settings.Settings;
+
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Node attribute that distinguishes which engine a data node runs.
+ *
+ * <p>Set on a node via:
+ * <pre>
+ *   node.attr.engine_mode: lucene     # default Lucene engine
+ *   node.attr.engine_mode: analytics  # DataFormatAware analytics engine
+ * </pre>
+ *
+ * The attribute is optional. When absent the node is treated as {@link EngineMode#LUCENE},
+ * which preserves the pre-existing behavior of every node before this attribute was introduced.
+ *
+ * @opensearch.internal
+ */
+public final class EngineModeNodeAttribute {
+
+    /** Bare attribute key as it appears on a {@link DiscoveryNode}'s attribute map. */
+    public static final String ENGINE_MODE_ATTRIBUTE_KEY = "engine_mode";
+
+    /** Fully-qualified setting key (i.e. {@code node.attr.engine_mode}) as it appears in {@link Settings}. */
+    public static final String ENGINE_MODE_SETTING_KEY = Node.NODE_ATTRIBUTES.getKey() + ENGINE_MODE_ATTRIBUTE_KEY;
+
+    private EngineModeNodeAttribute() {}
+
+    /**
+     * Allowed values for {@code node.attr.engine_mode}.
+     */
+    public enum EngineMode {
+        /** Default Lucene-backed engine ({@code InternalEngine}). */
+        LUCENE,
+        /** DataFormat-aware analytics engine. */
+        ANALYTICS;
+
+        /** Lower-cased name used as the on-the-wire attribute value. */
+        public String attributeValue() {
+            return name().toLowerCase(Locale.ROOT);
+        }
+    }
+
+    /** Default mode applied when the attribute is absent. */
+    public static final EngineMode DEFAULT = EngineMode.LUCENE;
+
+    /**
+     * Parse an attribute value into an {@link EngineMode}. Comparison is case-insensitive.
+     *
+     * @throws IllegalArgumentException if the value is not one of the known modes
+     */
+    public static EngineMode parse(String value) {
+        if (value == null || value.isEmpty()) {
+            return DEFAULT;
+        }
+        String normalized = value.toLowerCase(Locale.ROOT);
+        for (EngineMode mode : EngineMode.values()) {
+            if (mode.attributeValue().equals(normalized)) {
+                return mode;
+            }
+        }
+        throw new IllegalArgumentException(
+            "Unknown "
+                + ENGINE_MODE_SETTING_KEY
+                + " ["
+                + value
+                + "], must be one of "
+                + Arrays.stream(EngineMode.values()).map(EngineMode::attributeValue).collect(Collectors.toList())
+        );
+    }
+
+    /** Return the {@link EngineMode} for the given node, falling back to {@link #DEFAULT} when absent. */
+    public static EngineMode get(DiscoveryNode node) {
+        return parse(node.getAttributes().get(ENGINE_MODE_ATTRIBUTE_KEY));
+    }
+
+    /** Return the {@link EngineMode} for the given node attribute map, falling back to {@link #DEFAULT} when absent. */
+    public static EngineMode get(Map<String, String> attributes) {
+        return parse(attributes.get(ENGINE_MODE_ATTRIBUTE_KEY));
+    }
+
+    /** Return the {@link EngineMode} configured for the local node via {@code node.attr.engine_mode} in {@link Settings}. */
+    public static EngineMode get(Settings settings) {
+        return parse(settings.get(ENGINE_MODE_SETTING_KEY));
+    }
+
+    /**
+     * Validate a candidate {@code engine_mode} attribute value. Called by {@link Node#NODE_ATTRIBUTES}'s
+     * validator so the error surfaces at node startup rather than later when something tries to read it.
+     *
+     * @throws IllegalArgumentException if the value is not one of the known modes
+     */
+    public static void validate(String value) {
+        parse(value);
+    }
+}

--- a/server/src/main/java/org/opensearch/node/Node.java
+++ b/server/src/main/java/org/opensearch/node/Node.java
@@ -424,6 +424,9 @@ public class Node implements Closeable {
                     throw new IllegalArgumentException("invalid node.attr.server_name [" + value + "]", e);
                 }
             }
+            if (value.length() > 0 && EngineModeNodeAttribute.ENGINE_MODE_SETTING_KEY.equals(key)) {
+                EngineModeNodeAttribute.validate(value);
+            }
             return value;
         }, Property.NodeScope)
     );

--- a/server/src/test/java/org/opensearch/cluster/coordination/JoinTaskExecutorTests.java
+++ b/server/src/test/java/org/opensearch/cluster/coordination/JoinTaskExecutorTests.java
@@ -51,6 +51,7 @@ import org.opensearch.cluster.routing.allocation.AllocationService;
 import org.opensearch.common.SetOnce;
 import org.opensearch.common.UUIDs;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.node.EngineModeNodeAttribute;
 import org.opensearch.node.remotestore.RemoteStoreNodeService;
 import org.opensearch.repositories.RepositoriesService;
 import org.opensearch.repositories.RepositoryMissingException;
@@ -1511,6 +1512,50 @@ public class JoinTaskExecutorTests extends OpenSearchTestCase {
             Collections.singleton(DiscoveryNodeRole.CLUSTER_MANAGER_ROLE),
             Version.CURRENT
         );
+    }
+
+    /**
+     * End-to-end {@link JoinTaskExecutor#ensureNodesCompatibility} test: a remote-store cluster
+     * (segment-replication backed by a remote store) merges a data node with
+     * {@code engine_mode=lucene} and a data node with {@code engine_mode=analytics}. Both share
+     * the same remote-store repository attributes so the remote-store compatibility check passes;
+     * {@code engine_mode} is a free-form node attribute as far as join validation is concerned and
+     * must not block cluster formation regardless of mix.
+     */
+    public void testRemoteStoreClusterAcceptsMixedEngineModeDataNodes() {
+        Map<String, String> luceneAttrs = new HashMap<>(remoteStoreNodeAttributes(SEGMENT_REPO, TRANSLOG_REPO));
+        luceneAttrs.put(EngineModeNodeAttribute.ENGINE_MODE_ATTRIBUTE_KEY, "lucene");
+
+        Map<String, String> analyticsAttrs = new HashMap<>(remoteStoreNodeAttributes(SEGMENT_REPO, TRANSLOG_REPO));
+        analyticsAttrs.put(EngineModeNodeAttribute.ENGINE_MODE_ATTRIBUTE_KEY, "analytics");
+
+        DiscoveryNode existingLuceneNode = new DiscoveryNode(
+            UUIDs.base64UUID(),
+            buildNewFakeTransportAddress(),
+            luceneAttrs,
+            DiscoveryNodeRole.BUILT_IN_ROLES,
+            Version.CURRENT
+        );
+        ClusterState currentState = ClusterState.builder(ClusterName.DEFAULT)
+            .nodes(DiscoveryNodes.builder().add(existingLuceneNode).localNodeId(existingLuceneNode.getId()).build())
+            .build();
+
+        DiscoveryNode joiningAnalyticsNode = new DiscoveryNode(
+            UUIDs.base64UUID(),
+            buildNewFakeTransportAddress(),
+            analyticsAttrs,
+            DiscoveryNodeRole.BUILT_IN_ROLES,
+            Version.CURRENT
+        );
+
+        // Should pass the full compatibility chain: version + remote-store repos + engine_mode.
+        JoinTaskExecutor.ensureNodesCompatibility(joiningAnalyticsNode, currentState.getNodes(), currentState.metadata());
+
+        // And in the reverse direction: an analytics-only cluster accepting a lucene data node.
+        ClusterState analyticsCluster = ClusterState.builder(ClusterName.DEFAULT)
+            .nodes(DiscoveryNodes.builder().add(joiningAnalyticsNode).localNodeId(joiningAnalyticsNode.getId()).build())
+            .build();
+        JoinTaskExecutor.ensureNodesCompatibility(existingLuceneNode, analyticsCluster.getNodes(), analyticsCluster.metadata());
     }
 
     private static final String SEGMENT_REPO = "segment-repo";

--- a/server/src/test/java/org/opensearch/node/EngineModeNodeAttributeTests.java
+++ b/server/src/test/java/org/opensearch/node/EngineModeNodeAttributeTests.java
@@ -1,0 +1,93 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.node;
+
+import org.opensearch.Version;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.core.common.transport.TransportAddress;
+import org.opensearch.node.EngineModeNodeAttribute.EngineMode;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Map;
+
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.emptySet;
+
+public class EngineModeNodeAttributeTests extends OpenSearchTestCase {
+
+    public void testDefaultsToLuceneWhenAttributeAbsent() throws UnknownHostException {
+        DiscoveryNode node = makeNode(emptyMap());
+        assertEquals(EngineMode.LUCENE, EngineModeNodeAttribute.get(node));
+        assertEquals(EngineMode.LUCENE, EngineModeNodeAttribute.get(Settings.EMPTY));
+        assertEquals(EngineMode.LUCENE, EngineModeNodeAttribute.DEFAULT);
+    }
+
+    public void testParsesKnownValues() throws UnknownHostException {
+        assertEquals(EngineMode.LUCENE, EngineModeNodeAttribute.parse("lucene"));
+        assertEquals(EngineMode.ANALYTICS, EngineModeNodeAttribute.parse("analytics"));
+        // case-insensitive
+        assertEquals(EngineMode.LUCENE, EngineModeNodeAttribute.parse("LUCENE"));
+        assertEquals(EngineMode.ANALYTICS, EngineModeNodeAttribute.parse("Analytics"));
+
+        DiscoveryNode node = makeNode(Map.of(EngineModeNodeAttribute.ENGINE_MODE_ATTRIBUTE_KEY, "analytics"));
+        assertEquals(EngineMode.ANALYTICS, EngineModeNodeAttribute.get(node));
+    }
+
+    public void testReadsFromSettings() {
+        Settings settings = Settings.builder().put(EngineModeNodeAttribute.ENGINE_MODE_SETTING_KEY, "analytics").build();
+        assertEquals(EngineMode.ANALYTICS, EngineModeNodeAttribute.get(settings));
+    }
+
+    public void testRejectsUnknownValue() {
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> EngineModeNodeAttribute.parse("postgres"));
+        assertTrue(e.getMessage(), e.getMessage().contains("Unknown"));
+        assertTrue(e.getMessage(), e.getMessage().contains("engine_mode"));
+        assertTrue(e.getMessage(), e.getMessage().contains("postgres"));
+    }
+
+    public void testValidateRejectsUnknownValue() {
+        // valid values do not throw
+        EngineModeNodeAttribute.validate("lucene");
+        EngineModeNodeAttribute.validate("analytics");
+        EngineModeNodeAttribute.validate("");
+
+        expectThrows(IllegalArgumentException.class, () -> EngineModeNodeAttribute.validate("postgres"));
+    }
+
+    public void testNodeAttributesSettingValidatesEngineMode() {
+        // Built through the actual NODE_ATTRIBUTES affix setting so we exercise the wired-in validator.
+        Settings good = Settings.builder().put(EngineModeNodeAttribute.ENGINE_MODE_SETTING_KEY, "analytics").build();
+        // get() runs the validator
+        Node.NODE_ATTRIBUTES.getConcreteSetting(EngineModeNodeAttribute.ENGINE_MODE_SETTING_KEY).get(good);
+
+        Settings bad = Settings.builder().put(EngineModeNodeAttribute.ENGINE_MODE_SETTING_KEY, "postgres").build();
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> Node.NODE_ATTRIBUTES.getConcreteSetting(EngineModeNodeAttribute.ENGINE_MODE_SETTING_KEY).get(bad)
+        );
+    }
+
+    public void testSettingKeyMatchesNodeAttrPrefix() {
+        assertEquals("node.attr.engine_mode", EngineModeNodeAttribute.ENGINE_MODE_SETTING_KEY);
+        assertEquals("engine_mode", EngineModeNodeAttribute.ENGINE_MODE_ATTRIBUTE_KEY);
+    }
+
+    private static DiscoveryNode makeNode(Map<String, String> attributes) throws UnknownHostException {
+        return new DiscoveryNode(
+            "n1",
+            new TransportAddress(InetAddress.getByName("localhost"), 9300),
+            attributes,
+            emptySet(),
+            Version.CURRENT
+        );
+    }
+}


### PR DESCRIPTION
### Description

Introduces a new node attribute, `node.attr.engine_mode`, that distinguishes which engine a data node runs. This is plumbing only — it lays the foundation for future engine-mode-aware behavior (engine selection, allocation awareness) without changing any current code paths.

**What ships**

- New `EngineModeNodeAttribute` class (`server/src/main/java/org/opensearch/node/EngineModeNodeAttribute.java`):
  - Constants: `ENGINE_MODE_ATTRIBUTE_KEY = "engine_mode"`, `ENGINE_MODE_SETTING_KEY = "node.attr.engine_mode"`.
  - `EngineMode` enum: `LUCENE` (default Lucene `InternalEngine`), `ANALYTICS` (DataFormat-aware analytics engine).
  - `parse(String)` / `get(DiscoveryNode | Map | Settings)` helpers — case-insensitive parsing; `null` / empty defaults to `LUCENE` to preserve pre-existing behavior.
  - `validate(String)` — throws `IllegalArgumentException` on unknown values.
- `Node.NODE_ATTRIBUTES` validator now delegates to `EngineModeNodeAttribute.validate(...)` for the `engine_mode` key, so an invalid value (e.g. `engine_mode: postgres`) fails fast at node startup rather than later.

**What this PR does NOT do**

- No engine selection wiring yet — `IndexService#getEngineFactory()` still picks the engine the same way it did before. Consuming the attribute to switch between Lucene and DataFormatAware engines is the natural follow-up.
- No allocation decider yet — nothing currently constrains which nodes can host analytics-mode indices.
- No cluster-join enforcement — the attribute is intentionally non-blocking; mixed-mode clusters are allowed. The included join-test (`testRemoteStoreClusterAcceptsMixedEngineModeDataNodes`) is a regression guard that asserts a remote-store/segment-replication cluster accepts both `engine_mode=lucene` and `engine_mode=analytics` data nodes through the full `JoinTaskExecutor#ensureNodesCompatibility` chain.

### Usage

```yaml
# opensearch.yml
node.attr.engine_mode: lucene     # default Lucene engine (also the implicit default if unset)
node.attr.engine_mode: analytics  # DataFormat-aware analytics engine
```

### Related Issues

<!-- N/A -->

### Check List

- [x] Functionality includes testing.
  - `EngineModeNodeAttributeTests` — defaults, parsing (case-insensitive), settings reads, validator rejects unknowns, and an end-to-end check that the value goes through the actual `Node.NODE_ATTRIBUTES` affix-setting validator.
  - `JoinTaskExecutorTests#testRemoteStoreClusterAcceptsMixedEngineModeDataNodes` — mixed-mode data nodes on a remote-store cluster pass `ensureNodesCompatibility` in both directions.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).