### PR TITLE
Only warn about disabled gateway.auto_import_dangling_indices when explicitly set

### DIFF
--- a/server/src/main/java/org/opensearch/gateway/DanglingIndicesState.java
+++ b/server/src/main/java/org/opensearch/gateway/DanglingIndicesState.java
@@ -42,6 +42,7 @@ import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.common.settings.Setting;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ConcurrentCollections;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.index.Index;
@@ -103,11 +104,15 @@ public class DanglingIndicesState implements ClusterStateListener {
         this.danglingIndicesAllocator = danglingIndicesAllocator;
         this.clusterService = clusterService;
 
-        this.isAutoImportDanglingIndicesEnabled = AUTO_IMPORT_DANGLING_INDICES_SETTING.get(clusterService.getSettings());
+        final Settings settings = clusterService.getSettings();
+        this.isAutoImportDanglingIndicesEnabled = AUTO_IMPORT_DANGLING_INDICES_SETTING.get(settings);
 
         if (this.isAutoImportDanglingIndicesEnabled) {
             clusterService.addListener(this);
-        } else {
+        } else if (AUTO_IMPORT_DANGLING_INDICES_SETTING.exists(settings)) {
+            // Only warn when the user has explicitly disabled the (deprecated) setting. The default
+            // value is already disabled, so emitting this warning on every startup with the default
+            // configuration is just noise.
             logger.warn(
                 AUTO_IMPORT_DANGLING_INDICES_SETTING.getKey()
                     + " is disabled, dangling indices will not be automatically detected or imported and must be managed manually"

--- a/server/src/test/java/org/opensearch/gateway/DanglingIndicesStateTests.java
+++ b/server/src/test/java/org/opensearch/gateway/DanglingIndicesStateTests.java
@@ -31,6 +31,8 @@
 
 package org.opensearch.gateway;
 
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.Version;
 import org.opensearch.cluster.metadata.AliasMetadata;
 import org.opensearch.cluster.metadata.IndexGraveyard;
@@ -40,6 +42,7 @@ import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.index.Index;
 import org.opensearch.env.NodeEnvironment;
+import org.opensearch.test.MockLogAppender;
 import org.opensearch.test.OpenSearchTestCase;
 import org.hamcrest.Matchers;
 
@@ -285,6 +288,65 @@ public class DanglingIndicesStateTests extends OpenSearchTestCase {
             new DanglingIndicesState(env, metaStateService, localAllocateDangledIndices, clusterServiceMock);
 
             verify(clusterServiceMock, never()).addListener(any());
+        }
+    }
+
+    /**
+     * Check that no warning is logged when the setting is left at its (disabled) default, since that
+     * would be noise on every startup with the default configuration.
+     */
+    public void testNoWarningWhenSettingUsesDefault() throws Exception {
+        try (
+            NodeEnvironment env = newNodeEnvironment();
+            MockLogAppender appender = MockLogAppender.createForLoggers(LogManager.getLogger(DanglingIndicesState.class))
+        ) {
+            appender.addExpectation(
+                new MockLogAppender.UnseenEventExpectation(
+                    "no warning on default settings",
+                    DanglingIndicesState.class.getCanonicalName(),
+                    Level.WARN,
+                    "*" + AUTO_IMPORT_DANGLING_INDICES_SETTING.getKey() + " is disabled*"
+                )
+            );
+
+            MetaStateService metaStateService = new MetaStateService(env, xContentRegistry());
+            LocalAllocateDangledIndices localAllocateDangledIndices = mock(LocalAllocateDangledIndices.class);
+            final ClusterService clusterServiceMock = mock(ClusterService.class);
+            when(clusterServiceMock.getSettings()).thenReturn(Settings.EMPTY);
+
+            new DanglingIndicesState(env, metaStateService, localAllocateDangledIndices, clusterServiceMock);
+
+            appender.assertAllExpectationsMatched();
+        }
+    }
+
+    /**
+     * Check that a warning is logged when the user has explicitly disabled the setting, so the
+     * operational consequence of their choice is still surfaced.
+     */
+    public void testWarningWhenSettingExplicitlyDisabled() throws Exception {
+        try (
+            NodeEnvironment env = newNodeEnvironment();
+            MockLogAppender appender = MockLogAppender.createForLoggers(LogManager.getLogger(DanglingIndicesState.class))
+        ) {
+            appender.addExpectation(
+                new MockLogAppender.SeenEventExpectation(
+                    "warning when explicitly disabled",
+                    DanglingIndicesState.class.getCanonicalName(),
+                    Level.WARN,
+                    "*" + AUTO_IMPORT_DANGLING_INDICES_SETTING.getKey() + " is disabled*"
+                )
+            );
+
+            MetaStateService metaStateService = new MetaStateService(env, xContentRegistry());
+            LocalAllocateDangledIndices localAllocateDangledIndices = mock(LocalAllocateDangledIndices.class);
+            final Settings settings = Settings.builder().put(AUTO_IMPORT_DANGLING_INDICES_SETTING.getKey(), false).build();
+            final ClusterService clusterServiceMock = mock(ClusterService.class);
+            when(clusterServiceMock.getSettings()).thenReturn(settings);
+
+            new DanglingIndicesState(env, metaStateService, localAllocateDangledIndices, clusterServiceMock);
+
+            appender.assertAllExpectationsMatched();
         }
     }
 


### PR DESCRIPTION
### Description

`DanglingIndicesState` logs a `WARN` on startup whenever auto-import of dangling indices is disabled:

> gateway.auto_import_dangling_indices is disabled, dangling indices will not be automatically detected or imported and must be managed manually

The `gateway.auto_import_dangling_indices` setting is **deprecated** and **defaults to `false` (disabled)**, so this warning is emitted on *every* startup with the default configuration — pure noise about a deprecated, intentionally-off feature.

This change only emits the warning when the setting has been **explicitly set** by the user (`Setting.exists(settings)`). Operators who deliberately disable it still see the operational consequence; default configurations stay quiet.

An alternative would be to downgrade the message to `INFO`. I went with suppress-on-default because the reporter's concern is specifically that the *default* configuration shouldn't produce the warning — happy to switch to the downgrade if maintainers prefer it.

(Aside: the docs state the default is `true` while the code default is `false`; that documentation mismatch lives in the `documentation-website` repo and is out of scope here.)

### Related Issues

Resolves #21330

### Check List

- [x] Functionality includes testing.
  - Added `DanglingIndicesStateTests#testNoWarningWhenSettingUsesDefault` (no warning on default config) and `#testWarningWhenSettingExplicitlyDisabled` (warning still emitted when explicitly disabled).
- [x] All commits are signed off (DCO).
- [x] Commit changes are listed out in CHANGELOG.md file (the CHANGELOG is no longer used as of 3.6, so no entry is required).
- [x] Public documentation issue/PR created — N/A.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
