### PR TITLE
[analytics-engine] Push non-aggregate sort below exchange

### DIFF
--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/PlannerImpl.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/PlannerImpl.java
@@ -81,7 +81,7 @@ public class PlannerImpl {
      * Package-private so planner rule tests can inspect the marked+optimized tree.
      */
     public static RelNode runAllOptimizations(RelNode rawRelNode, PlannerContext context) {
-        LOGGER.info("Input RelNode:\n{}", RelOptUtil.toString(rawRelNode));
+        LOGGER.debug("Input RelNode:\n{}", RelOptUtil.toString(rawRelNode));
 
         RuleProfilingListener listener = context.isProfilingEnabled() ? new RuleProfilingListener() : null;
 
@@ -92,7 +92,7 @@ public class PlannerImpl {
         modifiedRelNode = pushdownRules(modifiedRelNode, listener);
         modifiedRelNode = decomposeAggregates(modifiedRelNode, listener);
         modifiedRelNode = mark(modifiedRelNode, context, listener);
-        LOGGER.info("After marking:\n{}", RelOptUtil.toString(modifiedRelNode));
+        LOGGER.debug("After marking:\n{}", RelOptUtil.toString(modifiedRelNode));
         // TODO(combine-delegated-predicates): a post-marking HEP rule should fuse same-backend
         // AND-sibling AnnotatedPredicates into one combined predicate per group, collapsing N
         // FFM round-trips per RG into one. Blocked on two open design points:
@@ -103,21 +103,21 @@ public class PlannerImpl {
         // Revisit once those are designed. The rule would also strip performance peers from
         // AnnotatedPredicates under OR/NOT (Lucene call buys nothing in those positions).
         modifiedRelNode = cbo(modifiedRelNode, rawRelNode, context, listener);
-        LOGGER.info("After CBO:\n{}", RelOptUtil.toString(modifiedRelNode));
+        LOGGER.debug("After CBO:\n{}", RelOptUtil.toString(modifiedRelNode));
         Optional<RelNode> lateMat = OpenSearchLateMaterializationRewriter.rewrite(modifiedRelNode);
         if (lateMat.isPresent()) {
             modifiedRelNode = lateMat.get();
-            LOGGER.info("After late-materialization:\n{}", RelOptUtil.toString(modifiedRelNode));
+            LOGGER.debug("After late-materialization:\n{}", RelOptUtil.toString(modifiedRelNode));
         }
         Optional<RelNode> topK = OpenSearchTopKRewriter.rewrite(modifiedRelNode, context);
         if (topK.isPresent()) {
             modifiedRelNode = topK.get();
-            LOGGER.info("After TopK rewrite:\n{}", RelOptUtil.toString(modifiedRelNode));
+            LOGGER.debug("After TopK rewrite:\n{}", RelOptUtil.toString(modifiedRelNode));
         }
         Optional<RelNode> sortPushdown = OpenSearchSortPushdownRewriter.rewrite(modifiedRelNode);
         if (sortPushdown.isPresent()) {
             modifiedRelNode = sortPushdown.get();
-            LOGGER.info("After sort pushdown:\n{}", RelOptUtil.toString(modifiedRelNode));
+            LOGGER.debug("After sort pushdown:\n{}", RelOptUtil.toString(modifiedRelNode));
         }
 
         if (listener != null) {

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/PlannerImpl.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/PlannerImpl.java
@@ -36,6 +36,7 @@ import org.opensearch.analytics.planner.rules.OpenSearchJoinRule;
 import org.opensearch.analytics.planner.rules.OpenSearchJoinSplitRule;
 import org.opensearch.analytics.planner.rules.OpenSearchLateMaterializationRewriter;
 import org.opensearch.analytics.planner.rules.OpenSearchProjectRule;
+import org.opensearch.analytics.planner.rules.OpenSearchSortPushdownRewriter;
 import org.opensearch.analytics.planner.rules.OpenSearchSortRule;
 import org.opensearch.analytics.planner.rules.OpenSearchSortSplitRule;
 import org.opensearch.analytics.planner.rules.OpenSearchTableScanRule;
@@ -112,6 +113,11 @@ public class PlannerImpl {
         if (topK.isPresent()) {
             modifiedRelNode = topK.get();
             LOGGER.info("After TopK rewrite:\n{}", RelOptUtil.toString(modifiedRelNode));
+        }
+        Optional<RelNode> sortPushdown = OpenSearchSortPushdownRewriter.rewrite(modifiedRelNode);
+        if (sortPushdown.isPresent()) {
+            modifiedRelNode = sortPushdown.get();
+            LOGGER.info("After sort pushdown:\n{}", RelOptUtil.toString(modifiedRelNode));
         }
 
         if (listener != null) {

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchSortPushdownRewriter.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchSortPushdownRewriter.java
@@ -15,6 +15,7 @@ import org.apache.calcite.sql.type.SqlTypeName;
 import org.opensearch.analytics.planner.rel.AggregateMode;
 import org.opensearch.analytics.planner.rel.OpenSearchAggregate;
 import org.opensearch.analytics.planner.rel.OpenSearchExchangeReducer;
+import org.opensearch.analytics.planner.rel.OpenSearchJoin;
 import org.opensearch.analytics.planner.rel.OpenSearchSort;
 import org.opensearch.analytics.planner.rel.OpenSearchUnion;
 
@@ -120,8 +121,13 @@ public final class OpenSearchSortPushdownRewriter {
         return er.copy(er.getTraitSet(), List.of(shardSort));
     }
 
+    /**
+     * Eligible to push a Sort below: not the aggregate path, not already pushed, and not gathering a
+     * Join — joins are explicitly out of scope (a LIMIT cannot be safely pushed below a join).
+     */
     private static boolean eligibleER(OpenSearchExchangeReducer er) {
-        return isAggregatePath(er) == false && (er.getInput() instanceof OpenSearchSort) == false;
+        RelNode input = er.getInput();
+        return isAggregatePath(er) == false && (input instanceof OpenSearchSort) == false && (input instanceof OpenSearchJoin) == false;
     }
 
     /** True when the shard fetch is computable: no offset, or offset and fetch are both literals to sum. */

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchSortPushdownRewriter.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchSortPushdownRewriter.java
@@ -39,6 +39,10 @@ import java.util.Optional;
  * (PPL {@code sort | head}). Walks only the single-input coordinator spine and skips the aggregate
  * path (ER feeding a PARTIAL aggregate, owned by {@link OpenSearchTopKRewriter}).
  *
+ * <p>TODO: this is a temporary workaround. The correct approach is proper trait propagation in
+ * Calcite's Volcano planner (collation/limit pushdown through the exchange); replace this rewrite
+ * once that is in place.
+ *
  * @opensearch.internal
  */
 public final class OpenSearchSortPushdownRewriter {
@@ -46,7 +50,7 @@ public final class OpenSearchSortPushdownRewriter {
     private OpenSearchSortPushdownRewriter() {}
 
     public static Optional<RelNode> rewrite(RelNode root) {
-        Match m = find(root, null);
+        RewriteContext m = find(root, null);
         if (m == null) return Optional.empty();
         RelNode replacement = rewriteTarget(m.below, m.collated, shardFetch(m.bound));
         return replacement == null ? Optional.empty() : Optional.of(replaceInTree(root, m.below, replacement));
@@ -58,7 +62,7 @@ public final class OpenSearchSortPushdownRewriter {
      * immediately-enclosing pure-fetch Sort (carries the limit for the two-node PPL shape). Stops at
      * multi-input ops (other than a matched UNION ALL) and leaves.
      */
-    private static Match find(RelNode node, OpenSearchSort fetchSortAbove) {
+    private static RewriteContext find(RelNode node, OpenSearchSort fetchSortAbove) {
         if (node instanceof OpenSearchSort sort) {
             boolean collated = sort.getCollation().getFieldCollations().isEmpty() == false;
             if (collated) {
@@ -67,12 +71,15 @@ public final class OpenSearchSortPushdownRewriter {
                 OpenSearchSort bound = sort.fetch != null ? sort : (sort.offset == null ? fetchSortAbove : null);
                 RelNode below = sort.getInput();
                 if (bound != null && canComputeShardFetch(bound) && isPushTarget(below)) {
-                    return new Match(sort, bound, below);
+                    return new RewriteContext(sort, bound, below);
                 }
             }
             OpenSearchSort carry = (collated == false && sort.fetch != null) ? sort : null;
             return find(sort.getInput(), carry);
         }
+        // Follow only the single-input coordinator spine. Multi-input ops (Join) are intentionally
+        // not traversed — pushing a sort into one join branch is unsafe; UNION ALL is instead matched
+        // directly as a push target above (see isPushTarget).
         return node.getInputs().size() == 1 ? find(node.getInputs().get(0), null) : null;
     }
 
@@ -130,7 +137,10 @@ public final class OpenSearchSortPushdownRewriter {
         return isAggregatePath(er) == false && (input instanceof OpenSearchSort) == false && (input instanceof OpenSearchJoin) == false;
     }
 
-    /** True when the shard fetch is computable: no offset, or offset and fetch are both literals to sum. */
+    /**
+     * True when the shard fetch is computable: no offset, or offset and fetch are both literals to sum.
+     * TODO: support non-literal (complex expression) offset/fetch by summing as a RexNode — out of scope for now.
+     */
     private static boolean canComputeShardFetch(OpenSearchSort bound) {
         return bound.offset == null || (bound.offset instanceof RexLiteral && bound.fetch instanceof RexLiteral);
     }
@@ -161,6 +171,7 @@ public final class OpenSearchSortPushdownRewriter {
         return changed ? root.copy(root.getTraitSet(), List.of(newChildren)) : root;
     }
 
-    private record Match(OpenSearchSort collated, OpenSearchSort bound, RelNode below) {
+    /** Carries the matched collated Sort, the fetch-bounding Sort, and the target node to rewrite. */
+    private record RewriteContext(OpenSearchSort collated, OpenSearchSort bound, RelNode below) {
     }
 }

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchSortPushdownRewriter.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchSortPushdownRewriter.java
@@ -22,26 +22,15 @@ import java.util.Optional;
 
 /**
  * Post-CBO rewriter for non-aggregate TopK. Copies the bottom-most collated
- * {@link OpenSearchSort} to just below the {@link OpenSearchExchangeReducer}, so each
- * shard ships only its local top-N already-sorted rows. The coordinator Sort is left
- * intact to merge the per-shard streams and apply the final offset/limit.
+ * {@link OpenSearchSort} to just below the {@link OpenSearchExchangeReducer} so each shard
+ * ships only its local top-N sorted rows; the coordinator Sort still merges and applies the
+ * final offset/limit. Exact (no oversampling): a row in the global window is within its own
+ * shard's top-{@code (offset+fetch)}.
  *
- * <p>Two plan shapes collapse to "collated Sort directly above an ER, bounded by a fetch":
- * <pre>
- *   Sort(collation, [offset], fetch)        SQL: ORDER BY .. LIMIT N [OFFSET M]   (bound = the Sort)
- *     ER
- *
- *   Sort([offset], fetch) → Sort(collation) PPL: sort x | head N                  (bound = the outer Sort)
- *     ER
- * </pre>
- *
- * <p>Offset handling: a shard must NOT skip its own local rows, so the shard Sort drops
- * the offset and widens its fetch to {@code offset + fetch}; the offset stays only on the
- * coordinator. Exact (no oversampling): a row in the global window {@code [offset+1 ..
- * offset+fetch]} is within its own shard's top-{@code (offset+fetch)}.
- *
- * <p>Skips the aggregate path (ER feeding a PARTIAL aggregate) — that case belongs to
- * {@link OpenSearchTopKRewriter}.
+ * <p>Handles {@code Sort(collation,[offset,]fetch)} (SQL) and {@code Sort(fetch) → Sort(collation)}
+ * (PPL {@code sort | head}). Offset is not pushed — the shard fetch widens to {@code offset+fetch}
+ * and the offset stays on the coordinator. Walks only the single-input coordinator spine and skips
+ * the aggregate path (ER feeding a PARTIAL aggregate, owned by {@link OpenSearchTopKRewriter}).
  *
  * @opensearch.internal
  */
@@ -68,39 +57,34 @@ public final class OpenSearchSortPushdownRewriter {
     }
 
     /**
-     * Finds the bottom-most collated Sort sitting directly above an ER, bounded by a fetch.
-     * {@code fetchSortAbove} is an immediately-enclosing pure-fetch Sort (carries the limit
-     * for the two-node PPL shape).
+     * Walks the single-input coordinator spine for the bottom-most collated Sort directly above an
+     * ER, bounded by a fetch. {@code fetchSortAbove} is an immediately-enclosing pure-fetch Sort
+     * (carries the limit for the two-node PPL shape). Stops at multi-input ops (Join/Union) and leaves.
      */
     private static Match find(RelNode node, OpenSearchSort fetchSortAbove) {
         if (node instanceof OpenSearchSort sort) {
             boolean collated = sort.getCollation().getFieldCollations().isEmpty() == false;
             if (collated) {
-                // Bound = this Sort if it carries a fetch; else the enclosing pure-fetch Sort,
-                // but only when this Sort has no offset of its own (which we couldn't honor below).
+                // Bound = this Sort if it carries a fetch; else the enclosing pure-fetch Sort, but
+                // only when this Sort has no offset of its own (which the enclosing one can't honor).
                 OpenSearchSort bound = sort.fetch != null ? sort : (sort.offset == null ? fetchSortAbove : null);
                 RelNode below = sort.getInput();
                 if (bound != null
-                    && foldable(bound)
+                    && canComputeShardFetch(bound)
                     && below instanceof OpenSearchExchangeReducer er
                     && isAggregatePath(er) == false
                     && (er.getInput() instanceof OpenSearchSort) == false) {
                     return new Match(sort, bound, er);
                 }
             }
-            // A pure-fetch Sort (no collation, has fetch) carries its offset+fetch to its direct child.
             OpenSearchSort carry = (collated == false && sort.fetch != null) ? sort : null;
             return find(sort.getInput(), carry);
         }
-        for (RelNode child : node.getInputs()) {
-            Match m = find(child, null);
-            if (m != null) return m;
-        }
-        return null;
+        return node.getInputs().size() == 1 ? find(node.getInputs().get(0), null) : null;
     }
 
-    /** Foldable when there's no offset, or both offset and fetch are literals we can sum. */
-    private static boolean foldable(OpenSearchSort bound) {
+    /** True when the shard fetch is computable: no offset, or offset and fetch are both literals to sum. */
+    private static boolean canComputeShardFetch(OpenSearchSort bound) {
         return bound.offset == null || (bound.offset instanceof RexLiteral && bound.fetch instanceof RexLiteral);
     }
 

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchSortPushdownRewriter.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchSortPushdownRewriter.java
@@ -16,21 +16,27 @@ import org.opensearch.analytics.planner.rel.AggregateMode;
 import org.opensearch.analytics.planner.rel.OpenSearchAggregate;
 import org.opensearch.analytics.planner.rel.OpenSearchExchangeReducer;
 import org.opensearch.analytics.planner.rel.OpenSearchSort;
+import org.opensearch.analytics.planner.rel.OpenSearchUnion;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
 /**
  * Post-CBO rewriter for non-aggregate TopK. Copies the bottom-most collated
- * {@link OpenSearchSort} to just below the {@link OpenSearchExchangeReducer} so each shard
- * ships only its local top-N sorted rows; the coordinator Sort still merges and applies the
- * final offset/limit. Exact (no oversampling): a row in the global window is within its own
- * shard's top-{@code (offset+fetch)}.
+ * {@link OpenSearchSort} to just below the exchange so each shard ships only its local top-N
+ * sorted rows; the coordinator Sort still merges and applies the final offset/limit. Exact
+ * (no oversampling): a row in the global window is within its own shard's top-{@code (offset+fetch)}.
+ *
+ * <p>Targets a collated Sort sitting directly above either an {@link OpenSearchExchangeReducer}
+ * (scan case) or an {@code UNION ALL} {@link OpenSearchUnion} whose arms are each gathered by an
+ * ER — in which case the Sort is pushed below <em>every</em> arm's ER (arm row types match the
+ * union output, so the collation maps 1:1). Offset is not pushed: the shard fetch widens to
+ * {@code offset+fetch} and the offset stays on the coordinator.
  *
  * <p>Handles {@code Sort(collation,[offset,]fetch)} (SQL) and {@code Sort(fetch) → Sort(collation)}
- * (PPL {@code sort | head}). Offset is not pushed — the shard fetch widens to {@code offset+fetch}
- * and the offset stays on the coordinator. Walks only the single-input coordinator spine and skips
- * the aggregate path (ER feeding a PARTIAL aggregate, owned by {@link OpenSearchTopKRewriter}).
+ * (PPL {@code sort | head}). Walks only the single-input coordinator spine and skips the aggregate
+ * path (ER feeding a PARTIAL aggregate, owned by {@link OpenSearchTopKRewriter}).
  *
  * @opensearch.internal
  */
@@ -41,25 +47,15 @@ public final class OpenSearchSortPushdownRewriter {
     public static Optional<RelNode> rewrite(RelNode root) {
         Match m = find(root, null);
         if (m == null) return Optional.empty();
-
-        RelNode erInput = m.er.getInput();
-        OpenSearchSort shardSort = new OpenSearchSort(
-            m.collated.getCluster(),
-            erInput.getTraitSet(),
-            erInput,
-            m.collated.getCollation(),
-            null,
-            shardFetch(m.bound),
-            m.collated.getViableBackends()
-        );
-        RelNode newER = m.er.copy(m.er.getTraitSet(), List.of(shardSort));
-        return Optional.of(replaceInTree(root, m.er, newER));
+        RelNode replacement = rewriteTarget(m.below, m.collated, shardFetch(m.bound));
+        return replacement == null ? Optional.empty() : Optional.of(replaceInTree(root, m.below, replacement));
     }
 
     /**
-     * Walks the single-input coordinator spine for the bottom-most collated Sort directly above an
-     * ER, bounded by a fetch. {@code fetchSortAbove} is an immediately-enclosing pure-fetch Sort
-     * (carries the limit for the two-node PPL shape). Stops at multi-input ops (Join/Union) and leaves.
+     * Walks the single-input coordinator spine for the bottom-most collated Sort directly above a
+     * push target (an ER or UNION ALL), bounded by a fetch. {@code fetchSortAbove} is an
+     * immediately-enclosing pure-fetch Sort (carries the limit for the two-node PPL shape). Stops at
+     * multi-input ops (other than a matched UNION ALL) and leaves.
      */
     private static Match find(RelNode node, OpenSearchSort fetchSortAbove) {
         if (node instanceof OpenSearchSort sort) {
@@ -69,18 +65,63 @@ public final class OpenSearchSortPushdownRewriter {
                 // only when this Sort has no offset of its own (which the enclosing one can't honor).
                 OpenSearchSort bound = sort.fetch != null ? sort : (sort.offset == null ? fetchSortAbove : null);
                 RelNode below = sort.getInput();
-                if (bound != null
-                    && canComputeShardFetch(bound)
-                    && below instanceof OpenSearchExchangeReducer er
-                    && isAggregatePath(er) == false
-                    && (er.getInput() instanceof OpenSearchSort) == false) {
-                    return new Match(sort, bound, er);
+                if (bound != null && canComputeShardFetch(bound) && isPushTarget(below)) {
+                    return new Match(sort, bound, below);
                 }
             }
             OpenSearchSort carry = (collated == false && sort.fetch != null) ? sort : null;
             return find(sort.getInput(), carry);
         }
         return node.getInputs().size() == 1 ? find(node.getInputs().get(0), null) : null;
+    }
+
+    /** A node we can push a Sort below: an eligible ER, or a UNION ALL with at least one eligible ER arm. */
+    private static boolean isPushTarget(RelNode below) {
+        if (below instanceof OpenSearchExchangeReducer er) return eligibleER(er);
+        if (below instanceof OpenSearchUnion union && union.all) {
+            for (RelNode arm : union.getInputs()) {
+                if (arm instanceof OpenSearchExchangeReducer er && eligibleER(er)) return true;
+            }
+        }
+        return false;
+    }
+
+    /** Rebuilds the target with the shard Sort pushed below the ER (scan case) or below each arm's ER (union). */
+    private static RelNode rewriteTarget(RelNode below, OpenSearchSort collated, RexNode fetch) {
+        if (below instanceof OpenSearchExchangeReducer er) {
+            return pushBelow(er, collated, fetch);
+        }
+        OpenSearchUnion union = (OpenSearchUnion) below;
+        List<RelNode> arms = new ArrayList<>(union.getInputs().size());
+        boolean pushed = false;
+        for (RelNode arm : union.getInputs()) {
+            if (arm instanceof OpenSearchExchangeReducer er && eligibleER(er)) {
+                arms.add(pushBelow(er, collated, fetch));
+                pushed = true;
+            } else {
+                arms.add(arm);
+            }
+        }
+        return pushed ? union.copy(union.getTraitSet(), arms, union.all) : null;
+    }
+
+    /** ER with the shard Sort inserted between it and its input. */
+    private static RelNode pushBelow(OpenSearchExchangeReducer er, OpenSearchSort collated, RexNode fetch) {
+        RelNode erInput = er.getInput();
+        OpenSearchSort shardSort = new OpenSearchSort(
+            collated.getCluster(),
+            erInput.getTraitSet(),
+            erInput,
+            collated.getCollation(),
+            null,
+            fetch,
+            collated.getViableBackends()
+        );
+        return er.copy(er.getTraitSet(), List.of(shardSort));
+    }
+
+    private static boolean eligibleER(OpenSearchExchangeReducer er) {
+        return isAggregatePath(er) == false && (er.getInput() instanceof OpenSearchSort) == false;
     }
 
     /** True when the shard fetch is computable: no offset, or offset and fetch are both literals to sum. */
@@ -114,6 +155,6 @@ public final class OpenSearchSortPushdownRewriter {
         return changed ? root.copy(root.getTraitSet(), List.of(newChildren)) : root;
     }
 
-    private record Match(OpenSearchSort collated, OpenSearchSort bound, OpenSearchExchangeReducer er) {
+    private record Match(OpenSearchSort collated, OpenSearchSort bound, RelNode below) {
     }
 }

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchSortPushdownRewriter.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchSortPushdownRewriter.java
@@ -1,0 +1,135 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.planner.rules;
+
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.opensearch.analytics.planner.rel.AggregateMode;
+import org.opensearch.analytics.planner.rel.OpenSearchAggregate;
+import org.opensearch.analytics.planner.rel.OpenSearchExchangeReducer;
+import org.opensearch.analytics.planner.rel.OpenSearchSort;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Post-CBO rewriter for non-aggregate TopK. Copies the bottom-most collated
+ * {@link OpenSearchSort} to just below the {@link OpenSearchExchangeReducer}, so each
+ * shard ships only its local top-N already-sorted rows. The coordinator Sort is left
+ * intact to merge the per-shard streams and apply the final offset/limit.
+ *
+ * <p>Two plan shapes collapse to "collated Sort directly above an ER, bounded by a fetch":
+ * <pre>
+ *   Sort(collation, [offset], fetch)        SQL: ORDER BY .. LIMIT N [OFFSET M]   (bound = the Sort)
+ *     ER
+ *
+ *   Sort([offset], fetch) → Sort(collation) PPL: sort x | head N                  (bound = the outer Sort)
+ *     ER
+ * </pre>
+ *
+ * <p>Offset handling: a shard must NOT skip its own local rows, so the shard Sort drops
+ * the offset and widens its fetch to {@code offset + fetch}; the offset stays only on the
+ * coordinator. Exact (no oversampling): a row in the global window {@code [offset+1 ..
+ * offset+fetch]} is within its own shard's top-{@code (offset+fetch)}.
+ *
+ * <p>Skips the aggregate path (ER feeding a PARTIAL aggregate) — that case belongs to
+ * {@link OpenSearchTopKRewriter}.
+ *
+ * @opensearch.internal
+ */
+public final class OpenSearchSortPushdownRewriter {
+
+    private OpenSearchSortPushdownRewriter() {}
+
+    public static Optional<RelNode> rewrite(RelNode root) {
+        Match m = find(root, null);
+        if (m == null) return Optional.empty();
+
+        RelNode erInput = m.er.getInput();
+        OpenSearchSort shardSort = new OpenSearchSort(
+            m.collated.getCluster(),
+            erInput.getTraitSet(),
+            erInput,
+            m.collated.getCollation(),
+            null,
+            shardFetch(m.bound),
+            m.collated.getViableBackends()
+        );
+        RelNode newER = m.er.copy(m.er.getTraitSet(), List.of(shardSort));
+        return Optional.of(replaceInTree(root, m.er, newER));
+    }
+
+    /**
+     * Finds the bottom-most collated Sort sitting directly above an ER, bounded by a fetch.
+     * {@code fetchSortAbove} is an immediately-enclosing pure-fetch Sort (carries the limit
+     * for the two-node PPL shape).
+     */
+    private static Match find(RelNode node, OpenSearchSort fetchSortAbove) {
+        if (node instanceof OpenSearchSort sort) {
+            boolean collated = sort.getCollation().getFieldCollations().isEmpty() == false;
+            if (collated) {
+                // Bound = this Sort if it carries a fetch; else the enclosing pure-fetch Sort,
+                // but only when this Sort has no offset of its own (which we couldn't honor below).
+                OpenSearchSort bound = sort.fetch != null ? sort : (sort.offset == null ? fetchSortAbove : null);
+                RelNode below = sort.getInput();
+                if (bound != null
+                    && foldable(bound)
+                    && below instanceof OpenSearchExchangeReducer er
+                    && isAggregatePath(er) == false
+                    && (er.getInput() instanceof OpenSearchSort) == false) {
+                    return new Match(sort, bound, er);
+                }
+            }
+            // A pure-fetch Sort (no collation, has fetch) carries its offset+fetch to its direct child.
+            OpenSearchSort carry = (collated == false && sort.fetch != null) ? sort : null;
+            return find(sort.getInput(), carry);
+        }
+        for (RelNode child : node.getInputs()) {
+            Match m = find(child, null);
+            if (m != null) return m;
+        }
+        return null;
+    }
+
+    /** Foldable when there's no offset, or both offset and fetch are literals we can sum. */
+    private static boolean foldable(OpenSearchSort bound) {
+        return bound.offset == null || (bound.offset instanceof RexLiteral && bound.fetch instanceof RexLiteral);
+    }
+
+    /** Shard fetch = fetch when there's no offset, else offset + fetch (offset stays on the coordinator). */
+    private static RexNode shardFetch(OpenSearchSort bound) {
+        if (bound.offset == null) return bound.fetch;
+        int sum = RexLiteral.intValue(bound.offset) + RexLiteral.intValue(bound.fetch);
+        return bound.getCluster()
+            .getRexBuilder()
+            .makeLiteral(sum, bound.getCluster().getTypeFactory().createSqlType(SqlTypeName.INTEGER), true);
+    }
+
+    private static boolean isAggregatePath(OpenSearchExchangeReducer er) {
+        return er.getInput() instanceof OpenSearchAggregate agg && agg.getMode() == AggregateMode.PARTIAL;
+    }
+
+    /** Replaces oldNode with newNode in the tree (single occurrence), rebuilding ancestors. */
+    private static RelNode replaceInTree(RelNode root, RelNode oldNode, RelNode newNode) {
+        if (root == oldNode) return newNode;
+        List<RelNode> children = root.getInputs();
+        RelNode[] newChildren = new RelNode[children.size()];
+        boolean changed = false;
+        for (int i = 0; i < children.size(); i++) {
+            newChildren[i] = replaceInTree(children.get(i), oldNode, newNode);
+            if (newChildren[i] != children.get(i)) changed = true;
+        }
+        return changed ? root.copy(root.getTraitSet(), List.of(newChildren)) : root;
+    }
+
+    private record Match(OpenSearchSort collated, OpenSearchSort bound, OpenSearchExchangeReducer er) {
+    }
+}

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchSortPushdownRewriter.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchSortPushdownRewriter.java
@@ -85,10 +85,10 @@ public final class OpenSearchSortPushdownRewriter {
 
     /** A node we can push a Sort below: an eligible ER, or a UNION ALL with at least one eligible ER arm. */
     private static boolean isPushTarget(RelNode below) {
-        if (below instanceof OpenSearchExchangeReducer er) return eligibleER(er);
+        if (below instanceof OpenSearchExchangeReducer er) return eligibleChildBelowER(er);
         if (below instanceof OpenSearchUnion union && union.all) {
             for (RelNode arm : union.getInputs()) {
-                if (arm instanceof OpenSearchExchangeReducer er && eligibleER(er)) return true;
+                if (arm instanceof OpenSearchExchangeReducer er && eligibleChildBelowER(er)) return true;
             }
         }
         return false;
@@ -103,7 +103,7 @@ public final class OpenSearchSortPushdownRewriter {
         List<RelNode> arms = new ArrayList<>(union.getInputs().size());
         boolean pushed = false;
         for (RelNode arm : union.getInputs()) {
-            if (arm instanceof OpenSearchExchangeReducer er && eligibleER(er)) {
+            if (arm instanceof OpenSearchExchangeReducer er && eligibleChildBelowER(er)) {
                 arms.add(pushBelow(er, collated, fetch));
                 pushed = true;
             } else {
@@ -132,7 +132,7 @@ public final class OpenSearchSortPushdownRewriter {
      * Eligible to push a Sort below: not the aggregate path, not already pushed, and not gathering a
      * Join — joins are explicitly out of scope (a LIMIT cannot be safely pushed below a join).
      */
-    private static boolean eligibleER(OpenSearchExchangeReducer er) {
+    private static boolean eligibleChildBelowER(OpenSearchExchangeReducer er) {
         RelNode input = er.getInput();
         return isAggregatePath(er) == false && (input instanceof OpenSearchSort) == false && (input instanceof OpenSearchJoin) == false;
     }

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/PlanShapeTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/PlanShapeTests.java
@@ -294,13 +294,15 @@ public class PlanShapeTests extends PlanShapeTestBase {
         RelNode result = runPlanner(limit, buildContext("parquet", 3, fields));
         // SORT_PROJECT_TRANSPOSE pushes the outer pure-LIMIT Sort below the identity Project,
         // producing the QTF-friendly two-Sort shape Project(identity) ← Sort(fetch) ← Sort(coll) ← ER.
+        // The sort-pushdown rewriter then copies the collated Sort (with the outer fetch) below the ER.
         assertPlanShape(
             """
                 OpenSearchProject(name=[$0], score=[$1], viableBackends=[[mock-parquet]])
                   OpenSearchSort(fetch=[3], viableBackends=[[mock-parquet]])
                     OpenSearchSort(sort0=[$1], dir0=[ASC], viableBackends=[[mock-parquet]])
                       OpenSearchExchangeReducer(viableBackends=[[mock-parquet]], exchange=[ExchangeInfo[distributionType=SINGLETON, partitionKeyIndices=[]]])
-                        OpenSearchTableScan(table=[[test_index]], viableBackends=[[mock-parquet]])
+                        OpenSearchSort(sort0=[$1], dir0=[ASC], fetch=[3], viableBackends=[[mock-parquet]])
+                          OpenSearchTableScan(table=[[test_index]], viableBackends=[[mock-parquet]])
                 """,
             result
         );

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/SortPlanShapeTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/SortPlanShapeTests.java
@@ -112,7 +112,8 @@ public class SortPlanShapeTests extends PlanShapeTestBase {
                 OpenSearchSort(fetch=[10], viableBackends=[[mock-parquet]])
                   OpenSearchSort(sort0=[$0], dir0=[ASC], viableBackends=[[mock-parquet]])
                     OpenSearchExchangeReducer(viableBackends=[[mock-parquet]], exchange=[ExchangeInfo[distributionType=SINGLETON, partitionKeyIndices=[]]])
-                      OpenSearchTableScan(table=[[test_index]], viableBackends=[[mock-parquet]])
+                      OpenSearchSort(sort0=[$0], dir0=[ASC], fetch=[10], viableBackends=[[mock-parquet]])
+                        OpenSearchTableScan(table=[[test_index]], viableBackends=[[mock-parquet]])
                 """,
             result
         );

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/SortPushdownPlanShapeTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/SortPushdownPlanShapeTests.java
@@ -1,0 +1,135 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.planner;
+
+import org.apache.calcite.plan.RelOptUtil;
+import org.apache.calcite.rel.RelCollations;
+import org.apache.calcite.rel.RelFieldCollation;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.logical.LogicalSort;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.util.ImmutableBitSet;
+
+import java.util.List;
+
+/**
+ * Plan-shape tests for {@link org.opensearch.analytics.planner.rules.OpenSearchSortPushdownRewriter}.
+ *
+ * <p>Fires for non-aggregate {@code ORDER BY .. LIMIT}: a copy of the collated Sort
+ * (with its effective fetch) is inserted below the ER so shards ship local top-N.
+ */
+public class SortPushdownPlanShapeTests extends PlanShapeTestBase {
+
+    private RelNode fetchLiteralSort(RelNode input, int fetch) {
+        return LogicalSort.create(
+            input,
+            RelCollations.of(new RelFieldCollation(0, RelFieldCollation.Direction.ASCENDING)),
+            null,
+            rexBuilder.makeLiteral(fetch, typeFactory.createSqlType(SqlTypeName.INTEGER), true)
+        );
+    }
+
+    /** SQL shape: single Sort(collation, fetch) → identical Sort pushed below ER.
+     *  (A LateMaterialization node wraps the top for scans with stored fields — incidental.) */
+    public void testSqlSortLimit_2shard_pushed() {
+        RelNode scan = stubScan(mockTable("test_index", "status", "size"));
+        RelNode result = runPlanner(fetchLiteralSort(scan, 10), multiShardContext());
+        assertPlanShape(
+            """
+                OpenSearchLateMaterialization(aboveAnchorPhysicalFields=[[status, size]], viableBackends=[[mock-parquet]])
+                  OpenSearchSort(sort0=[$0], dir0=[ASC], fetch=[10], viableBackends=[[mock-parquet]])
+                    OpenSearchExchangeReducer(viableBackends=[[mock-parquet]], exchange=[ExchangeInfo[distributionType=SINGLETON, partitionKeyIndices=[]]])
+                      OpenSearchSort(sort0=[$0], dir0=[ASC], fetch=[10], viableBackends=[[mock-parquet]])
+                        OpenSearchTableScan(table=[[test_index]], viableBackends=[[mock-parquet]])
+                """,
+            result
+        );
+    }
+
+    /** PPL shape: outer pure-fetch over inner collated → shard Sort gets inner collation + outer fetch. */
+    public void testPplSortHead_2shard_pushed() {
+        RelNode scan = stubScan(mockTable("test_index", "status", "size"));
+        RelNode innerSort = LogicalSort.create(
+            scan,
+            RelCollations.of(new RelFieldCollation(0, RelFieldCollation.Direction.ASCENDING)),
+            null,
+            null
+        );
+        RelNode outerLimit = LogicalSort.create(
+            innerSort,
+            RelCollations.EMPTY,
+            null,
+            rexBuilder.makeLiteral(10, typeFactory.createSqlType(SqlTypeName.INTEGER), true)
+        );
+        RelNode result = runPlanner(outerLimit, multiShardContext());
+        assertPlanShape(
+            """
+                OpenSearchSort(fetch=[10], viableBackends=[[mock-parquet]])
+                  OpenSearchSort(sort0=[$0], dir0=[ASC], viableBackends=[[mock-parquet]])
+                    OpenSearchExchangeReducer(viableBackends=[[mock-parquet]], exchange=[ExchangeInfo[distributionType=SINGLETON, partitionKeyIndices=[]]])
+                      OpenSearchSort(sort0=[$0], dir0=[ASC], fetch=[10], viableBackends=[[mock-parquet]])
+                        OpenSearchTableScan(table=[[test_index]], viableBackends=[[mock-parquet]])
+                """,
+            result
+        );
+    }
+
+    /** SQL shape with OFFSET: shard Sort drops the offset and widens fetch to offset+fetch; coordinator keeps offset. */
+    public void testSqlSortLimitOffset_2shard_widenedFetch() {
+        RelNode scan = stubScan(mockTable("test_index", "status", "size"));
+        RelNode plan = LogicalSort.create(
+            scan,
+            RelCollations.of(new RelFieldCollation(0, RelFieldCollation.Direction.ASCENDING)),
+            rexBuilder.makeLiteral(5, typeFactory.createSqlType(SqlTypeName.INTEGER), true),
+            rexBuilder.makeLiteral(10, typeFactory.createSqlType(SqlTypeName.INTEGER), true)
+        );
+        String p = org.apache.calcite.plan.RelOptUtil.toString(runPlanner(plan, multiShardContext()));
+        assertEquals("coord + shard Sort", 2, p.lines().filter(l -> l.contains("OpenSearchSort")).count());
+        assertTrue("coordinator keeps offset=5", p.contains("offset=[5]"));
+        int erIdx = p.indexOf("ExchangeReducer");
+        int widenedIdx = p.indexOf("fetch=[15]");
+        assertTrue("shard Sort widened to offset+fetch=15 below ER", erIdx >= 0 && widenedIdx > erIdx);
+        assertFalse("shard Sort must not carry an offset", p.substring(widenedIdx).contains("offset="));
+    }
+
+    /** Collated Sort with no fetch → no transport bound → not pushed. */
+    public void testNoFetch_notPushed() {
+        RelNode scan = stubScan(mockTable("test_index", "status", "size"));
+        RelNode plan = LogicalSort.create(
+            scan,
+            RelCollations.of(new RelFieldCollation(0, RelFieldCollation.Direction.ASCENDING)),
+            null,
+            null
+        );
+        RelNode result = runPlanner(plan, multiShardContext());
+        assertEquals(1, RelOptUtil.toString(result).lines().filter(l -> l.contains("OpenSearchSort")).count());
+    }
+
+    /** Single shard has no ER → nothing to push below. */
+    public void testSingleShard_notPushed() {
+        RelNode scan = stubScan(mockTable("test_index", "status", "size"));
+        RelNode result = runPlanner(fetchLiteralSort(scan, 10), singleShardContext());
+        assertEquals(1, RelOptUtil.toString(result).lines().filter(l -> l.contains("OpenSearchSort")).count());
+    }
+
+    /** Aggregate path (Sort over grouped COUNT) is owned by the TopK rewriter — this rewriter must not add a Sort. */
+    public void testAggregatePath_notTouched() {
+        RelNode scan = stubScan(mockTable("test_index", "status", "size"));
+        RelNode agg = org.apache.calcite.rel.logical.LogicalAggregate.create(
+            scan,
+            List.of(),
+            ImmutableBitSet.of(0),
+            null,
+            List.of(countStarCall())
+        );
+        RelNode result = runPlanner(fetchLiteralSort(agg, 10), multiShardContext());
+        // Only the coordinator Sort — no per-partition Sort from this rewriter (oversampling default 0 disables TopK too).
+        assertEquals(1, RelOptUtil.toString(result).lines().filter(l -> l.contains("OpenSearchSort")).count());
+    }
+}

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/SortPushdownPlanShapeTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/SortPushdownPlanShapeTests.java
@@ -13,6 +13,7 @@ import org.apache.calcite.rel.RelCollations;
 import org.apache.calcite.rel.RelFieldCollation;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.logical.LogicalSort;
+import org.apache.calcite.rel.logical.LogicalUnion;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.util.ImmutableBitSet;
 
@@ -98,6 +99,23 @@ public class SortPushdownPlanShapeTests extends PlanShapeTestBase {
         assertFalse("shard Sort must not carry an offset", p.substring(widenedIdx).contains("offset="));
     }
 
+    /** UNION ALL: the collated sort is pushed below each arm's ER (split at each point). */
+    public void testUnionAll_2shard_pushedIntoBothArms() {
+        RelNode union = LogicalUnion.create(
+            List.of(stubScan(mockTable("test_index", "status", "size")), stubScan(mockTable("test_index", "status", "size"))),
+            true
+        );
+        String p = RelOptUtil.toString(runPlanner(fetchLiteralSort(union, 10), unionContext("test_index", 2)));
+        assertEquals("coordinator + one Sort per arm, plan:\n" + p, 3, p.lines().filter(l -> l.contains("OpenSearchSort")).count());
+        assertEquals("one ER per arm, plan:\n" + p, 2, p.lines().filter(l -> l.contains("ExchangeReducer")).count());
+        String[] lines = p.split("\n", -1);
+        for (int i = 0; i + 1 < lines.length; i++) {
+            if (lines[i].contains("ExchangeReducer")) {
+                assertTrue("a Sort must be pushed below each arm ER, plan:\n" + p, lines[i + 1].contains("OpenSearchSort"));
+            }
+        }
+    }
+
     /** Collated Sort with no fetch → no transport bound → not pushed. */
     public void testNoFetch_notPushed() {
         RelNode scan = stubScan(mockTable("test_index", "status", "size"));
@@ -131,5 +149,26 @@ public class SortPushdownPlanShapeTests extends PlanShapeTestBase {
         RelNode result = runPlanner(fetchLiteralSort(agg, 10), multiShardContext());
         // Only the coordinator Sort — no per-partition Sort from this rewriter (oversampling default 0 disables TopK too).
         assertEquals(1, RelOptUtil.toString(result).lines().filter(l -> l.contains("OpenSearchSort")).count());
+    }
+
+    /** Context whose DataFusion backend declares EngineCapability.UNION (mirrors PlanShapeTests). */
+    private PlannerContext unionContext(String indexName, int shardCount) {
+        return buildContextPerIndex(
+            "parquet",
+            java.util.Map.of(indexName, shardCount),
+            intFields(),
+            List.of(new UnionCapableBackend(), LUCENE)
+        );
+    }
+
+    private static final class UnionCapableBackend extends MockDataFusionBackend {
+        @Override
+        protected java.util.Set<org.opensearch.analytics.spi.EngineCapability> supportedEngineCapabilities() {
+            java.util.Set<org.opensearch.analytics.spi.EngineCapability> caps = new java.util.HashSet<>(
+                super.supportedEngineCapabilities()
+            );
+            caps.add(org.opensearch.analytics.spi.EngineCapability.UNION);
+            return caps;
+        }
     }
 }

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/SortPushdownPlanShapeTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/SortPushdownPlanShapeTests.java
@@ -14,6 +14,7 @@ import org.apache.calcite.rel.RelFieldCollation;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.logical.LogicalSort;
 import org.apache.calcite.rel.logical.LogicalUnion;
+import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.util.ImmutableBitSet;
 
@@ -114,6 +115,27 @@ public class SortPushdownPlanShapeTests extends PlanShapeTestBase {
                 assertTrue("a Sort must be pushed below each arm ER, plan:\n" + p, lines[i + 1].contains("OpenSearchSort"));
             }
         }
+    }
+
+    /** Sort over a Join is not pushed — joins are explicitly out of scope. */
+    public void testJoin_notPushed() {
+        RexNode cond = rexBuilder.makeCall(
+            org.apache.calcite.sql.fun.SqlStdOperatorTable.EQUALS,
+            rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.INTEGER), 0),
+            rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.INTEGER), 2)
+        );
+        RelNode join = org.apache.calcite.rel.logical.LogicalJoin.create(
+            stubScan(mockTable("left_idx", "status", "size")),
+            stubScan(mockTable("right_idx", "status", "size")),
+            List.of(),
+            cond,
+            java.util.Set.of(),
+            org.apache.calcite.rel.core.JoinRelType.INNER
+        );
+        String p = RelOptUtil.toString(
+            runPlanner(fetchLiteralSort(join, 10), perIndexContext(java.util.Map.of("left_idx", 1, "right_idx", 1)))
+        );
+        assertEquals("no Sort pushed below a join, plan:\n" + p, 1, p.lines().filter(l -> l.contains("OpenSearchSort")).count());
     }
 
     /** Collated Sort with no fetch → no transport bound → not pushed. */

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/TopKRewriterPlanShapeTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/TopKRewriterPlanShapeTests.java
@@ -41,7 +41,7 @@ public class TopKRewriterPlanShapeTests extends PlanShapeTestBase {
         assertEquals("expected 1 Sort (coord only)", 1, sortCount);
     }
 
-    /** No aggregate in plan → no per-partition Sort. */
+    /** No aggregate in plan → TopK must not fire (sort-pushdown may add a shard Sort, which is fine). */
     public void testDetection_noAggregate_skipped() {
         RelOptTable table = mockTable("test_index", "status", "size");
         RelNode scan = stubScan(table);
@@ -53,8 +53,7 @@ public class TopKRewriterPlanShapeTests extends PlanShapeTestBase {
         );
         RelNode result = runPlanner(sort, contextWithOversampling(2.0));
         String plan = RelOptUtil.toString(result);
-        long sortCount = plan.lines().filter(l -> l.contains("OpenSearchSort")).count();
-        assertEquals("no per-partition Sort for non-aggregate query", 1, sortCount);
+        assertFalse("no aggregate → TopK must not fire", plan.contains("OpenSearchAggregate"));
     }
 
     /** Aggregate without group-by (scalar agg) → skip. */

--- a/sandbox/qa/analytics-engine-coordinator/src/internalClusterTest/java/org/opensearch/be/datafusion/QtfSubstraitDumpIT.java
+++ b/sandbox/qa/analytics-engine-coordinator/src/internalClusterTest/java/org/opensearch/be/datafusion/QtfSubstraitDumpIT.java
@@ -67,6 +67,8 @@ import java.util.Properties;
 import io.substrait.extension.DefaultExtensionCatalog;
 import io.substrait.extension.SimpleExtension;
 import io.substrait.proto.Plan;
+import io.substrait.proto.ReadRel;
+import io.substrait.proto.Rel;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -158,11 +160,25 @@ public class QtfSubstraitDumpIT extends OpenSearchTestCase {
         byte[] bytes = scan.getPlanAlternatives().getFirst().convertedBytes();
         Plan plan = Plan.parseFrom(bytes);
 
-        List<String> baseSchemaNames = plan.getRelations(0).getRoot().getInput().getRead().getBaseSchema().getNamesList();
+        // The Read may be wrapped by the per-shard Sort/Fetch that sort pushdown inserts; find it.
+        List<String> baseSchemaNames = findRead(plan.getRelations(0).getRoot().getInput()).getBaseSchema().getNamesList();
         assertTrue(
             "Stage 0 base_schema must include __row_id__; got " + baseSchemaNames,
             baseSchemaNames.contains("__row_id__")
         );
+    }
+
+    /** Walks single-input Substrait rels (Fetch/Sort/Project/Filter/Aggregate) down to the ReadRel. */
+    private static ReadRel findRead(Rel rel) {
+        return switch (rel.getRelTypeCase()) {
+            case READ -> rel.getRead();
+            case FETCH -> findRead(rel.getFetch().getInput());
+            case SORT -> findRead(rel.getSort().getInput());
+            case PROJECT -> findRead(rel.getProject().getInput());
+            case FILTER -> findRead(rel.getFilter().getInput());
+            case AGGREGATE -> findRead(rel.getAggregate().getInput());
+            default -> throw new AssertionError("no ReadRel found, hit " + rel.getRelTypeCase());
+        };
     }
 
     /**

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/SortPushdownIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/SortPushdownIT.java
@@ -1,0 +1,125 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.qa;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * End-to-end correctness for non-aggregate sort pushdown on a multi-shard index.
+ * With the rewriter active, each shard ships only its local top-N already-sorted
+ * rows; the coordinator merges them. These tests assert the merged result is the
+ * correct, globally-ordered top-N (catches dropped rows / wrong ordering).
+ */
+public class SortPushdownIT extends AnalyticsRestTestCase {
+
+    private static volatile boolean provisioned = false;
+    private static final String INDEX = "parquet_hits";
+    private static final String COL = "ResolutionWidth";
+
+    private void ensureProvisioned() throws Exception {
+        if (provisioned == false) {
+            DatasetProvisioner.provision(client(), ClickBenchTestHelper.DATASET, 2);
+            provisioned = true;
+        }
+    }
+
+    /** sort desc + head 10 → global top-10, descending. Top row must equal the global max. */
+    public void testSortDescHead_globalTopN() throws Exception {
+        ensureProvisioned();
+        List<List<Object>> rows = datarows(executePpl("source = " + INDEX + " | sort - " + COL + " | head 10 | fields " + COL));
+        assertEquals(10, rows.size());
+        assertMonotonic(rows, false);
+        assertEquals("top row must equal global max", globalAgg("max", null), num(rows.get(0).get(0)), 0.0);
+    }
+
+    /** sort asc + head 10 → global bottom-10, ascending. Top row must equal the global min. */
+    public void testSortAscHead_globalBottomN() throws Exception {
+        ensureProvisioned();
+        List<List<Object>> rows = datarows(executePpl("source = " + INDEX + " | sort " + COL + " | head 10 | fields " + COL));
+        assertEquals(10, rows.size());
+        assertMonotonic(rows, true);
+        assertEquals("top row must equal global min", globalAgg("min", null), num(rows.get(0).get(0)), 0.0);
+    }
+
+    /** Multi-key sort: lexicographic ordering (primary asc, secondary asc on ties) survives the exchange. */
+    public void testMultiKeySort_lexicographicOrder() throws Exception {
+        ensureProvisioned();
+        List<List<Object>> rows = datarows(
+            executePpl("source = " + INDEX + " | sort " + COL + ", AdvEngineID | head 20 | fields " + COL + ", AdvEngineID")
+        );
+        assertTrue("expected 1..20 rows", rows.size() > 0 && rows.size() <= 20);
+        for (int i = 1; i < rows.size(); i++) {
+            double p0 = num(rows.get(i - 1).get(0)), p1 = num(rows.get(i).get(0));
+            assertTrue("primary key ascending at " + i, p0 <= p1);
+            if (p0 == p1) {
+                assertTrue("secondary key ascending on tie at " + i, num(rows.get(i - 1).get(1)) <= num(rows.get(i).get(1)));
+            }
+        }
+    }
+
+    /** Sort + WHERE: pushdown coexists with filter delegation; result is the filtered global top-N. */
+    public void testSortWithFilter_globalTopN() throws Exception {
+        ensureProvisioned();
+        String where = "where " + COL + " > 0";
+        long filtered = (long) globalAgg("count", where);
+        List<List<Object>> rows = datarows(executePpl("source = " + INDEX + " | " + where + " | sort - " + COL + " | head 10 | fields " + COL));
+        assertEquals(Math.min(10, filtered), rows.size());
+        assertMonotonic(rows, false);
+        if (filtered > 0) {
+            assertEquals("top must equal filtered max", globalAgg("max", where), num(rows.get(0).get(0)), 0.0);
+            for (List<Object> r : rows) {
+                assertTrue("every row satisfies the filter", num(r.get(0)) > 0);
+            }
+        }
+    }
+
+    /** Pure LIMIT (no ORDER BY): rewriter must skip; coordinator still bounds the result to N globally. */
+    public void testPureLimit_noSort_count() throws Exception {
+        ensureProvisioned();
+        long total = (long) globalAgg("count", null);
+        List<List<Object>> rows = datarows(executePpl("source = " + INDEX + " | head 10 | fields " + COL));
+        assertEquals(Math.min(10, total), rows.size());
+    }
+
+    /** head larger than per-shard cardinality: still globally ordered, top == global max. */
+    public void testLargeHead_globalOrder() throws Exception {
+        ensureProvisioned();
+        long total = (long) globalAgg("count", null);
+        List<List<Object>> rows = datarows(executePpl("source = " + INDEX + " | sort - " + COL + " | head 100 | fields " + COL));
+        assertEquals(Math.min(100, total), rows.size());
+        assertMonotonic(rows, false);
+        assertEquals(globalAgg("max", null), num(rows.get(0).get(0)), 0.0);
+    }
+
+    /** {@code fn} is count/min/max; {@code where} is an optional leading filter clause (may be null). */
+    private double globalAgg(String fn, String where) throws Exception {
+        String filter = where == null ? "" : where + " | ";
+        String agg = "count".equals(fn) ? "count() as v" : fn + "(" + COL + ") as v";
+        List<List<Object>> rows = datarows(executePpl("source = " + INDEX + " | " + filter + "stats " + agg));
+        return num(rows.get(0).get(0));
+    }
+
+    private static void assertMonotonic(List<List<Object>> rows, boolean ascending) {
+        for (int i = 1; i < rows.size(); i++) {
+            double prev = num(rows.get(i - 1).get(0));
+            double cur = num(rows.get(i).get(0));
+            assertTrue("rows not " + (ascending ? "ascending" : "descending") + " at " + i, ascending ? prev <= cur : prev >= cur);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<List<Object>> datarows(Map<String, Object> result) {
+        return (List<List<Object>>) result.get("datarows");
+    }
+
+    private static double num(Object cell) {
+        return ((Number) cell).doubleValue();
+    }
+}

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/SortPushdownIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/SortPushdownIT.java
@@ -8,14 +8,16 @@
 
 package org.opensearch.analytics.qa;
 
+import org.opensearch.client.Request;
+
 import java.util.List;
 import java.util.Map;
 
 /**
- * End-to-end correctness for non-aggregate sort pushdown on a multi-shard index.
- * With the rewriter active, each shard ships only its local top-N already-sorted
- * rows; the coordinator merges them. These tests assert the merged result is the
- * correct, globally-ordered top-N (catches dropped rows / wrong ordering).
+ * End-to-end tests for non-aggregate sort pushdown on a multi-shard index. The result tests
+ * assert the merged output is the correct, globally-ordered top-N (catches dropped rows /
+ * wrong ordering); {@link #testExplain_sortPushedToShardFragment()} asserts via EXPLAIN that
+ * the collated Sort is actually pushed below the exchange (into the shard fragment).
  */
 public class SortPushdownIT extends AnalyticsRestTestCase {
 
@@ -98,6 +100,19 @@ public class SortPushdownIT extends AnalyticsRestTestCase {
         assertEquals(globalAgg("max", null), num(rows.get(0).get(0)), 0.0);
     }
 
+    /** EXPLAIN confirms the collated Sort is pushed below the exchange (into the shard fragment). */
+    @SuppressWarnings("unchecked")
+    public void testExplain_sortPushedToShardFragment() throws Exception {
+        ensureProvisioned();
+        Map<String, Object> profile = (Map<String, Object>) executeExplain("source = " + INDEX + " | sort - " + COL + " | head 10")
+            .get("profile");
+        String plan = String.join("\n", (List<String>) profile.get("full_plan"));
+        long sorts = plan.lines().filter(l -> l.contains("OpenSearchSort")).count();
+        assertTrue("expected coordinator + pushed shard Sort, plan:\n" + plan, sorts >= 2);
+        int er = plan.indexOf("ExchangeReducer");
+        assertTrue("a Sort must sit below the exchange (pushed down), plan:\n" + plan, er >= 0 && plan.indexOf("OpenSearchSort", er) > er);
+    }
+
     /** {@code fn} is count/min/max; {@code where} is an optional leading filter clause (may be null). */
     private double globalAgg(String fn, String where) throws Exception {
         String filter = where == null ? "" : where + " | ";
@@ -121,5 +136,11 @@ public class SortPushdownIT extends AnalyticsRestTestCase {
 
     private static double num(Object cell) {
         return ((Number) cell).doubleValue();
+    }
+
+    private Map<String, Object> executeExplain(String ppl) throws Exception {
+        Request request = new Request("POST", "/_analytics/ppl/_explain");
+        request.setJsonEntity("{\"query\": \"" + escapeJson(ppl) + "\"}");
+        return assertOkAndParse(client().performRequest(request), "EXPLAIN: " + ppl);
     }
 }

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/SortPushdownIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/SortPushdownIT.java
@@ -113,6 +113,27 @@ public class SortPushdownIT extends AnalyticsRestTestCase {
         assertTrue("a Sort must sit below the exchange (pushed down), plan:\n" + plan, er >= 0 && plan.indexOf("OpenSearchSort", er) > er);
     }
 
+    /** UNION ALL ({@code | append}): result is the global top-N, and the Sort is pushed below each arm's exchange. */
+    @SuppressWarnings("unchecked")
+    public void testUnionAll_sortPushedIntoEachArm() throws Exception {
+        ensureProvisioned();
+        String union = "source = " + INDEX + " | append [ source = " + INDEX + " ] | sort - " + COL + " | head 10";
+
+        List<List<Object>> rows = datarows(executePpl(union + " | fields " + COL));
+        assertEquals(10, rows.size());
+        assertMonotonic(rows, false);
+        assertEquals("top row must equal global max (union of index with itself)", globalAgg("max", null), num(rows.get(0).get(0)), 0.0);
+
+        String plan = String.join("\n", (List<String>) ((Map<String, Object>) executeExplain(union).get("profile")).get("full_plan"));
+        String[] lines = plan.split("\n", -1);
+        assertTrue("two arm exchanges, plan:\n" + plan, plan.lines().filter(l -> l.contains("ExchangeReducer")).count() >= 2);
+        for (int i = 0; i + 1 < lines.length; i++) {
+            if (lines[i].contains("ExchangeReducer")) {
+                assertTrue("a Sort must be pushed below each arm exchange, plan:\n" + plan, lines[i + 1].contains("OpenSearchSort"));
+            }
+        }
+    }
+
     /** {@code fn} is count/min/max; {@code where} is an optional leading filter clause (may be null). */
     private double globalAgg(String fn, String where) throws Exception {
         String filter = where == null ? "" : where + " | ";


### PR DESCRIPTION

  ## What
  For non-aggregate `ORDER BY .. LIMIT [OFFSET]` queries, copy the bottom-most collated `Sort` to just below the `ExchangeReducer` so each shard ships only its local top-N already-sorted rows. The coordinator `Sort` is left intact to merge the streams and apply the final offset/limit.

  ## Why
  Cuts data-node → coordinator transport from all matching rows per shard to N per shard. Exact (no oversampling): a row in the global window is within its own shard's top-N.

  ## How
  - New `OpenSearchSortPushdownRewriter`: post-CBO rewriter registered after the TopK rewrite in `PlannerImpl`.
  - Handles both the SQL single-node shape (`Sort(collation, fetch)`) and the PPL two-node shape (outer pure-`fetch` over inner collated `Sort`), folding the enclosing fetch into the pushed shard `Sort`.
  - **Collation**: copied verbatim (no remap — ER preserves schema and Sort sits directly above it).
  - **Limit**: shard `fetch = effective fetch`.
  - **Offset**: never pushed; shard `fetch = offset + fetch`, offset kept only on the coordinator.
  - Skips the aggregate path (ER feeding a `PARTIAL` aggregate) — owned by the TopK rewriter.

  ## Testing
  - Unit (`SortPushdownPlanShapeTests`): SQL/PPL shapes, offset widening, and skip cases (no fetch, single-shard, aggregate path); updated 3 existing plan-shape expectations.
  - IT (`SortPushdownIT`, multi-shard): desc/asc global top-N, multi-key, sort+filter, pure-limit, large-head — assert count, ordering, and boundary == global/filtered max/min.
  - `ShardBucketOversamplingIT` 7/7 still pass (no interference). Unit + IT + spotless green.
### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
