### PR TITLE
analytics-engine: Fix cross-shard COUNT(DISTINCT) over-counting 

### DIFF
--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchAggregateSplitRule.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchAggregateSplitRule.java
@@ -56,6 +56,12 @@ public class OpenSearchAggregateSplitRule extends RelOptRule {
     /** Skip the PARTIAL/FINAL split when it would emit a row type that fails Volcano's typeMatchesInferred. */
     private static boolean shouldSkipPartialFinalSplit(OpenSearchAggregate aggregate) {
         for (AggregateCall aggCall : aggregate.getAggCallList()) {
+            // DISTINCT aggregates (e.g. COUNT(DISTINCT x)) can't be decomposed into per-shard
+            // partials reduced additively: summing per-shard distinct counts double-counts any
+            // value present on more than one shard. Gather to the coordinator and aggregate once.
+            if (aggCall.isDistinct()) {
+                return true;
+            }
             if (isStateExpanding(aggCall.getAggregation())) {
                 return true;
             }

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/CoordinatorReduceIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/CoordinatorReduceIT.java
@@ -128,6 +128,58 @@ public class CoordinatorReduceIT extends AnalyticsRestTestCase {
     }
 
     /**
+     * Multi-shard dc correctness with heavy cross-shard value overlap. Unlike
+     * {@link #testDistinctCountAcrossShards()} (globally-unique values, so per-shard distinct sets
+     * never overlap and even a naive additive reduce is coincidentally right), here every shard
+     * sees the full value set. A correct cross-shard reduce must NOT sum per-shard distinct counts.
+     */
+    public void testDistinctCountCrossShardOverlap() throws Exception {
+        String index = "coord_reduce_dc_overlap";
+        int shards = 8;
+        try {
+            client().performRequest(new Request("DELETE", "/" + index));
+        } catch (Exception ignored) {}
+        String body = "{\"settings\": {"
+            + "  \"number_of_shards\": " + shards + ", \"number_of_replicas\": 0,"
+            + "  \"index.pluggable.dataformat.enabled\": true, \"index.pluggable.dataformat\": \"composite\","
+            + "  \"index.composite.primary_data_format\": \"parquet\", \"index.composite.secondary_data_formats\": \"\""
+            + "}, \"mappings\": {\"properties\": {\"value\": {\"type\": \"integer\"}}}}";
+        Request create = new Request("PUT", "/" + index);
+        create.setJsonEntity(body);
+        assertOkAndParse(client().performRequest(create), "create " + index);
+        Request health = new Request("GET", "/_cluster/health/" + index);
+        health.addParameter("wait_for_status", "green");
+        health.addParameter("timeout", "30s");
+        client().performRequest(health);
+
+        // 800 docs, value cycles 1..10 → every shard sees all 10 values (heavy cross-shard overlap).
+        int distinct = 10;
+        int total = 800;
+        StringBuilder bulk = new StringBuilder();
+        for (int i = 0; i < total; i++) {
+            bulk.append("{\"index\": {\"_id\": \"o").append(i).append("\"}}\n");
+            bulk.append("{\"value\": ").append((i % distinct) + 1).append("}\n");
+        }
+        bulkAndRefresh(index, bulk.toString());
+
+        // Exact distinct = number of groups returned by GROUP BY value (same engine).
+        Map<String, Object> grouped = executePpl("source = " + index + " | stats count() as c by value");
+        @SuppressWarnings("unchecked")
+        List<List<Object>> groupRows = (List<List<Object>>) grouped.get("datarows");
+        int exactDistinct = groupRows.size();
+
+        Map<String, Object> result = executePpl("source = " + index + " | stats dc(value) as dc");
+        long actual = ((Number) scalarRows(result, "dc").get(0).get(0)).longValue();
+
+        assertEquals("exact distinct (group count) must be " + distinct, distinct, exactDistinct);
+        assertTrue(
+            "dc(value) with cross-shard overlap should be ~" + distinct + " (±2), got " + actual
+                + " — a value near " + (distinct * shards) + " means per-shard distinct counts were summed across shards",
+            actual >= distinct - 2 && actual <= distinct + 2
+        );
+    }
+
+    /**
      * {@code stats percentile_approx(value, 50) as p} — t-digest approximate median.
      * STATE_EXPANDING, so the split rule gathers to coordinator + single-stage. Maps to
      * DataFusion's {@code approx_percentile_cont} via {@link

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/TwoShardAggregationIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/TwoShardAggregationIT.java
@@ -16,8 +16,9 @@ import java.util.Map;
  * stddev/var, span, values/list) and approximate tier {@code approx/} (distinct_count/dc/percentile/
  * median).
  *
- * <p>xfail: {@code distinct_count}/{@code dc} HLL cross-shard merge over-counts for repeated keyword
- * sets ({@code distinct_count(label)} = 5 at 1 shard, 9 at 2); correct for all-unique/low-card columns.
+ * <p>{@code distinct_count}/{@code dc} are correct cross-shard: DISTINCT aggregates skip the additive
+ * PARTIAL/FINAL split ({@link org.opensearch.analytics.planner.rules.OpenSearchAggregateSplitRule})
+ * and are computed once at the coordinator, so per-shard distinct counts are never summed.
  */
 public class TwoShardAggregationIT extends TwoShardReduceTestCase {
 
@@ -31,7 +32,8 @@ public class TwoShardAggregationIT extends TwoShardReduceTestCase {
 
     @Override
     protected Map<String, String> knownIssues() {
-        String hll = "HLL cross-shard merge over-counts repeated keyword sets (label 5->9 at 2 shards)";
-        return Map.of("distinct_count_label", hll, "distinct_count_by_cat", hll, "dc_label", hll);
+        // No known issues: dc/distinct_count cross-shard over-counting (repeated keyword sets,
+        // label 5->9 at 2 shards) is fixed by skipping the additive split for DISTINCT aggregates.
+        return Map.of();
     }
 }


### PR DESCRIPTION
`dc` / `distinct_count` / `COUNT(DISTINCT x)` over a multi-shard index over-counts.
  
The distributed planner split it into a per-shard `COUNT(DISTINCT)` PARTIAL plus a `SUM` FINAL (COUNT's additive reducer). Summing per-shard distinct counts double-counts any value present on more than one shard (e.g. `merge_coverage` keyword `label`: 5 distinct reported as 9 at 2 shards).

  ### Fix
  `OpenSearchAggregateSplitRule.shouldSkipPartialFinalSplit` now skips the additive PARTIAL/FINAL split for any `isDistinct` aggregate — the same single-stage coordinator-gather path `STATE_EXPANDING` aggregates already use. Distinctness is global and can't be reduced additively, so the aggregate is computed once at the coordinator. The `approx_distinct` (HLL) path is unaffected.

  ### Tests
  - Unmuted the previously-`xfail` dc/distinct_count checks in `TwoShardAggregationIT` (`dc_label`, `distinct_count_label`, `distinct_count_by_cat`) are now exact.
  - Added an 8-shard cross-shard-overlap regression test in `CoordinatorReduceIT`.
  - analytics-engine plan-shape unit tests + `CoordinatorReduceIT` pass; spotless clean.

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
