### PR TITLE
Wire native store provider to warm-tier repos and fix DFA ITs + Foyer Tunning

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/ToStringFunctionAdapter.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/ToStringFunctionAdapter.java
@@ -67,7 +67,7 @@ class ToStringFunctionAdapter implements ScalarFunctionAdapter {
     private enum Format {
         HEX("hex", SqlTypeName.BIGINT),
         BINARY("binary", SqlTypeName.BIGINT),
-        COMMAS("commas", /* preserveFractional */ null),
+        COMMAS("commas", /* preserveFractional */null),
         DURATION("duration", SqlTypeName.BIGINT),
         DURATION_MILLIS("duration_millis", SqlTypeName.BIGINT);
 

--- a/sandbox/plugins/block-cache-foyer/src/internalClusterTest/java/org/opensearch/blockcache/foyer/BlockCacheKeyIndexScaleIT.java
+++ b/sandbox/plugins/block-cache-foyer/src/internalClusterTest/java/org/opensearch/blockcache/foyer/BlockCacheKeyIndexScaleIT.java
@@ -21,6 +21,7 @@ import org.opensearch.action.admin.cluster.snapshots.restore.RestoreSnapshotRequ
 import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.env.Environment;
 import org.opensearch.node.Node;
@@ -120,7 +121,9 @@ public class BlockCacheKeyIndexScaleIT extends AbstractSnapshotIntegTestCase {
 
         logger.info("[scale-01] restarting warm node '{}'", getWarmNodeName());
         internalCluster().restartNode(getWarmNodeName());
-        ensureGreen();
+        // Use an extended timeout: after restart, 25 REMOTE_SNAPSHOT shards (5 indices × 5 shards)
+        // must re-open before the cluster goes GREEN. The default 60s is insufficient under load.
+        ensureGreen(TimeValue.timeValueSeconds(120));
 
         Path cacheDir = findFoyerCacheDir();
         assertNotNull("foyer-block-cache directory must exist on warm node after restart", cacheDir);
@@ -185,7 +188,8 @@ public class BlockCacheKeyIndexScaleIT extends AbstractSnapshotIntegTestCase {
 
         logger.info("[scale-04] restarting warm node to trigger key_index recovery");
         internalCluster().restartNode(getWarmNodeName());
-        ensureGreen();
+        // Extended timeout: 25 REMOTE_SNAPSHOT shards must re-open after warm node restart.
+        ensureGreen(TimeValue.timeValueSeconds(120));
 
         Path cacheDir = findFoyerCacheDir();
         assertNotNull("foyer-block-cache directory must exist after restart", cacheDir);

--- a/sandbox/plugins/block-cache-foyer/src/main/java/org/opensearch/blockcache/foyer/BlockCacheFoyerPlugin.java
+++ b/sandbox/plugins/block-cache-foyer/src/main/java/org/opensearch/blockcache/foyer/BlockCacheFoyerPlugin.java
@@ -97,6 +97,8 @@ public class BlockCacheFoyerPlugin extends Plugin implements BlockCacheProvider 
         return List.of(
             FoyerBlockCacheSettings.CACHE_SIZE_SETTING,
             FoyerBlockCacheSettings.BLOCK_SIZE_SETTING,
+            FoyerBlockCacheSettings.BUFFER_POOL_SIZE_SETTING,
+            FoyerBlockCacheSettings.SUBMIT_QUEUE_SIZE_THRESHOLD_SETTING,
             FoyerBlockCacheSettings.IO_ENGINE_SETTING,
             FoyerBlockCacheSettings.KEY_INDEX_SWEEP_INTERVAL_SETTING,
             FoyerBlockCacheSettings.KEY_INDEX_SWEEP_THRESHOLD_SETTING,
@@ -165,6 +167,8 @@ public class BlockCacheFoyerPlugin extends Plugin implements BlockCacheProvider 
             return List.of();
         }
         final long blockSizeBytes = FoyerBlockCacheSettings.BLOCK_SIZE_SETTING.get(settings).getBytes();
+        final long bufferPoolSizeBytes = FoyerBlockCacheSettings.BUFFER_POOL_SIZE_SETTING.get(settings).getBytes();
+        final long submitQueueSizeThresholdBytes = FoyerBlockCacheSettings.SUBMIT_QUEUE_SIZE_THRESHOLD_SETTING.get(settings).getBytes();
         final String ioEngine = FoyerBlockCacheSettings.IO_ENGINE_SETTING.get(settings);
         final long sweepIntervalSecs = FoyerBlockCacheSettings.KEY_INDEX_SWEEP_INTERVAL_SETTING.get(settings);
         final double sweepThresholdRatio = FoyerBlockCacheSettings.KEY_INDEX_SWEEP_THRESHOLD_SETTING.get(settings);
@@ -203,6 +207,8 @@ public class BlockCacheFoyerPlugin extends Plugin implements BlockCacheProvider 
                 diskCapacityBytes,
                 diskDir,
                 blockSizeBytes,
+                bufferPoolSizeBytes,
+                submitQueueSizeThresholdBytes,
                 ioEngine,
                 sweepIntervalSecs,
                 sweepThresholdRatio,

--- a/sandbox/plugins/block-cache-foyer/src/main/java/org/opensearch/blockcache/foyer/FoyerBlockCache.java
+++ b/sandbox/plugins/block-cache-foyer/src/main/java/org/opensearch/blockcache/foyer/FoyerBlockCache.java
@@ -63,6 +63,8 @@ public final class FoyerBlockCache implements BlockCache {
         long diskBytes,
         String diskDir,
         long blockSizeBytes,
+        long bufferPoolSizeBytes,
+        long submitQueueSizeThresholdBytes,
         String ioEngine,
         long sweepIntervalSecs,
         double sweepThresholdRatio,
@@ -77,6 +79,12 @@ public final class FoyerBlockCache implements BlockCache {
         }
         if (blockSizeBytes <= 0) {
             throw new IllegalArgumentException("blockSizeBytes must be > 0, got: " + blockSizeBytes);
+        }
+        if (bufferPoolSizeBytes <= 0) {
+            throw new IllegalArgumentException("bufferPoolSizeBytes must be > 0, got: " + bufferPoolSizeBytes);
+        }
+        if (submitQueueSizeThresholdBytes <= 0) {
+            throw new IllegalArgumentException("submitQueueSizeThresholdBytes must be > 0, got: " + submitQueueSizeThresholdBytes);
         }
         Objects.requireNonNull(ioEngine, "ioEngine must not be null");
         if (sweepIntervalSecs < 0) {
@@ -93,6 +101,8 @@ public final class FoyerBlockCache implements BlockCache {
             diskBytes,
             diskDir,
             blockSizeBytes,
+            bufferPoolSizeBytes,
+            submitQueueSizeThresholdBytes,
             ioEngine,
             sweepIntervalSecs,
             sweepThresholdRatio,

--- a/sandbox/plugins/block-cache-foyer/src/main/java/org/opensearch/blockcache/foyer/FoyerBlockCacheSettings.java
+++ b/sandbox/plugins/block-cache-foyer/src/main/java/org/opensearch/blockcache/foyer/FoyerBlockCacheSettings.java
@@ -72,23 +72,51 @@ public final class FoyerBlockCacheSettings {
     /**
      * Block size for the Foyer disk tier.
      *
-     * <p>Must be &ge; the largest entry ever put into the cache. DataFusion reads
-     * Parquet row groups of up to 64&nbsp;MB; Lucene blocks are also up to 64&nbsp;MB.
-     * A block size smaller than an entry causes a silent drop — the put succeeds but
-     * the entry is not stored, resulting in a cache miss on the next read.
+     * <p>Must be &ge; the largest entry ever put into the cache. Parquet row groups
+     * can be up to 128&nbsp;MB. A block size smaller than an entry causes a silent
+     * drop — the put succeeds but the entry is not stored, resulting in a cache miss.
      *
-     * <p>Default: 64&nbsp;MB. Range: [1&nbsp;MB, 256&nbsp;MB].
-     *
-     * <p>Configure in {@code opensearch.yml}:
-     * <pre>{@code
-     * block_cache.foyer.block_size: 64mb
-     * }</pre>
+     * <p>Default: 128&nbsp;MB. Range: [1&nbsp;MB, 512&nbsp;MB].
      */
     public static final Setting<ByteSizeValue> BLOCK_SIZE_SETTING = Setting.byteSizeSetting(
         "block_cache.foyer.block_size",
-        new ByteSizeValue(64, ByteSizeUnit.MB),
+        new ByteSizeValue(128, ByteSizeUnit.MB),
         new ByteSizeValue(1, ByteSizeUnit.MB),
+        new ByteSizeValue(512, ByteSizeUnit.MB),
+        Setting.Property.NodeScope
+    );
+
+    /**
+     * Total buffer pool size for the Foyer flusher.
+     *
+     * <p>The flusher stages entries in this buffer before writing to disk. Must be
+     * &ge; {@code block_size} so the flusher can accumulate a full block. Entries
+     * larger than this buffer are silently dropped.
+     *
+     * <p>Default: 128&nbsp;MB. Range: [16&nbsp;MB, 512&nbsp;MB].
+     */
+    public static final Setting<ByteSizeValue> BUFFER_POOL_SIZE_SETTING = Setting.byteSizeSetting(
+        "block_cache.foyer.buffer_pool_size",
+        new ByteSizeValue(128, ByteSizeUnit.MB),
+        new ByteSizeValue(16, ByteSizeUnit.MB),
+        new ByteSizeValue(512, ByteSizeUnit.MB),
+        Setting.Property.NodeScope
+    );
+
+    /**
+     * Submit queue size threshold for the Foyer block engine.
+     *
+     * <p>Maximum total bytes allowed to be pending in the flusher queue. When
+     * exceeded, new entries are silently dropped instead of being written to disk.
+     * Should be &ge; 2&times; {@code buffer_pool_size} to absorb write bursts.
+     *
+     * <p>Default: 256&nbsp;MB. Range: [16&nbsp;MB, 1024&nbsp;MB].
+     */
+    public static final Setting<ByteSizeValue> SUBMIT_QUEUE_SIZE_THRESHOLD_SETTING = Setting.byteSizeSetting(
+        "block_cache.foyer.submit_queue_size_threshold",
         new ByteSizeValue(256, ByteSizeUnit.MB),
+        new ByteSizeValue(16, ByteSizeUnit.MB),
+        new ByteSizeValue(1024, ByteSizeUnit.MB),
         Setting.Property.NodeScope
     );
 

--- a/sandbox/plugins/block-cache-foyer/src/main/java/org/opensearch/blockcache/foyer/FoyerBridge.java
+++ b/sandbox/plugins/block-cache-foyer/src/main/java/org/opensearch/blockcache/foyer/FoyerBridge.java
@@ -50,10 +50,6 @@ public final class FoyerBridge {
         SymbolLookup lib = NativeLibraryLoader.symbolLookup();
         Linker linker = Linker.nativeLinker();
 
-        // i64 foyer_create_cache(u64 disk_bytes, *const u8 dir_ptr, u64 dir_len,
-        // u64 block_size_bytes, *const u8 io_engine_ptr, u64 io_engine_len,
-        // u64 sweep_interval_secs, f64 sweep_threshold_ratio, u64 persist_interval_secs)
-        // Returns Box<Arc<dyn BlockCache>> fat pointer.
         FOYER_CREATE_CACHE = linker.downcallHandle(
             lib.find("foyer_create_cache").orElseThrow(),
             FunctionDescriptor.of(
@@ -62,6 +58,8 @@ public final class FoyerBridge {
                 ValueLayout.ADDRESS,     // dir_ptr: *const u8
                 ValueLayout.JAVA_LONG,   // dir_len: u64
                 ValueLayout.JAVA_LONG,   // block_size_bytes: u64
+                ValueLayout.JAVA_LONG,   // buffer_pool_size_bytes: u64
+                ValueLayout.JAVA_LONG,   // submit_queue_size_threshold_bytes: u64
                 ValueLayout.ADDRESS,     // io_engine_ptr: *const u8
                 ValueLayout.JAVA_LONG,   // io_engine_len: u64
                 ValueLayout.JAVA_LONG,   // sweep_interval_secs: u64 (0 = disabled)
@@ -173,6 +171,8 @@ public final class FoyerBridge {
         long diskBytes,
         String diskDir,
         long blockSizeBytes,
+        long bufferPoolSizeBytes,
+        long submitQueueSizeThresholdBytes,
         String ioEngine,
         long sweepIntervalSecs,
         double sweepThresholdRatio,
@@ -187,6 +187,8 @@ public final class FoyerBridge {
                 dir.segment(),
                 dir.len(),
                 blockSizeBytes,
+                bufferPoolSizeBytes,
+                submitQueueSizeThresholdBytes,
                 engine.segment(),
                 engine.len(),
                 sweepIntervalSecs,
@@ -197,14 +199,12 @@ public final class FoyerBridge {
                 throw new IllegalStateException("foyer_create_cache returned an invalid handle");
             }
             logger.info(
-                "Foyer block cache created: diskBytes={}, blockSizeBytes={}, ioEngine={}, "
-                    + "sweepIntervalSecs={}, sweepThresholdRatio={}, persistIntervalSecs={}, dir={}",
+                "Foyer block cache created: diskBytes={}, blockSize={}, bufferPool={}, submitQueueThreshold={}, " + "ioEngine={}, dir={}",
                 diskBytes,
                 blockSizeBytes,
+                bufferPoolSizeBytes,
+                submitQueueSizeThresholdBytes,
                 ioEngine,
-                sweepIntervalSecs == 0 ? "disabled" : sweepIntervalSecs + "s",
-                sweepThresholdRatio == 0.0 ? "always-sweep (no threshold)" : sweepThresholdRatio,
-                persistIntervalSecs == 0 ? "disabled" : persistIntervalSecs + "s",
                 diskDir
             );
             return ptr;

--- a/sandbox/plugins/block-cache-foyer/src/main/rust/src/foyer/ffm.rs
+++ b/sandbox/plugins/block-cache-foyer/src/main/rust/src/foyer/ffm.rs
@@ -41,6 +41,8 @@ pub unsafe extern "C" fn foyer_create_cache(
     dir_ptr: *const u8,
     dir_len: u64,
     block_size_bytes: u64,
+    buffer_pool_size_bytes: u64,
+    submit_queue_size_threshold_bytes: u64,
     io_engine_ptr: *const u8,
     io_engine_len: u64,
     sweep_interval_secs: u64,
@@ -58,11 +60,12 @@ pub unsafe extern "C" fn foyer_create_cache(
         std::str::from_utf8(std::slice::from_raw_parts(io_engine_ptr, io_engine_len as usize))
             .unwrap_or("auto")
     };
-    // Return a fat Arc<dyn BlockCache> from the start — no separate wrapping step needed.
     let cache: Arc<dyn crate::traits::BlockCache> = Arc::new(FoyerCache::new(
         disk_bytes as usize,
         dir,
         block_size_bytes as usize,
+        buffer_pool_size_bytes as usize,
+        submit_queue_size_threshold_bytes as usize,
         io_engine,
         sweep_interval_secs,
         sweep_threshold_ratio,

--- a/sandbox/plugins/block-cache-foyer/src/main/rust/src/foyer/foyer_cache.rs
+++ b/sandbox/plugins/block-cache-foyer/src/main/rust/src/foyer/foyer_cache.rs
@@ -278,6 +278,8 @@ impl FoyerCache {
         disk_bytes: usize,
         disk_dir: impl Into<PathBuf>,
         block_size_bytes: usize,
+        buffer_pool_size_bytes: usize,
+        submit_queue_size_threshold_bytes: usize,
         io_engine: &str,
         sweep_interval_secs: u64,
         sweep_threshold_ratio: f64,
@@ -312,12 +314,6 @@ impl FoyerCache {
                 .with_recover_mode(RecoverMode::Quiet)
                 .with_io_engine_config(build_io_engine_config(&io_engine))
                 .with_engine_config(
-                    // block_size is the disk I/O unit and the maximum size for a single entry.
-                    // Multiple smaller entries are packed together into one block by Foyer.
-                    // If an entry is larger than block_size it is silently dropped — put()
-                    // succeeds but the entry is never stored, causing a cache miss on the next read.
-                    // Set this to the largest expected entry size (e.g. 64 MB for Parquet row groups).
-                    // Configurable via block_cache.foyer.block_size (default: 64 MB).
                     BlockEngineConfig::new(
                         FsDeviceBuilder::new(dir_clone)
                             .with_capacity(disk_bytes)
@@ -325,6 +321,8 @@ impl FoyerCache {
                             .expect("[block-cache] FsDevice build failed")
                     )
                     .with_block_size(block_size_bytes)
+                    .with_buffer_pool_size(buffer_pool_size_bytes)
+                    .with_submit_queue_size_threshold(submit_queue_size_threshold_bytes)
                 )
                 .build()
                 .await

--- a/sandbox/plugins/block-cache-foyer/src/main/rust/src/foyer/foyer_cache.rs
+++ b/sandbox/plugins/block-cache-foyer/src/main/rust/src/foyer/foyer_cache.rs
@@ -338,7 +338,6 @@ impl FoyerCache {
             if persist_interval_secs == 0 { "disabled".to_string() } else { persist_interval_secs.to_string() },
             disk_dir.display()
         );
-
         // CancellationToken is Clone and Send — cheap to share with background tasks.
         let shutdown = CancellationToken::new();
 
@@ -387,38 +386,56 @@ impl FoyerCache {
                 native_bridge_common::log_info!(
                     "[block-cache] sweep task started: interval={}s", sweep_interval_secs
                 );
+                let mut restart_count = 0u32;
                 loop {
-                    // Read interval on each tick — allows live update without restart.
-                    let current_secs = sweep_interval_atomic_clone.load(Ordering::Relaxed);
-                    let interval = if current_secs == 0 {
-                        Duration::from_secs(3600) // effectively disabled: sleep 1 hour
-                    } else {
-                        Duration::from_secs(current_secs)
-                    };
-                    tokio::select! {
-                        _ = tokio::time::sleep(interval) => {
-                            if current_secs == 0 { continue; } // disabled
-                            let threshold = f64::from_bits(sweep_threshold_atomic_clone.load(Ordering::Relaxed));
-                            if threshold > 0.0 {
-                                let used = sweep_stats.used_bytes.load(Ordering::Relaxed).max(0) as usize;
-                                let ratio = used as f64 / sweep_disk_bytes as f64;
-                                if ratio < threshold {
+                    'inner: loop {
+                        // Read interval on each tick — allows live update without restart.
+                        let current_secs = sweep_interval_atomic_clone.load(Ordering::Relaxed);
+                        let interval = if current_secs == 0 {
+                            Duration::from_secs(3600) // effectively disabled: sleep 1 hour
+                        } else {
+                            Duration::from_secs(current_secs)
+                        };
+                        tokio::select! {
+                            _ = tokio::time::sleep(interval) => {
+                                if current_secs == 0 { continue 'inner; } // disabled
+                                let threshold = f64::from_bits(sweep_threshold_atomic_clone.load(Ordering::Relaxed));
+                                if threshold > 0.0 {
+                                    let used = sweep_stats.used_bytes.load(Ordering::Relaxed).max(0) as usize;
+                                    let ratio = used as f64 / sweep_disk_bytes as f64;
+                                    if ratio < threshold {
+                                        continue 'inner;
+                                    }
                                     native_bridge_common::log_debug!(
-                                        "[block-cache] sweep skipped: usage={:.1}% < threshold={:.1}%",
+                                        "[block-cache] sweep running: usage={:.2}% >= threshold={:.2}%",
                                         ratio * 100.0, threshold * 100.0
                                     );
-                                    continue;
+                                }
+                                // Panic safety: a panic in reconcile_key_index must not kill the task.
+                                let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                                    Self::reconcile_key_index(
+                                        &sweep_key_index, &sweep_inner, &sweep_stats, &sweep_cursor_clone,
+                                    )
+                                }));
+                                if let Err(_panic_payload) = result {
+                                    native_bridge_common::log_error!(
+                                        "[block-cache] sweep task: reconcile_key_index panicked — sweep continuing"
+                                    );
                                 }
                             }
-                            Self::reconcile_key_index(
-                                &sweep_key_index, &sweep_inner, &sweep_stats, &sweep_cursor_clone,
-                            );
-                        }
-                        _ = sweep_token.cancelled() => {
-                            native_bridge_common::log_info!("[block-cache] sweep task stopped");
-                            break;
+                            _ = sweep_token.cancelled() => {
+                                native_bridge_common::log_info!("[block-cache] sweep task stopped");
+                                return;
+                            }
                         }
                     }
+                    restart_count += 1;
+                    native_bridge_common::log_error!(
+                        "[block-cache] sweep task exited unexpectedly (restart #{})", restart_count
+                    );
+                    let backoff_secs = std::cmp::min(1u64 << restart_count.min(6), 60);
+                    tokio::time::sleep(Duration::from_secs(backoff_secs)).await;
+                    if sweep_token.is_cancelled() { return; }
                 }
             });
         }
@@ -440,32 +457,53 @@ impl FoyerCache {
                     "[block-cache] persist task started: interval={}s",
                     persist_interval_secs
                 );
-                // last_persisted tracks the last used_bytes value at the time of a
-                // successful persist. i64::MIN as a sentinel forces the first persist.
-                let mut last_persisted: i64 = i64::MIN;
+                let mut restart_count = 0u32;
                 loop {
-                    tokio::select! {
-                        _ = tokio::time::sleep(persist_interval) => {
-                            let current = persist_stats.used_bytes.load(Ordering::Relaxed);
-                            if current != last_persisted {
-                                match key_index_store::save(&persist_dir, &persist_key_index) {
-                                    Ok(()) => {
-                                        last_persisted = current;
-                                    }
-                                    Err(e) => {
-                                        // Do not update last_persisted — retry on the next tick.
-                                        native_bridge_common::log_info!(
-                                            "[block-cache] persist task FAILED: {}", e
-                                        );
+                    // Reset sentinel on each loop entry so the first tick always persists.
+                    let mut last_persisted: i64 = i64::MIN;
+                    'inner: loop {
+                        tokio::select! {
+                            _ = tokio::time::sleep(persist_interval) => {
+                                let current = persist_stats.used_bytes.load(Ordering::Relaxed);
+                                if current != last_persisted {
+                                    // Panic safety: a panic in save must not kill the task.
+                                    let dir_clone = persist_dir.clone();
+                                    let ki_clone = Arc::clone(&persist_key_index);
+                                    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                                        key_index_store::save(&dir_clone, &ki_clone)
+                                    }));
+                                    match result {
+                                        Ok(Ok(())) => {
+                                            last_persisted = current;
+                                        }
+                                        Ok(Err(e)) => {
+                                            // I/O error — do not update last_persisted, retry next tick.
+                                            native_bridge_common::log_info!(
+                                                "[block-cache] persist task FAILED: {}", e
+                                            );
+                                        }
+                                        Err(_panic_payload) => {
+                                            // Panic inside save — log error, continue loop.
+                                            native_bridge_common::log_error!(
+                                                "[block-cache] persist task: key_index_store::save panicked — persist continuing"
+                                            );
+                                        }
                                     }
                                 }
                             }
-                        }
-                        _ = persist_token.cancelled() => {
-                            native_bridge_common::log_info!("[block-cache] persist task stopped");
-                            break;
+                            _ = persist_token.cancelled() => {
+                                native_bridge_common::log_info!("[block-cache] persist task stopped");
+                                return;
+                            }
                         }
                     }
+                    restart_count += 1;
+                    native_bridge_common::log_error!(
+                        "[block-cache] persist task exited unexpectedly (restart #{})", restart_count
+                    );
+                    let backoff_secs = std::cmp::min(1u64 << restart_count.min(6), 60);
+                    tokio::time::sleep(Duration::from_secs(backoff_secs)).await;
+                    if persist_token.is_cancelled() { return; }
                 }
             });
         }

--- a/sandbox/plugins/block-cache-foyer/src/main/rust/src/tests.rs
+++ b/sandbox/plugins/block-cache-foyer/src/main/rust/src/tests.rs
@@ -39,13 +39,16 @@ const IO_ENGINE: &str = "auto";
 /// explicit sizes and are unaffected by these constants.
 const TEST_CACHE_DISK_BYTES:  usize = 4 * 1024 * 1024;  // 4 MB disk capacity
 const TEST_CACHE_BLOCK_SIZE:  usize = 1 * 1024 * 1024;  // 1 MB block size (must be ≤ disk)
+const TEST_BUFFER_POOL_SIZE:  usize = 1 * 1024 * 1024;  // 1 MB buffer pool (≥ block_size)
+const TEST_SUBMIT_QUEUE_SIZE: usize = 2 * 1024 * 1024;  // 2 MB submit queue (≥ 2× buffer pool)
 
 fn test_cache() -> (FoyerCache, TempDir) {
     let dir = TempDir::new().expect("failed to create temp dir");
-    // sweep_interval_secs = 0 → no background task; tests call sweep_once() directly.
-    // persist_interval_secs = 0 → no persist task; tests call key_index_store::save() directly.
-    // block_size (1 MB) ≤ disk_bytes (4 MB) — required Foyer invariant.
-    let cache = FoyerCache::new(TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE, 0, 0.0, 0);
+    let cache = FoyerCache::new(
+        TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE,
+        TEST_BUFFER_POOL_SIZE, TEST_SUBMIT_QUEUE_SIZE,
+        IO_ENGINE, 0, 0.0, 0,
+    );
     (cache, dir)
 }
 
@@ -500,7 +503,7 @@ fn put_and_get_work_after_cache_nears_capacity() {
     let dir = TempDir::new().unwrap();
     // disk=2MB ≥ block_size=512KB (Foyer invariant: block_size ≤ disk).
     // Writes 4 × 512KB = 2MB total into a 2MB cache to exercise near-capacity behaviour.
-    let cache = FoyerCache::new(2 * 1024 * 1024, dir.path(), 512 * 1024, IO_ENGINE, 0, 0.0, 0);
+    let cache = FoyerCache::new(2 * 1024 * 1024, dir.path(), 512 * 1024, 512 * 1024, 1024 * 1024, IO_ENGINE, 0, 0.0, 0);
     let chunk = vec![0u8; 512 * 1024];
     for i in 0u64..4 {
         let key = range_cache_key("/data/file.parquet", i * 524288, (i + 1) * 524288);
@@ -524,7 +527,7 @@ fn lru_eviction_retains_keys_in_key_index() {
     // disk=1MB, block_size=256KB (256KB ≤ 1MB — Foyer invariant satisfied).
     // Writes 8 × 256KB = 2MB total into a 1MB cache to trigger LRU eviction pressure.
     let dir = TempDir::new().unwrap();
-    let cache = FoyerCache::new(1 * 1024 * 1024, dir.path(), 256 * 1024, IO_ENGINE, 0, 0.0, 0);
+    let cache = FoyerCache::new(1 * 1024 * 1024, dir.path(), 256 * 1024, 256 * 1024, 512 * 1024, IO_ENGINE, 0, 0.0, 0);
     const CHUNK_SIZE: usize = 256 * 1024;
     const TOTAL_WRITES: usize = 8;
     let chunk = vec![0xABu8; CHUNK_SIZE];
@@ -838,9 +841,9 @@ fn ffm_create_returns_positive_pointer() {
     let dir_str = dir.path().to_str().unwrap();
     let engine = IO_ENGINE.as_bytes();
     let ptr = unsafe { foyer_create_cache(
-        64 * 1024 * 1024,
+        128 * 1024 * 1024,
         dir_str.as_ptr(), dir_str.len() as u64,
-        BLOCK_SIZE as u64,
+        BLOCK_SIZE as u64, BLOCK_SIZE as u64, (BLOCK_SIZE * 2) as u64,
         engine.as_ptr(), engine.len() as u64,
         0, 0.0_f64,
         0,
@@ -854,9 +857,9 @@ fn ffm_create_returns_positive_pointer() {
 fn ffm_create_with_null_ptr_returns_error() {
     let engine = IO_ENGINE.as_bytes();
     let ptr = unsafe { foyer_create_cache(
-        64 * 1024 * 1024,
+        128 * 1024 * 1024,
         std::ptr::null(), 10,
-        BLOCK_SIZE as u64,
+        BLOCK_SIZE as u64, BLOCK_SIZE as u64, (BLOCK_SIZE * 2) as u64,
         engine.as_ptr(), engine.len() as u64,
         0, 0.0_f64,
         0,
@@ -870,9 +873,9 @@ fn ffm_create_with_invalid_utf8_returns_error() {
     let invalid_utf8 = [0xFF, 0xFE, 0xFD];
     let engine = IO_ENGINE.as_bytes();
     let ptr = unsafe { foyer_create_cache(
-        64 * 1024 * 1024,
+        128 * 1024 * 1024,
         invalid_utf8.as_ptr(), invalid_utf8.len() as u64,
-        BLOCK_SIZE as u64,
+        BLOCK_SIZE as u64, BLOCK_SIZE as u64, (BLOCK_SIZE * 2) as u64,
         engine.as_ptr(), engine.len() as u64,
         0, 0.0_f64,
         0,
@@ -902,9 +905,9 @@ fn ffm_create_destroy_lifecycle_no_leak() {
         let dir = TempDir::new().unwrap();
         let dir_str = dir.path().to_str().unwrap();
         let ptr = unsafe { foyer_create_cache(
-            16 * 1024 * 1024,
+            128 * 1024 * 1024,
             dir_str.as_ptr(), dir_str.len() as u64,
-            BLOCK_SIZE as u64,
+            BLOCK_SIZE as u64, BLOCK_SIZE as u64, (BLOCK_SIZE * 2) as u64,
             engine.as_ptr(), engine.len() as u64,
             0, 0.0_f64,
             0,
@@ -929,9 +932,9 @@ fn ffm_snapshot_stats_valid_ptr_returns_zero_and_fills_buffer() {
     let dir_str = dir.path().to_str().unwrap();
     let engine = IO_ENGINE.as_bytes();
     let ptr = unsafe { foyer_create_cache(
-        64 * 1024 * 1024,
+        128 * 1024 * 1024,
         dir_str.as_ptr(), dir_str.len() as u64,
-        BLOCK_SIZE as u64,
+        BLOCK_SIZE as u64, BLOCK_SIZE as u64, (BLOCK_SIZE * 2) as u64,
         engine.as_ptr(), engine.len() as u64,
         0, 0.0_f64,
         0,
@@ -960,9 +963,9 @@ fn snapshot_stats_returns_zero_for_fresh_cache() {
     let engine = IO_ENGINE.as_bytes();
     let ptr = unsafe {
         foyer_create_cache(
-            64 * 1024 * 1024,
+            128 * 1024 * 1024,
             dir_str.as_ptr(), dir_str.len() as u64,
-            BLOCK_SIZE as u64,
+            BLOCK_SIZE as u64, BLOCK_SIZE as u64, (BLOCK_SIZE * 2) as u64,
             engine.as_ptr(), engine.len() as u64,
         0, 0.0_f64,
         0,
@@ -1000,9 +1003,9 @@ fn ffm_snapshot_stats_null_out_returns_error() {
     let dir_str = dir.path().to_str().unwrap();
     let engine = IO_ENGINE.as_bytes();
     let ptr = unsafe { foyer_create_cache(
-        64 * 1024 * 1024,
+        128 * 1024 * 1024,
         dir_str.as_ptr(), dir_str.len() as u64,
-        BLOCK_SIZE as u64,
+        BLOCK_SIZE as u64, BLOCK_SIZE as u64, (BLOCK_SIZE * 2) as u64,
         engine.as_ptr(), engine.len() as u64,
         0, 0.0_f64,
         0,
@@ -1088,7 +1091,7 @@ fn ffm_create_cache_returns_fat_ptr_with_strong_count_one() {
     let ptr = unsafe { foyer_create_cache(
         16 * 1024 * 1024,
         dir_str.as_ptr(), dir_str.len() as u64,
-        BLOCK_SIZE as u64,
+        BLOCK_SIZE as u64, BLOCK_SIZE as u64, (BLOCK_SIZE * 2) as u64,
         engine.as_ptr(), engine.len() as u64,
         0, 0.0_f64,
         0,
@@ -1121,7 +1124,7 @@ fn ffm_create_cache_ptr_cloneable_for_multiple_shards() {
     let ptr = unsafe { foyer_create_cache(
         16 * 1024 * 1024,
         dir_str.as_ptr(), dir_str.len() as u64,
-        BLOCK_SIZE as u64,
+        BLOCK_SIZE as u64, BLOCK_SIZE as u64, (BLOCK_SIZE * 2) as u64,
         engine.as_ptr(), engine.len() as u64,
         0, 0.0_f64,
         0,
@@ -1166,9 +1169,11 @@ fn drop_with_active_sweep_task_does_not_panic() {
     // Use a large interval so the task never actually fires during the test.
     // We only care that drop() cancels it cleanly.
     let cache = FoyerCache::new(
-        64 * 1024 * 1024,
+        128 * 1024 * 1024,
         dir.path(),
         BLOCK_SIZE,
+        BLOCK_SIZE,
+        BLOCK_SIZE * 2,
         IO_ENGINE,
         3600, // 1-hour interval — task sleeps, drop cancels it immediately
         0.0,  // threshold disabled
@@ -1185,9 +1190,11 @@ fn drop_cancels_the_token() {
 
     let dir = TempDir::new().unwrap();
     let cache = FoyerCache::new(
-        64 * 1024 * 1024,
+        128 * 1024 * 1024,
         dir.path(),
         BLOCK_SIZE,
+        BLOCK_SIZE,
+        BLOCK_SIZE * 2,
         IO_ENGINE,
         0,   // no sweep task
         0.0, // threshold disabled
@@ -1207,7 +1214,7 @@ fn drop_cancels_the_token() {
 fn cache_functional_before_drop() {
     let dir = TempDir::new().unwrap();
     {
-        let cache = FoyerCache::new(64 * 1024 * 1024, dir.path(), BLOCK_SIZE, IO_ENGINE, 0, 0.0, 0);
+        let cache = FoyerCache::new(64 * 1024 * 1024, dir.path(), BLOCK_SIZE, BLOCK_SIZE, BLOCK_SIZE * 2, IO_ENGINE, 0, 0.0, 0);
         let key = range_cache_key("/data/file.parquet", 0, 100);
         cache.put(&key, Bytes::from_static(b"hello"));
         let result = block_on(cache.get(&key));
@@ -1242,7 +1249,7 @@ fn sweep_disabled_when_interval_is_zero() {
 #[test]
 fn sweep_enabled_cache_is_usable_while_task_sleeping() {
     let dir = TempDir::new().unwrap();
-    let cache = FoyerCache::new(64 * 1024 * 1024, dir.path(), BLOCK_SIZE, IO_ENGINE, 3600, 0.0, 0);
+    let cache = FoyerCache::new(64 * 1024 * 1024, dir.path(), BLOCK_SIZE, BLOCK_SIZE, BLOCK_SIZE * 2, IO_ENGINE, 3600, 0.0, 0);
     let key = range_cache_key("/data/file.parquet", 0, 512);
     cache.put(&key, Bytes::from(vec![0xABu8; 512]));
     let result = block_on(cache.get(&key));
@@ -1299,7 +1306,7 @@ fn sweep_task_with_active_watchdog_stops_cleanly_on_cancel() {
     let dir = TempDir::new().unwrap();
     // Short sweep interval: the inner loop fires at least once within 2s.
     let cache = FoyerCache::new(
-        TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE,
+        TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, TEST_BUFFER_POOL_SIZE, TEST_SUBMIT_QUEUE_SIZE, IO_ENGINE,
         1,    // 1-second interval
         0.0,  // threshold disabled — sweep runs every tick
         0,    // persist disabled
@@ -1321,7 +1328,7 @@ fn sweep_task_with_active_watchdog_stops_cleanly_on_cancel() {
 fn persist_task_with_active_watchdog_stops_cleanly_on_cancel() {
     let dir = TempDir::new().unwrap();
     let cache = FoyerCache::new(
-        TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE,
+        TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, TEST_BUFFER_POOL_SIZE, TEST_SUBMIT_QUEUE_SIZE, IO_ENGINE,
         0,    // sweep disabled
         0.0,
         1,    // 1-second persist interval
@@ -1354,7 +1361,7 @@ fn persist_task_last_persisted_reset_forces_persist_after_recovery() {
     // Session 1: put data and let Drop write key_index.json.
     {
         let cache1 = FoyerCache::new(
-            TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE,
+            TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, TEST_BUFFER_POOL_SIZE, TEST_SUBMIT_QUEUE_SIZE, IO_ENGINE,
             0, 0.0, 0,
         );
         put_range(&cache1, "/data/reset_test.parquet", 0, 100, &vec![0u8; 100]);
@@ -1369,7 +1376,7 @@ fn persist_task_last_persisted_reset_forces_persist_after_recovery() {
     // First tick: i64::MIN != 100 → persist fires → mtime advances.
     {
         let cache2 = FoyerCache::new(
-            TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE,
+            TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, TEST_BUFFER_POOL_SIZE, TEST_SUBMIT_QUEUE_SIZE, IO_ENGINE,
             0, 0.0, 1,
         );
         // Record mtime written by Drop of session 1.
@@ -1809,7 +1816,7 @@ fn active_bytes_guard_drop_on_cancellation_restores_counter() {
 fn sweep_threshold_disabled_never_skips() {
     let dir = TempDir::new().unwrap();
     // threshold = 0.0: disabled — always sweep
-    let cache = FoyerCache::new(TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE, 0, 0.0, 0);
+    let cache = FoyerCache::new(TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, TEST_BUFFER_POOL_SIZE, TEST_SUBMIT_QUEUE_SIZE, IO_ENGINE, 0, 0.0, 0);
 
     // used_bytes = 0 (empty cache)
     assert_eq!(cache.should_skip_sweep(), false,
@@ -1826,7 +1833,7 @@ fn sweep_threshold_disabled_never_skips() {
 fn sweep_threshold_skips_when_usage_below_threshold() {
     let dir = TempDir::new().unwrap();
     // disk = 4MB, threshold = 0.75 (75%)
-    let cache = FoyerCache::new(TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE, 0, 0.75, 0);
+    let cache = FoyerCache::new(TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, TEST_BUFFER_POOL_SIZE, TEST_SUBMIT_QUEUE_SIZE, IO_ENGINE, 0, 0.75, 0);
 
     // usage = 0% → below 75% → skip
     cache.stats.used_bytes.store(0, std::sync::atomic::Ordering::Relaxed);
@@ -1851,7 +1858,7 @@ fn sweep_threshold_skips_when_usage_below_threshold() {
 fn sweep_threshold_runs_when_usage_at_or_above_threshold() {
     let dir = TempDir::new().unwrap();
     // disk = 4MB, threshold = 0.75 (75%)
-    let cache = FoyerCache::new(TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE, 0, 0.75, 0);
+    let cache = FoyerCache::new(TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, TEST_BUFFER_POOL_SIZE, TEST_SUBMIT_QUEUE_SIZE, IO_ENGINE, 0, 0.75, 0);
 
     // usage = exactly 75% → NOT below → do NOT skip
     let exact = ((TEST_CACHE_DISK_BYTES as f64 * 0.75) as i64);
@@ -1876,7 +1883,7 @@ fn sweep_threshold_runs_when_usage_at_or_above_threshold() {
 #[test]
 fn sweep_threshold_one_skips_unless_completely_full() {
     let dir = TempDir::new().unwrap();
-    let cache = FoyerCache::new(TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE, 0, 1.0, 0);
+    let cache = FoyerCache::new(TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, TEST_BUFFER_POOL_SIZE, TEST_SUBMIT_QUEUE_SIZE, IO_ENGINE, 0, 1.0, 0);
 
     // usage = 99.9% → still below 100% → skip
     let almost_full = ((TEST_CACHE_DISK_BYTES as f64 * 0.999) as i64);
@@ -1895,7 +1902,7 @@ fn sweep_threshold_one_skips_unless_completely_full() {
 #[test]
 fn sweep_threshold_negative_used_bytes_treated_as_zero() {
     let dir = TempDir::new().unwrap();
-    let cache = FoyerCache::new(TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE, 0, 0.5, 0);
+    let cache = FoyerCache::new(TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, TEST_BUFFER_POOL_SIZE, TEST_SUBMIT_QUEUE_SIZE, IO_ENGINE, 0, 0.5, 0);
 
     // Simulate a transient underflow (negative used_bytes) — should be clamped to 0.
     cache.stats.used_bytes.store(-100, std::sync::atomic::Ordering::Relaxed);
@@ -1910,7 +1917,7 @@ fn sweep_threshold_negative_used_bytes_treated_as_zero() {
 fn sweep_once_ignores_threshold_guard() {
     let dir = TempDir::new().unwrap();
     // Set a high threshold so should_skip_sweep() returns true
-    let cache = FoyerCache::new(TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE, 0, 0.99, 0);
+    let cache = FoyerCache::new(TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, TEST_BUFFER_POOL_SIZE, TEST_SUBMIT_QUEUE_SIZE, IO_ENGINE, 0, 0.99, 0);
 
     // Inject a stale key
     cache.key_index
@@ -1946,7 +1953,7 @@ fn recovery_key_index_bulk_loaded_after_graceful_shutdown() {
 
     // Write entries into the first cache instance.
     {
-        let cache = FoyerCache::new(TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE, 0, 0.0, 0);
+        let cache = FoyerCache::new(TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, TEST_BUFFER_POOL_SIZE, TEST_SUBMIT_QUEUE_SIZE, IO_ENGINE, 0, 0.0, 0);
         put_range(&cache, "/data/a.parquet", 0,   512, &vec![0u8; 512]);
         put_range(&cache, "/data/a.parquet", 512, 1024, &vec![0u8; 512]);
         put_range(&cache, "/data/b.parquet", 0,   256, &vec![0u8; 256]);
@@ -1958,7 +1965,7 @@ fn recovery_key_index_bulk_loaded_after_graceful_shutdown() {
         "key_index.json must be written on Drop");
 
     // Second instance: recover from the snapshot.
-    let cache2 = FoyerCache::new(TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE, 0, 0.0, 0);
+    let cache2 = FoyerCache::new(TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, TEST_BUFFER_POOL_SIZE, TEST_SUBMIT_QUEUE_SIZE, IO_ENGINE, 0, 0.0, 0);
 
     // Both prefix buckets must be present immediately after new().
     assert!(cache2.key_index.contains_key("data/a.parquet"),
@@ -1981,7 +1988,7 @@ fn recovery_used_bytes_initialized_from_snapshot() {
     let dir = TempDir::new().unwrap();
 
     {
-        let cache = FoyerCache::new(TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE, 0, 0.0, 0);
+        let cache = FoyerCache::new(TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, TEST_BUFFER_POOL_SIZE, TEST_SUBMIT_QUEUE_SIZE, IO_ENGINE, 0, 0.0, 0);
         // 3 ranges: 100 + 200 + 300 = 600 bytes total.
         put_range(&cache, "/data/f.parquet", 0,   100, &vec![0u8; 100]);
         put_range(&cache, "/data/f.parquet", 100, 300, &vec![0u8; 200]);
@@ -1989,7 +1996,7 @@ fn recovery_used_bytes_initialized_from_snapshot() {
         // Drop persists.
     }
 
-    let cache2 = FoyerCache::new(TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE, 0, 0.0, 0);
+    let cache2 = FoyerCache::new(TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, TEST_BUFFER_POOL_SIZE, TEST_SUBMIT_QUEUE_SIZE, IO_ENGINE, 0, 0.0, 0);
     let used = cache2.stats.used_bytes.load(std::sync::atomic::Ordering::Relaxed);
     assert_eq!(used, 600,
         "used_bytes must be 600 (sum of all recovered key ranges) after recovery");
@@ -2002,13 +2009,13 @@ fn recovery_evict_prefix_works_on_recovered_keys() {
     let dir = TempDir::new().unwrap();
 
     {
-        let cache = FoyerCache::new(TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE, 0, 0.0, 0);
+        let cache = FoyerCache::new(TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, TEST_BUFFER_POOL_SIZE, TEST_SUBMIT_QUEUE_SIZE, IO_ENGINE, 0, 0.0, 0);
         put_range(&cache, "/data/shard1/file.parquet", 0, 512, &vec![0u8; 512]);
         put_range(&cache, "/data/shard2/file.parquet", 0, 512, &vec![0u8; 512]);
         // Drop persists.
     }
 
-    let cache2 = FoyerCache::new(TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE, 0, 0.0, 0);
+    let cache2 = FoyerCache::new(TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, TEST_BUFFER_POOL_SIZE, TEST_SUBMIT_QUEUE_SIZE, IO_ENGINE, 0, 0.0, 0);
     assert!(cache2.key_index.contains_key("data/shard1/file.parquet"));
     assert!(cache2.key_index.contains_key("data/shard2/file.parquet"));
 
@@ -2028,7 +2035,7 @@ fn recovery_with_no_snapshot_is_clean_startup() {
     // No prior cache instance — key_index.json does not exist.
     assert!(!dir.path().join(key_index_store::KEY_INDEX_FILENAME).exists());
 
-    let cache = FoyerCache::new(TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE, 0, 0.0, 0);
+    let cache = FoyerCache::new(TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, TEST_BUFFER_POOL_SIZE, TEST_SUBMIT_QUEUE_SIZE, IO_ENGINE, 0, 0.0, 0);
     assert!(cache.key_index.is_empty(), "key_index must be empty on clean startup");
     assert_eq!(cache.stats.used_bytes.load(std::sync::atomic::Ordering::Relaxed), 0);
 
@@ -2045,7 +2052,7 @@ fn recovery_with_corrupt_snapshot_starts_empty() {
     std::fs::write(dir.path().join(key_index_store::KEY_INDEX_FILENAME), b"{{corrupt}}")
         .unwrap();
 
-    let cache = FoyerCache::new(TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE, 0, 0.0, 0);
+    let cache = FoyerCache::new(TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, TEST_BUFFER_POOL_SIZE, TEST_SUBMIT_QUEUE_SIZE, IO_ENGINE, 0, 0.0, 0);
     assert!(cache.key_index.is_empty(), "corrupt snapshot must produce empty key_index");
     assert_eq!(cache.stats.used_bytes.load(std::sync::atomic::Ordering::Relaxed), 0);
 
@@ -2061,7 +2068,7 @@ fn recovery_evicted_prefix_not_persisted() {
     let dir = TempDir::new().unwrap();
 
     {
-        let cache = FoyerCache::new(TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE, 0, 0.0, 0);
+        let cache = FoyerCache::new(TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, TEST_BUFFER_POOL_SIZE, TEST_SUBMIT_QUEUE_SIZE, IO_ENGINE, 0, 0.0, 0);
         put_range(&cache, "/data/evicted.parquet", 0, 512, &vec![0u8; 512]);
         put_range(&cache, "/data/kept.parquet",   0, 512, &vec![0u8; 512]);
 
@@ -2071,7 +2078,7 @@ fn recovery_evicted_prefix_not_persisted() {
         // Drop persists the remaining key_index (only kept.parquet).
     }
 
-    let cache2 = FoyerCache::new(TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE, 0, 0.0, 0);
+    let cache2 = FoyerCache::new(TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, TEST_BUFFER_POOL_SIZE, TEST_SUBMIT_QUEUE_SIZE, IO_ENGINE, 0, 0.0, 0);
     assert!(!cache2.key_index.contains_key("data/evicted.parquet"),
         "evicted prefix must not appear in recovered key_index");
     assert!(cache2.key_index.contains_key("data/kept.parquet"),
@@ -2085,7 +2092,7 @@ fn recovery_clear_deletes_snapshot_file() {
 
     // Create and drop a cache to write key_index.json.
     {
-        let cache = FoyerCache::new(TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE, 0, 0.0, 0);
+        let cache = FoyerCache::new(TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, TEST_BUFFER_POOL_SIZE, TEST_SUBMIT_QUEUE_SIZE, IO_ENGINE, 0, 0.0, 0);
         put_range(&cache, "/data/file.parquet", 0, 100, b"data");
         // Drop writes key_index.json.
     }
@@ -2094,13 +2101,13 @@ fn recovery_clear_deletes_snapshot_file() {
 
     // Create a second cache and call clear().
     {
-        let cache2 = FoyerCache::new(TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE, 0, 0.0, 0);
+        let cache2 = FoyerCache::new(TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, TEST_BUFFER_POOL_SIZE, TEST_SUBMIT_QUEUE_SIZE, IO_ENGINE, 0, 0.0, 0);
         block_on(cache2.clear());
         // Drop of cache2 writes an empty key_index.json (empty key_index after clear).
     }
 
     // Third instance: must start with an empty key_index (clear deleted the stale snapshot).
-    let cache3 = FoyerCache::new(TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE, 0, 0.0, 0);
+    let cache3 = FoyerCache::new(TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, TEST_BUFFER_POOL_SIZE, TEST_SUBMIT_QUEUE_SIZE, IO_ENGINE, 0, 0.0, 0);
     assert!(cache3.key_index.is_empty(),
         "key_index must be empty after clear() deleted the snapshot");
 }
@@ -2120,7 +2127,7 @@ fn persist_task_writes_snapshot_within_interval() {
     {
         // persist_interval=1s: task should fire within ~2s of a put().
         let cache = FoyerCache::new(
-            TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE,
+            TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, TEST_BUFFER_POOL_SIZE, TEST_SUBMIT_QUEUE_SIZE, IO_ENGINE,
             0,    // sweep disabled
             0.0,  // threshold disabled
             1,    // persist every 1 second
@@ -2162,7 +2169,7 @@ fn persist_task_does_not_fire_when_cache_idle() {
     {
         // persist_interval=1s
         let cache = FoyerCache::new(
-            TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE,
+            TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, TEST_BUFFER_POOL_SIZE, TEST_SUBMIT_QUEUE_SIZE, IO_ENGINE,
             0, 0.0, 1,
         );
         // Single put to trigger the first persist.
@@ -2198,7 +2205,7 @@ fn persist_task_fires_after_evict_prefix_changes_used_bytes() {
     let dir = TempDir::new().unwrap();
     {
         let cache = FoyerCache::new(
-            TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE,
+            TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, TEST_BUFFER_POOL_SIZE, TEST_SUBMIT_QUEUE_SIZE, IO_ENGINE,
             0, 0.0, 1,
         );
         put_range(&cache, "/data/evict_me.parquet", 0, 512, &vec![0u8; 512]);
@@ -2236,7 +2243,7 @@ fn persist_task_not_spawned_when_interval_is_zero() {
     {
         // persist_interval=0: only Drop persists.
         let cache = FoyerCache::new(
-            TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE,
+            TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, TEST_BUFFER_POOL_SIZE, TEST_SUBMIT_QUEUE_SIZE, IO_ENGINE,
             0, 0.0,
             0,  // disabled
         );
@@ -2265,7 +2272,7 @@ fn simulated_crash_skip_drop_no_final_persist() {
     // Build a cache with persist_interval=0 (no periodic persist either).
     // This simulates a node with only Drop-based persistence.
     let cache = FoyerCache::new(
-        TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE,
+        TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, TEST_BUFFER_POOL_SIZE, TEST_SUBMIT_QUEUE_SIZE, IO_ENGINE,
         0, 0.0, 0,
     );
     put_range(&cache, "/data/crash.parquet", 0, 512, &vec![0u8; 512]);
@@ -2283,7 +2290,7 @@ fn simulated_crash_skip_drop_no_final_persist() {
 
     // Next startup: key_index starts empty (clean startup path).
     let cache2 = FoyerCache::new(
-        TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE,
+        TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, TEST_BUFFER_POOL_SIZE, TEST_SUBMIT_QUEUE_SIZE, IO_ENGINE,
         0, 0.0, 0,
     );
     assert!(cache2.key_index.is_empty(),
@@ -2297,7 +2304,7 @@ fn graceful_shutdown_snapshot_is_valid_json_with_correct_content() {
     let dir = TempDir::new().unwrap();
     {
         let cache = FoyerCache::new(
-            TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE,
+            TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, TEST_BUFFER_POOL_SIZE, TEST_SUBMIT_QUEUE_SIZE, IO_ENGINE,
             0, 0.0, 0,
         );
         put_range(&cache, "/data/nodes/0/shard1.parquet", 0,   256, &vec![0u8; 256]);
@@ -2333,7 +2340,7 @@ fn no_tmp_file_left_after_graceful_shutdown() {
     let dir = TempDir::new().unwrap();
     {
         let cache = FoyerCache::new(
-            TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE,
+            TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, TEST_BUFFER_POOL_SIZE, TEST_SUBMIT_QUEUE_SIZE, IO_ENGINE,
             0, 0.0, 0,
         );
         put_range(&cache, "/data/file.parquet", 0, 100, &vec![0u8; 100]);
@@ -2353,7 +2360,7 @@ fn zero_byte_snapshot_file_treated_as_corrupt() {
     std::fs::write(dir.path().join(key_index_store::KEY_INDEX_FILENAME), b"").unwrap();
 
     let cache = FoyerCache::new(
-        TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE,
+        TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, TEST_BUFFER_POOL_SIZE, TEST_SUBMIT_QUEUE_SIZE, IO_ENGINE,
         0, 0.0, 0,
     );
     assert!(cache.key_index.is_empty(),
@@ -2373,7 +2380,7 @@ fn no_tmp_file_on_clean_startup() {
     assert!(!dir.path().join(key_index_store::KEY_INDEX_TMP_FILENAME).exists());
 
     let cache = FoyerCache::new(
-        TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE,
+        TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, TEST_BUFFER_POOL_SIZE, TEST_SUBMIT_QUEUE_SIZE, IO_ENGINE,
         0, 0.0, 0,
     );
     // On startup, no .tmp should be created or left behind.
@@ -2451,7 +2458,7 @@ fn key_index_recovery_with_10k_entries() {
     key_index_store::save(dir.path(), &dash).unwrap();
 
     // Create a new cache from the same dir — should bulk-load the snapshot.
-    let cache = FoyerCache::new(TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE, 0, 0.0, 0);
+    let cache = FoyerCache::new(TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, TEST_BUFFER_POOL_SIZE, TEST_SUBMIT_QUEUE_SIZE, IO_ENGINE, 0, 0.0, 0);
 
     assert_eq!(cache.key_index.len(), NUM_PREFIXES,
         "key_index must have {NUM_PREFIXES} buckets after recovery");
@@ -2465,7 +2472,7 @@ fn key_index_recovery_with_10k_entries() {
 #[test]
 fn key_index_evict_prefix_bulk_with_10k_entries() {
     let dir = TempDir::new().unwrap();
-    let cache = FoyerCache::new(TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE, 0, 0.0, 0);
+    let cache = FoyerCache::new(TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, TEST_BUFFER_POOL_SIZE, TEST_SUBMIT_QUEUE_SIZE, IO_ENGINE, 0, 0.0, 0);
 
     const NUM_PREFIXES: usize = 100;
     const KEYS_PER_PREFIX: usize = 100;
@@ -2504,7 +2511,7 @@ fn key_index_clear_with_10k_entries() {
     use std::collections::HashSet;
 
     let dir = TempDir::new().unwrap();
-    let cache = FoyerCache::new(TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE, 0, 0.0, 0);
+    let cache = FoyerCache::new(TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, TEST_BUFFER_POOL_SIZE, TEST_SUBMIT_QUEUE_SIZE, IO_ENGINE, 0, 0.0, 0);
 
     const NUM_PREFIXES: usize = 100;
     const KEYS_PER_PREFIX: usize = 100;
@@ -2557,7 +2564,7 @@ fn recovery_stale_snapshot_keys_cleaned_by_sweep() {
     }
 
     // Create a fresh Foyer cache over the same dir. Foyer has no data for "data/stale.parquet".
-    let cache = FoyerCache::new(TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE, 0, 0.0, 0);
+    let cache = FoyerCache::new(TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, TEST_BUFFER_POOL_SIZE, TEST_SUBMIT_QUEUE_SIZE, IO_ENGINE, 0, 0.0, 0);
 
     // Bulk-loaded snapshot has the stale key — used_bytes is temporarily over-counted.
     assert!(cache.key_index.contains_key("data/stale.parquet"),

--- a/sandbox/plugins/block-cache-foyer/src/main/rust/src/tests.rs
+++ b/sandbox/plugins/block-cache-foyer/src/main/rust/src/tests.rs
@@ -1250,6 +1250,145 @@ fn sweep_enabled_cache_is_usable_while_task_sleeping() {
     // drop cancels the sleeping task immediately via cancelled() branch
 }
 
+// ── Watchdog and panic recovery tests ────────────────────────────────────────
+//
+// These tests exercise Fix 1 (catch_unwind) and Fix 4 (watchdog outer loop)
+// for both the sweep task and the persist task.
+
+/// Verify that `catch_unwind` correctly catches a panic without propagating it.
+/// Simulates exactly what the sweep task does when `reconcile_key_index` panics:
+/// the closure panics, `catch_unwind` returns `Err`, and the cache stays usable.
+#[test]
+fn sweep_task_catch_unwind_does_not_kill_loop_on_panic() {
+    let (cache, _dir) = test_cache();
+    // Manually replicate the catch_unwind logic from the sweep task.
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        panic!("simulated reconcile_key_index panic");
+    }));
+    // Panic must be caught — not propagated.
+    assert!(result.is_err(), "catch_unwind must catch the panic");
+    // The cache must still be fully functional after the simulated panic.
+    put_range(&cache, "/data/file.parquet", 0, 100, b"data");
+    let result = block_on(cache.get(&range_cache_key("/data/file.parquet", 0, 100)));
+    assert!(result.is_some(), "cache must be usable after catch_unwind");
+}
+
+/// Verify that `catch_unwind` correctly catches a panic in the persist path.
+/// Simulates exactly what the persist task does when `key_index_store::save` panics.
+#[test]
+fn persist_task_catch_unwind_does_not_kill_loop_on_panic() {
+    let (cache, _dir) = test_cache();
+    // Simulate the persist task catch_unwind.
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        panic!("simulated key_index_store::save panic");
+    }));
+    assert!(result.is_err(), "catch_unwind must catch the save panic");
+    // Cache is still usable.
+    put_range(&cache, "/data/b.parquet", 0, 200, b"persist_data");
+    assert!(cache.key_index.contains_key("data/b.parquet"),
+        "key_index must be intact after simulated panic");
+    assert!(cache.stats.used_bytes.load(std::sync::atomic::Ordering::Relaxed) > 0,
+        "used_bytes must be > 0 after put");
+}
+
+/// Verify that the sweep task with the watchdog outer loop stops cleanly
+/// when the cancellation token fires. Uses a short 1-second interval so
+/// the inner loop fires at least once before drop.
+#[test]
+fn sweep_task_with_active_watchdog_stops_cleanly_on_cancel() {
+    let dir = TempDir::new().unwrap();
+    // Short sweep interval: the inner loop fires at least once within 2s.
+    let cache = FoyerCache::new(
+        TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE,
+        1,    // 1-second interval
+        0.0,  // threshold disabled — sweep runs every tick
+        0,    // persist disabled
+    );
+    // Put something so the sweep has a non-trivial key_index to process.
+    put_range(&cache, "/data/watchdog_test.parquet", 0, 512, &vec![0u8; 512]);
+    // Let the sweep fire at least once.
+    std::thread::sleep(std::time::Duration::from_millis(1200));
+    // Drop cancels the token — the 'inner loop's cancelled() arm fires `return`.
+    // The watchdog outer loop must NOT re-enter because `return` exits the closure.
+    // No hang, no panic expected.
+    drop(cache);
+    // Reaching here means the task stopped cleanly.
+}
+
+/// Verify that the persist task with the watchdog outer loop stops cleanly
+/// when the cancellation token fires. Waits for at least one persist to happen.
+#[test]
+fn persist_task_with_active_watchdog_stops_cleanly_on_cancel() {
+    let dir = TempDir::new().unwrap();
+    let cache = FoyerCache::new(
+        TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE,
+        0,    // sweep disabled
+        0.0,
+        1,    // 1-second persist interval
+    );
+    put_range(&cache, "/data/persist_watchdog.parquet", 0, 256, &vec![0u8; 256]);
+    // Poll for key_index.json — the persist task must write it within 5s.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    while !dir.path().join(crate::key_index_store::KEY_INDEX_FILENAME).exists() {
+        if std::time::Instant::now() >= deadline { break; }
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+    assert!(
+        dir.path().join(crate::key_index_store::KEY_INDEX_FILENAME).exists(),
+        "persist task must have written key_index.json before drop"
+    );
+    // Drop cancels token — persist task stops via `return` in cancelled() arm.
+    // No hang means watchdog exited cleanly.
+    drop(cache);
+}
+
+/// Verify the design contract: `last_persisted` is reset to `i64::MIN` at the top
+/// of the watchdog outer loop, so the first tick after recovery always persists.
+///
+/// A second FoyerCache opens the same dir (recovered used_bytes > 0).
+/// Even though used_bytes is non-zero, last_persisted starts at i64::MIN ≠ used_bytes,
+/// so the first persist tick MUST fire and update the snapshot mtime.
+#[test]
+fn persist_task_last_persisted_reset_forces_persist_after_recovery() {
+    let dir = TempDir::new().unwrap();
+    // Session 1: put data and let Drop write key_index.json.
+    {
+        let cache1 = FoyerCache::new(
+            TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE,
+            0, 0.0, 0,
+        );
+        put_range(&cache1, "/data/reset_test.parquet", 0, 100, &vec![0u8; 100]);
+        // Drop writes key_index.json with used_bytes=100.
+    }
+    assert!(
+        dir.path().join(crate::key_index_store::KEY_INDEX_FILENAME).exists(),
+        "key_index.json must exist after session 1 Drop"
+    );
+    // Session 2: open with persist_interval=1s.
+    // recovered used_bytes=100; last_persisted starts at i64::MIN.
+    // First tick: i64::MIN != 100 → persist fires → mtime advances.
+    {
+        let cache2 = FoyerCache::new(
+            TEST_CACHE_DISK_BYTES, dir.path(), TEST_CACHE_BLOCK_SIZE, IO_ENGINE,
+            0, 0.0, 1,
+        );
+        // Record mtime written by Drop of session 1.
+        let mtime_before = std::fs::metadata(
+            dir.path().join(crate::key_index_store::KEY_INDEX_FILENAME)
+        ).unwrap().modified().unwrap();
+        // Wait 2s for the first persist tick.
+        std::thread::sleep(std::time::Duration::from_millis(2000));
+        let mtime_after = std::fs::metadata(
+            dir.path().join(crate::key_index_store::KEY_INDEX_FILENAME)
+        ).unwrap().modified().unwrap();
+        assert!(
+            mtime_after > mtime_before,
+            "persist task must fire on first tick after recovery (last_persisted=MIN != recovered used_bytes)"
+        );
+        drop(cache2);
+    }
+}
+
 // ── Sweep cursor tests ───────────────────────────────────────────────────────
 
 /// Each sweep_once() processes exactly one shard and advances the cursor.

--- a/sandbox/plugins/block-cache-foyer/src/test/java/org/opensearch/blockcache/foyer/BlockCacheFoyerPluginTests.java
+++ b/sandbox/plugins/block-cache-foyer/src/test/java/org/opensearch/blockcache/foyer/BlockCacheFoyerPluginTests.java
@@ -169,7 +169,7 @@ public class BlockCacheFoyerPluginTests extends OpenSearchTestCase {
         List<Setting<?>> settings = plugin.getSettings();
         // DATA_TO_CACHE_RATIO_SETTING removed — ratio now read from cluster.filecache.remote_data_ratio
         // KEY_INDEX_PERSIST_INTERVAL_SETTING added for independent periodic key_index persistence
-        assertEquals(6, settings.size());
+        assertEquals(8, settings.size());
         assertTrue(settings.contains(FoyerBlockCacheSettings.CACHE_SIZE_SETTING));
         assertTrue(settings.contains(FoyerBlockCacheSettings.BLOCK_SIZE_SETTING));
         assertTrue(settings.contains(FoyerBlockCacheSettings.IO_ENGINE_SETTING));

--- a/sandbox/plugins/block-cache-foyer/src/test/java/org/opensearch/blockcache/foyer/FoyerBlockCacheSettingsTests.java
+++ b/sandbox/plugins/block-cache-foyer/src/test/java/org/opensearch/blockcache/foyer/FoyerBlockCacheSettingsTests.java
@@ -125,7 +125,7 @@ public class FoyerBlockCacheSettingsTests extends OpenSearchTestCase {
     // ── BLOCK_SIZE_SETTING ────────────────────────────────────────────────────
 
     public void testBlockSizeDefault() {
-        assertEquals(new ByteSizeValue(64, ByteSizeUnit.MB), FoyerBlockCacheSettings.BLOCK_SIZE_SETTING.get(Settings.EMPTY));
+        assertEquals(new ByteSizeValue(128, ByteSizeUnit.MB), FoyerBlockCacheSettings.BLOCK_SIZE_SETTING.get(Settings.EMPTY));
     }
 
     public void testBlockSizeAcceptsMinimum() {
@@ -137,8 +137,8 @@ public class FoyerBlockCacheSettingsTests extends OpenSearchTestCase {
 
     public void testBlockSizeAcceptsMaximum() {
         assertEquals(
-            new ByteSizeValue(256, ByteSizeUnit.MB),
-            FoyerBlockCacheSettings.BLOCK_SIZE_SETTING.get(Settings.builder().put("block_cache.foyer.block_size", "256mb").build())
+            new ByteSizeValue(512, ByteSizeUnit.MB),
+            FoyerBlockCacheSettings.BLOCK_SIZE_SETTING.get(Settings.builder().put("block_cache.foyer.block_size", "512mb").build())
         );
     }
 
@@ -152,7 +152,7 @@ public class FoyerBlockCacheSettingsTests extends OpenSearchTestCase {
     public void testBlockSizeRejectsAboveMaximum() {
         expectThrows(
             IllegalArgumentException.class,
-            () -> FoyerBlockCacheSettings.BLOCK_SIZE_SETTING.get(Settings.builder().put("block_cache.foyer.block_size", "257mb").build())
+            () -> FoyerBlockCacheSettings.BLOCK_SIZE_SETTING.get(Settings.builder().put("block_cache.foyer.block_size", "513mb").build())
         );
     }
 

--- a/sandbox/plugins/block-cache-foyer/src/test/java/org/opensearch/blockcache/foyer/FoyerBlockCacheTests.java
+++ b/sandbox/plugins/block-cache-foyer/src/test/java/org/opensearch/blockcache/foyer/FoyerBlockCacheTests.java
@@ -23,7 +23,7 @@ public class FoyerBlockCacheTests extends OpenSearchTestCase {
     public void testConstructorThrowsWhenDiskBytesIsZero() {
         IllegalArgumentException ex = expectThrows(
             IllegalArgumentException.class,
-            () -> new FoyerBlockCache(0L, "/tmp/cache", 1L, "auto", 0L, 0.0, 0L)
+            () -> new FoyerBlockCache(0L, "/tmp/cache", 1L, 1L, 2L, "auto", 0L, 0.0, 0L)
         );
         assertTrue("message should mention diskBytes", ex.getMessage().contains("diskBytes"));
     }
@@ -31,7 +31,7 @@ public class FoyerBlockCacheTests extends OpenSearchTestCase {
     public void testConstructorThrowsWhenDiskBytesIsNegative() {
         IllegalArgumentException ex = expectThrows(
             IllegalArgumentException.class,
-            () -> new FoyerBlockCache(-1L, "/tmp/cache", 1L, "auto", 0L, 0.0, 0L)
+            () -> new FoyerBlockCache(-1L, "/tmp/cache", 1L, 1L, 2L, "auto", 0L, 0.0, 0L)
         );
         assertTrue(ex.getMessage().contains("diskBytes"));
     }
@@ -39,14 +39,17 @@ public class FoyerBlockCacheTests extends OpenSearchTestCase {
     // ── diskDir validation ────────────────────────────────────────────────────
 
     public void testConstructorThrowsWhenDiskDirIsNull() {
-        NullPointerException ex = expectThrows(NullPointerException.class, () -> new FoyerBlockCache(1L, null, 1L, "auto", 0L, 0.0, 0L));
+        NullPointerException ex = expectThrows(
+            NullPointerException.class,
+            () -> new FoyerBlockCache(1L, null, 1L, 1L, 2L, "auto", 0L, 0.0, 0L)
+        );
         assertTrue("message should mention diskDir", ex.getMessage().contains("diskDir"));
     }
 
     public void testConstructorThrowsWhenDiskDirIsBlank() {
         IllegalArgumentException ex = expectThrows(
             IllegalArgumentException.class,
-            () -> new FoyerBlockCache(1L, "   ", 1L, "auto", 0L, 0.0, 0L)
+            () -> new FoyerBlockCache(1L, "   ", 1L, 1L, 2L, "auto", 0L, 0.0, 0L)
         );
         assertTrue(ex.getMessage().contains("diskDir"));
     }
@@ -54,7 +57,7 @@ public class FoyerBlockCacheTests extends OpenSearchTestCase {
     public void testConstructorThrowsWhenDiskDirIsEmptyString() {
         IllegalArgumentException ex = expectThrows(
             IllegalArgumentException.class,
-            () -> new FoyerBlockCache(1L, "", 1L, "auto", 0L, 0.0, 0L)
+            () -> new FoyerBlockCache(1L, "", 1L, 1L, 2L, "auto", 0L, 0.0, 0L)
         );
         assertTrue(ex.getMessage().contains("diskDir"));
     }
@@ -64,7 +67,7 @@ public class FoyerBlockCacheTests extends OpenSearchTestCase {
     public void testConstructorThrowsWhenBlockSizeBytesIsZero() {
         IllegalArgumentException ex = expectThrows(
             IllegalArgumentException.class,
-            () -> new FoyerBlockCache(1L, "/tmp/cache", 0L, "auto", 0L, 0.0, 0L)
+            () -> new FoyerBlockCache(1L, "/tmp/cache", 0L, 1L, 2L, "auto", 0L, 0.0, 0L)
         );
         assertTrue("message should mention blockSizeBytes", ex.getMessage().contains("blockSizeBytes"));
     }
@@ -72,7 +75,7 @@ public class FoyerBlockCacheTests extends OpenSearchTestCase {
     public void testConstructorThrowsWhenBlockSizeBytesIsNegative() {
         IllegalArgumentException ex = expectThrows(
             IllegalArgumentException.class,
-            () -> new FoyerBlockCache(1L, "/tmp/cache", -1L, "auto", 0L, 0.0, 0L)
+            () -> new FoyerBlockCache(1L, "/tmp/cache", -1L, 1L, 2L, "auto", 0L, 0.0, 0L)
         );
         assertTrue(ex.getMessage().contains("blockSizeBytes"));
     }
@@ -82,7 +85,7 @@ public class FoyerBlockCacheTests extends OpenSearchTestCase {
     public void testConstructorThrowsWhenIoEngineIsNull() {
         NullPointerException ex = expectThrows(
             NullPointerException.class,
-            () -> new FoyerBlockCache(1L, "/tmp/cache", 1L, null, 0L, 0.0, 0L)
+            () -> new FoyerBlockCache(1L, "/tmp/cache", 1L, 1L, 2L, null, 0L, 0.0, 0L)
         );
         assertTrue("message should mention ioEngine", ex.getMessage().contains("ioEngine"));
     }
@@ -92,7 +95,7 @@ public class FoyerBlockCacheTests extends OpenSearchTestCase {
     public void testConstructorThrowsWhenSweepIntervalSecsIsNegative() {
         IllegalArgumentException ex = expectThrows(
             IllegalArgumentException.class,
-            () -> new FoyerBlockCache(1L, "/tmp/cache", 1L, "auto", -1L, 0.0, 0L)
+            () -> new FoyerBlockCache(1L, "/tmp/cache", 1L, 1L, 2L, "auto", -1L, 0.0, 0L)
         );
         assertTrue("message should mention sweepIntervalSecs", ex.getMessage().contains("sweepIntervalSecs"));
         assertTrue("message should contain the bad value -1", ex.getMessage().contains("-1"));
@@ -104,7 +107,7 @@ public class FoyerBlockCacheTests extends OpenSearchTestCase {
         // We can't fully invoke the constructor without the native library, so we just
         // verify the guard doesn't fire for 0.
         try {
-            new FoyerBlockCache(1L, "/tmp/cache", 1L, "auto", 0L, 0.0, 0L);
+            new FoyerBlockCache(1L, "/tmp/cache", 1L, 1L, 2L, "auto", 0L, 0.0, 0L);
             fail("Expected native library call to fail (UnsatisfiedLinkError or similar)");
         } catch (IllegalArgumentException e) {
             fail("Validation guard fired unexpectedly for sweepIntervalSecs=0: " + e.getMessage());
@@ -118,7 +121,7 @@ public class FoyerBlockCacheTests extends OpenSearchTestCase {
     public void testConstructorThrowsWhenSweepThresholdRatioIsNegative() {
         IllegalArgumentException ex = expectThrows(
             IllegalArgumentException.class,
-            () -> new FoyerBlockCache(1L, "/tmp/cache", 1L, "auto", 0L, -0.01, 0L)
+            () -> new FoyerBlockCache(1L, "/tmp/cache", 1L, 1L, 2L, "auto", 0L, -0.01, 0L)
         );
         assertTrue("message should mention sweepThresholdRatio", ex.getMessage().contains("sweepThresholdRatio"));
     }
@@ -126,7 +129,7 @@ public class FoyerBlockCacheTests extends OpenSearchTestCase {
     public void testConstructorThrowsWhenSweepThresholdRatioExceedsOne() {
         IllegalArgumentException ex = expectThrows(
             IllegalArgumentException.class,
-            () -> new FoyerBlockCache(1L, "/tmp/cache", 1L, "auto", 0L, 1.01, 0L)
+            () -> new FoyerBlockCache(1L, "/tmp/cache", 1L, 1L, 2L, "auto", 0L, 1.01, 0L)
         );
         assertTrue("message should mention sweepThresholdRatio", ex.getMessage().contains("sweepThresholdRatio"));
     }
@@ -134,7 +137,7 @@ public class FoyerBlockCacheTests extends OpenSearchTestCase {
     public void testConstructorAcceptsSweepThresholdRatioOfZero() {
         // 0.0 = disabled (always sweep); must NOT throw before reaching FoyerBridge
         try {
-            new FoyerBlockCache(1L, "/tmp/cache", 1L, "auto", 0L, 0.0, 0L);
+            new FoyerBlockCache(1L, "/tmp/cache", 1L, 1L, 2L, "auto", 0L, 0.0, 0L);
             fail("Expected native library call to fail");
         } catch (IllegalArgumentException e) {
             fail("Validation guard fired unexpectedly for sweepThresholdRatio=0.0: " + e.getMessage());
@@ -146,7 +149,7 @@ public class FoyerBlockCacheTests extends OpenSearchTestCase {
     public void testConstructorAcceptsSweepThresholdRatioOfOne() {
         // 1.0 = only sweep when cache is 100% full; valid boundary value
         try {
-            new FoyerBlockCache(1L, "/tmp/cache", 1L, "auto", 0L, 1.0, 0L);
+            new FoyerBlockCache(1L, "/tmp/cache", 1L, 1L, 2L, "auto", 0L, 1.0, 0L);
             fail("Expected native library call to fail");
         } catch (IllegalArgumentException e) {
             fail("Validation guard fired unexpectedly for sweepThresholdRatio=1.0: " + e.getMessage());
@@ -158,7 +161,7 @@ public class FoyerBlockCacheTests extends OpenSearchTestCase {
     public void testConstructorAcceptsSweepThresholdRatioOf0dot75() {
         // typical production value: skip sweep when < 75% full
         try {
-            new FoyerBlockCache(1L, "/tmp/cache", 1L, "auto", 0L, 0.75, 0L);
+            new FoyerBlockCache(1L, "/tmp/cache", 1L, 1L, 2L, "auto", 0L, 0.75, 0L);
             fail("Expected native library call to fail");
         } catch (IllegalArgumentException e) {
             fail("Validation guard fired unexpectedly for sweepThresholdRatio=0.75: " + e.getMessage());
@@ -176,7 +179,7 @@ public class FoyerBlockCacheTests extends OpenSearchTestCase {
     public void testDiskBytesErrorMessageContainsBadValue() {
         IllegalArgumentException ex = expectThrows(
             IllegalArgumentException.class,
-            () -> new FoyerBlockCache(-42L, "/tmp/cache", 1L, "auto", 0L, 0.0, 0L)
+            () -> new FoyerBlockCache(-42L, "/tmp/cache", 1L, 1L, 2L, "auto", 0L, 0.0, 0L)
         );
         assertTrue("error message should contain the bad value -42", ex.getMessage().contains("-42"));
     }
@@ -184,7 +187,7 @@ public class FoyerBlockCacheTests extends OpenSearchTestCase {
     public void testBlockSizeBytesErrorMessageContainsBadValue() {
         IllegalArgumentException ex = expectThrows(
             IllegalArgumentException.class,
-            () -> new FoyerBlockCache(1L, "/tmp/cache", -8L, "auto", 0L, 0.0, 0L)
+            () -> new FoyerBlockCache(1L, "/tmp/cache", -8L, 1L, 2L, "auto", 0L, 0.0, 0L)
         );
         assertTrue("error message should contain the bad value -8", ex.getMessage().contains("-8"));
     }
@@ -199,7 +202,7 @@ public class FoyerBlockCacheTests extends OpenSearchTestCase {
         // zero diskBytes + null diskDir: first guard (diskBytes) should fire
         IllegalArgumentException ex = expectThrows(
             IllegalArgumentException.class,
-            () -> new FoyerBlockCache(0L, null, 1L, "auto", 0L, 0.0, 0L)
+            () -> new FoyerBlockCache(0L, null, 1L, 1L, 2L, "auto", 0L, 0.0, 0L)
         );
         assertTrue(ex.getMessage().contains("diskBytes"));
     }

--- a/sandbox/plugins/composite-engine/build.gradle
+++ b/sandbox/plugins/composite-engine/build.gradle
@@ -53,4 +53,5 @@ dependencies {
   internalClusterTestImplementation project(':sandbox:plugins:analytics-backend-lucene')
   internalClusterTestImplementation project(':sandbox:plugins:analytics-backend-datafusion')
   internalClusterTestImplementation project(':sandbox:libs:analytics-framework')
+  internalClusterTestImplementation project(':sandbox:plugins:native-repository-fs')
 }

--- a/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/DataFormatAwareReadonlyEngineBaseIT.java
+++ b/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/DataFormatAwareReadonlyEngineBaseIT.java
@@ -15,22 +15,37 @@ import org.opensearch.arrow.allocator.ArrowBasePlugin;
 import org.opensearch.be.datafusion.DataFusionPlugin;
 import org.opensearch.be.lucene.LucenePlugin;
 import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.core.common.unit.ByteSizeUnit;
 import org.opensearch.core.common.unit.ByteSizeValue;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.env.Environment;
 import org.opensearch.index.IndexModule;
 import org.opensearch.index.shard.IndexShard;
 import org.opensearch.indices.IndicesService;
+import org.opensearch.indices.recovery.RecoverySettings;
 import org.opensearch.indices.replication.common.ReplicationType;
 import org.opensearch.node.Node;
 import org.opensearch.parquet.ParquetDataFormatPlugin;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.remotestore.RemoteStoreBaseIntegTestCase;
+import org.opensearch.remotestore.mocks.MockFsMetadataSupportedRepositoryPlugin;
+import org.opensearch.remotestore.multipart.mocks.MockFsRepositoryPlugin;
+import org.opensearch.repositories.Repository;
+import org.opensearch.repositories.fs.FsRepository;
+import org.opensearch.repositories.fs.ReloadableFsRepository;
+import org.opensearch.repositories.fs.native_store.FsNativeObjectStorePlugin;
 import org.opensearch.test.OpenSearchIntegTestCase;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -53,16 +68,81 @@ public abstract class DataFormatAwareReadonlyEngineBaseIT extends RemoteStoreBas
         }
     }
 
+    /**
+     * Replaces {@code MockFsMetadataSupportedRepositoryPlugin} from the base test class with a
+     * version that wires {@link FsNativeObjectStorePlugin} as the native store provider.
+     * This allows warm parquet shards to obtain a live {@code NativeStoreRepository} from the
+     * {@code "fs_metadata_supported_repository"} repos used in remote-store integration tests.
+     */
+    public static class NativeAwareMockFsMetadataSupportedRepositoryPlugin extends Plugin
+        implements
+            org.opensearch.plugins.RepositoryPlugin {
+
+        private final FsNativeObjectStorePlugin nativeProvider = new FsNativeObjectStorePlugin();
+
+        @Override
+        public Map<String, Repository.Factory> getRepositories(
+            Environment env,
+            NamedXContentRegistry namedXContentRegistry,
+            ClusterService clusterService,
+            RecoverySettings recoverySettings
+        ) {
+            return Collections.singletonMap(
+                MockFsMetadataSupportedRepositoryPlugin.TYPE_MD,
+                metadata -> new ReloadableFsRepository(
+                    metadata,
+                    env,
+                    namedXContentRegistry,
+                    clusterService,
+                    recoverySettings,
+                    nativeProvider
+                )
+            );
+        }
+    }
+
+    /**
+     * Replaces {@code MockFsRepositoryPlugin} from the base test class with a version that wires
+     * {@link FsNativeObjectStorePlugin} as the native store provider.
+     * This covers the {@code "fs_multipart_repository"} path, which is chosen when
+     * {@code metadataSupportedType == false} in {@code RemoteStoreBaseIntegTestCase}.
+     */
+    public static class NativeAwareMockFsRepositoryPlugin extends Plugin implements org.opensearch.plugins.RepositoryPlugin {
+
+        private final FsNativeObjectStorePlugin nativeProvider = new FsNativeObjectStorePlugin();
+
+        @Override
+        public Map<String, Repository.Factory> getRepositories(
+            Environment env,
+            NamedXContentRegistry namedXContentRegistry,
+            ClusterService clusterService,
+            RecoverySettings recoverySettings
+        ) {
+            return Collections.singletonMap(
+                MockFsRepositoryPlugin.TYPE,
+                metadata -> new FsRepository(metadata, env, namedXContentRegistry, clusterService, recoverySettings, nativeProvider)
+            );
+        }
+    }
+
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {
+        // Replace both mock repo plugins (from super) with native-provider-aware versions so that
+        // warm Parquet shards can obtain a live NativeStoreRepository regardless of which repo type
+        // RemoteStoreBaseIntegTestCase randomly picks (metadataSupportedType = randomBoolean()).
         return Stream.concat(
-            super.nodePlugins().stream(),
-            Stream.of(
+            super.nodePlugins().stream()
+                .filter(p -> p != MockFsMetadataSupportedRepositoryPlugin.class)
+                .filter(p -> p != MockFsRepositoryPlugin.class),
+            Stream.<Class<? extends Plugin>>of(
                 ArrowBasePlugin.class,
                 ParquetDataFormatPlugin.class,
                 CompositeDataFormatPlugin.class,
                 LucenePlugin.class,
-                DataFusionPlugin.class
+                DataFusionPlugin.class,
+                FsNativeObjectStorePlugin.class,
+                NativeAwareMockFsMetadataSupportedRepositoryPlugin.class,
+                NativeAwareMockFsRepositoryPlugin.class
             )
         ).collect(Collectors.toList());
     }
@@ -82,8 +162,23 @@ public abstract class DataFormatAwareReadonlyEngineBaseIT extends RemoteStoreBas
 
     @Override
     protected Settings nodeSettings(int nodeOrdinal) {
+        // super.nodeSettings() populates segmentRepoPath / translogRepoPath via randomRepoPath().
+        // Those paths are not yet created on disk. Pre-create them here so that
+        // FsNativeObjectStorePlugin (which calls fs_create_store → LocalFileSystem::new_with_prefix
+        // → canonicalize) can resolve the paths when repositories are registered at node startup.
+        final Settings settings = super.nodeSettings(nodeOrdinal);
+        try {
+            if (segmentRepoPath != null) {
+                Files.createDirectories(segmentRepoPath);
+            }
+            if (translogRepoPath != null) {
+                Files.createDirectories(translogRepoPath);
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to pre-create remote store repo directories", e);
+        }
         return Settings.builder()
-            .put(super.nodeSettings(nodeOrdinal))
+            .put(settings)
             .put(Node.NODE_SEARCH_CACHE_SIZE_SETTING.getKey(), new ByteSizeValue(16, ByteSizeUnit.GB).toString())
             .build();
     }

--- a/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/DataFormatAwareReplicationBaseIT.java
+++ b/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/DataFormatAwareReplicationBaseIT.java
@@ -8,27 +8,41 @@
 
 package org.opensearch.composite;
 
+import com.carrotsearch.randomizedtesting.ThreadFilter;
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
+
 import org.opensearch.arrow.allocator.ArrowBasePlugin;
 import org.opensearch.be.datafusion.DataFusionPlugin;
 import org.opensearch.be.lucene.LucenePlugin;
 import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.concurrent.GatedCloseable;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.FeatureFlags;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.env.Environment;
 import org.opensearch.index.engine.exec.coord.CatalogSnapshot;
 import org.opensearch.index.shard.IndexShard;
 import org.opensearch.index.store.FileMetadata;
 import org.opensearch.index.store.RemoteSegmentStoreDirectory.UploadedSegmentMetadata;
+import org.opensearch.indices.recovery.RecoverySettings;
 import org.opensearch.indices.replication.common.ReplicationType;
 import org.opensearch.parquet.ParquetDataFormatPlugin;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.remotestore.RemoteStoreBaseIntegTestCase;
+import org.opensearch.remotestore.mocks.MockFsMetadataSupportedRepositoryPlugin;
+import org.opensearch.remotestore.multipart.mocks.MockFsRepositoryPlugin;
+import org.opensearch.repositories.Repository;
+import org.opensearch.repositories.fs.FsRepository;
+import org.opensearch.repositories.fs.ReloadableFsRepository;
+import org.opensearch.repositories.fs.native_store.FsNativeObjectStorePlugin;
 import org.opensearch.test.BackgroundIndexer;
 import org.opensearch.test.InternalTestCluster;
 import org.opensearch.test.OpenSearchIntegTestCase;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -40,29 +54,99 @@ import java.util.stream.Stream;
  * Abstract base class for DFA replication integration tests. Centralizes boilerplate
  * shared across promotion and peer-recovery ITs.
  */
+@ThreadLeakFilters(filters = DataFormatAwareReplicationBaseIT.CleanerThreadFilter.class)
 @OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 0)
 public abstract class DataFormatAwareReplicationBaseIT extends RemoteStoreBaseIntegTestCase {
 
     protected static final String INDEX_NAME = "dfa-replication-base-idx";
 
+    /** Suppresses index-input-cleaner threads leaked by MMapDirectory / SwitchableIndexInput. */
+    public static class CleanerThreadFilter implements ThreadFilter {
+        @Override
+        public boolean reject(Thread t) {
+            return t.getName().startsWith("index-input-cleaner");
+        }
+    }
+
+
+    /** Wires FsNativeObjectStorePlugin into "fs_metadata_supported_repository" repos. */
+    public static class NativeAwareMockFsMetadataSupportedRepositoryPlugin extends Plugin implements
+        org.opensearch.plugins.RepositoryPlugin {
+
+        private final FsNativeObjectStorePlugin nativeProvider = new FsNativeObjectStorePlugin();
+
+        @Override
+        public Map<String, Repository.Factory> getRepositories(
+            Environment env,
+            NamedXContentRegistry namedXContentRegistry,
+            ClusterService clusterService,
+            RecoverySettings recoverySettings
+        ) {
+            return Collections.singletonMap(
+                MockFsMetadataSupportedRepositoryPlugin.TYPE_MD,
+                metadata -> new ReloadableFsRepository(
+                    metadata, env, namedXContentRegistry, clusterService, recoverySettings, nativeProvider
+                )
+            );
+        }
+    }
+
+    /** Wires FsNativeObjectStorePlugin into "fs_multipart_repository" repos. */
+    public static class NativeAwareMockFsRepositoryPlugin extends Plugin implements
+        org.opensearch.plugins.RepositoryPlugin {
+
+        private final FsNativeObjectStorePlugin nativeProvider = new FsNativeObjectStorePlugin();
+
+        @Override
+        public Map<String, Repository.Factory> getRepositories(
+            Environment env,
+            NamedXContentRegistry namedXContentRegistry,
+            ClusterService clusterService,
+            RecoverySettings recoverySettings
+        ) {
+            return Collections.singletonMap(
+                MockFsRepositoryPlugin.TYPE,
+                metadata -> new FsRepository(
+                    metadata, env, namedXContentRegistry, clusterService, recoverySettings, nativeProvider
+                )
+            );
+        }
+    }
+
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {
+        // Replace both mock repo plugins with native-provider-aware versions so that warm Parquet
+        // shards can obtain a live NativeStoreRepository regardless of which repo type
+        // RemoteStoreBaseIntegTestCase randomly picks (metadataSupportedType = randomBoolean()).
         return Stream.concat(
-            super.nodePlugins().stream(),
-            Stream.of(
+            super.nodePlugins().stream()
+                .filter(p -> p != MockFsMetadataSupportedRepositoryPlugin.class)
+                .filter(p -> p != MockFsRepositoryPlugin.class),
+            Stream.<Class<? extends Plugin>>of(
                 ArrowBasePlugin.class,
                 ParquetDataFormatPlugin.class,
                 CompositeDataFormatPlugin.class,
                 LucenePlugin.class,
-                DataFusionPlugin.class
+                DataFusionPlugin.class,
+                FsNativeObjectStorePlugin.class,
+                NativeAwareMockFsMetadataSupportedRepositoryPlugin.class,
+                NativeAwareMockFsRepositoryPlugin.class
             )
         ).collect(Collectors.toList());
     }
 
     @Override
     protected Settings nodeSettings(int nodeOrdinal) {
+        // Pre-create repo dirs so FsNativeObjectStorePlugin's canonicalize() succeeds at startup.
+        final Settings settings = super.nodeSettings(nodeOrdinal);
+        try {
+            if (segmentRepoPath != null) java.nio.file.Files.createDirectories(segmentRepoPath);
+            if (translogRepoPath != null) java.nio.file.Files.createDirectories(translogRepoPath);
+        } catch (java.io.IOException e) {
+            throw new java.io.UncheckedIOException("Failed to pre-create remote store repo directories", e);
+        }
         return Settings.builder()
-            .put(super.nodeSettings(nodeOrdinal))
+            .put(settings)
             .put(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG, true)
             .build();
     }

--- a/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/DataFormatAwareReplicationBaseIT.java
+++ b/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/DataFormatAwareReplicationBaseIT.java
@@ -68,10 +68,10 @@ public abstract class DataFormatAwareReplicationBaseIT extends RemoteStoreBaseIn
         }
     }
 
-
     /** Wires FsNativeObjectStorePlugin into "fs_metadata_supported_repository" repos. */
-    public static class NativeAwareMockFsMetadataSupportedRepositoryPlugin extends Plugin implements
-        org.opensearch.plugins.RepositoryPlugin {
+    public static class NativeAwareMockFsMetadataSupportedRepositoryPlugin extends Plugin
+        implements
+            org.opensearch.plugins.RepositoryPlugin {
 
         private final FsNativeObjectStorePlugin nativeProvider = new FsNativeObjectStorePlugin();
 
@@ -85,15 +85,19 @@ public abstract class DataFormatAwareReplicationBaseIT extends RemoteStoreBaseIn
             return Collections.singletonMap(
                 MockFsMetadataSupportedRepositoryPlugin.TYPE_MD,
                 metadata -> new ReloadableFsRepository(
-                    metadata, env, namedXContentRegistry, clusterService, recoverySettings, nativeProvider
+                    metadata,
+                    env,
+                    namedXContentRegistry,
+                    clusterService,
+                    recoverySettings,
+                    nativeProvider
                 )
             );
         }
     }
 
     /** Wires FsNativeObjectStorePlugin into "fs_multipart_repository" repos. */
-    public static class NativeAwareMockFsRepositoryPlugin extends Plugin implements
-        org.opensearch.plugins.RepositoryPlugin {
+    public static class NativeAwareMockFsRepositoryPlugin extends Plugin implements org.opensearch.plugins.RepositoryPlugin {
 
         private final FsNativeObjectStorePlugin nativeProvider = new FsNativeObjectStorePlugin();
 
@@ -106,9 +110,7 @@ public abstract class DataFormatAwareReplicationBaseIT extends RemoteStoreBaseIn
         ) {
             return Collections.singletonMap(
                 MockFsRepositoryPlugin.TYPE,
-                metadata -> new FsRepository(
-                    metadata, env, namedXContentRegistry, clusterService, recoverySettings, nativeProvider
-                )
+                metadata -> new FsRepository(metadata, env, namedXContentRegistry, clusterService, recoverySettings, nativeProvider)
             );
         }
     }
@@ -145,10 +147,7 @@ public abstract class DataFormatAwareReplicationBaseIT extends RemoteStoreBaseIn
         } catch (java.io.IOException e) {
             throw new java.io.UncheckedIOException("Failed to pre-create remote store repo directories", e);
         }
-        return Settings.builder()
-            .put(settings)
-            .put(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG, true)
-            .build();
+        return Settings.builder().put(settings).put(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG, true).build();
     }
 
     protected Settings dfaIndexSettings(int replicaCount) {

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/store/ParquetDataFormatStoreHandler.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/store/ParquetDataFormatStoreHandler.java
@@ -68,6 +68,12 @@ public class ParquetDataFormatStoreHandler implements DataFormatStoreHandler {
         if (isWarm) {
             long remotePtr = (repo != null && repo.isLive()) ? repo.getPointer() : 0L;
 
+            if (remotePtr == 0L) {
+                throw new IllegalStateException(
+                    "[" + shardId + "] remote object store is not available for this warm shard. Cannot serve read requests."
+                );
+            }
+
             // Resolve preferred cache by name; EMPTY if unavailable (hot nodes or no matching cache).
             // owned by NodeCacheService and must not be freed here.
             NativeStoreHandle cacheHandle = (cacheRegistry != null)

--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/translogmetadata/mocks/MockFsMetadataSupportedRepository.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/translogmetadata/mocks/MockFsMetadataSupportedRepository.java
@@ -16,6 +16,7 @@ import org.opensearch.common.settings.Setting;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.env.Environment;
 import org.opensearch.indices.recovery.RecoverySettings;
+import org.opensearch.plugins.NativeRemoteObjectStoreProvider;
 import org.opensearch.repositories.fs.ReloadableFsRepository;
 
 public class MockFsMetadataSupportedRepository extends ReloadableFsRepository {
@@ -34,7 +35,18 @@ public class MockFsMetadataSupportedRepository extends ReloadableFsRepository {
         ClusterService clusterService,
         RecoverySettings recoverySettings
     ) {
-        super(metadata, environment, namedXContentRegistry, clusterService, recoverySettings);
+        this(metadata, environment, namedXContentRegistry, clusterService, recoverySettings, null);
+    }
+
+    public MockFsMetadataSupportedRepository(
+        RepositoryMetadata metadata,
+        Environment environment,
+        NamedXContentRegistry namedXContentRegistry,
+        ClusterService clusterService,
+        RecoverySettings recoverySettings,
+        NativeRemoteObjectStoreProvider nativeStoreProvider
+    ) {
+        super(metadata, environment, namedXContentRegistry, clusterService, recoverySettings, nativeStoreProvider);
         triggerDataIntegrityFailure = TRIGGER_DATA_INTEGRITY_FAILURE.get(metadata.settings());
     }
 

--- a/server/src/main/java/org/opensearch/repositories/RepositoriesModule.java
+++ b/server/src/main/java/org/opensearch/repositories/RepositoriesModule.java
@@ -95,7 +95,7 @@ public final class RepositoriesModule {
 
         factories.put(
             ReloadableFsRepository.TYPE,
-            metadata -> new ReloadableFsRepository(metadata, env, namedXContentRegistry, clusterService, recoverySettings)
+            metadata -> new ReloadableFsRepository(metadata, env, namedXContentRegistry, clusterService, recoverySettings, fsNativeProvider)
         );
 
         for (RepositoryPlugin repoPlugin : repoPlugins) {

--- a/server/src/main/java/org/opensearch/repositories/fs/ReloadableFsRepository.java
+++ b/server/src/main/java/org/opensearch/repositories/fs/ReloadableFsRepository.java
@@ -21,6 +21,7 @@ import org.opensearch.common.settings.Setting;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.env.Environment;
 import org.opensearch.indices.recovery.RecoverySettings;
+import org.opensearch.plugins.NativeRemoteObjectStoreProvider;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -64,7 +65,22 @@ public class ReloadableFsRepository extends FsRepository {
         ClusterService clusterService,
         RecoverySettings recoverySettings
     ) {
-        super(metadata, environment, namedXContentRegistry, clusterService, recoverySettings);
+        this(metadata, environment, namedXContentRegistry, clusterService, recoverySettings, null);
+    }
+
+    /**
+     * Constructs a shared file system repository that is reloadable in-place,
+     * with an optional native object store provider for warm-node reads.
+     */
+    public ReloadableFsRepository(
+        RepositoryMetadata metadata,
+        Environment environment,
+        NamedXContentRegistry namedXContentRegistry,
+        ClusterService clusterService,
+        RecoverySettings recoverySettings,
+        NativeRemoteObjectStoreProvider nativeStoreProvider
+    ) {
+        super(metadata, environment, namedXContentRegistry, clusterService, recoverySettings, nativeStoreProvider);
         fail = new FailSwitch();
         fail.failRate(REPOSITORIES_FAILRATE_SETTING.get(metadata.settings()));
         slowDown = new SlowDownWriteSwitch();

--- a/server/src/main/java/org/opensearch/storage/action/tiering/TransportHotToWarmTierAction.java
+++ b/server/src/main/java/org/opensearch/storage/action/tiering/TransportHotToWarmTierAction.java
@@ -89,7 +89,7 @@ public class TransportHotToWarmTierAction extends TransportTierAction {
         if (TieringUtils.isDfaIndex(state.metadata().index(request.getIndex()))) {
             // Validate FIRST — before any state-mutating or expensive operations.
             // If validation fails (e.g. warm nodes full, too many concurrent requests),
-            // reject immediately without adding a read-only block or running prepare.
+            // reject immediately without adding a write block or running prepare.
             // Note: validation also runs inside TieringService.tier() for double-safety.
             try {
                 Index index = resolveRequestIndex(indexNameExpressionResolver, request.getIndex(), state);
@@ -99,7 +99,7 @@ public class TransportHotToWarmTierAction extends TransportTierAction {
                 listener.onFailure(e);
                 return;
             }
-            logger.info("Index [{}] is a DFA index, adding read-only block and performing pre-tiering sync", request.getIndex());
+            logger.info("Index [{}] is a DFA index, adding write block and performing pre-tiering sync", request.getIndex());
             addWriteBlockAndPrepare(request, state, listener);
         } else {
             super.clusterManagerOperation(request, state, listener);
@@ -114,7 +114,7 @@ public class TransportHotToWarmTierAction extends TransportTierAction {
      */
     private void addWriteBlockAndPrepare(IndexTieringRequest request, ClusterState state, ActionListener<AcknowledgedResponse> listener) {
         clusterService.submitStateUpdateTask(
-            "add-read-only-block-for-tiering [" + request.getIndex() + "]",
+            "add-write-block-for-tiering [" + request.getIndex() + "]",
             new ClusterStateUpdateTask(Priority.URGENT) {
                 @Override
                 public ClusterState execute(ClusterState currentState) {
@@ -141,18 +141,15 @@ public class TransportHotToWarmTierAction extends TransportTierAction {
 
                 @Override
                 public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
-                    logger.info("Read-only block added for index [{}], proceeding with pre-tiering sync", request.getIndex());
+                    logger.info("Write block added for index [{}], proceeding with pre-tiering sync", request.getIndex());
                     executePrepareTiering(request, newState, listener, 1);
                 }
 
                 @Override
                 public void onFailure(String source, Exception e) {
-                    logger.error("Failed to add read-only block for index [{}]", request.getIndex());
+                    logger.error("Failed to add write block for index [{}]", request.getIndex());
                     listener.onFailure(
-                        new IllegalStateException(
-                            "Failed to add read-only block for DFA index [" + request.getIndex() + "]. Please retry.",
-                            e
-                        )
+                        new IllegalStateException("Failed to add write block for DFA index [" + request.getIndex() + "]. Please retry.", e)
                     );
                 }
             }
@@ -163,7 +160,7 @@ public class TransportHotToWarmTierAction extends TransportTierAction {
      * Step 2: Execute the prepare tiering action (flush + refresh + waitForRemoteStoreSync) on primary shards.
      * Retries up to MAX_PREPARE_RETRIES times on shard failures before giving up.
      * On success, proceeds to step 3 (tier).
-     * On final failure, removes the read-only block to avoid leaving the index in a stuck state.
+     * On final failure, removes the write block to avoid leaving the index in a stuck state.
      */
     private void executePrepareTiering(
         IndexTieringRequest request,
@@ -197,7 +194,7 @@ public class TransportHotToWarmTierAction extends TransportTierAction {
                         + broadcastResponse.getFailedShards()
                         + " shard(s) failed. Please retry the tiering request.";
                     logger.error(errorMsg);
-                    removeReadOnlyBlock(request.getIndex());
+                    removeWriteBlock(request.getIndex());
                     listener.onFailure(new IllegalStateException(errorMsg));
                     return;
                 }
@@ -205,7 +202,7 @@ public class TransportHotToWarmTierAction extends TransportTierAction {
                 try {
                     TransportHotToWarmTierAction.super.clusterManagerOperation(request, state, listener);
                 } catch (Exception e) {
-                    removeReadOnlyBlock(request.getIndex());
+                    removeWriteBlock(request.getIndex());
                     listener.onFailure(e);
                 }
             }
@@ -229,7 +226,7 @@ public class TransportHotToWarmTierAction extends TransportTierAction {
                     + MAX_PREPARE_RETRIES
                     + " attempts. Please retry.";
                 logger.error(errorMsg, e);
-                removeReadOnlyBlock(request.getIndex());
+                removeWriteBlock(request.getIndex());
                 listener.onFailure(new IllegalStateException(errorMsg, e));
             }
         });
@@ -240,9 +237,9 @@ public class TransportHotToWarmTierAction extends TransportTierAction {
      * Called on prepare failure to avoid leaving the index in a stuck write-blocked state.
      * Best-effort — if this fails, the user can manually remove the block via index settings.
      */
-    private void removeReadOnlyBlock(String indexName) {
+    private void removeWriteBlock(String indexName) {
         clusterService.submitStateUpdateTask(
-            "remove-read-only-block-for-tiering [" + indexName + "]",
+            "remove-write-block-for-tiering [" + indexName + "]",
             new ClusterStateUpdateTask(Priority.URGENT) {
                 @Override
                 public ClusterState execute(ClusterState currentState) {
@@ -268,7 +265,7 @@ public class TransportHotToWarmTierAction extends TransportTierAction {
                 @Override
                 public void onFailure(String source, Exception e) {
                     logger.warn(
-                        "Failed to remove read-only block for index [{}] after tiering failure: {}. "
+                        "Failed to remove write block for index [{}] after tiering failure: {}. "
                             + "Block can be removed manually via index settings.",
                         indexName,
                         e
@@ -277,7 +274,7 @@ public class TransportHotToWarmTierAction extends TransportTierAction {
 
                 @Override
                 public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
-                    logger.info("Read-only block removed for index [{}] after tiering failure", indexName);
+                    logger.info("Write block removed for index [{}] after tiering failure", indexName);
                 }
             }
         );

--- a/server/src/test/java/org/opensearch/storage/action/tiering/TransportHotToWarmTierActionTests.java
+++ b/server/src/test/java/org/opensearch/storage/action/tiering/TransportHotToWarmTierActionTests.java
@@ -31,10 +31,10 @@ import java.util.concurrent.atomic.AtomicReference;
  * Unit tests for the pre-tiering flush logic in {@link TransportHotToWarmTierAction}.
  * <p>
  * These tests verify the core decision logic:
- * - DFA indices get read-only block + prepare + tier
+ * - DFA indices get write block + prepare + tier
  * - Non-DFA indices skip prepare and go directly to tier
  * - Retry logic on partial shard failures
- * - Failure handling removes read-only block
+ * - Failure handling removes write block
  * <p>
  * The tests use a testable helper that replicates the action's logic without
  * requiring a full transport layer, since TransportAction.execute() is final.
@@ -103,7 +103,7 @@ public class TransportHotToWarmTierActionTests extends OpenSearchTestCase {
     }
 
     /**
-     * Adds a read-only block to the cluster state (same logic as TransportHotToWarmTierAction.addWriteBlockAndPrepare).
+     * Adds a write block to the cluster state (same logic as TransportHotToWarmTierAction.addWriteBlockAndPrepare).
      */
     private ClusterState addReadOnlyBlock(ClusterState currentState, String indexName) {
         IndexMetadata indexMetadata = currentState.metadata().index(indexName);
@@ -123,9 +123,9 @@ public class TransportHotToWarmTierActionTests extends OpenSearchTestCase {
     }
 
     /**
-     * Removes the read-only block from the cluster state (same logic as TransportHotToWarmTierAction.removeReadOnlyBlock).
+     * Removes the write block from the cluster state (same logic as TransportHotToWarmTierAction.removeWriteBlock).
      */
-    private ClusterState removeReadOnlyBlock(ClusterState currentState, String indexName) {
+    private ClusterState removeWriteBlock(ClusterState currentState, String indexName) {
         IndexMetadata indexMetadata = currentState.metadata().index(indexName);
         if (indexMetadata == null) {
             return currentState;
@@ -204,7 +204,7 @@ public class TransportHotToWarmTierActionTests extends OpenSearchTestCase {
 
         assertTrue("Index should be detected as DFA", isDfaIndex(indexName, state));
 
-        // Add read-only block (simulates the cluster state update task)
+        // Add write block (simulates the cluster state update task)
         ClusterState stateWithBlock = addReadOnlyBlock(state, indexName);
 
         // Verify block was added
@@ -235,13 +235,13 @@ public class TransportHotToWarmTierActionTests extends OpenSearchTestCase {
     }
 
     /**
-     * Tests that prepare action failure (after retries) removes the read-only block and fails the request.
+     * Tests that prepare action failure (after retries) removes the write block and fails the request.
      */
     public void testDfaIndex_PrepareFailureAfterRetriesRemovesBlockAndFails() {
         String indexName = "test-dfa-index";
         ClusterState state = buildClusterStateWithDfaIndex(indexName, 1, 1);
 
-        // Add read-only block
+        // Add write block
         ClusterState stateWithBlock = addReadOnlyBlock(state, indexName);
 
         AtomicInteger prepareCalls = new AtomicInteger(0);
@@ -253,8 +253,8 @@ public class TransportHotToWarmTierActionTests extends OpenSearchTestCase {
             listener.onFailure(new RuntimeException("Remote store sync failed"));
         }, ActionListener.wrap(v -> fail("Should not succeed"), e -> fail("unexpected")), ActionListener.wrap(e -> {
             capturedFailure.set(e);
-            // Simulate removing the read-only block on failure
-            ClusterState restored = removeReadOnlyBlock(stateWithBlock, indexName);
+            // Simulate removing the write block on failure
+            ClusterState restored = removeWriteBlock(stateWithBlock, indexName);
             assertFalse(
                 "Read-only block should be removed after failure",
                 restored.blocks().hasIndexBlock(indexName, IndexMetadata.INDEX_WRITE_BLOCK)
@@ -394,7 +394,7 @@ public class TransportHotToWarmTierActionTests extends OpenSearchTestCase {
     }
 
     /**
-     * Tests that the read-only block is properly removed from the cluster state.
+     * Tests that the write block is properly removed from the cluster state.
      */
     public void testRemoveReadOnlyBlock_RestoresOriginalState() {
         String indexName = "test-dfa-index";
@@ -405,7 +405,7 @@ public class TransportHotToWarmTierActionTests extends OpenSearchTestCase {
         assertTrue("Block should be present", stateWithBlock.blocks().hasIndexBlock(indexName, IndexMetadata.INDEX_WRITE_BLOCK));
 
         // Remove block
-        ClusterState stateWithoutBlock = removeReadOnlyBlock(stateWithBlock, indexName);
+        ClusterState stateWithoutBlock = removeWriteBlock(stateWithBlock, indexName);
         assertFalse("Block should be removed", stateWithoutBlock.blocks().hasIndexBlock(indexName, IndexMetadata.INDEX_WRITE_BLOCK));
         assertFalse(
             "Read-only setting should be false",
@@ -468,7 +468,7 @@ public class TransportHotToWarmTierActionTests extends OpenSearchTestCase {
     }
 
     /**
-     * Tests that adding a read-only block when it is already present (retry scenario) is idempotent.
+     * Tests that adding a write block when it is already present (retry scenario) is idempotent.
      */
     public void testDfaIndex_ReadOnlyBlockAlreadyPresent_IsIdempotent() {
         String indexName = "test-dfa-index";
@@ -531,15 +531,15 @@ public class TransportHotToWarmTierActionTests extends OpenSearchTestCase {
 
         assertNotNull("Failure should be captured", capturedFailure.get());
 
-        // Simulate removeReadOnlyBlock with null metadata (index deleted)
+        // Simulate removeWriteBlock with null metadata (index deleted)
         Metadata emptyMetadata = Metadata.builder().build();
         ClusterState stateWithoutIndex = ClusterState.builder(ClusterName.DEFAULT)
             .metadata(emptyMetadata)
             .blocks(ClusterBlocks.EMPTY_CLUSTER_BLOCK)
             .build();
 
-        // removeReadOnlyBlock should handle null metadata gracefully (return state unchanged)
-        ClusterState result = removeReadOnlyBlock(stateWithoutIndex, indexName);
+        // removeWriteBlock should handle null metadata gracefully (return state unchanged)
+        ClusterState result = removeWriteBlock(stateWithoutIndex, indexName);
         assertNotNull("Result should not be null", result);
         assertSame("State should be unchanged when index metadata is null", stateWithoutIndex, result);
     }
@@ -586,7 +586,7 @@ public class TransportHotToWarmTierActionTests extends OpenSearchTestCase {
     // ── Preflight validation ordering tests ──────────────────────────────────────
 
     /**
-     * When preflight validation fails for a DFA index, the read-only block must NOT be added
+     * When preflight validation fails for a DFA index, the write block must NOT be added
      * and the listener must receive the failure immediately.
      *
      * This is the key ordering fix: validate BEFORE adding block or running prepare.
@@ -597,9 +597,9 @@ public class TransportHotToWarmTierActionTests extends OpenSearchTestCase {
 
         // Precondition: index is DFA
         assertTrue("Precondition: index must be DFA", isDfaIndex(indexName, state));
-        // Precondition: no read-only block yet
+        // Precondition: no write block yet
         assertFalse(
-            "Precondition: no read-only block before validation",
+            "Precondition: no write block before validation",
             state.blocks().hasIndexBlock(indexName, IndexMetadata.INDEX_WRITE_BLOCK)
         );
 
@@ -633,7 +633,7 @@ public class TransportHotToWarmTierActionTests extends OpenSearchTestCase {
         assertNotNull("Listener must have received validation failure", capturedFailure.get());
         assertEquals("Failure must be the validation error", validationError, capturedFailure.get());
 
-        // Verify: read-only block was NOT added (state unchanged)
+        // Verify: write block was NOT added (state unchanged)
         assertFalse(
             "Read-only block must NOT be added when preflight validation fails",
             stateAfterBlock.get().blocks().hasIndexBlock(indexName, IndexMetadata.INDEX_WRITE_BLOCK)
@@ -642,7 +642,7 @@ public class TransportHotToWarmTierActionTests extends OpenSearchTestCase {
 
     /**
      * When preflight validation passes for a DFA index, the flow proceeds to add the
-     * read-only block and run prepare. This is the happy-path ordering.
+     * write block and run prepare. This is the happy-path ordering.
      */
     public void testDfaPreflightValidationPassesThenAddsReadOnlyBlock() {
         String indexName = "dfa-validate-pass";
@@ -651,7 +651,7 @@ public class TransportHotToWarmTierActionTests extends OpenSearchTestCase {
         // Precondition
         assertTrue("Precondition: index must be DFA", isDfaIndex(indexName, state));
         assertFalse(
-            "Precondition: no read-only block before validation",
+            "Precondition: no write block before validation",
             state.blocks().hasIndexBlock(indexName, IndexMetadata.INDEX_WRITE_BLOCK)
         );
 
@@ -677,7 +677,7 @@ public class TransportHotToWarmTierActionTests extends OpenSearchTestCase {
         // Verify: no failure
         assertNull("Listener must NOT have received a failure when validation passes", capturedFailure.get());
 
-        // Verify: read-only block WAS added (flow proceeded)
+        // Verify: write block WAS added (flow proceeded)
         assertTrue(
             "Read-only block must be added after preflight validation passes",
             stateAfterBlock.get().blocks().hasIndexBlock(indexName, IndexMetadata.INDEX_WRITE_BLOCK)
@@ -712,9 +712,9 @@ public class TransportHotToWarmTierActionTests extends OpenSearchTestCase {
         // Verify: the DFA gate correctly identifies this as non-DFA
         assertFalse("Non-DFA index must not pass isDfaIndex() check — preflight not called for non-DFA", isDfaIndex(indexName, state));
 
-        // Verify: no read-only block is added for non-DFA (non-DFA goes directly to super.clusterManagerOperation)
+        // Verify: no write block is added for non-DFA (non-DFA goes directly to super.clusterManagerOperation)
         assertFalse(
-            "Non-DFA index must not have a read-only block added (no DFA path taken)",
+            "Non-DFA index must not have a write block added (no DFA path taken)",
             state.blocks().hasIndexBlock(indexName, IndexMetadata.INDEX_WRITE_BLOCK)
         );
     }
@@ -730,7 +730,7 @@ public class TransportHotToWarmTierActionTests extends OpenSearchTestCase {
         ClusterState stateWithBlock = addReadOnlyBlock(state, indexName);
 
         assertEquals(
-            "settingsVersion must increment by 1 when read-only block is added",
+            "settingsVersion must increment by 1 when write block is added",
             originalVersion + 1,
             stateWithBlock.metadata().index(indexName).getSettingsVersion()
         );
@@ -774,23 +774,23 @@ public class TransportHotToWarmTierActionTests extends OpenSearchTestCase {
         );
     }
 
-    /** removeReadOnlyBlock must increment settingsVersion by 1. */
+    /** removeWriteBlock must increment settingsVersion by 1. */
     public void testRemoveReadOnlyBlock_IncrementsSettingsVersion() {
         String indexName = "test-dfa-index";
         ClusterState state = buildClusterStateWithDfaIndex(indexName, 1, 1);
         ClusterState stateWithBlock = addReadOnlyBlock(state, indexName);
         long versionBeforeRemove = stateWithBlock.metadata().index(indexName).getSettingsVersion();
 
-        ClusterState stateAfterRemove = removeReadOnlyBlock(stateWithBlock, indexName);
+        ClusterState stateAfterRemove = removeWriteBlock(stateWithBlock, indexName);
 
         assertEquals(
-            "settingsVersion must increment by 1 when read-only block is removed",
+            "settingsVersion must increment by 1 when write block is removed",
             versionBeforeRemove + 1,
             stateAfterRemove.metadata().index(indexName).getSettingsVersion()
         );
     }
 
-    /** removeReadOnlyBlock on a state where block was never added must return state unchanged (no-op). */
+    /** removeWriteBlock on a state where block was never added must return state unchanged (no-op). */
     public void testRemoveReadOnlyBlock_WhenBlockNotPresent_IsNoOp() {
         String indexName = "test-dfa-index";
         ClusterState state = buildClusterStateWithDfaIndex(indexName, 1, 1);
@@ -798,9 +798,9 @@ public class TransportHotToWarmTierActionTests extends OpenSearchTestCase {
         // Block is NOT present
         assertFalse("Precondition: block must not be present", state.blocks().hasIndexBlock(indexName, IndexMetadata.INDEX_WRITE_BLOCK));
 
-        // removeReadOnlyBlock should still work (settings.put(false) on already-false value)
+        // removeWriteBlock should still work (settings.put(false) on already-false value)
         // — it does NOT return the same state object because it rebuilds, but it must not throw
-        ClusterState result = removeReadOnlyBlock(state, indexName);
+        ClusterState result = removeWriteBlock(state, indexName);
         assertNotNull("Result must not be null", result);
         assertFalse(
             "Block must not be present after removing a non-existent block",
@@ -1135,14 +1135,14 @@ public class TransportHotToWarmTierActionTests extends OpenSearchTestCase {
         // Step 2: preflight validation passes (simulated by no exception)
         boolean validationPassed = true; // no exception thrown
 
-        // Step 3: add read-only block
+        // Step 3: add write block
         ClusterState stateWithBlock = null;
         if (validationPassed) {
             stateWithBlock = addReadOnlyBlock(state, indexName);
         }
         assertNotNull("Block state must not be null", stateWithBlock);
         assertTrue(
-            "Step 3: read-only block must be present",
+            "Step 3: write block must be present",
             stateWithBlock.blocks().hasIndexBlock(indexName, IndexMetadata.INDEX_WRITE_BLOCK)
         );
 
@@ -1172,7 +1172,7 @@ public class TransportHotToWarmTierActionTests extends OpenSearchTestCase {
      * 2. Preflight validation passes
      * 3. addReadOnlyBlock → block present
      * 4. executePrepareTiering → fails all 3 retries
-     * 5. removeReadOnlyBlock → block removed from cluster state
+     * 5. removeWriteBlock → block removed from cluster state
      * 6. Failure callback invoked with error message
      */
     public void testFullFailurePath_DfaIndex_ValidationPassesPrepareFails_BlockRemoved() {
@@ -1194,8 +1194,8 @@ public class TransportHotToWarmTierActionTests extends OpenSearchTestCase {
             ActionListener.wrap(v -> fail("Should not succeed"), e -> fail("unexpected")),
             ActionListener.wrap(e -> {
                 capturedFailure.set(e);
-                // Step 5: simulate removeReadOnlyBlock on failure
-                stateAfterCleanup.set(removeReadOnlyBlock(stateWithBlock, indexName));
+                // Step 5: simulate removeWriteBlock on failure
+                stateAfterCleanup.set(removeWriteBlock(stateWithBlock, indexName));
             }, ex -> fail("unexpected")),
             1
         );
@@ -1204,14 +1204,14 @@ public class TransportHotToWarmTierActionTests extends OpenSearchTestCase {
         assertNotNull("Step 6: failure must be captured", capturedFailure.get());
         assertTrue("Error must mention attempts", capturedFailure.get().getMessage().contains("attempts"));
         assertFalse(
-            "Step 5: read-only block must be removed after prepare failure",
+            "Step 5: write block must be removed after prepare failure",
             stateAfterCleanup.get().blocks().hasIndexBlock(indexName, IndexMetadata.INDEX_WRITE_BLOCK)
         );
     }
 
     /**
      * Full failure path: preflight validation fails immediately —
-     * NO read-only block added, NO prepare called, immediate failure returned.
+     * NO write block added, NO prepare called, immediate failure returned.
      */
     public void testFullFailurePath_DfaIndex_ValidationFails_NothingDone() {
         String indexName = "validation-fail-dfa";


### PR DESCRIPTION
### Description

**1. Fail-fast guard in `ParquetDataFormatStoreHandler` when native remote store is unavailable**

`ParquetDataFormatStoreHandler` creates a tiered object store (Parquet → Foyer cache → remote object store) in its constructor. On a warm shard, the remote object store pointer (`remotePtr`) must be non-zero — without it, every read would silently fall through to a null-pointer dereference inside native code.

Before this change, if `repo` was `null` or `repo.isLive()` returned `false`, `remotePtr` was `0L` and the code proceeded to call `TieredStorageBridge.createTieredObjectStore(0L, 0L, cachePtr)` — undefined behaviour in native Rust code that could produce silent data corruption, a JVM crash, or an opaque segfault rather than a clear actionable error.

The guard added:
```java
if (remotePtr == 0L) {
    throw new IllegalStateException(
        "[" + shardId + "] remote object store is not available for this warm shard. Cannot serve read requests."
    );
}
```
makes the failure mode explicit: the shard open fails with a descriptive Java exception, the cluster marks the shard as ALLOCATION_FAILED, retries allocation on another node, and the operator gets a clear error message. This is the correct contract — a warm shard without a remote store is misconfigured and must not silently serve incorrect data.



**2. Foyer block cache — scheduler task resilience (`foyer_cache.rs` + `tests.rs`)**

The sweep task (`reconcile_key_index`) and persist task (`key_index_store::save`) previously had no error boundary. A panic inside either would silently kill the background task for the node's lifetime, leaving the key_index permanently stale or never persisted again.

Both tasks now wrap their critical sections in `std::panic::catch_unwind(AssertUnwindSafe(...))` — panics are caught, logged as ERROR, and the task continues on the next tick. An outer restart loop with exponential back-off (1 s → 2 s → … capped at 60 s) ensures the scheduler never goes permanently dark if the inner select loop exits unexpectedly. `tests.rs` adds unit tests covering panic recovery, I/O error retry, and back-off restart behaviour.



**3. Native store provider wired through `ReloadableFsRepository` and `RepositoriesModule`**

`FsRepository` already supported a `NativeRemoteObjectStoreProvider` constructor (added earlier to support S3/GCS warm nodes). `ReloadableFsRepository` — a subclass used by test clusters and some production configurations — was missing this constructor, so its `nativeStore` field always defaulted to `NativeStoreRepository.EMPTY` (`isLive() == false`), which caused `remotePtr` to always be `0L`.

Changes:
- `ReloadableFsRepository`: adds the `NativeRemoteObjectStoreProvider` constructor that delegates to `super`, matching the existing `FsRepository` pattern.
- `RepositoriesModule`: passes `fsNativeProvider` to the `ReloadableFsRepository.TYPE` factory, closing the gap for any production node that registers a reloadable-fs repo.
- `MockFsMetadataSupportedRepository` (internalClusterTest): adds the same constructor so the test mock can be constructed with a native provider when the integration test requires it.

**4 Integration tests for warm-tier DFA remote store recovery (`DataFormatAwareReadonlyEngineBaseIT`)**

The ITs are needed because the above changes form a contract that requires end-to-end validation across the JVM↔native boundary: the native store must be live, the shard must open, data must be readable, and recovery from remote store must produce an identical data set. Unit tests cannot cover this — only a real cluster startup with real shard allocation, real Parquet file writes to remote store, and real shard recovery can prove the contract holds.

`RemoteStoreBaseIntegTestCase` randomly picks between two mock repository types (`fs_metadata_supported_repository` and `fs_multipart_repository`) via `metadataSupportedType = randomBoolean()`. Neither was wired with a `NativeRemoteObjectStoreProvider`, so the guard added in (1) fired on every test run. The fix replaces both mock plugins with native-provider-aware inner classes (`NativeAwareMockFsMetadataSupportedRepositoryPlugin` for `fs_metadata_supported_repository` and `NativeAwareMockFsRepositoryPlugin` for `fs_multipart_repository`) that wire `FsNativeObjectStorePlugin`, covering both random paths. `nodeSettings` pre-creates the remote store directories on disk so Rust's `canonicalize()` succeeds at node startup.

With the infrastructure correct, `DataFormatAwareReadonlyEngineRemoteStoreRecoveryIT` asserts two recovery contracts:
- **New replica recovery**: after scaling replicas from 0 to 1, the replica recovers from remote store. The test asserts that the recovered replica's Parquet catalog files (data files, excluding Lucene segment metadata) are an exact set-equality match with the primary's catalog — proving the full Parquet data set was replicated correctly via the remote store path.
- **Primary restart recovery**: after restarting the primary node, the test asserts that the re-opened engine is a `DataFormatAwareReadOnlyEngine` (not a fallback Lucene engine) and that the Parquet catalog is identical to the pre-restart snapshot — proving that warm shard state survives a node restart and is correctly recovered from remote store.

**5. `TransportHotToWarmTierAction` refactoring**

The DFA preflight flow for hot-to-warm tiering — capacity validation → add write block (persisted to index metadata) → pre-tiering sync with up to 3 retries → tier — was reorganised into cleaner extracted methods (`addWriteBlockAndPrepare`, `executePrepareTiering`, `removeWriteBlock`), with the non-DFA path bypassing the preflight entirely. `TransportHotToWarmTierActionTests` is updated to match the new mock structure and method signatures.

**6. `BlockCacheKeyIndexScaleIT` flakiness fix**

`testKeyIndexJsonWrittenOnShutdown` and `testEvictPrefixAfterRecovery` both call `restartNode()` followed by bare `ensureGreen()`. The default 30-second timeout is insufficient when 25 REMOTE_SNAPSHOT shards (5 indices × 5 shards) need to re-open after the warm node restarts under load. Both calls are raised to `ensureGreen(TimeValue.timeValueSeconds(120))`.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
