### PR TITLE
[Analytics Engine] Add DF metrics to profile API response

### DIFF
--- a/sandbox/libs/analytics-api/src/main/java/org/opensearch/analytics/exec/profile/TaskProfile.java
+++ b/sandbox/libs/analytics-api/src/main/java/org/opensearch/analytics/exec/profile/TaskProfile.java
@@ -12,17 +12,23 @@ import org.opensearch.core.xcontent.ToXContentObject;
 import org.opensearch.core.xcontent.XContentBuilder;
 
 import java.io.IOException;
+import java.util.Map;
 
 /**
- * Per-task profile snapshot. Captures target node, terminal state and
- * wall-clock elapsed time. A "task" is one dispatch unit within a stage
- * (one shard for SOURCE, one partition for HASH_PARTITIONED, one total for COORDINATOR).
+ * Per-task profile snapshot. Captures target node, terminal state,
+ * wall-clock elapsed time, and optional data-node execution metrics.
  *
  * @param node target node and shard the task ran on, or "(unknown)" if dispatch never happened
  * @param state terminal state — CREATED if the task was never dispatched
  * @param elapsedMs wall-clock time from dispatch to terminal, or 0 if never dispatched
+ * @param dataNodeMetrics execution metrics from the data node (DataFusion operator timings), or null if not profiled
  */
-public record TaskProfile(String node, String state, long elapsedMs) implements ToXContentObject {
+public record TaskProfile(String node, String state, long elapsedMs, Map<String, Long> dataNodeMetrics) implements ToXContentObject {
+
+    /** Convenience constructor without data node metrics. */
+    public TaskProfile(String node, String state, long elapsedMs) {
+        this(node, state, elapsedMs, null);
+    }
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
@@ -30,6 +36,13 @@ public record TaskProfile(String node, String state, long elapsedMs) implements 
         builder.field("node", node);
         builder.field("state", state);
         builder.field("elapsed_ms", elapsedMs);
+        if (dataNodeMetrics != null && dataNodeMetrics.isEmpty() == false) {
+            builder.startObject("data_node_metrics");
+            for (Map.Entry<String, Long> entry : dataNodeMetrics.entrySet()) {
+                builder.field(entry.getKey(), entry.getValue());
+            }
+            builder.endObject();
+        }
         builder.endObject();
         return builder;
     }

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/AnalyticsSearchService.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/AnalyticsSearchService.java
@@ -42,6 +42,7 @@ import org.opensearch.tasks.Task;
 import org.opensearch.tasks.TaskResourceTrackingService;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -176,18 +177,24 @@ public class AnalyticsSearchService implements AutoCloseable {
                         responseHandler.onBatch(batch);
                     }
                     long fragmentTookNanos = System.nanoTime() - startNanos;
-                    // Extract and log DataFusion execution metrics at DEBUG level
-                    if (LOGGER.isDebugEnabled()) {
+                    // Extract DataFusion execution metrics only when needed
+                    if (request.profile() || LOGGER.isDebugEnabled()) {
                         byte[] metricsJson = exec.resources().getExecutionMetrics();
-                        if (metricsJson != null) {
+                        if (LOGGER.isDebugEnabled() && metricsJson != null) {
                             LOGGER.debug(
                                 "[FragmentMetrics] shard={} metrics={}",
                                 shard.shardId(),
-                                new String(metricsJson, java.nio.charset.StandardCharsets.UTF_8)
+                                new String(metricsJson, StandardCharsets.UTF_8)
                             );
                         }
+                        if (request.profile() && metricsJson != null) {
+                            responseHandler.onCompleteWithMetrics(metricsJson);
+                        } else {
+                            responseHandler.onComplete();
+                        }
+                    } else {
+                        responseHandler.onComplete();
                     }
-                    responseHandler.onComplete();
                     ResolvedFragment resolved = exec.resolved();
                     DelegationDescriptor delegation = resolved.plan().getDelegationDescriptor();
                     boolean usedSecondaryIndex = delegation != null;
@@ -349,6 +356,11 @@ public class AnalyticsSearchService implements AutoCloseable {
         void onBatch(EngineResultBatch batch) throws Exception;
 
         void onComplete();
+
+        /** Called with execution metrics when profiling is enabled. Default delegates to onComplete(). */
+        default void onCompleteWithMetrics(byte[] metrics) {
+            onComplete();
+        }
 
         void onFailure(Exception e);
     }

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/AnalyticsSearchTransportService.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/AnalyticsSearchTransportService.java
@@ -8,8 +8,9 @@
 
 package org.opensearch.analytics.exec;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.types.pojo.Schema;
 import org.opensearch.analytics.backend.EngineResultBatch;
 import org.opensearch.analytics.exec.action.FetchByRowIdsAction;
 import org.opensearch.analytics.exec.action.FetchByRowIdsRequest;
@@ -52,7 +53,6 @@ import java.io.IOException;
  */
 @Singleton
 public class AnalyticsSearchTransportService {
-    private static final Logger logger = LogManager.getLogger(AnalyticsSearchTransportService.class);
 
     private final StreamTransportService transportService;
     private final ClusterService clusterService;
@@ -152,13 +152,36 @@ public class AnalyticsSearchTransportService {
      */
     private static AnalyticsSearchService.StreamingFragmentResponseHandler channelResponseHandler(TransportChannel channel) {
         return new AnalyticsSearchService.StreamingFragmentResponseHandler() {
+            private Schema batchSchema = null;
+            private BufferAllocator batchAllocator = null;
+
             @Override
             public void onBatch(EngineResultBatch batch) throws Exception {
-                channel.sendResponseBatch(new FragmentExecutionArrowResponse(batch.getArrowRoot()));
+                VectorSchemaRoot root = batch.getArrowRoot();
+                if (batchSchema == null && root.getFieldVectors().isEmpty() == false) {
+                    batchSchema = root.getSchema();
+                    batchAllocator = root.getFieldVectors().getFirst().getAllocator();
+                }
+                channel.sendResponseBatch(new FragmentExecutionArrowResponse(root));
             }
 
             @Override
             public void onComplete() {
+                channel.completeStream();
+            }
+
+            @Override
+            public void onCompleteWithMetrics(byte[] metrics) {
+                if (batchSchema != null && batchAllocator != null) {
+                    VectorSchemaRoot sentinel = VectorSchemaRoot.create(batchSchema, batchAllocator);
+                    sentinel.setRowCount(0);
+                    try {
+                        channel.sendResponseBatch(new FragmentExecutionArrowResponse(sentinel, metrics));
+                    } catch (Exception e) {
+                        // Stream may already be cancelled — close sentinel to prevent leak
+                        sentinel.close();
+                    }
+                }
                 channel.completeStream();
             }
 
@@ -240,15 +263,32 @@ public class AnalyticsSearchTransportService {
                 try {
                     FragmentExecutionArrowResponse last = stream.nextResponse();
                     while (last != null) {
+                        // Profiling sentinel: 0 rows with metadata attached. Deliver metrics and exit.
+                        if (last.getRoot() != null && last.getRoot().getRowCount() == 0 && last.getMetadata() != null) {
+                            listener.onStreamComplete(last.getMetadata());
+                            last.getRoot().close();
+                            return;
+                        }
+
                         FragmentExecutionArrowResponse next = stream.nextResponse();
-                        boolean isLast = next == null;
+                        // Treat sentinel as end-of-stream: the current batch is the last real data batch.
+                        boolean nextIsSentinel = next != null
+                            && next.getRoot() != null
+                            && next.getRoot().getRowCount() == 0
+                            && next.getMetadata() != null;
+                        boolean isLast = next == null || nextIsSentinel;
+
+                        // Deliver metrics BEFORE signalling isLast so they're stored on the
+                        // task before the profile snapshot fires.
+                        if (nextIsSentinel) {
+                            listener.onStreamComplete(next.getMetadata());
+                            next.getRoot().close();
+                        }
+
                         boolean keepReading = listener.onStreamResponse(last, isLast);
-                        if (!keepReading) {
-                            if (next != null) {
-                                if (next.getRoot() != null) {
-                                    next.getRoot().close();
-                                }
-                                logger.debug("[early-term] cancelling shard stream: reduce input satisfied (downstream consumer finished)");
+                        if (!keepReading || nextIsSentinel) {
+                            if (!isLast && next != null) {
+                                if (next.getRoot() != null) next.getRoot().close();
                                 stream.cancel("reduce input satisfied (downstream consumer finished)", null);
                             }
                             return;

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/DefaultPlanExecutor.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/DefaultPlanExecutor.java
@@ -286,11 +286,12 @@ public class DefaultPlanExecutor extends HandledTransportAction<AnalyticsQueryRe
                 dag,
                 threadPool,
                 queryTask,
-                queryAllocator,
-                ownsAllocator,
                 maxConcurrentShardRequestsPerNode,
                 maxShardsPerQuery,
-                List.of(queryListener)
+                List.of(queryListener),
+                queryAllocator,
+                ownsAllocator,
+                profile
             );
         } catch (Exception e) {
             if (ownsAllocator) queryAllocator.close();

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/QueryContext.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/QueryContext.java
@@ -47,6 +47,7 @@ public class QueryContext {
     private final List<AnalyticsOperationListener> operationListeners;
     private final BufferAllocator allocator;
     private final boolean ownsAllocator;
+    private final boolean profile;
     private volatile ExecutorService localTaskExecutor;
     private boolean closed;  // guarded by `this`
     /**
@@ -66,42 +67,8 @@ public class QueryContext {
      */
     private final Map<Integer, Map<Integer, ShardExecutionTarget>> resolvedTargetsByStage = new HashMap<>();
 
+    /** Full-parameter constructor. Tests use {@link #forTest} factories. */
     public QueryContext(
-        QueryDAG dag,
-        ThreadPool threadPool,
-        AnalyticsQueryTask parentTask,
-        BufferAllocator allocator,
-        boolean ownsAllocator,
-        int maxConcurrentShardRequestsPerNode,
-        int maxShardsPerQuery
-    ) {
-        this(dag, threadPool, parentTask, maxConcurrentShardRequestsPerNode, maxShardsPerQuery, List.of(), allocator, ownsAllocator);
-    }
-
-    public QueryContext(
-        QueryDAG dag,
-        ThreadPool threadPool,
-        AnalyticsQueryTask parentTask,
-        BufferAllocator allocator,
-        boolean ownsAllocator,
-        int maxConcurrentShardRequestsPerNode,
-        int maxShardsPerQuery,
-        List<AnalyticsOperationListener> operationListeners
-    ) {
-        this(
-            dag,
-            threadPool,
-            parentTask,
-            maxConcurrentShardRequestsPerNode,
-            maxShardsPerQuery,
-            operationListeners,
-            allocator,
-            ownsAllocator
-        );
-    }
-
-    /** Full-parameter constructor. Private; tests use {@link #forTest} factories. */
-    private QueryContext(
         QueryDAG dag,
         ThreadPool threadPool,
         AnalyticsQueryTask parentTask,
@@ -109,7 +76,8 @@ public class QueryContext {
         int maxShardsPerQuery,
         List<AnalyticsOperationListener> operationListeners,
         BufferAllocator allocator,
-        boolean ownsAllocator
+        boolean ownsAllocator,
+        boolean profile
     ) {
         this.dag = dag;
         this.threadPool = threadPool;
@@ -119,10 +87,16 @@ public class QueryContext {
         this.operationListeners = operationListeners;
         this.allocator = allocator;
         this.ownsAllocator = ownsAllocator;
+        this.profile = profile;
     }
 
     public QueryDAG dag() {
         return dag;
+    }
+
+    /** Whether profiling is enabled for this query (data nodes should collect and return metrics). */
+    public boolean profile() {
+        return profile;
     }
 
     public Executor searchExecutor() {
@@ -251,7 +225,8 @@ public class QueryContext {
             DEFAULT_MAX_SHARDS_PER_QUERY,
             operationListeners,
             testAllocator,
-            true
+            true,
+            false
         );
     }
 }

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/StreamingResponseListener.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/StreamingResponseListener.java
@@ -40,6 +40,13 @@ public interface StreamingResponseListener<Resp extends ActionResponse> {
     boolean onStreamResponse(Resp response, boolean isLast);
 
     /**
+     * Called after the stream is exhausted with any trailing metadata sent by the data node.
+     *
+     * @param trailingMetadata application metadata bytes, or {@code null} if none sent
+     */
+    default void onStreamComplete(byte[] trailingMetadata) {}
+
+    /**
      * Called when the request fails. Terminal failure event.
      *
      * @param e the exception that caused the failure

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/action/FragmentExecutionArrowResponse.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/action/FragmentExecutionArrowResponse.java
@@ -26,6 +26,10 @@ public class FragmentExecutionArrowResponse extends ArrowBatchResponse {
         super(root);
     }
 
+    public FragmentExecutionArrowResponse(VectorSchemaRoot root, byte[] metadata) {
+        super(root, metadata);
+    }
+
     public FragmentExecutionArrowResponse(StreamInput in) throws IOException {
         super(in);
     }

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/action/FragmentExecutionRequest.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/action/FragmentExecutionRequest.java
@@ -40,12 +40,18 @@ public class FragmentExecutionRequest extends ActionRequest implements ShardInvo
     private final int stageId;
     private final ShardId shardId;
     private final List<PlanAlternative> planAlternatives;
+    private final boolean profile;
 
     public FragmentExecutionRequest(String queryId, int stageId, ShardId shardId, List<PlanAlternative> planAlternatives) {
+        this(queryId, stageId, shardId, planAlternatives, false);
+    }
+
+    public FragmentExecutionRequest(String queryId, int stageId, ShardId shardId, List<PlanAlternative> planAlternatives, boolean profile) {
         this.queryId = queryId;
         this.stageId = stageId;
         this.shardId = shardId;
         this.planAlternatives = planAlternatives;
+        this.profile = profile;
     }
 
     public FragmentExecutionRequest(StreamInput in) throws IOException {
@@ -58,6 +64,7 @@ public class FragmentExecutionRequest extends ActionRequest implements ShardInvo
         for (int i = 0; i < numAlternatives; i++) {
             planAlternatives.add(new PlanAlternative(in));
         }
+        this.profile = in.readBoolean();
     }
 
     @Override
@@ -70,6 +77,7 @@ public class FragmentExecutionRequest extends ActionRequest implements ShardInvo
         for (PlanAlternative alt : planAlternatives) {
             alt.writeTo(out);
         }
+        out.writeBoolean(profile);
     }
 
     public String getQueryId() {
@@ -86,6 +94,10 @@ public class FragmentExecutionRequest extends ActionRequest implements ShardInvo
 
     public List<PlanAlternative> getPlanAlternatives() {
         return planAlternatives;
+    }
+
+    public boolean profile() {
+        return profile;
     }
 
     @Override

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/profile/QueryProfileBuilder.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/profile/QueryProfileBuilder.java
@@ -20,9 +20,14 @@ import org.opensearch.analytics.planner.dag.Stage;
 import org.opensearch.analytics.spi.FilterDelegationInstructionNode;
 import org.opensearch.analytics.spi.InstructionNode;
 import org.opensearch.analytics.spi.ShardScanWithDelegationInstructionNode;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.xcontent.DeprecationHandler;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Snapshots an {@link ExecutionGraph} into a {@link QueryProfile}. Pure read — no
@@ -99,9 +104,29 @@ public final class QueryProfileBuilder {
             long start = t.startedAtMs();
             long end = t.finishedAtMs();
             long elapsed = (start > 0 && end > 0) ? end - start : 0L;
-            out.add(new TaskProfile(describeTarget(t), t.state().name(), elapsed));
+            Map<String, Long> metrics = parseDataNodeMetrics(t.dataNodeMetrics());
+            out.add(new TaskProfile(describeTarget(t), t.state().name(), elapsed, metrics));
         }
         return out;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Long> parseDataNodeMetrics(byte[] json) {
+        if (json == null || json.length == 0) return null;
+        try {
+            var parser = XContentType.JSON.xContent()
+                .createParser(NamedXContentRegistry.EMPTY, DeprecationHandler.IGNORE_DEPRECATIONS, json);
+            Map<String, Object> raw = parser.map();
+            Map<String, Long> result = new LinkedHashMap<>();
+            for (Map.Entry<String, Object> entry : raw.entrySet()) {
+                if (entry.getValue() instanceof Number n) {
+                    result.put(entry.getKey(), n.longValue());
+                }
+            }
+            return result.isEmpty() ? null : result;
+        } catch (Exception e) {
+            return null;
+        }
     }
 
     private static String describeTarget(StageTask task) {

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stage/StageTask.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stage/StageTask.java
@@ -33,6 +33,7 @@ public abstract class StageTask {
     private final AtomicReference<StageTaskState> state = new AtomicReference<>(StageTaskState.CREATED);
     private volatile long startedAtMs;
     private volatile long finishedAtMs;
+    private volatile byte[] dataNodeMetrics;
 
     protected StageTask(StageTaskId id) {
         this.id = id;
@@ -44,6 +45,16 @@ public abstract class StageTask {
 
     public StageTaskState state() {
         return state.get();
+    }
+
+    /** Raw JSON metrics bytes received from the data node, or null if not profiled. */
+    public byte[] dataNodeMetrics() {
+        return dataNodeMetrics;
+    }
+
+    /** Set by the coordinator when metrics arrive from the data node. */
+    public void setDataNodeMetrics(byte[] metrics) {
+        this.dataNodeMetrics = metrics;
     }
 
     /** Wall-clock millis stamped on the first successful transition to {@link StageTaskState#RUNNING}, or 0 if never dispatched. */

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stage/shard/ShardFragmentStageExecution.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stage/shard/ShardFragmentStageExecution.java
@@ -123,7 +123,8 @@ public class ShardFragmentStageExecution extends AbstractStageExecution implemen
      * offload: reordering would let isLast race ahead and drop earlier batches via the
      * stage-terminal short-circuit. Inline also preserves end-to-end backpressure.
      */
-    StreamingResponseListener<FragmentExecutionArrowResponse> responseListenerFor(int sourceOrdinal, ActionListener<Void> listener) {
+    StreamingResponseListener<FragmentExecutionArrowResponse> responseListenerFor(ShardStageTask task, ActionListener<Void> listener) {
+        final int sourceOrdinal = ((ShardExecutionTarget) task.target()).ordinal();
         return new StreamingResponseListener<>() {
             @Override
             public boolean onStreamResponse(FragmentExecutionArrowResponse response, boolean isLast) {
@@ -160,6 +161,13 @@ public class ShardFragmentStageExecution extends AbstractStageExecution implemen
                 }
                 if (isLast) listener.onResponse(null);
                 return true;
+            }
+
+            @Override
+            public void onStreamComplete(byte[] trailingMetadata) {
+                if (trailingMetadata != null) {
+                    task.setDataNodeMetrics(trailingMetadata);
+                }
             }
 
             @Override

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stage/shard/ShardFragmentStageExecutionFactory.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stage/shard/ShardFragmentStageExecutionFactory.java
@@ -60,7 +60,8 @@ public final class ShardFragmentStageExecutionFactory implements StageExecutionF
             queryId,
             stageId,
             target.shardId(),
-            planAlternatives
+            planAlternatives,
+            config.profile()
         );
         // Execution pulls the resolver off `stage` and calls resolve() lazily at start().
         // This keeps target resolution out of the build phase so cancellation before

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stage/shard/ShardTaskRunner.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stage/shard/ShardTaskRunner.java
@@ -55,7 +55,7 @@ public final class ShardTaskRunner implements TaskRunner<ShardStageTask> {
         transport.dispatchFragmentStreaming(
             request,
             target.node(),
-            stage.responseListenerFor(target.ordinal(), listener),
+            stage.responseListenerFor(task, listener),
             config.parentTask(),
             pending
         );

--- a/sandbox/plugins/test-ppl-frontend/src/main/java/org/opensearch/ppl/action/RestPPLQueryAction.java
+++ b/sandbox/plugins/test-ppl-frontend/src/main/java/org/opensearch/ppl/action/RestPPLQueryAction.java
@@ -44,30 +44,27 @@ public class RestPPLQueryAction extends BaseRestHandler {
 
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
-        String queryText;
+        String queryText = null;
+        boolean profile = false;
         try (XContentParser parser = request.contentParser()) {
-            queryText = parseQueryText(parser);
-        }
-        boolean explain = request.path().endsWith("/_explain");
-        PPLRequest pplRequest = new PPLRequest(queryText, explain);
-        return channel -> client.execute(UnifiedPPLExecuteAction.INSTANCE, pplRequest, new RestToXContentListener<>(channel));
-    }
-
-    private String parseQueryText(XContentParser parser) throws IOException {
-        String query = null;
-        parser.nextToken(); // START_OBJECT
-        while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
-            String fieldName = parser.currentName();
             parser.nextToken();
-            if ("query".equals(fieldName)) {
-                query = parser.text();
-            } else {
-                parser.skipChildren();
+            while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
+                String fieldName = parser.currentName();
+                parser.nextToken();
+                if ("query".equals(fieldName)) {
+                    queryText = parser.text();
+                } else if ("profile".equals(fieldName)) {
+                    profile = parser.booleanValue();
+                } else {
+                    parser.skipChildren();
+                }
             }
         }
-        if (query == null || query.isEmpty()) {
+        if (queryText == null || queryText.isEmpty()) {
             throw new IllegalArgumentException("Request body must contain a 'query' field");
         }
-        return query;
+        boolean enableProfile = profile || request.path().endsWith("/_explain");
+        PPLRequest pplRequest = new PPLRequest(queryText, enableProfile);
+        return channel -> client.execute(UnifiedPPLExecuteAction.INSTANCE, pplRequest, new RestToXContentListener<>(channel));
     }
 }

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/ExplainApiIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/ExplainApiIT.java
@@ -32,8 +32,10 @@ public class ExplainApiIT extends AnalyticsRestTestCase {
 
     private static final Dataset DATASET = new Dataset("calcs", "calcs");
     private static final Dataset CLICKBENCH = ClickBenchTestHelper.DATASET;
+    private static final Dataset DELEGATION = new Dataset("delegation", "delegation");
     private static boolean dataProvisioned = false;
     private static boolean clickBenchProvisioned = false;
+    private static boolean delegationProvisioned = false;
 
     @Override
     protected void onBeforeQuery() throws IOException {
@@ -47,6 +49,13 @@ public class ExplainApiIT extends AnalyticsRestTestCase {
         if (clickBenchProvisioned == false) {
             DatasetProvisioner.provision(client(), CLICKBENCH);
             clickBenchProvisioned = true;
+        }
+    }
+
+    private void ensureDelegationProvisioned() throws IOException {
+        if (delegationProvisioned == false) {
+            DatasetProvisioner.provision(client(), DELEGATION);
+            delegationProvisioned = true;
         }
     }
 
@@ -177,10 +186,92 @@ public class ExplainApiIT extends AnalyticsRestTestCase {
         assertTrue("planning_time_ms is non-negative", planningTime >= 0);
     }
 
+    @SuppressWarnings("unchecked")
+    public void testProfileReturnsDataNodeMetrics() throws IOException {
+        ensureClickBenchProvisioned();
+        Map<String, Object> result = executeWithProfile(
+            "source=" + CLICKBENCH.indexName + " | stats avg(AdvEngineID) by RegionID"
+        );
+
+        Map<String, Object> profile = (Map<String, Object>) result.get("profile");
+        assertNotNull("profile present", profile);
+        List<Map<String, Object>> stages = (List<Map<String, Object>>) profile.get("stages");
+
+        Map<String, Object> shardStage = stages.stream()
+            .filter(s -> "SHARD_FRAGMENT".equals(s.get("execution_type")))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("no SHARD_FRAGMENT stage"));
+
+        List<Map<String, Object>> tasks = (List<Map<String, Object>>) shardStage.get("tasks");
+        assertNotNull("tasks present", tasks);
+
+        boolean anyMetrics = false;
+        for (Map<String, Object> task : tasks) {
+            Map<String, Object> metrics = (Map<String, Object>) task.get("data_node_metrics");
+            if (metrics != null) {
+                anyMetrics = true;
+                assertNotNull("output_rows present", metrics.get("output_rows"));
+                assertNotNull("elapsed_compute present", metrics.get("elapsed_compute"));
+                assertNotNull("output_batches present", metrics.get("output_batches"));
+                assertTrue("output_rows non-negative", ((Number) metrics.get("output_rows")).longValue() >= 0);
+            }
+        }
+        assertTrue("at least one task has data_node_metrics", anyMetrics);
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testProfileDelegatedQueryHasFFMCollectorCalls() throws IOException {
+        ensureDelegationProvisioned();
+        Map<String, Object> result = executeWithProfile(
+            "source=" + DELEGATION.indexName + " | where status = \"active\" | fields status, value"
+        );
+
+        Map<String, Object> profile = (Map<String, Object>) result.get("profile");
+        assertNotNull("profile present", profile);
+        List<Map<String, Object>> stages = (List<Map<String, Object>>) profile.get("stages");
+
+        Map<String, Object> shardStage = stages.stream()
+            .filter(s -> "SHARD_FRAGMENT".equals(s.get("execution_type")))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("no SHARD_FRAGMENT stage"));
+
+        List<Map<String, Object>> tasks = (List<Map<String, Object>>) shardStage.get("tasks");
+        assertNotNull("tasks present", tasks);
+        assertFalse("has tasks", tasks.isEmpty());
+
+        // Find a task with data_node_metrics (some shards may be empty on multi-node clusters)
+        Map<String, Object> metrics = null;
+        for (Map<String, Object> t : tasks) {
+            Map<String, Object> m = (Map<String, Object>) t.get("data_node_metrics");
+            if (m != null && m.containsKey("ffm_collector_calls")) {
+                metrics = m;
+                break;
+            }
+        }
+        assertNotNull("at least one task has data_node_metrics with ffm_collector_calls", metrics);
+
+        // Verify IndexedTableExec custom metrics proving Lucene delegation occurred
+        assertTrue(
+            "ffm_collector_calls > 0 (Lucene delegation occurred)",
+            ((Number) metrics.get("ffm_collector_calls")).longValue() > 0
+        );
+        assertNotNull("rows_matched present", metrics.get("rows_matched"));
+        assertEquals("rows_matched equals 10 (10% of 100 docs)", 10L, ((Number) metrics.get("rows_matched")).longValue());
+        assertNotNull("row_groups_processed present", metrics.get("row_groups_processed"));
+        assertNotNull("index_query_time present", metrics.get("index_query_time"));
+    }
+
     private Map<String, Object> executeExplain(String ppl) throws IOException {
         Request request = new Request("POST", "/_analytics/ppl/_explain");
         request.setJsonEntity("{\"query\": \"" + escapeJson(ppl) + "\"}");
         Response response = client().performRequest(request);
         return assertOkAndParse(response, "EXPLAIN: " + ppl);
+    }
+
+    private Map<String, Object> executeWithProfile(String ppl) throws IOException {
+        Request request = new Request("POST", "/_analytics/ppl");
+        request.setJsonEntity("{\"query\": \"" + escapeJson(ppl) + "\", \"profile\": true}");
+        Response response = client().performRequest(request);
+        return assertOkAndParse(response, "PROFILE: " + ppl);
     }
 }

--- a/sandbox/qa/analytics-engine-rest/src/test/resources/datasets/delegation/bulk.json
+++ b/sandbox/qa/analytics-engine-rest/src/test/resources/datasets/delegation/bulk.json
@@ -1,0 +1,200 @@
+{"index": {}}
+{"status": "active", "value": 0}
+{"index": {}}
+{"status": "inactive", "value": 1}
+{"index": {}}
+{"status": "inactive", "value": 2}
+{"index": {}}
+{"status": "inactive", "value": 3}
+{"index": {}}
+{"status": "inactive", "value": 4}
+{"index": {}}
+{"status": "inactive", "value": 5}
+{"index": {}}
+{"status": "inactive", "value": 6}
+{"index": {}}
+{"status": "inactive", "value": 7}
+{"index": {}}
+{"status": "inactive", "value": 8}
+{"index": {}}
+{"status": "inactive", "value": 9}
+{"index": {}}
+{"status": "active", "value": 10}
+{"index": {}}
+{"status": "inactive", "value": 11}
+{"index": {}}
+{"status": "inactive", "value": 12}
+{"index": {}}
+{"status": "inactive", "value": 13}
+{"index": {}}
+{"status": "inactive", "value": 14}
+{"index": {}}
+{"status": "inactive", "value": 15}
+{"index": {}}
+{"status": "inactive", "value": 16}
+{"index": {}}
+{"status": "inactive", "value": 17}
+{"index": {}}
+{"status": "inactive", "value": 18}
+{"index": {}}
+{"status": "inactive", "value": 19}
+{"index": {}}
+{"status": "active", "value": 20}
+{"index": {}}
+{"status": "inactive", "value": 21}
+{"index": {}}
+{"status": "inactive", "value": 22}
+{"index": {}}
+{"status": "inactive", "value": 23}
+{"index": {}}
+{"status": "inactive", "value": 24}
+{"index": {}}
+{"status": "inactive", "value": 25}
+{"index": {}}
+{"status": "inactive", "value": 26}
+{"index": {}}
+{"status": "inactive", "value": 27}
+{"index": {}}
+{"status": "inactive", "value": 28}
+{"index": {}}
+{"status": "inactive", "value": 29}
+{"index": {}}
+{"status": "active", "value": 30}
+{"index": {}}
+{"status": "inactive", "value": 31}
+{"index": {}}
+{"status": "inactive", "value": 32}
+{"index": {}}
+{"status": "inactive", "value": 33}
+{"index": {}}
+{"status": "inactive", "value": 34}
+{"index": {}}
+{"status": "inactive", "value": 35}
+{"index": {}}
+{"status": "inactive", "value": 36}
+{"index": {}}
+{"status": "inactive", "value": 37}
+{"index": {}}
+{"status": "inactive", "value": 38}
+{"index": {}}
+{"status": "inactive", "value": 39}
+{"index": {}}
+{"status": "active", "value": 40}
+{"index": {}}
+{"status": "inactive", "value": 41}
+{"index": {}}
+{"status": "inactive", "value": 42}
+{"index": {}}
+{"status": "inactive", "value": 43}
+{"index": {}}
+{"status": "inactive", "value": 44}
+{"index": {}}
+{"status": "inactive", "value": 45}
+{"index": {}}
+{"status": "inactive", "value": 46}
+{"index": {}}
+{"status": "inactive", "value": 47}
+{"index": {}}
+{"status": "inactive", "value": 48}
+{"index": {}}
+{"status": "inactive", "value": 49}
+{"index": {}}
+{"status": "active", "value": 50}
+{"index": {}}
+{"status": "inactive", "value": 51}
+{"index": {}}
+{"status": "inactive", "value": 52}
+{"index": {}}
+{"status": "inactive", "value": 53}
+{"index": {}}
+{"status": "inactive", "value": 54}
+{"index": {}}
+{"status": "inactive", "value": 55}
+{"index": {}}
+{"status": "inactive", "value": 56}
+{"index": {}}
+{"status": "inactive", "value": 57}
+{"index": {}}
+{"status": "inactive", "value": 58}
+{"index": {}}
+{"status": "inactive", "value": 59}
+{"index": {}}
+{"status": "active", "value": 60}
+{"index": {}}
+{"status": "inactive", "value": 61}
+{"index": {}}
+{"status": "inactive", "value": 62}
+{"index": {}}
+{"status": "inactive", "value": 63}
+{"index": {}}
+{"status": "inactive", "value": 64}
+{"index": {}}
+{"status": "inactive", "value": 65}
+{"index": {}}
+{"status": "inactive", "value": 66}
+{"index": {}}
+{"status": "inactive", "value": 67}
+{"index": {}}
+{"status": "inactive", "value": 68}
+{"index": {}}
+{"status": "inactive", "value": 69}
+{"index": {}}
+{"status": "active", "value": 70}
+{"index": {}}
+{"status": "inactive", "value": 71}
+{"index": {}}
+{"status": "inactive", "value": 72}
+{"index": {}}
+{"status": "inactive", "value": 73}
+{"index": {}}
+{"status": "inactive", "value": 74}
+{"index": {}}
+{"status": "inactive", "value": 75}
+{"index": {}}
+{"status": "inactive", "value": 76}
+{"index": {}}
+{"status": "inactive", "value": 77}
+{"index": {}}
+{"status": "inactive", "value": 78}
+{"index": {}}
+{"status": "inactive", "value": 79}
+{"index": {}}
+{"status": "active", "value": 80}
+{"index": {}}
+{"status": "inactive", "value": 81}
+{"index": {}}
+{"status": "inactive", "value": 82}
+{"index": {}}
+{"status": "inactive", "value": 83}
+{"index": {}}
+{"status": "inactive", "value": 84}
+{"index": {}}
+{"status": "inactive", "value": 85}
+{"index": {}}
+{"status": "inactive", "value": 86}
+{"index": {}}
+{"status": "inactive", "value": 87}
+{"index": {}}
+{"status": "inactive", "value": 88}
+{"index": {}}
+{"status": "inactive", "value": 89}
+{"index": {}}
+{"status": "active", "value": 90}
+{"index": {}}
+{"status": "inactive", "value": 91}
+{"index": {}}
+{"status": "inactive", "value": 92}
+{"index": {}}
+{"status": "inactive", "value": 93}
+{"index": {}}
+{"status": "inactive", "value": 94}
+{"index": {}}
+{"status": "inactive", "value": 95}
+{"index": {}}
+{"status": "inactive", "value": 96}
+{"index": {}}
+{"status": "inactive", "value": 97}
+{"index": {}}
+{"status": "inactive", "value": 98}
+{"index": {}}
+{"status": "inactive", "value": 99}

--- a/sandbox/qa/analytics-engine-rest/src/test/resources/datasets/delegation/mapping.json
+++ b/sandbox/qa/analytics-engine-rest/src/test/resources/datasets/delegation/mapping.json
@@ -1,0 +1,12 @@
+{
+  "settings": {
+    "number_of_shards": 1,
+    "number_of_replicas": 0
+  },
+  "mappings": {
+    "properties": {
+      "status": { "type": "keyword" },
+      "value": { "type": "integer" }
+    }
+  }
+}


### PR DESCRIPTION
## Description

Extends the analytics engine profile API to capture per-operator execution metrics from DataFusion on data nodes. When `profile=true`, each shard task in the profile output now includes a `data_node_metrics` map containing ~30 DataFusion execution counters (scan time, rows pruned, compute time, etc.).

### Trailing Sentinel Batch

DataFusion produces batches via a stream iterator with no lookahead. We only know the stream is exhausted when hasNext() returns false. At that point, all batches have already been sent over the wire. DataFusion's execution metrics (accumulated on the physical plan nodes) are only finalized after the stream is fully consumed. This creates a timing mismatch: we want to attach metrics to the last data batch's metadata, but we've already sent it by the time metrics are available.

To address this we implement a trailing "sentinel" batch which contains no rows and only metadata.

After the stream exhausts, construct an empty VectorSchemaRoot (0 rows, same schema) with metrics attached and send it as a trailing frame. The coordinator detects it via rowCount==0 && getMetadata()!=null and extracts metrics without processing it as data.

### Example output

```json
  {
    "columns": ["status", "value"],
    "rows": [
      ["active", 0],
      ["active", 10],
      ["active", 20],
      "..."
    ],
    "profile": {
      "query_id": "496bc1bd-5350-4fbe-96ec-712952d8b710",
      "full_plan": [
        "OpenSearchFilter(condition=[ANNOTATED_PREDICATE(id=0, backends=[lucene, datafusion], =($0, 'active'))],
  viableBackends=[[lucene, datafusion]])",
        "  OpenSearchTableScan(table=[[delegation_test]], viableBackends=[[lucene, datafusion]])"
      ],
      "planning_time_ms": 355,
      "execution_time_ms": 178,
      "stages": [
        {
          "stage_id": 0,
          "execution_type": "SHARD_FRAGMENT",
          "distribution": "SINGLETON",
          "state": "SUCCEEDED",
          "start_ms": 1780694708553730,
          "end_ms": 1780694708554544,
          "elapsed_ms": 178,
          "rows_processed": 50,
          "tasks_completed": 1,
          "tasks_failed": 0,
          "fragment": [
            "OpenSearchFilter(condition=[ANNOTATED_PREDICATE(id=0, backends=[lucene, datafusion], =($0,
  'active'))], viableBackends=[[lucene, datafusion]])",
            "  OpenSearchTableScan(table=[[delegation_test]], viableBackends=[[lucene, datafusion]])"
          ],
          "tasks": [
            {
              "node": "8Ki3qrh8RsGWFo045LluNg/shard[0]",
              "state": "FINISHED",
              "elapsed_ms": 177,
              "data_node_metrics": {
                "output_rows": 50,
                "elapsed_compute": 0,
                "index_query_time": 1247042,
                "parquet_read_time": 390416,
                "rows_matched": 50,
                "rows_pruned_by_page_index": 450,
                "row_groups_processed": 2,
                "row_groups_skipped": 0,
                "ffm_collector_calls": 2,
                "batches_produced": 2,
                "prefetch_wait_time": 1293375,
                "build_mask_time": 417,
                "filter_record_batch_time": 135750,
                "coalesce_time": 83334,
                "parquet_poll_time": 743125,
                "bytes_scanned": 2274,
                "time_elapsed_scanning_total": 2250750,
                "time_elapsed_opening": 35291,
                "position_map_identity": 2
              }
            }
          ]
        },
        {
          "stage_id": 1,
          "execution_type": "COORDINATOR_REDUCE",
          "state": "SUCCEEDED",
          "elapsed_ms": 178,
          "rows_processed": 0,
          "tasks_completed": 1,
          "tasks_failed": 0,
          "tasks": [
            {
              "node": "1.0",
              "state": "FINISHED",
              "elapsed_ms": 178
            }
          ]
        }
      ]
    }
  }
```

### Related Issues
N/A

### Check List
- [x] Functionality includes testing.
~~- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.~~
~~- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
