### PR TITLE
Close Kafka Consumer if KafkaPartitionConsumer fails to initialize

### DIFF
--- a/plugins/ingestion-kafka/src/main/java/org/opensearch/plugin/kafka/KafkaConsumerFactory.java
+++ b/plugins/ingestion-kafka/src/main/java/org/opensearch/plugin/kafka/KafkaConsumerFactory.java
@@ -24,7 +24,17 @@ public class KafkaConsumerFactory implements IngestionConsumerFactory<KafkaParti
     @Override
     public KafkaPartitionConsumer createShardConsumer(String clientId, int shardId, IngestionSource ingestionSource) {
         KafkaSourceConfig localConfig = new KafkaSourceConfig((int) ingestionSource.getMaxPollSize(), ingestionSource.params());
-        return new KafkaPartitionConsumer(clientId, localConfig, shardId);
+        // Constructing a KafkaPartitionConsumer should *never* throw an exception.
+        KafkaPartitionConsumer consumer = new KafkaPartitionConsumer(clientId, localConfig, shardId);
+        try {
+            // But initializing it *may* throw an exception.
+            consumer.initialize();
+        } catch (Exception e) {
+            // In which case, we *must* close the Kafka connection, or else it will leak.
+            consumer.close();
+            throw new IllegalStateException(e);
+        }
+        return consumer;
     }
 
     @Override

--- a/plugins/ingestion-kafka/src/main/java/org/opensearch/plugin/kafka/KafkaPartitionConsumer.java
+++ b/plugins/ingestion-kafka/src/main/java/org/opensearch/plugin/kafka/KafkaPartitionConsumer.java
@@ -23,7 +23,6 @@ import org.apache.logging.log4j.Logger;
 import org.opensearch.index.IngestionShardConsumer;
 import org.opensearch.index.IngestionShardPointer;
 
-import java.io.IOException;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.time.Duration;
@@ -47,9 +46,10 @@ public class KafkaPartitionConsumer implements IngestionShardConsumer<KafkaOffse
     protected final Consumer<byte[], byte[]> consumer;
 
     private long lastFetchedOffset = -1;
-    final String clientId;
-    final TopicPartition topicPartition;
-    final KafkaSourceConfig config;
+    private final String clientId;
+    private final int partitionId;
+    private final KafkaSourceConfig config;
+    private TopicPartition topicPartition;
 
     /**
      * Constructor
@@ -72,6 +72,10 @@ public class KafkaPartitionConsumer implements IngestionShardConsumer<KafkaOffse
         this.clientId = clientId;
         this.consumer = consumer;
         this.config = config;
+        this.partitionId = partitionId;
+    }
+
+    void initialize() throws Exception {
         String topic = config.getTopic();
         List<PartitionInfo> partitionInfos = AccessController.doPrivileged(
             (PrivilegedAction<List<PartitionInfo>>) () -> consumer.partitionsFor(
@@ -289,7 +293,7 @@ public class KafkaPartitionConsumer implements IngestionShardConsumer<KafkaOffse
     }
 
     @Override
-    public synchronized void close() throws IOException {
+    public synchronized void close() {
         consumer.close();
     }
 

--- a/plugins/ingestion-kafka/src/test/java/org/opensearch/plugin/kafka/KafkaPartitionConsumerTests.java
+++ b/plugins/ingestion-kafka/src/test/java/org/opensearch/plugin/kafka/KafkaPartitionConsumerTests.java
@@ -51,6 +51,7 @@ public class KafkaPartitionConsumerTests extends OpenSearchTestCase {
         PartitionInfo partitionInfo = new PartitionInfo("test-topic", 0, null, null, null);
         when(mockConsumer.partitionsFor(eq("test-topic"), any(Duration.class))).thenReturn(Collections.singletonList(partitionInfo));
         consumer = new KafkaPartitionConsumer("client1", config, 0, mockConsumer);
+        consumer.initialize();
     }
 
     public void testReadNext() throws Exception {
@@ -112,23 +113,16 @@ public class KafkaPartitionConsumerTests extends OpenSearchTestCase {
         params.put("bootstrap_servers", "localhost:9092");
         var kafkaSourceConfig = new KafkaSourceConfig(1000, params);
         when(mockConsumer.partitionsFor(eq("non-existent-topic"), any(Duration.class))).thenReturn(null);
-        try {
-            new KafkaPartitionConsumer("client1", kafkaSourceConfig, 0, mockConsumer);
-            fail("Expected IllegalArgumentException");
-        } catch (IllegalArgumentException e) {
-            assertEquals("Topic non-existent-topic does not exist", e.getMessage());
-        }
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> new KafkaPartitionConsumer("client1", kafkaSourceConfig, 0, mockConsumer).initialize()
+        );
     }
 
     public void testPartitionDoesNotExist() {
         PartitionInfo partitionInfo = new PartitionInfo("test-topic", 0, null, null, null);
         when(mockConsumer.partitionsFor(eq("test-topic"), any(Duration.class))).thenReturn(Collections.singletonList(partitionInfo));
-        try {
-            new KafkaPartitionConsumer("client1", config, 1, mockConsumer);
-            fail("Expected IllegalArgumentException");
-        } catch (IllegalArgumentException e) {
-            assertEquals("Partition 1 does not exist in topic test-topic", e.getMessage());
-        }
+        assertThrows(IllegalArgumentException.class, () -> new KafkaPartitionConsumer("client1", config, 1, mockConsumer).initialize());
     }
 
     public void testCreateConsumer() {
@@ -215,7 +209,7 @@ public class KafkaPartitionConsumerTests extends OpenSearchTestCase {
         assertEquals(-1, lag);
     }
 
-    public void testTopicMetadataFetchTimeoutUsedFromConfig() {
+    public void testTopicMetadataFetchTimeoutUsedFromConfig() throws Exception {
         Map<String, Object> params = new HashMap<>();
         params.put("topic", "test-topic");
         params.put("bootstrap_servers", "localhost:9092");
@@ -225,7 +219,7 @@ public class KafkaPartitionConsumerTests extends OpenSearchTestCase {
         PartitionInfo partitionInfo = new PartitionInfo("test-topic", 0, null, null, null);
         when(mockConsumer.partitionsFor(eq("test-topic"), any(Duration.class))).thenReturn(Collections.singletonList(partitionInfo));
 
-        new KafkaPartitionConsumer("client1", customConfig, 0, mockConsumer);
+        new KafkaPartitionConsumer("client1", customConfig, 0, mockConsumer).initialize();
 
         verify(mockConsumer).partitionsFor(eq("test-topic"), eq(Duration.ofMillis(5000)));
     }


### PR DESCRIPTION


<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
We could throw an exception in the KafkaPartitionConsumer constructor, and we were doing that after opening the Kafka Consumer (i.e. the thing that connects to Kafka). In that case, there was no good way to close the Consumer, resulting in a connection leak.

This change applies the idea that "heavy" resource allocation should either come right at the end of a constructor, or should be moved into another method. In this case, I went with another method.

### Related Issues
N/A

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
