### PR TITLE
Increase kafka metadata default read timeout to 30s

### DIFF
--- a/plugins/ingestion-kafka/src/main/java/org/opensearch/plugin/kafka/KafkaSourceConfig.java
+++ b/plugins/ingestion-kafka/src/main/java/org/opensearch/plugin/kafka/KafkaSourceConfig.java
@@ -21,7 +21,7 @@ public class KafkaSourceConfig {
     private final String PROP_TOPIC = "topic";
     private final String PROP_BOOTSTRAP_SERVERS = "bootstrap_servers";
     private static final String PROP_TOPIC_METADATA_FETCH_TIMEOUT_MS = "topic_metadata_fetch_timeout_ms";
-    private static final int DEFAULT_TOPIC_METADATA_FETCH_TIMEOUT_MS = 1000;
+    private static final int DEFAULT_TOPIC_METADATA_FETCH_TIMEOUT_MS = 30000;
 
     private final String topic;
     private final String bootstrapServers;

--- a/plugins/ingestion-kafka/src/test/java/org/opensearch/plugin/kafka/KafkaSourceConfigTests.java
+++ b/plugins/ingestion-kafka/src/test/java/org/opensearch/plugin/kafka/KafkaSourceConfigTests.java
@@ -48,7 +48,7 @@ public class KafkaSourceConfigTests extends OpenSearchTestCase {
 
         KafkaSourceConfig config = new KafkaSourceConfig(100, params);
 
-        Assert.assertEquals("Default topic metadata fetch timeout should be 1000ms", 1000, config.getTopicMetadataFetchTimeoutMs());
+        Assert.assertEquals("Default topic metadata fetch timeout should be 30000ms", 30000, config.getTopicMetadataFetchTimeoutMs());
         Assert.assertFalse(
             "topic_metadata_fetch_timeout_ms should not be in consumer configurations",
             config.getConsumerConfigurations().containsKey("topic_metadata_fetch_timeout_ms")


### PR DESCRIPTION
### Description
Kafka consumer reads the metadata during first time initialization and has a default 1s timeout. This is not sufficient sometimes and results in consumer initialization failures. Increase the default timeout to give it more time for metadata reads.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
