### PR TITLE
fix(analytics-engine): Route exact COUNT(DISTINCT) through APPROX_COUNT_DISTINCT

### DIFF
--- a/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/AggregateFunction.java
+++ b/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/AggregateFunction.java
@@ -24,7 +24,20 @@ public enum AggregateFunction {
     SUM0(Type.SIMPLE, SqlKind.SUM0),
     MIN(Type.SIMPLE, SqlKind.MIN),
     MAX(Type.SIMPLE, SqlKind.MAX),
-    COUNT(Type.SIMPLE, SqlKind.COUNT, fields(IF("count", new ArrowType.Int(64, true), SUM))),
+    COUNT(Type.SIMPLE, SqlKind.COUNT, fields(IF("count", new ArrowType.Int(64, true), SUM))) {
+        /**
+         * Single-arg {@code COUNT(DISTINCT x)} collapses onto {@link SqlStdOperatorTable#APPROX_COUNT_DISTINCT}.
+         * Distinctness is global and cannot be reduced additively across shards;
+         * {@link #APPROX_COUNT_DISTINCT} (Type.APPROXIMATE) carries the cross-shard merge.
+         */
+        @Override
+        public SqlAggFunction resolveOperator(SqlAggFunction op, boolean isDistinct, int argCount) {
+            if (isDistinct && argCount == 1) {
+                return SqlStdOperatorTable.APPROX_COUNT_DISTINCT;
+            }
+            return op;
+        }
+    },
     AVG(Type.SIMPLE, SqlKind.AVG),
 
     STDDEV_POP(Type.STATISTICAL, SqlKind.STDDEV_POP),
@@ -127,6 +140,14 @@ public enum AggregateFunction {
             }
         }
         return null;
+    }
+
+    /**
+     * Resolves an aggregate call shape (operator + flags) onto a standard {@link SqlAggFunction}.
+     * Default returns {@code op} unchanged; override per enum value to encode rewrites.
+     */
+    public SqlAggFunction resolveOperator(SqlAggFunction op, boolean isDistinct, int argCount) {
+        return op;
     }
 
     /** Case-insensitive name lookup; throws if not recognized. */

--- a/sandbox/libs/analytics-framework/src/test/java/org/opensearch/analytics/spi/AggregateFunctionTests.java
+++ b/sandbox/libs/analytics-framework/src/test/java/org/opensearch/analytics/spi/AggregateFunctionTests.java
@@ -11,7 +11,9 @@ package org.opensearch.analytics.spi;
 import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.sql.SqlAggFunction;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.opensearch.test.OpenSearchTestCase;
 
@@ -194,5 +196,29 @@ public class AggregateFunctionTests extends OpenSearchTestCase {
 
     public void testFromSqlKindReturnsNullForOther() {
         assertNull(AggregateFunction.fromSqlKind(SqlKind.OTHER));
+    }
+
+    public void testResolveOperatorRewritesCountDistinctToApprox() {
+        SqlAggFunction op = SqlStdOperatorTable.COUNT;
+        SqlAggFunction canon = AggregateFunction.COUNT.resolveOperator(op, /*isDistinct=*/ true, 1);
+        assertSame(SqlStdOperatorTable.APPROX_COUNT_DISTINCT, canon);
+    }
+
+    public void testResolveOperatorLeavesNonDistinctCountUnchanged() {
+        SqlAggFunction op = SqlStdOperatorTable.COUNT;
+        assertSame(op, AggregateFunction.COUNT.resolveOperator(op, false, 1));
+    }
+
+    public void testResolveOperatorLeavesMultiArgDistinctUnchanged() {
+        // count(DISTINCT a, b) is not rewritten — distinctness across multiple args isn't
+        // reducible to single-arg APPROX_COUNT_DISTINCT.
+        SqlAggFunction op = SqlStdOperatorTable.COUNT;
+        assertSame(op, AggregateFunction.COUNT.resolveOperator(op, true, 2));
+    }
+
+    public void testResolveOperatorDefaultIsIdentity() {
+        // Default override (e.g. SUM) returns the input op unchanged regardless of flags.
+        SqlAggFunction op = SqlStdOperatorTable.SUM;
+        assertSame(op, AggregateFunction.SUM.resolveOperator(op, true, 1));
     }
 }

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchAggregateRule.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchAggregateRule.java
@@ -14,6 +14,7 @@ import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.Aggregate;
 import org.apache.calcite.rel.core.AggregateCall;
+import org.apache.calcite.sql.SqlAggFunction;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.analytics.planner.CapabilityRegistry;
@@ -84,7 +85,13 @@ public class OpenSearchAggregateRule extends RelOptRule {
         List<AggregateCall> aggCalls = aggregate.getAggCallList();
         Map<Integer, AggregateCallAnnotation> callAnnotations = new LinkedHashMap<>(aggCalls.size());
         for (int i = 0; i < aggCalls.size(); i++) {
-            AggregateCall aggCall = aggCalls.get(i);
+            // Resolve via SPI: collapse equivalent call shapes (e.g. COUNT(DISTINCT x) →
+            // APPROX_COUNT_DISTINCT) onto standard operators before downstream resolution.
+            AggregateCall aggCall = resolveAggregateCall(aggCalls.get(i));
+            if (aggCall != aggCalls.get(i)) {
+                if (aggCalls == aggregate.getAggCallList()) aggCalls = new ArrayList<>(aggCalls);
+                aggCalls.set(i, aggCall);
+            }
             List<String> callViable = resolveViableBackendsForCall(aggCall, childFieldStorage);
             if (callViable.isEmpty()) {
                 throw new IllegalStateException("No backend supports aggregate function [" + aggCall.getAggregation().getName() + "]");
@@ -121,6 +128,36 @@ public class OpenSearchAggregateRule extends RelOptRule {
                 viableBackends,
                 callAnnotations
             )
+        );
+    }
+
+    /**
+     * Returns {@code call} unchanged when its operator already matches what
+     * {@link AggregateFunction#resolveOperator} returns, otherwise a new {@link AggregateCall}
+     * built against the resolved operator.
+     */
+    private static AggregateCall resolveAggregateCall(AggregateCall call) {
+        SqlAggFunction op = call.getAggregation();
+        AggregateFunction func;
+        try {
+            func = AggregateFunction.fromSqlAggFunction(op);
+        } catch (IllegalStateException ignored) {
+            return call;
+        }
+        SqlAggFunction resolvedOp = func.resolveOperator(op, call.isDistinct(), call.getArgList().size());
+        if (resolvedOp == op) return call;
+        return AggregateCall.create(
+            resolvedOp,
+            false,
+            true,
+            call.ignoreNulls(),
+            call.rexList,
+            call.getArgList(),
+            call.filterArg,
+            call.distinctKeys,
+            call.collation,
+            call.getType(),
+            call.getName()
         );
     }
 

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchAggregateSplitRule.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchAggregateSplitRule.java
@@ -56,13 +56,15 @@ public class OpenSearchAggregateSplitRule extends RelOptRule {
     /** Skip the PARTIAL/FINAL split when it would emit a row type that fails Volcano's typeMatchesInferred. */
     private static boolean shouldSkipPartialFinalSplit(OpenSearchAggregate aggregate) {
         for (AggregateCall aggCall : aggregate.getAggCallList()) {
-            // DISTINCT aggregates (e.g. COUNT(DISTINCT x)) can't be decomposed into per-shard
-            // partials reduced additively: summing per-shard distinct counts double-counts any
-            // value present on more than one shard. Gather to the coordinator and aggregate once.
-            if (aggCall.isDistinct()) {
+            // Aggregates that don't decompose additively across shards: APPROXIMATE
+            // (APPROX_COUNT_DISTINCT), STATE_EXPANDING (TAKE/FIRST/LAST/LIST/VALUES/
+            // PERCENTILE_APPROX/PATTERN), and any residual DISTINCT (e.g. multi-arg
+            // COUNT(DISTINCT a, b) that survived rewriting). Gather and aggregate once.
+            AggregateFunction.Type type = aggregateType(aggCall.getAggregation());
+            if (type == AggregateFunction.Type.STATE_EXPANDING || type == AggregateFunction.Type.APPROXIMATE) {
                 return true;
             }
-            if (isStateExpanding(aggCall.getAggregation())) {
+            if (aggCall.isDistinct()) {
                 return true;
             }
         }
@@ -90,11 +92,11 @@ public class OpenSearchAggregateSplitRule extends RelOptRule {
         return false;
     }
 
-    private static boolean isStateExpanding(SqlAggFunction op) {
+    private static AggregateFunction.Type aggregateType(SqlAggFunction op) {
         try {
-            return AggregateFunction.fromSqlAggFunction(op).getType() == AggregateFunction.Type.STATE_EXPANDING;
+            return AggregateFunction.fromSqlAggFunction(op).getType();
         } catch (IllegalStateException ignored) {
-            return false;
+            return null;
         }
     }
 

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/AggregateRuleTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/AggregateRuleTests.java
@@ -306,6 +306,32 @@ public class AggregateRuleTests extends BasePlannerRulesTests {
             assertTrue("Annotation must contain backend " + backend, annotation.getViableBackends().contains(backend));
     }
 
+    // ---- Operator resolution ----
+
+    /**
+     * Exact {@code COUNT(DISTINCT x)} is rewritten to {@code APPROX_COUNT_DISTINCT(x)} on the
+     * analytics-engine route — the resulting aggregate uses the standard approximate operator and
+     * is no longer marked {@code isDistinct}, so it routes through the APPROXIMATE
+     * single-stage gather path rather than the additive partial/final split.
+     */
+    public void testCountDistinctRewrittenToApproxCountDistinct() {
+        RelNode scan = stubScan(mockTable("test_index", "status", "size"));
+        AggregateCall countDistinct = AggregateCall.create(
+            SqlStdOperatorTable.COUNT,
+            true,
+            List.of(1),
+            -1,
+            scan,
+            typeFactory.createSqlType(SqlTypeName.BIGINT),
+            "dc"
+        );
+        OpenSearchAggregate agg = runAggregate(1, countDistinct);
+        assertEquals(1, agg.getAggCallList().size());
+        AggregateCall rebuilt = agg.getAggCallList().get(0);
+        assertSame(SqlStdOperatorTable.APPROX_COUNT_DISTINCT, rebuilt.getAggregation());
+        assertFalse("isDistinct must be cleared on the rewritten APPROX_COUNT_DISTINCT call", rebuilt.isDistinct());
+    }
+
     private OpenSearchAggregate runAggregate(int shardCount, AggregateCall aggCall) {
         RelNode result = runPlanner(makeAggregate(aggCall), defaultContext(shardCount));
         logger.info("Plan:\n{}", RelOptUtil.toString(result));

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/CoordinatorReduceIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/CoordinatorReduceIT.java
@@ -180,6 +180,56 @@ public class CoordinatorReduceIT extends AnalyticsRestTestCase {
     }
 
     /**
+     * Keyword-field counterpart to {@link #testDistinctCountCrossShardOverlap()} — the StringHLL
+     * accumulator path with cross-shard label overlap. Same shape: 8 shards, every shard sees the
+     * full label set, so a naive additive reduce would yield ~{@code distinct × shards}.
+     */
+    public void testDistinctCountCrossShardOverlapKeyword() throws Exception {
+        String index = "coord_reduce_dc_overlap_kw";
+        int shards = 8;
+        try {
+            client().performRequest(new Request("DELETE", "/" + index));
+        } catch (Exception ignored) {}
+        String body = "{\"settings\": {"
+            + "  \"number_of_shards\": " + shards + ", \"number_of_replicas\": 0,"
+            + "  \"index.pluggable.dataformat.enabled\": true, \"index.pluggable.dataformat\": \"composite\","
+            + "  \"index.composite.primary_data_format\": \"parquet\", \"index.composite.secondary_data_formats\": \"\""
+            + "}, \"mappings\": {\"properties\": {\"label\": {\"type\": \"keyword\"}}}}";
+        Request create = new Request("PUT", "/" + index);
+        create.setJsonEntity(body);
+        assertOkAndParse(client().performRequest(create), "create " + index);
+        Request health = new Request("GET", "/_cluster/health/" + index);
+        health.addParameter("wait_for_status", "green");
+        health.addParameter("timeout", "30s");
+        client().performRequest(health);
+
+        // 800 docs, label cycles lbl0..lbl9 → every shard sees all 10 labels.
+        int distinct = 10;
+        int total = 800;
+        StringBuilder bulk = new StringBuilder();
+        for (int i = 0; i < total; i++) {
+            bulk.append("{\"index\": {\"_id\": \"k").append(i).append("\"}}\n");
+            bulk.append("{\"label\": \"lbl").append(i % distinct).append("\"}\n");
+        }
+        bulkAndRefresh(index, bulk.toString());
+
+        Map<String, Object> grouped = executePpl("source = " + index + " | stats count() as c by label");
+        @SuppressWarnings("unchecked")
+        List<List<Object>> groupRows = (List<List<Object>>) grouped.get("datarows");
+        int exactDistinct = groupRows.size();
+
+        Map<String, Object> result = executePpl("source = " + index + " | stats dc(label) as dc");
+        long actual = ((Number) scalarRows(result, "dc").get(0).get(0)).longValue();
+
+        assertEquals("exact distinct (group count) must be " + distinct, distinct, exactDistinct);
+        assertTrue(
+            "dc(label) with cross-shard overlap should be ~" + distinct + " (±2), got " + actual
+                + " — a value near " + (distinct * shards) + " means per-shard distinct counts were summed across shards",
+            actual >= distinct - 2 && actual <= distinct + 2
+        );
+    }
+
+    /**
      * {@code stats percentile_approx(value, 50) as p} — t-digest approximate median.
      * STATE_EXPANDING, so the split rule gathers to coordinator + single-stage. Maps to
      * DataFusion's {@code approx_percentile_cont} via {@link

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/TwoShardAggregationIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/TwoShardAggregationIT.java
@@ -14,11 +14,8 @@ import java.util.Map;
 /**
  * 2-shard reduce correctness for aggregations: exact tier {@code agg/} (count/sum/avg/min/max,
  * stddev/var, span, values/list) and approximate tier {@code approx/} (distinct_count/dc/percentile/
- * median).
- *
- * <p>{@code distinct_count}/{@code dc} are correct cross-shard: DISTINCT aggregates skip the additive
- * PARTIAL/FINAL split ({@link org.opensearch.analytics.planner.rules.OpenSearchAggregateSplitRule})
- * and are computed once at the coordinator, so per-shard distinct counts are never summed.
+ * median). {@code distinct_count}/{@code dc} are rewritten to {@code APPROX_COUNT_DISTINCT} and
+ * computed once at the coordinator, so per-shard distinct counts are never summed.
  */
 public class TwoShardAggregationIT extends TwoShardReduceTestCase {
 
@@ -28,12 +25,5 @@ public class TwoShardAggregationIT extends TwoShardReduceTestCase {
         t.put("agg", false);       // exact
         t.put("approx", true);     // golden + tolerance
         return t;
-    }
-
-    @Override
-    protected Map<String, String> knownIssues() {
-        // No known issues: dc/distinct_count cross-shard over-counting (repeated keyword sets,
-        // label 5->9 at 2 shards) is fixed by skipping the additive split for DISTINCT aggregates.
-        return Map.of();
     }
 }


### PR DESCRIPTION
### Why
  #21961 routed every `isDistinct` aggregate through the single-stage gather path so dc() stopped over-counting across shards. That preserved correctness but lost dc()'s approximate semantics and shipped raw rows to the coordinator.

  ### What
Resolve the rewrite at the operator layer:

  * `AggregateFunction#resolveOperator` — instance method on the enum, default returns the input op; `COUNT` overrides it so single-arg `COUNT(DISTINCT x)` collapses onto `APPROX_COUNT_DISTINCT`. Adding new rewrites later means another override, not a switch.
  * `OpenSearchAggregateRule` consults the SPI (no DC-specific code in the rule) and rebuilds the call once when the operator changes.
  * `OpenSearchAggregateSplitRule.shouldSkipPartialFinalSplit` now skips for `Type.APPROXIMATE` alongside the existing `STATE_EXPANDING` and residual-`isDistinct` cases — the rewritten  aggregate runs once at the coordinator over gathered rows.

  `dc` / `distinct_count` now return the HLL estimate (correct, no over-count). Multi-arg `COUNT(DISTINCT a, b)` still falls through the safe single-stage path. Distributed sketch-merge (per-shard 16 KB sketches over the wire) is a follow-up.

  ### Tests
  - 4 unit cases for `resolveOperator` (rewrite, identity-on-default, multi-arg passthrough).
  - `AggregateRuleTests` verifies the planner emits `APPROX_COUNT_DISTINCT` for `COUNT(DISTINCT)`.
  - `TwoShardAggregationIT` (26/26 incl. previously-xfailed `dc_label` / `distinct_count_label` / `distinct_count_by_cat`) and `CoordinatorReduceIT` (20/20) green; spotless clean.

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
