### PR TITLE
Fix to handle dynamic mapping on the indexed-executor scan path

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_executor.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_executor.rs
@@ -535,6 +535,8 @@ async unsafe fn execute_indexed_with_context_inner(
     .await
     .map_err(DataFusionError::Execution)?;
     let schema = crate::schema_coerce::coerce_inferred_schema(schema);
+    // Widen to the plan's base_schema so columns absent from this shard's parquet (cross-shard drift) are null-filled at read time.
+    let schema = crate::session_context::widen_schema_from_plan(&ctx, &substrait_bytes, &table_name, &schema);
 
     let placeholder: Arc<dyn TableProvider> = Arc::new(PlaceholderProvider {
         schema: schema.clone(),

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/session_context.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/session_context.rs
@@ -72,7 +72,7 @@ pub struct IndexedExecutionConfig {
 /// Uses the `datafusion-substrait` consumer's `from_substrait_named_struct` for type conversion
 /// (which already marks all fields nullable). The consumer is built from the session's existing
 /// state — no throwaway SessionState needed.
-fn widen_schema_from_plan(
+pub(crate) fn widen_schema_from_plan(
     ctx: &SessionContext,
     plan_bytes: &[u8],
     table_name: &str,
@@ -270,7 +270,9 @@ pub async unsafe fn create_session_context(
     // Pre-widening field count — compared below to detect whether widening added columns.
     let inferred_field_count = inferred.fields().len();
 
-    // Widen to the plan's base_schema if this shard is missing union columns. No-op for single-index.
+    // Widen to the plan's base_schema if this shard's parquet is missing columns the plan
+    // expects (multi-index unions, or single-index cross-shard drift). No-op when the shard
+    // already covers every base_schema column.
     let resolved_schema = widen_schema_from_plan(&ctx, plan_bytes, &register_name, &inferred);
 
     // If widening added columns, disable stat collection: the global stats cache is keyed by

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/DynamicMappingSearchIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/DynamicMappingSearchIT.java
@@ -113,6 +113,65 @@ public class DynamicMappingSearchIT extends AnalyticsRestTestCase {
         assertValue("where match(" + FIELD_NAME + ", 'mia') | stats sum(" + FIELD_PRIORITY + ") as total", "total", 1.0);
     }
 
+    /**
+     * Cross-shard schema drift: a sparse dynamically-mapped field that exists in only one doc
+     * (hence in only one shard's parquet segments) must not break a filtered query that
+     * materializes rows. The coordinator's substrait base_schema names the field (it's in the
+     * merged index mapping), so the indexed-executor scan path must widen each shard's schema to
+     * base_schema and null-fill the absent column — otherwise shards lacking it fail with
+     * "No field named ...". Regression test for the indexed-path widening fix.
+     */
+    public void testCrossShardDriftFilteredQuery() throws Exception {
+        String index = "cross_shard_drift_e2e";
+        createTwoShardIndex(index, "{\"proto\": { \"type\": \"keyword\" }, \"common\": { \"type\": \"integer\" }}");
+
+        // 10 docs across 2 shards (natural _id hashing); exactly one carries the sparse field, so
+        // it lands in only one shard's parquet. The dynamic field enters the merged index mapping.
+        StringBuilder bulk = new StringBuilder();
+        for (int i = 1; i <= 10; i++) {
+            bulk.append("{\"index\": {}}\n");
+            if (i == 5) {
+                bulk.append("{\"proto\": \"TCP\", \"common\": ").append(i).append(", \"sparse_field\": 999}\n");
+            } else {
+                bulk.append("{\"proto\": \"TCP\", \"common\": ").append(i).append("}\n");
+            }
+        }
+        bulkIndexInto(index, bulk.toString());
+
+        // Sanity: the sparse field is dynamically mapped and present on exactly one doc.
+        assertCountIn(index, "where isnotnull(sparse_field) | stats count() as cnt", 1);
+
+        // The drift trigger: a filtered query that materializes rows (indexed-executor path).
+        // Before the fix this failed on the shard lacking sparse_field with "No field named".
+        Map<String, Object> result = executePpl("source = " + index + " | where proto = 'TCP' | fields common | sort common");
+        @SuppressWarnings("unchecked")
+        List<List<Object>> rows = (List<List<Object>>) result.get("datarows");
+        assertNotNull("drift query returned no datarows", rows);
+        assertEquals("filtered query over a drifted multi-shard index should return all matching rows", 10, rows.size());
+
+        // The drifted column reads back as its real value where present, NULL where absent.
+        assertValueIn(index, "where common = 5 | fields sparse_field", "sparse_field", 999.0);
+        assertCountIn(index, "where isnull(sparse_field) | stats count() as cnt", 9);
+    }
+
+    /**
+     * Filtered query against an index whose shards are all empty (zero docs / zero parquet files).
+     * The empty-shard guard derives the scan schema from the plan rather than from segments, so a
+     * row-materializing filtered query must return zero rows cleanly rather than erroring.
+     */
+    public void testFilteredQueryOnEmptyShards() throws Exception {
+        String index = "empty_shard_filter_e2e";
+        createTwoShardIndex(index, "{\"proto\": { \"type\": \"keyword\" }, \"common\": { \"type\": \"integer\" }}");
+
+        Map<String, Object> result = executePpl("source = " + index + " | where proto = 'TCP' | fields common | head 2");
+        @SuppressWarnings("unchecked")
+        List<List<Object>> rows = (List<List<Object>>) result.get("datarows");
+        assertNotNull("empty-shard query returned no datarows", rows);
+        assertEquals("filtered query on an empty index should return zero rows", 0, rows.size());
+
+        assertCountIn(index, "stats count() as cnt", 0);
+    }
+
     // ── Document builders ───────────────────────────────────────────────────
 
     /** Phase 1 doc: name + age only */
@@ -175,6 +234,68 @@ public class DynamicMappingSearchIT extends AnalyticsRestTestCase {
         health.addParameter("wait_for_status", "green");
         health.addParameter("timeout", "30s");
         client().performRequest(health);
+    }
+
+    /** Creates a 2-shard composite/parquet index (lucene secondary) with the given mapping properties. */
+    private void createTwoShardIndex(String index, String propertiesJson) throws Exception {
+        try {
+            client().performRequest(new Request("DELETE", "/" + index));
+        } catch (Exception ignored) {}
+
+        String body = "{"
+            + "\"settings\": {"
+            + "  \"number_of_shards\": 2,"
+            + "  \"number_of_replicas\": 0,"
+            + "  \"index.pluggable.dataformat.enabled\": true,"
+            + "  \"index.pluggable.dataformat\": \"composite\","
+            + "  \"index.composite.primary_data_format\": \"parquet\","
+            + "  \"index.composite.secondary_data_formats\": \"lucene\""
+            + "},"
+            + "\"mappings\": { \"properties\": " + propertiesJson + " }"
+            + "}";
+        Request req = new Request("PUT", "/" + index);
+        req.setJsonEntity(body);
+        assertEquals(true, assertOkAndParse(client().performRequest(req), "Create index " + index).get("acknowledged"));
+
+        Request health = new Request("GET", "/_cluster/health/" + index);
+        health.addParameter("wait_for_status", "green");
+        health.addParameter("timeout", "30s");
+        client().performRequest(health);
+    }
+
+    /** Bulk-index NDJSON into the named index with refresh. */
+    private void bulkIndexInto(String index, String ndjson) throws Exception {
+        Request req = new Request("POST", "/" + index + "/_bulk");
+        req.setJsonEntity(ndjson);
+        req.addParameter("refresh", "true");
+        req.setOptions(req.getOptions().toBuilder().addHeader("Content-Type", "application/x-ndjson").build());
+        Map<String, Object> response = assertOkAndParse(client().performRequest(req), "Bulk index " + index);
+        assertEquals("Bulk indexing should have no errors", false, response.get("errors"));
+    }
+
+    /** count-query assertion against an arbitrary index. */
+    private void assertCountIn(String index, String pplSuffix, int expected) throws IOException {
+        String ppl = "source = " + index + " | " + pplSuffix;
+        Map<String, Object> result = executePpl(ppl);
+        @SuppressWarnings("unchecked")
+        List<List<Object>> rows = (List<List<Object>>) result.get("datarows");
+        assertNotNull("Response missing 'datarows' for: " + ppl, rows);
+        assertEquals("Expected 1 row for count query: " + ppl, 1, rows.size());
+        assertEquals("Count mismatch for: " + ppl, expected, ((Number) rows.get(0).get(0)).longValue());
+    }
+
+    /** single-value assertion against an arbitrary index. */
+    private void assertValueIn(String index, String pplSuffix, String column, double expected) throws IOException {
+        String ppl = "source = " + index + " | " + pplSuffix;
+        Map<String, Object> result = executePpl(ppl);
+        List<String> columns = extractColumnNames(result);
+        @SuppressWarnings("unchecked")
+        List<List<Object>> rows = (List<List<Object>>) result.get("datarows");
+        assertNotNull("Response missing 'datarows' for: " + ppl, rows);
+        assertEquals(1, rows.size());
+        int idx = columns.indexOf(column);
+        assertTrue("Column '" + column + "' not found in: " + columns, idx >= 0);
+        assertEquals("Value mismatch for: " + ppl, expected, ((Number) rows.get(0).get(idx)).doubleValue(), 0.01);
     }
 
     private void bulkIndex(String ndjson) throws Exception {


### PR DESCRIPTION

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
The scan path already widens each shard's schema to the plan's base_schema, but the indexed-executor path rebuilds its own schema from build_segments (local shard only) and skipped widening. Fix: widen to base_schema there too, so absent columns are appended as nullable and null-filled at read time.


### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
