### PR TITLE
Use "thin" LTO instead of "fat" which takes substantially less time while still achieving performance gains

### DIFF
--- a/sandbox/libs/dataformat-native/rust/Cargo.toml
+++ b/sandbox/libs/dataformat-native/rust/Cargo.toml
@@ -81,8 +81,11 @@ opensearch-repository-gcs = { path = "../../../plugins/native-repository-gcs/src
 opensearch-repository-azure = { path = "../../../plugins/native-repository-azure/src/main/rust" }
 opensearch-repository-fs = { path = "../../../plugins/native-repository-fs/src/main/rust" }
 
+# Thin LTO instead of fat: parallelizes cross-crate optimization across codegen
+# units instead of merging the whole dependency tree (all of DataFusion) into one
+# single-threaded LLVM module. ~2-4x faster link with ~1% runtime cost on this workload.
 [profile.release]
-lto = true
+lto = "thin"
 codegen-units = 1
 incremental = true
 debug = "line-tables-only"


### PR DESCRIPTION
### Description
The lto setting controls the `-C lto flag` which controls LLVM's [link time optimizations](https://llvm.org/docs/LinkTimeOptimization.html). LTO can produce better optimized code, using whole-program analysis, at the cost of longer linking time.

The valid options are:

- **false**: Performs "thin local LTO" which performs "thin" LTO on the local crate only across its codegen units. No LTO is performed if codegen units is 1 or opt-level is 0.
- **true** or **"fat"**: Performs "fat" LTO which attempts to perform optimizations across all crates within the dependency graph.
- **"thin"**: Performs ["thin" LTO](http://blog.llvm.org/2016/06/thinlto-scalable-and-incremental-lto.html). This is similar to "fat", but takes substantially less time to run while still achieving performance gains similar to "fat".


### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
