### PR TITLE
Share one IndexSearcher per Lucene reader in filter delegation

### DIFF
--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/LuceneAnalyticsBackendPlugin.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/LuceneAnalyticsBackendPlugin.java
@@ -199,13 +199,9 @@ public class LuceneAnalyticsBackendPlugin implements AnalyticsSearchBackendPlugi
         ShardScanExecutionContext shardCtx = (ShardScanExecutionContext) ctx;
         IndexReaderProvider.Reader reader = shardCtx.getReader();
         LuceneReader luceneReader = reader.getReader(plugin.getDataFormat(), LuceneReader.class);
-        IndexSearcher searcher = new IndexSearcher(luceneReader.directoryReader());
-        if (shardCtx.getQueryCache() != null) {
-            searcher.setQueryCache(shardCtx.getQueryCache());
-        }
-        if (shardCtx.getQueryCachingPolicy() != null) {
-            searcher.setQueryCachingPolicy(shardCtx.getQueryCachingPolicy());
-        }
+        // Shared per-reader searcher (see LuceneReader#searcher) — a fresh one here crashes the node
+        // on self-union delegated scans.
+        IndexSearcher searcher = luceneReader.searcher(shardCtx.getQueryCache(), shardCtx.getQueryCachingPolicy());
         QueryShardContext queryShardContext = buildMinimalQueryShardContext(shardCtx, searcher);
         BooleanSupplier isCancelled = () -> {
             Task task = shardCtx.getTask();

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/LuceneReader.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/LuceneReader.java
@@ -9,25 +9,65 @@
 package org.opensearch.be.lucene;
 
 import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.QueryCache;
+import org.apache.lucene.search.QueryCachingPolicy;
 import org.opensearch.common.annotation.ExperimentalApi;
 
 import java.util.Map;
 import java.util.Objects;
 
 /**
- * Bundles a Lucene {@link DirectoryReader} with the {@code writer_generation → segment name}
- * map built at refresh time by matching the catalog's file sets against each leaf's files.
- *
- * <p>Built by {@link LuceneReaderManager#afterRefresh} and consumed by
- * {@link LuceneFilterDelegationHandle} — no attribute reads or file-set matching at query time.
- *
- * @param directoryReader the Lucene reader at the snapshot's point in time
- * @param generationToSegmentName {@code writer_generation → SegmentInfo.name in directoryReader}
+ * Bundles a Lucene {@link DirectoryReader} with the {@code writer_generation → segment name} map,
+ * plus one shared {@link IndexSearcher} per reader (see {@link #searcher}). Consumers must use that
+ * searcher rather than building their own: distinct {@code IndexSearcher}s over the same reader,
+ * both wired to the shared query cache, trip Lucene's "top-reader used to create Weight is not the
+ * same as the current reader's top-reader" assertion — fatal across the FFM boundary.
  */
 @ExperimentalApi
-public record LuceneReader(DirectoryReader directoryReader, Map<Long, String> generationToSegmentName) {
-    public LuceneReader {
-        Objects.requireNonNull(directoryReader, "directoryReader must not be null");
-        generationToSegmentName = Map.copyOf(generationToSegmentName);
+public final class LuceneReader {
+
+    private final DirectoryReader directoryReader;
+    private final Map<Long, String> generationToSegmentName;
+
+    /** Lazily built on first {@link #searcher} call; one shared instance per reader thereafter. */
+    private volatile IndexSearcher searcher;
+
+    public LuceneReader(DirectoryReader directoryReader, Map<Long, String> generationToSegmentName) {
+        this.directoryReader = Objects.requireNonNull(directoryReader, "directoryReader must not be null");
+        this.generationToSegmentName = Map.copyOf(generationToSegmentName);
+    }
+
+    public DirectoryReader directoryReader() {
+        return directoryReader;
+    }
+
+    public Map<Long, String> generationToSegmentName() {
+        return generationToSegmentName;
+    }
+
+    /**
+     * Returns the shared searcher over this reader, building it on first use with the given cache
+     * and policy. Later calls return the same instance and ignore their arguments (every caller on
+     * a shard passes the same per-shard cache/policy).
+     */
+    public IndexSearcher searcher(QueryCache queryCache, QueryCachingPolicy queryCachingPolicy) {
+        IndexSearcher local = searcher;
+        if (local != null) {
+            return local;
+        }
+        synchronized (this) {
+            if (searcher == null) {
+                IndexSearcher built = new IndexSearcher(directoryReader);
+                if (queryCache != null) {
+                    built.setQueryCache(queryCache);
+                }
+                if (queryCachingPolicy != null) {
+                    built.setQueryCachingPolicy(queryCachingPolicy);
+                }
+                searcher = built;
+            }
+            return searcher;
+        }
     }
 }

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/LuceneScanInstructionHandler.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/LuceneScanInstructionHandler.java
@@ -59,13 +59,8 @@ final class LuceneScanInstructionHandler implements FragmentInstructionHandler<S
         if (luceneReader == null) {
             throw new IllegalStateException("Lucene-driver fragment dispatched to a shard with no LuceneReader");
         }
-        IndexSearcher searcher = new IndexSearcher(luceneReader.directoryReader());
-        if (shardCtx.getQueryCache() != null) {
-            searcher.setQueryCache(shardCtx.getQueryCache());
-        }
-        if (shardCtx.getQueryCachingPolicy() != null) {
-            searcher.setQueryCachingPolicy(shardCtx.getQueryCachingPolicy());
-        }
+        // Shared per-reader searcher (see LuceneReader#searcher).
+        IndexSearcher searcher = luceneReader.searcher(shardCtx.getQueryCache(), shardCtx.getQueryCachingPolicy());
         Decoded decoded = decodeFragmentBytes(shardCtx, searcher);
         LOGGER.debug(
             "[lucene-count] shardId={} filterQuery={} columnNames={}",

--- a/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/LuceneFilterDelegationHandleQueryCacheTests.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/LuceneFilterDelegationHandleQueryCacheTests.java
@@ -30,7 +30,13 @@ import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -170,6 +176,68 @@ public class LuceneFilterDelegationHandleQueryCacheTests extends OpenSearchTestC
         Weight weight = searcher.createWeight(searcher.rewrite(query), ScoreMode.COMPLETE_NO_SCORES, 1.0f);
         int count = countMatchesOnLeaf(weight, reader.leaves().get(0));
         assertEquals(50, count);
+    }
+
+    /**
+     * Regression for the self-union (multisearch / append) node crash: two separate
+     * {@code IndexSearcher} instances over the SAME reader, both wired to one shared query cache,
+     * cache a {@code Weight} against searcher A's reader-context then evaluate it via searcher B —
+     * tripping Lucene's "top-reader used to create Weight is not the same as the current reader's
+     * top-reader" assertion (fatal across the FFM upcall). {@link LuceneReader#searcher} hands out
+     * ONE shared searcher per reader, so both delegated scans share a consistent reader-context.
+     */
+    public void testSharedSearcherSurvivesTwoScansWithSharedCache() throws Exception {
+        LRUQueryCache cache = new LRUQueryCache(100, 10 * 1024 * 1024, context -> true, 256);
+        AlwaysCachePolicy policy = new AlwaysCachePolicy();
+        LuceneReader luceneReader = buildLuceneReader();
+        Query query = new org.apache.lucene.search.TermQuery(new org.apache.lucene.index.Term("tag", "hello"));
+        var leaf = reader.leaves().get(0);
+
+        // Branch A — populates the shared cache against the shared searcher's reader-context.
+        IndexSearcher searcherA = luceneReader.searcher(cache, policy);
+        Weight weightA = searcherA.createWeight(searcherA.rewrite(query), ScoreMode.COMPLETE_NO_SCORES, 1.0f);
+        assertEquals("branch A matches 50 docs", 50, countMatchesOnLeaf(weightA, leaf));
+
+        // Branch B — second delegated scan over the same reader. Must be the SAME searcher instance,
+        // so reusing the cached Weight does not trip the top-reader assertion.
+        IndexSearcher searcherB = luceneReader.searcher(cache, policy);
+        assertSame("self-union scans must share one searcher per reader", searcherA, searcherB);
+        Weight weightB = searcherB.createWeight(searcherB.rewrite(query), ScoreMode.COMPLETE_NO_SCORES, 1.0f);
+        assertEquals("branch B (cache hit) matches the same 50 docs", 50, countMatchesOnLeaf(weightB, leaf));
+        assertTrue("second scan should hit the shared cache", cache.getHitCount() >= 1);
+    }
+
+    /**
+     * Multi-partition safety: DataFusion fans a scan across partitions that concurrently call
+     * {@code scorer(leaf)} on the shared searcher's Weight. Each gets its own Scorer and sees the
+     * same matches, with no exception escaping.
+     */
+    public void testSharedSearcherConcurrentScorersAcrossPartitions() throws Exception {
+        LRUQueryCache cache = new LRUQueryCache(100, 10 * 1024 * 1024, context -> true, 256);
+        AlwaysCachePolicy policy = new AlwaysCachePolicy();
+        IndexSearcher searcher = buildLuceneReader().searcher(cache, policy);
+        Query query = new org.apache.lucene.search.TermQuery(new org.apache.lucene.index.Term("tag", "hello"));
+        Weight weight = searcher.createWeight(searcher.rewrite(query), ScoreMode.COMPLETE_NO_SCORES, 1.0f);
+        var leaf = reader.leaves().get(0);
+
+        int partitions = 8;
+        ExecutorService pool = Executors.newFixedThreadPool(partitions);
+        try {
+            CountDownLatch start = new CountDownLatch(1);
+            List<Future<Integer>> futures = new ArrayList<>();
+            for (int p = 0; p < partitions; p++) {
+                futures.add(pool.submit(() -> {
+                    start.await();
+                    return countMatchesOnLeaf(weight, leaf);
+                }));
+            }
+            start.countDown();
+            for (Future<Integer> f : futures) {
+                assertEquals("each concurrent partition must see all 50 matches", 50, (int) f.get());
+            }
+        } finally {
+            pool.shutdownNow();
+        }
     }
 
     private int countMatchesOnLeaf(Weight weight, org.apache.lucene.index.LeafReaderContext leaf) throws IOException {


### PR DESCRIPTION


<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Delegated filter scans each built their own IndexSearcher over the shard's DirectoryReader. When two scans over the same reader share the node query cache (e.g. a self-union from multisearch/append), a Weight cached against one searcher's reader-context is evaluated via the other's, tripping Lucene's "top-reader used to create Weight is not the same as the current reader's top-reader" assertion — fatal across the FFM upcall, crashing the data node.

LuceneReader now exposes one lazily-built, shared IndexSearcher per reader; the delegation and count-scan paths use it instead of constructing their own. The shared cache stays attached, so cross-scan cache reuse is preserved.

Tests: shared-searcher reuse across two scans with a shared cache, and concurrent scorers across partitions (multi-partition thread-safety).

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
