### PR TITLE
[analytics-engine] Support PPL date_add/date_sub by lowering to DATETIME_PLUS on DataFusion

### DIFF
--- a/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/ScalarFunction.java
+++ b/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/ScalarFunction.java
@@ -258,6 +258,20 @@ public enum ScalarFunction {
      * rewrites the call into a DataFusion-native interval-add expression.
      */
     TIMESTAMPADD(Category.SCALAR, SqlKind.OTHER_FUNCTION),
+    /**
+     * PPL {@code DATE_ADD(<date|timestamp|time>, INTERVAL n unit)} — shift a temporal value
+     * forward by an interval, returning TIMESTAMP. Resolves through the SQL plugin's
+     * {@code DateAddSubFunction} UDF named {@code "DATE_ADD"}. The analytics-backend-datafusion
+     * adapter rewrites the call into {@code DATETIME_PLUS(base, interval)}, which binds through
+     * Substrait's standard {@code add(timestamp, interval)} to DataFusion's native interval add.
+     */
+    DATE_ADD(Category.SCALAR, SqlKind.OTHER_FUNCTION),
+    /**
+     * PPL {@code DATE_SUB(<date|timestamp|time>, INTERVAL n unit)} — the subtract counterpart of
+     * {@link #DATE_ADD}. Lowered to {@code DATETIME_PLUS(base, -interval)} by the
+     * analytics-backend-datafusion adapter.
+     */
+    DATE_SUB(Category.SCALAR, SqlKind.OTHER_FUNCTION),
 
     // ── JSON ────────────────────────────────────────────────────────
     JSON_APPEND(Category.SCALAR, SqlKind.OTHER_FUNCTION),

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionAnalyticsBackendPlugin.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionAnalyticsBackendPlugin.java
@@ -357,10 +357,6 @@ public class DataFusionAnalyticsBackendPlugin implements AnalyticsSearchBackendP
         // default catalog, so adapters rewrite to DF-native interval arithmetic.
         ScalarFunction.TIMESTAMPDIFF,
         ScalarFunction.TIMESTAMPADD,
-        // PPL `DATE_ADD(t, INTERVAL n unit)` / `DATE_SUB(t, INTERVAL n unit)` — shift a temporal
-        // value by an interval. Neither is bound by isthmus's default catalog (surfaces as
-        // "Unrecognized scalar function [DATE_ADD]"), so DateAddSubAdapter rewrites them to
-        // DATETIME_PLUS(base, ±interval), the same substrait-native add the timestamp adapters use.
         ScalarFunction.DATE_ADD,
         ScalarFunction.DATE_SUB
     );

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionAnalyticsBackendPlugin.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionAnalyticsBackendPlugin.java
@@ -356,7 +356,13 @@ public class DataFusionAnalyticsBackendPlugin implements AnalyticsSearchBackendP
         // TIMESTAMPADD('MINUTE', 1, @timestamp)))}. Both PPL UDFs are unknown to isthmus's
         // default catalog, so adapters rewrite to DF-native interval arithmetic.
         ScalarFunction.TIMESTAMPDIFF,
-        ScalarFunction.TIMESTAMPADD
+        ScalarFunction.TIMESTAMPADD,
+        // PPL `DATE_ADD(t, INTERVAL n unit)` / `DATE_SUB(t, INTERVAL n unit)` — shift a temporal
+        // value by an interval. Neither is bound by isthmus's default catalog (surfaces as
+        // "Unrecognized scalar function [DATE_ADD]"), so DateAddSubAdapter rewrites them to
+        // DATETIME_PLUS(base, ±interval), the same substrait-native add the timestamp adapters use.
+        ScalarFunction.DATE_ADD,
+        ScalarFunction.DATE_SUB
     );
 
     /**
@@ -635,6 +641,8 @@ public class DataFusionAnalyticsBackendPlugin implements AnalyticsSearchBackendP
                     Map.entry(ScalarFunction.CURTIME, currentTime),
                     Map.entry(ScalarFunction.DATE, new DateTimeAdapters.DateAdapter()),
                     Map.entry(ScalarFunction.DATETIME, new DateTimeAdapters.DatetimeAdapter()),
+                    Map.entry(ScalarFunction.DATE_ADD, new DateAddSubAdapter(true)),
+                    Map.entry(ScalarFunction.DATE_SUB, new DateAddSubAdapter(false)),
                     Map.entry(ScalarFunction.DATE_FORMAT, new RustUdfDateTimeAdapters.DateFormatAdapter()),
                     Map.entry(ScalarFunction.DAY, day),
                     Map.entry(ScalarFunction.DAYOFMONTH, day),

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DateAddSubAdapter.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DateAddSubAdapter.java
@@ -27,39 +27,21 @@ import java.util.List;
 
 /**
  * Rewrites PPL {@code DATE_ADD(base, INTERVAL n unit)} / {@code DATE_SUB(base, INTERVAL n unit)}
- * into {@code DATETIME_PLUS(CAST(base AS TIMESTAMP), interval)}.
+ * into {@code DATETIME_PLUS(CAST(base AS TIMESTAMP), interval)}, which lowers to Substrait's
+ * {@code add(timestamp, interval)} that DataFusion executes natively. The raw PPL UDFs have no
+ * Substrait binding, so isthmus rejects them.
  *
- * <p>The PPL {@code DATE_ADD} / {@code DATE_SUB} UDFs (named operators from
- * {@code DateAddSubFunction}) have no Substrait extension binding — isthmus rejects the raw call
- * with {@code "Unrecognized scalar function [DATE_ADD]"} / {@code "Unable to convert call
- * DATE_ADD(date?, interval_year)"}. {@code DATETIME_PLUS}, by contrast, lowers to Substrait's
- * standard {@code add(timestamp, interval)} which DataFusion executes natively — the same path
- * {@link EarliestLatestAdapter} and {@link TimestampDiffAdapter} already rely on for interval
- * arithmetic.
+ * <p>PPL's interval literal carries the leading-field value (e.g. {@code 90} for
+ * {@code INTERVAL 90 day}), but Substrait/DataFusion expect day-time intervals in milliseconds and
+ * year-month intervals in months. This adapter rebuilds the interval in those base units (under a
+ * {@link TimeUnit#DAY} or {@link TimeUnit#MONTH} qualifier) and folds the {@code DATE_SUB} sign in,
+ * the same way {@link EarliestLatestAdapter} does.
  *
- * <p><b>Interval value units.</b> PPL's {@code visitInterval} builds the literal with the
- * <em>leading-field value</em> (e.g. {@code 90} for {@code INTERVAL 90 day}). Substrait /
- * DataFusion, however, carry a day-time interval as <em>milliseconds</em> and a year-month interval
- * as <em>months</em>. Passing the PPL literal through unchanged therefore adds 90&nbsp;ms, not
- * 90&nbsp;days. This adapter reconstructs the interval in the backend's expected base units —
- * milliseconds under a {@link TimeUnit#DAY} qualifier for day-time units, months under a
- * {@link TimeUnit#MONTH} qualifier for the month family — exactly as {@link EarliestLatestAdapter}
- * does. The {@code DATE_SUB} sign is folded into the converted value.
- *
- * <p>The base is cast to the call's declared TIMESTAMP type first: PPL {@code DATE_ADD} always
- * returns TIMESTAMP (midnight UTC when the base is a DATE), and the DATE-to-TIMESTAMP cast maps to
- * arrow's Date32 to Timestamp(Nanosecond) kernel (see {@code TimestampFunctionAdapter}'s Shape B).
- *
- * <p><b>Scope.</b> Only DATE and TIMESTAMP bases are lowered. A TIME base is anchored to the
- * query-start date by the PPL UDF before the interval is added; this adapter has no access to that
- * date, so it leaves TIME bases (and any non-temporal base) on the UDF path rather than emitting an
- * epoch-anchored result. Likewise, sub-millisecond interval units (MICROSECOND) aren't representable
- * in Arrow's millisecond-granular day-time interval and are left for the UDF path. In both cases the
- * call is returned unchanged so Substrait conversion surfaces a precise "unrecognized function"
- * error rather than silently mis-lowering.
- *
- * <p>Returns the call unchanged when the shape isn't the expected {@code (base, INTERVAL literal)}
- * pair as well.
+ * <p>Only DATE and TIMESTAMP bases are lowered. TIME bases (the PPL UDF anchors them to the
+ * query-start date, which this adapter can't reproduce) and sub-millisecond units (MICROSECOND,
+ * unrepresentable in Arrow's millisecond-granular interval) are left on the UDF path, as is any
+ * unexpected shape — the call is returned unchanged so Substrait conversion raises a loud
+ * "unrecognized function" error rather than mis-lowering.
  *
  * @opensearch.internal
  */

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DateAddSubAdapter.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DateAddSubAdapter.java
@@ -1,0 +1,185 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion;
+
+import org.apache.calcite.avatica.util.TimeUnit;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlIntervalQualifier;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.opensearch.analytics.planner.rel.OperatorAnnotation;
+import org.opensearch.analytics.spi.FieldStorageInfo;
+import org.opensearch.analytics.spi.ScalarFunctionAdapter;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+/**
+ * Rewrites PPL {@code DATE_ADD(base, INTERVAL n unit)} / {@code DATE_SUB(base, INTERVAL n unit)}
+ * into {@code DATETIME_PLUS(CAST(base AS TIMESTAMP), interval)}.
+ *
+ * <p>The PPL {@code DATE_ADD} / {@code DATE_SUB} UDFs (named operators from
+ * {@code DateAddSubFunction}) have no Substrait extension binding — isthmus rejects the raw call
+ * with {@code "Unrecognized scalar function [DATE_ADD]"} / {@code "Unable to convert call
+ * DATE_ADD(date?, interval_year)"}. {@code DATETIME_PLUS}, by contrast, lowers to Substrait's
+ * standard {@code add(timestamp, interval)} which DataFusion executes natively — the same path
+ * {@link EarliestLatestAdapter} and {@link TimestampDiffAdapter} already rely on for interval
+ * arithmetic.
+ *
+ * <p><b>Interval value units.</b> PPL's {@code visitInterval} builds the literal with the
+ * <em>leading-field value</em> (e.g. {@code 90} for {@code INTERVAL 90 day}). Substrait /
+ * DataFusion, however, carry a day-time interval as <em>milliseconds</em> and a year-month interval
+ * as <em>months</em>. Passing the PPL literal through unchanged therefore adds 90&nbsp;ms, not
+ * 90&nbsp;days. This adapter reconstructs the interval in the backend's expected base units —
+ * milliseconds under a {@link TimeUnit#DAY} qualifier for day-time units, months under a
+ * {@link TimeUnit#MONTH} qualifier for the month family — exactly as {@link EarliestLatestAdapter}
+ * does. The {@code DATE_SUB} sign is folded into the converted value.
+ *
+ * <p>The base is cast to the call's declared TIMESTAMP type first: PPL {@code DATE_ADD} always
+ * returns TIMESTAMP (midnight UTC when the base is a DATE), and the DATE-to-TIMESTAMP cast maps to
+ * arrow's Date32 to Timestamp(Nanosecond) kernel (see {@code TimestampFunctionAdapter}'s Shape B).
+ *
+ * <p><b>Scope.</b> Only DATE and TIMESTAMP bases are lowered. A TIME base is anchored to the
+ * query-start date by the PPL UDF before the interval is added; this adapter has no access to that
+ * date, so it leaves TIME bases (and any non-temporal base) on the UDF path rather than emitting an
+ * epoch-anchored result. Likewise, sub-millisecond interval units (MICROSECOND) aren't representable
+ * in Arrow's millisecond-granular day-time interval and are left for the UDF path. In both cases the
+ * call is returned unchanged so Substrait conversion surfaces a precise "unrecognized function"
+ * error rather than silently mis-lowering.
+ *
+ * <p>Returns the call unchanged when the shape isn't the expected {@code (base, INTERVAL literal)}
+ * pair as well.
+ *
+ * @opensearch.internal
+ */
+class DateAddSubAdapter implements ScalarFunctionAdapter {
+
+    private static final long MILLIS_PER_SECOND = 1_000L;
+    private static final long MILLIS_PER_MINUTE = 60_000L;
+    private static final long MILLIS_PER_HOUR = 3_600_000L;
+    private static final long MILLIS_PER_DAY = 86_400_000L;
+    private static final long MILLIS_PER_WEEK = 7L * MILLIS_PER_DAY;
+
+    private final boolean isAdd;
+
+    DateAddSubAdapter(boolean isAdd) {
+        this.isAdd = isAdd;
+    }
+
+    @Override
+    public RexNode adapt(RexCall original, List<FieldStorageInfo> fieldStorage, RelOptCluster cluster) {
+        if (original.getOperands().size() != 2) {
+            return original;
+        }
+        RexNode base = original.getOperands().get(0);
+        RexNode intervalOperand = stripOperatorAnnotation(original.getOperands().get(1));
+        if (!(intervalOperand instanceof RexLiteral intervalLiteral)
+            || !SqlTypeName.INTERVAL_TYPES.contains(intervalLiteral.getType().getSqlTypeName())) {
+            return original;
+        }
+        SqlIntervalQualifier qualifier = intervalLiteral.getType().getIntervalQualifier();
+        BigDecimal leadingValue = intervalLiteral.getValueAs(BigDecimal.class);
+        if (qualifier == null || leadingValue == null) {
+            return original;
+        }
+
+        // PPL DATE_ADD/DATE_SUB accept DATE / TIMESTAMP / TIME bases, but we only lower DATE and
+        // TIMESTAMP. A DATE base casts to midnight UTC of the call's declared TIMESTAMP type and a
+        // TIMESTAMP base passes through; a TIME base, however, is anchored to the query-start DATE
+        // by the PPL UDF before the interval is added — a plain CAST(time AS TIMESTAMP) would anchor
+        // it to the epoch instead, silently shifting the result onto 1970-01-01. We can't reproduce
+        // query-date anchoring here, so leave TIME (and any other base type) for the UDF path:
+        // returning the original call surfaces a loud "Unrecognized scalar function" error rather
+        // than a wrong date.
+        SqlTypeName baseSqlType = base.getType().getSqlTypeName();
+        if (baseSqlType != SqlTypeName.DATE
+            && baseSqlType != SqlTypeName.TIMESTAMP
+            && baseSqlType != SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE) {
+            return original;
+        }
+
+        RexBuilder rexBuilder = cluster.getRexBuilder();
+        long signedLeading = (isAdd ? 1L : -1L) * leadingValue.longValueExact();
+
+        // Convert the leading-field value into the backend's base unit (millis for day-time, months
+        // for the month family) and emit a normalized qualifier — see class javadoc.
+        long baseValue;
+        TimeUnit baseUnit;
+        switch (qualifier.getUnit()) {
+            case MILLISECOND -> {
+                baseValue = signedLeading;
+                baseUnit = TimeUnit.DAY;
+            }
+            case SECOND -> {
+                baseValue = signedLeading * MILLIS_PER_SECOND;
+                baseUnit = TimeUnit.DAY;
+            }
+            case MINUTE -> {
+                baseValue = signedLeading * MILLIS_PER_MINUTE;
+                baseUnit = TimeUnit.DAY;
+            }
+            case HOUR -> {
+                baseValue = signedLeading * MILLIS_PER_HOUR;
+                baseUnit = TimeUnit.DAY;
+            }
+            case DAY -> {
+                baseValue = signedLeading * MILLIS_PER_DAY;
+                baseUnit = TimeUnit.DAY;
+            }
+            case WEEK -> {
+                baseValue = signedLeading * MILLIS_PER_WEEK;
+                baseUnit = TimeUnit.DAY;
+            }
+            case MONTH -> {
+                baseValue = signedLeading;
+                baseUnit = TimeUnit.MONTH;
+            }
+            case QUARTER -> {
+                baseValue = signedLeading * 3L;
+                baseUnit = TimeUnit.MONTH;
+            }
+            case YEAR -> {
+                baseValue = signedLeading * 12L;
+                baseUnit = TimeUnit.MONTH;
+            }
+            default -> {
+                // MICROSECOND (and any sub-millisecond unit) can't be represented exactly in
+                // Arrow's millisecond-granular IntervalDayTime, so don't silently truncate — fall
+                // through to the UDF path, which surfaces a loud error rather than a wrong result.
+                return original;
+            }
+        }
+
+        // PPL DATE_ADD/DATE_SUB return TIMESTAMP; lift the (possibly DATE) base to that type so
+        // DATETIME_PLUS yields a TIMESTAMP and the surrounding rowType matches the call's type.
+        RexNode baseTimestamp = rexBuilder.makeAbstractCast(original.getType(), base);
+        RexNode interval = rexBuilder.makeIntervalLiteral(
+            BigDecimal.valueOf(baseValue),
+            new SqlIntervalQualifier(baseUnit, null, SqlParserPos.ZERO)
+        );
+
+        RexNode shifted = rexBuilder.makeCall(SqlStdOperatorTable.DATETIME_PLUS, baseTimestamp, interval);
+        if (shifted.getType().equals(original.getType())) {
+            return shifted;
+        }
+        return rexBuilder.makeAbstractCast(original.getType(), shifted);
+    }
+
+    private static RexNode stripOperatorAnnotation(RexNode node) {
+        while (node instanceof OperatorAnnotation annotation && annotation.unwrap() != null) {
+            node = annotation.unwrap();
+        }
+        return node;
+    }
+}

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/DateTimeScalarFunctionsIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/DateTimeScalarFunctionsIT.java
@@ -197,6 +197,76 @@ public class DateTimeScalarFunctionsIT extends AnalyticsRestTestCase {
         assertFirstRowLong(oneRow("key00") + "| eval v = date('2024-01-15') - date('2024-01-10') | fields v", 5L);
     }
 
+    // ── DATE_ADD / DATE_SUB → DateAddSubAdapter (DATETIME_PLUS lowering) ──────────
+
+    public void testDateAddDayIntervalOnDateLiteral() throws IOException {
+        assertFirstRowString(
+            oneRow("key00") + "| eval v = date_add(date('1998-12-01'), interval 90 day) | fields v",
+            "1999-03-01 00:00:00"
+        );
+    }
+
+    public void testDateAddMonthIntervalOnDateLiteral() throws IOException {
+        assertFirstRowString(
+            oneRow("key00") + "| eval v = date_add(date('1993-07-01'), interval 3 month) | fields v",
+            "1993-10-01 00:00:00"
+        );
+    }
+
+    public void testDateAddYearIntervalOnDateLiteral() throws IOException {
+        assertFirstRowString(
+            oneRow("key00") + "| eval v = date_add(date('1994-01-01'), interval 1 year) | fields v",
+            "1995-01-01 00:00:00"
+        );
+    }
+
+    public void testDateSubDayIntervalOnDateLiteral() throws IOException {
+        assertFirstRowString(
+            oneRow("key00") + "| eval v = date_sub(date('1998-12-01'), interval 90 day) | fields v",
+            "1998-09-02 00:00:00"
+        );
+    }
+
+    public void testDateAddDayIntervalOnTimestampColumn() throws IOException {
+        // datetime0 at key00 == 2004-07-09 10:17:35; +1 day preserves the time-of-day.
+        assertFirstRowString(
+            oneRow("key00") + "| eval v = date_add(datetime0, interval 1 day) | fields v",
+            "2004-07-10 10:17:35"
+        );
+    }
+
+    public void testDateSubMonthIntervalOnTimestampColumn() throws IOException {
+        assertFirstRowString(
+            oneRow("key00") + "| eval v = date_sub(datetime0, interval 1 month) | fields v",
+            "2004-06-09 10:17:35"
+        );
+    }
+
+    public void testDateAddHourIntervalOnTimestampColumn() throws IOException {
+        assertFirstRowString(
+            oneRow("key00") + "| eval v = date_add(datetime0, interval 2 hour) | fields v",
+            "2004-07-09 12:17:35"
+        );
+    }
+
+    // MILLISECOND is the day-time base unit — exercises the 1:1 (no-scale) interval branch.
+    public void testDateAddMillisecondIntervalOnTimestampColumn() throws IOException {
+        assertFirstRowString(
+            oneRow("key00") + "| eval v = date_add(datetime0, interval 500 millisecond) | fields v",
+            "2004-07-09 10:17:35.5"
+        );
+    }
+
+    // date_add inside a WHERE predicate — the TPC-H q1/q4 shape that surfaced the gap.
+    public void testDateAddInWherePredicate() throws IOException {
+        assertFirstRowString(
+            oneRow("key00")
+                + "| where datetime0 < date_add(date('2005-01-01'), interval 1 year) "
+                + "| eval v = date_format(datetime0, '%Y-%m-%d') | fields v",
+            "2004-07-09"
+        );
+    }
+
     private void assertFirstRowString(String ppl, String expected) throws IOException {
         Object cell = firstRowFirstCell(ppl);
         assertNotNull("Expected non-null result for query [" + ppl + "]", cell);


### PR DESCRIPTION
### Description
Adds support for the PPL `date_add` / `date_sub` scalar functions on the DataFusion analytics backend. Before this change, any query using `date_add(<date|timestamp>, INTERVAL n unit)` or `date_sub(...)` failed at planning time with `Unrecognized scalar function [DATE_ADD]` (in a filter predicate) or `Unable to convert call DATE_ADD(date?, interval_year)` (in a join condition / projection), because `DATE_ADD/DATE_SUB `were absent from the `ScalarFunction` SPI enum and had no backend adapter.

These two PPL UDFs have no Substrait extension binding, so isthmus rejects them. `DATETIME_PLUS`, by contrast, lowers to Substrait's standard `add(timestamp, interval)`, which DataFusion executes natively — the same path `EarliestLatestAdapter` and `TimestampDiffAdapter` already rely on. The new `DateAddSubAdapter` rewrites `date_add/date_sub(base, INTERVAL n unit)` → `DATETIME_PLUS(CAST(base AS TIMESTAMP), interval)`, folding the date_sub sign into the interval.


Limitations:
  - A TIME base is anchored to the query-start date by the PPL UDF before adding; the adapter can't reproduce that date, so it leaves TIME (and any non-temporal) bases unlowered instead of emitting an epoch-anchored (wrong-date) result.
  - MICROSECOND (sub-millisecond) isn't representable in Arrow's millisecond-granular day-time interval, so it's left unlowered rather than silently truncated.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
