### PR TITLE
Log DataFusion execution metrics on data nodes

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/api.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/api.rs
@@ -83,6 +83,9 @@ pub struct QueryStreamHandle {
     /// Concurrency gate permit — held for the query's entire lifetime.
     /// Released on drop, which frees partition budget for other queries.
     _concurrency_permit: Option<tokio::sync::OwnedSemaphorePermit>,
+    /// Physical plan reference for post-execution metrics extraction.
+    /// Available after execution completes; read via `df_stream_get_metrics`.
+    physical_plan: Option<Arc<dyn datafusion::physical_plan::ExecutionPlan>>,
 }
 
 impl QueryStreamHandle {
@@ -104,6 +107,7 @@ impl QueryStreamHandle {
             _session_ctx: None,
             has_views,
             _concurrency_permit: permit,
+            physical_plan: None,
         }
     }
 
@@ -120,6 +124,51 @@ impl QueryStreamHandle {
             _session_ctx: Some(ctx),
             has_views,
             _concurrency_permit: permit,
+            physical_plan: None,
+        }
+    }
+
+    pub fn with_physical_plan(
+        stream: RecordBatchStreamAdapter<CrossRtStream>,
+        query_context: QueryTrackingContext,
+        ctx: datafusion::prelude::SessionContext,
+        permit: Option<tokio::sync::OwnedSemaphorePermit>,
+        plan: Arc<dyn datafusion::physical_plan::ExecutionPlan>,
+    ) -> Self {
+        let has_views = Self::schema_has_views(&stream.schema());
+        Self {
+            stream,
+            _query_tracking_context: query_context,
+            _session_ctx: Some(ctx),
+            has_views,
+            _concurrency_permit: permit,
+            physical_plan: Some(plan),
+        }
+    }
+
+    /// Returns execution metrics from ALL operators in the physical plan tree as JSON bytes.
+    /// Walks the tree recursively, collecting metrics from every node.
+    pub fn get_metrics_json(&self) -> Option<Vec<u8>> {
+        let plan = self.physical_plan.as_ref()?;
+        let mut map = serde_json::Map::new();
+        Self::collect_metrics(plan.as_ref(), &mut map);
+        if map.is_empty() {
+            return None;
+        }
+        serde_json::to_vec(&map).ok()
+    }
+
+    fn collect_metrics(plan: &dyn datafusion::physical_plan::ExecutionPlan, map: &mut serde_json::Map<String, serde_json::Value>) {
+        if let Some(metrics) = plan.metrics() {
+            for m in metrics.iter() {
+                let name = m.value().name().to_string();
+                let value = m.value().as_usize() as i64;
+                // Later operators override earlier ones if same name — leaf (scan) metrics take priority
+                map.insert(name, serde_json::Value::Number(serde_json::Number::from(value)));
+            }
+        }
+        for child in plan.children() {
+            Self::collect_metrics(child.as_ref(), map);
         }
     }
 }

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/ffm.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/ffm.rs
@@ -354,6 +354,37 @@ pub unsafe extern "C" fn df_stream_close(stream_ptr: i64) {
     api::stream_close(stream_ptr);
 }
 
+/// Returns execution metrics as JSON bytes for the given stream.
+/// Writes the pointer to allocated bytes into `out_ptr` and the length into `out_len_ptr`.
+/// Returns 0 on success, non-zero if no metrics are available.
+/// The caller must free the returned bytes via `df_free_metrics_buf`.
+#[no_mangle]
+pub unsafe extern "C" fn df_stream_get_metrics(stream_ptr: i64, out_ptr: *mut *const u8, out_len_ptr: *mut i64) -> i64 {
+    if stream_ptr == 0 {
+        return -1;
+    }
+    let handle = &*(stream_ptr as *const api::QueryStreamHandle);
+    match handle.get_metrics_json() {
+        Some(bytes) => {
+            let len = bytes.len() as i64;
+            let boxed = bytes.into_boxed_slice();
+            let ptr = Box::into_raw(boxed) as *const u8;
+            *out_ptr = ptr;
+            *out_len_ptr = len;
+            0
+        }
+        None => -1,
+    }
+}
+
+/// Frees a metrics buffer previously returned by `df_stream_get_metrics`.
+#[no_mangle]
+pub unsafe extern "C" fn df_free_metrics_buf(ptr: *mut u8, len: i64) {
+    if !ptr.is_null() && len > 0 {
+        let _ = Box::from_raw(std::slice::from_raw_parts_mut(ptr, len as usize));
+    }
+}
+
 #[no_mangle]
 pub extern "C" fn df_cancel_query(context_id: i64) {
     api::cancel_query(context_id);

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_executor.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_executor.rs
@@ -886,7 +886,7 @@ async unsafe fn execute_indexed_with_context_inner(
     let target_schema = crate::schema_coerce::coerce_inferred_schema(physical_plan.schema());
     let physical_plan = crate::relabel_exec::wrap_if_relabel_needed(physical_plan, target_schema)?;
     log_debug!("DataFusion physical plan:\n{}", displayable(physical_plan.as_ref()).indent(true));
-    let df_stream = execute_stream(physical_plan, ctx.task_ctx())
+    let df_stream = execute_stream(physical_plan.clone(), ctx.task_ctx())
         .map_err(|e| DataFusionError::Execution(format!("execute_stream: {}", e)))?;
 
     let (cross_rt_stream, abort_handle) =
@@ -898,6 +898,6 @@ async unsafe fn execute_indexed_with_context_inner(
 
     let schema = cross_rt_stream.schema();
     let wrapped = RecordBatchStreamAdapter::new(schema, cross_rt_stream);
-    let stream_handle = crate::api::QueryStreamHandle::with_session_context(wrapped, query_context, ctx, Some(permit));
+    let stream_handle = crate::api::QueryStreamHandle::with_physical_plan(wrapped, query_context, ctx, Some(permit), physical_plan);
     Ok(Box::into_raw(Box::new(stream_handle)) as i64)
 }

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/query_executor.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/query_executor.rs
@@ -301,7 +301,7 @@ pub async fn execute_with_context(
                 cross_rt_stream.schema(),
                 cross_rt_stream,
             );
-            return Ok::<i64, DataFusionError>(Box::into_raw(Box::new(wrapped)) as i64);
+            return Ok::<(i64, Option<Arc<dyn datafusion::physical_plan::ExecutionPlan>>), DataFusionError>((Box::into_raw(Box::new(wrapped)) as i64, None));
         }
 
         let dataframe = handle.ctx.execute_logical_plan(logical_plan).await?;
@@ -312,7 +312,7 @@ pub async fn execute_with_context(
         let physical_plan = crate::relabel_exec::wrap_if_relabel_needed(physical_plan, target_schema)?;
         log_debug!("DataFusion physical plan:\n{}", displayable(physical_plan.as_ref()).indent(true));
 
-        let df_stream = execute_stream(physical_plan, handle.ctx.task_ctx()).map_err(|e| {
+        let df_stream = execute_stream(physical_plan.clone(), handle.ctx.task_ctx()).map_err(|e| {
             error!("execute_with_context: failed to create stream: {}", e);
             e
         })?;
@@ -329,10 +329,10 @@ pub async fn execute_with_context(
             cross_rt_stream,
         );
 
-        Ok::<i64, DataFusionError>(Box::into_raw(Box::new(wrapped)) as i64)
+        Ok::<(i64, Option<Arc<dyn datafusion::physical_plan::ExecutionPlan>>), DataFusionError>((Box::into_raw(Box::new(wrapped)) as i64, Some(physical_plan)))
     };
 
-    let stream_ptr = crate::cancellation::cancellable(token.as_ref(), context_id, query_future)
+    let (stream_ptr, physical_plan) = crate::cancellation::cancellable(token.as_ref(), context_id, query_future)
         .await
         .map_err(|e| DataFusionError::Execution(e))?;
 
@@ -340,7 +340,10 @@ pub async fn execute_with_context(
     let stream = unsafe { *Box::from_raw(stream_ptr as *mut datafusion::physical_plan::stream::RecordBatchStreamAdapter<CrossRtStream>) };
     // Permit is held until the QueryStreamHandle is dropped (query complete).
     // If cancellation fires → stream drops → handle drops → permit drops → gate releases.
-    let stream_handle = crate::api::QueryStreamHandle::with_session_context(stream, handle.query_context, handle.ctx, Some(permit));
+    let stream_handle = match physical_plan {
+        Some(plan) => crate::api::QueryStreamHandle::with_physical_plan(stream, handle.query_context, handle.ctx, Some(permit), plan),
+        None => crate::api::QueryStreamHandle::with_session_context(stream, handle.query_context, handle.ctx, Some(permit)),
+    };
     Ok(Box::into_raw(Box::new(stream_handle)) as i64)
 }
 

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionResultStream.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionResultStream.java
@@ -21,6 +21,7 @@ import org.apache.arrow.vector.types.pojo.Schema;
 import org.opensearch.analytics.backend.EngineResultBatch;
 import org.opensearch.analytics.backend.EngineResultStream;
 import org.opensearch.analytics.exec.ArrowValues;
+import org.opensearch.analytics.exec.FragmentResources;
 import org.opensearch.be.datafusion.nativelib.NativeBridge;
 import org.opensearch.be.datafusion.nativelib.StreamHandle;
 import org.opensearch.common.annotation.ExperimentalApi;
@@ -42,7 +43,7 @@ import static org.apache.arrow.c.Data.importField;
  * @opensearch.experimental
  */
 @ExperimentalApi
-public class DatafusionResultStream implements EngineResultStream {
+public class DatafusionResultStream implements EngineResultStream, FragmentResources.MetricsCapable {
 
     private final StreamHandle streamHandle;
     private final BufferAllocator allocator;
@@ -62,6 +63,11 @@ public class DatafusionResultStream implements EngineResultStream {
             iteratorInstance = new BatchIterator(streamHandle, allocator, dictionaryProvider);
         }
         return iteratorInstance;
+    }
+
+    @Override
+    public byte[] getMetricsJson() {
+        return NativeBridge.streamGetMetrics(streamHandle.getPointer());
     }
 
     @Override

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/nativelib/NativeBridge.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/nativelib/NativeBridge.java
@@ -85,6 +85,8 @@ public final class NativeBridge {
     private static final MethodHandle STREAM_GET_SCHEMA;
     private static final MethodHandle STREAM_NEXT;
     private static final MethodHandle STREAM_CLOSE;
+    private static final MethodHandle STREAM_GET_METRICS;
+    private static final MethodHandle FREE_METRICS_BUF;
     private static final MethodHandle SQL_TO_SUBSTRAIT;
     private static final MethodHandle REGISTER_FILTER_TREE_CALLBACKS;
     private static final MethodHandle CREATE_LOCAL_SESSION;
@@ -240,6 +242,15 @@ public final class NativeBridge {
 
         STREAM_CLOSE = linker.downcallHandle(lib.find("df_stream_close").orElseThrow(), FunctionDescriptor.ofVoid(ValueLayout.JAVA_LONG));
 
+        STREAM_GET_METRICS = linker.downcallHandle(
+            lib.find("df_stream_get_metrics").orElseThrow(),
+            FunctionDescriptor.of(ValueLayout.JAVA_LONG, ValueLayout.JAVA_LONG, ValueLayout.ADDRESS, ValueLayout.ADDRESS)
+        );
+
+        FREE_METRICS_BUF = linker.downcallHandle(
+            lib.find("df_free_metrics_buf").orElseThrow(),
+            FunctionDescriptor.ofVoid(ValueLayout.ADDRESS, ValueLayout.JAVA_LONG)
+        );
         // i64 df_sql_to_substrait(shard_ptr, table_ptr, table_len, sql_ptr, sql_len, runtime_ptr, out_ptr, out_cap, out_len)
         SQL_TO_SUBSTRAIT = linker.downcallHandle(
             lib.find("df_sql_to_substrait").orElseThrow(),
@@ -865,6 +876,31 @@ public final class NativeBridge {
 
     public static void streamClose(long streamPtr) {
         NativeCall.invokeVoid(STREAM_CLOSE, streamPtr);
+    }
+
+    /**
+     * Extracts execution metrics from the stream's physical plan as JSON bytes.
+     * Returns null if no metrics are available (e.g., plan didn't capture them).
+     * Must be called BEFORE streamClose (the stream handle must still be alive).
+     */
+    public static byte[] streamGetMetrics(long streamPtr) {
+        try (var arena = Arena.ofConfined()) {
+            var outPtr = arena.allocate(ValueLayout.ADDRESS);
+            var outLen = arena.allocate(ValueLayout.JAVA_LONG);
+            long result = (long) STREAM_GET_METRICS.invokeExact(streamPtr, outPtr, outLen);
+            if (result != 0) {
+                return null; // no metrics available
+            }
+            long len = outLen.get(ValueLayout.JAVA_LONG, 0);
+            MemorySegment dataPtr = outPtr.get(ValueLayout.ADDRESS, 0);
+            byte[] bytes = dataPtr.reinterpret(len).toArray(ValueLayout.JAVA_BYTE);
+            // Free the Rust-allocated buffer
+            FREE_METRICS_BUF.invokeExact(dataPtr, len);
+            return bytes;
+        } catch (Throwable t) {
+            logger.debug("Failed to read native stream metrics", t);
+            return null;
+        }
     }
 
     // ---- Cancellation ----

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/AnalyticsSearchService.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/AnalyticsSearchService.java
@@ -176,6 +176,17 @@ public class AnalyticsSearchService implements AutoCloseable {
                         responseHandler.onBatch(batch);
                     }
                     long fragmentTookNanos = System.nanoTime() - startNanos;
+                    // Extract and log DataFusion execution metrics at DEBUG level
+                    if (LOGGER.isDebugEnabled()) {
+                        byte[] metricsJson = exec.resources().getExecutionMetrics();
+                        if (metricsJson != null) {
+                            LOGGER.debug(
+                                "[FragmentMetrics] shard={} metrics={}",
+                                shard.shardId(),
+                                new String(metricsJson, java.nio.charset.StandardCharsets.UTF_8)
+                            );
+                        }
+                    }
                     responseHandler.onComplete();
                     ResolvedFragment resolved = exec.resolved();
                     DelegationDescriptor delegation = resolved.plan().getDelegationDescriptor();

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/FragmentResources.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/FragmentResources.java
@@ -75,6 +75,23 @@ public final class FragmentResources implements AutoCloseable {
         return stream;
     }
 
+    /**
+     * Extracts execution metrics from the underlying engine stream (if supported).
+     * Must be called after the stream is exhausted but before close().
+     * Returns null if the stream doesn't support metrics extraction.
+     */
+    public byte[] getExecutionMetrics() {
+        if (stream instanceof MetricsCapable mc) {
+            return mc.getMetricsJson();
+        }
+        return null;
+    }
+
+    /** Marker interface for streams that can provide execution metrics. */
+    public interface MetricsCapable {
+        byte[] getMetricsJson();
+    }
+
     @Override
     public void close() throws Exception {
         // Close the stream and engine first so any in-flight release upcalls from native


### PR DESCRIPTION
## Description

After fragment execution completes on a data node, extract DataFusion per-operator execution metrics and log them at DEBUG level. This provides visibility into DataFusion execution performance (scan time, row pruning, compute time, etc.) without requiring transport-layer changes.

This is a more incremental change decomposing related PR to provide these metrics under the profile flag for analytics engine indices:
https://github.com/opensearch-project/OpenSearch/pull/21972

### Key Changes

1. Two additional FFM calls.

`df_stream_get_metrics` which is called post execution and when provided the `QueryStreamHandle`, extracts the execution metrics from the physical plan.

`df_free_metrics_buf` which is needed solely to clear the buffer populated by `df_stream_get_metrics` when returning metrics to java. Since the JVM cannot free the metrics buffer created and populated on the rust side, this extra call is needed simply to pass the metrics buffer back to rust so it can be freed.

2. QueryStreamHandle now must hold a reference to the the physical plan.

DF populates the physical plan with metrics on execution. As the stream handle is our view of query execution, we need to keep a reference to the physical plan here such that we can inspect and extract metrics once execution completes.

### Example log output

Test query
```
POST /_analytics/ppl
  {"query": "source = delegation_test | where status = \"active\" | fields status, value"}
```

```
[2026-06-05T13:29:33,109][DEBUG][o.o.a.e.AnalyticsSearchService] [runTask-0] [FragmentMetrics] shard=[delegation_test][0]
  metrics={"batches_pre_coalesce":2,"batches_produced":2,"build_mask_time":417,"bytes_scanned":2274,"coalesce_time":83334,"end_timestamp":1780690533109171000,"elapsed_compute":0,"ffm_collector_c
  alls":2,"filter_record_batch_time":135750,"index_query_time":1247042,"mask_slice_time":208,"min_skip_run_block_granular":2,"on_batch_mask_time":292,"output_batches":1,"output_bytes":163840,"ou
  tput_rows":50,"parquet_batches_received":2,"parquet_poll_time":743125,"parquet_read_time":390416,"position_map_identity":2,"prefetch_wait_count":2,"prefetch_wait_time":1293375,"projection_fixu
  p_time":959,"row_groups_processed":2,"rows_matched":50,"rows_pruned_by_page_index":450,"start_timestamp":1780690533106880000,"time_elapsed_opening":35291,"time_elapsed_processing":72625,"time_
  elapsed_scanning_total":2250750,"time_elapsed_scanning_until_data":2236292}
```

Readable version
```
  {
    "batches_pre_coalesce": 2,
    "batches_produced": 2,
    "build_mask_time": 417,
    "bytes_scanned": 2274,
    "coalesce_time": 83334,
    "elapsed_compute": 0,
    "end_timestamp": 1780690533109171000,
    "ffm_collector_calls": 2,
    "filter_record_batch_time": 135750,
    "index_query_time": 1247042,
    "mask_slice_time": 208,
    "min_skip_run_block_granular": 2,
    "on_batch_mask_time": 292,
    "output_batches": 1,
    "output_bytes": 163840,
    "output_rows": 50,
    "parquet_batches_received": 2,
    "parquet_poll_time": 743125,
    "parquet_read_time": 390416,
    "position_map_identity": 2,
    "prefetch_wait_count": 2,
    "prefetch_wait_time": 1293375,
    "projection_fixup_time": 959,
    "row_groups_processed": 2,
    "rows_matched": 50,
    "rows_pruned_by_page_index": 450,
    "start_timestamp": 1780690533106880000,
    "time_elapsed_opening": 35291,
    "time_elapsed_processing": 72625,
    "time_elapsed_scanning_total": 2250750,
    "time_elapsed_scanning_until_data": 2236292
  }
```

### How to enable

```json
PUT /_cluster/settings
{"transient":{"logger.org.opensearch.analytics.exec.AnalyticsSearchService":"DEBUG"}}
```

### Related Issues
N/A

### Check List
- [x] Functionality includes testing.
~~- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.~~
~~- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).