### PR TITLE
[Arrow Flight RPC] Add metadata channel on ArrowBatchResponse

### DIFF
--- a/plugins/arrow-base/src/main/java/org/opensearch/arrow/transport/ArrowBatchResponse.java
+++ b/plugins/arrow-base/src/main/java/org/opensearch/arrow/transport/ArrowBatchResponse.java
@@ -79,24 +79,42 @@ import java.io.IOException;
 public abstract class ArrowBatchResponse extends ActionResponse {
 
     private final VectorSchemaRoot batchRoot;
+    private final byte[] metadata;
 
     /**
-     * Send-side constructor: wraps a root populated by the producer.
+     * Send-side: wraps a root populated by the producer.
+     *
      * @param batchRoot the root to send; ownership transfers to the transport
      */
     protected ArrowBatchResponse(VectorSchemaRoot batchRoot) {
-        this.batchRoot = batchRoot;
+        this(batchRoot, null);
     }
 
     /**
-     * Receive-side constructor: claims ownership of the batch from the input.
-     * @param in must also implement {@link ArrowStreamInput}; throws otherwise
+     * Send-side: wraps a root with opaque application metadata that travels on the same
+     * Arrow Flight frame ({@code putNext(ArrowBuf)}). Use for per-batch metadata (row
+     * offsets, watermarks) or, by attaching to the last batch, stream-terminal payloads
+     * (profiling counters, summary stats).
+     *
+     * @param batchRoot the root to send; ownership transfers to the transport
+     * @param metadata opaque bytes to attach to this batch, or {@code null}
+     */
+    protected ArrowBatchResponse(VectorSchemaRoot batchRoot, byte[] metadata) {
+        this.batchRoot = batchRoot;
+        this.metadata = metadata;
+    }
+
+    /**
+     * Receive-side: claims ownership of the batch and pulls any attached metadata.
+     *
+     * @param in must also implement {@link ArrowStreamInput}
      * @throws IOException if reading fails
      */
     protected ArrowBatchResponse(StreamInput in) throws IOException {
         super(in);
         if (in instanceof ArrowStreamInput arrowIn) {
             this.batchRoot = arrowIn.getRoot();
+            this.metadata = arrowIn.getMetadata();
             arrowIn.claimOwnership();
         } else {
             throw new IllegalStateException(
@@ -111,6 +129,11 @@ public abstract class ArrowBatchResponse extends ActionResponse {
     /** Returns the Arrow root holding the response vectors. */
     public VectorSchemaRoot getRoot() {
         return batchRoot;
+    }
+
+    /** Returns the application metadata attached to this batch, or {@code null} if none. */
+    public byte[] getMetadata() {
+        return metadata;
     }
 
     @Override

--- a/plugins/arrow-base/src/main/java/org/opensearch/arrow/transport/ArrowStreamInput.java
+++ b/plugins/arrow-base/src/main/java/org/opensearch/arrow/transport/ArrowStreamInput.java
@@ -35,4 +35,12 @@ public interface ArrowStreamInput {
      * input's {@code close()} must not release the batch's buffers.
      */
     void claimOwnership();
+
+    /**
+     * Returns application metadata attached to this batch, or {@code null} if none. Bytes
+     * are owned by the consumer; lifetime is independent of the stream buffer.
+     */
+    default byte[] getMetadata() {
+        return null;
+    }
 }

--- a/plugins/arrow-flight-rpc/docs/native-arrow-transport-design.md
+++ b/plugins/arrow-flight-rpc/docs/native-arrow-transport-design.md
@@ -115,3 +115,41 @@ Do not reuse or close it — the framework transfers its buffers and closes it o
 Batches can be produced in parallel. Each batch must have its own `VectorSchemaRoot`
 (created from the channel's allocator). The framework serializes the transfer and send
 on the executor thread. The producer can queue batches without waiting for each to flush.
+
+## Application Metadata
+
+Each `ArrowBatchResponse` can carry an opaque `byte[]` of application metadata that
+travels on the same Flight frame as its data — Arrow Flight's
+`OutboundStreamListener.putNext(ArrowBuf metadata)` is what's used on the wire. The
+transport does not interpret these bytes; encoding and decoding are the action's
+responsibility.
+
+Typical uses:
+- **Per-batch metadata** keyed to *this* batch's data — row offsets, watermarks,
+  batch-level stats.
+- **Stream-terminal payloads** — attach to the last batch only. Profiling counters,
+  cumulative stats, summary blobs.
+
+```java
+// send-side: attach to the last batch
+boolean isLast = (b == batchCount - 1);
+if (isLast && profile) {
+    byte[] profileBytes = serializeProfile(...);
+    channel.sendResponseBatch(new MyQueryResponse(root, profileBytes));
+} else {
+    channel.sendResponseBatch(new MyQueryResponse(root));
+}
+
+// receive-side: read on every batch, act when present
+while ((r = stream.nextResponse()) != null) {
+    consume(r.getRoot());
+    byte[] meta = r.getMetadata();
+    if (meta != null) handleProfile(meta);
+}
+```
+
+Lifecycle: bytes are copied off the Flight wire buffer into a `byte[]` owned by the
+response, so the metadata outlives the stream cursor.
+
+The metadata channel is exposed on `ArrowBatchResponse` and is only available on the
+native Arrow path. The byte-serialized path does not surface it.

--- a/plugins/arrow-flight-rpc/docs/server-side-streaming-guide.md
+++ b/plugins/arrow-flight-rpc/docs/server-side-streaming-guide.md
@@ -93,3 +93,10 @@ flowchart TD
 - Always call either `completeStream()` (success) OR `sendResponse(exception)` (error)
 - Never call both methods
 - Stream must be explicitly completed or terminated
+
+### Trailing / per-batch metadata (native Arrow path)
+For actions whose response extends `ArrowBatchResponse`, opaque application metadata can be
+attached to any batch via `new MyResponse(root, byte[])` and read on the receiver via
+`response.getMetadata()`. Attach to the last batch for stream-terminal payloads
+(profiling counters, summary stats). See
+[native-arrow-transport-design.md](native-arrow-transport-design.md#application-metadata).

--- a/plugins/arrow-flight-rpc/src/internalClusterTest/java/org/opensearch/arrow/flight/StreamMetadataIT.java
+++ b/plugins/arrow-flight-rpc/src/internalClusterTest/java/org/opensearch/arrow/flight/StreamMetadataIT.java
@@ -1,0 +1,359 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.arrow.flight;
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.vector.IntVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.opensearch.Version;
+import org.opensearch.action.ActionRequest;
+import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.action.ActionType;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.TransportAction;
+import org.opensearch.arrow.allocator.ArrowBasePlugin;
+import org.opensearch.arrow.allocator.ArrowNativeAllocator;
+import org.opensearch.arrow.flight.transport.FlightStreamPlugin;
+import org.opensearch.arrow.spi.NativeAllocatorPoolConfig;
+import org.opensearch.arrow.transport.ArrowBatchResponse;
+import org.opensearch.arrow.transport.ArrowBatchResponseHandler;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.common.inject.Inject;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.action.ActionResponse;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.plugins.ActionPlugin;
+import org.opensearch.plugins.Plugin;
+import org.opensearch.plugins.PluginInfo;
+import org.opensearch.tasks.Task;
+import org.opensearch.test.OpenSearchIntegTestCase;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.StreamTransportService;
+import org.opensearch.transport.TransportChannel;
+import org.opensearch.transport.TransportException;
+import org.opensearch.transport.TransportRequestOptions;
+import org.opensearch.transport.stream.StreamErrorCode;
+import org.opensearch.transport.stream.StreamException;
+import org.opensearch.transport.stream.StreamTransportResponse;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.opensearch.common.util.FeatureFlags.STREAM_TRANSPORT;
+
+/**
+ * End-to-end test for {@link ArrowBatchResponse}'s metadata channel: producer attaches
+ * opaque bytes to a batch via {@code new ArrowBatchResponse(root, metadata)}; consumer
+ * reads them via {@code response.getMetadata()}. Wire path is Arrow Flight's
+ * {@code putNext(ArrowBuf)}.
+ */
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.SUITE, minNumDataNodes = 2, maxNumDataNodes = 2)
+public class StreamMetadataIT extends OpenSearchIntegTestCase {
+
+    private static final Schema DATA_SCHEMA = new Schema(
+        List.of(
+            new Field("batch_id", FieldType.nullable(new ArrowType.Int(32, true)), null),
+            new Field("value", FieldType.nullable(new ArrowType.Int(32, true)), null)
+        )
+    );
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        internalCluster().ensureAtLeastNumDataNodes(2);
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return List.of(TestPlugin.class, ArrowBasePlugin.class);
+    }
+
+    @Override
+    protected Collection<PluginInfo> additionalNodePlugins() {
+        return List.of(
+            new PluginInfo(
+                FlightStreamPlugin.class.getName(),
+                "classpath plugin",
+                "NA",
+                Version.CURRENT,
+                "1.8",
+                FlightStreamPlugin.class.getName(),
+                null,
+                List.of(ArrowBasePlugin.class.getName()),
+                false
+            )
+        );
+    }
+
+    @LockFeatureFlag(STREAM_TRANSPORT)
+    public void testMetadataAttachedToLastBatch() throws Exception {
+        DiscoveryNode node = getClusterState().nodes().iterator().next();
+        StreamTransportService sts = internalCluster().getInstance(StreamTransportService.class);
+
+        int dataBatches = 4;
+        int rowsPerBatch = 3;
+        byte[] expectedMetrics = "{\"output_rows\":12,\"elapsed_compute_ns\":12345}".getBytes(StandardCharsets.UTF_8);
+
+        Sink sink = new Sink();
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<Exception> failure = new AtomicReference<>();
+
+        sts.sendRequest(
+            node,
+            FragmentAction.NAME,
+            new FragmentRequest(dataBatches, rowsPerBatch, true),
+            TransportRequestOptions.builder().withType(TransportRequestOptions.Type.STREAM).build(),
+            new CollectingHandler(sink, latch, failure)
+        );
+
+        assertTrue(latch.await(30, TimeUnit.SECONDS));
+        assertNull(String.valueOf(failure.get()), failure.get());
+
+        assertEquals(dataBatches, sink.batchesSeen);
+        assertEquals(dataBatches * rowsPerBatch, sink.dataRowTotal);
+        assertEquals(1, sink.metadataObservations);
+        assertEquals(dataBatches - 1, sink.metadataBatchIndex);
+        assertArrayEquals(expectedMetrics, sink.metrics);
+    }
+
+    @LockFeatureFlag(STREAM_TRANSPORT)
+    public void testNoMetadataWhenProfilingDisabled() throws Exception {
+        DiscoveryNode node = getClusterState().nodes().iterator().next();
+        StreamTransportService sts = internalCluster().getInstance(StreamTransportService.class);
+
+        int dataBatches = 3;
+        int rowsPerBatch = 5;
+
+        Sink sink = new Sink();
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<Exception> failure = new AtomicReference<>();
+
+        sts.sendRequest(
+            node,
+            FragmentAction.NAME,
+            new FragmentRequest(dataBatches, rowsPerBatch, false),
+            TransportRequestOptions.builder().withType(TransportRequestOptions.Type.STREAM).build(),
+            new CollectingHandler(sink, latch, failure)
+        );
+
+        assertTrue(latch.await(30, TimeUnit.SECONDS));
+        assertNull(String.valueOf(failure.get()), failure.get());
+
+        assertEquals(dataBatches, sink.batchesSeen);
+        assertEquals(dataBatches * rowsPerBatch, sink.dataRowTotal);
+        assertEquals(0, sink.metadataObservations);
+        assertNull(sink.metrics);
+    }
+
+    static class Sink {
+        int batchesSeen = 0;
+        int dataRowTotal = 0;
+        int metadataObservations = 0;
+        int metadataBatchIndex = -1;
+        byte[] metrics = null;
+    }
+
+    static class CollectingHandler extends ArrowBatchResponseHandler<FragmentResponse> {
+        private final Sink sink;
+        private final CountDownLatch latch;
+        private final AtomicReference<Exception> failure;
+        private final List<VectorSchemaRoot> retainedRoots = new ArrayList<>();
+
+        CollectingHandler(Sink sink, CountDownLatch latch, AtomicReference<Exception> failure) {
+            this.sink = sink;
+            this.latch = latch;
+            this.failure = failure;
+        }
+
+        @Override
+        public void handleStreamResponse(StreamTransportResponse<FragmentResponse> stream) {
+            try {
+                FragmentResponse response;
+                while ((response = stream.nextResponse()) != null) {
+                    int idx = sink.batchesSeen++;
+                    VectorSchemaRoot root = response.getRoot();
+                    sink.dataRowTotal += root.getRowCount();
+                    if (response.getMetadata() != null) {
+                        sink.metadataObservations++;
+                        sink.metadataBatchIndex = idx;
+                        sink.metrics = response.getMetadata();
+                    }
+                    retainedRoots.add(root);
+                }
+                stream.close();
+            } catch (Exception e) {
+                failure.set(e);
+                stream.cancel("test error", e);
+            } finally {
+                for (VectorSchemaRoot r : retainedRoots)
+                    r.close();
+                latch.countDown();
+            }
+        }
+
+        @Override
+        public void handleException(TransportException exp) {
+            failure.set(exp);
+            latch.countDown();
+        }
+
+        @Override
+        public String executor() {
+            return ThreadPool.Names.GENERIC;
+        }
+
+        @Override
+        public FragmentResponse read(StreamInput in) throws IOException {
+            return new FragmentResponse(in);
+        }
+    }
+
+    public static class FragmentResponse extends ArrowBatchResponse {
+        public FragmentResponse(VectorSchemaRoot root) {
+            super(root);
+        }
+
+        public FragmentResponse(VectorSchemaRoot root, byte[] metadata) {
+            super(root, metadata);
+        }
+
+        public FragmentResponse(StreamInput in) throws IOException {
+            super(in);
+        }
+    }
+
+    public static class FragmentRequest extends ActionRequest {
+        private final int batchCount;
+        private final int rowsPerBatch;
+        private final boolean profile;
+
+        FragmentRequest(int batchCount, int rowsPerBatch, boolean profile) {
+            this.batchCount = batchCount;
+            this.rowsPerBatch = rowsPerBatch;
+            this.profile = profile;
+        }
+
+        public FragmentRequest(StreamInput in) throws IOException {
+            super(in);
+            this.batchCount = in.readInt();
+            this.rowsPerBatch = in.readInt();
+            this.profile = in.readBoolean();
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            out.writeInt(batchCount);
+            out.writeInt(rowsPerBatch);
+            out.writeBoolean(profile);
+        }
+
+        @Override
+        public ActionRequestValidationException validate() {
+            return null;
+        }
+    }
+
+    public static class FragmentAction extends ActionType<FragmentResponse> {
+        public static final FragmentAction INSTANCE = new FragmentAction();
+        public static final String NAME = "cluster:internal/test/fragment_with_metadata";
+
+        private FragmentAction() {
+            super(NAME, FragmentResponse::new);
+        }
+    }
+
+    public static class TransportFragmentAction extends TransportAction<FragmentRequest, FragmentResponse> {
+        private final BufferAllocator allocator;
+
+        @Inject
+        public TransportFragmentAction(
+            StreamTransportService streamTransportService,
+            ActionFilters actionFilters,
+            ArrowNativeAllocator nativeAllocator
+        ) {
+            super(FragmentAction.NAME, actionFilters, streamTransportService.getTaskManager());
+            this.allocator = nativeAllocator.getPoolAllocator(NativeAllocatorPoolConfig.POOL_FLIGHT)
+                .newChildAllocator("metadata-test", 0, Long.MAX_VALUE);
+            streamTransportService.registerRequestHandler(
+                FragmentAction.NAME,
+                ThreadPool.Names.GENERIC,
+                FragmentRequest::new,
+                this::handle
+            );
+        }
+
+        @Override
+        protected void doExecute(Task task, FragmentRequest request, ActionListener<FragmentResponse> listener) {
+            listener.onFailure(new UnsupportedOperationException("Use StreamTransportService"));
+        }
+
+        private void handle(FragmentRequest request, TransportChannel channel, Task task) throws IOException {
+            try {
+                long totalRows = 0;
+                for (int b = 0; b < request.batchCount; b++) {
+                    VectorSchemaRoot root = createDataBatch(b, request.rowsPerBatch);
+                    boolean isLast = (b == request.batchCount - 1);
+                    if (isLast && request.profile) {
+                        byte[] metrics = ("{\"output_rows\":" + (totalRows + request.rowsPerBatch) + ",\"elapsed_compute_ns\":12345}")
+                            .getBytes(StandardCharsets.UTF_8);
+                        channel.sendResponseBatch(new FragmentResponse(root, metrics));
+                    } else {
+                        channel.sendResponseBatch(new FragmentResponse(root));
+                    }
+                    totalRows += request.rowsPerBatch;
+                }
+                channel.completeStream();
+            } catch (StreamException e) {
+                if (e.getErrorCode() != StreamErrorCode.CANCELLED) channel.sendResponse(e);
+            } catch (Exception e) {
+                channel.sendResponse(e);
+            }
+        }
+
+        private VectorSchemaRoot createDataBatch(int batchIndex, int rowCount) {
+            VectorSchemaRoot root = VectorSchemaRoot.create(DATA_SCHEMA, allocator);
+            IntVector batchId = (IntVector) root.getVector("batch_id");
+            IntVector value = (IntVector) root.getVector("value");
+            batchId.allocateNew();
+            value.allocateNew();
+            for (int i = 0; i < rowCount; i++) {
+                batchId.setSafe(i, batchIndex);
+                value.setSafe(i, batchIndex * 1000 + i);
+            }
+            batchId.setValueCount(rowCount);
+            value.setValueCount(rowCount);
+            root.setRowCount(rowCount);
+            return root;
+        }
+    }
+
+    public static class TestPlugin extends Plugin implements ActionPlugin {
+        public TestPlugin() {}
+
+        @Override
+        public List<ActionHandler<? extends ActionRequest, ? extends ActionResponse>> getActions() {
+            return List.of(new ActionHandler<>(FragmentAction.INSTANCE, TransportFragmentAction.class));
+        }
+    }
+}

--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightOutboundHandler.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightOutboundHandler.java
@@ -155,7 +155,9 @@ class FlightOutboundHandler extends ProtocolOutboundHandler {
 
         try {
             VectorStreamOutput out;
+            byte[] metadata = null;
             if (task.response() instanceof ArrowBatchResponse arrowResponse) {
+                metadata = arrowResponse.getMetadata();
                 // Native Arrow path: zero-copy transfer producer's vectors into stream root
                 VectorSchemaRoot streamRoot = flightChannel.getRoot();
                 if (streamRoot == null) {
@@ -177,7 +179,7 @@ class FlightOutboundHandler extends ProtocolOutboundHandler {
                 task.response().writeTo(out);
             }
             try (out) {
-                flightChannel.sendBatch(getHeaderBuffer(task.requestId(), task.nodeVersion(), task.features()), out);
+                flightChannel.sendBatch(getHeaderBuffer(task.requestId(), task.nodeVersion(), task.features()), out, metadata);
                 messageListener.onResponseSent(task.requestId(), task.action(), task.response());
             }
         } catch (FlightRuntimeException e) {

--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightServerChannel.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightServerChannel.java
@@ -12,6 +12,7 @@ import org.apache.arrow.flight.BackpressureStrategy;
 import org.apache.arrow.flight.CallStatus;
 import org.apache.arrow.flight.FlightProducer.ServerStreamListener;
 import org.apache.arrow.flight.FlightRuntimeException;
+import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.logging.log4j.LogManager;
@@ -148,12 +149,15 @@ class FlightServerChannel implements TcpChannel, ArrowFlightChannel {
         return executor;
     }
 
-    /**
-     * Sends a batch of data as a VectorSchemaRoot.
-     *
-     * @param output StreamOutput for the response
-     */
     public void sendBatch(ByteBuffer header, VectorStreamOutput output) {
+        sendBatch(header, output, null);
+    }
+
+    /**
+     * Sends a batch, optionally with application metadata attached to the same Flight
+     * frame via {@code putNext(ArrowBuf)}. Metadata is opaque to the transport.
+     */
+    public void sendBatch(ByteBuffer header, VectorStreamOutput output, byte[] metadata) {
         if (cancelled) {
             throw StreamException.cancelled("Cannot flush more batches. Stream cancelled by the client");
         }
@@ -162,19 +166,24 @@ class FlightServerChannel implements TcpChannel, ArrowFlightChannel {
         }
         batchNumber.incrementAndGet();
         long batchStartTime = System.nanoTime();
-        // Only set for the first batch
         if (root == null) {
             middleware.setHeader(header);
             root = output.getRoot();
             serverStreamListener.start(root);
         } else {
             root = output.getRoot();
-            // placeholder to clear and fill the root with data for the next batch
         }
         logger.debug("Sending batch #{} for correlation ID: {}", batchNumber, correlationId);
-        // we do not want to close the root right after putNext() call as we do not know the status of it whether
-        // its transmitted at transport; we close them all at complete stream. TODO: optimize this behaviour
-        serverStreamListener.putNext();
+        // Roots are not closed right after putNext: gRPC may still hold zero-copy refs.
+        // They're released at completeStream. TODO: optimize.
+        if (metadata != null) {
+            // Flight takes ownership of metadataBuf via putNext(ArrowBuf).
+            ArrowBuf metadataBuf = allocator.buffer(metadata.length);
+            metadataBuf.writeBytes(metadata);
+            serverStreamListener.putNext(metadataBuf);
+        } else {
+            serverStreamListener.putNext();
+        }
         long putNextTime = (System.nanoTime() - batchStartTime) / 1_000_000;
         if (callTracker != null) {
             long rootSize = FlightUtils.calculateVectorSchemaRootSize(root);

--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightTransportResponse.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightTransportResponse.java
@@ -14,6 +14,7 @@ import org.apache.arrow.flight.FlightRuntimeException;
 import org.apache.arrow.flight.FlightStream;
 import org.apache.arrow.flight.HeaderCallOption;
 import org.apache.arrow.flight.Ticket;
+import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -125,7 +126,10 @@ class FlightTransportResponse<T extends TransportResponse> implements StreamTran
 
             VectorSchemaRoot streamRoot = flightStream.getRoot();
             currentBatchSize = FlightUtils.calculateVectorSchemaRootSize(streamRoot);
-            try (VectorStreamInput input = newStreamInput(streamRoot)) {
+            // Flight owns getLatestMetadata()'s buffer until the next next() call;
+            // we copy off so the response can outlive the stream cursor.
+            byte[] metadata = readMetadata();
+            try (VectorStreamInput input = newStreamInput(streamRoot, metadata)) {
                 input.setVersion(initialHeader.getVersion());
                 return handler.read(input);
             }
@@ -146,10 +150,26 @@ class FlightTransportResponse<T extends TransportResponse> implements StreamTran
         return currentBatchSize;
     }
 
-    private VectorStreamInput newStreamInput(VectorSchemaRoot streamRoot) {
+    private VectorStreamInput newStreamInput(VectorSchemaRoot streamRoot, byte[] metadata) {
         return isNativeHandler
-            ? VectorStreamInput.forNativeArrow(streamRoot, namedWriteableRegistry)
+            ? VectorStreamInput.forNativeArrow(streamRoot, namedWriteableRegistry, metadata)
             : VectorStreamInput.forByteSerialized(streamRoot, namedWriteableRegistry);
+    }
+
+    private byte[] readMetadata() {
+        return copyMetadata(flightStream.getLatestMetadata());
+    }
+
+    /**
+     * Copies an Arrow Flight metadata buffer into a {@code byte[]} the consumer owns, or
+     * returns {@code null} if the buffer is absent/empty. Package-private for testing.
+     */
+    static byte[] copyMetadata(ArrowBuf buf) {
+        if (buf == null || buf.readableBytes() == 0) return null;
+        int len = (int) buf.readableBytes();
+        byte[] copy = new byte[len];
+        buf.getBytes(0, copy);
+        return copy;
     }
 
     @Override

--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/VectorStreamInput.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/VectorStreamInput.java
@@ -65,7 +65,7 @@ abstract class VectorStreamInput extends StreamInput {
      * outlives the next Flight batch. Released by {@link NativeArrow#close()} unless the
      * response takes ownership via {@link NativeArrow#claimOwnership()}.
      */
-    static VectorStreamInput forNativeArrow(VectorSchemaRoot streamRoot, NamedWriteableRegistry registry) {
+    static VectorStreamInput forNativeArrow(VectorSchemaRoot streamRoot, NamedWriteableRegistry registry, byte[] metadata) {
         if (streamRoot.getFieldVectors().isEmpty()) {
             throw new IllegalStateException("Native Arrow batch has no field vectors");
         }
@@ -79,7 +79,11 @@ abstract class VectorStreamInput extends StreamInput {
             consumerRoot.close();
             throw t;
         }
-        return new NativeArrow(consumerRoot, registry);
+        return new NativeArrow(consumerRoot, registry, metadata);
+    }
+
+    static VectorStreamInput forNativeArrow(VectorSchemaRoot streamRoot, NamedWriteableRegistry registry) {
+        return forNativeArrow(streamRoot, registry, null);
     }
 
     /**
@@ -202,9 +206,11 @@ abstract class VectorStreamInput extends StreamInput {
     /** Native Arrow input: consumer root carrying vectors transferred from the Flight stream. */
     static final class NativeArrow extends VectorStreamInput implements ArrowStreamInput {
         private boolean transferred = false;
+        private final byte[] metadata;
 
-        NativeArrow(VectorSchemaRoot root, NamedWriteableRegistry registry) {
+        NativeArrow(VectorSchemaRoot root, NamedWriteableRegistry registry, byte[] metadata) {
             super(root, registry);
+            this.metadata = metadata;
         }
 
         @Override
@@ -220,6 +226,11 @@ abstract class VectorStreamInput extends StreamInput {
         @Override
         public void claimOwnership() {
             transferred = true;
+        }
+
+        @Override
+        public byte[] getMetadata() {
+            return metadata;
         }
 
         /** Releases the consumer root unless {@link #claimOwnership()} was called. */

--- a/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/FlightOutboundHandlerTests.java
+++ b/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/FlightOutboundHandlerTests.java
@@ -246,7 +246,7 @@ public class FlightOutboundHandlerTests extends OpenSearchTestCase {
                 // Clean up the stream root created by the handler
                 sentRoot.close();
                 return null;
-            }).when(mockFlightChannel).sendBatch(any(), any(VectorStreamOutput.class));
+            }).when(mockFlightChannel).sendBatch(any(), any(VectorStreamOutput.class), any());
 
             TestArrowResponse response = new TestArrowResponse(producerRoot);
             handler.sendResponseBatch(
@@ -291,7 +291,7 @@ public class FlightOutboundHandlerTests extends OpenSearchTestCase {
                 assertEquals(1, sentRoot.getRowCount());
                 assertEquals(99, ((IntVector) sentRoot.getVector("val")).get(0));
                 return null;
-            }).when(mockFlightChannel).sendBatch(any(), any(VectorStreamOutput.class));
+            }).when(mockFlightChannel).sendBatch(any(), any(VectorStreamOutput.class), any());
 
             doAnswer(invocation -> {
                 latch.countDown();

--- a/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/FlightServerChannelTests.java
+++ b/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/FlightServerChannelTests.java
@@ -9,12 +9,22 @@
 package org.opensearch.arrow.flight.transport;
 
 import org.apache.arrow.flight.FlightProducer.ServerStreamListener;
+import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.IntVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.apache.arrow.vector.types.pojo.Schema;
 import org.opensearch.arrow.flight.stats.FlightCallTracker;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.transport.stream.StreamErrorCode;
 import org.opensearch.transport.stream.StreamException;
 
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -27,6 +37,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -248,5 +260,66 @@ public class FlightServerChannelTests extends OpenSearchTestCase {
 
         StreamException ex = expectThrows(StreamException.class, ch::awaitReadyOrThrow);
         assertEquals(StreamErrorCode.CANCELLED, ex.getErrorCode());
+    }
+
+    /**
+     * sendBatch with non-null metadata must call {@code putNext(ArrowBuf)} (not {@code putNext()})
+     * with a buffer carrying the exact bytes the producer attached.
+     */
+    public void testSendBatchWithMetadataCallsPutNextWithBuf() throws Exception {
+        try (RootAllocator realAllocator = new RootAllocator()) {
+            FlightServerChannel ch = new FlightServerChannel(listener, realAllocator, middleware, callTracker, executor, 5_000);
+
+            VectorSchemaRoot root = newSingleIntRoot(realAllocator, 7);
+            byte[] metadata = "{\"output_rows\":1}".getBytes(StandardCharsets.UTF_8);
+            AtomicReference<byte[]> capturedMetadata = new AtomicReference<>();
+
+            // In production, Flight's putNext(ArrowBuf) takes ownership and frees the buffer.
+            // The mock doesn't, so close it here to avoid an allocator leak at test teardown.
+            doAnswer(inv -> {
+                ArrowBuf buf = inv.getArgument(0);
+                byte[] copy = new byte[(int) buf.readableBytes()];
+                buf.getBytes(0, copy);
+                capturedMetadata.set(copy);
+                buf.close();
+                return null;
+            }).when(listener).putNext(any(ArrowBuf.class));
+
+            try (VectorStreamOutput out = VectorStreamOutput.forNativeArrow(root)) {
+                ch.sendBatch(ByteBuffer.allocate(0), out, metadata);
+            }
+
+            verify(listener, times(1)).putNext(any(ArrowBuf.class));
+            verify(listener, never()).putNext();
+            assertArrayEquals("metadata bytes must round-trip into the ArrowBuf", metadata, capturedMetadata.get());
+            root.close();
+        }
+    }
+
+    /** sendBatch without metadata must call the no-arg {@code putNext()} variant. */
+    public void testSendBatchWithoutMetadataCallsPutNextNoArg() throws Exception {
+        try (RootAllocator realAllocator = new RootAllocator()) {
+            FlightServerChannel ch = new FlightServerChannel(listener, realAllocator, middleware, callTracker, executor, 5_000);
+            VectorSchemaRoot root = newSingleIntRoot(realAllocator, 1);
+
+            try (VectorStreamOutput out = VectorStreamOutput.forNativeArrow(root)) {
+                ch.sendBatch(ByteBuffer.allocate(0), out);
+            }
+
+            verify(listener, times(1)).putNext();
+            verify(listener, never()).putNext(any(ArrowBuf.class));
+            root.close();
+        }
+    }
+
+    private static VectorSchemaRoot newSingleIntRoot(BufferAllocator allocator, int value) {
+        Schema schema = new Schema(List.of(new Field("v", FieldType.nullable(new ArrowType.Int(32, true)), null)));
+        VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator);
+        IntVector vec = (IntVector) root.getVector("v");
+        vec.allocateNew();
+        vec.setSafe(0, value);
+        vec.setValueCount(1);
+        root.setRowCount(1);
+        return root;
     }
 }

--- a/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/FlightTransportResponseTests.java
+++ b/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/FlightTransportResponseTests.java
@@ -8,6 +8,8 @@
 
 package org.opensearch.arrow.flight.transport;
 
+import org.apache.arrow.memory.ArrowBuf;
+import org.apache.arrow.memory.RootAllocator;
 import org.opensearch.arrow.transport.ArrowBatchResponse;
 import org.opensearch.arrow.transport.ArrowBatchResponseHandler;
 import org.opensearch.core.transport.TransportResponse;
@@ -17,6 +19,7 @@ import org.opensearch.transport.TransportException;
 import org.opensearch.transport.TransportResponseHandler;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 public class FlightTransportResponseTests extends OpenSearchTestCase {
 
@@ -40,6 +43,28 @@ public class FlightTransportResponseTests extends OpenSearchTestCase {
         // MetricsTrackingResponseHandler in production path; null tracker is fine for this check.
         MetricsTrackingResponseHandler<TestArrowResponse> wrapped = new MetricsTrackingResponseHandler<>(new TestArrowHandler(), null);
         assertTrue(wrapped.skipsDeserialization());
+    }
+
+    public void testCopyMetadataNullBuffer() {
+        assertNull(FlightTransportResponse.copyMetadata(null));
+    }
+
+    public void testCopyMetadataEmptyBuffer() {
+        try (RootAllocator allocator = new RootAllocator(); ArrowBuf buf = allocator.buffer(0)) {
+            assertNull(FlightTransportResponse.copyMetadata(buf));
+        }
+    }
+
+    public void testCopyMetadataPopulatedBuffer() {
+        byte[] payload = "{\"output_rows\":42}".getBytes(StandardCharsets.UTF_8);
+        try (RootAllocator allocator = new RootAllocator(); ArrowBuf buf = allocator.buffer(payload.length)) {
+            buf.writeBytes(payload);
+            byte[] copy = FlightTransportResponse.copyMetadata(buf);
+            assertNotNull(copy);
+            assertArrayEquals(payload, copy);
+            // The copy is independent of the wire buffer.
+            assertNotSame(payload, copy);
+        }
     }
 
     private static final class TestArrowHandler extends ArrowBatchResponseHandler<TestArrowResponse> {


### PR DESCRIPTION
## Summary

Adds an opaque `byte[]` metadata channel on `ArrowBatchResponse` so a stream-transport action can attach bytes to a batch (or to its terminal batch) and read them back on the consumer. Wire path is Arrow Flight's `putNext(ArrowBuf)` / `getLatestMetadata()`. No changes to the public stream-transport SPI in `server/`.

This is a self-contained prototype. It's published as a draft so the use case in #21972 (DataFusion operator metrics → coordinator profile output) can borrow from it if helpful.

## Design rationale

The stream-transport tenets in #21253 and #21465 are: **the transport moves `TransportResponse` instances; the action defines the response shape**. Anything an action needs to send between nodes belongs on a request or response object. The transport stays narrow and is shared across actions.

Putting the metadata bytes on `ArrowBatchResponse` keeps the abstraction faithful to that:

- The metadata is a property of the response, where the action already lives. The action encodes; the consumer decodes.
- `server/transport/stream/StreamTransportResponse` doesn't grow new methods — every transport implementation that exists or will exist remains decoupled from this feature.
- `FlightTransportChannel` doesn't grow new methods either — plugins talk to it through the same `sendResponseBatch` they already use.
- The wire path is Arrow Flight's intended per-frame metadata mechanism (`putNext(ArrowBuf)`), not a custom convention layered on top.

The receive-side flow is symmetrical: `FlightTransportResponse` copies `getLatestMetadata()` into a `byte[]` on each frame (Flight retains buffer ownership otherwise), and the response constructor pulls it via `ArrowStreamInput.getMetadata()`.

The mechanism covers both shapes naturally: per-batch metadata (row offsets, watermarks, batch-level stats) and stream-terminal metadata (attach to the last batch — profile counters, summary stats).

## Integrating the analytics-engine profile flow (#21972)

The Rust FFM additions (`df_stream_get_metrics`, `df_free_metrics_buf`), the `profile` flag on `QueryContext` / `FragmentExecutionRequest`, and the `TaskProfile.dataNodeMetrics` parsing land as-is. Only the transport hop changes.

**Producer** (data node, `AnalyticsSearchService.executeFragmentStreamingAsync`): attach the metrics blob to the last batch's response.

```java
boolean isLast = (batchIdx == lastBatchIdx);
byte[] metrics = (isLast && request.profile()) ? exec.resources().getExecutionMetrics() : null;
channel.sendResponseBatch(metrics != null
    ? new FragmentExecutionArrowResponse(root, metrics)
    : new FragmentExecutionArrowResponse(root));
```

This drops the `onCompleteWithMetrics` callback, the reflection-based `sendStreamMetadata` call in `AnalyticsSearchTransportService`, and the `pendingStreamMetadata` field on `FlightTransportChannel`.

**Consumer** (coordinator, `AnalyticsSearchTransportService.handleStreamResponse`): read inside the existing batch loop.

```java
while ((next = stream.nextResponse()) != null) {
    /* existing batch handling */
    byte[] meta = next.getMetadata();
    if (meta != null) listener.onMetrics(meta);
}
```

This drops the `getTrailingMetadata()` call after the loop and the corresponding addition to `StreamTransportResponse`.

Empty-shard case: when no batches are produced, send a single `FragmentExecutionArrowResponse(emptyRoot, metricsBytes)` — the metadata rides on a real (zero-row but legitimately-shaped) batch, no sentinel convention needed.

## Tests

- `StreamMetadataIT` — profile=true: metadata observed once on the last batch, bytes intact end-to-end. profile=false: zero observations, data path identical.
- `FlightOutboundHandlerTests` updated for the new `sendBatch` signature.
- Existing unit tests + `NativeArrowTransportIT` pass.

## Test plan

- [x] `./gradlew :plugins:arrow-base:check :plugins:arrow-flight-rpc:check`
- [x] `./gradlew :plugins:arrow-flight-rpc:internalClusterTest --tests "*StreamMetadataIT" --tests "*NativeArrowTransportIT"`

## Related

- Native Arrow transport: #21253
- arrow-base extraction: #21465
- Motivating use case: #21972