### PR TITLE
Fix (about to be flaky) Netty4Http3ServerTransportTests sporadic test case failures

### DIFF
--- a/modules/transport-netty4/src/main/java/org/opensearch/http/netty4/Netty4Http3ServerTransport.java
+++ b/modules/transport-netty4/src/main/java/org/opensearch/http/netty4/Netty4Http3ServerTransport.java
@@ -72,9 +72,11 @@ import io.netty.handler.codec.compression.ZstdEncoder;
 import io.netty.handler.codec.http.HttpContentCompressor;
 import io.netty.handler.codec.http.HttpContentDecompressor;
 import io.netty.handler.codec.http.HttpObjectAggregator;
+import io.netty.handler.codec.http3.DefaultHttp3SettingsFrame;
 import io.netty.handler.codec.http3.Http3;
 import io.netty.handler.codec.http3.Http3FrameToHttpObjectCodec;
 import io.netty.handler.codec.http3.Http3ServerConnectionHandler;
+import io.netty.handler.codec.http3.Http3Settings;
 import io.netty.handler.codec.quic.QuicChannel;
 import io.netty.handler.codec.quic.QuicSslContext;
 import io.netty.handler.codec.quic.QuicSslContextBuilder;
@@ -324,6 +326,9 @@ public class Netty4Http3ServerTransport extends AbstractHttpServerTransport {
                     io.netty.handler.codec.http3.Http3.supportedApplicationProtocols()
                 ).build();
 
+                final Http3Settings http3Settings = new Http3Settings();
+                http3Settings.maxFieldSectionSize(SETTING_HTTP_MAX_HEADER_SIZE.get(settings).getBytes());
+
                 ch.pipeline().addLast(Http3.newQuicServerCodecBuilder().sslEngineProvider(q -> {
                     final QuicSslEngine engine = sslContext.newEngine(q.alloc());
                     q.attr(HTTP_SERVER_ENGINE_KEY).set(engine);
@@ -342,7 +347,11 @@ public class Netty4Http3ServerTransport extends AbstractHttpServerTransport {
                             ch.pipeline()
                                 .addLast(
                                     new Http3ServerConnectionHandler(
-                                        new HttpChannelHandler(Netty4Http3ServerTransport.this, handlingSettings)
+                                        new HttpChannelHandler(Netty4Http3ServerTransport.this, handlingSettings),
+                                        null,
+                                        null,
+                                        new DefaultHttp3SettingsFrame(http3Settings),
+                                        true
                                     )
                                 );
                         }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Fix (about to be flaky) Netty4Http3ServerTransportTests sporadic test case failures, caused by https://github.com/opensearch-project/OpenSearch/pull/21944 due to tightened checks

### Related Issues

Example failure: https://build.ci.opensearch.org/job/gradle-check/79418/testReport/junit/org.opensearch.http.netty4/Netty4Http3ServerTransportTests/testBadRequest/

```
[2026-06-04T12:55:09,564][ERROR][i.n.h.c.h.Http3RequestStreamInboundHandler] [[opensearch[transport_worker][T#1]]] Caught Http3Exception on channel [id: 0xb42d52f8, QuicStreamAddress{streamId=0}]
io.netty.handler.codec.http3.Http3Exception: Header size exceeded max allowed size (8192)
	at io.netty.handler.codec.http3.Http3CodecUtils.connectionError(Http3CodecUtils.java:247)
	at io.netty.handler.codec.http3.Http3FrameCodec.connectionError(Http3FrameCodec.java:147)
	at io.netty.handler.codec.http3.Http3FrameCodec.decodeHeaders(Http3FrameCodec.java:412)
	at io.netty.handler.codec.http3.Http3FrameCodec.decodeFrame(Http3FrameCodec.java:255)
	at io.netty.handler.codec.http3.Http3FrameCodec.decode(Http3FrameCodec.java:204)
	at io.netty.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:545)
	at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:484)
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:296)
	at io.netty.handler.codec.http3.Http3FrameCodec.channelRead(Http3FrameCodec.java:134)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1429)
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:918)
	at io.netty.handler.codec.quic.QuicheQuicStreamChannel$QuicStreamChannelUnsafe.recv(QuicheQuicStreamChannel.java:1025)
	at io.netty.handler.codec.quic.QuicheQuicStreamChannel.readable(QuicheQuicStreamChannel.java:460)
	at io.netty.handler.codec.quic.QuicheQuicChannel$QuicChannelUnsafe.recvStream(QuicheQuicChannel.java:1898)
	at io.netty.handler.codec.quic.QuicheQuicChannel$QuicChannelUnsafe.processReceived(QuicheQuicChannel.java:1775)
	at io.netty.handler.codec.quic.QuicheQuicChannel$QuicChannelUnsafe.connectionRecv(QuicheQuicChannel.java:1710)
	at io.netty.handler.codec.quic.QuicheQuicChannel.recv(QuicheQuicChannel.java:997)
	at io.netty.handler.codec.quic.QuicheQuicCodec$QuicCodecHeaderProcessor.process(QuicheQuicCodec.java:370)
	at io.netty.handler.codec.quic.QuicHeaderParser.parse(QuicHeaderParser.java:142)
	at io.netty.handler.codec.quic.QuicheQuicCodec.handleQuicPacket(QuicheQuicCodec.java:200)
	at io.netty.handler.codec.quic.QuicheQuicCodec.channelRead(QuicheQuicCodec.java:191)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:355)
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1429)
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:918)
	at io.netty.channel.nio.AbstractNioMessageChannel$NioMessageUnsafe.read(AbstractNioMessageChannel.java:100)
	at io.netty.channel.nio.AbstractNioChannel$AbstractNioUnsafe.handle(AbstractNioChannel.java:445)
	at io.netty.channel.nio.NioIoHandler$DefaultNioRegistration.handle(NioIoHandler.java:388)
	at io.netty.channel.nio.NioIoHandler.processSelectedKey(NioIoHandler.java:596)
	at io.netty.channel.nio.NioIoHandler.processSelectedKeysPlain(NioIoHandler.java:541)
	at io.netty.channel.nio.NioIoHandler.processSelectedKeys(NioIoHandler.java:514)
	at io.netty.channel.nio.NioIoHandler.run(NioIoHandler.java:484)
	at io.netty.channel.SingleThreadIoEventLoop.runIo(SingleThreadIoEventLoop.java:225)
	at io.netty.channel.SingleThreadIoEventLoop.run(SingleThreadIoEventLoop.java:196)
	at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:1195)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at java.base/java.lang.Thread.run(Thread.java:1474)
```

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
