### PR TITLE
Fix TopK oversampling to use the user's limit, not the system size cap

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/ToStringFunctionAdapter.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/ToStringFunctionAdapter.java
@@ -67,7 +67,7 @@ class ToStringFunctionAdapter implements ScalarFunctionAdapter {
     private enum Format {
         HEX("hex", SqlTypeName.BIGINT),
         BINARY("binary", SqlTypeName.BIGINT),
-        COMMAS("commas", /* preserveFractional */ null),
+        COMMAS("commas", /* preserveFractional */null),
         DURATION("duration", SqlTypeName.BIGINT),
         DURATION_MILLIS("duration_millis", SqlTypeName.BIGINT);
 

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchTopKRewriter.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchTopKRewriter.java
@@ -83,15 +83,22 @@ public final class OpenSearchTopKRewriter {
         return Optional.of(result);
     }
 
-    /** Walks the tree to find the bottommost Sort with collation above a FINAL aggregate. */
+    /**
+     * Walks the tree to find the <em>deepest</em> collated Sort above a FINAL aggregate. Recursing
+     * before matching is deliberate: PPL {@code ... | sort c | head N} arrives as a collated outer
+     * {@code LogicalSystemLimit(fetch=querySizeLimit)} over the user's collated {@code Sort(fetch=N)},
+     * and the oversampling must derive the shard fetch from the inner (tighter) N — not the outer
+     * size cap — or every shard over-fetches {@code ceil(querySizeLimit * factor) + querySizeLimit}
+     * rows. Preferring the deepest match honors the innermost limit.
+     */
     private static SortAboveFinal findSortAboveFinal(RelNode node) {
-        if (node instanceof OpenSearchSort sort && !sort.getCollation().getFieldCollations().isEmpty()) {
-            OpenSearchAggregate finalAgg = findFinalAgg(sort.getInput());
-            if (finalAgg != null) return new SortAboveFinal(sort, finalAgg);
-        }
         for (RelNode child : node.getInputs()) {
             SortAboveFinal found = findSortAboveFinal(child);
             if (found != null) return found;
+        }
+        if (node instanceof OpenSearchSort sort && !sort.getCollation().getFieldCollations().isEmpty()) {
+            OpenSearchAggregate finalAgg = findFinalAgg(sort.getInput());
+            if (finalAgg != null) return new SortAboveFinal(sort, finalAgg);
         }
         return null;
     }

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/TopKRewriterPlanShapeTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/TopKRewriterPlanShapeTests.java
@@ -112,6 +112,31 @@ public class TopKRewriterPlanShapeTests extends PlanShapeTestBase {
         assertTrue("at least 2 OpenSearchSort nodes expected", sortCount >= 2);
     }
 
+    /**
+     * Collated outer system-limit over a collated inner head: oversampling must honor the INNER
+     * fetch, not the outer cap. PPL {@code ... | sort - c | head 10} arrives as
+     * {@code SystemLimit(fetch=10000, sort0=$1 DESC) → Sort(fetch=10, sort0=$1 DESC) → ... → FINAL}.
+     * The per-partition shard Sort fetch must derive from 10 (→ ceil(10*2)+10 = 30), not from the
+     * 10000 system cap (which would over-fetch 30000 rows/shard).
+     */
+    public void testRewrite_collatedOuterLimit_honorsInnerFetch() {
+        RelNode inner = buildSortHeadOverGroupedCount(); // Sort(collation $1 DESC, fetch 10) over grouped count
+        // Outer system size-limit with the SAME collation and a large cap (what QueryService wraps).
+        RelNode outer = LogicalSort.create(
+            inner,
+            RelCollations.of(new RelFieldCollation(1, RelFieldCollation.Direction.DESCENDING)),
+            null,
+            rexBuilder.makeLiteral(10000, typeFactory.createSqlType(SqlTypeName.INTEGER), true)
+        );
+        RelNode result = runPlanner(outer, contextWithOversampling(2.0));
+        String plan = RelOptUtil.toString(result);
+        long sortCount = plan.lines().filter(l -> l.contains("OpenSearchSort")).count();
+        assertTrue("a per-partition Sort must be inserted", sortCount >= 2);
+        // Shard Sort fetch = ceil(innerFetch * factor) + innerFetch = ceil(10*2)+10 = 30.
+        assertTrue("shard Sort must be sized off the inner fetch (30), got plan:\n" + plan, plan.contains("fetch=[30]"));
+        assertFalse("shard Sort must NOT be sized off the 10000 system cap (30000)", plan.contains("fetch=[30000]"));
+    }
+
     /** SUM aggregate: partial SUM is directly sortable, no reduce_eval needed. */
     public void testRewrite_sumByGroup_sortInserted() {
         RelOptTable table = mockTable("test_index", "status", "size");

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/ShardBucketOversamplingIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/ShardBucketOversamplingIT.java
@@ -87,6 +87,67 @@ public class ShardBucketOversamplingIT extends AnalyticsRestTestCase {
         assertRowCount(result, 10);
     }
 
+    // ── Multi-shard TopK across sort placements / group-by / having ─────────────────────
+    // 84 distinct RegionID groups over 100 docs on 2 shards, so `head 10` (10 << 84) genuinely
+    // exercises the per-shard TopK oversampling path (a per-partition Sort+Limit below the ER).
+    //
+    // These assert only the DETERMINISTIC contract — row count, schema, no error — across the
+    // shape variations. They intentionally do NOT assert exact group membership/values: shard-bucket
+    // oversampling is approximate by design (see AnalyticsApproximationSettings); a globally-top-N
+    // group that ranks below every shard's local cutoff can legitimately be dropped, and tied
+    // sort-keys have no defined tie-break, so value-equality vs. an unsampled run is not a guaranteed
+    // property and would be flaky. The exactness of the fix (per-shard fetch sized off the inner
+    // limit, not the outer system cap) is pinned deterministically in TopKRewriterPlanShapeTests.
+
+    /** count by group, sort DESC on the agg, head 10. */
+    public void testCountByGroup_sortDescAgg_head10() throws Exception {
+        ensureProvisioned();
+        assertCountByQueryReturns("source = " + INDEX + " | stats count() as c by RegionID | sort - c | head 10", 10);
+    }
+
+    /** sort ASC on the agg, head 10 — opposite collation direction through the per-shard sort. */
+    public void testCountByGroup_sortAscAgg_head10() throws Exception {
+        ensureProvisioned();
+        assertCountByQueryReturns("source = " + INDEX + " | stats count() as c by RegionID | sort c | head 10", 10);
+    }
+
+    /** sort on the GROUP KEY (not the agg), head 10 — sort field is the by-column. */
+    public void testCountByGroup_sortOnGroupKey_head10() throws Exception {
+        ensureProvisioned();
+        assertCountByQueryReturns("source = " + INDEX + " | stats count() as c by RegionID | sort - RegionID | head 10", 10);
+    }
+
+    /** HAVING (post-stats where) between the agg and the limit, then sort + head. */
+    public void testCountByGroup_having_sortDesc_head10() throws Exception {
+        ensureProvisioned();
+        // `where c > 1` is PPL's HAVING: filters groups after aggregation, before sort/limit.
+        // 14 RegionID groups have count > 1 (12 at 2 + 2 at 3), so head 10 still bounds the result.
+        assertCountByQueryReturns(
+            "source = " + INDEX + " | stats count() as c by RegionID | where c > 1 | sort - c | head 10",
+            10
+        );
+    }
+
+    /** No head: grouped + sorted, every surviving group returned (redundant outer system limit
+     *  must not trim, and TopK must not fire when there is no user limit). */
+    public void testCountByGroup_sortDesc_noHead_returnsAllGroups() throws Exception {
+        ensureProvisioned();
+        // 84 distinct RegionID groups in the fixture.
+        assertCountByQueryReturns("source = " + INDEX + " | stats count() as c by RegionID | sort - c", 84);
+    }
+
+    /** Asserts the query returns exactly {@code expectedRows} rows with the expected [c, RegionID]
+     *  schema — the deterministic contract that holds regardless of oversampling factor. */
+    private void assertCountByQueryReturns(String ppl, int expectedRows) throws Exception {
+        Map<String, Object> result = executePPL(ppl);
+        List<List<Object>> rows = rowsOf(result);
+        assertEquals("row count", expectedRows, rows.size());
+        for (List<Object> row : rows) {
+            assertEquals("each row is [count, RegionID]", 2, row.size());
+            assertTrue("count column must be numeric, got " + row.get(0), row.get(0) instanceof Number);
+        }
+    }
+
     /** No oversampling (factor=0): query still works. */
     public void testFactorZero_queryWorks() throws Exception {
         ensureProvisioned();
@@ -111,6 +172,19 @@ public class ShardBucketOversamplingIT extends AnalyticsRestTestCase {
         List<?> rows = (List<?>) result.get("rows");
         assertNotNull("response must have rows, got: " + result.keySet(), rows);
         assertEquals(expected, rows.size());
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<List<Object>> rowsOf(Map<String, Object> result) {
+        List<?> rows = (List<?>) result.get("rows");
+        assertNotNull("response must have rows, got: " + result.keySet(), rows);
+        return (List<List<Object>>) rows;
+    }
+
+    private void setOversamplingFactor(double factor) throws Exception {
+        Request req = new Request("PUT", "/_cluster/settings");
+        req.setJsonEntity("{\"persistent\":{\"analytics.shard_bucket_oversampling_factor\": " + factor + "}}");
+        client().performRequest(req);
     }
 
     private Map<String, Object> executePPL(String ppl) throws Exception {


### PR DESCRIPTION


<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
A query like `... | stats count() by x | sort - c | head 10` was making each shard fetch way too many rows. The SQL plugin wraps every query in a system size-limit (default 10000), and the oversampling code was reading that 10000 instead of the user's `head 10` — so shards fetched ~30000 rows each instead of ~30.

The fix: when there are two stacked sorts (the system cap over the user's head), use the inner one (the real limit) to size the per-shard fetch.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
