### PR TITLE
Sandbox - Fix crash on single-shard HAVING queries

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/substrait_to_tree.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/substrait_to_tree.rs
@@ -88,22 +88,38 @@ pub struct ExtractionResult {
     pub tree: BoolNode,
 }
 
-/// Extract the filter expression from a DataFusion logical plan.
+/// Extract the scan-adjacent WHERE filter — the one carrying delegation markers, lowered
+/// against the scan schema by [`expr_to_bool_tree`]. Returns `None` if there's no such filter.
 ///
-/// Walks down through Projection/SubqueryAlias/etc. nodes to find the first
-/// `Filter` node. Returns `None` if there's no filter.
+/// Skips a HAVING/qualify (a Filter above an `Aggregate`/`Window`): its predicate references
+/// the aggregate/window output, absent from the scan schema, so lowering it would fail with
+/// "No field named count(...)". The HAVING is applied by the `FilterExec` DataFusion leaves
+/// above the aggregate; here we recurse past it to the real WHERE below.
 pub fn extract_filter_expr(plan: &LogicalPlan) -> Option<Expr> {
     match plan {
+        LogicalPlan::Filter(filter) if is_post_aggregate_filter(filter) => {
+            extract_filter_expr(filter.input.as_ref())
+        }
         LogicalPlan::Filter(filter) => Some(filter.predicate.clone()),
-        _ => {
-            for child in plan.inputs() {
-                if let Some(expr) = extract_filter_expr(child) {
-                    return Some(expr);
-                }
-            }
-            None
+        _ => plan.inputs().iter().find_map(|child| extract_filter_expr(child)),
+    }
+}
+
+/// Whether this Filter is a HAVING/qualify — its input reaches an `Aggregate`/`Window`
+/// (whose outputs aren't in the scan schema) through row-preserving operators.
+fn is_post_aggregate_filter(filter: &datafusion::logical_expr::Filter) -> bool {
+    fn schema_changes_below(plan: &LogicalPlan) -> bool {
+        match plan {
+            LogicalPlan::Aggregate(_) | LogicalPlan::Window(_) => true,
+            LogicalPlan::Projection(_)
+            | LogicalPlan::SubqueryAlias(_)
+            | LogicalPlan::Sort(_)
+            | LogicalPlan::Limit(_)
+            | LogicalPlan::Filter(_) => plan.inputs().iter().any(|c| schema_changes_below(c)),
+            _ => false,
         }
     }
+    schema_changes_below(filter.input.as_ref())
 }
 
 /// Convert a DataFusion filter `Expr` to a `BoolNode` tree.
@@ -483,6 +499,71 @@ mod tests {
     /// every `expr_to_bool_tree` call site repeats it.
     fn test_state() -> datafusion::execution::SessionState {
         SessionContext::new().state()
+    }
+
+    // ── extract_filter_expr ──────────────────────────────────────────
+
+    /// Plan a SQL string over a two-column memtable `t(k Utf8, qty Int32)`.
+    async fn plan_from_sql(sql: &str) -> LogicalPlan {
+        use datafusion::arrow::array::{Int32Array, StringArray};
+        use datafusion::arrow::record_batch::RecordBatch;
+        use datafusion::datasource::MemTable;
+        use datafusion::execution::context::SessionContext;
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("k", DataType::Utf8, false),
+            Field::new("qty", DataType::Int32, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(StringArray::from(vec!["a", "a", "b"])),
+                Arc::new(Int32Array::from(vec![10, 20, 30])),
+            ],
+        )
+        .unwrap();
+        let ctx = SessionContext::new();
+        ctx.register_table("t", Arc::new(MemTable::try_new(schema, vec![vec![batch]]).unwrap()))
+            .unwrap();
+        ctx.sql(sql).await.unwrap().logical_plan().clone()
+    }
+
+    fn predicate_columns(expr: &Expr) -> std::collections::HashSet<String> {
+        expr.column_refs().into_iter().map(|c| c.name.clone()).collect()
+    }
+
+    /// With a HAVING present, `extract_filter_expr` returns the scan-adjacent WHERE (on `qty`),
+    /// not the HAVING (on the aggregate output `count(*)`). Returning the HAVING would make
+    /// `expr_to_bool_tree` lower `count(...)` against the scan schema → the single-shard 500.
+    #[tokio::test]
+    async fn extract_filter_skips_having_returns_where() {
+        let plan = plan_from_sql("SELECT k, count(*) AS c FROM t WHERE qty > 5 GROUP BY k HAVING count(*) > 3").await;
+        let cols = predicate_columns(&extract_filter_expr(&plan).expect("scan-adjacent WHERE"));
+        assert!(cols.contains("qty"), "expected WHERE on `qty`, got {:?}", cols);
+        assert!(!cols.iter().any(|c| c.contains("count")), "must not return the HAVING, got {:?}", cols);
+    }
+
+    /// A qualify on a window output (`... | where rn <= N`) sits above `Sort → Projection →
+    /// WindowAggr`; `extract_filter_expr` sees through them to skip it and return the WHERE.
+    #[tokio::test]
+    async fn extract_filter_skips_window_qualify_over_sort() {
+        let plan = plan_from_sql(
+            "SELECT k, rn FROM \
+               (SELECT k, qty, count(*) OVER (PARTITION BY k ORDER BY qty) AS rn FROM t WHERE qty > 5) \
+             WHERE rn <= 2 ORDER BY k",
+        )
+        .await;
+        let cols = predicate_columns(&extract_filter_expr(&plan).expect("scan-adjacent WHERE"));
+        assert!(cols.contains("qty"), "expected WHERE on `qty`, got {:?}", cols);
+        assert!(!cols.iter().any(|c| c.contains("count") || c == "rn"), "must not return the qualify, got {:?}", cols);
+    }
+
+    /// A HAVING with no WHERE below the aggregate yields no scan-side filter (the HAVING runs in
+    /// the FilterExec above the aggregate; returning it would crash lowering against the scan schema).
+    #[tokio::test]
+    async fn extract_filter_having_only_returns_none() {
+        let plan = plan_from_sql("SELECT k, count(*) AS c FROM t GROUP BY k HAVING count(*) > 3").await;
+        assert!(extract_filter_expr(&plan).is_none(), "a HAVING must not be a scan-side filter");
     }
 
     // ── expr_to_bool_tree ────────────────────────────────────────────

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/ToStringFunctionAdapter.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/ToStringFunctionAdapter.java
@@ -67,7 +67,7 @@ class ToStringFunctionAdapter implements ScalarFunctionAdapter {
     private enum Format {
         HEX("hex", SqlTypeName.BIGINT),
         BINARY("binary", SqlTypeName.BIGINT),
-        COMMAS("commas", /* preserveFractional */ null),
+        COMMAS("commas", /* preserveFractional */null),
         DURATION("duration", SqlTypeName.BIGINT),
         DURATION_MILLIS("duration_millis", SqlTypeName.BIGINT);
 

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/RelNodeUtils.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/RelNodeUtils.java
@@ -163,6 +163,52 @@ public class RelNodeUtils {
     }
 
     /**
+     * Finds the scan-adjacent WHERE {@link OpenSearchFilter} — the one carrying delegation markers,
+     * lowered against the scan schema. Skips a HAVING/qualify (a filter above an aggregate or window),
+     * whose predicate references aggregate/window output absent from the scan. Mirrors the Rust-side
+     * {@code extract_filter_expr}. Returns {@code null} if there's no such filter.
+     */
+    public static OpenSearchFilter findScanAdjacentFilter(RelNode node) {
+        RelNode current = node;
+        while (current != null) {
+            if (current instanceof OpenSearchFilter filter && !hasAggregateBelow(filter.getInput())) {
+                return filter;
+            }
+            if (current.getInputs().isEmpty()) {
+                return null;
+            }
+            current = current.getInputs().getFirst();
+        }
+        return null;
+    }
+
+    /**
+     * Whether an {@link OpenSearchAggregate} or a window-bearing {@link OpenSearchProject}
+     * ({@code RexOver}) sits below {@code node}, reached through row-preserving Projects/Sorts.
+     * Such producers add columns absent from the scan schema, marking a Filter above them as
+     * a HAVING/qualify rather than a scan-adjacent WHERE.
+     */
+    private static boolean hasAggregateBelow(RelNode node) {
+        RelNode current = unwrapHep(node);
+        while (current != null) {
+            if (current instanceof OpenSearchAggregate) {
+                return true;
+            } else if (current instanceof OpenSearchProject project) {
+                if (project.containsOver()) {
+                    return true;
+                }
+            } else if (!(current instanceof OpenSearchSort)) {
+                return false;
+            }
+            if (current.getInputs().isEmpty()) {
+                return false;
+            }
+            current = unwrapHep(current.getInputs().getFirst());
+        }
+        return false;
+    }
+
+    /**
      * Qualified name of the first {@link OpenSearchTableScan} reachable from {@code node},
      * searching all inputs. Returns {@code null} if none is present.
      */

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/dag/FragmentConversionDriver.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/dag/FragmentConversionDriver.java
@@ -118,7 +118,9 @@ public class FragmentConversionDriver {
             // Derive filter tree shape BEFORE stripping (annotations must be intact). Mirrors
             // fuseDualViable so the deriver's classification matches the post-combiner tree
             // the data node actually sees.
-            OpenSearchFilter filter = RelNodeUtils.findNode(plan.resolvedFragment(), OpenSearchFilter.class);
+            // Scan-adjacent WHERE, not a HAVING above an aggregate — picking the HAVING would derive
+            // NO_DELEGATION and drop the WHERE's delegated filter at the data node.
+            OpenSearchFilter filter = RelNodeUtils.findScanAdjacentFilter(plan.resolvedFragment());
             FilterTreeShape treeShape = filter != null
                 ? FilterTreeShapeDeriver.derive(filter, plan.backendId(), fuseDualViable)
                 : FilterTreeShape.NO_DELEGATION;

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/dag/FragmentConversionDriverTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/dag/FragmentConversionDriverTests.java
@@ -20,6 +20,7 @@ import org.apache.calcite.rel.logical.LogicalJoin;
 import org.apache.calcite.rel.logical.LogicalProject;
 import org.apache.calcite.rel.logical.LogicalSort;
 import org.apache.calcite.rel.logical.LogicalUnion;
+import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlFunction;
@@ -568,6 +569,47 @@ public class FragmentConversionDriverTests extends BasePlannerRulesTests {
     }
 
     /**
+     * Builds {@code Filter(count(*) > 5) <- Aggregate(group=message, count) <- Filter(WHERE) <- Scan}
+     * — the single-shard HAVING-over-stats shape. The WHERE delegates to Lucene; the HAVING is a
+     * native predicate on the aggregate output.
+     */
+    private QueryDAG buildHavingOverDelegatedScanDag(
+        RexNode whereCondition,
+        RecordingConvertor dfConvertor,
+        RecordingSerializer serializer
+    ) {
+        var backends = delegationBackends(dfConvertor, serializer);
+        // Single shard: the whole plan (WHERE → Aggregate → HAVING) stays in one data-node fragment,
+        // so the HAVING sits directly above the WHERE's aggregate (it isn't split off to a coordinator).
+        var context = buildContext("parquet", 1, Map.of("message", Map.of("type", "keyword", "index", true)), backends);
+        RelNode scan = stubScan(mockTable("test_index", new String[] { "message" }, new SqlTypeName[] { SqlTypeName.VARCHAR }));
+        LogicalFilter where = LogicalFilter.create(scan, whereCondition);
+        AggregateCall count = AggregateCall.create(
+            SqlStdOperatorTable.COUNT,
+            false,
+            List.of(),
+            -1,
+            where,
+            typeFactory.createSqlType(SqlTypeName.BIGINT),
+            "cnt"
+        );
+        LogicalAggregate aggregate = LogicalAggregate.create(where, List.of(), ImmutableBitSet.of(0), null, List.of(count));
+        // HAVING on the count output (field 1) — references the aggregate result, can't push below the agg.
+        RelDataType bigintType = typeFactory.createSqlType(SqlTypeName.BIGINT);
+        RexNode havingCond = rexBuilder.makeCall(
+            SqlStdOperatorTable.GREATER_THAN,
+            rexBuilder.makeInputRef(bigintType, 1),
+            rexBuilder.makeLiteral(5L, bigintType, true)
+        );
+        LogicalFilter having = LogicalFilter.create(aggregate, havingCond);
+        RelNode cboOutput = runPlanner(having, context);
+        QueryDAG dag = DAGBuilder.build(cboOutput, context.getCapabilityRegistry(), mockClusterService(), TEST_RESOLVER);
+        PlanForker.forkAll(dag, context.getCapabilityRegistry());
+        FragmentConversionDriver.convertAll(dag, context.getCapabilityRegistry(), false);
+        return dag;
+    }
+
+    /**
      * Three-field delegation helper:
      *   - field 0 = status   (integer, indexed). NOTE: prod Lucene only filters keyword/text/
      *     match_only_text; {@link MockLuceneBackend} declares EQUALS over numerics for test
@@ -711,6 +753,23 @@ public class FragmentConversionDriverTests extends BasePlannerRulesTests {
         QueryDAG dag = buildSingleFieldDelegationDag(makeFullTextCall(MATCH_PHRASE_FUNCTION, 0, "hello world"), dfConvertor, serializer);
         StagePlan plan = leafStage(dag).getPlanAlternatives().getFirst();
         assertDelegationResult(plan, dfConvertor, serializer, 1, true, false, List.of("MATCH_PHRASE"), FilterTreeShape.CONJUNCTIVE);
+    }
+
+    /**
+     * Regression: HAVING over an Aggregate must not mask the scan-adjacent WHERE's delegation.
+     * Single-shard `... | where match_phrase(...) | stats count() by k | where count() > N`
+     * produces {@code Filter(HAVING) <- Aggregate <- Filter(WHERE) <- Scan}. The treeShape
+     * deriver must classify from the scan-adjacent WHERE (CONJUNCTIVE — it delegates to Lucene),
+     * not the topmost HAVING (which has no delegated predicates → NO_DELEGATION). A wrong
+     * NO_DELEGATION drops the delegated Collector at the data node, silently under-filtering.
+     */
+    public void testHavingOverAggregateDoesNotMaskWhereDelegation() {
+        RecordingConvertor dfConvertor = new RecordingConvertor();
+        RecordingSerializer serializer = new RecordingSerializer();
+        QueryDAG dag = buildHavingOverDelegatedScanDag(makeFullTextCall(MATCH_PHRASE_FUNCTION, 0, "hello world"), dfConvertor, serializer);
+        StagePlan plan = leafStage(dag).getPlanAlternatives().getFirst();
+        assertEquals("WHERE delegation must survive a HAVING above the aggregate", 1, plan.delegatedExpressions().size());
+        assertEquals("treeShape must come from the scan-adjacent WHERE, not the HAVING", FilterTreeShape.CONJUNCTIVE, treeShapeOf(plan));
     }
 
     /** Single native equals on a non-indexed field — single-viable to DataFusion, no delegation. */

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/FulltextWindowPplIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/FulltextWindowPplIT.java
@@ -26,6 +26,6 @@ public class FulltextWindowPplIT extends BasePplIT {
     /** Queries that fail at 1 shard: fulltext + window combinations unsupported. Skipped so the rest run and are visible. */
     @Override
     protected java.util.Set<Integer> getSkipQueries() {
-        return java.util.Set.of(1, 6, 8, 12, 13, 14, 15, 17, 19);
+        return java.util.Set.of(1, 6, 8, 12, 13, 14, 17);
     }
 }

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/MultiSourceJoinsPplIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/MultiSourceJoinsPplIT.java
@@ -26,6 +26,6 @@ public class MultiSourceJoinsPplIT extends BasePplIT {
     /** Queries that fail at 1 shard: multi-source join unsupported. Skipped so the rest run and are visible. */
     @Override
     protected java.util.Set<Integer> getSkipQueries() {
-        return java.util.Set.of(2, 4);
+        return java.util.Set.of(2);
     }
 }

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/SecurityLogsPplIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/SecurityLogsPplIT.java
@@ -26,6 +26,6 @@ public class SecurityLogsPplIT extends BasePplIT {
     /** Queries that fail at 1 shard: unsupported operations / value mismatch. Skipped so the rest run and are visible. */
     @Override
     protected java.util.Set<Integer> getSkipQueries() {
-        return java.util.Set.of(1, 2, 3, 4, 5, 7, 8);
+        return java.util.Set.of(2, 8);
     }
 }

--- a/sandbox/qa/analytics-engine-rest/src/test/resources/datasets/complex_joins/mapping_event_processor.json
+++ b/sandbox/qa/analytics-engine-rest/src/test/resources/datasets/complex_joins/mapping_event_processor.json
@@ -1,1 +1,1 @@
-{"mappings":{"properties":{"processor_type":{"type":"keyword"},"filter_in_count":{"type":"long"},"cluster_name":{"type":"keyword"}}}}
+{"settings":{"number_of_shards":1,"number_of_replicas":0},"mappings":{"properties":{"processor_type":{"type":"keyword"},"filter_in_count":{"type":"long"},"cluster_name":{"type":"keyword"}}}}

--- a/sandbox/qa/analytics-engine-rest/src/test/resources/datasets/complex_joins/mapping_tax_withholding.json
+++ b/sandbox/qa/analytics-engine-rest/src/test/resources/datasets/complex_joins/mapping_tax_withholding.json
@@ -1,1 +1,1 @@
-{"mappings":{"properties":{"log_level":{"type":"keyword"},"part_mid":{"type":"keyword"},"realm":{"type":"keyword"}}}}
+{"settings":{"number_of_shards":1,"number_of_replicas":0},"mappings":{"properties":{"log_level":{"type":"keyword"},"part_mid":{"type":"keyword"},"realm":{"type":"keyword"}}}}

--- a/sandbox/qa/analytics-engine-rest/src/test/resources/datasets/lookup_join_queries/mapping_sales_data.json
+++ b/sandbox/qa/analytics-engine-rest/src/test/resources/datasets/lookup_join_queries/mapping_sales_data.json
@@ -1,4 +1,8 @@
 {
+  "settings": {
+    "number_of_shards": 1,
+    "number_of_replicas": 0
+  },
   "mappings": {
     "properties": {
       "timestamp": {"type": "date"},

--- a/sandbox/qa/analytics-engine-rest/src/test/resources/datasets/lookup_join_queries/mapping_user_lookup.json
+++ b/sandbox/qa/analytics-engine-rest/src/test/resources/datasets/lookup_join_queries/mapping_user_lookup.json
@@ -1,1 +1,1 @@
-{"mappings":{"properties":{"user":{"type":"keyword"},"full_name":{"type":"text"},"manager":{"type":"keyword"},"department":{"type":"keyword"}}}}
+{"settings":{"number_of_shards":1,"number_of_replicas":0},"mappings":{"properties":{"user":{"type":"keyword"},"full_name":{"type":"text"},"manager":{"type":"keyword"},"department":{"type":"keyword"}}}}


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
For `... | stats count() as c by x | where c > 5`, the scan was handed the HAVING filter (on the count result) instead of the WHERE. The scan has no "count" column, so it 500'd with "No field named count(...)"; working around that, the WHERE got dropped and queries returned too many rows. Same bug hit `streamstats ... | where rn <= N`.

The filter picker (Rust + Java) now skips filters above an aggregate or window and uses the WHERE beneath; the HAVING still runs after the aggregate.

Also add missing settings blocks to a few test mappings (parquet config was being silently skipped) and unmute the PPL tests these fixes pass.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
