### PR TITLE
[analytics-engine] Decorrelate correlated EXISTS subqueries by stripping the existence-irrelevant subsearch limit

### DIFF
--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/PlannerImpl.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/PlannerImpl.java
@@ -15,12 +15,19 @@ import org.apache.calcite.plan.RelOptUtil;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.plan.volcano.AbstractConverter;
 import org.apache.calcite.plan.volcano.VolcanoPlanner;
+import org.apache.calcite.rel.RelHomogeneousShuttle;
 import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.RelShuttle;
 import org.apache.calcite.rel.core.Filter;
 import org.apache.calcite.rel.core.Project;
+import org.apache.calcite.rel.core.Sort;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rel.rules.CoreRules;
 import org.apache.calcite.rel.rules.ReduceExpressionsRule;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexShuttle;
+import org.apache.calcite.rex.RexSubQuery;
+import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql2rel.RelDecorrelator;
 import org.apache.calcite.tools.RelBuilder;
 import org.apache.logging.log4j.LogManager;
@@ -140,6 +147,14 @@ public class PlannerImpl {
      * emission. Runs first so every later phase observes a subquery-free tree.
      */
     private static RelNode removeSubQueries(RelNode input, RuleProfilingListener listener) {
+        // The PPL frontend injects a SUBSEARCH_MAXOUT Sort(fetch=N) at the top of every subsearch.
+        // Inside an EXISTS that limit is semantically irrelevant (existence needs only one row), but
+        // it becomes a correlated Sort(fetch>1) after FILTER_SUB_QUERY_TO_CORRELATE, which
+        // RelDecorrelator refuses to decorrelate (it only handles fetch==1) — leaving a
+        // LogicalCorrelate that the marking phase rejects with "unmarked child [LogicalCorrelate]".
+        // Strip that limit while the subquery is still an identifiable EXISTS RexSubQuery so the
+        // decorrelation below can fold it into a standard join.
+        RelNode prepared = stripExistsSubqueryLimits(input);
         return HepPhase.named("subquery-remove")
             .addRuleCollection(
                 List.of(
@@ -155,10 +170,59 @@ public class PlannerImpl {
             .postProcess(
                 withCorrelates -> RelDecorrelator.decorrelateQuery(
                     withCorrelates,
-                    RelBuilder.proto(Contexts.empty()).create(input.getCluster(), null)
+                    RelBuilder.proto(Contexts.empty()).create(prepared.getCluster(), null)
                 )
             )
-            .run(input, listener);
+            .run(prepared, listener);
+    }
+
+    /**
+     * Removes a top-level fetch-only {@link Sort} (no collation, no offset) from the body of every
+     * {@code EXISTS} {@link RexSubQuery} in the tree. The PPL frontend injects a SUBSEARCH_MAXOUT
+     * {@code Sort(fetch=N)} at the top of each subsearch; for an EXISTS that limit cannot change the
+     * boolean result (it only tests for ≥1 row), yet it blocks {@link RelDecorrelator} from
+     * decorrelating the correlated subquery. Scoped to EXISTS only — IN / scalar subqueries keep
+     * their limit, where it is semantically meaningful.
+     */
+    private static RelNode stripExistsSubqueryLimits(RelNode input) {
+        RexShuttle rexShuttle = new RexShuttle() {
+            @Override
+            public RexNode visitSubQuery(RexSubQuery subQuery) {
+                RexSubQuery rewritten = (RexSubQuery) super.visitSubQuery(subQuery);
+                if (rewritten.getOperator().getKind() == SqlKind.EXISTS) {
+                    RelNode body = stripExistsSubqueryLimits(rewritten.rel);
+                    RelNode unlimited = stripTopFetchOnlySort(body);
+                    if (unlimited != rewritten.rel) {
+                        return rewritten.clone(unlimited);
+                    }
+                    if (body != rewritten.rel) {
+                        return rewritten.clone(body);
+                    }
+                }
+                return rewritten;
+            }
+        };
+        RelShuttle relShuttle = new RelHomogeneousShuttle() {
+            @Override
+            public RelNode visit(RelNode node) {
+                RelNode visited = super.visit(node);
+                return visited.accept(rexShuttle);
+            }
+        };
+        return input.accept(relShuttle);
+    }
+
+    /**
+     * If {@code node} is a {@link Sort} that only limits row count (a {@code fetch} with no sort
+     * keys and no {@code offset}), returns its input; otherwise returns {@code node} unchanged. A
+     * sort with collation or an offset is preserved — dropping either could change which rows the
+     * EXISTS sees relative to a correlated predicate.
+     */
+    private static RelNode stripTopFetchOnlySort(RelNode node) {
+        if (node instanceof Sort sort && sort.getCollation().getFieldCollations().isEmpty() && sort.offset == null && sort.fetch != null) {
+            return sort.getInput();
+        }
+        return node;
     }
 
     /**

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/SubQueryPlanShapeTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/SubQueryPlanShapeTests.java
@@ -65,6 +65,34 @@ public class SubQueryPlanShapeTests extends PlanShapeTestBase {
         );
     }
 
+    /**
+     * Correlated EXISTS whose subquery carries a {@code LIMIT N} (N &gt; 1) — the shape the PPL
+     * frontend produces by injecting a {@code SUBSEARCH_MAXOUT} {@code Sort} inside the subsearch.
+     * {@link org.apache.calcite.sql2rel.RelDecorrelator} bails on a correlated {@code Sort(fetch &gt;
+     * 1)}, leaving a {@code LogicalCorrelate} that marking rejects. {@code stripExistsSubqueryLimits}
+     * removes the existence-irrelevant limit so the EXISTS still fully decorrelates.
+     */
+    public void testCorrelatedExistsWithSubqueryLimitIsLowered() {
+        ClusterState parserState = SqlPlannerTestFixture.clusterStateWith("test_index", intFields());
+        RelNode parsed = SqlPlannerTestFixture.parseSql(
+            "SELECT * FROM test_index t WHERE EXISTS" + " (SELECT 1 FROM test_index s WHERE s.status = t.status LIMIT 10)",
+            parserState
+        );
+        assertContainsSubQuery("Pre-condition: parsed plan must carry the EXISTS RexSubQuery", parsed);
+
+        RelNode result = runPlanner(parsed, singleShardContext());
+
+        assertNoSubQuery(
+            "correlated EXISTS with a subquery LIMIT must still fully lower (no leftover" + " RexSubQuery / LogicalCorrelate).",
+            result
+        );
+        assertNoCorrelate(
+            "RelDecorrelator cannot decorrelate a correlated Sort(fetch>1); the EXISTS subsearch"
+                + " limit must be stripped so no LogicalCorrelate survives into marking.",
+            result
+        );
+    }
+
     /** Uncorrelated IN-list: lowered through {@code FILTER_SUB_QUERY_TO_CORRELATE} too. */
     public void testInSubqueryIsLowered() {
         ClusterState parserState = SqlPlannerTestFixture.clusterStateWith("test_index", intFields());
@@ -93,6 +121,24 @@ public class SubQueryPlanShapeTests extends PlanShapeTestBase {
 
     private static void assertNoSubQuery(String message, RelNode plan) {
         if (findSubQuery(plan)) {
+            throw new AssertionError(message + "\nPost-optimize plan:\n" + RelOptUtil.toString(plan));
+        }
+    }
+
+    private static void assertNoCorrelate(String message, RelNode plan) {
+        boolean[] found = { false };
+        RelShuttle walker = new RelHomogeneousShuttle() {
+            @Override
+            public RelNode visit(RelNode node) {
+                if (node instanceof org.apache.calcite.rel.core.Correlate) {
+                    found[0] = true;
+                    return node;
+                }
+                return super.visit(node);
+            }
+        };
+        plan.accept(walker);
+        if (found[0]) {
             throw new AssertionError(message + "\nPost-optimize plan:\n" + RelOptUtil.toString(plan));
         }
     }

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/WhereCommandIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/WhereCommandIT.java
@@ -268,6 +268,28 @@ public class WhereCommandIT extends AnalyticsRestTestCase {
         );
     }
 
+    // A correlated EXISTS subsearch. The PPL frontend injects a SUBSEARCH_MAXOUT Sort(fetch=N) at
+    // the top of the subsearch; that correlated Sort(fetch>1) blocks RelDecorrelator, leaving a
+    // LogicalCorrelate that marking rejects ("unmarked child [LogicalCorrelate]"). The planner now
+    // strips the (existence-irrelevant) limit so the EXISTS decorrelates to a join. Two calcs rows
+    // have an int1 that equals some row's int0.
+    public void testCorrelatedExistsSubsearch() throws IOException {
+        assertRowCount(
+            "source=" + DATASET.indexName + " as o | where exists [ source=" + DATASET.indexName
+                + " as i | where i.int0 = o.int1 ] | fields int1",
+            2
+        );
+    }
+
+    // Complement of the EXISTS case: NOT EXISTS keeps the remaining 15 of 17 rows.
+    public void testCorrelatedNotExistsSubsearch() throws IOException {
+        assertRowCount(
+            "source=" + DATASET.indexName + " as o | where not exists [ source=" + DATASET.indexName
+                + " as i | where i.int0 = o.int1 ] | fields int1",
+            15
+        );
+    }
+
     // ── Helpers ─────────────────────────────────────────────────────────────
 
     private static List<Object> row(Object... values) {


### PR DESCRIPTION
### Description
A PPL query with a correlated `EXISTS` subsearch (e.g. `source=a | where exists [ source=b | where b.k = a.k ]`) hangs and times out (60s) on the analytics-engine DataFusion path.

**Root cause.** The PPL frontend injects a `SUBSEARCH_MAXOUT` `Sort(fetch=N)` at the top of every subsearch. Inside EXISTS, after `FILTER_SUB_QUERY_TO_CORRELATE` this is a correlated `Sort(fetch>1)`, which `RelDecorrelator` cannot decorrelate (it only handles fetch==1). The leftover `LogicalCorrelate` reaches the marking phase, which has no Correlate rule and throws `IllegalStateException`: ... unmarked child [LogicalCorrelate]. The external PPL frontend relays this as a client-side timeout rather than an error. Plain SQL EXISTS (no subsearch limit) was unaffected, which is why existing tests passed.

**Fix.** Add `PlannerImpl.stripExistsSubqueryLimits()`, run before the `*_SUB_QUERY_TO_CORRELATE` rules. It walks the tree and, for each `EXISTS` `RexSubQuery`, removes a top-level fetch-only Sort (no collation, no offset) from the subquery body. A row limit cannot change an existence test, so this is semantically safe; it is scoped to EXISTS only — IN/scalar subqueries keep their limit, where it is meaningful. With the limit gone, the correlated subquery decorrelates to a standard join as intended.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
