### PR TITLE
Mute flaky IndicesRequestCacheIT

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/indices/IndicesRequestCacheIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/IndicesRequestCacheIT.java
@@ -715,6 +715,7 @@ public class IndicesRequestCacheIT extends ParameterizedStaticSettingsOpenSearch
         }
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/14288")
     public void testDeleteAndCreateSameIndexShardOnSameNode() throws Exception {
         String node_1 = internalCluster().startNode(Settings.builder().build());
         Client client = client(node_1);


### PR DESCRIPTION
FYI @sgup432 

This is long-standing flaky test and one of the top remaining offenders. It fails with a 20 minute and I haven't found an obvious fix. Muting it for now.

Example failures in the past week:

- https://build.ci.opensearch.org/job/gradle-check/78838/testReport/
- https://build.ci.opensearch.org/job/gradle-check/79280/testReport/
- https://build.ci.opensearch.org/job/gradle-check/79489/testReport/
- https://build.ci.opensearch.org/job/gradle-check/79531/testReport/

### Related Issues
Related to #14288

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
