### PR TITLE
[Backport 2.19] Prevent negative fielddata stats by guarding against stale removals after shard reallocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Harden the circuit breaker and failure handle logic in query result consumer ([#19396](https://github.com/opensearch-project/OpenSearch/pull/19396))
 - Fix case insensitive and escaped query on wildcard ([#16827](https://github.com/opensearch-project/OpenSearch/pull/16827))
 - Fix array_index_out_of_bounds_exception with wildcard and aggregations ([#20842](https://github.com/opensearch-project/OpenSearch/pull/20842))
+- Prevent negative fielddata stats by guarding against stale removals after shard reallocation ([#21667](https://github.com/opensearch-project/OpenSearch/pull/21667))
 
 ### Security
 

--- a/server/src/internalClusterTest/java/org/opensearch/index/fielddata/FieldDataStatsNegativeIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/index/fielddata/FieldDataStatsNegativeIT.java
@@ -1,0 +1,129 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.fielddata;
+
+import org.opensearch.action.admin.cluster.node.stats.NodesStatsResponse;
+import org.opensearch.action.admin.indices.stats.IndicesStatsResponse;
+import org.opensearch.action.admin.indices.stats.ShardStats;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.index.query.MatchAllQueryBuilder;
+import org.opensearch.indices.IndicesService;
+import org.opensearch.search.sort.SortOrder;
+import org.opensearch.test.OpenSearchIntegTestCase;
+
+import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+
+/**
+ * Verifies fielddata byte counters do not go negative when a shard is relocated
+ * off and back to the same node while a sibling shard keeps the IndexService
+ * alive. Without the PR #21667 fix, stale CacheCleaner removals are routed by
+ * shardId to the current shard, decrementing a counter on bytes it never cached.
+ *
+ * Two timing levers:
+ * 1. Restore the production default cleanup interval (1m, vs the 1s set by
+ *    OpenSearchIntegTestCase) so the periodic cleaner cannot fire during the
+ *    relocation round-trips and prematurely drain stale entries.
+ * 2. After the round-trips are complete, drive cleanup synchronously via
+ *    IndicesFieldDataCache.clear() instead of waiting on the periodic timer.
+ *    Avoids Thread.sleep and runs deterministically.
+ */
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 0)
+public class FieldDataStatsNegativeIT extends OpenSearchIntegTestCase {
+
+    private static final String INDEX = "test_fd_stats";
+    private static final String FIELD = "name";
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return Settings.builder()
+            .put(super.nodeSettings(nodeOrdinal))
+            .put(IndicesService.INDICES_CACHE_CLEAN_INTERVAL_SETTING.getKey(), "1m")
+            .build();
+    }
+
+    public void testReproduceNegativeFieldDataStats() throws Exception {
+        final String node1 = internalCluster().startNode();
+        final String node2 = internalCluster().startNode();
+        ensureStableCluster(2);
+
+        assertAcked(
+            prepareCreate(INDEX).setSettings(
+                Settings.builder()
+                    .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 2)
+                    .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+                    .put("index.routing.allocation.include._name", node1)
+            ).setMapping(FIELD, "type=text,fielddata=true")
+        );
+        ensureGreen(INDEX);
+
+        // Multi-segment data: single-segment loadGlobal bypasses the cache.
+        for (int batch = 0; batch < 3; batch++) {
+            for (int i = 0; i < 5; i++) {
+                client().prepareIndex(INDEX).setSource(FIELD, "b" + batch + "_d" + i).get();
+            }
+            client().admin().indices().prepareRefresh(INDEX).get();
+            client().admin().indices().prepareFlush(INDEX).get();
+        }
+        populateCache();
+
+        assertThat("expected fielddata to be cached", getFieldDataBytes(), greaterThan(0L));
+
+        // 3 round-trips of shard 1. Shard 0 anchors the IndexService on node1.
+        for (int trip = 0; trip < 3; trip++) {
+            updateAllocationFilter(node1 + "," + node2);
+            ensureGreen(INDEX);
+            updateAllocationFilter(node1);
+            ensureGreen(INDEX);
+            populateCache();
+        }
+
+        // Drive cleanup synchronously instead of waiting for the periodic CacheCleaner.
+        // Equivalent to one cleaner tick: refresh() iterates the cache, fires onRemoval for
+        // entries whose readers have been closed — which is where the misrouted-decrement bug
+        // surfaces.
+        internalCluster().getInstance(IndicesService.class, node1).getIndicesFieldDataCache().getCache().refresh();
+
+        // Assert non-negative bytes at every layer.
+        // 1) Per-shard counter (ShardFieldData.totalMetric).
+        IndicesStatsResponse indicesStats = client().admin().indices().prepareStats(INDEX).clear().setFieldData(true).get();
+        for (ShardStats shardStats : indicesStats.getShards()) {
+            long bytes = shardStats.getStats().getFieldData().getMemorySizeInBytes();
+            assertThat("shard " + shardStats.getShardRouting().shardId() + " bytes: " + bytes, bytes, greaterThanOrEqualTo(0L));
+        }
+
+        // 2) Node-level stats: serialization throws on negative bytes, surfacing
+        // as a per-node failure even when one shard's counter happens to net positive.
+        NodesStatsResponse nodesStats = client().admin().cluster().prepareNodesStats().clear().setIndices(true).get();
+        assertThat("node stats had failures", nodesStats.failures().size(), org.hamcrest.Matchers.equalTo(0));
+        for (var node : nodesStats.getNodes()) {
+            long bytes = node.getIndices().getFieldData().getMemorySizeInBytes();
+            assertThat("node " + node.getNode().getName() + " bytes: " + bytes, bytes, greaterThanOrEqualTo(0L));
+        }
+    }
+
+    private void populateCache() {
+        client().prepareSearch(INDEX).setQuery(new MatchAllQueryBuilder()).addSort(FIELD, SortOrder.ASC).setSize(20).get();
+    }
+
+    private void updateAllocationFilter(String includeNames) {
+        client().admin()
+            .indices()
+            .prepareUpdateSettings(INDEX)
+            .setSettings(Settings.builder().put("index.routing.allocation.include._name", includeNames))
+            .get();
+    }
+
+    private long getFieldDataBytes() {
+        IndicesStatsResponse stats = client().admin().indices().prepareStats(INDEX).clear().setFieldData(true).get();
+        return stats.getTotal().getFieldData().getMemorySizeInBytes();
+    }
+}

--- a/server/src/internalClusterTest/java/org/opensearch/index/fielddata/FieldDataStatsNegativeIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/index/fielddata/FieldDataStatsNegativeIT.java
@@ -86,11 +86,10 @@ public class FieldDataStatsNegativeIT extends OpenSearchIntegTestCase {
             populateCache();
         }
 
-        // Drive cleanup synchronously instead of waiting for the periodic CacheCleaner.
-        // Equivalent to one cleaner tick: refresh() iterates the cache, fires onRemoval for
-        // entries whose readers have been closed — which is where the misrouted-decrement bug
-        // surfaces.
-        internalCluster().getInstance(IndicesService.class, node1).getIndicesFieldDataCache().getCache().refresh();
+        // On 2.19, IndexFieldCache.onClose calls cache.invalidate() synchronously when each
+        // shard's Lucene readers close. The misrouted onRemoval (and the resulting negative
+        // counter) therefore fires during the relocation round-trips above — no separate
+        // CacheCleaner tick is required to surface the bug.
 
         // Assert non-negative bytes at every layer.
         // 1) Per-shard counter (ShardFieldData.totalMetric).

--- a/server/src/main/java/org/opensearch/index/IndexService.java
+++ b/server/src/main/java/org/opensearch/index/IndexService.java
@@ -274,6 +274,10 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
                 this.indexSortSupplier = () -> null;
             }
             indexFieldData.setListener(new FieldDataCacheListener(this));
+            indexFieldData.setShardIdentityResolver(shardId -> {
+                final IndexShard shard = getShardOrNull(shardId.id());
+                return shard == null ? IndicesFieldDataCache.Key.NO_SHARD_IDENTITY : System.identityHashCode(shard);
+            });
             this.bitsetFilterCache = new BitsetFilterCache(indexSettings, new BitsetCacheListener(this));
             this.warmer = new IndexWarmer(threadPool, indexFieldData, bitsetFilterCache.createListener(threadPool));
             this.indexCache = new IndexCache(indexSettings, queryCache, bitsetFilterCache);

--- a/server/src/main/java/org/opensearch/index/fielddata/IndexFieldDataService.java
+++ b/server/src/main/java/org/opensearch/index/fielddata/IndexFieldDataService.java
@@ -43,6 +43,7 @@ import org.opensearch.index.IndexSettings;
 import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.indices.fielddata.cache.IndicesFieldDataCache;
+import org.opensearch.indices.fielddata.cache.IndicesFieldDataCache.Key;
 import org.opensearch.search.lookup.SearchLookup;
 
 import java.io.Closeable;
@@ -53,6 +54,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
+import java.util.function.ToIntFunction;
 
 /**
  * Service for field data (cacheing, etc)
@@ -91,6 +93,7 @@ public class IndexFieldDataService extends AbstractIndexComponent implements Clo
         public void onRemoval(ShardId shardId, String fieldName, boolean wasEvicted, long sizeInBytes) {}
     };
     private volatile IndexFieldDataCache.Listener listener = DEFAULT_NOOP_LISTENER;
+    private volatile ToIntFunction<ShardId> shardIdentityResolver = shardId -> Key.NO_SHARD_IDENTITY;
 
     public IndexFieldDataService(
         IndexSettings indexSettings,
@@ -150,7 +153,7 @@ public class IndexFieldDataService extends AbstractIndexComponent implements Clo
             if (cache == null) {
                 String cacheType = indexSettings.getValue(INDEX_FIELDDATA_CACHE_KEY);
                 if (FIELDDATA_CACHE_VALUE_NODE.equals(cacheType)) {
-                    cache = indicesFieldDataCache.buildIndexFieldDataCache(listener, index(), fieldName);
+                    cache = indicesFieldDataCache.buildIndexFieldDataCache(listener, index(), fieldName, shardIdentityResolver);
                 } else if ("none".equals(cacheType)) {
                     cache = new IndexFieldDataCache.None();
                 } else {
@@ -177,6 +180,18 @@ public class IndexFieldDataService extends AbstractIndexComponent implements Clo
             throw new IllegalStateException("can't set listener more than once");
         }
         this.listener = listener;
+    }
+
+    /**
+     * Sets the resolver that returns the current shard's {@code System.identityHashCode}
+     * (or 0 if none) for a given {@link ShardId}. Captured at cache-load time and used to
+     * skip stale decrements after shard reallocation.
+     */
+    public void setShardIdentityResolver(ToIntFunction<ShardId> shardIdentityResolver) {
+        if (shardIdentityResolver == null) {
+            throw new IllegalArgumentException("shardIdentityResolver must not be null");
+        }
+        this.shardIdentityResolver = shardIdentityResolver;
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/indices/fielddata/cache/IndicesFieldDataCache.java
+++ b/server/src/main/java/org/opensearch/indices/fielddata/cache/IndicesFieldDataCache.java
@@ -63,6 +63,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.ToIntFunction;
 import java.util.function.ToLongBiFunction;
 
 /**
@@ -99,7 +100,23 @@ public class IndicesFieldDataCache implements RemovalListener<IndicesFieldDataCa
     }
 
     public IndexFieldDataCache buildIndexFieldDataCache(IndexFieldDataCache.Listener listener, Index index, String fieldName) {
-        return new IndexFieldCache(logger, cache, index, fieldName, indicesFieldDataCacheListener, listener);
+        return buildIndexFieldDataCache(listener, index, fieldName, shardId -> Key.NO_SHARD_IDENTITY);
+    }
+
+    /**
+     * Build a cache that captures shard identity at load time. {@code shardIdentityResolver}
+     * returns the current shard's {@code System.identityHashCode} (or 0 if none) for a given
+     * {@link ShardId}. The captured value is stored on the {@link Key} and compared with the
+     * current shard's identity at removal time to skip stale per-shard decrements after shard
+     * reallocation (#20363).
+     */
+    public IndexFieldDataCache buildIndexFieldDataCache(
+        IndexFieldDataCache.Listener listener,
+        Index index,
+        String fieldName,
+        ToIntFunction<ShardId> shardIdentityResolver
+    ) {
+        return new IndexFieldCache(logger, cache, index, fieldName, shardIdentityResolver, indicesFieldDataCacheListener, listener);
     }
 
     public Cache<Key, Accountable> getCache() {
@@ -109,19 +126,33 @@ public class IndicesFieldDataCache implements RemovalListener<IndicesFieldDataCa
     @Override
     public void onRemoval(RemovalNotification<Key, Accountable> notification) {
         Key key = notification.getKey();
-        assert key != null && key.listeners != null;
+        assert key != null;
         IndexFieldCache indexCache = key.indexCache;
         final Accountable value = notification.getValue();
-        for (IndexFieldDataCache.Listener listener : key.listeners) {
+        final boolean wasEvicted = notification.getRemovalReason() == RemovalReason.EVICTED;
+        final long sizeInBytes = value.ramBytesUsed();
+
+        // Node-level listener (e.g. circuit breaker) must always fire — its accounting is
+        // node-wide, independent of which shard the entry belonged to.
+        try {
+            indexCache.nodeListener.onRemoval(key.shardId, indexCache.fieldName, wasEvicted, sizeInBytes);
+        } catch (Exception e) {
+            logger.error("Failed to call node-level listener on field data cache unloading", e);
+        }
+
+        // Per-shard listeners are skipped if the shard that originally cached this entry has been
+        // replaced (e.g. after reallocation). Without this check, the replacement shard would be
+        // decremented for memory it never accounted for, pushing stats negative (#20363).
+        final int currentShardIdentity = key.shardId == null
+            ? Key.NO_SHARD_IDENTITY
+            : indexCache.shardIdentityResolver.applyAsInt(key.shardId);
+        if (key.shardIdentity != Key.NO_SHARD_IDENTITY && key.shardIdentity != currentShardIdentity) {
+            return;
+        }
+        for (IndexFieldDataCache.Listener listener : indexCache.perShardListeners) {
             try {
-                listener.onRemoval(
-                    key.shardId,
-                    indexCache.fieldName,
-                    notification.getRemovalReason() == RemovalReason.EVICTED,
-                    value.ramBytesUsed()
-                );
+                listener.onRemoval(key.shardId, indexCache.fieldName, wasEvicted, sizeInBytes);
             } catch (Exception e) {
-                // load anyway since listeners should not throw exceptions
                 logger.error("Failed to call listener on field data cache unloading", e);
             }
         }
@@ -150,14 +181,36 @@ public class IndicesFieldDataCache implements RemovalListener<IndicesFieldDataCa
         final Index index;
         final String fieldName;
         private final Cache<Key, Accountable> cache;
-        private final Listener[] listeners;
+        final ToIntFunction<ShardId> shardIdentityResolver;
+        /**
+         * Listener registered at node level (e.g. the field-data circuit breaker). Always fires
+         * on removal regardless of shard identity, since its accounting tracks node-wide bytes
+         * independent of which shard they were charged to.
+         */
+        final Listener nodeListener;
+        /**
+         * Per-shard listeners (e.g. {@link org.opensearch.index.fielddata.ShardFieldData}). Skipped
+         * at removal time when the entry's captured shard identity no longer matches the current
+         * shard's identity, to avoid stale decrements after shard reallocation.
+         */
+        private final Listener[] perShardListeners;
 
-        IndexFieldCache(Logger logger, final Cache<Key, Accountable> cache, Index index, String fieldName, Listener... listeners) {
+        IndexFieldCache(
+            Logger logger,
+            final Cache<Key, Accountable> cache,
+            Index index,
+            String fieldName,
+            ToIntFunction<ShardId> shardIdentityResolver,
+            Listener nodeListener,
+            Listener... perShardListeners
+        ) {
             this.logger = logger;
-            this.listeners = listeners;
+            this.nodeListener = nodeListener;
+            this.perShardListeners = perShardListeners;
             this.index = index;
             this.fieldName = fieldName;
             this.cache = cache;
+            this.shardIdentityResolver = shardIdentityResolver;
         }
 
         @Override
@@ -169,20 +222,15 @@ public class IndicesFieldDataCache implements RemovalListener<IndicesFieldDataCa
             if (cacheHelper == null) {
                 throw new IllegalArgumentException("Reader " + context.reader() + " does not support caching");
             }
-            final Key key = new Key(this, cacheHelper.getKey(), shardId);
+            final int shardIdentity = shardId == null ? Key.NO_SHARD_IDENTITY : shardIdentityResolver.applyAsInt(shardId);
+            final Key key = new Key(this, cacheHelper.getKey(), shardId, shardIdentity);
             // noinspection unchecked
             final Accountable accountable = cache.computeIfAbsent(key, k -> {
                 cacheHelper.addClosedListener(IndexFieldCache.this);
-                Collections.addAll(k.listeners, this.listeners);
+                k.listeners.add(nodeListener);
+                Collections.addAll(k.listeners, perShardListeners);
                 final LeafFieldData fieldData = indexFieldData.loadDirect(context);
-                for (Listener listener : k.listeners) {
-                    try {
-                        listener.onCache(shardId, fieldName, fieldData);
-                    } catch (Exception e) {
-                        // load anyway since listeners should not throw exceptions
-                        logger.error("Failed to call listener on atomic field data loading", e);
-                    }
-                }
+                notifyOnCache(shardId, fieldData);
                 return fieldData;
             });
             return (FD) accountable;
@@ -199,23 +247,33 @@ public class IndicesFieldDataCache implements RemovalListener<IndicesFieldDataCa
             if (cacheHelper == null) {
                 throw new IllegalArgumentException("Reader " + indexReader + " does not support caching");
             }
-            final Key key = new Key(this, cacheHelper.getKey(), shardId);
+            final int shardIdentity = shardId == null ? Key.NO_SHARD_IDENTITY : shardIdentityResolver.applyAsInt(shardId);
+            final Key key = new Key(this, cacheHelper.getKey(), shardId, shardIdentity);
             // noinspection unchecked
             final Accountable accountable = cache.computeIfAbsent(key, k -> {
                 OpenSearchDirectoryReader.addReaderCloseListener(indexReader, IndexFieldCache.this);
-                Collections.addAll(k.listeners, this.listeners);
+                k.listeners.add(nodeListener);
+                Collections.addAll(k.listeners, perShardListeners);
                 final Accountable ifd = (Accountable) indexFieldData.loadGlobalDirect(indexReader);
-                for (Listener listener : k.listeners) {
-                    try {
-                        listener.onCache(shardId, fieldName, ifd);
-                    } catch (Exception e) {
-                        // load anyway since listeners should not throw exceptions
-                        logger.error("Failed to call listener on global ordinals loading", e);
-                    }
-                }
+                notifyOnCache(shardId, ifd);
                 return ifd;
             });
             return (IFD) accountable;
+        }
+
+        private void notifyOnCache(ShardId shardId, Accountable accountable) {
+            try {
+                nodeListener.onCache(shardId, fieldName, accountable);
+            } catch (Exception e) {
+                logger.error("Failed to call node-level listener on field data loading", e);
+            }
+            for (Listener listener : perShardListeners) {
+                try {
+                    listener.onCache(shardId, fieldName, accountable);
+                } catch (Exception e) {
+                    logger.error("Failed to call listener on field data loading", e);
+                }
+            }
         }
 
         @Override
@@ -258,16 +316,37 @@ public class IndicesFieldDataCache implements RemovalListener<IndicesFieldDataCa
      */
     @PublicApi(since = "1.0.0")
     public static class Key {
+        /**
+         * Sentinel meaning "no shard identity captured" — either tracking is disabled, the entry
+         * predates identity capture, or the shard was unresolvable at load time. The staleness
+         * check in {@link IndicesFieldDataCache#onRemoval(RemovalNotification)} treats this value
+         * as "always allow per-shard listeners through". Chosen as -1 because
+         * {@link System#identityHashCode(Object)} can return any int including 0, so 0 is not
+         * safe to use as a sentinel.
+         */
+        public static final int NO_SHARD_IDENTITY = -1;
+
         public final IndexFieldCache indexCache;
         public final IndexReader.CacheKey readerKey;
         public final ShardId shardId;
+        /**
+         * Identity of the IndexShard that inserted this entry, or {@link #NO_SHARD_IDENTITY} if
+         * tracking is disabled. Used at removal time to skip stale decrements after shard
+         * reallocation (#20363). Not part of equals/hashCode.
+         */
+        public final int shardIdentity;
 
         public final List<IndexFieldDataCache.Listener> listeners = new ArrayList<>();
 
         Key(IndexFieldCache indexCache, IndexReader.CacheKey readerKey, @Nullable ShardId shardId) {
+            this(indexCache, readerKey, shardId, NO_SHARD_IDENTITY);
+        }
+
+        Key(IndexFieldCache indexCache, IndexReader.CacheKey readerKey, @Nullable ShardId shardId, int shardIdentity) {
             this.indexCache = indexCache;
             this.readerKey = readerKey;
             this.shardId = shardId;
+            this.shardIdentity = shardIdentity;
         }
 
         @Override

--- a/server/src/test/java/org/opensearch/index/fielddata/FieldDataCacheTests.java
+++ b/server/src/test/java/org/opensearch/index/fielddata/FieldDataCacheTests.java
@@ -42,17 +42,23 @@ import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.NoMergePolicy;
 import org.apache.lucene.store.Directory;
+import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.BytesRef;
 import org.opensearch.common.lucene.index.OpenSearchDirectoryReader;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.core.index.Index;
 import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.core.indices.breaker.NoneCircuitBreakerService;
 import org.opensearch.index.fielddata.plain.AbstractLeafOrdinalsFieldData;
 import org.opensearch.index.fielddata.plain.PagedBytesIndexFieldData;
 import org.opensearch.index.fielddata.plain.SortedSetOrdinalsIndexFieldData;
 import org.opensearch.index.mapper.TextFieldMapper;
+import org.opensearch.indices.fielddata.cache.IndicesFieldDataCache;
 import org.opensearch.search.aggregations.support.CoreValuesSourceType;
 import org.opensearch.test.FieldMaskingReader;
 import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.hamcrest.Matchers.equalTo;
 
@@ -116,6 +122,217 @@ public class FieldDataCacheTests extends OpenSearchTestCase {
             TextFieldMapper.Defaults.FIELDDATA_MAX_FREQUENCY,
             TextFieldMapper.Defaults.FIELDDATA_MIN_SEGMENT_SIZE
         );
+    }
+
+    // The cache captures shardIdentity at load time and skips the per-shard listener's onRemoval
+    // when the current resolved identity differs (i.e. shard has been reallocated). The node-level
+    // listener must still fire so node-wide accounting (e.g. circuit breaker) stays consistent.
+    public void testCacheSkipsStalePerShardRemovalAfterReallocation() throws Exception {
+        Directory dir = newDirectory();
+        IndexWriterConfig iwc = new IndexWriterConfig(null);
+        iwc.setMergePolicy(NoMergePolicy.INSTANCE);
+        IndexWriter iw = new IndexWriter(dir, iwc);
+        // Two segments so loadGlobal goes through the cache path (single-segment is short-circuited).
+        for (int i = 0; i < 2; i++) {
+            Document doc = new Document();
+            doc.add(new SortedSetDocValuesField("field1", new BytesRef("v" + i)));
+            iw.addDocument(doc);
+            iw.commit();
+        }
+        iw.close();
+        DirectoryReader ir = OpenSearchDirectoryReader.wrap(DirectoryReader.open(dir), new ShardId("idx", "_na_", 0));
+
+        AtomicInteger nodeOnCache = new AtomicInteger();
+        AtomicInteger nodeOnRemoval = new AtomicInteger();
+        IndexFieldDataCache.Listener nodeListener = new IndexFieldDataCache.Listener() {
+            @Override
+            public void onCache(ShardId shardId, String fieldName, Accountable ramUsage) {
+                nodeOnCache.incrementAndGet();
+            }
+
+            @Override
+            public void onRemoval(ShardId shardId, String fieldName, boolean wasEvicted, long sizeInBytes) {
+                nodeOnRemoval.incrementAndGet();
+            }
+        };
+
+        AtomicInteger perShardOnCache = new AtomicInteger();
+        AtomicInteger perShardOnRemoval = new AtomicInteger();
+        IndexFieldDataCache.Listener perShardListener = new IndexFieldDataCache.Listener() {
+            @Override
+            public void onCache(ShardId shardId, String fieldName, Accountable ramUsage) {
+                perShardOnCache.incrementAndGet();
+            }
+
+            @Override
+            public void onRemoval(ShardId shardId, String fieldName, boolean wasEvicted, long sizeInBytes) {
+                perShardOnRemoval.incrementAndGet();
+            }
+        };
+
+        IndicesFieldDataCache nodeCache = new IndicesFieldDataCache(Settings.EMPTY, nodeListener);
+        Index index = new Index("idx", "_na_");
+        AtomicInteger currentIdentity = new AtomicInteger(4242);
+        IndexFieldDataCache fieldCache = nodeCache.buildIndexFieldDataCache(
+            perShardListener,
+            index,
+            "field1",
+            shardId -> currentIdentity.get()
+        );
+
+        SortedSetOrdinalsIndexFieldData ifd = createSortedDV("field1", fieldCache);
+        ifd.loadGlobal(ir);
+        assertEquals(1, nodeOnCache.get());
+        assertEquals(1, perShardOnCache.get());
+
+        // Simulate shard reallocation: the resolver now returns a different identity. The cached
+        // entry's captured identity (4242) no longer matches → per-shard onRemoval is skipped,
+        // but the node-level onRemoval still fires.
+        currentIdentity.set(9999);
+        nodeCache.getCache().invalidateAll();
+
+        assertEquals(1, nodeOnRemoval.get());
+        assertEquals(0, perShardOnRemoval.get());
+
+        ir.close();
+        dir.close();
+        nodeCache.close();
+    }
+
+    // When the resolved identity matches the captured identity, the per-shard listener's onRemoval
+    // fires as normal.
+    public void testCacheFiresPerShardRemovalWhenIdentityUnchanged() throws Exception {
+        Directory dir = newDirectory();
+        IndexWriterConfig iwc = new IndexWriterConfig(null);
+        iwc.setMergePolicy(NoMergePolicy.INSTANCE);
+        IndexWriter iw = new IndexWriter(dir, iwc);
+        for (int i = 0; i < 2; i++) {
+            Document doc = new Document();
+            doc.add(new SortedSetDocValuesField("field1", new BytesRef("v" + i)));
+            iw.addDocument(doc);
+            iw.commit();
+        }
+        iw.close();
+        DirectoryReader ir = OpenSearchDirectoryReader.wrap(DirectoryReader.open(dir), new ShardId("idx", "_na_", 0));
+
+        AtomicInteger perShardOnRemoval = new AtomicInteger();
+        IndexFieldDataCache.Listener perShardListener = new IndexFieldDataCache.Listener() {
+            @Override
+            public void onRemoval(ShardId shardId, String fieldName, boolean wasEvicted, long sizeInBytes) {
+                perShardOnRemoval.incrementAndGet();
+            }
+        };
+
+        IndicesFieldDataCache nodeCache = new IndicesFieldDataCache(Settings.EMPTY, new IndexFieldDataCache.Listener() {
+        });
+        Index index = new Index("idx", "_na_");
+        IndexFieldDataCache fieldCache = nodeCache.buildIndexFieldDataCache(perShardListener, index, "field1", shardId -> 4242);
+
+        SortedSetOrdinalsIndexFieldData ifd = createSortedDV("field1", fieldCache);
+        ifd.loadGlobal(ir);
+        nodeCache.getCache().invalidateAll();
+
+        assertEquals(1, perShardOnRemoval.get());
+
+        ir.close();
+        dir.close();
+        nodeCache.close();
+    }
+
+    // When listeners throw from onCache/onRemoval, the cache must swallow and log so other
+    // listeners and the load itself proceed normally.
+    public void testListenerExceptionsAreSwallowedDuringCacheAndRemoval() throws Exception {
+        Directory dir = newDirectory();
+        IndexWriterConfig iwc = new IndexWriterConfig(null);
+        iwc.setMergePolicy(NoMergePolicy.INSTANCE);
+        IndexWriter iw = new IndexWriter(dir, iwc);
+        for (int i = 0; i < 2; i++) {
+            Document doc = new Document();
+            doc.add(new SortedSetDocValuesField("field1", new BytesRef("v" + i)));
+            iw.addDocument(doc);
+            iw.commit();
+        }
+        iw.close();
+        DirectoryReader ir = OpenSearchDirectoryReader.wrap(DirectoryReader.open(dir), new ShardId("idx", "_na_", 0));
+
+        IndexFieldDataCache.Listener throwingNode = new IndexFieldDataCache.Listener() {
+            @Override
+            public void onCache(ShardId shardId, String fieldName, Accountable ramUsage) {
+                throw new RuntimeException("boom-cache-node");
+            }
+
+            @Override
+            public void onRemoval(ShardId shardId, String fieldName, boolean wasEvicted, long sizeInBytes) {
+                throw new RuntimeException("boom-removal-node");
+            }
+        };
+        IndexFieldDataCache.Listener throwingPerShard = new IndexFieldDataCache.Listener() {
+            @Override
+            public void onCache(ShardId shardId, String fieldName, Accountable ramUsage) {
+                throw new RuntimeException("boom-cache-shard");
+            }
+
+            @Override
+            public void onRemoval(ShardId shardId, String fieldName, boolean wasEvicted, long sizeInBytes) {
+                throw new RuntimeException("boom-removal-shard");
+            }
+        };
+
+        IndicesFieldDataCache nodeCache = new IndicesFieldDataCache(Settings.EMPTY, throwingNode);
+        Index index = new Index("idx", "_na_");
+        IndexFieldDataCache fieldCache = nodeCache.buildIndexFieldDataCache(throwingPerShard, index, "field1", shardId -> 1);
+
+        SortedSetOrdinalsIndexFieldData ifd = createSortedDV("field1", fieldCache);
+        // load should succeed despite throwing onCache listeners
+        ifd.loadGlobal(ir);
+        // removal path should also tolerate throwing listeners
+        nodeCache.getCache().invalidateAll();
+
+        ir.close();
+        dir.close();
+        nodeCache.close();
+    }
+
+    // The 3-arg buildIndexFieldDataCache overload uses a default resolver that returns
+    // NO_SHARD_IDENTITY, which means the staleness check always allows per-shard listeners through.
+    public void testThreeArgBuildUsesNoShardIdentitySentinel() throws Exception {
+        Directory dir = newDirectory();
+        IndexWriterConfig iwc = new IndexWriterConfig(null);
+        iwc.setMergePolicy(NoMergePolicy.INSTANCE);
+        IndexWriter iw = new IndexWriter(dir, iwc);
+        for (int i = 0; i < 2; i++) {
+            Document doc = new Document();
+            doc.add(new SortedSetDocValuesField("field1", new BytesRef("v" + i)));
+            iw.addDocument(doc);
+            iw.commit();
+        }
+        iw.close();
+        DirectoryReader ir = OpenSearchDirectoryReader.wrap(DirectoryReader.open(dir), new ShardId("idx", "_na_", 0));
+
+        AtomicInteger perShardOnRemoval = new AtomicInteger();
+        IndexFieldDataCache.Listener perShardListener = new IndexFieldDataCache.Listener() {
+            @Override
+            public void onRemoval(ShardId shardId, String fieldName, boolean wasEvicted, long sizeInBytes) {
+                perShardOnRemoval.incrementAndGet();
+            }
+        };
+
+        IndicesFieldDataCache nodeCache = new IndicesFieldDataCache(Settings.EMPTY, new IndexFieldDataCache.Listener() {
+        });
+        Index index = new Index("idx", "_na_");
+        // 3-arg overload — no shardIdentityResolver supplied
+        IndexFieldDataCache fieldCache = nodeCache.buildIndexFieldDataCache(perShardListener, index, "field1");
+
+        SortedSetOrdinalsIndexFieldData ifd = createSortedDV("field1", fieldCache);
+        ifd.loadGlobal(ir);
+        nodeCache.getCache().invalidateAll();
+
+        // Without identity tracking, every removal reaches the per-shard listener.
+        assertEquals(1, perShardOnRemoval.get());
+
+        ir.close();
+        dir.close();
+        nodeCache.close();
     }
 
     private class DummyAccountingFieldDataCache implements IndexFieldDataCache {

--- a/server/src/test/java/org/opensearch/index/fielddata/FieldDataStatsTests.java
+++ b/server/src/test/java/org/opensearch/index/fielddata/FieldDataStatsTests.java
@@ -35,6 +35,7 @@ import org.opensearch.common.FieldMemoryStats;
 import org.opensearch.common.FieldMemoryStatsTests;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.io.IOException;
@@ -53,4 +54,22 @@ public class FieldDataStatsTests extends OpenSearchTestCase {
         assertEquals(stats.getMemorySize(), read.getMemorySize());
         assertEquals(stats.getFields(), read.getFields());
     }
+
+    // onRemoval without a matching onCache pushes memorySize negative; writeVLong then throws.
+    public void testRemovalWithoutMatchingCacheGoesNegativeAndFailsSerialization() {
+        ShardFieldData data = new ShardFieldData();
+        ShardId shardId = new ShardId("index", "uuid", 0);
+        long bytes = 2_895_512L;
+
+        data.onRemoval(shardId, "foo", true, bytes);
+
+        FieldDataStats stats = data.stats("*");
+        assertEquals(-bytes, stats.getMemorySizeInBytes());
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        IllegalStateException e = expectThrows(IllegalStateException.class, () -> stats.writeTo(out));
+        assertTrue(e.getMessage().contains("Negative longs unsupported"));
+        assertTrue(e.getMessage().contains("-2895512"));
+    }
+
 }

--- a/server/src/test/java/org/opensearch/index/fielddata/IndexFieldDataServiceTests.java
+++ b/server/src/test/java/org/opensearch/index/fielddata/IndexFieldDataServiceTests.java
@@ -392,4 +392,15 @@ public class IndexFieldDataServiceTests extends OpenSearchSingleNodeTestCase {
         doTestRequireDocValues(new BooleanFieldMapper.BooleanFieldType("field"));
         doTestRequireDocValues(new BooleanFieldMapper.BooleanFieldType("field", true, false, false, null, Collections.emptyMap()));
     }
+
+    public void testSetShardIdentityResolverRejectsNull() {
+        IndicesFieldDataCache cache = new IndicesFieldDataCache(Settings.EMPTY, null);
+        IndexFieldDataService ifds = new IndexFieldDataService(
+            IndexSettingsModule.newIndexSettings("test", Settings.EMPTY),
+            cache,
+            null,
+            null
+        );
+        expectThrows(IllegalArgumentException.class, () -> ifds.setShardIdentityResolver(null));
+    }
 }


### PR DESCRIPTION
Backport of #21667 to the 2.19 branch.

### Summary
Cherry-picks 6d41554 — fixes negative `FieldDataStats.memorySize` causing API serialization error `IllegalStateException: Negative longs unsupported`.

### Notes on the backport
The fix logic is the same as on main, but the surrounding `IndicesFieldDataCache` differs between branches, so a few mechanical adaptations were needed:

- `IndicesFieldDataCache` on 2.19 has only the 2-arg `(Settings, Listener)` ctor (no `clusterService` / `threadPool` args). The `IndexFieldCache` inner class on 2.19 holds the `Cache<Key, Accountable>` directly rather than a back-reference to the outer `IndicesFieldDataCache`. The fix was applied in-place: `Key.shardIdentity` + `shardIdentityResolver` were added on top of the existing 2.19 structure rather than the main-style refactor (no `cacheKeysToClear` / `clear(Index)` indirection on 2.19).
- The new `FieldDataStatsNegativeIT` integ test calls `IndicesFieldDataCache#clear()` on main; that method does not exist on 2.19. Switched to `getCache().refresh()`, which is what the periodic `CacheCleaner` itself calls in 2.19 — equivalent in effect for the test's purpose.
- `testExceptionWhileRemovingKey` was dropped from the backport — it exercises 2.x-only `IndicesFieldDataCache#clear()` indirection logic that does not exist on 2.19. `testSetShardIdentityResolverRejectsNull` was kept and adapted to the 2-arg `IndicesFieldDataCache` ctor.
- Updates to test ctor calls in `FieldDataCacheTests` to use the 2.19 2-arg `IndicesFieldDataCache` constructor.

### Test plan
- [x] `:server:compileJava :server:compileTestJava :server:compileInternalClusterTestJava` — passes
- [x] `:server:test --tests FieldDataCacheTests --tests FieldDataStatsTests --tests IndexFieldDataServiceTests` — passes
- [x] `:server:spotlessApply` — clean