### PR TITLE
Fix PPL extract() (literal / TIME / MILLISECOND) and isnotnull-AND flatten

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/extract.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/extract.rs
@@ -273,6 +273,8 @@ fn extract_for_unit(unit: &str, dt: DateTime<Utc>) -> Option<i64> {
     let (dd, mo, yy) = (dt.day() as i64, dt.month() as i64, dt.year() as i64);
     match unit {
         "MICROSECOND" => Some(us),
+        // Millisecond fraction within the second (0..=999), matching SQL plugin semantics.
+        "MILLISECOND" => Some(us / 1_000),
         "SECOND" => Some(ss),
         "MINUTE" => Some(mm),
         "HOUR" => Some(hh),
@@ -342,6 +344,15 @@ mod tests {
         ] {
             assert_eq!(eval(unit), Some(want), "unit={unit}");
         }
+    }
+
+    #[test]
+    fn millisecond_returns_fraction_within_second() {
+        // Sample is 2020-03-15 10:30:45.123456 → ms fraction 123, μs fraction 123_456.
+        assert_eq!(eval("MILLISECOND"), Some(123));
+        assert_eq!(eval("millisecond"), Some(123));
+        // Boundary: a timestamp with no sub-second component → MILLISECOND = 0.
+        assert_eq!(compute("MILLISECOND", us(2024, 6, 15, 10, 30, 0)), Some(0));
     }
 
     #[test]

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/extract.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/extract.rs
@@ -15,9 +15,10 @@ use std::sync::Arc;
 
 use super::udf_identity;
 
-use chrono::{DateTime, Datelike, TimeZone, Timelike, Utc};
+use chrono::{DateTime, Datelike, NaiveTime, TimeZone, Timelike, Utc};
 use datafusion::arrow::array::{
-    Array, ArrayRef, AsArray, Int64Builder, TimestampMicrosecondArray,
+    Array, ArrayRef, AsArray, Int64Builder, StringArray, Time32MillisecondArray, Time32SecondArray,
+    Time64MicrosecondArray, Time64NanosecondArray, TimestampMicrosecondArray,
 };
 use datafusion::arrow::datatypes::{DataType, TimeUnit};
 use datafusion::common::{exec_err, plan_err, Result, ScalarValue};
@@ -43,7 +44,7 @@ impl ExtractUdf {
     }
 }
 
-udf_identity!(ExtractUdf, "extract");
+udf_identity!(ExtractUdf, "opensearch_extract");
 
 impl ScalarUDFImpl for ExtractUdf {
     fn as_any(&self) -> &dyn Any {
@@ -51,7 +52,7 @@ impl ScalarUDFImpl for ExtractUdf {
     }
 
     fn name(&self) -> &str {
-        "extract"
+        "opensearch_extract"
     }
 
     fn signature(&self) -> &Signature {
@@ -74,11 +75,15 @@ impl ScalarUDFImpl for ExtractUdf {
             other => return plan_err!("extract: arg 0 expected string unit, got {other:?}"),
         };
         let ts = match &arg_types[1] {
-            DataType::Timestamp(_, _) | DataType::Date32 | DataType::Date64
-            | DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View => {
+            DataType::Timestamp(_, _) | DataType::Date32 | DataType::Date64 => {
                 DataType::Timestamp(TimeUnit::Microsecond, None)
             }
-            other => return plan_err!("extract: arg 1 expected timestamp/date/string, got {other:?}"),
+            // Keep Utf8 so we can parse both ISO datetimes and bare time-of-day
+            // strings internally (DataFusion's Utf8→Timestamp cast rejects the latter).
+            DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View => DataType::Utf8,
+            // Time32/Time64: handle directly to avoid a Time→Timestamp cast kernel.
+            DataType::Time32(_) | DataType::Time64(_) => arg_types[1].clone(),
+            other => return plan_err!("extract: arg 1 expected timestamp/date/time/string, got {other:?}"),
         };
         Ok(vec![unit, ts])
     }
@@ -95,6 +100,12 @@ impl ScalarUDFImpl for ExtractUdf {
             let unit_str = scalar_utf8(unit)?;
             let micros = match ts {
                 ScalarValue::TimestampMicrosecond(v, _) => *v,
+                // Time-of-day → μs since 1970-01-01 so compute() reuses hour/minute/second.
+                ScalarValue::Time32Second(v) => v.map(|s| (s as i64) * 1_000_000),
+                ScalarValue::Time32Millisecond(v) => v.map(|ms| (ms as i64) * 1_000),
+                ScalarValue::Time64Microsecond(v) => *v,
+                ScalarValue::Time64Nanosecond(v) => v.map(|ns| ns / 1_000),
+                ScalarValue::Utf8(v) | ScalarValue::LargeUtf8(v) => v.as_deref().and_then(parse_string_to_micros),
                 other => return exec_err!("extract: unsupported ts scalar: {other:?}"),
             };
             let out = match (unit_str, micros) {
@@ -106,31 +117,124 @@ impl ScalarUDFImpl for ExtractUdf {
 
         let unit_arr = args.args[0].clone().into_array(n)?;
         let ts_arr = args.args[1].clone().into_array(n)?;
-        let ts = ts_arr
-            .as_any()
-            .downcast_ref::<TimestampMicrosecondArray>()
-            .ok_or_else(|| {
-                datafusion::common::DataFusionError::Execution(format!(
-                    "extract: expected Timestamp(Microsecond, None) after coercion, got {:?}",
-                    ts_arr.data_type()
-                ))
-            })?;
         let mut builder = Int64Builder::with_capacity(n);
-        for i in 0..n {
-            if ts.is_null(i) {
-                builder.append_null();
-                continue;
+        match ts_arr.data_type() {
+            DataType::Timestamp(TimeUnit::Microsecond, _) => {
+                let ts = ts_arr
+                    .as_any()
+                    .downcast_ref::<TimestampMicrosecondArray>()
+                    .ok_or_else(|| time_array_downcast_err(ts_arr.data_type()))?;
+                fill_int_builder(&mut builder, &unit_arr, ts.len(), |i| {
+                    if ts.is_null(i) { None } else { Some(ts.value(i)) }
+                })?;
             }
-            match unit_at(&unit_arr, i)? {
-                None => builder.append_null(),
-                Some(u) => match compute(&u, ts.value(i)) {
-                    Some(v) => builder.append_value(v),
-                    None => builder.append_null(),
-                },
+            DataType::Time32(TimeUnit::Second) => {
+                let arr = ts_arr.as_any().downcast_ref::<Time32SecondArray>()
+                    .ok_or_else(|| time_array_downcast_err(ts_arr.data_type()))?;
+                fill_int_builder(&mut builder, &unit_arr, arr.len(), |i| {
+                    if arr.is_null(i) { None } else { Some((arr.value(i) as i64) * 1_000_000) }
+                })?;
+            }
+            DataType::Time32(TimeUnit::Millisecond) => {
+                let arr = ts_arr.as_any().downcast_ref::<Time32MillisecondArray>()
+                    .ok_or_else(|| time_array_downcast_err(ts_arr.data_type()))?;
+                fill_int_builder(&mut builder, &unit_arr, arr.len(), |i| {
+                    if arr.is_null(i) { None } else { Some((arr.value(i) as i64) * 1_000) }
+                })?;
+            }
+            DataType::Time64(TimeUnit::Microsecond) => {
+                let arr = ts_arr.as_any().downcast_ref::<Time64MicrosecondArray>()
+                    .ok_or_else(|| time_array_downcast_err(ts_arr.data_type()))?;
+                fill_int_builder(&mut builder, &unit_arr, arr.len(), |i| {
+                    if arr.is_null(i) { None } else { Some(arr.value(i)) }
+                })?;
+            }
+            DataType::Time64(TimeUnit::Nanosecond) => {
+                let arr = ts_arr.as_any().downcast_ref::<Time64NanosecondArray>()
+                    .ok_or_else(|| time_array_downcast_err(ts_arr.data_type()))?;
+                fill_int_builder(&mut builder, &unit_arr, arr.len(), |i| {
+                    if arr.is_null(i) { None } else { Some(arr.value(i) / 1_000) }
+                })?;
+            }
+            DataType::Utf8 => {
+                let arr = ts_arr.as_any().downcast_ref::<StringArray>()
+                    .ok_or_else(|| time_array_downcast_err(ts_arr.data_type()))?;
+                fill_int_builder(&mut builder, &unit_arr, arr.len(), |i| {
+                    if arr.is_null(i) { None } else { parse_string_to_micros(arr.value(i)) }
+                })?;
+            }
+            other => {
+                return exec_err!(
+                    "extract: expected Timestamp(Microsecond, None), Time32/Time64, or Utf8 after coercion, got {other:?}"
+                )
             }
         }
         Ok(ColumnarValue::Array(Arc::new(builder.finish()) as ArrayRef))
     }
+}
+
+fn time_array_downcast_err(dt: &DataType) -> datafusion::common::DataFusionError {
+    datafusion::common::DataFusionError::Execution(format!(
+        "extract: array downcast failed for type {dt:?}"
+    ))
+}
+
+/// Parses an ISO datetime or bare time-of-day string into μs since Unix epoch (UTC).
+/// Time-of-day is anchored at 1970-01-01. Returns None on parse failure.
+fn parse_string_to_micros(s: &str) -> Option<i64> {
+    let trimmed = s.trim();
+    for fmt in &[
+        "%Y-%m-%d %H:%M:%S%.f",
+        "%Y-%m-%d %H:%M:%S",
+        "%Y-%m-%dT%H:%M:%S%.f",
+        "%Y-%m-%dT%H:%M:%SZ",
+        "%Y-%m-%dT%H:%M:%S",
+        "%Y-%m-%d",
+    ] {
+        if let Ok(naive) = chrono::NaiveDateTime::parse_from_str(trimmed, fmt) {
+            return Some(naive.and_utc().timestamp_micros());
+        }
+        // %Y-%m-%d alone
+        if *fmt == "%Y-%m-%d" {
+            if let Ok(date) = chrono::NaiveDate::parse_from_str(trimmed, fmt) {
+                return Some(date.and_hms_opt(0, 0, 0)?.and_utc().timestamp_micros());
+            }
+        }
+    }
+    // Bare time-of-day → attach 1970-01-01.
+    for fmt in &["%H:%M:%S%.f", "%H:%M:%S", "%H:%M"] {
+        if let Ok(time) = NaiveTime::parse_from_str(trimmed, fmt) {
+            let date = chrono::NaiveDate::from_ymd_opt(1970, 1, 1)?;
+            return Some(date.and_time(time).and_utc().timestamp_micros());
+        }
+    }
+    None
+}
+
+/// Fills the int64 builder by reading per-row μs values via `value_at` and running
+/// them through `compute`. Time-of-day inputs are anchored at 1970-01-01.
+fn fill_int_builder<F>(
+    builder: &mut Int64Builder,
+    unit_arr: &ArrayRef,
+    n: usize,
+    value_at: F,
+) -> Result<()>
+where
+    F: Fn(usize) -> Option<i64>,
+{
+    for i in 0..n {
+        match value_at(i) {
+            None => builder.append_null(),
+            Some(v) => match unit_at(unit_arr, i)? {
+                None => builder.append_null(),
+                Some(u) => match compute(&u, v) {
+                    Some(out) => builder.append_value(out),
+                    None => builder.append_null(),
+                },
+            },
+        }
+    }
+    Ok(())
 }
 
 fn scalar_utf8(s: &ScalarValue) -> Result<Option<String>> {

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/mod.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/mod.rs
@@ -215,7 +215,7 @@ pub fn register_all(ctx: &SessionContext) {
     ctx.register_udf(crate::indexed_table::substrait_to_tree::create_index_filter_udf());
     ctx.register_udf(crate::indexed_table::substrait_to_tree::create_delegation_possible_udf());
     log::info!(
-        "OpenSearch UDF register_all: convert_tz, conversion(numeric_conversion: num/auto/memk/rmcomma/rmunit/dur2sec/mstime, time_conversion: ctime/mktime), crc32, date_format, extract, from_unixtime, item, json_append, json_array_length, json_delete, json_extend, json_extract, json_extract_all, json_keys, json_set, makedate, maketime, minspan_bucket, mvappend, mvfind, mvzip, parse, range_bucket, rex_extract, rex_extract_multi, rex_offset, sha1, span_bucket, str_to_date, strftime, time_format, width_bucket registered"
+        "OpenSearch UDF register_all: convert_tz, conversion(numeric_conversion: num/auto/memk/rmcomma/rmunit/dur2sec/mstime, time_conversion: ctime/mktime), crc32, date_format, opensearch_extract, from_unixtime, item, json_append, json_array_length, json_delete, json_extend, json_extract, json_extract_all, json_keys, json_set, makedate, maketime, minspan_bucket, mvappend, mvfind, mvzip, parse, range_bucket, rex_extract, rex_extract_multi, rex_offset, sha1, span_bucket, str_to_date, strftime, time_format, width_bucket registered"
     );
 }
 

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionFragmentConvertor.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionFragmentConvertor.java
@@ -149,7 +149,7 @@ public class DataFusionFragmentConvertor implements FragmentConvertor {
         FunctionMappings.s(DateTimeAdapters.LOCAL_DATE_OP, "to_date"),
         FunctionMappings.s(DateTimeAdapters.LOCAL_TO_TIMESTAMP_OP, "to_timestamp"),
         FunctionMappings.s(DateTimeAdapters.LOCAL_DATE_TRUNC_OP, "date_trunc"),
-        FunctionMappings.s(RustUdfDateTimeAdapters.LOCAL_EXTRACT_OP, "extract"),
+        FunctionMappings.s(RustUdfDateTimeAdapters.LOCAL_EXTRACT_OP, "opensearch_extract"),
         FunctionMappings.s(RustUdfDateTimeAdapters.LOCAL_FROM_UNIXTIME_OP, "from_unixtime"),
         FunctionMappings.s(RustUdfDateTimeAdapters.LOCAL_MAKEDATE_OP, "makedate"),
         FunctionMappings.s(RustUdfDateTimeAdapters.LOCAL_MAKETIME_OP, "maketime"),

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/RustUdfDateTimeAdapters.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/RustUdfDateTimeAdapters.java
@@ -12,11 +12,13 @@ import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlFunction;
 import org.apache.calcite.sql.SqlFunctionCategory;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.type.OperandTypes;
 import org.apache.calcite.sql.type.ReturnTypes;
 import org.apache.calcite.sql.type.SqlOperandTypeChecker;
@@ -27,7 +29,11 @@ import org.opensearch.analytics.spi.AbstractNameMappingAdapter;
 import org.opensearch.analytics.spi.FieldStorageInfo;
 import org.opensearch.analytics.spi.NumericToDoubleAdapter;
 
+import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.List;
+import java.util.Locale;
+import java.util.Set;
 
 /**
  * Adapters for PPL datetime functions routed to Rust UDFs. Each {@code LOCAL_*_OP}
@@ -61,9 +67,29 @@ final class RustUdfDateTimeAdapters {
      * Adapter for PPL {@code extract(<unit> FROM <expr>)}.
      * <p>For TIME(p) operands, CASTs to VARCHAR so the call binds to the {@code (string, string)}
      * yaml overload — substrait-java 0.89.1 can't emit a {@code precision_time<P>} signature.
+     * <p>When the unit is a known date-part (YEAR/MONTH/DAY/...), the value is anchored to today's
+     * UTC date at plan time before the VARCHAR cast — matches SQL plugin's {@code FunctionProperties
+     * .getQueryStartClock()} snapshot semantics so date-parts on TIME values yield the current date
+     * rather than the 1970 epoch implied by Arrow's TIME representation.
      * Other operand types (DATE / TIMESTAMP / VARCHAR) pass through unchanged.
      */
     static final class ExtractAdapter extends AbstractNameMappingAdapter {
+
+        /** Units that need a date context; pure time-parts (HOUR/MINUTE/...) are absent. */
+        private static final Set<String> DATE_PART_UNITS = Set.of(
+            "YEAR",
+            "MONTH",
+            "DAY",
+            "WEEK",
+            "QUARTER",
+            "DOW",
+            "DOY",
+            "YEAR_MONTH",
+            "DAY_HOUR",
+            "DAY_MINUTE",
+            "DAY_SECOND",
+            "DAY_MICROSECOND"
+        );
 
         ExtractAdapter() {
             super(LOCAL_EXTRACT_OP, List.of(), List.of());
@@ -71,7 +97,7 @@ final class RustUdfDateTimeAdapters {
 
         @Override
         public RexNode adapt(RexCall original, List<FieldStorageInfo> fieldStorage, RelOptCluster cluster) {
-            RexCall toAdapt = isTimeValueOperand(original) ? castValueOperandToVarchar(original, cluster) : original;
+            RexCall toAdapt = isTimeValueOperand(original) ? rewriteTimeOperand(original, cluster) : original;
             return super.adapt(toAdapt, fieldStorage, cluster);
         }
 
@@ -79,17 +105,37 @@ final class RustUdfDateTimeAdapters {
             return call.getOperands().size() == 2 && call.getOperands().get(1).getType().getSqlTypeName() == SqlTypeName.TIME;
         }
 
-        private static RexCall castValueOperandToVarchar(RexCall original, RelOptCluster cluster) {
+        /**
+         * Builds the rewritten call for a TIME value operand. For date-part units, prepends today's
+         * UTC date to the time string so Rust parses it as a full timestamp; otherwise just casts
+         * TIME→VARCHAR.
+         */
+        private static RexCall rewriteTimeOperand(RexCall original, RelOptCluster cluster) {
             RexBuilder rexBuilder = cluster.getRexBuilder();
+            RexNode unit = original.getOperands().get(0);
             RexNode value = original.getOperands().get(1);
             RelDataType varcharType = rexBuilder.getTypeFactory()
                 .createTypeWithNullability(rexBuilder.getTypeFactory().createSqlType(SqlTypeName.VARCHAR), value.getType().isNullable());
-            RexNode castedValue = rexBuilder.makeCast(varcharType, value);
-            return (RexCall) rexBuilder.makeCall(
-                original.getType(),
-                original.getOperator(),
-                List.of(original.getOperands().get(0), castedValue)
-            );
+            RexNode timeAsVarchar = rexBuilder.makeCast(varcharType, value);
+            RexNode rewrittenValue = needsDateContext(unit) ? prependTodayLiteral(rexBuilder, varcharType, timeAsVarchar) : timeAsVarchar;
+            return (RexCall) rexBuilder.makeCall(original.getType(), original.getOperator(), List.of(unit, rewrittenValue));
+        }
+
+        /** True if the unit is a literal naming a date-part (the only case we can specialize). */
+        private static boolean needsDateContext(RexNode unit) {
+            if (!(unit instanceof RexLiteral)) {
+                return false;
+            }
+            Object raw = ((RexLiteral) unit).getValue2();
+            return raw != null && DATE_PART_UNITS.contains(raw.toString().toUpperCase(Locale.ROOT));
+        }
+
+        /** Returns {@code "<today> " || cast(time as varchar)}; today snapshotted at plan time. */
+        private static RexNode prependTodayLiteral(RexBuilder rexBuilder, RelDataType varcharType, RexNode timeAsVarchar) {
+            String todayPrefix = LocalDate.now(ZoneOffset.UTC).toString() + " ";
+            RelDataType nonNullVarchar = rexBuilder.getTypeFactory().createSqlType(SqlTypeName.VARCHAR);
+            RexNode prefix = rexBuilder.makeLiteral(todayPrefix, nonNullVarchar, false);
+            return rexBuilder.makeCall(varcharType, SqlStdOperatorTable.CONCAT, List.of(prefix, timeAsVarchar));
         }
     }
 

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/RustUdfDateTimeAdapters.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/RustUdfDateTimeAdapters.java
@@ -8,6 +8,11 @@
 
 package org.opensearch.be.datafusion;
 
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlFunction;
 import org.apache.calcite.sql.SqlFunctionCategory;
 import org.apache.calcite.sql.SqlKind;
@@ -17,7 +22,9 @@ import org.apache.calcite.sql.type.ReturnTypes;
 import org.apache.calcite.sql.type.SqlOperandTypeChecker;
 import org.apache.calcite.sql.type.SqlReturnTypeInference;
 import org.apache.calcite.sql.type.SqlTypeFamily;
+import org.apache.calcite.sql.type.SqlTypeName;
 import org.opensearch.analytics.spi.AbstractNameMappingAdapter;
+import org.opensearch.analytics.spi.FieldStorageInfo;
 import org.opensearch.analytics.spi.NumericToDoubleAdapter;
 
 import java.util.List;
@@ -38,7 +45,7 @@ final class RustUdfDateTimeAdapters {
         return new SqlFunction(name, SqlKind.OTHER_FUNCTION, ret, null, operands, SqlFunctionCategory.TIMEDATE);
     }
 
-    static final SqlOperator LOCAL_EXTRACT_OP = udf("extract", ReturnTypes.BIGINT_NULLABLE, OperandTypes.ANY_ANY);
+    static final SqlOperator LOCAL_EXTRACT_OP = udf("opensearch_extract", ReturnTypes.BIGINT_NULLABLE, OperandTypes.ANY_ANY);
     static final SqlOperator LOCAL_FROM_UNIXTIME_OP = udf("from_unixtime", ReturnTypes.TIMESTAMP_NULLABLE, OperandTypes.ANY);
     static final SqlOperator LOCAL_MAKETIME_OP = udf(
         "maketime",
@@ -50,9 +57,39 @@ final class RustUdfDateTimeAdapters {
     static final SqlOperator LOCAL_TIME_FORMAT_OP = udf("time_format", ReturnTypes.VARCHAR_NULLABLE, OperandTypes.ANY_ANY);
     static final SqlOperator LOCAL_STR_TO_DATE_OP = udf("str_to_date", ReturnTypes.TIMESTAMP_NULLABLE, OperandTypes.ANY_ANY);
 
+    /**
+     * Adapter for PPL {@code extract(<unit> FROM <expr>)}.
+     * <p>For TIME(p) operands, CASTs to VARCHAR so the call binds to the {@code (string, string)}
+     * yaml overload — substrait-java 0.89.1 can't emit a {@code precision_time<P>} signature.
+     * Other operand types (DATE / TIMESTAMP / VARCHAR) pass through unchanged.
+     */
     static final class ExtractAdapter extends AbstractNameMappingAdapter {
+
         ExtractAdapter() {
             super(LOCAL_EXTRACT_OP, List.of(), List.of());
+        }
+
+        @Override
+        public RexNode adapt(RexCall original, List<FieldStorageInfo> fieldStorage, RelOptCluster cluster) {
+            RexCall toAdapt = isTimeValueOperand(original) ? castValueOperandToVarchar(original, cluster) : original;
+            return super.adapt(toAdapt, fieldStorage, cluster);
+        }
+
+        private static boolean isTimeValueOperand(RexCall call) {
+            return call.getOperands().size() == 2 && call.getOperands().get(1).getType().getSqlTypeName() == SqlTypeName.TIME;
+        }
+
+        private static RexCall castValueOperandToVarchar(RexCall original, RelOptCluster cluster) {
+            RexBuilder rexBuilder = cluster.getRexBuilder();
+            RexNode value = original.getOperands().get(1);
+            RelDataType varcharType = rexBuilder.getTypeFactory()
+                .createTypeWithNullability(rexBuilder.getTypeFactory().createSqlType(SqlTypeName.VARCHAR), value.getType().isNullable());
+            RexNode castedValue = rexBuilder.makeCast(varcharType, value);
+            return (RexCall) rexBuilder.makeCall(
+                original.getType(),
+                original.getOperator(),
+                List.of(original.getOperands().get(0), castedValue)
+            );
         }
     }
 

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/SargAdapter.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/SargAdapter.java
@@ -28,6 +28,9 @@ class SargAdapter implements ScalarFunctionAdapter {
             return original;
         }
         RexBuilder rexBuilder = cluster.getRexBuilder();
-        return RexUtil.expandSearch(rexBuilder, null, original);
+        RexNode expanded = RexUtil.expandSearch(rexBuilder, null, original);
+        // Flatten the right-leaning AND chain that expandSearch produces (e.g.
+        // multi-point exclusions): Filter.<init> asserts RexUtil.isFlat on the condition.
+        return RexUtil.flatten(rexBuilder, expanded);
     }
 }

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/resources/opensearch_scalar_functions.yaml
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/resources/opensearch_scalar_functions.yaml
@@ -800,15 +800,13 @@ scalar_functions:
         variadic: { min: 1 }
         return: string
 
-  - name: "extract"
+  - name: "opensearch_extract"
     description: >-
-      Pull a MySQL-style calendar component (simple or composite) out of a
-      timestamp. The unit slot is a VARCHAR literal injected by the adapter
-      (matchKey token `str`); the timestamp slot is PPL's canonical
-      `precision_timestamp<P>` / `date`. Returns BIGINT regardless of unit —
-      composite units (e.g. `DAY_SECOND`) follow MySQL's digit-concatenation
-      semantics (see rust/src/udf/extract.rs). Routes to the Rust `extract`
-      UDF, not Calcite's EXTRACT operator.
+      Pull a MySQL-style calendar component out of a timestamp. Returns BIGINT.
+      Renamed from `extract` to avoid a name collision with substrait core's
+      enum-argument `extract` (substrait-java 0.89.1 crashes on the core variant).
+      Composite units (e.g. `DAY_SECOND`) follow MySQL's digit-concatenation
+      semantics — see rust/src/udf/extract.rs.
     impls:
       - args:
           - { value: string, name: "unit" }
@@ -822,6 +820,8 @@ scalar_functions:
           - { value: string, name: "unit" }
           - { value: "time", name: "value" }
         return: i64
+      # No `precision_time<P>` overload: substrait-java 0.89.1 can't stringify it.
+      # ExtractAdapter pre-CASTs TIME(p) operands to VARCHAR to bind below.
       - args:
           - { value: string, name: "unit" }
           - { value: "string", name: "value" }

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/RustUdfDateTimeAdaptersTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/RustUdfDateTimeAdaptersTests.java
@@ -16,11 +16,15 @@ import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.opensearch.test.OpenSearchTestCase;
 
+import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.List;
 
 /**
@@ -65,6 +69,48 @@ public class RustUdfDateTimeAdaptersTests extends OpenSearchTestCase {
 
         RexNode coercedValue = adaptedCall.getOperands().get(1);
         assertEquals(SqlTypeName.VARCHAR, coercedValue.getType().getSqlTypeName());
+        assertTrue(coercedValue instanceof RexCall && ((RexCall) coercedValue).getKind() == SqlKind.CAST);
+    }
+
+    /**
+     * {@code extract(YEAR FROM <TIME>)} must anchor the value to today's UTC date at plan time —
+     * otherwise Arrow's TIME→1970-01-01 anchor leaks through and YEAR returns 1970.
+     */
+    public void testExtractAdapterPrependsTodayForDatePartOnTime() {
+        RelDataType varchar = typeFactory.createSqlType(SqlTypeName.VARCHAR);
+        RelDataType time9 = typeFactory.createSqlType(SqlTypeName.TIME, 9);
+        RelDataType bigint = typeFactory.createSqlType(SqlTypeName.BIGINT);
+
+        RexNode unit = rexBuilder.makeLiteral("YEAR", varchar, true);
+        RexNode timeVal = rexBuilder.makeInputRef(time9, 0);
+        RexCall original = (RexCall) rexBuilder.makeCall(bigint, RustUdfDateTimeAdapters.LOCAL_EXTRACT_OP, List.of(unit, timeVal));
+
+        RexNode adapted = new RustUdfDateTimeAdapters.ExtractAdapter().adapt(original, List.of(), cluster);
+
+        RexCall adaptedCall = (RexCall) adapted;
+        RexNode coercedValue = adaptedCall.getOperands().get(1);
+        assertTrue("expected CONCAT wrapping the TIME cast", coercedValue instanceof RexCall);
+        RexCall concat = (RexCall) coercedValue;
+        assertEquals(SqlStdOperatorTable.CONCAT, concat.getOperator());
+        // First arg of the CONCAT is a literal "<today> " (UTC).
+        RexNode prefix = concat.getOperands().get(0);
+        assertTrue(prefix instanceof RexLiteral);
+        String expected = LocalDate.now(ZoneOffset.UTC).toString() + " ";
+        assertEquals(expected, ((RexLiteral) prefix).getValue2());
+    }
+
+    /** Pure time-part units (HOUR/MINUTE/SECOND/...) keep the existing TIME→VARCHAR cast path. */
+    public void testExtractAdapterKeepsBareCastForTimePartOnTime() {
+        RelDataType varchar = typeFactory.createSqlType(SqlTypeName.VARCHAR);
+        RelDataType time9 = typeFactory.createSqlType(SqlTypeName.TIME, 9);
+        RelDataType bigint = typeFactory.createSqlType(SqlTypeName.BIGINT);
+
+        RexNode unit = rexBuilder.makeLiteral("HOUR", varchar, true);
+        RexNode timeVal = rexBuilder.makeInputRef(time9, 0);
+        RexCall original = (RexCall) rexBuilder.makeCall(bigint, RustUdfDateTimeAdapters.LOCAL_EXTRACT_OP, List.of(unit, timeVal));
+
+        RexNode adapted = new RustUdfDateTimeAdapters.ExtractAdapter().adapt(original, List.of(), cluster);
+        RexNode coercedValue = ((RexCall) adapted).getOperands().get(1);
         assertTrue(coercedValue instanceof RexCall && ((RexCall) coercedValue).getKind() == SqlKind.CAST);
     }
 

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/RustUdfDateTimeAdaptersTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/RustUdfDateTimeAdaptersTests.java
@@ -1,0 +1,87 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion;
+
+import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.hep.HepPlanner;
+import org.apache.calcite.plan.hep.HepProgramBuilder;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.List;
+
+/**
+ * Tests for {@link RustUdfDateTimeAdapters}. Pins the {@code opensearch_extract}
+ * rename and the TIME→VARCHAR coercion in {@link RustUdfDateTimeAdapters.ExtractAdapter}.
+ */
+public class RustUdfDateTimeAdaptersTests extends OpenSearchTestCase {
+
+    private RelDataTypeFactory typeFactory;
+    private RexBuilder rexBuilder;
+    private RelOptCluster cluster;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        typeFactory = new JavaTypeFactoryImpl();
+        rexBuilder = new RexBuilder(typeFactory);
+        HepPlanner planner = new HepPlanner(new HepProgramBuilder().build());
+        cluster = RelOptCluster.create(planner, rexBuilder);
+    }
+
+    /** Pins the rename: substrait core's enum-arg `extract` would crash isthmus if we shared the name. */
+    public void testExtractOperatorNameAvoidsSubstraitCoreCollision() {
+        assertEquals("opensearch_extract", RustUdfDateTimeAdapters.LOCAL_EXTRACT_OP.getName());
+    }
+
+    /** {@code extract(<unit> FROM <TIME(p)>)} value operand must be CAST to VARCHAR (precision_time has no yaml overload). */
+    public void testExtractAdapterCastsTimeOperandToVarchar() {
+        RelDataType varchar = typeFactory.createSqlType(SqlTypeName.VARCHAR);
+        RelDataType time9 = typeFactory.createSqlType(SqlTypeName.TIME, 9);
+        RelDataType bigint = typeFactory.createSqlType(SqlTypeName.BIGINT);
+
+        RexNode unit = rexBuilder.makeLiteral("MINUTE", varchar, true);
+        RexNode timeVal = rexBuilder.makeInputRef(time9, 0);
+        RexCall original = (RexCall) rexBuilder.makeCall(bigint, RustUdfDateTimeAdapters.LOCAL_EXTRACT_OP, List.of(unit, timeVal));
+
+        RexNode adapted = new RustUdfDateTimeAdapters.ExtractAdapter().adapt(original, List.of(), cluster);
+
+        assertTrue(adapted instanceof RexCall);
+        RexCall adaptedCall = (RexCall) adapted;
+        assertEquals(unit, adaptedCall.getOperands().get(0));
+
+        RexNode coercedValue = adaptedCall.getOperands().get(1);
+        assertEquals(SqlTypeName.VARCHAR, coercedValue.getType().getSqlTypeName());
+        assertTrue(coercedValue instanceof RexCall && ((RexCall) coercedValue).getKind() == SqlKind.CAST);
+    }
+
+    /** Non-TIME operands (DATE / TIMESTAMP / VARCHAR) pass through unchanged. */
+    public void testExtractAdapterDoesNotCoerceTimestampOperand() {
+        RelDataType varchar = typeFactory.createSqlType(SqlTypeName.VARCHAR);
+        RelDataType timestamp6 = typeFactory.createSqlType(SqlTypeName.TIMESTAMP, 6);
+        RelDataType bigint = typeFactory.createSqlType(SqlTypeName.BIGINT);
+
+        RexNode unit = rexBuilder.makeLiteral("YEAR", varchar, true);
+        RexNode tsVal = rexBuilder.makeInputRef(timestamp6, 0);
+        RexCall original = (RexCall) rexBuilder.makeCall(bigint, RustUdfDateTimeAdapters.LOCAL_EXTRACT_OP, List.of(unit, tsVal));
+
+        RexNode adapted = new RustUdfDateTimeAdapters.ExtractAdapter().adapt(original, List.of(), cluster);
+
+        assertTrue(adapted instanceof RexCall);
+        RexCall adaptedCall = (RexCall) adapted;
+        assertSame(tsVal, adaptedCall.getOperands().get(1));
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/SargAdapterTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/SargAdapterTests.java
@@ -21,6 +21,7 @@ import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexUtil;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.type.SqlTypeName;
@@ -99,6 +100,28 @@ public class SargAdapterTests extends OpenSearchTestCase {
 
         assertFalse(isSearch(adapted));
         assertTrue(containsNoSearchOrSarg(adapted));
+    }
+
+    /** Builds {@code SEARCH(x, Sarg[(-inf..1), (1..2), (2..+inf)])} — the {@code x != 1 AND x != 2} shape. */
+    private RexCall buildPointExclusionsSearch() {
+        RangeSet<BigDecimal> rangeSet = TreeRangeSet.create();
+        rangeSet.add(Range.lessThan(BigDecimal.valueOf(1)));
+        rangeSet.add(Range.open(BigDecimal.valueOf(1), BigDecimal.valueOf(2)));
+        rangeSet.add(Range.greaterThan(BigDecimal.valueOf(2)));
+        Sarg<BigDecimal> sarg = Sarg.of(org.apache.calcite.rex.RexUnknownAs.UNKNOWN, ImmutableRangeSet.copyOf(rangeSet));
+        RexNode xRef = rexBuilder.makeInputRef(intType, 0);
+        RexNode sargLit = rexBuilder.makeSearchArgumentLiteral(sarg, intType);
+        return (RexCall) rexBuilder.makeCall(SqlStdOperatorTable.SEARCH, List.of(xRef, sargLit));
+    }
+
+    /** Multi-point-exclusion SEARCH expands to a nested-AND chain; adapter flattens to satisfy RexUtil.isFlat. */
+    public void testAdaptFlattensExpandedAndChain() {
+        RexCall original = buildPointExclusionsSearch();
+        RexNode adapted = new SargAdapter().adapt(original, List.of(), cluster);
+
+        assertFalse(isSearch(adapted));
+        assertTrue(containsNoSearchOrSarg(adapted));
+        assertTrue("expanded condition must be flat: " + adapted, RexUtil.isFlat(adapted));
     }
 
     /**

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rel/OpenSearchFilter.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rel/OpenSearchFilter.java
@@ -38,7 +38,8 @@ public class OpenSearchFilter extends Filter implements OpenSearchRelNode {
     private final List<String> viableBackends;
 
     public OpenSearchFilter(RelOptCluster cluster, RelTraitSet traitSet, RelNode input, RexNode condition, List<String> viableBackends) {
-        super(cluster, traitSet, input, condition);
+        // Filter.<init> asserts RexUtil.isFlat — flatten any nested AND/OR before super().
+        super(cluster, traitSet, input, RexUtil.flatten(cluster.getRexBuilder(), condition));
         this.viableBackends = viableBackends;
     }
 

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/DateTimeScalarFunctionsIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/DateTimeScalarFunctionsIT.java
@@ -133,6 +133,16 @@ public class DateTimeScalarFunctionsIT extends AnalyticsRestTestCase {
         assertFirstRowLong(oneRow("key00") + "| eval v = extract(DAY_HOUR FROM datetime0) | fields v", 910L);
     }
 
+    /** {@code extract(<unit> FROM '<varchar literal>')} returns the unit value. */
+    public void testExtractFromVarcharLiteral() throws IOException {
+        assertFirstRowLong(oneRow("key00") + "| eval v = extract(YEAR FROM '2003-12-31 17:30:00') | fields v", 2003L);
+    }
+
+    /** {@code extract(<unit> FROM TIME('<lit>'))} returns the unit value. */
+    public void testExtractFromTimeLiteral() throws IOException {
+        assertFirstRowLong(oneRow("key00") + "| eval v = extract(HOUR FROM time('17:30:00')) | fields v", 17L);
+    }
+
     public void testFromUnixtime() throws IOException {
         assertFirstRowString(
             oneRow("key00") + "| eval v = date_format(from_unixtime(1521467703), '%Y-%m-%d %H:%i:%s') | fields v",

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/WhereCommandIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/WhereCommandIT.java
@@ -165,6 +165,15 @@ public class WhereCommandIT extends AnalyticsRestTestCase {
         );
     }
 
+    /** Multiple {@code !=} conjuncts combined with {@code isnotnull}. */
+    public void testWhereMultipleNotEqualsAndIsNotNull() throws IOException {
+        // 13 non-null str2 values; excluding 'one' and 'two' leaves 11.
+        assertRowCount(
+            "source=" + DATASET.indexName + " | where str2 != 'one' and str2 != 'two' and isnotnull(str2) | fields str2",
+            11
+        );
+    }
+
     // ── IN / NOT IN ─────────────────────────────────────────────────────────
 
     public void testWhereInOnKeyword() throws IOException {


### PR DESCRIPTION
### Description

Fixes engine-planner-internal failures in `CalciteDateTimeFunctionIT` and `CalcitePPLConditionBuiltinFunctionIT` that crashed at plan time before reaching DataFusion.

### Query shapes fixed

- `extract(<unit> FROM '<lit>')` — string-literal operand
- `extract(<unit> FROM TIME('<lit>'))` — TIME-typed operand
- `extract(MILLISECOND FROM <timestamp>)` — was returning NULL
- `extract(<date-part> FROM TIME(...))` — was returning 1970 epoch instead of today's date
- `where a != X and a != Y and isnotnull(a)` — multiple `!=` conjuncts with `isnotnull`

### What changed

- **Renamed `extract` → `opensearch_extract`** in the substrait yaml + Rust UDF + Java operator. Substrait core's enum-arg `extract` was grouped with our value-arg variants under one FunctionFinder in isthmus, which cast every argument to `ValueArgument` and crashed on the core variant.
- **`ExtractAdapter` (analytics-backend-datafusion)** — CASTs `TIME(p)` operands to `VARCHAR` so the call binds the `(string, string)` overload (substrait-java 0.89.1 can't stringify `precision_time<P>`). For date-part units (`YEAR`/`MONTH`/`DAY`/...), anchors the time to today's UTC date at plan time so the result reflects the current date instead of the 1970 epoch implied by Arrow's TIME representation.
- **Rust `extract` UDF** — accepts bare `HH:MM:SS` strings via a new ISO/time-of-day parser; adds a `MILLISECOND` case; routes `Time32`/`Time64` arrays directly without a `Time→Timestamp` cast.
- **`SargAdapter`** — flattens the result of `RexUtil.expandSearch` so the right-leaning `AND` chain doesn't trip `Filter.isFlat`. **`OpenSearchFilter`** flattens defensively in its constructor.

### Tests

- Unit: `RustUdfDateTimeAdaptersTests` (rename, TIME→VARCHAR cast, date-part anchor, time-part bare-cast); `SargAdapterTests` flatten case.
- Rust: new `millisecond_returns_fraction_within_second` and `parse_string_to_micros` cases in `udf::extract::tests`.
- IT: `DateTimeScalarFunctionsIT` (extract from VARCHAR literal, extract from TIME literal); `WhereCommandIT` (multi-`!=` with `isnotnull`).

### Check List

- [x] Functionality includes testing.
- [ ] API changes companion pull request created, if applicable.
- [ ] Public documentation issue/PR created, if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.