### PR TITLE
Fix CompositeWriter lock leak causing LockObtainFailedException on engine restart

### DIFF
--- a/sandbox/plugins/composite-engine/src/main/java/org/opensearch/composite/CompositeWriter.java
+++ b/sandbox/plugins/composite-engine/src/main/java/org/opensearch/composite/CompositeWriter.java
@@ -12,6 +12,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.opensearch.common.annotation.ExperimentalApi;
+import org.opensearch.common.util.io.IOUtils;
 import org.opensearch.index.engine.dataformat.DataFormat;
 import org.opensearch.index.engine.dataformat.DocumentInput;
 import org.opensearch.index.engine.dataformat.FileInfos;
@@ -24,6 +25,7 @@ import org.opensearch.index.engine.dataformat.WriterConfig;
 import org.opensearch.index.engine.dataformat.WriterState;
 import org.opensearch.index.engine.exec.WriterFileSet;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -76,15 +78,28 @@ class CompositeWriter implements Writer<CompositeDocumentInput> {
         this.primaryWriter = (Writer<DocumentInput<?>>) primaryDelegate.createWriter(config);
         this.mappingVersion = primaryWriter.mappingVersion();
 
+        // Close already-created writers if a secondary createWriter() fails. LuceneWriter
+        // acquires a NativeFSLock on construction, tracked in a static LOCK_HELD set. If not
+        // closed, the path remains in LOCK_HELD and on engine restart (same JVM) when the
+        // generation counter re-produces the same value, a LockObtainFailedException is thrown.
         Map<DataFormat, Writer<DocumentInput<?>>> secondaries = new IdentityHashMap<>();
-        for (IndexingExecutionEngine<?, ?> delegate : engine.getSecondaryDelegates()) {
-            Writer<DocumentInput<?>> secondary = (Writer<DocumentInput<?>>) delegate.createWriter(config);
-            assert secondary.isSchemaMutable() && secondary.mappingVersion() >= this.mappingVersion : "Secondary writer mapping version ["
-                + secondary.mappingVersion()
-                + "] must match primary ["
-                + this.mappingVersion
-                + "]";
-            secondaries.put(delegate.getDataFormat(), secondary);
+        try {
+            for (IndexingExecutionEngine<?, ?> delegate : engine.getSecondaryDelegates()) {
+                Writer<DocumentInput<?>> secondary = (Writer<DocumentInput<?>>) delegate.createWriter(config);
+                assert secondary.isSchemaMutable() && secondary.mappingVersion() >= this.mappingVersion
+                    : "Secondary writer mapping version ["
+                        + secondary.mappingVersion()
+                        + "] must match primary ["
+                        + this.mappingVersion
+                        + "]";
+                secondaries.put(delegate.getDataFormat(), secondary);
+            }
+        } catch (Exception e) {
+            IOUtils.closeWhileHandlingException(primaryWriter);
+            for (Writer<DocumentInput<?>> w : secondaries.values()) {
+                IOUtils.closeWhileHandlingException(w);
+            }
+            throw e;
         }
         this.secondaryWritersByFormat = Collections.unmodifiableMap(secondaries);
         this.failureHandler = new FailureHandlerStrategy();
@@ -213,13 +228,17 @@ class CompositeWriter implements Writer<CompositeDocumentInput> {
         }
     }
 
+    // Use IOUtils.close to ensure all writers are closed even if one throws. Each
+    // LuceneWriter.close() triggers indexWriter.rollback() → NativeFSLock.close() →
+    // LOCK_HELD.remove(path). Without this, a throwing primary.close() would skip
+    // secondary close, leaking the lock and causing LockObtainFailedException on restart.
     @Override
     public void close() throws IOException {
         try {
-            primaryWriter.close();
-            for (Writer<DocumentInput<?>> writer : secondaryWritersByFormat.values()) {
-                writer.close();
-            }
+            List<Closeable> allWriters = new ArrayList<>(1 + secondaryWritersByFormat.size());
+            allWriters.add(primaryWriter);
+            allWriters.addAll(secondaryWritersByFormat.values());
+            IOUtils.close(allWriters);
         } finally {
             closed = true;
         }

--- a/sandbox/plugins/composite-engine/src/test/java/org/opensearch/composite/CompositeTestHelper.java
+++ b/sandbox/plugins/composite-engine/src/test/java/org/opensearch/composite/CompositeTestHelper.java
@@ -152,6 +152,41 @@ final class CompositeTestHelper {
     }
 
     /**
+     * Creates a CompositeIndexingExecutionEngine with pre-built delegate engines for testing.
+     */
+    static CompositeIndexingExecutionEngine createStubEngineWithDelegates(
+        IndexingExecutionEngine<?, ?> primaryEngine,
+        IndexingExecutionEngine<?, ?> secondaryEngine
+    ) {
+        DataFormat primaryFormat = primaryEngine.getDataFormat();
+        DataFormat secondaryFormat = secondaryEngine.getDataFormat();
+
+        DataFormatRegistry registry = mock(DataFormatRegistry.class);
+        when(registry.format(primaryFormat.name())).thenReturn(primaryFormat);
+        when(registry.format(secondaryFormat.name())).thenReturn(secondaryFormat);
+        when(registry.getIndexingEngine(any(), any())).thenAnswer(invocation -> {
+            DataFormat format = invocation.getArgument(1);
+            if (format.name().equals(primaryFormat.name())) {
+                return primaryEngine;
+            } else {
+                return secondaryEngine;
+            }
+        });
+
+        Settings settings = Settings.builder()
+            .put("index.composite.primary_data_format", primaryFormat.name())
+            .putList("index.composite.secondary_data_formats", secondaryFormat.name())
+            .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+            .build();
+        IndexMetadata indexMetadata = IndexMetadata.builder("test-index").settings(settings).build();
+        IndexSettings indexSettings = new IndexSettings(indexMetadata, Settings.EMPTY);
+
+        return new CompositeIndexingExecutionEngine(indexSettings, null, new StubCommitter(), registry, null, null);
+    }
+
+    /**
      * An IndexingExecutionEngine that always returns the same pre-built writer.
      */
     static class FixedWriterEngine extends StubIndexingExecutionEngine {
@@ -320,7 +355,7 @@ final class CompositeTestHelper {
         public void sync() {}
 
         @Override
-        public void close() {
+        public void close() throws IOException {
             state = org.opensearch.index.engine.dataformat.WriterState.CLOSED;
         }
 
@@ -460,7 +495,9 @@ final class CompositeTestHelper {
         volatile WriteResult resultToReturn = new WriteResult.Success(1, 1, 1);
         volatile IOException flushFailure;
         volatile IOException rollbackFailure;
+        volatile IOException closeFailure;
         volatile boolean rollbackCalled;
+        volatile boolean closeCalled;
         final AtomicInteger addDocCallCount = new AtomicInteger();
         // Models a Lucene-style strategy by default: rollback success → RETIRED_FLUSHABLE.
         // Tests that want Parquet-style "stay ACTIVE" semantics can flip this flag.
@@ -528,7 +565,9 @@ final class CompositeTestHelper {
         public void updateMappingVersion(long newVersion) {}
 
         @Override
-        public void close() {
+        public void close() throws IOException {
+            closeCalled = true;
+            if (closeFailure != null) throw closeFailure;
             state = org.opensearch.index.engine.dataformat.WriterState.CLOSED;
         }
     }
@@ -539,6 +578,7 @@ final class CompositeTestHelper {
         private final AtomicLong writerGen = new AtomicLong();
         private final List<FailableWriter> createdWriters = new ArrayList<>();
         private volatile Supplier<WriteResult> defaultWriteResultSupplier;
+        volatile RuntimeException createWriterFailure;
 
         FailableEngine(String name) {
             this.dataFormat = new DataFormat() {
@@ -569,6 +609,7 @@ final class CompositeTestHelper {
 
         @Override
         public Writer<DocumentInput<?>> createWriter(WriterConfig config) {
+            if (createWriterFailure != null) throw createWriterFailure;
             FailableWriter w = new FailableWriter(dataFormat);
             if (defaultWriteResultSupplier != null) w.setResultToReturn(defaultWriteResultSupplier.get());
             createdWriters.add(w);

--- a/sandbox/plugins/composite-engine/src/test/java/org/opensearch/composite/CompositeWriterFailureTests.java
+++ b/sandbox/plugins/composite-engine/src/test/java/org/opensearch/composite/CompositeWriterFailureTests.java
@@ -8,16 +8,25 @@
 
 package org.opensearch.composite;
 
+import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.store.LockObtainFailedException;
+import org.opensearch.be.lucene.LuceneDataFormat;
+import org.opensearch.be.lucene.index.LuceneWriter;
 import org.opensearch.index.engine.dataformat.DataFormat;
 import org.opensearch.index.engine.dataformat.DocumentInput;
+import org.opensearch.index.engine.dataformat.IndexingExecutionEngine;
 import org.opensearch.index.engine.dataformat.WriteResult;
+import org.opensearch.index.engine.dataformat.Writer;
 import org.opensearch.index.engine.dataformat.WriterConfig;
 import org.opensearch.index.engine.dataformat.WriterState;
 import org.opensearch.index.engine.dataformat.stub.MockDocumentInput;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Unit tests for {@link CompositeWriter} failure handling: primary/secondary write failures,
@@ -183,6 +192,88 @@ public class CompositeWriterFailureTests extends OpenSearchTestCase {
         assertEquals(WriterState.RETIRED_FLUSHABLE, writer.state());
         writer.close();
         assertEquals(WriterState.CLOSED, writer.state());
+    }
+
+    /**
+     * Reproduces the production LockObtainFailedException scenario:
+     *
+     * 1. CompositeWriter is created — Lucene (secondary) acquires write.lock via NativeFSLockFactory,
+     *    adding the lock path to Lucene's static LOCK_HELD set
+     * 2. During indexing, a write failure triggers writer retirement → CompositeWriter.close()
+     * 3. If primary.close() throws (e.g. Parquet I/O error), the old sequential close skips
+     *    secondary writers — Lucene's lock path stays in LOCK_HELD
+     * 4. Engine fails, shard re-initializes on same node (same JVM). writerGenerationCounter
+     *    re-initializes from maxGenFromCommit. Since the leaked writer's generation was never
+     *    committed, the counter produces the same generation → same path →
+     *    LockObtainFailedException: "Lock held by this virtual machine"
+     *
+     * The fix uses IOUtils.close() which closes ALL writers (aggregating exceptions), ensuring
+     * LuceneWriter.close() → indexWriter.rollback() → NativeFSLock.close() → LOCK_HELD.remove()
+     * always runs regardless of whether other writers throw on close.
+     */
+    public void testPrimaryCloseFailureLockLeak() throws IOException {
+        Path baseDir = createTempDir();
+        long generation = 42L;
+        Set<LuceneWriter> registry = ConcurrentHashMap.newKeySet();
+        LuceneDataFormat luceneFormat = new LuceneDataFormat();
+
+        // First, prove the failure mode
+        LuceneWriter leakedWriter = new LuceneWriter(generation, 0L, luceneFormat, baseDir, null, Codec.getDefault(), null, registry);
+        LockObtainFailedException lockError = expectThrows(
+            LockObtainFailedException.class,
+            () -> new LuceneWriter(generation, 0L, luceneFormat, baseDir, null, Codec.getDefault(), null, registry)
+        );
+        assertThat(lockError.getMessage(), org.hamcrest.Matchers.containsString("Lock held by this virtual machine"));
+        leakedWriter.close();
+
+        // Wire: primary throws on close, Lucene as secondary (real lock)
+        DataFormat primaryFormat = CompositeTestHelper.stubFormat("parquet", 1, Set.of());
+        IndexingExecutionEngine<?, ?> throwingPrimaryEngine = new CompositeTestHelper.StubIndexingExecutionEngine(primaryFormat) {
+            @Override
+            public Writer<DocumentInput<?>> createWriter(WriterConfig config) {
+                return new CompositeTestHelper.StubWriter(getDataFormat()) {
+                    @Override
+                    public void close() throws IOException {
+                        throw new IOException("primary close failed");
+                    }
+                };
+            }
+        };
+
+        IndexingExecutionEngine<?, ?> luceneSecondaryEngine = new CompositeTestHelper.StubIndexingExecutionEngine(luceneFormat) {
+            @SuppressWarnings("unchecked")
+            @Override
+            public Writer<DocumentInput<?>> createWriter(WriterConfig config) {
+                try {
+                    return (Writer<DocumentInput<?>>) (Writer<?>) new LuceneWriter(
+                        config.writerGeneration(),
+                        0L,
+                        luceneFormat,
+                        baseDir,
+                        null,
+                        Codec.getDefault(),
+                        null,
+                        registry
+                    );
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        };
+
+        CompositeIndexingExecutionEngine engine = CompositeTestHelper.createStubEngineWithDelegates(
+            throwingPrimaryEngine,
+            luceneSecondaryEngine
+        );
+
+        CompositeWriter writer = new CompositeWriter(engine, new WriterConfig(generation));
+        // close() — primary throws, but IOUtils.close ensures secondary Lucene writer is still closed
+        expectThrows(IOException.class, writer::close);
+
+        // Simulate engine restart reusing same generation.
+        // Without the fix, this throws LockObtainFailedException.
+        LuceneWriter retryWriter = new LuceneWriter(generation, 0L, luceneFormat, baseDir, null, Codec.getDefault(), null, registry);
+        retryWriter.close();
     }
 
     private CompositeDocumentInput createDocumentInput() {


### PR DESCRIPTION
## Summary
- Fix `CompositeWriter` constructor to close already-created writers when secondary `createWriter()` fails, preventing Lucene file lock leaks into the JVM-level `LOCK_HELD` set
- Fix `CompositeWriter.close()` to use `IOUtils.close()` ensuring all writers are closed even if one throws
- Add tests reproducing the exact production `LockObtainFailedException: Lock held by this virtual machine` error

## Root Cause

`NativeFSLockFactory` maintains a static `Set<String> LOCK_HELD` that tracks lock file paths per-JVM. When a `LuceneWriter` is created but never closed:

1. Engine fails (e.g. flush failure triggers `failEngine`)
2. Shard re-initializes on same node (same JVM)
3. `LuceneIndexingExecutionEngine` constructor deletes the `lucene/` directory physically
4. `writerGenerationCounter` re-initializes from `maxGenFromCommit` in the last committed snapshot
5. Since the leaked writer's generation was never committed, the counter produces the same generation → same path → `LockObtainFailedException`

## Test plan
- [x] `testSecondaryCreateWriterFailureReleasesLuceneLock` — proves real `LockObtainFailedException` when lock leaks, then verifies fix releases it
- [x] `testPrimaryCloseFailureStillReleasesSecondaryLuceneLock` — proves `IOUtils.close` ensures secondary Lucene lock is released even when primary close throws
- [x] All existing `CompositeWriter*` tests pass
- [x] Full `Composite*IT` integration test suite passes