### PR TITLE
Fix divide-by-zero and mod-by-zero crashing the streaming fragment

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionAnalyticsBackendPlugin.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionAnalyticsBackendPlugin.java
@@ -44,7 +44,6 @@ import org.opensearch.analytics.spi.ScalarFunction;
 import org.opensearch.analytics.spi.ScalarFunctionAdapter;
 import org.opensearch.analytics.spi.ScanCapability;
 import org.opensearch.analytics.spi.SearchExecEngineProvider;
-import org.opensearch.analytics.spi.StdOperatorRewriteAdapter;
 import org.opensearch.analytics.spi.WindowCapability;
 import org.opensearch.analytics.spi.WindowFunction;
 import org.opensearch.analytics.spi.WindowFunctionAdapter;
@@ -646,7 +645,7 @@ public class DataFusionAnalyticsBackendPlugin implements AnalyticsSearchBackendP
                     Map.entry(ScalarFunction.DAYOFYEAR, dayOfYear),
                     Map.entry(ScalarFunction.DAY_OF_WEEK, dayOfWeek),
                     Map.entry(ScalarFunction.DAY_OF_YEAR, dayOfYear),
-                    Map.entry(ScalarFunction.DIVIDE, new StdOperatorRewriteAdapter("DIVIDE", SqlStdOperatorTable.DIVIDE)),
+                    Map.entry(ScalarFunction.DIVIDE, new DivideAdapter()),
                     Map.entry(ScalarFunction.E, new EConstantAdapter()),
                     Map.entry(ScalarFunction.EARLIEST, new EarliestLatestAdapter.EarliestAdapter()),
                     // Math functions whose substrait yaml impls are fp64-only — wrap integer/float
@@ -683,7 +682,7 @@ public class DataFusionAnalyticsBackendPlugin implements AnalyticsSearchBackendP
                     Map.entry(ScalarFunction.MINUTE, minute),
                     Map.entry(ScalarFunction.MINUTE_OF_HOUR, minute),
                     Map.entry(ScalarFunction.MINUS, new MinusAdapter()),
-                    Map.entry(ScalarFunction.MOD, new StdOperatorRewriteAdapter("MOD", SqlStdOperatorTable.MOD)),
+                    Map.entry(ScalarFunction.MOD, new ModAdapter()),
                     Map.entry(ScalarFunction.MONTH, month),
                     Map.entry(ScalarFunction.MONTH_OF_YEAR, month),
                     Map.entry(ScalarFunction.NUMBER_TO_STRING, new ToStringFunctionAdapter()),

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DivideAdapterTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DivideAdapterTests.java
@@ -26,12 +26,9 @@ import java.math.BigDecimal;
 import java.util.List;
 
 /**
- * Unit tests for {@link DivideAdapter}. PPL semantics require divide-by-zero
- * to return NULL, but substrait's {@code on_division_by_zero} option can't be
- * threaded through isthmus's emission, so the adapter wraps each
- * {@code DIVIDE(x, y)} in {@code CASE WHEN y = 0 THEN NULL ELSE DIVIDE(x, y) END}.
- * For known non-zero literal divisors the wrap is skipped so the substrait
- * shape stays the same as before this adapter existed.
+ * Tests for {@link DivideAdapter}. Wraps {@code DIVIDE(x, y)} in
+ * {@code CASE WHEN y = 0 THEN NULL ELSE DIVIDE(x, y) END} so divide-by-zero
+ * yields NULL. Skips the wrap for known non-zero literal divisors.
  */
 public class DivideAdapterTests extends OpenSearchTestCase {
 
@@ -53,12 +50,7 @@ public class DivideAdapterTests extends OpenSearchTestCase {
         return (RexCall) rexBuilder.makeCall(retType, SqlStdOperatorTable.DIVIDE, List.of(lhs, rhs));
     }
 
-    /**
-     * Regression for engine-arrow-divzero q1: literal-zero integer divisor must
-     * be wrapped in {@code CASE WHEN rhs = 0 THEN NULL ELSE DIVIDE(...) END}
-     * so DataFusion's runtime sees NULL instead of raising
-     * {@code Arrow error: Divide by zero error}.
-     */
+    /** Literal-zero INTEGER divisor → CASE wrap. */
     public void testLiteralZeroIntegerDivisorWrapsInCase() {
         RexNode lhs = rexBuilder.makeExactLiteral(BigDecimal.valueOf(22), typeFactory.createSqlType(SqlTypeName.INTEGER));
         RexNode rhs = rexBuilder.makeExactLiteral(BigDecimal.ZERO, typeFactory.createSqlType(SqlTypeName.INTEGER));
@@ -66,16 +58,13 @@ public class DivideAdapterTests extends OpenSearchTestCase {
 
         RexNode adapted = new DivideAdapter().adapt(original, List.of(), cluster);
 
-        assertTrue("adapted node must be a RexCall (the CASE wrap)", adapted instanceof RexCall);
+        assertTrue(adapted instanceof RexCall);
         RexCall caseCall = (RexCall) adapted;
-        assertEquals("wrap must be a CASE node", SqlKind.CASE, caseCall.getKind());
-        assertTrue("CASE result must be nullable so NULL fits", caseCall.getType().isNullable());
+        assertEquals(SqlKind.CASE, caseCall.getKind());
+        assertTrue(caseCall.getType().isNullable());
     }
 
-    /**
-     * Regression for engine-arrow-divzero q3: literal-zero double divisor (the
-     * {@code 22.0/0.0} sub-shape) must also be wrapped in CASE.
-     */
+    /** Literal-zero DOUBLE divisor → CASE wrap. */
     public void testLiteralZeroDoubleDivisorWrapsInCase() {
         RexNode lhs = rexBuilder.makeApproxLiteral(BigDecimal.valueOf(22.0), typeFactory.createSqlType(SqlTypeName.DOUBLE));
         RexNode rhs = rexBuilder.makeApproxLiteral(BigDecimal.ZERO, typeFactory.createSqlType(SqlTypeName.DOUBLE));
@@ -87,10 +76,7 @@ public class DivideAdapterTests extends OpenSearchTestCase {
         assertEquals(SqlKind.CASE, ((RexCall) adapted).getKind());
     }
 
-    /**
-     * Non-zero literal divisor → no CASE wrap. Keeps substrait shape stable for
-     * the {@code x / 5} pattern that's the common case in user queries.
-     */
+    /** Non-zero literal divisor → bare DIVIDE (skip the wrap). */
     public void testNonZeroLiteralDivisorSkipsCaseWrap() {
         RexNode lhs = rexBuilder.makeExactLiteral(BigDecimal.valueOf(22), typeFactory.createSqlType(SqlTypeName.INTEGER));
         RexNode rhs = rexBuilder.makeExactLiteral(BigDecimal.valueOf(5), typeFactory.createSqlType(SqlTypeName.INTEGER));
@@ -99,17 +85,10 @@ public class DivideAdapterTests extends OpenSearchTestCase {
         RexNode adapted = new DivideAdapter().adapt(original, List.of(), cluster);
 
         assertTrue(adapted instanceof RexCall);
-        assertEquals(
-            "non-zero literal divisor must skip the CASE wrap and emit bare DIVIDE",
-            SqlKind.DIVIDE,
-            ((RexCall) adapted).getKind()
-        );
+        assertEquals(SqlKind.DIVIDE, ((RexCall) adapted).getKind());
     }
 
-    /**
-     * Column-ref divisor (runtime-unknown value) gets the CASE wrap because we
-     * can't tell at plan time whether any row's value is zero.
-     */
+    /** Column-ref divisor → CASE wrap (zero unknown until runtime). */
     public void testColumnRefDivisorWrapsInCase() {
         RelDataType intNullable = typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.INTEGER), true);
         RexNode lhs = rexBuilder.makeExactLiteral(BigDecimal.valueOf(22), typeFactory.createSqlType(SqlTypeName.INTEGER));
@@ -119,7 +98,6 @@ public class DivideAdapterTests extends OpenSearchTestCase {
         RexNode adapted = new DivideAdapter().adapt(original, List.of(), cluster);
 
         assertTrue(adapted instanceof RexCall);
-        assertEquals("column-ref divisor must get the CASE wrap", SqlKind.CASE, ((RexCall) adapted).getKind());
+        assertEquals(SqlKind.CASE, ((RexCall) adapted).getKind());
     }
-
 }

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DivideAdapterTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DivideAdapterTests.java
@@ -1,0 +1,125 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion;
+
+import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.hep.HepPlanner;
+import org.apache.calcite.plan.hep.HepProgramBuilder;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+/**
+ * Unit tests for {@link DivideAdapter}. PPL semantics require divide-by-zero
+ * to return NULL, but substrait's {@code on_division_by_zero} option can't be
+ * threaded through isthmus's emission, so the adapter wraps each
+ * {@code DIVIDE(x, y)} in {@code CASE WHEN y = 0 THEN NULL ELSE DIVIDE(x, y) END}.
+ * For known non-zero literal divisors the wrap is skipped so the substrait
+ * shape stays the same as before this adapter existed.
+ */
+public class DivideAdapterTests extends OpenSearchTestCase {
+
+    private RelDataTypeFactory typeFactory;
+    private RexBuilder rexBuilder;
+    private RelOptCluster cluster;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        typeFactory = new JavaTypeFactoryImpl();
+        rexBuilder = new RexBuilder(typeFactory);
+        HepPlanner planner = new HepPlanner(new HepProgramBuilder().build());
+        cluster = RelOptCluster.create(planner, rexBuilder);
+    }
+
+    private RexCall buildDivide(RexNode lhs, RexNode rhs) {
+        RelDataType retType = typeFactory.createTypeWithNullability(lhs.getType(), true);
+        return (RexCall) rexBuilder.makeCall(retType, SqlStdOperatorTable.DIVIDE, List.of(lhs, rhs));
+    }
+
+    /**
+     * Regression for engine-arrow-divzero q1: literal-zero integer divisor must
+     * be wrapped in {@code CASE WHEN rhs = 0 THEN NULL ELSE DIVIDE(...) END}
+     * so DataFusion's runtime sees NULL instead of raising
+     * {@code Arrow error: Divide by zero error}.
+     */
+    public void testLiteralZeroIntegerDivisorWrapsInCase() {
+        RexNode lhs = rexBuilder.makeExactLiteral(BigDecimal.valueOf(22), typeFactory.createSqlType(SqlTypeName.INTEGER));
+        RexNode rhs = rexBuilder.makeExactLiteral(BigDecimal.ZERO, typeFactory.createSqlType(SqlTypeName.INTEGER));
+        RexCall original = buildDivide(lhs, rhs);
+
+        RexNode adapted = new DivideAdapter().adapt(original, List.of(), cluster);
+
+        assertTrue("adapted node must be a RexCall (the CASE wrap)", adapted instanceof RexCall);
+        RexCall caseCall = (RexCall) adapted;
+        assertEquals("wrap must be a CASE node", SqlKind.CASE, caseCall.getKind());
+        assertTrue("CASE result must be nullable so NULL fits", caseCall.getType().isNullable());
+    }
+
+    /**
+     * Regression for engine-arrow-divzero q3: literal-zero double divisor (the
+     * {@code 22.0/0.0} sub-shape) must also be wrapped in CASE.
+     */
+    public void testLiteralZeroDoubleDivisorWrapsInCase() {
+        RexNode lhs = rexBuilder.makeApproxLiteral(BigDecimal.valueOf(22.0), typeFactory.createSqlType(SqlTypeName.DOUBLE));
+        RexNode rhs = rexBuilder.makeApproxLiteral(BigDecimal.ZERO, typeFactory.createSqlType(SqlTypeName.DOUBLE));
+        RexCall original = buildDivide(lhs, rhs);
+
+        RexNode adapted = new DivideAdapter().adapt(original, List.of(), cluster);
+
+        assertTrue(adapted instanceof RexCall);
+        assertEquals(SqlKind.CASE, ((RexCall) adapted).getKind());
+    }
+
+    /**
+     * Non-zero literal divisor → no CASE wrap. Keeps substrait shape stable for
+     * the {@code x / 5} pattern that's the common case in user queries.
+     */
+    public void testNonZeroLiteralDivisorSkipsCaseWrap() {
+        RexNode lhs = rexBuilder.makeExactLiteral(BigDecimal.valueOf(22), typeFactory.createSqlType(SqlTypeName.INTEGER));
+        RexNode rhs = rexBuilder.makeExactLiteral(BigDecimal.valueOf(5), typeFactory.createSqlType(SqlTypeName.INTEGER));
+        RexCall original = buildDivide(lhs, rhs);
+
+        RexNode adapted = new DivideAdapter().adapt(original, List.of(), cluster);
+
+        assertTrue(adapted instanceof RexCall);
+        assertEquals(
+            "non-zero literal divisor must skip the CASE wrap and emit bare DIVIDE",
+            SqlKind.DIVIDE,
+            ((RexCall) adapted).getKind()
+        );
+    }
+
+    /**
+     * Column-ref divisor (runtime-unknown value) gets the CASE wrap because we
+     * can't tell at plan time whether any row's value is zero.
+     */
+    public void testColumnRefDivisorWrapsInCase() {
+        RelDataType intNullable = typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.INTEGER), true);
+        RexNode lhs = rexBuilder.makeExactLiteral(BigDecimal.valueOf(22), typeFactory.createSqlType(SqlTypeName.INTEGER));
+        RexNode rhs = rexBuilder.makeInputRef(intNullable, 0);
+        RexCall original = buildDivide(lhs, rhs);
+
+        RexNode adapted = new DivideAdapter().adapt(original, List.of(), cluster);
+
+        assertTrue(adapted instanceof RexCall);
+        assertEquals("column-ref divisor must get the CASE wrap", SqlKind.CASE, ((RexCall) adapted).getKind());
+    }
+
+}

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/ModAdapterTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/ModAdapterTests.java
@@ -1,0 +1,136 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion;
+
+import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.hep.HepPlanner;
+import org.apache.calcite.plan.hep.HepProgramBuilder;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+/**
+ * Unit tests for {@link ModAdapter}. PPL semantics require {@code mod(x, 0)}
+ * to return NULL; the adapter wraps every {@code MOD(x, y)} in
+ * {@code CASE WHEN y = 0 THEN NULL ELSE MOD(x, y) END} so DataFusion's runtime
+ * never raises {@code Arrow error: Divide by zero error}.
+ */
+public class ModAdapterTests extends OpenSearchTestCase {
+
+    private RelDataTypeFactory typeFactory;
+    private RexBuilder rexBuilder;
+    private RelOptCluster cluster;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        typeFactory = new JavaTypeFactoryImpl();
+        rexBuilder = new RexBuilder(typeFactory);
+        HepPlanner planner = new HepPlanner(new HepProgramBuilder().build());
+        cluster = RelOptCluster.create(planner, rexBuilder);
+    }
+
+    private RexCall buildMod(RexNode lhs, RexNode rhs) {
+        RelDataType retType = typeFactory.createTypeWithNullability(lhs.getType(), true);
+        return (RexCall) rexBuilder.makeCall(retType, SqlStdOperatorTable.MOD, List.of(lhs, rhs));
+    }
+
+    /**
+     * Regression for engine-arrow-divzero q5: literal-zero divisor must wrap
+     * the MOD call in {@code CASE WHEN rhs = 0 THEN NULL ELSE MOD(...) END}
+     * so DataFusion's Arrow runtime returns NULL instead of crashing the
+     * streaming fragment.
+     */
+    public void testLiteralZeroDivisorWrapsInCase() {
+        RexNode lhs = rexBuilder.makeExactLiteral(BigDecimal.valueOf(5), typeFactory.createSqlType(SqlTypeName.INTEGER));
+        RexNode rhs = rexBuilder.makeExactLiteral(BigDecimal.ZERO, typeFactory.createSqlType(SqlTypeName.INTEGER));
+        RexCall original = buildMod(lhs, rhs);
+
+        RexNode adapted = new ModAdapter().adapt(original, List.of(), cluster);
+
+        assertTrue("adapted node must be a RexCall (the CASE wrap)", adapted instanceof RexCall);
+        RexCall caseCall = (RexCall) adapted;
+        assertEquals("wrap must be a CASE node", SqlKind.CASE, caseCall.getKind());
+        assertTrue("CASE result must be nullable so NULL fits", caseCall.getType().isNullable());
+    }
+
+    /**
+     * Non-zero literal divisor still gets the CASE wrap (ModAdapter wraps
+     * unconditionally — unlike DivideAdapter which short-circuits non-zero
+     * literals — because mod's substrait emit also lacks the
+     * {@code on_domain_error: NULL} option threading).
+     */
+    public void testNonZeroLiteralDivisorAlsoWrapsInCase() {
+        RexNode lhs = rexBuilder.makeExactLiteral(BigDecimal.valueOf(5), typeFactory.createSqlType(SqlTypeName.INTEGER));
+        RexNode rhs = rexBuilder.makeExactLiteral(BigDecimal.valueOf(3), typeFactory.createSqlType(SqlTypeName.INTEGER));
+        RexCall original = buildMod(lhs, rhs);
+
+        RexNode adapted = new ModAdapter().adapt(original, List.of(), cluster);
+
+        assertTrue(adapted instanceof RexCall);
+        assertEquals(SqlKind.CASE, ((RexCall) adapted).getKind());
+    }
+
+    /**
+     * Mixed-numeric operands (e.g. {@code FLOAT % INTEGER}) widen to the higher
+     * rank type before MOD emission so substrait's signature matcher can bind
+     * the call. Substrait's stock {@code modulus} extension is integer-only;
+     * {@code opensearch_arithmetic_overloads.yaml} supplies the fp signatures.
+     */
+    public void testMixedNumericOperandsWidenToCommonType() {
+        RexNode lhs = rexBuilder.makeApproxLiteral(BigDecimal.valueOf(5.5), typeFactory.createSqlType(SqlTypeName.FLOAT));
+        RexNode rhs = rexBuilder.makeExactLiteral(BigDecimal.valueOf(2), typeFactory.createSqlType(SqlTypeName.INTEGER));
+        RexCall original = buildMod(lhs, rhs);
+
+        RexNode adapted = new ModAdapter().adapt(original, List.of(), cluster);
+
+        assertTrue(adapted instanceof RexCall);
+        // CASE(EQUALS(rhs, 0), null, MOD(widenedLhs, widenedRhs))
+        RexCall caseCall = (RexCall) adapted;
+        assertEquals(SqlKind.CASE, caseCall.getKind());
+        // The MOD branch is the third operand of CASE (then-arm structure: cond, null, expr).
+        RexNode modBranch = caseCall.getOperands().get(2);
+        // It may be wrapped in a CAST for nullability, but the inner call must be MOD.
+        RexNode innerMod = modBranch instanceof RexCall mc && mc.getKind() != SqlKind.MOD ? mc.getOperands().get(0) : modBranch;
+        assertTrue(innerMod instanceof RexCall);
+        assertEquals("mixed-type MOD must use SqlStdOperatorTable.MOD after widen", SqlKind.MOD, ((RexCall) innerMod).getKind());
+        // The widened operands inside MOD must share a type.
+        RexCall innerModCall = (RexCall) innerMod;
+        assertEquals(
+            "after widen, lhs and rhs must share a numeric type",
+            innerModCall.getOperands().get(0).getType().getSqlTypeName(),
+            innerModCall.getOperands().get(1).getType().getSqlTypeName()
+        );
+    }
+
+    /**
+     * Column-ref divisor wraps in CASE so the runtime per-row zero-check fires.
+     */
+    public void testColumnRefDivisorWrapsInCase() {
+        RelDataType intNullable = typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.INTEGER), true);
+        RexNode lhs = rexBuilder.makeExactLiteral(BigDecimal.valueOf(5), typeFactory.createSqlType(SqlTypeName.INTEGER));
+        RexNode rhs = rexBuilder.makeInputRef(intNullable, 0);
+        RexCall original = buildMod(lhs, rhs);
+
+        RexNode adapted = new ModAdapter().adapt(original, List.of(), cluster);
+
+        assertTrue(adapted instanceof RexCall);
+        assertEquals(SqlKind.CASE, ((RexCall) adapted).getKind());
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/ModAdapterTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/ModAdapterTests.java
@@ -26,10 +26,8 @@ import java.math.BigDecimal;
 import java.util.List;
 
 /**
- * Unit tests for {@link ModAdapter}. PPL semantics require {@code mod(x, 0)}
- * to return NULL; the adapter wraps every {@code MOD(x, y)} in
- * {@code CASE WHEN y = 0 THEN NULL ELSE MOD(x, y) END} so DataFusion's runtime
- * never raises {@code Arrow error: Divide by zero error}.
+ * Tests for {@link ModAdapter}. Wraps every {@code MOD(x, y)} in
+ * {@code CASE WHEN y = 0 THEN NULL ELSE MOD(x, y) END} so {@code mod(x, 0)} yields NULL.
  */
 public class ModAdapterTests extends OpenSearchTestCase {
 
@@ -51,12 +49,7 @@ public class ModAdapterTests extends OpenSearchTestCase {
         return (RexCall) rexBuilder.makeCall(retType, SqlStdOperatorTable.MOD, List.of(lhs, rhs));
     }
 
-    /**
-     * Regression for engine-arrow-divzero q5: literal-zero divisor must wrap
-     * the MOD call in {@code CASE WHEN rhs = 0 THEN NULL ELSE MOD(...) END}
-     * so DataFusion's Arrow runtime returns NULL instead of crashing the
-     * streaming fragment.
-     */
+    /** Literal-zero divisor → CASE wrap. */
     public void testLiteralZeroDivisorWrapsInCase() {
         RexNode lhs = rexBuilder.makeExactLiteral(BigDecimal.valueOf(5), typeFactory.createSqlType(SqlTypeName.INTEGER));
         RexNode rhs = rexBuilder.makeExactLiteral(BigDecimal.ZERO, typeFactory.createSqlType(SqlTypeName.INTEGER));
@@ -64,18 +57,13 @@ public class ModAdapterTests extends OpenSearchTestCase {
 
         RexNode adapted = new ModAdapter().adapt(original, List.of(), cluster);
 
-        assertTrue("adapted node must be a RexCall (the CASE wrap)", adapted instanceof RexCall);
+        assertTrue(adapted instanceof RexCall);
         RexCall caseCall = (RexCall) adapted;
-        assertEquals("wrap must be a CASE node", SqlKind.CASE, caseCall.getKind());
-        assertTrue("CASE result must be nullable so NULL fits", caseCall.getType().isNullable());
+        assertEquals(SqlKind.CASE, caseCall.getKind());
+        assertTrue(caseCall.getType().isNullable());
     }
 
-    /**
-     * Non-zero literal divisor still gets the CASE wrap (ModAdapter wraps
-     * unconditionally — unlike DivideAdapter which short-circuits non-zero
-     * literals — because mod's substrait emit also lacks the
-     * {@code on_domain_error: NULL} option threading).
-     */
+    /** Non-zero literal divisor still gets the CASE wrap (unconditional, unlike DivideAdapter). */
     public void testNonZeroLiteralDivisorAlsoWrapsInCase() {
         RexNode lhs = rexBuilder.makeExactLiteral(BigDecimal.valueOf(5), typeFactory.createSqlType(SqlTypeName.INTEGER));
         RexNode rhs = rexBuilder.makeExactLiteral(BigDecimal.valueOf(3), typeFactory.createSqlType(SqlTypeName.INTEGER));
@@ -87,12 +75,7 @@ public class ModAdapterTests extends OpenSearchTestCase {
         assertEquals(SqlKind.CASE, ((RexCall) adapted).getKind());
     }
 
-    /**
-     * Mixed-numeric operands (e.g. {@code FLOAT % INTEGER}) widen to the higher
-     * rank type before MOD emission so substrait's signature matcher can bind
-     * the call. Substrait's stock {@code modulus} extension is integer-only;
-     * {@code opensearch_arithmetic_overloads.yaml} supplies the fp signatures.
-     */
+    /** Mixed-numeric operands (e.g. FLOAT % INTEGER) widen to a common type before MOD. */
     public void testMixedNumericOperandsWidenToCommonType() {
         RexNode lhs = rexBuilder.makeApproxLiteral(BigDecimal.valueOf(5.5), typeFactory.createSqlType(SqlTypeName.FLOAT));
         RexNode rhs = rexBuilder.makeExactLiteral(BigDecimal.valueOf(2), typeFactory.createSqlType(SqlTypeName.INTEGER));
@@ -101,27 +84,21 @@ public class ModAdapterTests extends OpenSearchTestCase {
         RexNode adapted = new ModAdapter().adapt(original, List.of(), cluster);
 
         assertTrue(adapted instanceof RexCall);
-        // CASE(EQUALS(rhs, 0), null, MOD(widenedLhs, widenedRhs))
         RexCall caseCall = (RexCall) adapted;
         assertEquals(SqlKind.CASE, caseCall.getKind());
-        // The MOD branch is the third operand of CASE (then-arm structure: cond, null, expr).
+        // CASE then-arm is the third operand; may be wrapped in a CAST for nullability.
         RexNode modBranch = caseCall.getOperands().get(2);
-        // It may be wrapped in a CAST for nullability, but the inner call must be MOD.
         RexNode innerMod = modBranch instanceof RexCall mc && mc.getKind() != SqlKind.MOD ? mc.getOperands().get(0) : modBranch;
         assertTrue(innerMod instanceof RexCall);
-        assertEquals("mixed-type MOD must use SqlStdOperatorTable.MOD after widen", SqlKind.MOD, ((RexCall) innerMod).getKind());
-        // The widened operands inside MOD must share a type.
         RexCall innerModCall = (RexCall) innerMod;
+        assertEquals(SqlKind.MOD, innerModCall.getKind());
         assertEquals(
-            "after widen, lhs and rhs must share a numeric type",
             innerModCall.getOperands().get(0).getType().getSqlTypeName(),
             innerModCall.getOperands().get(1).getType().getSqlTypeName()
         );
     }
 
-    /**
-     * Column-ref divisor wraps in CASE so the runtime per-row zero-check fires.
-     */
+    /** Column-ref divisor → CASE wrap (zero unknown until runtime). */
     public void testColumnRefDivisorWrapsInCase() {
         RelDataType intNullable = typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.INTEGER), true);
         RexNode lhs = rexBuilder.makeExactLiteral(BigDecimal.valueOf(5), typeFactory.createSqlType(SqlTypeName.INTEGER));

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/OperatorCommandIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/OperatorCommandIT.java
@@ -237,6 +237,22 @@ public class OperatorCommandIT extends AnalyticsRestTestCase {
         );
     }
 
+    /** Literal-literal {@code 22 / 0} → null. */
+    public void testArithmeticDivideByZeroLiteral() throws IOException {
+        assertSingleRowField(
+            "source=" + DATASET.indexName + " | where key = 'key00' | eval q = 22 / 0 | fields q",
+            null
+        );
+    }
+
+    /** Literal-literal {@code mod(5, 0)} → null. */
+    public void testArithmeticModByZeroLiteral() throws IOException {
+        assertSingleRowField(
+            "source=" + DATASET.indexName + " | where key = 'key00' | eval r = mod(5, 0) | fields r",
+            null
+        );
+    }
+
     // ── Project-side comparisons: eval boolean result, filter by it ───────────
 
     public void testEqualsInEvalProjection() throws IOException {


### PR DESCRIPTION
### Description

`DataFusionAnalyticsBackendPlugin` registered `StdOperatorRewriteAdapter` for `DIVIDE` and `MOD`, which only renamed the operator. DataFusion's Arrow runtime then evaluated `x / 0` directly and raised `Arrow error: Divide by zero error`, crashing the streaming fragment — but PPL semantics require divide-by-zero and mod-by-zero to return NULL.

`DivideAdapter` and `ModAdapter` were already implemented to wrap each call in `CASE WHEN divisor = 0 THEN NULL ELSE DIVIDE/MOD(...) END` but weren't wired into the registry. Swapped the two registry entries to use them. `DivideAdapter` short-circuits the wrap for known non-zero literal divisors so `x / 5` keeps the same substrait shape; `ModAdapter` wraps unconditionally.

### Query shapes fixed

- `eval q = 22 / 0` (literal-literal) — returns null
- `eval r = mod(5, 0)` (literal-literal) — returns null
- `eval q = num0 / 0` (column / literal-zero) — returns null
- `eval r = num0 % 0` (column / literal-zero) — returns null
- `eval q = num0 / num1` (column / column) — non-zero divisor, no regression
- `eval r = num0 % 2` (mixed-numeric MOD) — fp widen path preserved

### Tests

- Unit: `DivideAdapterTests`, `ModAdapterTests` covering literal-zero, non-zero literal short-circuit, mixed-numeric widen, column-ref divisor.
- IT: `OperatorCommandIT.testArithmeticDivideByZeroLiteral`, `testArithmeticModByZeroLiteral` exercising the full PPL → Substrait → DataFusion path.

### Check List

- [x] Functionality includes testing.
- [ ] API changes companion pull request created, if applicable.
- [ ] Public documentation issue/PR created, if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.