### PR TITLE
feat: read oversampling factor from node opensearch.yml

### DIFF
--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/DefaultPlanExecutor.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/DefaultPlanExecutor.java
@@ -39,6 +39,7 @@ import org.opensearch.analytics.planner.dag.FragmentConversionDriver;
 import org.opensearch.analytics.planner.dag.PlanAlternativeSelector;
 import org.opensearch.analytics.planner.dag.PlanForker;
 import org.opensearch.analytics.planner.dag.QueryDAG;
+import org.opensearch.analytics.settings.AnalyticsApproximationSettings;
 import org.opensearch.analytics.settings.AnalyticsQuerySettings;
 import org.opensearch.analytics.stats.AnalyticsStatsCollector;
 import org.opensearch.arrow.allocator.AllocationRejection;
@@ -95,6 +96,7 @@ public class DefaultPlanExecutor extends HandledTransportAction<AnalyticsQueryRe
     private volatile int maxConcurrentShardRequestsPerNode;
     private volatile boolean fuseDualViable;
     private volatile boolean preferMetadataDriver;
+    private volatile double oversamplingFactor;
     private final IndexNameExpressionResolver indexNameExpressionResolver;
     private final AnalyticsSearchSlowLog analyticsSearchSlowLog;
 
@@ -150,6 +152,9 @@ public class DefaultPlanExecutor extends HandledTransportAction<AnalyticsQueryRe
         this.preferMetadataDriver = AnalyticsPlugin.PREFER_METADATA_DRIVER.get(clusterService.getSettings());
         clusterService.getClusterSettings()
             .addSettingsUpdateConsumer(AnalyticsPlugin.PREFER_METADATA_DRIVER, v -> preferMetadataDriver = v);
+        this.oversamplingFactor = AnalyticsApproximationSettings.SHARD_BUCKET_OVERSAMPLING_FACTOR.get(clusterService.getSettings());
+        clusterService.getClusterSettings()
+            .addSettingsUpdateConsumer(AnalyticsApproximationSettings.SHARD_BUCKET_OVERSAMPLING_FACTOR, v -> oversamplingFactor = v);
         this.indexNameExpressionResolver = indexNameExpressionResolver;
         this.analyticsSearchSlowLog = analyticsSearchSlowLog;
     }
@@ -227,10 +232,15 @@ public class DefaultPlanExecutor extends HandledTransportAction<AnalyticsQueryRe
         // TODO: remove the null fallback once every front-end (test-ppl-frontend,
         // dsl-query-executor) threads an EngineContextProvider.getContext() snapshot through.
         ClusterState planningState = queryCtx != null ? queryCtx.clusterState() : clusterService.state();
-        RelNode plan = PlannerImpl.createPlan(
-            logicalFragment,
-            new PlannerContext(capabilityRegistry, planningState, indexNameExpressionResolver, false, preferMetadataDriver)
+        PlannerContext plannerContext = new PlannerContext(
+            capabilityRegistry,
+            planningState,
+            indexNameExpressionResolver,
+            false,
+            preferMetadataDriver
         );
+        plannerContext.setOversamplingFactor(oversamplingFactor);
+        RelNode plan = PlannerImpl.createPlan(logicalFragment, plannerContext);
         final String fullPlan = profile ? org.apache.calcite.plan.RelOptUtil.toString(plan) : null;
         QueryDAG dag = DAGBuilder.build(plan, capabilityRegistry, clusterService, indexNameExpressionResolver);
         PlanForker.forkAll(dag, capabilityRegistry);

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/PlannerContext.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/PlannerContext.java
@@ -29,6 +29,7 @@ public class PlannerContext {
     private final OpenSearchDistributionTraitDef distributionTraitDef;
     private final boolean profilingEnabled;
     private final boolean preferMetadataDriver;
+    private double oversamplingFactor;
     private int annotationIdCounter;
     private RuleProfilingListener.PlannerProfile lastProfile;
 
@@ -101,6 +102,14 @@ public class PlannerContext {
 
     public ClusterState getClusterState() {
         return clusterState;
+    }
+
+    public double getOversamplingFactor() {
+        return oversamplingFactor;
+    }
+
+    public void setOversamplingFactor(double oversamplingFactor) {
+        this.oversamplingFactor = oversamplingFactor;
     }
 
     public OpenSearchDistributionTraitDef getDistributionTraitDef() {

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchTopKRewriter.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchTopKRewriter.java
@@ -23,9 +23,7 @@ import org.opensearch.analytics.planner.rel.OpenSearchAggregate;
 import org.opensearch.analytics.planner.rel.OpenSearchExchangeReducer;
 import org.opensearch.analytics.planner.rel.OpenSearchProject;
 import org.opensearch.analytics.planner.rel.OpenSearchSort;
-import org.opensearch.analytics.settings.AnalyticsApproximationSettings;
 import org.opensearch.analytics.spi.AggregateFunction;
-import org.opensearch.common.settings.Settings;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -211,10 +209,7 @@ public final class OpenSearchTopKRewriter {
     }
 
     private static double resolveOversamplingFactor(PlannerContext context) {
-        // TODO: Move to per-index setting once index-pattern/alias resolution is handled.
-        Settings clusterSettings = context.getClusterState().metadata().settings();
-        if (clusterSettings == null) return 0.0;
-        return AnalyticsApproximationSettings.SHARD_BUCKET_OVERSAMPLING_FACTOR.get(clusterSettings);
+        return context.getOversamplingFactor();
     }
 
     private record SortAboveFinal(OpenSearchSort sort, OpenSearchAggregate finalAgg) {

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/TopKRewriterPlanShapeTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/TopKRewriterPlanShapeTests.java
@@ -19,11 +19,8 @@ import org.apache.calcite.rel.logical.LogicalSort;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.util.ImmutableBitSet;
-import org.opensearch.common.settings.Settings;
 
 import java.util.List;
-
-import static org.mockito.Mockito.when;
 
 /**
  * Plan shape tests for the TopK rewriter. Grouped into Detection (skip cases)
@@ -255,8 +252,7 @@ public class TopKRewriterPlanShapeTests extends PlanShapeTestBase {
 
     private PlannerContext contextWithOversampling(double factor) {
         PlannerContext ctx = buildContext("parquet", 2, intFields());
-        Settings clusterSettings = Settings.builder().put("analytics.shard_bucket_oversampling_factor", factor).build();
-        when(ctx.getClusterState().metadata().settings()).thenReturn(clusterSettings);
+        ctx.setOversamplingFactor(factor);
         return ctx;
     }
 }

--- a/sandbox/qa/analytics-engine-rest/build.gradle
+++ b/sandbox/qa/analytics-engine-rest/build.gradle
@@ -121,6 +121,7 @@ integTest {
     exclude '**/CoordinatorReduceMemtableIT.class'
     exclude '**/StreamingCoordinatorReduceIT.class'
     exclude '**/QueryCacheIT.class'
+    exclude '**/YmlOversamplingIT.class'
 
     // Note: parallel forks against the same 2-node testCluster slow the suite down
     // (cluster is the bottleneck, not JVM startup) and cause cross-fork data races
@@ -179,6 +180,24 @@ check.dependsOn(integTestStreaming)
 testClusters.integTestStreaming {
     numberOfNodes = 2
     configureAnalyticsCluster(delegate)
+}
+
+// ── YML oversampling variant: verifies TopK fires from opensearch.yml setting ─
+task integTestYmlOversampling(type: RestIntegTestTask) {
+    description = 'Verifies TopK oversampling works when set via opensearch.yml (node settings)'
+    testClassesDirs = sourceSets.test.output.classesDirs
+    classpath = sourceSets.test.runtimeClasspath
+    filter {
+        includeTestsMatching 'org.opensearch.analytics.qa.YmlOversamplingIT'
+    }
+    systemProperty 'tests.security.manager', 'false'
+}
+check.dependsOn(integTestYmlOversampling)
+
+testClusters.integTestYmlOversampling {
+    numberOfNodes = 2
+    configureAnalyticsCluster(delegate)
+    setting 'analytics.shard_bucket_oversampling_factor', '2.0'
 }
 
 // Run against an external cluster (no testClusters lifecycle):

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/YmlOversamplingIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/YmlOversamplingIT.java
@@ -1,0 +1,77 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.qa;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Verifies that {@code analytics.shard_bucket_oversampling_factor} set via opensearch.yml
+ * (node settings at bootstrap) is picked up by the TopK rewriter without any dynamic
+ * cluster settings API call.
+ *
+ * <p>The test cluster for this IT is configured in build.gradle with:
+ * {@code setting 'analytics.shard_bucket_oversampling_factor', '2.0'}
+ */
+public class YmlOversamplingIT extends AnalyticsRestTestCase {
+
+    private static final String INDEX = "yml_oversampling_test";
+
+    /**
+     * Grouped count + sort + head without any runtime cluster settings call.
+     * If TopK fires (oversampling from yml), the query succeeds with correct results.
+     * If TopK doesn't fire, it still succeeds but without per-shard pruning.
+     * We verify correctness: exact count values on a known dataset.
+     */
+    public void testTopKFiresFromYmlSetting() throws Exception {
+        // Create 2-shard index
+        createParquetIndex(INDEX, 2);
+
+        // 3 groups: A=6, B=4, C=2 docs
+        StringBuilder bulk = new StringBuilder();
+        for (int i = 0; i < 6; i++) bulk.append("{\"index\":{}}\n{\"grp\":\"A\"}\n");
+        for (int i = 0; i < 4; i++) bulk.append("{\"index\":{}}\n{\"grp\":\"B\"}\n");
+        for (int i = 0; i < 2; i++) bulk.append("{\"index\":{}}\n{\"grp\":\"C\"}\n");
+        bulkAndRefresh(INDEX, bulk.toString());
+
+        // No cluster settings API call — oversampling should come from yml
+        Map<String, Object> result = executePpl(
+            "source = " + INDEX + " | stats count() as c by grp | sort - c | head 2"
+        );
+        @SuppressWarnings("unchecked")
+        List<List<Object>> rows = (List<List<Object>>) result.get("datarows");
+        assertEquals("top-2 groups", 2, rows.size());
+        assertEquals("top group count", 6, ((Number) rows.get(0).get(0)).intValue());
+        assertEquals("top group key", "A", rows.get(0).get(1));
+        assertEquals("second group count", 4, ((Number) rows.get(1).get(0)).intValue());
+        assertEquals("second group key", "B", rows.get(1).get(1));
+    }
+
+    private void createParquetIndex(String index, int shards) throws Exception {
+        try { client().performRequest(new org.opensearch.client.Request("DELETE", "/" + index)); } catch (Exception ignored) {}
+        String body = "{\"settings\": {"
+            + "  \"number_of_shards\": " + shards + ", \"number_of_replicas\": 0,"
+            + "  \"index.pluggable.dataformat.enabled\": true, \"index.pluggable.dataformat\": \"composite\","
+            + "  \"index.composite.primary_data_format\": \"parquet\", \"index.composite.secondary_data_formats\": \"\""
+            + "}, \"mappings\": {\"properties\": {\"grp\": {\"type\": \"keyword\"}}}}";
+        org.opensearch.client.Request create = new org.opensearch.client.Request("PUT", "/" + index);
+        create.setJsonEntity(body);
+        assertOkAndParse(client().performRequest(create), "create " + index);
+        org.opensearch.client.Request health = new org.opensearch.client.Request("GET", "/_cluster/health/" + index);
+        health.addParameter("wait_for_status", "green");
+        health.addParameter("timeout", "30s");
+        client().performRequest(health);
+    }
+
+    private void bulkAndRefresh(String index, String body) throws Exception {
+        org.opensearch.client.Request bulk = new org.opensearch.client.Request("POST", "/" + index + "/_bulk?refresh=true");
+        bulk.setJsonEntity(body);
+        client().performRequest(bulk);
+    }
+}


### PR DESCRIPTION


TopK rewriter was reading analytics.shard_bucket_oversampling_factor from clusterState.metadata().settings() which only contains dynamically-applied cluster settings. Settings from opensearch.yml are node-local and not in cluster metadata.

Fix: read initial value from clusterService.getSettings() (includes yml) at executor startup, subscribe to dynamic updates, and pass the value into PlannerContext for the TopK rewriter to consume.

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
