### PR TITLE
Fix for stats and dynamic mappings

### DIFF
--- a/server/src/main/java/org/opensearch/index/engine/CatalogSnapshotStatsCache.java
+++ b/server/src/main/java/org/opensearch/index/engine/CatalogSnapshotStatsCache.java
@@ -11,6 +11,7 @@ package org.opensearch.index.engine;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.search.ReferenceManager;
 import org.opensearch.common.concurrent.GatedCloseable;
+import org.opensearch.index.engine.exec.WriterFileSet;
 import org.opensearch.index.engine.exec.coord.CatalogSnapshot;
 import org.opensearch.index.engine.exec.coord.CatalogSnapshotManager;
 import org.opensearch.index.shard.DocsStats;
@@ -106,7 +107,11 @@ public class CatalogSnapshotStatsCache implements ReferenceManager.RefreshListen
         // Compute docs stats from catalog snapshot
         long totalDocs = snapshot.getNumDocs();
         long deletedDocs = 0; // TODO: Add deleted docs support when available
-        long totalSizeInBytes = 0; // TODO: Compute total size if needed
+        long totalSizeInBytes = snapshot.getSegments()
+            .stream()
+            .flatMap(segment -> segment.dfGroupedSearchableFiles().values().stream())
+            .mapToLong(WriterFileSet::getTotalSize)
+            .sum();
 
         return new DocsStats.Builder().count(totalDocs).deleted(deletedDocs).totalSizeInBytes(totalSizeInBytes).build();
     }

--- a/server/src/main/java/org/opensearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/opensearch/index/mapper/DocumentParser.java
@@ -1315,12 +1315,7 @@ final class DocumentParser {
 
             Mapper.Builder builder = findTemplateBuilder(context, currentFieldName, XContentFieldType.STRING, dynamic, fullPath);
             if (builder == null) {
-                return handleNoTemplateFound(
-                    dynamic,
-                    () -> new TextFieldMapper.Builder(currentFieldName, context.mapperService().getIndexAnalyzers()).addMultiField(
-                        new KeywordFieldMapper.Builder("keyword").ignoreAbove(256)
-                    )
-                );
+                return handleNoTemplateFound(dynamic, builderSupplierForText(currentFieldName, context));
             }
             return builder;
         } else if (token == XContentParser.Token.VALUE_NUMBER) {
@@ -1370,6 +1365,16 @@ final class DocumentParser {
         throw new IllegalStateException(
             "Can't handle serializing a dynamic type with content token [" + token + "] and field name [" + currentFieldName + "]"
         );
+    }
+
+    private static java.util.function.Supplier<Mapper.Builder<?>> builderSupplierForText(String fieldName, ParseContext context) {
+        if (context.indexSettings().isPluggableDataFormatEnabled()) {
+            return () -> new TextFieldMapper.Builder(fieldName, context.mapperService().getIndexAnalyzers());
+        } else {
+            return () -> new TextFieldMapper.Builder(fieldName, context.mapperService().getIndexAnalyzers()).addMultiField(
+                new KeywordFieldMapper.Builder("keyword").ignoreAbove(256)
+            );
+        }
     }
 
     private static Mapper.Builder<?> handleNoTemplateFound(

--- a/server/src/main/java/org/opensearch/index/store/SubdirectoryAwareDirectory.java
+++ b/server/src/main/java/org/opensearch/index/store/SubdirectoryAwareDirectory.java
@@ -101,14 +101,12 @@ public class SubdirectoryAwareDirectory extends FilterDirectory {
         Path indexDir = shardPath.resolveIndex();
         for (String name : names) {
             Path resolved = fsDataPath.resolve(parseFilePath(name));
+            logger.trace("Resolved path: {} for file: {}", resolved, name);
             if (resolved.startsWith(indexDir)) {
                 indexFiles.add(resolved.toString());
+                logger.trace("Added to index file: {}", resolved);
             } else {
-                Path normalized = resolved.normalize();
-                if (normalized.startsWith(fsDataPath) == false) {
-                    throw new IOException("Path traversal detected: " + name + " resolves outside shard data path");
-                }
-                IOUtils.fsync(normalized, false);
+                IOUtils.fsync(resolved, false);
             }
         }
         if (indexFiles.isEmpty() == false) {

--- a/server/src/test/java/org/opensearch/index/engine/CatalogSnapshotStatsCacheTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/CatalogSnapshotStatsCacheTests.java
@@ -10,6 +10,7 @@ package org.opensearch.index.engine;
 
 import org.apache.logging.log4j.Logger;
 import org.opensearch.common.concurrent.GatedCloseable;
+import org.opensearch.index.engine.exec.WriterFileSet;
 import org.opensearch.index.engine.exec.coord.CatalogSnapshot;
 import org.opensearch.index.engine.exec.coord.CatalogSnapshotManager;
 import org.opensearch.index.shard.DocsStats;
@@ -187,5 +188,118 @@ public class CatalogSnapshotStatsCacheTests extends OpenSearchTestCase {
         } catch (Exception e) {
             fail("Refresh methods should not throw exceptions: " + e.getMessage());
         }
+    }
+
+    public void testComputeDocsStatsTotalSizeFromMultipleSegments() throws IOException {
+        CatalogSnapshotManager snapshotManager = mock(CatalogSnapshotManager.class);
+        Store store = mock(Store.class);
+        Logger logger = mock(Logger.class);
+
+        // Create temp files with known sizes
+        java.nio.file.Path tempDir = createTempDir();
+        java.nio.file.Files.write(tempDir.resolve("seg1.parquet"), new byte[1000]);
+        java.nio.file.Files.write(tempDir.resolve("seg2.parquet"), new byte[2500]);
+        java.nio.file.Files.write(tempDir.resolve("seg3.lucene"), new byte[500]);
+
+        WriterFileSet parquetSet1 = new WriterFileSet(tempDir.toString(), 1L, java.util.Set.of("seg1.parquet"), 5, 1L);
+        WriterFileSet parquetSet2 = new WriterFileSet(tempDir.toString(), 2L, java.util.Set.of("seg2.parquet"), 3, 1L);
+        WriterFileSet luceneSet = new WriterFileSet(tempDir.toString(), 1L, java.util.Set.of("seg3.lucene"), 5, 1L);
+
+        org.opensearch.index.engine.exec.Segment segment1 = org.opensearch.index.engine.exec.Segment.builder(1L)
+            .addSearchableFiles("parquet", parquetSet1)
+            .addSearchableFiles("lucene", luceneSet)
+            .build();
+        org.opensearch.index.engine.exec.Segment segment2 = org.opensearch.index.engine.exec.Segment.builder(2L)
+            .addSearchableFiles("parquet", parquetSet2)
+            .build();
+
+        CatalogSnapshot snapshot = mock(CatalogSnapshot.class);
+        when(snapshot.getSegments()).thenReturn(List.of(segment1, segment2));
+        when(snapshot.getNumDocs()).thenReturn(8L);
+        when(snapshot.collectFileSizesGroupedByExtension(store)).thenReturn(Collections.emptyMap());
+        when(snapshot.buildEngineSegments(any(), any())).thenReturn(Collections.emptyList());
+        when(snapshotManager.acquireSnapshot()).thenReturn(new GatedCloseable<>(snapshot, () -> {}));
+
+        CatalogSnapshotStatsCache cache = new CatalogSnapshotStatsCache(snapshotManager, store, null, () -> Collections.emptyMap(), logger);
+        cache.afterRefresh(true);
+
+        DocsStats docsStats = cache.getDocsStats();
+        assertEquals(8L, docsStats.getCount());
+        // totalSizeInBytes = 1000 + 2500 + 500 = 4000
+        assertEquals(4000L, docsStats.getTotalSizeInBytes());
+    }
+
+    public void testComputeDocsStatsTotalSizeWithEmptySegments() throws IOException {
+        CatalogSnapshotManager snapshotManager = mock(CatalogSnapshotManager.class);
+        Store store = mock(Store.class);
+        Logger logger = mock(Logger.class);
+
+        // Segment with no file sets
+        org.opensearch.index.engine.exec.Segment emptySegment = org.opensearch.index.engine.exec.Segment.builder(1L).build();
+
+        CatalogSnapshot snapshot = mock(CatalogSnapshot.class);
+        when(snapshot.getSegments()).thenReturn(List.of(emptySegment));
+        when(snapshot.getNumDocs()).thenReturn(0L);
+        when(snapshot.collectFileSizesGroupedByExtension(store)).thenReturn(Collections.emptyMap());
+        when(snapshot.buildEngineSegments(any(), any())).thenReturn(Collections.emptyList());
+        when(snapshotManager.acquireSnapshot()).thenReturn(new GatedCloseable<>(snapshot, () -> {}));
+
+        CatalogSnapshotStatsCache cache = new CatalogSnapshotStatsCache(snapshotManager, store, null, () -> Collections.emptyMap(), logger);
+        cache.afterRefresh(true);
+
+        DocsStats docsStats = cache.getDocsStats();
+        assertEquals(0L, docsStats.getCount());
+        assertEquals(0L, docsStats.getTotalSizeInBytes());
+    }
+
+    public void testComputeDocsStatsTotalSizeWithMissingFiles() throws IOException {
+        CatalogSnapshotManager snapshotManager = mock(CatalogSnapshotManager.class);
+        Store store = mock(Store.class);
+        Logger logger = mock(Logger.class);
+
+        // Create one real file and reference a non-existent file
+        java.nio.file.Path tempDir = createTempDir();
+        java.nio.file.Files.write(tempDir.resolve("exists.parquet"), new byte[750]);
+
+        WriterFileSet fileSet = new WriterFileSet(tempDir.toString(), 1L, java.util.Set.of("exists.parquet", "missing.parquet"), 10, 1L);
+
+        org.opensearch.index.engine.exec.Segment segment = org.opensearch.index.engine.exec.Segment.builder(1L)
+            .addSearchableFiles("parquet", fileSet)
+            .build();
+
+        CatalogSnapshot snapshot = mock(CatalogSnapshot.class);
+        when(snapshot.getSegments()).thenReturn(List.of(segment));
+        when(snapshot.getNumDocs()).thenReturn(10L);
+        when(snapshot.collectFileSizesGroupedByExtension(store)).thenReturn(Collections.emptyMap());
+        when(snapshot.buildEngineSegments(any(), any())).thenReturn(Collections.emptyList());
+        when(snapshotManager.acquireSnapshot()).thenReturn(new GatedCloseable<>(snapshot, () -> {}));
+
+        CatalogSnapshotStatsCache cache = new CatalogSnapshotStatsCache(snapshotManager, store, null, () -> Collections.emptyMap(), logger);
+
+        cache.afterRefresh(true);
+        DocsStats docsStats = cache.getDocsStats();
+        assertEquals(10L, docsStats.getCount());
+        // Only the existing file contributes; missing file returns 0
+        assertEquals(750L, docsStats.getTotalSizeInBytes());
+    }
+
+    public void testComputeDocsStatsTotalSizeNoSegments() throws IOException {
+        CatalogSnapshotManager snapshotManager = mock(CatalogSnapshotManager.class);
+        Store store = mock(Store.class);
+        Logger logger = mock(Logger.class);
+
+        CatalogSnapshot snapshot = mock(CatalogSnapshot.class);
+        when(snapshot.getSegments()).thenReturn(Collections.emptyList());
+        when(snapshot.getNumDocs()).thenReturn(0L);
+        when(snapshot.collectFileSizesGroupedByExtension(store)).thenReturn(Collections.emptyMap());
+        when(snapshot.buildEngineSegments(any(), any())).thenReturn(Collections.emptyList());
+        when(snapshotManager.acquireSnapshot()).thenReturn(new GatedCloseable<>(snapshot, () -> {}));
+
+        CatalogSnapshotStatsCache cache = new CatalogSnapshotStatsCache(snapshotManager, store, null, () -> Collections.emptyMap(), logger);
+
+        cache.afterRefresh(true);
+        DocsStats docsStats = cache.getDocsStats();
+        assertEquals(0L, docsStats.getCount());
+        assertEquals(0L, docsStats.getTotalSizeInBytes());
     }
 }

--- a/server/src/test/java/org/opensearch/index/mapper/DocumentParserTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/DocumentParserTests.java
@@ -37,11 +37,13 @@ import org.apache.lucene.util.BytesRef;
 import org.opensearch.Version;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.common.bytes.BytesArray;
 import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.index.IndexSettings;
+import org.opensearch.index.engine.dataformat.DocumentInput;
 import org.opensearch.index.mapper.ParseContext.Document;
 import org.opensearch.plugins.Plugin;
 
@@ -3635,5 +3637,42 @@ public class DocumentParserTests extends MapperServiceTestCase {
 
         assertThat(doc.getDocumentInput(), sameInstance(mockInput));
         assertNotNull(doc.rootDoc().getField("obj.inner"));
+    }
+
+    @LockFeatureFlag(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)
+    public void testDynamicTextFieldWithoutKeywordMultiFieldForPluggableDataFormat() throws Exception {
+        Settings pluggableSettings = Settings.builder()
+            .put("index.version.created", Version.CURRENT)
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+            .put("index.pluggable.dataformat.enabled", true)
+            .build();
+        DocumentMapper mapper = createDocumentMapper(pluggableSettings, mapping(b -> {}));
+        DocumentInput<?> noopInput = new CapturingDocumentInput();
+        ParsedDocument doc = mapper.parse(source(b -> b.field("dynamic_text", "hello world")), noopInput);
+
+        assertNotNull(doc.dynamicMappingsUpdate());
+        Mapper textMapper = doc.dynamicMappingsUpdate().root().getMapper("dynamic_text");
+        assertNotNull(textMapper);
+        assertThat(textMapper, instanceOf(TextFieldMapper.class));
+
+        // With pluggable data format, text field should NOT have .keyword multi-field
+        assertFalse("Text field should not have keyword multi-field with pluggable dataformat", textMapper.iterator().hasNext());
+    }
+
+    public void testDynamicTextFieldWithKeywordMultiFieldForNonPluggableDataFormat() throws Exception {
+        DocumentMapper mapper = createDocumentMapper(mapping(b -> {}));
+        ParsedDocument doc = mapper.parse(source(b -> b.field("dynamic_text", "hello world")));
+
+        assertNotNull(doc.dynamicMappingsUpdate());
+        Mapper textMapper = doc.dynamicMappingsUpdate().root().getMapper("dynamic_text");
+        assertNotNull(textMapper);
+        assertThat(textMapper, instanceOf(TextFieldMapper.class));
+
+        // Without pluggable data format, text field SHOULD have .keyword multi-field
+        assertTrue("Text field should have keyword multi-field without pluggable dataformat", textMapper.iterator().hasNext());
+        Mapper keywordSubField = textMapper.iterator().next();
+        assertThat(keywordSubField, instanceOf(KeywordFieldMapper.class));
+        assertEquals("dynamic_text.keyword", keywordSubField.name());
     }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
1. Fsync fix to use resolved path directly
2. Stats fix for doc stats
3. Dynamic mapping changes to only create text since doc values are always on for text in pluggable

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
