### PR TITLE
Push bare LIMIT down to shards (head N without ORDER BY)

### DIFF
--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchSortPushdownRewriter.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchSortPushdownRewriter.java
@@ -73,6 +73,11 @@ public final class OpenSearchSortPushdownRewriter {
                 if (bound != null && canComputeShardFetch(bound) && isPushTarget(below)) {
                     return new RewriteContext(sort, bound, below);
                 }
+            } else if (sort.fetch != null && canComputeShardFetch(sort) && isPushTarget(sort.getInput())) {
+                // Bare LIMIT, no ORDER BY (`head N`): push a fetch-only Sort below the ER so each
+                // shard caps at N instead of streaming its whole scan. Safe with no order — the
+                // coordinator just needs some N rows, and each shard's local N supplies them.
+                return new RewriteContext(sort, sort, sort.getInput());
             }
             OpenSearchSort carry = (collated == false && sort.fetch != null) ? sort : null;
             return find(sort.getInput(), carry);

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/SortPlanShapeTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/SortPlanShapeTests.java
@@ -72,6 +72,8 @@ public class SortPlanShapeTests extends PlanShapeTestBase {
             """, result);
     }
 
+    /** A bare LIMIT is pushed below the ER so each shard caps locally instead of streaming its whole
+     *  scan to the coordinator. See {@link SortPushdownPlanShapeTests#testBareLimit_2shard_pushed}. */
     public void testPureLimit_2shard() {
         RelNode scan = stubScan(mockTable("test_index", "status", "size"));
         RelNode plan = makeLimit(scan, 10);
@@ -80,7 +82,8 @@ public class SortPlanShapeTests extends PlanShapeTestBase {
             """
                 OpenSearchSort(fetch=[10], viableBackends=[[mock-parquet]])
                   OpenSearchExchangeReducer(viableBackends=[[mock-parquet]], exchange=[ExchangeInfo[distributionType=SINGLETON, partitionKeyIndices=[]]])
-                    OpenSearchTableScan(table=[[test_index]], viableBackends=[[mock-parquet]])
+                    OpenSearchSort(fetch=[10], viableBackends=[[mock-parquet]])
+                      OpenSearchTableScan(table=[[test_index]], viableBackends=[[mock-parquet]])
                 """,
             result
         );

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/SortPushdownPlanShapeTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/SortPushdownPlanShapeTests.java
@@ -37,6 +37,79 @@ public class SortPushdownPlanShapeTests extends PlanShapeTestBase {
         );
     }
 
+    /** A collation-free LIMIT — PPL {@code head N} / SQL {@code LIMIT N} with no {@code ORDER BY}. */
+    private RelNode bareLimit(RelNode input, int fetch) {
+        return LogicalSort.create(
+            input,
+            RelCollations.EMPTY,
+            null,
+            rexBuilder.makeLiteral(fetch, typeFactory.createSqlType(SqlTypeName.INTEGER), true)
+        );
+    }
+
+    /**
+     * Bare {@code head N} (no ORDER BY): a collation-free fetch must still be pushed below the ER so
+     * each shard caps locally at N rows. Without this, every shard streams its <em>entire</em> scan to
+     * the coordinator, which then trims to N — fetching every row defeats the limit. A limit without an
+     * order is always safe to push: the coordinator's N-row result is a subset of the union of each
+     * shard's N-row result, regardless of which rows each shard keeps.
+     */
+    public void testBareLimit_2shard_pushed() {
+        RelNode scan = stubScan(mockTable("test_index", "status", "size"));
+        RelNode result = runPlanner(bareLimit(scan, 10), multiShardContext());
+        assertPlanShape(
+            """
+                OpenSearchSort(fetch=[10], viableBackends=[[mock-parquet]])
+                  OpenSearchExchangeReducer(viableBackends=[[mock-parquet]], exchange=[ExchangeInfo[distributionType=SINGLETON, partitionKeyIndices=[]]])
+                    OpenSearchSort(fetch=[10], viableBackends=[[mock-parquet]])
+                      OpenSearchTableScan(table=[[test_index]], viableBackends=[[mock-parquet]])
+                """,
+            result
+        );
+    }
+
+    /** Bare LIMIT, single shard: no ER to push below — coordinator keeps the only Sort. */
+    public void testBareLimit_singleShard_notPushed() {
+        RelNode scan = stubScan(mockTable("test_index", "status", "size"));
+        RelNode result = runPlanner(bareLimit(scan, 10), singleShardContext());
+        assertEquals(1, RelOptUtil.toString(result).lines().filter(l -> l.contains("OpenSearchSort")).count());
+    }
+
+    /** Bare LIMIT with OFFSET: shard fetch widens to offset+fetch, offset stays on the coordinator. */
+    public void testBareLimitOffset_2shard_widenedFetch() {
+        RelNode scan = stubScan(mockTable("test_index", "status", "size"));
+        RelNode plan = LogicalSort.create(
+            scan,
+            RelCollations.EMPTY,
+            rexBuilder.makeLiteral(5, typeFactory.createSqlType(SqlTypeName.INTEGER), true),
+            rexBuilder.makeLiteral(10, typeFactory.createSqlType(SqlTypeName.INTEGER), true)
+        );
+        String p = RelOptUtil.toString(runPlanner(plan, multiShardContext()));
+        assertEquals("coord + shard Sort", 2, p.lines().filter(l -> l.contains("OpenSearchSort")).count());
+        assertTrue("coordinator keeps offset=5", p.contains("offset=[5]"));
+        int erIdx = p.indexOf("ExchangeReducer");
+        int widenedIdx = p.indexOf("fetch=[15]");
+        assertTrue("shard Sort widened to offset+fetch=15 below ER", erIdx >= 0 && widenedIdx > erIdx);
+        assertFalse("shard Sort must not carry an offset", p.substring(widenedIdx).contains("offset="));
+    }
+
+    /** Bare LIMIT over UNION ALL: the collation-free fetch is pushed below each arm's ER. */
+    public void testBareLimitUnionAll_2shard_pushedIntoBothArms() {
+        RelNode union = LogicalUnion.create(
+            List.of(stubScan(mockTable("test_index", "status", "size")), stubScan(mockTable("test_index", "status", "size"))),
+            true
+        );
+        String p = RelOptUtil.toString(runPlanner(bareLimit(union, 10), unionContext("test_index", 2)));
+        assertEquals("coordinator + one Sort per arm, plan:\n" + p, 3, p.lines().filter(l -> l.contains("OpenSearchSort")).count());
+        assertEquals("one ER per arm, plan:\n" + p, 2, p.lines().filter(l -> l.contains("ExchangeReducer")).count());
+        String[] lines = p.split("\n", -1);
+        for (int i = 0; i + 1 < lines.length; i++) {
+            if (lines[i].contains("ExchangeReducer")) {
+                assertTrue("a Sort must be pushed below each arm ER, plan:\n" + p, lines[i + 1].contains("OpenSearchSort"));
+            }
+        }
+    }
+
     /** SQL shape: single Sort(collation, fetch) → identical Sort pushed below ER.
      *  (A LateMaterialization node wraps the top for scans with stored fields — incidental.) */
     public void testSqlSortLimit_2shard_pushed() {


### PR DESCRIPTION


<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
A head N with no sort left the limit only on the coordinator, so every shard streamed its full scan and the coordinator trimmed to N. Push a collation-free fetch below the exchange so each shard caps at N locally. Safe without an order: the coordinator's N rows are a subset of the union of each shard's N rows.

Extends the existing collated-sort pushdown to the bare-fetch case, reusing its offset handling. Plan-shape tests cover the pushed shape plus single-shard, offset-widening, and UNION ALL. Updates testPureLimit_2shard, which had pinned the old shape.

Also tested with sql's default 10k limit applied:
```
OpenSearchProject(@timestamp=[$0], viableBackends=[[datafusion]])
  OpenSearchSort(fetch=[10000], viableBackends=[[datafusion]])
    OpenSearchExchangeReducer(viableBackends=[[datafusion]], exchange=[ExchangeInfo[distributionType=SINGLETON, partitionKeyIndices=[]]])
      OpenSearchSort(fetch=[10000], viableBackends=[[datafusion]])
        OpenSearchTableScan(table=[[lim_test]], viableBackends=[[lucene, datafusion]])
```

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
