### PR TITLE
Fix PPL date/time output, DATETIME tz, and convert_tz types

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/ConvertTzAdapter.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/ConvertTzAdapter.java
@@ -93,16 +93,23 @@ class ConvertTzAdapter implements ScalarFunctionAdapter {
             operands.set(slot, canonicalizeTzOperand(operands.get(slot), rexBuilder));
         }
 
-        // Identity short-circuit: both operands resolve to the same canonical
-        // string → the conversion is a no-op.
+        // Same from/to tz → no-op. SAFE-cast a VARCHAR operand to TIMESTAMP so the parent
+        // Project rowType stays consistent (bare VARCHAR trips RexUtil.compatibleTypes).
         String fromLiteral = tzLiteralValue(operands.get(1));
         String toLiteral = tzLiteralValue(operands.get(2));
         if (fromLiteral != null && toLiteral != null && fromLiteral.equals(toLiteral)) {
-            return operands.get(0);
+            RexNode operand = operands.get(0);
+            if (operand.getType().equals(original.getType())) {
+                return operand;
+            }
+            return rexBuilder.makeCast(original.getType(), operand, true, true);
         }
 
-        // UDF fallback. Preserve the original call's return type — see
-        // AbstractNameMappingAdapter for why (Project.isValid compatibleTypes check).
+        // Substrait declares convert_tz(precision_timestamp, string, string); SAFE-cast
+        // a VARCHAR timestamp slot so it binds (NULL on parse failure).
+        if (!operands.get(0).getType().equals(original.getType())) {
+            operands.set(0, rexBuilder.makeCast(original.getType(), operands.get(0), true, true));
+        }
         return rexBuilder.makeCall(original.getType(), LOCAL_CONVERT_TZ_OP, operands);
     }
 

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DateTimeAdapters.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DateTimeAdapters.java
@@ -8,13 +8,21 @@
 
 package org.opensearch.be.datafusion;
 
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlFunction;
 import org.apache.calcite.sql.SqlFunctionCategory;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.fun.SqlLibraryOperators;
 import org.apache.calcite.sql.type.OperandTypes;
 import org.apache.calcite.sql.type.ReturnTypes;
+import org.apache.calcite.sql.type.SqlTypeName;
 import org.opensearch.analytics.spi.AbstractNameMappingAdapter;
+import org.opensearch.analytics.spi.FieldStorageInfo;
+import org.opensearch.analytics.spi.ScalarFunctionAdapter;
 
 import java.util.List;
 
@@ -131,9 +139,34 @@ final class DateTimeAdapters {
         }
     }
 
-    static final class DatetimeAdapter extends AbstractNameMappingAdapter {
-        DatetimeAdapter() {
-            super(LOCAL_TO_TIMESTAMP_OP, List.of(), List.of());
+    /**
+     * Single-arg {@code DATETIME(string)} strips the trailing offset (+HH:MM / -HHMM / Z) so the
+     * result is wall-clock, not UTC-converted. Two-arg {@code DATETIME(string, tz)} and
+     * non-string operands route through {@code to_timestamp} unchanged.
+     *
+     * <p>This belongs in the PPL frontend ({@code PPLBuiltinOperators.DATETIME}) so every
+     * backend inherits the wall-clock semantic; lives here until the frontend owns it.
+     */
+    static final class DatetimeAdapter implements ScalarFunctionAdapter {
+
+        private static final String OFFSET_SUFFIX_PATTERN = "([+-][0-9]{2}:?[0-9]{2}|Z)$";
+
+        @Override
+        public RexNode adapt(RexCall original, List<FieldStorageInfo> fieldStorage, RelOptCluster cluster) {
+            RexBuilder rexBuilder = cluster.getRexBuilder();
+            List<RexNode> operands = original.getOperands();
+            if (operands.size() == 1 && SqlTypeName.CHAR_TYPES.contains(operands.get(0).getType().getSqlTypeName())) {
+                RexNode arg = operands.get(0);
+                RexNode pattern = rexBuilder.makeLiteral(OFFSET_SUFFIX_PATTERN);
+                RexNode replacement = rexBuilder.makeLiteral("");
+                RexNode stripped = rexBuilder.makeCall(
+                    arg.getType(),
+                    SqlLibraryOperators.REGEXP_REPLACE_3,
+                    List.of(arg, pattern, replacement)
+                );
+                return rexBuilder.makeCall(original.getType(), LOCAL_TO_TIMESTAMP_OP, List.of(stripped));
+            }
+            return rexBuilder.makeCall(original.getType(), LOCAL_TO_TIMESTAMP_OP, operands);
         }
     }
 }

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/MinusAdapter.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/MinusAdapter.java
@@ -55,8 +55,7 @@ class MinusAdapter implements ScalarFunctionAdapter {
         // DATE-DATE → integer day-count (legacy convention). Calcite infers the return type
         // as DATE, so returning BIGINT directly prevents ArrowValues from formatting
         // epoch-day 5 as the date "1970-01-06".
-        if (left.getType().getSqlTypeName() == SqlTypeName.DATE
-                && right.getType().getSqlTypeName() == SqlTypeName.DATE) {
+        if (left.getType().getSqlTypeName() == SqlTypeName.DATE && right.getType().getSqlTypeName() == SqlTypeName.DATE) {
             RelDataType bigint = rexBuilder.getTypeFactory().createSqlType(SqlTypeName.BIGINT);
             RexNode secsPerDay = rexBuilder.makeLiteral(java.math.BigDecimal.valueOf(86_400L), bigint);
             return rexBuilder.makeCall(SqlStdOperatorTable.DIVIDE, diffSeconds, secsPerDay);

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/MinusAdapter.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/MinusAdapter.java
@@ -52,6 +52,16 @@ class MinusAdapter implements ScalarFunctionAdapter {
         RexNode rightSeconds = rexBuilder.makeCall(UnixTimestampAdapter.LOCAL_TO_UNIXTIME_OP, right);
         RexNode diffSeconds = rexBuilder.makeCall(SqlStdOperatorTable.MINUS, leftSeconds, rightSeconds);
 
+        // DATE-DATE → integer day-count (legacy convention). Calcite infers the return type
+        // as DATE, so returning BIGINT directly prevents ArrowValues from formatting
+        // epoch-day 5 as the date "1970-01-06".
+        if (left.getType().getSqlTypeName() == SqlTypeName.DATE
+                && right.getType().getSqlTypeName() == SqlTypeName.DATE) {
+            RelDataType bigint = rexBuilder.getTypeFactory().createSqlType(SqlTypeName.BIGINT);
+            RexNode secsPerDay = rexBuilder.makeLiteral(java.math.BigDecimal.valueOf(86_400L), bigint);
+            return rexBuilder.makeCall(SqlStdOperatorTable.DIVIDE, diffSeconds, secsPerDay);
+        }
+
         // PPL's MINUS(DATETIME, DATETIME) infers TIMESTAMP at the call site; lift the
         // BIGINT seconds back through from_unixtime so Project.isValid type-matches.
         RelDataType fp64 = rexBuilder.getTypeFactory().createSqlType(SqlTypeName.DOUBLE);

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/ConvertTzAdapterTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/ConvertTzAdapterTests.java
@@ -225,4 +225,42 @@ public class ConvertTzAdapterTests extends OpenSearchTestCase {
         assertSame("column-valued from_tz must pass through unmodified", fromCol, call.getOperands().get(1));
         assertSame("column-valued to_tz must pass through unmodified", toCol, call.getOperands().get(2));
     }
+
+    /** Identity short-circuit with VARCHAR operand under a TIMESTAMP call → SAFE-cast. */
+    public void testIdentityShortCircuitWrapsInSafeCastWhenOperandTypeDiffers() {
+        RelDataType returnType = typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.TIMESTAMP, 9), true);
+        RexNode tsLiteral = rexBuilder.makeLiteral("2021-05-12 11:34:50");
+        RexNode fromTz = rexBuilder.makeLiteral("UTC");
+        RexNode toTz = rexBuilder.makeLiteral("UTC");
+        RexCall original = (RexCall) rexBuilder.makeCall(convertTzOp(returnType), List.of(tsLiteral, fromTz, toTz));
+
+        RexNode adapted = new ConvertTzAdapter().adapt(original, List.of(), cluster);
+
+        assertNotSame(tsLiteral, adapted);
+        assertEquals(original.getType(), adapted.getType());
+        assertTrue(adapted instanceof RexCall);
+        assertEquals(org.apache.calcite.sql.SqlKind.SAFE_CAST, ((RexCall) adapted).getOperator().getKind());
+    }
+
+    /** UDF fallback with VARCHAR timestamp operand → SAFE-cast slot 0 to TIMESTAMP. */
+    public void testUdfFallbackWrapsVarcharOperandInSafeCast() {
+        RelDataType returnType = typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.TIMESTAMP, 9), true);
+        RexNode tsLiteral = rexBuilder.makeLiteral("2021-05-12 11:34:50");
+        RexNode fromTz = rexBuilder.makeLiteral("UTC");
+        RexNode toTz = rexBuilder.makeLiteral("America/Los_Angeles");
+        RexCall original = (RexCall) rexBuilder.makeCall(convertTzOp(returnType), List.of(tsLiteral, fromTz, toTz));
+
+        RexNode adapted = new ConvertTzAdapter().adapt(original, List.of(), cluster);
+
+        assertTrue(adapted instanceof RexCall);
+        RexCall call = (RexCall) adapted;
+        assertSame(ConvertTzAdapter.LOCAL_CONVERT_TZ_OP, call.getOperator());
+        assertEquals(original.getType(), call.getType());
+
+        RexNode firstArg = call.getOperands().get(0);
+        assertNotSame(tsLiteral, firstArg);
+        assertEquals(original.getType(), firstArg.getType());
+        assertTrue(firstArg instanceof RexCall);
+        assertEquals(org.apache.calcite.sql.SqlKind.SAFE_CAST, ((RexCall) firstArg).getOperator().getKind());
+    }
 }

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatetimeAdapterTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatetimeAdapterTests.java
@@ -1,0 +1,100 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion;
+
+import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.hep.HepPlanner;
+import org.apache.calcite.plan.hep.HepProgramBuilder;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlFunction;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.fun.SqlLibraryOperators;
+import org.apache.calcite.sql.type.OperandTypes;
+import org.apache.calcite.sql.type.ReturnTypes;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.List;
+
+/** Covers DatetimeAdapter: VARCHAR operand gets offset-stripped, non-VARCHAR (TIMESTAMP) passes through, two-arg form passes through. */
+public class DatetimeAdapterTests extends OpenSearchTestCase {
+
+    private RelDataTypeFactory typeFactory;
+    private RexBuilder rexBuilder;
+    private RelOptCluster cluster;
+    private DateTimeAdapters.DatetimeAdapter adapter;
+
+    private static final SqlFunction DATETIME_OP = new SqlFunction(
+        "DATETIME",
+        SqlKind.OTHER_FUNCTION,
+        ReturnTypes.TIMESTAMP,
+        null,
+        OperandTypes.ANY,
+        SqlFunctionCategory.TIMEDATE
+    );
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        typeFactory = new JavaTypeFactoryImpl();
+        rexBuilder = new RexBuilder(typeFactory);
+        cluster = RelOptCluster.create(new HepPlanner(new HepProgramBuilder().build()), rexBuilder);
+        adapter = new DateTimeAdapters.DatetimeAdapter();
+    }
+
+    public void testSingleArgVarcharIsWrappedInRegexpReplace() {
+        RexNode arg = rexBuilder.makeLiteral("2008-01-01 02:00:00+10:00");
+        RexCall original = (RexCall) rexBuilder.makeCall(DATETIME_OP, List.of(arg));
+
+        RexNode adapted = adapter.adapt(original, List.of(), cluster);
+
+        assertTrue(adapted instanceof RexCall);
+        RexCall call = (RexCall) adapted;
+        assertSame(DateTimeAdapters.LOCAL_TO_TIMESTAMP_OP, call.getOperator());
+
+        RexNode wrapped = call.getOperands().get(0);
+        assertTrue(wrapped instanceof RexCall);
+        assertSame(SqlLibraryOperators.REGEXP_REPLACE_3, ((RexCall) wrapped).getOperator());
+    }
+
+    public void testSingleArgTimestampPassesThroughUnwrapped() {
+        RelDataType timestampType = typeFactory.createSqlType(SqlTypeName.TIMESTAMP, 3);
+        RexNode arg = rexBuilder.makeAbstractCast(timestampType, rexBuilder.makeLiteral("2020-01-01 00:00:00"));
+        RexCall original = (RexCall) rexBuilder.makeCall(DATETIME_OP, List.of(arg));
+
+        RexNode adapted = adapter.adapt(original, List.of(), cluster);
+
+        assertTrue(adapted instanceof RexCall);
+        RexCall call = (RexCall) adapted;
+        assertSame(DateTimeAdapters.LOCAL_TO_TIMESTAMP_OP, call.getOperator());
+        // Non-string operand passes through to to_timestamp without regexp_replace.
+        assertSame(arg, call.getOperands().get(0));
+    }
+
+    public void testTwoArgFormPassesThroughUnwrapped() {
+        RexNode ts = rexBuilder.makeLiteral("2008-01-01 02:00:00+10:00");
+        RexNode tz = rexBuilder.makeLiteral("UTC");
+        RexCall original = (RexCall) rexBuilder.makeCall(DATETIME_OP, List.of(ts, tz));
+
+        RexNode adapted = adapter.adapt(original, List.of(), cluster);
+
+        assertTrue(adapted instanceof RexCall);
+        RexCall call = (RexCall) adapted;
+        assertSame(DateTimeAdapters.LOCAL_TO_TIMESTAMP_OP, call.getOperator());
+        assertEquals(2, call.getOperands().size());
+        assertSame(ts, call.getOperands().get(0));
+        assertSame(tz, call.getOperands().get(1));
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/MinusAdapterTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/MinusAdapterTests.java
@@ -58,11 +58,19 @@ public class MinusAdapterTests extends OpenSearchTestCase {
         assertSame(UnixTimestampAdapter.LOCAL_TO_UNIXTIME_OP, ((RexCall) minus.getOperands().get(1)).getOperator());
     }
 
-    public void testDateMinusDateRewritesToUnixSecondsDiff() {
+    public void testDateMinusDateReturnsBigIntDayCount() {
         RexCall call = minusOf(SqlTypeName.DATE, SqlTypeName.DATE);
         RexNode adapted = adapter.adapt(call, List.of(), cluster);
-        // Same shape as TIMESTAMP-TIMESTAMP — DATE is the other gap-shape operand type.
-        assertSame(RustUdfDateTimeAdapters.LOCAL_FROM_UNIXTIME_OP, ((RexCall) unwrapCast(adapted)).getOperator());
+
+        // DATE-DATE → integer day-count: DIVIDE(MINUS(to_unixtime(L), to_unixtime(R)), 86400).
+        RexCall divide = (RexCall) adapted;
+        assertSame(SqlStdOperatorTable.DIVIDE, divide.getOperator());
+        assertSame(SqlTypeName.BIGINT, divide.getType().getSqlTypeName());
+
+        RexCall minus = (RexCall) divide.getOperands().get(0);
+        assertSame(SqlStdOperatorTable.MINUS, minus.getOperator());
+        assertSame(UnixTimestampAdapter.LOCAL_TO_UNIXTIME_OP, ((RexCall) minus.getOperands().get(0)).getOperator());
+        assertSame(UnixTimestampAdapter.LOCAL_TO_UNIXTIME_OP, ((RexCall) minus.getOperands().get(1)).getOperator());
     }
 
     public void testNumericMinusPassesThroughUnchanged() {

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/ArrowValues.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/ArrowValues.java
@@ -12,9 +12,15 @@ import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.VarCharVector;
 import org.apache.arrow.vector.complex.ListVector;
 import org.apache.arrow.vector.complex.MapVector;
+import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.util.Text;
 
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -45,7 +51,63 @@ public final class ArrowValues {
         if (vector instanceof ListVector && value instanceof List<?> raw) {
             return normalizeList(raw);
         }
+        // Date/Time/Timestamp cells return java.time.* so ExprValueUtils wraps them as
+        // ExprDateValue / ExprTimeValue / ExprTimestampValue and formats them.
+        Object temporal = normalizeTemporal(vector.getField().getType(), value);
+        if (temporal != null) {
+            return temporal;
+        }
         return normalize(value);
+    }
+
+    /** Returns LocalDate / LocalTime / LocalDateTime, or null for non-temporal types. */
+    private static Object normalizeTemporal(ArrowType type, Object value) {
+        if (value == null) return null;
+        if (type instanceof ArrowType.Date date) {
+            return toLocalDate(date, value);
+        }
+        if (type instanceof ArrowType.Time time) {
+            return toLocalTime(time, value);
+        }
+        if (type instanceof ArrowType.Timestamp ts) {
+            return toLocalDateTime(ts, value);
+        }
+        return null;
+    }
+
+    private static LocalDate toLocalDate(ArrowType.Date type, Object value) {
+        if (value instanceof LocalDate ld) return ld;
+        if (value instanceof LocalDateTime ldt) return ldt.toLocalDate();
+        long raw = ((Number) value).longValue();
+        return switch (type.getUnit()) {
+            case DAY -> LocalDate.ofEpochDay(raw);
+            case MILLISECOND -> LocalDate.ofEpochDay(Math.floorDiv(raw, 86_400_000L));
+        };
+    }
+
+    private static LocalTime toLocalTime(ArrowType.Time type, Object value) {
+        if (value instanceof LocalTime lt) return lt;
+        if (value instanceof LocalDateTime ldt) return ldt.toLocalTime();
+        long raw = ((Number) value).longValue();
+        long nanoOfDay = switch (type.getUnit()) {
+            case SECOND -> raw * 1_000_000_000L;
+            case MILLISECOND -> raw * 1_000_000L;
+            case MICROSECOND -> raw * 1_000L;
+            case NANOSECOND -> raw;
+        };
+        return LocalTime.ofNanoOfDay(nanoOfDay);
+    }
+
+    private static LocalDateTime toLocalDateTime(ArrowType.Timestamp type, Object value) {
+        if (value instanceof LocalDateTime ldt) return ldt;
+        long raw = ((Number) value).longValue();
+        Instant instant = switch (type.getUnit()) {
+            case SECOND -> Instant.ofEpochSecond(raw);
+            case MILLISECOND -> Instant.ofEpochMilli(raw);
+            case MICROSECOND -> Instant.ofEpochSecond(Math.floorDiv(raw, 1_000_000L), Math.floorMod(raw, 1_000_000L) * 1_000L);
+            case NANOSECOND -> Instant.ofEpochSecond(Math.floorDiv(raw, 1_000_000_000L), Math.floorMod(raw, 1_000_000_000L));
+        };
+        return LocalDateTime.ofInstant(instant, ZoneOffset.UTC);
     }
 
     private static Object normalize(Object value) {

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/ArrowValuesTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/ArrowValuesTests.java
@@ -1,0 +1,164 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.exec;
+
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.BigIntVector;
+import org.apache.arrow.vector.DateDayVector;
+import org.apache.arrow.vector.DateMilliVector;
+import org.apache.arrow.vector.TimeMicroVector;
+import org.apache.arrow.vector.TimeMilliVector;
+import org.apache.arrow.vector.TimeNanoVector;
+import org.apache.arrow.vector.TimeSecVector;
+import org.apache.arrow.vector.TimeStampMicroVector;
+import org.apache.arrow.vector.TimeStampMilliVector;
+import org.apache.arrow.vector.TimeStampNanoVector;
+import org.apache.arrow.vector.TimeStampSecVector;
+import org.apache.arrow.vector.VarCharVector;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+/** Covers null, bigint pass-through, VarChar, and Date/Time/Timestamp normalization to java.time.* */
+public class ArrowValuesTests extends OpenSearchTestCase {
+
+    private BufferAllocator allocator;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        allocator = new RootAllocator();
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        allocator.close();
+        super.tearDown();
+    }
+
+    public void testNullCellReturnsNull() {
+        try (BigIntVector v = new BigIntVector("x", allocator)) {
+            v.allocateNew(1);
+            v.setNull(0);
+            v.setValueCount(1);
+            assertNull(ArrowValues.toJavaValue(v, 0));
+        }
+    }
+
+    public void testBigIntPassThroughUnchanged() {
+        try (BigIntVector v = new BigIntVector("x", allocator)) {
+            v.allocateNew(1);
+            v.set(0, 42L);
+            v.setValueCount(1);
+            assertEquals(42L, ArrowValues.toJavaValue(v, 0));
+        }
+    }
+
+    public void testVarCharDecodedAsString() {
+        try (VarCharVector v = new VarCharVector("x", allocator)) {
+            v.allocateNew();
+            v.setSafe(0, "hello".getBytes(java.nio.charset.StandardCharsets.UTF_8));
+            v.setValueCount(1);
+            assertEquals("hello", ArrowValues.toJavaValue(v, 0));
+        }
+    }
+
+    public void testDateDayReturnsLocalDate() {
+        try (DateDayVector v = new DateDayVector("d", allocator)) {
+            v.allocateNew(1);
+            v.set(0, 20610);
+            v.setValueCount(1);
+            assertEquals(LocalDate.of(2026, 6, 6), ArrowValues.toJavaValue(v, 0));
+        }
+    }
+
+    public void testDateMilliReturnsLocalDate() {
+        try (DateMilliVector v = new DateMilliVector("d", allocator)) {
+            v.allocateNew(1);
+            v.set(0, 20_610L * 86_400_000L);
+            v.setValueCount(1);
+            assertEquals(LocalDate.of(2026, 6, 6), ArrowValues.toJavaValue(v, 0));
+        }
+    }
+
+    public void testTimeNanoReturnsLocalTime() {
+        try (TimeNanoVector v = new TimeNanoVector("t", allocator)) {
+            v.allocateNew(1);
+            v.set(0, 27_605_000_000_000L);
+            v.setValueCount(1);
+            assertEquals(LocalTime.of(7, 40, 5), ArrowValues.toJavaValue(v, 0));
+        }
+    }
+
+    public void testTimeMicroReturnsLocalTime() {
+        try (TimeMicroVector v = new TimeMicroVector("t", allocator)) {
+            v.allocateNew(1);
+            v.set(0, 27_605_000_000L);
+            v.setValueCount(1);
+            assertEquals(LocalTime.of(7, 40, 5), ArrowValues.toJavaValue(v, 0));
+        }
+    }
+
+    public void testTimeMilliReturnsLocalTime() {
+        try (TimeMilliVector v = new TimeMilliVector("t", allocator)) {
+            v.allocateNew(1);
+            v.set(0, 27_605_000);
+            v.setValueCount(1);
+            assertEquals(LocalTime.of(7, 40, 5), ArrowValues.toJavaValue(v, 0));
+        }
+    }
+
+    public void testTimeSecReturnsLocalTime() {
+        try (TimeSecVector v = new TimeSecVector("t", allocator)) {
+            v.allocateNew(1);
+            v.set(0, 27_605);
+            v.setValueCount(1);
+            assertEquals(LocalTime.of(7, 40, 5), ArrowValues.toJavaValue(v, 0));
+        }
+    }
+
+    public void testTimestampMilliReturnsLocalDateTimeUtc() {
+        try (TimeStampMilliVector v = new TimeStampMilliVector("ts", allocator)) {
+            v.allocateNew(1);
+            v.set(0, 1_780_731_605_000L);
+            v.setValueCount(1);
+            assertEquals(LocalDateTime.of(2026, 6, 6, 7, 40, 5), ArrowValues.toJavaValue(v, 0));
+        }
+    }
+
+    public void testTimestampSecondReturnsLocalDateTimeUtc() {
+        try (TimeStampSecVector v = new TimeStampSecVector("ts", allocator)) {
+            v.allocateNew(1);
+            v.set(0, 1_780_731_605L);
+            v.setValueCount(1);
+            assertEquals(LocalDateTime.of(2026, 6, 6, 7, 40, 5), ArrowValues.toJavaValue(v, 0));
+        }
+    }
+
+    public void testTimestampMicroReturnsLocalDateTimeUtc() {
+        try (TimeStampMicroVector v = new TimeStampMicroVector("ts", allocator)) {
+            v.allocateNew(1);
+            v.set(0, 1_780_731_605_000_000L);
+            v.setValueCount(1);
+            assertEquals(LocalDateTime.of(2026, 6, 6, 7, 40, 5), ArrowValues.toJavaValue(v, 0));
+        }
+    }
+
+    public void testTimestampNanoReturnsLocalDateTimeUtc() {
+        try (TimeStampNanoVector v = new TimeStampNanoVector("ts", allocator)) {
+            v.allocateNew(1);
+            v.set(0, 1_780_731_605_000_000_000L);
+            v.setValueCount(1);
+            assertEquals(LocalDateTime.of(2026, 6, 6, 7, 40, 5), ArrowValues.toJavaValue(v, 0));
+        }
+    }
+}

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/ConvertTzFunctionIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/ConvertTzFunctionIT.java
@@ -1,0 +1,63 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.qa;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * End-to-end coverage for PPL {@code convert_tz(<varchar>, ...)} routed through
+ * {@code ConvertTzAdapter}. Pins the SAFE-cast paths in identity short-circuit
+ * (same from/to tz) and UDF fallback (different tzs).
+ */
+public class ConvertTzFunctionIT extends AnalyticsRestTestCase {
+
+    private static final Dataset DATASET = new Dataset("calcs", "calcs");
+
+    private static boolean dataProvisioned = false;
+
+    @Override
+    protected void onBeforeQuery() throws IOException {
+        if (dataProvisioned == false) {
+            DatasetProvisioner.provision(client(), DATASET);
+            dataProvisioned = true;
+        }
+    }
+
+    private String oneRow() {
+        return "source=" + DATASET.indexName + " | where key='key00' | head 1 ";
+    }
+
+    /** Same from/to tz with VARCHAR operand → identity short-circuit returns the timestamp unchanged. */
+    public void testIdentityShortCircuitWithVarcharOperand() throws IOException {
+        assertFirstRowString(
+            oneRow() + "| eval v = convert_tz('2021-05-12 11:34:50', '+00:00', '+00:00') | fields v",
+            "2021-05-12 11:34:50"
+        );
+    }
+
+    /** Different from/to tz with VARCHAR operand → UDF fallback applies the offset. */
+    public void testUdfFallbackWithVarcharOperand() throws IOException {
+        assertFirstRowString(
+            oneRow() + "| eval v = convert_tz('2021-05-12 11:34:50', '+00:00', '-08:00') | fields v",
+            "2021-05-12 03:34:50"
+        );
+    }
+
+    private void assertFirstRowString(String ppl, String expected) throws IOException {
+        Map<String, Object> response = executePpl(ppl);
+        @SuppressWarnings("unchecked")
+        List<List<Object>> rows = (List<List<Object>>) response.get("datarows");
+        assertNotNull("Response missing 'datarows' for query: " + ppl, rows);
+        assertTrue("Expected at least one row for query: " + ppl, rows.size() >= 1);
+        Object cell = rows.get(0).get(0);
+        assertEquals("Value mismatch for query: " + ppl, expected, cell);
+    }
+}

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/DatetimeFunctionIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/DatetimeFunctionIT.java
@@ -1,0 +1,75 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.qa;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * End-to-end coverage for single-arg PPL {@code DATETIME(string)} routed through
+ * {@code DateTimeAdapters.DatetimeAdapter}. Single-arg form keeps wall-clock semantics:
+ * any trailing offset suffix (+HH:MM / -HHMM / Z) is stripped, then parsed.
+ */
+public class DatetimeFunctionIT extends AnalyticsRestTestCase {
+
+    private static final Dataset DATASET = new Dataset("calcs", "calcs");
+
+    private static boolean dataProvisioned = false;
+
+    @Override
+    protected void onBeforeQuery() throws IOException {
+        if (dataProvisioned == false) {
+            DatasetProvisioner.provision(client(), DATASET);
+            dataProvisioned = true;
+        }
+    }
+
+    private String oneRow() {
+        return "source=" + DATASET.indexName + " | where key='key00' | head 1 ";
+    }
+
+    public void testNoOffsetIdentity() throws IOException {
+        assertFirstRowString(
+            oneRow() + "| eval v = datetime('2008-01-01 02:00:00') | fields v",
+            "2008-01-01 02:00:00"
+        );
+    }
+
+    public void testPositiveOffsetStripped() throws IOException {
+        assertFirstRowString(
+            oneRow() + "| eval v = datetime('2008-01-01 02:00:00+10:00') | fields v",
+            "2008-01-01 02:00:00"
+        );
+    }
+
+    public void testNegativeOffsetStripped() throws IOException {
+        assertFirstRowString(
+            oneRow() + "| eval v = datetime('2008-01-01 02:00:00-05:00') | fields v",
+            "2008-01-01 02:00:00"
+        );
+    }
+
+    public void testZSuffixStripped() throws IOException {
+        assertFirstRowString(
+            oneRow() + "| eval v = datetime('2008-01-01T02:00:00Z') | fields v",
+            "2008-01-01 02:00:00"
+        );
+    }
+
+    private void assertFirstRowString(String ppl, String expected) throws IOException {
+        Map<String, Object> response = executePpl(ppl);
+        @SuppressWarnings("unchecked")
+        List<List<Object>> rows = (List<List<Object>>) response.get("datarows");
+        assertNotNull("Response missing 'datarows' for query: " + ppl, rows);
+        assertTrue("Expected at least one row for query: " + ppl, rows.size() >= 1);
+        Object cell = rows.get(0).get(0);
+        assertEquals("Value mismatch for query: " + ppl, expected, cell);
+    }
+}


### PR DESCRIPTION
### Description

Fixes three PPL query-shape issues in the sandbox parquet/datafusion path. All sandbox-side; no SQL plugin changes.

**Query shapes fixed**

| Shape | Was | Now |
|---|---|---|
| `eval x = curdate()` (and `current_date`, `curtime`, `current_time`) | wire returned raw long (epoch days / nanos-of-day, e.g. `20610`) | wire returns ISO string (`"2026-06-07"`, `"07:40:05.123"`) |
| `eval f = DATETIME('2008-01-01 02:00:00+10:00')` | UTC-converted `"2007-12-31 16:00:00"` | wall-clock kept `"2008-01-01 02:00:00"` |
| `eval x = convert_tz(<string-literal>, ...)` where the literal is the same in both tz args | `RexUtil.compatibleTypes` AssertionError on `VARCHAR` vs `TIMESTAMP(9)` | succeeds; SAFE cast handles invalid input as NULL |

**What changed**

- `ArrowValues` now emits Arrow Date/Time/Timestamp cells as `LocalDate` / `LocalTime` / `LocalDateTime`. The SQL plugin's `ExprValueUtils.fromObjectValue` routes these to `ExprDateValue` / `ExprTimeValue` / `ExprTimestampValue`, which format via `DateTimeFormatters` — so the wire response gets ISO strings without sandbox-side string formatting.
- `DatetimeAdapter` strips trailing offset suffix (`+HH:MM` / `-HHMM` / `Z`) from single-arg `DATETIME(<string>)` before passing to `to_timestamp`, so the result keeps wall-clock semantics. Gated on VARCHAR operands; TIMESTAMP inputs pass through unwrapped. Two-arg form unchanged.
- `ConvertTzAdapter` SAFE-casts the VARCHAR operand to TIMESTAMP in both the identity short-circuit and the UDF fallback so the surrounding Project rowType stays consistent.

### Check List

- [x] Functionality includes testing — `ArrowValuesTests` (13 cases) and `ConvertTzAdapterTests` cover both new SAFE-cast paths.
- [ ] API changes companion pull request created, if applicable.
- [ ] Public documentation issue/PR created, if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.