### PR TITLE
[Analytics-Engine] Route text-field filter to the keyword subfield

### DIFF
--- a/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/FieldStorageInfo.java
+++ b/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/FieldStorageInfo.java
@@ -31,12 +31,10 @@ public class FieldStorageInfo {
     private final boolean derived;
     private final LinkedHashSet<String> dependsOnPhysicalCols;
     /**
-     * For a {@code text} field that declares a {@code keyword} multifield, the subfield's name
-     * (e.g. {@code "keyword"}); {@code null} otherwise. Exact-equality predicates must target
-     * this subfield — a term query on the analyzed text field does not match (the analyzer
-     * lowercases/tokenizes the indexed value but a term query does not analyze its input).
+     * Subfield to target for exact-match (term) predicates — e.g. a text field's keyword
+     * multifield — or {@code null} when the field is queried directly. Resolved from the mapping.
      */
-    private final String keywordSubfield;
+    private final String exactMatchSubfield;
 
     public FieldStorageInfo(
         String fieldName,
@@ -52,7 +50,7 @@ public class FieldStorageInfo {
         this(fieldName, mappingType, fieldType, docValueFormats, indexFormats, storedFieldFormats, derived, new LinkedHashSet<>());
     }
 
-    /** Physical-field ctor with an explicit keyword multifield name (or {@code null} if none). */
+    /** Physical-field ctor with an explicit exact-match subfield name (or {@code null} if none). */
     public FieldStorageInfo(
         String fieldName,
         String mappingType,
@@ -61,7 +59,7 @@ public class FieldStorageInfo {
         List<String> indexFormats,
         List<String> storedFieldFormats,
         boolean derived,
-        String keywordSubfield
+        String exactMatchSubfield
     ) {
         this(
             fieldName,
@@ -72,7 +70,7 @@ public class FieldStorageInfo {
             storedFieldFormats,
             derived,
             new LinkedHashSet<>(),
-            keywordSubfield
+            exactMatchSubfield
         );
     }
 
@@ -98,7 +96,7 @@ public class FieldStorageInfo {
         List<String> storedFieldFormats,
         boolean derived,
         LinkedHashSet<String> dependsOnPhysicalCols,
-        String keywordSubfield
+        String exactMatchSubfield
     ) {
         this.fieldName = fieldName;
         this.mappingType = mappingType;
@@ -108,7 +106,7 @@ public class FieldStorageInfo {
         this.storedFieldFormats = storedFieldFormats;
         this.derived = derived;
         this.dependsOnPhysicalCols = dependsOnPhysicalCols;
-        this.keywordSubfield = keywordSubfield;
+        this.exactMatchSubfield = exactMatchSubfield;
     }
 
     /** Creates a derived column (agg result, expression) with no physical storage and no deps.
@@ -139,9 +137,10 @@ public class FieldStorageInfo {
         return fieldName;
     }
 
-    /** Name of this text field's {@code keyword} multifield (e.g. {@code "keyword"}), or {@code null}. */
-    public String getKeywordSubfield() {
-        return keywordSubfield;
+    /** Subfield to target for exact-match (term) predicates — e.g. a text field's {@code keyword}
+     *  multifield — or {@code null} when the field is queried directly. */
+    public String getExactMatchSubfield() {
+        return exactMatchSubfield;
     }
 
     public String getMappingType() {

--- a/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/FieldStorageInfo.java
+++ b/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/FieldStorageInfo.java
@@ -30,6 +30,13 @@ public class FieldStorageInfo {
     private final List<String> storedFieldFormats;
     private final boolean derived;
     private final LinkedHashSet<String> dependsOnPhysicalCols;
+    /**
+     * For a {@code text} field that declares a {@code keyword} multifield, the subfield's name
+     * (e.g. {@code "keyword"}); {@code null} otherwise. Exact-equality predicates must target
+     * this subfield — a term query on the analyzed text field does not match (the analyzer
+     * lowercases/tokenizes the indexed value but a term query does not analyze its input).
+     */
+    private final String keywordSubfield;
 
     public FieldStorageInfo(
         String fieldName,
@@ -45,6 +52,30 @@ public class FieldStorageInfo {
         this(fieldName, mappingType, fieldType, docValueFormats, indexFormats, storedFieldFormats, derived, new LinkedHashSet<>());
     }
 
+    /** Physical-field ctor with an explicit keyword multifield name (or {@code null} if none). */
+    public FieldStorageInfo(
+        String fieldName,
+        String mappingType,
+        FieldType fieldType,
+        List<String> docValueFormats,
+        List<String> indexFormats,
+        List<String> storedFieldFormats,
+        boolean derived,
+        String keywordSubfield
+    ) {
+        this(
+            fieldName,
+            mappingType,
+            fieldType,
+            docValueFormats,
+            indexFormats,
+            storedFieldFormats,
+            derived,
+            new LinkedHashSet<>(),
+            keywordSubfield
+        );
+    }
+
     public FieldStorageInfo(
         String fieldName,
         String mappingType,
@@ -55,6 +86,20 @@ public class FieldStorageInfo {
         boolean derived,
         LinkedHashSet<String> dependsOnPhysicalCols
     ) {
+        this(fieldName, mappingType, fieldType, docValueFormats, indexFormats, storedFieldFormats, derived, dependsOnPhysicalCols, null);
+    }
+
+    public FieldStorageInfo(
+        String fieldName,
+        String mappingType,
+        FieldType fieldType,
+        List<String> docValueFormats,
+        List<String> indexFormats,
+        List<String> storedFieldFormats,
+        boolean derived,
+        LinkedHashSet<String> dependsOnPhysicalCols,
+        String keywordSubfield
+    ) {
         this.fieldName = fieldName;
         this.mappingType = mappingType;
         this.fieldType = fieldType;
@@ -63,6 +108,7 @@ public class FieldStorageInfo {
         this.storedFieldFormats = storedFieldFormats;
         this.derived = derived;
         this.dependsOnPhysicalCols = dependsOnPhysicalCols;
+        this.keywordSubfield = keywordSubfield;
     }
 
     /** Creates a derived column (agg result, expression) with no physical storage and no deps.
@@ -91,6 +137,11 @@ public class FieldStorageInfo {
 
     public String getFieldName() {
         return fieldName;
+    }
+
+    /** Name of this text field's {@code keyword} multifield (e.g. {@code "keyword"}), or {@code null}. */
+    public String getKeywordSubfield() {
+        return keywordSubfield;
     }
 
     public String getMappingType() {

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/EqualsSerializer.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/EqualsSerializer.java
@@ -58,7 +58,14 @@ public class EqualsSerializer extends AbstractQuerySerializer {
             );
         }
 
-        String fieldName = FieldStorageInfo.resolve(fieldStorage, columnRef.getIndex()).getFieldName();
+        FieldStorageInfo field = FieldStorageInfo.resolve(fieldStorage, columnRef.getIndex());
+        // Exact equality on a text field must target its keyword multifield: a term query on the
+        // analyzed text field never matches (the analyzer lowercases/tokenizes the indexed value,
+        // but a term query does not analyze its input). Mirrors the SQL engine's convertTextToKeyword.
+        // Text fields without a keyword subfield fall back to the base name (analyzed term — same as SQL).
+        String fieldName = field.getKeywordSubfield() != null
+            ? field.getFieldName() + "." + field.getKeywordSubfield()
+            : field.getFieldName();
         // Calcite stores literals in canonical types (BigDecimal for ints, NlsString for
         // strings, etc.) that the OpenSearch Mapper can't parse directly. Convert at the
         // Calcite ↔ OpenSearch boundary so the mapper sees plain Java types.

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/EqualsSerializer.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/EqualsSerializer.java
@@ -59,12 +59,10 @@ public class EqualsSerializer extends AbstractQuerySerializer {
         }
 
         FieldStorageInfo field = FieldStorageInfo.resolve(fieldStorage, columnRef.getIndex());
-        // Exact equality on a text field must target its keyword multifield: a term query on the
-        // analyzed text field never matches (the analyzer lowercases/tokenizes the indexed value,
-        // but a term query does not analyze its input). Mirrors the SQL engine's convertTextToKeyword.
-        // Text fields without a keyword subfield fall back to the base name (analyzed term — same as SQL).
-        String fieldName = field.getKeywordSubfield() != null
-            ? field.getFieldName() + "." + field.getKeywordSubfield()
+        // Route exact equality to the field's exact-match subfield when it has one (e.g. text →
+        // .keyword); else query the field directly. Mirrors the SQL engine's text→keyword rewrite.
+        String fieldName = field.getExactMatchSubfield() != null
+            ? field.getFieldName() + "." + field.getExactMatchSubfield()
             : field.getFieldName();
         // Calcite stores literals in canonical types (BigDecimal for ints, NlsString for
         // strings, etc.) that the OpenSearch Mapper can't parse directly. Convert at the

--- a/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/QuerySerializerRegistryTests.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/QuerySerializerRegistryTests.java
@@ -40,6 +40,7 @@ import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryStringQueryBuilder;
 import org.opensearch.index.query.SimpleQueryStringBuilder;
 import org.opensearch.index.query.SimpleQueryStringFlag;
+import org.opensearch.index.query.TermQueryBuilder;
 import org.opensearch.index.query.WildcardQueryBuilder;
 import org.opensearch.test.OpenSearchTestCase;
 
@@ -64,6 +65,7 @@ public class QuerySerializerRegistryTests extends OpenSearchTestCase {
             new NamedWriteableRegistry.Entry(QueryBuilder.class, QueryStringQueryBuilder.NAME, QueryStringQueryBuilder::new),
             new NamedWriteableRegistry.Entry(QueryBuilder.class, SimpleQueryStringBuilder.NAME, SimpleQueryStringBuilder::new),
             new NamedWriteableRegistry.Entry(QueryBuilder.class, WildcardQueryBuilder.NAME, WildcardQueryBuilder::new),
+            new NamedWriteableRegistry.Entry(QueryBuilder.class, TermQueryBuilder.NAME, TermQueryBuilder::new),
             new NamedWriteableRegistry.Entry(QueryBuilder.class, MatchAllQueryBuilder.NAME, MatchAllQueryBuilder::new)
         )
     );
@@ -564,6 +566,80 @@ public class QuerySerializerRegistryTests extends OpenSearchTestCase {
 
         IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () -> serializer.serialize(call, fieldStorage));
         assertTrue("Exception message must contain 'query', got: " + exception.getMessage(), exception.getMessage().contains("query"));
+    }
+
+    // --- EQUALS text-field routing tests ---
+
+    /**
+     * EQUALS on a TEXT field that has a keyword multifield must build the TermQuery against the
+     * {@code .keyword} subfield. A raw TermQuery on the analyzed text field matches nothing
+     * (the analyzer lowercases/ tokenizes the indexed value, but TermQuery does not analyze the
+     * input). Mirrors the SQL engine's {@code OpenSearchTextType.convertTextToKeyword}.
+     */
+    public void testEqualsOnTextFieldWithKeywordSubfieldRoutesToKeyword() throws IOException {
+        DelegatedPredicateSerializer serializer = serializers.get(ScalarFunction.EQUALS);
+        assertNotNull("EQUALS serializer must be registered", serializer);
+
+        RelDataType varcharType = typeFactory.createSqlType(SqlTypeName.VARCHAR);
+        RexCall call = (RexCall) rexBuilder.makeCall(
+            SqlStdOperatorTable.EQUALS,
+            rexBuilder.makeInputRef(varcharType, 0),
+            rexBuilder.makeLiteral("F")
+        );
+        // text field "gender" WITH a keyword subfield named "keyword".
+        List<FieldStorageInfo> fieldStorage = List.of(
+            new FieldStorageInfo("gender", "text", FieldType.TEXT, List.of(), List.of("lucene"), List.of(), false, "keyword")
+        );
+
+        byte[] serialized = serializer.serialize(call, fieldStorage);
+        try (StreamInput input = new NamedWriteableAwareStreamInput(StreamInput.wrap(serialized), WRITEABLE_REGISTRY)) {
+            TermQueryBuilder term = (TermQueryBuilder) input.readNamedWriteable(QueryBuilder.class);
+            assertEquals("gender.keyword", term.fieldName());
+            assertEquals("F", term.value());
+        }
+    }
+
+    /**
+     * EQUALS on a TEXT field with NO keyword subfield leaves the field name unchanged (graceful
+     * fallback — same as the SQL engine, which only rewrites when a keyword subfield exists).
+     */
+    public void testEqualsOnTextFieldWithoutKeywordSubfieldKeepsField() throws IOException {
+        DelegatedPredicateSerializer serializer = serializers.get(ScalarFunction.EQUALS);
+        RelDataType varcharType = typeFactory.createSqlType(SqlTypeName.VARCHAR);
+        RexCall call = (RexCall) rexBuilder.makeCall(
+            SqlStdOperatorTable.EQUALS,
+            rexBuilder.makeInputRef(varcharType, 0),
+            rexBuilder.makeLiteral("F")
+        );
+        List<FieldStorageInfo> fieldStorage = List.of(
+            new FieldStorageInfo("gender", "text", FieldType.TEXT, List.of(), List.of("lucene"), List.of(), false)
+        );
+        byte[] serialized = serializer.serialize(call, fieldStorage);
+        try (StreamInput input = new NamedWriteableAwareStreamInput(StreamInput.wrap(serialized), WRITEABLE_REGISTRY)) {
+            TermQueryBuilder term = (TermQueryBuilder) input.readNamedWriteable(QueryBuilder.class);
+            assertEquals("gender", term.fieldName());
+        }
+    }
+
+    /**
+     * EQUALS on a KEYWORD field is unchanged — no rewrite (it's already exact-match).
+     */
+    public void testEqualsOnKeywordFieldUnchanged() throws IOException {
+        DelegatedPredicateSerializer serializer = serializers.get(ScalarFunction.EQUALS);
+        RelDataType varcharType = typeFactory.createSqlType(SqlTypeName.VARCHAR);
+        RexCall call = (RexCall) rexBuilder.makeCall(
+            SqlStdOperatorTable.EQUALS,
+            rexBuilder.makeInputRef(varcharType, 0),
+            rexBuilder.makeLiteral("Amber")
+        );
+        List<FieldStorageInfo> fieldStorage = List.of(
+            new FieldStorageInfo("firstname", "keyword", FieldType.KEYWORD, List.of(), List.of("lucene"), List.of(), false)
+        );
+        byte[] serialized = serializer.serialize(call, fieldStorage);
+        try (StreamInput input = new NamedWriteableAwareStreamInput(StreamInput.wrap(serialized), WRITEABLE_REGISTRY)) {
+            TermQueryBuilder term = (TermQueryBuilder) input.readNamedWriteable(QueryBuilder.class);
+            assertEquals("firstname", term.fieldName());
+        }
     }
 
     /**

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/FieldStorageResolver.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/FieldStorageResolver.java
@@ -160,17 +160,17 @@ public class FieldStorageResolver {
             indexFormats,
             storedFieldFormats,
             false,
-            keywordSubfieldOf(fieldType, fieldProps)
+            exactMatchSubfieldOf(fieldType, fieldProps)
         );
     }
 
     /**
      * For a {@code text} field with a {@code fields} multifield block, returns the name of the
      * first {@code keyword} subfield (e.g. {@code "keyword"}), or {@code null} if there is none.
-     * Exact-equality predicates route to this subfield (see {@link FieldStorageInfo#getKeywordSubfield()}).
+     * Exact-equality predicates route to this subfield (see {@link FieldStorageInfo#getExactMatchSubfield()}).
      */
     @SuppressWarnings("unchecked")
-    private static String keywordSubfieldOf(String fieldType, Map<String, Object> fieldProps) {
+    private static String exactMatchSubfieldOf(String fieldType, Map<String, Object> fieldProps) {
         if (!"text".equals(fieldType)) {
             return null;
         }

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/FieldStorageResolver.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/FieldStorageResolver.java
@@ -159,7 +159,30 @@ public class FieldStorageResolver {
             docValueFormats,
             indexFormats,
             storedFieldFormats,
-            false
+            false,
+            keywordSubfieldOf(fieldType, fieldProps)
         );
+    }
+
+    /**
+     * For a {@code text} field with a {@code fields} multifield block, returns the name of the
+     * first {@code keyword} subfield (e.g. {@code "keyword"}), or {@code null} if there is none.
+     * Exact-equality predicates route to this subfield (see {@link FieldStorageInfo#getKeywordSubfield()}).
+     */
+    @SuppressWarnings("unchecked")
+    private static String keywordSubfieldOf(String fieldType, Map<String, Object> fieldProps) {
+        if (!"text".equals(fieldType)) {
+            return null;
+        }
+        Object fields = fieldProps.get("fields");
+        if (!(fields instanceof Map<?, ?> subfields)) {
+            return null;
+        }
+        for (Map.Entry<?, ?> entry : subfields.entrySet()) {
+            if (entry.getValue() instanceof Map<?, ?> subProps && "keyword".equals(subProps.get("type"))) {
+                return String.valueOf(entry.getKey());
+            }
+        }
+        return null;
     }
 }

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/FieldStorageResolverTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/FieldStorageResolverTests.java
@@ -36,6 +36,25 @@ public class FieldStorageResolverTests extends OpenSearchTestCase {
         assertEquals(List.of("lucene"), info.getIndexFormats());
     }
 
+    public void testTextFieldWithKeywordSubfieldCapturesSubfieldName() {
+        FieldStorageResolver resolver = newResolver(
+            "parquet",
+            Map.of("gender", Map.of("type", "text", "fields", Map.of("keyword", Map.of("type", "keyword"))))
+        );
+        FieldStorageInfo info = resolver.resolve(List.of("gender")).get(0);
+        assertEquals("keyword", info.getKeywordSubfield());
+    }
+
+    public void testTextFieldWithoutKeywordSubfieldHasNullSubfield() {
+        FieldStorageResolver resolver = newResolver("parquet", Map.of("name", Map.of("type", "text")));
+        assertNull(resolver.resolve(List.of("name")).get(0).getKeywordSubfield());
+    }
+
+    public void testKeywordFieldHasNullSubfield() {
+        FieldStorageResolver resolver = newResolver("parquet", Map.of("tag", Map.of("type", "keyword")));
+        assertNull(resolver.resolve(List.of("tag")).get(0).getKeywordSubfield());
+    }
+
     public void testLongFieldGetsDocValuesInPrimaryFormat() {
         FieldStorageResolver resolver = newResolver("parquet", Map.of("age", Map.of("type", "long")));
 

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/FieldStorageResolverTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/FieldStorageResolverTests.java
@@ -42,17 +42,17 @@ public class FieldStorageResolverTests extends OpenSearchTestCase {
             Map.of("gender", Map.of("type", "text", "fields", Map.of("keyword", Map.of("type", "keyword"))))
         );
         FieldStorageInfo info = resolver.resolve(List.of("gender")).get(0);
-        assertEquals("keyword", info.getKeywordSubfield());
+        assertEquals("keyword", info.getExactMatchSubfield());
     }
 
     public void testTextFieldWithoutKeywordSubfieldHasNullSubfield() {
         FieldStorageResolver resolver = newResolver("parquet", Map.of("name", Map.of("type", "text")));
-        assertNull(resolver.resolve(List.of("name")).get(0).getKeywordSubfield());
+        assertNull(resolver.resolve(List.of("name")).get(0).getExactMatchSubfield());
     }
 
     public void testKeywordFieldHasNullSubfield() {
         FieldStorageResolver resolver = newResolver("parquet", Map.of("tag", Map.of("type", "keyword")));
-        assertNull(resolver.resolve(List.of("tag")).get(0).getKeywordSubfield());
+        assertNull(resolver.resolve(List.of("tag")).get(0).getExactMatchSubfield());
     }
 
     public void testLongFieldGetsDocValuesInPrimaryFormat() {

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/FilterDelegationIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/FilterDelegationIT.java
@@ -393,6 +393,89 @@ public class FilterDelegationIT extends AnalyticsRestTestCase {
         client().performRequest(req);
     }
 
+    private static final String KEYWORD_SUBFIELD_INDEX = "text_equals_keyword_subfield_e2e";
+
+    /**
+     * EQUALS on a {@code text} field that has a {@code .keyword} multifield must match the exact,
+     * case-sensitive value by routing the delegated term query to {@code <field>.keyword} — a term
+     * query does not analyze its input, so a term against the analyzed text field would compare the
+     * raw value (e.g. {@code "Engineer"}) to the lowercased indexed tokens ({@code "engineer"}) and
+     * match nothing. Before the fix this returned 0 rows; after, it matches via the keyword subfield.
+     */
+    public void testTextEqualsRoutesToKeywordSubfield() throws Exception {
+        createKeywordSubfieldIndex();
+
+        // 7 docs occupation="Engineer", 3 docs occupation="Doctor" (mixed case on purpose).
+        String exact = "source = " + KEYWORD_SUBFIELD_INDEX + " | where occupation = 'Engineer' | stats count() as c";
+        List<List<Object>> exactRows = rowsOf(executePplViaShim(exact));
+        assertEquals("scalar agg returns 1 row", 1, exactRows.size());
+        assertEquals("EQUALS on text field matches the exact (case-sensitive) keyword value", 7L,
+            ((Number) exactRows.get(0).get(0)).longValue());
+
+        // The lowercased form must NOT match: routing to .keyword is exact/case-sensitive, so
+        // 'engineer' != 'Engineer'. (A term query on the analyzed text field would wrongly match
+        // here — this asserts we are on the keyword path, not the analyzed-text path.)
+        String wrongCase = "source = " + KEYWORD_SUBFIELD_INDEX + " | where occupation = 'engineer' | stats count() as c";
+        List<List<Object>> wrongCaseRows = rowsOf(executePplViaShim(wrongCase));
+        assertEquals("lowercase value must not match the exact keyword value", 0L,
+            ((Number) wrongCaseRows.get(0).get(0)).longValue());
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<List<Object>> rowsOf(Map<String, Object> result) {
+        List<List<Object>> rows = (List<List<Object>>) result.get("rows");
+        assertNotNull("rows must not be null", rows);
+        return rows;
+    }
+
+    private void createKeywordSubfieldIndex() throws Exception {
+        try {
+            client().performRequest(new Request("DELETE", "/" + KEYWORD_SUBFIELD_INDEX));
+        } catch (Exception ignored) {}
+
+        String body = "{"
+            + "\"settings\": {"
+            + "  \"number_of_shards\": 1,"
+            + "  \"number_of_replicas\": 0,"
+            + "  \"index.pluggable.dataformat.enabled\": true,"
+            + "  \"index.pluggable.dataformat\": \"composite\","
+            + "  \"index.composite.primary_data_format\": \"parquet\","
+            + "  \"index.composite.secondary_data_formats\": \"lucene\""
+            + "},"
+            + "\"mappings\": {"
+            + "  \"properties\": {"
+            + "    \"occupation\": { \"type\": \"text\", \"fields\": { \"keyword\": { \"type\": \"keyword\" } } },"
+            + "    \"value\": { \"type\": \"integer\" }"
+            + "  }"
+            + "}"
+            + "}";
+
+        Request createIndex = new Request("PUT", "/" + KEYWORD_SUBFIELD_INDEX);
+        createIndex.setJsonEntity(body);
+        Map<String, Object> response = assertOkAndParse(client().performRequest(createIndex), "Create index");
+        assertEquals(true, response.get("acknowledged"));
+
+        Request health = new Request("GET", "/_cluster/health/" + KEYWORD_SUBFIELD_INDEX);
+        health.addParameter("wait_for_status", "green");
+        health.addParameter("timeout", "30s");
+        client().performRequest(health);
+
+        StringBuilder bulk = new StringBuilder();
+        for (int i = 0; i < 7; i++) {
+            bulk.append("{\"index\": {}}\n");
+            bulk.append("{\"occupation\": \"Engineer\", \"value\": 5}\n");
+        }
+        for (int i = 0; i < 3; i++) {
+            bulk.append("{\"index\": {}}\n");
+            bulk.append("{\"occupation\": \"Doctor\", \"value\": 3}\n");
+        }
+        Request bulkRequest = new Request("POST", "/" + KEYWORD_SUBFIELD_INDEX + "/_bulk");
+        bulkRequest.setJsonEntity(bulk.toString());
+        bulkRequest.addParameter("refresh", "true");
+        client().performRequest(bulkRequest);
+        client().performRequest(new Request("POST", "/" + KEYWORD_SUBFIELD_INDEX + "/_flush?force=true"));
+    }
+
     private void createIndex() throws Exception {
         try {
             client().performRequest(new Request("DELETE", "/" + INDEX_NAME));


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Equality on a `text` field returned zero rows: the delegated predicate built a term query on the analyzed text field, but a term query does not analyze its input, so it never matched the analyzed (e.g. lowercased) indexed tokens. Keyword fields were unaffected.

Capture a text field's keyword multifield name in FieldStorageInfo (populated by FieldStorageResolver from the mapping's `fields` block), and have EqualsSerializer target `field.<keyword>` when present. Text fields without a keyword subfield keep the base name. Mirrors the SQL engine's OpenSearchTextType.convertTextToKeyword.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
