### PR TITLE
Fix: TopK rewriter must honor sort.offset in shard-fetch sizing

### DIFF
--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchTopKRewriter.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchTopKRewriter.java
@@ -60,7 +60,19 @@ public final class OpenSearchTopKRewriter {
         double factor = resolveOversamplingFactor(context);
         if (factor <= 0.0) return Optional.empty();
 
-        long coordLimit = (sort.fetch instanceof RexLiteral lit) ? RexLiteral.intValue(lit) : 10_000L;
+        // coordLimit is the rank the coordinator must satisfy after merging shard streams: for
+        // `head N from M` it skips M then takes N, so the merged stream needs the global top-(M+N).
+        // Non-literal offsets bail to no-pushdown (PPL only emits literal offsets).
+        long fetch = (sort.fetch instanceof RexLiteral lit) ? RexLiteral.intValue(lit) : 10_000L;
+        long offset;
+        if (sort.offset == null) {
+            offset = 0L;
+        } else if (sort.offset instanceof RexLiteral lit) {
+            offset = RexLiteral.intValue(lit);
+        } else {
+            return Optional.empty();
+        }
+        long coordLimit = offset + fetch;
         long shardSize = (long) Math.ceil(coordLimit * factor) + coordLimit;
         if (shardSize > Integer.MAX_VALUE) return Optional.empty();
 

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/TopKRewriterPlanShapeTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/TopKRewriterPlanShapeTests.java
@@ -16,6 +16,7 @@ import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.AggregateCall;
 import org.apache.calcite.rel.logical.LogicalAggregate;
 import org.apache.calcite.rel.logical.LogicalSort;
+import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.util.ImmutableBitSet;
@@ -129,7 +130,7 @@ public class TopKRewriterPlanShapeTests extends PlanShapeTestBase {
         String plan = RelOptUtil.toString(result);
         long sortCount = plan.lines().filter(l -> l.contains("OpenSearchSort")).count();
         assertTrue("a per-partition Sort must be inserted", sortCount >= 2);
-        // Shard Sort fetch = ceil(innerFetch * factor) + innerFetch = ceil(10*2)+10 = 30.
+        // Shard Sort fetch = offset + ceil(fetch * factor) + fetch = 0 + ceil(10*2) + 10 = 30.
         assertTrue("shard Sort must be sized off the inner fetch (30), got plan:\n" + plan, plan.contains("fetch=[30]"));
         assertFalse("shard Sort must NOT be sized off the 10000 system cap (30000)", plan.contains("fetch=[30000]"));
     }
@@ -221,6 +222,101 @@ public class TopKRewriterPlanShapeTests extends PlanShapeTestBase {
                 """,
             result
         );
+    }
+
+    /**
+     * {@code head 10 from 1000}: PPL emits {@code Sort(collation, offset=1000, fetch=10)}. The
+     * coordinator skips 1000 then takes 10, so its merged stream must contain the global top-1010
+     * — i.e. {@code coordLimit = offset + fetch}. Shard fetch is then the usual oversampling
+     * formula applied to that coord limit: {@code ceil(coordLimit * factor) + coordLimit}.
+     *
+     * <p>Expected shard fetch: {@code ceil(1010*2) + 1010 = 3030}. Without offset handling the
+     * rewriter used {@code coordLimit = fetch = 10}, so each shard shipped 30 rows, the
+     * coordinator skipped 1000, and the result was empty.
+     */
+    public void testRewrite_sortWithOffset_shardFetchHonorsOffset() {
+        RelOptTable table = mockTable("test_index", "status", "size");
+        RelNode scan = stubScan(table);
+        LogicalAggregate agg = LogicalAggregate.create(scan, List.of(), ImmutableBitSet.of(0), null, List.of(countStarCall()));
+        RelNode sort = LogicalSort.create(
+            agg,
+            RelCollations.of(new RelFieldCollation(1, RelFieldCollation.Direction.DESCENDING)),
+            rexBuilder.makeLiteral(1000, typeFactory.createSqlType(SqlTypeName.INTEGER), true),
+            rexBuilder.makeLiteral(10, typeFactory.createSqlType(SqlTypeName.INTEGER), true)
+        );
+        RelNode result = runPlanner(sort, contextWithOversampling(2.0));
+        String plan = RelOptUtil.toString(result);
+        assertTrue(
+            "shard Sort must be sized as ceil((offset+fetch)*factor) + (offset+fetch) = 3030, got plan:\n" + plan,
+            plan.contains("fetch=[3030]")
+        );
+        // Pre-fix bug: shard Sort sized off bare fetch (30) — coordinator's skip-1000 would have emptied the result.
+        assertFalse("shard Sort must NOT be sized off fetch alone (30)", plan.contains("fetch=[30]"));
+    }
+
+    /**
+     * factor=1.0 with offset: oversampling collapses to {@code 2 * coordLimit}. For
+     * {@code head 10 from 1000} → 2*1010 = 2020. coordLimit = offset+fetch is still honored;
+     * factor=1 just removes the per-coord-row padding multiplier.
+     */
+    public void testRewrite_factorOne_twiceCoordLimit() {
+        RelOptTable table = mockTable("test_index", "status", "size");
+        RelNode scan = stubScan(table);
+        LogicalAggregate agg = LogicalAggregate.create(scan, List.of(), ImmutableBitSet.of(0), null, List.of(countStarCall()));
+        RelNode sort = LogicalSort.create(
+            agg,
+            RelCollations.of(new RelFieldCollation(1, RelFieldCollation.Direction.DESCENDING)),
+            rexBuilder.makeLiteral(1000, typeFactory.createSqlType(SqlTypeName.INTEGER), true),
+            rexBuilder.makeLiteral(10, typeFactory.createSqlType(SqlTypeName.INTEGER), true)
+        );
+        RelNode result = runPlanner(sort, contextWithOversampling(1.0));
+        String plan = RelOptUtil.toString(result);
+        assertTrue("factor=1 → shard fetch = 2 * (offset+fetch) = 2020, got plan:\n" + plan, plan.contains("fetch=[2020]"));
+    }
+
+    /**
+     * Offset close to {@code Integer.MAX_VALUE} pushes shardSize past int range — rewriter must
+     * bail (no per-partition Sort inserted). Without the bail an int overflow would produce a
+     * negative or wrong fetch literal.
+     */
+    public void testRewrite_offsetOverflow_bails() {
+        RelOptTable table = mockTable("test_index", "status", "size");
+        RelNode scan = stubScan(table);
+        LogicalAggregate agg = LogicalAggregate.create(scan, List.of(), ImmutableBitSet.of(0), null, List.of(countStarCall()));
+        RelNode sort = LogicalSort.create(
+            agg,
+            RelCollations.of(new RelFieldCollation(1, RelFieldCollation.Direction.DESCENDING)),
+            rexBuilder.makeLiteral(Integer.MAX_VALUE - 5, typeFactory.createSqlType(SqlTypeName.INTEGER), true),
+            rexBuilder.makeLiteral(10, typeFactory.createSqlType(SqlTypeName.INTEGER), true)
+        );
+        RelNode result = runPlanner(sort, contextWithOversampling(2.0));
+        String plan = RelOptUtil.toString(result);
+        long sortCount = plan.lines().filter(l -> l.contains("OpenSearchSort")).count();
+        assertEquals("overflow → no per-partition Sort inserted", 1, sortCount);
+    }
+
+    /**
+     * Non-literal offset (parameterized expression): rewriter bails to no-pushdown rather than
+     * guessing a value. Each shard ships everything; correct but slow. PPL emits literal offsets
+     * in practice, so this is a defensive check.
+     */
+    public void testRewrite_nonLiteralOffset_bails() {
+        RelOptTable table = mockTable("test_index", "status", "size");
+        RelNode scan = stubScan(table);
+        LogicalAggregate agg = LogicalAggregate.create(scan, List.of(), ImmutableBitSet.of(0), null, List.of(countStarCall()));
+        RexNode lit5 = rexBuilder.makeLiteral(5, typeFactory.createSqlType(SqlTypeName.INTEGER), true);
+        RexNode lit10 = rexBuilder.makeLiteral(10, typeFactory.createSqlType(SqlTypeName.INTEGER), true);
+        RexNode nonLiteralOffset = rexBuilder.makeCall(SqlStdOperatorTable.PLUS, lit5, lit10);
+        RelNode sort = LogicalSort.create(
+            agg,
+            RelCollations.of(new RelFieldCollation(1, RelFieldCollation.Direction.DESCENDING)),
+            nonLiteralOffset,
+            rexBuilder.makeLiteral(10, typeFactory.createSqlType(SqlTypeName.INTEGER), true)
+        );
+        RelNode result = runPlanner(sort, contextWithOversampling(2.0));
+        String plan = RelOptUtil.toString(result);
+        long sortCount = plan.lines().filter(l -> l.contains("OpenSearchSort")).count();
+        assertEquals("non-literal offset → no per-partition Sort inserted", 1, sortCount);
     }
 
     // ── Helpers ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
PPL sort -c | head N from M lowers to Sort(collation, offset=M, fetch=N). The coordinator merges shard streams, skips M, then takes N — so its merged stream must hold the global top-(M+N). The TopK rewriter sized the shard fetch from coordLimit = N alone, ignoring the offset. Each shard shipped only oversample × N rows, the coordinator's skip-M then emptied the result, and offset queries (e.g. TPC-H q39–q43) returned 0 rows whenever oversampling was on.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
