### PR TITLE
Fix performance-delegation demotion in filter delegation; remove fuse_dual_viable setting

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/bool_tree.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/bool_tree.rs
@@ -183,18 +183,16 @@ impl BoolNode {
         }
     }
 
-    /// Demote every `DelegationPossible` leaf to a plain `Predicate` carrying its
-    /// `original_expr`. Called when the filter classifies as `FilterClass::Tree`
-    /// (i.e. has any OR or NOT in its shape) — the bitmap-tree evaluator currently
-    /// has `unimplemented!()` arms for `DelegationPossible`, so any disjunctive query
-    /// containing a performance-delegated leaf would otherwise crash the data node.
+    /// Demote every `DelegationPossible` leaf to a plain native `Predicate`. Called for
+    /// `FilterClass::Tree` plans (any OR/NOT), whose evaluator can't run `DelegationPossible`.
+    /// The coordinator never puts perf directly under OR/NOT, but an AND-side perf leaf can ride
+    /// in a tree that still has a surviving OR/NOT (e.g. `tag=a AND (dual OR native)`); demoting
+    /// it to native keeps results correct, just skipping the opportunistic peer consult.
     ///
-    /// Demotion is a uniform, position-blind transform: every DelegationPossible in
-    /// the tree becomes a Predicate, even ones under all-AND ancestry within the
-    /// tree. That sacrifices the AND-side perf-delegation opportunity for those
-    /// queries — acceptable v1 trade-off — in exchange for "doesn't crash."
-    /// Position-aware demotion (only OR/NOT-positioned leaves) would need
-    /// DelegationPossible support in the bitmap-tree evaluator.
+    /// FIXME: move this Tree-classification awareness into the coordinator so it never emits a
+    /// `delegation_possible` that reaches a Tree plan; then this method goes away and the
+    /// evaluator arms can throw. Pairs with implementing performance delegation under OR/NOT in
+    /// the Tree-path evaluator.
     pub fn demote_delegation_possible(self) -> BoolNode {
         match self {
             BoolNode::And(children) => {

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/FilterDelegationForIndexFullConversionTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/FilterDelegationForIndexFullConversionTests.java
@@ -244,7 +244,7 @@ public class FilterDelegationForIndexFullConversionTests extends OpenSearchTestC
         RelNode marked = PlannerImpl.runAllOptimizations(filter, context);
         QueryDAG dag = DAGBuilder.build(marked, context.getCapabilityRegistry(), mockClusterService(), TEST_RESOLVER);
         PlanForker.forkAll(dag, context.getCapabilityRegistry());
-        FragmentConversionDriver.convertAll(dag, context.getCapabilityRegistry(), false);
+        FragmentConversionDriver.convertAll(dag, context.getCapabilityRegistry());
 
         Stage leaf = dag.rootStage();
         while (!leaf.getChildStages().isEmpty()) {

--- a/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/LuceneAnalyticsBackendPluginTests.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/LuceneAnalyticsBackendPluginTests.java
@@ -154,7 +154,7 @@ public class LuceneAnalyticsBackendPluginTests extends OpenSearchTestCase {
         PlanForker.forkAll(dag, context.getCapabilityRegistry());
         BackendPlanAdapter.adaptAll(dag, context.getCapabilityRegistry());
         PlanAlternativeSelector.selectAll(dag, context.getCapabilityRegistry(), false);
-        FragmentConversionDriver.convertAll(dag, context.getCapabilityRegistry(), false);
+        FragmentConversionDriver.convertAll(dag, context.getCapabilityRegistry());
 
         // Find the leaf stage (shard scan with filter)
         Stage leaf = dag.rootStage();

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/AnalyticsPlugin.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/AnalyticsPlugin.java
@@ -108,25 +108,6 @@ public class AnalyticsPlugin extends Plugin implements ExtensiblePlugin, ActionP
     );
 
     /**
-     * When {@code true} (default), performance-delegated leaves (driver natively evaluable,
-     * peer also viable) fuse with their correctness-delegated siblings even under {@code OR}
-     * / {@code NOT}. The combiner ships the entire boolean structure as a single delegated
-     * expression rather than throwing the dual-viable leaves back to native.
-     *
-     * <p>Default {@code true} — Lucene's term-dictionary random access typically beats
-     * managing per-leaf bitsets in DataFusion, so fusing the OR/NOT into one peer call is
-     * the favorable choice for the common workload. Flip to {@code false} for A/B comparison
-     * or to roll back if a workload regresses (e.g. very wide OR over highly-selective
-     * leaves where the driver's column scan would short-circuit before Lucene completes).
-     */
-    public static final Setting<Boolean> DELEGATION_FUSE_DUAL_VIABLE = Setting.boolSetting(
-        "analytics.delegation.fuse_dual_viable",
-        true,
-        Setting.Property.NodeScope,
-        Setting.Property.Dynamic
-    );
-
-    /**
      * Controls the metadata-only driver vs. value-producing peer choice when both are viable
      * for a stage:
      *
@@ -255,7 +236,6 @@ public class AnalyticsPlugin extends Plugin implements ExtensiblePlugin, ActionP
     public List<Setting<?>> getSettings() {
         List<Setting<?>> settings = new java.util.ArrayList<>();
         settings.add(COORDINATOR_BUFFER_LIMIT);
-        settings.add(DELEGATION_FUSE_DUAL_VIABLE);
         settings.add(PREFER_METADATA_DRIVER);
         settings.add(ReaderContextStore.READER_CONTEXT_KEEP_ALIVE);
         settings.addAll(org.opensearch.analytics.settings.AnalyticsApproximationSettings.all());

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/DefaultPlanExecutor.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/DefaultPlanExecutor.java
@@ -94,7 +94,6 @@ public class DefaultPlanExecutor extends HandledTransportAction<AnalyticsQueryRe
     private volatile long perQueryBufferLimit;
     private volatile int maxShardsPerQuery;
     private volatile int maxConcurrentShardRequestsPerNode;
-    private volatile boolean fuseDualViable;
     private volatile boolean preferMetadataDriver;
     private volatile double oversamplingFactor;
     private final IndexNameExpressionResolver indexNameExpressionResolver;
@@ -147,8 +146,6 @@ public class DefaultPlanExecutor extends HandledTransportAction<AnalyticsQueryRe
                 AnalyticsQuerySettings.MAX_CONCURRENT_SHARD_REQUESTS_PER_NODE,
                 v -> maxConcurrentShardRequestsPerNode = v
             );
-        this.fuseDualViable = AnalyticsPlugin.DELEGATION_FUSE_DUAL_VIABLE.get(clusterService.getSettings());
-        clusterService.getClusterSettings().addSettingsUpdateConsumer(AnalyticsPlugin.DELEGATION_FUSE_DUAL_VIABLE, v -> fuseDualViable = v);
         this.preferMetadataDriver = AnalyticsPlugin.PREFER_METADATA_DRIVER.get(clusterService.getSettings());
         clusterService.getClusterSettings()
             .addSettingsUpdateConsumer(AnalyticsPlugin.PREFER_METADATA_DRIVER, v -> preferMetadataDriver = v);
@@ -248,7 +245,7 @@ public class DefaultPlanExecutor extends HandledTransportAction<AnalyticsQueryRe
         // Collapse multi-backend stages to a single chosen alternative before conversion
         // so the convertor runs once per stage and the wire request carries one PlanAlternative.
         PlanAlternativeSelector.selectAll(dag, capabilityRegistry, preferMetadataDriver);
-        FragmentConversionDriver.convertAll(dag, capabilityRegistry, fuseDualViable);
+        FragmentConversionDriver.convertAll(dag, capabilityRegistry);
         final long planningTimeNanos = System.nanoTime() - planStartNanos;
         final long planningTimeMs = profile ? java.util.concurrent.TimeUnit.NANOSECONDS.toMillis(planningTimeNanos) : 0;
         logger.debug("[DefaultPlanExecutor] QueryDAG:\n{}", dag);

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/dag/DelegatedPredicateCombiner.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/dag/DelegatedPredicateCombiner.java
@@ -45,34 +45,33 @@ final class DelegatedPredicateCombiner {
     private final CapabilityRegistry registry;
     private final RexBuilder rexBuilder;
     private final List<DelegatedExpression> delegatedExpressions;
-    /**
-     * When true, dual-viable leaves are classified as correctness-delegated everywhere —
-     * the {@code delegation_possible} marker (driver-evaluates-natively + opportunistic peer
-     * consult) is not emitted under fuse=true. Result: one merged {@code delegated_predicate}
-     * ships the whole eligible subtree to the peer; the driver doesn't evaluate any
-     * delegatable arm itself. Trade-off: AND-side opportunistic optimization gone in
-     * exchange for cross-bucket merging under OR/NOT with native siblings.
-     */
-    private final boolean fuseDualViable;
 
     DelegatedPredicateCombiner(
         String operatorBackend,
         List<FieldStorageInfo> fieldStorage,
         CapabilityRegistry registry,
         RexBuilder rexBuilder,
-        List<DelegatedExpression> delegatedExpressions,
-        boolean fuseDualViable
+        List<DelegatedExpression> delegatedExpressions
     ) {
         this.operatorBackend = operatorBackend;
         this.fieldStorage = fieldStorage;
         this.registry = registry;
         this.rexBuilder = rexBuilder;
         this.delegatedExpressions = delegatedExpressions;
-        this.fuseDualViable = fuseDualViable;
     }
 
     /** Bottom-up: classify each node as Delegated (carries the RexNode subtree) or Resolved. */
     Classified classify(RexNode node, Function<OperatorAnnotation, RexNode> applyFn) {
+        return classify(node, applyFn, false);
+    }
+
+    /**
+     * @param underOrNot true when any ancestor is an OR/NOT. Performance delegation can't survive a
+     *                   disjunction, so a dual-viable leaf anywhere under an OR/NOT — even nested in
+     *                   an AND — is reclassified to correctness in combine(). Threaded so this
+     *                   happens before a mixed inner AND materializes and hides the perf marker.
+     */
+    private Classified classify(RexNode node, Function<OperatorAnnotation, RexNode> applyFn, boolean underOrNot) {
         if (node instanceof AnnotatedPredicate ap) {
             String backend = ap.getViableBackends().getFirst();
             if (!backend.equals(operatorBackend) && canSerialize(ap, backend)) {
@@ -80,10 +79,13 @@ final class DelegatedPredicateCombiner {
             } else if (!ap.getPerformanceDelegationBackends().isEmpty()) {
                 String peerBackend = ap.getPerformanceDelegationBackends().getFirst();
                 if (canSerialize(ap, peerBackend)) {
-                    // Under fuseDualViable, demote perf to correctness so the leaf merges
-                    // freely with correctness siblings and ships entirely to the peer.
-                    boolean isPerf = !fuseDualViable;
-                    return new Delegated(peerBackend, node, ap.getAnnotationId(), isPerf);
+                    // Dual-viable leaf → always performance-delegated. Demotion to correctness is
+                    // decided only by tree position in combine() (under OR/NOT), never here.
+                    // TODO: an AND-side perf leaf can still ride in a tree with a surviving OR/NOT
+                    // (e.g. tag=a AND (dual OR native)); the data node Tree-classifies the whole
+                    // tree and demotes this marker to native. Detecting that here would let the
+                    // data-node fallback be removed.
+                    return new Delegated(peerBackend, node, ap.getAnnotationId(), true);
                 }
             }
             return new Resolved(applyFn.apply(ap));
@@ -95,19 +97,23 @@ final class DelegatedPredicateCombiner {
                 return new Resolved(resolveCallChildren(call, applyFn));
             }
 
+            // Monotonic: once under an OR/NOT, every descendant is too (any depth of nested AND).
+            boolean childUnderOrNot = underOrNot || kind == SqlKind.OR || kind == SqlKind.NOT;
             List<Classified> kids = new ArrayList<>(call.getOperands().size());
             for (RexNode operand : call.getOperands()) {
-                kids.add(classify(operand, applyFn));
+                kids.add(classify(operand, applyFn, childUnderOrNot));
             }
-            return combine(call, kids, applyFn);
+            return combine(call, kids, applyFn, underOrNot);
         }
 
         return new Resolved(node);
     }
 
     /** Combines classified children of an AND/OR/NOT call into a single Classified result. */
-    private Classified combine(RexCall call, List<Classified> kids, Function<OperatorAnnotation, RexNode> applyFn) {
-        boolean isOrNot = call.getKind() == SqlKind.OR || call.getKind() == SqlKind.NOT;
+    private Classified combine(RexCall call, List<Classified> kids, Function<OperatorAnnotation, RexNode> applyFn, boolean underOrNot) {
+        // True under any OR/NOT (including an AND nested beneath one): perf can't survive a
+        // disjunction, so perf children here are carved to correctness.
+        boolean isOrNot = underOrNot || call.getKind() == SqlKind.OR || call.getKind() == SqlKind.NOT;
 
         List<Delegated> correctnessChildren = new ArrayList<>();
         List<Delegated> performanceChildren = new ArrayList<>();
@@ -116,21 +122,27 @@ final class DelegatedPredicateCombiner {
         boolean multiBackend = false;
 
         for (Classified c : kids) {
-            if (c instanceof Delegated d) {
-                // Under OR/NOT with fuse=false, perf-delegated leaves carve back to native:
-                // delegation_possible doesn't compose under disjunction (driver can't tell
-                // "leaf didn't match" from "no leaf matched when the peer missed"). Under
-                // fuse=true, classify() never emits perf, so this branch never fires.
-                if ((isOrNot && !fuseDualViable) && d.performanceDelegation()) {
-                    ordered.add(unwrapPreservingConnectors(d.subtree(), applyFn::apply));
-                } else {
-                    (d.performanceDelegation() ? performanceChildren : correctnessChildren).add(d);
-                    ordered.add(d);
-                    if (commonBackend == null) commonBackend = d.backend();
-                    else if (!commonBackend.equals(d.backend())) multiBackend = true;
-                }
-            } else {
+            if (c instanceof Delegated == false) {
                 ordered.add(((Resolved) c).node());
+                continue;
+            }
+            Delegated d = (Delegated) c;
+
+            // Under OR/NOT a perf child is reclassified to correctness (ships to the peer, fusing
+            // with same-backend correctness siblings); under AND it stays performance.
+            Delegated routed = (isOrNot && d.performanceDelegation())
+                ? new Delegated(d.backend(), d.subtree(), d.firstAnnotationId(), false)
+                : d;
+            if (routed.performanceDelegation()) {
+                performanceChildren.add(routed);
+            } else {
+                correctnessChildren.add(routed);
+            }
+            ordered.add(routed);
+            if (commonBackend == null) {
+                commonBackend = routed.backend();
+            } else if (!commonBackend.equals(routed.backend())) {
+                multiBackend = true;
             }
         }
 
@@ -152,10 +164,10 @@ final class DelegatedPredicateCombiner {
             int firstId = correctnessChildren.getFirst().firstAnnotationId();
             result = new Delegated(commonBackend, call, firstId, false);
         } else if (ordered.size() == performanceChildren.size() && correctnessChildren.isEmpty()) {
-            // All children performance-delegated to the same backend — bubble up so the
-            // parent can merge further up the tree before the Mixed branch flattens. Only
-            // reachable under fuse=false + AND (OR/NOT carved perf out above; fuse=true
-            // demotes perf to correctness so this branch never fires under fuse=true).
+            // All children performance-delegated to the same backend — bubble up so the parent can
+            // merge further up the tree before the Mixed branch flattens. Only reachable under AND:
+            // under OR/NOT a perf child is reclassified to correctness before this point, so it
+            // never arrives here as a performance child.
             outcome = "BUBBLE_UP PERF";
             int firstId = performanceChildren.getFirst().firstAnnotationId();
             result = new Delegated(commonBackend, call, firstId, true);
@@ -191,9 +203,8 @@ final class DelegatedPredicateCombiner {
 
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug(
-                "combine kind={} fuse={} kids={} (correctness={}, perf={}, multiBackend={}) → {}{}",
+                "combine kind={} kids={} (correctness={}, perf={}, multiBackend={}) → {}{}",
                 call.getKind(),
-                fuseDualViable,
                 kids.size(),
                 correctnessChildren.size(),
                 performanceChildren.size(),

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/dag/FilterTreeShapeDeriver.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/dag/FilterTreeShapeDeriver.java
@@ -58,65 +58,74 @@ final class FilterTreeShapeDeriver {
      *
      * @param filter              the OpenSearchFilter with annotations intact
      * @param drivingBackendId    the filter operator's resolved backend
-     * @param fuseDualViable      mirrors the {@code analytics.delegation.fuse_dual_viable} cluster
-     *                            setting. When {@code true}, the combiner fuses OR-of-same-backend
-     *                            delegated leaves into a single {@code delegated_predicate} call
-     *                            wrapping the OR; the post-combiner tree the data node sees is
-     *                            conjunctive (one delegated scalar at the top level). This deriver
-     *                            walks the pre-combiner condition, so it must mirror that fusion
-     *                            to keep the data-node evaluator path classification consistent.
      * @return the tree shape, or {@code null} if no delegated annotations exist
      */
-    static FilterTreeShape derive(OpenSearchFilter filter, String drivingBackendId, boolean fuseDualViable) {
-        Result result = walk(filter.getCondition(), drivingBackendId, fuseDualViable);
-        if (!result.hasDelegated) {
+    static FilterTreeShape derive(OpenSearchFilter filter, String drivingBackendId) {
+        Result result = walk(filter.getCondition(), drivingBackendId);
+        if (!result.hasCorrectness && !result.hasPerf) {
+            // Nothing delegated post-combine (all native, or a perf leaf under NOT that stays native).
             return FilterTreeShape.NO_DELEGATION;
         }
-        return result.hasMixed ? FilterTreeShape.INTERLEAVED_BOOLEAN_EXPRESSION : FilterTreeShape.CONJUNCTIVE;
+        return result.interleaved ? FilterTreeShape.INTERLEAVED_BOOLEAN_EXPRESSION : FilterTreeShape.CONJUNCTIVE;
     }
 
-    private static Result walk(RexNode node, String drivingBackendId, boolean fuseDualViable) {
+    /**
+     * Predicts what the combiner produces for a subtree, mirroring
+     * {@link DelegatedPredicateCombiner#combine}. Tracks four facts about the post-combine shape: a
+     * correctness-delegated shipment, a surviving performance marker, a driving-backend (native)
+     * predicate, and whether it needs the data-node tree evaluator (interleaved).
+     *
+     * <p>Performance delegation composes only under AND, so a perf leaf doesn't survive under OR/NOT:
+     * under OR it's reclassified to correctness (ships to the peer); under NOT it stays native
+     * (NOT(=) folds to != with no serializer). The shape label must match what the combiner emits,
+     * or the data node mis-routes (the historical "all-docs" disjunction bug).
+     */
+    private static Result walk(RexNode node, String drivingBackendId) {
         if (node instanceof AnnotatedPredicate predicate) {
-            // Two flavors of delegation count toward "hasDelegated":
-            // 1. Correctness — viableBackends differs from operator backend (the only backend
-            // that can evaluate is the peer).
-            // 2. Performance — operator backend can evaluate natively, but a peer was also
-            // viable and is available for opportunistic per-RG consultation.
             boolean isCorrectness = !predicate.getViableBackends().getFirst().equals(drivingBackendId);
             boolean isPerformance = !predicate.getPerformanceDelegationBackends().isEmpty();
-            boolean isDelegated = isCorrectness || isPerformance;
-            return new Result(isDelegated, false, !isDelegated, isPerformance);
+            boolean isDrivingBackend = !isCorrectness && !isPerformance;
+            return new Result(isCorrectness, isPerformance, isDrivingBackend, false);
         }
         if (node instanceof RexCall call) {
-            boolean isOrNot = call.getKind() == SqlKind.OR || call.getKind() == SqlKind.NOT;
+            boolean isOr = call.getKind() == SqlKind.OR;
+            boolean isNot = call.getKind() == SqlKind.NOT;
 
-            boolean hasDelegated = false;
+            boolean hasCorrectness = false;
+            boolean hasPerf = false;
             boolean hasDrivingBackend = false;
-            boolean hasPerformanceDelegation = false;
-            boolean hasMixed = false;
-
+            boolean interleaved = false;
             for (RexNode operand : call.getOperands()) {
-                Result childResult = walk(operand, drivingBackendId, fuseDualViable);
-                hasDelegated |= childResult.hasDelegated;
-                hasDrivingBackend |= childResult.hasDrivingBackend;
-                hasMixed |= childResult.hasMixed;
-                hasPerformanceDelegation |= childResult.hasPerformanceDelegation;
+                Result child = walk(operand, drivingBackendId);
+                hasCorrectness |= child.hasCorrectness;
+                hasPerf |= child.hasPerf;
+                hasDrivingBackend |= child.hasDrivingBackend;
+                interleaved |= child.interleaved;
             }
 
-            // Under OR/NOT, interleaving occurs when delegated children sit alongside something
-            // the combiner can't fuse with them:
-            // - native (driving-backend) operands — never fuse, always interleaved.
-            // - performance-delegated operands — interleaved only when fuseDualViable is off
-            // (carve-out throws perf back to native individually); with fusion on the
-            // combiner emits a single delegation_possible wrapping the whole OR/NOT.
-            boolean unfuseablePeer = hasDrivingBackend || (hasPerformanceDelegation && fuseDualViable == false);
-            hasMixed |= isOrNot && hasDelegated && unfuseablePeer;
+            // The data node does performance delegation only on the AND path, so a perf leaf can't
+            // stay perf under OR or NOT. Mirror combine():
+            if (hasPerf && isOr) {
+                // Under OR it's reclassified to correctness and shipped to the peer.
+                hasCorrectness = true;
+                hasPerf = false;
+            } else if (hasPerf && isNot) {
+                // Under NOT a dual-equality leaf folds to != (no serializer) and stays native.
+                hasDrivingBackend = true;
+                hasPerf = false;
+            }
 
-            return new Result(hasDelegated, hasMixed, hasDrivingBackend, hasPerformanceDelegation);
+            // Interleaving (tree evaluator needed) arises under OR/NOT when a delegated shipment
+            // sits alongside a driving-backend operand — the two can't collapse into one peer
+            // shipment. Under AND, driving-backend + delegated coexist as separate conjuncts
+            // (single-collector path), so AND never introduces interleaving on its own.
+            interleaved |= (isOr || isNot) && hasCorrectness && hasDrivingBackend;
+
+            return new Result(hasCorrectness, hasPerf, hasDrivingBackend, interleaved);
         }
         return new Result(false, false, false, false);
     }
 
-    private record Result(boolean hasDelegated, boolean hasMixed, boolean hasDrivingBackend, boolean hasPerformanceDelegation) {
+    private record Result(boolean hasCorrectness, boolean hasPerf, boolean hasDrivingBackend, boolean interleaved) {
     }
 }

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/dag/FragmentConversionDriver.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/dag/FragmentConversionDriver.java
@@ -80,13 +80,9 @@ public class FragmentConversionDriver {
     /**
      * Converts all {@link StagePlan} alternatives in the DAG, populating
      * {@link StagePlan#convertedBytes()} on each plan.
-     *
-     * @param fuseDualViable when {@code true}, performance-delegated leaves fuse with
-     *     correctness-delegated siblings even under OR/NOT. Sourced from the cluster setting
-     *     {@code analytics.delegation.fuse_dual_viable}.
      */
-    public static void convertAll(QueryDAG dag, CapabilityRegistry registry, boolean fuseDualViable) {
-        convertStage(dag.rootStage(), registry, fuseDualViable);
+    public static void convertAll(QueryDAG dag, CapabilityRegistry registry) {
+        convertStage(dag.rootStage(), registry);
         // Root stage executes locally at coordinator — store factory for instruction dispatch.
         Stage root = dag.rootStage();
         if (root.getExchangeSinkProvider() != null && !root.getPlanAlternatives().isEmpty()) {
@@ -95,9 +91,9 @@ public class FragmentConversionDriver {
         }
     }
 
-    private static void convertStage(Stage stage, CapabilityRegistry registry, boolean fuseDualViable) {
+    private static void convertStage(Stage stage, CapabilityRegistry registry) {
         for (Stage child : stage.getChildStages()) {
-            convertStage(child, registry, fuseDualViable);
+            convertStage(child, registry);
         }
         // After children are converted, surface any decorator-induced schema delta as
         // postDecorationSchemaBytes on the child plans. The reduce sink consults this when
@@ -115,15 +111,15 @@ public class FragmentConversionDriver {
             AnalyticsSearchBackendPlugin backend = registry.getBackend(plan.backendId());
             FragmentConvertor convertor = backend.getFragmentConvertor();
 
-            // Derive filter tree shape BEFORE stripping (annotations must be intact). Mirrors
-            // fuseDualViable so the deriver's classification matches the post-combiner tree
-            // the data node actually sees.
+            // Derive filter tree shape BEFORE stripping (annotations must be intact). The deriver
+            // mirrors the combiner's post-combine shape so the data node's classification matches
+            // the tree it actually receives.
             OpenSearchFilter filter = RelNodeUtils.findNode(plan.resolvedFragment(), OpenSearchFilter.class);
             FilterTreeShape treeShape = filter != null
-                ? FilterTreeShapeDeriver.derive(filter, plan.backendId(), fuseDualViable)
+                ? FilterTreeShapeDeriver.derive(filter, plan.backendId())
                 : FilterTreeShape.NO_DELEGATION;
 
-            IntraOperatorDelegationBytes delegationBytes = new IntraOperatorDelegationBytes(registry, fuseDualViable);
+            IntraOperatorDelegationBytes delegationBytes = new IntraOperatorDelegationBytes(registry);
             byte[] bytes = convert(plan.resolvedFragment(), convertor, delegationBytes);
 
             // Assemble instruction list
@@ -279,16 +275,10 @@ public class FragmentConversionDriver {
      */
     static final class IntraOperatorDelegationBytes {
         private final CapabilityRegistry registry;
-        private final boolean fuseDualViable;
         private List<DelegatedExpression> delegatedExpressions;
 
         IntraOperatorDelegationBytes(CapabilityRegistry registry) {
-            this(registry, false);
-        }
-
-        IntraOperatorDelegationBytes(CapabilityRegistry registry, boolean fuseDualViable) {
             this.registry = registry;
-            this.fuseDualViable = fuseDualViable;
         }
 
         /**
@@ -305,8 +295,7 @@ public class FragmentConversionDriver {
                 fieldStorage,
                 registry,
                 rexBuilder,
-                delegatedExpressions,
-                fuseDualViable
+                delegatedExpressions
             );
             return new AnnotationResolver() {
 

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/dag/DAGBuilderTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/dag/DAGBuilderTests.java
@@ -334,7 +334,7 @@ public class DAGBuilderTests extends BasePlannerRulesTests {
         QueryDAG dag = DAGBuilder.build(cbo, context.getCapabilityRegistry(), mockClusterService(), TEST_RESOLVER);
         LOGGER.info("QueryDAG:\n{}", dag);
         PlanForker.forkAll(dag, context.getCapabilityRegistry());
-        FragmentConversionDriver.convertAll(dag, context.getCapabilityRegistry(), false);
+        FragmentConversionDriver.convertAll(dag, context.getCapabilityRegistry());
 
         // LM at root with no above-ops: the LM stage IS the root — no synthetic post-LM stage.
         assertEquals(
@@ -406,7 +406,7 @@ public class DAGBuilderTests extends BasePlannerRulesTests {
         QueryDAG dag = DAGBuilder.build(cbo, context.getCapabilityRegistry(), mockClusterService(), TEST_RESOLVER);
         LOGGER.info("QueryDAG:\n{}", dag);
         PlanForker.forkAll(dag, context.getCapabilityRegistry());
-        FragmentConversionDriver.convertAll(dag, context.getCapabilityRegistry(), false);
+        FragmentConversionDriver.convertAll(dag, context.getCapabilityRegistry());
 
         // Stage 3 has real compute (the Project) on top of the StageInputScan → COORDINATOR_REDUCE.
         assertEquals(

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/dag/FilterTreeShapeDeriverTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/dag/FilterTreeShapeDeriverTests.java
@@ -32,7 +32,7 @@ public class FilterTreeShapeDeriverTests extends BasePlannerRulesTests {
         RexNode nativePred = annotated(DRIVING);
         OpenSearchFilter filter = buildFilter(nativePred);
 
-        FilterTreeShape shape = FilterTreeShapeDeriver.derive(filter, DRIVING, false);
+        FilterTreeShape shape = FilterTreeShapeDeriver.derive(filter, DRIVING);
         assertEquals("No delegation should return PLAIN", FilterTreeShape.NO_DELEGATION, shape);
     }
 
@@ -43,7 +43,7 @@ public class FilterTreeShapeDeriverTests extends BasePlannerRulesTests {
         RexNode andNode = rexBuilder.makeCall(SqlStdOperatorTable.AND, nativePred, delegated);
         OpenSearchFilter filter = buildFilter(andNode);
 
-        FilterTreeShape shape = FilterTreeShapeDeriver.derive(filter, DRIVING, false);
+        FilterTreeShape shape = FilterTreeShapeDeriver.derive(filter, DRIVING);
         assertEquals(FilterTreeShape.CONJUNCTIVE, shape);
     }
 
@@ -55,7 +55,7 @@ public class FilterTreeShapeDeriverTests extends BasePlannerRulesTests {
         RexNode andNode = rexBuilder.makeCall(SqlStdOperatorTable.AND, nativePred, delegated1, delegated2);
         OpenSearchFilter filter = buildFilter(andNode);
 
-        FilterTreeShape shape = FilterTreeShapeDeriver.derive(filter, DRIVING, false);
+        FilterTreeShape shape = FilterTreeShapeDeriver.derive(filter, DRIVING);
         assertEquals(FilterTreeShape.CONJUNCTIVE, shape);
     }
 
@@ -66,7 +66,7 @@ public class FilterTreeShapeDeriverTests extends BasePlannerRulesTests {
         RexNode orNode = rexBuilder.makeCall(SqlStdOperatorTable.OR, nativePred, delegated);
         OpenSearchFilter filter = buildFilter(orNode);
 
-        FilterTreeShape shape = FilterTreeShapeDeriver.derive(filter, DRIVING, false);
+        FilterTreeShape shape = FilterTreeShapeDeriver.derive(filter, DRIVING);
         assertEquals(FilterTreeShape.INTERLEAVED_BOOLEAN_EXPRESSION, shape);
     }
 
@@ -78,7 +78,7 @@ public class FilterTreeShapeDeriverTests extends BasePlannerRulesTests {
         RexNode notNode = rexBuilder.makeCall(SqlStdOperatorTable.NOT, andNode);
         OpenSearchFilter filter = buildFilter(notNode);
 
-        FilterTreeShape shape = FilterTreeShapeDeriver.derive(filter, DRIVING, false);
+        FilterTreeShape shape = FilterTreeShapeDeriver.derive(filter, DRIVING);
         assertEquals(FilterTreeShape.INTERLEAVED_BOOLEAN_EXPRESSION, shape);
     }
 
@@ -92,7 +92,7 @@ public class FilterTreeShapeDeriverTests extends BasePlannerRulesTests {
         RexNode andNode = rexBuilder.makeCall(SqlStdOperatorTable.AND, nativePred, orNode);
         OpenSearchFilter filter = buildFilter(andNode);
 
-        FilterTreeShape shape = FilterTreeShapeDeriver.derive(filter, DRIVING, false);
+        FilterTreeShape shape = FilterTreeShapeDeriver.derive(filter, DRIVING);
         assertEquals(FilterTreeShape.CONJUNCTIVE, shape);
     }
 
@@ -103,7 +103,7 @@ public class FilterTreeShapeDeriverTests extends BasePlannerRulesTests {
         RexNode notNode = rexBuilder.makeCall(SqlStdOperatorTable.NOT, delegated);
         OpenSearchFilter filter = buildFilter(notNode);
 
-        FilterTreeShape shape = FilterTreeShapeDeriver.derive(filter, DRIVING, false);
+        FilterTreeShape shape = FilterTreeShapeDeriver.derive(filter, DRIVING);
         assertEquals(FilterTreeShape.CONJUNCTIVE, shape);
     }
 
@@ -123,15 +123,18 @@ public class FilterTreeShapeDeriverTests extends BasePlannerRulesTests {
         return (AnnotatedPredicate) dualViable.narrowTo(DRIVING);
     }
 
+    // Delegated OR Dual: the Dual leaf can't stay performance-based under OR (perf delegation is
+    // AND-only in the data node), so it's demoted to correctness and fused with the Delegated leaf
+    // into ONE Lucene shipment. The shape is then a single delegated leaf → label = CONJUNCTIVE.
+    // (The label must match what the combiner emits; a mismatch here is what caused the all-docs bug.)
     public void testOrWithCorrectnessAndPerfDelegated() {
-        // OR(correctness-delegated, perf-delegated) — perf won't combine under OR → INTERLEAVED
         RexNode correctness = annotated(ACCEPTING);
         RexNode perf = perfDelegated();
         RexNode orNode = rexBuilder.makeCall(SqlStdOperatorTable.OR, correctness, perf);
         OpenSearchFilter filter = buildFilter(orNode);
 
-        FilterTreeShape shape = FilterTreeShapeDeriver.derive(filter, DRIVING, false);
-        assertEquals(FilterTreeShape.INTERLEAVED_BOOLEAN_EXPRESSION, shape);
+        FilterTreeShape shape = FilterTreeShapeDeriver.derive(filter, DRIVING);
+        assertEquals(FilterTreeShape.CONJUNCTIVE, shape);
     }
 
     public void testAndWithCorrectnessAndPerfDelegated() {
@@ -141,67 +144,19 @@ public class FilterTreeShapeDeriverTests extends BasePlannerRulesTests {
         RexNode andNode = rexBuilder.makeCall(SqlStdOperatorTable.AND, correctness, perf);
         OpenSearchFilter filter = buildFilter(andNode);
 
-        FilterTreeShape shape = FilterTreeShapeDeriver.derive(filter, DRIVING, false);
+        FilterTreeShape shape = FilterTreeShapeDeriver.derive(filter, DRIVING);
         assertEquals(FilterTreeShape.CONJUNCTIVE, shape);
     }
 
+    // NOT(dual-equality) is not delegated — it stays native → NO_DELEGATION. (Combiner counterpart:
+    // FragmentConversionDriverTests#testNotEqualsStaysNative, NOT(EQUALS) → 0 delegated expressions.)
     public void testNotOfPerfDelegated() {
-        // NOT(perf-delegated) — perf under NOT won't combine → INTERLEAVED
         RexNode perf = perfDelegated();
         RexNode notNode = rexBuilder.makeCall(SqlStdOperatorTable.NOT, perf);
         OpenSearchFilter filter = buildFilter(notNode);
 
-        FilterTreeShape shape = FilterTreeShapeDeriver.derive(filter, DRIVING, false);
-        assertEquals(FilterTreeShape.INTERLEAVED_BOOLEAN_EXPRESSION, shape);
-    }
-
-    // ---- fuse_dual_viable interaction ----
-
-    /**
-     * Same OR(correctness, perf) shape as {@link #testOrWithCorrectnessAndPerfDelegated} but
-     * with {@code fuseDualViable=true}: combiner fuses both delegated children (correctness ∪
-     * perf) into a single {@code delegated_predicate} placeholder wrapping the OR. The peer
-     * evaluates the whole boolean (driver can't decompose OR into independently-evaluable
-     * arms — {@code delegation_possible} only composes under AND). Post-combiner tree is a
-     * bare delegated leaf — conjunctive from the data-node evaluator's perspective.
-     */
-    public void testOrWithCorrectnessAndPerfDelegated_fused_isConjunctive() {
-        RexNode correctness = annotated(ACCEPTING);
-        RexNode perf = perfDelegated();
-        RexNode orNode = rexBuilder.makeCall(SqlStdOperatorTable.OR, correctness, perf);
-        OpenSearchFilter filter = buildFilter(orNode);
-
-        FilterTreeShape shape = FilterTreeShapeDeriver.derive(filter, DRIVING, true);
-        assertEquals(FilterTreeShape.CONJUNCTIVE, shape);
-    }
-
-    /**
-     * NOT(perf-delegated) with {@code fuseDualViable=true}: combiner keeps the perf leaf in
-     * the delegation pool under NOT, so the post-combiner tree is a single
-     * {@code delegation_possible} wrapping the NOT — conjunctive.
-     */
-    public void testNotOfPerfDelegated_fused_isConjunctive() {
-        RexNode perf = perfDelegated();
-        RexNode notNode = rexBuilder.makeCall(SqlStdOperatorTable.NOT, perf);
-        OpenSearchFilter filter = buildFilter(notNode);
-
-        FilterTreeShape shape = FilterTreeShapeDeriver.derive(filter, DRIVING, true);
-        assertEquals(FilterTreeShape.CONJUNCTIVE, shape);
-    }
-
-    /**
-     * Even with {@code fuseDualViable=true}, OR(delegated, native-non-delegable) stays
-     * INTERLEAVED — the native arm can't be folded into the peer's delegation no matter
-     * what the carve-out policy is. Fusion only collapses the perf-vs-correctness axis.
-     */
-    public void testOrWithDelegatedAndNative_fused_stillInterleaved() {
-        RexNode delegated = annotated(ACCEPTING);
-        RexNode nativePred = annotated(DRIVING);
-        RexNode orNode = rexBuilder.makeCall(SqlStdOperatorTable.OR, delegated, nativePred);
-        OpenSearchFilter filter = buildFilter(orNode);
-
-        FilterTreeShape shape = FilterTreeShapeDeriver.derive(filter, DRIVING, true);
-        assertEquals(FilterTreeShape.INTERLEAVED_BOOLEAN_EXPRESSION, shape);
+        FilterTreeShape shape = FilterTreeShapeDeriver.derive(filter, DRIVING);
+        assertEquals(FilterTreeShape.NO_DELEGATION, shape);
     }
 
     private OpenSearchFilter buildFilter(RexNode condition) {

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/dag/FragmentConversionDriverTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/dag/FragmentConversionDriverTests.java
@@ -111,7 +111,7 @@ public class FragmentConversionDriverTests extends BasePlannerRulesTests {
         LOGGER.info("Marked+CBO:\n{}", RelOptUtil.toString(cboOutput));
         QueryDAG dag = DAGBuilder.build(cboOutput, context.getCapabilityRegistry(), mockClusterService(), TEST_RESOLVER);
         PlanForker.forkAll(dag, context.getCapabilityRegistry());
-        FragmentConversionDriver.convertAll(dag, context.getCapabilityRegistry(), false);
+        FragmentConversionDriver.convertAll(dag, context.getCapabilityRegistry());
         LOGGER.info("QueryDAG after conversion:\n{}", dag);
         return dag;
     }
@@ -322,7 +322,7 @@ public class FragmentConversionDriverTests extends BasePlannerRulesTests {
         LOGGER.info("Marked+CBO:\n{}", RelOptUtil.toString(cboOutput));
         QueryDAG dag = DAGBuilder.build(cboOutput, context.getCapabilityRegistry(), mockClusterService(), TEST_RESOLVER);
         PlanForker.forkAll(dag, context.getCapabilityRegistry());
-        FragmentConversionDriver.convertAll(dag, context.getCapabilityRegistry(), false);
+        FragmentConversionDriver.convertAll(dag, context.getCapabilityRegistry());
 
         Stage root = dag.rootStage();
         assertNotNull("root alternative must have convertedBytes", root.getPlanAlternatives().getFirst().convertedBytes());
@@ -524,26 +524,6 @@ public class FragmentConversionDriverTests extends BasePlannerRulesTests {
         SqlTypeName[] fieldTypes,
         Map<String, Map<String, Object>> fields
     ) {
-        return buildDelegationDag(condition, dfConvertor, serializer, fieldNames, fieldTypes, fields, false);
-    }
-
-    /**
-     * Like the non-fused overload but threads {@code fuseDualViable} through to
-     * {@link FragmentConversionDriver#convertAll(QueryDAG, CapabilityRegistry, boolean)} so
-     * tests can flip the {@code analytics.delegation.fuse_dual_viable} cluster setting
-     * deterministically. With {@code fuse=true}, performance-delegated leaves under OR/NOT
-     * stay in the delegation pool instead of being thrown back to native — the entire boolean
-     * ships to the peer as one delegated expression.
-     */
-    private QueryDAG buildDelegationDag(
-        RexNode condition,
-        RecordingConvertor dfConvertor,
-        RecordingSerializer serializer,
-        String[] fieldNames,
-        SqlTypeName[] fieldTypes,
-        Map<String, Map<String, Object>> fields,
-        boolean fuseDualViable
-    ) {
         var backends = delegationBackends(dfConvertor, serializer);
         var context = buildContext("parquet", fields, backends);
         LogicalFilter filter = LogicalFilter.create(stubScan(mockTable("test_index", fieldNames, fieldTypes)), condition);
@@ -551,7 +531,7 @@ public class FragmentConversionDriverTests extends BasePlannerRulesTests {
         LOGGER.info("Marked+CBO:\n{}", RelOptUtil.toString(cboOutput));
         QueryDAG dag = DAGBuilder.build(cboOutput, context.getCapabilityRegistry(), mockClusterService(), TEST_RESOLVER);
         PlanForker.forkAll(dag, context.getCapabilityRegistry());
-        FragmentConversionDriver.convertAll(dag, context.getCapabilityRegistry(), fuseDualViable);
+        FragmentConversionDriver.convertAll(dag, context.getCapabilityRegistry());
         return dag;
     }
 
@@ -577,16 +557,6 @@ public class FragmentConversionDriverTests extends BasePlannerRulesTests {
      *   - field 2 = amount   (integer, NOT indexed) — SINGLE-VIABLE to DataFusion only.
      */
     private QueryDAG buildTwoFieldDelegationDag(RexNode condition, RecordingConvertor dfConvertor, RecordingSerializer serializer) {
-        return buildTwoFieldDelegationDag(condition, dfConvertor, serializer, false);
-    }
-
-    /** {@link #buildTwoFieldDelegationDag} with the {@code fuse_dual_viable} setting threaded through. */
-    private QueryDAG buildTwoFieldDelegationDag(
-        RexNode condition,
-        RecordingConvertor dfConvertor,
-        RecordingSerializer serializer,
-        boolean fuseDualViable
-    ) {
         return buildDelegationDag(
             condition,
             dfConvertor,
@@ -600,8 +570,7 @@ public class FragmentConversionDriverTests extends BasePlannerRulesTests {
                 Map.of("type", "keyword", "index", true),
                 "amount",
                 Map.of("type", "integer", "index", false)
-            ),
-            fuseDualViable
+            )
         );
     }
 
@@ -611,12 +580,7 @@ public class FragmentConversionDriverTests extends BasePlannerRulesTests {
      * Mirrors prod Lucene's {@code STANDARD_TYPES = {KEYWORD, TEXT, MATCH_ONLY_TEXT}} —
      * EQUALS-on-int is NOT a Lucene cap in prod even when the field has BKD points.
      */
-    private QueryDAG buildKeywordPlusNativeDag(
-        RexNode condition,
-        RecordingConvertor dfConvertor,
-        RecordingSerializer serializer,
-        boolean fuseDualViable
-    ) {
+    private QueryDAG buildKeywordPlusNativeDag(RexNode condition, RecordingConvertor dfConvertor, RecordingSerializer serializer) {
         return buildDelegationDag(
             condition,
             dfConvertor,
@@ -630,8 +594,7 @@ public class FragmentConversionDriverTests extends BasePlannerRulesTests {
                 Map.of("type", "keyword", "index", true),
                 "amount",
                 Map.of("type", "integer", "index", false)
-            ),
-            fuseDualViable
+            )
         );
     }
 
@@ -839,7 +802,7 @@ public class FragmentConversionDriverTests extends BasePlannerRulesTests {
         RelNode cboOutput = runPlanner(filter, context);
         QueryDAG dag = DAGBuilder.build(cboOutput, context.getCapabilityRegistry(), mockClusterService(), TEST_RESOLVER);
         PlanForker.forkAll(dag, context.getCapabilityRegistry());
-        FragmentConversionDriver.convertAll(dag, context.getCapabilityRegistry(), false);
+        FragmentConversionDriver.convertAll(dag, context.getCapabilityRegistry());
         StagePlan plan = leafStage(dag).getPlanAlternatives().getFirst();
 
         // Should produce 1 combined DelegatedExpression (not 2 individual ones)
@@ -899,7 +862,7 @@ public class FragmentConversionDriverTests extends BasePlannerRulesTests {
         RelNode cboOutput = runPlanner(filter, context);
         QueryDAG dag = DAGBuilder.build(cboOutput, context.getCapabilityRegistry(), mockClusterService(), TEST_RESOLVER);
         PlanForker.forkAll(dag, context.getCapabilityRegistry());
-        FragmentConversionDriver.convertAll(dag, context.getCapabilityRegistry(), false);
+        FragmentConversionDriver.convertAll(dag, context.getCapabilityRegistry());
         StagePlan plan = leafStage(dag).getPlanAlternatives().getFirst();
 
         // OR siblings targeting same backend should be combined into 1 DelegatedExpression
@@ -960,7 +923,7 @@ public class FragmentConversionDriverTests extends BasePlannerRulesTests {
         RelNode cboOutput = runPlanner(filter, context);
         QueryDAG dag = DAGBuilder.build(cboOutput, context.getCapabilityRegistry(), mockClusterService(), TEST_RESOLVER);
         PlanForker.forkAll(dag, context.getCapabilityRegistry());
-        FragmentConversionDriver.convertAll(dag, context.getCapabilityRegistry(), false);
+        FragmentConversionDriver.convertAll(dag, context.getCapabilityRegistry());
         StagePlan plan = leafStage(dag).getPlanAlternatives().getFirst();
 
         assertEquals("Pure Lucene nested OR(AND,leaf) should produce 1 expression", 1, plan.delegatedExpressions().size());
@@ -1012,7 +975,7 @@ public class FragmentConversionDriverTests extends BasePlannerRulesTests {
         RelNode cboOutput = runPlanner(filter, context);
         QueryDAG dag = DAGBuilder.build(cboOutput, context.getCapabilityRegistry(), mockClusterService(), TEST_RESOLVER);
         PlanForker.forkAll(dag, context.getCapabilityRegistry());
-        FragmentConversionDriver.convertAll(dag, context.getCapabilityRegistry(), false);
+        FragmentConversionDriver.convertAll(dag, context.getCapabilityRegistry());
         StagePlan plan = leafStage(dag).getPlanAlternatives().getFirst();
 
         assertEquals("OR(AND,AND) pure Lucene should produce 1 expression", 1, plan.delegatedExpressions().size());
@@ -1065,7 +1028,7 @@ public class FragmentConversionDriverTests extends BasePlannerRulesTests {
         RelNode cboOutput = runPlanner(filter, context);
         QueryDAG dag = DAGBuilder.build(cboOutput, context.getCapabilityRegistry(), mockClusterService(), TEST_RESOLVER);
         PlanForker.forkAll(dag, context.getCapabilityRegistry());
-        FragmentConversionDriver.convertAll(dag, context.getCapabilityRegistry(), false);
+        FragmentConversionDriver.convertAll(dag, context.getCapabilityRegistry());
         StagePlan plan = leafStage(dag).getPlanAlternatives().getFirst();
 
         assertEquals("AND(OR(AND,leaf),leaf) pure Lucene should produce 1 expression", 1, plan.delegatedExpressions().size());
@@ -1130,7 +1093,7 @@ public class FragmentConversionDriverTests extends BasePlannerRulesTests {
         RelNode cboOutput = runPlanner(filter, context);
         QueryDAG dag = DAGBuilder.build(cboOutput, context.getCapabilityRegistry(), mockClusterService(), TEST_RESOLVER);
         PlanForker.forkAll(dag, context.getCapabilityRegistry());
-        FragmentConversionDriver.convertAll(dag, context.getCapabilityRegistry(), false);
+        FragmentConversionDriver.convertAll(dag, context.getCapabilityRegistry());
         StagePlan plan = leafStage(dag).getPlanAlternatives().getFirst();
 
         // All 4 Lucene predicates combined into 1, native amount=200 stays separate
@@ -1221,7 +1184,7 @@ public class FragmentConversionDriverTests extends BasePlannerRulesTests {
         RelNode cboOutput = runPlanner(filter, context);
         QueryDAG dag = DAGBuilder.build(cboOutput, context.getCapabilityRegistry(), mockClusterService(), TEST_RESOLVER);
         PlanForker.forkAll(dag, context.getCapabilityRegistry());
-        FragmentConversionDriver.convertAll(dag, context.getCapabilityRegistry(), false);
+        FragmentConversionDriver.convertAll(dag, context.getCapabilityRegistry());
         StagePlan plan = leafStage(dag).getPlanAlternatives().getFirst();
         return new CombiningResult(plan, dfConvertor, serializer);
     }
@@ -1408,127 +1371,83 @@ public class FragmentConversionDriverTests extends BasePlannerRulesTests {
         assertTrue("AND structure should be preserved", strippedPlan.contains("AND"));
     }
 
-    // ---- fuse_dual_viable cluster setting ----
+    // ---- Dual-viable leaves stay performance-based by default ----
 
     /**
-     * Two performance-delegated leaves plus a correctness-delegated one under OR, with the
-     * {@code analytics.delegation.fuse_dual_viable} cluster setting governing how the perf
-     * leaves are emitted.
+     * Dual AND Dual: both leaves stay performance-based. The two same-backend perf leaves fuse into
+     * one shipped expression; the plan carries delegation_possible (DataFusion prunes natively +
+     * opportunistic peer consult) and NO delegated_predicate (nothing shipped wholesale to the peer).
      *
-     * <ul>
-     *   <li>{@code fuse=false} — combiner's OR/NOT carve-out throws each performance-delegated
-     *       leaf back individually: each becomes its own {@code delegation_possible} marker in
-     *       the driver plan AND its own entry in {@code delegatedExpressions}. So 3 leaves →
-     *       3 expressions and 2 separate {@code delegation_possible} markers (one per perf
-     *       leaf), the correctness one converts via the combine path.</li>
-     *   <li>{@code fuse=true} — combiner aggregates both perf leaves into a single perf
-     *       bucket and the correctness leaf into one correctness bucket. The perf bucket
-     *       emits ONE {@code delegation_possible} marker wrapping the combined perf subtree.
-     *       Total: 2 delegated expressions, 1 {@code delegation_possible}, 1
-     *       {@code delegated_predicate}.</li>
-     * </ul>
-     *
-     * <p>Setup: {@code status} is index=true (indexed integer) and {@code message} is keyword
-     * indexed — EQUALS on both is dual-viable (performance-delegation candidate). FUZZY on
-     * message is correctness-delegated to Lucene. Two distinct fields are used so Calcite's
-     * SEARCH/Sarg rewrite doesn't fold the two EQUALS into a single sargable predicate.
+     * <p>Regression guard for the perf-demotion bug: previously every dual-viable leaf was demoted to
+     * correctness-based delegation and shipped wholesale to Lucene — even under a plain AND where
+     * nothing forces it — so DataFusion never evaluated it. A demoted result here would show a bare
+     * delegated_predicate and zero delegation_possible.
      */
-    public void testOrPerformanceLeavesAndCorrectness_fuseDualViable_explicitFalse() {
-        var ctx = buildFuseTestSetup();
-        QueryDAG dag = buildKeywordFuseDag(ctx.condition, ctx.dfConvertor, ctx.serializer, /* fuseDualViable */ false);
-        StagePlan plan = leafStage(dag).getPlanAlternatives().getFirst();
-
-        assertEquals("fuse=false: 3 delegated expressions (2 perf leaves + 1 correctness)", 3, plan.delegatedExpressions().size());
-        String strippedPlan = RelOptUtil.toString(ctx.dfConvertor.shardScanFragment);
-        // Two separate delegation_possible markers — one per individually thrown-back perf leaf.
-        assertEquals(
-            "fuse=false: 2 separate delegation_possible markers in plan",
-            2,
-            countOccurrences(strippedPlan, "delegation_possible")
+    public void testAndTwoDual_defaultsToPerformanceDelegation() {
+        RecordingConvertor dfConvertor = new RecordingConvertor();
+        RecordingSerializer serializer = new RecordingSerializer();
+        // tag, message both keyword(indexed) → dual-viable for EQUALS; amount int(not indexed) = native.
+        RexNode tagEq = rexBuilder.makeCall(
+            SqlStdOperatorTable.EQUALS,
+            rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.VARCHAR), 0),
+            rexBuilder.makeLiteral("alpha")
         );
-        assertTrue("OR structure preserved", strippedPlan.contains("OR"));
+        RexNode msgEq = rexBuilder.makeCall(
+            SqlStdOperatorTable.EQUALS,
+            rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.VARCHAR), 1),
+            rexBuilder.makeLiteral("hello")
+        );
+        QueryDAG dag = buildKeywordPlusNativeDag(makeAnd(tagEq, msgEq), dfConvertor, serializer);
+        StagePlan plan = leafStage(dag).getPlanAlternatives().getFirst();
+        String stripped = RelOptUtil.toString(dfConvertor.shardScanFragment);
+
+        assertTrue(
+            "Dual AND Dual must stay performance-based (delegation_possible present). Plan: " + stripped,
+            stripped.contains(DelegationPossibleFunction.NAME)
+        );
+        assertFalse(
+            "Dual AND Dual must NOT be demoted to correctness (no delegated_predicate). Plan: " + stripped,
+            stripped.contains(DelegatedPredicateFunction.NAME)
+        );
     }
 
-    public void testOrPerformanceLeavesAndCorrectness_fuseDualViable_explicitTrue() {
+    // ---- OR with mixed correctness + performance delegation ----
+
+    /**
+     * {@code OR(perf-tag, perf-message, FUZZY-correctness)} — two dual-viable leaves plus a
+     * correctness-delegated leaf, all same-backend, under OR. Performance delegation can't survive
+     * a disjunction, and a correctness sibling is present, so the combiner fuses the entire OR into
+     * ONE {@code delegated_predicate} shipped to the peer: 1 delegated expression, 1
+     * delegated_predicate marker, 0 delegation_possible markers.
+     */
+    public void testOrPerformanceLeavesAndCorrectness_fusesToOneDelegated() {
         var ctx = buildFuseTestSetup();
-        QueryDAG dag = buildKeywordFuseDag(ctx.condition, ctx.dfConvertor, ctx.serializer, /* fuseDualViable */ true);
+        QueryDAG dag = buildKeywordFuseDag(ctx.condition, ctx.dfConvertor, ctx.serializer);
         StagePlan plan = leafStage(dag).getPlanAlternatives().getFirst();
 
-        // Under OR with mixed correctness+perf children, the driver can't decompose the boolean
-        // (delegation_possible only composes under AND). Combiner fuses ALL delegated children
-        // into a single delegated_predicate placeholder — peer evaluates the whole OR.
-        // Post-combiner shape: delegated_predicate(...) — one bare collector at top.
-        assertEquals(
-            "fuse=true under OR: 1 delegated expression (correctness + perf fused into one peer subtree)",
-            1,
-            plan.delegatedExpressions().size()
-        );
         String strippedPlan = RelOptUtil.toString(ctx.dfConvertor.shardScanFragment);
-        // No delegation_possible markers — OR with mixed kinds collapses to a single
-        // correctness-style placeholder so the data-node classifier sees a bare Collector
-        // (CONJUNCTIVE → SingleCollector evaluator), not OR(delegated, delegation_possible).
+        assertEquals("1 delegated expression (whole OR ships as one peer subtree)", 1, plan.delegatedExpressions().size());
         assertEquals(
-            "fuse=true under OR with correctness sibling: 0 delegation_possible markers",
+            "0 delegation_possible markers — performance delegation doesn't compose under OR",
             0,
             countOccurrences(strippedPlan, "delegation_possible")
         );
-        assertEquals(
-            "fuse=true: exactly 1 delegated_predicate marker at the top of the post-combiner tree",
-            1,
-            countOccurrences(strippedPlan, "delegated_predicate")
-        );
+        assertEquals("exactly 1 delegated_predicate marker at top", 1, countOccurrences(strippedPlan, "delegated_predicate"));
     }
 
     /**
-     * Randomized: picks {@code fuse} at random, asserts the discriminating invariant —
-     * perf-leaf count in the AST changes with the setting. Surfaces non-obvious combiner
-     * regressions across both branches over many test runs.
-     */
-    public void testOrPerformanceLeavesAndCorrectness_fuseDualViable_randomized() {
-        boolean fuse = randomBoolean();
-        var ctx = buildFuseTestSetup();
-        QueryDAG dag = buildKeywordFuseDag(ctx.condition, ctx.dfConvertor, ctx.serializer, fuse);
-        StagePlan plan = leafStage(dag).getPlanAlternatives().getFirst();
-
-        String strippedPlan = RelOptUtil.toString(ctx.dfConvertor.shardScanFragment);
-        int delegationPossibleMarkers = countOccurrences(strippedPlan, "delegation_possible");
-        int delegatedPredicateMarkers = countOccurrences(strippedPlan, "delegated_predicate");
-        if (fuse) {
-            // Under OR with mixed correctness+perf, fuse=true collapses the entire boolean to
-            // ONE delegated_predicate (peer evaluates whole OR). No delegation_possible because
-            // the driver can't decompose OR into independently-evaluable arms.
-            assertEquals("fuse=true: 0 delegation_possible markers (OR with correctness sibling fuses all)", 0, delegationPossibleMarkers);
-            assertEquals("fuse=true: 1 delegated_predicate marker at top of post-combiner tree", 1, delegatedPredicateMarkers);
-            assertEquals(
-                "fuse=true: 1 delegated expression (correctness + perf fused into one peer subtree)",
-                1,
-                plan.delegatedExpressions().size()
-            );
-        } else {
-            assertEquals("fuse=false: perf leaves carved out individually → 2 delegation_possible markers", 2, delegationPossibleMarkers);
-            assertEquals("fuse=false: 3 delegated expressions (2 perf leaves + correctness)", 3, plan.delegatedExpressions().size());
-        }
-    }
-
-    /**
-     * Regression: the exact prod bug shape — 2-leaf {@code OR(MATCH-correctness, EQUALS-perf)}.
-     * Pre-fix, the combiner Mixed branch emitted
-     * {@code OR(delegated_predicate(matchId), delegation_possible(EQUALS, eqId))}; the data-node
-     * Java deriver returned CONJUNCTIVE, the Rust classifier override forced SingleCollector,
-     * and {@code single_collector_id} on the OR top returned None — the residual extraction
-     * fell into the OR-passthrough arm and evaluated as {@code true} for every row, returning
-     * 100% match instead of the actual count (observed end-to-end on the ClickBench dataset:
-     * fuse=true returned 99,997,497 = total docs, fuse=false returned 28,313,573).
+     * Regression for the prod "all-docs" disjunction bug — 2-leaf {@code OR(MATCH-correctness,
+     * EQUALS-perf)}. Previously the combiner emitted {@code OR(delegated_predicate(matchId),
+     * delegation_possible(EQUALS, eqId))} while the tree-shape deriver labelled it CONJUNCTIVE; the
+     * data node trusted the label, forced the single-collector path onto a tree containing an OR,
+     * failed to apply the filter, and returned every row (ClickBench: 99,997,497 vs. the correct
+     * 28,313,573).
      *
-     * <p>Post-fix the combiner under OR/NOT with mixed correctness+perf same-backend children
-     * collapses both into one {@code delegated_predicate} placeholder. Post-combiner shape is a
-     * bare delegated leaf — Rust's {@code is_and_only_collector_tree} accepts it, and the
-     * SingleCollector evaluator routes the whole BoolQuery to Lucene.
-     *
-     * <p>This test pins the post-combiner shape: under fuse=true, exactly 1 delegated_predicate
-     * marker, zero delegation_possible markers, exactly 1 DelegatedExpression entry.
+     * <p>Now the combiner collapses an OR/NOT with a same-backend correctness sibling into one
+     * {@code delegated_predicate} — a bare delegated leaf the data node routes wholesale to Lucene.
+     * Pins: exactly 1 delegated_predicate marker, zero delegation_possible markers, 1 expression.
      */
-    public void testOrCorrectnessPlusPerf_twoLeaves_fuseDualViable_collapsesToOneDelegated() {
+    public void testOrCorrectnessPlusPerf_twoLeaves_collapsesToOneDelegated() {
         RecordingConvertor dfConvertor = new RecordingConvertor();
         RecordingSerializer serializer = new RecordingSerializer();
         // OR(MATCH(message,'hello') correctness-delegated, EQUALS(tag='alpha') perf-delegated)
@@ -1541,52 +1460,44 @@ public class FragmentConversionDriverTests extends BasePlannerRulesTests {
                 rexBuilder.makeLiteral("alpha")
             )
         );
-        QueryDAG dag = buildKeywordFuseDag(condition, dfConvertor, serializer, /* fuseDualViable */ true);
+        QueryDAG dag = buildKeywordFuseDag(condition, dfConvertor, serializer);
         StagePlan plan = leafStage(dag).getPlanAlternatives().getFirst();
 
         String strippedPlan = RelOptUtil.toString(dfConvertor.shardScanFragment);
         assertEquals(
-            "fuse=true 2-leaf OR(correctness, perf): 1 delegated expression (whole OR ships as one peer subtree)",
+            "2-leaf OR(correctness, perf): 1 delegated expression (whole OR ships as one peer subtree)",
             1,
             plan.delegatedExpressions().size()
         );
         assertEquals(
-            "fuse=true 2-leaf OR(correctness, perf): 0 delegation_possible markers — "
-                + "delegation_possible doesn't compose with disjunction",
+            "2-leaf OR(correctness, perf): 0 delegation_possible markers — doesn't compose under disjunction",
             0,
             countOccurrences(strippedPlan, "delegation_possible")
         );
         assertEquals(
-            "fuse=true 2-leaf OR(correctness, perf): exactly 1 delegated_predicate marker at top",
+            "2-leaf OR(correctness, perf): exactly 1 delegated_predicate marker at top",
             1,
             countOccurrences(strippedPlan, "delegated_predicate")
         );
     }
 
     /**
-     * Combiner shape matrix across AND/OR/NOT × fuse modes × native sibling presence.
-     * Each row pins the post-combiner shape via three counters:
+     * Combiner shape matrix across AND/OR/NOT × native-sibling presence. Each row pins the
+     * post-combiner shape via three counters:
      * <ol>
-     *   <li>number of {@code DelegatedExpression} entries the data node receives,</li>
-     *   <li>number of {@code delegated_predicate(annotationId)} markers in the rebuilt
-     *       RexCall (peer evaluates these subtrees end-to-end),</li>
-     *   <li>number of {@code delegation_possible(original, annotationId)} markers (driver
-     *       evaluates the wrapped predicate natively, peer consulted opportunistically).</li>
+     *   <li>{@code DelegatedExpression} entries the data node receives,</li>
+     *   <li>{@code delegated_predicate(id)} markers (peer evaluates these end-to-end),</li>
+     *   <li>{@code delegation_possible(original, id)} markers (driver evaluates natively, peer
+     *       consulted opportunistically).</li>
      * </ol>
      *
-     * <p>fuse=true contract: dual-viable leaves classify as correctness everywhere, so
-     * {@code delegation_possible} never appears under fuse=true. Cross-bucket merging
-     * (correctness + dual-viable in the same boolean) collapses to a single
-     * {@code delegated_predicate} regardless of native siblings.
-     *
-     * <p>fuse=false contract: dual-viable leaves stay as performance-delegated under AND
-     * (one {@code delegation_possible} per leaf) but get carved back to native individually
-     * under OR/NOT. Native-only siblings stay native at the top of the rebuilt boolean.
+     * <p>Rule: a dual-viable leaf is performance-delegated under AND (one delegation_possible per
+     * leaf); under OR/NOT it's reclassified to correctness, fusing with any same-backend correctness
+     * siblings into one delegated_predicate. Native-only siblings stay native at the top.
      *
      * <p>Field setup (from {@code buildKeywordPlusNativeDag}, prod-Lucene-shaped):
-     * tag:keyword(index=true) and message:keyword(index=true) → both dual-viable for EQUALS
-     * (perf-delegated to Lucene); message also handles MATCH/FUZZY (Lucene-correctness);
-     * amount:int(index=false) → no Lucene format, native-only.
+     * tag/message:keyword(index=true) → dual-viable for EQUALS; message also handles MATCH/FUZZY
+     * (Lucene-correctness); amount:int(index=false) → native-only.
      */
     public void testCombinerShapeMatrix_andOrNot_withAndWithoutNativeSibling() {
         // ── shapes ──────────────────────────────────────────────────────────
@@ -1609,64 +1520,68 @@ public class FragmentConversionDriverTests extends BasePlannerRulesTests {
         // amount has index=false → no Lucene format → native-only.
         RexNode nativeArm = makeEquals(2, SqlTypeName.INTEGER, 42);
 
-        // (label, condition, fuse=false expectation, fuse=true expectation)
+        // (label, condition, expectation) — expectation = {delegatedExpressions,
+        // delegated_predicate markers, delegation_possible markers}. Single expectation per shape:
+        // delegation is now decided purely by tree position.
+        //
+        // Rules: a dual-viable (perf) leaf stays performance-delegated (delegation_possible) under
+        // AND. Under OR/NOT it cannot stay perf (perf delegation is AND-only in the data node), so
+        // it's reclassified to correctness and ships to the peer, fusing with same-backend siblings.
         Object[][] cases = {
-            // ── AND: dual-viable stays as delegation_possible per-leaf under fuse=false ──
-            { "AND(MATCH, EQUALS-perf)", makeAnd(match, eqPerf), new int[] { 2, 1, 1 }, new int[] { 1, 1, 0 } },
-            { "AND(MATCH, EQUALS-perf, native)", makeAnd(match, eqPerf, nativeArm), new int[] { 2, 1, 1 }, new int[] { 1, 1, 0 } },
-            { "AND(MATCH, native)", makeAnd(match, nativeArm), new int[] { 1, 1, 0 }, new int[] { 1, 1, 0 } },
+            // ── AND: perf stays perf (delegation_possible per perf leaf) ──
+            { "AND(MATCH, EQUALS-perf)", makeAnd(match, eqPerf), new int[] { 2, 1, 1 } },
+            { "AND(MATCH, EQUALS-perf, native)", makeAnd(match, eqPerf, nativeArm), new int[] { 2, 1, 1 } },
+            { "AND(MATCH, native)", makeAnd(match, nativeArm), new int[] { 1, 1, 0 } },
 
-            // ── OR: dual-viable carves back to native under fuse=false ─────────
-            { "OR(MATCH, FUZZY)", or(match, fuzzy), new int[] { 1, 1, 0 }, new int[] { 1, 1, 0 } },
-            { "OR(EQUALS-perf, EQUALS-perf2)", or(eqPerf, eqPerf2), new int[] { 2, 0, 2 }, new int[] { 1, 1, 0 } },
-            { "OR(EQUALS-perf, EQUALS-perf2, native)", or(eqPerf, eqPerf2, nativeArm), new int[] { 2, 0, 2 }, new int[] { 1, 1, 0 } },
-            { "OR(MATCH, EQUALS-perf)", or(match, eqPerf), new int[] { 2, 1, 1 }, new int[] { 1, 1, 0 } },
-            { "OR(MATCH, EQUALS-perf, native)", or(match, eqPerf, nativeArm), new int[] { 2, 1, 1 }, new int[] { 1, 1, 0 } },
-            { "OR(MATCH, FUZZY, native)", or(match, fuzzy, nativeArm), new int[] { 1, 1, 0 }, new int[] { 1, 1, 0 } },
-            { "OR(MATCH, native)", or(match, nativeArm), new int[] { 1, 1, 0 }, new int[] { 1, 1, 0 } },
+            // ── OR perf-only: perf reclassified to correctness, fused into one peer shipment ──
+            { "OR(EQUALS-perf, EQUALS-perf2)", or(eqPerf, eqPerf2), new int[] { 1, 1, 0 } },
+            { "OR(EQUALS-perf, EQUALS-perf2, native)", or(eqPerf, eqPerf2, nativeArm), new int[] { 1, 1, 0 } },
+
+            // ── OR/NOT with a same-backend correctness sibling: perf fuses into it → 1 delegated_predicate ──
+            { "OR(MATCH, FUZZY)", or(match, fuzzy), new int[] { 1, 1, 0 } },
+            { "OR(MATCH, EQUALS-perf)", or(match, eqPerf), new int[] { 1, 1, 0 } },
+            { "OR(MATCH, EQUALS-perf, native)", or(match, eqPerf, nativeArm), new int[] { 1, 1, 0 } },
+            { "OR(MATCH, FUZZY, native)", or(match, fuzzy, nativeArm), new int[] { 1, 1, 0 } },
+            { "OR(MATCH, native)", or(match, nativeArm), new int[] { 1, 1, 0 } },
 
             // ── NOT shapes (Calcite folds NOT(=) → ≠ pre-combiner, so no perf survives there) ──
-            { "NOT(MATCH)", rexBuilder.makeCall(SqlStdOperatorTable.NOT, match), new int[] { 1, 1, 0 }, new int[] { 1, 1, 0 } },
-            { "NOT(EQUALS-perf)", rexBuilder.makeCall(SqlStdOperatorTable.NOT, eqPerf), new int[] { 0, 0, 0 }, new int[] { 0, 0, 0 } },
+            { "NOT(MATCH)", rexBuilder.makeCall(SqlStdOperatorTable.NOT, match), new int[] { 1, 1, 0 } },
+            { "NOT(EQUALS-perf)", rexBuilder.makeCall(SqlStdOperatorTable.NOT, eqPerf), new int[] { 0, 0, 0 } },
 
-            // ── NOT inside boolean — the prod-bug shape from the OR-fuse fix ───
-            { "OR(NOT(MATCH), EQUALS-perf)", or(notMatch, eqPerf), new int[] { 2, 1, 1 }, new int[] { 1, 1, 0 } },
-            { "OR(NOT(MATCH), EQUALS-perf, native)", or(notMatch, eqPerf, nativeArm), new int[] { 2, 1, 1 }, new int[] { 1, 1, 0 } },
-            { "AND(NOT(MATCH), EQUALS-perf, native)", makeAnd(notMatch, eqPerf, nativeArm), new int[] { 2, 1, 1 }, new int[] { 1, 1, 0 } },
-            { "OR(NOT(MATCH), native)", or(notMatch, nativeArm), new int[] { 1, 1, 0 }, new int[] { 1, 1, 0 } },
-            { "AND(NOT(MATCH), native)", makeAnd(notMatch, nativeArm), new int[] { 1, 1, 0 }, new int[] { 1, 1, 0 } }, };
+            // ── NOT inside boolean — the prod-bug shape from the OR-disjunction fix ───
+            { "OR(NOT(MATCH), EQUALS-perf)", or(notMatch, eqPerf), new int[] { 1, 1, 0 } },
+            { "OR(NOT(MATCH), EQUALS-perf, native)", or(notMatch, eqPerf, nativeArm), new int[] { 1, 1, 0 } },
+            { "AND(NOT(MATCH), EQUALS-perf, native)", makeAnd(notMatch, eqPerf, nativeArm), new int[] { 2, 1, 1 } },
+            { "OR(NOT(MATCH), native)", or(notMatch, nativeArm), new int[] { 1, 1, 0 } },
+            { "AND(NOT(MATCH), native)", makeAnd(notMatch, nativeArm), new int[] { 1, 1, 0 } }, };
 
         for (Object[] testCase : cases) {
             String label = (String) testCase[0];
             RexNode condition = (RexNode) testCase[1];
-            int[] expectedFalse = (int[]) testCase[2];
-            int[] expectedTrue = (int[]) testCase[3];
-            assertCombinerShape(label, condition, false, expectedFalse[0], expectedFalse[1], expectedFalse[2]);
-            assertCombinerShape(label, condition, true, expectedTrue[0], expectedTrue[1], expectedTrue[2]);
+            int[] expected = (int[]) testCase[2];
+            assertCombinerShape(label, condition, expected[0], expected[1], expected[2]);
         }
     }
 
     private void assertCombinerShape(
         String label,
         RexNode condition,
-        boolean fuse,
         int expDelegatedExprs,
         int expDelegatedPredicate,
         int expDelegationPossible
     ) {
         RecordingConvertor c = new RecordingConvertor();
-        QueryDAG d = buildKeywordPlusNativeDag(condition, c, new RecordingSerializer(), fuse);
+        QueryDAG d = buildKeywordPlusNativeDag(condition, c, new RecordingSerializer());
         StagePlan p = leafStage(d).getPlanAlternatives().getFirst();
         String stripped = RelOptUtil.toString(c.shardScanFragment);
-        String prefix = label + " fuse=" + fuse;
-        assertEquals(prefix + " — delegatedExpressions (plan: " + stripped + ")", expDelegatedExprs, p.delegatedExpressions().size());
+        assertEquals(label + " — delegatedExpressions (plan: " + stripped + ")", expDelegatedExprs, p.delegatedExpressions().size());
         assertEquals(
-            prefix + " — delegated_predicate markers (plan: " + stripped + ")",
+            label + " — delegated_predicate markers (plan: " + stripped + ")",
             expDelegatedPredicate,
             countOccurrences(stripped, "delegated_predicate")
         );
         assertEquals(
-            prefix + " — delegation_possible markers (plan: " + stripped + ")",
+            label + " — delegation_possible markers (plan: " + stripped + ")",
             expDelegationPossible,
             countOccurrences(stripped, "delegation_possible")
         );
@@ -1703,22 +1618,16 @@ public class FragmentConversionDriverTests extends BasePlannerRulesTests {
     private record FuseTestSetup(RecordingConvertor dfConvertor, RecordingSerializer serializer, RexNode condition) {
     }
 
-    /** Two-keyword-field delegation helper for the fuse tests. Both fields are dual-viable;
-     *  no integer field is involved, so this stays consistent with prod Lucene caps. */
-    private QueryDAG buildKeywordFuseDag(
-        RexNode condition,
-        RecordingConvertor dfConvertor,
-        RecordingSerializer serializer,
-        boolean fuseDualViable
-    ) {
+    /** Two-keyword-field delegation helper. Both fields are dual-viable; no integer field is
+     *  involved, so this stays consistent with prod Lucene caps. */
+    private QueryDAG buildKeywordFuseDag(RexNode condition, RecordingConvertor dfConvertor, RecordingSerializer serializer) {
         return buildDelegationDag(
             condition,
             dfConvertor,
             serializer,
             new String[] { "tag", "message" },
             new SqlTypeName[] { SqlTypeName.VARCHAR, SqlTypeName.VARCHAR },
-            Map.of("tag", Map.of("type", "keyword", "index", true), "message", Map.of("type", "keyword", "index", true)),
-            fuseDualViable
+            Map.of("tag", Map.of("type", "keyword", "index", true), "message", Map.of("type", "keyword", "index", true))
         );
     }
 
@@ -1776,7 +1685,7 @@ public class FragmentConversionDriverTests extends BasePlannerRulesTests {
         PlanForker.forkAll(dag, context.getCapabilityRegistry());
         IllegalStateException exception = expectThrows(
             IllegalStateException.class,
-            () -> FragmentConversionDriver.convertAll(dag, context.getCapabilityRegistry(), false)
+            () -> FragmentConversionDriver.convertAll(dag, context.getCapabilityRegistry())
         );
         assertTrue(exception.getMessage().contains("No DelegatedPredicateSerializer"));
     }
@@ -1820,7 +1729,7 @@ public class FragmentConversionDriverTests extends BasePlannerRulesTests {
         RelNode cboOutput = runPlanner(filter, context);
         QueryDAG dag = DAGBuilder.build(cboOutput, context.getCapabilityRegistry(), mockClusterService(), TEST_RESOLVER);
         PlanForker.forkAll(dag, context.getCapabilityRegistry());
-        FragmentConversionDriver.convertAll(dag, context.getCapabilityRegistry(), false);
+        FragmentConversionDriver.convertAll(dag, context.getCapabilityRegistry());
         StagePlan plan = leafStage(dag).getPlanAlternatives().getFirst();
         // Only MATCH_PHRASE delegated; EQUALS stays native (no serializer)
         assertEquals("Only serializable predicates delegated", 1, plan.delegatedExpressions().size());
@@ -1867,7 +1776,7 @@ public class FragmentConversionDriverTests extends BasePlannerRulesTests {
         RelNode cboOutput = runPlanner(filter, context);
         QueryDAG dag = DAGBuilder.build(cboOutput, context.getCapabilityRegistry(), mockClusterService(), TEST_RESOLVER);
         PlanForker.forkAll(dag, context.getCapabilityRegistry());
-        FragmentConversionDriver.convertAll(dag, context.getCapabilityRegistry(), false);
+        FragmentConversionDriver.convertAll(dag, context.getCapabilityRegistry());
         StagePlan plan = leafStage(dag).getPlanAlternatives().getFirst();
         // Correctness and performance delegated stay separate — 2 DelegatedExpressions
         assertEquals("Correctness and performance delegated stay separate", 2, plan.delegatedExpressions().size());
@@ -1953,8 +1862,9 @@ public class FragmentConversionDriverTests extends BasePlannerRulesTests {
     }
 
     /**
-     * match(Title,'ru') OR Referer='google' AND URL='US' AND GoodEvent=1
-     * Under OR, perf-delegated stays native (resolved via applyFn).
+     * match(Title,'ru') OR (Referer='google' AND URL='US' AND GoodEvent=1)
+     * Under OR the Referer/URL perf leaves ship to Lucene (reclassified to correctness), so the plan
+     * carries delegated_predicate but no delegation_possible. GoodEvent is native.
      */
     public void testOrCorrectnessWithPerfAndNative() {
         RecordingConvertor dfConvertor = new RecordingConvertor();
@@ -1986,12 +1896,11 @@ public class FragmentConversionDriverTests extends BasePlannerRulesTests {
             )
         );
         StagePlan plan = leafStage(dag).getPlanAlternatives().getFirst();
-        // match is correctness-delegated (1 expression), perf under AND already combined (1 expression)
         assertEquals(2, plan.delegatedExpressions().size());
         String strippedPlan = RelOptUtil.toString(dfConvertor.shardScanFragment);
         LOGGER.info("Plan (OR correctness with perf+native):\n{}", strippedPlan);
-        assertTrue("Should have delegated_predicate for match", strippedPlan.contains(DelegatedPredicateFunction.NAME));
-        assertTrue("Should have delegation_possible for perf", strippedPlan.contains(DelegationPossibleFunction.NAME));
+        assertTrue("Should have delegated_predicate", strippedPlan.contains(DelegatedPredicateFunction.NAME));
+        assertFalse("perf ships to Lucene under OR — no delegation_possible", strippedPlan.contains(DelegationPossibleFunction.NAME));
         assertEquals(FilterTreeShape.INTERLEAVED_BOOLEAN_EXPRESSION, treeShapeOf(plan));
     }
 
@@ -2030,7 +1939,10 @@ public class FragmentConversionDriverTests extends BasePlannerRulesTests {
         String strippedPlan = RelOptUtil.toString(dfConvertor.shardScanFragment);
         LOGGER.info("Plan (AND correctness OR perf + native):\n{}", strippedPlan);
         assertTrue("Should have delegated_predicate", strippedPlan.contains(DelegatedPredicateFunction.NAME));
-        assertTrue("Should have delegation_possible", strippedPlan.contains(DelegationPossibleFunction.NAME));
+        assertFalse(
+            "perf can't survive under OR — must not have delegation_possible",
+            strippedPlan.contains(DelegationPossibleFunction.NAME)
+        );
         assertEquals(FilterTreeShape.INTERLEAVED_BOOLEAN_EXPRESSION, treeShapeOf(plan));
     }
 

--- a/sandbox/qa/analytics-engine-coordinator/src/internalClusterTest/java/org/opensearch/be/datafusion/QtfSubstraitDumpIT.java
+++ b/sandbox/qa/analytics-engine-coordinator/src/internalClusterTest/java/org/opensearch/be/datafusion/QtfSubstraitDumpIT.java
@@ -140,7 +140,7 @@ public class QtfSubstraitDumpIT extends OpenSearchTestCase {
         LOGGER.info("[QTF-DUMP] QueryDAG (pre-conversion):\n{}", dag);
 
         PlanForker.forkAll(dag, context.getCapabilityRegistry());
-        FragmentConversionDriver.convertAll(dag, context.getCapabilityRegistry(), false);
+        FragmentConversionDriver.convertAll(dag, context.getCapabilityRegistry());
         LOGGER.info("[QTF-DUMP] QueryDAG (post-conversion, with backend-resolved fragments):\n{}", dag);
 
         // Walk every stage and dump its substrait Plan(s).
@@ -213,7 +213,7 @@ public class QtfSubstraitDumpIT extends OpenSearchTestCase {
         RelNode cbo = PlannerImpl.runAllOptimizations(parsed, context);
         QueryDAG dag = DAGBuilder.build(cbo, context.getCapabilityRegistry(), mockClusterService(), TEST_RESOLVER);
         PlanForker.forkAll(dag, context.getCapabilityRegistry());
-        FragmentConversionDriver.convertAll(dag, context.getCapabilityRegistry(), false);
+        FragmentConversionDriver.convertAll(dag, context.getCapabilityRegistry());
         return dag;
     }
 

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/CountFastPathIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/CountFastPathIT.java
@@ -183,8 +183,8 @@ public class CountFastPathIT extends AnalyticsRestTestCase {
             oracleWhere(d -> d.userID.equals("u_a") && tokenizedContains(d.message, "alpha"))
         );
 
-        // OR mixing keyword EQUALS with MATCH — the combiner's OR/NOT carve-out behavior
-        // depends on the fuse_dual_viable setting; both modes must produce the same count.
+        // OR mixing keyword EQUALS with MATCH — the dual-viable EQUALS fuses with the MATCH
+        // correctness sibling into one Lucene shipment under OR; the count is unaffected.
         assertCount(
             "where userID = 'u_b' OR match(message, 'gamma') | stats count() as cnt",
             oracleWhere(d -> d.userID.equals("u_b") || tokenizedContains(d.message, "gamma"))

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/FilterDelegationGoldenIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/FilterDelegationGoldenIT.java
@@ -16,10 +16,10 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Filter-delegation matrix IT. Walks every enabled {@link Shape} through the
- * {@code (prefer_metadata_driver × fuse_dual_viable)} 4-cell matrix, asserts response
- * equality (against {@code ppl/expected/q{N}.json}) and per-cell {@code chosen_backend} /
- * {@code tree_shape} on the SHARD_FRAGMENT profile.
+ * Filter-delegation matrix IT. Walks every enabled {@link Shape} through both
+ * {@code prefer_metadata_driver} values, asserts response equality (against
+ * {@code ppl/expected/q{N}.json}) and per-cell {@code chosen_backend} / {@code tree_shape}
+ * on the SHARD_FRAGMENT profile.
  *
  * <p>Leaf vocabulary: <b>Dual</b> (DataFusion + Lucene, e.g. keyword EQUALS),
  * <b>Native</b> (DataFusion only, e.g. long EQUALS), <b>Delegated</b> (Lucene only,
@@ -52,10 +52,9 @@ public class FilterDelegationGoldenIT extends AnalyticsRestTestCase {
 
     @Override
     public void tearDown() throws Exception {
-        // Restore defaults so a test that toggled {prefer,fuse} doesn't leak into the next.
+        // Restore default so a test that toggled prefer_metadata_driver doesn't leak into the next.
         try {
             setPreferMetadataDriver(true);
-            setFuseDualViable(true);
         } finally {
             super.tearDown();
         }
@@ -119,190 +118,108 @@ public class FilterDelegationGoldenIT extends AnalyticsRestTestCase {
     // =====================================================================
 
     /**
-     * Per-cell matrix for {@code (prefer_metadata_driver, fuse_dual_viable)}.
-     *
-     * <p>Cell args are in the order: {@code (prefer=true,fuse=false)},
-     * {@code (true,true)}, {@code (false,false)}, {@code (false,true)}.
-     *
-     * <p>{@link ChosenBackendandTreeShape#placeholder()} disables the stage assertion for that cell
-     * (the response oracle still runs). Used for shapes whose query throws before
-     * producing a profile (the 4 known-red bug shapes).
+     * Per-shape expected (chosen_backend, tree_shape), one cell per {@code prefer_metadata_driver}
+     * value: {@code (preferTrue, preferFalse)}.
      */
     private enum Shape {
+        // Cells are (prefer_metadata_driver=true, prefer=false). prefer=true lets Lucene drive the
+        // whole stage when every arm is Lucene-viable (chosen=lucene, no tree_shape); a native arm
+        // forces datafusion. prefer=false runs the combiner, where delegation shape is decided by
+        // tree position: a dual-viable leaf stays performance-delegated under AND; under OR/NOT it's
+        // reclassified to correctness and ships to Lucene (fusing with same-backend correctness
+        // siblings). A delegated shipment beside a native arm under OR is INTERLEAVED; otherwise CONJUNCTIVE.
+
         // Single leaf (3)
-        SINGLE_DUAL(1,
-            new ChosenBackendandTreeShape("lucene", null), new ChosenBackendandTreeShape("lucene", null),
-            new ChosenBackendandTreeShape("datafusion", "CONJUNCTIVE"), new ChosenBackendandTreeShape("datafusion", "CONJUNCTIVE")),
-        SINGLE_NATIVE(2,
-            new ChosenBackendandTreeShape("datafusion", null), new ChosenBackendandTreeShape("datafusion", null),
-            new ChosenBackendandTreeShape("datafusion", null), new ChosenBackendandTreeShape("datafusion", null)),
-        SINGLE_DELEGATED(3,
-            new ChosenBackendandTreeShape("lucene", null), new ChosenBackendandTreeShape("lucene", null),
-            new ChosenBackendandTreeShape("datafusion", "CONJUNCTIVE"), new ChosenBackendandTreeShape("datafusion", "CONJUNCTIVE")),
+        SINGLE_DUAL(1, lucene(), df("CONJUNCTIVE")),
+        SINGLE_NATIVE(2, df(null), df(null)),
+        SINGLE_DELEGATED(3, lucene(), df("CONJUNCTIVE")),
 
         // Two-leaf AND (6)
-        AND_DUAL_DUAL(4,
-            new ChosenBackendandTreeShape("lucene", null), new ChosenBackendandTreeShape("lucene", null),
-            new ChosenBackendandTreeShape("datafusion", "CONJUNCTIVE"), new ChosenBackendandTreeShape("datafusion", "CONJUNCTIVE")),
-        AND_NATIVE_NATIVE(5,
-            new ChosenBackendandTreeShape("datafusion", null), new ChosenBackendandTreeShape("datafusion", null),
-            new ChosenBackendandTreeShape("datafusion", null), new ChosenBackendandTreeShape("datafusion", null)),
-        AND_DELEGATED_DELEGATED(6,
-            new ChosenBackendandTreeShape("lucene", null), new ChosenBackendandTreeShape("lucene", null),
-            new ChosenBackendandTreeShape("datafusion", "CONJUNCTIVE"), new ChosenBackendandTreeShape("datafusion", "CONJUNCTIVE")),
-        AND_DUAL_NATIVE(7,
-            new ChosenBackendandTreeShape("datafusion", "CONJUNCTIVE"), new ChosenBackendandTreeShape("datafusion", "CONJUNCTIVE"),
-            new ChosenBackendandTreeShape("datafusion", "CONJUNCTIVE"), new ChosenBackendandTreeShape("datafusion", "CONJUNCTIVE")),
-        AND_DUAL_DELEGATED(8,
-            new ChosenBackendandTreeShape("lucene", null), new ChosenBackendandTreeShape("lucene", null),
-            new ChosenBackendandTreeShape("datafusion", "CONJUNCTIVE"), new ChosenBackendandTreeShape("datafusion", "CONJUNCTIVE")),
-        AND_NATIVE_DELEGATED(9,
-            new ChosenBackendandTreeShape("datafusion", "CONJUNCTIVE"), new ChosenBackendandTreeShape("datafusion", "CONJUNCTIVE"),
-            new ChosenBackendandTreeShape("datafusion", "CONJUNCTIVE"), new ChosenBackendandTreeShape("datafusion", "CONJUNCTIVE")),
+        AND_DUAL_DUAL(4, lucene(), df("CONJUNCTIVE")),
+        AND_NATIVE_NATIVE(5, df(null), df(null)),
+        AND_DELEGATED_DELEGATED(6, lucene(), df("CONJUNCTIVE")),
+        AND_DUAL_NATIVE(7, df("CONJUNCTIVE"), df("CONJUNCTIVE")),
+        AND_DUAL_DELEGATED(8, lucene(), df("CONJUNCTIVE")),
+        AND_NATIVE_DELEGATED(9, df("CONJUNCTIVE"), df("CONJUNCTIVE")),
 
         // Two-leaf OR (6)
-        OR_DUAL_DUAL(10,
-            new ChosenBackendandTreeShape("lucene", null), new ChosenBackendandTreeShape("lucene", null),
-            new ChosenBackendandTreeShape("datafusion", "INTERLEAVED_BOOLEAN_EXPRESSION"), new ChosenBackendandTreeShape("datafusion", "CONJUNCTIVE")),
-        OR_NATIVE_NATIVE(11,
-            new ChosenBackendandTreeShape("datafusion", null), new ChosenBackendandTreeShape("datafusion", null),
-            new ChosenBackendandTreeShape("datafusion", null), new ChosenBackendandTreeShape("datafusion", null)),
-        OR_DELEGATED_DELEGATED(12,
-            new ChosenBackendandTreeShape("lucene", null), new ChosenBackendandTreeShape("lucene", null),
-            new ChosenBackendandTreeShape("datafusion", "CONJUNCTIVE"), new ChosenBackendandTreeShape("datafusion", "CONJUNCTIVE")),
-        OR_DUAL_NATIVE(13,
-            new ChosenBackendandTreeShape("datafusion", "INTERLEAVED_BOOLEAN_EXPRESSION"), new ChosenBackendandTreeShape("datafusion", "INTERLEAVED_BOOLEAN_EXPRESSION"),
-            new ChosenBackendandTreeShape("datafusion", "INTERLEAVED_BOOLEAN_EXPRESSION"), new ChosenBackendandTreeShape("datafusion", "INTERLEAVED_BOOLEAN_EXPRESSION")),
-        OR_DUAL_DELEGATED(14,
-            new ChosenBackendandTreeShape("lucene", null), new ChosenBackendandTreeShape("lucene", null),
-            new ChosenBackendandTreeShape("datafusion", "INTERLEAVED_BOOLEAN_EXPRESSION"), new ChosenBackendandTreeShape("datafusion", "CONJUNCTIVE")),
-        OR_NATIVE_DELEGATED(15,
-            new ChosenBackendandTreeShape("datafusion", "INTERLEAVED_BOOLEAN_EXPRESSION"), new ChosenBackendandTreeShape("datafusion", "INTERLEAVED_BOOLEAN_EXPRESSION"),
-            new ChosenBackendandTreeShape("datafusion", "INTERLEAVED_BOOLEAN_EXPRESSION"), new ChosenBackendandTreeShape("datafusion", "INTERLEAVED_BOOLEAN_EXPRESSION")),
+        OR_DUAL_DUAL(10, lucene(), df("CONJUNCTIVE")),
+        OR_NATIVE_NATIVE(11, df(null), df(null)),
+        OR_DELEGATED_DELEGATED(12, lucene(), df("CONJUNCTIVE")),
+        OR_DUAL_NATIVE(13, df("INTERLEAVED_BOOLEAN_EXPRESSION"), df("INTERLEAVED_BOOLEAN_EXPRESSION")),
+        OR_DUAL_DELEGATED(14, lucene(), df("CONJUNCTIVE")),
+        OR_NATIVE_DELEGATED(15, df("INTERLEAVED_BOOLEAN_EXPRESSION"), df("INTERLEAVED_BOOLEAN_EXPRESSION")),
 
         // Three-leaf AND (7)
-        AND_DUAL_DUAL_DUAL(16,
-            new ChosenBackendandTreeShape("lucene", null), new ChosenBackendandTreeShape("lucene", null),
-            new ChosenBackendandTreeShape("datafusion", "CONJUNCTIVE"), new ChosenBackendandTreeShape("datafusion", "CONJUNCTIVE")),
-        AND_NATIVE_NATIVE_NATIVE(17,
-            new ChosenBackendandTreeShape("datafusion", null), new ChosenBackendandTreeShape("datafusion", null),
-            new ChosenBackendandTreeShape("datafusion", null), new ChosenBackendandTreeShape("datafusion", null)),
-        AND_DELEGATED_DELEGATED_DELEGATED(18,
-            new ChosenBackendandTreeShape("lucene", null), new ChosenBackendandTreeShape("lucene", null),
-            new ChosenBackendandTreeShape("datafusion", "CONJUNCTIVE"), new ChosenBackendandTreeShape("datafusion", "CONJUNCTIVE")),
-        AND_DUAL_DUAL_DELEGATED(19,
-            new ChosenBackendandTreeShape("lucene", null), new ChosenBackendandTreeShape("lucene", null),
-            new ChosenBackendandTreeShape("datafusion", "CONJUNCTIVE"), new ChosenBackendandTreeShape("datafusion", "CONJUNCTIVE")),
-        AND_DUAL_DUAL_NATIVE(20,
-            new ChosenBackendandTreeShape("datafusion", "CONJUNCTIVE"), new ChosenBackendandTreeShape("datafusion", "CONJUNCTIVE"),
-            new ChosenBackendandTreeShape("datafusion", "CONJUNCTIVE"), new ChosenBackendandTreeShape("datafusion", "CONJUNCTIVE")),
-        AND_DELEGATED_DELEGATED_NATIVE(21,
-            new ChosenBackendandTreeShape("datafusion", "CONJUNCTIVE"), new ChosenBackendandTreeShape("datafusion", "CONJUNCTIVE"),
-            new ChosenBackendandTreeShape("datafusion", "CONJUNCTIVE"), new ChosenBackendandTreeShape("datafusion", "CONJUNCTIVE")),
-        AND_DUAL_DELEGATED_NATIVE(22,
-            new ChosenBackendandTreeShape("datafusion", "CONJUNCTIVE"), new ChosenBackendandTreeShape("datafusion", "CONJUNCTIVE"),
-            new ChosenBackendandTreeShape("datafusion", "CONJUNCTIVE"), new ChosenBackendandTreeShape("datafusion", "CONJUNCTIVE")),
+        AND_DUAL_DUAL_DUAL(16, lucene(), df("CONJUNCTIVE")),
+        AND_NATIVE_NATIVE_NATIVE(17, df(null), df(null)),
+        AND_DELEGATED_DELEGATED_DELEGATED(18, lucene(), df("CONJUNCTIVE")),
+        AND_DUAL_DUAL_DELEGATED(19, lucene(), df("CONJUNCTIVE")),
+        AND_DUAL_DUAL_NATIVE(20, df("CONJUNCTIVE"), df("CONJUNCTIVE")),
+        AND_DELEGATED_DELEGATED_NATIVE(21, df("CONJUNCTIVE"), df("CONJUNCTIVE")),
+        AND_DUAL_DELEGATED_NATIVE(22, df("CONJUNCTIVE"), df("CONJUNCTIVE")),
 
         // Three-leaf OR (7)
-        OR_DUAL_DUAL_DUAL(23,
-            new ChosenBackendandTreeShape("lucene", null), new ChosenBackendandTreeShape("lucene", null),
-            new ChosenBackendandTreeShape("datafusion", "INTERLEAVED_BOOLEAN_EXPRESSION"), new ChosenBackendandTreeShape("datafusion", "CONJUNCTIVE")),
-        OR_NATIVE_NATIVE_NATIVE(24,
-            new ChosenBackendandTreeShape("datafusion", null), new ChosenBackendandTreeShape("datafusion", null),
-            new ChosenBackendandTreeShape("datafusion", null), new ChosenBackendandTreeShape("datafusion", null)),
-        OR_DELEGATED_DELEGATED_DELEGATED(25,
-            new ChosenBackendandTreeShape("lucene", null), new ChosenBackendandTreeShape("lucene", null),
-            new ChosenBackendandTreeShape("datafusion", "CONJUNCTIVE"), new ChosenBackendandTreeShape("datafusion", "CONJUNCTIVE")),
-        OR_DUAL_DUAL_DELEGATED(26,
-            new ChosenBackendandTreeShape("lucene", null), new ChosenBackendandTreeShape("lucene", null),
-            new ChosenBackendandTreeShape("datafusion", "INTERLEAVED_BOOLEAN_EXPRESSION"), new ChosenBackendandTreeShape("datafusion", "CONJUNCTIVE")),
-        OR_DUAL_DUAL_NATIVE(27,
-            new ChosenBackendandTreeShape("datafusion", "INTERLEAVED_BOOLEAN_EXPRESSION"), new ChosenBackendandTreeShape("datafusion", "INTERLEAVED_BOOLEAN_EXPRESSION"),
-            new ChosenBackendandTreeShape("datafusion", "INTERLEAVED_BOOLEAN_EXPRESSION"), new ChosenBackendandTreeShape("datafusion", "INTERLEAVED_BOOLEAN_EXPRESSION")),
-        OR_DELEGATED_DELEGATED_NATIVE(28,
-            new ChosenBackendandTreeShape("datafusion", "INTERLEAVED_BOOLEAN_EXPRESSION"), new ChosenBackendandTreeShape("datafusion", "INTERLEAVED_BOOLEAN_EXPRESSION"),
-            new ChosenBackendandTreeShape("datafusion", "INTERLEAVED_BOOLEAN_EXPRESSION"), new ChosenBackendandTreeShape("datafusion", "INTERLEAVED_BOOLEAN_EXPRESSION")),
-        OR_DUAL_DELEGATED_NATIVE(29,
-            new ChosenBackendandTreeShape("datafusion", "INTERLEAVED_BOOLEAN_EXPRESSION"), new ChosenBackendandTreeShape("datafusion", "INTERLEAVED_BOOLEAN_EXPRESSION"),
-            new ChosenBackendandTreeShape("datafusion", "INTERLEAVED_BOOLEAN_EXPRESSION"), new ChosenBackendandTreeShape("datafusion", "INTERLEAVED_BOOLEAN_EXPRESSION")),
+        OR_DUAL_DUAL_DUAL(23, lucene(), df("CONJUNCTIVE")),
+        OR_NATIVE_NATIVE_NATIVE(24, df(null), df(null)),
+        OR_DELEGATED_DELEGATED_DELEGATED(25, lucene(), df("CONJUNCTIVE")),
+        OR_DUAL_DUAL_DELEGATED(26, lucene(), df("CONJUNCTIVE")),
+        OR_DUAL_DUAL_NATIVE(27, df("INTERLEAVED_BOOLEAN_EXPRESSION"), df("INTERLEAVED_BOOLEAN_EXPRESSION")),
+        OR_DELEGATED_DELEGATED_NATIVE(28, df("INTERLEAVED_BOOLEAN_EXPRESSION"), df("INTERLEAVED_BOOLEAN_EXPRESSION")),
+        OR_DUAL_DELEGATED_NATIVE(29, df("INTERLEAVED_BOOLEAN_EXPRESSION"), df("INTERLEAVED_BOOLEAN_EXPRESSION")),
 
         // NOT(leaf) (3)
-        NOT_DUAL(30,
-            new ChosenBackendandTreeShape("datafusion", null), new ChosenBackendandTreeShape("datafusion", null),
-            new ChosenBackendandTreeShape("datafusion", null), new ChosenBackendandTreeShape("datafusion", null)),
-        NOT_NATIVE(31,
-            new ChosenBackendandTreeShape("datafusion", null), new ChosenBackendandTreeShape("datafusion", null),
-            new ChosenBackendandTreeShape("datafusion", null), new ChosenBackendandTreeShape("datafusion", null)),
-        NOT_DELEGATED(32,
-            new ChosenBackendandTreeShape("lucene", null), new ChosenBackendandTreeShape("lucene", null),
-            new ChosenBackendandTreeShape("datafusion", "CONJUNCTIVE"), new ChosenBackendandTreeShape("datafusion", "CONJUNCTIVE")),
+        NOT_DUAL(30, df(null), df(null)),
+        NOT_NATIVE(31, df(null), df(null)),
+        NOT_DELEGATED(32, lucene(), df("CONJUNCTIVE")),
 
         // Mixed connectors, depth 2 (6)
-        MIXED_OR_OF_ANDS_OF_DUALS(33,
-            new ChosenBackendandTreeShape("lucene", null), new ChosenBackendandTreeShape("lucene", null),
-            new ChosenBackendandTreeShape("datafusion", "INTERLEAVED_BOOLEAN_EXPRESSION"), new ChosenBackendandTreeShape("datafusion", "CONJUNCTIVE")),
-        MIXED_OR_OF_ANDS_OF_DELEGATED(34,
-            new ChosenBackendandTreeShape("lucene", null), new ChosenBackendandTreeShape("lucene", null),
-            new ChosenBackendandTreeShape("datafusion", "CONJUNCTIVE"), new ChosenBackendandTreeShape("datafusion", "CONJUNCTIVE")),
-        MIXED_OR_OF_DUAL_DELEGATED_ANDS(35,
-            new ChosenBackendandTreeShape("lucene", null), new ChosenBackendandTreeShape("lucene", null),
-            new ChosenBackendandTreeShape("datafusion", "INTERLEAVED_BOOLEAN_EXPRESSION"), new ChosenBackendandTreeShape("datafusion", "CONJUNCTIVE")),
-        MIXED_AND_OF_DUAL_DELEGATED_ORS(36,
-            new ChosenBackendandTreeShape("lucene", null), new ChosenBackendandTreeShape("lucene", null),
-            new ChosenBackendandTreeShape("datafusion", "INTERLEAVED_BOOLEAN_EXPRESSION"), new ChosenBackendandTreeShape("datafusion", "CONJUNCTIVE")),
-        MIXED_OR_OF_AND_OF_DUALS_AND_NATIVE(37,
-            new ChosenBackendandTreeShape("datafusion", "INTERLEAVED_BOOLEAN_EXPRESSION"), new ChosenBackendandTreeShape("datafusion", "INTERLEAVED_BOOLEAN_EXPRESSION"),
-            new ChosenBackendandTreeShape("datafusion", "INTERLEAVED_BOOLEAN_EXPRESSION"), new ChosenBackendandTreeShape("datafusion", "INTERLEAVED_BOOLEAN_EXPRESSION")),
-        MIXED_NOT_OF_AND_OF_DUALS(38,
-            new ChosenBackendandTreeShape("datafusion", null), new ChosenBackendandTreeShape("datafusion", null),
-            new ChosenBackendandTreeShape("datafusion", null), new ChosenBackendandTreeShape("datafusion", null));
+        MIXED_OR_OF_ANDS_OF_DUALS(33, lucene(), df("CONJUNCTIVE")),
+        MIXED_OR_OF_ANDS_OF_DELEGATED(34, lucene(), df("CONJUNCTIVE")),
+        MIXED_OR_OF_DUAL_DELEGATED_ANDS(35, lucene(), df("CONJUNCTIVE")),
+        MIXED_AND_OF_DUAL_DELEGATED_ORS(36, lucene(), df("CONJUNCTIVE")),
+        MIXED_OR_OF_AND_OF_DUALS_AND_NATIVE(37, df("INTERLEAVED_BOOLEAN_EXPRESSION"), df("INTERLEAVED_BOOLEAN_EXPRESSION")),
+        MIXED_NOT_OF_AND_OF_DUALS(38, df(null), df(null));
 
         final int queryNumber;
-        final Map<SettingCombination, ChosenBackendandTreeShape> cells;
+        final Map<Boolean, ChosenBackendandTreeShape> cells;
 
-        Shape(int queryNumber,
-              ChosenBackendandTreeShape preferTrue_fuseFalse,
-              ChosenBackendandTreeShape preferTrue_fuseTrue,
-              ChosenBackendandTreeShape preferFalse_fuseFalse,
-              ChosenBackendandTreeShape preferFalse_fuseTrue) {
+        Shape(int queryNumber, ChosenBackendandTreeShape preferTrue, ChosenBackendandTreeShape preferFalse) {
             this.queryNumber = queryNumber;
-            Map<SettingCombination, ChosenBackendandTreeShape> map = new LinkedHashMap<>();
-            map.put(new SettingCombination(true,  false), preferTrue_fuseFalse);
-            map.put(new SettingCombination(true,  true),  preferTrue_fuseTrue);
-            map.put(new SettingCombination(false, false), preferFalse_fuseFalse);
-            map.put(new SettingCombination(false, true),  preferFalse_fuseTrue);
+            Map<Boolean, ChosenBackendandTreeShape> map = new LinkedHashMap<>();
+            map.put(true, preferTrue);
+            map.put(false, preferFalse);
             this.cells = java.util.Collections.unmodifiableMap(map);
         }
+    }
+
+    private static ChosenBackendandTreeShape lucene() {
+        return new ChosenBackendandTreeShape("lucene", null);
+    }
+
+    private static ChosenBackendandTreeShape df(String treeShape) {
+        return new ChosenBackendandTreeShape("datafusion", treeShape);
     }
 
     // =====================================================================
     // Driver / matrix harness
     // =====================================================================
 
-    /** Cluster-setting combination: ({@code prefer_metadata_driver}, {@code fuse_dual_viable}). */
-    private record SettingCombination(boolean prefer, boolean fuse) {}
-
     /** Asserted SHARD_FRAGMENT profile fields. {@code treeShape == null} means the field
-     *  must be absent (Lucene-as-driver has no delegation instruction). A {@code null}
-     *  {@code chosenBackend} marks an unfilled placeholder cell — the harness will skip
-     *  the stage assertions for that cell, but still validate the row oracle. */
-    private record ChosenBackendandTreeShape(String chosenBackend, String treeShape) {
-        static ChosenBackendandTreeShape placeholder() { return new ChosenBackendandTreeShape(null, null); }
-        boolean isPlaceholder() { return chosenBackend == null; }
-    }
+     *  must be absent (Lucene-as-driver, or no delegation instruction). */
+    private record ChosenBackendandTreeShape(String chosenBackend, String treeShape) {}
 
     private void runShape(Shape shape) throws Exception {
         int queryNumber = shape.queryNumber;
         String ppl = DatasetProvisioner.loadResource(DATASET.queryResourcePath("ppl", "ppl", queryNumber)).trim();
         ppl = ppl.replace(DATASET.name, DATASET.indexName);
 
-        for (Map.Entry<SettingCombination, ChosenBackendandTreeShape> entry : shape.cells.entrySet()) {
-            SettingCombination key = entry.getKey();
+        for (Map.Entry<Boolean, ChosenBackendandTreeShape> entry : shape.cells.entrySet()) {
+            boolean prefer = entry.getKey();
             ChosenBackendandTreeShape expected = entry.getValue();
-            setPreferMetadataDriver(key.prefer());
-            setFuseDualViable(key.fuse());
+            setPreferMetadataDriver(prefer);
 
-            String label = shape + " prefer=" + key.prefer() + ",fuse=" + key.fuse();
+            String label = shape + " prefer=" + prefer;
 
             // Profile=false path — guards against any profile-only-induced behavior change masking a regression.
             Map<String, Object> bareResponse = executePpl(ppl, false);
@@ -318,11 +235,9 @@ public class FilterDelegationGoldenIT extends AnalyticsRestTestCase {
                 fail(label + " (profile=true) — " + validationError);
             }
 
-            if (expected.isPlaceholder() == false) {
-                Map<String, Object> stage = shardFragmentStage(response);
-                assertEquals(label + " — chosen_backend", expected.chosenBackend(), stage.get("chosen_backend"));
-                assertEquals(label + " — tree_shape", expected.treeShape(), stage.get("tree_shape"));
-            }
+            Map<String, Object> stage = shardFragmentStage(response);
+            assertEquals(label + " — chosen_backend", expected.chosenBackend(), stage.get("chosen_backend"));
+            assertEquals(label + " — tree_shape", expected.treeShape(), stage.get("tree_shape"));
         }
     }
 
@@ -356,12 +271,6 @@ public class FilterDelegationGoldenIT extends AnalyticsRestTestCase {
             if ("SHARD_FRAGMENT".equals(stage.get("execution_type"))) return stage;
         }
         throw new AssertionError("No SHARD_FRAGMENT stage in profile: " + stages);
-    }
-
-    private void setFuseDualViable(boolean value) throws Exception {
-        Request req = new Request("PUT", "/_cluster/settings");
-        req.setJsonEntity("{\"persistent\":{\"analytics.delegation.fuse_dual_viable\": " + value + "}}");
-        client().performRequest(req);
     }
 
     private void setPreferMetadataDriver(boolean value) throws Exception {

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/FilterDelegationIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/FilterDelegationIT.java
@@ -295,69 +295,60 @@ public class FilterDelegationIT extends AnalyticsRestTestCase {
     /**
      * OR(MATCH on text, EQUALS on keyword), oracle = 10. Both arms are Lucene-delegatable.
      * Under {@code prefer=true} Lucene drives end-to-end (combiner skipped, no tree_shape).
-     * Under {@code prefer=false} the combiner runs: {@code fuse=false} keeps
-     * {@code OR(delegated_predicate, delegation_possible)} as INTERLEAVED; {@code fuse=true}
-     * collapses to a single {@code delegated_predicate} as CONJUNCTIVE.
+     * Under {@code prefer=false} the combiner runs: the dual-viable EQUALS can't stay
+     * performance-delegated under OR, and it has a correctness sibling (the MATCH), so both
+     * collapse into a single {@code delegated_predicate} — CONJUNCTIVE.
      */
-    public void testOrCorrectnessAndPerf_fuseDualViable() throws Exception {
+    public void testOrCorrectnessAndPerf() throws Exception {
         createIndex();
         indexDocs();
 
         String ppl = "source = " + INDEX_NAME + " | where match(message, 'hello') or tag = 'hello' | stats count() as cnt";
-        Map<MatrixKey, ShardStage> expected = Map.of(
-            new MatrixKey(true, false), new ShardStage("lucene", null),
-            new MatrixKey(true, true), new ShardStage("lucene", null),
-            new MatrixKey(false, false), new ShardStage("datafusion", "INTERLEAVED_BOOLEAN_EXPRESSION"),
-            new MatrixKey(false, true), new ShardStage("datafusion", "CONJUNCTIVE")
-        );
-        runFuseMatrix(ppl, 10L, expected);
+        try {
+            // prefer=true: Lucene drives end-to-end, no delegation instruction (no tree_shape).
+            assertShardStage(ppl, 10L, /* prefer */ true, "lucene", null);
+            // prefer=false: combiner runs — the dual-viable EQUALS can't stay performance-delegated
+            // under OR, and it has a correctness sibling (the MATCH), so both collapse into a single
+            // delegated_predicate — CONJUNCTIVE.
+            assertShardStage(ppl, 10L, /* prefer */ false, "datafusion", "CONJUNCTIVE");
+        } finally {
+            setPreferMetadataDriver(true);
+        }
     }
 
     /**
-     * OR(EQUALS on keyword, EQUALS on integer), oracle = 20. The integer arm isn't
-     * Lucene-filterable, so the planner picks DataFusion in every cell, and the OR has a
-     * non-delegatable sibling which keeps the shape INTERLEAVED in both fuse modes.
+     * OR(EQUALS on keyword, EQUALS on integer), oracle = 20. The keyword EQUALS is dual-viable and,
+     * under the OR, is reclassified to correctness and shipped to Lucene; the integer EQUALS isn't
+     * Lucene-filterable and stays native. The two interleave under the OR → INTERLEAVED.
      */
-    public void testOrTwoPerf_fuseDualViable() throws Exception {
+    public void testOrTwoPerf() throws Exception {
         createIndex();
         indexDocs();
 
         String ppl = "source = " + INDEX_NAME + " | where tag = 'hello' or value = 3 | stats count() as cnt";
-        ShardStage interleavedDf = new ShardStage("datafusion", "INTERLEAVED_BOOLEAN_EXPRESSION");
-        Map<MatrixKey, ShardStage> expected = Map.of(
-            new MatrixKey(true, false), interleavedDf,
-            new MatrixKey(true, true), interleavedDf,
-            new MatrixKey(false, false), interleavedDf,
-            new MatrixKey(false, true), interleavedDf
-        );
-        runFuseMatrix(ppl, 20L, expected);
-    }
-
-    /** Cluster-setting combination: ({@code prefer_metadata_driver}, {@code fuse_dual_viable}). */
-    private record MatrixKey(boolean prefer, boolean fuse) {}
-
-    /** Asserted SHARD_FRAGMENT profile fields. {@code treeShape == null} means the field
-     *  must be absent (Lucene-as-driver has no delegation instruction). */
-    private record ShardStage(String chosenBackend, String treeShape) {}
-
-    private void runFuseMatrix(String ppl, long oracle, Map<MatrixKey, ShardStage> expected) throws Exception {
         try {
-            for (Map.Entry<MatrixKey, ShardStage> entry : expected.entrySet()) {
-                MatrixKey key = entry.getKey();
-                ShardStage want = entry.getValue();
-                setPreferMetadataDriver(key.prefer());
-                setFuseDualViable(key.fuse());
-
-                String label = "prefer=" + key.prefer() + ",fuse=" + key.fuse();
-                assertEquals(label + " — count", oracle, executeCount(ppl));
-                Map<String, Object> stage = shardFragmentStage(ppl);
-                assertEquals(label + " — chosen_backend", want.chosenBackend(), stage.get("chosen_backend"));
-                assertEquals(label + " — tree_shape", want.treeShape(), stage.get("tree_shape"));
-            }
+            // tag (keyword, dual) ships to Lucene under the OR; value (int, native) stays in
+            // DataFusion → the two interleave under the OR. Same shape both prefer modes.
+            assertShardStage(ppl, 20L, /* prefer */ true, "datafusion", "INTERLEAVED_BOOLEAN_EXPRESSION");
+            assertShardStage(ppl, 20L, /* prefer */ false, "datafusion", "INTERLEAVED_BOOLEAN_EXPRESSION");
         } finally {
-            setFuseDualViable(false);
             setPreferMetadataDriver(true);
         }
+    }
+
+    /**
+     * Sets {@code prefer_metadata_driver}, then asserts the count oracle and the SHARD_FRAGMENT
+     * profile's {@code chosen_backend} / {@code tree_shape}. A {@code null} {@code treeShape} means
+     * the field must be absent (Lucene-as-driver, or no delegation instruction).
+     */
+    private void assertShardStage(String ppl, long oracle, boolean prefer, String chosenBackend, String treeShape)
+        throws Exception {
+        setPreferMetadataDriver(prefer);
+        String label = "prefer=" + prefer;
+        assertEquals(label + " — count", oracle, executeCount(ppl));
+        Map<String, Object> stage = shardFragmentStage(ppl);
+        assertEquals(label + " — chosen_backend", chosenBackend, stage.get("chosen_backend"));
+        assertEquals(label + " — tree_shape", treeShape, stage.get("tree_shape"));
     }
 
     private long executeCount(String ppl) throws Exception {
@@ -379,12 +370,6 @@ public class FilterDelegationIT extends AnalyticsRestTestCase {
             if ("SHARD_FRAGMENT".equals(stage.get("execution_type"))) return stage;
         }
         throw new AssertionError("No SHARD_FRAGMENT stage in profile: " + stages);
-    }
-
-    private void setFuseDualViable(boolean value) throws Exception {
-        Request req = new Request("PUT", "/_cluster/settings");
-        req.setJsonEntity("{\"persistent\":{\"analytics.delegation.fuse_dual_viable\": " + value + "}}");
-        client().performRequest(req);
     }
 
     private void setPreferMetadataDriver(boolean value) throws Exception {

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/QueryCacheIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/QueryCacheIT.java
@@ -190,9 +190,9 @@ public class QueryCacheIT extends AnalyticsRestTestCase {
         Request settings = new Request("PUT", "/_cluster/settings");
         // Force prefer_metadata_driver=false so the predicate goes through DataFusion's
         // FilterDelegationHandle / Lucene Collector path — which is what populates the
-        // query cache. Under prefer=true (default since DELEGATION_FUSE_DUAL_VIABLE flip),
-        // single-MATCH count fragments take the Lucene-as-driver shortcut via
-        // IndexSearcher.count, bypassing the cache-tracking collector entirely.
+        // query cache. Under prefer=true (the default), single-MATCH count fragments take the
+        // Lucene-as-driver shortcut via IndexSearcher.count, bypassing the cache-tracking
+        // collector entirely.
         settings.setJsonEntity("{"
             + "\"transient\": {"
             + "  \"indices.queries.cache.min_frequency\": " + minFrequency + ","


### PR DESCRIPTION
## Problem

A *dual-viable* predicate — one both DataFusion and Lucene can evaluate, e.g. `keyword = 'x'` — sitting
under an `AND` was being demoted: shipped **wholesale to Lucene** as a correctness `delegated_predicate`,
with DataFusion doing no evaluation, even though it owns the operator and could prune the predicate
natively against its own columnar data.

`keyword='a' AND keyword='b'` on the current default (`analytics.delegation.fuse_dual_viable=true`)
produces `Filter: delegated_predicate(...)` — no `delegation_possible`, no DataFusion-side pruning. The
setting forces this wholesale-to-Lucene behavior for every dual-viable leaf under AND.

## Fix

Remove the `analytics.delegation.fuse_dual_viable` setting. Delegation is now decided purely by tree
position:

- **Dual leaf under AND → performance-delegated** (`delegation_possible`). DataFusion prunes it natively
  against its columnar data first, and consults Lucene per row-group only when its own pruning isn't
  selective enough. This is the demotion undone.
- **Dual leaf under OR/NOT → correctness-delegated to Lucene** (unchanged behavior vs the shipping
  default). Performance delegation cannot compose under disjunction in the data node yet, so a dual leaf
  anywhere under an OR/NOT is reclassified to correctness and shipped to Lucene (fused with same-backend
  correctness siblings into one BoolQuery); a delegated shipment beside a native arm stays INTERLEAVED.

The OR/NOT carve-back is depth-aware: it applies to a dual leaf anywhere under an OR/NOT, including one
nested inside an AND, not just a direct child. The filter tree-shape deriver is updated to match what
the combiner emits, so the data node's classification and the markers always agree.

Note this does **not** eliminate the data node's `demote_delegation_possible` path, which remains
load-bearing: a legitimate AND-side performance marker can still reach the data node when an OR survives
elsewhere in the same tree (e.g. `a AND (dual OR native)`, where the native arm keeps the OR from
collapsing to Lucene). The surviving OR makes the data node Tree-classify the whole tree, and the
demote handles that AND-side marker. The coordinator carve-back narrows what reaches the data node; it
does not make the demote redundant.

**Scope:** only the AND-with-dual case changes execution behavior. OR/NOT produces the same plan shape
and the same results as the shipping default.

## Correctness

All 38 filter-delegation golden-suite row counts are identical to the expected oracles. Verified live
against both the shipping default (`fuse=true`) and the prior `fuse=false` path — every shape, including
all OR/NOT shapes, returns the correct counts in both. This change is result-neutral: a dual leaf under
AND is now evaluated via `delegation_possible` (DataFusion prunes natively, consults Lucene only if
needed) instead of `delegated_predicate` (Lucene wholesale), but the rows returned are unchanged.

## Changes by file

- `DelegatedPredicateCombiner.java` — a dual-viable leaf is always classified performance; the structural
  OR/NOT rule (reclassify-to-correctness vs unwrap-to-native) replaces the flag-gated carve-back.
- `FilterTreeShapeDeriver.java` — shape prediction rewritten to mirror the combiner's post-combine shape;
  perf under OR/NOT no longer counts as delegated unless it fuses with a correctness sibling.
- `FragmentConversionDriver.java`, `DefaultPlanExecutor.java`, `AnalyticsPlugin.java` — remove the
  `fuse_dual_viable` setting and all of its plumbing.
- `bool_tree.rs` — comments only. Documents `demote_delegation_possible` as a load-bearing capability
  fallback: a legit AND-side performance marker can still reach the Tree evaluator when an OR survives
  elsewhere in the tree, and the demote handles it (until OR/NOT performance delegation is implemented).

## Tests

- New combiner test pins dual-AND-dual as performance-delegated.
- Deriver tests: `OR(correctness, perf)` → CONJUNCTIVE; lone `NOT(perf)` → NO_DELEGATION.
- Combiner/deriver tests pin the depth-aware OR/NOT carve-back (dual nested in an AND under an OR is
  still carved back to correctness, never emitted as a performance marker).
- Flag-specific tests rewritten to the single no-setting expectation; golden IT collapsed from 4-cell to
  2-cell now that the setting is gone.

## Diff size

16 files, +394 / −649 (net −255). Production code is nearly net-neutral; the bulk of the diff is test
cleanup from removing the setting.

| | insertions | deletions | net |
|---|---|---|---|
| src — code | +66 | −69 | −3 |
| src — comment | +53 | −66 | −13 |
| test — code | +182 | −376 | −194 |
| test — comment | +93 | −138 | −45 |

The fix itself is small: it removes the setting and replaces flag-gated branching with structural rules.
The large test delta is the golden IT collapsing from 4-cell to 2-cell and the flag-permutation tests
going away now that there's no flag.

## Follow-ups (not in this PR)

- Implement OR/NOT performance delegation in the data node, so dual predicates under disjunction can also
  get the opportunistic Lucene consult instead of native-only.