### PR TITLE
Reorder DynamicLimitPool::try_grow and split RSS-pressure error type

### DIFF
--- a/sandbox/libs/dataformat-native/rust/lib/src/lib.rs
+++ b/sandbox/libs/dataformat-native/rust/lib/src/lib.rs
@@ -35,8 +35,10 @@
 /// zero CPU overhead and negligible memory overhead. Profiling is activated on-demand
 /// via cluster settings at runtime. Dev/test builds (cargo build without --release)
 /// do not include profiling support.
+// Decay set to 1s so jemalloc resident reflects current usage within ~1s of free().
+// Runtime-tunable via cluster settings `native.jemalloc.{dirty,muzzy}_decay_ms`.
 #[export_name = "malloc_conf"]
-pub static MALLOC_CONF: &[u8] = b"dirty_decay_ms:30000,muzzy_decay_ms:30000,lg_tcache_max:16\0";
+pub static MALLOC_CONF: &[u8] = b"dirty_decay_ms:1000,muzzy_decay_ms:1000,lg_tcache_max:16\0";
 
 #[global_allocator]
 static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;

--- a/sandbox/modules/native-bridge/src/main/java/org/opensearch/nativebridge/NativeBridgeModule.java
+++ b/sandbox/modules/native-bridge/src/main/java/org/opensearch/nativebridge/NativeBridgeModule.java
@@ -49,7 +49,7 @@ public class NativeBridgeModule extends Plugin {
     /** jemalloc dirty page decay time (ms). Dynamically tunable — applied to all arenas at runtime. */
     public static final Setting<Long> JEMALLOC_DIRTY_DECAY_MS = Setting.longSetting(
         "native.jemalloc.dirty_decay_ms",
-        30_000L,
+        1_000L,
         -1L,
         Setting.Property.NodeScope,
         Setting.Property.Dynamic
@@ -58,7 +58,7 @@ public class NativeBridgeModule extends Plugin {
     /** jemalloc muzzy page decay time (ms). Dynamically tunable — applied to all arenas at runtime. */
     public static final Setting<Long> JEMALLOC_MUZZY_DECAY_MS = Setting.longSetting(
         "native.jemalloc.muzzy_decay_ms",
-        30_000L,
+        1_000L,
         -1L,
         Setting.Property.NodeScope,
         Setting.Property.Dynamic

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/memory.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/memory.rs
@@ -112,61 +112,10 @@ impl MemoryPool for DynamicLimitPool {
         reservation: &MemoryReservation,
         additional: usize,
     ) -> Result<(), DataFusionError> {
-        // Two-tier RSS guard for in-flight queries:
-        //
-        // - operator (85%): reject to trigger spill. The operator will flush its hash
-        //   table to disk and retry. This is recoverable — the query continues.
-        // - critical (95%): hard reject to prevent OOM. Last resort — even spill can't
-        //   save the node at this pressure level.
-        //
-        // Between 85-95%, the override (below) ensures spill sort buffers can still
-        // allocate: when the CAS fails and RSS has dropped below operator threshold
-        // (because the hash table was freed during spill), the override fires and
-        // allows the sort allocation through.
-        //
-        // The adaptive cache (cached_resident_bytes) bypasses the 100ms cache when
-        // the last value was above operator threshold — so the override sees the
-        // fresh (lower) RSS after spill frees memory, not a stale peak.
-        let limit = self.dynamic_limit.load(Ordering::Acquire);
-        let resident = crate::memory_guard::cached_resident_bytes();
-        if resident > 0 && limit >= 16 * 1024 * 1024 {
-            let thresholds = crate::memory_guard::get_thresholds();
-            let critical_bytes = (limit as f64 * thresholds.execution_critical) as usize;
-            let spill_bytes = (limit as f64 * thresholds.execution_spill) as usize;
-            let resident_usize = resident as usize;
-
-            // Critical (95%): hard reject — OOM imminent, protect the node.
-            if resident_usize > critical_bytes {
-                self.tripped_count.fetch_add(1, Ordering::Relaxed);
-                let used = self.used.load(Ordering::Relaxed);
-                return Err(crate::native_error::pool_limit_error(
-                    additional,
-                    reservation.consumer().name(),
-                    reservation.size(),
-                    0,
-                    limit,
-                ));
-            }
-
-            // Operator (85%): soft reject — triggers spill. The operator will
-            // flush to disk, free memory, then retry. Spill sort buffers will
-            // succeed on retry because RSS drops and the override allows them.
-            if resident_usize > spill_bytes {
-                self.tripped_count.fetch_add(1, Ordering::Relaxed);
-                let used = self.used.load(Ordering::Relaxed);
-                return Err(crate::native_error::pool_limit_error(
-                    additional,
-                    reservation.consumer().name(),
-                    reservation.size(),
-                    0,
-                    limit,
-                ));
-            }
-        }
-
+        // Decision order: CAS → override (stale fill) → RSS-critical → pool-fill.
         let dynamic_limit = &self.dynamic_limit;
 
-        // Fast path: try the normal CAS against the pool limit.
+        // 1. Try the pool-limit CAS. Succeeds when accounting has room.
         let cas_result = self.used
             .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |used| {
                 let limit = dynamic_limit.load(Ordering::Acquire);
@@ -178,20 +127,13 @@ impl MemoryPool for DynamicLimitPool {
             return Ok(());
         }
 
-        // Pool accounting says "full". Before failing the operator (which
-        // triggers spill), consult jemalloc as ground truth. If actual process
-        // memory is below the override threshold, the pool's "full" state is
-        // from stale phantoms or accounting drift — allow the grow.
-        //
-        // This gives already-executing operators a higher effective limit,
-        // preventing unnecessary spills when phantoms from finished queries
-        // haven't been released yet.
         let limit = dynamic_limit.load(Ordering::Acquire);
         let used = self.used.load(Ordering::Relaxed);
-        // Only attempt override if the allocation is plausible (won't overflow).
+
+        // 2. Pool says full. Forgive if jemalloc reports physical headroom
+        //    (pool view stale from accounting drift).
         if used.checked_add(additional).is_some() {
             if crate::memory_guard::should_override(limit, crate::memory_guard::OverrideContext::Execution) {
-                // jemalloc confirms headroom — allow the grow
                 let _ = self.used.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |u| {
                     u.checked_add(additional)
                 });
@@ -199,24 +141,29 @@ impl MemoryPool for DynamicLimitPool {
             }
         }
 
-        // Both pool and jemalloc confirm pressure. Check if RSS is critical —
-        // if so, cancel the query rather than spilling (spill can't help at 95%+).
+        // 3. RSS-critical ceiling: physical memory is genuinely pressured.
+        //    Cancel the allocation rather than spilling — recovery isn't possible.
         if crate::memory_guard::should_cancel_query(limit) {
+            self.tripped_count.fetch_add(1, Ordering::Relaxed);
+            let resident = crate::memory_guard::cached_resident_bytes();
             native_bridge_common::log_info!(
-                "Memory CANCEL: RSS exceeds critical threshold for consumer [{}]. Cancelling query to protect node.",
+                "Memory RSS-CRITICAL: RSS={}B exceeds critical threshold for consumer [{}]. Cancelling allocation to protect node.",
+                resident,
                 reservation.consumer().name()
             );
-            return Err(DataFusionError::ResourcesExhausted(format!(
-                "Query cancelled: native memory RSS exceeds critical threshold ({}% of pool limit {}B). \
-                 Reduce query concurrency or increase datafusion.memory_pool_limit_bytes.",
-                (crate::memory_guard::get_thresholds().execution_critical * 100.0) as u32,
-                limit
-            )));
+            return Err(crate::native_error::rss_critical_error(
+                additional,
+                reservation.consumer().name(),
+                reservation.size(),
+                limit,
+                used,
+                resident,
+            ));
         }
 
-        // RSS between operator (85%) and critical (95%) — reject (operator will spill)
+        // 4. Pool legitimately full but RSS is fine — return pool-fill error
+        //    so DataFusion's spill-capable operators can flush state to disk.
         self.tripped_count.fetch_add(1, Ordering::Relaxed);
-        let used = self.used.load(Ordering::Relaxed);
         Err(crate::native_error::pool_limit_error(
             additional,
             reservation.consumer().name(),
@@ -463,59 +410,95 @@ mod tests {
     }
 
     #[test]
-    fn test_hard_guard_rejects_when_rss_exceeds_critical() {
-        // Create a pool with a limit smaller than the current process RSS.
-        // A Rust test process typically uses 50-200MB RSS, so 20MB should
-        // always trigger the hard guard (RSS > 95% of 20MB = 19MB).
+    fn test_rss_critical_rejects_after_cas_fail_when_rss_exceeds_critical() {
+        // 20MB pool (above MIN_POOL_FOR_OVERRIDE), pre-filled so the next
+        // try_grow CAS-fails. Test process RSS typically 50-200MB, so
+        // RSS > 95% of 20MB and the rejection arrives via rss_critical_error.
         let (pool, handle) = new_pool(20 * 1024 * 1024); // 20MB
 
         let resident = crate::memory_guard::cached_resident_bytes();
         if resident <= 0 {
             return; // jemalloc not available in this test env
         }
-
         let critical_bytes = (20.0 * 1024.0 * 1024.0 * 0.95) as i64;
         if resident < critical_bytes {
             return; // RSS unexpectedly low — skip rather than false-fail
         }
 
-        let consumer = MemoryConsumer::new("hard_guard_test");
+        // Fill the pool so the CAS for the test allocation must fail.
+        let filler = MemoryConsumer::new("filler");
+        let mut filler_res = filler.register(&pool);
+        assert!(filler_res.try_grow(20 * 1024 * 1024).is_ok());
+
+        let consumer = MemoryConsumer::new("rss_critical_test");
         let mut reservation = consumer.register(&pool);
 
-        // The hard guard fires before the CAS — even a tiny grow should be rejected
         let result = reservation.try_grow(1024);
         assert!(
             result.is_err(),
-            "try_grow should fail when RSS ({}) exceeds critical threshold (95% of 20MB)",
+            "try_grow should fail when CAS fails and RSS ({}) exceeds critical (95% of 20MB)",
             resident
         );
+        if let Err(DataFusionError::ResourcesExhausted(msg)) = result {
+            assert!(
+                msg.contains("Native RSS pressure"),
+                "expected RSS-critical error, got: {}",
+                msg
+            );
+        }
         assert!(
             handle.tripped_count() >= 1,
-            "tripped_count should increment on hard guard rejection"
+            "tripped_count should increment on RSS-critical rejection"
         );
     }
 
     #[test]
-    fn test_hard_guard_passes_when_rss_below_critical() {
-        // Create a pool with a huge limit (1TB). The test process RSS is well
-        // below 95% of 1TB, so the hard guard should NOT fire.
+    fn test_rss_critical_passes_when_rss_below_critical() {
+        // 1TB pool; test process RSS is far below 95% of 1TB so a small
+        // allocation succeeds via CAS without engaging the RSS-critical path.
         let limit = 1024 * 1024 * 1024 * 1024_usize; // 1TB
         let (pool, handle) = new_pool(limit);
 
         let consumer = MemoryConsumer::new("large_pool_test");
         let mut reservation = consumer.register(&pool);
 
-        // A small allocation should succeed — RSS is far below 95% of 1TB
         let result = reservation.try_grow(4096);
         assert!(
             result.is_ok(),
-            "try_grow should succeed when RSS is well below 95% of 1TB pool limit"
+            "try_grow should succeed via CAS on a 1TB pool"
         );
         assert_eq!(
             handle.tripped_count(),
             0,
-            "tripped_count should remain 0 when hard guard does not fire"
+            "tripped_count should remain 0 when CAS succeeds"
         );
         assert_eq!(pool.reserved(), 4096);
+    }
+
+    #[test]
+    fn test_pool_fill_rejection_emits_pool_limit_error_not_rss_error() {
+        // 1KB pool — below MIN_POOL_FOR_OVERRIDE so override and RSS-critical
+        // skip. Asserts pool-fill rejections use pool_limit_error, not the
+        // RSS variant — locks the error-message contract for the Java parser.
+        let (pool, _handle) = new_pool(1024);
+        let consumer = MemoryConsumer::new("pool_fill_test");
+        let mut reservation = consumer.register(&pool);
+
+        let result = reservation.try_grow(2048);
+        assert!(result.is_err(), "exceeds pool limit, should fail");
+        if let Err(DataFusionError::ResourcesExhausted(msg)) = result {
+            assert!(
+                msg.contains("Failed to allocate"),
+                "expected pool_limit_error, got: {}",
+                msg
+            );
+            assert!(
+                msg.contains("Native RSS pressure") == false,
+                "pool-fill rejection must NOT use rss_critical_error: {}",
+                msg
+            );
+        } else {
+            panic!("expected ResourcesExhausted variant");
+        }
     }
 }

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/native_error.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/native_error.rs
@@ -49,6 +49,29 @@ pub fn pool_limit_error(
     ))
 }
 
+/// Allocation rejected because jemalloc resident bytes exceed the critical
+/// threshold of the pool. Distinct from `pool_limit_error` so callers can
+/// distinguish RSS-pressure rejections from pool-fill rejections.
+///
+/// Java conversion: `CircuitBreakingException` → HTTP 429
+/// Key phrase: "Native RSS pressure"
+pub fn rss_critical_error(
+    bytes_requested: usize,
+    consumer_name: &str,
+    consumer_reserved: usize,
+    pool_limit: usize,
+    pool_used: usize,
+    rss_bytes: i64,
+) -> DataFusionError {
+    DataFusionError::ResourcesExhausted(format!(
+        "Native RSS pressure: failed to allocate {} bytes for {} ({} already reserved). \
+         Native resident bytes {} exceed critical threshold of pool ({} used / {} limit). \
+         Cause: native memory pressure, not pool fill.",
+        bytes_requested, consumer_name, consumer_reserved,
+        rss_bytes, pool_used, pool_limit,
+    ))
+}
+
 /// Admission rejection: not enough pool capacity to start a new query.
 ///
 /// Produced when `acquire_budget` cannot reserve the phantom even at minimum

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/NativeErrorConverter.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/NativeErrorConverter.java
@@ -55,6 +55,7 @@ public final class NativeErrorConverter {
      */
     private static final List<ErrorPattern> PATTERNS = List.of(
         new ErrorPattern("Cannot reserve untracked memory budget", NativeErrorConverter::convertAdmissionRejection),
+        new ErrorPattern("Native RSS pressure", NativeErrorConverter::convertRssCritical),
         new ErrorPattern("Failed to allocate", NativeErrorConverter::convertPoolLimitExceeded)
     );
 
@@ -109,6 +110,24 @@ public final class NativeErrorConverter {
         return rejection;
     }
 
+    /**
+     * Converts an RSS-critical native error into a {@link CircuitBreakingException}
+     * (HTTP 429). Best-effort byte parsing — falls back to {@code limit=0/used=0}
+     * when the format regex doesn't match, since the key phrase has already
+     * classified the event.
+     */
+    private static Exception convertRssCritical(MatchedError match) {
+        long[] parsed = parseRssCriticalBytes(match.message());
+        long bytesRequested = parsed != null ? parsed[0] : 0L;
+        long limit = parsed != null ? parsed[1] : 0L;
+        String message = match.message().contains("[analytics_backend_datafusion]")
+            ? match.message()
+            : "[analytics_backend_datafusion] " + match.message();
+        CircuitBreakingException cbe = new CircuitBreakingException(message, bytesRequested, limit, CircuitBreaker.Durability.TRANSIENT);
+        cbe.initCause(match.original());
+        return cbe;
+    }
+
     // ─── Message parsing ────────────────────────────────────────────────────────
 
     /**
@@ -125,6 +144,29 @@ public final class NativeErrorConverter {
      */
     private static long[] parsePoolLimitBytes(String msg) {
         Matcher m = POOL_LIMIT_PATTERN.matcher(msg);
+        if (m.find() == false) {
+            return null;
+        }
+        try {
+            long bytesRequested = Long.parseLong(m.group(1));
+            long limit = Long.parseLong(m.group(2));
+            return new long[] { bytesRequested, limit };
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Matches the RSS-critical error format from native_error.rs:
+     * "Native RSS pressure: failed to allocate {N} bytes for {consumer} ({reserved} already reserved). Native resident bytes {rss} exceed critical threshold of pool ({used} used / {limit} limit). Cause: native memory pressure, not pool fill."
+     */
+    private static final Pattern RSS_CRITICAL_PATTERN = Pattern.compile(
+        "Native RSS pressure: failed to allocate (\\d+) bytes for .+ \\(\\d+ already reserved\\)\\. "
+            + "Native resident bytes -?\\d+ exceed critical threshold of pool \\(\\d+ used / (\\d+) limit\\)"
+    );
+
+    private static long[] parseRssCriticalBytes(String msg) {
+        Matcher m = RSS_CRITICAL_PATTERN.matcher(msg);
         if (m.find() == false) {
             return null;
         }


### PR DESCRIPTION
## What

Reorders `DynamicLimitPool::try_grow` and splits RSS-pressure errors out from pool-fill errors. Also lowers the default jemalloc decay from 30s to 1s.

## Why

`try_grow` is the allocation hot path for the DataFusion `MemoryPool`. It used to check jemalloc-resident bytes against `pool × 85%` **before** the pool-limit CAS — and reject when over the threshold. The intent was "trigger spill," but the spill path itself calls `try_grow` for its sort buffer, hits the same gate, and fails.

[Testing] On warm tier the cdylib's idle resident is ~130 MB, so any pool below ~155 MB had the gate trip on every allocation; under sustained concurrent load it triggered on production-default sizes too. Net effect: spill-capable operators (HashAggregate, Sort, TopK) couldn't recover when working set pushed RSS past the threshold.

## Fix

`try_grow` now resolves in this order:

1. **Pool CAS** — succeeds when accounting has room.
2. **Override on stale fill** — CAS-fail + jemalloc shows headroom → allow (handles accounting drift).
3. **RSS-critical** — CAS-fail + jemalloc above critical → cancel via new `rss_critical_error`.
4. **Pool-fill** — otherwise return `pool_limit_error`, which DataFusion converts into `operator.spill()`.

The pre-CAS RSS gate is removed; `execution_spill_threshold` now gates the override path only.

### Error split

Three rejection paths previously emitted the same `"Failed to allocate ... 0 available out of N limit"` message with `available=0` hard-coded for the RSS paths. Now:

- **Pool fill** → `pool_limit_error` with real `available = limit - used`. Java parser unchanged.
- **RSS critical** → new `rss_critical_error` carrying real `pool_used` / `pool_limit` / `rss_bytes`. `NativeErrorConverter` registers the new key phrase and converts to `CircuitBreakingException` (HTTP 429) — same retry surface, distinct message for triage.

### Decay

`MALLOC_CONF` decay reduced from `30000` to `1000` for both `dirty` and `muzzy`, with matching cluster-setting defaults. RSS now reflects current usage within ~1s instead of carrying a 60s lookback. `native.jemalloc.{dirty,muzzy}_decay_ms` remain runtime-tunable, so operators can revert without redeploy if a workload regresses.

## Behaviour changes

| Scenario | Before | After |
|---|---|---|
| Pool empty, RSS at 85–95% × pool | Reject pre-CAS | Allocate via CAS |
| Pool full, RSS at 85–95% × pool | (unreachable) | CAS fail → pool-fill error → operator spills |
| Pool full, RSS > 95% × pool | (unreachable) | CAS fail → RSS-critical cancel |
| Cancel-path Java conversion | RuntimeException → HTTP 500 | CircuitBreakingException → HTTP 429 |
| `tripped_count` | RSS-spill + RSS-critical + pool-fill | RSS-critical + pool-fill |

`execution.spill_threshold` is now an override gate, not a rejection threshold. `execution.critical_threshold` is now a post-CAS cancel only. Both stay dynamic.

## Test plan

**Unit (Rust):**
- `test_rss_critical_rejects_after_cas_fail_when_rss_exceeds_critical` — pre-fills pool, asserts rejection comes via `rss_critical_error`.
- `test_rss_critical_passes_when_rss_below_critical` — large pool, allocation succeeds via CAS.
- `test_pool_fill_rejection_emits_pool_limit_error_not_rss_error` — locks the error-message contract for the Java parser.

**Cluster (3 warm nodes, 1M docs / 200k unique groups, `count avg max min sum by host`):**

| Pool | Concurrency | Result | Spill captured |
|---|---|---|---|
| 256 MB | 1 | 200, 2.1s | 0 (working set fits) |
| 15 MB | 8 | 4×200 + 4×429 | 74 files / 180 MB |
| 128 MB | 8 | 8×200 | 51 files / 230 MB |

Captured spill files verified as real Arrow IPC streams. The 128 MB run is the dispositive case — pre-fix the RSS gate would have fired at 109 MB but cdylib idle is ~130 MB, so every allocation would have been rejected. Post-fix all 8 queries spill and complete.

A no-spill control at pool=1 GB / threshold=0.99 produced 8/8 success, 0 files, `tripped_count` delta 0 — confirming spill engages only when the pool genuinely fills.
