### PR TITLE
Fix ArrowBufferPool's totalAllocatedBytes calculation

### DIFF
--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/memory/ArrowBufferPool.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/memory/ArrowBufferPool.java
@@ -40,7 +40,11 @@ public class ArrowBufferPool implements Closeable {
      *                        {@code ParquetDataFormatPlugin#createComponents}
      */
     public ArrowBufferPool(Settings settings, ArrowNativeAllocator nativeAllocator) {
-        this.poolAllocator = nativeAllocator.getPoolAllocator(NativeAllocatorPoolConfig.POOL_INGEST);
+        BufferAllocator ingestPool = nativeAllocator.getPoolAllocator(NativeAllocatorPoolConfig.POOL_INGEST);
+        // Create a child allocator so that getTotalAllocatedBytes() reports only this instance's
+        // usage rather than the pool-wide total. Long.MAX_VALUE means this child imposes no limit
+        // of its own; the parent pool's dynamic limit is the only enforced constraint.
+        this.poolAllocator = ingestPool.newChildAllocator("ArrowBufferPool", 0, Long.MAX_VALUE);
         logger.debug("ArrowBufferPool: poolLimit={}", poolAllocator.getLimit());
     }
 
@@ -63,8 +67,6 @@ public class ArrowBufferPool implements Closeable {
 
     @Override
     public void close() {
-        // The framework owns the ingest pool's BufferAllocator; nothing to free here.
-        // Child allocators created via createChildAllocator are owned by their callers
-        // (VSRPool / ManagedVSR) and closed when those resources release.
+        poolAllocator.close();
     }
 }

--- a/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/memory/ArrowBufferPoolTests.java
+++ b/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/memory/ArrowBufferPoolTests.java
@@ -85,14 +85,49 @@ public class ArrowBufferPoolTests extends OpenSearchTestCase {
         assertEquals(0, pool.getTotalAllocatedBytes());
     }
 
-    public void testChildAllocatorGetsFullPoolLimit() {
+    /**
+     * Multiple ArrowBufferPool instances backed by the same NativeAllocator must report only
+     * their own memory usage via getTotalAllocatedBytes(), not the pool-wide total.
+     */
+    public void testMultiplePoolInstancesReportOwnUsageNotPoolWideTotal() {
+        ArrowBufferPool pool1 = new ArrowBufferPool(Settings.EMPTY, nativeAllocator);
+        ArrowBufferPool pool2 = new ArrowBufferPool(Settings.EMPTY, nativeAllocator);
+
+        BufferAllocator child1 = pool1.createChildAllocator("pool-1");
+        BufferAllocator child2 = pool2.createChildAllocator("pool-2");
+
+        ArrowBuf buf1 = child1.buffer(1024);
+        ArrowBuf buf2 = child2.buffer(2048);
+
+        long actualTotal = 1024 + 2048;
+
+        // Sum of individual pool reports must equal the actual total.
+        long sum = pool1.getTotalAllocatedBytes() + pool2.getTotalAllocatedBytes();
+        assertEquals("Sum of per-pool bytes must equal actual total", actualTotal, sum);
+
+        buf1.close();
+        buf2.close();
+        child1.close();
+        child2.close();
+        pool1.close();
+        pool2.close();
+    }
+
+    public void testChildAllocatorEnforcedByParentPoolLimit() {
         // Constrain the framework's ingest pool to a finite limit.
-        nativeAllocator.setPoolLimit(NativeAllocatorPoolConfig.POOL_INGEST, 1024L * 1024 * 1024);
+        long poolLimit = 1024L * 1024;
+        nativeAllocator.setPoolLimit(NativeAllocatorPoolConfig.POOL_INGEST, poolLimit);
 
         ArrowBufferPool pool = new ArrowBufferPool(Settings.EMPTY, nativeAllocator);
         BufferAllocator child = pool.createChildAllocator("c-full");
         try {
-            assertEquals(1024L * 1024 * 1024, child.getLimit());
+            // Child can allocate within the parent pool's limit
+            ArrowBuf buf = child.buffer(512 * 1024);
+            assertNotNull(buf);
+            buf.close();
+
+            // Child cannot allocate more than the parent pool's limit
+            expectThrows(org.apache.arrow.memory.OutOfMemoryException.class, () -> child.buffer(poolLimit + 1));
         } finally {
             child.close();
             pool.close();


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Fix ArrowBufferPool's totalAllocatedBytes calculation

### Related Issues
Resolves #22038
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [N/A] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [N/A] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
