### PR TITLE
[Sandbox] Propagate index.sort.field to DataFusion ListingTable

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/api.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/api.rs
@@ -330,6 +330,16 @@ pub struct ShardView {
     /// this routes reads through TieredObjectStore (local + remote).
     /// When no store is provided, uses default LocalFileSystem.
     pub store: Arc<dyn ObjectStore>,
+    /// Index sort fields, in priority order. Sourced from the index's
+    /// `index.sort.field` setting on the Java side. Empty when the index has
+    /// no `index.sort.field` configured. Parallel to `sort_orders`.
+    /// Used to build `ListingOptions.with_file_sort_order(...)` so DataFusion
+    /// advertises `output_ordering` from the scan and enables the
+    /// `sort_prefix` optimization on TopK / SortPreservingMerge.
+    pub sort_fields: Vec<String>,
+    /// Index sort directions per field — values: `"asc"` or `"desc"`.
+    /// Parallel to `sort_fields`. Sourced from `index.sort.order`.
+    pub sort_orders: Vec<String>,
 }
 
 /// Creates a DataFusion global runtime with the given resource limits.
@@ -500,6 +510,8 @@ pub fn create_reader(
     table_path: &str,
     filenames: Vec<String>,
     writer_generations: Vec<i64>,
+    sort_fields: Vec<String>,
+    sort_orders: Vec<String>,
     tokio_rt_manager: &RuntimeManager,
     store_ptr: i64,
 ) -> Result<i64, DataFusionError> {
@@ -508,6 +520,13 @@ pub fn create_reader(
             "create_reader: filenames ({}) and writer_generations ({}) must have the same length",
             filenames.len(),
             writer_generations.len()
+        )));
+    }
+    if sort_fields.len() != sort_orders.len() {
+        return Err(DataFusionError::Execution(format!(
+            "create_reader: sort_fields ({}) and sort_orders ({}) must have the same length",
+            sort_fields.len(),
+            sort_orders.len()
         )));
     }
 
@@ -536,6 +555,8 @@ pub fn create_reader(
         writer_generations: Arc::new(writer_generations),
         file_metadata: None,
         store,
+        sort_fields,
+        sort_orders,
     };
     Ok(Box::into_raw(Box::new(shard_view)) as i64)
 }
@@ -666,6 +687,8 @@ pub async unsafe fn execute_query(
                 context_id,
                 Arc::clone(&shard_view.store),
                 phantom_corrector,
+                &shard_view.sort_fields,
+                &shard_view.sort_orders,
             ).await
         }
     };

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/ffm.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/ffm.rs
@@ -189,6 +189,11 @@ pub unsafe extern "C" fn df_create_reader(
     writer_generations_ptr: *const i64,
     files_count: i64,
     store_ptr: i64,
+    sort_fields_ptr: *const *const u8,
+    sort_fields_len_ptr: *const i64,
+    sort_orders_ptr: *const *const u8,
+    sort_orders_len_ptr: *const i64,
+    sort_count: i64,
 ) -> i64 {
     let table_path = str_from_raw(table_path_ptr, table_path_len)
         .map_err(|e| format!("df_create_reader: {}", e))?;
@@ -204,8 +209,39 @@ pub unsafe extern "C" fn df_create_reader(
         );
         writer_generations.push(*writer_generations_ptr.add(i));
     }
+    // Decode parallel sort_fields / sort_orders String arrays. sort_count == 0 means no
+    // index sort configured; pass an empty Vec. The Java side guarantees
+    // sortFields.size() == sortOrders.size() (IndexSortConfig validates at index creation),
+    // so a single sort_count covers both arrays.
+    let mut sort_fields = Vec::with_capacity(sort_count as usize);
+    let mut sort_orders = Vec::with_capacity(sort_count as usize);
+    for i in 0..sort_count as usize {
+        let f_ptr = *sort_fields_ptr.add(i);
+        let f_len = *sort_fields_len_ptr.add(i);
+        sort_fields.push(
+            str_from_raw(f_ptr, f_len)
+                .map_err(|e| format!("df_create_reader: sort_field[{}]: {}", i, e))?
+                .to_string(),
+        );
+        let o_ptr = *sort_orders_ptr.add(i);
+        let o_len = *sort_orders_len_ptr.add(i);
+        sort_orders.push(
+            str_from_raw(o_ptr, o_len)
+                .map_err(|e| format!("df_create_reader: sort_order[{}]: {}", i, e))?
+                .to_string(),
+        );
+    }
     let mgr = get_rt_manager()?;
-    api::create_reader(table_path, filenames, writer_generations, &mgr, store_ptr).map_err(|e| e.to_string())
+    api::create_reader(
+        table_path,
+        filenames,
+        writer_generations,
+        sort_fields,
+        sort_orders,
+        &mgr,
+        store_ptr,
+    )
+    .map_err(|e| e.to_string())
 }
 
 #[no_mangle]

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/query_executor.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/query_executor.rs
@@ -53,6 +53,8 @@ pub async fn execute_query(
     context_id: i64,
     shard_store: Arc<dyn ObjectStore>,
     phantom_corrector: Option<Arc<crate::phantom_corrector::PhantomCorrector>>,
+    sort_fields: &[String],
+    sort_orders: &[String],
 ) -> Result<i64, DataFusionError> {
     // Build per-query RuntimeEnv with list-files cache pre-populated.
     let runtime_env = build_query_runtime_env(runtime, &table_path, object_metas.as_ref())?;
@@ -135,9 +137,15 @@ pub async fn execute_query(
         _ => {
             // Baseline: use standard ListingTable
             let file_format = ParquetFormat::new();
-            let listing_options = ListingOptions::new(Arc::new(file_format))
+            let mut listing_options = ListingOptions::new(Arc::new(file_format))
                 .with_file_extension(".parquet")
                 .with_collect_stat(true);
+            // Declare per-file sort order to DataFusion if the index has `index.sort.field`.
+            // See `session_context::build_file_sort_order` for what the declaration buys us
+            // and the case/nulls/non-sort caveats.
+            if let Some(sort_exprs) = crate::session_context::build_file_sort_order(sort_fields, sort_orders) {
+                listing_options = listing_options.with_file_sort_order(vec![sort_exprs]);
+            }
             let resolved_schema = listing_options
                 .infer_schema(&ctx.state(), &table_path)
                 .await

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/session_context.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/session_context.rs
@@ -13,6 +13,7 @@
 
 use std::sync::Arc;
 
+use native_bridge_common::log_debug;
 use datafusion::{
     common::DataFusionError,
     datasource::file_format::parquet::ParquetFormat,
@@ -204,6 +205,11 @@ pub async unsafe fn create_session_context(
     config.options_mut().execution.parquet.pushdown_filters = query_config.parquet_pushdown_filters;
     config.options_mut().execution.target_partitions = effective_partitions;
     config.options_mut().execution.batch_size = effective_batch_size;
+    // When the index has `index.sort.field`, ask DataFusion to use the sort-aware
+    // file-group partitioner so `output_ordering` can propagate from the scan.
+    if !shard_view.sort_fields.is_empty() {
+        config.options_mut().execution.split_file_groups_by_statistics = true;
+    }
 
     let mut state_builder = SessionStateBuilder::new()
         .with_config(config)
@@ -237,9 +243,20 @@ pub async unsafe fn create_session_context(
     crate::udwf::register_all(&ctx);
 
     // Register default ListingTable for parquet scans.
-    let listing_options = ListingOptions::new(Arc::new(ParquetFormat::default()))
+    //
+    // `target_partitions` on the listing options drives the sort-aware bin-packer in
+    // `split_groups_by_statistics_with_target_partitions`. We set it to the session's
+    // effective partition count so the bin-packer produces up to N groups (one file per
+    // group when min/max ranges can't chain). The session-state's `target_partitions`
+    // controls EnforceDistribution; this one is independent.
+    let mut listing_options = ListingOptions::new(Arc::new(ParquetFormat::default()))
         .with_file_extension(".parquet")
-        .with_collect_stat(true);
+        .with_collect_stat(true)
+        .with_target_partitions(effective_partitions);
+
+    if let Some(sort_exprs) = build_file_sort_order(&shard_view.sort_fields, &shard_view.sort_orders) {
+        listing_options = listing_options.with_file_sort_order(vec![sort_exprs]);
+    }
 
     // For multi-index queries, the plan's NamedTable carries the logical name (alias/pattern)
     // which differs from table_name (the concrete shard index). Extract it from the plan and
@@ -314,6 +331,11 @@ pub async unsafe fn create_session_context(
         );
         e
     })?;
+    log_debug!(
+        "create_session_context: registered table '{}' with file_sort_order_keys={}",
+        register_name,
+        shard_view.sort_fields.len()
+    );
 
     error!(
         "create_session_context: successfully registered table '{}', table_name_len={}",
@@ -445,6 +467,55 @@ fn try_acquire_budget(
         config.target_partitions,
         config.batch_size,
     ).ok()
+}
+
+/// Build a per-file sort-order declaration for `ListingOptions::with_file_sort_order`.
+///
+/// This is metadata, not a sort: it tells DataFusion the parquet files are already
+/// in this order so `output_ordering` propagates through the scan,
+/// `SortPreservingMergeExec` replaces `SortExec`, and `sort_prefix` TopK fires.
+/// The OpenSearch writer enforces this sort per segment, so the claim is
+/// verifiable-by-construction (DataFusion also checks per-file min/max stats).
+///
+/// Returns `None` when the index has no `index.sort.field` configured (the input
+/// `sort_fields` slice is empty), so the caller can skip
+/// `with_file_sort_order(...)` entirely.
+///
+/// Caller contract: `sort_fields.len() == sort_orders.len()`. The Java side
+/// (`DataFusionPlugin.createReaderManager`) guarantees this — `IndexSortConfig`
+/// validates size match at index creation, so by the time we get here the
+/// lengths agree.
+///
+/// Notes for readers:
+/// - `.sort(asc, nulls_first)` constructs a `SortExpr` — it does NOT execute a
+///   sort. Misleading name; it's a tuple builder.
+/// - `Column::from_name` (vs `col(&str)`): `col` lowercases via SQL identifier
+///   normalization (`col("EventTime")` → `"eventtime"`), which silently fails
+///   lookup against case-sensitive Arrow schemas. `from_name` preserves case.
+/// - Nulls placement mirrors Lucene's general default (ASC → NULLS FIRST,
+///   DESC → NULLS LAST). `index.sort.missing` can override this per field but
+///   the override isn't propagated yet. A wrong nulls claim at worst causes
+///   DataFusion's per-file chain validator to reject the ordering and fall back
+///   to a regular `SortExec` — never wrong results.
+pub(crate) fn build_file_sort_order(
+    sort_fields: &[String],
+    sort_orders: &[String],
+) -> Option<Vec<datafusion::logical_expr::SortExpr>> {
+    if sort_fields.is_empty() {
+        return None;
+    }
+    use datafusion::common::Column;
+    use datafusion::logical_expr::{Expr, SortExpr};
+    let sort_exprs: Vec<SortExpr> = sort_fields
+        .iter()
+        .zip(sort_orders.iter())
+        .map(|(name, order)| {
+            let ascending = order.eq_ignore_ascii_case("asc");
+            let nulls_first = ascending;
+            Expr::Column(Column::from_name(name.clone())).sort(ascending, nulls_first)
+        })
+        .collect();
+    Some(sort_exprs)
 }
 
 #[cfg(test)]

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionPlugin.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionPlugin.java
@@ -33,6 +33,8 @@ import org.opensearch.core.indices.breaker.CircuitBreakerStats;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.env.Environment;
 import org.opensearch.env.NodeEnvironment;
+import org.opensearch.index.IndexSettings;
+import org.opensearch.index.IndexSortConfig;
 import org.opensearch.index.engine.dataformat.DataFormatRegistry;
 import org.opensearch.index.engine.dataformat.ReaderManagerConfig;
 import org.opensearch.index.engine.exec.EngineReaderManager;
@@ -52,6 +54,7 @@ import org.opensearch.rest.RestController;
 import org.opensearch.rest.RestHandler;
 import org.opensearch.script.ScriptService;
 import org.opensearch.search.backpressure.trackers.NativeMemoryUsageTracker;
+import org.opensearch.search.sort.SortOrder;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.client.Client;
 import org.opensearch.watcher.ResourceWatcherService;
@@ -615,7 +618,37 @@ public class DataFusionPlugin extends Plugin
     @Override
     public EngineReaderManager<DatafusionReader> createReaderManager(ReaderManagerConfig settings) throws IOException {
         NativeStoreHandle dataformatAwareStoreHandle = settings.dataformatAwareStoreHandles().get(settings.format());
-        return new DatafusionReaderManager(settings.format(), settings.shardPath(), dataFusionService, dataformatAwareStoreHandle);
+        // Pull index.sort.field / index.sort.order off IndexSettings so the native reader can declare
+        // file sort order to DataFusion. Empty lists when the index has no index sort configured.
+        List<String> sortFields = List.of();
+        List<String> sortOrders = List.of();
+        IndexSettings indexSettings = settings.indexSettings();
+        if (indexSettings != null) {
+            Settings rawSettings = indexSettings.getSettings();
+            List<String> fields = IndexSortConfig.INDEX_SORT_FIELD_SETTING.get(rawSettings);
+            if (!fields.isEmpty()) {
+                sortFields = List.copyOf(fields);
+                // IndexSortConfig validates size match at index creation, so when
+                // index.sort.order is set its length equals fields.length. When omitted,
+                // every field defaults to asc — matches IndexSortConfig behavior.
+                if (IndexSortConfig.INDEX_SORT_ORDER_SETTING.exists(rawSettings)) {
+                    sortOrders = IndexSortConfig.INDEX_SORT_ORDER_SETTING.get(rawSettings)
+                        .stream()
+                        .map(o -> o == SortOrder.DESC ? "desc" : "asc")
+                        .toList();
+                } else {
+                    sortOrders = fields.stream().map(f -> "asc").toList();
+                }
+            }
+        }
+        return new DatafusionReaderManager(
+            settings.format(),
+            settings.shardPath(),
+            dataFusionService,
+            dataformatAwareStoreHandle,
+            sortFields,
+            sortOrders
+        );
     }
 
     @Override

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionReader.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionReader.java
@@ -47,8 +47,16 @@ public class DatafusionReader implements Closeable {
      * @param directoryPath shard data directory
      * @param writerFileSets the per-segment file sets from the catalog snapshot
      * @param dataformatAwareStoreHandle per-format native store handle (null on hot, live on warm)
+     * @param sortFields index.sort.field values (empty list when the index has no sort). Parallel to {@code sortOrders}.
+     * @param sortOrders index.sort.order values ("asc"/"desc"), parallel to {@code sortFields}.
      */
-    public DatafusionReader(String directoryPath, Collection<WriterFileSet> writerFileSets, NativeStoreHandle dataformatAwareStoreHandle) {
+    public DatafusionReader(
+        String directoryPath,
+        Collection<WriterFileSet> writerFileSets,
+        NativeStoreHandle dataformatAwareStoreHandle,
+        List<String> sortFields,
+        List<String> sortOrders
+    ) {
         this.directoryPath = directoryPath;
         List<MonoFileWriterSet> segments;
         if (writerFileSets == null || writerFileSets.isEmpty()) {
@@ -56,7 +64,7 @@ public class DatafusionReader implements Closeable {
         } else {
             segments = writerFileSets.stream().map(MonoFileWriterSet::from).toList();
         }
-        readerHandle = new ReaderHandle(directoryPath, segments, dataformatAwareStoreHandle);
+        readerHandle = new ReaderHandle(directoryPath, segments, dataformatAwareStoreHandle, sortFields, sortOrders);
     }
 
     /**

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionReaderManager.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionReaderManager.java
@@ -20,6 +20,7 @@ import org.opensearch.plugins.NativeStoreHandle;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -42,6 +43,14 @@ public class DatafusionReaderManager implements EngineReaderManager<DatafusionRe
     private final String directoryPath;
     private final DataFusionService dataFusionService;
     private final NativeStoreHandle dataformatAwareStoreHandle;
+    /**
+     * Sourced from {@code index.sort.field} once at construction; passed to every
+     * {@link DatafusionReader} created on refresh so the native side can declare
+     * file sort order to DataFusion's query optimizer.
+     */
+    private final List<String> sortFields;
+    /** Parallel to {@link #sortFields}; values are {@code "asc"} or {@code "desc"}. */
+    private final List<String> sortOrders;
 
     /**
      * Creates a reader manager.
@@ -51,17 +60,23 @@ public class DatafusionReaderManager implements EngineReaderManager<DatafusionRe
      * @param dataformatAwareStoreHandle per-format native store handle for reads (null if not available).
      *                                   Pointer is extracted at reader creation time via {@code getPointer()}.
      *                                   0 means use default local file system.
+     * @param sortFields {@code index.sort.field} values, or empty if no index sort.
+     * @param sortOrders {@code index.sort.order} values ("asc"/"desc"), parallel to {@code sortFields}.
      */
     public DatafusionReaderManager(
         DataFormat dataFormat,
         ShardPath shardPath,
         DataFusionService dataFusionService,
-        NativeStoreHandle dataformatAwareStoreHandle
+        NativeStoreHandle dataformatAwareStoreHandle,
+        List<String> sortFields,
+        List<String> sortOrders
     ) {
         this.dataFormat = dataFormat;
         this.directoryPath = shardPath.getDataPath().resolve(dataFormat.name()).toString();
         this.dataFusionService = dataFusionService;
         this.dataformatAwareStoreHandle = dataformatAwareStoreHandle;
+        this.sortFields = sortFields == null ? List.of() : sortFields;
+        this.sortOrders = sortOrders == null ? List.of() : sortOrders;
     }
 
     @Override
@@ -106,7 +121,9 @@ public class DatafusionReaderManager implements EngineReaderManager<DatafusionRe
         DatafusionReader reader = new DatafusionReader(
             directoryPath,
             catalogSnapshot.getSearchableFiles(dataFormat.name()),
-            dataformatAwareStoreHandle
+            dataformatAwareStoreHandle,
+            sortFields,
+            sortOrders
         );
         readers.put(catalogSnapshot.getId(), reader);
     }

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/nativelib/NativeBridge.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/nativelib/NativeBridge.java
@@ -208,8 +208,13 @@ public final class NativeBridge {
                 ValueLayout.ADDRESS,    // files_ptr
                 ValueLayout.ADDRESS,    // files_len_ptr
                 ValueLayout.ADDRESS,    // writer_generations_ptr
-                ValueLayout.JAVA_LONG,   // count (applies to all three parallel arrays)
-                ValueLayout.JAVA_LONG // object store ptr
+                ValueLayout.JAVA_LONG,  // count (applies to filenames + writer_generations)
+                ValueLayout.JAVA_LONG,  // object store ptr
+                ValueLayout.ADDRESS,    // sort_fields_ptr (parallel String[] for index.sort.field)
+                ValueLayout.ADDRESS,    // sort_fields_len_ptr
+                ValueLayout.ADDRESS,    // sort_orders_ptr (parallel String[] for index.sort.order: "asc"|"desc")
+                ValueLayout.ADDRESS,    // sort_orders_len_ptr
+                ValueLayout.JAVA_LONG   // sort_count (0 when index has no sort)
             )
         );
 
@@ -786,11 +791,18 @@ public final class NativeBridge {
      * @param path     shard data directory
      * @param segments per-segment metadata — each carries a single filename and writer generation
      * @param dataformatAwareStoreHandle per-format native store handle (null = local, live = use store pointer)
+     * @param sortFields index.sort.field values, or empty list if the index has no sort configured.
+     *                   Parallel to {@code sortOrders}.
+     * @param sortOrders index.sort.order values ("asc" or "desc"), parallel to {@code sortFields}.
+     *                   Used by Rust to call {@code ListingOptions.with_file_sort_order(...)} so the
+     *                   parquet scan advertises {@code output_ordering} to the DataFusion optimizer.
      */
     public static long createDatafusionReader(
         String path,
         List<org.opensearch.index.engine.exec.MonoFileWriterSet> segments,
-        NativeStoreHandle dataformatAwareStoreHandle
+        NativeStoreHandle dataformatAwareStoreHandle,
+        List<String> sortFields,
+        List<String> sortOrders
     ) {
         long storePtr = 0L;
         if (dataformatAwareStoreHandle != null) {
@@ -801,13 +813,40 @@ public final class NativeBridge {
                 storePtr = 0L;
             }
         }
+        if (sortFields == null) sortFields = List.of();
+        if (sortOrders == null) sortOrders = List.of();
+        if (sortFields.size() != sortOrders.size()) {
+            throw new IllegalArgumentException(
+                "createDatafusionReader: sortFields ("
+                    + sortFields.size()
+                    + ") and sortOrders ("
+                    + sortOrders.size()
+                    + ") must have the same length"
+            );
+        }
         try (var call = new NativeCall()) {
             var p = call.str(path);
             var f = call.strArray(segments.stream().map(org.opensearch.index.engine.exec.MonoFileWriterSet::file).toArray(String[]::new));
             var gens = call.longs(
                 segments.stream().mapToLong(org.opensearch.index.engine.exec.MonoFileWriterSet::writerGeneration).toArray()
             );
-            return call.invoke(CREATE_READER, p.segment(), p.len(), f.ptrs(), f.lens(), gens, f.count(), storePtr);
+            var sf = call.strArray(sortFields.toArray(String[]::new));
+            var so = call.strArray(sortOrders.toArray(String[]::new));
+            return call.invoke(
+                CREATE_READER,
+                p.segment(),
+                p.len(),
+                f.ptrs(),
+                f.lens(),
+                gens,
+                f.count(),
+                storePtr,
+                sf.ptrs(),
+                sf.lens(),
+                so.ptrs(),
+                so.lens(),
+                sf.count()
+            );
         }
     }
 

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/nativelib/ReaderHandle.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/nativelib/ReaderHandle.java
@@ -29,9 +29,17 @@ public final class ReaderHandle extends NativeHandle {
      * @param path the directory path containing data files
      * @param segments the per-segment file sets to read
      * @param dataformatAwareStoreHandle per-format native store handle (null = local, live = use store pointer)
+     * @param sortFields index.sort.field values (or empty if no index sort). Parallel to {@code sortOrders}.
+     * @param sortOrders index.sort.order values ("asc"/"desc"), parallel to {@code sortFields}.
      */
-    public ReaderHandle(String path, List<MonoFileWriterSet> segments, NativeStoreHandle dataformatAwareStoreHandle) {
-        super(NativeBridge.createDatafusionReader(path, segments, dataformatAwareStoreHandle));
+    public ReaderHandle(
+        String path,
+        List<MonoFileWriterSet> segments,
+        NativeStoreHandle dataformatAwareStoreHandle,
+        List<String> sortFields,
+        List<String> sortOrders
+    ) {
+        super(NativeBridge.createDatafusionReader(path, segments, dataformatAwareStoreHandle, sortFields, sortOrders));
         this.ownsPointer = true;
     }
 

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionNativeBridgeTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionNativeBridgeTests.java
@@ -72,7 +72,9 @@ public class DataFusionNativeBridgeTests extends OpenSearchTestCase {
         ReaderHandle readerHandle = new ReaderHandle(
             dataDir.toString(),
             java.util.List.of(MonoFileWriterSet.of(".", 0L, "test.parquet", 0L)),
-            null
+            null,
+            java.util.List.of(),
+            java.util.List.of()
         );
         assertTrue("Reader pointer should be non-zero", readerHandle.getPointer() != 0);
 
@@ -95,7 +97,9 @@ public class DataFusionNativeBridgeTests extends OpenSearchTestCase {
         ReaderHandle readerHandle = new ReaderHandle(
             dataDir.toString(),
             java.util.List.of(MonoFileWriterSet.of(".", 0L, "test.parquet", 0L)),
-            null
+            null,
+            java.util.List.of(),
+            java.util.List.of()
         );
         // Create session context with table registered
         long queryConfigPtr;
@@ -184,7 +188,9 @@ public class DataFusionNativeBridgeTests extends OpenSearchTestCase {
         ReaderHandle readerHandle = new ReaderHandle(
             dataDir.toString(),
             List.of(MonoFileWriterSet.of(dataDir.toString(), 1L, "test.parquet", 0L)),
-            storeHandle
+            storeHandle,
+            List.of(),
+            List.of()
         );
         assertTrue("Reader pointer should be non-zero", readerHandle.getPointer() != 0);
 

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionQueryExecutionTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionQueryExecutionTests.java
@@ -64,7 +64,13 @@ public class DataFusionQueryExecutionTests extends OpenSearchTestCase {
         Path dataDir = createTempDir("datafusion-data");
         Path testParquet = Path.of(getClass().getClassLoader().getResource("test.parquet").toURI());
         Files.copy(testParquet, dataDir.resolve("test.parquet"));
-        readerHandle = new ReaderHandle(dataDir.toString(), List.of(MonoFileWriterSet.of(".", 0L, "test.parquet", 0L)), storeHandle);
+        readerHandle = new ReaderHandle(
+            dataDir.toString(),
+            List.of(MonoFileWriterSet.of(".", 0L, "test.parquet", 0L)),
+            storeHandle,
+            List.of(),
+            List.of()
+        );
 
         configArena = Arena.ofConfined();
         MemorySegment configSegment = configArena.allocate(WireConfigSnapshot.BYTE_SIZE);

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionReaderManagerTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionReaderManagerTests.java
@@ -71,7 +71,7 @@ public class DatafusionReaderManagerTests extends OpenSearchTestCase {
         ShardPath shardPath = createTestShardPath();
         DataFusionService mockService = mock(DataFusionService.class);
 
-        DatafusionReaderManager manager = new DatafusionReaderManager(TEST_FORMAT, shardPath, mockService, null);
+        DatafusionReaderManager manager = new DatafusionReaderManager(TEST_FORMAT, shardPath, mockService, null, List.of(), List.of());
         assertNotNull(manager);
         manager.close();
     }
@@ -83,7 +83,14 @@ public class DatafusionReaderManagerTests extends OpenSearchTestCase {
         ShardPath shardPath = createTestShardPath();
         DataFusionService mockService = mock(DataFusionService.class);
 
-        DatafusionReaderManager manager = new DatafusionReaderManager(TEST_FORMAT, shardPath, mockService, NativeStoreHandle.EMPTY);
+        DatafusionReaderManager manager = new DatafusionReaderManager(
+            TEST_FORMAT,
+            shardPath,
+            mockService,
+            NativeStoreHandle.EMPTY,
+            List.of(),
+            List.of()
+        );
         assertNotNull(manager);
         manager.close();
     }
@@ -95,7 +102,7 @@ public class DatafusionReaderManagerTests extends OpenSearchTestCase {
         ShardPath shardPath = createTestShardPath();
         DataFusionService mockService = mock(DataFusionService.class);
 
-        DatafusionReaderManager manager = new DatafusionReaderManager(TEST_FORMAT, shardPath, mockService, null);
+        DatafusionReaderManager manager = new DatafusionReaderManager(TEST_FORMAT, shardPath, mockService, null, List.of(), List.of());
         // Should not throw — no readers to close
         manager.close();
     }
@@ -107,7 +114,7 @@ public class DatafusionReaderManagerTests extends OpenSearchTestCase {
         ShardPath shardPath = createTestShardPath();
         DataFusionService mockService = mock(DataFusionService.class);
 
-        DatafusionReaderManager manager = new DatafusionReaderManager(TEST_FORMAT, shardPath, mockService, null);
+        DatafusionReaderManager manager = new DatafusionReaderManager(TEST_FORMAT, shardPath, mockService, null, List.of(), List.of());
         manager.onFilesDeleted(null);
         verifyNoInteractions(mockService);
         manager.close();
@@ -120,7 +127,7 @@ public class DatafusionReaderManagerTests extends OpenSearchTestCase {
         ShardPath shardPath = createTestShardPath();
         DataFusionService mockService = mock(DataFusionService.class);
 
-        DatafusionReaderManager manager = new DatafusionReaderManager(TEST_FORMAT, shardPath, mockService, null);
+        DatafusionReaderManager manager = new DatafusionReaderManager(TEST_FORMAT, shardPath, mockService, null, List.of(), List.of());
         manager.onFilesDeleted(List.of());
         verifyNoInteractions(mockService);
         manager.close();
@@ -133,7 +140,7 @@ public class DatafusionReaderManagerTests extends OpenSearchTestCase {
         ShardPath shardPath = createTestShardPath();
         DataFusionService mockService = mock(DataFusionService.class);
 
-        DatafusionReaderManager manager = new DatafusionReaderManager(TEST_FORMAT, shardPath, mockService, null);
+        DatafusionReaderManager manager = new DatafusionReaderManager(TEST_FORMAT, shardPath, mockService, null, List.of(), List.of());
         manager.onFilesAdded(null);
         verifyNoInteractions(mockService);
         manager.close();
@@ -146,7 +153,7 @@ public class DatafusionReaderManagerTests extends OpenSearchTestCase {
         ShardPath shardPath = createTestShardPath();
         DataFusionService mockService = mock(DataFusionService.class);
 
-        DatafusionReaderManager manager = new DatafusionReaderManager(TEST_FORMAT, shardPath, mockService, null);
+        DatafusionReaderManager manager = new DatafusionReaderManager(TEST_FORMAT, shardPath, mockService, null, List.of(), List.of());
         manager.onFilesAdded(List.of());
         verifyNoInteractions(mockService);
         manager.close();
@@ -159,7 +166,7 @@ public class DatafusionReaderManagerTests extends OpenSearchTestCase {
         ShardPath shardPath = createTestShardPath();
         DataFusionService mockService = mock(DataFusionService.class);
 
-        DatafusionReaderManager manager = new DatafusionReaderManager(TEST_FORMAT, shardPath, mockService, null);
+        DatafusionReaderManager manager = new DatafusionReaderManager(TEST_FORMAT, shardPath, mockService, null, List.of(), List.of());
         Collection<String> files = List.of("seg_0.parquet", "seg_1.parquet");
         manager.onFilesDeleted(files);
 
@@ -176,7 +183,7 @@ public class DatafusionReaderManagerTests extends OpenSearchTestCase {
         ShardPath shardPath = createTestShardPath();
         DataFusionService mockService = mock(DataFusionService.class);
 
-        DatafusionReaderManager manager = new DatafusionReaderManager(TEST_FORMAT, shardPath, mockService, null);
+        DatafusionReaderManager manager = new DatafusionReaderManager(TEST_FORMAT, shardPath, mockService, null, List.of(), List.of());
         Collection<String> files = List.of("seg_0.parquet");
         manager.onFilesAdded(files);
 
@@ -193,7 +200,7 @@ public class DatafusionReaderManagerTests extends OpenSearchTestCase {
         ShardPath shardPath = createTestShardPath();
         DataFusionService mockService = mock(DataFusionService.class);
 
-        DatafusionReaderManager manager = new DatafusionReaderManager(TEST_FORMAT, shardPath, mockService, null);
+        DatafusionReaderManager manager = new DatafusionReaderManager(TEST_FORMAT, shardPath, mockService, null, List.of(), List.of());
         manager.beforeRefresh();
         manager.close();
     }
@@ -205,7 +212,7 @@ public class DatafusionReaderManagerTests extends OpenSearchTestCase {
         ShardPath shardPath = createTestShardPath();
         DataFusionService mockService = mock(DataFusionService.class);
 
-        DatafusionReaderManager manager = new DatafusionReaderManager(TEST_FORMAT, shardPath, mockService, null);
+        DatafusionReaderManager manager = new DatafusionReaderManager(TEST_FORMAT, shardPath, mockService, null, List.of(), List.of());
         // didRefresh=false means no new data — should be a no-op
         manager.afterRefresh(false, null);
         manager.close();
@@ -218,7 +225,7 @@ public class DatafusionReaderManagerTests extends OpenSearchTestCase {
         ShardPath shardPath = createTestShardPath();
         DataFusionService mockService = mock(DataFusionService.class);
 
-        DatafusionReaderManager manager = new DatafusionReaderManager(TEST_FORMAT, shardPath, mockService, null);
+        DatafusionReaderManager manager = new DatafusionReaderManager(TEST_FORMAT, shardPath, mockService, null, List.of(), List.of());
         expectThrows(IllegalArgumentException.class, () -> manager.getReader(null));
         manager.close();
     }

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionResultStreamTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionResultStreamTests.java
@@ -59,7 +59,13 @@ public class DatafusionResultStreamTests extends OpenSearchTestCase {
         Path dataDir = createTempDir("data");
         Path testParquet = Path.of(getClass().getClassLoader().getResource("test.parquet").toURI());
         Files.copy(testParquet, dataDir.resolve("test.parquet"));
-        readerHandle = new ReaderHandle(dataDir.toString(), List.of(MonoFileWriterSet.of(".", 0L, "test.parquet", 0L)), storeHandle);
+        readerHandle = new ReaderHandle(
+            dataDir.toString(),
+            List.of(MonoFileWriterSet.of(".", 0L, "test.parquet", 0L)),
+            storeHandle,
+            List.of(),
+            List.of()
+        );
 
         configArena = Arena.ofConfined();
         MemorySegment configSegment = configArena.allocate(WireConfigSnapshot.BYTE_SIZE);

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionSearchExecEngineTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionSearchExecEngineTests.java
@@ -55,7 +55,13 @@ public class DatafusionSearchExecEngineTests extends OpenSearchTestCase {
         Path dataDir = createTempDir("datafusion-data");
         Path testParquet = Path.of(getClass().getClassLoader().getResource("test.parquet").toURI());
         Files.copy(testParquet, dataDir.resolve("test.parquet"));
-        readerHandle = new ReaderHandle(dataDir.toString(), List.of(MonoFileWriterSet.of(".", 0L, "test.parquet", 0L)), storeHandle);
+        readerHandle = new ReaderHandle(
+            dataDir.toString(),
+            List.of(MonoFileWriterSet.of(".", 0L, "test.parquet", 0L)),
+            storeHandle,
+            List.of(),
+            List.of()
+        );
     }
 
     @Override

--- a/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/LuceneReaderManagerTests.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/LuceneReaderManagerTests.java
@@ -671,7 +671,8 @@ public class LuceneReaderManagerTests extends OpenSearchTestCase {
                 dataFormat,
                 mock(DataFormatRegistry.class),
                 shardPath,
-                Map.of()
+                Map.of(),
+                null
             );
 
             EngineReaderManager<?> rm = LuceneSearchBackEnd.createReaderManager(settings);
@@ -688,7 +689,8 @@ public class LuceneReaderManagerTests extends OpenSearchTestCase {
             dataFormat,
             mock(DataFormatRegistry.class),
             null,
-            Map.of()
+            Map.of(),
+            null
         );
 
         IllegalStateException ex = expectThrows(IllegalStateException.class, () -> LuceneSearchBackEnd.createReaderManager(settings));

--- a/sandbox/plugins/composite-engine/src/main/java/org/opensearch/composite/CompositeIndexingExecutionEngine.java
+++ b/sandbox/plugins/composite-engine/src/main/java/org/opensearch/composite/CompositeIndexingExecutionEngine.java
@@ -542,7 +542,8 @@ public class CompositeIndexingExecutionEngine implements IndexingExecutionEngine
             toAugment,
             config.registry(),
             config.shardPath(),
-            config.dataformatAwareStoreHandles()
+            config.dataformatAwareStoreHandles(),
+            config.indexSettings()
         );
     }
 

--- a/sandbox/qa/analytics-engine-coordinator/src/internalClusterTest/java/org/opensearch/be/datafusion/IndexSortPropagationIT.java
+++ b/sandbox/qa/analytics-engine-coordinator/src/internalClusterTest/java/org/opensearch/be/datafusion/IndexSortPropagationIT.java
@@ -1,0 +1,275 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion;
+
+import org.opensearch.Version;
+import org.opensearch.action.admin.indices.create.CreateIndexResponse;
+import org.opensearch.analytics.AnalyticsPlugin;
+import org.opensearch.analytics.exec.DefaultPlanExecutor;
+import org.opensearch.analytics.sql.SqlPlanRunner;
+import org.opensearch.arrow.allocator.ArrowBasePlugin;
+import org.opensearch.arrow.flight.transport.FlightStreamPlugin;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.FeatureFlags;
+import org.opensearch.composite.CompositeDataFormatPlugin;
+import org.opensearch.index.engine.dataformat.stub.MockCommitterEnginePlugin;
+import org.opensearch.parquet.ParquetOnlyDataFormatPlugin;
+import org.opensearch.plugins.Plugin;
+import org.opensearch.plugins.PluginInfo;
+import org.opensearch.test.OpenSearchIntegTestCase;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Correctness IT for the {@code index.sort.field} → DataFusion {@code with_file_sort_order(...)}
+ * propagation in the analytics-backend-datafusion vanilla query path.
+ *
+ * <p>Background. The DatafusionPlugin reads {@code index.sort.field} / {@code index.sort.order} off
+ * {@link org.opensearch.index.IndexSettings}, ships them across FFM in {@code df_create_reader},
+ * and threads them into {@link org.opensearch.index.engine.exec.EngineReaderManager} →
+ * {@code ShardView.sort_fields}/{@code sort_orders}. At session-context build time
+ * (Rust-side {@code session_context.rs}) the lists become a
+ * {@code ListingOptions::with_file_sort_order(...)} call, which makes DataFusion advertise
+ * {@code output_ordering} from {@code DataSourceExec} and unlock the
+ * {@code repartition_preserving_order} / {@code sort_prefix} optimizations.
+ *
+ * <p>{@code with_file_sort_order} is a <b>per-file claim</b> — DataFusion does not verify it. The
+ * claim is safe here only because the OpenSearch parquet writer enforces the same sort within
+ * each segment via {@code index.sort.field}. The risk we're guarding against in this IT is a
+ * regression where:
+ *
+ * <ul>
+ *   <li>the claim doesn't match the writer's actual physical layout, or</li>
+ *   <li>the optimizer mis-uses the claim and silently drops or re-orders rows.</li>
+ * </ul>
+ *
+ * <p>Strategy: ingest the same set of rows into two indices — one with {@code index.sort.field}
+ * configured, one without — and assert that the query results are byte-identical for several
+ * query shapes (filter-only, sort+limit, agg+sort). If our patch lies, results would differ.
+ *
+ * @opensearch.internal
+ */
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.SUITE, numDataNodes = 2, numClientNodes = 0)
+public class IndexSortPropagationIT extends OpenSearchIntegTestCase {
+
+    private static final String IDX_UNSORTED = "sort_prop_unsorted";
+    private static final String IDX_SORTED = "sort_prop_sorted";
+    private static final int DOC_COUNT = 30;
+    private static final int SHARDS = 2;
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return List.of(ArrowBasePlugin.class, CompositeDataFormatPlugin.class, MockCommitterEnginePlugin.class);
+    }
+
+    @Override
+    protected Collection<PluginInfo> additionalNodePlugins() {
+        return List.of(
+            classpathPlugin(FlightStreamPlugin.class, List.of(ArrowBasePlugin.class.getName())),
+            classpathPlugin(AnalyticsPlugin.class, Collections.emptyList()),
+            classpathPlugin(ParquetOnlyDataFormatPlugin.class, Collections.emptyList()),
+            classpathPlugin(DataFusionPlugin.class, List.of(AnalyticsPlugin.class.getName()))
+        );
+    }
+
+    private static PluginInfo classpathPlugin(Class<? extends Plugin> pluginClass, List<String> extendedPlugins) {
+        return new PluginInfo(
+            pluginClass.getName(),
+            "classpath plugin",
+            "NA",
+            Version.CURRENT,
+            "1.8",
+            pluginClass.getName(),
+            null,
+            extendedPlugins,
+            false
+        );
+    }
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return Settings.builder()
+            .put(super.nodeSettings(nodeOrdinal))
+            .put(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG, true)
+            .put(FeatureFlags.STREAM_TRANSPORT, true)
+            .build();
+    }
+
+    /**
+     * Filter-only query — no sort, no limit. Must produce the same rows in both indices.
+     */
+    public void testFilterOnly_resultsMatchAcrossSortedAndUnsorted() throws Exception {
+        createAndSeedBothIndices();
+        SqlPlanRunner runner = sqlPlanRunner();
+
+        List<Object[]> unsorted = runner.executeSql(
+            "SELECT URL, EventDate, CounterID FROM " + IDX_UNSORTED + " WHERE CounterID > 5"
+        );
+        List<Object[]> sorted = runner.executeSql(
+            "SELECT URL, EventDate, CounterID FROM " + IDX_SORTED + " WHERE CounterID > 5"
+        );
+
+        assertResultsEquivalent("filter-only", unsorted, sorted);
+    }
+
+    /**
+     * Sort+LIMIT — the query that actually exercises {@code sort_prefix} when the ORDER BY
+     * matches a prefix of {@code index.sort.field}. Both indices must produce the same top-N
+     * rows in the same order.
+     */
+    public void testSortLimit_resultsMatchAcrossSortedAndUnsorted() throws Exception {
+        createAndSeedBothIndices();
+        SqlPlanRunner runner = sqlPlanRunner();
+
+        // ORDER BY (CounterID DESC, EventDate DESC) is a prefix of the sort declared on IDX_SORTED.
+        String sql = " WHERE CounterID > 0 ORDER BY CounterID DESC, EventDate DESC LIMIT 10";
+        List<Object[]> unsorted = runner.executeSql("SELECT URL, EventDate, CounterID FROM " + IDX_UNSORTED + sql);
+        List<Object[]> sorted = runner.executeSql("SELECT URL, EventDate, CounterID FROM " + IDX_SORTED + sql);
+
+        assertEquals("LIMIT 10 must produce 10 rows for unsorted", 10, unsorted.size());
+        assertEquals("LIMIT 10 must produce 10 rows for sorted", 10, sorted.size());
+        // For sort+LIMIT, row ORDER must match — not just multiset equality.
+        assertOrderedRowsEqual("sort+limit", unsorted, sorted);
+    }
+
+    /**
+     * Agg + sort on aggregate output — the sort declaration must NOT bleed into queries that
+     * don't reference the sort columns in their ORDER BY.
+     */
+    public void testAggSortOnAggregate_resultsMatchAcrossSortedAndUnsorted() throws Exception {
+        createAndSeedBothIndices();
+        SqlPlanRunner runner = sqlPlanRunner();
+
+        String sql = " WHERE CounterID > 0 GROUP BY EventDate ORDER BY COUNT(*) DESC, EventDate ASC LIMIT 5";
+        List<Object[]> unsorted = runner.executeSql("SELECT EventDate, COUNT(*) AS c FROM " + IDX_UNSORTED + sql);
+        List<Object[]> sorted = runner.executeSql("SELECT EventDate, COUNT(*) AS c FROM " + IDX_SORTED + sql);
+
+        // tiebreaker-stable ORDER BY (count, then date) → ordered comparison is meaningful.
+        assertOrderedRowsEqual("agg+sort", unsorted, sorted);
+    }
+
+    /**
+     * ORDER BY a non-sort column. The sort declaration must not re-route results based on
+     * unrelated columns.
+     */
+    public void testSortOnNonSortColumn_resultsMatchAcrossSortedAndUnsorted() throws Exception {
+        createAndSeedBothIndices();
+        SqlPlanRunner runner = sqlPlanRunner();
+
+        String sql = " WHERE CounterID > 0 ORDER BY URL ASC LIMIT 8";
+        List<Object[]> unsorted = runner.executeSql("SELECT URL, CounterID FROM " + IDX_UNSORTED + sql);
+        List<Object[]> sorted = runner.executeSql("SELECT URL, CounterID FROM " + IDX_SORTED + sql);
+
+        assertOrderedRowsEqual("sort-on-non-sort-column", unsorted, sorted);
+    }
+
+    // ── Infrastructure ──────────────────────────────────────────────────────
+
+    private SqlPlanRunner sqlPlanRunner() {
+        String node = internalCluster().getNodeNames()[0];
+        ClusterService clusterService = internalCluster().getInstance(ClusterService.class, node);
+        DefaultPlanExecutor executor = internalCluster().getInstance(DefaultPlanExecutor.class, node);
+        return new SqlPlanRunner(clusterService, executor);
+    }
+
+    /**
+     * Creates two parallel indices ingested with the same docs:
+     *   - {@code IDX_UNSORTED}: no {@code index.sort.field}.
+     *   - {@code IDX_SORTED}: {@code index.sort.field=[CounterID, EventDate]} both descending.
+     */
+    private void createAndSeedBothIndices() {
+        // Local helper renamed to avoid ambiguity with OpenSearchIntegTestCase#createIndex
+        // overloads (the (String, Settings, String) form would collide on null arguments).
+        createCompositeIndex(IDX_UNSORTED, /*sortFields*/ null, /*sortOrders*/ null);
+        createCompositeIndex(IDX_SORTED, List.of("CounterID", "EventDate"), List.of("desc", "desc"));
+        seed(IDX_UNSORTED);
+        seed(IDX_SORTED);
+    }
+
+    private void createCompositeIndex(String name, List<String> sortFields, List<String> sortOrders) {
+        Settings.Builder settings = Settings.builder()
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, SHARDS)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+            .put("index.pluggable.dataformat.enabled", true)
+            .put("index.pluggable.dataformat", "composite")
+            .put("index.composite.primary_data_format", "parquet")
+            .putList("index.composite.secondary_data_formats");
+        if (sortFields != null && !sortFields.isEmpty()) {
+            settings.putList("index.sort.field", sortFields);
+            settings.putList("index.sort.order", sortOrders);
+        }
+
+        CreateIndexResponse response = client().admin()
+            .indices()
+            .prepareCreate(name)
+            .setSettings(settings.build())
+            .setMapping("URL", "type=keyword,index=false", "EventDate", "type=date", "CounterID", "type=integer")
+            .get();
+        assertTrue("index creation must be acknowledged for " + name, response.isAcknowledged());
+        ensureGreen(name);
+    }
+
+    /**
+     * Seeds the same {@code DOC_COUNT} docs into the given index. Doc IDs are stable so both
+     * indices end up with identical content.
+     */
+    private void seed(String index) {
+        for (int i = 0; i < DOC_COUNT; i++) {
+            // CounterID: 1..DOC_COUNT, EventDate spans 2026-05-01..2026-05-(1 + i mod 10).
+            // Same content for both indices — only physical layout differs because of index.sort.field.
+            client().prepareIndex(index)
+                .setId(String.valueOf(i))
+                .setSource(
+                    "URL",
+                    "https://example.com/page" + i,
+                    "EventDate",
+                    "2026-05-" + String.format(Locale.ROOT, "%02d", (i % 10) + 1),
+                    "CounterID",
+                    i + 1
+                )
+                .get();
+        }
+        client().admin().indices().prepareRefresh(index).get();
+        client().admin().indices().prepareFlush(index).get();
+    }
+
+    /**
+     * Multiset comparison — for queries where row order isn't guaranteed (e.g. filter-only).
+     * Sorts both lists by a stable key derived from each row before comparing.
+     */
+    private static void assertResultsEquivalent(String label, List<Object[]> a, List<Object[]> b) {
+        assertEquals(label + ": row count mismatch", a.size(), b.size());
+        List<String> aKeys = a.stream().map(IndexSortPropagationIT::rowKey).sorted().toList();
+        List<String> bKeys = b.stream().map(IndexSortPropagationIT::rowKey).sorted().toList();
+        assertEquals(label + ": row content mismatch", aKeys, bKeys);
+    }
+
+    /**
+     * Order-sensitive comparison — for queries with a deterministic ORDER BY.
+     */
+    private static void assertOrderedRowsEqual(String label, List<Object[]> a, List<Object[]> b) {
+        assertEquals(label + ": row count mismatch", a.size(), b.size());
+        for (int i = 0; i < a.size(); i++) {
+            assertEquals(label + ": row " + i + " mismatch", rowKey(a.get(i)), rowKey(b.get(i)));
+        }
+    }
+
+    private static String rowKey(Object[] row) {
+        StringBuilder sb = new StringBuilder();
+        for (Object cell : row) {
+            sb.append(cell == null ? "<null>" : cell.toString()).append('|');
+        }
+        return sb.toString();
+    }
+}

--- a/server/src/main/java/org/opensearch/index/engine/DataFormatAwareEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/DataFormatAwareEngine.java
@@ -347,7 +347,8 @@ public class DataFormatAwareEngine implements Indexer {
                     indexingExecutionEngine.getDataFormat(),
                     registry,
                     store.shardPath(),
-                    store.getDataformatAwareStoreHandles()
+                    store.getDataformatAwareStoreHandles(),
+                    engineConfig.getIndexSettings()
                 )
             );
 

--- a/server/src/main/java/org/opensearch/index/engine/DataFormatAwareNRTReplicationEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/DataFormatAwareNRTReplicationEngine.java
@@ -174,7 +174,7 @@ public class DataFormatAwareNRTReplicationEngine implements Indexer {
                             }
                         };
                     }
-                }), format, registry, store.shardPath(), store.getDataformatAwareStoreHandles())));
+                }), format, registry, store.shardPath(), store.getDataformatAwareStoreHandles(), engineConfig.getIndexSettings())));
             }
             readerManagersRef = Map.copyOf(aggregated);
 

--- a/server/src/main/java/org/opensearch/index/engine/DataFormatAwareReadOnlyEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/DataFormatAwareReadOnlyEngine.java
@@ -159,7 +159,8 @@ public class DataFormatAwareReadOnlyEngine implements Indexer {
                             format,
                             registry,
                             store.shardPath(),
-                            store.getDataformatAwareStoreHandles()
+                            store.getDataformatAwareStoreHandles(),
+                            engineConfig.getIndexSettings()
                         )
                     )
                 );

--- a/server/src/main/java/org/opensearch/index/engine/dataformat/ReaderManagerConfig.java
+++ b/server/src/main/java/org/opensearch/index/engine/dataformat/ReaderManagerConfig.java
@@ -9,6 +9,7 @@
 package org.opensearch.index.engine.dataformat;
 
 import org.opensearch.common.annotation.ExperimentalApi;
+import org.opensearch.index.IndexSettings;
 import org.opensearch.index.engine.exec.commit.IndexStoreProvider;
 import org.opensearch.index.shard.ShardPath;
 import org.opensearch.plugins.NativeStoreHandle;
@@ -28,10 +29,12 @@ import java.util.Optional;
  * @param dataformatAwareStoreHandles per-format native store handles for reads.
  *                                    Empty map if no native stores are available.
  *                                    Each plugin extracts its own handle via {@code handles.get(config.format())}.
+ * @param indexSettings the index settings (carries {@code IndexSortConfig} so backends can declare
+ *                      file sort order to their query optimizers).
  *
  * @opensearch.experimental
  */
 @ExperimentalApi
 public record ReaderManagerConfig(Optional<IndexStoreProvider> indexStoreProvider, DataFormat format, DataFormatRegistry registry,
-    ShardPath shardPath, Map<DataFormat, NativeStoreHandle> dataformatAwareStoreHandles) {
+    ShardPath shardPath, Map<DataFormat, NativeStoreHandle> dataformatAwareStoreHandles, IndexSettings indexSettings) {
 }

--- a/server/src/test/java/org/opensearch/index/engine/dataformat/DataFormatRegistryTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/dataformat/DataFormatRegistryTests.java
@@ -273,7 +273,7 @@ public class DataFormatRegistryTests extends OpenSearchTestCase {
         DataFormatRegistry registry = new DataFormatRegistry(pluginsService);
 
         Map<DataFormat, EngineReaderManager<?>> managers = registry.getReaderManager(
-            new ReaderManagerConfig(Optional.empty(), format, registry, shardPath, Map.of())
+            new ReaderManagerConfig(Optional.empty(), format, registry, shardPath, Map.of(), null)
         );
         assertEquals(1, managers.size());
         assertNotNull(managers.get(format));


### PR DESCRIPTION
### Description

Wires the index sort settings (`index.sort.field`, `index.sort.order`) end-to-end into DataFusion's `ListingOptions::with_file_sort_order(...)`. The OpenSearch parquet writer enforces this sort within each segment, so the per-file claim is verifiable-by-construction. Once advertised on `DataSourceExec`, downstream optimizers can fire:

- `output_ordering` propagates upward, letting `SortPreservingMergeExec` replace `SortExec(TopK)` when the query's ORDER BY matches.
- `sort_prefix` enables partial-sort early termination on TopK.
- `split_file_groups_by_statistics=true` (set when sort fields are present) keeps file boundaries intact for the bin-packer; combined with `target_partitions ≥ num_files`, the optimizer produces single-file groups with `output_ordering` validated by DataFusion's per-file min/max chain check.

**Java side.** `ReaderManagerConfig` now carries `IndexSettings`. `DataFusionPlugin.createReaderManager` reads `INDEX_SORT_FIELD_SETTING` / `INDEX_SORT_ORDER_SETTING` and passes them through `DatafusionReaderManager` → `DatafusionReader` → `ReaderHandle` → `NativeBridge.createDatafusionReader` as parallel `String[]` arrays plus a count. `SortOrder` enum is converted to its lowercase string form (`asc` / `desc`) for the wire.

**Rust side.** `df_create_reader` decodes the new FFM args. `ShardView` carries `pub sort_fields: Vec<String>` / `pub sort_orders: Vec<String>`. The session-context build site builds a `Vec<SortExpr>` and calls `with_file_sort_order(...)` on the `ListingOptions`. Uses `Expr::Column(Column::from_name(name.clone()))` rather than `col(&str)` — the latter goes through SQL identifier normalization and silently lowercases column names, producing an empty ordering at plan time when the Arrow schema is case-sensitive (e.g. `EventTime` vs `eventtime`). Sets `split_file_groups_by_statistics = true` and `with_target_partitions(effective_partitions)` on the `ListingOptions` when sort fields are present.

### Verification

End-to-end on a sorted ClickBench segment (`index.sort.field=[EventTime] asc`, single-segment shard) running

```
source = clickbench_mini | where SearchPhrase != '' | sort EventTime | head 10 | fields SearchPhrase
```

DataFusion physical plan from `RustLoggerBridge` DEBUG:

```
ProjectionExec: expr=[SearchPhrase@1 as SearchPhrase]
  SortPreservingMergeExec: [EventTime@0 ASC], fetch=10
    FilterExec: SearchPhrase@1 != , fetch=10
      RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1, maintains_sort_order=true
        DataSourceExec: file_groups={1 group: [..._merged_b.parquet]},
                        projection=[EventTime, SearchPhrase],
                        output_ordering=[EventTime@0 ASC],
                        ...
```

Concrete confirmations: `output_ordering=[EventTime@0 ASC]` advertised on DataSourceExec; `SortPreservingMergeExec` replaces `SortExec(TopK)`; `maintains_sort_order=true` on the upstream RepartitionExec; `fetch=10` pushed into FilterExec for early termination. No SortExec in the plan at all — the slow path never runs.

When `target_partitions < num_files` the plan degrades gracefully: no `output_ordering`, no `sort_prefix`, byte-range partitioning. Results are correct in both regimes — the optimization is purely about avoiding redundant sort work, not correctness.

### Pre-conditions for the optimization to fire on a query

1. The index has `index.sort.field` configured.
2. `search.concurrent_segment_search.mode != "none"`.
3. `search.concurrent.max_slice_count >= num_segments` (so `target_partitions ≥ num_files` and DataFusion's cross-file chain validator accepts the multi-file-group claim — or, equivalently, a single merged segment as in the verification above).
4. The query's `ORDER BY` is a prefix of `index.sort.field` with matching directions (otherwise the claim is inert — no harm, no benefit).

### What this does NOT change

- **Indexed path** (`QueryShardExec`) is unaffected. That path doesn't use `ListingTable` — it has its own `IndexedTableProvider`. A similar propagation could apply there separately if needed.
- **Sort key column directions on disk:** no re-ingest needed. The declaration is metadata only.

### Testing

- New `IndexSortPropagationIT` (internal cluster test) under `sandbox/qa/analytics-engine-coordinator`.
- Existing `DatafusionReaderManager` / `ReaderHandle` / `DataFormatRegistry` tests updated to pass the two new `List<String>` args at every call site.

### Related Issues

N/A

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.