### PR TITLE
Publish logger usage checker

### DIFF
--- a/test/logger-usage/build.gradle
+++ b/test/logger-usage/build.gradle
@@ -29,6 +29,7 @@
  */
 
 apply plugin: 'opensearch.java'
+apply plugin: 'opensearch.publish'
 
 dependencies {
   api "org.ow2.asm:asm:${versions.asm}"


### PR DESCRIPTION
## Summary
Publishes the `:test:logger-usage` project so external plugin repositories can resolve the logger usage checker used by build-tools.

The logger usage precommit plugin already wires external plugin builds to resolve `org.opensearch.test:logger-usage:${opensearch_version}`. This change makes that expected artifact publishable.

## Validation
- `./gradlew :test:logger-usage:publishToMavenLocal -Pcrypto.standard=FIPS-140-3 -Dbuild.snapshot=true`

## Companion PR
Job Scheduler companion: https://github.com/opensearch-project/job-scheduler/pull/933
