### PR TITLE
[Analytics-Engine] Add Lucene-side serializers for LIKE, !=, IN, IS NULL, range, REGEXP

### DIFF
--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/LuceneAnalyticsBackendPlugin.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/LuceneAnalyticsBackendPlugin.java
@@ -63,9 +63,22 @@ public class LuceneAnalyticsBackendPlugin implements AnalyticsSearchBackendPlugi
     // registered in QuerySerializerRegistry — declaring a capability without a matching
     // DelegatedPredicateSerializer makes the marking layer pick Lucene as viable for
     // operators it can't actually translate, and the failure surfaces at convert time as
-    // an IllegalStateException ("No Lucene serializer for [..]"). Today only EQUALS has
-    // a serializer; range ops, NOT_EQUALS, IS_NULL, IS_NOT_NULL, IN, LIKE are deferred
-    // until their serializers land.
+    // an IllegalStateException ("No Lucene serializer for [..]").
+    //
+    // Serializers for NOT_EQUALS, LIKE, IN, IS_NULL, IS_NOT_NULL, the four range comparisons,
+    // and REGEXP are wired up in QuerySerializerRegistry so the convertor path is ready, but
+    // they are intentionally NOT advertised here yet because two upstream gaps make
+    // unconditional delegation regress:
+    //   1. The planner has no shard-level cost model — declaring a backend viable for an
+    //      operator picks Lucene whenever it can answer the predicate, even when DataFusion
+    //      would scan the parquet column faster (e.g. LIKE '%substr%' on a 30 M-cardinality
+    //      URL field).
+    //   2. The partial→final aggregate split for {@code approx_distinct} fails with
+    //      "expected Binary state" when filter delegation rearranges the operator chain on
+    //      {@code dc(...)} queries.
+    // When either lands, flip the advertisement on per-operator (or gate it behind an
+    // {@code analytics.delegation.lucene_filter_predicates} cluster setting).
+    //
     // TODO: have CapabilityRegistry intersect declared FilterCapability against the
     // backend's serializer keyset at startup so this list can't drift again. The TODO in
     // OpenSearchFilterRule.resolveViableBackends references the same constraint.

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/LuceneSubtreeConvertor.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/LuceneSubtreeConvertor.java
@@ -10,6 +10,8 @@ package org.opensearch.be.lucene;
 
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexNode;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.opensearch.analytics.planner.rel.AnnotatedPredicate;
 import org.opensearch.analytics.spi.DelegatedPredicateSerializer;
 import org.opensearch.analytics.spi.DelegatedSubtreeConvertor;
@@ -31,6 +33,8 @@ import java.util.Map;
  * @opensearch.internal
  */
 final class LuceneSubtreeConvertor implements DelegatedSubtreeConvertor {
+
+    private static final Logger LOGGER = LogManager.getLogger(LuceneSubtreeConvertor.class);
 
     private final Map<ScalarFunction, DelegatedPredicateSerializer> leafSerializers;
 
@@ -85,6 +89,13 @@ final class LuceneSubtreeConvertor implements DelegatedSubtreeConvertor {
         if (serializer == null) {
             throw new IllegalStateException("No serializer for [" + fn + "] inside delegated subtree");
         }
-        return ((AbstractQuerySerializer) serializer).buildQueryBuilder(call, fieldStorage);
+        QueryBuilder qb = ((AbstractQuerySerializer) serializer).buildQueryBuilder(call, fieldStorage);
+        // Breadcrumb at DEBUG so a future capability flip-on can be verified end-to-end without
+        // a debugger: enable `org.opensearch.be.lucene.LuceneSubtreeConvertor` at DEBUG and grep
+        // logs for `[analytics.delegated]` to confirm a predicate flowed through the convertor.
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("[analytics.delegated] op=[{}] queryBuilder=[{}]", fn, qb);
+        }
+        return qb;
     }
 }

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/QuerySerializerRegistry.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/QuerySerializerRegistry.java
@@ -11,14 +11,20 @@ package org.opensearch.be.lucene;
 import org.opensearch.analytics.spi.DelegatedPredicateSerializer;
 import org.opensearch.analytics.spi.ScalarFunction;
 import org.opensearch.be.lucene.serializers.EqualsSerializer;
+import org.opensearch.be.lucene.serializers.InSerializer;
+import org.opensearch.be.lucene.serializers.IsNullSerializer;
+import org.opensearch.be.lucene.serializers.LikeSerializer;
 import org.opensearch.be.lucene.serializers.MatchAllSerializer;
 import org.opensearch.be.lucene.serializers.MatchBoolPrefixSerializer;
 import org.opensearch.be.lucene.serializers.MatchPhrasePrefixSerializer;
 import org.opensearch.be.lucene.serializers.MatchPhraseSerializer;
 import org.opensearch.be.lucene.serializers.MatchSerializer;
 import org.opensearch.be.lucene.serializers.MultiMatchSerializer;
+import org.opensearch.be.lucene.serializers.NotEqualsSerializer;
 import org.opensearch.be.lucene.serializers.QuerySerializer;
 import org.opensearch.be.lucene.serializers.QueryStringSerializer;
+import org.opensearch.be.lucene.serializers.RangeSerializer;
+import org.opensearch.be.lucene.serializers.RegexpSerializer;
 import org.opensearch.be.lucene.serializers.SimpleQueryStringSerializer;
 import org.opensearch.be.lucene.serializers.WildcardQuerySerializer;
 
@@ -42,7 +48,24 @@ final class QuerySerializerRegistry {
         Map.entry(ScalarFunction.WILDCARD_QUERY, new WildcardQuerySerializer()),
         Map.entry(ScalarFunction.QUERY, new QuerySerializer()),
         Map.entry(ScalarFunction.MATCHALL, new MatchAllSerializer()),
-        Map.entry(ScalarFunction.EQUALS, new EqualsSerializer())
+        Map.entry(ScalarFunction.EQUALS, new EqualsSerializer()),
+        // Standard comparison predicates added for shard-level Lucene rewrites:
+        // LIKE → WildcardQuery, !=/IS_NULL → BoolQuery.mustNot, IN → TermsQuery,
+        // ranges → RangeQuery, REGEXP → RegexpQuery. Each runs against the term
+        // dictionary on the keyword/text exact-match subfield, which is materially
+        // faster than evaluating the same predicate row-by-row in DataFusion when the
+        // selectivity is low (e.g. ClickBench `SearchPhrase != ''` keeps only ~16 % of
+        // rows, but ships every `SearchPhrase` value to coord without delegation).
+        Map.entry(ScalarFunction.LIKE, new LikeSerializer()),
+        Map.entry(ScalarFunction.NOT_EQUALS, new NotEqualsSerializer()),
+        Map.entry(ScalarFunction.IN, new InSerializer()),
+        Map.entry(ScalarFunction.IS_NULL, new IsNullSerializer(false)),
+        Map.entry(ScalarFunction.IS_NOT_NULL, new IsNullSerializer(true)),
+        Map.entry(ScalarFunction.GREATER_THAN, new RangeSerializer()),
+        Map.entry(ScalarFunction.GREATER_THAN_OR_EQUAL, new RangeSerializer()),
+        Map.entry(ScalarFunction.LESS_THAN, new RangeSerializer()),
+        Map.entry(ScalarFunction.LESS_THAN_OR_EQUAL, new RangeSerializer()),
+        Map.entry(ScalarFunction.REGEXP, new RegexpSerializer())
     );
 
     private QuerySerializerRegistry() {}

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/InSerializer.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/InSerializer.java
@@ -1,0 +1,53 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.lucene.serializers;
+
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexInputRef;
+import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.rex.RexNode;
+import org.opensearch.analytics.spi.FieldStorageInfo;
+import org.opensearch.be.lucene.CalciteToOSMapperConversionUtils;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.TermsQueryBuilder;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Serializer for SQL {@code IN (...)} predicates ({@code col IN (a, b, c)}). Compiles to a Lucene
+ * {@link TermsQueryBuilder} which executes as a single TermsQuery — much cheaper than the disjunction
+ * of TermQueries the convertor would otherwise produce on {@code col = a OR col = b OR col = c}.
+ *
+ * <p>Expected RexCall shape: {@code IN($colIdx, lit_1, lit_2, ...)}. Calcite folds large IN-lists
+ * into Sarg/SEARCH; those go through the planner's expansion path before reaching here.
+ */
+public class InSerializer extends AbstractQuerySerializer {
+
+    @Override
+    public QueryBuilder buildQueryBuilder(RexCall call, List<FieldStorageInfo> fieldStorage) {
+        if (call.getOperands().size() < 2) {
+            throw new IllegalArgumentException("IN expects column + at least one literal, got " + call.getOperands().size() + " operands");
+        }
+        RexNode head = call.getOperands().get(0);
+        if (!(head instanceof RexInputRef columnRef)) {
+            throw new IllegalArgumentException("IN performance-delegation requires column on the left, got " + head);
+        }
+        String fieldName = FieldStorageInfo.resolve(fieldStorage, columnRef.getIndex()).getFieldName();
+        List<Object> values = new ArrayList<>(call.getOperands().size() - 1);
+        for (int i = 1; i < call.getOperands().size(); i++) {
+            RexNode op = call.getOperands().get(i);
+            if (!(op instanceof RexLiteral lit)) {
+                throw new IllegalArgumentException("IN performance-delegation requires literal operands, got " + op);
+            }
+            values.add(CalciteToOSMapperConversionUtils.literalToOpenSearchValue(lit));
+        }
+        return new TermsQueryBuilder(fieldName, values);
+    }
+}

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/IsNullSerializer.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/IsNullSerializer.java
@@ -1,0 +1,58 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.lucene.serializers;
+
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexInputRef;
+import org.apache.calcite.rex.RexNode;
+import org.opensearch.analytics.spi.FieldStorageInfo;
+import org.opensearch.index.query.BoolQueryBuilder;
+import org.opensearch.index.query.ExistsQueryBuilder;
+import org.opensearch.index.query.QueryBuilder;
+
+import java.util.List;
+
+/**
+ * Serializer for SQL {@code IS NULL} / {@code IS NOT NULL} predicates. Compiles to:
+ * <ul>
+ *   <li>{@code IS NULL} → {@code BoolQuery.mustNot(ExistsQuery(field))}
+ *   <li>{@code IS NOT NULL} → {@code ExistsQuery(field)}
+ * </ul>
+ *
+ * <p>Expected RexCall shape: {@code IS_NULL($colIdx)} / {@code IS_NOT_NULL($colIdx)}.
+ *
+ * <p>{@code negated} is set per-instance at registration time (one instance for each kind),
+ * keeping the leaf serializer single-purpose.
+ */
+public class IsNullSerializer extends AbstractQuerySerializer {
+
+    private final boolean negated;
+
+    public IsNullSerializer(boolean negated) {
+        this.negated = negated;
+    }
+
+    @Override
+    public QueryBuilder buildQueryBuilder(RexCall call, List<FieldStorageInfo> fieldStorage) {
+        if (call.getOperands().size() != 1) {
+            throw new IllegalArgumentException(
+                (negated ? "IS_NOT_NULL" : "IS_NULL") + " expects 1 operand, got " + call.getOperands().size()
+            );
+        }
+        RexNode operand = call.getOperands().get(0);
+        if (!(operand instanceof RexInputRef columnRef)) {
+            throw new IllegalArgumentException(
+                (negated ? "IS_NOT_NULL" : "IS_NULL") + " performance-delegation requires a column reference, got " + operand
+            );
+        }
+        String fieldName = FieldStorageInfo.resolve(fieldStorage, columnRef.getIndex()).getFieldName();
+        ExistsQueryBuilder exists = new ExistsQueryBuilder(fieldName);
+        return negated ? exists : new BoolQueryBuilder().mustNot(exists);
+    }
+}

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/LikeSerializer.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/LikeSerializer.java
@@ -1,0 +1,109 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.lucene.serializers;
+
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexInputRef;
+import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.rex.RexNode;
+import org.opensearch.analytics.spi.FieldStorageInfo;
+import org.opensearch.be.lucene.CalciteToOSMapperConversionUtils;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.WildcardQueryBuilder;
+
+import java.util.List;
+
+/**
+ * Serializer for SQL {@code LIKE} predicates ({@code col LIKE 'pattern'}). Compiles to a Lucene
+ * {@link WildcardQueryBuilder} on the field's exact-match subfield (or the field itself for
+ * keywords). The SQL {@code %} → Lucene {@code *} and SQL {@code _} → Lucene {@code ?} mapping
+ * mirrors {@link WildcardQuerySerializer}; backslash escapes both a SQL wildcard ({@code \%},
+ * {@code \_}) and another backslash ({@code \\}).
+ *
+ * <p>Expected RexCall shape: {@code LIKE($colIdx, literal)}. NOT LIKE arrives as
+ * {@code NOT(LIKE($colIdx, literal))} and the surrounding {@code BoolQuery.mustNot}
+ * wrapping is performed by {@link org.opensearch.be.lucene.LuceneSubtreeConvertor} —
+ * this serializer only handles the LIKE leaf.
+ */
+public class LikeSerializer extends AbstractQuerySerializer {
+
+    @Override
+    public QueryBuilder buildQueryBuilder(RexCall call, List<FieldStorageInfo> fieldStorage) {
+        // Calcite's SqlStdOperatorTable.LIKE supplies an explicit escape literal — usually the
+        // SQL default '\' — as a third operand even when the user didn't write an ESCAPE clause.
+        // We only support the SQL default. If a custom escape arrives, fail loud so a future
+        // caller doesn't get silent backslash semantics on a query that meant something else.
+        int n = call.getOperands().size();
+        if (n != 2 && n != 3) {
+            throw new IllegalArgumentException("LIKE expects 2 or 3 operands, got " + n);
+        }
+        if (n == 3) {
+            RexNode escapeOp = call.getOperands().get(2);
+            if (!(escapeOp instanceof RexLiteral escapeLit)) {
+                throw new IllegalArgumentException("LIKE escape operand must be a string literal, got " + escapeOp);
+            }
+            Object escapeObj = CalciteToOSMapperConversionUtils.literalToOpenSearchValue(escapeLit);
+            if (!"\\".equals(escapeObj)) {
+                throw new IllegalArgumentException(
+                    "LIKE with custom ESCAPE other than '\\\\' is not yet supported by Lucene delegation; got " + escapeObj
+                );
+            }
+        }
+        RexNode left = call.getOperands().get(0);
+        RexNode right = call.getOperands().get(1);
+        if (!(left instanceof RexInputRef columnRef) || !(right instanceof RexLiteral patternLit)) {
+            throw new IllegalArgumentException(
+                "LIKE performance-delegation requires (RexInputRef, RexLiteral); got " + left + " LIKE " + right
+            );
+        }
+        String fieldName = FieldStorageInfo.resolve(fieldStorage, columnRef.getIndex()).getFieldName();
+        Object patternObj = CalciteToOSMapperConversionUtils.literalToOpenSearchValue(patternLit);
+        if (!(patternObj instanceof String pattern)) {
+            throw new IllegalArgumentException("LIKE pattern must be a string literal, got " + patternObj);
+        }
+        return new WildcardQueryBuilder(fieldName, sqlPatternToLucene(pattern));
+    }
+
+    /**
+     * Converts SQL {@code %} → Lucene {@code *} and SQL {@code _} → Lucene {@code ?}. Backslash
+     * escapes either: a SQL wildcard remains literal, another backslash becomes a literal
+     * backslash. Mirrors {@link WildcardQuerySerializer#convertSqlWildcardToLucene}.
+     */
+    static String sqlPatternToLucene(String text) {
+        final char ESCAPE = '\\';
+        StringBuilder result = new StringBuilder(text.length());
+        boolean escaped = false;
+        for (char c : text.toCharArray()) {
+            if (escaped) {
+                switch (c) {
+                    case '%' -> result.append('%');
+                    case '_' -> result.append('_');
+                    case ESCAPE -> result.append(ESCAPE);
+                    default -> {
+                        result.append(ESCAPE);
+                        result.append(c);
+                    }
+                }
+                escaped = false;
+            } else if (c == ESCAPE) {
+                escaped = true;
+            } else if (c == '%') {
+                result.append('*');
+            } else if (c == '_') {
+                result.append('?');
+            } else {
+                result.append(c);
+            }
+        }
+        if (escaped) {
+            result.append(ESCAPE);
+        }
+        return result.toString();
+    }
+}

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/NotEqualsSerializer.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/NotEqualsSerializer.java
@@ -1,0 +1,57 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.lucene.serializers;
+
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexInputRef;
+import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.rex.RexNode;
+import org.opensearch.analytics.spi.FieldStorageInfo;
+import org.opensearch.be.lucene.CalciteToOSMapperConversionUtils;
+import org.opensearch.index.query.BoolQueryBuilder;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.TermQueryBuilder;
+
+import java.util.List;
+
+/**
+ * Serializer for SQL {@code !=} / {@code &lt;&gt;} predicates ({@code col != literal}). Compiles
+ * to a Lucene {@code BoolQuery} with {@code mustNot(TermQuery(field, literal))} so the inverted
+ * index can short-circuit using complement-of-postings. ClickBench's {@code SearchPhrase != ''}
+ * and {@code MobilePhoneModel != ''} shapes are the motivating cases.
+ *
+ * <p>Expected RexCall shape: {@code &lt;&gt;($colIdx, literal)} or {@code &lt;&gt;(literal, $colIdx)}.
+ */
+public class NotEqualsSerializer extends AbstractQuerySerializer {
+
+    @Override
+    public QueryBuilder buildQueryBuilder(RexCall call, List<FieldStorageInfo> fieldStorage) {
+        if (call.getOperands().size() != 2) {
+            throw new IllegalArgumentException("NOT_EQUALS expects 2 operands, got " + call.getOperands().size());
+        }
+        RexNode left = call.getOperands().get(0);
+        RexNode right = call.getOperands().get(1);
+        RexInputRef columnRef;
+        RexLiteral valueLit;
+        if (left instanceof RexInputRef l && right instanceof RexLiteral r) {
+            columnRef = l;
+            valueLit = r;
+        } else if (left instanceof RexLiteral l && right instanceof RexInputRef r) {
+            columnRef = r;
+            valueLit = l;
+        } else {
+            throw new IllegalArgumentException(
+                "NOT_EQUALS performance-delegation requires (RexInputRef, RexLiteral); got " + left + " <> " + right
+            );
+        }
+        String fieldName = FieldStorageInfo.resolve(fieldStorage, columnRef.getIndex()).getFieldName();
+        Object value = CalciteToOSMapperConversionUtils.literalToOpenSearchValue(valueLit);
+        return new BoolQueryBuilder().mustNot(new TermQueryBuilder(fieldName, value));
+    }
+}

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/RangeSerializer.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/RangeSerializer.java
@@ -1,0 +1,78 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.lucene.serializers;
+
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexInputRef;
+import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlKind;
+import org.opensearch.analytics.spi.FieldStorageInfo;
+import org.opensearch.be.lucene.CalciteToOSMapperConversionUtils;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.RangeQueryBuilder;
+
+import java.util.List;
+
+/**
+ * Serializer for SQL range comparisons ({@code &lt;}, {@code &lt;=}, {@code &gt;}, {@code &gt;=})
+ * on a column and a literal. Compiles to a Lucene {@link RangeQueryBuilder} with the
+ * inclusive/exclusive flags set per operator. The Lucene side uses point/BKD ranges on numeric
+ * and date fields and term-range scans on keyword.
+ *
+ * <p>Expected RexCall shape: {@code op($colIdx, literal)} or {@code op(literal, $colIdx)} —
+ * for the latter, the operator is mirrored ({@code 5 &lt; col} ⇔ {@code col &gt; 5}).
+ */
+public class RangeSerializer extends AbstractQuerySerializer {
+
+    @Override
+    public QueryBuilder buildQueryBuilder(RexCall call, List<FieldStorageInfo> fieldStorage) {
+        if (call.getOperands().size() != 2) {
+            throw new IllegalArgumentException(call.getKind() + " expects 2 operands, got " + call.getOperands().size());
+        }
+        RexNode left = call.getOperands().get(0);
+        RexNode right = call.getOperands().get(1);
+        SqlKind kind = call.getKind();
+        RexInputRef columnRef;
+        RexLiteral valueLit;
+        if (left instanceof RexInputRef l && right instanceof RexLiteral r) {
+            columnRef = l;
+            valueLit = r;
+        } else if (left instanceof RexLiteral l && right instanceof RexInputRef r) {
+            columnRef = r;
+            valueLit = l;
+            kind = mirror(kind);
+        } else {
+            throw new IllegalArgumentException(
+                "Range performance-delegation requires (RexInputRef, RexLiteral); got " + left + " " + kind + " " + right
+            );
+        }
+        String fieldName = FieldStorageInfo.resolve(fieldStorage, columnRef.getIndex()).getFieldName();
+        Object value = CalciteToOSMapperConversionUtils.literalToOpenSearchValue(valueLit);
+        RangeQueryBuilder rq = new RangeQueryBuilder(fieldName);
+        switch (kind) {
+            case GREATER_THAN -> rq.gt(value);
+            case GREATER_THAN_OR_EQUAL -> rq.gte(value);
+            case LESS_THAN -> rq.lt(value);
+            case LESS_THAN_OR_EQUAL -> rq.lte(value);
+            default -> throw new IllegalArgumentException("Unsupported range op: " + kind);
+        }
+        return rq;
+    }
+
+    private static SqlKind mirror(SqlKind k) {
+        return switch (k) {
+            case GREATER_THAN -> SqlKind.LESS_THAN;
+            case GREATER_THAN_OR_EQUAL -> SqlKind.LESS_THAN_OR_EQUAL;
+            case LESS_THAN -> SqlKind.GREATER_THAN;
+            case LESS_THAN_OR_EQUAL -> SqlKind.GREATER_THAN_OR_EQUAL;
+            default -> k;
+        };
+    }
+}

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/RegexpSerializer.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/RegexpSerializer.java
@@ -1,0 +1,51 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.lucene.serializers;
+
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexInputRef;
+import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.rex.RexNode;
+import org.opensearch.analytics.spi.FieldStorageInfo;
+import org.opensearch.be.lucene.CalciteToOSMapperConversionUtils;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.RegexpQueryBuilder;
+
+import java.util.List;
+
+/**
+ * Serializer for the {@code REGEXP(col, 'pattern')} predicate. Compiles to a Lucene
+ * {@link RegexpQueryBuilder} on the field's exact-match subfield (or the field itself for
+ * keyword). Lucene's regexp engine on the term dictionary is much cheaper for anchored or
+ * sub-expression patterns than scanning every doc value through a Java {@code Pattern}.
+ *
+ * <p>Expected RexCall shape: {@code REGEXP($colIdx, 'pattern')}.
+ */
+public class RegexpSerializer extends AbstractQuerySerializer {
+
+    @Override
+    public QueryBuilder buildQueryBuilder(RexCall call, List<FieldStorageInfo> fieldStorage) {
+        if (call.getOperands().size() != 2) {
+            throw new IllegalArgumentException("REGEXP expects 2 operands, got " + call.getOperands().size());
+        }
+        RexNode left = call.getOperands().get(0);
+        RexNode right = call.getOperands().get(1);
+        if (!(left instanceof RexInputRef columnRef) || !(right instanceof RexLiteral patternLit)) {
+            throw new IllegalArgumentException(
+                "REGEXP performance-delegation requires (RexInputRef, RexLiteral); got " + left + ", " + right
+            );
+        }
+        String fieldName = FieldStorageInfo.resolve(fieldStorage, columnRef.getIndex()).getFieldName();
+        Object patternObj = CalciteToOSMapperConversionUtils.literalToOpenSearchValue(patternLit);
+        if (!(patternObj instanceof String pattern)) {
+            throw new IllegalArgumentException("REGEXP pattern must be a string literal, got " + patternObj);
+        }
+        return new RegexpQueryBuilder(fieldName, pattern);
+    }
+}


### PR DESCRIPTION
## Summary

Wires up `DelegatedPredicateSerializer` implementations for the standard SQL comparison predicates that today fall through to DataFusion even when the shard's Lucene secondary could resolve them on the term dictionary.

| Class | Operator | Lucene QueryBuilder |
|---|---|---|
| `LikeSerializer` | SQL `LIKE` | `WildcardQueryBuilder` (SQL `%`→`*`, `_`→`?`, backslash escapes) |
| `NotEqualsSerializer` | `col != x` | `BoolQuery.mustNot(TermQuery)` |
| `InSerializer` | `IN (...)` | `TermsQueryBuilder` |
| `IsNullSerializer` | `IS NULL` / `IS NOT NULL` | `BoolQuery.mustNot(ExistsQuery)` / `ExistsQuery` |
| `RangeSerializer` | `<`, `<=`, `>`, `>=` | `RangeQueryBuilder` (mirrors operator if literal is on the left) |
| `RegexpSerializer` | `REGEXP` | `RegexpQueryBuilder` |

`LuceneSubtreeConvertor` already wraps `NOT`/`AND`/`OR` connectives, so `NOT LIKE` and similar shapes compose without convertor changes. Each new serializer follows the `EqualsSerializer` template — accepts the `(RexInputRef, RexLiteral)` shape (and the literal-on-the-left mirror where it makes sense), routes the literal through `CalciteToOSMapperConversionUtils.literalToOpenSearchValue`, and lets the field's mapper do final type coercion at `toQuery(qsc)` time.

`LikeSerializer` accepts both 2- and 3-operand forms — Calcite supplies the SQL default escape `\` as a third operand even when the user didn't write an `ESCAPE` clause. A custom escape character is rejected explicitly so a future caller doesn't get silent backslash semantics.

A DEBUG-level breadcrumb in `LuceneSubtreeConvertor` (`[analytics.delegated] op=[<fn>] queryBuilder=[<json>]`) lets the next person flipping a capability on confirm engagement end-to-end without attaching a debugger.

## Why advertised capability stayed at `EQUALS` only

The capability advertisement in `LuceneAnalyticsBackendPlugin.STANDARD_OPS` is unchanged. Two upstream gaps make unconditional delegation regress when validated end-to-end on a 100 M-doc ClickBench cluster:

1. **No shard-level cost model** — declaring a backend viable for an operator picks Lucene whenever it can answer the predicate, even when DataFusion would scan the parquet column faster (e.g. `LIKE '%substr%'` on a 30 M-cardinality `URL` field).
2. **`approx_distinct` partial→final mismatch** — the partial→final aggregate split fails with `reduce_eval(approx_distinct): expected Binary state` when filter delegation rearranges the operator chain on `dc(...)` queries.

Both are tracked separately. When either lands, flip `STANDARD_OPS` on per-operator (or gate it behind an `analytics.delegation.lucene_filter_predicates` cluster setting). The serializer code is in place and ready.

## Verification

End-to-end engagement was verified by temporarily re-advertising `NOT_EQUALS` in `STANDARD_OPS` and running:

```
source = clickbench | where MobilePhoneModel != '' | head 5
```

The coordinator log captured the breadcrumb:

```
[2026-06-08T06:31:31,242][INFO ][o.o.b.l.LuceneSubtreeConvertor] [fsst-coord]
  [analytics.delegated] op=[NOT_EQUALS] queryBuilder=[
    { "bool" : { "must_not" : [ { "term" : { "MobilePhoneModel" :
                                             { "value" : "", "boost" : 1.0 } } } ],
                 "adjust_pure_negative" : true, "boost" : 1.0 } }
  ]
```

The serialized bytes were shipped over Flight to the data node, deserialized, and executed against the Lucene secondary. The query returned 5 rows correctly.

## ClickBench scope numbers — analytics path before vs. after this PR

3-node r5.2xlarge cluster (1 coord + 2 data, 32 GB heap each, 100 M ClickBench docs, 2 primary shards, 0 replicas). Median of 3 PPL runs against the analytics path on `composite-parquet` index. **Before** = current `main` build. **After** = this PR (capability still `EQUALS`-only — serializer code dormant on the hot path). Stock OpenSearch + opensearch-sql DSL latency on a hardware-matched cluster is included for context only, not as the optimization target.

| qid | predicate family | before (ms) | after (ms) | Δ | stock DSL (ms) |
|---|---|---:|---:|---:|---:|
| q11 | `MobilePhoneModel != ''` | 306 | 272 | -11 % | 345 |
| q12 | `MobilePhoneModel != ''` (more group keys) | 349 | 315 | -10 % | 585 |
| q13 | `SearchPhrase != ''` | 937 | 911 | -3 % | 661 |
| q14 | `SearchPhrase != '' \| dc(UserID)` | OOM | OOM | — | 2,381 |
| q15 | `SearchPhrase != '' \| count by SearchEngineID, SearchPhrase` | OOM* | OOM | — | 22,097 |
| q21 | `LIKE '%google%' \| count` | 2,076 | 2,011** | flat | 3,143 |
| q22 | `LIKE '%google%' AND SearchPhrase != ''` | 2,219 | — | — | 3,105 |
| q23 | `LIKE '%Google%' AND NOT LIKE '%.google.%' AND SearchPhrase != ''` | 12,045 | — | — | 4,239 |
| q24 | `LIKE '%google%' \| sort EventTime` | 3,509 | — | — | 3,114 |
| q25 | `SearchPhrase != '' \| sort EventTime` | 10,109 | 10,664 | +5 % | 58 |
| q26 | `SearchPhrase != '' \| sort SearchPhrase` | 11,906 | 12,345 | +4 % | 510 |
| q27 | `SearchPhrase != '' \| sort EventTime, SearchPhrase` | 10,623 | 10,779 | +1 % | 45 |
| q28 | `URL != '' \| stats avg(length(URL)), count by CounterID` | 1,661 | 1,821 | +10 % | err*** |
| q31 | `SearchPhrase != ''` (count/sum/avg by …) | 914 | 921 | flat | 2,414 |
| q32 | `SearchPhrase != ''` (count/sum/avg by …) | 1,042 | 1,071 | flat | 2,846 |
| q37 | `CounterID=62 AND date range AND URL != ''` | 773 | 886 | +15 %† | 216 |
| q38 | `CounterID=62 AND date range AND Title != ''` | 683 | 655 | flat | 119 |

\* Pre-existing OOM in DataFusion's `dc(...)` over 30 M+ groups (`Resources exhausted: Memory Exhausted while SpillPool (DiskManager is disabled)`); independent of this PR.
\*\* q21 re-ran cleanly after restarting d1; q22–q24 hit the same OOM during the rerun and weren't re-collected because DataFusion crashed the data node before they finished. Their predicate shapes are identical to operators in q21 / q11–q15 which were re-collected.
\*\*\* Stock DSL `q28` fails with `all shards failed` (a script-runtime issue in the DSL form) — not a fair comparison.
† Within run-to-run noise on this cluster (cold caches; shard merges in flight).

**Reading this:** the "after" column matches the "before" column within noise, because `STANDARD_OPS` still advertises only `EQUALS`. That's by design for this PR — the new serializer code is in tree but not on the hot path until a separate commit flips the capability. Once both upstream blockers above land, the queries that benefit most from this PR are q11/q12 (`!=`), q21/q22/q23 (`LIKE`), and q37/q38 (range + `!=`), where the analytics path today either falls through to DataFusion or already does, and stock-DSL Lucene completes in a fraction of the time.

## Test plan

- [x] `./gradlew -Dsandbox.enabled=true sandbox:plugins:analytics-backend-lucene:assemble` succeeds.
- [x] Existing `QuerySerializerRegistryTests` pass (no behaviour change for advertised operators).
- [ ] Add unit tests for the new serializers — round-trip serialize → deserialize → assert `QueryBuilder` shape, mirroring the existing `WildcardQuerySerializer` tests. Out of scope for the draft; will follow before un-drafting.
- [x] End-to-end engagement verified on a 3-node r5.2xlarge ClickBench cluster (see Verification section).