### PR TITLE
Fix support for != in search command and Date Nanos support

### DIFF
--- a/sandbox/libs/analytics-api/src/main/java/org/opensearch/analytics/schema/OpenSearchSchemaBuilder.java
+++ b/sandbox/libs/analytics-api/src/main/java/org/opensearch/analytics/schema/OpenSearchSchemaBuilder.java
@@ -253,14 +253,22 @@ public class OpenSearchSchemaBuilder {
         if (sqlType == null) {
             return null;
         }
-        // date / date_nanos both map to TIMESTAMP, but their sub-second precision differs and must
-        // be carried on the Calcite type (fractional-seconds digits): date → millis (3), date_nanos
-        // → nanos (9). Without an explicit precision, createSqlType(TIMESTAMP) defaults to 0, which
-        // downstream lowers to Timestamp(Second)→Millisecond; the parquet read of a date_nanos field
-        // then produces Timestamp(Nanosecond), and the reduce-stage RowConverter rejects the mismatch.
+        // TIMESTAMP must carry sub-second precision: date → millis (3), date_nanos → nanos (9).
+        // Without it the type defaults to precision 0 (→ millis downstream) and clashes with the
+        // parquet read's Timestamp(Nanosecond) for date_nanos. Switch (not default) so an unforeseen
+        // type mapping to TIMESTAMP fails loudly rather than silently inheriting 3.
         RelDataType base;
         if (sqlType == SqlTypeName.TIMESTAMP) {
-            int precision = "date_nanos".equals(opensearchType) ? 9 : 3;
+            int precision = switch (opensearchType) {
+                case "date" -> 3;
+                case "date_nanos" -> 9;
+                default -> throw new IllegalStateException(
+                    "OpenSearch type '"
+                        + opensearchType
+                        + "' maps to TIMESTAMP but has no declared sub-second "
+                        + "precision; add a case in buildLeafType"
+                );
+            };
             base = typeFactory.createSqlType(sqlType, precision);
         } else {
             base = typeFactory.createSqlType(sqlType);

--- a/sandbox/libs/analytics-api/src/main/java/org/opensearch/analytics/schema/OpenSearchSchemaBuilder.java
+++ b/sandbox/libs/analytics-api/src/main/java/org/opensearch/analytics/schema/OpenSearchSchemaBuilder.java
@@ -253,7 +253,19 @@ public class OpenSearchSchemaBuilder {
         if (sqlType == null) {
             return null;
         }
-        return typeFactory.createTypeWithNullability(typeFactory.createSqlType(sqlType), true);
+        // date / date_nanos both map to TIMESTAMP, but their sub-second precision differs and must
+        // be carried on the Calcite type (fractional-seconds digits): date → millis (3), date_nanos
+        // → nanos (9). Without an explicit precision, createSqlType(TIMESTAMP) defaults to 0, which
+        // downstream lowers to Timestamp(Second)→Millisecond; the parquet read of a date_nanos field
+        // then produces Timestamp(Nanosecond), and the reduce-stage RowConverter rejects the mismatch.
+        RelDataType base;
+        if (sqlType == SqlTypeName.TIMESTAMP) {
+            int precision = "date_nanos".equals(opensearchType) ? 9 : 3;
+            base = typeFactory.createSqlType(sqlType, precision);
+        } else {
+            base = typeFactory.createSqlType(sqlType);
+        }
+        return typeFactory.createTypeWithNullability(base, true);
     }
 
     private static AbstractTable buildTable(Map<String, Object> properties) {

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/LuceneFilterDelegationHandle.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/LuceneFilterDelegationHandle.java
@@ -104,7 +104,10 @@ final class LuceneFilterDelegationHandle implements FilterDelegationHandle {
                 StreamInput rawInput = StreamInput.wrap(expr.getExpressionBytes());
                 StreamInput input = new NamedWriteableAwareStreamInput(rawInput, registry);
                 QueryBuilder queryBuilder = input.readNamedWriteable(QueryBuilder.class);
-                Query query = queryBuilder.toQuery(context);
+                // Rewrite FieldExistsQuery → a postings-only equivalent: the lucene-secondary segment
+                // has no doc_values/norms (they live in the parquet primary), so a FieldExistsQuery
+                // built from an _exists_ clause (PPL `search field!=value`) would throw at rewrite().
+                Query query = LuceneQueryConversionUtils.rewriteFieldExistsForSecondary(queryBuilder.toQuery(context));
                 queries.put(expr.getAnnotationId(), query);
             } catch (IOException exception) {
                 throw new IllegalStateException(

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/LuceneQueryConversionUtils.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/LuceneQueryConversionUtils.java
@@ -8,7 +8,6 @@
 
 package org.opensearch.be.lucene;
 
-import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.BoostQuery;
@@ -111,21 +110,20 @@ public final class LuceneQueryConversionUtils {
     static boolean containsFieldExists(Query query) {
         boolean[] found = { false };
         query.visit(new QueryVisitor() {
+            // FieldExistsQuery reports itself only via visitLeaf, gated by acceptField.
+            @Override
+            public boolean acceptField(String field) {
+                return true;
+            }
+
             @Override
             public QueryVisitor getSubVisitor(BooleanClause.Occur occur, Query parent) {
-                return this; // descend into every clause regardless of occur
+                return this;
             }
 
             @Override
             public void visitLeaf(Query leaf) {
                 if (leaf instanceof FieldExistsQuery) {
-                    found[0] = true;
-                }
-            }
-
-            @Override
-            public void consumeTerms(Query q, Term... terms) {
-                if (q instanceof FieldExistsQuery) {
                     found[0] = true;
                 }
             }

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/LuceneQueryConversionUtils.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/LuceneQueryConversionUtils.java
@@ -1,0 +1,135 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.lucene;
+
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.BoostQuery;
+import org.apache.lucene.search.ConstantScoreQuery;
+import org.apache.lucene.search.DisjunctionMaxQuery;
+import org.apache.lucene.search.FieldExistsQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.QueryVisitor;
+import org.apache.lucene.search.TermRangeQuery;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Helpers for adapting Lucene {@link Query} trees so they can execute against the
+ * <b>lucene-secondary</b> segment of a composite parquet-primary index.
+ *
+ * <p>The secondary segment stores only the inverted index (postings) for keyword / text /
+ * match_only_text fields — their doc_values live in the parquet primary. Some queries that
+ * OpenSearch builds assume doc_values are present on the same segment they execute against;
+ * those need rewriting to a postings-only equivalent here.
+ */
+public final class LuceneQueryConversionUtils {
+
+    private LuceneQueryConversionUtils() {}
+
+    /**
+     * Rewrite every {@link FieldExistsQuery} in {@code query} to a postings-only existence query.
+     *
+     * <p><b>Why:</b> {@code MappedFieldType.existsQuery} emits a {@link FieldExistsQuery} whenever
+     * the mapping declares doc_values. On the secondary segment those doc_values are absent, and
+     * {@code FieldExistsQuery.rewrite()} throws ("indexes neither doc values, norms nor vectors").
+     * A {@link TermRangeQuery} with null bounds matches any doc that has ≥1 indexed term for the
+     * field — semantically equivalent to "field exists" for the postings-indexed keyword/text/
+     * match_only_text types that filter delegation supports.
+     *
+     * <p>This reaches us via the {@code query_string} the PPL {@code search} command compiles for
+     * {@code !=} / {@code NOT} / {@code _exists_} (e.g. {@code "_exists_:f AND NOT f:v"}). The
+     * {@code QueryStringQueryParser} can nest the {@link FieldExistsQuery} under Boolean (AND/OR/NOT),
+     * ConstantScore, Boost, or DisjunctionMax (multi-field) wrappers, so we recurse through all of
+     * them and rebuild only the branches that changed (reference-equality short-circuit). Any other
+     * container that still hides a {@link FieldExistsQuery} fails fast with an actionable message
+     * rather than the cryptic Lucene error at {@code searcher.rewrite()}.
+     *
+     * <p><b>Interim:</b> the clean long-term fix is for the secondary to read doc_values out of the
+     * parquet primary, after which {@link FieldExistsQuery} resolves natively and this rewrite can
+     * be deleted.
+     *
+     * @param query the compiled Lucene query (non-null)
+     * @return an equivalent query with all {@link FieldExistsQuery}s rewritten; the same instance
+     *         when nothing changed
+     */
+    public static Query rewriteFieldExistsForSecondary(Query query) {
+        if (query instanceof FieldExistsQuery fieldExists) {
+            // null lower/upper bound = unbounded both ends = "any term present for this field".
+            return new TermRangeQuery(fieldExists.getField(), null, null, true, true);
+        }
+        if (query instanceof ConstantScoreQuery constantScore) {
+            Query inner = rewriteFieldExistsForSecondary(constantScore.getQuery());
+            return inner == constantScore.getQuery() ? constantScore : new ConstantScoreQuery(inner);
+        }
+        if (query instanceof BoostQuery boost) {
+            Query inner = rewriteFieldExistsForSecondary(boost.getQuery());
+            return inner == boost.getQuery() ? boost : new BoostQuery(inner, boost.getBoost());
+        }
+        if (query instanceof BooleanQuery bool) {
+            BooleanQuery.Builder builder = new BooleanQuery.Builder();
+            builder.setMinimumNumberShouldMatch(bool.getMinimumNumberShouldMatch());
+            boolean changed = false;
+            for (BooleanClause clause : bool.clauses()) {
+                Query rewritten = rewriteFieldExistsForSecondary(clause.query());
+                changed |= rewritten != clause.query();
+                builder.add(rewritten, clause.occur());
+            }
+            return changed ? builder.build() : bool;
+        }
+        if (query instanceof DisjunctionMaxQuery disjunctionMax) {
+            List<Query> rewritten = new ArrayList<>(disjunctionMax.getDisjuncts().size());
+            boolean changed = false;
+            for (Query disjunct : disjunctionMax.getDisjuncts()) {
+                Query r = rewriteFieldExistsForSecondary(disjunct);
+                changed |= r != disjunct;
+                rewritten.add(r);
+            }
+            return changed ? new DisjunctionMaxQuery(rewritten, disjunctionMax.getTieBreakerMultiplier()) : disjunctionMax;
+        }
+        if (containsFieldExists(query)) {
+            throw new IllegalStateException(
+                "Unhandled query container wrapping a FieldExistsQuery on a doc-values-less secondary "
+                    + "segment; rewriteFieldExistsForSecondary must cover "
+                    + query.getClass().getName()
+                    + ": "
+                    + query
+            );
+        }
+        return query;
+    }
+
+    /** True if {@code query} contains a {@link FieldExistsQuery} anywhere in its subtree. */
+    static boolean containsFieldExists(Query query) {
+        boolean[] found = { false };
+        query.visit(new QueryVisitor() {
+            @Override
+            public QueryVisitor getSubVisitor(BooleanClause.Occur occur, Query parent) {
+                return this; // descend into every clause regardless of occur
+            }
+
+            @Override
+            public void visitLeaf(Query leaf) {
+                if (leaf instanceof FieldExistsQuery) {
+                    found[0] = true;
+                }
+            }
+
+            @Override
+            public void consumeTerms(Query q, Term... terms) {
+                if (q instanceof FieldExistsQuery) {
+                    found[0] = true;
+                }
+            }
+        });
+        return found[0];
+    }
+}

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/LuceneScanInstructionHandler.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/LuceneScanInstructionHandler.java
@@ -90,7 +90,10 @@ final class LuceneScanInstructionHandler implements FragmentInstructionHandler<S
             if (hasFilter) {
                 QueryShardContext qsc = LuceneAnalyticsBackendPlugin.buildMinimalQueryShardContext(shardCtx, searcher);
                 QueryBuilder queryBuilder = input.readNamedWriteable(QueryBuilder.class);
-                filterQuery = queryBuilder.toQuery(qsc);
+                // Rewrite FieldExistsQuery → postings-only equivalent for the doc-values-less
+                // lucene-secondary segment (same reason as the filter-delegation path). This covers
+                // the Lucene-driver scan path (count + non-count) executed by LuceneSearchExecEngine.
+                filterQuery = LuceneQueryConversionUtils.rewriteFieldExistsForSecondary(queryBuilder.toQuery(qsc));
             } else {
                 filterQuery = new MatchAllDocsQuery();
             }

--- a/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/LuceneQueryConversionUtilsTests.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/LuceneQueryConversionUtilsTests.java
@@ -1,0 +1,121 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.lucene;
+
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.BoostQuery;
+import org.apache.lucene.search.ConstantScoreQuery;
+import org.apache.lucene.search.DisjunctionMaxQuery;
+import org.apache.lucene.search.FieldExistsQuery;
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.search.TermRangeQuery;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.List;
+
+/**
+ * Unit tests for {@link LuceneQueryConversionUtils#rewriteFieldExistsForSecondary} — the
+ * interim rewrite that turns {@link FieldExistsQuery} (needs doc_values/norms, absent on the
+ * lucene-secondary segment) into a postings-only {@link TermRangeQuery}.
+ */
+public class LuceneQueryConversionUtilsTests extends OpenSearchTestCase {
+
+    private static FieldExistsQuery exists(String field) {
+        return new FieldExistsQuery(field);
+    }
+
+    /** A TermRangeQuery over {@code field} with both bounds null = "any term present". */
+    private static void assertExistsRewrite(Query rewritten, String field) {
+        assertThat(rewritten, instanceOf(TermRangeQuery.class));
+        TermRangeQuery trq = (TermRangeQuery) rewritten;
+        assertEquals(field, trq.getField());
+        assertNull("lower bound should be unbounded", trq.getLowerTerm());
+        assertNull("upper bound should be unbounded", trq.getUpperTerm());
+    }
+
+    public void testBareFieldExistsIsRewritten() {
+        assertExistsRewrite(LuceneQueryConversionUtils.rewriteFieldExistsForSecondary(exists("severityText")), "severityText");
+    }
+
+    public void testFieldExistsUnderConstantScore() {
+        Query in = new ConstantScoreQuery(exists("f"));
+        Query out = LuceneQueryConversionUtils.rewriteFieldExistsForSecondary(in);
+        assertThat(out, instanceOf(ConstantScoreQuery.class));
+        assertExistsRewrite(((ConstantScoreQuery) out).getQuery(), "f");
+    }
+
+    public void testFieldExistsUnderBoost() {
+        Query in = new BoostQuery(exists("f"), 2.0f);
+        Query out = LuceneQueryConversionUtils.rewriteFieldExistsForSecondary(in);
+        assertThat(out, instanceOf(BoostQuery.class));
+        assertEquals(2.0f, ((BoostQuery) out).getBoost(), 0.0f);
+        assertExistsRewrite(((BoostQuery) out).getQuery(), "f");
+    }
+
+    /** The q19/search shape: "_exists_:f AND NOT f:v" → Boolean{MUST exists, MUST_NOT term}. */
+    public void testFieldExistsUnderBooleanAndNot() {
+        BooleanQuery in = new BooleanQuery.Builder().add(exists("severityText"), BooleanClause.Occur.MUST)
+            .add(new TermQuery(new Term("severityText", "INFO")), BooleanClause.Occur.MUST_NOT)
+            .build();
+        Query out = LuceneQueryConversionUtils.rewriteFieldExistsForSecondary(in);
+        assertThat(out, instanceOf(BooleanQuery.class));
+        BooleanQuery bool = (BooleanQuery) out;
+        assertEquals(2, bool.clauses().size());
+        for (BooleanClause clause : bool.clauses()) {
+            if (clause.occur() == BooleanClause.Occur.MUST) {
+                assertExistsRewrite(clause.query(), "severityText");
+            } else {
+                assertThat(clause.query(), instanceOf(TermQuery.class)); // untouched
+            }
+        }
+    }
+
+    public void testFieldExistsUnderDisjunctionMax() {
+        DisjunctionMaxQuery in = new DisjunctionMaxQuery(List.of(exists("a"), new TermQuery(new Term("b", "x"))), 0.3f);
+        Query out = LuceneQueryConversionUtils.rewriteFieldExistsForSecondary(in);
+        assertThat(out, instanceOf(DisjunctionMaxQuery.class));
+        DisjunctionMaxQuery dm = (DisjunctionMaxQuery) out;
+        assertEquals(0.3f, dm.getTieBreakerMultiplier(), 0.0f);
+        boolean sawRange = dm.getDisjuncts().stream().anyMatch(q -> q instanceof TermRangeQuery);
+        assertTrue("a FieldExistsQuery disjunct should have become a TermRangeQuery", sawRange);
+    }
+
+    public void testNestedWrappers() {
+        Query in = new ConstantScoreQuery(
+            new BooleanQuery.Builder().add(new BoostQuery(exists("deep"), 1.5f), BooleanClause.Occur.SHOULD).build()
+        );
+        Query out = LuceneQueryConversionUtils.rewriteFieldExistsForSecondary(in);
+        // unwrap CS -> Boolean -> Boost -> TermRangeQuery
+        BooleanQuery bool = (BooleanQuery) ((ConstantScoreQuery) out).getQuery();
+        BoostQuery boost = (BoostQuery) bool.clauses().get(0).query();
+        assertExistsRewrite(boost.getQuery(), "deep");
+    }
+
+    /** No FieldExistsQuery anywhere → same instance returned (no needless rebuild). */
+    public void testUnaffectedQueryReturnedAsSameInstance() {
+        Query in = new BooleanQuery.Builder().add(new TermQuery(new Term("f", "v")), BooleanClause.Occur.MUST)
+            .add(new MatchAllDocsQuery(), BooleanClause.Occur.FILTER)
+            .build();
+        assertSame(in, LuceneQueryConversionUtils.rewriteFieldExistsForSecondary(in));
+    }
+
+    public void testLeafNonExistsReturnedAsSameInstance() {
+        Query in = new TermQuery(new Term("f", "v"));
+        assertSame(in, LuceneQueryConversionUtils.rewriteFieldExistsForSecondary(in));
+    }
+
+    public void testContainsFieldExistsDetection() {
+        assertTrue(LuceneQueryConversionUtils.containsFieldExists(new ConstantScoreQuery(exists("f"))));
+        assertFalse(LuceneQueryConversionUtils.containsFieldExists(new TermQuery(new Term("f", "v"))));
+    }
+}

--- a/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/LuceneQueryConversionUtilsTests.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/LuceneQueryConversionUtilsTests.java
@@ -23,6 +23,9 @@ import org.opensearch.test.OpenSearchTestCase;
 
 import java.util.List;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+
 /**
  * Unit tests for {@link LuceneQueryConversionUtils#rewriteFieldExistsForSecondary} — the
  * interim rewrite that turns {@link FieldExistsQuery} (needs doc_values/norms, absent on the

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/SearchFieldExistsDelegationIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/SearchFieldExistsDelegationIT.java
@@ -1,0 +1,161 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.qa;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Integration test for {@code !=} / {@code NOT field=value} predicates on keyword columns that
+ * are pushed to the lucene-secondary index via filter delegation.
+ *
+ * <p>The PPL frontend desugars {@code field != "v"} (and {@code NOT field = "v"}) into a
+ * {@code query_string} containing an {@code _exists_:field} clause. {@code _exists_} compiles to a
+ * Lucene {@code FieldExistsQuery}, which requires the field to index doc_values / norms / vectors.
+ * On a composite parquet-primary index the keyword doc_values live in the parquet primary, NOT the
+ * lucene-secondary segment that filter delegation queries — so {@code FieldExistsQuery.rewrite()}
+ * throws ("indexes neither doc values, norms nor vectors") and the whole query 500s.
+ *
+ * <p>{@code LuceneQueryConversionUtils.rewriteFieldExistsForSecondary} fixes this by rewriting the
+ * {@code FieldExistsQuery} into a postings-only {@code TermRangeQuery} before execution. These tests
+ * assert the queries now return the correct counts.
+ *
+ * <p>Dataset {@code app_logs_filter_delegation}: keyword {@code log_level} with ERROR=115, INFO=47,
+ * WARN=38 (200 docs total). All filtering routes through the delegation path.
+ */
+public class SearchFieldExistsDelegationIT extends AnalyticsRestTestCase {
+
+    private static final Dataset DATASET = new Dataset("app_logs_filter_delegation", "app_logs_filter_delegation");
+
+    private static boolean dataProvisioned = false;
+
+    private static final int TOTAL = 200;
+    private static final int ERROR = 115;
+    private static final int INFO = 47;
+    private static final int WARN = 38;
+
+    @Override
+    protected void onBeforeQuery() throws IOException {
+        if (dataProvisioned == false) {
+            // 2 shards so the predicate is delegated + reduced across shards (the failing topology).
+            DatasetProvisioner.provision(client(), DATASET, 2);
+            dataProvisioned = true;
+        }
+    }
+
+    // The bug reproducer is the PPL `search` command's {@code field != value} form. Per the SQL
+    // plugin's own SearchCommandIT: `!=` means "field EXISTS and is not equal", so the frontend
+    // emits a query_string with an `_exists_:field` clause → Lucene FieldExistsQuery → 500 on the
+    // doc-values-less lucene-secondary without rewriteFieldExistsForSecondary. (By contrast
+    // `NOT field=value` and `OR` do NOT emit `_exists_`, so they don't hit the bug — they're kept
+    // below as control cases that must pass with the fix on or off.)
+
+    /** REPRODUCER: {@code search log_level!="INFO"} → exists-and-not-INFO = ERROR + WARN. 500 before fix. */
+    public void testSearchNotEqualsKeyword() throws IOException {
+        String src = "search source=" + DATASET.indexName + " log_level!=\"INFO\"";
+        // Count check.
+        assertCount(src + " | stats count() as c", ERROR + WARN);
+        // Value check: the surviving log_levels are exactly {ERROR, WARN} with the right per-bucket
+        // counts and — crucially — INFO is absent. Guards against a wrong-rows-same-total pass.
+        assertCountsByLogLevel(src, Map.of("ERROR", (long) ERROR, "WARN", (long) WARN));
+    }
+
+    /** REPRODUCER: {@code !=} on a different keyword column → not field-specific. 500 before fix. */
+    public void testSearchNotEqualsOtherKeyword() throws IOException {
+        String src = "search source=" + DATASET.indexName + " service_name!=\"__nope__\"";
+        // service_name exists on every doc and is never "__nope__" → all 200 match, every level present.
+        assertCount(src + " | stats count() as c", TOTAL);
+        assertCountsByLogLevel(src, Map.of("ERROR", (long) ERROR, "INFO", (long) INFO, "WARN", (long) WARN));
+    }
+
+    /** CONTROL: {@code NOT log_level="INFO"} excludes INFO without an _exists_ clause (no bug path). */
+    public void testSearchNotFieldEqualsKeyword() throws IOException {
+        assertCount("search source=" + DATASET.indexName + " NOT log_level=\"INFO\" | stats count() as c", ERROR + WARN);
+    }
+
+    /** CONTROL: Boolean OR over keyword equality — two terms, no _exists_. */
+    public void testSearchOrEqualsKeyword() throws IOException {
+        assertCount(
+            "search source=" + DATASET.indexName + " log_level=\"ERROR\" OR log_level=\"FATAL\" | stats count() as c",
+            ERROR
+        );
+    }
+
+    /** CONTROL: plain equality via search (no _exists_) still matches the known count. */
+    public void testSearchEqualsKeywordBaseline() throws IOException {
+        assertCount("search source=" + DATASET.indexName + " log_level=\"INFO\" | stats count() as c", INFO);
+    }
+
+    /**
+     * REPRODUCER (non-count / value-returning): {@code search field!=v | fields ...} returns actual
+     * rows rather than a stats count, so it exercises the Lucene-driver SCAN path
+     * (LuceneSearchExecEngine over the filter query) — a different code path from the stats-count
+     * fast-path and from filter-delegation. Without the rewrite this 500s too. We assert the
+     * surviving log_level distribution (no INFO) by grouping, proving real rows came back.
+     */
+    public void testSearchNotEqualsReturnsRows() throws IOException {
+        String src = "search source=" + DATASET.indexName + " log_level!=\"INFO\"";
+        // fields projection (no stats) → value-returning scan; head bounds the payload.
+        Map<String, Object> response = executePpl(src + " | fields log_level | head 5");
+        @SuppressWarnings("unchecked")
+        List<List<Object>> rows = (List<List<Object>>) response.get("datarows");
+        assertNotNull("Response missing 'datarows'", rows);
+        assertEquals("expected 5 rows", 5, rows.size());
+        for (List<Object> row : rows) {
+            assertNotEquals("INFO must be excluded by !=", "INFO", row.get(0));
+        }
+        // And the full grouped distribution over the value-returning scan excludes INFO entirely.
+        assertCountsByLogLevel(src, Map.of("ERROR", (long) ERROR, "WARN", (long) WARN));
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────────
+
+    private void assertCount(String ppl, long expected) throws IOException {
+        Map<String, Object> response = executePpl(ppl);
+        @SuppressWarnings("unchecked")
+        List<List<Object>> rows = (List<List<Object>>) response.get("datarows");
+        assertNotNull("Response missing 'datarows' for query: " + ppl, rows);
+        assertEquals("Expected a single count row for query: " + ppl, 1, rows.size());
+        long actual = ((Number) rows.get(0).get(0)).longValue();
+        assertEquals("Count mismatch for query: " + ppl, expected, actual);
+    }
+
+    /**
+     * Runs {@code <searchPrefix> | stats count() as c by log_level} and asserts the returned
+     * level→count map equals {@code expected} exactly — same keys, same counts, no extras. This
+     * verifies the actual surviving rows (e.g. that INFO is truly excluded), not just a total.
+     */
+    private void assertCountsByLogLevel(String searchPrefix, Map<String, Long> expected) throws IOException {
+        Map<String, Object> response = executePpl(searchPrefix + " | stats count() as c by log_level");
+        @SuppressWarnings("unchecked")
+        List<List<Object>> rows = (List<List<Object>>) response.get("datarows");
+        assertNotNull("Response missing 'datarows'", rows);
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> schema = (List<Map<String, Object>>) response.get("schema");
+        // Locate the count vs log_level columns by name (column order is not guaranteed).
+        int countCol = -1;
+        int levelCol = -1;
+        for (int i = 0; i < schema.size(); i++) {
+            String name = String.valueOf(schema.get(i).get("name"));
+            if ("c".equals(name)) {
+                countCol = i;
+            } else if ("log_level".equals(name)) {
+                levelCol = i;
+            }
+        }
+        assertTrue("schema missing 'c'/'log_level' columns: " + schema, countCol >= 0 && levelCol >= 0);
+        Map<String, Long> actual = new HashMap<>();
+        for (List<Object> row : rows) {
+            actual.put(String.valueOf(row.get(levelCol)), ((Number) row.get(countCol)).longValue());
+        }
+        assertEquals("log_level → count map mismatch", expected, actual);
+    }
+}


### PR DESCRIPTION
### First Problem
PPL `search source=idx field!="v"` (and any `_exists_:field` clause) 500s on a composite parquet-primary / lucene-secondary index:

FieldExistsQuery requires that the field indexes doc values, norms or vectors, but field 'log_level' exists and indexes neither of these data structures

The frontend sends `!=` into a `query_string` carrying `_exists_:field`. `_exists_` for Search command and compiles to a Lucene `FieldExistsQuery`, which needs doc_values/norms/vectors on the segment it runs against. On a composite index the keyword doc_values live in the **parquet primary**, while the query executes on the **lucene-secondary** segment (postings only) — so `FieldExistsQuery.rewrite()` throws and the query fails.

### Second Problem

OpenSearchSchemaBuilder.buildLeafType mapped date/date_nanos to TIMESTAMP with no precision (defaults to 0 → millis downstream), but parquet reads date_nanos as nanos → coordinator reduce RowConverter throws Timestamp(ms) got Timestamp(ns) on multi-shard sort. Fix: set precision explicitly — date→3, date_nanos→9 via a switch that throws on unknown TIMESTAMP types. Nanos preserved end-to-end

### Fix
Rewrite `FieldExistsQuery` → a postings-only `TermRangeQuery(field, null, null)` ("field has ≥1 indexed term") before execution. This is semantically equivalent to "field exists" for the postings-indexed keyword/text/match_only_text types that filter delegation supports.

New helper `LuceneQueryConversionUtils.rewriteFieldExistsForSecondary(Query)` recurses through the Boolean / ConstantScore / Boost / DisjunctionMax wrappers the `query_string` parser emits, rebuilds only changed branches, and fails fast (via `QueryVisitor`) on any unhandled container still hiding a `FieldExistsQuery`.

Applied at **both** Lucene execution entry points:
  - `LuceneFilterDelegationHandle` — filter-delegation path (DataFusion-driven scans).
  - `LuceneScanInstructionHandler` — Lucene-driver scan/count path (`LuceneSearchExecEngine`).

### Tests
  - **Unit** (`LuceneQueryConversionUtilsTests`): rewrite across each wrapper, nested wrappers, unchanged-query reference-equality, and detection.
  - **Integration** (`SearchFieldExistsDelegationIT`, `app_logs_filter_delegation`, 2 shards):
    `search log_level!="INFO"` count + value (no INFO) assertions, a value-returning `| fields`
    variant (scan path), plus `NOT` / `OR` / `=` controls. Reverting the rewrite reproduces the 500.

### Follow-up
Interim fix. Long-term, the lucene-secondary should read doc_values from the parquet primary, after which `FieldExistsQuery` resolves natively and this rewrite can be removed.