### PR TITLE
feat: Add StatsPruneTree for segment, RG, and subtree-level pruning

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_executor.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_executor.rs
@@ -75,7 +75,7 @@ use crate::api::ShardView;
 use crate::datafusion_query_config::DatafusionQueryConfig;
 use crate::indexed_table::bool_tree::residual_bool_to_physical_expr;
 use crate::indexed_table::metrics::StreamMetrics;
-use crate::indexed_table::page_pruner::{build_pruning_predicate, PagePruneMetrics};
+use crate::indexed_table::page_pruner::{build_pruning_predicate, PagePruneMetrics, StatsPruneTree};
 
 
 /// Execute an indexed query.
@@ -596,6 +596,22 @@ async unsafe fn execute_indexed_with_context_inner(
         FilterClass::Tree => None,
     };
 
+    let prune_tree_config = extraction.as_ref().and_then(|e| {
+        let mut leaf_exprs: Vec<Arc<dyn PhysicalExpr>> = Vec::new();
+        collect_predicate_exprs(&e.tree, &mut leaf_exprs);
+        let leaf_predicates: HashMap<usize, Arc<PruningPredicate>> = leaf_exprs
+            .iter()
+            .filter_map(|expr| {
+                build_pruning_predicate(expr, schema.clone())
+                    .map(|pp| (Arc::as_ptr(expr) as *const () as usize, pp))
+            })
+            .collect();
+        if leaf_predicates.is_empty() {
+            return None;
+        }
+        Some((e.tree.clone(), Arc::new(leaf_predicates), schema.clone()))
+    });
+
     let predicate_columns = collect_predicate_column_indices(extraction.as_ref());
 
     let factory: EvaluatorFactory = match classification {
@@ -614,7 +630,7 @@ async unsafe fn execute_indexed_with_context_inner(
                 .and_then(|expr| build_pruning_predicate(expr, Arc::clone(&schema_for_pruner)));
 
             Arc::new(
-                move |segment: &SegmentFileInfo, _chunk, stream_metrics: &StreamMetrics| {
+                move |segment: &SegmentFileInfo, _chunk, stream_metrics: &StreamMetrics, stats_prune_tree: Option<&StatsPruneTree>| {
                     let pruner = Arc::new(PagePruner::new(
                         &schema_for_pruner,
                         Arc::clone(&segment.metadata),
@@ -625,6 +641,7 @@ async unsafe fn execute_indexed_with_context_inner(
                             residual_pruning_predicate.clone(),
                             residual_expr.clone(),
                             Some(PagePruneMetrics::from_stream_metrics(stream_metrics)),
+                            stats_prune_tree.cloned(),
                         ));
                     Ok(eval)
                 },
@@ -690,7 +707,7 @@ async unsafe fn execute_indexed_with_context_inner(
             let bloom_schema = schema.clone();
             let bloom_on_read = query_config.bloom_filter_on_read;
             Arc::new(
-                move |segment: &SegmentFileInfo, chunk, stream_metrics: &StreamMetrics| {
+                move |segment: &SegmentFileInfo, chunk, stream_metrics: &StreamMetrics, stats_prune_tree: Option<&StatsPruneTree>| {
                     let collector_opt: Option<Arc<dyn RowGroupDocsCollector>> = match &correctness_provider {
                         Some(provider) => {
                             let collector = FfmSegmentCollector::create(
@@ -746,6 +763,7 @@ async unsafe fn execute_indexed_with_context_inner(
                             Arc::new(crate::indexed_table::eval::single_collector::FfmDelegatedBackendCollectorFactory),
                             context_id,
                             bloom_config,
+                            stats_prune_tree.cloned(),
                         ));
                     Ok(eval)
                 },
@@ -798,7 +816,7 @@ async unsafe fn execute_indexed_with_context_inner(
             );
 
             Arc::new(
-                move |segment: &SegmentFileInfo, chunk, stream_metrics: &StreamMetrics| {
+                move |segment: &SegmentFileInfo, chunk, stream_metrics: &StreamMetrics, stats_prune_tree: Option<&StatsPruneTree>| {
                     // Build one collector per Collector leaf for this chunk.
                     let mut per_leaf: Vec<(i32, Arc<dyn RowGroupDocsCollector>)> =
                         Vec::with_capacity(providers.len());
@@ -842,6 +860,7 @@ async unsafe fn execute_indexed_with_context_inner(
                             stream_metrics,
                         )),
                         collector_strategy,
+                        stats_prune_tree: stats_prune_tree.cloned(),
                     });
                     Ok(eval)
                 },
@@ -869,6 +888,7 @@ async unsafe fn execute_indexed_with_context_inner(
         query_config: Arc::clone(&query_config),
         predicate_columns,
         emit_row_ids,
+        prune_tree_config,
     }));
     ctx.register_table(&table_name, provider)?;
 

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/eval/bitmap_tree.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/eval/bitmap_tree.rs
@@ -71,7 +71,7 @@ use roaring::RoaringBitmap;
 
 use super::{LeafBitmapSource, RgEvalContext, TreeEvaluator, TreePrefetch};
 use crate::indexed_table::bool_tree::ResolvedNode;
-use crate::indexed_table::page_pruner::{PagePruneMetrics, PagePruner};
+use crate::indexed_table::page_pruner::{PagePruneMetrics, PagePruner, StatsPruneTree};
 use crate::indexed_table::row_selection::{packed_bits_to_boolean_array, PositionMap};
 use datafusion::physical_optimizer::pruning::PruningPredicate;
 
@@ -88,6 +88,7 @@ impl TreeEvaluator for BitmapTreeEvaluator {
         page_pruner: &PagePruner,
         pruning_predicates: &HashMap<usize, Arc<PruningPredicate>>,
         page_prune_metrics: Option<&PagePruneMetrics>,
+        stats_prune_tree: Option<&StatsPruneTree>,
     ) -> Result<TreePrefetch, String> {
         let mut per_leaf = Vec::new();
         let mut dfs_counter = 0usize;
@@ -104,6 +105,7 @@ impl TreeEvaluator for BitmapTreeEvaluator {
             &mut dfs_counter,
             &mut per_leaf,
             /* under_all_and_path */ true,
+            stats_prune_tree,
         )?;
         Ok(TreePrefetch {
             candidates,
@@ -181,7 +183,27 @@ fn prefetch_node(
     dfs: &mut usize,
     out: &mut Vec<(usize, RoaringBitmap)>,
     under_all_and_path: bool,
+    stats_prune_tree: Option<&StatsPruneTree>,
 ) -> Result<RoaringBitmap, String> {
+    // RG-level subtree pruning: if this subtree provably can't match
+    // the current RG, skip the entire tree walk. Since collectors are
+    // always-true in the resolution, a false here means a Predicate
+    // under AND proved no match — collector bitmaps are irrelevant.
+    if let Some(spt) = stats_prune_tree {
+        if let Some(&false) = spt.rg_can_match.get(ctx.rg_idx) {
+            native_bridge_common::log_debug!(
+                "BitmapTree: skipping subtree for RG {} — pruned by RG-level stats",
+                ctx.rg_idx
+            );
+            if under_all_and_path {
+                skip_dfs(node, dfs);
+            } else {
+                skip_dfs_with_empty_bitmaps(node, dfs, out);
+            }
+            return Ok(RoaringBitmap::new());
+        }
+    }
+
     match node {
         ResolvedNode::And(children) => {
             let mut indices: Vec<usize> = (0..children.len()).collect();
@@ -207,7 +229,8 @@ fn prefetch_node(
                     page_prune_metrics,
                     dfs,
                     out,
-                    under_all_and_path, // AND preserves the all-AND path
+                    under_all_and_path,
+                    stats_prune_tree.and_then(|spt| spt.children.get(i)),
                 )?;
                 result_bitmap = Some(match result_bitmap {
                     None => child_bitmap,
@@ -271,6 +294,7 @@ fn prefetch_node(
                     out,
                     // OR breaks all-AND propagation for its subtree.
                     false,
+                    stats_prune_tree.and_then(|spt| spt.children.get(val)),
                 )?;
                 result_bitmap |= &filtered_bitmap;
 
@@ -304,6 +328,7 @@ fn prefetch_node(
                 dfs,
                 out,
                 /* under_all_and_path */ false,
+                stats_prune_tree.and_then(|spt| spt.children.first()),
             )?;
             // Candidate-stage is a superset. Inverting a superset does
             // NOT yield a superset of the true NOT — it yields a subset
@@ -435,6 +460,36 @@ fn skip_dfs(node: &ResolvedNode, dfs: &mut usize) {
             unimplemented!(
                 "invariant violation: DelegationPossible reached skip_dfs. \
                  Planner must drop performance peers under OR/NOT before fragment conversion."
+            )
+        }
+    }
+}
+
+/// Advance `dfs` and push empty bitmaps for each Collector leaf without
+/// making FFM calls. Used when a subtree is pruned by RG-level stats but
+/// refinement may still run (OR/NOT ancestor) — ensures the side-table
+/// has entries so refinement doesn't panic on missing keys.
+fn skip_dfs_with_empty_bitmaps(
+    node: &ResolvedNode,
+    dfs: &mut usize,
+    out: &mut Vec<(usize, RoaringBitmap)>,
+) {
+    match node {
+        ResolvedNode::And(children) | ResolvedNode::Or(children) => {
+            for c in children {
+                skip_dfs_with_empty_bitmaps(c, dfs, out);
+            }
+        }
+        ResolvedNode::Not(child) => skip_dfs_with_empty_bitmaps(child, dfs, out),
+        ResolvedNode::Collector { collector, .. } => {
+            *dfs += 1;
+            let key = Arc::as_ptr(collector) as *const () as usize;
+            out.push((key, RoaringBitmap::new()));
+        }
+        ResolvedNode::Predicate(_) => *dfs += 1,
+        ResolvedNode::DelegationPossible { .. } => {
+            unimplemented!(
+                "invariant violation: DelegationPossible reached skip_dfs_with_empty_bitmaps."
             )
         }
     }
@@ -1155,7 +1210,7 @@ mod tests {
         };
         let pruner = empty_pruner();
         let result = BitmapTreeEvaluator
-            .prefetch(&tree, &test_ctx(), &leaves, &pruner, &HashMap::new(), None)
+            .prefetch(&tree, &test_ctx(), &leaves, &pruner, &HashMap::new(), None, None)
             .unwrap();
         assert_eq!(result.candidates, bm(&[3, 4]));
         assert_eq!(result.per_leaf.len(), 2);
@@ -1169,7 +1224,7 @@ mod tests {
         };
         let pruner = empty_pruner();
         let result = BitmapTreeEvaluator
-            .prefetch(&tree, &test_ctx(), &leaves, &pruner, &HashMap::new(), None)
+            .prefetch(&tree, &test_ctx(), &leaves, &pruner, &HashMap::new(), None, None)
             .unwrap();
         assert_eq!(result.candidates, bm(&[1, 2, 3]));
     }
@@ -1182,7 +1237,7 @@ mod tests {
         };
         let pruner = empty_pruner();
         let result = BitmapTreeEvaluator
-            .prefetch(&tree, &test_ctx(), &leaves, &pruner, &HashMap::new(), None)
+            .prefetch(&tree, &test_ctx(), &leaves, &pruner, &HashMap::new(), None, None)
             .unwrap();
         // Universe is [0, 16). Minus {0,1,2} = {3..15}
         let expected: RoaringBitmap = (3u32..16).collect();
@@ -1197,7 +1252,7 @@ mod tests {
         };
         let pruner = empty_pruner();
         let state = BitmapTreeEvaluator
-            .prefetch(&tree, &test_ctx(), &leaves, &pruner, &HashMap::new(), None)
+            .prefetch(&tree, &test_ctx(), &leaves, &pruner, &HashMap::new(), None, None)
             .unwrap();
 
         let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, false)]));
@@ -1457,7 +1512,7 @@ mod tests {
         let pruner = empty_pruner();
 
         let result = BitmapTreeEvaluator
-            .prefetch(&tree, &test_ctx(), &leaves, &pruner, &HashMap::new(), None)
+            .prefetch(&tree, &test_ctx(), &leaves, &pruner, &HashMap::new(), None, None)
             .unwrap();
         assert!(result.candidates.is_empty());
     }
@@ -1497,7 +1552,7 @@ mod tests {
         let pruner = empty_pruner();
 
         let result = BitmapTreeEvaluator
-            .prefetch(&tree, &test_ctx(), &leaves, &pruner, &HashMap::new(), None)
+            .prefetch(&tree, &test_ctx(), &leaves, &pruner, &HashMap::new(), None, None)
             .unwrap();
         // OR contributes {5} from standalone_leaf → non-empty candidates.
         assert!(!result.candidates.is_empty());
@@ -1535,7 +1590,7 @@ mod tests {
         let pruner = empty_pruner();
 
         let result = BitmapTreeEvaluator
-            .prefetch(&tree, &test_ctx(), &leaves, &pruner, &HashMap::new(), None)
+            .prefetch(&tree, &test_ctx(), &leaves, &pruner, &HashMap::new(), None, None)
             .unwrap();
         // NOT inverts empty AND → universe.
         assert_eq!(result.candidates.len(), 16);
@@ -1566,7 +1621,9 @@ mod tests {
             subtree_cost(&test_predicate_node(), &ctx, &pruner, &pp),
             ctx.cost_predicate * COST_SCALE
         );
-        assert_eq!(subtree_cost(&collector_leaf(0), &ctx, &pruner, &pp), ctx.cost_collector * COST_SCALE);
+        assert_eq!(
+            subtree_cost(&collector_leaf(0), &ctx, &pruner, &pp), ctx.cost_collector * COST_SCALE
+        );
     }
 
     #[test]
@@ -1575,7 +1632,9 @@ mod tests {
         let pruner = empty_pruner();
         let pp = HashMap::new();
         let wrapped = ResolvedNode::Not(Box::new(test_predicate_node()));
-        assert_eq!(subtree_cost(&wrapped, &ctx, &pruner, &pp), ctx.cost_predicate * COST_SCALE);
+        assert_eq!(
+            subtree_cost(&wrapped, &ctx, &pruner, &pp), ctx.cost_predicate * COST_SCALE
+        );
     }
 
     #[test]
@@ -1720,5 +1779,155 @@ mod tests {
         ctx.collector_strategy = super::super::CollectorCallStrategy::PageRangeSplit;
         let bm = RoaringBitmap::new();
         assert_eq!(ranges_from_bitmap(&bm, &ctx), vec![]);
+    }
+
+    // ── StatsPruneTree subtree pruning in prefetch ─────────────────────
+
+    fn prune_tree_leaf(can_match: Vec<bool>) -> StatsPruneTree {
+        StatsPruneTree {
+            rg_can_match: can_match,
+            children: vec![],
+        }
+    }
+
+    fn prune_tree_and(
+        children: Vec<StatsPruneTree>,
+    ) -> StatsPruneTree {
+        let mut rg_can_match = vec![true; children[0].rg_can_match.len()];
+        for c in &children {
+            for (r, v) in rg_can_match.iter_mut().zip(c.rg_can_match.iter()) {
+                *r &= v;
+            }
+        }
+        StatsPruneTree {
+            rg_can_match,
+            children,
+        }
+    }
+
+    fn prune_tree_or(
+        children: Vec<StatsPruneTree>,
+    ) -> StatsPruneTree {
+        let mut rg_can_match = vec![false; children[0].rg_can_match.len()];
+        for c in &children {
+            for (r, v) in rg_can_match.iter_mut().zip(c.rg_can_match.iter()) {
+                *r |= v;
+            }
+        }
+        StatsPruneTree {
+            rg_can_match,
+            children,
+        }
+    }
+
+    #[test]
+    fn stats_prune_tree_root_and_false_skips_entire_rg() {
+        let tree = ResolvedNode::And(vec![collector_leaf(0), collector_leaf(1)]);
+        let leaves = FixedLeafBitmaps {
+            bitmaps: vec![bm(&[1, 2, 3]), bm(&[3, 4, 5])],
+        };
+        let pruner = empty_pruner();
+        let spt = prune_tree_and(vec![
+            prune_tree_leaf(vec![false]),
+            prune_tree_leaf(vec![true]),
+        ]);
+        let result = BitmapTreeEvaluator
+            .prefetch(&tree, &test_ctx(), &leaves, &pruner, &HashMap::new(), None, Some(&spt))
+            .unwrap();
+        assert!(result.candidates.is_empty());
+    }
+
+    #[test]
+    fn stats_prune_tree_or_skips_false_child() {
+        let tree = ResolvedNode::Or(vec![collector_leaf(0), collector_leaf(1)]);
+        let leaves = FixedLeafBitmaps {
+            bitmaps: vec![bm(&[10, 11, 12]), bm(&[3, 4])],
+        };
+        let pruner = empty_pruner();
+        let spt = prune_tree_or(vec![
+            prune_tree_leaf(vec![false]),
+            prune_tree_leaf(vec![true]),
+        ]);
+        let result = BitmapTreeEvaluator
+            .prefetch(&tree, &test_ctx(), &leaves, &pruner, &HashMap::new(), None, Some(&spt))
+            .unwrap();
+        assert_eq!(result.candidates, bm(&[3, 4]));
+    }
+
+    #[test]
+    fn stats_prune_tree_and_child_false_short_circuits() {
+        let tree = ResolvedNode::And(vec![collector_leaf(0), collector_leaf(1)]);
+        let leaves = FixedLeafBitmaps {
+            bitmaps: vec![bm(&[1, 2, 3]), bm(&[99])],
+        };
+        let pruner = empty_pruner();
+        let spt = prune_tree_and(vec![
+            prune_tree_leaf(vec![true]),
+            prune_tree_leaf(vec![false]),
+        ]);
+        let result = BitmapTreeEvaluator
+            .prefetch(&tree, &test_ctx(), &leaves, &pruner, &HashMap::new(), None, Some(&spt))
+            .unwrap();
+        assert!(result.candidates.is_empty());
+    }
+
+    #[test]
+    fn stats_prune_tree_nested_or_under_and() {
+        // AND(OR(collector0, collector1), collector2)
+        // Cost sort: collector2 (cost=10k) first, OR subtree (cost=20k) second.
+        // DFS order after sort: collector2=0, OR-child0=1(skipped), OR-child1=2.
+        let tree = ResolvedNode::And(vec![
+            ResolvedNode::Or(vec![collector_leaf(0), collector_leaf(1)]),
+            collector_leaf(2),
+        ]);
+        let leaves = FixedLeafBitmaps {
+            bitmaps: vec![bm(&[3, 4, 5]), bm(&[99]), bm(&[3, 4, 5, 6])],
+        };
+        let pruner = empty_pruner();
+        let or_spt = prune_tree_or(vec![
+            prune_tree_leaf(vec![false]),
+            prune_tree_leaf(vec![true]),
+        ]);
+        let spt = prune_tree_and(vec![or_spt, prune_tree_leaf(vec![true])]);
+        let result = BitmapTreeEvaluator
+            .prefetch(&tree, &test_ctx(), &leaves, &pruner, &HashMap::new(), None, Some(&spt))
+            .unwrap();
+        // collector2 (dfs=0) → {3,4,5}; OR-child1 (dfs=2) → {3,4,5,6}; OR = {3,4,5,6}
+        // AND = {3,4,5} ∩ {3,4,5,6} = {3,4,5}
+        assert_eq!(result.candidates, bm(&[3, 4, 5]));
+    }
+
+    #[test]
+    fn stats_prune_tree_or_all_children_false() {
+        let tree = ResolvedNode::And(vec![
+            ResolvedNode::Or(vec![collector_leaf(0), collector_leaf(1)]),
+            collector_leaf(2),
+        ]);
+        let leaves = FixedLeafBitmaps {
+            bitmaps: vec![bm(&[1, 2]), bm(&[3, 4]), bm(&[5, 6])],
+        };
+        let pruner = empty_pruner();
+        let or_spt = prune_tree_or(vec![
+            prune_tree_leaf(vec![false]),
+            prune_tree_leaf(vec![false]),
+        ]);
+        let spt = prune_tree_and(vec![or_spt, prune_tree_leaf(vec![true])]);
+        let result = BitmapTreeEvaluator
+            .prefetch(&tree, &test_ctx(), &leaves, &pruner, &HashMap::new(), None, Some(&spt))
+            .unwrap();
+        assert!(result.candidates.is_empty());
+    }
+
+    #[test]
+    fn stats_prune_tree_none_evaluates_normally() {
+        let tree = ResolvedNode::And(vec![collector_leaf(0), collector_leaf(1)]);
+        let leaves = FixedLeafBitmaps {
+            bitmaps: vec![bm(&[1, 2, 3, 4]), bm(&[3, 4, 5])],
+        };
+        let pruner = empty_pruner();
+        let result = BitmapTreeEvaluator
+            .prefetch(&tree, &test_ctx(), &leaves, &pruner, &HashMap::new(), None, None)
+            .unwrap();
+        assert_eq!(result.candidates, bm(&[3, 4]));
     }
 }

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/eval/mod.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/eval/mod.rs
@@ -83,6 +83,7 @@ pub(super) fn remap_expr_to_batch(
 use super::bool_tree::ResolvedNode;
 use super::page_pruner::PagePruneMetrics;
 use super::page_pruner::PagePruner;
+use super::page_pruner::StatsPruneTree;
 use super::row_selection::PositionMap;
 use super::stream::RowGroupInfo;
 use datafusion::arrow::buffer::Buffer;
@@ -272,6 +273,7 @@ pub trait TreeEvaluator: Send + Sync {
         page_pruner: &PagePruner,
         pruning_predicates: &HashMap<usize, Arc<PruningPredicate>>,
         page_prune_metrics: Option<&PagePruneMetrics>,
+        stats_prune_tree: Option<&StatsPruneTree>,
     ) -> Result<TreePrefetch, String>;
 
     /// Refinement stage: produce the exact per-row `BooleanArray` for one
@@ -348,6 +350,8 @@ pub struct TreeBitsetSource {
     /// recommended here — multiple FFM calls per collector per RG can
     /// be expensive in multi-collector trees.
     pub collector_strategy: CollectorCallStrategy,
+    /// Precomputed per-subtree RG match vectors. Built once at construction.
+    pub stats_prune_tree: Option<StatsPruneTree>,
 }
 
 impl RowGroupBitsetSource for TreeBitsetSource {
@@ -358,6 +362,18 @@ impl RowGroupBitsetSource for TreeBitsetSource {
         max_doc: i32,
     ) -> Result<Option<PrefetchedRg>, String> {
         let t = Instant::now();
+
+        // RG-level early-exit: precomputed from column stats at construction.
+        if let Some(ref ann) = self.stats_prune_tree {
+            if let Some(&false) = ann.rg_can_match.get(rg.index) {
+                native_bridge_common::log_debug!(
+                    "BitmapTree: skipping RG {} — pruned by RG-level stats",
+                    rg.index
+                );
+                return Ok(None);
+            }
+        }
+
         let ctx = RgEvalContext {
             rg_idx: rg.index,
             rg_first_row: rg.first_row,
@@ -405,6 +421,7 @@ impl RowGroupBitsetSource for TreeBitsetSource {
                 // inflate counts. We compute final page-level metrics below
                 // after the bitmap tree is fully resolved.
                 None,
+                self.stats_prune_tree.as_ref(),
             )
             .map_err(|e| format!("TreeBitsetSource::prefetch_rg(rg={}): {}", rg.index, e))?;
         if prefetch.candidates.is_empty() {
@@ -755,6 +772,7 @@ mod tests {
             _page_pruner: &PagePruner,
             _pruning_predicates: &HashMap<usize, Arc<PruningPredicate>>,
             _page_prune_metrics: Option<&PagePruneMetrics>,
+            _stats_prune_tree: Option<&StatsPruneTree>,
         ) -> Result<TreePrefetch, String> {
             Ok(TreePrefetch {
                 candidates: roaring::RoaringBitmap::new(),
@@ -803,6 +821,7 @@ mod tests {
             pruning_predicates: std::sync::Arc::new(HashMap::new()),
             page_prune_metrics: None,
             collector_strategy: CollectorCallStrategy::TightenOuterBounds,
+            stats_prune_tree: None,
         };
         assert!(!source.needs_row_mask());
     }

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/eval/predicate_evaluator.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/eval/predicate_evaluator.rs
@@ -23,7 +23,7 @@ use roaring::RoaringBitmap;
 
 use super::eval_helpers::{compute_page_ranges, evaluate_residual, universe_bitmap_from_page_ranges};
 use super::{PrefetchedRg, RowGroupBitsetSource};
-use crate::indexed_table::page_pruner::{PagePruneMetrics, PagePruner};
+use crate::indexed_table::page_pruner::{PagePruneMetrics, PagePruner, StatsPruneTree};
 use crate::indexed_table::row_selection::{bitmap_to_packed_bits, PositionMap};
 use crate::indexed_table::stream::RowGroupInfo;
 
@@ -35,6 +35,7 @@ pub struct PredicateOnlyEvaluator {
     pruning_predicate: Option<Arc<PruningPredicate>>,
     residual_expr: Option<Arc<dyn datafusion::physical_expr::PhysicalExpr>>,
     page_prune_metrics: Option<PagePruneMetrics>,
+    stats_prune_tree: Option<StatsPruneTree>,
 }
 
 impl PredicateOnlyEvaluator {
@@ -43,12 +44,14 @@ impl PredicateOnlyEvaluator {
         pruning_predicate: Option<Arc<PruningPredicate>>,
         residual_expr: Option<Arc<dyn datafusion::physical_expr::PhysicalExpr>>,
         page_prune_metrics: Option<PagePruneMetrics>,
+        stats_prune_tree: Option<StatsPruneTree>,
     ) -> Self {
         Self {
             page_pruner,
             pruning_predicate,
             residual_expr,
             page_prune_metrics,
+            stats_prune_tree,
         }
     }
 }
@@ -61,6 +64,17 @@ impl RowGroupBitsetSource for PredicateOnlyEvaluator {
         _max_doc: i32,
     ) -> Result<Option<PrefetchedRg>, String> {
         let t = Instant::now();
+
+        // RG-level early-exit: precomputed from column stats at construction.
+        if let Some(ref spt) = self.stats_prune_tree {
+            if let Some(&false) = spt.rg_can_match.get(rg.index) {
+                native_bridge_common::log_debug!(
+                    "PredicateOnly: skipping RG {} — pruned by RG-level stats",
+                    rg.index
+                );
+                return Ok(None);
+            }
+        }
 
         let page_ranges = compute_page_ranges(
             self.pruning_predicate.as_ref(),
@@ -100,5 +114,68 @@ impl RowGroupBitsetSource for PredicateOnlyEvaluator {
             return Ok(None);
         };
         Ok(Some(evaluate_residual(residual, batch, batch_len)?))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::indexed_table::page_pruner::PagePruner;
+    use datafusion::arrow::array::Int32Array;
+    use datafusion::arrow::datatypes::{DataType, Field, Schema};
+    use datafusion::parquet::arrow::arrow_reader::{ArrowReaderMetadata, ArrowReaderOptions};
+    use datafusion::parquet::arrow::ArrowWriter;
+    use std::sync::Arc;
+    use tempfile::NamedTempFile;
+
+    fn minimal_page_pruner() -> Arc<PagePruner> {
+        let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, false)]));
+        let batch = datafusion::arrow::record_batch::RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(Int32Array::from(vec![0i32; 8]))],
+        )
+        .unwrap();
+        let tmp = NamedTempFile::new().unwrap();
+        let mut writer = ArrowWriter::try_new(tmp.reopen().unwrap(), schema.clone(), None).unwrap();
+        writer.write(&batch).unwrap();
+        writer.close().unwrap();
+        let file = tmp.reopen().unwrap();
+        let options = ArrowReaderOptions::new().with_page_index(true);
+        let meta = ArrowReaderMetadata::load(&file, options).unwrap();
+        Arc::new(PagePruner::new(meta.schema(), meta.metadata().clone()))
+    }
+
+    #[test]
+    fn stats_prune_tree_skips_rg_when_false() {
+        let pruner = minimal_page_pruner();
+        let spt = StatsPruneTree {
+            rg_can_match: vec![false],
+            children: vec![],
+        };
+        let eval = PredicateOnlyEvaluator::new(pruner, None, None, None, Some(spt));
+        let rg = RowGroupInfo { index: 0, first_row: 0, num_rows: 8 };
+        assert!(eval.prefetch_rg(&rg, 0, 8).unwrap().is_none());
+    }
+
+    #[test]
+    fn stats_prune_tree_allows_rg_when_true() {
+        let pruner = minimal_page_pruner();
+        let spt = StatsPruneTree {
+            rg_can_match: vec![true],
+            children: vec![],
+        };
+        let eval = PredicateOnlyEvaluator::new(pruner, None, None, None, Some(spt));
+        let rg = RowGroupInfo { index: 0, first_row: 0, num_rows: 8 };
+        let prefetched = eval.prefetch_rg(&rg, 0, 8).unwrap().expect("should have candidates");
+        assert_eq!(prefetched.candidates.len(), 8);
+    }
+
+    #[test]
+    fn stats_prune_tree_none_does_not_prune() {
+        let pruner = minimal_page_pruner();
+        let eval = PredicateOnlyEvaluator::new(pruner, None, None, None, None);
+        let rg = RowGroupInfo { index: 0, first_row: 0, num_rows: 8 };
+        let prefetched = eval.prefetch_rg(&rg, 0, 8).unwrap().expect("should have candidates");
+        assert_eq!(prefetched.candidates.len(), 8);
     }
 }

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/eval/single_collector.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/eval/single_collector.rs
@@ -33,7 +33,7 @@ use roaring::RoaringBitmap;
 use super::{PrefetchedRg, RowGroupBitsetSource};
 use crate::indexed_table::ffm_callbacks::{create_provider, FfmSegmentCollector, ProviderHandle};
 use crate::indexed_table::index::RowGroupDocsCollector;
-use crate::indexed_table::page_pruner::{PagePruneMetrics, PagePruner};
+use crate::indexed_table::page_pruner::{PagePruneMetrics, PagePruner, StatsPruneTree};
 use crate::indexed_table::row_selection::{
     bitmap_to_packed_bits, packed_bits_to_boolean_array, row_selection_to_bitmap, PositionMap,
 };
@@ -93,7 +93,6 @@ impl DelegatedBackendCollectorFactory for FfmDelegatedBackendCollectorFactory {
         Ok(Arc::new(collector) as Arc<dyn RowGroupDocsCollector>)
     }
 }
-
 
 /// Per-RG state the evaluator keeps for refinement. In row-granular
 /// mode parquet narrowed fully via `with_predicate` + `RowSelection`
@@ -177,6 +176,8 @@ pub struct SingleCollectorEvaluator {
     context_id: i64,
     /// Bloom filter pruning config. None = disabled.
     bloom_config: Option<BloomConfig>,
+    /// Precomputed per-RG/subtree match status from RG-level column stats.
+    stats_prune_tree: Option<StatsPruneTree>,
 }
 
 /// Resources needed for per-RG bloom filter pruning.
@@ -204,6 +205,7 @@ impl SingleCollectorEvaluator {
         delegated_backend_collector_factory: Arc<dyn DelegatedBackendCollectorFactory>,
         context_id: i64,
         bloom_config: Option<BloomConfig>,
+        stats_prune_tree: Option<StatsPruneTree>,
     ) -> Self {
         Self {
             collector,
@@ -218,6 +220,7 @@ impl SingleCollectorEvaluator {
             delegated_backend_collector_factory,
             context_id,
             bloom_config,
+            stats_prune_tree,
         }
     }
 }
@@ -257,6 +260,17 @@ impl RowGroupBitsetSource for SingleCollectorEvaluator {
         max_doc: i32,
     ) -> Result<Option<PrefetchedRg>, String> {
         let t = Instant::now();
+
+        // RG-level early-exit: precomputed from column stats at construction.
+        if let Some(ref spt) = self.stats_prune_tree {
+            if let Some(&false) = spt.rg_can_match.get(rg.index) {
+                native_bridge_common::log_debug!(
+                    "SingleCollector: skipping RG {} — pruned by RG-level stats",
+                    rg.index
+                );
+                return Ok(None);
+            }
+        }
 
         // Page-prune to discover which row ranges survive.
         let page_ranges: Option<Vec<(i32, i32)>> = self.pruning_predicate.as_ref().and_then(|pp| {
@@ -690,7 +704,7 @@ mod tests {
             docs: vec![0, 3, 7],
         }) as Arc<dyn RowGroupDocsCollector>;
         let pruner = minimal_page_pruner();
-        let eval = SingleCollectorEvaluator::new(Some(collector), pruner, None, None, None, None, CollectorCallStrategy::FullRange, Arc::new(HashMap::new()), 0, Arc::new(FfmDelegatedBackendCollectorFactory), 0, None);
+        let eval = SingleCollectorEvaluator::new(Some(collector), pruner, None, None, None, None, CollectorCallStrategy::FullRange, Arc::new(HashMap::new()), 0, Arc::new(FfmDelegatedBackendCollectorFactory), 0, None, None);
 
         let rg = RowGroupInfo {
             index: 0,
@@ -706,7 +720,7 @@ mod tests {
     fn on_batch_mask_returns_none_for_path_b() {
         let collector = Arc::new(StubCollector { docs: vec![0] }) as Arc<dyn RowGroupDocsCollector>;
         let pruner = minimal_page_pruner();
-        let eval = SingleCollectorEvaluator::new(Some(collector), pruner, None, None, None, None, CollectorCallStrategy::FullRange, Arc::new(HashMap::new()), 0, Arc::new(FfmDelegatedBackendCollectorFactory), 0, None);
+        let eval = SingleCollectorEvaluator::new(Some(collector), pruner, None, None, None, None, CollectorCallStrategy::FullRange, Arc::new(HashMap::new()), 0, Arc::new(FfmDelegatedBackendCollectorFactory), 0, None, None);
         let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, false)]));
         let batch = datafusion::arrow::record_batch::RecordBatch::try_new(
             schema,
@@ -734,7 +748,7 @@ mod tests {
         // (it's the only post-decode filter we have on this path).
         let collector = Arc::new(StubCollector { docs: vec![0] }) as Arc<dyn RowGroupDocsCollector>;
         let pruner = minimal_page_pruner();
-        let eval = SingleCollectorEvaluator::new(Some(collector), pruner, None, None, None, None, CollectorCallStrategy::FullRange, Arc::new(HashMap::new()), 0, Arc::new(FfmDelegatedBackendCollectorFactory), 0, None);
+        let eval = SingleCollectorEvaluator::new(Some(collector), pruner, None, None, None, None, CollectorCallStrategy::FullRange, Arc::new(HashMap::new()), 0, Arc::new(FfmDelegatedBackendCollectorFactory), 0, None, None);
         assert!(eval.needs_row_mask());
     }
 
@@ -742,7 +756,7 @@ mod tests {
     fn empty_match_returns_none() {
         let collector = Arc::new(StubCollector { docs: vec![] }) as Arc<dyn RowGroupDocsCollector>;
         let pruner = minimal_page_pruner();
-        let eval = SingleCollectorEvaluator::new(Some(collector), pruner, None, None, None, None, CollectorCallStrategy::FullRange, Arc::new(HashMap::new()), 0, Arc::new(FfmDelegatedBackendCollectorFactory), 0, None);
+        let eval = SingleCollectorEvaluator::new(Some(collector), pruner, None, None, None, None, CollectorCallStrategy::FullRange, Arc::new(HashMap::new()), 0, Arc::new(FfmDelegatedBackendCollectorFactory), 0, None, None);
         let rg = RowGroupInfo {
             index: 0,
             first_row: 0,
@@ -762,7 +776,7 @@ mod tests {
             docs: vec![0, 3, 7],
         }) as Arc<dyn RowGroupDocsCollector>;
         let pruner = minimal_page_pruner();
-        let eval = SingleCollectorEvaluator::new(Some(collector), pruner, None, None, None, None, CollectorCallStrategy::FullRange, Arc::new(HashMap::new()), 0, Arc::new(FfmDelegatedBackendCollectorFactory), 0, None);
+        let eval = SingleCollectorEvaluator::new(Some(collector), pruner, None, None, None, None, CollectorCallStrategy::FullRange, Arc::new(HashMap::new()), 0, Arc::new(FfmDelegatedBackendCollectorFactory), 0, None, None);
 
         let rg = RowGroupInfo {
             index: 0,
@@ -774,8 +788,64 @@ mod tests {
         assert_eq!(got, vec![0u32, 3, 7]);
     }
 
+    #[test]
+    fn stats_prune_tree_skips_rg_when_false() {
+        let collector = Arc::new(StubCollector {
+            docs: vec![0, 3, 7],
+        }) as Arc<dyn RowGroupDocsCollector>;
+        let pruner = minimal_page_pruner();
+        let spt = StatsPruneTree {
+            rg_can_match: vec![false],
+            children: vec![],
+        };
+        let eval = SingleCollectorEvaluator::new(Some(collector), pruner, None, None, None, None, CollectorCallStrategy::FullRange, Arc::new(HashMap::new()), 0, Arc::new(FfmDelegatedBackendCollectorFactory), 0, None, Some(spt));
+        let rg = RowGroupInfo {
+            index: 0,
+            first_row: 0,
+            num_rows: 8,
+        };
+        assert!(eval.prefetch_rg(&rg, 0, 8).unwrap().is_none());
+    }
+
+    #[test]
+    fn stats_prune_tree_allows_rg_when_true() {
+        let collector = Arc::new(StubCollector {
+            docs: vec![0, 3, 7],
+        }) as Arc<dyn RowGroupDocsCollector>;
+        let pruner = minimal_page_pruner();
+        let spt = StatsPruneTree {
+            rg_can_match: vec![true],
+            children: vec![],
+        };
+        let eval = SingleCollectorEvaluator::new(Some(collector), pruner, None, None, None, None, CollectorCallStrategy::FullRange, Arc::new(HashMap::new()), 0, Arc::new(FfmDelegatedBackendCollectorFactory), 0, None, Some(spt));
+        let rg = RowGroupInfo {
+            index: 0,
+            first_row: 0,
+            num_rows: 8,
+        };
+        let prefetched = eval.prefetch_rg(&rg, 0, 8).unwrap().expect("should have matches");
+        let got: Vec<u32> = prefetched.candidates.iter().collect();
+        assert_eq!(got, vec![0u32, 3, 7]);
+    }
+
+    #[test]
+    fn stats_prune_tree_none_does_not_prune() {
+        let collector = Arc::new(StubCollector {
+            docs: vec![1, 5],
+        }) as Arc<dyn RowGroupDocsCollector>;
+        let pruner = minimal_page_pruner();
+        let eval = SingleCollectorEvaluator::new(Some(collector), pruner, None, None, None, None, CollectorCallStrategy::FullRange, Arc::new(HashMap::new()), 0, Arc::new(FfmDelegatedBackendCollectorFactory), 0, None, None);
+        let rg = RowGroupInfo {
+            index: 0,
+            first_row: 0,
+            num_rows: 8,
+        };
+        let prefetched = eval.prefetch_rg(&rg, 0, 8).unwrap().expect("should have matches");
+        let got: Vec<u32> = prefetched.candidates.iter().collect();
+        assert_eq!(got, vec![1u32, 5]);
+    }
+
     // Keep the `fmt` import used
     #[allow(dead_code)]
     fn _use(_: &dyn fmt::Debug) {}
 }
-

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/page_pruner.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/page_pruner.rs
@@ -50,6 +50,7 @@ use datafusion::parquet::file::metadata::ParquetMetaData;
 #[cfg(test)]
 use datafusion::physical_expr::expressions::{BinaryExpr, Column as PhysColumn, Literal};
 use datafusion::physical_expr::PhysicalExpr;
+use datafusion::physical_expr::utils::collect_columns;
 use datafusion::physical_optimizer::pruning::{PruningPredicate, PruningStatistics};
 
 /// Per-row-group page pruner. Owns schema + metadata references; the
@@ -84,7 +85,7 @@ impl PagePruner {
         metrics: Option<&PagePruneMetrics>,
     ) -> Option<RowSelection> {
         let columns =
-            datafusion::physical_expr::utils::collect_columns(pruning_predicate.orig_expr());
+            collect_columns(pruning_predicate.orig_expr());
         if columns.is_empty() {
             return None;
         }
@@ -184,7 +185,7 @@ impl PagePruner {
         let keep = match pruning_predicate.prune(&stats) {
             Ok(k) => k,
             Err(e) => {
-                log::debug!("page pruning error for rg {}: {}", rg_idx, e);
+                native_bridge_common::log_debug!("page pruning error for rg {}: {}", rg_idx, e);
                 if let Some(m) = metrics {
                     if let Some(ref c) = m.page_pruning_unavailable {
                         c.add(1);
@@ -272,12 +273,12 @@ pub fn build_pruning_predicate(
     let pruning_predicate = match PruningPredicate::try_new(Arc::clone(expr), schema) {
         Ok(pp) => pp,
         Err(e) => {
-            log::debug!("PruningPredicate::try_new failed for {:?}: {}", expr, e);
+            native_bridge_common::log_debug!("PruningPredicate::try_new failed for {:?}: {}", expr, e);
             return None;
         }
     };
     if pruning_predicate.always_true() {
-        log::trace!("PruningPredicate collapsed to always_true for {:?}", expr);
+        native_bridge_common::log_debug!("PruningPredicate collapsed to always_true for {:?}", expr);
         return None;
     }
     Some(Arc::new(pruning_predicate))
@@ -501,6 +502,217 @@ fn to_row_selection(keep: Vec<bool>, row_counts: &[usize]) -> RowSelection {
         }
     }
     RowSelection::from(out)
+}
+
+/// Evaluate a single predicate against RG-level column stats for the given RGs.
+/// Returns a `Vec<bool>` aligned to `rg_indices`.
+///
+/// Conservative on any error: returns `true` (can-match) for every RG rather
+/// than falsely pruning. This means a stats extraction failure, missing column,
+/// or `PruningPredicate::prune` error will never cause data loss — the RG will
+/// simply not be skipped.
+fn eval_leaf(
+    pruning_predicate: &PruningPredicate,
+    metadata: &ParquetMetaData,
+    schema: &SchemaRef,
+    rg_indices: &[usize],
+) -> Vec<bool> {
+    let num = rg_indices.len();
+    if num == 0 {
+        return vec![];
+    }
+    let columns = collect_columns(pruning_predicate.orig_expr());
+    if columns.is_empty() {
+        return vec![true; num];
+    }
+    let arrow_schema = schema.as_ref();
+    let rg_metas: Vec<_> = rg_indices
+        .iter()
+        .filter_map(|&idx| metadata.row_groups().get(idx))
+        .collect();
+    if rg_metas.len() != num {
+        return vec![true; num];
+    }
+    let mut col_stats: HashMap<String, (ArrayRef, ArrayRef, Option<ArrayRef>)> = HashMap::new();
+    for col in &columns {
+        if arrow_schema.index_of(col.name()).is_err() {
+            continue;
+        }
+        let converter = match StatisticsConverter::try_new(
+            col.name(), arrow_schema, metadata.file_metadata().schema_descr(),
+        ) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+        let min_arr = match converter.row_group_mins(rg_metas.iter().copied()) {
+            Ok(arr) => arr,
+            Err(_) => continue,
+        };
+        let max_arr = match converter.row_group_maxes(rg_metas.iter().copied()) {
+            Ok(arr) => arr,
+            Err(_) => continue,
+        };
+        let null_counts = converter
+            .row_group_null_counts(rg_metas.iter().copied())
+            .ok()
+            .map(|arr| Arc::new(arr) as ArrayRef);
+        col_stats.insert(col.name().to_string(), (min_arr, max_arr, null_counts));
+    }
+    if col_stats.is_empty() {
+        return vec![true; num];
+    }
+    let stats = RgLevelStats {
+        col_stats,
+        num_rgs: num,
+        row_counts: rg_metas.iter().map(|m| m.num_rows()).collect(),
+    };
+    match pruning_predicate.prune(&stats) {
+        Ok(keep) => keep,
+        Err(_) => vec![true; num],
+    }
+}
+
+struct RgLevelStats {
+    col_stats: HashMap<String, (ArrayRef, ArrayRef, Option<ArrayRef>)>,
+    num_rgs: usize,
+    row_counts: Vec<i64>,
+}
+
+impl PruningStatistics for RgLevelStats {
+    fn min_values(&self, column: &Column) -> Option<ArrayRef> {
+        self.col_stats.get(column.name()).map(|(m, _, _)| Arc::clone(m))
+    }
+    fn max_values(&self, column: &Column) -> Option<ArrayRef> {
+        self.col_stats.get(column.name()).map(|(_, m, _)| Arc::clone(m))
+    }
+    fn num_containers(&self) -> usize {
+        self.num_rgs
+    }
+    fn null_counts(&self, column: &Column) -> Option<ArrayRef> {
+        self.col_stats.get(column.name()).and_then(|(_, _, n)| n.clone())
+    }
+    fn row_counts(&self) -> Option<ArrayRef> {
+        let arr = Int64Array::from_iter_values(self.row_counts.iter().copied());
+        Some(Arc::new(arr) as ArrayRef)
+    }
+    fn contained(
+        &self,
+        _column: &Column,
+        _values: &std::collections::HashSet<ScalarValue>,
+    ) -> Option<BooleanArray> {
+        None
+    }
+}
+
+/// Precomputed tree of per-RG match vectors built from column statistics.
+/// Used for segment-level, RG-level, and subtree-level pruning.
+///
+/// # Example: 5 RGs, 9 leaves
+///
+/// Legend: `df` = Predicate leaf (parquet column stats), `luc` = Collector (always true).
+/// Each node shows its `rg_can_match` bitset: `[RG0, RG1, RG2, RG3, RG4]`.
+///
+/// ```text
+///                                  AND
+///                                [00001]
+///                /                  |                  \
+///              OR                   OR                  AND
+///           [01101]              [11111]              [00011]
+///          /       \          /     |     \          /       \
+///       AND         df     AND     luc     df      df        NOT
+///     [01100]    [00001] [00100] [11111] [11110] [00011]   [11111]
+///      /   \              /   \                              |
+///    df     df          df     df                           df
+/// [11100] [01111]    [11100] [00111]                     [11000]
+/// ```
+///
+/// Bottom-up:
+///   - AND(df[11100], df[01111]) = [01100]
+///   - OR₁(AND[01100], df[00001]) = [01101]
+///   - AND(df[11100], df[00111]) = [00100]
+///   - OR₂(AND[00100], luc[11111], df[11110]) = [11111]  ← luc dominates
+///   - NOT(df[11000]) = [11111]  ← conservative: can't prune through negation
+///   - AND₃(df[00011], NOT[11111]) = [00011]
+///   - Root AND(OR₁[01101], OR₂[11111], AND₃[00011]) = [00001]
+///
+/// Result: only RG4 survives. NOT is always [11111] because inverting
+/// stats-based pruning is unsound (superset inverted = subset).
+/// Subtree vectors enable short-circuiting: for RG0, AND₃=[0....] so the
+/// bitmap-tree walk skips that entire subtree (no FFM collector calls).
+#[derive(Clone)]
+pub struct StatsPruneTree {
+    /// Per-RG: `false` means this subtree provably can't match that RG.
+    pub rg_can_match: Vec<bool>,
+    pub children: Vec<StatsPruneTree>,
+}
+
+impl StatsPruneTree {
+    pub fn build_from_bool_node(
+        node: &super::bool_tree::BoolNode,
+        leaf_predicates: &HashMap<usize, Arc<PruningPredicate>>,
+        metadata: &ParquetMetaData,
+        schema: &SchemaRef,
+        rg_indices: &[usize],
+    ) -> Self {
+        use super::bool_tree::BoolNode;
+        let num = rg_indices.len();
+        match node {
+            BoolNode::And(children) => {
+                let annotated_children: Vec<_> = children
+                    .iter()
+                    .map(|c| Self::build_from_bool_node(c, leaf_predicates, metadata, schema, rg_indices))
+                    .collect();
+                let mut rg_can_match = vec![true; num];
+                for child in &annotated_children {
+                    for (r, c) in rg_can_match.iter_mut().zip(child.rg_can_match.iter()) {
+                        *r &= c;
+                    }
+                }
+                Self { rg_can_match, children: annotated_children }
+            }
+            BoolNode::Or(children) => {
+                let annotated_children: Vec<_> = children
+                    .iter()
+                    .map(|c| Self::build_from_bool_node(c, leaf_predicates, metadata, schema, rg_indices))
+                    .collect();
+                let mut rg_can_match = vec![false; num];
+                for child in &annotated_children {
+                    for (r, c) in rg_can_match.iter_mut().zip(child.rg_can_match.iter()) {
+                        *r |= c;
+                    }
+                }
+                Self { rg_can_match, children: annotated_children }
+            }
+            BoolNode::Not(child) => {
+                let annotated_child = Self::build_from_bool_node(child, leaf_predicates, metadata, schema, rg_indices);
+                // NOT is conservatively all-true: negating stats-based pruning is unsound
+                // because stats give a superset, and inverting a superset is a subset.
+                native_bridge_common::log_debug!("StatsPruneTree: NOT node → all-true (conservative, cannot prune through negation)");
+                Self { rg_can_match: vec![true; num], children: vec![annotated_child] }
+            }
+            BoolNode::Predicate(expr) => {
+                let key = Arc::as_ptr(expr) as *const () as usize;
+                let rg_can_match = match leaf_predicates.get(&key) {
+                    Some(pp) => eval_leaf(pp, metadata, schema, rg_indices),
+                    None => vec![true; num],
+                };
+                Self { rg_can_match, children: vec![] }
+            }
+            BoolNode::DelegationPossible { original_expr, .. } => {
+                let key = Arc::as_ptr(original_expr) as *const () as usize;
+                let rg_can_match = match leaf_predicates.get(&key) {
+                    Some(pp) => eval_leaf(pp, metadata, schema, rg_indices),
+                    None => vec![true; num],
+                };
+                Self { rg_can_match, children: vec![] }
+            }
+            BoolNode::Collector { .. } => {
+                // Collectors have no column stats — always all-true.
+                native_bridge_common::log_debug!("StatsPruneTree: Collector node → all-true (no column stats available)");
+                Self { rg_can_match: vec![true; num], children: vec![] }
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -1202,5 +1414,127 @@ mod tests {
             "RG0: only page 0 (min=0, max=7) overlaps price<4"
         );
         assert_eq!(count_rows_kept(&sel1), 0, "RG1: no page has values < 4");
+    }
+
+    /// Matches the tree from the doc comment on `StatsPruneTree`:
+    ///
+    /// ```text
+    ///                                  AND
+    ///                                [00001]
+    ///                /                  |                  \
+    ///              OR                   OR                  AND
+    ///           [01101]              [11111]              [00011]
+    ///          /       \          /     |     \          /       \
+    ///       AND         df     AND     luc     df      df        NOT
+    ///     [01100]    [00001] [00100] [11111] [11110] [00011]   [11111]
+    ///      /   \              /   \                              |
+    ///    df     df          df     df                           df
+    /// [11100] [01111]    [11100] [00111]                     [11000]
+    /// ```
+    ///
+    /// Uses 5 RGs (price ranges [0..9],[10..19],[20..29],[30..39],[40..49])
+    /// to verify the full shape and bitset propagation.
+    #[test]
+    fn stats_prune_tree_five_leaf_shape() {
+        use crate::indexed_table::bool_tree::BoolNode;
+
+        // 5 RGs: price [0..9], [10..19], [20..29], [30..39], [40..49]
+        let schema = Arc::new(Schema::new(vec![Field::new("price", DataType::Int32, false)]));
+        let tmp = NamedTempFile::new().unwrap();
+        let props = WriterProperties::builder()
+            .set_max_row_group_size(10)
+            .set_statistics_enabled(EnabledStatistics::Chunk)
+            .build();
+        let mut w = ArrowWriter::try_new(tmp.reopen().unwrap(), schema.clone(), Some(props)).unwrap();
+        for i in 0..5i32 {
+            let vals: Vec<i32> = (i * 10..(i + 1) * 10).collect();
+            let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(Int32Array::from(vals))]).unwrap();
+            w.write(&batch).unwrap();
+        }
+        w.close().unwrap();
+        let meta = ArrowReaderMetadata::load(&tmp.reopen().unwrap(), ArrowReaderOptions::new()).unwrap();
+        let arc_meta = meta.metadata().clone();
+        assert_eq!(arc_meta.num_row_groups(), 5);
+        let rg_indices: Vec<usize> = (0..5).collect();
+
+        // Leaf predicates and their expected rg_can_match bitsets:
+        let p1 = pred_leaf("price", Operator::Lt, 30, &schema);   // [11100]
+        let p2 = pred_leaf("price", Operator::GtEq, 10, &schema); // [01111]
+        let p3 = pred_leaf("price", Operator::Gt, 45, &schema);   // [00001]
+        let p4 = pred_leaf("price", Operator::Lt, 25, &schema);   // [11100]
+        let p5 = pred_leaf("price", Operator::GtEq, 20, &schema); // [00111]
+        let p6 = pred_leaf("price", Operator::Lt, 40, &schema);   // [11110]
+        let p7 = pred_leaf("price", Operator::Gt, 30, &schema);   // [00011]
+        let p8 = pred_leaf("price", Operator::Lt, 15, &schema);   // [11000]
+
+        // Tree: AND(OR(AND(p1,p2), p3), OR(AND(p4,p5), Collector, p6), AND(p7, NOT(p8)))
+        let collector = BoolNode::Collector { annotation_id: 0 };
+        let tree = BoolNode::And(vec![
+            BoolNode::Or(vec![
+                BoolNode::And(vec![p1.clone(), p2.clone()]),
+                p3.clone(),
+            ]),
+            BoolNode::Or(vec![
+                BoolNode::And(vec![p4.clone(), p5.clone()]),
+                collector,
+                p6.clone(),
+            ]),
+            BoolNode::And(vec![
+                p7.clone(),
+                BoolNode::Not(Box::new(p8.clone())),
+            ]),
+        ]);
+
+        // Build PruningPredicates for all df leaves.
+        let mut leaf_predicates: HashMap<usize, Arc<PruningPredicate>> = HashMap::new();
+        for node in [&p1, &p2, &p3, &p4, &p5, &p6, &p7, &p8] {
+            if let BoolNode::Predicate(expr) = node {
+                let key = Arc::as_ptr(expr) as *const () as usize;
+                let pp = build_pruning_predicate(expr, schema.clone()).unwrap();
+                leaf_predicates.insert(key, pp);
+            }
+        }
+
+        let spt = StatsPruneTree::build_from_bool_node(
+            &tree, &leaf_predicates, &arc_meta, &schema, &rg_indices,
+        );
+
+        // Verify bottom-up:
+        //   AND(p1[11100], p2[01111]) = [01100]
+        //   OR₁(AND[01100], p3[00001]) = [01101]
+        //   AND(p4[11100], p5[00111]) = [00100]
+        //   OR₂(AND[00100], luc[11111], p6[11110]) = [11111]  ← luc dominates
+        //   NOT(p8[11000]) = [11111]  ← conservative
+        //   AND₃(p7[00011], NOT[11111]) = [00011]
+        //   Root AND(OR₁[01101], OR₂[11111], AND₃[00011]) = [00001]
+
+        // Root
+        assert_eq!(spt.rg_can_match, vec![false, false, false, false, true]);
+        assert_eq!(spt.children.len(), 3);
+
+        // Child 0: OR₁
+        assert_eq!(spt.children[0].rg_can_match, vec![false, true, true, false, true]);
+        assert_eq!(spt.children[0].children.len(), 2);
+        // OR₁/AND
+        assert_eq!(spt.children[0].children[0].rg_can_match, vec![false, true, true, false, false]);
+        // OR₁/AND/p1
+        assert_eq!(spt.children[0].children[0].children[0].rg_can_match, vec![true, true, true, false, false]);
+        // OR₁/AND/p2
+        assert_eq!(spt.children[0].children[0].children[1].rg_can_match, vec![false, true, true, true, true]);
+        // OR₁/p3
+        assert_eq!(spt.children[0].children[1].rg_can_match, vec![false, false, false, false, true]);
+
+        // Child 1: OR₂ — luc makes it all-true
+        assert_eq!(spt.children[1].rg_can_match, vec![true, true, true, true, true]);
+
+        // Child 2: AND₃
+        assert_eq!(spt.children[2].rg_can_match, vec![false, false, false, true, true]);
+        assert_eq!(spt.children[2].children.len(), 2);
+        // AND₃/p7
+        assert_eq!(spt.children[2].children[0].rg_can_match, vec![false, false, false, true, true]);
+        // AND₃/NOT → always true
+        assert_eq!(spt.children[2].children[1].rg_can_match, vec![true, true, true, true, true]);
+        // AND₃/NOT/p8
+        assert_eq!(spt.children[2].children[1].children[0].rg_can_match, vec![true, true, false, false, false]);
     }
 }

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/stream.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/stream.rs
@@ -33,6 +33,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
+use native_bridge_common::log_debug;
 use datafusion::arrow::array::{Array, BooleanArray, UInt64Array};
 use datafusion::arrow::compute::filter_record_batch;
 use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
@@ -482,6 +483,8 @@ struct IndexedStream {
     mask_offset: usize,
     batch_offset: usize,
     finished: bool,
+    /// Wall-clock start time for per-segment timing. Set on first poll.
+    stream_start: Option<std::time::Instant>,
     metadata: Arc<ParquetMetaData>,
     predicate: Option<Arc<dyn datafusion::physical_expr::PhysicalExpr>>,
     initialized: bool,
@@ -575,6 +578,7 @@ impl IndexedStream {
             mask_offset: 0,
             batch_offset: 0,
             finished: false,
+            stream_start: None,
             metadata,
             predicate,
             initialized: false,
@@ -777,6 +781,7 @@ impl Stream for IndexedStream {
         let poll_start = Instant::now();
 
         if !self.initialized {
+            self.stream_start = Some(Instant::now());
             self.index_reader.init_prefetch();
             self.initialized = true;
         }
@@ -809,6 +814,7 @@ impl IndexedStream {
 
             // 2. If upstream is done and coalescer has drained, we're done.
             if self.coalescer_finished && self.batch_coalescer.is_empty() {
+                log_debug!("[scf-segment-done] file={} row_groups={} elapsed={:?}", self.object_path.filename().unwrap_or("?"), self.index_reader.row_groups.len(), self.stream_start.unwrap().elapsed());
                 return Poll::Ready(None);
             }
 
@@ -828,6 +834,7 @@ impl IndexedStream {
             if self.coalescer_finished {
                 // Unreachable in practice — step 1 already drained or
                 // step 2 already returned. Defensive.
+                log_debug!("[scf-segment-done] file={} row_groups={} elapsed={:?}", self.object_path.filename().unwrap_or("?"), self.index_reader.row_groups.len(), self.stream_start.unwrap().elapsed());
                 return Poll::Ready(None);
             }
 

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/table_provider.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/table_provider.rs
@@ -40,16 +40,19 @@ use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
 use datafusion::physical_plan::metrics::{ExecutionPlanMetricsSet, MetricsSet};
 use datafusion::physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties};
 use datafusion_common::DataFusionError;
+use datafusion::physical_optimizer::pruning::PruningPredicate;
 
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use futures::StreamExt;
 
+use super::bool_tree::BoolNode;
 use super::eval::RowGroupBitsetSource;
 use super::metrics::PartitionMetrics;
 use super::partitioning::{compute_assignments, PartitionAssignment, SegmentChunk, SegmentLayout};
 use super::stream::{FilterStrategy, IndexedExec, RowGroupInfo};
 use crate::datafusion_query_config::DatafusionQueryConfig;
 use crate::indexed_table::metrics::StreamMetrics;
+use crate::indexed_table::page_pruner::StatsPruneTree;
 use std::collections::HashSet;
 
 /// Info about a segment and its corresponding parquet file.
@@ -95,6 +98,7 @@ pub type EvaluatorFactory = Arc<
             &SegmentFileInfo,
             &SegmentChunk,
             &StreamMetrics,
+            Option<&StatsPruneTree>,
         ) -> Result<Arc<dyn RowGroupBitsetSource>, String>
         + Send
         + Sync,
@@ -133,6 +137,13 @@ pub struct IndexedTableConfig {
     /// from position (global_base + rg.first_row + position_in_rg) instead of
     /// being read from parquet. Other projected columns are read normally.
     pub emit_row_ids: bool,
+    /// Query-level data for building StatsPruneTree per segment.
+    /// (BoolNode tree, prebuilt PruningPredicates keyed by Arc ptr, schema)
+    pub prune_tree_config: Option<(
+        BoolNode,
+        Arc<std::collections::HashMap<usize, Arc<PruningPredicate>>>,
+        SchemaRef,
+    )>,
 }
 
 /// Table provider. Returns a `QueryShardExec` that fans out across chunks.
@@ -493,8 +504,24 @@ impl ExecutionPlan for QueryShardExec {
                 continue;
             }
 
+            // Build stats prune tree for segment/RG/subtree-level pruning.
+            let stats_prune_tree = self.config.prune_tree_config.as_ref().map(|(tree, preds, schema)| {
+                let rg_indices: Vec<usize> = row_groups.iter().map(|rg| rg.index).collect();
+                StatsPruneTree::build_from_bool_node(
+                    tree, preds, &segment.metadata, schema, &rg_indices,
+                )
+            });
+
+            // Segment-level skip: if no RG in the chunk can match, skip entirely.
+            if let Some(ref spt) = stats_prune_tree {
+                if !spt.rg_can_match.iter().any(|&k| k) {
+                    native_bridge_common::log_debug!("[segment-skip] skipping chunk — pruned by segment-level stats");
+                    continue;
+                }
+            }
+
             // Build evaluator for this chunk.
-            let evaluator = (self.config.evaluator_factory)(segment, chunk, &stream_metrics)
+            let evaluator = (self.config.evaluator_factory)(segment, chunk, &stream_metrics, stats_prune_tree.as_ref())
                 .map_err(|e| DataFusionError::External(e.into()))?;
 
             let props = Arc::new(PlanProperties::new(
@@ -631,13 +658,14 @@ mod tests {
             store: Arc::new(object_store::local::LocalFileSystem::new()),
             store_url: datafusion::execution::object_store::ObjectStoreUrl::local_filesystem(),
             // Evaluator factory would never be invoked for this test (no segments).
-            evaluator_factory: Arc::new(|_, _, _| unreachable!()),
+            evaluator_factory: Arc::new(|_, _, _, _| unreachable!()),
             pushdown_predicate: None,
             query_config: std::sync::Arc::new(
                 crate::datafusion_query_config::DatafusionQueryConfig::test_default(),
             ),
             predicate_columns: vec![],
             emit_row_ids: false,
+            prune_tree_config: None,
         }
     }
 

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/constant_predicate.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/constant_predicate.rs
@@ -80,13 +80,14 @@ async fn run_constant_residual(residual: Arc<dyn PhysicalExpr>) -> usize {
     let factory: EvaluatorFactory = {
         let schema = schema.clone();
         let residual = Arc::clone(&residual);
-        Arc::new(move |segment: &SegmentFileInfo, _chunk, stream_metrics| {
+        Arc::new(move |segment: &SegmentFileInfo, _chunk, stream_metrics, _stats_prune_tree| {
             let pruner = Arc::new(PagePruner::new(&schema, Arc::clone(&segment.metadata)));
             let eval: Arc<dyn RowGroupBitsetSource> = Arc::new(PredicateOnlyEvaluator::new(
                 pruner,
                 None,
                 Some(Arc::clone(&residual)),
                 Some(PagePruneMetrics::from_stream_metrics(stream_metrics)),
+                None,
             ));
             Ok(eval)
         })
@@ -109,7 +110,7 @@ async fn run_constant_residual(residual: Arc<dyn PhysicalExpr>) -> usize {
         pushdown_predicate: None,
         query_config: std::sync::Arc::new(qc),
         predicate_columns: vec![],
-        emit_row_ids: false,
+        emit_row_ids: false, prune_tree_config: None,
     }));
 
     let ctx = SessionContext::new();

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/dynamic_filter_pushdown.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/dynamic_filter_pushdown.rs
@@ -135,7 +135,7 @@ async fn run_indexed(
 
     let factory: super::super::table_provider::EvaluatorFactory = {
         let schema = schema.clone();
-        Arc::new(move |segment, _chunk, _stream_metrics| {
+        Arc::new(move |segment, _chunk, _stream_metrics, _stats_prune_tree| {
             let pruner = Arc::new(PagePruner::new(&schema, Arc::clone(&segment.metadata)));
             let collector: Arc<dyn RowGroupDocsCollector> = Arc::new(MatchAllCollector);
             let eval: Arc<dyn RowGroupBitsetSource> = Arc::new(
@@ -153,6 +153,7 @@ async fn run_indexed(
                         crate::indexed_table::eval::single_collector::FfmDelegatedBackendCollectorFactory,
                     ),
                     0,
+                    None,
                     None,
                 ),
             );
@@ -183,6 +184,7 @@ async fn run_indexed(
         query_config: std::sync::Arc::new(qc),
         predicate_columns: vec![],
         emit_row_ids: false,
+        prune_tree_config: None,
     }));
 
     let ctx = SessionContext::new();

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/fuzz/delegation.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/fuzz/delegation.rs
@@ -405,7 +405,7 @@ pub(in crate::indexed_table::tests_e2e) async fn execute_delegation_tree(
         let factory = Arc::clone(&factory);
         let provider_locks = Arc::clone(&provider_locks);
         let schema = loaded.schema.clone();
-        Arc::new(move |segment, _chunk, stream_metrics| {
+        Arc::new(move |segment, _chunk, stream_metrics, _stats_prune_tree| {
             let pruner = Arc::new(PagePruner::new(&schema, Arc::clone(&segment.metadata)));
             let eval: Arc<dyn RowGroupBitsetSource> = Arc::new(SingleCollectorEvaluator::new(
                 Some(Arc::clone(&correctness)),
@@ -419,6 +419,7 @@ pub(in crate::indexed_table::tests_e2e) async fn execute_delegation_tree(
                 segment.writer_generation,
                 Arc::clone(&factory),
                 0,
+                None,
                 None,
             ));
             Ok(eval)
@@ -467,7 +468,7 @@ pub(in crate::indexed_table::tests_e2e) async fn execute_delegation_tree(
         pushdown_predicate: Some(Arc::clone(&residual_physical)),
         query_config: Arc::new(qc),
         predicate_columns: pred_cols,
-        emit_row_ids: false,
+        emit_row_ids: false, prune_tree_config: None,
     }));
 
     let ctx = SessionContext::new();

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/fuzz/harness.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/fuzz/harness.rs
@@ -234,7 +234,7 @@ pub(in crate::indexed_table::tests_e2e) async fn execute_tree_with_plan_pushdown
                 })
                 .collect(),
         );
-        Arc::new(move |segment, _chunk, stream_metrics| {
+        Arc::new(move |segment, _chunk, stream_metrics, _stats_prune_tree| {
             let resolved = tree.resolve(&per_leaf)?;
             let pruner = Arc::new(PagePruner::new(&schema, Arc::clone(&segment.metadata)));
             let eval: Arc<dyn RowGroupBitsetSource> = Arc::new(TreeBitsetSource {
@@ -264,6 +264,7 @@ pub(in crate::indexed_table::tests_e2e) async fn execute_tree_with_plan_pushdown
                     crate::indexed_table::eval::CollectorCallStrategy::FullRange,
                     crate::indexed_table::eval::CollectorCallStrategy::PageRangeSplit,
                 ][seed as usize % 3],
+                stats_prune_tree: None,
             });
             Ok(eval)
         })
@@ -290,7 +291,7 @@ pub(in crate::indexed_table::tests_e2e) async fn execute_tree_with_plan_pushdown
         pushdown_predicate: None,
         query_config: Arc::new(qc),
         predicate_columns: collect_predicate_column_indices(&bool_tree),
-        emit_row_ids: false,
+        emit_row_ids: false, prune_tree_config: None,
     }));
 
     let ctx = SessionContext::new();
@@ -384,7 +385,7 @@ pub(in crate::indexed_table::tests_e2e) async fn execute_tree_single_collector(
         let schema = schema.clone();
         let residual_pp = residual_pp.clone();
         let residual_physical = residual_physical.clone();
-        Arc::new(move |segment, _chunk, stream_metrics| {
+        Arc::new(move |segment, _chunk, stream_metrics, _stats_prune_tree| {
             let pruner = Arc::new(PagePruner::new(&schema, Arc::clone(&segment.metadata)));
             let eval: Arc<dyn RowGroupBitsetSource> = Arc::new(SingleCollectorEvaluator::new(
                 Some(Arc::clone(&collector)),
@@ -403,6 +404,7 @@ pub(in crate::indexed_table::tests_e2e) async fn execute_tree_single_collector(
                 std::sync::Arc::new(crate::indexed_table::eval::single_collector::FfmDelegatedBackendCollectorFactory),
                 0,
                 None,
+                    None,
             ));
             let _ = segment;
             Ok(eval)
@@ -471,7 +473,7 @@ async fn run_single_collector_query(
         pushdown_predicate,
         query_config: Arc::new(qc),
         predicate_columns: pred_cols,
-        emit_row_ids: false,
+        emit_row_ids: false, prune_tree_config: None,
     }));
     let ctx = SessionContext::new();
     ctx.register_table("t", provider).unwrap();
@@ -680,7 +682,7 @@ async fn run_with_factory_plan(
         pushdown_predicate,
         query_config: Arc::new(qc),
         predicate_columns: vec![],
-        emit_row_ids: false,
+        emit_row_ids: false, prune_tree_config: None,
     }));
     let ctx = SessionContext::new();
     ctx.register_table("t", provider).unwrap();

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/mod.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/mod.rs
@@ -248,7 +248,7 @@ async fn run_tree_and_plan(
         let per_leaf = per_leaf.clone();
         let tree = Arc::clone(&tree);
         let schema = schema.clone();
-        Arc::new(move |segment, _chunk, _stream_metrics| {
+        Arc::new(move |segment, _chunk, _stream_metrics, _stats_prune_tree| {
             let resolved = tree.resolve(&per_leaf)?;
             let pruner = Arc::new(PagePruner::new(&schema, Arc::clone(&segment.metadata)));
             let eval: Arc<dyn RowGroupBitsetSource> = Arc::new(TreeBitsetSource {
@@ -270,6 +270,7 @@ async fn run_tree_and_plan(
                     ),
                 ),
                 collector_strategy: crate::indexed_table::eval::CollectorCallStrategy::TightenOuterBounds,
+                stats_prune_tree: None,
             });
             Ok(eval)
         })
@@ -296,7 +297,7 @@ async fn run_tree_and_plan(
         pushdown_predicate: None,
         query_config: std::sync::Arc::new(qc),
         predicate_columns: vec![],
-        emit_row_ids: false,
+        emit_row_ids: false, prune_tree_config: None,
     }));
 
     let ctx = SessionContext::new();

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/multi_segment.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/multi_segment.rs
@@ -144,7 +144,7 @@ async fn run_two_segment_query(
         {
             let per_segment_matches = Arc::clone(&per_segment_matches);
             let schema = schema.clone();
-            Arc::new(move |segment, _chunk, _stream_metrics| {
+            Arc::new(move |segment, _chunk, _stream_metrics, _stats_prune_tree| {
                 let matching = per_segment_matches
                     .get(segment.writer_generation as usize)
                     .cloned()
@@ -160,6 +160,7 @@ async fn run_two_segment_query(
                     segment.writer_generation,
                     std::sync::Arc::new(crate::indexed_table::eval::single_collector::FfmDelegatedBackendCollectorFactory),
                     0,
+                    None,
                     None,
                 ),
             );
@@ -184,7 +185,7 @@ async fn run_two_segment_query(
         pushdown_predicate: None,
         query_config: std::sync::Arc::new(qc),
         predicate_columns: vec![],
-        emit_row_ids: false,
+        emit_row_ids: false, prune_tree_config: None,
     }));
 
     let ctx = SessionContext::new();
@@ -346,7 +347,7 @@ async fn run_two_segment_query_witness(
         let schema = schema.clone();
         let in_flight = Arc::clone(&in_flight);
         let max_in_flight = Arc::clone(&max_in_flight);
-        Arc::new(move |segment, _chunk, _stream_metrics| {
+        Arc::new(move |segment, _chunk, _stream_metrics, _stats_prune_tree| {
             let matching = per_segment_matches
                 .get(segment.writer_generation as usize)
                 .cloned()
@@ -366,6 +367,7 @@ async fn run_two_segment_query_witness(
                     segment.writer_generation,
                     std::sync::Arc::new(crate::indexed_table::eval::single_collector::FfmDelegatedBackendCollectorFactory),
                     0,
+                    None,
                     None,
                 ),
             );
@@ -390,7 +392,7 @@ async fn run_two_segment_query_witness(
         pushdown_predicate: None,
         query_config: std::sync::Arc::new(qc),
         predicate_columns: vec![],
-        emit_row_ids: false,
+        emit_row_ids: false, prune_tree_config: None,
     }));
 
     let ctx = SessionContext::new();
@@ -554,7 +556,7 @@ async fn run_segments(specs: Vec<SegSpec>, num_partitions: usize) -> Vec<(i32, S
         {
             let per_segment_matches = Arc::clone(&per_segment_matches);
             let schema = schema.clone();
-            Arc::new(move |segment, _chunk, _stream_metrics| {
+            Arc::new(move |segment, _chunk, _stream_metrics, _stats_prune_tree| {
                 let matching = per_segment_matches
                     .get(segment.writer_generation as usize)
                     .cloned()
@@ -570,6 +572,7 @@ async fn run_segments(specs: Vec<SegSpec>, num_partitions: usize) -> Vec<(i32, S
                     segment.writer_generation,
                     std::sync::Arc::new(crate::indexed_table::eval::single_collector::FfmDelegatedBackendCollectorFactory),
                     0,
+                    None,
                     None,
                 ),
             );
@@ -594,7 +597,7 @@ async fn run_segments(specs: Vec<SegSpec>, num_partitions: usize) -> Vec<(i32, S
         pushdown_predicate: None,
         query_config: std::sync::Arc::new(qc),
         predicate_columns: vec![],
-        emit_row_ids: false,
+        emit_row_ids: false, prune_tree_config: None,
     }));
 
     let ctx = SessionContext::new();
@@ -1046,7 +1049,7 @@ async fn run_wide_segments(
     let factory: super::super::table_provider::EvaluatorFactory = {
         let tree = Arc::clone(&tree);
         let schema = schema.clone();
-        Arc::new(move |segment, _chunk, _stream_metrics| {
+        Arc::new(move |segment, _chunk, _stream_metrics, _stats_prune_tree| {
             // One (provider_key, collector) per Collector leaf — our trees
             // here use 1 collector leaf, so one pair.
             let leaf_count = tree.collector_leaf_count();
@@ -1074,6 +1077,7 @@ async fn run_wide_segments(
                     pruning_predicates: std::sync::Arc::new(std::collections::HashMap::new()),
                 page_prune_metrics: None,
                     collector_strategy: crate::indexed_table::eval::CollectorCallStrategy::TightenOuterBounds,
+                stats_prune_tree: None,
                 },
             );
             Ok(eval)
@@ -1097,7 +1101,7 @@ async fn run_wide_segments(
         pushdown_predicate: None,
         query_config: std::sync::Arc::new(qc),
         predicate_columns: vec![],
-        emit_row_ids: false,
+        emit_row_ids: false, prune_tree_config: None,
     }));
 
     let ctx = SessionContext::new();

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/null_columns.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/null_columns.rs
@@ -346,7 +346,7 @@ async fn assert_engine_matches_reference_null(name: &str, tree: NT) {
         let per_leaf = per_leaf.clone();
         let tree = Arc::clone(&tree);
         let schema = schema.clone();
-        Arc::new(move |segment, _chunk, _stream_metrics| {
+        Arc::new(move |segment, _chunk, _stream_metrics, _stats_prune_tree| {
             let resolved = tree.resolve(&per_leaf)?;
             let pruner = Arc::new(PagePruner::new(&schema, Arc::clone(&segment.metadata)));
             let eval: Arc<dyn RowGroupBitsetSource> = Arc::new(TreeBitsetSource {
@@ -361,6 +361,7 @@ async fn assert_engine_matches_reference_null(name: &str, tree: NT) {
                 page_prune_metrics: None,
                 collector_strategy:
                     crate::indexed_table::eval::CollectorCallStrategy::TightenOuterBounds,
+                stats_prune_tree: None,
             });
             Ok(eval)
         })
@@ -381,7 +382,7 @@ async fn assert_engine_matches_reference_null(name: &str, tree: NT) {
         pushdown_predicate: None,
         query_config: std::sync::Arc::new(qc),
         predicate_columns: vec![],
-        emit_row_ids: false,
+        emit_row_ids: false, prune_tree_config: None,
     }));
     let ctx = SessionContext::new();
     ctx.register_table("t", provider).unwrap();

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/page_pruning.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/page_pruning.rs
@@ -307,7 +307,7 @@ async fn run_bitmap_tree(tree: BoolNode) -> (Vec<i32>, Arc<dyn ExecutionPlan>) {
         let tree = Arc::clone(&tree);
         let schema = schema.clone();
         let pp_map = Arc::clone(&pp_map);
-        Arc::new(move |segment, _chunk, sm| {
+        Arc::new(move |segment, _chunk, sm, _stats_prune_tree| {
             let resolved = tree.resolve(&per_leaf)?;
             let pruner = Arc::new(PagePruner::new(&schema, Arc::clone(&segment.metadata)));
             let eval: Arc<dyn RowGroupBitsetSource> = Arc::new(TreeBitsetSource {
@@ -326,6 +326,7 @@ async fn run_bitmap_tree(tree: BoolNode) -> (Vec<i32>, Arc<dyn ExecutionPlan>) {
                 ),
                 collector_strategy:
                     crate::indexed_table::eval::CollectorCallStrategy::TightenOuterBounds,
+                stats_prune_tree: None,
             });
             Ok(eval)
         })
@@ -348,7 +349,7 @@ async fn run_single_collector(
         let schema = schema.clone();
         let residual_pp = residual_pp.clone();
         let residual_expr = Arc::clone(&residual_expr);
-        Arc::new(move |segment, _chunk, sm| {
+        Arc::new(move |segment, _chunk, sm, _stats_prune_tree| {
             let pruner = Arc::new(PagePruner::new(&schema, Arc::clone(&segment.metadata)));
             let eval: Arc<dyn RowGroupBitsetSource> = Arc::new(SingleCollectorEvaluator::new(
                 Some(collector_for_tag(collector_tag)),
@@ -363,6 +364,7 @@ async fn run_single_collector(
                 std::sync::Arc::new(crate::indexed_table::eval::single_collector::FfmDelegatedBackendCollectorFactory),
                 0,
                 None,
+                    None,
             ));
             Ok(eval)
         })
@@ -393,7 +395,7 @@ async fn execute_and_collect(
         pushdown_predicate: None,
         query_config: Arc::new(qc),
         predicate_columns: vec![],
-        emit_row_ids: false,
+        emit_row_ids: false, prune_tree_config: None,
     }));
 
     let ctx = SessionContext::new();

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/qtf_fetch_phase.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/qtf_fetch_phase.rs
@@ -76,7 +76,7 @@ async fn query_phase(tree: BoolNode) -> Vec<i64> {
         let per_leaf = per_leaf.clone();
         let tree = Arc::clone(&tree);
         let schema = schema.clone();
-        Arc::new(move |segment, _chunk, _stream_metrics| {
+        Arc::new(move |segment, _chunk, _stream_metrics, _stats_prune_tree| {
             let resolved = tree.resolve(&per_leaf)?;
             let pruner = Arc::new(PagePruner::new(&schema, Arc::clone(&segment.metadata)));
             let eval: Arc<dyn RowGroupBitsetSource> = Arc::new(TreeBitsetSource {
@@ -99,6 +99,7 @@ async fn query_phase(tree: BoolNode) -> Vec<i64> {
                 ),
                 collector_strategy:
                     crate::indexed_table::eval::CollectorCallStrategy::TightenOuterBounds,
+                stats_prune_tree: None,
             });
             Ok(eval)
         })
@@ -122,7 +123,7 @@ async fn query_phase(tree: BoolNode) -> Vec<i64> {
             qc
         }),
         predicate_columns: vec![0, 1, 2, 3],
-        emit_row_ids: true,
+        emit_row_ids: true, prune_tree_config: None,
     }));
 
     let ctx = SessionContext::new();

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/row_id_emission.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/row_id_emission.rs
@@ -66,7 +66,7 @@ async fn run_tree_row_ids(tree: BoolNode) -> Vec<i64> {
         let per_leaf = per_leaf.clone();
         let tree = Arc::clone(&tree);
         let schema = schema.clone();
-        Arc::new(move |segment, _chunk, _stream_metrics| {
+        Arc::new(move |segment, _chunk, _stream_metrics, _stats_prune_tree| {
             let resolved = tree.resolve(&per_leaf)?;
             let pruner = Arc::new(PagePruner::new(&schema, Arc::clone(&segment.metadata)));
             let eval: Arc<dyn RowGroupBitsetSource> = Arc::new(TreeBitsetSource {
@@ -89,6 +89,7 @@ async fn run_tree_row_ids(tree: BoolNode) -> Vec<i64> {
                 ),
                 collector_strategy:
                     crate::indexed_table::eval::CollectorCallStrategy::TightenOuterBounds,
+                stats_prune_tree: None,
             });
             Ok(eval)
         })
@@ -112,7 +113,7 @@ async fn run_tree_row_ids(tree: BoolNode) -> Vec<i64> {
             qc
         }),
         predicate_columns: vec![0, 1, 2, 3],
-        emit_row_ids: true,
+        emit_row_ids: true, prune_tree_config: None,
     }));
 
     let ctx = SessionContext::new();
@@ -230,7 +231,7 @@ async fn run_tree_row_ids_with_global_base(tree: BoolNode, global_base: u64) -> 
         let per_leaf = per_leaf.clone();
         let tree = Arc::clone(&tree);
         let schema = schema.clone();
-        Arc::new(move |segment, _chunk, _stream_metrics| {
+        Arc::new(move |segment, _chunk, _stream_metrics, _stats_prune_tree| {
             let resolved = tree.resolve(&per_leaf)?;
             let pruner = Arc::new(PagePruner::new(&schema, Arc::clone(&segment.metadata)));
             let eval: Arc<dyn RowGroupBitsetSource> = Arc::new(TreeBitsetSource {
@@ -253,6 +254,7 @@ async fn run_tree_row_ids_with_global_base(tree: BoolNode, global_base: u64) -> 
                 ),
                 collector_strategy:
                     crate::indexed_table::eval::CollectorCallStrategy::TightenOuterBounds,
+                stats_prune_tree: None,
             });
             Ok(eval)
         })
@@ -276,7 +278,7 @@ async fn run_tree_row_ids_with_global_base(tree: BoolNode, global_base: u64) -> 
             qc
         }),
         predicate_columns: vec![0, 1, 2, 3],
-        emit_row_ids: true,
+        emit_row_ids: true, prune_tree_config: None,
     }));
 
     let ctx = SessionContext::new();
@@ -492,7 +494,7 @@ async fn test_row_id_with_data_columns() {
         let per_leaf = per_leaf.clone();
         let tree = Arc::clone(&tree);
         let schema = schema.clone();
-        Arc::new(move |segment, _chunk, _stream_metrics| {
+        Arc::new(move |segment, _chunk, _stream_metrics, _stats_prune_tree| {
             let resolved = tree.resolve(&per_leaf)?;
             let pruner = Arc::new(PagePruner::new(&schema, Arc::clone(&segment.metadata)));
             let eval: Arc<dyn RowGroupBitsetSource> = Arc::new(TreeBitsetSource {
@@ -515,6 +517,7 @@ async fn test_row_id_with_data_columns() {
                 ),
                 collector_strategy:
                     crate::indexed_table::eval::CollectorCallStrategy::TightenOuterBounds,
+                stats_prune_tree: None,
             });
             Ok(eval)
         })
@@ -538,7 +541,7 @@ async fn test_row_id_with_data_columns() {
             qc
         }),
         predicate_columns: vec![0, 1, 2, 3],
-        emit_row_ids: true,
+        emit_row_ids: true, prune_tree_config: None,
     }));
 
     let ctx = SessionContext::new();
@@ -739,7 +742,7 @@ async fn run_two_segments_row_ids(tree: BoolNode) -> Vec<i64> {
         let per_leaf = per_leaf.clone();
         let tree = Arc::clone(&tree);
         let schema = schema.clone();
-        Arc::new(move |segment, _chunk, _stream_metrics| {
+        Arc::new(move |segment, _chunk, _stream_metrics, _stats_prune_tree| {
             let resolved = tree.resolve(&per_leaf)?;
             let pruner = Arc::new(PagePruner::new(&schema, Arc::clone(&segment.metadata)));
             let eval: Arc<dyn RowGroupBitsetSource> = Arc::new(TreeBitsetSource {
@@ -762,6 +765,7 @@ async fn run_two_segments_row_ids(tree: BoolNode) -> Vec<i64> {
                 ),
                 collector_strategy:
                     crate::indexed_table::eval::CollectorCallStrategy::TightenOuterBounds,
+                stats_prune_tree: None,
             });
             Ok(eval)
         })
@@ -785,7 +789,7 @@ async fn run_two_segments_row_ids(tree: BoolNode) -> Vec<i64> {
             qc
         }),
         predicate_columns: vec![0, 1, 2, 3],
-        emit_row_ids: true,
+        emit_row_ids: true, prune_tree_config: None,
     }));
 
     let ctx = SessionContext::new();

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/schema_drift.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/schema_drift.rs
@@ -103,7 +103,7 @@ async fn run_missing_col_tree(tree_bool: BoolNode) -> usize {
     let factory: super::super::table_provider::EvaluatorFactory = {
         let tree = Arc::clone(&tree);
         let schema = schema.clone();
-        Arc::new(move |segment, _chunk, _stream_metrics| {
+        Arc::new(move |segment, _chunk, _stream_metrics, _stats_prune_tree| {
             let resolved = tree.resolve(&[])?;
             let pruner = Arc::new(PagePruner::new(&schema, Arc::clone(&segment.metadata)));
             let eval: Arc<dyn RowGroupBitsetSource> = Arc::new(TreeBitsetSource {
@@ -117,6 +117,7 @@ async fn run_missing_col_tree(tree_bool: BoolNode) -> usize {
                 pruning_predicates: std::sync::Arc::new(std::collections::HashMap::new()),
                 page_prune_metrics: None,
                     collector_strategy: crate::indexed_table::eval::CollectorCallStrategy::TightenOuterBounds,
+                stats_prune_tree: None,
             });
             Ok(eval)
         })
@@ -136,7 +137,7 @@ async fn run_missing_col_tree(tree_bool: BoolNode) -> usize {
         pushdown_predicate: None,
         query_config: std::sync::Arc::new(qc),
         predicate_columns: vec![],
-        emit_row_ids: false,
+        emit_row_ids: false, prune_tree_config: None,
     }));
     let ctx = SessionContext::new();
     ctx.register_table("t", provider).unwrap();
@@ -409,7 +410,7 @@ async fn query_with_mismatched_schema(
     let factory: super::super::table_provider::EvaluatorFactory = {
         let tree = Arc::clone(&tree);
         let schema = table_schema.clone();
-        Arc::new(move |segment, _chunk, _stream_metrics| {
+        Arc::new(move |segment, _chunk, _stream_metrics, _stats_prune_tree| {
             let resolved = tree.resolve(&[])?;
             let pruner = Arc::new(PagePruner::new(&schema, Arc::clone(&segment.metadata)));
             let eval: Arc<dyn RowGroupBitsetSource> = Arc::new(TreeBitsetSource {
@@ -424,6 +425,7 @@ async fn query_with_mismatched_schema(
                 page_prune_metrics: None,
                 collector_strategy:
                     crate::indexed_table::eval::CollectorCallStrategy::TightenOuterBounds,
+                stats_prune_tree: None,
             });
             Ok(eval)
         })
@@ -443,7 +445,7 @@ async fn query_with_mismatched_schema(
         pushdown_predicate: None,
         query_config: std::sync::Arc::new(qc),
         predicate_columns: vec![],
-        emit_row_ids: false,
+        emit_row_ids: false, prune_tree_config: None,
     }));
     let ctx = SessionContext::new();
     ctx.register_table("t", provider).unwrap();

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/streaming_at_scale.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/streaming_at_scale.rs
@@ -419,7 +419,7 @@ async fn run_large(
         let per_leaf = per_leaf.clone();
         let tree = Arc::clone(&tree);
         let schema = schema.clone();
-        Arc::new(move |segment, _chunk, _stream_metrics| {
+        Arc::new(move |segment, _chunk, _stream_metrics, _stats_prune_tree| {
             let resolved = tree.resolve(&per_leaf)?;
             let pruner = Arc::new(PagePruner::new(&schema, Arc::clone(&segment.metadata)));
             let eval: Arc<dyn RowGroupBitsetSource> = Arc::new(TreeBitsetSource {
@@ -433,6 +433,7 @@ async fn run_large(
                 pruning_predicates: std::sync::Arc::new(std::collections::HashMap::new()),
                 page_prune_metrics: None,
                     collector_strategy: crate::indexed_table::eval::CollectorCallStrategy::TightenOuterBounds,
+                    stats_prune_tree: None,
             });
             Ok(eval)
         })
@@ -453,7 +454,7 @@ async fn run_large(
         pushdown_predicate: None,
         query_config: std::sync::Arc::new(qc),
         predicate_columns: vec![],
-        emit_row_ids: false,
+        emit_row_ids: false, prune_tree_config: None,
     }));
 
     let ctx = SessionContext::new();
@@ -871,7 +872,7 @@ async fn run_large_partitioned(
         let per_leaf = per_leaf.clone();
         let tree = Arc::clone(&tree);
         let schema = schema.clone();
-        Arc::new(move |segment, _chunk, _stream_metrics| {
+        Arc::new(move |segment, _chunk, _stream_metrics, _stats_prune_tree| {
             let resolved = tree.resolve(&per_leaf)?;
             let pruner = Arc::new(PagePruner::new(&schema, Arc::clone(&segment.metadata)));
             let eval: Arc<dyn RowGroupBitsetSource> = Arc::new(TreeBitsetSource {
@@ -885,6 +886,7 @@ async fn run_large_partitioned(
                 pruning_predicates: std::sync::Arc::new(std::collections::HashMap::new()),
                 page_prune_metrics: None,
                     collector_strategy: crate::indexed_table::eval::CollectorCallStrategy::TightenOuterBounds,
+                    stats_prune_tree: None,
             });
             Ok(eval)
         })
@@ -904,7 +906,7 @@ async fn run_large_partitioned(
         pushdown_predicate: None,
         query_config: std::sync::Arc::new(qc),
         predicate_columns: vec![],
-        emit_row_ids: false,
+        emit_row_ids: false, prune_tree_config: None,
     }));
     let ctx = SessionContext::new();
     ctx.register_table("t", provider).unwrap();


### PR DESCRIPTION
Introduce StatsPruneTree — a precomputed tree of per-RG match vectors built from RG-level column statistics. Enables three levels of pruning:

1. Segment-level skip: if no RG in a chunk can match, skip entirely.
2. RG-level skip: SingleCollector and BitmapTree evaluators skip individual RGs whose root rg_can_match is false.
3. Subtree-level skip (BitmapTree only): within prefetch_node, children of AND/OR nodes are skipped when their subtree rg_can_match is false, avoiding expensive Collector FFM calls.

```
 # Example: 5 RGs, 9 leaves

 Legend: `df` = Predicate leaf (parquet column stats), `luc` = Collector (always true).
 Each node shows its `rg_can_match` bitset: `[RG0, RG1, RG2, RG3, RG4]`.

 ```
                                  AND
                                [00001]
                /                  |                  \
              OR                   OR                  AND
           [01101]              [11111]              [00011]
          /       \          /     |     \          /       \
       AND         df     AND     luc     df      df        NOT
     [01100]    [00001] [00100] [11111] [11110] [00011]   [11111]
      /   \              /   \                               |
    df     df          df     df                             df
 [11100] [01111]    [11100] [00111]                        [11000]
 ```

 Bottom-up:
   - AND(df[11100], df[01111]) = [01100]
   - OR₁(AND[01100], df[00001]) = [01101]
   - AND(df[11100], df[00111]) = [00100]
   - OR₂(AND[00100], luc[11111], df[11110]) = [11111]  ← luc dominates
   - NOT(df[11000]) = [11111]  ← conservative: can't prune through negation
   - AND₃(df[00011], NOT[11111]) = [00011]
   - Root AND(OR₁[01101], OR₂[11111], AND₃[00011]) = [00001]

 Result: only RG4 survives. NOT is always [11111] because inverting stats-based pruning is unsound (superset inverted = subset). Subtree vectors enable short-circuiting: for RG0, AND₃=[0....] so the bitmap-tree walk skips that entire subtree (no FFM collector calls).
```

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
