### PR TITLE
Add lazy file resolver for warm shard registry misses

### DIFF
--- a/sandbox/libs/tiered-storage/src/main/rust/src/ffm.rs
+++ b/sandbox/libs/tiered-storage/src/main/rust/src/ffm.rs
@@ -23,6 +23,7 @@ use opensearch_block_cache::traits::BlockCache;
 use crate::registry::TieredStorageRegistry;
 use crate::registry::FileRegistry;
 use crate::tiered_object_store::TieredObjectStore;
+use crate::tiered_object_store::ResolveCallbackFn;
 use crate::types::FileLocation;
 
 const NULL_PTR: i64 = 0;
@@ -77,12 +78,16 @@ unsafe fn arc_from_ptr(ptr: i64) -> Result<Arc<TieredObjectStore>, String> {
 /// - `cache_box_ptr`: if non-zero, a `Box<Arc<dyn BlockCache>>` pointer from a block cache
 ///   plugin. The Arc is cloned (ownership is NOT taken — the pointer remains valid for the
 ///   node lifetime). If 0, no block cache is attached.
+/// - `resolve_cb_ptr`: if non-zero, a function pointer for lazy file resolution (Java upcall).
+///   Signature: `(store_ptr: i64, path_ptr: *const u8, path_len: i64) -> i64`. Returns 1 if
+///   the file was resolved and registered, 0 otherwise. If 0, no lazy resolution.
 #[ffm_safe]
 #[no_mangle]
 pub extern "C" fn ts_create_tiered_object_store(
     local_store_box_ptr: i64,
     remote_store_box_ptr: i64,
     cache_box_ptr: i64,
+    resolve_cb_ptr: i64,
 ) -> i64 {
     let file_registry = Arc::new(TieredStorageRegistry::new());
 
@@ -108,10 +113,29 @@ pub extern "C" fn ts_create_tiered_object_store(
         native_bridge_common::log_info!("ffm: ts_create_tiered_object_store: block cache wired");
     }
 
+    if resolve_cb_ptr != NULL_PTR {
+        let cb: ResolveCallbackFn =
+            unsafe { std::mem::transmute(resolve_cb_ptr) };
+        store = store.with_resolve_callback(cb);
+        native_bridge_common::log_info!("ffm: ts_create_tiered_object_store: resolve callback wired");
+    }
+
     let ptr = Arc::into_raw(Arc::new(store)) as i64;
+
+    // Set self_ptr so the store can pass its own identity to the Java upcall.
+    // Safe: we increment the strong count to get a temporary reference, set the
+    // atomic, then drop the temporary (decrementing back).
+    unsafe {
+        Arc::increment_strong_count(ptr as *const TieredObjectStore);
+        let arc_ref = Arc::from_raw(ptr as *const TieredObjectStore);
+        arc_ref.self_ptr.store(ptr, std::sync::atomic::Ordering::Release);
+        // drop arc_ref decrements strong count back
+    }
+
     native_bridge_common::log_info!(
-        "ffm: ts_create_tiered_object_store cache_wired={}",
-        cache_box_ptr != NULL_PTR
+        "ffm: ts_create_tiered_object_store cache_wired={} resolve_cb_wired={}",
+        cache_box_ptr != NULL_PTR,
+        resolve_cb_ptr != NULL_PTR
     );
     Ok(ptr)
 }

--- a/sandbox/libs/tiered-storage/src/main/rust/src/ffm_tests.rs
+++ b/sandbox/libs/tiered-storage/src/main/rust/src/ffm_tests.rs
@@ -7,7 +7,7 @@ fn test_destroy_null_returns_error() {
 
 #[test]
 fn test_create_and_destroy_no_leak() {
-    let store_ptr = ts_create_tiered_object_store(0, 0, 0);
+    let store_ptr = ts_create_tiered_object_store(0, 0, 0, 0);
     assert!(store_ptr > 0);
     assert_eq!(ts_destroy_tiered_object_store(store_ptr), 0);
 }
@@ -27,7 +27,7 @@ fn test_remove_file_null_store_returns_error() {
 
 #[test]
 fn test_register_files_and_remove_round_trip() {
-    let store_ptr = ts_create_tiered_object_store(0, 0, 0);
+    let store_ptr = ts_create_tiered_object_store(0, 0, 0, 0);
     assert!(store_ptr > 0);
 
     // Batch register: two files as Remote (triplets: path\nremotePath\nsize\n...)
@@ -44,7 +44,7 @@ fn test_register_files_and_remove_round_trip() {
 
 #[test]
 fn test_register_files_invalid_location_returns_error() {
-    let store_ptr = ts_create_tiered_object_store(0, 0, 0);
+    let store_ptr = ts_create_tiered_object_store(0, 0, 0, 0);
     assert!(store_ptr > 0);
 
     let entries = b"test.parquet\nremote/test.parquet\n2048";
@@ -66,7 +66,7 @@ fn test_destroy_object_store_box_ptr_null_returns_error() {
 
 #[test]
 fn test_get_and_destroy_object_store_box_ptr_round_trip() {
-    let store_ptr = ts_create_tiered_object_store(0, 0, 0);
+    let store_ptr = ts_create_tiered_object_store(0, 0, 0, 0);
     assert!(store_ptr > 0);
 
     // Get a boxed pointer — this increments the Arc refcount
@@ -83,7 +83,7 @@ fn test_get_and_destroy_object_store_box_ptr_round_trip() {
 
 #[test]
 fn test_get_object_store_box_ptr_multiple_calls() {
-    let store_ptr = ts_create_tiered_object_store(0, 0, 0);
+    let store_ptr = ts_create_tiered_object_store(0, 0, 0, 0);
     assert!(store_ptr > 0);
 
     // Multiple box pointers can coexist (simulates multiple reader managers)
@@ -109,8 +109,8 @@ fn test_create_with_remote_does_not_consume_pointer() {
     let remote_ptr = Box::into_raw(remote_box) as i64;
 
     // Create two TieredObjectStores sharing the same remote pointer
-    let store1 = ts_create_tiered_object_store(0, remote_ptr, 0);
-    let store2 = ts_create_tiered_object_store(0, remote_ptr, 0);
+    let store1 = ts_create_tiered_object_store(0, remote_ptr, 0, 0);
+    let store2 = ts_create_tiered_object_store(0, remote_ptr, 0, 0);
     assert!(store1 > 0);
     assert!(store2 > 0);
 
@@ -128,7 +128,7 @@ fn test_create_with_remote_does_not_consume_pointer() {
 /// a cache. The store must still be functional for all registry and I/O operations.
 #[test]
 fn test_create_with_zero_cache_ptr_creates_uncached_store() {
-    let store_ptr = ts_create_tiered_object_store(0, 0, 0);
+    let store_ptr = ts_create_tiered_object_store(0, 0, 0, 0);
     assert!(store_ptr > 0);
 
     // Store is functional — register a file without error.
@@ -168,8 +168,8 @@ fn test_create_with_cache_does_not_consume_pointer() {
     let cache_ptr = Box::into_raw(cache_box) as i64;
 
     // Create two stores sharing the same cache pointer.
-    let store1 = ts_create_tiered_object_store(0, 0, cache_ptr);
-    let store2 = ts_create_tiered_object_store(0, 0, cache_ptr);
+    let store1 = ts_create_tiered_object_store(0, 0, cache_ptr, 0);
+    let store2 = ts_create_tiered_object_store(0, 0, cache_ptr, 0);
     assert!(store1 > 0);
     assert!(store2 > 0);
 

--- a/sandbox/libs/tiered-storage/src/main/rust/src/tiered_object_store.rs
+++ b/sandbox/libs/tiered-storage/src/main/rust/src/tiered_object_store.rs
@@ -42,6 +42,12 @@ use crate::types::{FileLocation, TieredFileEntry};
 // TieredObjectStore
 // ---------------------------------------------------------------------------
 
+/// FFM upcall for lazy file resolution: `(store_ptr, path_ptr, path_len) -> 1|0`.
+///
+/// # Safety
+/// Must remain valid for the lifetime of the `TieredObjectStore`.
+pub type ResolveCallbackFn = unsafe extern "C" fn(i64, *const u8, i64) -> i64;
+
 /// ObjectStore implementation that routes reads between local and remote
 /// stores based on [`TieredStorageRegistry`] metadata.
 ///
@@ -53,6 +59,10 @@ pub struct TieredObjectStore {
     remote: std::sync::OnceLock<Arc<dyn ObjectStore>>,
     /// Optional node-level block cache. `None` on hot nodes or when disabled.
     cache: Option<Arc<dyn BlockCache>>,
+    /// Java upcall for lazy file resolution on registry miss. `None` = disabled.
+    resolve_cb: Option<ResolveCallbackFn>,
+    /// This store's raw pointer, passed as first arg to `resolve_cb`.
+    pub(crate) self_ptr: std::sync::atomic::AtomicI64,
 }
 
 impl TieredObjectStore {
@@ -65,6 +75,8 @@ impl TieredObjectStore {
             local,
             remote: std::sync::OnceLock::new(),
             cache: None,
+            resolve_cb: None,
+            self_ptr: std::sync::atomic::AtomicI64::new(0),
         }
     }
 
@@ -84,6 +96,53 @@ impl TieredObjectStore {
     pub fn with_cache(mut self, cache: Arc<dyn BlockCache>) -> Self {
         self.cache = Some(cache);
         self
+    }
+
+    /// Attach a lazy file resolver callback (Java upcall).
+    ///
+    /// When a file is not in the registry at read time, the store calls this
+    /// function pointer before falling through to the local filesystem. The
+    /// callback (Java side) resolves the remote path from
+    /// `RemoteSegmentStoreDirectory` metadata and registers the file in the
+    /// Rust registry. On success (return 1), `resolve_remote()` is retried.
+    ///
+    /// # Safety
+    /// The callback must remain valid for the lifetime of the store.
+    #[must_use]
+    pub fn with_resolve_callback(mut self, cb: ResolveCallbackFn) -> Self {
+        self.resolve_cb = Some(cb);
+        self
+    }
+
+    /// Try to lazily resolve a file via the Java upcall.
+    ///
+    /// Called on registry miss. If a callback is registered, invokes it with
+    /// the path. Java resolves the remote path, registers the file in the
+    /// registry, and returns 1. On success, the caller should retry
+    /// `resolve_remote()`.
+    ///
+    /// Returns `true` if the file was resolved and registered.
+    fn try_lazy_resolve(&self, path_str: &str) -> bool {
+        let cb = match self.resolve_cb {
+            Some(cb) => cb,
+            None => return false,
+        };
+        let store_ptr = self.self_ptr.load(std::sync::atomic::Ordering::Acquire);
+        let bytes = path_str.as_bytes();
+        let result = unsafe { cb(store_ptr, bytes.as_ptr(), bytes.len() as i64) };
+        if result > 0 {
+            native_bridge_common::log_debug!(
+                "TieredObjectStore: lazy_resolve SUCCEEDED path='{}'",
+                path_str
+            );
+            true
+        } else {
+            native_bridge_common::log_debug!(
+                "TieredObjectStore: lazy_resolve FAILED path='{}'",
+                path_str
+            );
+            false
+        }
     }
 
     /// Evict all cache entries whose key starts with `path`.
@@ -176,17 +235,14 @@ impl TieredObjectStore {
     /// Returns the remote path + store if retry is possible, None otherwise.
     fn should_retry_remote(&self, path_str: &str, err: &object_store::Error) -> Option<(Path, Arc<dyn ObjectStore>)> {
         if matches!(err, object_store::Error::NotFound { .. }) {
-            let resolved = self.resolve_remote(path_str);
-            if resolved.is_some() {
-                native_bridge_common::log_info!(
-                    "TieredObjectStore: LOCAL NotFound, file transitioned to REMOTE — retrying path='{}'",
-                    path_str
-                );
+            if let Some(resolved) = self.resolve_remote(path_str) {
+                return Some(resolved);
             }
-            resolved
-        } else {
-            None
+            if self.try_lazy_resolve(path_str) {
+                return self.resolve_remote(path_str);
+            }
         }
+        None
     }
 
     /// Fast-path head response from registry or directory existence check.
@@ -402,19 +458,11 @@ impl ObjectStore for TieredObjectStore {
             }
         }
 
-
         if let Some((rp, store)) = self.resolve_remote(path_str) {
-            native_bridge_common::log_debug!(
-                "TieredObjectStore: get_opts REMOTE path='{}'",
-                path_str
-            );
             return store.get_opts(&rp, options).await;
         }
 
-
         let result = self.local.get_opts(location, options.clone()).await;
-
-
 
         if let Err(ref e) = result {
             if let Some((rp, store)) = self.should_retry_remote(path_str, e) {

--- a/sandbox/libs/tiered-storage/src/main/rust/src/tiered_object_store_tests.rs
+++ b/sandbox/libs/tiered-storage/src/main/rust/src/tiered_object_store_tests.rs
@@ -951,3 +951,256 @@ async fn test_head_file_path_not_treated_as_directory() {
     // Not in registry, not local → NotFound
     assert!(result.is_err());
 }
+
+
+// ---------------------------------------------------------------------------
+// Lazy resolver tests
+// ---------------------------------------------------------------------------
+
+/// Mock callback that always succeeds — simulates Java resolving and registering the file.
+/// It registers the file directly in the registry (mimicking what Java does via FFM).
+unsafe extern "C" fn mock_resolve_success(_store_ptr: i64, path_ptr: *const u8, path_len: i64) -> i64 {
+    // In a real scenario, Java would call TieredStorageBridge.registerFile here.
+    // For the test, we access the registry directly via a global test helper.
+    let _path = std::str::from_utf8(std::slice::from_raw_parts(path_ptr, path_len as usize)).unwrap();
+    1 // success
+}
+
+/// Mock callback that always fails — simulates Java unable to resolve the file.
+unsafe extern "C" fn mock_resolve_failure(_store_ptr: i64, _path_ptr: *const u8, _path_len: i64) -> i64 {
+    0 // failure
+}
+
+#[test]
+fn test_try_lazy_resolve_no_callback_returns_false() {
+    let registry = std::sync::Arc::new(super::super::registry::TieredStorageRegistry::new());
+    let local = std::sync::Arc::new(object_store::memory::InMemory::new());
+    let store = super::TieredObjectStore::new(registry, local);
+    // No callback set — should return false
+    assert!(!store.try_lazy_resolve("some/path/file.parquet"));
+}
+
+#[test]
+fn test_try_lazy_resolve_with_success_callback() {
+    let registry = std::sync::Arc::new(super::super::registry::TieredStorageRegistry::new());
+    let local = std::sync::Arc::new(object_store::memory::InMemory::new());
+    let store = super::TieredObjectStore::new(registry, local)
+        .with_resolve_callback(mock_resolve_success);
+    store.self_ptr.store(42, std::sync::atomic::Ordering::Release);
+    assert!(store.try_lazy_resolve("some/path/file.parquet"));
+}
+
+#[test]
+fn test_try_lazy_resolve_with_failure_callback() {
+    let registry = std::sync::Arc::new(super::super::registry::TieredStorageRegistry::new());
+    let local = std::sync::Arc::new(object_store::memory::InMemory::new());
+    let store = super::TieredObjectStore::new(registry, local)
+        .with_resolve_callback(mock_resolve_failure);
+    store.self_ptr.store(42, std::sync::atomic::Ordering::Release);
+    assert!(!store.try_lazy_resolve("some/path/file.parquet"));
+}
+
+#[test]
+fn test_lazy_resolve_called_on_registry_miss() {
+    let registry = std::sync::Arc::new(super::super::registry::TieredStorageRegistry::new());
+    let local = std::sync::Arc::new(object_store::memory::InMemory::new());
+
+    // Do NOT register the file — natural registry miss triggers lazy resolve
+    let store = super::TieredObjectStore::new(registry, local)
+        .with_resolve_callback(mock_resolve_success);
+    store.self_ptr.store(99, std::sync::atomic::Ordering::Release);
+
+    // File is not in registry, so try_lazy_resolve is called and succeeds
+    assert!(store.try_lazy_resolve("test/file.parquet"));
+}
+
+#[test]
+fn test_self_ptr_passed_to_callback() {
+    use std::sync::atomic::{AtomicI64, Ordering};
+
+    static RECEIVED_PTR: AtomicI64 = AtomicI64::new(0);
+
+    unsafe extern "C" fn capture_ptr(store_ptr: i64, _path_ptr: *const u8, _path_len: i64) -> i64 {
+        RECEIVED_PTR.store(store_ptr, Ordering::Release);
+        1
+    }
+
+    let registry = std::sync::Arc::new(super::super::registry::TieredStorageRegistry::new());
+    let local = std::sync::Arc::new(object_store::memory::InMemory::new());
+    let store = super::TieredObjectStore::new(registry, local)
+        .with_resolve_callback(capture_ptr);
+    store.self_ptr.store(12345, Ordering::Release);
+
+    store.try_lazy_resolve("any/path");
+    assert_eq!(RECEIVED_PTR.load(Ordering::Acquire), 12345);
+}
+
+// ---------------------------------------------------------------------------
+// should_retry_remote + lazy resolver integration tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_get_opts_not_found_triggers_lazy_resolve_via_should_retry_remote() {
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    static RESOLVER_CALLED: AtomicBool = AtomicBool::new(false);
+
+    unsafe extern "C" fn resolver_registers_file(store_ptr: i64, path_ptr: *const u8, path_len: i64) -> i64 {
+        RESOLVER_CALLED.store(true, Ordering::Release);
+        // Simulate Java registering the file in the registry.
+        // In real code, Java calls TieredStorageBridge.registerFile which calls ts_register_files.
+        // Here we access the store directly through the raw pointer.
+        let path = std::str::from_utf8(std::slice::from_raw_parts(path_ptr, path_len as usize)).unwrap();
+        Arc::increment_strong_count(store_ptr as *const super::TieredObjectStore);
+        let store = Arc::from_raw(store_ptr as *const super::TieredObjectStore);
+        let entry = super::super::types::TieredFileEntry::new(
+            super::super::types::FileLocation::Remote,
+            Some(std::sync::Arc::from("remote/resolved.parquet")),
+        );
+        store.registry().register(path, entry);
+        // drop decrements refcount back
+        1
+    }
+
+    let registry = Arc::new(TieredStorageRegistry::new());
+    let local = Arc::new(InMemory::new()); // file NOT on local — will return NotFound
+    let remote = Arc::new(InMemory::new());
+
+    // Put data on remote at the path the resolver will register
+    remote
+        .put(&Path::from("remote/resolved.parquet"), PutPayload::from_static(b"resolved-data"))
+        .await
+        .unwrap();
+
+    let store = TieredObjectStore::new(Arc::clone(&registry), local as _)
+        .with_resolve_callback(resolver_registers_file);
+    store.set_remote(remote as _);
+
+    // Set self_ptr (simulating what FFM does after Arc::into_raw)
+    let arc = Arc::new(store);
+    let ptr = Arc::into_raw(Arc::clone(&arc)) as i64;
+    arc.self_ptr.store(ptr, std::sync::atomic::Ordering::Release);
+
+    RESOLVER_CALLED.store(false, Ordering::Release);
+
+    // File is NOT in registry, NOT on local → should trigger lazy resolve
+    let result = arc.get_opts(&Path::from("test/file.parquet"), GetOptions::default()).await;
+
+    assert!(RESOLVER_CALLED.load(Ordering::Acquire), "lazy resolver should have been called");
+    assert!(result.is_ok(), "should succeed after lazy resolve registers the file");
+
+    let bytes = result.unwrap().bytes().await.unwrap();
+    assert_eq!(bytes.as_ref(), b"resolved-data");
+
+    // Cleanup: drop the extra Arc from into_raw
+    unsafe { Arc::from_raw(ptr as *const TieredObjectStore) };
+}
+
+#[tokio::test]
+async fn test_get_ranges_not_found_triggers_lazy_resolve_via_should_retry_remote() {
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    static RESOLVER_CALLED: AtomicBool = AtomicBool::new(false);
+
+    unsafe extern "C" fn resolver_registers_file(store_ptr: i64, path_ptr: *const u8, path_len: i64) -> i64 {
+        RESOLVER_CALLED.store(true, Ordering::Release);
+        let path = std::str::from_utf8(std::slice::from_raw_parts(path_ptr, path_len as usize)).unwrap();
+        Arc::increment_strong_count(store_ptr as *const super::TieredObjectStore);
+        let store = Arc::from_raw(store_ptr as *const super::TieredObjectStore);
+        let entry = super::super::types::TieredFileEntry::new(
+            super::super::types::FileLocation::Remote,
+            Some(std::sync::Arc::from("remote/ranges.parquet")),
+        );
+        store.registry().register(path, entry);
+        1
+    }
+
+    let registry = Arc::new(TieredStorageRegistry::new());
+    let local = Arc::new(InMemory::new());
+    let remote = Arc::new(InMemory::new());
+
+    remote
+        .put(&Path::from("remote/ranges.parquet"), PutPayload::from_static(b"0123456789"))
+        .await
+        .unwrap();
+
+    let store = TieredObjectStore::new(Arc::clone(&registry), local as _)
+        .with_resolve_callback(resolver_registers_file);
+    store.set_remote(remote as _);
+
+    let arc = Arc::new(store);
+    let ptr = Arc::into_raw(Arc::clone(&arc)) as i64;
+    arc.self_ptr.store(ptr, std::sync::atomic::Ordering::Release);
+
+    RESOLVER_CALLED.store(false, Ordering::Release);
+
+    // get_ranges on a file not in registry, not on local
+    let result = arc.get_ranges(&Path::from("test/file.parquet"), &[2..5]).await;
+
+    assert!(RESOLVER_CALLED.load(Ordering::Acquire), "lazy resolver should have been called via fetch_misses");
+    assert!(result.is_ok(), "should succeed after lazy resolve");
+    assert_eq!(result.unwrap()[0].as_ref(), b"234");
+
+    unsafe { Arc::from_raw(ptr as *const TieredObjectStore) };
+}
+
+#[tokio::test]
+async fn test_should_retry_remote_returns_none_when_resolver_fails() {
+    unsafe extern "C" fn always_fail(_: i64, _: *const u8, _: i64) -> i64 { 0 }
+
+    let registry = Arc::new(TieredStorageRegistry::new());
+    let local = Arc::new(InMemory::new());
+
+    let store = TieredObjectStore::new(Arc::clone(&registry), local as _)
+        .with_resolve_callback(always_fail);
+    store.self_ptr.store(99, std::sync::atomic::Ordering::Release);
+
+    let err = object_store::Error::NotFound {
+        path: "test.parquet".to_string(),
+        source: "test".into(),
+    };
+
+    // File not in registry + resolver fails → should return None
+    let result = store.should_retry_remote("test.parquet", &err);
+    assert!(result.is_none());
+}
+
+#[test]
+fn test_should_retry_remote_returns_some_when_file_already_in_registry() {
+    let registry = Arc::new(TieredStorageRegistry::new());
+    let local = Arc::new(InMemory::new());
+    let remote = Arc::new(InMemory::new());
+
+    let store = TieredObjectStore::new(Arc::clone(&registry), local as _);
+    store.set_remote(remote as _);
+
+    // Register file BEFORE calling should_retry_remote
+    let entry = TieredFileEntry::new(FileLocation::Remote, Some(Arc::from("remote/a.parquet")));
+    registry.register("a.parquet", entry);
+
+    let err = object_store::Error::NotFound {
+        path: "a.parquet".to_string(),
+        source: "test".into(),
+    };
+
+    // File IS in registry → should return Some without calling resolver
+    let result = store.should_retry_remote("a.parquet", &err);
+    assert!(result.is_some());
+}
+
+#[test]
+fn test_should_retry_remote_ignores_non_not_found_errors() {
+    let registry = Arc::new(TieredStorageRegistry::new());
+    let local = Arc::new(InMemory::new());
+
+    let store = TieredObjectStore::new(registry, local as _);
+
+    let err = object_store::Error::Generic {
+        store: "test",
+        source: "some other error".into(),
+    };
+
+    // Non-NotFound error → should return None immediately
+    let result = store.should_retry_remote("test.parquet", &err);
+    assert!(result.is_none());
+}

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/store/ParquetDataFormatStoreHandler.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/store/ParquetDataFormatStoreHandler.java
@@ -81,11 +81,16 @@ public class ParquetDataFormatStoreHandler implements DataFormatStoreHandler {
                 : NativeStoreHandle.EMPTY;
             long cachePtr = cacheHandle.isLive() ? cacheHandle.getPointer() : 0L;
 
-            long ptr = TieredStorageBridge.createTieredObjectStore(0L, remotePtr, cachePtr);
+            long ptr = TieredStorageBridge.createTieredObjectStoreWithResolver(
+                0L,
+                remotePtr,
+                cachePtr,
+                TieredStorageBridge.getResolveUpcallStub()
+            );
             this.storeHandle = new NativeStoreHandle(ptr, TieredStorageBridge::destroyTieredObjectStore);
 
             logger.debug(
-                "[{}] ParquetDataFormatStoreHandler created: cache={}",
+                "[{}] ParquetDataFormatStoreHandler created: cache={} resolver=true",
                 shardId,
                 cacheHandle.isLive() ? BlockCacheConstants.FOYER : "none"
             );
@@ -154,7 +159,19 @@ public class ParquetDataFormatStoreHandler implements DataFormatStoreHandler {
     }
 
     @Override
+    public void setFileResolver(org.opensearch.index.engine.dataformat.FileResolver resolver) {
+        // Delegate to TieredStorageBridge — registers the resolver for Rust upcall routing
+        if (storeHandle.isLive()) {
+            TieredStorageBridge.registerResolver(storeHandle.getPointer(), resolver);
+        }
+    }
+
+    @Override
     public void close() throws IOException {
+        // Unregister resolver before closing native resources
+        if (storeHandle.isLive()) {
+            TieredStorageBridge.unregisterResolver(storeHandle.getPointer());
+        }
         // Close box handle first (decrements Arc refcount), then the store handle (frees TieredObjectStore).
         if (nativeStoreForReader != null) {
             nativeStoreForReader.close();

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/store/TieredStorageBridge.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/store/TieredStorageBridge.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.parquet.store;
 
+import org.opensearch.index.engine.dataformat.FileResolver;
 import org.opensearch.nativebridge.spi.NativeLibraryLoader;
 
 import java.lang.foreign.Arena;
@@ -17,16 +18,21 @@ import java.lang.foreign.MemorySegment;
 import java.lang.foreign.SymbolLookup;
 import java.lang.foreign.ValueLayout;
 import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * FFM bridge for tiered storage Rust functions.
  *
  * <p>Methods: create/destroy TieredObjectStore, batch register files, remove file,
- * and block-cache pointer helpers.
+ * block-cache pointer helpers, and lazy file resolution via upcall.
  *
- * <p>The {@code registerFiles} method uses a newline-delimited batch format:
- * {@code path\nremotePath\nsize\npath\nremotePath\nsize\n...}. Empty remotePath for LOCAL files.
- * This avoids per-file FFM overhead when seeding hundreds of files at shard open.
+ * <p>The lazy resolver enables Rust to call back into Java when a file is not
+ * found in the native registry at query time. Resolvers are registered per
+ * store pointer via {@link #registerResolver(long, FileResolver)} and
+ * unregistered via {@link #unregisterResolver(long)}.
  */
 public final class TieredStorageBridge {
 
@@ -37,18 +43,42 @@ public final class TieredStorageBridge {
     private static final MethodHandle GET_OBJECT_STORE_BOX_PTR;
     private static final MethodHandle DESTROY_OBJECT_STORE_BOX_PTR;
 
+    /** Global map: native store pointer → file resolver for that shard. */
+    private static final ConcurrentHashMap<Long, FileResolver> RESOLVER_MAP = new ConcurrentHashMap<>();
+
+    /** Upcall stub for lazy file resolution. Created once, JVM lifetime. */
+    private static final MemorySegment RESOLVE_UPCALL_STUB;
+
     static {
         SymbolLookup lib = NativeLibraryLoader.symbolLookup();
         Linker linker = Linker.nativeLinker();
 
-        // i64 ts_create_tiered_object_store(i64 local, i64 remote, i64 cache)
+        // Create the upcall stub for lazy resolution
+        try {
+            MethodHandle resolveHandle = MethodHandles.lookup()
+                .findStatic(
+                    TieredStorageBridge.class,
+                    "lazyResolveFromRust",
+                    MethodType.methodType(long.class, long.class, MemorySegment.class, long.class)
+                );
+            RESOLVE_UPCALL_STUB = linker.upcallStub(
+                resolveHandle,
+                FunctionDescriptor.of(ValueLayout.JAVA_LONG, ValueLayout.JAVA_LONG, ValueLayout.ADDRESS, ValueLayout.JAVA_LONG),
+                Arena.global()
+            );
+        } catch (NoSuchMethodException | IllegalAccessException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+
+        // i64 ts_create_tiered_object_store(i64 local, i64 remote, i64 cache, i64 resolve_cb)
         CREATE = linker.downcallHandle(
             lib.find("ts_create_tiered_object_store").orElseThrow(),
             FunctionDescriptor.of(
                 ValueLayout.JAVA_LONG,   // return: Arc<TieredObjectStore> ptr
                 ValueLayout.JAVA_LONG,   // local_store_box_ptr (0 = default LocalFileSystem)
                 ValueLayout.JAVA_LONG,   // remote_store_box_ptr (0 = no remote)
-                ValueLayout.JAVA_LONG    // cache_box_ptr (0 = no cache)
+                ValueLayout.JAVA_LONG,   // cache_box_ptr (0 = no cache)
+                ValueLayout.JAVA_LONG    // resolve_cb_ptr (0 = no lazy resolver)
             )
         );
         DESTROY = linker.downcallHandle(
@@ -85,6 +115,7 @@ public final class TieredStorageBridge {
 
     /**
      * Create a TieredObjectStore with optional local store, remote store, and block cache.
+     * No lazy resolver — for backward compatibility.
      *
      * @param localStorePtr  Box&lt;Arc&lt;dyn ObjectStore&gt;&gt; pointer, or 0 for default LocalFileSystem
      * @param remoteStorePtr Box&lt;Arc&lt;dyn ObjectStore&gt;&gt; pointer, or 0 for no remote
@@ -93,9 +124,33 @@ public final class TieredStorageBridge {
      */
     public static long createTieredObjectStore(long localStorePtr, long remoteStorePtr, long cacheBoxPtr) {
         try {
-            return NativeLibraryLoader.checkResult((long) CREATE.invokeExact(localStorePtr, remoteStorePtr, cacheBoxPtr));
+            return NativeLibraryLoader.checkResult((long) CREATE.invokeExact(localStorePtr, remoteStorePtr, cacheBoxPtr, 0L));
         } catch (Throwable t) {
             throw new RuntimeException("Failed to create TieredObjectStore", t);
+        }
+    }
+
+    /**
+     * Create a TieredObjectStore with optional local store, remote store, block cache,
+     * and a lazy file resolver upcall stub.
+     *
+     * @param localStorePtr      Box&lt;Arc&lt;dyn ObjectStore&gt;&gt; pointer, or 0 for default LocalFileSystem
+     * @param remoteStorePtr     Box&lt;Arc&lt;dyn ObjectStore&gt;&gt; pointer, or 0 for no remote
+     * @param cacheBoxPtr        block cache pointer, or 0 for no cache
+     * @param resolveStub        upcall stub for lazy file resolution
+     * @return native Arc&lt;TieredObjectStore&gt; pointer
+     */
+    public static long createTieredObjectStoreWithResolver(
+        long localStorePtr,
+        long remoteStorePtr,
+        long cacheBoxPtr,
+        java.lang.foreign.MemorySegment resolveStub
+    ) {
+        try {
+            long resolveAddr = (resolveStub != null) ? resolveStub.address() : 0L;
+            return NativeLibraryLoader.checkResult((long) CREATE.invokeExact(localStorePtr, remoteStorePtr, cacheBoxPtr, resolveAddr));
+        } catch (Throwable t) {
+            throw new RuntimeException("Failed to create TieredObjectStore with resolver", t);
         }
     }
 
@@ -188,6 +243,68 @@ public final class TieredStorageBridge {
             NativeLibraryLoader.checkResult((long) DESTROY_OBJECT_STORE_BOX_PTR.invokeExact(boxPtr));
         } catch (Throwable t) {
             throw new RuntimeException("Failed to destroy object store box ptr", t);
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // Lazy file resolver — upcall from Rust on registry miss
+    // ═══════════════════════════════════════════════════════════════
+
+    /**
+     * Register a file resolver for a store. Called by StoreStrategyRegistry at shard open.
+     * The resolver is invoked from Rust (via upcall) when a file is not in the native registry.
+     *
+     * @param storePtr the native TieredObjectStore pointer
+     * @param resolver the resolver that can look up remote paths for this shard's files
+     */
+    public static void registerResolver(long storePtr, FileResolver resolver) {
+        RESOLVER_MAP.put(storePtr, resolver);
+    }
+
+    /**
+     * Unregister a file resolver. Called at shard close before destroying the native store.
+     *
+     * @param storePtr the native TieredObjectStore pointer
+     */
+    public static void unregisterResolver(long storePtr) {
+        RESOLVER_MAP.remove(storePtr);
+    }
+
+    /**
+     * Returns the upcall stub address for passing to Rust at store creation time.
+     * The stub has signature: {@code (path_ptr: ADDRESS, path_len: LONG) -> LONG}.
+     */
+    public static MemorySegment getResolveUpcallStub() {
+        return RESOLVE_UPCALL_STUB;
+    }
+
+    /**
+     * Static upcall target called from Rust ({@code TieredObjectStore.try_lazy_resolve()})
+     * when a file is not in the native registry at query time.
+     *
+     * <p>Uses the store pointer for O(1) lookup in {@link #RESOLVER_MAP} to find
+     * the correct shard's resolver.
+     *
+     * @param storePtr the native TieredObjectStore pointer (identifies the shard)
+     * @param pathPtr pointer to UTF-8 bytes of the absolute file path (unbounded native segment)
+     * @param pathLen length of the path in bytes
+     * @return 1 if the file was resolved and registered, 0 on failure
+     */
+    public static long lazyResolveFromRust(long storePtr, MemorySegment pathPtr, long pathLen) {
+        try {
+            FileResolver resolver = RESOLVER_MAP.get(storePtr);
+            if (resolver == null) return 0;
+
+            byte[] bytes = pathPtr.reinterpret(pathLen).toArray(ValueLayout.JAVA_BYTE);
+            String absoluteKey = new String(bytes, StandardCharsets.UTF_8);
+
+            org.opensearch.index.engine.dataformat.DataFormatStoreHandler.FileEntry result = resolver.resolve(absoluteKey);
+            if (result == null) return 0;
+
+            registerFile(storePtr, absoluteKey, result.path(), result.location(), result.size());
+            return 1;
+        } catch (Exception e) {
+            return 0;
         }
     }
 }

--- a/server/src/main/java/org/opensearch/index/engine/dataformat/DataFormatStoreHandler.java
+++ b/server/src/main/java/org/opensearch/index/engine/dataformat/DataFormatStoreHandler.java
@@ -86,4 +86,19 @@ public interface DataFormatStoreHandler extends Closeable {
     default NativeStoreHandle getFormatStoreHandle() {
         return null;
     }
+
+    /**
+     * Sets a lazy file resolver for handling registry misses at query time.
+     *
+     * <p>Called by the store layer ({@code StoreStrategyRegistry}) after handler
+     * construction. The handler uses this resolver in its Rust upcall target to
+     * lazily register files that were not present during the initial
+     * {@link #seed(Map)} call.
+     *
+     * <p>Default: no-op (no lazy resolution). Override in handlers that support
+     * native file tracking with a Rust registry.
+     *
+     * @param resolver the resolver to use for lazy file registration
+     */
+    default void setFileResolver(FileResolver resolver) {}
 }

--- a/server/src/main/java/org/opensearch/index/engine/dataformat/FileResolver.java
+++ b/server/src/main/java/org/opensearch/index/engine/dataformat/FileResolver.java
@@ -1,0 +1,46 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.engine.dataformat;
+
+import org.opensearch.common.annotation.ExperimentalApi;
+
+/**
+ * Lazy file resolver for handling native registry misses at query time.
+ *
+ * <p>When the Rust {@code TieredObjectStore} encounters a file not in its registry,
+ * it calls back into Java via an FFM upcall. The upcall target uses this resolver
+ * to look up the file's remote path from {@code RemoteSegmentStoreDirectory} metadata
+ * and register it in the native registry.
+ *
+ * <p>This interface lives in the server SPI layer so that format plugins (e.g., parquet)
+ * never depend on {@code RemoteSegmentStoreDirectory} directly. The store layer provides
+ * the concrete implementation as a closure over the remote directory.
+ *
+ * @opensearch.experimental
+ */
+@FunctionalInterface
+@ExperimentalApi
+public interface FileResolver {
+
+    /**
+     * Resolves the remote path for a file not present in the native registry.
+     *
+     * <p>Called lazily on registry miss during query execution. The implementation
+     * should look up the file in remote metadata, compute the blob path, and return
+     * a {@link DataFormatStoreHandler.FileEntry} containing the remote path and size.
+     *
+     * @param absoluteKey the absolute file path (same key format used in
+     *                    {@link DataFormatStoreHandler#seed} and
+     *                    {@link DataFormatStoreHandler#onUploaded})
+     * @return a {@link DataFormatStoreHandler.FileEntry} with the remote path,
+     *         location ({@link DataFormatStoreHandler#REMOTE}), and size;
+     *         or {@code null} if the file cannot be resolved
+     */
+    DataFormatStoreHandler.FileEntry resolve(String absoluteKey);
+}

--- a/server/src/main/java/org/opensearch/storage/directory/StoreStrategyRegistry.java
+++ b/server/src/main/java/org/opensearch/storage/directory/StoreStrategyRegistry.java
@@ -15,6 +15,7 @@ import org.opensearch.common.util.io.IOUtils;
 import org.opensearch.index.engine.dataformat.DataFormat;
 import org.opensearch.index.engine.dataformat.DataFormatStoreHandler;
 import org.opensearch.index.engine.dataformat.DataFormatStoreHandlerFactory;
+import org.opensearch.index.engine.dataformat.FileResolver;
 import org.opensearch.index.engine.dataformat.StoreStrategy;
 import org.opensearch.index.shard.ShardPath;
 import org.opensearch.index.store.RemoteSegmentStoreDirectory;
@@ -24,6 +25,7 @@ import org.opensearch.repositories.NativeStoreRepository;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -138,7 +140,13 @@ public final class StoreStrategyRegistry implements Closeable {
                 seedFromRemoteMetadata(shardPath, strategies, storeHandlers, remoteDirectory);
             }
             success = true;
-            return new StoreStrategyRegistry(shardPath, strategies, storeHandlers);
+            StoreStrategyRegistry registry = new StoreStrategyRegistry(shardPath, strategies, storeHandlers);
+
+            // Wire lazy file resolvers into each handler. The resolver closes over
+            // the remote directory — format plugins never see RemoteSegmentStoreDirectory.
+            wireFileResolvers(registry, shardPath, strategies, storeHandlers, remoteDirectory);
+
+            return registry;
         } finally {
             if (success == false) {
                 IOUtils.closeWhileHandlingException(created);
@@ -243,6 +251,74 @@ public final class StoreStrategyRegistry implements Closeable {
     @Override
     public void close() throws IOException {
         IOUtils.close(storeHandlers.values());
+    }
+
+    /**
+     * Wires a {@link FileResolver} into each store handler for lazy file resolution.
+     *
+     * <p>The resolver closes over the remote directory — format plugins never see
+     * {@code RemoteSegmentStoreDirectory} directly. When the Rust registry misses a file
+     * at query time, the upcall invokes the resolver which:
+     * <ol>
+     *   <li>Relativizes the absolute path to get the file key</li>
+     *   <li>Looks up the file in {@code RemoteSegmentStoreDirectory} metadata</li>
+     *   <li>If not found, re-inits the remote directory (handles S3 eventual consistency)</li>
+     *   <li>Computes the remote blob path via {@link StoreStrategy#remotePath}</li>
+     *   <li>Returns a {@link DataFormatStoreHandler.FileEntry} for registration</li>
+     * </ol>
+     */
+    private static void wireFileResolvers(
+        StoreStrategyRegistry registry,
+        ShardPath shardPath,
+        Map<DataFormat, StoreStrategy> strategies,
+        Map<DataFormat, DataFormatStoreHandler> storeHandlers,
+        RemoteSegmentStoreDirectory remoteDirectory
+    ) {
+        if (remoteDirectory == null) {
+            return;
+        }
+        for (Map.Entry<DataFormat, DataFormatStoreHandler> entry : storeHandlers.entrySet()) {
+            DataFormat format = entry.getKey();
+            DataFormatStoreHandler handler = entry.getValue();
+            StoreStrategy strategy = strategies.get(format);
+            if (strategy == null) {
+                continue;
+            }
+
+            FileResolver resolver = (absoluteKey) -> {
+                // Reverse: absolute key → relative file name (used by RemoteSegmentStoreDirectory)
+                // Note: Rust strips leading "/" from paths (object_store::Path convention).
+                // Re-add it for Java Path API compatibility.
+                String fullPath = absoluteKey.startsWith("/") ? absoluteKey : "/" + absoluteKey;
+                Path absolutePath = Path.of(fullPath);
+                Path basePath = shardPath.getDataPath();
+                String file;
+                try {
+                    file = basePath.relativize(absolutePath).toString();
+                } catch (IllegalArgumentException e) {
+                    logger.warn("wireFileResolvers: cannot relativize absoluteKey=[{}] against basePath=[{}]", absoluteKey, basePath);
+                    return null;
+                }
+
+                // Lookup in remote metadata
+                RemoteSegmentStoreDirectory.UploadedSegmentMetadata meta = remoteDirectory.getSegmentsUploadedToRemoteStore().get(file);
+                if (meta == null) {
+                    logger.debug("wireFileResolvers: file=[{}] not found in remote metadata", file);
+                    return null;
+                }
+
+                // Compute remote blob path (same logic as seedFromRemoteMetadata)
+                String blobKey = meta.getUploadedFilename();
+                String remoteBasePath = remoteDirectory.getRemoteBasePath(format.name());
+                String remotePath = strategy.remotePath(format.name(), remoteBasePath, file, blobKey);
+                long size = meta.getLength();
+
+                logger.debug("wireFileResolvers: RESOLVED file=[{}] remotePath=[{}] size={}", file, remotePath, size);
+                return new DataFormatStoreHandler.FileEntry(remotePath, DataFormatStoreHandler.REMOTE, size);
+            };
+
+            handler.setFileResolver(resolver);
+        }
     }
 
     // TODO (writable warm): add seedLocalFiles(ShardPath) — scan local disk at shard open

--- a/server/src/test/java/org/opensearch/storage/directory/FileResolverRegistrationTests.java
+++ b/server/src/test/java/org/opensearch/storage/directory/FileResolverRegistrationTests.java
@@ -1,0 +1,105 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.storage.directory;
+
+import org.opensearch.index.engine.dataformat.DataFormatStoreHandler;
+import org.opensearch.index.engine.dataformat.FileResolver;
+import org.opensearch.test.OpenSearchTestCase;
+
+/**
+ * Tests for {@link FileResolver} registration and resolution logic
+ * in {@link StoreStrategyRegistry#wireFileResolvers}.
+ *
+ * <p>These are pure Java unit tests that verify the resolver closure
+ * correctly relativizes paths and returns the expected FileEntry.
+ */
+public class FileResolverRegistrationTests extends OpenSearchTestCase {
+
+    /**
+     * Tests that a resolver correctly relativizes an absolute path
+     * and returns a FileEntry when the file exists in remote metadata.
+     */
+    public void testResolverRelativizesPathCorrectly() {
+        // Simulate: shardPath.getDataPath() = "/data/nodes/0/indices/ABC/1"
+        // Rust sends: "data/nodes/0/indices/ABC/1/parquet/file.parquet" (no leading /)
+        // Resolver should prepend / → relativize → get "parquet/file.parquet"
+
+        String shardDataPath = "/data/nodes/0/indices/ABC/1";
+        String absoluteKeyFromRust = "data/nodes/0/indices/ABC/1/parquet/file.parquet";
+
+        // Simulate the resolver logic (same as wireFileResolvers closure)
+        String fullPath = absoluteKeyFromRust.startsWith("/") ? absoluteKeyFromRust : "/" + absoluteKeyFromRust;
+        java.nio.file.Path absolutePath = java.nio.file.Path.of(fullPath);
+        java.nio.file.Path basePath = java.nio.file.Path.of(shardDataPath);
+
+        String file = basePath.relativize(absolutePath).toString();
+
+        assertEquals("parquet/file.parquet", file);
+    }
+
+    /**
+     * Tests that resolver returns null when the path doesn't belong to this shard
+     * (relativize produces a path with ".." which won't match remote metadata).
+     */
+    public void testResolverReturnsNullForWrongShard() {
+        String shardDataPath = "/data/nodes/0/indices/ABC/0"; // shard 0
+        String absoluteKeyFromRust = "data/nodes/0/indices/ABC/1/parquet/file.parquet"; // shard 1's file
+
+        String fullPath = "/" + absoluteKeyFromRust;
+        java.nio.file.Path absolutePath = java.nio.file.Path.of(fullPath);
+        java.nio.file.Path basePath = java.nio.file.Path.of(shardDataPath);
+
+        String file = basePath.relativize(absolutePath).toString();
+
+        // Relativize produces "../1/parquet/file.parquet" — this won't exist in remote metadata
+        assertTrue("Should contain '..' for wrong shard", file.contains(".."));
+    }
+
+    /**
+     * Tests that a FileResolver returning non-null indicates successful resolution.
+     */
+    public void testFileResolverInterfaceContract() {
+        FileResolver successResolver = (absoluteKey) -> new DataFormatStoreHandler.FileEntry(
+            "remote/blob/path",
+            DataFormatStoreHandler.REMOTE,
+            1024
+        );
+
+        FileResolver failureResolver = (absoluteKey) -> null;
+
+        DataFormatStoreHandler.FileEntry result = successResolver.resolve("/some/path");
+        assertNotNull(result);
+        assertEquals("remote/blob/path", result.path());
+        assertEquals(DataFormatStoreHandler.REMOTE, result.location());
+        assertEquals(1024, result.size());
+
+        assertNull(failureResolver.resolve("/some/path"));
+    }
+
+    /**
+     * Tests that leading slash handling is consistent between seed and resolve paths.
+     */
+    public void testLeadingSlashConsistency() {
+        // Seed path: Java does shardPath.getDataPath().resolve("parquet/file.parquet").toString()
+        // → "/data/nodes/0/indices/ABC/1/parquet/file.parquet" (with leading /)
+        //
+        // Rust strips it in register(): key = "data/nodes/0/indices/ABC/1/parquet/file.parquet"
+        // Rust strips it in get(): same
+        // Rust sends to callback: "data/nodes/0/indices/ABC/1/parquet/file.parquet" (no leading /)
+        //
+        // Resolver adds / back: "/data/nodes/0/indices/ABC/1/parquet/file.parquet"
+        // Then relativizes against shardPath → "parquet/file.parquet"
+
+        String seedKey = "/data/nodes/0/indices/ABC/1/parquet/file.parquet";
+        String rustKey = seedKey.substring(1); // Rust strips leading /
+        String resolverInput = "/" + rustKey; // Resolver adds it back
+
+        assertEquals(seedKey, resolverInput); // Must match what seed used
+    }
+}


### PR DESCRIPTION
Adds a Rust-to-Java upcall mechanism that resolves remote file paths on registry miss at query time, eliminating NotFound errors on warm shards caused by timing gaps between seed and engine open.

- Rust: TieredObjectStore calls Java via resolve_cb(store_ptr, path, len)
- Java: TieredStorageBridge owns RESOLVER_MAP with O(1) lookup by store ptr
- Server: StoreStrategyRegistry creates per-shard FileResolver closures
- Handler: ParquetDataFormatStoreHandler delegates to TieredStorageBridge

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
