### PR TITLE
Dynamic filter support for indexed path

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/datafusion_query_config.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/datafusion_query_config.rs
@@ -72,6 +72,13 @@ pub struct DatafusionQueryConfig {
     pub query_strategy: QueryStrategy,
     /// Whether to use bloom filters for row group pruning on the indexed read path.
     pub bloom_filter_on_read: bool,
+    /// Whether to accept and apply runtime dynamic filters (TopK / join)
+    /// pushed into the indexed scan via physical filter pushdown, pruning row
+    /// groups whose parquet statistics cannot satisfy the tightening predicate.
+    /// Off → `QueryShardExec` declines the pushdown (parent keeps its
+    /// `FilterExec`), so behaviour is identical to before this feature. Exposed
+    /// as a toggle to A/B the performance impact.
+    pub indexed_dynamic_filter_pushdown: bool,
 }
 
 /// FFM wire format. Must stay in lockstep with the Java `MemoryLayout`.
@@ -105,6 +112,8 @@ pub struct WireDatafusionQueryConfig {
     pub query_strategy: i32,
     /// 0 = false, 1 = true
     pub bloom_filter_on_read: i32,
+    /// 0 = false, 1 = true
+    pub indexed_dynamic_filter_pushdown: i32,
 }
 
 impl DatafusionQueryConfig {
@@ -129,6 +138,9 @@ impl DatafusionQueryConfig {
             tree_collector_strategy: CollectorCallStrategy::TightenOuterBounds,
             query_strategy: QueryStrategy::None,
             bloom_filter_on_read: true,
+            // On by default — matches the Java cluster-setting default
+            // (`datafusion.indexed.dynamic_filter_pushdown`). Toggle to A/B perf.
+            indexed_dynamic_filter_pushdown: true,
         }
     }
 
@@ -200,6 +212,7 @@ impl DatafusionQueryConfig {
                 _ => QueryStrategy::None,
             },
             bloom_filter_on_read: w.bloom_filter_on_read != 0,
+            indexed_dynamic_filter_pushdown: w.indexed_dynamic_filter_pushdown != 0,
         }
     }
 }
@@ -268,6 +281,10 @@ impl DatafusionQueryConfigBuilder {
         self.0.bloom_filter_on_read = v;
         self
     }
+    pub fn indexed_dynamic_filter_pushdown(mut self, v: bool) -> Self {
+        self.0.indexed_dynamic_filter_pushdown = v;
+        self
+    }
     pub fn build(self) -> DatafusionQueryConfig {
         self.0
     }
@@ -290,6 +307,7 @@ mod tests {
         assert_eq!(c.force_pushdown, None);
         assert_eq!(c.cost_predicate, 1);
         assert_eq!(c.cost_collector, 10);
+        assert!(c.indexed_dynamic_filter_pushdown);
     }
 
     #[test]
@@ -316,10 +334,12 @@ mod tests {
             tree_collector_strategy: 1,
             query_strategy: 1,
             bloom_filter_on_read: 1,
+            indexed_dynamic_filter_pushdown: 1,
         };
         let ptr = &wire as *const _ as i64;
         let c = unsafe { DatafusionQueryConfig::from_ffm_ptr(ptr) };
         assert_eq!(c.batch_size, 16384);
+        assert!(c.indexed_dynamic_filter_pushdown);
         assert_eq!(c.target_partitions, 8);
         assert_eq!(c.min_skip_run_default, 512);
         assert!((c.min_skip_run_selectivity_threshold - 0.07).abs() < 1e-9);
@@ -350,10 +370,12 @@ mod tests {
             tree_collector_strategy: 1,
             query_strategy: 0,
             bloom_filter_on_read: 0,
+            indexed_dynamic_filter_pushdown: 0,
         };
         let ptr = &wire as *const _ as i64;
         let c = unsafe { DatafusionQueryConfig::from_ffm_ptr(ptr) };
         assert_eq!(c.force_strategy, None);
+        assert!(!c.indexed_dynamic_filter_pushdown);
         assert_eq!(c.force_pushdown, None);
         assert_eq!(c.query_strategy, QueryStrategy::None);
     }

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/dynamic_filter.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/dynamic_filter.rs
@@ -1,0 +1,219 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+//! Runtime dynamic-filter pruning for the indexed scan.
+//!
+//! A parent `SortExec`-TopK (or join) pushes a `DynamicFilterPhysicalExpr` into
+//! `QueryShardExec` via physical filter pushdown. The filter starts as the
+//! `true` placeholder and is *tightened* at runtime (e.g. `ts > <heap-min>`) as
+//! the TopK heap fills. [`DynamicRgPruner`] watches that filter and, per row
+//! group, decides whether the RG's parquet statistics prove it cannot satisfy
+//! the current predicate — in which case the RG is skipped entirely.
+//!
+//! # Correctness
+//!
+//! The filter references only the SORT columns. RG statistics span *all* rows in
+//! the RG (a superset of the WHERE-passing candidates), so `RG.max <= threshold`
+//! implies no candidate in that RG can reach the top-k. Pruning is therefore
+//! conservative: we may miss a skip, but never drop a qualifying row. This holds
+//! regardless of how the WHERE clause was split between Lucene and parquet. See
+//! `docs/dynamic-filters-indexed-table-impl.md` §4b.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use datafusion::arrow::array::{ArrayRef, BooleanArray, UInt64Array};
+use datafusion::arrow::datatypes::{Schema, SchemaRef};
+use datafusion::common::{Column, ScalarValue};
+use datafusion::parquet::arrow::arrow_reader::statistics::StatisticsConverter;
+use datafusion::parquet::file::metadata::{ParquetMetaData, RowGroupMetaData};
+use datafusion::parquet::schema::types::SchemaDescriptor;
+use datafusion::physical_expr::PhysicalExpr;
+use datafusion::physical_expr_common::physical_expr::{
+    snapshot_generation, snapshot_physical_expr,
+};
+use datafusion::physical_optimizer::pruning::{PruningPredicate, PruningStatistics};
+
+/// `PruningStatistics` over a single parquet row group (one container). Mirrors
+/// DataFusion's private `RowGroupPruningStatistics`
+/// (`datasource-parquet/src/row_group_filter.rs`) but scoped to exactly one RG.
+struct SingleRowGroupStatistics<'a> {
+    parquet_schema: &'a SchemaDescriptor,
+    rg_meta: &'a RowGroupMetaData,
+    arrow_schema: &'a Schema,
+}
+
+impl<'a> SingleRowGroupStatistics<'a> {
+    fn converter<'b>(&'a self, column: &'b Column) -> datafusion::common::Result<StatisticsConverter<'a>> {
+        Ok(StatisticsConverter::try_new(
+            &column.name,
+            self.arrow_schema,
+            self.parquet_schema,
+        )?)
+    }
+
+    fn iter(&'a self) -> impl Iterator<Item = &'a RowGroupMetaData> + 'a {
+        std::iter::once(self.rg_meta)
+    }
+}
+
+impl PruningStatistics for SingleRowGroupStatistics<'_> {
+    fn min_values(&self, column: &Column) -> Option<ArrayRef> {
+        self.converter(column)
+            .and_then(|c| Ok(c.row_group_mins(self.iter())?))
+            .ok()
+    }
+
+    fn max_values(&self, column: &Column) -> Option<ArrayRef> {
+        self.converter(column)
+            .and_then(|c| Ok(c.row_group_maxes(self.iter())?))
+            .ok()
+    }
+
+    fn num_containers(&self) -> usize {
+        1
+    }
+
+    fn null_counts(&self, column: &Column) -> Option<ArrayRef> {
+        self.converter(column)
+            .and_then(|c| Ok(c.row_group_null_counts(self.iter())?))
+            .ok()
+            .map(|counts| Arc::new(counts) as ArrayRef)
+    }
+
+    fn row_counts(&self, _column: &Column) -> Option<ArrayRef> {
+        let counts: UInt64Array = std::iter::once(Some(self.rg_meta.num_rows() as u64)).collect();
+        Some(Arc::new(counts) as ArrayRef)
+    }
+
+    fn contained(&self, _column: &Column, _values: &HashSet<ScalarValue>) -> Option<BooleanArray> {
+        None
+    }
+}
+
+/// Watches a pushed-down dynamic filter and prunes row groups whose parquet
+/// statistics cannot satisfy the current (tightening) predicate.
+///
+/// Cheap in steady state: [`should_prune_rg`] only rebuilds the
+/// `PruningPredicate` when the filter's generation actually changes (an atomic
+/// read of the snapshot generation), matching DataFusion's `FilePruner`
+/// discipline.
+pub struct DynamicRgPruner {
+    /// The conjoined dynamic filter (still containing `DynamicFilterPhysicalExpr`
+    /// nodes). Snapshotted on demand to a concrete predicate.
+    filter: Arc<dyn PhysicalExpr>,
+    /// Full (parquet) schema — used to build the `PruningPredicate`.
+    full_schema: SchemaRef,
+    /// Generation of the snapshot currently cached in `pruning_predicate`.
+    /// `u64::MAX` means "nothing cached yet" (forces a build on first use).
+    cached_generation: u64,
+    /// Cached pruning predicate for the current generation. `None` when the
+    /// snapshot couldn't be turned into a pruning predicate (e.g. an expression
+    /// `PruningPredicate` can't handle) — in which case we never prune.
+    pruning_predicate: Option<Arc<PruningPredicate>>,
+}
+
+impl DynamicRgPruner {
+    /// Build a pruner over `filter`. Returns `None` if `filter` is `None`
+    /// (no dynamic filter was accepted), so the hot path can skip all work.
+    pub fn new(
+        filter: Option<Arc<dyn PhysicalExpr>>,
+        full_schema: SchemaRef,
+    ) -> Option<Self> {
+        filter.map(|filter| Self {
+            filter,
+            full_schema,
+            cached_generation: u64::MAX,
+            pruning_predicate: None,
+        })
+    }
+
+    /// Refresh the cached `PruningPredicate` if the dynamic filter has changed
+    /// since the last call. Cheap when unchanged (just an atomic generation
+    /// read). Returns the current generation.
+    fn refresh(&mut self) -> u64 {
+        let generation = snapshot_generation(&self.filter);
+        if generation == self.cached_generation && self.pruning_predicate.is_some() {
+            return generation;
+        }
+        if generation == self.cached_generation {
+            // Same generation, but we have no predicate cached (build failed or
+            // first call with a non-prunable snapshot) — nothing to redo.
+            return generation;
+        }
+        self.cached_generation = generation;
+        // Flatten any DynamicFilterPhysicalExpr to its current concrete value.
+        self.pruning_predicate = snapshot_physical_expr(Arc::clone(&self.filter))
+            .ok()
+            .and_then(|snap| {
+                PruningPredicate::try_new(snap, Arc::clone(&self.full_schema))
+                    .ok()
+                    .map(Arc::new)
+            });
+        generation
+    }
+
+    /// The current concrete pruning predicate (snapshotting the dynamic filter
+    /// at its tightening so far), plus the schema needed to evaluate it against
+    /// RG stats. Generation-gated, so cheap when the filter hasn't moved.
+    ///
+    /// Handed to the prefetch closure so an RG can be excluded *before* the
+    /// (expensive) Lucene/FFM eval runs. `None` when no prunable predicate is
+    /// available yet.
+    pub fn current_pruning_predicate(&mut self) -> Option<RgPruningContext> {
+        self.refresh();
+        self.pruning_predicate
+            .clone()
+            .map(|predicate| RgPruningContext {
+                predicate,
+                schema: Arc::clone(&self.full_schema),
+            })
+    }
+
+    /// True if row group `rg_idx` can be skipped: the current predicate proves
+    /// that *no* row in the RG (and hence no candidate) can satisfy it.
+    ///
+    /// Conservative — returns `false` (scan the RG) on any uncertainty: missing
+    /// stats, non-prunable predicate, or evaluation error. Never skips on doubt.
+    pub fn should_prune_rg(&mut self, metadata: &Arc<ParquetMetaData>, rg_idx: usize) -> bool {
+        let Some(ctx) = self.current_pruning_predicate() else {
+            return false;
+        };
+        ctx.rg_provably_excluded(metadata, rg_idx)
+    }
+}
+
+/// A snapshotted pruning predicate plus the schema to evaluate it. Cheaply
+/// cloneable (`Arc` inside) and `Send`, so it can be moved into the prefetch
+/// `spawn_blocking` closure to gate the Lucene eval.
+#[derive(Clone)]
+pub struct RgPruningContext {
+    predicate: Arc<PruningPredicate>,
+    schema: SchemaRef,
+}
+
+impl RgPruningContext {
+    /// True if row group `rg_idx`'s parquet statistics prove it cannot satisfy
+    /// the predicate. Conservative: `false` on any missing stats / error.
+    pub fn rg_provably_excluded(&self, metadata: &Arc<ParquetMetaData>, rg_idx: usize) -> bool {
+        let Some(rg_meta) = metadata.row_groups().get(rg_idx) else {
+            return false;
+        };
+        let stats = SingleRowGroupStatistics {
+            parquet_schema: metadata.file_metadata().schema_descr(),
+            rg_meta,
+            arrow_schema: self.schema.as_ref(),
+        };
+        // `prune` returns one bool per container (we have exactly one). `false`
+        // means "provably cannot match" → safe to skip. Any error => keep.
+        match self.predicate.prune(&stats) {
+            Ok(keep) => keep.first().is_some_and(|k| !*k),
+            Err(_) => false,
+        }
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/dynamic_filter_probe.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/dynamic_filter_probe.rs
@@ -1,0 +1,202 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+//! Probe test (no production code): confirms that DataFusion's post-optimization
+//! `FilterPushdown` rule actually delivers a `DynamicFilterPhysicalExpr` to a
+//! **leaf** scan's `handle_child_pushdown_result` when a `SortExec { fetch }`
+//! (TopK) sits above it.
+//!
+//! This is the make-or-break prerequisite for wiring dynamic filters into
+//! `IndexedExec`/`QueryShardExec`: if the filter never reaches our leaf, the
+//! whole feature is moot. We model our scan with a minimal recording leaf so
+//! the test is hermetic and fast.
+
+#![cfg(test)]
+
+use std::any::Any;
+use std::fmt;
+use std::sync::{Arc, Mutex};
+
+use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use datafusion::common::config::ConfigOptions;
+use datafusion::common::tree_node::{TreeNode, TreeNodeRecursion};
+use datafusion::common::Result;
+use datafusion::execution::{SendableRecordBatchStream, TaskContext};
+use datafusion::physical_expr::expressions::{col, DynamicFilterPhysicalExpr};
+use datafusion::physical_expr::{EquivalenceProperties, LexOrdering, PhysicalSortExpr};
+use datafusion::physical_optimizer::filter_pushdown::FilterPushdown;
+use datafusion::physical_optimizer::PhysicalOptimizerRule;
+use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
+use datafusion::physical_plan::filter_pushdown::{
+    ChildPushdownResult, FilterPushdownPhase, FilterPushdownPropagation, PushedDown,
+};
+use datafusion::physical_plan::sorts::sort::SortExec;
+use datafusion::physical_plan::{
+    DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties, Partitioning,
+};
+use datafusion::physical_expr::PhysicalExpr;
+
+/// What a leaf observed in `handle_child_pushdown_result`. Shared out-of-band
+/// (the optimizer clones/rebuilds nodes, so we can't read it back off the plan).
+#[derive(Default)]
+struct Observed {
+    /// Stringified filters that arrived as parent_filters.
+    arrived: Vec<String>,
+    /// Whether at least one arriving filter was a DynamicFilterPhysicalExpr.
+    saw_dynamic: bool,
+}
+
+/// Minimal leaf scan that records the filters pushed to it. Mirrors the role of
+/// `QueryShardExec` for the purpose of this probe — a leaf with no children that
+/// must accept a Post-phase dynamic filter.
+#[derive(Clone)]
+struct RecordingLeaf {
+    schema: SchemaRef,
+    props: Arc<PlanProperties>,
+    observed: Arc<Mutex<Observed>>,
+}
+
+impl RecordingLeaf {
+    fn new(schema: SchemaRef, observed: Arc<Mutex<Observed>>) -> Self {
+        let props = Arc::new(PlanProperties::new(
+            EquivalenceProperties::new(schema.clone()),
+            Partitioning::UnknownPartitioning(1),
+            EmissionType::Incremental,
+            Boundedness::Bounded,
+        ));
+        Self { schema, props, observed }
+    }
+}
+
+impl fmt::Debug for RecordingLeaf {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "RecordingLeaf")
+    }
+}
+
+impl DisplayAs for RecordingLeaf {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "RecordingLeaf")
+    }
+}
+
+impl ExecutionPlan for RecordingLeaf {
+    fn name(&self) -> &str {
+        "RecordingLeaf"
+    }
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+    fn properties(&self) -> &Arc<PlanProperties> {
+        &self.props
+    }
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![]
+    }
+    fn with_new_children(
+        self: Arc<Self>,
+        _children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        Ok(self)
+    }
+    fn execute(
+        &self,
+        _partition: usize,
+        _context: Arc<TaskContext>,
+    ) -> Result<SendableRecordBatchStream> {
+        unreachable!("probe test never executes the plan")
+    }
+
+    /// The behaviour under test: when the TopK above us pushes its dynamic
+    /// filter, it arrives here as `parent_filters`. Record what we see and
+    /// claim support so the optimizer is happy.
+    fn handle_child_pushdown_result(
+        &self,
+        _phase: FilterPushdownPhase,
+        child_pushdown_result: ChildPushdownResult,
+        _config: &ConfigOptions,
+    ) -> Result<FilterPushdownPropagation<Arc<dyn ExecutionPlan>>> {
+        let mut obs = self.observed.lock().unwrap();
+        let mut statuses = Vec::new();
+        for f in &child_pushdown_result.parent_filters {
+            obs.arrived.push(format!("{}", f.filter));
+            // Detect a DynamicFilterPhysicalExpr anywhere in the expr tree.
+            let mut is_dynamic = false;
+            f.filter
+                .apply(|e| {
+                    if e.as_any().downcast_ref::<DynamicFilterPhysicalExpr>().is_some() {
+                        is_dynamic = true;
+                    }
+                    Ok(TreeNodeRecursion::Continue)
+                })
+                .ok();
+            obs.saw_dynamic |= is_dynamic;
+            statuses.push(PushedDown::Yes);
+        }
+        Ok(FilterPushdownPropagation::with_parent_pushdown_result(statuses))
+    }
+}
+
+fn test_schema() -> SchemaRef {
+    Arc::new(Schema::new(vec![
+        Field::new("ts", DataType::Int64, false),
+        Field::new("brand", DataType::Utf8, true),
+    ]))
+}
+
+/// SortExec(ts DESC, fetch=Some(k)) over RecordingLeaf, then run the
+/// post-optimization FilterPushdown rule. Assert a dynamic filter arrived.
+#[test]
+fn dynamic_filter_reaches_leaf_under_topk() {
+    let schema = test_schema();
+    let observed = Arc::new(Mutex::new(Observed::default()));
+    let leaf: Arc<dyn ExecutionPlan> =
+        Arc::new(RecordingLeaf::new(schema.clone(), Arc::clone(&observed)));
+
+    // ORDER BY ts DESC LIMIT 10
+    let sort_expr = PhysicalSortExpr {
+        expr: col("ts", &schema).unwrap(),
+        options: datafusion::arrow::compute::SortOptions {
+            descending: true,
+            nulls_first: false,
+        },
+    };
+    let ordering = LexOrdering::new(vec![sort_expr]).unwrap();
+    let sort = Arc::new(SortExec::new(ordering, leaf).with_fetch(Some(10)));
+
+    let mut config = ConfigOptions::default();
+    // Defaults are already true, but be explicit — this is the switch.
+    config.optimizer.enable_dynamic_filter_pushdown = true;
+    config.optimizer.enable_topk_dynamic_filter_pushdown = true;
+
+    let rule = FilterPushdown::new_post_optimization();
+    let _optimized = rule
+        .optimize(sort, &config)
+        .expect("post-optimization filter pushdown should not error");
+
+    let obs = observed.lock().unwrap();
+    assert!(
+        obs.saw_dynamic,
+        "expected a DynamicFilterPhysicalExpr to reach the leaf; arrived filters = {:?}",
+        obs.arrived
+    );
+    // Exactly one filter arrives — the TopK self-filter. Its `Display` at plan
+    // time is the opaque `DynamicFilter [ empty ]` placeholder (the concrete
+    // `ts > <threshold>` value materializes only at runtime via snapshot()).
+    // This is *why* acceptance keys on the referenced columns, not the printed
+    // value: we must downcast + walk the children to find the sort column.
+    assert_eq!(obs.arrived.len(), 1, "expected exactly the TopK self-filter");
+    assert!(
+        obs.arrived[0].contains("DynamicFilter"),
+        "arrived filter should be the dynamic placeholder; got {:?}",
+        obs.arrived
+    );
+}

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/metrics.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/metrics.rs
@@ -100,6 +100,15 @@ pub struct StreamMetrics {
     /// Time spent polling the inner parquet stream (pull decoded
     /// batch), isolating decode from our own processing.
     pub parquet_poll_time: Option<Time>,
+    /// Count of row groups skipped by the runtime dynamic-filter pruner at the
+    /// PREFETCH phase — before the Lucene/FFM eval ran. This saves both the
+    /// index eval and the parquet decode. Zero when no dynamic filter was pushed.
+    pub dynamic_filter_rg_pruned_at_prefetch: Option<Count>,
+    /// Count of row groups skipped by the runtime dynamic-filter pruner at the
+    /// POLL phase — after the Lucene/FFM eval but before parquet decode. Catches
+    /// RGs that became prunable only after the filter tightened further between
+    /// prefetch (which runs ~1 RG ahead) and processing.
+    pub dynamic_filter_rg_pruned_at_poll: Option<Count>,
     /// Accumulated inner `DataSourceExec` parquet metrics (shared across partitions).
     pub inner_parquet_metrics: Option<Arc<std::sync::Mutex<Vec<MetricsSet>>>>,
 }
@@ -139,6 +148,8 @@ impl StreamMetrics {
             mask_slice_time: None,
             projection_fixup_time: None,
             parquet_poll_time: None,
+            dynamic_filter_rg_pruned_at_prefetch: None,
+            dynamic_filter_rg_pruned_at_poll: None,
             inner_parquet_metrics: None,
         }
     }
@@ -177,6 +188,8 @@ pub struct PartitionMetrics {
     pub mask_slice_time: Time,
     pub projection_fixup_time: Time,
     pub parquet_poll_time: Time,
+    pub dynamic_filter_rg_pruned_at_prefetch: Count,
+    pub dynamic_filter_rg_pruned_at_poll: Count,
 }
 
 impl PartitionMetrics {
@@ -219,6 +232,8 @@ impl PartitionMetrics {
                 .subset_time("projection_fixup_time", partition),
             parquet_poll_time: MetricBuilder::new(metrics)
                 .subset_time("parquet_poll_time", partition),
+            dynamic_filter_rg_pruned_at_prefetch: counter("dynamic_filter_rg_pruned_at_prefetch"),
+            dynamic_filter_rg_pruned_at_poll: counter("dynamic_filter_rg_pruned_at_poll"),
         }
     }
 
@@ -259,6 +274,8 @@ impl PartitionMetrics {
             mask_slice_time: Some(self.mask_slice_time),
             projection_fixup_time: Some(self.projection_fixup_time),
             parquet_poll_time: Some(self.parquet_poll_time),
+            dynamic_filter_rg_pruned_at_prefetch: Some(self.dynamic_filter_rg_pruned_at_prefetch),
+            dynamic_filter_rg_pruned_at_poll: Some(self.dynamic_filter_rg_pruned_at_poll),
             inner_parquet_metrics,
         }
     }

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/mod.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/mod.rs
@@ -56,6 +56,7 @@
 
 pub mod bloom_pruner;
 pub mod bool_tree;
+pub mod dynamic_filter;
 pub mod eval;
 pub mod row_id_injection;
 pub mod ffm_callbacks;
@@ -72,3 +73,6 @@ pub mod table_provider;
 
 #[cfg(test)]
 mod tests_e2e;
+
+#[cfg(test)]
+mod dynamic_filter_probe;

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/stream.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/stream.rs
@@ -85,7 +85,19 @@ struct PrefetchedRowGroup {
     prefetched: PrefetchedRg,
 }
 
-type PrefetchResult = std::result::Result<Option<PrefetchedRowGroup>, String>;
+/// Outcome of one prefetch task.
+enum PrefetchOutcome {
+    /// RG fetched with a non-empty candidate set.
+    Fetched(PrefetchedRowGroup),
+    /// RG had no candidates (empty bitmap) or fell outside the doc range —
+    /// skipped without a parquet read. Attributed to `rg_skipped`.
+    Empty,
+    /// RG excluded by the dynamic filter at prefetch time, before the Lucene
+    /// eval ran. Attributed to `dynamic_filter_rg_pruned_at_prefetch`.
+    Pruned,
+}
+
+type PrefetchResult = std::result::Result<PrefetchOutcome, String>;
 type PrefetchHandle = JoinHandle<PrefetchResult>;
 
 // ── IndexReader (drives the evaluator RG-by-RG with prefetch overlap) ──
@@ -110,9 +122,21 @@ struct IndexReader {
     /// polled (and returned Pending). Used to attribute wait time when
     /// the receiver eventually resolves.
     pending_since: Option<Instant>,
+    /// Parquet metadata for this segment — needed to evaluate a dynamic-filter
+    /// snapshot against an RG's statistics before kicking off its Lucene eval.
+    /// `None` only in unit tests that don't exercise dynamic-filter pruning.
+    metadata: Option<Arc<ParquetMetaData>>,
+    /// Snapshot of the runtime dynamic filter (refreshed by the stream before
+    /// each `poll_next_row_group`). When present, `start_prefetch` checks it
+    /// against the target RG's stats and skips the Lucene eval if the RG is
+    /// provably excluded. `None` when no dynamic filter was pushed.
+    dynamic_prune_ctx: Option<super::dynamic_filter::RgPruningContext>,
+    /// Count of RGs skipped at prefetch time (before the Lucene eval).
+    dynamic_filter_rg_pruned_at_prefetch: Option<datafusion::physical_plan::metrics::Count>,
 }
 
 impl IndexReader {
+    #[allow(clippy::too_many_arguments)]
     fn new(
         evaluator: Arc<dyn RowGroupBitsetSource>,
         row_groups: Vec<RowGroupInfo>,
@@ -120,6 +144,8 @@ impl IndexReader {
         rg_skipped: Option<datafusion::physical_plan::metrics::Count>,
         prefetch_wait_time: Option<datafusion::physical_plan::metrics::Time>,
         prefetch_wait_count: Option<datafusion::physical_plan::metrics::Count>,
+        metadata: Option<Arc<ParquetMetaData>>,
+        dynamic_filter_rg_pruned_at_prefetch: Option<datafusion::physical_plan::metrics::Count>,
     ) -> Self {
         Self {
             evaluator,
@@ -132,31 +158,50 @@ impl IndexReader {
             prefetch_wait_time,
             prefetch_wait_count,
             pending_since: None,
+            metadata,
+            dynamic_prune_ctx: None,
+            dynamic_filter_rg_pruned_at_prefetch,
         }
     }
 
+    /// Result of a prefetch task. `Pruned` is distinct from `Ok(None)`
+    /// (empty candidate set): it means the dynamic filter excluded the RG
+    /// before the Lucene eval ran, so it must be attributed to the
+    /// prefetch-phase prune counter rather than `rg_skipped`.
     fn fetch_row_group(
         evaluator: &Arc<dyn RowGroupBitsetSource>,
         row_groups: &[RowGroupInfo],
         rg_idx: usize,
         doc_range: Option<(i32, i32)>,
-    ) -> std::result::Result<Option<PrefetchedRowGroup>, String> {
+        prune: Option<(super::dynamic_filter::RgPruningContext, Arc<ParquetMetaData>)>,
+    ) -> std::result::Result<PrefetchOutcome, String> {
         if rg_idx >= row_groups.len() {
-            return Ok(None);
+            return Ok(PrefetchOutcome::Empty);
         }
         let rg = row_groups[rg_idx].clone();
+
+        // Prefetch-phase dynamic-filter prune: if the snapshot-so-far proves
+        // this RG's parquet stats cannot match, skip BEFORE the (expensive)
+        // Lucene/FFM eval. Conservative — only skips on proof; the threshold
+        // only tightens, so an RG excluded here stays excluded.
+        if let Some((ctx, metadata)) = prune.as_ref() {
+            if ctx.rg_provably_excluded(metadata, rg.index) {
+                return Ok(PrefetchOutcome::Pruned);
+            }
+        }
+
         let mut min_doc = rg.first_row as i32;
         let mut max_doc = (rg.first_row + rg.num_rows) as i32;
         if let Some((range_min, range_max)) = doc_range {
             min_doc = min_doc.max(range_min);
             max_doc = max_doc.min(range_max);
             if min_doc >= max_doc {
-                return Ok(None);
+                return Ok(PrefetchOutcome::Empty);
             }
         }
         match evaluator.prefetch_rg(&rg, min_doc, max_doc)? {
-            None => Ok(None),
-            Some(prefetched) => Ok(Some(PrefetchedRowGroup { rg, prefetched })),
+            None => Ok(PrefetchOutcome::Empty),
+            Some(prefetched) => Ok(PrefetchOutcome::Fetched(PrefetchedRowGroup { rg, prefetched })),
         }
     }
 
@@ -167,8 +212,14 @@ impl IndexReader {
         let evaluator = Arc::clone(&self.evaluator);
         let row_groups = self.row_groups.clone();
         let doc_range = self.doc_range;
+        // Snapshot-so-far + metadata, moved into the blocking task so the
+        // prefetch-phase prune runs off the poll thread.
+        let prune = match (self.dynamic_prune_ctx.clone(), self.metadata.as_ref()) {
+            (Some(ctx), Some(md)) => Some((ctx, Arc::clone(md))),
+            _ => None,
+        };
         let handle = tokio::task::spawn_blocking(move || {
-            Self::fetch_row_group(&evaluator, &row_groups, rg_idx, doc_range)
+            Self::fetch_row_group(&evaluator, &row_groups, rg_idx, doc_range, prune)
         });
         self.pending_prefetch = Some(handle);
     }
@@ -185,11 +236,19 @@ impl IndexReader {
                 self.current_rg_idx += 1;
                 self.start_prefetch(self.current_rg_idx);
                 match result {
-                    Ok(Some(p)) => return Poll::Ready(Ok(Some(p))),
-                    Ok(None) => {
+                    Ok(PrefetchOutcome::Fetched(p)) => return Poll::Ready(Ok(Some(p))),
+                    Ok(PrefetchOutcome::Empty) => {
                         // RG had no candidates — skipped without a
                         // parquet read. Count for EXPLAIN ANALYZE.
                         if let Some(ref c) = self.rg_skipped {
+                            c.add(1);
+                        }
+                        continue;
+                    }
+                    Ok(PrefetchOutcome::Pruned) => {
+                        // RG excluded by the dynamic filter before the Lucene
+                        // eval ran — the prefetch-phase win.
+                        if let Some(ref c) = self.dynamic_filter_rg_pruned_at_prefetch {
                             c.add(1);
                         }
                         continue;
@@ -292,6 +351,11 @@ pub struct IndexedExec {
     /// Index in the OUTPUT schema where computed `___row_id` should be inserted.
     /// `None` when `emit_row_ids=false` or `___row_id` is not in projection.
     pub(crate) row_id_output_index: Option<usize>,
+    /// Optional runtime dynamic filter (TopK / join) accepted via physical
+    /// pushdown, referencing the sort columns. Used to prune row groups whose
+    /// parquet statistics cannot satisfy the (tightening) predicate. `None`
+    /// when no dynamic filter was pushed to this query.
+    pub(crate) dynamic_filter: Option<Arc<dyn datafusion::physical_expr::PhysicalExpr>>,
 }
 
 impl fmt::Debug for IndexedExec {
@@ -365,6 +429,8 @@ impl ExecutionPlan for IndexedExec {
             self.stream_metrics.rg_skipped.clone(),
             self.stream_metrics.prefetch_wait_time.clone(),
             self.stream_metrics.prefetch_wait_count.clone(),
+            Some(Arc::clone(&self.metadata)),
+            self.stream_metrics.dynamic_filter_rg_pruned_at_prefetch.clone(),
         );
         Ok(Box::pin(IndexedStream::new(
             self.schema.clone(),
@@ -387,6 +453,7 @@ impl ExecutionPlan for IndexedExec {
             self.global_base,
             self.emit_row_ids,
             self.row_id_output_index,
+            self.dynamic_filter.clone(),
         )))
     }
 }
@@ -455,6 +522,10 @@ struct IndexedStream {
     emit_row_ids: bool,
     /// Index in the output schema where computed `___row_id` is inserted.
     row_id_output_index: Option<usize>,
+    /// Per-stream runtime dynamic-filter pruner. `None` when no dynamic filter
+    /// was pushed. Owns its own snapshot generation tracking, so it must NOT be
+    /// shared across sibling segment streams.
+    dynamic_rg_pruner: Option<super::dynamic_filter::DynamicRgPruner>,
 }
 
 impl IndexedStream {
@@ -480,10 +551,15 @@ impl IndexedStream {
         global_base: u64,
         emit_row_ids: bool,
         row_id_output_index: Option<usize>,
+        dynamic_filter: Option<Arc<dyn datafusion::physical_expr::PhysicalExpr>>,
     ) -> Self {
         let evaluator = Arc::clone(&index_reader.evaluator);
         let batch_coalescer =
             LimitedBatchCoalescer::new(schema.clone(), target_batch_size, None);
+        let dynamic_rg_pruner = super::dynamic_filter::DynamicRgPruner::new(
+            dynamic_filter,
+            full_schema.clone(),
+        );
         Self {
             schema,
             full_schema,
@@ -518,6 +594,7 @@ impl IndexedStream {
             global_base,
             emit_row_ids,
             row_id_output_index,
+            dynamic_rg_pruner,
         }
     }
 
@@ -832,10 +909,34 @@ impl IndexedStream {
                 continue;
             }
 
+            // Refresh the dynamic-filter snapshot the IndexReader hands to its
+            // prefetch tasks, so the next prefetch can prune (skipping the
+            // Lucene eval) using the filter's tightening so far.
+            if let Some(ref mut pruner) = self.dynamic_rg_pruner {
+                self.index_reader.dynamic_prune_ctx = pruner.current_pruning_predicate();
+            }
+
             // Poll for next row group
             match self.index_reader.poll_next_row_group(cx) {
                 Poll::Ready(Ok(Some(prefetched))) => {
                     let rg = prefetched.rg;
+
+                    // Poll-phase dynamic-filter prune (backstop): the filter may
+                    // have tightened further since this RG was prefetched (~1 RG
+                    // ahead). Re-check against the latest snapshot; skip the
+                    // parquet decode if now provably excluded. Conservative:
+                    // only skips on proof (see dynamic_filter::DynamicRgPruner).
+                    if self.dynamic_rg_pruner.is_some() {
+                        let metadata = Arc::clone(&self.metadata);
+                        let pruner = self.dynamic_rg_pruner.as_mut().unwrap();
+                        if pruner.should_prune_rg(&metadata, rg.index) {
+                            if let Some(ref c) = self.metrics.dynamic_filter_rg_pruned_at_poll {
+                                c.add(1);
+                            }
+                            continue;
+                        }
+                    }
+
                     let candidates = prefetched.prefetched.candidates;
                     let prefetch_mask_buffer = prefetched.prefetched.mask_buffer;
 
@@ -1095,6 +1196,8 @@ mod tests {
         let mut reader = IndexReader::new(
             evaluator.clone(),
             vec![rg_info],
+            None,
+            None,
             None,
             None,
             None,

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/table_provider.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/table_provider.rs
@@ -297,6 +297,7 @@ impl TableProvider for IndexedTableProvider {
             metrics: ExecutionPlanMetricsSet::new(),
             inner_parquet_metrics: Arc::new(std::sync::Mutex::new(Vec::new())),
             row_id_output_index,
+            dynamic_filters: Vec::new(),
         }))
     }
 
@@ -325,6 +326,16 @@ pub struct QueryShardExec {
     /// Column index in the OUTPUT schema where computed `___row_id` should be
     /// injected. `None` means no row ID computation (normal data path).
     row_id_output_index: Option<usize>,
+    /// Runtime dynamic filters accepted from a parent operator (typically a
+    /// `SortExec`-TopK `DynamicFilterPhysicalExpr`) via physical filter
+    /// pushdown. Each is read per row-group at execution time to prune RGs
+    /// whose parquet statistics cannot satisfy the (tightening) predicate.
+    /// Empty unless `handle_child_pushdown_result` accepted one.
+    ///
+    /// These reference only the SORT columns, never the WHERE clause — so they
+    /// are orthogonal to the Lucene/parquet boolean split. See
+    /// `docs/dynamic-filters-indexed-table-impl.md` §4b.
+    dynamic_filters: Vec<Arc<dyn datafusion::physical_expr::PhysicalExpr>>,
 }
 
 impl fmt::Debug for QueryShardExec {
@@ -385,6 +396,63 @@ impl ExecutionPlan for QueryShardExec {
         Some(combined)
     }
 
+    /// Accept runtime dynamic filters (TopK / join) pushed from a parent.
+    ///
+    /// `QueryShardExec` is a leaf (no children), so the default
+    /// `gather_filters_for_pushdown` already returns an empty description — the
+    /// parent's self-filter arrives here as `parent_filters`. We accept a filter
+    /// only in the `Post` phase and only when every column it references is a
+    /// readable parquet column in our schema (so per-RG statistics pruning is
+    /// possible). Anything else is declined, leaving the parent's safety-net
+    /// `FilterExec` in place — declining is always correctness-safe.
+    fn handle_child_pushdown_result(
+        &self,
+        phase: datafusion::physical_plan::filter_pushdown::FilterPushdownPhase,
+        child_pushdown_result: datafusion::physical_plan::filter_pushdown::ChildPushdownResult,
+        _config: &datafusion::config::ConfigOptions,
+    ) -> Result<
+        datafusion::physical_plan::filter_pushdown::FilterPushdownPropagation<
+            Arc<dyn ExecutionPlan>,
+        >,
+    > {
+        use datafusion::physical_plan::filter_pushdown::{
+            FilterPushdownPhase, FilterPushdownPropagation, PushedDown,
+        };
+
+        // Feature gate: when disabled, decline everything so behaviour is
+        // identical to before this feature (parent keeps its FilterExec).
+        if !self.config.query_config.indexed_dynamic_filter_pushdown {
+            return Ok(FilterPushdownPropagation::if_all(child_pushdown_result));
+        }
+
+        // Only the Post phase carries dynamic filters; in Pre we own static
+        // WHERE semantics via the BoolNode tree and want no interference.
+        if phase != FilterPushdownPhase::Post {
+            return Ok(FilterPushdownPropagation::if_all(child_pushdown_result));
+        }
+
+        let mut statuses = Vec::with_capacity(child_pushdown_result.parent_filters.len());
+        let mut accepted: Vec<Arc<dyn datafusion::physical_expr::PhysicalExpr>> = Vec::new();
+        for f in &child_pushdown_result.parent_filters {
+            if self.dynamic_filter_is_acceptable(&f.filter) {
+                statuses.push(PushedDown::Yes);
+                accepted.push(Arc::clone(&f.filter));
+            } else {
+                statuses.push(PushedDown::No);
+            }
+        }
+
+        if accepted.is_empty() {
+            return Ok(FilterPushdownPropagation::with_parent_pushdown_result(statuses));
+        }
+
+        let new_self = self.clone_with_dynamic_filters(accepted);
+        Ok(
+            FilterPushdownPropagation::with_parent_pushdown_result(statuses)
+                .with_updated_node(Arc::new(new_self) as Arc<dyn ExecutionPlan>),
+        )
+    }
+
     fn execute(
         &self,
         partition: usize,
@@ -397,6 +465,14 @@ impl ExecutionPlan for QueryShardExec {
         let pmetrics = PartitionMetrics::new(&self.metrics, partition);
         let stream_metrics =
             pmetrics.into_stream_metrics(Some(Arc::clone(&self.inner_parquet_metrics)));
+
+        // Conjoin any accepted runtime dynamic filters into one predicate,
+        // shared (by Arc) across every chunk's IndexedExec. The inner
+        // DynamicFilterPhysicalExpr state is shared with the producing TopK, so
+        // all streams observe the same runtime tightening.
+        let dynamic_filter: Option<Arc<dyn datafusion::physical_expr::PhysicalExpr>> =
+            (!self.dynamic_filters.is_empty())
+                .then(|| datafusion::physical_expr::utils::conjunction(self.dynamic_filters.clone()));
 
         // Build one IndexedExec per SegmentChunk and execute it immediately,
         // collecting per-chunk streams. We then chain them sequentially into
@@ -455,6 +531,7 @@ impl ExecutionPlan for QueryShardExec {
                 global_base: segment.global_base,
                 emit_row_ids: self.config.emit_row_ids,
                 row_id_output_index: self.row_id_output_index,
+                dynamic_filter: dynamic_filter.clone(),
             };
             streams.push(exec.execute(0, Arc::clone(&context))?);
         }
@@ -472,6 +549,62 @@ impl ExecutionPlan for QueryShardExec {
                 let chained = futures::stream::iter(streams).flatten();
                 Ok(Box::pin(RecordBatchStreamAdapter::new(schema, chained)))
             }
+        }
+    }
+}
+
+impl QueryShardExec {
+    /// True if `filter` can be used for per-RG statistics pruning: every column
+    /// it references must exist in our full (parquet) schema. Dynamic filters
+    /// reference sort columns; a sort on a Lucene-only / computed column (not in
+    /// the parquet file) is declined so we never try to prune on absent stats.
+    ///
+    /// Conservative by design — a `false` here just keeps the parent's
+    /// `FilterExec` and forgoes the optimization; it can never drop a row.
+    fn dynamic_filter_is_acceptable(
+        &self,
+        filter: &Arc<dyn datafusion::physical_expr::PhysicalExpr>,
+    ) -> bool {
+        use datafusion::common::tree_node::{TreeNode, TreeNodeRecursion};
+        use datafusion::physical_expr::expressions::Column;
+
+        let mut all_cols_known = true;
+        let mut saw_column = false;
+        let _ = filter.apply(|e| {
+            if let Some(c) = e.as_any().downcast_ref::<Column>() {
+                saw_column = true;
+                if self.full_schema.index_of(c.name()).is_err() {
+                    all_cols_known = false;
+                    return Ok(TreeNodeRecursion::Stop);
+                }
+            }
+            Ok(TreeNodeRecursion::Continue)
+        });
+        // Require at least one resolved column — a column-free predicate (e.g.
+        // the bare `true` placeholder) carries no pruning signal.
+        saw_column && all_cols_known
+    }
+
+    /// Rebuild this exec with accepted dynamic filters attached. `QueryShardExec`
+    /// holds a non-`Clone` `ExecutionPlanMetricsSet`; we mint a fresh one (the
+    /// pushdown rewrite happens before execution, so no metrics are lost) and
+    /// reuse the shared `Arc` fields verbatim.
+    fn clone_with_dynamic_filters(
+        &self,
+        dynamic_filters: Vec<Arc<dyn datafusion::physical_expr::PhysicalExpr>>,
+    ) -> Self {
+        QueryShardExec {
+            config: Arc::clone(&self.config),
+            full_schema: self.full_schema.clone(),
+            projected_schema: self.projected_schema.clone(),
+            projection: self.projection.clone(),
+            assignments: self.assignments.clone(),
+            properties: Arc::clone(&self.properties),
+            predicate: self.predicate.clone(),
+            metrics: ExecutionPlanMetricsSet::new(),
+            inner_parquet_metrics: Arc::clone(&self.inner_parquet_metrics),
+            row_id_output_index: self.row_id_output_index,
+            dynamic_filters,
         }
     }
 }

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/dynamic_filter_pushdown.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/dynamic_filter_pushdown.rs
@@ -1,0 +1,270 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+//! End-to-end verification of runtime dynamic-filter (TopK) pruning on the
+//! indexed scan.
+//!
+//! Builds `SELECT ... ORDER BY price DESC LIMIT k` over a single segment with
+//! four disjoint-range row groups, lets DataFusion's default physical optimizer
+//! insert `SortExec { fetch }` + push its `DynamicFilterPhysicalExpr` into
+//! `QueryShardExec`, executes, then asserts:
+//!   1. results equal the full-scan top-k (correctness), and
+//!   2. `dynamic_filter_rg_pruned > 0` (the optimization actually fired).
+
+use std::sync::Arc;
+
+use datafusion::arrow::array::{Int32Array, StringArray};
+use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::execution::context::SessionContext;
+use datafusion::parquet::arrow::arrow_reader::{ArrowReaderMetadata, ArrowReaderOptions};
+use datafusion::parquet::arrow::ArrowWriter;
+use futures::StreamExt;
+use tempfile::NamedTempFile;
+
+use super::super::index::RowGroupDocsCollector;
+use super::super::page_pruner::PagePruner;
+use super::super::stream::{FilterStrategy, RowGroupInfo};
+use super::super::table_provider::{IndexedTableConfig, IndexedTableProvider, SegmentFileInfo};
+use super::super::eval::RowGroupBitsetSource;
+
+/// 16 rows, `price` = 15..0 **descending** in file order, 4 rows per row group →
+/// RG ranges (by row position) [15..12], [11..8], [7..4], [3..0]. The scan reads
+/// row groups in index order, so the *highest* prices arrive first. That is the
+/// "extreme values appear early" shape a DESC-TopK needs: after RG0 the heap
+/// threshold is high enough to prune the later, lower-valued row groups.
+///
+/// This mirrors a time-ordered OpenSearch index queried `ORDER BY ts DESC LIMIT
+/// k` where recent (high) values sit in the first row groups read.
+const ROWS: usize = 16;
+const RG_ROWS: usize = 4;
+
+fn write_fixture() -> (NamedTempFile, SchemaRef) {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("brand", DataType::Utf8, false),
+        Field::new("price", DataType::Int32, false),
+    ]));
+    let brands: Vec<String> = (0..ROWS).map(|i| format!("b{i}")).collect();
+    // Descending in file order: row 0 has the highest price (15), so RG0 holds
+    // the top values and a DESC TopK can prune later RGs.
+    let prices: Vec<i32> = (0..ROWS as i32).map(|i| ROWS as i32 - 1 - i).collect();
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(StringArray::from(brands)),
+            Arc::new(Int32Array::from(prices)),
+        ],
+    )
+    .unwrap();
+    let tmp = NamedTempFile::new().unwrap();
+    let props = datafusion::parquet::file::properties::WriterProperties::builder()
+        .set_max_row_group_size(RG_ROWS)
+        .set_statistics_enabled(datafusion::parquet::file::properties::EnabledStatistics::Page)
+        .build();
+    let mut w = ArrowWriter::try_new(tmp.reopen().unwrap(), schema.clone(), Some(props)).unwrap();
+    w.write(&batch).unwrap();
+    w.close().unwrap();
+    (tmp, schema)
+}
+
+/// Match-all collector: every doc in `[min_doc, max_doc)` is a candidate, so
+/// the only thing that can prune a row group is the dynamic filter.
+#[derive(Debug)]
+struct MatchAllCollector;
+
+impl RowGroupDocsCollector for MatchAllCollector {
+    fn collect_packed_u64_bitset(&self, min_doc: i32, max_doc: i32) -> Result<Vec<u64>, String> {
+        let span = (max_doc - min_doc).max(0) as usize;
+        let mut out = vec![0u64; span.div_ceil(64)];
+        for rel in 0..span {
+            out[rel / 64] |= 1u64 << (rel % 64);
+        }
+        Ok(out)
+    }
+}
+
+/// Build the indexed provider over the fixture and run `sql`. Returns the
+/// `(price)` rows in emission order plus the executed physical plan (for
+/// reading metrics).
+async fn run_indexed(
+    sql: &str,
+) -> (
+    Vec<i32>,
+    Arc<dyn datafusion::physical_plan::ExecutionPlan>,
+) {
+    let (tmp, schema) = write_fixture();
+    let path = tmp.path().to_path_buf();
+    let size = std::fs::metadata(&path).unwrap().len();
+    let file = std::fs::File::open(&path).unwrap();
+    let meta =
+        ArrowReaderMetadata::load(&file, ArrowReaderOptions::new().with_page_index(true)).unwrap();
+    let parquet_meta = meta.metadata().clone();
+
+    let mut rgs = Vec::new();
+    let mut offset = 0i64;
+    for i in 0..parquet_meta.num_row_groups() {
+        let n = parquet_meta.row_group(i).num_rows();
+        rgs.push(RowGroupInfo {
+            index: i,
+            first_row: offset,
+            num_rows: n,
+        });
+        offset += n;
+    }
+    assert!(
+        rgs.len() >= 4,
+        "fixture should have >=4 row groups, got {}",
+        rgs.len()
+    );
+
+    let object_path = object_store::path::Path::from(path.to_string_lossy().as_ref());
+    let segment = SegmentFileInfo {
+        writer_generation: 0,
+        max_doc: offset,
+        object_path,
+        parquet_size: size,
+        row_groups: rgs,
+        metadata: Arc::clone(&parquet_meta),
+        global_base: 0,
+    };
+
+    let factory: super::super::table_provider::EvaluatorFactory = {
+        let schema = schema.clone();
+        Arc::new(move |segment, _chunk, _stream_metrics| {
+            let pruner = Arc::new(PagePruner::new(&schema, Arc::clone(&segment.metadata)));
+            let collector: Arc<dyn RowGroupDocsCollector> = Arc::new(MatchAllCollector);
+            let eval: Arc<dyn RowGroupBitsetSource> = Arc::new(
+                crate::indexed_table::eval::single_collector::SingleCollectorEvaluator::new(
+                    Some(collector),
+                    pruner,
+                    None,
+                    None,
+                    None,
+                    None,
+                    crate::indexed_table::eval::single_collector::CollectorCallStrategy::FullRange,
+                    std::sync::Arc::new(std::collections::HashMap::new()),
+                    segment.writer_generation,
+                    std::sync::Arc::new(
+                        crate::indexed_table::eval::single_collector::FfmDelegatedBackendCollectorFactory,
+                    ),
+                    0,
+                    None,
+                ),
+            );
+            Ok(eval)
+        })
+    };
+
+    let store: Arc<dyn object_store::ObjectStore> =
+        Arc::new(object_store::local::LocalFileSystem::new());
+    let store_url = datafusion::execution::object_store::ObjectStoreUrl::local_filesystem();
+    // Row-granular so the parquet stream + dynamic filter behave like production;
+    // single partition so all RGs flow through one stream.
+    // One batch per row group (RG_ROWS): the stream flushes after each RG so
+    // SortExec can tighten the dynamic filter between row groups, instead of
+    // coalescing all rows into a single end-of-stream batch.
+    let qc = crate::datafusion_query_config::DatafusionQueryConfig::builder()
+        .target_partitions(1)
+        .batch_size(RG_ROWS)
+        .indexed_dynamic_filter_pushdown(true)
+        .build();
+    let provider = Arc::new(IndexedTableProvider::new(IndexedTableConfig {
+        schema: schema.clone(),
+        segments: vec![segment],
+        store,
+        store_url,
+        evaluator_factory: factory,
+        pushdown_predicate: None,
+        query_config: std::sync::Arc::new(qc),
+        predicate_columns: vec![],
+        emit_row_ids: false,
+    }));
+
+    let ctx = SessionContext::new();
+    ctx.register_table("t", provider).unwrap();
+    let df = ctx.sql(sql).await.unwrap();
+    let plan = df.create_physical_plan().await.unwrap();
+    let task_ctx = ctx.task_ctx();
+    let mut stream =
+        datafusion::physical_plan::execute_stream(Arc::clone(&plan), task_ctx).unwrap();
+    let mut prices: Vec<i32> = Vec::new();
+    while let Some(batch) = stream.next().await {
+        let b = batch.unwrap();
+        let price = b
+            .column(b.schema().index_of("price").unwrap())
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap();
+        for i in 0..b.num_rows() {
+            prices.push(price.value(i));
+        }
+    }
+    (prices, plan)
+}
+
+/// Recursively sum a named counter across the plan tree.
+fn sum_metric(plan: &Arc<dyn datafusion::physical_plan::ExecutionPlan>, name: &str) -> usize {
+    let mut total = 0usize;
+    if let Some(metrics) = plan.metrics() {
+        total += metrics.sum_by_name(name).map(|v| v.as_usize()).unwrap_or(0);
+    }
+    for child in plan.children() {
+        total += sum_metric(child, name);
+    }
+    total
+}
+
+fn rg_pruned_at_prefetch(plan: &Arc<dyn datafusion::physical_plan::ExecutionPlan>) -> usize {
+    sum_metric(plan, "dynamic_filter_rg_pruned_at_prefetch")
+}
+
+fn rg_pruned_at_poll(plan: &Arc<dyn datafusion::physical_plan::ExecutionPlan>) -> usize {
+    sum_metric(plan, "dynamic_filter_rg_pruned_at_poll")
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn topk_dynamic_filter_prunes_row_groups() {
+    // ORDER BY price DESC LIMIT 2 → top-2 prices are 15, 14 (both in the last RG
+    // [12..15]). As the TopK heap fills, the threshold rises and the earlier RGs
+    // ([0..3], [4..7], [8..11]) become prunable.
+    let (prices, plan) = run_indexed("SELECT brand, price FROM t ORDER BY price DESC LIMIT 2").await;
+
+    // (1) Correctness: exactly the global top-2 by price, in DESC order.
+    assert_eq!(prices, vec![15, 14], "top-2 DESC prices");
+
+    // (2) Both prune phases fire for this query. The prefetch runs ~1 RG ahead,
+    // so once RG0 fills the heap, the next RGs are pruned BEFORE their Lucene
+    // eval (prefetch phase); the final RG is caught at the poll phase after the
+    // filter tightens further. We assert each phase independently to prove both
+    // code paths are exercised.
+    let at_prefetch = rg_pruned_at_prefetch(&plan);
+    let at_poll = rg_pruned_at_poll(&plan);
+    assert!(
+        at_prefetch > 0,
+        "expected >=1 RG pruned at the PREFETCH phase (skipping the Lucene eval), \
+         at_prefetch={at_prefetch} at_poll={at_poll}"
+    );
+    assert!(
+        at_poll > 0,
+        "expected >=1 RG pruned at the POLL phase (backstop after further tightening), \
+         at_prefetch={at_prefetch} at_poll={at_poll}"
+    );
+    // Three of four RGs pruned (RG0 is processed to fill the heap).
+    assert_eq!(at_prefetch + at_poll, 3, "expected 3 of 4 RGs pruned");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn no_limit_means_no_dynamic_filter_pruning() {
+    // Without a fetch/limit there is no TopK and hence no dynamic filter, so
+    // nothing should be pruned and all 16 rows are returned.
+    let (prices, plan) = run_indexed("SELECT brand, price FROM t ORDER BY price DESC").await;
+    assert_eq!(prices.len(), ROWS, "full result set without LIMIT");
+    assert_eq!(prices.first().copied(), Some(15));
+    assert_eq!(rg_pruned_at_prefetch(&plan), 0, "no filter → no prefetch prune");
+    assert_eq!(rg_pruned_at_poll(&plan), 0, "no filter → no poll prune");
+}

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/mod.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/mod.rs
@@ -39,6 +39,7 @@ use super::table_provider::{IndexedTableConfig, IndexedTableProvider, SegmentFil
 
 mod boolean_algebra;
 mod constant_predicate;
+mod dynamic_filter_pushdown;
 mod fuzz;
 mod metrics;
 mod multi_segment;

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionSettings.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionSettings.java
@@ -74,6 +74,20 @@ public final class DatafusionSettings {
     );
 
     /**
+     * Whether the indexed scan accepts runtime dynamic filters (TopK / join)
+     * pushed down via physical filter pushdown and uses them to prune row groups
+     * whose parquet statistics cannot satisfy the tightening predicate. On by
+     * default; turn off to A/B the performance impact. When off, the scan
+     * declines the pushdown and behaves exactly as before this feature.
+     */
+    public static final Setting<Boolean> INDEXED_DYNAMIC_FILTER_PUSHDOWN = Setting.boolSetting(
+        "datafusion.indexed.dynamic_filter_pushdown",
+        true,
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
+    );
+
+    /**
      * Default minimum run length (in rows) below which the indexed stream skips
      * row-selection optimizations and falls back to sequential decode. Shorter runs
      * have higher per-row overhead from selection vector maintenance.
@@ -273,7 +287,8 @@ public final class DatafusionSettings {
         INDEXED_SINGLE_COLLECTOR_STRATEGY,
         INDEXED_TREE_COLLECTOR_STRATEGY,
         INDEXED_MAX_COLLECTOR_PARALLELISM,
-        INDEXED_QUERY_STRATEGY
+        INDEXED_QUERY_STRATEGY,
+        INDEXED_DYNAMIC_FILTER_PUSHDOWN
     );
 
     // ── Snapshot management ──
@@ -316,6 +331,7 @@ public final class DatafusionSettings {
             .treeCollectorStrategy(strategyToWireValue(INDEXED_TREE_COLLECTOR_STRATEGY.get(settings)))
             .maxCollectorParallelism(INDEXED_MAX_COLLECTOR_PARALLELISM.get(settings))
             .queryStrategy(queryStrategyToWireValue(INDEXED_QUERY_STRATEGY.get(settings)))
+            .indexedDynamicFilterPushdown(INDEXED_DYNAMIC_FILTER_PUSHDOWN.get(settings))
             .build();
 
         registerListeners(clusterSettings);
@@ -340,6 +356,7 @@ public final class DatafusionSettings {
             .treeCollectorStrategy(strategyToWireValue(INDEXED_TREE_COLLECTOR_STRATEGY.get(settings)))
             .maxCollectorParallelism(INDEXED_MAX_COLLECTOR_PARALLELISM.get(settings))
             .queryStrategy(queryStrategyToWireValue(INDEXED_QUERY_STRATEGY.get(settings)))
+            .indexedDynamicFilterPushdown(INDEXED_DYNAMIC_FILTER_PUSHDOWN.get(settings))
             .build();
     }
 
@@ -378,6 +395,10 @@ public final class DatafusionSettings {
 
         clusterSettings.addSettingsUpdateConsumer(INDEXED_QUERY_STRATEGY, newValue -> {
             snapshot = WireConfigSnapshot.builder(snapshot).queryStrategy(queryStrategyToWireValue(newValue)).build();
+        });
+
+        clusterSettings.addSettingsUpdateConsumer(INDEXED_DYNAMIC_FILTER_PUSHDOWN, newValue -> {
+            snapshot = WireConfigSnapshot.builder(snapshot).indexedDynamicFilterPushdown(newValue).build();
         });
 
         clusterSettings.addSettingsUpdateConsumer(SearchService.CONCURRENT_SEGMENT_SEARCH_TARGET_MAX_SLICE_COUNT_SETTING, newValue -> {

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/WireConfigSnapshot.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/WireConfigSnapshot.java
@@ -26,7 +26,7 @@ import java.lang.foreign.ValueLayout;
 public final class WireConfigSnapshot {
 
     /** Total byte size of the wire struct ({@code WireDatafusionQueryConfig}). */
-    public static final long BYTE_SIZE = 76;
+    public static final long BYTE_SIZE = 80;
 
     private final int batchSize;
     private final int targetPartitions;
@@ -38,6 +38,7 @@ public final class WireConfigSnapshot {
     private final int singleCollectorStrategy;
     private final int treeCollectorStrategy;
     private final int queryStrategy;
+    private final boolean indexedDynamicFilterPushdown;
 
     private WireConfigSnapshot(Builder builder) {
         this.batchSize = builder.batchSize;
@@ -50,6 +51,7 @@ public final class WireConfigSnapshot {
         this.singleCollectorStrategy = builder.singleCollectorStrategy;
         this.treeCollectorStrategy = builder.treeCollectorStrategy;
         this.queryStrategy = builder.queryStrategy;
+        this.indexedDynamicFilterPushdown = builder.indexedDynamicFilterPushdown;
     }
 
     public static Builder builder() {
@@ -70,7 +72,8 @@ public final class WireConfigSnapshot {
             .maxCollectorParallelism(current.maxCollectorParallelism)
             .singleCollectorStrategy(current.singleCollectorStrategy)
             .treeCollectorStrategy(current.treeCollectorStrategy)
-            .queryStrategy(current.queryStrategy);
+            .queryStrategy(current.queryStrategy)
+            .indexedDynamicFilterPushdown(current.indexedDynamicFilterPushdown);
     }
 
     public int batchSize() {
@@ -111,6 +114,10 @@ public final class WireConfigSnapshot {
 
     public int queryStrategy() {
         return queryStrategy;
+    }
+
+    public boolean indexedDynamicFilterPushdown() {
+        return indexedDynamicFilterPushdown;
     }
 
     /**
@@ -175,6 +182,8 @@ public final class WireConfigSnapshot {
         segment.set(ValueLayout.JAVA_INT, 68, queryStrategy);
         // Offset 72: bloom_filter_on_read (i32) — 0 = false, 1 = true
         segment.set(ValueLayout.JAVA_INT, 72, bloomFilterOnRead ? 1 : 0);
+        // Offset 76: indexed_dynamic_filter_pushdown (i32) — 0 = false, 1 = true
+        segment.set(ValueLayout.JAVA_INT, 76, indexedDynamicFilterPushdown ? 1 : 0);
     }
 
     /**
@@ -192,6 +201,7 @@ public final class WireConfigSnapshot {
         private int singleCollectorStrategy = 2; // PageRangeSplit
         private int treeCollectorStrategy = 1;   // TightenOuterBounds
         private int queryStrategy = 2;           // IndexedPredicateOnly (matches DatafusionSettings default "indexed")
+        private boolean indexedDynamicFilterPushdown = true; // runtime TopK/join RG pruning on by default
 
         private Builder() {}
 
@@ -242,6 +252,11 @@ public final class WireConfigSnapshot {
 
         public Builder queryStrategy(int queryStrategy) {
             this.queryStrategy = queryStrategy;
+            return this;
+        }
+
+        public Builder indexedDynamicFilterPushdown(boolean indexedDynamicFilterPushdown) {
+            this.indexedDynamicFilterPushdown = indexedDynamicFilterPushdown;
             return this;
         }
 

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionPluginSettingsTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionPluginSettingsTests.java
@@ -114,7 +114,7 @@ public class DataFusionPluginSettingsTests extends OpenSearchTestCase {
     public void testGetSettingsReturnsTotalExpectedCount() {
         try (DataFusionPlugin plugin = new DataFusionPlugin()) {
             List<Setting<?>> settings = plugin.getSettings();
-            assertEquals(27, settings.size());
+            assertEquals(28, settings.size());
         } catch (Exception e) {
             throw new AssertionError(e);
         }

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionSettingsTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionSettingsTests.java
@@ -69,7 +69,7 @@ public class DatafusionSettingsTests extends OpenSearchTestCase {
     }
 
     public void testAllSettingsContainsAllExpectedSettings() {
-        assertEquals(27, DatafusionSettings.ALL_SETTINGS.size());
+        assertEquals(28, DatafusionSettings.ALL_SETTINGS.size());
         assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DataFusionPlugin.DATAFUSION_REDUCE_TARGET_PARTITIONS));
         assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DataFusionPlugin.DATAFUSION_SPILL_DIRECTORY));
         assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DatafusionSettings.INDEXED_BATCH_SIZE));
@@ -81,6 +81,7 @@ public class DatafusionSettingsTests extends OpenSearchTestCase {
         assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DatafusionSettings.INDEXED_TREE_COLLECTOR_STRATEGY));
         assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DatafusionSettings.INDEXED_MAX_COLLECTOR_PARALLELISM));
         assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DatafusionSettings.INDEXED_QUERY_STRATEGY));
+        assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DatafusionSettings.INDEXED_DYNAMIC_FILTER_PUSHDOWN));
     }
 
     public void testDefaultSnapshotValuesMatchDefaults() {

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/WireConfigSnapshotTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/WireConfigSnapshotTests.java
@@ -17,7 +17,7 @@ import java.lang.foreign.ValueLayout;
 public class WireConfigSnapshotTests extends OpenSearchTestCase {
 
     public void testByteSize() {
-        assertEquals(76L, WireConfigSnapshot.BYTE_SIZE);
+        assertEquals(80L, WireConfigSnapshot.BYTE_SIZE);
     }
 
     public void testWriteToWritesCorrectValuesAtCorrectOffsets() {
@@ -31,6 +31,7 @@ public class WireConfigSnapshotTests extends OpenSearchTestCase {
             .singleCollectorStrategy(2)
             .treeCollectorStrategy(1)
             .queryStrategy(2)
+            .indexedDynamicFilterPushdown(true)
             .build();
 
         try (Arena arena = Arena.ofConfined()) {
@@ -46,6 +47,7 @@ public class WireConfigSnapshotTests extends OpenSearchTestCase {
             assertEquals(2, segment.get(ValueLayout.JAVA_INT, 60)); // single_collector_strategy
             assertEquals(1, segment.get(ValueLayout.JAVA_INT, 64)); // tree_collector_strategy
             assertEquals(2, segment.get(ValueLayout.JAVA_INT, 68)); // query_strategy = IndexedPredicateOnly
+            assertEquals(1, segment.get(ValueLayout.JAVA_INT, 76)); // indexed_dynamic_filter_pushdown = true
         }
     }
 
@@ -88,6 +90,7 @@ public class WireConfigSnapshotTests extends OpenSearchTestCase {
         assertEquals(2, snapshot.singleCollectorStrategy());  // page_range_split
         assertEquals(1, snapshot.treeCollectorStrategy());    // tighten_outer_bounds
         assertEquals(2, snapshot.queryStrategy());            // IndexedPredicateOnly
+        assertEquals(true, snapshot.indexedDynamicFilterPushdown()); // on by default
     }
 
     public void testBuilderCopyPreservesAllFields() {
@@ -102,6 +105,7 @@ public class WireConfigSnapshotTests extends OpenSearchTestCase {
             .singleCollectorStrategy(0)
             .treeCollectorStrategy(2)
             .queryStrategy(1)
+            .indexedDynamicFilterPushdown(false)
             .build();
 
         WireConfigSnapshot copy = WireConfigSnapshot.builder(original).build();
@@ -116,5 +120,6 @@ public class WireConfigSnapshotTests extends OpenSearchTestCase {
         assertEquals(original.singleCollectorStrategy(), copy.singleCollectorStrategy());
         assertEquals(original.treeCollectorStrategy(), copy.treeCollectorStrategy());
         assertEquals(original.queryStrategy(), copy.queryStrategy());
+        assertEquals(original.indexedDynamicFilterPushdown(), copy.indexedDynamicFilterPushdown());
     }
 }


### PR DESCRIPTION
## Summary

Adds **runtime dynamic-filter pushdown** to the indexed-parquet scan in `analytics-backend-datafusion`.

### What dynamic filters do

When a query has an ordering + LIMIT (e.g. `ORDER BY ts DESC LIMIT N`), DataFusion's `SortExec`-TopK pushes a `DynamicFilterPhysicalExpr` down into `QueryShardExec`. The filter starts as the trivial `true` placeholder and is **tightened at runtime** as the TopK heap fills (e.g. `ts > <current heap-min>`). Per row group, the scan checks the parquet statistics against the latest snapshot of that filter and skips the entire row group if it can prove no row in it can reach the top-k. The filter only references the SORT columns, so RG min/max stats span a strict superset of WHERE-passing candidates — pruning is **conservative** (we may miss a skip, never drop a qualifying row).

### What this PR adds

- `dynamic_filter.rs` — `DynamicRgPruner` that watches the dynamic filter's snapshot generation, builds a `PruningPredicate` from the latest snapshot, and decides per-RG whether stats prove the RG cannot satisfy the predicate.
- `dynamic_filter_probe.rs` — Helper that probes whether the planner-pushed filter is in fact a `DynamicFilterPhysicalExpr` and extracts it for the pruner.
- Wires the pruner into `indexed_table/stream.rs` at two points: (a) at prefetch-time when scheduling a row group, and (b) as a poll-phase backstop just before parquet decode (since the filter may have tightened further during the ~1-RG prefetch lead).
- New metric `dynamic_filter_rg_pruned_at_poll` to count pruned RGs at the poll-phase backstop.
- New `IndexedTableProvider` integration to accept the pushed filter via DataFusion's physical filter-pushdown API.
- New cluster setting `datafusion.indexed.dynamic_filter_pushdown` (default `true`, `NodeScope` + `Dynamic`) — turn off to A/B the perf impact; when off, the scan declines the pushdown and behaves exactly as before.
- Threads the new flag through `DatafusionSettings` and `WireConfigSnapshot` to the Rust side.
- End-to-end Rust tests in `tests_e2e/dynamic_filter_pushdown.rs`.

Cherry-picked from https://github.com/bharath-techie/OpenSearch/tree/dynamic-filter (commit `5261e102f3a`); also bumps the asserted setting count in `DataFusionPluginSettingsTests.testGetSettingsReturnsTotalExpectedCount` from 27 → 28 to reflect the new setting.

## Test plan

- [x] `cargo build --release` for the workspace under `sandbox/libs/dataformat-native/rust`
- [x] `./gradlew :sandbox:plugins:analytics-backend-datafusion:test --tests DataFusionPluginSettingsTests` (BUILD SUCCESSFUL locally)
- [ ] Full `gradle-check` / `sandbox-check` on CI
- [ ] Rust e2e tests in `tests_e2e/dynamic_filter_pushdown.rs`

Co-authored-by: bharath-techie <bharath78910@gmail.com>