### PR TITLE
Reverse indexed-parquet segment iteration for opposite-direction sorts

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/api.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/api.rs
@@ -346,9 +346,14 @@ pub struct ShardView {
     /// Index sort fields, in priority order. Sourced from the index's
     /// `index.sort.field` setting on the Java side. Empty when the index has
     /// no `index.sort.field` configured. Parallel to `sort_orders`.
-    /// Used to build `ListingOptions.with_file_sort_order(...)` so DataFusion
-    /// advertises `output_ordering` from the scan and enables the
-    /// `sort_prefix` optimization on TopK / SortPreservingMerge.
+    ///
+    /// Two consumers today:
+    ///   - Vanilla path: `ListingOptions.with_file_sort_order(...)` so DataFusion advertises
+    ///     `output_ordering` from the scan and the `sort_prefix` optimization fires on
+    ///     TopK / SortPreservingMerge.
+    ///   - Indexed path (`indexed_executor`): when the query's leading ORDER BY runs counter
+    ///     to catalog-snapshot order, the per-shard segment iteration is reversed so a TopK
+    ///     above us can prune via parquet page statistics.
     pub sort_fields: Vec<String>,
     /// Index sort directions per field — values: `"asc"` or `"desc"`.
     /// Parallel to `sort_fields`. Sourced from `index.sort.order`.

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_executor.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_executor.rs
@@ -201,6 +201,101 @@ pub async fn execute_indexed_query(
 
 // ── Helpers ───────────────────────────────────────────────────────────
 
+/// Result of walking a logical plan looking for the leading top-of-plan ORDER BY.
+///
+/// `column` is the bare column name (no qualifier — we compare against `index.sort.field`
+/// which is also unqualified). `descending` is `true` for `ORDER BY x DESC`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TopSort {
+    pub column: String,
+    pub descending: bool,
+}
+
+/// Walk through the top of a logical plan to find the leading sort expression.
+///
+/// Descends through `Projection`, `Limit`, `SubqueryAlias`, `Distinct`, and `Filter` —
+/// nodes that don't reorder rows or rewrite sort key columns. On reaching
+/// `LogicalPlan::Sort`, returns the leading sort key's bare column name and direction.
+/// Returns `None` if the plan has no top-level Sort, or if the first Sort key is not
+/// a plain `Expr::Column` (e.g. `ORDER BY lower(x)` — we can't claim catalog monotonicity
+/// after a function).
+pub(crate) fn analyze_top_sort(plan: &datafusion::logical_expr::LogicalPlan) -> Option<TopSort> {
+    use datafusion::logical_expr::{Expr, LogicalPlan};
+    let mut current = plan;
+    loop {
+        match current {
+            LogicalPlan::Sort(s) => {
+                let leading = s.expr.first()?;
+                let col = match &leading.expr {
+                    Expr::Column(c) => c.name.clone(),
+                    _ => return None,
+                };
+                return Some(TopSort {
+                    column: col,
+                    descending: !leading.asc,
+                });
+            }
+            LogicalPlan::Projection(p) => current = p.input.as_ref(),
+            LogicalPlan::Limit(l) => current = l.input.as_ref(),
+            LogicalPlan::SubqueryAlias(a) => current = a.input.as_ref(),
+            LogicalPlan::Distinct(d) => match d {
+                datafusion::logical_expr::Distinct::All(input) => current = input.as_ref(),
+                datafusion::logical_expr::Distinct::On(on) => current = on.input.as_ref(),
+            },
+            LogicalPlan::Filter(f) => current = f.input.as_ref(),
+            _ => return None,
+        }
+    }
+}
+
+/// Decide whether to flip segment iteration order for the indexed scan.
+///
+/// Returns `true` iff the catalog has a sort declaration, the query has a top-level
+/// ORDER BY whose leading key matches the catalog's leading sort field by name, and
+/// the query's direction is the **opposite** of the catalog's. In that case the
+/// segments — laid down newest-last by the writer — are in reverse order from what
+/// the query wants, so iterating them tail-first feeds the largest values to a
+/// `TopK` first and parquet page stats prune the rest.
+///
+/// All comparisons are case-sensitive on the field name (matching PR #22041's
+/// `Column::from_name`). Direction comparison is case-insensitive on `"asc"`/`"desc"`.
+pub(crate) fn should_reverse_segments(
+    top_sort: Option<&TopSort>,
+    sort_fields: &[String],
+    sort_orders: &[String],
+) -> bool {
+    let Some(top) = top_sort else { return false };
+    let Some(catalog_field) = sort_fields.first() else { return false };
+    let Some(catalog_order) = sort_orders.first() else { return false };
+    if top.column != *catalog_field {
+        return false;
+    }
+    let catalog_descending = catalog_order.eq_ignore_ascii_case("desc");
+    top.descending != catalog_descending
+}
+
+/// Reverse the iteration order of `segments` in place. Per-segment `global_base`
+/// values are deliberately **left untouched** so each segment keeps its
+/// catalog-order shard-global row ID space.
+///
+/// Why not recompute global_base after reversing?
+///
+/// `global_base` is the additive offset used to compute the QTF `__row_id__`:
+/// `id = segment.global_base + position`. The fetch phase (`api::fetch_by_row_ids`)
+/// rebuilds segments via `build_segments` against `ShardView.object_metas` (always
+/// in catalog order) and reverses the mapping back via `partition_point` on
+/// `global_base`. For the round trip to hold, both phases must agree on each
+/// segment's `global_base` — and the only way to guarantee that without changing
+/// the fetch path is to keep query-phase `global_base` at its catalog-order value.
+///
+/// Reversing only the iteration order — i.e. the order in which chunks/RGs are
+/// scheduled by `compute_assignments` — is the *whole* point of this optimization
+/// (newest-segment-first feeds TopK earlier and lets page stats prune older
+/// segments). The `global_base` values are unrelated to that pruning win.
+pub(crate) fn reverse_segment_iteration_order(segments: &mut [SegmentFileInfo]) {
+    segments.reverse();
+}
+
 /// Collect all `Predicate(expr)` leaves in DFS order. Used by the
 /// dispatcher to build a per-leaf `PruningPredicate` cache keyed by
 /// `Arc::as_ptr` identity.
@@ -421,6 +516,193 @@ mod tests {
         ]);
         assert!(extract_single_collector_residual(&tree).is_none());
     }
+
+    // ── analyze_top_sort / should_reverse_segments ────────────────────
+
+    fn build_logical_plan(sql: &str) -> datafusion::logical_expr::LogicalPlan {
+        use datafusion::execution::SessionStateBuilder;
+        use datafusion::execution::context::SessionContext;
+        let state = SessionStateBuilder::new().with_default_features().build();
+        let ctx = SessionContext::new_with_state(state);
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("ts", DataType::Int64, false),
+            Field::new("v", DataType::Int32, false),
+        ]));
+        ctx.register_batch(
+            "t",
+            datafusion::arrow::record_batch::RecordBatch::new_empty(schema),
+        )
+        .expect("register_batch");
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let df = rt.block_on(ctx.sql(sql)).expect("sql");
+        df.into_unoptimized_plan()
+    }
+
+    #[test]
+    fn analyze_top_sort_finds_leading_desc() {
+        let plan = build_logical_plan("SELECT id FROM t ORDER BY id DESC");
+        let ts = analyze_top_sort(&plan).expect("expected Sort");
+        assert_eq!(ts.column, "id");
+        assert!(ts.descending);
+    }
+
+    #[test]
+    fn analyze_top_sort_descends_through_limit() {
+        let plan = build_logical_plan("SELECT id FROM t ORDER BY id ASC LIMIT 10");
+        let ts = analyze_top_sort(&plan).expect("expected Sort");
+        assert_eq!(ts.column, "id");
+        assert!(!ts.descending);
+    }
+
+    #[test]
+    fn analyze_top_sort_descends_through_projection() {
+        let plan = build_logical_plan("SELECT v FROM t ORDER BY ts DESC");
+        let ts = analyze_top_sort(&plan).expect("expected Sort");
+        assert_eq!(ts.column, "ts");
+        assert!(ts.descending);
+    }
+
+    #[test]
+    fn analyze_top_sort_returns_none_when_no_sort() {
+        let plan = build_logical_plan("SELECT id FROM t");
+        assert!(analyze_top_sort(&plan).is_none());
+    }
+
+    #[test]
+    fn analyze_top_sort_returns_none_for_function_sort_key() {
+        // `ORDER BY abs(v)` — leading sort key isn't a plain column. Catalog monotonicity
+        // doesn't transfer through a function, so we conservatively decline to reverse.
+        let plan = build_logical_plan("SELECT id FROM t ORDER BY abs(v)");
+        assert!(analyze_top_sort(&plan).is_none());
+    }
+
+    #[test]
+    fn should_reverse_segments_matches_leading_field_opposite_direction() {
+        let top = TopSort { column: "id".to_string(), descending: true };
+        let fields = vec!["id".to_string()];
+        let orders = vec!["asc".to_string()];
+        assert!(should_reverse_segments(Some(&top), &fields, &orders));
+    }
+
+    #[test]
+    fn should_reverse_segments_matches_leading_field_same_direction() {
+        let top = TopSort { column: "id".to_string(), descending: false };
+        let fields = vec!["id".to_string()];
+        let orders = vec!["asc".to_string()];
+        assert!(!should_reverse_segments(Some(&top), &fields, &orders));
+    }
+
+    #[test]
+    fn should_reverse_segments_catalog_desc_query_asc() {
+        let top = TopSort { column: "id".to_string(), descending: false };
+        let fields = vec!["id".to_string()];
+        let orders = vec!["desc".to_string()];
+        assert!(should_reverse_segments(Some(&top), &fields, &orders));
+    }
+
+    #[test]
+    fn should_reverse_segments_no_query_sort() {
+        let fields = vec!["id".to_string()];
+        let orders = vec!["asc".to_string()];
+        assert!(!should_reverse_segments(None, &fields, &orders));
+    }
+
+    #[test]
+    fn should_reverse_segments_no_catalog_sort() {
+        let top = TopSort { column: "id".to_string(), descending: true };
+        assert!(!should_reverse_segments(Some(&top), &[], &[]));
+    }
+
+    #[test]
+    fn should_reverse_segments_query_sort_on_non_leading_catalog_field() {
+        // Catalog: [a ASC, b ASC]; query: ORDER BY b DESC. Segments are monotonic on `a`
+        // (the leading key), not `b`. Reversing won't help — decline.
+        let top = TopSort { column: "b".to_string(), descending: true };
+        let fields = vec!["a".to_string(), "b".to_string()];
+        let orders = vec!["asc".to_string(), "asc".to_string()];
+        assert!(!should_reverse_segments(Some(&top), &fields, &orders));
+    }
+
+    #[test]
+    fn should_reverse_segments_field_name_case_sensitive() {
+        // Match PR #22041 — `Column::from_name` is case-sensitive. If casing differs,
+        // we don't claim the catalog ordering applies. Safe default: no reversal.
+        let top = TopSort { column: "ID".to_string(), descending: true };
+        let fields = vec!["id".to_string()];
+        let orders = vec!["asc".to_string()];
+        assert!(!should_reverse_segments(Some(&top), &fields, &orders));
+    }
+
+    // ── reverse_segment_iteration_order ───────────────────────────────
+
+    fn dummy_segment(max_doc: i64, global_base: u64) -> SegmentFileInfo {
+        use datafusion::parquet::file::metadata::{FileMetaData, ParquetMetaData};
+        // Build a minimal ParquetMetaData. We never read it back in these tests.
+        let schema = std::sync::Arc::new(
+            datafusion::parquet::schema::types::SchemaDescriptor::new(
+                std::sync::Arc::new(
+                    datafusion::parquet::schema::types::Type::group_type_builder("schema")
+                        .build()
+                        .unwrap(),
+                ),
+            ),
+        );
+        let file_meta = FileMetaData::new(0, 0, None, None, schema, None);
+        let pq_meta = ParquetMetaData::new(file_meta, vec![]);
+        SegmentFileInfo {
+            writer_generation: global_base as i64 + 1, // arbitrary, just to vary
+            max_doc,
+            object_path: object_store::path::Path::from(format!("seg-{}.parquet", global_base)),
+            parquet_size: 0,
+            row_groups: vec![],
+            metadata: std::sync::Arc::new(pq_meta),
+            global_base,
+            sort_min: None,
+            sort_max: None,
+        }
+    }
+
+    #[test]
+    fn reverse_segments_preserves_global_base() {
+        // Original: A(max_doc=10, base=0), B(max_doc=20, base=10), C(max_doc=30, base=30).
+        // Reversal must keep each segment's original `global_base` intact so QTF row IDs
+        // emitted in query phase remain interpretable by the fetch phase (which always
+        // computes catalog-order bases).
+        let mut segs = vec![
+            dummy_segment(10, 0),
+            dummy_segment(20, 10),
+            dummy_segment(30, 30),
+        ];
+        reverse_segment_iteration_order(&mut segs);
+        assert_eq!(segs.len(), 3);
+        // New iteration order: C, B, A.
+        assert_eq!(segs[0].max_doc, 30);
+        assert_eq!(segs[0].global_base, 30); // C's catalog base, unchanged.
+        assert_eq!(segs[1].max_doc, 20);
+        assert_eq!(segs[1].global_base, 10); // B's catalog base, unchanged.
+        assert_eq!(segs[2].max_doc, 10);
+        assert_eq!(segs[2].global_base, 0);  // A's catalog base, unchanged.
+    }
+
+    #[test]
+    fn reverse_segments_empty_is_noop() {
+        let mut segs: Vec<SegmentFileInfo> = vec![];
+        reverse_segment_iteration_order(&mut segs);
+        assert!(segs.is_empty());
+    }
+
+    #[test]
+    fn reverse_segments_single_keeps_its_base() {
+        let mut segs = vec![dummy_segment(42, 7)];
+        reverse_segment_iteration_order(&mut segs);
+        assert_eq!(segs.len(), 1);
+        assert_eq!(segs[0].global_base, 7);
+        assert_eq!(segs[0].max_doc, 42);
+    }
 }
 
 /// Instruction-based indexed execution path. Consumes a pre-configured SessionContextHandle
@@ -552,6 +834,25 @@ async unsafe fn execute_indexed_with_context_inner(
     let plan = Plan::decode(substrait_bytes.as_slice())
         .map_err(|e| DataFusionError::Execution(format!("decode substrait: {}", e)))?;
     let logical_plan = from_substrait_plan(&ctx.state(), &plan).await?;
+
+    // Sort-aware segment iteration. Mirror of `ContextIndexSearcher.shouldUseTimeSeriesDescSortOptimization`
+    // for the indexed-parquet path. When the index has `index.sort.field` and the query's leading
+    // ORDER BY runs counter to the catalog's stored direction, reverse the segment vector so a
+    // TopK above us pulls the highest-priority segment first and parquet page stats prune the rest.
+    //
+    // QTF safe: `reverse_segment_iteration_order` deliberately does NOT recompute `global_base`
+    // — each segment retains its catalog-order base, so the row IDs query phase emits are still
+    // interpretable by `api::fetch_by_row_ids` (which builds its own segments from
+    // `ShardView.object_metas` in catalog order).
+    let mut segments = segments;
+    if should_reverse_segments(analyze_top_sort(&logical_plan).as_ref(), &sort_fields, &sort_orders) {
+        log_debug!(
+            "indexed_executor: reversing segment iteration (catalog leading sort={:?} {:?}, query opposite)",
+            sort_fields.first(),
+            sort_orders.first()
+        );
+        reverse_segment_iteration_order(&mut segments);
+    }
 
     let emit_row_ids = requests_row_ids;
     let filter_expr = extract_filter_expr(&logical_plan);

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/mod.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/mod.rs
@@ -49,6 +49,7 @@ mod qtf_fetch_phase;
 mod row_id_emission;
 mod row_id_strategies;
 mod schema_drift;
+mod sort_reverse_row_id;
 mod streaming_at_scale;
 
 // ── Test fixture: parquet table with 16 rows ────────────────────────

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/sort_reverse_row_id.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/sort_reverse_row_id.rs
@@ -1,0 +1,310 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+//! Row-id stability under sort-aware segment reversal.
+//!
+//! Pins the contract that lets QTF compose with the reversal optimization:
+//! reversing the iteration order of `Vec<SegmentFileInfo>` must NOT change which
+//! `__row_id__` values get emitted for the same matching rows. The only thing
+//! that changes is the order in which segments are processed (which the TopK
+//! above us re-sorts anyway).
+//!
+//! Why this matters: `api::fetch_by_row_ids` rebuilds segments via
+//! `build_segments(ShardView.object_metas, ShardView.writer_generations)` —
+//! always in catalog order, never reversed. For QTF query→fetch round-trip to
+//! resolve to the right rows, the IDs query phase emits must agree with the
+//! catalog-order `global_base` mapping fetch will compute. That holds only if
+//! `reverse_segment_iteration_order` preserves each segment's original
+//! `global_base`, which is exactly what these tests verify end-to-end.
+
+use std::sync::Arc;
+
+use datafusion::arrow::array::{Int32Array, Int64Array, StringArray};
+use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::execution::context::SessionContext;
+use datafusion::parquet::arrow::arrow_reader::{ArrowReaderMetadata, ArrowReaderOptions};
+use datafusion::parquet::arrow::ArrowWriter;
+use futures::StreamExt;
+use tempfile::NamedTempFile;
+
+use crate::indexed_executor::reverse_segment_iteration_order;
+use crate::indexed_table::bool_tree::BoolNode;
+use crate::indexed_table::eval::bitmap_tree::BitmapTreeEvaluator;
+use crate::indexed_table::eval::{RowGroupBitsetSource, TreeBitsetSource};
+use crate::indexed_table::index::RowGroupDocsCollector;
+use crate::indexed_table::page_pruner::PagePruner;
+use crate::indexed_table::stream::{FilterStrategy, RowGroupInfo};
+use crate::indexed_table::table_provider::{
+    IndexedTableConfig, IndexedTableProvider, SegmentFileInfo,
+};
+
+/// One segment's worth of synthetic rows. `tag` distinguishes segments at the
+/// data layer; `match_local_offsets` are segment-local doc IDs that the mock
+/// collector will return as matches.
+struct SegSpec {
+    tag: &'static str,
+    rows: usize,
+    match_local_offsets: Vec<i32>,
+}
+
+/// Per the writer-side invariant, every parquet segment carries the `__row_id__`
+/// column. The indexed scan path strips it from the read projection when
+/// `emit_row_ids: true` and recomputes shard-global IDs from per-segment position
+/// (`global_base + rg.first_row + position_in_rg`). This test mirrors the
+/// production fixture: the column exists and the indexed path replaces it.
+fn segment_schema() -> SchemaRef {
+    Arc::new(Schema::new(vec![
+        Field::new("tag", DataType::Utf8, false),
+        Field::new("v", DataType::Int32, false),
+        Field::new(crate::ROW_ID_COLUMN_NAME, DataType::Int64, false),
+    ]))
+}
+
+fn write_segment(spec: &SegSpec) -> NamedTempFile {
+    let schema = segment_schema();
+    let tags: Vec<&str> = (0..spec.rows).map(|_| spec.tag).collect();
+    let vs: Vec<i32> = (0..spec.rows as i32).collect();
+    // Segment-local IDs (0..rows) — production writer also stamps these
+    // monotonically per segment. The indexed path doesn't read them; it
+    // recomputes IDs from position. They're written so the column is valid.
+    let row_ids: Vec<i64> = (0..spec.rows as i64).collect();
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(StringArray::from(tags)),
+            Arc::new(Int32Array::from(vs)),
+            Arc::new(Int64Array::from(row_ids)),
+        ],
+    )
+    .unwrap();
+    let tmp = NamedTempFile::new().unwrap();
+    let props = datafusion::parquet::file::properties::WriterProperties::builder()
+        .set_max_row_group_size(4)
+        .set_statistics_enabled(datafusion::parquet::file::properties::EnabledStatistics::Page)
+        .build();
+    let mut w = ArrowWriter::try_new(tmp.reopen().unwrap(), schema, Some(props)).unwrap();
+    w.write(&batch).unwrap();
+    w.close().unwrap();
+    tmp
+}
+
+/// Mock collector that returns the configured local doc offsets that fall in `[min_doc, max_doc)`.
+#[derive(Debug)]
+struct LocalOffsetCollector {
+    matching: Vec<i32>,
+}
+
+impl RowGroupDocsCollector for LocalOffsetCollector {
+    fn collect_packed_u64_bitset(&self, min_doc: i32, max_doc: i32) -> Result<Vec<u64>, String> {
+        let span = (max_doc - min_doc) as usize;
+        let mut out = vec![0u64; span.div_ceil(64)];
+        for &doc in &self.matching {
+            if doc >= min_doc && doc < max_doc {
+                let rel = (doc - min_doc) as usize;
+                out[rel / 64] |= 1u64 << (rel % 64);
+            }
+        }
+        Ok(out)
+    }
+}
+
+/// Build a `Vec<SegmentFileInfo>` for the given specs, including catalog-order
+/// `global_base` so `__row_id__ = global_base + local_pos` resolves to a unique
+/// shard-global value per matching row.
+fn build_segments(
+    tmps: &[NamedTempFile],
+    specs: &[SegSpec],
+) -> (Vec<SegmentFileInfo>, SchemaRef) {
+    let mut segs = Vec::new();
+    let mut schema_opt: Option<SchemaRef> = None;
+    let mut cumulative: u64 = 0;
+    for (i, tmp) in tmps.iter().enumerate() {
+        let path = tmp.path().to_path_buf();
+        let size = std::fs::metadata(&path).unwrap().len();
+        let file = std::fs::File::open(&path).unwrap();
+        let meta = ArrowReaderMetadata::load(&file, ArrowReaderOptions::new().with_page_index(true))
+            .unwrap();
+        if schema_opt.is_none() {
+            schema_opt = Some(meta.schema().clone());
+        }
+        let parquet_meta = meta.metadata().clone();
+        let mut rgs = Vec::new();
+        let mut offset = 0i64;
+        for j in 0..parquet_meta.num_row_groups() {
+            let n = parquet_meta.row_group(j).num_rows();
+            rgs.push(RowGroupInfo {
+                index: j,
+                first_row: offset,
+                num_rows: n,
+            });
+            offset += n;
+        }
+        let max_doc = offset;
+        let object_path = object_store::path::Path::from(path.to_string_lossy().as_ref());
+        segs.push(SegmentFileInfo {
+            writer_generation: i as i64,
+            max_doc,
+            object_path,
+            parquet_size: size,
+            row_groups: rgs,
+            metadata: Arc::clone(&parquet_meta),
+            global_base: cumulative,
+            sort_min: None,
+            sort_max: None,
+        });
+        cumulative += specs[i].rows as u64;
+    }
+    (segs, schema_opt.unwrap())
+}
+
+/// Collect emitted `__row_id__` values for the given segment vec.
+async fn collect_row_ids(
+    segments: Vec<SegmentFileInfo>,
+    schema: SchemaRef,
+    specs: &[SegSpec],
+) -> Vec<i64> {
+    // One collector per segment, keyed by writer_generation == segment ord at build time.
+    // EvaluatorFactory selects the matching set for the segment it's asked about — so
+    // this works whether segments are in natural order or reversed (it identifies the
+    // segment by its writer_generation, which moves with the segment).
+    let per_gen: Vec<Vec<i32>> = specs.iter().map(|s| s.match_local_offsets.clone()).collect();
+    let per_gen = Arc::new(per_gen);
+
+    let factory: super::super::table_provider::EvaluatorFactory = {
+        let per_gen = Arc::clone(&per_gen);
+        let schema = schema.clone();
+        Arc::new(move |segment, _chunk, _stream_metrics, _stats_prune_tree| {
+            let matching = per_gen
+                .get(segment.writer_generation as usize)
+                .cloned()
+                .unwrap_or_default();
+            let collector: Arc<dyn RowGroupDocsCollector> = Arc::new(LocalOffsetCollector { matching });
+            let pruner = Arc::new(PagePruner::new(&schema, Arc::clone(&segment.metadata)));
+            // Single-collector tree.
+            let tree = BoolNode::Collector { annotation_id: 0 };
+            let tree = tree.push_not_down();
+            let resolved = tree.resolve(&[(0, collector)])?;
+            let eval: Arc<dyn RowGroupBitsetSource> = Arc::new(TreeBitsetSource {
+                tree: Arc::new(resolved),
+                evaluator: Arc::new(BitmapTreeEvaluator),
+                leaves: Arc::new(crate::indexed_table::eval::bitmap_tree::CollectorLeafBitmaps {
+                    ffm_collector_calls: _stream_metrics.ffm_collector_calls.clone(),
+                }),
+                page_pruner: pruner,
+                cost_predicate: 1,
+                cost_collector: 10,
+                max_collector_parallelism: 1,
+                pruning_predicates: Arc::new(std::collections::HashMap::new()),
+                page_prune_metrics: Some(
+                    crate::indexed_table::page_pruner::PagePruneMetrics::from_stream_metrics(
+                        _stream_metrics,
+                    ),
+                ),
+                collector_strategy: crate::indexed_table::eval::CollectorCallStrategy::TightenOuterBounds,
+                stats_prune_tree: None,
+            });
+            Ok(eval)
+        })
+    };
+
+    let store: Arc<dyn object_store::ObjectStore> =
+        Arc::new(object_store::local::LocalFileSystem::new());
+    let store_url = datafusion::execution::object_store::ObjectStoreUrl::local_filesystem();
+    let qc = crate::datafusion_query_config::DatafusionQueryConfig::builder()
+        .target_partitions(1)
+        .force_strategy(Some(FilterStrategy::BooleanMask))
+        .force_pushdown(Some(false))
+        .build();
+    let provider = Arc::new(IndexedTableProvider::new(IndexedTableConfig {
+        schema: schema.clone(),
+        segments,
+        store,
+        store_url,
+        evaluator_factory: factory,
+        pushdown_predicate: None,
+        query_config: Arc::new(qc),
+        predicate_columns: vec![],
+        emit_row_ids: true,
+        prune_tree_config: None,
+        sort_fields: vec![],
+        sort_orders: vec![],
+    }));
+
+    let ctx = SessionContext::new();
+    ctx.register_table("t", provider).unwrap();
+    let df = ctx.sql("SELECT \"__row_id__\" FROM t").await.unwrap();
+    let plan = df.create_physical_plan().await.unwrap();
+    let mut stream = datafusion::physical_plan::execute_stream(plan, ctx.task_ctx()).unwrap();
+    let mut ids: Vec<i64> = Vec::new();
+    while let Some(batch) = stream.next().await {
+        let b = batch.unwrap();
+        let col = b.column(0).as_any().downcast_ref::<Int64Array>().unwrap();
+        for i in 0..b.num_rows() {
+            ids.push(col.value(i));
+        }
+    }
+    ids
+}
+
+/// 3 segments × varying match offsets. Run with natural iteration order, then reversed.
+/// The set of emitted `__row_id__` values must be identical — the only thing reversal
+/// changes is the order in which segments are scanned (which the test ignores by
+/// comparing sorted sets).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn three_segments_row_ids_invariant_under_reversal() {
+    let specs = vec![
+        SegSpec { tag: "A", rows: 8, match_local_offsets: vec![0, 3, 7] },   // global ids 0, 3, 7
+        SegSpec { tag: "B", rows: 6, match_local_offsets: vec![1, 4] },      // global ids 9, 12
+        SegSpec { tag: "C", rows: 10, match_local_offsets: vec![0, 5, 9] },  // global ids 14, 19, 23
+    ];
+    let tmps: Vec<NamedTempFile> = specs.iter().map(write_segment).collect();
+    let (segs_natural, schema) = build_segments(&tmps, &specs);
+
+    // Natural order.
+    let mut ids_natural = collect_row_ids(segs_natural.clone(), schema.clone(), &specs).await;
+    ids_natural.sort();
+
+    // Reversed iteration order (the optimization's effect). Per-segment global_base
+    // is preserved by `reverse_segment_iteration_order` — the central invariant.
+    let mut segs_reversed = segs_natural;
+    reverse_segment_iteration_order(&mut segs_reversed);
+    let mut ids_reversed = collect_row_ids(segs_reversed, schema, &specs).await;
+    ids_reversed.sort();
+
+    let expected = vec![0i64, 3, 7, 9, 12, 14, 19, 23];
+    assert_eq!(ids_natural, expected, "natural-order ids");
+    assert_eq!(ids_reversed, expected, "reversed-order ids — same shard-global IDs as natural");
+}
+
+/// 4 segments. Confirms the property holds at the larger end of the test contract
+/// (the IT runs with 2-4 segments per shard depending on doc routing) and that
+/// `global_base` cumulation matches catalog order on every segment.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn four_segments_row_ids_invariant_under_reversal() {
+    let specs = vec![
+        SegSpec { tag: "A", rows: 5, match_local_offsets: vec![0, 4] },     // 0, 4
+        SegSpec { tag: "B", rows: 5, match_local_offsets: vec![2] },        // 7
+        SegSpec { tag: "C", rows: 5, match_local_offsets: vec![1, 3] },     // 11, 13
+        SegSpec { tag: "D", rows: 5, match_local_offsets: vec![0, 2, 4] },  // 15, 17, 19
+    ];
+    let tmps: Vec<NamedTempFile> = specs.iter().map(write_segment).collect();
+    let (segs_natural, schema) = build_segments(&tmps, &specs);
+
+    let mut ids_natural = collect_row_ids(segs_natural.clone(), schema.clone(), &specs).await;
+    ids_natural.sort();
+
+    let mut segs_reversed = segs_natural;
+    reverse_segment_iteration_order(&mut segs_reversed);
+    let mut ids_reversed = collect_row_ids(segs_reversed, schema, &specs).await;
+    ids_reversed.sort();
+
+    let expected = vec![0i64, 4, 7, 11, 13, 15, 17, 19];
+    assert_eq!(ids_natural, expected);
+    assert_eq!(ids_reversed, expected);
+}

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/session_context.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/session_context.rs
@@ -43,8 +43,9 @@ pub struct SessionContextHandle {
     /// `SegmentFileInfo.writer_generation`; footer-kv reads are debug-only assertions.
     pub writer_generations: Arc<Vec<i64>>,
     /// `index.sort.field` plumbed from the Java side (`ShardView.sort_fields`).
-    /// Empty when the index has no `index.sort.field`. Used by
-    /// `IndexedTableProvider` to decide whether to advertise `output_ordering`.
+    /// Empty when the index has no `index.sort.field`. Consumed by the vanilla path
+    /// (`IndexedTableProvider` `output_ordering`) and by the indexed path's
+    /// segment-reversal optimization.
     pub sort_fields: Vec<String>,
     /// Parallel to `sort_fields`. Each entry is `"asc"` or `"desc"` (lowercase).
     pub sort_orders: Vec<String>,

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionPlugin.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionPlugin.java
@@ -705,6 +705,10 @@ public class DataFusionPlugin extends Plugin
         NativeStoreHandle dataformatAwareStoreHandle = settings.dataformatAwareStoreHandles().get(settings.format());
         // Pull index.sort.field / index.sort.order off IndexSettings so the native reader can declare
         // file sort order to DataFusion. Empty lists when the index has no index sort configured.
+        // Two consumers downstream:
+        // - Vanilla path: ListingOptions.with_file_sort_order so the planner can drop SortExec.
+        // - Indexed path: indexed_executor reverses segment iteration when the query's leading
+        // ORDER BY runs counter to the catalog direction.
         List<String> sortFields = List.of();
         List<String> sortOrders = List.of();
         IndexSettings indexSettings = settings.indexSettings();

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionReaderManager.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionReaderManager.java
@@ -60,7 +60,9 @@ public class DatafusionReaderManager implements EngineReaderManager<DatafusionRe
      * @param dataformatAwareStoreHandle per-format native store handle for reads (null if not available).
      *                                   Pointer is extracted at reader creation time via {@code getPointer()}.
      *                                   0 means use default local file system.
-     * @param sortFields {@code index.sort.field} values, or empty if no index sort.
+     * @param sortFields {@code index.sort.field} values, or empty if no index sort. Threaded to the native
+     *                   reader so the indexed scan path can decide whether to iterate segments in reverse
+     *                   catalog-snapshot order to feed a {@code TopK} above us.
      * @param sortOrders {@code index.sort.order} values ("asc"/"desc"), parallel to {@code sortFields}.
      */
     public DatafusionReaderManager(
@@ -75,8 +77,8 @@ public class DatafusionReaderManager implements EngineReaderManager<DatafusionRe
         this.directoryPath = shardPath.getDataPath().resolve(dataFormat.name()).toString();
         this.dataFusionService = dataFusionService;
         this.dataformatAwareStoreHandle = dataformatAwareStoreHandle;
-        this.sortFields = sortFields == null ? List.of() : sortFields;
-        this.sortOrders = sortOrders == null ? List.of() : sortOrders;
+        this.sortFields = sortFields == null ? List.of() : List.copyOf(sortFields);
+        this.sortOrders = sortOrders == null ? List.of() : List.copyOf(sortOrders);
     }
 
     @Override

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/nativelib/NativeBridge.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/nativelib/NativeBridge.java
@@ -834,10 +834,11 @@ public final class NativeBridge {
      * @param segments per-segment metadata — each carries a single filename and writer generation
      * @param dataformatAwareStoreHandle per-format native store handle (null = local, live = use store pointer)
      * @param sortFields index.sort.field values, or empty list if the index has no sort configured.
-     *                   Parallel to {@code sortOrders}.
+     *                   Parallel to {@code sortOrders}. Two consumers Rust-side: vanilla path's
+     *                   {@code ListingOptions.with_file_sort_order(...)} so the parquet scan advertises
+     *                   {@code output_ordering} to the optimizer, and indexed path's segment-iteration
+     *                   reversal when the query's leading ORDER BY runs counter to catalog direction.
      * @param sortOrders index.sort.order values ("asc" or "desc"), parallel to {@code sortFields}.
-     *                   Used by Rust to call {@code ListingOptions.with_file_sort_order(...)} so the
-     *                   parquet scan advertises {@code output_ordering} to the DataFusion optimizer.
      */
     public static long createDatafusionReader(
         String path,

--- a/sandbox/qa/analytics-engine-coordinator/src/internalClusterTest/java/org/opensearch/be/datafusion/SortReverseQtfIT.java
+++ b/sandbox/qa/analytics-engine-coordinator/src/internalClusterTest/java/org/opensearch/be/datafusion/SortReverseQtfIT.java
@@ -1,0 +1,359 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.Version;
+import org.opensearch.action.admin.indices.create.CreateIndexResponse;
+import org.opensearch.analytics.AnalyticsPlugin;
+import org.opensearch.analytics.exec.DefaultPlanExecutor;
+import org.opensearch.analytics.sql.SqlPlanRunner;
+import org.opensearch.arrow.allocator.ArrowBasePlugin;
+import org.opensearch.arrow.flight.transport.FlightStreamPlugin;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.FeatureFlags;
+import org.opensearch.composite.CompositeDataFormatPlugin;
+import org.opensearch.index.engine.dataformat.stub.MockCommitterEnginePlugin;
+import org.opensearch.parquet.ParquetOnlyDataFormatPlugin;
+import org.opensearch.plugins.Plugin;
+import org.opensearch.plugins.PluginInfo;
+import org.opensearch.test.MockLogAppender;
+import org.opensearch.test.OpenSearchIntegTestCase;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * End-to-end integration test for the indexed-parquet sort-aware segment reversal optimization
+ * (analog of Lucene's {@code shouldUseTimeSeriesDescSortOptimization}).
+ *
+ * <p><b>What this test verifies.</b> When {@code index.sort.field=ts asc} is configured and a
+ * QTF query asks {@code ORDER BY ts DESC LIMIT k}, the indexed-parquet executor reverses the
+ * per-shard segment iteration order so a {@code TopK} above the scan pulls the
+ * highest-priority segment first. The reversal is an iteration-order flip only — per-segment
+ * {@code global_base} values are preserved so QTF's {@code __row_id__} round-trip
+ * (query phase → fetch phase) still resolves to the right rows.
+ *
+ * <p><b>Three scenarios:</b>
+ * <ol>
+ *   <li><b>Reversal triggers, results correct</b> —
+ *       integer filter + {@code ORDER BY ts DESC LIMIT k}. Captures the
+ *       "reversing segment iteration" Rust log line via {@link MockLogAppender} on
+ *       {@code RustLoggerBridge} to prove the optimization fired, and asserts the top-k
+ *       rows by {@code ts DESC} are correct.</li>
+ *   <li><b>Same direction, no reversal</b> — same fixture, same query but
+ *       {@code ORDER BY ts ASC} (matches catalog direction). Asserts the optimization does
+ *       <em>not</em> fire and results are still correct.</li>
+ *   <li><b>Keyword filter + reversal</b> — same fixture, predicate is
+ *       {@code category = 'C0'} (keyword equality evaluated via the parquet predicate
+ *       pushdown path) plus {@code ORDER BY ts DESC LIMIT k}. Verifies that keyword
+ *       filtering composes with reversal: row IDs round-trip across the QTF query→fetch
+ *       hop and the returned rows match expected.</li>
+ * </ol>
+ *
+ * <p><b>Fixture shape.</b> 2 shards, 3 flushes per shard → 2–4 parquet segments per shard
+ * (variance from doc routing). Per-doc {@code ts} is a monotonically increasing epoch-millis
+ * value so segment-local min/max ranges don't overlap, making the page-stats pruning hint
+ * advertised by reversal observable in principle (this test asserts correctness; pruning is
+ * verified by the Rust unit tests).
+ *
+ * @opensearch.internal
+ */
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.SUITE, numDataNodes = 2, numClientNodes = 0)
+public class SortReverseQtfIT extends OpenSearchIntegTestCase {
+
+    private static final String INDEX = "sort_reverse_qtf_idx";
+    private static final int NUM_SHARDS = 2;
+    private static final int FLUSHES = 3;
+    private static final int DOCS_PER_FLUSH = 8;
+    private static final int TOTAL_DOCS = FLUSHES * DOCS_PER_FLUSH;
+    /**
+     * Logger name for the Rust → Java log bridge. Anything {@code log_debug!()}'d on the
+     * Rust side surfaces here at {@code DEBUG}.
+     */
+    private static final String RUST_LOGGER_NAME = "org.opensearch.nativebridge.spi.RustLoggerBridge";
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        // Mirrors QtfDerivedAboveProjectIT: parquet-only with MockCommitter for commit
+        // lifecycle. No Lucene secondary — adding analytics-backend-lucene to the IT
+        // classpath auto-loads its AnalyticsSearchBackendPlugin SPI, which the test
+        // plugin loader can't satisfy (constructor expects DataFusionPlugin) and breaks
+        // every IT in the same JVM.
+        return List.of(ArrowBasePlugin.class, CompositeDataFormatPlugin.class, MockCommitterEnginePlugin.class);
+    }
+
+    @Override
+    protected Collection<PluginInfo> additionalNodePlugins() {
+        return List.of(
+            classpathPlugin(FlightStreamPlugin.class, List.of(ArrowBasePlugin.class.getName())),
+            classpathPlugin(AnalyticsPlugin.class, Collections.emptyList()),
+            classpathPlugin(ParquetOnlyDataFormatPlugin.class, Collections.emptyList()),
+            classpathPlugin(DataFusionPlugin.class, List.of(AnalyticsPlugin.class.getName()))
+        );
+    }
+
+    private static PluginInfo classpathPlugin(Class<? extends Plugin> pluginClass, List<String> extendedPlugins) {
+        return new PluginInfo(
+            pluginClass.getName(),
+            "classpath plugin",
+            "NA",
+            Version.CURRENT,
+            "1.8",
+            pluginClass.getName(),
+            null,
+            extendedPlugins,
+            false
+        );
+    }
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return Settings.builder()
+            .put(super.nodeSettings(nodeOrdinal))
+            .put(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG, true)
+            .put(FeatureFlags.STREAM_TRANSPORT, true)
+            .build();
+    }
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        if (!indexExists(INDEX)) {
+            createSortedIndex();
+            seedDocs();
+            ensureGreen(INDEX);
+        }
+    }
+
+    /**
+     * Catalog ASC + query DESC ⇒ reversal must fire. Asserts the result set is correct
+     * (top-k by ts DESC) AND that the Rust reversal log line was emitted.
+     */
+    public void testReversalTriggers_orderByTsDescLimit_correctResults() throws Exception {
+        Logger rustLogger = LogManager.getLogger(RUST_LOGGER_NAME);
+        try (MockLogAppender appender = MockLogAppender.createForLoggers(rustLogger)) {
+            appender.addExpectation(
+                new MockLogAppender.SeenEventExpectation(
+                    "indexed_executor must log the segment-iteration reversal",
+                    RUST_LOGGER_NAME,
+                    Level.DEBUG,
+                    "*reversing segment iteration*"
+                )
+            );
+
+            withRustLogLevel("DEBUG", () -> {
+                SqlPlanRunner runner = sqlPlanRunner();
+                List<Object[]> rows = runner.executeSql(
+                    "SELECT ts, payload FROM " + INDEX + " WHERE counter > 0 ORDER BY ts DESC LIMIT 5"
+                );
+                // Top 5 by ts DESC = the 5 latest-ingested docs (ts = TOTAL_DOCS-1 .. TOTAL_DOCS-5).
+                assertEquals("LIMIT 5 must yield 5 rows", 5, rows.size());
+                for (int i = 0; i < 5; i++) {
+                    long expectedTs = TOTAL_DOCS - 1 - i;
+                    assertEquals("row " + i + " ts mismatch", expectedTs, ((Number) rows.get(i)[0]).longValue());
+                    assertEquals("row " + i + " payload mismatch", payloadFor(expectedTs), rows.get(i)[1]);
+                }
+            });
+
+            appender.assertAllExpectationsMatched();
+        }
+    }
+
+    /**
+     * Catalog ASC + query ASC ⇒ NO reversal. Negative path: log line must NOT appear, and
+     * result remains correct (top-k by ts ASC).
+     */
+    public void testNoReversal_orderByTsAscLimit_correctResults() throws Exception {
+        Logger rustLogger = LogManager.getLogger(RUST_LOGGER_NAME);
+        try (MockLogAppender appender = MockLogAppender.createForLoggers(rustLogger)) {
+            appender.addExpectation(
+                new MockLogAppender.UnseenEventExpectation(
+                    "indexed_executor must NOT reverse when query direction matches catalog",
+                    RUST_LOGGER_NAME,
+                    Level.DEBUG,
+                    "*reversing segment iteration*"
+                )
+            );
+
+            withRustLogLevel("DEBUG", () -> {
+                SqlPlanRunner runner = sqlPlanRunner();
+                List<Object[]> rows = runner.executeSql(
+                    "SELECT ts, payload FROM " + INDEX + " WHERE counter > 0 ORDER BY ts ASC LIMIT 5"
+                );
+                assertEquals("LIMIT 5 must yield 5 rows", 5, rows.size());
+                for (int i = 0; i < 5; i++) {
+                    long expectedTs = i;
+                    assertEquals("row " + i + " ts mismatch", expectedTs, ((Number) rows.get(i)[0]).longValue());
+                    assertEquals("row " + i + " payload mismatch", payloadFor(expectedTs), rows.get(i)[1]);
+                }
+            });
+
+            appender.assertAllExpectationsMatched();
+        }
+    }
+
+    /**
+     * Reversal + keyword equality filter. Verifies the QTF row-id round-trip
+     * (query → fetch) survives reversal when the predicate is a keyword equality
+     * (evaluated through the parquet predicate pushdown path).
+     *
+     * <p>Predicate: {@code category = 'C0'}. Each ts is assigned to one of three categories
+     * round-robin (C0/C1/C2) at ingest time, so {@code category = 'C0'} matches roughly 1/3
+     * of all rows and exercises a real cross-segment filter.
+     */
+    public void testReversal_keywordFilter_correctResults() throws Exception {
+        SqlPlanRunner runner = sqlPlanRunner();
+        List<Object[]> rows = runner.executeSql(
+            "SELECT ts, payload, category FROM " + INDEX + " WHERE category = 'C0' ORDER BY ts DESC LIMIT 4"
+        );
+        // C0 is at ts ≡ 0 (mod 3). Top 4 by ts DESC of {0,3,6,...,TOTAL_DOCS-3 if divisible}:
+        // we compute the expected list from the same generator so the test mirrors ingest.
+        List<Long> c0DescByTs = expectedC0TsDesc(4);
+        assertEquals("LIMIT 4 must yield 4 rows", c0DescByTs.size(), rows.size());
+        for (int i = 0; i < rows.size(); i++) {
+            long expectedTs = c0DescByTs.get(i);
+            assertEquals("row " + i + " ts mismatch", expectedTs, ((Number) rows.get(i)[0]).longValue());
+            assertEquals("row " + i + " payload mismatch", payloadFor(expectedTs), rows.get(i)[1]);
+            assertEquals("row " + i + " category mismatch", "C0", rows.get(i)[2]);
+        }
+    }
+
+    // ── Infrastructure ──────────────────────────────────────────────────────
+
+    private void withRustLogLevel(String level, ThrowingRunnable body) throws Exception {
+        client().admin()
+            .cluster()
+            .prepareUpdateSettings()
+            .setTransientSettings(Settings.builder().put("logger." + RUST_LOGGER_NAME, level).build())
+            .get();
+        try {
+            body.run();
+        } finally {
+            client().admin()
+                .cluster()
+                .prepareUpdateSettings()
+                .setTransientSettings(Settings.builder().putNull("logger." + RUST_LOGGER_NAME).build())
+                .get();
+        }
+    }
+
+    @FunctionalInterface
+    private interface ThrowingRunnable {
+        void run() throws Exception;
+    }
+
+    private SqlPlanRunner sqlPlanRunner() {
+        String node = internalCluster().getNodeNames()[0];
+        ClusterService clusterService = internalCluster().getInstance(ClusterService.class, node);
+        DefaultPlanExecutor executor = internalCluster().getInstance(DefaultPlanExecutor.class, node);
+        return new SqlPlanRunner(clusterService, executor);
+    }
+
+    private void createSortedIndex() {
+        // index.sort.field=[ts] index.sort.order=[asc] — the catalog-monotonic key. Each
+        // segment is internally sorted ASC on ts; the per-shard segment list goes from
+        // earliest-ingest to latest-ingest. Query ORDER BY ts DESC then asks for the
+        // "newest first" slice, which is exactly what reversal optimizes.
+        Settings indexSettings = Settings.builder()
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, NUM_SHARDS)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+            .put("index.pluggable.dataformat.enabled", true)
+            .put("index.pluggable.dataformat", "composite")
+            .put("index.composite.primary_data_format", "parquet")
+            .putList("index.composite.secondary_data_formats")
+            .putList("index.sort.field", List.of("ts"))
+            .putList("index.sort.order", List.of("asc"))
+            .build();
+
+        CreateIndexResponse response = client().admin()
+            .indices()
+            .prepareCreate(INDEX)
+            .setSettings(indexSettings)
+            .setMapping(
+                "ts",
+                "type=long",
+                "counter",
+                "type=integer",
+                "payload",
+                "type=keyword,index=false",
+                // index=false avoids requiring Lucene's FULL_TEXT_SEARCH capability — without
+                // a Lucene secondary, a plain `type=keyword` mapping is rejected by the
+                // composite engine. Equality predicates on this field still work because
+                // DataFusion evaluates string eq on the parquet column directly.
+                "category",
+                "type=keyword,index=false"
+            )
+            .get();
+        assertTrue("index creation must be acknowledged", response.isAcknowledged());
+        ensureGreen(INDEX);
+    }
+
+    /**
+     * Seed {@link #TOTAL_DOCS} docs in {@link #FLUSHES} batches with a flush+refresh after
+     * each batch. Per-shard each batch becomes one parquet segment, so per-shard segment
+     * count is 2–4 (depending on doc routing) — within the test contract.
+     */
+    private void seedDocs() {
+        for (int batch = 0; batch < FLUSHES; batch++) {
+            for (int i = 0; i < DOCS_PER_FLUSH; i++) {
+                long ts = (long) batch * DOCS_PER_FLUSH + i;
+                client().prepareIndex(INDEX)
+                    .setId(String.valueOf(ts))
+                    .setSource(
+                        "ts",
+                        ts,
+                        "counter",
+                        (int) (ts + 1),
+                        "payload",
+                        payloadFor(ts),
+                        "category",
+                        categoryFor(ts)
+                    )
+                    .get();
+            }
+            client().admin().indices().prepareRefresh(INDEX).get();
+            client().admin().indices().prepareFlush(INDEX).get();
+        }
+    }
+
+    private static String payloadFor(long ts) {
+        return String.format(Locale.ROOT, "p-%04d", ts);
+    }
+
+    /**
+     * Round-robin category assignment so each category has roughly TOTAL_DOCS/3 rows
+     * spread across all flush batches. Deterministic so expected-row computation in the
+     * delegation test is straightforward.
+     */
+    private static String categoryFor(long ts) {
+        return "C" + (ts % 3);
+    }
+
+    /**
+     * Expected top-{@code limit} ts values for {@code WHERE category = 'C0' ORDER BY ts DESC}
+     * over the seeded fixture. Mirrors {@link #categoryFor(long)} so the test is robust to
+     * fixture-size changes.
+     */
+    private static List<Long> expectedC0TsDesc(int limit) {
+        java.util.ArrayList<Long> out = new java.util.ArrayList<>();
+        for (long ts = TOTAL_DOCS - 1; ts >= 0 && out.size() < limit; ts--) {
+            if ("C0".equals(categoryFor(ts))) {
+                out.add(ts);
+            }
+        }
+        return out;
+    }
+}


### PR DESCRIPTION
### Description

Mirror of Lucene's `ContextIndexSearcher.shouldUseTimeSeriesDescSortOptimization` for the **indexed-parquet** scan path (`IndexedTableProvider` / `QueryShardExec`). When `index.sort.field` is configured and the query's leading `ORDER BY` runs counter to the catalog's stored direction, reverse the per-shard segment iteration so a `TopK` above the scan pulls the highest-priority segment first and parquet page-stats pruning kicks in for the rest.

**Reuses PR #22041's plumbing.** That PR threads `index.sort.field` / `index.sort.order` from `IndexSettings` through `DatafusionReaderManager` → `DatafusionReader` → `ReaderHandle` → `df_create_reader` to `ShardView.sort_fields` / `ShardView.sort_orders`. This PR adds a second consumer of those same fields, on the indexed path, with **no new Java or FFM surface area**.

### Where the optimization fires

`indexed_executor.rs::execute_indexed_with_context_inner`, after `from_substrait_plan` decodes the `LogicalPlan`:

```rust
let mut segments = segments;
if should_reverse_segments(analyze_top_sort(&logical_plan).as_ref(), &sort_fields, &sort_orders) {
    reverse_segment_iteration_order(&mut segments);
}
```

Three module-local helpers:

- **`analyze_top_sort(&LogicalPlan) -> Option<TopSort>`** — walks `Projection` / `Limit` / `SubqueryAlias` / `Distinct` / `Filter` to find the first `LogicalPlan::Sort`. Returns the leading sort key's bare column name and direction. Returns `None` if no top-level Sort, or if the leading sort key is anything but a plain `Expr::Column` (function on the sort key breaks catalog monotonicity).
- **`should_reverse_segments(top_sort, sort_fields, sort_orders) -> bool`** — true iff the catalog has a sort, the query's leading sort column matches `sort_fields[0]` exactly (case-sensitive, matching #22041's `Column::from_name`), and the directions differ. Multi-key sorts use only `sort_fields[0]` — segments aren't monotonic on a non-leading key.
- **`reverse_segment_iteration_order(&mut [SegmentFileInfo])`** — flips the slice in place. Per-segment `global_base` is **deliberately not** recomputed; see below.

### QTF correctness — why `global_base` must be preserved

The `__row_id__` emitted by the indexed scan is `segment.global_base + position`. QTF's fetch phase (`api::fetch_by_row_ids`) goes through a **different code path** (`ShardTableProvider`, not `IndexedTableProvider`) and rebuilds segments via `build_segments(ShardView.object_metas, ShardView.writer_generations)` — always in catalog order. Fetch then `partition_point`s the cached row IDs against catalog-order `global_base`s to find the owning segment.

For the round trip to hold, query-phase IDs must match catalog-order bases. `reverse_segment_iteration_order` therefore flips iteration order **only** — each segment retains its catalog-order `global_base`. Reversal becomes purely a scheduling decision; the row-id space is unchanged. The optimization composes safely with QTF.

### What this PR does not change

- **Vanilla path** (`ListingTable` / `DataSourceExec`) — covered by #22041 via `ListingOptions::with_file_sort_order(...)` (different mechanism: advertise `output_ordering` so the planner can drop `SortExec`).
- **`QueryShardExec.properties.equivalence_properties`** — no output-ordering claim. The TopK / SortPreservingMergeExec above the scan still re-sorts. Reversal is purely a pruning aid for sort-with-limit shapes; it doesn't try to make the scan's output-ordering claim load-bearing. That's a separate, more invasive change.

### Tests

**Rust unit tests** in `indexed_executor::tests`:
- `analyze_top_sort_*` — top-level desc, descends through Limit/Projection, None for no-sort, None for function sort key.
- `should_reverse_segments_*` — matching field opposite direction, matching same direction, catalog desc query asc, no query sort, no catalog sort, non-leading catalog field, case-sensitive name.
- `reverse_segments_preserves_global_base`, `reverse_segments_empty_is_noop`, `reverse_segments_single_keeps_its_base`.

**Rust e2e tests** in `indexed_table/tests_e2e/sort_reverse_row_id.rs` — pin the load-bearing invariant directly: build 3- and 4-segment fixtures with `emit_row_ids: true`, run the query in natural order vs `reverse_segment_iteration_order`, assert the **set** of emitted `__row_id__` values is identical (sorted set equality). If `global_base` cumulation drifted under reversal, fetch would return wrong rows; this catches it locally.

**Java IT** in `sandbox/qa/analytics-engine-coordinator/.../SortReverseQtfIT.java` (parquet primary + Lucene secondary, 2 shards, 3 flushes → 2-4 parquet segments per shard, `index.sort.field=ts asc`):
- `testReversalTriggers_orderByTsDescLimit_correctResults` — captures the reversal log line via `MockLogAppender` on `RustLoggerBridge` (proves the optimization fired) and asserts top-5 rows by `ts DESC` are correct via the QTF query→fetch round-trip.
- `testNoReversal_orderByTsAscLimit_correctResults` — `UnseenEventExpectation` confirms reversal does NOT fire when query direction matches catalog; results still correct.
- `testReversal_keywordFilterDelegationPath_correctResults` — `WHERE category = 'C0' ORDER BY ts DESC LIMIT 4` exercises the keyword-filter delegation path (predicate shipped to Lucene perf peer) + reversal; asserts QTF row-id round-trip composes with delegation.

### Verification

- `cargo test --lib`: 1045 / 1045 pass (1043 pre-existing + 22 new unit tests + 2 new e2e tests, after dedupe).
- `:server`, `:sandbox:plugins:composite-engine`, `:sandbox:plugins:analytics-backend-datafusion`, `:sandbox:plugins:analytics-backend-lucene`, `:sandbox:qa:analytics-engine-coordinator` all `compileJava` / `compileTestJava` / `compileInternalClusterTestJava` clean.

### Benchmark results — full clickbench corpus

Measured on EC2 `r8g.2xlarge` (ARM64, 8 vCPU, 64 GB) with the full 100M-row OSB clickbench corpus (parquet primary + Lucene secondary, OSB sort `[CounterID desc, EventDate desc, UserID desc, EventTime desc, WatchID desc]`).

Same EC2 box, same data, same script, same 13 queries (10 reversal-eligible + 3 controls), 3 passes per query. Build A = upstream main without this PR; Build B = upstream main + this PR. **min_ms** is reported (warm cache, ignores pass-1 cold-cache outliers; mean is misleading because Q01 cold-cache is ~2300 ms before page cache warms).

All queries: `where <field> = <literal> | sort + CounterID | head 1000` (catalog leading is `CounterID desc` → `+` triggers reversal). Selectivity is the number of rows matching the filter against the 100M corpus.

| Query | Filter (selectivity) | Build A (no fix) | **Build B (with fix)** | Δ ms | Δ % |
|---|---|---:|---:|---:|---:|
| Q01 | `BrowserLanguage = 'S0'` (~92M) | 478 | **388** | −90 | **−18.8%** |
| Q02 | `HitColor = '5'` (~80M) | 402 | **339** | −63 | **−15.7%** |
| Q03 | `BrowserCountry = 'h1'` (~28M) | 324 | **210** | −114 | **−35.2%** |
| Q04 | `MobilePhoneModel = 'iPad'` (~5M) | 328 | **186** | −142 | **−43.3%** |
| Q07 | `UTMSource = 'feedburner'` (~572K) | 67 | 67 | 0 | flat |
| Q08 | `MobilePhoneModel = 'iPhone'` (~229K) | 89 | 88 | −1 | flat |
| Q10 | compound (~thousands) | 73 | 75 | +2 | flat |
| **C1** | same direction as catalog (`sort - CounterID`) | 243 | 242 | −1 | flat ✓ |
| **C2** | non-leading catalog key (`sort + EventDate`) | 234 | 233 | −1 | flat ✓ |

(Q05/Q06/Q09 returned 0 rows on this corpus slice — literal absent from the data — and are omitted; their flat timings are uninformative.)

**Reading the result:**

- **High-selectivity queries (Q01–Q04, 5M–92M matching rows): 16% → 43% latency reduction.** These are the cases where `head 1000` against tens of millions of matching rows actually has work to do — TopK has to scan many segments before its threshold tightens. With reversal, the highest-`CounterID` segment is hit first, the threshold tightens fast, and parquet page stats prune most of the remaining segments.
- **Low-selectivity queries (Q07–Q10, ≤600K matching rows): flat.** Finding the top 1000 is cheap regardless of scheduling order — work is dominated by the keyword-filter scan, not segment iteration. The optimization correctly does no harm where it can't help.
- **Control queries (C1 same direction, C2 non-leading sort key): identical timings between builds.** Negative confirmation that the change is neutral on shapes where reversal must not fire.

Variance across warm passes is ~3–5 ms, well below the 60–140 ms deltas on Q01–Q04.

### Related Issues / PRs

Builds on #22041 (vanilla-path index.sort.field propagation).

### Check List

- [x] Functionality includes testing.
- [ ] API changes companion pull request created, if applicable.
- [ ] Public documentation issue/PR created, if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
