### PR TITLE
Add fancy-regex to Cargo.lock (follow-up to #22002)

### DIFF
--- a/sandbox/libs/dataformat-native/rust/Cargo.lock
+++ b/sandbox/libs/dataformat-native/rust/Cargo.lock
@@ -405,7 +405,16 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.6.3",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec 0.8.0",
 ]
 
 [[package]]
@@ -413,6 +422,12 @@ name = "bit-vec"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -1638,6 +1653,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fancy-regex"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e24cb5a94bcae1e5408b0effca5cd7172ea3c5755049c5f3af4cd283a165298"
+dependencies = [
+ "bit-set 0.8.0",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "fastant"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2814,6 +2840,7 @@ dependencies = [
  "datafusion-execution",
  "datafusion-expr",
  "datafusion-substrait",
+ "fancy-regex",
  "futures",
  "jsonpath-rust",
  "libc",
@@ -3234,8 +3261,8 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b476131c3c86cb68032fdc5cb6d5a1045e3e42d96b69fa599fd77701e1f5bf"
 dependencies = [
- "bit-set",
- "bit-vec",
+ "bit-set 0.5.3",
+ "bit-vec 0.6.3",
  "bitflags",
  "lazy_static",
  "num-traits",


### PR DESCRIPTION
### Description

Follow-up to #22002 (now merged), addressing @mch2's review request to update the lockfile.

#22002 added `fancy-regex = "=0.14.0"` to `sandbox/plugins/analytics-backend-datafusion/rust/Cargo.toml` (used by the grok UDF, `src/udf/grok.rs`) but did not commit the matching `Cargo.lock` entry. As a result `Cargo.toml` and the workspace `Cargo.lock` (`sandbox/libs/dataformat-native/rust/Cargo.lock`) are inconsistent on `main`: a `--locked` build would fail because the lock is missing `fancy-regex`.

This regenerates the lock so it resolves `fancy-regex` and its transitive deps. The diff is limited to:
- `fancy-regex 0.14.0` (deps: `bit-set 0.8.0`, `regex-automata`, `regex-syntax` — the latter two already present via the `regex` crate),
- new transitive deps `bit-set 0.8.0` and `bit-vec 0.8.0`,
- `fancy-regex` added to the `opensearch-datafusion` package's dependency list,
- version qualifiers where `bit-set`/`bit-vec` now have two versions in the graph.

No existing locked versions are bumped. Verified with `cargo metadata --locked` (passes — lock matches the manifest).

### Check List
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
