### PR TITLE
Add support for double, int and long to ExtraFieldValue #104

### DIFF
--- a/server/src/main/java/org/opensearch/index/mapper/extrasource/AbstractPackedArray.java
+++ b/server/src/main/java/org/opensearch/index/mapper/extrasource/AbstractPackedArray.java
@@ -74,6 +74,9 @@ abstract class AbstractPackedArray {
             return view;
         }
 
+        // This cache is intentionally lock-free. The expected indexing path consumes each
+        // value from one thread; if a value is shared concurrently, duplicate first-time
+        // resolution is harmless because all resolved views contain the same bytes.
         byte[] arr;
         int off;
         if (packed instanceof BytesArray ba) {
@@ -100,9 +103,15 @@ abstract class AbstractPackedArray {
     }
 
     protected static long decodeLongLEAt(final byte[] a, final int p) {
-        // cast makes the int-to-long promotion explicit; the mask treats each chunk as unsigned.
-        return (((long) decodeIntLEAt(a, p)) & 0xFFFFFFFFL) | ((((long) decodeIntLEAt(a, p + Integer.BYTES)) & 0xFFFFFFFFL)
-            << Integer.SIZE);
+        // Decode bytes directly; mask each signed byte as unsigned before shifting.
+        return ((long) a[p] & 0xFFL)
+            | (((long) a[p + 1] & 0xFFL) << 8)
+            | (((long) a[p + 2] & 0xFFL) << 16)
+            | (((long) a[p + 3] & 0xFFL) << 24)
+            | (((long) a[p + 4] & 0xFFL) << 32)
+            | (((long) a[p + 5] & 0xFFL) << 40)
+            | (((long) a[p + 6] & 0xFFL) << 48)
+            | (((long) a[p + 7] & 0xFFL) << 56);
     }
 
     protected static float decodeFloatLEAt(final byte[] a, final int p) {

--- a/server/src/main/java/org/opensearch/index/mapper/extrasource/AbstractPackedArray.java
+++ b/server/src/main/java/org/opensearch/index/mapper/extrasource/AbstractPackedArray.java
@@ -47,6 +47,9 @@ abstract class AbstractPackedArray {
     AbstractPackedArray(BytesReference packed, int dimension, byte[] bytes, int bytesOffset, int bytesPerElement, String valueType) {
         this.packed = Objects.requireNonNull(packed, "packed must not be null");
         this.dimension = dimension;
+        if (bytes != null) {
+            Objects.checkFromIndexSize(bytesOffset, packed.length(), bytes.length);
+        }
         this.resolvedBytes = bytes == null ? null : new ResolvedBytes(bytes, bytesOffset);
         validate(packed.length(), dimension, bytesPerElement, valueType);
     }

--- a/server/src/main/java/org/opensearch/index/mapper/extrasource/AbstractPackedArray.java
+++ b/server/src/main/java/org/opensearch/index/mapper/extrasource/AbstractPackedArray.java
@@ -1,0 +1,121 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.mapper.extrasource;
+
+import org.opensearch.core.common.bytes.BytesArray;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * Shared storage and little-endian decoding for packed primitive arrays.
+ *
+ * <p>Element access is intentionally left to the concrete primitive types instead of
+ * being modeled with generics. Java generics would require boxed values such as
+ * {@code Integer}, {@code Long}, {@code Float}, and {@code Double}; keeping
+ * type-specific accessors avoids that overhead on indexing paths.</p>
+ */
+abstract class AbstractPackedArray {
+
+    protected final int dimension;
+    protected volatile byte[] bytes;
+    protected volatile int bytesOffset;
+
+    private final BytesReference packed;
+
+    AbstractPackedArray(BytesReference packed, int dimension, byte[] bytes, int bytesOffset, int bytesPerElement, String valueType) {
+        this.packed = Objects.requireNonNull(packed, "packed must not be null");
+        this.dimension = dimension;
+        this.bytes = bytes;
+        this.bytesOffset = bytesOffset;
+        validate(packed.length(), dimension, bytesPerElement, valueType);
+    }
+
+    public final int dimension() {
+        return dimension;
+    }
+
+    public final boolean isPackedLE() {
+        return true;
+    }
+
+    public final BytesReference packedBytes() {
+        return packed;
+    }
+
+    public final void writePayloadTo(StreamOutput out) throws IOException {
+        out.writeVInt(dimension());
+        out.writeBytesReference(packed);
+    }
+
+    protected final void ensureBytes() {
+        if (bytes != null) {
+            return;
+        }
+
+        byte[] arr;
+        int off;
+        if (packed instanceof BytesArray ba) {
+            arr = ba.array();
+            off = ba.offset();
+        } else {
+            arr = BytesReference.toBytes(packed);
+            off = 0;
+        }
+
+        bytesOffset = off;
+        bytes = arr;
+    }
+
+    protected final void checkIndex(int i) {
+        if (i < 0 || i >= dimension) {
+            throw new IndexOutOfBoundsException("i=" + i + " dim=" + dimension);
+        }
+    }
+
+    protected final int decodeIntLEAt(final int p) {
+        return decodeIntLEAt(bytes, p);
+    }
+
+    private static int decodeIntLEAt(final byte[] a, final int p) {
+        return (a[p] & 0xFF) | ((a[p + 1] & 0xFF) << 8) | ((a[p + 2] & 0xFF) << 16) | ((a[p + 3] & 0xFF) << 24);
+    }
+
+    protected final long decodeLongLEAt(final int p) {
+        final byte[] a = bytes;
+        return (decodeIntLEAt(a, p) & 0xFFFFFFFFL) | ((decodeIntLEAt(a, p + Integer.BYTES) & 0xFFFFFFFFL) << 32);
+    }
+
+    protected final float decodeFloatLEAt(final int p) {
+        return Float.intBitsToFloat(decodeIntLEAt(p));
+    }
+
+    protected final double decodeDoubleLEAt(final int p) {
+        return Double.longBitsToDouble(decodeLongLEAt(p));
+    }
+
+    private static void validate(int byteLen, int dim, int bytesPerElement, String valueType) {
+        if (dim < 0) {
+            throw new IllegalArgumentException("dimension must be >= 0 (got " + dim + ")");
+        }
+        final int expected;
+        try {
+            expected = Math.multiplyExact(dim, bytesPerElement);
+        } catch (ArithmeticException e) {
+            throw new IllegalArgumentException("dimension too large: " + dim, e);
+        }
+        if (byteLen != expected) {
+            throw new IllegalArgumentException(
+                "Bad packed " + valueType + " length=" + byteLen + " expected=" + expected + " (dim=" + dim + ")"
+            );
+        }
+    }
+}

--- a/server/src/main/java/org/opensearch/index/mapper/extrasource/AbstractPackedArray.java
+++ b/server/src/main/java/org/opensearch/index/mapper/extrasource/AbstractPackedArray.java
@@ -22,20 +22,32 @@ import java.util.Objects;
  * being modeled with generics. Java generics would require boxed values such as
  * {@code Integer}, {@code Long}, {@code Float}, and {@code Double}; keeping
  * type-specific accessors avoids that overhead on indexing paths.</p>
+ *
+ * <p>The repeated {@code get(int)} and array materialization loops in subclasses are
+ * deliberate. Extracting them into a generic or callback-based helper would add boxing
+ * or per-element indirection in hot indexing paths.</p>
  */
 abstract class AbstractPackedArray {
 
+    protected static final class ResolvedBytes {
+        final byte[] bytes;
+        final int offset;
+
+        private ResolvedBytes(byte[] bytes, int offset) {
+            this.bytes = bytes;
+            this.offset = offset;
+        }
+    }
+
     protected final int dimension;
-    protected volatile byte[] bytes;
-    protected volatile int bytesOffset;
 
     private final BytesReference packed;
+    private volatile ResolvedBytes resolvedBytes;
 
     AbstractPackedArray(BytesReference packed, int dimension, byte[] bytes, int bytesOffset, int bytesPerElement, String valueType) {
         this.packed = Objects.requireNonNull(packed, "packed must not be null");
         this.dimension = dimension;
-        this.bytes = bytes;
-        this.bytesOffset = bytesOffset;
+        this.resolvedBytes = bytes == null ? null : new ResolvedBytes(bytes, bytesOffset);
         validate(packed.length(), dimension, bytesPerElement, valueType);
     }
 
@@ -56,9 +68,10 @@ abstract class AbstractPackedArray {
         out.writeBytesReference(packed);
     }
 
-    protected final void ensureBytes() {
-        if (bytes != null) {
-            return;
+    protected final ResolvedBytes ensureBytes() {
+        ResolvedBytes view = resolvedBytes;
+        if (view != null) {
+            return view;
         }
 
         byte[] arr;
@@ -71,8 +84,9 @@ abstract class AbstractPackedArray {
             off = 0;
         }
 
-        bytesOffset = off;
-        bytes = arr;
+        view = new ResolvedBytes(arr, off);
+        resolvedBytes = view;
+        return view;
     }
 
     protected final void checkIndex(int i) {
@@ -81,25 +95,22 @@ abstract class AbstractPackedArray {
         }
     }
 
-    protected final int decodeIntLEAt(final int p) {
-        return decodeIntLEAt(bytes, p);
-    }
-
-    private static int decodeIntLEAt(final byte[] a, final int p) {
+    protected static int decodeIntLEAt(final byte[] a, final int p) {
         return (a[p] & 0xFF) | ((a[p + 1] & 0xFF) << 8) | ((a[p + 2] & 0xFF) << 16) | ((a[p + 3] & 0xFF) << 24);
     }
 
-    protected final long decodeLongLEAt(final int p) {
-        final byte[] a = bytes;
-        return (decodeIntLEAt(a, p) & 0xFFFFFFFFL) | ((decodeIntLEAt(a, p + Integer.BYTES) & 0xFFFFFFFFL) << 32);
+    protected static long decodeLongLEAt(final byte[] a, final int p) {
+        // cast makes the int-to-long promotion explicit; the mask treats each chunk as unsigned.
+        return (((long) decodeIntLEAt(a, p)) & 0xFFFFFFFFL) | ((((long) decodeIntLEAt(a, p + Integer.BYTES)) & 0xFFFFFFFFL)
+            << Integer.SIZE);
     }
 
-    protected final float decodeFloatLEAt(final int p) {
-        return Float.intBitsToFloat(decodeIntLEAt(p));
+    protected static float decodeFloatLEAt(final byte[] a, final int p) {
+        return Float.intBitsToFloat(decodeIntLEAt(a, p));
     }
 
-    protected final double decodeDoubleLEAt(final int p) {
-        return Double.longBitsToDouble(decodeLongLEAt(p));
+    protected static double decodeDoubleLEAt(final byte[] a, final int p) {
+        return Double.longBitsToDouble(decodeLongLEAt(a, p));
     }
 
     private static void validate(int byteLen, int dim, int bytesPerElement, String valueType) {

--- a/server/src/main/java/org/opensearch/index/mapper/extrasource/AbstractPackedArray.java
+++ b/server/src/main/java/org/opensearch/index/mapper/extrasource/AbstractPackedArray.java
@@ -104,13 +104,8 @@ abstract class AbstractPackedArray {
 
     protected static long decodeLongLEAt(final byte[] a, final int p) {
         // Decode bytes directly; mask each signed byte as unsigned before shifting.
-        return ((long) a[p] & 0xFFL)
-            | (((long) a[p + 1] & 0xFFL) << 8)
-            | (((long) a[p + 2] & 0xFFL) << 16)
-            | (((long) a[p + 3] & 0xFFL) << 24)
-            | (((long) a[p + 4] & 0xFFL) << 32)
-            | (((long) a[p + 5] & 0xFFL) << 40)
-            | (((long) a[p + 6] & 0xFFL) << 48)
+        return ((long) a[p] & 0xFFL) | (((long) a[p + 1] & 0xFFL) << 8) | (((long) a[p + 2] & 0xFFL) << 16) | (((long) a[p + 3] & 0xFFL)
+            << 24) | (((long) a[p + 4] & 0xFFL) << 32) | (((long) a[p + 5] & 0xFFL) << 40) | (((long) a[p + 6] & 0xFFL) << 48)
             | (((long) a[p + 7] & 0xFFL) << 56);
     }
 

--- a/server/src/main/java/org/opensearch/index/mapper/extrasource/AbstractPrimitiveArray.java
+++ b/server/src/main/java/org/opensearch/index/mapper/extrasource/AbstractPrimitiveArray.java
@@ -17,6 +17,10 @@ import org.opensearch.core.common.bytes.BytesReference;
  * generic base class. Java generics would require boxed values such as {@code Integer},
  * {@code Long}, {@code Float}, and {@code Double}; keeping primitive arrays and
  * type-specific accessors avoids that overhead on indexing paths.</p>
+ *
+ * <p>The small amount of repeated primitive-specific code is deliberate. Sharing it
+ * through generic helpers would require boxed values or indirect callbacks where callers
+ * currently use primitive arrays directly.</p>
  */
 abstract class AbstractPrimitiveArray {
 

--- a/server/src/main/java/org/opensearch/index/mapper/extrasource/AbstractPrimitiveArray.java
+++ b/server/src/main/java/org/opensearch/index/mapper/extrasource/AbstractPrimitiveArray.java
@@ -1,0 +1,40 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.mapper.extrasource;
+
+import org.opensearch.core.common.bytes.BytesReference;
+
+/**
+ * Shared behavior for arrays backed by Java primitive arrays.
+ *
+ * <p>The concrete classes keep their own primitive array type instead of using a
+ * generic base class. Java generics would require boxed values such as {@code Integer},
+ * {@code Long}, {@code Float}, and {@code Double}; keeping primitive arrays and
+ * type-specific accessors avoids that overhead on indexing paths.</p>
+ */
+abstract class AbstractPrimitiveArray {
+
+    private final int dimension;
+
+    AbstractPrimitiveArray(int dimension) {
+        this.dimension = dimension;
+    }
+
+    public final int dimension() {
+        return dimension;
+    }
+
+    public final boolean isPackedLE() {
+        return false;
+    }
+
+    public final BytesReference packedBytes() {
+        throw new IllegalStateException("Not packed");
+    }
+}

--- a/server/src/main/java/org/opensearch/index/mapper/extrasource/DoubleArrayValue.java
+++ b/server/src/main/java/org/opensearch/index/mapper/extrasource/DoubleArrayValue.java
@@ -76,8 +76,10 @@ public non-sealed interface DoubleArrayValue extends ExtraFieldValue {
     double get(int i);
 
     /**
-     * Convenience; may allocate/copy for packed (allocating double[] is unavoidable).
-     * Packed implementation must NOT perform an extra byte[] compaction copy.
+     * Convenience; allocates a double array for packed values.
+     * Zero-copy decoding is used when the packed value is backed by a usable byte array.
+     * For other BytesReference implementations, decoding may lazily materialize one cached
+     * byte array.
      */
     double[] asDoubleArray();
 

--- a/server/src/main/java/org/opensearch/index/mapper/extrasource/DoubleArrayValue.java
+++ b/server/src/main/java/org/opensearch/index/mapper/extrasource/DoubleArrayValue.java
@@ -1,0 +1,106 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.mapper.extrasource;
+
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+
+/**
+ * A double array value used in {@link ExtraFieldValue}.
+ *
+ * <p>Supports both primitive (decoded) and packed (little-endian) representations.</p>
+ */
+public non-sealed interface DoubleArrayValue extends ExtraFieldValue {
+
+    @Override
+    default Type type() {
+        return Type.DOUBLE_ARRAY;
+    }
+
+    /**
+     * Creates a {@link DoubleArrayValue} from packed little-endian bytes.
+     *
+     * @param packed the packed double bytes (dimension * 8 bytes)
+     * @param dimension the number of double elements
+     * @return a double-array value backed by the provided bytes
+     * @throws IllegalArgumentException if the byte length does not match {@code dimension * 8}
+     */
+    static DoubleArrayValue fromPackedBytes(BytesReference packed, int dimension) {
+        return PackedDoubleArray.fromPackedBytes(packed, dimension);
+    }
+
+    /**
+     * Creates a {@link DoubleArrayValue} from a packed little-endian byte array.
+     *
+     * @param packed the packed double bytes (dimension * 8 bytes)
+     * @param dimension the number of double elements
+     * @return a double-array value backed by the provided array
+     * @throws IllegalArgumentException if the byte length does not match {@code dimension * 8}
+     */
+    static DoubleArrayValue fromPackedArray(byte[] packed, int dimension) {
+        return PackedDoubleArray.fromPackedArray(packed, dimension);
+    }
+
+    /**
+     * Creates a {@link DoubleArrayValue} from a double array.
+     *
+     * @param values the double values
+     * @return a double-array value backed by the provided array
+     */
+    static DoubleArrayValue fromDoubleArray(double[] values) {
+        return new PrimitiveDoubleArray(values);
+    }
+
+    /** Number of double elements. */
+    int dimension();
+
+    /** True if backed by little-endian packed bytes. */
+    boolean isPackedLE();
+
+    /**
+     * Packed bytes for the double vector (LE, 8 * dimension bytes).
+     * Only valid when isPackedLE() == true.
+     */
+    BytesReference packedBytes();
+
+    /** Random access (packed reads 8 bytes at i*8; non-packed returns v[i]). */
+    double get(int i);
+
+    /**
+     * Convenience; may allocate/copy for packed (allocating double[] is unavoidable).
+     * Packed implementation must NOT perform an extra byte[] compaction copy.
+     */
+    double[] asDoubleArray();
+
+    @Override
+    default int size() {
+        return dimension();
+    }
+
+    @Override
+    default void writeBodyTo(StreamOutput out) throws IOException {
+        out.writeBoolean(isPackedLE());
+        writePayloadTo(out);
+    }
+
+    void writePayloadTo(StreamOutput out) throws IOException;
+
+    static DoubleArrayValue readBodyFrom(StreamInput in) throws IOException {
+        final boolean packedLE = in.readBoolean();
+        if (packedLE) {
+            final int dim = in.readVInt();
+            return PackedDoubleArray.readBodyFrom(in, dim);
+        } else {
+            return PrimitiveDoubleArray.readBodyFrom(in);
+        }
+    }
+}

--- a/server/src/main/java/org/opensearch/index/mapper/extrasource/ExtraFieldValue.java
+++ b/server/src/main/java/org/opensearch/index/mapper/extrasource/ExtraFieldValue.java
@@ -21,7 +21,7 @@ import java.io.IOException;
  * directly to the indexing layer.</p>
  */
 @ExperimentalApi()
-public sealed interface ExtraFieldValue permits FloatArrayValue, BytesValue {
+public sealed interface ExtraFieldValue permits DoubleArrayValue, FloatArrayValue, IntArrayValue, LongArrayValue, BytesValue {
 
     /**
      * Supported extra field value types.
@@ -29,8 +29,10 @@ public sealed interface ExtraFieldValue permits FloatArrayValue, BytesValue {
     @ExperimentalApi
     enum Type {
         BYTES((byte) 0, BytesValue::readBodyFrom),
-        FLOAT_ARRAY((byte) 1, FloatArrayValue::readBodyFrom);
-        // TODO add double, int and long
+        FLOAT_ARRAY((byte) 1, FloatArrayValue::readBodyFrom),
+        INT_ARRAY((byte) 2, IntArrayValue::readBodyFrom),
+        LONG_ARRAY((byte) 3, LongArrayValue::readBodyFrom),
+        DOUBLE_ARRAY((byte) 4, DoubleArrayValue::readBodyFrom);
 
         private final byte id;
         private final Reader reader;

--- a/server/src/main/java/org/opensearch/index/mapper/extrasource/ExtraFieldValue.java
+++ b/server/src/main/java/org/opensearch/index/mapper/extrasource/ExtraFieldValue.java
@@ -21,8 +21,7 @@ import java.io.IOException;
  * directly to the indexing layer.</p>
  */
 @ExperimentalApi()
-public sealed interface ExtraFieldValue permits DoubleArrayValue, FloatArrayValue, IntArrayValue, LongArrayValue, BytesValue {
-
+public sealed interface ExtraFieldValue permits BytesValue, FloatArrayValue, DoubleArrayValue, IntArrayValue, LongArrayValue {
     /**
      * Supported extra field value types.
      */
@@ -30,9 +29,9 @@ public sealed interface ExtraFieldValue permits DoubleArrayValue, FloatArrayValu
     enum Type {
         BYTES((byte) 0, BytesValue::readBodyFrom),
         FLOAT_ARRAY((byte) 1, FloatArrayValue::readBodyFrom),
-        INT_ARRAY((byte) 2, IntArrayValue::readBodyFrom),
-        LONG_ARRAY((byte) 3, LongArrayValue::readBodyFrom),
-        DOUBLE_ARRAY((byte) 4, DoubleArrayValue::readBodyFrom);
+        DOUBLE_ARRAY((byte) 2, DoubleArrayValue::readBodyFrom),
+        INT_ARRAY((byte) 3, IntArrayValue::readBodyFrom),
+        LONG_ARRAY((byte) 4, LongArrayValue::readBodyFrom);
 
         private final byte id;
         private final Reader reader;

--- a/server/src/main/java/org/opensearch/index/mapper/extrasource/FloatArrayValue.java
+++ b/server/src/main/java/org/opensearch/index/mapper/extrasource/FloatArrayValue.java
@@ -76,8 +76,10 @@ public non-sealed interface FloatArrayValue extends ExtraFieldValue {
     float get(int i);
 
     /**
-     * Convenience; may allocate/copy for packed (allocating float[] is unavoidable).
-     * Packed implementation must NOT perform an extra byte[] compaction copy.
+     * Convenience; allocates a float array for packed values.
+     * Zero-copy decoding is used when the packed value is backed by a usable byte array.
+     * For other BytesReference implementations, decoding may lazily materialize one cached
+     * byte array.
      */
     float[] asFloatArray();
 

--- a/server/src/main/java/org/opensearch/index/mapper/extrasource/IntArrayValue.java
+++ b/server/src/main/java/org/opensearch/index/mapper/extrasource/IntArrayValue.java
@@ -1,0 +1,106 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.mapper.extrasource;
+
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+
+/**
+ * An int array value used in {@link ExtraFieldValue}.
+ *
+ * <p>Supports both primitive (decoded) and packed (little-endian) representations.</p>
+ */
+public non-sealed interface IntArrayValue extends ExtraFieldValue {
+
+    @Override
+    default Type type() {
+        return Type.INT_ARRAY;
+    }
+
+    /**
+     * Creates an {@link IntArrayValue} from packed little-endian bytes.
+     *
+     * @param packed the packed int bytes (dimension * 4 bytes)
+     * @param dimension the number of int elements
+     * @return an int-array value backed by the provided bytes
+     * @throws IllegalArgumentException if the byte length does not match {@code dimension * 4}
+     */
+    static IntArrayValue fromPackedBytes(BytesReference packed, int dimension) {
+        return PackedIntArray.fromPackedBytes(packed, dimension);
+    }
+
+    /**
+     * Creates an {@link IntArrayValue} from a packed little-endian byte array.
+     *
+     * @param packed the packed int bytes (dimension * 4 bytes)
+     * @param dimension the number of int elements
+     * @return an int-array value backed by the provided array
+     * @throws IllegalArgumentException if the byte length does not match {@code dimension * 4}
+     */
+    static IntArrayValue fromPackedArray(byte[] packed, int dimension) {
+        return PackedIntArray.fromPackedArray(packed, dimension);
+    }
+
+    /**
+     * Creates an {@link IntArrayValue} from an int array.
+     *
+     * @param values the int values
+     * @return an int-array value backed by the provided array
+     */
+    static IntArrayValue fromIntArray(int[] values) {
+        return new PrimitiveIntArray(values);
+    }
+
+    /** Number of int elements. */
+    int dimension();
+
+    /** True if backed by little-endian packed bytes. */
+    boolean isPackedLE();
+
+    /**
+     * Packed bytes for the int vector (LE, 4 * dimension bytes).
+     * Only valid when isPackedLE() == true.
+     */
+    BytesReference packedBytes();
+
+    /** Random access (packed reads 4 bytes at i*4; non-packed returns v[i]). */
+    int get(int i);
+
+    /**
+     * Convenience; may allocate/copy for packed (allocating int[] is unavoidable).
+     * Packed implementation must NOT perform an extra byte[] compaction copy.
+     */
+    int[] asIntArray();
+
+    @Override
+    default int size() {
+        return dimension();
+    }
+
+    @Override
+    default void writeBodyTo(StreamOutput out) throws IOException {
+        out.writeBoolean(isPackedLE());
+        writePayloadTo(out);
+    }
+
+    void writePayloadTo(StreamOutput out) throws IOException;
+
+    static IntArrayValue readBodyFrom(StreamInput in) throws IOException {
+        final boolean packedLE = in.readBoolean();
+        if (packedLE) {
+            final int dim = in.readVInt();
+            return PackedIntArray.readBodyFrom(in, dim);
+        } else {
+            return PrimitiveIntArray.readBodyFrom(in);
+        }
+    }
+}

--- a/server/src/main/java/org/opensearch/index/mapper/extrasource/IntArrayValue.java
+++ b/server/src/main/java/org/opensearch/index/mapper/extrasource/IntArrayValue.java
@@ -76,8 +76,10 @@ public non-sealed interface IntArrayValue extends ExtraFieldValue {
     int get(int i);
 
     /**
-     * Convenience; may allocate/copy for packed (allocating int[] is unavoidable).
-     * Packed implementation must NOT perform an extra byte[] compaction copy.
+     * Convenience; allocates an int array for packed values.
+     * Zero-copy decoding is used when the packed value is backed by a usable byte array.
+     * For other BytesReference implementations, decoding may lazily materialize one cached
+     * byte array.
      */
     int[] asIntArray();
 

--- a/server/src/main/java/org/opensearch/index/mapper/extrasource/LongArrayValue.java
+++ b/server/src/main/java/org/opensearch/index/mapper/extrasource/LongArrayValue.java
@@ -1,0 +1,106 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.mapper.extrasource;
+
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+
+/**
+ * A long array value used in {@link ExtraFieldValue}.
+ *
+ * <p>Supports both primitive (decoded) and packed (little-endian) representations.</p>
+ */
+public non-sealed interface LongArrayValue extends ExtraFieldValue {
+
+    @Override
+    default Type type() {
+        return Type.LONG_ARRAY;
+    }
+
+    /**
+     * Creates a {@link LongArrayValue} from packed little-endian bytes.
+     *
+     * @param packed the packed long bytes (dimension * 8 bytes)
+     * @param dimension the number of long elements
+     * @return a long-array value backed by the provided bytes
+     * @throws IllegalArgumentException if the byte length does not match {@code dimension * 8}
+     */
+    static LongArrayValue fromPackedBytes(BytesReference packed, int dimension) {
+        return PackedLongArray.fromPackedBytes(packed, dimension);
+    }
+
+    /**
+     * Creates a {@link LongArrayValue} from a packed little-endian byte array.
+     *
+     * @param packed the packed long bytes (dimension * 8 bytes)
+     * @param dimension the number of long elements
+     * @return a long-array value backed by the provided array
+     * @throws IllegalArgumentException if the byte length does not match {@code dimension * 8}
+     */
+    static LongArrayValue fromPackedArray(byte[] packed, int dimension) {
+        return PackedLongArray.fromPackedArray(packed, dimension);
+    }
+
+    /**
+     * Creates a {@link LongArrayValue} from a long array.
+     *
+     * @param values the long values
+     * @return a long-array value backed by the provided array
+     */
+    static LongArrayValue fromLongArray(long[] values) {
+        return new PrimitiveLongArray(values);
+    }
+
+    /** Number of long elements. */
+    int dimension();
+
+    /** True if backed by little-endian packed bytes. */
+    boolean isPackedLE();
+
+    /**
+     * Packed bytes for the long vector (LE, 8 * dimension bytes).
+     * Only valid when isPackedLE() == true.
+     */
+    BytesReference packedBytes();
+
+    /** Random access (packed reads 8 bytes at i*8; non-packed returns v[i]). */
+    long get(int i);
+
+    /**
+     * Convenience; may allocate/copy for packed (allocating long[] is unavoidable).
+     * Packed implementation must NOT perform an extra byte[] compaction copy.
+     */
+    long[] asLongArray();
+
+    @Override
+    default int size() {
+        return dimension();
+    }
+
+    @Override
+    default void writeBodyTo(StreamOutput out) throws IOException {
+        out.writeBoolean(isPackedLE());
+        writePayloadTo(out);
+    }
+
+    void writePayloadTo(StreamOutput out) throws IOException;
+
+    static LongArrayValue readBodyFrom(StreamInput in) throws IOException {
+        final boolean packedLE = in.readBoolean();
+        if (packedLE) {
+            final int dim = in.readVInt();
+            return PackedLongArray.readBodyFrom(in, dim);
+        } else {
+            return PrimitiveLongArray.readBodyFrom(in);
+        }
+    }
+}

--- a/server/src/main/java/org/opensearch/index/mapper/extrasource/LongArrayValue.java
+++ b/server/src/main/java/org/opensearch/index/mapper/extrasource/LongArrayValue.java
@@ -76,8 +76,10 @@ public non-sealed interface LongArrayValue extends ExtraFieldValue {
     long get(int i);
 
     /**
-     * Convenience; may allocate/copy for packed (allocating long[] is unavoidable).
-     * Packed implementation must NOT perform an extra byte[] compaction copy.
+     * Convenience; allocates a long array for packed values.
+     * Zero-copy decoding is used when the packed value is backed by a usable byte array.
+     * For other BytesReference implementations, decoding may lazily materialize one cached
+     * byte array.
      */
     long[] asLongArray();
 

--- a/server/src/main/java/org/opensearch/index/mapper/extrasource/PackedDoubleArray.java
+++ b/server/src/main/java/org/opensearch/index/mapper/extrasource/PackedDoubleArray.java
@@ -30,6 +30,7 @@ final class PackedDoubleArray extends AbstractPackedArray implements DoubleArray
     }
 
     static PackedDoubleArray fromPackedArray(byte[] packedArray, int dimension) {
+        Objects.requireNonNull(packedArray, "packedArray must not be null");
         return fromPackedArray(packedArray, 0, packedArray.length, dimension);
     }
 

--- a/server/src/main/java/org/opensearch/index/mapper/extrasource/PackedDoubleArray.java
+++ b/server/src/main/java/org/opensearch/index/mapper/extrasource/PackedDoubleArray.java
@@ -1,0 +1,78 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.mapper.extrasource;
+
+import org.opensearch.core.common.bytes.BytesArray;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.common.io.stream.StreamInput;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * Packed little-endian doubles.
+ *
+ * <p>Canonical storage is a {@link BytesReference} for efficient transport.</p>
+ */
+final class PackedDoubleArray extends AbstractPackedArray implements DoubleArrayValue {
+
+    private volatile double[] cached;
+
+    static PackedDoubleArray fromPackedBytes(BytesReference packed, int dimension) {
+        Objects.requireNonNull(packed, "packed must not be null");
+        return new PackedDoubleArray(packed, dimension, null, 0);
+    }
+
+    static PackedDoubleArray fromPackedArray(byte[] packedArray, int dimension) {
+        return fromPackedArray(packedArray, 0, packedArray.length, dimension);
+    }
+
+    static PackedDoubleArray fromPackedArray(byte[] packedArray, int offset, int length, int dimension) {
+        Objects.requireNonNull(packedArray, "packedArray must not be null");
+        BytesReference packed = new BytesArray(packedArray, offset, length);
+        return new PackedDoubleArray(packed, dimension, packedArray, offset);
+    }
+
+    private PackedDoubleArray(BytesReference packed, int dimension, byte[] bytes, int bytesOffset) {
+        super(packed, dimension, bytes, bytesOffset, Double.BYTES, "double");
+    }
+
+    static PackedDoubleArray readBodyFrom(StreamInput in, int dim) throws IOException {
+        return fromPackedBytes(in.readBytesReference(), dim);
+    }
+
+    @Override
+    public double get(int i) {
+        checkIndex(i);
+        double[] v = cached;
+        if (v != null) {
+            return v[i];
+        }
+        ensureBytes();
+        return decodeDoubleLEAt(bytesOffset + i * Double.BYTES);
+    }
+
+    @Override
+    public double[] asDoubleArray() {
+        double[] v = cached;
+        if (v != null) return v;
+
+        ensureBytes();
+
+        v = new double[dimension];
+        int p = bytesOffset;
+        for (int i = 0; i < dimension; i++) {
+            v[i] = decodeDoubleLEAt(p);
+            p += Double.BYTES;
+        }
+
+        cached = v;
+        return v;
+    }
+}

--- a/server/src/main/java/org/opensearch/index/mapper/extrasource/PackedDoubleArray.java
+++ b/server/src/main/java/org/opensearch/index/mapper/extrasource/PackedDoubleArray.java
@@ -54,8 +54,8 @@ final class PackedDoubleArray extends AbstractPackedArray implements DoubleArray
         if (v != null) {
             return v[i];
         }
-        ensureBytes();
-        return decodeDoubleLEAt(bytesOffset + i * Double.BYTES);
+        ResolvedBytes resolved = ensureBytes();
+        return decodeDoubleLEAt(resolved.bytes, resolved.offset + i * Double.BYTES);
     }
 
     @Override
@@ -63,12 +63,12 @@ final class PackedDoubleArray extends AbstractPackedArray implements DoubleArray
         double[] v = cached;
         if (v != null) return v;
 
-        ensureBytes();
+        ResolvedBytes resolved = ensureBytes();
 
         v = new double[dimension];
-        int p = bytesOffset;
+        int p = resolved.offset;
         for (int i = 0; i < dimension; i++) {
-            v[i] = decodeDoubleLEAt(p);
+            v[i] = decodeDoubleLEAt(resolved.bytes, p);
             p += Double.BYTES;
         }
 

--- a/server/src/main/java/org/opensearch/index/mapper/extrasource/PackedFloatArray.java
+++ b/server/src/main/java/org/opensearch/index/mapper/extrasource/PackedFloatArray.java
@@ -41,6 +41,7 @@ final class PackedFloatArray extends AbstractPackedArray implements FloatArrayVa
     }
 
     public static PackedFloatArray fromPackedArray(byte[] packedArray, int dimension) {
+        Objects.requireNonNull(packedArray, "packedArray must not be null");
         return fromPackedArray(packedArray, 0, packedArray.length, dimension);
     }
 

--- a/server/src/main/java/org/opensearch/index/mapper/extrasource/PackedFloatArray.java
+++ b/server/src/main/java/org/opensearch/index/mapper/extrasource/PackedFloatArray.java
@@ -11,7 +11,6 @@ package org.opensearch.index.mapper.extrasource;
 import org.opensearch.core.common.bytes.BytesArray;
 import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.core.common.io.stream.StreamInput;
-import org.opensearch.core.common.io.stream.StreamOutput;
 
 import java.io.IOException;
 import java.util.Objects;
@@ -32,14 +31,7 @@ import java.util.Objects;
  * transiently materialize/allocate more than once, but results are equivalent.</p>
  */
 
-final class PackedFloatArray implements FloatArrayValue {
-
-    private final BytesReference packed;
-    private final int dimension;
-
-    // Lazily materialized backing for fast decoding
-    private volatile byte[] bytes;
-    private volatile int bytesOffset;
+final class PackedFloatArray extends AbstractPackedArray implements FloatArrayValue {
 
     private volatile float[] cached;
 
@@ -59,77 +51,22 @@ final class PackedFloatArray implements FloatArrayValue {
     }
 
     private PackedFloatArray(BytesReference packed, int dimension, byte[] bytes, int bytesOffset) {
-        this.packed = packed;
-        this.dimension = dimension;
-        this.bytes = bytes;
-        this.bytesOffset = bytesOffset;
-        validate(packed.length(), dimension);
-    }
-
-    @Override
-    public int dimension() {
-        return dimension;
-    }
-
-    @Override
-    public boolean isPackedLE() {
-        return true;
-    }
-
-    @Override
-    public BytesReference packedBytes() {
-        return packed;
-    }
-
-    @Override
-    public void writePayloadTo(StreamOutput out) throws IOException {
-        out.writeVInt(dimension());
-        out.writeBytesReference(packed);
+        super(packed, dimension, bytes, bytesOffset, Float.BYTES, "float");
     }
 
     static PackedFloatArray readBodyFrom(StreamInput in, int dim) throws IOException {
         return fromPackedBytes(in.readBytesReference(), dim);
     }
 
-    private void ensureBytes() {
-        if (bytes != null) {
-            return;
-        }
-
-        byte[] arr;
-        int off;
-
-        // Avoid compaction/copy for the common array-backed case
-        // Otherwise, compact once if needed (composite/paged/etc).
-        if (packed instanceof BytesArray ba) {
-            arr = ba.array();
-            off = ba.offset();
-        } else {
-            arr = BytesReference.toBytes(packed);
-            off = 0;
-        }
-
-        bytesOffset = off;
-        bytes = arr;
-    }
-
-    private float decodeAt(final int p) {
-        final byte[] a = bytes;
-        final int bits = (a[p] & 0xFF) | ((a[p + 1] & 0xFF) << 8) | ((a[p + 2] & 0xFF) << 16) | ((a[p + 3] & 0xFF) << 24);
-        return Float.intBitsToFloat(bits);
-    }
-
     @Override
     public float get(int i) {
-        if (i < 0 || i >= dimension) {
-            throw new IndexOutOfBoundsException("i=" + i + " dim=" + dimension);
-        }
+        checkIndex(i);
         float[] v = cached;
         if (v != null) {
             return v[i];
         }
         ensureBytes();
-        return decodeAt(bytesOffset + (i << 2));
+        return decodeFloatLEAt(bytesOffset + i * Float.BYTES);
     }
 
     @Override
@@ -142,26 +79,11 @@ final class PackedFloatArray implements FloatArrayValue {
         v = new float[dimension];
         int p = bytesOffset;
         for (int i = 0; i < dimension; i++) {
-            v[i] = decodeAt(p);
-            p += 4;
+            v[i] = decodeFloatLEAt(p);
+            p += Float.BYTES;
         }
 
         cached = v;
         return v;
-    }
-
-    private static void validate(int byteLen, int dim) {
-        if (dim < 0) {
-            throw new IllegalArgumentException("dimension must be >= 0 (got " + dim + ")");
-        }
-        final int expected;
-        try {
-            expected = Math.multiplyExact(dim, 4);
-        } catch (ArithmeticException e) {
-            throw new IllegalArgumentException("dimension too large: " + dim, e);
-        }
-        if (byteLen != expected) {
-            throw new IllegalArgumentException("Bad packed float length=" + byteLen + " expected=" + expected + " (dim=" + dim + ")");
-        }
     }
 }

--- a/server/src/main/java/org/opensearch/index/mapper/extrasource/PackedFloatArray.java
+++ b/server/src/main/java/org/opensearch/index/mapper/extrasource/PackedFloatArray.java
@@ -65,8 +65,8 @@ final class PackedFloatArray extends AbstractPackedArray implements FloatArrayVa
         if (v != null) {
             return v[i];
         }
-        ensureBytes();
-        return decodeFloatLEAt(bytesOffset + i * Float.BYTES);
+        ResolvedBytes resolved = ensureBytes();
+        return decodeFloatLEAt(resolved.bytes, resolved.offset + i * Float.BYTES);
     }
 
     @Override
@@ -74,12 +74,12 @@ final class PackedFloatArray extends AbstractPackedArray implements FloatArrayVa
         float[] v = cached;
         if (v != null) return v;
 
-        ensureBytes();
+        ResolvedBytes resolved = ensureBytes();
 
         v = new float[dimension];
-        int p = bytesOffset;
+        int p = resolved.offset;
         for (int i = 0; i < dimension; i++) {
-            v[i] = decodeFloatLEAt(p);
+            v[i] = decodeFloatLEAt(resolved.bytes, p);
             p += Float.BYTES;
         }
 

--- a/server/src/main/java/org/opensearch/index/mapper/extrasource/PackedIntArray.java
+++ b/server/src/main/java/org/opensearch/index/mapper/extrasource/PackedIntArray.java
@@ -54,8 +54,8 @@ final class PackedIntArray extends AbstractPackedArray implements IntArrayValue 
         if (v != null) {
             return v[i];
         }
-        ensureBytes();
-        return decodeIntLEAt(bytesOffset + i * Integer.BYTES);
+        ResolvedBytes resolved = ensureBytes();
+        return decodeIntLEAt(resolved.bytes, resolved.offset + i * Integer.BYTES);
     }
 
     @Override
@@ -63,12 +63,12 @@ final class PackedIntArray extends AbstractPackedArray implements IntArrayValue 
         int[] v = cached;
         if (v != null) return v;
 
-        ensureBytes();
+        ResolvedBytes resolved = ensureBytes();
 
         v = new int[dimension];
-        int p = bytesOffset;
+        int p = resolved.offset;
         for (int i = 0; i < dimension; i++) {
-            v[i] = decodeIntLEAt(p);
+            v[i] = decodeIntLEAt(resolved.bytes, p);
             p += Integer.BYTES;
         }
 

--- a/server/src/main/java/org/opensearch/index/mapper/extrasource/PackedIntArray.java
+++ b/server/src/main/java/org/opensearch/index/mapper/extrasource/PackedIntArray.java
@@ -30,6 +30,7 @@ final class PackedIntArray extends AbstractPackedArray implements IntArrayValue 
     }
 
     static PackedIntArray fromPackedArray(byte[] packedArray, int dimension) {
+        Objects.requireNonNull(packedArray, "packedArray must not be null");
         return fromPackedArray(packedArray, 0, packedArray.length, dimension);
     }
 

--- a/server/src/main/java/org/opensearch/index/mapper/extrasource/PackedIntArray.java
+++ b/server/src/main/java/org/opensearch/index/mapper/extrasource/PackedIntArray.java
@@ -1,0 +1,78 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.mapper.extrasource;
+
+import org.opensearch.core.common.bytes.BytesArray;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.common.io.stream.StreamInput;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * Packed little-endian ints.
+ *
+ * <p>Canonical storage is a {@link BytesReference} for efficient transport.</p>
+ */
+final class PackedIntArray extends AbstractPackedArray implements IntArrayValue {
+
+    private volatile int[] cached;
+
+    static PackedIntArray fromPackedBytes(BytesReference packed, int dimension) {
+        Objects.requireNonNull(packed, "packed must not be null");
+        return new PackedIntArray(packed, dimension, null, 0);
+    }
+
+    static PackedIntArray fromPackedArray(byte[] packedArray, int dimension) {
+        return fromPackedArray(packedArray, 0, packedArray.length, dimension);
+    }
+
+    static PackedIntArray fromPackedArray(byte[] packedArray, int offset, int length, int dimension) {
+        Objects.requireNonNull(packedArray, "packedArray must not be null");
+        BytesReference packed = new BytesArray(packedArray, offset, length);
+        return new PackedIntArray(packed, dimension, packedArray, offset);
+    }
+
+    private PackedIntArray(BytesReference packed, int dimension, byte[] bytes, int bytesOffset) {
+        super(packed, dimension, bytes, bytesOffset, Integer.BYTES, "int");
+    }
+
+    static PackedIntArray readBodyFrom(StreamInput in, int dim) throws IOException {
+        return fromPackedBytes(in.readBytesReference(), dim);
+    }
+
+    @Override
+    public int get(int i) {
+        checkIndex(i);
+        int[] v = cached;
+        if (v != null) {
+            return v[i];
+        }
+        ensureBytes();
+        return decodeIntLEAt(bytesOffset + i * Integer.BYTES);
+    }
+
+    @Override
+    public int[] asIntArray() {
+        int[] v = cached;
+        if (v != null) return v;
+
+        ensureBytes();
+
+        v = new int[dimension];
+        int p = bytesOffset;
+        for (int i = 0; i < dimension; i++) {
+            v[i] = decodeIntLEAt(p);
+            p += Integer.BYTES;
+        }
+
+        cached = v;
+        return v;
+    }
+}

--- a/server/src/main/java/org/opensearch/index/mapper/extrasource/PackedLongArray.java
+++ b/server/src/main/java/org/opensearch/index/mapper/extrasource/PackedLongArray.java
@@ -30,6 +30,7 @@ final class PackedLongArray extends AbstractPackedArray implements LongArrayValu
     }
 
     static PackedLongArray fromPackedArray(byte[] packedArray, int dimension) {
+        Objects.requireNonNull(packedArray, "packedArray must not be null");
         return fromPackedArray(packedArray, 0, packedArray.length, dimension);
     }
 

--- a/server/src/main/java/org/opensearch/index/mapper/extrasource/PackedLongArray.java
+++ b/server/src/main/java/org/opensearch/index/mapper/extrasource/PackedLongArray.java
@@ -1,0 +1,78 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.mapper.extrasource;
+
+import org.opensearch.core.common.bytes.BytesArray;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.common.io.stream.StreamInput;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * Packed little-endian longs.
+ *
+ * <p>Canonical storage is a {@link BytesReference} for efficient transport.</p>
+ */
+final class PackedLongArray extends AbstractPackedArray implements LongArrayValue {
+
+    private volatile long[] cached;
+
+    static PackedLongArray fromPackedBytes(BytesReference packed, int dimension) {
+        Objects.requireNonNull(packed, "packed must not be null");
+        return new PackedLongArray(packed, dimension, null, 0);
+    }
+
+    static PackedLongArray fromPackedArray(byte[] packedArray, int dimension) {
+        return fromPackedArray(packedArray, 0, packedArray.length, dimension);
+    }
+
+    static PackedLongArray fromPackedArray(byte[] packedArray, int offset, int length, int dimension) {
+        Objects.requireNonNull(packedArray, "packedArray must not be null");
+        BytesReference packed = new BytesArray(packedArray, offset, length);
+        return new PackedLongArray(packed, dimension, packedArray, offset);
+    }
+
+    private PackedLongArray(BytesReference packed, int dimension, byte[] bytes, int bytesOffset) {
+        super(packed, dimension, bytes, bytesOffset, Long.BYTES, "long");
+    }
+
+    static PackedLongArray readBodyFrom(StreamInput in, int dim) throws IOException {
+        return fromPackedBytes(in.readBytesReference(), dim);
+    }
+
+    @Override
+    public long get(int i) {
+        checkIndex(i);
+        long[] v = cached;
+        if (v != null) {
+            return v[i];
+        }
+        ensureBytes();
+        return decodeLongLEAt(bytesOffset + i * Long.BYTES);
+    }
+
+    @Override
+    public long[] asLongArray() {
+        long[] v = cached;
+        if (v != null) return v;
+
+        ensureBytes();
+
+        v = new long[dimension];
+        int p = bytesOffset;
+        for (int i = 0; i < dimension; i++) {
+            v[i] = decodeLongLEAt(p);
+            p += Long.BYTES;
+        }
+
+        cached = v;
+        return v;
+    }
+}

--- a/server/src/main/java/org/opensearch/index/mapper/extrasource/PackedLongArray.java
+++ b/server/src/main/java/org/opensearch/index/mapper/extrasource/PackedLongArray.java
@@ -54,8 +54,8 @@ final class PackedLongArray extends AbstractPackedArray implements LongArrayValu
         if (v != null) {
             return v[i];
         }
-        ensureBytes();
-        return decodeLongLEAt(bytesOffset + i * Long.BYTES);
+        ResolvedBytes resolved = ensureBytes();
+        return decodeLongLEAt(resolved.bytes, resolved.offset + i * Long.BYTES);
     }
 
     @Override
@@ -63,12 +63,12 @@ final class PackedLongArray extends AbstractPackedArray implements LongArrayValu
         long[] v = cached;
         if (v != null) return v;
 
-        ensureBytes();
+        ResolvedBytes resolved = ensureBytes();
 
         v = new long[dimension];
-        int p = bytesOffset;
+        int p = resolved.offset;
         for (int i = 0; i < dimension; i++) {
-            v[i] = decodeLongLEAt(p);
+            v[i] = decodeLongLEAt(resolved.bytes, p);
             p += Long.BYTES;
         }
 

--- a/server/src/main/java/org/opensearch/index/mapper/extrasource/PrimitiveDoubleArray.java
+++ b/server/src/main/java/org/opensearch/index/mapper/extrasource/PrimitiveDoubleArray.java
@@ -15,33 +15,33 @@ import java.io.IOException;
 import java.util.Objects;
 
 /**
- * Primitive floats
- * This can be used by clients that already have float[].
+ * Primitive doubles.
+ * This can be used by clients that already have double[].
  */
-final class PrimitiveFloatArray extends AbstractPrimitiveArray implements FloatArrayValue {
-    private final float[] v;
+final class PrimitiveDoubleArray extends AbstractPrimitiveArray implements DoubleArrayValue {
+    private final double[] v;
 
-    public PrimitiveFloatArray(float[] v) {
+    PrimitiveDoubleArray(double[] v) {
         super(Objects.requireNonNull(v, "values must not be null").length);
         this.v = v;
     }
 
     @Override
-    public float get(int i) {
+    public double get(int i) {
         return v[i];
     }
 
     @Override
-    public float[] asFloatArray() {
+    public double[] asDoubleArray() {
         return v;
     }
 
     @Override
     public void writePayloadTo(StreamOutput out) throws IOException {
-        out.writeFloatArray(v);
+        out.writeDoubleArray(v);
     }
 
-    static PrimitiveFloatArray readBodyFrom(StreamInput in) throws IOException {
-        return new PrimitiveFloatArray(in.readFloatArray());
+    static PrimitiveDoubleArray readBodyFrom(StreamInput in) throws IOException {
+        return new PrimitiveDoubleArray(in.readDoubleArray());
     }
 }

--- a/server/src/main/java/org/opensearch/index/mapper/extrasource/PrimitiveIntArray.java
+++ b/server/src/main/java/org/opensearch/index/mapper/extrasource/PrimitiveIntArray.java
@@ -15,33 +15,33 @@ import java.io.IOException;
 import java.util.Objects;
 
 /**
- * Primitive floats
- * This can be used by clients that already have float[].
+ * Primitive ints.
+ * This can be used by clients that already have int[].
  */
-final class PrimitiveFloatArray extends AbstractPrimitiveArray implements FloatArrayValue {
-    private final float[] v;
+final class PrimitiveIntArray extends AbstractPrimitiveArray implements IntArrayValue {
+    private final int[] v;
 
-    public PrimitiveFloatArray(float[] v) {
+    PrimitiveIntArray(int[] v) {
         super(Objects.requireNonNull(v, "values must not be null").length);
         this.v = v;
     }
 
     @Override
-    public float get(int i) {
+    public int get(int i) {
         return v[i];
     }
 
     @Override
-    public float[] asFloatArray() {
+    public int[] asIntArray() {
         return v;
     }
 
     @Override
     public void writePayloadTo(StreamOutput out) throws IOException {
-        out.writeFloatArray(v);
+        out.writeIntArray(v);
     }
 
-    static PrimitiveFloatArray readBodyFrom(StreamInput in) throws IOException {
-        return new PrimitiveFloatArray(in.readFloatArray());
+    static PrimitiveIntArray readBodyFrom(StreamInput in) throws IOException {
+        return new PrimitiveIntArray(in.readIntArray());
     }
 }

--- a/server/src/main/java/org/opensearch/index/mapper/extrasource/PrimitiveLongArray.java
+++ b/server/src/main/java/org/opensearch/index/mapper/extrasource/PrimitiveLongArray.java
@@ -15,33 +15,33 @@ import java.io.IOException;
 import java.util.Objects;
 
 /**
- * Primitive floats
- * This can be used by clients that already have float[].
+ * Primitive longs.
+ * This can be used by clients that already have long[].
  */
-final class PrimitiveFloatArray extends AbstractPrimitiveArray implements FloatArrayValue {
-    private final float[] v;
+final class PrimitiveLongArray extends AbstractPrimitiveArray implements LongArrayValue {
+    private final long[] v;
 
-    public PrimitiveFloatArray(float[] v) {
+    PrimitiveLongArray(long[] v) {
         super(Objects.requireNonNull(v, "values must not be null").length);
         this.v = v;
     }
 
     @Override
-    public float get(int i) {
+    public long get(int i) {
         return v[i];
     }
 
     @Override
-    public float[] asFloatArray() {
+    public long[] asLongArray() {
         return v;
     }
 
     @Override
     public void writePayloadTo(StreamOutput out) throws IOException {
-        out.writeFloatArray(v);
+        out.writeLongArray(v);
     }
 
-    static PrimitiveFloatArray readBodyFrom(StreamInput in) throws IOException {
-        return new PrimitiveFloatArray(in.readFloatArray());
+    static PrimitiveLongArray readBodyFrom(StreamInput in) throws IOException {
+        return new PrimitiveLongArray(in.readLongArray());
     }
 }

--- a/server/src/test/java/org/opensearch/index/mapper/extrasource/ExtraFieldValueTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/extrasource/ExtraFieldValueTests.java
@@ -14,6 +14,9 @@ import org.opensearch.core.common.bytes.BytesArray;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.test.OpenSearchTestCase;
 
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
@@ -39,7 +42,7 @@ public class ExtraFieldValueTests extends OpenSearchTestCase {
     }
 
     public void testFloatArrayWriteReadRoundTrip() throws Exception {
-        PrimitiveFloatArray v = new PrimitiveFloatArray(new float[] { 10.5f, -2.25f });
+        FloatArrayValue v = FloatArrayValue.fromFloatArray(new float[] { 10.5f, -2.25f });
 
         BytesStreamOutput out = new BytesStreamOutput();
         v.writeTo(out);
@@ -56,6 +59,114 @@ public class ExtraFieldValueTests extends OpenSearchTestCase {
         assertEquals(-2.25f, fav.get(1), 0.0f);
     }
 
+    public void testIntArrayWriteReadRoundTrip() throws Exception {
+        IntArrayValue v = IntArrayValue.fromIntArray(new int[] { 10, -2 });
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        v.writeTo(out);
+
+        StreamInput in = out.bytes().streamInput();
+        ExtraFieldValue read = ExtraFieldValue.readFrom(in);
+
+        assertThat(read, instanceOf(IntArrayValue.class));
+        IntArrayValue iav = (IntArrayValue) read;
+
+        assertThat(iav.type(), is(ExtraFieldValue.Type.INT_ARRAY));
+        assertThat(iav.dimension(), is(2));
+        assertThat(iav.get(0), is(10));
+        assertThat(iav.get(1), is(-2));
+    }
+
+    public void testLongArrayWriteReadRoundTrip() throws Exception {
+        LongArrayValue v = LongArrayValue.fromLongArray(new long[] { 10L, -2L });
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        v.writeTo(out);
+
+        StreamInput in = out.bytes().streamInput();
+        ExtraFieldValue read = ExtraFieldValue.readFrom(in);
+
+        assertThat(read, instanceOf(LongArrayValue.class));
+        LongArrayValue lav = (LongArrayValue) read;
+
+        assertThat(lav.type(), is(ExtraFieldValue.Type.LONG_ARRAY));
+        assertThat(lav.dimension(), is(2));
+        assertThat(lav.get(0), is(10L));
+        assertThat(lav.get(1), is(-2L));
+    }
+
+    public void testDoubleArrayWriteReadRoundTrip() throws Exception {
+        DoubleArrayValue v = DoubleArrayValue.fromDoubleArray(new double[] { 10.5d, -2.25d });
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        v.writeTo(out);
+
+        StreamInput in = out.bytes().streamInput();
+        ExtraFieldValue read = ExtraFieldValue.readFrom(in);
+
+        assertThat(read, instanceOf(DoubleArrayValue.class));
+        DoubleArrayValue dav = (DoubleArrayValue) read;
+
+        assertThat(dav.type(), is(ExtraFieldValue.Type.DOUBLE_ARRAY));
+        assertThat(dav.dimension(), is(2));
+        assertEquals(10.5d, dav.get(0), 0.0d);
+        assertEquals(-2.25d, dav.get(1), 0.0d);
+    }
+
+    public void testPackedIntArrayWriteReadRoundTrip() throws Exception {
+        int[] vals = new int[] { 10, -2 };
+        IntArrayValue v = IntArrayValue.fromPackedArray(packIntLE(vals), vals.length);
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        v.writeTo(out);
+
+        StreamInput in = out.bytes().streamInput();
+        ExtraFieldValue read = ExtraFieldValue.readFrom(in);
+
+        assertThat(read, instanceOf(IntArrayValue.class));
+        IntArrayValue iav = (IntArrayValue) read;
+
+        assertThat(iav.type(), is(ExtraFieldValue.Type.INT_ARRAY));
+        assertThat(iav.isPackedLE(), is(true));
+        assertArrayEquals(vals, iav.asIntArray());
+    }
+
+    public void testPackedLongArrayWriteReadRoundTrip() throws Exception {
+        long[] vals = new long[] { 10L, -2L };
+        LongArrayValue v = LongArrayValue.fromPackedArray(packLongLE(vals), vals.length);
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        v.writeTo(out);
+
+        StreamInput in = out.bytes().streamInput();
+        ExtraFieldValue read = ExtraFieldValue.readFrom(in);
+
+        assertThat(read, instanceOf(LongArrayValue.class));
+        LongArrayValue lav = (LongArrayValue) read;
+
+        assertThat(lav.type(), is(ExtraFieldValue.Type.LONG_ARRAY));
+        assertThat(lav.isPackedLE(), is(true));
+        assertArrayEquals(vals, lav.asLongArray());
+    }
+
+    public void testPackedDoubleArrayWriteReadRoundTrip() throws Exception {
+        double[] vals = new double[] { 10.5d, -2.25d };
+        DoubleArrayValue v = DoubleArrayValue.fromPackedArray(packDoubleLE(vals), vals.length);
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        v.writeTo(out);
+
+        StreamInput in = out.bytes().streamInput();
+        ExtraFieldValue read = ExtraFieldValue.readFrom(in);
+
+        assertThat(read, instanceOf(DoubleArrayValue.class));
+        DoubleArrayValue dav = (DoubleArrayValue) read;
+
+        assertThat(dav.type(), is(ExtraFieldValue.Type.DOUBLE_ARRAY));
+        assertThat(dav.isPackedLE(), is(true));
+        assertArrayEquals(vals, dav.asDoubleArray(), 0.0d);
+    }
+
     public void testUnknownTypeIdThrows() throws Exception {
         BytesStreamOutput out = new BytesStreamOutput();
 
@@ -66,5 +177,29 @@ public class ExtraFieldValueTests extends OpenSearchTestCase {
         StreamInput in = out.bytes().streamInput();
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> ExtraFieldValue.readFrom(in));
         assertThat(e.getMessage(), containsString("Unknown ExtraFieldValue.Type id"));
+    }
+
+    private static byte[] packIntLE(int[] vals) {
+        ByteBuffer buffer = ByteBuffer.allocate(vals.length * Integer.BYTES).order(ByteOrder.LITTLE_ENDIAN);
+        for (int value : vals) {
+            buffer.putInt(value);
+        }
+        return buffer.array();
+    }
+
+    private static byte[] packLongLE(long[] vals) {
+        ByteBuffer buffer = ByteBuffer.allocate(vals.length * Long.BYTES).order(ByteOrder.LITTLE_ENDIAN);
+        for (long value : vals) {
+            buffer.putLong(value);
+        }
+        return buffer.array();
+    }
+
+    private static byte[] packDoubleLE(double[] vals) {
+        ByteBuffer buffer = ByteBuffer.allocate(vals.length * Double.BYTES).order(ByteOrder.LITTLE_ENDIAN);
+        for (double value : vals) {
+            buffer.putDouble(value);
+        }
+        return buffer.array();
     }
 }

--- a/server/src/test/java/org/opensearch/index/mapper/extrasource/ExtraFieldValuesIngestTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/extrasource/ExtraFieldValuesIngestTests.java
@@ -81,7 +81,7 @@ public class ExtraFieldValuesIngestTests extends MapperServiceTestCase {
 
         var source = source(b -> b.field("other", "x"));
 
-        ExtraFieldValues efv = new ExtraFieldValues(Map.of("obj.vec", new PrimitiveFloatArray(new float[] { 10.5f, 20.25f })));
+        ExtraFieldValues efv = new ExtraFieldValues(Map.of("obj.vec", FloatArrayValue.fromFloatArray(new float[] { 10.5f, 20.25f })));
 
         SourceToParse stp = new SourceToParse(
             "test",
@@ -97,6 +97,62 @@ public class ExtraFieldValuesIngestTests extends MapperServiceTestCase {
         assertThat(doc.rootDoc().getField("obj.vec_type").binaryValue().utf8ToString(), is("FLOAT_ARRAY"));
         assertThat(doc.rootDoc().getField("obj.vec_dim").numericValue().intValue(), is(2));
         assertThat(doc.rootDoc().getField("obj.vec_f0").numericValue().floatValue(), is(10.5f));
+    }
+
+    public void testExtraFieldValues_numericArrayTypes() throws Exception {
+        DocumentMapper dm = createDocumentMapper(mapping(b -> {
+            b.startObject("int_field");
+            {
+                b.field("type", ExtraFieldValuesMapperPlugin.EXTRA_FIELDS_TEST);
+            }
+            b.endObject();
+            b.startObject("long_field");
+            {
+                b.field("type", ExtraFieldValuesMapperPlugin.EXTRA_FIELDS_TEST);
+            }
+            b.endObject();
+            b.startObject("double_field");
+            {
+                b.field("type", ExtraFieldValuesMapperPlugin.EXTRA_FIELDS_TEST);
+            }
+            b.endObject();
+        }));
+
+        var source = source(b -> b.field("other", "x"));
+
+        ExtraFieldValues efv = new ExtraFieldValues(
+            Map.of(
+                "int_field",
+                IntArrayValue.fromIntArray(new int[] { 10, 20 }),
+                "long_field",
+                LongArrayValue.fromLongArray(new long[] { 100L, 200L }),
+                "double_field",
+                DoubleArrayValue.fromDoubleArray(new double[] { 1.5d, 2.5d })
+            )
+        );
+
+        SourceToParse stp = new SourceToParse(
+            "test",
+            "1",
+            source.source(),
+            MediaType.fromMediaType(source.getMediaType().mediaType()),
+            null,
+            efv
+        );
+
+        ParsedDocument doc = dm.parse(stp);
+
+        assertThat(doc.rootDoc().getField("int_field_type").binaryValue().utf8ToString(), is("INT_ARRAY"));
+        assertThat(doc.rootDoc().getField("int_field_dim").numericValue().intValue(), is(2));
+        assertThat(doc.rootDoc().getField("int_field_i0").numericValue().intValue(), is(10));
+
+        assertThat(doc.rootDoc().getField("long_field_type").binaryValue().utf8ToString(), is("LONG_ARRAY"));
+        assertThat(doc.rootDoc().getField("long_field_dim").numericValue().intValue(), is(2));
+        assertThat(doc.rootDoc().getField("long_field_l0").numericValue().longValue(), is(100L));
+
+        assertThat(doc.rootDoc().getField("double_field_type").binaryValue().utf8ToString(), is("DOUBLE_ARRAY"));
+        assertThat(doc.rootDoc().getField("double_field_dim").numericValue().intValue(), is(2));
+        assertThat(doc.rootDoc().getField("double_field_d0").numericValue().doubleValue(), is(1.5d));
     }
 
     public void testExtraFieldValues_throwsIfNoMapper() throws Exception {

--- a/server/src/test/java/org/opensearch/index/mapper/extrasource/ExtraFieldValuesTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/extrasource/ExtraFieldValuesTests.java
@@ -61,7 +61,13 @@ public class ExtraFieldValuesTests extends OpenSearchTestCase {
                 "field_bytes",
                 new BytesValue(new BytesArray(new byte[] { 9, 8, 7 })),
                 "field_vec",
-                new PrimitiveFloatArray(new float[] { 1.25f, -3.75f })
+                FloatArrayValue.fromFloatArray(new float[] { 1.25f, -3.75f }),
+                "field_ints",
+                IntArrayValue.fromIntArray(new int[] { 10, -20 }),
+                "field_longs",
+                LongArrayValue.fromLongArray(new long[] { 100L, -200L }),
+                "field_doubles",
+                DoubleArrayValue.fromDoubleArray(new double[] { 2.5d, -4.5d })
             )
         );
 
@@ -72,7 +78,7 @@ public class ExtraFieldValuesTests extends OpenSearchTestCase {
         ExtraFieldValues read = new ExtraFieldValues(in);
 
         assertThat(read.isEmpty(), is(false));
-        assertThat(read.values().keySet(), containsInAnyOrder("field_bytes", "field_vec"));
+        assertThat(read.values().keySet(), containsInAnyOrder("field_bytes", "field_vec", "field_ints", "field_longs", "field_doubles"));
 
         ExtraFieldValue v1 = read.get("field_bytes");
         assertThat(v1, instanceOf(BytesValue.class));
@@ -86,5 +92,29 @@ public class ExtraFieldValuesTests extends OpenSearchTestCase {
         assertThat(fav.dimension(), is(2));
         assertEquals(1.25f, fav.get(0), 0.0f);
         assertEquals(-3.75f, fav.get(1), 0.0f);
+
+        ExtraFieldValue v3 = read.get("field_ints");
+        assertThat(v3, instanceOf(IntArrayValue.class));
+        IntArrayValue iav = (IntArrayValue) v3;
+        assertThat(iav.type(), is(ExtraFieldValue.Type.INT_ARRAY));
+        assertThat(iav.dimension(), is(2));
+        assertThat(iav.get(0), is(10));
+        assertThat(iav.get(1), is(-20));
+
+        ExtraFieldValue v4 = read.get("field_longs");
+        assertThat(v4, instanceOf(LongArrayValue.class));
+        LongArrayValue lav = (LongArrayValue) v4;
+        assertThat(lav.type(), is(ExtraFieldValue.Type.LONG_ARRAY));
+        assertThat(lav.dimension(), is(2));
+        assertThat(lav.get(0), is(100L));
+        assertThat(lav.get(1), is(-200L));
+
+        ExtraFieldValue v5 = read.get("field_doubles");
+        assertThat(v5, instanceOf(DoubleArrayValue.class));
+        DoubleArrayValue dav = (DoubleArrayValue) v5;
+        assertThat(dav.type(), is(ExtraFieldValue.Type.DOUBLE_ARRAY));
+        assertThat(dav.dimension(), is(2));
+        assertEquals(2.5d, dav.get(0), 0.0d);
+        assertEquals(-4.5d, dav.get(1), 0.0d);
     }
 }

--- a/server/src/test/java/org/opensearch/index/mapper/extrasource/ExtraTestFieldMapper.java
+++ b/server/src/test/java/org/opensearch/index/mapper/extrasource/ExtraTestFieldMapper.java
@@ -98,6 +98,21 @@ public class ExtraTestFieldMapper extends ParametrizedFieldMapper {
             if (fav.dimension() > 0) {
                 context.doc().add(new StoredField(fieldType().name() + "_f0", fav.get(0)));
             }
+        } else if (v instanceof IntArrayValue iav) {
+            context.doc().add(new StoredField(fieldType().name() + "_dim", iav.dimension()));
+            if (iav.dimension() > 0) {
+                context.doc().add(new StoredField(fieldType().name() + "_i0", iav.get(0)));
+            }
+        } else if (v instanceof LongArrayValue lav) {
+            context.doc().add(new StoredField(fieldType().name() + "_dim", lav.dimension()));
+            if (lav.dimension() > 0) {
+                context.doc().add(new StoredField(fieldType().name() + "_l0", lav.get(0)));
+            }
+        } else if (v instanceof DoubleArrayValue dav) {
+            context.doc().add(new StoredField(fieldType().name() + "_dim", dav.dimension()));
+            if (dav.dimension() > 0) {
+                context.doc().add(new StoredField(fieldType().name() + "_d0", dav.get(0)));
+            }
         } else {
             throw new MapperParsingException("Unsupported ExtraFieldValue impl: " + v.getClass().getName());
         }

--- a/server/src/test/java/org/opensearch/index/mapper/extrasource/NumericArrayValueTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/extrasource/NumericArrayValueTests.java
@@ -173,6 +173,20 @@ public class NumericArrayValueTests extends OpenSearchTestCase {
         assertThat(doubleError.getMessage(), containsString("values must not be null"));
     }
 
+    public void testPackedArrayFactoriesRejectNull() {
+        NullPointerException floatError = expectThrows(NullPointerException.class, () -> FloatArrayValue.fromPackedArray(null, 1));
+        assertThat(floatError.getMessage(), containsString("packedArray must not be null"));
+
+        NullPointerException intError = expectThrows(NullPointerException.class, () -> IntArrayValue.fromPackedArray(null, 1));
+        assertThat(intError.getMessage(), containsString("packedArray must not be null"));
+
+        NullPointerException longError = expectThrows(NullPointerException.class, () -> LongArrayValue.fromPackedArray(null, 1));
+        assertThat(longError.getMessage(), containsString("packedArray must not be null"));
+
+        NullPointerException doubleError = expectThrows(NullPointerException.class, () -> DoubleArrayValue.fromPackedArray(null, 1));
+        assertThat(doubleError.getMessage(), containsString("packedArray must not be null"));
+    }
+
     private static byte[] packIntLE(int[] vals) {
         ByteBuffer buffer = ByteBuffer.allocate(vals.length * Integer.BYTES).order(ByteOrder.LITTLE_ENDIAN);
         for (int value : vals) {

--- a/server/src/test/java/org/opensearch/index/mapper/extrasource/NumericArrayValueTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/extrasource/NumericArrayValueTests.java
@@ -1,0 +1,199 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.mapper.extrasource;
+
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
+
+public class NumericArrayValueTests extends OpenSearchTestCase {
+
+    public void testPrimitiveIntArray() throws Exception {
+        int[] vals = new int[] { 10, -2, 0, Integer.MIN_VALUE, Integer.MAX_VALUE };
+        IntArrayValue array = IntArrayValue.fromIntArray(vals);
+
+        assertThat(array.dimension(), is(vals.length));
+        assertThat(array.isPackedLE(), is(false));
+        assertThat(array.asIntArray(), sameInstance(vals));
+        for (int i = 0; i < vals.length; i++) {
+            assertThat(array.get(i), is(vals[i]));
+        }
+        expectThrows(IllegalStateException.class, array::packedBytes);
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        array.writePayloadTo(out);
+
+        StreamInput in = out.bytes().streamInput();
+        PrimitiveIntArray read = PrimitiveIntArray.readBodyFrom(in);
+        assertArrayEquals(vals, read.asIntArray());
+    }
+
+    public void testPackedIntArray() throws Exception {
+        int[] vals = new int[] { 10, -2, 0, Integer.MIN_VALUE, Integer.MAX_VALUE };
+        IntArrayValue array = IntArrayValue.fromPackedArray(packIntLE(vals), vals.length);
+
+        assertThat(array.dimension(), is(vals.length));
+        assertThat(array.isPackedLE(), is(true));
+        for (int i = 0; i < vals.length; i++) {
+            assertThat(array.get(i), is(vals[i]));
+        }
+        assertArrayEquals(vals, array.asIntArray());
+        assertThat(array.asIntArray(), sameInstance(array.asIntArray()));
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        array.writePayloadTo(out);
+
+        StreamInput in = out.bytes().streamInput();
+        assertThat(in.readVInt(), is(vals.length));
+        PackedIntArray read = PackedIntArray.readBodyFrom(in, vals.length);
+        assertArrayEquals(vals, read.asIntArray());
+
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> IntArrayValue.fromPackedArray(new byte[3], 1));
+        assertThat(e.getMessage(), containsString("Bad packed int length"));
+        expectThrows(IndexOutOfBoundsException.class, () -> array.get(-1));
+        expectThrows(IndexOutOfBoundsException.class, () -> array.get(vals.length));
+    }
+
+    public void testPrimitiveLongArray() throws Exception {
+        long[] vals = new long[] { 10L, -2L, 0L, Long.MIN_VALUE, Long.MAX_VALUE };
+        LongArrayValue array = LongArrayValue.fromLongArray(vals);
+
+        assertThat(array.dimension(), is(vals.length));
+        assertThat(array.isPackedLE(), is(false));
+        assertThat(array.asLongArray(), sameInstance(vals));
+        for (int i = 0; i < vals.length; i++) {
+            assertThat(array.get(i), is(vals[i]));
+        }
+        expectThrows(IllegalStateException.class, array::packedBytes);
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        array.writePayloadTo(out);
+
+        StreamInput in = out.bytes().streamInput();
+        PrimitiveLongArray read = PrimitiveLongArray.readBodyFrom(in);
+        assertArrayEquals(vals, read.asLongArray());
+    }
+
+    public void testPackedLongArray() throws Exception {
+        long[] vals = new long[] { 10L, -2L, 0L, Long.MIN_VALUE, Long.MAX_VALUE };
+        LongArrayValue array = LongArrayValue.fromPackedArray(packLongLE(vals), vals.length);
+
+        assertThat(array.dimension(), is(vals.length));
+        assertThat(array.isPackedLE(), is(true));
+        for (int i = 0; i < vals.length; i++) {
+            assertThat(array.get(i), is(vals[i]));
+        }
+        assertArrayEquals(vals, array.asLongArray());
+        assertThat(array.asLongArray(), sameInstance(array.asLongArray()));
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        array.writePayloadTo(out);
+
+        StreamInput in = out.bytes().streamInput();
+        assertThat(in.readVInt(), is(vals.length));
+        PackedLongArray read = PackedLongArray.readBodyFrom(in, vals.length);
+        assertArrayEquals(vals, read.asLongArray());
+
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> LongArrayValue.fromPackedArray(new byte[7], 1));
+        assertThat(e.getMessage(), containsString("Bad packed long length"));
+        expectThrows(IndexOutOfBoundsException.class, () -> array.get(-1));
+        expectThrows(IndexOutOfBoundsException.class, () -> array.get(vals.length));
+    }
+
+    public void testPrimitiveDoubleArray() throws Exception {
+        double[] vals = new double[] { 10.5d, -2.25d, 0d, Double.MIN_VALUE, Double.MAX_VALUE };
+        DoubleArrayValue array = DoubleArrayValue.fromDoubleArray(vals);
+
+        assertThat(array.dimension(), is(vals.length));
+        assertThat(array.isPackedLE(), is(false));
+        assertThat(array.asDoubleArray(), sameInstance(vals));
+        for (int i = 0; i < vals.length; i++) {
+            assertEquals(vals[i], array.get(i), 0.0d);
+        }
+        expectThrows(IllegalStateException.class, array::packedBytes);
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        array.writePayloadTo(out);
+
+        StreamInput in = out.bytes().streamInput();
+        PrimitiveDoubleArray read = PrimitiveDoubleArray.readBodyFrom(in);
+        assertArrayEquals(vals, read.asDoubleArray(), 0.0d);
+    }
+
+    public void testPackedDoubleArray() throws Exception {
+        double[] vals = new double[] { 10.5d, -2.25d, 0d, Double.MIN_VALUE, Double.MAX_VALUE };
+        DoubleArrayValue array = DoubleArrayValue.fromPackedArray(packDoubleLE(vals), vals.length);
+
+        assertThat(array.dimension(), is(vals.length));
+        assertThat(array.isPackedLE(), is(true));
+        for (int i = 0; i < vals.length; i++) {
+            assertEquals(vals[i], array.get(i), 0.0d);
+        }
+        assertArrayEquals(vals, array.asDoubleArray(), 0.0d);
+        assertThat(array.asDoubleArray(), sameInstance(array.asDoubleArray()));
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        array.writePayloadTo(out);
+
+        StreamInput in = out.bytes().streamInput();
+        assertThat(in.readVInt(), is(vals.length));
+        PackedDoubleArray read = PackedDoubleArray.readBodyFrom(in, vals.length);
+        assertArrayEquals(vals, read.asDoubleArray(), 0.0d);
+
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> DoubleArrayValue.fromPackedArray(new byte[7], 1));
+        assertThat(e.getMessage(), containsString("Bad packed double length"));
+        expectThrows(IndexOutOfBoundsException.class, () -> array.get(-1));
+        expectThrows(IndexOutOfBoundsException.class, () -> array.get(vals.length));
+    }
+
+    public void testPrimitiveArrayFactoriesRejectNull() {
+        NullPointerException floatError = expectThrows(NullPointerException.class, () -> FloatArrayValue.fromFloatArray(null));
+        assertThat(floatError.getMessage(), containsString("values must not be null"));
+
+        NullPointerException intError = expectThrows(NullPointerException.class, () -> IntArrayValue.fromIntArray(null));
+        assertThat(intError.getMessage(), containsString("values must not be null"));
+
+        NullPointerException longError = expectThrows(NullPointerException.class, () -> LongArrayValue.fromLongArray(null));
+        assertThat(longError.getMessage(), containsString("values must not be null"));
+
+        NullPointerException doubleError = expectThrows(NullPointerException.class, () -> DoubleArrayValue.fromDoubleArray(null));
+        assertThat(doubleError.getMessage(), containsString("values must not be null"));
+    }
+
+    private static byte[] packIntLE(int[] vals) {
+        ByteBuffer buffer = ByteBuffer.allocate(vals.length * Integer.BYTES).order(ByteOrder.LITTLE_ENDIAN);
+        for (int value : vals) {
+            buffer.putInt(value);
+        }
+        return buffer.array();
+    }
+
+    private static byte[] packLongLE(long[] vals) {
+        ByteBuffer buffer = ByteBuffer.allocate(vals.length * Long.BYTES).order(ByteOrder.LITTLE_ENDIAN);
+        for (long value : vals) {
+            buffer.putLong(value);
+        }
+        return buffer.array();
+    }
+
+    private static byte[] packDoubleLE(double[] vals) {
+        ByteBuffer buffer = ByteBuffer.allocate(vals.length * Double.BYTES).order(ByteOrder.LITTLE_ENDIAN);
+        for (double value : vals) {
+            buffer.putDouble(value);
+        }
+        return buffer.array();
+    }
+}


### PR DESCRIPTION
 Resolves [#22017](https://github.com/opensearch-project/OpenSearch/issues/22017)


**Add support for double, int and long to _ExtraFieldValue_**

Related [#20765](https://github.com/opensearch-project/OpenSearch/issues/20765)

 
This is part of broader contribution to support big vectors indexing in gRPC out of _source_ field.

https://github.com/opensearch-project/OpenSearch/issues/19638

 

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
