### PR TITLE
[Sandbox] Propagate index.sort.field to IndexedTableProvider

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/api.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/api.rs
@@ -949,6 +949,7 @@ pub async unsafe fn fetch_by_row_ids(
         shard_view.object_metas.as_ref(),
         shard_view.writer_generations.as_ref(),
         metadata_cache,
+        &shard_view.sort_fields,
     )
         .await
         .map_err(DataFusionError::Execution)?;

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_executor.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_executor.rs
@@ -176,6 +176,8 @@ pub async fn execute_indexed_query(
         table_path: shard_view.table_path.clone(),
         object_metas: shard_view.object_metas.clone(),
         writer_generations: shard_view.writer_generations.clone(),
+        sort_fields: shard_view.sort_fields.clone(),
+        sort_orders: shard_view.sort_orders.clone(),
         query_context: crate::query_tracker::QueryTrackingContext::new(context_id, runtime.runtime_env.memory_pool.clone(), crate::query_tracker::QueryType::Shard),
         table_name: table_name.clone(),
         indexed_config: None, // derive classification from tree
@@ -506,6 +508,8 @@ async unsafe fn execute_indexed_with_context_inner(
     let table_path = handle.table_path;
     let object_metas = handle.object_metas;
     let writer_generations = handle.writer_generations;
+    let sort_fields = handle.sort_fields;
+    let sort_orders = handle.sort_orders;
     let query_context = handle.query_context;
     let io_handle = handle.io_handle;
     // Extract context_id early so it can be captured by the per-segment closures
@@ -532,6 +536,7 @@ async unsafe fn execute_indexed_with_context_inner(
         object_metas.as_ref(),
         writer_generations.as_ref(),
         metadata_cache,
+        &sort_fields,
     )
     .await
     .map_err(DataFusionError::Execution)?;
@@ -890,6 +895,8 @@ async unsafe fn execute_indexed_with_context_inner(
         predicate_columns,
         emit_row_ids,
         prune_tree_config,
+        sort_fields: sort_fields.clone(),
+        sort_orders: sort_orders.clone(),
     }));
     ctx.register_table(&table_name, provider)?;
 

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/partitioning.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/partitioning.rs
@@ -25,6 +25,8 @@
 //! Ported verbatim from PR #21164.
 
 use super::stream::RowGroupInfo;
+use super::table_provider::SegmentFileInfo;
+use datafusion::common::ScalarValue;
 
 /// One contiguous chunk of row groups within a single segment.
 #[derive(Debug, Clone)]
@@ -146,4 +148,226 @@ pub fn compute_assignments(
     }
 
     assignments
+}
+
+/// Whether segments form a sorted chain on the lead `index.sort.field` column,
+/// determined from per-segment min/max footer stats: after sorting segments by
+/// `sort_min`, every segment's `sort_min` is strictly greater than the previous
+/// segment's `sort_max`. Same algorithm as DataFusion's
+/// `is_ordering_valid_for_file_groups` (`file_scan_config.rs:1347-1363`),
+/// applied at the segment-within-a-shard granularity.
+///
+/// Returns `false` when:
+/// - any segment has `sort_min`/`sort_max` set to `None` (treated as
+///   "can't prove a chain" — same as DataFusion's missing-stats handling),
+/// - any pair has overlapping ranges,
+/// - `partial_cmp` returns `None` (incomparable types).
+///
+/// Empty input → `false` (nothing to advertise).
+pub fn segments_chain_on_sort_key(segments: &[SegmentFileInfo]) -> bool {
+    if segments.is_empty() {
+        return false;
+    }
+
+    // Collect (min, max) for each segment; bail on the first None.
+    let mut bounds: Vec<(&ScalarValue, &ScalarValue)> = Vec::with_capacity(segments.len());
+    for seg in segments {
+        match (&seg.sort_min, &seg.sort_max) {
+            (Some(lo), Some(hi)) => bounds.push((lo, hi)),
+            _ => return false,
+        }
+    }
+
+    // Sort by min; bail if any pair is incomparable.
+    let mut order: Vec<usize> = (0..bounds.len()).collect();
+    let mut incomparable = false;
+    order.sort_by(|&a, &b| {
+        bounds[a].0.partial_cmp(bounds[b].0).unwrap_or_else(|| {
+            incomparable = true;
+            std::cmp::Ordering::Equal
+        })
+    });
+    if incomparable {
+        return false;
+    }
+
+    // Walk in sorted-by-min order: each segment's min must be > the previous segment's max.
+    for w in order.windows(2) {
+        let prev_max = bounds[w[0]].1;
+        let curr_min = bounds[w[1]].0;
+        match curr_min.partial_cmp(prev_max) {
+            Some(std::cmp::Ordering::Greater) => continue,
+            // Equal/less means overlap; None means incomparable.
+            _ => return false,
+        }
+    }
+    true
+}
+
+/// One-partition-per-segment assignment for the sort-aware path.
+///
+/// Used when:
+/// - `sort_fields` is non-empty,
+/// - `segments_chain_on_sort_key(...)` returned true,
+/// - `target_partitions >= segments.len()` (so the optimizer's
+///   `validated_output_ordering` chain check at `file_scan_config.rs:551`
+///   would accept the layout — vanilla path mirror).
+///
+/// Produces one `PartitionAssignment` per segment, ordered by `sort_min`
+/// ascending. Each assignment holds a single `SegmentChunk` covering all RGs
+/// of that segment in their physical (sorted) order — because the writer
+/// k-way-merges sorted chunks at finalize, RGs within a segment are in lead
+/// sort-key order.
+///
+/// Caller must handle the case where this is inappropriate (chain doesn't
+/// hold, target_partitions too low, sort fields empty) by falling back to
+/// the row-count-balanced `compute_assignments`.
+pub fn compute_assignments_one_per_segment(
+    segments: &[SegmentFileInfo],
+    layouts: &[SegmentLayout],
+) -> Vec<PartitionAssignment> {
+    debug_assert_eq!(segments.len(), layouts.len(),
+        "segments and layouts must match (one entry per segment)");
+    if segments.is_empty() {
+        return Vec::new();
+    }
+
+    // Order segments by sort_min — bail to existing partitioning if anything
+    // is missing (defensive; caller is supposed to have checked already).
+    let mut order: Vec<usize> = (0..segments.len()).collect();
+    let mut incomparable = false;
+    order.sort_by(|&a, &b| {
+        match (segments[a].sort_min.as_ref(), segments[b].sort_min.as_ref()) {
+            (Some(la), Some(lb)) => la.partial_cmp(lb).unwrap_or_else(|| {
+                incomparable = true;
+                std::cmp::Ordering::Equal
+            }),
+            // If we got here without sort_min on every segment, caller's
+            // invariant is broken; preserve original order rather than panic.
+            _ => {
+                incomparable = true;
+                std::cmp::Ordering::Equal
+            }
+        }
+    });
+    if incomparable {
+        // Fail safe: caller is supposed to have run the chain check, but if
+        // somehow we're here without comparable bounds, fall back to row-count
+        // partitioning so we don't produce an unsorted-but-claimed-sorted plan.
+        return compute_assignments(layouts, segments.len().max(1));
+    }
+
+    let mut assignments: Vec<PartitionAssignment> = Vec::with_capacity(segments.len());
+    for seg_idx in order {
+        let layout = &layouts[seg_idx];
+        if layout.row_groups.is_empty() {
+            continue;
+        }
+        let rg_indices: Vec<usize> = layout.row_groups.iter().map(|rg| rg.index).collect();
+        let first = layout.row_groups.first().unwrap();
+        let last = layout.row_groups.last().unwrap();
+        let doc_min = first.first_row as i32;
+        let doc_max = (last.first_row + last.num_rows) as i32;
+        assignments.push(PartitionAssignment {
+            chunks: vec![SegmentChunk {
+                segment_idx: seg_idx,
+                doc_min,
+                doc_max,
+                row_group_indices: rg_indices,
+            }],
+        });
+    }
+    assignments
+}
+
+/// Test-only variant of `segments_chain_on_sort_key` that takes the
+/// `(sort_min, sort_max)` pairs directly — the chain logic is independent of
+/// the rest of `SegmentFileInfo`. Public so unit tests can call it without
+/// constructing a full `ParquetMetaData`.
+#[cfg(test)]
+pub(crate) fn chain_on_sort_bounds(bounds: &[(Option<ScalarValue>, Option<ScalarValue>)]) -> bool {
+    if bounds.is_empty() {
+        return false;
+    }
+    let mut refs: Vec<(&ScalarValue, &ScalarValue)> = Vec::with_capacity(bounds.len());
+    for (lo, hi) in bounds {
+        match (lo, hi) {
+            (Some(lo), Some(hi)) => refs.push((lo, hi)),
+            _ => return false,
+        }
+    }
+    let mut order: Vec<usize> = (0..refs.len()).collect();
+    let mut incomparable = false;
+    order.sort_by(|&a, &b| {
+        refs[a].0.partial_cmp(refs[b].0).unwrap_or_else(|| {
+            incomparable = true;
+            std::cmp::Ordering::Equal
+        })
+    });
+    if incomparable {
+        return false;
+    }
+    for w in order.windows(2) {
+        let prev_max = refs[w[0]].1;
+        let curr_min = refs[w[1]].0;
+        match curr_min.partial_cmp(prev_max) {
+            Some(std::cmp::Ordering::Greater) => continue,
+            _ => return false,
+        }
+    }
+    true
+}
+
+#[cfg(test)]
+mod chain_tests {
+    use super::*;
+    use datafusion::common::ScalarValue;
+
+    fn s(lo: Option<i64>, hi: Option<i64>) -> (Option<ScalarValue>, Option<ScalarValue>) {
+        (
+            lo.map(|v| ScalarValue::Int64(Some(v))),
+            hi.map(|v| ScalarValue::Int64(Some(v))),
+        )
+    }
+
+    #[test]
+    fn empty_input_returns_false() {
+        assert!(!chain_on_sort_bounds(&[]));
+    }
+
+    #[test]
+    fn missing_stats_returns_false() {
+        let bounds = [s(Some(1), Some(10)), s(None, Some(20))];
+        assert!(!chain_on_sort_bounds(&bounds));
+    }
+
+    #[test]
+    fn disjoint_chain_returns_true() {
+        // Segments arrive in non-sorted order; the helper must sort them itself.
+        let bounds = [
+            s(Some(20), Some(30)),
+            s(Some(1), Some(10)),
+            s(Some(31), Some(40)),
+        ];
+        assert!(chain_on_sort_bounds(&bounds));
+    }
+
+    #[test]
+    fn touching_boundary_is_overlap() {
+        // Equality at the boundary doesn't chain — strict > only, matches DataFusion.
+        let bounds = [s(Some(1), Some(10)), s(Some(10), Some(20))];
+        assert!(!chain_on_sort_bounds(&bounds));
+    }
+
+    #[test]
+    fn overlapping_ranges_returns_false() {
+        let bounds = [s(Some(1), Some(15)), s(Some(10), Some(20))];
+        assert!(!chain_on_sort_bounds(&bounds));
+    }
+
+    #[test]
+    fn single_segment_with_stats_chains_trivially() {
+        let bounds = [s(Some(1), Some(10))];
+        assert!(chain_on_sort_bounds(&bounds));
+    }
 }

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/segment_info.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/segment_info.rs
@@ -25,9 +25,11 @@ use super::table_provider::SegmentFileInfo;
 use std::sync::Arc;
 
 use datafusion::catalog::Session;
+use datafusion::common::ScalarValue;
 use datafusion::datasource::file_format::parquet::ParquetFormat;
 use datafusion::datasource::file_format::FileFormat;
 use datafusion::execution::cache::cache_manager::FileMetadataCache;
+use datafusion::parquet::arrow::arrow_reader::statistics::StatisticsConverter;
 
 /// Parquet footer kv key under which the writer stamps the writer generation.
 /// Must match `parquet-data-format`'s `WRITER_GENERATION_KEY`.
@@ -52,6 +54,7 @@ pub async fn build_segments(
     object_metas: &[object_store::ObjectMeta],
     writer_generations: &[i64],
     metadata_cache: Arc<dyn FileMetadataCache>,
+    sort_fields: &[String],
 ) -> Result<(Vec<SegmentFileInfo>, arrow::datatypes::SchemaRef), String> {
     if object_metas.len() != writer_generations.len() {
         return Err(format!(
@@ -74,7 +77,7 @@ pub async fn build_segments(
         // RuntimeEnv that `infer_schema` uses below shares this data when
         // both are pointed at the same object location, so this isn't a
         // duplicated cold fetch in practice.
-        let (_file_schema, size, pq_meta) = parquet_bridge::load_parquet_metadata(
+        let (file_schema, size, pq_meta) = parquet_bridge::load_parquet_metadata(
             Arc::clone(&store),
             &meta.location,
             Arc::clone(&metadata_cache),
@@ -105,6 +108,17 @@ pub async fn build_segments(
         #[cfg(debug_assertions)]
         debug_assert_footer_generation_matches_catalog(&pq_meta, writer_generation, &meta.location);
 
+        // Compute per-segment min/max on the LEAD `index.sort.field` column.
+        // None,None when no sort field is configured, when the column isn't in this
+        // file's schema, when the type isn't supported by `StatisticsConverter`, or
+        // when any RG is missing stats. The per-RG min/max → segment min/max
+        // aggregation mirrors what DataFusion's `validated_output_ordering` does
+        // at `file_scan_config.rs:1347-1363` (chain check).
+        let (sort_min, sort_max) = match sort_fields.first() {
+            Some(lead) => compute_segment_sort_bounds(lead, &file_schema, &pq_meta),
+            None => (None, None),
+        };
+
         segments.push(SegmentFileInfo {
             writer_generation,
             max_doc,
@@ -113,6 +127,8 @@ pub async fn build_segments(
             row_groups,
             metadata: pq_meta,
             global_base,
+            sort_min,
+            sort_max,
         });
     }
 
@@ -174,6 +190,97 @@ fn debug_assert_footer_generation_matches_catalog(
         "parquet footer writer_generation ({}) disagrees with catalog ({}) for file {}",
         footer_gen, catalog_generation, location
     );
+}
+
+/// Read per-RG min/max stats for `lead_field` from the parquet footer and
+/// reduce them to a per-segment (min-of-mins, max-of-maxes) pair.
+///
+/// Returns `(None, None)` when:
+/// - `lead_field` is absent from this file's arrow schema (segment was
+///   written before that field existed),
+/// - `StatisticsConverter::try_new` rejects the type (logical types whose
+///   parquet-side stats can't decode losslessly),
+/// - any RG lacks stats for the column (one missing RG → "can't chain").
+///
+/// Mirrors how DataFusion's `MinMaxStatistics::new_from_files` aggregates
+/// per-file stats; we operate at the RG-within-a-segment granularity instead.
+fn compute_segment_sort_bounds(
+    lead_field: &str,
+    file_schema: &arrow::datatypes::SchemaRef,
+    pq_meta: &ParquetMetaData,
+) -> (Option<ScalarValue>, Option<ScalarValue>) {
+    if file_schema.index_of(lead_field).is_err() {
+        return (None, None);
+    }
+
+    let converter = match StatisticsConverter::try_new(
+        lead_field,
+        file_schema,
+        pq_meta.file_metadata().schema_descr(),
+    ) {
+        Ok(c) => c,
+        Err(_) => return (None, None),
+    };
+
+    let row_groups = pq_meta.row_groups();
+    if row_groups.is_empty() {
+        return (None, None);
+    }
+
+    let mins = match converter.row_group_mins(row_groups.iter()) {
+        Ok(arr) => arr,
+        Err(_) => return (None, None),
+    };
+    let maxes = match converter.row_group_maxes(row_groups.iter()) {
+        Ok(arr) => arr,
+        Err(_) => return (None, None),
+    };
+
+    // If any RG lacks stats, both arrays will have null entries at that
+    // position. Treat that as "can't chain" — a single missing RG poisons the
+    // whole-segment claim because we can't prove a chain across RGs.
+    if mins.null_count() > 0 || maxes.null_count() > 0 {
+        return (None, None);
+    }
+
+    // Reduce the per-RG stat arrays to (min-of-mins, max-of-maxes) by walking
+    // the rows as ScalarValues. We can't use arrow::compute::min/max directly
+    // because the result type isn't a ScalarValue without a per-DataType match.
+    // ScalarValue's PartialOrd handles all the supported types we'd see in a
+    // sort key (Int64/Date32/Date64/Timestamp/Utf8/etc.).
+    let mut acc_min: Option<ScalarValue> = None;
+    for i in 0..mins.len() {
+        let v = match ScalarValue::try_from_array(&*mins, i) {
+            Ok(v) => v,
+            Err(_) => return (None, None),
+        };
+        acc_min = Some(match acc_min.take() {
+            Some(prev) => match prev.partial_cmp(&v) {
+                Some(std::cmp::Ordering::Less) | Some(std::cmp::Ordering::Equal) => prev,
+                Some(std::cmp::Ordering::Greater) => v,
+                None => return (None, None),
+            },
+            None => v,
+        });
+    }
+
+    let mut acc_max: Option<ScalarValue> = None;
+    for i in 0..maxes.len() {
+        let v = match ScalarValue::try_from_array(&*maxes, i) {
+            Ok(v) => v,
+            Err(_) => return (None, None),
+        };
+        acc_max = Some(match acc_max.take() {
+            Some(prev) => match prev.partial_cmp(&v) {
+                Some(std::cmp::Ordering::Greater) | Some(std::cmp::Ordering::Equal) => prev,
+                Some(std::cmp::Ordering::Less) => v,
+                None => return (None, None),
+            },
+            None => v,
+        });
+    }
+
+    (acc_min, acc_max)
 }
 
 #[cfg(test)]
@@ -263,6 +370,7 @@ mod tests {
             &metas,
             &gens,
             default_metadata_cache(),
+            &[],
         )
         .await
         .unwrap();
@@ -319,6 +427,7 @@ mod tests {
             &metas,
             &gens,
             default_metadata_cache(),
+            &[],
         )
         .await
         .unwrap();
@@ -385,6 +494,7 @@ mod tests {
             &metas_ab,
             &gens_ab,
             default_metadata_cache(),
+            &[],
         )
         .await
         .unwrap();
@@ -394,6 +504,7 @@ mod tests {
             &metas_ba,
             &gens_ba,
             default_metadata_cache(),
+            &[],
         )
         .await
         .unwrap();
@@ -446,6 +557,7 @@ mod tests {
             &metas,
             &gens,
             default_metadata_cache(),
+            &[],
         )
         .await;
         assert!(

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/table_provider.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/table_provider.rs
@@ -35,9 +35,11 @@ use datafusion::datasource::TableType;
 use datafusion::execution::SendableRecordBatchStream;
 use datafusion::logical_expr::{Expr, TableProviderFilterPushDown};
 use datafusion::parquet::file::metadata::ParquetMetaData;
-use datafusion::physical_expr::{EquivalenceProperties, Partitioning};
+use datafusion::physical_expr::{EquivalenceProperties, LexOrdering, Partitioning, PhysicalSortExpr};
+use datafusion::physical_expr::expressions::col as physical_col;
+use datafusion::arrow::compute::SortOptions;
 use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
-use datafusion::physical_plan::metrics::{ExecutionPlanMetricsSet, MetricsSet};
+use datafusion::physical_plan::metrics::{Count, ExecutionPlanMetricsSet, MetricBuilder, MetricsSet};
 use datafusion::physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties};
 use datafusion_common::DataFusionError;
 use datafusion::physical_optimizer::pruning::PruningPredicate;
@@ -49,8 +51,11 @@ use super::bool_tree::BoolNode;
 use super::eval::RowGroupBitsetSource;
 use super::metrics::PartitionMetrics;
 use super::parquet_bridge::ReadIoStats;
-use super::partitioning::{compute_assignments, PartitionAssignment, SegmentChunk, SegmentLayout};
-use super::stream::{IndexedExec, RowGroupInfo};
+use super::partitioning::{
+    compute_assignments, compute_assignments_one_per_segment, segments_chain_on_sort_key,
+    PartitionAssignment, SegmentChunk, SegmentLayout,
+};
+use super::stream::{FilterStrategy, IndexedExec, RowGroupInfo};
 use crate::datafusion_query_config::DatafusionQueryConfig;
 use crate::indexed_table::metrics::StreamMetrics;
 use crate::indexed_table::page_pruner::StatsPruneTree;
@@ -75,6 +80,14 @@ pub struct SegmentFileInfo {
     /// Cumulative row count from all preceding segments. Used to compute
     /// shard-global row IDs: `global_base + rg.first_row + position_in_rg`.
     pub global_base: u64,
+    /// Min/max of the LEAD `index.sort.field` column across all row groups
+    /// in this segment, read from parquet footer column statistics.
+    /// Both `None` when no sort field is configured, when any RG is missing
+    /// stats for the lead column, or when the column type isn't supported by
+    /// `StatisticsConverter`. `None` means the segment cannot participate in
+    /// the chain decision (treated as "can't chain").
+    pub sort_min: Option<datafusion::common::ScalarValue>,
+    pub sort_max: Option<datafusion::common::ScalarValue>,
 }
 
 /// Factory: build a `RowGroupBitsetSource` for one `SegmentChunk`.
@@ -105,6 +118,46 @@ pub type EvaluatorFactory = Arc<
         + Send
         + Sync,
 >;
+
+/// Build a `LexOrdering` from `sort_fields` / `sort_orders` against the given
+/// projected schema, mirroring DataFusion's `create_ordering`
+/// (`physical-expr/src/physical_expr.rs:134`):
+/// - on first column that doesn't resolve, **break** out of the loop and
+///   keep whatever prefix we built (the rest is "violated"),
+/// - returns `None` when the prefix is empty (no useful claim to advertise).
+///
+/// Direction strings are `"asc"` / `"desc"` (lowercase, as plumbed from Java).
+/// Nulls placement matches Lucene's convention: ASC → NULLS FIRST,
+/// DESC → NULLS LAST. Same as the vanilla path's `build_file_sort_order` in
+/// `session_context.rs`.
+fn build_projected_lex_ordering(
+    projected_schema: &SchemaRef,
+    sort_fields: &[String],
+    sort_orders: &[String],
+) -> Option<LexOrdering> {
+    if sort_fields.is_empty() {
+        return None;
+    }
+    let mut exprs: Vec<PhysicalSortExpr> = Vec::with_capacity(sort_fields.len());
+    for (i, field) in sort_fields.iter().enumerate() {
+        let phys = match physical_col(field, projected_schema) {
+            Ok(e) => e,
+            Err(_) => break,
+        };
+        let descending = sort_orders
+            .get(i)
+            .map(|s| s.eq_ignore_ascii_case("desc"))
+            .unwrap_or(false);
+        let ascending = !descending;
+        let opts = SortOptions {
+            descending,
+            // ASC → NULLS FIRST, DESC → NULLS LAST (matches Lucene + vanilla path).
+            nulls_first: ascending,
+        };
+        exprs.push(PhysicalSortExpr::new(phys, opts));
+    }
+    LexOrdering::new(exprs)
+}
 
 /// Configuration used to build an `IndexedTableProvider`.
 pub struct IndexedTableConfig {
@@ -146,6 +199,13 @@ pub struct IndexedTableConfig {
         Arc<std::collections::HashMap<usize, Arc<PruningPredicate>>>,
         SchemaRef,
     )>,
+    /// `index.sort.field` — column names that the parquet writer used to sort
+    /// rows on disk. Empty when the index has no `index.sort.field`.
+    pub sort_fields: Vec<String>,
+    /// Parallel to `sort_fields`. Each entry is `"asc"` or `"desc"` (lowercase,
+    /// matches the wire format from `DataFusionPlugin`). Same length as
+    /// `sort_fields` (validated at index creation).
+    pub sort_orders: Vec<String>,
 }
 
 /// Table provider. Returns a `QueryShardExec` that fans out across chunks.
@@ -285,15 +345,67 @@ impl TableProvider for IndexedTableProvider {
                 row_groups: seg.row_groups.clone(),
             })
             .collect();
-        let assignments =
-            compute_assignments(&layouts, self.config.query_config.target_partitions.max(1));
+
+        // Decide whether to use the sort-aware path: requires a configured
+        // index sort, segments that chain on the lead sort key (per-segment
+        // min/max are disjoint), `target_partitions >= num_segments` so the
+        // optimizer's chain check at `file_scan_config.rs:551` would accept,
+        // and that we're not on the QTF row-id-emit path (gated for v1).
+        let target_partitions = self.config.query_config.target_partitions.max(1);
+        let chain_ok = !self.config.sort_fields.is_empty()
+            && !self.config.emit_row_ids
+            && segments_chain_on_sort_key(&self.config.segments)
+            && target_partitions >= self.config.segments.len();
+
+        // Build the LexOrdering against the projected schema. If the lead
+        // sort field is projected away, this returns None and we fall back to
+        // the row-count partitioning. Mirror of `create_ordering` at
+        // `physical-expr/src/physical_expr.rs:134` — break on first
+        // unresolvable column rather than erroring out.
+        let lex_ordering = if chain_ok {
+            build_projected_lex_ordering(
+                &projected_schema,
+                &self.config.sort_fields,
+                &self.config.sort_orders,
+            )
+        } else {
+            None
+        };
+
+        let (assignments, eq_properties, advertised_ordering) = if chain_ok && lex_ordering.is_some() {
+            let assignments =
+                compute_assignments_one_per_segment(&self.config.segments, &layouts);
+            let lex = lex_ordering.unwrap();
+            let eq = EquivalenceProperties::new_with_orderings(
+                projected_schema.clone(),
+                vec![lex.clone()],
+            );
+            (assignments, eq, Some(lex))
+        } else {
+            let assignments = compute_assignments(&layouts, target_partitions);
+            (
+                assignments,
+                EquivalenceProperties::new(projected_schema.clone()),
+                None,
+            )
+        };
 
         let properties = Arc::new(PlanProperties::new(
-            EquivalenceProperties::new(projected_schema.clone()),
+            eq_properties,
             Partitioning::UnknownPartitioning(assignments.len().max(1)),
             EmissionType::Incremental,
             Boundedness::Bounded,
         ));
+
+        // Surface the sort-aware-path decision as a counter so it's visible in
+        // EXPLAIN ANALYZE / `metrics()` output: 1 when ordering was advertised
+        // (chain held + lead column projected + non-QTF), 0 otherwise.
+        let metrics = ExecutionPlanMetricsSet::new();
+        let ordering_optimized: Count =
+            MetricBuilder::new(&metrics).global_counter("ordering_optimized");
+        if advertised_ordering.is_some() {
+            ordering_optimized.add(1);
+        }
 
         Ok(Arc::new(QueryShardExec {
             config: Arc::clone(&self.config),
@@ -303,11 +415,12 @@ impl TableProvider for IndexedTableProvider {
             assignments,
             properties,
             predicate,
-            metrics: ExecutionPlanMetricsSet::new(),
+            metrics,
             inner_parquet_metrics: Arc::new(std::sync::Mutex::new(Vec::new())),
             io_stats: Arc::new(ReadIoStats::default()),
             row_id_output_index,
             dynamic_filters: Vec::new(),
+            advertised_ordering,
         }))
     }
 
@@ -347,6 +460,12 @@ pub struct QueryShardExec {
     /// are orthogonal to the Lucene/parquet boolean split. See
     /// `docs/dynamic-filters-indexed-table-impl.md` §4b.
     dynamic_filters: Vec<Arc<dyn datafusion::physical_expr::PhysicalExpr>>,
+    /// Sort ordering this scan claims to produce — `Some` only when the
+    /// sort-aware partitioning fired (chain holds + lead column is in the
+    /// projected schema). Each `IndexedExec` spawned by `execute()` advertises
+    /// the same ordering so DataFusion's `EnforceSorting` can substitute
+    /// `SortPreservingMergeExec` for the outer `SortExec(TopK)`.
+    advertised_ordering: Option<LexOrdering>,
 }
 
 impl fmt::Debug for QueryShardExec {
@@ -360,12 +479,38 @@ impl fmt::Debug for QueryShardExec {
 
 impl DisplayAs for QueryShardExec {
     fn fmt_as(&self, _t: DisplayFormatType, f: &mut std::fmt::Formatter) -> fmt::Result {
+        // `ordering=` shows whether the sort-aware path fired:
+        //   - `unsorted`: no `index.sort.field`, OR sort field set but the
+        //     sort-aware path didn't fire (chain didn't hold, target_partitions
+        //     too low, lead column projected away, or QTF row-id-emit gate).
+        //   - `sorted=[<col> ASC|DESC, ...]`: chain held, output_ordering
+        //     advertised → DataFusion can substitute SortPreservingMergeExec.
         write!(
             f,
-            "QueryShardExec: partitions={}, segments={}",
+            "QueryShardExec: partitions={}, segments={}, ordering={}",
             self.assignments.len(),
             self.config.segments.len(),
+            describe_ordering(&self.advertised_ordering),
         )
+    }
+}
+
+fn describe_ordering(ordering: &Option<LexOrdering>) -> String {
+    match ordering {
+        None => "unsorted".to_string(),
+        Some(lex) => {
+            use std::fmt::Write;
+            let mut s = String::from("sorted=[");
+            for (i, e) in lex.iter().enumerate() {
+                if i > 0 {
+                    s.push_str(", ");
+                }
+                let dir = if e.options.descending { "DESC" } else { "ASC" };
+                let _ = write!(&mut s, "{} {}", e.expr, dir);
+            }
+            s.push(']');
+            s
+        }
     }
 }
 
@@ -517,8 +662,23 @@ impl ExecutionPlan for QueryShardExec {
             let evaluator = (self.config.evaluator_factory)(segment, chunk, &stream_metrics, stats_prune_tree.as_ref())
                 .map_err(|e| DataFusionError::External(e.into()))?;
 
+            // When the sort-aware path fired (`advertised_ordering: Some`), the
+            // chain-aware partitioning guarantees this chunk is one whole
+            // segment, and the writer's k-way-merge guarantees rows in this
+            // segment are in lead-key order. So this `IndexedExec` produces a
+            // sorted run and we advertise the same ordering as the parent
+            // `QueryShardExec`. Without this, `EnforceSorting` can't see that
+            // input partitions are already sorted and won't substitute
+            // `SortPreservingMergeExec` for the outer `SortExec(TopK)`.
+            let exec_eq_props = match &self.advertised_ordering {
+                Some(lex) => EquivalenceProperties::new_with_orderings(
+                    self.projected_schema.clone(),
+                    vec![lex.clone()],
+                ),
+                None => EquivalenceProperties::new(self.projected_schema.clone()),
+            };
             let props = Arc::new(PlanProperties::new(
-                EquivalenceProperties::new(self.projected_schema.clone()),
+                exec_eq_props,
                 Partitioning::UnknownPartitioning(1),
                 EmissionType::Incremental,
                 Boundedness::Bounded,
@@ -630,6 +790,7 @@ impl QueryShardExec {
             io_stats: Arc::clone(&self.io_stats),
             row_id_output_index: self.row_id_output_index,
             dynamic_filters,
+            advertised_ordering: self.advertised_ordering.clone(),
         }
     }
 }
@@ -671,6 +832,8 @@ mod tests {
             predicate_columns: vec![],
             emit_row_ids: false,
             prune_tree_config: None,
+            sort_fields: vec![],
+            sort_orders: vec![],
         }
     }
 

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/constant_predicate.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/constant_predicate.rs
@@ -73,7 +73,9 @@ async fn run_constant_residual(residual: Arc<dyn PhysicalExpr>) -> usize {
         row_groups: rgs,
         metadata: Arc::clone(&parquet_meta),
         global_base: 0,
-    };
+            sort_min: None,
+        sort_max: None,
+};
 
     // FilterClass::None: no pruning predicate (column-less), constant applied
     // as residual in on_batch_mask.
@@ -110,7 +112,10 @@ async fn run_constant_residual(residual: Arc<dyn PhysicalExpr>) -> usize {
         pushdown_predicate: None,
         query_config: std::sync::Arc::new(qc),
         predicate_columns: vec![],
-        emit_row_ids: false, prune_tree_config: None,
+        emit_row_ids: false,
+        prune_tree_config: None,
+        sort_fields: vec![],
+        sort_orders: vec![],
     }));
 
     let ctx = SessionContext::new();

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/dynamic_filter_pushdown.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/dynamic_filter_pushdown.rs
@@ -131,7 +131,9 @@ async fn run_indexed(
         row_groups: rgs,
         metadata: Arc::clone(&parquet_meta),
         global_base: 0,
-    };
+            sort_min: None,
+        sort_max: None,
+};
 
     let factory: super::super::table_provider::EvaluatorFactory = {
         let schema = schema.clone();
@@ -185,6 +187,8 @@ async fn run_indexed(
         predicate_columns: vec![],
         emit_row_ids: false,
         prune_tree_config: None,
+        sort_fields: vec![],
+        sort_orders: vec![],
     }));
 
     let ctx = SessionContext::new();

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/fuzz/delegation.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/fuzz/delegation.rs
@@ -468,7 +468,10 @@ pub(in crate::indexed_table::tests_e2e) async fn execute_delegation_tree(
         pushdown_predicate: Some(Arc::clone(&residual_physical)),
         query_config: Arc::new(qc),
         predicate_columns: pred_cols,
-        emit_row_ids: false, prune_tree_config: None,
+        emit_row_ids: false,
+        prune_tree_config: None,
+        sort_fields: vec![],
+        sort_orders: vec![],
     }));
 
     let ctx = SessionContext::new();

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/fuzz/harness.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/fuzz/harness.rs
@@ -105,7 +105,9 @@ pub(in crate::indexed_table::tests_e2e) fn load_segment(corpus: &Corpus) -> Load
             row_groups: rgs,
             metadata: Arc::clone(&parquet_meta),
             global_base: 0,
-        });
+                    sort_min: None,
+            sort_max: None,
+});
         global_first_row += seg_rows as i64;
     }
     LoadedSegment {
@@ -291,7 +293,10 @@ pub(in crate::indexed_table::tests_e2e) async fn execute_tree_with_plan_pushdown
         pushdown_predicate: None,
         query_config: Arc::new(qc),
         predicate_columns: collect_predicate_column_indices(&bool_tree),
-        emit_row_ids: false, prune_tree_config: None,
+        emit_row_ids: false,
+        prune_tree_config: None,
+        sort_fields: vec![],
+        sort_orders: vec![],
     }));
 
     let ctx = SessionContext::new();
@@ -473,7 +478,10 @@ async fn run_single_collector_query(
         pushdown_predicate,
         query_config: Arc::new(qc),
         predicate_columns: pred_cols,
-        emit_row_ids: false, prune_tree_config: None,
+        emit_row_ids: false,
+        prune_tree_config: None,
+        sort_fields: vec![],
+        sort_orders: vec![],
     }));
     let ctx = SessionContext::new();
     ctx.register_table("t", provider).unwrap();
@@ -682,7 +690,10 @@ async fn run_with_factory_plan(
         pushdown_predicate,
         query_config: Arc::new(qc),
         predicate_columns: vec![],
-        emit_row_ids: false, prune_tree_config: None,
+        emit_row_ids: false,
+        prune_tree_config: None,
+        sort_fields: vec![],
+        sort_orders: vec![],
     }));
     let ctx = SessionContext::new();
     ctx.register_table("t", provider).unwrap();

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/mod.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/mod.rs
@@ -230,7 +230,9 @@ async fn run_tree_and_plan(
         row_groups: rgs,
         metadata: Arc::clone(&parquet_meta),
             global_base: 0,
-    };
+            sort_min: None,
+        sort_max: None,
+};
 
     // Normalize NOT push-down; build one collector per Collector leaf in DFS order.
     let tree = tree.push_not_down();
@@ -297,7 +299,10 @@ async fn run_tree_and_plan(
         pushdown_predicate: None,
         query_config: std::sync::Arc::new(qc),
         predicate_columns: vec![],
-        emit_row_ids: false, prune_tree_config: None,
+        emit_row_ids: false,
+        prune_tree_config: None,
+        sort_fields: vec![],
+        sort_orders: vec![],
     }));
 
     let ctx = SessionContext::new();

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/multi_segment.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/multi_segment.rs
@@ -131,7 +131,9 @@ async fn run_two_segment_query(
             row_groups: rgs,
             metadata: Arc::clone(&parquet_meta),
             global_base: 0,
-        });
+                    sort_min: None,
+            sort_max: None,
+});
     }
 
     let schema = schema_opt.unwrap();
@@ -185,7 +187,10 @@ async fn run_two_segment_query(
         pushdown_predicate: None,
         query_config: std::sync::Arc::new(qc),
         predicate_columns: vec![],
-        emit_row_ids: false, prune_tree_config: None,
+        emit_row_ids: false,
+        prune_tree_config: None,
+        sort_fields: vec![],
+        sort_orders: vec![],
     }));
 
     let ctx = SessionContext::new();
@@ -334,7 +339,9 @@ async fn run_two_segment_query_witness(
             row_groups: rgs,
             metadata: Arc::clone(&parquet_meta),
             global_base: 0,
-        });
+                    sort_min: None,
+            sort_max: None,
+});
     }
 
     let schema = schema_opt.unwrap();
@@ -392,7 +399,10 @@ async fn run_two_segment_query_witness(
         pushdown_predicate: None,
         query_config: std::sync::Arc::new(qc),
         predicate_columns: vec![],
-        emit_row_ids: false, prune_tree_config: None,
+        emit_row_ids: false,
+        prune_tree_config: None,
+        sort_fields: vec![],
+        sort_orders: vec![],
     }));
 
     let ctx = SessionContext::new();
@@ -547,7 +557,9 @@ async fn run_segments(specs: Vec<SegSpec>, num_partitions: usize) -> Vec<(i32, S
             row_groups: rgs,
             metadata: Arc::clone(&parquet_meta),
             global_base: 0,
-        });
+                    sort_min: None,
+            sort_max: None,
+});
     }
 
     let schema = schema_opt.unwrap();
@@ -597,7 +609,10 @@ async fn run_segments(specs: Vec<SegSpec>, num_partitions: usize) -> Vec<(i32, S
         pushdown_predicate: None,
         query_config: std::sync::Arc::new(qc),
         predicate_columns: vec![],
-        emit_row_ids: false, prune_tree_config: None,
+        emit_row_ids: false,
+        prune_tree_config: None,
+        sort_fields: vec![],
+        sort_orders: vec![],
     }));
 
     let ctx = SessionContext::new();
@@ -1038,7 +1053,9 @@ async fn run_wide_segments(
             row_groups: rgs,
             metadata: Arc::clone(&parquet_meta),
             global_base: 0,
-        });
+                    sort_min: None,
+            sort_max: None,
+});
     }
 
     let schema = schema_opt.unwrap();
@@ -1101,7 +1118,10 @@ async fn run_wide_segments(
         pushdown_predicate: None,
         query_config: std::sync::Arc::new(qc),
         predicate_columns: vec![],
-        emit_row_ids: false, prune_tree_config: None,
+        emit_row_ids: false,
+        prune_tree_config: None,
+        sort_fields: vec![],
+        sort_orders: vec![],
     }));
 
     let ctx = SessionContext::new();

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/null_columns.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/null_columns.rs
@@ -334,7 +334,9 @@ async fn assert_engine_matches_reference_null(name: &str, tree: NT) {
         row_groups: rgs,
         metadata: Arc::clone(&parquet_meta),
             global_base: 0,
-    };
+            sort_min: None,
+        sort_max: None,
+};
 
     let tree = Arc::new(bt);
     let per_leaf: Vec<(i32, Arc<dyn RowGroupDocsCollector>)> = collectors
@@ -382,7 +384,10 @@ async fn assert_engine_matches_reference_null(name: &str, tree: NT) {
         pushdown_predicate: None,
         query_config: std::sync::Arc::new(qc),
         predicate_columns: vec![],
-        emit_row_ids: false, prune_tree_config: None,
+        emit_row_ids: false,
+        prune_tree_config: None,
+        sort_fields: vec![],
+        sort_orders: vec![],
     }));
     let ctx = SessionContext::new();
     ctx.register_table("t", provider).unwrap();

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/page_pruning.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/page_pruning.rs
@@ -217,7 +217,9 @@ fn load_segment(tmp: &NamedTempFile) -> (SegmentFileInfo, SchemaRef) {
         row_groups: rgs,
         metadata: parquet_meta,
             global_base: 0,
-    };
+            sort_min: None,
+        sort_max: None,
+};
     (seg, schema)
 }
 
@@ -395,7 +397,10 @@ async fn execute_and_collect(
         pushdown_predicate: None,
         query_config: Arc::new(qc),
         predicate_columns: vec![],
-        emit_row_ids: false, prune_tree_config: None,
+        emit_row_ids: false,
+        prune_tree_config: None,
+        sort_fields: vec![],
+        sort_orders: vec![],
     }));
 
     let ctx = SessionContext::new();

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/qtf_fetch_phase.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/qtf_fetch_phase.rs
@@ -62,7 +62,9 @@ async fn query_phase(tree: BoolNode) -> Vec<i64> {
         row_groups: rgs,
         metadata: Arc::clone(&parquet_meta),
         global_base: 0,
-    };
+            sort_min: None,
+        sort_max: None,
+};
 
     let tree = tree.push_not_down();
     let collectors = wire_collectors(&tree);
@@ -123,7 +125,10 @@ async fn query_phase(tree: BoolNode) -> Vec<i64> {
             qc
         }),
         predicate_columns: vec![0, 1, 2, 3],
-        emit_row_ids: true, prune_tree_config: None,
+        emit_row_ids: true,
+        prune_tree_config: None,
+        sort_fields: vec![],
+        sort_orders: vec![],
     }));
 
     let ctx = SessionContext::new();

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/row_id_emission.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/row_id_emission.rs
@@ -52,7 +52,9 @@ async fn run_tree_row_ids(tree: BoolNode) -> Vec<i64> {
         row_groups: rgs,
         metadata: Arc::clone(&parquet_meta),
         global_base: 0,
-    };
+            sort_min: None,
+        sort_max: None,
+};
 
     let tree = tree.push_not_down();
     let collectors = wire_collectors(&tree);
@@ -113,7 +115,10 @@ async fn run_tree_row_ids(tree: BoolNode) -> Vec<i64> {
             qc
         }),
         predicate_columns: vec![0, 1, 2, 3],
-        emit_row_ids: true, prune_tree_config: None,
+        emit_row_ids: true,
+        prune_tree_config: None,
+        sort_fields: vec![],
+        sort_orders: vec![],
     }));
 
     let ctx = SessionContext::new();
@@ -217,7 +222,9 @@ async fn run_tree_row_ids_with_global_base(tree: BoolNode, global_base: u64) -> 
         row_groups: rgs,
         metadata: Arc::clone(&parquet_meta),
         global_base,
-    };
+            sort_min: None,
+        sort_max: None,
+};
 
     let tree = tree.push_not_down();
     let collectors = wire_collectors(&tree);
@@ -278,7 +285,10 @@ async fn run_tree_row_ids_with_global_base(tree: BoolNode, global_base: u64) -> 
             qc
         }),
         predicate_columns: vec![0, 1, 2, 3],
-        emit_row_ids: true, prune_tree_config: None,
+        emit_row_ids: true,
+        prune_tree_config: None,
+        sort_fields: vec![],
+        sort_orders: vec![],
     }));
 
     let ctx = SessionContext::new();
@@ -479,7 +489,9 @@ async fn test_row_id_with_data_columns() {
         row_groups: rgs,
         metadata: Arc::clone(&parquet_meta),
         global_base: 0,
-    };
+            sort_min: None,
+        sort_max: None,
+};
 
     // Filter: brand = "amazon" (rows 0,1,2,3,12)
     let tree = BoolNode::And(vec![index_leaf(0)]).push_not_down();
@@ -541,7 +553,10 @@ async fn test_row_id_with_data_columns() {
             qc
         }),
         predicate_columns: vec![0, 1, 2, 3],
-        emit_row_ids: true, prune_tree_config: None,
+        emit_row_ids: true,
+        prune_tree_config: None,
+        sort_fields: vec![],
+        sort_orders: vec![],
     }));
 
     let ctx = SessionContext::new();
@@ -719,7 +734,9 @@ async fn run_two_segments_row_ids(tree: BoolNode) -> Vec<i64> {
         row_groups: rgs1,
         metadata: Arc::clone(&parquet_meta1),
         global_base: 0,
-    };
+            sort_min: None,
+        sort_max: None,
+};
     let segment2 = SegmentFileInfo {
         writer_generation: 1,
         max_doc: 16,
@@ -728,7 +745,9 @@ async fn run_two_segments_row_ids(tree: BoolNode) -> Vec<i64> {
         row_groups: rgs2,
         metadata: Arc::clone(&parquet_meta2),
         global_base: 16,
-    };
+            sort_min: None,
+        sort_max: None,
+};
 
     let tree = tree.push_not_down();
     let collectors = wire_collectors(&tree);
@@ -789,7 +808,10 @@ async fn run_two_segments_row_ids(tree: BoolNode) -> Vec<i64> {
             qc
         }),
         predicate_columns: vec![0, 1, 2, 3],
-        emit_row_ids: true, prune_tree_config: None,
+        emit_row_ids: true,
+        prune_tree_config: None,
+        sort_fields: vec![],
+        sort_orders: vec![],
     }));
 
     let ctx = SessionContext::new();

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/schema_drift.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/schema_drift.rs
@@ -97,7 +97,9 @@ async fn run_missing_col_tree(tree_bool: BoolNode) -> usize {
         row_groups: rgs,
         metadata: Arc::clone(&parquet_meta),
             global_base: 0,
-    };
+            sort_min: None,
+        sort_max: None,
+};
 
     let tree = Arc::new(tree_bool);
     let factory: super::super::table_provider::EvaluatorFactory = {
@@ -137,7 +139,10 @@ async fn run_missing_col_tree(tree_bool: BoolNode) -> usize {
         pushdown_predicate: None,
         query_config: std::sync::Arc::new(qc),
         predicate_columns: vec![],
-        emit_row_ids: false, prune_tree_config: None,
+        emit_row_ids: false,
+        prune_tree_config: None,
+        sort_fields: vec![],
+        sort_orders: vec![],
     }));
     let ctx = SessionContext::new();
     ctx.register_table("t", provider).unwrap();
@@ -405,7 +410,9 @@ async fn query_with_mismatched_schema(
         row_groups: rgs,
         metadata: Arc::clone(&parquet_meta),
         global_base: 0,
-    };
+            sort_min: None,
+        sort_max: None,
+};
     let tree = Arc::new(tree_bool);
     let factory: super::super::table_provider::EvaluatorFactory = {
         let tree = Arc::clone(&tree);
@@ -445,7 +452,10 @@ async fn query_with_mismatched_schema(
         pushdown_predicate: None,
         query_config: std::sync::Arc::new(qc),
         predicate_columns: vec![],
-        emit_row_ids: false, prune_tree_config: None,
+        emit_row_ids: false,
+        prune_tree_config: None,
+        sort_fields: vec![],
+        sort_orders: vec![],
     }));
     let ctx = SessionContext::new();
     ctx.register_table("t", provider).unwrap();

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/streaming_at_scale.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/streaming_at_scale.rs
@@ -407,7 +407,9 @@ async fn run_large(
         row_groups: rgs,
         metadata: Arc::clone(&parquet_meta),
             global_base: 0,
-    };
+            sort_min: None,
+        sort_max: None,
+};
 
     let tree = Arc::new(tree);
     let per_leaf: Vec<(i32, Arc<dyn RowGroupDocsCollector>)> = collectors
@@ -454,7 +456,10 @@ async fn run_large(
         pushdown_predicate: None,
         query_config: std::sync::Arc::new(qc),
         predicate_columns: vec![],
-        emit_row_ids: false, prune_tree_config: None,
+        emit_row_ids: false,
+        prune_tree_config: None,
+        sort_fields: vec![],
+        sort_orders: vec![],
     }));
 
     let ctx = SessionContext::new();
@@ -860,7 +865,9 @@ async fn run_large_partitioned(
         row_groups: rgs,
         metadata: Arc::clone(&parquet_meta),
             global_base: 0,
-    };
+            sort_min: None,
+        sort_max: None,
+};
 
     let tree = Arc::new(tree);
     let per_leaf: Vec<(i32, Arc<dyn RowGroupDocsCollector>)> = collectors
@@ -906,7 +913,10 @@ async fn run_large_partitioned(
         pushdown_predicate: None,
         query_config: std::sync::Arc::new(qc),
         predicate_columns: vec![],
-        emit_row_ids: false, prune_tree_config: None,
+        emit_row_ids: false,
+        prune_tree_config: None,
+        sort_fields: vec![],
+        sort_orders: vec![],
     }));
     let ctx = SessionContext::new();
     ctx.register_table("t", provider).unwrap();

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/session_context.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/session_context.rs
@@ -42,6 +42,12 @@ pub struct SessionContextHandle {
     /// Java-side catalog snapshot via `create_reader`. Authoritative for stamping
     /// `SegmentFileInfo.writer_generation`; footer-kv reads are debug-only assertions.
     pub writer_generations: Arc<Vec<i64>>,
+    /// `index.sort.field` plumbed from the Java side (`ShardView.sort_fields`).
+    /// Empty when the index has no `index.sort.field`. Used by
+    /// `IndexedTableProvider` to decide whether to advertise `output_ordering`.
+    pub sort_fields: Vec<String>,
+    /// Parallel to `sort_fields`. Each entry is `"asc"` or `"desc"` (lowercase).
+    pub sort_orders: Vec<String>,
     pub query_context: QueryTrackingContext,
     pub table_name: String,
     /// When set, indicates this session uses the indexed execution path with filter delegation.
@@ -348,6 +354,8 @@ pub async unsafe fn create_session_context(
         table_path: shard_view.table_path.clone(),
         object_metas: shard_view.object_metas.clone(),
         writer_generations: shard_view.writer_generations.clone(),
+        sort_fields: shard_view.sort_fields.clone(),
+        sort_orders: shard_view.sort_orders.clone(),
         query_context,
         table_name: table_name.to_string(),
         indexed_config: None,
@@ -646,6 +654,8 @@ mod tests {
             table_path,
             object_metas: Arc::new(vec![]),
             writer_generations: Arc::new(vec![]),
+            sort_fields: vec![],
+            sort_orders: vec![],
             query_context,
             table_name: "t".to_string(),
             indexed_config: None,


### PR DESCRIPTION
## Description

Wires `index.sort.field` into the **indexed** query path — the path that fires when a `WHERE` clause includes a delegating predicate, routing through `IndexedTableProvider` / `QueryShardExec`.

Without this, indexed-path sort+limit queries pay a full TopK `SortExec` even though each segment is physically sorted on disk by the writer. After this PR, when per-segment sort-key min/max ranges chain disjointly and the slice budget allows one segment per partition, `QueryShardExec` advertises `output_ordering` and DataFusion's `EnforceSorting` substitutes `SortPreservingMergeExec` for the outer `SortExec(TopK)`, unlocking `sort_prefix` early termination.

## End-to-end verification

Tested on a controlled `sort_chain_test` index (4 segments, one day per segment so EventTime ranges chain disjointly).

**Before — `slice=1`, `target_partitions < num_segments` → falls back to row-count partitioning:**
```
ProjectionExec: expr=[EventTime@0 as EventTime, alpha as category]
  SortExec: TopK(fetch=10), expr=[EventTime@0 ASC], preserve_partitioning=[false]
    CooperativeExec
      QueryShardExec: partitions=1, segments=4, ordering=unsorted
```

**After — `slice=8`, `target_partitions ≥ num_segments` + chain holds → sort-aware path fires:**
```
ProjectionExec: expr=[EventTime@0 as EventTime, alpha as category]
  SortPreservingMergeExec: [EventTime@0 ASC], fetch=10
    QueryShardExec: partitions=4, segments=4, ordering=sorted=[EventTime@0 ASC]
```

Concrete confirmations: `ordering=sorted=[EventTime@0 ASC]` advertised on `QueryShardExec`; `SortPreservingMergeExec` replaces `SortExec(TopK)`; one partition per segment.

The `ordering=…` field is rendered by `QueryShardExec::DisplayAs` (added in this PR); a `Count` metric `ordering_optimized` (1 / 0) is published so the decision also surfaces in `EXPLAIN ANALYZE` / `metrics()` output.

## Background: why two paths

Dispatch in `api.rs::execute_query`:
- Substrait plan contains `index_filter(...)` UDF → indexed path (`execute_indexed_query` → `IndexedTableProvider` → `QueryShardExec`).
- Otherwise → vanilla path (`query_executor::execute_query` → `ListingTable` → `DataSourceExec`).

The indexed path uses a custom `TableProvider` so it needs its own plumbing of `index.sort.field` end-to-end (the vanilla path uses DataFusion's built-in `ListingOptions::with_file_sort_order(...)`).

## What this PR does

### Rust side

`IndexedTableConfig` now carries `sort_fields: Vec<String>` and `sort_orders: Vec<String>` (mirror of `ShardView`).

`SegmentFileInfo` gains `sort_min: Option<ScalarValue>` / `sort_max: Option<ScalarValue>`, populated in `build_segments` by reading per-RG min/max via `StatisticsConverter::row_group_mins / row_group_maxes` and reducing to a per-segment min/max for the LEAD sort field. `None` if any RG lacks stats — that segment can't participate in the chain decision.

Two new helpers in `partitioning.rs`:
- `segments_chain_on_sort_key(...)` — same chain check DataFusion does at `file_scan_config.rs:1347-1363`, applied at the segment-within-a-shard granularity. Sorts segments by `sort_min`, requires every segment's `sort_min` to be strictly greater than the previous segment's `sort_max`.
- `compute_assignments_one_per_segment(...)` — one `PartitionAssignment` per segment, in `sort_min` order. Used only when the chain holds AND `target_partitions ≥ num_segments`. Existing `compute_assignments` unchanged for the fallback path.

`IndexedTableProvider::scan` decides the sort-aware path when **all** of:
- `sort_fields` is non-empty,
- `emit_row_ids = false` (QTF row-id emit gated for v1 — `TODO` to revisit),
- `segments_chain_on_sort_key(...)` returned true,
- `target_partitions ≥ num_segments`,
- the lead sort column resolves against the projected schema.

When all five hold, it builds a `LexOrdering` (case-preserving via `physical_expr::expressions::col`, mirroring `create_ordering` — break-on-missing-col rather than error), advertises it via `EquivalenceProperties::new_with_orderings(...)` on `QueryShardExec`, and threads the same orderings down to each per-chunk `IndexedExec` so DataFusion's `EnforceSorting` can substitute `SortPreservingMergeExec` for the outer `SortExec(TopK)`.

### Java side

`ShardView.sort_fields` / `sort_orders` are threaded through `SessionContextHandle` → `IndexedTableConfig`.

### Observability

`QueryShardExec`'s `DisplayAs` reports the decision in plan dumps (see "End-to-end verification" above):
- `ordering=unsorted` — sort-aware path didn't fire,
- `ordering=sorted=[<col> ASC|DESC, ...]` — sort-aware path fired, ordering advertised.

A `Count` metric `ordering_optimized` (1 when fired, 0 otherwise) is published so the decision is visible in `EXPLAIN ANALYZE` / `metrics()`.

## Pre-conditions for the optimization to fire on a query

1. Query routes through the indexed path (WHERE has a delegating predicate — `=`, `!=`, `IS NULL`, `IS NOT NULL`, `LIKE`, `>`, `>=`, `<`, `<=`, IN/RANGE via `SARG`, or full-text functions).
2. The index has `index.sort.field` configured.
3. Source data has per-file disjoint min/max ranges on the sort key (globally pre-sorted ingest, naturally-temporal ingest, or range-partitioned ingest).
4. `search.concurrent_segment_search.mode != "none"`.
5. `search.concurrent.max_slice_count ≥ num_segments` so `target_partitions ≥ num_segments`.
6. Query's `ORDER BY` is a prefix of `index.sort.field` with matching directions.

If any pre-condition fails, the path falls back to the existing row-count-balanced partitioning. **Correctness is preserved in both regimes.**

## Testing

- 6 new unit tests in `partitioning::chain_tests`: empty input, missing stats, disjoint chain, touching boundary (counts as overlap), overlapping ranges, single-segment-with-stats. All passing.
- Existing `tests_e2e/*` configs updated to pass empty `sort_fields` / `sort_orders` (no behavior change for them).
- `cargo build --release` and `cargo build --tests --release` both green.
- End-to-end verified on a running cluster: bracketed `max_slice_count` (LOW=1, EQ=4, HIGH=8) on a 4-segment disjoint-EventTime test index; LOW shows `SortExec` + `ordering=unsorted`, EQ/HIGH show `SortPreservingMergeExec` + `ordering=sorted=[EventTime@0 ASC]` with no outer SortExec. See plan dumps in "End-to-end verification" above.

## DataFusion code pointers (branch 53)

- Chain validator: `datafusion/datasource/src/file_scan_config.rs:1347-1363` (`is_ordering_valid_for_file_groups`).
- Silent-empty trap on bad column lookup: `datafusion/physical-expr/src/physical_expr.rs:134` (`create_ordering`).
- `EquivalenceProperties::new_with_orderings`: `datafusion/physical-expr/src/equivalence/properties/mod.rs:221`.

### Check List

- [x] Functionality includes testing.
- [x] End-to-end verification on a running cluster.
- [ ] API changes companion pull request created, if applicable.
- [ ] Public documentation issue/PR created, if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.