### PR TITLE
Prototypical implementation of encryption support for the Parquet/DataFusion integration

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -32,3 +32,4 @@ systemProp.jdk.tls.client.protocols=TLSv1.2,TLSv1.3
 
 # jvm args for faster test execution by default
 systemProp.tests.jvm.argline=-XX:TieredStopAtLevel=1 -XX:ReservedCodeCacheSize=64m
+systemProp.sandbox.enabled=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -32,4 +32,3 @@ systemProp.jdk.tls.client.protocols=TLSv1.2,TLSv1.3
 
 # jvm args for faster test execution by default
 systemProp.tests.jvm.argline=-XX:TieredStopAtLevel=1 -XX:ReservedCodeCacheSize=64m
-systemProp.sandbox.enabled=true

--- a/sandbox/libs/dataformat-native/rust/Cargo.lock
+++ b/sandbox/libs/dataformat-native/rust/Cargo.lock
@@ -1021,6 +1021,7 @@ dependencies = [
  "foldhash 0.2.0",
  "half",
  "hashbrown 0.17.1",
+ "hex",
  "indexmap",
  "itertools 0.14.0",
  "libc",
@@ -1205,6 +1206,7 @@ dependencies = [
  "log",
  "object_store",
  "parking_lot",
+ "parquet",
  "rand 0.9.4",
  "tempfile",
  "url",
@@ -2874,6 +2876,7 @@ dependencies = [
  "substrait",
  "tempfile",
  "thiserror 1.0.69",
+ "thrift",
  "tokio",
  "tokio-metrics",
  "tokio-stream",
@@ -2902,10 +2905,14 @@ name = "opensearch-parquet-format"
 version = "0.1.0"
 dependencies = [
  "arrow",
+ "arrow-array",
+ "arrow-buffer",
  "arrow-ipc",
+ "arrow-schema",
  "crc32fast",
  "dashmap 5.5.3",
  "lazy_static",
+ "log",
  "native-bridge-common",
  "opensearch-parquet-format",
  "parquet",
@@ -3040,6 +3047,7 @@ dependencies = [
  "num-traits",
  "object_store",
  "paste",
+ "ring",
  "seq-macro",
  "simdutf8",
  "snap",
@@ -4217,6 +4225,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
+]
+
+[[package]]
 name = "thrift"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4224,7 +4241,9 @@ checksum = "7e54bc85fc7faa8bc175c4bab5b92ba8d9a3ce893d0e9f42cc455c8ab16a9e09"
 dependencies = [
  "byteorder",
  "integer-encoding",
+ "log",
  "ordered-float",
+ "threadpool",
 ]
 
 [[package]]

--- a/sandbox/libs/dataformat-native/src/main/java/org/opensearch/nativebridge/spi/NativeCall.java
+++ b/sandbox/libs/dataformat-native/src/main/java/org/opensearch/nativebridge/spi/NativeCall.java
@@ -125,6 +125,32 @@ public final class NativeCall implements AutoCloseable {
         return new StrArray(ptrs, lens, strings.length);
     }
 
+    /**
+     * Parallel pointer and length arrays for passing byte-array lists to native code.
+     */
+    public record ByteArrayList(MemorySegment ptrs, MemorySegment lens, long count) {
+    }
+
+    /**
+     * Marshal a Java byte[][] into parallel native arrays of pointers and lengths.
+     */
+    public ByteArrayList bytesArray(byte[][] arrays) {
+        ensureOpen();
+        if (arrays == null) {
+            throw new NullPointerException("Cannot marshal null byte array list to native");
+        }
+        MemorySegment ptrs = arena.allocate(ValueLayout.ADDRESS, arrays.length);
+        MemorySegment lens = arena.allocate(ValueLayout.JAVA_LONG, arrays.length);
+        for (int i = 0; i < arrays.length; i++) {
+            if (arrays[i] == null) {
+                throw new NullPointerException("Cannot marshal null byte array at index " + i);
+            }
+            ptrs.setAtIndex(ValueLayout.ADDRESS, i, arena.allocateFrom(ValueLayout.JAVA_BYTE, arrays[i]));
+            lens.setAtIndex(ValueLayout.JAVA_LONG, i, arrays[i].length);
+        }
+        return new ByteArrayList(ptrs, lens, arrays.length);
+    }
+
     // ---- Out-buffer with overflow detection ----
 
     /**

--- a/sandbox/plugins/analytics-backend-datafusion/build.gradle
+++ b/sandbox/plugins/analytics-backend-datafusion/build.gradle
@@ -102,6 +102,13 @@ dependencies {
   testImplementation project(':plugins:arrow-base')
   testCompileOnly 'org.immutables:value-annotations:2.8.8'
 
+  // Test-only: provides NativeParquetWriter + PmeKey* classes for writing encrypted Parquet files
+  // in DataFusionEncryptedQueryExecutionTests. Not part of the runtime plugin classpath.
+  // TODO: Possibly consolidate this to shared plugin
+  testImplementation project(':sandbox:plugins:parquet-data-format')
+  // plugin-stats-spi is compileOnly in parquet-data-format; expose it explicitly for tests
+  // that call NativeParquetWriter.write() / flush() which use StatsRecorder at runtime.
+  testImplementation project(':sandbox:libs:plugin-stats-spi')
 }
 
 test {

--- a/sandbox/plugins/analytics-backend-datafusion/rust/Cargo.toml
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["rlib"]
 
 [dependencies]
 libc = "0.2"
-datafusion = { workspace = true }
+datafusion = { workspace = true, features = ["parquet_encryption"] }
 datafusion-expr = { workspace = true }
 datafusion-datasource = { workspace = true }
 datafusion-common = { workspace = true }
@@ -46,6 +46,9 @@ async-trait = { workspace = true }
 chrono = { workspace = true }
 roaring = "=0.10.12"
 thiserror = { workspace = true }
+# Required to use thrift::protocol::TCompactInputProtocol for parsing
+# parquet::format::FileCryptoMetaData in pme_reader.rs.
+thrift = "=0.17.0"
 
 # convert_tz UDF
 chrono-tz = "=0.10.4"
@@ -103,6 +106,7 @@ proptest = { workspace = true }
 # Used only by tiered_storage_integration_tests.rs, which exercise FoyerCache /
 # TieredBlockCache directly through the TieredObjectStore.
 opensearch-block-cache = { path = "../../block-cache-foyer/src/main/rust" }
+bytes = { workspace = true }
 
 [[bench]]
 name = "query_bench"

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/api.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/api.rs
@@ -411,6 +411,10 @@ pub struct ShardView {
     /// Index sort directions per field — values: `"asc"` or `"desc"`.
     /// Parallel to `sort_fields`. Sourced from `index.sort.order`.
     pub sort_orders: Vec<String>,
+    /// Per-file footer keys for PME-encrypted files (filename → 32-byte AES-GCM key).
+    pub file_footer_keys: Arc<HashMap<String, Vec<u8>>>,
+    /// Per-file AAD prefixes for PME-encrypted files (filename → binary AAD prefix).
+    pub file_aad_prefixes: Arc<HashMap<String, Vec<u8>>>,
 }
 
 /// Creates a DataFusion global runtime with the given resource limits.
@@ -767,6 +771,8 @@ pub fn create_reader(
     writer_generations: Vec<i64>,
     sort_fields: Vec<String>,
     sort_orders: Vec<String>,
+    file_footer_keys: HashMap<String, Vec<u8>>,
+    file_aad_prefixes: HashMap<String, Vec<u8>>,
     tokio_rt_manager: &RuntimeManager,
     store_ptr: i64,
 ) -> Result<i64, DataFusionError> {
@@ -825,6 +831,8 @@ pub fn create_reader(
         store,
         sort_fields,
         sort_orders,
+        file_footer_keys: Arc::new(file_footer_keys),
+        file_aad_prefixes: Arc::new(file_aad_prefixes),
     };
     Ok(Box::into_raw(Box::new(shard_view)) as i64)
 }
@@ -907,6 +915,8 @@ pub async unsafe fn execute_query(
                 shard_view.object_metas.clone(),
                 table_name.to_string(),
                 plan_bytes.to_vec(),
+                shard_view.file_footer_keys.clone(),
+                shard_view.file_aad_prefixes.clone(),
                 runtime,
                 cpu_executor,
                 query_memory_pool,
@@ -956,7 +966,10 @@ pub async unsafe fn fetch_by_row_ids(
 ) -> Result<i64, DataFusionError> {
     use crate::indexed_table::row_selection::build_row_selection_with_min_skip_run;
     use crate::indexed_table::segment_info::build_segments;
-    use crate::query_executor::{store_url_from_table_path, wrap_stream_as_handle};
+    use crate::query_executor::{
+        build_query_runtime_env, store_url_from_table_path, wrap_stream_as_handle,
+        OpenSearchPmeDecryptionFactory, OPENSEARCH_PME_FACTORY_ID,
+    };
 
     // ── 1. Build RuntimeEnv + SessionContext ──
 
@@ -967,6 +980,18 @@ pub async unsafe fn fetch_by_row_ids(
         Arc::clone(&shard_view.store),
         None,
     )?;
+
+    // Register PME decryption factory when the shard contains encrypted files.
+    // Needed so infer_schema (via ParquetFormat::infer_schema) can decrypt footers.
+    if shard_view.file_footer_keys.is_empty() == false {
+        runtime_env.register_parquet_encryption_factory(
+            OPENSEARCH_PME_FACTORY_ID,
+            Arc::new(OpenSearchPmeDecryptionFactory::new(
+                Arc::clone(&shard_view.file_footer_keys),
+                Arc::clone(&shard_view.file_aad_prefixes),
+            )),
+        );
+    }
 
     let mut config = SessionConfig::new();
     config.options_mut().execution.parquet.pushdown_filters = true;
@@ -990,9 +1015,22 @@ pub async unsafe fn fetch_by_row_ids(
         shard_view.writer_generations.as_ref(),
         metadata_cache,
         &shard_view.sort_fields,
+        &shard_view.file_footer_keys,
+        &shard_view.file_aad_prefixes,
     )
         .await
         .map_err(DataFusionError::Execution)?;
+
+    // Build PME factory for column data decryption during scan.
+    let encryption_factory: Option<Arc<dyn datafusion_execution::parquet_encryption::EncryptionFactory>> =
+        if shard_view.file_footer_keys.is_empty() == false {
+            Some(Arc::new(OpenSearchPmeDecryptionFactory::new(
+                Arc::clone(&shard_view.file_footer_keys),
+                Arc::clone(&shard_view.file_aad_prefixes),
+            )))
+        } else {
+            None
+        };
 
     // Distribute global row_ids to per-file local positions.
     // Note: Java validates non-empty + ascending row_ids before the FFM call; we don't repeat that here.
@@ -1051,15 +1089,31 @@ pub async unsafe fn fetch_by_row_ids(
     // ── 3. Register ShardTableProvider ──
 
     let store_url = store_url_from_table_path(&shard_view.table_path)?;
-    let listing_options = datafusion::datasource::listing::ListingOptions::new(
-        Arc::new(datafusion::datasource::file_format::parquet::ParquetFormat::new())
-    ).with_file_extension(".parquet").with_collect_stat(true);
+
+    // For PME-encrypted shards, the ParquetFormat must carry factory_id so
+    // infer_schema can decrypt footers via the already-registered factory.
+    let listing_format: Arc<dyn datafusion::datasource::file_format::FileFormat> =
+        if shard_view.file_footer_keys.is_empty() == false {
+            use datafusion_common::config::TableParquetOptions;
+            let mut opts = TableParquetOptions::default();
+            opts.crypto.factory_id = Some(OPENSEARCH_PME_FACTORY_ID.to_owned());
+            Arc::new(
+                datafusion::datasource::file_format::parquet::ParquetFormat::new()
+                    .with_options(opts),
+            )
+        } else {
+            Arc::new(datafusion::datasource::file_format::parquet::ParquetFormat::new())
+        };
+    let listing_options = datafusion::datasource::listing::ListingOptions::new(listing_format)
+        .with_file_extension(".parquet")
+        .with_collect_stat(true);
     let resolved_schema = listing_options.infer_schema(&ctx.state(), &shard_view.table_path).await?;
 
     let provider = Arc::new(ShardTableProvider::new(ShardTableConfig {
         file_schema: resolved_schema,
         files,
         store_url,
+        encryption_factory,
     }));
     ctx.register_table("t", provider)?;
 
@@ -1409,6 +1463,8 @@ pub unsafe fn sql_to_substrait(
     let runtime = &*(runtime_ptr as *const DataFusionRuntime);
     let table_path = shard_view.table_path.clone();
     let object_metas = shard_view.object_metas.clone();
+    let file_footer_keys = shard_view.file_footer_keys.clone();
+    let file_aad_prefixes = shard_view.file_aad_prefixes.clone();
     let table_name = table_name.to_string();
 
     manager.io_runtime.block_on(async {
@@ -1422,6 +1478,30 @@ pub unsafe fn sql_to_substrait(
         );
         let runtime_env = crate::query_executor::query_runtime_env_builder(runtime, list_file_cache).build()?;
 
+        // Register the PME decryption factory and configure ParquetFormat with the factory_id
+        // so that infer_schema can read the encrypted Parquet footer.
+        // Note: registering the factory in RuntimeEnv alone is not sufficient — ParquetFormat
+        // must also have options.crypto.factory_id set, otherwise get_file_decryption_properties
+        // returns None and infer_schema fails with "encrypted footer but decryption properties
+        // were not provided".
+        let parquet_format = if file_footer_keys.is_empty() == false {
+            use crate::query_executor::OPENSEARCH_PME_FACTORY_ID;
+            use crate::query_executor::OpenSearchPmeDecryptionFactory;
+            use datafusion_common::config::TableParquetOptions;
+            runtime_env.register_parquet_encryption_factory(
+                OPENSEARCH_PME_FACTORY_ID,
+                Arc::new(OpenSearchPmeDecryptionFactory::new(
+                    Arc::clone(&file_footer_keys),
+                    Arc::clone(&file_aad_prefixes),
+                )),
+            );
+            let mut parquet_options = TableParquetOptions::default();
+            parquet_options.crypto.factory_id = Some(OPENSEARCH_PME_FACTORY_ID.to_owned());
+            ParquetFormat::new().with_options(parquet_options)
+        } else {
+            ParquetFormat::new()
+        };
+
         let state = SessionStateBuilder::new()
             .with_config(SessionConfig::new())
             .with_runtime_env(Arc::from(runtime_env))
@@ -1431,7 +1511,7 @@ pub unsafe fn sql_to_substrait(
         crate::udf::register_all(&ctx);
         crate::udaf::register_all(&ctx);
 
-        let listing_options = ListingOptions::new(Arc::new(ParquetFormat::new()))
+        let listing_options = ListingOptions::new(Arc::new(parquet_format))
             .with_file_extension(".parquet")
             .with_collect_stat(true);
         let schema = listing_options

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/cache/custom_cache_manager.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/cache/custom_cache_manager.rs
@@ -493,7 +493,7 @@ impl CustomCacheManager {
         let location = object_meta.location.clone();
         let meta = object_meta.clone();
         let (schema, _size, pq_meta) = rt_handle.block_on(async {
-            parquet_bridge::load_parquet_metadata_with_meta(store, &location, meta, metadata_cache).await
+            parquet_bridge::load_parquet_metadata_with_meta(store, &location, meta, metadata_cache, None).await
         })?;
 
         Ok(Some((schema, pq_meta)))

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/ffm.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/ffm.rs
@@ -12,6 +12,7 @@ use std::slice;
 use std::str;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
+use std::collections::HashMap;
 
 use log::warn;
 use native_bridge_common::ffm_safe;
@@ -57,6 +58,32 @@ use crate::cache::page_index;
 
 static TOKIO_RUNTIME_MANAGER: RwLock<Option<Arc<RuntimeManager>>> = RwLock::new(None);
 
+unsafe fn bytes_from_raw<'a>(ptr: *const u8, len: i64, arg_name: &str) -> Result<&'a [u8], String> {
+    if len < 0 {
+        return Err(format!("negative {} length: {}", arg_name, len));
+    }
+    if len == 0 {
+        return Ok(&[]);
+    }
+    if ptr.is_null() {
+        return Err(format!("null {} pointer", arg_name));
+    }
+    Ok(slice::from_raw_parts(ptr, len as usize))
+}
+
+unsafe fn ptr_array_from_raw<'a, T>(ptr: *const T, count: i64, arg_name: &str) -> Result<&'a [T], String> {
+    if count < 0 {
+        return Err(format!("negative {} count: {}", arg_name, count));
+    }
+    if count == 0 {
+        return Ok(&[]);
+    }
+    if ptr.is_null() {
+        return Err(format!("null {} pointer", arg_name));
+    }
+    Ok(slice::from_raw_parts(ptr, count as usize))
+}
+
 unsafe fn str_from_raw<'a>(ptr: *const u8, len: i64) -> Result<&'a str, String> {
     if ptr.is_null() {
         return Err("null string pointer".to_string());
@@ -66,6 +93,66 @@ unsafe fn str_from_raw<'a>(ptr: *const u8, len: i64) -> Result<&'a str, String> 
     }
     let bytes = slice::from_raw_parts(ptr, len as usize);
     str::from_utf8(bytes).map_err(|e| format!("invalid UTF-8: {}", e))
+}
+
+unsafe fn str_from_raw_named<'a>(ptr: *const u8, len: i64, arg_name: &str) -> Result<&'a str, String> {
+    if ptr.is_null() {
+        return Err(format!("null {} pointer", arg_name));
+    }
+    if len < 0 {
+        return Err(format!("negative {} length: {}", arg_name, len));
+    }
+
+    let bytes = bytes_from_raw(ptr, len, arg_name)?;
+    str::from_utf8(bytes).map_err(|e| format!("invalid UTF-8 for {}: {}", arg_name, e))
+}
+
+unsafe fn string_array_from_raw(
+    ptrs: *const *const u8,
+    lens: *const i64,
+    count: i64,
+    arg_name: &str,
+) -> Result<Vec<String>, String> {
+    let ptrs = ptr_array_from_raw(ptrs, count, &format!("{} pointers", arg_name))?;
+    let lens = ptr_array_from_raw(lens, count, &format!("{} lengths", arg_name))?;
+    let mut values = Vec::with_capacity(count.max(0) as usize);
+    for (idx, (&ptr, &len)) in ptrs.iter().zip(lens.iter()).enumerate() {
+        values.push(str_from_raw_named(ptr, len, &format!("{}[{}]", arg_name, idx))?.to_string());
+    }
+    Ok(values)
+}
+
+unsafe fn footer_keys_from_raw(
+    key_files_ptr: *const *const u8,
+    key_files_len_ptr: *const i64,
+    key_files_count: i64,
+    key_bytes_ptr: *const *const u8,
+    key_bytes_len_ptr: *const i64,
+    key_bytes_count: i64,
+) -> Result<HashMap<String, Vec<u8>>, String> {
+    if key_files_count != key_bytes_count {
+        return Err("key file and key byte counts must match".to_string());
+    }
+
+    let key_files = string_array_from_raw(key_files_ptr, key_files_len_ptr, key_files_count, "key_files")?;
+    let key_ptrs = ptr_array_from_raw(key_bytes_ptr, key_bytes_count, "key_bytes pointers")?;
+    let key_lens = ptr_array_from_raw(key_bytes_len_ptr, key_bytes_count, "key_bytes lengths")?;
+    let mut file_footer_keys = HashMap::with_capacity(key_files_count.max(0) as usize);
+
+    for (idx, ((file_name, &key_ptr), &key_len)) in key_files
+        .iter()
+        .zip(key_ptrs.iter())
+        .zip(key_lens.iter())
+        .enumerate()
+    {
+        let key = bytes_from_raw(key_ptr, key_len, &format!("key_bytes[{}]", idx))?.to_vec();
+        if key.is_empty() {
+            return Err(format!("empty footer key for file {}", file_name));
+        }
+        file_footer_keys.insert(file_name.clone(), key);
+    }
+
+    Ok(file_footer_keys)
 }
 
 fn get_rt_manager() -> Result<Arc<RuntimeManager>, String> {
@@ -255,6 +342,18 @@ pub unsafe extern "C" fn df_create_reader(
     sort_orders_ptr: *const *const u8,
     sort_orders_len_ptr: *const i64,
     sort_count: i64,
+    key_files_ptr: *const *const u8,
+    key_files_len_ptr: *const i64,
+    key_files_count: i64,
+    key_bytes_ptr: *const *const u8,
+    key_bytes_len_ptr: *const i64,
+    key_bytes_count: i64,
+    aad_files_ptr: *const *const u8,
+    aad_files_len_ptr: *const i64,
+    aad_files_count: i64,
+    aad_bytes_ptr: *const *const u8,
+    aad_bytes_len_ptr: *const i64,
+    aad_bytes_count: i64,
 ) -> i64 {
     let table_path = str_from_raw(table_path_ptr, table_path_len)
         .map_err(|e| format!("df_create_reader: {}", e))?;
@@ -292,6 +391,14 @@ pub unsafe extern "C" fn df_create_reader(
                 .to_string(),
         );
     }
+    let file_footer_keys = footer_keys_from_raw(
+        key_files_ptr, key_files_len_ptr, key_files_count,
+        key_bytes_ptr, key_bytes_len_ptr, key_bytes_count,
+    ).map_err(|e| format!("df_create_reader: {}", e))?;
+    let file_aad_prefixes = footer_keys_from_raw(
+        aad_files_ptr, aad_files_len_ptr, aad_files_count,
+        aad_bytes_ptr, aad_bytes_len_ptr, aad_bytes_count,
+    ).map_err(|e| format!("df_create_reader: {}", e))?;
     let mgr = get_rt_manager()?;
     api::create_reader(
         table_path,
@@ -299,6 +406,8 @@ pub unsafe extern "C" fn df_create_reader(
         writer_generations,
         sort_fields,
         sort_orders,
+        file_footer_keys,
+        file_aad_prefixes,
         &mgr,
         store_ptr,
     )
@@ -309,6 +418,102 @@ pub unsafe extern "C" fn df_create_reader(
 pub unsafe extern "C" fn df_close_reader(ptr: i64) {
     api::close_reader(ptr);
 }
+
+/// Read `FileCryptoMetaData.key_metadata` from the tail of a Parquet file via
+/// range reads against the object store identified by `store_ptr`.
+///
+/// Signature: `(table_path_ptr, table_path_len, filename_ptr, filename_len,
+///              store_ptr, out_buf_ptr, out_buf_cap, out_len_ptr) → i64`
+///
+/// Return values (success half ≥ 0):
+/// - `0` — encrypted file; `key_metadata` bytes written to `out_buf`; length in `*out_len_ptr`.
+/// - `1` — not encrypted (PAR1 magic) or no `key_metadata` present; `out_buf` unchanged.
+/// - `< 0` — error; negated pointer to a heap-allocated error string (freed by `checkResult`).
+///
+/// Java `NativeBridge.readFooterKeyMetadata` maps 0→bytes, 1→null, <0→throw.
+#[ffm_safe]
+#[no_mangle]
+pub unsafe extern "C" fn df_read_footer_key_metadata(
+    table_path_ptr: *const u8,
+    table_path_len: i64,
+    filename_ptr: *const u8,
+    filename_len: i64,
+    store_ptr: i64,
+    out_buf_ptr: *mut u8,
+    out_buf_cap: i64,
+    out_len_ptr: *mut i64,
+) -> i64 {
+    use datafusion::execution::runtime_env::RuntimeEnvBuilder;
+    use datafusion::datasource::listing::ListingTableUrl;
+
+    let table_path = str_from_raw(table_path_ptr, table_path_len)
+        .map_err(|e| format!("df_read_footer_key_metadata: {}", e))?;
+    let filename = str_from_raw(filename_ptr, filename_len)
+        .map_err(|e| format!("df_read_footer_key_metadata: {}", e))?;
+    if out_buf_ptr.is_null() {
+        return Err("df_read_footer_key_metadata: null out_buf_ptr".to_string());
+    }
+    if out_len_ptr.is_null() {
+        return Err("df_read_footer_key_metadata: null out_len_ptr".to_string());
+    }
+    if out_buf_cap <= 0 {
+        return Err(format!("df_read_footer_key_metadata: out_buf_cap must be positive, got {}", out_buf_cap));
+    }
+
+    // Resolve the object store: same logic as `create_reader` in `api.rs`.
+    let store: std::sync::Arc<dyn object_store::ObjectStore> = if store_ptr > 0 {
+        // store_ptr > 0: warm / tiered shard. The value is a pointer to a
+        // heap-allocated `Arc<dyn ObjectStore>` created by `TieredStorageBridge` /
+        // `ParquetDataFormatStoreHandler` and kept alive by the Java
+        // `NativeStoreHandle` for the duration of this call.
+        // SAFETY: lifetime is guaranteed by the caller.
+        let boxed = &*(store_ptr as *const std::sync::Arc<dyn object_store::ObjectStore>);
+        std::sync::Arc::clone(boxed)
+    } else {
+        // store_ptr == 0: hot / local shard. Build a minimal throw-away
+        // `RuntimeEnv` with the DataFusion defaults, which registers a
+        // `LocalFileSystem` object store for `file://` URLs and absolute paths.
+        // The `RuntimeEnv` is dropped immediately after the two range reads
+        // complete; it carries no cached state and does not interact with the
+        // global DataFusion runtime.
+        let table_url = ListingTableUrl::parse(table_path)
+            .map_err(|e| format!("df_read_footer_key_metadata: invalid table path: {}", e))?;
+        let default_rt = RuntimeEnvBuilder::new()
+            .build()
+            .map_err(|e| format!("df_read_footer_key_metadata: runtime build failed: {}", e))?;
+        default_rt
+            .object_store(&table_url)
+            .map_err(|e| format!("df_read_footer_key_metadata: object_store resolution failed: {}", e))?
+    };
+
+    let mgr = get_rt_manager()?;
+    // Issues exactly two `ObjectStore::get_range` calls — one for the 8-byte
+    // tail (magic + `FileCryptoMetaData` length) and one for the Thrift payload.
+    // The full file is never downloaded.
+    let result = timed_block_on(
+        &mgr.io_runtime,
+        "read_footer_key_metadata",
+        crate::pme_reader::read_footer_key_metadata(store.as_ref(), table_path, filename),
+    )
+    .map_err(|e| e.to_string())?;
+
+    match result {
+        None => Ok(1), // not encrypted / no key_metadata
+        Some(bytes) => {
+            let len = bytes.len() as i64;
+            if len > out_buf_cap {
+                return Err(format!(
+                    "df_read_footer_key_metadata: key_metadata ({} bytes) exceeds out_buf_cap ({})",
+                    len, out_buf_cap
+                ));
+            }
+            std::ptr::copy_nonoverlapping(bytes.as_ptr(), out_buf_ptr, bytes.len());
+            *out_len_ptr = len;
+            Ok(0)
+        }
+    }
+}
+
 
 #[ffm_safe]
 #[no_mangle]
@@ -561,6 +766,12 @@ pub unsafe extern "C" fn df_sql_to_substrait(
         .map_err(|e| format!("df_sql_to_substrait: table_name: {}", e))?;
     let sql =
         str_from_raw(sql_ptr, sql_len).map_err(|e| format!("df_sql_to_substrait: sql: {}", e))?;
+    if out_cap < 0 {
+        return Err(format!("df_sql_to_substrait: negative output capacity: {}", out_cap));
+    }
+    if out_cap > 0 && out_ptr.is_null() {
+        return Err("df_sql_to_substrait: null output buffer pointer".to_string());
+    }
     let bytes = api::sql_to_substrait(shard_view_ptr, table_name, sql, runtime_ptr, &mgr)
         .map_err(|e| e.to_string())?;
     write_out_buffer(&bytes, out_ptr, out_cap, out_len, "substrait plan")?;
@@ -1621,4 +1832,82 @@ mod tests {
         // ── Cleanup ──
         shutdown_test_runtime();
     }
+
+    #[test]
+    fn test_bytes_from_raw_rejects_negative_length() {
+        let err = unsafe { bytes_from_raw(std::ptr::null(), -1, "plan") }.unwrap_err();
+        assert!(err.contains("negative plan length"));
+    }
+
+    #[test]
+    fn test_string_array_from_raw_rejects_missing_lengths_pointer() {
+        let value = b"file.parquet";
+        let ptrs = [value.as_ptr()];
+        let err = unsafe { string_array_from_raw(ptrs.as_ptr(), std::ptr::null(), 1, "files") }.unwrap_err();
+        assert!(err.contains("null files lengths pointer"));
+    }
+
+    #[test]
+    fn test_footer_keys_from_raw_rejects_count_mismatch() {
+        let err = unsafe {
+            footer_keys_from_raw(
+                std::ptr::null(),
+                std::ptr::null(),
+                1,
+                std::ptr::null(),
+                std::ptr::null(),
+                0,
+            )
+        }
+        .unwrap_err();
+        assert!(err.contains("counts must match"));
+    }
+
+    #[test]
+    fn test_footer_keys_from_raw_rejects_empty_key() {
+        let file = b"test.parquet";
+        let key: [u8; 0] = [];
+        let file_ptrs = [file.as_ptr()];
+        let file_lens = [file.len() as i64];
+        let key_ptrs = [key.as_ptr()];
+        let key_lens = [0_i64];
+
+        let err = unsafe {
+            footer_keys_from_raw(
+                file_ptrs.as_ptr(),
+                file_lens.as_ptr(),
+                1,
+                key_ptrs.as_ptr(),
+                key_lens.as_ptr(),
+                1,
+            )
+        }
+        .unwrap_err();
+        assert!(err.contains("empty footer key for file test.parquet"));
+    }
+
+    #[test]
+    fn test_footer_keys_from_raw_parses_valid_input() {
+        let file = b"test.parquet";
+        let key = [1_u8, 2, 3, 4];
+        let file_ptrs = [file.as_ptr()];
+        let file_lens = [file.len() as i64];
+        let key_ptrs = [key.as_ptr()];
+        let key_lens = [key.len() as i64];
+
+        let keys = unsafe {
+            footer_keys_from_raw(
+                file_ptrs.as_ptr(),
+                file_lens.as_ptr(),
+                1,
+                key_ptrs.as_ptr(),
+                key_lens.as_ptr(),
+                1,
+            )
+        }
+        .unwrap();
+
+        assert_eq!(keys.get("test.parquet"), Some(&key.to_vec()));
+    }
 }
+

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/helper.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/helper.rs
@@ -106,7 +106,20 @@ pub async fn register_listing_table(
     sort_fields: &[String],
     sort_orders: &[String],
 ) -> Result<(), DataFusionError> {
-    let mut listing_options = ListingOptions::new(Arc::new(ParquetFormat::new()))
+    register_listing_table_with_format(ctx, table_name, table_path, sort_fields, sort_orders, ParquetFormat::new()).await
+}
+
+/// Like [`register_listing_table`] but accepts a pre-configured [`ParquetFormat`]
+/// (e.g. one with PME encryption options already set).
+pub async fn register_listing_table_with_format(
+    ctx: &SessionContext,
+    table_name: &str,
+    table_path: ListingTableUrl,
+    sort_fields: &[String],
+    sort_orders: &[String],
+    parquet_format: ParquetFormat,
+) -> Result<(), DataFusionError> {
+    let mut listing_options = ListingOptions::new(Arc::new(parquet_format))
         .with_file_extension(".parquet")
         .with_collect_stat(true);
     if let Some(sort_exprs) = build_file_sort_order(sort_fields, sort_orders) {

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_executor.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_executor.rs
@@ -135,6 +135,8 @@ pub async fn execute_indexed_query(
         has_topk: false,
         prepared_plan: None,
         phantom_reservation: None,
+        file_footer_keys: Arc::clone(&shard_view.file_footer_keys),
+        file_aad_prefixes: Arc::clone(&shard_view.file_aad_prefixes),
     };
     let ptr = Box::into_raw(Box::new(handle)) as i64;
 
@@ -870,6 +872,9 @@ async unsafe fn execute_indexed_with_context_inner(
     let sort_orders = handle.sort_orders;
     let query_context = handle.query_context;
     let io_handle = handle.io_handle;
+    // Extract PME maps before handle is fully consumed.
+    let file_footer_keys = handle.file_footer_keys;
+    let file_aad_prefixes = handle.file_aad_prefixes;
     // Extract context_id early so it can be captured by the per-segment closures
     // below. The closures pass it through every FFM upcall so Java can route each
     // callback to the correct per-query FilterDelegationHandle and DelegationThreadTracker.
@@ -904,6 +909,8 @@ async unsafe fn execute_indexed_with_context_inner(
         writer_generations.as_ref(),
         metadata_cache,
         &sort_fields,
+        &file_footer_keys,
+        &file_aad_prefixes,
     )
     .await
     .map_err(DataFusionError::Execution)?;
@@ -1304,6 +1311,18 @@ async unsafe fn execute_indexed_with_context_inner(
         .map_err(|e| DataFusionError::Execution(format!("parse table_path URL: {}", e)))?;
     let store_url = ObjectStoreUrl::parse(format!("{}://{}", parsed.scheme(), parsed.authority()))?;
 
+    // Build PME decryption factory for column-data decryption in the indexed scan path.
+    let encryption_factory: Option<std::sync::Arc<dyn datafusion_execution::parquet_encryption::EncryptionFactory>> =
+        if file_footer_keys.is_empty() == false {
+            use crate::query_executor::OpenSearchPmeDecryptionFactory;
+            Some(std::sync::Arc::new(OpenSearchPmeDecryptionFactory::new(
+                Arc::clone(&file_footer_keys),
+                Arc::clone(&file_aad_prefixes),
+            )))
+        } else {
+            None
+        };
+
     let provider = Arc::new(IndexedTableProvider::new(IndexedTableConfig {
         schema: schema.clone(),
         segments,
@@ -1318,6 +1337,7 @@ async unsafe fn execute_indexed_with_context_inner(
         sort_fields: sort_fields.clone(),
         sort_orders: sort_orders.clone(),
         cancellation_token: crate::query_tracker::get_cancellation_token(context_id),
+        encryption_factory,
     }));
     ctx.register_table(&register_name, provider)?;
 

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/parquet_bridge.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/parquet_bridge.rs
@@ -44,9 +44,11 @@ use datafusion::physical_plan::ExecutionPlan;
 use datafusion_datasource::file_scan_config::FileScanConfigBuilder;
 use datafusion_datasource::source::DataSourceExec;
 use datafusion_datasource::PartitionedFile;
+use datafusion_execution::parquet_encryption::EncryptionFactory;
 use futures::future::BoxFuture;
 use futures::FutureExt;
 use object_store::{ObjectStore, ObjectStoreExt};
+use parquet::encryption::decrypt::FileDecryptionProperties;
 use prost::bytes::Bytes;
 
 // ── Parquet Metadata Loading ─────────────────────────────────────────
@@ -56,6 +58,9 @@ use prost::bytes::Bytes;
 /// On a cache hit the cached (footer-only) metadata is returned with no IO.
 /// On a cache miss we fetch with `PageIndexPolicy::Skip` — never fetching page
 /// index bytes — then store the footer in the cache for future hits.
+///
+/// `decryption_props` – when `Some`, the PME footer key is passed through so
+/// the encrypted footer can be read. Plain-text files ignore this parameter.
 ///
 /// Issues a `head()` to learn the file's size + last-modified. Callers that
 /// already hold an authoritative [`ObjectMeta`] (e.g. from the listing snapshot
@@ -67,12 +72,13 @@ pub async fn load_parquet_metadata(
     store: Arc<dyn ObjectStore>,
     location: &object_store::path::Path,
     metadata_cache: Arc<dyn FileMetadataCache>,
+    decryption_props: Option<Arc<FileDecryptionProperties>>,
 ) -> std::result::Result<(SchemaRef, u64, Arc<ParquetMetaData>), String> {
     let meta = store
         .head(location)
         .await
         .map_err(|e| format!("object-store head {location}: {e}"))?;
-    load_parquet_metadata_with_meta(store, location, meta, metadata_cache).await
+    load_parquet_metadata_with_meta(store, location, meta, metadata_cache, decryption_props).await
 }
 
 /// Like [`load_parquet_metadata`] but uses a caller-supplied [`ObjectMeta`]
@@ -85,6 +91,7 @@ pub async fn load_parquet_metadata_with_meta(
     location: &object_store::path::Path,
     meta: object_store::ObjectMeta,
     metadata_cache: Arc<dyn FileMetadataCache>,
+    decryption_props: Option<Arc<FileDecryptionProperties>>,
 ) -> std::result::Result<(SchemaRef, u64, Arc<ParquetMetaData>), String> {
     let size = meta.size;
 
@@ -119,9 +126,13 @@ pub async fn load_parquet_metadata_with_meta(
         Some(m) => m,
         None => {
             let mut reader = ParquetObjectReader::new(Arc::clone(&store), location.clone());
+            let mut metadata_reader = ParquetMetaDataReader::new()
+                .with_page_index_policy(policy);
+            if let Some(props) = decryption_props {
+                metadata_reader = metadata_reader.with_decryption_properties(Some(props));
+            }
             let fetched = Arc::new(
-                ParquetMetaDataReader::new()
-                    .with_page_index_policy(policy)
+                metadata_reader
                     .load_and_finish(&mut reader, size)
                     .await
                     .map_err(|e| format!("load parquet metadata {location}: {e}"))?,
@@ -171,6 +182,9 @@ pub struct RowGroupStreamConfig {
     pub projection: Option<Vec<usize>>,
     pub predicate: Option<Arc<dyn datafusion::physical_expr::PhysicalExpr>>,
     pub io_stats: Arc<ReadIoStats>,
+    /// When set, DataFusion calls this factory for each file to get per-file
+    /// `FileDecryptionProperties` so column data can be decrypted during scan.
+    pub encryption_factory: Option<Arc<dyn EncryptionFactory>>,
 }
 
 /// Create a stream that reads a single row group using `RowSelection`.
@@ -240,6 +254,12 @@ fn create_stream_with_access_plan(
         // cannot use page index because we have collector bitset matches that are not visible
         // with just parquet predicates
         .with_enable_page_index(false);
+
+    // Wire PME decryption factory so DataFusion resolves per-file
+    // FileDecryptionProperties before reading column data.
+    if let Some(ref factory) = config.encryption_factory {
+        parquet_source = parquet_source.with_encryption_factory(Arc::clone(factory));
+    }
 
     if push_predicate {
         if let Some(ref pred) = config.predicate {

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/segment_info.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/segment_info.rs
@@ -22,6 +22,7 @@ use datafusion::parquet::file::metadata::ParquetMetaData;
 use super::parquet_bridge;
 use super::stream::RowGroupInfo;
 use super::table_provider::SegmentFileInfo;
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use datafusion::catalog::Session;
@@ -30,6 +31,8 @@ use datafusion::datasource::file_format::parquet::ParquetFormat;
 use datafusion::datasource::file_format::FileFormat;
 use datafusion::execution::cache::cache_manager::FileMetadataCache;
 use datafusion::parquet::arrow::arrow_reader::statistics::StatisticsConverter;
+use datafusion_common::config::TableParquetOptions;
+use parquet::encryption::decrypt::FileDecryptionProperties;
 
 /// Parquet footer kv key under which the writer stamps the writer generation.
 /// Must match `parquet-data-format`'s `WRITER_GENERATION_KEY`.
@@ -40,6 +43,11 @@ const WRITER_GENERATION_KEY: &str = "opensearch.writer_generation";
 ///
 /// `writer_generations[i]` is the writer generation of `object_metas[i]`. Both slices
 /// must have the same length.
+///
+/// `file_footer_keys` / `file_aad_prefixes` – per-file PME keys (filename → bytes).
+/// When non-empty, per-file `FileDecryptionProperties` are built and passed to
+/// `load_parquet_metadata` so the encrypted footer can be read. `infer_schema`
+/// likewise uses a PME-configured `ParquetFormat`.
 ///
 /// The returned schema is the **union across all segment parquet files**,
 /// computed by `ParquetFormat::infer_schema` — the same function
@@ -55,6 +63,8 @@ pub async fn build_segments(
     writer_generations: &[i64],
     metadata_cache: Arc<dyn FileMetadataCache>,
     sort_fields: &[String],
+    file_footer_keys: &HashMap<String, Vec<u8>>,
+    file_aad_prefixes: &HashMap<String, Vec<u8>>,
 ) -> Result<(Vec<SegmentFileInfo>, arrow::datatypes::SchemaRef), String> {
     if object_metas.len() != writer_generations.len() {
         return Err(format!(
@@ -72,6 +82,9 @@ pub async fn build_segments(
     let mut cumulative_rows: u64 = 0;
 
     for (seg_ord, meta) in object_metas.iter().enumerate() {
+        // Build per-file decryption properties if a footer key is registered for this file.
+        let decryption_props = build_decryption_props(&meta.location, file_footer_keys, file_aad_prefixes);
+
         // Per-segment parquet metadata (RG info, page index) — still needed
         // regardless of schema derivation. The file_metadata_cache on the
         // RuntimeEnv that `infer_schema` uses below shares this data when
@@ -85,6 +98,7 @@ pub async fn build_segments(
             &meta.location,
             meta.clone(),
             Arc::clone(&metadata_cache),
+            decryption_props,
         )
         .await
         .map_err(|e| format!("parquet metadata {}: {}", meta.location, e))?;
@@ -147,12 +161,39 @@ pub async fn build_segments(
     //      if configured.
     // Use Utf8View — ParquetOpener's apply_file_schema_type_coercions keeps the file/table
     // schemas aligned, so QTF's coordinator-declared Utf8View matches the produced batches.
-    let format = ParquetFormat::default().with_force_view_types(true);
-    let schema = FileFormat::infer_schema(&format, state, &store, object_metas)
+    //
+    // When the shard contains PME-encrypted files, the ParquetFormat must be configured
+    // with the PME factory_id so infer_schema can decrypt the footer during schema fetch.
+    let format: Box<dyn FileFormat> = if file_footer_keys.is_empty() == false {
+        use crate::query_executor::OPENSEARCH_PME_FACTORY_ID;
+        let mut opts = TableParquetOptions::default();
+        opts.crypto.factory_id = Some(OPENSEARCH_PME_FACTORY_ID.to_owned());
+        Box::new(ParquetFormat::new().with_force_view_types(true).with_options(opts))
+    } else {
+        Box::new(ParquetFormat::default().with_force_view_types(true))
+    };
+    let schema = FileFormat::infer_schema(format.as_ref(), state, &store, object_metas)
         .await
         .map_err(|e| format!("infer_schema union: {}", e))?;
 
     Ok((segments, schema))
+}
+
+/// Build `FileDecryptionProperties` for a single file if a footer key is registered for it.
+fn build_decryption_props(
+    location: &object_store::path::Path,
+    file_footer_keys: &HashMap<String, Vec<u8>>,
+    file_aad_prefixes: &HashMap<String, Vec<u8>>,
+) -> Option<Arc<FileDecryptionProperties>> {
+    let filename = location.filename()?;
+    let footer_key = file_footer_keys.get(filename)?;
+    let mut builder = FileDecryptionProperties::builder(footer_key.clone());
+    if let Some(aad) = file_aad_prefixes.get(filename) {
+        if aad.is_empty() == false {
+            builder = builder.with_aad_prefix(aad.clone());
+        }
+    }
+    builder.build().ok()
 }
 
 /// Read the writer generation out of a parquet footer's key-value metadata and panic if
@@ -304,6 +345,26 @@ mod tests {
         Arc::new(DefaultFilesMetadataCache::new(50 * 1024 * 1024))
     }
 
+    /// Shorthand: call `build_segments` without PME keys (plain-text files).
+    async fn build_segments_plain(
+        state: &dyn datafusion::catalog::Session,
+        store: Arc<dyn object_store::ObjectStore>,
+        object_metas: &[object_store::ObjectMeta],
+        writer_generations: &[i64],
+        metadata_cache: Arc<dyn FileMetadataCache>,
+    ) -> Result<(Vec<SegmentFileInfo>, arrow::datatypes::SchemaRef), String> {
+        build_segments(
+            state,
+            store,
+            object_metas,
+            writer_generations,
+            metadata_cache,
+            &HashMap::new(),
+            &HashMap::new(),
+        )
+        .await
+    }
+
     /// Write a parquet file with the given schema + arrays into `dir`
     /// under `filename`. Returns the absolute filesystem path.
     fn write_parquet(
@@ -368,7 +429,7 @@ mod tests {
         let metas = object_metas(store.as_ref(), &[p0, p1]).await;
         let ctx = SessionContext::new();
         let gens: Vec<i64> = (0..metas.len() as i64).collect();
-        let (segments, merged) = build_segments(
+        let (segments, merged) = build_segments_plain(
             &ctx.state(),
             Arc::clone(&store),
             &metas,
@@ -425,7 +486,7 @@ mod tests {
         let metas = object_metas(store.as_ref(), &[p0, p1]).await;
         let ctx = SessionContext::new();
         let gens: Vec<i64> = (0..metas.len() as i64).collect();
-        let (_segments, merged) = build_segments(
+        let (_segments, merged) = build_segments_plain(
             &ctx.state(),
             Arc::clone(&store),
             &metas,
@@ -492,7 +553,7 @@ mod tests {
         let gens_ab: Vec<i64> = (0..metas_ab.len() as i64).collect();
         let gens_ba: Vec<i64> = (0..metas_ba.len() as i64).collect();
 
-        let (_, schema_ab) = build_segments(
+        let (_, schema_ab) = build_segments_plain(
             &ctx.state(),
             Arc::clone(&store),
             &metas_ab,
@@ -502,7 +563,7 @@ mod tests {
         )
         .await
         .unwrap();
-        let (_, schema_ba) = build_segments(
+        let (_, schema_ba) = build_segments_plain(
             &ctx.state(),
             Arc::clone(&store),
             &metas_ba,
@@ -555,7 +616,7 @@ mod tests {
         let metas = object_metas(store.as_ref(), &[p0, p1]).await;
         let ctx = SessionContext::new();
         let gens: Vec<i64> = (0..metas.len() as i64).collect();
-        let result = build_segments(
+        let result = build_segments_plain(
             &ctx.state(),
             Arc::clone(&store),
             &metas,

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/stream.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/stream.rs
@@ -56,6 +56,7 @@ use super::parquet_bridge::{self, RowGroupStreamConfig};
 use super::row_selection::{build_mask, build_row_selection_with_min_skip_run, PositionMap};
 use crate::datafusion_query_config::DatafusionQueryConfig;
 use datafusion::physical_plan::coalesce::{LimitedBatchCoalescer, PushBatchStatus};
+use datafusion_execution::parquet_encryption::EncryptionFactory;
 use std::time::{Duration, Instant};
 
 /// Row group metadata.
@@ -390,6 +391,9 @@ pub struct IndexedExec {
     /// dispatching further row groups and `IndexedStream` stops draining.
     /// `None` disables cancellation checks.
     pub(crate) cancellation_token: Option<tokio_util::sync::CancellationToken>,
+    /// PME decryption factory — when set, DataFusion calls it for each file to get
+    /// per-file `FileDecryptionProperties` so column data can be decrypted during scan.
+    pub(crate) encryption_factory: Option<Arc<dyn EncryptionFactory>>,
 }
 
 impl fmt::Debug for IndexedExec {
@@ -485,6 +489,7 @@ impl ExecutionPlan for IndexedExec {
             self.emit_row_ids,
             self.row_id_output_index,
             self.dynamic_filter.clone(),
+            self.encryption_factory.clone(),
         )))
     }
 }
@@ -562,6 +567,9 @@ struct IndexedStream {
     /// was pushed. Owns its own snapshot generation tracking, so it must NOT be
     /// shared across sibling segment streams.
     dynamic_rg_pruner: Option<super::dynamic_filter::DynamicRgPruner>,
+    /// PME decryption factory — when set, DataFusion calls it for each file to get
+    /// per-file `FileDecryptionProperties` so column data can be decrypted during scan.
+    encryption_factory: Option<Arc<dyn EncryptionFactory>>,
 }
 
 impl IndexedStream {
@@ -587,6 +595,7 @@ impl IndexedStream {
         emit_row_ids: bool,
         row_id_output_index: Option<usize>,
         dynamic_filter: Option<Arc<dyn datafusion::physical_expr::PhysicalExpr>>,
+        encryption_factory: Option<Arc<dyn EncryptionFactory>>,
     ) -> Self {
         let evaluator = Arc::clone(&index_reader.evaluator);
         let batch_coalescer =
@@ -631,6 +640,7 @@ impl IndexedStream {
             emit_row_ids,
             row_id_output_index,
             dynamic_rg_pruner,
+            encryption_factory,
         }
     }
 
@@ -673,6 +683,7 @@ impl IndexedStream {
                 .io_stats
                 .clone()
                 .unwrap_or_else(|| Arc::new(super::parquet_bridge::ReadIoStats::default())),
+            encryption_factory: self.encryption_factory.clone(),
         }
     }
 

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/table_provider.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/table_provider.rs
@@ -55,7 +55,8 @@ use super::partitioning::{
     compute_assignments, compute_assignments_one_per_segment, segments_chain_on_sort_key,
     PartitionAssignment, SegmentChunk, SegmentLayout,
 };
-use super::stream::{IndexedExec, RowGroupInfo};
+use super::stream::{FilterStrategy, IndexedExec, RowGroupInfo};
+use datafusion_execution::parquet_encryption::EncryptionFactory;
 use crate::datafusion_query_config::DatafusionQueryConfig;
 use crate::indexed_table::metrics::StreamMetrics;
 use crate::indexed_table::page_pruner::StatsPruneTree;
@@ -210,6 +211,9 @@ pub struct IndexedTableConfig {
     /// down to `IndexReader` so the scan cooperatively stops when the query task
     /// is cancelled. `None` for untracked queries (`context_id == 0`) and tests.
     pub cancellation_token: Option<tokio_util::sync::CancellationToken>,
+    /// Per-shard PME decryption factory. When set, DataFusion calls it for each
+    /// file to get `FileDecryptionProperties` before reading column data.
+    pub encryption_factory: Option<Arc<dyn EncryptionFactory>>,
 }
 
 /// Table provider. Returns a `QueryShardExec` that fans out across chunks.
@@ -704,6 +708,7 @@ impl ExecutionPlan for QueryShardExec {
                 row_id_output_index: self.row_id_output_index,
                 dynamic_filter: dynamic_filter.clone(),
                 cancellation_token: self.config.cancellation_token.clone(),
+                encryption_factory: self.config.encryption_factory.clone(),
             };
             streams.push(exec.execute(0, Arc::clone(&context))?);
         }
@@ -834,6 +839,7 @@ mod tests {
             sort_fields: vec![],
             sort_orders: vec![],
             cancellation_token: None,
+            encryption_factory: None,
         }
     }
 

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/constant_predicate.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/constant_predicate.rs
@@ -119,6 +119,7 @@ async fn run_constant_residual(residual: Arc<dyn PhysicalExpr>) -> usize {
         sort_fields: vec![],
         sort_orders: vec![],
         cancellation_token: None,
+        encryption_factory: None,
     }));
 
     let ctx = SessionContext::new();

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/fuzz/delegation.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/fuzz/delegation.rs
@@ -474,6 +474,7 @@ pub(in crate::indexed_table::tests_e2e) async fn execute_delegation_tree(
         sort_fields: vec![],
         sort_orders: vec![],
         cancellation_token: None,
+        encryption_factory: None,
     }));
 
     let ctx = SessionContext::new();

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/fuzz/harness.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/fuzz/harness.rs
@@ -311,6 +311,7 @@ pub(in crate::indexed_table::tests_e2e) async fn execute_tree_with_plan_pushdown
         sort_fields: vec![],
         sort_orders: vec![],
         cancellation_token: None,
+        encryption_factory: None,
     }));
 
     let ctx = SessionContext::new();
@@ -498,6 +499,7 @@ async fn run_single_collector_query(
         sort_fields: vec![],
         sort_orders: vec![],
         cancellation_token: None,
+        encryption_factory: None,
     }));
     let ctx = SessionContext::new();
     ctx.register_table("t", provider).unwrap();
@@ -715,6 +717,7 @@ async fn run_with_factory_plan(
         sort_fields: vec![],
         sort_orders: vec![],
         cancellation_token: None,
+        encryption_factory: None,
     }));
     let ctx = SessionContext::new();
     ctx.register_table("t", provider).unwrap();

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/mod.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/mod.rs
@@ -306,6 +306,7 @@ async fn run_tree_and_plan(
         sort_fields: vec![],
         sort_orders: vec![],
         cancellation_token: None,
+        encryption_factory: None,
     }));
 
     let ctx = SessionContext::new();

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/multi_segment.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/multi_segment.rs
@@ -193,6 +193,7 @@ async fn run_two_segment_query(
         sort_fields: vec![],
         sort_orders: vec![],
         cancellation_token: None,
+        encryption_factory: None,
     }));
 
     let ctx = SessionContext::new();
@@ -407,6 +408,7 @@ async fn run_two_segment_query_witness(
         sort_fields: vec![],
         sort_orders: vec![],
         cancellation_token: None,
+        encryption_factory: None,
     }));
 
     let ctx = SessionContext::new();
@@ -619,6 +621,7 @@ async fn run_segments(specs: Vec<SegSpec>, num_partitions: usize) -> Vec<(i32, S
         sort_fields: vec![],
         sort_orders: vec![],
         cancellation_token: None,
+        encryption_factory: None,
     }));
 
     let ctx = SessionContext::new();
@@ -1129,6 +1132,7 @@ async fn run_wide_segments(
         sort_fields: vec![],
         sort_orders: vec![],
         cancellation_token: None,
+        encryption_factory: None,
     }));
 
     let ctx = SessionContext::new();

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/null_columns.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/null_columns.rs
@@ -389,6 +389,7 @@ async fn assert_engine_matches_reference_null(name: &str, tree: NT) {
         sort_fields: vec![],
         sort_orders: vec![],
         cancellation_token: None,
+        encryption_factory: None,
     }));
     let ctx = SessionContext::new();
     ctx.register_table("t", provider).unwrap();

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/page_pruning.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/page_pruning.rs
@@ -403,6 +403,7 @@ async fn execute_and_collect(
         sort_fields: vec![],
         sort_orders: vec![],
         cancellation_token: None,
+        encryption_factory: None,
     }));
 
     let ctx = SessionContext::new();

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/qtf_fetch_phase.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/qtf_fetch_phase.rs
@@ -130,6 +130,7 @@ async fn query_phase(tree: BoolNode) -> Vec<i64> {
         sort_fields: vec![],
         sort_orders: vec![],
         cancellation_token: None,
+        encryption_factory: None,
     }));
 
     let ctx = SessionContext::new();
@@ -233,6 +234,7 @@ async fn fetch_phase(
         file_schema: file_schema.clone(),
         files: vec![shard_file],
         store_url: store_url.clone(),
+        encryption_factory: None,
     }));
 
     // Register object store and table
@@ -444,6 +446,7 @@ async fn test_qtf_full_loop_two_segments() {
         file_schema: file_schema.clone(),
         files: vec![shard_file],
         store_url: store_url.clone(),
+        encryption_factory: None,
     }));
 
     let ctx = SessionContext::new();

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/row_id_emission.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/row_id_emission.rs
@@ -120,6 +120,7 @@ async fn run_tree_row_ids(tree: BoolNode) -> Vec<i64> {
         sort_fields: vec![],
         sort_orders: vec![],
         cancellation_token: None,
+        encryption_factory: None,
     }));
 
     let ctx = SessionContext::new();
@@ -291,6 +292,7 @@ async fn run_tree_row_ids_with_global_base(tree: BoolNode, global_base: u64) -> 
         sort_fields: vec![],
         sort_orders: vec![],
         cancellation_token: None,
+        encryption_factory: None,
     }));
 
     let ctx = SessionContext::new();
@@ -560,6 +562,7 @@ async fn test_row_id_with_data_columns() {
         sort_fields: vec![],
         sort_orders: vec![],
         cancellation_token: None,
+        encryption_factory: None,
     }));
 
     let ctx = SessionContext::new();
@@ -816,6 +819,7 @@ async fn run_two_segments_row_ids(tree: BoolNode) -> Vec<i64> {
         sort_fields: vec![],
         sort_orders: vec![],
         cancellation_token: None,
+        encryption_factory: None,
     }));
 
     let ctx = SessionContext::new();

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/schema_drift.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/schema_drift.rs
@@ -144,6 +144,7 @@ async fn run_missing_col_tree(tree_bool: BoolNode) -> usize {
         sort_fields: vec![],
         sort_orders: vec![],
         cancellation_token: None,
+        encryption_factory: None,
     }));
     let ctx = SessionContext::new();
     ctx.register_table("t", provider).unwrap();
@@ -458,6 +459,7 @@ async fn query_with_mismatched_schema(
         sort_fields: vec![],
         sort_orders: vec![],
         cancellation_token: None,
+        encryption_factory: None,
     }));
     let ctx = SessionContext::new();
     ctx.register_table("t", provider).unwrap();

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/streaming_at_scale.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/streaming_at_scale.rs
@@ -461,6 +461,7 @@ async fn run_large(
         sort_fields: vec![],
         sort_orders: vec![],
         cancellation_token: None,
+        encryption_factory: None,
     }));
 
     let ctx = SessionContext::new();
@@ -919,6 +920,7 @@ async fn run_large_partitioned(
         sort_fields: vec![],
         sort_orders: vec![],
         cancellation_token: None,
+        encryption_factory: None,
     }));
     let ctx = SessionContext::new();
     ctx.register_table("t", provider).unwrap();

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/lib.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/lib.rs
@@ -22,6 +22,7 @@ pub const ROW_ID_COLUMN_NAME: &str = "__row_id__";
 
 pub(crate) mod agg_mode;
 pub mod api;
+pub mod pme_reader;
 pub mod cache;
 pub mod cancellation;
 pub mod cross_rt_stream;

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/pme_reader.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/pme_reader.rs
@@ -1,0 +1,313 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+//! Object-store-aware Parquet PME footer key-metadata reader.
+//!
+//! Reads `FileCryptoMetaData.key_metadata` from the tail of a Parquet file via
+//! range reads — never downloads the full object.
+//!
+//! # Algorithm
+//! 1. `ObjectStore::head` → get `file_size`.
+//! 2. Range-read last 8 bytes `[file_size-8 .. file_size]`.
+//! 3. Bytes `[4..8]` are the magic:
+//!    - `b"PAR1"` → unencrypted, return `Ok(None)`.
+//!    - `b"PARE"` → encrypted, continue.
+//!    - Anything else → fail closed.
+//! 4. Bytes `[0..4]` = 4-byte LE length of `FileCryptoMetaData` Thrift payload.
+//! 5. Range-read `FileCryptoMetaData` bytes.
+//! 6. Deserialise the payload with `parquet::format::FileCryptoMetaData`
+//!    via `parquet::thrift::TSerializable` and `thrift::protocol::TCompactInputProtocol`.
+
+use datafusion::common::DataFusionError;
+use object_store::{ObjectStore, ObjectStoreExt};
+use parquet::format::FileCryptoMetaData;
+use parquet::thrift::TSerializable;
+
+/// Encrypted Parquet file magic.
+const PARE_MAGIC: &[u8] = b"PARE";
+/// Plain-text Parquet file magic.
+const PAR1_MAGIC: &[u8] = b"PAR1";
+
+/// Read `FileCryptoMetaData.key_metadata` from the tail of a Parquet file via
+/// range reads against `store`.
+///
+/// The file path is resolved exactly as `create_object_metas` in `api.rs`:
+/// absolute `filename` is used as-is; otherwise
+/// `<table_path.trim_end_matches('/')>/<filename>` is used.
+///
+/// Returns:
+/// - `Ok(Some(bytes))` — encrypted file with `key_metadata` present.
+/// - `Ok(None)`        — plain-text (`PAR1`) file, or `PARE` file with no
+///   `key_metadata` field in `FileCryptoMetaData`.
+/// - `Err(_)`          — I/O error, file too small, unsupported magic, or
+///   malformed Thrift payload.
+pub async fn read_footer_key_metadata(
+    store: &dyn ObjectStore,
+    table_path: &str,
+    filename: &str,
+) -> Result<Option<Vec<u8>>, DataFusionError> {
+    // Path resolution mirrors `create_object_metas` in `api.rs`.
+    let full_path = if filename.starts_with('/') || filename.contains(table_path) {
+        filename.to_string()
+    } else {
+        format!("{}/{}", table_path.trim_end_matches('/'), filename)
+    };
+    let path = object_store::path::Path::from(full_path.as_str());
+
+    // 1. Get file size via head().
+    let meta = store.head(&path).await.map_err(|e| {
+        DataFusionError::Execution(format!("pme_reader: head({}) failed: {}", full_path, e))
+    })?;
+    let file_size = meta.size as u64;
+
+    if file_size < 8 {
+        return Err(DataFusionError::Execution(format!(
+            "pme_reader: file {} is too small ({} bytes) to be a valid Parquet file",
+            full_path, file_size
+        )));
+    }
+
+    // 2. Range-read last 8 bytes: [FileCryptoMetaData_len: 4 LE][magic: 4].
+    let tail = store
+        .get_range(&path, (file_size - 8)..(file_size))
+        .await
+        .map_err(|e| {
+            DataFusionError::Execution(format!(
+                "pme_reader: get_range(tail 8 bytes) for {} failed: {}",
+                full_path, e
+            ))
+        })?;
+
+    if tail.len() < 8 {
+        return Err(DataFusionError::Execution(format!(
+            "pme_reader: expected 8 tail bytes from {}, got {}",
+            full_path,
+            tail.len()
+        )));
+    }
+
+    // 3. Check magic at tail[4..8].
+    let magic = &tail[4..8];
+    if magic == PAR1_MAGIC {
+        return Ok(None);
+    }
+    if magic != PARE_MAGIC {
+        return Err(DataFusionError::Execution(format!(
+            "pme_reader: unexpected Parquet magic [{:#x},{:#x},{:#x},{:#x}] in {} — \
+             expected PAR1 (plain-text) or PARE (encrypted)",
+            magic[0], magic[1], magic[2], magic[3], full_path
+        )));
+    }
+
+    // 4. Parse 4-byte LE FileCryptoMetaData length from tail[0..4].
+    let crypto_meta_len = i32::from_le_bytes([tail[0], tail[1], tail[2], tail[3]]);
+    if crypto_meta_len <= 0 {
+        return Err(DataFusionError::Execution(format!(
+            "pme_reader: invalid FileCryptoMetaData length {} in {}",
+            crypto_meta_len, full_path
+        )));
+    }
+    let crypto_meta_len = crypto_meta_len as u64;
+    if file_size < 8 + crypto_meta_len {
+        return Err(DataFusionError::Execution(format!(
+            "pme_reader: FileCryptoMetaData length {} exceeds file size {} in {}",
+            crypto_meta_len, file_size, full_path
+        )));
+    }
+
+    // 5. Range-read FileCryptoMetaData Thrift bytes.
+    let meta_start = file_size - 8 - crypto_meta_len;
+    let meta_end = file_size - 8;
+    let crypto_meta = store
+        .get_range(&path, meta_start..meta_end)
+        .await
+        .map_err(|e| {
+            DataFusionError::Execution(format!(
+                "pme_reader: get_range(FileCryptoMetaData) for {} failed: {}",
+                full_path, e
+            ))
+        })?;
+
+    // 6. Deserialise FileCryptoMetaData using parquet-rs generated Thrift types.
+    //    TCompactInputProtocol wraps an std::io::Read, so we use a Cursor over
+    //    the fetched bytes. TSerializable::read_from_in_protocol drives the
+    //    generated field-by-field parser; any structural mismatch is returned
+    //    as a Thrift error rather than a panic.
+    let mut cursor = std::io::Cursor::new(&crypto_meta[..]);
+    let mut protocol = thrift::protocol::TCompactInputProtocol::new(&mut cursor);
+    let file_crypto_meta = FileCryptoMetaData::read_from_in_protocol(&mut protocol)
+        .map_err(|e| {
+            DataFusionError::Execution(format!(
+                "pme_reader: Thrift parse error for {}: {}",
+                full_path, e
+            ))
+        })?;
+
+    Ok(file_crypto_meta.key_metadata)
+}
+
+// ---- Tests -------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use bytes::Bytes;
+    use object_store::memory::InMemory;
+    use object_store::path::Path;
+    use object_store::PutPayload;
+
+    // ---- helpers ----
+
+    /// Serialise a `FileCryptoMetaData` to a Thrift compact-protocol byte buffer
+    /// using the parquet-rs generated codec (the same codec the reader uses).
+    fn serialize_file_crypto_meta(meta: &FileCryptoMetaData) -> Vec<u8> {
+        use parquet::thrift::TCompactOutputProtocol;
+        let mut buf = Vec::new();
+        let mut protocol = TCompactOutputProtocol::new(&mut buf);
+        meta.write_to_out_protocol(&mut protocol).unwrap();
+        buf
+    }
+
+    /// Build a valid `FileCryptoMetaData` Thrift compact buffer.
+    ///
+    /// `key_meta` is `Some` → field 2 is present; `None` → field 2 absent.
+    fn build_crypto_meta_thrift(key_meta: Option<&[u8]>) -> Vec<u8> {
+        use parquet::format::{AesGcmV1, EncryptionAlgorithm, FileCryptoMetaData};
+        let algo = EncryptionAlgorithm::AESGCMV1(AesGcmV1::new(None, None, None));
+        let meta = FileCryptoMetaData::new(algo, key_meta.map(|b| b.to_vec()));
+        serialize_file_crypto_meta(&meta)
+    }
+
+    /// Build a synthetic encrypted Parquet file with `key_meta` in the footer.
+    fn make_encrypted_parquet(key_meta: &[u8]) -> Vec<u8> {
+        let thrift = build_crypto_meta_thrift(Some(key_meta));
+        let crypto_meta_len = thrift.len() as i32;
+        let mut file = vec![0u8; 8]; // fake row-group data prefix
+        file.extend_from_slice(&thrift);
+        file.extend_from_slice(&crypto_meta_len.to_le_bytes());
+        file.extend_from_slice(b"PARE");
+        file
+    }
+
+    /// Build a synthetic encrypted PARE file with no `key_metadata` field.
+    fn make_encrypted_parquet_no_km() -> Vec<u8> {
+        let thrift = build_crypto_meta_thrift(None);
+        let crypto_meta_len = thrift.len() as i32;
+        let mut file = vec![0u8; 8];
+        file.extend_from_slice(&thrift);
+        file.extend_from_slice(&crypto_meta_len.to_le_bytes());
+        file.extend_from_slice(b"PARE");
+        file
+    }
+
+    /// Build a synthetic plain-text Parquet file (PAR1 magic, no FileCryptoMetaData).
+    fn make_plaintext_parquet() -> Vec<u8> {
+        let mut file = vec![0u8; 8];
+        file.extend_from_slice(b"PAR1");
+        file
+    }
+
+    /// Put `data` into `store` at `path`.
+    async fn put(store: &dyn ObjectStore, path: &str, data: Vec<u8>) {
+        store
+            .put(&Path::from(path), PutPayload::from(Bytes::from(data)))
+            .await
+            .unwrap();
+    }
+
+    // ---- object-store integration tests ----
+
+    #[tokio::test]
+    async fn encrypted_file_returns_key_metadata() {
+        let store = InMemory::new();
+        let key_meta = b"{\"version\":1,\"data_key_id\":\"default\",\"message_id\":\"AAAAAAAAAAAAAAAA\"}";
+        let data = make_encrypted_parquet(key_meta);
+        put(&store, "shard/seg.parquet", data).await;
+
+        let result = read_footer_key_metadata(&store, "shard", "seg.parquet").await.unwrap();
+        assert_eq!(result, Some(key_meta.to_vec()));
+    }
+
+    #[tokio::test]
+    async fn plaintext_file_returns_none() {
+        let store = InMemory::new();
+        let data = make_plaintext_parquet();
+        put(&store, "shard/plain.parquet", data).await;
+
+        let result = read_footer_key_metadata(&store, "shard", "plain.parquet").await.unwrap();
+        assert_eq!(result, None);
+    }
+
+    #[tokio::test]
+    async fn pare_without_key_metadata_returns_none() {
+        let store = InMemory::new();
+        let data = make_encrypted_parquet_no_km();
+        put(&store, "shard/nokm.parquet", data).await;
+
+        let result = read_footer_key_metadata(&store, "shard", "nokm.parquet").await.unwrap();
+        assert_eq!(result, None);
+    }
+
+    #[tokio::test]
+    async fn file_too_small_fails() {
+        let store = InMemory::new();
+        put(&store, "shard/short.parquet", vec![0u8; 4]).await;
+
+        let result = read_footer_key_metadata(&store, "shard", "short.parquet").await;
+        assert!(result.is_err(), "file with < 8 bytes must fail");
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("too small"), "error message should mention too small: {}", msg);
+    }
+
+    #[tokio::test]
+    async fn bad_magic_fails_closed() {
+        let store = InMemory::new();
+        let mut data = vec![0u8; 8];
+        data.extend_from_slice(b"XXXX"); // unsupported magic
+        put(&store, "shard/bad.parquet", data).await;
+
+        let result = read_footer_key_metadata(&store, "shard", "bad.parquet").await;
+        assert!(result.is_err(), "unknown magic must fail closed");
+    }
+
+    #[tokio::test]
+    async fn negative_crypto_meta_len_fails() {
+        let store = InMemory::new();
+        let mut data = vec![0u8; 8];
+        data.extend_from_slice(&(-1i32).to_le_bytes());
+        data.extend_from_slice(b"PARE");
+        put(&store, "shard/neglen.parquet", data).await;
+
+        let result = read_footer_key_metadata(&store, "shard", "neglen.parquet").await;
+        assert!(result.is_err(), "negative crypto_meta_len must fail");
+    }
+
+    #[tokio::test]
+    async fn corrupt_thrift_fails() {
+        // Truncated / garbage bytes after PARE magic with a plausible length.
+        let store = InMemory::new();
+        let junk = vec![0xFF, 0xFE, 0xFD]; // not a valid Thrift compact struct
+        let len = junk.len() as i32;
+        let mut data = vec![0u8; 8];
+        data.extend_from_slice(&junk);
+        data.extend_from_slice(&len.to_le_bytes());
+        data.extend_from_slice(b"PARE");
+        put(&store, "shard/corrupt.parquet", data).await;
+
+        let result = read_footer_key_metadata(&store, "shard", "corrupt.parquet").await;
+        assert!(result.is_err(), "corrupt Thrift payload must fail");
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("Thrift parse error"),
+            "error should mention Thrift parse: {}",
+            msg
+        );
+    }
+}
+

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/query_executor.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/query_executor.rs
@@ -6,9 +6,12 @@
  * compatible open source license.
  */
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use native_bridge_common::log_debug;
+use async_trait::async_trait;
+use arrow::datatypes::SchemaRef;
 use datafusion::{
     common::DataFusionError,
     datasource::listing::ListingTableUrl,
@@ -20,18 +23,77 @@ use datafusion::execution::cache::cache_manager::{CacheManagerConfig, CachedFile
 use datafusion::execution::cache::{CacheAccessor, DefaultListFilesCache};
 use datafusion::execution::context::SessionContext;
 use datafusion::logical_expr::{col, lit};
+use datafusion_common::config::EncryptionFactoryOptions;
+use datafusion::datasource::file_format::parquet::ParquetFormat;
+use datafusion_execution::parquet_encryption::EncryptionFactory;
 use datafusion_substrait::logical_plan::consumer::from_substrait_plan;
 use log::error;
 use object_store::ObjectMeta;
 use object_store::ObjectStore;
+use object_store::path::Path;
+use parquet::encryption::decrypt::FileDecryptionProperties;
+use parquet::encryption::encrypt::FileEncryptionProperties;
 use prost::Message;
 use substrait::proto::Plan;
 
 use crate::api::{DataFusionRuntime, ShardFileInfo};
 use crate::cross_rt_stream::CrossRtStream;
 use crate::executor::DedicatedExecutor;
-use crate::helper::{build_query_runtime_env_with_store, build_query_session_context, register_listing_table};
+use crate::helper::{build_query_runtime_env_with_store, build_query_session_context, register_listing_table, register_listing_table_with_format};
 use crate::session_context::SessionContextHandle;
+
+pub const OPENSEARCH_PME_FACTORY_ID: &str = "opensearch_pme";
+
+#[derive(Debug)]
+pub struct OpenSearchPmeDecryptionFactory {
+    file_footer_keys: Arc<HashMap<String, Vec<u8>>>,
+    file_aad_prefixes: Arc<HashMap<String, Vec<u8>>>,
+}
+
+impl OpenSearchPmeDecryptionFactory {
+    pub fn new(file_footer_keys: Arc<HashMap<String, Vec<u8>>>, file_aad_prefixes: Arc<HashMap<String, Vec<u8>>>) -> Self {
+        Self { file_footer_keys, file_aad_prefixes }
+    }
+}
+
+#[async_trait]
+impl EncryptionFactory for OpenSearchPmeDecryptionFactory {
+    async fn get_file_encryption_properties(
+        &self,
+        _config: &EncryptionFactoryOptions,
+        _schema: &SchemaRef,
+        _file_path: &Path,
+    ) -> datafusion_common::Result<Option<Arc<FileEncryptionProperties>>> {
+        Ok(None)
+    }
+
+    async fn get_file_decryption_properties(
+        &self,
+        _config: &EncryptionFactoryOptions,
+        file_path: &Path,
+    ) -> datafusion_common::Result<Option<Arc<FileDecryptionProperties>>> {
+        let filename = match file_path.filename() {
+            Some(f) => f,
+            None => return Ok(None),
+        };
+        match self.file_footer_keys.get(filename) {
+            Some(footer_key) => {
+                let mut builder = FileDecryptionProperties::builder(footer_key.clone());
+                // Set the AAD prefix if present — required for files written with an AAD prefix.
+                if let Some(aad_prefix) = self.file_aad_prefixes.get(filename) {
+                    if !aad_prefix.is_empty() {
+                        builder = builder.with_aad_prefix(aad_prefix.clone());
+                    }
+                }
+                let properties = builder
+                    .build()
+                    .map_err(|e| DataFusionError::Execution(format!("Failed to build PME decryption properties: {}", e)))?;
+                Ok(Some(properties))
+            }
+            None => Ok(None),
+        }
+    }
+}
 
 /// Execute a vanilla parquet query: substrait plan → DataFusion → CrossRtStream.
 /// File access goes through DataFusion's registered object store.
@@ -45,6 +107,8 @@ pub async fn execute_query(
     object_metas: Arc<Vec<ObjectMeta>>,
     table_name: String,
     plan_bytes: Vec<u8>,
+    file_footer_keys: Arc<HashMap<String, Vec<u8>>>,
+    file_aad_prefixes: Arc<HashMap<String, Vec<u8>>>,
     runtime: &DataFusionRuntime,
     cpu_executor: DedicatedExecutor,
     query_memory_pool: Option<Arc<dyn datafusion::execution::memory_pool::MemoryPool>>,
@@ -65,6 +129,25 @@ pub async fn execute_query(
         query_memory_pool,
     )?;
 
+    // Register the PME decryption factory when the shard contains encrypted files.
+    // Both the factory registration AND the ParquetFormat factory_id option are required:
+    // registration alone is insufficient — DataFusion only calls get_file_decryption_properties
+    // when ParquetFormat.options.crypto.factory_id is set.
+    let parquet_format = if file_footer_keys.is_empty() == false {
+        runtime_env.register_parquet_encryption_factory(
+            OPENSEARCH_PME_FACTORY_ID,
+            Arc::new(OpenSearchPmeDecryptionFactory::new(
+                Arc::clone(&file_footer_keys),
+                Arc::clone(&file_aad_prefixes),
+            )),
+        );
+        let mut parquet_options = datafusion_common::config::TableParquetOptions::default();
+        parquet_options.crypto.factory_id = Some(OPENSEARCH_PME_FACTORY_ID.to_owned());
+        ParquetFormat::new().with_options(parquet_options)
+    } else {
+        ParquetFormat::new()
+    };
+
     // Build a fresh session context per query (default optimizer rules on the
     // vanilla path). TODO : Tune this during planning per query.
     let ctx = build_query_session_context(
@@ -77,7 +160,7 @@ pub async fn execute_query(
     // Register the standard DataFusion ListingTable. This function only runs the vanilla
     // (non-row-id) path — QTF row-id plans always route to the indexed executor.
     // Declares the per-file sort order when the index has `index.sort.field`.
-    register_listing_table(&ctx, &table_name, table_path, sort_fields, sort_orders).await?;
+    register_listing_table_with_format(&ctx, &table_name, table_path, sort_fields, sort_orders, parquet_format).await?;
 
     // Planning: build the query DataFrame (Substrait decode for normal search, native filter for an
     // engine-internal point lookup). Physical planning + execution below is shared by both.

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/scoped_page_index_reader.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/scoped_page_index_reader.rs
@@ -221,6 +221,7 @@ impl AsyncFileReader for ScopedPageIndexReader {
                 &location,
                 object_meta,
                 Arc::clone(&metadata_cache),
+                None,
             )
             .await
             .map_err(|e| ParquetError::General(format!("footer metadata {location}: {e}")))?;

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/session_context.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/session_context.rs
@@ -72,6 +72,12 @@ pub struct SessionContextHandle {
     /// Phantom reservation holding pool capacity for untracked memory.
     /// Dropped when the handle is closed, releasing the capacity.
     pub(crate) phantom_reservation: Option<datafusion::execution::memory_pool::MemoryReservation>,
+    /// Per-file PME footer keys (filename → 32-byte AES-GCM key). Carried from
+    /// `ShardView` so the indexed execution path can pass them to `build_segments`
+    /// for metadata decryption and to `IndexedTableConfig` for column data decryption.
+    pub file_footer_keys: Arc<std::collections::HashMap<String, Vec<u8>>>,
+    /// Per-file PME AAD prefixes (filename → binary AAD prefix).
+    pub file_aad_prefixes: Arc<std::collections::HashMap<String, Vec<u8>>>,
 }
 
 /// Configuration for indexed execution with filter delegation, provided by Java.
@@ -190,6 +196,20 @@ pub async unsafe fn create_session_context(
         Arc::clone(&shard_view.store),
     );
 
+    // Register PME decryption factory when footer keys are present.
+    // Both the factory registration AND the ParquetFormat factory_id must be set —
+    // DataFusion only calls the factory when the format is configured with the matching id.
+    if shard_view.file_footer_keys.is_empty() == false {
+        use crate::query_executor::{OPENSEARCH_PME_FACTORY_ID, OpenSearchPmeDecryptionFactory};
+        runtime_env.register_parquet_encryption_factory(
+            OPENSEARCH_PME_FACTORY_ID,
+            Arc::new(OpenSearchPmeDecryptionFactory::new(
+                Arc::clone(&shard_view.file_footer_keys),
+                Arc::clone(&shard_view.file_aad_prefixes),
+            )),
+        );
+    }
+
     // Acquire memory budget from cached parquet metadata (zero I/O).
     // On cache miss (first query for this shard), skip — subsequent queries benefit.
     let phantom_reservation = try_acquire_budget(
@@ -258,12 +278,24 @@ pub async unsafe fn create_session_context(
 
     // Register default ListingTable for parquet scans.
     //
+    // When PME footer keys are present, configure the ParquetFormat with the factory id
+    // so DataFusion's scan path calls get_file_decryption_properties on the registered factory.
     // `target_partitions` on the listing options drives the sort-aware bin-packer in
     // `split_groups_by_statistics_with_target_partitions`. We set it to the session's
     // effective partition count so the bin-packer produces up to N groups (one file per
     // group when min/max ranges can't chain). The session-state's `target_partitions`
     // controls EnforceDistribution; this one is independent.
-    let mut listing_options = ListingOptions::new(Arc::new(ParquetFormat::default()))
+    let parquet_format: Arc<dyn datafusion::datasource::file_format::FileFormat> =
+        if shard_view.file_footer_keys.is_empty() == false {
+            use crate::query_executor::OPENSEARCH_PME_FACTORY_ID;
+            use datafusion_common::config::TableParquetOptions;
+            let mut parquet_options = TableParquetOptions::default();
+            parquet_options.crypto.factory_id = Some(OPENSEARCH_PME_FACTORY_ID.to_owned());
+            Arc::new(ParquetFormat::new().with_options(parquet_options))
+        } else {
+            Arc::new(ParquetFormat::default())
+        };
+    let mut listing_options = ListingOptions::new(parquet_format)
         .with_file_extension(".parquet")
         .with_collect_stat(true)
         .with_target_partitions(effective_partitions);
@@ -300,6 +332,7 @@ pub async unsafe fn create_session_context(
                 &meta.location,
                 meta.clone(),
                 Arc::clone(&metadata_cache),
+                None,
             )
             .await;
         }
@@ -393,6 +426,8 @@ pub async unsafe fn create_session_context(
         has_topk,
         prepared_plan: None,
         phantom_reservation: phantom,
+        file_footer_keys: Arc::clone(&shard_view.file_footer_keys),
+        file_aad_prefixes: Arc::clone(&shard_view.file_aad_prefixes),
     };
     Ok(Box::into_raw(Box::new(handle)) as i64)
 }
@@ -752,6 +787,8 @@ mod tests {
             has_topk: false,
             prepared_plan: None,
             phantom_reservation: None,
+            file_footer_keys: Arc::new(std::collections::HashMap::new()),
+            file_aad_prefixes: Arc::new(std::collections::HashMap::new()),
         };
         (handle, buf)
     }

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/shard_table_provider.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/shard_table_provider.rs
@@ -25,6 +25,7 @@ use datafusion_datasource::file_groups::FileGroup;
 use datafusion_datasource::file_scan_config::FileScanConfigBuilder;
 use datafusion_datasource::table_schema::TableSchema;
 use datafusion_datasource::PartitionedFile;
+use datafusion_execution::parquet_encryption::EncryptionFactory;
 
 pub use crate::api::ShardFileInfo;
 
@@ -32,6 +33,9 @@ pub struct ShardTableConfig {
     pub file_schema: SchemaRef,
     pub files: Vec<ShardFileInfo>,
     pub store_url: ObjectStoreUrl,
+    /// PME decryption factory — when set, DataFusion calls it for each file to
+    /// derive `FileDecryptionProperties` before reading column data.
+    pub encryption_factory: Option<Arc<dyn EncryptionFactory>>,
 }
 
 pub struct ShardTableProvider {
@@ -110,6 +114,12 @@ impl TableProvider for ShardTableProvider {
         );
 
         let parquet_source = ParquetSource::new(table_schema);
+        // Wire PME decryption factory when the shard contains encrypted files.
+        let parquet_source = if let Some(ref factory) = self.config.encryption_factory {
+            parquet_source.with_encryption_factory(Arc::clone(factory))
+        } else {
+            parquet_source
+        };
 
         let mut builder = FileScanConfigBuilder::new(
             self.config.store_url.clone(),

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionPlugin.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionPlugin.java
@@ -23,6 +23,7 @@ import org.opensearch.be.datafusion.cache.CacheManager;
 import org.opensearch.be.datafusion.cache.CacheSettings;
 import org.opensearch.be.datafusion.cache.CacheUtils;
 import org.opensearch.be.datafusion.nativelib.NativeBridge;
+import org.opensearch.cluster.metadata.CryptoMetadata;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.node.DiscoveryNodes;
 import org.opensearch.cluster.service.ClusterService;
@@ -83,6 +84,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
+import java.util.Optional;
 import java.util.function.Supplier;
 
 import io.substrait.extension.DefaultExtensionCatalog;
@@ -954,13 +956,30 @@ public class DataFusionPlugin extends Plugin
                 }
             }
         }
+        // TODO: At the moment, PME uses index.store.parquet.crypto.* settings (not the Lucene-plugin index.store.crypto.* keys).
+        // This is because the setting is defined by the Lucene plugin, even though it should be defined
+        // in a generic place. We should find a consolidated location for this.
+        // However, CryptoMetadata.fromIndexSettings() assumes the Lucene-Plugin style keys, so
+        // we can't use it. So, we must extract them manually.
+        Optional<CryptoMetadata> cryptoMetadata = Optional.empty();
+        if (indexSettings != null) {
+            org.opensearch.common.settings.Settings raw = indexSettings.getSettings();
+            String keyProviderName = raw.get("index.store.parquet.crypto.key_provider");
+            if (keyProviderName != null && !keyProviderName.isEmpty()) {
+                String keyProviderType = raw.get("index.store.parquet.crypto.key_provider_type", "");
+                cryptoMetadata = Optional.of(
+                    new CryptoMetadata(keyProviderName, keyProviderType, org.opensearch.common.settings.Settings.EMPTY)
+                );
+            }
+        }
         return new DatafusionReaderManager(
             settings.format(),
             settings.shardPath(),
             dataFusionService,
             dataformatAwareStoreHandle,
             sortFields,
-            sortOrders
+            sortOrders,
+            cryptoMetadata
         );
     }
 

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionReader.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionReader.java
@@ -18,8 +18,10 @@ import org.opensearch.plugins.NativeStoreHandle;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
 /**
  * DataFusion reader for JNI operations.
@@ -38,7 +40,7 @@ public class DatafusionReader implements Closeable {
     private final ReaderHandle readerHandle;
 
     /**
-     * Creates a DatafusionReader for the given shard directory and per-segment files.
+     * Creates a DatafusionReader for the given shard directory and per-segment files (no encryption).
      * <p>
      * Each {@link WriterFileSet} is narrowed to a {@link MonoFileWriterSet} — Parquet
      * produces exactly one file per segment. This fails fast if a multi-file set is
@@ -50,12 +52,32 @@ public class DatafusionReader implements Closeable {
      * @param sortFields index.sort.field values (empty list when the index has no sort). Parallel to {@code sortOrders}.
      * @param sortOrders index.sort.order values ("asc"/"desc"), parallel to {@code sortFields}.
      */
+    /**
+     * Creates a DatafusionReader without encryption (plaintext files).
+     */
+    public DatafusionReader(String directoryPath, Collection<WriterFileSet> writerFileSets, NativeStoreHandle dataformatAwareStoreHandle) {
+        this(directoryPath, writerFileSets, dataformatAwareStoreHandle, List.of(), List.of(), Map.of(), Map.of());
+    }
+
+    /**
+     * Creates a DatafusionReader with per-file footer keys and AAD prefixes for PME-encrypted files.
+     *
+     * @param directoryPath  shard data directory
+     * @param writerFileSets the per-segment file sets from the catalog snapshot
+     * @param dataformatAwareStoreHandle per-format native store handle (null on hot, live on warm)
+     * @param sortFields index.sort.field values (empty list when the index has no sort). Parallel to {@code sortOrders}.
+     * @param sortOrders index.sort.order values ("asc"/"desc"), parallel to {@code sortFields}.
+     * @param fileFooterKeys map from absolute file path to 32-byte AES-GCM footer key
+     * @param fileAadPrefixes map from absolute file path to binary AAD prefix bytes
+     */
     public DatafusionReader(
         String directoryPath,
         Collection<WriterFileSet> writerFileSets,
         NativeStoreHandle dataformatAwareStoreHandle,
         List<String> sortFields,
-        List<String> sortOrders
+        List<String> sortOrders,
+        Map<String, byte[]> fileFooterKeys,
+        Map<String, byte[]> fileAadPrefixes
     ) {
         this.directoryPath = directoryPath;
         List<MonoFileWriterSet> segments;
@@ -64,7 +86,7 @@ public class DatafusionReader implements Closeable {
         } else {
             segments = writerFileSets.stream().map(MonoFileWriterSet::from).toList();
         }
-        readerHandle = new ReaderHandle(directoryPath, segments, dataformatAwareStoreHandle, sortFields, sortOrders);
+        readerHandle = new ReaderHandle(directoryPath, segments, dataformatAwareStoreHandle, sortFields, sortOrders, fileFooterKeys, fileAadPrefixes);
     }
 
     /**

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionReaderManager.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionReaderManager.java
@@ -10,19 +10,38 @@ package org.opensearch.be.datafusion;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.opensearch.cluster.metadata.CryptoMetadata;
+import org.opensearch.common.crypto.MasterKeyProvider;
 import org.opensearch.common.annotation.ExperimentalApi;
+import org.opensearch.crypto.CryptoHandlerRegistry;
+import org.opensearch.crypto.CryptoRegistryException;
 import org.opensearch.index.engine.dataformat.DataFormat;
 import org.opensearch.index.engine.exec.EngineReaderManager;
+import org.opensearch.index.engine.exec.WriterFileSet;
 import org.opensearch.index.engine.exec.coord.CatalogSnapshot;
 import org.opensearch.index.shard.ShardPath;
+import org.opensearch.plugins.CryptoKeyProviderPlugin;
 import org.opensearch.plugins.NativeStoreHandle;
+import org.opensearch.be.datafusion.nativelib.NativeBridge;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+import java.util.Base64;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
 
 /**
  * Manages {@link DatafusionReader} instances per shard.
@@ -51,9 +70,38 @@ public class DatafusionReaderManager implements EngineReaderManager<DatafusionRe
     private final List<String> sortFields;
     /** Parallel to {@link #sortFields}; values are {@code "asc"} or {@code "desc"}. */
     private final List<String> sortOrders;
+    private final Optional<CryptoMetadata> cryptoMetadata;
+    /** Path to the PME keyfile shared across all shards of this index on this node. */
+    private final Path keyfilePath;
+
 
     /**
-     * Creates a reader manager.
+     * Creates a reader manager with sort order and optional crypto metadata.
+     */
+    public DatafusionReaderManager(
+        DataFormat dataFormat,
+        ShardPath shardPath,
+        DataFusionService dataFusionService,
+        NativeStoreHandle dataformatAwareStoreHandle,
+        List<String> sortFields,
+        List<String> sortOrders,
+        Optional<CryptoMetadata> cryptoMetadata
+    ) {
+        this.dataFormat = dataFormat;
+        this.directoryPath = shardPath.getDataPath().resolve(dataFormat.name()).toString();
+        this.dataFusionService = dataFusionService;
+        this.dataformatAwareStoreHandle = dataformatAwareStoreHandle;
+        this.sortFields = sortFields == null ? List.of() : List.copyOf(sortFields);
+        this.sortOrders = sortOrders == null ? List.of() : List.copyOf(sortOrders);
+        this.cryptoMetadata = cryptoMetadata;
+        // keyfile is at <nodeDataPath>/indices/keyfile — two levels up from shard data path.
+        // shardPath.getDataPath() = .../indices/<shardId>
+        // .getParent().getParent() = .../indices (index-shared keyfile location)
+        this.keyfilePath = shardPath.getDataPath().getParent().getParent().resolve("keyfile");
+    }
+
+    /**
+     * Creates a reader manager without crypto metadata (unencrypted indices).
      * @param dataFormat the data format for this reader
      * @param shardPath the shard path to read data from
      * @param dataFusionService node-level service for cache management
@@ -73,12 +121,17 @@ public class DatafusionReaderManager implements EngineReaderManager<DatafusionRe
         List<String> sortFields,
         List<String> sortOrders
     ) {
-        this.dataFormat = dataFormat;
-        this.directoryPath = shardPath.getDataPath().resolve(dataFormat.name()).toString();
-        this.dataFusionService = dataFusionService;
-        this.dataformatAwareStoreHandle = dataformatAwareStoreHandle;
-        this.sortFields = sortFields == null ? List.of() : List.copyOf(sortFields);
-        this.sortOrders = sortOrders == null ? List.of() : List.copyOf(sortOrders);
+        this(dataFormat, shardPath, dataFusionService, dataformatAwareStoreHandle, sortFields, sortOrders, Optional.empty());
+    }
+
+    public DatafusionReaderManager(
+        DataFormat dataFormat,
+        ShardPath shardPath,
+        DataFusionService dataFusionService,
+        NativeStoreHandle dataformatAwareStoreHandle,
+        Optional<CryptoMetadata> cryptoMetadata
+    ) {
+        this(dataFormat, shardPath, dataFusionService, dataformatAwareStoreHandle, List.of(), List.of(), cryptoMetadata);
     }
 
     @Override
@@ -143,14 +196,267 @@ public class DatafusionReaderManager implements EngineReaderManager<DatafusionRe
     public void afterRefresh(boolean didRefresh, CatalogSnapshot catalogSnapshot) throws IOException {
         if (didRefresh == false) return;
         if (readers.containsKey(catalogSnapshot.getId())) return;
+        logger.trace("DataFusion PME: afterRefresh — building reader encrypted=[{}]", cryptoMetadata.isPresent());
+        Collection<WriterFileSet> fileSets = catalogSnapshot.getSearchableFiles(dataFormat.name());
+        Map<String, byte[]> fileFooterKeys = new HashMap<>();
+        Map<String, byte[]> fileAadPrefixes = new HashMap<>();
+        rehydrateEncryptionMaterial(fileSets, fileFooterKeys, fileAadPrefixes);
+        logger.trace("DataFusion PME: rehydrated keys for {} files", fileFooterKeys.size());
         DatafusionReader reader = new DatafusionReader(
             directoryPath,
-            catalogSnapshot.getSearchableFiles(dataFormat.name()),
+            fileSets,
             dataformatAwareStoreHandle,
             sortFields,
-            sortOrders
+            sortOrders,
+            fileFooterKeys,
+            fileAadPrefixes
         );
         readers.put(catalogSnapshot.getId(), reader);
+    }
+
+    private void rehydrateEncryptionMaterial(
+        Collection<WriterFileSet> fileSets,
+        Map<String, byte[]> fileFooterKeys,
+        Map<String, byte[]> fileAadPrefixes
+    ) throws IOException {
+        if (fileSets == null || fileSets.isEmpty()) {
+            return;
+        }
+
+        logger.trace("DataFusion PME: rehydrateEncryptionMaterial — {} file sets", fileSets.size());
+
+        // Resolve store pointer once for all files in this refresh.
+        // 0 = default local filesystem; >0 = tiered/object-store via NativeStoreHandle.
+        long storePtr = 0L;
+        if (dataformatAwareStoreHandle != null) {
+            try {
+                storePtr = dataformatAwareStoreHandle.getPointer();
+            } catch (IllegalStateException e) {
+                // Handle closed between check and extraction — fall back to local.
+                storePtr = 0L;
+            }
+        }
+
+        byte[] dataKey = null;
+        try {
+            for (WriterFileSet fileSet : fileSets) {
+                for (String file : fileSet.files()) {
+                    logger.trace("DataFusion PME: reading footer key_metadata for file=[{}]", file);
+                    byte[] keyMetadataBytes = NativeBridge.readFooterKeyMetadata(directoryPath, file, storePtr);
+                    if (keyMetadataBytes == null) {
+                        // Plain-text file or PARE without key_metadata — no decryption needed.
+                        logger.trace("DataFusion PME: file=[{}] not encrypted", file);
+                        continue;
+                    }
+
+                    // Encrypted file — require cryptoMetadata to be configured.
+                    if (cryptoMetadata.isPresent() == false) {
+                        throw new IOException(
+                            "PME-encrypted file found but no crypto metadata configured for this index: " + file
+                        );
+                    }
+
+                    // Load the data key on first encounter (shared across all files in this shard).
+                    if (dataKey == null) {
+                        dataKey = loadDataKey();
+                    }
+
+                    String keyMetadataJson = new String(keyMetadataBytes, StandardCharsets.UTF_8);
+                    byte[] messageId = parseMessageIdFromKeyMetadataJson(file, keyMetadataJson);
+                    byte[] footerKey = deriveFooterKey(dataKey, messageId);
+                    logger.trace("DataFusion PME: footer key derived for file=[{}] keyLen=[{}]", file, footerKey.length);
+                    fileFooterKeys.put(file, footerKey);
+                    fileAadPrefixes.put(file, buildAadPrefix(messageId));
+                    logger.trace("DataFusion PME: AAD prefix built for file=[{}]", file);
+                }
+            }
+        } finally {
+            if (dataKey != null) {
+                Arrays.fill(dataKey, (byte) 0);
+            }
+        }
+
+        logger.trace("DataFusion PME: rehydration complete — {} footer keys, {} AAD prefixes",
+            fileFooterKeys.size(), fileAadPrefixes.size());
+    }
+
+    /**
+     * Loads the raw 32-byte index data key from the keyfile using the configured
+     * {@link MasterKeyProvider}. Mirrors {@code PmeKeyfileManager.loadKey()} — inlined here
+     * to avoid a compile-scope dependency on {@code parquet-data-format}.
+     */
+    private byte[] loadDataKey() throws IOException {
+        if (cryptoMetadata.isPresent() == false) {
+            throw new IOException("PME-encrypted files present but no crypto metadata configured for this index");
+        }
+        if (Files.exists(keyfilePath) == false) {
+            throw new IOException("PME keyfile not found at [" + keyfilePath + "]; cannot derive footer keys for encrypted files");
+        }
+        byte[] encryptedKey = Files.readAllBytes(keyfilePath);
+        try (MasterKeyProvider keyProvider = createKeyProviderForRead()) {
+            if (keyProvider == null) {
+                throw new IOException("PME metadata present but index crypto settings are not configured");
+            }
+            byte[] rawKey = keyProvider.decryptKey(encryptedKey);
+            if (rawKey == null || rawKey.length != 32) {
+                throw new IOException("PME keyfile decrypted to unexpected length: " + (rawKey == null ? 0 : rawKey.length));
+            }
+            logger.trace("DataFusion PME: data key loaded from keyfile [{}]", keyfilePath);
+            return rawKey;
+        }
+    }
+
+    // TODO: The helpers below (deriveFooterKey, parseMessageIdFromKeyMetadataJson, buildAadPrefix)
+    //  duplicate logic that lives canonically in PmeKeyDerivation and PmeFileKeyMetadata inside the
+    //  parquet-data-format plugin. They are inlined here because parquet-data-format is only on
+    //  the testImplementation classpath of this module — adding it as a compile/implementation
+    //  dependency would create a plugin-to-plugin compile dependency that causes jar-hell at
+    //  runtime (both plugins load in separate classloaders under the same OpenSearch node).
+    //  The right long-term fix is to extract the shared PME crypto primitives into a dedicated
+    //  library module (e.g. sandbox:libs:pme-crypto) that both plugins can depend on without
+    //  classloader conflicts. Until then, keep these helpers in sync with the originals manually.
+
+    /**
+     * Derives the PME footer key from the 32-byte data key and 16-byte message_id.
+     * Inlined from {@code PmeKeyDerivation.deriveFooterKey()} — see TODO above.
+     *
+     * <pre>
+     * PRK          = HMAC-SHA384(key=dataKey,  data=messageId)
+     * T1           = HMAC-SHA384(key=PRK,       data=context || 0x01)
+     * footerKey    = first 16 bytes of T1
+     * context      = "opensearch/parquet-pme/footer-key/v1"
+     * </pre>
+     */
+    private static byte[] deriveFooterKey(byte[] dataKey, byte[] messageId) throws IOException {
+        try {
+            byte[] prk = hmacSha384(dataKey, messageId);
+            String context = "opensearch/parquet-pme/footer-key/v1";
+            byte[] contextBytes = context.getBytes(StandardCharsets.UTF_8);
+            byte[] expandInput = new byte[contextBytes.length + 1];
+            System.arraycopy(contextBytes, 0, expandInput, 0, contextBytes.length);
+            expandInput[contextBytes.length] = 0x01;
+            byte[] t1 = hmacSha384(prk, expandInput);
+            Arrays.fill(prk, (byte) 0);
+            // TODO: 16 bytes due to current parquet-rs limitation (mirrors PmeKeyDerivation.FOOTER_KEY_BYTES)
+            // This might be solved with parquet-rs v59, see https://github.com/apache/arrow-rs/pull/9203
+            return Arrays.copyOf(t1, 16);
+        } catch (NoSuchAlgorithmException | InvalidKeyException e) {
+            throw new IOException("PME footer key derivation failed", e);
+        }
+    }
+
+    private static byte[] hmacSha384(byte[] key, byte[] data) throws NoSuchAlgorithmException, InvalidKeyException {
+        Mac mac = Mac.getInstance("HmacSHA384");
+        mac.init(new SecretKeySpec(key, "HmacSHA384"));
+        return mac.doFinal(data);
+    }
+
+    /**
+     * Parses the {@code message_id} field from a v1 PME key-metadata JSON string.
+     * Uses Jackson with {@code FAIL_ON_UNKNOWN_PROPERTIES=true} so any unrecognised
+     * field causes a hard failure (fail-closed). Validates:
+     * <ul>
+     *   <li>{@code version} == 1</li>
+     *   <li>{@code data_key_id} == {@code "default"}</li>
+     *   <li>{@code message_id} decodes from base64url to exactly 16 bytes</li>
+     * </ul>
+     */
+    private static byte[] parseMessageIdFromKeyMetadataJson(String file, String json) throws IOException {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true);
+        PmeKeyMetadata meta;
+        try {
+            meta = mapper.readValue(json, PmeKeyMetadata.class);
+        } catch (Exception e) {
+            throw new IOException("PME key metadata JSON parse error for file: " + file, e);
+        }
+        if (meta.version != 1) {
+            throw new IOException(
+                "PME key metadata version must be 1, got " + meta.version + " for file: " + file
+            );
+        }
+        if ("default".equals(meta.data_key_id) == false) {
+            throw new IOException(
+                "PME key metadata data_key_id must be 'default', got '" + meta.data_key_id
+                    + "' for file: " + file
+            );
+        }
+        if (meta.message_id == null || meta.message_id.isEmpty()) {
+            throw new IOException("PME key metadata missing message_id for file: " + file);
+        }
+        byte[] messageId;
+        try {
+            messageId = Base64.getUrlDecoder().decode(meta.message_id);
+        } catch (IllegalArgumentException e) {
+            throw new IOException("PME key metadata invalid base64url message_id for file: " + file, e);
+        }
+        if (messageId.length != 16) {
+            throw new IOException(
+                "PME key metadata message_id must be 16 bytes, got " + messageId.length
+                    + " for file: " + file
+            );
+        }
+        return messageId;
+    }
+
+    /** Jackson DTO for PME key-metadata JSON. All fields are required; unknown fields are rejected. */
+    private static class PmeKeyMetadata {
+        public int version;
+        public String data_key_id;
+        public String message_id;
+    }
+
+    /**
+     * Builds the v1 binary AAD prefix for the given 16-byte message_id.
+     * Inlined from {@code PmeKeyDerivation.buildAadPrefix()} — see TODO above.
+     *
+     * <pre>
+     * u16_be(domain.len) || domain || u8(1) || u16_be(dataKeyId.len) || dataKeyId || messageId[16]
+     * </pre>
+     */
+    private static byte[] buildAadPrefix(byte[] messageId) {
+        byte[] domain = "opensearch/parquet-pme/file/v1".getBytes(StandardCharsets.UTF_8);
+        byte[] dataKeyId = "default".getBytes(StandardCharsets.UTF_8);
+        byte[] aad = new byte[2 + domain.length + 1 + 2 + dataKeyId.length + 16];
+        int pos = 0;
+        aad[pos++] = (byte) (domain.length >>> 8);
+        aad[pos++] = (byte) domain.length;
+        System.arraycopy(domain, 0, aad, pos, domain.length);
+        pos += domain.length;
+        aad[pos++] = 0x01; // version
+        aad[pos++] = (byte) (dataKeyId.length >>> 8);
+        aad[pos++] = (byte) dataKeyId.length;
+        System.arraycopy(dataKeyId, 0, aad, pos, dataKeyId.length);
+        pos += dataKeyId.length;
+        System.arraycopy(messageId, 0, aad, pos, 16);
+        return aad;
+    }
+
+    private MasterKeyProvider createKeyProviderForRead() {
+        if (cryptoMetadata.isPresent() == false) {
+            return null;
+        }
+
+        CryptoMetadata metadata = cryptoMetadata.get();
+        CryptoHandlerRegistry cryptoHandlerRegistry = CryptoHandlerRegistry.getInstance();
+        if (cryptoHandlerRegistry == null) {
+            throw new IllegalStateException("CryptoHandlerRegistry is not initialized");
+        }
+
+        // PME only needs the MasterKeyProvider to decrypt the keyfile — it does NOT require a
+        // full CryptoPlugin (which handles data-at-rest encryption via CryptoHandler).
+        // Calling fetchCryptoHandler() would try to create a CryptoHandler, which requires a
+        // CryptoPlugin to be registered. The mock-pme-kms (and any PME-only plugin) only
+        // implements CryptoKeyProviderPlugin, so we go directly to getCryptoKeyProviderPlugin.
+        CryptoKeyProviderPlugin keyProviderPlugin = cryptoHandlerRegistry.getCryptoKeyProviderPlugin(metadata.keyProviderType());
+        if (keyProviderPlugin == null) {
+            throw new CryptoRegistryException(
+                metadata.keyProviderName(),
+                metadata.keyProviderType(),
+                "Crypto key provider plugin not found for DataFusion PME read"
+            );
+        }
+        return keyProviderPlugin.createKeyProvider(metadata);
     }
 
     private Collection<String> toAbsolutePaths(Collection<String> fileNames) {

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/GetService.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/GetService.java
@@ -115,7 +115,7 @@ public class GetService implements Closeable {
             // ReaderHandle registers the native pointer with NativeHandle so downstream
             // validatePointer() calls in executeQueryAsync() find it in the live set.
             MonoFileWriterSet segment = MonoFileWriterSet.of(parquetDir, parquetSet.writerGeneration(), parquetFile, 0L);
-            try (ReaderHandle readerHandle = new ReaderHandle(parquetDir, List.of(segment), null, List.of(), List.of())) {
+            try (ReaderHandle readerHandle = new ReaderHandle(parquetDir, List.of(segment), null)) {
                 long readerPtr = readerHandle.getPointer();
                 // Internal-search get-by-row-id: the native side ignores Substrait and builds a
                 // DataFrame plan filtering `__row_id__ = rowId` with pushdown enabled. __row_id__ is
@@ -143,7 +143,7 @@ public class GetService implements Closeable {
                 String parquetDir = parquetSet.directory();
                 String parquetFile = parquetSet.files().iterator().next();
                 MonoFileWriterSet writerSet = MonoFileWriterSet.of(parquetDir, parquetSet.writerGeneration(), parquetFile, 0L);
-                try (ReaderHandle readerHandle = new ReaderHandle(parquetDir, List.of(writerSet), null, List.of(), List.of())) {
+                try (ReaderHandle readerHandle = new ReaderHandle(parquetDir, List.of(writerSet), null)) {
                     long readerPtr = readerHandle.getPointer();
                     // Internal-search seq-no scan: the native side ignores Substrait and builds a
                     // DataFrame plan filtering `_seq_no > seqNoFloor`, projecting only the version

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/nativelib/NativeBridge.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/nativelib/NativeBridge.java
@@ -151,6 +151,7 @@ public final class NativeBridge {
     private static final MethodHandle EXECUTE_LOCAL_PREPARED_PLAN;
     private static final MethodHandle FETCH_BY_ROW_IDS;
     private static final MethodHandle UPDATE_CONCURRENCY_GATE;
+    private static final MethodHandle READ_FOOTER_KEY_METADATA;
 
     static {
         SymbolLookup lib = NativeLibraryLoader.symbolLookup();
@@ -236,6 +237,12 @@ public final class NativeBridge {
             FunctionDescriptor.ofVoid(ValueLayout.JAVA_LONG, ValueLayout.JAVA_LONG, ValueLayout.JAVA_LONG, ValueLayout.JAVA_LONG)
         );
 
+        // df_create_reader(path, path_len,
+        //   files_ptrs, files_lens, writer_generations, count, store_ptr,
+        //   key_files_ptrs, key_files_lens, key_files_count,
+        //   key_bytes_ptrs, key_bytes_lens, key_bytes_count,
+        //   aad_files_ptrs, aad_files_lens, aad_files_count,
+        //   aad_bytes_ptrs, aad_bytes_lens, aad_bytes_count) -> i64
         CREATE_READER = linker.downcallHandle(
             lib.find("df_create_reader").orElseThrow(),
             FunctionDescriptor.of(
@@ -251,7 +258,19 @@ public final class NativeBridge {
                 ValueLayout.ADDRESS,    // sort_fields_len_ptr
                 ValueLayout.ADDRESS,    // sort_orders_ptr (parallel String[] for index.sort.order: "asc"|"desc")
                 ValueLayout.ADDRESS,    // sort_orders_len_ptr
-                ValueLayout.JAVA_LONG   // sort_count (0 when index has no sort)
+                ValueLayout.JAVA_LONG,  // sort_count (0 when index has no sort)
+                ValueLayout.ADDRESS,    // key_files_ptrs
+                ValueLayout.ADDRESS,    // key_files_lens
+                ValueLayout.JAVA_LONG,  // key_files_count
+                ValueLayout.ADDRESS,    // key_bytes_ptrs
+                ValueLayout.ADDRESS,    // key_bytes_lens
+                ValueLayout.JAVA_LONG,  // key_bytes_count
+                ValueLayout.ADDRESS,    // aad_files_ptrs
+                ValueLayout.ADDRESS,    // aad_files_lens
+                ValueLayout.JAVA_LONG,  // aad_files_count
+                ValueLayout.ADDRESS,    // aad_bytes_ptrs
+                ValueLayout.ADDRESS,    // aad_bytes_lens
+                ValueLayout.JAVA_LONG   // aad_bytes_count
             )
         );
 
@@ -635,6 +654,25 @@ public final class NativeBridge {
             lib.find("df_update_concurrency_gate").orElseThrow(),
             FunctionDescriptor.of(ValueLayout.JAVA_LONG, ValueLayout.ADDRESS, ValueLayout.JAVA_LONG, ValueLayout.JAVA_INT)
         );
+
+        // i64 df_read_footer_key_metadata(table_path_ptr, table_path_len,
+        //   filename_ptr, filename_len, store_ptr,
+        //   out_buf_ptr, out_buf_cap, out_len_ptr) → i64
+        // Returns 0 = key_metadata written; 1 = not encrypted; <0 = error.
+        READ_FOOTER_KEY_METADATA = linker.downcallHandle(
+            lib.find("df_read_footer_key_metadata").orElseThrow(),
+            FunctionDescriptor.of(
+                ValueLayout.JAVA_LONG,
+                ValueLayout.ADDRESS,    // table_path_ptr
+                ValueLayout.JAVA_LONG,  // table_path_len
+                ValueLayout.ADDRESS,    // filename_ptr
+                ValueLayout.JAVA_LONG,  // filename_len
+                ValueLayout.JAVA_LONG,  // store_ptr
+                ValueLayout.ADDRESS,    // out_buf_ptr
+                ValueLayout.JAVA_LONG,  // out_buf_cap
+                ValueLayout.ADDRESS     // out_len_ptr
+            )
+        );
     }
 
     private NativeBridge() {}
@@ -895,7 +933,7 @@ public final class NativeBridge {
     // ---- Reader management (confined Arena for path + file strings) ----
 
     /**
-     * Creates a native reader. Returns an opaque native pointer.
+     * Creates a native reader with footer keys and AAD prefixes for PME-encrypted files. Returns an opaque native pointer.
      * Freed by {@link #closeDatafusionReader}.
      *
      * @param path     shard data directory
@@ -913,7 +951,9 @@ public final class NativeBridge {
         List<org.opensearch.index.engine.exec.MonoFileWriterSet> segments,
         NativeStoreHandle dataformatAwareStoreHandle,
         List<String> sortFields,
-        List<String> sortOrders
+        List<String> sortOrders,
+        java.util.Map<String, byte[]> fileFooterKeys,
+        java.util.Map<String, byte[]> fileAadPrefixes
     ) {
         long storePtr = 0L;
         if (dataformatAwareStoreHandle != null) {
@@ -935,6 +975,14 @@ public final class NativeBridge {
                     + ") must have the same length"
             );
         }
+        if (fileFooterKeys == null) fileFooterKeys = java.util.Map.of();
+        if (fileAadPrefixes == null) fileAadPrefixes = java.util.Map.of();
+        java.util.List<java.util.Map.Entry<String, byte[]>> keyEntries = new java.util.ArrayList<>(fileFooterKeys.entrySet());
+        java.util.List<java.util.Map.Entry<String, byte[]>> aadEntries = new java.util.ArrayList<>(fileAadPrefixes.entrySet());
+        String[] keyFiles = keyEntries.stream().map(java.util.Map.Entry::getKey).toArray(String[]::new);
+        byte[][] keyBytes = keyEntries.stream().map(java.util.Map.Entry::getValue).toArray(byte[][]::new);
+        String[] aadFiles = aadEntries.stream().map(java.util.Map.Entry::getKey).toArray(String[]::new);
+        byte[][] aadBytes = aadEntries.stream().map(java.util.Map.Entry::getValue).toArray(byte[][]::new);
         try (var call = new NativeCall()) {
             var p = call.str(path);
             var f = call.strArray(segments.stream().map(org.opensearch.index.engine.exec.MonoFileWriterSet::file).toArray(String[]::new));
@@ -943,6 +991,10 @@ public final class NativeBridge {
             );
             var sf = call.strArray(sortFields.toArray(String[]::new));
             var so = call.strArray(sortOrders.toArray(String[]::new));
+            var kf = call.strArray(keyFiles);
+            var kb = call.bytesArray(keyBytes);
+            var af = call.strArray(aadFiles);
+            var ab = call.bytesArray(aadBytes);
             return call.invoke(
                 CREATE_READER,
                 p.segment(),
@@ -956,13 +1008,48 @@ public final class NativeBridge {
                 sf.lens(),
                 so.ptrs(),
                 so.lens(),
-                sf.count()
+                sf.count(),
+                kf.ptrs(),
+                kf.lens(),
+                kf.count(),
+                kb.ptrs(),
+                kb.lens(),
+                kb.count(),
+                af.ptrs(),
+                af.lens(),
+                af.count(),
+                ab.ptrs(),
+                ab.lens(),
+                ab.count()
             );
         }
     }
 
+    public static long createDatafusionReader(
+        String path,
+        List<org.opensearch.index.engine.exec.MonoFileWriterSet> segments,
+        NativeStoreHandle dataformatAwareStoreHandle
+    ) {
+        return createDatafusionReader(path, segments, dataformatAwareStoreHandle,
+            List.of(), List.of(), java.util.Map.of(), java.util.Map.of());
+    }
+
     public static void closeDatafusionReader(long ptr) {
         NativeCall.invokeVoid(CLOSE_READER, ptr);
+    }
+
+    /**
+     * Convenience overload for {@link #executeQueryAsync} with no context and no query config
+     * (contextId=0, queryConfigPtr=0). Intended for tests and simple query paths.
+     */
+    public static void executeQueryAsync(
+        long readerPtr,
+        String tableName,
+        byte[] substraitPlan,
+        long runtimePtr,
+        ActionListener<Long> listener
+    ) {
+        executeQueryAsync(readerPtr, tableName, substraitPlan, runtimePtr, 0L, 0L, listener);
     }
 
     // ---- Query execution (confined Arena for tableName + plan bytes) ----
@@ -974,6 +1061,9 @@ public final class NativeBridge {
     /** {@code internal_search_mode}: seq-no scan — native plan filters {@code _seq_no > bound}, {@code substraitPlan} ignored. */
     public static final long INTERNAL_SEARCH_SEQ_NO_ABOVE = 2L;
 
+    /**
+     * Executes a query asynchronously with explicit context and config pointers.
+     */
     public static void executeQueryAsync(
         long readerPtr,
         String tableName,
@@ -1770,4 +1860,49 @@ public final class NativeBridge {
     }
 
     public static void initLogger() {}
+
+    /**
+     * Sentinel returned by {@link #readFooterKeyMetadata} when the file is not encrypted
+     * (PAR1 magic) or the encrypted footer has no {@code key_metadata} field.
+     * MUST match {@code Ok(1)} returned by {@code df_read_footer_key_metadata} in Rust.
+     */
+    private static final long READ_FOOTER_KEY_METADATA_NOT_ENCRYPTED = 1L;
+
+    /**
+     * Reads {@code FileCryptoMetaData.key_metadata} from the tail of a Parquet file via
+     * two object-store range reads — never downloads the full file.
+     *
+     * @param tablePath the shard data directory (absolute path or object-store URL)
+     * @param filename  the Parquet file name relative to {@code tablePath}
+     * @param storePtr  native object-store pointer ({@code NativeStoreHandle.getPointer()}),
+     *                  or {@code 0} to use the default local filesystem
+     * @return the raw {@code key_metadata} bytes if the file is PME-encrypted,
+     *         or {@code null} if the file is plain-text or has no {@code key_metadata}
+     * @throws RuntimeException on I/O error, malformed footer, or unsupported magic
+     */
+    public static byte[] readFooterKeyMetadata(String tablePath, String filename, long storePtr) {
+        try (var call = new NativeCall()) {
+            var tp = call.str(tablePath);
+            var fn = call.str(filename);
+            // V1 key_metadata JSON has no variable-size fields:
+            //   {"version":1,"data_key_id":"default","message_id":"<22 chars>"}
+            //   prefix (51) + base64url(16-byte message_id without padding: ⌈16/3⌉×4 − 2 = 22) + suffix "}" (2) = 75 bytes exactly.
+            //   base64url formula: 16 = 5×3 + 1 → 20 full-group chars + 2 remainder chars, no padding = 22.
+            // 128 bytes is used as a power-of-two ceiling that tolerates minor future v2 format changes.
+            // If the buffer is exceeded, Rust returns an error (< 0) without writing any bytes and
+            // the call throws RuntimeException — fail-closed, no truncated or partial output.
+            var out = call.outBuffer(128);
+            long rc = call.invoke(
+                READ_FOOTER_KEY_METADATA,
+                tp.segment(), tp.len(),
+                fn.segment(), fn.len(),
+                storePtr,
+                out.data(), (long) out.capacity(), out.lenOut()
+            );
+            if (rc == READ_FOOTER_KEY_METADATA_NOT_ENCRYPTED) {
+                return null;
+            }
+            return out.toByteArray();
+        }
+    }
 }

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/nativelib/ReaderHandle.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/nativelib/ReaderHandle.java
@@ -12,7 +12,11 @@ import org.opensearch.analytics.backend.jni.NativeHandle;
 import org.opensearch.index.engine.exec.MonoFileWriterSet;
 import org.opensearch.plugins.NativeStoreHandle;
 
+import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.IntStream;
 
 /**
  * Type-safe handle for native reader.
@@ -37,16 +41,89 @@ public final class ReaderHandle extends NativeHandle {
         List<MonoFileWriterSet> segments,
         NativeStoreHandle dataformatAwareStoreHandle,
         List<String> sortFields,
+        List<String> sortOrders,
+        java.util.Map<String, byte[]> fileFooterKeys,
+        java.util.Map<String, byte[]> fileAadPrefixes
+    ) {
+        super(NativeBridge.createDatafusionReader(path, segments, dataformatAwareStoreHandle, sortFields, sortOrders, fileFooterKeys, fileAadPrefixes));
+        this.ownsPointer = true;
+    }
+
+    public ReaderHandle(String path, List<MonoFileWriterSet> segments, NativeStoreHandle dataformatAwareStoreHandle) {
+        this(path, segments, dataformatAwareStoreHandle, List.of(), List.of(), java.util.Map.of(), java.util.Map.of());
+    }
+
+    /**
+     * Convenience constructor for sort-only reads (no encryption).
+     */
+    public ReaderHandle(
+        String path,
+        List<MonoFileWriterSet> segments,
+        NativeStoreHandle dataformatAwareStoreHandle,
+        List<String> sortFields,
         List<String> sortOrders
     ) {
-        super(NativeBridge.createDatafusionReader(path, segments, dataformatAwareStoreHandle, sortFields, sortOrders));
-        this.ownsPointer = true;
+        this(path, segments, dataformatAwareStoreHandle, sortFields, sortOrders, java.util.Map.of(), java.util.Map.of());
     }
 
     /** Wraps an existing pointer without taking ownership. */
     private ReaderHandle(long existingPtr) {
         super(existingPtr);
         this.ownsPointer = false;
+    }
+
+    /**
+     * Convenience constructor for unencrypted reads from a directory (test / simple read path).
+     *
+     * @param directoryPath directory containing the Parquet files
+     * @param files         file names (relative to directory) to register as segments
+     */
+    public ReaderHandle(String directoryPath, String[] files) {
+        this(directoryPath, fileNamesToSegments(directoryPath, files), null);
+    }
+
+    /**
+     * Convenience constructor for PME-encrypted reads (test / simple read path).
+     *
+     * @param directoryPath   directory containing the Parquet files
+     * @param files           file names (relative to directory) to register as segments
+     * @param footerKeyFiles  file names that have footer keys (parallel with {@code footerKeys})
+     * @param footerKeys      raw 32-byte footer keys, one per {@code footerKeyFiles} entry
+     * @param aadPrefixFiles  file names that have AAD prefixes (parallel with {@code aadPrefixes})
+     * @param aadPrefixes     binary AAD prefix bytes, one per {@code aadPrefixFiles} entry
+     */
+    public ReaderHandle(
+        String directoryPath,
+        String[] files,
+        String[] footerKeyFiles,
+        byte[][] footerKeys,
+        String[] aadPrefixFiles,
+        byte[][] aadPrefixes
+    ) {
+        this(
+            directoryPath,
+            fileNamesToSegments(directoryPath, files),
+            null,
+            List.of(),
+            List.of(),
+            toMap(footerKeyFiles, footerKeys),
+            toMap(aadPrefixFiles, aadPrefixes)
+        );
+    }
+
+    private static List<MonoFileWriterSet> fileNamesToSegments(String directoryPath, String[] files) {
+        if (files == null || files.length == 0) return List.of();
+        return Arrays.stream(files)
+            .map(f -> MonoFileWriterSet.of(directoryPath, 0L, f, 0L))
+            .toList();
+    }
+
+    private static Map<String, byte[]> toMap(String[] keys, byte[][] values) {
+        if (keys == null || keys.length == 0) return Map.of();
+        Map<String, byte[]> map = new HashMap<>();
+        IntStream.range(0, Math.min(keys.length, values.length))
+            .forEach(i -> map.put(keys[i], values[i]));
+        return map;
     }
 
     @Override

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionEncryptedQueryExecutionTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionEncryptedQueryExecutionTests.java
@@ -1,0 +1,276 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion;
+
+import org.apache.arrow.c.ArrowArray;
+import org.apache.arrow.c.ArrowSchema;
+import org.apache.arrow.c.CDataDictionaryProvider;
+import org.apache.arrow.c.Data;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.opensearch.be.datafusion.nativelib.NativeBridge;
+import org.opensearch.be.datafusion.nativelib.ReaderHandle;
+import org.opensearch.be.datafusion.nativelib.StreamHandle;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.nativebridge.spi.ArrowExport;
+import org.opensearch.parquet.bridge.NativeParquetWriter;
+import org.opensearch.parquet.bridge.RustBridge;
+import org.opensearch.parquet.encryption.PmeDataKey;
+import org.opensearch.parquet.encryption.PmeFileEncryptionInputs;
+import org.opensearch.parquet.encryption.PmeFileKeyMetadata;
+import org.opensearch.parquet.encryption.PmeKeyDerivation;
+import org.opensearch.test.OpenSearchTestCase;
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+
+import static org.apache.arrow.c.Data.importField;
+
+/**
+ * End-to-end test: write a PME-encrypted Parquet file, then query it through DataFusion's
+ * SQL execution path with decryption keys supplied to {@link ReaderHandle}.
+ *
+ * <p>This is the encrypted companion of {@link DataFusionQueryExecutionTests}. The test:
+ * <ol>
+ *   <li>Writes an encrypted Parquet file using {@link NativeParquetWriter} with a derived
+ *       PME footer key (as the real write path does via {@link PmeFileEncryptionInputs}).</li>
+ *   <li>Parses the metadata and re-derives the footer key + AAD prefix from the same data key
+ *       (simulating what the read path does via {@code PmeContext}).</li>
+ *   <li>Creates a {@link ReaderHandle} that supplies the footer key and AAD prefix to
+ *       DataFusion's decryption factory.</li>
+ *   <li>Runs the same SQL queries as {@link DataFusionQueryExecutionTests} and asserts
+ *       identical results.</li>
+ * </ol>
+ */
+public class DataFusionEncryptedQueryExecutionTests extends OpenSearchTestCase {
+
+    private static final String TABLE = "enc_table";
+    private static final String FILE = "encrypted.parquet";
+
+    private NativeRuntimeHandle runtimeHandle;
+    private Path dataDir;
+    private Arena configArena;
+    private long queryConfigPtr;
+
+    /** The 32-byte data key used to derive per-file footer keys. */
+    private byte[] dataKey;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        RustBridge.initLogger();
+        NativeBridge.initTokioRuntimeManager(2);
+        Path spillDir = createTempDir("datafusion-spill");
+        runtimeHandle = new NativeRuntimeHandle(
+            NativeBridge.createGlobalRuntime(128 * 1024 * 1024, 0L, spillDir.toString(), 64 * 1024 * 1024)
+        );
+
+        // Build a valid WireConfigSnapshot so Rust's from_ffm_ptr never sees a null pointer.
+        configArena = Arena.ofConfined();
+        MemorySegment configSegment = configArena.allocate(WireConfigSnapshot.BYTE_SIZE);
+        WireConfigSnapshot.builder().build().writeTo(configSegment);
+        queryConfigPtr = configSegment.address();
+
+        dataKey = randomByteArrayOfLength(PmeKeyDerivation.DATA_KEY_BYTES);
+        dataDir = createTempDir("datafusion-encrypted");
+        writeEncryptedParquet(dataDir.resolve(FILE).toString());
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        configArena.close();
+        runtimeHandle.close();
+        super.tearDown();
+    }
+
+    // ---- tests ----
+
+    public void testSelectAllEncrypted() throws Exception {
+        try (ReaderHandle reader = encryptedReader()) {
+            List<Object[]> rows = executeQuery(reader, "SELECT id, score FROM " + TABLE);
+            assertEquals(3, rows.size());
+            assertEquals(1L, rows.get(0)[0]);
+            assertEquals(100L, rows.get(0)[1]);
+            assertEquals(2L, rows.get(1)[0]);
+            assertEquals(200L, rows.get(1)[1]);
+            assertEquals(3L, rows.get(2)[0]);
+            assertEquals(300L, rows.get(2)[1]);
+        }
+    }
+
+    public void testFilterEncrypted() throws Exception {
+        try (ReaderHandle reader = encryptedReader()) {
+            List<Object[]> rows = executeQuery(reader, "SELECT id FROM " + TABLE + " WHERE id > 1");
+            assertEquals(2, rows.size());
+            assertEquals(2L, rows.get(0)[0]);
+            assertEquals(3L, rows.get(1)[0]);
+        }
+    }
+
+    public void testAggregationEncrypted() throws Exception {
+        try (ReaderHandle reader = encryptedReader()) {
+            List<Object[]> rows = executeQuery(reader, "SELECT SUM(score) as total, COUNT(*) as cnt FROM " + TABLE);
+            assertEquals(1, rows.size());
+            assertEquals(600L, rows.get(0)[0]); // 100 + 200 + 300
+            assertEquals(3L, rows.get(0)[1]);
+        }
+    }
+
+    /**
+     * Verifies that DataFusion rejects the encrypted file when no decryption key is provided.
+     * An unencrypted {@link ReaderHandle} must fail to query the file.
+     */
+    public void testUnencryptedReaderFailsOnEncryptedFile() {
+        try (ReaderHandle reader = new ReaderHandle(dataDir.toString(), new String[] { FILE })) {
+            expectThrows(Exception.class, () -> executeQuery(reader, "SELECT id FROM " + TABLE));
+        }
+    }
+
+    // ---- helpers ----
+
+    /**
+     * Writes a small encrypted Parquet file to {@code filePath} with three rows:
+     * (id=1, score=100), (id=2, score=200), (id=3, score=300).
+     *
+     * <p>Uses {@link NativeParquetWriter} with a {@link PmeFileEncryptionInputs} derived from
+     * {@link #dataKey}, mirroring the production write path.
+     */
+    private void writeEncryptedParquet(String filePath) throws Exception {
+        Schema schema = new Schema(
+            List.of(
+                new Field("id", FieldType.nullable(new ArrowType.Int(64, true)), null),
+                new Field("score", FieldType.nullable(new ArrowType.Int(64, true)), null)
+            )
+        );
+
+        PmeFileEncryptionInputs enc = PmeFileEncryptionInputs.create(new PmeDataKey(dataKey));
+
+        try (
+            RootAllocator allocator = new RootAllocator();
+            ArrowExport schemaExport = exportSchema(allocator, schema)
+        ) {
+            NativeParquetWriter writer = new NativeParquetWriter(filePath, schemaExport.getSchemaAddress(), enc);
+
+            int[][] rows = { { 1, 100 }, { 2, 200 }, { 3, 300 } };
+            for (int[] r : rows) {
+                try (ArrowExport batch = exportRow(allocator, schema, r[0], r[1])) {
+                    writer.write(batch.getArrayAddress(), batch.getSchemaAddress());
+                }
+            }
+            writer.flush();
+        }
+    }
+
+    /**
+     * Creates a {@link ReaderHandle} with the derived footer key and AAD prefix, read from
+     * the Parquet file's key_metadata footer field and derived via the same data key.
+     */
+    private ReaderHandle encryptedReader() throws Exception {
+        String filePath = dataDir.resolve(FILE).toString();
+        byte[] keyMetadataBytes = RustBridge.readParquetKeyMetadata(filePath);
+        assertNotNull("Encrypted file must contain key_metadata", keyMetadataBytes);
+
+        PmeFileKeyMetadata meta = PmeFileKeyMetadata.parse(keyMetadataBytes);
+        assertEquals(PmeFileKeyMetadata.DEFAULT_DATA_KEY_ID, meta.dataKeyId());
+
+        byte[] footerKey = PmeKeyDerivation.deriveFooterKey(dataKey, meta.messageId());
+        byte[] aadPrefix = PmeKeyDerivation.buildAadPrefix(meta.messageId());
+
+        return new ReaderHandle(
+            dataDir.toString(),
+            new String[] { FILE },
+            new String[] { FILE },
+            new byte[][] { footerKey },
+            new String[] { FILE },
+            new byte[][] { aadPrefix }
+        );
+    }
+
+    private List<Object[]> executeQuery(ReaderHandle reader, String sql) {
+        byte[] substraitBytes = NativeBridge.sqlToSubstrait(reader.getPointer(), TABLE, sql, runtimeHandle.get());
+        assertNotNull(substraitBytes);
+        assertTrue(substraitBytes.length > 0);
+
+        long streamPtr = asyncCall(
+            listener -> NativeBridge.executeQueryAsync(reader.getPointer(), TABLE, substraitBytes, runtimeHandle.get(), 0L, queryConfigPtr, listener)
+        );
+        assertTrue(streamPtr != 0);
+
+        try (
+            StreamHandle streamHandle = new StreamHandle(streamPtr, runtimeHandle);
+            RootAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+            CDataDictionaryProvider dictProvider = new CDataDictionaryProvider()
+        ) {
+            long schemaAddr = asyncCall(listener -> NativeBridge.streamGetSchema(streamHandle.getPointer(), listener));
+            Schema schema = new Schema(importField(allocator, ArrowSchema.wrap(schemaAddr), dictProvider).getChildren(), null);
+            VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator);
+            List<Object[]> rows = new ArrayList<>();
+
+            while (true) {
+                long arrayAddr = asyncCall(
+                    listener -> NativeBridge.streamNext(runtimeHandle.get(), streamHandle.getPointer(), listener)
+                );
+                if (arrayAddr == 0) break;
+                Data.importIntoVectorSchemaRoot(allocator, ArrowArray.wrap(arrayAddr), root, dictProvider);
+                int cols = root.getFieldVectors().size();
+                for (int r = 0; r < root.getRowCount(); r++) {
+                    Object[] row = new Object[cols];
+                    for (int c = 0; c < cols; c++) {
+                        row[c] = root.getFieldVectors().get(c).getObject(r);
+                    }
+                    rows.add(row);
+                }
+            }
+            root.close();
+            return rows;
+        }
+    }
+
+    private long asyncCall(Consumer<ActionListener<Long>> call) {
+        CompletableFuture<Long> future = new CompletableFuture<>();
+        call.accept(new ActionListener<>() {
+            @Override
+            public void onResponse(Long v) { future.complete(v); }
+            @Override
+            public void onFailure(Exception e) { future.completeExceptionally(e); }
+        });
+        return future.join();
+    }
+
+    private static ArrowExport exportSchema(RootAllocator allocator, Schema schema) {
+        ArrowSchema arrowSchema = ArrowSchema.allocateNew(allocator);
+        Data.exportSchema(allocator, schema, null, arrowSchema);
+        return new ArrowExport(null, arrowSchema);
+    }
+
+    private static ArrowExport exportRow(RootAllocator allocator, Schema schema, long id, long score) {
+        try (VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator)) {
+            org.apache.arrow.vector.BigIntVector idVec = (org.apache.arrow.vector.BigIntVector) root.getVector("id");
+            org.apache.arrow.vector.BigIntVector scoreVec = (org.apache.arrow.vector.BigIntVector) root.getVector("score");
+            idVec.setSafe(0, id);
+            scoreVec.setSafe(0, score);
+            root.setRowCount(1);
+            ArrowArray array = ArrowArray.allocateNew(allocator);
+            ArrowSchema arrowSchema = ArrowSchema.allocateNew(allocator);
+            Data.exportVectorSchemaRoot(allocator, root, null, array, arrowSchema);
+            return new ArrowExport(array, arrowSchema);
+        }
+    }
+}
+
+
+

--- a/sandbox/plugins/mock-pme-kms/build.gradle
+++ b/sandbox/plugins/mock-pme-kms/build.gradle
@@ -1,0 +1,15 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+opensearchplugin {
+  description = 'Mock PME KMS plugin for development and integration testing. ' +
+    'Provides a dummy MasterKeyProvider that uses random 32-byte keys with identity ' +
+    'decryption (no real KMS required). NOT for production use.'
+  classname = 'org.opensearch.crypto.mock.MockPmeKmsPlugin'
+}
+

--- a/sandbox/plugins/mock-pme-kms/src/main/java/org/opensearch/crypto/mock/MockPmeKmsPlugin.java
+++ b/sandbox/plugins/mock-pme-kms/src/main/java/org/opensearch/crypto/mock/MockPmeKmsPlugin.java
@@ -1,0 +1,45 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.crypto.mock;
+
+import org.opensearch.cluster.metadata.CryptoMetadata;
+import org.opensearch.common.crypto.MasterKeyProvider;
+import org.opensearch.plugins.CryptoKeyProviderPlugin;
+import org.opensearch.plugins.Plugin;
+
+/**
+ * TODO: Mock KMS for testing; should be also consolidated with testing approach used by Lucene encryption plugin.
+ *
+ * OpenSearch plugin that registers a dummy KMS provider for PME end-to-end testing.
+ *
+ * <p>Installs the {@value #TYPE} key provider type. Configure an encrypted Parquet index with:
+ * <pre>
+ *   "index.store.parquet.crypto.key_provider":      "any-name"
+ *   "index.store.parquet.crypto.key_provider_type": "mock-pme"
+ * </pre>
+ *
+ * <p><strong>NOT for production use.</strong> The provider performs no real key-wrapping;
+ * decryption is an identity function. Install only in development or CI clusters.
+ */
+public class MockPmeKmsPlugin extends Plugin implements CryptoKeyProviderPlugin {
+
+    /** Key provider type string used in index settings. */
+    public static final String TYPE = "mock-pme";
+
+    @Override
+    public MasterKeyProvider createKeyProvider(CryptoMetadata cryptoMetadata) {
+        return new MockPmeMasterKeyProvider(cryptoMetadata);
+    }
+
+    @Override
+    public String type() {
+        return TYPE;
+    }
+}
+

--- a/sandbox/plugins/mock-pme-kms/src/main/java/org/opensearch/crypto/mock/MockPmeMasterKeyProvider.java
+++ b/sandbox/plugins/mock-pme-kms/src/main/java/org/opensearch/crypto/mock/MockPmeMasterKeyProvider.java
@@ -1,0 +1,87 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.crypto.mock;
+
+import org.opensearch.cluster.metadata.CryptoMetadata;
+import org.opensearch.common.crypto.DataKeyPair;
+import org.opensearch.common.crypto.MasterKeyProvider;
+
+import java.security.SecureRandom;
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * TODO: Mock KMS for testing; should be also consolidated with testing approach used by Lucene encryption plugin.
+ *
+ * Dummy {@link MasterKeyProvider} for development and integration testing.
+ *
+ * <p>Generates cryptographically random 32-byte data keys via {@link SecureRandom}.
+ * The "encrypted" key stored in the keyfile is identical to the raw key — {@link #decryptKey}
+ * is an identity function. This satisfies the PME key-round-trip contract
+ * ({@code decryptKey(encryptedKey) == rawKey}) without requiring a real KMS.
+ *
+ * <p><strong>NOT for production use.</strong> Any node that can read the keyfile can
+ * decrypt all Parquet data without KMS involvement.
+ */
+public class MockPmeMasterKeyProvider implements MasterKeyProvider {
+
+    private static final SecureRandom RANDOM = new SecureRandom();
+    private static final int KEY_LENGTH_BYTES = 32;
+
+    MockPmeMasterKeyProvider(@SuppressWarnings("unused") CryptoMetadata cryptoMetadata) {}
+
+    /**
+     * Generates a fresh random 32-byte key pair.
+     *
+     * <p>Both {@code rawKey} and {@code encryptedKey} in the returned pair contain the same
+     * random bytes. The keyfile will store {@code encryptedKey}; {@link #decryptKey} returns
+     * it unchanged. The PME derivation step in {@code PmeKeyDerivation} then produces the
+     * actual per-file footer key from {@code rawKey}.
+     */
+    @Override
+    public DataKeyPair generateDataPair() {
+        byte[] key = new byte[KEY_LENGTH_BYTES];
+        RANDOM.nextBytes(key);
+        // Store a copy as encryptedKey so callers cannot accidentally alias both halves.
+        byte[] encryptedKeyCopy = key.clone();
+        return new DataKeyPair(key, encryptedKeyCopy);
+    }
+
+    /**
+     * Identity decryption — returns {@code encryptedKey} unchanged.
+     *
+     * <p>Because {@link #generateDataPair} stores the same bytes in both fields of the pair,
+     * returning the input here is equivalent to "decrypting" back to the original raw key.
+     */
+    @Override
+    public byte[] decryptKey(byte[] encryptedKey) {
+        // Return a defensive copy so callers cannot mutate the stored reference.
+        return encryptedKey.clone();
+    }
+
+    /** Returns a fixed mock key ID. */
+    @Override
+    public String getKeyId() {
+        return "mock-pme-key-id";
+    }
+
+    /** Returns an empty encryption context — no real KMS context needed. */
+    @Override
+    public Map<String, String> getEncryptionContext() {
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public void close() {
+        // Nothing to close — no network connections or KMS sessions.
+    }
+}
+
+
+

--- a/sandbox/plugins/mock-pme-kms/src/main/java/org/opensearch/crypto/mock/package-info.java
+++ b/sandbox/plugins/mock-pme-kms/src/main/java/org/opensearch/crypto/mock/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/**
+ * Dummy KMS plugin for Parquet Modular Encryption (PME) development and integration testing.
+ *
+ * <p>Provides {@link org.opensearch.crypto.mock.MockPmeKmsPlugin}, which registers the
+ * {@code "mock-pme"} key provider type. The provider uses random 32-byte keys with
+ * identity decryption — no external KMS service is required.
+ *
+ * <p><strong>NOT for production use.</strong>
+ */
+package org.opensearch.crypto.mock;
+

--- a/sandbox/plugins/parquet-data-format/benchmarks/src/main/java/org/opensearch/parquet/benchmark/VSRRotationBenchmark.java
+++ b/sandbox/plugins/parquet-data-format/benchmarks/src/main/java/org/opensearch/parquet/benchmark/VSRRotationBenchmark.java
@@ -145,7 +145,7 @@ public class VSRRotationBenchmark {
         Settings idxSettings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT).build();
         IndexMetadata indexMetadata = IndexMetadata.builder("benchmark-index").settings(idxSettings).build();
         indexSettings = new IndexSettings(indexMetadata, Settings.EMPTY);
-        vsrManager = new VSRManager(filePath, indexSettings, schema, bufferPool, maxRowsPerVSR, threadPool, runAsync, 0L);
+        vsrManager = new VSRManager(filePath, indexSettings, schema, bufferPool, maxRowsPerVSR, threadPool, runAsync, 0L, null);
     }
 
     @Benchmark

--- a/sandbox/plugins/parquet-data-format/build.gradle
+++ b/sandbox/plugins/parquet-data-format/build.gradle
@@ -12,6 +12,8 @@ opensearchplugin {
   extendedPlugins = ['arrow-base', 'composite-engine']
 }
 
+apply plugin: 'opensearch.internal-cluster-test'
+
 java { sourceCompatibility = JavaVersion.toVersion(25); targetCompatibility = JavaVersion.toVersion(25) }
 
 dependencies {
@@ -122,6 +124,14 @@ test {
   systemProperty 'io.netty.noUnsafe', 'false'
   systemProperty 'io.netty.tryUnsafe', 'true'
   systemProperty 'io.netty.tryReflectionSetAccessible', 'true'
+  systemProperty 'native.lib.path', project(':sandbox:libs:dataformat-native').ext.nativeLibPath.absolutePath
+  dependsOn ':sandbox:libs:dataformat-native:buildRustLibrary'
+}
+
+tasks.named('internalClusterTest').configure {
+  jvmArgs '--add-opens=java.base/java.nio=ALL-UNNAMED'
+  jvmArgs '--add-opens=java.base/sun.nio.ch=ALL-UNNAMED'
+  jvmArgs '--enable-native-access=ALL-UNNAMED'
   systemProperty 'native.lib.path', project(':sandbox:libs:dataformat-native').ext.nativeLibPath.absolutePath
   dependsOn ':sandbox:libs:dataformat-native:buildRustLibrary'
 }

--- a/sandbox/plugins/parquet-data-format/scripts/e2e/.gitignore
+++ b/sandbox/plugins/parquet-data-format/scripts/e2e/.gitignore
@@ -1,0 +1,2 @@
+.cluster*.log
+.cluster.pid

--- a/sandbox/plugins/parquet-data-format/scripts/e2e/README.md
+++ b/sandbox/plugins/parquet-data-format/scripts/e2e/README.md
@@ -1,0 +1,141 @@
+# PME End-to-End Integration Tests
+
+These scripts are just meant as temporary fast means to perform actual PME
+end-to-end tests. These should be replaced by a more standard solution.
+
+Shell-script end-to-end integration tests for Parquet Modular Encryption (PME)
+against a real single-node OpenSearch cluster, using the `mock-pme-kms` plugin
+as a dummy KMS (no external service required).
+
+## Prerequisites
+
+| Requirement | Notes |
+|---|---|
+| JDK 25 | Set `JAVA_HOME`. JDK 21 minimum, 25 recommended for sandbox modules. |
+| Rust + cargo | For the native library build step. |
+| `curl` | REST test calls. |
+| `jq` | JSON assertion parsing. |
+| Port 9200 | Must be free on localhost. |
+
+## Files
+
+```
+scripts/e2e/
+├── setup-cluster.sh              Build plugins and start OpenSearch (background).
+├── test-pme.sh                   Run REST tests against a running cluster.
+├── test-pme-kms-unavailable.sh   Verify encrypted indices are inaccessible without KMS.
+├── teardown.sh                   Stop the cluster started by setup-cluster.sh.
+└── run-all.sh                    Full lifecycle: build → start → test → KMS-off → stop.
+
+sandbox/plugins/mock-pme-kms/
+└── ...                           Dummy KMS plugin (no real KMS, identity decryption).
+```
+
+## Quickstart
+
+```bash
+# From the repo root — full lifecycle in one command:
+./sandbox/plugins/parquet-data-format/scripts/e2e/run-all.sh
+
+# Skip the Gradle build if plugins are already assembled:
+./sandbox/plugins/parquet-data-format/scripts/e2e/run-all.sh --skip-build
+
+# Keep the cluster running after the test run (for manual inspection):
+./sandbox/plugins/parquet-data-format/scripts/e2e/run-all.sh --keep-cluster
+```
+
+## Step-by-step
+
+```bash
+# 1. Build and start the cluster (blocks until cluster is healthy):
+./sandbox/plugins/parquet-data-format/scripts/e2e/setup-cluster.sh
+
+# 2. Run the tests against the running cluster:
+./sandbox/plugins/parquet-data-format/scripts/e2e/test-pme.sh
+
+# 3. Stop the cluster when done:
+./sandbox/plugins/parquet-data-format/scripts/e2e/teardown.sh
+```
+
+## Test against an existing cluster
+
+If you already have a cluster running elsewhere:
+
+```bash
+./sandbox/plugins/parquet-data-format/scripts/e2e/test-pme.sh --host=http://my-host:9200
+```
+
+The test script checks that `parquet-data-format`, `mock-pme-kms`, and
+`analytics-backend-lucene` are installed. Use `GET /_cat/plugins` to verify.
+
+The Parquet engine also requires the experimental node feature flag:
+```
+opensearch.experimental.feature.pluggable.dataformat.enabled: true
+```
+`setup-cluster.sh` and `run-all.sh` set this automatically for the Gradle run
+cluster via `-Dtests.opensearch.opensearch.experimental.feature.pluggable.dataformat.enabled=true`.
+The `analytics-backend-lucene` plugin is also required because it provides the
+committer used by the pluggable data format engine.
+
+The scripts also pass the Rust native library to the OpenSearch JVM via
+`-Dtests.jvm.argline=-Dnative.lib.path=...`. If you use `--skip-build`, make
+sure `sandbox/libs/dataformat-native:buildRustLibrary` has already produced the
+platform library under `sandbox/libs/dataformat-native/rust/target/release/`.
+
+With the feature flag enabled, successful indexing writes Parquet files under
+the shard data path, for example:
+```
+build/testclusters/runTask-0/data/nodes/0/indices/<uuid>/0/parquet/_parquet_file_generation_*.parquet
+```
+Normal `_search` requests against these Parquet-backed shards currently fail
+with `Cannot apply function on indexer class org.opensearch.index.engine.DataFormatAwareEngine directly on IndexShard`.
+The e2e test reports those checks as `XFAIL`. That means the Parquet indexing
+path is active, not that Lucene was used.
+
+## What is tested
+
+| Test | Description |
+|---|---|
+| T1 | Create encrypted Parquet index with `mock-pme` key provider |
+| T2 | Index 5 documents + force-refresh |
+| T3 | Match-all search returns all 5 documents |
+| T4 | Term query on encrypted field returns correct subset + correct source values |
+| T5 | Aggregation (SUM + COUNT) over encrypted numeric field returns correct result |
+| T6 | Delete encrypted index — subsequent search returns HTTP 404 |
+| T7 | Two independent encrypted indices each have separate keyfiles and isolated data |
+| T8-A | Unencrypted Parquet index indexes successfully and hits the same `_search` XFAIL |
+| T8-B | Plain Lucene index works normally alongside Parquet indices |
+| T9 | Create persistent encrypted index readable with KMS; left for Phase 4 |
+| T9-A | (Phase 4, no-KMS cluster) Encrypted index returns error or 0 hits |
+| T9-B | (Phase 4, no-KMS cluster) Creating new encrypted index is rejected |
+| T9-C | (Phase 4, no-KMS cluster) Plain index remains fully readable |
+
+## The mock-pme-kms plugin
+
+`MockPmeKmsPlugin` registers the key provider type `"mock-pme"`. It uses a pure
+Java implementation with no Mockito dependency — suitable for installation in a
+real node.
+
+Key behaviour:
+- `generateDataPair()` — generates a fresh 32-byte key via `SecureRandom`.
+  The "encrypted" copy is identical to the raw key (identity wrapping).
+- `decryptKey(bytes)` — returns the input unchanged.
+
+This satisfies the PME round-trip contract (`decryptKey(encryptedKey) == rawKey`)
+without any external KMS service.
+
+**Not for production use.** Any party that can read the keyfile can decrypt the
+data without KMS involvement.
+
+## Index settings used by the tests
+
+```json
+{
+  "settings": {
+    "index.pluggable.dataformat.enabled": true,
+    "index.pluggable.dataformat": "parquet",
+    "index.store.parquet.crypto.key_provider": "test",
+    "index.store.parquet.crypto.key_provider_type": "mock-pme"
+  }
+}
+```

--- a/sandbox/plugins/parquet-data-format/scripts/e2e/run-all.sh
+++ b/sandbox/plugins/parquet-data-format/scripts/e2e/run-all.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../../.." && pwd)"
+CLUSTER_PID_FILE="${SCRIPT_DIR}/.cluster.pid"
+CLUSTER_LOG_FILE_KMS="${SCRIPT_DIR}/.cluster-no-kms.log"
+
+SKIP_BUILD_FLAG=""
+KEEP_CLUSTER=false
+
+for arg in "$@"; do
+    case "${arg}" in
+        --skip-build)   SKIP_BUILD_FLAG="--skip-build" ;;
+        --keep-cluster) KEEP_CLUSTER=true ;;
+        *) echo "[run-all] Unknown argument: ${arg}" >&2; exit 1 ;;
+    esac
+done
+
+info() { echo "[run-all] $*"; }
+
+native_lib_path() {
+    local lib_ext
+    case "$(uname -s)" in
+        Darwin) lib_ext="dylib" ;;
+        Linux)  lib_ext="so" ;;
+        *)      info "ERROR: Unsupported OS for native library lookup: $(uname -s)" >&2; exit 1 ;;
+    esac
+    echo "${REPO_ROOT}/sandbox/libs/dataformat-native/rust/target/release/libopensearch_native.${lib_ext}"
+}
+
+assert_ports_available() {
+    local url="http://localhost:9200"
+    if curl -sf "${url}/_cluster/health" -o /dev/null 2>/dev/null; then
+        info "ERROR: an OpenSearch cluster is already responding at ${url}." >&2
+        info "Run teardown.sh or stop the stale process before continuing." >&2
+        exit 1
+    fi
+
+    if command -v lsof &>/dev/null; then
+        local busy_ports
+        busy_ports=$(lsof -nP -iTCP:9200 -iTCP:9300 -sTCP:LISTEN 2>/dev/null || true)
+        if [[ -n "${busy_ports}" ]]; then
+            info "ERROR: OpenSearch ports are already in use:" >&2
+            echo "${busy_ports}" >&2
+            info "Run teardown.sh or stop the stale process before continuing." >&2
+            exit 1
+        fi
+    fi
+}
+
+# ---- ensure teardown on exit unless --keep-cluster ---------------------------
+
+cleanup() {
+    if [[ "${KEEP_CLUSTER}" == false ]]; then
+        info "Tearing down cluster ..."
+        bash "${SCRIPT_DIR}/teardown.sh"
+        # Also remove the no-kms log file
+        rm -f "${CLUSTER_LOG_FILE_KMS}"
+    else
+        info "Cluster kept running (--keep-cluster). Use teardown.sh when done."
+    fi
+}
+trap cleanup EXIT
+
+# ---- Phase 1: Start cluster with KMS -----------------------------------------
+
+info "=== Phase 1: Start cluster (with mock-pme-kms) ==="
+if ! bash "${SCRIPT_DIR}/setup-cluster.sh" ${SKIP_BUILD_FLAG}; then
+    info "Cluster setup FAILED — aborting."
+    exit 1
+fi
+
+# ---- Phase 2: Run main PME end-to-end tests ----------------------------------
+
+info "=== Phase 2: Run PME end-to-end tests ==="
+bash "${SCRIPT_DIR}/test-pme.sh"
+TEST_EXIT=$?
+
+if [[ ${TEST_EXIT} -ne 0 ]]; then
+    info "Main PME tests FAILED (exit ${TEST_EXIT}) — skipping KMS-unavailable phase."
+    exit ${TEST_EXIT}
+fi
+
+# ---- Phase 3: Restart cluster WITHOUT mock-pme-kms --------------------------
+# The pme-t9-persist index (created in T9 of test-pme.sh) must still be present
+# on disk so we can verify that its data is inaccessible without the key provider.
+
+info "=== Phase 3: Restart cluster WITHOUT mock-pme-kms ==="
+info "Stopping current cluster ..."
+bash "${SCRIPT_DIR}/teardown.sh"
+
+# Small grace period to ensure the OS releases the port before the next start.
+sleep 3
+assert_ports_available
+
+info "Starting cluster WITHOUT mock-pme-kms (parquet-data-format + analytics-backend-lucene + analytics-backend-datafusion) ..."
+GRADLEW="${REPO_ROOT}/gradlew"
+if [[ ! -x "${GRADLEW}" ]]; then
+    info "ERROR: gradlew not found at ${GRADLEW}" >&2
+    exit 1
+fi
+
+NATIVE_LIB_PATH="$(native_lib_path)"
+if [[ ! -f "${NATIVE_LIB_PATH}" ]]; then
+    info "ERROR: Native library not found at ${NATIVE_LIB_PATH}." >&2
+    info "Run run-all.sh without --skip-build to build it." >&2
+    exit 1
+fi
+
+"${GRADLEW}" \
+    -Dsandbox.enabled=true \
+    -PinstalledPlugins='["arrow-base", "arrow-flight-rpc", "analytics-engine", "parquet-data-format", "analytics-backend-lucene", "analytics-backend-datafusion"]' \
+    -Dtests.jvm.argline="-Dnative.lib.path=${NATIVE_LIB_PATH} --enable-native-access=ALL-UNNAMED" \
+    -Dtests.opensearch.opensearch.experimental.feature.pluggable.dataformat.enabled=true \
+    -Dtests.opensearch.opensearch.experimental.feature.transport.stream.enabled=true \
+    -Dtests.opensearch.logger.org.opensearch.parquet.encryption=TRACE \
+    -Dtests.opensearch.logger.org.opensearch.be.datafusion=TRACE \
+    run \
+    --preserve-data \
+    > "${CLUSTER_LOG_FILE_KMS}" 2>&1 &
+
+NO_KMS_PID=$!
+echo "${NO_KMS_PID}" > "${CLUSTER_PID_FILE}"
+info "No-KMS cluster PID: ${NO_KMS_PID} (log: ${CLUSTER_LOG_FILE_KMS})"
+
+# Wait for cluster to come up.
+url="http://localhost:9200"
+timeout=120
+elapsed=0
+info "Waiting for no-KMS cluster at ${url} (timeout ${timeout}s) ..."
+while ! curl -sf "${url}/_cluster/health" -o /dev/null 2>/dev/null; do
+    if ! kill -0 "${NO_KMS_PID}" 2>/dev/null; then
+        info "ERROR: No-KMS Gradle run process exited before the cluster became available." >&2
+        info "Check ${CLUSTER_LOG_FILE_KMS} for details." >&2
+        if [[ -s "${CLUSTER_LOG_FILE_KMS}" ]]; then
+            tail -n 40 "${CLUSTER_LOG_FILE_KMS}" >&2 || true
+        fi
+        exit 1
+    fi
+    sleep 2
+    elapsed=$((elapsed + 2))
+    if [[ ${elapsed} -ge ${timeout} ]]; then
+        info "ERROR: No-KMS cluster did not start within ${timeout}s. Check ${CLUSTER_LOG_FILE_KMS}." >&2
+        exit 1
+    fi
+done
+info "No-KMS cluster is up."
+
+# Enable TRACE logging for PME packages in the no-KMS cluster as well.
+info "Enabling TRACE logging for PME packages in no-KMS cluster ..."
+trace_resp=$(curl -s -w "\n%{http_code}" -X PUT "http://localhost:9200/_cluster/settings" \
+    -H "Content-Type: application/json" \
+    -d '{
+      "transient": {
+        "logger.org.opensearch.parquet.encryption": "TRACE",
+        "logger.org.opensearch.be.datafusion": "TRACE"
+      }
+    }')
+trace_status=$(echo "${trace_resp}" | tail -n1)
+if [[ "${trace_status}" == "200" ]]; then
+    info "Trace logging enabled in no-KMS cluster."
+    info "TRACE messages will appear in: ${REPO_ROOT}/build/testclusters/runTask-0/logs/runTask.log"
+else
+    info "WARNING: could not set trace logging (HTTP ${trace_status}) — continuing."
+fi
+
+# ---- Phase 4: Run KMS-unavailable tests -------------------------------------
+
+info "=== Phase 4: Run KMS-unavailable tests ==="
+bash "${SCRIPT_DIR}/test-pme-kms-unavailable.sh"
+KMS_UNAVAIL_EXIT=$?
+
+# ---- result ------------------------------------------------------------------
+
+info "=== Phase 5: Results ==="
+if [[ ${TEST_EXIT} -eq 0 && ${KMS_UNAVAIL_EXIT} -eq 0 ]]; then
+    info "All PME end-to-end tests PASSED (main + KMS-unavailable)."
+    exit 0
+else
+    [[ ${TEST_EXIT}        -ne 0 ]] && info "Main PME tests FAILED (exit ${TEST_EXIT})."
+    [[ ${KMS_UNAVAIL_EXIT} -ne 0 ]] && info "KMS-unavailable tests FAILED (exit ${KMS_UNAVAIL_EXIT})."
+    exit 1
+fi
+

--- a/sandbox/plugins/parquet-data-format/scripts/e2e/setup-cluster.sh
+++ b/sandbox/plugins/parquet-data-format/scripts/e2e/setup-cluster.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CLUSTER_PID_FILE="${SCRIPT_DIR}/.cluster.pid"
+CLUSTER_LOG_FILE="${SCRIPT_DIR}/.cluster.log"
+
+info()  { echo "[setup] $*"; }
+error() { echo "[setup] ERROR: $*" >&2; }
+
+native_lib_path() {
+    local lib_ext
+    case "$(uname -s)" in
+        Darwin) lib_ext="dylib" ;;
+        Linux)  lib_ext="so" ;;
+        *)      error "Unsupported OS for native library lookup: $(uname -s)"; exit 1 ;;
+    esac
+    echo "${REPO_ROOT}/sandbox/libs/dataformat-native/rust/target/release/libopensearch_native.${lib_ext}"
+}
+
+assert_ports_available() {
+    local url="http://localhost:9200"
+    if curl -sf "${url}/_cluster/health" -o /dev/null 2>/dev/null; then
+        error "An OpenSearch cluster is already responding at ${url}."
+        error "Run teardown.sh or stop the stale process before starting a fresh e2e cluster."
+        exit 1
+    fi
+
+    if command -v lsof &>/dev/null; then
+        local busy_ports
+        busy_ports=$(lsof -nP -iTCP:9200 -iTCP:9300 -sTCP:LISTEN 2>/dev/null || true)
+        if [[ -n "${busy_ports}" ]]; then
+            error "OpenSearch ports are already in use:"
+            echo "${busy_ports}" >&2
+            error "Run teardown.sh or stop the stale process before starting a fresh e2e cluster."
+            exit 1
+        fi
+    fi
+}
+
+wait_for_cluster() {
+    local url="http://localhost:9200"
+    local timeout=120
+    local elapsed=0
+    info "Waiting for cluster at ${url} (timeout ${timeout}s) ..."
+    while ! curl -sf "${url}/_cluster/health" -o /dev/null 2>/dev/null; do
+        if [[ -n "${GRADLE_PID:-}" ]] && ! kill -0 "${GRADLE_PID}" 2>/dev/null; then
+            error "Gradle run process exited before the cluster became available."
+            error "Check ${CLUSTER_LOG_FILE} for details."
+            if [[ -s "${CLUSTER_LOG_FILE}" ]]; then
+                tail -n 40 "${CLUSTER_LOG_FILE}" >&2 || true
+            fi
+            exit 1
+        fi
+        sleep 2
+        elapsed=$((elapsed + 2))
+        if [[ ${elapsed} -ge ${timeout} ]]; then
+            error "Cluster did not become available within ${timeout}s."
+            error "Check ${CLUSTER_LOG_FILE} for details."
+            exit 1
+        fi
+    done
+    info "Cluster is up."
+}
+
+# ---- parse args --------------------------------------------------------------
+
+SKIP_BUILD=false
+for arg in "$@"; do
+    case "${arg}" in
+        --skip-build) SKIP_BUILD=true ;;
+        *) error "Unknown argument: ${arg}"; exit 1 ;;
+    esac
+done
+
+# ---- sanity checks -----------------------------------------------------------
+
+if [[ -f "${CLUSTER_PID_FILE}" ]]; then
+    existing_pid=$(cat "${CLUSTER_PID_FILE}")
+    if kill -0 "${existing_pid}" 2>/dev/null; then
+        info "Cluster already running (PID ${existing_pid}). Use teardown.sh first."
+        exit 0
+    else
+        info "Stale PID file found — removing."
+        rm -f "${CLUSTER_PID_FILE}"
+    fi
+fi
+
+assert_ports_available
+
+if ! command -v java &>/dev/null && [[ -z "${JAVA_HOME:-}" ]]; then
+    error "JAVA_HOME is not set and 'java' is not on PATH."
+    exit 1
+fi
+
+# ---- build -------------------------------------------------------------------
+
+cd "${REPO_ROOT}"
+
+GRADLEW="${REPO_ROOT}/gradlew"
+if [[ ! -x "${GRADLEW}" ]]; then
+    error "gradlew not found or not executable at ${GRADLEW}"
+    exit 1
+fi
+
+if [[ "${SKIP_BUILD}" == false ]]; then
+    info "Building native Rust library ..."
+    "${GRADLEW}" -Dsandbox.enabled=true ':sandbox:libs:dataformat-native:buildRustLibrary' || { error "Rust build failed"; exit 1; }
+
+    info "Building parquet-data-format plugin ..."
+    "${GRADLEW}" -Dsandbox.enabled=true ':sandbox:plugins:parquet-data-format:assemble' -x test || { error "parquet-data-format build failed"; exit 1; }
+
+    info "Building mock-pme-kms plugin ..."
+    "${GRADLEW}" -Dsandbox.enabled=true ':sandbox:plugins:mock-pme-kms:assemble' -x test || { error "mock-pme-kms build failed"; exit 1; }
+
+    info "Building analytics-engine plugin ..."
+    "${GRADLEW}" -Dsandbox.enabled=true ':sandbox:plugins:analytics-engine:assemble' -x test || { error "analytics-engine build failed"; exit 1; }
+
+    info "Building analytics-backend-lucene plugin ..."
+    "${GRADLEW}" -Dsandbox.enabled=true ':sandbox:plugins:analytics-backend-lucene:assemble' -x test|| {
+        error "analytics-backend-lucene build failed"
+        exit 1
+    }
+
+    info "Building analytics-backend-datafusion plugin ..."
+    "${GRADLEW}" -Dsandbox.enabled=true ':sandbox:plugins:analytics-backend-datafusion:assemble' -x test|| {
+        error "analytics-backend-datafusion build failed"
+        exit 1
+    }
+else
+    info "Skipping build (--skip-build)."
+fi
+
+NATIVE_LIB_PATH="$(native_lib_path)"
+if [[ ! -f "${NATIVE_LIB_PATH}" ]]; then
+    error "Native library not found at ${NATIVE_LIB_PATH}."
+    error "Run setup-cluster.sh without --skip-build to build it."
+    exit 1
+fi
+
+# ---- start cluster -----------------------------------------------------------
+
+info "Starting OpenSearch cluster with parquet-data-format + mock-pme-kms + analytics-backend-lucene + analytics-backend-datafusion plugins ..."
+# -Dtests.opensearch.logger.* is handled by RunTask.java: each property with the
+# prefix "tests.opensearch." has the prefix stripped and is written as a key=value
+# entry into opensearch.yml via node.setting().  Writing logger.X=TRACE into
+# opensearch.yml is the only reliable way to get TRACE-level output from plugin
+# code, because the dynamic PUT /_cluster/settings approach sets the level AFTER
+# log4j2 has already initialized, and does not always propagate to loggers that
+# were created in plugin classloaders before the setting was applied.
+
+"${GRADLEW}" \
+    -Dsandbox.enabled=true \
+    -PinstalledPlugins='["arrow-base", "arrow-flight-rpc", "analytics-engine", "parquet-data-format", "mock-pme-kms", "analytics-backend-lucene", "analytics-backend-datafusion"]' \
+    -Dtests.jvm.argline="-Dnative.lib.path=${NATIVE_LIB_PATH} --enable-native-access=ALL-UNNAMED" \
+    -Dtests.opensearch.opensearch.experimental.feature.pluggable.dataformat.enabled=true \
+    -Dtests.opensearch.opensearch.experimental.feature.transport.stream.enabled=true \
+    -Dtests.opensearch.logger.org.opensearch.parquet.encryption=TRACE \
+    -Dtests.opensearch.logger.org.opensearch.be.datafusion=TRACE \
+    run \
+    > "${CLUSTER_LOG_FILE}" 2>&1 &
+
+GRADLE_PID=$!
+echo "${GRADLE_PID}" > "${CLUSTER_PID_FILE}"
+info "Gradle process PID: ${GRADLE_PID} (Gradle output: ${CLUSTER_LOG_FILE})"
+info "OpenSearch server log: ${REPO_ROOT}/build/testclusters/runTask-0/logs/runTask.log"
+
+wait_for_cluster
+
+# ---- enable TRACE logging for PME packages ----------------------------------
+# OpenSearch supports dynamic logger configuration via the cluster settings API.
+# Setting logger.<package>=TRACE causes log4j2 to emit TRACE-level messages for
+# that package without requiring a node restart or a custom log4j2.properties.
+# This ensures that all encrypted data-access flow messages from
+#   org.opensearch.parquet.encryption  (PmeKeyfileManager, PmeDataKeyCache, PmeContext)
+#   org.opensearch.be.datafusion       (DatafusionReaderManager)
+# appear in the cluster log during e2e tests.
+
+info "Enabling TRACE logging for PME packages via cluster settings API ..."
+trace_resp=$(curl -s -w "\n%{http_code}" -X PUT "http://localhost:9200/_cluster/settings" \
+    -H "Content-Type: application/json" \
+    -d '{
+      "transient": {
+        "logger.org.opensearch.parquet.encryption": "TRACE",
+        "logger.org.opensearch.be.datafusion": "TRACE"
+      }
+    }')
+trace_status=$(echo "${trace_resp}" | tail -n1)
+trace_body=$(echo "${trace_resp}" | sed '$d')
+if [[ "${trace_status}" == "200" ]]; then
+    info "Trace logging enabled (HTTP 200). Response: ${trace_body}"
+    info "TRACE messages will appear in: ${REPO_ROOT}/build/testclusters/runTask-0/logs/runTask.log"
+else
+    info "WARNING: could not set trace logging (HTTP ${trace_status}): ${trace_body} — continuing."
+fi
+
+info "Cluster ready. Run test-pme.sh to execute end-to-end tests."

--- a/sandbox/plugins/parquet-data-format/scripts/e2e/teardown.sh
+++ b/sandbox/plugins/parquet-data-format/scripts/e2e/teardown.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../../.." && pwd)"
+CLUSTER_PID_FILE="${SCRIPT_DIR}/.cluster.pid"
+CLUSTER_LOG_FILE="${SCRIPT_DIR}/.cluster.log"
+TESTCLUSTER_PATH="${REPO_ROOT}/build/testclusters/runTask-0"
+
+info()  { echo "[teardown] $*"; }
+error() { echo "[teardown] ERROR: $*" >&2; }
+
+stopped_any=false
+
+wait_for_exit() {
+    local pid="$1"
+    local timeout=15
+    local elapsed=0
+    while kill -0 "${pid}" 2>/dev/null; do
+        sleep 1
+        elapsed=$((elapsed + 1))
+        if [[ ${elapsed} -ge ${timeout} ]]; then
+            info "Process ${pid} did not stop cleanly — sending SIGKILL."
+            kill -9 "${pid}" 2>/dev/null || true
+            break
+        fi
+    done
+}
+
+stop_recorded_gradle_pid() {
+    if [[ ! -f "${CLUSTER_PID_FILE}" ]]; then
+        info "No .cluster.pid file found."
+        return
+    fi
+
+    local pid
+    pid=$(cat "${CLUSTER_PID_FILE}")
+    if ! kill -0 "${pid}" 2>/dev/null; then
+        info "Process ${pid} is already gone."
+        rm -f "${CLUSTER_PID_FILE}"
+        return
+    fi
+
+    info "Stopping Gradle run process (PID ${pid}) ..."
+
+    # In non-interactive scripts the Gradle child can share our process group.
+    # Killing that group terminates run-all.sh before it can clean up orphaned
+    # OpenSearch JVMs, so only use group termination when the group is distinct.
+    local pgid current_pgid
+    pgid=$(ps -o pgid= -p "${pid}" 2>/dev/null | tr -d ' ')
+    current_pgid=$(ps -o pgid= -p "$$" 2>/dev/null | tr -d ' ')
+    if [[ -n "${pgid}" && "${pgid}" != "0" && "${pgid}" != "${current_pgid}" ]]; then
+        kill -- "-${pgid}" 2>/dev/null || kill "${pid}" 2>/dev/null || true
+    else
+        kill "${pid}" 2>/dev/null || true
+    fi
+
+    wait_for_exit "${pid}"
+    rm -f "${CLUSTER_PID_FILE}"
+    stopped_any=true
+}
+
+stop_orphaned_opensearch_pids() {
+    local pid
+    local found=false
+    local pattern="opensearch.path.home=${TESTCLUSTER_PATH}/distro"
+    local pids
+    pids=$(pgrep -f "${pattern}" 2>/dev/null || true)
+
+    for pid in ${pids}; do
+        if [[ "${pid}" == "$$" ]]; then
+            continue
+        fi
+        if kill -0 "${pid}" 2>/dev/null; then
+            found=true
+            info "Stopping orphaned OpenSearch testcluster process (PID ${pid}) ..."
+            kill "${pid}" 2>/dev/null || true
+            wait_for_exit "${pid}"
+            stopped_any=true
+        fi
+    done
+
+    if [[ "${found}" == false ]]; then
+        info "No orphaned OpenSearch testcluster processes found."
+    fi
+}
+
+stop_recorded_gradle_pid
+stop_orphaned_opensearch_pids
+
+if [[ "${stopped_any}" == true ]]; then
+    info "Cluster stopped."
+else
+    info "Nothing to stop."
+fi
+
+if [[ -f "${CLUSTER_LOG_FILE}" ]]; then
+    info "Log file retained at: ${CLUSTER_LOG_FILE}"
+fi

--- a/sandbox/plugins/parquet-data-format/scripts/e2e/test-pme-kms-unavailable.sh
+++ b/sandbox/plugins/parquet-data-format/scripts/e2e/test-pme-kms-unavailable.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+
+set -uo pipefail
+
+HOST="${1:-http://localhost:9200}"
+
+PASS=0
+FAIL=0
+ERRORS=()
+REST_SEQ=0
+exec 3>&2
+
+info()  { echo "[kms-unavail] $*"; }
+ok()    { echo "[kms-unavail] ✓ $1"; PASS=$((PASS + 1)); }
+fail()  { echo "[kms-unavail] ✗ $1 — $2" >&2; FAIL=$((FAIL + 1)); ERRORS+=("$1: $2"); }
+
+log_rest_block() {
+    local id="$1"
+    local marker="$2"
+    local content="$3"
+    if [[ -z "${content}" ]]; then
+        printf '[kms-unavail][REST %s] %s <empty>\n' "${id}" "${marker}" >&3
+        return
+    fi
+    if command -v jq &>/dev/null && jq -e . >/dev/null 2>&1 <<< "${content}"; then
+        while IFS= read -r line; do
+            printf '[kms-unavail][REST %s] %s %s\n' "${id}" "${marker}" "${line}" >&3
+        done < <(jq '.' <<< "${content}")
+    else
+        while IFS= read -r line; do
+            printf '[kms-unavail][REST %s] %s %s\n' "${id}" "${marker}" "${line}" >&3
+        done <<< "${content}"
+    fi
+}
+
+os_req() {
+    local method="$1"
+    local path="$2"
+    local body="${3:-}"
+    REST_SEQ=$((REST_SEQ + 1))
+    local request_id="$$.${REST_SEQ}.${RANDOM}"
+    local args=(-s -w "\n%{http_code}" -X "${method}" "${HOST}${path}" -H "Content-Type: application/json")
+    if [[ -n "${body}" ]]; then
+        args+=(-d "${body}")
+    fi
+    printf '[kms-unavail][REST %s] > %s %s%s\n' "${request_id}" "${method}" "${HOST}" "${path}" >&3
+    if [[ -n "${body}" ]]; then
+        log_rest_block "${request_id}" ">" "${body}"
+    fi
+    local response
+    response=$(curl "${args[@]}")
+    local status
+    status=$(tail -n1 <<< "${response}")
+    local response_body
+    response_body=$(sed '$d' <<< "${response}")
+    printf '[kms-unavail][REST %s] < HTTP %s\n' "${request_id}" "${status}" >&3
+    log_rest_block "${request_id}" "<" "${response_body}"
+    printf '%s\n' "${response}"
+}
+
+http_status() { tail -n1 <<< "$1"; }
+http_body()   { sed '$d' <<< "$1"; }
+
+assert_status() {
+    local name="$1" response="$2" expected="$3"
+    local actual
+    actual=$(http_status "${response}")
+    if [[ "${actual}" == "${expected}" ]]; then
+        ok "${name}"
+    else
+        fail "${name}" "expected HTTP ${expected}, got HTTP ${actual} — body: $(http_body "${response}")"
+    fi
+}
+
+# ---- prerequisite check ------------------------------------------------------
+
+info "Checking cluster health at ${HOST} ..."
+health_resp=$(os_req GET "/_cluster/health")
+if [[ "$(http_status "${health_resp}")" != "200" ]]; then
+    echo "[kms-unavail] ERROR: cluster not reachable at ${HOST}" >&2
+    exit 1
+fi
+info "Cluster reachable."
+
+# Verify that mock-pme-kms is NOT installed (it must have been removed for this test).
+plugins_resp=$(os_req GET "/_cat/plugins?h=component&format=json")
+if jq -r '.[].component' <<< "$(http_body "${plugins_resp}")" 2>/dev/null | grep -q "mock-pme-kms"; then
+    echo "[kms-unavail] ERROR: mock-pme-kms is still installed — restart cluster without it first." >&2
+    exit 1
+fi
+info "Confirmed: mock-pme-kms plugin is NOT installed."
+
+# ---- T9-A: Encrypted index must not be searchable without KMS ----------------
+#
+# When the key provider plugin is missing the search engine cannot decrypt the
+# Parquet footer keys.  The query should therefore either:
+#   (a) return an HTTP error (5xx), or
+#   (b) return HTTP 200 but with 0 hits (e.g. if the shard is in a degraded state
+#       and returns empty results rather than an error).
+# We accept either outcome as a pass — the important invariant is that the
+# plaintext document data is NOT returned.
+
+info "--- T9-A: Encrypted index must not return plaintext docs without KMS ---"
+
+search_resp=$(os_req GET "/pme-t9-persist/_search" '{"query":{"match_all":{}}}')
+search_status=$(http_status "${search_resp}")
+search_body=$(http_body "${search_resp}")
+hit_count=$(jq -r '.hits.total.value // 0' <<< "${search_body}" 2>/dev/null || echo "0")
+
+info "Search status: ${search_status}, hit count: ${hit_count}"
+
+if [[ "${search_status}" != "200" ]]; then
+    # Error response — encryption enforcement working correctly.
+    ok "T9-A/encrypted-index-error-without-kms"
+elif [[ "${hit_count}" == "0" ]]; then
+    # Zero hits — data inaccessible without key provider.
+    ok "T9-A/encrypted-index-zero-hits-without-kms"
+else
+    # Plaintext documents returned — this must NOT happen.
+    fail "T9-A/encrypted-index-inaccessible-without-kms" \
+        "got ${hit_count} hits (status=${search_status}): encrypted data MUST NOT be readable without KMS"
+fi
+
+# ---- T9-B: Creating a new encrypted index without KMS must fail --------------
+#
+# Attempting to create an index with index.store.parquet.crypto.key_provider set
+# while the key provider plugin is absent must not produce a usable shard.  The
+# current implementation accepts the index metadata but reports
+# shards_acknowledged=false because the shard cannot start without the provider.
+
+info "--- T9-B: Creating a new encrypted index without KMS must fail ---"
+
+os_req DELETE "/pme-t9-new-enc" > /dev/null 2>&1 || true
+new_enc_resp=$(os_req PUT "/pme-t9-new-enc" '{
+  "settings": {
+    "index.pluggable.dataformat.enabled": true,
+    "index.pluggable.dataformat": "parquet",
+    "index.store.parquet.crypto.key_provider": "test",
+    "index.store.parquet.crypto.key_provider_type": "mock-pme",
+    "number_of_shards": 1,
+    "number_of_replicas": 0
+  }
+}')
+new_enc_status=$(http_status "${new_enc_resp}")
+new_enc_body=$(http_body "${new_enc_resp}")
+if [[ "${new_enc_status}" == "400" || "${new_enc_status}" == "500" ]]; then
+    ok "T9-B/new-encrypted-index-rejected-without-kms"
+elif [[ "${new_enc_status}" == "200" ]] && [[ "$(jq -r '.shards_acknowledged // false' <<< "${new_enc_body}" 2>/dev/null)" == "false" ]]; then
+    ok "T9-B/new-encrypted-index-shard-not-started-without-kms"
+else
+    fail "T9-B/new-encrypted-index-rejected-without-kms" \
+        "expected 4xx/5xx or HTTP 200 with shards_acknowledged=false, got HTTP ${new_enc_status}"
+fi
+
+# ---- T9-C: Plain (unencrypted) index must still work -------------------------
+
+info "--- T9-C: Plain index remains readable without KMS ---"
+
+os_req DELETE "/pme-t9c-plain" > /dev/null 2>&1 || true
+plain_resp=$(os_req PUT "/pme-t9c-plain" '{
+  "settings": {"number_of_shards":1,"number_of_replicas":0},
+  "mappings": {"properties":{"name":{"type":"keyword"}}}
+}')
+assert_status "T9-C/create-plain" "${plain_resp}" "200"
+
+os_req POST "/pme-t9c-plain/_doc/0" '{"name":"unencrypted_doc"}' > /dev/null
+os_req POST "/pme-t9c-plain/_refresh" > /dev/null
+
+plain_search=$(os_req GET "/pme-t9c-plain/_search" '{"query":{"match_all":{}}}')
+assert_status "T9-C/plain-search-status" "${plain_search}" "200"
+plain_hits=$(jq -r '.hits.total.value' <<< "$(http_body "${plain_search}")" 2>/dev/null)
+if [[ "${plain_hits}" == "1" ]]; then
+    ok "T9-C/plain-readable-without-kms"
+else
+    fail "T9-C/plain-readable-without-kms" "expected 1 hit, got ${plain_hits}"
+fi
+
+os_req DELETE "/pme-t9c-plain" > /dev/null 2>&1 || true
+
+# ---- summary -----------------------------------------------------------------
+
+echo ""
+echo "======================================="
+echo " KMS-Unavailable Test Results"
+echo "======================================="
+echo " PASSED : ${PASS}"
+echo " FAILED : ${FAIL}"
+echo "======================================="
+
+if [[ ${FAIL} -gt 0 ]]; then
+    echo ""
+    echo "Failed tests:"
+    for e in "${ERRORS[@]}"; do
+        echo "  - ${e}"
+    done
+    exit 1
+fi
+echo " All KMS-unavailable tests passed."

--- a/sandbox/plugins/parquet-data-format/scripts/e2e/test-pme.sh
+++ b/sandbox/plugins/parquet-data-format/scripts/e2e/test-pme.sh
@@ -1,0 +1,519 @@
+#!/usr/bin/env bash
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+
+set -uo pipefail
+
+# ---- configuration -----------------------------------------------------------
+
+HOST="${1:-http://localhost:9200}"
+# Allow --host flag anywhere
+for arg in "$@"; do
+    case "${arg}" in
+        --host=*) HOST="${arg#--host=}" ;;
+        --host)   ;; # value follows — handled below
+    esac
+done
+
+PASS=0
+FAIL=0
+XFAIL=0
+ERRORS=()
+XFAILS=()
+REST_SEQ=0
+exec 3>&2
+
+# ---- helpers -----------------------------------------------------------------
+
+info()  { echo "[test] $*"; }
+ok()    { echo "[test] ✓ $1"; PASS=$((PASS + 1)); }
+fail()  { echo "[test] ✗ $1 — $2" >&2; FAIL=$((FAIL + 1)); ERRORS+=("$1: $2"); }
+xfail() { echo "[test] XFAIL $1 — $2"; XFAIL=$((XFAIL + 1)); XFAILS+=("$1: $2"); }
+
+log_rest_block() {
+    local id="$1"
+    local marker="$2"
+    local content="$3"
+    if [[ -z "${content}" ]]; then
+        printf '[test][REST %s] %s <empty>\n' "${id}" "${marker}" >&3
+        return
+    fi
+    if command -v jq &>/dev/null && jq -e . >/dev/null 2>&1 <<< "${content}"; then
+        while IFS= read -r line; do
+            printf '[test][REST %s] %s %s\n' "${id}" "${marker}" "${line}" >&3
+        done < <(jq '.' <<< "${content}")
+    else
+        while IFS= read -r line; do
+            printf '[test][REST %s] %s %s\n' "${id}" "${marker}" "${line}" >&3
+        done <<< "${content}"
+    fi
+}
+
+# Execute a curl request and print status code + body.
+# Usage: os_req METHOD PATH [body_json]
+os_req() {
+    local method="$1"
+    local path="$2"
+    local body="${3:-}"
+    REST_SEQ=$((REST_SEQ + 1))
+    local request_id="$$.${REST_SEQ}.${RANDOM}"
+    local args=(-s -w "\n%{http_code}" -X "${method}" "${HOST}${path}" -H "Content-Type: application/json")
+    if [[ -n "${body}" ]]; then
+        args+=(-d "${body}")
+    fi
+    printf '[test][REST %s] > %s %s%s\n' "${request_id}" "${method}" "${HOST}" "${path}" >&3
+    if [[ -n "${body}" ]]; then
+        log_rest_block "${request_id}" ">" "${body}"
+    fi
+    local response
+    response=$(curl "${args[@]}")
+    local status
+    status=$(tail -n1 <<< "${response}")
+    local response_body
+    response_body=$(sed '$d' <<< "${response}")
+    printf '[test][REST %s] < HTTP %s\n' "${request_id}" "${status}" >&3
+    log_rest_block "${request_id}" "<" "${response_body}"
+    printf '%s\n' "${response}"
+}
+
+# Parse HTTP status code from os_req output (last line).
+http_status() { tail -n1 <<< "$1"; }
+
+# Parse response body from os_req output (all lines except the last).
+# NOTE: head -n -1 is GNU-only; sed '$d' works on both macOS (BSD) and Linux.
+http_body() { sed '$d' <<< "$1"; }
+
+# Assert that a jq expression evaluates to the expected string.
+# Usage: assert_jq TEST_NAME json_string jq_expr expected_value
+assert_jq() {
+    local name="$1"
+    local json="$2"
+    local expr="$3"
+    local expected="$4"
+    local actual
+    actual=$(jq -r "${expr}" <<< "${json}" 2>/dev/null || echo "__jq_error__")
+    if [[ "${actual}" == "${expected}" ]]; then
+        ok "${name}"
+    else
+        fail "${name}" "expected '${expected}', got '${actual}'"
+        echo "[test]   response body:" >&2
+        echo "${json}" | jq '.' 2>/dev/null || echo "${json}" >&2
+    fi
+}
+
+# Assert HTTP status code.
+assert_status() {
+    local name="$1"
+    local response="$2"
+    local expected="$3"
+    local actual
+    actual=$(http_status "${response}")
+    if [[ "${actual}" == "${expected}" ]]; then
+        ok "${name}"
+    else
+        fail "${name}" "expected HTTP ${expected}, got HTTP ${actual} — body: $(http_body "${response}")"
+    fi
+}
+
+is_dataformat_search_failure() {
+    local response="$1"
+    [[ "$(http_status "${response}")" == "500" ]] \
+        && grep -q "DataFormatAwareEngine directly on IndexShard" <<< "$(http_body "${response}")"
+}
+
+assert_search_hits_or_xfail() {
+    local name="$1"
+    local index="$2"
+    local query_json="$3"
+    local expected="$4"
+    local resp
+    resp=$(os_req GET "/${index}/_search" "${query_json}")
+    if is_dataformat_search_failure "${resp}"; then
+        xfail "${name}" "standard _search is not yet wired for DataFormatAwareEngine-backed shards"
+        return 0
+    fi
+    assert_status "${name}/status" "${resp}" "200"
+    local count
+    count=$(jq -r '.hits.total.value' <<< "$(http_body "${resp}")" 2>/dev/null || echo "__jq_error__")
+    if [[ "${count}" == "${expected}" ]]; then
+        ok "${name}"
+    else
+        fail "${name}" "expected ${expected} hits, got ${count}"
+    fi
+}
+
+assert_search_jq_or_xfail() {
+    local name="$1"
+    local path="$2"
+    local query_json="$3"
+    local jq_expr="$4"
+    local expected="$5"
+    local resp
+    resp=$(os_req GET "${path}" "${query_json}")
+    if is_dataformat_search_failure "${resp}"; then
+        xfail "${name}" "standard _search is not yet wired for DataFormatAwareEngine-backed shards"
+        return 0
+    fi
+    assert_status "${name}/status" "${resp}" "200"
+    assert_jq "${name}" "$(http_body "${resp}")" "${jq_expr}" "${expected}"
+}
+
+# Index settings for an encrypted Parquet index (mock-pme provider).
+encrypted_index_settings() {
+    cat <<'JSON'
+{
+  "settings": {
+    "index.pluggable.dataformat.enabled": true,
+    "index.pluggable.dataformat": "parquet",
+    "index.store.parquet.crypto.key_provider": "test",
+    "index.store.parquet.crypto.key_provider_type": "mock-pme",
+    "number_of_shards": 1,
+    "number_of_replicas": 0
+  },
+  "mappings": {
+    "properties": {
+      "title":  { "type": "keyword" },
+      "amount": { "type": "long"    },
+      "tag":    { "type": "keyword" }
+    }
+  }
+}
+JSON
+}
+
+# Index settings for an unencrypted Parquet index.
+unencrypted_parquet_index_settings() {
+    cat <<'JSON'
+{
+  "settings": {
+    "index.pluggable.dataformat.enabled": true,
+    "index.pluggable.dataformat": "parquet",
+    "number_of_shards": 1,
+    "number_of_replicas": 0
+  },
+  "mappings": {
+    "properties": {
+      "title":  { "type": "keyword" },
+      "amount": { "type": "long"    },
+      "tag":    { "type": "keyword" }
+    }
+  }
+}
+JSON
+}
+
+plain_index_settings() {
+    cat <<'JSON'
+{
+  "settings": {
+    "number_of_shards": 1,
+    "number_of_replicas": 0
+  },
+  "mappings": {
+    "properties": {
+      "name": { "type": "keyword" }
+    }
+  }
+}
+JSON
+}
+
+# Assert that an index was created with the expected encrypted-Parquet settings.
+# Usage: assert_encrypted_index_settings TEST_PREFIX index_name
+assert_encrypted_index_settings() {
+    local prefix="$1"
+    local index="$2"
+    local s
+    s=$(os_req GET "/${index}/_settings")
+    assert_status "${prefix}/settings-status" "${s}" "200"
+    local body
+    body=$(http_body "${s}")
+    assert_jq "${prefix}/parquet-enabled" "${body}" ".[\"${index}\"].settings.index.pluggable[\"dataformat.enabled\"]" "true"
+    assert_jq "${prefix}/parquet-format"  "${body}" ".[\"${index}\"].settings.index.pluggable.dataformat"              "parquet"
+    assert_jq "${prefix}/crypto-provider" "${body}" ".[\"${index}\"].settings.index.store.parquet.crypto.key_provider_type" "mock-pme"
+}
+
+# Assert that an index was created with Parquet enabled and no encryption provider.
+# Usage: assert_unencrypted_parquet_index_settings TEST_PREFIX index_name
+assert_unencrypted_parquet_index_settings() {
+    local prefix="$1"
+    local index="$2"
+    local s
+    s=$(os_req GET "/${index}/_settings")
+    assert_status "${prefix}/settings-status" "${s}" "200"
+    local body
+    body=$(http_body "${s}")
+    assert_jq "${prefix}/parquet-enabled" "${body}" ".[\"${index}\"].settings.index.pluggable[\"dataformat.enabled\"]" "true"
+    assert_jq "${prefix}/parquet-format"  "${body}" ".[\"${index}\"].settings.index.pluggable.dataformat"              "parquet"
+    local provider
+    provider=$(jq -r ".[\"${index}\"].settings.index.store.parquet.crypto.key_provider_type // \"null\"" <<< "${body}" 2>/dev/null)
+    if [[ "${provider}" == "null" ]]; then
+        ok "${prefix}/no-crypto-provider"
+    else
+        fail "${prefix}/no-crypto-provider" "expected no crypto provider setting, got '${provider}'"
+        echo "[test]   response body:" >&2
+        echo "${body}" | jq '.' 2>/dev/null || echo "${body}" >&2
+    fi
+}
+
+# Assert that an index was created WITHOUT Parquet/encryption settings.
+# Usage: assert_plain_index_settings TEST_PREFIX index_name
+assert_plain_index_settings() {
+    local prefix="$1"
+    local index="$2"
+    local s
+    s=$(os_req GET "/${index}/_settings")
+    assert_status "${prefix}/settings-status" "${s}" "200"
+    local body
+    body=$(http_body "${s}")
+    local pf
+    pf=$(jq -r ".[\"${index}\"].settings.index.pluggable.dataformat // \"null\"" <<< "${body}" 2>/dev/null)
+    if [[ "${pf}" == "null" || -z "${pf}" ]]; then
+        ok "${prefix}/no-parquet"
+    else
+        fail "${prefix}/no-parquet" "expected no parquet dataformat setting, got '${pf}'"
+        echo "[test]   response body:" >&2
+        echo "${body}" | jq '.' 2>/dev/null || echo "${body}" >&2
+    fi
+}
+
+# ---- prerequisite check ------------------------------------------------------
+
+info "Checking cluster health at ${HOST} ..."
+health_resp=$(os_req GET "/_cluster/health")
+if [[ "$(http_status "${health_resp}")" != "200" ]]; then
+    echo "[test] ERROR: cluster not reachable at ${HOST}" >&2
+    exit 1
+fi
+health_status=$(jq -r '.status' <<< "$(http_body "${health_resp}")" 2>/dev/null)
+info "Cluster status: ${health_status}"
+
+# Verify parquet-data-format plugin is installed.
+plugins_resp=$(os_req GET "/_cat/plugins?h=component&format=json")
+if ! jq -r '.[].component' <<< "$(http_body "${plugins_resp}")" 2>/dev/null | grep -q "parquet-data-format"; then
+    echo "[test] ERROR: parquet-data-format plugin is not installed. Run setup-cluster.sh first." >&2
+    exit 1
+fi
+if ! jq -r '.[].component' <<< "$(http_body "${plugins_resp}")" 2>/dev/null | grep -q "mock-pme-kms"; then
+    echo "[test] ERROR: mock-pme-kms plugin is not installed. Run setup-cluster.sh first." >&2
+    exit 1
+fi
+if ! jq -r '.[].component' <<< "$(http_body "${plugins_resp}")" 2>/dev/null | grep -q "analytics-backend-lucene"; then
+    echo "[test] ERROR: analytics-backend-lucene plugin is not installed. It provides the CommitterFactory required by the pluggable data format engine." >&2
+    exit 1
+fi
+if ! jq -r '.[].component' <<< "$(http_body "${plugins_resp}")" 2>/dev/null | grep -q "analytics-backend-datafusion"; then
+    echo "[test] ERROR: analytics-backend-datafusion plugin is not installed. It provides the SearchBackEndPlugin for ParquetDataFormat." >&2
+    exit 1
+fi
+info "Required plugins present."
+
+# ---- cleanup from previous run -----------------------------------------------
+
+for idx in pme-t1 pme-t7-alpha pme-t7-beta pme-t8-parquet pme-plain; do
+    os_req DELETE "/${idx}" > /dev/null 2>&1 || true
+done
+
+# ---- T1: Create encrypted index ----------------------------------------------
+
+info "--- T1: Create encrypted Parquet index ---"
+resp=$(os_req PUT "/pme-t1" "$(encrypted_index_settings)")
+assert_status "T1/create-status" "${resp}" "200"
+assert_jq    "T1/create-ack"    "$(http_body "${resp}")" '.acknowledged' "true"
+
+# ---- T1b: Verify index settings confirm Parquet + encryption -----------------
+
+info "--- T1b: Verify index settings (Parquet + encryption) ---"
+assert_encrypted_index_settings "T1b" "pme-t1"
+
+# ---- T2: Index documents and refresh -----------------------------------------
+
+info "--- T2: Index documents + refresh ---"
+docs=(
+    '{"title":"alpha","amount":100,"tag":"group-a"}'
+    '{"title":"beta", "amount":200,"tag":"group-a"}'
+    '{"title":"gamma","amount":300,"tag":"group-b"}'
+    '{"title":"delta","amount":400,"tag":"group-b"}'
+    '{"title":"epsilon","amount":500,"tag":"group-b"}'
+)
+for i in "${!docs[@]}"; do
+    r=$(os_req POST "/pme-t1/_doc/${i}" "${docs[$i]}")
+    assert_status "T2/index-doc-${i}" "${r}" "201"
+done
+
+r=$(os_req POST "/pme-t1/_refresh")
+assert_status "T2/refresh" "${r}" "200"
+
+# ---- T3: Match-all returns all docs ------------------------------------------
+
+info "--- T3: Match-all returns all documents ---"
+assert_search_hits_or_xfail "T3/match-all-count" "pme-t1" '{"query":{"match_all":{}}}' "5"
+
+# ---- T4: Term query ----------------------------------------------------------
+
+info "--- T4: Term query on encrypted field ---"
+resp=$(os_req GET "/pme-t1/_search" '{"query":{"term":{"tag":"group-a"}}}')
+if is_dataformat_search_failure "${resp}"; then
+    xfail "T4/term-search" "standard _search is not yet wired for DataFormatAwareEngine-backed shards"
+else
+    assert_status "T4/term-status" "${resp}" "200"
+    assert_jq    "T4/term-count"   "$(http_body "${resp}")" '.hits.total.value' "2"
+    # Verify the returned document titles
+    titles=$(jq -r '[.hits.hits[]._source.title] | sort | join(",")' <<< "$(http_body "${resp}")")
+    if [[ "${titles}" == "alpha,beta" ]]; then
+        ok "T4/term-titles"
+    else
+        fail "T4/term-titles" "expected 'alpha,beta', got '${titles}'"
+    fi
+fi
+
+# ---- T5: Aggregation ---------------------------------------------------------
+
+info "--- T5: Aggregation (sum + count) over encrypted field ---"
+agg_query='{"size":0,"aggs":{"total_amount":{"sum":{"field":"amount"}},"doc_count":{"value_count":{"field":"amount"}}}}'
+resp=$(os_req GET "/pme-t1/_search" "${agg_query}")
+if is_dataformat_search_failure "${resp}"; then
+    xfail "T5/agg-search" "standard _search is not yet wired for DataFormatAwareEngine-backed shards"
+else
+    assert_status "T5/agg-status"  "${resp}" "200"
+    # OpenSearch returns sum as a float (1500.0); compare with floor to handle both int and float.
+    agg_sum=$(jq -r '.aggregations.total_amount.value | floor' <<< "$(http_body "${resp}")" 2>/dev/null)
+    if [[ "${agg_sum}" == "1500" ]]; then ok "T5/agg-sum"; else fail "T5/agg-sum" "expected 1500, got ${agg_sum}"; fi
+    assert_jq    "T5/agg-count"    "$(http_body "${resp}")" '.aggregations.doc_count.value'   "5"
+fi
+
+# ---- T6: Delete encrypted index ----------------------------------------------
+
+info "--- T6: Delete encrypted index ---"
+resp=$(os_req DELETE "/pme-t1")
+assert_status "T6/delete-status" "${resp}" "200"
+assert_jq    "T6/delete-ack"    "$(http_body "${resp}")" '.acknowledged' "true"
+
+# After deletion the index must not exist.
+resp=$(os_req GET "/pme-t1/_search" '{"query":{"match_all":{}}}')
+del_status=$(http_status "${resp}")
+if [[ "${del_status}" == "404" ]]; then
+    ok "T6/post-delete-404"
+else
+    fail "T6/post-delete-404" "expected HTTP 404 after deletion, got ${del_status}"
+fi
+
+# ---- T7: Two independent encrypted indices -----------------------------------
+
+info "--- T7: Two independent encrypted indices ---"
+resp=$(os_req PUT "/pme-t7-alpha" "$(encrypted_index_settings)")
+assert_status "T7/create-alpha" "${resp}" "200"
+assert_encrypted_index_settings "T7/settings-alpha" "pme-t7-alpha"
+resp=$(os_req PUT "/pme-t7-beta" "$(encrypted_index_settings)")
+assert_status "T7/create-beta"  "${resp}" "200"
+assert_encrypted_index_settings "T7/settings-beta" "pme-t7-beta"
+
+for i in 0 1 2; do
+    os_req POST "/pme-t7-alpha/_doc/${i}" "{\"title\":\"a${i}\",\"amount\":$((i*10)),\"tag\":\"alpha\"}" > /dev/null
+    os_req POST "/pme-t7-beta/_doc/${i}"  "{\"title\":\"b${i}\",\"amount\":$((i*100)),\"tag\":\"beta\"}"  > /dev/null
+done
+
+os_req POST "/pme-t7-alpha/_refresh" > /dev/null
+os_req POST "/pme-t7-beta/_refresh"  > /dev/null
+
+# Each index should see only its own documents once Parquet search is wired.
+assert_search_hits_or_xfail "T7/alpha-count" "pme-t7-alpha" '{"query":{"match_all":{}}}' "3"
+assert_search_hits_or_xfail "T7/beta-count" "pme-t7-beta" '{"query":{"match_all":{}}}' "3"
+
+# A cross-index query must return exactly 6.
+assert_search_jq_or_xfail "T7/cross-index-count" "/pme-t7-alpha,pme-t7-beta/_search" '{"query":{"match_all":{}}}' '.hits.total.value' "6"
+
+# Data must stay isolated: alpha docs must not appear in beta and vice versa.
+assert_search_jq_or_xfail "T7/alpha-no-beta-data" "/pme-t7-alpha/_search" '{"query":{"term":{"tag":"beta"}}}' '.hits.total.value' "0"
+assert_search_jq_or_xfail "T7/beta-no-alpha-data" "/pme-t7-beta/_search" '{"query":{"term":{"tag":"alpha"}}}' '.hits.total.value' "0"
+
+# ---- T8-A: Unencrypted Parquet index has same search limitation -------------
+
+info "--- T8-A: Unencrypted Parquet index has same _search limitation ---"
+resp=$(os_req PUT "/pme-t8-parquet" "$(unencrypted_parquet_index_settings)")
+assert_status "T8-A/create-unencrypted-parquet" "${resp}" "200"
+assert_unencrypted_parquet_index_settings "T8-A/settings-unencrypted-parquet" "pme-t8-parquet"
+
+for i in 0 1; do
+    os_req POST "/pme-t8-parquet/_doc/${i}" "{\"title\":\"parquet_${i}\",\"amount\":$((i+1)),\"tag\":\"plain-parquet\"}" > /dev/null
+done
+os_req POST "/pme-t8-parquet/_refresh" > /dev/null
+
+assert_search_hits_or_xfail "T8-A/unencrypted-parquet-count" "pme-t8-parquet" '{"query":{"match_all":{}}}' "2"
+
+# ---- T8-B: Plain Lucene index alongside Parquet indices ---------------------
+
+info "--- T8-B: Plain Lucene index works alongside Parquet indices ---"
+resp=$(os_req PUT "/pme-plain" "$(plain_index_settings)")
+assert_status "T8-B/create-plain" "${resp}" "200"
+assert_plain_index_settings "T8-B/settings-plain" "pme-plain"
+
+for i in 0 1; do
+    os_req POST "/pme-plain/_doc/${i}" "{\"name\":\"plain_doc_${i}\"}" > /dev/null
+done
+os_req POST "/pme-plain/_refresh" > /dev/null
+
+resp=$(os_req GET "/pme-plain/_search" '{"query":{"match_all":{}}}')
+assert_status "T8-B/plain-search-status" "${resp}" "200"
+assert_jq "T8-B/plain-count" "$(http_body "${resp}")" '.hits.total.value' "2"
+
+# ---- cleanup -----------------------------------------------------------------
+
+for idx in pme-t7-alpha pme-t7-beta pme-t8-parquet pme-plain; do
+    os_req DELETE "/${idx}" > /dev/null 2>&1 || true
+done
+
+# ---- T9: Negative — encrypted index readable only when KMS is available ------
+# This index is intentionally NOT deleted here.  run-all.sh will restart the
+# cluster without the mock-pme-kms plugin and verify that the index cannot be
+# searched in that configuration (see test-pme-kms-unavailable.sh).
+
+info "--- T9: Create persistent encrypted index for KMS-unavailable test ---"
+os_req DELETE "/pme-t9-persist" > /dev/null 2>&1 || true
+resp=$(os_req PUT "/pme-t9-persist" "$(encrypted_index_settings)")
+assert_status "T9/create-persist" "${resp}" "200"
+assert_encrypted_index_settings "T9/settings-persist" "pme-t9-persist"
+
+for i in 0 1 2; do
+    r=$(os_req POST "/pme-t9-persist/_doc/${i}" "{\"title\":\"secret_${i}\",\"amount\":$((i*7)),\"tag\":\"secret\"}")
+    assert_status "T9/index-doc-${i}" "${r}" "201"
+done
+r=$(os_req POST "/pme-t9-persist/_refresh")
+assert_status "T9/refresh" "${r}" "200"
+
+assert_search_hits_or_xfail "T9/readable-with-kms" "pme-t9-persist" '{"query":{"match_all":{}}}' "3"
+info "Index pme-t9-persist left alive for KMS-unavailable test phase."
+
+# ---- summary -----------------------------------------------------------------
+
+echo ""
+echo "======================================="
+echo " PME E2E Test Results"
+echo "======================================="
+echo " PASSED : ${PASS}"
+echo " XFAIL  : ${XFAIL}"
+echo " FAILED : ${FAIL}"
+echo "======================================="
+
+if [[ ${XFAIL} -gt 0 ]]; then
+    echo ""
+    echo "Expected failures:"
+    for e in "${XFAILS[@]}"; do
+        echo "  - ${e}"
+    done
+fi
+
+if [[ ${FAIL} -gt 0 ]]; then
+    echo ""
+    echo "Failed tests:"
+    for e in "${ERRORS[@]}"; do
+        echo "  - ${e}"
+    done
+    exit 1
+fi
+echo " All tests passed."

--- a/sandbox/plugins/parquet-data-format/src/internalClusterTest/java/org/opensearch/parquet/encryption/MockPmeMasterKeyProviderPlugin.java
+++ b/sandbox/plugins/parquet-data-format/src/internalClusterTest/java/org/opensearch/parquet/encryption/MockPmeMasterKeyProviderPlugin.java
@@ -1,0 +1,62 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.parquet.encryption;
+
+import org.opensearch.cluster.metadata.CryptoMetadata;
+import org.opensearch.common.Randomness;
+import org.opensearch.common.crypto.DataKeyPair;
+import org.opensearch.common.crypto.MasterKeyProvider;
+import org.opensearch.plugins.CryptoKeyProviderPlugin;
+import org.opensearch.plugins.Plugin;
+
+import static org.mockito.AdditionalAnswers.returnsFirstArg;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * TODO: Mock KMS for testing; should be also consolidated with testing approach used by Lucene encryption plugin.
+ *
+ * Test plugin that provides a mock {@link MasterKeyProvider} for PME integration tests.
+ *
+ * <p>Analogous to {@code MockCryptoKeyProviderPlugin} in the Lucene storage-encryption plugin.
+ * The mock provider uses random but fixed-per-instance 32-byte keys and implements
+ * {@code decryptKey} as an identity function (returns the first argument unchanged), so
+ * key material round-trips through the keyfile without a real KMS.
+ *
+ * <p>Registers under the type {@value #TYPE}. Integration tests configure their indices with
+ * {@code index.store.parquet.crypto.key_provider_type = "mock-pme"}.
+ */
+public class MockPmeMasterKeyProviderPlugin extends Plugin implements CryptoKeyProviderPlugin {
+
+    public static final String TYPE = "mock-pme";
+
+    @Override
+    public MasterKeyProvider createKeyProvider(CryptoMetadata cryptoMetadata) {
+        MasterKeyProvider provider = mock(MasterKeyProvider.class);
+
+        byte[] rawKey = new byte[32];
+        byte[] encryptedKey = new byte[32];
+        Randomness.get().nextBytes(rawKey);
+        Randomness.get().nextBytes(encryptedKey);
+
+        when(provider.generateDataPair()).thenReturn(new DataKeyPair(rawKey, encryptedKey));
+        // Identity decrypt: the keyfile stores "encryptedKey", decryptKey returns it as-is.
+        // This means every call to decryptKey returns the same bytes that were written,
+        // satisfying the 32-byte length check in PmeKeyfileManager without a real KMS.
+        when(provider.decryptKey(any(byte[].class))).then(returnsFirstArg());
+        return provider;
+    }
+
+    @Override
+    public String type() {
+        return TYPE;
+    }
+}
+

--- a/sandbox/plugins/parquet-data-format/src/internalClusterTest/java/org/opensearch/parquet/encryption/ParquetPmeEncryptedIT.java
+++ b/sandbox/plugins/parquet-data-format/src/internalClusterTest/java/org/opensearch/parquet/encryption/ParquetPmeEncryptedIT.java
@@ -1,0 +1,131 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.parquet.encryption;
+
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.parquet.ParquetDataFormatPlugin;
+import org.opensearch.parquet.engine.ParquetDataFormat;
+import org.opensearch.plugins.Plugin;
+import org.opensearch.test.OpenSearchIntegTestCase;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.hamcrest.Matchers.is;
+
+/**
+ * End-to-end integration tests for Parquet Modular Encryption (PME).
+ *
+ * <p>Analogous to {@code CryptoDirectoryIntegTestCases} in the Lucene storage-encryption
+ * plugin. A {@link MockPmeMasterKeyProviderPlugin} is loaded as a node plugin so that the
+ * {@link org.opensearch.crypto.CryptoHandlerRegistry} can resolve the key provider without
+ * a real KMS. Every index is created with:
+ * <ul>
+ *   <li>{@code index.pluggable.dataformat = "parquet"} — activates the Parquet data format engine</li>
+ *   <li>{@code index.store.parquet.crypto.key_provider = "test"} — triggers PME context creation</li>
+ *   <li>{@code index.store.parquet.crypto.key_provider_type = "mock-pme"} — selects the mock provider</li>
+ * </ul>
+ *
+ * <p>The tests verify that documents can be indexed and searched transparently through the
+ * full PME stack (keyfile creation → key derivation → Parquet write → read).
+ */
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.SUITE, numDataNodes = 1)
+public class ParquetPmeEncryptedIT extends OpenSearchIntegTestCase {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return Arrays.asList(ParquetDataFormatPlugin.class, MockPmeMasterKeyProviderPlugin.class);
+    }
+
+    @Override
+    protected boolean addMockInternalEngine() {
+        // Must return false so the real Parquet engine is used, not OpenSearch's mock engine.
+        // This mirrors the same override in CryptoDirectoryIntegTestCases.
+        return false;
+    }
+
+    /** Index settings shared by all test methods: Parquet format + PME mock provider. */
+    private Settings encryptedParquetIndexSettings() {
+        return Settings.builder()
+            .put("index.pluggable.dataformat.enabled", true)
+            .put("index.pluggable.dataformat", ParquetDataFormat.PARQUET_DATA_FORMAT_NAME)
+            .put("index.store.parquet.crypto.key_provider", "test")
+            .put("index.store.parquet.crypto.key_provider_type", MockPmeMasterKeyProviderPlugin.TYPE)
+            .put(indexSettings())
+            .build();
+    }
+
+    /**
+     * Verifies that documents indexed into an encrypted Parquet index are searchable.
+     * This exercises the full write path (keyfile creation, key derivation, PME footer key
+     * injection into parquet-rs) and the full read path (keyfile load, key derivation,
+     * footer key resolution for decryption).
+     */
+    public void testIndexAndSearch() {
+        createIndex("pme-test", encryptedParquetIndexSettings());
+
+        long nbDocs = randomIntBetween(1, 50);
+        for (long i = 0; i < nbDocs; i++) {
+            index("pme-test", "doc", String.valueOf(i), "field", "value_" + i);
+        }
+        refresh("pme-test");
+
+        SearchResponse response = client().prepareSearch("pme-test").get();
+        assertThat(response.getHits().getTotalHits().value(), is(nbDocs));
+    }
+
+    /**
+     * Verifies that an encrypted Parquet index can be deleted and is then gone.
+     * Deletion must also evict the PME cache entries cleanly (no leaked key material).
+     */
+    public void testDeleteEncryptedIndex() {
+        createIndex("pme-delete", encryptedParquetIndexSettings());
+
+        long nbDocs = randomIntBetween(1, 20);
+        for (long i = 0; i < nbDocs; i++) {
+            index("pme-delete", "doc", String.valueOf(i), "field", "value_" + i);
+        }
+        refresh("pme-delete");
+
+        SearchResponse before = client().prepareSearch("pme-delete").get();
+        assertThat(before.getHits().getTotalHits().value(), is(nbDocs));
+
+        client().admin().indices().prepareDelete("pme-delete").get();
+
+        expectThrows(Exception.class, () -> client().prepareSearch("pme-delete").get());
+    }
+
+    /**
+     * Verifies that multiple separate encrypted indices each get their own keyfile and
+     * are independently readable. Each index uses the same mock provider but generates
+     * a distinct data key (different {@code generateDataPair()} call per index).
+     */
+    public void testTwoIndependentEncryptedIndices() {
+        createIndex("pme-alpha", encryptedParquetIndexSettings());
+        createIndex("pme-beta", encryptedParquetIndexSettings());
+
+        for (long i = 0; i < 5; i++) {
+            index("pme-alpha", "doc", String.valueOf(i), "color", "red");
+            index("pme-beta", "doc", String.valueOf(i), "color", "blue");
+        }
+        refresh("pme-alpha", "pme-beta");
+
+        SearchResponse alpha = client().prepareSearch("pme-alpha").get();
+        SearchResponse beta = client().prepareSearch("pme-beta").get();
+        assertThat(alpha.getHits().getTotalHits().value(), is(5L));
+        assertThat(beta.getHits().getTotalHits().value(), is(5L));
+    }
+}
+
+
+
+
+
+

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/ParquetDataFormatPlugin.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/ParquetDataFormatPlugin.java
@@ -38,6 +38,7 @@ import org.opensearch.index.engine.dataformat.IndexingExecutionEngine;
 import org.opensearch.index.engine.dataformat.StoreStrategy;
 import org.opensearch.index.store.PrecomputedChecksumStrategy;
 import org.opensearch.parquet.bridge.RustBridge;
+import org.opensearch.parquet.encryption.PmeDataKeyCache;
 import org.opensearch.parquet.engine.ParquetDataFormat;
 import org.opensearch.parquet.engine.ParquetIndexingEngine;
 import org.opensearch.parquet.fields.ArrowSchemaBuilder;
@@ -189,6 +190,9 @@ public class ParquetDataFormatPlugin extends Plugin implements DataFormatPlugin,
             cs.addSettingsUpdateConsumer(ParquetSettings.MERGE_POOL_MAX, newMax -> RustBridge.setMergePoolLimit(newMax));
         }
 
+        this.nativeAllocator = pluginComponentRegistry.getComponent(ArrowNativeAllocator.class)
+            .orElseThrow(() -> new IllegalStateException("ArrowNativeAllocator not available; arrow-base plugin must be installed"));
+        PmeDataKeyCache.initialize();
         return Collections.emptyList();
     }
 

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/ParquetSettings.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/ParquetSettings.java
@@ -862,7 +862,32 @@ public final class ParquetSettings {
             BLOOM_FILTER_ENABLED_VALUE_SETTING,
             TYPE_ENCODING_SETTINGS,
             TYPE_COMPRESSION_SETTINGS,
-            TYPE_BLOOM_FILTER_SETTINGS
+            TYPE_BLOOM_FILTER_SETTINGS,
+            CRYPTO_KEY_PROVIDER,
+            CRYPTO_KEY_PROVIDER_TYPE
         );
     }
+
+    /**
+     * Index-scoped setting: name of the PME master key provider.
+     * TODO: Consolidate this with setting from Lucene encryption plugin.
+     */
+    public static final Setting<String> CRYPTO_KEY_PROVIDER = Setting.simpleString(
+        "index.store.parquet.crypto.key_provider",
+        Setting.Property.NodeScope,
+        Setting.Property.IndexScope,
+        Setting.Property.InternalIndex
+    );
+
+    /**
+     * Index-scoped setting: type of the PME master key provider (e.g. {@code "mock-pme"}).
+     * TODO: Consolidate this with setting from Lucene encryption plugin.
+     */
+    public static final Setting<String> CRYPTO_KEY_PROVIDER_TYPE = Setting.simpleString(
+        "index.store.parquet.crypto.key_provider_type",
+        "aws-kms",
+        Setting.Property.NodeScope,
+        Setting.Property.IndexScope,
+        Setting.Property.InternalIndex
+    );
 }

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/bridge/NativeParquetWriter.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/bridge/NativeParquetWriter.java
@@ -12,6 +12,7 @@ import org.opensearch.common.SetOnce;
 import org.opensearch.index.engine.dataformat.RowIdMapping;
 import org.opensearch.parquet.stats.ParquetShardStatsTracker;
 import org.opensearch.plugin.stats.StatsRecorder;
+import org.opensearch.parquet.encryption.PmeFileEncryptionInputs;
 
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -48,7 +49,7 @@ public class NativeParquetWriter {
      */
     public NativeParquetWriter(String filePath, ParquetShardStatsTracker stats) {
         this.filePath = filePath;
-        this.stats = stats;
+        this.stats = stats != null ? stats : new ParquetShardStatsTracker();
     }
 
     /**
@@ -58,6 +59,29 @@ public class NativeParquetWriter {
      */
     public NativeParquetWriter(String filePath) {
         this(filePath, new ParquetShardStatsTracker());
+    }
+
+    /**
+     * Convenience constructor that creates AND immediately initializes the native writer.
+     *
+     * <p>Intended for tests and simple write-paths that do not need deferred initialization.
+     * Uses an empty sort config and writer generation 0. The {@code encryptionInputs}
+     * are zeroed immediately after the native writer is created.
+     *
+     * @param filePath         path to the Parquet file to write
+     * @param schemaAddress    native memory address of the Arrow schema
+     * @param encryptionInputs per-file PME inputs; {@code null} writes an unencrypted file
+     * @throws IOException if the native writer creation fails
+     */
+    public NativeParquetWriter(String filePath, long schemaAddress, PmeFileEncryptionInputs encryptionInputs) throws IOException {
+        this(filePath);
+        initialize(
+            java.nio.file.Path.of(filePath).getFileName().toString(),
+            schemaAddress,
+            ParquetSortConfig.empty(),
+            0L,
+            encryptionInputs
+        );
     }
 
     /**
@@ -72,10 +96,32 @@ public class NativeParquetWriter {
      * @throws IllegalStateException if already initialized
      */
     public void initialize(String indexName, long schemaAddress, ParquetSortConfig sortConfig, long writerGeneration) throws IOException {
+        initialize(indexName, schemaAddress, sortConfig, writerGeneration, null);
+    }
+
+    /**
+     * Initializes the native Rust Parquet writer with optional PME encryption.
+     *
+     * @param indexName         the index name for settings lookup
+     * @param schemaAddress     the native memory address of the Arrow schema
+     * @param sortConfig        the sort configuration for the Parquet file
+     * @param writerGeneration  the writer generation to store in file metadata
+     * @param encryptionInputs  per-file PME inputs; {@code null} writes an unencrypted file
+     * @throws IOException if the native writer creation fails
+     * @throws IllegalStateException if already initialized
+     */
+    public void initialize(String indexName, long schemaAddress, ParquetSortConfig sortConfig, long writerGeneration,
+                           PmeFileEncryptionInputs encryptionInputs) throws IOException {
         if (initialized) {
             throw new IllegalStateException("Writer already initialized: " + filePath);
         }
-        RustBridge.createWriter(filePath, indexName, schemaAddress, sortConfig, writerGeneration);
+        try {
+            RustBridge.createWriter(filePath, indexName, schemaAddress, sortConfig, writerGeneration, encryptionInputs);
+        } finally {
+            if (encryptionInputs != null) {
+                encryptionInputs.zero();
+            }
+        }
         initialized = true;
     }
 

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/bridge/RustBridge.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/bridge/RustBridge.java
@@ -13,6 +13,7 @@ import org.opensearch.index.engine.dataformat.RowIdMapping;
 import org.opensearch.nativebridge.spi.NativeCall;
 import org.opensearch.nativebridge.spi.NativeLibraryLoader;
 import org.opensearch.parquet.stats.ParquetNativeRuntimeStats;
+import org.opensearch.parquet.encryption.PmeFileEncryptionInputs;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -42,8 +43,10 @@ public class RustBridge {
     private static final MethodHandle WRITE;
     private static final MethodHandle FINALIZE_WRITER;
     private static final MethodHandle GET_FILE_METADATA;
+    private static final MethodHandle GET_FILE_METADATA_DECRYPTED;
     private static final MethodHandle GET_COLUMN_METADATA;
     private static final MethodHandle GET_FILTERED_BYTES;
+    private static final MethodHandle READ_KEY_METADATA;
     private static final MethodHandle ON_SETTINGS_UPDATE;
     private static final MethodHandle REMOVE_SETTINGS;
     private static final MethodHandle MERGE_FILES;
@@ -60,6 +63,9 @@ public class RustBridge {
     static {
         SymbolLookup lib = NativeLibraryLoader.symbolLookup();
         Linker linker = Linker.nativeLinker();
+        // parquet_create_writer(file, file_len, schema_address,
+        //   footer_key, footer_key_len, key_metadata_json, key_metadata_json_len,
+        //   aad_prefix, aad_prefix_len) -> i64
         CREATE_WRITER = linker.downcallHandle(
             lib.find("parquet_create_writer").orElseThrow(),
             FunctionDescriptor.of(
@@ -76,17 +82,18 @@ public class RustBridge {
                 ValueLayout.JAVA_LONG,   // reverse_sorts (vals, count)
                 ValueLayout.ADDRESS,
                 ValueLayout.JAVA_LONG,   // nulls_first (vals, count)
-                ValueLayout.JAVA_LONG    // writer_generation
+                ValueLayout.JAVA_LONG,   // writer_generation
+                ValueLayout.ADDRESS, ValueLayout.JAVA_LONG,  // footer_key
+                ValueLayout.ADDRESS, ValueLayout.JAVA_LONG,  // key_metadata_json
+                ValueLayout.ADDRESS, ValueLayout.JAVA_LONG   // aad_prefix
             )
         );
         WRITE = linker.downcallHandle(
             lib.find("parquet_write").orElseThrow(),
             FunctionDescriptor.of(
                 ValueLayout.JAVA_LONG,
-                ValueLayout.ADDRESS,
-                ValueLayout.JAVA_LONG,
-                ValueLayout.JAVA_LONG,
-                ValueLayout.JAVA_LONG
+                ValueLayout.ADDRESS, ValueLayout.JAVA_LONG,
+                ValueLayout.JAVA_LONG, ValueLayout.JAVA_LONG
             )
         );
         FINALIZE_WRITER = linker.downcallHandle(
@@ -120,6 +127,21 @@ public class RustBridge {
                 ValueLayout.ADDRESS   // num_row_groups_out
             )
         );
+        // parquet_get_file_metadata_decrypted(file, footer_key, footer_key_len,
+        //   aad_prefix, aad_prefix_len, version_out, num_rows_out, created_by_buf,
+        //   created_by_buf_len, created_by_len_out) -> i64
+        GET_FILE_METADATA_DECRYPTED = linker.downcallHandle(
+            lib.find("parquet_get_file_metadata_decrypted").orElseThrow(),
+            FunctionDescriptor.of(
+                ValueLayout.JAVA_LONG,
+                ValueLayout.ADDRESS, ValueLayout.JAVA_LONG,  // file
+                ValueLayout.ADDRESS, ValueLayout.JAVA_LONG,  // footer_key
+                ValueLayout.ADDRESS, ValueLayout.JAVA_LONG,  // aad_prefix
+                ValueLayout.ADDRESS, ValueLayout.ADDRESS,     // version_out, num_rows_out
+                ValueLayout.ADDRESS, ValueLayout.JAVA_LONG,  // created_by_buf, len
+                ValueLayout.ADDRESS                           // created_by_len_out
+            )
+        );
         GET_FILTERED_BYTES = linker.downcallHandle(
             lib.find("parquet_get_filtered_native_bytes_used").orElseThrow(),
             FunctionDescriptor.of(ValueLayout.JAVA_LONG, ValueLayout.ADDRESS, ValueLayout.JAVA_LONG)
@@ -133,6 +155,16 @@ public class RustBridge {
                 ValueLayout.ADDRESS,
                 ValueLayout.JAVA_LONG,
                 ValueLayout.ADDRESS
+            )
+        );
+        // parquet_read_key_metadata(file, file_len, out_buf, out_buf_len, out_len_out) -> i64
+        READ_KEY_METADATA = linker.downcallHandle(
+            lib.find("parquet_read_key_metadata").orElseThrow(),
+            FunctionDescriptor.of(
+                ValueLayout.JAVA_LONG,
+                ValueLayout.ADDRESS, ValueLayout.JAVA_LONG,  // file
+                ValueLayout.ADDRESS, ValueLayout.JAVA_LONG,  // out_buf
+                ValueLayout.ADDRESS                           // out_len_out
             )
         );
         ON_SETTINGS_UPDATE = linker.downcallHandle(
@@ -292,7 +324,8 @@ public class RustBridge {
 
     public static void initLogger() {}
 
-    static void createWriter(String file, String indexName, long schemaAddress, ParquetSortConfig sortConfig, long writerGeneration)
+    static void createWriter(String file, String indexName, long schemaAddress, ParquetSortConfig sortConfig, long writerGeneration,
+                             PmeFileEncryptionInputs encryptionInputs)
         throws IOException {
         try (var call = new NativeCall()) {
             var f = call.str(file);
@@ -314,7 +347,13 @@ public class RustBridge {
                 (long) sortConfig.reverseSorts().size(),
                 nullsFirstArray,
                 (long) sortConfig.nullsFirst().size(),
-                writerGeneration
+                writerGeneration,
+                encryptionInputs != null ? call.bytes(encryptionInputs.footerKey()) : MemorySegment.NULL,
+                encryptionInputs != null ? (long) encryptionInputs.footerKey().length : 0L,
+                encryptionInputs != null ? call.bytes(encryptionInputs.keyMetadataJson()) : MemorySegment.NULL,
+                encryptionInputs != null ? (long) encryptionInputs.keyMetadataJson().length : 0L,
+                encryptionInputs != null ? call.bytes(encryptionInputs.aadPrefix()) : MemorySegment.NULL,
+                encryptionInputs != null ? (long) encryptionInputs.aadPrefix().length : 0L
             );
         }
     }
@@ -431,6 +470,106 @@ public class RustBridge {
             int len = (int) outLen.get(ValueLayout.JAVA_LONG, 0);
             return new String(out.data().asSlice(0, len).toArray(ValueLayout.JAVA_BYTE), StandardCharsets.UTF_8);
         }
+    }
+
+    /**
+     * Reads the encrypted Parquet file metadata using the provided per-file encryption inputs.
+     *
+     * @param file             path to the encrypted Parquet file
+     * @param encryptionInputs per-file PME inputs containing the derived footer key and AAD prefix
+     * @return file metadata
+     * @throws IOException if reading or decryption fails
+     */
+    public static ParquetFileMetadata getFileMetadata(String file, PmeFileEncryptionInputs encryptionInputs) throws IOException {
+        if (encryptionInputs == null) {
+            return getFileMetadata(file);
+        }
+        try (var call = new NativeCall()) {
+            var f = call.str(file);
+            byte[] footerKeyBytes = encryptionInputs.footerKey();
+            byte[] aadBytes = encryptionInputs.aadPrefix();
+            var footerKey = call.bytes(footerKeyBytes);
+            var aadPrefix = call.bytes(aadBytes);
+            var versionOut = call.intOut();
+            var numRowsOut = call.longOut();
+            var out = call.outBuffer(1024);
+            call.invokeIO(
+                GET_FILE_METADATA_DECRYPTED,
+                f.segment(), f.len(),
+                footerKey, (long) footerKeyBytes.length,
+                aadPrefix, (long) aadBytes.length,
+                versionOut, numRowsOut,
+                out.data(), (long) out.capacity(),
+                out.lenOut()
+            );
+            int createdByLen = out.actualLength();
+            return new ParquetFileMetadata(
+                versionOut.get(ValueLayout.JAVA_INT, 0),
+                numRowsOut.get(ValueLayout.JAVA_LONG, 0),
+                createdByLen >= 0
+                    ? new String(out.data().asSlice(0, createdByLen).toArray(ValueLayout.JAVA_BYTE), StandardCharsets.UTF_8)
+                    : null,
+                0L,
+                0
+            );
+        }
+    }
+
+    /**
+     * Returns the decrypted row count for an encrypted Parquet file.
+     *
+     * @param file             path to the encrypted Parquet file
+     * @param encryptionInputs per-file PME inputs containing the derived footer key and AAD prefix
+     * @return total row count
+     * @throws IOException if reading or decryption fails
+     */
+    public static long getDecryptedNumRows(String file, PmeFileEncryptionInputs encryptionInputs) throws IOException {
+        return getFileMetadata(file, encryptionInputs).numRows();
+    }
+
+    /**
+     * Reads the plaintext {@code key_metadata} bytes from an encrypted Parquet file's
+     * {@code FileCryptoMetaData} without decrypting the footer.
+     *
+     * <p>Returns {@code null} if the file is not encrypted or has no {@code key_metadata}.
+     *
+     * @param file path to the Parquet file
+     * @return UTF-8 JSON key metadata bytes, or {@code null}
+     * @throws IOException if the file cannot be read or is malformed
+     */
+    public static byte[] readKeyMetadata(String file) throws IOException {
+        try (var call = new NativeCall()) {
+            var f = call.str(file);
+            var out = call.outBuffer(256);
+            long rc = call.invokeIO(
+                READ_KEY_METADATA,
+                f.segment(), f.len(),
+                out.data(), (long) out.capacity(),
+                out.lenOut()
+            );
+            if (rc == 1) {
+                // Not encrypted or no key_metadata.
+                return null;
+            }
+            int len = out.actualLength();
+            if (len < 0) {
+                return null;
+            }
+            return out.data().asSlice(0, len).toArray(ValueLayout.JAVA_BYTE);
+        }
+    }
+
+    /**
+     * Alias for {@link #readKeyMetadata(String)} — reads the plaintext {@code key_metadata}
+     * bytes from an encrypted Parquet file's {@code FileCryptoMetaData} without decrypting
+     * the footer.
+     *
+     * @param file path to the Parquet file
+     * @return raw key_metadata bytes, or {@code null} if not encrypted / no metadata
+     * @throws IOException if the file cannot be read or is malformed
+     */
+    public static byte[] readParquetKeyMetadata(String file) throws IOException {
+        return readKeyMetadata(file);
     }
 
     public static long getFilteredNativeBytesUsed(String pathPrefix) {

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/bridge/package-info.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/bridge/package-info.java
@@ -29,7 +29,7 @@
  *
  * <h2>Writer Lifecycle</h2>
  * <pre>
- * createWriter(filePath, schemaAddress)  — initialize native writer with Arrow schema
+ * createWriter(filePath, schemaAddress, encryptionConfig) — initialize native writer with Arrow schema (+ optional PME)
  * write(arrayAddress, schemaAddress)     — send a batch of Arrow data (repeatable)
  * finalizeWriter(filePath)                  — finalize Parquet file, returns metadata
  * syncToDisk(filePath)                  — fsync the file to durable storage

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/encryption/PmeCacheKey.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/encryption/PmeCacheKey.java
@@ -1,0 +1,82 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.parquet.encryption;
+
+import java.util.Objects;
+
+/**
+ * Immutable composite key for PME data-key cache entries.
+ *
+ * <p>Follows the same pattern as {@code ShardCacheKey} in the Lucene storage-encryption
+ * plugin. Equality and hashing are based on {@code indexUuid} and {@code shardId},
+ * giving shard-level lifecycle control: each shard holds its own cache entry and can
+ * be evicted independently when the shard closes. Multiple shards of the same index
+ * on the same node each decrypt the index-level keyfile once and cache the result
+ * separately, which keeps eviction simple — no reference counting of "how many shards
+ * are still alive for this index" is required.
+ *
+ * <p>The {@code dataKeyId} field is carried for convenience (logging) but is
+ * <em>not</em> part of key identity, mirroring how {@code ShardCacheKey} carries
+ * {@code indexName} for logging without including it in {@code equals}/{@code hashCode}.
+ *
+ * <p>In v1 the only valid {@code dataKeyId} is {@link PmeFileKeyMetadata#DEFAULT_DATA_KEY_ID}.
+ *
+ * @opensearch.internal
+ */
+final class PmeCacheKey {
+
+    private final String indexUuid;
+    private final int shardId;
+    /** Convenience field — NOT part of key identity. */
+    private final String dataKeyId;
+    private int hash; // lazy-computed, matches ShardCacheKey pattern
+
+    PmeCacheKey(String indexUuid, int shardId, String dataKeyId) {
+        this.indexUuid = Objects.requireNonNull(indexUuid, "indexUuid must not be null");
+        this.shardId = shardId;
+        this.dataKeyId = Objects.requireNonNull(dataKeyId, "dataKeyId must not be null");
+    }
+
+    String getIndexUuid() {
+        return indexUuid;
+    }
+
+    int getShardId() {
+        return shardId;
+    }
+
+    String getDataKeyId() {
+        return dataKeyId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof PmeCacheKey)) return false;
+        PmeCacheKey that = (PmeCacheKey) o;
+        // dataKeyId is NOT part of equality — only uuid + shardId
+        return shardId == that.shardId && indexUuid.equals(that.indexUuid);
+    }
+
+    @Override
+    public int hashCode() {
+        int h = hash;
+        if (h == 0) {
+            h = Objects.hash(indexUuid, shardId);
+            if (h == 0) h = 1; // avoid zero sentinel, mirrors ShardCacheKey
+            hash = h;
+        }
+        return h;
+    }
+
+    @Override
+    public String toString() {
+        return indexUuid + "/" + dataKeyId + "-shard-" + shardId;
+    }
+}

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/encryption/PmeContext.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/encryption/PmeContext.java
@@ -1,0 +1,159 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.parquet.encryption;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.cluster.metadata.CryptoMetadata;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.index.IndexSettings;
+import org.opensearch.parquet.ParquetSettings;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+/**
+ * Per-engine PME (Parquet Modular Encryption) context.
+ *
+ * <p>This is the public entry point for callers. Each {@code ParquetIndexingEngine}
+ * holds one instance (or {@code null} for unencrypted indices). The context ties
+ * together:
+ * <ul>
+ *   <li>The index-level {@link CryptoMetadata} (key provider type and name).</li>
+ *   <li>The index UUID and shard ID, which together form the cache key in
+ *       {@link PmeDataKeyCache} and mirror the shard-lifecycle eviction model of the
+ *       Lucene storage-encryption plugin.</li>
+ *   <li>The index data path, which is the directory that holds the {@code keyfile}.</li>
+ * </ul>
+ *
+ * <p>The data key itself lives in the node-level {@link PmeDataKeyCache}; this class
+ * never holds raw key bytes directly.
+ *
+ * <p>Lifecycle:
+ * <ol>
+ *   <li>{@link #create(IndexSettings, Path, int)} — called once per engine at shard open time.</li>
+ *   <li>{@link #createFileEncryptionInputs()} — called once per Parquet file to be written.</li>
+ *   <li>{@link #evict()} — called when the engine (shard) is closed; zeroes this shard's
+ *       cached key material.</li>
+ * </ol>
+ */
+public final class PmeContext {
+
+    private static final Logger logger = LogManager.getLogger(PmeContext.class);
+
+    private final CryptoMetadata cryptoMetadata;
+    private final Path indexDataPath;
+    private final String indexUuid;
+    private final int shardId;
+
+    private PmeContext(CryptoMetadata cryptoMetadata, Path indexDataPath, String indexUuid, int shardId) {
+        this.cryptoMetadata = cryptoMetadata;
+        this.indexDataPath = indexDataPath;
+        this.indexUuid = indexUuid;
+        this.shardId = shardId;
+    }
+
+    /**
+     * Creates a {@link PmeContext} if the index is configured for PME encryption, or
+     * returns {@code null} for unencrypted indices.
+     *
+     * <p>On first call for a given shard, the keyfile is created via
+     * {@link PmeKeyfileManager#initOrLoad} and the data key is loaded into
+     * {@link PmeDataKeyCache}. Subsequent calls (from other shards of the same index)
+     * hit the cache under their own shard-keyed entry.
+     *
+     * @param indexSettings  the index settings; {@code null} → returns {@code null}
+     * @param indexDataPath  index-level data directory (parent of shard directories)
+     * @param shardId        the shard ID; used as part of the cache key for shard-lifecycle eviction
+     * @return context, or {@code null} if encryption is not configured
+     * @throws IOException if keyfile initialisation or key loading fails
+     */
+    public static PmeContext create(IndexSettings indexSettings, Path indexDataPath, int shardId) throws IOException {
+        return create(indexSettings, indexDataPath, shardId, null);
+    }
+
+    /**
+     * Exposed for testing only:
+     *
+     * <p>The {@code loaderOverride} parameter is package-private for testing: pass a
+     * pre-built {@link PmeDataKeyCache.DataKeyLoader} (backed by a mock
+     * {@link org.opensearch.common.crypto.MasterKeyProvider}) to bypass
+     * {@link org.opensearch.crypto.CryptoHandlerRegistry}. Pass {@code null} for
+     * production use; the loader will then be derived from {@code indexSettings}.
+     *
+     * @param indexSettings  the index settings; {@code null} → returns {@code null}
+     * @param indexDataPath  index-level data directory (parent of shard directories)
+     * @param shardId        the shard ID; used as part of the cache key for shard-lifecycle eviction
+     * @param loaderOverride test-only key loader; {@code null} in production
+     * @return context, or {@code null} if encryption is not configured
+     * @throws IOException if keyfile initialisation or key loading fails
+     */
+    static PmeContext create(IndexSettings indexSettings, Path indexDataPath, int shardId, PmeDataKeyCache.DataKeyLoader loaderOverride)
+        throws IOException {
+        if (indexSettings == null) {
+            return null;
+        }
+        // Build CryptoMetadata from Parquet-specific settings (index.store.parquet.crypto.*)
+        // instead of calling CryptoMetadata.fromIndexSettings(), which reads the Lucene-plugin
+        // keys (index.store.crypto.*) that we cannot register to avoid a setting-name collision.
+        Settings raw = indexSettings.getSettings();
+        String keyProviderName = ParquetSettings.CRYPTO_KEY_PROVIDER.get(raw);
+        if (keyProviderName == null || keyProviderName.isEmpty()) {
+            return null;
+        }
+        String keyProviderType = ParquetSettings.CRYPTO_KEY_PROVIDER_TYPE.get(raw);
+        CryptoMetadata cryptoMetadata = new CryptoMetadata(keyProviderName, keyProviderType, Settings.EMPTY);
+        String indexUuid = indexSettings.getUUID();
+        PmeContext ctx = new PmeContext(cryptoMetadata, indexDataPath, indexUuid, shardId);
+        PmeDataKeyCache.DataKeyLoader loader = loaderOverride != null
+            ? loaderOverride
+            : () -> PmeKeyfileManager.initOrLoad(indexDataPath, cryptoMetadata);
+        // Eagerly populate the cache so errors surface at shard-open time, not at write time.
+        PmeDataKeyCache.getInstance().getOrLoad(indexUuid, shardId, PmeFileKeyMetadata.DEFAULT_DATA_KEY_ID, loader);
+        logger.debug("PME context initialised for index [{}] shard [{}]", indexUuid, shardId);
+        return ctx;
+    }
+
+
+    /**
+     * Creates per-file PME encryption inputs for a new Parquet file.
+     *
+     * <p>Retrieves the data key from {@link PmeDataKeyCache} (cache hit in the normal case),
+     * then delegates to {@link PmeFileEncryptionInputs#create(PmeDataKey)}.
+     * The returned inputs hold derived key material; the caller (
+     * {@code NativeParquetWriter}) is responsible for calling
+     * {@link PmeFileEncryptionInputs#zero()} immediately after the native writer
+     * has consumed them.
+     *
+     * @return single-use per-file encryption inputs
+     * @throws IOException if the data key cannot be loaded
+     */
+    public PmeFileEncryptionInputs createFileEncryptionInputs() throws IOException {
+        logger.trace("PME: createFileEncryptionInputs for index=[{}] shard=[{}]", indexUuid, shardId);
+        PmeDataKey dataKey = PmeDataKeyCache.getInstance().getOrLoad(
+            indexUuid,
+            shardId,
+            PmeFileKeyMetadata.DEFAULT_DATA_KEY_ID,
+            () -> PmeKeyfileManager.initOrLoad(indexDataPath, cryptoMetadata)
+        );
+        PmeFileEncryptionInputs inputs = PmeFileEncryptionInputs.create(dataKey);
+        logger.trace("PME: file encryption inputs created for index=[{}] shard=[{}]", indexUuid, shardId);
+        return inputs;
+    }
+
+    /**
+     * Evicts this shard's data key from the node-level cache, zeroing key material.
+     * Must be called when the engine is closed (i.e. from {@code ParquetIndexingEngine#close}).
+     * Other shards of the same index that are still open retain their own cache entries.
+     */
+    public void evict() {
+        PmeDataKeyCache.getInstance().evict(indexUuid, shardId, PmeFileKeyMetadata.DEFAULT_DATA_KEY_ID);
+        logger.debug("PME data key evicted for index [{}] shard [{}]", indexUuid, shardId);
+    }
+}

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/encryption/PmeDataKey.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/encryption/PmeDataKey.java
@@ -1,0 +1,57 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.parquet.encryption;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+/**
+ * Scoped 32-byte data key holder with best-effort zeroing.
+ *
+ * <p>Callers receive key material via {@link #bytes()}, which returns a defensive copy.
+ * The internal backing array is zeroed on {@link #zero()}, which must be called before
+ * the instance is discarded (e.g., on cache eviction or shard close).
+ */
+public final class PmeDataKey {
+
+    private final byte[] keyBytes;
+
+    /**
+     * Creates a new key holder. The provided array is defensively copied;
+     * the caller should zero their copy immediately after construction.
+     *
+     * <p>In production code, obtain instances via {@link PmeDataKeyCache#getOrLoad}.
+     * This constructor is public to allow test-only direct construction.
+     *
+     * @param keyBytes raw 32-byte data key
+     */
+    public PmeDataKey(byte[] keyBytes) {
+        Objects.requireNonNull(keyBytes, "keyBytes must not be null");
+        if (keyBytes.length != PmeKeyDerivation.DATA_KEY_BYTES) {
+            throw new IllegalArgumentException("data key must be 32 bytes, got: " + keyBytes.length);
+        }
+        this.keyBytes = keyBytes.clone();
+    }
+
+    /**
+     * Returns a defensive copy of the 32-byte key material.
+     * The caller is responsible for zeroing the returned array after use.
+     */
+    byte[] bytes() {
+        return keyBytes.clone();
+    }
+
+    /**
+     * Best-effort zeroing of the internal key material.
+     * Call before discarding this instance (e.g., on eviction).
+     */
+    void zero() {
+        Arrays.fill(keyBytes, (byte) 0);
+    }
+}

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/encryption/PmeDataKeyCache.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/encryption/PmeDataKeyCache.java
@@ -1,0 +1,192 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.parquet.encryption;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * Node-level cache for PME index data keys.
+ *
+ * <p>Follows the same singleton pattern as {@code NodeLevelKeyCache} in the Lucene
+ * storage-encryption plugin: a single instance is created during plugin startup via
+ * {@link #initialize()} and accessed through {@link #getInstance()}. Unlike a bare
+ * utility class with only static fields, this allows the cache to hold per-instance
+ * configuration in the future (e.g. TTL settings passed to {@code initialize}) and
+ * supports clean teardown via {@link #reset()} in tests.
+ *
+ * <p>Internally keyed by {@link PmeCacheKey} ({@code indexUuid} + {@code shardId}),
+ * mirroring how {@code NodeLevelKeyCache} uses {@code ShardCacheKey}. Shard-level keying
+ * gives precise lifecycle control: each shard's entry is evicted independently on shard
+ * close, with no need to reference-count how many shards of the same index are still open.
+ * Multiple shards of the same index each hold a separately cached copy of the same decrypted
+ * data key — an acceptable memory tradeoff for the lifecycle simplicity it provides. The
+ * public API accepts individual parameters and constructs the key internally, exactly as
+ * {@code NodeLevelKeyCache.get(indexUuid, shardId, indexName)} does.
+ *
+ * <p>On eviction, the internal key material is zeroed via {@link PmeDataKey#zero()}.
+ *
+ * <p>The singleton is initialised by {@link #initialize()}, which is called once from
+ * {@link org.opensearch.parquet.ParquetDataFormatPlugin#createComponents}.
+ *
+ * <p>TODO: The Lucene storage-encryption plugin ({@code NodeLevelKeyCache} /
+ * {@code MasterKeyHealthMonitor}) adds proactive KMS health monitoring on top of a
+ * similar cache: it runs a periodic background check for all encrypted indices, applies
+ * index-level read/write blocks when the KMS is unreachable, and removes them
+ * automatically once the KMS recovers. Consider adding equivalent functionality here:
+ * <ul>
+ *   <li>A configurable TTL ({@code expireAfterWrite}) so that a KMS outage is detected
+ *       at the next background refresh rather than only on the next cold cache miss.</li>
+ *   <li>A background health-check thread that proactively re-loads all cached data keys
+ *       at the configured interval.</li>
+ *   <li>Block management ({@code index.blocks.read} / {@code index.blocks.write}) when
+ *       the KMS cannot be reached and the cached key has expired.</li>
+ *   <li>Automatic block removal and shard-retry trigger upon KMS recovery.</li>
+ * </ul>
+ */
+public final class PmeDataKeyCache {
+
+    private static final Logger logger = LogManager.getLogger(PmeDataKeyCache.class);
+
+    private static PmeDataKeyCache INSTANCE;
+
+    private final ConcurrentHashMap<PmeCacheKey, PmeDataKey> cache = new ConcurrentHashMap<>();
+
+    private PmeDataKeyCache() {}
+
+    /**
+     * Initialises the singleton instance. Must be called once during plugin startup
+     * (from {@link org.opensearch.parquet.ParquetDataFormatPlugin#createComponents})
+     * before any call to {@link #getInstance()}.
+     *
+     * <p>Idempotent: a second call has no effect if the instance already exists.
+     */
+    public static synchronized void initialize() {
+        if (INSTANCE == null) {
+            INSTANCE = new PmeDataKeyCache();
+        }
+    }
+
+    /**
+     * Returns the singleton instance.
+     *
+     * @throws IllegalStateException if {@link #initialize()} has not been called yet
+     */
+    static PmeDataKeyCache getInstance() {
+        if (INSTANCE == null) {
+            throw new IllegalStateException("PmeDataKeyCache not initialized.");
+        }
+        return INSTANCE;
+    }
+
+    /**
+     * Returns the cached {@link PmeDataKey}, or loads it via {@code loader}, caches it,
+     * and returns it.
+     *
+     * <p>Mirrors {@code NodeLevelKeyCache.get(indexUuid, shardId, indexName)}: individual
+     * parameters are accepted and the {@link PmeCacheKey} is constructed internally.
+     *
+     * <p>The raw key bytes returned by {@code loader} are defensively zeroed immediately
+     * after the {@link PmeDataKey} is constructed.
+     *
+     * @param indexUuid     the index UUID
+     * @param shardId       the shard ID
+     * @param dataKeyId     the data-key identifier ({@link PmeFileKeyMetadata#DEFAULT_DATA_KEY_ID} for now)
+     * @param loader        called exactly once on cache miss; the caller is responsible for
+     *                      closing over any path or context needed to load the key material
+     * @return the cached or freshly loaded data key
+     * @throws IOException if the loader fails
+     */
+    PmeDataKey getOrLoad(String indexUuid, int shardId, String dataKeyId, DataKeyLoader loader) throws IOException {
+        Objects.requireNonNull(indexUuid, "indexUuid must not be null");
+        Objects.requireNonNull(dataKeyId, "dataKeyId must not be null");
+
+        PmeCacheKey key = new PmeCacheKey(indexUuid, shardId, dataKeyId);
+        PmeDataKey existing = cache.get(key);
+        if (existing != null) {
+            logger.trace("PME key cache: HIT for index=[{}] shard=[{}] keyId=[{}]", indexUuid, shardId, dataKeyId);
+            return existing;
+        }
+        synchronized (cache) {
+            existing = cache.get(key);
+            if (existing != null) {
+                logger.trace("PME key cache: HIT (double-check) for index=[{}] shard=[{}] keyId=[{}]", indexUuid, shardId, dataKeyId);
+                return existing;
+            }
+            logger.trace("PME key cache: MISS for index=[{}] shard=[{}] keyId=[{}] — loading from keyfile", indexUuid, shardId, dataKeyId);
+            byte[] rawKey = loader.load();
+            try {
+                PmeDataKey dataKey = new PmeDataKey(rawKey);
+                cache.put(key, dataKey);
+                logger.trace("PME key cache: stored new key for index=[{}] shard=[{}] keyId=[{}]", indexUuid, shardId, dataKeyId);
+                return dataKey;
+            } finally {
+                Arrays.fill(rawKey, (byte) 0);
+            }
+        }
+    }
+
+    /**
+     * Removes the data key from the cache and zeros its internal key material.
+     * Should be called when the shard is closed, mirroring the shard-lifecycle eviction
+     * used by {@code NodeLevelKeyCache.evict(indexUuid, shardId, indexName)}.
+     *
+     * @param indexUuid the index UUID
+     * @param shardId   the shard ID
+     * @param dataKeyId the data-key identifier
+     */
+    void evict(String indexUuid, int shardId, String dataKeyId) {
+        PmeCacheKey key = new PmeCacheKey(indexUuid, shardId, dataKeyId);
+        PmeDataKey removed = cache.remove(key);
+        if (removed != null) {
+            logger.trace("PME key cache: evicted and zeroed key for index=[{}] shard=[{}] keyId=[{}]", indexUuid, shardId, dataKeyId);
+            removed.zero();
+        } else {
+            logger.trace("PME key cache: evict called but no entry found for index=[{}] shard=[{}] keyId=[{}]", indexUuid, shardId, dataKeyId);
+        }
+    }
+
+    /**
+     * Clears all cached keys, zeroing their key material.
+     * Primarily for testing purposes.
+     */
+    void clear() {
+        cache.forEach((k, v) -> v.zero());
+        cache.clear();
+    }
+
+    /**
+     * Resets the singleton instance completely.
+     * Primarily for testing purposes where complete cleanup between tests is needed.
+     *
+     * <p>Mirrors {@code NodeLevelKeyCache.reset()} in the Lucene storage-encryption plugin.
+     */
+    static synchronized void reset() {
+        if (INSTANCE != null) {
+            INSTANCE.clear();
+            INSTANCE = null;
+        }
+    }
+
+    /**
+     * Supplier that may throw {@link IOException}, used for loading key material
+     * from the keyfile on a cache miss.
+     */
+    @FunctionalInterface
+    interface DataKeyLoader {
+        byte[] load() throws IOException;
+    }
+}
+
+

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/encryption/PmeFileEncryptionInputs.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/encryption/PmeFileEncryptionInputs.java
@@ -1,0 +1,119 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.parquet.encryption;
+
+import java.security.SecureRandom;
+import java.util.Arrays;
+import java.util.Objects;
+
+/**
+ * Per-file PME (Parquet Modular Encryption) inputs for a single Parquet file.
+ *
+ * <p>Bundles the derived 32-byte AES-GCM footer key, the key-metadata JSON bytes
+ * (stored verbatim in {@code FileCryptoMetaData.key_metadata}), and the binary
+ * AAD prefix (used for all GCM ciphertexts in the file).
+ *
+ * <p>Instances are single-use. Call {@link #zero()} after the native writer has
+ * consumed the key material to minimise the key's time in heap memory.
+ *
+ * <p>Thread-safety: not thread-safe; do not share between threads.
+ */
+public final class PmeFileEncryptionInputs {
+
+    private final byte[] footerKey;       // 32 bytes, zeroed after native use
+    private final byte[] keyMetadataJson; // UTF-8 JSON stored in Parquet footer
+    private final byte[] aadPrefix;       // binary AAD prefix for all ciphertexts
+
+    private PmeFileEncryptionInputs(byte[] footerKey, byte[] keyMetadataJson, byte[] aadPrefix) {
+        this.footerKey = footerKey;
+        this.keyMetadataJson = keyMetadataJson;
+        this.aadPrefix = aadPrefix;
+    }
+
+    /**
+     * Creates per-file encryption inputs for a new Parquet file.
+     *
+     * <p>Generates a random 16-byte {@code message_id}, derives the 32-byte footer key
+     * via {@link PmeKeyDerivation#deriveFooterKey}, builds the v1 key-metadata JSON via
+     * {@link PmeFileKeyMetadata}, and constructs the binary AAD prefix via
+     * {@link PmeKeyDerivation#buildAadPrefix}.
+     *
+     * @param dataKey the 32-byte index data key; its internal bytes are NOT zeroed here
+     * @return per-file encryption inputs ready to be passed to the native writer
+     */
+    public static PmeFileEncryptionInputs create(PmeDataKey dataKey) {
+        Objects.requireNonNull(dataKey, "dataKey must not be null");
+        byte[] messageId = new byte[PmeKeyDerivation.MESSAGE_ID_BYTES];
+        new SecureRandom().nextBytes(messageId);
+
+        byte[] dataKeyBytes = dataKey.bytes();
+        byte[] footerKey;
+        try {
+            footerKey = PmeKeyDerivation.deriveFooterKey(dataKeyBytes, messageId);
+        } finally {
+            Arrays.fill(dataKeyBytes, (byte) 0);
+        }
+
+        byte[] keyMetadataJson = PmeFileKeyMetadata.forNewFile(messageId).toJsonBytes();
+        byte[] aadPrefix = PmeKeyDerivation.buildAadPrefix(messageId);
+        Arrays.fill(messageId, (byte) 0);
+
+        return new PmeFileEncryptionInputs(footerKey, keyMetadataJson, aadPrefix);
+    }
+
+    /**
+     * Creates inputs for <em>decryption only</em> from already-known key material.
+     *
+     * <p>Used when reading back an encrypted file: the footer key and AAD prefix
+     * are reconstructed from the data key and message_id parsed from the file footer.
+     * The {@code keyMetadataJson} is left empty since it is not needed for reads.
+     *
+     * @param footerKey 32-byte derived footer key; defensive copy is taken
+     * @param aadPrefix binary AAD prefix; defensive copy is taken
+     * @return decryption-only inputs
+     */
+    public static PmeFileEncryptionInputs forDecryption(byte[] footerKey, byte[] aadPrefix) {
+        Objects.requireNonNull(footerKey, "footerKey must not be null");
+        Objects.requireNonNull(aadPrefix, "aadPrefix must not be null");
+        return new PmeFileEncryptionInputs(footerKey.clone(), new byte[0], aadPrefix.clone());
+    }
+
+    /**
+     * Returns a defensive copy of the derived footer key.
+     * The caller should zero the returned array after use.
+     */
+    public byte[] footerKey() {
+        return footerKey.clone();
+    }
+
+    /**
+     * Returns a defensive copy of the key-metadata JSON bytes.
+     */
+    public byte[] keyMetadataJson() {
+        return keyMetadataJson.clone();
+    }
+
+    /**
+     * Returns a defensive copy of the binary AAD prefix.
+     * The caller should zero the returned array after use.
+     */
+    public byte[] aadPrefix() {
+        return aadPrefix.clone();
+    }
+
+    /**
+     * Best-effort zeroing of the footer key and AAD prefix held by this instance.
+     * Call this after the native writer has consumed the key material.
+     */
+    public void zero() {
+        Arrays.fill(footerKey, (byte) 0);
+        Arrays.fill(aadPrefix, (byte) 0);
+    }
+}
+

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/encryption/PmeFileKeyMetadata.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/encryption/PmeFileKeyMetadata.java
@@ -1,0 +1,166 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.parquet.encryption;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Objects;
+
+/**
+ * v1 PME footer key metadata serializer and parser.
+ *
+ * <p>The metadata is stored as compact UTF-8 JSON in Parquet {@code FileCryptoMetaData.key_metadata}.
+ * It is plaintext bootstrap data — not secret — and is validated only after the file decrypts
+ * successfully and AAD validation passes.
+ *
+ * <p>V1 JSON format (exact field order, no insignificant whitespace):
+ * <pre>
+ * {"version":1,"data_key_id":"default","message_id":"&lt;base64url-22-chars&gt;"}
+ * </pre>
+ *
+ * <p>Readers must fail closed on: missing fields, malformed values, unknown versions,
+ * unexpected fields, {@code data_key_id} != {@code "default"}, or {@code message_id} not
+ * decoding to exactly 16 bytes.
+ */
+public final class PmeFileKeyMetadata {
+
+    /** The only supported metadata version. */
+    static final int V1 = 1;
+
+    /** The only valid {@code data_key_id} in v1. */
+    public static final String DEFAULT_DATA_KEY_ID = "default";
+
+    private static final int MESSAGE_ID_BYTES = 16;
+
+    private static final ObjectMapper MAPPER = new ObjectMapper()
+        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true);
+
+    private final int version;
+    private final String dataKeyId;
+    private final byte[] messageId; // 16 raw bytes
+
+    private PmeFileKeyMetadata(int version, String dataKeyId, byte[] messageId) {
+        this.version = version;
+        this.dataKeyId = dataKeyId;
+        this.messageId = messageId;
+    }
+
+    /**
+     * Creates v1 metadata for a new Parquet file using the given random 16-byte message_id.
+     *
+     * @param messageId 16 random bytes generated per file
+     * @return new v1 metadata instance
+     */
+    public static PmeFileKeyMetadata forNewFile(byte[] messageId) {
+        Objects.requireNonNull(messageId, "messageId must not be null");
+        if (messageId.length != MESSAGE_ID_BYTES) {
+            throw new IllegalArgumentException("messageId must be 16 bytes, got: " + messageId.length);
+        }
+        return new PmeFileKeyMetadata(V1, DEFAULT_DATA_KEY_ID, messageId.clone());
+    }
+
+    /**
+     * Serializes to compact UTF-8 JSON bytes in the exact v1 field order:
+     * {@code version}, {@code data_key_id}, {@code message_id}.
+     *
+     * @return compact JSON bytes, safe to store in {@code FileCryptoMetaData.key_metadata}
+     */
+    public byte[] toJsonBytes() {
+        String b64 = Base64.getUrlEncoder().withoutPadding().encodeToString(messageId);
+        // Manual construction guarantees exact field order as required by the v1 spec.
+        String json = "{\"version\":" + version
+            + ",\"data_key_id\":\"" + dataKeyId
+            + "\",\"message_id\":\"" + b64 + "\"}";
+        return json.getBytes(StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Parses and validates v1 JSON bytes from a Parquet footer.
+     * Rejects: missing fields, unknown versions, wrong {@code data_key_id}, malformed
+     * {@code message_id}, and unknown JSON fields.
+     *
+     * @param jsonBytes raw bytes from {@code FileCryptoMetaData.key_metadata}
+     * @return validated metadata instance
+     * @throws IOException if the bytes are malformed, version is unsupported, or validation fails
+     */
+    public static PmeFileKeyMetadata parse(byte[] jsonBytes) throws IOException {
+        Objects.requireNonNull(jsonBytes, "jsonBytes must not be null");
+        if (jsonBytes.length == 0) {
+            throw new IOException("PME key metadata is empty");
+        }
+        JsonRepr raw;
+        try {
+            raw = MAPPER.readValue(jsonBytes, JsonRepr.class);
+        } catch (Exception e) {
+            throw new IOException("Failed to parse PME key metadata JSON: " + e.getMessage(), e);
+        }
+        if (raw.version != V1) {
+            throw new IOException("Unsupported PME metadata version: " + raw.version);
+        }
+        if (raw.dataKeyId == null || raw.dataKeyId.isEmpty()) {
+            throw new IOException("PME metadata missing data_key_id");
+        }
+        if (DEFAULT_DATA_KEY_ID.equals(raw.dataKeyId) == false) {
+            throw new IOException("PME v1 data_key_id must be 'default', got: " + raw.dataKeyId);
+        }
+        if (raw.messageId == null || raw.messageId.isEmpty()) {
+            throw new IOException("PME metadata missing message_id");
+        }
+        byte[] messageIdBytes;
+        try {
+            messageIdBytes = Base64.getUrlDecoder().decode(raw.messageId);
+        } catch (IllegalArgumentException e) {
+            throw new IOException("PME metadata message_id is not valid base64url: " + e.getMessage(), e);
+        }
+        if (messageIdBytes.length != MESSAGE_ID_BYTES) {
+            throw new IOException(
+                "PME metadata message_id must decode to 16 bytes, got: " + messageIdBytes.length
+            );
+        }
+        return new PmeFileKeyMetadata(raw.version, raw.dataKeyId, messageIdBytes);
+    }
+
+    public int version() {
+        return version;
+    }
+
+    public String dataKeyId() {
+        return dataKeyId;
+    }
+
+    /** Returns a defensive copy of the 16-byte message_id. */
+    public byte[] messageId() {
+        return messageId.clone();
+    }
+
+    /** Jackson POJO for deserialization only. */
+    private static final class JsonRepr {
+        public final int version;
+        public final String dataKeyId;
+        public final String messageId;
+
+        @JsonCreator
+        JsonRepr(
+            @JsonProperty(value = "version", required = true) int version,
+            @JsonProperty(value = "data_key_id", required = true) String dataKeyId,
+            @JsonProperty(value = "message_id", required = true) String messageId
+        ) {
+            this.version = version;
+            this.dataKeyId = dataKeyId;
+            this.messageId = messageId;
+        }
+    }
+}
+

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/encryption/PmeKeyDerivation.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/encryption/PmeKeyDerivation.java
@@ -1,0 +1,138 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.parquet.encryption;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+import java.util.Objects;
+/**
+ * v1 PME per-file key derivation and AAD prefix construction.
+ *
+ * Key derivation (two-step HMAC-SHA384, mirrors Lucene storage encryption):
+ *   PRK          = HMAC-SHA384(key=dataKey, data=messageId)
+ *   T1           = HMAC-SHA384(key=PRK,     data=context||0x01)
+ *   pmeFooterKey = first 16 bytes of T1 (TODO: Should be full 32 bytes)
+ *   context      = "opensearch/parquet-pme/footer-key/v1"
+ *
+ * AAD prefix (binary, not JSON):
+ *   u16_be(domain.len) || domain || u8(version) || u16_be(dataKeyId.len) || dataKeyId || messageId[16]
+ */
+public final class PmeKeyDerivation {
+    /**
+     * Domain-separation label for deriving PME footer keys.
+     */
+    private static final String FOOTER_KEY_CONTEXT = "opensearch/parquet-pme/footer-key/v1";
+
+    /**
+     * HKDF-style expand input: UTF8(FOOTER_KEY_CONTEXT) || 0x01, where 0x01 is the first block counter.
+     */
+    private static final byte [] FOOTER_KEY_CONTEXT_BYTES = appendHkdfCounter(FOOTER_KEY_CONTEXT.getBytes(StandardCharsets.UTF_8), (byte) 1);
+
+    /**
+     * Domain label embedded in the binary AAD prefix for encrypted Parquet files.
+     */
+    private static final String AAD_DOMAIN = "opensearch/parquet-pme/file/v1";
+
+    /**
+     * Version byte embedded in the binary AAD prefix format.
+     */
+    private static final int AAD_VERSION_BYTE = 1;
+
+    /**
+     * HMAC algorithm used for both extract and expand steps of the v1 key derivation.
+     */
+    private static final String HMAC_ALGORITHM = "HmacSHA384";
+
+    /**
+     * Required size of the unwrapped index data key returned by the key provider.
+     */
+    public static final int DATA_KEY_BYTES = 32;
+
+    /**
+     * Required size of the per-file random message_id stored in PME key metadata.
+     */
+    public static final int MESSAGE_ID_BYTES = 16;
+
+    /**
+     * Size of the derived Parquet footer key passed to parquet-rs.
+     * TODO: For now, only write 16 bytes due to limitations in parquet-rs.
+     */
+    private static final int FOOTER_KEY_BYTES = 16;
+    private PmeKeyDerivation() {}
+    /**
+     * Derives the 32-byte PME footer key from the 32-byte data key and 16-byte message_id.
+     *
+     * @param dataKey   32-byte unwrapped index data key
+     * @param messageId 16-byte per-file random value
+     * @return 32-byte derived key; caller must zero after use
+     */
+    public static byte[] deriveFooterKey(byte[] dataKey, byte[] messageId) {
+        Objects.requireNonNull(dataKey, "dataKey must not be null");
+        Objects.requireNonNull(messageId, "messageId must not be null");
+        if (dataKey.length != DATA_KEY_BYTES) {
+            throw new IllegalArgumentException("dataKey must be 32 bytes, got: " + dataKey.length);
+        }
+        if (messageId.length != MESSAGE_ID_BYTES) {
+            throw new IllegalArgumentException("messageId must be 16 bytes, got: " + messageId.length);
+        }
+        try {
+            byte[] prk = hmac(dataKey, messageId);
+            byte[] t1 = hmac(prk, FOOTER_KEY_CONTEXT_BYTES);
+            Arrays.fill(prk, (byte) 0);
+            return Arrays.copyOf(t1, FOOTER_KEY_BYTES);
+        } catch (NoSuchAlgorithmException | InvalidKeyException e) {
+            throw new IllegalStateException("PME key derivation failed", e);
+        }
+    }
+    /**
+     * Builds the v1 binary AAD prefix for the given message_id.
+     *
+     * @param messageId 16-byte per-file random value
+     * @return binary AAD prefix bytes
+     */
+    public static byte[] buildAadPrefix(byte[] messageId) {
+        Objects.requireNonNull(messageId, "messageId must not be null");
+        if (messageId.length != MESSAGE_ID_BYTES) {
+            throw new IllegalArgumentException("messageId must be 16 bytes, got: " + messageId.length);
+        }
+        byte[] domainBytes = AAD_DOMAIN.getBytes(StandardCharsets.UTF_8);
+        byte[] dataKeyIdBytes = PmeFileKeyMetadata.DEFAULT_DATA_KEY_ID.getBytes(StandardCharsets.UTF_8);
+        int totalLen = 2 + domainBytes.length + 1 + 2 + dataKeyIdBytes.length + MESSAGE_ID_BYTES;
+        byte[] aad = new byte[totalLen];
+        int pos = 0;
+        aad[pos++] = (byte) (domainBytes.length >>> 8);
+        aad[pos++] = (byte) domainBytes.length;
+        System.arraycopy(domainBytes, 0, aad, pos, domainBytes.length);
+        pos += domainBytes.length;
+        aad[pos++] = (byte) AAD_VERSION_BYTE;
+        aad[pos++] = (byte) (dataKeyIdBytes.length >>> 8);
+        aad[pos++] = (byte) dataKeyIdBytes.length;
+        System.arraycopy(dataKeyIdBytes, 0, aad, pos, dataKeyIdBytes.length);
+        pos += dataKeyIdBytes.length;
+        System.arraycopy(messageId, 0, aad, pos, MESSAGE_ID_BYTES);
+        return aad;
+    }
+    private static byte[] hmac(byte[] key, byte[] data) throws NoSuchAlgorithmException, InvalidKeyException {
+        Mac mac = Mac.getInstance(HMAC_ALGORITHM);
+        mac.init(new SecretKeySpec(key, HMAC_ALGORITHM));
+        return mac.doFinal(data);
+    }
+
+    /**
+     * Adds an RFC 5869 HKDF-style block counter to the given input.
+     */
+    private static byte[] appendHkdfCounter(byte[] input, byte counter) {
+        byte[] output = new byte[input.length + 1];
+        System.arraycopy(input, 0, output, 0, input.length);
+        output[input.length] = counter;
+        return output;
+    }
+}

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/encryption/PmeKeyfileManager.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/encryption/PmeKeyfileManager.java
@@ -1,0 +1,177 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.parquet.encryption;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.cluster.metadata.CryptoMetadata;
+import org.opensearch.common.crypto.DataKeyPair;
+import org.opensearch.common.crypto.MasterKeyProvider;
+import org.opensearch.crypto.CryptoHandlerRegistry;
+import org.opensearch.crypto.CryptoRegistryException;
+import org.opensearch.plugins.CryptoKeyProviderPlugin;
+
+import java.io.IOException;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
+import java.util.Arrays;
+import java.util.UUID;
+
+/**
+ * Manages the index-level PME keyfile.
+ *
+ * <p>The keyfile is stored at:
+ * <pre>
+ *   &lt;dataPath&gt;/indices/&lt;indexUUID&gt;/keyfile
+ * </pre>
+ * where {@code <dataPath>} is the node data directory and {@code <indexUUID>} is the index
+ * UUID. This is two levels above the per-shard data path
+ * ({@code .../indices/<indexUUID>/<shardId>/index}), so a single keyfile is shared across
+ * all shards of the same index on this node. The same convention is used by
+ * {@code opensearch-storage-encryption} for Lucene segment encryption.
+ *
+ * <p>The keyfile stores the {@link MasterKeyProvider}-wrapped (encrypted) form of the
+ * 32-byte AES-GCM data key used to derive per-file footer keys.
+ *
+ * <h2>Write path (first shard to open on this node for a given index)</h2>
+ * <ol>
+ *   <li>Call {@link MasterKeyProvider#generateDataPair()} to obtain the raw + encrypted key.</li>
+ *   <li>Write the encrypted key to {@code keyfile.tmp} on the plain filesystem, then
+ *       atomically rename it to {@code keyfile}.  Concurrent shard engines that lose the
+ *       rename race delete the tmp file and read the winner's keyfile instead.</li>
+ *   <li>Return the raw key; caller must zero after use.</li>
+ * </ol>
+ * <p>Note: Lucene storage encryption uses a {@code Lucene Directory} for keyfile writes and
+ * relies on the directory's own concurrency guarantees rather than an explicit atomic rename.
+ * We use tmp+rename here because we write directly to the filesystem without a directory
+ * abstraction.
+ *
+ * <h2>Read path (keyfile already exists)</h2>
+ * <ol>
+ *   <li>Read encrypted bytes from {@code keyfile}.</li>
+ *   <li>Decrypt with {@link MasterKeyProvider#decryptKey(byte[])}.</li>
+ *   <li>Return the raw key; caller must zero after use.</li>
+ * </ol>
+ */
+final class PmeKeyfileManager {
+
+    private static final Logger logger = LogManager.getLogger(PmeKeyfileManager.class);
+
+    static final String KEYFILE_NAME = "keyfile";
+
+    private PmeKeyfileManager() {}
+
+    /**
+     * Returns the raw 32-byte data key for the given index, creating the keyfile if absent.
+     *
+     * <p>This method is safe to call concurrently from multiple shard engines on the same index:
+     * the atomic rename ensures exactly one key is persisted, and the loser re-reads that key.
+     *
+     * @param indexDataPath index-level data directory (parent of all shard directories)
+     * @param cryptoMetadata encryption configuration for the index
+     * @return raw 32-byte data key; <strong>caller must zero after use</strong>
+     * @throws IOException              if keyfile I/O fails
+     * @throws IllegalArgumentException if the decrypted key is not {@value PmeKeyDerivation#DATA_KEY_BYTES} bytes
+     */
+    static byte[] initOrLoad(Path indexDataPath, CryptoMetadata cryptoMetadata) throws IOException {
+        Path keyfilePath = indexDataPath.resolve(KEYFILE_NAME);
+        logger.trace("PME keyfile initOrLoad: path=[{}] exists=[{}]", keyfilePath, Files.exists(keyfilePath));
+        try (MasterKeyProvider provider = createKeyProvider(cryptoMetadata)) {
+            if (Files.exists(keyfilePath)) {
+                return loadKey(keyfilePath, provider);
+            }
+            return createKey(indexDataPath, keyfilePath, provider);
+        }
+    }
+
+    /**
+     * Package-private overload that accepts a pre-built {@link MasterKeyProvider} directly.
+     * Intended for unit tests only — production code must use
+     * {@link #initOrLoad(Path, CryptoMetadata)}.
+     */
+    static byte[] initOrLoad(Path indexDataPath, MasterKeyProvider provider) throws IOException {
+        Path keyfilePath = indexDataPath.resolve(KEYFILE_NAME);
+        logger.trace("PME keyfile initOrLoad (test overload): path=[{}] exists=[{}]", keyfilePath, Files.exists(keyfilePath));
+        if (Files.exists(keyfilePath)) {
+            return loadKey(keyfilePath, provider);
+        }
+        return createKey(indexDataPath, keyfilePath, provider);
+    }
+
+    // ---- private helpers ----
+
+    private static byte[] loadKey(Path keyfilePath, MasterKeyProvider provider) throws IOException {
+        logger.trace("PME keyfile: loading existing keyfile from [{}]", keyfilePath);
+        byte[] encryptedKey = Files.readAllBytes(keyfilePath);
+        byte[] rawKey = provider.decryptKey(encryptedKey);
+        validateKeyLength(rawKey, keyfilePath);
+        logger.trace("PME keyfile: key loaded and decrypted from [{}]", keyfilePath);
+        return rawKey;
+    }
+
+    private static byte[] createKey(Path indexDataPath, Path keyfilePath, MasterKeyProvider provider) throws IOException {
+        logger.trace("PME keyfile: no keyfile found, generating new data key at [{}]", keyfilePath);
+        DataKeyPair pair = provider.generateDataPair();
+        byte[] rawKey = pair.getRawKey();
+        validateKeyLength(rawKey, keyfilePath);
+
+        // Use a unique tmp name per attempt so concurrent callers don't overwrite each other's
+        // tmp file before the atomic rename. Each loser sees FileAlreadyExistsException or
+        // NoSuchFileException (if another thread already won and moved the same tmp file) and
+        // falls through to load the winner's keyfile.
+        // TODO: Research whether we can find a more coordinated way to coordinate this.
+        // TODO: I am wondering whether we should just use a JVM synchronized lock
+        Path tmp = indexDataPath.resolve("keyfile.tmp." + UUID.randomUUID());
+        Files.write(tmp, pair.getEncryptedKey(), StandardOpenOption.CREATE_NEW);
+        try {
+            Files.move(tmp, keyfilePath, StandardCopyOption.ATOMIC_MOVE);
+            logger.trace("PME keyfile: successfully created keyfile at [{}]", keyfilePath);
+        } catch (FileAlreadyExistsException | NoSuchFileException e) {
+            // Another shard won the race — use their keyfile.
+            logger.trace("PME keyfile: lost rename race at [{}], loading winner's keyfile", keyfilePath);
+            Files.deleteIfExists(tmp);
+            Arrays.fill(rawKey, (byte) 0);
+            rawKey = loadKey(keyfilePath, provider);
+        }
+        return rawKey;
+    }
+
+    private static void validateKeyLength(byte[] rawKey, Path keyfilePath) {
+        int expected = PmeKeyDerivation.DATA_KEY_BYTES;
+        int actual = rawKey == null ? 0 : rawKey.length;
+        if (actual != expected) {
+            throw new IllegalArgumentException(
+                "PME keyfile decrypted to " + actual + " bytes, expected " + expected + ": " + keyfilePath
+            );
+        }
+    }
+
+    private static MasterKeyProvider createKeyProvider(CryptoMetadata cm) {
+        CryptoHandlerRegistry registry = CryptoHandlerRegistry.getInstance();
+        if (registry == null) {
+            throw new IllegalStateException("CryptoHandlerRegistry not initialized");
+        }
+        CryptoKeyProviderPlugin plugin = registry.getCryptoKeyProviderPlugin(cm.keyProviderType());
+        if (plugin == null) {
+            throw new CryptoRegistryException(
+                cm.keyProviderName(),
+                cm.keyProviderType(),
+                "Crypto key provider plugin not found for PME write path"
+            );
+        }
+        return plugin.createKeyProvider(cm);
+    }
+}
+
+
+

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/encryption/package-info.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/encryption/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/**
+ * PME (Parquet Modular Encryption) key management for the parquet-data-format plugin.
+ *
+ * <p>Implements v1 key management following the spec in {@code pme-key-management.md}:
+ * <ul>
+ *   <li>Index-level {@code keyfile} stores the provider-wrapped data key (same convention as
+ *       Lucene storage encryption).</li>
+ *   <li>Node-level {@link org.opensearch.parquet.encryption.PmeDataKeyCache} caches decrypted
+ *       data keys, keyed by index UUID.</li>
+ *   <li>Per-file key derivation uses two-step HMAC-SHA384 with context
+ *       {@code "opensearch/parquet-pme/footer-key/v1"}.</li>
+ *   <li>Per-file key metadata ({@code version}, {@code data_key_id}, {@code message_id}) is
+ *       stored as compact UTF-8 JSON in {@code FileCryptoMetaData.key_metadata}.</li>
+ *   <li>Binary AAD prefix encodes domain, version, data key id, and message_id.</li>
+ * </ul>
+ *
+ * <p>Entry point for callers: {@link org.opensearch.parquet.encryption.PmeContext}.
+ */
+package org.opensearch.parquet.encryption;
+

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/engine/ParquetIndexingEngine.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/engine/ParquetIndexingEngine.java
@@ -28,6 +28,8 @@ import org.opensearch.index.store.PrecomputedChecksumStrategy;
 import org.opensearch.parquet.ParquetSettings;
 import org.opensearch.parquet.bridge.NativeSettings;
 import org.opensearch.parquet.bridge.RustBridge;
+import org.opensearch.parquet.encryption.PmeContext;
+import org.opensearch.parquet.encryption.PmeFileEncryptionInputs;
 import org.opensearch.parquet.memory.ArrowBufferPool;
 import org.opensearch.parquet.merge.NativeParquetMergeStrategy;
 import org.opensearch.parquet.merge.ParquetMergeExecutor;
@@ -60,11 +62,8 @@ import static org.opensearch.parquet.ParquetDataFormatPlugin.PARQUET_DATA_FORMAT
  *   <li>A shared {@link ArrowBufferPool} for Arrow memory allocation across all writers.</li>
  *   <li>Writer creation per writer generation, each producing a separate Parquet file.</li>
  *   <li>Native memory usage reporting (Arrow allocations + Rust-side allocations).</li>
+ *   <li>Optional PME encryption via {@link PmeContext} (one per engine, null if unencrypted).</li>
  * </ul>
- *
- * <p>Node-level {@link Settings} are passed through to each {@link ParquetWriter} at creation
- * time, where writer-specific settings (e.g., {@code parquet.max_rows_per_vsr}) are
- * extracted and applied.
  */
 public class ParquetIndexingEngine implements IndexingExecutionEngine<ParquetDataFormat, ParquetDocumentInput> {
 
@@ -88,6 +87,8 @@ public class ParquetIndexingEngine implements IndexingExecutionEngine<ParquetDat
     private final FormatChecksumStrategy checksumStrategy;
     private final Merger parquetMerger;
     private final ParquetShardStatsTracker statsTracker = new ParquetShardStatsTracker();
+    /** Non-null when the index is configured for PME encryption; null otherwise. */
+    private final PmeContext pmeContext;
 
     /**
      * Creates a new ParquetIndexingEngine.
@@ -156,6 +157,7 @@ public class ParquetIndexingEngine implements IndexingExecutionEngine<ParquetDat
         this.nodeSettings = settings;
         this.threadPool = threadPool;
         this.checksumStrategy = checksumStrategy;
+        this.pmeContext = initializePmeContext(indexSettings, shardPath);
         try {
             Files.createDirectory(shardPath.resolve(dataFormat.name()));
         } catch (FileAlreadyExistsException ex) {
@@ -245,6 +247,14 @@ public class ParquetIndexingEngine implements IndexingExecutionEngine<ParquetDat
         long mappingVersion = mappingVersionSupplier.get();
         Schema schema = getOrBuildSchema();
         Path filePath = buildParquetFilePath(shardPath, config.writerGeneration(), null);
+        PmeFileEncryptionInputs encryptionInputs = null;
+        if (pmeContext != null) {
+            try {
+                encryptionInputs = pmeContext.createFileEncryptionInputs();
+            } catch (IOException e) {
+                throw new RuntimeException("Failed to create PME encryption inputs for " + filePath, e);
+            }
+        }
         return new ParquetWriter(
             filePath.toString(),
             config.writerGeneration(),
@@ -256,7 +266,8 @@ public class ParquetIndexingEngine implements IndexingExecutionEngine<ParquetDat
             indexSettings,
             threadPool,
             checksumStrategy,
-            statsTracker
+            statsTracker,
+            encryptionInputs
         );
     }
 
@@ -349,6 +360,33 @@ public class ParquetIndexingEngine implements IndexingExecutionEngine<ParquetDat
             );
         }
         bufferPool.close();
+        if (pmeContext != null) {
+            pmeContext.evict();
+        }
+    }
+
+    /**
+     * Initializes the per-engine {@link PmeContext} if the index is configured for encryption.
+     * Returns {@code null} for unencrypted indices.
+     *
+     * <p>The index-level keyfile (at {@code <index-data-dir>/keyfile}) is created atomically
+     * on first call; concurrent shard engines race on {@code CREATE_NEW}, the loser reads the
+     * winner's file.
+     */
+    private static PmeContext initializePmeContext(IndexSettings indexSettings, ShardPath shardPath) {
+        if (indexSettings == null) {
+            return null;
+        }
+        // Index-level data directory: parent of all shard directories.
+        // shardPath.getDataPath() = .../indices/{uuid}/{shardId}/index
+        //   -> .getParent() = .../indices/{uuid}/{shardId}
+        //   -> .getParent().getParent() = .../indices/{uuid}  (index-level dir)
+        Path indexDataPath = shardPath.getDataPath().getParent().getParent();
+        try {
+            return PmeContext.create(indexSettings, indexDataPath, shardPath.getShardId().id());
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to initialize PME context for index " + indexSettings.getIndex().getUUID(), e);
+        }
     }
 
     /**

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/vsr/VSRManager.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/vsr/VSRManager.java
@@ -24,6 +24,7 @@ import org.opensearch.parquet.ParquetDataFormatPlugin;
 import org.opensearch.parquet.bridge.NativeParquetWriter;
 import org.opensearch.parquet.bridge.ParquetFileMetadata;
 import org.opensearch.parquet.bridge.ParquetSortConfig;
+import org.opensearch.parquet.encryption.PmeFileEncryptionInputs;
 import org.opensearch.parquet.fields.ArrowFieldRegistry;
 import org.opensearch.parquet.fields.ParquetField;
 import org.opensearch.parquet.memory.ArrowBufferPool;
@@ -76,6 +77,7 @@ public class VSRManager implements AutoCloseable {
     private final int ROTATION_TIMEOUT = 120;
     private LongAdder rowCount = new LongAdder();
     private long acceptedRows = 0L;
+    private final PmeFileEncryptionInputs encryptionInputs;
 
     /**
      * Creates a new VSRManager with asynchronous background writes (production default).
@@ -90,7 +92,7 @@ public class VSRManager implements AutoCloseable {
         long writerGeneration,
         ParquetShardStatsTracker stats
     ) {
-        this(fileName, indexSettings, schema, bufferPool, maxRowsPerVSR, threadPool, true, writerGeneration, stats);
+        this(fileName, indexSettings, schema, bufferPool, maxRowsPerVSR, threadPool, true, writerGeneration, stats, null);
     }
 
     /**
@@ -114,7 +116,8 @@ public class VSRManager implements AutoCloseable {
             threadPool,
             true,
             writerGeneration,
-            new ParquetShardStatsTracker()
+            new ParquetShardStatsTracker(),
+            null
         );
     }
 
@@ -128,20 +131,40 @@ public class VSRManager implements AutoCloseable {
         ArrowBufferPool bufferPool,
         int maxRowsPerVSR,
         ThreadPool threadPool,
+        long writerGeneration,
+        PmeFileEncryptionInputs encryptionInputs
+    ) {
+        this(fileName, indexSettings, schema, bufferPool, maxRowsPerVSR, threadPool, true, writerGeneration, null, encryptionInputs);
+    }
+
+    /**
+     * Creates a new VSRManager with stats and optional encryption.
+     */
+    public VSRManager(
+        String fileName,
+        IndexSettings indexSettings,
+        Schema schema,
+        ArrowBufferPool bufferPool,
+        int maxRowsPerVSR,
+        ThreadPool threadPool,
+        long writerGeneration,
+        ParquetShardStatsTracker stats,
+        PmeFileEncryptionInputs encryptionInputs
+    ) {
+        this(fileName, indexSettings, schema, bufferPool, maxRowsPerVSR, threadPool, true, writerGeneration, stats, encryptionInputs);
+    }
+
+    public VSRManager(
+        String fileName,
+        IndexSettings indexSettings,
+        Schema schema,
+        ArrowBufferPool bufferPool,
+        int maxRowsPerVSR,
+        ThreadPool threadPool,
         boolean runAsync,
         long writerGeneration
     ) {
-        this(
-            fileName,
-            indexSettings,
-            schema,
-            bufferPool,
-            maxRowsPerVSR,
-            threadPool,
-            runAsync,
-            writerGeneration,
-            new ParquetShardStatsTracker()
-        );
+        this(fileName, indexSettings, schema, bufferPool, maxRowsPerVSR, threadPool, runAsync, writerGeneration, new ParquetShardStatsTracker(), null);
     }
 
     /**
@@ -157,6 +180,7 @@ public class VSRManager implements AutoCloseable {
      *                 if false, they run on the calling thread (for benchmarks/tests)
      * @param writerGeneration the writer generation to store in file metadata
      * @param stats shard-level stats tracker
+     * @param encryptionInputs per-file PME inputs; {@code null} for unencrypted
      */
     public VSRManager(
         String fileName,
@@ -167,15 +191,17 @@ public class VSRManager implements AutoCloseable {
         ThreadPool threadPool,
         boolean runAsync,
         long writerGeneration,
-        ParquetShardStatsTracker stats
+        ParquetShardStatsTracker stats,
+        PmeFileEncryptionInputs encryptionInputs
     ) {
         this.fileName = fileName;
         this.indexSettings = indexSettings;
         this.writerGeneration = writerGeneration;
-        this.stats = stats;
+        this.stats = stats != null ? stats : new ParquetShardStatsTracker();
         this.vsrPool = new VSRPool("pool-" + fileName, schema, bufferPool, maxRowsPerVSR);
         this.threadPool = threadPool;
         this.vsrRotationThread = runAsync ? ParquetDataFormatPlugin.PARQUET_THREAD_POOL_NAME : ThreadPool.Names.SAME;
+        this.encryptionInputs = encryptionInputs;
         this.managedVSR.set(vsrPool.getActiveVSR());
         this.writer = new NativeParquetWriter(fileName, stats);
     }
@@ -360,11 +386,12 @@ public class VSRManager implements AutoCloseable {
             if (writer != null) {
                 writer.flush();
             }
-            vsrPool.close();
-            managedVSR.set(null);
         } catch (Exception e) {
             logger.error("Error during close for {}: {}", fileName, e.getMessage());
             throw new RuntimeException("Failed to close VSRManager: " + e.getMessage(), e);
+        } finally {
+            vsrPool.close();
+            managedVSR.set(null);
         }
     }
 
@@ -376,7 +403,7 @@ public class VSRManager implements AutoCloseable {
             String indexName = indexSettings.getIndex().getName();
             ParquetSortConfig sortConfig = new ParquetSortConfig(indexSettings);
             try (ArrowSchema schema = vsr.exportSchema()) {
-                writer.initialize(indexName, schema.memoryAddress(), sortConfig, writerGeneration);
+                writer.initialize(indexName, schema.memoryAddress(), sortConfig, writerGeneration, encryptionInputs);
             }
         }
     }

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/writer/ParquetWriter.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/writer/ParquetWriter.java
@@ -24,6 +24,7 @@ import org.opensearch.parquet.ParquetDataFormatPlugin;
 import org.opensearch.parquet.ParquetSettings;
 import org.opensearch.parquet.bridge.ParquetFileMetadata;
 import org.opensearch.parquet.engine.ParquetDataFormat;
+import org.opensearch.parquet.encryption.PmeFileEncryptionInputs;
 import org.opensearch.parquet.memory.ArrowBufferPool;
 import org.opensearch.parquet.stats.ParquetShardStatsTracker;
 import org.opensearch.parquet.vsr.VSRManager;
@@ -126,18 +127,83 @@ public class ParquetWriter implements Writer<ParquetDocumentInput> {
         ThreadPool threadPool,
         FormatChecksumStrategy checksumStrategy
     ) {
-        this(
+        this(file, writerGeneration, mappingVersion, dataFormat, schema, schemaSupplier, bufferPool, indexSettings, threadPool, checksumStrategy, (ParquetShardStatsTracker) null, null);
+    }
+
+    /**
+     * Creates a new ParquetWriter with optional PME encryption.
+     *
+     * <p>If {@code encryptionInputs} is non-null, the footer key is zeroed immediately after
+     * the native writer is initialized inside {@link VSRManager}.
+     *
+     * @param encryptionInputs per-file PME inputs; {@code null} writes an unencrypted file
+     */
+    public ParquetWriter(
+        String file,
+        long writerGeneration,
+        long mappingVersion,
+        ParquetDataFormat dataFormat,
+        Schema schema,
+        Supplier<Schema> schemaSupplier,
+        ArrowBufferPool bufferPool,
+        IndexSettings indexSettings,
+        ThreadPool threadPool,
+        FormatChecksumStrategy checksumStrategy,
+        PmeFileEncryptionInputs encryptionInputs
+    ) {
+        this.file = file;
+        this.writerGeneration = writerGeneration;
+        this.mappingVersion = mappingVersion;
+        this.dataFormat = dataFormat;
+        this.checksumStrategy = checksumStrategy;
+        this.schemaSupplier = schemaSupplier;
+        this.stats = null;
+        this.vsrManager = new VSRManager(
             file,
-            writerGeneration,
-            mappingVersion,
-            dataFormat,
-            schema,
-            schemaSupplier,
-            bufferPool,
             indexSettings,
+            schema,
+            bufferPool,
+            ParquetSettings.MAX_ROWS_PER_VSR.get(indexSettings.getSettings()),
             threadPool,
-            checksumStrategy,
-            new ParquetShardStatsTracker()
+            writerGeneration,
+            encryptionInputs
+        );
+    }
+
+    /**
+     * Creates a new ParquetWriter with both stats tracking and optional PME encryption.
+     */
+    public ParquetWriter(
+        String file,
+        long writerGeneration,
+        long mappingVersion,
+        ParquetDataFormat dataFormat,
+        Schema schema,
+        Supplier<Schema> schemaSupplier,
+        ArrowBufferPool bufferPool,
+        IndexSettings indexSettings,
+        ThreadPool threadPool,
+        FormatChecksumStrategy checksumStrategy,
+        ParquetShardStatsTracker stats,
+        PmeFileEncryptionInputs encryptionInputs
+    ) {
+        this.file = file;
+        this.writerGeneration = writerGeneration;
+        this.mappingVersion = mappingVersion;
+        this.dataFormat = dataFormat;
+        this.checksumStrategy = checksumStrategy;
+        this.schemaSupplier = schemaSupplier;
+        this.stats = stats;
+        this.vsrManager = new VSRManager(
+            file,
+            indexSettings,
+            schema,
+            bufferPool,
+            ParquetSettings.MAX_ROWS_PER_VSR.get(indexSettings.getSettings()),
+            threadPool,
+            writerGeneration,
+            stats,
+            encryptionInputs
         );
     }
 
@@ -156,9 +222,9 @@ public class ParquetWriter implements Writer<ParquetDocumentInput> {
                 return new WriteResult.Failure(e, -1, -1, -1);
             }
             acceptedRows++;
-            stats.addDocsIndexed(1);
+            if (stats != null) stats.addDocsIndexed(1);
             return new WriteResult.Success(1L, 1L, 1L);
-        }, stats::addIndexTimeMillis);
+        }, stats != null ? stats::addIndexTimeMillis : millis -> {});
     }
 
     @Override
@@ -201,14 +267,16 @@ public class ParquetWriter implements Writer<ParquetDocumentInput> {
             checksumStrategy.registerChecksum(new FileMetadata(dataFormat.name(), fileName), metadata.crc32(), writerGeneration);
         }
 
-        MonoFileWriterSet monoFileSet = MonoFileWriterSet.of(
+        MonoFileWriterSet fileSet = MonoFileWriterSet.of(
             filePath.getParent().toAbsolutePath(),
             writerGeneration,
             fileName,
             metadata.numRows(),
             ParquetDataFormatPlugin.PARQUET_FORMAT_VERSION
         );
-        return FileInfos.builder().putWriterFileSet(dataFormat, monoFileSet).rowIdMapping(vsrManager.getRowIdMapping()).build();
+
+
+        return FileInfos.builder().putWriterFileSet(dataFormat, fileSet).rowIdMapping(vsrManager.getRowIdMapping()).build();
     }
 
     @Override
@@ -255,6 +323,7 @@ public class ParquetWriter implements Writer<ParquetDocumentInput> {
         }
     }
 
+
     @Override
     public void close() throws IOException {
         try {
@@ -263,5 +332,4 @@ public class ParquetWriter implements Writer<ParquetDocumentInput> {
             state = WriterState.CLOSED;
         }
     }
-
 }

--- a/sandbox/plugins/parquet-data-format/src/main/rust/Cargo.toml
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/Cargo.toml
@@ -14,8 +14,12 @@ crate-type = ["rlib"]
 
 [dependencies]
 arrow = { workspace = true }
-parquet = { workspace = true }
+parquet = { workspace = true, features = ["encryption"] }
 arrow-ipc = { workspace = true }
+arrow-array = { workspace = true }
+arrow-schema = { workspace = true }
+arrow-buffer = { workspace = true }
+log = { workspace = true }
 lazy_static = { workspace = true }
 dashmap = { workspace = true }
 tempfile = { workspace = true }

--- a/sandbox/plugins/parquet-data-format/src/main/rust/src/ffm.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/src/ffm.rs
@@ -11,15 +11,17 @@
 //! Return convention: `>= 0` success, `< 0` error pointer (negate to get ptr,
 //! call `native_error_message`/`native_error_free`).
 
+use std::fs::File;
 use std::slice;
 use std::str;
 
-use native_bridge_common::{ffm_safe, log_debug};
+use native_bridge_common::ffm_safe;
+use parquet::file::reader::{FileReader, SerializedFileReader};
 
 use crate::native_settings::NativeSettings;
 use crate::field_config::FieldConfig;
 use crate::merge;
-use crate::writer::{NativeParquetWriter, SETTINGS_STORE};
+use crate::writer::{NativeParquetWriter, ParquetEncryptionOptions, SETTINGS_STORE};
 
 unsafe fn str_from_raw<'a>(ptr: *const u8, len: i64) -> Result<&'a str, String> {
     if ptr.is_null() {
@@ -66,10 +68,43 @@ unsafe fn bool_array_from_raw(
     (0..n).map(|i| *vals.add(i) != 0).collect()
 }
 
+unsafe fn optional_bytes_from_raw(ptr: *const u8, len: i64) -> Result<Option<Vec<u8>>, String> {
+    if ptr.is_null() {
+        return Ok(None);
+    }
+    if len < 0 {
+        return Err(format!("negative byte length: {}", len));
+    }
+    if len == 0 {
+        return Ok(Some(Vec::new()));
+    }
+    let bytes = slice::from_raw_parts(ptr, len as usize);
+    Ok(Some(bytes.to_vec()))
+}
+
+unsafe fn required_bytes_from_raw(ptr: *const u8, len: i64, field: &str) -> Result<Vec<u8>, String> {
+    if ptr.is_null() {
+        return Err(format!("{}: null pointer", field));
+    }
+    if len < 0 {
+        return Err(format!("{}: negative length {}", field, len));
+    }
+    if len == 0 {
+        return Ok(Vec::new());
+    }
+    let bytes = slice::from_raw_parts(ptr, len as usize);
+    Ok(bytes.to_vec())
+}
+
 // ---------------------------------------------------------------------------
 // Writer lifecycle
 // ---------------------------------------------------------------------------
 
+/// Creates a native Parquet writer.
+///
+/// Encryption is activated when `footer_key_ptr` is non-null. All three encryption fields
+/// (`footer_key`, `key_metadata_json`, `aad_prefix`) must be provided together.
+/// Pass null pointers and zero lengths for an unencrypted file.
 #[ffm_safe]
 #[no_mangle]
 pub unsafe extern "C" fn parquet_create_writer(
@@ -86,6 +121,12 @@ pub unsafe extern "C" fn parquet_create_writer(
     nulls_first_vals: *const i64,
     nulls_first_count: i64,
     writer_generation: i64,
+    footer_key_ptr: *const u8,
+    footer_key_len: i64,
+    key_metadata_json_ptr: *const u8,
+    key_metadata_json_len: i64,
+    aad_prefix_ptr: *const u8,
+    aad_prefix_len: i64,
 ) -> i64 {
     let filename = str_from_raw(file_ptr, file_len)
         .map_err(|e| format!("parquet_create_writer file: {}", e))?.to_string();
@@ -96,7 +137,21 @@ pub unsafe extern "C" fn parquet_create_writer(
     let reverse_sorts = bool_array_from_raw(reverse_vals, reverse_count);
     let nulls_first = bool_array_from_raw(nulls_first_vals, nulls_first_count);
 
-    NativeParquetWriter::create_writer(filename, index_name, schema_address, sort_columns, reverse_sorts, nulls_first, writer_generation)
+    let encryption_options = if footer_key_ptr.is_null() {
+        None
+    } else {
+        let footer_key = required_bytes_from_raw(footer_key_ptr, footer_key_len, "footer_key")
+            .map_err(|e| format!("parquet_create_writer: {}", e))?;
+        let key_metadata_json = required_bytes_from_raw(
+            key_metadata_json_ptr, key_metadata_json_len, "key_metadata_json")
+            .map_err(|e| format!("parquet_create_writer: {}", e))?;
+        let aad_prefix = optional_bytes_from_raw(aad_prefix_ptr, aad_prefix_len)
+            .map_err(|e| format!("parquet_create_writer: aad_prefix: {}", e))?
+            .unwrap_or_default();
+        Some(ParquetEncryptionOptions { footer_key, key_metadata_json, aad_prefix })
+    };
+
+    NativeParquetWriter::create_writer(filename, index_name, schema_address, sort_columns, reverse_sorts, nulls_first, writer_generation, encryption_options)
         .map(|_| 0)
         .map_err(|e| e.to_string())
 }
@@ -216,9 +271,6 @@ pub unsafe extern "C" fn parquet_get_column_metadata(
     out_buf_len: i64,
     out_len: *mut i64,
 ) -> i64 {
-    use parquet::file::reader::{FileReader, SerializedFileReader};
-    use std::fs::File;
-
     let filename = str_from_raw(file_ptr, file_len).map_err(|e| format!("parquet_get_column_metadata: {}", e))?.to_string();
     let file = File::open(&filename).map_err(|e| format!("Failed to open file: {}", e))?;
     let reader = SerializedFileReader::new(file).map_err(|e| format!("Failed to read parquet: {}", e))?;
@@ -257,6 +309,86 @@ pub unsafe extern "C" fn parquet_get_column_metadata(
     std::ptr::copy_nonoverlapping(bytes.as_ptr(), out_buf, n);
     if !out_len.is_null() { *out_len = n as i64; }
     Ok(0)
+}
+
+/// Reads encrypted Parquet file metadata.
+/// footer_key and aad_prefix are required when non-null.
+#[ffm_safe]
+#[no_mangle]
+pub unsafe extern "C" fn parquet_get_file_metadata_decrypted(
+    file_ptr: *const u8,
+    file_len: i64,
+    footer_key_ptr: *const u8,
+    footer_key_len: i64,
+    aad_prefix_ptr: *const u8,
+    aad_prefix_len: i64,
+    version_out: *mut i32,
+    num_rows_out: *mut i64,
+    created_by_buf: *mut u8,
+    created_by_buf_len: i64,
+    created_by_len_out: *mut i64,
+) -> i64 {
+    let filename = str_from_raw(file_ptr, file_len)
+        .map_err(|e| format!("parquet_get_file_metadata_decrypted: {}", e))?.to_string();
+    let footer_key = required_bytes_from_raw(footer_key_ptr, footer_key_len, "footer_key")
+        .map_err(|e| format!("parquet_get_file_metadata_decrypted: {}", e))?;
+    if footer_key.is_empty() {
+        return Err("parquet_get_file_metadata_decrypted: footer_key must not be empty".to_string());
+    }
+    let aad_prefix = optional_bytes_from_raw(aad_prefix_ptr, aad_prefix_len)
+        .map_err(|e| format!("parquet_get_file_metadata_decrypted: aad_prefix: {}", e))?;
+
+    let fm = NativeParquetWriter::get_file_metadata_decrypted(filename, footer_key, aad_prefix)
+        .map_err(|e| e.to_string())?;
+    if !version_out.is_null() { *version_out = fm.version(); }
+    if !num_rows_out.is_null() { *num_rows_out = fm.num_rows(); }
+    if let Some(cb) = fm.created_by() {
+        if !created_by_buf.is_null() && created_by_buf_len > 0 {
+            let bytes = cb.as_bytes();
+            let n = bytes.len().min(created_by_buf_len as usize);
+            std::ptr::copy_nonoverlapping(bytes.as_ptr(), created_by_buf, n);
+            if !created_by_len_out.is_null() { *created_by_len_out = n as i64; }
+        }
+    } else if !created_by_len_out.is_null() {
+        *created_by_len_out = -1;
+    }
+    Ok(0)
+}
+
+
+/// Reads the plaintext `key_metadata` bytes from `FileCryptoMetaData` without decrypting.
+///
+/// Returns 0 and writes bytes to `out_buf` if key_metadata is present.
+/// Returns 1 if the file is not encrypted or has no key_metadata (out_buf untouched).
+/// Returns negative error code on failure.
+#[ffm_safe]
+#[no_mangle]
+pub unsafe extern "C" fn parquet_read_key_metadata(
+    file_ptr: *const u8,
+    file_len: i64,
+    out_buf: *mut u8,
+    out_buf_len: i64,
+    out_len_out: *mut i64,
+) -> i64 {
+    let filename = str_from_raw(file_ptr, file_len)
+        .map_err(|e| format!("parquet_read_key_metadata: {}", e))?.to_string();
+
+    match NativeParquetWriter::read_key_metadata(filename).map_err(|e| e.to_string())? {
+        None => Ok(1), // Not encrypted or no key_metadata
+        Some(key_metadata) => {
+            let n = key_metadata.len();
+            if !out_buf.is_null() && out_buf_len > 0 {
+                let copy_len = n.min(out_buf_len as usize);
+                std::ptr::copy_nonoverlapping(key_metadata.as_ptr(), out_buf, copy_len);
+                if !out_len_out.is_null() {
+                    *out_len_out = copy_len as i64;
+                }
+            } else if !out_len_out.is_null() {
+                *out_len_out = n as i64;
+            }
+            Ok(0)
+        }
+    }
 }
 
 #[no_mangle]

--- a/sandbox/plugins/parquet-data-format/src/main/rust/src/test_utils.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/src/test_utils.rs
@@ -72,7 +72,7 @@ pub fn get_temp_file_path(name: &str) -> (tempfile::TempDir, String) {
 
 pub fn create_writer_and_assert_success(filename: &str) -> (Arc<Schema>, i64) {
     let (schema, schema_ptr) = create_test_ffi_schema();
-    let result = NativeParquetWriter::create_writer(filename.to_string(), "test-index".to_string(), schema_ptr, vec![], vec![], vec![], 0);
+    let result = NativeParquetWriter::create_writer(filename.to_string(), "test-index".to_string(), schema_ptr, vec![], vec![], vec![], 0, None);
     assert!(result.is_ok());
     (schema, schema_ptr)
 }
@@ -80,7 +80,7 @@ pub fn create_writer_and_assert_success(filename: &str) -> (Arc<Schema>, i64) {
 pub fn create_sorted_writer_and_assert_success(filename: &str, sort_column: &str, reverse: bool) -> (Arc<Schema>, i64) {
     let (schema, schema_ptr) = create_test_ffi_schema();
     let result = NativeParquetWriter::create_writer(
-        filename.to_string(), "test-index".to_string(), schema_ptr, vec![sort_column.to_string()], vec![reverse], vec![false], 0
+        filename.to_string(), "test-index".to_string(), schema_ptr, vec![sort_column.to_string()], vec![reverse], vec![false], 0, None
     );
     assert!(result.is_ok());
     (schema, schema_ptr)

--- a/sandbox/plugins/parquet-data-format/src/main/rust/src/tests/mod.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/src/tests/mod.rs
@@ -13,8 +13,7 @@ use std::thread;
 use tempfile::tempdir;
 
 use crate::test_utils::*;
-use crate::writer::NativeParquetWriter;
-use crate::writer::SETTINGS_STORE;
+use crate::writer::{NativeParquetWriter, ParquetEncryptionOptions, SETTINGS_STORE};
 use crate::native_settings::NativeSettings;
 
 use std::fs::File;
@@ -32,7 +31,7 @@ fn test_create_writer_success() {
 fn test_create_writer_invalid_path() {
     let invalid_path = "/invalid/path/that/does/not/exist/test.parquet";
     let (_schema, schema_ptr) = create_test_ffi_schema();
-    let result = NativeParquetWriter::create_writer(invalid_path.to_string(), "test-index".to_string(), schema_ptr, vec![], vec![], vec![], 0);
+    let result = NativeParquetWriter::create_writer(invalid_path.to_string(), "test-index".to_string(), schema_ptr, vec![], vec![], vec![], 0, None);
     assert!(result.is_err());
     cleanup_ffi_schema(schema_ptr);
 }
@@ -40,7 +39,7 @@ fn test_create_writer_invalid_path() {
 #[test]
 fn test_create_writer_invalid_schema_pointer() {
     let (_temp_dir, filename) = get_temp_file_path("invalid_schema.parquet");
-    let result = NativeParquetWriter::create_writer(filename, "test-index".to_string(), 0, vec![], vec![], vec![], 0);
+    let result = NativeParquetWriter::create_writer(filename, "test-index".to_string(), 0, vec![], vec![], vec![], 0, None);
     assert!(result.is_err());
     assert!(result.unwrap_err().to_string().contains("Invalid schema address"));
 }
@@ -50,12 +49,75 @@ fn test_create_writer_multiple_times_same_file() {
     let (_temp_dir, filename) = get_temp_file_path("duplicate.parquet");
     let (_schema, schema_ptr) = create_writer_and_assert_success(&filename);
     let (_, schema_ptr2) = create_test_ffi_schema();
-    let result2 = NativeParquetWriter::create_writer(filename.clone(), "test-index".to_string(), schema_ptr2, vec![], vec![], vec![], 0);
+    let result2 = NativeParquetWriter::create_writer(filename.clone(), "test-index".to_string(), schema_ptr2, vec![], vec![], vec![], 0, None);
     assert!(result2.is_err());
     assert!(result2.unwrap_err().to_string().contains("Writer already exists"));
     cleanup_ffi_schema(schema_ptr2);
     close_writer_and_cleanup_schema(&filename, schema_ptr);
 }
+
+#[test]
+fn test_create_writer_with_pme_encryption() {
+    let (_temp_dir, filename) = get_temp_file_path("pme.parquet");
+    let (_schema, schema_ptr) = create_test_ffi_schema();
+    let encryption_options = Some(ParquetEncryptionOptions {
+        footer_key: vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
+        key_metadata_json: b"{\"key\":\"test\"}".to_vec(),
+        aad_prefix: vec![],
+    });
+
+    let result = NativeParquetWriter::create_writer(filename.clone(), "test-index".to_string(), schema_ptr, vec![], vec![], vec![], 0, encryption_options);
+    assert!(result.is_ok());
+
+    let finalize_result = NativeParquetWriter::finalize_writer(filename.clone()).unwrap().unwrap();
+    assert!(finalize_result.crc32 != 0);
+    cleanup_ffi_schema(schema_ptr);
+}
+
+#[test]
+fn test_get_file_metadata_decrypted_with_footer_key() {
+    let (_temp_dir, filename) = get_temp_file_path("pme_decrypted_read.parquet");
+    let (_schema, schema_ptr) = create_test_ffi_schema();
+    let footer_key = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
+    let encryption_options = Some(ParquetEncryptionOptions {
+        footer_key: footer_key.clone(),
+        key_metadata_json: b"{\"key\":\"test\"}".to_vec(),
+        aad_prefix: vec![],
+    });
+
+    NativeParquetWriter::create_writer(filename.clone(), "test-index".to_string(), schema_ptr, vec![], vec![], vec![], 0, encryption_options).unwrap();
+    let (array_ptr, data_schema_ptr) = create_test_ffi_data().unwrap();
+    NativeParquetWriter::write_data(filename.clone(), array_ptr, data_schema_ptr).unwrap();
+    cleanup_ffi_data(array_ptr, data_schema_ptr);
+    NativeParquetWriter::finalize_writer(filename.clone()).unwrap();
+
+    let decrypted_metadata = NativeParquetWriter::get_file_metadata_decrypted(filename.clone(), footer_key, None).unwrap();
+    assert_eq!(decrypted_metadata.num_rows(), 3);
+    cleanup_ffi_schema(schema_ptr);
+}
+
+#[test]
+fn test_get_file_metadata_decrypted_with_wrong_footer_key_fails() {
+    let (_temp_dir, filename) = get_temp_file_path("pme_wrong_key_read.parquet");
+    let (_schema, schema_ptr) = create_test_ffi_schema();
+    let encryption_options = Some(ParquetEncryptionOptions {
+        footer_key: vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
+        key_metadata_json: b"{\"key\":\"test\"}".to_vec(),
+        aad_prefix: vec![],
+    });
+
+    NativeParquetWriter::create_writer(filename.clone(), "test-index".to_string(), schema_ptr, vec![], vec![], vec![], 0, encryption_options).unwrap();
+    NativeParquetWriter::finalize_writer(filename.clone()).unwrap();
+
+    let result = NativeParquetWriter::get_file_metadata_decrypted(
+        filename.clone(),
+        vec![9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9],
+        None,
+    );
+    assert!(result.is_err());
+    cleanup_ffi_schema(schema_ptr);
+}
+
 
 #[test]
 fn test_write_data_success() {
@@ -138,6 +200,7 @@ fn test_finalize_writer_with_data_returns_correct_metadata() {
     let metadata = result.unwrap().unwrap();
     assert_eq!(metadata.metadata.file_metadata().num_rows(), 6);
     assert!(metadata.metadata.file_metadata().version() > 0);
+    assert_eq!(metadata.metadata.file_metadata().schema_descr().num_columns(), 2);
     assert_ne!(metadata.crc32, 0, "CRC32 should be non-zero for a file with data");
     cleanup_ffi_schema(schema_ptr);
 }
@@ -157,7 +220,7 @@ fn test_close_multiple_times_same_file() {
     cleanup_ffi_data(array_ptr, data_schema_ptr);
     let result1 = NativeParquetWriter::finalize_writer(filename.clone());
     assert!(result1.is_ok());
-    let result2 = NativeParquetWriter::finalize_writer(filename);
+    let result2 = NativeParquetWriter::finalize_writer(filename.clone());
     assert!(result2.is_err());
     assert!(result2.unwrap_err().to_string().contains("Writer not found"));
     cleanup_ffi_schema(schema_ptr);

--- a/sandbox/plugins/parquet-data-format/src/main/rust/src/writer.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/src/writer.rs
@@ -15,8 +15,12 @@ use arrow_ipc::reader::FileReader as IpcFileReader;
 use dashmap::DashMap;
 use lazy_static::lazy_static;
 use parquet::arrow::ArrowWriter;
+use parquet::arrow::arrow_reader::{ArrowReaderMetadata, ArrowReaderOptions};
+use parquet::encryption::decrypt::FileDecryptionProperties;
+use parquet::encryption::encrypt::FileEncryptionProperties;
 use parquet::file::reader::{FileReader, SerializedFileReader};
 use std::fs::File;
+use std::io::{Read, Seek, SeekFrom};
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 
@@ -364,6 +368,18 @@ lazy_static! {
 
 pub struct NativeParquetWriter;
 
+/// Per-file PME encryption inputs passed from the Java bridge.
+///
+/// All fields are already fully derived by the Java side:
+/// - `footer_key`: 32-byte derived AES-256 key (HMAC-SHA384 two-step derivation)
+/// - `key_metadata_json`: v1 JSON bytes for `FileCryptoMetaData.key_metadata`
+/// - `aad_prefix`: binary AAD prefix (domain + version + data_key_id + message_id)
+pub struct ParquetEncryptionOptions {
+    pub footer_key: Vec<u8>,
+    pub key_metadata_json: Vec<u8>,
+    pub aad_prefix: Vec<u8>,
+}
+
 impl NativeParquetWriter {
     /// Returns true if a writer is currently open for the given filename.
     pub fn has_writer(filename: &str) -> bool {
@@ -388,6 +404,7 @@ impl NativeParquetWriter {
         reverse_sorts: Vec<bool>,
         nulls_first: Vec<bool>,
         writer_generation: i64,
+        encryption_options: Option<ParquetEncryptionOptions>,
     ) -> Result<(), Box<dyn std::error::Error>> {
         log_debug!(
             "create_writer called for file: {}, index: {}, schema_address: {}, sort_columns: {:?}, reverse_sorts: {:?}, nulls_first: {:?}, writer_generation: {}",
@@ -441,8 +458,21 @@ impl NativeParquetWriter {
         } else {
             let file = File::create(&temp_filename)?;
             let (crc_file, crc_handle) = CrcWriter::new(file);
-            let props = WriterPropertiesBuilder::build_with_generation(&settings, Some(writer_generation), &schema)
-                .map_err(|e| format!("Invalid encoding/compression config: {}", e))?;
+            let enc_file_props = if let Some(ref opts) = encryption_options {
+                let enc_builder = FileEncryptionProperties::builder(opts.footer_key.clone())
+                    .with_footer_key_metadata(opts.key_metadata_json.clone());
+                let enc_builder = if opts.aad_prefix.is_empty() == false {
+                    enc_builder.with_aad_prefix(opts.aad_prefix.clone())
+                } else {
+                    enc_builder
+                };
+                Some(enc_builder.build()?)
+            } else {
+                None
+            };
+            let props = WriterPropertiesBuilder::build_with_generation_and_encryption(
+                &settings, Some(writer_generation), &schema, enc_file_props
+            ).map_err(|e| format!("Invalid encoding/compression config: {}", e))?;
             let writer = ArrowWriter::try_new(crc_file, schema, Some(props))?;
             (WriterVariant::Parquet(Arc::new(Mutex::new(writer))), Some(crc_handle))
         };
@@ -573,7 +603,7 @@ impl NativeParquetWriter {
                         Ok(mutex) => {
                             let writer = mutex.into_inner().unwrap();
                             match writer.close() {
-                                Ok(_) => {
+                                Ok(parquet_metadata) => {
                                     let crc32 = crc_handle.map(|h| h.crc32()).unwrap_or(0);
                                     log_info!("Successfully closed temp writer for: {}", temp_filename);
 
@@ -582,10 +612,11 @@ impl NativeParquetWriter {
 
                                     log_debug!("CRC32 for file {}: {:#010x}", filename, crc32);
 
-                                    let file = File::open(&filename)?;
-                                    let reader = SerializedFileReader::new(file)?;
-                                    let parquet_metadata = reader.metadata().clone();
 
+                                    // Use metadata returned by ArrowWriter::close() directly.
+                                    // This avoids re-reading the (potentially encrypted) footer
+                                    // via SerializedFileReader, which would fail without
+                                    // decryption properties.
                                     Ok(Some(FinalizeResult { metadata: parquet_metadata, crc32, row_id_mapping: None }))
                                 }
                                 Err(e) => {
@@ -821,4 +852,260 @@ impl NativeParquetWriter {
             filename, metadata.file_metadata().version(), metadata.file_metadata().num_rows(), metadata.num_row_groups());
         Ok(metadata)
     }
+
+    /// Reads the encrypted Parquet file metadata using the provided footer key and AAD prefix.
+    pub fn get_file_metadata_decrypted(
+        filename: String,
+        footer_key: Vec<u8>,
+        aad_prefix: Option<Vec<u8>>,
+    ) -> Result<parquet::file::metadata::FileMetaData, Box<dyn std::error::Error>> {
+        let file = File::open(&filename)?;
+        let mut dec_builder = FileDecryptionProperties::builder(footer_key);
+        if let Some(aad) = aad_prefix {
+            if aad.is_empty() == false {
+                dec_builder = dec_builder.with_aad_prefix(aad);
+            }
+        }
+        let decryption_properties = dec_builder.build()?;
+        let options = ArrowReaderOptions::new().with_file_decryption_properties(decryption_properties);
+        let metadata = ArrowReaderMetadata::load(&file, options)?;
+        let file_metadata = metadata.metadata().file_metadata().clone();
+        log_debug!(
+            "Decrypted metadata for {}: version={}, num_rows={}",
+            filename, file_metadata.version(), file_metadata.num_rows()
+        );
+        Ok(file_metadata)
+    }
+
+
+    /// Reads the plaintext `key_metadata` bytes from an encrypted Parquet file's
+    /// `FileCryptoMetaData` without decrypting the footer.
+    ///
+    /// Returns `None` if the file is not encrypted (magic "PAR1") or has no `key_metadata`.
+    /// Returns `Some(bytes)` with the raw key_metadata bytes otherwise.
+    pub fn read_key_metadata(filename: String) -> Result<Option<Vec<u8>>, Box<dyn std::error::Error>> {
+        let mut file = File::open(&filename)?;
+        let file_size = file.seek(SeekFrom::End(0))?;
+        if file_size < 8 {
+            return Err(format!("File too small to be a valid Parquet file: {}", filename).into());
+        }
+
+        // Read last 8 bytes: [footer_or_crypto_meta_len: 4 le bytes] [magic: 4 bytes]
+        file.seek(SeekFrom::End(-8))?;
+        let mut tail = [0u8; 8];
+        file.read_exact(&mut tail)?;
+
+        let magic = &tail[4..8];
+        if magic != b"PARE" {
+            // Not an encrypted Parquet file — no key_metadata.
+            return Ok(None);
+        }
+
+        // Encrypted file: last 8 bytes = [FileCryptoMetaData_len: i32 le][b"PARE"]
+        let crypto_meta_len = i32::from_le_bytes([tail[0], tail[1], tail[2], tail[3]]);
+        if crypto_meta_len <= 0 {
+            return Err(format!("Invalid FileCryptoMetaData length {} in {}", crypto_meta_len, filename).into());
+        }
+        let crypto_meta_len = crypto_meta_len as u64;
+        if file_size < 8 + crypto_meta_len {
+            return Err(format!("FileCryptoMetaData length exceeds file size in {}", filename).into());
+        }
+
+        // Read FileCryptoMetaData Thrift compact bytes
+        file.seek(SeekFrom::End(-(8 + crypto_meta_len as i64)))?;
+        let mut crypto_meta_bytes = vec![0u8; crypto_meta_len as usize];
+        file.read_exact(&mut crypto_meta_bytes)?;
+
+        // Parse FileCryptoMetaData using parquet-rs Thrift types.
+        // FileCryptoMetaData compact Thrift layout:
+        //   field 1 (EncryptionAlgorithm, type struct): parse and skip
+        //   field 2 (key_metadata, type binary, optional): if present, read bytes
+        // We use a minimal hand-rolled parser to avoid thrift crate version coupling.
+        parse_key_metadata_from_file_crypto_meta(&crypto_meta_bytes)
+    }
+}
+
+/// Minimal Thrift compact protocol parser for `FileCryptoMetaData.key_metadata`.
+///
+/// We only need field 2 (binary, optional). We skip field 1 (EncryptionAlgorithm struct)
+/// by recursively skipping the struct, then read field 2 if present.
+fn parse_key_metadata_from_file_crypto_meta(bytes: &[u8]) -> Result<Option<Vec<u8>>, Box<dyn std::error::Error>> {
+    let mut pos = 0usize;
+
+    // Thrift compact field header: (delta << 4) | type
+    // Type codes: 1=bool_true, 2=bool_false, 3=i8, 4=i16, 5=i32, 6=i64, 7=double,
+    //             8=binary, 9=list, 10=set, 11=map, 12=struct
+
+    let mut last_field_id: i16 = 0;
+
+    loop {
+        if pos >= bytes.len() {
+            break;
+        }
+        let byte = bytes[pos];
+        pos += 1;
+
+        if byte == 0x00 {
+            // STOP field — end of struct
+            break;
+        }
+
+        let delta = (byte >> 4) as i16;
+        let type_id = byte & 0x0F;
+
+        let field_id = if delta == 0 {
+            // zig-zag encoded full field id follows
+            let (fid, consumed) = read_zigzag_i16(&bytes[pos..])?;
+            pos += consumed;
+            fid
+        } else {
+            last_field_id + delta
+        };
+        last_field_id = field_id;
+
+        match field_id {
+            1 => {
+                // EncryptionAlgorithm — type must be struct (0x0C)
+                if type_id != 0x0C {
+                    return Err(format!("Expected struct for field 1, got type {}", type_id).into());
+                }
+                pos = skip_thrift_struct(bytes, pos)?;
+            }
+            2 => {
+                // key_metadata — type must be binary (0x08)
+                if type_id != 0x08 {
+                    return Err(format!("Expected binary for field 2, got type {}", type_id).into());
+                }
+                let (len, consumed) = read_varint_u64(&bytes[pos..])?;
+                pos += consumed;
+                let len = len as usize;
+                if pos + len > bytes.len() {
+                    return Err("key_metadata length exceeds buffer".into());
+                }
+                let key_metadata = bytes[pos..pos + len].to_vec();
+                return Ok(Some(key_metadata));
+            }
+            _ => {
+                // Skip unknown field
+                pos = skip_thrift_field(bytes, pos, type_id)?;
+            }
+        }
+    }
+
+    Ok(None)
+}
+
+/// Skip a complete Thrift compact struct (including nested structs), returning new position.
+fn skip_thrift_struct(bytes: &[u8], mut pos: usize) -> Result<usize, Box<dyn std::error::Error>> {
+    let mut last_field_id: i16 = 0;
+    loop {
+        if pos >= bytes.len() {
+            break;
+        }
+        let byte = bytes[pos];
+        pos += 1;
+        if byte == 0x00 {
+            break; // STOP
+        }
+        let delta = (byte >> 4) as i16;
+        let type_id = byte & 0x0F;
+        let field_id = if delta == 0 {
+            let (fid, consumed) = read_zigzag_i16(&bytes[pos..])?;
+            pos += consumed;
+            fid
+        } else {
+            last_field_id + delta
+        };
+        last_field_id = field_id;
+        pos = skip_thrift_field(bytes, pos, type_id)?;
+    }
+    Ok(pos)
+}
+
+/// Skip a single Thrift compact field value of the given type, returning new position.
+fn skip_thrift_field(bytes: &[u8], mut pos: usize, type_id: u8) -> Result<usize, Box<dyn std::error::Error>> {
+    match type_id {
+        0x01 | 0x02 => { /* bool: no extra bytes */ }
+        0x03 => { pos += 1; } // i8: 1 byte
+        0x04 | 0x05 | 0x06 => {
+            // i16/i32/i64: zigzag varint
+            let (_, consumed) = read_varint_u64(&bytes[pos..])?;
+            pos += consumed;
+        }
+        0x07 => { pos += 8; } // double: 8 bytes
+        0x08 => {
+            // binary: varint length + bytes
+            let (len, consumed) = read_varint_u64(&bytes[pos..])?;
+            pos += consumed + len as usize;
+        }
+        0x09 | 0x0A => {
+            // list/set: size_and_type byte, then elements
+            if pos >= bytes.len() {
+                return Err("Unexpected end of buffer in list/set".into());
+            }
+            let size_type = bytes[pos];
+            pos += 1;
+            let elem_type = size_type & 0x0F;
+            let size = if (size_type >> 4) == 0x0F {
+                let (s, consumed) = read_varint_u64(&bytes[pos..])?;
+                pos += consumed;
+                s as usize
+            } else {
+                (size_type >> 4) as usize
+            };
+            for _ in 0..size {
+                pos = skip_thrift_field(bytes, pos, elem_type)?;
+            }
+        }
+        0x0B => {
+            // map: size varint, then key_type/val_type byte, then entries
+            let (size, consumed) = read_varint_u64(&bytes[pos..])?;
+            pos += consumed;
+            if size > 0 {
+                if pos >= bytes.len() {
+                    return Err("Unexpected end of buffer in map".into());
+                }
+                let kv_type = bytes[pos];
+                pos += 1;
+                let key_type = (kv_type >> 4) & 0x0F;
+                let val_type = kv_type & 0x0F;
+                for _ in 0..size {
+                    pos = skip_thrift_field(bytes, pos, key_type)?;
+                    pos = skip_thrift_field(bytes, pos, val_type)?;
+                }
+            }
+        }
+        0x0C => {
+            // nested struct: recurse
+            pos = skip_thrift_struct(bytes, pos)?;
+        }
+        _ => {
+            return Err(format!("Unknown Thrift compact type id: {}", type_id).into());
+        }
+    }
+    Ok(pos)
+}
+
+fn read_varint_u64(bytes: &[u8]) -> Result<(u64, usize), Box<dyn std::error::Error>> {
+    let mut value: u64 = 0;
+    let mut shift = 0u32;
+    let mut consumed = 0usize;
+    for &b in bytes {
+        consumed += 1;
+        value |= ((b & 0x7F) as u64) << shift;
+        if b & 0x80 == 0 {
+            return Ok((value, consumed));
+        }
+        shift += 7;
+        if shift >= 64 {
+            return Err("Varint overflow".into());
+        }
+    }
+    Err("Unexpected end of varint".into())
+}
+
+fn read_zigzag_i16(bytes: &[u8]) -> Result<(i16, usize), Box<dyn std::error::Error>> {
+    let (n, consumed) = read_varint_u64(bytes)?;
+    let zigzag = ((n >> 1) as i16) ^ (-((n & 1) as i16));
+    Ok((zigzag, consumed))
 }

--- a/sandbox/plugins/parquet-data-format/src/main/rust/src/writer_properties_builder.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/src/writer_properties_builder.rs
@@ -108,6 +108,25 @@ impl WriterPropertiesBuilder {
 
     /// Builds WriterProperties with an optional writer generation stored as key-value metadata.
     pub fn build_with_generation(config: &NativeSettings, writer_generation: Option<i64>, schema: &ArrowSchema) -> Result<WriterProperties, String> {
+        Ok(Self::build_inner(config, writer_generation, schema)?.build())
+    }
+
+    /// Builds WriterProperties with optional writer generation and optional PME encryption.
+    pub fn build_with_generation_and_encryption(
+        config: &NativeSettings,
+        writer_generation: Option<i64>,
+        schema: &ArrowSchema,
+        encryption: Option<std::sync::Arc<parquet::encryption::encrypt::FileEncryptionProperties>>,
+    ) -> Result<WriterProperties, String> {
+        let mut builder = Self::build_inner(config, writer_generation, schema)?;
+        if let Some(enc) = encryption {
+            builder = builder.with_file_encryption_properties(enc);
+        }
+        Ok(builder.build())
+    }
+
+    /// Returns the inner WriterPropertiesBuilder with all settings applied (without calling .build()).
+    fn build_inner(config: &NativeSettings, writer_generation: Option<i64>, schema: &ArrowSchema) -> Result<parquet::file::properties::WriterPropertiesBuilder, String> {
         let mut builder = WriterProperties::builder();
 
         // Apply compression settings
@@ -138,7 +157,7 @@ impl WriterPropertiesBuilder {
         }
         builder = builder.set_key_value_metadata(Some(kv_metadata));
 
-        Ok(builder.build())
+        Ok(builder)
     }
 
     /// Applies compression settings to the builder.

--- a/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/bridge/NativeParquetWriterTests.java
+++ b/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/bridge/NativeParquetWriterTests.java
@@ -52,7 +52,9 @@ public class NativeParquetWriterTests extends OpenSearchTestCase {
 
     @Override
     public void tearDown() throws Exception {
-        allocator.close();
+        if (allocator != null) {
+            allocator.close();
+        }
         super.tearDown();
     }
 
@@ -234,6 +236,50 @@ public class NativeParquetWriterTests extends OpenSearchTestCase {
         try (ArrowExport dataExport = exportData(new int[] { 1 }, new String[] { "a" }, new long[] { 1L })) {
             expectThrows(IOException.class, () -> writer.write(dataExport.getArrayAddress(), 0L));
         }
+    }
+
+    public void testGetFileMetadataForEncryptedFileRequiresDecryptionConfig() throws Exception {
+        String filePath = createTempDir().resolve("encrypted-read.parquet").toString();
+
+        // Build a fixed data key and message_id so we can reconstruct read inputs after write.
+        byte[] dataKey = new byte[32];
+        byte[] messageId = new byte[16];
+        random().nextBytes(dataKey);
+        random().nextBytes(messageId);
+
+        byte[] footerKey = org.opensearch.parquet.encryption.PmeKeyDerivation.deriveFooterKey(dataKey, messageId);
+        byte[] aadPrefix = org.opensearch.parquet.encryption.PmeKeyDerivation.buildAadPrefix(messageId);
+        // writeConfig is zeroed by NativeParquetWriter after creation; keep footerKey/aadPrefix for reads.
+        org.opensearch.parquet.encryption.PmeFileEncryptionInputs writeConfig =
+            org.opensearch.parquet.encryption.PmeFileEncryptionInputs.forDecryption(footerKey, aadPrefix);
+
+        NativeParquetWriter writer;
+        try (ArrowExport export = exportSchema()) {
+            writer = new NativeParquetWriter(filePath, export.getSchemaAddress(), writeConfig);
+        }
+        try (ArrowExport export = exportData(new int[] { 1 }, new String[] { "alice" }, new long[] { 10L })) {
+            writer.write(export.getArrayAddress(), export.getSchemaAddress());
+        }
+        writer.flush();
+
+        // Build a fresh decryption config from the still-valid local key bytes.
+        org.opensearch.parquet.encryption.PmeFileEncryptionInputs decryptionConfig =
+            org.opensearch.parquet.encryption.PmeFileEncryptionInputs.forDecryption(footerKey, aadPrefix);
+
+        expectThrows(IOException.class, () -> RustBridge.getFileMetadata(filePath));
+        ParquetFileMetadata decryptedMetadata = RustBridge.getFileMetadata(filePath, decryptionConfig);
+        assertEquals(1L, decryptedMetadata.numRows());
+
+        long decryptedRows = RustBridge.getDecryptedNumRows(filePath, decryptionConfig);
+        assertEquals(1L, decryptedRows);
+
+        // Wrong key: same messageId but different dataKey → different footerKey → decryption fails.
+        byte[] wrongDataKey = new byte[32];
+        random().nextBytes(wrongDataKey);
+        byte[] wrongFooterKey = org.opensearch.parquet.encryption.PmeKeyDerivation.deriveFooterKey(wrongDataKey, messageId);
+        org.opensearch.parquet.encryption.PmeFileEncryptionInputs wrongKeyConfig =
+            org.opensearch.parquet.encryption.PmeFileEncryptionInputs.forDecryption(wrongFooterKey, aadPrefix);
+        expectThrows(IOException.class, () -> RustBridge.getDecryptedNumRows(filePath, wrongKeyConfig));
     }
 
     private NativeParquetWriter createWriter(String filePath) throws Exception {

--- a/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/encryption/PmeContextTests.java
+++ b/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/encryption/PmeContextTests.java
@@ -1,0 +1,144 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.parquet.encryption;
+
+import org.opensearch.common.crypto.DataKeyPair;
+import org.opensearch.common.crypto.MasterKeyProvider;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.index.IndexSettings;
+import org.opensearch.test.IndexSettingsModule;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link PmeContext}.
+ *
+ * <p>Because {@link PmeContext} normally resolves the key loader via
+ * {@link org.opensearch.crypto.CryptoHandlerRegistry}, tests inject a loader directly
+ * using the package-private {@link PmeContext#create(IndexSettings, Path, int, PmeDataKeyCache.DataKeyLoader)}
+ * overload, backed by a mock {@link MasterKeyProvider}.
+ */
+public class PmeContextTests extends OpenSearchTestCase {
+
+    private static final int KEY_LEN = PmeKeyDerivation.DATA_KEY_BYTES;
+
+    private Path indexDataPath;
+    private MasterKeyProvider provider;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        PmeDataKeyCache.initialize();
+        indexDataPath = createTempDir();
+        provider = mockProvider(makeRawKey((byte) 0x55), new byte[] { 1, 2, 3 });
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        PmeDataKeyCache.reset();
+        super.tearDown();
+    }
+
+    // ---- helpers ----
+
+    private static byte[] makeRawKey(byte fill) {
+        byte[] k = new byte[KEY_LEN];
+        Arrays.fill(k, fill);
+        return k;
+    }
+
+    private static MasterKeyProvider mockProvider(byte[] rawKey, byte[] encryptedKey) throws IOException {
+        MasterKeyProvider p = mock(MasterKeyProvider.class);
+        when(p.generateDataPair()).thenReturn(new DataKeyPair(rawKey.clone(), encryptedKey.clone()));
+        when(p.decryptKey(any())).thenReturn(rawKey.clone());
+        return p;
+    }
+
+    private static IndexSettings encryptedIndexSettings() {
+        Settings settings = Settings.builder()
+            .put("index.store.parquet.crypto.key_provider", "test-provider")
+            .put("index.store.parquet.crypto.key_provider_type", "mock")
+            .build();
+        return IndexSettingsModule.newIndexSettings("test-index", settings);
+    }
+
+    private static IndexSettings plainIndexSettings() {
+        return IndexSettingsModule.newIndexSettings("test-index", Settings.EMPTY);
+    }
+
+    private PmeDataKeyCache.DataKeyLoader loaderFor(MasterKeyProvider p) {
+        return () -> PmeKeyfileManager.initOrLoad(indexDataPath, p);
+    }
+
+    // ---- create ----
+
+    public void testCreateReturnsNullForNullIndexSettings() throws IOException {
+        assertNull(PmeContext.create(null, indexDataPath, 0, null));
+    }
+
+    public void testCreateReturnsNullWhenEncryptionNotConfigured() throws IOException {
+        assertNull(PmeContext.create(plainIndexSettings(), indexDataPath, 0, null));
+    }
+
+    public void testCreateReturnsContextAndPopulatesCache() throws IOException {
+        IndexSettings settings = encryptedIndexSettings();
+        PmeContext ctx = PmeContext.create(settings, indexDataPath, 0, loaderFor(provider));
+        assertNotNull(ctx);
+
+        // Subsequent getOrLoad must be a cache hit — loader must NOT be called.
+        AtomicBoolean loaderCalled = new AtomicBoolean(false);
+        PmeDataKeyCache.getInstance().getOrLoad(
+            settings.getUUID(), 0, PmeFileKeyMetadata.DEFAULT_DATA_KEY_ID,
+            () -> { loaderCalled.set(true); return makeRawKey((byte) 0); }
+        );
+        assertFalse("cache must already contain the key after create()", loaderCalled.get());
+    }
+
+    // ---- evict ----
+
+    public void testEvictZerosCachedKeyMaterial() throws IOException {
+        IndexSettings settings = encryptedIndexSettings();
+        PmeContext ctx = PmeContext.create(settings, indexDataPath, 0, loaderFor(provider));
+        assertNotNull(ctx);
+
+        PmeDataKey keyBefore = PmeDataKeyCache.getInstance().getOrLoad(
+            settings.getUUID(), 0, PmeFileKeyMetadata.DEFAULT_DATA_KEY_ID, loaderFor(provider)
+        );
+        ctx.evict();
+
+        byte[] afterEviction = keyBefore.bytes();
+        try {
+            assertArrayEquals("evicted key must be zeroed", new byte[KEY_LEN], afterEviction);
+        } finally {
+            Arrays.fill(afterEviction, (byte) 0);
+        }
+    }
+
+    public void testEvictThenCreateReInitializesContext() throws IOException {
+        PmeContext ctx = PmeContext.create(encryptedIndexSettings(), indexDataPath, 0, loaderFor(provider));
+        assertNotNull(ctx);
+        ctx.evict();
+
+        MasterKeyProvider provider2 = mockProvider(makeRawKey((byte) 0x66), new byte[] { 9 });
+        PmeContext ctx2 = PmeContext.create(encryptedIndexSettings(), indexDataPath, 0, loaderFor(provider2));
+        assertNotNull(ctx2);
+
+        PmeFileEncryptionInputs inputs = ctx2.createFileEncryptionInputs();
+        assertNotNull(inputs);
+        inputs.zero();
+    }
+}

--- a/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/encryption/PmeDataKeyCacheTests.java
+++ b/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/encryption/PmeDataKeyCacheTests.java
@@ -1,0 +1,152 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.parquet.encryption;
+
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class PmeDataKeyCacheTests extends OpenSearchTestCase {
+
+    private static final int KEY_LEN = PmeKeyDerivation.DATA_KEY_BYTES;
+    private static final String INDEX_UUID = "test-index-uuid";
+    private static final String DATA_KEY_ID = PmeFileKeyMetadata.DEFAULT_DATA_KEY_ID;
+    private static final int SHARD_A = 0;
+    private static final int SHARD_B = 1;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        PmeDataKeyCache.initialize();
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        PmeDataKeyCache.reset();
+        super.tearDown();
+    }
+
+    // ---- getOrLoad ----
+
+    public void testGetOrLoadCallsLoaderOnCacheMiss() throws IOException {
+        byte[] rawKey = new byte[KEY_LEN];
+        Arrays.fill(rawKey, (byte) 7);
+
+        PmeDataKey result = PmeDataKeyCache.getInstance().getOrLoad(INDEX_UUID, SHARD_A, DATA_KEY_ID, () -> rawKey.clone());
+
+        byte[] got = result.bytes();
+        try {
+            assertArrayEquals(rawKey, got);
+        } finally {
+            Arrays.fill(got, (byte) 0);
+        }
+    }
+
+    public void testGetOrLoadReturnsCachedValueOnSecondCall() throws IOException {
+        AtomicInteger loaderCalls = new AtomicInteger(0);
+        byte[] rawKey = new byte[KEY_LEN];
+
+        PmeDataKey first = PmeDataKeyCache.getInstance().getOrLoad(INDEX_UUID, SHARD_A, DATA_KEY_ID, () -> {
+            loaderCalls.incrementAndGet();
+            return rawKey.clone();
+        });
+
+        PmeDataKey second = PmeDataKeyCache.getInstance().getOrLoad(INDEX_UUID, SHARD_A, DATA_KEY_ID, () -> {
+            loaderCalls.incrementAndGet();
+            return rawKey.clone();
+        });
+
+        assertEquals("loader must be called exactly once", 1, loaderCalls.get());
+        assertSame("must return the identical cached instance", first, second);
+    }
+
+    public void testGetOrLoadZerosRawKeyAfterConstruction() throws IOException {
+        byte[] sentinel = new byte[KEY_LEN];
+        Arrays.fill(sentinel, (byte) 0x55);
+        byte[] copy = sentinel.clone();
+
+        PmeDataKeyCache.getInstance().getOrLoad(INDEX_UUID, SHARD_A, DATA_KEY_ID, () -> sentinel);
+
+        byte[] zeros = new byte[KEY_LEN];
+        assertArrayEquals("loader array must be zeroed after caching", zeros, sentinel);
+
+        PmeDataKey cached = PmeDataKeyCache.getInstance().getOrLoad(
+            INDEX_UUID, SHARD_A, DATA_KEY_ID, () -> { throw new IOException("should not be called"); }
+        );
+        byte[] got = cached.bytes();
+        try {
+            assertArrayEquals(copy, got);
+        } finally {
+            Arrays.fill(got, (byte) 0);
+        }
+    }
+
+    // ---- evict ----
+
+    public void testEvictZerosKeyMaterialAndForcesReload() throws IOException {
+        byte[] rawKey = new byte[KEY_LEN];
+        Arrays.fill(rawKey, (byte) 42);
+
+        PmeDataKey inserted = PmeDataKeyCache.getInstance().getOrLoad(INDEX_UUID, SHARD_A, DATA_KEY_ID, () -> rawKey.clone());
+        PmeDataKeyCache.getInstance().evict(INDEX_UUID, SHARD_A, DATA_KEY_ID);
+
+        byte[] afterEviction = inserted.bytes();
+        try {
+            assertArrayEquals("evicted key must be zeroed", new byte[KEY_LEN], afterEviction);
+        } finally {
+            Arrays.fill(afterEviction, (byte) 0);
+        }
+
+        AtomicInteger reloadCount = new AtomicInteger(0);
+        PmeDataKeyCache.getInstance().getOrLoad(INDEX_UUID, SHARD_A, DATA_KEY_ID, () -> {
+            reloadCount.incrementAndGet();
+            return rawKey.clone();
+        });
+        assertEquals("loader must be called again after eviction", 1, reloadCount.get());
+    }
+
+    public void testEvictNonExistentKeyIsNoOp() {
+        PmeDataKeyCache.getInstance().evict(INDEX_UUID, SHARD_A, DATA_KEY_ID);
+    }
+
+    // ---- shard isolation ----
+
+    public void testDifferentShardsHaveIndependentEntries() throws IOException {
+        byte[] keyA = new byte[KEY_LEN];
+        Arrays.fill(keyA, (byte) 1);
+        byte[] keyB = new byte[KEY_LEN];
+        Arrays.fill(keyB, (byte) 2);
+
+        PmeDataKey a = PmeDataKeyCache.getInstance().getOrLoad(INDEX_UUID, SHARD_A, DATA_KEY_ID, () -> keyA.clone());
+        PmeDataKey b = PmeDataKeyCache.getInstance().getOrLoad(INDEX_UUID, SHARD_B, DATA_KEY_ID, () -> keyB.clone());
+
+        assertNotSame(a, b);
+
+        byte[] gotA = a.bytes();
+        byte[] gotB = b.bytes();
+        try {
+            assertArrayEquals(keyA, gotA);
+            assertArrayEquals(keyB, gotB);
+        } finally {
+            Arrays.fill(gotA, (byte) 0);
+            Arrays.fill(gotB, (byte) 0);
+        }
+
+        PmeDataKeyCache.getInstance().evict(INDEX_UUID, SHARD_A, DATA_KEY_ID);
+        byte[] bAfter = b.bytes();
+        try {
+            assertArrayEquals("evicting shard A must not zero shard B", keyB, bAfter);
+        } finally {
+            Arrays.fill(bAfter, (byte) 0);
+        }
+    }
+}
+

--- a/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/encryption/PmeFileKeyMetadataTests.java
+++ b/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/encryption/PmeFileKeyMetadataTests.java
@@ -1,0 +1,179 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.parquet.encryption;
+
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Base64;
+
+/**
+ * Tests for {@link PmeFileKeyMetadata} — v1 JSON round-trip and rejection cases.
+ */
+public class PmeFileKeyMetadataTests extends OpenSearchTestCase {
+
+    private static byte[] randomMessageId() {
+        byte[] id = new byte[16];
+        random().nextBytes(id);
+        return id;
+    }
+
+    // ---- forNewFile ----
+
+    public void testForNewFileRejectsNullMessageId() {
+        expectThrows(NullPointerException.class, () -> PmeFileKeyMetadata.forNewFile(null));
+    }
+
+    public void testForNewFileRejectsWrongLength() {
+        expectThrows(IllegalArgumentException.class, () -> PmeFileKeyMetadata.forNewFile(new byte[8]));
+        expectThrows(IllegalArgumentException.class, () -> PmeFileKeyMetadata.forNewFile(new byte[32]));
+    }
+
+    public void testForNewFileSetsV1Fields() {
+        byte[] messageId = randomMessageId();
+        PmeFileKeyMetadata meta = PmeFileKeyMetadata.forNewFile(messageId);
+
+        assertEquals(PmeFileKeyMetadata.V1, meta.version());
+        assertEquals(PmeFileKeyMetadata.DEFAULT_DATA_KEY_ID, meta.dataKeyId());
+        assertArrayEquals(messageId, meta.messageId());
+    }
+
+    public void testForNewFileDefensiveCopyOfMessageId() {
+        byte[] messageId = randomMessageId();
+        PmeFileKeyMetadata meta = PmeFileKeyMetadata.forNewFile(messageId);
+        Arrays.fill(messageId, (byte) 0);
+        // Mutating the original must not affect the stored value.
+        byte[] stored = meta.messageId();
+        boolean allZero = true;
+        for (byte b : stored) {
+            if (b != 0) {
+                allZero = false;
+                break;
+            }
+        }
+        assertFalse("messageId stored inside metadata must be a defensive copy", allZero);
+    }
+
+    // ---- toJsonBytes ----
+
+    public void testToJsonBytesProducesCompactJson() {
+        byte[] messageId = new byte[16]; // all zeros for determinism
+        String expectedB64 = Base64.getUrlEncoder().withoutPadding().encodeToString(messageId);
+        byte[] json = PmeFileKeyMetadata.forNewFile(messageId).toJsonBytes();
+        String jsonStr = new String(json, StandardCharsets.UTF_8);
+
+        assertEquals(
+            "{\"version\":1,\"data_key_id\":\"default\",\"message_id\":\"" + expectedB64 + "\"}",
+            jsonStr
+        );
+    }
+
+    public void testToJsonBytesIsUtf8() {
+        byte[] json = PmeFileKeyMetadata.forNewFile(randomMessageId()).toJsonBytes();
+        // Must be valid UTF-8 (no exception).
+        String str = new String(json, StandardCharsets.UTF_8);
+        assertTrue(str.startsWith("{"));
+    }
+
+    // ---- parse: happy path ----
+
+    public void testRoundTrip() throws IOException {
+        byte[] messageId = randomMessageId();
+        PmeFileKeyMetadata original = PmeFileKeyMetadata.forNewFile(messageId);
+        byte[] json = original.toJsonBytes();
+
+        PmeFileKeyMetadata parsed = PmeFileKeyMetadata.parse(json);
+
+        assertEquals(PmeFileKeyMetadata.V1, parsed.version());
+        assertEquals(PmeFileKeyMetadata.DEFAULT_DATA_KEY_ID, parsed.dataKeyId());
+        assertArrayEquals(messageId, parsed.messageId());
+    }
+
+    public void testParseExampleFromSpec() throws IOException {
+        // Example from pme-key-management.md
+        String json = "{\"version\":1,\"data_key_id\":\"default\",\"message_id\":\"VfN2M7dPjJxYpI3aLc0S6A\"}";
+        PmeFileKeyMetadata meta = PmeFileKeyMetadata.parse(json.getBytes(StandardCharsets.UTF_8));
+
+        assertEquals(1, meta.version());
+        assertEquals("default", meta.dataKeyId());
+        assertEquals(16, meta.messageId().length);
+    }
+
+    // ---- parse: rejection cases ----
+
+    public void testParseRejectsNull() {
+        expectThrows(NullPointerException.class, () -> PmeFileKeyMetadata.parse(null));
+    }
+
+    public void testParseRejectsEmptyBytes() {
+        expectThrows(IOException.class, () -> PmeFileKeyMetadata.parse(new byte[0]));
+    }
+
+    public void testParseRejectsUnknownVersion() {
+        String json = "{\"version\":99,\"data_key_id\":\"default\",\"message_id\":\"VfN2M7dPjJxYpI3aLc0S6A\"}";
+        expectThrows(IOException.class, () -> PmeFileKeyMetadata.parse(json.getBytes(StandardCharsets.UTF_8)));
+    }
+
+    public void testParseRejectsWrongDataKeyId() {
+        String json = "{\"version\":1,\"data_key_id\":\"custom\",\"message_id\":\"VfN2M7dPjJxYpI3aLc0S6A\"}";
+        expectThrows(IOException.class, () -> PmeFileKeyMetadata.parse(json.getBytes(StandardCharsets.UTF_8)));
+    }
+
+    public void testParseRejectsMissingVersion() {
+        String json = "{\"data_key_id\":\"default\",\"message_id\":\"VfN2M7dPjJxYpI3aLc0S6A\"}";
+        expectThrows(IOException.class, () -> PmeFileKeyMetadata.parse(json.getBytes(StandardCharsets.UTF_8)));
+    }
+
+    public void testParseRejectsMissingDataKeyId() {
+        String json = "{\"version\":1,\"message_id\":\"VfN2M7dPjJxYpI3aLc0S6A\"}";
+        expectThrows(IOException.class, () -> PmeFileKeyMetadata.parse(json.getBytes(StandardCharsets.UTF_8)));
+    }
+
+    public void testParseRejectsMissingMessageId() {
+        String json = "{\"version\":1,\"data_key_id\":\"default\"}";
+        expectThrows(IOException.class, () -> PmeFileKeyMetadata.parse(json.getBytes(StandardCharsets.UTF_8)));
+    }
+
+    public void testParseRejectsUnknownField() {
+        String json = "{\"version\":1,\"data_key_id\":\"default\",\"message_id\":\"VfN2M7dPjJxYpI3aLc0S6A\",\"extra\":\"x\"}";
+        expectThrows(IOException.class, () -> PmeFileKeyMetadata.parse(json.getBytes(StandardCharsets.UTF_8)));
+    }
+
+    public void testParseRejectsMalformedBase64MessageId() {
+        String json = "{\"version\":1,\"data_key_id\":\"default\",\"message_id\":\"not-valid-!!!\"}";
+        expectThrows(IOException.class, () -> PmeFileKeyMetadata.parse(json.getBytes(StandardCharsets.UTF_8)));
+    }
+
+    public void testParseRejectsMessageIdDecodingToWrongLength() {
+        // 8 bytes → 11 base64url chars (not 16 bytes)
+        String b64 = Base64.getUrlEncoder().withoutPadding().encodeToString(new byte[8]);
+        String json = "{\"version\":1,\"data_key_id\":\"default\",\"message_id\":\"" + b64 + "\"}";
+        expectThrows(IOException.class, () -> PmeFileKeyMetadata.parse(json.getBytes(StandardCharsets.UTF_8)));
+    }
+
+    public void testParseRejectsMalformedJson() {
+        expectThrows(IOException.class, () -> PmeFileKeyMetadata.parse("not json".getBytes(StandardCharsets.UTF_8)));
+    }
+
+    // ---- messageId returns defensive copy ----
+
+    public void testMessageIdReturnsCopy() throws IOException {
+        byte[] messageId = randomMessageId();
+        PmeFileKeyMetadata meta = PmeFileKeyMetadata.parse(PmeFileKeyMetadata.forNewFile(messageId).toJsonBytes());
+
+        byte[] first = meta.messageId();
+        Arrays.fill(first, (byte) 0xFF);
+        byte[] second = meta.messageId();
+
+        assertArrayEquals("messageId() must return a fresh copy each time", messageId, second);
+    }
+}
+

--- a/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/encryption/PmeKeyDerivationTests.java
+++ b/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/encryption/PmeKeyDerivationTests.java
@@ -1,0 +1,166 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.parquet.encryption;
+
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+/**
+ * Tests for {@link PmeKeyDerivation} — derivation correctness and AAD prefix structure.
+ */
+public class PmeKeyDerivationTests extends OpenSearchTestCase {
+
+    private static final int DATA_KEY_BYTES = 32;
+    private static final int MESSAGE_ID_BYTES = 16;
+    private static final int FOOTER_KEY_BYTES = 16; // TODO to be changed when 32 bit keys get available in parquet-rs
+
+    private static byte[] dataKey(byte fill) {
+        byte[] k = new byte[DATA_KEY_BYTES];
+        Arrays.fill(k, fill);
+        return k;
+    }
+
+    private static byte[] messageId(byte fill) {
+        byte[] id = new byte[MESSAGE_ID_BYTES];
+        Arrays.fill(id, fill);
+        return id;
+    }
+
+    // ---- deriveFooterKey: input validation ----
+
+    public void testDeriveFooterKeyRejectsNullDataKey() {
+        expectThrows(NullPointerException.class, () -> PmeKeyDerivation.deriveFooterKey(null, messageId((byte) 1)));
+    }
+
+    public void testDeriveFooterKeyRejectsNullMessageId() {
+        expectThrows(NullPointerException.class, () -> PmeKeyDerivation.deriveFooterKey(dataKey((byte) 1), null));
+    }
+
+    public void testDeriveFooterKeyRejectsShortDataKey() {
+        expectThrows(IllegalArgumentException.class, () -> PmeKeyDerivation.deriveFooterKey(new byte[16], messageId((byte) 1)));
+    }
+
+    public void testDeriveFooterKeyRejectsLongDataKey() {
+        expectThrows(IllegalArgumentException.class, () -> PmeKeyDerivation.deriveFooterKey(new byte[64], messageId((byte) 1)));
+    }
+
+    public void testDeriveFooterKeyRejectsShortMessageId() {
+        expectThrows(IllegalArgumentException.class, () -> PmeKeyDerivation.deriveFooterKey(dataKey((byte) 1), new byte[8]));
+    }
+
+    public void testDeriveFooterKeyRejectsLongMessageId() {
+        expectThrows(IllegalArgumentException.class, () -> PmeKeyDerivation.deriveFooterKey(dataKey((byte) 1), new byte[32]));
+    }
+
+    // ---- deriveFooterKey: output properties ----
+
+    public void testDeriveFooterKeyIsDeterministic() {
+        byte[] dk = dataKey((byte) 0x42);
+        byte[] mid = messageId((byte) 0x13);
+        byte[] k1 = PmeKeyDerivation.deriveFooterKey(dk, mid);
+        byte[] k2 = PmeKeyDerivation.deriveFooterKey(dk, mid);
+        assertArrayEquals("derivation must be deterministic", k1, k2);
+    }
+
+    public void testDeriveFooterKeyDiffersForDifferentMessageIds() {
+        byte[] dk = dataKey((byte) 0x55);
+        byte[] k1 = PmeKeyDerivation.deriveFooterKey(dk, messageId((byte) 0x01));
+        byte[] k2 = PmeKeyDerivation.deriveFooterKey(dk, messageId((byte) 0x02));
+        assertFalse("different message_ids must produce different keys", Arrays.equals(k1, k2));
+    }
+
+    public void testDeriveFooterKeyDiffersForDifferentDataKeys() {
+        byte[] mid = messageId((byte) 0x33);
+        byte[] k1 = PmeKeyDerivation.deriveFooterKey(dataKey((byte) 0x11), mid);
+        byte[] k2 = PmeKeyDerivation.deriveFooterKey(dataKey((byte) 0x22), mid);
+        assertFalse("different data keys must produce different footer keys", Arrays.equals(k1, k2));
+    }
+
+    public void testDeriveFooterKeyKnownVector() {
+        // Zero data key + zero message_id: derive and check length/non-zero (no hardcoded HMAC bytes,
+        // but at least verify derivation runs end-to-end and produces a non-trivially-zero result).
+        byte[] dk = new byte[DATA_KEY_BYTES];
+        byte[] mid = new byte[MESSAGE_ID_BYTES];
+        byte[] key = PmeKeyDerivation.deriveFooterKey(dk, mid);
+        assertEquals(FOOTER_KEY_BYTES, key.length);
+        // HMAC-SHA384 of all-zero input with all-zero key is not all-zeros.
+        boolean allZero = true;
+        for (byte b : key) {
+            if (b != 0) { allZero = false; break; }
+        }
+        assertFalse("derived key must not be all-zero for all-zero inputs", allZero);
+    }
+
+    // ---- buildAadPrefix: input validation ----
+
+    public void testBuildAadPrefixRejectsNullMessageId() {
+        expectThrows(NullPointerException.class, () -> PmeKeyDerivation.buildAadPrefix(null));
+    }
+
+    public void testBuildAadPrefixRejectsWrongLength() {
+        expectThrows(IllegalArgumentException.class, () -> PmeKeyDerivation.buildAadPrefix(new byte[8]));
+        expectThrows(IllegalArgumentException.class, () -> PmeKeyDerivation.buildAadPrefix(new byte[32]));
+    }
+
+    // ---- buildAadPrefix: structure ----
+
+    public void testBuildAadPrefixStructure() {
+        byte[] mid = messageId((byte) 0x77);
+        byte[] aad = PmeKeyDerivation.buildAadPrefix(mid);
+
+        // domain = "opensearch/parquet-pme/file/v1" (30 bytes)
+        byte[] domain = "opensearch/parquet-pme/file/v1".getBytes(StandardCharsets.UTF_8);
+        assertEquals(30, domain.length);
+
+        // dataKeyId = "default" (7 bytes)
+        byte[] dataKeyId = "default".getBytes(StandardCharsets.UTF_8);
+
+        int expectedLen = 2 + domain.length + 1 + 2 + dataKeyId.length + MESSAGE_ID_BYTES;
+        assertEquals("AAD prefix length must match spec", expectedLen, aad.length);
+
+        // u16_be(domain.length)
+        assertEquals((byte) 0, aad[0]);
+        assertEquals((byte) 30, aad[1]);
+
+        // domain bytes
+        for (int i = 0; i < domain.length; i++) {
+            assertEquals("domain byte " + i, domain[i], aad[2 + i]);
+        }
+
+        int pos = 2 + domain.length;
+        // u8(version) = 1
+        assertEquals((byte) 1, aad[pos++]);
+        // u16_be(dataKeyId.length) = 7
+        assertEquals((byte) 0, aad[pos++]);
+        assertEquals((byte) 7, aad[pos++]);
+        // dataKeyId bytes
+        for (int i = 0; i < dataKeyId.length; i++) {
+            assertEquals("dataKeyId byte " + i, dataKeyId[i], aad[pos + i]);
+        }
+        pos += dataKeyId.length;
+        // messageId[16]
+        for (int i = 0; i < MESSAGE_ID_BYTES; i++) {
+            assertEquals("messageId byte " + i, mid[i], aad[pos + i]);
+        }
+    }
+
+    public void testBuildAadPrefixIsDeterministic() {
+        byte[] mid = messageId((byte) 0x11);
+        assertArrayEquals(PmeKeyDerivation.buildAadPrefix(mid), PmeKeyDerivation.buildAadPrefix(mid));
+    }
+
+    public void testBuildAadPrefixDiffersForDifferentMessageIds() {
+        byte[] aad1 = PmeKeyDerivation.buildAadPrefix(messageId((byte) 0x01));
+        byte[] aad2 = PmeKeyDerivation.buildAadPrefix(messageId((byte) 0x02));
+        assertFalse("different message_ids must produce different AAD prefixes", Arrays.equals(aad1, aad2));
+    }
+}
+

--- a/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/encryption/PmeKeyfileManagerTests.java
+++ b/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/encryption/PmeKeyfileManagerTests.java
@@ -1,0 +1,142 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.parquet.encryption;
+
+import org.opensearch.common.crypto.DataKeyPair;
+import org.opensearch.common.crypto.MasterKeyProvider;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class PmeKeyfileManagerTests extends OpenSearchTestCase {
+
+    private static final int KEY_LEN = PmeKeyDerivation.DATA_KEY_BYTES;
+
+    // ---- helpers ----
+
+    private static byte[] makeRawKey(byte fill) {
+        byte[] k = new byte[KEY_LEN];
+        Arrays.fill(k, fill);
+        return k;
+    }
+
+    private static MasterKeyProvider mockProvider(byte[] rawKey, byte[] encryptedKey) throws IOException {
+        MasterKeyProvider provider = mock(MasterKeyProvider.class);
+        when(provider.generateDataPair()).thenReturn(new DataKeyPair(rawKey.clone(), encryptedKey.clone()));
+        when(provider.decryptKey(any())).thenReturn(rawKey.clone());
+        return provider;
+    }
+
+    // ---- initOrLoad: keyfile absent ----
+
+    public void testCreatesKeyfileWhenAbsent() throws IOException {
+        Path dir = createTempDir();
+        byte[] rawKey = makeRawKey((byte) 0xAB);
+        byte[] encKey = new byte[] { 1, 2, 3 };
+
+        byte[] result = PmeKeyfileManager.initOrLoad(dir, mockProvider(rawKey, encKey));
+        try {
+            assertArrayEquals(rawKey, result);
+        } finally {
+            Arrays.fill(result, (byte) 0);
+        }
+
+        Path keyfile = dir.resolve(PmeKeyfileManager.KEYFILE_NAME);
+        assertTrue("keyfile must exist after init", Files.exists(keyfile));
+        assertArrayEquals(encKey, Files.readAllBytes(keyfile));
+    }
+
+    // ---- initOrLoad: keyfile present ----
+
+    public void testLoadsExistingKeyfile() throws IOException {
+        Path dir = createTempDir();
+        byte[] rawKey = makeRawKey((byte) 0xCD);
+        byte[] encKey = new byte[] { 9, 8, 7 };
+
+        // Pre-write the keyfile.
+        Files.write(dir.resolve(PmeKeyfileManager.KEYFILE_NAME), encKey);
+
+        byte[] result = PmeKeyfileManager.initOrLoad(dir, mockProvider(rawKey, encKey));
+        try {
+            assertArrayEquals(rawKey, result);
+        } finally {
+            Arrays.fill(result, (byte) 0);
+        }
+    }
+
+    // ---- initOrLoad: race condition ----
+
+    public void testConcurrentInitProducesConsistentKey() throws Exception {
+        Path dir = createTempDir();
+        byte[] rawKey = makeRawKey((byte) 0x77);
+        byte[] encKey = new byte[] { 5, 6, 7, 8 };
+
+        int threads = 4;
+        CountDownLatch start = new CountDownLatch(1);
+        AtomicInteger errors = new AtomicInteger(0);
+        byte[][] results = new byte[threads][];
+        Thread[] workers = new Thread[threads];
+
+        for (int i = 0; i < threads; i++) {
+            final int idx = i;
+            workers[idx] = new Thread(() -> {
+                try {
+                    MasterKeyProvider p = mockProvider(rawKey, encKey);
+                    start.await();
+                    results[idx] = PmeKeyfileManager.initOrLoad(dir, p);
+                } catch (Exception e) {
+                    errors.incrementAndGet();
+                }
+            });
+            workers[idx].start();
+        }
+
+        start.countDown();
+        for (Thread w : workers) {
+            w.join(10_000);
+        }
+
+        assertEquals("no thread should have failed", 0, errors.get());
+        for (byte[] r : results) {
+            assertNotNull(r);
+            assertArrayEquals("all threads must get the same key", rawKey, r);
+            Arrays.fill(r, (byte) 0);
+        }
+
+        assertTrue(Files.exists(dir.resolve(PmeKeyfileManager.KEYFILE_NAME)));
+        // No stray tmp files should remain (each uses a unique UUID name).
+        long tmpCount;
+        try (java.util.stream.Stream<Path> stream = Files.list(dir)) {
+            tmpCount = stream.filter(p -> p.getFileName().toString().startsWith("keyfile.tmp.")).count();
+        }
+        assertEquals("stray tmp keyfiles should be cleaned up", 0, tmpCount);
+    }
+
+    // ---- validation ----
+
+    public void testThrowsIfDecryptedKeyHasWrongLength() throws IOException {
+        Path dir = createTempDir();
+        byte[] shortKey = new byte[16]; // wrong length
+
+        MasterKeyProvider provider = mock(MasterKeyProvider.class);
+        when(provider.generateDataPair()).thenReturn(new DataKeyPair(shortKey, new byte[] { 1 }));
+        when(provider.decryptKey(any())).thenReturn(shortKey);
+
+        expectThrows(IllegalArgumentException.class, () -> PmeKeyfileManager.initOrLoad(dir, provider));
+    }
+}

--- a/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/writer/ParquetWriterEncryptedTests.java
+++ b/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/writer/ParquetWriterEncryptedTests.java
@@ -1,0 +1,236 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.parquet.writer;
+
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.opensearch.Version;
+import org.opensearch.arrow.allocator.ArrowNativeAllocator;
+import org.opensearch.arrow.spi.NativeAllocatorPoolConfig;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.index.IndexSettings;
+import org.opensearch.index.engine.dataformat.FileInfos;
+import org.opensearch.index.engine.dataformat.FlushInput;
+import org.opensearch.index.mapper.KeywordFieldMapper;
+import org.opensearch.index.mapper.MappedFieldType;
+import org.opensearch.index.mapper.NumberFieldMapper;
+import org.opensearch.parquet.ParquetDataFormatPlugin;
+import org.opensearch.parquet.bridge.RustBridge;
+import org.opensearch.parquet.encryption.PmeDataKey;
+import org.opensearch.parquet.encryption.PmeFileEncryptionInputs;
+import org.opensearch.parquet.encryption.PmeFileKeyMetadata;
+import org.opensearch.parquet.encryption.PmeKeyDerivation;
+import org.opensearch.parquet.engine.ParquetDataFormat;
+import org.opensearch.parquet.fields.ArrowFieldRegistry;
+import org.opensearch.parquet.fields.ParquetField;
+import org.opensearch.parquet.memory.ArrowBufferPool;
+import org.opensearch.parquet.stats.ParquetShardStatsTracker;
+import org.opensearch.parquet.ParquetBaseTests;
+import org.opensearch.threadpool.FixedExecutorBuilder;
+import org.opensearch.threadpool.ThreadPool;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Encrypted variants of {@link ParquetWriterTests}.
+ */
+public class ParquetWriterEncryptedTests extends ParquetBaseTests {
+
+    private ArrowNativeAllocator nativeAllocator;
+    private ArrowBufferPool bufferPool;
+    private MappedFieldType idField;
+    private MappedFieldType nameField;
+    private MappedFieldType scoreField;
+    private Schema schema;
+    private ThreadPool threadPool;
+    private IndexSettings indexSettings;
+
+    private byte[] dataKey;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        RustBridge.initLogger();
+        nativeAllocator = new ArrowNativeAllocator();
+        nativeAllocator.getOrCreatePool(NativeAllocatorPoolConfig.POOL_INGEST, 0L, Long.MAX_VALUE, null);
+        bufferPool = new ArrowBufferPool(Settings.EMPTY, nativeAllocator);
+        idField = new NumberFieldMapper.NumberFieldType("id", NumberFieldMapper.NumberType.INTEGER);
+        nameField = new KeywordFieldMapper.KeywordFieldType("name");
+        scoreField = new NumberFieldMapper.NumberFieldType("score", NumberFieldMapper.NumberType.LONG);
+        schema = buildSchema(List.of(idField, nameField, scoreField));
+        Settings idxSettings = Settings.builder()
+            .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+            .build();
+        IndexMetadata indexMetadata = IndexMetadata.builder("test-index").settings(idxSettings).build();
+        indexSettings = new IndexSettings(indexMetadata, Settings.EMPTY);
+        Settings settings = Settings.builder().put("node.name", "parquetwriter-encrypted-test").build();
+        threadPool = new ThreadPool(
+            settings,
+            new FixedExecutorBuilder(
+                settings,
+                ParquetDataFormatPlugin.PARQUET_THREAD_POOL_NAME,
+                1,
+                -1,
+                "thread_pool." + ParquetDataFormatPlugin.PARQUET_THREAD_POOL_NAME
+            )
+        );
+        dataKey = randomByteArrayOfLength(PmeKeyDerivation.DATA_KEY_BYTES);
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        terminate(threadPool);
+        bufferPool.close();
+        if (nativeAllocator != null) {
+            nativeAllocator.close();
+            nativeAllocator = null;
+        }
+        super.tearDown();
+    }
+
+    private PmeFileEncryptionInputs encryptionInputs() {
+        return PmeFileEncryptionInputs.create(new PmeDataKey(dataKey));
+    }
+
+    private PmeFileEncryptionInputs decryptionInputs(String filePath) throws Exception {
+        byte[] keyMetadataBytes = RustBridge.readKeyMetadata(filePath);
+        assertNotNull("Encrypted file must contain key_metadata", keyMetadataBytes);
+        PmeFileKeyMetadata meta = PmeFileKeyMetadata.parse(keyMetadataBytes);
+        assertEquals(PmeFileKeyMetadata.DEFAULT_DATA_KEY_ID, meta.dataKeyId());
+        byte[] footerKey = PmeKeyDerivation.deriveFooterKey(dataKey, meta.messageId());
+        byte[] aadPrefix = PmeKeyDerivation.buildAadPrefix(meta.messageId());
+        return PmeFileEncryptionInputs.forDecryption(footerKey, aadPrefix);
+    }
+
+    private Schema buildSchema(List<MappedFieldType> fieldTypes) {
+        List<Field> fields = new ArrayList<>();
+        for (MappedFieldType ft : fieldTypes) {
+            ParquetField pf = ArrowFieldRegistry.getParquetField(ft.typeName());
+            assertNotNull("No ParquetField registered for type: " + ft.typeName(), pf);
+            fields.add(new Field(ft.name(), pf.getFieldType(), null));
+        }
+        // Metadata fields are required by the ParquetDocumentInput assertion
+        fields.addAll(metadataFields());
+        return new Schema(fields);
+    }
+
+    private ParquetWriter createWriter(String filePath, PmeFileEncryptionInputs enc) {
+        return new ParquetWriter(
+            filePath,
+            1L,
+            1L,
+            new ParquetDataFormat(),
+            schema,
+            () -> schema,
+            bufferPool,
+            indexSettings,
+            threadPool,
+            null,
+            (ParquetShardStatsTracker) null,
+            enc
+        );
+    }
+
+    public void testEncryptedSingleDocumentFlush() throws Exception {
+        String filePath = createTempDir().resolve("encrypted-single.parquet").toString();
+        ParquetWriter writer = createWriter(filePath, encryptionInputs());
+
+        ParquetDocumentInput doc = new ParquetDocumentInput();
+        populateMetadataFields(doc);
+        doc.addField(idField, 42);
+        doc.addField(nameField, "alice");
+        doc.addField(scoreField, 500L);
+        doc.setRowId("__row_id__", 0);
+        writer.addDoc(doc);
+        doc.close();
+        writer.flush(FlushInput.EMPTY);
+
+        assertTrue("Encrypted parquet file must exist", Files.exists(Path.of(filePath)));
+        expectThrows(Exception.class, () -> RustBridge.getFileMetadata(filePath));
+        PmeFileEncryptionInputs dec = decryptionInputs(filePath);
+        assertEquals(1, RustBridge.getFileMetadata(filePath, dec).numRows());
+    }
+
+    public void testEncryptedMultipleDocumentsFlush() throws Exception {
+        String filePath = createTempDir().resolve("encrypted-multi.parquet").toString();
+        ParquetWriter writer = createWriter(filePath, encryptionInputs());
+
+        int count = randomIntBetween(2, 20);
+        for (int i = 0; i < count; i++) {
+            ParquetDocumentInput doc = new ParquetDocumentInput();
+            populateMetadataFields(doc);
+            doc.addField(idField, i);
+            doc.addField(nameField, "user_" + i);
+            doc.addField(scoreField, (long) (i * 100));
+            doc.setRowId("__row_id__", i);
+            writer.addDoc(doc);
+            doc.close();
+        }
+
+        FileInfos fileInfos = writer.flush(FlushInput.EMPTY);
+        assertNotNull(fileInfos);
+        assertTrue(Files.exists(Path.of(filePath)));
+        expectThrows(Exception.class, () -> RustBridge.getFileMetadata(filePath));
+        PmeFileEncryptionInputs dec = decryptionInputs(filePath);
+        assertEquals(count, RustBridge.getFileMetadata(filePath, dec).numRows());
+    }
+
+    public void testEncryptedReadWithWrongKeyFails() throws Exception {
+        String filePath = createTempDir().resolve("encrypted-wrong-key.parquet").toString();
+        ParquetWriter writer = createWriter(filePath, encryptionInputs());
+
+        ParquetDocumentInput doc = new ParquetDocumentInput();
+        populateMetadataFields(doc);
+        doc.addField(idField, 1);
+        doc.addField(nameField, "bob");
+        doc.addField(scoreField, 99L);
+        doc.setRowId("__row_id__", 0);
+        writer.addDoc(doc);
+        doc.close();
+        writer.flush(FlushInput.EMPTY);
+
+        byte[] keyMetadataBytes = RustBridge.readKeyMetadata(filePath);
+        PmeFileKeyMetadata meta = PmeFileKeyMetadata.parse(keyMetadataBytes);
+        byte[] wrongDataKey = randomByteArrayOfLength(PmeKeyDerivation.DATA_KEY_BYTES);
+        byte[] wrongFooterKey = PmeKeyDerivation.deriveFooterKey(wrongDataKey, meta.messageId());
+        byte[] aadPrefix = PmeKeyDerivation.buildAadPrefix(meta.messageId());
+        PmeFileEncryptionInputs wrongDec = PmeFileEncryptionInputs.forDecryption(wrongFooterKey, aadPrefix);
+        expectThrows(Exception.class, () -> RustBridge.getDecryptedNumRows(filePath, wrongDec));
+    }
+
+    public void testEncryptedFooterKeyMetadataRoundTrip() throws Exception {
+        String filePath = createTempDir().resolve("encrypted-meta.parquet").toString();
+        ParquetWriter writer = createWriter(filePath, encryptionInputs());
+
+        ParquetDocumentInput doc = new ParquetDocumentInput();
+        populateMetadataFields(doc);
+        doc.addField(idField, 7);
+        doc.addField(nameField, "meta-test");
+        doc.addField(scoreField, 777L);
+        doc.setRowId("__row_id__", 0);
+        writer.addDoc(doc);
+        doc.close();
+        writer.flush(FlushInput.EMPTY);
+
+        byte[] keyMetadataBytes = RustBridge.readKeyMetadata(filePath);
+        assertNotNull(keyMetadataBytes);
+
+        PmeFileKeyMetadata meta = PmeFileKeyMetadata.parse(keyMetadataBytes);
+        assertEquals(1, meta.version());
+        assertEquals(PmeFileKeyMetadata.DEFAULT_DATA_KEY_ID, meta.dataKeyId());
+        assertEquals(16, meta.messageId().length);
+    }
+}
+

--- a/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/writer/ParquetWriterTests.java
+++ b/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/writer/ParquetWriterTests.java
@@ -26,6 +26,8 @@ import org.opensearch.index.mapper.NumberFieldMapper;
 import org.opensearch.parquet.ParquetBaseTests;
 import org.opensearch.parquet.ParquetDataFormatPlugin;
 import org.opensearch.parquet.bridge.RustBridge;
+import org.opensearch.parquet.encryption.PmeFileEncryptionInputs;
+import org.opensearch.parquet.encryption.PmeKeyDerivation;
 import org.opensearch.parquet.engine.ParquetDataFormat;
 import org.opensearch.parquet.fields.ArrowFieldRegistry;
 import org.opensearch.parquet.fields.ParquetField;
@@ -37,6 +39,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 public class ParquetWriterTests extends ParquetBaseTests {
 
@@ -97,106 +100,126 @@ public class ParquetWriterTests extends ParquetBaseTests {
 
     public void testAddDocReturnsSuccess() throws Exception {
         String filePath = createTempDir().resolve("success.parquet").toString();
-        ParquetWriter writer = new ParquetWriter(
-            filePath,
-            1L,
-            1L,
-            new ParquetDataFormat(),
-            schema,
-            () -> schema,
-            bufferPool,
-            indexSettings,
-            threadPool,
-            null
-        );
-
-        ParquetDocumentInput doc = new ParquetDocumentInput();
-        populateMetadataFields(doc);
-        doc.addField(idField, 1);
-        doc.addField(nameField, "alice");
-        doc.addField(scoreField, 100L);
-        doc.setRowId(DocumentInput.ROW_ID_FIELD, 0);
-        WriteResult result = writer.addDoc(doc);
-        assertTrue(result instanceof WriteResult.Success);
-        doc.close();
-        writer.flush(FlushInput.EMPTY);
+        try (ParquetWriter writer = new ParquetWriter(
+            filePath, 1L, 1L, new ParquetDataFormat(), schema, () -> schema, bufferPool, indexSettings, threadPool, null
+        )) {
+            ParquetDocumentInput doc = new ParquetDocumentInput();
+            populateMetadataFields(doc);
+            doc.addField(idField, 1);
+            doc.addField(nameField, "alice");
+            doc.addField(scoreField, 100L);
+            doc.setRowId(DocumentInput.ROW_ID_FIELD, 0);
+            WriteResult result = writer.addDoc(doc);
+            assertTrue(result instanceof WriteResult.Success);
+            doc.close();
+            writer.flush(FlushInput.EMPTY);
+        }
     }
 
     public void testSingleDocumentFlush() throws Exception {
         String filePath = createTempDir().resolve("single.parquet").toString();
-        ParquetWriter writer = new ParquetWriter(
-            filePath,
-            1L,
-            1L,
-            new ParquetDataFormat(),
-            schema,
-            () -> schema,
-            bufferPool,
-            indexSettings,
-            threadPool,
-            null
-        );
+        try (ParquetWriter writer = new ParquetWriter(
+            filePath, 1L, 1L, new ParquetDataFormat(), schema, () -> schema, bufferPool, indexSettings, threadPool, null
+        )) {
+            ParquetDocumentInput doc = new ParquetDocumentInput();
+            populateMetadataFields(doc);
+            doc.addField(idField, 42);
+            doc.addField(nameField, "bob");
+            doc.addField(scoreField, 500L);
+            doc.setRowId(DocumentInput.ROW_ID_FIELD, 0);
+            writer.addDoc(doc);
+            doc.close();
 
-        ParquetDocumentInput doc = new ParquetDocumentInput();
-        populateMetadataFields(doc);
-        doc.addField(idField, 42);
-        doc.addField(nameField, "bob");
-        doc.addField(scoreField, 500L);
-        doc.setRowId(DocumentInput.ROW_ID_FIELD, 0);
-        writer.addDoc(doc);
-        doc.close();
-
-        writer.flush(FlushInput.EMPTY);
-        assertEquals(1, RustBridge.getFileMetadata(filePath).numRows());
+            writer.flush(FlushInput.EMPTY);
+            assertEquals(1, RustBridge.getFileMetadata(filePath).numRows());
+        }
     }
 
     public void testMultipleDocumentsFlush() throws Exception {
         String filePath = createTempDir().resolve("multi.parquet").toString();
-        ParquetWriter writer = new ParquetWriter(
-            filePath,
-            1L,
-            1L,
-            new ParquetDataFormat(),
-            schema,
-            () -> schema,
-            bufferPool,
-            indexSettings,
-            threadPool,
-            null
-        );
+        try (ParquetWriter writer = new ParquetWriter(
+            filePath, 1L, 1L, new ParquetDataFormat(), schema, () -> schema, bufferPool, indexSettings, threadPool, null
+        )) {
+            for (int i = 0; i < 10; i++) {
+                ParquetDocumentInput doc = new ParquetDocumentInput();
+                populateMetadataFields(doc);
+                doc.addField(idField, i);
+                doc.addField(nameField, "user_" + i);
+                doc.addField(scoreField, (long) (i * 100));
+                doc.setRowId("__row_id__", i);
+                writer.addDoc(doc);
+                doc.close();
+            }
 
-        for (int i = 0; i < 10; i++) {
-            ParquetDocumentInput doc = new ParquetDocumentInput();
-            populateMetadataFields(doc);
-            doc.addField(idField, i);
-            doc.addField(nameField, "user_" + i);
-            doc.addField(scoreField, (long) (i * 100));
-            doc.setRowId("__row_id__", i);
-            writer.addDoc(doc);
-            doc.close();
+            FileInfos fileInfos = writer.flush(FlushInput.EMPTY);
+            assertNotNull(fileInfos);
+            assertTrue(Files.exists(Path.of(filePath)));
+            assertEquals(10, RustBridge.getFileMetadata(filePath).numRows());
         }
-
-        FileInfos fileInfos = writer.flush(FlushInput.EMPTY);
-        assertNotNull(fileInfos);
-        assertTrue(Files.exists(Path.of(filePath)));
-        assertEquals(10, RustBridge.getFileMetadata(filePath).numRows());
     }
 
     public void testFlushWithNoDocuments() throws Exception {
         String filePath = createTempDir().resolve("empty.parquet").toString();
-        ParquetWriter writer = new ParquetWriter(
-            filePath,
-            1L,
-            1L,
-            new ParquetDataFormat(),
-            schema,
-            () -> schema,
-            bufferPool,
-            indexSettings,
-            threadPool,
-            null
+        try (ParquetWriter writer = new ParquetWriter(
+            filePath, 1L, 1L, new ParquetDataFormat(), schema, () -> schema, bufferPool, indexSettings, threadPool, null
+        )) {
+            assertEquals(FileInfos.empty(), writer.flush(FlushInput.EMPTY));
+        }
+    }
+
+    public void testSyncAfterFlush() throws Exception {
+        String filePath = createTempDir().resolve("sync.parquet").toString();
+        try (ParquetWriter writer = new ParquetWriter(
+            filePath, 1L, 1L, new ParquetDataFormat(), schema, () -> schema, bufferPool, indexSettings, threadPool, null
+        )) {
+            ParquetDocumentInput doc = new ParquetDocumentInput();
+            populateMetadataFields(doc);
+            doc.addField(idField, 1);
+            doc.addField(nameField, "alice");
+            doc.addField(scoreField, 100L);
+            doc.setRowId("__row_id__", 0);
+            writer.addDoc(doc);
+            doc.close();
+
+            writer.flush(FlushInput.EMPTY);
+            assertTrue(Files.exists(Path.of(filePath)));
+        }
+    }
+
+    public void testFlushPersistsPerFilePmeMetadata() throws Exception {
+        String filePath = createTempDir().resolve("encrypted.parquet").toString();
+
+        // Build encryption inputs directly from known key material.
+        byte[] dataKey = randomByteArrayOfLength(32);
+        byte[] messageId = randomByteArrayOfLength(16);
+        byte[] footerKey = PmeKeyDerivation.deriveFooterKey(dataKey, messageId);
+        byte[] aadPrefix = PmeKeyDerivation.buildAadPrefix(messageId);
+        PmeFileEncryptionInputs encryptionConfig = PmeFileEncryptionInputs.forDecryption(footerKey, aadPrefix);
+
+        FileInfos fileInfos;
+        try (ParquetWriter writer = new ParquetWriter(
+            filePath, 1L, 1L, new ParquetDataFormat(), schema, () -> schema, bufferPool, indexSettings, threadPool, null, encryptionConfig
+        )) {
+            ParquetDocumentInput doc = new ParquetDocumentInput();
+            populateMetadataFields(doc);
+            doc.addField(idField, 7);
+            doc.addField(nameField, "enc");
+            doc.addField(scoreField, 700L);
+            doc.setRowId("__row_id__", 0);
+            writer.addDoc(doc);
+            doc.close();
+
+            fileInfos = writer.flush(FlushInput.EMPTY);
+        }
+        String fileName = Path.of(filePath).getFileName().toString();
+        Map<String, String> metadata = fileInfos.writerFilesMap().values().iterator().next().metadataForFile(fileName);
+
+        // PME key_metadata is now stored only in the Parquet file footer — not in catalog metadata.
+        // The WriterFileSet must be empty to avoid duplicating key material in the catalog.
+        assertTrue(
+            "Encrypted Parquet file must not emit PME per-file catalog metadata; got: " + metadata,
+            metadata.isEmpty()
         );
-        assertEquals(FileInfos.empty(), writer.flush(FlushInput.EMPTY));
     }
 
     private Schema buildSchema(List<MappedFieldType> fieldTypes) {

--- a/server/src/main/java/org/opensearch/index/engine/exec/WriterFileSet.java
+++ b/server/src/main/java/org/opensearch/index/engine/exec/WriterFileSet.java
@@ -16,9 +16,12 @@ import org.opensearch.core.common.io.stream.Writeable;
 import org.opensearch.index.engine.exec.coord.DataformatAwareCatalogSnapshot;
 import org.opensearch.index.engine.exec.coord.LuceneVersionConverter;
 
+import java.io.EOFException;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -45,13 +48,35 @@ public sealed class WriterFileSet implements Writeable permits MonoFileWriterSet
     private final Set<String> files;
     private final long numRows;
     private final long formatVersion;
+    private final Map<String, Map<String, String>> perFileMetadata;
 
     public WriterFileSet(String directory, long writerGeneration, Set<String> files, long numRows, long formatVersion) {
+        this(directory, writerGeneration, files, numRows, formatVersion, Map.of());
+    }
+
+    /** Convenience constructor (no formatVersion, with perFileMetadata). */
+    public WriterFileSet(String directory, long writerGeneration, Set<String> files, long numRows, Map<String, Map<String, String>> perFileMetadata) {
+        this(directory, writerGeneration, files, numRows, 0L, perFileMetadata);
+    }
+
+    public WriterFileSet(
+        String directory,
+        long writerGeneration,
+        Set<String> files,
+        long numRows,
+        long formatVersion,
+        Map<String, Map<String, String>> perFileMetadata
+    ) {
         this.directory = directory;
         this.writerGeneration = writerGeneration;
         this.files = Set.copyOf(files);
         this.numRows = numRows;
         this.formatVersion = formatVersion;
+        Map<String, Map<String, String>> normalizedMetadata = new HashMap<>();
+        for (Map.Entry<String, Map<String, String>> entry : perFileMetadata.entrySet()) {
+            normalizedMetadata.put(entry.getKey(), Map.copyOf(entry.getValue()));
+        }
+        this.perFileMetadata = Map.copyOf(normalizedMetadata);
     }
 
     /**
@@ -69,6 +94,21 @@ public sealed class WriterFileSet implements Writeable permits MonoFileWriterSet
         this.formatVersion = version == DataformatAwareCatalogSnapshot.SERIALIZATION_VERSION_ONE
             ? in.readLong()
             : LuceneVersionConverter.encode(Version.LATEST);
+        this.perFileMetadata = readPerFileMetadata(in);
+    }
+
+    /** Deserializes using the current serialization version. */
+    public WriterFileSet(StreamInput in, String directory) throws IOException {
+        this(in, directory, DataformatAwareCatalogSnapshot.CURRENT_SERIALIZATION_VERSION);
+    }
+
+    private static Map<String, Map<String, String>> readPerFileMetadata(StreamInput in) throws IOException {
+        try {
+            return in.readMap(StreamInput::readString, stream -> stream.readMap(StreamInput::readString, StreamInput::readString));
+        } catch (EOFException e) {
+            // Older snapshots may not contain per-file metadata; treat as empty.
+            return Map.of();
+        }
     }
 
     public String directory() {
@@ -91,6 +131,14 @@ public sealed class WriterFileSet implements Writeable permits MonoFileWriterSet
         return formatVersion;
     }
 
+    public Map<String, Map<String, String>> perFileMetadata() {
+        return perFileMetadata;
+    }
+
+    public Map<String, String> metadataForFile(String fileName) {
+        return perFileMetadata.getOrDefault(fileName, Map.of());
+    }
+
     public long getTotalSize() {
         return files.stream().mapToLong(file -> {
             try {
@@ -111,6 +159,8 @@ public sealed class WriterFileSet implements Writeable permits MonoFileWriterSet
             + files
             + ", formatVersion="
             + formatVersion
+            + ", metadataFiles="
+            + perFileMetadata.keySet()
             + '}';
     }
 
@@ -120,6 +170,11 @@ public sealed class WriterFileSet implements Writeable permits MonoFileWriterSet
         out.writeStringCollection(files);
         out.writeLong(numRows);
         out.writeLong(formatVersion);
+        out.writeMap(
+            perFileMetadata,
+            StreamOutput::writeString,
+            (stream, metadata) -> stream.writeMap(metadata, StreamOutput::writeString, StreamOutput::writeString)
+        );
     }
 
     @Override
@@ -160,6 +215,7 @@ public sealed class WriterFileSet implements Writeable permits MonoFileWriterSet
         private long numRows;
         private long formatVersion = 0L;
         private final Set<String> files = new HashSet<>();
+        private final Map<String, Map<String, String>> perFileMetadata = new HashMap<>();
 
         public Builder directory(Path directory) {
             this.directory = directory;
@@ -191,6 +247,18 @@ public sealed class WriterFileSet implements Writeable permits MonoFileWriterSet
             return this;
         }
 
+        public Builder addFileMetadata(String fileName, Map<String, String> metadata) {
+            this.perFileMetadata.put(fileName, Map.copyOf(metadata));
+            return this;
+        }
+
+        public Builder addPerFileMetadata(Map<String, Map<String, String>> metadataByFile) {
+            for (Map.Entry<String, Map<String, String>> entry : metadataByFile.entrySet()) {
+                addFileMetadata(entry.getKey(), entry.getValue());
+            }
+            return this;
+        }
+
         public WriterFileSet build() {
             if (directory == null) {
                 throw new IllegalStateException("directory must be set");
@@ -200,7 +268,7 @@ public sealed class WriterFileSet implements Writeable permits MonoFileWriterSet
                 throw new IllegalStateException("writerGeneration must be set");
             }
 
-            return new WriterFileSet(directory.toString(), writerGeneration, files, numRows, formatVersion);
+            return new WriterFileSet(directory.toString(), writerGeneration, files, numRows, formatVersion, perFileMetadata);
         }
     }
 }

--- a/server/src/main/java/org/opensearch/index/engine/exec/WriterFileSet.java
+++ b/server/src/main/java/org/opensearch/index/engine/exec/WriterFileSet.java
@@ -16,12 +16,9 @@ import org.opensearch.core.common.io.stream.Writeable;
 import org.opensearch.index.engine.exec.coord.DataformatAwareCatalogSnapshot;
 import org.opensearch.index.engine.exec.coord.LuceneVersionConverter;
 
-import java.io.EOFException;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
 
 /**
@@ -48,35 +45,13 @@ public sealed class WriterFileSet implements Writeable permits MonoFileWriterSet
     private final Set<String> files;
     private final long numRows;
     private final long formatVersion;
-    private final Map<String, Map<String, String>> perFileMetadata;
 
     public WriterFileSet(String directory, long writerGeneration, Set<String> files, long numRows, long formatVersion) {
-        this(directory, writerGeneration, files, numRows, formatVersion, Map.of());
-    }
-
-    /** Convenience constructor (no formatVersion, with perFileMetadata). */
-    public WriterFileSet(String directory, long writerGeneration, Set<String> files, long numRows, Map<String, Map<String, String>> perFileMetadata) {
-        this(directory, writerGeneration, files, numRows, 0L, perFileMetadata);
-    }
-
-    public WriterFileSet(
-        String directory,
-        long writerGeneration,
-        Set<String> files,
-        long numRows,
-        long formatVersion,
-        Map<String, Map<String, String>> perFileMetadata
-    ) {
         this.directory = directory;
         this.writerGeneration = writerGeneration;
         this.files = Set.copyOf(files);
         this.numRows = numRows;
         this.formatVersion = formatVersion;
-        Map<String, Map<String, String>> normalizedMetadata = new HashMap<>();
-        for (Map.Entry<String, Map<String, String>> entry : perFileMetadata.entrySet()) {
-            normalizedMetadata.put(entry.getKey(), Map.copyOf(entry.getValue()));
-        }
-        this.perFileMetadata = Map.copyOf(normalizedMetadata);
     }
 
     /**
@@ -94,21 +69,6 @@ public sealed class WriterFileSet implements Writeable permits MonoFileWriterSet
         this.formatVersion = version == DataformatAwareCatalogSnapshot.SERIALIZATION_VERSION_ONE
             ? in.readLong()
             : LuceneVersionConverter.encode(Version.LATEST);
-        this.perFileMetadata = readPerFileMetadata(in);
-    }
-
-    /** Deserializes using the current serialization version. */
-    public WriterFileSet(StreamInput in, String directory) throws IOException {
-        this(in, directory, DataformatAwareCatalogSnapshot.CURRENT_SERIALIZATION_VERSION);
-    }
-
-    private static Map<String, Map<String, String>> readPerFileMetadata(StreamInput in) throws IOException {
-        try {
-            return in.readMap(StreamInput::readString, stream -> stream.readMap(StreamInput::readString, StreamInput::readString));
-        } catch (EOFException e) {
-            // Older snapshots may not contain per-file metadata; treat as empty.
-            return Map.of();
-        }
     }
 
     public String directory() {
@@ -131,14 +91,6 @@ public sealed class WriterFileSet implements Writeable permits MonoFileWriterSet
         return formatVersion;
     }
 
-    public Map<String, Map<String, String>> perFileMetadata() {
-        return perFileMetadata;
-    }
-
-    public Map<String, String> metadataForFile(String fileName) {
-        return perFileMetadata.getOrDefault(fileName, Map.of());
-    }
-
     public long getTotalSize() {
         return files.stream().mapToLong(file -> {
             try {
@@ -159,8 +111,6 @@ public sealed class WriterFileSet implements Writeable permits MonoFileWriterSet
             + files
             + ", formatVersion="
             + formatVersion
-            + ", metadataFiles="
-            + perFileMetadata.keySet()
             + '}';
     }
 
@@ -170,11 +120,6 @@ public sealed class WriterFileSet implements Writeable permits MonoFileWriterSet
         out.writeStringCollection(files);
         out.writeLong(numRows);
         out.writeLong(formatVersion);
-        out.writeMap(
-            perFileMetadata,
-            StreamOutput::writeString,
-            (stream, metadata) -> stream.writeMap(metadata, StreamOutput::writeString, StreamOutput::writeString)
-        );
     }
 
     @Override
@@ -215,7 +160,6 @@ public sealed class WriterFileSet implements Writeable permits MonoFileWriterSet
         private long numRows;
         private long formatVersion = 0L;
         private final Set<String> files = new HashSet<>();
-        private final Map<String, Map<String, String>> perFileMetadata = new HashMap<>();
 
         public Builder directory(Path directory) {
             this.directory = directory;
@@ -247,18 +191,6 @@ public sealed class WriterFileSet implements Writeable permits MonoFileWriterSet
             return this;
         }
 
-        public Builder addFileMetadata(String fileName, Map<String, String> metadata) {
-            this.perFileMetadata.put(fileName, Map.copyOf(metadata));
-            return this;
-        }
-
-        public Builder addPerFileMetadata(Map<String, Map<String, String>> metadataByFile) {
-            for (Map.Entry<String, Map<String, String>> entry : metadataByFile.entrySet()) {
-                addFileMetadata(entry.getKey(), entry.getValue());
-            }
-            return this;
-        }
-
         public WriterFileSet build() {
             if (directory == null) {
                 throw new IllegalStateException("directory must be set");
@@ -268,7 +200,7 @@ public sealed class WriterFileSet implements Writeable permits MonoFileWriterSet
                 throw new IllegalStateException("writerGeneration must be set");
             }
 
-            return new WriterFileSet(directory.toString(), writerGeneration, files, numRows, formatVersion, perFileMetadata);
+            return new WriterFileSet(directory.toString(), writerGeneration, files, numRows, formatVersion);
         }
     }
 }

--- a/server/src/test/java/org/opensearch/index/engine/exec/WriterFileSetTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/exec/WriterFileSetTests.java
@@ -14,7 +14,6 @@ import org.opensearch.test.OpenSearchTestCase;
 
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
 
 /**
@@ -49,26 +48,6 @@ public class WriterFileSetTests extends OpenSearchTestCase {
         assertEquals(original.writerGeneration(), deserialized.writerGeneration());
         assertEquals(original.files(), deserialized.files());
         assertEquals(original.numRows(), deserialized.numRows());
-        assertEquals(original.perFileMetadata(), deserialized.perFileMetadata());
-    }
-
-    public void testPerFileMetadataRoundTrip() throws Exception {
-        WriterFileSet original = new WriterFileSet(
-            "/tmp/original",
-            3L,
-            Set.of("_0.parquet"),
-            42L,
-            Map.of("_0.parquet", Map.of("opensearch.pme.encrypted", "true", "opensearch.pme.kms.instance_id", "kms-1"))
-        );
-
-        WriterFileSet deserialized = copyWriteable(
-            original,
-            new NamedWriteableRegistry(Collections.emptyList()),
-            in -> new WriterFileSet(in, "/tmp/other")
-        );
-
-        assertEquals(original.perFileMetadata(), deserialized.perFileMetadata());
-        assertEquals("true", deserialized.metadataForFile("_0.parquet").get("opensearch.pme.encrypted"));
     }
 
     public void testStreamRoundTripPreservesFormatVersion() throws Exception {
@@ -95,9 +74,6 @@ public class WriterFileSetTests extends OpenSearchTestCase {
         for (int i = 0; i < fileCount; i++) {
             files.add(randomAlphaOfLength(6) + "." + randomFrom("cfs", "si", "dat", "parquet"));
         }
-        Map<String, Map<String, String>> metadata = randomBoolean()
-            ? Map.of()
-            : Map.of(files.iterator().next(), Map.of("opensearch.pme.encrypted", "true"));
-        return new WriterFileSet(directory, randomNonNegativeLong(), files, randomIntBetween(0, 10000), 0L, metadata);
+        return new WriterFileSet(directory, randomNonNegativeLong(), files, randomIntBetween(0, 10000), 0L);
     }
 }

--- a/server/src/test/java/org/opensearch/index/engine/exec/WriterFileSetTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/exec/WriterFileSetTests.java
@@ -14,6 +14,7 @@ import org.opensearch.test.OpenSearchTestCase;
 
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -48,6 +49,26 @@ public class WriterFileSetTests extends OpenSearchTestCase {
         assertEquals(original.writerGeneration(), deserialized.writerGeneration());
         assertEquals(original.files(), deserialized.files());
         assertEquals(original.numRows(), deserialized.numRows());
+        assertEquals(original.perFileMetadata(), deserialized.perFileMetadata());
+    }
+
+    public void testPerFileMetadataRoundTrip() throws Exception {
+        WriterFileSet original = new WriterFileSet(
+            "/tmp/original",
+            3L,
+            Set.of("_0.parquet"),
+            42L,
+            Map.of("_0.parquet", Map.of("opensearch.pme.encrypted", "true", "opensearch.pme.kms.instance_id", "kms-1"))
+        );
+
+        WriterFileSet deserialized = copyWriteable(
+            original,
+            new NamedWriteableRegistry(Collections.emptyList()),
+            in -> new WriterFileSet(in, "/tmp/other")
+        );
+
+        assertEquals(original.perFileMetadata(), deserialized.perFileMetadata());
+        assertEquals("true", deserialized.metadataForFile("_0.parquet").get("opensearch.pme.encrypted"));
     }
 
     public void testStreamRoundTripPreservesFormatVersion() throws Exception {
@@ -74,6 +95,9 @@ public class WriterFileSetTests extends OpenSearchTestCase {
         for (int i = 0; i < fileCount; i++) {
             files.add(randomAlphaOfLength(6) + "." + randomFrom("cfs", "si", "dat", "parquet"));
         }
-        return new WriterFileSet(directory, randomNonNegativeLong(), files, randomIntBetween(0, 10000), 0L);
+        Map<String, Map<String, String>> metadata = randomBoolean()
+            ? Map.of()
+            : Map.of(files.iterator().next(), Map.of("opensearch.pme.encrypted", "true"));
+        return new WriterFileSet(directory, randomNonNegativeLong(), files, randomIntBetween(0, 10000), 0L, metadata);
     }
 }

--- a/server/src/test/java/org/opensearch/index/engine/exec/coord/DataformatAwareCatalogSnapshotTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/exec/coord/DataformatAwareCatalogSnapshotTests.java
@@ -458,7 +458,7 @@ public class DataformatAwareCatalogSnapshotTests extends OpenSearchTestCase {
         for (int i = 0; i < fileCount; i++) {
             files.add(randomAlphaOfLength(6) + "." + randomFrom(extensions));
         }
-        return new WriterFileSet(directory, writerGeneration, files, randomIntBetween(0, 10000), 0L, randomPerFileMetadata(files));
+        return new WriterFileSet(directory, writerGeneration, files, randomIntBetween(0, 10000), 0L);
     }
 
     private Segment randomSegment() {
@@ -540,15 +540,7 @@ public class DataformatAwareCatalogSnapshotTests extends OpenSearchTestCase {
         for (int i = 0; i < fileCount; i++) {
             files.add(randomAlphaOfLength(6) + "." + randomFrom(extensions));
         }
-        return new WriterFileSet(directory, writerGeneration, files, randomIntBetween(0, 10000), 0L, randomPerFileMetadata(files));
-    }
-
-    private Map<String, Map<String, String>> randomPerFileMetadata(Set<String> files) {
-        if (randomBoolean()) {
-            return Map.of();
-        }
-        String file = randomFrom(files.toArray(new String[0]));
-        return Map.of(file, Map.of("opensearch.pme.encrypted", "true", "opensearch.pme.kms.instance_id", randomAlphaOfLength(5)));
+        return new WriterFileSet(directory, writerGeneration, files, randomIntBetween(0, 10000), 0L);
     }
 
     private void assertSnapshotFieldsEqual(String context, DataformatAwareCatalogSnapshot expected, DataformatAwareCatalogSnapshot actual) {
@@ -587,7 +579,6 @@ public class DataformatAwareCatalogSnapshotTests extends OpenSearchTestCase {
                 assertEquals(context + ": writerGeneration", expectedWfs.writerGeneration(), actualWfs.writerGeneration());
                 assertEquals(context + ": files", expectedWfs.files(), actualWfs.files());
                 assertEquals(context + ": numRows", expectedWfs.numRows(), actualWfs.numRows());
-                assertEquals(context + ": perFileMetadata", expectedWfs.perFileMetadata(), actualWfs.perFileMetadata());
             }
         }
         assertEquals(context + ": lastWriterGeneration", expected.getLastWriterGeneration(), actual.getLastWriterGeneration());

--- a/server/src/test/java/org/opensearch/index/engine/exec/coord/DataformatAwareCatalogSnapshotTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/exec/coord/DataformatAwareCatalogSnapshotTests.java
@@ -458,7 +458,7 @@ public class DataformatAwareCatalogSnapshotTests extends OpenSearchTestCase {
         for (int i = 0; i < fileCount; i++) {
             files.add(randomAlphaOfLength(6) + "." + randomFrom(extensions));
         }
-        return new WriterFileSet(directory, writerGeneration, files, randomIntBetween(0, 10000), 0L);
+        return new WriterFileSet(directory, writerGeneration, files, randomIntBetween(0, 10000), 0L, randomPerFileMetadata(files));
     }
 
     private Segment randomSegment() {
@@ -540,7 +540,15 @@ public class DataformatAwareCatalogSnapshotTests extends OpenSearchTestCase {
         for (int i = 0; i < fileCount; i++) {
             files.add(randomAlphaOfLength(6) + "." + randomFrom(extensions));
         }
-        return new WriterFileSet(directory, writerGeneration, files, randomIntBetween(0, 10000), 0L);
+        return new WriterFileSet(directory, writerGeneration, files, randomIntBetween(0, 10000), 0L, randomPerFileMetadata(files));
+    }
+
+    private Map<String, Map<String, String>> randomPerFileMetadata(Set<String> files) {
+        if (randomBoolean()) {
+            return Map.of();
+        }
+        String file = randomFrom(files.toArray(new String[0]));
+        return Map.of(file, Map.of("opensearch.pme.encrypted", "true", "opensearch.pme.kms.instance_id", randomAlphaOfLength(5)));
     }
 
     private void assertSnapshotFieldsEqual(String context, DataformatAwareCatalogSnapshot expected, DataformatAwareCatalogSnapshot actual) {
@@ -579,6 +587,7 @@ public class DataformatAwareCatalogSnapshotTests extends OpenSearchTestCase {
                 assertEquals(context + ": writerGeneration", expectedWfs.writerGeneration(), actualWfs.writerGeneration());
                 assertEquals(context + ": files", expectedWfs.files(), actualWfs.files());
                 assertEquals(context + ": numRows", expectedWfs.numRows(), actualWfs.numRows());
+                assertEquals(context + ": perFileMetadata", expectedWfs.perFileMetadata(), actualWfs.perFileMetadata());
             }
         }
         assertEquals(context + ": lastWriterGeneration", expected.getLastWriterGeneration(), actual.getLastWriterGeneration());


### PR DESCRIPTION

### Description

This is a *draft* pull request containing a prototypical implementation of read and write paths for encrypted Parquet files.

This shall be the basis for finalizing decisions around the following topics:

- Key derivation algorithm
- Encryption algorithm
- Format of PME footer
- Format of PME AAD data
- etc

A RFC issue will follow up shortly after the issue for providing a suitable space for discussing these topics and documenting decisions.

#### Limitations

Note: This is so far not production ready. This is caused also by the following reasons:

- The currently used parquet-rs library only supports AES with 128 bit keys. It does not support 256 bit keys. A fix for this might be introduced along with https://github.com/apache/arrow-rs/issues/9202 released in parquet-rs  version 59
- The implementation cannot reuse flags from [opensearch-storage-encryption](https://github.com/opensearch-project/opensearch-storage-encryption) (the "Lucene plugin"). At the moment, these flags are doubled up and adapted to Parquet. A consolidated impl will be necessary.
- Testing is just done with ad-hoc methods, also a here a consolidated approach will be necessary, especially regarding the KMS provider.

#### Unexpected behaviors

These are not necessarily issues. Yet, people should be aware of it to allow for discussion.

- parquet-rx supports only AES-GCM encryption format, not the AES-GCM-CTR: This is actually fine, the encryption with AES-GCM only happens on the block level. Thus, no further measures are necessary to support block level access to encrypted files.
- This mirrors a behavioral oddity already implemented by the [opensearch-storage-encryption](https://github.com/opensearch-project/opensearch-storage-encryption) plugin. The encrypted KMS key is saved in an index specific dir of the current node. However, there is no sync mechanism between nodes. Effectively, that means that each node has its own disticnt KMS keys. This might be no actual problem, but it is odd.



### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
