### PR TITLE
Return 400 for deeply nested queries exceeding protobuf recursion limit

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionSearcher.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionSearcher.java
@@ -73,6 +73,13 @@ public class DatafusionSearcher implements EngineSearcher<DatafusionContext> {
         try {
             streamPtr = future.join();
         } catch (Exception exception) {
+            if (containsRecursionLimit(exception)) {
+                throw new IllegalArgumentException(
+                    "Query too deeply nested: the expression exceeds the maximum nesting depth supported by the execution engine. "
+                        + "Simplify the query by reducing nested function calls.",
+                    exception
+                );
+            }
             throw new IOException("Query execution with session context failed", exception);
         }
         // NativeBridge#executeWithContextAsync has already marked the handle consumed (which
@@ -130,5 +137,18 @@ public class DatafusionSearcher implements EngineSearcher<DatafusionContext> {
     public void close() {
         // ReaderHandle lifecycle is owned by DatafusionReader / EngineReaderManager,
         // not by the searcher. Do not close it here.
+    }
+
+    // TODO: Handle recursion limit on the Rust side (e.g. increase prost decode limit or
+    // return a structured error code) so Java doesn't need to pattern-match on error messages.
+    private static boolean containsRecursionLimit(Throwable t) {
+        for (int depth = 0; t != null && depth < NativeErrorConverter.MAX_CAUSE_CHAIN_DEPTH; depth++) {
+            String msg = t.getMessage();
+            if (msg != null && msg.contains("recursion limit reached")) {
+                return true;
+            }
+            t = t.getCause();
+        }
+        return false;
     }
 }

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/NativeErrorConverter.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/NativeErrorConverter.java
@@ -53,9 +53,15 @@ public final class NativeErrorConverter {
      * Registered error patterns, checked in order. First match wins.
      * Key phrases correspond to stable prefixes in Rust native_error.rs.
      */
+    /**
+     * Maximum depth to walk the exception cause chain when matching error patterns.
+     */
+    static final int MAX_CAUSE_CHAIN_DEPTH = 10;
+
     private static final List<ErrorPattern> PATTERNS = List.of(
         new ErrorPattern("Cannot reserve untracked memory budget", NativeErrorConverter::convertAdmissionRejection),
-        new ErrorPattern("Failed to allocate", NativeErrorConverter::convertPoolLimitExceeded)
+        new ErrorPattern("Failed to allocate", NativeErrorConverter::convertPoolLimitExceeded),
+        new ErrorPattern("Query too deeply nested", NativeErrorConverter::convertRecursionLimit)
     );
 
     /**
@@ -70,7 +76,7 @@ public final class NativeErrorConverter {
         }
         Throwable current = original;
         int depth = 0;
-        while (current != null && depth < 10) {
+        while (current != null && depth < MAX_CAUSE_CHAIN_DEPTH) {
             String msg = current.getMessage();
             if (msg != null) {
                 for (ErrorPattern pattern : PATTERNS) {
@@ -107,6 +113,15 @@ public final class NativeErrorConverter {
         );
         rejection.initCause(match.original());
         return rejection;
+    }
+
+    private static Exception convertRecursionLimit(MatchedError match) {
+        IllegalArgumentException iae = new IllegalArgumentException(
+            "Query too deeply nested: the expression exceeds the maximum nesting depth supported by the execution engine. "
+                + "Simplify the query by reducing nested function calls."
+        );
+        iae.initCause(match.original());
+        return iae;
     }
 
     // ─── Message parsing ────────────────────────────────────────────────────────

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/NestedQueryRecursionLimitIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/NestedQueryRecursionLimitIT.java
@@ -1,0 +1,109 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.qa;
+
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+import org.opensearch.client.ResponseException;
+
+/**
+ * Integration test verifying that deeply nested PPL expressions return a 400 error
+ * with a meaningful message instead of a 500 internal server error.
+ *
+ * <p>Reproduces: https://github.com/opensearch-project/OpenSearch/issues/XXXXX
+ * Root cause: prost protobuf decoder recursion limit (default 100) is exceeded when
+ * Substrait plan has 31+ nested ScalarFunction calls (each adds ~3 protobuf nesting levels).
+ */
+public class NestedQueryRecursionLimitIT extends AnalyticsRestTestCase {
+
+    private static final String INDEX = "nested_recursion_test";
+
+    public void testDeeplyNestedQueryReturns400() throws Exception {
+        createIndex();
+        indexData();
+
+        // 50 nested calls should fail with 400 (not 500)
+        String deep = buildNestedExpr(50);
+        Request badRequest = new Request("POST", "/_analytics/ppl");
+        badRequest.setJsonEntity("{\"query\": \"source=" + INDEX + " | eval result = " + deep + "\"}");
+        try {
+            client().performRequest(badRequest);
+            fail("Expected 400 error for deeply nested query");
+        } catch (ResponseException e) {
+            int status = e.getResponse().getStatusLine().getStatusCode();
+            assertTrue(
+                "Expected 400 but got " + status + ": " + e.getMessage(),
+                status == 400
+            );
+            String body = new String(e.getResponse().getEntity().getContent().readAllBytes(), java.nio.charset.StandardCharsets.UTF_8);
+            assertTrue(
+                "Error should mention nesting depth, got: " + body,
+                body.contains("too deeply nested") || body.contains("nesting depth")
+            );
+        }
+    }
+
+    private String buildNestedExpr(int depth) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < depth; i++) {
+            sb.append(i % 2 == 0 ? "ceil(" : "floor(");
+        }
+        sb.append("value");
+        for (int i = 0; i < depth; i++) {
+            sb.append(")");
+        }
+        return sb.toString();
+    }
+
+    private void createIndex() throws Exception {
+        try {
+            client().performRequest(new Request("DELETE", "/" + INDEX));
+        } catch (ResponseException e) {
+            if (e.getResponse().getStatusLine().getStatusCode() != 404) throw e;
+        } catch (Exception ignored) {}
+
+        Request create = new Request("PUT", "/" + INDEX);
+        create.setJsonEntity("{"
+            + "\"settings\": {"
+            + "  \"index.number_of_shards\": 1,"
+            + "  \"index.number_of_replicas\": 0,"
+            + "  \"index.pluggable.dataformat.enabled\": true,"
+            + "  \"index.pluggable.dataformat\": \"composite\","
+            + "  \"index.composite.primary_data_format\": \"parquet\","
+            + "  \"index.composite.secondary_data_formats\": [\"lucene\"]"
+            + "},"
+            + "\"mappings\": {"
+            + "  \"properties\": {"
+            + "    \"value\": {\"type\": \"double\"}"
+            + "  }"
+            + "}"
+            + "}");
+        client().performRequest(create);
+    }
+
+    private void indexData() throws Exception {
+        Request bulk = new Request("POST", "/" + INDEX + "/_bulk");
+        bulk.addParameter("refresh", "true");
+        bulk.setJsonEntity(
+            "{\"index\":{}}\n{\"value\":3.7}\n"
+                + "{\"index\":{}}\n{\"value\":8.2}\n"
+                + "{\"index\":{}}\n{\"value\":1.5}\n"
+        );
+        client().performRequest(bulk);
+
+        Request flush = new Request("POST", "/" + INDEX + "/_flush");
+        flush.addParameter("force", "true");
+        client().performRequest(flush);
+
+        Request health = new Request("GET", "/_cluster/health/" + INDEX);
+        health.addParameter("wait_for_status", "yellow");
+        health.addParameter("timeout", "30s");
+        client().performRequest(health);
+    }
+}


### PR DESCRIPTION
### Description

Queries with 31+ nested function calls (e.g. `ceil(floor(ceil(...)))`) cause the prost protobuf decoder on the data node to hit its recursion limit when decoding the Substrait plan. Previously this surfaced as an opaque 500 `Stage 0 failed` error. Two fixes added:

- (`AnalyticsSearchService`): detects `recursion limit reached` in the native exception cause chain and throws `IllegalArgumentException` (HTTP 400) with a user-friendly message before the error crosses the gRPC boundary.

- (`NativeErrorConverter`): adds pattern for `Query too deeply nested` so the coordinator-side `convertException()` maps these to `IllegalArgumentException` (400).

