### PR TITLE
[dup PR] [analytics] Add per-backend delegation predicate block-list setting

### DIFF
--- a/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/ScalarFunction.java
+++ b/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/ScalarFunction.java
@@ -444,6 +444,19 @@ public enum ScalarFunction {
     }
 
     /**
+     * Resolves a configuration/setting token (case-insensitive) to a {@link ScalarFunction}, throwing
+     * a descriptive {@link IllegalArgumentException} if unrecognized. Used by cluster settings that
+     * name predicate functions (e.g. the delegation block-list).
+     */
+    public static ScalarFunction fromToken(String token) {
+        try {
+            return valueOf(token.trim().toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Unknown scalar function [" + token + "]");
+        }
+    }
+
+    /**
      * Maps a Calcite SqlFunction to a ScalarFunction by name, or null if not recognized.
      */
     public static ScalarFunction fromSqlFunction(SqlFunction function) {

--- a/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/SqlLikePattern.java
+++ b/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/SqlLikePattern.java
@@ -1,0 +1,91 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.spi;
+
+/**
+ * Escape-aware classifier for SQL {@code LIKE} patterns, shared by the marking layer (to map a LIKE
+ * predicate onto the {@code PREFIX} vs {@code LIKE} block-list vocabulary) and the Lucene LIKE
+ * serializer (to choose {@code PrefixQuery} vs {@code WildcardQuery}). Centralizing the shape logic
+ * keeps those two consumers in lockstep.
+ *
+ * <p>SQL {@code LIKE} wildcards: {@code %} matches any run of characters, {@code _} matches exactly one.
+ * The default escape character is backslash ({@code \}); {@code \%}, {@code \_}, {@code \\} are literal.
+ *
+ * <p>A pattern is {@link Shape#PREFIX} iff it is literal text followed by exactly one trailing
+ * {@code %} and contains no other unescaped wildcard (no {@code _}, no other {@code %}). Such a pattern
+ * is answerable by a prefix scan of the term dictionary. Everything else (leading/embedded {@code %},
+ * any {@code _}, or no wildcard at all) is {@link Shape#GENERAL}.
+ *
+ * @opensearch.internal
+ */
+public final class SqlLikePattern {
+
+    /** The shape of a LIKE pattern, used to pick the cheapest equivalent Lucene query. */
+    public enum Shape {
+        /** literal-prefix + single trailing {@code %} → {@code PrefixQuery}. */
+        PREFIX,
+        /** any other wildcard layout → {@code WildcardQuery}. */
+        GENERAL
+    }
+
+    private static final char ESCAPE = '\\';
+    private static final char PCT = '%';
+    private static final char UNDERSCORE = '_';
+
+    private SqlLikePattern() {}
+
+    /** Classify a SQL LIKE pattern's shape. */
+    public static Shape classify(String pattern) {
+        int unescapedPct = 0;
+        boolean trailingPct = false;
+        boolean escaped = false;
+        for (int i = 0; i < pattern.length(); i++) {
+            char c = pattern.charAt(i);
+            if (escaped) {
+                escaped = false; // this char is a literal
+                continue;
+            }
+            if (c == ESCAPE) {
+                escaped = true;
+            } else if (c == UNDERSCORE) {
+                return Shape.GENERAL; // single-char wildcard → not a pure prefix
+            } else if (c == PCT) {
+                unescapedPct++;
+                trailingPct = (i == pattern.length() - 1);
+            }
+        }
+        return (unescapedPct == 1 && trailingPct) ? Shape.PREFIX : Shape.GENERAL;
+    }
+
+    /**
+     * For a {@link Shape#PREFIX} pattern, the literal prefix with escapes resolved (e.g. {@code "fo\%o%"}
+     * → {@code "fo%o"}). Behavior is undefined for non-PREFIX patterns; callers should classify first.
+     */
+    public static String prefixLiteral(String pattern) {
+        StringBuilder sb = new StringBuilder(pattern.length());
+        boolean escaped = false;
+        for (int i = 0; i < pattern.length(); i++) {
+            char c = pattern.charAt(i);
+            if (escaped) {
+                sb.append(c);
+                escaped = false;
+            } else if (c == ESCAPE) {
+                escaped = true;
+            } else if (c == PCT) {
+                break; // the single trailing % terminates the literal prefix
+            } else {
+                sb.append(c);
+            }
+        }
+        if (escaped) {
+            sb.append(ESCAPE); // dangling trailing backslash — preserve literally
+        }
+        return sb.toString();
+    }
+}

--- a/sandbox/libs/analytics-framework/src/test/java/org/opensearch/analytics/spi/ScalarFunctionTests.java
+++ b/sandbox/libs/analytics-framework/src/test/java/org/opensearch/analytics/spi/ScalarFunctionTests.java
@@ -224,4 +224,21 @@ public class ScalarFunctionTests extends OpenSearchTestCase {
         assertNotNull("fromSqlFunction must resolve known names", resolved);
         assertSame(ScalarFunction.UPPER, resolved);
     }
+
+    // ── fromToken: case-insensitive token resolution ───────────────────────────────────────
+
+    public void testFromTokenCaseInsensitive() {
+        // fromToken trims surrounding whitespace and upper-cases before valueOf.
+        assertSame(ScalarFunction.LIKE, ScalarFunction.fromToken("like"));
+        assertSame(ScalarFunction.LIKE, ScalarFunction.fromToken("LIKE"));
+        assertSame(ScalarFunction.EQUALS, ScalarFunction.fromToken("  Equals "));
+    }
+
+    public void testFromTokenRejectsUnknown() {
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> ScalarFunction.fromToken("NOPE"));
+        assertTrue(
+            "exception message must mention the failure, got: " + e.getMessage(),
+            e.getMessage().contains("Unknown scalar function")
+        );
+    }
 }

--- a/sandbox/libs/analytics-framework/src/test/java/org/opensearch/analytics/spi/SqlLikePatternTests.java
+++ b/sandbox/libs/analytics-framework/src/test/java/org/opensearch/analytics/spi/SqlLikePatternTests.java
@@ -1,0 +1,38 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.spi;
+
+import org.opensearch.test.OpenSearchTestCase;
+
+public class SqlLikePatternTests extends OpenSearchTestCase {
+
+    public void testPrefixShape() {
+        assertEquals(SqlLikePattern.Shape.PREFIX, SqlLikePattern.classify("foo%"));
+        assertEquals(SqlLikePattern.Shape.PREFIX, SqlLikePattern.classify("a%"));
+        // escaped percent before the single trailing wildcard is still a prefix
+        assertEquals(SqlLikePattern.Shape.PREFIX, SqlLikePattern.classify("fo\\%o%"));
+    }
+
+    public void testGeneralShapes() {
+        assertEquals("leading wildcard", SqlLikePattern.Shape.GENERAL, SqlLikePattern.classify("%foo"));
+        assertEquals("embedded wildcard", SqlLikePattern.Shape.GENERAL, SqlLikePattern.classify("f%o%"));
+        assertEquals("contains-style", SqlLikePattern.Shape.GENERAL, SqlLikePattern.classify("%foo%"));
+        assertEquals("underscore present", SqlLikePattern.Shape.GENERAL, SqlLikePattern.classify("fo_%"));
+        assertEquals("single underscore", SqlLikePattern.Shape.GENERAL, SqlLikePattern.classify("on_"));
+        assertEquals("no wildcard at all", SqlLikePattern.Shape.GENERAL, SqlLikePattern.classify("exact"));
+        // fully escaped percent → no real wildcard → GENERAL (no prefix scan applies)
+        assertEquals("escaped trailing percent is literal", SqlLikePattern.Shape.GENERAL, SqlLikePattern.classify("foo\\%"));
+    }
+
+    public void testPrefixLiteralResolvesEscapes() {
+        assertEquals("foo", SqlLikePattern.prefixLiteral("foo%"));
+        assertEquals("fo%o", SqlLikePattern.prefixLiteral("fo\\%o%"));
+        assertEquals("a_b", SqlLikePattern.prefixLiteral("a\\_b%"));
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/api.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/api.rs
@@ -1199,8 +1199,13 @@ fn derive_schema_from_partial_plan(
         DataFusionError::Execution(format!("derive_schema_from_partial_plan: decode failed: {}", e))
     })?;
 
+    let mut config = SessionConfig::new();
+    // Match the indexed executor's single-partition behavior so partial_aggregate_schema
+    // never finds a spurious Partial node (which would incorrectly declare Binary HLL state
+    // while the data node emits Int64 finalized output via Mode::Default).
+    config.options_mut().execution.target_partitions = 1;
     let state = SessionStateBuilder::new()
-        .with_config(SessionConfig::new())
+        .with_config(config)
         .with_default_features()
         .with_physical_optimizer_rules(crate::agg_mode::physical_optimizer_rules_without_combine())
         .build();

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/substrait_to_tree.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/substrait_to_tree.rs
@@ -90,11 +90,17 @@ pub struct ExtractionResult {
 
 /// Extract the filter expression from a DataFusion logical plan.
 ///
-/// Walks down through Projection/SubqueryAlias/etc. nodes to find the first
-/// `Filter` node. Returns `None` if there's no filter.
+/// Returns the SCAN-LEVEL filter predicate, or `None`. A `Filter` qualifies only when its input
+/// reaches a `TableScan` through schema-preserving nodes; a `Filter` above an `Aggregate` is a
+/// HAVING predicate over aggregate outputs (e.g. `count(Int64(1)) > 0`) and must NOT be returned —
+/// lowering it against the raw scan schema fails with "No field named ...". A HAVING filter is
+/// skipped while still descending past the aggregate to find the real WHERE filter below it.
 pub fn extract_filter_expr(plan: &LogicalPlan) -> Option<Expr> {
     match plan {
-        LogicalPlan::Filter(filter) => Some(filter.predicate.clone()),
+        LogicalPlan::Filter(filter) if reaches_scan_without_schema_change(filter.input.as_ref()) => {
+            Some(filter.predicate.clone())
+        }
+        // Anything else (HAVING Filter, Aggregate, Projection, ...): descend into inputs.
         _ => {
             for child in plan.inputs() {
                 if let Some(expr) = extract_filter_expr(child) {
@@ -103,6 +109,21 @@ pub fn extract_filter_expr(plan: &LogicalPlan) -> Option<Expr> {
             }
             None
         }
+    }
+}
+
+/// True if `plan` is a `TableScan` reachable through only schema-preserving pass-through nodes
+/// (Filter / Projection / SubqueryAlias / Sort / Limit) — i.e. no Aggregate/Window/Join/Union in
+/// between. Used to decide whether a `Filter`'s predicate is expressed over the scan schema.
+fn reaches_scan_without_schema_change(plan: &LogicalPlan) -> bool {
+    match plan {
+        LogicalPlan::TableScan(_) => true,
+        LogicalPlan::Filter(_)
+        | LogicalPlan::Projection(_)
+        | LogicalPlan::SubqueryAlias(_)
+        | LogicalPlan::Sort(_)
+        | LogicalPlan::Limit(_) => plan.inputs().iter().any(|c| reaches_scan_without_schema_change(c)),
+        _ => false,
     }
 }
 
@@ -755,5 +776,44 @@ mod tests {
             ]),
         ]);
         assert_eq!(classify_filter(&tree), FilterClass::Tree);
+    }
+
+    // ── extract_filter_expr: must return the SCAN-level filter, not a HAVING filter ──
+
+    #[test]
+    fn extract_filter_returns_scan_level_predicate_below_aggregate() {
+        use datafusion::logical_expr::LogicalPlanBuilder;
+        use datafusion::datasource::empty::EmptyTable;
+
+        // Plan: Filter(count(*) > 0)  ← HAVING, over aggregate output
+        //         Aggregate(group=[qty], aggs=[count(*)])
+        //           Filter(price > 100)  ← WHERE, scan-level
+        //             TableScan
+        let provider = Arc::new(EmptyTable::new(test_schema()));
+        let plan = LogicalPlanBuilder::scan("t", provider_as_source(provider), None)
+            .unwrap()
+            .filter(col("price").gt(lit(100i32)))
+            .unwrap()
+            .aggregate(vec![col("qty")], vec![datafusion::functions_aggregate::expr_fn::count(lit(1i64))])
+            .unwrap()
+            .filter(datafusion::functions_aggregate::expr_fn::count(lit(1i64)).gt(lit(0i64)))
+            .unwrap()
+            .build()
+            .unwrap();
+
+        let extracted = extract_filter_expr(&plan).expect("a scan-level filter must be found");
+        // Must be the WHERE predicate (references the scan column `price`), NOT the HAVING
+        // predicate (references the aggregate output count(...)). Asserting the rendered expr
+        // mentions `price` and not `count` pins that we stopped at the Aggregate boundary.
+        let rendered = format!("{extracted}");
+        assert!(rendered.contains("price"), "expected scan-level WHERE on price, got: {rendered}");
+        assert!(!rendered.contains("count"), "must not return the HAVING count() predicate, got: {rendered}");
+    }
+
+    /// EmptyTable as a TableSource for LogicalPlanBuilder::scan.
+    fn provider_as_source(
+        provider: Arc<dyn datafusion::datasource::TableProvider>,
+    ) -> Arc<dyn datafusion::logical_expr::TableSource> {
+        datafusion::datasource::provider_as_source(provider)
     }
 }

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/LuceneAnalyticsBackendPlugin.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/LuceneAnalyticsBackendPlugin.java
@@ -66,9 +66,12 @@ public class LuceneAnalyticsBackendPlugin implements AnalyticsSearchBackendPlugi
     // an IllegalStateException ("No Lucene serializer for [..]"). EQUALS and LIKE have
     // serializers today; range ops, NOT_EQUALS, IS_NULL, IS_NOT_NULL, IN are deferred until
     // their serializers land.
-    // LIKE delegation is a performance pre-filter (DataFusion re-verifies the exact predicate),
-    // so the Lucene query only needs to be a superset of matches; it is governed at runtime by the
-    // analytics.delegation.<backend>.blocked_predicates kill-switch.
+    //
+    // LIKE is a performance pre-filter (DataFusion re-verifies), so the Lucene query only needs to be a
+    // superset. On KEYWORD it runs against the single raw term (correct). On analyzed TEXT a wildcard
+    // matches per-token and can fail in the scan path, so text LIKE is delegated only when the field has
+    // a keyword exact-match subfield to route to (LikeSerializer targets field.<keyword>); the marking
+    // layer (OpenSearchFilterRule) drops delegation for text LIKE without one.
     // TODO: have CapabilityRegistry intersect declared FilterCapability against the
     // backend's serializer keyset at startup so this list can't drift again. The TODO in
     // OpenSearchFilterRule.resolveViableBackends references the same constraint.

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/LuceneAnalyticsBackendPlugin.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/LuceneAnalyticsBackendPlugin.java
@@ -63,13 +63,16 @@ public class LuceneAnalyticsBackendPlugin implements AnalyticsSearchBackendPlugi
     // registered in QuerySerializerRegistry — declaring a capability without a matching
     // DelegatedPredicateSerializer makes the marking layer pick Lucene as viable for
     // operators it can't actually translate, and the failure surfaces at convert time as
-    // an IllegalStateException ("No Lucene serializer for [..]"). Today only EQUALS has
-    // a serializer; range ops, NOT_EQUALS, IS_NULL, IS_NOT_NULL, IN, LIKE are deferred
-    // until their serializers land.
+    // an IllegalStateException ("No Lucene serializer for [..]"). EQUALS and LIKE have
+    // serializers today; range ops, NOT_EQUALS, IS_NULL, IS_NOT_NULL, IN are deferred until
+    // their serializers land.
+    // LIKE delegation is a performance pre-filter (DataFusion re-verifies the exact predicate),
+    // so the Lucene query only needs to be a superset of matches; it is governed at runtime by the
+    // analytics.delegation.<backend>.blocked_predicates kill-switch.
     // TODO: have CapabilityRegistry intersect declared FilterCapability against the
     // backend's serializer keyset at startup so this list can't drift again. The TODO in
     // OpenSearchFilterRule.resolveViableBackends references the same constraint.
-    private static final Set<ScalarFunction> STANDARD_OPS = Set.of(ScalarFunction.EQUALS);
+    private static final Set<ScalarFunction> STANDARD_OPS = Set.of(ScalarFunction.EQUALS, ScalarFunction.LIKE);
 
     private static final Set<ScalarFunction> FULL_TEXT_OPS = Set.of(
         ScalarFunction.MATCH,

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/QuerySerializerRegistry.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/QuerySerializerRegistry.java
@@ -11,6 +11,7 @@ package org.opensearch.be.lucene;
 import org.opensearch.analytics.spi.DelegatedPredicateSerializer;
 import org.opensearch.analytics.spi.ScalarFunction;
 import org.opensearch.be.lucene.serializers.EqualsSerializer;
+import org.opensearch.be.lucene.serializers.LikeSerializer;
 import org.opensearch.be.lucene.serializers.MatchAllSerializer;
 import org.opensearch.be.lucene.serializers.MatchBoolPrefixSerializer;
 import org.opensearch.be.lucene.serializers.MatchPhrasePrefixSerializer;
@@ -42,7 +43,8 @@ final class QuerySerializerRegistry {
         Map.entry(ScalarFunction.WILDCARD_QUERY, new WildcardQuerySerializer()),
         Map.entry(ScalarFunction.QUERY, new QuerySerializer()),
         Map.entry(ScalarFunction.MATCHALL, new MatchAllSerializer()),
-        Map.entry(ScalarFunction.EQUALS, new EqualsSerializer())
+        Map.entry(ScalarFunction.EQUALS, new EqualsSerializer()),
+        Map.entry(ScalarFunction.LIKE, new LikeSerializer())
     );
 
     private QuerySerializerRegistry() {}

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/LikeSerializer.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/LikeSerializer.java
@@ -1,0 +1,119 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.lucene.serializers;
+
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexInputRef;
+import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.fun.SqlLikeOperator;
+import org.opensearch.analytics.spi.FieldStorageInfo;
+import org.opensearch.analytics.spi.SqlLikePattern;
+import org.opensearch.be.lucene.CalciteToOSMapperConversionUtils;
+import org.opensearch.index.query.PrefixQueryBuilder;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.WildcardQueryBuilder;
+
+import java.util.List;
+
+/**
+ * Serializer for SQL/PPL {@code LIKE} / {@code ILIKE} on a column with a literal pattern. Delegated as
+ * a <em>performance</em> pre-filter — DataFusion re-verifies the exact predicate, so the Lucene query
+ * need only be a <b>superset</b> of true matches.
+ *
+ * <p>Dispatch (via {@link SqlLikePattern}): {@code 'prefix%'} → {@link PrefixQueryBuilder} (term-dict
+ * prefix scan); anything else → {@link WildcardQueryBuilder} (SQL {@code %}/{@code _} → {@code *}/{@code ?}).
+ * {@code ILIKE} (PPL default {@code like}) sets {@code caseInsensitive(true)}.
+ *
+ * <p>Negation is handled by the boolean path, not here: Calcite forbids a negated LIKE as a
+ * {@code RexCall}, so {@code NOT LIKE} arrives as {@code NOT(LIKE(...))} and this only sees positive LIKE.
+ */
+public class LikeSerializer extends AbstractQuerySerializer {
+
+    @Override
+    public QueryBuilder buildQueryBuilder(RexCall call, List<FieldStorageInfo> fieldStorage) {
+        SqlOperator operator = call.getOperator();
+        List<RexNode> operands = call.getOperands();
+        if (operands.size() < 2) {
+            throw new IllegalArgumentException("LIKE expects at least 2 operands, got " + operands.size());
+        }
+        RexNode left = operands.get(0);
+        RexNode right = operands.get(1);
+
+        RexInputRef columnRef;
+        RexLiteral patternLit;
+        if (left instanceof RexInputRef l && right instanceof RexLiteral r) {
+            columnRef = l;
+            patternLit = r;
+        } else if (left instanceof RexLiteral l && right instanceof RexInputRef r) {
+            columnRef = r;
+            patternLit = l;
+        } else {
+            throw new IllegalArgumentException("LIKE delegation requires (RexInputRef, RexLiteral); got " + left + " LIKE " + right);
+        }
+
+        String fieldName = FieldStorageInfo.resolve(fieldStorage, columnRef.getIndex()).getFieldName();
+        Object patternValue = CalciteToOSMapperConversionUtils.literalToOpenSearchValue(patternLit);
+        if (patternValue == null) {
+            throw new IllegalArgumentException("LIKE pattern must be a non-null literal");
+        }
+        String pattern = patternValue.toString();
+        boolean caseInsensitive = operator instanceof SqlLikeOperator likeOp && !likeOp.isCaseSensitive();
+
+        if (SqlLikePattern.classify(pattern) == SqlLikePattern.Shape.PREFIX) {
+            PrefixQueryBuilder qb = new PrefixQueryBuilder(fieldName, SqlLikePattern.prefixLiteral(pattern));
+            qb.caseInsensitive(caseInsensitive);
+            return qb;
+        }
+        WildcardQueryBuilder qb = new WildcardQueryBuilder(fieldName, convertSqlWildcardToLucene(pattern));
+        qb.caseInsensitive(caseInsensitive);
+        return qb;
+    }
+
+    /**
+     * Converts SQL wildcard characters ({@code %} and {@code _}) to Lucene wildcard characters
+     * ({@code *} and {@code ?}). Escaped wildcards ({@code \%}, {@code \_}) are treated as literals,
+     * and Lucene's own metacharacters ({@code *}, {@code ?}, {@code \}) in the literal text are escaped
+     * so they match literally.
+     */
+    private static String convertSqlWildcardToLucene(String text) {
+        final char ESCAPE = '\\';
+        StringBuilder result = new StringBuilder(text.length());
+        boolean escaped = false;
+        for (int i = 0; i < text.length(); i++) {
+            char c = text.charAt(i);
+            if (escaped) {
+                // Previous char was the SQL escape: this char is a literal (escape Lucene metachars).
+                appendLiteral(result, c);
+                escaped = false;
+            } else if (c == ESCAPE) {
+                escaped = true;
+            } else if (c == '%') {
+                result.append('*');
+            } else if (c == '_') {
+                result.append('?');
+            } else {
+                appendLiteral(result, c);
+            }
+        }
+        if (escaped) {
+            appendLiteral(result, ESCAPE); // dangling trailing backslash → literal backslash
+        }
+        return result.toString();
+    }
+
+    /** Append {@code c} as a literal, escaping Lucene wildcard metacharacters. */
+    private static void appendLiteral(StringBuilder sb, char c) {
+        if (c == '*' || c == '?' || c == '\\') {
+            sb.append('\\');
+        }
+        sb.append(c);
+    }
+}

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/LikeSerializer.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/LikeSerializer.java
@@ -59,7 +59,13 @@ public class LikeSerializer extends AbstractQuerySerializer {
             throw new IllegalArgumentException("LIKE delegation requires (RexInputRef, RexLiteral); got " + left + " LIKE " + right);
         }
 
-        String fieldName = FieldStorageInfo.resolve(fieldStorage, columnRef.getIndex()).getFieldName();
+        FieldStorageInfo field = FieldStorageInfo.resolve(fieldStorage, columnRef.getIndex());
+        // Route to the field's exact-match subfield when it has one (a text field's .keyword): a
+        // wildcard over the raw keyword term is the valid superset, whereas a wildcard over the
+        // analyzed text field is not. Marking only delegates text LIKE when this subfield exists.
+        String fieldName = field.getExactMatchSubfield() != null
+            ? field.getFieldName() + "." + field.getExactMatchSubfield()
+            : field.getFieldName();
         Object patternValue = CalciteToOSMapperConversionUtils.literalToOpenSearchValue(patternLit);
         if (patternValue == null) {
             throw new IllegalArgumentException("LIKE pattern must be a non-null literal");

--- a/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/QuerySerializerRegistryTests.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/QuerySerializerRegistryTests.java
@@ -254,6 +254,20 @@ public class QuerySerializerRegistryTests extends OpenSearchTestCase {
         }
     }
 
+    // --- LikeSerializer registration test ---
+
+    /**
+     * Tests that the LIKE serializer is registered and backed by {@link org.opensearch.be.lucene.serializers.LikeSerializer}.
+     */
+    public void testLikeSerializerRegistered() {
+        DelegatedPredicateSerializer serializer = QuerySerializerRegistry.getSerializers().get(ScalarFunction.LIKE);
+        assertNotNull("LIKE serializer must be registered", serializer);
+        assertTrue(
+            "LIKE serializer must be an instance of LikeSerializer",
+            serializer instanceof org.opensearch.be.lucene.serializers.LikeSerializer
+        );
+    }
+
     // --- MatchAllSerializer tests ---
 
     /**

--- a/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/serializers/LikeSerializerTests.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/serializers/LikeSerializerTests.java
@@ -1,0 +1,120 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.lucene.serializers;
+
+import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.fun.SqlLibraryOperators;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.opensearch.analytics.spi.FieldStorageInfo;
+import org.opensearch.analytics.spi.FieldType;
+import org.opensearch.index.query.PrefixQueryBuilder;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.WildcardQueryBuilder;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.List;
+
+/**
+ * Unit tests for {@link LikeSerializer}: prefix-vs-wildcard dispatch, ILIKE case-insensitivity,
+ * SQL→Lucene wildcard conversion, and refusal to delegate negated LIKE.
+ */
+public class LikeSerializerTests extends OpenSearchTestCase {
+
+    private final LikeSerializer serializer = new LikeSerializer();
+    private RelDataTypeFactory typeFactory;
+    private RexBuilder rexBuilder;
+    private RelDataType varchar;
+
+    private static final List<FieldStorageInfo> FIELD_STORAGE = List.of(
+        new FieldStorageInfo("str0", "keyword", FieldType.KEYWORD, List.of(), List.of("lucene"), List.of(), false)
+    );
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        typeFactory = new JavaTypeFactoryImpl();
+        rexBuilder = new RexBuilder(typeFactory);
+        varchar = typeFactory.createSqlType(SqlTypeName.VARCHAR);
+    }
+
+    private RexNode like(String pattern) {
+        return rexBuilder.makeCall(SqlStdOperatorTable.LIKE, rexBuilder.makeInputRef(varchar, 0), rexBuilder.makeLiteral(pattern));
+    }
+
+    private RexNode ilike(String pattern) {
+        return rexBuilder.makeCall(SqlLibraryOperators.ILIKE, rexBuilder.makeInputRef(varchar, 0), rexBuilder.makeLiteral(pattern));
+    }
+
+    private QueryBuilder build(RexNode call) {
+        return serializer.buildQueryBuilder((org.apache.calcite.rex.RexCall) call, FIELD_STORAGE);
+    }
+
+    public void testPrefixPatternBuildsPrefixQuery() {
+        QueryBuilder qb = build(like("OFF%"));
+        assertTrue("prefix-shaped LIKE → PrefixQuery", qb instanceof PrefixQueryBuilder);
+        PrefixQueryBuilder p = (PrefixQueryBuilder) qb;
+        assertEquals("str0", p.fieldName());
+        assertEquals("OFF", p.value());
+        assertFalse("SQL LIKE is case-sensitive", p.caseInsensitive());
+    }
+
+    public void testContainsPatternBuildsWildcardQuery() {
+        QueryBuilder qb = build(like("%foo%"));
+        assertTrue("contains-shaped LIKE → WildcardQuery", qb instanceof WildcardQueryBuilder);
+        WildcardQueryBuilder w = (WildcardQueryBuilder) qb;
+        assertEquals("str0", w.fieldName());
+        assertEquals("*foo*", w.value());
+    }
+
+    public void testUnderscoreBuildsWildcardQuery() {
+        WildcardQueryBuilder w = (WildcardQueryBuilder) build(like("on_"));
+        assertEquals("on?", w.value());
+    }
+
+    public void testIlikeIsCaseInsensitive() {
+        PrefixQueryBuilder p = (PrefixQueryBuilder) build(ilike("furn%"));
+        assertTrue("ILIKE → caseInsensitive", p.caseInsensitive());
+        assertEquals("furn", p.value());
+
+        WildcardQueryBuilder w = (WildcardQueryBuilder) build(ilike("%mid%"));
+        assertTrue(w.caseInsensitive());
+    }
+
+    public void testMatchAllPatternIsEmptyPrefix() {
+        // LIKE '%' matches every (non-null) value → empty-prefix PrefixQuery, a valid superset.
+        PrefixQueryBuilder p = (PrefixQueryBuilder) build(like("%"));
+        assertEquals("", p.value());
+    }
+
+    public void testEscapedWildcardTreatedAsLiteral() {
+        // '50\%%' → literal "50%" prefix + trailing wildcard → PrefixQuery("50%")
+        PrefixQueryBuilder p = (PrefixQueryBuilder) build(like("50\\%%"));
+        assertEquals("50%", p.value());
+    }
+
+    public void testLuceneMetacharsEscapedInWildcard() {
+        // a real '*' in the LIKE literal must be escaped so Lucene matches it literally
+        WildcardQueryBuilder w = (WildcardQueryBuilder) build(like("a*b%c"));
+        assertEquals("a\\*b*c", w.value());
+    }
+
+    /** Calcite forbids a negated LIKE as a RexCall, so NOT LIKE arrives as NOT(LIKE(...)) — the
+     *  serializer only ever sees positive LIKE. Pins that representation contract. */
+    public void testNegatedLikeOperatorCannotBeConstructedAsRexCall() {
+        expectThrows(
+            AssertionError.class,
+            () -> rexBuilder.makeCall(SqlStdOperatorTable.NOT_LIKE, rexBuilder.makeInputRef(varchar, 0), rexBuilder.makeLiteral("foo%"))
+        );
+    }
+}

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/DefaultPlanExecutor.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/DefaultPlanExecutor.java
@@ -39,9 +39,8 @@ import org.opensearch.analytics.planner.dag.FragmentConversionDriver;
 import org.opensearch.analytics.planner.dag.PlanAlternativeSelector;
 import org.opensearch.analytics.planner.dag.PlanForker;
 import org.opensearch.analytics.planner.dag.QueryDAG;
-import org.opensearch.analytics.settings.AnalyticsApproximationSettings;
 import org.opensearch.analytics.settings.AnalyticsQuerySettings;
-import org.opensearch.analytics.settings.DelegationBlockList;
+import org.opensearch.analytics.settings.PlannerSettings;
 import org.opensearch.analytics.stats.AnalyticsStatsCollector;
 import org.opensearch.arrow.allocator.AllocationRejection;
 import org.opensearch.cluster.ClusterState;
@@ -96,8 +95,7 @@ public class DefaultPlanExecutor extends HandledTransportAction<AnalyticsQueryRe
     private volatile int maxShardsPerQuery;
     private volatile int maxConcurrentShardRequestsPerNode;
     private volatile boolean preferMetadataDriver;
-    private volatile double oversamplingFactor;
-    private final DelegationBlockList delegationBlockList;
+    private final PlannerSettings plannerSettings;
     private final IndexNameExpressionResolver indexNameExpressionResolver;
     private final AnalyticsSearchSlowLog analyticsSearchSlowLog;
 
@@ -140,12 +138,6 @@ public class DefaultPlanExecutor extends HandledTransportAction<AnalyticsQueryRe
         this.maxShardsPerQuery = AnalyticsQuerySettings.MAX_SHARDS_PER_QUERY.get(clusterService.getSettings());
         clusterService.getClusterSettings()
             .addSettingsUpdateConsumer(AnalyticsQuerySettings.MAX_SHARDS_PER_QUERY, v -> maxShardsPerQuery = v);
-        // Per-backend delegation block-list; self-registers an affix update consumer for live changes.
-        this.delegationBlockList = DelegationBlockList.create(
-            clusterService.getClusterSettings(),
-            clusterService.getSettings(),
-            capabilityRegistry
-        );
         this.maxConcurrentShardRequestsPerNode = AnalyticsQuerySettings.MAX_CONCURRENT_SHARD_REQUESTS_PER_NODE.get(
             clusterService.getSettings()
         );
@@ -157,9 +149,13 @@ public class DefaultPlanExecutor extends HandledTransportAction<AnalyticsQueryRe
         this.preferMetadataDriver = AnalyticsPlugin.PREFER_METADATA_DRIVER.get(clusterService.getSettings());
         clusterService.getClusterSettings()
             .addSettingsUpdateConsumer(AnalyticsPlugin.PREFER_METADATA_DRIVER, v -> preferMetadataDriver = v);
-        this.oversamplingFactor = AnalyticsApproximationSettings.SHARD_BUCKET_OVERSAMPLING_FACTOR.get(clusterService.getSettings());
-        clusterService.getClusterSettings()
-            .addSettingsUpdateConsumer(AnalyticsApproximationSettings.SHARD_BUCKET_OVERSAMPLING_FACTOR, v -> oversamplingFactor = v);
+        // Planner settings (oversampling factor + delegation block-list); self-registers update
+        // consumers for live changes.
+        this.plannerSettings = PlannerSettings.create(
+            clusterService.getClusterSettings(),
+            clusterService.getSettings(),
+            capabilityRegistry
+        );
         this.indexNameExpressionResolver = indexNameExpressionResolver;
         this.analyticsSearchSlowLog = analyticsSearchSlowLog;
     }
@@ -244,8 +240,7 @@ public class DefaultPlanExecutor extends HandledTransportAction<AnalyticsQueryRe
             false,
             preferMetadataDriver
         );
-        plannerContext.setOversamplingFactor(oversamplingFactor);
-        plannerContext.setDelegationBlockList(delegationBlockList);
+        plannerContext.setPlannerSettings(plannerSettings);
         RelNode plan = PlannerImpl.createPlan(logicalFragment, plannerContext);
         final String fullPlan = profile ? org.apache.calcite.plan.RelOptUtil.toString(plan) : null;
         QueryDAG dag = DAGBuilder.build(plan, capabilityRegistry, clusterService, indexNameExpressionResolver);

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/DefaultPlanExecutor.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/DefaultPlanExecutor.java
@@ -41,6 +41,7 @@ import org.opensearch.analytics.planner.dag.PlanForker;
 import org.opensearch.analytics.planner.dag.QueryDAG;
 import org.opensearch.analytics.settings.AnalyticsApproximationSettings;
 import org.opensearch.analytics.settings.AnalyticsQuerySettings;
+import org.opensearch.analytics.settings.DelegationBlockList;
 import org.opensearch.analytics.stats.AnalyticsStatsCollector;
 import org.opensearch.arrow.allocator.AllocationRejection;
 import org.opensearch.cluster.ClusterState;
@@ -96,6 +97,7 @@ public class DefaultPlanExecutor extends HandledTransportAction<AnalyticsQueryRe
     private volatile int maxConcurrentShardRequestsPerNode;
     private volatile boolean preferMetadataDriver;
     private volatile double oversamplingFactor;
+    private final DelegationBlockList delegationBlockList;
     private final IndexNameExpressionResolver indexNameExpressionResolver;
     private final AnalyticsSearchSlowLog analyticsSearchSlowLog;
 
@@ -138,6 +140,12 @@ public class DefaultPlanExecutor extends HandledTransportAction<AnalyticsQueryRe
         this.maxShardsPerQuery = AnalyticsQuerySettings.MAX_SHARDS_PER_QUERY.get(clusterService.getSettings());
         clusterService.getClusterSettings()
             .addSettingsUpdateConsumer(AnalyticsQuerySettings.MAX_SHARDS_PER_QUERY, v -> maxShardsPerQuery = v);
+        // Per-backend delegation block-list; self-registers an affix update consumer for live changes.
+        this.delegationBlockList = DelegationBlockList.create(
+            clusterService.getClusterSettings(),
+            clusterService.getSettings(),
+            capabilityRegistry
+        );
         this.maxConcurrentShardRequestsPerNode = AnalyticsQuerySettings.MAX_CONCURRENT_SHARD_REQUESTS_PER_NODE.get(
             clusterService.getSettings()
         );
@@ -237,6 +245,7 @@ public class DefaultPlanExecutor extends HandledTransportAction<AnalyticsQueryRe
             preferMetadataDriver
         );
         plannerContext.setOversamplingFactor(oversamplingFactor);
+        plannerContext.setDelegationBlockList(delegationBlockList);
         RelNode plan = PlannerImpl.createPlan(logicalFragment, plannerContext);
         final String fullPlan = profile ? org.apache.calcite.plan.RelOptUtil.toString(plan) : null;
         QueryDAG dag = DAGBuilder.build(plan, capabilityRegistry, clusterService, indexNameExpressionResolver);

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/PlannerContext.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/PlannerContext.java
@@ -9,6 +9,7 @@
 package org.opensearch.analytics.planner;
 
 import org.opensearch.analytics.planner.rel.OpenSearchDistributionTraitDef;
+import org.opensearch.analytics.settings.DelegationBlockList;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.common.Nullable;
@@ -32,6 +33,9 @@ public class PlannerContext {
     private double oversamplingFactor;
     private int annotationIdCounter;
     private RuleProfilingListener.PlannerProfile lastProfile;
+    // Per-backend delegation block-list. Defaults to empty (nothing blocked); DefaultPlanExecutor
+    // injects the live, settings-backed instance via setDelegationBlockList before planning.
+    private DelegationBlockList delegationBlockList = DelegationBlockList.empty();
 
     public PlannerContext(CapabilityRegistry capabilityRegistry, ClusterState clusterState) {
         this(capabilityRegistry, clusterState, null, false, true);
@@ -98,6 +102,16 @@ public class PlannerContext {
 
     public CapabilityRegistry getCapabilityRegistry() {
         return capabilityRegistry;
+    }
+
+    /** Per-backend delegation block-list consulted at marking time. Never null (defaults to empty). */
+    public DelegationBlockList getDelegationBlockList() {
+        return delegationBlockList;
+    }
+
+    /** Inject the live, settings-backed block-list. Called by {@code DefaultPlanExecutor} before planning. */
+    public void setDelegationBlockList(DelegationBlockList delegationBlockList) {
+        this.delegationBlockList = delegationBlockList;
     }
 
     public ClusterState getClusterState() {

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/PlannerContext.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/PlannerContext.java
@@ -10,6 +10,7 @@ package org.opensearch.analytics.planner;
 
 import org.opensearch.analytics.planner.rel.OpenSearchDistributionTraitDef;
 import org.opensearch.analytics.settings.DelegationBlockList;
+import org.opensearch.analytics.settings.PlannerSettings;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.common.Nullable;
@@ -30,12 +31,12 @@ public class PlannerContext {
     private final OpenSearchDistributionTraitDef distributionTraitDef;
     private final boolean profilingEnabled;
     private final boolean preferMetadataDriver;
-    private double oversamplingFactor;
     private int annotationIdCounter;
     private RuleProfilingListener.PlannerProfile lastProfile;
-    // Per-backend delegation block-list. Defaults to empty (nothing blocked); DefaultPlanExecutor
-    // injects the live, settings-backed instance via setDelegationBlockList before planning.
-    private DelegationBlockList delegationBlockList = DelegationBlockList.empty();
+    // Cluster settings the planner consults at planning time (oversampling factor + delegation
+    // block-list). Defaults to planner defaults; DefaultPlanExecutor injects the live, settings-backed
+    // instance via setPlannerSettings before planning.
+    private PlannerSettings plannerSettings = PlannerSettings.defaults();
 
     public PlannerContext(CapabilityRegistry capabilityRegistry, ClusterState clusterState) {
         this(capabilityRegistry, clusterState, null, false, true);
@@ -106,12 +107,12 @@ public class PlannerContext {
 
     /** Per-backend delegation block-list consulted at marking time. Never null (defaults to empty). */
     public DelegationBlockList getDelegationBlockList() {
-        return delegationBlockList;
+        return plannerSettings.getDelegationBlockList();
     }
 
-    /** Inject the live, settings-backed block-list. Called by {@code DefaultPlanExecutor} before planning. */
-    public void setDelegationBlockList(DelegationBlockList delegationBlockList) {
-        this.delegationBlockList = delegationBlockList;
+    /** Inject the live, settings-backed planner settings. Called by {@code DefaultPlanExecutor} before planning. */
+    public void setPlannerSettings(PlannerSettings plannerSettings) {
+        this.plannerSettings = plannerSettings;
     }
 
     public ClusterState getClusterState() {
@@ -119,11 +120,7 @@ public class PlannerContext {
     }
 
     public double getOversamplingFactor() {
-        return oversamplingFactor;
-    }
-
-    public void setOversamplingFactor(double oversamplingFactor) {
-        this.oversamplingFactor = oversamplingFactor;
+        return plannerSettings.getOversamplingFactor();
     }
 
     public OpenSearchDistributionTraitDef getDistributionTraitDef() {

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchFilterRule.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchFilterRule.java
@@ -24,6 +24,7 @@ import org.opensearch.analytics.planner.RelNodeUtils;
 import org.opensearch.analytics.planner.rel.AnnotatedPredicate;
 import org.opensearch.analytics.planner.rel.OpenSearchFilter;
 import org.opensearch.analytics.planner.rel.OpenSearchRelNode;
+import org.opensearch.analytics.settings.DelegationBlockList;
 import org.opensearch.analytics.spi.DelegationType;
 import org.opensearch.analytics.spi.FieldStorageInfo;
 import org.opensearch.analytics.spi.FieldType;
@@ -251,6 +252,17 @@ public class OpenSearchFilterRule extends RelOptRule {
                 }
             }
             viableSet.retainAll(registry.scalarBackendsAnyFormat(scalarFunc, returnType));
+        }
+
+        // Per-backend delegation block-list. Drop backends that block this predicate so it is never
+        // marked viable for them — but only when a non-blocked backend survives: blocking is a
+        // delegation knob and must never make a predicate unexecutable.
+        DelegationBlockList blockList = context.getDelegationBlockList();
+        if (!blockList.isEmpty()) {
+            boolean someBackendSurvives = viableSet.stream().anyMatch(backend -> !blockList.isBlocked(backend, function));
+            if (someBackendSurvives) {
+                viableSet.removeIf(backend -> blockList.isBlocked(backend, function));
+            }
         }
 
         if (viableSet.isEmpty()) {

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchFilterRule.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchFilterRule.java
@@ -198,6 +198,19 @@ public class OpenSearchFilterRule extends RelOptRule {
                 // field only when the field has indexFormats=[lucene] set in the mapping).
                 // TODO: for FULL_TEXT operators, extract required params from RexCall
                 fieldViable = new HashSet<>(registry.filterBackendsForField(function, storageInfo));
+
+                // LIKE on an analyzed TEXT field is only a valid delegated superset when the field has
+                // a keyword exact-match subfield to route the wildcard to (see LikeSerializer); on a
+                // bare text field a per-token wildcard under-matches and can fail in the scan path.
+                // Drop FILTER-delegation acceptors (e.g. Lucene) for that case so the predicate stays
+                // on the driving engine. Keyword fields and text-with-subfield are unaffected.
+                // TODO: support LIKE delegation for pure-text fields WITHOUT a keyword subfield (e.g.
+                // via an ngram/analyzed-aware Lucene query) so they don't fall back to DataFusion.
+                if (function == ScalarFunction.LIKE
+                    && FieldType.text().contains(storageInfo.getFieldType())
+                    && storageInfo.getExactMatchSubfield() == null) {
+                    fieldViable.removeAll(registry.delegationAcceptors(DelegationType.FILTER));
+                }
             }
 
             viableSet.retainAll(fieldViable);

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/settings/AnalyticsQuerySettings.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/settings/AnalyticsQuerySettings.java
@@ -8,12 +8,37 @@
 
 package org.opensearch.analytics.settings;
 
+import org.opensearch.analytics.spi.ScalarFunction;
 import org.opensearch.common.settings.Setting;
 
 import java.util.List;
 
 /** Cluster-level settings for analytics query execution limits. */
 public final class AnalyticsQuerySettings {
+
+    /** Affix-setting prefix; full key is {@code analytics.delegation.<backend>.blocked_predicates}. */
+    public static final String DELEGATION_BLOCKED_PREDICATES_PREFIX = "analytics.delegation.";
+
+    /**
+     * Per-backend block-list of predicate functions that must NOT be delegated to that backend. Affix
+     * (namespaced) setting: the backend name is the namespace, the value is a list of
+     * {@link ScalarFunction} names (case-insensitive). Models the operator-facing
+     * {@code Map<BackendName, List<BlockedPredicate>>} contract.
+     *
+     * <pre>
+     * analytics.delegation.lucene.blocked_predicates:  ["LIKE","EQUALS"]
+     * </pre>
+     *
+     * <p>Default empty. Enforced at the marking layer ({@code OpenSearchFilterRule}): a blocked
+     * predicate is dropped from that backend's viable set, so the planner leaves it on a non-blocked
+     * backend. Dynamic + NodeScope. Registry-derived validation (namespace must be a FILTER-delegation
+     * acceptor; predicate must have a serializer on that backend) runs in {@code DelegationBlockList}.
+     */
+    public static final Setting.AffixSetting<List<ScalarFunction>> DELEGATION_BLOCKED_PREDICATES = Setting.affixKeySetting(
+        DELEGATION_BLOCKED_PREDICATES_PREFIX,
+        "blocked_predicates",
+        key -> Setting.listSetting(key, List.of(), ScalarFunction::fromToken, Setting.Property.NodeScope, Setting.Property.Dynamic)
+    );
 
     public static final Setting<Integer> MAX_SHARDS_PER_QUERY = Setting.intSetting(
         "analytics.query.max_shards_per_query",
@@ -38,7 +63,7 @@ public final class AnalyticsQuerySettings {
     );
 
     public static List<Setting<?>> all() {
-        return List.of(MAX_SHARDS_PER_QUERY, MAX_CONCURRENT_SHARD_REQUESTS_PER_NODE);
+        return List.of(DELEGATION_BLOCKED_PREDICATES, MAX_SHARDS_PER_QUERY, MAX_CONCURRENT_SHARD_REQUESTS_PER_NODE);
     }
 
     private AnalyticsQuerySettings() {}

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/settings/DelegationBlockList.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/settings/DelegationBlockList.java
@@ -42,6 +42,16 @@ public final class DelegationBlockList {
 
     private static final Logger LOGGER = LogManager.getLogger(DelegationBlockList.class);
 
+    /**
+     * Built-in default block-list, seeded for any acceptor namespace the operator has not explicitly
+     * configured. LIKE delegation to Lucene is blocked by default: leading-wildcard LIKE on a plain
+     * term dictionary is a full term-dictionary sweep (the LIKE-on-URL ~6x regression), so we keep it
+     * on the driving engine until an opt-in (e.g. a wildcard/trigram subfield) makes it worthwhile.
+     * Operators can re-enable by explicitly clearing the namespace: {@code
+     * analytics.delegation.lucene.blocked_predicates: []}.
+     */
+    private static final Map<String, EnumSet<ScalarFunction>> DEFAULT_BLOCKED = Map.of("lucene", EnumSet.of(ScalarFunction.LIKE));
+
     /** backendName -> blocked predicate functions. Absent/empty entry ⇒ nothing blocked. */
     private final Map<String, EnumSet<ScalarFunction>> blockedByBackend;
 
@@ -73,9 +83,14 @@ public final class DelegationBlockList {
         Map<String, EnumSet<ScalarFunction>> map = new ConcurrentHashMap<>();
         DelegationBlockList blockList = new DelegationBlockList(map);
         Map<String, List<ScalarFunction>> initial = AnalyticsQuerySettings.DELEGATION_BLOCKED_PREDICATES.getAsMap(initialSettings);
+        // Built-in defaults first, so an operator's explicit value for the same namespace (incl. an
+        // explicit empty list, which clears the default) wins below.
+        seedDefaults(registry, map, initial.keySet());
         for (Map.Entry<String, List<ScalarFunction>> e : initial.entrySet()) {
             validate(registry, e.getKey(), e.getValue());
-            if (!e.getValue().isEmpty()) {
+            if (e.getValue().isEmpty()) {
+                map.remove(e.getKey()); // explicit empty list overrides any built-in default
+            } else {
                 map.put(e.getKey(), toEnumSet(e.getValue()));
             }
         }
@@ -85,6 +100,31 @@ public final class DelegationBlockList {
             (backendName, predicates) -> validate(registry, backendName, predicates)
         );
         return blockList;
+    }
+
+    /**
+     * Seeds {@link #DEFAULT_BLOCKED} for every acceptor namespace the operator has <em>not</em>
+     * explicitly configured ({@code explicitlyConfigured}). Best-effort: a default that doesn't
+     * validate against the runtime registry (backend isn't a FILTER acceptor, or has no serializer
+     * for the predicate) is skipped with a debug log rather than failing node startup.
+     */
+    private static void seedDefaults(
+        CapabilityRegistry registry,
+        Map<String, EnumSet<ScalarFunction>> map,
+        Set<String> explicitlyConfigured
+    ) {
+        for (Map.Entry<String, EnumSet<ScalarFunction>> e : DEFAULT_BLOCKED.entrySet()) {
+            if (explicitlyConfigured.contains(e.getKey())) {
+                continue; // operator owns this namespace; their value (set below) takes precedence
+            }
+            try {
+                validate(registry, e.getKey(), List.copyOf(e.getValue()));
+            } catch (IllegalArgumentException ex) {
+                LOGGER.debug("Skipping default delegation block-list for backend [{}]: {}", e.getKey(), ex.getMessage());
+                continue;
+            }
+            map.put(e.getKey(), EnumSet.copyOf(e.getValue()));
+        }
     }
 
     /**

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/settings/DelegationBlockList.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/settings/DelegationBlockList.java
@@ -1,0 +1,153 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.settings;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.analytics.planner.CapabilityRegistry;
+import org.opensearch.analytics.spi.DelegationType;
+import org.opensearch.analytics.spi.ScalarFunction;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Settings;
+
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Resolved, hot-reloadable view of the per-backend delegation block-list configured via
+ * {@link AnalyticsQuerySettings#DELEGATION_BLOCKED_PREDICATES}. Holds the operator-facing
+ * {@code Map<BackendName, List<BlockedPredicate>>} as a {@code Map<String, EnumSet<ScalarFunction>>}
+ * so the marking-time hot path ({@link #isBlocked}) is an enum-set membership check.
+ *
+ * <p>The vocabulary is <b>derived from the runtime backend registry</b>, not a parallel enum: a
+ * backend namespace is valid only if the backend <em>accepts</em> FILTER delegation
+ * ({@link CapabilityRegistry#delegationAcceptors}), and a predicate is valid only if that backend
+ * ships a serializer for it ({@code delegatedPredicateSerializers().keySet()}). Today Lucene is the
+ * only FILTER-delegation acceptor, so any other namespace (e.g. {@code datafusion}) is rejected.
+ * Validation runs at <b>setting-update time</b> (the affix update consumer / initial seed), so an
+ * invalid backend or unsupported predicate fails the cluster-settings update with a clear message.
+ *
+ * @opensearch.internal
+ */
+public final class DelegationBlockList {
+
+    private static final Logger LOGGER = LogManager.getLogger(DelegationBlockList.class);
+
+    /** backendName -> blocked predicate functions. Absent/empty entry ⇒ nothing blocked. */
+    private final Map<String, EnumSet<ScalarFunction>> blockedByBackend;
+
+    private DelegationBlockList(Map<String, EnumSet<ScalarFunction>> blockedByBackend) {
+        this.blockedByBackend = blockedByBackend;
+    }
+
+    /** An empty block-list — nothing is blocked. */
+    public static DelegationBlockList empty() {
+        return new DelegationBlockList(new ConcurrentHashMap<>());
+    }
+
+    /** Test/seed factory from a plain map (assumes pre-validated input). */
+    public static DelegationBlockList fromMap(Map<String, List<ScalarFunction>> seed) {
+        Map<String, EnumSet<ScalarFunction>> map = new ConcurrentHashMap<>();
+        for (Map.Entry<String, List<ScalarFunction>> e : seed.entrySet()) {
+            map.put(e.getKey(), toEnumSet(e.getValue()));
+        }
+        return new DelegationBlockList(map);
+    }
+
+    /**
+     * Production factory: seeds from the current cluster settings and registers an affix update
+     * consumer + validator so later {@code analytics.delegation.<backend>.blocked_predicates} changes
+     * are validated against {@code registry} and applied live. The validator rejects (1) a namespace
+     * that is not a FILTER-delegation acceptor and (2) a predicate the acceptor has no serializer for.
+     */
+    public static DelegationBlockList create(ClusterSettings clusterSettings, Settings initialSettings, CapabilityRegistry registry) {
+        Map<String, EnumSet<ScalarFunction>> map = new ConcurrentHashMap<>();
+        DelegationBlockList blockList = new DelegationBlockList(map);
+        Map<String, List<ScalarFunction>> initial = AnalyticsQuerySettings.DELEGATION_BLOCKED_PREDICATES.getAsMap(initialSettings);
+        for (Map.Entry<String, List<ScalarFunction>> e : initial.entrySet()) {
+            validate(registry, e.getKey(), e.getValue());
+            if (!e.getValue().isEmpty()) {
+                map.put(e.getKey(), toEnumSet(e.getValue()));
+            }
+        }
+        clusterSettings.addAffixUpdateConsumer(
+            AnalyticsQuerySettings.DELEGATION_BLOCKED_PREDICATES,
+            blockList::update,
+            (backendName, predicates) -> validate(registry, backendName, predicates)
+        );
+        return blockList;
+    }
+
+    /**
+     * Rejects an invalid block-list entry: an unknown delegation-target backend, or a predicate the
+     * target backend cannot delegate (no serializer). Called by the affix update validator, so a bad
+     * value fails the cluster-settings update before {@link #update} ever runs.
+     */
+    private static void validate(CapabilityRegistry registry, String backendName, List<ScalarFunction> predicates) {
+        if (predicates.isEmpty()) {
+            return; // clearing a namespace is always allowed
+        }
+        List<String> acceptors = registry.delegationAcceptors(DelegationType.FILTER);
+        if (!acceptors.contains(backendName)) {
+            throw new IllegalArgumentException(
+                "analytics.delegation."
+                    + backendName
+                    + ".blocked_predicates: ["
+                    + backendName
+                    + "] is not a delegation-target backend; FILTER delegation acceptors are "
+                    + acceptors
+            );
+        }
+        Set<ScalarFunction> delegatable = registry.getBackend(backendName).delegatedPredicateSerializers().keySet();
+        for (ScalarFunction predicate : predicates) {
+            if (!delegatable.contains(predicate)) {
+                throw new IllegalArgumentException(
+                    "analytics.delegation."
+                        + backendName
+                        + ".blocked_predicates: ["
+                        + predicate
+                        + "] is not delegatable to ["
+                        + backendName
+                        + "]; delegatable predicates are "
+                        + delegatable
+                );
+            }
+        }
+    }
+
+    /** Update (or clear) the blocked set for one backend namespace. Called by the settings-update thread. */
+    private void update(String backendName, List<ScalarFunction> blocked) {
+        if (blocked == null || blocked.isEmpty()) {
+            blockedByBackend.remove(backendName);
+        } else {
+            blockedByBackend.put(backendName, toEnumSet(blocked));
+        }
+        LOGGER.info("Delegation block-list updated: backend [{}] now blocks {}", backendName, blocked);
+    }
+
+    /** True iff {@code predicate} is blocked from delegation to {@code backendName}. */
+    public boolean isBlocked(String backendName, ScalarFunction predicate) {
+        EnumSet<ScalarFunction> set = blockedByBackend.get(backendName);
+        return set != null && set.contains(predicate);
+    }
+
+    /** True iff there is at least one block entry (lets callers skip per-predicate work when empty). */
+    public boolean isEmpty() {
+        return blockedByBackend.isEmpty();
+    }
+
+    private static EnumSet<ScalarFunction> toEnumSet(List<ScalarFunction> values) {
+        EnumSet<ScalarFunction> set = EnumSet.noneOf(ScalarFunction.class);
+        set.addAll(values);
+        return set;
+    }
+}

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/settings/PlannerSettings.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/settings/PlannerSettings.java
@@ -1,0 +1,79 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.settings;
+
+import org.opensearch.analytics.planner.CapabilityRegistry;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Settings;
+
+/**
+ * Top-level, hot-reloadable view of the cluster settings the planner consults at planning time.
+ * Bundles the otherwise-scattered planner knobs into one wrapper so the planner context carries a
+ * single object instead of one field (plus update wiring) per setting:
+ *
+ * <ul>
+ *   <li>{@code analytics.shard_bucket_oversampling_factor} — shard-bucket oversampling factor
+ *       (volatile; updated live).</li>
+ *   <li>{@code analytics.delegation.<backend>.blocked_predicates} — the per-backend delegation
+ *       block-list ({@link DelegationBlockList}, which self-updates via its own affix consumer).</li>
+ * </ul>
+ *
+ * <p>{@link #create} reads current values and self-registers the dynamic update consumers, so a
+ * single instance built at executor construction stays current for the node's lifetime. Tests that
+ * don't exercise cluster settings use {@link #defaults()} or {@link #of}.
+ *
+ * @opensearch.internal
+ */
+public final class PlannerSettings {
+
+    private volatile double oversamplingFactor;
+    private final DelegationBlockList delegationBlockList;
+
+    private PlannerSettings(double oversamplingFactor, DelegationBlockList delegationBlockList) {
+        this.oversamplingFactor = oversamplingFactor;
+        this.delegationBlockList = delegationBlockList;
+    }
+
+    /**
+     * Production factory: seeds from the current cluster settings and registers update consumers so
+     * later changes apply live. The block-list ({@link DelegationBlockList#create}) self-registers its
+     * own affix consumer + registry-derived validator; the oversampling factor is refreshed here.
+     */
+    public static PlannerSettings create(ClusterSettings clusterSettings, Settings initialSettings, CapabilityRegistry registry) {
+        DelegationBlockList blockList = DelegationBlockList.create(clusterSettings, initialSettings, registry);
+        PlannerSettings settings = new PlannerSettings(
+            AnalyticsApproximationSettings.SHARD_BUCKET_OVERSAMPLING_FACTOR.get(initialSettings),
+            blockList
+        );
+        clusterSettings.addSettingsUpdateConsumer(
+            AnalyticsApproximationSettings.SHARD_BUCKET_OVERSAMPLING_FACTOR,
+            v -> settings.oversamplingFactor = v
+        );
+        return settings;
+    }
+
+    /** Planner defaults for unit tests: no oversampling, nothing blocked. */
+    public static PlannerSettings defaults() {
+        return new PlannerSettings(0.0, DelegationBlockList.empty());
+    }
+
+    /** Explicit values for tests that exercise a specific setting. */
+    public static PlannerSettings of(double oversamplingFactor, DelegationBlockList delegationBlockList) {
+        return new PlannerSettings(oversamplingFactor, delegationBlockList);
+    }
+
+    public double getOversamplingFactor() {
+        return oversamplingFactor;
+    }
+
+    /** Per-backend delegation block-list consulted at marking time. Never null (defaults to empty). */
+    public DelegationBlockList getDelegationBlockList() {
+        return delegationBlockList;
+    }
+}

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/FilterRuleTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/FilterRuleTests.java
@@ -28,10 +28,12 @@ import org.apache.calcite.util.ImmutableBitSet;
 import org.opensearch.analytics.planner.rel.AnnotatedPredicate;
 import org.opensearch.analytics.planner.rel.OpenSearchFilter;
 import org.opensearch.analytics.planner.rel.OpenSearchTableScan;
+import org.opensearch.analytics.settings.DelegationBlockList;
 import org.opensearch.analytics.spi.AnalyticsSearchBackendPlugin;
 import org.opensearch.analytics.spi.BackendCapabilityProvider;
 import org.opensearch.analytics.spi.DelegationType;
 import org.opensearch.analytics.spi.EngineCapability;
+import org.opensearch.analytics.spi.ScalarFunction;
 
 import java.util.List;
 import java.util.Map;
@@ -86,6 +88,71 @@ public class FilterRuleTests extends BasePlannerRulesTests {
         // Operator-level: only child backend (no delegation configured)
         assertEquals(1, result.getViableBackends().size());
         assertTrue(result.getViableBackends().contains(MockDataFusionBackend.NAME));
+    }
+
+    /**
+     * Keyword equality is normally viable for both backends per-predicate (see
+     * {@link #testKeywordEqualsAnnotatedWithBothBackends}). Blocking EQUALS for the Lucene backend
+     * via the delegation block-list must drop Lucene from the predicate's viable set, leaving only
+     * DataFusion — so the predicate is never delegated to Lucene.
+     */
+    public void testBlockListDropsBlockedBackendFromPredicate() {
+        DelegationBlockList blockList = DelegationBlockList.fromMap(Map.of(MockLuceneBackend.NAME, List.of(ScalarFunction.EQUALS)));
+        OpenSearchFilter result = runFilterWithBlockList(
+            "parquet",
+            Map.of("country_name", Map.of("type", "keyword", "index", true)),
+            new String[] { "country_name" },
+            new SqlTypeName[] { SqlTypeName.VARCHAR },
+            makeEquals(0, SqlTypeName.VARCHAR, "US"),
+            blockList
+        );
+
+        AnnotatedPredicate annotated = (AnnotatedPredicate) result.getCondition();
+        assertTrue("DataFusion stays viable", annotated.getViableBackends().contains(MockDataFusionBackend.NAME));
+        assertFalse("Lucene dropped by block-list", annotated.getViableBackends().contains(MockLuceneBackend.NAME));
+        assertEquals(1, annotated.getViableBackends().size());
+    }
+
+    /**
+     * Safety invariant: blocking must never make a predicate unexecutable. If EVERY viable backend
+     * blocks the shape, the block-list is ignored and all backends remain (there is nowhere else to
+     * run the predicate). Here both backends block EQUALS, so the annotation keeps both.
+     */
+    public void testBlockListIgnoredWhenAllViableBackendsBlock() {
+        DelegationBlockList blockList = DelegationBlockList.fromMap(
+            Map.of(MockLuceneBackend.NAME, List.of(ScalarFunction.EQUALS), MockDataFusionBackend.NAME, List.of(ScalarFunction.EQUALS))
+        );
+        OpenSearchFilter result = runFilterWithBlockList(
+            "parquet",
+            Map.of("country_name", Map.of("type", "keyword", "index", true)),
+            new String[] { "country_name" },
+            new SqlTypeName[] { SqlTypeName.VARCHAR },
+            makeEquals(0, SqlTypeName.VARCHAR, "US"),
+            blockList
+        );
+
+        AnnotatedPredicate annotated = (AnnotatedPredicate) result.getCondition();
+        assertEquals("both backends retained — blocking can't strand the predicate", 2, annotated.getViableBackends().size());
+    }
+
+    /**
+     * Blocking a predicate for one backend must not affect a different, non-blocked predicate shape:
+     * blocking EQUALS for Lucene leaves a keyword-equality dual-viable annotation untouched when the
+     * block targets a different backend namespace that doesn't exist.
+     */
+    public void testBlockListUnknownBackendIsNoOp() {
+        DelegationBlockList blockList = DelegationBlockList.fromMap(Map.of("not-a-backend", List.of(ScalarFunction.EQUALS)));
+        OpenSearchFilter result = runFilterWithBlockList(
+            "parquet",
+            Map.of("country_name", Map.of("type", "keyword", "index", true)),
+            new String[] { "country_name" },
+            new SqlTypeName[] { SqlTypeName.VARCHAR },
+            makeEquals(0, SqlTypeName.VARCHAR, "US"),
+            blockList
+        );
+
+        AnnotatedPredicate annotated = (AnnotatedPredicate) result.getCondition();
+        assertEquals("both backends still viable", 2, annotated.getViableBackends().size());
     }
 
     // ---- Viable backends with delegation ----
@@ -647,6 +714,25 @@ public class FilterRuleTests extends BasePlannerRulesTests {
         RexNode condition
     ) {
         return runFilter(format, fields, fieldNames, fieldTypes, condition, delegationBackends(), Set.of(MockDataFusionBackend.NAME));
+    }
+
+    /** Mirrors {@code runFilter} but injects a {@link DelegationBlockList} into the planner context. */
+    private OpenSearchFilter runFilterWithBlockList(
+        String format,
+        Map<String, Map<String, Object>> fields,
+        String[] fieldNames,
+        SqlTypeName[] fieldTypes,
+        RexNode condition,
+        DelegationBlockList blockList
+    ) {
+        PlannerContext context = buildContext(format, fields, List.of(DATAFUSION, LUCENE));
+        context.setDelegationBlockList(blockList);
+        RelOptTable table = mockTable("test_index", fieldNames, fieldTypes);
+        LogicalFilter filter = LogicalFilter.create(stubScan(table), condition);
+        RelNode result = unwrapExchange(runPlanner(filter, context));
+        logger.info("Plan:\n{}", RelOptUtil.toString(result));
+        assertTrue("Expected OpenSearchFilter, got " + result.getClass().getSimpleName(), result instanceof OpenSearchFilter);
+        return (OpenSearchFilter) result;
     }
 
     /**

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/FilterRuleTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/FilterRuleTests.java
@@ -73,6 +73,26 @@ public class FilterRuleTests extends BasePlannerRulesTests {
         assertPredicateAnnotation(annotated, MockDataFusionBackend.NAME, MockLuceneBackend.NAME);
     }
 
+    /**
+     * Keyword {@code LIKE 'foo%'} — both backends viable per-predicate. Mirrors the
+     * {@link #testKeywordEqualsAnnotatedWithBothBackends} shape but exercises the LIKE
+     * wiring: the Lucene backend declares {@code ScalarFunction.LIKE} in its STANDARD_OPS
+     * (matching production {@code LuceneAnalyticsBackendPlugin.STANDARD_OPS = {EQUALS, LIKE}}),
+     * so a LIKE predicate on a keyword field is Lucene-viable and can be delegated to Lucene.
+     */
+    public void testLikePredicateAnnotatedWithLuceneViable() {
+        OpenSearchFilter result = runFilter(
+            "parquet",
+            Map.of("country_name", Map.of("type", "keyword", "index", true)),
+            new String[] { "country_name" },
+            new SqlTypeName[] { SqlTypeName.VARCHAR },
+            makeLike(0, "foo%")
+        );
+
+        AnnotatedPredicate annotated = (AnnotatedPredicate) result.getCondition();
+        assertPredicateAnnotation(annotated, MockDataFusionBackend.NAME, MockLuceneBackend.NAME);
+    }
+
     /** Keyword equality — both backends viable per-predicate, operator-level only child. */
     public void testKeywordEqualsAnnotatedWithBothBackends() {
         OpenSearchFilter result = runFilter(
@@ -786,6 +806,16 @@ public class FilterRuleTests extends BasePlannerRulesTests {
         assertTrue("Expected OpenSearchFilter, got " + result.getClass().getSimpleName(), result instanceof OpenSearchFilter);
         assertPipelineViableBackends(result, List.of(OpenSearchFilter.class, OpenSearchTableScan.class), expectedViable);
         return (OpenSearchFilter) result;
+    }
+
+    /**
+     * Builds a {@code $fieldIndex LIKE 'pattern'} predicate over a VARCHAR input ref, using
+     * Calcite's {@link SqlStdOperatorTable#LIKE}. Mirrors {@code makeEquals} but for the LIKE
+     * shape exercised by {@link #testLikePredicateAnnotatedWithLuceneViable}.
+     */
+    private RexNode makeLike(int fieldIndex, String pattern) {
+        RelDataType varchar = typeFactory.createSqlType(SqlTypeName.VARCHAR);
+        return rexBuilder.makeCall(SqlStdOperatorTable.LIKE, rexBuilder.makeInputRef(varchar, fieldIndex), rexBuilder.makeLiteral(pattern));
     }
 
     private void assertPredicateAnnotation(AnnotatedPredicate predicate, String... expectedBackends) {

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/FilterRuleTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/FilterRuleTests.java
@@ -29,6 +29,7 @@ import org.opensearch.analytics.planner.rel.AnnotatedPredicate;
 import org.opensearch.analytics.planner.rel.OpenSearchFilter;
 import org.opensearch.analytics.planner.rel.OpenSearchTableScan;
 import org.opensearch.analytics.settings.DelegationBlockList;
+import org.opensearch.analytics.settings.PlannerSettings;
 import org.opensearch.analytics.spi.AnalyticsSearchBackendPlugin;
 import org.opensearch.analytics.spi.BackendCapabilityProvider;
 import org.opensearch.analytics.spi.DelegationType;
@@ -746,7 +747,7 @@ public class FilterRuleTests extends BasePlannerRulesTests {
         DelegationBlockList blockList
     ) {
         PlannerContext context = buildContext(format, fields, List.of(DATAFUSION, LUCENE));
-        context.setDelegationBlockList(blockList);
+        context.setPlannerSettings(PlannerSettings.of(0.0, blockList));
         RelOptTable table = mockTable("test_index", fieldNames, fieldTypes);
         LogicalFilter filter = LogicalFilter.create(stubScan(table), condition);
         RelNode result = unwrapExchange(runPlanner(filter, context));

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/TopKRewriterPlanShapeTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/TopKRewriterPlanShapeTests.java
@@ -20,6 +20,8 @@ import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.util.ImmutableBitSet;
+import org.opensearch.analytics.settings.DelegationBlockList;
+import org.opensearch.analytics.settings.PlannerSettings;
 
 import java.util.List;
 
@@ -348,7 +350,7 @@ public class TopKRewriterPlanShapeTests extends PlanShapeTestBase {
 
     private PlannerContext contextWithOversampling(double factor) {
         PlannerContext ctx = buildContext("parquet", 2, intFields());
-        ctx.setOversamplingFactor(factor);
+        ctx.setPlannerSettings(PlannerSettings.of(factor, DelegationBlockList.empty()));
         return ctx;
     }
 }

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/WindowPlanShapeTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/WindowPlanShapeTests.java
@@ -741,7 +741,7 @@ public class WindowPlanShapeTests extends PlanShapeTestBase {
 
         RexNode over = rb.makeOver(
             typeFactory.createSqlType(SqlTypeName.BIGINT),
-            (SqlAggFunction) SqlStdOperatorTable.SUM,
+            SqlStdOperatorTable.SUM,
             List.of(rb.makeInputRef(scan, 1)),
             ImmutableList.of(rb.makeInputRef(scan, 0)),    // PARTITION BY status
             ImmutableList.of(),
@@ -823,7 +823,7 @@ public class WindowPlanShapeTests extends PlanShapeTestBase {
         RexBuilder rb = scan.getCluster().getRexBuilder();
         RexNode over = rb.makeOver(
             typeFactory.createSqlType(SqlTypeName.BIGINT),
-            (SqlAggFunction) SqlStdOperatorTable.SUM,
+            SqlStdOperatorTable.SUM,
             List.of(rb.makeInputRef(scan, 1)),
             ImmutableList.of(rb.makeInputRef(scan, 0)),     // PARTITION BY status
             ImmutableList.of(new RexFieldCollation(rb.makeInputRef(scan, 1), Set.of())),  // ORDER BY size

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/settings/DelegationBlockListTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/settings/DelegationBlockListTests.java
@@ -1,0 +1,150 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.settings;
+
+import org.opensearch.analytics.planner.CapabilityRegistry;
+import org.opensearch.analytics.planner.FieldStorageResolver;
+import org.opensearch.analytics.spi.AnalyticsSearchBackendPlugin;
+import org.opensearch.analytics.spi.BackendCapabilityProvider;
+import org.opensearch.analytics.spi.DelegatedPredicateSerializer;
+import org.opensearch.analytics.spi.DelegationType;
+import org.opensearch.analytics.spi.EngineCapability;
+import org.opensearch.analytics.spi.ScalarFunction;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+
+public class DelegationBlockListTests extends OpenSearchTestCase {
+
+    /** Lucene-like backend: accepts FILTER delegation and ships serializers for EQUALS + LIKE. */
+    private static final String LUCENE = "lucene";
+
+    private CapabilityRegistry registry() {
+        AnalyticsSearchBackendPlugin lucene = new AnalyticsSearchBackendPlugin() {
+            @Override
+            public String name() {
+                return LUCENE;
+            }
+
+            @Override
+            public BackendCapabilityProvider getCapabilityProvider() {
+                return new BackendCapabilityProvider() {
+                    @Override
+                    public Set<EngineCapability> supportedEngineCapabilities() {
+                        return Set.of();
+                    }
+
+                    @Override
+                    public Set<DelegationType> acceptedDelegations() {
+                        return Set.of(DelegationType.FILTER);
+                    }
+                };
+            }
+
+            @Override
+            public Map<ScalarFunction, DelegatedPredicateSerializer> delegatedPredicateSerializers() {
+                // Only EQUALS and LIKE are delegatable (have serializers) in this fixture.
+                DelegatedPredicateSerializer stub = (call, fieldStorage) -> new byte[0];
+                return Map.of(ScalarFunction.EQUALS, stub, ScalarFunction.LIKE, stub);
+            }
+        };
+        Function<IndexMetadata, FieldStorageResolver> fieldStorageFactory = FieldStorageResolver::new;
+        return new CapabilityRegistry(List.of(lucene), fieldStorageFactory);
+    }
+
+    private ClusterSettings clusterSettings(Settings settings) {
+        return new ClusterSettings(settings, Set.of(AnalyticsQuerySettings.DELEGATION_BLOCKED_PREDICATES));
+    }
+
+    public void testEmptyBlocksNothing() {
+        DelegationBlockList blockList = DelegationBlockList.empty();
+        assertTrue(blockList.isEmpty());
+        assertFalse(blockList.isBlocked(LUCENE, ScalarFunction.LIKE));
+    }
+
+    public void testSeedFromClusterSettings() {
+        Settings settings = Settings.builder().putList("analytics.delegation.lucene.blocked_predicates", "LIKE", "equals").build();
+        DelegationBlockList blockList = DelegationBlockList.create(clusterSettings(settings), settings, registry());
+        assertTrue(blockList.isBlocked(LUCENE, ScalarFunction.LIKE));
+        assertTrue("case-insensitive token parsed", blockList.isBlocked(LUCENE, ScalarFunction.EQUALS));
+    }
+
+    public void testDynamicUpdate() {
+        ClusterSettings clusterSettings = clusterSettings(Settings.EMPTY);
+        DelegationBlockList blockList = DelegationBlockList.create(clusterSettings, Settings.EMPTY, registry());
+        assertTrue(blockList.isEmpty());
+
+        clusterSettings.applySettings(Settings.builder().putList("analytics.delegation.lucene.blocked_predicates", "LIKE").build());
+        assertTrue(blockList.isBlocked(LUCENE, ScalarFunction.LIKE));
+
+        // Clearing the list removes the backend's block entry.
+        clusterSettings.applySettings(Settings.builder().putList("analytics.delegation.lucene.blocked_predicates").build());
+        assertFalse(blockList.isBlocked(LUCENE, ScalarFunction.LIKE));
+        assertTrue(blockList.isEmpty());
+    }
+
+    public void testUnknownPredicateNameRejectedByElementParser() {
+        // A token that isn't a ScalarFunction fails the list element parser at update time.
+        ClusterSettings clusterSettings = clusterSettings(Settings.EMPTY);
+        DelegationBlockList.create(clusterSettings, Settings.EMPTY, registry());
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> clusterSettings.applySettings(
+                Settings.builder().putList("analytics.delegation.lucene.blocked_predicates", "NONSENSE").build()
+            )
+        );
+    }
+
+    public void testNonAcceptorBackendNamespaceRejected() {
+        // datafusion is not a FILTER-delegation acceptor → the namespace is rejected at update time.
+        ClusterSettings clusterSettings = clusterSettings(Settings.EMPTY);
+        DelegationBlockList.create(clusterSettings, Settings.EMPTY, registry());
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> clusterSettings.applySettings(
+                Settings.builder().putList("analytics.delegation.datafusion.blocked_predicates", "LIKE").build()
+            )
+        );
+        assertTrue("cause: " + e, causeChainContains(e, "not a delegation-target backend"));
+    }
+
+    public void testNonDelegatablePredicateRejected() {
+        // REGEXP has no serializer in this fixture → rejected even for the valid lucene namespace.
+        ClusterSettings clusterSettings = clusterSettings(Settings.EMPTY);
+        DelegationBlockList.create(clusterSettings, Settings.EMPTY, registry());
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> clusterSettings.applySettings(
+                Settings.builder().putList("analytics.delegation.lucene.blocked_predicates", "REGEXP").build()
+            )
+        );
+        assertTrue("cause: " + e, causeChainContains(e, "not delegatable"));
+    }
+
+    public void testSeedRejectsInvalidNamespaceAtConstruction() {
+        Settings settings = Settings.builder().putList("analytics.delegation.datafusion.blocked_predicates", "LIKE").build();
+        expectThrows(IllegalArgumentException.class, () -> DelegationBlockList.create(clusterSettings(settings), settings, registry()));
+    }
+
+    /** The cluster-settings layer wraps the validator's IllegalArgumentException; search the chain. */
+    private static boolean causeChainContains(Throwable t, String fragment) {
+        for (Throwable c = t; c != null; c = c.getCause()) {
+            if (c.getMessage() != null && c.getMessage().contains(fragment)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/settings/DelegationBlockListTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/settings/DelegationBlockListTests.java
@@ -81,15 +81,34 @@ public class DelegationBlockListTests extends OpenSearchTestCase {
         assertTrue("case-insensitive token parsed", blockList.isBlocked(LUCENE, ScalarFunction.EQUALS));
     }
 
+    public void testDefaultBlocksLikeOnLucene() {
+        // No operator configuration → the built-in default blocks LIKE delegation to lucene.
+        DelegationBlockList blockList = DelegationBlockList.create(clusterSettings(Settings.EMPTY), Settings.EMPTY, registry());
+        assertFalse(blockList.isEmpty());
+        assertTrue("LIKE blocked on lucene by default", blockList.isBlocked(LUCENE, ScalarFunction.LIKE));
+        assertFalse("only LIKE is blocked by default", blockList.isBlocked(LUCENE, ScalarFunction.EQUALS));
+    }
+
+    public void testExplicitEmptyListOverridesDefault() {
+        // An operator clearing the namespace (explicit empty list) re-enables LIKE delegation.
+        Settings settings = Settings.builder().putList("analytics.delegation.lucene.blocked_predicates").build();
+        DelegationBlockList blockList = DelegationBlockList.create(clusterSettings(settings), settings, registry());
+        assertTrue(blockList.isEmpty());
+        assertFalse(blockList.isBlocked(LUCENE, ScalarFunction.LIKE));
+    }
+
     public void testDynamicUpdate() {
         ClusterSettings clusterSettings = clusterSettings(Settings.EMPTY);
         DelegationBlockList blockList = DelegationBlockList.create(clusterSettings, Settings.EMPTY, registry());
-        assertTrue(blockList.isEmpty());
+        assertTrue("LIKE blocked on lucene by default", blockList.isBlocked(LUCENE, ScalarFunction.LIKE));
 
-        clusterSettings.applySettings(Settings.builder().putList("analytics.delegation.lucene.blocked_predicates", "LIKE").build());
+        clusterSettings.applySettings(
+            Settings.builder().putList("analytics.delegation.lucene.blocked_predicates", "LIKE", "equals").build()
+        );
         assertTrue(blockList.isBlocked(LUCENE, ScalarFunction.LIKE));
+        assertTrue(blockList.isBlocked(LUCENE, ScalarFunction.EQUALS));
 
-        // Clearing the list removes the backend's block entry.
+        // Clearing the list removes the backend's block entry (and overrides the built-in default).
         clusterSettings.applySettings(Settings.builder().putList("analytics.delegation.lucene.blocked_predicates").build());
         assertFalse(blockList.isBlocked(LUCENE, ScalarFunction.LIKE));
         assertTrue(blockList.isEmpty());

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/LikeDelegationIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/LikeDelegationIT.java
@@ -1,0 +1,144 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.qa;
+
+import org.opensearch.client.Request;
+import org.opensearch.client.ResponseException;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * End-to-end coverage for SQL/PPL {@code LIKE} delegation to Lucene (prefix + wildcard) and the
+ * per-backend delegation block-list. Asserts correct counts for each LIKE shape, then blocks LIKE
+ * via {@code analytics.delegation.lucene.blocked_predicates} and asserts identical counts (delegation
+ * off ⇒ DataFusion path) — same results, different execution path. Also checks a non-{@code lucene}
+ * namespace is rejected.
+ */
+public class LikeDelegationIT extends AnalyticsRestTestCase {
+
+    private static final String INDEX_NAME = "like_delegation_e2e";
+    private static final String BLOCK_KEY = "analytics.delegation.lucene.blocked_predicates";
+
+    public void testLikeDelegationCorrectnessAndBlockListParity() throws Exception {
+        createIndex();
+        indexDocs();
+
+        // Ground truth over the corpus (see indexDocs): str0 ∈
+        //   "apple" ×4, "applesauce" ×3, "banana" ×2, "cherry pie" ×1 (a multi-token value).
+        // SQL LIKE is a whole-value match over the raw keyword (DataFusion semantics, which the
+        // delegated Lucene query must reproduce). The values are chosen so each pattern is unambiguous.
+        assertLikeCount("xyz%", 0);          // nothing starts with xyz
+        assertLikeCount("apple%", 7);        // prefix: "apple"×4 + "applesauce"×3
+        assertLikeCount("%sauce%", 3);       // contains: only "applesauce"×3
+        assertLikeCount("banan_", 2);        // underscore: "banana"×2 ("banan" + one char)
+        assertLikeCount("%pie", 1);          // suffix on a multi-token value: "cherry pie"×1
+        // Case-insensitivity: PPL like() is ILIKE — uppercase pattern still matches lowercase data.
+        assertPplLikeCount("APPLE%", 7);
+
+        // Now block LIKE delegation to Lucene cluster-wide; results must be identical (DataFusion path).
+        setBlockedPredicates("\"LIKE\"");
+        try {
+            assertLikeCount("apple%", 7);
+            assertLikeCount("%sauce%", 3);
+            assertLikeCount("banan_", 2);
+            assertPplLikeCount("APPLE%", 7);
+        } finally {
+            setBlockedPredicates(""); // clear
+        }
+    }
+
+    /** The block-list only accepts the {@code lucene} namespace (the sole FILTER-delegation acceptor). */
+    public void testBlockListRejectsNonLuceneBackend() throws Exception {
+        Request req = new Request("PUT", "/_cluster/settings");
+        req.setJsonEntity("{\"persistent\":{\"analytics.delegation.datafusion.blocked_predicates\": [\"LIKE\"]}}");
+        ResponseException e = expectThrows(ResponseException.class, () -> client().performRequest(req));
+        assertEquals(400, e.getResponse().getStatusLine().getStatusCode());
+    }
+
+    // ---- helpers ----
+
+    private void assertLikeCount(String pattern, long expected) throws Exception {
+        String ppl = "source = " + INDEX_NAME + " | where str0 LIKE '" + pattern + "' | stats count() as c";
+        assertCount(ppl, expected, "str0 LIKE '" + pattern + "'");
+    }
+
+    private void assertPplLikeCount(String pattern, long expected) throws Exception {
+        String ppl = "source = " + INDEX_NAME + " | where like(str0, '" + pattern + "') | stats count() as c";
+        assertCount(ppl, expected, "like(str0, '" + pattern + "')");
+    }
+
+    @SuppressWarnings("unchecked")
+    private void assertCount(String ppl, long expected, String label) throws Exception {
+        Map<String, Object> result = executePplViaShim(ppl);
+        List<List<Object>> rows = (List<List<Object>>) result.get("rows");
+        assertNotNull("rows must not be null for " + label, rows);
+        assertEquals("count agg must return 1 row for " + label, 1, rows.size());
+        Number c = (Number) rows.get(0).get(0);
+        assertEquals("count for " + label, expected, c.longValue());
+    }
+
+    private void setBlockedPredicates(String jsonListContents) throws Exception {
+        Request req = new Request("PUT", "/_cluster/settings");
+        req.setJsonEntity("{\"persistent\":{\"" + BLOCK_KEY + "\": [" + jsonListContents + "]}}");
+        client().performRequest(req);
+    }
+
+    private void createIndex() throws Exception {
+        try {
+            client().performRequest(new Request("DELETE", "/" + INDEX_NAME));
+        } catch (Exception ignored) {}
+
+        String body = "{"
+            + "\"settings\": {"
+            + "  \"number_of_shards\": 1,"
+            + "  \"number_of_replicas\": 0,"
+            + "  \"index.pluggable.dataformat.enabled\": true,"
+            + "  \"index.pluggable.dataformat\": \"composite\","
+            + "  \"index.composite.primary_data_format\": \"parquet\","
+            + "  \"index.composite.secondary_data_formats\": \"lucene\""
+            + "},"
+            + "\"mappings\": {"
+            + "  \"properties\": {"
+            + "    \"str0\": { \"type\": \"keyword\" }"
+            + "  }"
+            + "}"
+            + "}";
+
+        Request createIndex = new Request("PUT", "/" + INDEX_NAME);
+        createIndex.setJsonEntity(body);
+        Map<String, Object> response = assertOkAndParse(client().performRequest(createIndex), "Create index");
+        assertEquals(true, response.get("acknowledged"));
+
+        Request health = new Request("GET", "/_cluster/health/" + INDEX_NAME);
+        health.addParameter("wait_for_status", "green");
+        health.addParameter("timeout", "30s");
+        client().performRequest(health);
+    }
+
+    private void indexDocs() throws Exception {
+        StringBuilder bulk = new StringBuilder();
+        appendDocs(bulk, "apple", 4);
+        appendDocs(bulk, "applesauce", 3);
+        appendDocs(bulk, "banana", 2);
+        appendDocs(bulk, "cherry pie", 1);
+
+        Request bulkReq = new Request("POST", "/" + INDEX_NAME + "/_bulk");
+        bulkReq.addParameter("refresh", "true");
+        bulkReq.setJsonEntity(bulk.toString());
+        assertOkAndParse(client().performRequest(bulkReq), "Bulk index");
+    }
+
+    private static void appendDocs(StringBuilder bulk, String value, int count) {
+        for (int i = 0; i < count; i++) {
+            bulk.append("{\"index\": {}}\n");
+            bulk.append("{\"str0\": \"").append(value).append("\"}\n");
+        }
+    }
+}

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/LikeDelegationIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/LikeDelegationIT.java
@@ -16,10 +16,11 @@ import java.util.Map;
 
 /**
  * End-to-end coverage for SQL/PPL {@code LIKE} delegation to Lucene (prefix + wildcard) and the
- * per-backend delegation block-list. Asserts correct counts for each LIKE shape, then blocks LIKE
- * via {@code analytics.delegation.lucene.blocked_predicates} and asserts identical counts (delegation
- * off ⇒ DataFusion path) — same results, different execution path. Also checks a non-{@code lucene}
- * namespace is rejected.
+ * per-backend delegation block-list. LIKE delegation to Lucene is blocked by default, so these tests
+ * first clear {@code analytics.delegation.lucene.blocked_predicates} (an explicit empty list overrides
+ * the built-in default) to exercise the delegated Lucene path, assert correct counts for each LIKE
+ * shape, then re-block LIKE and assert identical counts (delegation off ⇒ DataFusion path) — same
+ * results, different execution path. Also checks a non-{@code lucene} namespace is rejected.
  */
 public class LikeDelegationIT extends AnalyticsRestTestCase {
 
@@ -30,27 +31,30 @@ public class LikeDelegationIT extends AnalyticsRestTestCase {
         createIndex();
         indexDocs();
 
-        // Ground truth over the corpus (see indexDocs): str0 ∈
-        //   "apple" ×4, "applesauce" ×3, "banana" ×2, "cherry pie" ×1 (a multi-token value).
-        // SQL LIKE is a whole-value match over the raw keyword (DataFusion semantics, which the
-        // delegated Lucene query must reproduce). The values are chosen so each pattern is unambiguous.
-        assertLikeCount("xyz%", 0);          // nothing starts with xyz
-        assertLikeCount("apple%", 7);        // prefix: "apple"×4 + "applesauce"×3
-        assertLikeCount("%sauce%", 3);       // contains: only "applesauce"×3
-        assertLikeCount("banan_", 2);        // underscore: "banana"×2 ("banan" + one char)
-        assertLikeCount("%pie", 1);          // suffix on a multi-token value: "cherry pie"×1
-        // Case-insensitivity: PPL like() is ILIKE — uppercase pattern still matches lowercase data.
-        assertPplLikeCount("APPLE%", 7);
-
-        // Now block LIKE delegation to Lucene cluster-wide; results must be identical (DataFusion path).
-        setBlockedPredicates("\"LIKE\"");
+        // LIKE delegation to Lucene is blocked by default; clear the namespace (explicit empty list
+        // overrides the built-in default) so this phase actually exercises the delegated Lucene path.
+        setBlockedPredicates("");
         try {
+            // Ground truth over the corpus (see indexDocs): str0 ∈
+            //   "apple" ×4, "applesauce" ×3, "banana" ×2, "cherry pie" ×1 (a multi-token value).
+            // SQL LIKE is a whole-value match over the raw keyword (DataFusion semantics, which the
+            // delegated Lucene query must reproduce). The values are chosen so each pattern is unambiguous.
+            assertLikeCount("xyz%", 0);          // nothing starts with xyz
+            assertLikeCount("apple%", 7);        // prefix: "apple"×4 + "applesauce"×3
+            assertLikeCount("%sauce%", 3);       // contains: only "applesauce"×3
+            assertLikeCount("banan_", 2);        // underscore: "banana"×2 ("banan" + one char)
+            assertLikeCount("%pie", 1);          // suffix on a multi-token value: "cherry pie"×1
+            // Case-insensitivity: PPL like() is ILIKE — uppercase pattern still matches lowercase data.
+            assertPplLikeCount("APPLE%", 7);
+
+            // Now block LIKE delegation to Lucene cluster-wide; results must be identical (DataFusion path).
+            setBlockedPredicates("\"LIKE\"");
             assertLikeCount("apple%", 7);
             assertLikeCount("%sauce%", 3);
             assertLikeCount("banan_", 2);
             assertPplLikeCount("APPLE%", 7);
         } finally {
-            setBlockedPredicates(""); // clear
+            setBlockedPredicates(""); // restore: leave delegation enabled for the cluster
         }
     }
 
@@ -64,9 +68,15 @@ public class LikeDelegationIT extends AnalyticsRestTestCase {
         createIndex();
         indexDocs();
 
-        assertMsgLikeCount("Service%", 9);   // both "Service ..." families: 7 + 2
-        assertMsgLikeCount("%timeout%", 1);  // only "Gateway timeout error"
-        assertMsgLikeCount("%alpha%", 7);    // only the alpha family
+        // Clear the default LIKE block so the text-field LIKE is delegated against msg.keyword.
+        setBlockedPredicates("");
+        try {
+            assertMsgLikeCount("Service%", 9);   // both "Service ..." families: 7 + 2
+            assertMsgLikeCount("%timeout%", 1);  // only "Gateway timeout error"
+            assertMsgLikeCount("%alpha%", 7);    // only the alpha family
+        } finally {
+            setBlockedPredicates("");
+        }
     }
 
     /** The block-list only accepts the {@code lucene} namespace (the sole FILTER-delegation acceptor). */

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/LikeDelegationIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/LikeDelegationIT.java
@@ -54,6 +54,21 @@ public class LikeDelegationIT extends AnalyticsRestTestCase {
         }
     }
 
+    /**
+     * LIKE on a {@code text} field that has a {@code .keyword} subfield: the wildcard is delegated
+     * against {@code msg.keyword} (raw value), so it matches the whole stored string exactly as
+     * DataFusion's native LIKE would. msg ∈ "Service alpha started"×7, "Service beta stopped"×2,
+     * "Gateway timeout error"×1.
+     */
+    public void testLikeOnTextFieldWithKeywordSubfield() throws Exception {
+        createIndex();
+        indexDocs();
+
+        assertMsgLikeCount("Service%", 9);   // both "Service ..." families: 7 + 2
+        assertMsgLikeCount("%timeout%", 1);  // only "Gateway timeout error"
+        assertMsgLikeCount("%alpha%", 7);    // only the alpha family
+    }
+
     /** The block-list only accepts the {@code lucene} namespace (the sole FILTER-delegation acceptor). */
     public void testBlockListRejectsNonLuceneBackend() throws Exception {
         Request req = new Request("PUT", "/_cluster/settings");
@@ -67,6 +82,11 @@ public class LikeDelegationIT extends AnalyticsRestTestCase {
     private void assertLikeCount(String pattern, long expected) throws Exception {
         String ppl = "source = " + INDEX_NAME + " | where str0 LIKE '" + pattern + "' | stats count() as c";
         assertCount(ppl, expected, "str0 LIKE '" + pattern + "'");
+    }
+
+    private void assertMsgLikeCount(String pattern, long expected) throws Exception {
+        String ppl = "source = " + INDEX_NAME + " | where msg LIKE '" + pattern + "' | stats count() as c";
+        assertCount(ppl, expected, "msg LIKE '" + pattern + "'");
     }
 
     private void assertPplLikeCount(String pattern, long expected) throws Exception {
@@ -106,7 +126,8 @@ public class LikeDelegationIT extends AnalyticsRestTestCase {
             + "},"
             + "\"mappings\": {"
             + "  \"properties\": {"
-            + "    \"str0\": { \"type\": \"keyword\" }"
+            + "    \"str0\": { \"type\": \"keyword\" },"
+            + "    \"msg\": { \"type\": \"text\", \"fields\": { \"keyword\": { \"type\": \"keyword\" } } }"
             + "  }"
             + "}"
             + "}";
@@ -124,10 +145,11 @@ public class LikeDelegationIT extends AnalyticsRestTestCase {
 
     private void indexDocs() throws Exception {
         StringBuilder bulk = new StringBuilder();
-        appendDocs(bulk, "apple", 4);
-        appendDocs(bulk, "applesauce", 3);
-        appendDocs(bulk, "banana", 2);
-        appendDocs(bulk, "cherry pie", 1);
+        // str0 (keyword) value paired with a msg (text+keyword-subfield) value per doc.
+        appendDocs(bulk, "apple", "Service alpha started", 4);
+        appendDocs(bulk, "applesauce", "Service alpha started", 3);
+        appendDocs(bulk, "banana", "Service beta stopped", 2);
+        appendDocs(bulk, "cherry pie", "Gateway timeout error", 1);
 
         Request bulkReq = new Request("POST", "/" + INDEX_NAME + "/_bulk");
         bulkReq.addParameter("refresh", "true");
@@ -135,10 +157,10 @@ public class LikeDelegationIT extends AnalyticsRestTestCase {
         assertOkAndParse(client().performRequest(bulkReq), "Bulk index");
     }
 
-    private static void appendDocs(StringBuilder bulk, String value, int count) {
+    private static void appendDocs(StringBuilder bulk, String str0, String msg, int count) {
         for (int i = 0; i < count; i++) {
             bulk.append("{\"index\": {}}\n");
-            bulk.append("{\"str0\": \"").append(value).append("\"}\n");
+            bulk.append("{\"str0\": \"").append(str0).append("\", \"msg\": \"").append(msg).append("\"}\n");
         }
     }
 }


### PR DESCRIPTION
Introduces an operational kill-switch for predicate delegation from a driving
backend (DataFusion) to a secondary backend (Lucene), so delegated predicate
shapes can be blocked at runtime without a deploy.

  - analytics.delegation.<backend>.blocked_predicates: an affix (namespaced)
    cluster setting modelling Map<BackendName, List<BlockedPredicate>>. Values
    are ScalarFunction names (case-insensitive); the vocabulary is the existing
    ScalarFunction enum, not a parallel type. Dynamic + NodeScope.
  - DelegationBlockList: resolves to Map<backend, EnumSet<ScalarFunction>> with
    a live affix update consumer; isBlocked() is the marking-time hot path. The
    block-list is validated against the runtime backend registry, not hardcoded:
      * the backend namespace must be an actual FILTER-delegation acceptor
        (today only "lucene"); any other namespace (e.g. datafusion) is rejected.
      * each predicate must have a serializer on that backend
        (delegatedPredicateSerializers keyset); non-delegatable predicates are
        rejected.
    Validation runs at setting-update time, so an invalid backend or predicate
    fails the cluster-settings update with a clear message.
  - Enforced at the marking layer (OpenSearchFilterRule.resolveViableBackends):
    a blocked predicate is dropped from a backend's viable set so the planner
    leaves it on a non-blocked backend. Only drops when a non-blocked backend
    survives — blocking is a delegation knob, never makes a predicate
    unexecutable.
  - Threaded through PlannerContext (defaults to empty); DefaultPlanExecutor
    owns the live instance.

Unit tests: DelegationBlockListTests (seed, dynamic update, unknown-name
rejection, non-acceptor namespace rejection, non-delegatable predicate
rejection) and FilterRuleTests block-list marking cases (drop, all-blocked
no-op, unknown-backend no-op). analytics-engine + analytics-framework suites
green; spotless clean.

Phase 0 of delegation predicate coverage (see ~/AnalyticsPlugin/DelegationPredicates).

Signed-off-by: Sandesh Kumar <sandeshkr419@gmail.com><!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
