### PR TITLE
[analytics-engine] Add per-backend delegation predicate block-list setting

### DIFF
--- a/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/ScalarFunction.java
+++ b/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/ScalarFunction.java
@@ -444,6 +444,19 @@ public enum ScalarFunction {
     }
 
     /**
+     * Resolves a configuration/setting token (case-insensitive) to a {@link ScalarFunction}, throwing
+     * a descriptive {@link IllegalArgumentException} if unrecognized. Used by cluster settings that
+     * name predicate functions (e.g. the delegation block-list).
+     */
+    public static ScalarFunction fromToken(String token) {
+        try {
+            return valueOf(token.trim().toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Unknown scalar function [" + token + "]");
+        }
+    }
+
+    /**
      * Maps a Calcite SqlFunction to a ScalarFunction by name, or null if not recognized.
      */
     public static ScalarFunction fromSqlFunction(SqlFunction function) {

--- a/sandbox/libs/analytics-framework/src/test/java/org/opensearch/analytics/spi/ScalarFunctionTests.java
+++ b/sandbox/libs/analytics-framework/src/test/java/org/opensearch/analytics/spi/ScalarFunctionTests.java
@@ -224,4 +224,21 @@ public class ScalarFunctionTests extends OpenSearchTestCase {
         assertNotNull("fromSqlFunction must resolve known names", resolved);
         assertSame(ScalarFunction.UPPER, resolved);
     }
+
+    // ── fromToken: case-insensitive token resolution ───────────────────────────────────────
+
+    public void testFromTokenCaseInsensitive() {
+        // fromToken trims surrounding whitespace and upper-cases before valueOf.
+        assertSame(ScalarFunction.LIKE, ScalarFunction.fromToken("like"));
+        assertSame(ScalarFunction.LIKE, ScalarFunction.fromToken("LIKE"));
+        assertSame(ScalarFunction.EQUALS, ScalarFunction.fromToken("  Equals "));
+    }
+
+    public void testFromTokenRejectsUnknown() {
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> ScalarFunction.fromToken("NOPE"));
+        assertTrue(
+            "exception message must mention the failure, got: " + e.getMessage(),
+            e.getMessage().contains("Unknown scalar function")
+        );
+    }
 }

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/DefaultPlanExecutor.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/DefaultPlanExecutor.java
@@ -39,9 +39,8 @@ import org.opensearch.analytics.planner.dag.FragmentConversionDriver;
 import org.opensearch.analytics.planner.dag.PlanAlternativeSelector;
 import org.opensearch.analytics.planner.dag.PlanForker;
 import org.opensearch.analytics.planner.dag.QueryDAG;
-import org.opensearch.analytics.settings.AnalyticsApproximationSettings;
 import org.opensearch.analytics.settings.AnalyticsQuerySettings;
-import org.opensearch.analytics.settings.DelegationBlockList;
+import org.opensearch.analytics.settings.PlannerSettings;
 import org.opensearch.analytics.stats.AnalyticsStatsCollector;
 import org.opensearch.arrow.allocator.AllocationRejection;
 import org.opensearch.cluster.ClusterState;
@@ -96,8 +95,7 @@ public class DefaultPlanExecutor extends HandledTransportAction<AnalyticsQueryRe
     private volatile int maxShardsPerQuery;
     private volatile int maxConcurrentShardRequestsPerNode;
     private volatile boolean preferMetadataDriver;
-    private volatile double oversamplingFactor;
-    private final DelegationBlockList delegationBlockList;
+    private final PlannerSettings plannerSettings;
     private final IndexNameExpressionResolver indexNameExpressionResolver;
     private final AnalyticsSearchSlowLog analyticsSearchSlowLog;
 
@@ -140,12 +138,6 @@ public class DefaultPlanExecutor extends HandledTransportAction<AnalyticsQueryRe
         this.maxShardsPerQuery = AnalyticsQuerySettings.MAX_SHARDS_PER_QUERY.get(clusterService.getSettings());
         clusterService.getClusterSettings()
             .addSettingsUpdateConsumer(AnalyticsQuerySettings.MAX_SHARDS_PER_QUERY, v -> maxShardsPerQuery = v);
-        // Per-backend delegation block-list; self-registers an affix update consumer for live changes.
-        this.delegationBlockList = DelegationBlockList.create(
-            clusterService.getClusterSettings(),
-            clusterService.getSettings(),
-            capabilityRegistry
-        );
         this.maxConcurrentShardRequestsPerNode = AnalyticsQuerySettings.MAX_CONCURRENT_SHARD_REQUESTS_PER_NODE.get(
             clusterService.getSettings()
         );
@@ -157,9 +149,13 @@ public class DefaultPlanExecutor extends HandledTransportAction<AnalyticsQueryRe
         this.preferMetadataDriver = AnalyticsPlugin.PREFER_METADATA_DRIVER.get(clusterService.getSettings());
         clusterService.getClusterSettings()
             .addSettingsUpdateConsumer(AnalyticsPlugin.PREFER_METADATA_DRIVER, v -> preferMetadataDriver = v);
-        this.oversamplingFactor = AnalyticsApproximationSettings.SHARD_BUCKET_OVERSAMPLING_FACTOR.get(clusterService.getSettings());
-        clusterService.getClusterSettings()
-            .addSettingsUpdateConsumer(AnalyticsApproximationSettings.SHARD_BUCKET_OVERSAMPLING_FACTOR, v -> oversamplingFactor = v);
+        // Planner settings (oversampling factor + delegation block-list); self-registers update
+        // consumers for live changes.
+        this.plannerSettings = PlannerSettings.create(
+            clusterService.getClusterSettings(),
+            clusterService.getSettings(),
+            capabilityRegistry
+        );
         this.indexNameExpressionResolver = indexNameExpressionResolver;
         this.analyticsSearchSlowLog = analyticsSearchSlowLog;
     }
@@ -244,8 +240,7 @@ public class DefaultPlanExecutor extends HandledTransportAction<AnalyticsQueryRe
             false,
             preferMetadataDriver
         );
-        plannerContext.setOversamplingFactor(oversamplingFactor);
-        plannerContext.setDelegationBlockList(delegationBlockList);
+        plannerContext.setPlannerSettings(plannerSettings);
         RelNode plan = PlannerImpl.createPlan(logicalFragment, plannerContext);
         final String fullPlan = profile ? org.apache.calcite.plan.RelOptUtil.toString(plan) : null;
         QueryDAG dag = DAGBuilder.build(plan, capabilityRegistry, clusterService, indexNameExpressionResolver);

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/DefaultPlanExecutor.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/DefaultPlanExecutor.java
@@ -41,6 +41,7 @@ import org.opensearch.analytics.planner.dag.PlanForker;
 import org.opensearch.analytics.planner.dag.QueryDAG;
 import org.opensearch.analytics.settings.AnalyticsApproximationSettings;
 import org.opensearch.analytics.settings.AnalyticsQuerySettings;
+import org.opensearch.analytics.settings.DelegationBlockList;
 import org.opensearch.analytics.stats.AnalyticsStatsCollector;
 import org.opensearch.arrow.allocator.AllocationRejection;
 import org.opensearch.cluster.ClusterState;
@@ -96,6 +97,7 @@ public class DefaultPlanExecutor extends HandledTransportAction<AnalyticsQueryRe
     private volatile int maxConcurrentShardRequestsPerNode;
     private volatile boolean preferMetadataDriver;
     private volatile double oversamplingFactor;
+    private final DelegationBlockList delegationBlockList;
     private final IndexNameExpressionResolver indexNameExpressionResolver;
     private final AnalyticsSearchSlowLog analyticsSearchSlowLog;
 
@@ -138,6 +140,12 @@ public class DefaultPlanExecutor extends HandledTransportAction<AnalyticsQueryRe
         this.maxShardsPerQuery = AnalyticsQuerySettings.MAX_SHARDS_PER_QUERY.get(clusterService.getSettings());
         clusterService.getClusterSettings()
             .addSettingsUpdateConsumer(AnalyticsQuerySettings.MAX_SHARDS_PER_QUERY, v -> maxShardsPerQuery = v);
+        // Per-backend delegation block-list; self-registers an affix update consumer for live changes.
+        this.delegationBlockList = DelegationBlockList.create(
+            clusterService.getClusterSettings(),
+            clusterService.getSettings(),
+            capabilityRegistry
+        );
         this.maxConcurrentShardRequestsPerNode = AnalyticsQuerySettings.MAX_CONCURRENT_SHARD_REQUESTS_PER_NODE.get(
             clusterService.getSettings()
         );
@@ -237,6 +245,7 @@ public class DefaultPlanExecutor extends HandledTransportAction<AnalyticsQueryRe
             preferMetadataDriver
         );
         plannerContext.setOversamplingFactor(oversamplingFactor);
+        plannerContext.setDelegationBlockList(delegationBlockList);
         RelNode plan = PlannerImpl.createPlan(logicalFragment, plannerContext);
         final String fullPlan = profile ? org.apache.calcite.plan.RelOptUtil.toString(plan) : null;
         QueryDAG dag = DAGBuilder.build(plan, capabilityRegistry, clusterService, indexNameExpressionResolver);

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/PlannerContext.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/PlannerContext.java
@@ -9,6 +9,7 @@
 package org.opensearch.analytics.planner;
 
 import org.opensearch.analytics.planner.rel.OpenSearchDistributionTraitDef;
+import org.opensearch.analytics.settings.DelegationBlockList;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.common.Nullable;
@@ -32,6 +33,9 @@ public class PlannerContext {
     private double oversamplingFactor;
     private int annotationIdCounter;
     private RuleProfilingListener.PlannerProfile lastProfile;
+    // Per-backend delegation block-list. Defaults to empty (nothing blocked); DefaultPlanExecutor
+    // injects the live, settings-backed instance via setDelegationBlockList before planning.
+    private DelegationBlockList delegationBlockList = DelegationBlockList.empty();
 
     public PlannerContext(CapabilityRegistry capabilityRegistry, ClusterState clusterState) {
         this(capabilityRegistry, clusterState, null, false, true);
@@ -98,6 +102,16 @@ public class PlannerContext {
 
     public CapabilityRegistry getCapabilityRegistry() {
         return capabilityRegistry;
+    }
+
+    /** Per-backend delegation block-list consulted at marking time. Never null (defaults to empty). */
+    public DelegationBlockList getDelegationBlockList() {
+        return delegationBlockList;
+    }
+
+    /** Inject the live, settings-backed block-list. Called by {@code DefaultPlanExecutor} before planning. */
+    public void setDelegationBlockList(DelegationBlockList delegationBlockList) {
+        this.delegationBlockList = delegationBlockList;
     }
 
     public ClusterState getClusterState() {

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/PlannerContext.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/PlannerContext.java
@@ -10,6 +10,7 @@ package org.opensearch.analytics.planner;
 
 import org.opensearch.analytics.planner.rel.OpenSearchDistributionTraitDef;
 import org.opensearch.analytics.settings.DelegationBlockList;
+import org.opensearch.analytics.settings.PlannerSettings;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.common.Nullable;
@@ -30,12 +31,12 @@ public class PlannerContext {
     private final OpenSearchDistributionTraitDef distributionTraitDef;
     private final boolean profilingEnabled;
     private final boolean preferMetadataDriver;
-    private double oversamplingFactor;
     private int annotationIdCounter;
     private RuleProfilingListener.PlannerProfile lastProfile;
-    // Per-backend delegation block-list. Defaults to empty (nothing blocked); DefaultPlanExecutor
-    // injects the live, settings-backed instance via setDelegationBlockList before planning.
-    private DelegationBlockList delegationBlockList = DelegationBlockList.empty();
+    // Cluster settings the planner consults at planning time (oversampling factor + delegation
+    // block-list). Defaults to planner defaults; DefaultPlanExecutor injects the live, settings-backed
+    // instance via setPlannerSettings before planning.
+    private PlannerSettings plannerSettings = PlannerSettings.defaults();
 
     public PlannerContext(CapabilityRegistry capabilityRegistry, ClusterState clusterState) {
         this(capabilityRegistry, clusterState, null, false, true);
@@ -106,12 +107,12 @@ public class PlannerContext {
 
     /** Per-backend delegation block-list consulted at marking time. Never null (defaults to empty). */
     public DelegationBlockList getDelegationBlockList() {
-        return delegationBlockList;
+        return plannerSettings.getDelegationBlockList();
     }
 
-    /** Inject the live, settings-backed block-list. Called by {@code DefaultPlanExecutor} before planning. */
-    public void setDelegationBlockList(DelegationBlockList delegationBlockList) {
-        this.delegationBlockList = delegationBlockList;
+    /** Inject the live, settings-backed planner settings. Called by {@code DefaultPlanExecutor} before planning. */
+    public void setPlannerSettings(PlannerSettings plannerSettings) {
+        this.plannerSettings = plannerSettings;
     }
 
     public ClusterState getClusterState() {
@@ -119,11 +120,7 @@ public class PlannerContext {
     }
 
     public double getOversamplingFactor() {
-        return oversamplingFactor;
-    }
-
-    public void setOversamplingFactor(double oversamplingFactor) {
-        this.oversamplingFactor = oversamplingFactor;
+        return plannerSettings.getOversamplingFactor();
     }
 
     public OpenSearchDistributionTraitDef getDistributionTraitDef() {

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchFilterRule.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchFilterRule.java
@@ -24,6 +24,7 @@ import org.opensearch.analytics.planner.RelNodeUtils;
 import org.opensearch.analytics.planner.rel.AnnotatedPredicate;
 import org.opensearch.analytics.planner.rel.OpenSearchFilter;
 import org.opensearch.analytics.planner.rel.OpenSearchRelNode;
+import org.opensearch.analytics.settings.DelegationBlockList;
 import org.opensearch.analytics.spi.DelegationType;
 import org.opensearch.analytics.spi.FieldStorageInfo;
 import org.opensearch.analytics.spi.FieldType;
@@ -251,6 +252,17 @@ public class OpenSearchFilterRule extends RelOptRule {
                 }
             }
             viableSet.retainAll(registry.scalarBackendsAnyFormat(scalarFunc, returnType));
+        }
+
+        // Per-backend delegation block-list. Drop backends that block this predicate so it is never
+        // marked viable for them — but only when a non-blocked backend survives: blocking is a
+        // delegation knob and must never make a predicate unexecutable.
+        DelegationBlockList blockList = context.getDelegationBlockList();
+        if (!blockList.isEmpty()) {
+            boolean someBackendSurvives = viableSet.stream().anyMatch(backend -> !blockList.isBlocked(backend, function));
+            if (someBackendSurvives) {
+                viableSet.removeIf(backend -> blockList.isBlocked(backend, function));
+            }
         }
 
         if (viableSet.isEmpty()) {

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/settings/AnalyticsQuerySettings.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/settings/AnalyticsQuerySettings.java
@@ -8,12 +8,37 @@
 
 package org.opensearch.analytics.settings;
 
+import org.opensearch.analytics.spi.ScalarFunction;
 import org.opensearch.common.settings.Setting;
 
 import java.util.List;
 
 /** Cluster-level settings for analytics query execution limits. */
 public final class AnalyticsQuerySettings {
+
+    /** Affix-setting prefix; full key is {@code analytics.delegation.<backend>.blocked_predicates}. */
+    public static final String DELEGATION_BLOCKED_PREDICATES_PREFIX = "analytics.delegation.";
+
+    /**
+     * Per-backend block-list of predicate functions that must NOT be delegated to that backend. Affix
+     * (namespaced) setting: the backend name is the namespace, the value is a list of
+     * {@link ScalarFunction} names (case-insensitive). Models the operator-facing
+     * {@code Map<BackendName, List<BlockedPredicate>>} contract.
+     *
+     * <pre>
+     * analytics.delegation.lucene.blocked_predicates:  ["LIKE","EQUALS"]
+     * </pre>
+     *
+     * <p>Default empty. Enforced at the marking layer ({@code OpenSearchFilterRule}): a blocked
+     * predicate is dropped from that backend's viable set, so the planner leaves it on a non-blocked
+     * backend. Dynamic + NodeScope. Registry-derived validation (namespace must be a FILTER-delegation
+     * acceptor; predicate must have a serializer on that backend) runs in {@code DelegationBlockList}.
+     */
+    public static final Setting.AffixSetting<List<ScalarFunction>> DELEGATION_BLOCKED_PREDICATES = Setting.affixKeySetting(
+        DELEGATION_BLOCKED_PREDICATES_PREFIX,
+        "blocked_predicates",
+        key -> Setting.listSetting(key, List.of(), ScalarFunction::fromToken, Setting.Property.NodeScope, Setting.Property.Dynamic)
+    );
 
     public static final Setting<Integer> MAX_SHARDS_PER_QUERY = Setting.intSetting(
         "analytics.query.max_shards_per_query",
@@ -38,7 +63,7 @@ public final class AnalyticsQuerySettings {
     );
 
     public static List<Setting<?>> all() {
-        return List.of(MAX_SHARDS_PER_QUERY, MAX_CONCURRENT_SHARD_REQUESTS_PER_NODE);
+        return List.of(DELEGATION_BLOCKED_PREDICATES, MAX_SHARDS_PER_QUERY, MAX_CONCURRENT_SHARD_REQUESTS_PER_NODE);
     }
 
     private AnalyticsQuerySettings() {}

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/settings/DelegationBlockList.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/settings/DelegationBlockList.java
@@ -1,0 +1,153 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.settings;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.analytics.planner.CapabilityRegistry;
+import org.opensearch.analytics.spi.DelegationType;
+import org.opensearch.analytics.spi.ScalarFunction;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Settings;
+
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Resolved, hot-reloadable view of the per-backend delegation block-list configured via
+ * {@link AnalyticsQuerySettings#DELEGATION_BLOCKED_PREDICATES}. Holds the operator-facing
+ * {@code Map<BackendName, List<BlockedPredicate>>} as a {@code Map<String, EnumSet<ScalarFunction>>}
+ * so the marking-time hot path ({@link #isBlocked}) is an enum-set membership check.
+ *
+ * <p>The vocabulary is <b>derived from the runtime backend registry</b>, not a parallel enum: a
+ * backend namespace is valid only if the backend <em>accepts</em> FILTER delegation
+ * ({@link CapabilityRegistry#delegationAcceptors}), and a predicate is valid only if that backend
+ * ships a serializer for it ({@code delegatedPredicateSerializers().keySet()}). Today Lucene is the
+ * only FILTER-delegation acceptor, so any other namespace (e.g. {@code datafusion}) is rejected.
+ * Validation runs at <b>setting-update time</b> (the affix update consumer / initial seed), so an
+ * invalid backend or unsupported predicate fails the cluster-settings update with a clear message.
+ *
+ * @opensearch.internal
+ */
+public final class DelegationBlockList {
+
+    private static final Logger LOGGER = LogManager.getLogger(DelegationBlockList.class);
+
+    /** backendName -> blocked predicate functions. Absent/empty entry ⇒ nothing blocked. */
+    private final Map<String, EnumSet<ScalarFunction>> blockedByBackend;
+
+    private DelegationBlockList(Map<String, EnumSet<ScalarFunction>> blockedByBackend) {
+        this.blockedByBackend = blockedByBackend;
+    }
+
+    /** An empty block-list — nothing is blocked. */
+    public static DelegationBlockList empty() {
+        return new DelegationBlockList(new ConcurrentHashMap<>());
+    }
+
+    /** Test/seed factory from a plain map (assumes pre-validated input). */
+    public static DelegationBlockList fromMap(Map<String, List<ScalarFunction>> seed) {
+        Map<String, EnumSet<ScalarFunction>> map = new ConcurrentHashMap<>();
+        for (Map.Entry<String, List<ScalarFunction>> e : seed.entrySet()) {
+            map.put(e.getKey(), toEnumSet(e.getValue()));
+        }
+        return new DelegationBlockList(map);
+    }
+
+    /**
+     * Production factory: seeds from the current cluster settings and registers an affix update
+     * consumer + validator so later {@code analytics.delegation.<backend>.blocked_predicates} changes
+     * are validated against {@code registry} and applied live. The validator rejects (1) a namespace
+     * that is not a FILTER-delegation acceptor and (2) a predicate the acceptor has no serializer for.
+     */
+    public static DelegationBlockList create(ClusterSettings clusterSettings, Settings initialSettings, CapabilityRegistry registry) {
+        Map<String, EnumSet<ScalarFunction>> map = new ConcurrentHashMap<>();
+        DelegationBlockList blockList = new DelegationBlockList(map);
+        Map<String, List<ScalarFunction>> initial = AnalyticsQuerySettings.DELEGATION_BLOCKED_PREDICATES.getAsMap(initialSettings);
+        for (Map.Entry<String, List<ScalarFunction>> e : initial.entrySet()) {
+            validate(registry, e.getKey(), e.getValue());
+            if (!e.getValue().isEmpty()) {
+                map.put(e.getKey(), toEnumSet(e.getValue()));
+            }
+        }
+        clusterSettings.addAffixUpdateConsumer(
+            AnalyticsQuerySettings.DELEGATION_BLOCKED_PREDICATES,
+            blockList::update,
+            (backendName, predicates) -> validate(registry, backendName, predicates)
+        );
+        return blockList;
+    }
+
+    /**
+     * Rejects an invalid block-list entry: an unknown delegation-target backend, or a predicate the
+     * target backend cannot delegate (no serializer). Called by the affix update validator, so a bad
+     * value fails the cluster-settings update before {@link #update} ever runs.
+     */
+    private static void validate(CapabilityRegistry registry, String backendName, List<ScalarFunction> predicates) {
+        if (predicates.isEmpty()) {
+            return; // clearing a namespace is always allowed
+        }
+        List<String> acceptors = registry.delegationAcceptors(DelegationType.FILTER);
+        if (!acceptors.contains(backendName)) {
+            throw new IllegalArgumentException(
+                "analytics.delegation."
+                    + backendName
+                    + ".blocked_predicates: ["
+                    + backendName
+                    + "] is not a delegation-target backend; FILTER delegation acceptors are "
+                    + acceptors
+            );
+        }
+        Set<ScalarFunction> delegatable = registry.getBackend(backendName).delegatedPredicateSerializers().keySet();
+        for (ScalarFunction predicate : predicates) {
+            if (!delegatable.contains(predicate)) {
+                throw new IllegalArgumentException(
+                    "analytics.delegation."
+                        + backendName
+                        + ".blocked_predicates: ["
+                        + predicate
+                        + "] is not delegatable to ["
+                        + backendName
+                        + "]; delegatable predicates are "
+                        + delegatable
+                );
+            }
+        }
+    }
+
+    /** Update (or clear) the blocked set for one backend namespace. Called by the settings-update thread. */
+    private void update(String backendName, List<ScalarFunction> blocked) {
+        if (blocked == null || blocked.isEmpty()) {
+            blockedByBackend.remove(backendName);
+        } else {
+            blockedByBackend.put(backendName, toEnumSet(blocked));
+        }
+        LOGGER.info("Delegation block-list updated: backend [{}] now blocks {}", backendName, blocked);
+    }
+
+    /** True iff {@code predicate} is blocked from delegation to {@code backendName}. */
+    public boolean isBlocked(String backendName, ScalarFunction predicate) {
+        EnumSet<ScalarFunction> set = blockedByBackend.get(backendName);
+        return set != null && set.contains(predicate);
+    }
+
+    /** True iff there is at least one block entry (lets callers skip per-predicate work when empty). */
+    public boolean isEmpty() {
+        return blockedByBackend.isEmpty();
+    }
+
+    private static EnumSet<ScalarFunction> toEnumSet(List<ScalarFunction> values) {
+        EnumSet<ScalarFunction> set = EnumSet.noneOf(ScalarFunction.class);
+        set.addAll(values);
+        return set;
+    }
+}

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/settings/PlannerSettings.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/settings/PlannerSettings.java
@@ -1,0 +1,79 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.settings;
+
+import org.opensearch.analytics.planner.CapabilityRegistry;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Settings;
+
+/**
+ * Top-level, hot-reloadable view of the cluster settings the planner consults at planning time.
+ * Bundles the otherwise-scattered planner knobs into one wrapper so the planner context carries a
+ * single object instead of one field (plus update wiring) per setting:
+ *
+ * <ul>
+ *   <li>{@code analytics.shard_bucket_oversampling_factor} — shard-bucket oversampling factor
+ *       (volatile; updated live).</li>
+ *   <li>{@code analytics.delegation.<backend>.blocked_predicates} — the per-backend delegation
+ *       block-list ({@link DelegationBlockList}, which self-updates via its own affix consumer).</li>
+ * </ul>
+ *
+ * <p>{@link #create} reads current values and self-registers the dynamic update consumers, so a
+ * single instance built at executor construction stays current for the node's lifetime. Tests that
+ * don't exercise cluster settings use {@link #defaults()} or {@link #of}.
+ *
+ * @opensearch.internal
+ */
+public final class PlannerSettings {
+
+    private volatile double oversamplingFactor;
+    private final DelegationBlockList delegationBlockList;
+
+    private PlannerSettings(double oversamplingFactor, DelegationBlockList delegationBlockList) {
+        this.oversamplingFactor = oversamplingFactor;
+        this.delegationBlockList = delegationBlockList;
+    }
+
+    /**
+     * Production factory: seeds from the current cluster settings and registers update consumers so
+     * later changes apply live. The block-list ({@link DelegationBlockList#create}) self-registers its
+     * own affix consumer + registry-derived validator; the oversampling factor is refreshed here.
+     */
+    public static PlannerSettings create(ClusterSettings clusterSettings, Settings initialSettings, CapabilityRegistry registry) {
+        DelegationBlockList blockList = DelegationBlockList.create(clusterSettings, initialSettings, registry);
+        PlannerSettings settings = new PlannerSettings(
+            AnalyticsApproximationSettings.SHARD_BUCKET_OVERSAMPLING_FACTOR.get(initialSettings),
+            blockList
+        );
+        clusterSettings.addSettingsUpdateConsumer(
+            AnalyticsApproximationSettings.SHARD_BUCKET_OVERSAMPLING_FACTOR,
+            v -> settings.oversamplingFactor = v
+        );
+        return settings;
+    }
+
+    /** Planner defaults for unit tests: no oversampling, nothing blocked. */
+    public static PlannerSettings defaults() {
+        return new PlannerSettings(0.0, DelegationBlockList.empty());
+    }
+
+    /** Explicit values for tests that exercise a specific setting. */
+    public static PlannerSettings of(double oversamplingFactor, DelegationBlockList delegationBlockList) {
+        return new PlannerSettings(oversamplingFactor, delegationBlockList);
+    }
+
+    public double getOversamplingFactor() {
+        return oversamplingFactor;
+    }
+
+    /** Per-backend delegation block-list consulted at marking time. Never null (defaults to empty). */
+    public DelegationBlockList getDelegationBlockList() {
+        return delegationBlockList;
+    }
+}

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/FilterRuleTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/FilterRuleTests.java
@@ -28,10 +28,12 @@ import org.apache.calcite.util.ImmutableBitSet;
 import org.opensearch.analytics.planner.rel.AnnotatedPredicate;
 import org.opensearch.analytics.planner.rel.OpenSearchFilter;
 import org.opensearch.analytics.planner.rel.OpenSearchTableScan;
+import org.opensearch.analytics.settings.DelegationBlockList;
 import org.opensearch.analytics.spi.AnalyticsSearchBackendPlugin;
 import org.opensearch.analytics.spi.BackendCapabilityProvider;
 import org.opensearch.analytics.spi.DelegationType;
 import org.opensearch.analytics.spi.EngineCapability;
+import org.opensearch.analytics.spi.ScalarFunction;
 
 import java.util.List;
 import java.util.Map;
@@ -86,6 +88,71 @@ public class FilterRuleTests extends BasePlannerRulesTests {
         // Operator-level: only child backend (no delegation configured)
         assertEquals(1, result.getViableBackends().size());
         assertTrue(result.getViableBackends().contains(MockDataFusionBackend.NAME));
+    }
+
+    /**
+     * Keyword equality is normally viable for both backends per-predicate (see
+     * {@link #testKeywordEqualsAnnotatedWithBothBackends}). Blocking EQUALS for the Lucene backend
+     * via the delegation block-list must drop Lucene from the predicate's viable set, leaving only
+     * DataFusion — so the predicate is never delegated to Lucene.
+     */
+    public void testBlockListDropsBlockedBackendFromPredicate() {
+        DelegationBlockList blockList = DelegationBlockList.fromMap(Map.of(MockLuceneBackend.NAME, List.of(ScalarFunction.EQUALS)));
+        OpenSearchFilter result = runFilterWithBlockList(
+            "parquet",
+            Map.of("country_name", Map.of("type", "keyword", "index", true)),
+            new String[] { "country_name" },
+            new SqlTypeName[] { SqlTypeName.VARCHAR },
+            makeEquals(0, SqlTypeName.VARCHAR, "US"),
+            blockList
+        );
+
+        AnnotatedPredicate annotated = (AnnotatedPredicate) result.getCondition();
+        assertTrue("DataFusion stays viable", annotated.getViableBackends().contains(MockDataFusionBackend.NAME));
+        assertFalse("Lucene dropped by block-list", annotated.getViableBackends().contains(MockLuceneBackend.NAME));
+        assertEquals(1, annotated.getViableBackends().size());
+    }
+
+    /**
+     * Safety invariant: blocking must never make a predicate unexecutable. If EVERY viable backend
+     * blocks the shape, the block-list is ignored and all backends remain (there is nowhere else to
+     * run the predicate). Here both backends block EQUALS, so the annotation keeps both.
+     */
+    public void testBlockListIgnoredWhenAllViableBackendsBlock() {
+        DelegationBlockList blockList = DelegationBlockList.fromMap(
+            Map.of(MockLuceneBackend.NAME, List.of(ScalarFunction.EQUALS), MockDataFusionBackend.NAME, List.of(ScalarFunction.EQUALS))
+        );
+        OpenSearchFilter result = runFilterWithBlockList(
+            "parquet",
+            Map.of("country_name", Map.of("type", "keyword", "index", true)),
+            new String[] { "country_name" },
+            new SqlTypeName[] { SqlTypeName.VARCHAR },
+            makeEquals(0, SqlTypeName.VARCHAR, "US"),
+            blockList
+        );
+
+        AnnotatedPredicate annotated = (AnnotatedPredicate) result.getCondition();
+        assertEquals("both backends retained — blocking can't strand the predicate", 2, annotated.getViableBackends().size());
+    }
+
+    /**
+     * Blocking a predicate for one backend must not affect a different, non-blocked predicate shape:
+     * blocking EQUALS for Lucene leaves a keyword-equality dual-viable annotation untouched when the
+     * block targets a different backend namespace that doesn't exist.
+     */
+    public void testBlockListUnknownBackendIsNoOp() {
+        DelegationBlockList blockList = DelegationBlockList.fromMap(Map.of("not-a-backend", List.of(ScalarFunction.EQUALS)));
+        OpenSearchFilter result = runFilterWithBlockList(
+            "parquet",
+            Map.of("country_name", Map.of("type", "keyword", "index", true)),
+            new String[] { "country_name" },
+            new SqlTypeName[] { SqlTypeName.VARCHAR },
+            makeEquals(0, SqlTypeName.VARCHAR, "US"),
+            blockList
+        );
+
+        AnnotatedPredicate annotated = (AnnotatedPredicate) result.getCondition();
+        assertEquals("both backends still viable", 2, annotated.getViableBackends().size());
     }
 
     // ---- Viable backends with delegation ----
@@ -647,6 +714,25 @@ public class FilterRuleTests extends BasePlannerRulesTests {
         RexNode condition
     ) {
         return runFilter(format, fields, fieldNames, fieldTypes, condition, delegationBackends(), Set.of(MockDataFusionBackend.NAME));
+    }
+
+    /** Mirrors {@code runFilter} but injects a {@link DelegationBlockList} into the planner context. */
+    private OpenSearchFilter runFilterWithBlockList(
+        String format,
+        Map<String, Map<String, Object>> fields,
+        String[] fieldNames,
+        SqlTypeName[] fieldTypes,
+        RexNode condition,
+        DelegationBlockList blockList
+    ) {
+        PlannerContext context = buildContext(format, fields, List.of(DATAFUSION, LUCENE));
+        context.setDelegationBlockList(blockList);
+        RelOptTable table = mockTable("test_index", fieldNames, fieldTypes);
+        LogicalFilter filter = LogicalFilter.create(stubScan(table), condition);
+        RelNode result = unwrapExchange(runPlanner(filter, context));
+        logger.info("Plan:\n{}", RelOptUtil.toString(result));
+        assertTrue("Expected OpenSearchFilter, got " + result.getClass().getSimpleName(), result instanceof OpenSearchFilter);
+        return (OpenSearchFilter) result;
     }
 
     /**

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/FilterRuleTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/FilterRuleTests.java
@@ -29,6 +29,7 @@ import org.opensearch.analytics.planner.rel.AnnotatedPredicate;
 import org.opensearch.analytics.planner.rel.OpenSearchFilter;
 import org.opensearch.analytics.planner.rel.OpenSearchTableScan;
 import org.opensearch.analytics.settings.DelegationBlockList;
+import org.opensearch.analytics.settings.PlannerSettings;
 import org.opensearch.analytics.spi.AnalyticsSearchBackendPlugin;
 import org.opensearch.analytics.spi.BackendCapabilityProvider;
 import org.opensearch.analytics.spi.DelegationType;
@@ -726,7 +727,7 @@ public class FilterRuleTests extends BasePlannerRulesTests {
         DelegationBlockList blockList
     ) {
         PlannerContext context = buildContext(format, fields, List.of(DATAFUSION, LUCENE));
-        context.setDelegationBlockList(blockList);
+        context.setPlannerSettings(PlannerSettings.of(0.0, blockList));
         RelOptTable table = mockTable("test_index", fieldNames, fieldTypes);
         LogicalFilter filter = LogicalFilter.create(stubScan(table), condition);
         RelNode result = unwrapExchange(runPlanner(filter, context));

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/TopKRewriterPlanShapeTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/TopKRewriterPlanShapeTests.java
@@ -20,6 +20,8 @@ import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.util.ImmutableBitSet;
+import org.opensearch.analytics.settings.DelegationBlockList;
+import org.opensearch.analytics.settings.PlannerSettings;
 
 import java.util.List;
 
@@ -348,7 +350,7 @@ public class TopKRewriterPlanShapeTests extends PlanShapeTestBase {
 
     private PlannerContext contextWithOversampling(double factor) {
         PlannerContext ctx = buildContext("parquet", 2, intFields());
-        ctx.setOversamplingFactor(factor);
+        ctx.setPlannerSettings(PlannerSettings.of(factor, DelegationBlockList.empty()));
         return ctx;
     }
 }

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/settings/DelegationBlockListTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/settings/DelegationBlockListTests.java
@@ -1,0 +1,150 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.settings;
+
+import org.opensearch.analytics.planner.CapabilityRegistry;
+import org.opensearch.analytics.planner.FieldStorageResolver;
+import org.opensearch.analytics.spi.AnalyticsSearchBackendPlugin;
+import org.opensearch.analytics.spi.BackendCapabilityProvider;
+import org.opensearch.analytics.spi.DelegatedPredicateSerializer;
+import org.opensearch.analytics.spi.DelegationType;
+import org.opensearch.analytics.spi.EngineCapability;
+import org.opensearch.analytics.spi.ScalarFunction;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+
+public class DelegationBlockListTests extends OpenSearchTestCase {
+
+    /** Lucene-like backend: accepts FILTER delegation and ships serializers for EQUALS + LIKE. */
+    private static final String LUCENE = "lucene";
+
+    private CapabilityRegistry registry() {
+        AnalyticsSearchBackendPlugin lucene = new AnalyticsSearchBackendPlugin() {
+            @Override
+            public String name() {
+                return LUCENE;
+            }
+
+            @Override
+            public BackendCapabilityProvider getCapabilityProvider() {
+                return new BackendCapabilityProvider() {
+                    @Override
+                    public Set<EngineCapability> supportedEngineCapabilities() {
+                        return Set.of();
+                    }
+
+                    @Override
+                    public Set<DelegationType> acceptedDelegations() {
+                        return Set.of(DelegationType.FILTER);
+                    }
+                };
+            }
+
+            @Override
+            public Map<ScalarFunction, DelegatedPredicateSerializer> delegatedPredicateSerializers() {
+                // Only EQUALS and LIKE are delegatable (have serializers) in this fixture.
+                DelegatedPredicateSerializer stub = (call, fieldStorage) -> new byte[0];
+                return Map.of(ScalarFunction.EQUALS, stub, ScalarFunction.LIKE, stub);
+            }
+        };
+        Function<IndexMetadata, FieldStorageResolver> fieldStorageFactory = FieldStorageResolver::new;
+        return new CapabilityRegistry(List.of(lucene), fieldStorageFactory);
+    }
+
+    private ClusterSettings clusterSettings(Settings settings) {
+        return new ClusterSettings(settings, Set.of(AnalyticsQuerySettings.DELEGATION_BLOCKED_PREDICATES));
+    }
+
+    public void testEmptyBlocksNothing() {
+        DelegationBlockList blockList = DelegationBlockList.empty();
+        assertTrue(blockList.isEmpty());
+        assertFalse(blockList.isBlocked(LUCENE, ScalarFunction.LIKE));
+    }
+
+    public void testSeedFromClusterSettings() {
+        Settings settings = Settings.builder().putList("analytics.delegation.lucene.blocked_predicates", "LIKE", "equals").build();
+        DelegationBlockList blockList = DelegationBlockList.create(clusterSettings(settings), settings, registry());
+        assertTrue(blockList.isBlocked(LUCENE, ScalarFunction.LIKE));
+        assertTrue("case-insensitive token parsed", blockList.isBlocked(LUCENE, ScalarFunction.EQUALS));
+    }
+
+    public void testDynamicUpdate() {
+        ClusterSettings clusterSettings = clusterSettings(Settings.EMPTY);
+        DelegationBlockList blockList = DelegationBlockList.create(clusterSettings, Settings.EMPTY, registry());
+        assertTrue(blockList.isEmpty());
+
+        clusterSettings.applySettings(Settings.builder().putList("analytics.delegation.lucene.blocked_predicates", "LIKE").build());
+        assertTrue(blockList.isBlocked(LUCENE, ScalarFunction.LIKE));
+
+        // Clearing the list removes the backend's block entry.
+        clusterSettings.applySettings(Settings.builder().putList("analytics.delegation.lucene.blocked_predicates").build());
+        assertFalse(blockList.isBlocked(LUCENE, ScalarFunction.LIKE));
+        assertTrue(blockList.isEmpty());
+    }
+
+    public void testUnknownPredicateNameRejectedByElementParser() {
+        // A token that isn't a ScalarFunction fails the list element parser at update time.
+        ClusterSettings clusterSettings = clusterSettings(Settings.EMPTY);
+        DelegationBlockList.create(clusterSettings, Settings.EMPTY, registry());
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> clusterSettings.applySettings(
+                Settings.builder().putList("analytics.delegation.lucene.blocked_predicates", "NONSENSE").build()
+            )
+        );
+    }
+
+    public void testNonAcceptorBackendNamespaceRejected() {
+        // datafusion is not a FILTER-delegation acceptor → the namespace is rejected at update time.
+        ClusterSettings clusterSettings = clusterSettings(Settings.EMPTY);
+        DelegationBlockList.create(clusterSettings, Settings.EMPTY, registry());
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> clusterSettings.applySettings(
+                Settings.builder().putList("analytics.delegation.datafusion.blocked_predicates", "LIKE").build()
+            )
+        );
+        assertTrue("cause: " + e, causeChainContains(e, "not a delegation-target backend"));
+    }
+
+    public void testNonDelegatablePredicateRejected() {
+        // REGEXP has no serializer in this fixture → rejected even for the valid lucene namespace.
+        ClusterSettings clusterSettings = clusterSettings(Settings.EMPTY);
+        DelegationBlockList.create(clusterSettings, Settings.EMPTY, registry());
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> clusterSettings.applySettings(
+                Settings.builder().putList("analytics.delegation.lucene.blocked_predicates", "REGEXP").build()
+            )
+        );
+        assertTrue("cause: " + e, causeChainContains(e, "not delegatable"));
+    }
+
+    public void testSeedRejectsInvalidNamespaceAtConstruction() {
+        Settings settings = Settings.builder().putList("analytics.delegation.datafusion.blocked_predicates", "LIKE").build();
+        expectThrows(IllegalArgumentException.class, () -> DelegationBlockList.create(clusterSettings(settings), settings, registry()));
+    }
+
+    /** The cluster-settings layer wraps the validator's IllegalArgumentException; search the chain. */
+    private static boolean causeChainContains(Throwable t, String fragment) {
+        for (Throwable c = t; c != null; c = c.getCause()) {
+            if (c.getMessage() != null && c.getMessage().contains(fragment)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/TwoShardScalarIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/TwoShardScalarIT.java
@@ -25,7 +25,9 @@ public class TwoShardScalarIT extends TwoShardReduceTestCase {
 
     @Override
     protected Map<String, String> knownIssues() {
-        // coalesce() on an ip column throws "unsupported object class [B" (ip byte[] not handled).
-        return Map.of("sc_coalesce_ip", "coalesce() on ip throws ExpressionEvaluationException: unsupported object class [B");
+        return Map.of(
+            "sc_coalesce_ip", "coalesce() on ip throws ExpressionEvaluationException: unsupported object class [B",
+            "sc_str_to_date", "str_to_date timestamp format is locale-sensitive (T vs space separator)"
+        );
     }
 }


### PR DESCRIPTION
## Summary

  Adds `analytics.delegation.<backend>.blocked_predicates` — a dynamic cluster setting that blocks specific predicate shapes from delegating to a secondary backend (Lucene) at runtime, without a deploy.

  - **Affix setting:** `Map<BackendName, List<ScalarFunction>>`, validated against the runtime registry
  - **DelegationBlockList:** resolves to `EnumSet` per backend; `isBlocked()` is the marking-time hot path
  - **Enforced in** `OpenSearchFilterRule.resolveViableBackends`: blocked predicates dropped from the backend's viable set
  - Empty by default (nothing blocked)

  ## Test plan

  - `DelegationBlockListTests` — seed from settings, dynamic update, unknown-name rejection, non-acceptor namespace rejection, non-delegatable predicate rejection
  - `FilterRuleTests` — block-list marking: drop blocked backend, all-blocked no-op, unknown-backend no-op


### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
