### PR TITLE
Return 400 for queries exceeding plan depth limit

### DIFF
--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/RelNodeUtils.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/RelNodeUtils.java
@@ -188,12 +188,16 @@ public class RelNodeUtils {
      *
      * @param plan the root of the RelNode tree
      * @return array of distinct index names in encounter order
-     * @throws IllegalStateException if the plan exceeds the maximum depth
+     * @throws IllegalArgumentException if the plan exceeds the maximum depth
      */
     public static String[] extractIndices(RelNode plan) {
         java.util.Set<String> indices = new java.util.LinkedHashSet<>();
         if (!collectIndices(plan, indices, 0)) {
-            throw new IllegalStateException("Query plan exceeds maximum depth (" + MAX_EXTRACT_INDICES_DEPTH + ") for index extraction");
+            throw new IllegalArgumentException(
+                "Query plan exceeds maximum depth ("
+                    + MAX_EXTRACT_INDICES_DEPTH
+                    + ") for index extraction. Simplify the query by reducing nested joins or subqueries."
+            );
         }
         return indices.toArray(String[]::new);
     }

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/RelNodeUtilsTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/RelNodeUtilsTests.java
@@ -147,7 +147,7 @@ public class RelNodeUtilsTests extends OpenSearchTestCase {
         }
         // The plan exceeds MAX_EXTRACT_INDICES_DEPTH — should throw rather than silently skip
         RelNode deepPlan = node;
-        IllegalStateException e = expectThrows(IllegalStateException.class, () -> RelNodeUtils.extractIndices(deepPlan));
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> RelNodeUtils.extractIndices(deepPlan));
         assertTrue(e.getMessage().contains("maximum depth"));
     }
 


### PR DESCRIPTION
### Description

The depth guard in `RelNodeUtils.extractIndices()` throws `IllegalStateException` when a query plan exceeds `MAX_EXTRACT_INDICES_DEPTH` (15 levels, triggered by 15+ JOINs).

`IllegalStateException` maps to HTTP 500 in the REST layer. This should instead be `IllegalArgumentException` which maps to 400 Bad Request.
