### PR TITLE
[analytics-lucene] Delegate bare comparisons (>, >=, <, <=) to Lucene

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/query_executor.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/query_executor.rs
@@ -348,6 +348,14 @@ pub async fn execute_with_context(
         // ProjectRowIdOptimizer (registered in session_context when strategy=ListingTable).
         let physical_plan = dataframe.create_physical_plan().await?;
 
+        // If SETUP_PARTIAL_AGGREGATE fired but prepare_partial_plan failed to pre-build,
+        // apply mode stripping here so the data node emits Partial state (Binary HLL sketch).
+        let physical_plan = if handle.aggregate_mode == crate::agg_mode::Mode::Partial {
+            crate::agg_mode::apply_aggregate_mode(physical_plan, crate::agg_mode::Mode::Partial)?
+        } else {
+            physical_plan
+        };
+
         let target_schema = crate::schema_coerce::coerce_inferred_schema(physical_plan.schema());
         let physical_plan = crate::relabel_exec::wrap_if_relabel_needed(physical_plan, target_schema)?;
 

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/LuceneAnalyticsBackendPlugin.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/LuceneAnalyticsBackendPlugin.java
@@ -69,7 +69,13 @@ public class LuceneAnalyticsBackendPlugin implements AnalyticsSearchBackendPlugi
     // TODO: have CapabilityRegistry intersect declared FilterCapability against the
     // backend's serializer keyset at startup so this list can't drift again. The TODO in
     // OpenSearchFilterRule.resolveViableBackends references the same constraint.
-    private static final Set<ScalarFunction> STANDARD_OPS = Set.of(ScalarFunction.EQUALS);
+    private static final Set<ScalarFunction> STANDARD_OPS = Set.of(
+        ScalarFunction.EQUALS,
+        ScalarFunction.GREATER_THAN,
+        ScalarFunction.GREATER_THAN_OR_EQUAL,
+        ScalarFunction.LESS_THAN,
+        ScalarFunction.LESS_THAN_OR_EQUAL
+    );
 
     private static final Set<ScalarFunction> FULL_TEXT_OPS = Set.of(
         ScalarFunction.MATCH,

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/LuceneQueryConversionUtils.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/LuceneQueryConversionUtils.java
@@ -14,6 +14,7 @@ import org.apache.lucene.search.BoostQuery;
 import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.DisjunctionMaxQuery;
 import org.apache.lucene.search.FieldExistsQuery;
+import org.apache.lucene.search.IndexOrDocValuesQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.QueryVisitor;
 import org.apache.lucene.search.TermRangeQuery;
@@ -61,6 +62,11 @@ public final class LuceneQueryConversionUtils {
      *         when nothing changed
      */
     public static Query rewriteFieldExistsForSecondary(Query query) {
+        // IndexOrDocValuesQuery wraps an index query + a doc-values query; the secondary has no
+        // doc-values, so unwrap to just the index query (TermRangeQuery against the term dictionary).
+        if (query instanceof IndexOrDocValuesQuery idv) {
+            return rewriteFieldExistsForSecondary(idv.getIndexQuery());
+        }
         if (query instanceof FieldExistsQuery fieldExists) {
             // null lower/upper bound = unbounded both ends = "any term present for this field".
             return new TermRangeQuery(fieldExists.getField(), null, null, true, true);

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/QuerySerializerRegistry.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/QuerySerializerRegistry.java
@@ -10,6 +10,7 @@ package org.opensearch.be.lucene;
 
 import org.opensearch.analytics.spi.DelegatedPredicateSerializer;
 import org.opensearch.analytics.spi.ScalarFunction;
+import org.opensearch.be.lucene.serializers.ComparisonSerializer;
 import org.opensearch.be.lucene.serializers.EqualsSerializer;
 import org.opensearch.be.lucene.serializers.MatchAllSerializer;
 import org.opensearch.be.lucene.serializers.MatchBoolPrefixSerializer;
@@ -42,7 +43,11 @@ final class QuerySerializerRegistry {
         Map.entry(ScalarFunction.WILDCARD_QUERY, new WildcardQuerySerializer()),
         Map.entry(ScalarFunction.QUERY, new QuerySerializer()),
         Map.entry(ScalarFunction.MATCHALL, new MatchAllSerializer()),
-        Map.entry(ScalarFunction.EQUALS, new EqualsSerializer())
+        Map.entry(ScalarFunction.EQUALS, new EqualsSerializer()),
+        Map.entry(ScalarFunction.GREATER_THAN, new ComparisonSerializer()),
+        Map.entry(ScalarFunction.GREATER_THAN_OR_EQUAL, new ComparisonSerializer()),
+        Map.entry(ScalarFunction.LESS_THAN, new ComparisonSerializer()),
+        Map.entry(ScalarFunction.LESS_THAN_OR_EQUAL, new ComparisonSerializer())
     );
 
     private QuerySerializerRegistry() {}

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/ComparisonSerializer.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/ComparisonSerializer.java
@@ -1,0 +1,81 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.lucene.serializers;
+
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexInputRef;
+import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlKind;
+import org.opensearch.analytics.spi.FieldStorageInfo;
+import org.opensearch.be.lucene.CalciteToOSMapperConversionUtils;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.RangeQueryBuilder;
+
+import java.util.List;
+
+/**
+ * Serializer for bare comparison predicates ({@code >}, {@code >=}, {@code <}, {@code <=}).
+ * Produces a single-bound {@link RangeQueryBuilder}.
+ */
+public class ComparisonSerializer extends AbstractQuerySerializer {
+
+    @Override
+    public QueryBuilder buildQueryBuilder(RexCall call, List<FieldStorageInfo> fieldStorage) {
+        if (call.getOperands().size() != 2) {
+            throw new IllegalArgumentException("Comparison expects 2 operands, got " + call.getOperands().size());
+        }
+        RexNode left = call.getOperands().get(0);
+        RexNode right = call.getOperands().get(1);
+
+        RexInputRef columnRef;
+        RexLiteral valueLit;
+        boolean reversed;
+        if (left instanceof RexInputRef l && right instanceof RexLiteral r) {
+            columnRef = l;
+            valueLit = r;
+            reversed = false;
+        } else if (left instanceof RexLiteral l && right instanceof RexInputRef r) {
+            columnRef = r;
+            valueLit = l;
+            reversed = true;
+        } else {
+            throw new IllegalArgumentException(
+                "Comparison performance-delegation requires (RexInputRef, RexLiteral); got " + left + " op " + right
+            );
+        }
+
+        FieldStorageInfo field = FieldStorageInfo.resolve(fieldStorage, columnRef.getIndex());
+        String fieldName = field.getExactMatchSubfield() != null
+            ? field.getFieldName() + "." + field.getExactMatchSubfield()
+            : field.getFieldName();
+        Object value = CalciteToOSMapperConversionUtils.literalToOpenSearchValue(valueLit);
+
+        RangeQueryBuilder range = new RangeQueryBuilder(fieldName);
+        SqlKind kind = reversed ? flipKind(call.getKind()) : call.getKind();
+        switch (kind) {
+            case GREATER_THAN -> range.gt(value);
+            case GREATER_THAN_OR_EQUAL -> range.gte(value);
+            case LESS_THAN -> range.lt(value);
+            case LESS_THAN_OR_EQUAL -> range.lte(value);
+            default -> throw new IllegalArgumentException("Unsupported comparison kind: " + kind);
+        }
+        return range;
+    }
+
+    private static SqlKind flipKind(SqlKind kind) {
+        return switch (kind) {
+            case GREATER_THAN -> SqlKind.LESS_THAN;
+            case GREATER_THAN_OR_EQUAL -> SqlKind.LESS_THAN_OR_EQUAL;
+            case LESS_THAN -> SqlKind.GREATER_THAN;
+            case LESS_THAN_OR_EQUAL -> SqlKind.GREATER_THAN_OR_EQUAL;
+            default -> kind;
+        };
+    }
+}

--- a/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/serializers/ComparisonSerializerTests.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/serializers/ComparisonSerializerTests.java
@@ -1,0 +1,106 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.lucene.serializers;
+
+import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.opensearch.analytics.spi.FieldStorageInfo;
+import org.opensearch.analytics.spi.FieldType;
+import org.opensearch.index.query.RangeQueryBuilder;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.List;
+
+public class ComparisonSerializerTests extends OpenSearchTestCase {
+
+    private final ComparisonSerializer serializer = new ComparisonSerializer();
+    private RelDataTypeFactory typeFactory;
+    private RexBuilder rexBuilder;
+    private RelDataType integer;
+
+    private static final List<FieldStorageInfo> FIELD_STORAGE = List.of(
+        new FieldStorageInfo("price", "keyword", FieldType.KEYWORD, List.of(), List.of("lucene"), List.of(), false)
+    );
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        typeFactory = new JavaTypeFactoryImpl();
+        rexBuilder = new RexBuilder(typeFactory);
+        integer = typeFactory.createSqlType(SqlTypeName.INTEGER);
+    }
+
+    public void testGreaterThan() {
+        RexNode call = rexBuilder.makeCall(
+            SqlStdOperatorTable.GREATER_THAN,
+            rexBuilder.makeInputRef(integer, 0),
+            rexBuilder.makeLiteral(100, integer, false)
+        );
+        RangeQueryBuilder range = (RangeQueryBuilder) serializer.buildQueryBuilder((org.apache.calcite.rex.RexCall) call, FIELD_STORAGE);
+        assertEquals("price", range.fieldName());
+        assertEquals(100, range.from());
+        assertFalse(range.includeLower());
+        assertNull(range.to());
+    }
+
+    public void testGreaterThanOrEqual() {
+        RexNode call = rexBuilder.makeCall(
+            SqlStdOperatorTable.GREATER_THAN_OR_EQUAL,
+            rexBuilder.makeInputRef(integer, 0),
+            rexBuilder.makeLiteral(50, integer, false)
+        );
+        RangeQueryBuilder range = (RangeQueryBuilder) serializer.buildQueryBuilder((org.apache.calcite.rex.RexCall) call, FIELD_STORAGE);
+        assertEquals("price", range.fieldName());
+        assertEquals(50, range.from());
+        assertTrue(range.includeLower());
+    }
+
+    public void testLessThan() {
+        RexNode call = rexBuilder.makeCall(
+            SqlStdOperatorTable.LESS_THAN,
+            rexBuilder.makeInputRef(integer, 0),
+            rexBuilder.makeLiteral(200, integer, false)
+        );
+        RangeQueryBuilder range = (RangeQueryBuilder) serializer.buildQueryBuilder((org.apache.calcite.rex.RexCall) call, FIELD_STORAGE);
+        assertEquals("price", range.fieldName());
+        assertEquals(200, range.to());
+        assertFalse(range.includeUpper());
+        assertNull(range.from());
+    }
+
+    public void testLessThanOrEqual() {
+        RexNode call = rexBuilder.makeCall(
+            SqlStdOperatorTable.LESS_THAN_OR_EQUAL,
+            rexBuilder.makeInputRef(integer, 0),
+            rexBuilder.makeLiteral(999, integer, false)
+        );
+        RangeQueryBuilder range = (RangeQueryBuilder) serializer.buildQueryBuilder((org.apache.calcite.rex.RexCall) call, FIELD_STORAGE);
+        assertEquals("price", range.fieldName());
+        assertEquals(999, range.to());
+        assertTrue(range.includeUpper());
+    }
+
+    public void testReversedOperandFlipsDirection() {
+        // 100 < col ⇒ col > 100
+        RexNode call = rexBuilder.makeCall(
+            SqlStdOperatorTable.LESS_THAN,
+            rexBuilder.makeLiteral(100, integer, false),
+            rexBuilder.makeInputRef(integer, 0)
+        );
+        RangeQueryBuilder range = (RangeQueryBuilder) serializer.buildQueryBuilder((org.apache.calcite.rex.RexCall) call, FIELD_STORAGE);
+        assertEquals("price", range.fieldName());
+        assertEquals(100, range.from());
+        assertFalse(range.includeLower());
+    }
+}

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/ComparisonDelegationIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/ComparisonDelegationIT.java
@@ -1,0 +1,120 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.qa;
+
+import org.opensearch.client.Request;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * E2E integration test for bare comparison predicates delegated to Lucene on a composite
+ * parquet+lucene index. Keyword fields use lexicographic ordering.
+ */
+public class ComparisonDelegationIT extends AnalyticsRestTestCase {
+
+    private static final String INDEX_NAME = "comparison_delegation_e2e";
+
+    public void testComparisonOperatorsOnKeywordFields() throws Exception {
+        createIndex();
+        indexDocs();
+
+        // All comparisons are lexicographic on keyword fields.
+        // price values: "10","20","30","40","50","60","70","80","90","100"
+        // Lexicographic order: "10" < "100" < "20" < "30" < "40" < "50" < "60" < "70" < "80" < "90"
+
+        // price > '50' → "60","70","80","90" (4 docs — "100" < "50" lexicographically)
+        String gtPpl = "source = " + INDEX_NAME + " | where price > '50' | stats count() as c";
+        Map<String, Object> gtResult = executePplViaShim(gtPpl);
+        @SuppressWarnings("unchecked")
+        List<List<Object>> gtRows = (List<List<Object>>) gtResult.get("rows");
+        assertNotNull("rows must not be null", gtRows);
+        assertEquals("scalar agg must return exactly 1 row", 1, gtRows.size());
+        assertEquals("price > '50' should match 4 docs (lexicographic)", 4L, ((Number) gtRows.get(0).get(0)).longValue());
+
+        // price >= '50' → "50","60","70","80","90" (5 docs)
+        String gtePpl = "source = " + INDEX_NAME + " | where price >= '50' | stats count() as c";
+        Map<String, Object> gteResult = executePplViaShim(gtePpl);
+        @SuppressWarnings("unchecked")
+        List<List<Object>> gteRows = (List<List<Object>>) gteResult.get("rows");
+        assertNotNull("rows must not be null", gteRows);
+        assertEquals("scalar agg must return exactly 1 row", 1, gteRows.size());
+        assertEquals("price >= '50' should match 5 docs (lexicographic)", 5L, ((Number) gteRows.get(0).get(0)).longValue());
+
+        // price < '30' → "10","100","20" (3 docs — lexicographic)
+        String ltPpl = "source = " + INDEX_NAME + " | where price < '30' | stats count() as c";
+        Map<String, Object> ltResult = executePplViaShim(ltPpl);
+        @SuppressWarnings("unchecked")
+        List<List<Object>> ltRows = (List<List<Object>>) ltResult.get("rows");
+        assertNotNull("rows must not be null", ltRows);
+        assertEquals("scalar agg must return exactly 1 row", 1, ltRows.size());
+        assertEquals("price < '30' should match 3 docs (lexicographic)", 3L, ((Number) ltRows.get(0).get(0)).longValue());
+
+        // price <= '30' → "10","100","20","30" (4 docs — lexicographic)
+        String ltePpl = "source = " + INDEX_NAME + " | where price <= '30' | stats count() as c";
+        Map<String, Object> lteResult = executePplViaShim(ltePpl);
+        @SuppressWarnings("unchecked")
+        List<List<Object>> lteRows = (List<List<Object>>) lteResult.get("rows");
+        assertNotNull("rows must not be null", lteRows);
+        assertEquals("scalar agg must return exactly 1 row", 1, lteRows.size());
+        assertEquals("price <= '30' should match 4 docs (lexicographic)", 4L, ((Number) lteRows.get(0).get(0)).longValue());
+    }
+
+    private void createIndex() throws Exception {
+        try {
+            client().performRequest(new Request("DELETE", "/" + INDEX_NAME));
+        } catch (Exception ignored) {}
+
+        String body = "{"
+            + "\"settings\": {"
+            + "  \"number_of_shards\": 1,"
+            + "  \"number_of_replicas\": 0,"
+            + "  \"index.pluggable.dataformat.enabled\": true,"
+            + "  \"index.pluggable.dataformat\": \"composite\","
+            + "  \"index.composite.primary_data_format\": \"parquet\","
+            + "  \"index.composite.secondary_data_formats\": \"lucene\""
+            + "},"
+            + "\"mappings\": {"
+            + "  \"properties\": {"
+            + "    \"price\": { \"type\": \"keyword\" },"
+            + "    \"qty\": { \"type\": \"keyword\" }"
+            + "  }"
+            + "}"
+            + "}";
+
+        Request createIndex = new Request("PUT", "/" + INDEX_NAME);
+        createIndex.setJsonEntity(body);
+        Map<String, Object> response = assertOkAndParse(client().performRequest(createIndex), "Create index");
+        assertEquals(true, response.get("acknowledged"));
+
+        Request health = new Request("GET", "/_cluster/health/" + INDEX_NAME);
+        health.addParameter("wait_for_status", "green");
+        health.addParameter("timeout", "30s");
+        client().performRequest(health);
+    }
+
+    private void indexDocs() throws Exception {
+        String[] prices = {"10", "20", "30", "40", "50", "60", "70", "80", "90", "100"};
+        String[] qtys = {"1", "2", "3", "4", "5", "6", "7", "8", "9", "10"};
+
+        StringBuilder bulk = new StringBuilder();
+        for (int i = 0; i < 10; i++) {
+            bulk.append("{\"index\": {}}\n");
+            bulk.append("{\"price\": \"").append(prices[i]).append("\", \"qty\": \"").append(qtys[i]).append("\"}\n");
+        }
+
+        Request bulkRequest = new Request("POST", "/" + INDEX_NAME + "/_bulk");
+        bulkRequest.setJsonEntity(bulk.toString());
+        bulkRequest.addParameter("refresh", "true");
+        client().performRequest(bulkRequest);
+
+        // Flush to ensure parquet files are written
+        client().performRequest(new Request("POST", "/" + INDEX_NAME + "/_flush?force=true"));
+    }
+}


### PR DESCRIPTION
## Summary

  Adds `ComparisonSerializer` for single-bound range predicates on keyword fields, delegating to Lucene's `TermRangeQuery` via the term dictionary.

  - **GT** (`col > value`) → `RangeQuery.gt(value)`
  - **GTE** (`col >= value`) → `RangeQuery.gte(value)`
  - **LT** (`col < value`) → `RangeQuery.lt(value)`
  - **LTE** (`col <= value`) → `RangeQuery.lte(value)`

  Handles reversed operand order (`100 < col` → `col > 100`). Text fields route to the keyword exact-match subfield.

  Also fixes `IndexOrDocValuesQuery` incompatibility with the composite Lucene secondary (which has inverted index but no sorted doc-values): unwraps to the index-only `TermRangeQuery` in `LuceneQueryConversionUtils`, same
  pattern as the existing `FieldExistsQuery` rewrite.

  Includes the `query_executor.rs` fallback fix for `Mode::Partial` — ensures the data node emits HLL sketch state when `SETUP_PARTIAL_AGGREGATE` fired but `prepare_partial_plan` failed to pre-build.

  ## Test plan

  - `ComparisonSerializerTests` — GT, GTE, LT, LTE, reversed operand direction
  - `ComparisonDelegationIT` — keyword lexicographic range on composite parquet+lucene index
  - `PplClickBenchIT` — all 42 queries green (exit criteria)

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
