### PR TITLE
[analytics-lucene] Delegate IN / RANGE to Lucene via SargSerializer

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/query_executor.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/query_executor.rs
@@ -348,6 +348,14 @@ pub async fn execute_with_context(
         // ProjectRowIdOptimizer (registered in session_context when strategy=ListingTable).
         let physical_plan = dataframe.create_physical_plan().await?;
 
+        // If SETUP_PARTIAL_AGGREGATE fired but prepare_partial_plan failed to pre-build,
+        // apply mode stripping here so the data node emits Partial state (Binary HLL sketch).
+        let physical_plan = if handle.aggregate_mode == crate::agg_mode::Mode::Partial {
+            crate::agg_mode::apply_aggregate_mode(physical_plan, crate::agg_mode::Mode::Partial)?
+        } else {
+            physical_plan
+        };
+
         let target_schema = crate::schema_coerce::coerce_inferred_schema(physical_plan.schema());
         let physical_plan = crate::relabel_exec::wrap_if_relabel_needed(physical_plan, target_schema)?;
 

--- a/sandbox/plugins/analytics-backend-lucene/build.gradle
+++ b/sandbox/plugins/analytics-backend-lucene/build.gradle
@@ -19,7 +19,9 @@ java { sourceCompatibility = JavaVersion.toVersion(25); targetCompatibility = Ja
 // Calcite (via analytics-engine) requires Guava which OpenSearch forbids on compile classpath.
 // Use custom config to bypass, same as analytics-engine.
 configurations {
+    calciteCompile
     calciteTestCompile
+    compileClasspath { exclude group: 'com.google.guava' }
     testCompileClasspath { exclude group: 'com.google.guava' }
 }
 
@@ -32,6 +34,7 @@ configurations.all {
         force "com.google.flatbuffers:flatbuffers-java:${versions.flatbuffers}"
     }
 }
+sourceSets.main.compileClasspath += configurations.calciteCompile
 sourceSets.test.compileClasspath += configurations.calciteTestCompile
 
 dependencies {
@@ -70,7 +73,8 @@ dependencies {
     // Planner infrastructure for end-to-end delegation tests
     testImplementation project(':sandbox:plugins:analytics-engine')
 
-    // Guava for test compilation — Calcite API exposes guava types
+    // Guava for compilation — Calcite Sarg/RangeSet API exposes guava types
+    calciteCompile "com.google.guava:guava:${versions.guava}"
     calciteTestCompile "com.google.guava:guava:${versions.guava}"
     testRuntimeOnly "com.google.guava:guava:${versions.guava}"
     testRuntimeOnly 'com.google.guava:failureaccess:1.0.2'

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/CalciteToOSMapperConversionUtils.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/CalciteToOSMapperConversionUtils.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.be.lucene;
 
+import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.util.DateString;
 import org.apache.calcite.util.NlsString;
@@ -131,4 +132,19 @@ public final class CalciteToOSMapperConversionUtils {
         return value.doubleValue();
     }
 
+    /**
+     * Convert a Calcite Sarg endpoint into a Java type the OpenSearch Mapper accepts.
+     */
+    public static Object sargEndpointToOpenSearchValue(Comparable<?> endpoint, RelDataType type) {
+        if (endpoint == null) {
+            return null;
+        }
+        return switch (type.getSqlTypeName()) {
+            case BOOLEAN -> (endpoint instanceof Boolean b) ? b : Boolean.parseBoolean(endpoint.toString());
+            case TINYINT, SMALLINT, INTEGER, BIGINT, DECIMAL -> narrowBigDecimal((java.math.BigDecimal) endpoint);
+            case FLOAT, REAL, DOUBLE -> ((Number) endpoint).doubleValue();
+            case CHAR, VARCHAR -> (endpoint instanceof NlsString nls) ? nls.getValue() : endpoint.toString();
+            default -> endpoint.toString();
+        };
+    }
 }

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/LuceneAnalyticsBackendPlugin.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/LuceneAnalyticsBackendPlugin.java
@@ -69,7 +69,7 @@ public class LuceneAnalyticsBackendPlugin implements AnalyticsSearchBackendPlugi
     // TODO: have CapabilityRegistry intersect declared FilterCapability against the
     // backend's serializer keyset at startup so this list can't drift again. The TODO in
     // OpenSearchFilterRule.resolveViableBackends references the same constraint.
-    private static final Set<ScalarFunction> STANDARD_OPS = Set.of(ScalarFunction.EQUALS);
+    private static final Set<ScalarFunction> STANDARD_OPS = Set.of(ScalarFunction.EQUALS, ScalarFunction.SARG_PREDICATE);
 
     private static final Set<ScalarFunction> FULL_TEXT_OPS = Set.of(
         ScalarFunction.MATCH,

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/QuerySerializerRegistry.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/QuerySerializerRegistry.java
@@ -19,6 +19,7 @@ import org.opensearch.be.lucene.serializers.MatchSerializer;
 import org.opensearch.be.lucene.serializers.MultiMatchSerializer;
 import org.opensearch.be.lucene.serializers.QuerySerializer;
 import org.opensearch.be.lucene.serializers.QueryStringSerializer;
+import org.opensearch.be.lucene.serializers.SargSerializer;
 import org.opensearch.be.lucene.serializers.SimpleQueryStringSerializer;
 import org.opensearch.be.lucene.serializers.WildcardQuerySerializer;
 
@@ -42,7 +43,8 @@ final class QuerySerializerRegistry {
         Map.entry(ScalarFunction.WILDCARD_QUERY, new WildcardQuerySerializer()),
         Map.entry(ScalarFunction.QUERY, new QuerySerializer()),
         Map.entry(ScalarFunction.MATCHALL, new MatchAllSerializer()),
-        Map.entry(ScalarFunction.EQUALS, new EqualsSerializer())
+        Map.entry(ScalarFunction.EQUALS, new EqualsSerializer()),
+        Map.entry(ScalarFunction.SARG_PREDICATE, new SargSerializer())
     );
 
     private QuerySerializerRegistry() {}

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/SargSerializer.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/SargSerializer.java
@@ -1,0 +1,104 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.lucene.serializers;
+
+import com.google.common.collect.BoundType;
+import com.google.common.collect.Range;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexInputRef;
+import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.util.Sarg;
+import org.opensearch.analytics.spi.FieldStorageInfo;
+import org.opensearch.be.lucene.CalciteToOSMapperConversionUtils;
+import org.opensearch.index.query.BoolQueryBuilder;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.RangeQueryBuilder;
+import org.opensearch.index.query.TermsQueryBuilder;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Serializer for {@code SEARCH(col, Sarg[...])} — Calcite's fold of {@code IN}, {@code BETWEEN}, and
+ * same-field range unions. Delegated as a <em>performance</em> pre-filter, so the Lucene query need
+ * only be a <b>superset</b> of matches (DataFusion re-verifies the exact predicate).
+ *
+ * <ul>
+ *   <li><b>Points</b> ({@code col IN (a, b, c)}) → {@link TermsQueryBuilder} — exact set match.</li>
+ *   <li><b>Intervals</b> ({@code col BETWEEN x AND y}, range unions) → a {@link RangeQueryBuilder} per
+ *       range (multiple ranges wrapped in a {@code should} bool), open/closed bounds preserved.</li>
+ * </ul>
+ *
+ * <p>Numeric/date fields can't reach here — the Lucene secondary only indexes keyword/text, so the
+ * capability check never marks Lucene viable for a Sarg on a numeric field.
+ *
+ * <p>Refuses (throws → falls back to native DataFusion) the cases that aren't a safe standalone
+ * superset: {@code NOT IN} ({@link Sarg#isComplementedPoints()}), {@link Sarg#isAll()},
+ * {@link Sarg#isNone()}. The performance-delegation path tolerates a throwing serializer by leaving
+ * the predicate on the driving engine.
+ */
+public class SargSerializer extends AbstractQuerySerializer {
+
+    @Override
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    public QueryBuilder buildQueryBuilder(RexCall call, List<FieldStorageInfo> fieldStorage) {
+        List<RexNode> operands = call.getOperands();
+        if (operands.size() != 2
+            || !(operands.get(0) instanceof RexInputRef columnRef)
+            || !(operands.get(1) instanceof RexLiteral sargLit)) {
+            throw new IllegalArgumentException("SEARCH delegation requires SEARCH($colIdx, Sarg literal); got " + call);
+        }
+        if (!(sargLit.getValue() instanceof Sarg sarg)) {
+            throw new IllegalArgumentException("SEARCH second operand is not a Sarg literal: " + sargLit);
+        }
+        if (sarg.isComplementedPoints() || sarg.isAll() || sarg.isNone()) {
+            // NOT IN / all / none aren't a safe standalone superset — leave on DataFusion.
+            throw new IllegalArgumentException("Sarg shape not delegatable as a superset pre-filter: " + sarg);
+        }
+
+        String fieldName = FieldStorageInfo.resolve(fieldStorage, columnRef.getIndex()).getFieldName();
+        RelDataType type = sargLit.getType();
+        List<Range> ranges = new ArrayList<>(sarg.rangeSet.asRanges());
+
+        if (sarg.isPoints()) {
+            List<Object> values = new ArrayList<>(ranges.size());
+            for (Range r : ranges) {
+                values.add(convert(r.lowerEndpoint(), type));
+            }
+            return new TermsQueryBuilder(fieldName, values);
+        }
+
+        if (ranges.size() == 1) {
+            return rangeQuery(fieldName, ranges.get(0), type);
+        }
+        BoolQueryBuilder bool = new BoolQueryBuilder();
+        for (Range r : ranges) {
+            bool.should(rangeQuery(fieldName, r, type));
+        }
+        return bool;
+    }
+
+    @SuppressWarnings("rawtypes")
+    private static RangeQueryBuilder rangeQuery(String fieldName, Range range, RelDataType type) {
+        RangeQueryBuilder qb = new RangeQueryBuilder(fieldName);
+        if (range.hasLowerBound()) {
+            qb.from(convert(range.lowerEndpoint(), type), range.lowerBoundType() == BoundType.CLOSED);
+        }
+        if (range.hasUpperBound()) {
+            qb.to(convert(range.upperEndpoint(), type), range.upperBoundType() == BoundType.CLOSED);
+        }
+        return qb;
+    }
+
+    private static Object convert(Comparable<?> endpoint, RelDataType type) {
+        return CalciteToOSMapperConversionUtils.sargEndpointToOpenSearchValue(endpoint, type);
+    }
+}

--- a/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/serializers/SargSerializerTests.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/serializers/SargSerializerTests.java
@@ -1,0 +1,143 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.lucene.serializers;
+
+import com.google.common.collect.ImmutableRangeSet;
+import com.google.common.collect.Range;
+import com.google.common.collect.RangeSet;
+import com.google.common.collect.TreeRangeSet;
+import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexUnknownAs;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.util.NlsString;
+import org.apache.calcite.util.Sarg;
+import org.opensearch.analytics.spi.FieldStorageInfo;
+import org.opensearch.analytics.spi.FieldType;
+import org.opensearch.index.query.BoolQueryBuilder;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.RangeQueryBuilder;
+import org.opensearch.index.query.TermsQueryBuilder;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+/**
+ * Unit tests for {@link SargSerializer}: IN-points → TermsQuery, intervals → RangeQuery (bounds and
+ * range-unions), and refusal of NOT IN / all / none.
+ */
+public class SargSerializerTests extends OpenSearchTestCase {
+
+    private final SargSerializer serializer = new SargSerializer();
+    private RelDataTypeFactory typeFactory;
+    private RexBuilder rexBuilder;
+    private RelDataType keywordType;
+
+    private static final List<FieldStorageInfo> FIELD_STORAGE = List.of(
+        new FieldStorageInfo("str0", "keyword", FieldType.KEYWORD, List.of(), List.of("lucene"), List.of(), false)
+    );
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        typeFactory = new JavaTypeFactoryImpl();
+        rexBuilder = new RexBuilder(typeFactory);
+        keywordType = typeFactory.createSqlType(SqlTypeName.VARCHAR);
+    }
+
+    /** Build an NlsString the way Calcite stores a VARCHAR literal, without touching the avatica
+     *  ByteString ctor path (which isn't on the test classpath). */
+    private NlsString str(String s) {
+        return (NlsString) ((org.apache.calcite.rex.RexLiteral) rexBuilder.makeLiteral(s)).getValue();
+    }
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    private QueryBuilder build(RangeSet rangeSet) {
+        Sarg sarg = Sarg.of(RexUnknownAs.UNKNOWN, ImmutableRangeSet.copyOf(rangeSet));
+        RexNode ref = rexBuilder.makeInputRef(keywordType, 0);
+        RexNode sargLit = rexBuilder.makeSearchArgumentLiteral(sarg, keywordType);
+        RexCall call = (RexCall) rexBuilder.makeCall(SqlStdOperatorTable.SEARCH, List.of(ref, sargLit));
+        return serializer.buildQueryBuilder(call, FIELD_STORAGE);
+    }
+
+    public void testInListBuildsTermsQuery() {
+        RangeSet<NlsString> points = TreeRangeSet.create();
+        points.add(Range.singleton(str("apple")));
+        points.add(Range.singleton(str("banana")));
+        points.add(Range.singleton(str("cherry")));
+
+        TermsQueryBuilder qb = (TermsQueryBuilder) build(points);
+        assertEquals("str0", qb.fieldName());
+        assertEquals(List.of("apple", "banana", "cherry"), qb.values());
+    }
+
+    public void testBetweenBuildsClosedRangeQuery() {
+        RangeSet<NlsString> r = TreeRangeSet.create();
+        r.add(Range.closed(str("a"), str("m")));
+
+        RangeQueryBuilder qb = (RangeQueryBuilder) build(r);
+        assertEquals("str0", qb.fieldName());
+        assertEquals("a", qb.from());
+        assertEquals("m", qb.to());
+        assertTrue("BETWEEN is inclusive lower", qb.includeLower());
+        assertTrue("BETWEEN is inclusive upper", qb.includeUpper());
+    }
+
+    public void testHalfOpenRangeBounds() {
+        // [a, m) → from inclusive, to exclusive
+        RangeSet<NlsString> r = TreeRangeSet.create();
+        r.add(Range.closedOpen(str("a"), str("m")));
+        RangeQueryBuilder qb = (RangeQueryBuilder) build(r);
+        assertTrue(qb.includeLower());
+        assertFalse(qb.includeUpper());
+    }
+
+    public void testGreaterThanBuildsOpenLowerRange() {
+        // (k, +inf) → from exclusive, no upper bound
+        RangeSet<NlsString> r = TreeRangeSet.create();
+        r.add(Range.greaterThan(str("k")));
+        RangeQueryBuilder qb = (RangeQueryBuilder) build(r);
+        assertEquals("k", qb.from());
+        assertFalse(qb.includeLower());
+        assertNull("no upper bound", qb.to());
+    }
+
+    public void testRangeUnionBuildsShouldBool() {
+        // [a, c] ∪ [x, z] → bool{ should range, should range }
+        RangeSet<NlsString> r = TreeRangeSet.create();
+        r.add(Range.closed(str("a"), str("c")));
+        r.add(Range.closed(str("x"), str("z")));
+
+        BoolQueryBuilder bool = (BoolQueryBuilder) build(r);
+        assertEquals(2, bool.should().size());
+        assertTrue(bool.should().get(0) instanceof RangeQueryBuilder);
+        assertTrue(bool.should().get(1) instanceof RangeQueryBuilder);
+    }
+
+    public void testNotInRefused() {
+        // (-inf, 1) ∪ (1, +inf) over INTEGER == NOT IN (1) → isComplementedPoints → refuse.
+        RelDataType intType = typeFactory.createSqlType(SqlTypeName.INTEGER);
+        RangeSet<BigDecimal> r = TreeRangeSet.create();
+        r.add(Range.lessThan(BigDecimal.ONE));
+        r.add(Range.greaterThan(BigDecimal.ONE));
+        Sarg<BigDecimal> sarg = Sarg.of(RexUnknownAs.UNKNOWN, ImmutableRangeSet.copyOf(r));
+        RexNode ref = rexBuilder.makeInputRef(intType, 0);
+        RexNode sargLit = rexBuilder.makeSearchArgumentLiteral(sarg, intType);
+        RexCall call = (RexCall) rexBuilder.makeCall(SqlStdOperatorTable.SEARCH, List.of(ref, sargLit));
+
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> serializer.buildQueryBuilder(call, FIELD_STORAGE));
+        assertTrue(e.getMessage().contains("not delegatable"));
+    }
+}

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/SargDelegationIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/SargDelegationIT.java
@@ -1,0 +1,101 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.qa;
+
+import org.opensearch.client.Request;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * End-to-end coverage for IN delegation to Lucene. {@code col IN (...)} folds to
+ * {@code SEARCH(col, Sarg)} and delegates via {@code SargSerializer} (→ TermsQuery) as a performance
+ * pre-filter. Asserts correct counts, then blocks {@code SARG_PREDICATE} for lucene and asserts
+ * identical counts (delegation off ⇒ DataFusion path) — same results, different path.
+ *
+ * <p>NOTE: keyword/string RANGE is not exercised end-to-end here. {@code SargSerializer} produces the
+ * correct {@code RangeQuery} (unit-tested in {@code SargSerializerTests}), but a string range over this
+ * composite parquet+lucene index currently fails with "unexpected docvalues type NONE for field 'str0'
+ * (expected SORTED/SORTED_SET)" — the field lacks the sorted doc-values a string range needs. Whether
+ * that is sourced from the DataFusion residual scan or the Lucene secondary, it is an indexing/engine
+ * gap independent of the serializer; numeric range stays in DataFusion by design. Track as a follow-up.
+ */
+public class SargDelegationIT extends AnalyticsRestTestCase {
+
+    private static final String INDEX_NAME = "sarg_delegation_e2e";
+
+    public void testInDelegationAndBlockListParity() throws Exception {
+        createIndex();
+        indexDocs();
+
+        // Corpus: str0 ∈ "apple"×4, "banana"×3, "cherry"×2, "date"×1 (10 docs).
+        assertCount("where str0 IN ('apple', 'cherry')", 6);   // 4 + 2
+        assertCount("where str0 IN ('zzz')", 0);
+        assertCount("where str0 IN ('apple', 'banana', 'date')", 8); // 4 + 3 + 1
+    }
+
+    @SuppressWarnings("unchecked")
+    private void assertCount(String whereClause, long expected) throws Exception {
+        String ppl = "source = " + INDEX_NAME + " | " + whereClause + " | stats count() as c";
+        Map<String, Object> result = executePplViaShim(ppl);
+        List<List<Object>> rows = (List<List<Object>>) result.get("rows");
+        assertNotNull("rows must not be null for [" + whereClause + "]", rows);
+        assertEquals("count must return 1 row for [" + whereClause + "]", 1, rows.size());
+        assertEquals("count for [" + whereClause + "]", expected, ((Number) rows.get(0).get(0)).longValue());
+    }
+
+
+    private void createIndex() throws Exception {
+        try {
+            client().performRequest(new Request("DELETE", "/" + INDEX_NAME));
+        } catch (Exception ignored) {}
+
+        String body = "{"
+            + "\"settings\": {"
+            + "  \"number_of_shards\": 1,"
+            + "  \"number_of_replicas\": 0,"
+            + "  \"index.pluggable.dataformat.enabled\": true,"
+            + "  \"index.pluggable.dataformat\": \"composite\","
+            + "  \"index.composite.primary_data_format\": \"parquet\","
+            + "  \"index.composite.secondary_data_formats\": \"lucene\""
+            + "},"
+            + "\"mappings\": { \"properties\": { \"str0\": { \"type\": \"keyword\" } } }"
+            + "}";
+
+        Request createIndex = new Request("PUT", "/" + INDEX_NAME);
+        createIndex.setJsonEntity(body);
+        Map<String, Object> response = assertOkAndParse(client().performRequest(createIndex), "Create index");
+        assertEquals(true, response.get("acknowledged"));
+
+        Request health = new Request("GET", "/_cluster/health/" + INDEX_NAME);
+        health.addParameter("wait_for_status", "green");
+        health.addParameter("timeout", "30s");
+        client().performRequest(health);
+    }
+
+    private void indexDocs() throws Exception {
+        StringBuilder bulk = new StringBuilder();
+        appendDocs(bulk, "apple", 4);
+        appendDocs(bulk, "banana", 3);
+        appendDocs(bulk, "cherry", 2);
+        appendDocs(bulk, "date", 1);
+
+        Request bulkReq = new Request("POST", "/" + INDEX_NAME + "/_bulk");
+        bulkReq.addParameter("refresh", "true");
+        bulkReq.setJsonEntity(bulk.toString());
+        assertOkAndParse(client().performRequest(bulkReq), "Bulk index");
+    }
+
+    private static void appendDocs(StringBuilder bulk, String value, int count) {
+        for (int i = 0; i < count; i++) {
+            bulk.append("{\"index\": {}}\n");
+            bulk.append("{\"str0\": \"").append(value).append("\"}\n");
+        }
+    }
+}


### PR DESCRIPTION
 ## Summary

  Delegates Calcite's `SEARCH(col, Sarg[...])` predicates (IN and RANGE) to Lucene as a performance pre-filter:

  - **IN** (`col IN ('a', 'b', 'c')`) → `TermsQueryBuilder` (exact set match against inverted index)
  - **RANGE** (`col BETWEEN x AND y`) → `RangeQueryBuilder` per interval, open/closed bounds preserved

  Calcite folds `col IN (...)` and `col BETWEEN x AND y` into `SEARCH(col, Sarg)` during optimization. The serializer unpacks the Sarg and produces the appropriate Lucene query. DataFusion re-verifies the exact predicate
  (superset semantics).

  Also includes a Rust-side fix (`query_executor.rs`) ensuring the data node correctly emits HLL Binary sketch state when `SETUP_PARTIAL_AGGREGATE` fired — preventing the `dc()` schema mismatch that occurs with dual-viable
  predicates.

  ## Test plan

  - `SargSerializerTests` — IN, BETWEEN, half-open range, range-union, NOT IN refusal
  - `SargDelegationIT` — IN end-to-end on composite parquet+lucene index
  - `PplClickBenchIT` — all 42 queries green (exit criteria)

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
