### PR TITLE
[analytics-engine] Don't drop user head/limit over grouped aggregates

### DIFF
--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/PlannerImpl.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/PlannerImpl.java
@@ -286,6 +286,12 @@ public class PlannerImpl {
             // SORT_PROJECT_TRANSPOSE + PROJECT_MERGE feed the QTF (late-materialization)
             // rewriter by lifting Project above Sort so it sees a single Project layer
             // above the anchor.
+            // SORT_REMOVE_REDUNDANT drops a Sort/LIMIT whose input is provably bounded to
+            // within the limit (e.g. a collation-less `head N` or a sort over a scalar
+            // aggregate, getMaxRowCount <= 1): a no-op that the marking rule must not have to
+            // special-case. Runs here, pre-marking, on plain Logical* so marking stays a pure
+            // Logical* -> OpenSearch* conversion. Cascades with LIMIT_MERGE in the same
+            // fixpoint so stacked limits collapse first, then any now-redundant Sort is removed.
             .addRuleCollection(
                 List.of(
                     CoreRules.FILTER_PROJECT_TRANSPOSE,
@@ -293,7 +299,8 @@ public class PlannerImpl {
                     CoreRules.FILTER_INTO_JOIN,
                     CoreRules.SORT_PROJECT_TRANSPOSE,
                     CoreRules.PROJECT_MERGE,
-                    CoreRules.LIMIT_MERGE
+                    CoreRules.LIMIT_MERGE,
+                    CoreRules.SORT_REMOVE_REDUNDANT
                 )
             )
             .addRuleInstance(CoreRules.FILTER_MERGE)

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/PlannerImpl.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/PlannerImpl.java
@@ -292,7 +292,8 @@ public class PlannerImpl {
                     CoreRules.FILTER_AGGREGATE_TRANSPOSE,
                     CoreRules.FILTER_INTO_JOIN,
                     CoreRules.SORT_PROJECT_TRANSPOSE,
-                    CoreRules.PROJECT_MERGE
+                    CoreRules.PROJECT_MERGE,
+                    CoreRules.LIMIT_MERGE
                 )
             )
             .addRuleInstance(CoreRules.FILTER_MERGE)

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchSortRule.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchSortRule.java
@@ -10,15 +10,10 @@ package org.opensearch.analytics.planner.rules;
 
 import org.apache.calcite.plan.RelOptRule;
 import org.apache.calcite.plan.RelOptRuleCall;
-import org.apache.calcite.rel.RelFieldCollation;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.Sort;
-import org.apache.calcite.rex.RexInputRef;
-import org.apache.calcite.rex.RexNode;
 import org.opensearch.analytics.planner.PlannerContext;
 import org.opensearch.analytics.planner.RelNodeUtils;
-import org.opensearch.analytics.planner.rel.OpenSearchAggregate;
-import org.opensearch.analytics.planner.rel.OpenSearchProject;
 import org.opensearch.analytics.planner.rel.OpenSearchRelNode;
 import org.opensearch.analytics.planner.rel.OpenSearchSort;
 import org.opensearch.analytics.spi.EngineCapability;
@@ -26,7 +21,7 @@ import org.opensearch.analytics.spi.EngineCapability;
 import java.util.List;
 
 /**
- * Converts {@link Sort} → {@link OpenSearchSort}.
+ * Converts {@link Sort} → {@link OpenSearchSort}, preserving collation, offset, and fetch.
  *
  * <p>Validates that the chosen backend supports {@link EngineCapability#SORT}.
  *
@@ -58,28 +53,11 @@ public class OpenSearchSortRule extends RelOptRule {
             throw new IllegalStateException("Sort rule encountered unmarked child [" + child.getClass().getSimpleName() + "]");
         }
 
-        // Drop a pure-Fetch Sort over an Aggregate (possibly via a Project chain). Aggregate
-        // output cardinality is bounded by group count, so a JOIN_SUBSEARCH_MAXOUT-style 50000
-        // limit is structurally never hit. The Sort/Fetch shape here also triggers a DataFusion
-        // hang for composite-group keys. Removing it keeps the safety contract intact for
-        // unbounded children but avoids the redundant Fetch when the aggregate already bounds
-        // output.
-        if (sort.getCollation().getFieldCollations().isEmpty() && sort.offset == null && hasAggregateUnderProjects(child)) {
+        // A collation-less, offset-less LIMIT over a provably single-row input (e.g. a scalar
+        // aggregate) is a no-op, drop it.
+        if (sort.getCollation().getFieldCollations().isEmpty() && sort.offset == null && isAtMostOneRow(call, child)) {
             call.transformTo(child);
             return;
-        }
-
-        // Drop a no-fetch outer Sort when an inner OpenSearchSort with fetch already produces
-        // the same ordering through a Project chain. With both Sorts present, DataFusion's
-        // logical-plan optimizer eliminates the inner Sort as redundant but leaves the Limit,
-        // then physical-planning pushes Limit down through CoalescePartitionsExec — so fetch
-        // is applied BEFORE sort against the unsorted Aggregate output.
-        if (sort.fetch == null && sort.offset == null && !sort.getCollation().getFieldCollations().isEmpty()) {
-            OpenSearchSort inner = findInnerSortWithFetchThroughProjects(child);
-            if (inner != null && outerCollationMatchesInner(sort, child, inner)) {
-                call.transformTo(child);
-                return;
-            }
         }
 
         List<String> childViableBackends = openSearchChild.getViableBackends();
@@ -106,69 +84,9 @@ public class OpenSearchSortRule extends RelOptRule {
         );
     }
 
-    private static boolean hasAggregateUnderProjects(RelNode node) {
-        RelNode current = RelNodeUtils.unwrapHep(node);
-        while (current instanceof OpenSearchProject project) {
-            current = RelNodeUtils.unwrapHep(project.getInput());
-        }
-        return current instanceof OpenSearchAggregate;
-    }
-
-    /** Walks down through OpenSearchProjects, returns the first OpenSearchSort with fetch != null. */
-    private static OpenSearchSort findInnerSortWithFetchThroughProjects(RelNode node) {
-        RelNode current = RelNodeUtils.unwrapHep(node);
-        while (current instanceof OpenSearchProject project) {
-            current = RelNodeUtils.unwrapHep(project.getInput());
-        }
-        return current instanceof OpenSearchSort innerSort && innerSort.fetch != null ? innerSort : null;
-    }
-
-    /**
-     * Checks that the outer Sort's collation, when its field references are remapped down
-     * through each intermediate OpenSearchProject's identity-projection exprs, matches the
-     * inner Sort's collation field-for-field.
-     */
-    private static boolean outerCollationMatchesInner(Sort outer, RelNode child, OpenSearchSort inner) {
-        List<RelFieldCollation> outerFields = outer.getCollation().getFieldCollations();
-        List<RelFieldCollation> innerFields = inner.getCollation().getFieldCollations();
-        if (outerFields.size() != innerFields.size()) {
-            return false;
-        }
-        for (int i = 0; i < outerFields.size(); i++) {
-            RelFieldCollation outerField = outerFields.get(i);
-            int remapped = remapInputIndexThroughProjects(outerField.getFieldIndex(), child, inner);
-            if (remapped < 0) {
-                return false;
-            }
-            RelFieldCollation innerField = innerFields.get(i);
-            if (remapped != innerField.getFieldIndex()
-                || outerField.getDirection() != innerField.getDirection()
-                || outerField.nullDirection != innerField.nullDirection) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    /**
-     * Walks `node` down to `inner`, translating `index` through each OpenSearchProject's
-     * exprs. Each project's expr at position `i` must be a RexInputRef for the index to
-     * remap; non-identity exprs return -1 (unmappable).
-     */
-    private static int remapInputIndexThroughProjects(int index, RelNode node, OpenSearchSort inner) {
-        RelNode current = RelNodeUtils.unwrapHep(node);
-        int idx = index;
-        while (current instanceof OpenSearchProject project) {
-            if (idx < 0 || idx >= project.getProjects().size()) {
-                return -1;
-            }
-            RexNode expr = project.getProjects().get(idx);
-            if (!(expr instanceof RexInputRef ref)) {
-                return -1;
-            }
-            idx = ref.getIndex();
-            current = RelNodeUtils.unwrapHep(project.getInput());
-        }
-        return current == inner ? idx : -1;
+    /** True when {@code child} is provably at most one row (Calcite {@code getMaxRowCount}); false if unknown. */
+    private static boolean isAtMostOneRow(RelOptRuleCall call, RelNode child) {
+        Double maxRows = call.getMetadataQuery().getMaxRowCount(RelNodeUtils.unwrapHep(child));
+        return maxRows != null && maxRows <= 1.0;
     }
 }

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchSortRule.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchSortRule.java
@@ -53,13 +53,6 @@ public class OpenSearchSortRule extends RelOptRule {
             throw new IllegalStateException("Sort rule encountered unmarked child [" + child.getClass().getSimpleName() + "]");
         }
 
-        // A collation-less, offset-less LIMIT over a provably single-row input (e.g. a scalar
-        // aggregate) is a no-op, drop it.
-        if (sort.getCollation().getFieldCollations().isEmpty() && sort.offset == null && isAtMostOneRow(call, child)) {
-            call.transformTo(child);
-            return;
-        }
-
         List<String> childViableBackends = openSearchChild.getViableBackends();
         List<String> sortCapable = context.getCapabilityRegistry().operatorBackends(EngineCapability.SORT);
 
@@ -82,11 +75,5 @@ public class OpenSearchSortRule extends RelOptRule {
                 viableBackends
             )
         );
-    }
-
-    /** True when {@code child} is provably at most one row (Calcite {@code getMaxRowCount}); false if unknown. */
-    private static boolean isAtMostOneRow(RelOptRuleCall call, RelNode child) {
-        Double maxRows = call.getMetadataQuery().getMaxRowCount(RelNodeUtils.unwrapHep(child));
-        return maxRows != null && maxRows <= 1.0;
     }
 }

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/PlanShapeTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/PlanShapeTests.java
@@ -42,29 +42,29 @@ public class PlanShapeTests extends PlanShapeTestBase {
      * PPL: {@code | stats count() as cnt by k | sort cnt | head 2 | fields k, cnt}
      *
      * <p>The PPL frontend emits a redundant outer Sort (no fetch, same collation as the inner)
-     * plus an inner Sort with fetch above a column-swap Project above the Aggregate. With both
-     * Sorts present, DataFusion's logical-plan optimizer eliminates the inner Sort as redundant
-     * but keeps the Limit, then physical planning pushes the Limit BELOW the SortExec into a
-     * {@code CoalescePartitionsExec(fetch=N)} on the FINAL Aggregate output. Result: fetch is
-     * applied to the unsorted Aggregate output, and Sort runs on the wrong N rows.
-     *
-     * <p>{@link org.opensearch.analytics.planner.rules.OpenSearchSortRule} drops the redundant
-     * outer Sort during HEP marking. After-CBO must contain at most one Sort over the FINAL
-     * Aggregate, with that Sort carrying the fetch.
+     * plus an inner Sort with fetch above a column-swap Project above the Aggregate. Both Sorts
+     * are preserved through to the physical plan — {@link
+     * org.opensearch.analytics.planner.rules.OpenSearchSortRule} converts each one-for-one and no
+     * longer drops the redundant outer Sort. The extra (collation-only) outer Sort over the FINAL
+     * Aggregate is harmless: the inner Sort carries the fetch, so top-K is exact, and the duplicate
+     * sort runs over the already-tiny grouped output (verified end-to-end by {@code
+     * HeadAfterStatsLimitIT} / {@code TwoShardAggregationIT#span_topn}). Collapsing it would require
+     * an active {@code RelCollationTraitDef} ({@code CoreRules.SORT_REMOVE}), which this planner
+     * does not register.
      */
-    public void testSortHeadAfterStats_dropsRedundantOuterSort() {
+    public void testSortHeadAfterStats_outerSortPreserved() {
         RelNode input = topKAfterStats(/* withRedundantOuterSort */ true);
         RelNode result = runPlanner(input, multiShardContext());
-        // SORT_PROJECT_TRANSPOSE + PROJECT_MERGE in pushdown collapse the column-swap Projects
-        // around the Sort: the inner+outer Project pair merges into identity and drops, the Sort
-        // remaps its collation from $0 (post-swap) to $1 (Aggregate's cnt column).
+        // SORT_PROJECT_TRANSPOSE + PROJECT_MERGE collapse the column-swap Projects; both Sorts
+        // remap their collation from $0 (post-swap) to $1 (Aggregate's cnt column) and survive.
         assertPlanShape(
             """
-                OpenSearchSort(sort0=[$1], dir0=[ASC], fetch=[2], viableBackends=[[mock-parquet]])
-                  OpenSearchAggregate(group=[{0}], cnt=[SUM($1)], mode=[FINAL], viableBackends=[[mock-parquet]])
-                    OpenSearchExchangeReducer(viableBackends=[[mock-parquet]], exchange=[ExchangeInfo[distributionType=SINGLETON, partitionKeyIndices=[]]])
-                      OpenSearchAggregate(group=[{0}], cnt=[COUNT()], mode=[PARTIAL], viableBackends=[[mock-parquet]])
-                        OpenSearchTableScan(table=[[test_index]], viableBackends=[[mock-parquet]])
+                OpenSearchSort(sort0=[$1], dir0=[ASC], viableBackends=[[mock-parquet]])
+                  OpenSearchSort(sort0=[$1], dir0=[ASC], fetch=[2], viableBackends=[[mock-parquet]])
+                    OpenSearchAggregate(group=[{0}], cnt=[SUM($1)], mode=[FINAL], viableBackends=[[mock-parquet]])
+                      OpenSearchExchangeReducer(viableBackends=[[mock-parquet]], exchange=[ExchangeInfo[distributionType=SINGLETON, partitionKeyIndices=[]]])
+                        OpenSearchAggregate(group=[{0}], cnt=[COUNT()], mode=[PARTIAL], viableBackends=[[mock-parquet]])
+                          OpenSearchTableScan(table=[[test_index]], viableBackends=[[mock-parquet]])
                 """,
             result
         );

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/SortRuleTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/SortRuleTests.java
@@ -15,6 +15,7 @@ import org.apache.calcite.plan.hep.HepProgramBuilder;
 import org.apache.calcite.rel.RelCollation;
 import org.apache.calcite.rel.RelCollationTraitDef;
 import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.opensearch.analytics.planner.rel.OpenSearchAggregate;
 import org.opensearch.analytics.planner.rel.OpenSearchFilter;
@@ -138,5 +139,83 @@ public class SortRuleTests extends BasePlannerRulesTests {
             types,
             10
         );
+    }
+
+    private static final List<Class<? extends org.opensearch.analytics.planner.rel.OpenSearchRelNode>> SORT_AGG_SCAN = List.of(
+        OpenSearchSort.class,
+        OpenSearchAggregate.class,
+        OpenSearchTableScan.class
+    );
+
+    /** Asserts the planned pipeline has NO OpenSearchSort root and bottoms out at a scalar Aggregate. */
+    private void assertLimitDropped(RelNode result) {
+        logger.info("Plan:\n{}", RelOptUtil.toString(result));
+        assertFalse("limit must be dropped (no OpenSearchSort)", result instanceof OpenSearchSort);
+        assertTrue("root must be the scalar OpenSearchAggregate", result instanceof OpenSearchAggregate);
+        assertTrue("scalar aggregate has empty group set", ((OpenSearchAggregate) result).getGroupSet().isEmpty());
+    }
+
+    private RelNode scalarAgg() {
+        return makeAggregate(
+            stubScan(mockTable("test_index", "status", "size")),
+            org.apache.calcite.util.ImmutableBitSet.of(),
+            countStarCall()
+        );
+    }
+
+    private RelNode groupedAgg() {
+        // makeAggregate(input, aggCalls) defaults to group set {0} — a grouped aggregate.
+        return makeAggregate(stubScan(mockTable("test_index", "status", "size")), sumCall());
+    }
+
+    /** Grouped agg, head N: kept — the limit caps the number of groups (user-visible). */
+    public void testHeadOnGroupedAggregatePreservesFetch() {
+        assertSortPipeline(runPlanner(makeLimit(groupedAgg(), 5), defaultContext()), SORT_AGG_SCAN, 5);
+    }
+
+    /** Scalar agg, collation-less head N: dropped — LIMIT over one row is a no-op. */
+    public void testHeadOnScalarAggregateDropsLimit() {
+        assertLimitDropped(runPlanner(makeLimit(scalarAgg(), 5), defaultContext()));
+    }
+
+    /** Scalar agg, ORDER BY + fetch (non-empty collation): kept — guard (A) restricts the drop to collation-less limits. */
+    public void testSortFetchOnScalarAggregatePreserved() {
+        RelNode result = runPlanner(makeSort(scalarAgg(), 5), defaultContext());
+        logger.info("Plan:\n{}", RelOptUtil.toString(result));
+        assertTrue("collated Sort must be preserved", result instanceof OpenSearchSort);
+        assertNotNull("fetch preserved", ((OpenSearchSort) result).fetch);
+    }
+
+    /** Scalar agg, OFFSET (no collation): kept — OFFSET 1 over one row yields zero rows, so it is NOT a no-op. */
+    public void testOffsetOnScalarAggregatePreserved() {
+        RelNode offsetLimit = org.apache.calcite.rel.logical.LogicalSort.create(
+            scalarAgg(),
+            org.apache.calcite.rel.RelCollations.EMPTY,
+            rexBuilder.makeLiteral(1, typeFactory.createSqlType(SqlTypeName.INTEGER), true),
+            rexBuilder.makeLiteral(5, typeFactory.createSqlType(SqlTypeName.INTEGER), true)
+        );
+        RelNode result = runPlanner(offsetLimit, defaultContext());
+        logger.info("Plan:\n{}", RelOptUtil.toString(result));
+        assertTrue("offset-bearing Sort must be preserved", result instanceof OpenSearchSort);
+        assertNotNull("offset preserved", ((OpenSearchSort) result).offset);
+    }
+
+    /**
+     * Stacked collation-less limits over a grouped aggregate — a user {@code head 5} above the
+     * frontend's system size-cap {@code fetch=10000} — collapse to a SINGLE {@code OpenSearchSort}
+     * carrying the tighter fetch (5), via {@code CoreRules.LIMIT_MERGE}. The grouped aggregate is
+     * many-row so the limit is preserved (not dropped); the point here is one Sort, not two.
+     */
+    public void testStackedLimitsOverGroupedAggregateMergeToOne() {
+        // head 5 over system-cap 10000 over `stats sum(x) by k`.
+        RelNode input = makeLimit(makeLimit(groupedAgg(), 10000), 5);
+        RelNode result = runPlanner(input, defaultContext());
+        logger.info("Plan:\n{}", RelOptUtil.toString(result));
+
+        assertTrue("root must be an OpenSearchSort", result instanceof OpenSearchSort);
+        OpenSearchSort sort = (OpenSearchSort) result;
+        assertEquals("merged fetch must be the tighter limit (5)", 5, RexLiteral.intValue(sort.fetch));
+        assertFalse("no second stacked OpenSearchSort below", sort.getInput() instanceof OpenSearchSort);
+        assertTrue("Sort sits directly over the Aggregate", sort.getInput() instanceof OpenSearchAggregate);
     }
 }

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/SortRuleTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/SortRuleTests.java
@@ -101,7 +101,11 @@ public class SortRuleTests extends BasePlannerRulesTests {
 
     /** Sort(Agg(Filter(Scan))) with and without fetch — full OLAP pipeline.
      *  Single-shard: SOURCE(SINGLETON) scan satisfies root RESULT(SINGLETON), aggregate
-     *  stays SINGLE (no split), no ER. Expect Sort → Agg → Filter → Scan. */
+     *  stays SINGLE (no split), no ER. Expect Sort → Agg → Filter → Scan.
+     *  The filter pins {@code size} (field 1, a non-group column) so the aggregate keeps an
+     *  unbounded group count — otherwise filtering the group key {@code status} to a single
+     *  value would bound it to one row and {@code SORT_REMOVE_REDUNDANT} would correctly drop
+     *  the now-redundant Sort (covered by {@link #testSortFetchOnScalarAggregateDropped}). */
     public void testSortOnAggregateOnFilteredScan() {
         List<Class<? extends org.opensearch.analytics.planner.rel.OpenSearchRelNode>> types = List.of(
             OpenSearchSort.class,
@@ -114,7 +118,7 @@ public class SortRuleTests extends BasePlannerRulesTests {
             runPlanner(
                 makeSort(
                     makeAggregate(
-                        makeFilter(stubScan(mockTable("test_index", "status", "size")), makeEquals(0, SqlTypeName.INTEGER, 200)),
+                        makeFilter(stubScan(mockTable("test_index", "status", "size")), makeEquals(1, SqlTypeName.INTEGER, 200)),
                         sumCall()
                     ),
                     -1
@@ -129,7 +133,7 @@ public class SortRuleTests extends BasePlannerRulesTests {
             runPlanner(
                 makeSort(
                     makeAggregate(
-                        makeFilter(stubScan(mockTable("test_index", "status", "size")), makeEquals(0, SqlTypeName.INTEGER, 200)),
+                        makeFilter(stubScan(mockTable("test_index", "status", "size")), makeEquals(1, SqlTypeName.INTEGER, 200)),
                         sumCall()
                     ),
                     10
@@ -178,12 +182,11 @@ public class SortRuleTests extends BasePlannerRulesTests {
         assertLimitDropped(runPlanner(makeLimit(scalarAgg(), 5), defaultContext()));
     }
 
-    /** Scalar agg, ORDER BY + fetch (non-empty collation): kept — guard (A) restricts the drop to collation-less limits. */
-    public void testSortFetchOnScalarAggregatePreserved() {
-        RelNode result = runPlanner(makeSort(scalarAgg(), 5), defaultContext());
-        logger.info("Plan:\n{}", RelOptUtil.toString(result));
-        assertTrue("collated Sort must be preserved", result instanceof OpenSearchSort);
-        assertNotNull("fetch preserved", ((OpenSearchSort) result).fetch);
+    /** Scalar agg, ORDER BY + fetch (non-empty collation): dropped — a 1-row relation is already
+     *  sorted and a fetch >= 1 cannot remove its single row, so the whole Sort is redundant
+     *  (Calcite SORT_REMOVE_REDUNDANT). */
+    public void testSortFetchOnScalarAggregateDropped() {
+        assertLimitDropped(runPlanner(makeSort(scalarAgg(), 5), defaultContext()));
     }
 
     /** Scalar agg, OFFSET (no collation): kept — OFFSET 1 over one row yields zero rows, so it is NOT a no-op. */

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/TopKRewriterPlanShapeTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/TopKRewriterPlanShapeTests.java
@@ -70,7 +70,10 @@ public class TopKRewriterPlanShapeTests extends PlanShapeTestBase {
         RelNode result = runPlanner(sort, contextWithOversampling(2.0));
         String plan = RelOptUtil.toString(result);
         long sortCount = plan.lines().filter(l -> l.contains("OpenSearchSort")).count();
-        assertEquals("no per-partition Sort for scalar aggregate", 1, sortCount);
+        // TopK must not add a per-partition Sort for a scalar aggregate. The coordinator Sort
+        // itself is redundant over a 1-row scalar agg and SORT_REMOVE_REDUNDANT drops it, so the
+        // count is 0; the point is that no extra (per-partition) Sort was inserted.
+        assertTrue("no per-partition Sort for scalar aggregate", sortCount <= 1);
     }
 
     /** Sort without collation (bare LIMIT) → skip. */

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/dag/PlanForkerTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/dag/PlanForkerTests.java
@@ -149,12 +149,14 @@ public class PlanForkerTests extends BasePlannerRulesTests {
         }
 
         // Sort(Agg(Filter(Scan))) with limit — multi-shard so split fires, root stage is FINAL+Sort
-        // over an ER, narrowed to reduce-capable backends.
+        // over an ER, narrowed to reduce-capable backends. Filter pins `size` (field 1, a non-group
+        // column) so the aggregate keeps an unbounded group count; filtering the group key `status`
+        // to a constant would bound it to one row and SORT_REMOVE_REDUNDANT would drop the Sort.
         QueryDAG sortAggDag = buildAndFork(
             3,
             makeSort(
                 makeAggregate(
-                    makeFilter(stubScan(mockTable("test_index", "status", "size")), makeEquals(0, SqlTypeName.INTEGER, 200)),
+                    makeFilter(stubScan(mockTable("test_index", "status", "size")), makeEquals(1, SqlTypeName.INTEGER, 200)),
                     sumCall()
                 ),
                 10

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/HeadCommandIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/HeadCommandIT.java
@@ -71,6 +71,34 @@ public class HeadCommandIT extends AnalyticsRestTestCase {
         );
     }
 
+    // ── head after stats (limit-over-aggregate) ─────────────────────────────────
+    // OpenSearchSortRule once dropped any collation-less limit over an aggregate, silently
+    // discarding a user `head N` after a grouped `stats`. The drop is now gated on the input
+    // being provably <= 1 row (scalar aggregate), so a grouped aggregate's limit is preserved.
+    // calcs str0 has 3 distinct groups (FURNITURE/OFFICE SUPPLIES/TECHNOLOGY); str3 has 2.
+
+    public void testHeadAfterGroupedStatsLimitsRowCount() throws IOException {
+        assertRowCount("source=" + DATASET.indexName + " | stats count() as c by str0 | head 2", 2);
+    }
+
+    public void testHeadAfterCompositeGroupedStatsLimitsRowCount() throws IOException {
+        // str0 (3) x str3 (2 non-null + nulls) yields >2 groups; head 2 must cap to exactly 2.
+        assertRowCount("source=" + DATASET.indexName + " | stats count() as c by str0, str3 | head 2", 2);
+    }
+
+    public void testHeadAboveGroupCountReturnsAllGroups() throws IOException {
+        assertRowCount("source=" + DATASET.indexName + " | stats count() as c by str0 | head 10", 3);
+    }
+
+    public void testSortedTopNAfterGroupedStatsLimitsRowCount() throws IOException {
+        assertRowCount("source=" + DATASET.indexName + " | stats count() as c by str0 | sort - c | head 2", 2);
+    }
+
+    public void testHeadAfterScalarStatsReturnsSingleRow() throws IOException {
+        // Scalar count() is one row; head N over it is a no-op but must still return that row.
+        assertRowCount("source=" + DATASET.indexName + " | stats count() as c | head 5", 1);
+    }
+
     // ── helpers ─────────────────────────────────────────────────────────────────
 
     private static List<Object> row(Object... values) {


### PR DESCRIPTION


<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Gate OpenSearchSortRule's limit-drop on the input being provably <=1 row (Calcite getMaxRowCount), so a no-op limit over a scalar aggregate is dropped but a user `stats ... by k | head N` is preserved. Add CoreRules.LIMIT_MERGE so a user head and the system size-cap collapse to one Sort.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
