### PR TITLE
PPL date/time fixes 15 new scalars, TIME comparison, sub-ms precision, format tokens

### DIFF
--- a/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/ScalarFunction.java
+++ b/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/ScalarFunction.java
@@ -285,12 +285,57 @@ public enum ScalarFunction {
      * analytics-backend-datafusion adapter.
      */
     DATE_SUB(Category.SCALAR, SqlKind.OTHER_FUNCTION),
+    /**
+     * PPL {@code ADDDATE(<date|timestamp>, N | INTERVAL n unit)} — shift a temporal value forward.
+     * Shares the {@code DATE_ADD} lowering: the integer form is treated as {@code INTERVAL N DAY}.
+     * TIME bases (anchored to the query-start date by the PPL UDF) are left on the UDF path.
+     */
+    ADDDATE(Category.SCALAR, SqlKind.OTHER_FUNCTION),
+    /**
+     * PPL {@code SUBDATE(<date|timestamp>, N | INTERVAL n unit)} — the subtract counterpart of
+     * {@link #ADDDATE}, sharing the {@code DATE_SUB} lowering.
+     */
+    SUBDATE(Category.SCALAR, SqlKind.OTHER_FUNCTION),
     UTC_DATE(Category.SCALAR, SqlKind.OTHER_FUNCTION),
     UTC_TIME(Category.SCALAR, SqlKind.OTHER_FUNCTION),
     UTC_TIMESTAMP(Category.SCALAR, SqlKind.OTHER_FUNCTION),
     DAYNAME(Category.SCALAR, SqlKind.OTHER_FUNCTION),
     MONTHNAME(Category.SCALAR, SqlKind.OTHER_FUNCTION),
     MINUTE_OF_DAY(Category.SCALAR, SqlKind.OTHER_FUNCTION),
+    /**
+     * PPL {@code DATEDIFF(a, b)} — whole-day difference between the calendar dates of two temporal
+     * values ({@code arg1 - arg2}, time-of-day discarded), returning BIGINT. Lowered to a
+     * day-index subtraction by the analytics-backend-datafusion adapter.
+     */
+    DATEDIFF(Category.SCALAR, SqlKind.OTHER_FUNCTION),
+    /** PPL {@code TO_DAYS(x)} — days since {@code 0000-01-01} (BIGINT). Epoch-arithmetic lowering. */
+    TO_DAYS(Category.SCALAR, SqlKind.OTHER_FUNCTION),
+    /** PPL {@code TO_SECONDS(x)} — seconds since {@code 0000-01-01} (BIGINT). Epoch-arithmetic lowering. */
+    TO_SECONDS(Category.SCALAR, SqlKind.OTHER_FUNCTION),
+    /** PPL {@code FROM_DAYS(n)} — inverse of {@link #TO_DAYS}, returns DATE. Epoch-arithmetic lowering. */
+    FROM_DAYS(Category.SCALAR, SqlKind.OTHER_FUNCTION),
+    /** PPL {@code TIME_TO_SEC(x)} — seconds-of-day of a TIME/TIMESTAMP (BIGINT). Epoch-arithmetic lowering. */
+    TIME_TO_SEC(Category.SCALAR, SqlKind.OTHER_FUNCTION),
+    /** PPL {@code SEC_TO_TIME(n)} — time-of-day n seconds past midnight (TIME). from_unixtime-based lowering. */
+    SEC_TO_TIME(Category.SCALAR, SqlKind.OTHER_FUNCTION),
+    /** PPL {@code WEEKDAY(x)} — day-of-week Mon=0..Sun=6 (INTEGER). date_part('dow') remap lowering. */
+    WEEKDAY(Category.SCALAR, SqlKind.OTHER_FUNCTION),
+    /** PPL {@code PERIOD_ADD(P, n)} — add n months to a YYYYMM period (INTEGER). Integer-arithmetic lowering. */
+    PERIOD_ADD(Category.SCALAR, SqlKind.OTHER_FUNCTION),
+    /** PPL {@code PERIOD_DIFF(P1, P2)} — months between two YYYYMM periods (INTEGER). Integer-arithmetic lowering. */
+    PERIOD_DIFF(Category.SCALAR, SqlKind.OTHER_FUNCTION),
+    /** PPL {@code GET_FORMAT(type, region)} — constant MySQL format string (VARCHAR). Plan-time literal fold. */
+    GET_FORMAT(Category.SCALAR, SqlKind.OTHER_FUNCTION),
+    /** PPL {@code ADDTIME(a, b)} — a plus b's time-of-day (TIME if a is TIME, else TIMESTAMP). */
+    ADDTIME(Category.SCALAR, SqlKind.OTHER_FUNCTION),
+    /** PPL {@code SUBTIME(a, b)} — a minus b's time-of-day (TIME if a is TIME, else TIMESTAMP). */
+    SUBTIME(Category.SCALAR, SqlKind.OTHER_FUNCTION),
+    /** PPL {@code TIMEDIFF(a, b)} (engine label TIME_DIFF) — difference of two times as a TIME. */
+    TIME_DIFF(Category.SCALAR, SqlKind.OTHER_FUNCTION),
+    /** PPL {@code LAST_DAY(x)} — last day of x's month (DATE). date_trunc('month')+1mo-1day lowering. */
+    LAST_DAY(Category.SCALAR, SqlKind.OTHER_FUNCTION),
+    /** PPL {@code YEARWEEK(x[, mode])} — year*100+week (INTEGER) via the os_yearweek Rust UDF. */
+    YEARWEEK(Category.SCALAR, SqlKind.OTHER_FUNCTION),
 
     // ── JSON ────────────────────────────────────────────────────────
     JSON_APPEND(Category.SCALAR, SqlKind.OTHER_FUNCTION),

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/os_strftime.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/os_strftime.rs
@@ -138,15 +138,15 @@ fn render_token(tok: Token, dt: DateTime<Utc>, mode: FormatMode) -> Option<Rende
         // PPL bug-for-bug: %w uses Mon=1..Sun=7 despite MySQL docs claiming Sun=0.
         Token::WLower => date_only!(Str(dt.weekday().number_from_monday().to_string())),
         Token::J => date_only!(Str(format!("{:03}", dt.ordinal()))),
-        // %U/%u/%V/%v render unpadded (PPL emits via '%d', not '%02d')
-        Token::UUpper => date_only!(Str(week_number_sunday_first(dt).to_string())),
-        Token::ULower => date_only!(Str(week_number_monday_first(dt).to_string())),
-        Token::VUpper => date_only!(Str(week_number_sunday_first_01(dt).to_string())),
-        Token::VLower => date_only!(Str(week_number_monday_first_01(dt).to_string())),
+        // %U/%u/%V/%v render zero-padded to width 2 (matches MySQL docs and PPL DateTimeFormatterUtil).
+        Token::UUpper => date_only!(Str(format!("{:02}", week_number_sunday_first(dt)))),
+        Token::ULower => date_only!(Str(format!("{:02}", week_number_monday_first(dt)))),
+        Token::VUpper => date_only!(Str(format!("{:02}", week_number_sunday_first_01(dt)))),
+        Token::VLower => date_only!(Str(format!("{:02}", week_number_monday_first_01(dt)))),
         Token::XUpper => date_only!(Str(format!("{:04}", week_year_sunday_first(dt)))),
         Token::XLower => date_only!(Str(format!("{:04}", week_year_monday_first(dt)))),
-        // %c is zero-padded month (PPL: 'MM' pattern, not MySQL's documented unpadded behavior)
-        Token::C => Str(if time_mode { "0".into() } else { format!("{:02}", dt.month()) }),
+        // %c emits month with no leading zero (MySQL semantics).
+        Token::C => Str(if time_mode { "0".into() } else { dt.month().to_string() }),
         Token::DLower => Str(if time_mode { "00".into() } else { format!("{:02}", dt.day()) }),
         Token::E => Str(if time_mode { "0".into() } else { dt.day().to_string() }),
         Token::MLower => Str(if time_mode { "00".into() } else { format!("{:02}", dt.month()) }),
@@ -649,27 +649,27 @@ mod tests {
 
     #[test]
     fn week_tokens_iso_and_first_day() {
-        // %U/%u/%V/%v unpadded; %v is MySQL mode 3 (Monday-first, 01..53), distinct from ISO.
+        // %U/%u/%V/%v zero-padded to width 2 (MySQL docs); %v is MySQL mode 3 (Monday-first, 01..53), distinct from ISO.
         let dt = sample(); // 2020-03-15 = Sunday
         assert_eq!(fmt(dt, "%U", FormatMode::Date).unwrap(), "11");
         assert_eq!(fmt(dt, "%v", FormatMode::Date).unwrap(), "10");
 
-        // 1998-01-31 (Saturday): all four week tokens render `4`.
+        // 1998-01-31 (Saturday): all four week tokens render `04`.
         let jan31 = Utc.with_ymd_and_hms(1998, 1, 31, 0, 0, 0).unwrap();
         assert_eq!(fmt(jan31, "%U %u %V %v %W %w %X %x %Y %y", FormatMode::Date).unwrap(),
-                   "4 4 4 4 Saturday 6 1998 1998 1998 98");
+                   "04 04 04 04 Saturday 6 1998 1998 1998 98");
     }
 
     #[test]
     fn date_format_timestamp_full_token_set() {
-        // Full token set from CalciteDateTimeFunctionIT.testDateFormat: %c is zero-padded; %P literal.
+        // Full token set from CalciteDateTimeFunctionIT.testDateFormat: %c is unpadded; %P literal.
         let ts = chrono::NaiveDate::from_ymd_opt(1998, 1, 31)
             .unwrap()
             .and_hms_micro_opt(13, 14, 15, 12_345)
             .unwrap();
         let dt = chrono::Utc.from_utc_datetime(&ts);
         let fmtstr = "%a %b %c %D %d %e %f %H %h %I %i %j %k %l %M %m %p %r %S %s %T %% %P";
-        let want = "Sat Jan 01 31st 31 31 012345 13 01 01 14 031 13 1 January 01 PM 01:14:15 PM 15 15 13:14:15 % P";
+        let want = "Sat Jan 1 31st 31 31 012345 13 01 01 14 031 13 1 January 01 PM 01:14:15 PM 15 15 13:14:15 % P";
         assert_eq!(fmt(dt, fmtstr, FormatMode::Date).unwrap(), want);
     }
 

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/os_week.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/os_week.rs
@@ -6,9 +6,12 @@
  * compatible open source license.
  */
 
-//! `os_week(date [, mode])` — MySQL `WEEK()` semantics (modes 0..7), used by PPL's
-//! `WEEK` / `WEEK_OF_YEAR`. DataFusion's `date_part('week', ts)` is ISO-only and disagrees
-//! with MySQL's default mode 0 (Sunday-first).
+//! MySQL `WEEK()` / `YEARWEEK()` semantics (modes 0..7), used by PPL's `WEEK` / `WEEK_OF_YEAR`
+//! and `YEARWEEK`. DataFusion's `date_part('week', ts)` is ISO-only and disagrees with MySQL's
+//! default mode 0 (Sunday-first). Both UDFs share the per-mode week math (`os_week_number`):
+//!
+//! - `os_week(date [, mode])` → the MySQL week number.
+//! - `os_yearweek(date [, mode])` → `year * 100 + week`, with MySQL's year-boundary roll.
 
 use std::sync::Arc;
 
@@ -25,6 +28,7 @@ use super::udf_identity;
 
 pub fn register_all(ctx: &SessionContext) {
     ctx.register_udf(ScalarUDF::from(OsWeekUdf::new()));
+    ctx.register_udf(ScalarUDF::from(OsYearweekUdf::new()));
 }
 
 #[derive(Debug)]
@@ -119,6 +123,123 @@ impl ScalarUDFImpl for OsWeekUdf {
         }
         Ok(ColumnarValue::Array(Arc::new(builder.finish()) as ArrayRef))
     }
+}
+
+#[derive(Debug)]
+pub struct OsYearweekUdf {
+    signature: Signature,
+}
+
+impl OsYearweekUdf {
+    pub fn new() -> Self {
+        Self {
+            signature: Signature::user_defined(Volatility::Immutable),
+        }
+    }
+}
+
+udf_identity!(OsYearweekUdf, "os_yearweek");
+
+impl ScalarUDFImpl for OsYearweekUdf {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn name(&self) -> &str {
+        "os_yearweek"
+    }
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+    fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
+        if arg_types.is_empty() || arg_types.len() > 2 {
+            return plan_err!("os_yearweek expects 1 or 2 arguments, got {}", arg_types.len());
+        }
+        Ok(DataType::Int32)
+    }
+    fn coerce_types(&self, arg_types: &[DataType]) -> Result<Vec<DataType>> {
+        if arg_types.is_empty() || arg_types.len() > 2 {
+            return plan_err!("os_yearweek expects 1 or 2 arguments, got {}", arg_types.len());
+        }
+        let mut out = Vec::with_capacity(arg_types.len());
+        match &arg_types[0] {
+            DataType::Date32
+            | DataType::Date64
+            | DataType::Timestamp(_, _)
+            | DataType::Utf8
+            | DataType::LargeUtf8
+            | DataType::Utf8View => out.push(DataType::Date32),
+            other => return plan_err!("os_yearweek: arg 0 expected date/timestamp/string, got {other:?}"),
+        }
+        if arg_types.len() == 2 {
+            match &arg_types[1] {
+                DataType::Int8
+                | DataType::Int16
+                | DataType::Int32
+                | DataType::Int64
+                | DataType::UInt8
+                | DataType::UInt16
+                | DataType::UInt32
+                | DataType::UInt64 => out.push(DataType::Int32),
+                other => return plan_err!("os_yearweek: arg 1 expected integer mode, got {other:?}"),
+            }
+        }
+        Ok(out)
+    }
+
+    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
+        let n = args.number_rows;
+        let date_arg = args.args[0].clone().into_array(n)?;
+        let mode_arg = if args.args.len() == 2 {
+            Some(args.args[1].clone().into_array(n)?)
+        } else {
+            None
+        };
+        let dates = date_arg
+            .as_any()
+            .downcast_ref::<datafusion::arrow::array::Date32Array>()
+            .ok_or_else(|| datafusion::error::DataFusionError::Internal(
+                "os_yearweek: arg 0 not coerced to Date32".to_string(),
+            ))?;
+        let mut builder = Int32Builder::with_capacity(n);
+        for i in 0..n {
+            if dates.is_null(i) {
+                builder.append_null();
+                continue;
+            }
+            let mode = match &mode_arg {
+                Some(arr) if arr.is_null(i) => 0,
+                Some(arr) => arr.as_primitive::<datafusion::arrow::datatypes::Int32Type>().value(i),
+                None => 0,
+            };
+            let days = dates.value(i);
+            let date = NaiveDate::from_num_days_from_ce_opt(days + 719_163)
+                .ok_or_else(|| datafusion::error::DataFusionError::Execution(
+                    format!("os_yearweek: invalid Date32 day count {days}"),
+                ))?;
+            builder.append_value(os_yearweek_number(date, mode));
+        }
+        Ok(ColumnarValue::Array(Arc::new(builder.finish()) as ArrayRef))
+    }
+}
+
+/// MySQL `YEARWEEK(date, mode)` — `year * 100 + week`. Keeps the caller's mode unless its week
+/// number is 0, in which case it bumps to mode 2 (for mode ≤ 4) or 7 so the date rolls into the
+/// prior year's last week; the year is the calendar year, decremented when an early-January date
+/// falls in the 52/53 week range (i.e. belongs to the prior year). Reuses [`os_week_number`].
+fn os_yearweek_number(date: NaiveDate, mode: i32) -> i32 {
+    let mode_resolved = if os_week_number(date, mode) != 0 {
+        mode
+    } else if mode.rem_euclid(8) <= 4 {
+        2
+    } else {
+        7
+    };
+    let week = os_week_number(date, mode_resolved);
+    let mut year = date.year();
+    if week > 51 && date.day() < 7 {
+        year -= 1;
+    }
+    year * 100 + week as i32
 }
 
 /// MySQL `WEEK()` modes 0..7; see
@@ -242,6 +363,38 @@ mod tests {
         ];
         for (d, mode, want) in cases {
             assert_eq!(os_week_number(*d, *mode), *want, "date={d}, mode={mode}");
+        }
+    }
+
+    #[test]
+    fn os_yearweek_matches_sql_plugin() {
+        // From CalciteDateTimeFunctionIT.testYearWeek: yearweek('2003-10-03')=200339,
+        // yearweek('2003-10-03', 3)=200340.
+        let d = NaiveDate::from_ymd_opt(2003, 10, 3).unwrap();
+        assert_eq!(os_yearweek_number(d, 0), 200339);
+        assert_eq!(os_yearweek_number(d, 3), 200340);
+    }
+
+    #[test]
+    fn os_yearweek_rolls_year_at_boundary() {
+        // 2000-01-01 (Sat), mode 0 → week 0 → bumps to mode 2 → prior year's last week (1999-52).
+        let d = NaiveDate::from_ymd_opt(2000, 1, 1).unwrap();
+        assert_eq!(os_yearweek_number(d, 0), 199952);
+    }
+
+    #[test]
+    fn os_yearweek_delegates_per_mode_to_os_week_number() {
+        // 2008-02-20 is mid-February — far enough from year boundaries that neither the
+        // mode-bump branch (week == 0) nor the year-decrement branch (week > 51 && day < 7)
+        // can fire. Under those conditions, the algebraic contract is:
+        //     os_yearweek_number(d, mode) == year * 100 + os_week_number(d, mode)
+        // Pins that the per-mode math comes from os_week_number for every mode 0..7 — without
+        // claiming exact week numbers for each mode (which the os_week_number tests already
+        // cover for the modes they exercise).
+        let d = NaiveDate::from_ymd_opt(2008, 2, 20).unwrap();
+        for mode in 0..8 {
+            let expected = 2008 * 100 + os_week_number(d, mode) as i32;
+            assert_eq!(os_yearweek_number(d, mode), expected, "mode={mode}");
         }
     }
 }

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/os_week.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/os_week.rs
@@ -141,9 +141,6 @@ impl OsYearweekUdf {
 udf_identity!(OsYearweekUdf, "os_yearweek");
 
 impl ScalarUDFImpl for OsYearweekUdf {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
     fn name(&self) -> &str {
         "os_yearweek"
     }

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/AddSubTimeAdapter.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/AddSubTimeAdapter.java
@@ -1,0 +1,81 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion;
+
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.opensearch.analytics.spi.FieldStorageInfo;
+import org.opensearch.analytics.spi.NumericToDoubleAdapter;
+import org.opensearch.analytics.spi.ScalarFunctionAdapter;
+
+import java.util.List;
+
+/**
+ * PPL {@code ADDTIME(a, b)} / {@code SUBTIME(a, b)} — add (or subtract) the <em>time-of-day</em> of
+ * {@code b} to/from the temporal value {@code a}.
+ *
+ * <p>Return type (already inferred onto the call by the PPL frontend): {@code TIME} when {@code a}
+ * is a {@code TIME}, otherwise {@code TIMESTAMP}. {@code b} contributes only its seconds-of-day,
+ * {@code delta = to_unixtime(anchor(b)) MOD 86400}.
+ *
+ * <ul>
+ *   <li><b>TIMESTAMP result:</b> {@code from_unixtime(to_unixtime(a) ± delta)} — whole-second epoch
+ *       arithmetic, rebuilt into a timestamp.</li>
+ *   <li><b>TIME result</b> (a is TIME): {@code maketime} of {@code secondsOfDay(a) ± delta},
+ *       normalized into a day — see {@link TimeOfDayLowering#secondsToTime}.</li>
+ * </ul>
+ *
+ * <p>TIME operands are anchored to a TIMESTAMP first because {@code to_unixtime} rejects an Arrow
+ * {@code Time64} (see {@link TimeOfDayLowering#secondsOfDay}). {@code from_unixtime} takes fp64.
+ *
+ * @opensearch.internal
+ */
+class AddSubTimeAdapter implements ScalarFunctionAdapter {
+
+    private final boolean isAdd;
+
+    AddSubTimeAdapter(boolean isAdd) {
+        this.isAdd = isAdd;
+    }
+
+    @Override
+    public RexNode adapt(RexCall original, List<FieldStorageInfo> fieldStorage, RelOptCluster cluster) {
+        if (original.getOperands().size() != 2) {
+            return original;
+        }
+        RexBuilder rexBuilder = cluster.getRexBuilder();
+        RexNode a = original.getOperands().get(0);
+        RexNode b = original.getOperands().get(1);
+        RexNode delta = TimeOfDayLowering.secondsOfDay(b, cluster);
+        org.apache.calcite.sql.SqlOperator addsub = isAdd ? SqlStdOperatorTable.PLUS : SqlStdOperatorTable.MINUS;
+
+        if (original.getType().getSqlTypeName() == SqlTypeName.TIME) {
+            RexNode combined = rexBuilder.makeCall(addsub, TimeOfDayLowering.secondsOfDay(a, cluster), delta);
+            return TimeOfDayLowering.secondsToTime(combined, original.getType(), cluster);
+        }
+
+        // TIMESTAMP result: from_unixtime(to_unixtime(a) ± delta).
+        RexNode anchoredA = DatePartAdapters.coerceCharacterOperandToTimestamp(a, cluster);
+        RexNode aEpoch = rexBuilder.makeCall(UnixTimestampAdapter.LOCAL_TO_UNIXTIME_OP, anchoredA);
+        RexNode epoch = rexBuilder.makeCall(addsub, aEpoch, delta);
+        RexNode epochDouble = NumericToDoubleAdapter.widenToDoubleIfNumeric(epoch, cluster);
+        RelDataType tsType = rexBuilder.getTypeFactory()
+            .createTypeWithNullability(rexBuilder.getTypeFactory().createSqlType(SqlTypeName.TIMESTAMP), true);
+        RexNode ts = rexBuilder.makeCall(tsType, RustUdfDateTimeAdapters.LOCAL_FROM_UNIXTIME_OP, List.of(epochDouble));
+        if (ts.getType().equals(original.getType())) {
+            return ts;
+        }
+        return rexBuilder.makeCast(original.getType(), ts, true);
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/ComparisonTemporalCoercionAdapter.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/ComparisonTemporalCoercionAdapter.java
@@ -13,8 +13,10 @@ import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.type.SqlTypeFamily;
 import org.apache.calcite.sql.type.SqlTypeName;
+import org.opensearch.analytics.planner.rel.OperatorAnnotation;
 import org.opensearch.analytics.spi.FieldStorageInfo;
 import org.opensearch.analytics.spi.ScalarFunctionAdapter;
 
@@ -22,16 +24,10 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Coerces a bare character operand of a binary comparison to {@code TIMESTAMP} when the other
- * operand is temporal ({@code DATE} / {@code TIME} / {@code TIMESTAMP}), so the comparison resolves
- * to a Substrait signature DataFusion can execute.
- *
- * <p>Needed because a temporal comparison inside a subquery loses its coercion: decorrelation
- * constant-folds the PPL {@code TIMESTAMP} UDF wrapper to a bare string before the scalar-function
- * adapter pass runs, leaving an unconvertible {@code timestamp vs string} comparison. Recovering it
- * here is independent of how the string arrived (folded UDF, native {@code DATE '...'} literal, or a
- * string column); the cast reuses {@link DatePartAdapters#coerceCharacterOperandToTimestamp}. Other
- * shapes (e.g. {@code gender = 'F'}, numeric ranges) pass through unchanged.
+ * Coerces a comparison operand to {@code TIMESTAMP} when isthmus has no Substrait sig for the call:
+ * char-vs-temporal (decorrelation folded the PPL {@code TIMESTAMP} UDF to a bare string), or
+ * TIME-vs-{DATE,TIMESTAMP} (Calcite wraps TIME with {@code to_timestamp(precision_time<P>)} which
+ * has no yaml impl). Both shapes route through {@link DatePartAdapters#coerceCharacterOperandToTimestamp}.
  *
  * @opensearch.internal
  */
@@ -45,15 +41,18 @@ class ComparisonTemporalCoercionAdapter implements ScalarFunctionAdapter {
         }
         RexNode left = operands.get(0);
         RexNode right = operands.get(1);
+
+        // TIME vs DATE/TIMESTAMP — rewrite the TIME side to today-anchored TIMESTAMP
+        RexNode newLeft = coerceTimeIfApplicable(left, right, cluster);
+        RexNode newRight = coerceTimeIfApplicable(right, left, cluster);
+        if (newLeft != left || newRight != right) {
+            return rebuild(original, newLeft, newRight, cluster);
+        }
+
         boolean leftChar = isCharacter(left);
         boolean rightChar = isCharacter(right);
         boolean leftTemporal = isTemporal(left);
         boolean rightTemporal = isTemporal(right);
-
-        // Only act on a temporal-vs-character mix: coerce the character side to TIMESTAMP. Any other
-        // shape (temporal/temporal, char/char, numeric, etc.) is left to isthmus unchanged.
-        RexNode newLeft = left;
-        RexNode newRight = right;
         if (leftChar && rightTemporal) {
             newLeft = DatePartAdapters.coerceCharacterOperandToTimestamp(left, cluster);
         } else if (rightChar && leftTemporal) {
@@ -61,10 +60,64 @@ class ComparisonTemporalCoercionAdapter implements ScalarFunctionAdapter {
         } else {
             return original;
         }
-
         if (newLeft == left && newRight == right) {
             return original;
         }
+        return rebuild(original, newLeft, newRight, cluster);
+    }
+
+    /** TIME (or wrapped TIME) compared with DATE/TIMESTAMP — rewrite to today-anchored TIMESTAMP, preserving any outer annotation. */
+    private static RexNode coerceTimeIfApplicable(RexNode self, RexNode other, RelOptCluster cluster) {
+        RexNode timeInner = unwrapToTime(self);
+        if (timeInner == null) {
+            return self;
+        }
+        if (unwrapToTime(other) != null || !isDateOrTimestampOrWrapped(other)) {
+            return self;
+        }
+        RexNode rewritten = DatePartAdapters.coerceCharacterOperandToTimestamp(timeInner, cluster);
+        if (self instanceof OperatorAnnotation annotation && annotation.unwrap() != null) {
+            return annotation.withAdaptedOriginal(rewritten);
+        }
+        return rewritten;
+    }
+
+    /** True for a raw DATE/TIMESTAMP, or a {@code to_timestamp(date)}/{@code CAST(date AS TIMESTAMP)} wrapper. */
+    private static boolean isDateOrTimestampOrWrapped(RexNode node) {
+        RexNode stripped = stripAnnotation(node);
+        if (isDateOrTimestamp(stripped)) {
+            return true;
+        }
+        if (stripped instanceof RexCall call && call.getOperands().size() == 1) {
+            return isDateOrTimestamp(stripAnnotation(call.getOperands().get(0)))
+                && (call.getOperator() == DateTimeAdapters.LOCAL_TO_TIMESTAMP_OP || call.isA(SqlKind.CAST));
+        }
+        return false;
+    }
+
+    /** Returns the TIME-typed inner if node is raw TIME or a single-operand to_timestamp/CAST around TIME; else null. Strips OperatorAnnotation at every level — recursion threads annotations through intermediate nodes. */
+    private static RexNode unwrapToTime(RexNode node) {
+        RexNode stripped = stripAnnotation(node);
+        if (isTime(stripped)) {
+            return stripped;
+        }
+        if (stripped instanceof RexCall call && call.getOperands().size() == 1) {
+            RexNode inner = stripAnnotation(call.getOperands().get(0));
+            if (isTime(inner) && (call.getOperator() == DateTimeAdapters.LOCAL_TO_TIMESTAMP_OP || call.isA(SqlKind.CAST))) {
+                return inner;
+            }
+        }
+        return null;
+    }
+
+    private static RexNode stripAnnotation(RexNode node) {
+        while (node instanceof OperatorAnnotation annotation && annotation.unwrap() != null) {
+            node = annotation.unwrap();
+        }
+        return node;
+    }
+
+    private static RexNode rebuild(RexCall original, RexNode newLeft, RexNode newRight, RelOptCluster cluster) {
         RexBuilder rexBuilder = cluster.getRexBuilder();
         List<RexNode> coerced = new ArrayList<>(2);
         coerced.add(newLeft);
@@ -74,6 +127,16 @@ class ComparisonTemporalCoercionAdapter implements ScalarFunctionAdapter {
 
     private static boolean isCharacter(RexNode node) {
         return SqlTypeFamily.CHARACTER.contains(node.getType());
+    }
+
+    private static boolean isTime(RexNode node) {
+        SqlTypeName name = node.getType().getSqlTypeName();
+        return name == SqlTypeName.TIME || name == SqlTypeName.TIME_WITH_LOCAL_TIME_ZONE;
+    }
+
+    private static boolean isDateOrTimestamp(RexNode node) {
+        SqlTypeName name = node.getType().getSqlTypeName();
+        return name == SqlTypeName.DATE || name == SqlTypeName.TIMESTAMP || name == SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE;
     }
 
     private static boolean isTemporal(RexNode node) {

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/ComparisonTemporalCoercionAdapter.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/ComparisonTemporalCoercionAdapter.java
@@ -110,6 +110,8 @@ class ComparisonTemporalCoercionAdapter implements ScalarFunctionAdapter {
         return null;
     }
 
+    // TODO: annotation stripping should be centralised in FragmentConversionDriver; revisit alongside the other adapters that strip
+    // locally.
     private static RexNode stripAnnotation(RexNode node) {
         while (node instanceof OperatorAnnotation annotation && annotation.unwrap() != null) {
             node = annotation.unwrap();

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionAnalyticsBackendPlugin.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionAnalyticsBackendPlugin.java
@@ -369,7 +369,33 @@ public class DataFusionAnalyticsBackendPlugin implements AnalyticsSearchBackendP
         ScalarFunction.TIMESTAMPDIFF,
         ScalarFunction.TIMESTAMPADD,
         ScalarFunction.DATE_ADD,
-        ScalarFunction.DATE_SUB
+        ScalarFunction.DATE_SUB,
+        // PPL `ADDDATE(base, N|INTERVAL)` / `SUBDATE(...)` — share the DATE_ADD/DATE_SUB adapter;
+        // the integer-days form is normalized to INTERVAL N DAY. DATE / TIMESTAMP bases only.
+        ScalarFunction.ADDDATE,
+        ScalarFunction.SUBDATE,
+        // PPL `DATEDIFF(a, b)` — calendar-day delta, lowered to a day-index subtraction.
+        ScalarFunction.DATEDIFF,
+        // PPL epoch-arithmetic datetime scalars — lower to to_unixtime/from_unixtime + integer math.
+        ScalarFunction.TO_DAYS,
+        ScalarFunction.TO_SECONDS,
+        ScalarFunction.FROM_DAYS,
+        ScalarFunction.TIME_TO_SEC,
+        ScalarFunction.SEC_TO_TIME,
+        // PPL WEEKDAY — date_part('dow') remapped to MySQL Mon=0..Sun=6.
+        ScalarFunction.WEEKDAY,
+        // PPL PERIOD_ADD / PERIOD_DIFF — pure integer YYYYMM arithmetic.
+        ScalarFunction.PERIOD_ADD,
+        ScalarFunction.PERIOD_DIFF,
+        // PPL GET_FORMAT(type, region) — plan-time fold to a constant format string.
+        ScalarFunction.GET_FORMAT,
+        // PPL ADDTIME / SUBTIME / TIMEDIFF — time-of-day arithmetic via to_unixtime + maketime.
+        ScalarFunction.ADDTIME,
+        ScalarFunction.SUBTIME,
+        ScalarFunction.TIME_DIFF,
+        // PPL LAST_DAY — date_trunc('month') + 1 month - 1 day. YEARWEEK — os_yearweek Rust UDF.
+        ScalarFunction.LAST_DAY,
+        ScalarFunction.YEARWEEK
     );
 
     /**
@@ -656,6 +682,23 @@ public class DataFusionAnalyticsBackendPlugin implements AnalyticsSearchBackendP
                     Map.entry(ScalarFunction.DATETIME, new DateTimeAdapters.DatetimeAdapter()),
                     Map.entry(ScalarFunction.DATE_ADD, new DateAddSubAdapter(true)),
                     Map.entry(ScalarFunction.DATE_SUB, new DateAddSubAdapter(false)),
+                    Map.entry(ScalarFunction.ADDDATE, new DateAddSubAdapter(true)),
+                    Map.entry(ScalarFunction.SUBDATE, new DateAddSubAdapter(false)),
+                    Map.entry(ScalarFunction.DATEDIFF, new DateDiffAdapter()),
+                    Map.entry(ScalarFunction.TO_DAYS, new EpochArithmeticAdapters.ToDaysAdapter()),
+                    Map.entry(ScalarFunction.TO_SECONDS, new EpochArithmeticAdapters.ToSecondsAdapter()),
+                    Map.entry(ScalarFunction.FROM_DAYS, new EpochArithmeticAdapters.FromDaysAdapter()),
+                    Map.entry(ScalarFunction.TIME_TO_SEC, new EpochArithmeticAdapters.TimeToSecAdapter()),
+                    Map.entry(ScalarFunction.SEC_TO_TIME, new SecToTimeAdapter()),
+                    Map.entry(ScalarFunction.WEEKDAY, new WeekdayAdapter()),
+                    Map.entry(ScalarFunction.PERIOD_ADD, new PeriodArithmeticAdapters.PeriodAddAdapter()),
+                    Map.entry(ScalarFunction.PERIOD_DIFF, new PeriodArithmeticAdapters.PeriodDiffAdapter()),
+                    Map.entry(ScalarFunction.GET_FORMAT, new GetFormatAdapter()),
+                    Map.entry(ScalarFunction.ADDTIME, new AddSubTimeAdapter(true)),
+                    Map.entry(ScalarFunction.SUBTIME, new AddSubTimeAdapter(false)),
+                    Map.entry(ScalarFunction.TIME_DIFF, new TimeDiffAdapter()),
+                    Map.entry(ScalarFunction.LAST_DAY, new LastDayAdapter()),
+                    Map.entry(ScalarFunction.YEARWEEK, new RustUdfDateTimeAdapters.OsYearweekAdapter()),
                     Map.entry(ScalarFunction.DATE_FORMAT, new RustUdfDateTimeAdapters.DateFormatAdapter()),
                     Map.entry(ScalarFunction.DAY, day),
                     Map.entry(ScalarFunction.DAYNAME, new RustUdfDateTimeAdapters.DaynameAdapter()),

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionFragmentConvertor.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionFragmentConvertor.java
@@ -149,6 +149,7 @@ public class DataFusionFragmentConvertor implements FragmentConvertor {
         FunctionMappings.s(RustUdfDateTimeAdapters.LOCAL_TIME_FORMAT_OP, "time_format"),
         FunctionMappings.s(RustUdfDateTimeAdapters.LOCAL_STR_TO_DATE_OP, "str_to_date"),
         FunctionMappings.s(RustUdfDateTimeAdapters.LOCAL_OS_WEEK_OP, "os_week"),
+        FunctionMappings.s(RustUdfDateTimeAdapters.LOCAL_OS_YEARWEEK_OP, "os_yearweek"),
         FunctionMappings.s(SqlLibraryOperators.REGEXP_CONTAINS, "regex_match"),
         FunctionMappings.s(SqlStdOperatorTable.REPLACE, "replace"),
         FunctionMappings.s(SqlLibraryOperators.REGEXP_REPLACE_3, "regexp_replace"),

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DateAddSubAdapter.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DateAddSubAdapter.java
@@ -31,7 +31,8 @@ import java.util.List;
 
 /**
  * Rewrites PPL {@code DATE_ADD(base, INTERVAL n unit)} / {@code DATE_SUB(base, INTERVAL n unit)}
- * into {@code DATETIME_PLUS(CAST(base AS TIMESTAMP), interval)}, which lowers to Substrait's
+ * (and the alias forms {@code ADDDATE} / {@code SUBDATE}) into
+ * {@code DATETIME_PLUS(CAST(base AS TIMESTAMP), interval)}, which lowers to Substrait's
  * {@code add(timestamp, interval)} that DataFusion executes natively. The raw PPL UDFs have no
  * Substrait binding, so isthmus rejects them.
  *
@@ -44,6 +45,10 @@ import java.util.List;
  * year-month intervals in months. This adapter rebuilds the interval in those base units (under a
  * {@link TimeUnit#DAY} or {@link TimeUnit#MONTH} qualifier) and folds the {@code DATE_SUB} sign in,
  * the same way {@link EarliestLatestAdapter} does.
+ *
+ * <p>{@code ADDDATE(base, n_days)} / {@code SUBDATE(base, n_days)} share the same lowering: the
+ * integer second operand is rebuilt as an {@code INTERVAL n DAY} literal before the standard
+ * interval path runs. This matches the SQL plugin's {@code AddSubDateFunction} semantics.
  *
  * <p>DATE / TIMESTAMP / TIME / character bases are all lowered. TIME anchors to today-UTC at plan
  * time, which can drift from the PPL UDF's query-start anchor across UTC midnight or cached plans
@@ -74,21 +79,14 @@ class DateAddSubAdapter implements ScalarFunctionAdapter {
         }
         RexBuilder rexBuilder = cluster.getRexBuilder();
         RexNode base = original.getOperands().get(0);
-        RexNode intervalOperand = stripOperatorAnnotation(original.getOperands().get(1));
-
-        SqlIntervalQualifier qualifier;
-        BigDecimal leadingValue;
-        if (intervalOperand instanceof RexLiteral intervalLiteral
-            && SqlTypeName.INTERVAL_TYPES.contains(intervalLiteral.getType().getSqlTypeName())) {
-            qualifier = intervalLiteral.getType().getIntervalQualifier();
-            leadingValue = intervalLiteral.getValueAs(BigDecimal.class);
-        } else if (SqlTypeFamily.NUMERIC.contains(intervalOperand.getType()) && intervalOperand instanceof RexLiteral numericLiteral) {
-            // ADDDATE/SUBDATE integer form: ADDDATE(base, N) is treated as INTERVAL N DAY.
-            qualifier = new SqlIntervalQualifier(TimeUnit.DAY, null, SqlParserPos.ZERO);
-            leadingValue = numericLiteral.getValueAs(BigDecimal.class);
-        } else {
+        RexNode rawSecond = stripOperatorAnnotation(original.getOperands().get(1));
+        // ADDDATE/SUBDATE accept INTEGER days; rebuild as INTERVAL n DAY so the interval path runs.
+        RexLiteral intervalLiteral = asIntervalLiteral(rawSecond, rexBuilder);
+        if (intervalLiteral == null) {
             return original;
         }
+        SqlIntervalQualifier qualifier = intervalLiteral.getType().getIntervalQualifier();
+        BigDecimal leadingValue = intervalLiteral.getValueAs(BigDecimal.class);
         if (qualifier == null || leadingValue == null) {
             return original;
         }
@@ -193,5 +191,26 @@ class DateAddSubAdapter implements ScalarFunctionAdapter {
             node = annotation.unwrap();
         }
         return node;
+    }
+
+    /**
+     * Returns {@code node} when it's already an interval literal; for an integer literal returns a
+     * synthetic {@code INTERVAL n DAY} literal (the ADDDATE/SUBDATE integer-days form). Anything
+     * else returns null so the caller can pass the call through to the UDF path.
+     */
+    private static RexLiteral asIntervalLiteral(RexNode node, RexBuilder rexBuilder) {
+        if (node instanceof RexLiteral lit) {
+            if (SqlTypeName.INTERVAL_TYPES.contains(lit.getType().getSqlTypeName())) {
+                return lit;
+            }
+            if (SqlTypeName.INT_TYPES.contains(lit.getType().getSqlTypeName())) {
+                BigDecimal days = lit.getValueAs(BigDecimal.class);
+                if (days == null) {
+                    return null;
+                }
+                return rexBuilder.makeIntervalLiteral(days, new SqlIntervalQualifier(TimeUnit.DAY, null, SqlParserPos.ZERO));
+            }
+        }
+        return null;
     }
 }

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DateAddSubAdapter.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DateAddSubAdapter.java
@@ -35,6 +35,10 @@ import java.util.List;
  * {@code add(timestamp, interval)} that DataFusion executes natively. The raw PPL UDFs have no
  * Substrait binding, so isthmus rejects them.
  *
+ * <p>Also handles ADDDATE/SUBDATE's integer form: {@code ADDDATE(base, N)} is treated as
+ * {@code INTERVAL N DAY} per MySQL semantics — the integer second operand is normalized to a
+ * day-interval literal before the standard lowering proceeds.
+ *
  * <p>PPL's interval literal carries the leading-field value (e.g. {@code 90} for
  * {@code INTERVAL 90 day}), but Substrait/DataFusion expect day-time intervals in milliseconds and
  * year-month intervals in months. This adapter rebuilds the interval in those base units (under a
@@ -68,19 +72,26 @@ class DateAddSubAdapter implements ScalarFunctionAdapter {
         if (original.getOperands().size() != 2) {
             return original;
         }
+        RexBuilder rexBuilder = cluster.getRexBuilder();
         RexNode base = original.getOperands().get(0);
         RexNode intervalOperand = stripOperatorAnnotation(original.getOperands().get(1));
-        if (!(intervalOperand instanceof RexLiteral intervalLiteral)
-            || !SqlTypeName.INTERVAL_TYPES.contains(intervalLiteral.getType().getSqlTypeName())) {
+
+        SqlIntervalQualifier qualifier;
+        BigDecimal leadingValue;
+        if (intervalOperand instanceof RexLiteral intervalLiteral
+            && SqlTypeName.INTERVAL_TYPES.contains(intervalLiteral.getType().getSqlTypeName())) {
+            qualifier = intervalLiteral.getType().getIntervalQualifier();
+            leadingValue = intervalLiteral.getValueAs(BigDecimal.class);
+        } else if (SqlTypeFamily.NUMERIC.contains(intervalOperand.getType()) && intervalOperand instanceof RexLiteral numericLiteral) {
+            // ADDDATE/SUBDATE integer form: ADDDATE(base, N) is treated as INTERVAL N DAY.
+            qualifier = new SqlIntervalQualifier(TimeUnit.DAY, null, SqlParserPos.ZERO);
+            leadingValue = numericLiteral.getValueAs(BigDecimal.class);
+        } else {
             return original;
         }
-        SqlIntervalQualifier qualifier = intervalLiteral.getType().getIntervalQualifier();
-        BigDecimal leadingValue = intervalLiteral.getValueAs(BigDecimal.class);
         if (qualifier == null || leadingValue == null) {
             return original;
         }
-
-        RexBuilder rexBuilder = cluster.getRexBuilder();
 
         // Character base appears post-decorrelation when the PPL DATE() wrapper is folded off a
         // literal inside EXISTS/IN/scalar subqueries — coerce back to plain Calcite TIMESTAMP (not

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DateDiffAdapter.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DateDiffAdapter.java
@@ -1,0 +1,82 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion;
+
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.opensearch.analytics.spi.FieldStorageInfo;
+import org.opensearch.analytics.spi.ScalarFunctionAdapter;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+/**
+ * Rewrites PPL {@code DATEDIFF(a, b)} into a DataFusion-native expression. The PPL UDF has no
+ * Substrait binding, so isthmus rejects it.
+ *
+ * <p>MySQL/PPL semantics: {@code DATEDIFF} is the whole-day difference between the <em>calendar
+ * dates</em> of the two arguments — {@code DATEDIFF('2000-01-02 00:00:00', '2000-01-01 23:59:59')}
+ * is {@code 1}, not {@code 0}, because the time-of-day is discarded. Argument order is
+ * {@code arg1 - arg2}.
+ *
+ * <p>Lowering (per operand {@code x}, {@code dayNumber(x) = FLOOR(to_unixtime(x) / 86400)}):
+ * <pre>{@code   DATEDIFF(a, b)  →  CAST(dayNumber(a) - dayNumber(b) AS <retType>)}</pre>
+ * {@code to_unixtime} yields whole epoch seconds (UTC), and the {@code / 86400} floor-divide maps
+ * any instant within a UTC day to that day's epoch-day index — so the floor-divide <em>is</em> the
+ * day truncation and the subtraction is an exact calendar-day delta. Both primitives
+ * ({@code to_unixtime}, integer arithmetic) lower through the local {@code to_unixtime} UDF (see
+ * {@link UnixTimestampAdapter}) and the Substrait default catalog. (A {@code date_trunc('day', x)}
+ * wrapper is unnecessary and, on this stack, isthmus can't bind {@code DATE_TRUNC(char, timestamp)}.)
+ *
+ * @opensearch.internal
+ */
+class DateDiffAdapter implements ScalarFunctionAdapter {
+
+    @Override
+    public RexNode adapt(RexCall original, List<FieldStorageInfo> fieldStorage, RelOptCluster cluster) {
+        if (original.getOperands().size() != 2) {
+            return original;
+        }
+        RexBuilder rexBuilder = cluster.getRexBuilder();
+        RexNode left = dayNumber(original.getOperands().get(0), cluster);
+        RexNode right = dayNumber(original.getOperands().get(1), cluster);
+        RexNode diff = rexBuilder.makeCall(SqlStdOperatorTable.MINUS, left, right);
+        if (diff.getType().equals(original.getType())) {
+            return diff;
+        }
+        return rexBuilder.makeCast(original.getType(), diff, true);
+    }
+
+    /**
+     * {@code to_unixtime(x) / 86400} — the epoch-day index of {@code x}. {@code to_unixtime} returns
+     * BIGINT whole seconds, so the divide is integer division (truncates toward zero); for the UTC
+     * epoch seconds of any post-1970 date that equals {@code floor}, giving the calendar-day index.
+     * No explicit FLOOR — isthmus has no {@code FLOOR(i64)} signature.
+     *
+     * <p>A bare {@code TIME} operand (e.g. {@code DATEDIFF(TIME('23:59:59'), TIME('00:00:00'))}) is
+     * anchored to a TIMESTAMP first via {@link DatePartAdapters#coerceCharacterOperandToTimestamp},
+     * because {@code to_unixtime} rejects an Arrow {@code Time64}. Both TIME operands anchor to the
+     * same (today's) date, so their day-numbers cancel — matching MySQL's {@code DATEDIFF} on times
+     * returning 0.
+     */
+    private static RexNode dayNumber(RexNode operand, RelOptCluster cluster) {
+        RexBuilder rexBuilder = cluster.getRexBuilder();
+        RexNode anchored = DatePartAdapters.coerceCharacterOperandToTimestamp(operand, cluster);
+        RexNode epochSeconds = rexBuilder.makeCall(UnixTimestampAdapter.LOCAL_TO_UNIXTIME_OP, anchored);
+        RexNode secondsPerDay = rexBuilder.makeExactLiteral(
+            BigDecimal.valueOf(TimeOfDayLowering.SECONDS_PER_DAY),
+            rexBuilder.getTypeFactory().createSqlType(SqlTypeName.BIGINT)
+        );
+        return rexBuilder.makeCall(SqlStdOperatorTable.DIVIDE, epochSeconds, secondsPerDay);
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DateDiffAdapter.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DateDiffAdapter.java
@@ -58,16 +58,14 @@ class DateDiffAdapter implements ScalarFunctionAdapter {
     }
 
     /**
-     * {@code to_unixtime(x) / 86400} — the epoch-day index of {@code x}. {@code to_unixtime} returns
-     * BIGINT whole seconds, so the divide is integer division (truncates toward zero); for the UTC
-     * epoch seconds of any post-1970 date that equals {@code floor}, giving the calendar-day index.
-     * No explicit FLOOR — isthmus has no {@code FLOOR(i64)} signature.
-     *
-     * <p>A bare {@code TIME} operand (e.g. {@code DATEDIFF(TIME('23:59:59'), TIME('00:00:00'))}) is
-     * anchored to a TIMESTAMP first via {@link DatePartAdapters#coerceCharacterOperandToTimestamp},
-     * because {@code to_unixtime} rejects an Arrow {@code Time64}. Both TIME operands anchor to the
-     * same (today's) date, so their day-numbers cancel — matching MySQL's {@code DATEDIFF} on times
-     * returning 0.
+     * Epoch-day index of {@code x}: floor-divide {@code to_unixtime(x)} by 86400. SQL {@code /}
+     * truncates toward zero, which differs from floor for negative epoch seconds (pre-1970) — and
+     * isthmus has no {@code FLOOR(i64)} in the bound catalog, so the floor is expressed in pure
+     * integer arithmetic:
+     * <pre>{@code   floor(x / d) = (x - ((x MOD d + d) MOD d)) / d}</pre>
+     * Bare {@code TIME} operands are anchored to today's TIMESTAMP first ({@code to_unixtime}
+     * rejects {@code Time64}); both operands anchor to the same date so their day-numbers cancel,
+     * matching MySQL's {@code DATEDIFF}-on-times returning 0.
      */
     private static RexNode dayNumber(RexNode operand, RelOptCluster cluster) {
         RexBuilder rexBuilder = cluster.getRexBuilder();
@@ -77,6 +75,10 @@ class DateDiffAdapter implements ScalarFunctionAdapter {
             BigDecimal.valueOf(TimeOfDayLowering.SECONDS_PER_DAY),
             rexBuilder.getTypeFactory().createSqlType(SqlTypeName.BIGINT)
         );
-        return rexBuilder.makeCall(SqlStdOperatorTable.DIVIDE, epochSeconds, secondsPerDay);
+        RexNode mod1 = rexBuilder.makeCall(SqlStdOperatorTable.MOD, epochSeconds, secondsPerDay);
+        RexNode plusDay = rexBuilder.makeCall(SqlStdOperatorTable.PLUS, mod1, secondsPerDay);
+        RexNode floorMod = rexBuilder.makeCall(SqlStdOperatorTable.MOD, plusDay, secondsPerDay);
+        RexNode numerator = rexBuilder.makeCall(SqlStdOperatorTable.MINUS, epochSeconds, floorMod);
+        return rexBuilder.makeCall(SqlStdOperatorTable.DIVIDE, numerator, secondsPerDay);
     }
 }

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DateTimeAdapters.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DateTimeAdapters.java
@@ -9,6 +9,7 @@
 package org.opensearch.be.datafusion;
 
 import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexLiteral;
@@ -201,6 +202,14 @@ final class DateTimeAdapters {
                 );
                 return rexBuilder.makeCall(original.getType(), LOCAL_TO_TIMESTAMP_OP, List.of(stripped));
             }
+            // 1-arg DATETIME with a TIME operand — Calcite emits stock TIME as substrait
+            // precision_time<P>, which has no to_timestamp yaml binding. Anchor to a TIMESTAMP
+            // first via the shared coercion path so isthmus binds the precision_timestamp<P> arm.
+            // Same workaround TimeFormatAdapter / DatePartAdapters use.
+            if (operands.size() == 1 && operands.get(0).getType().getSqlTypeName() == SqlTypeName.TIME) {
+                RexNode anchored = DatePartAdapters.coerceCharacterOperandToTimestamp(operands.get(0), cluster);
+                return rexBuilder.makeCall(original.getType(), LOCAL_TO_TIMESTAMP_OP, List.of(anchored));
+            }
             return rexBuilder.makeCall(original.getType(), LOCAL_TO_TIMESTAMP_OP, operands);
         }
 
@@ -218,8 +227,9 @@ final class DateTimeAdapters {
                 return foldTwoArgLiteral(valLit.getValueAs(String.class), tzLit.getValueAs(String.class), original, cluster);
             }
 
-            // column input: strip offset via regex, treat as UTC source (legacy SQL plugin parity)
-            String fromTzLiteral = "+00:00";
+            // Column input with no embedded TZ in the value: tz arg is the SOURCE zone (MySQL
+            // semantics — value is interpreted AT the given tz, then expressed in UTC). The legacy
+            // SQL plugin path treated tz as target, which inverted the offset direction.
             RexNode strippedValue;
             if (SqlTypeName.CHAR_TYPES.contains(value.getType().getSqlTypeName())) {
                 RexNode pattern = rexBuilder.makeLiteral(OFFSET_SUFFIX_PATTERN);
@@ -233,8 +243,12 @@ final class DateTimeAdapters {
                 strippedValue = value;
             }
             RexNode asTimestamp = rexBuilder.makeCall(original.getType(), LOCAL_TO_TIMESTAMP_OP, List.of(strippedValue));
-            RexNode fromTz = rexBuilder.makeLiteral(fromTzLiteral);
-            return rexBuilder.makeCall(original.getType(), ConvertTzAdapter.LOCAL_CONVERT_TZ_OP, List.of(asTimestamp, fromTz, tzArg));
+            // makeLiteral(String) infers CHAR(N) from the literal's length; the convert_tz yaml
+            // binds the 2nd/3rd operands as `string` (unbounded VARCHAR), so a CHAR(6) "+00:00"
+            // would fail isthmus signature lookup (`convert_tz(precision_timestamp, char<6>, string)`).
+            RelDataType varchar = rexBuilder.getTypeFactory().createSqlType(SqlTypeName.VARCHAR);
+            RexNode toTz = rexBuilder.makeLiteral("+00:00", varchar, true);
+            return rexBuilder.makeCall(original.getType(), ConvertTzAdapter.LOCAL_CONVERT_TZ_OP, List.of(asTimestamp, tzArg, toTz));
         }
 
         /** Plan-time fold of DATETIME(value-literal, tz-literal). Returns a typed TIMESTAMP literal or NULL on invalid input. */
@@ -243,13 +257,20 @@ final class DateTimeAdapters {
             if (value == null || tz == null) {
                 return rexBuilder.makeNullLiteral(original.getType());
             }
-            // extract source offset (default UTC)
-            String sourceTz = "+00:00";
+            // MySQL DATETIME semantics: when value has an embedded offset, that's the source zone
+            // and the user's tz arg is the target. When value has NO embedded offset, the user's tz
+            // arg is the SOURCE (value is interpreted AT that tz) and the target is UTC.
+            String sourceTz;
+            String targetTz;
             String stripped = value;
             java.util.regex.Matcher m = OFFSET_SUFFIX_REGEX.matcher(value);
             if (m.find()) {
                 sourceTz = "Z".equals(m.group()) ? "+00:00" : m.group();
+                targetTz = tz;
                 stripped = value.substring(0, m.start());
+            } else {
+                sourceTz = tz;
+                targetTz = "+00:00";
             }
             java.time.LocalDateTime ldt;
             try {
@@ -262,7 +283,7 @@ final class DateTimeAdapters {
             String canonicalTo;
             try {
                 canonicalFrom = ConvertTzAdapter.canonicalizeTz(sourceTz);
-                canonicalTo = ConvertTzAdapter.canonicalizeTz(tz);
+                canonicalTo = ConvertTzAdapter.canonicalizeTz(targetTz);
             } catch (IllegalArgumentException invalidTz) {
                 return rexBuilder.makeNullLiteral(original.getType());
             }

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DateTimeAdapters.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DateTimeAdapters.java
@@ -243,12 +243,13 @@ final class DateTimeAdapters {
                 strippedValue = value;
             }
             RexNode asTimestamp = rexBuilder.makeCall(original.getType(), LOCAL_TO_TIMESTAMP_OP, List.of(strippedValue));
-            // makeLiteral(String) infers CHAR(N) from the literal's length; the convert_tz yaml
-            // binds the 2nd/3rd operands as `string` (unbounded VARCHAR), so a CHAR(6) "+00:00"
-            // would fail isthmus signature lookup (`convert_tz(precision_timestamp, char<6>, string)`).
+            // convert_tz yaml binds tz operands as unbounded `string`; cast both away from CHAR(N).
             RelDataType varchar = rexBuilder.getTypeFactory().createSqlType(SqlTypeName.VARCHAR);
+            RexNode tzArgVarchar = SqlTypeName.CHAR_TYPES.contains(tzArg.getType().getSqlTypeName())
+                ? rexBuilder.makeCast(varchar, tzArg, true)
+                : tzArg;
             RexNode toTz = rexBuilder.makeLiteral("+00:00", varchar, true);
-            return rexBuilder.makeCall(original.getType(), ConvertTzAdapter.LOCAL_CONVERT_TZ_OP, List.of(asTimestamp, tzArg, toTz));
+            return rexBuilder.makeCall(original.getType(), ConvertTzAdapter.LOCAL_CONVERT_TZ_OP, List.of(asTimestamp, tzArgVarchar, toTz));
         }
 
         /** Plan-time fold of DATETIME(value-literal, tz-literal). Returns a typed TIMESTAMP literal or NULL on invalid input. */

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/EarliestLatestAdapter.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/EarliestLatestAdapter.java
@@ -148,11 +148,20 @@ public final class EarliestLatestAdapter {
             tsAligned = rexBuilder.makeCast(plainTs, tsArg);
         }
 
-        return rexBuilder.makeCall(
+        RexNode comparison = rexBuilder.makeCall(
             isEarliest ? SqlStdOperatorTable.GREATER_THAN_OR_EQUAL : SqlStdOperatorTable.LESS_THAN_OR_EQUAL,
             tsAligned,
             rhs
         );
+
+        // Pin the result to the original call's declared type. Comparison return-type inference makes
+        // the result BOOLEAN NOT NULL when both operands are non-null (a folded literal vs now()),
+        // but the EARLIEST/LATEST call was declared nullable BOOLEAN — the enclosing Filter/Project
+        // cached that type, so a bare comparison trips Calcite's BOOLEAN vs BOOLEAN NOT NULL assert.
+        if (comparison.getType().equals(call.getType())) {
+            return comparison;
+        }
+        return rexBuilder.makeCast(call.getType(), comparison, true);
     }
 
     /** Builds the right-hand side of the comparison (a TIMESTAMP-typed expression). */

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/EpochArithmeticAdapters.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/EpochArithmeticAdapters.java
@@ -1,0 +1,166 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion;
+
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.opensearch.analytics.spi.FieldStorageInfo;
+import org.opensearch.analytics.spi.NumericToDoubleAdapter;
+import org.opensearch.analytics.spi.ScalarFunctionAdapter;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+/**
+ * Lowerings for PPL datetime scalars that reduce to epoch arithmetic over the local
+ * {@code to_unixtime} / {@code from_unixtime} UDFs (see {@link UnixTimestampAdapter},
+ * {@link RustUdfDateTimeAdapters}). The raw PPL UDFs have no Substrait binding, so isthmus rejects
+ * them; each adapter rewrites to {@code to_unixtime(...)} plus integer arithmetic that lowers
+ * through the Substrait default catalog.
+ *
+ * <p>Constants:
+ * <ul>
+ *   <li>{@code DAYS_YEAR0_TO_EPOCH = 719528} — days from {@code 0000-01-01} to {@code 1970-01-01}
+ *       (MySQL's day 1 is {@code 0000-01-01}, so {@code TO_DAYS('1970-01-01') = 719528}).</li>
+ *   <li>{@code SECONDS_YEAR0_TO_EPOCH = 62167219200} — seconds for the same span
+ *       ({@code 719528 * 86400}).</li>
+ * </ul>
+ *
+ * @opensearch.internal
+ */
+final class EpochArithmeticAdapters {
+
+    private EpochArithmeticAdapters() {}
+
+    private static final long SECONDS_PER_DAY = 86_400L;
+    private static final long DAYS_YEAR0_TO_EPOCH = 719_528L;
+    private static final long SECONDS_YEAR0_TO_EPOCH = DAYS_YEAR0_TO_EPOCH * SECONDS_PER_DAY;
+
+    private static RexNode bigintLit(RexBuilder rexBuilder, long value) {
+        return rexBuilder.makeExactLiteral(BigDecimal.valueOf(value), rexBuilder.getTypeFactory().createSqlType(SqlTypeName.BIGINT));
+    }
+
+    private static RexNode toUnixtime(RexBuilder rexBuilder, RexNode operand) {
+        return rexBuilder.makeCall(UnixTimestampAdapter.LOCAL_TO_UNIXTIME_OP, operand);
+    }
+
+    private static RexNode pinReturnType(RexBuilder rexBuilder, RexNode expr, RexCall original) {
+        if (expr.getType().equals(original.getType())) {
+            return expr;
+        }
+        return rexBuilder.makeCast(original.getType(), expr, true);
+    }
+
+    /**
+     * PPL {@code TO_DAYS(x)} — days since {@code 0000-01-01} (BIGINT):
+     * {@code to_unixtime(x) / 86400 + 719528}.
+     */
+    static final class ToDaysAdapter implements ScalarFunctionAdapter {
+        @Override
+        public RexNode adapt(RexCall original, List<FieldStorageInfo> fieldStorage, RelOptCluster cluster) {
+            if (original.getOperands().size() != 1) {
+                return original;
+            }
+            // Reject a malformed string literal at plan time with the PPL format-hint message
+            // (HTTP 400) rather than letting to_unixtime fail opaquely at runtime (HTTP 500).
+            DatetimeLiteralValidator.validate(original.getOperands().get(0), DatetimeLiteralValidator.Kind.DATE);
+            RexBuilder rexBuilder = cluster.getRexBuilder();
+            RexNode epochDays = rexBuilder.makeCall(
+                SqlStdOperatorTable.DIVIDE,
+                toUnixtime(rexBuilder, original.getOperands().get(0)),
+                bigintLit(rexBuilder, SECONDS_PER_DAY)
+            );
+            RexNode totalDays = rexBuilder.makeCall(SqlStdOperatorTable.PLUS, epochDays, bigintLit(rexBuilder, DAYS_YEAR0_TO_EPOCH));
+            return pinReturnType(rexBuilder, totalDays, original);
+        }
+    }
+
+    /**
+     * PPL {@code TO_SECONDS(x)} — seconds since {@code 0000-01-01} (BIGINT):
+     * {@code to_unixtime(x) + 62167219200}.
+     */
+    static final class ToSecondsAdapter implements ScalarFunctionAdapter {
+        @Override
+        public RexNode adapt(RexCall original, List<FieldStorageInfo> fieldStorage, RelOptCluster cluster) {
+            if (original.getOperands().size() != 1) {
+                return original;
+            }
+            // Reject a malformed string literal at plan time (HTTP 400 + format hint) instead of an
+            // opaque runtime to_unixtime parse error. Kind.DATE accepts both bare dates and full
+            // datetimes, so valid TO_SECONDS inputs like '2020-09-16 07:40:00' still pass.
+            DatetimeLiteralValidator.validate(original.getOperands().get(0), DatetimeLiteralValidator.Kind.DATE);
+            RexBuilder rexBuilder = cluster.getRexBuilder();
+            RexNode total = rexBuilder.makeCall(
+                SqlStdOperatorTable.PLUS,
+                toUnixtime(rexBuilder, original.getOperands().get(0)),
+                bigintLit(rexBuilder, SECONDS_YEAR0_TO_EPOCH)
+            );
+            return pinReturnType(rexBuilder, total, original);
+        }
+    }
+
+    /**
+     * PPL {@code FROM_DAYS(n)} — inverse of {@link ToDaysAdapter}, returns DATE:
+     * {@code from_unixtime((n - 719528) * 86400)}.
+     */
+    static final class FromDaysAdapter implements ScalarFunctionAdapter {
+        @Override
+        public RexNode adapt(RexCall original, List<FieldStorageInfo> fieldStorage, RelOptCluster cluster) {
+            if (original.getOperands().size() != 1) {
+                return original;
+            }
+            RexBuilder rexBuilder = cluster.getRexBuilder();
+            RexNode days = rexBuilder.makeCast(
+                rexBuilder.getTypeFactory().createSqlType(SqlTypeName.BIGINT),
+                original.getOperands().get(0),
+                true
+            );
+            RexNode epochDays = rexBuilder.makeCall(SqlStdOperatorTable.MINUS, days, bigintLit(rexBuilder, DAYS_YEAR0_TO_EPOCH));
+            RexNode epochSeconds = rexBuilder.makeCall(SqlStdOperatorTable.MULTIPLY, epochDays, bigintLit(rexBuilder, SECONDS_PER_DAY));
+            // from_unixtime's Substrait signature is fp64; widen the i64 seconds to DOUBLE or
+            // isthmus rejects the call with "Unable to convert call from_unixtime(i64)".
+            RexNode epochSecondsDouble = NumericToDoubleAdapter.widenToDoubleIfNumeric(epochSeconds, cluster);
+            RelDataType tsType = rexBuilder.getTypeFactory()
+                .createTypeWithNullability(rexBuilder.getTypeFactory().createSqlType(SqlTypeName.TIMESTAMP), true);
+            RexNode ts = rexBuilder.makeCall(tsType, RustUdfDateTimeAdapters.LOCAL_FROM_UNIXTIME_OP, List.of(epochSecondsDouble));
+            return pinReturnType(rexBuilder, ts, original);
+        }
+    }
+
+    /**
+     * PPL {@code TIME_TO_SEC(x)} — seconds-of-day of a TIME / TIMESTAMP (BIGINT):
+     * {@code to_unixtime(x) MOD 86400}. The modulus discards the date, so anchoring is irrelevant.
+     * {@code to_unixtime} rejects an Arrow {@code Time64} operand, and a direct
+     * {@code CAST(time AS timestamp)} is also unsupported by DataFusion's optimizer
+     * ({@code Unsupported CAST from Time64(ns) to Timestamp}), so a bare {@code TIME} is anchored to
+     * today UTC via the shared {@link DatePartAdapters#coerceCharacterOperandToTimestamp} CONCAT path
+     * (cast to VARCHAR, prefix today's date, parse as TIMESTAMP) — the date is modded away anyway.
+     */
+    static final class TimeToSecAdapter implements ScalarFunctionAdapter {
+        @Override
+        public RexNode adapt(RexCall original, List<FieldStorageInfo> fieldStorage, RelOptCluster cluster) {
+            if (original.getOperands().size() != 1) {
+                return original;
+            }
+            RexBuilder rexBuilder = cluster.getRexBuilder();
+            RexNode operand = DatePartAdapters.coerceCharacterOperandToTimestamp(original.getOperands().get(0), cluster);
+            RexNode secOfDay = rexBuilder.makeCall(
+                SqlStdOperatorTable.MOD,
+                toUnixtime(rexBuilder, operand),
+                bigintLit(rexBuilder, SECONDS_PER_DAY)
+            );
+            return pinReturnType(rexBuilder, secOfDay, original);
+        }
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/GetFormatAdapter.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/GetFormatAdapter.java
@@ -1,0 +1,90 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion;
+
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.opensearch.analytics.spi.FieldStorageInfo;
+import org.opensearch.analytics.spi.ScalarFunctionAdapter;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * PPL {@code GET_FORMAT(<type>, <region>)} — returns the MySQL format string for a given temporal
+ * type ({@code DATE}/{@code TIME}/{@code TIMESTAMP}/{@code DATETIME}) and region
+ * ({@code USA}/{@code JIS}/{@code ISO}/{@code EUR}/{@code INTERNAL}). Both operands are string
+ * literals, so the adapter folds the call to the resolved format-string literal at plan time —
+ * there is nothing to evaluate at runtime. The result feeds {@code date_format(value, <fmt>)}.
+ *
+ * <p>The table mirrors the SQL plugin's {@code DateTimeFunctions} GET_FORMAT map. {@code DATETIME}
+ * is an alias of {@code TIMESTAMP}. An unknown {@code (type, region)} pair leaves the call
+ * unchanged so the downstream planner surfaces a loud error rather than a wrong format.
+ *
+ * @opensearch.internal
+ */
+class GetFormatAdapter implements ScalarFunctionAdapter {
+
+    private static final Map<String, String> FORMATS = Map.ofEntries(
+        Map.entry("date|usa", "%m.%d.%Y"),
+        Map.entry("date|jis", "%Y-%m-%d"),
+        Map.entry("date|iso", "%Y-%m-%d"),
+        Map.entry("date|eur", "%d.%m.%Y"),
+        Map.entry("date|internal", "%Y%m%d"),
+        Map.entry("time|usa", "%h:%i:%s %p"),
+        Map.entry("time|jis", "%H:%i:%s"),
+        Map.entry("time|iso", "%H:%i:%s"),
+        Map.entry("time|eur", "%H.%i.%s"),
+        Map.entry("time|internal", "%H%i%s"),
+        Map.entry("timestamp|usa", "%Y-%m-%d %H.%i.%s"),
+        Map.entry("timestamp|jis", "%Y-%m-%d %H:%i:%s"),
+        Map.entry("timestamp|iso", "%Y-%m-%d %H:%i:%s"),
+        Map.entry("timestamp|eur", "%Y-%m-%d %H.%i.%s"),
+        Map.entry("timestamp|internal", "%Y%m%d%H%i%s")
+    );
+
+    @Override
+    public RexNode adapt(RexCall original, List<FieldStorageInfo> fieldStorage, RelOptCluster cluster) {
+        if (original.getOperands().size() != 2) {
+            return original;
+        }
+        String type = stringLiteral(original.getOperands().get(0));
+        String region = stringLiteral(original.getOperands().get(1));
+        if (type == null || region == null) {
+            return original;
+        }
+        // DATETIME is an alias of TIMESTAMP.
+        String typeKey = type.toLowerCase(Locale.ROOT);
+        if (typeKey.equals("datetime")) {
+            typeKey = "timestamp";
+        }
+        String format = FORMATS.get(typeKey + "|" + region.toLowerCase(Locale.ROOT));
+        if (format == null) {
+            return original;
+        }
+        RexBuilder rexBuilder = cluster.getRexBuilder();
+        return rexBuilder.makeLiteral(format, original.getType(), true);
+    }
+
+    private static String stringLiteral(RexNode operand) {
+        if (!(operand instanceof RexLiteral literal)) {
+            return null;
+        }
+        SqlTypeName typeName = literal.getType().getSqlTypeName();
+        if (typeName != SqlTypeName.CHAR && typeName != SqlTypeName.VARCHAR) {
+            return null;
+        }
+        return literal.getValueAs(String.class);
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/LastDayAdapter.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/LastDayAdapter.java
@@ -1,0 +1,86 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion;
+
+import org.apache.calcite.avatica.util.TimeUnit;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlIntervalQualifier;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.opensearch.analytics.spi.FieldStorageInfo;
+import org.opensearch.analytics.spi.ScalarFunctionAdapter;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+/**
+ * PPL {@code last_day(x)} — the last day of {@code x}'s month, returned as a DATE.
+ *
+ * <p>Lowering: {@code date_trunc('month', x) + INTERVAL 1 MONTH - INTERVAL 1 DAY}, cast to the
+ * call's declared DATE type. {@code date_trunc('month', x)} snaps to the first of the month,
+ * {@code + 1 month} reaches the first of the next month, and {@code - 1 day} lands on the last day
+ * of the original month (correct for all month lengths, including leap-year February). Routes
+ * through the local {@code date_trunc} UDF ({@link DateTimeAdapters#LOCAL_DATE_TRUNC_OP}) and
+ * {@code DATETIME_PLUS}, both of which bind via Substrait (the stock
+ * {@code SqlLibraryOperators.DATE_TRUNC} does not).
+ *
+ * <p>DATE / TIMESTAMP operands cast straight to TIMESTAMP; VARCHAR / TIME operands are anchored via
+ * {@link DatePartAdapters#coerceCharacterOperandToTimestamp}.
+ *
+ * @opensearch.internal
+ */
+class LastDayAdapter implements ScalarFunctionAdapter {
+
+    @Override
+    public RexNode adapt(RexCall original, List<FieldStorageInfo> fieldStorage, RelOptCluster cluster) {
+        if (original.getOperands().size() != 1) {
+            return original;
+        }
+        RexBuilder rexBuilder = cluster.getRexBuilder();
+        RelDataType tsType = rexBuilder.getTypeFactory()
+            .createTypeWithNullability(rexBuilder.getTypeFactory().createSqlType(SqlTypeName.TIMESTAMP), true);
+
+        RexNode operand = original.getOperands().get(0);
+        RexNode asTimestamp;
+        SqlTypeName operandType = operand.getType().getSqlTypeName();
+        if (operandType == SqlTypeName.TIMESTAMP
+            || operandType == SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE
+            || operandType == SqlTypeName.DATE) {
+            asTimestamp = rexBuilder.makeCast(tsType, operand);
+        } else {
+            // VARCHAR date string / TIME — anchor to a TIMESTAMP the engine can read.
+            asTimestamp = DatePartAdapters.coerceCharacterOperandToTimestamp(operand, cluster);
+        }
+
+        RelDataType varchar = rexBuilder.getTypeFactory().createSqlType(SqlTypeName.VARCHAR);
+        RexNode monthLiteral = rexBuilder.makeLiteral("month", varchar, true);
+        RexNode firstOfMonth = rexBuilder.makeCall(DateTimeAdapters.LOCAL_DATE_TRUNC_OP, monthLiteral, asTimestamp);
+
+        RexNode plusMonth = rexBuilder.makeCall(
+            SqlStdOperatorTable.DATETIME_PLUS,
+            firstOfMonth,
+            rexBuilder.makeIntervalLiteral(BigDecimal.ONE, new SqlIntervalQualifier(TimeUnit.MONTH, null, SqlParserPos.ZERO))
+        );
+        RexNode lastDay = rexBuilder.makeCall(
+            SqlStdOperatorTable.DATETIME_PLUS,
+            plusMonth,
+            rexBuilder.makeIntervalLiteral(BigDecimal.valueOf(-1), new SqlIntervalQualifier(TimeUnit.DAY, null, SqlParserPos.ZERO))
+        );
+
+        if (lastDay.getType().equals(original.getType())) {
+            return lastDay;
+        }
+        return rexBuilder.makeCast(original.getType(), lastDay, true);
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/PeriodArithmeticAdapters.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/PeriodArithmeticAdapters.java
@@ -1,0 +1,115 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion;
+
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.opensearch.analytics.spi.FieldStorageInfo;
+import org.opensearch.analytics.spi.ScalarFunctionAdapter;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+/**
+ * Lowerings for PPL {@code PERIOD_ADD} / {@code PERIOD_DIFF}, which operate on MySQL "period"
+ * integers in {@code YYYYMM} form. Both reduce to pure integer arithmetic — no temporal primitives
+ * — by converting a period to an absolute month index {@code monthIndex(P) = (P / 100) * 12 + (P % 100)}.
+ *
+ * <p>The PPL frontend's 2-digit-year shorthand ({@code YYMM → 20YY}) is not reproduced here: PPL
+ * emits these calls with full {@code YYYYMM} integers, and the absolute-month arithmetic below is
+ * exact for that form.
+ *
+ * @opensearch.internal
+ */
+final class PeriodArithmeticAdapters {
+
+    private PeriodArithmeticAdapters() {}
+
+    private static RexNode intLit(RexBuilder rexBuilder, RelDataType intType, long value) {
+        return rexBuilder.makeExactLiteral(BigDecimal.valueOf(value), intType);
+    }
+
+    /** {@code (P / 100) * 12 + (P % 100)} — the absolute month index of a YYYYMM period. */
+    private static RexNode monthIndex(RexBuilder rexBuilder, RelDataType intType, RexNode period) {
+        RexNode years = rexBuilder.makeCall(SqlStdOperatorTable.DIVIDE, period, intLit(rexBuilder, intType, 100));
+        RexNode yearMonths = rexBuilder.makeCall(SqlStdOperatorTable.MULTIPLY, years, intLit(rexBuilder, intType, 12));
+        RexNode month = rexBuilder.makeCall(SqlStdOperatorTable.MOD, period, intLit(rexBuilder, intType, 100));
+        return rexBuilder.makeCall(SqlStdOperatorTable.PLUS, yearMonths, month);
+    }
+
+    private static RexNode pinReturnType(RexBuilder rexBuilder, RexNode expr, RexCall original) {
+        if (expr.getType().equals(original.getType())) {
+            return expr;
+        }
+        return rexBuilder.makeCast(original.getType(), expr, true);
+    }
+
+    /**
+     * PPL {@code PERIOD_ADD(P, n)} — add {@code n} months to period {@code P}, returning YYYYMM.
+     * With {@code m = monthIndex(P) - 1 + n} (shift to 0-based month), the result is
+     * {@code (m / 12) * 100 + (m % 12) + 1}.
+     */
+    static final class PeriodAddAdapter implements ScalarFunctionAdapter {
+        @Override
+        public RexNode adapt(RexCall original, List<FieldStorageInfo> fieldStorage, RelOptCluster cluster) {
+            if (original.getOperands().size() != 2) {
+                return original;
+            }
+            RexBuilder rexBuilder = cluster.getRexBuilder();
+            RelDataType intType = rexBuilder.getTypeFactory().createSqlType(SqlTypeName.BIGINT);
+            RexNode period = rexBuilder.makeCast(intType, original.getOperands().get(0), true);
+            RexNode months = rexBuilder.makeCast(intType, original.getOperands().get(1), true);
+            // m = monthIndex(P) - 1 + n (0-based absolute month)
+            RexNode base = rexBuilder.makeCall(
+                SqlStdOperatorTable.MINUS,
+                monthIndex(rexBuilder, intType, period),
+                intLit(rexBuilder, intType, 1)
+            );
+            RexNode m = rexBuilder.makeCall(SqlStdOperatorTable.PLUS, base, months);
+            // (m / 12) * 100 + (m % 12) + 1
+            RexNode years = rexBuilder.makeCall(SqlStdOperatorTable.DIVIDE, m, intLit(rexBuilder, intType, 12));
+            RexNode yearPart = rexBuilder.makeCall(SqlStdOperatorTable.MULTIPLY, years, intLit(rexBuilder, intType, 100));
+            RexNode monthPart = rexBuilder.makeCall(SqlStdOperatorTable.MOD, m, intLit(rexBuilder, intType, 12));
+            RexNode yyyymm = rexBuilder.makeCall(
+                SqlStdOperatorTable.PLUS,
+                rexBuilder.makeCall(SqlStdOperatorTable.PLUS, yearPart, monthPart),
+                intLit(rexBuilder, intType, 1)
+            );
+            return pinReturnType(rexBuilder, yyyymm, original);
+        }
+    }
+
+    /**
+     * PPL {@code PERIOD_DIFF(P1, P2)} — months between two YYYYMM periods ({@code P1 - P2}):
+     * {@code monthIndex(P1) - monthIndex(P2)}.
+     */
+    static final class PeriodDiffAdapter implements ScalarFunctionAdapter {
+        @Override
+        public RexNode adapt(RexCall original, List<FieldStorageInfo> fieldStorage, RelOptCluster cluster) {
+            if (original.getOperands().size() != 2) {
+                return original;
+            }
+            RexBuilder rexBuilder = cluster.getRexBuilder();
+            RelDataType intType = rexBuilder.getTypeFactory().createSqlType(SqlTypeName.BIGINT);
+            RexNode p1 = rexBuilder.makeCast(intType, original.getOperands().get(0), true);
+            RexNode p2 = rexBuilder.makeCast(intType, original.getOperands().get(1), true);
+            RexNode diff = rexBuilder.makeCall(
+                SqlStdOperatorTable.MINUS,
+                monthIndex(rexBuilder, intType, p1),
+                monthIndex(rexBuilder, intType, p2)
+            );
+            return pinReturnType(rexBuilder, diff, original);
+        }
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/RustUdfDateTimeAdapters.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/RustUdfDateTimeAdapters.java
@@ -66,6 +66,9 @@ final class RustUdfDateTimeAdapters {
     /** WEEK(date [, mode]) target — MySQL semantics, accepts 1- and 2-arg forms. */
     static final SqlOperator LOCAL_OS_WEEK_OP = udf("os_week", ReturnTypes.INTEGER_NULLABLE, OperandTypes.VARIADIC);
 
+    /** YEARWEEK(date [, mode]) target — routes to the Rust {@code os_yearweek} UDF. */
+    static final SqlOperator LOCAL_OS_YEARWEEK_OP = udf("os_yearweek", ReturnTypes.INTEGER_NULLABLE, OperandTypes.VARIADIC);
+
     /**
      * Adapter for PPL {@code extract(<unit> FROM <expr>)}.
      * <p>For TIME(p) operands, CASTs to VARCHAR so the call binds to the {@code (string, string)}
@@ -177,6 +180,20 @@ final class RustUdfDateTimeAdapters {
         @Override
         public RexNode adapt(RexCall original, List<FieldStorageInfo> fieldStorage, RelOptCluster cluster) {
             validateFirstArgIfStringLiteral(original, DatetimeLiteralValidator.Kind.TIMESTAMP);
+            // Calcite-stock TIME serialises to substrait precision_time<P>, which has no yaml
+            // signature (substrait-java 0.89.1 lacks ToTypeString for PrecisionTime, so the yaml
+            // can't even declare one). Anchor a TIME first operand to a TIMESTAMP via the shared
+            // coercion path so isthmus binds the precision_timestamp<P> arm — same workaround
+            // DatePartAdapters uses for hour/minute/second.
+            if (!original.getOperands().isEmpty() && original.getOperands().get(0).getType().getSqlTypeName() == SqlTypeName.TIME) {
+                RexBuilder rexBuilder = cluster.getRexBuilder();
+                List<RexNode> coerced = new java.util.ArrayList<>(original.getOperands().size());
+                coerced.add(DatePartAdapters.coerceCharacterOperandToTimestamp(original.getOperands().get(0), cluster));
+                for (int i = 1; i < original.getOperands().size(); i++) {
+                    coerced.add(original.getOperands().get(i));
+                }
+                return rexBuilder.makeCall(original.getType(), LOCAL_TIME_FORMAT_OP, coerced);
+            }
             return super.adapt(original, fieldStorage, cluster);
         }
     }
@@ -284,6 +301,33 @@ final class RustUdfDateTimeAdapters {
                 coerced.add(originalOperands.get(i));
             }
             return rexBuilder.makeCall(original.getType(), LOCAL_OS_WEEK_OP, coerced);
+        }
+    }
+
+    /**
+     * PPL {@code YEARWEEK(date[, mode])} — routes to the {@code os_yearweek} Rust UDF (year*100+week
+     * with MySQL year-boundary semantics). The first operand is coerced to TIMESTAMP via the shared
+     * {@link DatePartAdapters#coerceCharacterOperandToTimestamp} helper (handling character/TIME forms
+     * the same way {@code WEEKDAY}/{@code os_week} do) so it binds the yaml {@code precision_timestamp<P>}
+     * signature; an optional {@code mode} operand passes through unchanged.
+     */
+    static final class OsYearweekAdapter extends AbstractNameMappingAdapter {
+        OsYearweekAdapter() {
+            super(LOCAL_OS_YEARWEEK_OP, List.of(), List.of());
+        }
+
+        @Override
+        public RexNode adapt(RexCall original, List<FieldStorageInfo> fieldStorage, RelOptCluster cluster) {
+            if (original.getOperands().isEmpty()) {
+                return super.adapt(original, fieldStorage, cluster);
+            }
+            RexBuilder rexBuilder = cluster.getRexBuilder();
+            List<RexNode> coerced = new java.util.ArrayList<>(original.getOperands().size());
+            coerced.add(DatePartAdapters.coerceCharacterOperandToTimestamp(original.getOperands().get(0), cluster));
+            for (int i = 1; i < original.getOperands().size(); i++) {
+                coerced.add(original.getOperands().get(i));
+            }
+            return rexBuilder.makeCall(original.getType(), LOCAL_OS_YEARWEEK_OP, coerced);
         }
     }
 

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/RustUdfDateTimeAdapters.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/RustUdfDateTimeAdapters.java
@@ -163,12 +163,24 @@ final class RustUdfDateTimeAdapters {
         DaynameAdapter() {
             super(LOCAL_DATE_FORMAT_OP, List.of(), List.of("%W"));
         }
+
+        @Override
+        public RexNode adapt(RexCall original, List<FieldStorageInfo> fieldStorage, RelOptCluster cluster) {
+            validateFirstArgIfStringLiteral(original, DatetimeLiteralValidator.Kind.TIMESTAMP);
+            return super.adapt(original, fieldStorage, cluster);
+        }
     }
 
     // MONTHNAME(x) → date_format(x, '%M'). %M renders full month name (e.g. "September").
     static final class MonthnameAdapter extends AbstractNameMappingAdapter {
         MonthnameAdapter() {
             super(LOCAL_DATE_FORMAT_OP, List.of(), List.of("%M"));
+        }
+
+        @Override
+        public RexNode adapt(RexCall original, List<FieldStorageInfo> fieldStorage, RelOptCluster cluster) {
+            validateFirstArgIfStringLiteral(original, DatetimeLiteralValidator.Kind.TIMESTAMP);
+            return super.adapt(original, fieldStorage, cluster);
         }
     }
 

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/SecToTimeAdapter.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/SecToTimeAdapter.java
@@ -1,0 +1,46 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion;
+
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.opensearch.analytics.spi.FieldStorageInfo;
+import org.opensearch.analytics.spi.ScalarFunctionAdapter;
+
+import java.util.List;
+
+/**
+ * PPL {@code sec_to_time(n)} — the time-of-day {@code n} seconds past midnight (returns TIME).
+ *
+ * <p>Lowering: cast {@code n} to BIGINT and hand it to {@link TimeOfDayLowering#secondsToTime}, which
+ * normalizes into {@code [0, 86400)} and builds a {@code Time64} via the {@code maketime(h, m, s)}
+ * Rust UDF. MySQL wraps second counts past a day (e.g. {@code sec_to_time(123456) = 10:17:36}); the
+ * helper's floor-mod normalization provides that wrap. A direct {@code from_unixtime(n)} +
+ * {@code CAST AS TIME} can't be used — DataFusion's optimizer rejects {@code CAST from Timestamp to
+ * Time} — so {@code maketime} produces the {@code Time64} directly.
+ *
+ * @opensearch.internal
+ */
+class SecToTimeAdapter implements ScalarFunctionAdapter {
+
+    @Override
+    public RexNode adapt(RexCall original, List<FieldStorageInfo> fieldStorage, RelOptCluster cluster) {
+        if (original.getOperands().size() != 1) {
+            return original;
+        }
+        RexBuilder rexBuilder = cluster.getRexBuilder();
+        RelDataType bigint = rexBuilder.getTypeFactory().createSqlType(SqlTypeName.BIGINT);
+        RexNode seconds = rexBuilder.makeCast(bigint, original.getOperands().get(0), true);
+        return TimeOfDayLowering.secondsToTime(seconds, original.getType(), cluster);
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/SubstraitPlanPojoRewriter.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/SubstraitPlanPojoRewriter.java
@@ -11,7 +11,6 @@ package org.opensearch.be.datafusion;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.TimeUnit;
 
 import io.substrait.expression.Expression;
 import io.substrait.expression.ImmutableExpression;
@@ -23,24 +22,12 @@ import io.substrait.relation.RelCopyOnWriteVisitor;
 import io.substrait.util.EmptyVisitationContext;
 
 /**
- * POJO-layer Substrait plan rewriter. Runs before the plan is serialized to protobuf
- * and patches expressions that isthmus emits incorrectly or that DataFusion's
- * substrait consumer cannot handle. Today it covers two cases:
- * <ul>
- *   <li>{@code PrecisionTimestampLiteral} at precision 9 (ns) is rescaled to precision 3
- *       (ms) — DataFusion's substrait consumer does not coerce ns→ms when comparing
- *       against parquet's ms-stored {@code date} fields. Precision 6 (µs) is left intact
- *       so {@code cast('… .123456' AS TIMESTAMP)} preserves microsecond fractions.</li>
- *   <li>{@code VarCharLiteral} → {@code StrLiteral} — DataFusion 53.1.0's consumer
- *       has no VarCharLiteral arm; the two literal types are byte-identical.</li>
- * </ul>
+ * POJO-layer Substrait plan rewriter. Rewrites {@code VarCharLiteral} → {@code StrLiteral}
+ * — DataFusion 53.1.0's consumer has no VarCharLiteral arm; the two literal types are
+ * byte-identical. Sibling {@link SubstraitPlanProtoRewriter} runs after this on the proto
+ * layer for fixes the POJO API can't express.
  *
- * <p>Sibling {@link SubstraitPlanProtoRewriter} runs after this class on the proto layer
- * for fixes that require setting fields the POJO API doesn't expose.
- *
- * <p>TODO: remove this class once both upstream gaps are closed — substrait-java
- * isthmus inspects the source precision when lowering timestamp literals, and
- * datafusion-substrait adds a VarCharLiteral arm to its consumer.
+ * <p>TODO: remove this class once datafusion-substrait adds a VarCharLiteral arm to its consumer.
  *
  * @opensearch.internal
  */
@@ -124,33 +111,12 @@ class SubstraitPlanPojoRewriter {
             super(relVisitor);
         }
 
-        // Only coerce precision 9 (ns) → 3 (ms): DataFusion's substrait consumer can't
-        // compare a ns literal against parquet's ms-stored Timestamp field. Precision 6
-        // (µs) literals pass through so cast('…123456' AS TIMESTAMP) keeps the µs fraction.
-        @Override
-        public Optional<Expression> visit(Expression.PrecisionTimestampLiteral pts, EmptyVisitationContext ctx) {
-            if (pts.precision() == 9) {
-                return Optional.of(
-                    ImmutableExpression.PrecisionTimestampLiteral.builder()
-                        .value(TimeUnit.NANOSECONDS.toMillis(pts.value()))
-                        .precision(3)
-                        .nullable(pts.nullable())
-                        .build()
-                );
-            }
-            return Optional.empty();
-        }
-
-        // Convert VarCharLiteral to StrLiteral — DataFusion 53.1.0's Substrait consumer
-        // does not support VarChar literals (errors with "Unsupported literal_type: Some(VarChar(...))").
-        // VARCHAR and STRING are semantically identical for literals (both represent UTF-8 strings);
-        // only the type system distinguishes them via length constraints. Rewriting VarCharLiteral →
-        // StrLiteral preserves value and nullability while making the plan consumable by DataFusion.
-        // Affects: AddTotals label parameters, Chart/Trendline string options, CASE string constants.
+        // VarChar → Str: DataFusion 53.1.0 errors on VarChar with "Unsupported literal_type"; the
+        // two are byte-identical for literals. Affects AddTotals labels, Chart/Trendline options,
+        // CASE string constants.
         @Override
         public Optional<Expression> visit(Expression.VarCharLiteral vcl, EmptyVisitationContext ctx) {
             return Optional.of(ImmutableExpression.StrLiteral.builder().value(vcl.value()).nullable(vcl.nullable()).build());
         }
     }
-
 }

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/SubstraitPlanPojoRewriter.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/SubstraitPlanPojoRewriter.java
@@ -27,8 +27,10 @@ import io.substrait.util.EmptyVisitationContext;
  * and patches expressions that isthmus emits incorrectly or that DataFusion's
  * substrait consumer cannot handle. Today it covers two cases:
  * <ul>
- *   <li>{@code PrecisionTimestampLiteral} arrives at precision 6 (µs) regardless of
- *       the source type; rescaled to precision 3 (ms) to match parquet storage.</li>
+ *   <li>{@code PrecisionTimestampLiteral} at precision 9 (ns) is rescaled to precision 3
+ *       (ms) — DataFusion's substrait consumer does not coerce ns→ms when comparing
+ *       against parquet's ms-stored {@code date} fields. Precision 6 (µs) is left intact
+ *       so {@code cast('… .123456' AS TIMESTAMP)} preserves microsecond fractions.</li>
  *   <li>{@code VarCharLiteral} → {@code StrLiteral} — DataFusion 53.1.0's consumer
  *       has no VarCharLiteral arm; the two literal types are byte-identical.</li>
  * </ul>
@@ -122,14 +124,15 @@ class SubstraitPlanPojoRewriter {
             super(relVisitor);
         }
 
-        // Isthmus hardcodes timestamp literals to precision 6 (microseconds).
-        // Parquet stores Timestamp(MILLISECOND), so convert to precision 3.
+        // Only coerce precision 9 (ns) → 3 (ms): DataFusion's substrait consumer can't
+        // compare a ns literal against parquet's ms-stored Timestamp field. Precision 6
+        // (µs) literals pass through so cast('…123456' AS TIMESTAMP) keeps the µs fraction.
         @Override
         public Optional<Expression> visit(Expression.PrecisionTimestampLiteral pts, EmptyVisitationContext ctx) {
-            if (pts.precision() != 3) {
+            if (pts.precision() == 9) {
                 return Optional.of(
                     ImmutableExpression.PrecisionTimestampLiteral.builder()
-                        .value(toMillis(pts.value(), pts.precision()))
+                        .value(TimeUnit.NANOSECONDS.toMillis(pts.value()))
                         .precision(3)
                         .nullable(pts.nullable())
                         .build()
@@ -150,14 +153,4 @@ class SubstraitPlanPojoRewriter {
         }
     }
 
-    private static long toMillis(long value, int precision) {
-        return switch (precision) {
-            case 0 -> value * 1000L;
-            case 6 -> TimeUnit.MICROSECONDS.toMillis(value);
-            case 9 -> TimeUnit.NANOSECONDS.toMillis(value);
-            default -> throw new IllegalArgumentException(
-                "Unsupported timestamp precision: " + precision + ". Expected 0 (seconds), 6 (micros), or 9 (nanos)."
-            );
-        };
-    }
 }

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/TimeDiffAdapter.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/TimeDiffAdapter.java
@@ -1,0 +1,48 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion;
+
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.opensearch.analytics.spi.FieldStorageInfo;
+import org.opensearch.analytics.spi.ScalarFunctionAdapter;
+
+import java.util.List;
+
+/**
+ * PPL {@code TIMEDIFF(a, b)} (engine label {@code TIME_DIFF}) — the difference between two
+ * time-of-day values as a {@code TIME}: {@code maketime} of
+ * {@code secondsOfDay(a) - secondsOfDay(b)}, normalized into a day (e.g.
+ * {@code TIMEDIFF('23:59:59', '13:00:00') = '10:59:59'}).
+ *
+ * <p>Both operands are anchored to a TIMESTAMP before {@code to_unixtime} (which rejects an Arrow
+ * {@code Time64}); the result is rebuilt with {@code maketime} rather than a {@code CAST AS TIME}
+ * that DataFusion's optimizer rejects. See {@link TimeOfDayLowering}.
+ *
+ * @opensearch.internal
+ */
+class TimeDiffAdapter implements ScalarFunctionAdapter {
+
+    @Override
+    public RexNode adapt(RexCall original, List<FieldStorageInfo> fieldStorage, RelOptCluster cluster) {
+        if (original.getOperands().size() != 2) {
+            return original;
+        }
+        RexBuilder rexBuilder = cluster.getRexBuilder();
+        RexNode diff = rexBuilder.makeCall(
+            SqlStdOperatorTable.MINUS,
+            TimeOfDayLowering.secondsOfDay(original.getOperands().get(0), cluster),
+            TimeOfDayLowering.secondsOfDay(original.getOperands().get(1), cluster)
+        );
+        return TimeOfDayLowering.secondsToTime(diff, original.getType(), cluster);
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/TimeOfDayLowering.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/TimeOfDayLowering.java
@@ -1,0 +1,88 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion;
+
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.opensearch.analytics.spi.NumericToDoubleAdapter;
+
+import java.math.BigDecimal;
+
+/**
+ * Shared lowering helpers for PPL time-of-day arithmetic, used by {@link SecToTimeAdapter},
+ * {@link AddSubTimeAdapter}, and {@link TimeDiffAdapter}.
+ *
+ * <p>The key building block is {@link #secondsToTime}: it turns a BIGINT seconds expression into a
+ * {@code TIME} value via the {@code maketime(h, m, s)} Rust UDF, because a direct
+ * {@code CAST(timestamp AS TIME)} is rejected by DataFusion's optimizer
+ * ({@code Unsupported CAST from Timestamp to Time}). The seconds are first normalized into a single
+ * day {@code [0, 86400)} with {@code ((s MOD 86400) + 86400) MOD 86400} so negative differences and
+ * past-midnight sums wrap the MySQL way.
+ *
+ * @opensearch.internal
+ */
+final class TimeOfDayLowering {
+
+    private TimeOfDayLowering() {}
+
+    static final long SECONDS_PER_DAY = 86_400L;
+
+    static RexNode bigintLit(RexBuilder rexBuilder, long value) {
+        return rexBuilder.makeExactLiteral(BigDecimal.valueOf(value), rexBuilder.getTypeFactory().createSqlType(SqlTypeName.BIGINT));
+    }
+
+    /**
+     * The seconds-of-day {@code [0, 86400)} of a temporal value:
+     * {@code ((to_unixtime(anchor(x)) MOD 86400) + 86400) MOD 86400}. The floor-mod is required
+     * because pre-1970 values have a negative epoch and SQL {@code MOD} truncates toward zero (so a
+     * bare {@code MOD 86400} would yield a negative seconds-of-day).
+     */
+    static RexNode secondsOfDay(RexNode operand, RelOptCluster cluster) {
+        RexBuilder rexBuilder = cluster.getRexBuilder();
+        RexNode anchored = DatePartAdapters.coerceCharacterOperandToTimestamp(operand, cluster);
+        RexNode epoch = rexBuilder.makeCall(UnixTimestampAdapter.LOCAL_TO_UNIXTIME_OP, anchored);
+        RexNode mod1 = rexBuilder.makeCall(SqlStdOperatorTable.MOD, epoch, bigintLit(rexBuilder, SECONDS_PER_DAY));
+        RexNode plusDay = rexBuilder.makeCall(SqlStdOperatorTable.PLUS, mod1, bigintLit(rexBuilder, SECONDS_PER_DAY));
+        return rexBuilder.makeCall(SqlStdOperatorTable.MOD, plusDay, bigintLit(rexBuilder, SECONDS_PER_DAY));
+    }
+
+    /**
+     * Build a {@code TIME}-typed value from a BIGINT seconds expression: normalize into
+     * {@code [0, 86400)}, decompose into hour/minute/second, and call {@code maketime(h, m, s)}.
+     */
+    static RexNode secondsToTime(RexNode secondsExpr, RelDataType timeType, RelOptCluster cluster) {
+        RexBuilder rexBuilder = cluster.getRexBuilder();
+        // norm = ((s MOD 86400) + 86400) MOD 86400 — wraps negatives and >1-day sums into a day.
+        RexNode mod1 = rexBuilder.makeCall(SqlStdOperatorTable.MOD, secondsExpr, bigintLit(rexBuilder, SECONDS_PER_DAY));
+        RexNode plusDay = rexBuilder.makeCall(SqlStdOperatorTable.PLUS, mod1, bigintLit(rexBuilder, SECONDS_PER_DAY));
+        RexNode norm = rexBuilder.makeCall(SqlStdOperatorTable.MOD, plusDay, bigintLit(rexBuilder, SECONDS_PER_DAY));
+
+        RexNode hour = rexBuilder.makeCall(SqlStdOperatorTable.DIVIDE, norm, bigintLit(rexBuilder, 3600));
+        RexNode minute = rexBuilder.makeCall(
+            SqlStdOperatorTable.DIVIDE,
+            rexBuilder.makeCall(SqlStdOperatorTable.MOD, norm, bigintLit(rexBuilder, 3600)),
+            bigintLit(rexBuilder, 60)
+        );
+        RexNode second = rexBuilder.makeCall(SqlStdOperatorTable.MOD, norm, bigintLit(rexBuilder, 60));
+
+        return rexBuilder.makeCall(
+            timeType,
+            RustUdfDateTimeAdapters.LOCAL_MAKETIME_OP,
+            java.util.List.of(
+                NumericToDoubleAdapter.widenToDoubleIfNumeric(hour, cluster),
+                NumericToDoubleAdapter.widenToDoubleIfNumeric(minute, cluster),
+                NumericToDoubleAdapter.widenToDoubleIfNumeric(second, cluster)
+            )
+        );
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/TimestampFunctionAdapter.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/TimestampFunctionAdapter.java
@@ -185,13 +185,9 @@ class TimestampFunctionAdapter implements ScalarFunctionAdapter {
             if (value == null) {
                 return null;
             }
-            // Folding at the resolved precision is correct here. Sub-millisecond fidelity is
-            // a separate, lower-level concern: SubstraitPlanRewriter#visit(PrecisionTimestampLiteral)
-            // renormalizes everything to precision 3 because the parquet write path stores
-            // {@code Timestamp(MILLISECOND)}, so bumping the fold precision would not survive
-            // the wire. testMicrosecond's {@code .123456 → 123000} is owned by that path, not
-            // by this adapter — see SubstraitPlanRewriter.toMillis.
-            return rexBuilder.makeTimestampLiteral(parseTimestamp(value), precision);
+            // Sub-ms inputs need precision ≥6 — makeTimestampLiteral truncates the value to the precision.
+            LocalDateTime ldt = parseLocalDateTime(value);
+            return rexBuilder.makeTimestampLiteral(toTimestampString(ldt), foldPrecision(ldt, precision));
         }
 
         // Shapes B and C: TIMESTAMP(DATE/TIME(<varchar literal>)). After bottom-up
@@ -215,7 +211,8 @@ class TimestampFunctionAdapter implements ScalarFunctionAdapter {
                 } catch (DateTimeParseException e) {
                     return null;
                 }
-                return rexBuilder.makeTimestampLiteral(toTimestampString(date.atStartOfDay()), precision);
+                LocalDateTime midnight = date.atStartOfDay();
+                return rexBuilder.makeTimestampLiteral(toTimestampString(midnight), foldPrecision(midnight, precision));
             }
 
             // Shape C: TIMESTAMP(TIME('lit')) — combine time with today's UTC date.
@@ -227,7 +224,8 @@ class TimestampFunctionAdapter implements ScalarFunctionAdapter {
                     return null;
                 }
                 LocalDate today = LocalDate.now(ZoneOffset.UTC);
-                return rexBuilder.makeTimestampLiteral(toTimestampString(LocalDateTime.of(today, time)), precision);
+                LocalDateTime ldt = LocalDateTime.of(today, time);
+                return rexBuilder.makeTimestampLiteral(toTimestampString(ldt), foldPrecision(ldt, precision));
             }
         }
 
@@ -255,23 +253,26 @@ class TimestampFunctionAdapter implements ScalarFunctionAdapter {
         if (tsValue == null || timeValue == null) {
             return null;
         }
-        TimestampString tsStr = parseTimestamp(tsValue);
+        LocalDateTime base = parseLocalDateTime(tsValue);
         LocalTime addTime;
         try {
             addTime = parseTimeOfDay(timeValue);
         } catch (DateTimeParseException e) {
             return null;
         }
-        // Compose: take tsStr, advance by addTime's nano-of-day. Use LocalDateTime
-        // for arithmetic, then re-render to TimestampString.
-        LocalDateTime base;
-        try {
-            base = LocalDateTime.parse(tsStr.toString().replace(' ', 'T'));
-        } catch (DateTimeParseException e) {
-            return null;
-        }
         LocalDateTime sum = base.plusNanos(addTime.toNanoOfDay());
-        return rexBuilder.makeTimestampLiteral(toTimestampString(sum), precision);
+        return rexBuilder.makeTimestampLiteral(toTimestampString(sum), foldPrecision(sum, precision));
+    }
+
+    /**
+     * Bump fold precision to 6 when the input carries non-zero sub-millisecond digits.
+     * {@code makeTimestampLiteral(value, precision)} truncates the value to {@code precision}
+     * fractional digits, so folding {@code .123456} at the resolved precision (3) silently drops
+     * the µs digits the user typed. {@code TimestampString} exposes no nano accessor, so the
+     * precision decision is keyed off the source {@link LocalDateTime}'s nano-of-second instead.
+     */
+    private static int foldPrecision(LocalDateTime ldt, int resolved) {
+        return ldt.getNano() % 1_000_000 == 0 ? resolved : Math.max(resolved, 6);
     }
 
     private static LocalTime parseTimeOfDay(String input) {

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/WeekdayAdapter.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/WeekdayAdapter.java
@@ -1,0 +1,53 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion;
+
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.fun.SqlLibraryOperators;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.opensearch.analytics.spi.FieldStorageInfo;
+import org.opensearch.analytics.spi.ScalarFunctionAdapter;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+/**
+ * PPL {@code weekday(x)} → {@code CAST((date_part('dow', x) + 6) MOD 7 AS <retType>)}.
+ *
+ * <p>PPL/MySQL {@code WEEKDAY} indexes Monday=0 .. Sunday=6, but DataFusion/Postgres
+ * {@code date_part('dow')} returns Sunday=0 .. Saturday=6. The {@code (dow + 6) MOD 7} remap shifts
+ * Sunday(0)→6 and Monday(1)→0, matching MySQL.
+ *
+ * <p>VARCHAR / TIME operand handling is shared via
+ * {@link DatePartAdapters#coerceCharacterOperandToTimestamp} (see {@link DayOfWeekAdapter}).
+ *
+ * @opensearch.internal
+ */
+class WeekdayAdapter implements ScalarFunctionAdapter {
+
+    @Override
+    public RexNode adapt(RexCall original, List<FieldStorageInfo> fieldStorage, RelOptCluster cluster) {
+        if (original.getOperands().size() != 1) {
+            return original;
+        }
+        RexBuilder rexBuilder = cluster.getRexBuilder();
+        RelDataType varchar = cluster.getTypeFactory().createSqlType(SqlTypeName.VARCHAR);
+        RexNode partLiteral = rexBuilder.makeLiteral("dow", varchar, true);
+        RexNode operand = DatePartAdapters.coerceCharacterOperandToTimestamp(original.getOperands().get(0), cluster);
+        RexNode dow = rexBuilder.makeCall(SqlLibraryOperators.DATE_PART, partLiteral, operand);
+        RexNode shifted = rexBuilder.makeCall(SqlStdOperatorTable.PLUS, dow, rexBuilder.makeExactLiteral(BigDecimal.valueOf(6)));
+        RexNode weekday = rexBuilder.makeCall(SqlStdOperatorTable.MOD, shifted, rexBuilder.makeExactLiteral(BigDecimal.valueOf(7)));
+        return rexBuilder.makeCast(original.getType(), weekday);
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/resources/opensearch_scalar_functions.yaml
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/resources/opensearch_scalar_functions.yaml
@@ -1001,6 +1001,35 @@ scalar_functions:
           - { value: "i32", name: "mode" }
         return: i32
 
+  - name: "os_yearweek"
+    description: >-
+      Compute MySQL's YEARWEEK(date [, mode]) — returns year * 100 + week with
+      MySQL's mode and year-boundary semantics (an early-January date can roll
+      into the prior year's last week). Routes to the Rust `os_yearweek` UDF
+      (rust/src/udf/os_week.rs).
+    impls:
+      - args:
+          - { value: "date", name: "value" }
+        return: i32
+      - args:
+          - { value: "precision_timestamp<P>", name: "value" }
+        return: i32
+      - args:
+          - { value: "string", name: "value" }
+        return: i32
+      - args:
+          - { value: "date", name: "value" }
+          - { value: "i32", name: "mode" }
+        return: i32
+      - args:
+          - { value: "precision_timestamp<P>", name: "value" }
+          - { value: "i32", name: "mode" }
+        return: i32
+      - args:
+          - { value: "string", name: "value" }
+          - { value: "i32", name: "mode" }
+        return: i32
+
   - name: "md5"
     description: "Return the 128-bit MD5 digest of the input string as a lowercase hex string."
     impls:

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/ComparisonTemporalCoercionAdapterTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/ComparisonTemporalCoercionAdapterTests.java
@@ -1,0 +1,183 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion;
+
+import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.volcano.VolcanoPlanner;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.List;
+
+/** Unit tests for {@link ComparisonTemporalCoercionAdapter}. */
+public class ComparisonTemporalCoercionAdapterTests extends OpenSearchTestCase {
+
+    private final RelDataTypeFactory typeFactory = new JavaTypeFactoryImpl();
+    private final RexBuilder rexBuilder = new RexBuilder(typeFactory);
+    private final RelOptCluster cluster = RelOptCluster.create(new VolcanoPlanner(), rexBuilder);
+    private final ComparisonTemporalCoercionAdapter adapter = new ComparisonTemporalCoercionAdapter();
+
+    private RexNode field(SqlTypeName name) {
+        return rexBuilder.makeInputRef(typeFactory.createSqlType(name), 0);
+    }
+
+    private RexCall eq(RexNode l, RexNode r) {
+        return (RexCall) rexBuilder.makeCall(SqlStdOperatorTable.EQUALS, List.of(l, r));
+    }
+
+    /** TIME vs TIMESTAMP: TIME side rewritten to today-anchored TIMESTAMP, TIMESTAMP side untouched. */
+    public void testTimeVsTimestampCoercesTimeSide() {
+        RexNode time = field(SqlTypeName.TIME);
+        RexNode ts = field(SqlTypeName.TIMESTAMP);
+        RexCall original = eq(time, ts);
+
+        RexCall adapted = (RexCall) adapter.adapt(original, List.of(), cluster);
+
+        assertNotSame(original, adapted);
+        RexNode newLeft = adapted.getOperands().get(0);
+        assertEquals(SqlKind.CAST, newLeft.getKind());
+        assertSame(SqlTypeName.TIMESTAMP, newLeft.getType().getSqlTypeName());
+        assertSame("TIMESTAMP side must not be rewritten", ts, adapted.getOperands().get(1));
+    }
+
+    /** TIMESTAMP vs TIME: symmetric case, only TIME side is rewritten. */
+    public void testTimestampVsTimeCoercesTimeSide() {
+        RexNode ts = field(SqlTypeName.TIMESTAMP);
+        RexNode time = field(SqlTypeName.TIME);
+        RexCall original = eq(ts, time);
+
+        RexCall adapted = (RexCall) adapter.adapt(original, List.of(), cluster);
+
+        assertNotSame(original, adapted);
+        assertSame("TIMESTAMP side must not be rewritten", ts, adapted.getOperands().get(0));
+        RexNode newRight = adapted.getOperands().get(1);
+        assertEquals(SqlKind.CAST, newRight.getKind());
+        assertSame(SqlTypeName.TIMESTAMP, newRight.getType().getSqlTypeName());
+    }
+
+    /** TIME vs DATE: same path — TIME rewritten, DATE untouched. */
+    public void testTimeVsDateCoercesTimeSide() {
+        RexNode time = field(SqlTypeName.TIME);
+        RexNode date = field(SqlTypeName.DATE);
+        RexCall original = eq(time, date);
+
+        RexCall adapted = (RexCall) adapter.adapt(original, List.of(), cluster);
+
+        assertNotSame(original, adapted);
+        assertSame(SqlTypeName.TIMESTAMP, adapted.getOperands().get(0).getType().getSqlTypeName());
+        assertSame(date, adapted.getOperands().get(1));
+    }
+
+    /** TIME vs TIME — load-bearing guard preserves the native comparison. */
+    public void testTimeVsTimePassesThrough() {
+        RexCall original = eq(field(SqlTypeName.TIME), field(SqlTypeName.TIME));
+
+        RexCall adapted = (RexCall) adapter.adapt(original, List.of(), cluster);
+
+        assertSame(original, adapted);
+    }
+
+    /** DATE vs TIMESTAMP — Substrait already binds; passthrough. */
+    public void testDateVsTimestampPassesThrough() {
+        RexCall original = eq(field(SqlTypeName.DATE), field(SqlTypeName.TIMESTAMP));
+
+        RexCall adapted = (RexCall) adapter.adapt(original, List.of(), cluster);
+
+        assertSame(original, adapted);
+    }
+
+    /** VARCHAR vs TIMESTAMP — pre-existing char-vs-temporal branch still fires after the TIME branch addition. */
+    public void testVarcharVsTimestampStillCoerced() {
+        RexNode varchar = field(SqlTypeName.VARCHAR);
+        RexNode ts = field(SqlTypeName.TIMESTAMP);
+        RexCall original = eq(varchar, ts);
+
+        RexCall adapted = (RexCall) adapter.adapt(original, List.of(), cluster);
+
+        assertNotSame(original, adapted);
+        assertSame(SqlTypeName.TIMESTAMP, adapted.getOperands().get(0).getType().getSqlTypeName());
+        assertSame(ts, adapted.getOperands().get(1));
+    }
+
+    /** Numeric-vs-numeric — adapter is registered against comparison ops generically; non-temporal calls pass through. */
+    public void testNumericComparisonPassesThrough() {
+        RexCall original = eq(field(SqlTypeName.INTEGER), field(SqlTypeName.INTEGER));
+
+        RexCall adapted = (RexCall) adapter.adapt(original, List.of(), cluster);
+
+        assertSame(original, adapted);
+    }
+
+    /**
+     * Calcite's binary-comparison type-coercion wraps the TIME side with
+     * {@code to_timestamp(time)} to align with a DATE peer — that's the actual production input
+     * shape (not a raw TIME ref). The adapter must unwrap to find the inner TIME and rewrite it.
+     */
+    public void testToTimestampWrappedTimeVsDateCoerces() {
+        RexNode timeRef = field(SqlTypeName.TIME);
+        RexNode wrappedTime = rexBuilder.makeCall(
+            typeFactory.createSqlType(SqlTypeName.TIMESTAMP),
+            DateTimeAdapters.LOCAL_TO_TIMESTAMP_OP,
+            List.of(timeRef)
+        );
+        RexNode date = field(SqlTypeName.DATE);
+        RexCall original = eq(wrappedTime, date);
+
+        RexCall adapted = (RexCall) adapter.adapt(original, List.of(), cluster);
+
+        assertNotSame("wrapped TIME must trigger the coercion path", original, adapted);
+        assertSame(SqlTypeName.TIMESTAMP, adapted.getOperands().get(0).getType().getSqlTypeName());
+        assertSame("DATE peer must not be rewritten", date, adapted.getOperands().get(1));
+    }
+
+    /**
+     * {@code CAST(time AS TIMESTAMP)} is the other wrapped form Calcite's coercion may emit. The
+     * adapter's {@code unwrapToTime} also recognises CAST as a single-operand wrapper.
+     */
+    public void testCastWrappedTimeVsTimestampCoerces() {
+        RexNode timeRef = field(SqlTypeName.TIME);
+        RexNode castTime = rexBuilder.makeCast(typeFactory.createSqlType(SqlTypeName.TIMESTAMP), timeRef);
+        RexNode ts = field(SqlTypeName.TIMESTAMP);
+        RexCall original = eq(castTime, ts);
+
+        RexCall adapted = (RexCall) adapter.adapt(original, List.of(), cluster);
+
+        assertNotSame("CAST-wrapped TIME must trigger the coercion path", original, adapted);
+        assertSame(SqlTypeName.TIMESTAMP, adapted.getOperands().get(0).getType().getSqlTypeName());
+        assertSame(ts, adapted.getOperands().get(1));
+    }
+
+    /**
+     * The DATE/TIMESTAMP peer can also arrive wrapped (e.g. {@code to_timestamp(date)}); the adapter
+     * still has to recognise it as a temporal peer to fire the TIME-side rewrite.
+     */
+    public void testTimeVsToTimestampWrappedDateCoerces() {
+        RexNode time = field(SqlTypeName.TIME);
+        RexNode dateRef = field(SqlTypeName.DATE);
+        RexNode wrappedDate = rexBuilder.makeCall(
+            typeFactory.createSqlType(SqlTypeName.TIMESTAMP),
+            DateTimeAdapters.LOCAL_TO_TIMESTAMP_OP,
+            List.of(dateRef)
+        );
+        RexCall original = eq(time, wrappedDate);
+
+        RexCall adapted = (RexCall) adapter.adapt(original, List.of(), cluster);
+
+        assertNotSame("wrapped DATE peer must still trigger TIME-side coercion", original, adapted);
+        assertSame(SqlTypeName.TIMESTAMP, adapted.getOperands().get(0).getType().getSqlTypeName());
+        assertSame("wrapped DATE peer must not be re-rewritten", wrappedDate, adapted.getOperands().get(1));
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DateAddSubAdapterTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DateAddSubAdapterTests.java
@@ -31,7 +31,7 @@ import org.opensearch.test.OpenSearchTestCase;
 import java.math.BigDecimal;
 import java.util.List;
 
-/** Covers {@link DateAddSubAdapter}: TIME base anchors to today UTC before DATETIME_PLUS. */
+/** Covers {@link DateAddSubAdapter}: TIME base anchors to today UTC; integer-days form rebuilds as INTERVAL DAY. */
 public class DateAddSubAdapterTests extends OpenSearchTestCase {
 
     private final RelDataTypeFactory typeFactory = new JavaTypeFactoryImpl();
@@ -40,6 +40,24 @@ public class DateAddSubAdapterTests extends OpenSearchTestCase {
 
     private static final SqlFunction DATE_ADD_OP = new SqlFunction(
         "DATE_ADD",
+        SqlKind.OTHER_FUNCTION,
+        ReturnTypes.TIMESTAMP,
+        null,
+        OperandTypes.VARIADIC,
+        SqlFunctionCategory.TIMEDATE
+    );
+
+    private static final SqlFunction ADDDATE_OP = new SqlFunction(
+        "ADDDATE",
+        SqlKind.OTHER_FUNCTION,
+        ReturnTypes.TIMESTAMP,
+        null,
+        OperandTypes.VARIADIC,
+        SqlFunctionCategory.TIMEDATE
+    );
+
+    private static final SqlFunction SUBDATE_OP = new SqlFunction(
+        "SUBDATE",
         SqlKind.OTHER_FUNCTION,
         ReturnTypes.TIMESTAMP,
         null,
@@ -69,5 +87,80 @@ public class DateAddSubAdapterTests extends OpenSearchTestCase {
         assertEquals(SqlKind.CAST, castNode.getKind());
         RexCall concat = (RexCall) castNode.getOperands().get(0);
         assertEquals("||", concat.getOperator().getName());
+    }
+
+    /** ADDDATE(DATE-col, 1) → DATETIME_PLUS(CAST(date AS …), INTERVAL 1 DAY). The integer 1 is rebuilt as a DAY interval. */
+    public void testAddDateIntegerDaysOnDateRebuiltAsIntervalDay() {
+        RelDataType dateType = typeFactory.createSqlType(SqlTypeName.DATE);
+        RexNode dateCol = rexBuilder.makeInputRef(dateType, 0);
+        RexNode oneInt = rexBuilder.makeLiteral(1, typeFactory.createSqlType(SqlTypeName.INTEGER), false);
+        RexCall original = (RexCall) rexBuilder.makeCall(ADDDATE_OP, List.of(dateCol, oneInt));
+
+        RexNode adapted = new DateAddSubAdapter(true).adapt(original, List.of(), cluster);
+
+        RexCall outer = adapted instanceof RexCall && ((RexCall) adapted).getKind() == SqlKind.CAST
+            ? (RexCall) ((RexCall) adapted).getOperands().get(0)
+            : (RexCall) adapted;
+        assertSame(SqlStdOperatorTable.DATETIME_PLUS, outer.getOperator());
+        RexNode shiftedInterval = outer.getOperands().get(1);
+        assertTrue(SqlTypeName.INTERVAL_TYPES.contains(shiftedInterval.getType().getSqlTypeName()));
+        assertEquals(TimeUnit.DAY, shiftedInterval.getType().getIntervalQualifier().getUnit());
+        // INTERVAL DAY values are stored in millis after the unit-rebuild step; +1 day = +86400000.
+        long signed = ((org.apache.calcite.rex.RexLiteral) shiftedInterval).getValueAs(Long.class);
+        assertEquals(86_400_000L, signed);
+    }
+
+    /** SUBDATE(TIMESTAMP-col, 5) → DATETIME_PLUS(ts, INTERVAL -5 DAY). Sign folded for SUB. */
+    public void testSubDateIntegerDaysFoldsSign() {
+        RelDataType tsType = typeFactory.createSqlType(SqlTypeName.TIMESTAMP);
+        RexNode tsCol = rexBuilder.makeInputRef(tsType, 0);
+        RexNode fiveInt = rexBuilder.makeLiteral(5, typeFactory.createSqlType(SqlTypeName.INTEGER), false);
+        RexCall original = (RexCall) rexBuilder.makeCall(SUBDATE_OP, List.of(tsCol, fiveInt));
+
+        RexNode adapted = new DateAddSubAdapter(false).adapt(original, List.of(), cluster);
+
+        RexCall outer = adapted instanceof RexCall && ((RexCall) adapted).getKind() == SqlKind.CAST
+            ? (RexCall) ((RexCall) adapted).getOperands().get(0)
+            : (RexCall) adapted;
+        assertSame(SqlStdOperatorTable.DATETIME_PLUS, outer.getOperator());
+        long signed = ((org.apache.calcite.rex.RexLiteral) outer.getOperands().get(1)).getValueAs(Long.class);
+        // 5 days in millis, negated for SUB.
+        assertEquals(-5L * 86_400_000L, signed);
+    }
+
+    /**
+     * Non-literal second operand (an integer column ref, not a literal) cannot be normalized to an
+     * INTERVAL by {@code asIntervalLiteral} — the adapter must pass the call through unchanged so
+     * isthmus surfaces a binding failure rather than producing a malformed interval.
+     */
+    public void testAddDateNonLiteralSecondOperandPassesThrough() {
+        RelDataType dateType = typeFactory.createSqlType(SqlTypeName.DATE);
+        RelDataType intType = typeFactory.createSqlType(SqlTypeName.INTEGER);
+        RexNode dateCol = rexBuilder.makeInputRef(dateType, 0);
+        RexNode intCol = rexBuilder.makeInputRef(intType, 1);
+        RexCall original = (RexCall) rexBuilder.makeCall(ADDDATE_OP, List.of(dateCol, intCol));
+
+        RexNode adapted = new DateAddSubAdapter(true).adapt(original, List.of(), cluster);
+
+        assertSame("non-literal second operand must leave the call unchanged", original, adapted);
+    }
+
+    /**
+     * MICROSECOND interval falls through to the UDF path — Arrow's IntervalDayTime is
+     * millisecond-resolution so the adapter cannot represent a µs increment. The adapter returns
+     * the original call so the engine surfaces a loud error rather than silently truncating.
+     */
+    public void testDateAddMicrosecondIntervalPassesThrough() {
+        RelDataType tsType = typeFactory.createSqlType(SqlTypeName.TIMESTAMP);
+        RexNode tsCol = rexBuilder.makeInputRef(tsType, 0);
+        RexNode microInterval = rexBuilder.makeIntervalLiteral(
+            BigDecimal.valueOf(500),
+            new SqlIntervalQualifier(TimeUnit.MICROSECOND, null, SqlParserPos.ZERO)
+        );
+        RexCall original = (RexCall) rexBuilder.makeCall(DATE_ADD_OP, List.of(tsCol, microInterval));
+
+        RexNode adapted = new DateAddSubAdapter(true).adapt(original, List.of(), cluster);
+
+        assertSame("MICROSECOND interval must leave the call unchanged", original, adapted);
     }
 }

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DateDiffAdapterTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DateDiffAdapterTests.java
@@ -1,0 +1,138 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion;
+
+import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.hep.HepPlanner;
+import org.apache.calcite.plan.hep.HepProgramBuilder;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlFunction;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.type.OperandTypes;
+import org.apache.calcite.sql.type.ReturnTypes;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.List;
+
+/**
+ * Unit tests for {@link DateDiffAdapter}. PPL {@code DATEDIFF(a, b)} is the whole-day
+ * difference between the calendar dates of {@code a} and {@code b} (arg1 − arg2), so the
+ * adapter must truncate each operand to its day before differencing — not subtract raw
+ * instants. The lowering is
+ * {@code FLOOR(to_unixtime(date_trunc('day', a)) / 86400) - FLOOR(to_unixtime(date_trunc('day', b)) / 86400)}.
+ */
+public class DateDiffAdapterTests extends OpenSearchTestCase {
+
+    private RelDataTypeFactory typeFactory;
+    private RexBuilder rexBuilder;
+    private RelOptCluster cluster;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        typeFactory = new JavaTypeFactoryImpl();
+        rexBuilder = new RexBuilder(typeFactory);
+        HepPlanner planner = new HepPlanner(new HepProgramBuilder().build());
+        cluster = RelOptCluster.create(planner, rexBuilder);
+    }
+
+    private SqlFunction datediffOp() {
+        return new SqlFunction(
+            "DATEDIFF",
+            SqlKind.OTHER_FUNCTION,
+            ReturnTypes.BIGINT_FORCE_NULLABLE,
+            null,
+            OperandTypes.ANY_ANY,
+            SqlFunctionCategory.TIMEDATE
+        );
+    }
+
+    private RexCall buildDateDiff() {
+        RelDataType ts = typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.TIMESTAMP), true);
+        RexNode a = rexBuilder.makeInputRef(ts, 0);
+        RexNode b = rexBuilder.makeInputRef(ts, 1);
+        RelDataType ret = typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.BIGINT), true);
+        return (RexCall) rexBuilder.makeCall(ret, datediffOp(), List.of(a, b));
+    }
+
+    /** DATEDIFF(a, b) lowers to a subtraction of two day-counts. */
+    public void testDateDiffLowersToDayCountSubtraction() {
+        RexNode result = new DateDiffAdapter().adapt(buildDateDiff(), List.of(), cluster);
+        assertTrue("expected a rewritten call, got: " + result, result instanceof RexCall);
+        // The top of the rewrite is a MINUS (possibly wrapped in a CAST to the declared return type).
+        RexCall out = (RexCall) result;
+        RexCall minus = out.getOperator() == SqlStdOperatorTable.MINUS ? out : firstMinusOperand(out);
+        assertNotNull("rewrite must contain a MINUS of two day-counts", minus);
+        assertEquals(SqlStdOperatorTable.MINUS, minus.getOperator());
+    }
+
+    /** The rewrite must not leave the raw DATEDIFF operator in place. */
+    public void testDateDiffDoesNotPassThrough() {
+        RexCall call = buildDateDiff();
+        RexNode result = new DateDiffAdapter().adapt(call, List.of(), cluster);
+        assertTrue("DATEDIFF must be rewritten, not returned unchanged", result != call);
+    }
+
+    /**
+     * TIME operands route through {@code coerceCharacterOperandToTimestamp}: {@code to_unixtime}
+     * rejects a Time64, so each TIME must be anchored to a TIMESTAMP first. The to_unixtime
+     * operand must therefore NOT be a raw TIME-typed value.
+     */
+    public void testDateDiffOnTimeOperandsAnchorsBeforeUnixtime() {
+        RelDataType time = typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.TIME), true);
+        RelDataType ret = typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.BIGINT), true);
+        RexNode a = rexBuilder.makeInputRef(time, 0);
+        RexNode b = rexBuilder.makeInputRef(time, 1);
+        RexCall call = (RexCall) rexBuilder.makeCall(ret, datediffOp(), List.of(a, b));
+
+        RexNode result = new DateDiffAdapter().adapt(call, List.of(), cluster);
+
+        // Walk the tree, find every to_unixtime call — none should have a TIME-typed operand.
+        assertNoToUnixtimeOnRawTime(result);
+    }
+
+    private static void assertNoToUnixtimeOnRawTime(RexNode node) {
+        if (!(node instanceof RexCall call)) {
+            return;
+        }
+        if (call.getOperator() == UnixTimestampAdapter.LOCAL_TO_UNIXTIME_OP) {
+            assertNotEquals(
+                "to_unixtime operand must be anchored, not a raw TIME",
+                SqlTypeName.TIME,
+                call.getOperands().get(0).getType().getSqlTypeName()
+            );
+        }
+        for (RexNode op : call.getOperands()) {
+            assertNoToUnixtimeOnRawTime(op);
+        }
+    }
+
+    private static RexCall firstMinusOperand(RexCall call) {
+        for (RexNode op : call.getOperands()) {
+            if (op instanceof RexCall c) {
+                if (c.getOperator() == SqlStdOperatorTable.MINUS) {
+                    return c;
+                }
+                RexCall nested = firstMinusOperand(c);
+                if (nested != null) {
+                    return nested;
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/EarliestLatestAdapterTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/EarliestLatestAdapterTests.java
@@ -86,6 +86,23 @@ public class EarliestLatestAdapterTests extends OpenSearchTestCase {
         return (RexCall) rexBuilder.makeCall(boolType, latestUdf, List.of(lit, tsRef));
     }
 
+    /**
+     * Regression: when the timestamp operand is NOT NULL (e.g. {@code earliest('now', utc_timestamp())}
+     * where utc_timestamp() and the folded literal are both non-null), the comparison's inferred
+     * return type is {@code BOOLEAN NOT NULL}, but the EARLIEST call was declared nullable BOOLEAN.
+     * The adapter must pin the result to the call's declared type or the enclosing Project/Filter
+     * trips Calcite's {@code BOOLEAN vs BOOLEAN NOT NULL} assertion at execution time.
+     */
+    public void testNotNullTimestampOperandPinsResultType() {
+        RelDataType notNullTs = typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.TIMESTAMP, 3), false);
+        RexNode notNullTsRef = rexBuilder.makeInputRef(notNullTs, 0);
+        RelDataType nullableBool = typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.BOOLEAN), true);
+        RexCall call = (RexCall) rexBuilder.makeCall(nullableBool, earliestUdf, List.of(rexBuilder.makeLiteral("now"), notNullTsRef));
+
+        RexNode result = earliestAdapter.adapt(call, List.of(), cluster);
+        assertEquals("rewrite must preserve the call's declared (nullable BOOLEAN) type", call.getType(), result.getType());
+    }
+
     // ── Absolute literal: emits TIMESTAMP_LITERAL, no symbolic now() ───────────
 
     public void testAbsoluteIsoDateEmitsTimestampLiteral() {

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/EpochArithmeticAdaptersTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/EpochArithmeticAdaptersTests.java
@@ -1,0 +1,179 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion;
+
+import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.hep.HepPlanner;
+import org.apache.calcite.plan.hep.HepProgramBuilder;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlFunction;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.type.OperandTypes;
+import org.apache.calcite.sql.type.ReturnTypes;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+/**
+ * Unit tests for {@link EpochArithmeticAdapters}. These adapters lower PPL TO_DAYS / TO_SECONDS /
+ * FROM_DAYS / TIME_TO_SEC to {@code to_unixtime} / {@code from_unixtime} plus integer arithmetic.
+ * The tests assert the rewrite <em>shape</em> (the raw PPL op is replaced and the expected
+ * arithmetic operator tops the tree) — exact numeric values are covered by the QA ITs against a
+ * real DataFusion runtime.
+ */
+public class EpochArithmeticAdaptersTests extends OpenSearchTestCase {
+
+    private RelDataTypeFactory typeFactory;
+    private RexBuilder rexBuilder;
+    private RelOptCluster cluster;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        typeFactory = new JavaTypeFactoryImpl();
+        rexBuilder = new RexBuilder(typeFactory);
+        HepPlanner planner = new HepPlanner(new HepProgramBuilder().build());
+        cluster = RelOptCluster.create(planner, rexBuilder);
+    }
+
+    private RexCall unaryCall(String name, RelDataType returnType, SqlTypeName operandType) {
+        SqlFunction op = new SqlFunction(
+            name,
+            SqlKind.OTHER_FUNCTION,
+            ReturnTypes.explicit(returnType),
+            null,
+            OperandTypes.ANY,
+            SqlFunctionCategory.TIMEDATE
+        );
+        RelDataType arg = typeFactory.createTypeWithNullability(typeFactory.createSqlType(operandType), true);
+        RexNode ref = rexBuilder.makeInputRef(arg, 0);
+        return (RexCall) rexBuilder.makeCall(returnType, op, List.of(ref));
+    }
+
+    private RelDataType bigint() {
+        return typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.BIGINT), true);
+    }
+
+    /** Recursively search for the first RexCall using {@code operator}. */
+    private static RexCall findOp(RexNode node, org.apache.calcite.sql.SqlOperator operator) {
+        if (node instanceof RexCall call) {
+            if (call.getOperator() == operator) {
+                return call;
+            }
+            for (RexNode op : call.getOperands()) {
+                RexCall found = findOp(op, operator);
+                if (found != null) {
+                    return found;
+                }
+            }
+        }
+        return null;
+    }
+
+    public void testToDaysLowersToDividePlus() {
+        RexCall call = unaryCall("TO_DAYS", bigint(), SqlTypeName.TIMESTAMP);
+        RexNode result = new EpochArithmeticAdapters.ToDaysAdapter().adapt(call, List.of(), cluster);
+        assertTrue("TO_DAYS must be rewritten", result != call);
+        assertNotNull("expected a PLUS (epochDays + 719528)", findOp(result, SqlStdOperatorTable.PLUS));
+        assertNotNull("expected a DIVIDE (seconds / 86400)", findOp(result, SqlStdOperatorTable.DIVIDE));
+        assertNotNull("expected to_unixtime", findOp(result, UnixTimestampAdapter.LOCAL_TO_UNIXTIME_OP));
+    }
+
+    public void testToSecondsLowersToPlusOverUnixtime() {
+        RexCall call = unaryCall("TO_SECONDS", bigint(), SqlTypeName.TIMESTAMP);
+        RexNode result = new EpochArithmeticAdapters.ToSecondsAdapter().adapt(call, List.of(), cluster);
+        assertTrue(result != call);
+        assertNotNull("expected a PLUS (seconds + 62167219200)", findOp(result, SqlStdOperatorTable.PLUS));
+        assertNotNull("expected to_unixtime", findOp(result, UnixTimestampAdapter.LOCAL_TO_UNIXTIME_OP));
+    }
+
+    public void testFromDaysLowersToFromUnixtime() {
+        RelDataType dateType = typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.DATE), true);
+        SqlFunction op = new SqlFunction(
+            "FROM_DAYS",
+            SqlKind.OTHER_FUNCTION,
+            ReturnTypes.explicit(dateType),
+            null,
+            OperandTypes.ANY,
+            SqlFunctionCategory.TIMEDATE
+        );
+        RexNode n = rexBuilder.makeExactLiteral(BigDecimal.valueOf(738049), typeFactory.createSqlType(SqlTypeName.BIGINT));
+        RexCall call = (RexCall) rexBuilder.makeCall(dateType, op, List.of(n));
+        RexNode result = new EpochArithmeticAdapters.FromDaysAdapter().adapt(call, List.of(), cluster);
+        assertTrue(result != call);
+        assertNotNull("expected from_unixtime", findOp(result, RustUdfDateTimeAdapters.LOCAL_FROM_UNIXTIME_OP));
+        assertNotNull("expected a MULTIPLY (days * 86400)", findOp(result, SqlStdOperatorTable.MULTIPLY));
+    }
+
+    /**
+     * A TIME operand must be anchored to a TIMESTAMP before to_unixtime (which rejects Time64).
+     * The anchoring goes through the CONCAT(today, ' ', CAST(time AS VARCHAR)) → parse path, so the
+     * to_unixtime operand must no longer be the raw TIME input ref.
+     */
+    public void testTimeToSecAnchorsTimeBeforeUnixtime() {
+        RexCall call = unaryCall("TIME_TO_SEC", bigint(), SqlTypeName.TIME);
+        RexNode result = new EpochArithmeticAdapters.TimeToSecAdapter().adapt(call, List.of(), cluster);
+        assertTrue(result != call);
+        assertNotNull("expected MOD (seconds % 86400)", findOp(result, SqlStdOperatorTable.MOD));
+        RexCall unixtime = findOp(result, UnixTimestampAdapter.LOCAL_TO_UNIXTIME_OP);
+        assertNotNull("expected to_unixtime", unixtime);
+        // The to_unixtime operand must NOT be a raw TIME-typed value (that's the unsupported path).
+        assertNotEquals(
+            "to_unixtime operand must be anchored, not the raw TIME",
+            SqlTypeName.TIME,
+            unixtime.getOperands().get(0).getType().getSqlTypeName()
+        );
+    }
+
+    public void testTimeToSecTimestampOperandNotCast() {
+        RexCall call = unaryCall("TIME_TO_SEC", bigint(), SqlTypeName.TIMESTAMP);
+        RexNode result = new EpochArithmeticAdapters.TimeToSecAdapter().adapt(call, List.of(), cluster);
+        assertNotNull("expected MOD", findOp(result, SqlStdOperatorTable.MOD));
+    }
+
+    /** Builds {@code FN('<literal>')} with a VARCHAR string-literal operand. */
+    private RexCall unaryStringLiteralCall(String name, String literal) {
+        SqlFunction op = new SqlFunction(
+            name,
+            SqlKind.OTHER_FUNCTION,
+            ReturnTypes.explicit(bigint()),
+            null,
+            OperandTypes.ANY,
+            SqlFunctionCategory.TIMEDATE
+        );
+        RexNode lit = rexBuilder.makeLiteral(literal, typeFactory.createSqlType(SqlTypeName.VARCHAR), true);
+        return (RexCall) rexBuilder.makeCall(bigint(), op, List.of(lit));
+    }
+
+    /** TO_DAYS rejects a malformed date literal at plan time with the PPL format-hint message. */
+    public void testToDaysInvalidLiteralThrowsFormatHint() {
+        RexCall call = unaryStringLiteralCall("TO_DAYS", "2025-13-02");
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> new EpochArithmeticAdapters.ToDaysAdapter().adapt(call, List.of(), cluster)
+        );
+        assertTrue("message must carry the format hint, got: " + e.getMessage(), e.getMessage().contains("unsupported format"));
+    }
+
+    /** TO_SECONDS still accepts a valid full-datetime literal (Kind.DATE accepts date + datetime). */
+    public void testToSecondsValidDatetimeLiteralPasses() {
+        RexCall call = unaryStringLiteralCall("TO_SECONDS", "2020-09-16 07:40:00");
+        RexNode result = new EpochArithmeticAdapters.ToSecondsAdapter().adapt(call, List.of(), cluster);
+        assertNotNull("valid datetime literal must lower, not throw", findOp(result, SqlStdOperatorTable.PLUS));
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/LastDayAdapterTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/LastDayAdapterTests.java
@@ -1,0 +1,159 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion;
+
+import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.hep.HepPlanner;
+import org.apache.calcite.plan.hep.HepProgramBuilder;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlFunction;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.type.OperandTypes;
+import org.apache.calcite.sql.type.ReturnTypes;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.List;
+
+/**
+ * Unit tests for {@link LastDayAdapter}. The lowering is
+ * {@code date_trunc('month', x) + INTERVAL 1 MONTH - INTERVAL 1 DAY}, so each test asserts the
+ * rewrite contains both the {@code date_trunc} call and two {@code DATETIME_PLUS} layers — exact
+ * date values are covered by the QA IT against a real DataFusion runtime.
+ */
+public class LastDayAdapterTests extends OpenSearchTestCase {
+
+    private RelDataTypeFactory typeFactory;
+    private RexBuilder rexBuilder;
+    private RelOptCluster cluster;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        typeFactory = new JavaTypeFactoryImpl();
+        rexBuilder = new RexBuilder(typeFactory);
+        HepPlanner planner = new HepPlanner(new HepProgramBuilder().build());
+        cluster = RelOptCluster.create(planner, rexBuilder);
+    }
+
+    private static RexCall findOp(RexNode node, SqlOperator operator) {
+        if (node instanceof RexCall call) {
+            if (call.getOperator() == operator) {
+                return call;
+            }
+            for (RexNode op : call.getOperands()) {
+                RexCall found = findOp(op, operator);
+                if (found != null) {
+                    return found;
+                }
+            }
+        }
+        return null;
+    }
+
+    private RexCall lastDayCall(SqlTypeName operandType) {
+        SqlFunction op = new SqlFunction(
+            "LAST_DAY",
+            SqlKind.OTHER_FUNCTION,
+            ReturnTypes.DATE_NULLABLE,
+            null,
+            OperandTypes.ANY,
+            SqlFunctionCategory.TIMEDATE
+        );
+        RelDataType dateType = typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.DATE), true);
+        RelDataType arg = typeFactory.createTypeWithNullability(typeFactory.createSqlType(operandType), true);
+        return (RexCall) rexBuilder.makeCall(dateType, op, List.of(rexBuilder.makeInputRef(arg, 0)));
+    }
+
+    /** date_trunc + 2× DATETIME_PLUS appears for every operand type. */
+    private void assertLastDayShape(RexNode result) {
+        assertNotNull("expected date_trunc('month', ...)", findOp(result, DateTimeAdapters.LOCAL_DATE_TRUNC_OP));
+        assertNotNull("expected DATETIME_PLUS (+1 month, -1 day)", findOp(result, SqlStdOperatorTable.DATETIME_PLUS));
+    }
+
+    public void testLastDayOnDateLowersWithoutAnchor() {
+        RexCall call = lastDayCall(SqlTypeName.DATE);
+        RexNode result = new LastDayAdapter().adapt(call, List.of(), cluster);
+        assertTrue("LAST_DAY must be rewritten", result != call);
+        assertLastDayShape(result);
+    }
+
+    public void testLastDayOnTimestampLowersWithoutAnchor() {
+        RexCall call = lastDayCall(SqlTypeName.TIMESTAMP);
+        RexNode result = new LastDayAdapter().adapt(call, List.of(), cluster);
+        assertTrue(result != call);
+        assertLastDayShape(result);
+    }
+
+    /**
+     * VARCHAR / TIME bases must route through {@code coerceCharacterOperandToTimestamp} so the
+     * operand handed to {@code date_trunc} is TIMESTAMP-typed (a direct CAST(time→timestamp) would
+     * be rejected by DataFusion's optimizer; the helper uses today-date prefix + CONCAT instead).
+     * The invariant we pin: the date_trunc call's value operand is TIMESTAMP, not the source type.
+     */
+    public void testLastDayOnVarcharAnchorsViaCoercion() {
+        RexCall call = lastDayCall(SqlTypeName.VARCHAR);
+        RexNode result = new LastDayAdapter().adapt(call, List.of(), cluster);
+        assertTrue(result != call);
+        assertLastDayShape(result);
+        RexCall dateTrunc = findOp(result, DateTimeAdapters.LOCAL_DATE_TRUNC_OP);
+        assertNotNull(dateTrunc);
+        assertEquals(
+            "date_trunc value operand must be TIMESTAMP after VARCHAR coercion",
+            SqlTypeName.TIMESTAMP,
+            dateTrunc.getOperands().get(1).getType().getSqlTypeName()
+        );
+    }
+
+    public void testLastDayOnTimeAnchorsViaCoercion() {
+        RexCall call = lastDayCall(SqlTypeName.TIME);
+        RexNode result = new LastDayAdapter().adapt(call, List.of(), cluster);
+        assertTrue(result != call);
+        assertLastDayShape(result);
+        RexCall dateTrunc = findOp(result, DateTimeAdapters.LOCAL_DATE_TRUNC_OP);
+        assertNotNull(dateTrunc);
+        // TIME path uses CONCAT(today, ' ', CAST(time AS VARCHAR)) → CAST TIMESTAMP — that CONCAT
+        // is the load-bearing marker that the TIME-anchoring branch ran (vs the no-op DATE branch).
+        assertNotNull("TIME operand must route through CONCAT-anchor", findOp(result, SqlStdOperatorTable.CONCAT));
+        assertEquals(
+            "date_trunc value operand must be TIMESTAMP after TIME coercion",
+            SqlTypeName.TIMESTAMP,
+            dateTrunc.getOperands().get(1).getType().getSqlTypeName()
+        );
+    }
+
+    /** Wrong-arity input (zero or two operands) must pass through unchanged so the engine surfaces it. */
+    public void testLastDayWrongArityPassesThrough() {
+        SqlFunction op = new SqlFunction(
+            "LAST_DAY",
+            SqlKind.OTHER_FUNCTION,
+            ReturnTypes.DATE_NULLABLE,
+            null,
+            OperandTypes.ANY_ANY,
+            SqlFunctionCategory.TIMEDATE
+        );
+        RelDataType dateType = typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.DATE), true);
+        RelDataType ts = typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.TIMESTAMP), true);
+        RexCall twoArg = (RexCall) rexBuilder.makeCall(
+            dateType,
+            op,
+            List.of(rexBuilder.makeInputRef(ts, 0), rexBuilder.makeInputRef(ts, 1))
+        );
+        RexNode result = new LastDayAdapter().adapt(twoArg, List.of(), cluster);
+        assertSame("two-arg LAST_DAY must pass through unchanged", twoArg, result);
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/OsYearweekAdapterTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/OsYearweekAdapterTests.java
@@ -1,0 +1,142 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion;
+
+import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.hep.HepPlanner;
+import org.apache.calcite.plan.hep.HepProgramBuilder;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlFunction;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.type.OperandTypes;
+import org.apache.calcite.sql.type.ReturnTypes;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+/**
+ * Unit tests for {@link RustUdfDateTimeAdapters.OsYearweekAdapter}. The adapter must (a) coerce a
+ * VARCHAR / TIME first operand to TIMESTAMP via {@link DatePartAdapters#coerceCharacterOperandToTimestamp}
+ * before binding the {@code precision_timestamp<P>} signature, and (b) preserve a 2-arg call's mode
+ * operand unchanged. The 0-arg branch falls back to the parent {@code AbstractNameMappingAdapter}.
+ */
+public class OsYearweekAdapterTests extends OpenSearchTestCase {
+
+    private RelDataTypeFactory typeFactory;
+    private RexBuilder rexBuilder;
+    private RelOptCluster cluster;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        typeFactory = new JavaTypeFactoryImpl();
+        rexBuilder = new RexBuilder(typeFactory);
+        HepPlanner planner = new HepPlanner(new HepProgramBuilder().build());
+        cluster = RelOptCluster.create(planner, rexBuilder);
+    }
+
+    private RelDataType nullable(SqlTypeName t) {
+        return typeFactory.createTypeWithNullability(typeFactory.createSqlType(t), true);
+    }
+
+    private RexCall yearweekCall(List<RexNode> operands, int operandTypeCount) {
+        SqlFunction op = new SqlFunction(
+            "YEARWEEK",
+            SqlKind.OTHER_FUNCTION,
+            ReturnTypes.INTEGER_NULLABLE,
+            null,
+            operandTypeCount == 2 ? OperandTypes.ANY_ANY : OperandTypes.ANY,
+            SqlFunctionCategory.TIMEDATE
+        );
+        return (RexCall) rexBuilder.makeCall(nullable(SqlTypeName.INTEGER), op, operands);
+    }
+
+    /**
+     * 1-arg form with a VARCHAR operand: the rewrite must (a) replace YEARWEEK with the os_yearweek
+     * UDF op, and (b) replace the raw VARCHAR operand with a TIMESTAMP-typed expression.
+     */
+    public void testYearweekVarcharOperandCoercedToTimestamp() {
+        RexNode lit = rexBuilder.makeLiteral("2003-10-03", typeFactory.createSqlType(SqlTypeName.VARCHAR), true);
+        RexCall call = yearweekCall(List.of(lit), 1);
+
+        RexNode result = new RustUdfDateTimeAdapters.OsYearweekAdapter().adapt(call, List.of(), cluster);
+
+        assertTrue("YEARWEEK must be rewritten", result instanceof RexCall);
+        RexCall rewritten = (RexCall) result;
+        assertSame("rewrite must target os_yearweek", RustUdfDateTimeAdapters.LOCAL_OS_YEARWEEK_OP, rewritten.getOperator());
+        assertEquals(
+            "coerced operand must be TIMESTAMP-typed",
+            SqlTypeName.TIMESTAMP,
+            rewritten.getOperands().get(0).getType().getSqlTypeName()
+        );
+    }
+
+    /**
+     * 2-arg form: the date operand is coerced, but the integer mode operand passes through unchanged
+     * — its type must NOT be transformed and the value must be preserved.
+     */
+    public void testYearweekModeOperandPassesThroughUnchanged() {
+        RexNode dateLit = rexBuilder.makeLiteral("2003-10-03", typeFactory.createSqlType(SqlTypeName.VARCHAR), true);
+        RexNode mode = rexBuilder.makeExactLiteral(BigDecimal.valueOf(3), typeFactory.createSqlType(SqlTypeName.INTEGER));
+        RexCall call = yearweekCall(List.of(dateLit, mode), 2);
+
+        RexNode result = new RustUdfDateTimeAdapters.OsYearweekAdapter().adapt(call, List.of(), cluster);
+
+        RexCall rewritten = (RexCall) result;
+        assertSame(RustUdfDateTimeAdapters.LOCAL_OS_YEARWEEK_OP, rewritten.getOperator());
+        assertEquals("mode operand must be preserved at index 1", 2, rewritten.getOperands().size());
+        assertSame("mode operand must be the same RexNode (identity), not a re-wrapped copy", mode, rewritten.getOperands().get(1));
+    }
+
+    /** TIMESTAMP first operand must skip the coercion path and route directly to os_yearweek. */
+    public void testYearweekTimestampOperandTargetsOsYearweek() {
+        RexNode tsRef = rexBuilder.makeInputRef(nullable(SqlTypeName.TIMESTAMP), 0);
+        RexCall call = yearweekCall(List.of(tsRef), 1);
+
+        RexNode result = new RustUdfDateTimeAdapters.OsYearweekAdapter().adapt(call, List.of(), cluster);
+
+        RexCall rewritten = (RexCall) result;
+        assertSame(RustUdfDateTimeAdapters.LOCAL_OS_YEARWEEK_OP, rewritten.getOperator());
+        assertEquals(
+            "TIMESTAMP operand must remain TIMESTAMP after coercion (no-op)",
+            SqlTypeName.TIMESTAMP,
+            rewritten.getOperands().get(0).getType().getSqlTypeName()
+        );
+    }
+
+    /**
+     * 0-arg call must fall back to the parent name-mapping adapter — coercion logic only runs when
+     * there is at least one operand to coerce.
+     */
+    public void testYearweekZeroArgFallsThroughToParent() {
+        RexCall call = (RexCall) rexBuilder.makeCall(
+            nullable(SqlTypeName.INTEGER),
+            new SqlFunction(
+                "YEARWEEK",
+                SqlKind.OTHER_FUNCTION,
+                ReturnTypes.INTEGER_NULLABLE,
+                null,
+                OperandTypes.NILADIC,
+                SqlFunctionCategory.TIMEDATE
+            ),
+            List.of()
+        );
+        RexNode result = new RustUdfDateTimeAdapters.OsYearweekAdapter().adapt(call, List.of(), cluster);
+        assertTrue("0-arg YEARWEEK should still produce a RexCall (parent's name-mapping result)", result instanceof RexCall);
+        assertSame(RustUdfDateTimeAdapters.LOCAL_OS_YEARWEEK_OP, ((RexCall) result).getOperator());
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/PeriodWeekdaySecToTimeAdapterTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/PeriodWeekdaySecToTimeAdapterTests.java
@@ -1,0 +1,135 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion;
+
+import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.hep.HepPlanner;
+import org.apache.calcite.plan.hep.HepProgramBuilder;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlFunction;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.fun.SqlLibraryOperators;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.type.OperandTypes;
+import org.apache.calcite.sql.type.ReturnTypes;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+/**
+ * Unit tests for {@link WeekdayAdapter}, {@link SecToTimeAdapter}, and {@link PeriodArithmeticAdapters}.
+ * They assert the rewrite <em>shape</em> (raw PPL op replaced, expected primitives present); exact
+ * numeric values are covered by the QA ITs against a real DataFusion runtime.
+ */
+public class PeriodWeekdaySecToTimeAdapterTests extends OpenSearchTestCase {
+
+    private RelDataTypeFactory typeFactory;
+    private RexBuilder rexBuilder;
+    private RelOptCluster cluster;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        typeFactory = new JavaTypeFactoryImpl();
+        rexBuilder = new RexBuilder(typeFactory);
+        HepPlanner planner = new HepPlanner(new HepProgramBuilder().build());
+        cluster = RelOptCluster.create(planner, rexBuilder);
+    }
+
+    private static RexCall findOp(RexNode node, SqlOperator operator) {
+        if (node instanceof RexCall call) {
+            if (call.getOperator() == operator) {
+                return call;
+            }
+            for (RexNode op : call.getOperands()) {
+                RexCall found = findOp(op, operator);
+                if (found != null) {
+                    return found;
+                }
+            }
+        }
+        return null;
+    }
+
+    private RexCall unaryCall(String name, RelDataType returnType, SqlTypeName operandType) {
+        SqlFunction op = new SqlFunction(
+            name,
+            SqlKind.OTHER_FUNCTION,
+            ReturnTypes.explicit(returnType),
+            null,
+            OperandTypes.ANY,
+            SqlFunctionCategory.TIMEDATE
+        );
+        RelDataType arg = typeFactory.createTypeWithNullability(typeFactory.createSqlType(operandType), true);
+        return (RexCall) rexBuilder.makeCall(returnType, op, List.of(rexBuilder.makeInputRef(arg, 0)));
+    }
+
+    private RexCall binaryIntCall(String name) {
+        RelDataType intType = typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.INTEGER), true);
+        SqlFunction op = new SqlFunction(
+            name,
+            SqlKind.OTHER_FUNCTION,
+            ReturnTypes.INTEGER_NULLABLE,
+            null,
+            OperandTypes.NUMERIC_NUMERIC,
+            SqlFunctionCategory.TIMEDATE
+        );
+        RexNode a = rexBuilder.makeExactLiteral(BigDecimal.valueOf(200801), typeFactory.createSqlType(SqlTypeName.INTEGER));
+        RexNode b = rexBuilder.makeExactLiteral(BigDecimal.valueOf(2), typeFactory.createSqlType(SqlTypeName.INTEGER));
+        return (RexCall) rexBuilder.makeCall(intType, op, List.of(a, b));
+    }
+
+    private RelDataType bigint() {
+        return typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.BIGINT), true);
+    }
+
+    private RelDataType time() {
+        return typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.TIME), true);
+    }
+
+    public void testWeekdayRemapsDow() {
+        RexCall call = unaryCall("WEEKDAY", typeFactory.createSqlType(SqlTypeName.INTEGER), SqlTypeName.TIMESTAMP);
+        RexNode result = new WeekdayAdapter().adapt(call, List.of(), cluster);
+        assertTrue("WEEKDAY must be rewritten", result != call);
+        assertNotNull("expected date_part('dow', ...)", findOp(result, SqlLibraryOperators.DATE_PART));
+        assertNotNull("expected MOD 7 remap", findOp(result, SqlStdOperatorTable.MOD));
+    }
+
+    public void testSecToTimeUsesMaketimeNotCast() {
+        RexCall call = unaryCall("SEC_TO_TIME", typeFactory.createSqlType(SqlTypeName.TIME), SqlTypeName.BIGINT);
+        RexNode result = new SecToTimeAdapter().adapt(call, List.of(), cluster);
+        assertTrue(result != call);
+        assertNotNull("expected maketime(h,m,s)", findOp(result, RustUdfDateTimeAdapters.LOCAL_MAKETIME_OP));
+        assertNotNull("expected MOD (wrap to a day / decompose)", findOp(result, SqlStdOperatorTable.MOD));
+    }
+
+    public void testPeriodAddLowersToIntegerArithmetic() {
+        RexCall call = binaryIntCall("PERIOD_ADD");
+        RexNode result = new PeriodArithmeticAdapters.PeriodAddAdapter().adapt(call, List.of(), cluster);
+        assertTrue(result != call);
+        assertNotNull("expected DIVIDE (month index / 12)", findOp(result, SqlStdOperatorTable.DIVIDE));
+        assertNotNull("expected MOD (month within year)", findOp(result, SqlStdOperatorTable.MOD));
+    }
+
+    public void testPeriodDiffLowersToSubtraction() {
+        RexCall call = binaryIntCall("PERIOD_DIFF");
+        RexNode result = new PeriodArithmeticAdapters.PeriodDiffAdapter().adapt(call, List.of(), cluster);
+        assertTrue(result != call);
+        assertNotNull("expected MINUS (monthIndex(p1) - monthIndex(p2))", findOp(result, SqlStdOperatorTable.MINUS));
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/RustUdfDateTimeAdaptersTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/RustUdfDateTimeAdaptersTests.java
@@ -130,4 +130,92 @@ public class RustUdfDateTimeAdaptersTests extends OpenSearchTestCase {
         RexCall adaptedCall = (RexCall) adapted;
         assertSame(tsVal, adaptedCall.getOperands().get(1));
     }
+
+    /** DAYNAME with a valid date literal lowers without throwing. */
+    public void testDaynameAdapterAcceptsValidDateLiteral() {
+        RexCall original = makeDateFormatCall("2020-08-26");
+        RexNode adapted = new RustUdfDateTimeAdapters.DaynameAdapter().adapt(original, List.of(), cluster);
+        assertTrue(adapted instanceof RexCall);
+    }
+
+    /** DAYNAME with an invalid date literal rejects at plan time with the format-hint message. */
+    public void testDaynameAdapterRejectsInvalidDateLiteral() {
+        RexCall original = makeDateFormatCall("2025-13-02");
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> new RustUdfDateTimeAdapters.DaynameAdapter().adapt(original, List.of(), cluster)
+        );
+        assertTrue(
+            "expected unsupported-format hint, got: " + e.getMessage(),
+            e.getMessage().contains("2025-13-02") && e.getMessage().contains("unsupported format")
+        );
+    }
+
+    /** DAYNAME rejects out-of-range time-of-day in a full datetime literal. */
+    public void testDaynameAdapterRejectsInvalidDatetimeLiteral() {
+        RexCall original = makeDateFormatCall("2025-12-01 15:02:61");
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> new RustUdfDateTimeAdapters.DaynameAdapter().adapt(original, List.of(), cluster)
+        );
+        assertTrue(e.getMessage().contains("unsupported format"));
+    }
+
+    /** MONTHNAME with a valid date literal lowers without throwing. */
+    public void testMonthnameAdapterAcceptsValidDateLiteral() {
+        RexCall original = makeDateFormatCall("2020-08-26");
+        RexNode adapted = new RustUdfDateTimeAdapters.MonthnameAdapter().adapt(original, List.of(), cluster);
+        assertTrue(adapted instanceof RexCall);
+    }
+
+    /** MONTHNAME with an invalid date literal rejects at plan time with the format-hint message. */
+    public void testMonthnameAdapterRejectsInvalidDateLiteral() {
+        RexCall original = makeDateFormatCall("2025-13-02");
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> new RustUdfDateTimeAdapters.MonthnameAdapter().adapt(original, List.of(), cluster)
+        );
+        assertTrue(
+            "expected unsupported-format hint, got: " + e.getMessage(),
+            e.getMessage().contains("2025-13-02") && e.getMessage().contains("unsupported format")
+        );
+    }
+
+    /** MONTHNAME rejects out-of-range time-of-day in a full datetime literal — symmetric with DAYNAME's invalid-datetime test. */
+    public void testMonthnameAdapterRejectsInvalidDatetimeLiteral() {
+        RexCall original = makeDateFormatCall("2025-12-01 15:02:61");
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> new RustUdfDateTimeAdapters.MonthnameAdapter().adapt(original, List.of(), cluster)
+        );
+        assertTrue(e.getMessage().contains("unsupported format"));
+    }
+
+    /**
+     * Non-literal operand (column ref) skips validation and passes through unchanged — pins the
+     * {@code validateFirstArgIfStringLiteral} early-exit on non-literal inputs so DAYNAME / MONTHNAME
+     * over a real column doesn't throw plan-time on values the adapter can't statically analyse.
+     */
+    public void testDaynameAdapterNonLiteralOperandSkipsValidation() {
+        RelDataType ts = typeFactory.createSqlType(SqlTypeName.TIMESTAMP);
+        RexNode tsCol = rexBuilder.makeInputRef(ts, 0);
+        RexNode fmt = rexBuilder.makeLiteral("%W", typeFactory.createSqlType(SqlTypeName.VARCHAR), true);
+        RexCall original = (RexCall) rexBuilder.makeCall(
+            typeFactory.createSqlType(SqlTypeName.VARCHAR),
+            RustUdfDateTimeAdapters.LOCAL_DATE_FORMAT_OP,
+            List.of(tsCol, fmt)
+        );
+
+        RexNode adapted = new RustUdfDateTimeAdapters.DaynameAdapter().adapt(original, List.of(), cluster);
+
+        assertTrue("non-literal operand must lower without throwing", adapted instanceof RexCall);
+    }
+
+    /** Builds a {@code date_format(<varchar-literal>, <fmt>)} call shaped like the rewritten DAYNAME / MONTHNAME input. */
+    private RexCall makeDateFormatCall(String literal) {
+        RelDataType varchar = typeFactory.createSqlType(SqlTypeName.VARCHAR);
+        RexNode operand = rexBuilder.makeLiteral(literal, varchar, true);
+        RexNode fmt = rexBuilder.makeLiteral("%W", varchar, true);
+        return (RexCall) rexBuilder.makeCall(varchar, RustUdfDateTimeAdapters.LOCAL_DATE_FORMAT_OP, List.of(operand, fmt));
+    }
 }

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/SubstraitPlanPojoRewriterTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/SubstraitPlanPojoRewriterTests.java
@@ -28,9 +28,9 @@ public class SubstraitPlanPojoRewriterTests extends OpenSearchTestCase {
 
     private static final TypeCreator R = TypeCreator.of(false);
 
-    public void testTimestampPrecision6ConvertedTo3() {
-        long epochMicros = 1704067200000000L; // 2024-01-01T00:00:00Z in micros
-        long expectedMillis = 1704067200000L;
+    public void testTimestampPrecision6Preserved() {
+        // preserve µs precision so cast('… .123456' AS TIMESTAMP) keeps the microsecond fraction
+        long epochMicros = 1704067200123456L;
 
         Expression literal = ImmutableExpression.PrecisionTimestampLiteral.builder()
             .value(epochMicros)
@@ -44,8 +44,8 @@ public class SubstraitPlanPojoRewriterTests extends OpenSearchTestCase {
         Expression condition = getFilterCondition(rewritten);
         assertTrue(condition instanceof Expression.PrecisionTimestampLiteral);
         Expression.PrecisionTimestampLiteral pts = (Expression.PrecisionTimestampLiteral) condition;
-        assertEquals(3, pts.precision());
-        assertEquals(expectedMillis, pts.value());
+        assertEquals(6, pts.precision());
+        assertEquals(epochMicros, pts.value());
     }
 
     public void testTimestampPrecision9ConvertedTo3() {
@@ -62,6 +62,40 @@ public class SubstraitPlanPojoRewriterTests extends OpenSearchTestCase {
         Expression.PrecisionTimestampLiteral pts = (Expression.PrecisionTimestampLiteral) condition;
         assertEquals(3, pts.precision());
         assertEquals(expectedMillis, pts.value());
+    }
+
+    public void testTimestampPrecision6PreservedInsideScalarFunction() {
+        // µs literals inside e.g. cast(varchar -> timestamp) projections must keep their precision
+        long epochMicros = 1696161600123456L;
+
+        Expression tsLiteral = ImmutableExpression.PrecisionTimestampLiteral.builder()
+            .value(epochMicros)
+            .precision(6)
+            .nullable(false)
+            .build();
+
+        FieldReference fieldRef = FieldReference.newRootStructReference(0, R.precisionTimestamp(3));
+
+        SimpleExtension.ExtensionCollection extensions = DefaultExtensionCatalog.DEFAULT_COLLECTION;
+        SimpleExtension.ScalarFunctionVariant gtFunc = extensions.getScalarFunction(
+            SimpleExtension.FunctionAnchor.of(DefaultExtensionCatalog.FUNCTIONS_COMPARISON, "gt:any_any")
+        );
+
+        Expression gtCall = Expression.ScalarFunctionInvocation.builder()
+            .declaration(gtFunc)
+            .addArguments(fieldRef, tsLiteral)
+            .outputType(R.BOOLEAN)
+            .build();
+
+        Plan plan = buildFilterPlan(gtCall);
+        Plan rewritten = SubstraitPlanPojoRewriter.rewrite(plan);
+
+        Expression condition = getFilterCondition(rewritten);
+        Expression.ScalarFunctionInvocation rewrittenGt = (Expression.ScalarFunctionInvocation) condition;
+        Expression arg1 = (Expression) rewrittenGt.arguments().get(1);
+        Expression.PrecisionTimestampLiteral pts = (Expression.PrecisionTimestampLiteral) arg1;
+        assertEquals(6, pts.precision());
+        assertEquals(epochMicros, pts.value());
     }
 
     public void testTimestampPrecision3Unchanged() {
@@ -83,13 +117,14 @@ public class SubstraitPlanPojoRewriterTests extends OpenSearchTestCase {
         assertEquals(epochMillis, pts.value());
     }
 
-    public void testTimestampInsideScalarFunction() {
-        long epochMicros = 1704067200000000L;
-        long expectedMillis = 1704067200000L;
+    public void testTimestampPrecision9InsideScalarFunctionConvertedTo3() {
+        // ns-precision literal in a function arg is still coerced to ms — DataFusion can't compare ns against parquet ms storage
+        long epochNanos = 1704067200123456789L;
+        long expectedMillis = 1704067200123L;
 
         Expression tsLiteral = ImmutableExpression.PrecisionTimestampLiteral.builder()
-            .value(epochMicros)
-            .precision(6)
+            .value(epochNanos)
+            .precision(9)
             .nullable(false)
             .build();
 
@@ -132,11 +167,18 @@ public class SubstraitPlanPojoRewriterTests extends OpenSearchTestCase {
         assertEquals(List.of("parquet_dates"), rewrittenScan.getNames());
     }
 
-    public void testUnsupportedPrecisionThrows() {
-        Expression literal = ImmutableExpression.PrecisionTimestampLiteral.builder().value(12345L).precision(4).nullable(false).build();
+    public void testNonStandardPrecisionUnchanged() {
+        // only precision 9 is rewritten now; other precisions pass through untouched
+        Expression literal = ImmutableExpression.PrecisionTimestampLiteral.builder().value(12345L).precision(0).nullable(false).build();
 
         Plan plan = buildFilterPlan(literal);
-        expectThrows(IllegalArgumentException.class, () -> SubstraitPlanPojoRewriter.rewrite(plan));
+        Plan rewritten = SubstraitPlanPojoRewriter.rewrite(plan);
+
+        Expression condition = getFilterCondition(rewritten);
+        assertTrue(condition instanceof Expression.PrecisionTimestampLiteral);
+        Expression.PrecisionTimestampLiteral pts = (Expression.PrecisionTimestampLiteral) condition;
+        assertEquals(0, pts.precision());
+        assertEquals(12345L, pts.value());
     }
 
     // --- VarCharLiteral → StrLiteral tests ---

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/SubstraitPlanPojoRewriterTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/SubstraitPlanPojoRewriterTests.java
@@ -28,9 +28,9 @@ public class SubstraitPlanPojoRewriterTests extends OpenSearchTestCase {
 
     private static final TypeCreator R = TypeCreator.of(false);
 
-    public void testTimestampPrecision6Preserved() {
-        // preserve µs precision so cast('… .123456' AS TIMESTAMP) keeps the microsecond fraction
-        long epochMicros = 1704067200123456L;
+    /** precision-6 literal passes through unchanged — DataFusion handles coercion against ms columns. */
+    public void testTimestampPrecision6PassThrough() {
+        long epochMicros = 1704067200000000L;
 
         Expression literal = ImmutableExpression.PrecisionTimestampLiteral.builder()
             .value(epochMicros)
@@ -38,64 +38,23 @@ public class SubstraitPlanPojoRewriterTests extends OpenSearchTestCase {
             .nullable(false)
             .build();
 
-        Plan plan = buildFilterPlan(literal);
-        Plan rewritten = SubstraitPlanPojoRewriter.rewrite(plan);
+        Plan rewritten = SubstraitPlanPojoRewriter.rewrite(buildFilterPlan(literal));
 
-        Expression condition = getFilterCondition(rewritten);
-        assertTrue(condition instanceof Expression.PrecisionTimestampLiteral);
-        Expression.PrecisionTimestampLiteral pts = (Expression.PrecisionTimestampLiteral) condition;
+        Expression.PrecisionTimestampLiteral pts = (Expression.PrecisionTimestampLiteral) getFilterCondition(rewritten);
         assertEquals(6, pts.precision());
         assertEquals(epochMicros, pts.value());
     }
 
-    public void testTimestampPrecision9ConvertedTo3() {
-        long epochNanos = 1704067200000000000L; // 2024-01-01T00:00:00Z in nanos
-        long expectedMillis = 1704067200000L;
+    public void testTimestampPrecision9PassThrough() {
+        long epochNanos = 1704067200000000000L;
 
         Expression literal = ImmutableExpression.PrecisionTimestampLiteral.builder().value(epochNanos).precision(9).nullable(false).build();
 
-        Plan plan = buildFilterPlan(literal);
-        Plan rewritten = SubstraitPlanPojoRewriter.rewrite(plan);
+        Plan rewritten = SubstraitPlanPojoRewriter.rewrite(buildFilterPlan(literal));
 
-        Expression condition = getFilterCondition(rewritten);
-        assertTrue(condition instanceof Expression.PrecisionTimestampLiteral);
-        Expression.PrecisionTimestampLiteral pts = (Expression.PrecisionTimestampLiteral) condition;
-        assertEquals(3, pts.precision());
-        assertEquals(expectedMillis, pts.value());
-    }
-
-    public void testTimestampPrecision6PreservedInsideScalarFunction() {
-        // µs literals inside e.g. cast(varchar -> timestamp) projections must keep their precision
-        long epochMicros = 1696161600123456L;
-
-        Expression tsLiteral = ImmutableExpression.PrecisionTimestampLiteral.builder()
-            .value(epochMicros)
-            .precision(6)
-            .nullable(false)
-            .build();
-
-        FieldReference fieldRef = FieldReference.newRootStructReference(0, R.precisionTimestamp(3));
-
-        SimpleExtension.ExtensionCollection extensions = DefaultExtensionCatalog.DEFAULT_COLLECTION;
-        SimpleExtension.ScalarFunctionVariant gtFunc = extensions.getScalarFunction(
-            SimpleExtension.FunctionAnchor.of(DefaultExtensionCatalog.FUNCTIONS_COMPARISON, "gt:any_any")
-        );
-
-        Expression gtCall = Expression.ScalarFunctionInvocation.builder()
-            .declaration(gtFunc)
-            .addArguments(fieldRef, tsLiteral)
-            .outputType(R.BOOLEAN)
-            .build();
-
-        Plan plan = buildFilterPlan(gtCall);
-        Plan rewritten = SubstraitPlanPojoRewriter.rewrite(plan);
-
-        Expression condition = getFilterCondition(rewritten);
-        Expression.ScalarFunctionInvocation rewrittenGt = (Expression.ScalarFunctionInvocation) condition;
-        Expression arg1 = (Expression) rewrittenGt.arguments().get(1);
-        Expression.PrecisionTimestampLiteral pts = (Expression.PrecisionTimestampLiteral) arg1;
-        assertEquals(6, pts.precision());
-        assertEquals(epochMicros, pts.value());
+        Expression.PrecisionTimestampLiteral pts = (Expression.PrecisionTimestampLiteral) getFilterCondition(rewritten);
+        assertEquals(9, pts.precision());
+        assertEquals(epochNanos, pts.value());
     }
 
     public void testTimestampPrecision3Unchanged() {
@@ -107,24 +66,20 @@ public class SubstraitPlanPojoRewriterTests extends OpenSearchTestCase {
             .nullable(false)
             .build();
 
-        Plan plan = buildFilterPlan(literal);
-        Plan rewritten = SubstraitPlanPojoRewriter.rewrite(plan);
+        Plan rewritten = SubstraitPlanPojoRewriter.rewrite(buildFilterPlan(literal));
 
-        Expression condition = getFilterCondition(rewritten);
-        assertTrue(condition instanceof Expression.PrecisionTimestampLiteral);
-        Expression.PrecisionTimestampLiteral pts = (Expression.PrecisionTimestampLiteral) condition;
+        Expression.PrecisionTimestampLiteral pts = (Expression.PrecisionTimestampLiteral) getFilterCondition(rewritten);
         assertEquals(3, pts.precision());
         assertEquals(epochMillis, pts.value());
     }
 
-    public void testTimestampPrecision9InsideScalarFunctionConvertedTo3() {
-        // ns-precision literal in a function arg is still coerced to ms — DataFusion can't compare ns against parquet ms storage
-        long epochNanos = 1704067200123456789L;
-        long expectedMillis = 1704067200123L;
+    public void testTimestampInsideScalarFunction() {
+        // Rewriter walks into scalar-function arguments but no longer touches timestamp literals.
+        long epochMicros = 1704067200000000L;
 
         Expression tsLiteral = ImmutableExpression.PrecisionTimestampLiteral.builder()
-            .value(epochNanos)
-            .precision(9)
+            .value(epochMicros)
+            .precision(6)
             .nullable(false)
             .build();
 
@@ -141,17 +96,12 @@ public class SubstraitPlanPojoRewriterTests extends OpenSearchTestCase {
             .outputType(R.BOOLEAN)
             .build();
 
-        Plan plan = buildFilterPlan(gtCall);
-        Plan rewritten = SubstraitPlanPojoRewriter.rewrite(plan);
+        Plan rewritten = SubstraitPlanPojoRewriter.rewrite(buildFilterPlan(gtCall));
 
-        Expression condition = getFilterCondition(rewritten);
-        assertTrue(condition instanceof Expression.ScalarFunctionInvocation);
-        Expression.ScalarFunctionInvocation rewrittenGt = (Expression.ScalarFunctionInvocation) condition;
-        Expression arg1 = (Expression) rewrittenGt.arguments().get(1);
-        assertTrue(arg1 instanceof Expression.PrecisionTimestampLiteral);
-        Expression.PrecisionTimestampLiteral pts = (Expression.PrecisionTimestampLiteral) arg1;
-        assertEquals(3, pts.precision());
-        assertEquals(expectedMillis, pts.value());
+        Expression.ScalarFunctionInvocation rewrittenGt = (Expression.ScalarFunctionInvocation) getFilterCondition(rewritten);
+        Expression.PrecisionTimestampLiteral arg1 = (Expression.PrecisionTimestampLiteral) rewrittenGt.arguments().get(1);
+        assertEquals(6, arg1.precision());
+        assertEquals(epochMicros, arg1.value());
     }
 
     public void testBareNameUnchanged() {
@@ -165,20 +115,6 @@ public class SubstraitPlanPojoRewriterTests extends OpenSearchTestCase {
 
         NamedScan rewrittenScan = (NamedScan) rewritten.getRoots().get(0).getInput();
         assertEquals(List.of("parquet_dates"), rewrittenScan.getNames());
-    }
-
-    public void testNonStandardPrecisionUnchanged() {
-        // only precision 9 is rewritten now; other precisions pass through untouched
-        Expression literal = ImmutableExpression.PrecisionTimestampLiteral.builder().value(12345L).precision(0).nullable(false).build();
-
-        Plan plan = buildFilterPlan(literal);
-        Plan rewritten = SubstraitPlanPojoRewriter.rewrite(plan);
-
-        Expression condition = getFilterCondition(rewritten);
-        assertTrue(condition instanceof Expression.PrecisionTimestampLiteral);
-        Expression.PrecisionTimestampLiteral pts = (Expression.PrecisionTimestampLiteral) condition;
-        assertEquals(0, pts.precision());
-        assertEquals(12345L, pts.value());
     }
 
     // --- VarCharLiteral → StrLiteral tests ---

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/TimeArithmeticAdapterTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/TimeArithmeticAdapterTests.java
@@ -1,0 +1,205 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion;
+
+import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.hep.HepPlanner;
+import org.apache.calcite.plan.hep.HepProgramBuilder;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlFunction;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.type.OperandTypes;
+import org.apache.calcite.sql.type.ReturnTypes;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.List;
+
+/**
+ * Unit tests for {@link AddSubTimeAdapter}, {@link TimeDiffAdapter}, and {@link GetFormatAdapter}.
+ * Shape-level assertions; exact values are covered by the QA ITs.
+ */
+public class TimeArithmeticAdapterTests extends OpenSearchTestCase {
+
+    private RelDataTypeFactory typeFactory;
+    private RexBuilder rexBuilder;
+    private RelOptCluster cluster;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        typeFactory = new JavaTypeFactoryImpl();
+        rexBuilder = new RexBuilder(typeFactory);
+        HepPlanner planner = new HepPlanner(new HepProgramBuilder().build());
+        cluster = RelOptCluster.create(planner, rexBuilder);
+    }
+
+    private static RexCall findOp(RexNode node, SqlOperator operator) {
+        if (node instanceof RexCall call) {
+            if (call.getOperator() == operator) {
+                return call;
+            }
+            for (RexNode op : call.getOperands()) {
+                RexCall found = findOp(op, operator);
+                if (found != null) {
+                    return found;
+                }
+            }
+        }
+        return null;
+    }
+
+    private RelDataType nullable(SqlTypeName t) {
+        return typeFactory.createTypeWithNullability(typeFactory.createSqlType(t), true);
+    }
+
+    private RexCall binaryCall(String name, RelDataType returnType, SqlTypeName op0, SqlTypeName op1) {
+        SqlFunction op = new SqlFunction(
+            name,
+            SqlKind.OTHER_FUNCTION,
+            ReturnTypes.explicit(returnType),
+            null,
+            OperandTypes.ANY_ANY,
+            SqlFunctionCategory.TIMEDATE
+        );
+        RexNode a = rexBuilder.makeInputRef(nullable(op0), 0);
+        RexNode b = rexBuilder.makeInputRef(nullable(op1), 1);
+        return (RexCall) rexBuilder.makeCall(returnType, op, List.of(a, b));
+    }
+
+    /** ADDTIME with a TIME result builds the value via maketime (not a CAST to TIME). */
+    public void testAddTimeTimeResultUsesMaketime() {
+        RexCall call = binaryCall("ADDTIME", nullable(SqlTypeName.TIME), SqlTypeName.TIME, SqlTypeName.TIME);
+        RexNode result = new AddSubTimeAdapter(true).adapt(call, List.of(), cluster);
+        assertTrue(result != call);
+        assertNotNull("TIME result must use maketime", findOp(result, RustUdfDateTimeAdapters.LOCAL_MAKETIME_OP));
+    }
+
+    /** ADDTIME with a TIMESTAMP result goes through from_unixtime epoch arithmetic. */
+    public void testAddTimeTimestampResultUsesFromUnixtime() {
+        RexCall call = binaryCall("ADDTIME", nullable(SqlTypeName.TIMESTAMP), SqlTypeName.TIMESTAMP, SqlTypeName.TIMESTAMP);
+        RexNode result = new AddSubTimeAdapter(true).adapt(call, List.of(), cluster);
+        assertTrue(result != call);
+        assertNotNull("TIMESTAMP result must use from_unixtime", findOp(result, RustUdfDateTimeAdapters.LOCAL_FROM_UNIXTIME_OP));
+        assertNotNull("must read operand epochs via to_unixtime", findOp(result, UnixTimestampAdapter.LOCAL_TO_UNIXTIME_OP));
+    }
+
+    /** SUBTIME on a TIMESTAMP subtracts the delta (a MINUS appears over the epoch sum). */
+    public void testSubTimeTimestampUsesMinus() {
+        RexCall call = binaryCall("SUBTIME", nullable(SqlTypeName.TIMESTAMP), SqlTypeName.TIMESTAMP, SqlTypeName.TIMESTAMP);
+        RexNode result = new AddSubTimeAdapter(false).adapt(call, List.of(), cluster);
+        assertTrue(result != call);
+        assertNotNull("subtract path must contain a MINUS", findOp(result, SqlStdOperatorTable.MINUS));
+    }
+
+    public void testTimeDiffUsesMaketimeOverMinus() {
+        RexCall call = binaryCall("TIME_DIFF", nullable(SqlTypeName.TIME), SqlTypeName.TIME, SqlTypeName.TIME);
+        RexNode result = new TimeDiffAdapter().adapt(call, List.of(), cluster);
+        assertTrue(result != call);
+        assertNotNull("TIMEDIFF must build a TIME via maketime", findOp(result, RustUdfDateTimeAdapters.LOCAL_MAKETIME_OP));
+        assertNotNull("TIMEDIFF subtracts the two seconds-of-day", findOp(result, SqlStdOperatorTable.MINUS));
+    }
+
+    public void testGetFormatFoldsToLiteral() {
+        RelDataType varchar = nullable(SqlTypeName.VARCHAR);
+        SqlFunction op = new SqlFunction(
+            "GET_FORMAT",
+            SqlKind.OTHER_FUNCTION,
+            ReturnTypes.explicit(varchar),
+            null,
+            OperandTypes.ANY_ANY,
+            SqlFunctionCategory.TIMEDATE
+        );
+        RexNode type = rexBuilder.makeLiteral("DATE", typeFactory.createSqlType(SqlTypeName.VARCHAR), true);
+        RexNode region = rexBuilder.makeLiteral("USA", typeFactory.createSqlType(SqlTypeName.VARCHAR), true);
+        RexCall call = (RexCall) rexBuilder.makeCall(varchar, op, List.of(type, region));
+        RexNode result = new GetFormatAdapter().adapt(call, List.of(), cluster);
+        // makeLiteral with a nullable type wraps the literal in a CAST; unwrap to the inner literal.
+        RexLiteral literal = asLiteral(result);
+        assertNotNull("GET_FORMAT must fold to a (possibly cast-wrapped) literal", literal);
+        assertEquals("%m.%d.%Y", literal.getValueAs(String.class));
+    }
+
+    private static RexLiteral asLiteral(RexNode node) {
+        if (node instanceof RexLiteral literal) {
+            return literal;
+        }
+        if (node instanceof RexCall call && call.getKind() == SqlKind.CAST && call.getOperands().size() == 1) {
+            return asLiteral(call.getOperands().get(0));
+        }
+        return null;
+    }
+
+    /**
+     * GET_FORMAT(DATETIME, ...) re-maps the type key to TIMESTAMP under the hood — DATETIME is a
+     * MySQL alias of TIMESTAMP and shares the same five region entries.
+     */
+    public void testGetFormatDatetimeAliasResolvesToTimestampEntry() {
+        RelDataType varchar = nullable(SqlTypeName.VARCHAR);
+        SqlFunction op = new SqlFunction(
+            "GET_FORMAT",
+            SqlKind.OTHER_FUNCTION,
+            ReturnTypes.explicit(varchar),
+            null,
+            OperandTypes.ANY_ANY,
+            SqlFunctionCategory.TIMEDATE
+        );
+        RexNode type = rexBuilder.makeLiteral("DATETIME", typeFactory.createSqlType(SqlTypeName.VARCHAR), true);
+        RexNode region = rexBuilder.makeLiteral("ISO", typeFactory.createSqlType(SqlTypeName.VARCHAR), true);
+        RexCall call = (RexCall) rexBuilder.makeCall(varchar, op, List.of(type, region));
+        RexNode result = new GetFormatAdapter().adapt(call, List.of(), cluster);
+        RexLiteral literal = asLiteral(result);
+        assertNotNull("GET_FORMAT(DATETIME, ISO) must fold to the TIMESTAMP|ISO format", literal);
+        assertEquals("%Y-%m-%d %H:%i:%s", literal.getValueAs(String.class));
+    }
+
+    /** A non-literal first operand prevents plan-time fold; the call passes through unchanged. */
+    public void testGetFormatNonLiteralOperandPassesThrough() {
+        RelDataType varchar = nullable(SqlTypeName.VARCHAR);
+        SqlFunction op = new SqlFunction(
+            "GET_FORMAT",
+            SqlKind.OTHER_FUNCTION,
+            ReturnTypes.explicit(varchar),
+            null,
+            OperandTypes.ANY_ANY,
+            SqlFunctionCategory.TIMEDATE
+        );
+        RexNode columnRef = rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.VARCHAR), 0);
+        RexNode region = rexBuilder.makeLiteral("USA", typeFactory.createSqlType(SqlTypeName.VARCHAR), true);
+        RexCall call = (RexCall) rexBuilder.makeCall(varchar, op, List.of(columnRef, region));
+        RexNode result = new GetFormatAdapter().adapt(call, List.of(), cluster);
+        assertSame("non-literal type operand must leave GET_FORMAT unchanged", call, result);
+    }
+
+    public void testGetFormatUnknownPairPassesThrough() {
+        RelDataType varchar = nullable(SqlTypeName.VARCHAR);
+        SqlFunction op = new SqlFunction(
+            "GET_FORMAT",
+            SqlKind.OTHER_FUNCTION,
+            ReturnTypes.explicit(varchar),
+            null,
+            OperandTypes.ANY_ANY,
+            SqlFunctionCategory.TIMEDATE
+        );
+        RexNode type = rexBuilder.makeLiteral("DATE", typeFactory.createSqlType(SqlTypeName.VARCHAR), true);
+        RexNode region = rexBuilder.makeLiteral("BOGUS", typeFactory.createSqlType(SqlTypeName.VARCHAR), true);
+        RexCall call = (RexCall) rexBuilder.makeCall(varchar, op, List.of(type, region));
+        RexNode result = new GetFormatAdapter().adapt(call, List.of(), cluster);
+        assertSame("unknown (type, region) must pass through unchanged", call, result);
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/TimeFormatAdapterTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/TimeFormatAdapterTests.java
@@ -1,0 +1,116 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion;
+
+import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.hep.HepPlanner;
+import org.apache.calcite.plan.hep.HepProgramBuilder;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlFunction;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.type.OperandTypes;
+import org.apache.calcite.sql.type.ReturnTypes;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.List;
+
+/**
+ * Unit tests for {@link RustUdfDateTimeAdapters.TimeFormatAdapter}. The adapter must coerce a
+ * stock-Calcite {@code TIME} first operand to {@code TIMESTAMP} before isthmus serialises it,
+ * because substrait-java 0.89.1 has no {@code precision_time<P>} signature in the yaml. Other
+ * operand kinds (TIMESTAMP, DATE, VARCHAR) bind directly and must pass through unchanged.
+ */
+public class TimeFormatAdapterTests extends OpenSearchTestCase {
+
+    private RelDataTypeFactory typeFactory;
+    private RexBuilder rexBuilder;
+    private RelOptCluster cluster;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        typeFactory = new JavaTypeFactoryImpl();
+        rexBuilder = new RexBuilder(typeFactory);
+        HepPlanner planner = new HepPlanner(new HepProgramBuilder().build());
+        cluster = RelOptCluster.create(planner, rexBuilder);
+    }
+
+    private RelDataType nullable(SqlTypeName t) {
+        return typeFactory.createTypeWithNullability(typeFactory.createSqlType(t), true);
+    }
+
+    private RexCall timeFormatCall(SqlTypeName firstOperandType) {
+        SqlFunction op = new SqlFunction(
+            "TIME_FORMAT",
+            SqlKind.OTHER_FUNCTION,
+            ReturnTypes.VARCHAR_NULLABLE,
+            null,
+            OperandTypes.ANY_ANY,
+            SqlFunctionCategory.TIMEDATE
+        );
+        RexNode value = rexBuilder.makeInputRef(nullable(firstOperandType), 0);
+        RexNode fmt = rexBuilder.makeLiteral("%H:%i:%s", typeFactory.createSqlType(SqlTypeName.VARCHAR), true);
+        return (RexCall) rexBuilder.makeCall(nullable(SqlTypeName.VARCHAR), op, List.of(value, fmt));
+    }
+
+    /**
+     * TIME first operand triggers the today-anchor coercion: the rewritten call's first operand
+     * is TIMESTAMP-typed, so isthmus binds the {@code time_format(precision_timestamp<P>, string)}
+     * yaml arm instead of failing on {@code precision_time<P>}.
+     */
+    public void testTimeOperandCoercedToTimestamp() {
+        RexCall call = timeFormatCall(SqlTypeName.TIME);
+        RexNode result = new RustUdfDateTimeAdapters.TimeFormatAdapter().adapt(call, List.of(), cluster);
+
+        assertTrue("rewrite must produce a RexCall", result instanceof RexCall);
+        RexCall rewritten = (RexCall) result;
+        assertSame("operator must remain time_format", RustUdfDateTimeAdapters.LOCAL_TIME_FORMAT_OP, rewritten.getOperator());
+        assertEquals(
+            "first operand must be TIMESTAMP after coercion",
+            SqlTypeName.TIMESTAMP,
+            rewritten.getOperands().get(0).getType().getSqlTypeName()
+        );
+        assertEquals("format-string operand must pass through unchanged at index 1", 2, rewritten.getOperands().size());
+    }
+
+    /** TIMESTAMP first operand binds directly to the yaml — no coercion, parent {@code adapt} runs. */
+    public void testTimestampOperandPassesThroughUnchanged() {
+        RexCall call = timeFormatCall(SqlTypeName.TIMESTAMP);
+        RexNode result = new RustUdfDateTimeAdapters.TimeFormatAdapter().adapt(call, List.of(), cluster);
+
+        RexCall rewritten = (RexCall) result;
+        assertSame(RustUdfDateTimeAdapters.LOCAL_TIME_FORMAT_OP, rewritten.getOperator());
+        assertEquals(
+            "TIMESTAMP operand must remain TIMESTAMP",
+            SqlTypeName.TIMESTAMP,
+            rewritten.getOperands().get(0).getType().getSqlTypeName()
+        );
+    }
+
+    /** VARCHAR first operand must not trip the TIME coercion path. */
+    public void testVarcharOperandSkipsCoercion() {
+        RexCall call = timeFormatCall(SqlTypeName.VARCHAR);
+        RexNode result = new RustUdfDateTimeAdapters.TimeFormatAdapter().adapt(call, List.of(), cluster);
+
+        RexCall rewritten = (RexCall) result;
+        assertSame(RustUdfDateTimeAdapters.LOCAL_TIME_FORMAT_OP, rewritten.getOperator());
+        assertEquals(
+            "VARCHAR operand must remain VARCHAR (not coerced to TIMESTAMP)",
+            SqlTypeName.VARCHAR,
+            rewritten.getOperands().get(0).getType().getSqlTypeName()
+        );
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/TimeOfDayLoweringTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/TimeOfDayLoweringTests.java
@@ -1,0 +1,141 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion;
+
+import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.hep.HepPlanner;
+import org.apache.calcite.plan.hep.HepProgramBuilder;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.opensearch.test.OpenSearchTestCase;
+
+/**
+ * Unit tests for {@link TimeOfDayLowering}. The two helpers each emit a floor-mod chain
+ * ({@code ((s MOD 86400) + 86400) MOD 86400}) so negative epochs (pre-1970) wrap the MySQL way
+ * rather than yielding a negative seconds-of-day. The shape these tests pin is the number of
+ * {@code MOD} / {@code PLUS} / {@code DIVIDE} nodes — exact numeric values come out at runtime
+ * and are covered by the QA ITs (e.g. {@code testSecToTimeWrapsOverOneDay}).
+ */
+public class TimeOfDayLoweringTests extends OpenSearchTestCase {
+
+    private RelDataTypeFactory typeFactory;
+    private RexBuilder rexBuilder;
+    private RelOptCluster cluster;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        typeFactory = new JavaTypeFactoryImpl();
+        rexBuilder = new RexBuilder(typeFactory);
+        HepPlanner planner = new HepPlanner(new HepProgramBuilder().build());
+        cluster = RelOptCluster.create(planner, rexBuilder);
+    }
+
+    private static int countOps(RexNode node, SqlOperator operator) {
+        if (!(node instanceof RexCall call)) {
+            return 0;
+        }
+        int sum = call.getOperator() == operator ? 1 : 0;
+        for (RexNode op : call.getOperands()) {
+            sum += countOps(op, operator);
+        }
+        return sum;
+    }
+
+    private static RexCall findOp(RexNode node, SqlOperator operator) {
+        if (node instanceof RexCall call) {
+            if (call.getOperator() == operator) {
+                return call;
+            }
+            for (RexNode op : call.getOperands()) {
+                RexCall found = findOp(op, operator);
+                if (found != null) {
+                    return found;
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * {@code secondsOfDay(timestamp)} emits the floor-mod chain
+     * {@code ((to_unixtime(x) MOD 86400) + 86400) MOD 86400} — exactly two MODs and one PLUS, with
+     * a single {@code to_unixtime} reading the operand once.
+     */
+    public void testSecondsOfDayEmitsFloorModChain() {
+        RelDataType ts = typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.TIMESTAMP), true);
+        RexNode operand = rexBuilder.makeInputRef(ts, 0);
+
+        RexNode result = TimeOfDayLowering.secondsOfDay(operand, cluster);
+
+        assertEquals("floor-mod requires exactly 2 MOD ops", 2, countOps(result, SqlStdOperatorTable.MOD));
+        assertEquals("floor-mod requires exactly 1 PLUS op", 1, countOps(result, SqlStdOperatorTable.PLUS));
+        assertEquals("operand should be read via to_unixtime once", 1, countOps(result, UnixTimestampAdapter.LOCAL_TO_UNIXTIME_OP));
+    }
+
+    /**
+     * {@code secondsToTime} emits a normalized hour/minute/second decomposition wrapped in a
+     * {@code maketime} call. The hour/minute/second branches each reference {@code norm} (the
+     * floor-mod chain {@code ((s MOD 86400) + 86400) MOD 86400}) independently — RexNode trees
+     * don't share subtrees, so the chain is duplicated three times: 3 × (2 MOD + 1 PLUS) = 6
+     * MOD + 3 PLUS from the floor-mod chains, plus 2 extra MODs for the minute/second tails
+     * = 8 MOD total. Two DIVIDEs: hour = norm/3600 and minute = (norm % 3600) / 60.
+     */
+    public void testSecondsToTimeNormalizesAndBuildsMaketime() {
+        RelDataType bigint = typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.BIGINT), true);
+        RelDataType time = typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.TIME), true);
+        RexNode seconds = rexBuilder.makeInputRef(bigint, 0);
+
+        RexNode result = TimeOfDayLowering.secondsToTime(seconds, time, cluster);
+
+        assertTrue("result must be a RexCall", result instanceof RexCall);
+        RexCall top = (RexCall) result;
+        assertSame("maketime must be the top of the rewrite", RustUdfDateTimeAdapters.LOCAL_MAKETIME_OP, top.getOperator());
+        assertEquals("maketime takes (hour, minute, second)", 3, top.getOperands().size());
+        // 3 × floor-mod chain (each branch references `norm` independently) + 2 minute/second tails.
+        assertEquals("expected 8 MOD ops (3× floor-mod + minute-mod + second-mod)", 8, countOps(result, SqlStdOperatorTable.MOD));
+        assertEquals("expected 3 PLUS ops (floor-mod +86400 in each of 3 branches)", 3, countOps(result, SqlStdOperatorTable.PLUS));
+        assertEquals("expected 2 DIVIDE ops (hour and minute)", 2, countOps(result, SqlStdOperatorTable.DIVIDE));
+    }
+
+    /** {@code secondsToTime} preserves the caller's TIME type on the maketime call's return. */
+    public void testSecondsToTimeReturnTypeMatchesCallerType() {
+        RelDataType bigint = typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.BIGINT), true);
+        RelDataType time = typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.TIME), true);
+        RexNode seconds = rexBuilder.makeInputRef(bigint, 0);
+
+        RexNode result = TimeOfDayLowering.secondsToTime(seconds, time, cluster);
+
+        assertEquals("result type must equal the timeType arg", time, result.getType());
+    }
+
+    /** {@code secondsOfDay} on a VARCHAR / TIME operand routes through coerceCharacterOperandToTimestamp. */
+    public void testSecondsOfDayAnchorsCharacterOperand() {
+        RelDataType varchar = typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.VARCHAR), true);
+        RexNode operand = rexBuilder.makeInputRef(varchar, 0);
+
+        RexNode result = TimeOfDayLowering.secondsOfDay(operand, cluster);
+
+        // Anchoring path emits CONCAT('today', ...) / CAST AS TIMESTAMP — to_unixtime sees a TIMESTAMP, not VARCHAR.
+        RexCall toUnixtime = findOp(result, UnixTimestampAdapter.LOCAL_TO_UNIXTIME_OP);
+        assertNotNull("expected to_unixtime in the rewrite", toUnixtime);
+        assertNotEquals(
+            "to_unixtime operand must be anchored, not the raw VARCHAR",
+            SqlTypeName.VARCHAR,
+            toUnixtime.getOperands().get(0).getType().getSqlTypeName()
+        );
+    }
+}

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/ArrowValues.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/ArrowValues.java
@@ -23,6 +23,8 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.temporal.ChronoField;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -34,10 +36,15 @@ import java.util.regex.Pattern;
 public final class ArrowValues {
 
     // Space-separator output matches the SQL plugin's ExprTimestampValue.
+    // Variable-fraction (1..9 digits, trailing zeros stripped) matches DATE_TIME_FORMATTER_VARIABLE_NANOS.
     private static final DateTimeFormatter TIMESTAMP_NO_NANO = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss", Locale.ROOT);
-    private static final DateTimeFormatter TIMESTAMP_WITH_NANO = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSSSSSSS", Locale.ROOT);
+    private static final DateTimeFormatter TIMESTAMP_WITH_NANO = new DateTimeFormatterBuilder().appendPattern("yyyy-MM-dd HH:mm:ss")
+        .appendFraction(ChronoField.NANO_OF_SECOND, 1, 9, true)
+        .toFormatter(Locale.ROOT);
     private static final DateTimeFormatter TIME_NO_NANO = DateTimeFormatter.ofPattern("HH:mm:ss", Locale.ROOT);
-    private static final DateTimeFormatter TIME_WITH_NANO = DateTimeFormatter.ofPattern("HH:mm:ss.SSSSSSSSS", Locale.ROOT);
+    private static final DateTimeFormatter TIME_WITH_NANO = new DateTimeFormatterBuilder().appendPattern("HH:mm:ss")
+        .appendFraction(ChronoField.NANO_OF_SECOND, 1, 9, true)
+        .toFormatter(Locale.ROOT);
     // DataFusion CAST(temporal AS VARCHAR) — date and time joined by 'T', optional fraction.
     private static final Pattern ISO_TIMESTAMP_T = Pattern.compile("^(\\d{4}-\\d{2}-\\d{2})T(\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?)$");
 

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/ArrowValuesTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/ArrowValuesTests.java
@@ -127,7 +127,7 @@ public class ArrowValuesTests extends OpenSearchTestCase {
             v.allocateNew(1);
             v.set(0, 27_605_123_456L);
             v.setValueCount(1);
-            assertEquals("07:40:05.123456000", ArrowValues.toJavaValue(v, 0));
+            assertEquals("07:40:05.123456", ArrowValues.toJavaValue(v, 0));
         }
     }
 
@@ -172,7 +172,7 @@ public class ArrowValuesTests extends OpenSearchTestCase {
             v.allocateNew(1);
             v.set(0, 1_780_731_605_123_456L);
             v.setValueCount(1);
-            assertEquals("2026-06-06 07:40:05.123456000", ArrowValues.toJavaValue(v, 0));
+            assertEquals("2026-06-06 07:40:05.123456", ArrowValues.toJavaValue(v, 0));
         }
     }
 

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/ConditionalFunctionsIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/ConditionalFunctionsIT.java
@@ -381,6 +381,23 @@ public class ConditionalFunctionsIT extends AnalyticsRestTestCase {
         );
     }
 
+    /**
+     * Regression: {@code earliest} inside an {@code eval} (Project context) over a non-null
+     * TIMESTAMP column. The {@code datetime0} column is non-null, and a folded TIMESTAMP literal
+     * is also non-null, so the comparison's inferred return type is {@code BOOLEAN NOT NULL}
+     * — but the {@code earliest} call was declared nullable BOOLEAN. Without the type-pinning
+     * cast in {@code EarliestLatestAdapter}, the enclosing Project's cached rowType (nullable
+     * BOOLEAN) trips Calcite's {@code BOOLEAN vs BOOLEAN NOT NULL} assertion at execution.
+     * All 17 calcs rows have {@code datetime0 >= 1900-01-01}, so the predicate is true everywhere.
+     */
+    public void testEarliestInProjectOverNotNullTimestampDoesNotCrash() throws IOException {
+        assertFirstRowLong(
+            "source = " + DATASET.indexName + " | eval is_after = earliest('1900-01-01 00:00:00', `datetime0`)"
+                + " | where is_after | stats count() as cnt",
+            17L
+        );
+    }
+
     // ── helpers ─────────────────────────────────────────────────────────────
 
     private void assertFirstRowString(String ppl, String expected) throws IOException {

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/DateTimeScalarFunctionsIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/DateTimeScalarFunctionsIT.java
@@ -394,6 +394,216 @@ public class DateTimeScalarFunctionsIT extends AnalyticsRestTestCase {
         );
     }
 
+    // ── New PPL datetime scalars (ADDDATE/SUBDATE, DATEDIFF, TO_DAYS/TO_SECONDS/FROM_DAYS, ──────
+    //    TIME_TO_SEC/SEC_TO_TIME, WEEKDAY, PERIOD_ADD/PERIOD_DIFF, GET_FORMAT, ADDTIME/SUBTIME/
+    //    TIMEDIFF, LAST_DAY, YEARWEEK) — pin MySQL semantics that the q-suite smoke tests don't.
+
+    /** ADDTIME(timestamp, time) crossing midnight rolls the date forward (matches legacy SQL). */
+    public void testAddTimeCrossesMidnight() throws IOException {
+        // datetime0 = 2004-07-09 10:17:35Z; +14:00:00 → 2004-07-10 00:17:35.
+        assertFirstRowString(
+            oneRow("key00") + "| eval v = date_format(addtime(datetime0, time('14:00:00')), '%Y-%m-%d %H:%i:%s') | fields v",
+            "2004-07-10 00:17:35"
+        );
+    }
+
+    /** SUBTIME on a TIMESTAMP that wraps backwards into the previous day. */
+    public void testSubTimeWrapsToPreviousDay() throws IOException {
+        // datetime0 = 2004-07-09 10:17:35Z; -11:00:00 → 2004-07-08 23:17:35.
+        assertFirstRowString(
+            oneRow("key00") + "| eval v = date_format(subtime(datetime0, time('11:00:00')), '%Y-%m-%d %H:%i:%s') | fields v",
+            "2004-07-08 23:17:35"
+        );
+    }
+
+    /** ADDTIME(time, time) returns a TIME — exercises the maketime branch (not from_unixtime). */
+    public void testAddTimeOnTimeReturnsTime() throws IOException {
+        // 19:36:22 + 02:30:00 → 22:06:22.
+        assertFirstRowString(
+            oneRow("key00") + "| eval v = time_format(addtime(time1, time('02:30:00')), '%H:%i:%s') | fields v",
+            "22:06:22"
+        );
+    }
+
+    /** DATEDIFF discards time-of-day — DATEDIFF('2000-01-02 00:00:00', '2000-01-01 23:59:59') = 1 not 0. */
+    public void testDateDiffIgnoresTimeOfDay() throws IOException {
+        assertFirstRowLong(
+            oneRow("key00") + "| eval d = datediff('2000-01-02 00:00:00', '2000-01-01 23:59:59') | fields d",
+            1L
+        );
+    }
+
+    /**
+     * DATEDIFF on two TIME operands: both anchor to the same (today's UTC) date, so their day-counts
+     * cancel — matches MySQL's documented behavior of returning 0 even when the time-of-day values
+     * span a notional day boundary. Pins the DateDiffAdapter TIME-anchoring path end-to-end.
+     */
+    public void testDateDiffOnTimeOperandsReturnsZero() throws IOException {
+        assertFirstRowLong(
+            oneRow("key00") + "| eval d = datediff(time('23:59:59'), time('00:00:00')) | fields d",
+            0L
+        );
+    }
+
+    /** TO_DAYS('1970-01-01') = 719528 — pins the MySQL day-1 origin (year 0000-01-01). */
+    public void testToDaysEpochAnchor() throws IOException {
+        assertFirstRowLong(oneRow("key00") + "| eval d = to_days('1970-01-01') | fields d", 719_528L);
+    }
+
+    /** TO_SECONDS('1970-01-01 00:00:00') = 62167219200 — same anchor, second-resolution. */
+    public void testToSecondsEpochAnchor() throws IOException {
+        assertFirstRowLong(oneRow("key00") + "| eval s = to_seconds('1970-01-01 00:00:00') | fields s", 62_167_219_200L);
+    }
+
+    /** FROM_DAYS round-trip: TO_DAYS('1970-01-01') back through FROM_DAYS yields 1970-01-01. */
+    public void testFromDaysRoundTripsThroughEpochAnchor() throws IOException {
+        assertFirstRowString(
+            oneRow("key00") + "| eval d = date_format(from_days(719528), '%Y-%m-%d') | fields d",
+            "1970-01-01"
+        );
+    }
+
+    /** TIME_TO_SEC on a full TIMESTAMP — modulus discards the date, returning seconds-of-day. */
+    public void testTimeToSecOnTimestamp() throws IOException {
+        // datetime0 at key00 = 10:17:35 → 10*3600 + 17*60 + 35 = 37055.
+        assertFirstRowLong(oneRow("key00") + "| eval s = time_to_sec(datetime0) | fields s", 37_055L);
+    }
+
+    /** SEC_TO_TIME(123456) wraps past one day → MySQL 10:17:36 (123456 % 86400 = 37056). */
+    public void testSecToTimeWrapsOverOneDay() throws IOException {
+        assertFirstRowString(
+            oneRow("key00") + "| eval t = time_format(sec_to_time(123456), '%H:%i:%s') | fields t",
+            "10:17:36"
+        );
+    }
+
+    /** WEEKDAY remap: 2004-07-09 was a Friday → MySQL 4 (Mon=0..Sun=6). */
+    public void testWeekdayMatchesMySql() throws IOException {
+        assertFirstRowLong(oneRow("key00") + "| eval w = weekday(datetime0) | fields w", 4L);
+    }
+
+    /** PERIOD_ADD(202612, 1) rolls into the next year: → 202701. */
+    public void testPeriodAddRollsAcrossYearBoundary() throws IOException {
+        assertFirstRowLong(oneRow("key00") + "| eval p = period_add(202612, 1) | fields p", 202_701L);
+    }
+
+    /** PERIOD_DIFF(202612, 202601) = 11 — months between two YYYYMM periods within the same year. */
+    public void testPeriodDiffWithinYear() throws IOException {
+        assertFirstRowLong(oneRow("key00") + "| eval d = period_diff(202612, 202601) | fields d", 11L);
+    }
+
+    /** GET_FORMAT(DATE, 'EUR') folds to '%d.%m.%Y' at plan time. */
+    public void testGetFormatDateEurFoldsAtPlanTime() throws IOException {
+        assertFirstRowString(oneRow("key00") + "| eval f = get_format(DATE, 'EUR') | fields f", "%d.%m.%Y");
+    }
+
+    /** LAST_DAY in February of a leap year resolves to the 29th, not the 28th. */
+    public void testLastDayLeapYearFebruary() throws IOException {
+        // Use a TIMESTAMP literal so the operand-typing path matches the dataset use.
+        assertFirstRowString(
+            oneRow("key00") + "| eval ld = date_format(last_day('2024-02-15'), '%Y-%m-%d') | fields ld",
+            "2024-02-29"
+        );
+    }
+
+    /** YEARWEEK mode 0 vs mode 3 differ for 2003-10-03 (200339 vs 200340) — pins the mode arg path. */
+    public void testYearweekModeArgChangesResult() throws IOException {
+        assertFirstRowLong(oneRow("key00") + "| eval y = yearweek('2003-10-03') | fields y", 200_339L);
+        assertFirstRowLong(oneRow("key00") + "| eval y = yearweek('2003-10-03', 3) | fields y", 200_340L);
+    }
+
+    /** ADDDATE shares DATE_ADD's lowering — INTERVAL form on a DATE column. */
+    public void testAddDateIntervalForm() throws IOException {
+        assertFirstRowString(
+            oneRow("key00") + "| eval d = date_format(adddate(date0, interval 7 day), '%Y-%m-%d') | fields d",
+            "2004-04-22"
+        );
+    }
+
+    /** ADDDATE integer form — per SPI: integer N is treated as INTERVAL N DAY. */
+    public void testAddDateIntegerForm() throws IOException {
+        assertFirstRowString(
+            oneRow("key00") + "| eval d = date_format(adddate(date0, 7), '%Y-%m-%d') | fields d",
+            "2004-04-22"
+        );
+    }
+
+    /** SUBDATE shares DATE_SUB's lowering — INTERVAL form on a DATE column. */
+    public void testSubDateIntervalForm() throws IOException {
+        assertFirstRowString(
+            oneRow("key00") + "| eval d = date_format(subdate(date0, interval 1 month), '%Y-%m-%d') | fields d",
+            "2004-03-15"
+        );
+    }
+
+    /** SUBDATE integer form — per SPI: integer N is treated as INTERVAL N DAY. */
+    public void testSubDateIntegerForm() throws IOException {
+        assertFirstRowString(
+            oneRow("key00") + "| eval d = date_format(subdate(date0, 5), '%Y-%m-%d') | fields d",
+            "2004-04-10"
+        );
+    }
+
+    /** TIMEDIFF returns a TIME — value of '23:59:59' minus '13:00:00' is '10:59:59'. */
+    public void testTimeDiffReturnsTime() throws IOException {
+        assertFirstRowString(
+            oneRow("key00") + "| eval td = time_format(timediff(time('23:59:59'), time('13:00:00')), '%H:%i:%s') | fields td",
+            "10:59:59"
+        );
+    }
+
+    /**
+     * TIME_TO_SEC on a bare TIME literal exercises the today-anchor path
+     * ({@code DatePartAdapters#coerceCharacterOperandToTimestamp}) end-to-end. The MOD 86400
+     * discards the date, so result equals the time-of-day's second count regardless of the anchor.
+     */
+    public void testTimeToSecOnTimeLiteral() throws IOException {
+        // 19:36:22 → 19*3600 + 36*60 + 22 = 70582.
+        assertFirstRowLong(oneRow("key00") + "| eval s = time_to_sec(time('19:36:22')) | fields s", 70_582L);
+    }
+
+    /** YEARWEEK on a TIMESTAMP column (not literal) exercises the os_yearweek column path. */
+    public void testYearweekOnTimestampColumn() throws IOException {
+        // datetime0 at key00 = 2004-07-09 (Fri); mode 0 (Sun-first) → week 27 of 2004 → 200427.
+        assertFirstRowLong(oneRow("key00") + "| eval y = yearweek(datetime0) | fields y", 200_427L);
+    }
+
+    /**
+     * {@code time_format(time_column, fmt)} against a TIME column — distinct from the
+     * {@code time_format(maketime(...), fmt)} path covered by {@link #testAddTimeOnTimeReturnsTime}.
+     * The {@code time1} column at key00 is {@code 19:36:22}.
+     */
+    public void testTimeFormatOnTimeColumn() throws IOException {
+        assertFirstRowString(
+            oneRow("key00") + "| eval v = time_format(time1, '%H:%i:%s') | fields v",
+            "19:36:22"
+        );
+    }
+
+    /**
+     * ADDTIME with a TIMESTAMP column + TIME column (both non-literals) exercises the column-vs-column
+     * branch — distinct from the literal-time branch covered by {@link #testAddTimeCrossesMidnight}.
+     */
+    public void testAddTimeTimestampPlusTimeColumn() throws IOException {
+        // datetime0 at key00 = 2004-07-09 10:17:35; time1 = 19:36:22 → 2004-07-10 05:53:57.
+        assertFirstRowString(
+            oneRow("key00") + "| eval v = date_format(addtime(datetime0, time1), '%Y-%m-%d %H:%i:%s') | fields v",
+            "2004-07-10 05:53:57"
+        );
+    }
+
+    /**
+     * LAST_DAY over a DATE column — exercises the no-anchor DATE branch end-to-end. The
+     * {@code testLastDayLeapYearFebruary} IT only covers a string literal.
+     */
+    public void testLastDayOnDateColumn() throws IOException {
+        // date0 at key00 = 2004-04-15 → last day of April 2004 = 2004-04-30.
+        assertFirstRowString(
+            oneRow("key00") + "| eval v = date_format(last_day(date0), '%Y-%m-%d') | fields v",
+            "2004-04-30"
+        );
+    }
+
     private void assertFirstRowString(String ppl, String expected) throws IOException {
         Object cell = firstRowFirstCell(ppl);
         assertNotNull("Expected non-null result for query [" + ppl + "]", cell);

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/DateTimeScalarFunctionsIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/DateTimeScalarFunctionsIT.java
@@ -317,8 +317,6 @@ public class DateTimeScalarFunctionsIT extends AnalyticsRestTestCase {
     }
 
     // MILLISECOND is the day-time base unit — exercises the 1:1 (no-scale) interval branch.
-    // Pending sql cluster A+D: combined UDT bridging + value rendering
-    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/sql/pull/<TBD>")
     public void testDateAddMillisecondIntervalOnTimestampColumn() throws IOException {
         assertFirstRowString(
             oneRow("key00") + "| eval v = date_add(datetime0, interval 500 millisecond) | fields v",

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/DateTimeScalarFunctionsIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/DateTimeScalarFunctionsIT.java
@@ -544,6 +544,44 @@ public class DateTimeScalarFunctionsIT extends AnalyticsRestTestCase {
         );
     }
 
+    /** ADDDATE with a non-DAY interval unit — exercises the adapter's HOUR branch on a TIMESTAMP base. */
+    public void testAddDateIntervalHourOnTimestamp() throws IOException {
+        // datetime0 at key00 = 2004-07-09 10:17:35 → +5 hours = 2004-07-09 15:17:35.
+        assertFirstRowString(
+            oneRow("key00") + "| eval d = date_format(adddate(datetime0, interval 5 hour), '%Y-%m-%d %H:%i:%s') | fields d",
+            "2004-07-09 15:17:35"
+        );
+    }
+
+    /** SUBDATE with a non-DAY interval unit — exercises the adapter's MINUTE branch with sign-flip. */
+    public void testSubDateIntervalMinuteOnTimestamp() throws IOException {
+        // datetime0 = 2004-07-09 10:17:35 → -30 minutes = 2004-07-09 09:47:35.
+        assertFirstRowString(
+            oneRow("key00") + "| eval d = date_format(subdate(datetime0, interval 30 minute), '%Y-%m-%d %H:%i:%s') | fields d",
+            "2004-07-09 09:47:35"
+        );
+    }
+
+    /** ADDDATE on a TIMESTAMP column (not literal) — exercises the column-base lowering for ADDDATE. */
+    public void testAddDateIntegerDaysOnTimestampColumn() throws IOException {
+        // datetime0 = 2004-07-09 10:17:35 → +30 days = 2004-08-08 10:17:35.
+        assertFirstRowString(
+            oneRow("key00") + "| eval d = date_format(adddate(datetime0, 30), '%Y-%m-%d %H:%i:%s') | fields d",
+            "2004-08-08 10:17:35"
+        );
+    }
+
+    /**
+     * ADDDATE with a VARCHAR base — exercises the {@code characterBase} branch in
+     * {@code DateAddSubAdapter} that routes through {@code coerceCharacterOperandToTimestamp}.
+     */
+    public void testAddDateVarcharBaseCoerces() throws IOException {
+        assertFirstRowString(
+            oneRow("key00") + "| eval d = date_format(adddate('2020-08-26', interval 7 day), '%Y-%m-%d %H:%i:%s') | fields d",
+            "2020-09-02 00:00:00"
+        );
+    }
+
     /** TIMEDIFF returns a TIME — value of '23:59:59' minus '13:00:00' is '10:59:59'. */
     public void testTimeDiffReturnsTime() throws IOException {
         assertFirstRowString(

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/DateTimeScalarFunctionsIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/DateTimeScalarFunctionsIT.java
@@ -115,16 +115,43 @@ public class DateTimeScalarFunctionsIT extends AnalyticsRestTestCase {
     /**
      * {@code microsecond(timestamp('<lit>'))} extracts the sub-second component. MicrosecondAdapter
      * coerces the operand and computes {@code MOD(date_part('microsecond', ts), 1_000_000)}.
-     *
-     * <p>The AE/parquet store keeps {@code Timestamp(MILLISECOND)} (see TimestampFunctionAdapter
-     * precision notes), so sub-millisecond digits are truncated on this path: {@code .123456} reads
-     * back as {@code 123000}. This asserts the millisecond-precise value the engine produces today;
-     * full microsecond fidelity is a separate, pre-existing precision limitation.
+     * Millisecond-aligned input keeps the resolved (precision-3) fold, so {@code .123 → 123000}.
      */
     public void testMicrosecondOnTimestamp() throws IOException {
         assertFirstRowLong(
             oneRow("key00") + "| eval v = microsecond(timestamp('2020-09-16 17:30:00.123')) | fields v",
             123000L
+        );
+    }
+
+    /**
+     * Sub-ms input ({@code .123456}) preserves all 6 µs digits — the TimestampFunctionAdapter
+     * fold bumps precision to 6 when the input carries non-zero sub-ms digits. Pre-fix this
+     * silently truncated to {@code 123000}.
+     */
+    public void testMicrosecondOnTimestampPreservesMicroseconds() throws IOException {
+        assertFirstRowLong(
+            oneRow("key00") + "| eval v = microsecond(timestamp('2020-09-16 17:30:00.123456')) | fields v",
+            123456L
+        );
+    }
+
+    /**
+     * Boundary: a single µs digit ({@code .000001}) must round-trip as {@code 1}, not be lost to
+     * the ms-aligned fast path. The {@code subSecondNanos % 1_000_000 != 0} check pins this.
+     */
+    public void testMicrosecondOnTimestampSingleMicrosecond() throws IOException {
+        assertFirstRowLong(
+            oneRow("key00") + "| eval v = microsecond(timestamp('2020-09-16 17:30:00.000001')) | fields v",
+            1L
+        );
+    }
+
+    /** {@code date_format(_, '%f')} renders the 6-digit fractional second — pins the µs-preservation end-to-end. */
+    public void testDateFormatPercentFOnTimestampMicros() throws IOException {
+        assertFirstRowString(
+            oneRow("key00") + "| eval v = date_format(timestamp('2020-09-16 17:30:00.123456'), '%f') | fields v",
+            "123456"
         );
     }
 

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/DateTimeScalarFunctionsIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/DateTimeScalarFunctionsIT.java
@@ -458,6 +458,22 @@ public class DateTimeScalarFunctionsIT extends AnalyticsRestTestCase {
         );
     }
 
+    /** DATEDIFF spanning the epoch — pins floor-divide; truncate-toward-zero would return 0. */
+    public void testDateDiffAcrossEpochBoundary() throws IOException {
+        assertFirstRowLong(
+            oneRow("key00") + "| eval d = datediff('1970-01-01 00:00:00', '1969-12-31 12:00:00') | fields d",
+            1L
+        );
+    }
+
+    /** DATEDIFF on a pre-1970 pair — both operands negative-epoch, floor-divide preserves the calendar delta. */
+    public void testDateDiffPre1970Pair() throws IOException {
+        assertFirstRowLong(
+            oneRow("key00") + "| eval d = datediff('1969-12-31 00:00:00', '1969-12-30 00:00:00') | fields d",
+            1L
+        );
+    }
+
     /**
      * DATEDIFF on two TIME operands: both anchor to the same (today's UTC) date, so their day-counts
      * cancel — matches MySQL's documented behavior of returning 0 even when the time-of-day values

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/DatetimeCoverageIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/DatetimeCoverageIT.java
@@ -156,6 +156,24 @@ public class DatetimeCoverageIT extends AnalyticsRestTestCase {
         assertNull("out-of-range tz must fold to NULL post-fix", cell);
     }
 
+    /** Cluster B: 2-arg DATETIME with null string operands returns TIMESTAMP-typed null rows.
+     * Mirrors {@code CalcitePPLBuiltinFunctionsNullIT.testDatetimeNullString}; the SAFE-cast in
+     * {@link org.opensearch.be.datafusion.ConvertTzAdapter} keeps the lowering well-typed when
+     * arg0 is a typed-null string ({@code precision_timestamp(9)?} mismatch pre-fix). */
+    public void testClusterB_twoArgDatetimeNullOperandsReturnNull() throws IOException {
+        // nullif(x, x) → typed-null string, mirroring null `name` / `state` columns in the SQL fixture.
+        Map<String, Object> response = executePpl(
+            oneRow()
+                + "| eval n = nullif(key, key), t = nullif(key, key) "
+                + "| eval d1 = DATETIME(n, '+10:00'), d2 = datetime('2004-02-28 23:00:00-10:00', t) "
+                + "| fields d1, d2"
+        );
+        assertSchemaType(response, "d1", "timestamp");
+        assertSchemaType(response, "d2", "timestamp");
+        assertNull("DATETIME(null, '+10:00') must be NULL", firstRowOf(response, "d1"));
+        assertNull("datetime('2004-02-28 23:00:00-10:00', null) must be NULL", firstRowOf(response, "d2"));
+    }
+
     /** Cluster B: now(0)/sysdate(0) FSP-arg overload resolves. Asserts type+nonnull only. */
     public void testClusterB_nowFspVariant() throws IOException {
         Map<String, Object> response = executePpl(oneRow() + "| eval f = sysdate(0) | fields f");

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/DatetimeCoverageIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/DatetimeCoverageIT.java
@@ -181,6 +181,38 @@ public class DatetimeCoverageIT extends AnalyticsRestTestCase {
         assertEquals("date_sub(time, -30min) wall time must be 08:30:00", "08:30:00", firstRowFirstCell(response));
     }
 
+    /** Cluster B: ADDDATE(DATE, integer days) lowers via DateAddSubAdapter integer-days form. */
+    public void testClusterB_addDateIntegerDaysOnDate() throws IOException {
+        assertFirstRowString(
+            oneRow() + "| eval f = adddate(date('2020-08-26'), 1) | fields f",
+            "2020-08-27"
+        );
+    }
+
+    /** Cluster B: SUBDATE(DATE, integer days) — sign folded by adapter. */
+    public void testClusterB_subDateIntegerDaysOnDate() throws IOException {
+        assertFirstRowString(
+            oneRow() + "| eval f = subdate(date('2020-08-26'), 1) | fields f",
+            "2020-08-25"
+        );
+    }
+
+    /** Cluster B: ADDDATE(TIMESTAMP, integer days) — promotes to TIMESTAMP wall time. */
+    public void testClusterB_addDateIntegerDaysOnTimestamp() throws IOException {
+        assertFirstRowString(
+            oneRow() + "| eval f = adddate(timestamp('2020-09-16 17:30:00'), 1) | fields f",
+            "2020-09-17 17:30:00"
+        );
+    }
+
+    /** Cluster B: ADDDATE(DATE, INTERVAL n DAY) — interval form sharing the DATE_ADD path. */
+    public void testClusterB_addDateIntervalOnDate() throws IOException {
+        assertFirstRowString(
+            oneRow() + "| eval f = adddate(date('2020-08-26'), interval 3 day) | fields f",
+            "2020-08-29 00:00:00"
+        );
+    }
+
     /** Cluster B: TIMESTAMPADD standalone string-overload resolves. */
     public void testClusterB_timestampAddStandalone() throws IOException {
         assertFirstRowString(

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/DatetimeCoverageIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/DatetimeCoverageIT.java
@@ -18,11 +18,10 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Regression gate for the {@code fix/ai/cluster-all} cluster commits. Each method exercises
- * one query shape that flipped from FAILING to PASSING with that body of work; a regression
- * here signals one of the underlying cluster commits has been undone. Coverage shapes are
- * sourced from {@code tests/parquet/a-date-time-failed/} and
- * {@code tests/parquet/assertion-error-deep-dive/}.
+ * Regression gates for PPL date/time/timestamp coverage on the analytics-engine route. Each test
+ * exercises one query shape that previously failed; a regression here signals that one of the
+ * underlying fixes has been undone. Coverage shapes are sourced from
+ * {@code tests/parquet/a-date-time-failed/} and {@code tests/parquet/assertion-error-deep-dive/}.
  */
 public class DatetimeCoverageIT extends AnalyticsRestTestCase {
 
@@ -43,12 +42,11 @@ public class DatetimeCoverageIT extends AnalyticsRestTestCase {
     }
 
     // ─────────────────────────────────────────────────────────────────────────
-    // Cluster A — span() preserves bucket type for date / time inputs (5 methods)
-    // commit f29a5a5927f
+    // span() preserves bucket type for date / time inputs (5 tests)
     // ─────────────────────────────────────────────────────────────────────────
 
-    /** Cluster A: span(date, 1d) bucket renders as bare date, no '00:00:00' suffix. */
-    public void testClusterA_spanDateTypePreservesDate() throws IOException {
+    /** span(date, 1d) bucket renders as bare date, no '00:00:00' suffix. */
+    public void testSpanDateTypePreservesDate() throws IOException {
         Map<String, Object> response = executePpl(
             "source=" + DATASET.indexName + " | stats count() as c by span(date0, 1d) as date_span | sort date_span | head 1"
         );
@@ -59,8 +57,8 @@ public class DatetimeCoverageIT extends AnalyticsRestTestCase {
         assertSchemaType(response, "date_span", "date");
     }
 
-    /** Cluster A: span(date, 1month) preserves date type, bucket on month boundary. */
-    public void testClusterA_spanDateUnitMonth() throws IOException {
+    /** span(date, 1month) preserves date type, bucket on month boundary. */
+    public void testSpanDateUnitMonth() throws IOException {
         Map<String, Object> response = executePpl(
             "source=" + DATASET.indexName + " | stats count() as c by span(date1, 1month) as date_span | sort date_span | head 1"
         );
@@ -69,8 +67,8 @@ public class DatetimeCoverageIT extends AnalyticsRestTestCase {
         assertSchemaType(response, "date_span", "date");
     }
 
-    /** Cluster A: span(time, 1h) returns TIME-typed bucket, no '1970-01-01' prefix. */
-    public void testClusterA_spanTimeTypePreservesTime() throws IOException {
+    /** span(time, 1h) returns TIME-typed bucket, no '1970-01-01' prefix. */
+    public void testSpanTimeTypePreservesTime() throws IOException {
         Map<String, Object> response = executePpl(
             "source=" + DATASET.indexName + " | where key='key00' | stats count() by span(time1, 1h) as time_span"
         );
@@ -80,8 +78,8 @@ public class DatetimeCoverageIT extends AnalyticsRestTestCase {
         assertSchemaType(response, "time_span", "time");
     }
 
-    /** Cluster A: span(time, 1minute) returns TIME-typed bucket. */
-    public void testClusterA_spanTimeUnitMinute() throws IOException {
+    /** span(time, 1minute) returns TIME-typed bucket. */
+    public void testSpanTimeUnitMinute() throws IOException {
         Map<String, Object> response = executePpl(
             "source=" + DATASET.indexName + " | where key='key00' | stats count() by span(time1, 1minute) as time_span"
         );
@@ -90,14 +88,16 @@ public class DatetimeCoverageIT extends AnalyticsRestTestCase {
         assertSchemaType(response, "time_span", "time");
     }
 
-    /** Cluster A: span over an eval-derived DATE expression preserves DATE typing. */
-    // Pending sql plugin: DateOnlyType bridging on span() result requires OpenSearchTypeFactory
-    // changes (SQL plugin is read-only on this branch). The Calcite-side return-type inference
-    // for SpanFunction forwards operand 0's type (DATE), but the substrait round-trip materializes
-    // the wire as Timestamp(Microsecond), and the SQL plugin's value renderer only strips midnight
-    // suffix when the type is DateOnlyType — not plain DATE. Cluster-A peers have the same shape.
+    /** span over an eval-derived DATE expression preserves DATE typing. */
+    // TODO(sql-plugin): broaden midnight-suffix strip in AnalyticsExecutionEngine#convert to recognise
+    // ExprDateType (the SQL plugin's DATE UDT), not just DateOnlyType. The eval-derived `date(...)`
+    // produces ExprDateType, which SpanFunction.getReturnTypeInference forwards through the call;
+    // the renderer's `instanceof DateOnlyType` check at AnalyticsExecutionEngine.java:236 misses,
+    // so the value comes back as "2004-04-01 00:00:00" instead of bare "2004-04-01". One-line fix:
+    // swap the predicate for `OpenSearchTypeFactory.isDateExprType(type)` (already true for both
+    // DateOnlyType and ExprDateType / stock DATE). Same for the TimeOnlyType branch below it.
     @AwaitsFix(bugUrl = "https://github.com/opensearch-project/sql/pull/<TBD>")
-    public void testClusterA_spanCustomFormatDate() throws IOException {
+    public void testSpanCustomFormatDate() throws IOException {
         Map<String, Object> response = executePpl(
             oneRow() + "| eval d = date('2004-04-15') | stats count() by span(d, 1month) as date_span"
         );
@@ -107,12 +107,12 @@ public class DatetimeCoverageIT extends AnalyticsRestTestCase {
     }
 
     // ─────────────────────────────────────────────────────────────────────────
-    // Cluster B — Missing function overloads now resolved (14 methods)
-    // commit bd2cf9d54b9
+    // Function overload resolution — 2-arg DATETIME, FSP variants, TIME args, ADDDATE/SUBDATE,
+    // TIMESTAMPADD/DIFF standalone, DATE_PART(unit, TIME), 2-arg FROM_UNIXTIME.
     // ─────────────────────────────────────────────────────────────────────────
 
-    /** Cluster B: 2-arg DATETIME(literal, tz-literal) folds to a typed TIMESTAMP. */
-    public void testClusterB_twoArgDatetimeLiteralFold() throws IOException {
+    /** 2-arg DATETIME(literal, tz-literal) folds to a typed TIMESTAMP. */
+    public void testTwoArgDatetimeLiteralFold() throws IOException {
         // +10:00 offset shifts wall time back 10h → '2007-12-31 16:00:00'.
         assertFirstRowString(
             oneRow() + "| eval f = datetime('2008-01-01 02:00:00', '+10:00') | fields f",
@@ -120,8 +120,8 @@ public class DatetimeCoverageIT extends AnalyticsRestTestCase {
         );
     }
 
-    /** Cluster B: 2-arg DATETIME with named-zone string — schema only; value depends on TZ. */
-    public void testClusterB_twoArgDatetimeNamedZone() throws IOException {
+    /** 2-arg DATETIME with named-zone string — schema only; value depends on TZ. */
+    public void testTwoArgDatetimeNamedZone() throws IOException {
         Map<String, Object> response = executePpl(
             oneRow() + "| eval f = datetime('2008-01-01 02:00:00', 'America/Los_Angeles') | fields f"
         );
@@ -129,8 +129,8 @@ public class DatetimeCoverageIT extends AnalyticsRestTestCase {
         assertSchemaType(response, "f", "timestamp");
     }
 
-    /** Cluster B: 2-arg DATETIME with column input resolves through the same overload. */
-    public void testClusterB_twoArgDatetimeColInput() throws IOException {
+    /** 2-arg DATETIME with column input resolves through the same overload. */
+    public void testTwoArgDatetimeColInput() throws IOException {
         Map<String, Object> response = executePpl(
             oneRow() + "| eval f = datetime(datetime0, '+00:00') | fields f"
         );
@@ -139,8 +139,8 @@ public class DatetimeCoverageIT extends AnalyticsRestTestCase {
         assertEquals("col-input DATETIME with +00:00 must be identity", "2004-07-09 10:17:35", cell);
     }
 
-    /** Cluster B: 2-arg DATETIME with out-of-range tz folds to NULL (instead of HTTP 400). */
-    public void testClusterB_twoArgDatetimeBoundsFoldsNull() throws IOException {
+    /** 2-arg DATETIME with out-of-range tz folds to NULL (instead of HTTP 400). */
+    public void testTwoArgDatetimeBoundsFoldsNull() throws IOException {
         Map<String, Object> response = executePpl(
             oneRow() + "| eval f = datetime('2008-01-01 02:00:00', '+15:00') | fields f"
         );
@@ -148,11 +148,11 @@ public class DatetimeCoverageIT extends AnalyticsRestTestCase {
         assertNull("out-of-range tz must fold to NULL post-fix", cell);
     }
 
-    /** Cluster B: 2-arg DATETIME with null string operands returns TIMESTAMP-typed null rows.
+    /** 2-arg DATETIME with null string operands returns TIMESTAMP-typed null rows.
      * Mirrors {@code CalcitePPLBuiltinFunctionsNullIT.testDatetimeNullString}; the SAFE-cast in
      * {@link org.opensearch.be.datafusion.ConvertTzAdapter} keeps the lowering well-typed when
      * arg0 is a typed-null string ({@code precision_timestamp(9)?} mismatch pre-fix). */
-    public void testClusterB_twoArgDatetimeNullOperandsReturnNull() throws IOException {
+    public void testTwoArgDatetimeNullOperandsReturnNull() throws IOException {
         // nullif(x, x) → typed-null string, mirroring null `name` / `state` columns in the SQL fixture.
         Map<String, Object> response = executePpl(
             oneRow()
@@ -166,16 +166,16 @@ public class DatetimeCoverageIT extends AnalyticsRestTestCase {
         assertNull("datetime('2004-02-28 23:00:00-10:00', null) must be NULL", firstRowOf(response, "d2"));
     }
 
-    /** Cluster B: now(0)/sysdate(0) FSP-arg overload resolves. Asserts type+nonnull only. */
-    public void testClusterB_nowFspVariant() throws IOException {
+    /** now(0)/sysdate(0) FSP-arg overload resolves. Asserts type+nonnull only. */
+    public void testNowFspVariant() throws IOException {
         Map<String, Object> response = executePpl(oneRow() + "| eval f = sysdate(0) | fields f");
         Object cell = firstRowFirstCell(response);
         assertNotNull("sysdate(0) must be non-null post-fix", cell);
         assertSchemaType(response, "f", "timestamp");
     }
 
-    /** Cluster B: DATE_ADD(TIME, interval) overload resolves. */
-    public void testClusterB_dateAddOnTime() throws IOException {
+    /** DATE_ADD(TIME, interval) overload resolves. */
+    public void testDateAddOnTime() throws IOException {
         // Time-only DATE_ADD lifts to a date_add over today's date; pin the time-of-day suffix only.
         Map<String, Object> response = executePpl(
             oneRow() + "| eval f = time_format(date_add(time('09:00:00'), interval 1 hour), '%H:%i:%s') | fields f"
@@ -183,90 +183,90 @@ public class DatetimeCoverageIT extends AnalyticsRestTestCase {
         assertEquals("date_add(time, +1h) wall time must be 10:00:00", "10:00:00", firstRowFirstCell(response));
     }
 
-    /** Cluster B: DATE_SUB(TIME, interval) overload resolves. */
-    public void testClusterB_dateSubOnTime() throws IOException {
+    /** DATE_SUB(TIME, interval) overload resolves. */
+    public void testDateSubOnTime() throws IOException {
         Map<String, Object> response = executePpl(
             oneRow() + "| eval f = time_format(date_sub(time('09:00:00'), interval 30 minute), '%H:%i:%s') | fields f"
         );
         assertEquals("date_sub(time, -30min) wall time must be 08:30:00", "08:30:00", firstRowFirstCell(response));
     }
 
-    /** Cluster B: ADDDATE(DATE, integer days) lowers via DateAddSubAdapter integer-days form. */
-    public void testClusterB_addDateIntegerDaysOnDate() throws IOException {
+    /** ADDDATE(DATE, integer days) lowers via DateAddSubAdapter integer-days form. */
+    public void testAddDateIntegerDaysOnDate() throws IOException {
         assertFirstRowString(
             oneRow() + "| eval f = adddate(date('2020-08-26'), 1) | fields f",
             "2020-08-27"
         );
     }
 
-    /** Cluster B: SUBDATE(DATE, integer days) — sign folded by adapter. */
-    public void testClusterB_subDateIntegerDaysOnDate() throws IOException {
+    /** SUBDATE(DATE, integer days) — sign folded by adapter. */
+    public void testSubDateIntegerDaysOnDate() throws IOException {
         assertFirstRowString(
             oneRow() + "| eval f = subdate(date('2020-08-26'), 1) | fields f",
             "2020-08-25"
         );
     }
 
-    /** Cluster B: ADDDATE(TIMESTAMP, integer days) — promotes to TIMESTAMP wall time. */
-    public void testClusterB_addDateIntegerDaysOnTimestamp() throws IOException {
+    /** ADDDATE(TIMESTAMP, integer days) — promotes to TIMESTAMP wall time. */
+    public void testAddDateIntegerDaysOnTimestamp() throws IOException {
         assertFirstRowString(
             oneRow() + "| eval f = adddate(timestamp('2020-09-16 17:30:00'), 1) | fields f",
             "2020-09-17 17:30:00"
         );
     }
 
-    /** Cluster B: ADDDATE(DATE, INTERVAL n DAY) — interval form sharing the DATE_ADD path. */
-    public void testClusterB_addDateIntervalOnDate() throws IOException {
+    /** ADDDATE(DATE, INTERVAL n DAY) — interval form sharing the DATE_ADD path. */
+    public void testAddDateIntervalOnDate() throws IOException {
         assertFirstRowString(
             oneRow() + "| eval f = adddate(date('2020-08-26'), interval 3 day) | fields f",
             "2020-08-29 00:00:00"
         );
     }
 
-    /** Cluster B: TIMESTAMPADD standalone string-overload resolves. */
-    public void testClusterB_timestampAddStandalone() throws IOException {
+    /** TIMESTAMPADD standalone string-overload resolves. */
+    public void testTimestampAddStandalone() throws IOException {
         assertFirstRowString(
             oneRow() + "| eval f = date_format(timestampadd(YEAR, 1, '2024-01-15 12:00:00'), '%Y-%m-%d %H:%i:%s') | fields f",
             "2025-01-15 12:00:00"
         );
     }
 
-    /** Cluster B: TIMESTAMPDIFF standalone string-overload resolves. */
-    public void testClusterB_timestampDiffStandalone() throws IOException {
+    /** TIMESTAMPDIFF standalone string-overload resolves. */
+    public void testTimestampDiffStandalone() throws IOException {
         Map<String, Object> response = executePpl(
             oneRow() + "| eval f = timestampdiff(DAY, '2024-01-01 00:00:00', '2024-01-31 00:00:00') | fields f"
         );
         assertEquals("timestampdiff(DAY,...) must be 30", 30L, ((Number) firstRowFirstCell(response)).longValue());
     }
 
-    /** Cluster B: TIMESTAMPDIFF(MONTH, ...) approximation rounds to whole months. */
-    public void testClusterB_timestampDiffMonthApprox() throws IOException {
+    /** TIMESTAMPDIFF(MONTH, ...) approximation rounds to whole months. */
+    public void testTimestampDiffMonthApprox() throws IOException {
         Map<String, Object> response = executePpl(
             oneRow() + "| eval f = timestampdiff(MONTH, '2024-01-01 00:00:00', '2024-07-15 00:00:00') | fields f"
         );
         assertEquals("timestampdiff(MONTH,...) over 6m14d must be 6", 6L, ((Number) firstRowFirstCell(response)).longValue());
     }
 
-    /** Cluster B: HOUR(TIME(...)) resolves through the DATE_PART(unit, TIME) overload. */
-    public void testClusterB_datePartTimeHour() throws IOException {
+    /** HOUR(TIME(...)) resolves through the DATE_PART(unit, TIME) overload. */
+    public void testDatePartTimeHour() throws IOException {
         Map<String, Object> response = executePpl(oneRow() + "| eval f = hour(time('17:30:45')) | fields f");
         assertEquals("hour(TIME) must be 17", 17L, ((Number) firstRowFirstCell(response)).longValue());
     }
 
-    /** Cluster B: MINUTE(TIME(...)) resolves through the DATE_PART(unit, TIME) overload. */
-    public void testClusterB_datePartTimeMinute() throws IOException {
+    /** MINUTE(TIME(...)) resolves through the DATE_PART(unit, TIME) overload. */
+    public void testDatePartTimeMinute() throws IOException {
         Map<String, Object> response = executePpl(oneRow() + "| eval f = minute(time('17:30:45')) | fields f");
         assertEquals("minute(TIME) must be 30", 30L, ((Number) firstRowFirstCell(response)).longValue());
     }
 
-    /** Cluster B: SECOND(TIME(...)) resolves through the DATE_PART(unit, TIME) overload. */
-    public void testClusterB_datePartTimeSecond() throws IOException {
+    /** SECOND(TIME(...)) resolves through the DATE_PART(unit, TIME) overload. */
+    public void testDatePartTimeSecond() throws IOException {
         Map<String, Object> response = executePpl(oneRow() + "| eval f = second(time('17:30:45')) | fields f");
         assertEquals("second(TIME) must be 45", 45L, ((Number) firstRowFirstCell(response)).longValue());
     }
 
-    /** Cluster B: FROM_UNIXTIME(epoch, format) 2-arg overload renders correctly. */
-    public void testClusterB_fromUnixTimeWithFormat() throws IOException {
+    /** FROM_UNIXTIME(epoch, format) 2-arg overload renders correctly. */
+    public void testFromUnixTimeWithFormat() throws IOException {
         // 1521467703 = 2018-03-19 13:55:03 UTC.
         assertFirstRowString(
             oneRow() + "| eval f = from_unixtime(1521467703, '%Y-%m-%d %H:%i:%s') | fields f",
@@ -275,94 +275,92 @@ public class DatetimeCoverageIT extends AnalyticsRestTestCase {
     }
 
     // ─────────────────────────────────────────────────────────────────────────
-    // Cluster C — Invalid date literals → HTTP 4xx with format hint (10 methods)
-    // commit ade6344a7d3 + sandbox commit 5ffb7414aea
+    // Invalid string literals → HTTP 4xx with format hint (validation at plan time).
     // ─────────────────────────────────────────────────────────────────────────
 
-    /** Cluster C: DATE('2025-13-02') rejects with a format hint. */
-    public void testClusterC_invalidDateMonth13() throws IOException {
+    /** DATE('2025-13-02') rejects with a format hint. */
+    public void testInvalidDateMonth13() throws IOException {
         assertErrorContains(oneRow() + "| eval a = date('2025-13-02') | fields a", "2025-13-02");
     }
 
-    /** Cluster C: TIME('16:00:61') rejects with a format hint. */
-    public void testClusterC_invalidTimeSecond61() throws IOException {
+    /** TIME('16:00:61') rejects with a format hint. */
+    public void testInvalidTimeSecond61() throws IOException {
         assertErrorContains(oneRow() + "| eval a = time('16:00:61') | fields a", "16:00:61");
     }
 
-    /** Cluster C: TIMESTAMP('2025-12-01 15:02:61') rejects with a format hint. */
-    public void testClusterC_invalidTimestampSecond61() throws IOException {
+    /** TIMESTAMP('2025-12-01 15:02:61') rejects with a format hint. */
+    public void testInvalidTimestampSecond61() throws IOException {
         assertErrorContains(oneRow() + "| eval a = timestamp('2025-12-01 15:02:61') | fields a", "2025-12-01 15:02:61");
     }
 
-    /** Cluster C: DATETIME('2025-13-02') with bad date folds to NULL (single-arg form). */
-    public void testClusterC_invalidDatetimeFoldsNull() throws IOException {
+    /** DATETIME('2025-13-02') with bad date folds to NULL (single-arg form). */
+    public void testInvalidDatetimeFoldsNull() throws IOException {
         // Single-arg DATETIME's contract on this branch is NULL fold (vs. throw for DATE/TIME/TIMESTAMP).
         Map<String, Object> response = executePpl(oneRow() + "| eval a = datetime('2025-13-02') | fields a");
         Object cell = firstRowFirstCell(response);
         assertNull("DATETIME('2025-13-02') must fold to NULL", cell);
     }
 
-    /** Cluster C: CAST('xxx' AS DATE) rejects with a format hint. */
-    public void testClusterC_castStringToDateRejects() throws IOException {
+    /** CAST('xxx' AS DATE) rejects with a format hint. */
+    public void testCastStringToDateRejects() throws IOException {
         assertErrorContains(oneRow() + "| eval a = cast('xxx' as DATE) | fields a", "xxx");
     }
 
-    /** Cluster C: CAST('xxx' AS TIME) rejects with a format hint. */
-    public void testClusterC_castStringToTimeRejects() throws IOException {
+    /** CAST('xxx' AS TIME) rejects with a format hint. */
+    public void testCastStringToTimeRejects() throws IOException {
         assertErrorContains(oneRow() + "| eval a = cast('xxx' as TIME) | fields a", "xxx");
     }
 
-    /** Cluster C: CAST('xxx' AS TIMESTAMP) rejects with a format hint. */
-    public void testClusterC_castStringToTimestampRejects() throws IOException {
+    /** CAST('xxx' AS TIMESTAMP) rejects with a format hint. */
+    public void testCastStringToTimestampRejects() throws IOException {
         assertErrorContains(oneRow() + "| eval a = cast('xxx' as TIMESTAMP) | fields a", "xxx");
     }
 
-    /** Cluster C: TIMESTAMPADD with a bad string literal rejects. */
-    public void testClusterC_timestampAddBadLiteralRejects() throws IOException {
+    /** TIMESTAMPADD with a bad string literal rejects. */
+    public void testTimestampAddBadLiteralRejects() throws IOException {
         assertErrorContains(oneRow() + "| eval a = timestampadd(YEAR, 1, '2025-13-02') | fields a", "2025-13-02");
     }
 
-    /** Cluster C: TIMESTAMPDIFF with a bad string literal rejects. */
-    public void testClusterC_timestampDiffBadLiteralRejects() throws IOException {
+    /** TIMESTAMPDIFF with a bad string literal rejects. */
+    public void testTimestampDiffBadLiteralRejects() throws IOException {
         assertErrorContains(
             oneRow() + "| eval a = timestampdiff(DAY, '2025-13-02', '2025-12-01') | fields a",
             "2025-13-02"
         );
     }
 
-    /** Cluster C: HOUR('99:99:99') rejects (was silent 200 returning 0 pre-fix). */
-    public void testClusterC_hourBadStringRejects() throws IOException {
+    /** HOUR('99:99:99') rejects (was silent 200 returning 0 pre-fix). */
+    public void testHourBadStringRejects() throws IOException {
         assertErrorContains(oneRow() + "| eval a = hour('99:99:99') | fields a", "99:99:99");
     }
 
-    /** Cluster C: DAYNAME('2025-13-02') rejects at plan time with the format hint (no StreamException). */
-    public void testClusterC_daynameBadStringRejects() throws IOException {
+    /** DAYNAME('2025-13-02') rejects at plan time with the format hint (no StreamException). */
+    public void testDaynameBadStringRejects() throws IOException {
         assertErrorContains(oneRow() + "| eval a = dayname('2025-13-02') | fields a", "unsupported format");
     }
 
-    /** Cluster C: MONTHNAME('2025-13-02') rejects at plan time with the format hint (no StreamException). */
-    public void testClusterC_monthnameBadStringRejects() throws IOException {
+    /** MONTHNAME('2025-13-02') rejects at plan time with the format hint (no StreamException). */
+    public void testMonthnameBadStringRejects() throws IOException {
         assertErrorContains(oneRow() + "| eval a = monthname('2025-13-02') | fields a", "unsupported format");
     }
 
-    /** Cluster C: DAYNAME with a valid date literal renders the full weekday name (positive path). */
-    public void testClusterC_daynameValidLiteral() throws IOException {
+    /** DAYNAME with a valid date literal renders the full weekday name (positive path). */
+    public void testDaynameValidLiteral() throws IOException {
         // 2020-08-26 was a Wednesday.
         assertFirstRowString(oneRow() + "| eval a = dayname('2020-08-26') | fields a", "Wednesday");
     }
 
-    /** Cluster C: MONTHNAME with a valid date literal renders the full month name (positive path). */
-    public void testClusterC_monthnameValidLiteral() throws IOException {
+    /** MONTHNAME with a valid date literal renders the full month name (positive path). */
+    public void testMonthnameValidLiteral() throws IOException {
         assertFirstRowString(oneRow() + "| eval a = monthname('2020-08-26') | fields a", "August");
     }
 
     // ─────────────────────────────────────────────────────────────────────────
-    // Cluster D — Datetime stringification: space separator, no epoch prefix (5 methods)
-    // commit 6988b804646
+    // Datetime stringification — space separator, no 1970-epoch prefix, boolean upper-case.
     // ─────────────────────────────────────────────────────────────────────────
 
-    /** Cluster D: list(date) renders with space separator, not 'T'. */
-    public void testClusterD_listFunctionDateUsesSpace() throws IOException {
+    /** list(date) renders with space separator, not 'T'. */
+    public void testListFunctionDateUsesSpace() throws IOException {
         Map<String, Object> response = executePpl(
             "source=" + DATASET.indexName + " | where key='key00' | stats list(datetime0) as l"
         );
@@ -374,8 +372,8 @@ public class DatetimeCoverageIT extends AnalyticsRestTestCase {
         assertEquals("list element must use space separator", "2004-07-09 10:17:35", list.get(0));
     }
 
-    /** Cluster D: list(timestamp) preserves space separator (timestamp-element accumulator path). */
-    public void testClusterD_listFunctionTimestampUsesSpace() throws IOException {
+    /** list(timestamp) preserves space separator (timestamp-element accumulator path). */
+    public void testListFunctionTimestampUsesSpace() throws IOException {
         Map<String, Object> response = executePpl(
             "source=" + DATASET.indexName + " | where key='key00' | stats list(datetime0) as l | head 1"
         );
@@ -386,29 +384,28 @@ public class DatetimeCoverageIT extends AnalyticsRestTestCase {
             "2004-07-09 10:17:35", list.get(0));
     }
 
-    /** Cluster D: cast(boolean AS string) emits upper-case TRUE post-fix (CastToVarcharRewriter). */
-    public void testClusterD_castBooleanToStringUppercase() throws IOException {
+    /** cast(boolean AS string) emits upper-case TRUE post-fix (CastToVarcharRewriter). */
+    public void testCastBooleanToStringUppercase() throws IOException {
         // bool0 at key00 = true; PPL contract matches tostring(boolean) = uppercase.
         assertFirstRowString(oneRow() + "| eval a = cast(bool0 as string) | fields a", "TRUE");
     }
 
-    /** Cluster D: cast(true AS string) literal form renders upper-case. */
-    public void testClusterD_castTrueLiteralToStringUppercase() throws IOException {
+    /** cast(true AS string) literal form renders upper-case. */
+    public void testCastTrueLiteralToStringUppercase() throws IOException {
         assertFirstRowString(oneRow() + "| eval a = cast(true as string) | fields a", "TRUE");
     }
 
-    /** Cluster D: cast(false AS string) literal form renders upper-case. */
-    public void testClusterD_castFalseLiteralToStringUppercase() throws IOException {
+    /** cast(false AS string) literal form renders upper-case. */
+    public void testCastFalseLiteralToStringUppercase() throws IOException {
         assertFirstRowString(oneRow() + "| eval a = cast(false as string) | fields a", "FALSE");
     }
 
     // ─────────────────────────────────────────────────────────────────────────
-    // Cluster E — Sub-second precision: microseconds round-trip (5 methods)
-    // commit 91b7c0bc6d3
+    // Sub-second precision — microseconds round-trip without ms-truncation.
     // ─────────────────────────────────────────────────────────────────────────
 
-    /** Cluster E: cast(varchar AS TIMESTAMP) preserves microseconds (not truncated to ms). */
-    public void testClusterE_castTimestampPreservesMicros() throws IOException {
+    /** cast(varchar AS TIMESTAMP) preserves microseconds (not truncated to ms). */
+    public void testCastTimestampPreservesMicros() throws IOException {
         assertFirstRowString(
             oneRow()
                 + "| eval a = date_format(cast('2023-10-01 12:00:00.123456' as TIMESTAMP), '%Y-%m-%d %H:%i:%s.%f') | fields a",
@@ -416,8 +413,8 @@ public class DatetimeCoverageIT extends AnalyticsRestTestCase {
         );
     }
 
-    /** Cluster E: microsecond('… .123456') returns 123456, not 123000. */
-    public void testClusterE_microsecondTimestampSixDigits() throws IOException {
+    /** microsecond('… .123456') returns 123456, not 123000. */
+    public void testMicrosecondTimestampSixDigits() throws IOException {
         Map<String, Object> response = executePpl(
             oneRow() + "| eval f = microsecond('2024-01-15 12:00:00.123456') | fields f"
         );
@@ -425,16 +422,16 @@ public class DatetimeCoverageIT extends AnalyticsRestTestCase {
             123456L, ((Number) firstRowFirstCell(response)).longValue());
     }
 
-    /** Cluster E: date_format('… .123456', '%f') emits the 6-digit fractional second. */
-    public void testClusterE_dateFormatPercentFFullSixDigits() throws IOException {
+    /** date_format('… .123456', '%f') emits the 6-digit fractional second. */
+    public void testDateFormatPercentFFullSixDigits() throws IOException {
         assertFirstRowString(
             oneRow() + "| eval f = date_format('2024-01-15 12:00:00.123456', '%f') | fields f",
             "123456"
         );
     }
 
-    /** Cluster E: microsecond on a varchar column resolves through the same string-overload arm. */
-    public void testClusterE_microsecondOnVarcharColumn() throws IOException {
+    /** microsecond on a varchar column resolves through the same string-overload arm. */
+    public void testMicrosecondOnVarcharColumn() throws IOException {
         Map<String, Object> response = executePpl(
             oneRow() + "| eval s = '2024-01-15 12:00:00.654321' | eval f = microsecond(s) | fields f"
         );
@@ -442,8 +439,8 @@ public class DatetimeCoverageIT extends AnalyticsRestTestCase {
             654321L, ((Number) firstRowFirstCell(response)).longValue());
     }
 
-    /** Cluster E: μs=1 fraction surfaces as 1 (not zeroed by ms-truncation). */
-    public void testClusterE_nanosecondLiteralFold() throws IOException {
+    /** μs=1 fraction surfaces as 1 (not zeroed by ms-truncation). */
+    public void testNanosecondLiteralFold() throws IOException {
         Map<String, Object> response = executePpl(
             oneRow() + "| eval f = microsecond('2024-01-15 12:00:00.000001') | fields f"
         );
@@ -453,34 +450,33 @@ public class DatetimeCoverageIT extends AnalyticsRestTestCase {
     }
 
     // ─────────────────────────────────────────────────────────────────────────
-    // Cluster F — Format-token / mode / value-range gaps (11 methods)
-    // commit 91b7c0bc6d3
+    // Format-token / mode / value-range — week modes, format tokens, MAKEDATE/MAKETIME, CAST.
     // ─────────────────────────────────────────────────────────────────────────
 
-    /** Cluster F: WEEK(date) default mode 0 returns MySQL-style 7 (not ISO 8). */
-    public void testClusterF_weekDefaultMode0() throws IOException {
+    /** WEEK(date) default mode 0 returns MySQL-style 7 (not ISO 8). */
+    public void testWeekDefaultMode0() throws IOException {
         Map<String, Object> response = executePpl(oneRow() + "| eval f = week(date('2008-02-20')) | fields f");
         assertEquals("week(date('2008-02-20')) default mode 0 must be 7",
             7L, ((Number) firstRowFirstCell(response)).longValue());
     }
 
-    /** Cluster F: WEEK(date, mode) — mode-arg overload resolves to a positive int. */
-    public void testClusterF_weekModeArgOverload() throws IOException {
+    /** WEEK(date, mode) — mode-arg overload resolves to a positive int. */
+    public void testWeekModeArgOverload() throws IOException {
         Map<String, Object> response = executePpl(oneRow() + "| eval f = week(date('2008-02-20'), 1) | fields f");
         Object cell = firstRowFirstCell(response);
         assertNotNull("week(date, mode) must be non-null post-fix", cell);
         assertTrue("week(date, 1) must be a positive integer", ((Number) cell).longValue() > 0);
     }
 
-    /** Cluster F: WEEK_OF_YEAR(date) default mode 0 returns MySQL-style 7. */
-    public void testClusterF_weekOfYearMode0() throws IOException {
+    /** WEEK_OF_YEAR(date) default mode 0 returns MySQL-style 7. */
+    public void testWeekOfYearMode0() throws IOException {
         Map<String, Object> response = executePpl(oneRow() + "| eval f = week_of_year(date('2008-02-20')) | fields f");
         assertEquals("week_of_year(date('2008-02-20')) default mode 0 must be 7",
             7L, ((Number) firstRowFirstCell(response)).longValue());
     }
 
-    /** Cluster F: str_to_date('1-May-13', '%d-%b-%y') resolves the %b month abbreviation. */
-    public void testClusterF_strToDatePercentB() throws IOException {
+    /** str_to_date('1-May-13', '%d-%b-%y') resolves the %b month abbreviation. */
+    public void testStrToDatePercentB() throws IOException {
         // Pre-fix %b silently mapped to month=1; post-fix it parses 'May' = 5.
         assertFirstRowString(
             oneRow() + "| eval f = date_format(str_to_date('1-May-13', '%d-%b-%y'), '%Y-%m-%d %H:%i:%s') | fields f",
@@ -488,8 +484,8 @@ public class DatetimeCoverageIT extends AnalyticsRestTestCase {
         );
     }
 
-    /** Cluster F: date_format with %c %U %u %V %v emits month-no-leading-zero + correct week numbering. */
-    public void testClusterF_dateFormatPercentTokens() throws IOException {
+    /** date_format with %c %U %u %V %v emits month-no-leading-zero + correct week numbering. */
+    public void testDateFormatPercentTokens() throws IOException {
         // 2024-01-28 — Sunday. Mode 0 (Sun-first): U=4, V=4. Mode 1 (Mon-first): u=4, v=4.
         assertFirstRowString(
             oneRow() + "| eval f = date_format(date('2024-01-28'), '%c %U %u %V %v') | fields f",
@@ -497,8 +493,8 @@ public class DatetimeCoverageIT extends AnalyticsRestTestCase {
         );
     }
 
-    /** Cluster F: unix_timestamp(numeric YYYYMMDDhhmmss) parses the compact form. */
-    public void testClusterF_unixTimestampNumericLiteral() throws IOException {
+    /** unix_timestamp(numeric YYYYMMDDhhmmss) parses the compact form. */
+    public void testUnixTimestampNumericLiteral() throws IOException {
         Map<String, Object> response = executePpl(
             oneRow() + "| eval f = unix_timestamp(20771122143845) | fields f"
         );
@@ -509,24 +505,24 @@ public class DatetimeCoverageIT extends AnalyticsRestTestCase {
             3404817525.0, ((Number) cell).doubleValue(), 0.5);
     }
 
-    /** Cluster F: convert_tz with out-of-range tz folds to NULL (not HTTP 400). */
-    public void testClusterF_convertTzOutOfRangeFolds() throws IOException {
+    /** convert_tz with out-of-range tz folds to NULL (not HTTP 400). */
+    public void testConvertTzOutOfRangeFolds() throws IOException {
         Map<String, Object> response = executePpl(
             oneRow() + "| eval f = convert_tz('2024-01-15 12:00:00', '+15:00', '+00:00') | fields f"
         );
         assertNull("out-of-range source tz must fold to NULL", firstRowFirstCell(response));
     }
 
-    /** Cluster F: cast('1985-10-09 12:00:00' AS TIME) returns the time portion only. */
-    public void testClusterF_castTimeFromDatetimeString() throws IOException {
+    /** cast('1985-10-09 12:00:00' AS TIME) returns the time portion only. */
+    public void testCastTimeFromDatetimeString() throws IOException {
         assertFirstRowString(
             oneRow() + "| eval f = time_format(cast('1985-10-09 12:00:00' as TIME), '%H:%i:%s') | fields f",
             "12:00:00"
         );
     }
 
-    /** Cluster F: date_format with the rich %a/%b/%c/%D/%H/%i token spec round-trips. */
-    public void testClusterF_dateFormatRichSpec() throws IOException {
+    /** date_format with the rich %a/%b/%c/%D/%H/%i token spec round-trips. */
+    public void testDateFormatRichSpec() throws IOException {
         // Locale-independent subset of the deep-dive 23-token spec (drops %j/%P/%r/%T).
         assertFirstRowString(
             oneRow()
@@ -535,8 +531,8 @@ public class DatetimeCoverageIT extends AnalyticsRestTestCase {
         );
     }
 
-    /** Cluster F: MAKEDATE with fractional and >365 day-of-year inputs (deep-dive ADD-4). */
-    public void testClusterF_makeDateFractionalDayOfYear() throws IOException {
+    /** MAKEDATE with fractional and >365 day-of-year inputs. */
+    public void testMakeDateFractionalDayOfYear() throws IOException {
         // makedate(1945, 5.9) → '1945-01-06' (FLOOR rounding); makedate(1984, 1984) → '1989-06-06'.
         assertFirstRowString(
             oneRow()
@@ -545,8 +541,8 @@ public class DatetimeCoverageIT extends AnalyticsRestTestCase {
         );
     }
 
-    /** Cluster F: MAKETIME with integer and fractional H/M/S inputs (deep-dive ADD-5). */
-    public void testClusterF_makeTimeFractional() throws IOException {
+    /** MAKETIME with integer and fractional H/M/S inputs. */
+    public void testMakeTimeFractional() throws IOException {
         // maketime(20, 30, 40) → '20:30:40'; maketime(20.2, 49.5, 42.1) → '20:50:42.x'.
         // %H:%i:%s drops the fractional tail (engine-specific and not gate-stable).
         assertFirstRowString(
@@ -557,11 +553,11 @@ public class DatetimeCoverageIT extends AnalyticsRestTestCase {
     }
 
     // ─────────────────────────────────────────────────────────────────────────
-    // Cherry-pick (PR 22014, ecfd145baed) — TIMESTAMP composition + HOUR fold (2 methods)
+    // TIMESTAMP composition + HOUR plan-time fold.
     // ─────────────────────────────────────────────────────────────────────────
 
-    /** Cherry-pick: TIMESTAMP(date_col, time_col) combines the two operands. */
-    public void testCherryPick_timestampDateAndTimeArgs() throws IOException {
+    /** TIMESTAMP(date_col, time_col) combines the two operands. */
+    public void testTimestampDateAndTimeArgs() throws IOException {
         // date0 at key00 = '2004-04-15'; time1 at key00 = '19:36:22'.
         assertFirstRowString(
             oneRow() + "| eval f = date_format(timestamp(date0, time1), '%Y-%m-%d %H:%i:%s') | fields f",
@@ -569,15 +565,15 @@ public class DatetimeCoverageIT extends AnalyticsRestTestCase {
         );
     }
 
-    /** Cherry-pick: HOUR(TIME('17:30:00')) literal-folds at plan time. */
-    public void testCherryPick_hourOfTimeLiteralFold() throws IOException {
+    /** HOUR(TIME('17:30:00')) literal-folds at plan time. */
+    public void testHourOfTimeLiteralFold() throws IOException {
         Map<String, Object> response = executePpl(oneRow() + "| eval f = hour(time('17:30:00')) | fields f");
         assertEquals("hour(TIME('17:30:00')) must fold to 17", 17L,
             ((Number) firstRowFirstCell(response)).longValue());
     }
 
     // ─────────────────────────────────────────────────────────────────────────
-    // Boundary values — min/max supported date/time/timestamp (7 methods)
+    // Boundary values — min/max supported date/time/timestamp.
     // ─────────────────────────────────────────────────────────────────────────
 
     /** Boundary: cast('0001-01-01' AS DATE) — ANSI-SQL min DATE round-trips. */

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/DatetimeCoverageIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/DatetimeCoverageIT.java
@@ -48,8 +48,6 @@ public class DatetimeCoverageIT extends AnalyticsRestTestCase {
     // ─────────────────────────────────────────────────────────────────────────
 
     /** Cluster A: span(date, 1d) bucket renders as bare date, no '00:00:00' suffix. */
-    // Pending sql cluster A: DateOnlyType / TimeOnlyType UDT bridging in OpenSearchTypeFactory
-    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/sql/pull/<TBD>")
     public void testClusterA_spanDateTypePreservesDate() throws IOException {
         Map<String, Object> response = executePpl(
             "source=" + DATASET.indexName + " | stats count() as c by span(date0, 1d) as date_span | sort date_span | head 1"
@@ -62,8 +60,6 @@ public class DatetimeCoverageIT extends AnalyticsRestTestCase {
     }
 
     /** Cluster A: span(date, 1month) preserves date type, bucket on month boundary. */
-    // Pending sql cluster A: DateOnlyType / TimeOnlyType UDT bridging in OpenSearchTypeFactory
-    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/sql/pull/<TBD>")
     public void testClusterA_spanDateUnitMonth() throws IOException {
         Map<String, Object> response = executePpl(
             "source=" + DATASET.indexName + " | stats count() as c by span(date1, 1month) as date_span | sort date_span | head 1"
@@ -74,8 +70,6 @@ public class DatetimeCoverageIT extends AnalyticsRestTestCase {
     }
 
     /** Cluster A: span(time, 1h) returns TIME-typed bucket, no '1970-01-01' prefix. */
-    // Pending sql cluster A: DateOnlyType / TimeOnlyType UDT bridging in OpenSearchTypeFactory
-    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/sql/pull/<TBD>")
     public void testClusterA_spanTimeTypePreservesTime() throws IOException {
         Map<String, Object> response = executePpl(
             "source=" + DATASET.indexName + " | where key='key00' | stats count() by span(time1, 1h) as time_span"
@@ -87,8 +81,6 @@ public class DatetimeCoverageIT extends AnalyticsRestTestCase {
     }
 
     /** Cluster A: span(time, 1minute) returns TIME-typed bucket. */
-    // Pending sql cluster A: DateOnlyType / TimeOnlyType UDT bridging in OpenSearchTypeFactory
-    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/sql/pull/<TBD>")
     public void testClusterA_spanTimeUnitMinute() throws IOException {
         Map<String, Object> response = executePpl(
             "source=" + DATASET.indexName + " | where key='key00' | stats count() by span(time1, 1minute) as time_span"
@@ -99,7 +91,11 @@ public class DatetimeCoverageIT extends AnalyticsRestTestCase {
     }
 
     /** Cluster A: span over an eval-derived DATE expression preserves DATE typing. */
-    // Pending sql cluster A: DateOnlyType / TimeOnlyType UDT bridging in OpenSearchTypeFactory
+    // Pending sql plugin: DateOnlyType bridging on span() result requires OpenSearchTypeFactory
+    // changes (SQL plugin is read-only on this branch). The Calcite-side return-type inference
+    // for SpanFunction forwards operand 0's type (DATE), but the substrait round-trip materializes
+    // the wire as Timestamp(Microsecond), and the SQL plugin's value renderer only strips midnight
+    // suffix when the type is DateOnlyType — not plain DATE. Cluster-A peers have the same shape.
     @AwaitsFix(bugUrl = "https://github.com/opensearch-project/sql/pull/<TBD>")
     public void testClusterA_spanCustomFormatDate() throws IOException {
         Map<String, Object> response = executePpl(
@@ -116,8 +112,6 @@ public class DatetimeCoverageIT extends AnalyticsRestTestCase {
     // ─────────────────────────────────────────────────────────────────────────
 
     /** Cluster B: 2-arg DATETIME(literal, tz-literal) folds to a typed TIMESTAMP. */
-    // Pending sql cluster A+D: combined UDT bridging + value rendering
-    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/sql/pull/<TBD>")
     public void testClusterB_twoArgDatetimeLiteralFold() throws IOException {
         // +10:00 offset shifts wall time back 10h → '2007-12-31 16:00:00'.
         assertFirstRowString(
@@ -136,8 +130,6 @@ public class DatetimeCoverageIT extends AnalyticsRestTestCase {
     }
 
     /** Cluster B: 2-arg DATETIME with column input resolves through the same overload. */
-    // Pending sql cluster A+D: combined UDT bridging + value rendering
-    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/sql/pull/<TBD>")
     public void testClusterB_twoArgDatetimeColInput() throws IOException {
         Map<String, Object> response = executePpl(
             oneRow() + "| eval f = datetime(datetime0, '+00:00') | fields f"
@@ -416,8 +408,6 @@ public class DatetimeCoverageIT extends AnalyticsRestTestCase {
     // ─────────────────────────────────────────────────────────────────────────
 
     /** Cluster E: cast(varchar AS TIMESTAMP) preserves microseconds (not truncated to ms). */
-    // Pending sql cluster A+D: combined UDT bridging + value rendering
-    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/sql/pull/<TBD>")
     public void testClusterE_castTimestampPreservesMicros() throws IOException {
         assertFirstRowString(
             oneRow()
@@ -499,8 +489,6 @@ public class DatetimeCoverageIT extends AnalyticsRestTestCase {
     }
 
     /** Cluster F: date_format with %c %U %u %V %v emits month-no-leading-zero + correct week numbering. */
-    // Pending sql cluster A+D: combined UDT bridging + value rendering
-    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/sql/pull/<TBD>")
     public void testClusterF_dateFormatPercentTokens() throws IOException {
         // 2024-01-28 — Sunday. Mode 0 (Sun-first): U=4, V=4. Mode 1 (Mon-first): u=4, v=4.
         assertFirstRowString(
@@ -530,8 +518,6 @@ public class DatetimeCoverageIT extends AnalyticsRestTestCase {
     }
 
     /** Cluster F: cast('1985-10-09 12:00:00' AS TIME) returns the time portion only. */
-    // Pending sql cluster A+D: combined UDT bridging + value rendering
-    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/sql/pull/<TBD>")
     public void testClusterF_castTimeFromDatetimeString() throws IOException {
         assertFirstRowString(
             oneRow() + "| eval f = time_format(cast('1985-10-09 12:00:00' as TIME), '%H:%i:%s') | fields f",
@@ -540,8 +526,6 @@ public class DatetimeCoverageIT extends AnalyticsRestTestCase {
     }
 
     /** Cluster F: date_format with the rich %a/%b/%c/%D/%H/%i token spec round-trips. */
-    // Pending sql cluster A+D: combined UDT bridging + value rendering
-    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/sql/pull/<TBD>")
     public void testClusterF_dateFormatRichSpec() throws IOException {
         // Locale-independent subset of the deep-dive 23-token spec (drops %j/%P/%r/%T).
         assertFirstRowString(
@@ -562,8 +546,6 @@ public class DatetimeCoverageIT extends AnalyticsRestTestCase {
     }
 
     /** Cluster F: MAKETIME with integer and fractional H/M/S inputs (deep-dive ADD-5). */
-    // Pending sql cluster A+D: combined UDT bridging + value rendering
-    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/sql/pull/<TBD>")
     public void testClusterF_makeTimeFractional() throws IOException {
         // maketime(20, 30, 40) → '20:30:40'; maketime(20.2, 49.5, 42.1) → '20:50:42.x'.
         // %H:%i:%s drops the fractional tail (engine-specific and not gate-stable).
@@ -617,8 +599,6 @@ public class DatetimeCoverageIT extends AnalyticsRestTestCase {
     }
 
     /** Boundary: max supported TIMESTAMP at milli precision — just under the i64-ns epoch ceiling (2262-04-11). */
-    // Pending sql cluster A+D: combined UDT bridging + value rendering
-    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/sql/pull/<TBD>")
     public void testBoundary_maxSupportedTimestampMilli() throws IOException {
         // engine prints fractional seconds as-given; no zero-pad to µs
         assertFirstRowString(
@@ -642,8 +622,6 @@ public class DatetimeCoverageIT extends AnalyticsRestTestCase {
     }
 
     /** Boundary: cast('23:59:59.999999' AS TIME) — last-µs-of-day TIME round-trips. */
-    // Pending sql cluster A+D: combined UDT bridging + value rendering
-    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/sql/pull/<TBD>")
     public void testBoundary_maxSupportedTime() throws IOException {
         assertFirstRowString(oneRow() + "| eval a = cast('23:59:59.999999' as TIME) | fields a", "23:59:59.999999");
     }

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/DatetimeCoverageIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/DatetimeCoverageIT.java
@@ -325,6 +325,27 @@ public class DatetimeCoverageIT extends AnalyticsRestTestCase {
         assertErrorContains(oneRow() + "| eval a = hour('99:99:99') | fields a", "99:99:99");
     }
 
+    /** Cluster C: DAYNAME('2025-13-02') rejects at plan time with the format hint (no StreamException). */
+    public void testClusterC_daynameBadStringRejects() throws IOException {
+        assertErrorContains(oneRow() + "| eval a = dayname('2025-13-02') | fields a", "unsupported format");
+    }
+
+    /** Cluster C: MONTHNAME('2025-13-02') rejects at plan time with the format hint (no StreamException). */
+    public void testClusterC_monthnameBadStringRejects() throws IOException {
+        assertErrorContains(oneRow() + "| eval a = monthname('2025-13-02') | fields a", "unsupported format");
+    }
+
+    /** Cluster C: DAYNAME with a valid date literal renders the full weekday name (positive path). */
+    public void testClusterC_daynameValidLiteral() throws IOException {
+        // 2020-08-26 was a Wednesday.
+        assertFirstRowString(oneRow() + "| eval a = dayname('2020-08-26') | fields a", "Wednesday");
+    }
+
+    /** Cluster C: MONTHNAME with a valid date literal renders the full month name (positive path). */
+    public void testClusterC_monthnameValidLiteral() throws IOException {
+        assertFirstRowString(oneRow() + "| eval a = monthname('2020-08-26') | fields a", "August");
+    }
+
     // ─────────────────────────────────────────────────────────────────────────
     // Cluster D — Datetime stringification: space separator, no epoch prefix (5 methods)
     // commit 6988b804646

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/ExtensiveCoveragePplIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/ExtensiveCoveragePplIT.java
@@ -26,6 +26,6 @@ public class ExtensiveCoveragePplIT extends BasePplIT {
     /** Queries that fail at 1 shard: mixed: date/time formatting, string-value, unsupported-fn (see per-q). Skipped so the rest run and are visible. */
     @Override
     protected java.util.Set<Integer> getSkipQueries() {
-        return java.util.Set.of(8, 19, 20, 22, 24, 25, 28, 29, 30, 39, 52, 55, 56, 57, 58, 59, 60, 61, 62, 77, 81, 85, 88, 93, 94, 95, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 108, 110, 111, 112, 114, 115, 117, 119, 120, 125, 126, 128, 131, 132, 136, 137, 138, 139, 143, 144, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 160, 162, 163, 188, 189, 190, 191, 196);
+        return java.util.Set.of(8, 19, 20, 22, 24, 25, 28, 29, 30, 39, 52, 55, 56, 57, 58, 59, 60, 61, 62, 77, 81, 85, 88, 93, 94, 95, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 108, 110, 111, 114, 115, 117, 120, 131, 132, 136, 143, 149, 150, 153, 154, 155, 157, 160, 162, 163, 188, 189, 190, 191, 196);
     }
 }

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/TimestampFunctionIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/TimestampFunctionIT.java
@@ -227,12 +227,36 @@ public class TimestampFunctionIT extends AnalyticsRestTestCase {
         );
     }
 
-    // Pending sql cluster A+D: combined UDT bridging + value rendering
-    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/sql/pull/<TBD>")
-    public void testTimeEqualsDateDoesNotCrash() throws IOException {
-        // Pre-fix this lowered to to_timestamp(Date32) which DataFusion rejected at runtime.
+    // ── TIME-vs-{DATE,TIMESTAMP} comparison routes through ComparisonTemporalCoercionAdapter ──
+    // Pre-fix every shape failed plan-time with "Unable to convert call to_timestamp(precision_time<9>?)".
+
+    /** TIME = DATE — today-anchored midnight is not 2004-07-09. */
+    public void testTimeEqualsDate() throws IOException {
         Object cell = firstRowFirstCell(oneRow("key00") + "| eval v = time('00:00:00') = date('2004-07-09') | fields v");
-        assertTrue("Expected boolean result, got: " + cell, cell instanceof Boolean);
+        assertEquals(Boolean.FALSE, cell);
+    }
+
+    /** {@code DATE < TIME} — TIME lifts to today-anchored TIMESTAMP, so a past DATE is less than today. */
+    public void testDateLessThanTime() throws IOException {
+        Object cell = firstRowFirstCell(oneRow("key00") + "| eval v = date('2020-09-16') < time('09:07:00') | fields v");
+        assertEquals(Boolean.TRUE, cell);
+    }
+
+    /** TIME = TIMESTAMP — same time-of-day on today's date holds. */
+    public void testTimeEqualsTimestampSameTimeOfDay() throws IOException {
+        String today = LocalDate.now(ZoneOffset.UTC).toString();
+        Object cell = firstRowFirstCell(
+            oneRow("key00") + "| eval v = time('10:20:30') = timestamp('" + today + " 10:20:30') | fields v"
+        );
+        assertEquals(Boolean.TRUE, cell);
+    }
+
+    /** TIMESTAMP != TIME — opposite direction. */
+    public void testTimestampNotEqualsTime() throws IOException {
+        Object cell = firstRowFirstCell(
+            oneRow("key00") + "| eval v = timestamp('1984-12-15 10:20:30') != time('10:20:30') | fields v"
+        );
+        assertEquals(Boolean.TRUE, cell);
     }
 
     // ── helpers ──────────────────────────────────────────────────────────────────

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/TimestampFunctionIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/TimestampFunctionIT.java
@@ -8,7 +8,6 @@
 
 package org.opensearch.analytics.qa;
 
-import org.apache.lucene.tests.util.LuceneTestCase.AwaitsFix;
 import org.opensearch.client.Request;
 import org.opensearch.client.Response;
 import org.opensearch.client.ResponseException;
@@ -116,8 +115,6 @@ public class TimestampFunctionIT extends AnalyticsRestTestCase {
 
     // ── Shape C: TIMESTAMP(TIME('<lit>')) → fold with today's UTC date ───────────
 
-    // Pending sql cluster A+D: combined UDT bridging + value rendering
-    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/sql/pull/<TBD>")
     public void testShapeCTimeLiteralFoldsWithTodayUtc() throws IOException {
         // Today's date varies, so we extract the time-of-day component and assert that
         // (year(v) >= 2020) AND time_format(v) == '10:20:30'. The combination pins the

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/TwoShardCommandIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/TwoShardCommandIT.java
@@ -38,7 +38,7 @@ public class TwoShardCommandIT extends TwoShardReduceTestCase {
     }
 
     /** Override solely to attach @AwaitsFix; inherited body is unchanged. */
-    // Pending sql cluster A+D: combined UDT bridging + value rendering
+    // Pending sql plugin: timechart bucket renders as bare DATE instead of TIMESTAMP (3/18 sub-checks fail).
     @Override
     @AwaitsFix(bugUrl = "https://github.com/opensearch-project/sql/pull/<TBD>")
     public void testReduceCorrectnessAcrossTwoShards() throws IOException {


### PR DESCRIPTION
## Summary

Wave 2 of PPL date/time fixes on the analytics-engine route. Adds 15 missing datetime scalars, lowers query shapes that previously hit Substrait binding gaps, and tightens MySQL-semantic correctness on existing functions. Unmutes 16 of the 18 `@AwaitsFix` ITs gated in #22045.

## What's in each commit

### Add 15 PPL datetime scalars over DataFusion

- New scalars: `ADDDATE`, `SUBDATE`, `DATEDIFF`, `TO_DAYS` / `TO_SECONDS` / `FROM_DAYS` / `TIME_TO_SEC`, `SEC_TO_TIME`, `WEEKDAY`, `PERIOD_ADD` / `PERIOD_DIFF`, `GET_FORMAT`, `ADDTIME` / `SUBTIME` / `TIMEDIFF`, `LAST_DAY`, `YEARWEEK`.
- Per-function adapters lower each call to `to_unixtime` / `from_unixtime` + integer arithmetic, `date_trunc`, `maketime`, or a Rust UDF (new `os_yearweek`).
- Unmutes 15 `ExtensiveCoveragePplIT` golden queries (q112/119/125/126/128/137/138/139/144/147/148/151/152/156/158).

### Fix TIME-vs-{DATE,TIMESTAMP} comparison via operand coercion

- Calcite's binary-comparison type coercion wraps a TIME operand with `to_timestamp(precision_time<P>)`, which has no yaml binding (substrait-java 0.89.1 lacks `ToTypeString` for `PrecisionTime`).
- Extend `ComparisonTemporalCoercionAdapter` to anchor the TIME side to a today-UTC TIMESTAMP.
- Queries like `time('00:00:00') = date('2004-07-09')` now resolve.

### Register PPL ADDDATE/SUBDATE with integer-days overload

- The integer form (`adddate(date, 7)`) was bailed by `DateAddSubAdapter`.
- Adapter now rebuilds an integer second operand as `INTERVAL N DAY` before the standard interval-lowering path runs.

### Preserve sub-millisecond precision in timestamp literal folds

- `timestamp('2020-09-16 17:30:00.123456')` was folded at parquet's resolved precision (3) and silently truncated to `.123`.
- `TimestampFunctionAdapter` now bumps fold precision to 6 when the input carries non-zero sub-ms digits.
- `microsecond(...)` and `date_format(_, '%f')` round-trip the full 6 digits.

### Reject invalid string literals in DAYNAME/MONTHNAME at plan time

- `DAYNAME('2025-13-02')` previously crashed the streaming fragment with a generic `StreamException`.
- Adapters now validate at plan time and return HTTP 400 with the typed `unsupported format` hint, matching the `DATE` / `TIME` / `TIMESTAMP` siblings.

### Pin convert_tz precision-9 path with regression IT

- Locks in the precision-9 SAFE-cast contract (already shipped in earlier `dd3a231eb2e`) against future regression.
- Mirrors `CalcitePPLBuiltinFunctionsNullIT`'s null-string DATETIME shape.

### Unmute 14 datetime ITs

Five narrow follow-up fixes that flip previously-pending regression gates green:

- `ArrowValues` TIMESTAMP/TIME render: variable-fraction (1..9 digits, trailing zeros stripped) instead of fixed-9 — `.999999000` → `.999999`.
- `DatetimeAdapter` (1-arg): TIME operand anchored to TIMESTAMP before `to_timestamp` (yaml has no `precision_time<P>` arm).
- `DatetimeAdapter` (2-arg, column path): synthesised tz literal as VARCHAR (was CHAR(N)) so isthmus binds the `convert_tz(_, string, string)` arm.
- `DatetimeAdapter` (2-arg, fold + column): MySQL semantics — when the value has no embedded TZ offset, the user's tz arg is the **source** zone (target=UTC), not the target. Inverted the offset direction pre-fix.
- `os_strftime` Rust UDF: `%c` emits unpadded month; `%U` / `%u` / `%V` / `%v` emit zero-padded width-2 week numbers (matches MySQL docs and PPL DateTimeFormatterUtil).

### Drop as_any from OsYearweekUdf for DataFusion 54 compat

- Mainline #22063 removed `as_any` from `ScalarUDFImpl` (the `udf_identity!` macro now provides it). The new `OsYearweekUdf` still declared the override.
- Drop the override; trait dispatch falls through to the macro's impl.

Also includes a behavior-only rename of `DatetimeCoverageIT` test methods (dropped internal cluster-letter labels in favor of behavior-named methods).

## Query shapes added / fixed

### New scalars (each lowers to a DataFusion-native plan)

| Function | Example query | Notes |
|---|---|---|
| `ADDDATE`, `SUBDATE` | `adddate(date0, 7)`, `adddate(date0, interval 7 day)`, `subdate(date0, interval 1 month)`, `adddate(datetime0, interval 5 hour)`, `subdate(datetime0, interval 30 minute)`, `adddate('2020-08-26', interval 7 day)` | Integer-days, INTERVAL form, DATE / TIMESTAMP / VARCHAR base |
| `DATEDIFF` | `datediff('2000-01-02 00:00:00', '2000-01-01 23:59:59')` (= 1, time-of-day discarded), `datediff(time('23:59:59'), time('00:00:00'))` (= 0, both anchored to today) | |
| `TO_DAYS` | `to_days('1970-01-01')` (= 719528, MySQL day-1 origin) | |
| `TO_SECONDS` | `to_seconds('1970-01-01 00:00:00')` (= 62167219200) | |
| `FROM_DAYS` | `from_days(719528)` (= 1970-01-01) | |
| `TIME_TO_SEC` | `time_to_sec(datetime0)`, `time_to_sec(time('19:36:22'))` | |
| `SEC_TO_TIME` | `sec_to_time(123456)` (= 10:17:36, MOD-86400 wrap) | |
| `WEEKDAY` | `weekday(datetime0)` (Mon=0..Sun=6) | |
| `PERIOD_ADD` | `period_add(202612, 1)` (= 202701, year-boundary roll) | |
| `PERIOD_DIFF` | `period_diff(202612, 202601)` (= 11) | |
| `GET_FORMAT` | `get_format(DATE, 'EUR')` (= '%d.%m.%Y') | All 5 region variants |
| `ADDTIME`, `SUBTIME` | `addtime(datetime0, time('14:00:00'))` (cross-midnight), `subtime(datetime0, time('11:00:00'))`, `addtime(datetime0, time1)`, `addtime(time1, time('02:30:00'))` | TIMESTAMP+TIME and TIME+TIME |
| `TIMEDIFF` | `timediff(time('23:59:59'), time('13:00:00'))` (= 10:59:59) | |
| `LAST_DAY` | `last_day('2024-02-15')` (= 2024-02-29, leap-year), `last_day(date0)`, `last_day(datetime0)` | |
| `YEARWEEK` | `yearweek('2003-10-03')` (= 200339), `yearweek('2003-10-03', 3)` (= 200340), `yearweek(datetime0)` | All 8 modes |

### Function-overload gaps closed

| Shape | Now resolves |
|---|---|
| `datetime('2008-01-01 02:00:00', '+10:00')` | 2-arg DATETIME literal fold (= '2007-12-31 16:00:00', MySQL source-tz semantics) |
| `datetime('2008-01-01 02:00:00', 'America/Los_Angeles')` | 2-arg DATETIME with named-zone string |
| `datetime(datetime0, '+00:00')` | 2-arg DATETIME with column input |
| `datetime('2008-01-01 02:00:00', '+15:00')` | Out-of-range tz folds to NULL (was HTTP 400) |
| `DATETIME(null_str, '+10:00')` | Null operands fold to typed-null TIMESTAMP |
| `sysdate(0)` / `now(0)` | FSP-arg overload |
| `date_add(time('09:00:00'), interval 1 hour)`, `date_sub(time('09:00:00'), interval 30 minute)` | DATE_ADD/SUB on TIME operand |
| `timestampadd(YEAR, 1, '2024-01-15 12:00:00')`, `timestampdiff(DAY, '...', '...')`, `timestampdiff(MONTH, '...', '...')` | Standalone string-overload |
| `hour(time('17:30:45'))`, `minute(time('17:30:45'))`, `second(time('17:30:45'))` | DATE_PART(unit, TIME) |
| `from_unixtime(1521467703, '%Y-%m-%d %H:%i:%s')` | 2-arg FROM_UNIXTIME |
| `timestamp(date0, time1)` | 2-arg TIMESTAMP composition |
| `timestamp(time('10:20:30'))` | 1-arg TIMESTAMP(TIME) — folds with today-UTC |

### Comparisons across mixed temporal types

| Shape | Result |
|---|---|
| `time('00:00:00') = date('2004-07-09')` | TIME side anchored to today-UTC; resolves to BOOLEAN |
| `date('2020-09-16') < time('09:07:00')` | Symmetric — DATE < anchored-TIME |
| `time('10:20:30') = timestamp('<today> 10:20:30')` | TRUE on same time-of-day |
| `timestamp('1984-12-15 10:20:30') != time('10:20:30')` | TIMESTAMP != TIME (anchored) |

### Span types

| Shape | Now |
|---|---|
| `span(date0, 1d)`, `span(date1, 1month)` | Bare date string, `date` schema type (was `2004-04-15 00:00:00` / `timestamp`) |
| `span(time1, 1h)`, `span(time1, 1minute)` | Time-of-day, `time` schema type (was `1970-01-01 19:00:00`) |

### Format-token / rendering

| Shape | Now |
|---|---|
| `date_format(date('2024-01-28'), '%c %U %u %V %v')` | `1 04 04 04 04` (was `01 4 4 4 4`) |
| `date_format(timestamp('1998-01-31 13:14:15'), '%a %b %c %D %d %H %i %M %m %S')` | `Sat Jan 1 31st 31 13 14 January 01 15` (was `Sat Jan 01 …`) |
| `date_format('2024-01-15 12:00:00.123456', '%f')` | `123456` (was `123000`) |
| `microsecond('2024-01-15 12:00:00.123456')` | `123456` (was `123000`) |
| `microsecond('2024-01-15 12:00:00.000001')` | `1` (was `0`) |
| `cast('2023-10-01 12:00:00.123456' as TIMESTAMP)` rendered | `.123456` preserved (was truncated to `.123`) |
| `cast('2262-04-11 23:47:16.854' as TIMESTAMP)` | `2262-04-11 23:47:16.854` (was `…854000`) |
| `cast('23:59:59.999999' as TIME)` | `23:59:59.999999` (was `…999999000`) |
| `date_add(datetime0, interval 500 millisecond)` | `2004-07-09 10:17:35.5` (was `…500000000`) |
| `cast('1985-10-09 12:00:00' as TIME)` | `12:00:00` |
| `maketime(20.2, 49.5, 42.1)` rendered via `time_format(_, '%H:%i:%s')` | `20:50:42` |

### Error-contract / validation

| Shape | HTTP 400 with `unsupported format` |
|---|---|
| `dayname('2025-13-02')`, `monthname('2025-13-02')` | New plan-time validation (was `StreamException` 500) |
| `date('2025-13-02')`, `time('16:00:61')`, `timestamp('2025-12-01 15:02:61')` | Existing |
| `cast('xxx' as DATE)`, `cast('xxx' as TIME)`, `cast('xxx' as TIMESTAMP)` | Existing |
| `timestampadd(YEAR, 1, '2025-13-02')`, `timestampdiff(DAY, '2025-13-02', ...)` | Existing |
| `hour('99:99:99')` | Existing |
| `datetime('2025-13-02')` | Folds to NULL (1-arg form) |
| `convert_tz(_, '+15:00', '+00:00')` | Out-of-range tz folds to NULL |

### Boundary / range

| Shape | Now |
|---|---|
| `cast('0001-01-01' as DATE)`, `cast('9999-12-31' as DATE)` | ANSI-SQL min/max DATE round-trip |
| `cast('1677-09-21 00:12:44' as TIMESTAMP)` | Min TIMESTAMP (i64-ns floor) |
| `cast('2200-01-01 00:00:00' as TIMESTAMP)` | Below year-2262 ceiling |
| `cast('00:00:00' as TIME)` | Midnight TIME |
| `timestamp('3077-04-12 09:07:00')` | Plan-time reject — `outside the supported range` (no opaque Arrow overflow) |

### Other

| Shape | Now |
|---|---|
| `eval is_after = earliest('1900-01-01 00:00:00', datetime0) | where is_after | …` | `earliest` in Project context over non-null TIMESTAMP no longer trips Calcite's BOOLEAN-vs-BOOLEAN-NOT-NULL assert |

## Still skipped (2 of 18)

- **`DatetimeCoverageIT.testSpanCustomFormatDate`** — `span()` over an eval-derived `date(...)` returns the bucket as `"2004-04-01 00:00:00"` instead of the bare `"2004-04-01"`. The renderer in `AnalyticsExecutionEngine#convert` only strips the midnight suffix when the type is `DateOnlyType` (column-mapping UDT), but the eval-derived path produces `ExprDateType`. Fix is one line in the SQL plugin (broaden the predicate to `OpenSearchTypeFactory.isDateExprType(type)`); out of scope here. TODO captured on the test.
- **`TwoShardCommandIT.testReduceCorrectnessAcrossTwoShards`** — `timechart` bucket renders as bare `DATE` instead of `TIMESTAMP` (3 of 18 reduce sub-checks fail). Same renderer/typing gap, surfaces in the multi-shard reduce harness.

## Test plan

- [x] `:sandbox:plugins:analytics-backend-datafusion:check` — green (Java + Rust unit tests).
- [x] `:sandbox:libs:analytics-framework:check` — green.
- [x] `:sandbox:plugins:analytics-engine:check` — green.
- [x] `:sandbox:qa:analytics-engine-rest:integTest` — green for the 16 unmuted ITs against a 2-node test cluster; the 2 remaining `@AwaitsFix` tests stay skipped with rationale.
- [x] Spotless clean on every touched module.
