### PR TITLE
Specifically disable gradle build cache but keep dep cache in sandbox test

### DIFF
--- a/.github/workflows/sandbox-check.yml
+++ b/.github/workflows/sandbox-check.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Set Cargo build jobs
         run: echo "CARGO_BUILD_JOBS=$(nproc)" >> $GITHUB_ENV
       - name: Run sandbox check
-        run: ./gradlew check -p sandbox -Dsandbox.enabled=true -PrustDebug
+        run: ./gradlew check -p sandbox -Dsandbox.enabled=true -PrustDebug --no-build-cache
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4


### PR DESCRIPTION


<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Specifically disable gradle build cache but keep dep cache in sandbox test

### Related Issues
We have gradle cache enabled on setup-java but also include build cache.
which sometimes can make build stale if changes is only on rust side not on gradle side.
```
      - name: Set up JDK 25
        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
        with:
          java-version: 25
          distribution: temurin
          cache: gradle
```

Specifically disable build cache on the gradle command.

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
