### PR TITLE
[analytics-lucene] Delegate comparisons, IN/RANGE, and REGEXP to Lucene

### DIFF
--- a/gradle/missing-javadoc.gradle
+++ b/gradle/missing-javadoc.gradle
@@ -173,8 +173,15 @@ def javadocProjects = [
   project(":libs:opensearch-compress"),
   project(":server")
 ]
-// Sandbox projects — only present when -Dsandbox.enabled=true
+// Sandbox projects — only present when -Dsandbox.enabled=true.
 rootProject.allprojects.findAll { it.path.startsWith(':sandbox:') }.each { javadocProjects.add(it) }
+
+// analytics-backend-lucene: SargSerializer uses Calcite's Sarg API which exposes Guava types
+// (BoundType, Range) that forbidden-dependencies blocks from compileClasspath. Exclude until
+// Guava is available on the javadoc classpath.
+rootProject.allprojects.findAll { it.path == ':sandbox:plugins:analytics-backend-lucene' }.each {
+  it.tasks.withType(MissingJavadocTask) { isExcluded = true }
+}
 
 configure(javadocProjects) {
   project.tasks.withType(MissingJavadocTask) {

--- a/sandbox/plugins/analytics-backend-lucene/build.gradle
+++ b/sandbox/plugins/analytics-backend-lucene/build.gradle
@@ -19,7 +19,9 @@ java { sourceCompatibility = JavaVersion.toVersion(25); targetCompatibility = Ja
 // Calcite (via analytics-engine) requires Guava which OpenSearch forbids on compile classpath.
 // Use custom config to bypass, same as analytics-engine.
 configurations {
+    calciteCompile
     calciteTestCompile
+    compileClasspath { exclude group: 'com.google.guava' }
     testCompileClasspath { exclude group: 'com.google.guava' }
 }
 
@@ -32,6 +34,7 @@ configurations.all {
         force "com.google.flatbuffers:flatbuffers-java:${versions.flatbuffers}"
     }
 }
+sourceSets.main.compileClasspath += configurations.calciteCompile
 sourceSets.test.compileClasspath += configurations.calciteTestCompile
 
 dependencies {
@@ -70,7 +73,8 @@ dependencies {
     // Planner infrastructure for end-to-end delegation tests
     testImplementation project(':sandbox:plugins:analytics-engine')
 
-    // Guava for test compilation — Calcite API exposes guava types
+    // Guava for compilation — Calcite Sarg/RangeSet API exposes guava types
+    calciteCompile "com.google.guava:guava:${versions.guava}"
     calciteTestCompile "com.google.guava:guava:${versions.guava}"
     testRuntimeOnly "com.google.guava:guava:${versions.guava}"
     testRuntimeOnly 'com.google.guava:failureaccess:1.0.2'

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/CalciteToOSMapperConversionUtils.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/CalciteToOSMapperConversionUtils.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.be.lucene;
 
+import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.util.DateString;
 import org.apache.calcite.util.NlsString;
@@ -131,4 +132,19 @@ public final class CalciteToOSMapperConversionUtils {
         return value.doubleValue();
     }
 
+    /**
+     * Convert a Calcite Sarg endpoint into a Java type the OpenSearch Mapper accepts.
+     */
+    public static Object sargEndpointToOpenSearchValue(Comparable<?> endpoint, RelDataType type) {
+        if (endpoint == null) {
+            return null;
+        }
+        return switch (type.getSqlTypeName()) {
+            case BOOLEAN -> (endpoint instanceof Boolean b) ? b : Boolean.parseBoolean(endpoint.toString());
+            case TINYINT, SMALLINT, INTEGER, BIGINT, DECIMAL -> narrowBigDecimal((java.math.BigDecimal) endpoint);
+            case FLOAT, REAL, DOUBLE -> ((Number) endpoint).doubleValue();
+            case CHAR, VARCHAR -> (endpoint instanceof NlsString nls) ? nls.getValue() : endpoint.toString();
+            default -> endpoint.toString();
+        };
+    }
 }

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/LuceneAnalyticsBackendPlugin.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/LuceneAnalyticsBackendPlugin.java
@@ -74,7 +74,12 @@ public class LuceneAnalyticsBackendPlugin implements AnalyticsSearchBackendPlugi
         ScalarFunction.NOT_EQUALS,
         ScalarFunction.IS_NULL,
         ScalarFunction.IS_NOT_NULL,
-        ScalarFunction.LIKE
+        ScalarFunction.LIKE,
+        ScalarFunction.GREATER_THAN,
+        ScalarFunction.GREATER_THAN_OR_EQUAL,
+        ScalarFunction.LESS_THAN,
+        ScalarFunction.LESS_THAN_OR_EQUAL,
+        ScalarFunction.SARG_PREDICATE
     );
 
     private static final Set<ScalarFunction> FULL_TEXT_OPS = Set.of(

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/LuceneQueryConversionUtils.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/LuceneQueryConversionUtils.java
@@ -14,6 +14,7 @@ import org.apache.lucene.search.BoostQuery;
 import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.DisjunctionMaxQuery;
 import org.apache.lucene.search.FieldExistsQuery;
+import org.apache.lucene.search.IndexOrDocValuesQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.QueryVisitor;
 import org.apache.lucene.search.TermRangeQuery;
@@ -61,6 +62,11 @@ public final class LuceneQueryConversionUtils {
      *         when nothing changed
      */
     public static Query rewriteFieldExistsForSecondary(Query query) {
+        // IndexOrDocValuesQuery wraps an index query + a doc-values query; the secondary has no
+        // doc-values, so unwrap to just the index query (TermRangeQuery against the term dictionary).
+        if (query instanceof IndexOrDocValuesQuery idv) {
+            return rewriteFieldExistsForSecondary(idv.getIndexQuery());
+        }
         if (query instanceof FieldExistsQuery fieldExists) {
             // null lower/upper bound = unbounded both ends = "any term present for this field".
             return new TermRangeQuery(fieldExists.getField(), null, null, true, true);

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/QuerySerializerRegistry.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/QuerySerializerRegistry.java
@@ -10,6 +10,7 @@ package org.opensearch.be.lucene;
 
 import org.opensearch.analytics.spi.DelegatedPredicateSerializer;
 import org.opensearch.analytics.spi.ScalarFunction;
+import org.opensearch.be.lucene.serializers.ComparisonSerializer;
 import org.opensearch.be.lucene.serializers.EqualsSerializer;
 import org.opensearch.be.lucene.serializers.IsNullSerializer;
 import org.opensearch.be.lucene.serializers.LikeSerializer;
@@ -22,6 +23,8 @@ import org.opensearch.be.lucene.serializers.MultiMatchSerializer;
 import org.opensearch.be.lucene.serializers.NotEqualsSerializer;
 import org.opensearch.be.lucene.serializers.QuerySerializer;
 import org.opensearch.be.lucene.serializers.QueryStringSerializer;
+import org.opensearch.be.lucene.serializers.RegexpSerializer;
+import org.opensearch.be.lucene.serializers.SargSerializer;
 import org.opensearch.be.lucene.serializers.SimpleQueryStringSerializer;
 import org.opensearch.be.lucene.serializers.WildcardQuerySerializer;
 
@@ -49,7 +52,13 @@ final class QuerySerializerRegistry {
         Map.entry(ScalarFunction.NOT_EQUALS, new NotEqualsSerializer()),
         Map.entry(ScalarFunction.IS_NULL, new IsNullSerializer(false)),
         Map.entry(ScalarFunction.IS_NOT_NULL, new IsNullSerializer(true)),
-        Map.entry(ScalarFunction.LIKE, new LikeSerializer())
+        Map.entry(ScalarFunction.LIKE, new LikeSerializer()),
+        Map.entry(ScalarFunction.GREATER_THAN, new ComparisonSerializer()),
+        Map.entry(ScalarFunction.GREATER_THAN_OR_EQUAL, new ComparisonSerializer()),
+        Map.entry(ScalarFunction.LESS_THAN, new ComparisonSerializer()),
+        Map.entry(ScalarFunction.LESS_THAN_OR_EQUAL, new ComparisonSerializer()),
+        Map.entry(ScalarFunction.REGEXP, new RegexpSerializer()),
+        Map.entry(ScalarFunction.SARG_PREDICATE, new SargSerializer())
     );
 
     private QuerySerializerRegistry() {}

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/ComparisonSerializer.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/ComparisonSerializer.java
@@ -1,0 +1,81 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.lucene.serializers;
+
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexInputRef;
+import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlKind;
+import org.opensearch.analytics.spi.FieldStorageInfo;
+import org.opensearch.be.lucene.CalciteToOSMapperConversionUtils;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.RangeQueryBuilder;
+
+import java.util.List;
+
+/**
+ * Serializer for bare comparison predicates ({@code >}, {@code >=}, {@code <}, {@code <=}).
+ * Produces a single-bound {@link RangeQueryBuilder}.
+ */
+public class ComparisonSerializer extends AbstractQuerySerializer {
+
+    @Override
+    public QueryBuilder buildQueryBuilder(RexCall call, List<FieldStorageInfo> fieldStorage) {
+        if (call.getOperands().size() != 2) {
+            throw new IllegalArgumentException("Comparison expects 2 operands, got " + call.getOperands().size());
+        }
+        RexNode left = call.getOperands().get(0);
+        RexNode right = call.getOperands().get(1);
+
+        RexInputRef columnRef;
+        RexLiteral valueLit;
+        boolean reversed;
+        if (left instanceof RexInputRef l && right instanceof RexLiteral r) {
+            columnRef = l;
+            valueLit = r;
+            reversed = false;
+        } else if (left instanceof RexLiteral l && right instanceof RexInputRef r) {
+            columnRef = r;
+            valueLit = l;
+            reversed = true;
+        } else {
+            throw new IllegalArgumentException(
+                "Comparison performance-delegation requires (RexInputRef, RexLiteral); got " + left + " op " + right
+            );
+        }
+
+        FieldStorageInfo field = FieldStorageInfo.resolve(fieldStorage, columnRef.getIndex());
+        String fieldName = field.getExactMatchSubfield() != null
+            ? field.getFieldName() + "." + field.getExactMatchSubfield()
+            : field.getFieldName();
+        Object value = CalciteToOSMapperConversionUtils.literalToOpenSearchValue(valueLit);
+
+        RangeQueryBuilder range = new RangeQueryBuilder(fieldName);
+        SqlKind kind = reversed ? flipKind(call.getKind()) : call.getKind();
+        switch (kind) {
+            case GREATER_THAN -> range.gt(value);
+            case GREATER_THAN_OR_EQUAL -> range.gte(value);
+            case LESS_THAN -> range.lt(value);
+            case LESS_THAN_OR_EQUAL -> range.lte(value);
+            default -> throw new IllegalArgumentException("Unsupported comparison kind: " + kind);
+        }
+        return range;
+    }
+
+    private static SqlKind flipKind(SqlKind kind) {
+        return switch (kind) {
+            case GREATER_THAN -> SqlKind.LESS_THAN;
+            case GREATER_THAN_OR_EQUAL -> SqlKind.LESS_THAN_OR_EQUAL;
+            case LESS_THAN -> SqlKind.GREATER_THAN;
+            case LESS_THAN_OR_EQUAL -> SqlKind.GREATER_THAN_OR_EQUAL;
+            default -> kind;
+        };
+    }
+}

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/RegexpSerializer.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/RegexpSerializer.java
@@ -1,0 +1,62 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.lucene.serializers;
+
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexInputRef;
+import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.util.NlsString;
+import org.opensearch.analytics.spi.FieldStorageInfo;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.RegexpQueryBuilder;
+
+import java.util.List;
+
+/**
+ * Serializer for the REGEXP full-text function ({@code regexp(field, pattern)}).
+ * Produces a {@link RegexpQueryBuilder} against the field (or its keyword exact-match subfield).
+ *
+ * <p>Expected RexCall shape: {@code REGEXP($colIdx, patternLiteral)}.
+ */
+public class RegexpSerializer extends AbstractQuerySerializer {
+
+    @Override
+    public QueryBuilder buildQueryBuilder(RexCall call, List<FieldStorageInfo> fieldStorage) {
+        if (call.getOperands().size() < 2) {
+            throw new IllegalArgumentException("REGEXP expects at least 2 operands (field, pattern), got " + call.getOperands().size());
+        }
+        RexNode fieldNode = call.getOperands().get(0);
+        RexNode patternNode = call.getOperands().get(1);
+
+        if (!(fieldNode instanceof RexInputRef columnRef)) {
+            throw new IllegalArgumentException("REGEXP first operand must be a column reference, got " + fieldNode);
+        }
+        if (!(patternNode instanceof RexLiteral patternLit)) {
+            throw new IllegalArgumentException("REGEXP second operand must be a literal pattern, got " + patternNode);
+        }
+
+        FieldStorageInfo field = FieldStorageInfo.resolve(fieldStorage, columnRef.getIndex());
+        String fieldName = field.getExactMatchSubfield() != null
+            ? field.getFieldName() + "." + field.getExactMatchSubfield()
+            : field.getFieldName();
+
+        Object raw = patternLit.getValue2();
+        String pattern;
+        if (raw instanceof NlsString nls) {
+            pattern = nls.getValue();
+        } else if (raw instanceof String s) {
+            pattern = s;
+        } else {
+            pattern = raw != null ? raw.toString() : "";
+        }
+
+        return new RegexpQueryBuilder(fieldName, pattern);
+    }
+}

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/SargSerializer.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/SargSerializer.java
@@ -1,0 +1,104 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.lucene.serializers;
+
+import com.google.common.collect.BoundType;
+import com.google.common.collect.Range;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexInputRef;
+import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.util.Sarg;
+import org.opensearch.analytics.spi.FieldStorageInfo;
+import org.opensearch.be.lucene.CalciteToOSMapperConversionUtils;
+import org.opensearch.index.query.BoolQueryBuilder;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.RangeQueryBuilder;
+import org.opensearch.index.query.TermsQueryBuilder;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Serializer for {@code SEARCH(col, Sarg[...])} — Calcite's fold of {@code IN}, {@code BETWEEN}, and
+ * same-field range unions. Delegated as a <em>performance</em> pre-filter, so the Lucene query need
+ * only be a <b>superset</b> of matches (DataFusion re-verifies the exact predicate).
+ *
+ * <ul>
+ *   <li><b>Points</b> ({@code col IN (a, b, c)}) → {@link TermsQueryBuilder} — exact set match.</li>
+ *   <li><b>Intervals</b> ({@code col BETWEEN x AND y}, range unions) → a {@link RangeQueryBuilder} per
+ *       range (multiple ranges wrapped in a {@code should} bool), open/closed bounds preserved.</li>
+ * </ul>
+ *
+ * <p>Numeric/date fields can't reach here — the Lucene secondary only indexes keyword/text, so the
+ * capability check never marks Lucene viable for a Sarg on a numeric field.
+ *
+ * <p>Refuses (throws → falls back to native DataFusion) the cases that aren't a safe standalone
+ * superset: {@code NOT IN} ({@link Sarg#isComplementedPoints()}), {@link Sarg#isAll()},
+ * {@link Sarg#isNone()}. The performance-delegation path tolerates a throwing serializer by leaving
+ * the predicate on the driving engine.
+ */
+public class SargSerializer extends AbstractQuerySerializer {
+
+    @Override
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    public QueryBuilder buildQueryBuilder(RexCall call, List<FieldStorageInfo> fieldStorage) {
+        List<RexNode> operands = call.getOperands();
+        if (operands.size() != 2
+            || !(operands.get(0) instanceof RexInputRef columnRef)
+            || !(operands.get(1) instanceof RexLiteral sargLit)) {
+            throw new IllegalArgumentException("SEARCH delegation requires SEARCH($colIdx, Sarg literal); got " + call);
+        }
+        if (!(sargLit.getValue() instanceof Sarg sarg)) {
+            throw new IllegalArgumentException("SEARCH second operand is not a Sarg literal: " + sargLit);
+        }
+        if (sarg.isComplementedPoints() || sarg.isAll() || sarg.isNone()) {
+            // NOT IN / all / none aren't a safe standalone superset — leave on DataFusion.
+            throw new IllegalArgumentException("Sarg shape not delegatable as a superset pre-filter: " + sarg);
+        }
+
+        String fieldName = FieldStorageInfo.resolve(fieldStorage, columnRef.getIndex()).getFieldName();
+        RelDataType type = sargLit.getType();
+        List<Range> ranges = new ArrayList<>(sarg.rangeSet.asRanges());
+
+        if (sarg.isPoints()) {
+            List<Object> values = new ArrayList<>(ranges.size());
+            for (Range r : ranges) {
+                values.add(convert(r.lowerEndpoint(), type));
+            }
+            return new TermsQueryBuilder(fieldName, values);
+        }
+
+        if (ranges.size() == 1) {
+            return rangeQuery(fieldName, ranges.get(0), type);
+        }
+        BoolQueryBuilder bool = new BoolQueryBuilder();
+        for (Range r : ranges) {
+            bool.should(rangeQuery(fieldName, r, type));
+        }
+        return bool;
+    }
+
+    @SuppressWarnings("rawtypes")
+    private static RangeQueryBuilder rangeQuery(String fieldName, Range range, RelDataType type) {
+        RangeQueryBuilder qb = new RangeQueryBuilder(fieldName);
+        if (range.hasLowerBound()) {
+            qb.from(convert(range.lowerEndpoint(), type), range.lowerBoundType() == BoundType.CLOSED);
+        }
+        if (range.hasUpperBound()) {
+            qb.to(convert(range.upperEndpoint(), type), range.upperBoundType() == BoundType.CLOSED);
+        }
+        return qb;
+    }
+
+    private static Object convert(Comparable<?> endpoint, RelDataType type) {
+        return CalciteToOSMapperConversionUtils.sargEndpointToOpenSearchValue(endpoint, type);
+    }
+}

--- a/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/serializers/ComparisonSerializerTests.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/serializers/ComparisonSerializerTests.java
@@ -1,0 +1,106 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.lucene.serializers;
+
+import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.opensearch.analytics.spi.FieldStorageInfo;
+import org.opensearch.analytics.spi.FieldType;
+import org.opensearch.index.query.RangeQueryBuilder;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.List;
+
+public class ComparisonSerializerTests extends OpenSearchTestCase {
+
+    private final ComparisonSerializer serializer = new ComparisonSerializer();
+    private RelDataTypeFactory typeFactory;
+    private RexBuilder rexBuilder;
+    private RelDataType integer;
+
+    private static final List<FieldStorageInfo> FIELD_STORAGE = List.of(
+        new FieldStorageInfo("price", "keyword", FieldType.KEYWORD, List.of(), List.of("lucene"), List.of(), false)
+    );
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        typeFactory = new JavaTypeFactoryImpl();
+        rexBuilder = new RexBuilder(typeFactory);
+        integer = typeFactory.createSqlType(SqlTypeName.INTEGER);
+    }
+
+    public void testGreaterThan() {
+        RexNode call = rexBuilder.makeCall(
+            SqlStdOperatorTable.GREATER_THAN,
+            rexBuilder.makeInputRef(integer, 0),
+            rexBuilder.makeLiteral(100, integer, false)
+        );
+        RangeQueryBuilder range = (RangeQueryBuilder) serializer.buildQueryBuilder((org.apache.calcite.rex.RexCall) call, FIELD_STORAGE);
+        assertEquals("price", range.fieldName());
+        assertEquals(100, range.from());
+        assertFalse(range.includeLower());
+        assertNull(range.to());
+    }
+
+    public void testGreaterThanOrEqual() {
+        RexNode call = rexBuilder.makeCall(
+            SqlStdOperatorTable.GREATER_THAN_OR_EQUAL,
+            rexBuilder.makeInputRef(integer, 0),
+            rexBuilder.makeLiteral(50, integer, false)
+        );
+        RangeQueryBuilder range = (RangeQueryBuilder) serializer.buildQueryBuilder((org.apache.calcite.rex.RexCall) call, FIELD_STORAGE);
+        assertEquals("price", range.fieldName());
+        assertEquals(50, range.from());
+        assertTrue(range.includeLower());
+    }
+
+    public void testLessThan() {
+        RexNode call = rexBuilder.makeCall(
+            SqlStdOperatorTable.LESS_THAN,
+            rexBuilder.makeInputRef(integer, 0),
+            rexBuilder.makeLiteral(200, integer, false)
+        );
+        RangeQueryBuilder range = (RangeQueryBuilder) serializer.buildQueryBuilder((org.apache.calcite.rex.RexCall) call, FIELD_STORAGE);
+        assertEquals("price", range.fieldName());
+        assertEquals(200, range.to());
+        assertFalse(range.includeUpper());
+        assertNull(range.from());
+    }
+
+    public void testLessThanOrEqual() {
+        RexNode call = rexBuilder.makeCall(
+            SqlStdOperatorTable.LESS_THAN_OR_EQUAL,
+            rexBuilder.makeInputRef(integer, 0),
+            rexBuilder.makeLiteral(999, integer, false)
+        );
+        RangeQueryBuilder range = (RangeQueryBuilder) serializer.buildQueryBuilder((org.apache.calcite.rex.RexCall) call, FIELD_STORAGE);
+        assertEquals("price", range.fieldName());
+        assertEquals(999, range.to());
+        assertTrue(range.includeUpper());
+    }
+
+    public void testReversedOperandFlipsDirection() {
+        // 100 < col ⇒ col > 100
+        RexNode call = rexBuilder.makeCall(
+            SqlStdOperatorTable.LESS_THAN,
+            rexBuilder.makeLiteral(100, integer, false),
+            rexBuilder.makeInputRef(integer, 0)
+        );
+        RangeQueryBuilder range = (RangeQueryBuilder) serializer.buildQueryBuilder((org.apache.calcite.rex.RexCall) call, FIELD_STORAGE);
+        assertEquals("price", range.fieldName());
+        assertEquals(100, range.from());
+        assertFalse(range.includeLower());
+    }
+}

--- a/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/serializers/RegexpSerializerTests.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/serializers/RegexpSerializerTests.java
@@ -1,0 +1,79 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.lucene.serializers;
+
+import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlFunction;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.type.OperandTypes;
+import org.apache.calcite.sql.type.ReturnTypes;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.opensearch.analytics.spi.FieldStorageInfo;
+import org.opensearch.analytics.spi.FieldType;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.RegexpQueryBuilder;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.List;
+
+public class RegexpSerializerTests extends OpenSearchTestCase {
+
+    private static final SqlFunction REGEXP_FN = new SqlFunction(
+        "REGEXP",
+        SqlKind.OTHER_FUNCTION,
+        ReturnTypes.BOOLEAN,
+        null,
+        OperandTypes.ANY_ANY,
+        SqlFunctionCategory.USER_DEFINED_FUNCTION
+    );
+
+    private final RegexpSerializer serializer = new RegexpSerializer();
+    private RelDataTypeFactory typeFactory;
+    private RexBuilder rexBuilder;
+    private RelDataType varchar;
+
+    private static final List<FieldStorageInfo> FIELD_STORAGE = List.of(
+        new FieldStorageInfo("url", "keyword", FieldType.KEYWORD, List.of(), List.of("lucene"), List.of(), false)
+    );
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        typeFactory = new JavaTypeFactoryImpl();
+        rexBuilder = new RexBuilder(typeFactory);
+        varchar = typeFactory.createSqlType(SqlTypeName.VARCHAR);
+    }
+
+    private RexNode regexpCall(String pattern) {
+        return rexBuilder.makeCall(REGEXP_FN, rexBuilder.makeInputRef(varchar, 0), rexBuilder.makeLiteral(pattern));
+    }
+
+    public void testRegexpProducesRegexpQuery() {
+        QueryBuilder qb = serializer.buildQueryBuilder((org.apache.calcite.rex.RexCall) regexpCall(".*google\\.com.*"), FIELD_STORAGE);
+        assertTrue(qb instanceof RegexpQueryBuilder);
+        RegexpQueryBuilder rq = (RegexpQueryBuilder) qb;
+        assertEquals("url", rq.fieldName());
+        assertEquals(".*google\\.com.*", rq.value());
+    }
+
+    public void testRegexpRoutesToExactMatchSubfield() {
+        List<FieldStorageInfo> withSubfield = List.of(
+            new FieldStorageInfo("msg", "text", FieldType.TEXT, List.of(), List.of("lucene"), List.of(), false, "keyword")
+        );
+        QueryBuilder qb = serializer.buildQueryBuilder((org.apache.calcite.rex.RexCall) regexpCall("error[0-9]+"), withSubfield);
+        RegexpQueryBuilder rq = (RegexpQueryBuilder) qb;
+        assertEquals("msg.keyword", rq.fieldName());
+        assertEquals("error[0-9]+", rq.value());
+    }
+}

--- a/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/serializers/SargSerializerTests.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/serializers/SargSerializerTests.java
@@ -1,0 +1,143 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.lucene.serializers;
+
+import com.google.common.collect.ImmutableRangeSet;
+import com.google.common.collect.Range;
+import com.google.common.collect.RangeSet;
+import com.google.common.collect.TreeRangeSet;
+import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexUnknownAs;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.util.NlsString;
+import org.apache.calcite.util.Sarg;
+import org.opensearch.analytics.spi.FieldStorageInfo;
+import org.opensearch.analytics.spi.FieldType;
+import org.opensearch.index.query.BoolQueryBuilder;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.RangeQueryBuilder;
+import org.opensearch.index.query.TermsQueryBuilder;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+/**
+ * Unit tests for {@link SargSerializer}: IN-points → TermsQuery, intervals → RangeQuery (bounds and
+ * range-unions), and refusal of NOT IN / all / none.
+ */
+public class SargSerializerTests extends OpenSearchTestCase {
+
+    private final SargSerializer serializer = new SargSerializer();
+    private RelDataTypeFactory typeFactory;
+    private RexBuilder rexBuilder;
+    private RelDataType keywordType;
+
+    private static final List<FieldStorageInfo> FIELD_STORAGE = List.of(
+        new FieldStorageInfo("str0", "keyword", FieldType.KEYWORD, List.of(), List.of("lucene"), List.of(), false)
+    );
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        typeFactory = new JavaTypeFactoryImpl();
+        rexBuilder = new RexBuilder(typeFactory);
+        keywordType = typeFactory.createSqlType(SqlTypeName.VARCHAR);
+    }
+
+    /** Build an NlsString the way Calcite stores a VARCHAR literal, without touching the avatica
+     *  ByteString ctor path (which isn't on the test classpath). */
+    private NlsString str(String s) {
+        return (NlsString) ((org.apache.calcite.rex.RexLiteral) rexBuilder.makeLiteral(s)).getValue();
+    }
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    private QueryBuilder build(RangeSet rangeSet) {
+        Sarg sarg = Sarg.of(RexUnknownAs.UNKNOWN, ImmutableRangeSet.copyOf(rangeSet));
+        RexNode ref = rexBuilder.makeInputRef(keywordType, 0);
+        RexNode sargLit = rexBuilder.makeSearchArgumentLiteral(sarg, keywordType);
+        RexCall call = (RexCall) rexBuilder.makeCall(SqlStdOperatorTable.SEARCH, List.of(ref, sargLit));
+        return serializer.buildQueryBuilder(call, FIELD_STORAGE);
+    }
+
+    public void testInListBuildsTermsQuery() {
+        RangeSet<NlsString> points = TreeRangeSet.create();
+        points.add(Range.singleton(str("apple")));
+        points.add(Range.singleton(str("banana")));
+        points.add(Range.singleton(str("cherry")));
+
+        TermsQueryBuilder qb = (TermsQueryBuilder) build(points);
+        assertEquals("str0", qb.fieldName());
+        assertEquals(List.of("apple", "banana", "cherry"), qb.values());
+    }
+
+    public void testBetweenBuildsClosedRangeQuery() {
+        RangeSet<NlsString> r = TreeRangeSet.create();
+        r.add(Range.closed(str("a"), str("m")));
+
+        RangeQueryBuilder qb = (RangeQueryBuilder) build(r);
+        assertEquals("str0", qb.fieldName());
+        assertEquals("a", qb.from());
+        assertEquals("m", qb.to());
+        assertTrue("BETWEEN is inclusive lower", qb.includeLower());
+        assertTrue("BETWEEN is inclusive upper", qb.includeUpper());
+    }
+
+    public void testHalfOpenRangeBounds() {
+        // [a, m) → from inclusive, to exclusive
+        RangeSet<NlsString> r = TreeRangeSet.create();
+        r.add(Range.closedOpen(str("a"), str("m")));
+        RangeQueryBuilder qb = (RangeQueryBuilder) build(r);
+        assertTrue(qb.includeLower());
+        assertFalse(qb.includeUpper());
+    }
+
+    public void testGreaterThanBuildsOpenLowerRange() {
+        // (k, +inf) → from exclusive, no upper bound
+        RangeSet<NlsString> r = TreeRangeSet.create();
+        r.add(Range.greaterThan(str("k")));
+        RangeQueryBuilder qb = (RangeQueryBuilder) build(r);
+        assertEquals("k", qb.from());
+        assertFalse(qb.includeLower());
+        assertNull("no upper bound", qb.to());
+    }
+
+    public void testRangeUnionBuildsShouldBool() {
+        // [a, c] ∪ [x, z] → bool{ should range, should range }
+        RangeSet<NlsString> r = TreeRangeSet.create();
+        r.add(Range.closed(str("a"), str("c")));
+        r.add(Range.closed(str("x"), str("z")));
+
+        BoolQueryBuilder bool = (BoolQueryBuilder) build(r);
+        assertEquals(2, bool.should().size());
+        assertTrue(bool.should().get(0) instanceof RangeQueryBuilder);
+        assertTrue(bool.should().get(1) instanceof RangeQueryBuilder);
+    }
+
+    public void testNotInRefused() {
+        // (-inf, 1) ∪ (1, +inf) over INTEGER == NOT IN (1) → isComplementedPoints → refuse.
+        RelDataType intType = typeFactory.createSqlType(SqlTypeName.INTEGER);
+        RangeSet<BigDecimal> r = TreeRangeSet.create();
+        r.add(Range.lessThan(BigDecimal.ONE));
+        r.add(Range.greaterThan(BigDecimal.ONE));
+        Sarg<BigDecimal> sarg = Sarg.of(RexUnknownAs.UNKNOWN, ImmutableRangeSet.copyOf(r));
+        RexNode ref = rexBuilder.makeInputRef(intType, 0);
+        RexNode sargLit = rexBuilder.makeSearchArgumentLiteral(sarg, intType);
+        RexCall call = (RexCall) rexBuilder.makeCall(SqlStdOperatorTable.SEARCH, List.of(ref, sargLit));
+
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> serializer.buildQueryBuilder(call, FIELD_STORAGE));
+        assertTrue(e.getMessage().contains("not delegatable"));
+    }
+}

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/settings/AnalyticsQuerySettings.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/settings/AnalyticsQuerySettings.java
@@ -39,7 +39,18 @@ public final class AnalyticsQuerySettings {
         "blocked_predicates",
         key -> Setting.listSetting(
             key,
-            key.contains("lucene") ? List.of("IS_NULL", "IS_NOT_NULL", "LIKE") : List.of(),
+            key.contains("lucene")
+                ? List.of(
+                    "IS_NULL",
+                    "IS_NOT_NULL",
+                    "LIKE",
+                    "GREATER_THAN",
+                    "GREATER_THAN_OR_EQUAL",
+                    "LESS_THAN",
+                    "LESS_THAN_OR_EQUAL",
+                    "SARG_PREDICATE"
+                )
+                : List.of(),
             ScalarFunction::fromToken,
             Setting.Property.NodeScope,
             Setting.Property.Dynamic

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/FilterDelegationExtendedIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/FilterDelegationExtendedIT.java
@@ -67,7 +67,24 @@ public class FilterDelegationExtendedIT extends AnalyticsRestTestCase {
         new Case("where isnull(str1) | stats min(num0) as c", 30, false),
         new Case("where isnull(str1) | stats max(num0) as c", 100, false),
         new Case("where isnull(str1) | stats dc(str0) as c", 4, false),
-        new Case("where isnull(str1) | fields str0", 4, true)
+        new Case("where isnull(str1) | fields str0", 4, true),
+
+        // ===== LIKE (keyword field only) =====
+        new Case("where str0 like 'app%' | stats count() as c", 3, false),
+        new Case("where str0 like 'ban%' | stats sum(num0) as c", 150, false),
+        new Case("where str0 like '%e%' | stats count() as c", 7, false),
+
+        // ===== Comparisons (GT/GTE/LT/LTE on integer field) =====
+        new Case("where num0 > 50 | stats count() as c", 5, false),
+        new Case("where num0 >= 50 | stats count() as c", 6, false),
+        new Case("where num0 < 40 | stats count() as c", 3, false),
+        new Case("where num0 <= 40 | stats count() as c", 4, false),
+        new Case("where num0 > 50 | stats sum(num0) as c", 400, false),
+        new Case("where num0 > 50 | stats dc(str0) as c", 3, false),
+
+        // ===== IN =====
+        new Case("where str0 in ('apple', 'cherry') | stats count() as c", 5, false),
+        new Case("where str0 in ('apple', 'cherry') | stats sum(num0) as c", 210, false)
     );
 
     private static boolean dataProvisioned = false;


### PR DESCRIPTION
## Summary

  - Add ComparisonSerializer (GT/GTE/LT/LTE) → TermRangeQuery on keyword fields
  - Add SargSerializer (IN → TermsQuery, RANGE → TermRangeQuery) for Calcite SARG predicates
  - Add RegexpSerializer for REGEXP full-text delegation path
  - IndexOrDocValuesQuery unwrap for composite-secondary keyword range queries (no sorted doc-values)
  - Expand default delegation blocklist with all new predicates (production safety; IT overrides to empty)
  - Expand FilterDelegationExtendedIT with LIKE, comparison, and IN test cases (32 total)


  ## Test plan

  - `FilterDelegationExtendedIT` — 32 cases across all predicate shapes × aggregates (count/sum/min/max/dc/avg/fields)
  - `FilterDelegationGoldenIT` — all 38 delegation routing shapes pass
  - `ComparisonSerializerTests`, `SargSerializerTests`, `RegexpSerializerTests` — unit tests
  - Full integTest suite green (excluding pre-existing `TwoShardAggregationIT` failure from DF54 upgrade)

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
