### PR TITLE
[analytics-engine] Fix conv() numeric arg and percentile shortcuts

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/ConvAdapter.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/ConvAdapter.java
@@ -8,6 +8,12 @@
 
 package org.opensearch.be.datafusion;
 
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlFunction;
 import org.apache.calcite.sql.SqlFunctionCategory;
 import org.apache.calcite.sql.SqlKind;
@@ -15,24 +21,29 @@ import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.type.OperandTypes;
 import org.apache.calcite.sql.type.ReturnTypes;
 import org.apache.calcite.sql.type.SqlTypeFamily;
-import org.opensearch.analytics.spi.AbstractNameMappingAdapter;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.opensearch.analytics.spi.FieldStorageInfo;
+import org.opensearch.analytics.spi.ScalarFunctionAdapter;
 
 import java.util.List;
 
 /**
- * Cat-4 rename adapter for PPL's {@code conv(n, fromBase, toBase)} — base conversion. Rewrites
- * the PPL UDF (registered upstream under the name {@code "CONVERT"} by
- * {@code ConvFunction.toUDF}) to a locally-declared {@link SqlFunction} whose substrait sig is
- * mapped to the {@code conv} Rust UDF (see {@code rust/src/udf/conv.rs} and the YAML signature in
+ * Adapter for PPL's {@code conv(n, fromBase, toBase)} — base conversion. Rewrites the PPL UDF
+ * (registered upstream under the name {@code "CONVERT"} by {@code ConvFunction.toUDF}) to a
+ * locally-declared {@link SqlFunction} whose substrait sig is mapped to the {@code conv} Rust UDF
+ * (see {@code rust/src/udf/conv.rs} and the YAML signature in
  * {@code src/main/resources/opensearch_scalar_functions.yaml}).
  *
  * <p>Semantics mirror {@code Long.toString(Long.parseLong(n, fromBase), toBase)} — same as PPL's
- * {@code ConvFunction.conv}. Operand types: any string/integer for {@code n}, integer for the
- * two bases. Return type: string.
+ * {@code ConvFunction.conv}. PPL accepts a string OR a numeric first arg ({@code conv(intCol, 10,
+ * 16)}), but the Rust UDF takes a string; on the Substrait/pushdown path there is no implicit
+ * cast, so a numeric {@code n} fails signature resolution ("conv: arg 0 expected string, got
+ * Int32"). Cast a numeric {@code n} to VARCHAR here so the Rust UDF always receives a string —
+ * mirroring how {@code StrftimeFunctionAdapter} folds numeric inputs onto its canonical type.
  *
  * @opensearch.internal
  */
-class ConvAdapter extends AbstractNameMappingAdapter {
+class ConvAdapter implements ScalarFunctionAdapter {
 
     static final SqlOperator LOCAL_CONV_OP = new SqlFunction(
         "conv",
@@ -43,7 +54,21 @@ class ConvAdapter extends AbstractNameMappingAdapter {
         SqlFunctionCategory.USER_DEFINED_FUNCTION
     );
 
-    ConvAdapter() {
-        super(LOCAL_CONV_OP, List.of(), List.of());
+    @Override
+    public RexNode adapt(RexCall original, List<FieldStorageInfo> fieldStorage, RelOptCluster cluster) {
+        List<RexNode> operands = original.getOperands();
+        if (operands.size() != 3) {
+            return cluster.getRexBuilder().makeCall(original.getType(), LOCAL_CONV_OP, operands);
+        }
+        RexNode n = operands.get(0);
+        RexNode converted = SqlTypeName.NUMERIC_TYPES.contains(n.getType().getSqlTypeName()) ? castToVarchar(n, cluster) : n;
+        return cluster.getRexBuilder().makeCall(original.getType(), LOCAL_CONV_OP, List.of(converted, operands.get(1), operands.get(2)));
+    }
+
+    private static RexNode castToVarchar(RexNode operand, RelOptCluster cluster) {
+        RelDataTypeFactory factory = cluster.getTypeFactory();
+        RelDataType varchar = factory.createTypeWithNullability(factory.createSqlType(SqlTypeName.VARCHAR), operand.getType().isNullable());
+        RexBuilder rexBuilder = cluster.getRexBuilder();
+        return rexBuilder.makeCast(varchar, operand, true, false);
     }
 }

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionFragmentConvertor.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionFragmentConvertor.java
@@ -316,10 +316,22 @@ public class DataFusionFragmentConvertor implements FragmentConvertor {
     ) {
         @Override
         public RexNode normaliseLiteralArg(int argIndex, RexLiteral lit, RexBuilder rexBuilder, RelDataTypeFactory typeFactory) {
-            if (argIndex == 1 && lit.getValue() instanceof BigDecimal bd) {
-                BigDecimal scaled = bd.divide(BigDecimal.valueOf(100), MathContext.DECIMAL64);
-                RelDataType doubleType = typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.DOUBLE), true);
-                return rexBuilder.makeLiteral(scaled, doubleType);
+            // The percentile literal arrives as INTEGER for the standard form percentile(x, 50)
+            // but DOUBLE for the percNN/pNN shortcut (perc50 → 50.0E0), and getValue()'s backing
+            // type differs between the two. Read it through getValueAs so both representations
+            // rescale uniformly; pattern-matching get() on BigDecimal missed the DOUBLE shortcut
+            // and let the unscaled 50.0 reach DataFusion ("must be between 0.0 and 1.0").
+            if (argIndex == 1 && SqlTypeName.NUMERIC_TYPES.contains(lit.getType().getSqlTypeName())) {
+                BigDecimal bd = lit.getValueAs(BigDecimal.class);
+                if (bd != null) {
+                    BigDecimal scaled = bd.divide(BigDecimal.valueOf(100), MathContext.DECIMAL64);
+                    RelDataType doubleType = typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.DOUBLE), true);
+                    return rexBuilder.makeLiteral(scaled, doubleType);
+                }
+                // bd == null only for a SQL-NULL percent (getValueAs returns null for NULL value) —
+                // not a valid percentile and never produced by the percNN/pNN suffix or an explicit
+                // numeric percentile() arg. Pass it through unchanged; DataFusion rejects a NULL
+                // percentile at planning. There is no scaled-vs-unscaled ambiguity (NULL ≠ 50.0).
             }
             return lit;
         }

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/MathScalarFunctionsIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/MathScalarFunctionsIT.java
@@ -349,6 +349,33 @@ public class MathScalarFunctionsIT extends AnalyticsRestTestCase {
         assertEquals("-64", cell);
     }
 
+    /** {@code conv(255, 10, 16) = 'ff'} — NUMERIC literal first arg. The Rust UDF declared arg0 as
+     *  strict Utf8 and rejected Int32 ("conv: arg 0 expected string, got Int32"); arg0 must coerce. */
+    public void testConvNumericLiteralFirstArg() throws IOException {
+        Object cell = firstRowFirstCell(oneRow("key00") + "| eval v = conv(255, 10, 16) | fields v");
+        assertEquals("ff", cell);
+    }
+
+    /** {@code conv(int3, 10, 16)} on an INTEGER COLUMN — mirrors the SQL plugin's {@code testConv}
+     *  (conv(age, 10, 16)), the exact shape the coercion bug surfaced on. int3 = 8 at key00 → 'ff'
+     *  of 8 is '8'; key01's int3 = 13 → 'd'. */
+    public void testConvNumericColumnFirstArg() throws IOException {
+        assertEquals("8", firstRowFirstCell(oneRow("key00") + "| eval v = conv(int3, 10, 16) | fields v"));
+        assertEquals("d", firstRowFirstCell(oneRow("key01") + "| eval v = conv(int3, 10, 16) | fields v"));
+    }
+
+    /** {@code conv(CAST(int3 AS LONG), 10, 16)} — BIGINT (not just INT) first arg also coerces.
+     *  Dynamic JSON-int columns map to long, so this is the common production type. int3 = 8 → '8'. */
+    public void testConvBigintFirstArg() throws IOException {
+        assertEquals("8", firstRowFirstCell(oneRow("key00") + "| eval v = conv(cast(int3 as long), 10, 16) | fields v"));
+    }
+
+    /** {@code conv(int0, 10, 16)} where int0 is NULL (key01) → NULL. Null first arg must propagate,
+     *  not error, through the numeric-arg coercion. */
+    public void testConvNullFirstArg() throws IOException {
+        assertNull(firstRowFirstCell(oneRow("key01") + "| eval v = conv(int0, 10, 16) | fields v"));
+    }
+
     /** Invalid radix surfaces as a 5xx with Java's NumberFormatException message text. The exact
      *  phrasing matters: {@code testConvWithInvalidRadix} in the SQL plugin's integ-test asserts
      *  on the {@code "less than Character.MIN_RADIX"} substring. */

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/PercentileShortcutIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/PercentileShortcutIT.java
@@ -1,0 +1,86 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.qa;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Regression coverage for PPL percentile SHORTCUTS ({@code percNN}, {@code pNN}) on the
+ * analytics-engine route.
+ *
+ * <p>The standard form {@code percentile(field, 50)} emits the percent as an INTEGER literal
+ * ({@code $f1=[50]}), which {@code DataFusionFragmentConvertor.LOCAL_PERCENTILE_APPROX_OP
+ * .normaliseLiteralArg} rescales from PPL's [0,100] to DataFusion's [0,1] before substrait
+ * emission. The shortcut form {@code perc50(field)} instead emits a DOUBLE literal
+ * ({@code $f1=[50.0E0:DOUBLE]}); the rescale guard only matched one literal representation, so
+ * the unscaled {@code 50.0} reached DataFusion and failed planning with
+ * "Percentile value must be between 0.0 and 1.0 inclusive, 50 is invalid". The two forms must
+ * agree.
+ */
+public class PercentileShortcutIT extends AnalyticsRestTestCase {
+
+    private static final Dataset DATASET = new Dataset("calcs", "calcs");
+    private static boolean dataProvisioned = false;
+
+    @Override
+    protected void onBeforeQuery() throws IOException {
+        if (dataProvisioned == false) {
+            DatasetProvisioner.provision(client(), DATASET);
+            dataProvisioned = true;
+        }
+    }
+
+    /** {@code perc50(num0)} must equal the known-good {@code percentile(num0, 50)}. */
+    public void testPerc50_matchesStandardPercentile() throws IOException {
+        assertShortcutMatchesStandard("perc50(num0)", "percentile(num0, 50)");
+    }
+
+    /** {@code p95(num0)} (the {@code pNN} spelling) must equal {@code percentile(num0, 95)}. */
+    public void testP95_matchesStandardPercentile() throws IOException {
+        assertShortcutMatchesStandard("p95(num0)", "percentile(num0, 95)");
+    }
+
+    /** Fractional shortcut {@code perc25.5(num0)} must equal {@code percentile(num0, 25.5)}. */
+    public void testPerc25_5_matchesStandardPercentile() throws IOException {
+        assertShortcutMatchesStandard("perc25.5(num0)", "percentile(num0, 25.5)");
+    }
+
+    /** Further fractional spellings exercised by the SQL plugin's percentile-shortcut suite
+     *  ({@code perc99.5}, {@code p75.25}, {@code perc0.1}) — each must equal its standard form. */
+    public void testFractionalSpellings_matchStandardPercentile() throws IOException {
+        assertShortcutMatchesStandard("perc99.5(num0)", "percentile(num0, 99.5)");
+        assertShortcutMatchesStandard("p75.25(num0)", "percentile(num0, 75.25)");
+        assertShortcutMatchesStandard("perc0.1(num0)", "percentile(num0, 0.1)");
+    }
+
+    /** Rescale boundaries: perc0 → 0.0 and perc100 → 1.0 (the inclusive [0,1] edges DataFusion
+     *  validates). perc100 is the value the original bug rejected as ">1.0"; assert both edges
+     *  fire and equal their standard forms. */
+    public void testBoundaryPercentiles_matchStandardPercentile() throws IOException {
+        assertShortcutMatchesStandard("perc0(num0)", "percentile(num0, 0)");
+        assertShortcutMatchesStandard("perc100(num0)", "percentile(num0, 100)");
+    }
+
+    private void assertShortcutMatchesStandard(String shortcut, String standard) throws IOException {
+        double expected = singleAgg("source=" + DATASET.indexName + " | stats " + standard + " as v");
+        double actual = singleAgg("source=" + DATASET.indexName + " | stats " + shortcut + " as v");
+        assertEquals("shortcut " + shortcut + " must equal " + standard, expected, actual, 1e-9);
+    }
+
+    @SuppressWarnings("unchecked")
+    private double singleAgg(String ppl) throws IOException {
+        Map<String, Object> response = executePpl(ppl);
+        List<List<Object>> rows = (List<List<Object>>) response.get("datarows");
+        assertNotNull("Response missing 'datarows' for query: " + ppl, rows);
+        assertEquals("expected one aggregate row for query: " + ppl, 1, rows.size());
+        return ((Number) rows.get(0).get(0)).doubleValue();
+    }
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Two PPL function bugs that failed at DataFusion planning time on the parquet route:

- conv(intCol, 10, 16) failed ("conv: arg 0 expected string, got Int32"): PPL accepts a numeric first arg but the Rust UDF takes a string and the pushdown path adds no implicit cast. ConvAdapter now casts a numeric first arg to VARCHAR (mirrors StrftimeFunctionAdapter); Rust UDF unchanged.

- perc50/p95/perc25.5 failed ("Percentile value must be between 0.0 and 1.0") while percentile(x, 50) worked: the shortcut emits a DOUBLE literal but the [0,100]->[0,1] rescale only matched the INTEGER form. Read the percent via getValueAs(BigDecimal.class) so both forms rescale.
### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
