### PR TITLE
fix(analysis): Add path boundary validation in resolveAnalyzerPath

### DIFF
--- a/server/src/main/java/org/opensearch/index/analysis/Analysis.java
+++ b/server/src/main/java/org/opensearch/index/analysis/Analysis.java
@@ -343,6 +343,9 @@ public class Analysis {
     }
 
     public static Path resolveAnalyzerPath(Environment env, String wordListPath) {
+        if (isUnderConfig(env, wordListPath) == false) {
+            throw new IllegalArgumentException("Resource path must be inside config directory: " + wordListPath);
+        }
         return env.configDir().resolve(wordListPath).normalize();
     }
 

--- a/server/src/test/java/org/opensearch/index/analysis/AnalysisTests.java
+++ b/server/src/test/java/org/opensearch/index/analysis/AnalysisTests.java
@@ -66,11 +66,13 @@ public class AnalysisTests extends OpenSearchTestCase {
         assertThat(set.contains("baz"), is(false));
     }
 
-    public void testParseNonExistingFile() {
-        Path tempDir = createTempDir();
+    public void testParseNonExistingFile() throws IOException {
+        Path home = createTempDir();
+        Path config = home.resolve("config");
+        Files.createDirectory(config);
         Settings nodeSettings = Settings.builder()
-            .put("foo.bar_path", tempDir.resolve("foo.dict"))
-            .put(Environment.PATH_HOME_SETTING.getKey(), tempDir)
+            .put("foo.bar_path", config.resolve("foo.dict"))
+            .put(Environment.PATH_HOME_SETTING.getKey(), home)
             .build();
         Environment env = TestEnvironment.newEnvironment(nodeSettings);
         IllegalArgumentException ex = expectThrows(
@@ -82,9 +84,11 @@ public class AnalysisTests extends OpenSearchTestCase {
     }
 
     public void testParseFalseEncodedFile() throws IOException {
-        Path tempDir = createTempDir();
-        Path dict = tempDir.resolve("foo.dict");
-        Settings nodeSettings = Settings.builder().put("foo.bar_path", dict).put(Environment.PATH_HOME_SETTING.getKey(), tempDir).build();
+        Path home = createTempDir();
+        Path config = home.resolve("config");
+        Files.createDirectory(config);
+        Path dict = config.resolve("foo.dict");
+        Settings nodeSettings = Settings.builder().put("foo.bar_path", dict).put(Environment.PATH_HOME_SETTING.getKey(), home).build();
         try (OutputStream writer = Files.newOutputStream(dict)) {
             writer.write(new byte[] { (byte) 0xff, 0x00, 0x00 }); // some invalid UTF-8
             writer.write('\n');
@@ -99,9 +103,11 @@ public class AnalysisTests extends OpenSearchTestCase {
     }
 
     public void testParseWordList() throws IOException {
-        Path tempDir = createTempDir();
-        Path dict = tempDir.resolve("foo.dict");
-        Settings nodeSettings = Settings.builder().put("foo.bar_path", dict).put(Environment.PATH_HOME_SETTING.getKey(), tempDir).build();
+        Path home = createTempDir();
+        Path config = home.resolve("config");
+        Files.createDirectory(config);
+        Path dict = config.resolve("foo.dict");
+        Settings nodeSettings = Settings.builder().put("foo.bar_path", dict).put(Environment.PATH_HOME_SETTING.getKey(), home).build();
         try (BufferedWriter writer = Files.newBufferedWriter(dict, StandardCharsets.UTF_8)) {
             writer.write("hello");
             writer.write('\n');
@@ -140,9 +146,33 @@ public class AnalysisTests extends OpenSearchTestCase {
         }
         Settings nodeSettings = Settings.builder().put("foo.bar_path", dict).put(Environment.PATH_HOME_SETTING.getKey(), home).build();
         Environment env = TestEnvironment.newEnvironment(nodeSettings);
-        RuntimeException ex = expectThrows(RuntimeException.class, () -> Analysis.parseWordList(env, nodeSettings, "foo.bar", s -> {
-            throw new RuntimeException("Error while parsing rule = " + s);
-        }));
-        assertEquals("Line [1]: Invalid rule", ex.getMessage());
+        IllegalArgumentException ex = expectThrows(
+            IllegalArgumentException.class,
+            () -> Analysis.parseWordList(env, nodeSettings, "foo.bar", s -> s)
+        );
+        assertTrue(ex.getMessage().contains("Resource path must be inside config directory"));
+    }
+
+    public void testResolveAnalyzerPathRejectsPathTraversal() {
+        Path home = createTempDir();
+        Settings settings = Settings.builder().put(Environment.PATH_HOME_SETTING.getKey(), home).build();
+        Environment env = TestEnvironment.newEnvironment(settings);
+
+        IllegalArgumentException ex = expectThrows(
+            IllegalArgumentException.class,
+            () -> Analysis.resolveAnalyzerPath(env, "../../tmp/data.txt")
+        );
+        assertTrue(ex.getMessage().contains("Resource path must be inside config directory"));
+    }
+
+    public void testResolveAnalyzerPathValidPath() {
+        Path home = createTempDir();
+        Settings settings = Settings.builder().put(Environment.PATH_HOME_SETTING.getKey(), home).build();
+        Environment env = TestEnvironment.newEnvironment(settings);
+
+        Path resolved = Analysis.resolveAnalyzerPath(env, "analyzers/stopwords.txt");
+        Path configDir = env.configDir().toAbsolutePath();
+
+        assertTrue("Valid path should resolve within configDir", resolved.startsWith(configDir));
     }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Validate that the resolved path remains within configDir() after normalization. Previously, the method only normalized the path without checking boundaries, allowing relative paths to resolve outside the intended directory.

Also add tests verifying both valid paths and rejected traversal attempts.

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
