### PR TITLE
Fix replica stuck behind primary after stale segrep retry

### DIFF
--- a/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationTargetService.java
+++ b/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationTargetService.java
@@ -364,10 +364,18 @@ public class SegmentReplicationTargetService extends AbstractLifecycleComponent 
                         // update visible checkpoint to primary
                         updateVisibleCheckpoint(state.getReplicationId(), replicaShard);
 
-                        // if we received a checkpoint during the copy event that is ahead of this
-                        // try and process it.
+                        // If the latest checkpoint known from the primary is still ahead of what this replica has
+                        // actually replicated, process it to catch up. We compare against the replica's achieved
+                        // checkpoint rather than the checkpoint this round targeted (receivedCheckpoint). A retry
+                        // round may finalize against a stale metadata checkpoint returned by the primary (see #20550
+                        // and #20551), leaving the replica behind the checkpoint it was asked to sync to. Comparing
+                        // against the targeted checkpoint would miss this case and leave the replica permanently
+                        // behind until the next publish; comparing against the achieved checkpoint re-triggers the
+                        // catch-up. In the normal case the achieved checkpoint is at least the targeted one, so this
+                        // does not introduce extra rounds.
                         ReplicationCheckpoint latestReceivedCheckpoint = replicator.getPrimaryCheckpoint(replicaShard.shardId());
-                        if (Objects.nonNull(latestReceivedCheckpoint) && latestReceivedCheckpoint.isAheadOf(receivedCheckpoint)) {
+                        if (Objects.nonNull(latestReceivedCheckpoint)
+                            && latestReceivedCheckpoint.isAheadOf(replicaShard.getLatestReplicationCheckpoint())) {
                             processLatestReceivedCheckpoint(replicaShard, thread);
                         }
                     }

--- a/server/src/test/java/org/opensearch/indices/replication/SegmentReplicationTargetServiceTests.java
+++ b/server/src/test/java/org/opensearch/indices/replication/SegmentReplicationTargetServiceTests.java
@@ -66,6 +66,8 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 
 import static org.opensearch.index.seqno.SequenceNumbers.NO_OPS_PERFORMED;
@@ -630,18 +632,63 @@ public class SegmentReplicationTargetServiceTests extends IndexShardTestCase {
     public void testStartReplicationListenerSuccess() throws InterruptedException {
         sut.updateLatestReceivedCheckpoint(aheadCheckpoint, replicaShard);
         SegmentReplicationTargetService spy = spy(sut);
+        // Model the replica's achieved checkpoint. A successful round advances it to the checkpoint it targeted, so
+        // the done-handler observes the replica has caught up and does not retrigger another round.
+        IndexShard spyReplicaShard = spy(replicaShard);
+        AtomicReference<ReplicationCheckpoint> achieved = new AtomicReference<>(replicaShard.getLatestReplicationCheckpoint());
+        doAnswer(i -> achieved.get()).when(spyReplicaShard).getLatestReplicationCheckpoint();
         CountDownLatch latch = new CountDownLatch(1);
         doAnswer(i -> {
+            achieved.set(i.getArgument(1));
             ((SegmentReplicationTargetService.SegmentReplicationListener) i.getArgument(3)).onReplicationDone(state);
             latch.countDown();
             return null;
         }).when(spy).startReplication(any(), any(), anyBoolean(), any());
         doNothing().when(spy).updateVisibleCheckpoint(eq(0L), any());
-        spy.afterIndexShardStarted(replicaShard);
+        spy.afterIndexShardStarted(spyReplicaShard);
 
         latch.await(2, TimeUnit.SECONDS);
-        verify(spy, (atLeastOnce())).updateVisibleCheckpoint(eq(0L), eq(replicaShard));
+        verify(spy, (atLeastOnce())).updateVisibleCheckpoint(eq(0L), eq(spyReplicaShard));
+        // Only the initial entry from afterIndexShardStarted; the done-handler must not retrigger since the replica
+        // caught up to the targeted checkpoint.
         verify(spy, times(1)).processLatestReceivedCheckpoint(any(), any());
+    }
+
+    /**
+     * Regression test for the scenario described in #20550 / #20551. After a failed round is retried, the retry may
+     * finalize against a stale metadata checkpoint returned by the primary, leaving the replica behind the checkpoint
+     * it was asked to sync to. The done-handler must detect that the replica is still behind the primary's latest
+     * known checkpoint - by comparing against the replica's achieved checkpoint, not the checkpoint the round targeted -
+     * and trigger another round so the replica eventually catches up. Here the first round finalizes without advancing
+     * the replica's checkpoint (stale sync); the second round advances it, after which no further round is triggered.
+     */
+    public void testStartReplicationRetriggersWhenReplicaSyncedToStaleCheckpoint() throws InterruptedException {
+        sut.updateLatestReceivedCheckpoint(aheadCheckpoint, replicaShard);
+        SegmentReplicationTargetService spy = spy(sut);
+        IndexShard spyReplicaShard = spy(replicaShard);
+        AtomicReference<ReplicationCheckpoint> achieved = new AtomicReference<>(replicaShard.getLatestReplicationCheckpoint());
+        doAnswer(i -> achieved.get()).when(spyReplicaShard).getLatestReplicationCheckpoint();
+        AtomicInteger rounds = new AtomicInteger(0);
+        CountDownLatch latch = new CountDownLatch(2);
+        doAnswer(i -> {
+            // First round finalizes against a stale checkpoint and does NOT advance the replica. The second
+            // (retriggered) round successfully advances the replica to the checkpoint it was asked to sync to.
+            if (rounds.incrementAndGet() >= 2) {
+                achieved.set(i.getArgument(1));
+            }
+            ((SegmentReplicationTargetService.SegmentReplicationListener) i.getArgument(3)).onReplicationDone(state);
+            latch.countDown();
+            return null;
+        }).when(spy).startReplication(any(), any(), anyBoolean(), any());
+        doNothing().when(spy).updateVisibleCheckpoint(eq(0L), any());
+        spy.afterIndexShardStarted(spyReplicaShard);
+
+        assertTrue("expected the replica to be retriggered until it caught up", latch.await(5, TimeUnit.SECONDS));
+        // Two rounds: the initial stale round plus the retriggered catch-up round.
+        verify(spy, times(2)).startReplication(eq(spyReplicaShard), any(), anyBoolean(), any());
+        // processLatestReceivedCheckpoint: once from afterIndexShardStarted and once from the done-handler after the
+        // first (stale) round. The second round catches up, so the done-handler does not retrigger again.
+        verify(spy, org.mockito.Mockito.atLeast(2)).processLatestReceivedCheckpoint(any(), any());
     }
 
     public void testStartReplicationListenerFailure() throws InterruptedException {


### PR DESCRIPTION
A segment replication retry can finalize against a stale metadata checkpoint returned by the primary (see #20550, #20551), leaving the replica behind the checkpoint it was asked to sync to. This leads to the replica being stale until the next publish. If another publish never happens, it is stale forever. I believe this is the case of flakiness in FullRollingRestartIT where the test fails on timeout waiting for the replica to catch up. The fix is to compare against the replica's achieved checkpoint instead so a round that finalized behind its target retriggers catch-up. In the normal case the achieved checkpoint matches the target, so no extra rounds are introduced.

### Related Issues
Resolves #18490

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
