### PR TITLE
[analytics-datafusion] Apply aggregate mode in indexed executor, remove dc() delegation block gate

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/agg_mode.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/agg_mode.rs
@@ -319,7 +319,23 @@ mod tests {
             !rules.iter().any(|r| r.name() == combine_name),
             "CombinePartialFinalAggregate should be filtered out"
         );
-        // Verify we still have other rules
         assert!(!rules.is_empty(), "Should have other optimizer rules");
     }
+
+    /// Verifies apply_aggregate_mode(Partial) strips the Final aggregate and keeps
+    /// only the Partial subtree — the core behavior the indexed executor relies on
+    /// for engine-native-merge (dc/HLL) queries.
+    #[tokio::test]
+    async fn test_apply_partial_strips_final() {
+        let plan = make_agg_plan().await;
+        let display_before = plan_string(&plan);
+        assert!(display_before.contains("AggregateExec: mode=Final"), "expected Final in plan");
+        assert!(display_before.contains("AggregateExec: mode=Partial"), "expected Partial in plan");
+
+        let stripped = apply_aggregate_mode(plan, Mode::Partial).unwrap();
+        let display_after = plan_string(&stripped);
+        assert!(!display_after.contains("mode=Final"), "Final should be stripped");
+        assert!(display_after.contains("mode=Partial"), "Partial should remain");
+    }
+
 }

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_executor.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_executor.rs
@@ -500,6 +500,7 @@ async unsafe fn execute_indexed_with_context_inner(
 
     let query_config = Arc::new(handle.query_config);
     let num_partitions = query_config.target_partitions.max(1);
+    let aggregate_mode = handle.aggregate_mode;
     let ctx = handle.ctx;
     let table_name = handle.table_name;
     let table_path = handle.table_path;
@@ -880,6 +881,13 @@ async unsafe fn execute_indexed_with_context_inner(
     // types. The target is schema_coerce::coerce_inferred_schema(physical_schema) — same
     // narrowing the partition-stream registration uses, so consumer-side StreamingTable
     // and producer-side batches agree by construction (see crate::relabel_exec).
+    // Apply aggregate mode stripping when prepare_partial_plan was called (engine-native-merge).
+    // This makes the indexed executor produce Binary HLL state (Partial) instead of Int64 (Final).
+    let physical_plan = if aggregate_mode != crate::agg_mode::Mode::Default {
+        crate::agg_mode::apply_aggregate_mode(physical_plan, aggregate_mode)?
+    } else {
+        physical_plan
+    };
     let target_schema = crate::schema_coerce::coerce_inferred_schema(physical_plan.schema());
     let physical_plan = crate::relabel_exec::wrap_if_relabel_needed(physical_plan, target_schema)?;
     log_debug!("DataFusion physical plan:\n{}", displayable(physical_plan.as_ref()).indent(true));

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/substrait_to_tree.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/substrait_to_tree.rs
@@ -460,13 +460,24 @@ impl ScalarUDFImpl for DelegationPossibleUdf {
     }
     fn invoke_with_args(
         &self,
-        _args: ScalarFunctionArgs,
+        args: ScalarFunctionArgs,
     ) -> datafusion::common::Result<ColumnarValue> {
-        Err(datafusion::common::DataFusionError::Internal(format!(
-            "{} UDF body invoked — expr_to_bool_tree did not unwrap the marker; \
-                 treat as a serious correctness bug",
-            DELEGATION_POSSIBLE_FUNCTION_NAME
-        )))
+        // Pass-through: evaluate the original predicate (first arg) directly.
+        // Expected on the prepare_partial_plan path where FilterExec retains the
+        // delegation_possible wrapper. On the indexed path, expr_to_bool_tree should
+        // unwrap the marker before execution — log a warning if we reach here
+        // unexpectedly so correctness issues surface in logs without crashing.
+        log::warn!(
+            "delegation_possible UDF evaluated at runtime — expected only on \
+             prepare_partial_plan path; if this appears on a data-node indexed query, \
+             expr_to_bool_tree may have missed the marker"
+        );
+        args.args.into_iter().next().ok_or_else(|| {
+            datafusion::common::DataFusionError::Internal(format!(
+                "{} UDF invoked with no arguments",
+                DELEGATION_POSSIBLE_FUNCTION_NAME
+            ))
+        })
     }
 }
 

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/PlannerContext.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/PlannerContext.java
@@ -33,7 +33,6 @@ public class PlannerContext {
     private final boolean preferMetadataDriver;
     private int annotationIdCounter;
     private RuleProfilingListener.PlannerProfile lastProfile;
-    private boolean hasEngineNativeMergeAggregate;
     // Cluster settings the planner consults at planning time (oversampling factor + delegation
     // block-list). Defaults to planner defaults; DefaultPlanExecutor injects the live, settings-backed
     // instance via setPlannerSettings before planning.
@@ -126,14 +125,6 @@ public class PlannerContext {
 
     public OpenSearchDistributionTraitDef getDistributionTraitDef() {
         return distributionTraitDef;
-    }
-
-    public boolean hasEngineNativeMergeAggregate() {
-        return hasEngineNativeMergeAggregate;
-    }
-
-    public void setHasEngineNativeMergeAggregate(boolean value) {
-        this.hasEngineNativeMergeAggregate = value;
     }
 
     /**

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/PlannerImpl.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/PlannerImpl.java
@@ -18,8 +18,6 @@ import org.apache.calcite.plan.volcano.VolcanoPlanner;
 import org.apache.calcite.rel.RelHomogeneousShuttle;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.RelShuttle;
-import org.apache.calcite.rel.core.Aggregate;
-import org.apache.calcite.rel.core.AggregateCall;
 import org.apache.calcite.rel.core.Filter;
 import org.apache.calcite.rel.core.Project;
 import org.apache.calcite.rel.core.Sort;
@@ -54,7 +52,6 @@ import org.opensearch.analytics.planner.rules.OpenSearchTopKRewriter;
 import org.opensearch.analytics.planner.rules.OpenSearchUnionRule;
 import org.opensearch.analytics.planner.rules.OpenSearchUnionSplitRule;
 import org.opensearch.analytics.planner.rules.OpenSearchValuesRule;
-import org.opensearch.analytics.spi.AggregateFunction;
 
 import java.util.List;
 import java.util.Optional;
@@ -102,7 +99,6 @@ public class PlannerImpl {
         modifiedRelNode = reduceExpressions(modifiedRelNode, listener);
         modifiedRelNode = pushdownRules(modifiedRelNode, listener);
         modifiedRelNode = decomposeAggregates(modifiedRelNode, listener);
-        context.setHasEngineNativeMergeAggregate(containsEngineNativeMergeAggregate(modifiedRelNode));
         modifiedRelNode = mark(modifiedRelNode, context, listener);
         LOGGER.debug("After marking:\n{}", RelOptUtil.toString(modifiedRelNode));
         // TODO(combine-delegated-predicates): a post-marking HEP rule should fuse same-backend
@@ -341,25 +337,6 @@ public class PlannerImpl {
      * <p>TODO: add SortPushdown rule here — pushes Sort below Exchange to data nodes for top-K
      * optimization.
      */
-    /**
-     * True if the plan contains an aggregate with engine-native-merge semantics (intermediate
-     * wire type differs from output type, e.g. APPROX_COUNT_DISTINCT emits Binary HLL state).
-     * When present, filter delegation must be suppressed to avoid plan-shape divergence between
-     * derive_schema_from_partial_plan and the data-node execution.
-     */
-    private static boolean containsEngineNativeMergeAggregate(RelNode node) {
-        if (node instanceof Aggregate agg) {
-            for (AggregateCall call : agg.getAggCallList()) {
-                if (AggregateFunction.isEngineNativeMerge(call)) {
-                    return true;
-                }
-            }
-        }
-        for (RelNode child : node.getInputs()) {
-            if (containsEngineNativeMergeAggregate(child)) return true;
-        }
-        return false;
-    }
 
     private static RelNode mark(RelNode input, PlannerContext context, RuleProfilingListener listener) {
         return HepPhase.named("marking")

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchFilterRule.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchFilterRule.java
@@ -254,19 +254,6 @@ public class OpenSearchFilterRule extends RelOptRule {
             viableSet.retainAll(registry.scalarBackendsAnyFormat(scalarFunc, returnType));
         }
 
-        // TODO: Temporary workaround — suppress dual-viable filters for dc() (engine-native-merge)
-        // queries. When delegation_possible UDF wraps a predicate in an APPROX_COUNT_DISTINCT plan,
-        // the shard execution path produces Int64 instead of the expected Binary HLL intermediate,
-        // causing a schema mismatch at the reduce sink. Proper fix requires changes to the DataFusion
-        // local execution path to honour the prepared partial plan when delegation_possible is present.
-        if (context.hasEngineNativeMergeAggregate() && viableSet.size() > 1) {
-            List<String> delegationAcceptors = registry.delegationAcceptors(DelegationType.FILTER);
-            boolean drivingBackendSurvives = viableSet.stream().anyMatch(b -> !delegationAcceptors.contains(b));
-            if (drivingBackendSurvives) {
-                viableSet.removeAll(delegationAcceptors);
-            }
-        }
-
         // Per-backend delegation block-list. Drop backends that block this predicate so it is never
         // marked viable for them — but only when a non-blocked backend survives: blocking is a
         // delegation knob and must never make a predicate unexecutable.

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/FilterDelegationExtendedIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/FilterDelegationExtendedIT.java
@@ -84,7 +84,30 @@ public class FilterDelegationExtendedIT extends AnalyticsRestTestCase {
 
         // ===== IN =====
         new Case("where str0 in ('apple', 'cherry') | stats count() as c", 5, false),
-        new Case("where str0 in ('apple', 'cherry') | stats sum(num0) as c", 210, false)
+        new Case("where str0 in ('apple', 'cherry') | stats sum(num0) as c", 210, false),
+
+        // ===== AVG — additional exact-integer cases =====
+        new Case("where str0 != 'cherry' | stats avg(num0) as c", 50, false),
+
+        // ===== dc() across more predicate shapes =====
+        new Case("where str0 != 'banana' | stats dc(str0) as c", 3, false),
+        new Case("where isnull(str1) | stats dc(num0) as c", 4, false),
+        new Case("where isnotnull(str1) | stats dc(num0) as c", 6, false),
+
+        // ===== PERCENTILE =====
+        new Case("where str0 != 'apple' | stats percentile(num0, 50) as c", 70, false),
+        new Case("where isnull(str1) | stats percentile(num0, 50) as c", 70, false)
+    );
+
+    private record StatisticalCase(String pplSuffix, double expected) {}
+
+    private static final List<StatisticalCase> STATISTICAL_CASES = List.of(
+        new StatisticalCase("where str0 != 'apple' | stats stddev_pop(num0) as c", 20.0),
+        new StatisticalCase("where str0 != 'apple' | stats stddev_samp(num0) as c", 21.602469),
+        new StatisticalCase("where isnull(str1) | stats stddev_pop(num0) as c", 25.860201),
+        new StatisticalCase("where isnull(str1) | stats stddev_samp(num0) as c", 29.860788),
+        new StatisticalCase("where isnotnull(str1) | stats stddev_pop(num0) as c", 27.487371),
+        new StatisticalCase("where isnotnull(str1) | stats stddev_samp(num0) as c", 30.110906)
     );
 
     private static boolean dataProvisioned = false;
@@ -112,6 +135,28 @@ public class FilterDelegationExtendedIT extends AnalyticsRestTestCase {
         }
         if (!failures.isEmpty()) {
             fail("Filter delegation failures (" + failures.size() + " of " + CASES.size() + "):\n"
+                + String.join("\n", failures));
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testStatisticalAggregatesWithDelegation() throws Exception {
+        List<String> failures = new java.util.ArrayList<>();
+        for (StatisticalCase dc : STATISTICAL_CASES) {
+            try {
+                String ppl = "source = " + DATASET.indexName + " | " + dc.pplSuffix;
+                Map<String, Object> result = executePpl(ppl);
+                List<List<Object>> rows = (List<List<Object>>) result.get("datarows");
+                assertNotNull("datarows null for [" + dc.pplSuffix + "]", rows);
+                assertEquals("expected 1 agg row for [" + dc.pplSuffix + "]", 1, rows.size());
+                double actual = ((Number) rows.get(0).get(0)).doubleValue();
+                assertEquals("[" + dc.pplSuffix + "]", dc.expected, actual, 0.1);
+            } catch (AssertionError | Exception e) {
+                failures.add(dc.pplSuffix + " → " + e.getMessage());
+            }
+        }
+        if (!failures.isEmpty()) {
+            fail("Statistical aggregate failures (" + failures.size() + " of " + STATISTICAL_CASES.size() + "):\n"
                 + String.join("\n", failures));
         }
     }


### PR DESCRIPTION
 ## Summary

The indexed executor now applies `aggregate_mode` stripping (Mode::Partial) after building its physical plan, producing Binary HLL state instead of Int64 for engine-native-merge aggregates (dc/APPROX_COUNT_DISTINCT). This fixes the schema mismatch at the reduce sink without needing to suppress filter delegation at marking time.

- **indexed_executor.rs**: Apply `apply_aggregate_mode` after physical plan build when `aggregate_mode != Mode::Default`
- **substrait_to_tree.rs**: `delegation_possible` UDF body returns first arg (transparent pass-through) instead of panicking — allows prepared_plan FilterExec to evaluate normally
- **OpenSearchFilterRule.java**: Remove engine-native-merge gate (no longer needed)
- **PlannerContext/PlannerImpl**: Remove dead `hasEngineNativeMergeAggregate` flag and `containsEngineNativeMergeAggregate` method
- **FilterDelegationExtendedIT**: Expand with stddev_pop/samp, percentile, additional dc() shapes (29 exact + 6 double-tolerance cases on 2 shards)

## Context

When filter predicates are dual-viable (can execute on both DataFusion and Lucene), they get wrapped in `delegation_possible(...)` in the substrait, which routes execution to the indexed executor. Previously, the indexed executor always re-decoded substrait with Mode::Default — producing Int64 (final aggregate output) instead of Binary HLL intermediate state. The coordinator expected Binary (from `derive_schema_from_partial_plan`), causing a type mismatch.

 The prior workaround suppressed dual-viable marking for dc() queries entirely (the "gate"), preventing filter delegation from benefiting dc() queries. This PR removes that gate by teaching the indexed executor to respect aggregate mode.

## Testing

- `FilterDelegationExtendedIT` — 35 cases: included more count/sum/avg/min/max/dc/percentile/stddev_pop/stddev_samp/fields (2-shard dataset)
- `PplClickBenchIT` — all 42 queries pass (including Q23: LIKE + dc + correctness delegation)
- `FilterDelegationGoldenIT` — all 38 routing shapes pass

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
