### PR TITLE
Added fix to preserve replicatingCommitData on generation bump

### DIFF
--- a/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/DataFormatAwareReplicationPromotionIT.java
+++ b/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/DataFormatAwareReplicationPromotionIT.java
@@ -184,6 +184,57 @@ public class DataFormatAwareReplicationPromotionIT extends DataFormatAwareReplic
     }
 
     /**
+     * Verifies that a generation bump on the replica preserves the primary's replicated
+     * SegmentInfos ({@code replicatingCommitData}).
+     *
+     * <p>The test indexes and refreshes (no flush) so segment replication delivers a snapshot to
+     * the replica and sets {@code replicatingCommitData} to a non-null value, then flushes the
+     * replica to trigger a generation bump, and finally asserts that the replica's catalog snapshot
+     * still has non-null {@code replicatingCommitData}.
+     */
+    public void testGenerationBumpPreservesReplicatingCommitData() throws Exception {
+        createDfaIndex(1);
+
+        // 1. Refresh-level replication delivers a snapshot to the replica (sets replicatingCommitData,
+        // no commit-generation change => no bump).
+        indexDocs(50);
+        client().admin().indices().prepareRefresh(INDEX_NAME).get();
+
+        String replicaNode = replicaNodeNames().get(0);
+        org.opensearch.index.shard.IndexShard replica = getIndexShard(replicaNode, INDEX_NAME);
+
+        // Pre-condition (guards test validity): once segrep has delivered, the replica's current
+        // snapshot must carry a non-null replicatingCommitData.
+        assertBusy(
+            () -> assertReplicatingCommitDataNotNull(replica, "after initial replication"),
+            60,
+            java.util.concurrent.TimeUnit.SECONDS
+        );
+
+        // 2. Trigger a generation bump on the replica.
+        replica.flush(new org.opensearch.action.admin.indices.flush.FlushRequest(INDEX_NAME).force(true).waitIfOngoing(true));
+
+        // 3. The bump must NOT have dropped replicatingCommitData.
+        assertReplicatingCommitDataNotNull(replica, "after generation bump (replica flush)");
+    }
+
+    private void assertReplicatingCommitDataNotNull(org.opensearch.index.shard.IndexShard shard, String when) throws Exception {
+        try (
+            org.opensearch.common.concurrent.GatedCloseable<org.opensearch.index.engine.exec.coord.CatalogSnapshot> ref = shard
+                .getCatalogSnapshot()
+        ) {
+            org.opensearch.index.engine.exec.coord.CatalogSnapshot snapshot = ref.get();
+            assertTrue(
+                "expected DataformatAwareCatalogSnapshot but got " + snapshot.getClass().getName(),
+                snapshot instanceof org.opensearch.index.engine.exec.coord.DataformatAwareCatalogSnapshot
+            );
+            Object replicatingCommitData = ((org.opensearch.index.engine.exec.coord.DataformatAwareCatalogSnapshot) snapshot)
+                .getReplicatingCommitData();
+            assertNotNull("replica catalog snapshot replicatingCommitData must not be null " + when, replicatingCommitData);
+        }
+    }
+
+    /**
      * Builds a BackgroundIndexer that swallows indexing failures. Writes issued during the brief
      * no-primary window around a cancel/promote will get UnavailableShardsException; the test
      * tolerates these as expected.

--- a/server/src/main/java/org/opensearch/index/engine/exec/coord/CatalogSnapshotManager.java
+++ b/server/src/main/java/org/opensearch/index/engine/exec/coord/CatalogSnapshotManager.java
@@ -341,6 +341,9 @@ public class CatalogSnapshotManager implements Closeable {
             latestCatalogSnapshot.getCommitDataFormatVersion()
         );
 
+        // Carry forward the primary's replicated SegmentInfos; same segment set, so it still applies.
+        newSnapshot.setReplicatingCommitData(latestCatalogSnapshot.getReplicatingCommitData());
+
         installSnapshot(newSnapshot);
     }
 

--- a/server/src/test/java/org/opensearch/index/engine/exec/coord/CatalogSnapshotManagerTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/exec/coord/CatalogSnapshotManagerTests.java
@@ -836,6 +836,92 @@ public class CatalogSnapshotManagerTests extends OpenSearchTestCase {
     }
 
     /**
+     * Once an initial snapshot carries non-null {@code replicatingCommitData}, a generation bump
+     * must carry it forward so the replica's catalog snapshot never loses the primary's replicated
+     * SegmentInfos.
+     */
+    public void testBumpGenerationPreservesReplicatingCommitData() throws Exception {
+        Object commitData = new Object();
+        DataformatAwareCatalogSnapshot initial = new DataformatAwareCatalogSnapshot(1L, 1L, 0L, randomSegments(), 1L, Map.of());
+        initial.setLastCommitInfo("segments_1", 1L, 0L);
+        initial.setReplicatingCommitData(commitData);
+
+        CatalogSnapshotManager manager = new CatalogSnapshotManager(
+            List.of(initial),
+            CatalogSnapshotDeletionPolicy.KEEP_LATEST_ONLY,
+            files -> Map.of(),
+            Map.of(),
+            List.of(),
+            null,
+            mock(CommitFileManager.class)
+        );
+        try {
+            // A single bump must carry the data forward by identity.
+            manager.bumpGeneration();
+            try (GatedCloseable<CatalogSnapshot> ref = manager.acquireSnapshot()) {
+                DataformatAwareCatalogSnapshot latest = (DataformatAwareCatalogSnapshot) ref.get();
+                assertNotNull("replicatingCommitData must survive a generation bump", latest.getReplicatingCommitData());
+                assertSame("replicatingCommitData must be carried forward unchanged", commitData, latest.getReplicatingCommitData());
+            }
+
+            // Repeated bumps must keep it non-null at every generation.
+            int extraBumps = randomIntBetween(1, 10);
+            for (int i = 0; i < extraBumps; i++) {
+                manager.bumpGeneration();
+                try (GatedCloseable<CatalogSnapshot> ref = manager.acquireSnapshot()) {
+                    DataformatAwareCatalogSnapshot latest = (DataformatAwareCatalogSnapshot) ref.get();
+                    assertNotNull("replicatingCommitData must remain non-null after repeated bumps", latest.getReplicatingCommitData());
+                    assertSame(commitData, latest.getReplicatingCommitData());
+                }
+            }
+        } finally {
+            manager.close();
+        }
+    }
+
+    /**
+     * {@code applyReplicationSnapshot} followed by a generation bump must keep the incoming
+     * snapshot's non-null {@code replicatingCommitData} (the value the primary replicated).
+     */
+    public void testReplicationSnapshotThenBumpPreservesReplicatingCommitData() throws Exception {
+        CatalogSnapshotManager manager = replicaManager(null, List.of(), Map.of(), mock(CommitFileManager.class));
+        try {
+            CatalogSnapshot previous;
+            try (GatedCloseable<CatalogSnapshot> ref = manager.acquireSnapshot()) {
+                previous = ref.get();
+            }
+
+            Object commitData = new Object();
+            DataformatAwareCatalogSnapshot incoming = new DataformatAwareCatalogSnapshot(
+                randomNonNegativeLong(),
+                previous.getGeneration() + 1,
+                randomNonNegativeLong(),
+                randomSegments(),
+                randomNonNegativeLong(),
+                randomUserData(randomIntBetween(0, 4))
+            );
+            incoming.setReplicatingCommitData(commitData);
+
+            manager.applyReplicationSnapshot(incoming);
+            try (GatedCloseable<CatalogSnapshot> ref = manager.acquireSnapshot()) {
+                DataformatAwareCatalogSnapshot latest = (DataformatAwareCatalogSnapshot) ref.get();
+                assertNotNull("replicatingCommitData must be copied from the incoming snapshot", latest.getReplicatingCommitData());
+                assertSame(commitData, latest.getReplicatingCommitData());
+            }
+
+            // The subsequent bump (e.g. a replica flush) must not drop it to null.
+            manager.bumpGeneration();
+            try (GatedCloseable<CatalogSnapshot> ref = manager.acquireSnapshot()) {
+                DataformatAwareCatalogSnapshot latest = (DataformatAwareCatalogSnapshot) ref.get();
+                assertNotNull("replicatingCommitData must survive the post-replication bump", latest.getReplicatingCommitData());
+                assertSame(commitData, latest.getReplicatingCommitData());
+            }
+        } finally {
+            manager.close();
+        }
+    }
+
+    /**
      * Replica manager with a {@link CommitFileManager} must protect commit-owned files
      * (e.g. {@code segments_N}, {@code write.lock}) from the startup orphan sweep, even when
      * they are present on disk but not referenced by the initial committed snapshot.


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
### Problem
  On a DataFormatAware NRT-replication replica, a primary-term transition could fail the engine with `CorruptIndexException` / `NoSuchFileException` — the latest on-disk commit (`segments_N`) referenced segment files that had been deleted.
  
  ### Root cause
  `CatalogSnapshotManager.bumpGeneration()` built the next catalog snapshot but did not carry ove `replicatingCommitData` (the primary's replicated `SegmentInfos`), unlike its siblings `commitNewSnapshot()` and `applyReplicationSnapshot()`. With it null, `LuceneReplicaCommitter` fell back to a stale `lastCommittedSegmentInfos` and wrote a `segments_N` describing the pre-merge segment set, while the deletion policy (using the current catalog) removed those now-unreferenced files — orphaning segments the commit still pointed to. The failure only surfaced later, when `ReadOnlyEngine` read that commit during `resetEngineToGlobalCheckpoint`.
  
  ### Fix
  Carry `replicatingCommitData` forward in `bumpGeneration()` (the bump preserves the same segment set, so the primary's `SegmentInfos` still applies). This re-couples the committed `segments_N` with the files the deletion policy retains — matching vanilla `NRTReplicationEngine`, where the committed infos and retained files derive from the same object and cannot diverge.
  
  ### Testing
  Added `DataFormatAwareReplicationPromotionIT.testGenerationBumpPreservesReplicatingCommitData`: delivers a replicated snapshot to the replica (sets `replicatingCommitData`), triggers a generation bump via flush, and asserts the snapshot still carries non-null `replicatingCommitData`. Fails without the fix, passes with it.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
