### PR TITLE
Fix CPU stall in geotile_grid aggregation by limiting max tiles per doc

### DIFF
--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/GeoTileUtils.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/GeoTileUtils.java
@@ -295,8 +295,13 @@ public final class GeoTileUtils {
      * @param geoShapeDocValue {@link GeoShapeDocValue}
      * @param precision int
      * @return {@link List} of {@link Long}
+     * @throws IllegalArgumentException if the number of tiles to process exceeds the maximum allowed
      */
     public static List<Long> encodeShape(final GeoShapeDocValue geoShapeDocValue, final int precision) {
+        // Maximum number of tiles that can be generated for a single shape.
+        // This prevents excessive CPU usage and memory consumption when processing shapes at high precision levels.
+        final int maxTilesPerShape = 10000;
+
         final GeoShapeDocValue.BoundingRectangle boundingRectangle = geoShapeDocValue.getBoundingRectangle();
         // generate all the grid long values that this shape intersects.
         final long totalTilesAtPrecision = 1L << checkPrecisionRange(precision);
@@ -306,9 +311,30 @@ public final class GeoTileUtils {
         // take maxY and for maxYTile we need to take minY.
         int minYTile = getYTile(boundingRectangle.getMaxY(), totalTilesAtPrecision);
         int maxYTile = getYTile(boundingRectangle.getMinY(), totalTilesAtPrecision);
+        // Calculate the number of tiles that would be processed
+        long xTileCount = (long) maxXTile - minXTile + 1;
+        long yTileCount = (long) maxYTile - minYTile + 1;
+        long totalTilesToProcess = xTileCount * yTileCount;
+        // Prevent excessive CPU usage by limiting the number of tiles to process
+        if (totalTilesToProcess > maxTilesPerShape) {
+            throw new IllegalArgumentException(
+                "The geotile_grid aggregation would process "
+                    + totalTilesToProcess
+                    + " tiles for this shape at precision "
+                    + precision
+                    + ", which exceeds the maximum allowed ("
+                    + maxTilesPerShape
+                    + "). Please use a lower precision value (recommended: precision <= 20 for geo_shape fields)."
+            );
+        }
+
         final List<Long> encodedValues = new ArrayList<>();
         for (int x = minXTile; x <= maxXTile; x++) {
             for (int y = minYTile; y <= maxYTile; y++) {
+                // Check for thread interruption to allow query cancellation
+                if (Thread.interrupted()) {
+                    throw new IllegalStateException("Query was cancelled or timed out during geotile_grid aggregation");
+                }
                 // Convert the precision, x , y to encoded value.
                 long encodedValue = longEncodeTiles(precision, x, y);
                 // Convert encoded value to rectangle

--- a/server/src/test/java/org/opensearch/search/aggregations/bucket/geogrid/GeoTileUtilsTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/bucket/geogrid/GeoTileUtilsTests.java
@@ -265,4 +265,52 @@ public class GeoTileUtilsTests extends OpenSearchTestCase {
         assertThat(GeoTileUtils.getYTile(y, tiles), equalTo(yTile));
 
     }
+
+    /**
+     * Test that encodeShape throws an exception when the number of tiles exceeds the maximum allowed.
+     * This prevents CPU spikes and infinite loops when processing shapes at very high precision levels.
+     */
+    public void testEncodeShapeWithExcessiveTiles() {
+        // Create a Line shape similar to the LineString in the bug report
+        org.opensearch.geometry.Line line = new org.opensearch.geometry.Line(
+            new double[] { 120.69105, 120.75767, 120.82192 },
+            new double[] { -2.10922, -2.15919, -2.18774 }
+        );
+
+        org.opensearch.common.geo.GeoShapeDocValue geoShapeDocValue = org.opensearch.common.geo.GeoShapeDocValue.createGeometryDocValue(
+            line
+        );
+
+        // At precision 29, this should throw an IllegalArgumentException due to excessive tiles
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> GeoTileUtils.encodeShape(geoShapeDocValue, 29)
+        );
+
+        assertThat(exception.getMessage(), containsString("would process"));
+        assertThat(exception.getMessage(), containsString("tiles for this shape at precision 29"));
+        assertThat(exception.getMessage(), containsString("exceeds the maximum allowed"));
+        assertThat(exception.getMessage(), containsString("recommended: precision <= 20 for geo_shape fields"));
+    }
+
+    /**
+     * Test that encodeShape works correctly with reasonable precision values.
+     */
+    public void testEncodeShapeWithReasonablePrecision() {
+        // Create a small Line
+        org.opensearch.geometry.Line line = new org.opensearch.geometry.Line(
+            new double[] { 120.69105, 120.75767, 120.82192 },
+            new double[] { -2.10922, -2.15919, -2.18774 }
+        );
+
+        org.opensearch.common.geo.GeoShapeDocValue geoShapeDocValue = org.opensearch.common.geo.GeoShapeDocValue.createGeometryDocValue(
+            line
+        );
+
+        // At precision 10, this should work fine
+        java.util.List<Long> tiles = GeoTileUtils.encodeShape(geoShapeDocValue, 10);
+        assertNotNull(tiles);
+        assertTrue(tiles.size() > 0);
+        assertTrue(tiles.size() < 10000); // Should be well under the limit
+    }
 }


### PR DESCRIPTION
### Description
Fixed bug where geotile_grid aggregation on geo_shape fields caused CPU spikes and node unresponsiveness. The fix implements two safeguards:

Tile Limit Check: Prevents processing when the number of tiles exceeds 10,000, throwing a clear error with actionable guidance
Cancellation Support: Adds thread interruption checks in the tile processing loop to respect query timeouts and cancellation requests
Why a 3-coordinate LineString causes billions of iterations:
At precision 29, there are 2^29 = 536M tiles per axis. Even a tiny LineString spanning ~0.13° × 0.08° results in ~2.4M × ~1.5M = 3.6 billion tile intersection checks, each performing expensive geometric calculations.

### Related Issues
Resolves #[[20413](https://github.com/opensearch-project/OpenSearch/issues/20413)]


### Check List
- [x] Functionality includes testing.
          Added testEncodeShapeWithExcessiveTiles() - Verifies exception thrown at precision 29
          Added testEncodeShapeWithReasonablePrecision() - Verifies normal operation at precision 10
          All tests pass: ./gradlew :server:test and ./gradlew :modules:geo:test  
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
