### PR TITLE
Add missing physical plan debug logs for pure-Parquet and coordinator paths

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/local_executor.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/local_executor.rs
@@ -184,11 +184,13 @@ impl LocalSession {
             DataFusionError::Execution(format!("Failed to decode Substrait plan: {}", e))
         })?;
         let logical_plan = from_substrait_plan(&self.ctx.state(), &plan).await?;
+        log_debug!("DataFusion logical plan:\n{}", logical_plan.display_indent());
         let dataframe = self.ctx.execute_logical_plan(logical_plan).await?;
         let physical_plan = dataframe.create_physical_plan().await?;
 
         let target_schema = crate::schema_coerce::coerce_inferred_schema(physical_plan.schema());
         let physical_plan = crate::relabel_exec::wrap_if_relabel_needed(physical_plan, target_schema)?;
+        log_debug!("DataFusion physical plan:\n{}", displayable(physical_plan.as_ref()).indent(true));
         datafusion::physical_plan::execute_stream(physical_plan, self.ctx.task_ctx())
             .map_err(|e| DataFusionError::Execution(format!("execute_substrait: {}", e)))
     }

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/query_executor.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/query_executor.rs
@@ -350,6 +350,7 @@ pub async fn execute_with_context(
 
         let target_schema = crate::schema_coerce::coerce_inferred_schema(physical_plan.schema());
         let physical_plan = crate::relabel_exec::wrap_if_relabel_needed(physical_plan, target_schema)?;
+        log_debug!("DataFusion physical plan:\n{}", displayable(physical_plan.as_ref()).indent(true));
 
         let df_stream = execute_stream(physical_plan.clone(), handle.ctx.task_ctx()).map_err(|e| {
             error!("execute_with_context: failed to create stream: {}", e);

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionMemtableReduceSinkTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionMemtableReduceSinkTests.java
@@ -8,6 +8,8 @@
 
 package org.opensearch.be.datafusion;
 
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.BigIntVector;
@@ -47,6 +49,7 @@ import io.substrait.extension.SimpleExtension;
  * batches, same downstream assertion — exercises the buffered-batch handoff path instead of the
  * streaming sender path.
  */
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
 public class DatafusionMemtableReduceSinkTests extends OpenSearchTestCase {
 
     public void testInputIdConstantMatchesDesign() {

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionReduceSinkTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionReduceSinkTests.java
@@ -8,6 +8,8 @@
 
 package org.opensearch.be.datafusion;
 
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.BigIntVector;
@@ -60,6 +62,7 @@ import io.substrait.extension.SimpleExtension;
  *       reduced result.</li>
  * </ul>
  */
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
 public class DatafusionReduceSinkTests extends OpenSearchTestCase {
 
     public void testArrowSchemaIpcEncodesSchema() {


### PR DESCRIPTION
The indexed executor (delegation path) logs both logical and physical DataFusion plans at DEBUG level, but the query executor (pure Parquet) only logs the logical plan, and the local executor (coordinator reduce) logs neither.

This adds the missing `log_debug!` statements so all three execution paths consistently log both plans:

| Executor | Before | After |
|----------|--------|-------|
| `indexed_executor.rs` (delegation) | ✅ logical + ✅ physical | no change |
| `query_executor.rs` (pure Parquet) | ✅ logical + ❌ physical | ✅ logical + ✅ physical |
| `local_executor.rs` (coordinator) | ❌ neither | ✅ logical + ✅ physical |

Enable logger
```
PUT /_cluster/settings
  {
    "transient": {
      "logger.org.opensearch.nativebridge.spi.RustLoggerBridge": "DEBUG"
    }
  }
```

### Thread leaks in test runs

Our tests configure 2 DF worker threads which persist beyond the lifetime of the test. When we add an up call from DF these threads become visible to the JVM and tracked by the test infrastructure. As these thread pools persist beyond the lifetime of the test teardown our test harness considers them "leaked".

To help identify these "leaked" threads we tag them with names in our logging up call.
```
static void log(int level, MemorySegment msgPtr, long msgLen) {
        Thread t = Thread.currentThread();
        if (t.getName().startsWith("Thread-")) {
            t.setName("datafusion-native-" + t.getId());
        }
```

And observer that this is the reported to leak by test infrastructure.
```
 DatafusionMemtableReduceSinkTests > classMethod FAILED
      com.carrotsearch.randomizedtesting.ThreadLeakError: 1 thread leaked from SUITE scope at org.opensearch.be.datafusion.DatafusionMemtableReduceSinkTests:
         1) Thread[id=45, name=datafusion-native-45, state=RUNNABLE, group=main]
              at (empty stack)
```

Datafusion in our tests delegates to a fixed worker thread pool and we should not need to worry about these threads making upcall leaking.
(In `DatafusionMemtableReduceSinkTests` which previously reported the above thread leaks)
```
        NativeBridge.initTokioRuntimeManager(2);
```

To resolve these i've added some annotations to various tests impacted by these new upcalls which cause them to report thread leaks.