### PR TITLE
Add min_number_of_replicas setting

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/IndexMetadata.java
@@ -292,6 +292,15 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         Property.IndexScope
     );
 
+    public static final String SETTING_MIN_NUMBER_OF_REPLICAS = "index.min_number_of_replicas";
+    public static final Setting<Integer> INDEX_MIN_NUMBER_OF_REPLICAS_SETTING = Setting.intSetting(
+        SETTING_MIN_NUMBER_OF_REPLICAS,
+        -1,
+        -1,
+        Property.Dynamic,
+        Property.IndexScope
+    );
+
     /**
      * Setting to control the number of search only replicas for an index.
      * A search only replica exists solely to perform read operations for a shard and are designed to achieve
@@ -1416,6 +1425,11 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         return numberOfReplicas;
     }
 
+    public int getMinNumberOfReplicas() {
+        int min = INDEX_MIN_NUMBER_OF_REPLICAS_SETTING.get(settings);
+        return min == -1 ? numberOfReplicas : min;
+    }
+
     public int getNumberOfSearchOnlyReplicas() {
         return numberOfSearchOnlyReplicas;
     }
@@ -2373,6 +2387,18 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             }
             final int numberOfReplicas = INDEX_NUMBER_OF_REPLICAS_SETTING.get(settings);
             final int numberOfSearchReplicas = INDEX_NUMBER_OF_SEARCH_REPLICAS_SETTING.get(settings);
+            final int minNumberOfReplicas = INDEX_MIN_NUMBER_OF_REPLICAS_SETTING.get(settings);
+            if (minNumberOfReplicas != -1 && minNumberOfReplicas > numberOfReplicas) {
+                throw new IllegalArgumentException(
+                    "index.min_number_of_replicas ["
+                        + minNumberOfReplicas
+                        + "] must be <= index.number_of_replicas ["
+                        + numberOfReplicas
+                        + "] for ["
+                        + index
+                        + "]"
+                );
+            }
 
             int routingPartitionSize = INDEX_ROUTING_PARTITION_SIZE_SETTING.get(settings);
             if (routingPartitionSize != 1 && routingPartitionSize >= getRoutingNumShards()) {

--- a/server/src/main/java/org/opensearch/cluster/metadata/MetadataUpdateSettingsService.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/MetadataUpdateSettingsService.java
@@ -286,7 +286,16 @@ public class MetadataUpdateSettingsService {
                              *
                              * TODO: should we update the in-sync allocation IDs once the data is deleted by the node?
                              */
-                            routingTableBuilder.updateNumberOfReplicas(updatedNumberOfReplicas, actualIndices);
+                            for (String index : actualIndices) {
+                                final IndexMetadata indexMd = currentState.metadata().index(index);
+                                int minFromSetting = IndexMetadata.INDEX_MIN_NUMBER_OF_REPLICAS_SETTING.exists(openSettings)
+                                    ? IndexMetadata.INDEX_MIN_NUMBER_OF_REPLICAS_SETTING.get(openSettings)
+                                    : (indexMd != null
+                                        ? IndexMetadata.INDEX_MIN_NUMBER_OF_REPLICAS_SETTING.get(indexMd.getSettings())
+                                        : -1);
+                                int minReplicas = minFromSetting == -1 ? updatedNumberOfReplicas : minFromSetting;
+                                routingTableBuilder.updateNumberOfReplicas(updatedNumberOfReplicas, minReplicas, new String[] { index });
+                            }
                             metadataBuilder.updateNumberOfReplicas(updatedNumberOfReplicas, actualIndices);
                             logger.info("updating number_of_replicas to [{}] for indices {}", updatedNumberOfReplicas, actualIndices);
                         }

--- a/server/src/main/java/org/opensearch/cluster/routing/RoutingTable.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/RoutingTable.java
@@ -533,6 +533,22 @@ public class RoutingTable implements Iterable<IndexRoutingTable>, Diffable<Routi
          * @return the builder
          */
         public Builder updateNumberOfReplicas(final int numberOfReplicas, final String[] indices) {
+            return updateNumberOfReplicas(numberOfReplicas, numberOfReplicas, indices);
+        }
+
+        /**
+         * Update the number of replicas for the specified indices, respecting a minimum replica floor.
+         * <p>
+         * If the current replica count is below {@code minNumberOfReplicas}, replicas are added up to the minimum.
+         * If the current replica count is above {@code numberOfReplicas}, replicas are removed down to that number.
+         * If the current count is between min and max, no changes are made.
+         *
+         * @param numberOfReplicas    the desired (maximum) number of replicas
+         * @param minNumberOfReplicas the minimum number of replicas to maintain
+         * @param indices             the indices to update the number of replicas for
+         * @return the builder
+         */
+        public Builder updateNumberOfReplicas(final int numberOfReplicas, final int minNumberOfReplicas, final String[] indices) {
             if (indicesRouting == null) {
                 throw new IllegalStateException("once build is called the builder cannot be reused");
             }
@@ -548,9 +564,8 @@ public class RoutingTable implements Iterable<IndexRoutingTable>, Diffable<Routi
                 for (IndexShardRoutingTable indexShardRoutingTable : indexRoutingTable) {
                     builder.addIndexShard(indexShardRoutingTable);
                 }
-                if (currentNumberOfReplicas < numberOfReplicas) {
-                    // now, add "empty" ones
-                    for (int i = 0; i < (numberOfReplicas - currentNumberOfReplicas); i++) {
+                if (currentNumberOfReplicas < minNumberOfReplicas) {
+                    for (int i = 0; i < (minNumberOfReplicas - currentNumberOfReplicas); i++) {
                         builder.addReplica();
                     }
                 } else if (currentNumberOfReplicas > numberOfReplicas) {

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/AllocationService.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/AllocationService.java
@@ -392,7 +392,12 @@ public class AllocationService {
                 final String[] indices = entry.getValue().toArray(new String[0]);
                 // we do *not* update the in sync allocation ids as they will be removed upon the first index
                 // operation which make these copies stale
-                routingTableBuilder.updateNumberOfReplicas(numberOfReplicas, indices);
+                for (String index : indices) {
+                    final IndexMetadata indexMd = clusterState.metadata().index(index);
+                    int minFromSetting = IndexMetadata.INDEX_MIN_NUMBER_OF_REPLICAS_SETTING.get(indexMd.getSettings());
+                    final int minReplicas = minFromSetting == -1 ? numberOfReplicas : minFromSetting;
+                    routingTableBuilder.updateNumberOfReplicas(numberOfReplicas, minReplicas, new String[] { index });
+                }
                 metadataBuilder.updateNumberOfReplicas(numberOfReplicas, indices);
                 updatedIndices.addAll(Set.of(indices));
                 logger.info("updating number_of_replicas to [{}] for indices {}", numberOfReplicas, indices);

--- a/server/src/main/java/org/opensearch/common/settings/IndexScopedSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/IndexScopedSettings.java
@@ -102,6 +102,7 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
                 IndexMetadata.INDEX_AUTO_EXPAND_REPLICAS_SETTING,
                 IndexMetadata.INDEX_AUTO_EXPAND_SEARCH_REPLICAS_SETTING,
                 IndexMetadata.INDEX_NUMBER_OF_REPLICAS_SETTING,
+                IndexMetadata.INDEX_MIN_NUMBER_OF_REPLICAS_SETTING,
                 IndexMetadata.INDEX_NUMBER_OF_SHARDS_SETTING,
                 IndexMetadata.INDEX_ROUTING_PARTITION_SIZE_SETTING,
                 IndexMetadata.INDEX_NUMBER_OF_ROUTING_SHARDS_SETTING,

--- a/server/src/test/java/org/opensearch/cluster/routing/allocation/UpdateNumberOfReplicasTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/allocation/UpdateNumberOfReplicasTests.java
@@ -436,4 +436,151 @@ public class UpdateNumberOfReplicasTests extends OpenSearchAllocationTestCase {
         assertEquals(shardRoutingTable.replicaShards().get(0).state(), STARTED);
         assertEquals(shardRoutingTable.replicaShards().get(0).currentNodeId(), nodeHoldingReplica);
     }
+
+    public void testMinNumberOfReplicas() {
+        AllocationService strategy = createAllocationService(
+            Settings.builder().put("cluster.routing.allocation.node_concurrent_recoveries", 10).build()
+        );
+
+        Metadata metadata = Metadata.builder()
+            .put(
+                IndexMetadata.builder("test")
+                    .settings(settings(Version.CURRENT))
+                    .numberOfShards(1)
+                    .numberOfReplicas(3)
+                    .settings(
+                        Settings.builder()
+                            .put(settings(Version.CURRENT).build())
+                            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+                            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 3)
+                            .put(IndexMetadata.SETTING_MIN_NUMBER_OF_REPLICAS, 1)
+                    )
+            )
+            .build();
+
+        RoutingTable routingTable = RoutingTable.builder().addAsNew(metadata.index("test")).build();
+
+        ClusterState clusterState = ClusterState.builder(ClusterName.CLUSTER_NAME_SETTING.getDefault(Settings.EMPTY))
+            .metadata(metadata)
+            .routingTable(routingTable)
+            .build();
+
+        // Add 4 nodes and start all shards
+        clusterState = ClusterState.builder(clusterState)
+            .nodes(DiscoveryNodes.builder().add(newNode("node1")).add(newNode("node2")).add(newNode("node3")).add(newNode("node4")))
+            .build();
+        clusterState = strategy.reroute(clusterState, "reroute");
+        clusterState = startInitializingShardsAndReroute(strategy, clusterState);
+        clusterState = startInitializingShardsAndReroute(strategy, clusterState);
+
+        // Verify: 1 primary + 3 replicas, all started
+        assertThat(clusterState.routingTable().index("test").shard(0).size(), equalTo(4));
+        assertThat(clusterState.routingTable().index("test").shard(0).primaryShard().state(), equalTo(STARTED));
+        for (ShardRouting replica : clusterState.routingTable().index("test").shard(0).replicaShards()) {
+            assertThat(replica.state(), equalTo(STARTED));
+        }
+
+        // Now update number_of_replicas to 2 with min=1.
+        // This should remove 1 replica (from 3 down to 2).
+        final String[] indices = { "test" };
+        RoutingTable updatedRoutingTable = RoutingTable.builder(clusterState.routingTable()).updateNumberOfReplicas(2, 1, indices).build();
+        metadata = Metadata.builder(clusterState.metadata()).updateNumberOfReplicas(2, indices).build();
+        clusterState = ClusterState.builder(clusterState).routingTable(updatedRoutingTable).metadata(metadata).build();
+
+        assertThat(clusterState.routingTable().index("test").shard(0).size(), equalTo(3));
+        assertThat(clusterState.routingTable().index("test").shard(0).replicaShards().size(), equalTo(2));
+
+        // Now simulate: current replicas=2, update with numberOfReplicas=2 and min=1.
+        // Since current (2) is between min (1) and max (2), no changes should happen.
+        updatedRoutingTable = RoutingTable.builder(clusterState.routingTable()).updateNumberOfReplicas(2, 1, indices).build();
+        assertThat(updatedRoutingTable.index("test").shard(0).size(), equalTo(3));
+        assertThat(updatedRoutingTable.index("test").shard(0).replicaShards().size(), equalTo(2));
+
+        // Now simulate: current replicas=2, update with numberOfReplicas=3 and min=1.
+        // Since current (2) is between min (1) and max (3), no changes — we don't add up to max.
+        updatedRoutingTable = RoutingTable.builder(clusterState.routingTable()).updateNumberOfReplicas(3, 1, indices).build();
+        assertThat(updatedRoutingTable.index("test").shard(0).size(), equalTo(3));
+        assertThat(updatedRoutingTable.index("test").shard(0).replicaShards().size(), equalTo(2));
+
+        // Now reduce to 0 replicas with min=1.
+        // Since current (2) > max (0)... wait, that doesn't make sense with min > max.
+        // Let's test: reduce max to 1 with min=1. Current=2, should remove down to 1.
+        updatedRoutingTable = RoutingTable.builder(clusterState.routingTable()).updateNumberOfReplicas(1, 1, indices).build();
+        assertThat(updatedRoutingTable.index("test").shard(0).size(), equalTo(2));
+        assertThat(updatedRoutingTable.index("test").shard(0).replicaShards().size(), equalTo(1));
+    }
+
+    public void testMinNumberOfReplicasAddsUpToMin() {
+        AllocationService strategy = createAllocationService(
+            Settings.builder().put("cluster.routing.allocation.node_concurrent_recoveries", 10).build()
+        );
+
+        // Start with 0 replicas
+        Metadata metadata = Metadata.builder()
+            .put(IndexMetadata.builder("test").settings(settings(Version.CURRENT)).numberOfShards(1).numberOfReplicas(0))
+            .build();
+
+        RoutingTable routingTable = RoutingTable.builder().addAsNew(metadata.index("test")).build();
+
+        ClusterState clusterState = ClusterState.builder(ClusterName.CLUSTER_NAME_SETTING.getDefault(Settings.EMPTY))
+            .metadata(metadata)
+            .routingTable(routingTable)
+            .build();
+
+        clusterState = ClusterState.builder(clusterState).nodes(DiscoveryNodes.builder().add(newNode("node1"))).build();
+        clusterState = strategy.reroute(clusterState, "reroute");
+        clusterState = startInitializingShardsAndReroute(strategy, clusterState);
+
+        // Verify: 1 primary + 0 replicas
+        assertThat(clusterState.routingTable().index("test").shard(0).size(), equalTo(1));
+
+        // Now update with numberOfReplicas=3 and min=1.
+        // Current (0) < min (1), so should add up to 1 (not 3).
+        final String[] indices = { "test" };
+        RoutingTable updatedRoutingTable = RoutingTable.builder(clusterState.routingTable()).updateNumberOfReplicas(3, 1, indices).build();
+
+        assertThat(updatedRoutingTable.index("test").shard(0).size(), equalTo(2));
+        assertThat(updatedRoutingTable.index("test").shard(0).replicaShards().size(), equalTo(1));
+    }
+
+    public void testMinNumberOfReplicasDefaultBehavior() {
+        // When min is not set, the 2-arg overload should behave identically to before:
+        // it adds/removes to match numberOfReplicas exactly.
+        Metadata metadata = Metadata.builder()
+            .put(IndexMetadata.builder("test").settings(settings(Version.CURRENT)).numberOfShards(1).numberOfReplicas(1))
+            .build();
+
+        RoutingTable routingTable = RoutingTable.builder().addAsNew(metadata.index("test")).build();
+
+        // 1 shard + 1 replica = 2 shard routings
+        assertThat(routingTable.index("test").shard(0).size(), equalTo(2));
+
+        // Using the old 2-arg overload to increase replicas to 3
+        final String[] indices = { "test" };
+        RoutingTable updated = RoutingTable.builder(routingTable).updateNumberOfReplicas(3, indices).build();
+        assertThat(updated.index("test").shard(0).size(), equalTo(4));
+        assertThat(updated.index("test").shard(0).replicaShards().size(), equalTo(3));
+
+        // Using the old 2-arg overload to decrease back to 1
+        updated = RoutingTable.builder(updated).updateNumberOfReplicas(1, indices).build();
+        assertThat(updated.index("test").shard(0).size(), equalTo(2));
+        assertThat(updated.index("test").shard(0).replicaShards().size(), equalTo(1));
+    }
+
+    public void testMinNumberOfReplicasValidation() {
+        // min_number_of_replicas > number_of_replicas should fail
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> IndexMetadata.builder("test")
+                .settings(
+                    Settings.builder()
+                        .put(settings(Version.CURRENT).build())
+                        .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+                        .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1)
+                        .put(IndexMetadata.SETTING_MIN_NUMBER_OF_REPLICAS, 2)
+                )
+                .build()
+        );
+        assertThat(e.getMessage(), equalTo("index.min_number_of_replicas [2] must be <= index.number_of_replicas [1] for [test]"));
+    }
 }


### PR DESCRIPTION


<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This relaxes shard allocation so that the number of replicas can be within a range without needing to add/remove replicas.

This should prevent unnecessary shard movement during a deployment.

Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>

### Related Issues
N/A

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
