### PR TITLE
Deprecate REST client (finally)

### DIFF
--- a/client/rest/src/main/java/org/opensearch/client/RestClient.java
+++ b/client/rest/src/main/java/org/opensearch/client/RestClient.java
@@ -136,7 +136,11 @@ import static java.util.Collections.singletonList;
  * Requests can be either synchronous or asynchronous. The asynchronous variants all end with {@code Async}.
  * <p>
  * Requests can be traced by enabling trace logging for "tracer". The trace logger outputs requests and responses in curl format.
+ *
+ * @deprecated the {@code RestClient} is deprecated is going to be removed in future releases, please consider using official
+ * OpenSearch Java Client or {@code RestHighLevelClient}
  */
+@Deprecated
 public class RestClient implements Closeable {
 
     private static final Log logger = LogFactory.getLog(RestClient.class);

--- a/client/rest/src/main/java/org/opensearch/client/RestClientBuilder.java
+++ b/client/rest/src/main/java/org/opensearch/client/RestClientBuilder.java
@@ -63,7 +63,11 @@ import java.util.Optional;
  * Helps creating a new {@link RestClient}. Allows to set the most common http client configuration options when internally
  * creating the underlying {@link HttpAsyncClient}. Also allows to provide an externally created
  * {@link HttpAsyncClient} in case additional customization is needed.
+ *
+ * @deprecated the {@code RestClient} is deprecated is going to be removed in future releases, please consider using official
+ * OpenSearch Java Client or {@code RestHighLevelClient}
  */
+@Deprecated
 public final class RestClientBuilder {
     /**
      * The default connection timeout in milliseconds.


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Deprecate REST client ( `RestClient`). The internal HTTP client (see please https://github.com/opensearch-project/OpenSearch/issues/20634) has been introduced and designed for OpenSearch internal use only. The `RestHighLevelClient` is still going to be supported for now but migrated away from `RestClient`.

### Related Issues
Closes https://github.com/opensearch-project/OpenSearch/issues/5424

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
