### PR TITLE
[analytics-engine] Fix delegation blocklist defaults not applied at boot

### DIFF
--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/settings/DelegationBlockList.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/settings/DelegationBlockList.java
@@ -14,9 +14,11 @@ import org.opensearch.analytics.planner.CapabilityRegistry;
 import org.opensearch.analytics.spi.DelegationType;
 import org.opensearch.analytics.spi.ScalarFunction;
 import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
 
 import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -73,6 +75,22 @@ public final class DelegationBlockList {
         Map<String, EnumSet<ScalarFunction>> map = new ConcurrentHashMap<>();
         DelegationBlockList blockList = new DelegationBlockList(map);
         Map<String, List<ScalarFunction>> initial = AnalyticsQuerySettings.DELEGATION_BLOCKED_PREDICATES.getAsMap(initialSettings);
+        // Seed missing namespaces with setting defaults (getAsMap skips unset keys).
+        for (String acceptor : registry.delegationAcceptors(DelegationType.FILTER)) {
+            if (!initial.containsKey(acceptor)) {
+                Setting<List<ScalarFunction>> concrete = AnalyticsQuerySettings.DELEGATION_BLOCKED_PREDICATES
+                    .getConcreteSettingForNamespace(acceptor);
+                List<ScalarFunction> defaults = concrete.get(initialSettings);
+                if (!defaults.isEmpty()) {
+                    Set<ScalarFunction> delegatable = registry.getBackend(acceptor).delegatedPredicateSerializers().keySet();
+                    List<ScalarFunction> applicable = defaults.stream().filter(delegatable::contains).toList();
+                    if (!applicable.isEmpty()) {
+                        initial = new HashMap<>(initial);
+                        initial.put(acceptor, applicable);
+                    }
+                }
+            }
+        }
         for (Map.Entry<String, List<ScalarFunction>> e : initial.entrySet()) {
             validate(registry, e.getKey(), e.getValue());
             if (!e.getValue().isEmpty()) {

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/settings/DelegationBlockListTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/settings/DelegationBlockListTests.java
@@ -84,12 +84,15 @@ public class DelegationBlockListTests extends OpenSearchTestCase {
     public void testDynamicUpdate() {
         ClusterSettings clusterSettings = clusterSettings(Settings.EMPTY);
         DelegationBlockList blockList = DelegationBlockList.create(clusterSettings, Settings.EMPTY, registry());
-        assertTrue(blockList.isEmpty());
-
-        clusterSettings.applySettings(Settings.builder().putList("analytics.delegation.lucene.blocked_predicates", "LIKE").build());
+        // Defaults seed LIKE (the only default that has a serializer in this fixture).
         assertTrue(blockList.isBlocked(LUCENE, ScalarFunction.LIKE));
 
-        // Clearing the list removes the backend's block entry.
+        // Explicit update overrides the seeded default.
+        clusterSettings.applySettings(Settings.builder().putList("analytics.delegation.lucene.blocked_predicates", "EQUALS").build());
+        assertTrue(blockList.isBlocked(LUCENE, ScalarFunction.EQUALS));
+        assertFalse(blockList.isBlocked(LUCENE, ScalarFunction.LIKE));
+
+        // Clearing the list removes all blocks.
         clusterSettings.applySettings(Settings.builder().putList("analytics.delegation.lucene.blocked_predicates").build());
         assertFalse(blockList.isBlocked(LUCENE, ScalarFunction.LIKE));
         assertTrue(blockList.isEmpty());
@@ -136,6 +139,61 @@ public class DelegationBlockListTests extends OpenSearchTestCase {
     public void testSeedRejectsInvalidNamespaceAtConstruction() {
         Settings settings = Settings.builder().putList("analytics.delegation.datafusion.blocked_predicates", "LIKE").build();
         expectThrows(IllegalArgumentException.class, () -> DelegationBlockList.create(clusterSettings(settings), settings, registry()));
+    }
+
+    public void testDefaultsSeededWhenSettingsEmpty() {
+        // Fixture with IS_NULL, IS_NOT_NULL, LIKE serializers — mirrors the real Lucene backend.
+        DelegatedPredicateSerializer stub = (call, fieldStorage) -> new byte[0];
+        AnalyticsSearchBackendPlugin luceneWithDefaults = new AnalyticsSearchBackendPlugin() {
+            @Override
+            public String name() {
+                return LUCENE;
+            }
+
+            @Override
+            public BackendCapabilityProvider getCapabilityProvider() {
+                return new BackendCapabilityProvider() {
+                    @Override
+                    public Set<EngineCapability> supportedEngineCapabilities() {
+                        return Set.of();
+                    }
+
+                    @Override
+                    public Set<DelegationType> acceptedDelegations() {
+                        return Set.of(DelegationType.FILTER);
+                    }
+                };
+            }
+
+            @Override
+            public Map<ScalarFunction, DelegatedPredicateSerializer> delegatedPredicateSerializers() {
+                return Map.ofEntries(
+                    Map.entry(ScalarFunction.EQUALS, stub),
+                    Map.entry(ScalarFunction.NOT_EQUALS, stub),
+                    Map.entry(ScalarFunction.IS_NULL, stub),
+                    Map.entry(ScalarFunction.IS_NOT_NULL, stub),
+                    Map.entry(ScalarFunction.LIKE, stub),
+                    Map.entry(ScalarFunction.GREATER_THAN, stub),
+                    Map.entry(ScalarFunction.GREATER_THAN_OR_EQUAL, stub),
+                    Map.entry(ScalarFunction.LESS_THAN, stub),
+                    Map.entry(ScalarFunction.LESS_THAN_OR_EQUAL, stub),
+                    Map.entry(ScalarFunction.SARG_PREDICATE, stub)
+                );
+            }
+        };
+        CapabilityRegistry reg = new CapabilityRegistry(List.of(luceneWithDefaults), FieldStorageResolver::new);
+        DelegationBlockList blockList = DelegationBlockList.create(clusterSettings(Settings.EMPTY), Settings.EMPTY, reg);
+        assertFalse("defaults should be seeded", blockList.isEmpty());
+        assertTrue(blockList.isBlocked(LUCENE, ScalarFunction.IS_NULL));
+        assertTrue(blockList.isBlocked(LUCENE, ScalarFunction.IS_NOT_NULL));
+        assertTrue(blockList.isBlocked(LUCENE, ScalarFunction.LIKE));
+        assertTrue(blockList.isBlocked(LUCENE, ScalarFunction.GREATER_THAN));
+        assertTrue(blockList.isBlocked(LUCENE, ScalarFunction.GREATER_THAN_OR_EQUAL));
+        assertTrue(blockList.isBlocked(LUCENE, ScalarFunction.LESS_THAN));
+        assertTrue(blockList.isBlocked(LUCENE, ScalarFunction.LESS_THAN_OR_EQUAL));
+        assertTrue(blockList.isBlocked(LUCENE, ScalarFunction.SARG_PREDICATE));
+        assertFalse(blockList.isBlocked(LUCENE, ScalarFunction.EQUALS));
+        assertFalse(blockList.isBlocked(LUCENE, ScalarFunction.NOT_EQUALS));
     }
 
     /** The cluster-settings layer wraps the validator's IllegalArgumentException; search the chain. */


### PR DESCRIPTION
 ## Summary
  - `AffixSetting.getAsMap()` skips unset namespaces, so default blocked predicates were never seeded
  - Explicitly resolve defaults for each delegation-acceptor namespace at boot

  ## Test plan
  -  Added`DelegationBlockListTests.testDefaultsSeededWhenSettingsEmpty` (unit test)
  - `FilterDelegationExtendedIT` + `FilterDelegationGoldenIT` (integration)

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
