### PR TITLE
Bind substrait min/max for boolean

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/src/main/resources/opensearch_aggregate_functions.yaml
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/resources/opensearch_aggregate_functions.yaml
@@ -13,10 +13,10 @@ aggregate_functions:
         return: i64
   - name: min
     description: >-
-      Min of a set of string values. Standard substrait functions_arithmetic.yaml
-      only defines min for i8..fp64; this overload extends it to strings so PPL
-      `stats min(varchar_field)` can bind a Substrait call and dispatch to
-      DataFusion's native min UDF, which supports Utf8 natively.
+      Min over string or boolean values. Substrait's stdlib functions_arithmetic.yaml
+      only defines min for i8..fp64; these overloads extend the binding so PPL
+      `stats min(varchar|bool)` resolves and dispatches to DataFusion's native
+      min UDF, which already supports Utf8 and Boolean.
     impls:
       - args:
           - name: x
@@ -25,9 +25,16 @@ aggregate_functions:
         decomposable: MANY
         intermediate: "string?"
         return: "string?"
+      - args:
+          - name: x
+            value: "boolean"
+        nullability: DECLARED_OUTPUT
+        decomposable: MANY
+        intermediate: "boolean?"
+        return: "boolean?"
   - name: max
     description: >-
-      Max of a set of string values. See min above.
+      Max over string or boolean values. See min above.
     impls:
       - args:
           - name: x
@@ -36,6 +43,13 @@ aggregate_functions:
         decomposable: MANY
         intermediate: "string?"
         return: "string?"
+      - args:
+          - name: x
+            value: "boolean"
+        nullability: DECLARED_OUTPUT
+        decomposable: MANY
+        intermediate: "boolean?"
+        return: "boolean?"
   - name: take
     description: >-
       PPL `take(field, N)` — bounded, arrival-order array. Custom Rust UDAF in

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionFragmentConvertorTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionFragmentConvertorTests.java
@@ -766,6 +766,26 @@ public class DataFusionFragmentConvertorTests extends OpenSearchTestCase {
     }
 
     /**
+     * Substrait's stdlib only defines min/max for i8..fp64; opensearch_aggregate_functions.yaml
+     * adds str and bool overloads so PPL `stats min/max` over varchar / boolean fields binds.
+     */
+    public void testMinMaxYamlDeclaresStringAndBooleanOverloads() {
+        assertAggregateImplKeys("min", "min:str", "min:bool");
+        assertAggregateImplKeys("max", "max:str", "max:bool");
+    }
+
+    private void assertAggregateImplKeys(String name, String... expectedKeys) {
+        java.util.Set<String> actual = extensions.aggregateFunctions()
+            .stream()
+            .filter(v -> name.equals(v.name()))
+            .map(SimpleExtension.Function::key)
+            .collect(java.util.stream.Collectors.toSet());
+        for (String key : expectedKeys) {
+            assertTrue(name + " yaml must declare impl with key " + key + " (got " + actual + ")", actual.contains(key));
+        }
+    }
+
+    /**
      * Regression: a lifted-window Project wrapper, shaped {@code Project_outer(Project_lower(input))}
      * with the outer's RexInputRefs pointing into the lower's appended window column, used
      * to lose its lower layer when re-wired. The next attach-on-top then crashed deserialising

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/MinMaxBooleanIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/MinMaxBooleanIT.java
@@ -1,0 +1,87 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.qa;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * End-to-end coverage for {@code stats min(bool_field)} / {@code stats max(bool_field)}
+ * over the shared `calcs` dataset. Substrait core's {@code functions_arithmetic.yaml}
+ * declares min/max only for i8..fp64; the sandbox extension adds a boolean overload so
+ * isthmus' {@code AggregateFunctionConverter} can bind these calls and route them to
+ * DataFusion's native min/max.
+ */
+public class MinMaxBooleanIT extends AnalyticsRestTestCase {
+
+    private static final Dataset DATASET = new Dataset("calcs", "calcs");
+
+    private static boolean dataProvisioned = false;
+
+    @Override
+    protected void onBeforeQuery() throws IOException {
+        if (dataProvisioned == false) {
+            DatasetProvisioner.provision(client(), DATASET);
+            dataProvisioned = true;
+        }
+    }
+
+    public void testMinMaxBoolean() throws IOException {
+        // bool1 has 6 true + 6 false rows (5 nulls are skipped by min/max).
+        assertRowsEqual(
+            "source=" + DATASET.indexName + " | stats min(bool1) as min_b, max(bool1) as max_b",
+            row(false, true)
+        );
+    }
+
+    public void testMinMaxBooleanGroupedByKeyword() throws IOException {
+        // Each str0 group contains both true and false bool0 rows, so min collapses to
+        // false and max to true within every group.
+        assertRowsEqual(
+            "source=" + DATASET.indexName + " | stats min(bool0) as min_b, max(bool0) as max_b by str0 | sort str0",
+            row(false, true, "FURNITURE"),
+            row(false, true, "OFFICE SUPPLIES"),
+            row(false, true, "TECHNOLOGY")
+        );
+    }
+
+    public void testMinMaxMixedBooleanAndNumeric() throws IOException {
+        // int0 ranges 1..11 across non-null rows; bool1 covers both polarities.
+        assertRowsEqual(
+            "source=" + DATASET.indexName
+                + " | stats min(int0) as min_i, max(int0) as max_i,"
+                + " min(bool1) as min_b, max(bool1) as max_b",
+            row(1, 11, false, true)
+        );
+    }
+
+    private static List<Object> row(Object... values) {
+        return Arrays.asList(values);
+    }
+
+    @SafeVarargs
+    @SuppressWarnings("varargs")
+    private final void assertRowsEqual(String ppl, List<Object>... expected) throws IOException {
+        Map<String, Object> response = executePpl(ppl);
+        @SuppressWarnings("unchecked")
+        List<List<Object>> actualRows = (List<List<Object>>) response.get("datarows");
+        assertNotNull("Response missing 'datarows' for query: " + ppl, actualRows);
+        assertEquals("Row count mismatch for query: " + ppl, expected.length, actualRows.size());
+        for (int i = 0; i < expected.length; i++) {
+            List<Object> want = expected[i];
+            List<Object> got = actualRows.get(i);
+            assertEquals("Column count mismatch at row " + i + " for query: " + ppl, want.size(), got.size());
+            for (int j = 0; j < want.size(); j++) {
+                assertEquals("Cell mismatch at row " + i + ", col " + j + " for query: " + ppl, want.get(j), got.get(j));
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Description

Substrait's `functions_arithmetic.yaml` declares `min`/`max` only for `i8..fp64`, so PPL `stats min(bool_field)` / `max(bool_field)` failed with:

```
UnsupportedOperationException: Unable to find binding for call MIN($N)
```

DataFusion's native min/max UDAF already handles the `Boolean` arrow type — only the substrait binding was missing. This PR adds a `boolean` impl alongside the existing `string` overload in `opensearch_aggregate_functions.yaml` so isthmus can bind these calls and route them to DataFusion.

### Semantics

`min`/`max` over a boolean column treat values as ordered (`false < true`):

- `min(bool_field)` → `false` if any row has `false`, `true` only if every row is `true`. Equivalent to "all-true across rows" → logical AND.
- `max(bool_field)` → `true` if any row has `true`, `false` only if every row is `false`. Equivalent to "at-least-one-true" → logical OR.

### Query shapes now supported

```ppl
| stats min(bool_field), max(bool_field)
| stats min(bool_field), max(bool_field) by group_field
| stats min(int_field), max(int_field), min(bool_field), max(bool_field)
```

Including deeply-nested boolean fields (e.g. `min(resource.attributes.telemetry.sdk.enabled)`).

### Tests

- **Unit**: `DataFusionFragmentConvertorTests.testMinMaxYamlDeclaresStringAndBooleanOverloads` — asserts the yaml declares `min:str`/`min:bool` and `max:str`/`max:bool` impls.
- **Sandbox QA IT**: new `MinMaxBooleanIT` covers the three query shapes above end-to-end against a parquet-backed index.

### PPL Calcite tests in the SQL plugin unblocked

- `CalcitePPLAggregationIT.testMinMaxWithBooleanNestedField`
- `CalcitePPLAggregationIT.testMixedTypesNestedFieldAggregations`
- `CalcitePPLAggregationPaginatingIT.testMinMaxWithBooleanNestedField`
- `CalcitePPLAggregationPaginatingIT.testMixedTypesNestedFieldAggregations`

### Check List

- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).