### PR TITLE
Lower bin span=Nday via from_unixtime

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DateAddSubAdapter.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DateAddSubAdapter.java
@@ -11,6 +11,7 @@ package org.opensearch.be.datafusion;
 import org.apache.calcite.avatica.util.TimeUnit;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexLiteral;
@@ -83,6 +84,10 @@ class DateAddSubAdapter implements ScalarFunctionAdapter {
         // ADDDATE/SUBDATE accept INTEGER days; rebuild as INTERVAL n DAY so the interval path runs.
         RexLiteral intervalLiteral = asIntervalLiteral(rawSecond, rexBuilder);
         if (intervalLiteral == null) {
+            // Non-literal integer days (e.g. `bin span=Nday`): see adaptNonLiteralIntegerDays.
+            if (rawSecond != null && SqlTypeName.INT_TYPES.contains(rawSecond.getType().getSqlTypeName())) {
+                return adaptNonLiteralIntegerDays(original, base, rawSecond, cluster);
+            }
             return original;
         }
         SqlIntervalQualifier qualifier = intervalLiteral.getType().getIntervalQualifier();
@@ -162,6 +167,77 @@ class DateAddSubAdapter implements ScalarFunctionAdapter {
             return shifted;
         }
         return rexBuilder.makeAbstractCast(original.getType(), shifted);
+    }
+
+    /**
+     * Non-literal integer-days form (e.g. {@code bin span=Nday}). DataFusion can't evaluate
+     * {@code Int64 * Interval(DayTime)} at runtime, so lower to
+     * {@code from_unixtime(baseEpochSec + daysExpr * 86400.0)}; base must be a foldable literal.
+     */
+    private RexNode adaptNonLiteralIntegerDays(RexCall original, RexNode base, RexNode daysExpr, RelOptCluster cluster) {
+        RexBuilder rexBuilder = cluster.getRexBuilder();
+        Long baseEpochSeconds = tryFoldBaseToEpochSeconds(base);
+        if (baseEpochSeconds == null) {
+            // Non-literal base — leave the call unchanged so the UDF path raises a
+            // clearer error than a downstream DF planner failure.
+            return original;
+        }
+        RelDataTypeFactory typeFactory = rexBuilder.getTypeFactory();
+        // daysExpr * 86400.0 → DOUBLE epoch-seconds delta.
+        RelDataType doubleType = typeFactory.createSqlType(SqlTypeName.DOUBLE);
+        RexNode daysAsDouble = rexBuilder.makeAbstractCast(
+            typeFactory.createTypeWithNullability(doubleType, daysExpr.getType().isNullable()),
+            daysExpr
+        );
+        long signedSecPerDay = isAdd ? 86_400L : -86_400L;
+        RexNode secPerDayLit = rexBuilder.makeApproxLiteral(BigDecimal.valueOf(signedSecPerDay), doubleType);
+        RexNode deltaSec = rexBuilder.makeCall(SqlStdOperatorTable.MULTIPLY, daysAsDouble, secPerDayLit);
+        RexNode baseSec = rexBuilder.makeApproxLiteral(BigDecimal.valueOf(baseEpochSeconds), doubleType);
+        RexNode totalSec = rexBuilder.makeCall(SqlStdOperatorTable.PLUS, baseSec, deltaSec);
+        RexNode ts = rexBuilder.makeCall(
+            typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.TIMESTAMP, 3), daysExpr.getType().isNullable()),
+            RustUdfDateTimeAdapters.LOCAL_FROM_UNIXTIME_OP,
+            List.of(totalSec)
+        );
+        if (ts.getType().equals(original.getType())) {
+            return ts;
+        }
+        return rexBuilder.makeAbstractCast(original.getType(), ts);
+    }
+
+    /**
+     * Folds a CHAR ({@code YYYY-MM-DD}) / DATE / TIMESTAMP literal to epoch-seconds at midnight UTC.
+     * Returns null when {@code base} is not such a literal.
+     */
+    private static Long tryFoldBaseToEpochSeconds(RexNode base) {
+        if (!(base instanceof RexLiteral lit)) {
+            return null;
+        }
+        Object value = lit.getValue2();
+        if (value == null) {
+            return null;
+        }
+        try {
+            if (SqlTypeFamily.CHARACTER.contains(lit.getType())) {
+                String s = value.toString().trim();
+                if (s.length() == 10) {
+                    return LocalDate.parse(s).atStartOfDay(ZoneOffset.UTC).toEpochSecond();
+                }
+                return null;
+            }
+            SqlTypeName tn = lit.getType().getSqlTypeName();
+            if (tn == SqlTypeName.DATE) {
+                int days = ((Number) value).intValue();
+                return days * 86_400L;
+            }
+            if (tn == SqlTypeName.TIMESTAMP || tn == SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE) {
+                long millis = ((Number) value).longValue();
+                return millis / 1_000L;
+            }
+        } catch (RuntimeException ignored) {
+            return null;
+        }
+        return null;
     }
 
     /** Lift the base to the call's TIMESTAMP type. TIME prepends today-UTC; character base passes through. */

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DateAddSubAdapterTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DateAddSubAdapterTests.java
@@ -163,4 +163,99 @@ public class DateAddSubAdapterTests extends OpenSearchTestCase {
 
         assertSame("MICROSECOND interval must leave the call unchanged", original, adapted);
     }
+
+    /**
+     * ADDDATE('1970-01-01', daysExpr) — bin span=Nday lowering shape. Second operand is computed
+     * (MOD-based subtract on an integer column ref), not a literal. Adapter must lower to
+     * {@code from_unixtime(baseEpochSec + daysExpr * 86400.0)} where baseEpochSec=0.
+     */
+    public void testAddDateCharLiteralBaseWithComputedI64DaysLowersToFromUnixtime() {
+        RelDataType i64 = typeFactory.createSqlType(SqlTypeName.BIGINT);
+        RexNode epochCharLit = rexBuilder.makeLiteral("1970-01-01");
+        RexNode daysCol = rexBuilder.makeInputRef(i64, 0);
+        RexNode mod = rexBuilder.makeCall(SqlStdOperatorTable.MOD, daysCol, rexBuilder.makeLiteral(7, i64, false));
+        RexNode daysExpr = rexBuilder.makeCall(SqlStdOperatorTable.MINUS, daysCol, mod);
+        RexCall original = (RexCall) rexBuilder.makeCall(ADDDATE_OP, List.of(epochCharLit, daysExpr));
+
+        RexNode adapted = new DateAddSubAdapter(true).adapt(original, List.of(), cluster);
+
+        RexCall fromUnixtime = unwrapCast(adapted);
+        assertEquals("from_unixtime", fromUnixtime.getOperator().getName());
+        // Inner expr: PLUS(baseSec=0.0, MULTIPLY(CAST(daysExpr AS DOUBLE), 86400.0))
+        RexCall plus = (RexCall) fromUnixtime.getOperands().get(0);
+        assertSame(SqlStdOperatorTable.PLUS, plus.getOperator());
+        assertEquals(0.0, ((org.apache.calcite.rex.RexLiteral) plus.getOperands().get(0)).getValueAs(Double.class), 0.0);
+        RexCall multiply = (RexCall) plus.getOperands().get(1);
+        assertSame(SqlStdOperatorTable.MULTIPLY, multiply.getOperator());
+        assertEquals(86_400.0, ((org.apache.calcite.rex.RexLiteral) multiply.getOperands().get(1)).getValueAs(Double.class), 0.0);
+    }
+
+    /** SUBDATE('1970-01-01', i64Expr) — sign-flipped multiplier (-86400). */
+    public void testSubDateCharLiteralBaseWithI64DaysFlipsMultiplierSign() {
+        RelDataType i64 = typeFactory.createSqlType(SqlTypeName.BIGINT);
+        RexNode epochCharLit = rexBuilder.makeLiteral("1970-01-01");
+        RexNode daysCol = rexBuilder.makeInputRef(i64, 0);
+        RexCall original = (RexCall) rexBuilder.makeCall(SUBDATE_OP, List.of(epochCharLit, daysCol));
+
+        RexNode adapted = new DateAddSubAdapter(false).adapt(original, List.of(), cluster);
+
+        RexCall fromUnixtime = unwrapCast(adapted);
+        assertEquals("from_unixtime", fromUnixtime.getOperator().getName());
+        RexCall plus = (RexCall) fromUnixtime.getOperands().get(0);
+        RexCall multiply = (RexCall) plus.getOperands().get(1);
+        assertEquals(-86_400.0, ((org.apache.calcite.rex.RexLiteral) multiply.getOperands().get(1)).getValueAs(Double.class), 0.0);
+    }
+
+    /** DATE-literal base folds to epoch-seconds via days × 86400. */
+    public void testAddDateDateLiteralBaseFoldsViaDaysTimes86400() {
+        RelDataType i64 = typeFactory.createSqlType(SqlTypeName.BIGINT);
+        // 1970-01-02 = 1 day after epoch → baseSec = 86400.
+        RexNode dateLit = rexBuilder.makeDateLiteral(new org.apache.calcite.util.DateString("1970-01-02"));
+        RexNode daysCol = rexBuilder.makeInputRef(i64, 0);
+        RexCall original = (RexCall) rexBuilder.makeCall(ADDDATE_OP, List.of(dateLit, daysCol));
+
+        RexNode adapted = new DateAddSubAdapter(true).adapt(original, List.of(), cluster);
+
+        RexCall fromUnixtime = unwrapCast(adapted);
+        assertEquals("from_unixtime", fromUnixtime.getOperator().getName());
+        RexCall plus = (RexCall) fromUnixtime.getOperands().get(0);
+        assertEquals(86_400.0, ((org.apache.calcite.rex.RexLiteral) plus.getOperands().get(0)).getValueAs(Double.class), 0.0);
+    }
+
+    /** TIMESTAMP-literal base folds via millis ÷ 1000. */
+    public void testAddDateTimestampLiteralBaseFoldsViaMillisDiv1000() {
+        RelDataType i64 = typeFactory.createSqlType(SqlTypeName.BIGINT);
+        // 1970-01-01 00:00:01 UTC → baseSec = 1.
+        RexNode tsLit = rexBuilder.makeTimestampLiteral(new org.apache.calcite.util.TimestampString("1970-01-01 00:00:01"), 0);
+        RexNode daysCol = rexBuilder.makeInputRef(i64, 0);
+        RexCall original = (RexCall) rexBuilder.makeCall(ADDDATE_OP, List.of(tsLit, daysCol));
+
+        RexNode adapted = new DateAddSubAdapter(true).adapt(original, List.of(), cluster);
+
+        RexCall fromUnixtime = unwrapCast(adapted);
+        assertEquals("from_unixtime", fromUnixtime.getOperator().getName());
+        RexCall plus = (RexCall) fromUnixtime.getOperands().get(0);
+        assertEquals(1.0, ((org.apache.calcite.rex.RexLiteral) plus.getOperands().get(0)).getValueAs(Double.class), 0.0);
+    }
+
+    /** Non-foldable base (column ref, not literal) with computed i64 days passes through. */
+    public void testAddDateNonLiteralBaseWithI64DaysPassesThrough() {
+        RelDataType dateType = typeFactory.createSqlType(SqlTypeName.DATE);
+        RelDataType i64 = typeFactory.createSqlType(SqlTypeName.BIGINT);
+        RexNode dateCol = rexBuilder.makeInputRef(dateType, 0);
+        RexNode daysCol = rexBuilder.makeInputRef(i64, 1);
+        RexCall original = (RexCall) rexBuilder.makeCall(ADDDATE_OP, List.of(dateCol, daysCol));
+
+        RexNode adapted = new DateAddSubAdapter(true).adapt(original, List.of(), cluster);
+
+        assertSame("non-foldable base must leave the call unchanged", original, adapted);
+    }
+
+    /** Unwrap an outer CAST around the from_unixtime call (return-type alignment). */
+    private static RexCall unwrapCast(RexNode node) {
+        if (node instanceof RexCall call && call.getKind() == SqlKind.CAST) {
+            return (RexCall) call.getOperands().get(0);
+        }
+        return (RexCall) node;
+    }
 }

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/BinTimestampSpanIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/BinTimestampSpanIT.java
@@ -1,0 +1,82 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.qa;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * End-to-end coverage for PPL {@code bin <ts_field> span=Nday} over the shared `calcs`
+ * dataset. The lowering builds {@code ADDDATE(epoch_char_literal, days_since_epoch_expr)};
+ * the adapter folds the literal base into seconds and emits {@code from_unixtime(...)}
+ * because DataFusion cannot multiply Int64 × Interval(DayTime) at runtime.
+ */
+public class BinTimestampSpanIT extends AnalyticsRestTestCase {
+
+    private static final Dataset DATASET = new Dataset("calcs", "calcs");
+
+    private static boolean dataProvisioned = false;
+
+    @Override
+    protected void onBeforeQuery() throws IOException {
+        if (dataProvisioned == false) {
+            DatasetProvisioner.provision(client(), DATASET);
+            dataProvisioned = true;
+        }
+    }
+
+    public void testBinTimestampSpan7Days() throws IOException {
+        // calcs.datetime0 spans 2004-07-04..08-02 (17 rows). 7-day bins anchored at the
+        // unix epoch land on Mondays: 2004-06-28 + 7k. Bucket counts:
+        //   2004-07-01 → 2,  2004-07-08 → 4,  2004-07-15 → 2,
+        //   2004-07-22 → 7,  2004-07-29 → 2.
+        assertRowsEqual(
+            "source=" + DATASET.indexName + " | bin datetime0 span=7day | stats count() as cnt by datetime0 | sort datetime0",
+            row(2L, "2004-07-01 00:00:00"),
+            row(4L, "2004-07-08 00:00:00"),
+            row(2L, "2004-07-15 00:00:00"),
+            row(7L, "2004-07-22 00:00:00"),
+            row(2L, "2004-07-29 00:00:00")
+        );
+    }
+
+    public void testBinTimestampSpan1Day() throws IOException {
+        // 1-day bins. 14 distinct days (some collapse — e.g. 2004-07-28 has 3 rows).
+        assertRowsEqual(
+            "source=" + DATASET.indexName + " | bin datetime0 span=1day | stats count() as cnt by datetime0 | sort - cnt | head 3",
+            row(3L, "2004-07-28 00:00:00"),
+            row(2L, "2004-07-14 00:00:00"),
+            row(1L, "2004-07-04 00:00:00")
+        );
+    }
+
+    private static List<Object> row(Object... values) {
+        return Arrays.asList(values);
+    }
+
+    @SafeVarargs
+    @SuppressWarnings("varargs")
+    private final void assertRowsEqual(String ppl, List<Object>... expected) throws IOException {
+        Map<String, Object> response = executePpl(ppl);
+        @SuppressWarnings("unchecked")
+        List<List<Object>> actualRows = (List<List<Object>>) response.get("datarows");
+        assertNotNull("Response missing 'datarows' for query: " + ppl, actualRows);
+        assertEquals("Row count mismatch for query: " + ppl, expected.length, actualRows.size());
+        for (int i = 0; i < expected.length; i++) {
+            List<Object> want = expected[i];
+            List<Object> got = actualRows.get(i);
+            assertEquals("Column count mismatch at row " + i + " for query: " + ppl, want.size(), got.size());
+            for (int j = 0; j < want.size(); j++) {
+                assertEquals("Cell mismatch at row " + i + ", col " + j + " for query: " + ppl, want.get(j), got.get(j));
+            }
+        }
+    }
+}

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/BinTimestampSpanIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/BinTimestampSpanIT.java
@@ -50,8 +50,9 @@ public class BinTimestampSpanIT extends AnalyticsRestTestCase {
 
     public void testBinTimestampSpan1Day() throws IOException {
         // 1-day bins. 14 distinct days (some collapse — e.g. 2004-07-28 has 3 rows).
+        // Tie-break on datetime0 so cnt=1 buckets order deterministically.
         assertRowsEqual(
-            "source=" + DATASET.indexName + " | bin datetime0 span=1day | stats count() as cnt by datetime0 | sort - cnt | head 3",
+            "source=" + DATASET.indexName + " | bin datetime0 span=1day | stats count() as cnt by datetime0 | sort - cnt, datetime0 | head 3",
             row(3L, "2004-07-28 00:00:00"),
             row(2L, "2004-07-14 00:00:00"),
             row(1L, "2004-07-04 00:00:00")

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/BinTimestampSpanIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/BinTimestampSpanIT.java
@@ -75,7 +75,15 @@ public class BinTimestampSpanIT extends AnalyticsRestTestCase {
             List<Object> got = actualRows.get(i);
             assertEquals("Column count mismatch at row " + i + " for query: " + ppl, want.size(), got.size());
             for (int j = 0; j < want.size(); j++) {
-                assertEquals("Cell mismatch at row " + i + ", col " + j + " for query: " + ppl, want.get(j), got.get(j));
+                Object w = want.get(j);
+                Object g = got.get(j);
+                String label = "Cell mismatch at row " + i + ", col " + j + " for query: " + ppl;
+                // count() comes back as Integer when the value fits, Long otherwise; compare by magnitude.
+                if (w instanceof Number && g instanceof Number) {
+                    assertEquals(label, ((Number) w).longValue(), ((Number) g).longValue());
+                } else {
+                    assertEquals(label, w, g);
+                }
             }
         }
     }


### PR DESCRIPTION
### Description

PPL `bin @timestamp span=Nday` is lowered to `ADDDATE('1970-01-01', daysSinceEpoch_minus_mod)` where the second operand is a *computed* integer expression, not a literal. The existing `DateAddSubAdapter` only accepted integer literals and bailed on the computed case, leaving the call as `ADDDATE(char<10>, i64?)` with no Substrait binding:

```
IllegalArgumentException: Unable to convert call ADDDATE(char<10>, i64?).
```

A naïve `DATETIME_PLUS(base, daysExpr * INTERVAL '1' DAY)` round-trips through Substrait but DataFusion rejects it at runtime — `Int64 × Interval(DayTime)` multiplication is plan-time-fold-only. This PR lowers the call to `from_unixtime(baseEpochSec + daysExpr * 86400.0)` instead, which DataFusion executes natively. The base must be a foldable date/timestamp/char literal so its epoch-seconds offset is computable at adapter time — the bin lowering always passes a literal epoch date, so this covers every PPL bin invocation.

### Semantics

`bin <ts_field> span=Nday` partitions a timestamp column into fixed-width N-day buckets anchored at the Unix epoch. Each row's `<ts_field>` is replaced with the bucket-start timestamp (midnight UTC of the bin boundary). Same shape as Splunk's `bin span=Nday`.

### Query shapes now supported

```ppl
| bin <ts_field> span=1day
| bin <ts_field> span=Nday                 (N >= 1)
| bin <ts_field> span=Nday | stats count() by <ts_field>
| bin <ts_field> span=Nday | sort <ts_field> | head K
| ... | bin <ts_field> span=Nday | ...     (after multisearch, lookups, etc.)
```

The same adapter path also handles `subdate(literal_base, days_expr)` (sign-flipped multiplier).

### Tests

- **Unit**: `DateAddSubAdapterTests` adds five cases covering ADDDATE/SUBDATE on char, date, and timestamp literal bases, plus the non-foldable-base passthrough.
- **Sandbox QA IT**: new `BinTimestampSpanIT` over the shared `calcs` dataset asserts both 7-day bucket pivots (anchored at Unix epoch Mondays) and 1-day bucket counts end-to-end against a parquet-backed index.

### PPL Calcite tests in the SQL plugin unblocked

- `CalciteBinCommandIT.testBinTimestampSpan6Days`
- `CalciteBinCommandIT.testBinTimestampSpan7Days`
- `CalciteMultisearchCommandIT.testMultisearchBinTimestamp`

### Check List

- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).