### PR TITLE
Cast variadic concat operands to varchar

### DIFF
--- a/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/ScalarFunction.java
+++ b/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/ScalarFunction.java
@@ -87,6 +87,11 @@ public enum ScalarFunction {
      * rename surfaces as a compile error rather than as a silent string mismatch at runtime.
      */
     CONCAT(Category.STRING, SqlKind.OTHER_FUNCTION, SqlStdOperatorTable.CONCAT),
+    /**
+     * Variadic {@code CONCAT(a, b, …)} — {@code SqlLibraryOperators.CONCAT_FUNCTION}, distinct from binary {@code ||}.
+     * Substrait CONSISTENT consistency requires the per-op adapter to unify operand types before emission.
+     */
+    CONCAT_FUNCTION(Category.STRING, SqlKind.OTHER_FUNCTION, org.apache.calcite.sql.fun.SqlLibraryOperators.CONCAT_FUNCTION),
     CONCAT_WS(Category.STRING, SqlKind.OTHER_FUNCTION),
     CHAR_LENGTH(Category.STRING, SqlKind.OTHER_FUNCTION),
     REPLACE(Category.STRING, SqlKind.OTHER_FUNCTION),

--- a/sandbox/libs/analytics-framework/src/test/java/org/opensearch/analytics/spi/ScalarFunctionTests.java
+++ b/sandbox/libs/analytics-framework/src/test/java/org/opensearch/analytics/spi/ScalarFunctionTests.java
@@ -89,6 +89,15 @@ public class ScalarFunctionTests extends OpenSearchTestCase {
         assertEquals(ScalarFunction.CONCAT, ScalarFunction.fromSqlOperatorWithFallback(SqlStdOperatorTable.CONCAT));
     }
 
+    public void testFromSqlOperatorResolvesVariadicConcatViaReferenceOperator() {
+        // SqlLibraryOperators.CONCAT_FUNCTION shares the name "CONCAT" with the binary `||` enum
+        // constant, so identifier-name fallback resolves to the wrong constant. The
+        // referenceOperator pin disambiguates by singleton identity, routing the variadic
+        // call to its dedicated adapter.
+        assertEquals("CONCAT", SqlLibraryOperators.CONCAT_FUNCTION.getName());
+        assertSame(ScalarFunction.CONCAT_FUNCTION, ScalarFunction.fromSqlOperatorWithFallback(SqlLibraryOperators.CONCAT_FUNCTION));
+    }
+
     // ── fromSqlOperatorWithFallback: identifier-name branch ────────────────────────────────
 
     public void testFromSqlOperatorResolvesViaIdentifierName() {

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/ConcatVariadicAdapter.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/ConcatVariadicAdapter.java
@@ -1,0 +1,60 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion;
+
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.opensearch.analytics.spi.FieldStorageInfo;
+import org.opensearch.analytics.spi.ScalarFunctionAdapter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Normalises operand types for {@code SqlLibraryOperators.CONCAT_FUNCTION} (variadic CONCAT).
+ * Substrait's {@code concat} extension declares CONSISTENT parameter consistency, but Calcite
+ * leaves short string literals as {@code CHAR}/FixedChar alongside VARCHAR field refs — isthmus
+ * rejects the mixed-type call. This adapter casts every non-VARCHAR operand to VARCHAR
+ * (preserving nullability) so substrait sees a uniform-typed variadic call.
+ */
+class ConcatVariadicAdapter implements ScalarFunctionAdapter {
+
+    @Override
+    public RexNode adapt(RexCall original, List<FieldStorageInfo> fieldStorage, RelOptCluster cluster) {
+        List<RexNode> operands = original.getOperands();
+        if (operands.isEmpty()) {
+            return original;
+        }
+        RexBuilder rexBuilder = cluster.getRexBuilder();
+        RelDataTypeFactory typeFactory = rexBuilder.getTypeFactory();
+        boolean changed = false;
+        List<RexNode> normalised = new ArrayList<>(operands.size());
+        for (RexNode operand : operands) {
+            SqlTypeName sqlType = operand.getType().getSqlTypeName();
+            if (sqlType == SqlTypeName.VARCHAR) {
+                normalised.add(operand);
+                continue;
+            }
+            // CHAR / FixedChar / other string token → cast to VARCHAR, preserve nullability.
+            RelDataType varchar = typeFactory.createSqlType(SqlTypeName.VARCHAR);
+            RelDataType nullableVarchar = typeFactory.createTypeWithNullability(varchar, operand.getType().isNullable());
+            normalised.add(rexBuilder.makeCast(nullableVarchar, operand));
+            changed = true;
+        }
+        if (!changed) {
+            return original;
+        }
+        return rexBuilder.makeCall(original.getType(), original.getOperator(), normalised);
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionAnalyticsBackendPlugin.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionAnalyticsBackendPlugin.java
@@ -138,6 +138,7 @@ public class DataFusionAnalyticsBackendPlugin implements AnalyticsSearchBackendP
         ScalarFunction.CEIL,
         ScalarFunction.CAST,
         ScalarFunction.CONCAT,
+        ScalarFunction.CONCAT_FUNCTION,
         ScalarFunction.SAFE_CAST,
         // CASE — Calcite emits CASE WHEN ... THEN ... END for conditional expressions, including
         // PPL `count(eval(predicate))` (lowered to COUNT(CASE WHEN predicate THEN ... ELSE NULL END))
@@ -676,6 +677,7 @@ public class DataFusionAnalyticsBackendPlugin implements AnalyticsSearchBackendP
                     Map.entry(ScalarFunction.CIDRMATCH, new CidrMatchFunctionAdapter()),
                     Map.entry(ScalarFunction.COALESCE, new CoalesceAdapter()),
                     Map.entry(ScalarFunction.CONCAT, new ConcatFunctionAdapter()),
+                    Map.entry(ScalarFunction.CONCAT_FUNCTION, new ConcatVariadicAdapter()),
                     Map.entry(ScalarFunction.CONVERT, new ConvAdapter()),
                     Map.entry(ScalarFunction.CONVERT_TZ, new ConvertTzAdapter()),
                     Map.entry(ScalarFunction.COS, new NumericToDoubleAdapter(SqlStdOperatorTable.COS)),

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/ConcatVariadicAdapterTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/ConcatVariadicAdapterTests.java
@@ -1,0 +1,124 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion;
+
+import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.hep.HepPlanner;
+import org.apache.calcite.plan.hep.HepProgramBuilder;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.fun.SqlLibraryOperators;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.List;
+
+/**
+ * Unit tests for {@link ConcatVariadicAdapter}. Pins the type-normalisation contract that lets
+ * substrait's CONSISTENT-consistency {@code concat} extension accept Calcite's mixed FixedChar /
+ * VARCHAR operand types without rejecting the variadic call.
+ */
+public class ConcatVariadicAdapterTests extends OpenSearchTestCase {
+
+    private RelDataTypeFactory typeFactory;
+    private RexBuilder rexBuilder;
+    private RelOptCluster cluster;
+    private RelDataType varcharType;
+    private RelDataType charType;
+
+    private final ConcatVariadicAdapter adapter = new ConcatVariadicAdapter();
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        typeFactory = new JavaTypeFactoryImpl();
+        rexBuilder = new RexBuilder(typeFactory);
+        HepPlanner planner = new HepPlanner(new HepProgramBuilder().build());
+        cluster = RelOptCluster.create(planner, rexBuilder);
+        varcharType = typeFactory.createSqlType(SqlTypeName.VARCHAR);
+        charType = typeFactory.createSqlType(SqlTypeName.CHAR, 5);
+    }
+
+    public void testAdaptCastsFixedCharOperandToVarchar() {
+        // CONCAT(varcharField, charLiteral, varcharField) — the middle operand is FixedChar/CHAR.
+        RexNode field0 = rexBuilder.makeInputRef(varcharType, 0);
+        RexNode charLiteral = rexBuilder.makeInputRef(charType, 1);
+        RexNode field2 = rexBuilder.makeInputRef(varcharType, 2);
+        RexCall original = (RexCall) rexBuilder.makeCall(SqlLibraryOperators.CONCAT_FUNCTION, field0, charLiteral, field2);
+
+        RexCall adapted = (RexCall) adapter.adapt(original, List.of(), cluster);
+
+        // Every operand must be VARCHAR after the rewrite.
+        for (int i = 0; i < adapted.getOperands().size(); i++) {
+            assertEquals(
+                "operand " + i + " must be VARCHAR after normalisation",
+                SqlTypeName.VARCHAR,
+                adapted.getOperands().get(i).getType().getSqlTypeName()
+            );
+        }
+    }
+
+    public void testAdaptPreservesOperatorIdentity() {
+        // The rewritten call must keep the original SqlLibraryOperators.CONCAT_FUNCTION operator
+        // by reference — substrait emission keys on operator identity, so a fresh binary CONCAT
+        // would route to the wrong substrait extension.
+        RexNode field0 = rexBuilder.makeInputRef(varcharType, 0);
+        RexNode charLiteral = rexBuilder.makeInputRef(charType, 1);
+        RexCall original = (RexCall) rexBuilder.makeCall(SqlLibraryOperators.CONCAT_FUNCTION, field0, charLiteral);
+
+        RexCall adapted = (RexCall) adapter.adapt(original, List.of(), cluster);
+
+        assertSame("operator identity must be preserved", original.getOperator(), adapted.getOperator());
+    }
+
+    public void testAdaptPreservesCallReturnType() {
+        // CASE-style or wrapper rewrites can drift the call's RelDataType; this adapter must not.
+        RexNode field0 = rexBuilder.makeInputRef(varcharType, 0);
+        RexNode charLiteral = rexBuilder.makeInputRef(charType, 1);
+        RexCall original = (RexCall) rexBuilder.makeCall(SqlLibraryOperators.CONCAT_FUNCTION, field0, charLiteral);
+
+        RexCall adapted = (RexCall) adapter.adapt(original, List.of(), cluster);
+
+        assertEquals("call return type must equal the original", original.getType(), adapted.getType());
+    }
+
+    public void testAdaptPreservesNullabilityWhenCasting() {
+        // A non-nullable CHAR operand must produce a non-nullable VARCHAR cast; a nullable
+        // VARCHAR field passes through. Nullability drift would change isthmus' downstream
+        // null-handling decisions.
+        RelDataType nonNullableChar = typeFactory.createTypeWithNullability(charType, false);
+        RexNode field0 = rexBuilder.makeInputRef(varcharType, 0);
+        RexNode charLiteral = rexBuilder.makeInputRef(nonNullableChar, 1);
+        RexCall original = (RexCall) rexBuilder.makeCall(SqlLibraryOperators.CONCAT_FUNCTION, field0, charLiteral);
+
+        RexCall adapted = (RexCall) adapter.adapt(original, List.of(), cluster);
+
+        assertFalse(
+            "non-nullable CHAR operand must produce a non-nullable VARCHAR cast",
+            adapted.getOperands().get(1).getType().isNullable()
+        );
+    }
+
+    public void testAdaptAllVarcharIsNoOp() {
+        // Early-return path: if every operand is already VARCHAR, the original RexCall is returned
+        // by reference. Avoids gratuitous allocation and downstream rewrite churn.
+        RexNode field0 = rexBuilder.makeInputRef(varcharType, 0);
+        RexNode field1 = rexBuilder.makeInputRef(varcharType, 1);
+        RexNode field2 = rexBuilder.makeInputRef(varcharType, 2);
+        RexCall original = (RexCall) rexBuilder.makeCall(SqlLibraryOperators.CONCAT_FUNCTION, field0, field1, field2);
+
+        RexNode adapted = adapter.adapt(original, List.of(), cluster);
+
+        assertSame("all-VARCHAR call must pass through unchanged", original, adapted);
+    }
+}

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/ConcatVariadicIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/ConcatVariadicIT.java
@@ -1,0 +1,76 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.qa;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * End-to-end coverage for variadic {@code concat(...)} over the shared `calcs` dataset.
+ * Substrait declares {@code concat} with CONSISTENT parameter consistency, so a mixed
+ * VARCHAR / FixedChar operand list (the natural shape when fields and short string
+ * literals appear together) trips isthmus' consistency check. The adapter pre-casts
+ * every non-VARCHAR operand to VARCHAR so substrait emits a uniform-typed call.
+ */
+public class ConcatVariadicIT extends AnalyticsRestTestCase {
+
+    private static final Dataset DATASET = new Dataset("calcs", "calcs");
+
+    private static boolean dataProvisioned = false;
+
+    @Override
+    protected void onBeforeQuery() throws IOException {
+        if (dataProvisioned == false) {
+            DatasetProvisioner.provision(client(), DATASET);
+            dataProvisioned = true;
+        }
+    }
+
+    public void testConcatThreeStringLiterals() throws IOException {
+        // 3-arg concat of short literals — every operand is FixedChar, so the cast
+        // path is exercised across all three slots.
+        assertRowsEqual(
+            "source=" + DATASET.indexName + " | eval r = concat('He', 'll', 'o') | fields r | head 1",
+            row("Hello")
+        );
+    }
+
+    public void testConcatFieldAndLiteralAndField() throws IOException {
+        // Mixed shape: VARCHAR field + FixedChar literal + VARCHAR field. First row of
+        // calcs has str2=`one` and str3=`e`, so the result is `one-e`.
+        assertRowsEqual(
+            "source=" + DATASET.indexName + " | eval r = concat(str2, '-', str3) | fields r | head 1",
+            row("one-e")
+        );
+    }
+
+    private static List<Object> row(Object... values) {
+        return Arrays.asList(values);
+    }
+
+    @SafeVarargs
+    @SuppressWarnings("varargs")
+    private final void assertRowsEqual(String ppl, List<Object>... expected) throws IOException {
+        Map<String, Object> response = executePpl(ppl);
+        @SuppressWarnings("unchecked")
+        List<List<Object>> actualRows = (List<List<Object>>) response.get("datarows");
+        assertNotNull("Response missing 'datarows' for query: " + ppl, actualRows);
+        assertEquals("Row count mismatch for query: " + ppl, expected.length, actualRows.size());
+        for (int i = 0; i < expected.length; i++) {
+            List<Object> want = expected[i];
+            List<Object> got = actualRows.get(i);
+            assertEquals("Column count mismatch at row " + i + " for query: " + ppl, want.size(), got.size());
+            for (int j = 0; j < want.size(); j++) {
+                assertEquals("Cell mismatch at row " + i + ", col " + j + " for query: " + ppl, want.get(j), got.get(j));
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Description

Substrait's `concat` extension declares CONSISTENT parameter consistency — every variadic operand must have the same type. Calcite preserves operand types verbatim, so a call like `concat(field, '-', field)` arrives at substrait emission with `Str` at indices 0/2 (field refs) and `FixedChar` at index 1 (the short literal). Isthmus rejects it:

```
Variadic arguments must have consistent types when parameterConsistency is CONSISTENT.
Argument at index 1 has type Str{nullable=false} but argument at index 3 has type
FixedChar{nullable=false, length=1}
```

The existing `ConcatFunctionAdapter` only handles the binary `||` operator (`SqlStdOperatorTable.CONCAT`); the variadic form (`SqlLibraryOperators.CONCAT_FUNCTION`) had no adapter. This PR adds a `CONCAT_FUNCTION` enum entry pinned to the Calcite operator and a `ConcatVariadicAdapter` that casts every non-VARCHAR operand to VARCHAR (preserving nullability) before substrait sees the call. DataFusion handles the cast natively.

### Semantics

`concat(...)` returns the string concatenation of every operand in left-to-right order. NULL propagation is preserved by the existing binary-CONCAT adapter for the 2-arg form; the variadic form follows DataFusion's native semantics (treats NULL as the empty string for variadic concat — same as Splunk's `concat`).

### Query shapes now supported

```ppl
| eval r = concat('a', 'b', 'c')                          (3+ short literals)
| eval r = concat(field, '-', field)                      (mixed VARCHAR + FixedChar)
| eval r = concat(field1, field2, field3)                 (all field refs)
| eval r = concat('prefix:', field, ':', field, ':suffix')(arbitrary mix)
| stats ... by concat(field, '-', field)                  (composed in stats)
| sort -concat(field1, field2)                            (composed in sort)
```

### Tests

- **Unit**:
  - `ConcatVariadicAdapterTests` — five cases: mixed VARCHAR/CHAR rewrite, operator-identity preservation, return-type preservation, nullability preservation, all-VARCHAR no-op early return.
  - `ScalarFunctionTests` — adds a case asserting `fromSqlOperatorWithFallback(CONCAT_FUNCTION)` resolves to `ScalarFunction.CONCAT_FUNCTION` via the reference-operator path (the binary `||` and variadic `CONCAT` share the same display name, so identity disambiguation matters).
- **Sandbox QA IT**: new `ConcatVariadicIT` over the shared `calcs` dataset asserts the all-FixedChar and mixed-shape forms end-to-end against a parquet-backed index.

### PPL Calcite tests in the SQL plugin unblocked

- `CalcitePPLStringBuiltinFunctionIT.testConcat`
- `NfwPplDashboardIT.testTopSourceAndDestinationByBytes`
- `NfwPplDashboardIT.testTopSourceAndDestinationPackets`

### Check List

- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).