### PR TITLE
Fix flaky tests in MatchScalarFunctionsiT

### DIFF
--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/DatasetProvisioner.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/DatasetProvisioner.java
@@ -104,9 +104,15 @@ public final class DatasetProvisioner {
         flushRequest.addParameter("force", "true");
         client.performRequest(flushRequest);
 
-        // Wait for index health
+        // Wait for index health. wait_for_status=yellow only guarantees primaries are assigned, not
+        // that every shard copy is active and done initializing — on a multi-node cluster a search
+        // can then race ahead of the shard becoming searchable and fail with "no such shard". Wait
+        // for green + all shards active + none initializing so the first query always finds them.
         Request healthRequest = new Request("GET", "/_cluster/health/" + indexName);
-        healthRequest.addParameter("wait_for_status", "yellow");
+        healthRequest.addParameter("wait_for_status", "green");
+        healthRequest.addParameter("wait_for_active_shards", "all");
+        healthRequest.addParameter("wait_for_no_initializing_shards", "true");
+        healthRequest.addParameter("wait_for_no_relocating_shards", "true");
         healthRequest.addParameter("timeout", "60s");
         client.performRequest(healthRequest);
 


### PR DESCRIPTION


<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
The post-bulk health check waited only for wait_for_status=yellow, which guarantees primaries are assigned but not that every shard copy is active and done initializing. On the suite's 2-node test cluster a query could then race ahead of the shard becoming searchable and fail with "no such shard".

This surfaced most visibly on MathScalarFunctionsIT.testConvInvalidRadixThrows — the only test that expects the query to throw — because its catch (ResponseException) block swallowed the "no such shard" 500 and then failed on the error-message assertion, making an infrastructure race look like a conv() radix-message bug.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
