### PR TITLE
Fix disable_objects array parsing to preserve dotted field names

### DIFF
--- a/server/src/main/java/org/opensearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/opensearch/index/mapper/DocumentParser.java
@@ -1192,7 +1192,10 @@ final class DocumentParser {
                 )
             );
         }
-        final String[] paths = splitAndValidatePath(lastFieldName);
+        // When disable_objects is enabled, dotted field names must be treated as literal single-segment
+        // names. Splitting them would cause getDynamicParentMapper to create intermediate ObjectMappers
+        // without disable_objects=tru.
+        final String[] paths = mapper.disableObjects() ? new String[] { lastFieldName } : splitAndValidatePath(lastFieldName);
         while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
             if (token == XContentParser.Token.START_OBJECT) {
                 parseObject(context, mapper, lastFieldName, paths);

--- a/server/src/main/java/org/opensearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/opensearch/index/mapper/DocumentParser.java
@@ -281,6 +281,10 @@ final class DocumentParser {
         return new MapperParsingException("failed to parse", e);
     }
 
+    private static String[] resolvePathForParsing(ObjectMapper mapper, String fieldName) {
+        return mapper.disableObjects() ? new String[] { fieldName } : splitAndValidatePath(fieldName);
+    }
+
     private static String[] splitAndValidatePath(String fullFieldPath) {
         if (fullFieldPath.contains(".")) {
             String[] parts = fullFieldPath.split("\\.");
@@ -637,7 +641,7 @@ final class DocumentParser {
             while (token != XContentParser.Token.END_OBJECT) {
                 if (token == XContentParser.Token.FIELD_NAME) {
                     currentFieldName = parser.currentName();
-                    paths = mapper.disableObjects() ? new String[] { currentFieldName } : splitAndValidatePath(currentFieldName);
+                    paths = resolvePathForParsing(mapper, currentFieldName);
                     if (containsDisabledObjectMapper(mapper, paths)) {
                         parser.nextToken();
                         parser.skipChildren();
@@ -1192,10 +1196,7 @@ final class DocumentParser {
                 )
             );
         }
-        // When disable_objects is enabled, dotted field names must be treated as literal single-segment
-        // names. Splitting them would cause getDynamicParentMapper to create intermediate ObjectMappers
-        // without disable_objects=tru.
-        final String[] paths = mapper.disableObjects() ? new String[] { lastFieldName } : splitAndValidatePath(lastFieldName);
+        final String[] paths = resolvePathForParsing(mapper, lastFieldName);
         while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
             if (token == XContentParser.Token.START_OBJECT) {
                 parseObject(context, mapper, lastFieldName, paths);

--- a/server/src/test/java/org/opensearch/index/mapper/DocumentParserTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/DocumentParserTests.java
@@ -3567,16 +3567,10 @@ public class DocumentParserTests extends MapperServiceTestCase {
             if (logAttrsMapper instanceof ObjectMapper logAttrsObj) {
                 // There should be NO "app" ObjectMapper child
                 Mapper appMapper = logAttrsObj.getMapper("app");
-                assertNull(
-                    "ObjectMapper 'app' should NOT exist under LogAttributes (dotted name should be kept flat)",
-                    appMapper
-                );
+                assertNull("ObjectMapper 'app' should NOT exist under LogAttributes (dotted name should be kept flat)", appMapper);
                 // There SHOULD be a "app.payment" FieldMapper child
                 Mapper appPaymentMapper = logAttrsObj.getMapper("app.payment");
-                assertNotNull(
-                    "FieldMapper 'app.payment' should exist as flat field under LogAttributes",
-                    appPaymentMapper
-                );
+                assertNotNull("FieldMapper 'app.payment' should exist as flat field under LogAttributes", appPaymentMapper);
                 assertTrue("'app.payment' should be a FieldMapper", appPaymentMapper instanceof FieldMapper);
             }
         }
@@ -3618,15 +3612,9 @@ public class DocumentParserTests extends MapperServiceTestCase {
         Mapping dynamicUpdate = doc.dynamicMappingsUpdate();
         if (dynamicUpdate != null) {
             Mapper metricsMapper = dynamicUpdate.root().getMapper("metrics");
-            assertNull(
-                "ObjectMapper 'metrics' should NOT exist at root (dotted name should be kept flat)",
-                metricsMapper
-            );
+            assertNull("ObjectMapper 'metrics' should NOT exist at root (dotted name should be kept flat)", metricsMapper);
             Mapper metricsCpuMapper = dynamicUpdate.root().getMapper("metrics.cpu");
-            assertNull(
-                "ObjectMapper 'metrics.cpu' should NOT exist at root",
-                metricsCpuMapper
-            );
+            assertNull("ObjectMapper 'metrics.cpu' should NOT exist at root", metricsCpuMapper);
             // The flat field "metrics.cpu.cores" should exist
             Mapper coresMapper = dynamicUpdate.root().getMapper("metrics.cpu.cores");
             assertNotNull("FieldMapper 'metrics.cpu.cores' should exist as flat field", coresMapper);

--- a/server/src/test/java/org/opensearch/index/mapper/DocumentParserTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/DocumentParserTests.java
@@ -3510,6 +3510,130 @@ public class DocumentParserTests extends MapperServiceTestCase {
         assertNull("Null field should not be created", doc.rootDoc().getField("mixed_nulls.null_field"));
     }
 
+    public void testDisableObjectsArrayWithDottedFieldNameNoIntermediateObjectMapper() throws Exception {
+        // Regression test: When a nested object contains an array value under disable_objects,
+        // the flattened dotted field name (e.g., "app.payment") must NOT be split by
+        // parseNonDynamicArray's splitAndValidatePath. Splitting would cause getDynamicParentMapper
+        // to create an intermediate ObjectMapper ("app") without disable_objects=true, breaking
+        // the flat-field contract and potentially causing recursive field name expansion.
+
+        // Test at nested ObjectMapper level (like the TextBench LogAttributes case)
+        DocumentMapper mapper = createDocumentMapper(topMapping(b -> {
+            b.field("dynamic", "true");
+            b.startObject("properties");
+            {
+                b.startObject("LogAttributes");
+                {
+                    b.field("type", "object");
+                    b.field("disable_objects", true);
+                }
+                b.endObject();
+            }
+            b.endObject();
+        }));
+
+        // Nested object with array: {"LogAttributes": {"app": {"payment": ["visa", "mastercard"]}}}
+        // After flattening, field name becomes "app.payment" and the value is an array.
+        // The bug would cause "app" to become an ObjectMapper without disable_objects.
+        ParsedDocument doc = mapper.parse(source(b -> {
+            b.startObject("LogAttributes");
+            {
+                b.startObject("app");
+                {
+                    b.startArray("payment");
+                    b.value("visa");
+                    b.value("mastercard");
+                    b.endArray();
+                }
+                b.endObject();
+            }
+            b.endObject();
+        }));
+
+        assertNotNull(doc);
+        // "app.payment" should be a flat field with 2 values
+        IndexableField[] paymentFields = doc.rootDoc().getFields("LogAttributes.app.payment");
+        assertNotNull("Field 'LogAttributes.app.payment' should exist", paymentFields);
+        assertEquals("Should have 2 values for the array", 2, paymentFields.length);
+        assertEquals("visa", paymentFields[0].stringValue());
+        assertEquals("mastercard", paymentFields[1].stringValue());
+
+        // Verify no intermediate ObjectMapper "app" was created in the dynamic mapping update
+        Mapping dynamicUpdate = doc.dynamicMappingsUpdate();
+        if (dynamicUpdate != null) {
+            // The update should contain a FieldMapper for "app.payment" under LogAttributes,
+            // NOT an ObjectMapper for "app"
+            Mapper logAttrsMapper = dynamicUpdate.root().getMapper("LogAttributes");
+            if (logAttrsMapper instanceof ObjectMapper logAttrsObj) {
+                // There should be NO "app" ObjectMapper child
+                Mapper appMapper = logAttrsObj.getMapper("app");
+                assertNull(
+                    "ObjectMapper 'app' should NOT exist under LogAttributes (dotted name should be kept flat)",
+                    appMapper
+                );
+                // There SHOULD be a "app.payment" FieldMapper child
+                Mapper appPaymentMapper = logAttrsObj.getMapper("app.payment");
+                assertNotNull(
+                    "FieldMapper 'app.payment' should exist as flat field under LogAttributes",
+                    appPaymentMapper
+                );
+                assertTrue("'app.payment' should be a FieldMapper", appPaymentMapper instanceof FieldMapper);
+            }
+        }
+    }
+
+    public void testDisableObjectsRootArrayWithDottedFieldNameNoIntermediateObjectMapper() throws Exception {
+        // Same regression test but at root level with disable_objects=true
+        DocumentMapper mapper = createDocumentMapper(topMapping(b -> {
+            b.field("disable_objects", true);
+            b.field("dynamic", "true");
+        }));
+
+        // Nested object with array: {"metrics": {"cpu": {"cores": [1, 2, 3, 4]}}}
+        // After flattening, field name becomes "metrics.cpu.cores" and the value is an array.
+        ParsedDocument doc = mapper.parse(source(b -> {
+            b.startObject("metrics");
+            {
+                b.startObject("cpu");
+                {
+                    b.startArray("cores");
+                    b.value(1);
+                    b.value(2);
+                    b.value(3);
+                    b.value(4);
+                    b.endArray();
+                }
+                b.endObject();
+            }
+            b.endObject();
+        }));
+
+        assertNotNull(doc);
+        // "metrics.cpu.cores" should be a flat field with 4 values
+        IndexableField[] coreFields = doc.rootDoc().getFields("metrics.cpu.cores");
+        assertNotNull("Field 'metrics.cpu.cores' should exist", coreFields);
+        assertEquals("Should have 8 fields (4 values * 2 fields each for numeric)", 8, coreFields.length);
+
+        // Verify no intermediate ObjectMapper "metrics" or "metrics.cpu" was created
+        Mapping dynamicUpdate = doc.dynamicMappingsUpdate();
+        if (dynamicUpdate != null) {
+            Mapper metricsMapper = dynamicUpdate.root().getMapper("metrics");
+            assertNull(
+                "ObjectMapper 'metrics' should NOT exist at root (dotted name should be kept flat)",
+                metricsMapper
+            );
+            Mapper metricsCpuMapper = dynamicUpdate.root().getMapper("metrics.cpu");
+            assertNull(
+                "ObjectMapper 'metrics.cpu' should NOT exist at root",
+                metricsCpuMapper
+            );
+            // The flat field "metrics.cpu.cores" should exist
+            Mapper coresMapper = dynamicUpdate.root().getMapper("metrics.cpu.cores");
+            assertNotNull("FieldMapper 'metrics.cpu.cores' should exist as flat field", coresMapper);
+            assertTrue("'metrics.cpu.cores' should be a FieldMapper", coresMapper instanceof FieldMapper);
+        }
+    }
+
     public void testGeoPointWithCopyTo() throws Exception {
         DocumentMapper mapper = createDocumentMapper(mapping(b -> {
             b.startObject("point");


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
```
final String[] paths = mapper.disableObjects() ? new String[] { lastFieldName } : splitAndValidatePath(lastFieldName);
```
This ensures that when parseNonDynamicArray is called from a disable_objects context (e.g., via processFlattenedTokenForDisableObjects for a dotted field whose value is an array), the dotted field name is kept as a single literal path segment. This prevents parseValue - getDynamicParentMapper from splitting it further and creating rogue intermediate ObjectMappers that lack disable_objects=true.

Tests Added
1. testDisableObjectsArrayWithDottedFieldNameNoIntermediateObjectMapper
```
Simulates the TextBench LogAttributes scenario at nested ObjectMapper level
Indexes {"LogAttributes": {"app": {"payment": ["visa", "mastercard"]}}}
Asserts that LogAttributes.app.payment is a single flat FieldMapper
Asserts that NO intermediate ObjectMapper "app" is created in the dynamic mapping update
```
2. testDisableObjectsRootArrayWithDottedFieldNameNoIntermediateObjectMapper
```
Same scenario at root level with disable_objects=true
Indexes {"metrics": {"cpu": {"cores": [1, 2, 3, 4]}}}
Asserts that metrics.cpu.cores is a single flat FieldMapper
Asserts that NO intermediate ObjectMappers "metrics" or "metrics.cpu" are created
```
### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
