### PR TITLE
getCommitStats from committer in DataFormatAwareReadOnlyEngine

### DIFF
--- a/server/src/main/java/org/opensearch/index/engine/DataFormatAwareReadOnlyEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/DataFormatAwareReadOnlyEngine.java
@@ -12,7 +12,6 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.lucene.index.IndexCommit;
 import org.apache.lucene.index.IndexWriter;
-import org.apache.lucene.index.SegmentInfos;
 import org.apache.lucene.store.AlreadyClosedException;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.SetOnce;
@@ -521,12 +520,7 @@ public class DataFormatAwareReadOnlyEngine implements Indexer {
     @Override
     public CommitStats commitStats() {
         ensureOpen();
-        try {
-            return new CommitStats(store.readLastCommittedSegmentsInfo());
-        } catch (Exception e) {
-            logger.debug("Unable to read last committed SegmentInfos; returning empty CommitStats", e);
-            return new CommitStats(new SegmentInfos(org.apache.lucene.util.Version.LATEST.major));
-        }
+        return committer.getCommitStats();
     }
 
     @Override

--- a/server/src/test/java/org/opensearch/index/engine/DataFormatAwareReadOnlyEngineTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/DataFormatAwareReadOnlyEngineTests.java
@@ -64,6 +64,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static org.opensearch.index.engine.EngineTestCase.tombstoneDocSupplier;
@@ -190,6 +191,15 @@ public class DataFormatAwareReadOnlyEngineTests extends OpenSearchTestCase {
     }
 
     private EngineConfig buildConfig(Store store, IndexSettings indexSettings, Engine.EventListener listener) {
+        return buildConfig(store, indexSettings, listener, config -> new InMemoryCommitter(store));
+    }
+
+    private EngineConfig buildConfig(
+        Store store,
+        IndexSettings indexSettings,
+        Engine.EventListener listener,
+        CommitterFactory committerFactory
+    ) {
         Path translogPath = createTempDir().resolve("translog");
         TranslogConfig translogConfig = new TranslogConfig(
             shardId,
@@ -200,7 +210,6 @@ public class DataFormatAwareReadOnlyEngineTests extends OpenSearchTestCase {
             false
         );
         DataFormatRegistry registry = createMockRegistry();
-        CommitterFactory committerFactory = config -> new InMemoryCommitter(store);
         EngineConfig.Builder builder = new EngineConfig.Builder().shardId(shardId)
             .threadPool(threadPool)
             .indexSettings(indexSettings)
@@ -742,6 +751,80 @@ public class DataFormatAwareReadOnlyEngineTests extends OpenSearchTestCase {
         } finally {
             engine.close();
             config.getStore().close();
+        }
+    }
+
+    // ---------- commitStats Tests ----------
+
+    /**
+     * commitStats() must delegate to the committer's (cached) stats and NOT re-read the store on
+     * each call. Proven two ways: the committer's getCommitStats() is invoked once per call, and the
+     * exact instance it returns is propagated unchanged through the engine.
+     */
+    public void testCommitStatsDelegatesToCommitter() throws IOException {
+        String translogUUID = UUID.randomUUID().toString();
+        String historyUUID = UUID.randomUUID().toString();
+        bootstrapStoreWithMetadata(store, translogUUID, historyUUID);
+        RecordingCommitter recordingCommitter = new RecordingCommitter(store);
+        try (
+            DataFormatAwareReadOnlyEngine engine = new DataFormatAwareReadOnlyEngine(
+                buildConfig(store, warmIndexSettings(), null, config -> recordingCommitter)
+            )
+        ) {
+            int before = recordingCommitter.getCommitStatsCalls.get();
+
+            CommitStats first = engine.commitStats();
+            CommitStats second = engine.commitStats();
+
+            assertNotNull("commitStats must not be null", first);
+            assertEquals(
+                "commitStats() must call committer.getCommitStats() exactly once per invocation",
+                before + 2,
+                recordingCommitter.getCommitStatsCalls.get()
+            );
+            assertSame("engine must return the committer's cached CommitStats instance unchanged", first, second);
+            assertSame("engine must return the committer's cached CommitStats instance", recordingCommitter.cached, first);
+        }
+    }
+
+    /** commitStats() must surface the committer's actual commit point (correct generation). */
+    public void testCommitStatsReturnsExpectedGeneration() throws IOException {
+        try (DataFormatAwareReadOnlyEngine engine = createReadOnlyEngine()) {
+            long expectedGeneration = store.readLastCommittedSegmentsInfo().getGeneration();
+            CommitStats commitStats = engine.commitStats();
+            assertNotNull(commitStats);
+            assertEquals("commitStats must report the committed generation", expectedGeneration, commitStats.getGeneration());
+            assertNotNull("commitStats must carry a commit id", commitStats.getId());
+        }
+    }
+
+    /** commitStats() must honor engine lifecycle — after close it must throw, not read the store. */
+    public void testCommitStatsAfterCloseThrowsAlreadyClosed() throws IOException {
+        DataFormatAwareReadOnlyEngine engine = createReadOnlyEngine();
+        engine.close();
+        expectThrows(AlreadyClosedException.class, engine::commitStats);
+    }
+
+    /**
+     * Test committer that records how many times getCommitStats() is called and always returns the
+     * same cached instance — mirroring the production committer, which caches SegmentInfos so stats
+     * calls do no I/O.
+     */
+    private static class RecordingCommitter extends InMemoryCommitter {
+        final AtomicInteger getCommitStatsCalls = new AtomicInteger();
+        final CommitStats cached;
+
+        RecordingCommitter(Store store) throws IOException {
+            super(store);
+            // Build the cached value once via the base (store-reading) implementation, then serve it
+            // from memory on every subsequent call — no further store reads.
+            this.cached = super.getCommitStats();
+        }
+
+        @Override
+        public CommitStats getCommitStats() {
+            getCommitStatsCalls.incrementAndGet();
+            return cached;
         }
     }
 


### PR DESCRIPTION

### Description
commitStats() called store.readLastCommittedSegmentsInfo(), which lists the remote-backed directory and reads segments_N on every call. On warm nodes that is a synchronous S3 round-trip executed on the MANAGEMENT thread pool; because _nodes/stats fans out per shard it starved the pool and made warm nodes drop out of _cat/allocation and time out _nodes/info.

In this commit, we serve CommitStats from the committer's cached SegmentInfos instead which caches the metadata and doesn't need S3 I/O every time on the stats path.

### Check List
- [Yes] Functionality includes testing.
- [NA] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [NA] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
