### PR TITLE
Support field collapsing + rescore

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/110_field_collapsing.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/110_field_collapsing.yml
@@ -246,25 +246,6 @@ setup:
           collapse: { field: numeric_group }
 
 ---
-"field collapsing and rescore":
-
-  - do:
-      catch:      /cannot use \`collapse\` in conjunction with \`rescore\`/
-      search:
-        allow_partial_search_results: false
-        rest_total_hits_as_int: true
-        index: test
-        body:
-          collapse: { field: numeric_group }
-          rescore:
-            window_size: 20
-            query:
-              rescore_query:
-                match_all: {}
-              query_weight: 1
-              rescore_query_weight: 2
-
----
 "no hits and inner_hits":
 
   - skip:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/111_field_collapsing_with_rescore.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/111_field_collapsing_with_rescore.yml
@@ -1,0 +1,109 @@
+setup:
+  - skip:
+      version: " - 3.7.99"
+      reason: "field collapsing with rescore was added later"
+  - do:
+      indices.create:
+        index: products
+        body:
+          mappings:
+            properties:
+              product_id: { type: keyword }
+              description: { type: text }
+              popularity: { type: integer }
+  - do:
+      bulk:
+        index: products
+        refresh: true
+        body:
+          - '{"index": {"_id": "1", "routing": "0"}}'
+          - '{"product_id": "0", "description": "flat tv 4K HDR", "score": 2, "popularity": 30}'
+          - '{"index": {"_id": "2", "routing": "10"}}'
+          - '{"product_id": "10", "description": "LED Smart TV 32", "score": 5, "popularity": 100}'
+          - '{"index": {"_id": "3", "routing": "10"}}'
+          - '{"product_id": "10", "description": "LED Smart TV 65", "score": 10, "popularity": 50}'
+          - '{"index": {"_id": "4", "routing": "0"}}'
+          - '{"product_id": "0", "description": "flat tv", "score": 1, "popularity": 10}'
+          - '{"index": {"_id": "5", "routing": "20"}}'
+          - '{"product_id": "20", "description": "just a tv", "score": 100, "popularity": 3}'
+          - '{"index": {"_id": "6", "routing": "30"}}'
+          - '{"product_id": "30", "description": "basic tv", "score": 0, "popularity": 1000}'
+
+---
+"field collapsing and rescore":
+  - do:
+      search:
+        index: products
+        body:
+          query:
+            bool:
+              filter:
+                match:
+                  description: "tv"
+              should:
+                script_score:
+                  query: { match_all: { } }
+                  script:
+                    source: "doc['score'].value"
+          collapse:
+            field: product_id
+          rescore:
+            query:
+              rescore_query:
+                script_score:
+                  query: { match_all: { } }
+                  script:
+                    source: "doc['popularity'].value"
+              query_weight: 0
+              rescore_query_weight: 1
+
+  - match: { hits.total.value: 6 }
+  - length: { hits.hits: 4 }
+  - match: { hits.hits.0._id:  "6" }
+  - match: { hits.hits.0._score:  1000 }
+  - match: { hits.hits.0.fields.product_id:  ["30"] }
+  - match: { hits.hits.1._id:  "3" }
+  - match: { hits.hits.1._score:  50 }
+  - match: { hits.hits.1.fields.product_id:  ["10"] }
+  - match: { hits.hits.2._id: "1" }
+  - match: { hits.hits.2._score: 30 }
+  - match: { hits.hits.2.fields.product_id: ["0"] }
+  - match: { hits.hits.3._id: "5" }
+  - match: { hits.hits.3._score: 3 }
+  - match: { hits.hits.3.fields.product_id: ["20"] }
+
+---
+"field collapsing and rescore with window_size":
+  - do:
+      search:
+        index: products
+        body:
+          query:
+            bool:
+              filter:
+                match:
+                  description: "tv"
+              should:
+                script_score:
+                  query: { match_all: { } }
+                  script:
+                    source: "doc['score'].value"
+          collapse:
+            field: product_id
+          rescore:
+            window_size: 2
+            query:
+              rescore_query:
+                script_score:
+                  query: { match_all: { } }
+                  script:
+                    source: "doc['popularity'].value"
+              query_weight: 0
+              rescore_query_weight: 1
+          size: 1
+
+  - match: { hits.total.value: 6 }
+  - length: { hits.hits: 1 }
+  - match: { hits.hits.0._id: "3" }
+  - match: { hits.hits.0._score: 50 }
+  - match: { hits.hits.0.fields.product_id: ["10"] }

--- a/server/src/internalClusterTest/java/org/opensearch/search/functionscore/QueryRescorerIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/functionscore/QueryRescorerIT.java
@@ -1046,6 +1046,7 @@ public class QueryRescorerIT extends ParameterizedStaticSettingsOpenSearchIntegT
      * Unlike {@link #testRescoreAfterCollapseRandom()}, the documents are NOT routed by group, so a group's
      * documents land on different shards based on the (random) document id.
      */
+    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/pull/22131#issue-4647788700")
     public void testRescoreAfterCollapseGroupAcrossShards() throws Exception {
         int numShards = randomIntBetween(2, 5);
         assertAcked(

--- a/server/src/internalClusterTest/java/org/opensearch/search/functionscore/QueryRescorerIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/functionscore/QueryRescorerIT.java
@@ -51,14 +51,13 @@ import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.index.query.functionscore.ScoreFunctionBuilders;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
+import org.opensearch.search.collapse.CollapseBuilder;
 import org.opensearch.search.rescore.QueryRescoreMode;
 import org.opensearch.search.rescore.QueryRescorerBuilder;
 import org.opensearch.search.sort.SortBuilders;
 import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Comparator;
+import java.util.*;
 
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_REPLICAS;
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_SHARDS;
@@ -870,5 +869,179 @@ public class QueryRescorerIT extends ParameterizedStaticSettingsOpenSearchIntegT
         for (SearchHit hit : resp.getHits().getHits()) {
             assertThat(hit.getScore(), equalTo(101f));
         }
+    }
+
+    record GroupDoc(String id, String group, float firstPassScore, float secondPassScore, boolean shouldFilter) {}
+
+    public void testRescoreAfterCollapse() throws Exception {
+        assertAcked(
+            prepareCreate("test").setMapping(
+                jsonBuilder().startObject()
+                    .startObject("properties")
+                    .startObject("group")
+                    .field("type", "keyword")
+                    .endObject()
+                    .startObject("shouldFilter")
+                    .field("type", "boolean")
+                    .endObject()
+                    .endObject()
+                    .endObject()
+            )
+        );
+        ensureGreen("test");
+
+        GroupDoc[] groupDocs = new GroupDoc[] {
+            new GroupDoc("1", "c", 200, 1, false),
+            new GroupDoc("2", "a", 1, 10, true),
+            new GroupDoc("3", "b", 2, 30, false),
+            new GroupDoc("4", "c", 1, 1000, false),
+            // should be highest on rescore, but filtered out during collapse
+            new GroupDoc("5", "a", 2, 20, false),
+            new GroupDoc("6", "b", 1, 40, false),
+        };
+        List<IndexRequestBuilder> requests = new ArrayList<>();
+        for (var doc: groupDocs) {
+            requests.add(
+                client().prepareIndex("test")
+                    .setId(doc.id())
+                    .setRouting(doc.group())
+                    .setSource(
+                        "group",
+                        doc.group(),
+                        "firstPassScore",
+                        doc.firstPassScore(),
+                        "secondPassScore",
+                        doc.secondPassScore(),
+                        "shouldFilter",
+                        doc.shouldFilter()
+                    )
+            );
+        }
+        indexRandom(true, requests);
+
+        SearchResponse searchResponse = client().prepareSearch("test")
+            .setQuery(fieldValueScoreQuery("firstPassScore"))
+            .setRescorer(
+                new QueryRescorerBuilder(
+                    fieldValueScoreQuery("secondPassScore")
+                ).setQueryWeight(1.0f)
+                    .setRescoreQueryWeight(1.0f)
+                    .setScoreMode(QueryRescoreMode.Total)
+            )
+            .setCollapse(new CollapseBuilder("group"))
+            .get();
+        assertSearchResponse(searchResponse);
+        assertThat(searchResponse.getHits().getTotalHits().value(), equalTo(5L));
+        assertThat(searchResponse.getHits().getHits().length, equalTo(3));
+
+        SearchHit hit1 = searchResponse.getHits().getHits()[0];
+        assertThat(hit1.getId(), equalTo("1"));
+        assertThat(hit1.getScore(), equalTo(201.0f));
+        assertThat(hit1.field("group").getValues().size(), equalTo(1));
+        assertThat(hit1.field("group").getValues().getFirst(), equalTo("c"));
+
+        SearchHit hit2 = searchResponse.getHits().getHits()[1];
+        assertThat(hit2.getId(), equalTo("3"));
+        assertThat(hit2.getScore(), equalTo(32.0f));
+        assertThat(hit2.field("group").getValues().size(), equalTo(1));
+        assertThat(hit2.field("group").getValues().getFirst(), equalTo("b"));
+
+        SearchHit hit3 = searchResponse.getHits().getHits()[2];
+        assertThat(hit3.getId(), equalTo("5"));
+        assertThat(hit3.getScore(), equalTo(22.0f));
+        assertThat(hit3.field("group").getValues().size(), equalTo(1));
+        assertThat(hit3.field("group").getValues().getFirst(), equalTo("a"));
+    }
+
+    public void testRescoreAfterCollapseRandom() throws Exception {
+        assertAcked(
+            prepareCreate("test").setMapping(
+                jsonBuilder().startObject()
+                    .startObject("properties")
+                    .startObject("group")
+                    .field("type", "keyword")
+                    .endObject()
+                    .startObject("shouldFilter")
+                    .field("type", "boolean")
+                    .endObject()
+                    .endObject()
+                    .endObject()
+            )
+        );
+        ensureGreen("test");
+        int numGroups = randomIntBetween(1, 100);
+        int numDocs = atLeast(100);
+        GroupDoc[] groups = new GroupDoc[numGroups];
+        long expectedNumHits = 0;
+        List<IndexRequestBuilder> requests = new ArrayList<>();
+        for (int i = 0; i < numDocs; i++) {
+            int group = randomIntBetween(0, numGroups - 1);
+            boolean shouldFilter = rarely();
+            String id = UUID.randomUUID().toString();
+            float firstPassScore = randomFloat();
+            float secondPassScore = randomFloat();
+            float bestScore = groups[group] == null ? -1 : groups[group].firstPassScore;
+            GroupDoc doc = new GroupDoc(id, Integer.toString(group), firstPassScore, secondPassScore, shouldFilter);
+            if (shouldFilter == false) {
+                if (firstPassScore == bestScore) {
+                    // avoid tiebreaker
+                    continue;
+                }
+                expectedNumHits++;
+                if (firstPassScore > bestScore) {
+                    groups[group] = doc;
+                }
+            }
+            requests.add(
+                client().prepareIndex("test")
+                    .setId(doc.id())
+                    .setRouting(doc.group())
+                    .setSource(
+                        "group",
+                        doc.group(),
+                        "firstPassScore",
+                        doc.firstPassScore(),
+                        "secondPassScore",
+                        doc.secondPassScore(),
+                        "shouldFilter",
+                        doc.shouldFilter()
+                    )
+            );
+        }
+        indexRandom(true, requests);
+
+        GroupDoc[] sortedGroups = Arrays.stream(groups)
+            .filter(Objects::nonNull)
+            .sorted(Comparator.comparingDouble(GroupDoc::secondPassScore).reversed())
+            .toArray(GroupDoc[]::new);
+
+        SearchResponse searchResponse = client().prepareSearch("test")
+            .setQuery(fieldValueScoreQuery("firstPassScore"))
+            .setRescorer(
+                new QueryRescorerBuilder(
+                    fieldValueScoreQuery("secondPassScore")
+                ).setQueryWeight(0f)
+                    .setRescoreQueryWeight(1.0f)
+                    .windowSize(numGroups)
+            )
+            .setCollapse(new CollapseBuilder("group"))
+            .setSize(Math.min(numGroups, 10))
+            .get();
+
+        assertSearchResponse(searchResponse);
+        assertThat(searchResponse.getHits().getTotalHits().value(), equalTo(expectedNumHits));
+        for (int pos = 0; pos < searchResponse.getHits().getHits().length; pos++) {
+            SearchHit hit = searchResponse.getHits().getAt(pos);
+            assertThat(hit.getId(), equalTo(sortedGroups[pos].id()));
+            assertThat(hit.field("group").getValue(), equalTo(sortedGroups[pos].group()));
+            assertThat(hit.getScore(), equalTo(sortedGroups[pos].secondPassScore));
+        }
+    }
+
+    private QueryBuilder fieldValueScoreQuery(String scoreField) {
+        return functionScoreQuery(
+            termQuery("shouldFilter", false),
+            ScoreFunctionBuilders.fieldValueFactorFunction(scoreField)
+        ).boostMode(CombineFunction.REPLACE);
     }
 }

--- a/server/src/internalClusterTest/java/org/opensearch/search/functionscore/QueryRescorerIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/functionscore/QueryRescorerIT.java
@@ -1038,6 +1038,102 @@ public class QueryRescorerIT extends ParameterizedStaticSettingsOpenSearchIntegT
         }
     }
 
+    /**
+     * Verifies collapse + rescore when the documents of a single group are spread across multiple shards.
+     * <p>
+     * Unlike {@link #testRescoreAfterCollapseRandom()}, the documents are NOT routed by group, so a group's
+     * documents land on different shards based on the (random) document id.
+     */
+    public void testRescoreAfterCollapseGroupAcrossShards() throws Exception {
+        int numShards = randomIntBetween(2, 5);
+        assertAcked(
+            prepareCreate("test").setSettings(Settings.builder().put(SETTING_NUMBER_OF_SHARDS, numShards))
+                .setMapping(
+                    jsonBuilder().startObject()
+                        .startObject("properties")
+                        .startObject("group")
+                        .field("type", "keyword")
+                        .endObject()
+                        .startObject("shouldFilter")
+                        .field("type", "boolean")
+                        .endObject()
+                        .endObject()
+                        .endObject()
+                )
+        );
+        ensureGreen("test");
+        // Keep the number of groups small relative to the number of documents so that each group is very likely
+        // to have its documents spread across several shards.
+        int numGroups = randomIntBetween(1, 10);
+        int numDocs = atLeast(100);
+        GroupDoc[] groups = new GroupDoc[numGroups];
+        long expectedNumHits = 0;
+        List<IndexRequestBuilder> requests = new ArrayList<>();
+        for (int i = 0; i < numDocs; i++) {
+            int group = randomIntBetween(0, numGroups - 1);
+            boolean shouldFilter = rarely();
+            String id = UUID.randomUUID().toString();
+            float firstPassScore = randomFloat();
+            float secondPassScore = randomFloat();
+            float bestScore = groups[group] == null ? -1 : groups[group].firstPassScore;
+            GroupDoc doc = new GroupDoc(id, Integer.toString(group), firstPassScore, secondPassScore, shouldFilter);
+            if (shouldFilter == false) {
+                if (firstPassScore == bestScore) {
+                    // avoid tiebreaker
+                    continue;
+                }
+                expectedNumHits++;
+                if (firstPassScore > bestScore) {
+                    groups[group] = doc;
+                }
+            }
+            requests.add(
+                // Intentionally do NOT route by group, so a group's documents are distributed across shards
+                // by the (random) document id.
+                client().prepareIndex("test")
+                    .setId(doc.id())
+                    .setSource(
+                        "group",
+                        doc.group(),
+                        "firstPassScore",
+                        doc.firstPassScore(),
+                        "secondPassScore",
+                        doc.secondPassScore(),
+                        "shouldFilter",
+                        doc.shouldFilter()
+                    )
+            );
+        }
+        indexRandom(true, requests);
+
+        GroupDoc[] sortedGroups = Arrays.stream(groups)
+            .filter(Objects::nonNull)
+            .sorted(Comparator.comparingDouble(GroupDoc::secondPassScore).reversed())
+            .toArray(GroupDoc[]::new);
+
+        SearchResponse searchResponse = client().prepareSearch("test")
+            .setQuery(fieldValueScoreQuery("firstPassScore"))
+            .setRescorer(
+                new QueryRescorerBuilder(
+                    fieldValueScoreQuery("secondPassScore")
+                ).setQueryWeight(0f)
+                    .setRescoreQueryWeight(1.0f)
+                    .windowSize(numGroups)
+            )
+            .setCollapse(new CollapseBuilder("group"))
+            .setSize(Math.min(numGroups, 10))
+            .get();
+
+        assertSearchResponse(searchResponse);
+        assertThat(searchResponse.getHits().getTotalHits().value(), equalTo(expectedNumHits));
+        for (int pos = 0; pos < searchResponse.getHits().getHits().length; pos++) {
+            SearchHit hit = searchResponse.getHits().getAt(pos);
+            assertThat(hit.getId(), equalTo(sortedGroups[pos].id()));
+            assertThat(hit.field("group").getValue(), equalTo(sortedGroups[pos].group()));
+            assertThat(hit.getScore(), equalTo(sortedGroups[pos].secondPassScore));
+        }
+    }
+
     private QueryBuilder fieldValueScoreQuery(String scoreField) {
         return functionScoreQuery(
             termQuery("shouldFilter", false),

--- a/server/src/internalClusterTest/java/org/opensearch/search/functionscore/QueryRescorerIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/functionscore/QueryRescorerIT.java
@@ -57,7 +57,13 @@ import org.opensearch.search.rescore.QueryRescorerBuilder;
 import org.opensearch.search.sort.SortBuilders;
 import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
 
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_REPLICAS;
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_SHARDS;
@@ -871,7 +877,8 @@ public class QueryRescorerIT extends ParameterizedStaticSettingsOpenSearchIntegT
         }
     }
 
-    record GroupDoc(String id, String group, float firstPassScore, float secondPassScore, boolean shouldFilter) {}
+    record GroupDoc(String id, String group, float firstPassScore, float secondPassScore, boolean shouldFilter) {
+    }
 
     public void testRescoreAfterCollapse() throws Exception {
         assertAcked(
@@ -897,10 +904,9 @@ public class QueryRescorerIT extends ParameterizedStaticSettingsOpenSearchIntegT
             new GroupDoc("4", "c", 1, 1000, false),
             // should be highest on rescore, but filtered out during collapse
             new GroupDoc("5", "a", 2, 20, false),
-            new GroupDoc("6", "b", 1, 40, false),
-        };
+            new GroupDoc("6", "b", 1, 40, false), };
         List<IndexRequestBuilder> requests = new ArrayList<>();
-        for (var doc: groupDocs) {
+        for (var doc : groupDocs) {
             requests.add(
                 client().prepareIndex("test")
                     .setId(doc.id())
@@ -922,9 +928,7 @@ public class QueryRescorerIT extends ParameterizedStaticSettingsOpenSearchIntegT
         SearchResponse searchResponse = client().prepareSearch("test")
             .setQuery(fieldValueScoreQuery("firstPassScore"))
             .setRescorer(
-                new QueryRescorerBuilder(
-                    fieldValueScoreQuery("secondPassScore")
-                ).setQueryWeight(1.0f)
+                new QueryRescorerBuilder(fieldValueScoreQuery("secondPassScore")).setQueryWeight(1.0f)
                     .setRescoreQueryWeight(1.0f)
                     .setScoreMode(QueryRescoreMode.Total)
             )
@@ -1018,9 +1022,7 @@ public class QueryRescorerIT extends ParameterizedStaticSettingsOpenSearchIntegT
         SearchResponse searchResponse = client().prepareSearch("test")
             .setQuery(fieldValueScoreQuery("firstPassScore"))
             .setRescorer(
-                new QueryRescorerBuilder(
-                    fieldValueScoreQuery("secondPassScore")
-                ).setQueryWeight(0f)
+                new QueryRescorerBuilder(fieldValueScoreQuery("secondPassScore")).setQueryWeight(0f)
                     .setRescoreQueryWeight(1.0f)
                     .windowSize(numGroups)
             )
@@ -1114,9 +1116,7 @@ public class QueryRescorerIT extends ParameterizedStaticSettingsOpenSearchIntegT
         SearchResponse searchResponse = client().prepareSearch("test")
             .setQuery(fieldValueScoreQuery("firstPassScore"))
             .setRescorer(
-                new QueryRescorerBuilder(
-                    fieldValueScoreQuery("secondPassScore")
-                ).setQueryWeight(0f)
+                new QueryRescorerBuilder(fieldValueScoreQuery("secondPassScore")).setQueryWeight(0f)
                     .setRescoreQueryWeight(1.0f)
                     .windowSize(numGroups)
             )
@@ -1135,9 +1135,8 @@ public class QueryRescorerIT extends ParameterizedStaticSettingsOpenSearchIntegT
     }
 
     private QueryBuilder fieldValueScoreQuery(String scoreField) {
-        return functionScoreQuery(
-            termQuery("shouldFilter", false),
-            ScoreFunctionBuilders.fieldValueFactorFunction(scoreField)
-        ).boostMode(CombineFunction.REPLACE);
+        return functionScoreQuery(termQuery("shouldFilter", false), ScoreFunctionBuilders.fieldValueFactorFunction(scoreField)).boostMode(
+            CombineFunction.REPLACE
+        );
     }
 }

--- a/server/src/main/java/org/opensearch/search/SearchService.java
+++ b/server/src/main/java/org/opensearch/search/SearchService.java
@@ -1761,9 +1761,6 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
                     );
                 }
             }
-            if (context.rescore() != null && context.rescore().isEmpty() == false) {
-                throw new SearchException(shardTarget, "cannot use `collapse` in conjunction with `rescore`");
-            }
             final CollapseContext collapseContext = source.collapse().build(queryShardContext);
             context.collapse(collapseContext);
         }

--- a/server/src/main/java/org/opensearch/search/query/TopDocsCollectorContext.java
+++ b/server/src/main/java/org/opensearch/search/query/TopDocsCollectorContext.java
@@ -855,27 +855,6 @@ public abstract class TopDocsCollectorContext extends QueryCollectorContext impl
                 trackTotalHitsUpTo,
                 hasFilterCollector
             );
-        } else if (searchContext.collapse() != null) {
-            int numDocs = Math.min(searchContext.from() + searchContext.size(), totalNumDocs);
-            final boolean rescore = searchContext.rescore().isEmpty() == false;
-            if (rescore) {
-                assert searchContext.sort() == null;
-                for (RescoreContext rescoreContext : searchContext.rescore()) {
-                    numDocs = Math.max(numDocs, rescoreContext.getWindowSize());
-                }
-            }
-            return new CollapsingTopDocsCollectorContext(
-                searchContext.collapse(),
-                searchContext.sort(),
-                numDocs,
-                searchContext.trackScores(),
-                searchContext.searchAfter()
-            ) {
-                @Override
-                public boolean shouldRescore() {
-                    return rescore;
-                }
-            };
         } else {
             int numDocs = Math.min(searchContext.from() + searchContext.size(), totalNumDocs);
             final boolean rescore = searchContext.rescore().isEmpty() == false;
@@ -885,21 +864,36 @@ public abstract class TopDocsCollectorContext extends QueryCollectorContext impl
                     numDocs = Math.max(numDocs, rescoreContext.getWindowSize());
                 }
             }
-            return new SimpleTopDocsCollectorContext(
-                reader,
-                query,
-                searchContext.sort(),
-                searchContext.searchAfter(),
-                numDocs,
-                searchContext.trackScores(),
-                searchContext.trackTotalHitsUpTo(),
-                hasFilterCollector
-            ) {
-                @Override
-                public boolean shouldRescore() {
-                    return rescore;
-                }
-            };
+            if (searchContext.collapse() != null) {
+                return new CollapsingTopDocsCollectorContext(
+                    searchContext.collapse(),
+                    searchContext.sort(),
+                    numDocs,
+                    searchContext.trackScores(),
+                    searchContext.searchAfter()
+                ) {
+                    @Override
+                    public boolean shouldRescore() {
+                        return rescore;
+                    }
+                };
+            } else {
+                return new SimpleTopDocsCollectorContext(
+                    reader,
+                    query,
+                    searchContext.sort(),
+                    searchContext.searchAfter(),
+                    numDocs,
+                    searchContext.trackScores(),
+                    searchContext.trackTotalHitsUpTo(),
+                    hasFilterCollector
+                ) {
+                    @Override
+                    public boolean shouldRescore() {
+                        return rescore;
+                    }
+                };
+            }
         }
     }
 

--- a/server/src/main/java/org/opensearch/search/query/TopDocsCollectorContext.java
+++ b/server/src/main/java/org/opensearch/search/query/TopDocsCollectorContext.java
@@ -857,13 +857,25 @@ public abstract class TopDocsCollectorContext extends QueryCollectorContext impl
             );
         } else if (searchContext.collapse() != null) {
             int numDocs = Math.min(searchContext.from() + searchContext.size(), totalNumDocs);
+            final boolean rescore = searchContext.rescore().isEmpty() == false;
+            if (rescore) {
+                assert searchContext.sort() == null;
+                for (RescoreContext rescoreContext : searchContext.rescore()) {
+                    numDocs = Math.max(numDocs, rescoreContext.getWindowSize());
+                }
+            }
             return new CollapsingTopDocsCollectorContext(
                 searchContext.collapse(),
                 searchContext.sort(),
                 numDocs,
                 searchContext.trackScores(),
                 searchContext.searchAfter()
-            );
+            ) {
+                @Override
+                public boolean shouldRescore() {
+                    return rescore;
+                }
+            };
         } else {
             int numDocs = Math.min(searchContext.from() + searchContext.size(), totalNumDocs);
             final boolean rescore = searchContext.rescore().isEmpty() == false;

--- a/server/src/main/java/org/opensearch/search/rescore/RescoreProcessor.java
+++ b/server/src/main/java/org/opensearch/search/rescore/RescoreProcessor.java
@@ -127,7 +127,9 @@ public class RescoreProcessor {
         FieldDoc[] newFieldDocs = new FieldDoc[rescoredTopDocs.scoreDocs.length];
         for (int i = 0; i < rescoredTopDocs.scoreDocs.length; i++) {
             ScoreDoc scoreDoc = rescoredTopDocs.scoreDocs[i];
-            assert snapShot.docIdToCollapseValue().containsKey(scoreDoc.doc) : "rescore must not introduce new docs";
+            if (!snapShot.docIdToCollapseValue().containsKey(scoreDoc.doc)) {
+                throw new IllegalStateException("rescore must not introduce new docs, but doc " + scoreDoc.doc + " was not in original results");
+            }
             newCollapseValues[i] = snapShot.docIdToCollapseValue().get(scoreDoc.doc);
             // Carry the rescored score in the sort value: CollapseTopFieldDocs.merge orders by FieldDoc.fields.
             newFieldDocs[i] = new FieldDoc(scoreDoc.doc, scoreDoc.score, new Object[] { scoreDoc.score });

--- a/server/src/main/java/org/opensearch/search/rescore/RescoreProcessor.java
+++ b/server/src/main/java/org/opensearch/search/rescore/RescoreProcessor.java
@@ -55,6 +55,9 @@ public class RescoreProcessor {
     /** Collapse information needed to rebuild a {@link CollapseTopFieldDocs} after rescoring. */
     private record CollapseSnapShot(String field, SortField[] sortFields, Map<Integer, Object> docIdToCollapseValue) {
         static CollapseSnapShot capture(CollapseTopFieldDocs docs) {
+            if (docs.scoreDocs.length != docs.collapseValues.length) {
+                throw new IllegalStateException("scoreDocs and collapseValues arrays must have the same length");
+            }
             Map<Integer, Object> map = new HashMap<>();
             for (int i = 0; i < docs.scoreDocs.length; i++) {
                 map.put(

--- a/server/src/main/java/org/opensearch/search/rescore/RescoreProcessor.java
+++ b/server/src/main/java/org/opensearch/search/rescore/RescoreProcessor.java
@@ -32,13 +32,18 @@
 
 package org.opensearch.search.rescore;
 
+import org.apache.lucene.search.FieldDoc;
 import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.grouping.CollapseTopFieldDocs;
 import org.opensearch.OpenSearchException;
 import org.opensearch.common.lucene.search.TopDocsAndMaxScore;
 import org.opensearch.search.internal.SearchContext;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * RescoreProcessor of a search request, used to run potentially expensive scoring models against the top matching documents.
@@ -47,10 +52,29 @@ import java.io.IOException;
  */
 public class RescoreProcessor {
 
+    /** Collapse information needed to rebuild a {@link CollapseTopFieldDocs} after rescoring. */
+    private record CollapseSnapShot(String field, SortField[] sortFields, Map<Integer, Object> docIdToCollapseValue) {
+        static CollapseSnapShot capture(CollapseTopFieldDocs docs) {
+            Map<Integer, Object> map = new HashMap<>();
+            for (int i = 0; i < docs.scoreDocs.length; i++) {
+                map.put(
+                    docs.scoreDocs[i].doc,
+                    docs.collapseValues[i]
+                );
+            }
+            return new CollapseSnapShot(docs.field, docs.fields, map);
+        }
+    }
+
     public void process(SearchContext context) {
         TopDocs topDocs = context.queryResult().topDocs().topDocs;
         if (topDocs.scoreDocs.length == 0) {
             return;
+        }
+        // Capture the collapse information before rescoring reorders the score docs in place.
+        CollapseSnapShot collapseSnapShot = null;
+        if (topDocs instanceof CollapseTopFieldDocs docs) {
+            collapseSnapShot = CollapseSnapShot.capture(docs);
         }
         try {
             for (RescoreContext ctx : context.rescore()) {
@@ -58,6 +82,13 @@ public class RescoreProcessor {
                 // It is the responsibility of the rescorer to sort the resulted top docs,
                 // here we only assert that this condition is met.
                 assert context.sort() == null && topDocsSortedByScore(topDocs) : "topdocs should be sorted after rescore";
+            }
+            // Rescoring drops the collapse information, so reconstruct the CollapseTopFieldDocs from the snapshot.
+            if (collapseSnapShot != null) {
+                topDocs = reconstructCollapseTopFieldDocs(
+                    collapseSnapShot,
+                    topDocs
+                );
             }
             context.queryResult()
                 .topDocs(new TopDocsAndMaxScore(topDocs, topDocs.scoreDocs[0].score), context.queryResult().sortValueFormats());
@@ -82,5 +113,31 @@ public class RescoreProcessor {
             lastScore = doc.score;
         }
         return true;
+    }
+
+    private static CollapseTopFieldDocs reconstructCollapseTopFieldDocs(
+        CollapseSnapShot snapShot,
+        TopDocs rescoredTopDocs
+    ) {
+        // collapse + rescore is always score-sorted (rescore cannot be combined with sort), so the sort value
+        // built below is a single score. This assertion guards that precondition.
+        assert snapShot.sortFields().length == 1 && SortField.FIELD_SCORE.equals(snapShot.sortFields()[0])
+            : "rescore must always sort by score descending";
+        Object[] newCollapseValues = new Object[rescoredTopDocs.scoreDocs.length];
+        FieldDoc[] newFieldDocs = new FieldDoc[rescoredTopDocs.scoreDocs.length];
+        for (int i = 0; i < rescoredTopDocs.scoreDocs.length; i++) {
+            ScoreDoc scoreDoc = rescoredTopDocs.scoreDocs[i];
+            assert snapShot.docIdToCollapseValue().containsKey(scoreDoc.doc) : "rescore must not introduce new docs";
+            newCollapseValues[i] = snapShot.docIdToCollapseValue().get(scoreDoc.doc);
+            // Carry the rescored score in the sort value: CollapseTopFieldDocs.merge orders by FieldDoc.fields.
+            newFieldDocs[i] = new FieldDoc(scoreDoc.doc, scoreDoc.score, new Object[] { scoreDoc.score });
+        }
+        return new CollapseTopFieldDocs(
+            snapShot.field(),
+            rescoredTopDocs.totalHits,
+            newFieldDocs,
+            snapShot.sortFields(),
+            newCollapseValues
+        );
     }
 }

--- a/server/src/main/java/org/opensearch/search/rescore/RescoreProcessor.java
+++ b/server/src/main/java/org/opensearch/search/rescore/RescoreProcessor.java
@@ -60,10 +60,7 @@ public class RescoreProcessor {
             }
             Map<Integer, Object> map = new HashMap<>();
             for (int i = 0; i < docs.scoreDocs.length; i++) {
-                map.put(
-                    docs.scoreDocs[i].doc,
-                    docs.collapseValues[i]
-                );
+                map.put(docs.scoreDocs[i].doc, docs.collapseValues[i]);
             }
             return new CollapseSnapShot(docs.field, docs.fields, map);
         }
@@ -88,10 +85,7 @@ public class RescoreProcessor {
             }
             // Rescoring drops the collapse information, so reconstruct the CollapseTopFieldDocs from the snapshot.
             if (collapseSnapShot != null) {
-                topDocs = reconstructCollapseTopFieldDocs(
-                    collapseSnapShot,
-                    topDocs
-                );
+                topDocs = reconstructCollapseTopFieldDocs(collapseSnapShot, topDocs);
             }
             context.queryResult()
                 .topDocs(new TopDocsAndMaxScore(topDocs, topDocs.scoreDocs[0].score), context.queryResult().sortValueFormats());
@@ -118,10 +112,7 @@ public class RescoreProcessor {
         return true;
     }
 
-    private static CollapseTopFieldDocs reconstructCollapseTopFieldDocs(
-        CollapseSnapShot snapShot,
-        TopDocs rescoredTopDocs
-    ) {
+    private static CollapseTopFieldDocs reconstructCollapseTopFieldDocs(CollapseSnapShot snapShot, TopDocs rescoredTopDocs) {
         // collapse + rescore is always score-sorted (rescore cannot be combined with sort), so the sort value
         // built below is a single score. This assertion guards that precondition.
         assert snapShot.sortFields().length == 1 && SortField.FIELD_SCORE.equals(snapShot.sortFields()[0])
@@ -131,7 +122,9 @@ public class RescoreProcessor {
         for (int i = 0; i < rescoredTopDocs.scoreDocs.length; i++) {
             ScoreDoc scoreDoc = rescoredTopDocs.scoreDocs[i];
             if (!snapShot.docIdToCollapseValue().containsKey(scoreDoc.doc)) {
-                throw new IllegalStateException("rescore must not introduce new docs, but doc " + scoreDoc.doc + " was not in original results");
+                throw new IllegalStateException(
+                    "rescore must not introduce new docs, but doc " + scoreDoc.doc + " was not in original results"
+                );
             }
             newCollapseValues[i] = snapShot.docIdToCollapseValue().get(scoreDoc.doc);
             // Carry the rescored score in the sort value: CollapseTopFieldDocs.merge orders by FieldDoc.fields.

--- a/server/src/test/java/org/opensearch/search/rescore/RescoreProcessorTests.java
+++ b/server/src/test/java/org/opensearch/search/rescore/RescoreProcessorTests.java
@@ -1,0 +1,227 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.rescore;
+
+import org.apache.lucene.search.Explanation;
+import org.apache.lucene.search.FieldDoc;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.SortField;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.TotalHits;
+import org.apache.lucene.search.grouping.CollapseTopFieldDocs;
+import org.opensearch.common.lucene.search.TopDocsAndMaxScore;
+import org.opensearch.search.DocValueFormat;
+import org.opensearch.search.internal.SearchContext;
+import org.opensearch.search.query.QuerySearchResult;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class RescoreProcessorTests extends OpenSearchTestCase {
+
+    private static final SortField[] SORT_BY_SCORE = new SortField[] { SortField.FIELD_SCORE };
+
+    /** Rescorer test double that returns a predefined {@link TopDocs} and records how many times it ran. */
+    private static class RecordingRescorer implements Rescorer {
+        private final TopDocs output;
+        int invocations = 0;
+
+        RecordingRescorer(TopDocs output) {
+            this.output = output;
+        }
+
+        @Override
+        public TopDocs rescore(TopDocs topDocs, IndexSearcher searcher, RescoreContext rescoreContext) {
+            invocations++;
+            return output;
+        }
+
+        @Override
+        public Explanation explain(
+            int topLevelDocId,
+            IndexSearcher searcher,
+            RescoreContext rescoreContext,
+            Explanation sourceExplanation
+        ) {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    private static SearchContext mockContext(QuerySearchResult queryResult, Rescorer rescorer) {
+        SearchContext context = mock(SearchContext.class);
+        when(context.queryResult()).thenReturn(queryResult);
+        when(context.rescore()).thenReturn(List.of(new RescoreContext(10, rescorer)));
+        // sort() defaults to null, which the in-process assertion requires for a rescore.
+        return context;
+    }
+
+    private static TopDocs scoreDocs(int totalHits, ScoreDoc... docs) {
+        return new TopDocs(new TotalHits(totalHits, TotalHits.Relation.EQUAL_TO), docs);
+    }
+
+    private static CollapseTopFieldDocs collapseDocs(String field, ScoreDoc[] docs, Object[] collapseValues) {
+        return new CollapseTopFieldDocs(
+            field,
+            new TotalHits(docs.length, TotalHits.Relation.EQUAL_TO),
+            docs,
+            SORT_BY_SCORE,
+            collapseValues
+        );
+    }
+
+    public void testEmptyTopDocsIsNoOpAndDoesNotRescore() {
+        QuerySearchResult queryResult = new QuerySearchResult();
+        TopDocs empty = scoreDocs(0);
+        queryResult.topDocs(new TopDocsAndMaxScore(empty, Float.NaN), new DocValueFormat[0]);
+
+        RecordingRescorer rescorer = new RecordingRescorer(scoreDocs(0));
+        new RescoreProcessor().process(mockContext(queryResult, rescorer));
+
+        assertEquals(0, rescorer.invocations);
+        assertSame(empty, queryResult.topDocs().topDocs);
+    }
+
+    public void testRescoreWithoutCollapseReplacesTopDocs() {
+        QuerySearchResult queryResult = new QuerySearchResult();
+        TopDocs original = scoreDocs(2, new ScoreDoc(1, 2.0f), new ScoreDoc(2, 1.0f));
+        queryResult.topDocs(new TopDocsAndMaxScore(original, 2.0f), new DocValueFormat[0]);
+
+        // Rescorer reorders the docs and bumps the scores; result stays sorted by score descending.
+        TopDocs rescored = scoreDocs(2, new ScoreDoc(2, 10.0f), new ScoreDoc(1, 4.0f));
+        RecordingRescorer rescorer = new RecordingRescorer(rescored);
+
+        new RescoreProcessor().process(mockContext(queryResult, rescorer));
+
+        assertEquals(1, rescorer.invocations);
+        TopDocs result = queryResult.topDocs().topDocs;
+        assertFalse(result instanceof CollapseTopFieldDocs);
+        assertSame(rescored, result);
+        assertEquals(10.0f, queryResult.topDocs().maxScore, 0.0f);
+    }
+
+    public void testRescoreAfterCollapseReconstructsCollapseTopFieldDocs() {
+        QuerySearchResult queryResult = new QuerySearchResult();
+        ScoreDoc[] collapsed = new ScoreDoc[] {
+            new FieldDoc(10, 5.0f, new Object[] { 5.0f }),
+            new FieldDoc(20, 3.0f, new Object[] { 3.0f }),
+            new FieldDoc(30, 1.0f, new Object[] { 1.0f }) };
+        Object[] collapseValues = new Object[] { "a", "b", "c" };
+        CollapseTopFieldDocs original = collapseDocs("group", collapsed, collapseValues);
+        // CollapseTopFieldDocs hits are FieldDocs, so a single sort value format is required.
+        queryResult.topDocs(new TopDocsAndMaxScore(original, 5.0f), new DocValueFormat[] { DocValueFormat.RAW });
+
+        // Rescoring drops collapse info and returns plain ScoreDocs in a new order.
+        TopDocs rescored = scoreDocs(3, new ScoreDoc(30, 9.0f), new ScoreDoc(10, 8.0f), new ScoreDoc(20, 2.0f));
+        RecordingRescorer rescorer = new RecordingRescorer(rescored);
+
+        new RescoreProcessor().process(mockContext(queryResult, rescorer));
+
+        assertEquals(1, rescorer.invocations);
+        TopDocs result = queryResult.topDocs().topDocs;
+        assertTrue(result instanceof CollapseTopFieldDocs);
+        CollapseTopFieldDocs collapseResult = (CollapseTopFieldDocs) result;
+        assertEquals("group", collapseResult.field);
+        assertArrayEquals(SORT_BY_SCORE, collapseResult.fields);
+
+        // For every hit: order follows the rescored docs, the original collapse value is preserved,
+        // and the rescored score is carried both as the score and as the sole sort value.
+        int[] expectedDocs = { 30, 10, 20 };
+        Object[] expectedCollapseValues = { "c", "a", "b" };
+        float[] expectedScores = { 9.0f, 8.0f, 2.0f };
+        assertEquals(expectedDocs.length, collapseResult.scoreDocs.length);
+        for (int i = 0; i < expectedDocs.length; i++) {
+            FieldDoc hit = (FieldDoc) collapseResult.scoreDocs[i];
+            assertEquals(expectedDocs[i], hit.doc);
+            assertEquals(expectedCollapseValues[i], collapseResult.collapseValues[i]);
+            assertEquals(expectedScores[i], hit.score, 0.0f);
+            assertEquals(1, hit.fields.length);
+            assertEquals(expectedScores[i], (float) hit.fields[0], 0.0f);
+        }
+        assertEquals(9.0f, queryResult.topDocs().maxScore, 0.0f);
+    }
+
+    public void testCaptureFailsWhenCollapseArrayLengthsMismatch() {
+        QuerySearchResult queryResult = new QuerySearchResult();
+        ScoreDoc[] collapsed = new ScoreDoc[] {
+            new FieldDoc(10, 2.0f, new Object[] { 2.0f }),
+            new FieldDoc(20, 1.0f, new Object[] { 1.0f }) };
+        // Deliberately mismatched: two hits but a single collapse value.
+        CollapseTopFieldDocs original = collapseDocs("group", collapsed, new Object[] { "a" });
+        queryResult.topDocs(new TopDocsAndMaxScore(original, 2.0f), new DocValueFormat[] { DocValueFormat.RAW });
+
+        RecordingRescorer rescorer = new RecordingRescorer(scoreDocs(0));
+        SearchContext context = mockContext(queryResult, rescorer);
+
+        IllegalStateException e = expectThrows(IllegalStateException.class, () -> new RescoreProcessor().process(context));
+        assertEquals("scoreDocs and collapseValues arrays must have the same length", e.getMessage());
+        assertEquals(0, rescorer.invocations);
+    }
+
+    public void testReconstructFailsWhenRescoreIntroducesUnknownDoc() {
+        QuerySearchResult queryResult = new QuerySearchResult();
+        ScoreDoc[] collapsed = new ScoreDoc[] {
+            new FieldDoc(10, 2.0f, new Object[] { 2.0f }),
+            new FieldDoc(20, 1.0f, new Object[] { 1.0f }) };
+        CollapseTopFieldDocs original = collapseDocs("group", collapsed, new Object[] { "a", "b" });
+        queryResult.topDocs(new TopDocsAndMaxScore(original, 2.0f), new DocValueFormat[] { DocValueFormat.RAW });
+
+        // Doc 99 was never part of the original results.
+        TopDocs rescored = scoreDocs(2, new ScoreDoc(99, 5.0f), new ScoreDoc(10, 4.0f));
+        RecordingRescorer rescorer = new RecordingRescorer(rescored);
+        SearchContext context = mockContext(queryResult, rescorer);
+
+        IllegalStateException e = expectThrows(IllegalStateException.class, () -> new RescoreProcessor().process(context));
+        assertEquals("rescore must not introduce new docs, but doc 99 was not in original results", e.getMessage());
+        // Unlike testCaptureFailsWhenCollapseArrayLengthsMismatch (which fails before rescoring),
+        // this failure happens during reconstruction, i.e. after rescoring ran.
+        assertEquals(1, rescorer.invocations);
+    }
+
+    public void testMultipleRescorersAreAppliedInOrder() {
+        QuerySearchResult queryResult = new QuerySearchResult();
+        TopDocs original = scoreDocs(2, new ScoreDoc(1, 2.0f), new ScoreDoc(2, 1.0f));
+        queryResult.topDocs(new TopDocsAndMaxScore(original, 2.0f), new DocValueFormat[0]);
+
+        TopDocs afterFirst = scoreDocs(2, new ScoreDoc(2, 6.0f), new ScoreDoc(1, 5.0f));
+        TopDocs afterSecond = scoreDocs(2, new ScoreDoc(1, 9.0f), new ScoreDoc(2, 7.0f));
+        RecordingRescorer first = new RecordingRescorer(afterFirst);
+        RecordingRescorer second = new RecordingRescorer(afterSecond);
+
+        SearchContext context = mock(SearchContext.class);
+        when(context.queryResult()).thenReturn(queryResult);
+        when(context.rescore()).thenReturn(List.of(new RescoreContext(10, first), new RescoreContext(10, second)));
+
+        new RescoreProcessor().process(context);
+
+        assertEquals(1, first.invocations);
+        assertEquals(1, second.invocations);
+        assertSame(afterSecond, queryResult.topDocs().topDocs);
+        assertEquals(9.0f, queryResult.topDocs().maxScore, 0.0f);
+    }
+
+    public void testNoRescorersLeavesTopDocsUnchanged() {
+        QuerySearchResult queryResult = new QuerySearchResult();
+        TopDocs original = scoreDocs(1, new ScoreDoc(1, 2.0f));
+        queryResult.topDocs(new TopDocsAndMaxScore(original, 2.0f), new DocValueFormat[0]);
+
+        SearchContext context = mock(SearchContext.class);
+        when(context.queryResult()).thenReturn(queryResult);
+        when(context.rescore()).thenReturn(Collections.emptyList());
+
+        new RescoreProcessor().process(context);
+
+        assertSame(original, queryResult.topDocs().topDocs);
+        assertEquals(2.0f, queryResult.topDocs().maxScore, 0.0f);
+    }
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

First of all, thank you to all the maintainers and contributors of OpenSearch. We use OpenSearch for the search system of our e-commerce platform, and it has been a huge help — this is my first attempt to give something back to the project.

To be upfront: as this is my first contribution, I used AI assistance to navigate and understand the codebase. That said, all of the source code changes in this PR were written by my own hand. I'd be grateful for your patience and guidance, and I'm happy to address any feedback.

> [!IMPORTANT]
> This PR is essentially a port of the `collapse` + `rescore` feature implemented in Elasticsearch (elastic/elasticsearch#107779).
>
> While porting it, I found a **cross-shard correctness issue**: when a collapse group's documents are spread across multiple shards, the group representative can be chosen incorrectly (see `Known limitation: groups spread across shards` below). 
> It has a clear mitigation (route by the collapse field, as the feature already recommends), and single-shard / non-rescore cases are unaffected.
>
> **I'd appreciate maintainer guidance before finalizing this:** is the known limitation (with the routing mitigation + a tracked follow-up) acceptable for this PR, or should the cross-shard fix land first / in the same PR?

### Description

This change adds support for using `rescore` in conjunction with `collapse` in search requests, which was previously rejected with `cannot use 'collapse' in conjunction with 'rescore'`.

Rescoring is applied to the top-ranked document per collapsed group on each shard. After rescoring, the collapse group information is reconstructed so that the coordinator-level merge (deduplication of groups across shards) and the `fields` output keep working as before.

This implements the same functionality that Elasticsearch added in elastic/elasticsearch#107779.

#### Semantics

- Rescoring runs per shard, on the top document of each collapsed group selected by the first-pass query.
- To guarantee that only one top document per collapse key is rescored globally, it is recommended to index documents using the collapse field value as the routing key (same recommendation as Elasticsearch documents for this feature).
- Rescorers are not applied to `inner_hits`.
- Since `rescore` cannot be combined with `sort` (existing restriction), `collapse` + `rescore` always operates on score-sorted hits.

#### Known limitation: groups spread across shards

When the documents of a single collapse group are **spread across multiple shards** (i.e. the collapse field is not used as the routing key), the group representative may be chosen incorrectly. This is reproduced by the integration test `testRescoreAfterCollapseGroupAcrossShards`.

**Root cause.** After rescoring, `RescoreProcessor` rebuilds the `CollapseTopFieldDocs` with the **rescored score** stored as the `FieldDoc` sort value, and the coordinator-level merge (`CollapseTopFieldDocs.merge`) deduplicates groups by that same value. So `CollapseTopFieldDocs` ends up using a single sort field for *both* the cross-shard group dedup (which should use the first-pass score) *and* the final ordering (which should use the rescored score). When a group spans shards, the representative is therefore picked by the rescored (second-pass) score instead of the first-pass score.


### Related Issues
Resolves #7484 
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
