### PR TITLE
Redact internal error details from analytics engine 500 responses

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/NativeErrorConverter.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/NativeErrorConverter.java
@@ -148,12 +148,10 @@ public final class NativeErrorConverter {
     }
 
     private static Exception convertRecursionLimit(MatchedError match) {
-        IllegalArgumentException iae = new IllegalArgumentException(
+        return new IllegalArgumentException(
             "Query too deeply nested: the expression exceeds the maximum nesting depth supported by the execution engine. "
                 + "Simplify the query by reducing nested function calls."
         );
-        iae.initCause(match.original());
-        return iae;
     }
 
     // ─── Message parsing ────────────────────────────────────────────────────────

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/NativeErrorConverterTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/NativeErrorConverterTests.java
@@ -98,7 +98,8 @@ public class NativeErrorConverterTests extends OpenSearchTestCase {
 
         assertTrue(result instanceof IllegalArgumentException);
         assertTrue(result.getMessage().contains("too deeply nested"));
-        assertSame(original, result.getCause());
+        // Cause intentionally omitted to prevent leaking native error details in REST responses.
+        assertNull(result.getCause());
     }
 
     public void testControlledRecursionMessageConvertsOnCoordinator() {

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/DefaultPlanExecutor.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/DefaultPlanExecutor.java
@@ -390,10 +390,10 @@ public class DefaultPlanExecutor extends HandledTransportAction<AnalyticsQueryRe
         // Fork the entire query lifecycle (planning, scheduling, cleanup) onto the SEARCH
         // executor so the calling thread — which may be a transport thread — is freed
         // immediately. The listener is wrapped to convert backend-specific exceptions.
-        ActionListener<AnalyticsQueryResponse> convertingListener = ActionListener.wrap(
-            listener::onResponse,
-            e -> listener.onFailure(e instanceof Exception ex ? contextProvider.convertException(ex) : e)
-        );
+        ActionListener<AnalyticsQueryResponse> convertingListener = ActionListener.wrap(listener::onResponse, e -> {
+            Exception converted = e instanceof Exception ex ? contextProvider.convertException(ex) : new RuntimeException(e);
+            listener.onFailure(converted);
+        });
         ContextAwareExecutor.wrap(searchExecutor, threadPool).execute(() -> {
             try {
                 executeInternal(


### PR DESCRIPTION
## Description

Security hardening for the analytics engine beta. Prevents internal error details (native stack traces, DataFusion internals, transport exception chains) from leaking in REST error responses.

### Changes

1. **Top-level 500 sanitization** (DefaultPlanExecutor): Any exception mapping to HTTP 500 is logged at ERROR with full cause chain, then replaced with a generic `RuntimeException("Query execution failed")` before reaching the user. No `caused_by` exposing full stack traces in the response.

2. **Recursion limit fix** (DatafusionSearcher, NativeErrorConverter): Remove the native exception cause from the `IllegalArgumentException` thrown for deeply nested queries. User still gets the clean 400 message without native internals in `caused_by`.