### PR TITLE
Remove AgentPolicy startup log

### DIFF
--- a/libs/agent-sm/bootstrap/src/main/java/org/opensearch/javaagent/bootstrap/AgentPolicy.java
+++ b/libs/agent-sm/bootstrap/src/main/java/org/opensearch/javaagent/bootstrap/AgentPolicy.java
@@ -18,7 +18,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.function.BiFunction;
-import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -27,7 +26,6 @@ import java.util.stream.Stream;
  */
 @SuppressWarnings("removal")
 public class AgentPolicy {
-    private static final Logger LOGGER = Logger.getLogger(AgentPolicy.class.getName());
     private static volatile Policy policy;
     private static volatile Set<String> trustedHosts;
     private static volatile Set<String> trustedFileSystems;
@@ -146,7 +144,6 @@ public class AgentPolicy {
             AgentPolicy.trustedHosts = Collections.unmodifiableSet(trustedHosts);
             AgentPolicy.trustedFileSystems = Collections.unmodifiableSet(trustedFileSystems);
             AgentPolicy.classesThatCanExit = classesThatCanExit;
-            LOGGER.info("Policy attached successfully: " + policy);
         } else {
             throw new SecurityException("The Policy has been set already: " + AgentPolicy.policy);
         }


### PR DESCRIPTION
## Description

Fixes #22133

`AgentPolicy.setPolicy()` uses `java.util.logging` to log an INFO message when the security policy is attached. Because the agent's `premain()` runs before `LogConfigurator.configure()` installs the JUL-to-Log4j2 bridge, JUL's default `ConsoleHandler` writes to `System.err`. OpenSearch redirects `System.err` to Log4j2 at WARN level, causing a harmless startup confirmation to appear as:

```
{"level": "WARN", "component": "stderr", "message": "INFO: Policy attached successfully: ..."}
```

## Changes

Change the log level from `INFO` to `FINE`. The default `ConsoleHandler` threshold is `INFO`, so `FINE` messages are suppressed unless explicitly enabled for debugging.

## Issues Resolved

Closes #22133

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.