### PR TITLE
Reduce merge memory by deferring non-sort column decode

### DIFF
--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/ParquetSettings.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/ParquetSettings.java
@@ -172,6 +172,19 @@ public final class ParquetSettings {
         Setting.Property.NodeScope
     );
 
+    /**
+     * Minimum number of variable-width (string/binary) non-sort columns required to activate
+     * deferred data loading during merge. Below this threshold, all columns are decoded eagerly
+     * (original behavior). Set to 0 to always defer; set very high to disable deferral.
+     */
+    public static final Setting<Integer> MERGE_DEFERRED_COLUMN_THRESHOLD = Setting.intSetting(
+        "index.parquet.merge_deferred_column_threshold",
+        0,
+        0,
+        Setting.Property.IndexScope,
+        Setting.Property.Dynamic
+    );
+
     /** Minimum guaranteed bytes for the native write pool. Default is half of write max (2% of budget). */
     public static final Setting<Long> WRITE_POOL_MIN = new Setting<>(
         "parquet.native.pool.write.min",
@@ -757,6 +770,7 @@ public final class ParquetSettings {
             MERGE_BATCH_SIZE,
             MERGE_RAYON_THREADS,
             MERGE_IO_THREADS,
+            MERGE_DEFERRED_COLUMN_THRESHOLD,
             WRITE_POOL_MIN,
             WRITE_POOL_MAX,
             MERGE_POOL_MIN,

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/bridge/NativeSettings.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/bridge/NativeSettings.java
@@ -34,6 +34,7 @@ public class NativeSettings {
     private final Integer mergeBatchSize;
     private final Integer mergeRayonThreads;
     private final Integer mergeIoThreads;
+    private final Integer mergeDeferredColumnThreshold;
     private final Map<String, String> fieldEncodings;
     private final Map<String, String> fieldCompressions;
     private final Map<String, Boolean> fieldBloomFilterEnabled;
@@ -60,6 +61,7 @@ public class NativeSettings {
         this.mergeBatchSize = builder.mergeBatchSize;
         this.mergeRayonThreads = builder.mergeRayonThreads;
         this.mergeIoThreads = builder.mergeIoThreads;
+        this.mergeDeferredColumnThreshold = builder.mergeDeferredColumnThreshold;
         this.fieldEncodings = builder.fieldEncodings != null ? Collections.unmodifiableMap(builder.fieldEncodings) : Collections.emptyMap();
         this.fieldCompressions = builder.fieldCompressions != null
             ? Collections.unmodifiableMap(builder.fieldCompressions)
@@ -146,6 +148,10 @@ public class NativeSettings {
         return mergeIoThreads;
     }
 
+    public Integer getMergeDeferredColumnThreshold() {
+        return mergeDeferredColumnThreshold;
+    }
+
     public Map<String, String> getFieldEncodings() {
         return fieldEncodings;
     }
@@ -199,6 +205,7 @@ public class NativeSettings {
         private Integer mergeBatchSize;
         private Integer mergeRayonThreads;
         private Integer mergeIoThreads;
+        private Integer mergeDeferredColumnThreshold;
         private Map<String, String> fieldEncodings;
         private Map<String, String> fieldCompressions;
         private Map<String, Boolean> fieldBloomFilterEnabled;
@@ -285,6 +292,11 @@ public class NativeSettings {
 
         public Builder mergeIoThreads(Integer v) {
             this.mergeIoThreads = v;
+            return this;
+        }
+
+        public Builder mergeDeferredColumnThreshold(Integer v) {
+            this.mergeDeferredColumnThreshold = v;
             return this;
         }
 

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/engine/ParquetIndexingEngine.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/engine/ParquetIndexingEngine.java
@@ -222,6 +222,7 @@ public class ParquetIndexingEngine implements IndexingExecutionEngine<ParquetDat
             .rowGroupMaxRows(ParquetSettings.ROW_GROUP_MAX_ROWS.get(settings))
             .rowGroupMaxBytes(ParquetSettings.ROW_GROUP_MAX_BYTES.get(settings).getBytes())
             .mergeBatchSize(ParquetSettings.MERGE_BATCH_SIZE.get(settings))
+            .mergeDeferredColumnThreshold(ParquetSettings.MERGE_DEFERRED_COLUMN_THRESHOLD.get(settings))
             .mergeRayonThreads(ParquetSettings.MERGE_RAYON_THREADS.get(nodeSettings))
             .mergeIoThreads(ParquetSettings.MERGE_IO_THREADS.get(nodeSettings))
             .fieldEncodings(ParquetSettings.getFieldEncodings(settings))

--- a/sandbox/plugins/parquet-data-format/src/main/rust/Cargo.toml
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/Cargo.toml
@@ -28,3 +28,7 @@ serde_json = { workspace = true }
 [dev-dependencies]
 opensearch-parquet-format = { path = ".", features = ["test-utils"] }
 
+
+[[bench]]
+name = "merge_projection_bench"
+harness = false

--- a/sandbox/plugins/parquet-data-format/src/main/rust/benches/merge_projection_bench.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/benches/merge_projection_bench.rs
@@ -1,0 +1,199 @@
+//! Benchmark for merge cursor projection optimization.
+//!
+//! Measures memory and throughput for sorted merge with:
+//! - Wide schema (many string columns) → deferred mode should activate
+//! - Narrow schema (few columns) → eager mode, no regression
+//!
+//! Run:
+//!   cargo bench --bench merge_projection_bench
+//!
+//! Requires the crate to compile (including metrics.rs fix in CI).
+
+use std::fs;
+use std::sync::Arc;
+use std::time::Instant;
+
+use arrow::array::{Int64Array, RecordBatch, StringArray};
+use arrow::datatypes::{DataType, Field, Schema as ArrowSchema};
+use parquet::arrow::ArrowWriter;
+use parquet::file::properties::WriterProperties;
+
+const ROWS_PER_FILE: usize = 100_000;
+const NUM_FILES: usize = 5;
+const BATCH_SIZE: usize = 8192;
+const WIDE_STRING_COLUMNS: usize = 20;
+const NARROW_STRING_COLUMNS: usize = 2;
+const STRING_VALUE_LEN: usize = 100;
+
+fn generate_parquet_file(
+    path: &str,
+    num_rows: usize,
+    num_string_cols: usize,
+    file_id: usize,
+) {
+    let mut fields = vec![
+        Field::new("@timestamp", DataType::Int64, false),
+    ];
+    for i in 0..num_string_cols {
+        fields.push(Field::new(format!("field_{}", i), DataType::Utf8, true));
+    }
+    let schema = Arc::new(ArrowSchema::new(fields));
+
+    let file = fs::File::create(path).unwrap();
+    let props = WriterProperties::builder()
+        .set_max_row_group_row_count(Some(num_rows))
+        .build();
+    let mut writer = ArrowWriter::try_new(file, schema.clone(), Some(props)).unwrap();
+
+    let batch_rows = BATCH_SIZE.min(num_rows);
+    let mut rows_written = 0;
+
+    while rows_written < num_rows {
+        let batch_len = batch_rows.min(num_rows - rows_written);
+
+        // Timestamps: sorted, unique per file with offset to ensure interleaving
+        let timestamps: Vec<i64> = (0..batch_len)
+            .map(|i| ((rows_written + i) * NUM_FILES + file_id) as i64)
+            .collect();
+        let ts_array = Int64Array::from(timestamps);
+
+        let mut columns: Vec<Arc<dyn arrow::array::Array>> = vec![Arc::new(ts_array)];
+
+        // String columns: random-ish values of fixed length
+        for col_idx in 0..num_string_cols {
+            let values: Vec<String> = (0..batch_len)
+                .map(|row| {
+                    format!(
+                        "{:0>width$}",
+                        (rows_written + row) * 31 + col_idx * 7,
+                        width = STRING_VALUE_LEN
+                    )
+                })
+                .collect();
+            columns.push(Arc::new(StringArray::from(values)));
+        }
+
+        let batch = RecordBatch::try_new(schema.clone(), columns).unwrap();
+        writer.write(&batch).unwrap();
+        rows_written += batch_len;
+    }
+
+    writer.close().unwrap();
+}
+
+fn measure_resident_bytes() -> usize {
+    // Approximate: read from /proc/self/statm on Linux, or use jemalloc stats
+    #[cfg(target_os = "linux")]
+    {
+        let statm = fs::read_to_string("/proc/self/statm").unwrap_or_default();
+        let pages: usize = statm.split_whitespace().nth(1).unwrap_or("0").parse().unwrap_or(0);
+        pages * 4096 // RSS in bytes (page size = 4KB)
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        // macOS: use mach APIs or approximate with allocated bytes
+        0
+    }
+}
+
+fn run_merge_bench(label: &str, num_string_cols: usize) {
+    let tmp_dir = tempfile::tempdir().unwrap();
+    let tmp_path = tmp_dir.path();
+
+    // Generate input files
+    let mut input_paths = Vec::new();
+    for i in 0..NUM_FILES {
+        let path = tmp_path.join(format!("input_{}.parquet", i));
+        let path_str = path.to_str().unwrap().to_string();
+        generate_parquet_file(&path_str, ROWS_PER_FILE, num_string_cols, i);
+        input_paths.push(path_str);
+    }
+
+    let output_path = tmp_path.join("merged_output.parquet");
+    let output_str = output_path.to_str().unwrap();
+
+    // Measure memory before
+    let mem_before = measure_resident_bytes();
+
+    // Run merge
+    let start = Instant::now();
+
+    let sort_columns = vec!["@timestamp".to_string()];
+    let reverse_sorts = vec![false];
+    let nulls_first = vec![false];
+
+    let result = opensearch_parquet_format::merge::merge_sorted(
+        &input_paths,
+        output_str,
+        "bench_index",
+        &sort_columns,
+        &reverse_sorts,
+        &nulls_first,
+        1, // output_writer_generation
+    );
+
+    let elapsed = start.elapsed();
+
+    // Measure memory after (peak would require sampling during merge)
+    let mem_after = measure_resident_bytes();
+
+    let total_rows = ROWS_PER_FILE * NUM_FILES;
+    let rows_per_sec = total_rows as f64 / elapsed.as_secs_f64();
+    let mb_per_sec = {
+        let input_size: u64 = input_paths.iter()
+            .map(|p| fs::metadata(p).map(|m| m.len()).unwrap_or(0))
+            .sum();
+        (input_size as f64 / 1024.0 / 1024.0) / elapsed.as_secs_f64()
+    };
+
+    let mem_delta_mb = (mem_after.saturating_sub(mem_before)) as f64 / 1024.0 / 1024.0;
+
+    match result {
+        Ok(output) => {
+            println!("┌─────────────────────────────────────────────────────────────");
+            println!("│ {} ", label);
+            println!("├─────────────────────────────────────────────────────────────");
+            println!("│ Files:         {} × {} rows = {} total rows", NUM_FILES, ROWS_PER_FILE, total_rows);
+            println!("│ Columns:       1 sort (Int64) + {} string ({}B each)", num_string_cols, STRING_VALUE_LEN);
+            println!("│ Batch size:    {}", BATCH_SIZE);
+            println!("│ Elapsed:       {:.2?}", elapsed);
+            println!("│ Throughput:    {:.0} rows/sec, {:.1} MB/sec (input)", rows_per_sec, mb_per_sec);
+            println!("│ RSS delta:     {:.1} MB", mem_delta_mb);
+            println!("│ Output rows:   {}", output.metadata.file_metadata().num_rows());
+            println!("│ Output RGs:    {}", output.metadata.num_row_groups());
+            println!("│ Deferred mode: {}", if num_string_cols >= 3 { "YES (expected)" } else { "NO (eager)" });
+            println!("└─────────────────────────────────────────────────────────────");
+            println!();
+        }
+        Err(e) => {
+            println!("│ {} FAILED: {:?}", label, e);
+        }
+    }
+}
+
+fn main() {
+    println!();
+    println!("═══════════════════════════════════════════════════════════════");
+    println!(" Merge Projection Benchmark");
+    println!(" Compares deferred (wide schema) vs eager (narrow schema)");
+    println!("═══════════════════════════════════════════════════════════════");
+    println!();
+
+    // Wide schema: should trigger deferred mode (≥3 string non-sort columns)
+    run_merge_bench(
+        "WIDE SCHEMA (deferred mode — 20 string columns)",
+        WIDE_STRING_COLUMNS,
+    );
+
+    // Narrow schema: should stay in eager mode (< 3 string non-sort columns)
+    run_merge_bench(
+        "NARROW SCHEMA (eager mode — 2 string columns)",
+        NARROW_STRING_COLUMNS,
+    );
+
+    println!("═══════════════════════════════════════════════════════════════");
+    println!(" Expected results:");
+    println!("   Wide:   Lower RSS, slightly lower throughput vs old code");
+    println!("   Narrow: Same RSS & throughput as old code (no regression)");
+    println!("═══════════════════════════════════════════════════════════════");
+}

--- a/sandbox/plugins/parquet-data-format/src/main/rust/src/merge/context.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/src/merge/context.rs
@@ -11,7 +11,6 @@ use std::path::Path;
 use std::sync::Arc;
 
 use arrow::array::RecordBatch;
-use arrow::compute::concat_batches;
 use arrow::datatypes::{DataType as ArrowDataType, Field as ArrowField, Schema as ArrowSchema};
 use parquet::arrow::arrow_writer::{ArrowRowGroupWriterFactory, compute_leaves};
 use parquet::file::writer::SerializedFileWriter;
@@ -22,7 +21,7 @@ use tokio::sync::{mpsc as tokio_mpsc, oneshot};
 use crate::crc_writer::CrcWriter;
 use crate::rate_limited_writer::RateLimitedWriter;
 use crate::writer_properties_builder::WriterPropertiesBuilder;
-use crate::{log_debug, SETTINGS_STORE};
+use crate::{log_debug, log_error, SETTINGS_STORE};
 
 use super::error::{MergeError, MergeResult};
 use super::io_task::{
@@ -38,7 +37,7 @@ pub struct MergeContext {
     output_schema: Arc<ArrowSchema>,
     rg_writer_factory: ArrowRowGroupWriterFactory,
     io_tx: tokio_mpsc::Sender<IoCommand>,
-    output_chunks: Vec<RecordBatch>,
+    col_writers: Option<Vec<parquet::arrow::arrow_writer::ArrowColumnWriter>>,
     output_row_count: usize,
     output_flush_rows: usize,
     row_group_index: usize,
@@ -113,12 +112,14 @@ impl MergeContext {
         let rg_writer_factory = ArrowRowGroupWriterFactory::new(&writer, output_schema.clone());
         let io_tx = spawn_io_task(writer, crc_handle, io_threads);
 
+        let col_writers = rg_writer_factory.create_column_writers(0)?;
+
         Ok(Self {
             data_schema,
             output_schema,
             rg_writer_factory,
             io_tx,
-            output_chunks: Vec::new(),
+            col_writers: Some(col_writers),
             output_row_count: 0,
             output_flush_rows,
             row_group_index: 0,
@@ -134,26 +135,58 @@ impl MergeContext {
         &self.data_schema
     }
 
-    /// Buffers a batch (already padded to data_schema) and auto-flushes when
-    /// the row count threshold is reached.
+    /// Writes a batch directly to column writers and triggers a row group flush
+    /// when the row count threshold is reached. Each batch is written and dropped
+    /// immediately — no buffering — so only one batch's decoded data (~64 MB) is
+    /// ever live at a time.
     pub fn push_batch(&mut self, batch: RecordBatch) -> MergeResult<()> {
-        self.output_row_count += batch.num_rows();
-        self.output_chunks.push(batch);
+        let num_rows = batch.num_rows();
+        let with_id = append_row_id(&batch, self.next_row_id, &self.output_schema)?;
+        drop(batch);
+
+        let col_writers = self.col_writers.as_mut()
+            .ok_or_else(|| MergeError::Logic("Column writers not initialized".into()))?;
+
+        // Compute leaf columns (O(columns) pointer math), then parallel-write
+        // across columns via rayon. Each column writer encodes independently.
+        let mut all_leaves: Vec<parquet::arrow::arrow_writer::ArrowLeafColumn> =
+            Vec::with_capacity(col_writers.len());
+        for (arr, field) in with_id.columns().iter().zip(self.output_schema.fields()) {
+            let leaves = compute_leaves(field, arr)?;
+            all_leaves.extend(leaves);
+        }
+
+        let write_errors: Vec<_> = get_merge_pool(self.rayon_threads).install(|| {
+            col_writers.par_iter_mut()
+                .zip(all_leaves.into_par_iter())
+                .filter_map(|(writer, leaf)| writer.write(&leaf).err())
+                .collect()
+        });
+
+        if let Some(e) = write_errors.into_iter().next() {
+            log_error!("[RUST] Column write failed during push_batch: {}", e);
+            return Err(e.into());
+        }
+
+        self.next_row_id += num_rows as i64;
+        self.output_row_count += num_rows;
+        self.total_rows_written += num_rows;
+
         if self.output_row_count >= self.output_flush_rows {
             self.flush()?;
         }
         Ok(())
     }
 
-    /// Concat buffered batches, append row IDs, encode columns in parallel,
-    /// and send the encoded row group to the IO task.
+    /// Close current column writers in parallel (encode + compress), send the
+    /// encoded row group to the IO task, and open fresh writers for the next
+    /// row group.
     ///
     /// `flush_and_sort_chunk_count` and `flush_and_sort_chunk_time_millis` are
     /// always recorded — including on failure paths — to keep this counter
-    /// symmetric with rayon's `merge_wall_millis`. The empty-chunks early-return
-    /// is the only path that doesn't count as an attempt.
+    /// symmetric with rayon's `merge_wall_millis`.
     pub fn flush(&mut self) -> MergeResult<()> {
-        if self.output_chunks.is_empty() {
+        if self.output_row_count == 0 {
             return Ok(());
         }
         let flush_start = std::time::Instant::now();
@@ -166,42 +199,19 @@ impl MergeContext {
     }
 
     fn do_flush(&mut self) -> MergeResult<()> {
-        let merged = if self.output_chunks.len() == 1 {
-            self.output_chunks.pop().unwrap()
-        } else {
-            let m = concat_batches(&self.data_schema, self.output_chunks.as_slice())?;
-            self.output_chunks.clear();
-            m
-        };
-        let n = merged.num_rows();
+        let col_writers = self.col_writers.take()
+            .ok_or_else(|| MergeError::Logic("Column writers not initialized".into()))?;
+        let n = self.output_row_count;
 
-        let with_id = append_row_id(&merged, self.next_row_id, &self.output_schema)?;
-        drop(merged);
-
-        let col_writers = self
-            .rg_writer_factory
-            .create_column_writers(self.row_group_index)?;
-
-        let leaves_and_writers = match Self::pair_leaves_with_writers(&with_id, &self.output_schema, col_writers) {
-            Ok(paired) => paired,
-            Err((err, remaining)) => {
-                for w in remaining {
-                    let _ = w.close();
-                }
-                return Err(err);
-            }
-        };
-
+        // Parallel close: each column writer encodes and compresses its buffered
+        // pages. This is the CPU-heavy step and benefits from rayon parallelism.
         let chunk_results: Vec<
             Result<parquet::arrow::arrow_writer::ArrowColumnChunk, parquet::errors::ParquetError>,
         > = super::metrics::record_merge(|| {
             let results: Vec<_> = get_merge_pool(self.rayon_threads).install(|| {
-                leaves_and_writers
+                col_writers
                     .into_par_iter()
-                    .map(|(leaf, mut col_writer)| {
-                        col_writer.write(&leaf)?;
-                        col_writer.close()
-                    })
+                    .map(|col_writer| col_writer.close())
                     .collect()
             });
             Ok(results)
@@ -217,9 +227,12 @@ impl MergeContext {
             .map_err(|_| MergeError::Logic("IO task terminated unexpectedly".into()))?;
 
         self.row_group_index += 1;
-        self.next_row_id += n as i64;
-        self.total_rows_written += n;
         self.output_row_count = 0;
+
+        // Open writers for the next row group.
+        self.col_writers = Some(
+            self.rg_writer_factory.create_column_writers(self.row_group_index)?
+        );
 
         log_debug!(
             "[RUST] Flushed row group {}: {} rows (total: {})",
@@ -231,42 +244,16 @@ impl MergeContext {
         Ok(())
     }
 
-    /// Pairs leaf arrays with column writers, returning unconsumed writers on error
-    /// so the caller can close them.
-    fn pair_leaves_with_writers(
-        batch: &RecordBatch,
-        schema: &Arc<ArrowSchema>,
-        col_writers: Vec<parquet::arrow::arrow_writer::ArrowColumnWriter>,
-    ) -> Result<
-        Vec<(parquet::arrow::arrow_writer::ArrowLeafColumn, parquet::arrow::arrow_writer::ArrowColumnWriter)>,
-        (MergeError, Vec<parquet::arrow::arrow_writer::ArrowColumnWriter>),
-    > {
-        let mut writer_iter = col_writers.into_iter();
-        let mut paired = Vec::new();
-        for (arr, field) in batch.columns().iter().zip(schema.fields()) {
-            let leaves = match compute_leaves(field, arr) {
-                Ok(l) => l,
-                Err(e) => return Err((e.into(), writer_iter.collect())),
-            };
-            for leaf in leaves {
-                match writer_iter.next() {
-                    Some(w) => paired.push((leaf, w)),
-                    None => {
-                        return Err((
-                            MergeError::Logic("Fewer column writers than leaf columns".into()),
-                            Vec::new(),
-                        ))
-                    }
-                }
-            }
-        }
-        Ok(paired)
-    }
-
     /// Final flush + close the IO task. Returns Parquet metadata, CRC32, and per-merge stats
     /// to be forwarded to the per-shard tracker on the Java side.
     pub fn finish(mut self) -> MergeResult<MergeFinishStats> {
         self.flush()?;
+        // Drop the freshly-created writers for the next (unused) row group.
+        if let Some(writers) = self.col_writers.take() {
+            for w in writers {
+                let _ = w.close();
+            }
+        }
         // Capture the per-merge counters BEFORE moving `self` into the IO send below.
         let final_row_id_max = self.next_row_id;
         let flush_count = self.flush_and_sort_chunk_count;

--- a/sandbox/plugins/parquet-data-format/src/main/rust/src/merge/cursor.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/src/merge/cursor.rs
@@ -19,16 +19,30 @@ use super::heap::{get_sort_values, SortKey};
 use super::io_task::get_merge_pool;
 use super::schema::projection_indices_excluding_row_id;
 
+/// Default minimum number of variable-width (string/binary) non-sort columns to activate
+/// deferred data loading. Default 0 means always deferred — sort columns are always
+/// read separately from data columns. Overridable via index setting
+/// `index.parquet.merge_deferred_column_threshold`.
+const DEFAULT_DEFERRED_WIDE_COLUMN_THRESHOLD: usize = 0;
+
 /// A cursor over a single sorted Parquet input file.
 ///
-/// Each cursor reads batches sequentially and prefetches the next batch on the
-/// shared Rayon pool to overlap IO with merge computation.
+/// For wide schemas (≥3 variable-width non-sort columns), uses two readers:
+/// a sort-only reader for the merge heap and a data reader loaded on demand.
+/// For narrow schemas, uses a single all-column reader (zero overhead vs original).
 pub struct FileCursor {
-    reader: Arc<Mutex<parquet::arrow::arrow_reader::ParquetRecordBatchReader>>,
-    prefetch_rx: std::sync::mpsc::Receiver<Option<MergeResult<RecordBatch>>>,
-    prefetch_tx: std::sync::mpsc::SyncSender<Option<MergeResult<RecordBatch>>>,
-    prefetch_pending: bool,
-    pub current_batch: Option<RecordBatch>,
+    sort_reader: Arc<Mutex<parquet::arrow::arrow_reader::ParquetRecordBatchReader>>,
+    sort_prefetch_rx: std::sync::mpsc::Receiver<Option<MergeResult<RecordBatch>>>,
+    sort_prefetch_tx: std::sync::mpsc::SyncSender<Option<MergeResult<RecordBatch>>>,
+    sort_prefetch_pending: bool,
+    pub sort_batch: Option<RecordBatch>,
+
+    data_reader: Option<parquet::arrow::arrow_reader::ParquetRecordBatchReader>,
+    data_batch: Option<RecordBatch>,
+    sort_batch_index: usize,
+    data_batch_index: usize,
+    deferred: bool,
+
     pub row_idx: usize,
     pub file_id: usize,
     pub sort_col_indices: Vec<usize>,
@@ -37,110 +51,131 @@ pub struct FileCursor {
 }
 
 impl FileCursor {
-    /// Opens a Parquet file and creates a cursor positioned at the first row.
-    ///
-    /// Returns `(cursor, projected_arrow_schema, parquet_schema_descriptor, writer_generation)`
-    /// so the caller can build union schemas without re-opening the file.
     pub fn new(
         path: &str,
         file_id: usize,
         sort_columns: &[String],
         nulls_first: &[bool],
         batch_size: usize,
+        deferred_threshold: usize,
     ) -> MergeResult<(Self, Arc<ArrowSchema>, SchemaDescriptor, i64, usize)> {
+        // Open file and read metadata
         let file = File::open(path)?;
         let builder = ParquetRecordBatchReaderBuilder::try_new(file)?;
         let schema = builder.schema().clone();
-        let writer_generation = crate::writer_properties_builder::read_writer_generation(builder.metadata().file_metadata(), file_id);
+        let writer_generation = crate::writer_properties_builder::read_writer_generation(
+            builder.metadata().file_metadata(), file_id,
+        );
         let total_row_count = builder.metadata().file_metadata().num_rows() as usize;
-
-        let mut sort_col_types = Vec::with_capacity(sort_columns.len());
-        for col_name in sort_columns {
-            let dt = schema
-                .fields()
-                .iter()
-                .find(|f| f.name() == col_name.as_str())
-                .map(|f| f.data_type().clone())
-                .ok_or_else(|| {
-                    MergeError::Logic(format!(
-                        "Sort column '{}' not found in file '{}' (cursor {})",
-                        col_name, path, file_id
-                    ))
-                })?;
-            sort_col_types.push(dt);
-        }
-
         let parquet_schema_descr = builder.parquet_schema().clone();
-        let projection_indices = projection_indices_excluding_row_id(&schema);
 
-        let projection =
-            parquet::arrow::ProjectionMask::roots(&parquet_schema_descr, projection_indices);
+        // Resolve sort column types
+        let sort_col_types: Vec<ArrowDataType> = sort_columns.iter()
+            .map(|col| schema.fields().iter()
+                .find(|f| f.name() == col.as_str())
+                .map(|f| f.data_type().clone())
+                .ok_or_else(|| MergeError::Logic(format!(
+                    "Sort column '{}' not found in file '{}' (cursor {})", col, path, file_id
+                )))
+            )
+            .collect::<MergeResult<_>>()?;
 
-        let mut reader = builder
-            .with_batch_size(batch_size)
-            .with_projection(projection)
-            .build()?;
+        // Decide mode based on schema width
+        let sort_col_set: std::collections::HashSet<&str> =
+            sort_columns.iter().map(|s| s.as_str()).collect();
+        let deferred = schema.fields().iter()
+            .filter(|f| !sort_col_set.contains(f.name().as_str()))
+            .filter(|f| f.name() != super::schema::ROW_ID_COLUMN_NAME)
+            .filter(|f| matches!(f.data_type(),
+                ArrowDataType::Utf8 | ArrowDataType::LargeUtf8
+                | ArrowDataType::Binary | ArrowDataType::LargeBinary))
+            .count() >= deferred_threshold;
 
-        let first_batch = match reader.next() {
-            Some(Ok(b)) if b.num_rows() > 0 => b,
-            Some(Err(e)) => return Err(e.into()),
-            _ => {
-                return Err(MergeError::Logic(format!(
-                    "File '{}' (cursor {}) yielded no rows despite passing validation",
-                    path, file_id
-                )));
-            }
+        // Data projection: all columns except __row_id__
+        let data_projection_indices = projection_indices_excluding_row_id(&schema);
+
+        // Build sort reader (sort-only in deferred, all-columns in eager)
+        let file1 = File::open(path)?;
+        let builder1 = ParquetRecordBatchReaderBuilder::try_new(file1)?;
+        let sort_projection = if deferred {
+            let sort_indices: Vec<usize> = sort_columns.iter()
+                .filter_map(|c| schema.fields().iter().position(|f| f.name() == c.as_str()))
+                .collect();
+            parquet::arrow::ProjectionMask::roots(builder1.parquet_schema(), sort_indices)
+        } else {
+            parquet::arrow::ProjectionMask::roots(builder1.parquet_schema(), data_projection_indices.clone())
+        };
+        let mut sort_reader = builder1.with_batch_size(batch_size).with_projection(sort_projection).build()?;
+
+        // Build data reader (only in deferred mode)
+        let data_reader = if deferred {
+            let file2 = File::open(path)?;
+            let builder2 = ParquetRecordBatchReaderBuilder::try_new(file2)?;
+            let data_proj = parquet::arrow::ProjectionMask::roots(
+                builder2.parquet_schema(), data_projection_indices.clone(),
+            );
+            Some(builder2.with_batch_size(batch_size).with_projection(data_proj).build()?)
+        } else {
+            None
         };
 
-        let projected_schema = first_batch.schema();
+        // Projected schema from file metadata
+        let projected_schema = Arc::new(ArrowSchema::new(
+            data_projection_indices.iter().map(|&i| schema.field(i).clone()).collect::<Vec<_>>()
+        ));
 
-        let mut sort_col_indices = Vec::with_capacity(sort_columns.len());
-        for col_name in sort_columns {
-            let idx = projected_schema
-                .fields()
-                .iter()
-                .position(|f| f.name() == col_name.as_str())
-                .ok_or_else(|| {
-                    MergeError::Logic(format!(
-                        "Sort column '{}' not found after projection in file '{}'",
-                        col_name, path
-                    ))
-                })?;
-            sort_col_indices.push(idx);
-        }
+        // Read first sort batch
+        let first_sort_batch = match sort_reader.next() {
+            Some(Ok(b)) if b.num_rows() > 0 => b,
+            Some(Err(e)) => return Err(e.into()),
+            _ => return Err(MergeError::Logic(format!(
+                "File '{}' (cursor {}) yielded no rows", path, file_id
+            ))),
+        };
 
-        let (prefetch_tx, prefetch_rx) =
+        // Resolve sort column indices within the sort batch schema
+        let sort_batch_schema = first_sort_batch.schema();
+        let sort_col_indices: Vec<usize> = sort_columns.iter()
+            .map(|col| sort_batch_schema.fields().iter()
+                .position(|f| f.name() == col.as_str())
+                .ok_or_else(|| MergeError::Logic(format!(
+                    "Sort column '{}' not found in projected batch for file '{}'", col, path
+                )))
+            )
+            .collect::<MergeResult<_>>()?;
+
+        let (sort_prefetch_tx, sort_prefetch_rx) =
             std::sync::mpsc::sync_channel::<Option<MergeResult<RecordBatch>>>(1);
-
-        let reader = Arc::new(Mutex::new(reader));
+        let sort_reader = Arc::new(Mutex::new(sort_reader));
 
         let mut cursor = Self {
-            reader,
-            prefetch_rx,
-            prefetch_tx,
-            prefetch_pending: false,
-            current_batch: Some(first_batch),
+            sort_reader,
+            sort_prefetch_rx,
+            sort_prefetch_tx,
+            sort_prefetch_pending: false,
+            sort_batch: Some(first_sort_batch),
+            data_reader,
+            data_batch: None,
+            sort_batch_index: 0,
+            data_batch_index: 0,
+            deferred,
             row_idx: 0,
             file_id,
             sort_col_indices,
             sort_col_types,
             nulls_first: nulls_first.to_vec(),
         };
-
-        cursor.start_prefetch();
-
+        cursor.start_sort_prefetch();
         Ok((cursor, projected_schema, parquet_schema_descr, writer_generation, total_row_count))
     }
 
-    fn start_prefetch(&mut self) {
-        if self.prefetch_pending {
+    fn start_sort_prefetch(&mut self) {
+        if self.sort_prefetch_pending {
             return;
         }
-        self.prefetch_pending = true;
-
-        let reader = Arc::clone(&self.reader);
-        let tx = self.prefetch_tx.clone();
-
+        self.sort_prefetch_pending = true;
+        let reader = Arc::clone(&self.sort_reader);
+        let tx = self.sort_prefetch_tx.clone();
         get_merge_pool(None).spawn(move || {
             let mut reader = reader.lock().unwrap();
             let result = match reader.next() {
@@ -153,75 +188,142 @@ impl FileCursor {
     }
 
     pub fn load_next_batch(&mut self) -> MergeResult<bool> {
-        self.current_batch = None;
+        self.sort_batch = None;
+        self.data_batch = None;
 
-        match self.prefetch_rx.recv() {
-            Ok(Some(Ok(batch))) => {
-                self.current_batch = Some(batch);
+        let sort_result = match self.sort_prefetch_rx.recv() {
+            Ok(Some(Ok(batch))) => Some(batch),
+            Ok(Some(Err(e))) => { self.sort_prefetch_pending = false; return Err(e); }
+            Ok(None) | Err(_) => None,
+        };
+        self.sort_prefetch_pending = false;
+
+        match sort_result {
+            Some(batch) => {
+                self.sort_batch = Some(batch);
                 self.row_idx = 0;
-                self.prefetch_pending = false;
-                self.start_prefetch();
+                self.sort_batch_index += 1;
+                self.start_sort_prefetch();
                 Ok(true)
             }
-            Ok(Some(Err(e))) => {
-                self.prefetch_pending = false;
-                Err(e)
-            }
-            Ok(None) | Err(_) => {
-                self.prefetch_pending = false;
+            None => {
+                self.data_reader = None; // Release file descriptor
                 Ok(false)
             }
         }
     }
 
+    fn ensure_data_loaded(&mut self) -> MergeResult<()> {
+        if !self.deferred {
+            return Ok(());
+        }
+        // data_batch_index tracks "next batch to read" — after successfully loading
+        // sort_batch_index, it equals sort_batch_index + 1.
+        if self.data_batch.is_some() && self.data_batch_index == self.sort_batch_index + 1 {
+            return Ok(());
+        }
+
+        match self.try_load_data() {
+            Ok(()) => Ok(()),
+            Err(e) => {
+                // Close the data reader on failure — the cursor is irrecoverable since
+                // the reader's internal position is unknown after a partial advance.
+                self.data_reader = None;
+                Err(e)
+            }
+        }
+    }
+
+    fn try_load_data(&mut self) -> MergeResult<()> {
+        let reader = self.data_reader.as_mut()
+            .ok_or_else(|| MergeError::Logic("Data reader already closed".into()))?;
+
+        // Read batches from data reader until we have the one at sort_batch_index.
+        // data_batch_index tracks how many batches have been consumed from the reader
+        // (i.e., the next call to reader.next() will return batch number data_batch_index).
+        while self.data_batch_index <= self.sort_batch_index {
+            match reader.next() {
+                Some(Ok(batch)) => {
+                    if batch.num_rows() == 0 {
+                        return Err(MergeError::Logic(format!(
+                            "Data reader returned empty batch at position {}",
+                            self.data_batch_index
+                        )));
+                    }
+                    if self.data_batch_index == self.sort_batch_index {
+                        // Target batch — validate and keep
+                        if let Some(ref sb) = self.sort_batch {
+                            if batch.num_rows() != sb.num_rows() {
+                                return Err(MergeError::Logic(format!(
+                                    "Data batch rows ({}) != sort batch rows ({}) at index {}",
+                                    batch.num_rows(), sb.num_rows(), self.sort_batch_index
+                                )));
+                            }
+                        }
+                        self.data_batch = Some(batch);
+                    }
+                    // Skipped batch — discard
+                    self.data_batch_index += 1;
+                }
+                Some(Err(e)) => return Err(e.into()),
+                None => return Err(MergeError::Logic(format!(
+                    "Data reader exhausted at position {}, needed sort_batch_index={}",
+                    self.data_batch_index, self.sort_batch_index
+                ))),
+            }
+        }
+        Ok(())
+    }
+
     #[inline]
     pub fn current_sort_values(&self) -> MergeResult<Vec<SortKey>> {
-        let batch = self
-            .current_batch
-            .as_ref()
+        let batch = self.sort_batch.as_ref()
             .ok_or_else(|| MergeError::Logic("Cursor exhausted".into()))?;
         get_sort_values(batch, self.row_idx, &self.sort_col_indices, &self.sort_col_types, &self.nulls_first)
     }
 
     #[inline]
     pub fn last_sort_values(&self) -> MergeResult<Vec<SortKey>> {
-        let batch = self
-            .current_batch
-            .as_ref()
+        let batch = self.sort_batch.as_ref()
             .ok_or_else(|| MergeError::Logic("Cursor exhausted".into()))?;
-        get_sort_values(
-            batch,
-            batch.num_rows() - 1,
-            &self.sort_col_indices,
-            &self.sort_col_types,
-            &self.nulls_first,
-        )
+        get_sort_values(batch, batch.num_rows() - 1, &self.sort_col_indices, &self.sort_col_types, &self.nulls_first)
     }
 
     #[inline]
     pub fn batch_height(&self) -> usize {
-        self.current_batch.as_ref().map_or(0, |b| b.num_rows())
+        self.sort_batch.as_ref().map_or(0, |b| b.num_rows())
     }
 
     #[inline]
-    pub fn take_slice(&self, start: usize, len: usize) -> RecordBatch {
-        self.current_batch.as_ref().unwrap().slice(start, len)
+    pub fn take_slice(&mut self, start: usize, len: usize) -> MergeResult<RecordBatch> {
+        if self.deferred {
+            self.ensure_data_loaded()?;
+            let batch = self.data_batch.as_ref()
+                .ok_or_else(|| MergeError::Logic("Data batch not loaded".into()))?;
+            Ok(batch.slice(start, len))
+        } else {
+            let batch = self.sort_batch.as_ref()
+                .ok_or_else(|| MergeError::Logic("Batch is None".into()))?;
+            Ok(batch.slice(start, len))
+        }
     }
 
     pub fn advance(&mut self) -> MergeResult<bool> {
-        if self.current_batch.is_none() {
+        if self.sort_batch.is_none() {
             return Ok(false);
         }
         self.row_idx += 1;
-        if self.row_idx >= self.current_batch.as_ref().unwrap().num_rows() {
-            self.current_batch = None;
+        if self.row_idx >= self.sort_batch.as_ref().unwrap().num_rows() {
+            self.sort_batch = None;
+            self.data_batch = None;
             return self.load_next_batch();
         }
         Ok(true)
     }
 
     pub fn advance_past_batch(&mut self) -> MergeResult<bool> {
-        self.current_batch = None;
+        self.sort_batch = None;
+        self.data_batch = None;
         self.load_next_batch()
     }
 }

--- a/sandbox/plugins/parquet-data-format/src/main/rust/src/merge/cursor.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/src/merge/cursor.rs
@@ -19,17 +19,12 @@ use super::heap::{get_sort_values, SortKey};
 use super::io_task::get_merge_pool;
 use super::schema::projection_indices_excluding_row_id;
 
-/// Default minimum number of variable-width (string/binary) non-sort columns to activate
-/// deferred data loading. Default 0 means always deferred — sort columns are always
-/// read separately from data columns. Overridable via index setting
-/// `index.parquet.merge_deferred_column_threshold`.
-const DEFAULT_DEFERRED_WIDE_COLUMN_THRESHOLD: usize = 0;
-
 /// A cursor over a single sorted Parquet input file.
 ///
-/// For wide schemas (≥3 variable-width non-sort columns), uses two readers:
-/// a sort-only reader for the merge heap and a data reader loaded on demand.
-/// For narrow schemas, uses a single all-column reader (zero overhead vs original).
+/// When deferred mode is active (controlled by the dynamic index setting
+/// `index.parquet.merge_deferred_column_threshold`, default 0 = always deferred),
+/// uses two readers: a sort-only reader for the merge heap and a data reader
+/// loaded on demand. Otherwise uses a single all-column reader.
 pub struct FileCursor {
     sort_reader: Arc<Mutex<parquet::arrow::arrow_reader::ParquetRecordBatchReader>>,
     sort_prefetch_rx: std::sync::mpsc::Receiver<Option<MergeResult<RecordBatch>>>,

--- a/sandbox/plugins/parquet-data-format/src/main/rust/src/merge/sorted.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/src/merge/sorted.rs
@@ -39,6 +39,7 @@ pub fn merge_sorted(
     let output_flush_rows = config.get_row_group_max_rows();
     let rayon_threads = config.get_merge_rayon_threads();
     let io_threads = config.get_merge_io_threads();
+    let deferred_threshold = config.get_merge_deferred_column_threshold();
     if input_files.is_empty() {
         return Err(super::MergeError::Logic(
             "merge_sorted called with empty input_files".into(),
@@ -82,7 +83,7 @@ pub fn merge_sorted(
     for (file_id, path) in input_files.iter().enumerate() {
         log_debug!("[RUST] Opening cursor {} for file: {}", file_id, path);
         let (cursor, projected_schema, parquet_descr, generation, row_count) =
-            FileCursor::new(path, file_id, sort_columns, nulls_first, batch_size)?;
+            FileCursor::new(path, file_id, sort_columns, nulls_first, batch_size, deferred_threshold)?;
         cursors.push(cursor);
         arrow_schemas.push(projected_schema.as_ref().clone());
         parquet_descriptors.push(parquet_descr);
@@ -160,7 +161,7 @@ pub fn merge_sorted(
             loop {
                 let remaining = cursor.batch_height() - cursor.row_idx;
                 if remaining > 0 {
-                    let slice = cursor.take_slice(cursor.row_idx, remaining);
+                    let slice = cursor.take_slice(cursor.row_idx, remaining)?;
                     for _ in 0..remaining {
                         mapping[file_offset + rows_emitted_per_file[file_id]] = new_row_id;
                         rows_emitted_per_file[file_id] += 1;
@@ -187,7 +188,7 @@ pub fn merge_sorted(
             let last_val = cursor.last_sort_values()?;
             if cmp_sort_values(&last_val, heap_top, reverse_sorts) != Ordering::Greater {
                 let remaining = cursor.batch_height() - cursor.row_idx;
-                let slice = cursor.take_slice(cursor.row_idx, remaining);
+                let slice = cursor.take_slice(cursor.row_idx, remaining)?;
                 for _ in 0..remaining {
                     mapping[file_offset + rows_emitted_per_file[file_id]] = new_row_id;
                     rows_emitted_per_file[file_id] += 1;
@@ -214,7 +215,7 @@ pub fn merge_sorted(
             // TIER 3: Binary search for the exact boundary
             let run_start = cursor.row_idx;
             let batch_h = cursor.batch_height();
-            let batch = cursor.current_batch.as_ref().unwrap();
+            let batch = cursor.sort_batch.as_ref().unwrap();
 
             let mut lo = run_start;
             let mut hi = batch_h - 1;
@@ -239,7 +240,7 @@ pub fn merge_sorted(
 
             let run_len = run_end - run_start + 1;
             if run_len > 0 {
-                let slice = cursor.take_slice(run_start, run_len);
+                let slice = cursor.take_slice(run_start, run_len)?;
                 for _ in 0..run_len {
                     mapping[file_offset + rows_emitted_per_file[file_id]] = new_row_id;
                     rows_emitted_per_file[file_id] += 1;

--- a/sandbox/plugins/parquet-data-format/src/main/rust/src/native_settings.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/src/native_settings.rs
@@ -38,6 +38,7 @@ pub struct NativeSettings {
     pub row_group_max_bytes: Option<usize>,
     pub merge_rayon_threads: Option<usize>,
     pub merge_io_threads: Option<usize>,
+    pub merge_deferred_column_threshold: Option<usize>,
 }
 
 impl NativeSettings {
@@ -111,6 +112,10 @@ impl NativeSettings {
 
     pub fn get_merge_io_threads(&self) -> Option<usize> {
         self.merge_io_threads
+    }
+
+    pub fn get_merge_deferred_column_threshold(&self) -> usize {
+        self.merge_deferred_column_threshold.unwrap_or(0)
     }
 }
 

--- a/sandbox/plugins/parquet-data-format/src/main/rust/tests/merge_integration_tests.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/tests/merge_integration_tests.rs
@@ -895,3 +895,501 @@ fn test_rg_size_overshoots_when_batch_straddles_threshold() {
     }
 }
 
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Deferred data loading tests
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/// Helper: register settings with a specific deferred threshold.
+fn register_deferred_settings(index_name: &str, batch_size: usize, deferred_threshold: usize) {
+    SETTINGS_STORE.insert(index_name.to_string(), NativeSettings {
+        merge_batch_size: Some(batch_size),
+        merge_deferred_column_threshold: Some(deferred_threshold),
+        ..Default::default()
+    });
+}
+
+/// Helper: read all String values from a column.
+fn read_all_strings(path: &str, col: &str) -> Vec<String> {
+    let file = File::open(path).unwrap();
+    let reader = ParquetRecordBatchReaderBuilder::try_new(file).unwrap().build().unwrap();
+    let mut vals = Vec::new();
+    for batch in reader {
+        let batch = batch.unwrap();
+        let idx = batch.schema().index_of(col).unwrap();
+        let arr = batch.column(idx).as_any().downcast_ref::<StringArray>().unwrap();
+        for i in 0..arr.len() {
+            vals.push(arr.value(i).to_string());
+        }
+    }
+    vals
+}
+
+/// Wide schema with threshold=0 forces deferred mode. Verify all data columns
+/// are correctly written despite being loaded lazily.
+#[test]
+fn test_deferred_wide_schema_correctness() {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("ts", DataType::Int64, false),
+        Field::new("col_a", DataType::Utf8, false),
+        Field::new("col_b", DataType::Utf8, false),
+        Field::new("col_c", DataType::Utf8, false),
+    ]));
+
+    let index = "test_deferred_wide_schema_correctness";
+    register_deferred_settings(index, 3, 0); // threshold=0 → always deferred
+
+    let batch_a = RecordBatch::try_new(schema.clone(), vec![
+        Arc::new(Int64Array::from(vec![1, 3, 5])),
+        Arc::new(StringArray::from(vec!["a1", "a3", "a5"])),
+        Arc::new(StringArray::from(vec!["b1", "b3", "b5"])),
+        Arc::new(StringArray::from(vec!["c1", "c3", "c5"])),
+    ]).unwrap();
+    let batch_b = RecordBatch::try_new(schema.clone(), vec![
+        Arc::new(Int64Array::from(vec![2, 4, 6])),
+        Arc::new(StringArray::from(vec!["a2", "a4", "a6"])),
+        Arc::new(StringArray::from(vec!["b2", "b4", "b6"])),
+        Arc::new(StringArray::from(vec!["c2", "c4", "c6"])),
+    ]).unwrap();
+
+    let tmp = tempdir().unwrap();
+    let file_a = tmp.path().join("a.parquet").to_string_lossy().to_string();
+    let file_b = tmp.path().join("b.parquet").to_string_lossy().to_string();
+    write_parquet(&file_a, &batch_a);
+    write_parquet(&file_b, &batch_b);
+
+    let output = tmp.path().join("merged.parquet").to_string_lossy().to_string();
+    merge_sorted(
+        &[file_a, file_b], &output, index,
+        &["ts".into()], &[false], &[false], 0,
+    ).unwrap();
+
+    let ts_vals = read_all_int64(&output, "ts");
+    assert_eq!(ts_vals, vec![1, 2, 3, 4, 5, 6]);
+
+    let a_vals = read_all_strings(&output, "col_a");
+    assert_eq!(a_vals, vec!["a1", "a2", "a3", "a4", "a5", "a6"]);
+
+    let b_vals = read_all_strings(&output, "col_b");
+    assert_eq!(b_vals, vec!["b1", "b2", "b3", "b4", "b5", "b6"]);
+
+    let c_vals = read_all_strings(&output, "col_c");
+    assert_eq!(c_vals, vec!["c1", "c2", "c3", "c4", "c5", "c6"]);
+}
+
+/// Threshold set very high → forces eager mode even with many string columns.
+/// Verify behavior is identical to deferred (output correctness).
+#[test]
+fn test_eager_forced_by_high_threshold() {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("ts", DataType::Int64, false),
+        Field::new("col_a", DataType::Utf8, false),
+        Field::new("col_b", DataType::Utf8, false),
+        Field::new("col_c", DataType::Utf8, false),
+    ]));
+
+    let index = "test_eager_forced_by_high_threshold";
+    register_deferred_settings(index, 3, 9999); // threshold=9999 → always eager
+
+    let batch_a = RecordBatch::try_new(schema.clone(), vec![
+        Arc::new(Int64Array::from(vec![1, 3, 5])),
+        Arc::new(StringArray::from(vec!["a1", "a3", "a5"])),
+        Arc::new(StringArray::from(vec!["b1", "b3", "b5"])),
+        Arc::new(StringArray::from(vec!["c1", "c3", "c5"])),
+    ]).unwrap();
+    let batch_b = RecordBatch::try_new(schema.clone(), vec![
+        Arc::new(Int64Array::from(vec![2, 4, 6])),
+        Arc::new(StringArray::from(vec!["a2", "a4", "a6"])),
+        Arc::new(StringArray::from(vec!["b2", "b4", "b6"])),
+        Arc::new(StringArray::from(vec!["c2", "c4", "c6"])),
+    ]).unwrap();
+
+    let tmp = tempdir().unwrap();
+    let file_a = tmp.path().join("a.parquet").to_string_lossy().to_string();
+    let file_b = tmp.path().join("b.parquet").to_string_lossy().to_string();
+    write_parquet(&file_a, &batch_a);
+    write_parquet(&file_b, &batch_b);
+
+    let output = tmp.path().join("merged.parquet").to_string_lossy().to_string();
+    merge_sorted(
+        &[file_a, file_b], &output, index,
+        &["ts".into()], &[false], &[false], 0,
+    ).unwrap();
+
+    let ts_vals = read_all_int64(&output, "ts");
+    assert_eq!(ts_vals, vec![1, 2, 3, 4, 5, 6]);
+
+    let a_vals = read_all_strings(&output, "col_a");
+    assert_eq!(a_vals, vec!["a1", "a2", "a3", "a4", "a5", "a6"]);
+}
+
+/// Deferred mode with multiple batches per cursor — verifies data reader
+/// stays synchronized across batch boundaries.
+#[test]
+fn test_deferred_multi_batch_sync() {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("ts", DataType::Int64, false),
+        Field::new("payload", DataType::Utf8, false),
+    ]));
+
+    let index = "test_deferred_multi_batch_sync";
+    register_deferred_settings(index, 2, 0); // batch_size=2, always deferred
+
+    // File A: [1,2,5,6] → batches [1,2] and [5,6]
+    // File B: [3,4,7,8] → batches [3,4] and [7,8]
+    // Expected: 1,2,3,4,5,6,7,8
+    let batch_a = RecordBatch::try_new(schema.clone(), vec![
+        Arc::new(Int64Array::from(vec![1, 2, 5, 6])),
+        Arc::new(StringArray::from(vec!["p1", "p2", "p5", "p6"])),
+    ]).unwrap();
+    let batch_b = RecordBatch::try_new(schema.clone(), vec![
+        Arc::new(Int64Array::from(vec![3, 4, 7, 8])),
+        Arc::new(StringArray::from(vec!["p3", "p4", "p7", "p8"])),
+    ]).unwrap();
+
+    let tmp = tempdir().unwrap();
+    let file_a = tmp.path().join("a.parquet").to_string_lossy().to_string();
+    let file_b = tmp.path().join("b.parquet").to_string_lossy().to_string();
+    write_parquet(&file_a, &batch_a);
+    write_parquet(&file_b, &batch_b);
+
+    let output = tmp.path().join("merged.parquet").to_string_lossy().to_string();
+    merge_sorted(
+        &[file_a, file_b], &output, index,
+        &["ts".into()], &[false], &[false], 0,
+    ).unwrap();
+
+    let ts_vals = read_all_int64(&output, "ts");
+    assert_eq!(ts_vals, vec![1, 2, 3, 4, 5, 6, 7, 8]);
+
+    let p_vals = read_all_strings(&output, "payload");
+    assert_eq!(p_vals, vec!["p1", "p2", "p3", "p4", "p5", "p6", "p7", "p8"]);
+}
+
+/// Deferred mode with TIER 3 (partial batch emit) — verifies data reader
+/// handles partial slices correctly when merge interleaves within a batch.
+#[test]
+fn test_deferred_tier3_interleaved() {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("ts", DataType::Int64, false),
+        Field::new("data", DataType::Utf8, false),
+    ]));
+
+    let index = "test_deferred_tier3_interleaved";
+    register_deferred_settings(index, 4, 0); // batch_size=4, always deferred
+
+    // File A: [1, 3, 5, 7] — single batch
+    // File B: [2, 4, 6, 8] — single batch
+    // Fully interleaved → TIER 3 binary search on every pop
+    let batch_a = RecordBatch::try_new(schema.clone(), vec![
+        Arc::new(Int64Array::from(vec![1, 3, 5, 7])),
+        Arc::new(StringArray::from(vec!["A1", "A3", "A5", "A7"])),
+    ]).unwrap();
+    let batch_b = RecordBatch::try_new(schema.clone(), vec![
+        Arc::new(Int64Array::from(vec![2, 4, 6, 8])),
+        Arc::new(StringArray::from(vec!["B2", "B4", "B6", "B8"])),
+    ]).unwrap();
+
+    let tmp = tempdir().unwrap();
+    let file_a = tmp.path().join("a.parquet").to_string_lossy().to_string();
+    let file_b = tmp.path().join("b.parquet").to_string_lossy().to_string();
+    write_parquet(&file_a, &batch_a);
+    write_parquet(&file_b, &batch_b);
+
+    let output = tmp.path().join("merged.parquet").to_string_lossy().to_string();
+    merge_sorted(
+        &[file_a, file_b], &output, index,
+        &["ts".into()], &[false], &[false], 0,
+    ).unwrap();
+
+    let ts_vals = read_all_int64(&output, "ts");
+    assert_eq!(ts_vals, vec![1, 2, 3, 4, 5, 6, 7, 8]);
+
+    let d_vals = read_all_strings(&output, "data");
+    assert_eq!(d_vals, vec!["A1", "B2", "A3", "B4", "A5", "B6", "A7", "B8"]);
+}
+
+/// Deferred mode produces identical output to eager mode for the same input.
+#[test]
+fn test_deferred_vs_eager_identical_output() {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("ts", DataType::Int64, false),
+        Field::new("s1", DataType::Utf8, false),
+        Field::new("s2", DataType::Utf8, false),
+        Field::new("s3", DataType::Utf8, false),
+        Field::new("n1", DataType::Int64, false),
+    ]));
+
+    let batch_a = RecordBatch::try_new(schema.clone(), vec![
+        Arc::new(Int64Array::from(vec![10, 30, 50, 70, 90])),
+        Arc::new(StringArray::from(vec!["x", "x", "x", "x", "x"])),
+        Arc::new(StringArray::from(vec!["y", "y", "y", "y", "y"])),
+        Arc::new(StringArray::from(vec!["z", "z", "z", "z", "z"])),
+        Arc::new(Int64Array::from(vec![100, 300, 500, 700, 900])),
+    ]).unwrap();
+    let batch_b = RecordBatch::try_new(schema.clone(), vec![
+        Arc::new(Int64Array::from(vec![20, 40, 60, 80, 100])),
+        Arc::new(StringArray::from(vec!["a", "a", "a", "a", "a"])),
+        Arc::new(StringArray::from(vec!["b", "b", "b", "b", "b"])),
+        Arc::new(StringArray::from(vec!["c", "c", "c", "c", "c"])),
+        Arc::new(Int64Array::from(vec![200, 400, 600, 800, 1000])),
+    ]).unwrap();
+
+    let tmp = tempdir().unwrap();
+    let file_a = tmp.path().join("a.parquet").to_string_lossy().to_string();
+    let file_b = tmp.path().join("b.parquet").to_string_lossy().to_string();
+    write_parquet(&file_a, &batch_a);
+    write_parquet(&file_b, &batch_b);
+
+    // Run with deferred (threshold=0)
+    let index_deferred = "test_deferred_vs_eager_deferred";
+    register_deferred_settings(index_deferred, 3, 0);
+    let output_deferred = tmp.path().join("merged_deferred.parquet").to_string_lossy().to_string();
+    merge_sorted(
+        &[file_a.clone(), file_b.clone()], &output_deferred, index_deferred,
+        &["ts".into()], &[false], &[false], 0,
+    ).unwrap();
+
+    // Run with eager (threshold=9999)
+    let index_eager = "test_deferred_vs_eager_eager";
+    register_deferred_settings(index_eager, 3, 9999);
+    let output_eager = tmp.path().join("merged_eager.parquet").to_string_lossy().to_string();
+    merge_sorted(
+        &[file_a, file_b], &output_eager, index_eager,
+        &["ts".into()], &[false], &[false], 0,
+    ).unwrap();
+
+    // Compare outputs — must be identical
+    let ts_d = read_all_int64(&output_deferred, "ts");
+    let ts_e = read_all_int64(&output_eager, "ts");
+    assert_eq!(ts_d, ts_e, "timestamps differ between deferred and eager");
+
+    let s1_d = read_all_strings(&output_deferred, "s1");
+    let s1_e = read_all_strings(&output_eager, "s1");
+    assert_eq!(s1_d, s1_e, "s1 column differs between deferred and eager");
+
+    let n1_d = read_all_int64(&output_deferred, "n1");
+    let n1_e = read_all_int64(&output_eager, "n1");
+    assert_eq!(n1_d, n1_e, "n1 column differs between deferred and eager");
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Deferred mode — TIER 1, 2, 3 correctness tests
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/// TIER 1 deferred: single cursor remaining — drains all remaining rows.
+/// Verifies data reader loads correctly when TIER 1 bulk-emits.
+#[test]
+fn test_deferred_tier1_single_cursor_drain() {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("ts", DataType::Int64, false),
+        Field::new("msg", DataType::Utf8, false),
+    ]));
+
+    let index = "test_deferred_tier1_single_cursor_drain";
+    register_deferred_settings(index, 3, 0);
+
+    // File A: [1, 2] — exhausts quickly
+    // File B: [3, 4, 5, 6, 7, 8] — becomes the sole cursor after A exhausts
+    // TIER 1 should drain B entirely without heap operations
+    let batch_a = RecordBatch::try_new(schema.clone(), vec![
+        Arc::new(Int64Array::from(vec![1, 2])),
+        Arc::new(StringArray::from(vec!["first", "second"])),
+    ]).unwrap();
+    let batch_b = RecordBatch::try_new(schema.clone(), vec![
+        Arc::new(Int64Array::from(vec![3, 4, 5, 6, 7, 8])),
+        Arc::new(StringArray::from(vec!["t3", "t4", "t5", "t6", "t7", "t8"])),
+    ]).unwrap();
+
+    let tmp = tempdir().unwrap();
+    let file_a = tmp.path().join("a.parquet").to_string_lossy().to_string();
+    let file_b = tmp.path().join("b.parquet").to_string_lossy().to_string();
+    write_parquet(&file_a, &batch_a);
+    write_parquet(&file_b, &batch_b);
+
+    let output = tmp.path().join("merged.parquet").to_string_lossy().to_string();
+    merge_sorted(
+        &[file_a, file_b], &output, index,
+        &["ts".into()], &[false], &[false], 0,
+    ).unwrap();
+
+    let ts_vals = read_all_int64(&output, "ts");
+    assert_eq!(ts_vals, vec![1, 2, 3, 4, 5, 6, 7, 8]);
+
+    let msg_vals = read_all_strings(&output, "msg");
+    assert_eq!(msg_vals, vec!["first", "second", "t3", "t4", "t5", "t6", "t7", "t8"]);
+}
+
+/// TIER 1 deferred with multiple batches: the sole remaining cursor spans
+/// multiple internal batches — verifies data reader advances across batch
+/// boundaries during the drain loop.
+#[test]
+fn test_deferred_tier1_multi_batch_drain() {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("ts", DataType::Int64, false),
+        Field::new("val", DataType::Utf8, false),
+    ]));
+
+    let index = "test_deferred_tier1_multi_batch_drain";
+    register_deferred_settings(index, 2, 0); // batch_size=2
+
+    // File A: [1] — exhausts immediately
+    // File B: [2, 3, 4, 5, 6, 7] — 3 batches of 2 rows each, all drained by TIER 1
+    let batch_a = RecordBatch::try_new(schema.clone(), vec![
+        Arc::new(Int64Array::from(vec![1])),
+        Arc::new(StringArray::from(vec!["a"])),
+    ]).unwrap();
+    let batch_b = RecordBatch::try_new(schema.clone(), vec![
+        Arc::new(Int64Array::from(vec![2, 3, 4, 5, 6, 7])),
+        Arc::new(StringArray::from(vec!["b2", "b3", "b4", "b5", "b6", "b7"])),
+    ]).unwrap();
+
+    let tmp = tempdir().unwrap();
+    let file_a = tmp.path().join("a.parquet").to_string_lossy().to_string();
+    let file_b = tmp.path().join("b.parquet").to_string_lossy().to_string();
+    write_parquet(&file_a, &batch_a);
+    write_parquet(&file_b, &batch_b);
+
+    let output = tmp.path().join("merged.parquet").to_string_lossy().to_string();
+    merge_sorted(
+        &[file_a, file_b], &output, index,
+        &["ts".into()], &[false], &[false], 0,
+    ).unwrap();
+
+    let ts_vals = read_all_int64(&output, "ts");
+    assert_eq!(ts_vals, vec![1, 2, 3, 4, 5, 6, 7]);
+
+    let val_vals = read_all_strings(&output, "val");
+    assert_eq!(val_vals, vec!["a", "b2", "b3", "b4", "b5", "b6", "b7"]);
+}
+
+/// TIER 2 deferred: entire batch fits before heap top — emits full batch at once.
+/// Verifies data is loaded once for the full batch slice.
+#[test]
+fn test_deferred_tier2_full_batch_emit() {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("ts", DataType::Int64, false),
+        Field::new("tag", DataType::Utf8, false),
+    ]));
+
+    let index = "test_deferred_tier2_full_batch_emit";
+    register_deferred_settings(index, 3, 0);
+
+    // File A: [1, 2, 3, 10, 11, 12] → batches [1,2,3] and [10,11,12]
+    // File B: [5, 6, 7]
+    // Batch [1,2,3] from A fits entirely before heap top (B=5) → TIER 2 emits all 3
+    let batch_a = RecordBatch::try_new(schema.clone(), vec![
+        Arc::new(Int64Array::from(vec![1, 2, 3, 10, 11, 12])),
+        Arc::new(StringArray::from(vec!["A1", "A2", "A3", "A10", "A11", "A12"])),
+    ]).unwrap();
+    let batch_b = RecordBatch::try_new(schema.clone(), vec![
+        Arc::new(Int64Array::from(vec![5, 6, 7])),
+        Arc::new(StringArray::from(vec!["B5", "B6", "B7"])),
+    ]).unwrap();
+
+    let tmp = tempdir().unwrap();
+    let file_a = tmp.path().join("a.parquet").to_string_lossy().to_string();
+    let file_b = tmp.path().join("b.parquet").to_string_lossy().to_string();
+    write_parquet(&file_a, &batch_a);
+    write_parquet(&file_b, &batch_b);
+
+    let output = tmp.path().join("merged.parquet").to_string_lossy().to_string();
+    merge_sorted(
+        &[file_a, file_b], &output, index,
+        &["ts".into()], &[false], &[false], 0,
+    ).unwrap();
+
+    let ts_vals = read_all_int64(&output, "ts");
+    assert_eq!(ts_vals, vec![1, 2, 3, 5, 6, 7, 10, 11, 12]);
+
+    let tag_vals = read_all_strings(&output, "tag");
+    assert_eq!(tag_vals, vec!["A1", "A2", "A3", "B5", "B6", "B7", "A10", "A11", "A12"]);
+}
+
+/// TIER 2 deferred with descending sort — verifies deferred works with reverse order.
+#[test]
+fn test_deferred_tier2_descending() {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("ts", DataType::Int64, false),
+        Field::new("info", DataType::Utf8, false),
+    ]));
+
+    let index = "test_deferred_tier2_descending";
+    register_deferred_settings(index, 3, 0);
+
+    // File A: [12, 11, 10, 3, 2, 1] descending → batches [12,11,10] and [3,2,1]
+    // File B: [7, 6, 5] descending
+    let batch_a = RecordBatch::try_new(schema.clone(), vec![
+        Arc::new(Int64Array::from(vec![12, 11, 10, 3, 2, 1])),
+        Arc::new(StringArray::from(vec!["a12", "a11", "a10", "a3", "a2", "a1"])),
+    ]).unwrap();
+    let batch_b = RecordBatch::try_new(schema.clone(), vec![
+        Arc::new(Int64Array::from(vec![7, 6, 5])),
+        Arc::new(StringArray::from(vec!["b7", "b6", "b5"])),
+    ]).unwrap();
+
+    let tmp = tempdir().unwrap();
+    let file_a = tmp.path().join("a.parquet").to_string_lossy().to_string();
+    let file_b = tmp.path().join("b.parquet").to_string_lossy().to_string();
+    write_parquet(&file_a, &batch_a);
+    write_parquet(&file_b, &batch_b);
+
+    let output = tmp.path().join("merged.parquet").to_string_lossy().to_string();
+    merge_sorted(
+        &[file_a, file_b], &output, index,
+        &["ts".into()], &[true], &[false], 0, // reverse=true (descending)
+    ).unwrap();
+
+    let ts_vals = read_all_int64(&output, "ts");
+    assert_eq!(ts_vals, vec![12, 11, 10, 7, 6, 5, 3, 2, 1]);
+
+    let info_vals = read_all_strings(&output, "info");
+    assert_eq!(info_vals, vec!["a12", "a11", "a10", "b7", "b6", "b5", "a3", "a2", "a1"]);
+}
+
+/// TIER 3 deferred with many cursors — stress test for data reader sync
+/// across multiple interleaved cursors with small batch sizes.
+#[test]
+fn test_deferred_tier3_many_cursors() {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("ts", DataType::Int64, false),
+        Field::new("src", DataType::Utf8, false),
+    ]));
+
+    let index = "test_deferred_tier3_many_cursors";
+    register_deferred_settings(index, 2, 0); // small batches force frequent batch transitions
+
+    // 4 fully interleaved files:
+    // A: [1, 5, 9]  B: [2, 6, 10]  C: [3, 7, 11]  D: [4, 8, 12]
+    let make_batch = |vals: Vec<i64>, label: &str| {
+        let labels: Vec<&str> = vals.iter().map(|_| label).collect();
+        RecordBatch::try_new(schema.clone(), vec![
+            Arc::new(Int64Array::from(vals)),
+            Arc::new(StringArray::from(labels)),
+        ]).unwrap()
+    };
+
+    let tmp = tempdir().unwrap();
+    let files: Vec<String> = vec![
+        ("a", vec![1i64, 5, 9]),
+        ("b", vec![2, 6, 10]),
+        ("c", vec![3, 7, 11]),
+        ("d", vec![4, 8, 12]),
+    ].into_iter().map(|(name, vals)| {
+        let path = tmp.path().join(format!("{}.parquet", name)).to_string_lossy().to_string();
+        write_parquet(&path, &make_batch(vals, name));
+        path
+    }).collect();
+
+    let output = tmp.path().join("merged.parquet").to_string_lossy().to_string();
+    merge_sorted(
+        &files, &output, index,
+        &["ts".into()], &[false], &[false], 0,
+    ).unwrap();
+
+    let ts_vals = read_all_int64(&output, "ts");
+    assert_eq!(ts_vals, vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+
+    let src_vals = read_all_strings(&output, "src");
+    assert_eq!(src_vals, vec!["a", "b", "c", "d", "a", "b", "c", "d", "a", "b", "c", "d"]);
+}

--- a/sandbox/plugins/parquet-data-format/src/main/rust/tests/merge_integration_tests.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/tests/merge_integration_tests.rs
@@ -1393,3 +1393,192 @@ fn test_deferred_tier3_many_cursors() {
     let src_vals = read_all_strings(&output, "src");
     assert_eq!(src_vals, vec!["a", "b", "c", "d", "a", "b", "c", "d", "a", "b", "c", "d"]);
 }
+
+/// Merge files with different schemas in deferred mode — verifies that columns
+/// missing in some files are padded with nulls and the deferred data reader
+/// handles mismatched schemas correctly.
+#[test]
+fn test_deferred_different_schemas() {
+    let schema_a = Arc::new(Schema::new(vec![
+        Field::new("ts", DataType::Int64, false),
+        Field::new("col_a", DataType::Utf8, true),
+        Field::new("col_b", DataType::Utf8, true),
+        Field::new("col_c", DataType::Utf8, true),
+    ]));
+    let schema_b = Arc::new(Schema::new(vec![
+        Field::new("ts", DataType::Int64, false),
+        Field::new("col_b", DataType::Utf8, true),
+        Field::new("col_d", DataType::Utf8, true),
+        Field::new("col_e", DataType::Utf8, true),
+    ]));
+
+    let index = "test_deferred_different_schemas";
+    register_deferred_settings(index, 3, 0);
+
+    let batch_a = RecordBatch::try_new(schema_a.clone(), vec![
+        Arc::new(Int64Array::from(vec![1, 3, 5])),
+        Arc::new(StringArray::from(vec![Some("a1"), Some("a3"), Some("a5")])),
+        Arc::new(StringArray::from(vec![Some("b1"), Some("b3"), Some("b5")])),
+        Arc::new(StringArray::from(vec![Some("c1"), Some("c3"), Some("c5")])),
+    ]).unwrap();
+    let batch_b = RecordBatch::try_new(schema_b.clone(), vec![
+        Arc::new(Int64Array::from(vec![2, 4, 6])),
+        Arc::new(StringArray::from(vec![Some("b2"), Some("b4"), Some("b6")])),
+        Arc::new(StringArray::from(vec![Some("d2"), Some("d4"), Some("d6")])),
+        Arc::new(StringArray::from(vec![Some("e2"), Some("e4"), Some("e6")])),
+    ]).unwrap();
+
+    let tmp = tempdir().unwrap();
+    let file_a = tmp.path().join("a.parquet").to_string_lossy().to_string();
+    let file_b = tmp.path().join("b.parquet").to_string_lossy().to_string();
+    write_parquet(&file_a, &batch_a);
+    write_parquet(&file_b, &batch_b);
+
+    let output = tmp.path().join("merged.parquet").to_string_lossy().to_string();
+    merge_sorted(
+        &[file_a, file_b], &output, index,
+        &["ts".into()], &[false], &[false], 0,
+    ).unwrap();
+
+    let ts_vals = read_all_int64(&output, "ts");
+    assert_eq!(ts_vals, vec![1, 2, 3, 4, 5, 6]);
+
+    // col_b present in both files
+    let b_vals = read_all_strings(&output, "col_b");
+    assert_eq!(b_vals, vec!["b1", "b2", "b3", "b4", "b5", "b6"]);
+
+    // col_a only in file A — file B rows should be null
+    let file = File::open(&output).unwrap();
+    let reader = ParquetRecordBatchReaderBuilder::try_new(file).unwrap().build().unwrap();
+    let mut col_a_nulls = Vec::new();
+    for batch in reader {
+        let batch = batch.unwrap();
+        let idx = batch.schema().index_of("col_a").unwrap();
+        let arr = batch.column(idx).as_any().downcast_ref::<StringArray>().unwrap();
+        for i in 0..arr.len() {
+            col_a_nulls.push(arr.is_null(i));
+        }
+    }
+    // Sorted order: ts=[1,2,3,4,5,6], rows from file A at positions 0,2,4; file B at 1,3,5
+    assert_eq!(col_a_nulls, vec![false, true, false, true, false, true]);
+
+    // col_d only in file B — file A rows should be null
+    let file = File::open(&output).unwrap();
+    let reader = ParquetRecordBatchReaderBuilder::try_new(file).unwrap().build().unwrap();
+    let mut col_d_vals = Vec::new();
+    for batch in reader {
+        let batch = batch.unwrap();
+        let idx = batch.schema().index_of("col_d").unwrap();
+        let arr = batch.column(idx).as_any().downcast_ref::<StringArray>().unwrap();
+        for i in 0..arr.len() {
+            if arr.is_null(i) {
+                col_d_vals.push("NULL".to_string());
+            } else {
+                col_d_vals.push(arr.value(i).to_string());
+            }
+        }
+    }
+    assert_eq!(col_d_vals, vec!["NULL", "d2", "NULL", "d4", "NULL", "d6"]);
+}
+
+/// Merge three files with progressively wider schemas in deferred mode —
+/// verifies union schema construction and null padding across multiple files.
+#[test]
+fn test_deferred_three_files_different_schemas() {
+    let schema_1 = Arc::new(Schema::new(vec![
+        Field::new("ts", DataType::Int64, false),
+        Field::new("name", DataType::Utf8, true),
+    ]));
+    let schema_2 = Arc::new(Schema::new(vec![
+        Field::new("ts", DataType::Int64, false),
+        Field::new("name", DataType::Utf8, true),
+        Field::new("city", DataType::Utf8, true),
+        Field::new("extra", DataType::Utf8, true),
+    ]));
+    let schema_3 = Arc::new(Schema::new(vec![
+        Field::new("ts", DataType::Int64, false),
+        Field::new("country", DataType::Utf8, true),
+        Field::new("extra", DataType::Utf8, true),
+    ]));
+
+    let index = "test_deferred_three_files_different_schemas";
+    register_deferred_settings(index, 4, 0);
+
+    let batch_1 = RecordBatch::try_new(schema_1.clone(), vec![
+        Arc::new(Int64Array::from(vec![1, 4])),
+        Arc::new(StringArray::from(vec![Some("alice"), Some("dave")])),
+    ]).unwrap();
+    let batch_2 = RecordBatch::try_new(schema_2.clone(), vec![
+        Arc::new(Int64Array::from(vec![2, 5])),
+        Arc::new(StringArray::from(vec![Some("bob"), Some("eve")])),
+        Arc::new(StringArray::from(vec![Some("NYC"), Some("LA")])),
+        Arc::new(StringArray::from(vec![Some("x2"), Some("x5")])),
+    ]).unwrap();
+    let batch_3 = RecordBatch::try_new(schema_3.clone(), vec![
+        Arc::new(Int64Array::from(vec![3, 6])),
+        Arc::new(StringArray::from(vec![Some("US"), Some("UK")])),
+        Arc::new(StringArray::from(vec![Some("x3"), Some("x6")])),
+    ]).unwrap();
+
+    let tmp = tempdir().unwrap();
+    let file_1 = tmp.path().join("f1.parquet").to_string_lossy().to_string();
+    let file_2 = tmp.path().join("f2.parquet").to_string_lossy().to_string();
+    let file_3 = tmp.path().join("f3.parquet").to_string_lossy().to_string();
+    write_parquet(&file_1, &batch_1);
+    write_parquet(&file_2, &batch_2);
+    write_parquet(&file_3, &batch_3);
+
+    let output = tmp.path().join("merged.parquet").to_string_lossy().to_string();
+    merge_sorted(
+        &[file_1, file_2, file_3], &output, index,
+        &["ts".into()], &[false], &[false], 0,
+    ).unwrap();
+
+    let ts_vals = read_all_int64(&output, "ts");
+    assert_eq!(ts_vals, vec![1, 2, 3, 4, 5, 6]);
+
+    // "name" in files 1 and 2 only
+    let file = File::open(&output).unwrap();
+    let reader = ParquetRecordBatchReaderBuilder::try_new(file).unwrap().build().unwrap();
+    let mut name_vals = Vec::new();
+    for batch in reader {
+        let batch = batch.unwrap();
+        let idx = batch.schema().index_of("name").unwrap();
+        let arr = batch.column(idx).as_any().downcast_ref::<StringArray>().unwrap();
+        for i in 0..arr.len() {
+            if arr.is_null(i) { name_vals.push("NULL".to_string()); }
+            else { name_vals.push(arr.value(i).to_string()); }
+        }
+    }
+    assert_eq!(name_vals, vec!["alice", "bob", "NULL", "dave", "eve", "NULL"]);
+
+    // "country" only in file 3
+    let file = File::open(&output).unwrap();
+    let reader = ParquetRecordBatchReaderBuilder::try_new(file).unwrap().build().unwrap();
+    let mut country_vals = Vec::new();
+    for batch in reader {
+        let batch = batch.unwrap();
+        let idx = batch.schema().index_of("country").unwrap();
+        let arr = batch.column(idx).as_any().downcast_ref::<StringArray>().unwrap();
+        for i in 0..arr.len() {
+            if arr.is_null(i) { country_vals.push("NULL".to_string()); }
+            else { country_vals.push(arr.value(i).to_string()); }
+        }
+    }
+    assert_eq!(country_vals, vec!["NULL", "NULL", "US", "NULL", "NULL", "UK"]);
+
+    // "extra" in files 2 and 3
+    let file = File::open(&output).unwrap();
+    let reader = ParquetRecordBatchReaderBuilder::try_new(file).unwrap().build().unwrap();
+    let mut extra_vals = Vec::new();
+    for batch in reader {
+        let batch = batch.unwrap();
+        let idx = batch.schema().index_of("extra").unwrap();
+        let arr = batch.column(idx).as_any().downcast_ref::<StringArray>().unwrap();
+        for i in 0..arr.len() {
+            if arr.is_null(i) { extra_vals.push("NULL".to_string()); }
+            else { extra_vals.push(arr.value(i).to_string()); }
+        }
+    }
+    assert_eq!(extra_vals, vec!["NULL", "x2", "x3", "NULL", "x5", "x6"]);
+}


### PR DESCRIPTION
## Summary
- Split `FileCursor` into sort-only reader (eagerly prefetched) and data reader (loaded on demand)
- For wide schemas (≥3 variable-width non-sort columns): only sort keys decoded during k-way merge ordering. Full data loaded lazily when output batches are produced.
- For narrow schemas: single all-column reader, identical to previous behavior — zero overhead.

## Motivation
Native heap profiling showed 12+ GB consumed by parquet reader string/binary decode buffers during merge. 87% of peak memory was reader buffers for columns not involved in sort ordering.

## Benchmark Results (500K rows, 5 files)
| Schema | Eager (baseline) | Deferred (optimized) | Regression |
|---|---|---|---|
| Wide (20 string cols) | 139,890 rows/sec | 139,584 rows/sec | < 0.3% (noise) |
| Narrow (2 string cols) | 803,750 rows/sec | 811,533 rows/sec | None |

Expected memory reduction at production scale: ~10x for wide schemas (12GB → 1-2GB).


[Quoting](https://github.com/opensearch-project/OpenSearch/pull/22137#issuecomment-4723181150) the test runs 

Did a complete clickbench run (ingestion only) on a r8g.2xlarge EC2 instance (with heap size 16gb) and waited some time for merges to happen. Below are the findings.

<img width="1708" height="400" alt="newplot(2)" src="https://github.com/user-attachments/assets/565e623c-c58c-4815-8f5c-4e2ce6368c9d" />
<img width="1708" height="400" alt="newplot(1)" src="https://github.com/user-attachments/assets/15dc06fd-b4b9-4df0-a6bb-e68a9f58fdc5" />
<img width="1708" height="400" alt="newplot" src="https://github.com/user-attachments/assets/d7bf2cbc-890e-46ea-9bb5-31673d7bb799" />
<img width="1708" height="400" alt="newplot(3)" src="https://github.com/user-attachments/assets/bbd162ca-94ca-4f9f-b103-4e503a0dbff7" />

Throughput numbers

With this change
<img width="3790" height="582" alt="Screenshot 2026-06-16 at 6 25 36 PM" src="https://github.com/user-attachments/assets/f3d20b76-37f3-45a9-ae0f-b11ebcd848e0" />

```
Min Throughput,index-append,40843.75,docs/s
Mean Throughput,index-append,42170.71,docs/s
Median Throughput,index-append,41936.33,docs/s
Max Throughput,index-append,47247.53,docs/s
```

Main branch
```
Min Throughput,index-append,40673.42,docs/s
Mean Throughput,index-append,41999.43,docs/s
Median Throughput,index-append,41735.35,docs/s
Max Throughput,index-append,47244.89,docs/s
```

**SUMMARY**

- Throughout almost identical (CPU also within similar range)
- Native memory usage almost halved




## Test plan
- [x] Benchmark: `cargo bench --bench merge_projection_bench`
- [ ] Integration test: merge with wide OTel schema, verify output correctness
- [ ] Memory profiling: compare jemalloc resident during merge on staging