### PR TITLE
Release borrowed Arrow buffers when a coordinator-reduce query aborts

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/api.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/api.rs
@@ -87,6 +87,9 @@ pub struct QueryStreamHandle {
     /// Physical plan reference for post-execution metrics extraction.
     /// Available after execution completes; read via `df_stream_get_metrics`.
     physical_plan: Option<Arc<dyn datafusion::physical_plan::ExecutionPlan>>,
+    /// Fires when the spawned CPU task has fully dropped; `stream_close` waits on it so borrowed
+    /// input batches are released before the per-query allocator closes. `None` outside coordinator-reduce.
+    task_done: Option<tokio::sync::oneshot::Receiver<()>>,
 }
 
 impl QueryStreamHandle {
@@ -109,7 +112,14 @@ impl QueryStreamHandle {
             has_views,
             _concurrency_permit: permit,
             physical_plan: None,
+            task_done: None,
         }
+    }
+
+    /// Attaches the task-completion signal `stream_close` joins on before the allocator closes.
+    pub fn with_task_done(mut self, task_done: tokio::sync::oneshot::Receiver<()>) -> Self {
+        self.task_done = Some(task_done);
+        self
     }
 
     pub fn with_session_context(
@@ -126,6 +136,7 @@ impl QueryStreamHandle {
             has_views,
             _concurrency_permit: permit,
             physical_plan: None,
+            task_done: None,
         }
     }
 
@@ -144,6 +155,7 @@ impl QueryStreamHandle {
             has_views,
             _concurrency_permit: permit,
             physical_plan: Some(plan),
+            task_done: None,
         }
     }
 
@@ -1264,8 +1276,31 @@ fn view_needs_gc(buffers: &[arrow::buffer::Buffer], bytes_used: usize) -> bool {
 /// # Safety
 /// `stream_ptr` must be 0 or a valid pointer returned by `execute_query`.
 pub unsafe fn stream_close(stream_ptr: i64) {
-    if stream_ptr != 0 {
-        let _ = Box::from_raw(stream_ptr as *mut QueryStreamHandle);
+    if stream_ptr == 0 {
+        return;
+    }
+    let mut handle = Box::from_raw(stream_ptr as *mut QueryStreamHandle);
+    // Dropping the handle aborts the CPU task but does not wait for it; on the coordinator-reduce
+    // path that task still holds Java-borrowed input batches. Wait for it to fully unwind (signal
+    // fires once its batches drop) before returning, so the caller's allocator close is safe.
+    let task_done = handle.task_done.take();
+    drop(handle);
+    if let Some(rx) = task_done {
+        if let Some(mgr) = crate::ffm::try_get_rt_manager() {
+            // Already aborted, so this resolves as soon as the task unwinds; 30s is a backstop
+            // against a wedged task hanging the reduce thread. If it fires we proceed anyway and
+            // may leak the borrow — log it so a recurring timeout is visible rather than silent.
+            let timed_out = mgr
+                .io_runtime
+                .block_on(async { tokio::time::timeout(std::time::Duration::from_secs(30), rx).await })
+                .is_err();
+            if timed_out {
+                native_bridge_common::log_error!(
+                    "stream_close: timed out after 30s waiting for the reduce CPU task to release \
+                     borrowed buffers; proceeding with allocator close (possible leak)"
+                );
+            }
+        }
     }
 }
 
@@ -1736,14 +1771,15 @@ pub async unsafe fn execute_local_plan(
     // shape as `execute_query`, so existing `stream_next` / `stream_close`
     // drain this handle unchanged. Use the cancellable variant so the CPU
     // task can be aborted mid-execution when cancel_query fires.
-    let (cross_rt_stream, abort_handle) =
+    let (cross_rt_stream, abort_handle, task_done) =
         CrossRtStream::new_with_df_error_stream_cancellable(df_stream, manager.cpu_executor());
     if let Some(h) = abort_handle {
         query_tracker::set_abort_handle(context_id, h);
     }
     let wrapped = RecordBatchStreamAdapter::new(cross_rt_stream.schema(), cross_rt_stream);
 
-    let handle = QueryStreamHandle::new(wrapped, query_context, permit);
+    // Attach the teardown signal so stream_close releases borrowed input batches before allocator close.
+    let handle = QueryStreamHandle::new(wrapped, query_context, permit).with_task_done(task_done);
     Ok(Box::into_raw(Box::new(handle)) as i64)
 }
 
@@ -1779,14 +1815,15 @@ pub unsafe fn execute_local_prepared_plan(
     let _guard = manager.io_runtime.enter();
     let df_stream = session.execute_prepared()?;
 
-    let (cross_rt_stream, abort_handle) =
+    let (cross_rt_stream, abort_handle, task_done) =
         CrossRtStream::new_with_df_error_stream_cancellable(df_stream, manager.cpu_executor());
     if let Some(h) = abort_handle {
         query_tracker::set_abort_handle(context_id, h);
     }
     let wrapped = RecordBatchStreamAdapter::new(cross_rt_stream.schema(), cross_rt_stream);
 
-    let handle = QueryStreamHandle::new(wrapped, query_context, permit);
+    // Same teardown signal as execute_local_plan.
+    let handle = QueryStreamHandle::new(wrapped, query_context, permit).with_task_done(task_done);
     Ok(Box::into_raw(Box::new(handle)) as i64)
 }
 
@@ -1833,9 +1870,10 @@ pub unsafe fn sender_send(
     array_data.align_buffers();
 
     let struct_array = StructArray::from(array_data);
-    let batch = RecordBatch::from(struct_array);
-
-    Ok(sender.send_blocking(Ok(batch), io_handle))
+    // Zero-copy: from_ffi BORROWS the Java buffers, keeping them alive until DataFusion drops the
+    // batch. stream_close's teardown barrier releases that borrow before the allocator closes.
+    let borrowed_batch = RecordBatch::from(struct_array);
+    Ok(sender.send_blocking(Ok(borrowed_batch), io_handle))
 }
 
 /// Closes a partition stream sender. Dropping the sender closes the mpsc,

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/cross_rt_stream.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/cross_rt_stream.rs
@@ -20,8 +20,21 @@ use datafusion::error::DataFusionError;
 use datafusion::physical_plan::SendableRecordBatchStream;
 use futures::{future::BoxFuture, FutureExt, Stream, StreamExt};
 use tokio::sync::mpsc::{channel, Sender};
+use tokio::sync::oneshot;
 use tokio::task::AbortHandle;
 use tokio_stream::wrappers::ReceiverStream;
+
+/// Fires its `oneshot` when dropped. Held inside the spawned task body so the signal is sent on
+/// every exit path (drain, error, abort-unwind, panic).
+struct DoneGuard(Option<oneshot::Sender<()>>);
+
+impl Drop for DoneGuard {
+    fn drop(&mut self) {
+        if let Some(tx) = self.0.take() {
+            let _ = tx.send(());
+        }
+    }
+}
 
 // This is used to execute a DataFusion stream on a dedicated CPU executor but consume the results on
 // the main I/O runtime.
@@ -59,21 +72,24 @@ impl CrossRtStream {
         stream: SendableRecordBatchStream,
         exec: DedicatedExecutor,
     ) -> Self {
-        let (cross_rt, _abort_handle) = Self::new_with_df_error_stream_cancellable(stream, exec);
+        let (cross_rt, _abort_handle, _done_rx) = Self::new_with_df_error_stream_cancellable(stream, exec);
         cross_rt
     }
 
-    /// Like [`new_with_df_error_stream`](Self::new_with_df_error_stream), but also returns
-    /// an [`AbortHandle`] that can be used to cancel the CPU task externally.
+    /// Like [`new_with_df_error_stream`](Self::new_with_df_error_stream), but also returns an
+    /// [`AbortHandle`] and a `oneshot::Receiver` that fires once the spawned task has fully dropped
+    /// (completion or abort) — the barrier `stream_close` waits on before the allocator closes.
     pub fn new_with_df_error_stream_cancellable(
         stream: SendableRecordBatchStream,
         exec: DedicatedExecutor,
-    ) -> (Self, Option<AbortHandle>) {
+    ) -> (Self, Option<AbortHandle>, oneshot::Receiver<()>) {
         let schema = stream.schema();
         let (tx, rx) = channel(1);
         let tx_captured = tx.clone();
+        let (done_tx, done_rx) = oneshot::channel();
 
         let fut = async move {
+            let _done = DoneGuard(Some(done_tx));
             tokio::pin!(stream);
             while let Some(res) = stream.next().await {
                 if tx_captured.send(res).await.is_err() {
@@ -107,7 +123,7 @@ impl CrossRtStream {
             phantom_corrector: None,
         };
 
-        (cross_rt, abort_handle)
+        (cross_rt, abort_handle, done_rx)
     }
 
     pub fn schema(&self) -> SchemaRef {
@@ -265,6 +281,48 @@ mod tests {
 
         let cross = CrossRtStream::new_with_df_error_stream(inner, exec.clone());
         assert_eq!(cross.schema(), schema);
+        exec.join_blocking();
+    }
+
+    // done_rx must fire only after the spawned task fully unwinds (its borrowed batches dropped),
+    // on both exit paths: full drain and abort.
+
+    #[tokio::test]
+    async fn done_rx_fires_after_full_drain() {
+        let exec = test_exec();
+        let schema = test_schema();
+        let inner = Box::pin(RecordBatchStreamAdapter::new(
+            schema.clone(),
+            stream::iter(vec![Ok(test_batch(&[1, 2, 3]))]),
+        ));
+
+        let (cross, _abort, done_rx) = CrossRtStream::new_with_df_error_stream_cancellable(inner, exec.clone());
+        let wrapped = RecordBatchStreamAdapter::new(cross.schema(), cross);
+        tokio::pin!(wrapped);
+        while wrapped.next().await.is_some() {}
+
+        assert!(done_rx.await.is_ok(), "done_rx must fire once the spawned task fully drops");
+        exec.join_blocking();
+    }
+
+    #[tokio::test]
+    async fn done_rx_fires_after_abort() {
+        let exec = test_exec();
+        let schema = test_schema();
+        // Never-ending stream so the task is still live when we abort it.
+        let inner = Box::pin(RecordBatchStreamAdapter::new(
+            schema.clone(),
+            stream::pending::<Result<RecordBatch, DataFusionError>>(),
+        ));
+
+        let (cross, abort, done_rx) = CrossRtStream::new_with_df_error_stream_cancellable(inner, exec.clone());
+        // Hold the stream so the abort, not a drop, is what ends the task.
+        let _wrapped = RecordBatchStreamAdapter::new(cross.schema(), cross);
+
+        abort.expect("cancellable constructor yields an abort handle").abort();
+
+        let fired = tokio::time::timeout(std::time::Duration::from_secs(5), done_rx).await;
+        assert!(fired.is_ok(), "done_rx must fire after the task is aborted");
         exec.join_blocking();
     }
 }

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/ffm.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/ffm.rs
@@ -73,6 +73,11 @@ fn get_rt_manager() -> Result<Arc<RuntimeManager>, String> {
         .ok_or_else(|| "Runtime manager not initialized".to_string())
 }
 
+/// Non-erroring accessor; `None` before init / after shutdown.
+pub(crate) fn try_get_rt_manager() -> Option<Arc<RuntimeManager>> {
+    TOKIO_RUNTIME_MANAGER.read().clone()
+}
+
 
 #[no_mangle]
 pub extern "C" fn df_init_runtime_manager(cpu_threads: i32, datanode_multiplier: f64, coordinator_multiplier: f64) {

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_executor.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_executor.rs
@@ -469,7 +469,7 @@ async unsafe fn execute_indexed_with_context_inner(
         let plan_schema = crate::schema_coerce::coerce_inferred_schema(plan_schema);
         let empty_exec = EmptyExec::new(Arc::clone(&plan_schema));
         let df_stream = empty_exec.execute(0, handle.ctx.task_ctx())?;
-        let (cross_rt_stream, abort_handle) =
+        let (cross_rt_stream, abort_handle, _task_done) =
             CrossRtStream::new_with_df_error_stream_cancellable(df_stream, cpu_executor);
         if let Some(h) = abort_handle {
             crate::query_tracker::set_abort_handle(context_id_early, h);
@@ -914,7 +914,7 @@ async unsafe fn execute_indexed_with_context_inner(
     let df_stream = execute_stream(physical_plan.clone(), ctx.task_ctx())
         .map_err(|e| DataFusionError::Execution(format!("execute_stream: {}", e)))?;
 
-    let (cross_rt_stream, abort_handle) =
+    let (cross_rt_stream, abort_handle, _task_done) =
         CrossRtStream::new_with_df_error_stream_cancellable(df_stream, cpu_executor);
 
     if let Some(h) = abort_handle {

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/query_executor.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/query_executor.rs
@@ -197,7 +197,7 @@ pub async fn execute_query(
     })?;
 
     // Wrap in CrossRtStream — CPU work runs on DedicatedExecutor
-    let (cross_rt_stream, abort_handle) =
+    let (cross_rt_stream, abort_handle, _task_done) =
         CrossRtStream::new_with_df_error_stream_cancellable(df_stream, cpu_executor);
 
     if let Some(h) = abort_handle {
@@ -292,7 +292,7 @@ pub async fn execute_with_context(
                 error!("execute_with_context: failed to execute prepared plan: {}", e);
                 e
             })?;
-            let (cross_rt_stream, abort_handle) =
+            let (cross_rt_stream, abort_handle, _task_done) =
                 CrossRtStream::new_with_df_error_stream_cancellable(df_stream, cpu_executor);
             if let Some(h) = abort_handle {
                 crate::query_tracker::set_abort_handle(context_id, h);
@@ -331,7 +331,7 @@ pub async fn execute_with_context(
                 e
             })?;
 
-            let (cross_rt_stream, abort_handle) =
+            let (cross_rt_stream, abort_handle, _task_done) =
                 CrossRtStream::new_with_df_error_stream_cancellable(df_stream, cpu_executor);
             if let Some(h) = abort_handle {
                 crate::query_tracker::set_abort_handle(context_id, h);
@@ -357,7 +357,7 @@ pub async fn execute_with_context(
             e
         })?;
 
-        let (cross_rt_stream, abort_handle) =
+        let (cross_rt_stream, abort_handle, _task_done) =
             CrossRtStream::new_with_df_error_stream_cancellable(df_stream, cpu_executor);
 
         if let Some(h) = abort_handle {

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/AnalyticsSearchTransportService.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/AnalyticsSearchTransportService.java
@@ -162,7 +162,19 @@ public class AnalyticsSearchTransportService {
                     batchSchema = root.getSchema();
                     batchAllocator = root.getFieldVectors().getFirst().getAllocator();
                 }
-                channel.sendResponseBatch(new FragmentExecutionArrowResponse(root));
+                // On success Flight takes ownership of root. If sendResponseBatch throws (e.g. the
+                // stream already closed after a mid-stream failure), Flight never took ownership, so
+                // close root here to avoid leaking the imported batch.
+                try {
+                    channel.sendResponseBatch(new FragmentExecutionArrowResponse(root));
+                } catch (Exception e) {
+                    try {
+                        root.close();
+                    } catch (Exception ce) {
+                        e.addSuppressed(ce);
+                    }
+                    throw e;
+                }
             }
 
             @Override
@@ -194,6 +206,16 @@ public class AnalyticsSearchTransportService {
                 }
             }
         };
+    }
+
+    /** Closes a response's claimed Arrow root if present, swallowing close failures. */
+    private static void closeResponseQuietly(FragmentExecutionArrowResponse response) {
+        if (response == null || response.getRoot() == null) {
+            return;
+        }
+        try {
+            response.getRoot().close();
+        } catch (Exception ignore) {}
     }
 
     Transport.Connection getConnection(String clusterAlias, String nodeId) {
@@ -260,17 +282,24 @@ public class AnalyticsSearchTransportService {
 
             @Override
             public void handleStreamResponse(StreamTransportResponse<FragmentExecutionArrowResponse> stream) {
+                // We own each claimed response root until it's handed to the consumer. `last`/`next`
+                // hold what the loop still owns; null each the instant ownership transfers so the
+                // finally can release any undelivered prefetch on failure (stream.close() frees only
+                // the cursor, not claimed roots).
+                FragmentExecutionArrowResponse last = null;
+                FragmentExecutionArrowResponse next = null;
                 try {
-                    FragmentExecutionArrowResponse last = stream.nextResponse();
+                    last = stream.nextResponse();
                     while (last != null) {
                         // Profiling sentinel: 0 rows with metadata attached. Deliver metrics and exit.
                         if (last.getRoot() != null && last.getRoot().getRowCount() == 0 && last.getMetadata() != null) {
                             listener.onStreamComplete(last.getMetadata());
                             last.getRoot().close();
+                            last = null;
                             return;
                         }
 
-                        FragmentExecutionArrowResponse next = stream.nextResponse();
+                        next = stream.nextResponse();
                         // Treat sentinel as end-of-stream: the current batch is the last real data batch.
                         boolean nextIsSentinel = next != null
                             && next.getRoot() != null
@@ -283,21 +312,31 @@ public class AnalyticsSearchTransportService {
                         if (nextIsSentinel) {
                             listener.onStreamComplete(next.getMetadata());
                             next.getRoot().close();
+                            next = null;
                         }
 
-                        boolean keepReading = listener.onStreamResponse(last, isLast);
+                        // Consumer takes ownership of `last` (it closes the root on all its paths).
+                        // Null our ref before the call so a throw can't make finally double-close it.
+                        FragmentExecutionArrowResponse delivering = last;
+                        last = null;
+                        boolean keepReading = listener.onStreamResponse(delivering, isLast);
                         if (!keepReading || nextIsSentinel) {
                             if (!isLast && next != null) {
                                 if (next.getRoot() != null) next.getRoot().close();
+                                next = null;
                                 stream.cancel("reduce input satisfied (downstream consumer finished)", null);
                             }
                             return;
                         }
                         last = next;
+                        next = null;
                     }
                 } catch (Exception e) {
                     listener.onFailure(e);
                 } finally {
+                    // Release any batches the loop still owns and never delivered.
+                    closeResponseQuietly(last);
+                    closeResponseQuietly(next);
                     try {
                         stream.close();
                     } catch (Exception ignore) {}

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stage/coordinator/ReduceStageExecution.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stage/coordinator/ReduceStageExecution.java
@@ -37,6 +37,10 @@ import java.util.concurrent.Executor;
  * forks the actual reduce computation to the SEARCH pool. This prevents deadlocking SEARCH
  * (where fragment execution runs) while keeping reduce compute off the scheduler threads.
  *
+ * <p>Releasing the Java buffers DataFusion borrows for its reduce working set is handled natively:
+ * {@code backendSink.close()} → {@code df_stream_close} joins the plan-driving CPU task before
+ * returning, so every borrowed batch is dropped before the terminal transition closes the allocator.
+ *
  * @opensearch.internal
  */
 public final class ReduceStageExecution extends AbstractStageExecution implements SinkProvidingStageExecution {
@@ -96,22 +100,19 @@ public final class ReduceStageExecution extends AbstractStageExecution implement
 
     @Override
     protected List<StageTask> materializeTasks() {
-        return List.of(new LocalStageTask(new StageTaskId(getStageId(), 0), listener -> {
-            reduceExecutor.execute(() -> {
-                try {
-                    backendSink.reduce(listener);
-                } catch (Exception e) {
-                    listener.onFailure(e);
-                }
-            });
-        }));
+        return List.of(new LocalStageTask(new StageTaskId(getStageId(), 0), listener -> reduceExecutor.execute(() -> {
+            try {
+                backendSink.reduce(listener);
+            } catch (Exception e) {
+                listener.onFailure(e);
+            }
+        })));
     }
 
     @Override
     protected void onTerminalTransition(State terminal) {
         if (terminal == State.CANCELLED || terminal == State.FAILED) {
             if (backendSink instanceof CancellableExchangeSink cancellable) {
-                logger.warn("[ReduceStageExecution] stage {} terminal={}, firing cancellable.cancel()", getStageId(), terminal);
                 try {
                     cancellable.cancel();
                 } catch (Exception e) {
@@ -119,6 +120,7 @@ public final class ReduceStageExecution extends AbstractStageExecution implement
                 }
             }
         }
+        // Joins the native plan-driving task, releasing borrowed buffers before the allocator closes.
         try {
             backendSink.close();
         } catch (Exception ignore) {}

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/AnalyticsSearchTransportServiceTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/AnalyticsSearchTransportServiceTests.java
@@ -8,24 +8,50 @@
 
 package org.opensearch.analytics.exec;
 
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.IntVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.apache.arrow.vector.types.pojo.Schema;
 import org.opensearch.analytics.exec.action.FragmentExecutionAction;
+import org.opensearch.analytics.exec.action.FragmentExecutionArrowResponse;
+import org.opensearch.analytics.exec.action.FragmentExecutionRequest;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.cluster.node.DiscoveryNodes;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.indices.IndicesService;
+import org.opensearch.tasks.Task;
 import org.opensearch.tasks.TaskResourceTrackingService;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.StreamTransportService;
+import org.opensearch.transport.Transport;
+import org.opensearch.transport.TransportResponseHandler;
+import org.opensearch.transport.stream.StreamTransportResponse;
 
+import java.util.List;
+
+import org.mockito.ArgumentCaptor;
+
+import static java.util.Collections.singletonList;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
- * Verifies that the fragment execution handler is registered with SAME executor
- * (admission control runs on transport thread) but forks execution internally
- * via {@link AnalyticsSearchService#executeFragmentStreamingAsync}.
+ * Verifies fragment handler registration and the stream-drain ownership contract in
+ * {@link AnalyticsSearchTransportService#dispatchFragmentStreaming} — specifically that a batch
+ * prefetched (read one ahead, to compute {@code isLast}) but never delivered to the consumer is
+ * released when the stream fails mid-drain. Otherwise its claimed Arrow root (POOL_FLIGHT buffers)
+ * would leak on every failed query.
  */
 public class AnalyticsSearchTransportServiceTests extends OpenSearchTestCase {
 
@@ -47,5 +73,118 @@ public class AnalyticsSearchTransportServiceTests extends OpenSearchTestCase {
             any(),
             any()
         );
+    }
+
+    /**
+     * When the consumer's {@code onStreamResponse} throws mid-drain, the drain loop owns a
+     * prefetched batch it never delivered. That batch's root must be closed by the loop's finally —
+     * {@code stream.close()} only frees the cursor, not the already-claimed response root.
+     */
+    public void testPrefetchedRootReleasedWhenConsumerThrows() throws Exception {
+        try (RootAllocator root = new RootAllocator(Long.MAX_VALUE)) {
+            // last: delivered to the consumer (which throws). next: prefetched, never delivered.
+            VectorSchemaRoot lastRoot = newIntRoot(root, "a", 1);
+            VectorSchemaRoot nextRoot = newIntRoot(root, "b", 2);
+            FragmentExecutionArrowResponse last = new FragmentExecutionArrowResponse(lastRoot);
+            FragmentExecutionArrowResponse next = new FragmentExecutionArrowResponse(nextRoot);
+
+            @SuppressWarnings("unchecked")
+            StreamTransportResponse<FragmentExecutionArrowResponse> stream = mock(StreamTransportResponse.class);
+            when(stream.nextResponse()).thenReturn(last, next, null);
+
+            TransportResponseHandler<FragmentExecutionArrowResponse> handler = captureHandler(new StreamingResponseListener<>() {
+                @Override
+                public boolean onStreamResponse(FragmentExecutionArrowResponse response, boolean isLast) {
+                    throw new RuntimeException("consumer failed mid-stream");
+                }
+
+                @Override
+                public void onFailure(Exception e) {}
+            });
+
+            handler.handleStreamResponse(stream);
+
+            // next was prefetched and never delivered, so the drain loop's finally must release it.
+            assertTrue("prefetched-but-undelivered root buffers must be freed", isClosed(nextRoot));
+            // The undelivered prefetch is closed by the loop; the delivered batch's ownership left the
+            // loop, so only the consumer is responsible for it — close it here to avoid the test leaking.
+            if (!isClosed(lastRoot)) {
+                lastRoot.close();
+            }
+            verify(stream).close();
+        }
+    }
+
+    /** Builds and registers the service, captures the streaming handler passed to sendChildRequest. */
+    private TransportResponseHandler<FragmentExecutionArrowResponse> captureHandler(
+        StreamingResponseListener<FragmentExecutionArrowResponse> listener
+    ) {
+        StreamTransportService transportService = mock(StreamTransportService.class);
+        AnalyticsSearchService searchService = mock(AnalyticsSearchService.class);
+        IndicesService indicesService = mock(IndicesService.class);
+        ClusterService clusterService = mock(ClusterService.class);
+        TaskResourceTrackingService taskResourceTrackingService = mock(TaskResourceTrackingService.class);
+
+        // getConnection(null, nodeId) -> clusterService.state().nodes().get(nodeId) -> getConnection(node)
+        DiscoveryNode node = mock(DiscoveryNode.class);
+        DiscoveryNodes nodes = mock(DiscoveryNodes.class);
+        ClusterState state = mock(ClusterState.class);
+        when(clusterService.state()).thenReturn(state);
+        when(state.nodes()).thenReturn(nodes);
+        when(nodes.get(any())).thenReturn(node);
+        when(transportService.getConnection(node)).thenReturn(mock(Transport.Connection.class));
+
+        AnalyticsSearchTransportService service = new AnalyticsSearchTransportService(
+            transportService,
+            clusterService,
+            searchService,
+            indicesService,
+            taskResourceTrackingService
+        );
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<TransportResponseHandler<FragmentExecutionArrowResponse>> handlerCaptor = ArgumentCaptor.forClass(
+            TransportResponseHandler.class
+        );
+        // Capture the handler instead of actually sending.
+        doAnswer(inv -> null).when(transportService)
+            .sendChildRequest(
+                any(Transport.Connection.class),
+                eq(FragmentExecutionAction.NAME),
+                any(),
+                any(),
+                any(),
+                handlerCaptor.capture()
+            );
+
+        DiscoveryNode target = mock(DiscoveryNode.class);
+        when(target.getId()).thenReturn("node-1");
+        service.dispatchFragmentStreaming(
+            mock(FragmentExecutionRequest.class),
+            target,
+            listener,
+            mock(Task.class),
+            new PendingExecutions(1)
+        );
+
+        List<TransportResponseHandler<FragmentExecutionArrowResponse>> handlers = handlerCaptor.getAllValues();
+        assertFalse("handler must have been dispatched to sendChildRequest", handlers.isEmpty());
+        return handlers.get(handlers.size() - 1);
+    }
+
+    private static VectorSchemaRoot newIntRoot(BufferAllocator allocator, String name, int value) {
+        Field field = new Field(name, FieldType.nullable(new ArrowType.Int(32, true)), null);
+        Schema schema = new Schema(singletonList(field));
+        VectorSchemaRoot vsr = VectorSchemaRoot.create(schema, allocator);
+        IntVector vec = (IntVector) vsr.getVector(name);
+        vec.allocateNew(1);
+        vec.set(0, value);
+        vsr.setRowCount(1);
+        return vsr;
+    }
+
+    /** A closed VectorSchemaRoot has released its buffers — its vectors report zero buffer size. */
+    private static boolean isClosed(VectorSchemaRoot vsr) {
+        return vsr.getFieldVectors().stream().allMatch(v -> v.getBufferSize() == 0);
     }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
When a reduce query is cancelled mid-stream, ex. it trips the coordinator buffer limit or a memory pool limit, native allocated_bytes stayed high after traffic stopped. Two buffers were leaked per aborted query:

1. Reduce-input borrow. Batches fed to the DataFusion reduce session are exported zero-copy via Arrow C-Data, so their buffers stay Java-allocated until DataFusion drops the batch. On abort the per-query allocator was closed while the plan-driving CPU task still held those batches. Fix: CrossRtStream now exposes a completion signal (fired when the spawned task fully unwinds, on every exit path); stream_close aborts the task and blocks on that signal, so every borrowed batch is released before Java closes the allocator. Enforcing an ordered teardown.

2. Orphaned prefetch. The coordinator drain loop reads one batch ahead to detect end-of-stream; on abort that prefetched batch was never delivered and never closed (stream.close() frees the cursor, not the claimed root). Fix: track the in-flight batches and release any the loop still owns in finally.


Steps used to test:

1. start server with gradle run
2. Ran expensive query over local cb dataset:

```
 curl -s -XPOST localhost:9200/_plugins/_ppl -H 'Content-Type: application/json' -d '{"query":"source=clickbench | stats dc(WatchID) by SearchEngineID, RegionID"}'
{
  "error": {
    "reason": "Error occurred in OpenSearch engine: Failed to read message.",
    "details": "StreamException[errorCode=CANCELLED, message=Failed to read message.]; java.lang.RuntimeException: org.apache.arrow.memory.OutOfMemoryException: Failure allocating buffer.\nFor more details, please send request for Json format to see the raw response from OpenSearch engine.",
    "type": "StreamException"
  },
  "status": 500
}%     
```

Before:
```
      "flight" : {
        "allocated_bytes" : 566526832,
        "peak_bytes" : 923153736,
        "limit_bytes" : 1330193955,
        "min_bytes" : 534401305,
        "group" : "transport"
      },
      "query" : {
        "allocated_bytes" : 128,
        "peak_bytes" : 1287427218,
        "limit_bytes" : 1330193955,
        "min_bytes" : 534401305,
        "group" : "search"
      },
```

After;
```
curl -s 'localhost:9200/_plugins/arrow_base/stats?pretty' | grep -A6 -E '"(flight|query|reduce)"'
      "flight" : {
        "allocated_bytes" : 0,
        "peak_bytes" : 33554432,
        "limit_bytes" : 1336003264,
        "min_bytes" : 534401305,
        "group" : "transport"
      },
      "query" : {
        "allocated_bytes" : 0,
        "peak_bytes" : 1007096382,
        "limit_bytes" : 1336003264,
        "min_bytes" : 534401305,
        "group" : "search"
      },
```

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
