### PR TITLE
Fix default SSE type to send AES256 header

### DIFF
--- a/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3Repository.java
+++ b/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3Repository.java
@@ -137,7 +137,7 @@ class S3Repository extends MeteredBlobStoreRepository {
      */
     static final Setting<String> SERVER_SIDE_ENCRYPTION_TYPE_SETTING = Setting.simpleString(
         "server_side_encryption_type",
-        BUCKET_DEFAULT_ENCRYPTION_TYPE,
+        ServerSideEncryption.AES256.toString(),
         value -> {
             if (!(value.equals(ServerSideEncryption.AES256.toString())
                 || value.equals(ServerSideEncryption.AWS_KMS.toString())


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
 Changes the default value of `server_side_encryption_type` from `bucket_default` to `AES256`.
 When set to `bucket_default`, no `x-amz-server-side-encryption` header is sent on S3 PutObject requests. This causes silent snapshot failures for customers whose S3 bucket policies require the encryption header (`DenyUnEncryptedObjectUploads`).

### Testing
Manual Testing:
1. Created S3 bucket `sukriiti-sse-test-bucket` in account `122610524023` (`us-east-1`)
2. Applied bucket policy with `DenyUnEncryptedObjectUploads` statement that denies `s3:PutObject` unless `x-amz-server-side-encryption` header is `AES256 `or `aws:kms`
  
Test 1: PutObject without encryption header (simulates old `bucket_default` default)
  ```
  $ echo "test-data" | aws s3 cp - s3://sukriiti-sse-test-bucket/test-no-header.dat
  
  upload failed: An error occurred (AccessDenied) when calling the PutObject operation:
  User: arn:aws:sts::122610524023:assumed-role/Admin/sukriiti-Isengard is not authorized
  to perform: s3:PutObject on resource: "arn:aws:s3:::sukriiti-sse-test-bucket/test-no-header.dat"
  with an explicit deny in a resource-based policy
  ```
  Access Denied: confirms the regression behavior.
  
  Test 2: PutObject with `x-amz-server-side-encryption: AES256` header (new default)
  ```
  $ aws s3api put-object --bucket sukriiti-sse-test-bucket --key test-with-aes256.dat \
      --body /dev/stdin --server-side-encryption AES256 <<< "test-data"
  
  {
      "ETag": "\"b29ecea7752a2a038df885aaa8cb0bc5\"",
      "ChecksumCRC64NVME": "QGLusVvG35c=",
      "ChecksumType": "FULL_OBJECT",
      "ServerSideEncryption": "AES256"
  }
  ```
 Upload succeeded: confirms the fix works.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
