### PR TITLE
Remove arrow module reference from jvm.options --add-opens

### DIFF
--- a/distribution/src/config/jvm.options
+++ b/distribution/src/config/jvm.options
@@ -85,7 +85,9 @@ ${error.file}
 23:-XX:CompileCommand=dontinline,java/lang/invoke/MethodHandle.asTypeUncached
 
 21-:-javaagent:agent/opensearch-agent.jar
-21-:--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED
+# Required by Arrow memory-core (DirectByteBuffer access); targets ALL-UNNAMED
+# because Arrow loads via plugin classloader (classpath), not module path
+21-:--add-opens=java.base/java.nio=ALL-UNNAMED
 
 # For cases with high memory-mapped file counts, a lower value can improve stability and
 # prevent issues like "leaked" maps or performance degradation. A value of 1 effectively


### PR DESCRIPTION
## Description

Fixes #22132

The global `jvm.options` contains:
```
21-:--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED
```

This references the `org.apache.arrow.memory.core` named module, which only exists when the `arrow-flight-rpc` plugin is installed. On default installations (minimal or standard distribution without the plugin), the JVM emits:

```
WARNING: Unknown module: org.apache.arrow.memory.core specified to --add-opens
```

## Changes

Drop the named module target from the `--add-opens` directive, keeping only `ALL-UNNAMED`. The Arrow Flight plugin loads in the unnamed module space (plugin classloader), so `ALL-UNNAMED` is sufficient for its runtime access to `java.nio.DirectByteBuffer` internals.

## Issues Resolved

Closes #22132

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.