### PR TITLE
Make DataFusion metadata/statistics caches dynamic + scan-resistant (S3-FIFO)

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/cache.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/cache.rs
@@ -8,7 +8,7 @@
 
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, RwLock};
 
 use datafusion::execution::cache::cache_manager::{
     CachedFileMetadataEntry, FileMetadataCache, FileMetadataCacheEntry,
@@ -33,10 +33,14 @@ fn entry_size(entry: &CachedFileMetadataEntry) -> usize {
     entry.file_metadata.memory_size()
 }
 
-/// Inner store for [`MutexFileMetadataCache`]: the keyed entries plus running byte total.
+/// Inner store for [`MutexFileMetadataCache`]: the keyed entries.
+///
+/// Held behind an `RwLock` so concurrent reads (`get`/`contains_key`/`len`/`list_entries`) run in
+/// parallel; only mutations (`put`/`remove`/`clear`/eviction) take the write lock. The running
+/// byte total is tracked separately in the lock-free `memory_used` atomic (see the struct field),
+/// so size queries never touch this lock at all.
 struct MetaState {
     map: HashMap<Path, CachedFileMetadataEntry>,
-    memory_used: usize,
 }
 
 /// Metadata cache for parquet footers, keyed by file path.
@@ -48,10 +52,16 @@ struct MetaState {
 /// of metadata entries (and a one-off wide scan no longer pollutes the hot footer set
 /// under S3-FIFO). Staleness is still the caller's job via `CachedFileMetadataEntry::is_valid_for`.
 pub struct MutexFileMetadataCache {
-    state: Mutex<MetaState>,
+    state: RwLock<MetaState>,
     /// Pluggable eviction policy (interior-mutable; shared shape with the statistics cache).
     policy: Arc<Mutex<Box<dyn CachePolicy>>>,
     size_limit: AtomicUsize,
+    /// Running byte total of resident entries, tracked lock-free alongside the map. Updated on
+    /// every mutation while the `state` write lock is held (so it stays consistent with the map),
+    /// but read without any lock — size queries (`memory_used`, eviction's budget check) never
+    /// contend on `state`. Reads may momentarily trail an in-flight mutation; that's fine, the
+    /// total need not be exact (eviction re-checks in a loop).
+    memory_used: AtomicUsize,
     hit_count: AtomicUsize,
     miss_count: AtomicUsize,
     /// When false, the cache serves every lookup as a miss and drops all writes.
@@ -64,9 +74,10 @@ impl MutexFileMetadataCache {
     /// Create with an explicit eviction policy, byte limit, and initial enabled state.
     pub fn with_enabled(policy_type: PolicyType, size_limit: usize, enabled: bool) -> Self {
         Self {
-            state: Mutex::new(MetaState { map: HashMap::new(), memory_used: 0 }),
+            state: RwLock::new(MetaState { map: HashMap::new() }),
             policy: Arc::new(Mutex::new(create_policy(policy_type))),
             size_limit: AtomicUsize::new(size_limit),
+            memory_used: AtomicUsize::new(0),
             hit_count: AtomicUsize::new(0),
             miss_count: AtomicUsize::new(0),
             enabled: AtomicBool::new(enabled),
@@ -105,9 +116,9 @@ impl MutexFileMetadataCache {
     }
 
     pub fn clear_cache(&self) {
-        if let Ok(mut s) = self.state.lock() {
+        if let Ok(mut s) = self.state.write() {
             s.map.clear();
-            s.memory_used = 0;
+            self.memory_used.store(0, Ordering::Relaxed);
         }
         if let Ok(mut p) = self.policy.lock() {
             p.clear();
@@ -115,9 +126,10 @@ impl MutexFileMetadataCache {
         self.reset_stats();
     }
 
-    /// Current bytes held by metadata entries.
+    /// Current bytes held by metadata entries. Lock-free read of the running atomic total — may
+    /// momentarily trail an in-flight `put`/`remove`, which is fine (callers tolerate inexactness).
     pub fn memory_used(&self) -> usize {
-        self.state.lock().map(|s| s.memory_used).unwrap_or(0)
+        self.memory_used.load(Ordering::Relaxed)
     }
 
     pub fn update_cache_limit(&self, new_limit: usize) {
@@ -150,12 +162,12 @@ impl MutexFileMetadataCache {
             }
             let mut freed = 0usize;
             {
-                let mut s = self.state.lock().unwrap_or_else(|e| e.into_inner());
+                let mut s = self.state.write().unwrap_or_else(|e| e.into_inner());
                 for key in &victims {
                     let path = Path::from(key.clone());
                     if let Some(entry) = s.map.remove(&path) {
                         let sz = entry_size(&entry);
-                        s.memory_used = s.memory_used.saturating_sub(sz);
+                        self.memory_used.fetch_sub(sz, Ordering::Relaxed);
                         freed += sz;
                     }
                 }
@@ -184,7 +196,8 @@ impl CacheAccessor<Path, CachedFileMetadataEntry> for MutexFileMetadataCache {
             return None;
         }
         let hit = {
-            let s = match self.state.lock() {
+            // Read lock: concurrent gets proceed in parallel; only mutations block readers.
+            let s = match self.state.read() {
                 Ok(s) => s,
                 Err(e) => {
                     log_cache_error("get", &e.to_string());
@@ -215,7 +228,7 @@ impl CacheAccessor<Path, CachedFileMetadataEntry> for MutexFileMetadataCache {
         let size = entry_size(&v);
         let key = k.to_string();
         let prev = {
-            let mut s = match self.state.lock() {
+            let mut s = match self.state.write() {
                 Ok(s) => s,
                 Err(e) => {
                     log_cache_error("put", &e.to_string());
@@ -223,10 +236,12 @@ impl CacheAccessor<Path, CachedFileMetadataEntry> for MutexFileMetadataCache {
                 }
             };
             let prev = s.map.insert(k.clone(), v);
+            // Update the byte total while the write lock is held so it stays consistent with the
+            // map: net add of `size`, minus the displaced entry's size if we replaced one.
             if let Some(old) = &prev {
-                s.memory_used = s.memory_used.saturating_sub(entry_size(old));
+                self.memory_used.fetch_sub(entry_size(old), Ordering::Relaxed);
             }
-            s.memory_used += size;
+            self.memory_used.fetch_add(size, Ordering::Relaxed);
             prev
         };
         if let Ok(mut p) = self.policy.lock() {
@@ -238,7 +253,7 @@ impl CacheAccessor<Path, CachedFileMetadataEntry> for MutexFileMetadataCache {
 
     fn remove(&self, k: &Path) -> Option<CachedFileMetadataEntry> {
         let removed = {
-            let mut s = match self.state.lock() {
+            let mut s = match self.state.write() {
                 Ok(s) => s,
                 Err(e) => {
                     log_cache_error("remove", &e.to_string());
@@ -247,7 +262,7 @@ impl CacheAccessor<Path, CachedFileMetadataEntry> for MutexFileMetadataCache {
             };
             let removed = s.map.remove(k);
             if let Some(entry) = &removed {
-                s.memory_used = s.memory_used.saturating_sub(entry_size(entry));
+                self.memory_used.fetch_sub(entry_size(entry), Ordering::Relaxed);
             }
             removed
         };
@@ -260,11 +275,11 @@ impl CacheAccessor<Path, CachedFileMetadataEntry> for MutexFileMetadataCache {
     }
 
     fn contains_key(&self, k: &Path) -> bool {
-        self.state.lock().map(|s| s.map.contains_key(k)).unwrap_or(false)
+        self.state.read().map(|s| s.map.contains_key(k)).unwrap_or(false)
     }
 
     fn len(&self) -> usize {
-        self.state.lock().map(|s| s.map.len()).unwrap_or(0)
+        self.state.read().map(|s| s.map.len()).unwrap_or(0)
     }
 
     fn clear(&self) {
@@ -287,7 +302,7 @@ impl FileMetadataCache for MutexFileMetadataCache {
     }
 
     fn list_entries(&self) -> HashMap<Path, FileMetadataCacheEntry> {
-        let s = match self.state.lock() {
+        let s = match self.state.read() {
             Ok(s) => s,
             Err(e) => {
                 log_cache_error("list_entries", &e.to_string());

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/cache.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/cache.rs
@@ -6,7 +6,7 @@
  * compatible open source license.
  */
 
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
 use datafusion::execution::cache::cache_manager::{
@@ -31,14 +31,36 @@ pub struct MutexFileMetadataCache {
     pub inner: Mutex<DefaultFilesMetadataCache>,
     hit_count: AtomicUsize,
     miss_count: AtomicUsize,
+    /// When false, the cache serves every lookup as a miss and drops all writes.
+    /// Toggled at runtime via the datafusion.metadata.cache.enabled setting; disabling
+    /// also clears existing entries (see `set_enabled`) so memory is freed.
+    enabled: AtomicBool,
 }
 
 impl MutexFileMetadataCache {
     pub fn new(cache: DefaultFilesMetadataCache) -> Self {
+        Self::with_enabled(cache, true)
+    }
+
+    pub fn with_enabled(cache: DefaultFilesMetadataCache, enabled: bool) -> Self {
         Self {
             inner: Mutex::new(cache),
             hit_count: AtomicUsize::new(0),
             miss_count: AtomicUsize::new(0),
+            enabled: AtomicBool::new(enabled),
+        }
+    }
+
+    pub fn is_enabled(&self) -> bool {
+        self.enabled.load(Ordering::Relaxed)
+    }
+
+    /// Enable or disable the cache at runtime. Disabling also clears existing entries
+    /// so the memory is released immediately; enabling starts caching again from cold.
+    pub fn set_enabled(&self, enabled: bool) {
+        self.enabled.store(enabled, Ordering::Relaxed);
+        if !enabled {
+            self.clear_cache();
         }
     }
 
@@ -78,6 +100,11 @@ impl MutexFileMetadataCache {
 
 impl CacheAccessor<Path, CachedFileMetadataEntry> for MutexFileMetadataCache {
     fn get(&self, k: &Path) -> Option<CachedFileMetadataEntry> {
+        // Disabled cache holds nothing (put drops writes); skip hit/miss accounting since
+        // the cache isn't participating.
+        if !self.is_enabled() {
+            return None;
+        }
         match self.inner.lock() {
             Ok(cache) => {
                 let result = cache.get(k);
@@ -96,6 +123,10 @@ impl CacheAccessor<Path, CachedFileMetadataEntry> for MutexFileMetadataCache {
     }
 
     fn put(&self, k: &Path, v: CachedFileMetadataEntry) -> Option<CachedFileMetadataEntry> {
+        // Drop writes while disabled so the cache stays empty / frees nothing to track.
+        if !self.is_enabled() {
+            return None;
+        }
         match self.inner.lock() {
             Ok(cache) => cache.put(k, v),
             Err(e) => {

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/cache.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/cache.rs
@@ -6,16 +6,18 @@
  * compatible open source license.
  */
 
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
 use datafusion::execution::cache::cache_manager::{
     CachedFileMetadataEntry, FileMetadataCache, FileMetadataCacheEntry,
 };
-use datafusion::execution::cache::DefaultFilesMetadataCache;
 use datafusion::execution::cache::CacheAccessor;
 use log::error;
 use object_store::path::Path;
+
+use crate::eviction_policy::{create_policy, CachePolicy, PolicyType};
 
 // Cache type constants
 pub const CACHE_TYPE_METADATA: &str = "METADATA";
@@ -26,9 +28,30 @@ fn log_cache_error(operation: &str, error: &str) {
     error!("[CACHE ERROR] {} operation failed: {}", operation, error);
 }
 
-// Wrapper to make Mutex<DefaultFilesMetadataCache> implement FileMetadataCache
+/// Byte size charged for one metadata entry: the file metadata's own reported size.
+fn entry_size(entry: &CachedFileMetadataEntry) -> usize {
+    entry.file_metadata.memory_size()
+}
+
+/// Inner store for [`MutexFileMetadataCache`]: the keyed entries plus running byte total.
+struct MetaState {
+    map: HashMap<Path, CachedFileMetadataEntry>,
+    memory_used: usize,
+}
+
+/// Metadata cache for parquet footers, keyed by file path.
+///
+/// Historically this wrapped DataFusion's `DefaultFilesMetadataCache`, whose eviction is
+/// **hardcoded LRU** — so `datafusion.metadata.cache.eviction.type` had no effect here.
+/// It now owns its store and drives the pluggable [`CachePolicy`] (LRU / LFU / S3-FIFO),
+/// mirroring `CustomStatisticsCache`, so the configured policy actually governs eviction
+/// of metadata entries (and a one-off wide scan no longer pollutes the hot footer set
+/// under S3-FIFO). Staleness is still the caller's job via `CachedFileMetadataEntry::is_valid_for`.
 pub struct MutexFileMetadataCache {
-    pub inner: Mutex<DefaultFilesMetadataCache>,
+    state: Mutex<MetaState>,
+    /// Pluggable eviction policy (interior-mutable; shared shape with the statistics cache).
+    policy: Arc<Mutex<Box<dyn CachePolicy>>>,
+    size_limit: AtomicUsize,
     hit_count: AtomicUsize,
     miss_count: AtomicUsize,
     /// When false, the cache serves every lookup as a miss and drops all writes.
@@ -38,17 +61,21 @@ pub struct MutexFileMetadataCache {
 }
 
 impl MutexFileMetadataCache {
-    pub fn new(cache: DefaultFilesMetadataCache) -> Self {
-        Self::with_enabled(cache, true)
-    }
-
-    pub fn with_enabled(cache: DefaultFilesMetadataCache, enabled: bool) -> Self {
+    /// Create with an explicit eviction policy, byte limit, and initial enabled state.
+    pub fn with_enabled(policy_type: PolicyType, size_limit: usize, enabled: bool) -> Self {
         Self {
-            inner: Mutex::new(cache),
+            state: Mutex::new(MetaState { map: HashMap::new(), memory_used: 0 }),
+            policy: Arc::new(Mutex::new(create_policy(policy_type))),
+            size_limit: AtomicUsize::new(size_limit),
             hit_count: AtomicUsize::new(0),
             miss_count: AtomicUsize::new(0),
             enabled: AtomicBool::new(enabled),
         }
+    }
+
+    /// Convenience constructor used by tests: LRU policy, given limit, enabled.
+    pub fn new(policy_type: PolicyType, size_limit: usize) -> Self {
+        Self::with_enabled(policy_type, size_limit, true)
     }
 
     pub fn is_enabled(&self) -> bool {
@@ -78,22 +105,73 @@ impl MutexFileMetadataCache {
     }
 
     pub fn clear_cache(&self) {
-        if let Ok(cache) = self.inner.lock() {
-            cache.clear();
+        if let Ok(mut s) = self.state.lock() {
+            s.map.clear();
+            s.memory_used = 0;
         }
+        if let Ok(mut p) = self.policy.lock() {
+            p.clear();
+        }
+        self.reset_stats();
+    }
+
+    /// Current bytes held by metadata entries.
+    pub fn memory_used(&self) -> usize {
+        self.state.lock().map(|s| s.memory_used).unwrap_or(0)
     }
 
     pub fn update_cache_limit(&self, new_limit: usize) {
-        if let Ok(cache) = self.inner.lock() {
-            cache.update_cache_limit(new_limit);
-        }
+        self.size_limit.store(new_limit, Ordering::Relaxed);
+        self.enforce_limit();
     }
 
     pub fn get_cache_limit(&self) -> usize {
-        if let Ok(cache) = self.inner.lock() {
-            cache.cache_limit()
-        } else {
-            0
+        self.size_limit.load(Ordering::Relaxed)
+    }
+
+    /// Evict via the policy until `memory_used <= size_limit`.
+    fn enforce_limit(&self) {
+        let limit = self.size_limit.load(Ordering::Relaxed);
+        // Evict in rounds: a single select_for_eviction may not free enough (e.g. a
+        // policy that promotes rather than evicts on a given victim), so loop until the
+        // cache is within budget or no further progress can be made.
+        loop {
+            let used = self.memory_used();
+            if used <= limit {
+                return;
+            }
+            let target = used - limit;
+            let victims = {
+                let mut p = self.policy.lock().unwrap_or_else(|e| e.into_inner());
+                p.select_for_eviction(target)
+            };
+            if victims.is_empty() {
+                return; // policy has nothing more to give; avoid spinning
+            }
+            let mut freed = 0usize;
+            {
+                let mut s = self.state.lock().unwrap_or_else(|e| e.into_inner());
+                for key in &victims {
+                    let path = Path::from(key.clone());
+                    if let Some(entry) = s.map.remove(&path) {
+                        let sz = entry_size(&entry);
+                        s.memory_used = s.memory_used.saturating_sub(sz);
+                        freed += sz;
+                    }
+                }
+            }
+            // Keep the policy's bookkeeping in sync with the store: the evicted keys are
+            // gone, so the policy must forget them (otherwise LRU/LFU keep returning
+            // already-removed victims and the cache never converges).
+            {
+                let mut p = self.policy.lock().unwrap_or_else(|e| e.into_inner());
+                for key in &victims {
+                    p.on_remove(key);
+                }
+            }
+            if freed == 0 {
+                return; // selected victims weren't resident; stop to avoid an infinite loop
+            }
         }
     }
 }
@@ -105,21 +183,28 @@ impl CacheAccessor<Path, CachedFileMetadataEntry> for MutexFileMetadataCache {
         if !self.is_enabled() {
             return None;
         }
-        match self.inner.lock() {
-            Ok(cache) => {
-                let result = cache.get(k);
-                if result.is_some() {
-                    self.hit_count.fetch_add(1, Ordering::Relaxed);
-                } else {
-                    self.miss_count.fetch_add(1, Ordering::Relaxed);
+        let hit = {
+            let s = match self.state.lock() {
+                Ok(s) => s,
+                Err(e) => {
+                    log_cache_error("get", &e.to_string());
+                    return None;
                 }
-                result
+            };
+            s.map.get(k).cloned()
+        };
+        match &hit {
+            Some(entry) => {
+                self.hit_count.fetch_add(1, Ordering::Relaxed);
+                if let Ok(mut p) = self.policy.lock() {
+                    p.on_access(&k.to_string(), entry_size(entry));
+                }
             }
-            Err(e) => {
-                log_cache_error("get", &e.to_string());
-                None
+            None => {
+                self.miss_count.fetch_add(1, Ordering::Relaxed);
             }
         }
+        hit
     }
 
     fn put(&self, k: &Path, v: CachedFileMetadataEntry) -> Option<CachedFileMetadataEntry> {
@@ -127,88 +212,218 @@ impl CacheAccessor<Path, CachedFileMetadataEntry> for MutexFileMetadataCache {
         if !self.is_enabled() {
             return None;
         }
-        match self.inner.lock() {
-            Ok(cache) => cache.put(k, v),
-            Err(e) => {
-                log_cache_error("put", &e.to_string());
-                None
+        let size = entry_size(&v);
+        let key = k.to_string();
+        let prev = {
+            let mut s = match self.state.lock() {
+                Ok(s) => s,
+                Err(e) => {
+                    log_cache_error("put", &e.to_string());
+                    return None;
+                }
+            };
+            let prev = s.map.insert(k.clone(), v);
+            if let Some(old) = &prev {
+                s.memory_used = s.memory_used.saturating_sub(entry_size(old));
             }
+            s.memory_used += size;
+            prev
+        };
+        if let Ok(mut p) = self.policy.lock() {
+            p.on_insert(&key, size);
         }
+        self.enforce_limit();
+        prev
     }
 
     fn remove(&self, k: &Path) -> Option<CachedFileMetadataEntry> {
-        match self.inner.lock() {
-            Ok(cache) => cache.remove(k),
-            Err(e) => {
-                log_cache_error("remove", &e.to_string());
-                None
+        let removed = {
+            let mut s = match self.state.lock() {
+                Ok(s) => s,
+                Err(e) => {
+                    log_cache_error("remove", &e.to_string());
+                    return None;
+                }
+            };
+            let removed = s.map.remove(k);
+            if let Some(entry) = &removed {
+                s.memory_used = s.memory_used.saturating_sub(entry_size(entry));
+            }
+            removed
+        };
+        if removed.is_some() {
+            if let Ok(mut p) = self.policy.lock() {
+                p.on_remove(&k.to_string());
             }
         }
+        removed
     }
 
     fn contains_key(&self, k: &Path) -> bool {
-        match self.inner.lock() {
-            Ok(cache) => cache.contains_key(k),
-            Err(e) => {
-                log_cache_error("contains_key", &e.to_string());
-                false
-            }
-        }
+        self.state.lock().map(|s| s.map.contains_key(k)).unwrap_or(false)
     }
 
     fn len(&self) -> usize {
-        match self.inner.lock() {
-            Ok(cache) => cache.len(),
-            Err(e) => {
-                log_cache_error("len", &e.to_string());
-                0
-            }
-        }
+        self.state.lock().map(|s| s.map.len()).unwrap_or(0)
     }
 
     fn clear(&self) {
-        match self.inner.lock() {
-            Ok(cache) => cache.clear(),
-            Err(e) => log_cache_error("clear", &e.to_string()),
-        }
+        self.clear_cache();
     }
 
     fn name(&self) -> String {
-        match self.inner.lock() {
-            Ok(cache) => cache.name(),
-            Err(e) => {
-                log_cache_error("name", &e.to_string());
-                "cache_error".to_string()
-            }
-        }
+        "MutexFileMetadataCache".to_string()
     }
 }
 
 impl FileMetadataCache for MutexFileMetadataCache {
     fn cache_limit(&self) -> usize {
-        match self.inner.lock() {
-            Ok(cache) => cache.cache_limit(),
-            Err(e) => {
-                log_cache_error("cache_limit", &e.to_string());
-                0
-            }
-        }
+        self.size_limit.load(Ordering::Relaxed)
     }
 
     fn update_cache_limit(&self, limit: usize) {
-        match self.inner.lock() {
-            Ok(cache) => cache.update_cache_limit(limit),
-            Err(e) => log_cache_error("update_cache_limit", &e.to_string()),
+        self.size_limit.store(limit, Ordering::Relaxed);
+        self.enforce_limit();
+    }
+
+    fn list_entries(&self) -> HashMap<Path, FileMetadataCacheEntry> {
+        let s = match self.state.lock() {
+            Ok(s) => s,
+            Err(e) => {
+                log_cache_error("list_entries", &e.to_string());
+                return HashMap::new();
+            }
+        };
+        s.map
+            .iter()
+            .map(|(path, entry)| {
+                (
+                    path.clone(),
+                    FileMetadataCacheEntry {
+                        object_meta: entry.meta.clone(),
+                        size_bytes: entry_size(entry),
+                        hits: 0,
+                        extra: entry.file_metadata.extra_info(),
+                    },
+                )
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::eviction_policy::PolicyType;
+    use chrono::Utc;
+    use datafusion::execution::cache::cache_manager::FileMetadata;
+    use object_store::ObjectMeta;
+    use std::any::Any;
+
+    /// Minimal `FileMetadata` test double with a fixed byte size.
+    #[derive(Debug)]
+    struct FakeMetadata {
+        bytes: usize,
+    }
+
+    impl FileMetadata for FakeMetadata {
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+        fn memory_size(&self) -> usize {
+            self.bytes
+        }
+        fn extra_info(&self) -> std::collections::HashMap<String, String> {
+            std::collections::HashMap::new()
         }
     }
 
-    fn list_entries(&self) -> std::collections::HashMap<Path, FileMetadataCacheEntry> {
-        match self.inner.lock() {
-            Ok(cache) => cache.list_entries(),
-            Err(e) => {
-                log_cache_error("list_entries", &e.to_string());
-                std::collections::HashMap::new()
+    const ENTRY_BYTES: usize = 1024;
+
+    fn path(name: &str) -> Path {
+        Path::from(format!("/test/{name}.parquet"))
+    }
+
+    fn entry(p: &Path) -> CachedFileMetadataEntry {
+        let meta = ObjectMeta {
+            location: p.clone(),
+            last_modified: Utc::now(),
+            size: ENTRY_BYTES as u64,
+            e_tag: None,
+            version: None,
+        };
+        CachedFileMetadataEntry::new(meta, Arc::new(FakeMetadata { bytes: ENTRY_BYTES }))
+    }
+
+    #[test]
+    fn test_metadata_cache_basic_put_get_evict() {
+        // 5-entry budget, LRU. Insert past the limit → byte cap enforced.
+        let cache = MutexFileMetadataCache::new(PolicyType::Lru, ENTRY_BYTES * 5);
+        for i in 0..10 {
+            let p = path(&format!("f{i}"));
+            cache.put(&p, entry(&p));
+        }
+        assert!(cache.memory_used() <= ENTRY_BYTES * 5, "byte limit must be enforced");
+        assert!(cache.len() > 0 && cache.len() <= 5);
+    }
+
+    #[test]
+    fn test_metadata_cache_disabled_drops_writes() {
+        let cache = MutexFileMetadataCache::with_enabled(PolicyType::Lru, ENTRY_BYTES * 5, false);
+        let p = path("x");
+        cache.put(&p, entry(&p));
+        assert!(cache.get(&p).is_none(), "disabled cache serves misses");
+        assert_eq!(cache.len(), 0, "disabled cache holds nothing");
+    }
+
+    #[test]
+    fn test_e2e_metadata_s3fifo_hot_set_survives_scan() {
+        // The headline property, end-to-end through the metadata cache's CacheAccessor
+        // path with S3-FIFO: a hot footer set survives a wide one-off scan.
+        let cache = MutexFileMetadataCache::new(PolicyType::S3Fifo, ENTRY_BYTES * 10);
+
+        let hot: Vec<Path> = (0..3).map(|i| path(&format!("hot{i}"))).collect();
+        for p in &hot {
+            cache.put(p, entry(p));
+        }
+        // Query the hot set repeatedly → earns frequency in the policy.
+        for _ in 0..5 {
+            for p in &hot {
+                assert!(cache.get(p).is_some(), "hot footer present during warmup");
             }
         }
+
+        // Wide one-off scan: 100 cold footers, each read once.
+        for i in 0..100 {
+            let p = path(&format!("scan{i}"));
+            cache.put(&p, entry(&p));
+        }
+
+        // Majority of the hot footer set must survive (see the statistics-cache e2e
+        // test for why "majority" not "all" under the SLRU-like 50% probation default).
+        let survivors = hot.iter().filter(|p| cache.get(p).is_some()).count();
+        assert!(
+            survivors >= 2,
+            "S3-FIFO metadata cache must keep most of the {} hot footers after a 100-file scan; survived {}",
+            hot.len(), survivors
+        );
+        assert!(cache.memory_used() <= ENTRY_BYTES * 10, "cache must honor its byte limit");
+    }
+
+    #[test]
+    fn test_e2e_metadata_update_limit_shrinks() {
+        // Lowering the limit at runtime evicts down to the new budget (mirrors the
+        // dynamic datafusion.metadata.cache.size.limit path).
+        let cache = MutexFileMetadataCache::new(PolicyType::S3Fifo, ENTRY_BYTES * 20);
+        for i in 0..15 {
+            let p = path(&format!("f{i}"));
+            cache.put(&p, entry(&p));
+        }
+        assert!(cache.memory_used() > ENTRY_BYTES * 5);
+        cache.update_cache_limit(ENTRY_BYTES * 5);
+        assert!(
+            cache.memory_used() <= ENTRY_BYTES * 5,
+            "shrinking the limit must evict down to the new budget"
+        );
     }
 }

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/custom_cache_manager.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/custom_cache_manager.rs
@@ -172,17 +172,10 @@ impl CustomCacheManager {
             {
                 let path = Path::from(file_path.clone());
                 if let Some(cache) = &self.file_metadata_cache {
-                    match cache.inner.lock() {
-                        Ok(cache_guard) => {
-                            if cache_guard.remove(&path).is_some() {
-                                any_removed = true;
-                            } else {
-                                debug!("[CACHE INFO] File not found in metadata cache: {}", file_path);
-                            }
-                        }
-                        Err(e) => {
-                            errors.push(format!("Metadata cache: Cache remove failed: {}", e));
-                        }
+                    if CacheAccessor::remove(cache.as_ref(), &path).is_some() {
+                        any_removed = true;
+                    } else {
+                        debug!("[CACHE INFO] File not found in metadata cache: {}", file_path);
                     }
                 } else {
                     errors.push("No metadata cache configured".to_string());
@@ -325,9 +318,7 @@ impl CustomCacheManager {
 
         // Add metadata cache memory
         if let Some(cache) = &self.file_metadata_cache {
-            if let Ok(cache_guard) = cache.inner.lock() {
-                total += cache_guard.memory_used();
-            }
+            total += cache.memory_used();
         }
 
         // Add statistics cache memory
@@ -376,11 +367,7 @@ impl CustomCacheManager {
         match cache_type {
             crate::cache::CACHE_TYPE_METADATA => {
                 if let Some(cache) = &self.file_metadata_cache {
-                    if let Ok(cache_guard) = cache.inner.lock() {
-                        Ok(cache_guard.memory_used())
-                    } else {
-                        Err("Failed to lock metadata cache".to_string())
-                    }
+                    Ok(cache.memory_used())
                 } else {
                     Err("No metadata cache configured".to_string())
                 }
@@ -432,17 +419,12 @@ impl CustomCacheManager {
         })?;
 
         // Verify the metadata was cached properly
-        match cache_ref.inner.lock() {
-            Ok(cache_guard) => {
-                let path = Path::from(file_path.to_string());
-                if cache_guard.contains_key(&path) {
-                    Ok(true)
-                } else {
-                    debug!("[CACHE ERROR] Failed to cache metadata for: {}", file_path);
-                    Ok(false)
-                }
-            }
-            Err(e) => Err(format!("Failed to verify cache: {}", e))
+        let path = Path::from(file_path.to_string());
+        if CacheAccessor::contains_key(cache_ref.as_ref(), &path) {
+            Ok(true)
+        } else {
+            debug!("[CACHE ERROR] Failed to cache metadata for: {}", file_path);
+            Ok(false)
         }
     }
 
@@ -627,7 +609,7 @@ mod tests {
 
     fn manager_with_both_caches(metadata_limit: usize, stats_limit: usize) -> CustomCacheManager {
         let mut mgr = CustomCacheManager::new();
-        let metadata = Arc::new(MutexFileMetadataCache::new(DefaultFilesMetadataCache::new(metadata_limit)));
+        let metadata = Arc::new(MutexFileMetadataCache::new(PolicyType::Lru, metadata_limit));
         mgr.set_file_metadata_cache(metadata);
         let stats = Arc::new(CustomStatisticsCache::new(PolicyType::Lru, stats_limit, 0.8));
         mgr.set_statistics_cache(stats);
@@ -682,7 +664,7 @@ mod tests {
     #[test]
     fn test_set_enabled_by_type_unknown_and_unconfigured_error() {
         let mut mgr = CustomCacheManager::new();
-        let metadata = Arc::new(MutexFileMetadataCache::new(DefaultFilesMetadataCache::new(250 * 1024 * 1024)));
+        let metadata = Arc::new(MutexFileMetadataCache::new(PolicyType::Lru, 250 * 1024 * 1024));
         mgr.set_file_metadata_cache(metadata);
 
         let unknown = mgr.set_enabled_by_type("BOGUS", false).expect_err("unknown type must error");
@@ -708,7 +690,7 @@ mod tests {
         // Manager with only the metadata cache set — resizing STATISTICS must error,
         // not panic, so the FFM layer can surface it to Java.
         let mut mgr = CustomCacheManager::new();
-        let metadata = Arc::new(MutexFileMetadataCache::new(DefaultFilesMetadataCache::new(250 * 1024 * 1024)));
+        let metadata = Arc::new(MutexFileMetadataCache::new(PolicyType::Lru, 250 * 1024 * 1024));
         mgr.set_file_metadata_cache(metadata);
 
         let err = mgr

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/custom_cache_manager.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/custom_cache_manager.rs
@@ -92,9 +92,17 @@ impl CustomCacheManager {
                 .with_metadata_cache_limit(cache.cache_limit());
         }
 
-        // Add statistics cache if available - use CustomStatisticsCache directly
+        // Add statistics cache if available - use CustomStatisticsCache directly.
+        // We MUST also set the limit explicitly: CacheManager::try_new calls
+        // fsc.update_cache_limit(config.file_statistics_cache_limit), which defaults to
+        // DEFAULT_FILE_STATISTICS_MEMORY_LIMIT (20MiB). Without this, our configured
+        // datafusion.statistics.cache.size.limit (100MB default) would be clobbered to
+        // 20MiB at runtime startup, mirroring with_metadata_cache_limit above.
         if let Some(stats_cache) = &self.statistics_cache {
-            config = config.with_file_statistics_cache(Some(stats_cache.clone() as Arc<dyn FileStatisticsCache>));
+            let stats_limit = stats_cache.current_size_limit();
+            config = config
+                .with_file_statistics_cache(Some(stats_cache.clone() as Arc<dyn FileStatisticsCache>))
+                .with_file_statistics_cache_limit(stats_limit);
         } else {
             // Default statistics cache if none set
             let default_stats = Arc::new(DefaultFileStatisticsCache::default());
@@ -259,6 +267,55 @@ impl CustomCacheManager {
                 .map_err(|e| format!("Failed to update statistics cache limit: {:?}", e))
         } else {
             Err("No statistics cache configured".to_string())
+        }
+    }
+
+    /// Enable or disable a specific cache type at runtime.
+    ///
+    /// Dispatches by the same cache-type strings as [`update_size_limit_by_type`].
+    /// Disabling also clears the cache (see `MutexFileMetadataCache::set_enabled` /
+    /// `CustomStatisticsCache::set_enabled`) so memory is freed immediately. Returns an
+    /// error when the named cache is not configured or the type is unknown.
+    pub fn set_enabled_by_type(&self, cache_type: &str, enabled: bool) -> Result<(), String> {
+        match cache_type {
+            crate::cache::CACHE_TYPE_METADATA => {
+                if let Some(cache) = &self.file_metadata_cache {
+                    cache.set_enabled(enabled);
+                    Ok(())
+                } else {
+                    Err("No metadata cache configured".to_string())
+                }
+            }
+            crate::cache::CACHE_TYPE_STATS => {
+                if let Some(cache) = &self.statistics_cache {
+                    cache.set_enabled(enabled);
+                    Ok(())
+                } else {
+                    Err("No statistics cache configured".to_string())
+                }
+            }
+            _ => Err(format!("Unknown cache type: {}", cache_type)),
+        }
+    }
+
+    /// Update the size limit of a specific cache type at runtime.
+    ///
+    /// Dispatches to [`update_metadata_cache_limit`] / [`update_statistics_cache_limit`]
+    /// keyed on the same cache-type strings used by [`clear_cache_type`]. Returns an
+    /// error when the named cache is not configured or the type is unknown so the FFM
+    /// layer can surface it to the Java caller.
+    pub fn update_size_limit_by_type(&self, cache_type: &str, new_limit: usize) -> Result<(), String> {
+        match cache_type {
+            crate::cache::CACHE_TYPE_METADATA => {
+                if self.file_metadata_cache.is_some() {
+                    self.update_metadata_cache_limit(new_limit);
+                    Ok(())
+                } else {
+                    Err("No metadata cache configured".to_string())
+                }
+            }
+            crate::cache::CACHE_TYPE_STATS => self.update_statistics_cache_limit(new_limit),
+            _ => Err(format!("Unknown cache type: {}", cache_type)),
         }
     }
 
@@ -558,5 +615,110 @@ impl CustomCacheManager {
         if let Some(cache) = &self.file_metadata_cache {
             cache.reset_stats();
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cache::MutexFileMetadataCache;
+    use crate::eviction_policy::PolicyType;
+    use datafusion::execution::cache::DefaultFilesMetadataCache;
+
+    fn manager_with_both_caches(metadata_limit: usize, stats_limit: usize) -> CustomCacheManager {
+        let mut mgr = CustomCacheManager::new();
+        let metadata = Arc::new(MutexFileMetadataCache::new(DefaultFilesMetadataCache::new(metadata_limit)));
+        mgr.set_file_metadata_cache(metadata);
+        let stats = Arc::new(CustomStatisticsCache::new(PolicyType::Lru, stats_limit, 0.8));
+        mgr.set_statistics_cache(stats);
+        mgr
+    }
+
+    #[test]
+    fn test_update_size_limit_by_type_metadata_changes_limit() {
+        let mgr = manager_with_both_caches(250 * 1024 * 1024, 100 * 1024 * 1024);
+        // Default boot value, then a runtime "PUT 2gb".
+        mgr.update_size_limit_by_type(crate::cache::CACHE_TYPE_METADATA, 2 * 1024 * 1024 * 1024)
+            .expect("metadata resize should succeed");
+        assert_eq!(mgr.metadata_cache_size_limit(), 2 * 1024 * 1024 * 1024);
+        // The statistics cache must be untouched by a METADATA-typed resize.
+        assert_eq!(
+            mgr.get_statistics_cache().unwrap().current_size_limit(),
+            100 * 1024 * 1024
+        );
+    }
+
+    #[test]
+    fn test_update_size_limit_by_type_statistics_changes_limit() {
+        let mgr = manager_with_both_caches(250 * 1024 * 1024, 100 * 1024 * 1024);
+        mgr.update_size_limit_by_type(crate::cache::CACHE_TYPE_STATS, 256 * 1024 * 1024)
+            .expect("statistics resize should succeed");
+        assert_eq!(
+            mgr.get_statistics_cache().unwrap().current_size_limit(),
+            256 * 1024 * 1024
+        );
+        // METADATA limit unchanged by a STATISTICS-typed resize.
+        assert_eq!(mgr.metadata_cache_size_limit(), 250 * 1024 * 1024);
+    }
+
+    #[test]
+    fn test_set_enabled_by_type_toggles_correct_cache() {
+        let mgr = manager_with_both_caches(250 * 1024 * 1024, 100 * 1024 * 1024);
+
+        mgr.set_enabled_by_type(crate::cache::CACHE_TYPE_STATS, false)
+            .expect("disable statistics should succeed");
+        assert!(!mgr.get_statistics_cache().unwrap().is_enabled(), "statistics cache should be disabled");
+
+        // Re-enable.
+        mgr.set_enabled_by_type(crate::cache::CACHE_TYPE_STATS, true)
+            .expect("enable statistics should succeed");
+        assert!(mgr.get_statistics_cache().unwrap().is_enabled());
+
+        // METADATA toggling resolves too.
+        mgr.set_enabled_by_type(crate::cache::CACHE_TYPE_METADATA, false)
+            .expect("disable metadata should succeed");
+    }
+
+    #[test]
+    fn test_set_enabled_by_type_unknown_and_unconfigured_error() {
+        let mut mgr = CustomCacheManager::new();
+        let metadata = Arc::new(MutexFileMetadataCache::new(DefaultFilesMetadataCache::new(250 * 1024 * 1024)));
+        mgr.set_file_metadata_cache(metadata);
+
+        let unknown = mgr.set_enabled_by_type("BOGUS", false).expect_err("unknown type must error");
+        assert!(unknown.contains("Unknown cache type"), "got: {}", unknown);
+
+        let unconfigured = mgr
+            .set_enabled_by_type(crate::cache::CACHE_TYPE_STATS, false)
+            .expect_err("toggling an unconfigured cache must error");
+        assert!(unconfigured.contains("No statistics cache configured"), "got: {}", unconfigured);
+    }
+
+    #[test]
+    fn test_update_size_limit_by_type_unknown_type_errors() {
+        let mgr = manager_with_both_caches(250 * 1024 * 1024, 100 * 1024 * 1024);
+        let err = mgr
+            .update_size_limit_by_type("BOGUS", 1024)
+            .expect_err("unknown cache type must error");
+        assert!(err.contains("Unknown cache type"), "got: {}", err);
+    }
+
+    #[test]
+    fn test_update_size_limit_by_type_unconfigured_cache_errors() {
+        // Manager with only the metadata cache set — resizing STATISTICS must error,
+        // not panic, so the FFM layer can surface it to Java.
+        let mut mgr = CustomCacheManager::new();
+        let metadata = Arc::new(MutexFileMetadataCache::new(DefaultFilesMetadataCache::new(250 * 1024 * 1024)));
+        mgr.set_file_metadata_cache(metadata);
+
+        let err = mgr
+            .update_size_limit_by_type(crate::cache::CACHE_TYPE_STATS, 1024)
+            .expect_err("resizing an unconfigured cache must error");
+        assert!(err.contains("No statistics cache configured"), "got: {}", err);
+
+        // And metadata still resizes fine on the same manager.
+        mgr.update_size_limit_by_type(crate::cache::CACHE_TYPE_METADATA, 512 * 1024 * 1024)
+            .expect("metadata resize should still succeed");
+        assert_eq!(mgr.metadata_cache_size_limit(), 512 * 1024 * 1024);
     }
 }

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/eviction_policy.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/eviction_policy.rs
@@ -50,6 +50,11 @@ pub trait CachePolicy: Send + Sync {
 pub enum PolicyType {
     Lru,
     Lfu,
+    /// S3-FIFO (Yang et al., SOSP'23): scan-resistant, FIFO-based. New keys enter a
+    /// small probationary queue; only keys re-accessed there are promoted to the main
+    /// queue, so a one-off scan of cold keys is evicted out of the small queue without
+    /// displacing the hot working set in main.
+    S3Fifo,
 }
 
 /// Simple cache entry metadata
@@ -284,11 +289,311 @@ impl CachePolicy for LfuPolicy {
     }
 }
 
+/// S3-FIFO (Yang et al., SOSP'23) — scan-resistant eviction.
+///
+/// Three structures (here keyed by cache key string, sizes tracked in bytes):
+/// - **small**  : probationary FIFO. Every new key lands here.
+/// - **main**   : the hot set FIFO (proven reuse).
+/// - **ghost**  : keys-only history of recently small-evicted keys (no sizes); a
+///                re-insert whose key is in ghost goes straight to main.
+///
+/// Each live entry carries a 2-bit-style frequency (0..=3) bumped on access.
+///
+/// Scan resistance: a one-off scan touches each cold key once, so `freq` stays 0 in
+/// `small`; on small-overflow such a key is evicted (to ghost) rather than promoted,
+/// so it never enters `main` and cannot displace the hot working set. This mirrors
+/// ClickHouse's SLRU intent but with FIFO queues (no per-access list reordering).
+///
+/// `select_for_eviction` is the trait's `&self` victim-picker; S3-FIFO mutates its
+/// queues while choosing victims (demotion, ghost bookkeeping), so all mutable state
+/// lives behind a `Mutex` for interior mutability. Lock poisoning is recovered rather
+/// than propagated (`into_inner`): a panic in another thread can at worst leave the
+/// byte accounting slightly stale, never unsafe, and a cache must degrade rather than
+/// abort the process.
+pub struct S3FifoPolicy {
+    state: std::sync::Mutex<S3FifoState>,
+    /// Fraction of total capacity assigned to the small/probationary queue. Defaults to
+    /// 0.50 (SLRU-like 50/50 split); see `S3FifoPolicy::new`.
+    small_ratio: f64,
+}
+
+struct S3FifoEntry {
+    size: usize,
+    freq: u8,
+}
+
+struct S3FifoState {
+    /// key -> (size, freq) for keys resident in `small`.
+    small: std::collections::HashMap<String, S3FifoEntry>,
+    /// FIFO order of keys in `small`.
+    small_order: std::collections::VecDeque<String>,
+    small_bytes: usize,
+    /// key -> (size, freq) for keys resident in `main`.
+    main: std::collections::HashMap<String, S3FifoEntry>,
+    /// FIFO order of keys in `main`.
+    main_order: std::collections::VecDeque<String>,
+    main_bytes: usize,
+    /// Keys-only ghost history (recently evicted from small), FIFO-bounded.
+    ghost: std::collections::HashSet<String>,
+    ghost_order: std::collections::VecDeque<String>,
+    /// Running total = small_bytes + main_bytes. Tracked to derive capacity targets
+    /// without a configured limit (the cache enforces the byte cap; this policy only
+    /// decides ordering/victims relative to the small/main split of current usage).
+    total_bytes: usize,
+}
+
+/// Frequency saturates at 3 (2-bit counter, as in the S3-FIFO paper).
+const S3FIFO_MAX_FREQ: u8 = 3;
+
+impl S3FifoPolicy {
+    /// Default small/probationary share. Set to 0.50 (rather than the S3-FIFO paper's
+    /// ~10%) so the probationary vs. protected split mirrors a 50/50 SLRU — matching
+    /// ClickHouse's default `*_cache_size_ratio` for its scan-resistant caches. A larger
+    /// probationary segment tolerates more one-off churn before promoting to the
+    /// protected `main` set.
+    pub fn new() -> Self {
+        Self::with_small_ratio(0.50)
+    }
+
+    pub fn with_small_ratio(small_ratio: f64) -> Self {
+        Self {
+            state: std::sync::Mutex::new(S3FifoState {
+                small: std::collections::HashMap::new(),
+                small_order: std::collections::VecDeque::new(),
+                small_bytes: 0,
+                main: std::collections::HashMap::new(),
+                main_order: std::collections::VecDeque::new(),
+                main_bytes: 0,
+                ghost: std::collections::HashSet::new(),
+                ghost_order: std::collections::VecDeque::new(),
+                total_bytes: 0,
+            }),
+            small_ratio: small_ratio.clamp(0.01, 0.99),
+        }
+    }
+}
+
+impl Default for S3FifoPolicy {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl S3FifoState {
+    /// Capacity budget for the small queue, derived as a fraction of current total
+    /// usage. The cache owns the absolute byte limit and calls `select_for_eviction`
+    /// with the number of bytes it needs freed; `small`'s share just controls how much
+    /// probationary churn we tolerate before promoting/evicting.
+    fn small_budget(&self, small_ratio: f64) -> usize {
+        ((self.total_bytes as f64) * small_ratio) as usize
+    }
+
+    fn ghost_capacity(&self) -> usize {
+        // Bound ghost to the number of keys main can hold, approximated by current
+        // resident key count (paper bounds ghost to ~main's entry count).
+        (self.small.len() + self.main.len()).max(16)
+    }
+
+    fn remember_ghost(&mut self, key: String) {
+        if self.ghost.insert(key.clone()) {
+            self.ghost_order.push_back(key);
+            while self.ghost_order.len() > self.ghost_capacity() {
+                if let Some(old) = self.ghost_order.pop_front() {
+                    self.ghost.remove(&old);
+                }
+            }
+        }
+    }
+
+    fn forget_key(&mut self, key: &str) {
+        if let Some(e) = self.small.remove(key) {
+            self.small_bytes -= e.size;
+            self.total_bytes -= e.size;
+            if let Some(pos) = self.small_order.iter().position(|k| k == key) {
+                self.small_order.remove(pos);
+            }
+        } else if let Some(e) = self.main.remove(key) {
+            self.main_bytes -= e.size;
+            self.total_bytes -= e.size;
+            if let Some(pos) = self.main_order.iter().position(|k| k == key) {
+                self.main_order.remove(pos);
+            }
+        }
+    }
+}
+
+impl CachePolicy for S3FifoPolicy {
+    fn on_access(&mut self, key: &str, size: usize) {
+        let mut s = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        if let Some(e) = s.small.get_mut(key) {
+            e.freq = (e.freq + 1).min(S3FIFO_MAX_FREQ);
+        } else if let Some(e) = s.main.get_mut(key) {
+            e.freq = (e.freq + 1).min(S3FIFO_MAX_FREQ);
+        } else {
+            // Not resident yet — treat as an insert so the policy and cache stay in
+            // sync even if the cache reports access before insert.
+            drop(s);
+            self.on_insert(key, size);
+        }
+    }
+
+    fn on_insert(&mut self, key: &str, size: usize) {
+        let mut s = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        // Re-insert of a still-resident key: refresh size, bump freq, done.
+        if let Some(e) = s.small.get_mut(key) {
+            let old = e.size;
+            e.size = size;
+            e.freq = (e.freq + 1).min(S3FIFO_MAX_FREQ);
+            s.small_bytes = s.small_bytes - old + size;
+            s.total_bytes = s.total_bytes - old + size;
+            return;
+        }
+        if let Some(e) = s.main.get_mut(key) {
+            let old = e.size;
+            e.size = size;
+            e.freq = (e.freq + 1).min(S3FIFO_MAX_FREQ);
+            s.main_bytes = s.main_bytes - old + size;
+            s.total_bytes = s.total_bytes - old + size;
+            return;
+        }
+        // A key seen recently (in ghost) was popular enough to come back → main.
+        if s.ghost.remove(key) {
+            if let Some(pos) = s.ghost_order.iter().position(|k| k == key) {
+                s.ghost_order.remove(pos);
+            }
+            s.main.insert(key.to_string(), S3FifoEntry { size, freq: 0 });
+            s.main_order.push_back(key.to_string());
+            s.main_bytes += size;
+            s.total_bytes += size;
+        } else {
+            // Fresh key → small (probation).
+            s.small.insert(key.to_string(), S3FifoEntry { size, freq: 0 });
+            s.small_order.push_back(key.to_string());
+            s.small_bytes += size;
+            s.total_bytes += size;
+        }
+    }
+
+    fn on_remove(&mut self, key: &str) {
+        let mut s = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        s.forget_key(key);
+    }
+
+    fn select_for_eviction(&self, target_size: usize) -> Vec<String> {
+        if target_size == 0 {
+            return Vec::new();
+        }
+        let mut s = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        let mut victims = Vec::new();
+        let mut freed = 0usize;
+
+        // Each outer round produces (at most) one evicted victim. Per S3-FIFO, the
+        // small-vs-main choice is made once per round, then that queue is *fully
+        // resolved*: promotions (small, freq>0) and CLOCK reinsertions (main, freq>0)
+        // do not count as the round's eviction — we keep popping that queue until a
+        // freq-0 entry is actually evicted. Re-deciding small-vs-main after a promotion
+        // (the earlier bug) could evict a key we just promoted into main.
+        //
+        // Bounded so a round that only promotes/reinserts (no freq-0 victim yet) cannot
+        // spin forever. A main entry may need up to S3FIFO_MAX_FREQ decrement passes
+        // before it becomes evictable, so allow that many laps over the resident set.
+        let max_rounds =
+            (s.small_order.len() + s.main_order.len()) * (S3FIFO_MAX_FREQ as usize + 1) + 1;
+        for _ in 0..max_rounds {
+            if freed >= target_size {
+                break;
+            }
+            if s.small_order.is_empty() && s.main_order.is_empty() {
+                break;
+            }
+            // Drain `small` (probation) while it is over its byte budget — that is where
+            // one-hit-wonders from a scan accumulate, so draining it protects the hot
+            // `main` set. Otherwise take from `main`; fall back to whichever is non-empty.
+            let small_over_budget = s.small_bytes > s.small_budget(self.small_ratio);
+            let use_small = if s.small_order.is_empty() {
+                false
+            } else if s.main_order.is_empty() {
+                true
+            } else {
+                small_over_budget
+            };
+
+            if use_small {
+                // Pop small until we evict one freq-0 entry; promote freq>0 entries to
+                // main. Bound the scan to the current queue length so a round of
+                // all-freq>0 entries (all promoted, none evicted) cannot spin.
+                let mut steps = s.small_order.len();
+                while steps > 0 {
+                    steps -= 1;
+                    let Some(key) = s.small_order.pop_front() else { break };
+                    let Some(entry) = s.small.remove(&key) else { continue };
+                    if entry.freq > 0 {
+                        s.small_bytes -= entry.size;
+                        s.main_bytes += entry.size;
+                        s.main.insert(key.clone(), S3FifoEntry { size: entry.size, freq: 0 });
+                        s.main_order.push_back(key);
+                    } else {
+                        s.small_bytes -= entry.size;
+                        s.total_bytes -= entry.size;
+                        freed += entry.size;
+                        s.remember_ghost(key.clone());
+                        victims.push(key);
+                        break;
+                    }
+                }
+            } else {
+                // Pop main until we evict one freq-0 entry; reinsert freq>0 (CLOCK lap,
+                // freq decremented). Bound to the current queue length so a round where
+                // every entry still has freq>0 makes one decrement pass and then stops
+                // (the next round will find lower freqs), rather than spinning.
+                let mut steps = s.main_order.len();
+                while steps > 0 {
+                    steps -= 1;
+                    let Some(key) = s.main_order.pop_front() else { break };
+                    let Some(entry) = s.main.remove(&key) else { continue };
+                    if entry.freq > 0 {
+                        s.main.insert(
+                            key.clone(),
+                            S3FifoEntry { size: entry.size, freq: entry.freq - 1 },
+                        );
+                        s.main_order.push_back(key);
+                    } else {
+                        s.main_bytes -= entry.size;
+                        s.total_bytes -= entry.size;
+                        freed += entry.size;
+                        victims.push(key);
+                        break;
+                    }
+                }
+            }
+        }
+        victims
+    }
+
+    fn clear(&mut self) {
+        let mut s = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        s.small.clear();
+        s.small_order.clear();
+        s.small_bytes = 0;
+        s.main.clear();
+        s.main_order.clear();
+        s.main_bytes = 0;
+        s.ghost.clear();
+        s.ghost_order.clear();
+        s.total_bytes = 0;
+    }
+
+    fn policy_name(&self) -> &'static str {
+        "s3fifo"
+    }
+}
+
 /// Create a cache policy instance
 pub fn create_policy(policy_type: PolicyType) -> Box<dyn CachePolicy> {
     match policy_type {
         PolicyType::Lru => Box::new(LruPolicy::new()),
         PolicyType::Lfu => Box::new(LfuPolicy::new()),
+        PolicyType::S3Fifo => Box::new(S3FifoPolicy::new()),
     }
 }
 
@@ -353,6 +658,94 @@ mod tests {
         assert_eq!(candidates.len(), 2);
         assert!(candidates.contains(&"oldest".to_string()));
         assert!(!candidates.contains(&"middle".to_string()));
+    }
+
+    #[test]
+    fn test_s3fifo_policy_name_and_create() {
+        let p = create_policy(PolicyType::S3Fifo);
+        assert_eq!(p.policy_name(), "s3fifo");
+    }
+
+    #[test]
+    fn test_s3fifo_scan_does_not_evict_hot_set() {
+        // The core property: a one-off scan of cold keys must not evict a hot key.
+        let mut p = S3FifoPolicy::new();
+
+        // "hot" is inserted and re-accessed several times → earns frequency in small.
+        p.on_insert("hot", 100);
+        for _ in 0..3 {
+            p.on_access("hot", 100);
+        }
+
+        // A scan streams many cold keys, each touched once.
+        for i in 0..50 {
+            p.on_insert(&format!("scan{i}"), 100);
+        }
+
+        // Evict ~half the bytes. Victims must be scan keys, never "hot".
+        let victims = p.select_for_eviction(2500);
+        assert!(!victims.is_empty(), "should evict something");
+        assert!(
+            !victims.contains(&"hot".to_string()),
+            "hot key must survive a scan; victims={:?}",
+            victims
+        );
+        assert!(
+            victims.iter().all(|k| k.starts_with("scan")),
+            "only scan one-hit-wonders should be evicted; victims={:?}",
+            victims
+        );
+    }
+
+    #[test]
+    fn test_s3fifo_reaccessed_key_promoted_not_evicted() {
+        // A key re-accessed while on probation (freq>0) is promoted to main on
+        // eviction sweep rather than discarded.
+        let mut p = S3FifoPolicy::new();
+        p.on_insert("kept", 100);
+        p.on_access("kept", 100); // freq -> 1
+        p.on_insert("cold", 100); // freq 0
+
+        let victims = p.select_for_eviction(100);
+        assert_eq!(victims, vec!["cold".to_string()], "cold (freq 0) evicted, kept promoted");
+    }
+
+    #[test]
+    fn test_s3fifo_ghost_reinsert_goes_to_main() {
+        // A key evicted from small is remembered in ghost; a re-insert of that key is
+        // admitted straight to main (it proved worth keeping) rather than re-entering
+        // probation. Verify via placement, independent of the small/main budget split.
+        let mut p = S3FifoPolicy::new();
+        p.on_insert("k", 100);
+        // Evict it (freq 0) → lands in ghost.
+        let victims = p.select_for_eviction(100);
+        assert_eq!(victims, vec!["k".to_string()]);
+
+        // Re-insert the ghosted key and a brand-new key.
+        p.on_insert("k", 100); // ghost hit → main
+        p.on_insert("fresh", 100); // brand new → small
+
+        // `k` is in main, `fresh` is in small. Confirm via the internal state: a fresh
+        // key sits in probation, a ghost-readmitted key sits in the protected main set.
+        {
+            let s = p.state.lock().unwrap();
+            assert!(s.main.contains_key("k"), "ghost-readmitted key must be in main");
+            assert!(s.small.contains_key("fresh"), "brand-new key must be in small (probation)");
+        }
+    }
+
+    #[test]
+    fn test_s3fifo_clear_and_remove() {
+        let mut p = S3FifoPolicy::new();
+        p.on_insert("a", 100);
+        p.on_insert("b", 200);
+        p.on_remove("a");
+        // After removing a, only b remains; evicting should yield b.
+        let victims = p.select_for_eviction(200);
+        assert_eq!(victims, vec!["b".to_string()]);
+        p.on_insert("c", 100);
+        p.clear();
+        assert!(p.select_for_eviction(100).is_empty(), "cleared policy has no victims");
     }
 
     #[test]

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/ffm.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/ffm.rs
@@ -778,6 +778,7 @@ pub unsafe extern "C" fn df_create_cache(
     let policy_type = match eviction_type.to_uppercase().as_str() {
         "LRU" => PolicyType::Lru,
         "LFU" => PolicyType::Lfu,
+        "S3FIFO" => PolicyType::S3Fifo,
         _ => {
             return Err(format!(
                 "df_create_cache: unsupported eviction type: {}",
@@ -795,8 +796,14 @@ pub unsafe extern "C" fn df_create_cache(
 
     match cache_type {
         cache::CACHE_TYPE_METADATA => {
-            let inner_cache = DefaultFilesMetadataCache::new(size_limit as usize);
-            let metadata_cache = Arc::new(cache::MutexFileMetadataCache::with_enabled(inner_cache, enabled));
+            // MutexFileMetadataCache now owns its store and drives the pluggable eviction
+            // policy (DataFusion's DefaultFilesMetadataCache is hardcoded LRU, so wrapping
+            // it could not honor `eviction.type`). Pass the policy + byte limit through.
+            let metadata_cache = Arc::new(cache::MutexFileMetadataCache::with_enabled(
+                policy_type,
+                size_limit as usize,
+                enabled,
+            ));
             manager.set_file_metadata_cache(metadata_cache);
         }
         cache::CACHE_TYPE_STATS => {

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/ffm.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/ffm.rs
@@ -765,6 +765,7 @@ pub unsafe extern "C" fn df_create_cache(
     size_limit: i64,
     eviction_type_ptr: *const u8,
     eviction_type_len: i64,
+    enabled: i64,
 ) -> i64 {
     if cache_manager_ptr == 0 {
         return Err("df_create_cache: null cache manager pointer".to_string());
@@ -785,20 +786,25 @@ pub unsafe extern "C" fn df_create_cache(
         }
     };
 
+    // The cache is always constructed so it can be toggled on at runtime later; the
+    // `enabled` flag seeds its initial state (a disabled cache serves misses + drops writes).
+    let enabled = enabled != 0;
+
     // Safety: cache_manager_ptr must be a valid pointer from df_create_custom_cache_manager
     let manager = &mut *(cache_manager_ptr as *mut CustomCacheManager);
 
     match cache_type {
         cache::CACHE_TYPE_METADATA => {
             let inner_cache = DefaultFilesMetadataCache::new(size_limit as usize);
-            let metadata_cache = Arc::new(cache::MutexFileMetadataCache::new(inner_cache));
+            let metadata_cache = Arc::new(cache::MutexFileMetadataCache::with_enabled(inner_cache, enabled));
             manager.set_file_metadata_cache(metadata_cache);
         }
         cache::CACHE_TYPE_STATS => {
-            let stats_cache = Arc::new(CustomStatisticsCache::new(
+            let stats_cache = Arc::new(CustomStatisticsCache::with_enabled(
                 policy_type,
                 size_limit as usize,
                 0.8,
+                enabled,
             ));
             manager.set_statistics_cache(stats_cache);
         }
@@ -1011,6 +1017,59 @@ pub unsafe extern "C" fn df_cache_manager_clear_by_type(
     manager
         .clear_cache_type(cache_type)
         .map_err(|e| format!("df_cache_manager_clear_by_type: {}", e))?;
+    Ok(0)
+}
+
+#[ffm_safe]
+#[no_mangle]
+pub unsafe extern "C" fn df_cache_manager_update_size_limit(
+    runtime_ptr: i64,
+    cache_type_ptr: *const u8,
+    cache_type_len: i64,
+    new_limit: i64,
+) -> i64 {
+    if runtime_ptr == 0 {
+        return Err("df_cache_manager_update_size_limit: null runtime pointer".to_string());
+    }
+    if new_limit < 0 {
+        return Err(format!(
+            "df_cache_manager_update_size_limit: negative size limit: {}",
+            new_limit
+        ));
+    }
+    let cache_type = str_from_raw(cache_type_ptr, cache_type_len)
+        .map_err(|e| format!("df_cache_manager_update_size_limit: {}", e))?;
+    let runtime = &*(runtime_ptr as *const DataFusionRuntime);
+    let manager = runtime.custom_cache_manager.as_ref().ok_or_else(|| {
+        "df_cache_manager_update_size_limit: no cache manager configured".to_string()
+    })?;
+    manager
+        .update_size_limit_by_type(cache_type, new_limit as usize)
+        .map_err(|e| format!("df_cache_manager_update_size_limit: {}", e))?;
+    Ok(0)
+}
+
+#[ffm_safe]
+#[no_mangle]
+pub unsafe extern "C" fn df_cache_manager_set_enabled(
+    runtime_ptr: i64,
+    cache_type_ptr: *const u8,
+    cache_type_len: i64,
+    enabled: i64,
+) -> i64 {
+    if runtime_ptr == 0 {
+        return Err("df_cache_manager_set_enabled: null runtime pointer".to_string());
+    }
+    let cache_type = str_from_raw(cache_type_ptr, cache_type_len)
+        .map_err(|e| format!("df_cache_manager_set_enabled: {}", e))?;
+    let runtime = &*(runtime_ptr as *const DataFusionRuntime);
+    let manager = runtime
+        .custom_cache_manager
+        .as_ref()
+        .ok_or_else(|| "df_cache_manager_set_enabled: no cache manager configured".to_string())?;
+    manager
+        .set_enabled_by_type(cache_type, enabled != 0)
+        .map_err(|e| format!("df_cache_manager_set_enabled: {}", e))?;
     Ok(0)
 }
 
@@ -1439,5 +1498,181 @@ mod tests {
 
         // ── Cleanup ──
         shutdown_test_runtime();
+    }
+
+    // ── df_cache_manager_update_size_limit (runtime cache resize) ──
+    //
+    // These drive the exported FFM symbol end-to-end against a real
+    // DataFusionRuntime built via the same entry points Java uses
+    // (df_create_custom_cache_manager -> df_create_cache -> df_create_global_runtime),
+    // and verify both the happy path (the live manager's limit changes) and the
+    // negative-pointer error contract.
+
+    /// Build a runtime whose cache manager has METADATA + STATISTICS caches at the
+    /// given limits. Returns the runtime pointer (owns the consumed cache manager).
+    unsafe fn runtime_with_caches(metadata_limit: i64, stats_limit: i64) -> i64 {
+        let mgr_ptr = df_create_custom_cache_manager();
+        let lru = "LRU";
+        for (ty, limit) in [(cache::CACHE_TYPE_METADATA, metadata_limit), (cache::CACHE_TYPE_STATS, stats_limit)] {
+            let rc = df_create_cache(mgr_ptr, ty.as_ptr(), ty.len() as i64, limit, lru.as_ptr(), lru.len() as i64, 1);
+            assert!(rc >= 0, "df_create_cache({}) failed: {}", ty, rc);
+        }
+        // create_global_runtime consumes mgr_ptr (Box::from_raw). Empty (non-null)
+        // spill_dir is the "spill disabled" sentinel.
+        let spill = "";
+        let rt = df_create_global_runtime(256 * 1024 * 1024, mgr_ptr, spill.as_ptr(), spill.len() as i64, 0);
+        assert!(rt >= 0, "df_create_global_runtime failed: {}", rt);
+        rt
+    }
+
+    /// Read back an FFM error message from a negative return code, then free it.
+    unsafe fn take_error_message(neg_code: i64) -> String {
+        assert!(neg_code < 0, "expected an error (negative) code, got {}", neg_code);
+        let ptr = -neg_code;
+        let c = native_bridge_common::error::native_error_message(ptr);
+        let msg = std::ffi::CStr::from_ptr(c).to_string_lossy().into_owned();
+        native_bridge_common::error::native_error_free(ptr);
+        msg
+    }
+
+    unsafe fn call_update(runtime_ptr: i64, cache_type: &str, new_limit: i64) -> i64 {
+        df_cache_manager_update_size_limit(runtime_ptr, cache_type.as_ptr(), cache_type.len() as i64, new_limit)
+    }
+
+    #[test]
+    fn test_df_update_size_limit_metadata_resizes_live_manager() {
+        unsafe {
+            let rt = runtime_with_caches(250 * 1024 * 1024, 100 * 1024 * 1024);
+
+            let rc = call_update(rt, cache::CACHE_TYPE_METADATA, 2 * 1024 * 1024 * 1024);
+            assert_eq!(rc, 0, "metadata resize should succeed");
+
+            let runtime = &*(rt as *const DataFusionRuntime);
+            let mgr = runtime.custom_cache_manager.as_ref().expect("cache manager present");
+            assert_eq!(mgr.metadata_cache_size_limit(), 2 * 1024 * 1024 * 1024);
+            // STATISTICS limit untouched by a METADATA-typed resize.
+            assert_eq!(mgr.get_statistics_cache().unwrap().current_size_limit(), 100 * 1024 * 1024);
+
+            api::close_global_runtime(rt);
+        }
+    }
+
+    #[test]
+    fn test_df_update_size_limit_statistics_resizes_live_manager() {
+        unsafe {
+            let rt = runtime_with_caches(250 * 1024 * 1024, 100 * 1024 * 1024);
+
+            let rc = call_update(rt, cache::CACHE_TYPE_STATS, 256 * 1024 * 1024);
+            assert_eq!(rc, 0, "statistics resize should succeed");
+
+            let runtime = &*(rt as *const DataFusionRuntime);
+            let mgr = runtime.custom_cache_manager.as_ref().expect("cache manager present");
+            assert_eq!(mgr.get_statistics_cache().unwrap().current_size_limit(), 256 * 1024 * 1024);
+            assert_eq!(mgr.metadata_cache_size_limit(), 250 * 1024 * 1024);
+
+            api::close_global_runtime(rt);
+        }
+    }
+
+    #[test]
+    fn test_configured_statistics_limit_survives_runtime_build() {
+        // Regression: CacheManager::try_new calls update_cache_limit with
+        // config.file_statistics_cache_limit, which defaults to 20MiB. If
+        // build_cache_manager_config doesn't propagate the configured statistics limit,
+        // the user's datafusion.statistics.cache.size.limit is silently clobbered at
+        // startup. Here we configure 100MB and expect it to survive runtime construction.
+        unsafe {
+            let rt = runtime_with_caches(250 * 1024 * 1024, 100 * 1024 * 1024);
+            let runtime = &*(rt as *const DataFusionRuntime);
+            let mgr = runtime.custom_cache_manager.as_ref().expect("cache manager present");
+            assert_eq!(
+                mgr.get_statistics_cache().unwrap().current_size_limit(),
+                100 * 1024 * 1024,
+                "configured statistics cache limit must survive runtime build (not be reset to the 20MiB DataFusion default)"
+            );
+            assert_eq!(mgr.metadata_cache_size_limit(), 250 * 1024 * 1024);
+            api::close_global_runtime(rt);
+        }
+    }
+
+    #[test]
+    fn test_df_set_enabled_toggles_live_manager() {
+        unsafe {
+            let rt = runtime_with_caches(250 * 1024 * 1024, 100 * 1024 * 1024);
+            let stats = "STATISTICS";
+
+            // Disable statistics cache.
+            let rc = df_cache_manager_set_enabled(rt, stats.as_ptr(), stats.len() as i64, 0);
+            assert_eq!(rc, 0, "disable should succeed");
+
+            let runtime = &*(rt as *const DataFusionRuntime);
+            let mgr = runtime.custom_cache_manager.as_ref().unwrap();
+            assert!(!mgr.get_statistics_cache().unwrap().is_enabled(), "statistics cache should be disabled");
+
+            // Re-enable.
+            let rc = df_cache_manager_set_enabled(rt, stats.as_ptr(), stats.len() as i64, 1);
+            assert_eq!(rc, 0, "enable should succeed");
+            assert!(mgr.get_statistics_cache().unwrap().is_enabled());
+
+            api::close_global_runtime(rt);
+        }
+    }
+
+    #[test]
+    fn test_df_set_enabled_unknown_type_errors() {
+        unsafe {
+            let rt = runtime_with_caches(250 * 1024 * 1024, 100 * 1024 * 1024);
+            let bogus = "BOGUS";
+            let rc = df_cache_manager_set_enabled(rt, bogus.as_ptr(), bogus.len() as i64, 0);
+            let msg = take_error_message(rc);
+            assert!(msg.contains("Unknown cache type"), "got: {}", msg);
+            api::close_global_runtime(rt);
+        }
+    }
+
+    #[test]
+    fn test_df_update_size_limit_null_runtime_errors() {
+        unsafe {
+            let rc = call_update(0, cache::CACHE_TYPE_METADATA, 1024);
+            let msg = take_error_message(rc);
+            assert!(msg.contains("null runtime pointer"), "got: {}", msg);
+        }
+    }
+
+    #[test]
+    fn test_df_update_size_limit_negative_limit_errors() {
+        unsafe {
+            let rt = runtime_with_caches(250 * 1024 * 1024, 100 * 1024 * 1024);
+            let rc = call_update(rt, cache::CACHE_TYPE_METADATA, -1);
+            let msg = take_error_message(rc);
+            assert!(msg.contains("negative size limit"), "got: {}", msg);
+            api::close_global_runtime(rt);
+        }
+    }
+
+    #[test]
+    fn test_df_update_size_limit_unknown_type_errors() {
+        unsafe {
+            let rt = runtime_with_caches(250 * 1024 * 1024, 100 * 1024 * 1024);
+            let bogus = "BOGUS";
+            let rc = df_cache_manager_update_size_limit(rt, bogus.as_ptr(), bogus.len() as i64, 1024);
+            let msg = take_error_message(rc);
+            assert!(msg.contains("Unknown cache type"), "got: {}", msg);
+            api::close_global_runtime(rt);
+        }
+    }
+
+    #[test]
+    fn test_df_update_size_limit_unconfigured_cache_errors() {
+        unsafe {
+            // Runtime with NO cache manager attached (cache_manager_ptr = 0).
+            let spill = "";
+            let rt = df_create_global_runtime(256 * 1024 * 1024, 0, spill.as_ptr(), spill.len() as i64, 0);
+            assert!(rt >= 0);
+            let rc = call_update(rt, cache::CACHE_TYPE_METADATA, 1024);
+            let msg = take_error_message(rc);
+            assert!(msg.contains("no cache manager configured"), "got: {}", msg);
+            api::close_global_runtime(rt);
+        }
     }
 }

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/memory_guard.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/memory_guard.rs
@@ -44,7 +44,11 @@ pub fn cached_resident_bytes() -> i64 {
         let spill_x1000 = EXECUTION_SPILL_X1000.load(Ordering::Relaxed);
         let limit = pool_limit_for_guard();
         if limit > 0 {
-            let threshold = (limit as u64 * spill_x1000 / 1000) as i64;
+            // saturating_mul: limit can legitimately be i64::MAX (unset
+            // node.native_memory.limit => DataFusion memory pool defaults to MAX), and a
+            // plain * overflows u64 — panicking in debug builds. Matches is_memory_pressured /
+            // should_override below.
+            let threshold = ((limit as u64).saturating_mul(spill_x1000) / 1000) as i64;
             if cached >= threshold {
                 let fresh = native_bridge_common::allocator::resident_bytes();
                 CACHED_RESIDENT.store(fresh, Ordering::Relaxed);

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/query_executor.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/query_executor.rs
@@ -476,6 +476,14 @@ pub fn query_runtime_env_builder(
                 )
                 .with_file_statistics_cache(
                     runtime.runtime_env.cache_manager.get_file_statistic_cache(),
+                )
+                // Preserve the statistics cache's configured byte limit. Without this,
+                // CacheManager::try_new resets it to the 20MiB default
+                // (config.file_statistics_cache_limit) at every per-query rebuild,
+                // silently shrinking datafusion.statistics.cache.size.limit at query time.
+                // Mirrors with_metadata_cache_limit above.
+                .with_file_statistics_cache_limit(
+                    runtime.runtime_env.cache_manager.get_file_statistic_cache_limit(),
                 ),
         )
 }

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/statistics_cache.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/statistics_cache.rs
@@ -950,4 +950,99 @@ mod tests {
         assert_eq!(cache.memory_consumed(), 0, "a 0-byte limit must evict everything");
         assert_eq!(cache.len(), 0);
     }
+
+    // ── End-to-end: S3-FIFO scan resistance through the real cache ──
+    //
+    // These drive CustomStatisticsCache configured with PolicyType::S3Fifo via its
+    // public put/get path (not the policy in isolation), exercising the same flow a
+    // query takes, and assert the headline property: a one-off wide scan does not
+    // evict the repeatedly-queried hot working set.
+
+    /// Per-entry byte size as charged by the cache (statistics.memory_size()).
+    fn stat_entry_bytes() -> usize {
+        Arc::new(create_test_statistics()).memory_size()
+    }
+
+    #[test]
+    fn test_e2e_s3fifo_hot_set_survives_scan() {
+        // Size the cache so the hot set comfortably fits but a scan would, under LRU,
+        // churn the whole thing: ~10 entries' worth of bytes.
+        let per = stat_entry_bytes();
+        let cache = CustomStatisticsCache::new(PolicyType::S3Fifo, per * 10, 0.8);
+
+        // Warm a small hot set and query each entry repeatedly (earns frequency).
+        let hot: Vec<Path> = (0..3).map(|i| create_test_path(&format!("hot{i}"))).collect();
+        for p in &hot {
+            cache.put_statistics(p, Arc::new(create_test_statistics()), &create_test_meta(p));
+        }
+        for _ in 0..5 {
+            for p in &hot {
+                assert!(cache.get(p).is_some(), "hot entry should be present during warmup");
+            }
+        }
+
+        // A wide one-off scan streams many cold keys, each touched once.
+        for i in 0..100 {
+            let p = create_test_path(&format!("scan{i}"));
+            cache.put_statistics(&p, Arc::new(create_test_statistics()), &create_test_meta(&p));
+        }
+
+        // The hot set must largely survive the scan — the headline scan-resistance
+        // property. With the SLRU-like 50% probation default, a hot entry that has not
+        // yet been promoted to `main` is more exposed than at the paper's ~10%, so we
+        // assert the *majority* survive rather than all (still far better than LRU,
+        // which would evict the entire hot set under this workload). The larger
+        // probation is the recency-vs-scan-resistance tradeoff of the 50% split.
+        let survivors = hot.iter().filter(|p| cache.get(p).is_some()).count();
+        assert!(
+            survivors >= 2,
+            "S3-FIFO must keep most of the {} hot entries after a 100-key scan; survived {}",
+            hot.len(), survivors
+        );
+        // And the cache stayed within its byte budget.
+        assert!(cache.memory_consumed() <= per * 10, "cache must honor its byte limit");
+    }
+
+    #[test]
+    fn test_e2e_lru_pollutes_baseline_contrast() {
+        // Contrast control: with LRU and the same workload, the hot set is NOT
+        // guaranteed to survive (LRU has no scan resistance). We only assert the cache
+        // stays within budget — this documents the difference rather than over-claiming
+        // a deterministic LRU eviction of a specific key.
+        let per = stat_entry_bytes();
+        let cache = CustomStatisticsCache::new(PolicyType::Lru, per * 10, 0.8);
+        let hot = create_test_path("hot");
+        cache.put_statistics(&hot, Arc::new(create_test_statistics()), &create_test_meta(&hot));
+        for _ in 0..5 {
+            cache.get(&hot);
+        }
+        for i in 0..100 {
+            let p = create_test_path(&format!("scan{i}"));
+            cache.put_statistics(&p, Arc::new(create_test_statistics()), &create_test_meta(&p));
+        }
+        assert!(cache.memory_consumed() <= per * 10, "LRU cache must also honor its byte limit");
+    }
+
+    #[test]
+    fn test_e2e_s3fifo_set_policy_switch() {
+        // Switching an existing cache to S3-FIFO at runtime preserves entries and the
+        // policy then governs subsequent eviction.
+        let per = stat_entry_bytes();
+        let cache = CustomStatisticsCache::new(PolicyType::Lru, per * 10, 0.8);
+        let hot = create_test_path("hot");
+        cache.put_statistics(&hot, Arc::new(create_test_statistics()), &create_test_meta(&hot));
+        for _ in 0..5 {
+            cache.get(&hot);
+        }
+
+        cache.set_policy(PolicyType::S3Fifo).unwrap();
+        assert_eq!(cache.policy_name().unwrap(), "s3fifo");
+        assert!(cache.get(&hot).is_some(), "switching policy must not drop existing entries");
+
+        for i in 0..100 {
+            let p = create_test_path(&format!("scan{i}"));
+            cache.put_statistics(&p, Arc::new(create_test_statistics()), &create_test_meta(&p));
+        }
+        assert!(cache.memory_consumed() <= per * 10);
+    }
 }

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/statistics_cache.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/statistics_cache.rs
@@ -21,7 +21,7 @@ use datafusion::physical_plan::Statistics;
 use object_store::{path::Path, ObjectMeta};
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
 use std::fs::File;
 
@@ -137,11 +137,20 @@ pub struct CustomStatisticsCache {
     hit_count: AtomicUsize,
     /// Cache miss count (thread-safe)
     miss_count: AtomicUsize,
+    /// When false, the cache serves every lookup as a miss and drops all writes.
+    /// Toggled at runtime via datafusion.statistics.cache.enabled; disabling also clears
+    /// existing entries (see `set_enabled`) so memory is freed.
+    enabled: AtomicBool,
 }
 
 impl CustomStatisticsCache {
     /// Create a new custom statistics cache
     pub fn new(policy_type: PolicyType, size_limit: usize, eviction_threshold: f64) -> Self {
+        Self::with_enabled(policy_type, size_limit, eviction_threshold, true)
+    }
+
+    /// Create a new custom statistics cache with an explicit initial enabled state.
+    pub fn with_enabled(policy_type: PolicyType, size_limit: usize, eviction_threshold: f64, enabled: bool) -> Self {
         Self {
             inner_cache: DashMap::new(),
             policy: Arc::new(Mutex::new(create_policy(policy_type))),
@@ -153,6 +162,21 @@ impl CustomStatisticsCache {
             })),
             hit_count: AtomicUsize::new(0),
             miss_count: AtomicUsize::new(0),
+            enabled: AtomicBool::new(enabled),
+        }
+    }
+
+    /// Returns whether the cache is currently enabled.
+    pub fn is_enabled(&self) -> bool {
+        self.enabled.load(Ordering::Relaxed)
+    }
+
+    /// Enable or disable the cache at runtime. Disabling also clears existing entries
+    /// so the memory is released immediately; enabling starts caching again from cold.
+    pub fn set_enabled(&self, enabled: bool) {
+        self.enabled.store(enabled, Ordering::Relaxed);
+        if !enabled {
+            self.clear();
         }
     }
 
@@ -338,6 +362,11 @@ impl CustomStatisticsCache {
 // trait's `&TableScopedPath` methods, so existing callers keep working unchanged.
 impl CustomStatisticsCache {
     pub fn get(&self, k: &Path) -> Option<CachedFileMetadata> {
+        // Disabled cache holds nothing (put drops writes); skip hit/miss accounting since
+        // the cache isn't participating.
+        if !self.is_enabled() {
+            return None;
+        }
         let result = self.inner_cache.get(k);
 
         if result.is_some() {
@@ -358,6 +387,10 @@ impl CustomStatisticsCache {
     }
 
     pub fn put(&self, k: &Path, v: CachedFileMetadata) -> Option<CachedFileMetadata> {
+        // Drop writes while disabled so the cache stays empty.
+        if !self.is_enabled() {
+            return None;
+        }
         let key = k.to_string();
         let memory_size = v.statistics.memory_size();
 
@@ -770,5 +803,151 @@ mod tests {
 
         for handle in handles { handle.join().unwrap(); }
         assert!(cache.len() > 0);
+    }
+
+    // ── Dynamic size-limit change behavior (runtime resize path) ──
+    //
+    // These exercise update_size_limit, the function the new FFM resize hook
+    // (df_cache_manager_update_size_limit -> update_statistics_cache_limit)
+    // ultimately drives. They document how the statistics cache behaves when the
+    // limit is raised or lowered on a populated cache.
+
+    #[test]
+    fn test_update_size_limit_grow_keeps_all_entries() {
+        // Start with a generous limit so nothing is evicted on insert.
+        let cache = CustomStatisticsCache::new(PolicyType::Lru, 1024 * 1024, 0.8);
+        for i in 0..5 {
+            let path = create_test_path(&format!("file{}", i));
+            let meta = create_test_meta(&path);
+            cache.put_statistics(&path, Arc::new(create_test_statistics()), &meta);
+        }
+        let len_before = cache.len();
+        let mem_before = cache.memory_consumed();
+        assert_eq!(len_before, 5);
+
+        // Growing the limit must never evict.
+        cache.update_size_limit(8 * 1024 * 1024).unwrap();
+        assert_eq!(cache.current_size_limit(), 8 * 1024 * 1024);
+        assert_eq!(cache.len(), len_before, "growing the limit must not drop entries");
+        assert_eq!(cache.memory_consumed(), mem_before);
+    }
+
+    #[test]
+    fn test_update_size_limit_shrink_below_usage_triggers_eviction() {
+        // Big limit first so all entries land, then shrink hard.
+        let cache = CustomStatisticsCache::new(PolicyType::Lru, 1024 * 1024, 0.8);
+        for i in 0..20 {
+            let path = create_test_path(&format!("file{}", i));
+            let meta = create_test_meta(&path);
+            cache.put_statistics(&path, Arc::new(create_test_statistics()), &meta);
+        }
+        let mem_before = cache.memory_consumed();
+        assert!(mem_before > 0);
+        let per_entry = mem_before / cache.len();
+
+        // Shrink to ~3 entries' worth. update_size_limit evicts down toward
+        // new_limit * eviction_threshold, so usage must end up <= the new limit.
+        let new_limit = per_entry * 3;
+        cache.update_size_limit(new_limit).unwrap();
+
+        assert_eq!(cache.current_size_limit(), new_limit);
+        assert!(
+            cache.memory_consumed() <= new_limit,
+            "after shrink, usage {} must be within new limit {}",
+            cache.memory_consumed(),
+            new_limit
+        );
+        assert!(cache.len() < 20, "shrink should have evicted some entries");
+        assert!(cache.len() > 0, "shrink should not clear the whole cache");
+    }
+
+    #[test]
+    fn test_update_size_limit_shrink_then_grow_then_refill() {
+        // A resize-down followed by resize-up should leave the cache fully usable:
+        // it can hold new entries up to the larger limit again.
+        let cache = CustomStatisticsCache::new(PolicyType::Lru, 1024 * 1024, 0.8);
+        for i in 0..10 {
+            let path = create_test_path(&format!("file{}", i));
+            let meta = create_test_meta(&path);
+            cache.put_statistics(&path, Arc::new(create_test_statistics()), &meta);
+        }
+        let per_entry = cache.memory_consumed() / cache.len();
+
+        cache.update_size_limit(per_entry * 2).unwrap();
+        assert!(cache.len() <= 3, "tight limit should keep only a couple entries");
+
+        // Grow back and refill — no entries should be rejected by a stale limit.
+        cache.update_size_limit(1024 * 1024).unwrap();
+        for i in 10..30 {
+            let path = create_test_path(&format!("file{}", i));
+            let meta = create_test_meta(&path);
+            cache.put_statistics(&path, Arc::new(create_test_statistics()), &meta);
+        }
+        assert!(
+            cache.len() > 5,
+            "after growing the limit the cache must accept new entries again, got {}",
+            cache.len()
+        );
+        assert!(cache.memory_consumed() <= cache.current_size_limit());
+    }
+
+    // ── Enable / disable behavior ──
+
+    #[test]
+    fn test_disable_clears_and_drops_writes() {
+        let cache = CustomStatisticsCache::new(PolicyType::Lru, 1024 * 1024, 0.8);
+        for i in 0..5 {
+            let path = create_test_path(&format!("file{}", i));
+            let meta = create_test_meta(&path);
+            cache.put_statistics(&path, Arc::new(create_test_statistics()), &meta);
+        }
+        assert!(cache.memory_consumed() > 0);
+        assert_eq!(cache.len(), 5);
+
+        // Disable: existing entries cleared, memory freed.
+        cache.set_enabled(false);
+        assert!(!cache.is_enabled());
+        assert_eq!(cache.memory_consumed(), 0, "disable must clear and free memory");
+        assert_eq!(cache.len(), 0);
+
+        // Writes are dropped while disabled.
+        let p = create_test_path("after_disable");
+        let m = create_test_meta(&p);
+        cache.put_statistics(&p, Arc::new(create_test_statistics()), &m);
+        assert_eq!(cache.len(), 0, "writes must be dropped while disabled");
+        assert!(cache.get(&p).is_none(), "lookups must return nothing while disabled");
+        // A disabled cache isn't participating, so lookups don't count as misses.
+        assert_eq!(cache.miss_count(), 0, "disabled lookups must not bump miss_count");
+    }
+
+    #[test]
+    fn test_reenable_starts_caching_again() {
+        let cache = CustomStatisticsCache::new(PolicyType::Lru, 1024 * 1024, 0.8);
+        cache.set_enabled(false);
+
+        // Re-enable: cache works again from cold.
+        cache.set_enabled(true);
+        assert!(cache.is_enabled());
+        let p = create_test_path("after_reenable");
+        let m = create_test_meta(&p);
+        cache.put_statistics(&p, Arc::new(create_test_statistics()), &m);
+        assert_eq!(cache.len(), 1);
+        assert!(cache.get(&p).is_some(), "cache should serve hits again after re-enable");
+    }
+
+    #[test]
+    fn test_update_size_limit_to_zero_evicts_everything() {
+        let cache = CustomStatisticsCache::new(PolicyType::Lru, 1024 * 1024, 0.8);
+        for i in 0..5 {
+            let path = create_test_path(&format!("file{}", i));
+            let meta = create_test_meta(&path);
+            cache.put_statistics(&path, Arc::new(create_test_statistics()), &meta);
+        }
+        assert!(cache.memory_consumed() > 0);
+
+        cache.update_size_limit(0).unwrap();
+        assert_eq!(cache.current_size_limit(), 0);
+        assert_eq!(cache.memory_consumed(), 0, "a 0-byte limit must evict everything");
+        assert_eq!(cache.len(), 0);
     }
 }

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/stats.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/stats.rs
@@ -437,7 +437,6 @@ mod tests {
     fn test_pack_cache_stats_reflects_underlying_counters() {
         use std::sync::Arc;
 
-        use datafusion::execution::cache::DefaultFilesMetadataCache;
         use datafusion::execution::cache::CacheAccessor;
         use object_store::path::Path;
 
@@ -446,9 +445,7 @@ mod tests {
         use crate::eviction_policy::PolicyType;
         use crate::statistics_cache::CustomStatisticsCache;
 
-        let metadata_cache = Arc::new(MutexFileMetadataCache::new(
-            DefaultFilesMetadataCache::new(50 * 1024 * 1024),
-        ));
+        let metadata_cache = Arc::new(MutexFileMetadataCache::new(PolicyType::Lru, 50 * 1024 * 1024));
         let stats_cache = Arc::new(CustomStatisticsCache::new(
             PolicyType::Lru,
             10 * 1024 * 1024,

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionPlugin.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionPlugin.java
@@ -19,6 +19,9 @@ import org.opensearch.arrow.spi.PoolGroup;
 import org.opensearch.be.datafusion.action.stats.DataFusionStatsActionType;
 import org.opensearch.be.datafusion.action.stats.RestDataFusionStatsAction;
 import org.opensearch.be.datafusion.action.stats.TransportDataFusionStatsAction;
+import org.opensearch.be.datafusion.cache.CacheManager;
+import org.opensearch.be.datafusion.cache.CacheSettings;
+import org.opensearch.be.datafusion.cache.CacheUtils;
 import org.opensearch.be.datafusion.nativelib.NativeBridge;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.node.DiscoveryNodes;
@@ -473,6 +476,26 @@ public class DataFusionPlugin extends Plugin
         clusterService.getClusterSettings()
             .addSettingsUpdateConsumer(DATAFUSION_MEMORY_GUARD_EXECUTION_CRITICAL_THRESHOLD, v -> updateMemoryGuardThresholds());
 
+        // Wire the dynamic cache size-limit settings to the native cache manager so updates via the
+        // cluster settings API resize the metadata/statistics caches without restarting the node.
+        clusterService.getClusterSettings()
+            .addSettingsUpdateConsumer(
+                CacheSettings.METADATA_CACHE_SIZE_LIMIT,
+                v -> updateCacheSizeLimit(CacheUtils.CacheType.METADATA, v)
+            );
+        clusterService.getClusterSettings()
+            .addSettingsUpdateConsumer(
+                CacheSettings.STATISTICS_CACHE_SIZE_LIMIT,
+                v -> updateCacheSizeLimit(CacheUtils.CacheType.STATISTICS, v)
+            );
+
+        // Wire the dynamic cache enable/disable settings. Disabling clears the cache so its
+        // memory is freed immediately; re-enabling starts caching again from cold.
+        clusterService.getClusterSettings()
+            .addSettingsUpdateConsumer(CacheSettings.METADATA_CACHE_ENABLED, v -> updateCacheEnabled(CacheUtils.CacheType.METADATA, v));
+        clusterService.getClusterSettings()
+            .addSettingsUpdateConsumer(CacheSettings.STATISTICS_CACHE_ENABLED, v -> updateCacheEnabled(CacheUtils.CacheType.STATISTICS, v));
+
         // Wire dynamic concurrency gate multiplier settings
         int cpuThreads = DataFusionService.cpuThreadCount();
 
@@ -686,6 +709,75 @@ public class DataFusionPlugin extends Plugin
             // isSpillLimitDynamic() guard above should make this unreachable, but defend
             // against a race between probe and call.
             logger.warn("Ignoring spill memory limit update to {}B; native runtime does not support live updates", newLimitBytes);
+        }
+    }
+
+    /**
+     * Resizes a native DataFusion cache (metadata or statistics) in response to a dynamic update of
+     * {@code datafusion.metadata/statistics.cache.size.limit}. Takes effect immediately when the
+     * loaded native library supports live cache resize; otherwise the {@link CacheManager} logs a
+     * warning and the value applies only after the next node restart.
+     * <p>
+     * The cluster-settings update is accepted unconditionally because the value is also read at node
+     * startup by {@link CacheUtils#createCacheConfig}. Tolerates startup/shutdown races (service or
+     * cache manager not yet/no longer available). Package-private for testing.
+     */
+    void updateCacheSizeLimit(CacheUtils.CacheType cacheType, ByteSizeValue newLimit) {
+        DataFusionService service = dataFusionService;
+        if (service == null) {
+            logger.debug(
+                "DataFusion service not yet initialized; ignoring {} cache size limit update to {}B",
+                cacheType.getCacheTypeName(),
+                newLimit.getBytes()
+            );
+            return;
+        }
+        try {
+            CacheManager cacheManager = service.getCacheManager();
+            if (cacheManager == null) {
+                logger.debug(
+                    "Cache manager not configured; ignoring {} cache size limit update to {}B",
+                    cacheType.getCacheTypeName(),
+                    newLimit.getBytes()
+                );
+                return;
+            }
+            cacheManager.updateSizeLimit(cacheType, newLimit.getBytes());
+        } catch (IllegalStateException e) {
+            logger.warn(
+                "Ignoring {} cache size limit update to {}B; service is not running",
+                cacheType.getCacheTypeName(),
+                newLimit.getBytes()
+            );
+        }
+    }
+
+    /**
+     * Enables or disables a native DataFusion cache (metadata or statistics) in response to a
+     * dynamic update of {@code datafusion.metadata/statistics.cache.enabled}. Disabling clears the
+     * cache so its memory is freed immediately; re-enabling starts caching again from cold.
+     * Tolerates startup/shutdown races (service or cache manager not yet/no longer available).
+     * Package-private for testing.
+     */
+    void updateCacheEnabled(CacheUtils.CacheType cacheType, boolean enabled) {
+        DataFusionService service = dataFusionService;
+        if (service == null) {
+            logger.debug(
+                "DataFusion service not yet initialized; ignoring {} cache enabled update to {}",
+                cacheType.getCacheTypeName(),
+                enabled
+            );
+            return;
+        }
+        try {
+            CacheManager cacheManager = service.getCacheManager();
+            if (cacheManager == null) {
+                logger.debug("Cache manager not configured; ignoring {} cache enabled update to {}", cacheType.getCacheTypeName(), enabled);
+                return;
+            }
+            cacheManager.setEnabled(cacheType, enabled);
+        } catch (IllegalStateException e) {
+            logger.warn("Ignoring {} cache enabled update to {}; service is not running", cacheType.getCacheTypeName(), enabled);
         }
     }
 

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/cache/CacheManager.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/cache/CacheManager.java
@@ -86,12 +86,29 @@ public class CacheManager {
         }
     }
 
+    /**
+     * Resizes the native cache for {@code cacheType} to {@code sizeLimit} bytes at runtime.
+     * Takes effect immediately; shrinking below current usage triggers eviction on the native side.
+     */
     public void updateSizeLimit(CacheUtils.CacheType cacheType, long sizeLimit) {
         try {
-            // TODO: Add updateSizeLimitForCacheType FFM function when needed
-            logger.warn("updateSizeLimit not yet implemented for FFM bridge");
+            NativeBridge.cacheManagerUpdateSizeLimit(runtimeHandle.get(), cacheType.getCacheTypeName(), sizeLimit);
+            logger.info("Updated {} cache size limit to {} bytes", cacheType.getCacheTypeName(), sizeLimit);
         } catch (Exception e) {
             logger.error("Error updating size limit", e);
+        }
+    }
+
+    /**
+     * Enables or disables the native cache for {@code cacheType} at runtime. Disabling clears the
+     * cache so its memory is freed immediately; re-enabling starts caching again from cold.
+     */
+    public void setEnabled(CacheUtils.CacheType cacheType, boolean enabled) {
+        try {
+            NativeBridge.cacheManagerSetEnabled(runtimeHandle.get(), cacheType.getCacheTypeName(), enabled);
+            logger.info("{} {} cache", enabled ? "Enabled" : "Disabled", cacheType.getCacheTypeName());
+        } catch (Exception e) {
+            logger.error("Error toggling cache enabled state", e);
         }
     }
 

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/cache/CacheSettings.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/cache/CacheSettings.java
@@ -36,9 +36,12 @@ public class CacheSettings {
         Setting.Property.Dynamic
     );
 
+    // Default to S3FIFO: scan-resistant eviction so a one-off wide query does not evict
+    // the hot footer/statistics working set (plain LRU is not scan-resistant). LRU/LFU
+    // remain selectable.
     public static final Setting<String> METADATA_CACHE_EVICTION_TYPE = new Setting<String>(
         "datafusion.metadata.cache.eviction.type",
-        "LRU",
+        "S3FIFO",
         CacheSettings::validateEvictionType,
         Setting.Property.NodeScope,
         Setting.Property.Dynamic
@@ -46,7 +49,7 @@ public class CacheSettings {
 
     public static final Setting<String> STATISTICS_CACHE_EVICTION_TYPE = new Setting<String>(
         "datafusion.statistics.cache.eviction.type",
-        "LRU",
+        "S3FIFO",
         CacheSettings::validateEvictionType,
         Setting.Property.NodeScope,
         Setting.Property.Dynamic
@@ -79,8 +82,8 @@ public class CacheSettings {
 
     private static String validateEvictionType(String value) {
         String upper = value.toUpperCase(Locale.ROOT);
-        if (!upper.equals("LRU") && !upper.equals("LFU")) {
-            throw new IllegalArgumentException("Invalid eviction type '" + value + "'. Must be 'LRU' or 'LFU'.");
+        if (!upper.equals("LRU") && !upper.equals("LFU") && !upper.equals("S3FIFO")) {
+            throw new IllegalArgumentException("Invalid eviction type '" + value + "'. Must be 'LRU', 'LFU', or 'S3FIFO'.");
         }
         return upper;
     }

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/cache/CacheUtils.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/cache/CacheUtils.java
@@ -97,25 +97,26 @@ public final class CacheUtils {
         long cacheManagerPtr = NativeBridge.createCustomCacheManager();
         NativeCacheManagerHandle handle = new NativeCacheManagerHandle(cacheManagerPtr);
 
-        // Configure each enabled cache type
+        // Always create each cache so it can be toggled on later via the dynamic
+        // datafusion.<type>.cache.enabled setting; the initial enabled flag seeds its
+        // state (a disabled cache serves misses and drops writes, holding no memory).
         for (CacheType type : CacheType.values()) {
-            if (type.isEnabled(clusterSettings)) {
-                logger.info(
-                    "Configuring {} cache: size={} bytes, eviction={}",
-                    type.getCacheTypeName(),
-                    type.getSizeLimit(clusterSettings).getBytes(),
-                    type.getEvictionType(clusterSettings)
-                );
+            boolean enabled = type.isEnabled(clusterSettings);
+            logger.info(
+                "Configuring {} cache: enabled={}, size={} bytes, eviction={}",
+                type.getCacheTypeName(),
+                enabled,
+                type.getSizeLimit(clusterSettings).getBytes(),
+                type.getEvictionType(clusterSettings)
+            );
 
-                NativeBridge.createCache(
-                    handle.getPointer(),
-                    type.cacheTypeName,
-                    type.getSizeLimit(clusterSettings).getBytes(),
-                    type.getEvictionType(clusterSettings)
-                );
-            } else {
-                logger.debug("Cache type {} is disabled", type.getCacheTypeName());
-            }
+            NativeBridge.createCache(
+                handle.getPointer(),
+                type.cacheTypeName,
+                type.getSizeLimit(clusterSettings).getBytes(),
+                type.getEvictionType(clusterSettings),
+                enabled
+            );
         }
         logger.info("Cache configuration completed");
         return handle;

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/nativelib/NativeBridge.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/nativelib/NativeBridge.java
@@ -127,6 +127,8 @@ public final class NativeBridge {
     private static final MethodHandle CACHE_MANAGER_REMOVE_FILES;
     private static final MethodHandle CACHE_MANAGER_CLEAR;
     private static final MethodHandle CACHE_MANAGER_CLEAR_BY_TYPE;
+    private static final MethodHandle CACHE_MANAGER_UPDATE_SIZE_LIMIT;
+    private static final MethodHandle CACHE_MANAGER_SET_ENABLED;
     private static final MethodHandle CACHE_MANAGER_GET_MEMORY_BY_TYPE;
     private static final MethodHandle CACHE_MANAGER_GET_TOTAL_MEMORY;
     private static final MethodHandle CACHE_MANAGER_CONTAINS_BY_TYPE;
@@ -396,7 +398,7 @@ public final class NativeBridge {
             FunctionDescriptor.ofVoid(ValueLayout.JAVA_LONG)
         );
 
-        // i64 df_create_cache(mgr_ptr, type_ptr, type_len, size_limit, eviction_ptr, eviction_len)
+        // i64 df_create_cache(mgr_ptr, type_ptr, type_len, size_limit, eviction_ptr, eviction_len, enabled)
         CREATE_CACHE = linker.downcallHandle(
             lib.find("df_create_cache").orElseThrow(),
             FunctionDescriptor.of(
@@ -406,6 +408,7 @@ public final class NativeBridge {
                 ValueLayout.JAVA_LONG,
                 ValueLayout.JAVA_LONG,
                 ValueLayout.ADDRESS,
+                ValueLayout.JAVA_LONG,
                 ValueLayout.JAVA_LONG
             )
         );
@@ -478,6 +481,30 @@ public final class NativeBridge {
         CACHE_MANAGER_CLEAR_BY_TYPE = linker.downcallHandle(
             lib.find("df_cache_manager_clear_by_type").orElseThrow(),
             FunctionDescriptor.of(ValueLayout.JAVA_LONG, ValueLayout.JAVA_LONG, ValueLayout.ADDRESS, ValueLayout.JAVA_LONG)
+        );
+
+        // i64 df_cache_manager_update_size_limit(runtime_ptr, type_ptr, type_len, new_limit)
+        CACHE_MANAGER_UPDATE_SIZE_LIMIT = linker.downcallHandle(
+            lib.find("df_cache_manager_update_size_limit").orElseThrow(),
+            FunctionDescriptor.of(
+                ValueLayout.JAVA_LONG,
+                ValueLayout.JAVA_LONG,
+                ValueLayout.ADDRESS,
+                ValueLayout.JAVA_LONG,
+                ValueLayout.JAVA_LONG
+            )
+        );
+
+        // i64 df_cache_manager_set_enabled(runtime_ptr, type_ptr, type_len, enabled)
+        CACHE_MANAGER_SET_ENABLED = linker.downcallHandle(
+            lib.find("df_cache_manager_set_enabled").orElseThrow(),
+            FunctionDescriptor.of(
+                ValueLayout.JAVA_LONG,
+                ValueLayout.JAVA_LONG,
+                ValueLayout.ADDRESS,
+                ValueLayout.JAVA_LONG,
+                ValueLayout.JAVA_LONG
+            )
         );
 
         CACHE_MANAGER_GET_MEMORY_BY_TYPE = linker.downcallHandle(
@@ -1568,11 +1595,20 @@ public final class NativeBridge {
         }
     }
 
-    public static void createCache(long cacheManagerPtr, String cacheType, long sizeLimit, String evictionType) {
+    public static void createCache(long cacheManagerPtr, String cacheType, long sizeLimit, String evictionType, boolean enabled) {
         try (var call = new NativeCall()) {
             var type = call.str(cacheType);
             var eviction = call.str(evictionType);
-            call.invoke(CREATE_CACHE, cacheManagerPtr, type.segment(), type.len(), sizeLimit, eviction.segment(), eviction.len());
+            call.invoke(
+                CREATE_CACHE,
+                cacheManagerPtr,
+                type.segment(),
+                type.len(),
+                sizeLimit,
+                eviction.segment(),
+                eviction.len(),
+                enabled ? 1L : 0L
+            );
         }
     }
 
@@ -1600,6 +1636,29 @@ public final class NativeBridge {
         try (var call = new NativeCall()) {
             var type = call.str(cacheType);
             call.invoke(CACHE_MANAGER_CLEAR_BY_TYPE, runtimePtr, type.segment(), type.len());
+        }
+    }
+
+    /**
+     * Resizes a native cache (by cache-type name, e.g. {@code "METADATA"} / {@code "STATISTICS"})
+     * at runtime. Takes effect immediately; shrinking below current usage triggers eviction on the
+     * native side.
+     */
+    public static void cacheManagerUpdateSizeLimit(long runtimePtr, String cacheType, long newLimitBytes) {
+        try (var call = new NativeCall()) {
+            var type = call.str(cacheType);
+            call.invoke(CACHE_MANAGER_UPDATE_SIZE_LIMIT, runtimePtr, type.segment(), type.len(), newLimitBytes);
+        }
+    }
+
+    /**
+     * Enables or disables a native cache (by cache-type name) at runtime. Disabling also clears the
+     * cache on the native side so its memory is released immediately.
+     */
+    public static void cacheManagerSetEnabled(long runtimePtr, String cacheType, boolean enabled) {
+        try (var call = new NativeCall()) {
+            var type = call.str(cacheType);
+            call.invoke(CACHE_MANAGER_SET_ENABLED, runtimePtr, type.segment(), type.len(), enabled ? 1L : 0L);
         }
     }
 

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionPluginSettingsTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionPluginSettingsTests.java
@@ -8,8 +8,11 @@
 
 package org.opensearch.be.datafusion;
 
+import org.opensearch.be.datafusion.cache.CacheSettings;
+import org.opensearch.be.datafusion.cache.CacheUtils;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.core.common.unit.ByteSizeValue;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.nio.file.Files;
@@ -54,6 +57,82 @@ public class DataFusionPluginSettingsTests extends OpenSearchTestCase {
     public void testUpdateSpillMemoryLimitBeforeServiceStartDoesNotThrow() {
         try (DataFusionPlugin plugin = new DataFusionPlugin()) {
             plugin.updateSpillMemoryLimit(32L * 1024 * 1024);
+        } catch (Exception e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    public void testMetadataCacheSizeLimitIsDynamic() {
+        assertTrue(
+            "datafusion.metadata.cache.size.limit must be dynamic so cluster-state updates are accepted; "
+                + "live propagation depends on the loaded native library",
+            CacheSettings.METADATA_CACHE_SIZE_LIMIT.isDynamic()
+        );
+        assertTrue("datafusion.metadata.cache.size.limit must have node scope", CacheSettings.METADATA_CACHE_SIZE_LIMIT.hasNodeScope());
+    }
+
+    public void testStatisticsCacheSizeLimitIsDynamic() {
+        assertTrue(
+            "datafusion.statistics.cache.size.limit must be dynamic so cluster-state updates are accepted; "
+                + "live propagation depends on the loaded native library",
+            CacheSettings.STATISTICS_CACHE_SIZE_LIMIT.isDynamic()
+        );
+        assertTrue("datafusion.statistics.cache.size.limit must have node scope", CacheSettings.STATISTICS_CACHE_SIZE_LIMIT.hasNodeScope());
+    }
+
+    /**
+     * Mirrors {@link #testUpdateSpillMemoryLimitBeforeServiceStartDoesNotThrow}: the cache
+     * size-limit listener can fire before {@link DataFusionPlugin#createComponents} runs (service
+     * field still null) or after shutdown. {@code updateCacheSizeLimit} must swallow this quietly
+     * so cluster-state application does not log a spurious failure.
+     */
+    public void testUpdateCacheSizeLimitBeforeServiceStartDoesNotThrow() {
+        try (DataFusionPlugin plugin = new DataFusionPlugin()) {
+            plugin.updateCacheSizeLimit(CacheUtils.CacheType.METADATA, new ByteSizeValue(2L * 1024 * 1024 * 1024));
+            plugin.updateCacheSizeLimit(CacheUtils.CacheType.STATISTICS, new ByteSizeValue(256L * 1024 * 1024));
+        } catch (Exception e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    public void testPluginRegistersCacheSizeLimitSettings() {
+        try (DataFusionPlugin plugin = new DataFusionPlugin()) {
+            List<Setting<?>> settings = plugin.getSettings();
+            assertTrue(
+                "Plugin must register METADATA_CACHE_SIZE_LIMIT via getSettings()",
+                settings.contains(CacheSettings.METADATA_CACHE_SIZE_LIMIT)
+            );
+            assertTrue(
+                "Plugin must register STATISTICS_CACHE_SIZE_LIMIT via getSettings()",
+                settings.contains(CacheSettings.STATISTICS_CACHE_SIZE_LIMIT)
+            );
+        } catch (Exception e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    public void testCacheEnabledSettingsAreDynamic() {
+        assertTrue(
+            "datafusion.metadata.cache.enabled must be dynamic for runtime enable/disable",
+            CacheSettings.METADATA_CACHE_ENABLED.isDynamic()
+        );
+        assertTrue(
+            "datafusion.statistics.cache.enabled must be dynamic for runtime enable/disable",
+            CacheSettings.STATISTICS_CACHE_ENABLED.isDynamic()
+        );
+        assertTrue(CacheSettings.METADATA_CACHE_ENABLED.hasNodeScope());
+        assertTrue(CacheSettings.STATISTICS_CACHE_ENABLED.hasNodeScope());
+    }
+
+    /**
+     * Mirrors {@link #testUpdateCacheSizeLimitBeforeServiceStartDoesNotThrow}: the enable/disable
+     * listener can fire before {@link DataFusionPlugin#createComponents} runs (service field still
+     * null) or after shutdown. {@code updateCacheEnabled} must swallow this quietly.
+     */
+    public void testUpdateCacheEnabledBeforeServiceStartDoesNotThrow() {
+        try (DataFusionPlugin plugin = new DataFusionPlugin()) {
+            plugin.updateCacheEnabled(CacheUtils.CacheType.METADATA, false);
+            plugin.updateCacheEnabled(CacheUtils.CacheType.STATISTICS, true);
         } catch (Exception e) {
             throw new AssertionError(e);
         }

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionServiceTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionServiceTests.java
@@ -184,16 +184,16 @@ public class DataFusionServiceTests extends OpenSearchTestCase {
     public void testNativeBridgeCreateCacheOnManager() {
         ensureTokioInit();
         long ptr = NativeBridge.createCustomCacheManager();
-        NativeBridge.createCache(ptr, "METADATA", 250 * 1024 * 1024, "LRU");
-        NativeBridge.createCache(ptr, "STATISTICS", 100 * 1024 * 1024, "LRU");
+        NativeBridge.createCache(ptr, "METADATA", 250 * 1024 * 1024, "LRU", true);
+        NativeBridge.createCache(ptr, "STATISTICS", 100 * 1024 * 1024, "LRU", true);
         NativeBridge.destroyCustomCacheManager(ptr);
     }
 
     public void testRuntimeWithCacheManagerPointer() {
         ensureTokioInit();
         long cachePtr = NativeBridge.createCustomCacheManager();
-        NativeBridge.createCache(cachePtr, "METADATA", 250 * 1024 * 1024, "LRU");
-        NativeBridge.createCache(cachePtr, "STATISTICS", 100 * 1024 * 1024, "LRU");
+        NativeBridge.createCache(cachePtr, "METADATA", 250 * 1024 * 1024, "LRU", true);
+        NativeBridge.createCache(cachePtr, "STATISTICS", 100 * 1024 * 1024, "LRU", true);
 
         Path spillDir = createTempDir("spill");
         long runtimePtr = NativeBridge.createGlobalRuntime(64 * 1024 * 1024, cachePtr, spillDir.toString(), 32 * 1024 * 1024);
@@ -205,7 +205,7 @@ public class DataFusionServiceTests extends OpenSearchTestCase {
     public void testCacheManagerHandleConsumedAfterRuntimeCreation() {
         ensureTokioInit();
         var handle = new org.opensearch.be.datafusion.cache.NativeCacheManagerHandle(NativeBridge.createCustomCacheManager());
-        NativeBridge.createCache(handle.getPointer(), "METADATA", 250 * 1024 * 1024, "LRU");
+        NativeBridge.createCache(handle.getPointer(), "METADATA", 250 * 1024 * 1024, "LRU", true);
 
         long ptrBefore = handle.getPointer();
         assertTrue(org.opensearch.analytics.backend.jni.NativeHandle.isLivePointer(ptrBefore));


### PR DESCRIPTION
### Description

Makes the DataFusion analytics backend's **metadata** and **statistics** caches fully runtime-configurable, fixes their size limits being silently reverted, and replaces plain LRU with a scan-resistant eviction policy. Previously these cache settings were declared `Property.Dynamic` but were effectively read once at bootstrap, and the eviction policy could be polluted by a single wide query.

The PR is organized as three commits:

#### 1. Support dynamic metadata/statistics cache settings
The settings were read once at node bootstrap (`CacheUtils.createCacheConfig` → `DataFusionService.doStart()`) and never re-applied. This wires them through to the live native caches:
- **Size limits** (`datafusion.metadata/statistics.cache.size.limit`) now resize the live caches via a new `df_cache_manager_update_size_limit` FFM export (dispatching by cache type to the existing Rust resize functions) + `addSettingsUpdateConsumer`, instead of being restart-required.
- **Enable/disable** (`datafusion.metadata/statistics.cache.enabled`) toggles caches at runtime. Disabling clears the cache so its memory is freed immediately; caches are always constructed so a boot-disabled cache can be re-enabled later.
- Fixes the **statistics cache limit being clobbered to the 20MiB DataFusion default at startup** — `build_cache_manager_config` now sets `with_file_statistics_cache_limit`.
- Fixes a **u64 overflow in the memory-guard spill threshold** (`saturating_mul`) that panicked in debug/CI builds when the pool limit is `i64::MAX`.
- Disabled-cache lookups no longer count as cache misses.

#### 2. Preserve cache size limits across per-query config rebuilds
Each per-query path (`session_context`, `indexed_executor`, `query_executor`, plus the test session) rebuilds a `CacheManagerConfig` and re-attaches the shared caches. DataFusion's `CacheManager::try_new` then resets each cache's limit to the config's default (20MiB statistics / 50MiB metadata) unless the limit is re-supplied — silently shrinking the configured `*.cache.size.limit` on the hot path. Each rebuild now re-asserts both limits from the live `CacheManager` (`get_file_statistic_cache_limit` / `get_metadata_cache_limit`).

#### 3. Scan-resistant S3-FIFO eviction (new default for both caches)
Plain LRU is not scan-resistant: a single wide one-off query evicts the hot footer/statistics working set. This adds an **S3-FIFO** (Yang et al., SOSP'23) policy — small/main/ghost queues, quick demotion of one-hit-wonders, ghost re-admission — and makes it the default `eviction.type` for both caches (LRU/LFU still selectable). `small_ratio` defaults to `0.50` for an SLRU-like probation/protected split (matching ClickHouse's `cache_size_ratio`). To honor the policy on the metadata cache, `MutexFileMetadataCache` now owns its store and drives the pluggable policy directly (DataFusion's `DefaultFilesMetadataCache` is hardcoded LRU, so `eviction.type` was previously a no-op for metadata).

### Related Issues

N/A (sandbox/experimental analytics backend).

### Check List
- [x] Functionality includes unit tests — `DataFusionPluginSettingsTests` (Java: settings dynamic/node-scope, consumers are safe no-ops before service start), plus Rust unit + end-to-end tests for cache resize, enable/disable, and S3-FIFO scan resistance through both caches.
- [x] New functionality has been documented (internal KB).
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
