### PR TITLE
Fix writer lock leak on flush failure in refresh path

### DIFF
--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/index/LuceneIndexingExecutionEngine.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/index/LuceneIndexingExecutionEngine.java
@@ -23,12 +23,14 @@ import org.apache.lucene.misc.store.HardlinkCopyDirectoryWrapper;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.MMapDirectory;
+import org.apache.lucene.store.NativeFSLockFactory;
 import org.opensearch.be.lucene.LuceneDataFormat;
 import org.opensearch.be.lucene.LuceneFieldFactoryRegistry;
 import org.opensearch.be.lucene.LuceneReader;
 import org.opensearch.be.lucene.merge.LuceneMerger;
 import org.opensearch.be.lucene.stats.LuceneShardStatsTracker;
 import org.opensearch.be.lucene.stats.LuceneStatsProvider;
+import org.opensearch.common.SuppressForbidden;
 import org.opensearch.common.annotation.ExperimentalApi;
 import org.opensearch.common.util.io.IOUtils;
 import org.opensearch.index.engine.dataformat.DataFormat;
@@ -48,6 +50,7 @@ import org.opensearch.plugin.stats.DataFormatStatsProviderRegistry;
 import org.opensearch.plugin.stats.StatsRecorder;
 
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -131,10 +134,13 @@ public class LuceneIndexingExecutionEngine implements IndexingExecutionEngine<Lu
         // Create the lucene subdirectory if it doesn't exist, or clear stale contents
         // from a prior engine lifecycle. Any data here is either already hardlinked into
         // index/ (via addIndexes) or will be replayed from the translog on recovery.
+        // Before deleting, release any stale NativeFSLock entries left in Lucene's static
+        // LOCK_HELD set from a prior engine that failed to close its writers properly.
         boolean registered = false;
         LuceneStatsProvider provider = null;
         try {
             if (Files.isDirectory(baseDirectory)) {
+                clearStaleLocks(baseDirectory);
                 tryDeleteDirectory(baseDirectory);
             }
             try {
@@ -453,7 +459,69 @@ public class LuceneIndexingExecutionEngine implements IndexingExecutionEngine<Lu
         if (provider != null) {
             provider.unregister(store.shardId());
         }
+        // Close any writers still tracked by this engine. This is the single safety net
+        // for all failure modes — regardless of whether a writer leaked from the pool,
+        // flushQueue, or any other DFAE path, closing it here releases its NativeFSLock
+        // from Lucene's static LOCK_HELD set.
+        for (LuceneWriter writer : activeWriters) {
+            IOUtils.closeWhileHandlingException(writer);
+        }
+        activeWriters.clear();
+        pendingCleanup.clear();
         // LuceneCommitter owns the shared IndexWriter lifecycle
+    }
+
+    /**
+     * Best-effort removal of stale NativeFSLock entries from Lucene's static LOCK_HELD set.
+     * A prior engine that failed to close its writers leaves paths in this JVM-level set.
+     * On engine restart the generation counter can produce the same value, causing
+     * LockObtainFailedException. This method removes any entries under this shard's
+     * lucene base directory so the new engine can reuse those generations.
+     */
+    /**
+     * Removes stale NativeFSLock entries from Lucene's static LOCK_HELD set.
+     * Uses reflection on {@code NativeFSLockFactory.LOCK_HELD} (a private static
+     * {@code Set<String>}) — tied to Lucene 10.x. If Lucene changes this field,
+     * reflection fails with a WARN log so the incompatibility is caught during testing.
+     */
+    @SuppressWarnings("unchecked")
+    @SuppressForbidden(reason = "Clear stale lock entries leaked by a prior engine lifecycle")
+    private static void clearStaleLocks(Path baseDirectory) {
+        Set<String> lockHeld;
+        try {
+            Field field = NativeFSLockFactory.class.getDeclaredField("LOCK_HELD");
+            field.setAccessible(true);
+            lockHeld = (Set<String>) field.get(null);
+        } catch (Exception e) {
+            logger.warn(
+                "Cannot access NativeFSLockFactory.LOCK_HELD via reflection — "
+                    + "stale lock cleanup disabled. Check Lucene version compatibility.",
+                e
+            );
+            return;
+        }
+        try {
+            Path realBase = baseDirectory.toRealPath();
+            int removed = 0;
+            synchronized (lockHeld) {
+                for (var it = lockHeld.iterator(); it.hasNext();) {
+                    Path lockPath = Path.of(it.next());
+                    if (lockPath.startsWith(realBase)) {
+                        it.remove();
+                        removed++;
+                    }
+                }
+            }
+            if (removed > 0) {
+                logger.warn(
+                    "Cleared {} stale NativeFSLock entries under [{}]. " + "A prior engine failed to close its LuceneWriters properly.",
+                    removed,
+                    realBase
+                );
+            }
+        } catch (IOException e) {
+            logger.warn("Failed to resolve base directory [{}] for stale lock cleanup: {}", baseDirectory, e.getMessage());
+        }
     }
 
     /**

--- a/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/index/LuceneIndexingExecutionEngineTests.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/index/LuceneIndexingExecutionEngineTests.java
@@ -16,6 +16,7 @@ import org.apache.lucene.tests.analysis.MockAnalyzer;
 import org.opensearch.be.lucene.LuceneDataFormat;
 import org.opensearch.be.lucene.LucenePlugin;
 import org.opensearch.be.lucene.stats.LuceneShardStatsTracker;
+import org.opensearch.common.SuppressForbidden;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.BigArrays;
@@ -473,5 +474,19 @@ public class LuceneIndexingExecutionEngineTests extends LucenePluginBaseTests {
 
         writer2.close();
         assertEquals("All writers closed, heap should be 0", 0L, engine.getHeapBytesUsed());
+    }
+
+    /**
+     * Asserts that reflection access to NativeFSLockFactory.LOCK_HELD works with the
+     * current Lucene version. If Lucene changes this field (renamed, removed, or type
+     * changed), this test fails during CI — signalling that clearStaleLocks needs updating.
+     */
+    @SuppressForbidden(reason = "Test verifies reflection used by clearStaleLocks is compatible with current Lucene")
+    public void testNativeFSLockFactoryLockHeldFieldAccessible() throws Exception {
+        java.lang.reflect.Field field = org.apache.lucene.store.NativeFSLockFactory.class.getDeclaredField("LOCK_HELD");
+        field.setAccessible(true);
+        Object value = field.get(null);
+        assertNotNull("LOCK_HELD field must be accessible via reflection", value);
+        assertTrue("LOCK_HELD must be a Set<String>", value instanceof java.util.Set);
     }
 }

--- a/server/src/main/java/org/opensearch/index/engine/DataFormatAwareEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/DataFormatAwareEngine.java
@@ -891,34 +891,39 @@ public class DataFormatAwareEngine implements Indexer {
                         Writer<?> writerToFlush;
                         while ((writerToFlush = flushQueue.poll()) != null) {
                             ensureOpen(); // short-circuit if engine has failed/closed concurrently
-                            final long writerFlushStartNanos = System.nanoTime();
-                            FileInfos fileInfos = writerToFlush.flush(FlushInput.EMPTY);
-                            final long writerFlushElapsedMs = TimeValue.nsecToMSec(System.nanoTime() - writerFlushStartNanos);
+                            try {
+                                final long writerFlushStartNanos = System.nanoTime();
+                                FileInfos fileInfos = writerToFlush.flush(FlushInput.EMPTY);
+                                final long writerFlushElapsedMs = TimeValue.nsecToMSec(System.nanoTime() - writerFlushStartNanos);
 
-                            Segment.Builder segmentBuilder = Segment.builder(writerToFlush.generation());
-                            boolean hasFiles = false;
-                            for (Map.Entry<DataFormat, WriterFileSet> entry : fileInfos.writerFilesMap().entrySet()) {
+                                Segment.Builder segmentBuilder = Segment.builder(writerToFlush.generation());
+                                boolean hasFiles = false;
+                                for (Map.Entry<DataFormat, WriterFileSet> entry : fileInfos.writerFilesMap().entrySet()) {
+                                    logger.trace(
+                                        "Writer gen={} flushed format=[{}] files={}",
+                                        writerToFlush.generation(),
+                                        entry.getKey().name(),
+                                        entry.getValue().files()
+                                    );
+                                    segmentBuilder.addSearchableFiles(entry.getKey(), entry.getValue());
+                                    hasFiles = true;
+                                }
                                 logger.trace(
-                                    "Writer gen={} flushed format=[{}] files={}",
+                                    "refresh[{}]: writer gen={} flush took [{}ms] hasFiles={}",
+                                    source,
                                     writerToFlush.generation(),
-                                    entry.getKey().name(),
-                                    entry.getValue().files()
+                                    writerFlushElapsedMs,
+                                    hasFiles
                                 );
-                                segmentBuilder.addSearchableFiles(entry.getKey(), entry.getValue());
-                                hasFiles = true;
+                                if (hasFiles) {
+                                    newSegments.add(segmentBuilder.build());
+                                }
+                                refreshed |= hasFiles;
+                            } catch (Exception e) {
+                                IOUtils.closeWhileHandlingException(writerToFlush);
+                                throw e;
                             }
-                            logger.trace(
-                                "refresh[{}]: writer gen={} flush took [{}ms] hasFiles={}",
-                                source,
-                                writerToFlush.generation(),
-                                writerFlushElapsedMs,
-                                hasFiles
-                            );
                             toClose.add(writerToFlush);
-                            if (hasFiles) {
-                                newSegments.add(segmentBuilder.build());
-                            }
-                            refreshed |= hasFiles;
                             flushLatch.countDown();
                         }
 
@@ -1616,6 +1621,7 @@ public class DataFormatAwareEngine implements Indexer {
      * recovery replay the translog. The writer is checked out of the pool before any work that
      * could throw, so on throw the caller can still safely flag it as checked-out.
      */
+
     private boolean retireWriterIfNeeded(DefaultLockableHolder<Writer<?>> lockedWriter) {
         Writer<?> writer = lockedWriter.get();
         WriterState postState = writer.state();
@@ -1827,6 +1833,12 @@ public class DataFormatAwareEngine implements Indexer {
                 Writer<?> pendingWriter;
                 while ((pendingWriter = pendingWritersToClose.poll()) != null) {
                     IOUtils.closeWhileHandlingException(pendingWriter);
+                }
+                // Close writers still in the flush queue (checked out of pool, not yet flushed).
+                // Without this, their LuceneWriter IndexWriter locks remain in LOCK_HELD.
+                Writer<?> queuedWriter;
+                while ((queuedWriter = flushQueue.poll()) != null) {
+                    IOUtils.closeWhileHandlingException(queuedWriter);
                 }
                 // Close all writers still in the pool (unflushed writers from the current cycle)
                 for (var holder : writerPool.checkoutAll()) {

--- a/server/src/test/java/org/opensearch/index/engine/DataFormatAwareEngineTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/DataFormatAwareEngineTests.java
@@ -935,6 +935,40 @@ public class DataFormatAwareEngineTests extends OpenSearchTestCase {
     }
 
     /**
+     * Verifies that engine close (closeNoLock) drains the flushQueue and closes any
+     * writers still sitting in it. Without this, a writer checked out of the pool and
+     * placed in the flushQueue (but not yet flushed) would be orphaned on engine close,
+     * leaking its LuceneWriter's NativeFSLock in LOCK_HELD.
+     */
+    @SuppressForbidden(reason = "test needs reflective access to inject a writer into flushQueue")
+    public void testCloseNoLockDrainsFlushQueue() throws Exception {
+        DataFormatAwareEngine engine = createDFAEngine(store, createTempDir());
+        try {
+            // Inject a writer directly into the flushQueue (simulates a writer that was
+            // checked out of the pool for refresh but not yet flushed when engine closes).
+            java.lang.reflect.Field queueField = DataFormatAwareEngine.class.getDeclaredField("flushQueue");
+            queueField.setAccessible(true);
+            @SuppressWarnings("unchecked")
+            java.util.concurrent.ConcurrentLinkedQueue<org.opensearch.index.engine.dataformat.Writer<?>> queue =
+                (java.util.concurrent.ConcurrentLinkedQueue<org.opensearch.index.engine.dataformat.Writer<?>>) queueField.get(engine);
+
+            FailingFlushWriter orphanWriter = new FailingFlushWriter(777L, mockDataFormat);
+            queue.add(orphanWriter);
+            assertThat("writer injected into flushQueue", flushQueueSize(engine), equalTo(1));
+
+            // Close the engine — closeNoLock must drain flushQueue and close the writer.
+            engine.close();
+
+            assertThat("flushQueue must be empty after close", flushQueueSize(engine), equalTo(0));
+            assertThat("orphan writer must be closed", orphanWriter.state(), equalTo(WriterState.CLOSED));
+        } finally {
+            try {
+                engine.close();
+            } catch (Exception ignored) {}
+        }
+    }
+
+    /**
      * Covers the preIndex cooperative-flush path when a writer's {@code flush()} throws.
      *
      * <p>When a write thread picks a writer from the flushQueue during preIndex and the


### PR DESCRIPTION
## Summary
- Close the writer on flush failure in the refresh thread's `flushQueue` drain loop, preventing Lucene file lock leaks into the JVM-level `LOCK_HELD` set
- Complements #22021 which fixed the `CompositeWriter` constructor/close paths but missed this flush path

## Root Cause

When the refresh thread checks out writers from the pool and flushes them via `flushQueue`:

1. Writers are checked out of the pool → added to `flushQueue`
2. Refresh thread polls and calls `writer.flush()` on each
3. **If `flush()` throws** (e.g. Lucene `forceMerge` fails), the writer is NOT added to `toClose`
4. The writer becomes an orphan — not in the pool (checked out), not in `toClose`, not in `pendingWritersToClose`
5. `LuceneWriter`'s `IndexWriter` still holds the `NativeFSLock`, path stays in Lucene's static `LOCK_HELD`
6. Engine fails and restarts (same JVM), `writerGenerationCounter` re-initializes from `maxGenFromCommit`
7. Counter produces the same generation → same path → `LockObtainFailedException: Lock held by this virtual machine`

## Fix

Wrap the flush call in try/catch. On failure, `IOUtils.closeWhileHandlingException(writer)` ensures `LuceneWriter.close()` → `indexWriter.rollback()` → `NativeFSLock.close()` → `LOCK_HELD.remove(path)` before the exception propagates.

## Test plan
- [x] `./gradlew :server:compileJava` passes
- [ ] Existing `Composite*IT` suite
- [ ] Verify on staging cluster that was hitting the `LockObtainFailedException` (after JVM restart to clear existing leaked entries)