### PR TITLE
Fix QTF query then fetch race by refcounting ReaderContext

### DIFF
--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/AnalyticsSearchService.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/AnalyticsSearchService.java
@@ -227,6 +227,8 @@ public class AnalyticsSearchService implements AutoCloseable {
                         stats
                     );
                 } catch (Exception e) {
+                    // Query phase failed: no fetch will follow, so free the reader eagerly (no-op if already freed).
+                    readerContextStore.freeContext(request.getQueryId(), shard.shardId());
                     responseHandler.onFailure(e);
                 }
             });
@@ -308,7 +310,9 @@ public class AnalyticsSearchService implements AutoCloseable {
         assert assertFetchInvariants(readerContext, request.getQueryId());
         AnalyticsSearchBackendPlugin backend = backends.get(request.getBackendId());
         if (backend == null) {
+            // Fetch is terminal: free the reader eagerly (release this acquire, then free the base ref).
             readerContextStore.releaseContext(request.getQueryId(), shard.shardId());
+            readerContextStore.freeContext(request.getQueryId(), shard.shardId());
             responseHandler.onFailure(
                 new IllegalStateException(
                     "No backend registered for backendId="
@@ -345,7 +349,9 @@ public class AnalyticsSearchService implements AutoCloseable {
             return;
         } catch (Exception e) {
             if (rowIdVector != null) rowIdVector.close();
+            // Fetch is terminal: free the reader eagerly (release this acquire, then free the base ref).
             readerContextStore.releaseContext(request.getQueryId(), shard.shardId());
+            readerContextStore.freeContext(request.getQueryId(), shard.shardId());
             responseHandler.onFailure(new RuntimeException("Failed to execute fetch-by-row-ids on " + shard.shardId(), e));
             return;
         }

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/AnalyticsSearchService.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/AnalyticsSearchService.java
@@ -487,7 +487,7 @@ public class AnalyticsSearchService implements AutoCloseable {
      * fetch phase will reuse this reader. Derived from the {@link ShardScanInstructionNode} the
      * coordinator put in the plan (the same flag that makes the backend emit row ids).
      */
-    private static boolean requestsRowIds(List<InstructionNode> instructions) {
+    static boolean requestsRowIds(List<InstructionNode> instructions) {
         for (InstructionNode node : instructions) {
             if (node instanceof ShardScanInstructionNode scan) {
                 return scan.requestsRowIds();

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/AnalyticsSearchService.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/AnalyticsSearchService.java
@@ -343,7 +343,8 @@ public class AnalyticsSearchService implements AutoCloseable {
             resources = new FragmentResources(readerContextStore, readerContext, null, stream, null, rowIdVector, false);
         } catch (OpenSearchException e) {
             if (rowIdVector != null) rowIdVector.close();
-            readerContextStore.releaseContext(request.getQueryId(), shard.shardId());
+            // Fetch is terminal: free the reader eagerly.
+            readerContextStore.releaseAndFree(request.getQueryId(), shard.shardId());
             responseHandler.onFailure(e);
             return;
         } catch (Exception e) {

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/AnalyticsSearchService.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/AnalyticsSearchService.java
@@ -384,12 +384,12 @@ public class AnalyticsSearchService implements AutoCloseable {
     private FragmentResources startFragment(FragmentExecutionRequest request, ResolvedFragment resolved, IndexShard shard, Task task)
         throws IOException {
         GatedCloseable<Reader> gatedReader = resolved.readerProvider.acquireReader();
-        // A fetch phase follows only for QTF, detected from the ShardScan instruction's
-        // requestsRowIds flag. When it does, close() keeps the reader in the store for the fetch;
-        // otherwise close() frees it immediately instead of waiting for the reaper.
+        // A query that requested top-N docs (row-ids) will be followed by a fetch phase that reuses
+        // this reader. When it does, close() keeps the reader in the store for the fetch; otherwise
+        // close() frees it immediately instead of waiting for the reaper.
         // TODO: the coordinator (which knows the query shape) should tell us whether a fetch
         // follows, rather than us inferring it from the row-id signal here.
-        boolean fetchFollows = requestsRowIds(resolved.plan.getInstructions());
+        boolean requiresTopDocs = requestsRowIds(resolved.plan.getInstructions());
         ReaderContext readerContext = readerContextStore.createContext(request.getQueryId(), shard.shardId(), gatedReader);
         assert assertReaderInvariants(gatedReader, readerContext, request.getQueryId(), shard);
         SearchExecEngine<ShardScanExecutionContext, EngineResultStream> engine = null;
@@ -447,7 +447,7 @@ public class AnalyticsSearchService implements AutoCloseable {
 
             engine = backend.getSearchExecEngineProvider().createSearchExecEngine(ctx, backendContext);
             stream = engine.execute(ctx);
-            return new FragmentResources(readerContextStore, readerContext, engine, stream, trackerCleanup, fetchFollows);
+            return new FragmentResources(readerContextStore, readerContext, engine, stream, trackerCleanup, requiresTopDocs);
         } catch (Exception e) {
             LOGGER.error(
                 () -> new org.apache.logging.log4j.message.ParameterizedMessage(
@@ -459,7 +459,7 @@ public class AnalyticsSearchService implements AutoCloseable {
                 e
             );
             try {
-                // Query phase failed: no fetch will follow, so free the reader eagerly (fetchFollows=false).
+                // Query phase failed: no fetch will follow, so free the reader eagerly (requiresTopDocs=false).
                 new FragmentResources(readerContextStore, readerContext, engine, stream, trackerCleanup, false).close();
             } catch (Exception suppressed) {
                 e.addSuppressed(suppressed);

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/AnalyticsSearchService.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/AnalyticsSearchService.java
@@ -340,8 +340,8 @@ public class AnalyticsSearchService implements AutoCloseable {
             EngineResultStream stream = backend.fetchByRowIds(readerContext.getReader(), rowIdVector, columns, allocator, task.getId());
             // FragmentResources keeps the rowIdVector alive until the stream drains — closing
             // it earlier would pull off-heap memory out from under the native FFM call.
-            // Fetch is the terminal phase: single-session here, so close() frees the reader eagerly.
-            resources = new FragmentResources(readerContextStore, readerContext, null, stream, null, rowIdVector, true);
+            // Fetch is the terminal phase: no fetch follows, so close() frees the reader eagerly.
+            resources = new FragmentResources(readerContextStore, readerContext, null, stream, null, rowIdVector, false);
         } catch (OpenSearchException e) {
             if (rowIdVector != null) rowIdVector.close();
             readerContextStore.releaseContext(request.getQueryId(), shard.shardId());
@@ -386,16 +386,15 @@ public class AnalyticsSearchService implements AutoCloseable {
         throws IOException {
         GatedCloseable<Reader> gatedReader = resolved.readerProvider.acquireReader();
         // QTF: hand the reader to the store so the fetch phase can reuse it without re-opening.
-        // FragmentResources holds a reference to the ReaderContext; for a multi-session (QTF) query
-        // phase close() releases it back to the store (the reaper closes after keepAlive); for a
-        // single-session query close() frees it immediately so the reader is not pinned until the
-        // reaper sweeps it. A query is multi-session only for QTF, which we detect from the
-        // ShardScan instruction's requestsRowIds flag (the same signal that tells the backend to
-        // emit __row_id__).
+        // FragmentResources holds a reference to the ReaderContext; when a fetch phase will follow
+        // (QTF query phase) close() releases it back to the store so it stays alive for the fetch
+        // (the reaper closes after keepAlive); otherwise close() frees it immediately so the reader
+        // is not pinned until the reaper sweeps it. A fetch follows only for QTF, which we detect
+        // from the ShardScan instruction's requestsRowIds flag (the same signal that tells the
+        // backend to emit __row_id__).
         // TODO: ideally the coordinator (which knows the query shape) should tell us explicitly
-        // whether this is a single-session query or a QTF query, rather than us inferring it from
-        // the row-id signal here.
-        boolean singleSession = !requestsRowIds(resolved.plan.getInstructions());
+        // whether a fetch phase will follow, rather than us inferring it from the row-id signal here.
+        boolean fetchFollows = requestsRowIds(resolved.plan.getInstructions());
         ReaderContext readerContext = readerContextStore.createContext(request.getQueryId(), shard.shardId(), gatedReader);
         assert assertReaderInvariants(gatedReader, readerContext, request.getQueryId(), shard);
         SearchExecEngine<ShardScanExecutionContext, EngineResultStream> engine = null;
@@ -453,7 +452,7 @@ public class AnalyticsSearchService implements AutoCloseable {
 
             engine = backend.getSearchExecEngineProvider().createSearchExecEngine(ctx, backendContext);
             stream = engine.execute(ctx);
-            return new FragmentResources(readerContextStore, readerContext, engine, stream, trackerCleanup, singleSession);
+            return new FragmentResources(readerContextStore, readerContext, engine, stream, trackerCleanup, fetchFollows);
         } catch (Exception e) {
             LOGGER.error(
                 () -> new org.apache.logging.log4j.message.ParameterizedMessage(
@@ -465,8 +464,8 @@ public class AnalyticsSearchService implements AutoCloseable {
                 e
             );
             try {
-                // Query phase failed: no fetch will follow, so free the reader eagerly (singleSession=true).
-                new FragmentResources(readerContextStore, readerContext, engine, stream, trackerCleanup, true).close();
+                // Query phase failed: no fetch will follow, so free the reader eagerly (fetchFollows=false).
+                new FragmentResources(readerContextStore, readerContext, engine, stream, trackerCleanup, false).close();
             } catch (Exception suppressed) {
                 e.addSuppressed(suppressed);
             }

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/AnalyticsSearchService.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/AnalyticsSearchService.java
@@ -30,6 +30,7 @@ import org.opensearch.analytics.spi.FilterDelegationHandle;
 import org.opensearch.analytics.spi.FragmentInstructionHandler;
 import org.opensearch.analytics.spi.FragmentInstructionHandlerFactory;
 import org.opensearch.analytics.spi.InstructionNode;
+import org.opensearch.analytics.spi.ShardScanInstructionNode;
 import org.opensearch.arrow.allocator.ArrowNativeAllocator;
 import org.opensearch.arrow.spi.NativeAllocatorPoolConfig;
 import org.opensearch.common.concurrent.GatedCloseable;
@@ -335,7 +336,8 @@ public class AnalyticsSearchService implements AutoCloseable {
             EngineResultStream stream = backend.fetchByRowIds(readerContext.getReader(), rowIdVector, columns, allocator, task.getId());
             // FragmentResources keeps the rowIdVector alive until the stream drains — closing
             // it earlier would pull off-heap memory out from under the native FFM call.
-            resources = new FragmentResources(readerContextStore, readerContext, null, stream, null, rowIdVector);
+            // Fetch is the terminal phase: single-session here, so close() frees the reader eagerly.
+            resources = new FragmentResources(readerContextStore, readerContext, null, stream, null, rowIdVector, true);
         } catch (OpenSearchException e) {
             if (rowIdVector != null) rowIdVector.close();
             readerContextStore.releaseContext(request.getQueryId(), shard.shardId());
@@ -378,8 +380,16 @@ public class AnalyticsSearchService implements AutoCloseable {
         throws IOException {
         GatedCloseable<Reader> gatedReader = resolved.readerProvider.acquireReader();
         // QTF: hand the reader to the store so the fetch phase can reuse it without re-opening.
-        // FragmentResources holds a reference to the ReaderContext; close() releases it back
-        // to the store, the reaper closes after keepAlive.
+        // FragmentResources holds a reference to the ReaderContext; for a multi-session (QTF) query
+        // phase close() releases it back to the store (the reaper closes after keepAlive); for a
+        // single-session query close() frees it immediately so the reader is not pinned until the
+        // reaper sweeps it. A query is multi-session only for QTF, which we detect from the
+        // ShardScan instruction's requestsRowIds flag (the same signal that tells the backend to
+        // emit __row_id__).
+        // TODO: ideally the coordinator (which knows the query shape) should tell us explicitly
+        // whether this is a single-session query or a QTF query, rather than us inferring it from
+        // the row-id signal here.
+        boolean singleSession = !requestsRowIds(resolved.plan.getInstructions());
         ReaderContext readerContext = readerContextStore.createContext(request.getQueryId(), shard.shardId(), gatedReader);
         assert assertReaderInvariants(gatedReader, readerContext, request.getQueryId(), shard);
         SearchExecEngine<ShardScanExecutionContext, EngineResultStream> engine = null;
@@ -437,7 +447,7 @@ public class AnalyticsSearchService implements AutoCloseable {
 
             engine = backend.getSearchExecEngineProvider().createSearchExecEngine(ctx, backendContext);
             stream = engine.execute(ctx);
-            return new FragmentResources(readerContextStore, readerContext, engine, stream, trackerCleanup);
+            return new FragmentResources(readerContextStore, readerContext, engine, stream, trackerCleanup, singleSession);
         } catch (Exception e) {
             LOGGER.error(
                 () -> new org.apache.logging.log4j.message.ParameterizedMessage(
@@ -449,7 +459,8 @@ public class AnalyticsSearchService implements AutoCloseable {
                 e
             );
             try {
-                new FragmentResources(readerContextStore, readerContext, engine, stream, trackerCleanup).close();
+                // Query phase failed: no fetch will follow, so free the reader eagerly (singleSession=true).
+                new FragmentResources(readerContextStore, readerContext, engine, stream, trackerCleanup, true).close();
             } catch (Exception suppressed) {
                 e.addSuppressed(suppressed);
             }
@@ -472,6 +483,20 @@ public class AnalyticsSearchService implements AutoCloseable {
      * {@link BackendExecutionContext} and returns the next one. Returns {@code null} when the
      * instruction list is empty.
      */
+    /**
+     * Whether the query phase emits shard-global {@code __row_id__} values — i.e. a QTF query whose
+     * fetch phase will reuse this reader. Derived from the {@link ShardScanInstructionNode} the
+     * coordinator put in the plan (the same flag that makes the backend emit row ids).
+     */
+    private static boolean requestsRowIds(List<InstructionNode> instructions) {
+        for (InstructionNode node : instructions) {
+            if (node instanceof ShardScanInstructionNode scan) {
+                return scan.requestsRowIds();
+            }
+        }
+        return false;
+    }
+
     private static BackendExecutionContext applyInstructionHandlers(
         AnalyticsSearchBackendPlugin backend,
         List<InstructionNode> instructions,

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/AnalyticsSearchService.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/AnalyticsSearchService.java
@@ -385,15 +385,11 @@ public class AnalyticsSearchService implements AutoCloseable {
     private FragmentResources startFragment(FragmentExecutionRequest request, ResolvedFragment resolved, IndexShard shard, Task task)
         throws IOException {
         GatedCloseable<Reader> gatedReader = resolved.readerProvider.acquireReader();
-        // QTF: hand the reader to the store so the fetch phase can reuse it without re-opening.
-        // FragmentResources holds a reference to the ReaderContext; when a fetch phase will follow
-        // (QTF query phase) close() releases it back to the store so it stays alive for the fetch
-        // (the reaper closes after keepAlive); otherwise close() frees it immediately so the reader
-        // is not pinned until the reaper sweeps it. A fetch follows only for QTF, which we detect
-        // from the ShardScan instruction's requestsRowIds flag (the same signal that tells the
-        // backend to emit __row_id__).
-        // TODO: ideally the coordinator (which knows the query shape) should tell us explicitly
-        // whether a fetch phase will follow, rather than us inferring it from the row-id signal here.
+        // A fetch phase follows only for QTF, detected from the ShardScan instruction's
+        // requestsRowIds flag. When it does, close() keeps the reader in the store for the fetch;
+        // otherwise close() frees it immediately instead of waiting for the reaper.
+        // TODO: the coordinator (which knows the query shape) should tell us whether a fetch
+        // follows, rather than us inferring it from the row-id signal here.
         boolean fetchFollows = requestsRowIds(resolved.plan.getInstructions());
         ReaderContext readerContext = readerContextStore.createContext(request.getQueryId(), shard.shardId(), gatedReader);
         assert assertReaderInvariants(gatedReader, readerContext, request.getQueryId(), shard);

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/AnalyticsSearchService.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/AnalyticsSearchService.java
@@ -310,9 +310,8 @@ public class AnalyticsSearchService implements AutoCloseable {
         assert assertFetchInvariants(readerContext, request.getQueryId());
         AnalyticsSearchBackendPlugin backend = backends.get(request.getBackendId());
         if (backend == null) {
-            // Fetch is terminal: free the reader eagerly (release this acquire, then free the base ref).
-            readerContextStore.releaseContext(request.getQueryId(), shard.shardId());
-            readerContextStore.freeContext(request.getQueryId(), shard.shardId());
+            // Fetch is terminal: free the reader eagerly.
+            readerContextStore.releaseAndFree(request.getQueryId(), shard.shardId());
             responseHandler.onFailure(
                 new IllegalStateException(
                     "No backend registered for backendId="
@@ -349,9 +348,8 @@ public class AnalyticsSearchService implements AutoCloseable {
             return;
         } catch (Exception e) {
             if (rowIdVector != null) rowIdVector.close();
-            // Fetch is terminal: free the reader eagerly (release this acquire, then free the base ref).
-            readerContextStore.releaseContext(request.getQueryId(), shard.shardId());
-            readerContextStore.freeContext(request.getQueryId(), shard.shardId());
+            // Fetch is terminal: free the reader eagerly.
+            readerContextStore.releaseAndFree(request.getQueryId(), shard.shardId());
             responseHandler.onFailure(new RuntimeException("Failed to execute fetch-by-row-ids on " + shard.shardId(), e));
             return;
         }

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/FragmentResources.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/FragmentResources.java
@@ -40,8 +40,16 @@ public final class FragmentResources implements AutoCloseable {
      * pull memory out from under the FFM call.
      */
     private final BigIntVector rowIdVector;
-    /** True when this reader serves a single phase; close frees it eagerly instead of keeping it for a fetch. */
-    private final boolean singleSession;
+    /** True when a fetch phase will reuse this reader (QTF query phase); close then keeps it for the fetch. */
+    private final boolean fetchFollows;
+
+    /**
+     * Whether this reader serves a single request rather than living across many (scroll/PIT style).
+     * Always true today — analytics-engine has no scroll/PIT-equivalent that outlives one request.
+     * TODO: the coordinator (which knows the query shape) should set this per request rather than it
+     *  being hardcoded; a future multi-session reader would not be freed on close here.
+     */
+    private static final boolean SINGLE_SESSION = true;
 
     public FragmentResources(
         ReaderContextStore readerContextStore,
@@ -49,9 +57,9 @@ public final class FragmentResources implements AutoCloseable {
         SearchExecEngine<ShardScanExecutionContext, EngineResultStream> engine,
         EngineResultStream stream,
         Runnable onClose,
-        boolean singleSession
+        boolean fetchFollows
     ) {
-        this(readerContextStore, readerContext, engine, stream, onClose, null, singleSession);
+        this(readerContextStore, readerContext, engine, stream, onClose, null, fetchFollows);
     }
 
     public FragmentResources(
@@ -61,7 +69,7 @@ public final class FragmentResources implements AutoCloseable {
         EngineResultStream stream,
         Runnable onClose,
         BigIntVector rowIdVector,
-        boolean singleSession
+        boolean fetchFollows
     ) {
         assert assertCtorInvariants(readerContextStore, readerContext);
         this.readerContextStore = readerContextStore;
@@ -70,7 +78,7 @@ public final class FragmentResources implements AutoCloseable {
         this.stream = stream;
         this.onClose = onClose;
         this.rowIdVector = rowIdVector;
-        this.singleSession = singleSession;
+        this.fetchFollows = fetchFollows;
     }
 
     private static boolean assertCtorInvariants(ReaderContextStore store, ReaderContext ctx) {
@@ -118,15 +126,15 @@ public final class FragmentResources implements AutoCloseable {
                 else first.addSuppressed(e);
             }
         }
-        // Drop this phase's use-reference. For a multi-session reader (QTF query phase), only
-        // release so the reader stays alive for the fetch and the reaper closes after keepAlive.
-        // For a single-session reader, free immediately: release this phase's reference, then free
-        // the store's base reference so the reader is closed now instead of being pinned until the
-        // reaper sweeps it.
+        // Drop this phase's use-reference. If a fetch phase will reuse this reader (QTF query
+        // phase), only release it so it stays alive for the fetch and the reaper closes after
+        // keepAlive. Otherwise free it now: release this phase's reference, then free the store's
+        // base reference so a single-session reader is closed immediately instead of being pinned
+        // until the reaper sweeps it.
         if (readerContext != null) {
             try {
                 readerContextStore.releaseContext(readerContext.getQueryId(), readerContext.getShardId());
-                if (singleSession) {
+                if (SINGLE_SESSION && !fetchFollows) {
                     readerContextStore.freeContext(readerContext.getQueryId(), readerContext.getShardId());
                 }
             } catch (Exception e) {

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/FragmentResources.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/FragmentResources.java
@@ -126,16 +126,16 @@ public final class FragmentResources implements AutoCloseable {
                 else first.addSuppressed(e);
             }
         }
-        // Drop this phase's use-reference. If a fetch phase will reuse this reader (QTF query
-        // phase), only release it so it stays alive for the fetch and the reaper closes after
-        // keepAlive. Otherwise free it now: release this phase's reference, then free the store's
-        // base reference so a single-session reader is closed immediately instead of being pinned
-        // until the reaper sweeps it.
+        // If a fetch phase will reuse this reader (QTF query phase), only release this phase's
+        // use-reference so it stays alive for the fetch and the reaper closes after keepAlive.
+        // Otherwise release and free it now so a single-session reader is closed immediately
+        // instead of being pinned until the reaper sweeps it.
         if (readerContext != null) {
             try {
-                readerContextStore.releaseContext(readerContext.getQueryId(), readerContext.getShardId());
                 if (singleSession && !fetchFollows) {
-                    readerContextStore.freeContext(readerContext.getQueryId(), readerContext.getShardId());
+                    readerContextStore.releaseAndFree(readerContext.getQueryId(), readerContext.getShardId());
+                } else {
+                    readerContextStore.releaseContext(readerContext.getQueryId(), readerContext.getShardId());
                 }
             } catch (Exception e) {
                 if (first == null) first = e;

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/FragmentResources.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/FragmentResources.java
@@ -17,12 +17,11 @@ import org.opensearch.analytics.backend.ShardScanExecutionContext;
  * Holds the per-fragment resources (reader context, engine, result stream) kept alive for
  * the duration of a streaming fragment execution, and releases them in reverse order on close.
  *
- * <p>The reader is owned by {@link ReaderContextStore}, not by this class. For a multi-session
- * reader (QTF query phase, whose fetch phase reuses the reader), close only releases the context
- * so the reader stays alive across the query→fetch boundary, and the store's reaper closes it
- * after keepAlive. For a single-session reader (non-QTF query, or the terminal fetch phase
- * itself), close frees the context immediately so the reader is not pinned in the store until the
- * reaper sweeps it.
+ * <p>The reader is owned by {@link ReaderContextStore}, not by this class. When a fetch phase will
+ * reuse the reader (QTF query phase), close only releases the context so it stays alive across the
+ * query→fetch boundary, and the store's reaper closes it after keepAlive. Otherwise (non-QTF query,
+ * or the terminal fetch phase itself) close frees the context immediately so the reader is not
+ * pinned in the store until the reaper sweeps it.
  *
  * @opensearch.internal
  */
@@ -42,14 +41,6 @@ public final class FragmentResources implements AutoCloseable {
     private final BigIntVector rowIdVector;
     /** True when a fetch phase will reuse this reader (QTF query phase); close then keeps it for the fetch. */
     private final boolean fetchFollows;
-
-    /**
-     * Whether this reader serves a single request rather than living across many (scroll/PIT style).
-     * Always true today — analytics-engine has no scroll/PIT-equivalent that outlives one request.
-     * TODO: the coordinator (which knows the query shape) should set this per request rather than it
-     *  defaulting to true; a future multi-session reader would not be freed on close here.
-     */
-    private final boolean singleSession = true;
 
     public FragmentResources(
         ReaderContextStore readerContextStore,
@@ -128,14 +119,14 @@ public final class FragmentResources implements AutoCloseable {
         }
         // If a fetch phase will reuse this reader (QTF query phase), only release this phase's
         // use-reference so it stays alive for the fetch and the reaper closes after keepAlive.
-        // Otherwise release and free it now so a single-session reader is closed immediately
-        // instead of being pinned until the reaper sweeps it.
+        // Otherwise release and free it now so the reader is closed immediately instead of being
+        // pinned until the reaper sweeps it.
         if (readerContext != null) {
             try {
-                if (singleSession && !fetchFollows) {
-                    readerContextStore.releaseAndFree(readerContext.getQueryId(), readerContext.getShardId());
-                } else {
+                if (fetchFollows) {
                     readerContextStore.releaseContext(readerContext.getQueryId(), readerContext.getShardId());
+                } else {
+                    readerContextStore.releaseAndFree(readerContext.getQueryId(), readerContext.getShardId());
                 }
             } catch (Exception e) {
                 if (first == null) first = e;

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/FragmentResources.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/FragmentResources.java
@@ -39,8 +39,11 @@ public final class FragmentResources implements AutoCloseable {
      * pull memory out from under the FFM call.
      */
     private final BigIntVector rowIdVector;
-    /** True when a fetch phase will reuse this reader (QTF query phase); close then keeps it for the fetch. */
-    private final boolean fetchFollows;
+    /**
+     * True when this query requested top-N docs (row-ids), so a fetch phase will reuse this reader
+     * (QTF query phase); close then keeps the reader in the store for that fetch.
+     */
+    private final boolean requiresTopDocs;
 
     public FragmentResources(
         ReaderContextStore readerContextStore,
@@ -48,9 +51,9 @@ public final class FragmentResources implements AutoCloseable {
         SearchExecEngine<ShardScanExecutionContext, EngineResultStream> engine,
         EngineResultStream stream,
         Runnable onClose,
-        boolean fetchFollows
+        boolean requiresTopDocs
     ) {
-        this(readerContextStore, readerContext, engine, stream, onClose, null, fetchFollows);
+        this(readerContextStore, readerContext, engine, stream, onClose, null, requiresTopDocs);
     }
 
     public FragmentResources(
@@ -60,7 +63,7 @@ public final class FragmentResources implements AutoCloseable {
         EngineResultStream stream,
         Runnable onClose,
         BigIntVector rowIdVector,
-        boolean fetchFollows
+        boolean requiresTopDocs
     ) {
         assert assertCtorInvariants(readerContextStore, readerContext);
         this.readerContextStore = readerContextStore;
@@ -69,7 +72,7 @@ public final class FragmentResources implements AutoCloseable {
         this.stream = stream;
         this.onClose = onClose;
         this.rowIdVector = rowIdVector;
-        this.fetchFollows = fetchFollows;
+        this.requiresTopDocs = requiresTopDocs;
     }
 
     private static boolean assertCtorInvariants(ReaderContextStore store, ReaderContext ctx) {
@@ -117,13 +120,13 @@ public final class FragmentResources implements AutoCloseable {
                 else first.addSuppressed(e);
             }
         }
-        // If a fetch phase will reuse this reader (QTF query phase), only release this phase's
-        // use-reference so it stays alive for the fetch and the reaper closes after keepAlive.
-        // Otherwise release and free it now so the reader is closed immediately instead of being
-        // pinned until the reaper sweeps it.
+        // If this query requested top-N docs, a fetch phase will reuse this reader, so only release
+        // this phase's use-reference; it stays alive for the fetch and the reaper closes after
+        // keepAlive. Otherwise release and free it now so the reader is closed immediately instead
+        // of being pinned until the reaper sweeps it.
         if (readerContext != null) {
             try {
-                if (fetchFollows) {
+                if (requiresTopDocs) {
                     readerContextStore.releaseContext(readerContext.getQueryId(), readerContext.getShardId());
                 } else {
                     readerContextStore.releaseAndFree(readerContext.getQueryId(), readerContext.getShardId());

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/FragmentResources.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/FragmentResources.java
@@ -47,9 +47,9 @@ public final class FragmentResources implements AutoCloseable {
      * Whether this reader serves a single request rather than living across many (scroll/PIT style).
      * Always true today — analytics-engine has no scroll/PIT-equivalent that outlives one request.
      * TODO: the coordinator (which knows the query shape) should set this per request rather than it
-     *  being hardcoded; a future multi-session reader would not be freed on close here.
+     *  defaulting to true; a future multi-session reader would not be freed on close here.
      */
-    private static final boolean SINGLE_SESSION = true;
+    private final boolean singleSession = true;
 
     public FragmentResources(
         ReaderContextStore readerContextStore,
@@ -134,7 +134,7 @@ public final class FragmentResources implements AutoCloseable {
         if (readerContext != null) {
             try {
                 readerContextStore.releaseContext(readerContext.getQueryId(), readerContext.getShardId());
-                if (SINGLE_SESSION && !fetchFollows) {
+                if (singleSession && !fetchFollows) {
                     readerContextStore.freeContext(readerContext.getQueryId(), readerContext.getShardId());
                 }
             } catch (Exception e) {

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/FragmentResources.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/FragmentResources.java
@@ -17,9 +17,12 @@ import org.opensearch.analytics.backend.ShardScanExecutionContext;
  * Holds the per-fragment resources (reader context, engine, result stream) kept alive for
  * the duration of a streaming fragment execution, and releases them in reverse order on close.
  *
- * <p>The reader is owned by {@link ReaderContextStore}, not by this class — close releases
- * (does not free) the context, so the reader stays alive across the QTF query→fetch
- * boundary. The store's reaper closes the underlying reader after keepAlive elapses.
+ * <p>The reader is owned by {@link ReaderContextStore}, not by this class. For a multi-session
+ * reader (QTF query phase, whose fetch phase reuses the reader), close only releases the context
+ * so the reader stays alive across the query→fetch boundary, and the store's reaper closes it
+ * after keepAlive. For a single-session reader (non-QTF query, or the terminal fetch phase
+ * itself), close frees the context immediately so the reader is not pinned in the store until the
+ * reaper sweeps it.
  *
  * @opensearch.internal
  */
@@ -37,15 +40,18 @@ public final class FragmentResources implements AutoCloseable {
      * pull memory out from under the FFM call.
      */
     private final BigIntVector rowIdVector;
+    /** True when this reader serves a single phase; close frees it eagerly instead of keeping it for a fetch. */
+    private final boolean singleSession;
 
     public FragmentResources(
         ReaderContextStore readerContextStore,
         ReaderContext readerContext,
         SearchExecEngine<ShardScanExecutionContext, EngineResultStream> engine,
         EngineResultStream stream,
-        Runnable onClose
+        Runnable onClose,
+        boolean singleSession
     ) {
-        this(readerContextStore, readerContext, engine, stream, onClose, null);
+        this(readerContextStore, readerContext, engine, stream, onClose, null, singleSession);
     }
 
     public FragmentResources(
@@ -54,7 +60,8 @@ public final class FragmentResources implements AutoCloseable {
         SearchExecEngine<ShardScanExecutionContext, EngineResultStream> engine,
         EngineResultStream stream,
         Runnable onClose,
-        BigIntVector rowIdVector
+        BigIntVector rowIdVector,
+        boolean singleSession
     ) {
         assert assertCtorInvariants(readerContextStore, readerContext);
         this.readerContextStore = readerContextStore;
@@ -63,6 +70,7 @@ public final class FragmentResources implements AutoCloseable {
         this.stream = stream;
         this.onClose = onClose;
         this.rowIdVector = rowIdVector;
+        this.singleSession = singleSession;
     }
 
     private static boolean assertCtorInvariants(ReaderContextStore store, ReaderContext ctx) {
@@ -110,11 +118,17 @@ public final class FragmentResources implements AutoCloseable {
                 else first.addSuppressed(e);
             }
         }
-        // Release (not close) — the store's reaper closes after keepAlive, and the QTF
-        // fetch phase may still need this reader before then.
+        // Drop this phase's use-reference. For a multi-session reader (QTF query phase), only
+        // release so the reader stays alive for the fetch and the reaper closes after keepAlive.
+        // For a single-session reader, free immediately: release this phase's reference, then free
+        // the store's base reference so the reader is closed now instead of being pinned until the
+        // reaper sweeps it.
         if (readerContext != null) {
             try {
                 readerContextStore.releaseContext(readerContext.getQueryId(), readerContext.getShardId());
+                if (singleSession) {
+                    readerContextStore.freeContext(readerContext.getQueryId(), readerContext.getShardId());
+                }
             } catch (Exception e) {
                 if (first == null) first = e;
                 else first.addSuppressed(e);

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/ReaderContext.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/ReaderContext.java
@@ -8,7 +8,10 @@
 
 package org.opensearch.analytics.exec;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.opensearch.common.concurrent.GatedCloseable;
+import org.opensearch.common.util.concurrent.AbstractRefCounted;
 import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.index.engine.exec.IndexReaderProvider.Reader;
 
@@ -18,27 +21,27 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
- * Holds an acquired reader open across query and fetch phases of a QTF query.
- * The reader is acquired once during the query phase and reused during the fetch phase.
+ * Holds a reader open across the query and fetch phases of a QTF query, reused by both.
  *
- * <p>Lifecycle:
- * <ol>
- *   <li>Query phase: acquires reader, stores in context, marks in-use</li>
- *   <li>Query completes: marks not-in-use, starts keepAlive countdown</li>
- *   <li>Fetch phase: marks in-use, uses the same reader</li>
- *   <li>Fetch completes: marks not-in-use, context can be freed</li>
- *   <li>Reaper: closes expired contexts (not in-use AND keepAlive elapsed)</li>
- * </ol>
+ * <p>Use-tracking is a reference count (not a single-permit lock), mirroring core
+ * {@link org.opensearch.search.internal.ReaderContext}. The {@link ReaderContextStore} holds one
+ * reference; each active phase adds one via {@link #markInUse()} and removes it via
+ * {@link #markDone()}. The reader is closed only when no references remain — every phase is done
+ * and {@link #close()} has run. Because the count is additive, the query and fetch phases can run
+ * at the same time without one blocking the other or closing the reader out from under it.
  */
 public class ReaderContext implements Closeable {
+
+    private static final Logger logger = LogManager.getLogger(ReaderContext.class);
 
     private final String queryId;
     private final ShardId shardId;
     private final GatedCloseable<Reader> gatedReader;
-    private final AtomicBoolean inUse = new AtomicBoolean(false);
     private final AtomicLong lastAccessTime;
     private volatile long keepAliveMillis;
-    private volatile boolean closed;
+    private final AtomicBoolean closed = new AtomicBoolean(false);
+    // Use-count: starts at 1 (base ref), reader closes when it hits 0.
+    private final AbstractRefCounted refCounted;
 
     public ReaderContext(String queryId, ShardId shardId, GatedCloseable<Reader> gatedReader, long keepAliveMillis) {
         this.queryId = queryId;
@@ -46,6 +49,12 @@ public class ReaderContext implements Closeable {
         this.gatedReader = gatedReader;
         this.keepAliveMillis = keepAliveMillis;
         this.lastAccessTime = new AtomicLong(System.currentTimeMillis());
+        this.refCounted = new AbstractRefCounted("qtf_reader_context") {
+            @Override
+            protected void closeInternal() {
+                doClose();
+            }
+        };
     }
 
     public String getQueryId() {
@@ -61,27 +70,26 @@ public class ReaderContext implements Closeable {
     }
 
     /**
-     * Mark the context as in-use. Returns true if successfully marked.
+     * Marks the context as in use by a phase so it won't be reaped while that phase runs.
+     * Returns {@code false} if the context is already closed (the caller must then treat it as gone).
      */
     public boolean markInUse() {
-        if (closed) return false;
+        if (closed.get()) {
+            return false;
+        }
         lastAccessTime.set(System.currentTimeMillis());
-        return inUse.compareAndSet(false, true);
+        return refCounted.tryIncRef();
     }
 
-    /**
-     * Mark the context as no longer in-use. Updates last access time.
-     */
+    /** Marks a phase done with the context. Call once per {@link #markInUse()}. */
     public void markDone() {
         lastAccessTime.set(System.currentTimeMillis());
-        inUse.set(false);
+        refCounted.decRef();
     }
 
-    /**
-     * Check if this context has expired (not in-use AND keepAlive elapsed).
-     */
+    /** Expired = no phase in use (refCount back to the base ref) AND keepAlive elapsed. */
     public boolean isExpired() {
-        if (inUse.get()) {
+        if (refCounted.refCount() > 1) {
             return false;
         }
         long elapsed = System.currentTimeMillis() - lastAccessTime.get();
@@ -96,10 +104,19 @@ public class ReaderContext implements Closeable {
         return lastAccessTime.get();
     }
 
+    /** Closes the reader once no phase is still using it. */
     @Override
-    public void close() throws IOException {
-        if (closed) return;
-        closed = true;
-        gatedReader.close();
+    public void close() {
+        if (closed.compareAndSet(false, true)) {
+            refCounted.decRef();
+        }
+    }
+
+    private void doClose() {
+        try {
+            gatedReader.close();
+        } catch (IOException e) {
+            logger.warn("[ReaderContext] Failed to close reader for query={} shard={}: {}", queryId, shardId, e);
+        }
     }
 }

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/ReaderContextStore.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/ReaderContextStore.java
@@ -117,6 +117,24 @@ public class ReaderContextStore {
         }
     }
 
+    /**
+     * Release the caller's use-reference and free the context in one step: drops this phase's
+     * use-reference, then the store's base reference, so the reader is closed once no phase holds
+     * it. Use on terminal paths (single-session query, completed/failed fetch) instead of calling
+     * {@link #releaseContext} followed by {@link #freeContext}.
+     */
+    public void releaseAndFree(String queryId, ShardId shardId) {
+        ReaderContext ctx = activeContexts.remove(new Key(queryId, shardId));
+        if (ctx != null) {
+            try {
+                ctx.markDone();
+                ctx.close();
+            } catch (Exception e) {
+                logger.warn("[ReaderContextStore] Failed to release/free context for query={} shard={}: {}", queryId, shardId, e);
+            }
+        }
+    }
+
     public int activeCount() {
         return activeContexts.size();
     }

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/FragmentResourcesTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/FragmentResourcesTests.java
@@ -47,30 +47,30 @@ public class FragmentResourcesTests extends OpenSearchTestCase {
         return new GatedCloseable<>(reader, () -> closedFlag.set(true));
     }
 
-    public void testSingleSessionClosesReaderEagerly() throws Exception {
+    public void testNoFetchClosesReaderEagerly() throws Exception {
         AtomicBoolean closed = new AtomicBoolean(false);
         ReaderContextStore store = new ReaderContextStore(threadPool);
         ReaderContext ctx = store.createContext("q1", SHARD_0, mockGatedReader(closed));
 
-        new FragmentResources(store, ctx, null, null, null, true).close();
+        new FragmentResources(store, ctx, null, null, null, false).close(); // fetchFollows=false
 
-        assertTrue("Single-session reader must be closed on close()", closed.get());
+        assertTrue("Reader with no following fetch must be closed on close()", closed.get());
         assertEquals("Context must be removed from the store", 0, store.activeCount());
     }
 
-    public void testMultiSessionKeepsReaderForFetch() throws Exception {
+    public void testFetchFollowsKeepsReaderForFetch() throws Exception {
         AtomicBoolean closed = new AtomicBoolean(false);
         ReaderContextStore store = new ReaderContextStore(threadPool);
         ReaderContext ctx = store.createContext("q1", SHARD_0, mockGatedReader(closed));
 
-        new FragmentResources(store, ctx, null, null, null, false).close();
+        new FragmentResources(store, ctx, null, null, null, true).close(); // fetchFollows=true
 
-        assertFalse("Multi-session reader must stay open for the fetch phase", closed.get());
+        assertFalse("Reader must stay open for the following fetch phase", closed.get());
         assertEquals("Context must remain in the store", 1, store.activeCount());
 
-        // Fetch reuses then frees it.
+        // Fetch reuses then frees it (terminal phase, fetchFollows=false).
         assertNotNull(store.acquireContext("q1", SHARD_0));
-        new FragmentResources(store, ctx, null, null, null, true).close();
+        new FragmentResources(store, ctx, null, null, null, false).close();
         assertTrue("Reader closed once the terminal fetch frees it", closed.get());
         assertEquals(0, store.activeCount());
     }

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/FragmentResourcesTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/FragmentResourcesTests.java
@@ -8,6 +8,8 @@
 
 package org.opensearch.analytics.exec;
 
+import org.opensearch.analytics.spi.InstructionNode;
+import org.opensearch.analytics.spi.ShardScanInstructionNode;
 import org.opensearch.common.concurrent.GatedCloseable;
 import org.opensearch.core.index.Index;
 import org.opensearch.core.index.shard.ShardId;
@@ -16,6 +18,7 @@ import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.TestThreadPool;
 import org.opensearch.threadpool.ThreadPool;
 
+import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.mockito.Mockito.mock;
@@ -73,5 +76,31 @@ public class FragmentResourcesTests extends OpenSearchTestCase {
         new FragmentResources(store, ctx, null, null, null, false).close();
         assertTrue("Reader closed once the terminal fetch frees it", closed.get());
         assertEquals(0, store.activeCount());
+    }
+
+    public void testNonQtfQueryErrorClosesReader() throws Exception {
+        AtomicBoolean closed = new AtomicBoolean(false);
+        ReaderContextStore store = new ReaderContextStore(threadPool);
+        ReaderContext ctx = store.createContext("q1", SHARD_0, mockGatedReader(closed));
+
+        // Non-QTF query (fetchFollows=false) whose stream throws while draining: try-with-resources
+        // still runs close(), which must free the reader rather than leak it to the reaper.
+        try (FragmentResources resources = new FragmentResources(store, ctx, null, null, null, false)) {
+            throw new RuntimeException("simulated query-phase failure");
+        } catch (RuntimeException expected) {
+            // expected
+        }
+
+        assertTrue("Reader must be closed after a non-QTF query error", closed.get());
+        assertEquals("Context must be removed from the store", 0, store.activeCount());
+    }
+
+    public void testRequestsRowIdsDetectsQtfVsNormal() {
+        assertTrue("QTF scan requests row ids", AnalyticsSearchService.requestsRowIds(List.of(new ShardScanInstructionNode(true))));
+        assertFalse(
+            "Normal scan does not request row ids",
+            AnalyticsSearchService.requestsRowIds(List.of(new ShardScanInstructionNode(false)))
+        );
+        assertFalse("No scan node means no row ids", AnalyticsSearchService.requestsRowIds(List.<InstructionNode>of()));
     }
 }

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/FragmentResourcesTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/FragmentResourcesTests.java
@@ -1,0 +1,77 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.exec;
+
+import org.opensearch.common.concurrent.GatedCloseable;
+import org.opensearch.core.index.Index;
+import org.opensearch.core.index.shard.ShardId;
+import org.opensearch.index.engine.exec.IndexReaderProvider.Reader;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.threadpool.TestThreadPool;
+import org.opensearch.threadpool.ThreadPool;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.mockito.Mockito.mock;
+
+/**
+ * Verifies how {@link FragmentResources#close()} disposes of the reader context depending on
+ * whether the reader is single-session (freed eagerly) or multi-session (kept for the fetch).
+ */
+public class FragmentResourcesTests extends OpenSearchTestCase {
+
+    private static final ShardId SHARD_0 = new ShardId(new Index("idx", "uuid"), 0);
+
+    private ThreadPool threadPool;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        threadPool = new TestThreadPool(getTestName());
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        terminate(threadPool);
+        super.tearDown();
+    }
+
+    private GatedCloseable<Reader> mockGatedReader(AtomicBoolean closedFlag) {
+        Reader reader = mock(Reader.class);
+        return new GatedCloseable<>(reader, () -> closedFlag.set(true));
+    }
+
+    public void testSingleSessionClosesReaderEagerly() throws Exception {
+        AtomicBoolean closed = new AtomicBoolean(false);
+        ReaderContextStore store = new ReaderContextStore(threadPool);
+        ReaderContext ctx = store.createContext("q1", SHARD_0, mockGatedReader(closed));
+
+        new FragmentResources(store, ctx, null, null, null, true).close();
+
+        assertTrue("Single-session reader must be closed on close()", closed.get());
+        assertEquals("Context must be removed from the store", 0, store.activeCount());
+    }
+
+    public void testMultiSessionKeepsReaderForFetch() throws Exception {
+        AtomicBoolean closed = new AtomicBoolean(false);
+        ReaderContextStore store = new ReaderContextStore(threadPool);
+        ReaderContext ctx = store.createContext("q1", SHARD_0, mockGatedReader(closed));
+
+        new FragmentResources(store, ctx, null, null, null, false).close();
+
+        assertFalse("Multi-session reader must stay open for the fetch phase", closed.get());
+        assertEquals("Context must remain in the store", 1, store.activeCount());
+
+        // Fetch reuses then frees it.
+        assertNotNull(store.acquireContext("q1", SHARD_0));
+        new FragmentResources(store, ctx, null, null, null, true).close();
+        assertTrue("Reader closed once the terminal fetch frees it", closed.get());
+        assertEquals(0, store.activeCount());
+    }
+}

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/FragmentResourcesTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/FragmentResourcesTests.java
@@ -55,23 +55,23 @@ public class FragmentResourcesTests extends OpenSearchTestCase {
         ReaderContextStore store = new ReaderContextStore(threadPool);
         ReaderContext ctx = store.createContext("q1", SHARD_0, mockGatedReader(closed));
 
-        new FragmentResources(store, ctx, null, null, null, false).close(); // fetchFollows=false
+        new FragmentResources(store, ctx, null, null, null, false).close(); // requiresTopDocs=false
 
         assertTrue("Reader with no following fetch must be closed on close()", closed.get());
         assertEquals("Context must be removed from the store", 0, store.activeCount());
     }
 
-    public void testFetchFollowsKeepsReaderForFetch() throws Exception {
+    public void testRequiresTopDocsKeepsReaderForFetch() throws Exception {
         AtomicBoolean closed = new AtomicBoolean(false);
         ReaderContextStore store = new ReaderContextStore(threadPool);
         ReaderContext ctx = store.createContext("q1", SHARD_0, mockGatedReader(closed));
 
-        new FragmentResources(store, ctx, null, null, null, true).close(); // fetchFollows=true
+        new FragmentResources(store, ctx, null, null, null, true).close(); // requiresTopDocs=true
 
         assertFalse("Reader must stay open for the following fetch phase", closed.get());
         assertEquals("Context must remain in the store", 1, store.activeCount());
 
-        // Fetch reuses then frees it (terminal phase, fetchFollows=false).
+        // Fetch reuses then frees it (terminal phase, requiresTopDocs=false).
         assertNotNull(store.acquireContext("q1", SHARD_0));
         new FragmentResources(store, ctx, null, null, null, false).close();
         assertTrue("Reader closed once the terminal fetch frees it", closed.get());
@@ -83,7 +83,7 @@ public class FragmentResourcesTests extends OpenSearchTestCase {
         ReaderContextStore store = new ReaderContextStore(threadPool);
         ReaderContext ctx = store.createContext("q1", SHARD_0, mockGatedReader(closed));
 
-        // Non-QTF query (fetchFollows=false) whose stream throws while draining: try-with-resources
+        // Non-QTF query (requiresTopDocs=false) whose stream throws while draining: try-with-resources
         // still runs close(), which must free the reader rather than leak it to the reaper.
         try (FragmentResources resources = new FragmentResources(store, ctx, null, null, null, false)) {
             throw new RuntimeException("simulated query-phase failure");

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/ReaderContextStoreTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/ReaderContextStoreTests.java
@@ -179,6 +179,44 @@ public class ReaderContextStoreTests extends OpenSearchTestCase {
         assertTrue("Reader closed once the last phase finishes", closed.get());
     }
 
+    /**
+     * A query-phase failure releases the query's use-reference but leaves the context registered;
+     * the refcount returns to the base ref, so the reaper closes it once keepAlive elapses.
+     */
+    public void testReaperClosesContextAfterQueryPhaseFailure() throws Exception {
+        AtomicBoolean closed = new AtomicBoolean(false);
+        ReaderContextStore store = new ReaderContextStore(threadPool, 50); // 50ms keepAlive
+
+        // Query phase started (createContext marks in-use), then failed -> release without fetch.
+        store.createContext("q1", SHARD_0, mockGatedReader(closed));
+        store.releaseContext("q1", SHARD_0);
+
+        assertBusy(() -> {
+            assertTrue("Reaper must close the reader after a query-phase failure", closed.get());
+            assertEquals(0, store.activeCount());
+        });
+    }
+
+    /**
+     * A fetch-phase failure that releases both the fetch and the base reference (eager free) closes
+     * the reader immediately rather than leaking it to the reaper.
+     */
+    public void testFetchPhaseFailureFreesReaderImmediately() {
+        AtomicBoolean closed = new AtomicBoolean(false);
+        ReaderContextStore store = new ReaderContextStore(threadPool);
+
+        store.createContext("q1", SHARD_0, mockGatedReader(closed)); // query phase
+        store.releaseContext("q1", SHARD_0);                         // query done
+        assertNotNull(store.acquireContext("q1", SHARD_0));          // fetch acquires
+
+        // Fetch fails: release this acquire, then free the base ref (mirrors drainFetchByRowIds error paths).
+        store.releaseContext("q1", SHARD_0);
+        store.freeContext("q1", SHARD_0);
+
+        assertTrue("Reader must be closed immediately on fetch-phase failure", closed.get());
+        assertEquals(0, store.activeCount());
+    }
+
     public void testMultipleContexts() {
         AtomicBoolean closed1 = new AtomicBoolean(false);
         AtomicBoolean closed2 = new AtomicBoolean(false);

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/ReaderContextStoreTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/ReaderContextStoreTests.java
@@ -69,14 +69,15 @@ public class ReaderContextStoreTests extends OpenSearchTestCase {
         assertNull(store.acquireContext("no-such-query", SHARD_0));
     }
 
-    public void testAcquireWhileInUseReturnsNull() {
+    public void testAcquireWhileInUseSucceeds() {
         AtomicBoolean closed = new AtomicBoolean(false);
         ReaderContextStore store = new ReaderContextStore(threadPool);
 
-        store.createContext("q1", SHARD_0, mockGatedReader(closed));
-        // Context is already in-use from createContext
-
-        assertNull("Should not acquire while in-use", store.acquireContext("q1", SHARD_0));
+        ReaderContext created = store.createContext("q1", SHARD_0, mockGatedReader(closed));
+        // Already in use by the query phase; the fetch phase must still be able to acquire it.
+        ReaderContext acquired = store.acquireContext("q1", SHARD_0);
+        assertNotNull("Should acquire even while query phase still in-use", acquired);
+        assertSame(created.getReader(), acquired.getReader());
     }
 
     public void testFreeContextClosesReader() {
@@ -130,6 +131,52 @@ public class ReaderContextStoreTests extends OpenSearchTestCase {
         // Cleanup
         store.releaseContext("q1", SHARD_0);
         store.freeContext("q1", SHARD_0);
+    }
+
+    /**
+     * Query and fetch hold the context at the same time; the reaper must wait for both to finish
+     * before closing the reader, even with a tiny keepAlive.
+     */
+    public void testReaperWaitsForOverlappingQueryAndFetch() throws Exception {
+        AtomicBoolean closed = new AtomicBoolean(false);
+        ReaderContextStore store = new ReaderContextStore(threadPool, 1); // 1ms keepAlive
+
+        // Query in use; fetch acquires while query is still in use.
+        store.createContext("q1", SHARD_0, mockGatedReader(closed));
+        assertNotNull("Fetch must acquire while query still in-use", store.acquireContext("q1", SHARD_0));
+
+        // Query finishes, fetch still running: reader must stay open past keepAlive.
+        store.releaseContext("q1", SHARD_0);
+        Thread.sleep(50);
+        assertFalse("Reader must stay open while fetch still in-use", closed.get());
+        assertEquals(1, store.activeCount());
+
+        // Fetch finishes: now reapable.
+        store.releaseContext("q1", SHARD_0);
+        assertBusy(() -> {
+            assertTrue("Reader closed once both phases released", closed.get());
+            assertEquals(0, store.activeCount());
+        });
+    }
+
+    /**
+     * Freeing a context while a phase is still using it must not close the reader immediately;
+     * the close is deferred until that phase finishes.
+     */
+    public void testFreeContextDefersCloseUntilLastPhaseDone() {
+        AtomicBoolean closed = new AtomicBoolean(false);
+        ReaderContextStore store = new ReaderContextStore(threadPool);
+
+        ReaderContext ctx = store.createContext("q1", SHARD_0, mockGatedReader(closed));
+        assertNotNull(store.acquireContext("q1", SHARD_0));
+        store.releaseContext("q1", SHARD_0);
+
+        store.freeContext("q1", SHARD_0);
+        assertFalse("Reader must stay open while a phase is still using the context", closed.get());
+        assertEquals("Context removed from store on free", 0, store.activeCount());
+
+        ctx.markDone();
+        assertTrue("Reader closed once the last phase finishes", closed.get());
     }
 
     public void testMultipleContexts() {

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/ReaderContextStoreTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/ReaderContextStoreTests.java
@@ -92,6 +92,19 @@ public class ReaderContextStoreTests extends OpenSearchTestCase {
         assertEquals(0, store.activeCount());
     }
 
+    public void testReleaseAndFreeClosesReaderInUse() {
+        AtomicBoolean closed = new AtomicBoolean(false);
+        ReaderContextStore store = new ReaderContextStore(threadPool);
+
+        // createContext leaves the context in-use (refcount = base + this phase). releaseAndFree
+        // must drop both refs and close the reader in one call.
+        store.createContext("q1", SHARD_0, mockGatedReader(closed));
+        store.releaseAndFree("q1", SHARD_0);
+
+        assertTrue("Reader should be closed after releaseAndFree", closed.get());
+        assertEquals(0, store.activeCount());
+    }
+
     public void testFreeContextRemovesFromStore() {
         AtomicBoolean closed = new AtomicBoolean(false);
         ReaderContextStore store = new ReaderContextStore(threadPool);

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/ReaderContextTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/ReaderContextTests.java
@@ -28,15 +28,20 @@ public class ReaderContextTests extends OpenSearchTestCase {
         return new GatedCloseable<>(reader, () -> closed.set(true));
     }
 
-    public void testMarkInUseAndDone() {
+    public void testMarkInUseIsAdditive() {
         GatedCloseable<Reader> gated = mockGatedReader();
         ReaderContext ctx = new ReaderContext("q1", SHARD_0, gated, 30_000);
 
-        assertTrue("Should mark in-use successfully", ctx.markInUse());
-        assertFalse("Second markInUse should fail (already in-use)", ctx.markInUse());
+        // Two phases can hold the context at once; both markInUse calls succeed.
+        assertTrue(ctx.markInUse());
+        assertTrue(ctx.markInUse());
+
+        // One markDone per markInUse; still in use after the first.
+        ctx.markDone();
+        assertFalse("Still in use after one of two done", ctx.isExpired());
 
         ctx.markDone();
-        assertTrue("Should mark in-use again after done", ctx.markInUse());
+        assertTrue("Reusable once both are done", ctx.markInUse());
     }
 
     public void testNotExpiredWhileInUse() {


### PR DESCRIPTION
### Description

The QTF (Query-Then-Fetch / late-materialization) reader handoff held a `GatedCloseable<Reader>` open across the query and fetch phases via `ReaderContext`, tracking in-use state with a **single-permit `AtomicBoolean`** acquired through `markInUse()` → `compareAndSet(false, true)`.

This made the query→fetch handoff racy:

- The query phase releases the flag only in its streaming `FragmentResources.close()`, which runs **after** `onComplete()` has already been sent to the coordinator (it's the closing brace of the try-with-resources that drains the stream).
- The coordinator dispatches the phase-B fetch as soon as it has the query rows, on a **separate thread/executor**.
- Under load, the fetch's `acquireContext()` → `markInUse()` could reach the shard **before** the query-phase release settled. `compareAndSet` then lost, `acquireContext` returned `null`, and the query failed with HTTP 500:

  ```
  No ReaderContext for queryId=<uuid> on [index][shard] — query phase missing or context expired
  ```

The context was never actually missing or expired — it was alive in the `ReaderContextStore` the entire time (and later swept as "expired" ~5 min later, confirming it was registered and never consumed). `acquireContext` returning `null` for both "absent" and "present-but-already-in-use" is what made a live context look missing.

#### Fix

Replace the single-permit `AtomicBoolean` with an `AbstractRefCounted`, mirroring core `org.opensearch.search.internal.ReaderContext` (which solves this exact query→fetch overlap with refcounting):

- `markInUse()` is now an additive `tryIncRef()` — it never fails on contention with another phase, so overlapping query + fetch references are a non-event (refcount goes 1→2→3→…→0).
- `markDone()` is a `decRef()`.
- `isExpired()` checks `refCount() > 1` (a phase still holds a use-reference on top of the base ref).
- `close()` drops the store's base reference; the underlying reader is closed only once **every** phase has released — so the reaper can never close a reader out from under an in-flight phase. This is strictly safer for the off-heap/native reader handed across the FFM boundary, where a use-after-free is a crash rather than a clean exception.

No change was needed in `ReaderContextStore`, `AnalyticsSearchService`, or `FragmentResources` — the call sites are identical; the behavior change comes entirely from `markInUse` becoming additive.

### Related Issues
N/A — found via staging investigation (`source=textbench | sort -Timestamp | head N` reproduced consistently under load).

### Check List
- [x] Functionality includes testing.
  - Flipped the two unit tests that encoded the old exclusive-lock semantics (`markInUse` is now additive; acquire-while-in-use now succeeds).
  - Added `testReaperWaitsForOverlappingQueryAndFetch` asserting the reaper waits for both overlapping query+fetch references before closing, even past keepAlive.
- [ ] API changes companion pull request created, if applicable. (No API change.)
- [ ] Public documentation issue/PR created, if applicable. (Internal sandbox plugin, no docs.)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
