### PR TITLE
Harden force merge, VSR dedup, and refreshLock safety in DataFormatAwareEngine

### DIFF
--- a/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/CompositeFieldValidationIT.java
+++ b/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/CompositeFieldValidationIT.java
@@ -1,0 +1,107 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.composite;
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+
+import org.opensearch.action.bulk.BulkItemResponse;
+import org.opensearch.action.bulk.BulkResponse;
+import org.opensearch.action.index.IndexRequest;
+import org.opensearch.arrow.allocator.ArrowBasePlugin;
+import org.opensearch.be.datafusion.DataFusionPlugin;
+import org.opensearch.be.lucene.LucenePlugin;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.FeatureFlags;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.parquet.ParquetDataFormatPlugin;
+import org.opensearch.plugins.Plugin;
+import org.opensearch.test.OpenSearchIntegTestCase;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+/**
+ * Integration tests for field validation in the composite data format engine.
+ * Validates that system-managed metadata fields reject external input and that
+ * multi-value fields are rejected for columnar formats.
+ */
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 1)
+public class CompositeFieldValidationIT extends OpenSearchIntegTestCase {
+
+    private static final String INDEX_NAME = "test-field-validation";
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return Arrays.asList(
+            ArrowBasePlugin.class,
+            ParquetDataFormatPlugin.class,
+            CompositeDataFormatPlugin.class,
+            LucenePlugin.class,
+            DataFusionPlugin.class
+        );
+    }
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return Settings.builder()
+            .put(super.nodeSettings(nodeOrdinal))
+            .put(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG, true)
+            .build();
+    }
+
+    private Settings compositeIndexSettings() {
+        return Settings.builder()
+            .put("index.number_of_shards", 1)
+            .put("index.number_of_replicas", 0)
+            .put("index.pluggable.dataformat.enabled", true)
+            .put("index.pluggable.dataformat", "composite")
+            .put("index.composite.primary_data_format", "parquet")
+            .putList("index.composite.secondary_data_formats", "lucene")
+            .build();
+    }
+
+    public void testRowIdFieldRejectedInDocument() throws Exception {
+        client().admin()
+            .indices()
+            .prepareCreate(INDEX_NAME)
+            .setSettings(compositeIndexSettings())
+            .setMapping("name", "type=keyword", "age", "type=integer")
+            .get();
+        ensureGreen(INDEX_NAME);
+
+        BulkResponse bulkResponse = client().prepareBulk()
+            .add(new IndexRequest(INDEX_NAME).source(XContentType.JSON, "__row_id__", 999, "name", "test", "age", 25))
+            .get();
+
+        assertTrue("Expected bulk to have failures for __row_id__ field", bulkResponse.hasFailures());
+        BulkItemResponse item = bulkResponse.getItems()[0];
+        assertTrue(item.isFailed());
+        assertTrue(item.getFailureMessage().contains("metadata field and cannot be added inside a document"));
+    }
+
+    public void testMultipleValuesForSameFieldRejected() throws Exception {
+        client().admin()
+            .indices()
+            .prepareCreate(INDEX_NAME)
+            .setSettings(compositeIndexSettings())
+            .setMapping("name", "type=keyword", "age", "type=integer")
+            .get();
+        ensureGreen(INDEX_NAME);
+
+        BulkResponse bulkResponse = client().prepareBulk()
+            .add(new IndexRequest(INDEX_NAME).source("{\"age\": [10, 20], \"name\": \"test\"}", XContentType.JSON))
+            .get();
+
+        assertTrue("Expected rejection for multi-value field", bulkResponse.hasFailures());
+        BulkItemResponse item = bulkResponse.getItems()[0];
+        assertTrue(item.isFailed());
+        assertTrue(item.getFailureMessage().contains("multiple values"));
+    }
+}

--- a/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/CompositeForceMergeIT.java
+++ b/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/CompositeForceMergeIT.java
@@ -1,0 +1,189 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.composite;
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+
+import org.opensearch.action.admin.indices.forcemerge.ForceMergeResponse;
+import org.opensearch.arrow.allocator.ArrowBasePlugin;
+import org.opensearch.be.datafusion.DataFusionPlugin;
+import org.opensearch.be.lucene.LucenePlugin;
+import org.opensearch.common.concurrent.GatedCloseable;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.FeatureFlags;
+import org.opensearch.index.engine.DataFormatAwareEngine;
+import org.opensearch.index.engine.exec.coord.CatalogSnapshot;
+import org.opensearch.parquet.ParquetDataFormatPlugin;
+import org.opensearch.plugins.Plugin;
+import org.opensearch.test.OpenSearchIntegTestCase;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+/**
+ * Integration tests for force merge behavior in the DataFormatAwareEngine
+ * via the composite engine.
+ */
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 1)
+public class CompositeForceMergeIT extends OpenSearchIntegTestCase {
+
+    private static final String INDEX_NAME = "test-force-merge";
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return Arrays.asList(
+            ArrowBasePlugin.class,
+            ParquetDataFormatPlugin.class,
+            CompositeDataFormatPlugin.class,
+            LucenePlugin.class,
+            DataFusionPlugin.class
+        );
+    }
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return Settings.builder()
+            .put(super.nodeSettings(nodeOrdinal))
+            .put(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG, true)
+            .build();
+    }
+
+    private Settings compositeIndexSettings() {
+        return Settings.builder()
+            .put("index.number_of_shards", 1)
+            .put("index.number_of_replicas", 0)
+            .put("index.refresh_interval", "-1")
+            .put("index.pluggable.dataformat.enabled", true)
+            .put("index.pluggable.dataformat", "composite")
+            .put("index.composite.primary_data_format", "parquet")
+            .putList("index.composite.secondary_data_formats", "lucene")
+            .build();
+    }
+
+    public void testForceMergeReducesSegmentsToOne() throws Exception {
+        client().admin()
+            .indices()
+            .prepareCreate(INDEX_NAME)
+            .setSettings(compositeIndexSettings())
+            .setMapping("name", "type=keyword", "age", "type=integer")
+            .get();
+        ensureGreen(INDEX_NAME);
+
+        int docsPerCycle = 10;
+        int cycles = 5;
+        for (int cycle = 0; cycle < cycles; cycle++) {
+            for (int i = 0; i < docsPerCycle; i++) {
+                client().prepareIndex(INDEX_NAME).setSource("name", randomAlphaOfLength(8), "age", randomIntBetween(1, 100)).get();
+            }
+            client().admin().indices().prepareRefresh(INDEX_NAME).get();
+        }
+        client().admin().indices().prepareFlush(INDEX_NAME).setForce(true).get();
+
+        long segmentsBefore = getSegmentCount();
+        assertTrue("Expected multiple segments before merge, got " + segmentsBefore, segmentsBefore > 1);
+
+        ForceMergeResponse response = client().admin().indices().prepareForceMerge(INDEX_NAME).setMaxNumSegments(1).setFlush(true).get();
+        assertEquals(0, response.getFailedShards());
+
+        long segmentsAfter = getSegmentCount();
+        assertEquals("Expected exactly 1 segment after force merge to 1", 1, segmentsAfter);
+        assertEquals(docsPerCycle * cycles, getTotalDocCount());
+    }
+
+    public void testForceMergeWithMaxNumSegmentsGreaterThanOne() throws Exception {
+        client().admin()
+            .indices()
+            .prepareCreate(INDEX_NAME)
+            .setSettings(compositeIndexSettings())
+            .setMapping("name", "type=keyword", "age", "type=integer")
+            .get();
+        ensureGreen(INDEX_NAME);
+
+        int totalDocs = 20;
+        // Index one doc per refresh to create many small segments
+        for (int i = 0; i < totalDocs; i++) {
+            client().prepareIndex(INDEX_NAME).setSource("name", randomAlphaOfLength(8), "age", randomIntBetween(1, 100)).get();
+            client().admin().indices().prepareRefresh(INDEX_NAME).get();
+        }
+        client().admin().indices().prepareFlush(INDEX_NAME).setForce(true).get();
+
+        long segmentsBefore = getSegmentCount();
+        assertTrue("Expected many segments, got " + segmentsBefore, segmentsBefore > 5);
+
+        int maxNumSegments = 5;
+        ForceMergeResponse response = client().admin()
+            .indices()
+            .prepareForceMerge(INDEX_NAME)
+            .setMaxNumSegments(maxNumSegments)
+            .setFlush(true)
+            .get();
+        assertEquals(0, response.getFailedShards());
+
+        long segmentsAfter = getSegmentCount();
+        assertTrue("Expected segments <= " + maxNumSegments + " after force merge, got " + segmentsAfter, segmentsAfter <= maxNumSegments);
+        assertTrue("Expected segments reduced, before=" + segmentsBefore + " after=" + segmentsAfter, segmentsAfter < segmentsBefore);
+        assertEquals(totalDocs, getTotalDocCount());
+    }
+
+    public void testForceMergeFlushesBeforeMerging() throws Exception {
+        client().admin()
+            .indices()
+            .prepareCreate(INDEX_NAME)
+            .setSettings(compositeIndexSettings())
+            .setMapping("name", "type=keyword", "age", "type=integer")
+            .get();
+        ensureGreen(INDEX_NAME);
+
+        int totalDocs = 20;
+        // Index docs without refresh — data sits in indexing buffer
+        for (int i = 0; i < totalDocs; i++) {
+            client().prepareIndex(INDEX_NAME).setSource("name", randomAlphaOfLength(8), "age", randomIntBetween(1, 100)).get();
+        }
+
+        // Force merge with flush=true should flush unflushed data first
+        ForceMergeResponse response = client().admin().indices().prepareForceMerge(INDEX_NAME).setMaxNumSegments(1).setFlush(true).get();
+        assertEquals(0, response.getFailedShards());
+
+        // Verify all docs are present via catalog snapshot
+        assertEquals(totalDocs, getTotalDocCount());
+    }
+
+    public void testForceMergeOnEmptyIndex() throws Exception {
+        client().admin()
+            .indices()
+            .prepareCreate(INDEX_NAME)
+            .setSettings(compositeIndexSettings())
+            .setMapping("name", "type=keyword", "age", "type=integer")
+            .get();
+        ensureGreen(INDEX_NAME);
+
+        ForceMergeResponse response = client().admin().indices().prepareForceMerge(INDEX_NAME).setMaxNumSegments(1).setFlush(true).get();
+        assertEquals(0, response.getFailedShards());
+        assertEquals(0, getTotalDocCount());
+    }
+
+    private long getSegmentCount() {
+        DataFormatAwareEngine engine = CompositeEngineHelper.getEngine(internalCluster().clusterService(), internalCluster(), INDEX_NAME);
+        try (GatedCloseable<CatalogSnapshot> snapshotRef = engine.acquireLastCommittedSnapshot(false)) {
+            return snapshotRef.get().getSegments().size();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private long getTotalDocCount() {
+        DataFormatAwareEngine engine = CompositeEngineHelper.getEngine(internalCluster().clusterService(), internalCluster(), INDEX_NAME);
+        try (GatedCloseable<CatalogSnapshot> snapshotRef = engine.acquireLastCommittedSnapshot(false)) {
+            return snapshotRef.get().getNumDocs();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/sandbox/plugins/composite-engine/src/main/java/org/opensearch/composite/CompositeDataFormatPlugin.java
+++ b/sandbox/plugins/composite-engine/src/main/java/org/opensearch/composite/CompositeDataFormatPlugin.java
@@ -34,11 +34,13 @@ import org.opensearch.index.engine.dataformat.IndexingExecutionEngine;
 import org.opensearch.index.engine.dataformat.StoreStrategy;
 import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.index.mapper.MapperParsingException;
+import org.opensearch.index.mapper.MetadataFieldMapper;
 import org.opensearch.index.shard.IndexSettingProvider;
 import org.opensearch.indices.IndexCreationException;
 import org.opensearch.indices.IndicesService;
 import org.opensearch.plugin.stats.DataFormatStatsProviderRegistry;
 import org.opensearch.plugins.ExtensiblePlugin;
+import org.opensearch.plugins.MapperPlugin;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.repositories.RepositoriesService;
 import org.opensearch.script.ScriptService;
@@ -94,7 +96,7 @@ import java.util.stream.Collectors;
  * @opensearch.experimental
  */
 @ExperimentalApi
-public class CompositeDataFormatPlugin extends Plugin implements DataFormatPlugin, ExtensiblePlugin {
+public class CompositeDataFormatPlugin extends Plugin implements DataFormatPlugin, ExtensiblePlugin, MapperPlugin {
 
     private static final Logger logger = LogManager.getLogger(CompositeDataFormatPlugin.class);
 
@@ -438,6 +440,11 @@ public class CompositeDataFormatPlugin extends Plugin implements DataFormatPlugi
             }
         }
         return Map.copyOf(strategies);
+    }
+
+    @Override
+    public Map<String, MetadataFieldMapper.TypeParser> getMetadataMappers() {
+        return Map.of(RowIdFieldMapper.CONTENT_TYPE, RowIdFieldMapper.PARSER);
     }
 
 }

--- a/sandbox/plugins/composite-engine/src/main/java/org/opensearch/composite/RowIdFieldMapper.java
+++ b/sandbox/plugins/composite-engine/src/main/java/org/opensearch/composite/RowIdFieldMapper.java
@@ -1,0 +1,93 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.composite;
+
+import org.apache.lucene.search.Query;
+import org.opensearch.index.engine.dataformat.DocumentInput;
+import org.opensearch.index.mapper.MappedFieldType;
+import org.opensearch.index.mapper.MetadataFieldMapper;
+import org.opensearch.index.mapper.TextSearchInfo;
+import org.opensearch.index.mapper.ValueFetcher;
+import org.opensearch.index.query.QueryShardContext;
+import org.opensearch.search.lookup.SearchLookup;
+
+import java.util.Collections;
+
+/**
+ * Metadata field mapper for the internal {@code __row_id__} field.
+ * <p>
+ * This field is system-managed and assigned by the data format engine during
+ * indexing. It cannot be set externally — any attempt to include it in a
+ * document body will be rejected by the inherited
+ * {@link MetadataFieldMapper#parseCreateField} with a {@code MapperParsingException}.
+ * <p>
+ * The actual row ID value is written directly into the Arrow vector by the
+ * VSR layer, not through Lucene's doc values mechanism. The field type
+ * declares {@code hasDocValues=true} as a metadata hint for the data format
+ * engine to indicate the field is retrievable.
+ *
+ * @opensearch.experimental
+ */
+public class RowIdFieldMapper extends MetadataFieldMapper {
+
+    /** Field name: {@value}. */
+    public static final String NAME = DocumentInput.ROW_ID_FIELD;
+
+    /** Content type identifier used for mapper registration. */
+    public static final String CONTENT_TYPE = DocumentInput.ROW_ID_FIELD;
+
+    /** Fixed type parser — the row ID mapper has no configurable parameters. */
+    public static final TypeParser PARSER = new FixedTypeParser(c -> new RowIdFieldMapper());
+
+    private static final RowIdFieldType ROW_ID_FIELD_TYPE_INSTANCE = new RowIdFieldType();
+
+    /**
+     * Private constructor — instances are created exclusively via {@link #PARSER}.
+     */
+    private RowIdFieldMapper() {
+        super(ROW_ID_FIELD_TYPE_INSTANCE);
+    }
+
+    @Override
+    protected String contentType() {
+        return CONTENT_TYPE;
+    }
+
+    /**
+     * Field type for the {@code __row_id__} metadata field.
+     * <p>
+     * Not indexed, not stored, has doc values. Not searchable or queryable —
+     * {@link #termQuery} and {@link #valueFetcher} throw
+     * {@link UnsupportedOperationException}.
+     */
+    public static class RowIdFieldType extends MappedFieldType {
+
+        /**
+         * Creates the row ID field type: not indexed, not stored, has doc values.
+         */
+        public RowIdFieldType() {
+            super(NAME, false, false, false, TextSearchInfo.NONE, Collections.emptyMap());
+        }
+
+        @Override
+        public ValueFetcher valueFetcher(QueryShardContext context, SearchLookup searchLookup, String format) {
+            throw new UnsupportedOperationException("valueFetcher operation is unsupported on: " + NAME);
+        }
+
+        @Override
+        public String typeName() {
+            return CONTENT_TYPE;
+        }
+
+        @Override
+        public Query termQuery(Object value, QueryShardContext context) {
+            throw new UnsupportedOperationException("termQuery operation is unsupported on: " + NAME);
+        }
+    }
+}

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/vsr/VSRManager.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/vsr/VSRManager.java
@@ -18,6 +18,7 @@ import org.opensearch.index.IndexSettings;
 import org.opensearch.index.engine.dataformat.DocumentInput;
 import org.opensearch.index.engine.dataformat.RowIdMapping;
 import org.opensearch.index.mapper.MappedFieldType;
+import org.opensearch.index.mapper.MapperParsingException;
 import org.opensearch.nativebridge.spi.ArrowExport;
 import org.opensearch.parquet.ParquetDataFormatPlugin;
 import org.opensearch.parquet.bridge.NativeParquetWriter;
@@ -33,6 +34,9 @@ import org.opensearch.parquet.writer.ParquetDocumentInput;
 import org.opensearch.threadpool.ThreadPool;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Set;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -183,8 +187,15 @@ public class VSRManager implements AutoCloseable {
      * Adds a document to the active VSR, rotating if necessary.
      * Transfers collected fields from the document input into the active VSR
      * using the ArrowFieldRegistry to resolve typed vector writes.
+     * <p>
+     * Enforces single-value semantics: if the same {@link MappedFieldType} instance
+     * appears more than once in the document's field list, a {@link MapperParsingException}
+     * is thrown. Identity equality (reference {@code ==}) is used because the mapper
+     * service reuses field type instances — the same instance appearing twice indicates
+     * a multi-value field, which columnar formats do not support.
      *
      * @param doc the document input containing field-value pairs
+     * @throws MapperParsingException if a field appears more than once in the document
      */
     public void addDocument(ParquetDocumentInput doc) throws IOException {
         if (pendingWrite != null && pendingWrite.isDone()) {
@@ -204,8 +215,14 @@ public class VSRManager implements AutoCloseable {
             );
         }
         ManagedVSR activeVSR = managedVSR.get();
+        Set<MappedFieldType> dedup = Collections.newSetFromMap(new IdentityHashMap<>());
         for (FieldValuePair pair : doc.getFinalInput()) {
             MappedFieldType fieldType = pair.getFieldType();
+            if (dedup.add(fieldType) == false) {
+                throw new MapperParsingException(
+                    "Cannot accept multiple values for field: [" + fieldType.name() + "] of type: [" + fieldType.typeName() + "]."
+                );
+            }
             ParquetField parquetField = ArrowFieldRegistry.getParquetField(fieldType.typeName());
             if (parquetField == null) {
                 // Defense-in-depth: schema reconciliation is supposed to happen in

--- a/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/vsr/VSRManagerTests.java
+++ b/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/vsr/VSRManagerTests.java
@@ -22,6 +22,7 @@ import org.opensearch.index.IndexSettings;
 import org.opensearch.index.engine.dataformat.DataFormat;
 import org.opensearch.index.engine.dataformat.DocumentInput;
 import org.opensearch.index.mapper.KeywordFieldMapper;
+import org.opensearch.index.mapper.MapperParsingException;
 import org.opensearch.index.mapper.NumberFieldMapper;
 import org.opensearch.parquet.ParquetBaseTests;
 import org.opensearch.parquet.ParquetDataFormatPlugin;
@@ -582,6 +583,55 @@ public class VSRManagerTests extends ParquetBaseTests {
         ParquetFileMetadata metadata = manager.flush();
         assertNotNull(metadata);
         assertEquals(totalDocs, metadata.numRows());
+    }
+
+    public void testRejectsDuplicateFieldInSingleDocument() throws Exception {
+        List<Field> fields = new ArrayList<>();
+        fields.addAll(metadataFields());
+        fields.add(new Field("val", FieldType.nullable(new ArrowType.Int(32, true)), null));
+        schema = new Schema(fields);
+
+        String filePath = createTempDir().resolve("dedup.parquet").toString();
+        VSRManager manager = new VSRManager(filePath, indexSettings, schema, bufferPool, 50000, threadPool, 0L);
+
+        NumberFieldMapper.NumberFieldType valField = new NumberFieldMapper.NumberFieldType("val", NumberFieldMapper.NumberType.INTEGER);
+        assignTestCapabilities(valField, PARQUET_FORMAT);
+
+        ParquetDocumentInput doc = new ParquetDocumentInput();
+        populateMetadataFields(doc);
+        doc.addField(valField, 10);
+        doc.addField(valField, 20); // same field instance — multi-value
+
+        doc.setRowId(DocumentInput.ROW_ID_FIELD, 0);
+        MapperParsingException e = expectThrows(MapperParsingException.class, () -> manager.addDocument(doc));
+        assertTrue(e.getMessage().contains("Cannot accept multiple values for field: [val]"));
+        manager.close();
+    }
+
+    public void testAllowsDistinctFieldsInSingleDocument() throws Exception {
+        List<Field> fields = new ArrayList<>();
+        fields.addAll(metadataFields());
+        fields.add(new Field("price", FieldType.nullable(new ArrowType.Int(32, true)), null));
+        fields.add(new Field("qty", FieldType.nullable(new ArrowType.Int(32, true)), null));
+        schema = new Schema(fields);
+
+        String filePath = createTempDir().resolve("distinct.parquet").toString();
+        VSRManager manager = new VSRManager(filePath, indexSettings, schema, bufferPool, 50000, threadPool, 0L);
+
+        NumberFieldMapper.NumberFieldType priceField = new NumberFieldMapper.NumberFieldType("price", NumberFieldMapper.NumberType.INTEGER);
+        NumberFieldMapper.NumberFieldType qtyField = new NumberFieldMapper.NumberFieldType("qty", NumberFieldMapper.NumberType.INTEGER);
+        assignTestCapabilities(priceField, PARQUET_FORMAT);
+        assignTestCapabilities(qtyField, PARQUET_FORMAT);
+
+        ParquetDocumentInput doc = new ParquetDocumentInput();
+        populateMetadataFields(doc);
+        doc.addField(priceField, 10);
+        doc.addField(qtyField, 5);
+        doc.setRowId(DocumentInput.ROW_ID_FIELD, 0);
+
+        manager.addDocument(doc);
+        assertEquals(1, manager.getActiveManagedVSR().getRowCount());
+        manager.flush();
     }
 
 }

--- a/server/src/main/java/org/opensearch/index/engine/DataFormatAwareEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/DataFormatAwareEngine.java
@@ -433,14 +433,20 @@ public class DataFormatAwareEngine implements Indexer {
                     return gen;
                 }
             );
-            this.mergeScheduler = new MergeScheduler(
-                mergeHandler,
-                this::applyMergeChanges,
-                catalogSnapshotManager::incrementUnreferencedFileCleanUps,
-                shardId,
-                engineConfig.getIndexSettings(),
-                engineConfig.getThreadPool()
-            );
+            // Merge failure cleanup: cleans up unreferenced files and acts as a safety net
+            // for refreshLock. The preMergeCommitHook acquires refreshLock on the merge thread;
+            // if the merge fails before applyMergeChanges can release it, this callback ensures
+            // the lock is not permanently held.
+            this.mergeScheduler = new MergeScheduler(mergeHandler, this::applyMergeChanges, () -> {
+                try {
+                    catalogSnapshotManager.incrementUnreferencedFileCleanUps();
+                } finally {
+                    if (refreshLock.isHeldByCurrentThread()) {
+                        logger.debug("releasing refreshLock held after merge failure (safety-net unlock)");
+                        refreshLock.unlock();
+                    }
+                }
+            }, shardId, engineConfig.getIndexSettings(), engineConfig.getThreadPool());
 
             success = true;
             logger.trace("created new DataFormatBasedEngine");
@@ -1192,6 +1198,20 @@ public class DataFormatAwareEngine implements Indexer {
         refresh("write indexing buffer");
     }
 
+    /**
+     * Forces a merge to reduce the number of segments to at most {@code maxNumSegments}.
+     * <p>
+     * This method is a no-op for {@code upgrade}, {@code upgradeOnlyAncientSegments}, and
+     * {@code onlyExpungeDeletes} operations since those are Lucene-specific concepts not
+     * applicable to the data format engine.
+     * <p>
+     * When {@code flush} is true, a full flush is performed first to ensure all in-flight
+     * indexing data (pending VSR writes, buffered segments) is committed before merge
+     * candidate selection runs. This guarantees force merge operates on the complete
+     * set of segments.
+     * <p>
+     * Runs synchronously on the calling {@code FORCE_MERGE} thread.
+     */
     @Override
     public void forceMerge(
         boolean flush,
@@ -1201,7 +1221,13 @@ public class DataFormatAwareEngine implements Indexer {
         boolean upgradeOnlyAncientSegments,
         String forceMergeUUID
     ) throws EngineException, IOException {
-        mergeScheduler.forceMerge(1);
+        if (upgrade || upgradeOnlyAncientSegments || onlyExpungeDeletes) {
+            return;
+        }
+        mergeScheduler.forceMerge(maxNumSegments);
+        if (flush) {
+            flush(true, true);
+        }
     }
 
     /** {@inheritDoc} Returns the heap RAM bytes used by the indexing execution engine. */

--- a/server/src/main/java/org/opensearch/index/engine/dataformat/merge/MergeScheduler.java
+++ b/server/src/main/java/org/opensearch/index/engine/dataformat/merge/MergeScheduler.java
@@ -23,6 +23,7 @@ import org.opensearch.threadpool.ThreadPool;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
@@ -47,6 +48,7 @@ public class MergeScheduler {
     private final ThreadPool threadPool;
     private final AtomicInteger activeMerges = new AtomicInteger(0);
     private final AtomicBoolean isShutdown = new AtomicBoolean(false);
+    private final Semaphore forceMergeLock = new Semaphore(1);
     private volatile int maxConcurrentMerges;
     private volatile int maxMergeCount;
     private final MergeSchedulerConfig mergeSchedulerConfig;
@@ -132,37 +134,24 @@ public class MergeScheduler {
 
     /**
      * Forces a merge down to at most {@code maxNumSegment} segments.
-     * Runs synchronously on the calling thread.
+     * Runs synchronously on the calling thread, which must be a
+     * {@link ThreadPool.Names#FORCE_MERGE} thread. Only one force merge
+     * may execute per shard at a time — concurrent callers block until
+     * the ongoing force merge completes.
      *
      * @param maxNumSegment the maximum number of segments after the force merge
      */
     public void forceMerge(int maxNumSegment) throws IOException {
-        if (activeMerges.get() > 0) {
-            logger.warn("Cannot force merge while background merges are active");
-            throw new IllegalStateException("Cannot force merge while background merges are active");
-        }
-        Collection<OneMerge> oneMerges = mergeHandler.findForceMerges(maxNumSegment);
-
-        for (OneMerge oneMerge : oneMerges) {
-            threadPool.executor(ThreadPool.Names.FORCE_MERGE).execute(() -> {
-                long totalSizeInBytes = oneMerge.getTotalSizeInBytes();
-                long totalNumDocs = oneMerge.getTotalNumDocs();
-                long timeNS = System.nanoTime();
-                long tookMS = 0;
-                try {
-                    mergeStatsTracker.beforeMerge(totalNumDocs, totalSizeInBytes);
-                    MergeResult mergeResult = mergeHandler.doMerge(oneMerge);
-                    applyMergeChanges.accept(mergeResult, oneMerge);
-                    mergeHandler.onMergeFinished(oneMerge);
-                    tookMS = TimeValue.nsecToMSec((System.nanoTime() - timeNS));
-                } catch (Exception e) {
-                    logger.error(new ParameterizedMessage("Force merge failed for: {}", oneMerge), e);
-                    mergeHandler.onMergeFailure(oneMerge);
-                    onMergeFailureCleanup.run();
-                } finally {
-                    mergeStatsTracker.afterMerge(tookMS, totalNumDocs, totalSizeInBytes);
-                }
-            });
+        assert Thread.currentThread().getName().contains(ThreadPool.Names.FORCE_MERGE)
+            : "forceMerge must be called on FORCE_MERGE thread but was: " + Thread.currentThread().getName();
+        forceMergeLock.acquireUninterruptibly();
+        try {
+            Collection<OneMerge> oneMerges = mergeHandler.findForceMerges(maxNumSegment);
+            for (OneMerge oneMerge : oneMerges) {
+                runMerge(oneMerge);
+            }
+        } finally {
+            forceMergeLock.release();
         }
     }
 
@@ -224,43 +213,61 @@ public class MergeScheduler {
     }
 
     /**
-     * Submits a merge task to the thread pool's force merge executor.
+     * Submits a merge task to the thread pool's merge executor.
      *
      * @param oneMerge the merge to execute
      */
     private void submitMergeTask(OneMerge oneMerge) {
         activeMerges.incrementAndGet();
         threadPool.executor(ThreadPool.Names.MERGE).execute(() -> {
-            long totalSizeInBytes = oneMerge.getTotalSizeInBytes();
-            long totalNumDocs = oneMerge.getTotalNumDocs();
-            long timeNS = System.nanoTime();
-            long tookMS = 0;
             try {
                 if (isShutdown.get()) {
                     logger.debug("MergeScheduler is shutdown, skipping merge");
                     return;
                 }
-
-                mergeStatsTracker.beforeMerge(totalNumDocs, totalSizeInBytes);
-
-                MergeResult mergeResult = mergeHandler.doMerge(oneMerge);
-                applyMergeChanges.accept(mergeResult, oneMerge);
-                mergeHandler.onMergeFinished(oneMerge);
-
-                tookMS = TimeValue.nsecToMSec((System.nanoTime() - timeNS));
-                logger.info("Merge {} completed in {}ms, result: {}", oneMerge, tookMS, mergeResult.getMergedWriterFileSet());
-
+                runMerge(oneMerge);
             } catch (Exception e) {
-                logger.error(new ParameterizedMessage("Unexpected error during merge for: {}", oneMerge), e);
-                mergeHandler.onMergeFailure(oneMerge);
-                onMergeFailureCleanup.run();
+                // runMerge already invoked onMergeFailureCleanup; swallow to prevent
+                // uncaught exception on the merge thread pool.
             } finally {
-                mergeStatsTracker.afterMerge(tookMS, totalNumDocs, totalSizeInBytes);
-
                 activeMerges.decrementAndGet();
                 // A completed merge may free up capacity for new merges, so check again.
                 executeMerge();
             }
         });
+    }
+
+    /**
+     * Executes a single merge and applies or cleans up the result.
+     * <p>
+     * This is the single point that owns the merge lifecycle:
+     * <ol>
+     *   <li>{@code doMerge} — may acquire {@code refreshLock} via the pre-merge-commit hook</li>
+     *   <li>On success: {@code applyMergeChanges} — releases {@code refreshLock}</li>
+     *   <li>On failure: {@code onMergeFailureCleanup} — releases {@code refreshLock} if still held</li>
+     * </ol>
+     * By funnelling both background and force merges through this method, the lock
+     * release guarantee is maintained in exactly one code path.
+     */
+    private void runMerge(OneMerge oneMerge) throws IOException {
+        long totalSizeInBytes = oneMerge.getTotalSizeInBytes();
+        long totalNumDocs = oneMerge.getTotalNumDocs();
+        long timeNS = System.nanoTime();
+        long tookMS = 0;
+        try {
+            mergeStatsTracker.beforeMerge(totalNumDocs, totalSizeInBytes);
+            MergeResult mergeResult = mergeHandler.doMerge(oneMerge);
+            applyMergeChanges.accept(mergeResult, oneMerge);
+            mergeHandler.onMergeFinished(oneMerge);
+            tookMS = TimeValue.nsecToMSec((System.nanoTime() - timeNS));
+            logger.info("Merge {} completed in {}ms, result: {}", oneMerge, tookMS, mergeResult.getMergedWriterFileSet());
+        } catch (Exception e) {
+            logger.error(new ParameterizedMessage("Merge failed for: {}", oneMerge), e);
+            mergeHandler.onMergeFailure(oneMerge);
+            onMergeFailureCleanup.run();
+            throw e instanceof IOException ? (IOException) e : new IOException(e);
+        } finally {
+            mergeStatsTracker.afterMerge(tookMS, totalNumDocs, totalSizeInBytes);
+        }
     }
 }

--- a/server/src/test/java/org/opensearch/index/engine/DataFormatAwareEngineTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/DataFormatAwareEngineTests.java
@@ -2020,9 +2020,17 @@ public class DataFormatAwareEngineTests extends OpenSearchTestCase {
             assertThat("each refresh must invoke beforeRefresh once", beforeAfterSeed, equalTo(2));
             assertThat("each refresh must invoke afterRefresh once", afterAfterSeed, equalTo(2));
 
-            // forceMerge submits the merge to the FORCE_MERGE executor and returns without
-            // waiting. Poll the catalog until the merged snapshot is visible (or fail fast).
-            engine.forceMerge(false, 1, false, false, false, "test-force-merge");
+            // forceMerge runs synchronously on a FORCE_MERGE thread. Dispatch to a
+            // thread with the expected name to satisfy the MergeScheduler assertion.
+            Thread fmThread = new Thread(() -> {
+                try {
+                    engine.forceMerge(false, 1, false, false, false, "test-force-merge");
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }, "force_merge-test");
+            fmThread.start();
+            fmThread.join(30_000);
 
             assertBusy(() -> {
                 try (GatedCloseable<CatalogSnapshot> ref = engine.acquireSnapshot()) {

--- a/server/src/test/java/org/opensearch/index/engine/dataformat/merge/MergeTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/dataformat/merge/MergeTests.java
@@ -11,6 +11,7 @@ package org.opensearch.index.engine.dataformat.merge;
 import org.opensearch.common.SuppressForbidden;
 import org.opensearch.common.concurrent.GatedCloseable;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.index.MergeSchedulerConfig;
@@ -39,6 +40,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 
 import static org.opensearch.index.IndexSettingsTests.newIndexMeta;
@@ -55,10 +57,11 @@ public class MergeTests extends OpenSearchTestCase {
 
     private final List<ExecutorService> executors = new CopyOnWriteArrayList<>();
 
-    private ExecutorService daemonPool() {
+    private ExecutorService daemonPool(String name) {
         ExecutorService pool = Executors.newCachedThreadPool(r -> {
             Thread t = new Thread(r);
             t.setDaemon(true);
+            t.setName(name + "-" + t.threadId());
             return t;
         });
         executors.add(pool);
@@ -67,9 +70,35 @@ public class MergeTests extends OpenSearchTestCase {
 
     private ThreadPool mockThreadPool() {
         ThreadPool tp = mock(ThreadPool.class);
-        when(tp.executor(eq(ThreadPool.Names.MERGE))).thenReturn(daemonPool());
-        when(tp.executor(eq(ThreadPool.Names.FORCE_MERGE))).thenReturn(daemonPool());
+        when(tp.executor(eq(ThreadPool.Names.MERGE))).thenReturn(daemonPool(ThreadPool.Names.MERGE));
+        when(tp.executor(eq(ThreadPool.Names.FORCE_MERGE))).thenReturn(daemonPool(ThreadPool.Names.FORCE_MERGE));
         return tp;
+    }
+
+    /**
+     * Runs the given action on a thread whose name contains
+     * {@link ThreadPool.Names#FORCE_MERGE} to satisfy the forceMerge assertion.
+     */
+    private void onForceMergeThread(ThrowingRunnable action) throws Exception {
+        AtomicReference<Exception> failure = new AtomicReference<>();
+        Thread t = new Thread(() -> {
+            try {
+                action.run();
+            } catch (Exception e) {
+                failure.set(e);
+            }
+        }, ThreadPool.Names.FORCE_MERGE + "-test");
+        t.setDaemon(true);
+        t.start();
+        t.join(30_000);
+        if (failure.get() != null) {
+            throw failure.get();
+        }
+    }
+
+    @FunctionalInterface
+    private interface ThrowingRunnable {
+        void run() throws Exception;
     }
 
     @Override
@@ -343,10 +372,10 @@ public class MergeTests extends OpenSearchTestCase {
         scheduler.refreshConfig();
     }
 
-    public void testSchedulerTriggerAndForceMerge() throws IOException {
+    public void testSchedulerTriggerAndForceMerge() throws Exception {
         MergeScheduler scheduler = createMergeScheduler();
         scheduler.triggerMerges();
-        scheduler.forceMerge(1);
+        onForceMergeThread(() -> scheduler.forceMerge(1));
     }
 
     @SuppressForbidden(reason = "test needs to set private isShutdown field via reflection")
@@ -452,7 +481,7 @@ public class MergeTests extends OpenSearchTestCase {
             latch.countDown();
         }, () -> {}, SHARD_ID, mergeSchedulerSettings(), mockThreadPool());
 
-        scheduler.forceMerge(1);
+        onForceMergeThread(() -> scheduler.forceMerge(1));
         assertTrue(latch.await(5, TimeUnit.SECONDS));
         assertNotNull(captured.get());
     }
@@ -466,5 +495,238 @@ public class MergeTests extends OpenSearchTestCase {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
+    }
+
+    // ---- MergeScheduler: forceMerge serialization and lifecycle tests ----
+
+    public void testForceMergeSerializesOnlyConcurrentCallers() throws Exception {
+        List<Segment> segments = createSegments(3);
+        CountDownLatch mergeStarted = new CountDownLatch(1);
+        CountDownLatch allowMergeToFinish = new CountDownLatch(1);
+        MockDataFormat format = new MockDataFormat();
+        WriterFileSet mergedWfs = new WriterFileSet(createTempDir().toString(), 99L, Set.of("merged.dat"), 3, 0L);
+        MergeResult mergeResult = new MergeResult(Map.of(format, mergedWfs));
+
+        Merger slowMerger = mergeInput -> {
+            mergeStarted.countDown();
+            try {
+                allowMergeToFinish.await(10, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            return mergeResult;
+        };
+        MergeHandler handler = createHandlerWithRealPolicy(snapshotSupplierOf(segments), slowMerger);
+
+        MergeScheduler scheduler = new MergeScheduler(
+            handler,
+            (mr, om) -> {},
+            () -> {},
+            SHARD_ID,
+            mergeSchedulerSettings(),
+            mockThreadPool()
+        );
+
+        AtomicBoolean secondStarted = new AtomicBoolean(false);
+        AtomicBoolean secondFinished = new AtomicBoolean(false);
+
+        Thread t1 = new Thread(() -> {
+            try {
+                scheduler.forceMerge(1);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }, ThreadPool.Names.FORCE_MERGE + "-t1");
+
+        Thread t2 = new Thread(() -> {
+            try {
+                mergeStarted.await(5, TimeUnit.SECONDS);
+                secondStarted.set(true);
+                scheduler.forceMerge(1);
+                secondFinished.set(true);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }, ThreadPool.Names.FORCE_MERGE + "-t2");
+
+        t1.start();
+        t2.start();
+
+        assertTrue(mergeStarted.await(5, TimeUnit.SECONDS));
+        Thread.sleep(200);
+        // Second caller should be blocked (not finished) while first is in progress
+        assertTrue(secondStarted.get());
+        assertFalse(secondFinished.get());
+
+        allowMergeToFinish.countDown();
+        t1.join(5000);
+        t2.join(5000);
+        assertTrue(secondFinished.get());
+    }
+
+    public void testForceMergeBlocksUntilComplete() throws Exception {
+        List<Segment> segments = createSegments(3);
+        MockDataFormat format = new MockDataFormat();
+        WriterFileSet mergedWfs = new WriterFileSet(createTempDir().toString(), 99L, Set.of("merged.dat"), 3, 0L);
+        MergeResult mergeResult = new MergeResult(Map.of(format, mergedWfs));
+
+        Merger slowMerger = mergeInput -> {
+            try {
+                Thread.sleep(200);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            return mergeResult;
+        };
+        MergeHandler handler = createHandlerWithRealPolicy(snapshotSupplierOf(segments), slowMerger);
+
+        MergeScheduler scheduler = new MergeScheduler(
+            handler,
+            (mr, om) -> {},
+            () -> {},
+            SHARD_ID,
+            mergeSchedulerSettings(),
+            mockThreadPool()
+        );
+
+        long start = System.nanoTime();
+        onForceMergeThread(() -> scheduler.forceMerge(1));
+        long elapsed = TimeValue.nsecToMSec(System.nanoTime() - start);
+
+        assertTrue("forceMerge should block until complete, took " + elapsed + "ms", elapsed >= 150);
+    }
+
+    public void testForceMergePropagatesFailure() throws Exception {
+        List<Segment> segments = createSegments(3);
+
+        Merger failingMerger = mergeInput -> { throw new IOException("simulated merge failure"); };
+        MergeHandler handler = createHandlerWithRealPolicy(snapshotSupplierOf(segments), failingMerger);
+
+        MergeScheduler scheduler = new MergeScheduler(
+            handler,
+            (mr, om) -> {},
+            () -> {},
+            SHARD_ID,
+            mergeSchedulerSettings(),
+            mockThreadPool()
+        );
+
+        AtomicReference<Exception> caught = new AtomicReference<>();
+        onForceMergeThread(() -> {
+            try {
+                scheduler.forceMerge(1);
+            } catch (IOException e) {
+                caught.set(e);
+            }
+        });
+        assertNotNull("Expected IOException from forceMerge", caught.get());
+        assertTrue(caught.get().getMessage().contains("simulated merge failure"));
+    }
+
+    public void testRunMergeInvokesCleanupOnFailure() throws Exception {
+        List<Segment> segments = createSegments(3);
+        AtomicBoolean cleanupCalled = new AtomicBoolean(false);
+
+        Merger failingMerger = mergeInput -> { throw new IOException("merge failure"); };
+        MergeHandler handler = createHandlerWithRealPolicy(snapshotSupplierOf(segments), failingMerger);
+
+        MergeScheduler scheduler = new MergeScheduler(
+            handler,
+            (mr, om) -> {},
+            () -> cleanupCalled.set(true),
+            SHARD_ID,
+            mergeSchedulerSettings(),
+            mockThreadPool()
+        );
+
+        // Use forceMerge which catches exceptions from runMerge properly
+        onForceMergeThread(() -> {
+            try {
+                scheduler.forceMerge(1);
+            } catch (IOException expected) {
+                // expected
+            }
+        });
+        assertTrue("onMergeFailureCleanup should be called", cleanupCalled.get());
+    }
+
+    public void testRunMergeInvokesApplyOnSuccess() throws Exception {
+        List<Segment> segments = createSegments(3);
+        MockDataFormat format = new MockDataFormat();
+        WriterFileSet mergedWfs = new WriterFileSet(createTempDir().toString(), 99L, Set.of("merged.dat"), 3, 0L);
+        MergeResult mergeResult = new MergeResult(Map.of(format, mergedWfs));
+        AtomicReference<MergeResult> capturedResult = new AtomicReference<>();
+
+        Merger merger = mergeInput -> mergeResult;
+        MergeHandler handler = createHandlerWithRealPolicy(snapshotSupplierOf(segments), merger);
+
+        BiConsumer<MergeResult, OneMerge> applyCallback = (mr, om) -> capturedResult.set(mr);
+
+        MergeScheduler scheduler = new MergeScheduler(
+            handler,
+            applyCallback,
+            () -> {},
+            SHARD_ID,
+            mergeSchedulerSettings(),
+            mockThreadPool()
+        );
+
+        onForceMergeThread(() -> scheduler.forceMerge(1));
+        assertSame(mergeResult, capturedResult.get());
+    }
+
+    public void testForceMergeWithNoSegmentsIsNoop() throws Exception {
+        MergeScheduler scheduler = new MergeScheduler(createNoopHandler(emptySnapshotSupplier()), (mr, om) -> {
+            fail("applyMergeChanges should not be called");
+        }, () -> { fail("onMergeFailureCleanup should not be called"); }, SHARD_ID, mergeSchedulerSettings(), mockThreadPool());
+
+        onForceMergeThread(() -> scheduler.forceMerge(1));
+    }
+
+    public void testConcurrentForceMergeAndBackgroundMerge() throws Exception {
+        List<Segment> segments = createSegments(15);
+        MockDataFormat format = new MockDataFormat();
+        WriterFileSet mergedWfs = new WriterFileSet(createTempDir().toString(), 99L, Set.of("merged.dat"), 15, 0L);
+        MergeResult mergeResult = new MergeResult(Map.of(format, mergedWfs));
+
+        Merger merger = mergeInput -> mergeResult;
+        MergeHandler handler = createHandlerWithRealPolicy(snapshotSupplierOf(segments), merger);
+
+        MergeScheduler scheduler = new MergeScheduler(
+            handler,
+            (mr, om) -> {},
+            () -> {},
+            SHARD_ID,
+            mergeSchedulerSettings(),
+            mockThreadPool()
+        );
+
+        AtomicReference<Exception> forceMergeError = new AtomicReference<>();
+        AtomicReference<Exception> triggerError = new AtomicReference<>();
+
+        Thread forceMergeThread = new Thread(() -> {
+            try {
+                scheduler.forceMerge(1);
+            } catch (Exception e) {
+                forceMergeError.set(e);
+            }
+        }, ThreadPool.Names.FORCE_MERGE + "-test");
+
+        Thread triggerThread = new Thread(() -> {
+            try {
+                scheduler.triggerMerges();
+            } catch (Exception e) {
+                triggerError.set(e);
+            }
+        });
+
+        forceMergeThread.start();
+        triggerThread.start();
+
+        forceMergeThread.join(10000);
+        triggerThread.join(10000);
+
+        assertNull("forceMerge should complete without error", forceMergeError.get());
+        assertNull("triggerMerges should complete without error", triggerError.get());
     }
 }


### PR DESCRIPTION

  Summary

  This PR hardens several correctness and concurrency issues in the DataFormat-aware engine's merge and indexing paths:

  Bug Fixes:

  - VSRManager multi-value dedup — The dedup Set was created but never populated (add() was missing), making the duplicate-field
  rejection dead code. Documents with repeated fields would silently overwrite Arrow vector values.
  - Force merge fire-and-forget — forceMerge dispatched tasks to the thread pool but never waited for completion, so the transport
  layer returned success before merges finished. Now runs synchronously on the caller's FORCE_MERGE thread.

  Improvements:

  - Force merge serialization — Semaphore(1) ensures only one force merge runs per shard at a time; concurrent callers block
  rather than throwing IllegalStateException.
  - Flush after force merge — Calls flush(true, true) when the flush parameter is set (default), ensuring all changes are visible. This is in line with existing guarantees. 
  - Reduced refreshLock fragility — Extracted runMerge() as a single method encapsulating the doMerge→apply/cleanup lifecycle.
  Both background and force merges funnel through it, keeping the lock release contract in one place.
  - RowIdFieldMapper — Registered as a MetadataFieldMapper so user-provided __row_id__ values in documents are rejected at parse
  time via inherited parseCreateField().
  - Debug logging — Safety-net refreshLock unlock now logs at DEBUG level for diagnosing merge-failure paths in production.

  Testing

  - Existing MergeTests and VSRManagerTests cover basic flows
  - Integration validated via composite engine suite (CompositeMergeIT)


### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
