### PR TITLE
[Arrow] Use ALL-UNNAMED for java.nio add-opens

### DIFF
--- a/distribution/src/config/jvm.options
+++ b/distribution/src/config/jvm.options
@@ -85,7 +85,7 @@ ${error.file}
 23:-XX:CompileCommand=dontinline,java/lang/invoke/MethodHandle.asTypeUncached
 
 21-:-javaagent:agent/opensearch-agent.jar
-21-:--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED
+21-:--add-opens=java.base/java.nio=ALL-UNNAMED
 
 # For cases with high memory-mapped file counts, a lower value can improve stability and
 # prevent issues like "leaked" maps or performance degradation. A value of 1 effectively

--- a/plugins/arrow-flight-rpc/README.md
+++ b/plugins/arrow-flight-rpc/README.md
@@ -33,7 +33,7 @@ opensearch.experimental.feature.transport.stream.enabled: true
 -Dio.netty.noUnsafe=false
 -Dio.netty.tryUnsafe=true
 -Dio.netty.tryReflectionSetAccessible=true
---add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED
+--add-opens=java.base/java.nio=ALL-UNNAMED
 ```
 
 3. Install and run the plugin manually

--- a/plugins/arrow-flight-rpc/build.gradle
+++ b/plugins/arrow-flight-rpc/build.gradle
@@ -84,7 +84,7 @@ test {
   systemProperty 'io.netty.noUnsafe', 'false'
   systemProperty 'io.netty.tryUnsafe', 'true'
   systemProperty 'io.netty.tryReflectionSetAccessible', 'true'
-  jvmArgs += ["--add-opens", "java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED"]
+  jvmArgs += ["--add-opens", "java.base/java.nio=ALL-UNNAMED"]
 }
 
 internalClusterTest {
@@ -92,7 +92,7 @@ internalClusterTest {
   systemProperty 'io.netty.noUnsafe', 'false'
   systemProperty 'io.netty.tryUnsafe', 'true'
   systemProperty 'io.netty.tryReflectionSetAccessible', 'true'
-  jvmArgs += ["--add-opens", "java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED"]
+  jvmArgs += ["--add-opens", "java.base/java.nio=ALL-UNNAMED"]
 }
 
 spotless {

--- a/plugins/arrow-flight-rpc/src/internalClusterTest/java/org/opensearch/arrow/flight/NativeAllocatorBoundaryIT.java
+++ b/plugins/arrow-flight-rpc/src/internalClusterTest/java/org/opensearch/arrow/flight/NativeAllocatorBoundaryIT.java
@@ -78,6 +78,46 @@ public class NativeAllocatorBoundaryIT extends OpenSearchIntegTestCase {
     }
 
     /**
+     * Verifies that the Arrow classes used by the plugin are running from the unnamed module.
+     */
+    public void testArrowRuntimeClassesAreUnnamedModules() {
+        ArrowNativeAllocator allocator = internalCluster().getInstance(ArrowNativeAllocator.class);
+        BufferAllocator queryPool = allocator.getPoolAllocator(NativeAllocatorPoolConfig.POOL_QUERY);
+
+        Module arrowApiModule = BufferAllocator.class.getModule();
+        Module runtimeAllocatorModule = queryPool.getClass().getModule();
+        Module pluginAllocatorModule = allocator.getClass().getModule();
+
+        assertNotNull("Arrow API module should not be null", arrowApiModule);
+        assertNotNull("Arrow runtime allocator module should not be null", runtimeAllocatorModule);
+        assertNotNull("arrow-base plugin allocator module should not be null", pluginAllocatorModule);
+
+        logger.info(
+            "Arrow module probe: BufferAllocator module[name={}, named={}, loader={}], "
+                + "runtime allocator class={} module[name={}, named={}, loader={}], "
+                + "plugin allocator module[name={}, named={}, loader={}]",
+            arrowApiModule.getName(),
+            arrowApiModule.isNamed(),
+            BufferAllocator.class.getClassLoader(),
+            queryPool.getClass().getName(),
+            runtimeAllocatorModule.getName(),
+            runtimeAllocatorModule.isNamed(),
+            queryPool.getClass().getClassLoader(),
+            pluginAllocatorModule.getName(),
+            pluginAllocatorModule.isNamed(),
+            allocator.getClass().getClassLoader()
+        );
+
+        assertFalse("Arrow API should be loaded as an unnamed module", arrowApiModule.isNamed());
+        assertFalse("Arrow runtime allocator should be loaded as an unnamed module", runtimeAllocatorModule.isNamed());
+        assertFalse("arrow-base plugin allocator should be loaded as an unnamed module", pluginAllocatorModule.isNamed());
+
+        try (var buffer = queryPool.buffer(1024)) {
+            assertThat(buffer.capacity(), is(1024L));
+        }
+    }
+
+    /**
      * Verifies that per-pool limits cap allocations: when one pool is full,
      * allocations through it fail even if other pools have headroom.
      */

--- a/plugins/examples/stream-transport-example/build.gradle
+++ b/plugins/examples/stream-transport-example/build.gradle
@@ -19,7 +19,7 @@ internalClusterTest {
   systemProperty 'io.netty.noUnsafe', 'false'
   systemProperty 'io.netty.tryUnsafe', 'true'
   systemProperty 'io.netty.tryReflectionSetAccessible', 'true'
-  jvmArgs += ["--add-opens", "java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED"]
+  jvmArgs += ["--add-opens", "java.base/java.nio=ALL-UNNAMED"]
 }
 
 tasks.named('missingJavadoc').configure { enabled = false }

--- a/sandbox/plugins/analytics-backend-datafusion/build.gradle
+++ b/sandbox/plugins/analytics-backend-datafusion/build.gradle
@@ -105,7 +105,7 @@ dependencies {
 }
 
 test {
-  jvmArgs += ["--add-opens", "java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED"]
+  jvmArgs += ["--add-opens", "java.base/java.nio=ALL-UNNAMED"]
   jvmArgs += ["--enable-native-access=ALL-UNNAMED"]
   systemProperty 'native.lib.path', project(':sandbox:libs:dataformat-native').ext.nativeLibPath.absolutePath
   systemProperty 'test.policy.contents', file('src/main/plugin-metadata/plugin-security.policy').text

--- a/sandbox/plugins/analytics-engine/build.gradle
+++ b/sandbox/plugins/analytics-engine/build.gradle
@@ -217,7 +217,6 @@ test {
   systemProperty 'io.netty.noUnsafe', 'false'
   systemProperty 'io.netty.tryUnsafe', 'true'
   systemProperty 'io.netty.tryReflectionSetAccessible', 'true'
-  jvmArgs += ["--add-opens", "java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED"]
 }
 
 // Arrow/Flight requires these JVM flags
@@ -230,5 +229,4 @@ internalClusterTest {
   systemProperty 'io.netty.noUnsafe', 'false'
   systemProperty 'io.netty.tryUnsafe', 'true'
   systemProperty 'io.netty.tryReflectionSetAccessible', 'true'
-  jvmArgs += ["--add-opens", "java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED"]
 }

--- a/sandbox/plugins/composite-engine/build.gradle
+++ b/sandbox/plugins/composite-engine/build.gradle
@@ -28,7 +28,7 @@ tasks.named('compileInternalClusterTestJava').configure {
 
 tasks.named('internalClusterTest').configure {
   jvmArgs += [
-    '--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED',
+    '--add-opens=java.base/java.nio=ALL-UNNAMED',
     '--enable-native-access=ALL-UNNAMED'
   ]
 }

--- a/sandbox/plugins/parquet-data-format/benchmarks/build.gradle
+++ b/sandbox/plugins/parquet-data-format/benchmarks/build.gradle
@@ -81,7 +81,7 @@ spotless {
 }
 
 run.jvmArgs += [
-  '--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED'
+  '--add-opens=java.base/java.nio=ALL-UNNAMED'
 ]
 
 run.environment += [

--- a/sandbox/plugins/parquet-data-format/build.gradle
+++ b/sandbox/plugins/parquet-data-format/build.gradle
@@ -118,8 +118,6 @@ test {
   jvmArgs '--add-opens=java.base/java.nio=ALL-UNNAMED'
   jvmArgs '--add-opens=java.base/sun.nio.ch=ALL-UNNAMED'
   jvmArgs '--enable-native-access=ALL-UNNAMED'
-  // Required by arrow-memory-netty for Unsafe / direct-memory access
-  jvmArgs += ["--add-opens", "java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED"]
   systemProperty 'io.netty.allocator.numDirectArenas', '1'
   systemProperty 'io.netty.noUnsafe', 'false'
   systemProperty 'io.netty.tryUnsafe', 'true'

--- a/sandbox/qa/analytics-engine-coordinator/build.gradle
+++ b/sandbox/qa/analytics-engine-coordinator/build.gradle
@@ -156,5 +156,4 @@ internalClusterTest {
   systemProperty 'io.netty.tryReflectionSetAccessible', 'true'
   systemProperty 'native.lib.path', project(':sandbox:libs:dataformat-native').ext.nativeLibPath.absolutePath
   dependsOn ':sandbox:libs:dataformat-native:buildRustLibrary'
-  jvmArgs += ["--add-opens", "java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED"]
 }


### PR DESCRIPTION
### Description

The default distribution currently includes this JVM option:

```text
21-:--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED
```

When the `org.apache.arrow.memory.core` named module is not present at JVM startup, the JVM emits:

```text
WARNING: Unknown module: org.apache.arrow.memory.core specified to --add-opens
```

This happens even on nodes that do not install Arrow plugins, because the option is part of the global distribution `jvm.options`.

This PR keeps the required `java.nio` access for classpath/plugin code by targeting `ALL-UNNAMED` only:

```text
21-:--add-opens=java.base/java.nio=ALL-UNNAMED
```

The important compatibility point is that the Arrow classes used by the OpenSearch plugins are loaded from the unnamed module space in the current plugin/test runtime. To make that explicit, this PR adds an internal cluster test that checks the Arrow API class, runtime allocator class, and plugin allocator class are all unnamed modules, then performs a real Arrow buffer allocation.

### What changed

- Update the global distribution `jvm.options` entry to use `ALL-UNNAMED` only.
- Align the same Arrow `java.nio` add-opens option in Arrow Flight, example, sandbox, and analytics QA Gradle configurations.
- Remove duplicate named-module `add-opens` entries where an `ALL-UNNAMED` entry already existed.
- Update the Arrow Flight README manual startup guidance.
- Add coverage in `NativeAllocatorBoundaryIT` to prove the relevant Arrow/runtime/plugin classes are unnamed modules and that Arrow allocation still works.

### Context

This is related to #22132 and is a more complete variant of the direction proposed in #22145. The extra changes are intended to address the review concern that Arrow Flight still needs the JVM option and should continue to function after removing the named module target.

### Test plan

- [x] Minimal JVM reproduction:

```bash
java --add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED -version
# emits: WARNING: Unknown module: org.apache.arrow.memory.core specified to --add-opens

java --add-opens=java.base/java.nio=ALL-UNNAMED -version
# no Unknown module warning
```

- [x] Arrow unit tests:

```bash
./gradlew :plugins:arrow-base:test :plugins:arrow-flight-rpc:test --no-build-cache -Dbuild.snapshot=false
```

- [x] Arrow Flight internal cluster tests:

```bash
./gradlew :plugins:arrow-flight-rpc:internalClusterTest --no-build-cache -Dbuild.snapshot=false
```

This covers the current `FlightClient.getStream(...)` to `ArrowFlightProducer.getStream(...)` path, native allocator behavior, metadata streaming, batch streaming, and stream search/aggregation coverage.

- [x] Sandbox Arrow/DataFusion/Parquet consumers:

```bash
./gradlew \
  :sandbox:plugins:analytics-backend-datafusion:test \
  :sandbox:plugins:parquet-data-format:test \
  :sandbox:plugins:analytics-engine:test \
  --no-build-cache -Dbuild.snapshot=false -Dsandbox.enabled=true
```

- [x] Analytics coordinator QA:

```bash
./gradlew :sandbox:qa:analytics-engine-coordinator:internalClusterTest \
  --no-build-cache -Dbuild.snapshot=false -Dsandbox.enabled=true
```

- [x] Stream transport example default run:

```bash
./gradlew :example-plugins:stream-transport-example:internalClusterTest \
  --no-build-cache -Dbuild.snapshot=false
```

The default run succeeds; the example tests are annotated with `@AwaitsFix` and are skipped by default. With `-Dtests.awaitsfix=true`, the native Arrow example tests pass, while the non-native example still fails because it starts `FlightStreamPlugin` without `ArrowBasePlugin`. That failure is pre-existing and unrelated to this JVM option change.

- [x] Arrow plugin smoke test using packaged distribution config:

```bash
./gradlew :qa:smoke-test-arrow-plugins:integTest --no-build-cache -Dbuild.snapshot=false
```

The test cluster started with the packaged option:

```text
--add-opens=java.base/java.nio=ALL-UNNAMED
```

and logs/test reports did not contain:

```text
Unknown module: org.apache.arrow.memory.core specified to --add-opens
```

- [x] Targeted precommit/format checks:

```bash
./gradlew \
  :plugins:arrow-flight-rpc:spotlessJavaCheck \
  :plugins:arrow-flight-rpc:precommit \
  :example-plugins:stream-transport-example:precommit \
  :qa:smoke-test-arrow-plugins:precommit \
  --no-build-cache -Dbuild.snapshot=false

./gradlew \
  :sandbox:plugins:analytics-backend-datafusion:precommit \
  :sandbox:plugins:analytics-engine:precommit \
  :sandbox:plugins:composite-engine:precommit \
  :sandbox:plugins:parquet-data-format:precommit \
  :sandbox:qa:analytics-engine-coordinator:precommit \
  --no-build-cache -Dbuild.snapshot=false -Dsandbox.enabled=true
```

### Related Issues

Related to #22132
Related to #22145

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request: not applicable.
- [x] Public documentation issue/PR: not applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.