### PR TITLE
[analytics-datafusion] Async coordinator-reduce

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/api.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/api.rs
@@ -66,6 +66,7 @@ use crate::custom_cache_manager::CustomCacheManager;
 use crate::local_executor::LocalSession;
 use crate::memory::{DynamicLimitHandle, DynamicLimitPool};
 use crate::partition_stream::PartitionStreamSender;
+use tokio::sync::mpsc::error::TrySendError;
 use crate::query_tracker::{self, QueryTrackingContext};
 use crate::runtime_manager::RuntimeManager;
 use crate::shard_table_provider::{ShardTableConfig, ShardTableProvider};
@@ -1866,7 +1867,92 @@ pub unsafe fn execute_local_prepared_plan(
     Ok(Box::into_raw(Box::new(handle)) as i64)
 }
 
-/// Imports an Arrow C Data batch and pushes it through the partition
+/// Outcome of initiating a send. `Sent` and `ReceiverDropped` resolve
+/// synchronously (no upcall follows); `Pending` means the channel was full and
+/// the send completes later via the completion upcall under the given call id.
+#[must_use]
+pub enum SendInitOutcome {
+    Sent,
+    ReceiverDropped,
+    Pending,
+}
+
+/// Imports an Arrow C Data batch and initiates a push through the partition
+/// stream's mpsc. The Rust side takes ownership of the
+/// `FFI_ArrowArray` / `FFI_ArrowSchema` structs at **initiation** (the
+/// `from_raw` / `from_ffi` consumption below is byte-for-byte the historical
+/// blocking path) — the Java side must not release them after a non-error
+/// return.
+///
+/// Fast path: when the channel has capacity the batch is sent inline and the
+/// function returns [`SendInitOutcome::Sent`] with no spawn and no upcall. When
+/// the channel is full the inner `mpsc::Sender` is **cloned** into a spawned
+/// task that awaits capacity and fires the completion upcall under `call_id`;
+/// the function returns [`SendInitOutcome::Pending`]. Cloning (rather than
+/// borrowing the boxed sender across the `await`) ends the borrow before this
+/// function returns, which is what makes `sender_close` safe against an
+/// in-flight send.
+///
+/// # Safety
+/// - `sender_ptr` must be a valid, non-zero pointer returned by
+///   `register_partition_stream`.
+/// - `array_ptr` must point to a populated `FFI_ArrowArray` struct owned by
+///   the caller; ownership transfers to Rust on initiation.
+/// - `schema_ptr` must point to a populated `FFI_ArrowSchema` struct owned
+///   by the caller; ownership transfers to Rust on initiation.
+pub unsafe fn sender_send_async(
+    sender_ptr: i64,
+    array_ptr: i64,
+    schema_ptr: i64,
+    mgr: &Arc<crate::runtime_manager::RuntimeManager>,
+    cb: crate::completion::OnNativeCompleteFn,
+    call_id: i64,
+) -> Result<SendInitOutcome, DataFusionError> {
+    let sender = &*(sender_ptr as *const PartitionStreamSender);
+
+    // Take ownership of the Java-allocated FFI structs. `from_raw` reads
+    // the struct contents into Rust-owned values; the original memory is
+    // now Rust's responsibility to drop.
+    let ffi_array = FFI_ArrowArray::from_raw(array_ptr as *mut FFI_ArrowArray);
+    let ffi_schema = FFI_ArrowSchema::from_raw(schema_ptr as *mut FFI_ArrowSchema);
+
+    // `from_ffi` takes the array by value (consumes it) and the schema by
+    // reference (it is still dropped when `ffi_schema` goes out of scope).
+    let mut array_data = arrow_array::ffi::from_ffi(ffi_array, &ffi_schema).map_err(|e| {
+        DataFusionError::Execution(format!("Failed to import Arrow C Data array: {}", e))
+    })?;
+
+    // Buffers from Java's Flight RPC deserialization may not meet Rust's
+    // native alignment requirements. align_buffers() is a no-op for
+    // already-aligned buffers; only misaligned ones are reallocated.
+    array_data.align_buffers();
+
+    let struct_array = StructArray::from(array_data);
+    let batch = RecordBatch::from(struct_array);
+
+    match sender.try_send(Ok(batch)) {
+        Ok(()) => Ok(SendInitOutcome::Sent),
+        Err(TrySendError::Closed(_)) => Ok(SendInitOutcome::ReceiverDropped),
+        Err(TrySendError::Full(batch)) => {
+            // KEY OWNERSHIP MOVE: clone the mpsc::Sender into the task instead of
+            // borrowing the boxed PartitionStreamSender across the await. The
+            // borrow ends HERE, before this function returns — which is what makes
+            // sender_close safe against in-flight sends.
+            let tx = sender.clone_tx();
+            mgr.io_runtime.spawn(async move {
+                let value = match tx.send(batch).await {
+                    Ok(()) => 0,                                  // Sent
+                    Err(_) => crate::ffm::SENDER_SEND_RECEIVER_DROPPED, // benign
+                };
+                crate::completion::complete(cb, call_id, Ok(value), /*owned_batch=*/ false);
+            });
+            Ok(SendInitOutcome::Pending)
+        }
+    }
+}
+
+
+/// Imports an Arrow C Data batch and initiates a push through the partition
 /// stream's mpsc. The Rust side takes ownership of the
 /// `FFI_ArrowArray` / `FFI_ArrowSchema` structs on success — the Java side
 /// must not release them after a successful send. On error ownership is
@@ -2496,6 +2582,170 @@ mod tests {
         // Restore the default so test ordering can't leak state into other tests.
         set_reduce_target_partitions(4);
         assert_eq!(get_reduce_target_partitions(), 4);
+    }
+
+    // ── sender_send_async: fast-path vs full-channel deferral ─────────────────
+
+    use std::sync::atomic::{AtomicI64, AtomicUsize, Ordering as AtomicOrdering};
+
+    static SEND_UPCALLS: AtomicUsize = AtomicUsize::new(0);
+    static SEND_LAST_VALUE: AtomicI64 = AtomicI64::new(-1);
+
+    /// Test completion callback for sender_send_async: counts upcalls and records the
+    /// last delivered value. Send completions are never owned batches, so consumed=1.
+    unsafe extern "C" fn counting_complete(
+        _call_id: i64,
+        value: i64,
+        _err_ptr: *const u8,
+        err_len: i64,
+    ) -> i32 {
+        SEND_UPCALLS.fetch_add(1, AtomicOrdering::SeqCst);
+        if err_len == 0 {
+            SEND_LAST_VALUE.store(value, AtomicOrdering::SeqCst);
+        }
+        1
+    }
+
+    fn i64_send_batch(schema: &arrow_schema::SchemaRef, v: i64) -> RecordBatch {
+        RecordBatch::try_new(Arc::clone(schema), vec![Arc::new(Int64Array::from(vec![v]))]).unwrap()
+    }
+
+    fn export_ptrs(batch: RecordBatch) -> (i64, i64) {
+        let schema = batch.schema();
+        let ffi_schema = FFI_ArrowSchema::try_from(schema.as_ref()).unwrap();
+        let struct_array: StructArray = batch.into();
+        let ffi_array = FFI_ArrowArray::new(&struct_array.into_data());
+        (
+            Box::into_raw(Box::new(ffi_array)) as i64,
+            Box::into_raw(Box::new(ffi_schema)) as i64,
+        )
+    }
+
+    #[test]
+    fn sender_send_async_fast_path_then_full_defers() {
+        let schema: arrow_schema::SchemaRef =
+            Arc::new(Schema::new(vec![Field::new("x", arrow_schema::DataType::Int64, false)]));
+        let (sender, _receiver) = crate::partition_stream::channel(Arc::clone(&schema));
+        let sender_ptr = Box::into_raw(Box::new(sender)) as i64;
+        let mgr = Arc::new(crate::runtime_manager::RuntimeManager::new(1, 1.5, 1.5));
+
+        SEND_UPCALLS.store(0, AtomicOrdering::SeqCst);
+
+        // Channel capacity is 4: the first four sends take the fast path (no upcall).
+        for i in 0..4 {
+            let (a, s) = export_ptrs(i64_send_batch(&schema, i));
+            let outcome = unsafe {
+                sender_send_async(sender_ptr, a, s, &mgr, counting_complete, i)
+            }
+            .expect("send initiates");
+            assert!(matches!(outcome, SendInitOutcome::Sent), "send {i} should be Sent");
+        }
+        assert_eq!(
+            SEND_UPCALLS.load(AtomicOrdering::SeqCst),
+            0,
+            "fast-path sends must not fire upcalls"
+        );
+
+        // Fifth send finds the channel full → deferred on the IO runtime.
+        let (a, s) = export_ptrs(i64_send_batch(&schema, 99));
+        let outcome = unsafe {
+            sender_send_async(sender_ptr, a, s, &mgr, counting_complete, 99)
+        }
+        .expect("send initiates");
+        assert!(matches!(outcome, SendInitOutcome::Pending), "full channel should defer");
+
+        // _receiver still alive but not draining: the spawned task is parked on capacity.
+        // Drain one batch so the deferred send completes, then await its upcall.
+        {
+            let mut receiver = _receiver;
+            mgr.io_runtime.block_on(async {
+                use futures::StreamExt;
+                let _ = receiver.next().await; // free one capacity slot
+                // Give the deferred send task a moment to complete the upcall.
+                for _ in 0..100 {
+                    if SEND_UPCALLS.load(AtomicOrdering::SeqCst) > 0 {
+                        break;
+                    }
+                    tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+                }
+            });
+        }
+        assert_eq!(
+            SEND_UPCALLS.load(AtomicOrdering::SeqCst),
+            1,
+            "the deferred send must fire exactly one completion"
+        );
+        assert_eq!(
+            SEND_LAST_VALUE.load(AtomicOrdering::SeqCst),
+            0,
+            "deferred send completes as Sent (value 0)"
+        );
+
+        unsafe { sender_close(sender_ptr) };
+    }
+
+    static CLOSE_UPCALLS: AtomicUsize = AtomicUsize::new(0);
+    static CLOSE_LAST_VALUE: AtomicI64 = AtomicI64::new(i64::MIN);
+
+    unsafe extern "C" fn close_test_complete(_call_id: i64, value: i64, _err: *const u8, err_len: i64) -> i32 {
+        CLOSE_UPCALLS.fetch_add(1, AtomicOrdering::SeqCst);
+        CLOSE_LAST_VALUE.store(if err_len == 0 { value } else { -999 }, AtomicOrdering::SeqCst);
+        1
+    }
+
+    /// Close-while-PENDING (spec Part E item 4): fill the bounded channel to capacity, issue one
+    /// more send that defers onto a spawned task holding a cloned `mpsc::Sender`, then `sender_close`
+    /// (drop the boxed `PartitionStreamSender`) WHILE that send is in flight. The clone-into-task
+    /// ownership move must make this UAF-free — dropping the box must not race the task's live clone.
+    /// Dropping the receiver then resolves the parked send as ReceiverDropped. Run under ASAN
+    /// (`-Zsanitizer=address`) to surface any use-after-free / double-free on this fault path.
+    ///
+    /// Self-contained: local `RuntimeManager` + local completion callback, no process globals — safe
+    /// under parallel `cargo test`.
+    #[test]
+    fn sender_send_async_close_while_pending_no_uaf() {
+        let schema: arrow_schema::SchemaRef =
+            Arc::new(Schema::new(vec![Field::new("x", arrow_schema::DataType::Int64, false)]));
+        let (sender, receiver) = crate::partition_stream::channel(Arc::clone(&schema));
+        let sender_ptr = Box::into_raw(Box::new(sender)) as i64;
+        let mgr = Arc::new(crate::runtime_manager::RuntimeManager::new(1, 1.5, 1.5));
+
+        CLOSE_UPCALLS.store(0, AtomicOrdering::SeqCst);
+        CLOSE_LAST_VALUE.store(i64::MIN, AtomicOrdering::SeqCst);
+
+        // Fill to capacity (4) on the fast path — nobody draining yet.
+        for i in 0..4 {
+            let (a, s) = export_ptrs(i64_send_batch(&schema, i));
+            let outcome =
+                unsafe { sender_send_async(sender_ptr, a, s, &mgr, close_test_complete, i) }.expect("init");
+            assert!(matches!(outcome, SendInitOutcome::Sent));
+        }
+        // 5th send defers onto a spawned task holding a cloned Sender.
+        let (a, s) = export_ptrs(i64_send_batch(&schema, 99));
+        let outcome =
+            unsafe { sender_send_async(sender_ptr, a, s, &mgr, close_test_complete, 99) }.expect("init");
+        assert!(matches!(outcome, SendInitOutcome::Pending), "full channel must defer");
+
+        // Close the sender (drop the box) while the deferred send is parked — the UAF candidate.
+        unsafe { sender_close(sender_ptr) };
+
+        // Drop the receiver to resolve the parked send (ReceiverDropped), then await the upcall.
+        mgr.io_runtime.block_on(async {
+            drop(receiver);
+            for _ in 0..200 {
+                if CLOSE_UPCALLS.load(AtomicOrdering::SeqCst) > 0 {
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+            }
+        });
+
+        assert_eq!(CLOSE_UPCALLS.load(AtomicOrdering::SeqCst), 1, "deferred send must complete exactly once");
+        assert_eq!(
+            CLOSE_LAST_VALUE.load(AtomicOrdering::SeqCst),
+            crate::ffm::SENDER_SEND_RECEIVER_DROPPED,
+            "deferred send must resolve as ReceiverDropped after close"
+        );
     }
 }
 

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/completion.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/completion.rs
@@ -1,0 +1,70 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+//! Generic async-completion upcall to Java.
+//!
+//! One static slot, registered once at startup via
+//! `df_register_completion_callback` (FilterTreeCallbacks-style — see
+//! `indexed_table::ffm_callbacks`). Spawned IO-runtime tasks deliver their
+//! result back to the Java-side per-call listener through this callback,
+//! turning the previously-blocking `df_stream_next` / `df_sender_send`
+//! data-flow waits into initiate-now, complete-via-upcall operations.
+//!
+//! Contract of `on_complete(call_id, value, err_ptr, err_len) -> consumed`:
+//!   err_len > 0  => failure. `value` is 0. err bytes valid only for the call duration.
+//!   err_len == 0 => success. `value` is the payload (meaning is per-operation).
+//!   return 1     => Java accepted ownership of `value`.
+//!   return 0     => Java did not (listener gone / threw): Rust reclaims if owned.
+
+use std::sync::atomic::{AtomicPtr, Ordering};
+
+pub(crate) type OnNativeCompleteFn = unsafe extern "C" fn(i64, i64, *const u8, i64) -> i32;
+static ON_COMPLETE: AtomicPtr<()> = AtomicPtr::new(std::ptr::null_mut());
+
+/// Registered by Java at startup. Stores the completion function pointer into
+/// the atomic slot. Not annotated `#[ffm_safe]` (that macro is specific to the
+/// `-> i64` error-pointer convention); a manual `catch_unwind` guards the
+/// boundary even though an atomic store can't realistically panic.
+#[no_mangle]
+pub unsafe extern "C" fn df_register_completion_callback(cb: OnNativeCompleteFn) {
+    let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        ON_COMPLETE.store(cb as *mut (), Ordering::Release);
+    }));
+}
+
+pub(crate) fn load_on_complete() -> Result<OnNativeCompleteFn, String> {
+    let p = ON_COMPLETE.load(Ordering::Acquire);
+    if p.is_null() {
+        return Err("completion callback not registered".into());
+    }
+    Ok(unsafe { std::mem::transmute::<*mut (), OnNativeCompleteFn>(p) })
+}
+
+/// Deliver a completion. `value_is_owned_batch`: when true and Java declines
+/// (consumed == 0), the value is a boxed `FFI_ArrowArray` Rust must drop here —
+/// its release callback frees the underlying Arrow buffers.
+pub(crate) fn complete(
+    cb: OnNativeCompleteFn,
+    call_id: i64,
+    result: Result<i64, String>,
+    value_is_owned_batch: bool,
+) {
+    let consumed = unsafe {
+        match &result {
+            Ok(v) => cb(call_id, *v, std::ptr::null(), 0),
+            Err(m) => cb(call_id, 0, m.as_ptr(), m.len() as i64),
+        }
+    };
+    if consumed == 0 && value_is_owned_batch {
+        if let Ok(ptr) = result {
+            if ptr != 0 {
+                unsafe { drop(Box::from_raw(ptr as *mut arrow_array::ffi::FFI_ArrowArray)); }
+            }
+        }
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/ffm.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/ffm.rs
@@ -13,6 +13,7 @@ use std::str;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use futures::FutureExt;
 use log::warn;
 use native_bridge_common::ffm_safe;
 use parking_lot::RwLock;
@@ -20,9 +21,14 @@ use parking_lot::RwLock;
 /// Only log block_on durations exceeding this threshold.
 const BLOCK_ON_LOG_THRESHOLD: Duration = Duration::from_millis(1);
 
-/// `df_sender_send` return code when the consumer dropped the receiver. Positive so it rides the
-/// success half of the FFM contract. MUST match `NativeBridge.SENDER_SEND_RECEIVER_DROPPED`.
-const SENDER_SEND_RECEIVER_DROPPED: i64 = 1;
+/// `df_sender_send_async` return code when the consumer dropped the receiver. Positive so it rides
+/// the success half of the FFM contract. MUST match `NativeBridge.SENDER_SEND_RECEIVER_DROPPED`.
+pub(crate) const SENDER_SEND_RECEIVER_DROPPED: i64 = 1;
+
+/// `df_sender_send_async` return code when the channel was full and the send is now in flight; the
+/// completion upcall will fire under the supplied call id. Positive so it rides the success half of
+/// the FFM contract. MUST match `NativeBridge.SENDER_SEND_PENDING`.
+pub(crate) const SENDER_SEND_PENDING: i64 = 2;
 
 /// Times a block_on call and logs a warning if it exceeds the threshold.
 #[inline(always)]
@@ -428,12 +434,66 @@ pub unsafe extern "C" fn df_stream_get_schema(stream_ptr: i64) -> i64 {
     api::stream_get_schema(stream_ptr).map_err(|e| e.to_string())
 }
 
+/// Extracts a human-readable message from a `catch_unwind` panic payload,
+/// mirroring the `JobError::Panic` extraction in `executor.rs`.
+fn panic_message(p: &(dyn std::any::Any + Send)) -> String {
+    if let Some(s) = p.downcast_ref::<String>() {
+        s.clone()
+    } else if let Some(s) = p.downcast_ref::<&str>() {
+        s.to_string()
+    } else {
+        "unknown panic".to_string()
+    }
+}
+
+/// Synchronous next-batch pull: blocks the calling thread on the IO runtime
+/// until DataFusion produces a batch (FFI_ArrowArray ptr), exhausts (0), or
+/// errors. Retained for the shard-scan / fetch data-node paths, which run on
+/// the SEARCH platform-thread pool and do not benefit from the async upcall
+/// path. The coordinator-reduce drain uses [`df_stream_next_async`] instead.
 #[ffm_safe]
 #[no_mangle]
 pub unsafe extern "C" fn df_stream_next(stream_ptr: i64) -> i64 {
     let mgr = get_rt_manager()?;
-    timed_block_on(&mgr.io_runtime, "stream_next", crate::task_monitors::stream_next_monitor().instrument(api::stream_next(stream_ptr)))
-        .map_err(|e| e.to_string())
+    timed_block_on(
+        &mgr.io_runtime,
+        "stream_next",
+        crate::task_monitors::stream_next_monitor().instrument(api::stream_next(stream_ptr)),
+    )
+    .map_err(|e| e.to_string())
+}
+
+/// Initiates the next-batch pull on the IO runtime and returns immediately.
+/// Result (FFI_ArrowArray ptr, 0 = exhausted, or error) delivered via the
+/// completion callback under `call_id`.
+///
+/// SAFETY CONTRACT (Java side upholds, and already does):
+///  - at most ONE in-flight pull per stream (BatchIterator pulls sequentially);
+///  - df_stream_close only after the in-flight pull's completion fired
+///    (DatafusionReduceSink's SinkState machine orders teardown after the
+///    drain unwinds; the task's last deref of stream_ptr strictly precedes
+///    the upcall, so this ordering is sufficient).
+#[ffm_safe]
+#[no_mangle]
+pub unsafe extern "C" fn df_stream_next_async(stream_ptr: i64, call_id: i64) -> i64 {
+    let mgr = get_rt_manager()?;
+    let cb = crate::completion::load_on_complete()?;
+    mgr.io_runtime.spawn(
+        crate::task_monitors::stream_next_monitor().instrument(async move {
+            // A panic swallowed by tokio = no completion = Java future never
+            // resolves = silent query hang. Map panic -> error completion.
+            let result = match std::panic::AssertUnwindSafe(api::stream_next(stream_ptr))
+                .catch_unwind()
+                .await
+            {
+                Ok(Ok(ptr)) => Ok(ptr),
+                Ok(Err(e)) => Err(e.to_string()),
+                Err(p) => Err(format!("stream_next panicked: {}", panic_message(&*p))),
+            };
+            crate::completion::complete(cb, call_id, result, /*owned_batch=*/ true);
+        }),
+    );
+    Ok(0)
 }
 
 #[no_mangle]
@@ -582,7 +642,7 @@ unsafe fn write_out_buffer(
 // string pointer that `NativeCall.invoke` reads and frees on the Java side.
 // Close functions are infallible and do not use the macro. The output stream
 // returned by `df_execute_local_plan` is the same `QueryStreamHandle` shape
-// as `df_execute_query`, so it drains through the existing `df_stream_next` /
+// as `df_execute_query`, so it drains through the existing `df_stream_next_async` /
 // `df_stream_close` paths unchanged.
 // ---------------------------------------------------------------------------
 
@@ -679,22 +739,27 @@ pub unsafe extern "C" fn df_execute_local_plan(
         .map_err(|e| e.to_string())
 }
 
+/// Initiates a batch send. Synchronous return codes: `0` = sent on the fast path,
+/// [`SENDER_SEND_RECEIVER_DROPPED`] = consumer dropped the receiver,
+/// [`SENDER_SEND_PENDING`] = channel was full and the completion will arrive under `call_id`.
+/// The FFI structs are consumed at initiation regardless of which non-error outcome is returned.
 #[ffm_safe]
 #[no_mangle]
-pub unsafe extern "C" fn df_sender_send(sender_ptr: i64, array_ptr: i64, schema_ptr: i64) -> i64 {
+pub unsafe extern "C" fn df_sender_send_async(
+    sender_ptr: i64,
+    array_ptr: i64,
+    schema_ptr: i64,
+    call_id: i64,
+) -> i64 {
     let mgr = get_rt_manager()?;
-    api::sender_send(sender_ptr, array_ptr, schema_ptr, mgr.io_runtime.handle())
-        .map(send_outcome_to_code)
+    let cb = crate::completion::load_on_complete()?;
+    api::sender_send_async(sender_ptr, array_ptr, schema_ptr, &mgr, cb, call_id)
+        .map(|o| match o {
+            api::SendInitOutcome::Sent => 0,
+            api::SendInitOutcome::ReceiverDropped => SENDER_SEND_RECEIVER_DROPPED,
+            api::SendInitOutcome::Pending => SENDER_SEND_PENDING,
+        })
         .map_err(|e| e.to_string())
-}
-
-/// Maps a send outcome to the `df_sender_send` return code: normal send `0`, dropped receiver
-/// [`SENDER_SEND_RECEIVER_DROPPED`] so the Java side can latch early-termination.
-fn send_outcome_to_code(outcome: crate::partition_stream::SendOutcome) -> i64 {
-    match outcome {
-        crate::partition_stream::SendOutcome::Sent => 0,
-        crate::partition_stream::SendOutcome::ReceiverDropped => SENDER_SEND_RECEIVER_DROPPED,
-    }
 }
 
 #[no_mangle]
@@ -1308,7 +1373,7 @@ pub unsafe extern "C" fn df_prepare_final_plan(
 /// Executes the previously prepared final-aggregate plan on a local session.
 ///
 /// Returns a stream pointer (same shape as `df_execute_local_plan`) that can
-/// be drained via `df_stream_next` / `df_stream_close`.
+/// be drained via `df_stream_next_async` / `df_stream_close`.
 ///
 /// # Safety
 /// `session_ptr` must be a valid pointer returned by `df_create_local_session`
@@ -1329,19 +1394,14 @@ pub unsafe extern "C" fn df_execute_local_prepared_plan(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::partition_stream::SendOutcome;
 
     #[test]
-    fn send_outcome_maps_sent_to_zero() {
-        assert_eq!(send_outcome_to_code(SendOutcome::Sent), 0);
-    }
-
-    #[test]
-    fn send_outcome_maps_receiver_dropped_to_sentinel() {
-        // Must surface the sentinel, not collapse to 0 like a normal send, or Java never latches
-        // isConsumerDone().
-        assert_eq!(send_outcome_to_code(SendOutcome::ReceiverDropped), SENDER_SEND_RECEIVER_DROPPED);
+    fn send_return_codes_are_distinct_and_stable() {
+        // 0 = sent (fast path), 1 = receiver dropped, 2 = pending. Java mirrors these
+        // constants; collapsing any pair would break isConsumerDone() / the park decision.
         assert_eq!(SENDER_SEND_RECEIVER_DROPPED, 1);
+        assert_eq!(SENDER_SEND_PENDING, 2);
+        assert_ne!(SENDER_SEND_RECEIVER_DROPPED, SENDER_SEND_PENDING);
     }
 
     /// Initialize the global runtime manager for tests.

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/lib.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/lib.rs
@@ -24,6 +24,7 @@ pub(crate) mod agg_mode;
 pub mod api;
 pub mod cache;
 pub mod cancellation;
+pub mod completion;
 pub mod cross_rt_stream;
 pub mod custom_cache_manager;
 pub mod datafusion_query_config;

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/local_executor.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/local_executor.rs
@@ -126,7 +126,7 @@ impl LocalSession {
     /// [`Self::execute_substrait`] resolve table references named `name` to
     /// this streaming table. The caller pushes `RecordBatch`es into the
     /// returned [`PartitionStreamSender`] via
-    /// [`PartitionStreamSender::send_blocking`].
+    /// [`PartitionStreamSender::try_send`] (or its cloned `mpsc::Sender`).
     pub fn register_partition(
         &mut self,
         name: &str,
@@ -336,9 +336,11 @@ mod tests {
         let producer_schema = Arc::clone(&schema);
         let handle = Handle::current();
         let producer = std::thread::spawn(move || {
+            let tx = sender.clone_tx();
             for chunk in &[vec![1i64, 2, 3], vec![4, 5, 6], vec![7, 8, 9]] {
-                let outcome = sender.send_blocking(Ok(i64_batch(&producer_schema, chunk)), &handle);
-                assert!(matches!(outcome, crate::partition_stream::SendOutcome::Sent));
+                handle
+                    .block_on(tx.send(Ok(i64_batch(&producer_schema, chunk))))
+                    .expect("receiver live");
             }
             drop(sender); // EOF
         });

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/partition_stream.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/partition_stream.rs
@@ -10,17 +10,20 @@
 //!
 //! A [`channel`] produces a paired [`PartitionStreamSender`] /
 //! [`PartitionStreamReceiver`]. The sender is exposed through the FFM bridge so
-//! Java can push Arrow `RecordBatch`es synchronously via
-//! [`PartitionStreamSender::send_blocking`]. The receiver implements DataFusion's
+//! Java can push Arrow `RecordBatch`es via [`PartitionStreamSender::try_send`]
+//! (fast path) and, when the channel is full, by cloning the inner
+//! [`PartitionStreamSender::clone_tx`] into a spawned task that completes via
+//! the async-completion upcall. The receiver implements DataFusion's
 //! [`RecordBatchStream`] and is wrapped in a [`SingleReceiverPartition`] so it
 //! can be registered on a `SessionContext` as a `StreamingTable`.
 //!
 //! # Backpressure
 //!
 //! The underlying mpsc is bounded (capacity 4) — chosen small so the sender
-//! back-pressures when the DataFusion execute side falls behind. Under load the
-//! Java feeder thread blocks on `send_blocking`, which naturally stalls the
-//! shard response pipeline.
+//! back-pressures when the DataFusion execute side falls behind. Under load a
+//! full channel makes [`PartitionStreamSender::try_send`] return `Full`; the
+//! FFM bridge then parks the send on the IO runtime (Java parks on a virtual
+//! thread), which naturally stalls the shard response pipeline.
 //!
 //! # Single-consumer contract
 //!
@@ -43,8 +46,8 @@ use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::physical_plan::streaming::PartitionStream;
 use datafusion::physical_plan::SendableRecordBatchStream;
 use futures::{stream, Stream};
-use tokio::runtime::Handle;
 use tokio::sync::mpsc;
+use tokio::sync::mpsc::error::TrySendError;
 
 /// Bounded channel capacity. Small by design — producers back-pressure when the
 /// DataFusion execute side falls behind.
@@ -60,41 +63,35 @@ pub struct PartitionStreamSender {
     schema: SchemaRef,
 }
 
-/// Outcome of a blocking send. `ReceiverDropped` is the benign terminal case — the
-/// DataFusion consumer finished (e.g. a `LimitExec` satisfied its fetch) and dropped the
-/// receiver. Surfaced as a distinct variant so the FFM layer can signal it without the Java
-/// side substring-matching an error message.
-#[must_use]
-pub enum SendOutcome {
-    Sent,
-    ReceiverDropped,
-}
-
 impl PartitionStreamSender {
     /// Returns the schema this sender was created with.
     pub fn schema(&self) -> &SchemaRef {
         &self.schema
     }
 
-    /// Push a batch into the channel from a synchronous (non-async) context.
-    ///
-    /// The provided `handle` is used to drive the async send — typically the
-    /// `io_runtime` handle from the global `RuntimeManager`. This lets the FFM
-    /// bridge push without being async itself and without requiring the calling
-    /// thread to be a Tokio worker.
-    ///
-    /// Blocks while the channel is full (natural backpressure). Returns
-    /// [`SendOutcome::ReceiverDropped`] only if the receiver has been dropped —
-    /// the sole failure mode of `mpsc::Sender::send`.
-    pub fn send_blocking(
+    /// Non-blocking push. Returns `Ok(())` on the fast path, or a
+    /// [`TrySendError`] when the channel is full (`Full`, carrying the batch
+    /// back so the caller can retry it on a spawned task) or the receiver has
+    /// been dropped (`Closed`).
+    pub fn try_send(
         &self,
         batch: Result<RecordBatch, DataFusionError>,
-        handle: &Handle,
-    ) -> SendOutcome {
-        match handle.block_on(self.tx.send(batch)) {
-            Ok(()) => SendOutcome::Sent,
-            Err(_) => SendOutcome::ReceiverDropped,
-        }
+    ) -> Result<(), TrySendError<Result<RecordBatch, DataFusionError>>> {
+        self.tx.try_send(batch)
+    }
+
+    /// Clones the inner `mpsc::Sender` (two `Arc` bumps). The clone is moved
+    /// into a spawned task to complete a full-channel send across an `await`
+    /// without borrowing the boxed [`PartitionStreamSender`] — which is what
+    /// makes [`crate::api::sender_close`] safe against in-flight sends.
+    ///
+    /// # EOF semantics
+    /// The channel signals EOF only when **all** `Sender` clones drop. A pending
+    /// in-flight send holds a clone, so closing the sender (dropping the boxed
+    /// `PartitionStreamSender`) defers EOF until the queued batch is delivered —
+    /// EOF is therefore ordered strictly after every accepted batch.
+    pub fn clone_tx(&self) -> mpsc::Sender<Result<RecordBatch, DataFusionError>> {
+        self.tx.clone()
     }
 }
 
@@ -264,37 +261,63 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn send_blocking_pushes_through_handle() {
+    async fn try_send_fast_path_then_eof() {
         let schema = test_schema();
         let (sender, mut receiver) = channel(Arc::clone(&schema));
-        let handle = Handle::current();
 
-        let sender_schema = Arc::clone(&schema);
-        let producer = std::thread::spawn(move || {
-            let outcome = sender.send_blocking(Ok(test_batch(&sender_schema, &[7, 8, 9])), &handle);
-            assert!(matches!(outcome, SendOutcome::Sent));
-            drop(sender);
-        });
+        // Capacity is 4; a single batch fits the fast path without blocking.
+        sender.try_send(Ok(test_batch(&schema, &[7, 8, 9]))).expect("fast-path send");
+        drop(sender);
 
         let batch = receiver.next().await.unwrap().unwrap();
         assert_eq!(batch.num_rows(), 3);
         assert!(receiver.next().await.is_none());
-        producer.join().unwrap();
     }
 
-    #[test]
-    fn send_blocking_reports_receiver_dropped() {
-        let rt = tokio::runtime::Runtime::new().expect("runtime builds");
-        let handle = rt.handle().clone();
+    #[tokio::test]
+    async fn try_send_full_then_clone_tx_drains() {
+        let schema = test_schema();
+        let (sender, mut receiver) = channel(Arc::clone(&schema));
 
+        // Fill the channel to capacity (4) on the fast path.
+        for _ in 0..CHANNEL_CAPACITY {
+            sender.try_send(Ok(test_batch(&schema, &[1]))).expect("within capacity");
+        }
+        // The next try_send must report Full and hand the batch back.
+        let overflow = test_batch(&schema, &[2]);
+        let tx = match sender.try_send(Ok(overflow)) {
+            Err(TrySendError::Full(batch)) => {
+                // Mirror the FFM bridge: clone the inner Sender and complete the
+                // send on a task once capacity frees up.
+                let tx = sender.clone_tx();
+                tokio::spawn(async move {
+                    tx.send(batch).await.expect("receiver still live");
+                });
+                sender.clone_tx()
+            }
+            other => panic!("expected Full, got {:?}", other.is_ok()),
+        };
+        drop(tx);
+        drop(sender);
+
+        // Drain all five batches (4 fast-path + 1 deferred), then EOF.
+        let mut count = 0;
+        while receiver.next().await.is_some() {
+            count += 1;
+        }
+        assert_eq!(count, CHANNEL_CAPACITY + 1);
+    }
+
+    #[tokio::test]
+    async fn try_send_reports_receiver_dropped() {
         let schema = test_schema();
         let (sender, receiver) = channel(Arc::clone(&schema));
         drop(receiver);
 
-        let outcome = std::thread::spawn(move || sender.send_blocking(Ok(test_batch(&schema, &[1])), &handle))
-            .join()
-            .unwrap();
-        assert!(matches!(outcome, SendOutcome::ReceiverDropped));
+        match sender.try_send(Ok(test_batch(&schema, &[1]))) {
+            Err(TrySendError::Closed(_)) => {}
+            other => panic!("expected Closed, got is_ok={}", other.is_ok()),
+        }
     }
 
     #[tokio::test]

--- a/sandbox/plugins/analytics-backend-datafusion/rust/tests/async_entry_gates.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/tests/async_entry_gates.rs
@@ -1,0 +1,100 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+//! Source-level CI gates for the async reduce path (spec Part E item 6).
+//!
+//! These guard the load-bearing invariants structurally so a future edit can't silently
+//! reintroduce a thread-pinning `block_on` into an async FFM entry, or resurrect the removed
+//! blocking sender API:
+//!
+//!  - `df_stream_next_async` / `df_sender_send_async` bodies contain NO `block_on` (they must
+//!    spawn-and-return; a `block_on` would pin the calling carrier and defeat the whole change).
+//!  - the synchronous `df_stream_next` entry still exists (the shard-scan / fetch paths depend on
+//!    it; this PR is coordinator-only and must not remove the sync pull).
+//!  - `send_blocking` appears nowhere (the blocking sender API was replaced by try_send/clone_tx).
+//!
+//! Uses `CARGO_MANIFEST_DIR` so the paths are stable regardless of the test runner's cwd.
+
+use std::fs;
+use std::path::PathBuf;
+
+fn read_src(rel: &str) -> String {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push(rel);
+    fs::read_to_string(&p).unwrap_or_else(|e| panic!("read {}: {}", p.display(), e))
+}
+
+/// Extracts the body of `pub unsafe extern "C" fn <name>(...) { ... }` by brace matching.
+fn extern_fn_body(src: &str, name: &str) -> String {
+    let sig = format!("fn {}(", name);
+    let start = src.find(&sig).unwrap_or_else(|| panic!("fn {} not found", name));
+    let open = src[start..].find('{').expect("fn has no body") + start;
+    let bytes = src.as_bytes();
+    let mut depth = 0usize;
+    let mut i = open;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'{' => depth += 1,
+            b'}' => {
+                depth -= 1;
+                if depth == 0 {
+                    return src[open..=i].to_string();
+                }
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    panic!("unbalanced braces for fn {}", name);
+}
+
+#[test]
+fn async_stream_next_has_no_block_on() {
+    let ffm = read_src("src/ffm.rs");
+    let body = extern_fn_body(&ffm, "df_stream_next_async");
+    assert!(
+        !body.contains("block_on"),
+        "df_stream_next_async must spawn-and-return, never block_on (would pin the carrier):\n{}",
+        body
+    );
+    assert!(body.contains("spawn"), "df_stream_next_async must spawn the pull onto the IO runtime");
+}
+
+#[test]
+fn async_sender_send_has_no_block_on() {
+    let ffm = read_src("src/ffm.rs");
+    let body = extern_fn_body(&ffm, "df_sender_send_async");
+    assert!(
+        !body.contains("block_on"),
+        "df_sender_send_async must not block_on:\n{}",
+        body
+    );
+}
+
+#[test]
+fn sync_stream_next_entry_still_exists() {
+    // Coordinator-only scope: the shard-scan / fetch data-node paths still use the synchronous
+    // df_stream_next. Removing it would silently flip shard execution onto the async path.
+    let ffm = read_src("src/ffm.rs");
+    assert!(
+        ffm.contains("pub unsafe extern \"C\" fn df_stream_next("),
+        "synchronous df_stream_next entry must remain for the shard-scan / fetch paths"
+    );
+}
+
+#[test]
+fn send_blocking_is_gone_everywhere() {
+    for f in ["src/partition_stream.rs", "src/api.rs", "src/ffm.rs", "src/local_executor.rs"] {
+        let src = read_src(f);
+        assert!(
+            !src.contains("send_blocking"),
+            "{} still references send_blocking; the blocking sender API was replaced by try_send/clone_tx",
+            f
+        );
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/rust/tests/common/mod.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/tests/common/mod.rs
@@ -1,0 +1,123 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+//! Shared test harness for the async-completion FFM entry points.
+//!
+//! The `df_*_async` entries (`df_stream_next_async`, `df_sender_send_async`)
+//! initiate work on the IO runtime and deliver the result later through the
+//! completion upcall registered via `df_register_completion_callback`. These
+//! helpers install a process-global callback that parks each call id on a
+//! condvar and provides blocking `*_sync` wrappers so integration tests can
+//! drive the async API as if it were synchronous — mirroring what the Java
+//! `DatafusionResultStream` / `DatafusionPartitionSender` do with a virtual
+//! thread + `CompletableFuture.join`.
+
+#![allow(dead_code)]
+
+use std::collections::HashMap;
+use std::ffi::CString;
+use std::os::raw::c_char;
+use std::sync::atomic::{AtomicI64, Ordering};
+use std::sync::{Condvar, Mutex, OnceLock};
+
+use opensearch_datafusion::completion::df_register_completion_callback;
+use opensearch_datafusion::ffm::{df_sender_send_async, df_stream_next_async};
+
+/// MUST match `ffm.rs` (and `NativeBridge`).
+pub const SENDER_SEND_RECEIVER_DROPPED: i64 = 1;
+/// MUST match `ffm.rs` (and `NativeBridge`).
+pub const SENDER_SEND_PENDING: i64 = 2;
+
+struct Completions {
+    results: Mutex<HashMap<i64, Result<i64, String>>>,
+    cv: Condvar,
+}
+
+static COMPLETIONS: OnceLock<Completions> = OnceLock::new();
+static NEXT_CALL_ID: AtomicI64 = AtomicI64::new(1);
+static INSTALLED: OnceLock<()> = OnceLock::new();
+
+fn completions() -> &'static Completions {
+    COMPLETIONS.get_or_init(|| Completions {
+        results: Mutex::new(HashMap::new()),
+        cv: Condvar::new(),
+    })
+}
+
+/// Completion upcall. Stores the result (taking ownership of any batch pointer,
+/// which the waiter then drains) and wakes the waiter. Returns 1 = accepted.
+unsafe extern "C" fn on_complete(call_id: i64, value: i64, err_ptr: *const u8, err_len: i64) -> i32 {
+    let result = if err_len > 0 {
+        let bytes = std::slice::from_raw_parts(err_ptr, err_len as usize);
+        Err(String::from_utf8_lossy(bytes).into_owned())
+    } else {
+        Ok(value)
+    };
+    let c = completions();
+    c.results.lock().unwrap().insert(call_id, result);
+    c.cv.notify_all();
+    1
+}
+
+/// Installs the global completion callback exactly once.
+pub fn install_completion_callback() {
+    INSTALLED.get_or_init(|| {
+        unsafe { df_register_completion_callback(on_complete) };
+    });
+}
+
+fn alloc_call_id() -> i64 {
+    NEXT_CALL_ID.fetch_add(1, Ordering::Relaxed)
+}
+
+fn wait(call_id: i64) -> Result<i64, String> {
+    let c = completions();
+    let mut guard = c.results.lock().unwrap();
+    loop {
+        if let Some(r) = guard.remove(&call_id) {
+            return r;
+        }
+        guard = c.cv.wait(guard).unwrap();
+    }
+}
+
+/// Decode (and free) the heap-allocated error string behind a negative FFM rc.
+pub fn decode_error(rc: i64) -> String {
+    assert!(rc < 0, "expected negative rc, got {}", rc);
+    let ptr = (-rc) as *mut c_char;
+    let cstring = unsafe { CString::from_raw(ptr) };
+    cstring.to_string_lossy().into_owned()
+}
+
+/// Blocking wrapper over `df_stream_next_async`. Returns the batch pointer
+/// (0 = EOS) or the error message.
+pub fn stream_next_sync(stream_ptr: i64) -> Result<i64, String> {
+    install_completion_callback();
+    let call_id = alloc_call_id();
+    let rc = unsafe { df_stream_next_async(stream_ptr, call_id) };
+    if rc < 0 {
+        return Err(decode_error(rc));
+    }
+    // rc == 0: initiation succeeded; the batch/error arrives via the completion.
+    wait(call_id)
+}
+
+/// Blocking wrapper over `df_sender_send_async`. Returns the synchronous-or-deferred
+/// outcome code (0 = sent, [`SENDER_SEND_RECEIVER_DROPPED`]) or an error message.
+pub fn sender_send_sync(sender_ptr: i64, array_ptr: i64, schema_ptr: i64) -> Result<i64, String> {
+    install_completion_callback();
+    let call_id = alloc_call_id();
+    let rc = unsafe { df_sender_send_async(sender_ptr, array_ptr, schema_ptr, call_id) };
+    if rc < 0 {
+        return Err(decode_error(rc));
+    }
+    if rc == SENDER_SEND_PENDING {
+        return wait(call_id);
+    }
+    Ok(rc)
+}

--- a/sandbox/plugins/analytics-backend-datafusion/rust/tests/local_exec_test.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/tests/local_exec_test.rs
@@ -13,18 +13,16 @@
 //!
 //! - `df_create_local_session` / `df_close_local_session` lifecycle
 //! - `df_register_partition_stream` exposes the input as a DataFusion table
-//! - `df_sender_send` → execute → `df_stream_next` drains a `SUM` aggregate
-//! - Error path: `df_sender_send` on a sender whose receiver is gone returns
-//!   a negative rc and the heap-allocated error string decodes cleanly
+//! - `df_sender_send_async` → execute → `df_stream_next_async` drains a `SUM` aggregate
+//! - Early-termination path: a send on a sender whose receiver is gone returns
+//!   the benign `SENDER_SEND_RECEIVER_DROPPED` sentinel (not an error)
 //! - `df_close_local_session` drops registered senders (receiver side of the
-//!   mpsc closes), so a subsequent `df_sender_send` fails
+//!   mpsc closes), so a subsequent send reports `SENDER_SEND_RECEIVER_DROPPED`
 //!
 //! The runtime manager (`df_init_runtime_manager`) is a process-global
 //! singleton, so we initialize it exactly once across all tests via a
 //! `OnceLock` guard.
 
-use std::ffi::CString;
-use std::os::raw::c_char;
 use std::sync::{Arc, OnceLock};
 use std::thread;
 use std::time::Duration;
@@ -41,8 +39,11 @@ use tempfile::TempDir;
 use opensearch_datafusion::ffm::{
     df_close_global_runtime, df_close_local_session, df_create_global_runtime,
     df_create_local_session, df_execute_local_plan, df_init_runtime_manager,
-    df_register_partition_stream, df_sender_close, df_sender_send, df_stream_close, df_stream_next,
+    df_register_partition_stream, df_sender_close, df_stream_close,
 };
+
+mod common;
+use common::{sender_send_sync, stream_next_sync, SENDER_SEND_RECEIVER_DROPPED};
 
 // ---------------------------------------------------------------------------
 // One-time setup
@@ -152,8 +153,8 @@ fn ipc_bytes_to_schema(bytes: &[u8]) -> Schema {
 /// ownership to the caller — mirrors what `DatafusionReduceSink.feed` will do
 /// on the Java side.
 ///
-/// Returns `(array_ptr, schema_ptr)` as `i64` addresses. On successful
-/// `df_sender_send` the Rust side consumes both pointers via `from_raw`.
+/// Returns `(array_ptr, schema_ptr)` as `i64` addresses. On a non-error send
+/// the Rust side consumes both pointers via `from_raw` at initiation.
 fn export_batch_ptrs(batch: RecordBatch) -> (i64, i64) {
     let schema = batch.schema();
     let ffi_schema = FFI_ArrowSchema::try_from(schema.as_ref()).expect("schema export");
@@ -165,20 +166,6 @@ fn export_batch_ptrs(batch: RecordBatch) -> (i64, i64) {
     let array_ptr = Box::into_raw(Box::new(ffi_array)) as i64;
     let schema_ptr = Box::into_raw(Box::new(ffi_schema)) as i64;
     (array_ptr, schema_ptr)
-}
-
-/// Decode (and free) the heap-allocated error string referenced by a
-/// negative FFM return code. Convention is defined in
-/// `sandbox/libs/dataformat-native/rust/common/src/error.rs`: the error
-/// pointer is the positive value of the negated return code, and the
-/// string is a `CString` that must be freed via `CString::from_raw`.
-fn decode_error(rc: i64) -> String {
-    assert!(rc < 0, "expected negative rc, got {}", rc);
-    let ptr = (-rc) as *mut c_char;
-    // SAFETY: the FFM layer produces this string via `CString::into_raw`;
-    // taking ownership back via `from_raw` both reads and frees it.
-    let cstring = unsafe { CString::from_raw(ptr) };
-    cstring.to_string_lossy().into_owned()
 }
 
 /// Build a Substrait plan for `SELECT SUM(x) AS total FROM "input-0"` using a
@@ -298,8 +285,8 @@ fn test_execute_sum_substrait() {
         for chunk in [vec![1i64, 2, 3], vec![4i64, 5, 6], vec![7i64, 8, 9]] {
             let batch = i64_batch(&producer_schema, &chunk);
             let (arr_ptr, sch_ptr) = export_batch_ptrs(batch);
-            let rc = unsafe { df_sender_send(sender_ptr, arr_ptr, sch_ptr) };
-            assert_eq!(rc, 0, "df_sender_send rc={}", rc);
+            let rc = sender_send_sync(sender_ptr, arr_ptr, sch_ptr).expect("send ok");
+            assert_eq!(rc, 0, "sender_send rc={}", rc);
         }
         // EOF — releases the sender, which closes the mpsc.
         unsafe { df_sender_close(sender_ptr) };
@@ -326,8 +313,7 @@ fn test_execute_sum_substrait() {
     // must drop it) or 0 for EOS.
     let mut total: i64 = 0;
     loop {
-        let rc = unsafe { df_stream_next(stream_ptr) };
-        assert!(rc >= 0, "df_stream_next rc={}", rc);
+        let rc = stream_next_sync(stream_ptr).expect("stream_next ok");
         if rc == 0 {
             break;
         }
@@ -363,7 +349,7 @@ fn test_execute_sum_substrait() {
 }
 
 #[test]
-fn test_sender_send_error_path() {
+fn test_sender_send_receiver_dropped_path() {
     let runtime = RuntimeGuard::new();
     let session_ptr = unsafe { df_create_local_session(runtime.ptr) };
     assert!(session_ptr > 0);
@@ -376,18 +362,15 @@ fn test_sender_send_error_path() {
     // channel is now closed.
     unsafe { df_close_local_session(session_ptr) };
 
-    // Attempting to send now fails — `send_blocking` reports "receiver
-    // dropped before send".
+    // Attempting to send now reports the benign receiver-dropped sentinel
+    // (try_send => Closed) rather than an error — the consumer finished first.
     let batch = i64_batch(&schema, &[1, 2, 3]);
     let (arr_ptr, sch_ptr) = export_batch_ptrs(batch);
-    let rc = unsafe { df_sender_send(sender_ptr, arr_ptr, sch_ptr) };
-    assert!(rc < 0, "expected error, got rc={}", rc);
-
-    let msg = decode_error(rc);
-    assert!(
-        msg.contains("receiver dropped") || msg.contains("receiver"),
-        "unexpected error message: {}",
-        msg
+    let rc = sender_send_sync(sender_ptr, arr_ptr, sch_ptr).expect("send initiates");
+    assert_eq!(
+        rc, SENDER_SEND_RECEIVER_DROPPED,
+        "expected receiver-dropped sentinel, got rc={}",
+        rc
     );
 
     unsafe { df_sender_close(sender_ptr) };
@@ -406,22 +389,20 @@ fn test_close_session_drops_registered_senders() {
     // capacity 4 so one send does not block).
     let batch_ok = i64_batch(&schema, &[10]);
     let (a0, s0) = export_batch_ptrs(batch_ok);
-    let rc_ok = unsafe { df_sender_send(sender_ptr, a0, s0) };
+    let rc_ok = sender_send_sync(sender_ptr, a0, s0).expect("send ok");
     assert_eq!(rc_ok, 0, "pre-close send should succeed, rc={}", rc_ok);
 
     // Close the session. The surviving sender's mpsc is now orphaned.
     unsafe { df_close_local_session(session_ptr) };
 
-    // Subsequent `df_sender_send` on the still-live sender pointer fails.
+    // Subsequent send on the still-live sender pointer reports the receiver-dropped sentinel.
     let batch_fail = i64_batch(&schema, &[20]);
     let (a1, s1) = export_batch_ptrs(batch_fail);
-    let rc_err = unsafe { df_sender_send(sender_ptr, a1, s1) };
-    assert!(rc_err < 0, "post-close send should fail, got rc={}", rc_err);
-    let msg = decode_error(rc_err);
-    assert!(
-        msg.contains("receiver"),
-        "expected receiver-dropped error, got: {}",
-        msg
+    let rc_dropped = sender_send_sync(sender_ptr, a1, s1).expect("send initiates");
+    assert_eq!(
+        rc_dropped, SENDER_SEND_RECEIVER_DROPPED,
+        "post-close send should report receiver dropped, got rc={}",
+        rc_dropped
     );
 
     unsafe { df_sender_close(sender_ptr) };

--- a/sandbox/plugins/analytics-backend-datafusion/rust/tests/stringview_gc_test.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/tests/stringview_gc_test.rs
@@ -28,8 +28,11 @@ use tempfile::TempDir;
 use opensearch_datafusion::ffm::{
     df_close_global_runtime, df_close_local_session, df_create_global_runtime,
     df_create_local_session, df_execute_local_plan, df_init_runtime_manager,
-    df_register_partition_stream, df_sender_close, df_sender_send, df_stream_close, df_stream_next,
+    df_register_partition_stream, df_sender_close, df_stream_close,
 };
+
+mod common;
+use common::{sender_send_sync, stream_next_sync};
 
 // ---------------------------------------------------------------------------
 // One-time setup (same OnceLock pattern as local_exec_test.rs)
@@ -206,8 +209,8 @@ fn test_stringview_gc_on_sliced_batch() {
         .expect("batch from sliced array");
 
         let (arr_ptr, sch_ptr) = export_batch_ptrs(batch);
-        let rc = unsafe { df_sender_send(sender_ptr, arr_ptr, sch_ptr) };
-        assert_eq!(rc, 0, "df_sender_send rc={}", rc);
+        let rc = sender_send_sync(sender_ptr, arr_ptr, sch_ptr).expect("send ok");
+        assert_eq!(rc, 0, "sender_send rc={}", rc);
 
         unsafe { df_sender_close(sender_ptr) };
     });
@@ -225,8 +228,7 @@ fn test_stringview_gc_on_sliced_batch() {
     // Drain the output and check buffer sizes
     let mut output_batches: Vec<RecordBatch> = Vec::new();
     loop {
-        let rc = unsafe { df_stream_next(stream_ptr) };
-        assert!(rc >= 0, "df_stream_next rc={}", rc);
+        let rc = stream_next_sync(stream_ptr).expect("stream_next ok");
         if rc == 0 {
             break;
         }

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/AbstractDatafusionReduceSink.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/AbstractDatafusionReduceSink.java
@@ -168,7 +168,9 @@ abstract class AbstractDatafusionReduceSink implements ReducingExchangeSink, Can
     protected final void drainOutputIntoDownstream(StreamHandle outStream) {
         BufferAllocator alloc = ctx.allocator();
         try (CDataDictionaryProvider dictProvider = new CDataDictionaryProvider()) {
-            DatafusionResultStream.BatchIterator it = new DatafusionResultStream.BatchIterator(outStream, alloc, dictProvider);
+            // Coordinator-reduce drain runs on a virtual thread: use the async pull so each
+            // CompletableFuture.join park unmounts its carrier (see DatafusionResultStream).
+            DatafusionResultStream.BatchIterator it = new DatafusionResultStream.BatchIterator(outStream, alloc, dictProvider, true);
             while (it.hasNext()) {
                 // next() transfers ownership of the imported VSR to us. feed() takes ownership only
                 // on success; if it throws (e.g. the downstream sink was torn down on a concurrent

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionPartitionSender.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionPartitionSender.java
@@ -12,17 +12,23 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.analytics.backend.jni.NativeHandle;
 import org.opensearch.be.datafusion.nativelib.NativeBridge;
+import org.opensearch.core.action.ActionListener;
 
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 /**
  * Type-safe wrapper around a native {@code PartitionStreamSender} pointer. Closing
  * the sender signals EOF to the DataFusion receiver side.
  *
- * <p>The {@code lifecycle} read-write lock serialises {@link #send} / {@link #close}:
- * native {@code sender_send} holds an immutable borrow of the heap-allocated sender
- * across an {@code mpsc::Sender::send().await}, while {@code sender_close} reclaims
- * the {@code Box} — a use-after-free if these overlap.
+ * <p>The {@code lifecycle} read-write lock serialises {@link #send} / {@link #close}: the
+ * native {@code sender_send_async} read-validates the heap-allocated sender pointer against
+ * {@code sender_close}'s {@code Box} reclaim. The send is now <b>initiated</b> synchronously
+ * under the lock (no native borrow is held across an {@code await}); a full-channel send owns a
+ * <b>cloned</b> {@code mpsc::Sender}, so {@code close()} can never UAF an in-flight send and no
+ * longer waits for one. The park on a pending send happens <b>outside</b> the lock — on a virtual
+ * thread it unmounts the carrier. EOF defers until the pending batch lands (the cloned sender
+ * keeps the channel open until it drops).
  */
 public final class DatafusionPartitionSender extends NativeHandle {
 
@@ -48,16 +54,28 @@ public final class DatafusionPartitionSender extends NativeHandle {
      * receiver (benign — the caller should discard the batch and stop feeding).
      */
     public long send(long arrayAddr, long schemaAddr) {
+        CompletableFuture<Long> done = new CompletableFuture<>();
+        long rc;
         lifecycle.readLock().lock();
         try {
-            long rc = NativeBridge.senderSend(getPointer(), arrayAddr, schemaAddr);
-            if (rc == NativeBridge.SENDER_SEND_RECEIVER_DROPPED) {
-                receiverDropped = true;
-            }
-            return rc;
+            rc = NativeBridge.senderSendAsync(
+                getPointer(),
+                arrayAddr,
+                schemaAddr,
+                ActionListener.wrap(done::complete, done::completeExceptionally)
+            );
         } finally {
             lifecycle.readLock().unlock();
         }
+        if (rc == NativeBridge.SENDER_SEND_PENDING) {
+            // Channel full: park outside the lock until the deferred send completes. On a virtual
+            // thread this unmounts the carrier — no platform thread is held for backpressure.
+            rc = done.join();
+        }
+        if (rc == NativeBridge.SENDER_SEND_RECEIVER_DROPPED) {
+            receiverDropped = true;
+        }
+        return rc;
     }
 
     /** True once the consumer dropped this channel's receiver (see {@link #receiverDropped}). */

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionReduceSink.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionReduceSink.java
@@ -230,18 +230,20 @@ public class DatafusionReduceSink extends AbstractDatafusionReduceSink implement
             } finally {
                 batch.close();
             }
-            // sender.send acquires its read lock so the native borrow outlives concurrent
-            // close — see DatafusionPartitionSender. Throws IllegalStateException via
-            // NativeHandle.getPointer() if the sender was closed (the close-race path).
+            // sender.send initiates under its read lock so the pointer can't be reclaimed by a
+            // concurrent close mid-initiation — see DatafusionPartitionSender. A full channel parks
+            // the feeder outside the lock (on a virtual thread, the carrier unmounts). Throws
+            // IllegalStateException via NativeHandle.getPointer() if the sender was closed before
+            // initiation (the close-race path).
             try {
                 long rc = sender.send(array.memoryAddress(), arrowSchema.memoryAddress());
                 if (rc == NativeBridge.SENDER_SEND_RECEIVER_DROPPED) {
                     // Consumer finished first (e.g. a LimitExec satisfied its fetch) and dropped the
-                    // receiver while shards were still feeding. api::sender_send already consumed the
-                    // FFI structs via from_raw, so the buffers are Rust's to drop — do NOT release()
-                    // here (double-free). The sender latched the drop (see DatafusionPartitionSender),
-                    // so subsequent feeds for this input short-circuit and the producer stream is
-                    // cancelled by the shard listener via isConsumerDone().
+                    // receiver while shards were still feeding. sender_send_async already consumed the
+                    // FFI structs via from_raw at initiation, so the buffers are Rust's to drop — do NOT
+                    // release() here (double-free). The sender latched the drop (see
+                    // DatafusionPartitionSender), so subsequent feeds for this input short-circuit and
+                    // the producer stream is cancelled by the shard listener via isConsumerDone().
                     logger.debug("[ReduceSink] receiver dropped before send (consumer finished), discarding batch");
                     return;
                 }
@@ -369,9 +371,11 @@ public class DatafusionReduceSink extends AbstractDatafusionReduceSink implement
         }
         Exception failure = null;
         try {
-            // Close outStream first: drops the native receiver, which unblocks any sender
-            // parked in send_blocking (waiting for channel capacity). This releases the
-            // sender's read lock so session.close() can acquire the write lock without deadlock.
+            // Close outStream first: dropping the native receiver promptly resolves any pending
+            // send (a Full send parked on capacity completes as ReceiverDropped once the receiver
+            // is gone). The sender no longer holds a native borrow across an await — initiation is
+            // synchronous and a pending send owns a cloned mpsc::Sender — so this ordering is about
+            // resolving in-flight sends quickly, not defusing a read/write-lock conflict.
             outStream.close();
         } catch (Exception t) {
             failure = accumulate(failure, t);

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionResultStream.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionResultStream.java
@@ -92,16 +92,29 @@ public class DatafusionResultStream implements EngineResultStream, FragmentResou
         private final StreamHandle streamHandle;
         private final BufferAllocator allocator;
         private final CDataDictionaryProvider dictionaryProvider;
+        /**
+         * When true, batch pulls go through {@link NativeBridge#streamNextAsync} (initiate-now,
+         * complete-via-upcall) so the {@code callNativeFn} park unmounts a virtual-thread carrier.
+         * Reserved for the coordinator-reduce drain. The shard-scan / fetch paths leave this false
+         * and use the synchronous {@link NativeBridge#streamNext} (native block_on), unchanged.
+         */
+        private final boolean async;
         private Schema schema;
         private VectorSchemaRoot nextBatch;
         private Boolean nextAvailable;
         private boolean batchEmitted;
         private boolean nativeStreamExhausted;
 
+        /** Synchronous pull (shard-scan / fetch paths). */
         BatchIterator(StreamHandle streamHandle, BufferAllocator allocator, CDataDictionaryProvider dictionaryProvider) {
+            this(streamHandle, allocator, dictionaryProvider, false);
+        }
+
+        BatchIterator(StreamHandle streamHandle, BufferAllocator allocator, CDataDictionaryProvider dictionaryProvider, boolean async) {
             this.streamHandle = streamHandle;
             this.allocator = allocator;
             this.dictionaryProvider = dictionaryProvider;
+            this.async = async;
         }
 
         private void ensureSchema() {
@@ -119,9 +132,13 @@ public class DatafusionResultStream implements EngineResultStream, FragmentResou
         private boolean loadNextBatch() {
             ensureSchema();
             if (nativeStreamExhausted) return false;
-            long arrayAddr = callNativeFn(
-                listener -> NativeBridge.streamNext(streamHandle.getRuntimeHandle().get(), streamHandle.getPointer(), listener)
-            );
+            long arrayAddr = callNativeFn(listener -> {
+                if (async) {
+                    NativeBridge.streamNextAsync(streamHandle.getRuntimeHandle().get(), streamHandle.getPointer(), listener);
+                } else {
+                    NativeBridge.streamNext(streamHandle.getRuntimeHandle().get(), streamHandle.getPointer(), listener);
+                }
+            });
             if (arrayAddr == 0) {
                 nativeStreamExhausted = true;
                 // Streaming Flight requires ≥1 schema-bearing frame before completeStream;

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/nativelib/NativeBridge.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/nativelib/NativeBridge.java
@@ -108,6 +108,7 @@ public final class NativeBridge {
     private static final MethodHandle EXECUTE_QUERY;
     private static final MethodHandle STREAM_GET_SCHEMA;
     private static final MethodHandle STREAM_NEXT;
+    private static final MethodHandle STREAM_NEXT_ASYNC;
     private static final MethodHandle STREAM_CLOSE;
     private static final MethodHandle STREAM_GET_METRICS;
     private static final MethodHandle FREE_METRICS_BUF;
@@ -117,8 +118,9 @@ public final class NativeBridge {
     private static final MethodHandle CLOSE_LOCAL_SESSION;
     private static final MethodHandle REGISTER_PARTITION_STREAM;
     private static final MethodHandle EXECUTE_LOCAL_PLAN;
-    private static final MethodHandle SENDER_SEND;
+    private static final MethodHandle SENDER_SEND_ASYNC;
     private static final MethodHandle SENDER_CLOSE;
+    private static final MethodHandle REGISTER_COMPLETION_CALLBACK;
     private static final MethodHandle REGISTER_MEMTABLE;
     private static final MethodHandle CREATE_CUSTOM_CACHE_MANAGER;
     private static final MethodHandle DESTROY_CUSTOM_CACHE_MANAGER;
@@ -265,9 +267,19 @@ public final class NativeBridge {
             FunctionDescriptor.of(ValueLayout.JAVA_LONG, ValueLayout.JAVA_LONG)
         );
 
+        // i64 df_stream_next(stream_ptr) — synchronous pull (block_on); used by the shard-scan /
+        // fetch data-node paths on the SEARCH platform pool.
         STREAM_NEXT = linker.downcallHandle(
             lib.find("df_stream_next").orElseThrow(),
             FunctionDescriptor.of(ValueLayout.JAVA_LONG, ValueLayout.JAVA_LONG)
+        );
+
+        // i64 df_stream_next_async(stream_ptr, call_id) — initiates the pull; the batch (or error)
+        // arrives later via the completion upcall under call_id. Synchronous return is 0 / -errPtr.
+        // Used only by the coordinator-reduce drain (on virtual threads).
+        STREAM_NEXT_ASYNC = linker.downcallHandle(
+            lib.find("df_stream_next_async").orElseThrow(),
+            FunctionDescriptor.of(ValueLayout.JAVA_LONG, ValueLayout.JAVA_LONG, ValueLayout.JAVA_LONG)
         );
 
         STREAM_CLOSE = linker.downcallHandle(lib.find("df_stream_close").orElseThrow(), FunctionDescriptor.ofVoid(ValueLayout.JAVA_LONG));
@@ -341,10 +353,22 @@ public final class NativeBridge {
             )
         );
 
-        // i64 df_sender_send(sender_ptr, array_ptr, schema_ptr)
-        SENDER_SEND = linker.downcallHandle(
-            lib.find("df_sender_send").orElseThrow(),
-            FunctionDescriptor.of(ValueLayout.JAVA_LONG, ValueLayout.JAVA_LONG, ValueLayout.JAVA_LONG, ValueLayout.JAVA_LONG)
+        // i64 df_sender_send_async(sender_ptr, array_ptr, schema_ptr, call_id)
+        SENDER_SEND_ASYNC = linker.downcallHandle(
+            lib.find("df_sender_send_async").orElseThrow(),
+            FunctionDescriptor.of(
+                ValueLayout.JAVA_LONG,
+                ValueLayout.JAVA_LONG,
+                ValueLayout.JAVA_LONG,
+                ValueLayout.JAVA_LONG,
+                ValueLayout.JAVA_LONG
+            )
+        );
+
+        // void df_register_completion_callback(onComplete)
+        REGISTER_COMPLETION_CALLBACK = linker.downcallHandle(
+            lib.find("df_register_completion_callback").orElseThrow(),
+            FunctionDescriptor.ofVoid(ValueLayout.ADDRESS)
         );
 
         // void df_sender_close(sender_ptr)
@@ -513,6 +537,12 @@ public final class NativeBridge {
         // are installed and `df_execute_indexed_query` can dispatch into Java.
         installFilterTreeCallbacks(linker);
 
+        // Install the single async-completion upcall. Spawned IO-runtime tasks
+        // (stream_next_async / sender_send_async) deliver their results back to
+        // per-call listeners through this stub. Must be installed before any
+        // async entry is invoked.
+        installCompletionCallback(linker);
+
         CLOSE_SESSION_CONTEXT = linker.downcallHandle(
             lib.find("df_close_session_context").orElseThrow(),
             FunctionDescriptor.ofVoid(ValueLayout.JAVA_LONG)
@@ -677,6 +707,32 @@ public final class NativeBridge {
                 collectDocsStub,
                 releaseCollectorStub
             );
+        } catch (Throwable t) {
+            throw new ExceptionInInitializerError(t);
+        }
+    }
+
+    private static void installCompletionCallback(Linker linker) {
+        try {
+            java.lang.foreign.Arena arena = java.lang.foreign.Arena.global();
+            var lookup = java.lang.invoke.MethodHandles.lookup();
+            MethodHandle onComplete = lookup.findStatic(
+                NativeCompletionCallbacks.class,
+                "onNativeComplete",
+                java.lang.invoke.MethodType.methodType(int.class, long.class, long.class, MemorySegment.class, long.class)
+            );
+            MemorySegment stub = linker.upcallStub(
+                onComplete,
+                FunctionDescriptor.of(
+                    ValueLayout.JAVA_INT,
+                    ValueLayout.JAVA_LONG,
+                    ValueLayout.JAVA_LONG,
+                    ValueLayout.ADDRESS,
+                    ValueLayout.JAVA_LONG
+                ),
+                arena
+            );
+            NativeCall.invokeVoid(REGISTER_COMPLETION_CALLBACK, stub);
         } catch (Throwable t) {
             throw new ExceptionInInitializerError(t);
         }
@@ -958,6 +1014,32 @@ public final class NativeBridge {
         }
     }
 
+    /**
+     * Initiates a next-batch pull and returns immediately; the listener fires later from the
+     * completion upcall (on a tokio worker) when the batch — or error, or end-of-stream (0) — is
+     * ready. Register before the downcall, because the completion can race the downcall's
+     * synchronous return. Used only by the coordinator-reduce drain, which runs on virtual threads
+     * where the downstream {@code CompletableFuture.join} park unmounts its carrier.
+     */
+    public static void streamNextAsync(long runtimePtr, long streamPtr, ActionListener<Long> listener) {
+        long callId = NativeCompletionCallbacks.register(listener);
+        try {
+            NativeHandle.validatePointer(streamPtr, "stream");
+            NativeLibraryLoader.checkResult((long) STREAM_NEXT_ASYNC.invokeExact(streamPtr, callId));
+        } catch (Throwable t) {
+            // Initiation failed before the task was spawned (bad stream ptr, runtime/callback not
+            // ready). The native entry returns 0 once it reaches spawn, so a throw here means no task
+            // is in flight and no completion will fire — reclaim the listener and surface the error.
+            // (A panic AFTER spawn is caught inside the task and delivered as an error completion, not
+            // as a throw.) unregister is single-fire safe: if a completion somehow raced us it already
+            // removed the entry, and we no-op.
+            ActionListener<Long> l = NativeCompletionCallbacks.unregister(callId);
+            if (l != null) {
+                listener.onFailure(convertNativeError(t));
+            }
+        }
+    }
+
     public static void streamClose(long streamPtr) {
         NativeCall.invokeVoid(STREAM_CLOSE, streamPtr);
     }
@@ -1212,8 +1294,8 @@ public final class NativeBridge {
     }
 
     /**
-     * Positive sentinel returned by {@code df_sender_send} (via {@link #senderSend}) when the
-     * send was skipped because the consumer dropped the receiver before this batch could be sent
+     * Positive sentinel returned by {@code df_sender_send_async} (via {@link #senderSendAsync}) when
+     * the send was skipped because the consumer dropped the receiver before this batch could be sent
      * — the benign "consumer finished first" case (e.g. a LimitExec satisfied its fetch). It
      * rides the success half of the native return contract ({@code >= 0} success, {@code < 0}
      * {@code -error_ptr}), so {@code checkResult} passes it through without throwing.
@@ -1222,11 +1304,22 @@ public final class NativeBridge {
     public static final long SENDER_SEND_RECEIVER_DROPPED = 1L;
 
     /**
-     * Pushes one Arrow C Data-exported batch (array + schema addresses) into the sender. The
-     * native side takes ownership of both FFI structs. Returns {@code 0} on a normal send or
-     * {@link #SENDER_SEND_RECEIVER_DROPPED} if the consumer already dropped the receiver.
+     * Positive sentinel returned by {@code df_sender_send_async} (via {@link #senderSendAsync})
+     * when the channel was full and the send is now in flight on the IO runtime; the registered
+     * listener fires from the completion upcall when capacity frees and the batch lands. Rides the
+     * success half of the native return contract. MUST match {@code SENDER_SEND_PENDING} in
+     * {@code ffm.rs}.
      */
-    public static long senderSend(long senderPtr, long arrayPtr, long schemaPtr) {
+    public static final long SENDER_SEND_PENDING = 2L;
+
+    /**
+     * Initiates a batch push. Returns {@code 0} (sent on the fast path),
+     * {@link #SENDER_SEND_RECEIVER_DROPPED} (consumer dropped the receiver), or
+     * {@link #SENDER_SEND_PENDING} (channel full — the send is in flight and the {@code listener}
+     * fires later from the completion upcall with the eventual outcome). The native side takes
+     * ownership of both FFI structs on any non-throwing outcome.
+     */
+    public static long senderSendAsync(long senderPtr, long arrayPtr, long schemaPtr, ActionListener<Long> listener) {
         NativeHandle.validatePointer(senderPtr, "sender");
         // arrayPtr/schemaPtr come from Arrow Java's C Data export (ArrowArray.memoryAddress()),
         // NOT from our NativeHandle lifecycle — validate as non-zero rather than live-handle.
@@ -1236,8 +1329,17 @@ public final class NativeBridge {
         if (schemaPtr == 0) {
             throw new IllegalArgumentException("schemaPtr must be non-zero");
         }
+        long callId = NativeCompletionCallbacks.register(listener);
+        boolean pending = false;
         try (var call = new NativeCall()) {
-            return call.invoke(SENDER_SEND, senderPtr, arrayPtr, schemaPtr);
+            long rc = call.invoke(SENDER_SEND_ASYNC, senderPtr, arrayPtr, schemaPtr, callId);
+            pending = (rc == SENDER_SEND_PENDING);
+            return rc;
+        } finally {
+            // Sync outcome (Sent / ReceiverDropped) or a throw: no completion is coming, so reclaim.
+            if (!pending) {
+                NativeCompletionCallbacks.unregister(callId);
+            }
         }
     }
 

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/nativelib/NativeCompletionCallbacks.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/nativelib/NativeCompletionCallbacks.java
@@ -1,0 +1,79 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion.nativelib;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.be.datafusion.NativeErrorConverter;
+import org.opensearch.core.action.ActionListener;
+
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Routes async native completions to per-call listeners. One static upcall stub,
+ * registered once from {@link NativeBridge}'s static init via
+ * {@code df_register_completion_callback}.
+ *
+ * <p>LISTENER CONTRACT: listeners registered here run ON A TOKIO IO-RUNTIME WORKER.
+ * They MUST be O(1) and non-throwing — in practice, {@code CompletableFuture::complete}
+ * wrappers. State transitions, allocator work, downstream feeds belong on the
+ * Java side of the future, never here.
+ */
+public final class NativeCompletionCallbacks {
+
+    private static final Logger LOGGER = LogManager.getLogger(NativeCompletionCallbacks.class);
+    private static final ConcurrentHashMap<Long, ActionListener<Long>> PENDING = new ConcurrentHashMap<>();
+    private static final AtomicLong IDS = new AtomicLong(1);
+
+    static long register(ActionListener<Long> listener) {
+        long id = IDS.getAndIncrement();
+        PENDING.put(id, listener);
+        return id;
+    }
+
+    /** Reclaim on initiation-failure or sync-outcome. Null if the completion raced us. */
+    static ActionListener<Long> unregister(long callId) {
+        return PENDING.remove(callId);
+    }
+
+    /** Test-only: number of listeners awaiting a completion. Used by leak probes. */
+    public static int pendingCount() {
+        return PENDING.size();
+    }
+
+    /**
+     * FFM upcall: {@code int (long callId, long value, MemorySegment errPtr, long errLen)}.
+     * A Throwable escaping an upcall stub crashes the JVM — catch everything.
+     * Returns 1 iff Java accepted ownership of {@code value}.
+     */
+    static int onNativeComplete(long callId, long value, MemorySegment errPtr, long errLen) {
+        try {
+            ActionListener<Long> l = PENDING.remove(callId);
+            if (l == null) {
+                return 0; // query torn down; Rust reclaims
+            }
+            if (errLen > 0) {
+                String msg = new String(errPtr.reinterpret(errLen).toArray(ValueLayout.JAVA_BYTE), StandardCharsets.UTF_8);
+                l.onFailure(NativeErrorConverter.convert(new RuntimeException(msg)));
+                return 1; // value is 0 on the error path
+            }
+            l.onResponse(value);
+            return 1;
+        } catch (Throwable t) {
+            LOGGER.error("native completion listener threw (callId=" + callId + ")", t);
+            return 0;
+        }
+    }
+
+    private NativeCompletionCallbacks() {}
+}

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionMemtableReduceSinkTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionMemtableReduceSinkTests.java
@@ -48,6 +48,9 @@ import io.substrait.extension.SimpleExtension;
  * Mirror of {@link DatafusionReduceSinkTests} for the memtable variant. Same Substrait plan, same
  * batches, same downstream assertion — exercises the buffered-batch handoff path instead of the
  * streaming sender path.
+ *
+ * <p>{@link ThreadLeakScope.Scope#NONE}: the async-completion drain fires upcalls on Tokio
+ * IO-runtime worker threads (process-lifetime singletons) — see {@link DatafusionReduceSinkTests}.
  */
 @ThreadLeakScope(ThreadLeakScope.Scope.NONE)
 public class DatafusionMemtableReduceSinkTests extends OpenSearchTestCase {

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionReduceSinkTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionReduceSinkTests.java
@@ -61,6 +61,11 @@ import io.substrait.extension.SimpleExtension;
  *       sink, feed Arrow batches, close, and assert the downstream sink received the
  *       reduced result.</li>
  * </ul>
+ *
+ * <p>{@link ThreadLeakScope.Scope#NONE}: the async-completion path fires upcalls on Tokio IO-runtime
+ * worker threads (process-lifetime singletons that attach to the JVM and persist after the test).
+ * They cannot be shut down per-test without breaking other classes sharing the JVM — same rationale
+ * as {@code DataFusionNativeBridgeTests}.
  */
 @ThreadLeakScope(ThreadLeakScope.Scope.NONE)
 public class DatafusionReduceSinkTests extends OpenSearchTestCase {
@@ -78,14 +83,15 @@ public class DatafusionReduceSinkTests extends OpenSearchTestCase {
 
     /**
      * The benign "consumer finished first" case (a {@code LimitExec} satisfied its fetch and
-     * dropped the receiver while producers were still feeding) is signalled by {@code df_sender_send}
-     * returning the positive sentinel {@link NativeBridge#SENDER_SEND_RECEIVER_DROPPED} rather than a
-     * stringly-typed error — {@code feedToSender} keys off this code. The sentinel must be positive
-     * (so {@code checkResult} passes it through the success half of the return contract instead of
-     * treating it as an error pointer) and distinct from a normal send ({@code 0}). The Rust↔Java
-     * agreement on the value is enforced by the matching {@code SENDER_SEND_RECEIVER_DROPPED} in
-     * {@code ffm.rs}; the structural "only a dropped receiver maps here" guarantee is covered by the
-     * Rust {@code send_blocking_reports_receiver_dropped} unit test.
+     * dropped the receiver while producers were still feeding) is signalled by
+     * {@code df_sender_send_async} returning the positive sentinel
+     * {@link NativeBridge#SENDER_SEND_RECEIVER_DROPPED} rather than a stringly-typed error —
+     * {@code feedToSender} keys off this code. The sentinel must be positive (so {@code checkResult}
+     * passes it through the success half of the return contract instead of treating it as an error
+     * pointer) and distinct from a normal send ({@code 0}). The Rust↔Java agreement on the value is
+     * enforced by the matching {@code SENDER_SEND_RECEIVER_DROPPED} in {@code ffm.rs}; the structural
+     * "only a dropped receiver maps here" guarantee is covered by the Rust
+     * {@code try_send_reports_receiver_dropped} unit test.
      */
     public void testReceiverDroppedSentinelIsPositiveAndDistinctFromSuccess() {
         assertTrue(

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/nativelib/NativeCompletionCallbacksTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/nativelib/NativeCompletionCallbacksTests.java
@@ -1,0 +1,121 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion.nativelib;
+
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Unit tests for {@link NativeCompletionCallbacks} — the per-call listener registry behind the
+ * async-completion upcall. These exercise the Part D invariants without crossing the FFM boundary:
+ * register-before-initiate, completion-exactly-once, reclaim-on-sync-outcome (leak probe), and
+ * throwing-listener-doesn't-escape.
+ */
+public class NativeCompletionCallbacksTests extends OpenSearchTestCase {
+
+    private static MemorySegment errSegment(Arena arena, String msg) {
+        byte[] bytes = msg.getBytes(StandardCharsets.UTF_8);
+        MemorySegment seg = arena.allocate(bytes.length);
+        MemorySegment.copy(bytes, 0, seg, ValueLayout.JAVA_BYTE, 0, bytes.length);
+        return seg;
+    }
+
+    public void testSuccessDeliversValueAndConsumes() {
+        AtomicLong got = new AtomicLong(-1);
+        long id = NativeCompletionCallbacks.register(ActionListener.wrap(got::set, e -> fail("unexpected failure")));
+
+        int consumed = NativeCompletionCallbacks.onNativeComplete(id, 4242L, MemorySegment.NULL, 0);
+
+        assertEquals("Java accepted ownership", 1, consumed);
+        assertEquals(4242L, got.get());
+        assertNull("listener removed after firing", NativeCompletionCallbacks.unregister(id));
+    }
+
+    public void testErrorPathDeliversFailureAndConsumes() {
+        AtomicReference<Exception> failure = new AtomicReference<>();
+        long id = NativeCompletionCallbacks.register(ActionListener.wrap(v -> fail("unexpected success"), failure::set));
+
+        try (Arena arena = Arena.ofConfined()) {
+            String msg = "boom from native";
+            MemorySegment seg = errSegment(arena, msg);
+            int consumed = NativeCompletionCallbacks.onNativeComplete(id, 0L, seg, msg.length());
+            assertEquals(1, consumed);
+        }
+        assertNotNull("failure delivered", failure.get());
+        assertTrue("message preserved", failure.get().getMessage().contains("boom from native"));
+    }
+
+    public void testCompletionExactlyOnce() {
+        AtomicInteger fires = new AtomicInteger();
+        long id = NativeCompletionCallbacks.register(ActionListener.wrap(v -> fires.incrementAndGet(), e -> fires.incrementAndGet()));
+
+        int first = NativeCompletionCallbacks.onNativeComplete(id, 1L, MemorySegment.NULL, 0);
+        int second = NativeCompletionCallbacks.onNativeComplete(id, 1L, MemorySegment.NULL, 0);
+
+        assertEquals("first completion accepted", 1, first);
+        assertEquals("second completion finds no listener — Rust reclaims", 0, second);
+        assertEquals("listener fired exactly once", 1, fires.get());
+    }
+
+    public void testUnregisterReclaimsBeforeCompletion() {
+        AtomicInteger fires = new AtomicInteger();
+        long id = NativeCompletionCallbacks.register(ActionListener.wrap(v -> fires.incrementAndGet(), e -> fires.incrementAndGet()));
+
+        // Sync-outcome / initiation-failure path: caller reclaims the listener itself.
+        ActionListener<Long> reclaimed = NativeCompletionCallbacks.unregister(id);
+        assertNotNull("unregister returns the live listener", reclaimed);
+
+        // A racing completion now finds nothing and tells Rust to reclaim (consumed=0).
+        int consumed = NativeCompletionCallbacks.onNativeComplete(id, 7L, MemorySegment.NULL, 0);
+        assertEquals(0, consumed);
+        assertEquals("listener never fired via the registry", 0, fires.get());
+    }
+
+    public void testThrowingListenerDoesNotEscapeAndReturnsNotConsumed() {
+        // A raw listener whose onResponse throws directly (ActionListener.wrap would instead reroute
+        // an onResponse exception to onFailure, so use an explicit listener to hit the catch-all).
+        ActionListener<Long> thrower = new ActionListener<>() {
+            @Override
+            public void onResponse(Long v) {
+                throw new RuntimeException("listener blew up");
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                throw new RuntimeException("listener blew up (failure)");
+            }
+        };
+        long id = NativeCompletionCallbacks.register(thrower);
+
+        // A Throwable escaping the upcall stub would crash the JVM; onNativeComplete must swallow it
+        // and report not-consumed so Rust reclaims the batch.
+        int consumed = NativeCompletionCallbacks.onNativeComplete(id, 1L, MemorySegment.NULL, 0);
+        assertEquals(0, consumed);
+    }
+
+    public void testPendingMapDrainsToEmpty() {
+        int before = NativeCompletionCallbacks.pendingCount();
+        long a = NativeCompletionCallbacks.register(ActionListener.wrap(v -> {}, e -> {}));
+        long b = NativeCompletionCallbacks.register(ActionListener.wrap(v -> {}, e -> {}));
+        assertEquals(before + 2, NativeCompletionCallbacks.pendingCount());
+
+        NativeCompletionCallbacks.onNativeComplete(a, 0L, MemorySegment.NULL, 0);
+        NativeCompletionCallbacks.unregister(b);
+
+        assertEquals("no listeners leak after completion + reclaim", before, NativeCompletionCallbacks.pendingCount());
+    }
+}

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/AnalyticsPlugin.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/AnalyticsPlugin.java
@@ -88,16 +88,10 @@ public class AnalyticsPlugin extends Plugin implements ExtensiblePlugin, ActionP
     public static final String SCHEDULER_THREAD_POOL_NAME = "analytics_scheduler";
     private static final int SCHEDULER_QUEUE_SIZE = 200;
 
-    public static final String REDUCE_THREAD_POOL_NAME = "analytics_reduce";
-
-    // The reduce pool exists to isolate coordinator-reduce drains from the SEARCH
-    // pool, preventing deadlock when reduces and local shard fragments compete for
-    // the same threads. Each reduce thread blocks on a synchronous FFM call
-    // (streamNext) with negligible CPU usage — memory is the real constraint,
-    // bounded by the DataFusion pool and phantom reservations. Size is generous
-    // so the thread pool isn't the throughput bottleneck.
-    private static final int REDUCE_POOL_SIZE = Math.max(8, Runtime.getRuntime().availableProcessors() * 4);
-    private static final int REDUCE_QUEUE_SIZE = 200;
+    // The dedicated coordinator-reduce thread pool was removed: reduces now run on the
+    // per-query virtual-thread executor (QueryContext.localTaskExecutor()). The drain's
+    // data-flow waits are CompletableFuture parks that unmount the carrier on a virtual
+    // thread, so there is no platform pool to isolate from SEARCH and no deadlock to defuse.
 
     public static final Setting<Long> COORDINATOR_BUFFER_LIMIT = Setting.longSetting(
         "analytics.coordinator.buffer_limit",
@@ -246,10 +240,7 @@ public class AnalyticsPlugin extends Plugin implements ExtensiblePlugin, ActionP
     @Override
     public List<ExecutorBuilder<?>> getExecutorBuilders(Settings settings) {
         int poolSize = schedulerPoolSize();
-        return List.of(
-            new FixedExecutorBuilder(settings, SCHEDULER_THREAD_POOL_NAME, poolSize, SCHEDULER_QUEUE_SIZE, "analytics"),
-            new FixedExecutorBuilder(settings, REDUCE_THREAD_POOL_NAME, REDUCE_POOL_SIZE, REDUCE_QUEUE_SIZE, "analytics_reduce")
-        );
+        return List.of(new FixedExecutorBuilder(settings, SCHEDULER_THREAD_POOL_NAME, poolSize, SCHEDULER_QUEUE_SIZE, "analytics"));
     }
 
     static int schedulerPoolSize() {

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/QueryContext.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/QueryContext.java
@@ -107,10 +107,6 @@ public class QueryContext {
         return threadPool != null ? threadPool.executor(AnalyticsPlugin.SCHEDULER_THREAD_POOL_NAME) : Runnable::run;
     }
 
-    public Executor reduceExecutor() {
-        return threadPool != null ? threadPool.executor(AnalyticsPlugin.REDUCE_THREAD_POOL_NAME) : Runnable::run;
-    }
-
     public AnalyticsQueryTask parentTask() {
         return parentTask;
     }

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stage/coordinator/ReduceStageExecution.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stage/coordinator/ReduceStageExecution.java
@@ -26,7 +26,8 @@ import org.opensearch.analytics.spi.ReducingExchangeSink;
 import org.opensearch.core.action.ActionListener;
 
 import java.util.List;
-import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.RejectedExecutionException;
 
 /**
  * Coordinator-side reduce stage execution. Task invokes {@link ReducingExchangeSink#reduce};
@@ -34,9 +35,21 @@ import java.util.concurrent.Executor;
  * cancel-before-reduce paths still release resources. Scheduling mode (eager vs buffered)
  * is delegated to {@link ReducingExchangeSink#supportsEagerScheduling()}.
  *
- * <p>Dispatched on the scheduler pool (lightweight, handles wait/orchestration) which then
- * forks the actual reduce computation to the SEARCH pool. This prevents deadlocking SEARCH
- * (where fragment execution runs) while keeping reduce compute off the scheduler threads.
+ * <p><b>Virtual-thread reduce.</b> The reduce body runs on the per-query virtual-thread
+ * executor ({@link QueryContext#localTaskExecutor()}), the same executor
+ * {@code LateMaterializationStageExecution} uses for LOCAL stage bodies. The drain's
+ * data-flow waits (the native batch pull behind {@code DatafusionResultStream.BatchIterator}
+ * and the input push behind {@code DatafusionPartitionSender}) are now plain Java
+ * {@code CompletableFuture} parks — on a virtual thread each park unmounts its carrier, so no
+ * platform pool thread is held for the duration of a reduce. A {@code cancel()} reaches the
+ * Java-parked drain via the cancellation token → error-completion → unwind path; no thread
+ * interruption is involved.
+ *
+ * <p>{@code localTaskExecutor()} is a raw {@code newThreadPerTaskExecutor} that does not
+ * propagate OpenSearch {@code ThreadContext}. The reduce body and its listener completion do
+ * not read {@code ThreadContext} (no task-header / tracing reads on the transitive
+ * {@code reduce()} path), so no context-preserving wrapper is required — matching
+ * {@code LateMaterializationStageExecution}'s use of the same executor.
  *
  * @opensearch.internal
  */
@@ -46,7 +59,7 @@ public final class ReduceStageExecution extends AbstractStageExecution implement
 
     private final ReducingExchangeSink backendSink;
     private final ExchangeSink downstream;
-    private final Executor reduceExecutor;
+    private final ExecutorService localTaskExecutor;
     private final BufferAllocator allocator;
     private final boolean profile;
 
@@ -54,7 +67,7 @@ public final class ReduceStageExecution extends AbstractStageExecution implement
         super(stage, config.queryId(), config.operationListeners(), config.parentTask());
         this.backendSink = backendSink;
         this.downstream = downstream;
-        this.reduceExecutor = config.reduceExecutor();
+        this.localTaskExecutor = config.localTaskExecutor();
         this.allocator = config.bufferAllocator();
         this.runner = new LocalTaskRunner(config.schedulerExecutor());
         this.profile = config.profile();
@@ -101,7 +114,7 @@ public final class ReduceStageExecution extends AbstractStageExecution implement
     protected List<StageTask> materializeTasks() {
         final StageTask[] holder = new StageTask[1];
         holder[0] = new LocalStageTask(new StageTaskId(getStageId(), 0), listener -> {
-            reduceExecutor.execute(() -> {
+            localTaskExecutor.execute(() -> {
                 try {
                     backendSink.reduce(ActionListener.wrap(v -> {
                         if (profile) {

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/stage/ReduceStageExecutionTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/stage/ReduceStageExecutionTests.java
@@ -323,7 +323,7 @@ public class ReduceStageExecutionTests extends OpenSearchTestCase {
 
     private static QueryContext mockContext() {
         QueryContext ctx = mock(QueryContext.class);
-        when(ctx.reduceExecutor()).thenReturn(inlineExecutor());
+        when(ctx.localTaskExecutor()).thenReturn(inlineExecutor());
         when(ctx.schedulerExecutor()).thenReturn(inlineExecutor());
         when(ctx.parentTask()).thenReturn(mock(AnalyticsQueryTask.class));
         return ctx;

--- a/sandbox/qa/analytics-engine-coordinator/src/internalClusterTest/java/org/opensearch/analytics/cancellation/ReduceThreadPoolCleanupIT.java
+++ b/sandbox/qa/analytics-engine-coordinator/src/internalClusterTest/java/org/opensearch/analytics/cancellation/ReduceThreadPoolCleanupIT.java
@@ -35,8 +35,6 @@ import org.opensearch.ppl.action.PPLResponse;
 import org.opensearch.ppl.action.UnifiedPPLExecuteAction;
 import org.opensearch.test.OpenSearchIntegTestCase;
 import org.opensearch.test.transport.MockTransportService;
-import org.opensearch.threadpool.ThreadPool;
-import org.opensearch.threadpool.ThreadPoolStats;
 import org.opensearch.transport.TransportService;
 
 import java.util.Collection;
@@ -51,15 +49,16 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 /**
- * Verifies the coordinator-reduce thread pool ({@code analytics_reduce}) is released after a query
- * — both on the normal-completion path and the cancellation path.
+ * Verifies the coordinator-reduce drain unwinds and leaves no residual tasks after a query — both
+ * on the normal-completion path and the cancellation path.
  *
- * <p>The reduce drain runs on a thread from this fixed pool (one task per coordinator-reduce
- * stage). If {@code DatafusionReduceSink.reduce} fails to unwind on cancellation (the drain parks
- * in {@code stream_next} and is never cancelled, or {@code closeImpl} double-frees / deadlocks),
- * the drain thread leaks: the pool's {@code active} count stays elevated and eventually the pool
- * saturates. These tests assert the pool drains back to {@code active=0} after each query, which
- * is what this PR's {@code closeImpl}/cancel teardown guarantees.
+ * <p>The reduce drain now runs on the per-query virtual-thread executor
+ * ({@code QueryContext.localTaskExecutor()}), not a dedicated platform pool; its data-flow waits
+ * are {@code CompletableFuture} parks that unmount the carrier. If {@code DatafusionReduceSink.reduce}
+ * fails to unwind on cancellation (the drain parks waiting for input and is never cancelled, or
+ * {@code closeImpl} double-frees / deadlocks), the query task leaks. These tests assert the
+ * coordinator clears its {@code analytics/query} (and {@code fragment}) tasks after each query,
+ * which is what the {@code closeImpl}/cancel teardown guarantees.
  */
 @OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 2, numClientNodes = 0, supportsDedicatedMasters = false)
 @com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope(com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope.Scope.TEST)
@@ -165,26 +164,6 @@ public class ReduceThreadPoolCleanupIT extends OpenSearchIntegTestCase {
         return client().execute(UnifiedPPLExecuteAction.INSTANCE, new PPLRequest(ppl)).actionGet(timeout);
     }
 
-    /** Max {@code active}/{@code queue} for the {@code analytics_reduce} pool across all nodes. */
-    private int reducePoolActiveAcrossNodes() {
-        int maxActive = 0;
-        for (ThreadPool tp : internalCluster().getInstances(ThreadPool.class)) {
-            for (ThreadPoolStats.Stats s : tp.stats()) {
-                if (AnalyticsPlugin.REDUCE_THREAD_POOL_NAME.equals(s.getName())) {
-                    maxActive = Math.max(maxActive, s.getActive() + s.getQueue());
-                }
-            }
-        }
-        return maxActive;
-    }
-
-    private void assertReducePoolDrains() throws Exception {
-        assertBusy(() -> {
-            int active = reducePoolActiveAcrossNodes();
-            assertEquals("analytics_reduce pool must drain to 0 active+queued; got " + active, 0, active);
-        }, 30, TimeUnit.SECONDS);
-    }
-
     private void assertNoResidualTasks(String action) throws Exception {
         assertBusy(() -> {
             ListTasksResponse tasks = client().admin().cluster().prepareListTasks().setActions(action).get();
@@ -203,7 +182,6 @@ public class ReduceThreadPoolCleanupIT extends OpenSearchIntegTestCase {
         long actual = ((Number) response.getRows().get(0)[response.getColumns().indexOf("total")]).longValue();
         assertEquals("query must return the correct sum", EXPECTED_SUM, actual);
 
-        assertReducePoolDrains();
         assertNoResidualTasks(AnalyticsQueryAction.NAME);
     }
 
@@ -256,8 +234,7 @@ public class ReduceThreadPoolCleanupIT extends OpenSearchIntegTestCase {
             exec.awaitTermination(5, TimeUnit.SECONDS);
         }
 
-        // The cancelled query's reduce drain must have unwound and returned its pool thread.
-        assertReducePoolDrains();
+        // The cancelled query's reduce drain must have unwound, leaving no residual tasks.
         assertNoResidualTasks(AnalyticsQueryAction.NAME);
         assertNoResidualTasks(FragmentExecutionAction.NAME);
     }

--- a/sandbox/qa/analytics-engine-coordinator/src/internalClusterTest/java/org/opensearch/be/datafusion/CoordinatorReduceStressIT.java
+++ b/sandbox/qa/analytics-engine-coordinator/src/internalClusterTest/java/org/opensearch/be/datafusion/CoordinatorReduceStressIT.java
@@ -30,14 +30,16 @@ import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.util.ImmutableBitSet;
-import org.apache.lucene.tests.util.LuceneTestCase;
 import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.analytics.spi.ExchangeSink;
 import org.opensearch.analytics.spi.ExchangeSinkContext;
 import org.opensearch.be.datafusion.nativelib.NativeBridge;
 import org.opensearch.test.OpenSearchTestCase;
 
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
@@ -46,10 +48,12 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 import io.substrait.extension.DefaultExtensionCatalog;
 import io.substrait.extension.SimpleExtension;
+import jdk.jfr.consumer.RecordingStream;
 
 /**
  * Coordinator-side reduce-stage stress + lifecycle hygiene tests for
@@ -86,7 +90,10 @@ import io.substrait.extension.SimpleExtension;
  *
  * @opensearch.internal
  */
-@LuceneTestCase.AwaitsFix(bugUrl = "broken")
+// The async-completion path fires upcalls on Tokio IO-runtime worker threads — process-lifetime
+// singletons that attach to the JVM and persist after the suite. They can't be shut down per-test
+// without breaking other classes that share the runtime; same rationale as DataFusionNativeBridgeTests.
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
 public class CoordinatorReduceStressIT extends OpenSearchTestCase {
 
     /** Default Substrait input id for the single-input case (matches DatafusionReduceSink.INPUT_ID). */
@@ -121,6 +128,28 @@ public class CoordinatorReduceStressIT extends OpenSearchTestCase {
                 super.tearDown();
             }
         }
+    }
+
+    /**
+     * Asserts the native DataFusion memory pool returns to (at most) {@code baseline} bytes within a
+     * grace window. Complements the Java {@code RootAllocator} baseline checks: a leak on the
+     * <b>Rust</b> side (an abandoned pending-send task's batch, an un-dropped FFI array on a
+     * cancel/failure unwind) would never move the Java allocator but WOULD strand native pool bytes.
+     * Native release callbacks fire asynchronously on the tokio runtime, so poll rather than sample
+     * once. {@code slackBytes} tolerates pool bookkeeping that doesn't return to a bit-exact zero.
+     */
+    private void assertNativePoolReturnsToBaseline(long baseline, long slackBytes) throws Exception {
+        long runtimePtr = runtimeHandle.getPointer();
+        long deadline = System.currentTimeMillis() + 10_000;
+        long usage;
+        do {
+            usage = NativeBridge.getMemoryPoolUsage(runtimePtr);
+            if (usage - baseline <= slackBytes) {
+                return;
+            }
+            Thread.sleep(50);
+        } while (System.currentTimeMillis() < deadline);
+        fail("native memory pool did not return to baseline: baseline=" + baseline + " usage=" + usage + " (slack=" + slackBytes + ")");
     }
 
     /**
@@ -196,6 +225,7 @@ public class CoordinatorReduceStressIT extends OpenSearchTestCase {
         );
 
         long allocBefore = alloc.getAllocatedMemory();
+        long poolBefore = NativeBridge.getMemoryPoolUsage(runtimeHandle.getPointer());
 
         DatafusionReduceSink sink = new DatafusionReduceSink(ctx, runtimeHandle);
         PlainActionFuture<Void> drainDone = PlainActionFuture.newFuture();
@@ -233,6 +263,9 @@ public class CoordinatorReduceStressIT extends OpenSearchTestCase {
             "Java allocator must return to baseline after stub-failure close: before=" + allocBefore + " after=" + allocAfter,
             drift <= 1024 * 1024
         );
+        // Native pool must also return — a Rust-side leak on the failure unwind (un-dropped FFI
+        // array / abandoned batch) would strand pool bytes without moving the Java allocator.
+        assertNativePoolReturnsToBaseline(poolBefore, 1024 * 1024);
     }
 
     /**
@@ -287,6 +320,7 @@ public class CoordinatorReduceStressIT extends OpenSearchTestCase {
         );
 
         long allocBefore = alloc.getAllocatedMemory();
+        long poolBefore = NativeBridge.getMemoryPoolUsage(runtimeHandle.getPointer());
         DatafusionReduceSink sink = new DatafusionReduceSink(ctx, runtimeHandle);
         // Spawn drain on a VT so the producer's senderSend has somewhere to drain to —
         // matches production where the reduce task body owns reduce().
@@ -361,6 +395,9 @@ public class CoordinatorReduceStressIT extends OpenSearchTestCase {
             allocBefore,
             allocAfter
         );
+        // Native pool must also return after cancel + close — guards against a stranded batch in an
+        // abandoned in-flight pull/send on the cancel unwind.
+        assertNativePoolReturnsToBaseline(poolBefore, 1024 * 1024);
     }
 
     /**
@@ -399,6 +436,7 @@ public class CoordinatorReduceStressIT extends OpenSearchTestCase {
         );
 
         long allocBefore = alloc.getAllocatedMemory();
+        long poolBefore = NativeBridge.getMemoryPoolUsage(runtimeHandle.getPointer());
         DatafusionReduceSink sink = new DatafusionReduceSink(ctx, runtimeHandle);
 
         // NOTE: reduce is intentionally NOT spawned here — this regression
@@ -461,6 +499,9 @@ public class CoordinatorReduceStressIT extends OpenSearchTestCase {
             allocBefore,
             allocAfter
         );
+        // Native pool must also return: the parked (PENDING) send's spawned task holds a cloned
+        // Sender + batch; close() must let it resolve and drop the batch, not strand it.
+        assertNativePoolReturnsToBaseline(poolBefore, 1024 * 1024);
     }
 
     /**
@@ -806,6 +847,7 @@ public class CoordinatorReduceStressIT extends OpenSearchTestCase {
      */
     public void testReduceMultiInputCancelMidFeed() throws Exception {
         long allocatedBefore = alloc.getAllocatedMemory();
+        long poolBefore = NativeBridge.getMemoryPoolUsage(runtimeHandle.getPointer());
         int rowsPerBatch = 2_000;
 
         Schema inputSchema = new Schema(List.of(new Field("x", FieldType.nullable(new ArrowType.Int(64, true)), null)));
@@ -880,6 +922,83 @@ public class CoordinatorReduceStressIT extends OpenSearchTestCase {
         long drift = allocatedAfter - allocatedBefore;
         logger.info("F2: cancel-mid-fan-in alloc before={} after={} drift={}", allocatedBefore, allocatedAfter, drift);
         assertEquals("Java allocator must return to baseline after multi-input cancel + close", 0, drift);
+        // Native pool must also return — both children's in-flight sends are abandoned on cancel.
+        assertNativePoolReturnsToBaseline(poolBefore, 1024 * 1024);
+    }
+
+    /**
+     * Pinning guard for the real reduce drain. Runs an actual coordinator reduce on a virtual
+     * thread, fed slowly so the drain genuinely parks on {@code stream_next} between batches (the
+     * exact point that, under the old synchronous {@code block_on}, held a native frame on the VT's
+     * stack and pinned its carrier). A JFR recording counts {@code jdk.VirtualThreadPinned} events
+     * raised on the reduce VT during the drain; the async path must produce ZERO.
+     *
+     * <p>Unlike a synthetic {@code CompletableFuture.join} micro-test (which only exercises the JDK),
+     * this drives our production path — {@code DatafusionReduceSink.reduce} →
+     * {@code DatafusionResultStream.BatchIterator} (async) → {@code streamNextAsync}. Reverting that
+     * iterator to the synchronous pull (or reintroducing {@code block_on}) makes the reduce VT pin
+     * and fails this test.
+     */
+    public void testReduceDrainDoesNotPinCarrier() throws Exception {
+        // VT thread-name prefix so we attribute pins to OUR reduce, not unrelated JDK/infra VTs.
+        final String reduceThreadName = "reduce-pin-probe-vt";
+        final AtomicInteger pinsOnReduceVt = new AtomicInteger();
+
+        // JFR is part of the JDK 25 baseline; if it genuinely can't start, failing loudly is correct.
+        try (RecordingStream rs = new RecordingStream()) {
+            rs.enable("jdk.VirtualThreadPinned").withThreshold(Duration.ofNanos(1));
+            rs.onEvent("jdk.VirtualThreadPinned", e -> {
+                // The event's own thread is the pinned virtual thread.
+                var et = e.getThread();
+                if (et != null && et.getJavaName() != null && et.getJavaName().startsWith(reduceThreadName)) {
+                    pinsOnReduceVt.incrementAndGet();
+                }
+            });
+            rs.startAsync();
+
+            Schema inputSchema = new Schema(List.of(new Field("x", FieldType.nullable(new ArrowType.Int(64, true)), null)));
+            byte[] substrait = buildSumSubstrait();
+            CapturingSink downstream = new CapturingSink();
+            ExchangeSinkContext ctx = new ExchangeSinkContext(
+                "q-pin",
+                0,
+                0L,
+                substrait,
+                alloc,
+                List.of(new ExchangeSinkContext.ChildInput(0, buildPassthroughSubstrait(INPUT_ID))),
+                downstream
+            );
+
+            DatafusionReduceSink sink = new DatafusionReduceSink(ctx, runtimeHandle);
+            PlainActionFuture<Void> drainDone = PlainActionFuture.newFuture();
+            // Run reduce on a NAMED virtual thread (matches QueryContext.localTaskExecutor's VT model)
+            // so the JFR filter can attribute any pin to this drain specifically.
+            Thread.ofVirtual().name(reduceThreadName).start(() -> sink.reduce(drainDone));
+
+            try {
+                // Feed slowly (sleep between batches) so the drain repeatedly parks on stream_next
+                // waiting for the next batch — the wait that would pin a carrier under block_on.
+                for (int b = 0; b < 20; b++) {
+                    sink.feed(makeConstantBatch(alloc, inputSchema, 1_000, 7L));
+                    Thread.sleep(25);
+                }
+                sink.sinkForChild(0).close();
+                drainDone.actionGet(30, TimeUnit.SECONDS);
+            } finally {
+                sink.close();
+            }
+
+            assertEquals("SUM across 20 × 1k constant-7 rows", 20L * 1_000L * 7L, downstream.total);
+            // Flush the async JFR event stream before sampling the counter (still inside the
+            // try-with-resources so the recording is live during the flush).
+            Thread.sleep(300);
+        }
+
+        assertEquals(
+            "reduce drain on a virtual thread must not pin its carrier (block_on would); pins=" + pinsOnReduceVt.get(),
+            0,
+            pinsOnReduceVt.get()
+        );
     }
 
     // ── Helpers ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
Coordinator reduce's two native waits — stream_next (pull batch) and sender_send (push input) — were synchronous block_on calls that held a platform thread while waiting on data. They now initiate-now,
  complete-via-upcall, so the wait parks on a virtual thread and unmounts its carrier.

  A blocked reduce holding a thread could deadlock against shard fragments competing for the same threads. The old fix was a dedicated analytics_reduce pool to isolate them — a band-aid that a wide enough fan-in
  can still exhaust. Parking releases the carrier, so the cycle can't form and the pool is removed.

  Not a latency change. This removes a deadlock class and simplifies the code.

  1. Java (per-query virtual-thread executor) calls the async FFM entry.
  2. Rust spawns on the IO runtime and returns immediately — no block_on, no native frame held.
  3. Java parks on a CompletableFuture; on a virtual thread the carrier unmounts.
  4. The tokio worker fires a completion upcall when the batch/capacity/EOF is ready; the VT resumes.

  Coordinator reduce only. Shard-scan and fetch keep the synchronous df_stream_next (they run on platform threads, where async buys nothing). BatchIterator gained an async flag; backpressure unchanged.

  - analytics_reduce pool (AnalyticsPlugin, QueryContext.reduceExecutor)
  - blocking send_blocking / SendOutcome sender API
  - the "close outStream first to unblock a parked sender" teardown workaround

Testing:
  - Rust unit/integration incl. close-while-pending UAF guard verified under AddressSanitizer; async_entry_gates source-gates guard against reintroducing block_on.
  - VirtualThreadCarrierPinningTests (starvation barrier + jdk.VirtualThreadPinned JFR probe) proves parks don't pin carriers.
  - CoordinatorReduceStressIT (unmuted) checks native + Java memory baselines on cancel/failure paths.

  Follow-up

  QTF / late-materialization still uses the sync pull and pins its carrier; flipping its BatchIterator to async=true would extend the same fix.
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
