### PR TITLE
Remove indexed-path tuning knobs

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/api.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/api.rs
@@ -47,7 +47,7 @@ use datafusion::common::DataFusionError;
 use datafusion::datasource::listing::ListingTableUrl;
 use datafusion::datasource::physical_plan::parquet::{ParquetAccessPlan, RowGroupAccess};
 use datafusion::execution::disk_manager::{DiskManagerBuilder, DiskManagerMode};
-use datafusion::execution::memory_pool::TrackConsumersPool;
+use datafusion::execution::memory_pool::{MemoryPool, TrackConsumersPool};
 use datafusion::execution::runtime_env::RuntimeEnvBuilder;
 use datafusion::execution::cache::cache_manager::CacheManagerConfig;
 use datafusion::execution::RecordBatchStream;
@@ -63,10 +63,16 @@ use roaring::RoaringBitmap;
 use crate::cancellation;
 use crate::cross_rt_stream::CrossRtStream;
 use crate::custom_cache_manager::CustomCacheManager;
+use crate::datafusion_query_config::DatafusionQueryConfig;
+use crate::helper::{build_query_runtime_env_with_store, new_query_tracking_context};
+use crate::indexed_executor::execute_indexed_query;
 use crate::local_executor::LocalSession;
 use crate::memory::{DynamicLimitHandle, DynamicLimitPool};
+use crate::memory_guard::{per_query_spill_budget, SpillBudget};
 use crate::partition_stream::PartitionStreamSender;
-use crate::query_tracker::{self, QueryTrackingContext};
+use crate::phantom_corrector::PhantomCorrector;
+use crate::query_executor;
+use crate::query_tracker::{self, QueryTrackingContext, QueryType};
 use crate::runtime_manager::RuntimeManager;
 use crate::shard_table_provider::{ShardTableConfig, ShardTableProvider};
 
@@ -843,54 +849,23 @@ pub async unsafe fn execute_query(
     let runtime = &*(runtime_ptr as *const DataFusionRuntime);
     let cpu_executor = manager.cpu_executor();
 
-    // Create per-query context — auto-registers in the global registry
+    // Create per-query context (auto-registers in the global registry) and extract
+    // its per-query memory pool overlaying the global pool.
     let global_pool = runtime.runtime_env.memory_pool.clone();
-    let mut query_context = QueryTrackingContext::new(context_id, global_pool.clone(), query_tracker::QueryType::Shard);
+    let (mut query_context, query_memory_pool) = new_query_tracking_context(
+        context_id,
+        global_pool.clone(),
+        QueryType::Shard,
+    );
 
-    let query_memory_pool = query_context
-        .memory_pool()
-        .map(|p| p as Arc<dyn datafusion::execution::memory_pool::MemoryPool>);
+    // Apply disk-pressure capping + memory budget, attaching phantom
+    // reservation/corrector to the query context.
+    let (effective_config, phantom_corrector) =
+        resolve_effective_config(shard_view, runtime, &global_pool, &query_config, &mut query_context);
 
-    // Check disk pressure: when spill is on and disk is dangerously low, reduce
-    // parallelism so each query produces less spill volume. When spill is off, disk
-    // health is irrelevant — there is no spill to throttle, so parallelism stays at
-    // the configured value. One statvfs call (~1µs) only on the enabled path.
-    let disk_capped_partitions = match crate::memory_guard::per_query_spill_budget() {
-        crate::memory_guard::SpillBudget::Critical => 1,
-        crate::memory_guard::SpillBudget::Disabled
-        | crate::memory_guard::SpillBudget::Available(_) => query_config.target_partitions,
-    };
-
-    // Acquire memory budget: reserve phantom for untracked memory.
-    // Best-effort from cached metadata (zero I/O). If not cached, skip budget
-    // — first query warms the cache, subsequent queries benefit.
-    let (effective_config, phantom_corrector) = {
-        let mut cfg = query_config.clone();
-        cfg.target_partitions = disk_capped_partitions;
-        let corrector = if let Some(budget) = try_acquire_budget_from_cache(shard_view, runtime, &global_pool, &cfg) {
-            cfg.target_partitions = budget.target_partitions;
-            cfg.batch_size = budget.batch_size;
-            let batches_in_pipeline = budget.target_partitions * 3 + 2; // partitions × multiplier + output channel(2)
-            let estimated_batch_bytes = if budget.phantom_bytes > 0 && batches_in_pipeline > 0 {
-                budget.phantom_bytes / batches_in_pipeline
-            } else {
-                cfg.batch_size * 100 // fallback
-            };
-            let corrector = Arc::new(crate::phantom_corrector::PhantomCorrector::new_from_metadata(
-                budget.phantom_bytes, estimated_batch_bytes, batches_in_pipeline,
-            ));
-            query_context.set_phantom_reservation(budget.phantom_reservation);
-            Some(query_context.set_phantom_corrector(corrector))
-        } else {
-            None
-        };
-        (cfg, corrector)
-    };
-
-    // Peek at plan bytes for routing signals.
-    // - is_indexed: index_filter UDF present (indexed query path)
-    // - has_row_id: __row_id__ column requested (QTF query phase)
-    let (is_indexed, has_row_id) = inspect_plan_bytes(plan_bytes);
+    // Route to the indexed executor when the plan has an index_filter UDF or
+    // requests __row_id__ (QTF query phase); otherwise the ListingTable path.
+    let use_indexed = use_indexed_path(plan_bytes);
 
     // Register cancellation token.
     let token = query_tracker::get_cancellation_token(context_id);
@@ -901,32 +876,19 @@ pub async unsafe fn execute_query(
     // in single-JVM test topologies where coordinator and data node share a gate.
 
     let query_future = async move {
-        // Routing logic:
-        // 1. Indexed query (has index_filter) → always indexed path
-        // 2. Has __row_id__ but not indexed (non-indexed + sort) → consult QueryStrategy
-        //    - ListingTable → vanilla path with ShardTableProvider + ProjectRowIdOptimizer
-        //    - IndexedPredicateOnly → indexed path (position-based row IDs)
-        //    - None → vanilla path (no row ID computation)
-        // 3. Neither → vanilla path
-        // Engine-internal point lookups pass an empty plan, so is_indexed/has_row_id are both
-        // false and this naturally resolves to the vanilla ListingTable path.
-        let use_indexed = is_indexed
-            || (has_row_id && effective_config.query_strategy != crate::datafusion_query_config::QueryStrategy::ListingTable);
-
         if use_indexed {
-            let qc = Arc::new(effective_config);
-            crate::indexed_executor::execute_indexed_query(
+            execute_indexed_query(
                 plan_bytes.to_vec(),
                 table_name.to_string(),
                 shard_view,
                 runtime,
                 cpu_executor,
                 query_memory_pool,
-                qc,
+                effective_config,
                 context_id,
             ).await
         } else {
-            crate::query_executor::execute_query(
+            query_executor::execute_query(
                 shard_view.table_path.clone(),
                 shard_view.object_metas.clone(),
                 table_name.to_string(),
@@ -980,17 +942,17 @@ pub async unsafe fn fetch_by_row_ids(
 ) -> Result<i64, DataFusionError> {
     use crate::indexed_table::row_selection::build_row_selection_with_min_skip_run;
     use crate::indexed_table::segment_info::build_segments;
-    use crate::query_executor::{build_query_runtime_env, store_url_from_table_path, wrap_stream_as_handle};
+    use crate::query_executor::{store_url_from_table_path, wrap_stream_as_handle};
 
     // ── 1. Build RuntimeEnv + SessionContext ──
 
-    let runtime_env = build_query_runtime_env(runtime, &shard_view.table_path, shard_view.object_metas.as_ref())?;
-
-    // Register shard-specific object store on file:// scheme for this query.
-    runtime_env.register_object_store(
-        &url::Url::parse("file://").unwrap(),
+    let runtime_env = build_query_runtime_env_with_store(
+        runtime,
+        &shard_view.table_path,
+        shard_view.object_metas.as_ref(),
         Arc::clone(&shard_view.store),
-    );
+        None,
+    )?;
 
     let mut config = SessionConfig::new();
     config.options_mut().execution.parquet.pushdown_filters = true;
@@ -1121,15 +1083,48 @@ pub async unsafe fn fetch_by_row_ids(
     Ok(wrap_stream_as_handle(df_stream, manager.cpu_executor(), runtime, context_id))
 }
 
-/// Inspect substrait plan bytes for routing signals.
-/// Returns (has_index_filter, has_row_id).
-fn inspect_plan_bytes(plan_bytes: &[u8]) -> (bool, bool) {
+/// Resolve the dynamic spill limit based on available disk space.
+/// Uses 80% of available space on the spill directory's filesystem.
+/// Falls back to 8GB if disk space cannot be determined.
+fn resolve_dynamic_spill_limit(spill_dir: &str) -> u64 {
+    const FRACTION: f64 = 0.80;
+    const FALLBACK: u64 = 8 * 1024 * 1024 * 1024; // 8GB
+
+    let _ = std::fs::create_dir_all(spill_dir);
+
+    match crate::memory_guard::available_disk_space(spill_dir) {
+        Some(available) => {
+            let limit = (available as f64 * FRACTION) as u64;
+            log::info!(
+                "Dynamic spill limit: {} bytes (80% of {} available on {})",
+                limit, available, spill_dir
+            );
+            limit
+        }
+        None => {
+            log::warn!(
+                "Could not determine disk space for '{}', using fallback {}GB",
+                spill_dir, FALLBACK / (1024 * 1024 * 1024)
+            );
+            FALLBACK
+        }
+    }
+}
+
+/// Whether a shard query routes to the indexed executor (vs the ListingTable path),
+/// decided by scanning the substrait plan bytes for two needles: the `index_filter`
+/// UDF name and the `__row_id__` column name. Either one → indexed path.
+///
+/// This is a cheap byte-substring scan, not a parse. A false positive on
+/// `index_filter` takes the indexed path and then fails in `execute_indexed_query`
+/// when `classify_filter` returns `None` (no automatic retry on the ListingTable
+/// path) — unreachable in practice because the needle is not a valid DataFusion
+/// identifier a plan would otherwise contain.
+fn use_indexed_path(plan_bytes: &[u8]) -> bool {
     const INDEX_FILTER: &[u8] = b"index_filter";
     const ROW_ID: &[u8] = crate::ROW_ID_COLUMN_NAME.as_bytes();
-    (
-        plan_bytes.windows(INDEX_FILTER.len()).any(|w| w == INDEX_FILTER),
-        plan_bytes.windows(ROW_ID.len()).any(|w| w == ROW_ID),
-    )
+    plan_bytes.windows(INDEX_FILTER.len()).any(|w| w == INDEX_FILTER)
+        || plan_bytes.windows(ROW_ID.len()).any(|w| w == ROW_ID)
 }
 
 /// Best-effort budget acquisition from cached parquet metadata.
@@ -1138,17 +1133,51 @@ fn inspect_plan_bytes(plan_bytes: &[u8]) -> (bool, bool) {
 /// If cached: extracts the schema + measured row bytes, acquires budget.
 /// If not cached: returns None (first query — skip budget, warm cache).
 /// Zero I/O in all cases.
-/// Best-effort budget acquisition from cached parquet metadata.
-///
-/// Looks up the first file's ParquetMetaData from the file metadata cache.
-/// If cached: extracts the schema + measured row bytes, acquires budget.
-/// If not cached: returns None (first query — skip budget, warm cache).
-/// Zero I/O in all cases.
+fn resolve_effective_config(
+    shard_view: &ShardView,
+    runtime: &DataFusionRuntime,
+    global_pool: &Arc<dyn MemoryPool>,
+    query_config: &DatafusionQueryConfig,
+    query_context: &mut QueryTrackingContext,
+) -> (Arc<DatafusionQueryConfig>, Option<Arc<PhantomCorrector>>) {
+    // Disk pressure: when spill is on and disk is dangerously low, cap parallelism
+    // to 1 so each query produces less spill volume. When spill is off, disk health
+    // is irrelevant — no spill to throttle. One statvfs call (~1µs) only when enabled.
+    let disk_capped_partitions = match per_query_spill_budget() {
+        SpillBudget::Critical => 1,
+        SpillBudget::Disabled | SpillBudget::Available(_) => query_config.target_partitions,
+    };
+
+    // Acquire memory budget: reserve phantom for untracked memory. Best-effort from
+    // cached metadata (zero I/O); if not cached, skip budget (first query warms the
+    // cache, subsequent queries benefit).
+    let mut cfg = query_config.clone();
+    cfg.target_partitions = disk_capped_partitions;
+    let corrector = if let Some(budget) = try_acquire_budget_from_cache(shard_view, runtime, global_pool, &cfg) {
+        cfg.target_partitions = budget.target_partitions;
+        cfg.batch_size = budget.batch_size;
+        let batches_in_pipeline = budget.target_partitions * 3 + 2; // partitions × multiplier + output channel(2)
+        let estimated_batch_bytes = if budget.phantom_bytes > 0 && batches_in_pipeline > 0 {
+            budget.phantom_bytes / batches_in_pipeline
+        } else {
+            cfg.batch_size * 100 // fallback
+        };
+        let corrector = Arc::new(PhantomCorrector::new_from_metadata(
+            budget.phantom_bytes, estimated_batch_bytes, batches_in_pipeline,
+        ));
+        query_context.set_phantom_reservation(budget.phantom_reservation);
+        Some(query_context.set_phantom_corrector(corrector))
+    } else {
+        None
+    };
+    (Arc::new(cfg), corrector)
+}
+
 fn try_acquire_budget_from_cache(
     shard_view: &ShardView,
     runtime: &DataFusionRuntime,
-    pool: &Arc<dyn datafusion::execution::memory_pool::MemoryPool>,
-    config: &crate::datafusion_query_config::DatafusionQueryConfig,
+    pool: &Arc<dyn MemoryPool>,
+    config: &DatafusionQueryConfig,
 ) -> Option<crate::query_budget::QueryMemoryBudget> {
     use datafusion::execution::cache::CacheAccessor;
     use parquet::arrow::parquet_to_arrow_schema;

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/datafusion_query_config.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/datafusion_query_config.rs
@@ -5,28 +5,7 @@
 //! setup time and copied into hot-path fields — never dereferenced on a
 //! per-batch or per-row hot path.
 
-use crate::indexed_table::eval::single_collector::CollectorCallStrategy;
 use crate::indexed_table::stream::FilterStrategy;
-
-/// Selects which execution path computes shard-global row IDs.
-///
-/// Selects which execution path computes shard-global row IDs.
-/// `None` = no row ID computation (baseline — reads ___row_id as a regular column).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum QueryStrategy {
-    /// No row ID optimizer applied. ___row_id is read as a regular column
-    /// without any row_base addition. Returns local (per-file) row IDs only.
-    None,
-    /// ShardTableProvider + ProjectRowIdOptimizer.
-    /// Reads ___row_id from parquet, adds row_base via physical optimizer rewrite.
-    /// Produces shard-global absolute row IDs.
-    ListingTable,
-    /// Predicate-only mode in the indexed executor.
-    /// Uses indexed pipeline (segment partitioning, prefetch, PositionMap).
-    /// Does NOT read ___row_id from disk — computes from position:
-    /// global_base + rg.first_row + position_in_rg. Zero column I/O for row ID.
-    IndexedPredicateOnly,
-}
 
 /// Engine-internal point lookup driven through the normal `df_execute_query`
 /// entry point. When active, the Substrait `plan_ptr` is ignored and the plan
@@ -70,8 +49,8 @@ pub struct DatafusionQueryConfig {
     pub batch_size: usize,
     // Single query concurrency
     pub target_partitions: usize,
-    /// DataFusion's own decode-time predicate pushdown on the vanilla path.
-    pub parquet_pushdown_filters: bool,
+    /// DataFusion's own decode-time predicate pushdown on the ListingTable path.
+    pub listing_table_pushdown_filters: bool,
 
     // Indexed-only
     pub min_skip_run_default: usize,
@@ -80,40 +59,14 @@ pub struct DatafusionQueryConfig {
     /// during decode (via `RowFilter` pushdown). Narrow row-granular
     /// selections benefit; block-granular ones don't.
     pub indexed_pushdown_filters: bool,
+    /// Optional override that pins the per-RG `min_skip_run` choice instead of
+    /// letting selectivity decide. Backed by the `datafusion.indexed.force_strategy`
+    /// cluster setting: `None` (wire `-1`) lets the selectivity heuristic run,
+    /// `RowSelection`/`BooleanMask` pin the choice node-wide. See
+    /// `IndexedStream::pick_min_skip_run`.
     pub force_strategy: Option<FilterStrategy>,
-    pub force_pushdown: Option<bool>,
     pub cost_predicate: u32,
     pub cost_collector: u32,
-    /// Maximum number of Collector-leaf FFM calls issued in parallel per
-    /// RG prefetch. 1 = today's fully-sequential behaviour (lowest CPU,
-    /// fastest short-circuit). `target_partitions × max_collector_parallelism`
-    /// bounds total concurrent Lucene threads; default is 1
-    ///
-    /// At higher values, short-circuit savings in AND/OR groups are
-    /// sacrificed (see `BitmapTreeEvaluator::prefetch`): collectors
-    /// beyond the first may run even if their result is not needed.
-    pub max_collector_parallelism: usize,
-    /// How the SingleCollectorEvaluator narrows collector doc ranges
-    /// relative to page-pruning results. `PageRangeSplit` is the default
-    /// — only one collector, so multiple FFM calls per RG is acceptable.
-    pub single_collector_strategy: CollectorCallStrategy,
-    /// How the bitmap tree evaluator narrows collector doc ranges.
-    /// `TightenOuterBounds` is the default — multiple collectors in the
-    /// tree means `PageRangeSplit` would multiply FFM calls.
-    pub tree_collector_strategy: CollectorCallStrategy,
-    /// Strategy for row ID emission on the vanilla path.
-    /// Only consulted when the plan requests row IDs (contains _global_row_id() UDF
-    /// or projects ___row_id).
-    pub query_strategy: QueryStrategy,
-    /// Whether to use bloom filters for row group pruning on the indexed read path.
-    pub bloom_filter_on_read: bool,
-    /// Whether to accept and apply runtime dynamic filters (TopK / join)
-    /// pushed into the indexed scan via physical filter pushdown, pruning row
-    /// groups whose parquet statistics cannot satisfy the tightening predicate.
-    /// Off → `QueryShardExec` declines the pushdown (parent keeps its
-    /// `FilterExec`), so behaviour is identical to before this feature. Exposed
-    /// as a toggle to A/B the performance impact.
-    pub indexed_dynamic_filter_pushdown: bool,
 }
 
 /// FFM wire format. Must stay in lockstep with the Java `MemoryLayout`.
@@ -129,26 +82,14 @@ pub struct WireDatafusionQueryConfig {
     pub min_skip_run_default: i64,
     pub min_skip_run_selectivity_threshold: f64,
     /// 0 = false, 1 = true
-    pub parquet_pushdown_filters: i32,
+    pub listing_table_pushdown_filters: i32,
     /// 0 = false, 1 = true
     pub indexed_pushdown_filters: i32,
-    /// -1 = None, 0 = RowSelection, 1 = BooleanMask
+    /// -1 = None, 0 = RowSelection, 1 = BooleanMask.
+    /// Backed by the `datafusion.indexed.force_strategy` cluster setting.
     pub force_strategy: i32,
-    /// -1 = None, 0 = false, 1 = true
-    pub force_pushdown: i32,
     pub cost_predicate: i32,
     pub cost_collector: i32,
-    pub max_collector_parallelism: i32,
-    /// 0 = FullRange, 1 = TightenOuterBounds, 2 = PageRangeSplit
-    pub single_collector_strategy: i32,
-    /// 0 = FullRange, 1 = TightenOuterBounds, 2 = PageRangeSplit
-    pub tree_collector_strategy: i32,
-    /// 0 = None (baseline), 1 = ListingTable, 2 = IndexedPredicateOnly
-    pub query_strategy: i32,
-    /// 0 = false, 1 = true
-    pub bloom_filter_on_read: i32,
-    /// 0 = false, 1 = true
-    pub indexed_dynamic_filter_pushdown: i32,
 }
 
 impl DatafusionQueryConfig {
@@ -160,22 +101,13 @@ impl DatafusionQueryConfig {
         Self {
             batch_size: 8192,
             target_partitions: 4,
-            parquet_pushdown_filters: false,
+            listing_table_pushdown_filters: false,
             min_skip_run_default: 1024,
             min_skip_run_selectivity_threshold: 0.03,
             indexed_pushdown_filters: true,
             force_strategy: None,
-            force_pushdown: None,
             cost_predicate: 1,
             cost_collector: 10,
-            max_collector_parallelism: 1,
-            single_collector_strategy: CollectorCallStrategy::PageRangeSplit,
-            tree_collector_strategy: CollectorCallStrategy::TightenOuterBounds,
-            query_strategy: QueryStrategy::None,
-            bloom_filter_on_read: true,
-            // On by default — matches the Java cluster-setting default
-            // (`datafusion.indexed.dynamic_filter_pushdown`). Toggle to A/B perf.
-            indexed_dynamic_filter_pushdown: true,
         }
     }
 
@@ -209,45 +141,22 @@ impl DatafusionQueryConfig {
     }
 
     fn from_wire(w: &WireDatafusionQueryConfig) -> Self {
-        let force_strategy = match w.force_strategy {
-            0 => Some(FilterStrategy::RowSelection),
-            1 => Some(FilterStrategy::BooleanMask),
-            _ => None,
-        };
-        let force_pushdown = match w.force_pushdown {
-            0 => Some(false),
-            1 => Some(true),
-            _ => None,
-        };
         Self {
             batch_size: w.batch_size as usize,
             target_partitions: w.target_partitions as usize,
-            parquet_pushdown_filters: w.parquet_pushdown_filters != 0,
+            listing_table_pushdown_filters: w.listing_table_pushdown_filters != 0,
             min_skip_run_default: w.min_skip_run_default as usize,
             min_skip_run_selectivity_threshold: w.min_skip_run_selectivity_threshold,
             indexed_pushdown_filters: w.indexed_pushdown_filters != 0,
-            force_strategy,
-            force_pushdown,
+            // `force_strategy` is backed by a cluster setting; `-1` means None
+            // (selectivity heuristic decides).
+            force_strategy: match w.force_strategy {
+                0 => Some(FilterStrategy::RowSelection),
+                1 => Some(FilterStrategy::BooleanMask),
+                _ => None,
+            },
             cost_predicate: w.cost_predicate as u32,
             cost_collector: w.cost_collector as u32,
-            max_collector_parallelism: (w.max_collector_parallelism as usize).max(1),
-            single_collector_strategy: match w.single_collector_strategy {
-                0 => CollectorCallStrategy::FullRange,
-                1 => CollectorCallStrategy::TightenOuterBounds,
-                _ => CollectorCallStrategy::PageRangeSplit,
-            },
-            tree_collector_strategy: match w.tree_collector_strategy {
-                0 => CollectorCallStrategy::FullRange,
-                2 => CollectorCallStrategy::PageRangeSplit,
-                _ => CollectorCallStrategy::TightenOuterBounds,
-            },
-            query_strategy: match w.query_strategy {
-                1 => QueryStrategy::ListingTable,
-                2 => QueryStrategy::IndexedPredicateOnly,
-                _ => QueryStrategy::None,
-            },
-            bloom_filter_on_read: w.bloom_filter_on_read != 0,
-            indexed_dynamic_filter_pushdown: w.indexed_dynamic_filter_pushdown != 0,
         }
     }
 }
@@ -268,8 +177,8 @@ impl DatafusionQueryConfigBuilder {
         self.0.target_partitions = v;
         self
     }
-    pub fn parquet_pushdown_filters(mut self, v: bool) -> Self {
-        self.0.parquet_pushdown_filters = v;
+    pub fn listing_table_pushdown_filters(mut self, v: bool) -> Self {
+        self.0.listing_table_pushdown_filters = v;
         self
     }
     pub fn min_skip_run_default(mut self, v: usize) -> Self {
@@ -288,36 +197,12 @@ impl DatafusionQueryConfigBuilder {
         self.0.force_strategy = v;
         self
     }
-    pub fn force_pushdown(mut self, v: Option<bool>) -> Self {
-        self.0.force_pushdown = v;
-        self
-    }
     pub fn cost_predicate(mut self, v: u32) -> Self {
         self.0.cost_predicate = v;
         self
     }
     pub fn cost_collector(mut self, v: u32) -> Self {
         self.0.cost_collector = v;
-        self
-    }
-    pub fn max_collector_parallelism(mut self, v: usize) -> Self {
-        self.0.max_collector_parallelism = v;
-        self
-    }
-    pub fn single_collector_strategy(mut self, v: CollectorCallStrategy) -> Self {
-        self.0.single_collector_strategy = v;
-        self
-    }
-    pub fn tree_collector_strategy(mut self, v: CollectorCallStrategy) -> Self {
-        self.0.tree_collector_strategy = v;
-        self
-    }
-    pub fn bloom_filter_on_read(mut self, v: bool) -> Self {
-        self.0.bloom_filter_on_read = v;
-        self
-    }
-    pub fn indexed_dynamic_filter_pushdown(mut self, v: bool) -> Self {
-        self.0.indexed_dynamic_filter_pushdown = v;
         self
     }
     pub fn build(self) -> DatafusionQueryConfig {
@@ -334,15 +219,13 @@ mod tests {
         let c = DatafusionQueryConfig::test_default();
         assert_eq!(c.batch_size, 8192);
         assert_eq!(c.target_partitions, 4);
-        assert!(!c.parquet_pushdown_filters);
+        assert!(!c.listing_table_pushdown_filters);
         assert_eq!(c.min_skip_run_default, 1024);
         assert!((c.min_skip_run_selectivity_threshold - 0.03).abs() < 1e-9);
         assert!(c.indexed_pushdown_filters);
         assert_eq!(c.force_strategy, None);
-        assert_eq!(c.force_pushdown, None);
         assert_eq!(c.cost_predicate, 1);
         assert_eq!(c.cost_collector, 10);
-        assert!(c.indexed_dynamic_filter_pushdown);
     }
 
     #[test]
@@ -370,33 +253,23 @@ mod tests {
             target_partitions: 8,
             min_skip_run_default: 512,
             min_skip_run_selectivity_threshold: 0.07,
-            parquet_pushdown_filters: 1,
+            listing_table_pushdown_filters: 1,
             indexed_pushdown_filters: 0,
             force_strategy: 1,
-            force_pushdown: 0,
             cost_predicate: 3,
             cost_collector: 17,
-            max_collector_parallelism: 4,
-            single_collector_strategy: 2,
-            tree_collector_strategy: 1,
-            query_strategy: 1,
-            bloom_filter_on_read: 1,
-            indexed_dynamic_filter_pushdown: 1,
         };
         let ptr = &wire as *const _ as i64;
         let c = unsafe { DatafusionQueryConfig::from_ffm_ptr(ptr) };
         assert_eq!(c.batch_size, 16384);
-        assert!(c.indexed_dynamic_filter_pushdown);
         assert_eq!(c.target_partitions, 8);
         assert_eq!(c.min_skip_run_default, 512);
         assert!((c.min_skip_run_selectivity_threshold - 0.07).abs() < 1e-9);
-        assert!(c.parquet_pushdown_filters);
+        assert!(c.listing_table_pushdown_filters);
         assert!(!c.indexed_pushdown_filters);
         assert_eq!(c.force_strategy, Some(FilterStrategy::BooleanMask));
-        assert_eq!(c.force_pushdown, Some(false));
         assert_eq!(c.cost_predicate, 3);
         assert_eq!(c.cost_collector, 17);
-        assert_eq!(c.query_strategy, QueryStrategy::ListingTable);
     }
 
     #[test]
@@ -406,24 +279,14 @@ mod tests {
             target_partitions: 4,
             min_skip_run_default: 1024,
             min_skip_run_selectivity_threshold: 0.03,
-            parquet_pushdown_filters: 0,
+            listing_table_pushdown_filters: 0,
             indexed_pushdown_filters: 1,
             force_strategy: -1,
-            force_pushdown: -1,
             cost_predicate: 1,
             cost_collector: 10,
-            max_collector_parallelism: 2,
-            single_collector_strategy: 2,
-            tree_collector_strategy: 1,
-            query_strategy: 0,
-            bloom_filter_on_read: 0,
-            indexed_dynamic_filter_pushdown: 0,
         };
         let ptr = &wire as *const _ as i64;
         let c = unsafe { DatafusionQueryConfig::from_ffm_ptr(ptr) };
         assert_eq!(c.force_strategy, None);
-        assert!(!c.indexed_dynamic_filter_pushdown);
-        assert_eq!(c.force_pushdown, None);
-        assert_eq!(c.query_strategy, QueryStrategy::None);
     }
 }

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/ffm.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/ffm.rs
@@ -1129,14 +1129,12 @@ pub unsafe extern "C" fn df_execute_with_context(
     let mgr_for_spawn = Arc::clone(&mgr);
 
     // Route based on whether the session was configured for indexed execution,
-    // or if the plan projects __row_id__ (QTF query phase) under a non-ListingTable
-    // fetch strategy.
+    // or if the plan projects __row_id__ (QTF query phase). QTF row-id computation
+    // always runs in the indexed executor.
     let has_row_id = plan_bytes
         .windows(crate::ROW_ID_COLUMN_NAME.len())
         .any(|w| w == crate::ROW_ID_COLUMN_NAME.as_bytes());
-    let query_strategy = session_handle.query_config.query_strategy;
-    let use_indexed = session_handle.indexed_config.is_some()
-        || (has_row_id && query_strategy != crate::datafusion_query_config::QueryStrategy::ListingTable);
+    let use_indexed = session_handle.indexed_config.is_some() || has_row_id;
     if use_indexed {
         // Extract target_partitions BEFORE boxing into raw pointer (session_handle is consumed).
         let partition_weight = session_handle.query_config.target_partitions.max(1) as u32;

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/helper.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/helper.rs
@@ -1,0 +1,185 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+//! Small shared helpers for the query execution paths.
+
+use std::sync::Arc;
+
+use datafusion::common::DataFusionError;
+use datafusion::datasource::file_format::parquet::ParquetFormat;
+use datafusion::datasource::listing::{ListingOptions, ListingTable, ListingTableConfig, ListingTableUrl};
+use datafusion::execution::context::SessionContext;
+use datafusion::execution::memory_pool::MemoryPool;
+use datafusion::execution::runtime_env::{RuntimeEnv, RuntimeEnvBuilder};
+use datafusion::execution::session_state::SessionStateBuilder;
+use datafusion::prelude::SessionConfig;
+use log::error;
+use object_store::{ObjectMeta, ObjectStore};
+
+use crate::agg_mode::physical_optimizer_rules_without_combine;
+use crate::api::DataFusionRuntime;
+use crate::datafusion_query_config::DatafusionQueryConfig;
+use crate::indexed_table::substrait_to_tree::{create_delegation_possible_udf, create_index_filter_udf};
+use crate::query_executor::build_query_runtime_env;
+use crate::query_tracker::{QueryTrackingContext, QueryType};
+use crate::schema_coerce::coerce_inferred_schema;
+use crate::session_context::build_file_sort_order;
+use crate::udaf;
+use crate::udf;
+
+/// Creates a per-query [`QueryTrackingContext`] (auto-registered in the global
+/// registry) and extracts its per-query memory pool as a `dyn MemoryPool`.
+///
+/// The returned pool is `Some` only when tracking is active; pass it to the
+/// executor so the query's allocations are charged against a pool that wraps
+/// `global_pool` (global limits stay enforced). Returns the context too so the
+/// caller can attach phantom reservations/correctors before execution.
+pub fn new_query_tracking_context(
+    context_id: i64,
+    global_pool: Arc<dyn MemoryPool>,
+    query_type: QueryType,
+) -> (QueryTrackingContext, Option<Arc<dyn MemoryPool>>) {
+    let query_context = QueryTrackingContext::new(context_id, global_pool, query_type);
+    let query_memory_pool = query_context.memory_pool().map(|p| p as Arc<dyn MemoryPool>);
+    (query_context, query_memory_pool)
+}
+
+/// Builds the per-query `RuntimeEnv` and registers the shard-specific object store.
+///
+/// Combines the three steps every query-execution entry point shares:
+/// 1. Build a per-query `RuntimeEnv` with the list-files cache pre-populated for
+///    `table_path` / `object_metas` (via [`build_query_runtime_env`]).
+/// 2. If `query_memory_pool` is `Some`, rebuild the env with that pool overlaid.
+///    The per-query pool wraps the global pool, so global limits stay enforced.
+/// 3. Register `shard_store` on the `file://` scheme so this query's reads route
+///    through `TieredObjectStore` (local + remote) or the default `LocalFileSystem`.
+pub fn build_query_runtime_env_with_store(
+    runtime: &DataFusionRuntime,
+    table_path: &ListingTableUrl,
+    object_metas: &[ObjectMeta],
+    shard_store: Arc<dyn ObjectStore>,
+    query_memory_pool: Option<Arc<dyn MemoryPool>>,
+) -> Result<Arc<RuntimeEnv>, DataFusionError> {
+    // Build per-query RuntimeEnv with list-files cache pre-populated.
+    let runtime_env = build_query_runtime_env(runtime, table_path, object_metas)?;
+
+    // If a per-query memory pool is provided, rebuild with it overlaid.
+    // The per-query pool wraps the global pool, so global limits are still enforced.
+    let runtime_env = if let Some(pool) = query_memory_pool {
+        Arc::from(
+            RuntimeEnvBuilder::from_runtime_env(&runtime_env)
+                .with_memory_pool(pool)
+                .build()
+                .map_err(|e| {
+                    error!("Failed to build runtime env with query pool: {}", e);
+                    e
+                })?,
+        )
+    } else {
+        runtime_env
+    };
+
+    // Register shard-specific object store on file:// scheme for this query.
+    // Routes reads through TieredObjectStore (local + remote) or default LocalFileSystem.
+    runtime_env.register_object_store(&url::Url::parse("file://").unwrap(), shard_store);
+
+    Ok(runtime_env)
+}
+
+/// Registers a standard DataFusion `ListingTable` for `table_path` under
+/// `table_name` so the substrait consumer can resolve the table.
+///
+/// Shared by the vanilla and indexed execution paths. Infers + coerces the
+/// schema, and — when `sort_fields`/`sort_orders` describe an `index.sort.field`
+/// — declares the per-file sort order to DataFusion (see
+/// [`build_file_sort_order`] for what that buys and its case/nulls caveats).
+/// Pass empty slices to skip the sort-order declaration.
+pub async fn register_listing_table(
+    ctx: &SessionContext,
+    table_name: &str,
+    table_path: ListingTableUrl,
+    sort_fields: &[String],
+    sort_orders: &[String],
+) -> Result<(), DataFusionError> {
+    let mut listing_options = ListingOptions::new(Arc::new(ParquetFormat::new()))
+        .with_file_extension(".parquet")
+        .with_collect_stat(true);
+    if let Some(sort_exprs) = build_file_sort_order(sort_fields, sort_orders) {
+        listing_options = listing_options.with_file_sort_order(vec![sort_exprs]);
+    }
+
+    let resolved_schema = listing_options
+        .infer_schema(&ctx.state(), &table_path)
+        .await
+        .map_err(|e| {
+            error!("Failed to infer schema: {}", e);
+            e
+        })?;
+    let resolved_schema = coerce_inferred_schema(resolved_schema);
+
+    let table_config = ListingTableConfig::new(table_path)
+        .with_listing_options(listing_options)
+        .with_schema(resolved_schema);
+    let provider = Arc::new(ListingTable::try_new(table_config).map_err(|e| {
+        error!("Failed to create listing table: {}", e);
+        e
+    })?);
+    ctx.register_table(table_name, provider).map_err(|e| {
+        error!("Failed to register listing table: {}", e);
+        e
+    })?;
+    Ok(())
+}
+
+/// Builds a per-query [`SessionContext`] shared by the vanilla and indexed paths.
+///
+/// Sets the common execution options (parquet pushdown, target partitions, batch
+/// size) from `query_config`, installs `runtime_env`, and registers the base
+/// scalar/aggregate UDFs.
+///
+/// `target_partitions` is passed explicitly because the paths differ: the vanilla
+/// path uses `query_config.target_partitions`, while the indexed path fans out via
+/// its own IndexedExec partitions and only needs a sane value here for any
+/// post-scan operators.
+///
+/// When `indexed_path` is true, the context is built for the indexed executor:
+/// the physical optimizer drops the combine-partial-final pass, and the indexed
+/// `index_filter` / `delegation_possible` UDFs are registered on top of the base
+/// UDFs. When false, the vanilla path's defaults are used.
+pub fn build_query_session_context(
+    query_config: &DatafusionQueryConfig,
+    runtime_env: Arc<RuntimeEnv>,
+    target_partitions: usize,
+    indexed_path: bool,
+) -> SessionContext {
+    let mut config = SessionConfig::new();
+    config.options_mut().execution.parquet.pushdown_filters = query_config.listing_table_pushdown_filters;
+    config.options_mut().execution.target_partitions = target_partitions.max(1);
+    config.options_mut().execution.batch_size = query_config.batch_size;
+
+    let mut builder = SessionStateBuilder::new()
+        .with_config(config)
+        .with_runtime_env(runtime_env)
+        .with_default_features();
+    if indexed_path {
+        // Indexed executor drives partial/final aggregation itself; drop the
+        // combine-partial-final physical optimizer pass.
+        builder = builder.with_physical_optimizer_rules(physical_optimizer_rules_without_combine());
+    }
+    let state = builder.build();
+
+    let ctx = SessionContext::new_with_state(state);
+    udf::register_all(&ctx);
+    udaf::register_all(&ctx);
+    if indexed_path {
+        // Indexed-path-only UDFs, on top of the base UDFs above.
+        ctx.register_udf(create_index_filter_udf());
+        ctx.register_udf(create_delegation_possible_udf());
+    }
+    ctx
+}

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_executor.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_executor.rs
@@ -25,16 +25,11 @@ use native_bridge_common::log_debug;
 use datafusion::{
     physical_plan::displayable,
     physical_plan::execute_stream,
-    execution::SessionStateBuilder,
-    execution::context::SessionContext,
     common::DataFusionError,
-    prelude::*,
     arrow::datatypes::SchemaRef,
     catalog::Session,
     common::tree_node::{TreeNode, TreeNodeRecursion},
     datasource::{TableProvider, TableType},
-    execution::cache::cache_manager::CachedFileList,
-    execution::cache::{CacheAccessor, DefaultListFilesCache, TableScopedPath},
     execution::memory_pool::MemoryPool,
     execution::object_store::ObjectStoreUrl,
     logical_expr::Expr,
@@ -51,6 +46,7 @@ use substrait::proto::Plan;
 use crate::api::DataFusionRuntime;
 use crate::cross_rt_stream::CrossRtStream;
 use crate::executor::DedicatedExecutor;
+use crate::helper::{build_query_runtime_env_with_store, build_query_session_context, register_listing_table};
 use crate::indexed_table::bool_tree::BoolNode;
 use crate::indexed_table::eval::bitmap_tree::{BitmapTreeEvaluator, CollectorLeafBitmaps};
 use crate::indexed_table::eval::single_collector::SingleCollectorEvaluator;
@@ -60,8 +56,7 @@ use crate::indexed_table::index::RowGroupDocsCollector;
 use crate::indexed_table::page_pruner::PagePruner;
 use crate::indexed_table::segment_info::build_segments;
 use crate::indexed_table::substrait_to_tree::{
-    classify_filter, create_index_filter_udf, expr_to_bool_tree,
-    extract_filter_expr, ExtractionResult, FilterClass,
+    classify_filter, expr_to_bool_tree, extract_filter_expr, ExtractionResult, FilterClass,
 };
 use crate::indexed_table::table_provider::{
     EvaluatorFactory, IndexedTableConfig, IndexedTableProvider, SegmentFileInfo,
@@ -99,63 +94,29 @@ pub async fn execute_indexed_query(
     context_id: i64,
 ) -> Result<i64, DataFusionError> {
     let num_partitions = query_config.target_partitions.max(1);
-    // Share caches with the global runtime (same as vanilla path): list-files
-    // pre-populated with the reader's object_metas, file-metadata and
-    // file-statistics inherited from the global runtime for cross-query reuse.
-    let list_file_cache = Arc::new(DefaultListFilesCache::default());
-    let table_scoped_path = TableScopedPath {
-        table: None,
-        path: shard_view.table_path.prefix().clone(),
-    };
-    list_file_cache.put(&table_scoped_path, CachedFileList::new(shard_view.object_metas.as_ref().clone()));
-
-    let mut runtime_env_builder = crate::query_executor::query_runtime_env_builder(runtime, list_file_cache);
-    if let Some(pool) = query_memory_pool {
-        runtime_env_builder = runtime_env_builder.with_memory_pool(pool);
-    }
-    let runtime_env = runtime_env_builder
-        .build()
-        .map_err(|e| DataFusionError::Execution(format!("runtime env: {}", e)))?;
-
-    // Register shard-specific object store on file:// scheme for this query.
-    runtime_env.register_object_store(
-        &url::Url::parse("file://").unwrap(),
+    // Build the per-query RuntimeEnv (list-files cache pre-populated, optional
+    // per-query pool overlay) and register the shard object store — shared with
+    // the vanilla path. File-metadata and file-statistics caches are inherited
+    // from the global runtime for cross-query reuse.
+    let runtime_env = build_query_runtime_env_with_store(
+        runtime,
+        &shard_view.table_path,
+        shard_view.object_metas.as_ref(),
         Arc::clone(&shard_view.store),
-    );
+        query_memory_pool,
+    )?;
 
-    let mut config = SessionConfig::new();
-    config.options_mut().execution.parquet.pushdown_filters = query_config.parquet_pushdown_filters;
-    // Indexed path fans out via IndexedExec partitions (derived from
-    // num_partitions), not DataFusion's. But DF wants a sane value here
-    // for any post-scan operators it may add.
-    config.options_mut().execution.target_partitions = num_partitions.max(1);
-    config.options_mut().execution.batch_size = query_config.batch_size;
-    let state = SessionStateBuilder::new()
-        .with_config(config)
-        .with_runtime_env(Arc::from(runtime_env))
-        .with_default_features()
-        .with_physical_optimizer_rules(crate::agg_mode::physical_optimizer_rules_without_combine())
-        .build();
-    let ctx = SessionContext::new_with_state(state);
-    ctx.register_udf(create_index_filter_udf());
-    ctx.register_udf(crate::indexed_table::substrait_to_tree::create_delegation_possible_udf());
-    crate::udf::register_all(&ctx);
-    crate::udaf::register_all(&ctx);
+    // Build a fresh session context per query. The indexed path fans out via
+    // IndexedExec partitions (derived from num_partitions), not DataFusion's, but
+    // DF still wants a sane value for any post-scan operators it may add. The
+    // `indexed_path` flag also drops the combine-partial-final optimizer pass and
+    // registers the indexed-only index_filter / delegation_possible UDFs.
+    let ctx = build_query_session_context(&query_config, runtime_env, num_partitions, true);
 
-    // Register default ListingTable so substrait consumer can resolve the table
-    let listing_options = datafusion::datasource::listing::ListingOptions::new(
-        Arc::new(datafusion::datasource::file_format::parquet::ParquetFormat::new()))
-        .with_file_extension(".parquet")
-        .with_collect_stat(true);
-    let resolved_schema = listing_options
-        .infer_schema(&ctx.state(), &shard_view.table_path)
-        .await?;
-    let resolved_schema = crate::schema_coerce::coerce_inferred_schema(resolved_schema);
-    let table_config = datafusion::datasource::listing::ListingTableConfig::new(shard_view.table_path.clone())
-        .with_listing_options(listing_options)
-        .with_schema(resolved_schema);
-    let provider = Arc::new(datafusion::datasource::listing::ListingTable::try_new(table_config)?);
-    ctx.register_table(&table_name, provider)?;
+    // Register default ListingTable so substrait consumer can resolve the table.
+    // No sort-order declaration on the indexed path (empty slices) — the indexed
+    // executor drives ordering itself via IndexedExec.
+    register_listing_table(&ctx, &table_name, shard_view.table_path.clone(), &[], &[]).await?;
 
     // Build SessionContextHandle and delegate to execute_indexed_with_context
     let handle = crate::session_context::SessionContextHandle {
@@ -1137,10 +1098,9 @@ async unsafe fn execute_indexed_with_context_inner(
                 .as_ref()
                 .and_then(|expr| build_pruning_predicate(expr, Arc::clone(&schema_for_pruner)));
 
-            let call_strategy = query_config.single_collector_strategy;
+            let call_strategy = CollectorCallStrategy::PageRangeSplit;
             let bloom_store = Arc::clone(&store);
             let bloom_schema = schema.clone();
-            let bloom_on_read = query_config.bloom_filter_on_read;
             Arc::new(
                 move |segment: &SegmentFileInfo, chunk, stream_metrics: &StreamMetrics, stats_prune_tree: Option<&Arc<StatsPruneTree>>| {
                     let collector_opt: Option<Arc<dyn RowGroupDocsCollector>> = match &correctness_provider {
@@ -1171,19 +1131,16 @@ async unsafe fn execute_indexed_with_context_inner(
                         &schema_for_pruner,
                         Arc::clone(&segment.metadata),
                     ));
-                    let bloom_config = if bloom_on_read {
-                        Some(crate::indexed_table::eval::single_collector::BloomConfig {
-                            store: Arc::clone(&bloom_store),
-                            object_path: segment.object_path.clone(),
-                            metadata: Arc::clone(&segment.metadata),
-                            arrow_schema: Arc::clone(&bloom_schema),
-                            io_handle: io_handle.clone(),
-                            rg_bloom_pruned: stream_metrics.rg_bloom_pruned.clone(),
-                            bloom_filter_eval_time: stream_metrics.bloom_filter_eval_time.clone(),
-                        })
-                    } else {
-                        None
-                    };
+                    // Bloom-filter row-group pruning is always enabled on the indexed read path.
+                    let bloom_config = Some(crate::indexed_table::eval::single_collector::BloomConfig {
+                        store: Arc::clone(&bloom_store),
+                        object_path: segment.object_path.clone(),
+                        metadata: Arc::clone(&segment.metadata),
+                        arrow_schema: Arc::clone(&bloom_schema),
+                        io_handle: io_handle.clone(),
+                        rg_bloom_pruned: stream_metrics.rg_bloom_pruned.clone(),
+                        bloom_filter_eval_time: stream_metrics.bloom_filter_eval_time.clone(),
+                    });
                     let eval: Arc<dyn RowGroupBitsetSource> =
                         Arc::new(SingleCollectorEvaluator::new(
                             collector_opt,
@@ -1229,8 +1186,8 @@ async unsafe fn execute_indexed_with_context_inner(
             let schema_for_pruner = schema.clone();
             let cost_predicate = query_config.cost_predicate;
             let cost_collector = query_config.cost_collector;
-            let max_collector_parallelism = query_config.max_collector_parallelism;
-            let collector_strategy = query_config.tree_collector_strategy;
+            let max_collector_parallelism = 1;
+            let collector_strategy = CollectorCallStrategy::TightenOuterBounds;
 
             // Build one `PruningPredicate` per unique `Predicate` leaf
             // in the tree. Key = `Arc::as_ptr(expr) as usize` — the

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/stream.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/stream.rs
@@ -67,10 +67,12 @@ pub struct RowGroupInfo {
 }
 
 
-/// Test-only override for the per-RG `min_skip_run` selectivity heuristic.
-/// `IndexedStream` normally picks `min_skip_run` from candidate
-/// selectivity; setting `force_strategy` to one of these variants pins the
-/// choice so tests can exercise either extreme.
+/// Override for the per-RG `min_skip_run` selectivity heuristic. `IndexedStream`
+/// normally picks `min_skip_run` from candidate selectivity; setting
+/// `force_strategy` to one of these variants pins the choice node-wide.
+///
+/// Backed by the `datafusion.indexed.force_strategy` cluster setting (wire
+/// `-1` = `None` = let selectivity decide).
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum FilterStrategy {
     /// Force row-granular selection (`min_skip_run = 1`).
@@ -442,7 +444,6 @@ impl ExecutionPlan for IndexedExec {
             Arc::clone(&self.metadata),
             self.predicate.clone(),
             self.stream_metrics.clone(),
-            self.query_config.force_pushdown,
             self.query_config.force_strategy,
             self.query_config.min_skip_run_default,
             self.query_config.min_skip_run_selectivity_threshold,
@@ -489,17 +490,20 @@ struct IndexedStream {
     predicate: Option<Arc<dyn datafusion::physical_expr::PhysicalExpr>>,
     initialized: bool,
     metrics: StreamMetrics,
-    force_pushdown: Option<bool>,
+    /// Optional override for the per-RG `min_skip_run` choice, backed by the
+    /// `datafusion.indexed.force_strategy` cluster setting — see `pick_min_skip_run`.
     force_strategy: Option<FilterStrategy>,
-    /// Baseline `min_skip_run` used when neither selectivity nor
-    /// `force_strategy` drives the choice. Extracted once from
-    /// `DatafusionQueryConfig` so the hot path reads a local `usize`.
+    /// Baseline `min_skip_run` used when selectivity drives the choice (the
+    /// only path in production; tests may pin it via `force_strategy`).
+    /// Extracted once from `DatafusionQueryConfig` so the hot path reads a
+    /// local `usize`.
     min_skip_run_default: usize,
     /// Below this candidate selectivity, pin `min_skip_run = 1`
     /// (row-granular selection). Same hot-path discipline as above.
     min_skip_run_selectivity_threshold: f64,
     /// Whether to ask parquet to apply residual predicates during decode.
-    /// `force_pushdown` still takes priority when set.
+    /// Node-wide default from the `datafusion.indexed.pushdown_filters`
+    /// cluster setting.
     indexed_pushdown_filters: bool,
     evaluator: Arc<dyn RowGroupBitsetSource>,
     /// Output coalescer — combines small post-filter batches up to
@@ -542,7 +546,6 @@ impl IndexedStream {
         metadata: Arc<ParquetMetaData>,
         predicate: Option<Arc<dyn datafusion::physical_expr::PhysicalExpr>>,
         metrics: StreamMetrics,
-        force_pushdown: Option<bool>,
         force_strategy: Option<FilterStrategy>,
         min_skip_run_default: usize,
         min_skip_run_selectivity_threshold: f64,
@@ -584,7 +587,6 @@ impl IndexedStream {
             predicate,
             initialized: false,
             metrics,
-            force_pushdown,
             force_strategy,
             min_skip_run_default,
             min_skip_run_selectivity_threshold,
@@ -597,6 +599,30 @@ impl IndexedStream {
             emit_row_ids,
             row_id_output_index,
             dynamic_rg_pruner,
+        }
+    }
+
+    /// Per-RG `min_skip_run` decision.
+    ///
+    /// When `force_strategy` is set (via the `datafusion.indexed.force_strategy`
+    /// cluster setting) it pins the choice to either extreme (`RowSelection` → 1,
+    /// `BooleanMask` → whole-RG select), bypassing the heuristic.
+    ///
+    /// Otherwise the choice is selectivity-driven: at low selectivity every gap
+    /// is worth skipping (`min_skip_run = 1`, row-granular); at higher selectivity
+    /// noisy short gaps would explode the selector Vec, so absorb anything shorter
+    /// than `min_skip_run_default` (block-granular).
+    fn pick_min_skip_run(&self, num_candidates: usize, rg_num_rows: usize) -> usize {
+        match self.force_strategy {
+            Some(FilterStrategy::RowSelection) => return 1,
+            Some(FilterStrategy::BooleanMask) => return rg_num_rows + 1,
+            None => {}
+        }
+        let selectivity = num_candidates as f64 / rg_num_rows as f64;
+        if selectivity < self.min_skip_run_selectivity_threshold {
+            1
+        } else {
+            self.min_skip_run_default
         }
     }
 
@@ -991,29 +1017,8 @@ impl IndexedStream {
                     self.current_rg_context = Some(prefetched.prefetched.context);
                     self.batch_offset = 0;
 
-                    // Decide min_skip_run for this RG.
-                    //
-                    // - `force_strategy = RowSelection`: row-granular
-                    //   (min_skip_run = 1) — "sparse" path.
-                    // - `force_strategy = BooleanMask`: disable skipping
-                    //   (min_skip_run > rg.num_rows) — full scan.
-                    // - otherwise: pick based on selectivity. At low
-                    //   selectivity every gap is worth skipping (1); at
-                    //   higher selectivity noisy short gaps would explode
-                    //   the selector Vec, so absorb anything smaller than
-                    //   the default block size.
-                    let selectivity = candidates.len() as f64 / rg.num_rows as f64;
-                    let min_skip_run = match self.force_strategy {
-                        Some(FilterStrategy::RowSelection) => 1,
-                        Some(FilterStrategy::BooleanMask) => rg.num_rows as usize + 1,
-                        None => {
-                            if selectivity < self.min_skip_run_selectivity_threshold {
-                                1
-                            } else {
-                                self.min_skip_run_default
-                            }
-                        }
-                    };
+                    // Decide min_skip_run for this RG (see `pick_min_skip_run`).
+                    let min_skip_run = self.pick_min_skip_run(candidates.len() as usize, rg.num_rows as usize);
 
                     // Metrics: track which regime we landed in, using the
                     // same counters as before so `EXPLAIN ANALYZE` output
@@ -1087,10 +1092,12 @@ impl IndexedStream {
                     // dropped (supports_filters_pushdown = Exact) so
                     // there's no safety net if pushdown misbehaves on a
                     // UDF-containing predicate.
-                    let base_push = self.force_pushdown.unwrap_or(self.indexed_pushdown_filters);
+                    // Node-wide `indexed_pushdown_filters` setting, gated by
+                    // alignment/forbid checks below.
                     let alignment_risk = min_skip_run != 1 && self.evaluator.needs_row_mask();
-                    let push =
-                        base_push && !alignment_risk && !self.evaluator.forbid_parquet_pushdown();
+                    let push = self.indexed_pushdown_filters
+                        && !alignment_risk
+                        && !self.evaluator.forbid_parquet_pushdown();
 
                     match self.create_row_selection_stream(&rg, selection, push) {
                         Ok((stream, plan)) => {

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/table_provider.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/table_provider.rs
@@ -55,7 +55,7 @@ use super::partitioning::{
     compute_assignments, compute_assignments_one_per_segment, segments_chain_on_sort_key,
     PartitionAssignment, SegmentChunk, SegmentLayout,
 };
-use super::stream::{FilterStrategy, IndexedExec, RowGroupInfo};
+use super::stream::{IndexedExec, RowGroupInfo};
 use crate::datafusion_query_config::DatafusionQueryConfig;
 use crate::indexed_table::metrics::StreamMetrics;
 use crate::indexed_table::page_pruner::StatsPruneTree;
@@ -571,12 +571,6 @@ impl ExecutionPlan for QueryShardExec {
         use datafusion::physical_plan::filter_pushdown::{
             FilterPushdownPhase, FilterPushdownPropagation, PushedDown,
         };
-
-        // Feature gate: when disabled, decline everything so behaviour is
-        // identical to before this feature (parent keeps its FilterExec).
-        if !self.config.query_config.indexed_dynamic_filter_pushdown {
-            return Ok(FilterPushdownPropagation::if_all(child_pushdown_result));
-        }
 
         // Only the Post phase carries dynamic filters; in Pre we own static
         // WHERE semantics via the BoolNode tree and want no interference.

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/constant_predicate.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/constant_predicate.rs
@@ -103,7 +103,7 @@ async fn run_constant_residual(residual: Arc<dyn PhysicalExpr>) -> usize {
     let qc = crate::datafusion_query_config::DatafusionQueryConfig::builder()
         .target_partitions(1)
         .force_strategy(Some(FilterStrategy::BooleanMask))
-        .force_pushdown(Some(false))
+        .indexed_pushdown_filters(false)
         .build();
     let provider = Arc::new(IndexedTableProvider::new(IndexedTableConfig {
         schema: schema.clone(),

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/dynamic_filter_pushdown.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/dynamic_filter_pushdown.rs
@@ -175,7 +175,6 @@ async fn run_indexed(
     let qc = crate::datafusion_query_config::DatafusionQueryConfig::builder()
         .target_partitions(1)
         .batch_size(RG_ROWS)
-        .indexed_dynamic_filter_pushdown(true)
         .build();
     let provider = Arc::new(IndexedTableProvider::new(IndexedTableConfig {
         schema: schema.clone(),

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/fuzz/delegation.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/fuzz/delegation.rs
@@ -442,7 +442,7 @@ pub(in crate::indexed_table::tests_e2e) async fn execute_delegation_tree(
     // arithmetic were wrong we'd silently corrupt results on any segment after the first.
     let qc = crate::datafusion_query_config::DatafusionQueryConfig::builder()
         .target_partitions(corpus.config.target_partitions.max(1))
-        .force_pushdown(Some(true))
+        .indexed_pushdown_filters(true)
         .batch_size(1024)
         .build();
 

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/fuzz/harness.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/fuzz/harness.rs
@@ -283,8 +283,12 @@ pub(in crate::indexed_table::tests_e2e) async fn execute_tree_with_plan_pushdown
     let mut qcb = crate::datafusion_query_config::DatafusionQueryConfig::builder()
         .target_partitions(cfg_target_partitions.max(1))
         .force_strategy(force_strategy)
-        .force_pushdown(force_pushdown)
         .batch_size(cfg_batch_size.unwrap_or([128, 1024, 8192][seed as usize % 3]));
+    // `force_pushdown` overrides the node-wide indexed_pushdown_filters default;
+    // `None` leaves the default in place.
+    if let Some(push) = force_pushdown {
+        qcb = qcb.indexed_pushdown_filters(push);
+    }
     if let Some(msr) = cfg_min_skip_run {
         qcb = qcb.min_skip_run_default(msr);
     }
@@ -473,7 +477,7 @@ async fn run_single_collector_query(
     let mut qcb = crate::datafusion_query_config::DatafusionQueryConfig::builder()
         .target_partitions(1)
         .force_strategy(force_strategy)
-        .force_pushdown(Some(true))
+        .indexed_pushdown_filters(true)
         .batch_size([128, 1024, 8192][loaded.segments.len() % 3]);
     if let Some(msr) = min_skip_run_override {
         qcb = qcb.min_skip_run_default(msr);
@@ -685,12 +689,16 @@ async fn run_with_factory_plan(
     let store: Arc<dyn object_store::ObjectStore> =
         Arc::new(object_store::local::LocalFileSystem::new());
     let store_url = datafusion::execution::object_store::ObjectStoreUrl::local_filesystem();
-    let qc = crate::datafusion_query_config::DatafusionQueryConfig::builder()
+    let mut qcb = crate::datafusion_query_config::DatafusionQueryConfig::builder()
         .target_partitions(1)
         .force_strategy(force_strategy)
-        .force_pushdown(force_pushdown)
-        .batch_size([256, 1024, 8192][loaded.segments.len() % 3])
-        .build();
+        .batch_size([256, 1024, 8192][loaded.segments.len() % 3]);
+    // `force_pushdown` overrides the node-wide indexed_pushdown_filters default;
+    // `None` leaves the default in place.
+    if let Some(push) = force_pushdown {
+        qcb = qcb.indexed_pushdown_filters(push);
+    }
+    let qc = qcb.build();
     let provider = Arc::new(IndexedTableProvider::new(IndexedTableConfig {
         schema: loaded.schema.clone(),
         segments: loaded.segments.clone(),

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/mod.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/mod.rs
@@ -290,7 +290,7 @@ async fn run_tree_and_plan(
     let qc = crate::datafusion_query_config::DatafusionQueryConfig::builder()
         .target_partitions(1)
         .force_strategy(Some(FilterStrategy::BooleanMask))
-        .force_pushdown(Some(false))
+        .indexed_pushdown_filters(false)
         .build();
     let provider = Arc::new(IndexedTableProvider::new(IndexedTableConfig {
         schema: schema.clone(),

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/multi_segment.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/multi_segment.rs
@@ -177,7 +177,7 @@ async fn run_two_segment_query(
     let qc = crate::datafusion_query_config::DatafusionQueryConfig::builder()
         .target_partitions(num_partitions)
         .force_strategy(Some(FilterStrategy::BooleanMask))
-        .force_pushdown(Some(false))
+        .indexed_pushdown_filters(false)
         .build();
     let provider = Arc::new(IndexedTableProvider::new(IndexedTableConfig {
         schema: schema.clone(),
@@ -390,7 +390,7 @@ async fn run_two_segment_query_witness(
     let qc = crate::datafusion_query_config::DatafusionQueryConfig::builder()
         .target_partitions(num_partitions)
         .force_strategy(Some(FilterStrategy::BooleanMask))
-        .force_pushdown(Some(false))
+        .indexed_pushdown_filters(false)
         .build();
     let provider = Arc::new(IndexedTableProvider::new(IndexedTableConfig {
         schema: schema.clone(),
@@ -601,7 +601,7 @@ async fn run_segments(specs: Vec<SegSpec>, num_partitions: usize) -> Vec<(i32, S
     let qc = crate::datafusion_query_config::DatafusionQueryConfig::builder()
         .target_partitions(num_partitions)
         .force_strategy(Some(FilterStrategy::BooleanMask))
-        .force_pushdown(Some(false))
+        .indexed_pushdown_filters(false)
         .build();
     let provider = Arc::new(IndexedTableProvider::new(IndexedTableConfig {
         schema: schema.clone(),
@@ -1110,7 +1110,7 @@ async fn run_wide_segments(
     let qc = crate::datafusion_query_config::DatafusionQueryConfig::builder()
         .target_partitions(num_partitions)
         .force_strategy(Some(FilterStrategy::BooleanMask))
-        .force_pushdown(Some(false))
+        .indexed_pushdown_filters(false)
         .build();
     let provider = Arc::new(IndexedTableProvider::new(IndexedTableConfig {
         schema: schema.clone(),
@@ -1469,7 +1469,7 @@ async fn run_wide_segments_with_stats_pruning(
     let qc = crate::datafusion_query_config::DatafusionQueryConfig::builder()
         .target_partitions(num_partitions)
         .force_strategy(Some(FilterStrategy::BooleanMask))
-        .force_pushdown(Some(false))
+        .indexed_pushdown_filters(false)
         .build();
     let provider = Arc::new(IndexedTableProvider::new(IndexedTableConfig {
         schema: schema.clone(),

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/null_columns.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/null_columns.rs
@@ -372,7 +372,7 @@ async fn assert_engine_matches_reference_null(name: &str, tree: NT) {
     let qc = crate::datafusion_query_config::DatafusionQueryConfig::builder()
         .target_partitions(1)
         .force_strategy(Some(FilterStrategy::BooleanMask))
-        .force_pushdown(Some(false))
+        .indexed_pushdown_filters(false)
         .build();
     let provider = Arc::new(IndexedTableProvider::new(IndexedTableConfig {
         schema: schema.clone(),

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/page_pruning.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/page_pruning.rs
@@ -387,7 +387,7 @@ async fn execute_and_collect(
     let qc = crate::datafusion_query_config::DatafusionQueryConfig::builder()
         .target_partitions(1)
         .force_strategy(Some(FilterStrategy::BooleanMask))
-        .force_pushdown(Some(false))
+        .indexed_pushdown_filters(false)
         .build();
     let provider = Arc::new(IndexedTableProvider::new(IndexedTableConfig {
         schema: schema.clone(),

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/qtf_fetch_phase.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/qtf_fetch_phase.rs
@@ -121,7 +121,7 @@ async fn query_phase(tree: BoolNode) -> Vec<i64> {
             let mut qc = crate::datafusion_query_config::DatafusionQueryConfig::test_default();
             qc.target_partitions = 1;
             qc.force_strategy = Some(FilterStrategy::BooleanMask);
-            qc.force_pushdown = Some(false);
+            qc.indexed_pushdown_filters = false;
             qc
         }),
         predicate_columns: vec![0, 1, 2, 3],

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/row_id_emission.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/row_id_emission.rs
@@ -111,7 +111,7 @@ async fn run_tree_row_ids(tree: BoolNode) -> Vec<i64> {
             let mut qc = crate::datafusion_query_config::DatafusionQueryConfig::test_default();
             qc.target_partitions = 1;
             qc.force_strategy = Some(FilterStrategy::BooleanMask);
-            qc.force_pushdown = Some(false);
+            qc.indexed_pushdown_filters = false;
             qc
         }),
         predicate_columns: vec![0, 1, 2, 3],
@@ -281,7 +281,7 @@ async fn run_tree_row_ids_with_global_base(tree: BoolNode, global_base: u64) -> 
             let mut qc = crate::datafusion_query_config::DatafusionQueryConfig::test_default();
             qc.target_partitions = 1;
             qc.force_strategy = Some(FilterStrategy::BooleanMask);
-            qc.force_pushdown = Some(false);
+            qc.indexed_pushdown_filters = false;
             qc
         }),
         predicate_columns: vec![0, 1, 2, 3],
@@ -549,7 +549,7 @@ async fn test_row_id_with_data_columns() {
             let mut qc = crate::datafusion_query_config::DatafusionQueryConfig::test_default();
             qc.target_partitions = 1;
             qc.force_strategy = Some(FilterStrategy::BooleanMask);
-            qc.force_pushdown = Some(false);
+            qc.indexed_pushdown_filters = false;
             qc
         }),
         predicate_columns: vec![0, 1, 2, 3],
@@ -804,7 +804,7 @@ async fn run_two_segments_row_ids(tree: BoolNode) -> Vec<i64> {
             let mut qc = crate::datafusion_query_config::DatafusionQueryConfig::test_default();
             qc.target_partitions = 1;
             qc.force_strategy = Some(FilterStrategy::BooleanMask);
-            qc.force_pushdown = Some(false);
+            qc.indexed_pushdown_filters = false;
             qc
         }),
         predicate_columns: vec![0, 1, 2, 3],

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/row_id_strategies.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/row_id_strategies.rs
@@ -6,10 +6,10 @@
  * compatible open source license.
  */
 
-//! End-to-end correctness tests for row ID emission across all three strategies.
+//! End-to-end correctness tests for shard-global row ID computation.
 //!
 //! These tests create real parquet files with known `___row_id` values and verify
-//! that all three `QueryStrategy` variants produce identical shard-global row IDs.
+//! that the row-base prefix-sum produces unique, contiguous shard-global row IDs.
 
 #[cfg(test)]
 mod tests {
@@ -26,7 +26,6 @@ mod tests {
     use tempfile::TempDir;
 
     use crate::api::{build_shard_files, FileRowMetadata};
-    use crate::datafusion_query_config::QueryStrategy;
     use crate::project_row_id_optimizer::ProjectRowIdOptimizer;
 
     /// Create a test parquet file with `___row_id` column containing positional indices.
@@ -282,13 +281,6 @@ mod tests {
         assert_eq!(result.schema().field(0).name(), "a");
         assert_eq!(result.schema().field(1).name(), "b");
     }
-
-    #[test]
-    fn test_query_strategy_default_is_none() {
-        let config = crate::datafusion_query_config::DatafusionQueryConfig::test_default();
-        assert_eq!(config.query_strategy, QueryStrategy::None);
-    }
-
 
     #[test]
     fn test_build_shard_files_empty() {

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/schema_drift.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/schema_drift.rs
@@ -127,7 +127,7 @@ async fn run_missing_col_tree(tree_bool: BoolNode) -> usize {
     let qc = crate::datafusion_query_config::DatafusionQueryConfig::builder()
         .target_partitions(1)
         .force_strategy(Some(FilterStrategy::BooleanMask))
-        .force_pushdown(Some(false))
+        .indexed_pushdown_filters(false)
         .build();
     let provider = Arc::new(IndexedTableProvider::new(IndexedTableConfig {
         schema: schema.clone(),
@@ -440,7 +440,7 @@ async fn query_with_mismatched_schema(
     let qc = crate::datafusion_query_config::DatafusionQueryConfig::builder()
         .target_partitions(1)
         .force_strategy(Some(FilterStrategy::BooleanMask))
-        .force_pushdown(Some(false))
+        .indexed_pushdown_filters(false)
         .build();
     let provider = Arc::new(IndexedTableProvider::new(IndexedTableConfig {
         schema: table_schema,

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/sort_reverse_row_id.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/sort_reverse_row_id.rs
@@ -220,7 +220,7 @@ async fn collect_row_ids(
     let qc = crate::datafusion_query_config::DatafusionQueryConfig::builder()
         .target_partitions(1)
         .force_strategy(Some(FilterStrategy::BooleanMask))
-        .force_pushdown(Some(false))
+        .indexed_pushdown_filters(false)
         .build();
     let provider = Arc::new(IndexedTableProvider::new(IndexedTableConfig {
         schema: schema.clone(),

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/streaming_at_scale.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/streaming_at_scale.rs
@@ -444,7 +444,7 @@ async fn run_large(
     let qc = crate::datafusion_query_config::DatafusionQueryConfig::builder()
         .target_partitions(1)
         .force_strategy(Some(FilterStrategy::BooleanMask))
-        .force_pushdown(Some(false))
+        .indexed_pushdown_filters(false)
         .build();
     let provider = Arc::new(IndexedTableProvider::new(IndexedTableConfig {
         schema: schema.clone(),
@@ -901,7 +901,7 @@ async fn run_large_partitioned(
     let qc = crate::datafusion_query_config::DatafusionQueryConfig::builder()
         .target_partitions(partitions)
         .force_strategy(Some(FilterStrategy::BooleanMask))
-        .force_pushdown(Some(false))
+        .indexed_pushdown_filters(false)
         .build();
     let provider = Arc::new(IndexedTableProvider::new(IndexedTableConfig {
         schema: schema.clone(),

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/lib.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/lib.rs
@@ -28,6 +28,7 @@ pub mod cross_rt_stream;
 pub mod datafusion_query_config;
 pub mod executor;
 pub mod ffm;
+pub mod helper;
 pub mod indexed_executor;
 pub mod indexed_table;
 pub mod io;

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/query_executor.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/query_executor.rs
@@ -11,17 +11,15 @@ use std::sync::Arc;
 use native_bridge_common::log_debug;
 use datafusion::{
     common::DataFusionError,
-    datasource::listing::{ListingOptions, ListingTable, ListingTableConfig, ListingTableUrl},
-    execution::context::SessionContext,
+    datasource::listing::ListingTableUrl,
     execution::runtime_env::RuntimeEnvBuilder,
-    execution::SessionStateBuilder,
     physical_plan::displayable,
     physical_plan::execute_stream,
-    prelude::*,
 };
-use datafusion::datasource::file_format::parquet::ParquetFormat;
 use datafusion::execution::cache::cache_manager::{CacheManagerConfig, CachedFileList};
 use datafusion::execution::cache::{CacheAccessor, DefaultListFilesCache};
+use datafusion::execution::context::SessionContext;
+use datafusion::logical_expr::{col, lit};
 use datafusion_substrait::logical_plan::consumer::from_substrait_plan;
 use log::error;
 use object_store::ObjectMeta;
@@ -29,9 +27,10 @@ use object_store::ObjectStore;
 use prost::Message;
 use substrait::proto::Plan;
 
+use crate::api::{DataFusionRuntime, ShardFileInfo};
 use crate::cross_rt_stream::CrossRtStream;
 use crate::executor::DedicatedExecutor;
-use crate::api::{DataFusionRuntime, ShardFileInfo};
+use crate::helper::{build_query_runtime_env_with_store, build_query_session_context, register_listing_table};
 use crate::session_context::SessionContextHandle;
 
 /// Execute a vanilla parquet query: substrait plan → DataFusion → CrossRtStream.
@@ -57,110 +56,28 @@ pub async fn execute_query(
     sort_orders: &[String],
     internal_search: crate::datafusion_query_config::InternalSearch,
 ) -> Result<i64, DataFusionError> {
-    // Build per-query RuntimeEnv with list-files cache pre-populated.
-    let runtime_env = build_query_runtime_env(runtime, &table_path, object_metas.as_ref())?;
-
-    // If a per-query memory pool is provided, rebuild with it overlaid.
-    // The per-query pool wraps the global pool, so global limits are still enforced.
-    let runtime_env = if let Some(pool) = query_memory_pool {
-        Arc::from(
-            RuntimeEnvBuilder::from_runtime_env(&runtime_env)
-                .with_memory_pool(pool)
-                .build()
-                .map_err(|e| {
-                    error!("Failed to build runtime env with query pool: {}", e);
-                    e
-                })?,
-        )
-    } else {
-        runtime_env
-    };
-
-    // Register shard-specific object store on file:// scheme for this query.
-    // Routes reads through TieredObjectStore (local + remote) or default LocalFileSystem.
-    runtime_env.register_object_store(
-        &url::Url::parse("file://").unwrap(),
+    // Build per-query RuntimeEnv (optional pool overlay) + register the shard store.
+    let runtime_env = build_query_runtime_env_with_store(
+        runtime,
+        &table_path,
+        object_metas.as_ref(),
         shard_store,
+        query_memory_pool,
+    )?;
+
+    // Build a fresh session context per query (default optimizer rules on the
+    // vanilla path). TODO : Tune this during planning per query.
+    let ctx = build_query_session_context(
+        query_config,
+        runtime_env,
+        query_config.target_partitions,
+        false, // vanilla path
     );
 
-    // Build a fresh session state per query. TODO : Tune this during planning per query
-    let mut config = SessionConfig::new();
-    config.options_mut().execution.parquet.pushdown_filters = query_config.parquet_pushdown_filters;
-    config.options_mut().execution.target_partitions = query_config.target_partitions;
-    config.options_mut().execution.batch_size = query_config.batch_size;
-
-    let state = SessionStateBuilder::new()
-        .with_config(config)
-        .with_runtime_env(runtime_env)
-        .with_default_features()
-        .build();
-
-    let ctx = SessionContext::new_with_state(state);
-    crate::udf::register_all(&ctx);
-    crate::udaf::register_all(&ctx);
-
-    // Register table provider based on strategy.
-    //
-    // Note: api::execute_query only routes to this function when the plan does NOT
-    // request row IDs (otherwise it dispatches to the indexed executor). The strategy
-    // therefore matters only for distinguishing the ShardTableProvider rewrite
-    // (ListingTable) from the plain ListingTable scan (None / IndexedPredicateOnly).
-    use crate::datafusion_query_config::QueryStrategy;
-    match query_config.query_strategy {
-        QueryStrategy::ListingTable => {
-            use crate::shard_table_provider::{ShardTableConfig, ShardTableProvider};
-
-            // Infer schema from the first file
-            let file_format = ParquetFormat::new();
-            let listing_options = ListingOptions::new(Arc::new(file_format))
-                .with_file_extension(".parquet")
-                .with_collect_stat(true);
-            let resolved_schema = listing_options
-                .infer_schema(&ctx.state(), &table_path)
-                .await
-                .map_err(|e| { error!("Failed to infer schema: {}", e); e })?;
-            let resolved_schema = crate::schema_coerce::coerce_inferred_schema(resolved_schema);
-
-            // Build ShardFileInfo with row_base from cumulative row counts
-            let store = ctx.state().runtime_env().object_store(&table_path)?;
-            let files = build_shard_file_infos(&store, object_metas.as_ref()).await?;
-
-            let store_url = store_url_from_table_path(&table_path)?;
-
-            let provider = Arc::new(ShardTableProvider::new(ShardTableConfig {
-                file_schema: resolved_schema,
-                files,
-                store_url,
-            }));
-            ctx.register_table(&table_name, provider)
-                .map_err(|e| { error!("Failed to register table: {}", e); e })?;
-        }
-        _ => {
-            // Baseline: use standard ListingTable
-            let file_format = ParquetFormat::new();
-            let mut listing_options = ListingOptions::new(Arc::new(file_format))
-                .with_file_extension(".parquet")
-                .with_collect_stat(true);
-            // Declare per-file sort order to DataFusion if the index has `index.sort.field`.
-            // See `session_context::build_file_sort_order` for what the declaration buys us
-            // and the case/nulls/non-sort caveats.
-            if let Some(sort_exprs) = crate::session_context::build_file_sort_order(sort_fields, sort_orders) {
-                listing_options = listing_options.with_file_sort_order(vec![sort_exprs]);
-            }
-            let resolved_schema = listing_options
-                .infer_schema(&ctx.state(), &table_path)
-                .await
-                .map_err(|e| { error!("Failed to infer schema: {}", e); e })?;
-            let resolved_schema = crate::schema_coerce::coerce_inferred_schema(resolved_schema);
-            let table_config = ListingTableConfig::new(table_path)
-                .with_listing_options(listing_options)
-                .with_schema(resolved_schema);
-            let provider = Arc::new(ListingTable::try_new(table_config)
-                .map_err(|e| { error!("Failed to create listing table: {}", e); e })?);
-            ctx.register_table(&table_name, provider)
-                .map_err(|e| { error!("Failed to register table: {}", e); e })?;
-        }
-    }
+    // Register the standard DataFusion ListingTable. This function only runs the vanilla
+    // (non-row-id) path — QTF row-id plans always route to the indexed executor.
+    // Declares the per-file sort order when the index has `index.sort.field`.
+    register_listing_table(&ctx, &table_name, table_path, sort_fields, sort_orders).await?;
 
     // Planning: build the query DataFrame (Substrait decode for normal search, native filter for an
     // engine-internal point lookup). Physical planning + execution below is shared by both.
@@ -174,19 +91,6 @@ pub async fn execute_query(
     // batches arriving from this producer agree by construction.
     let target_schema = crate::schema_coerce::coerce_inferred_schema(physical_plan.schema());
     let physical_plan = crate::relabel_exec::wrap_if_relabel_needed(physical_plan, target_schema)?;
-
-    // Apply row ID optimizer when ShardTableProvider injected `row_base`.
-    // For other strategies the vanilla scan output is already what the plan expects.
-    use datafusion::physical_optimizer::PhysicalOptimizerRule;
-    let physical_plan = match query_config.query_strategy {
-        QueryStrategy::ListingTable => {
-            // Rewrites ___row_id to ___row_id + row_base.
-            let optimizer = crate::project_row_id_optimizer::ProjectRowIdOptimizer;
-            let config = datafusion::common::config::ConfigOptions::default();
-            optimizer.optimize(physical_plan, &config)?
-        }
-        _ => physical_plan,
-    };
 
     let df_stream = execute_stream(physical_plan, ctx.task_ctx()).map_err(|e| {
         error!("Failed to create execution stream: {}", e);
@@ -284,10 +188,8 @@ async fn internal_search_dataframe(
 /// by the time this function is reached the pointer is already invalidated from
 /// Java's perspective and cleanup is pure RAII.
 ///
-/// When the plan requests row IDs and a `QueryStrategy` is configured, this
-/// function routes to the appropriate execution path:
-/// - `ListingTable`: applies `ProjectRowIdOptimizer` to the physical plan
-/// - `IndexedPredicateOnly`: delegates to the indexed executor with `emit_row_ids=true`
+/// This is the fragment (non-row-id) execution path: row-id-requesting plans are
+/// routed to the indexed executor by `df_execute_with_context` before reaching here.
 pub async fn execute_with_context(
     handle: SessionContextHandle,
     plan_bytes: &[u8],
@@ -297,44 +199,8 @@ pub async fn execute_with_context(
     // Permit was acquired by the caller (ffm.rs) on the IO runtime before
     // spawning on the CPU runtime, so the Java search thread blocks at the
     // gate when it is full — creating backpressure at the Java threadpool level.
-    use crate::datafusion_query_config::QueryStrategy;
-
     let context_id = handle.query_context.context_id();
     let token = crate::query_tracker::get_cancellation_token(context_id);
-
-    let query_strategy = handle.query_config.query_strategy;
-
-    // If ListingTable strategy: replace the default ListingTable with ShardTableProvider
-    // that adds row_base partition column for ProjectRowIdOptimizer.
-    // Also register the ProjectRowIdAnalyzer to ensure __row_id__ survives logical optimization.
-    if query_strategy == QueryStrategy::ListingTable {
-        use crate::shard_table_provider::{ShardTableConfig, ShardTableProvider};
-
-        handle.ctx.deregister_table(&handle.table_name)?;
-
-        let store = handle.ctx.state().runtime_env().object_store(&handle.table_path)?;
-
-        // Infer schema from existing files
-        let listing_options = ListingOptions::new(Arc::new(ParquetFormat::new()))
-            .with_file_extension(".parquet")
-            .with_collect_stat(true);
-        let resolved_schema = listing_options
-            .infer_schema(&handle.ctx.state(), &handle.table_path)
-            .await?;
-        let resolved_schema = crate::schema_coerce::coerce_inferred_schema(resolved_schema);
-
-        // Build ShardFileInfo with cumulative row_base from parquet metadata.
-        let files = build_shard_file_infos(&store, handle.object_metas.as_ref()).await?;
-
-        let store_url = store_url_from_table_path(&handle.table_path)?;
-
-        let provider = Arc::new(ShardTableProvider::new(ShardTableConfig {
-            file_schema: resolved_schema,
-            files,
-            store_url,
-        }));
-        handle.ctx.register_table(&handle.table_name, provider)?;
-    }
 
     let query_future = async {
         // If prepare_partial_plan stored a stripped plan on this handle (engine-native-merge

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/session_context.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/session_context.rs
@@ -199,7 +199,7 @@ pub async unsafe fn create_session_context(
     let phantom = phantom_reservation.map(|b| b.phantom_reservation);
 
     let mut config = SessionConfig::new();
-    config.options_mut().execution.parquet.pushdown_filters = query_config.parquet_pushdown_filters;
+    config.options_mut().execution.parquet.pushdown_filters = query_config.listing_table_pushdown_filters;
     config.options_mut().execution.target_partitions = effective_partitions;
     config.options_mut().execution.batch_size = effective_batch_size;
     // When the index has `index.sort.field`, ask DataFusion to use the sort-aware
@@ -218,21 +218,7 @@ pub async unsafe fn create_session_context(
             datafusion::physical_optimizer::optimizer::PhysicalOptimizer::new().rules
         });
 
-    // For ListingTable query strategy:
-    // 1. Add ProjectRowIdAnalyzer (logical) — ensures __row_id__ survives pruning.
-    // 2. Add ProjectRowIdOptimizer (physical) — computes __row_id__ + row_base.
-    if query_config.query_strategy == crate::datafusion_query_config::QueryStrategy::ListingTable {
-        state_builder = state_builder
-            .with_analyzer_rule(
-                Arc::new(crate::project_row_id_analyzer::ProjectRowIdAnalyzer::new())
-            )
-            .with_physical_optimizer_rule(
-                Arc::new(crate::project_row_id_optimizer::ProjectRowIdOptimizer)
-            );
-    }
-
     // Install the scoped page-index reader factory on every parquet scan.
-    // Registered AFTER ProjectRowIdOptimizer so it sees the final DataSourceExec.
     // Also, this SHOULD be the last optimizer to see all projections / predicates
     if page_index::is_scoped_page_index_enabled() {
         state_builder = state_builder.with_physical_optimizer_rule(Arc::new(

--- a/sandbox/plugins/analytics-backend-datafusion/src/internalClusterTest/java/org/opensearch/be/datafusion/DatafusionDynamicSettingsIT.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/internalClusterTest/java/org/opensearch/be/datafusion/DatafusionDynamicSettingsIT.java
@@ -70,26 +70,20 @@ public class DatafusionDynamicSettingsIT extends OpenSearchIntegTestCase {
             .prepareUpdateSettings()
             .setTransientSettings(
                 Settings.builder()
-                    .put("datafusion.indexed.batch_size", 16384)
-                    .put("datafusion.indexed.parquet_pushdown_filters", true)
+                    .put("datafusion.batch_size", 16384)
+                    .put("datafusion.listing_table.pushdown_filters", true)
                     .put("datafusion.indexed.min_skip_run_default", 2048)
                     .put("datafusion.indexed.min_skip_run_selectivity_threshold", 0.5)
-                    .put("datafusion.indexed.single_collector_strategy", "full_range")
-                    .put("datafusion.indexed.tree_collector_strategy", "page_range_split")
-                    .put("datafusion.indexed.max_collector_parallelism", 4)
                     .build()
             )
             .get();
         assertTrue(response.isAcknowledged());
 
         Settings transientSettings = response.getTransientSettings();
-        assertEquals("16384", transientSettings.get("datafusion.indexed.batch_size"));
-        assertEquals("true", transientSettings.get("datafusion.indexed.parquet_pushdown_filters"));
+        assertEquals("16384", transientSettings.get("datafusion.batch_size"));
+        assertEquals("true", transientSettings.get("datafusion.listing_table.pushdown_filters"));
         assertEquals("2048", transientSettings.get("datafusion.indexed.min_skip_run_default"));
         assertEquals("0.5", transientSettings.get("datafusion.indexed.min_skip_run_selectivity_threshold"));
-        assertEquals("full_range", transientSettings.get("datafusion.indexed.single_collector_strategy"));
-        assertEquals("page_range_split", transientSettings.get("datafusion.indexed.tree_collector_strategy"));
-        assertEquals("4", transientSettings.get("datafusion.indexed.max_collector_parallelism"));
     }
 
     public void testInvalidValuesAreRejected() {
@@ -98,7 +92,7 @@ public class DatafusionDynamicSettingsIT extends OpenSearchIntegTestCase {
             () -> client().admin()
                 .cluster()
                 .prepareUpdateSettings()
-                .setTransientSettings(Settings.builder().put("datafusion.indexed.batch_size", 0).build())
+                .setTransientSettings(Settings.builder().put("datafusion.batch_size", 0).build())
                 .get()
         );
 
@@ -108,15 +102,6 @@ public class DatafusionDynamicSettingsIT extends OpenSearchIntegTestCase {
                 .cluster()
                 .prepareUpdateSettings()
                 .setTransientSettings(Settings.builder().put("datafusion.indexed.min_skip_run_selectivity_threshold", 1.5).build())
-                .get()
-        );
-
-        expectThrows(
-            IllegalArgumentException.class,
-            () -> client().admin()
-                .cluster()
-                .prepareUpdateSettings()
-                .setTransientSettings(Settings.builder().put("datafusion.indexed.single_collector_strategy", "bogus").build())
                 .get()
         );
     }

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionSettings.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionSettings.java
@@ -39,8 +39,8 @@ public final class DatafusionSettings {
     // ── New indexed query settings ──
 
     /** Number of rows per batch in the indexed query execution path. */
-    public static final Setting<Integer> INDEXED_BATCH_SIZE = Setting.intSetting(
-        "datafusion.indexed.batch_size",
+    public static final Setting<Integer> BATCH_SIZE = Setting.intSetting(
+        "datafusion.batch_size",
         8192,
         1,
         Setting.Property.NodeScope,
@@ -48,44 +48,29 @@ public final class DatafusionSettings {
     );
 
     /**
-     * Whether DataFusion applies residual predicate pushdown during parquet decode
-     * on the indexed path. When true, narrow row-granular selections benefit from
-     * decode-time filtering via {@code RowFilter}. When false (default), the indexed
-     * stream handles filtering externally via bitmap-based row selection.
-     * <p>
-     * Note: ideally this decision should be taken by the planner on a per-query basis
-     * (e.g., based on filter shape and estimated selectivity). This setting acts as
-     * the node-wide default until per-query planner support is added.
+     * Whether DataFusion applies its own decode-time predicate pushdown on the
+     * ListingTable (non-indexed) query path. Maps to DataFusion's
+     * {@code execution.parquet.pushdown_filters} session option.
      */
-    public static final Setting<Boolean> INDEXED_PARQUET_PUSHDOWN_FILTERS = Setting.boolSetting(
-        "datafusion.indexed.parquet_pushdown_filters",
+    public static final Setting<Boolean> LISTING_TABLE_PUSHDOWN_FILTERS = Setting.boolSetting(
+        "datafusion.listing_table.pushdown_filters",
         false,
         Setting.Property.NodeScope,
         Setting.Property.Dynamic
     );
 
     /**
-     * Whether to use parquet bloom filters for row-group pruning on the indexed read path.
-     * When true, equality predicates are checked against the SBBF (Split Block Bloom Filter)
-     * embedded in the parquet footer before invoking the expensive FFM collector call.
-     * If the bloom filter proves absence, the row group is skipped entirely.
+     * Whether the indexed stream asks parquet to apply the residual predicate during
+     * decode (via {@code RowFilter} pushdown). When true (default), narrow row-granular
+     * selections benefit from decode-time filtering; when false, the indexed stream
+     * handles filtering externally via bitmap-based row selection.
+     * <p>
+     * Note: ideally this decision should be taken by the planner on a per-query basis
+     * (e.g., based on filter shape and estimated selectivity). This setting acts as
+     * the node-wide default until per-query planner support is added.
      */
-    public static final Setting<Boolean> INDEXED_BLOOM_FILTER_ON_READ = Setting.boolSetting(
-        "datafusion.indexed.bloom_filter_on_read",
-        true,
-        Setting.Property.NodeScope,
-        Setting.Property.Dynamic
-    );
-
-    /**
-     * Whether the indexed scan accepts runtime dynamic filters (TopK / join)
-     * pushed down via physical filter pushdown and uses them to prune row groups
-     * whose parquet statistics cannot satisfy the tightening predicate. On by
-     * default; turn off to A/B the performance impact. When off, the scan
-     * declines the pushdown and behaves exactly as before this feature.
-     */
-    public static final Setting<Boolean> INDEXED_DYNAMIC_FILTER_PUSHDOWN = Setting.boolSetting(
-        "datafusion.indexed.dynamic_filter_pushdown",
+    public static final Setting<Boolean> INDEXED_PUSHDOWN_FILTERS = Setting.boolSetting(
+        "datafusion.indexed.pushdown_filters",
         true,
         Setting.Property.NodeScope,
         Setting.Property.Dynamic
@@ -122,76 +107,44 @@ public final class DatafusionSettings {
         Setting.Property.Dynamic
     );
 
-    // Strategy constants for CollectorCallStrategy
-    public static final String STRATEGY_FULL_RANGE = "full_range";
-    public static final String STRATEGY_TIGHTEN_OUTER_BOUNDS = "tighten_outer_bounds";
-    public static final String STRATEGY_PAGE_RANGE_SPLIT = "page_range_split";
-
     /**
-     * How the SingleCollectorEvaluator narrows collector doc ranges relative to
-     * page-pruning results. Valid values: full_range, tighten_outer_bounds, page_range_split.
-     * Default is page_range_split — only one collector, so multiple FFM calls per RG is acceptable.
+     * Pins the indexed stream's per-row-group {@code min_skip_run} strategy instead of
+     * letting candidate selectivity decide. Accepts:
+     * <ul>
+     *   <li>{@code "none"} (default) — selectivity heuristic decides (wire {@code -1});</li>
+     *   <li>{@code "row_selection"} — force row-granular selection, {@code min_skip_run = 1} (wire {@code 0});</li>
+     *   <li>{@code "boolean_mask"} — force a single whole-RG select (wire {@code 1}).</li>
+     * </ul>
+     * Node-wide override intended for benchmarking/diagnostics; production normally
+     * leaves this at {@code "none"}.
      */
-    public static final Setting<String> INDEXED_SINGLE_COLLECTOR_STRATEGY = Setting.simpleString(
-        "datafusion.indexed.single_collector_strategy",
-        STRATEGY_PAGE_RANGE_SPLIT,
-        value -> {
-            switch (value) {
-                case STRATEGY_FULL_RANGE:
-                case STRATEGY_TIGHTEN_OUTER_BOUNDS:
-                case STRATEGY_PAGE_RANGE_SPLIT:
-                    break;
-                default:
-                    throw new IllegalArgumentException(
-                        "datafusion.indexed.single_collector_strategy must be one of "
-                            + "[full_range, tighten_outer_bounds, page_range_split], got: "
-                            + value
-                    );
-            }
-        },
+    public static final Setting<String> INDEXED_FORCE_STRATEGY = Setting.simpleString(
+        "datafusion.indexed.force_strategy",
+        "none",
+        DatafusionSettings::validateForceStrategy,
         Setting.Property.NodeScope,
         Setting.Property.Dynamic
     );
 
-    /**
-     * How the bitmap tree evaluator narrows collector doc ranges when multiple collectors
-     * are present. Valid values: full_range, tighten_outer_bounds, page_range_split.
-     * Default is tighten_outer_bounds — multiple collectors make page_range_split expensive.
-     */
-    public static final Setting<String> INDEXED_TREE_COLLECTOR_STRATEGY = Setting.simpleString(
-        "datafusion.indexed.tree_collector_strategy",
-        STRATEGY_TIGHTEN_OUTER_BOUNDS,
-        value -> {
-            switch (value) {
-                case STRATEGY_FULL_RANGE:
-                case STRATEGY_TIGHTEN_OUTER_BOUNDS:
-                case STRATEGY_PAGE_RANGE_SPLIT:
-                    break;
-                default:
-                    throw new IllegalArgumentException(
-                        "datafusion.indexed.tree_collector_strategy must be one of "
-                            + "[full_range, tighten_outer_bounds, page_range_split], got: "
-                            + value
-                    );
-            }
-        },
-        Setting.Property.NodeScope,
-        Setting.Property.Dynamic
-    );
+    private static void validateForceStrategy(String value) {
+        forceStrategyToWire(value);
+    }
 
-    /**
-     * Maximum number of Collector-leaf FFM calls issued in parallel per row-group
-     * prefetch. 1 = fully sequential (lowest CPU, fastest short-circuit). Higher
-     * values sacrifice short-circuit savings in AND/OR groups but reduce latency
-     * for independent collector leaves.
-     */
-    public static final Setting<Integer> INDEXED_MAX_COLLECTOR_PARALLELISM = Setting.intSetting(
-        "datafusion.indexed.max_collector_parallelism",
-        1,
-        1,
-        Setting.Property.NodeScope,
-        Setting.Property.Dynamic
-    );
+    /** Maps the {@link #INDEXED_FORCE_STRATEGY} string to the Rust wire code (-1/0/1). */
+    static int forceStrategyToWire(String value) {
+        switch (value) {
+            case "none":
+                return -1;
+            case "row_selection":
+                return 0;
+            case "boolean_mask":
+                return 1;
+            default:
+                throw new IllegalArgumentException(
+                    "Setting [datafusion.indexed.force_strategy] must be one of [none, row_selection, boolean_mask], got [" + value + "]"
+                );
+        }
+    }
 
     // ── Concurrency gate settings ──
 
@@ -216,47 +169,6 @@ public final class DatafusionSettings {
         1.5,
         0.1,
         10.0,
-        Setting.Property.NodeScope,
-        Setting.Property.Dynamic
-    );
-
-    // Query strategy constants
-    public static final String QUERY_STRATEGY_NONE = "none";
-    public static final String QUERY_STRATEGY_LISTING_TABLE = "listing_table";
-    public static final String QUERY_STRATEGY_INDEXED = "indexed";
-
-    /**
-     * Query strategy for query-then-fetch (QTF) row ID computation.
-     * <p>
-     * Controls how shard-global row IDs are computed when the query projects {@code __row_id__}.
-     * <ul>
-     *   <li>{@code none} — No global row ID computation. Reads {@code __row_id__} as a regular
-     *       column from parquet (per-file 0-based values, NOT shard-global). Useful for debugging.</li>
-     *   <li>{@code listing_table} — Uses ShardTableProvider with a {@code row_base} partition column.
-     *       Reads {@code __row_id__} from parquet and adds the file's cumulative row offset via
-     *       ProjectRowIdOptimizer ({@code __row_id__ + row_base = global_id}). Works with standard
-     *       DataFusion ListingTable scan path.</li>
-     *   <li>{@code indexed} — Uses the indexed pipeline (segment partitioning, PositionMap).
-     *       Computes row IDs from position ({@code global_base + rg.first_row + position_in_rg}).
-     *       Zero I/O for the row ID column. Fastest path when the indexed executor is available.</li>
-     * </ul>
-     * Default: {@code indexed}.
-     */
-    public static final Setting<String> INDEXED_QUERY_STRATEGY = Setting.simpleString(
-        "datafusion.indexed.query_strategy",
-        QUERY_STRATEGY_INDEXED,
-        value -> {
-            switch (value) {
-                case QUERY_STRATEGY_NONE:
-                case QUERY_STRATEGY_LISTING_TABLE:
-                case QUERY_STRATEGY_INDEXED:
-                    break;
-                default:
-                    throw new IllegalArgumentException(
-                        "datafusion.indexed.query_strategy must be one of " + "[none, listing_table, indexed], got: " + value
-                    );
-            }
-        },
         Setting.Property.NodeScope,
         Setting.Property.Dynamic
     );
@@ -312,16 +224,12 @@ public final class DatafusionSettings {
         CONCURRENCY_DATANODE_MULTIPLIER,
 
         // Indexed query settings — per-query tuning knobs for the indexed execution path
-        INDEXED_BATCH_SIZE,
-        INDEXED_PARQUET_PUSHDOWN_FILTERS,
-        INDEXED_BLOOM_FILTER_ON_READ,
+        BATCH_SIZE,
+        LISTING_TABLE_PUSHDOWN_FILTERS,
+        INDEXED_PUSHDOWN_FILTERS,
         INDEXED_MIN_SKIP_RUN_DEFAULT,
         INDEXED_MIN_SKIP_RUN_SELECTIVITY_THRESHOLD,
-        INDEXED_SINGLE_COLLECTOR_STRATEGY,
-        INDEXED_TREE_COLLECTOR_STRATEGY,
-        INDEXED_MAX_COLLECTOR_PARALLELISM,
-        INDEXED_QUERY_STRATEGY,
-        INDEXED_DYNAMIC_FILTER_PUSHDOWN
+        INDEXED_FORCE_STRATEGY
     );
 
     // ── Snapshot management ──
@@ -354,17 +262,13 @@ public final class DatafusionSettings {
         this.maxSliceCount = SearchService.CONCURRENT_SEGMENT_SEARCH_TARGET_MAX_SLICE_COUNT_SETTING.get(settings);
 
         this.snapshot = WireConfigSnapshot.builder()
-            .batchSize(INDEXED_BATCH_SIZE.get(settings))
+            .batchSize(BATCH_SIZE.get(settings))
             .targetPartitions(deriveTargetPartitions(this.concurrentSearchMode, this.maxSliceCount))
-            .parquetPushdownFilters(INDEXED_PARQUET_PUSHDOWN_FILTERS.get(settings))
-            .bloomFilterOnRead(INDEXED_BLOOM_FILTER_ON_READ.get(settings))
+            .listingTablePushdownFilters(LISTING_TABLE_PUSHDOWN_FILTERS.get(settings))
+            .indexedPushdownFilters(INDEXED_PUSHDOWN_FILTERS.get(settings))
             .minSkipRunDefault(INDEXED_MIN_SKIP_RUN_DEFAULT.get(settings))
             .minSkipRunSelectivityThreshold(INDEXED_MIN_SKIP_RUN_SELECTIVITY_THRESHOLD.get(settings))
-            .singleCollectorStrategy(strategyToWireValue(INDEXED_SINGLE_COLLECTOR_STRATEGY.get(settings)))
-            .treeCollectorStrategy(strategyToWireValue(INDEXED_TREE_COLLECTOR_STRATEGY.get(settings)))
-            .maxCollectorParallelism(INDEXED_MAX_COLLECTOR_PARALLELISM.get(settings))
-            .queryStrategy(queryStrategyToWireValue(INDEXED_QUERY_STRATEGY.get(settings)))
-            .indexedDynamicFilterPushdown(INDEXED_DYNAMIC_FILTER_PUSHDOWN.get(settings))
+            .forceStrategy(forceStrategyToWire(INDEXED_FORCE_STRATEGY.get(settings)))
             .build();
 
         registerListeners(clusterSettings);
@@ -379,31 +283,27 @@ public final class DatafusionSettings {
         this.maxSliceCount = SearchService.CONCURRENT_SEGMENT_SEARCH_TARGET_MAX_SLICE_COUNT_SETTING.get(settings);
 
         this.snapshot = WireConfigSnapshot.builder()
-            .batchSize(INDEXED_BATCH_SIZE.get(settings))
+            .batchSize(BATCH_SIZE.get(settings))
             .targetPartitions(deriveTargetPartitions(this.concurrentSearchMode, this.maxSliceCount))
-            .parquetPushdownFilters(INDEXED_PARQUET_PUSHDOWN_FILTERS.get(settings))
-            .bloomFilterOnRead(INDEXED_BLOOM_FILTER_ON_READ.get(settings))
+            .listingTablePushdownFilters(LISTING_TABLE_PUSHDOWN_FILTERS.get(settings))
+            .indexedPushdownFilters(INDEXED_PUSHDOWN_FILTERS.get(settings))
             .minSkipRunDefault(INDEXED_MIN_SKIP_RUN_DEFAULT.get(settings))
             .minSkipRunSelectivityThreshold(INDEXED_MIN_SKIP_RUN_SELECTIVITY_THRESHOLD.get(settings))
-            .singleCollectorStrategy(strategyToWireValue(INDEXED_SINGLE_COLLECTOR_STRATEGY.get(settings)))
-            .treeCollectorStrategy(strategyToWireValue(INDEXED_TREE_COLLECTOR_STRATEGY.get(settings)))
-            .maxCollectorParallelism(INDEXED_MAX_COLLECTOR_PARALLELISM.get(settings))
-            .queryStrategy(queryStrategyToWireValue(INDEXED_QUERY_STRATEGY.get(settings)))
-            .indexedDynamicFilterPushdown(INDEXED_DYNAMIC_FILTER_PUSHDOWN.get(settings))
+            .forceStrategy(forceStrategyToWire(INDEXED_FORCE_STRATEGY.get(settings)))
             .build();
     }
 
     void registerListeners(ClusterSettings clusterSettings) {
-        clusterSettings.addSettingsUpdateConsumer(INDEXED_BATCH_SIZE, newValue -> {
+        clusterSettings.addSettingsUpdateConsumer(BATCH_SIZE, newValue -> {
             snapshot = WireConfigSnapshot.builder(snapshot).batchSize(newValue).build();
         });
 
-        clusterSettings.addSettingsUpdateConsumer(INDEXED_PARQUET_PUSHDOWN_FILTERS, newValue -> {
-            snapshot = WireConfigSnapshot.builder(snapshot).parquetPushdownFilters(newValue).build();
+        clusterSettings.addSettingsUpdateConsumer(LISTING_TABLE_PUSHDOWN_FILTERS, newValue -> {
+            snapshot = WireConfigSnapshot.builder(snapshot).listingTablePushdownFilters(newValue).build();
         });
 
-        clusterSettings.addSettingsUpdateConsumer(INDEXED_BLOOM_FILTER_ON_READ, newValue -> {
-            snapshot = WireConfigSnapshot.builder(snapshot).bloomFilterOnRead(newValue).build();
+        clusterSettings.addSettingsUpdateConsumer(INDEXED_PUSHDOWN_FILTERS, newValue -> {
+            snapshot = WireConfigSnapshot.builder(snapshot).indexedPushdownFilters(newValue).build();
         });
 
         clusterSettings.addSettingsUpdateConsumer(INDEXED_MIN_SKIP_RUN_DEFAULT, newValue -> {
@@ -414,24 +314,8 @@ public final class DatafusionSettings {
             snapshot = WireConfigSnapshot.builder(snapshot).minSkipRunSelectivityThreshold(newValue).build();
         });
 
-        clusterSettings.addSettingsUpdateConsumer(INDEXED_SINGLE_COLLECTOR_STRATEGY, newValue -> {
-            snapshot = WireConfigSnapshot.builder(snapshot).singleCollectorStrategy(strategyToWireValue(newValue)).build();
-        });
-
-        clusterSettings.addSettingsUpdateConsumer(INDEXED_TREE_COLLECTOR_STRATEGY, newValue -> {
-            snapshot = WireConfigSnapshot.builder(snapshot).treeCollectorStrategy(strategyToWireValue(newValue)).build();
-        });
-
-        clusterSettings.addSettingsUpdateConsumer(INDEXED_MAX_COLLECTOR_PARALLELISM, newValue -> {
-            snapshot = WireConfigSnapshot.builder(snapshot).maxCollectorParallelism(newValue).build();
-        });
-
-        clusterSettings.addSettingsUpdateConsumer(INDEXED_QUERY_STRATEGY, newValue -> {
-            snapshot = WireConfigSnapshot.builder(snapshot).queryStrategy(queryStrategyToWireValue(newValue)).build();
-        });
-
-        clusterSettings.addSettingsUpdateConsumer(INDEXED_DYNAMIC_FILTER_PUSHDOWN, newValue -> {
-            snapshot = WireConfigSnapshot.builder(snapshot).indexedDynamicFilterPushdown(newValue).build();
+        clusterSettings.addSettingsUpdateConsumer(INDEXED_FORCE_STRATEGY, newValue -> {
+            snapshot = WireConfigSnapshot.builder(snapshot).forceStrategy(forceStrategyToWire(newValue)).build();
         });
 
         clusterSettings.addSettingsUpdateConsumer(SearchService.CONCURRENT_SEGMENT_SEARCH_TARGET_MAX_SLICE_COUNT_SETTING, newValue -> {
@@ -455,37 +339,6 @@ public final class DatafusionSettings {
      */
     public WireConfigSnapshot getSnapshot() {
         return snapshot;
-    }
-
-    /**
-     * Converts a strategy string to its wire format integer value.
-     * <p>
-     * Mapping: full_range = 0, tighten_outer_bounds = 1, page_range_split = 2.
-     */
-    static int strategyToWireValue(String strategy) {
-        switch (strategy) {
-            case STRATEGY_FULL_RANGE:
-                return 0;
-            case STRATEGY_TIGHTEN_OUTER_BOUNDS:
-                return 1;
-            case STRATEGY_PAGE_RANGE_SPLIT:
-                return 2;
-            default:
-                throw new IllegalArgumentException("Unknown strategy: " + strategy);
-        }
-    }
-
-    static int queryStrategyToWireValue(String strategy) {
-        switch (strategy) {
-            case QUERY_STRATEGY_NONE:
-                return 0;
-            case QUERY_STRATEGY_LISTING_TABLE:
-                return 1;
-            case QUERY_STRATEGY_INDEXED:
-                return 2;
-            default:
-                throw new IllegalArgumentException("Unknown fetch strategy: " + strategy);
-        }
     }
 
     /**

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/GetService.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/GetService.java
@@ -208,9 +208,7 @@ public class GetService implements Closeable {
          */
         private long executeInternalSearch(long readerPtr, long runtimePtr, long mode, long bound, String errorMessage) throws IOException {
             CompletableFuture<Long> future = new CompletableFuture<>();
-            WireConfigSnapshot configSnapshot = WireConfigSnapshot.builder(dfPlugin.getDatafusionSettings().getSnapshot())
-                .queryStrategy(1)
-                .build();
+            WireConfigSnapshot configSnapshot = WireConfigSnapshot.builder(dfPlugin.getDatafusionSettings().getSnapshot()).build();
             try (Arena arena = Arena.ofConfined()) {
                 MemorySegment configSegment = arena.allocate(WireConfigSnapshot.BYTE_SIZE);
                 configSnapshot.writeTo(configSegment);

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/WireConfigSnapshot.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/WireConfigSnapshot.java
@@ -26,32 +26,24 @@ import java.lang.foreign.ValueLayout;
 public final class WireConfigSnapshot {
 
     /** Total byte size of the wire struct ({@code WireDatafusionQueryConfig}). */
-    public static final long BYTE_SIZE = 80;
+    public static final long BYTE_SIZE = 52;
 
     private final int batchSize;
     private final int targetPartitions;
-    private final boolean parquetPushdownFilters;
-    private final boolean bloomFilterOnRead;
+    private final boolean listingTablePushdownFilters;
     private final int minSkipRunDefault;
     private final double minSkipRunSelectivityThreshold;
-    private final int maxCollectorParallelism;
-    private final int singleCollectorStrategy;
-    private final int treeCollectorStrategy;
-    private final int queryStrategy;
-    private final boolean indexedDynamicFilterPushdown;
+    private final boolean indexedPushdownFilters;
+    private final int forceStrategy;
 
     private WireConfigSnapshot(Builder builder) {
         this.batchSize = builder.batchSize;
         this.targetPartitions = builder.targetPartitions;
-        this.parquetPushdownFilters = builder.parquetPushdownFilters;
-        this.bloomFilterOnRead = builder.bloomFilterOnRead;
+        this.listingTablePushdownFilters = builder.listingTablePushdownFilters;
         this.minSkipRunDefault = builder.minSkipRunDefault;
         this.minSkipRunSelectivityThreshold = builder.minSkipRunSelectivityThreshold;
-        this.maxCollectorParallelism = builder.maxCollectorParallelism;
-        this.singleCollectorStrategy = builder.singleCollectorStrategy;
-        this.treeCollectorStrategy = builder.treeCollectorStrategy;
-        this.queryStrategy = builder.queryStrategy;
-        this.indexedDynamicFilterPushdown = builder.indexedDynamicFilterPushdown;
+        this.indexedPushdownFilters = builder.indexedPushdownFilters;
+        this.forceStrategy = builder.forceStrategy;
     }
 
     public static Builder builder() {
@@ -65,15 +57,11 @@ public final class WireConfigSnapshot {
     public static Builder builder(WireConfigSnapshot current) {
         return new Builder().batchSize(current.batchSize)
             .targetPartitions(current.targetPartitions)
-            .parquetPushdownFilters(current.parquetPushdownFilters)
-            .bloomFilterOnRead(current.bloomFilterOnRead)
+            .listingTablePushdownFilters(current.listingTablePushdownFilters)
             .minSkipRunDefault(current.minSkipRunDefault)
             .minSkipRunSelectivityThreshold(current.minSkipRunSelectivityThreshold)
-            .maxCollectorParallelism(current.maxCollectorParallelism)
-            .singleCollectorStrategy(current.singleCollectorStrategy)
-            .treeCollectorStrategy(current.treeCollectorStrategy)
-            .queryStrategy(current.queryStrategy)
-            .indexedDynamicFilterPushdown(current.indexedDynamicFilterPushdown);
+            .indexedPushdownFilters(current.indexedPushdownFilters)
+            .forceStrategy(current.forceStrategy);
     }
 
     public int batchSize() {
@@ -84,12 +72,8 @@ public final class WireConfigSnapshot {
         return targetPartitions;
     }
 
-    public boolean parquetPushdownFilters() {
-        return parquetPushdownFilters;
-    }
-
-    public boolean bloomFilterOnRead() {
-        return bloomFilterOnRead;
+    public boolean listingTablePushdownFilters() {
+        return listingTablePushdownFilters;
     }
 
     public int minSkipRunDefault() {
@@ -100,24 +84,13 @@ public final class WireConfigSnapshot {
         return minSkipRunSelectivityThreshold;
     }
 
-    public int maxCollectorParallelism() {
-        return maxCollectorParallelism;
+    public boolean indexedPushdownFilters() {
+        return indexedPushdownFilters;
     }
 
-    public int singleCollectorStrategy() {
-        return singleCollectorStrategy;
-    }
-
-    public int treeCollectorStrategy() {
-        return treeCollectorStrategy;
-    }
-
-    public int queryStrategy() {
-        return queryStrategy;
-    }
-
-    public boolean indexedDynamicFilterPushdown() {
-        return indexedDynamicFilterPushdown;
+    /** -1 = None (selectivity heuristic), 0 = RowSelection, 1 = BooleanMask. */
+    public int forceStrategy() {
+        return forceStrategy;
     }
 
     /**
@@ -125,7 +98,9 @@ public final class WireConfigSnapshot {
      * {@code WireDatafusionQueryConfig} {@code #[repr(C)]} layout.
      * <p>
      * The segment must be at least {@link #BYTE_SIZE} bytes and allocated from
-     * a confined {@code Arena} scoped to the query lifetime.
+     * a confined {@code Arena} scoped to the query lifetime. Fields that the Rust
+     * side no longer exposes as settings ({@code cost_predicate},
+     * {@code cost_collector}) are written as their fixed hardcoded values.
      *
      * <pre>
      * Offset  Size  Field                                Type     Source
@@ -134,19 +109,13 @@ public final class WireConfigSnapshot {
      * 8       8     target_partitions                    i64      from snapshot
      * 16      8     min_skip_run_default                 i64      from snapshot
      * 24      8     min_skip_run_selectivity_threshold   f64      from snapshot
-     * 32      4     parquet_pushdown_filters             i32      from snapshot (0/1)
-     * 36      4     indexed_pushdown_filters             i32      hardcoded 1
-     * 40      4     force_strategy                       i32      hardcoded -1
-     * 44      4     force_pushdown                       i32      hardcoded -1
-     * 48      4     cost_predicate                       i32      hardcoded 1
-     * 52      4     cost_collector                       i32      hardcoded 10
-     * 56      4     max_collector_parallelism            i32      from snapshot
-     * 60      4     single_collector_strategy            i32      from snapshot
-     * 64      4     tree_collector_strategy              i32      from snapshot
-     * 68      4     query_strategy                       i32      from snapshot (0/1/2)
-     * 72      4     bloom_filter_on_read                 i32      from snapshot (0/1)
+     * 32      4     listing_table_pushdown_filters       i32      from snapshot (0/1)
+     * 36      4     indexed_pushdown_filters             i32      from snapshot (0/1)
+     * 40      4     force_strategy                       i32      from snapshot (-1/0/1)
+     * 44      4     cost_predicate                       i32      hardcoded 1
+     * 48      4     cost_collector                       i32      hardcoded 10
      * ──────  ────
-     * Total: 76 bytes
+     * Total: 52 bytes
      * </pre>
      *
      * @param segment the target memory segment (at least {@link #BYTE_SIZE} bytes)
@@ -160,30 +129,16 @@ public final class WireConfigSnapshot {
         segment.set(ValueLayout.JAVA_LONG, 16, (long) minSkipRunDefault);
         // Offset 24: min_skip_run_selectivity_threshold (f64)
         segment.set(ValueLayout.JAVA_DOUBLE, 24, minSkipRunSelectivityThreshold);
-        // Offset 32: parquet_pushdown_filters (i32) — 0 = false, 1 = true
-        segment.set(ValueLayout.JAVA_INT, 32, parquetPushdownFilters ? 1 : 0);
-        // Offset 36: indexed_pushdown_filters (i32) — always 1 (hardcoded)
-        segment.set(ValueLayout.JAVA_INT, 36, 1);
-        // Offset 40: force_strategy (i32) — always -1 (None)
-        segment.set(ValueLayout.JAVA_INT, 40, -1);
-        // Offset 44: force_pushdown (i32) — always -1 (None)
-        segment.set(ValueLayout.JAVA_INT, 44, -1);
-        // Offset 48: cost_predicate (i32) — hardcoded 1
-        segment.set(ValueLayout.JAVA_INT, 48, 1);
-        // Offset 52: cost_collector (i32) — hardcoded 10
-        segment.set(ValueLayout.JAVA_INT, 52, 10);
-        // Offset 56: max_collector_parallelism (i32)
-        segment.set(ValueLayout.JAVA_INT, 56, maxCollectorParallelism);
-        // Offset 60: single_collector_strategy (i32)
-        segment.set(ValueLayout.JAVA_INT, 60, singleCollectorStrategy);
-        // Offset 64: tree_collector_strategy (i32)
-        segment.set(ValueLayout.JAVA_INT, 64, treeCollectorStrategy);
-        // Offset 68: query_strategy (i32) — 0 = None, 1 = ListingTable, 2 = IndexedPredicateOnly
-        segment.set(ValueLayout.JAVA_INT, 68, queryStrategy);
-        // Offset 72: bloom_filter_on_read (i32) — 0 = false, 1 = true
-        segment.set(ValueLayout.JAVA_INT, 72, bloomFilterOnRead ? 1 : 0);
-        // Offset 76: indexed_dynamic_filter_pushdown (i32) — 0 = false, 1 = true
-        segment.set(ValueLayout.JAVA_INT, 76, indexedDynamicFilterPushdown ? 1 : 0);
+        // Offset 32: listing_table_pushdown_filters (i32) — 0 = false, 1 = true
+        segment.set(ValueLayout.JAVA_INT, 32, listingTablePushdownFilters ? 1 : 0);
+        // Offset 36: indexed_pushdown_filters (i32) — 0 = false, 1 = true
+        segment.set(ValueLayout.JAVA_INT, 36, indexedPushdownFilters ? 1 : 0);
+        // Offset 40: force_strategy (i32) — -1 = None, 0 = RowSelection, 1 = BooleanMask
+        segment.set(ValueLayout.JAVA_INT, 40, forceStrategy);
+        // Offset 44: cost_predicate (i32) — hardcoded 1
+        segment.set(ValueLayout.JAVA_INT, 44, 1);
+        // Offset 48: cost_collector (i32) — hardcoded 10
+        segment.set(ValueLayout.JAVA_INT, 48, 10);
     }
 
     /**
@@ -193,15 +148,11 @@ public final class WireConfigSnapshot {
     public static final class Builder {
         private int batchSize = 8192;
         private int targetPartitions = 4;
-        private boolean parquetPushdownFilters = false;
-        private boolean bloomFilterOnRead = true;
+        private boolean listingTablePushdownFilters = false;
         private int minSkipRunDefault = 1024;
         private double minSkipRunSelectivityThreshold = 0.03;
-        private int maxCollectorParallelism = 1;
-        private int singleCollectorStrategy = 2; // PageRangeSplit
-        private int treeCollectorStrategy = 1;   // TightenOuterBounds
-        private int queryStrategy = 2;           // IndexedPredicateOnly (matches DatafusionSettings default "indexed")
-        private boolean indexedDynamicFilterPushdown = true; // runtime TopK/join RG pruning on by default
+        private boolean indexedPushdownFilters = true;
+        private int forceStrategy = -1;
 
         private Builder() {}
 
@@ -215,13 +166,8 @@ public final class WireConfigSnapshot {
             return this;
         }
 
-        public Builder parquetPushdownFilters(boolean parquetPushdownFilters) {
-            this.parquetPushdownFilters = parquetPushdownFilters;
-            return this;
-        }
-
-        public Builder bloomFilterOnRead(boolean bloomFilterOnRead) {
-            this.bloomFilterOnRead = bloomFilterOnRead;
+        public Builder listingTablePushdownFilters(boolean listingTablePushdownFilters) {
+            this.listingTablePushdownFilters = listingTablePushdownFilters;
             return this;
         }
 
@@ -235,28 +181,14 @@ public final class WireConfigSnapshot {
             return this;
         }
 
-        public Builder maxCollectorParallelism(int maxCollectorParallelism) {
-            this.maxCollectorParallelism = maxCollectorParallelism;
+        public Builder indexedPushdownFilters(boolean indexedPushdownFilters) {
+            this.indexedPushdownFilters = indexedPushdownFilters;
             return this;
         }
 
-        public Builder singleCollectorStrategy(int singleCollectorStrategy) {
-            this.singleCollectorStrategy = singleCollectorStrategy;
-            return this;
-        }
-
-        public Builder treeCollectorStrategy(int treeCollectorStrategy) {
-            this.treeCollectorStrategy = treeCollectorStrategy;
-            return this;
-        }
-
-        public Builder queryStrategy(int queryStrategy) {
-            this.queryStrategy = queryStrategy;
-            return this;
-        }
-
-        public Builder indexedDynamicFilterPushdown(boolean indexedDynamicFilterPushdown) {
-            this.indexedDynamicFilterPushdown = indexedDynamicFilterPushdown;
+        /** @param forceStrategy -1 = None (heuristic), 0 = RowSelection, 1 = BooleanMask. */
+        public Builder forceStrategy(int forceStrategy) {
+            this.forceStrategy = forceStrategy;
             return this;
         }
 

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionPluginSettingsTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionPluginSettingsTests.java
@@ -99,15 +99,10 @@ public class DataFusionPluginSettingsTests extends OpenSearchTestCase {
             List<Setting<?>> settings = plugin.getSettings();
             Set<String> settingKeys = settings.stream().map(Setting::getKey).collect(Collectors.toSet());
 
-            assertTrue(settingKeys.contains("datafusion.indexed.batch_size"));
-            assertTrue(settingKeys.contains("datafusion.indexed.parquet_pushdown_filters"));
-            assertTrue(settingKeys.contains("datafusion.indexed.bloom_filter_on_read"));
+            assertTrue(settingKeys.contains("datafusion.batch_size"));
+            assertTrue(settingKeys.contains("datafusion.listing_table.pushdown_filters"));
             assertTrue(settingKeys.contains("datafusion.indexed.min_skip_run_default"));
             assertTrue(settingKeys.contains("datafusion.indexed.min_skip_run_selectivity_threshold"));
-            assertTrue(settingKeys.contains("datafusion.indexed.single_collector_strategy"));
-            assertTrue(settingKeys.contains("datafusion.indexed.tree_collector_strategy"));
-            assertTrue(settingKeys.contains("datafusion.indexed.max_collector_parallelism"));
-            assertTrue(settingKeys.contains("datafusion.indexed.query_strategy"));
         } catch (Exception e) {
             throw new AssertionError(e);
         }
@@ -116,7 +111,7 @@ public class DataFusionPluginSettingsTests extends OpenSearchTestCase {
     public void testGetSettingsReturnsTotalExpectedCount() {
         try (DataFusionPlugin plugin = new DataFusionPlugin()) {
             List<Setting<?>> settings = plugin.getSettings();
-            assertEquals(35, settings.size());
+            assertEquals(31, settings.size());
         } catch (Exception e) {
             throw new AssertionError(e);
         }

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionSettingsPropertyTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionSettingsPropertyTests.java
@@ -20,7 +20,6 @@ import java.util.Set;
 public class DatafusionSettingsPropertyTests extends OpenSearchTestCase {
 
     private static final int ITERATIONS = 200;
-    private static final String[] STRATEGIES = { "full_range", "tighten_outer_bounds", "page_range_split" };
 
     private ClusterSettings createClusterSettings() {
         Set<Setting<?>> settingsSet = new HashSet<>(DatafusionSettings.ALL_SETTINGS);
@@ -37,38 +36,32 @@ public class DatafusionSettingsPropertyTests extends OpenSearchTestCase {
 
             WireConfigSnapshot before = datafusionSettings.getSnapshot();
 
-            int settingIndex = randomIntBetween(0, 8);
+            int settingIndex = randomIntBetween(0, 5);
             Settings newSettings;
 
             switch (settingIndex) {
                 case 0: // batch_size
                     int newBatchSize = randomIntBetween(1, 1_000_000);
-                    newSettings = Settings.builder().put("datafusion.indexed.batch_size", newBatchSize).build();
+                    newSettings = Settings.builder().put("datafusion.batch_size", newBatchSize).build();
                     clusterSettings.applySettings(newSettings);
                     WireConfigSnapshot afterBatch = datafusionSettings.getSnapshot();
                     assertEquals(newBatchSize, afterBatch.batchSize());
                     assertEquals(before.targetPartitions(), afterBatch.targetPartitions());
-                    assertEquals(before.parquetPushdownFilters(), afterBatch.parquetPushdownFilters());
+                    assertEquals(before.listingTablePushdownFilters(), afterBatch.listingTablePushdownFilters());
                     assertEquals(before.minSkipRunDefault(), afterBatch.minSkipRunDefault());
                     assertEquals(before.minSkipRunSelectivityThreshold(), afterBatch.minSkipRunSelectivityThreshold(), 0.0);
-                    assertEquals(before.singleCollectorStrategy(), afterBatch.singleCollectorStrategy());
-                    assertEquals(before.treeCollectorStrategy(), afterBatch.treeCollectorStrategy());
-                    assertEquals(before.maxCollectorParallelism(), afterBatch.maxCollectorParallelism());
                     break;
 
-                case 1: // parquet_pushdown_filters
-                    boolean newPushdown = before.parquetPushdownFilters() == false;
-                    newSettings = Settings.builder().put("datafusion.indexed.parquet_pushdown_filters", newPushdown).build();
+                case 1: // listing_table.pushdown_filters
+                    boolean newPushdown = before.listingTablePushdownFilters() == false;
+                    newSettings = Settings.builder().put("datafusion.listing_table.pushdown_filters", newPushdown).build();
                     clusterSettings.applySettings(newSettings);
                     WireConfigSnapshot afterPushdown = datafusionSettings.getSnapshot();
-                    assertEquals(newPushdown, afterPushdown.parquetPushdownFilters());
+                    assertEquals(newPushdown, afterPushdown.listingTablePushdownFilters());
                     assertEquals(before.batchSize(), afterPushdown.batchSize());
                     assertEquals(before.targetPartitions(), afterPushdown.targetPartitions());
                     assertEquals(before.minSkipRunDefault(), afterPushdown.minSkipRunDefault());
                     assertEquals(before.minSkipRunSelectivityThreshold(), afterPushdown.minSkipRunSelectivityThreshold(), 0.0);
-                    assertEquals(before.singleCollectorStrategy(), afterPushdown.singleCollectorStrategy());
-                    assertEquals(before.treeCollectorStrategy(), afterPushdown.treeCollectorStrategy());
-                    assertEquals(before.maxCollectorParallelism(), afterPushdown.maxCollectorParallelism());
                     break;
 
                 case 2: // min_skip_run_default
@@ -79,11 +72,8 @@ public class DatafusionSettingsPropertyTests extends OpenSearchTestCase {
                     assertEquals(newMinSkipRun, afterSkipRun.minSkipRunDefault());
                     assertEquals(before.batchSize(), afterSkipRun.batchSize());
                     assertEquals(before.targetPartitions(), afterSkipRun.targetPartitions());
-                    assertEquals(before.parquetPushdownFilters(), afterSkipRun.parquetPushdownFilters());
+                    assertEquals(before.listingTablePushdownFilters(), afterSkipRun.listingTablePushdownFilters());
                     assertEquals(before.minSkipRunSelectivityThreshold(), afterSkipRun.minSkipRunSelectivityThreshold(), 0.0);
-                    assertEquals(before.singleCollectorStrategy(), afterSkipRun.singleCollectorStrategy());
-                    assertEquals(before.treeCollectorStrategy(), afterSkipRun.treeCollectorStrategy());
-                    assertEquals(before.maxCollectorParallelism(), afterSkipRun.maxCollectorParallelism());
                     break;
 
                 case 3: // min_skip_run_selectivity_threshold
@@ -94,85 +84,31 @@ public class DatafusionSettingsPropertyTests extends OpenSearchTestCase {
                     assertEquals(newThreshold, afterThreshold.minSkipRunSelectivityThreshold(), 1e-15);
                     assertEquals(before.batchSize(), afterThreshold.batchSize());
                     assertEquals(before.targetPartitions(), afterThreshold.targetPartitions());
-                    assertEquals(before.parquetPushdownFilters(), afterThreshold.parquetPushdownFilters());
+                    assertEquals(before.listingTablePushdownFilters(), afterThreshold.listingTablePushdownFilters());
                     assertEquals(before.minSkipRunDefault(), afterThreshold.minSkipRunDefault());
-                    assertEquals(before.singleCollectorStrategy(), afterThreshold.singleCollectorStrategy());
-                    assertEquals(before.treeCollectorStrategy(), afterThreshold.treeCollectorStrategy());
-                    assertEquals(before.maxCollectorParallelism(), afterThreshold.maxCollectorParallelism());
                     break;
 
-                case 4: // single_collector_strategy
-                    String newSingle = STRATEGIES[randomIntBetween(0, 2)];
-                    newSettings = Settings.builder().put("datafusion.indexed.single_collector_strategy", newSingle).build();
-                    clusterSettings.applySettings(newSettings);
-                    WireConfigSnapshot afterSingle = datafusionSettings.getSnapshot();
-                    assertEquals(DatafusionSettings.strategyToWireValue(newSingle), afterSingle.singleCollectorStrategy());
-                    assertEquals(before.batchSize(), afterSingle.batchSize());
-                    assertEquals(before.targetPartitions(), afterSingle.targetPartitions());
-                    assertEquals(before.parquetPushdownFilters(), afterSingle.parquetPushdownFilters());
-                    assertEquals(before.minSkipRunDefault(), afterSingle.minSkipRunDefault());
-                    assertEquals(before.minSkipRunSelectivityThreshold(), afterSingle.minSkipRunSelectivityThreshold(), 0.0);
-                    assertEquals(before.treeCollectorStrategy(), afterSingle.treeCollectorStrategy());
-                    assertEquals(before.maxCollectorParallelism(), afterSingle.maxCollectorParallelism());
-                    break;
-
-                case 5: // tree_collector_strategy
-                    String newTree = STRATEGIES[randomIntBetween(0, 2)];
-                    newSettings = Settings.builder().put("datafusion.indexed.tree_collector_strategy", newTree).build();
-                    clusterSettings.applySettings(newSettings);
-                    WireConfigSnapshot afterTree = datafusionSettings.getSnapshot();
-                    assertEquals(DatafusionSettings.strategyToWireValue(newTree), afterTree.treeCollectorStrategy());
-                    assertEquals(before.batchSize(), afterTree.batchSize());
-                    assertEquals(before.targetPartitions(), afterTree.targetPartitions());
-                    assertEquals(before.parquetPushdownFilters(), afterTree.parquetPushdownFilters());
-                    assertEquals(before.minSkipRunDefault(), afterTree.minSkipRunDefault());
-                    assertEquals(before.minSkipRunSelectivityThreshold(), afterTree.minSkipRunSelectivityThreshold(), 0.0);
-                    assertEquals(before.singleCollectorStrategy(), afterTree.singleCollectorStrategy());
-                    assertEquals(before.maxCollectorParallelism(), afterTree.maxCollectorParallelism());
-                    break;
-
-                case 6: // max_collector_parallelism
-                    int newMaxParallelism = randomIntBetween(1, 64);
-                    newSettings = Settings.builder().put("datafusion.indexed.max_collector_parallelism", newMaxParallelism).build();
-                    clusterSettings.applySettings(newSettings);
-                    WireConfigSnapshot afterParallelism = datafusionSettings.getSnapshot();
-                    assertEquals(newMaxParallelism, afterParallelism.maxCollectorParallelism());
-                    assertEquals(before.batchSize(), afterParallelism.batchSize());
-                    assertEquals(before.targetPartitions(), afterParallelism.targetPartitions());
-                    assertEquals(before.parquetPushdownFilters(), afterParallelism.parquetPushdownFilters());
-                    assertEquals(before.minSkipRunDefault(), afterParallelism.minSkipRunDefault());
-                    assertEquals(before.minSkipRunSelectivityThreshold(), afterParallelism.minSkipRunSelectivityThreshold(), 0.0);
-                    assertEquals(before.singleCollectorStrategy(), afterParallelism.singleCollectorStrategy());
-                    assertEquals(before.treeCollectorStrategy(), afterParallelism.treeCollectorStrategy());
-                    break;
-
-                case 7: // max_slice_count
+                case 4: // max_slice_count
                     int newSliceCount = randomIntBetween(1, 32);
                     newSettings = Settings.builder().put("search.concurrent.max_slice_count", newSliceCount).build();
                     clusterSettings.applySettings(newSettings);
                     WireConfigSnapshot afterSlice = datafusionSettings.getSnapshot();
                     assertEquals(Math.min(newSliceCount, Runtime.getRuntime().availableProcessors()), afterSlice.targetPartitions());
                     assertEquals(before.batchSize(), afterSlice.batchSize());
-                    assertEquals(before.parquetPushdownFilters(), afterSlice.parquetPushdownFilters());
+                    assertEquals(before.listingTablePushdownFilters(), afterSlice.listingTablePushdownFilters());
                     assertEquals(before.minSkipRunDefault(), afterSlice.minSkipRunDefault());
                     assertEquals(before.minSkipRunSelectivityThreshold(), afterSlice.minSkipRunSelectivityThreshold(), 0.0);
-                    assertEquals(before.singleCollectorStrategy(), afterSlice.singleCollectorStrategy());
-                    assertEquals(before.treeCollectorStrategy(), afterSlice.treeCollectorStrategy());
-                    assertEquals(before.maxCollectorParallelism(), afterSlice.maxCollectorParallelism());
                     break;
 
-                case 8: // concurrent_search_mode
+                case 5: // concurrent_search_mode
                     newSettings = Settings.builder().put("search.concurrent_segment_search.mode", "none").build();
                     clusterSettings.applySettings(newSettings);
                     WireConfigSnapshot afterMode = datafusionSettings.getSnapshot();
                     assertEquals(1, afterMode.targetPartitions());
                     assertEquals(before.batchSize(), afterMode.batchSize());
-                    assertEquals(before.parquetPushdownFilters(), afterMode.parquetPushdownFilters());
+                    assertEquals(before.listingTablePushdownFilters(), afterMode.listingTablePushdownFilters());
                     assertEquals(before.minSkipRunDefault(), afterMode.minSkipRunDefault());
                     assertEquals(before.minSkipRunSelectivityThreshold(), afterMode.minSkipRunSelectivityThreshold(), 0.0);
-                    assertEquals(before.singleCollectorStrategy(), afterMode.singleCollectorStrategy());
-                    assertEquals(before.treeCollectorStrategy(), afterMode.treeCollectorStrategy());
-                    assertEquals(before.maxCollectorParallelism(), afterMode.maxCollectorParallelism());
                     break;
 
                 default:
@@ -188,13 +124,11 @@ public class DatafusionSettingsPropertyTests extends OpenSearchTestCase {
             datafusionSettings.registerListeners(clusterSettings);
 
             int newBatchSize = randomIntBetween(1, 1_000_000);
-            String newSingleStrategy = STRATEGIES[randomIntBetween(0, 2)];
             double newThreshold = randomDoubleBetween(0.0, 1.0, true);
 
             clusterSettings.applySettings(
                 Settings.builder()
-                    .put("datafusion.indexed.batch_size", newBatchSize)
-                    .put("datafusion.indexed.single_collector_strategy", newSingleStrategy)
+                    .put("datafusion.batch_size", newBatchSize)
                     .put("datafusion.indexed.min_skip_run_selectivity_threshold", newThreshold)
                     .build()
             );
@@ -202,11 +136,9 @@ public class DatafusionSettingsPropertyTests extends OpenSearchTestCase {
             WireConfigSnapshot finalSnapshot = datafusionSettings.getSnapshot();
 
             assertEquals(newBatchSize, finalSnapshot.batchSize());
-            assertEquals(DatafusionSettings.strategyToWireValue(newSingleStrategy), finalSnapshot.singleCollectorStrategy());
             assertEquals(newThreshold, finalSnapshot.minSkipRunSelectivityThreshold(), 1e-15);
-            assertEquals(false, finalSnapshot.parquetPushdownFilters());
+            assertEquals(false, finalSnapshot.listingTablePushdownFilters());
             assertEquals(1024, finalSnapshot.minSkipRunDefault());
-            assertEquals(1, finalSnapshot.maxCollectorParallelism());
         }
     }
 }

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionSettingsTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionSettingsTests.java
@@ -17,17 +17,24 @@ public class DatafusionSettingsTests extends OpenSearchTestCase {
     private static final int DEFAULT_PARALLELISM = Math.max(1, Math.min(Runtime.getRuntime().availableProcessors() / 2, 4));
 
     public void testBatchSizeSettingDefinition() {
-        assertEquals("datafusion.indexed.batch_size", DatafusionSettings.INDEXED_BATCH_SIZE.getKey());
-        assertEquals(Integer.valueOf(8192), DatafusionSettings.INDEXED_BATCH_SIZE.get(Settings.EMPTY));
-        assertTrue(DatafusionSettings.INDEXED_BATCH_SIZE.isDynamic());
-        assertTrue(DatafusionSettings.INDEXED_BATCH_SIZE.hasNodeScope());
+        assertEquals("datafusion.batch_size", DatafusionSettings.BATCH_SIZE.getKey());
+        assertEquals(Integer.valueOf(8192), DatafusionSettings.BATCH_SIZE.get(Settings.EMPTY));
+        assertTrue(DatafusionSettings.BATCH_SIZE.isDynamic());
+        assertTrue(DatafusionSettings.BATCH_SIZE.hasNodeScope());
     }
 
-    public void testParquetPushdownFiltersSettingDefinition() {
-        assertEquals("datafusion.indexed.parquet_pushdown_filters", DatafusionSettings.INDEXED_PARQUET_PUSHDOWN_FILTERS.getKey());
-        assertEquals(Boolean.FALSE, DatafusionSettings.INDEXED_PARQUET_PUSHDOWN_FILTERS.get(Settings.EMPTY));
-        assertTrue(DatafusionSettings.INDEXED_PARQUET_PUSHDOWN_FILTERS.isDynamic());
-        assertTrue(DatafusionSettings.INDEXED_PARQUET_PUSHDOWN_FILTERS.hasNodeScope());
+    public void testListingTablePushdownFiltersSettingDefinition() {
+        assertEquals("datafusion.listing_table.pushdown_filters", DatafusionSettings.LISTING_TABLE_PUSHDOWN_FILTERS.getKey());
+        assertEquals(Boolean.FALSE, DatafusionSettings.LISTING_TABLE_PUSHDOWN_FILTERS.get(Settings.EMPTY));
+        assertTrue(DatafusionSettings.LISTING_TABLE_PUSHDOWN_FILTERS.isDynamic());
+        assertTrue(DatafusionSettings.LISTING_TABLE_PUSHDOWN_FILTERS.hasNodeScope());
+    }
+
+    public void testIndexedPushdownFiltersSettingDefinition() {
+        assertEquals("datafusion.indexed.pushdown_filters", DatafusionSettings.INDEXED_PUSHDOWN_FILTERS.getKey());
+        assertEquals(Boolean.TRUE, DatafusionSettings.INDEXED_PUSHDOWN_FILTERS.get(Settings.EMPTY));
+        assertTrue(DatafusionSettings.INDEXED_PUSHDOWN_FILTERS.isDynamic());
+        assertTrue(DatafusionSettings.INDEXED_PUSHDOWN_FILTERS.hasNodeScope());
     }
 
     public void testMinSkipRunDefaultSettingDefinition() {
@@ -47,42 +54,43 @@ public class DatafusionSettingsTests extends OpenSearchTestCase {
         assertTrue(DatafusionSettings.INDEXED_MIN_SKIP_RUN_SELECTIVITY_THRESHOLD.hasNodeScope());
     }
 
-    public void testSingleCollectorStrategySettingDefinition() {
-        assertEquals("datafusion.indexed.single_collector_strategy", DatafusionSettings.INDEXED_SINGLE_COLLECTOR_STRATEGY.getKey());
-        assertEquals("page_range_split", DatafusionSettings.INDEXED_SINGLE_COLLECTOR_STRATEGY.get(Settings.EMPTY));
-        assertTrue(DatafusionSettings.INDEXED_SINGLE_COLLECTOR_STRATEGY.isDynamic());
-        assertTrue(DatafusionSettings.INDEXED_SINGLE_COLLECTOR_STRATEGY.hasNodeScope());
-    }
-
-    public void testTreeCollectorStrategySettingDefinition() {
-        assertEquals("datafusion.indexed.tree_collector_strategy", DatafusionSettings.INDEXED_TREE_COLLECTOR_STRATEGY.getKey());
-        assertEquals("tighten_outer_bounds", DatafusionSettings.INDEXED_TREE_COLLECTOR_STRATEGY.get(Settings.EMPTY));
-        assertTrue(DatafusionSettings.INDEXED_TREE_COLLECTOR_STRATEGY.isDynamic());
-        assertTrue(DatafusionSettings.INDEXED_TREE_COLLECTOR_STRATEGY.hasNodeScope());
-    }
-
-    public void testMaxCollectorParallelismSettingDefinition() {
-        assertEquals("datafusion.indexed.max_collector_parallelism", DatafusionSettings.INDEXED_MAX_COLLECTOR_PARALLELISM.getKey());
-        assertEquals(Integer.valueOf(1), DatafusionSettings.INDEXED_MAX_COLLECTOR_PARALLELISM.get(Settings.EMPTY));
-        assertTrue(DatafusionSettings.INDEXED_MAX_COLLECTOR_PARALLELISM.isDynamic());
-        assertTrue(DatafusionSettings.INDEXED_MAX_COLLECTOR_PARALLELISM.hasNodeScope());
-    }
-
     public void testAllSettingsContainsAllExpectedSettings() {
-        assertEquals(35, DatafusionSettings.ALL_SETTINGS.size());
+        assertEquals(31, DatafusionSettings.ALL_SETTINGS.size());
         assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DataFusionPlugin.DATAFUSION_REDUCE_TARGET_PARTITIONS));
         assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DataFusionPlugin.DATAFUSION_MEMORY_GUARD_SPILL_EXEMPT_CAP));
         assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DataFusionPlugin.DATAFUSION_SPILL_DIRECTORY));
-        assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DatafusionSettings.INDEXED_BATCH_SIZE));
-        assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DatafusionSettings.INDEXED_PARQUET_PUSHDOWN_FILTERS));
-        assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DatafusionSettings.INDEXED_BLOOM_FILTER_ON_READ));
+        assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DatafusionSettings.BATCH_SIZE));
+        assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DatafusionSettings.LISTING_TABLE_PUSHDOWN_FILTERS));
+        assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DatafusionSettings.INDEXED_PUSHDOWN_FILTERS));
         assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DatafusionSettings.INDEXED_MIN_SKIP_RUN_DEFAULT));
         assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DatafusionSettings.INDEXED_MIN_SKIP_RUN_SELECTIVITY_THRESHOLD));
-        assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DatafusionSettings.INDEXED_SINGLE_COLLECTOR_STRATEGY));
-        assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DatafusionSettings.INDEXED_TREE_COLLECTOR_STRATEGY));
-        assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DatafusionSettings.INDEXED_MAX_COLLECTOR_PARALLELISM));
-        assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DatafusionSettings.INDEXED_QUERY_STRATEGY));
-        assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DatafusionSettings.INDEXED_DYNAMIC_FILTER_PUSHDOWN));
+        assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DatafusionSettings.INDEXED_FORCE_STRATEGY));
+    }
+
+    public void testForceStrategySettingDefaultsAndMapping() {
+        assertEquals("datafusion.indexed.force_strategy", DatafusionSettings.INDEXED_FORCE_STRATEGY.getKey());
+        assertEquals("none", DatafusionSettings.INDEXED_FORCE_STRATEGY.get(Settings.EMPTY));
+        assertTrue(DatafusionSettings.INDEXED_FORCE_STRATEGY.isDynamic());
+        assertTrue(DatafusionSettings.INDEXED_FORCE_STRATEGY.hasNodeScope());
+
+        assertEquals(-1, DatafusionSettings.forceStrategyToWire("none"));
+        assertEquals(0, DatafusionSettings.forceStrategyToWire("row_selection"));
+        assertEquals(1, DatafusionSettings.forceStrategyToWire("boolean_mask"));
+
+        // Default snapshot encodes None (-1).
+        assertEquals(-1, new DatafusionSettings(Settings.EMPTY).getSnapshot().forceStrategy());
+
+        // A configured value flows into the snapshot.
+        DatafusionSettings ds = new DatafusionSettings(Settings.builder().put("datafusion.indexed.force_strategy", "boolean_mask").build());
+        assertEquals(1, ds.getSnapshot().forceStrategy());
+
+        // Invalid values are rejected at parse time.
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> DatafusionSettings.INDEXED_FORCE_STRATEGY.get(
+                Settings.builder().put("datafusion.indexed.force_strategy", "bogus").build()
+            )
+        );
     }
 
     public void testDefaultSnapshotValuesMatchDefaults() {
@@ -90,15 +98,10 @@ public class DatafusionSettingsTests extends OpenSearchTestCase {
         WireConfigSnapshot snapshot = ds.getSnapshot();
 
         assertEquals(8192, snapshot.batchSize());
-        assertEquals(false, snapshot.parquetPushdownFilters());
-        assertEquals(true, snapshot.bloomFilterOnRead());
+        assertEquals(false, snapshot.listingTablePushdownFilters());
         assertEquals(1024, snapshot.minSkipRunDefault());
         assertEquals(0.03, snapshot.minSkipRunSelectivityThreshold(), 1e-15);
-        assertEquals(2, snapshot.singleCollectorStrategy()); // page_range_split
-        assertEquals(1, snapshot.treeCollectorStrategy()); // tighten_outer_bounds
-        assertEquals(1, snapshot.maxCollectorParallelism());
         assertEquals(DEFAULT_PARALLELISM, snapshot.targetPartitions());
-        assertEquals(2, snapshot.queryStrategy()); // indexed
     }
 
     public void testTargetPartitionsPassthroughWhenNonZero() {
@@ -136,54 +139,13 @@ public class DatafusionSettingsTests extends OpenSearchTestCase {
         assertEquals(processors, ds.getSnapshot().targetPartitions());
     }
 
-    public void testStrategyToWireValueMapping() {
-        assertEquals(0, DatafusionSettings.strategyToWireValue("full_range"));
-        assertEquals(1, DatafusionSettings.strategyToWireValue("tighten_outer_bounds"));
-        assertEquals(2, DatafusionSettings.strategyToWireValue("page_range_split"));
-        expectThrows(IllegalArgumentException.class, () -> DatafusionSettings.strategyToWireValue("invalid"));
-    }
-
-    public void testQueryStrategySettingDefinition() {
-        assertEquals("datafusion.indexed.query_strategy", DatafusionSettings.INDEXED_QUERY_STRATEGY.getKey());
-        assertEquals("indexed", DatafusionSettings.INDEXED_QUERY_STRATEGY.get(Settings.EMPTY));
-        assertTrue(DatafusionSettings.INDEXED_QUERY_STRATEGY.isDynamic());
-        assertTrue(DatafusionSettings.INDEXED_QUERY_STRATEGY.hasNodeScope());
-    }
-
-    public void testQueryStrategyToWireValueMapping() {
-        assertEquals(0, DatafusionSettings.queryStrategyToWireValue("none"));
-        assertEquals(1, DatafusionSettings.queryStrategyToWireValue("listing_table"));
-        assertEquals(2, DatafusionSettings.queryStrategyToWireValue("indexed"));
-        expectThrows(IllegalArgumentException.class, () -> DatafusionSettings.queryStrategyToWireValue("invalid"));
-    }
-
-    public void testInvalidQueryStrategyIsRejected() {
-        Settings settings = Settings.builder().put("datafusion.indexed.query_strategy", "bogus").build();
-        expectThrows(IllegalArgumentException.class, () -> DatafusionSettings.INDEXED_QUERY_STRATEGY.get(settings));
-    }
-
     public void testBatchSizeZeroIsRejected() {
-        Settings settings = Settings.builder().put("datafusion.indexed.batch_size", 0).build();
-        expectThrows(IllegalArgumentException.class, () -> DatafusionSettings.INDEXED_BATCH_SIZE.get(settings));
-    }
-
-    public void testMaxCollectorParallelismNegativeIsRejected() {
-        Settings settings = Settings.builder().put("datafusion.indexed.max_collector_parallelism", -1).build();
-        expectThrows(IllegalArgumentException.class, () -> DatafusionSettings.INDEXED_MAX_COLLECTOR_PARALLELISM.get(settings));
+        Settings settings = Settings.builder().put("datafusion.batch_size", 0).build();
+        expectThrows(IllegalArgumentException.class, () -> DatafusionSettings.BATCH_SIZE.get(settings));
     }
 
     public void testSelectivityThresholdAboveBoundIsRejected() {
         Settings settings = Settings.builder().put("datafusion.indexed.min_skip_run_selectivity_threshold", 1.1).build();
         expectThrows(IllegalArgumentException.class, () -> DatafusionSettings.INDEXED_MIN_SKIP_RUN_SELECTIVITY_THRESHOLD.get(settings));
-    }
-
-    public void testInvalidSingleCollectorStrategyIsRejected() {
-        Settings settings = Settings.builder().put("datafusion.indexed.single_collector_strategy", "bogus").build();
-        expectThrows(IllegalArgumentException.class, () -> DatafusionSettings.INDEXED_SINGLE_COLLECTOR_STRATEGY.get(settings));
-    }
-
-    public void testInvalidTreeCollectorStrategyIsRejected() {
-        Settings settings = Settings.builder().put("datafusion.indexed.tree_collector_strategy", "bogus").build();
-        expectThrows(IllegalArgumentException.class, () -> DatafusionSettings.INDEXED_TREE_COLLECTOR_STRATEGY.get(settings));
     }
 }

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/WireConfigSnapshotTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/WireConfigSnapshotTests.java
@@ -17,21 +17,16 @@ import java.lang.foreign.ValueLayout;
 public class WireConfigSnapshotTests extends OpenSearchTestCase {
 
     public void testByteSize() {
-        assertEquals(80L, WireConfigSnapshot.BYTE_SIZE);
+        assertEquals(52L, WireConfigSnapshot.BYTE_SIZE);
     }
 
     public void testWriteToWritesCorrectValuesAtCorrectOffsets() {
         WireConfigSnapshot snapshot = WireConfigSnapshot.builder()
             .batchSize(8192)
             .targetPartitions(4)
-            .parquetPushdownFilters(true)
+            .listingTablePushdownFilters(true)
             .minSkipRunDefault(1024)
             .minSkipRunSelectivityThreshold(0.03)
-            .maxCollectorParallelism(4)
-            .singleCollectorStrategy(2)
-            .treeCollectorStrategy(1)
-            .queryStrategy(2)
-            .indexedDynamicFilterPushdown(true)
             .build();
 
         try (Arena arena = Arena.ofConfined()) {
@@ -42,17 +37,12 @@ public class WireConfigSnapshotTests extends OpenSearchTestCase {
             assertEquals(4L, segment.get(ValueLayout.JAVA_LONG, 8));
             assertEquals(1024L, segment.get(ValueLayout.JAVA_LONG, 16));
             assertEquals(0.03, segment.get(ValueLayout.JAVA_DOUBLE, 24), 1e-15);
-            assertEquals(1, segment.get(ValueLayout.JAVA_INT, 32)); // parquet_pushdown = true
-            assertEquals(4, segment.get(ValueLayout.JAVA_INT, 56)); // max_collector_parallelism
-            assertEquals(2, segment.get(ValueLayout.JAVA_INT, 60)); // single_collector_strategy
-            assertEquals(1, segment.get(ValueLayout.JAVA_INT, 64)); // tree_collector_strategy
-            assertEquals(2, segment.get(ValueLayout.JAVA_INT, 68)); // query_strategy = IndexedPredicateOnly
-            assertEquals(1, segment.get(ValueLayout.JAVA_INT, 76)); // indexed_dynamic_filter_pushdown = true
+            assertEquals(1, segment.get(ValueLayout.JAVA_INT, 32)); // listing_table_pushdown = true
         }
     }
 
-    public void testWriteToWritesParquetPushdownFalseAsZero() {
-        WireConfigSnapshot snapshot = WireConfigSnapshot.builder().parquetPushdownFilters(false).build();
+    public void testWriteToWritesListingTablePushdownFalseAsZero() {
+        WireConfigSnapshot snapshot = WireConfigSnapshot.builder().listingTablePushdownFilters(false).build();
 
         try (Arena arena = Arena.ofConfined()) {
             MemorySegment segment = arena.allocate(WireConfigSnapshot.BYTE_SIZE);
@@ -63,17 +53,41 @@ public class WireConfigSnapshotTests extends OpenSearchTestCase {
     }
 
     public void testHardcodedFieldsAreWrittenCorrectly() {
-        WireConfigSnapshot snapshot = WireConfigSnapshot.builder().batchSize(16384).targetPartitions(8).maxCollectorParallelism(6).build();
+        WireConfigSnapshot snapshot = WireConfigSnapshot.builder().batchSize(16384).targetPartitions(8).build();
 
         try (Arena arena = Arena.ofConfined()) {
             MemorySegment segment = arena.allocate(WireConfigSnapshot.BYTE_SIZE);
             snapshot.writeTo(segment);
 
-            assertEquals(1, segment.get(ValueLayout.JAVA_INT, 36));  // indexed_pushdown_filters
-            assertEquals(-1, segment.get(ValueLayout.JAVA_INT, 40)); // force_strategy
-            assertEquals(-1, segment.get(ValueLayout.JAVA_INT, 44)); // force_pushdown
-            assertEquals(1, segment.get(ValueLayout.JAVA_INT, 48));  // cost_predicate (hardcoded)
-            assertEquals(10, segment.get(ValueLayout.JAVA_INT, 52)); // cost_collector (hardcoded)
+            assertEquals(1, segment.get(ValueLayout.JAVA_INT, 36));  // indexed_pushdown_filters default (true)
+            assertEquals(-1, segment.get(ValueLayout.JAVA_INT, 40)); // force_strategy default (None)
+            assertEquals(1, segment.get(ValueLayout.JAVA_INT, 44));  // cost_predicate (hardcoded)
+            assertEquals(10, segment.get(ValueLayout.JAVA_INT, 48)); // cost_collector (hardcoded)
+        }
+    }
+
+    public void testIndexedPushdownFiltersIsWrittenFromSnapshot() {
+        for (boolean v : new boolean[] { true, false }) {
+            WireConfigSnapshot snapshot = WireConfigSnapshot.builder().indexedPushdownFilters(v).build();
+            try (Arena arena = Arena.ofConfined()) {
+                MemorySegment segment = arena.allocate(WireConfigSnapshot.BYTE_SIZE);
+                snapshot.writeTo(segment);
+                assertEquals(v ? 1 : 0, segment.get(ValueLayout.JAVA_INT, 36));
+            }
+            assertEquals(v, snapshot.indexedPushdownFilters());
+        }
+    }
+
+    public void testForceStrategyIsWrittenFromSnapshot() {
+        // 0 = RowSelection, 1 = BooleanMask, -1 = None
+        for (int wire : new int[] { -1, 0, 1 }) {
+            WireConfigSnapshot snapshot = WireConfigSnapshot.builder().forceStrategy(wire).build();
+            try (Arena arena = Arena.ofConfined()) {
+                MemorySegment segment = arena.allocate(WireConfigSnapshot.BYTE_SIZE);
+                snapshot.writeTo(segment);
+                assertEquals(wire, segment.get(ValueLayout.JAVA_INT, 40));
+            }
+            assertEquals(wire, snapshot.forceStrategy());
         }
     }
 
@@ -82,44 +96,31 @@ public class WireConfigSnapshotTests extends OpenSearchTestCase {
 
         assertEquals(8192, snapshot.batchSize());
         assertEquals(4, snapshot.targetPartitions());
-        assertEquals(false, snapshot.parquetPushdownFilters());
-        assertEquals(true, snapshot.bloomFilterOnRead());
+        assertEquals(false, snapshot.listingTablePushdownFilters());
         assertEquals(1024, snapshot.minSkipRunDefault());
         assertEquals(0.03, snapshot.minSkipRunSelectivityThreshold(), 1e-15);
-        assertEquals(1, snapshot.maxCollectorParallelism());
-        assertEquals(2, snapshot.singleCollectorStrategy());  // page_range_split
-        assertEquals(1, snapshot.treeCollectorStrategy());    // tighten_outer_bounds
-        assertEquals(2, snapshot.queryStrategy());            // IndexedPredicateOnly
-        assertEquals(true, snapshot.indexedDynamicFilterPushdown()); // on by default
+        assertEquals(true, snapshot.indexedPushdownFilters());
     }
 
     public void testBuilderCopyPreservesAllFields() {
         WireConfigSnapshot original = WireConfigSnapshot.builder()
             .batchSize(4096)
             .targetPartitions(16)
-            .parquetPushdownFilters(true)
-            .bloomFilterOnRead(false)
+            .listingTablePushdownFilters(true)
             .minSkipRunDefault(512)
             .minSkipRunSelectivityThreshold(0.5)
-            .maxCollectorParallelism(8)
-            .singleCollectorStrategy(0)
-            .treeCollectorStrategy(2)
-            .queryStrategy(1)
-            .indexedDynamicFilterPushdown(false)
+            .indexedPushdownFilters(false)
+            .forceStrategy(1)
             .build();
 
         WireConfigSnapshot copy = WireConfigSnapshot.builder(original).build();
 
         assertEquals(original.batchSize(), copy.batchSize());
         assertEquals(original.targetPartitions(), copy.targetPartitions());
-        assertEquals(original.parquetPushdownFilters(), copy.parquetPushdownFilters());
-        assertEquals(original.bloomFilterOnRead(), copy.bloomFilterOnRead());
+        assertEquals(original.listingTablePushdownFilters(), copy.listingTablePushdownFilters());
         assertEquals(original.minSkipRunDefault(), copy.minSkipRunDefault());
         assertEquals(original.minSkipRunSelectivityThreshold(), copy.minSkipRunSelectivityThreshold(), 0.0);
-        assertEquals(original.maxCollectorParallelism(), copy.maxCollectorParallelism());
-        assertEquals(original.singleCollectorStrategy(), copy.singleCollectorStrategy());
-        assertEquals(original.treeCollectorStrategy(), copy.treeCollectorStrategy());
-        assertEquals(original.queryStrategy(), copy.queryStrategy());
-        assertEquals(original.indexedDynamicFilterPushdown(), copy.indexedDynamicFilterPushdown());
+        assertEquals(original.indexedPushdownFilters(), copy.indexedPushdownFilters());
+        assertEquals(original.forceStrategy(), copy.forceStrategy());
     }
 }


### PR DESCRIPTION
### Description

Cleanup of the DataFusion analytics backend's **indexed query path**: remove dead/over-engineered per-query tuning knobs, fix the misleading/ hardcoded settings that remained, and consolidate the duplicated per-query setup shared by the indexed and ListingTable execution paths.

#### 1. Removed dead developer A/B/debug knobs

Six per-query settings were dev knobs whose production default was the only value ever used. Each was deleted (setting + FFM wire field + Rust config field + consumers) and hardcoded to its default:

| Removed setting | Hardcoded to |
|---|---|
| `datafusion.indexed.query_strategy` | QTF row-id computation **always** runs in the indexed executor; the `ListingTable`/`None` strategies (+ `ShardTableProvider` / `ProjectRowIdOptimizer` machinery) are dead-arm-collapsed |
| `datafusion.indexed.dynamic_filter_pushdown` | **true** |
| `datafusion.indexed.single_collector_strategy` | **PageRangeSplit** |
| `datafusion.indexed.tree_collector_strategy` | **TightenOuterBounds** |
| `datafusion.indexed.max_collector_parallelism` | **1** |
| `datafusion.indexed.bloom_filter_on_read` | **true** |

#### 2. Settings corrections

- **`force_strategy` → real setting.** The per-RG `min_skip_run` strategy override (`FilterStrategy`) was `#[cfg(test)]`-only. Promoted to a dynamic node-scope setting **`datafusion.indexed.force_strategy`** (`none` | `row_selection` | `boolean_mask`), wired Java→FFI→Rust.
- **`force_pushdown` removed.** A `#[cfg(test)]` per-query override that duplicated the production `indexed_pushdown_filters`. Removed from the config + wire struct; test call sites migrated to set `indexed_pushdown_filters` directly (fuzz harness keeps its `Option<bool>` knob).
- **`parquet_pushdown_filters` renamed** → **`datafusion.listing_table.pushdown_filters`** (it controls the ListingTable path's DataFusion decode-time pushdown, not the indexed path — the old name was misleading).
- **`indexed_pushdown_filters` made dynamic.** Was hardcoded to `1` in the wire snapshot; now a real setting **`datafusion.indexed.pushdown_filters`** (default `true`), wired through the snapshot + update listener.

#### 3. Final indexed settings

| Setting | Type | Default | Feeds |
|---|---|---|---|
| `datafusion.batch_size` | int | 8192 | both paths (DF batch size) |
| `datafusion.listing_table.pushdown_filters` | bool | false | ListingTable path (DF `parquet.pushdown_filters`) |
| `datafusion.indexed.pushdown_filters` | bool | true | indexed path (`RowFilter` residual pushdown) |
| `datafusion.indexed.min_skip_run_default` | int | 1024 | indexed path |
| `datafusion.indexed.min_skip_run_selectivity_threshold` | double | 0.03 | indexed path |
| `datafusion.indexed.force_strategy` | string | `none` | indexed path (`min_skip_run` strategy override) |

`target_partitions` is derived from `search.concurrent_segment_search.*` (not a direct setting). `cost_predicate`/`cost_collector` remain hardcoded wire constants (used by the indexed cost model). All node-scope + dynamic.

#### 4. Refactors (no behavior change)

- Consolidated the per-query setup shared by both executors into `helper.rs`:
  - `build_query_runtime_env_with_store` — RuntimeEnv + optional pool overlay + shard-store registration
  - `new_query_tracking_context` — tracking context + per-query pool extraction
  - `register_listing_table` — ListingTable registration (+ optional sort order)
  - `build_query_session_context` — SessionConfig/State/Context + base UDFs, with an `indexed_path` flag for the optimizer-rule + `index_filter`/`delegation_possible` UDF differences
- Extracted `resolve_effective_config` (disk-pressure cap + memory budget).
- Imports lifted to the top of each file (no inline `crate::`/`super::` paths).

#### Wire ABI

The Java `WireConfigSnapshot.writeTo` offsets and the Rust `#[repr(C)] WireDatafusionQueryConfig` stay in exact lockstep. Net layout: **80 → 52 bytes**. `DatafusionSettings.ALL_SETTINGS` / `plugin.getSettings()`: **28 → 24**.

### Related Issues
N/A — sandbox/experimental analytics backend cleanup.

### Check List
- [x] Functionality includes testing — Rust config wire round-trip unit tests + affected e2e tests; Java `WireConfigSnapshotTests`, `DatafusionSettingsTests`, `DatafusionSettingsPropertyTests`, `DataFusionPluginSettingsTests`, and `DatafusionDynamicSettingsIT` updated and passing.
- [ ] API changes companion pull request created, if applicable. (No external API change.)
- [ ] Public documentation issue/PR created, if applicable. (Internal sandbox plugin.)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

