### PR TITLE
Fixes for lazily loading parquet metadata

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/cache.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/cache.rs
@@ -14,6 +14,8 @@ use datafusion::execution::cache::cache_manager::{
 };
 use datafusion::execution::cache::DefaultFilesMetadataCache;
 use datafusion::execution::cache::CacheAccessor;
+use datafusion::datasource::physical_plan::parquet::metadata::CachedParquetMetaData;
+use datafusion::parquet::file::metadata::ParquetMetaData;
 use log::error;
 use object_store::path::Path;
 
@@ -24,6 +26,38 @@ pub const CACHE_TYPE_STATS: &str = "STATISTICS";
 // Helper function to log cache operations
 fn log_cache_error(operation: &str, error: &str) {
     error!("[CACHE ERROR] {} operation failed: {}", operation, error);
+}
+
+/// Return a cache entry whose `ParquetMetaData` carries footer-only metadata
+/// (no `ColumnIndex` / `OffsetIndex`). If the entry already lacks a page index —
+/// or isn't a `CachedParquetMetaData` at all — it's returned unchanged (no
+/// clone, no rebuild).
+fn strip_page_index(entry: CachedFileMetadataEntry) -> CachedFileMetadataEntry {
+    let Some(cached) = entry
+        .file_metadata
+        .as_any()
+        .downcast_ref::<CachedParquetMetaData>()
+    else {
+        return entry;
+    };
+    let meta = cached.parquet_metadata();
+    if meta.column_index().is_none() && meta.offset_index().is_none() {
+        // Already footer-only — keep the existing Arc, avoid a rebuild.
+        return entry;
+    }
+
+    // Rebuild without the page index. `ParquetMetaData` is cheap to reconstruct
+    // here (we only drop the two index vectors); the heavy decoded structures are
+    // released when the original Arc drops.
+    let stripped = ParquetMetaData::clone(meta)
+        .into_builder()
+        .set_column_index(None)
+        .set_offset_index(None)
+        .build();
+    CachedFileMetadataEntry::new(
+        entry.meta,
+        Arc::new(CachedParquetMetaData::new(Arc::new(stripped))),
+    )
 }
 
 // Wrapper to make Mutex<DefaultFilesMetadataCache> implement FileMetadataCache
@@ -96,6 +130,25 @@ impl CacheAccessor<Path, CachedFileMetadataEntry> for MutexFileMetadataCache {
     }
 
     fn put(&self, k: &Path, v: CachedFileMetadataEntry) -> Option<CachedFileMetadataEntry> {
+        // Enforce the footer-only invariant at the single cache chokepoint.
+        //
+        // DataFusion's parquet paths (`infer_schema`, the scan opener,
+        // `fetch_statistics`) hand this cache to `DFParquetMetadata::fetch_metadata`,
+        // which force-decodes the FULL page index (`ColumnIndex` + `OffsetIndex`
+        // for every column of every row group) before calling `put`
+        // (`datafusion-datasource-parquet/src/metadata.rs:156`). On wide schemas
+        // that decoded index is ~82% of the native heap and, since this is a shared
+        // LRU keyed by path, it also evicts the small footer-only entries the
+        // indexed path depends on.
+        //
+        // We can't stop DataFusion from decoding it, but we can refuse to *retain*
+        // it: strip the page index here so the cache only ever holds footer-only
+        // metadata. Page-level pruning is unaffected — the indexed path rebuilds a
+        // predicate-scoped page index per query (`indexed_table::page_index_loader`),
+        // and the vanilla scan opener re-reads the page index on demand into its
+        // own local reader state without ever putting it back here
+        // (`opener/mod.rs::load_page_index`).
+        let v = strip_page_index(v);
         match self.inner.lock() {
             Ok(cache) => cache.put(k, v),
             Err(e) => {
@@ -179,5 +232,130 @@ impl FileMetadataCache for MutexFileMetadataCache {
                 std::collections::HashMap::new()
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod strip_page_index_tests {
+    use super::*;
+    use datafusion::arrow::array::{Int64Array, RecordBatch};
+    use datafusion::arrow::datatypes::{DataType, Field, Schema};
+    use datafusion::parquet::arrow::arrow_reader::{ArrowReaderMetadata, ArrowReaderOptions};
+    use datafusion::parquet::arrow::ArrowWriter;
+    use datafusion::parquet::file::properties::{EnabledStatistics, WriterProperties};
+    use object_store::ObjectMeta;
+    use prost::bytes::Bytes;
+
+    /// Multi-page parquet bytes (page-level stats → a real page index).
+    fn parquet_with_page_index() -> Bytes {
+        let schema = Arc::new(Schema::new(vec![Field::new("v", DataType::Int64, false)]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(Int64Array::from((0..4096i64).collect::<Vec<_>>()))],
+        )
+        .unwrap();
+        let props = WriterProperties::builder()
+            .set_statistics_enabled(EnabledStatistics::Page)
+            .set_data_page_row_count_limit(128)
+            .build();
+        let mut buf: Vec<u8> = Vec::new();
+        let mut w = ArrowWriter::try_new(&mut buf, schema, Some(props)).unwrap();
+        w.write(&batch).unwrap();
+        w.close().unwrap();
+        Bytes::from(buf)
+    }
+
+    fn full_index_entry(bytes: &Bytes) -> CachedFileMetadataEntry {
+        let meta = ArrowReaderMetadata::load(
+            &bytes.clone(),
+            ArrowReaderOptions::new().with_page_index(true),
+        )
+        .unwrap();
+        let pq = meta.metadata().clone();
+        assert!(
+            pq.column_index().is_some() && pq.offset_index().is_some(),
+            "fixture must carry a page index"
+        );
+        let om = ObjectMeta {
+            location: Path::from("data.parquet"),
+            last_modified: chrono::Utc::now(),
+            size: bytes.len() as u64,
+            e_tag: None,
+            version: None,
+        };
+        CachedFileMetadataEntry::new(om, Arc::new(CachedParquetMetaData::new(pq)))
+    }
+
+    fn page_index_present(entry: &CachedFileMetadataEntry) -> bool {
+        let cached = entry
+            .file_metadata
+            .as_any()
+            .downcast_ref::<CachedParquetMetaData>()
+            .unwrap();
+        let m = cached.parquet_metadata();
+        m.column_index().is_some() || m.offset_index().is_some()
+    }
+
+    /// `put` of a full-index entry must store it footer-only; a subsequent `get`
+    /// returns metadata without a page index, but with footer row-group stats.
+    #[test]
+    fn put_strips_page_index_and_get_returns_footer_only() {
+        let bytes = parquet_with_page_index();
+        let entry = full_index_entry(&bytes);
+        assert!(page_index_present(&entry), "precondition: entry has page index");
+
+        let cache = MutexFileMetadataCache::new(DefaultFilesMetadataCache::new(64 * 1024 * 1024));
+        let key = Path::from("data.parquet");
+        cache.put(&key, entry);
+
+        let got = cache.get(&key).expect("entry must be retrievable");
+        assert!(
+            !page_index_present(&got),
+            "cached entry must be footer-only after put"
+        );
+        let cached = got
+            .file_metadata
+            .as_any()
+            .downcast_ref::<CachedParquetMetaData>()
+            .unwrap();
+        let m = cached.parquet_metadata();
+        assert!(m.num_row_groups() > 0);
+        assert!(
+            m.row_group(0).column(0).statistics().is_some(),
+            "footer row-group stats must survive the strip"
+        );
+    }
+
+    /// A strip of an already-footer-only entry keeps the SAME inner Arc (no
+    /// pointless rebuild).
+    #[test]
+    fn strip_is_noop_for_footer_only_entry() {
+        let bytes = parquet_with_page_index();
+        let meta = ArrowReaderMetadata::load(
+            &bytes.clone(),
+            ArrowReaderOptions::new().with_page_index(false),
+        )
+        .unwrap();
+        let pq = meta.metadata().clone();
+        assert!(pq.column_index().is_none() && pq.offset_index().is_none());
+        let om = ObjectMeta {
+            location: Path::from("data.parquet"),
+            last_modified: chrono::Utc::now(),
+            size: bytes.len() as u64,
+            e_tag: None,
+            version: None,
+        };
+        let entry = CachedFileMetadataEntry::new(om, Arc::new(CachedParquetMetaData::new(Arc::clone(&pq))));
+
+        let stripped = strip_page_index(entry);
+        let cached = stripped
+            .file_metadata
+            .as_any()
+            .downcast_ref::<CachedParquetMetaData>()
+            .unwrap();
+        assert!(
+            Arc::ptr_eq(cached.parquet_metadata(), &pq),
+            "footer-only entry must be returned unchanged (same Arc, no rebuild)"
+        );
     }
 }

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/custom_cache_manager.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/custom_cache_manager.rs
@@ -15,7 +15,6 @@ use crate::cache::MutexFileMetadataCache;
 use crate::statistics_cache::CustomStatisticsCache;
 use object_store::path::Path;
 use object_store::ObjectMeta;
-use datafusion::datasource::physical_plan::parquet::metadata::DFParquetMetadata;
 use log::{debug, error};
 
 /// Create ObjectMeta from a local file path.
@@ -86,10 +85,26 @@ impl CustomCacheManager {
     pub fn build_cache_manager_config(&self) -> CacheManagerConfig {
         let mut config = CacheManagerConfig::default();
 
-        // Add file metadata cache if available
+        // Add file metadata cache. If one was explicitly configured, use it.
+        // Otherwise install our own `MutexFileMetadataCache` wrapping a default
+        // rather than letting DataFusion auto-install a bare
+        // `DefaultFilesMetadataCache`. This matters because
+        // `MutexFileMetadataCache::put` enforces the footer-only invariant
+        // (strips the page index DataFusion force-decodes); a bare default cache
+        // would retain the full page index and reintroduce the heap blowup. See
+        // `crate::cache::strip_page_index`.
         if let Some(cache) = self.get_file_metadata_cache_for_datafusion() {
             config = config.with_file_metadata_cache(Some(cache.clone()))
                 .with_metadata_cache_limit(cache.cache_limit());
+        } else {
+            // Mirror the default limit DataFusion would have used.
+            let default_limit = CacheManagerConfig::default().metadata_cache_limit;
+            let wrapped = Arc::new(crate::cache::MutexFileMetadataCache::new(
+                datafusion::execution::cache::DefaultFilesMetadataCache::new(default_limit),
+            )) as Arc<dyn FileMetadataCache>;
+            config = config
+                .with_file_metadata_cache(Some(wrapped))
+                .with_metadata_cache_limit(default_limit);
         }
 
         // Add statistics cache if available - use CustomStatisticsCache directly
@@ -351,7 +366,8 @@ impl CustomCacheManager {
         let object_meta = object_metas.first()
             .ok_or_else(|| "No object metadata returned".to_string())?;
 
-        let store = Arc::new(object_store::local::LocalFileSystem::new());
+        let store: Arc<dyn object_store::ObjectStore> =
+            Arc::new(object_store::local::LocalFileSystem::new());
 
         // Get cache reference for DataFusion metadata loading
         let cache_ref = self.file_metadata_cache.as_ref()
@@ -359,19 +375,30 @@ impl CustomCacheManager {
 
         let metadata_cache = cache_ref.clone() as Arc<dyn FileMetadataCache>;
 
-        // Use DataFusion's metadata loading by passing reference to file_metadata_cache to get complete metadata
-        // IMPORTANT: When a cache is provided to DFParquetMetadata, fetch_metadata() will:
-        // 1. Enable page index loading (with_page_indexes(true))
-        // 2. Load the complete metadata including column and offset indexes
-        // 3. Automatically put the metadata into the cache (lines 155-160 in datafusion's metadata.rs)
-        // This ensures we cache exactly what DataFusion would cache during query execution
-        let _parquet_metadata = rt_handle.block_on(async {
-            let df_metadata = DFParquetMetadata::new(store.as_ref(), object_meta)
-                .with_file_metadata_cache(Some(metadata_cache));
-
-            // fetch_metadata() performs the cache put operation internally
-            df_metadata.fetch_metadata().await
-                .map_err(|e| format!("Failed to fetch metadata: {}", e))
+        // Warm the cache with FOOTER-ONLY metadata (row-group stats, schema), NOT
+        // the full page index.
+        //
+        // The previous implementation handed the cache to `DFParquetMetadata` and
+        // let `fetch_metadata` populate it — which forces a full page-index decode
+        // (`PageIndexPolicy::Optional`) for every column of every row group
+        // (`datafusion-datasource-parquet/src/metadata.rs:156`). On wide schemas
+        // that decoded index dominates the native heap, so pre-warming it here was
+        // pinning the worst case into the shared cache at startup.
+        //
+        // `parquet_bridge::load_parquet_metadata` decodes footer-only and publishes
+        // that entry to this same shared cache. Page-level pruning is restored
+        // per-query, scoped to predicate columns (see
+        // `indexed_table::page_index_loader`), so warming the full index here buys
+        // nothing but heap.
+        rt_handle.block_on(async {
+            crate::indexed_table::parquet_bridge::load_parquet_metadata(
+                Arc::clone(&store),
+                &object_meta.location,
+                Arc::clone(&metadata_cache),
+            )
+            .await
+            .map(|_| ())
+            .map_err(|e| format!("Failed to fetch metadata: {}", e))
         })?;
 
         // Verify the metadata was cached properly

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_executor.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_executor.rs
@@ -812,7 +812,7 @@ async unsafe fn execute_indexed_with_context_inner(
     let state = ctx.state();
     let metadata_cache = state.runtime_env().cache_manager.get_file_metadata_cache();
 
-    let (segments, schema) = build_segments(
+    let (mut segments, schema) = build_segments(
         &state,
         Arc::clone(&store),
         object_metas.as_ref(),
@@ -920,6 +920,61 @@ async unsafe fn execute_indexed_with_context_inner(
     });
 
     let predicate_columns = collect_predicate_column_indices(extraction.as_ref());
+
+    // Restore page-level pruning, scoped to predicate columns only.
+    //
+    // `build_segments` loads footer-only metadata (no page index) to keep the
+    // native heap bounded. The page pruner needs `ColumnIndex`/`OffsetIndex`,
+    // but only for the columns the predicate references. Here — once we know
+    // those columns — we lazily fetch+decode just their page index per segment
+    // and swap in the augmented metadata. On any failure each segment keeps its
+    // footer-only metadata and the pruner conservatively scans the whole RG
+    // (correct, just less pruning). Skipped entirely when there's no predicate.
+    if !predicate_columns.is_empty() {
+        let predicate_column_names: Vec<String> = predicate_columns
+            .iter()
+            .filter_map(|&i| schema.fields().get(i).map(|f| f.name().clone()))
+            .collect();
+        if !predicate_column_names.is_empty() {
+            // Keep the scoped page-index cache's byte budget in step with the
+            // runtime's configured metadata-cache limit (same tuning knob the
+            // footer cache uses). Cheap + idempotent.
+            crate::indexed_table::page_index_loader::set_scoped_cache_limit(
+                state.runtime_env().cache_manager.get_metadata_cache_limit(),
+            );
+            // Fetch each segment's scoped page index concurrently — these are
+            // independent small range-reads that funnel onto the IO runtime via
+            // the SpawnIoStore-wrapped object store. Serializing them would add
+            // ~num_segments round-trips to query setup.
+            use futures::future::join_all;
+            let futures = segments.iter().map(|segment| {
+                let parquet_cols =
+                    crate::indexed_table::page_index_loader::resolve_predicate_parquet_columns(
+                        &schema,
+                        &segment.metadata,
+                        &predicate_column_names,
+                    );
+                let store = Arc::clone(&store);
+                let object_path = segment.object_path.clone();
+                let footer = Arc::clone(&segment.metadata);
+                async move {
+                    crate::indexed_table::page_index_loader::load_scoped_page_index(
+                        &store,
+                        &object_path,
+                        &footer,
+                        &parquet_cols,
+                    )
+                    .await
+                }
+            });
+            let augmented = join_all(futures).await;
+            for (segment, maybe_aug) in segments.iter_mut().zip(augmented) {
+                if let Some(aug) = maybe_aug {
+                    segment.metadata = aug;
+                }
+            }
+        }
+    }
 
     let factory: EvaluatorFactory = match classification {
         FilterClass::None => {

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/mod.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/mod.rs
@@ -62,6 +62,7 @@ pub mod row_id_injection;
 pub mod ffm_callbacks;
 pub mod index;
 pub mod metrics;
+pub mod page_index_loader;
 pub mod page_pruner;
 pub mod parquet_bridge;
 pub mod partitioning;

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/page_index_loader.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/page_index_loader.rs
@@ -17,30 +17,49 @@
 //! production profiles) while only a handful of predicate columns are ever
 //! pruned on.
 //!
-//! This module restores page-level pruning **scoped to the predicate columns
-//! only**. Given a footer-only `ParquetMetaData` and the parquet column indices
-//! the query's predicate references, it:
+//! This module restores page-level pruning while keeping the heavy
+//! `ColumnIndex` **scoped to the predicate columns only**. Given a footer-only
+//! `ParquetMetaData` and the parquet column indices the query's predicate
+//! references, it:
 //!
-//!   1. Range-reads just those columns' `ColumnIndex` / `OffsetIndex` bytes
-//!      (per row group) over the object store, on the IO runtime.
+//!   1. Range-reads (per row group) the predicate columns' `ColumnIndex` bytes
+//!      plus *every* column's `OffsetIndex` bytes over the object store, on the
+//!      IO runtime.
 //!   2. Decodes them with arrow-rs's public per-column readers
 //!      ([`read_columns_indexes`] / [`read_offset_indexes`], which take a
 //!      `&[ColumnChunkMetaData]` slice).
-//!   3. Scatters the decoded entries into full-width per-RG vectors — real
-//!      entries at predicate-column positions, cheap placeholders elsewhere
-//!      ([`ColumnIndexMetaData::NONE`] / an empty `OffsetIndexMetaData`) — so
-//!      that `StatisticsConverter`'s absolute `index[rg][parquet_col]` indexing
-//!      stays valid.
-//!   4. Rebuilds a `ParquetMetaData` carrying that sparse page index.
+//!   3. Builds full-width per-RG vectors:
+//!      - `ColumnIndex`: real entries at predicate-column positions,
+//!        [`ColumnIndexMetaData::NONE`] placeholders elsewhere. The page pruner's
+//!        `StatisticsConverter` only dereferences predicate positions, so the
+//!        placeholders keep absolute `index[rg][parquet_col]` indexing valid and
+//!        cost almost nothing.
+//!      - `OffsetIndex`: real entries for *all* columns (no placeholders).
+//!   4. Rebuilds a `ParquetMetaData` carrying that page index.
+//!
+//! ## Why the OffsetIndex is kept for all columns (not just predicate columns)
+//!
+//! The `ColumnIndex` is read only at *prune* time, and only for predicate
+//! columns — so scoping it is safe and is where the heap savings come from. The
+//! `OffsetIndex` is different: it is also read at *scan* time. When the pruner
+//! produces a `RowSelection`, arrow-rs's `InMemoryRowGroup::fetch_ranges`
+//! dereferences `offset_index[col].page_locations` for every **projected**
+//! column (by absolute index) to compute which page byte ranges to fetch. If a
+//! projected column had only an empty placeholder there, the reader would fetch
+//! zero page ranges for it and fail with "failed to skip rows, expected N, got
+//! 0". This loader runs before the projection is known, so it keeps a real
+//! `OffsetIndex` for every column. That is cheap relative to the `ColumnIndex`:
+//! fixed-width page offsets/sizes with no per-page string min/max stats.
 //!
 //! The result is cached by `(file path, predicate-column-set)` so repeated
 //! queries over the same columns skip the re-decode.
 //!
 //! # Memory
 //!
-//! The augmented metadata retains page index for the predicate columns only —
-//! a few columns instead of all ~hundreds. Resident footprint stays close to
-//! the footer-only baseline; the scoped cache is bounded (see
+//! The augmented metadata retains the (heavy) `ColumnIndex` for the predicate
+//! columns only — a few columns instead of all ~hundreds — plus the (light)
+//! `OffsetIndex` for all columns. Resident footprint stays close to the
+//! footer-only baseline; the scoped cache is bounded (see
 //! [`MAX_SCOPED_ENTRIES`]).
 //!
 //! # Correctness / fallback
@@ -65,7 +84,6 @@ use datafusion::parquet::file::page_index::column_index::ColumnIndexMetaData;
 use datafusion::parquet::file::page_index::index_reader::{
     read_columns_indexes, read_offset_indexes,
 };
-use datafusion::parquet::file::page_index::offset_index::OffsetIndexMetaData;
 use datafusion::parquet::file::reader::{ChunkReader, Length};
 use object_store::ObjectStore;
 use prost::bytes::{Buf, Bytes};
@@ -445,11 +463,30 @@ async fn build_augmented_metadata(
         return None;
     }
 
-    // Phase 1: per RG, gather the predicate columns' chunks and compute the
-    // union byte ranges for the column index and offset index. Bail to
-    // footer-only if any predicate column in any RG lacks a page index.
+    // Phase 1: per RG, gather two things and compute their union byte ranges for
+    // a single vectored fetch. Bail to footer-only if any required index range is
+    // missing.
+    //
+    //  - ColumnIndex for the PREDICATE columns only. This is the heavy, string
+    //    min/max-laden structure the page pruner reads, and the pruner only ever
+    //    dereferences predicate positions (placeholders fill the rest), so
+    //    scoping it to predicate columns is exactly what bounds the heap.
+    //
+    //  - OffsetIndex for ALL columns. Unlike the ColumnIndex, the OffsetIndex is
+    //    consumed at READ time, not just at prune time: when a RowSelection is
+    //    active, arrow-rs's `InMemoryRowGroup::fetch_ranges` dereferences
+    //    `offset_index[col].page_locations` for every *projected* column by
+    //    absolute index to locate the pages to fetch. A missing/empty entry for a
+    //    projected column yields zero fetched page ranges and the read fails
+    //    ("failed to skip rows, expected N, got 0"). Since this loader runs before
+    //    we know the query's projection, we keep a real OffsetIndex for every
+    //    column. It is cheap relative to the ColumnIndex — fixed-width page
+    //    offsets/sizes, no per-page string stats (~a third of the page index, and
+    //    a small fraction of the predicate-column ColumnIndex on wide string
+    //    schemas).
     struct RgPlan {
         pred_chunks: Vec<ColumnChunkMetaData>,
+        all_chunks: Vec<ColumnChunkMetaData>,
         col_range: Range<u64>,
         off_range: Range<u64>,
     }
@@ -460,12 +497,18 @@ async fn build_augmented_metadata(
         let rg = footer_meta.row_group(rg_idx);
         let pred_chunks: Vec<ColumnChunkMetaData> =
             parquet_cols.iter().map(|&i| rg.column(i).clone()).collect();
+        let all_chunks: Vec<ColumnChunkMetaData> =
+            (0..num_cols).map(|i| rg.column(i).clone()).collect();
         let col_range = column_index_union(&pred_chunks)?;
-        let off_range = offset_index_union(&pred_chunks)?;
+        // OffsetIndex range spans every column (see note above). If any column
+        // lacks an offset index we bail to footer-only: the reader would
+        // otherwise take the offset-index branch and fail on the missing column.
+        let off_range = offset_index_union(&all_chunks)?;
         fetch_ranges.push(col_range.clone());
         fetch_ranges.push(off_range.clone());
         plans.push(RgPlan {
             pred_chunks,
+            all_chunks,
             col_range,
             off_range,
         });
@@ -499,33 +542,31 @@ async fn build_augmented_metadata(
         // `read_columns_indexes` / `read_offset_indexes` are deprecated in
         // arrow-rs (slated for removal) but are the only PUBLIC API that decodes
         // a *column subset*; the per-column primitives are `pub(crate)`. They
-        // return a Vec aligned to the `pred_chunks` slice we pass.
+        // return a Vec aligned to the chunk slice we pass.
+        //
+        // ColumnIndex: predicate columns only (the part we scope to bound the heap).
+        // OffsetIndex: every column (needed by the reader for projected columns —
+        // see the Phase 1 note), so decode against the full chunk list.
         #[allow(deprecated)]
         let decoded_cols = read_columns_indexes(&col_reader, &plan.pred_chunks).ok()??;
         #[allow(deprecated)]
-        let decoded_offs = read_offset_indexes(&off_reader, &plan.pred_chunks).ok()??;
-        if decoded_cols.len() != parquet_cols.len() || decoded_offs.len() != parquet_cols.len() {
+        let decoded_offs = read_offset_indexes(&off_reader, &plan.all_chunks).ok()??;
+        if decoded_cols.len() != parquet_cols.len() || decoded_offs.len() != num_cols {
             return None;
         }
 
-        // Full-width rows: NONE / empty placeholders everywhere, real entries at
-        // predicate positions. `StatisticsConverter` only ever dereferences the
-        // predicate positions; placeholders keep absolute indexing valid and are
-        // zero-allocation.
+        // ColumnIndex row: NONE placeholders everywhere, real entries at predicate
+        // positions. `StatisticsConverter` only ever dereferences the predicate
+        // positions, so placeholders keep absolute indexing valid and are cheap.
         let mut col_row: Vec<ColumnIndexMetaData> =
             (0..num_cols).map(|_| ColumnIndexMetaData::NONE).collect();
-        let mut off_row: Vec<OffsetIndexMetaData> = (0..num_cols)
-            .map(|_| OffsetIndexMetaData {
-                page_locations: Vec::new(),
-                unencoded_byte_array_data_bytes: None,
-            })
-            .collect();
         for (k, &parquet_col) in parquet_cols.iter().enumerate() {
             col_row[parquet_col] = decoded_cols[k].clone();
-            off_row[parquet_col] = decoded_offs[k].clone();
         }
         column_index.push(col_row);
-        offset_index.push(off_row);
+        // OffsetIndex row: real entries for every column, already aligned to
+        // absolute column order by `all_chunks`.
+        offset_index.push(decoded_offs);
     }
 
     // Phase 4: rebuild metadata with the sparse page index grafted on.
@@ -678,6 +719,111 @@ mod tests {
         // Sanity: `price >= 20` keeps the last two 8-row pages (rows 16..32).
         assert_eq!(kept(&full_sel), 16);
         assert_eq!(kept(&scoped_sel), 16);
+    }
+
+    /// Read the rows kept by a `RowSelection` for a single projected leaf column,
+    /// using the given metadata. Returns the decoded i32 values (in order) or the
+    /// reader error. This drives arrow-rs's `InMemoryRowGroup::fetch_ranges` down
+    /// the offset-index branch (selection present), which dereferences
+    /// `offset_index[projected_col].page_locations` by absolute index — exactly
+    /// the path that breaks when a projected column carries only an empty
+    /// placeholder offset index.
+    fn read_selected_column(
+        bytes: &Bytes,
+        meta: &Arc<ParquetMetaData>,
+        leaf_col: usize,
+        selection: RowSelection,
+    ) -> std::result::Result<Vec<i32>, String> {
+        use datafusion::parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+        use datafusion::parquet::arrow::ProjectionMask;
+
+        let arm = ArrowReaderMetadata::try_new(Arc::clone(meta), ArrowReaderOptions::new())
+            .map_err(|e| format!("try_new metadata: {e}"))?;
+        let builder =
+            ParquetRecordBatchReaderBuilder::new_with_metadata(bytes.clone(), arm);
+        let proj = ProjectionMask::leaves(builder.parquet_schema(), [leaf_col]);
+        let mut reader = builder
+            .with_row_groups(vec![0])
+            .with_projection(proj)
+            .with_row_selection(selection)
+            .build()
+            .map_err(|e| format!("build reader: {e}"))?;
+
+        let mut out = Vec::new();
+        while let Some(next) = reader.next() {
+            let batch = next.map_err(|e| format!("read batch: {e}"))?;
+            let a = batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .ok_or("projected column was not Int32")?;
+            for i in 0..a.len() {
+                out.push(a.value(i));
+            }
+        }
+        Ok(out)
+    }
+
+    /// Regression: the augmented metadata is fed not only to the page pruner but
+    /// to the actual parquet data reader (see `parquet_bridge::bridge_config` →
+    /// `CachedMetadataReader`). When the pruner yields a `RowSelection` and the
+    /// query projects a column that is NOT a predicate column, arrow-rs locates
+    /// the pages to fetch via that column's `OffsetIndex`. If we had scoped the
+    /// OffsetIndex to predicate columns only (empty placeholder elsewhere), the
+    /// reader would fetch zero page ranges for the projected column and fail
+    /// ("failed to skip rows, expected N, got 0"). Keeping a real OffsetIndex for
+    /// every column makes this read succeed and match the full-index read.
+    ///
+    /// Predicate is on `price` (col 0); projection is `qty` (col 1) — the
+    /// non-predicate column. The selection keeps rows 16..32.
+    #[tokio::test]
+    async fn scoped_index_reads_non_predicate_projected_column() {
+        clear_scoped_cache_for_test();
+        let (bytes, schema) = two_col_parquet();
+        let (store, loc) = stage(bytes.clone()).await;
+        let fo = footer_only(&bytes);
+
+        // Scope to the predicate column `price` (col 0) only — `qty` (col 1) is
+        // NOT in the predicate set, so its ColumnIndex is a placeholder. Its
+        // OffsetIndex, however, must be real for the read below to work.
+        let parquet_cols =
+            resolve_predicate_parquet_columns(&schema, &fo, &["price".to_string()]);
+        assert_eq!(parquet_cols, vec![0]);
+
+        let augmented = load_scoped_page_index(&store, &loc, &fo, &parquet_cols)
+            .await
+            .expect("augmentation must succeed");
+
+        // The augmented OffsetIndex must carry real page locations for the
+        // non-predicate column too, not an empty placeholder.
+        let oi = augmented.offset_index().expect("augmented has offset index");
+        assert!(
+            !oi[0][1].page_locations.is_empty(),
+            "non-predicate column (qty) must keep a real offset index, not an empty placeholder"
+        );
+
+        // `price >= 20` keeps the last two 8-row pages → rows 16..32.
+        let selection = RowSelection::from(vec![
+            datafusion::parquet::arrow::arrow_reader::RowSelector::skip(16),
+            datafusion::parquet::arrow::arrow_reader::RowSelector::select(16),
+        ]);
+
+        // Read `qty` (col 1) through the scoped/augmented metadata.
+        let scoped_vals = read_selected_column(&bytes, &augmented, 1, selection.clone())
+            .expect("reading a non-predicate projected column must succeed with scoped metadata");
+
+        // Ground truth: the same read through the full page index.
+        let full = full_index(&bytes);
+        let full_vals = read_selected_column(&bytes, &full, 1, selection)
+            .expect("full-index read must succeed");
+
+        // qty values are 100..132, so rows 16..32 are 116..132.
+        let expected: Vec<i32> = (116..132).collect();
+        assert_eq!(scoped_vals, expected, "scoped read returned wrong qty values");
+        assert_eq!(
+            scoped_vals, full_vals,
+            "scoped read must match the full-index read exactly"
+        );
     }
 
     #[tokio::test]
@@ -1328,5 +1474,391 @@ mod real_parquet {
         }
         assert!(checked > 0, "no file had >=3 prunable numeric columns for boolean tests");
         eprintln!("verified complex-boolean scoped==full on {}/{} files", checked, files.len());
+    }
+}
+
+/// Truth-table tests: quantify page-index bytes scanned and scoped-cache bytes
+/// filled, **with** scoping (this change) vs **without** (the full-page-index
+/// baseline DataFusion/the listing path would read). These are the reliable,
+/// deterministic measurements behind the design.
+///
+/// Method:
+///  - A `CountingStore` wraps `InMemory` and sums the bytes of every range read
+///    (`get_opts`/`get_ranges` both funnel through `get_opts` in object_store
+///    0.13). This is the exact "parquet bytes scanned for the page index".
+///  - WITHOUT change (full page index): the bytes are the union of every
+///    column's `ColumnIndex` + `OffsetIndex` ranges across all row groups —
+///    computed directly from footer metadata offsets/lengths (what a
+///    `PageIndexPolicy::Optional` decode reads). Cache fill = full
+///    `ParquetMetaData::memory_size()`.
+///  - WITH change (scoped): drive `load_scoped_page_index` through the
+///    CountingStore and read the actual bytes scanned; cache fill =
+///    `scoped_cache_bytes_for_test()`.
+#[cfg(test)]
+mod truth_table {
+    use super::*;
+    use arrow::array::{Int32Array, RecordBatch, StringArray};
+    use arrow::datatypes::{DataType, Field, Schema};
+    use datafusion::parquet::arrow::arrow_reader::{ArrowReaderMetadata, ArrowReaderOptions};
+    use datafusion::parquet::arrow::ArrowWriter;
+    use datafusion::parquet::file::properties::{EnabledStatistics, WriterProperties};
+    use object_store::memory::InMemory;
+    use object_store::path::Path as ObjPath;
+    use object_store::{
+        GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta, ObjectStore,
+        ObjectStoreExt, PutMultipartOptions, PutOptions, PutPayload, PutResult,
+    };
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::Mutex as StdMutex;
+
+    /// ObjectStore wrapper that counts page-index range-read bytes two ways:
+    ///  - `requested`: the raw bytes the caller asks for (sum of the ranges
+    ///    passed to `get_ranges`). This is the loader's *intent* — what page
+    ///    index it scopes to — independent of transport coalescing.
+    ///  - `fetched`: the bytes actually pulled from storage after object_store's
+    ///    `get_ranges` coalesces adjacent ranges (`get_opts` bounded reads). On
+    ///    small/contiguous files this can exceed `requested` because coalescing
+    ///    merges the predicate-CI and all-OI ranges (plus any gap) into one read.
+    #[derive(Debug)]
+    struct CountingStore {
+        inner: Arc<InMemory>,
+        requested: Arc<AtomicU64>,
+        fetched: Arc<AtomicU64>,
+        reads: Arc<AtomicU64>,
+    }
+
+    impl std::fmt::Display for CountingStore {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "CountingStore({})", self.inner)
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl ObjectStore for CountingStore {
+        async fn put_opts(
+            &self,
+            location: &ObjPath,
+            payload: PutPayload,
+            opts: PutOptions,
+        ) -> object_store::Result<PutResult> {
+            self.inner.put_opts(location, payload, opts).await
+        }
+        async fn put_multipart_opts(
+            &self,
+            location: &ObjPath,
+            opts: PutMultipartOptions,
+        ) -> object_store::Result<Box<dyn MultipartUpload>> {
+            self.inner.put_multipart_opts(location, opts).await
+        }
+        async fn get_opts(
+            &self,
+            location: &ObjPath,
+            options: GetOptions,
+        ) -> object_store::Result<GetResult> {
+            // `fetched`: bytes actually pulled from storage (post-coalescing).
+            if let Some(range) = options.range.as_ref() {
+                if let object_store::GetRange::Bounded(r) = range {
+                    self.fetched.fetch_add(r.end - r.start, Ordering::Relaxed);
+                    self.reads.fetch_add(1, Ordering::Relaxed);
+                }
+            }
+            self.inner.get_opts(location, options).await
+        }
+
+        async fn get_ranges(
+            &self,
+            location: &ObjPath,
+            ranges: &[std::ops::Range<u64>],
+        ) -> object_store::Result<Vec<Bytes>> {
+            // `requested`: the loader's true intent (sum of the exact ranges it
+            // asks for), before object_store coalesces adjacent ranges.
+            let req: u64 = ranges.iter().map(|r| r.end - r.start).sum();
+            self.requested.fetch_add(req, Ordering::Relaxed);
+            self.inner.get_ranges(location, ranges).await
+        }
+        fn list(
+            &self,
+            prefix: Option<&ObjPath>,
+        ) -> futures::stream::BoxStream<'static, object_store::Result<ObjectMeta>> {
+            self.inner.list(prefix)
+        }
+        fn delete_stream(
+            &self,
+            locations: futures::stream::BoxStream<'static, object_store::Result<ObjPath>>,
+        ) -> futures::stream::BoxStream<'static, object_store::Result<ObjPath>> {
+            self.inner.delete_stream(locations)
+        }
+        async fn list_with_delimiter(
+            &self,
+            prefix: Option<&ObjPath>,
+        ) -> object_store::Result<ListResult> {
+            self.inner.list_with_delimiter(prefix).await
+        }
+        async fn copy_opts(
+            &self,
+            from: &ObjPath,
+            to: &ObjPath,
+            options: object_store::CopyOptions,
+        ) -> object_store::Result<()> {
+            self.inner.copy_opts(from, to, options).await
+        }
+    }
+
+    /// 10 columns: 4 numeric (`n0..n3`, candidate filter columns) + 6 wide string
+    /// columns (`s0..s5`, the ColumnIndex hogs). One row group, multiple pages.
+    fn wide_parquet() -> (Bytes, SchemaRef) {
+        let mut fields: Vec<Field> = Vec::new();
+        for i in 0..4 {
+            fields.push(Field::new(format!("n{i}"), DataType::Int32, false));
+        }
+        for i in 0..6 {
+            fields.push(Field::new(format!("s{i}"), DataType::Utf8, false));
+        }
+        let schema = Arc::new(Schema::new(fields));
+
+        const ROWS: usize = 4096;
+        let mut cols: Vec<arrow::array::ArrayRef> = Vec::new();
+        for c in 0..4 {
+            let v: Vec<i32> = (0..ROWS as i32).map(|r| r + c * 1000).collect();
+            cols.push(Arc::new(Int32Array::from(v)));
+        }
+        for c in 0..6 {
+            // Long-ish, distinct strings → fat per-page min/max in the ColumnIndex.
+            let v: Vec<String> = (0..ROWS)
+                .map(|r| format!("col{c}_row{r:06}_padding_padding_padding"))
+                .collect();
+            cols.push(Arc::new(StringArray::from(v)));
+        }
+        let batch = RecordBatch::try_new(schema.clone(), cols).unwrap();
+
+        let props = WriterProperties::builder()
+            .set_max_row_group_size(ROWS)
+            .set_data_page_row_count_limit(256) // many pages → real page index
+            .set_write_batch_size(256)
+            .set_statistics_enabled(EnabledStatistics::Page)
+            .build();
+        let mut buf: Vec<u8> = Vec::new();
+        let mut w = ArrowWriter::try_new(&mut buf, schema.clone(), Some(props)).unwrap();
+        w.write(&batch).unwrap();
+        w.close().unwrap();
+        (Bytes::from(buf), schema)
+    }
+
+    struct Counters {
+        requested: Arc<AtomicU64>,
+        #[allow(dead_code)]
+        fetched: Arc<AtomicU64>,
+        #[allow(dead_code)]
+        reads: Arc<AtomicU64>,
+    }
+    impl Counters {
+        fn reset(&self) {
+            self.requested.store(0, Ordering::Relaxed);
+            self.fetched.store(0, Ordering::Relaxed);
+            self.reads.store(0, Ordering::Relaxed);
+        }
+        fn requested(&self) -> u64 { self.requested.load(Ordering::Relaxed) }
+    }
+
+    async fn stage_counting(bytes: Bytes) -> (Arc<dyn ObjectStore>, Counters, ObjPath) {
+        let inner = Arc::new(InMemory::new());
+        let loc = ObjPath::from("data.parquet");
+        inner.put(&loc, PutPayload::from_bytes(bytes)).await.unwrap();
+        let requested = Arc::new(AtomicU64::new(0));
+        let fetched = Arc::new(AtomicU64::new(0));
+        let reads = Arc::new(AtomicU64::new(0));
+        let store: Arc<dyn ObjectStore> = Arc::new(CountingStore {
+            inner,
+            requested: Arc::clone(&requested),
+            fetched: Arc::clone(&fetched),
+            reads: Arc::clone(&reads),
+        });
+        (store, Counters { requested, fetched, reads }, loc)
+    }
+
+    fn footer_only(bytes: &Bytes) -> Arc<ParquetMetaData> {
+        ArrowReaderMetadata::load(&bytes.clone(), ArrowReaderOptions::new().with_page_index(false))
+            .unwrap()
+            .metadata()
+            .clone()
+    }
+
+    fn full_index(bytes: &Bytes) -> Arc<ParquetMetaData> {
+        ArrowReaderMetadata::load(&bytes.clone(), ArrowReaderOptions::new().with_page_index(true))
+            .unwrap()
+            .metadata()
+            .clone()
+    }
+
+    /// Bytes the WITHOUT-change (full page index) path reads off disk: the sum of
+    /// every column's ColumnIndex + OffsetIndex lengths across all row groups.
+    fn full_page_index_disk_bytes(meta: &ParquetMetaData) -> u64 {
+        let mut total = 0u64;
+        for rg in meta.row_groups() {
+            for c in rg.columns() {
+                total += c.column_index_length().unwrap_or(0).max(0) as u64;
+                total += c.offset_index_length().unwrap_or(0).max(0) as u64;
+            }
+        }
+        total
+    }
+
+    /// Bytes the scoped path *should* read off disk: ColumnIndex for predicate
+    /// columns + OffsetIndex for all columns, across all row groups.
+    fn scoped_page_index_disk_bytes(meta: &ParquetMetaData, predicate_cols: &[usize]) -> u64 {
+        let mut total = 0u64;
+        for rg in meta.row_groups() {
+            for &pc in predicate_cols {
+                total += rg.column(pc).column_index_length().unwrap_or(0).max(0) as u64;
+            }
+            for c in rg.columns() {
+                total += c.offset_index_length().unwrap_or(0).max(0) as u64;
+            }
+        }
+        total
+    }
+
+    // Serialize against the process-global scoped cache.
+    static GUARD: StdMutex<()> = StdMutex::new(());
+
+    /// The headline truth table. Prints a table and asserts the invariants:
+    ///  - scoped page-index bytes scanned < full page-index bytes (CI scoped)
+    ///  - scoped cache fill < full metadata size
+    ///  - scoped cache holds exactly one entry after one file/predicate load
+    ///  - a second identical load is a pure cache hit (zero additional bytes)
+    #[tokio::test]
+    async fn truth_table_bytes_and_cache() {
+        let _g = GUARD.lock().unwrap();
+        clear_scoped_cache_for_test();
+
+        let (bytes, schema) = wide_parquet();
+        let full = full_index(&bytes);
+        let total_cols = full.row_group(0).columns().len();
+
+        // Predicate touches a single numeric column n1 (parquet col 1).
+        let (store, ctr, loc) = stage_counting(bytes.clone()).await;
+        let fo = footer_only(&bytes);
+        let predicate_cols = resolve_predicate_parquet_columns(&schema, &fo, &["n1".to_string()]);
+        assert_eq!(predicate_cols, vec![1]);
+
+        // --- Expected page-index bytes, computed from metadata (independent of
+        //     the loader): "WITHOUT" = full all-column CI+OI; "WITH" = scoped. ---
+        let full_bytes = full_page_index_disk_bytes(&full);
+        let scoped_bytes_expected = scoped_page_index_disk_bytes(&full, &predicate_cols);
+        let full_mem = full.memory_size();
+
+        // --- WITH change: drive the scoped loader through the counting store ---
+        ctr.reset();
+        let augmented = load_scoped_page_index(&store, &loc, &fo, &predicate_cols)
+            .await
+            .expect("scoped load");
+        let scoped_requested = ctr.requested(); // loader intent: exact scoped ranges
+        let scoped_cache_fill = scoped_cache_bytes_for_test();
+        let entries_after_first = scoped_cache_len_for_test();
+
+        // --- Second identical load = pure cache hit, zero extra bytes ---
+        ctr.reset();
+        let _hit = load_scoped_page_index(&store, &loc, &fo, &predicate_cols)
+            .await
+            .expect("scoped load (hit)");
+        let requested_on_hit = ctr.requested();
+        let stats = scoped_cache_stats();
+
+        eprintln!("\n=== PAGE-INDEX TRUTH TABLE ({total_cols} cols, 1 RG, predicate=[n1]) ===");
+        eprintln!("{:<46} {:>12} {:>12}", "metric", "WITHOUT", "WITH");
+        eprintln!("{:<46} {:>12} {:>12}", "page-index bytes (expected, disk)", full_bytes, scoped_bytes_expected);
+        eprintln!("{:<46} {:>12} {:>12}", "page-index bytes REQUESTED by loader", full_bytes, scoped_requested);
+        eprintln!("{:<46} {:>12} {:>12}", "cache fill (bytes)", full_mem, scoped_cache_fill);
+        eprintln!("{:<46} {:>12} {:>12}", "cache entries", "n/a", entries_after_first);
+        eprintln!("{:<46} {:>12} {:>12}", "bytes requested on 2nd (cache hit)", "n/a", requested_on_hit);
+        eprintln!("cache stats after 2 loads: {stats:?}");
+        eprintln!(
+            "scoped REQUESTED {:.1}% of full page-index bytes; cache fill {:.1}% of full metadata\n",
+            100.0 * scoped_requested as f64 / full_bytes as f64,
+            100.0 * scoped_cache_fill as f64 / full_mem as f64,
+        );
+
+        // Invariants (robust across coalescing — assert on REQUESTED intent and
+        // cache memory, not on post-coalesce fetched bytes which depend on file
+        // layout):
+        //
+        // 1. The loader REQUESTS materially fewer page-index bytes than the full
+        //    decode: predicate-column ColumnIndex (1 of 10 cols) + all-column
+        //    OffsetIndex, vs every column's CI+OI. The 6 fat string ColumnIndexes
+        //    are excluded.
+        assert!(
+            scoped_requested < full_bytes,
+            "scoped REQUESTED page-index bytes ({scoped_requested}) must be < full ({full_bytes})"
+        );
+        // 2. Requested bytes equal what metadata says the scoped set is (the
+        //    loader reads exactly the predicate-CI + all-OI ranges).
+        assert_eq!(
+            scoped_requested, scoped_bytes_expected,
+            "loader must request exactly the scoped page-index ranges"
+        );
+        // 3. Cache fill is smaller than retaining full metadata.
+        assert!(
+            scoped_cache_fill < full_mem,
+            "scoped cache fill ({scoped_cache_fill}) must be < full metadata size ({full_mem})"
+        );
+        // 4. One entry after one (file,predicate) load.
+        assert_eq!(entries_after_first, 1, "exactly one scoped cache entry");
+        // 5. Second identical load is a pure cache hit: zero page-index bytes.
+        assert_eq!(requested_on_hit, 0, "cache hit must request zero page-index bytes");
+        assert_eq!(stats.hits, 1, "second load must register one cache hit");
+        assert_eq!(stats.misses, 1, "first load must register one cache miss");
+
+        // The augmented metadata must carry a real OffsetIndex for ALL columns
+        // (read-path correctness) and a real ColumnIndex only for the predicate
+        // column.
+        let ci = augmented.column_index().unwrap();
+        let oi = augmented.offset_index().unwrap();
+        for c in 0..total_cols {
+            assert!(!oi[0][c].page_locations.is_empty(), "col {c} must keep real OffsetIndex");
+        }
+        assert!(!matches!(ci[0][1], ColumnIndexMetaData::NONE), "predicate col has real ColumnIndex");
+        assert!(matches!(ci[0][0], ColumnIndexMetaData::NONE), "non-predicate col ColumnIndex is NONE");
+
+        clear_scoped_cache_for_test();
+    }
+
+    /// Distinct predicate-column sets over the same file are independent cache
+    /// entries; widening the predicate scans more ColumnIndex bytes.
+    #[tokio::test]
+    async fn truth_table_wider_predicate_scans_more() {
+        let _g = GUARD.lock().unwrap();
+        clear_scoped_cache_for_test();
+
+        let (bytes, schema) = wide_parquet();
+        let full = full_index(&bytes);
+        let (store, ctr, loc) = stage_counting(bytes.clone()).await;
+        let fo = footer_only(&bytes);
+
+        // 1-column predicate.
+        let one = resolve_predicate_parquet_columns(&schema, &fo, &["n0".to_string()]);
+        ctr.reset();
+        let _ = load_scoped_page_index(&store, &loc, &fo, &one).await.unwrap();
+        let req_one = ctr.requested();
+
+        // 3-column predicate (distinct key → separate entry, fresh decode).
+        let three =
+            resolve_predicate_parquet_columns(&schema, &fo, &["n0".into(), "n1".into(), "n2".into()]);
+        ctr.reset();
+        let _ = load_scoped_page_index(&store, &loc, &fo, &three).await.unwrap();
+        let req_three = ctr.requested();
+
+        let full_bytes = full_page_index_disk_bytes(&full);
+        eprintln!(
+            "\nwider-predicate REQUESTED bytes: 1-col {req_one}, 3-col {req_three}, full {full_bytes}"
+        );
+        // More predicate columns → more ColumnIndex bytes requested (the OffsetIndex
+        // part is the same all-column set in both).
+        assert!(req_three > req_one, "3-col predicate must request more CI bytes than 1-col");
+        // Both still less than the full all-column ColumnIndex+OffsetIndex.
+        assert!(req_three < full_bytes, "even 3-col scoped < full page index");
+        // Two distinct (file, predicate-cols) keys → two cache entries.
+        assert_eq!(scoped_cache_len_for_test(), 2, "distinct predicate sets are distinct entries");
+
+        clear_scoped_cache_for_test();
     }
 }

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/page_index_loader.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/page_index_loader.rs
@@ -1,0 +1,1332 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+//! Scoped, lazy page-index loading for the indexed table's page pruner.
+//!
+//! # Why this exists
+//!
+//! Footer-only metadata loading (see [`super::parquet_bridge::load_parquet_metadata`])
+//! deliberately drops the parquet page index (`ColumnIndex` + `OffsetIndex`)
+//! from the cached `ParquetMetaData`, because decoding it for *every* column of
+//! *every* row group dominates the native heap on wide schemas (~82% in
+//! production profiles) while only a handful of predicate columns are ever
+//! pruned on.
+//!
+//! This module restores page-level pruning **scoped to the predicate columns
+//! only**. Given a footer-only `ParquetMetaData` and the parquet column indices
+//! the query's predicate references, it:
+//!
+//!   1. Range-reads just those columns' `ColumnIndex` / `OffsetIndex` bytes
+//!      (per row group) over the object store, on the IO runtime.
+//!   2. Decodes them with arrow-rs's public per-column readers
+//!      ([`read_columns_indexes`] / [`read_offset_indexes`], which take a
+//!      `&[ColumnChunkMetaData]` slice).
+//!   3. Scatters the decoded entries into full-width per-RG vectors — real
+//!      entries at predicate-column positions, cheap placeholders elsewhere
+//!      ([`ColumnIndexMetaData::NONE`] / an empty `OffsetIndexMetaData`) — so
+//!      that `StatisticsConverter`'s absolute `index[rg][parquet_col]` indexing
+//!      stays valid.
+//!   4. Rebuilds a `ParquetMetaData` carrying that sparse page index.
+//!
+//! The result is cached by `(file path, predicate-column-set)` so repeated
+//! queries over the same columns skip the re-decode.
+//!
+//! # Memory
+//!
+//! The augmented metadata retains page index for the predicate columns only —
+//! a few columns instead of all ~hundreds. Resident footprint stays close to
+//! the footer-only baseline; the scoped cache is bounded (see
+//! [`MAX_SCOPED_ENTRIES`]).
+//!
+//! # Correctness / fallback
+//!
+//! Any failure (file has no page index, a predicate column lacks an index
+//! range, a decode/range error) makes augmentation return `None`. The caller
+//! then keeps the footer-only metadata and the page pruner conservatively
+//! no-ops (scans the whole RG) — never a wrong result.
+
+use std::ops::Range;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use once_cell::sync::Lazy;
+
+use datafusion::parquet::arrow::arrow_reader::statistics::StatisticsConverter;
+use datafusion::parquet::errors::{ParquetError, Result as ParquetResult};
+use datafusion::parquet::file::metadata::{
+    ColumnChunkMetaData, ParquetColumnIndex, ParquetMetaData, ParquetOffsetIndex,
+};
+use datafusion::parquet::file::page_index::column_index::ColumnIndexMetaData;
+use datafusion::parquet::file::page_index::index_reader::{
+    read_columns_indexes, read_offset_indexes,
+};
+use datafusion::parquet::file::page_index::offset_index::OffsetIndexMetaData;
+use datafusion::parquet::file::reader::{ChunkReader, Length};
+use object_store::ObjectStore;
+use prost::bytes::{Buf, Bytes};
+
+use arrow::datatypes::SchemaRef;
+
+/// Default byte budget for the scoped page-index cache, used until the caller
+/// sets one from the runtime's metadata-cache limit (see
+/// [`set_scoped_cache_limit`]). 64 MiB is generous for predicate-column-only
+/// page index (a few columns × row groups per file) yet a tiny fraction of the
+/// footer-only baseline the page-index strip already buys us.
+const DEFAULT_SCOPED_CACHE_LIMIT: usize = 64 * 1024 * 1024;
+
+/// Cache key: object-store path + the sorted set of parquet column indices the
+/// page index was built for.
+#[derive(Clone, PartialEq, Eq, Hash)]
+struct ScopedKey {
+    path: String,
+    parquet_cols: Vec<usize>,
+}
+
+/// One cached entry: the augmented metadata, its decoded size, and a
+/// last-used tick for LRU ordering.
+struct ScopedEntry {
+    meta: Arc<ParquetMetaData>,
+    size: usize,
+    last_used: u64,
+}
+
+/// Byte-bounded LRU over scoped page-index metadata, keyed by
+/// `(file, predicate-column-set)`.
+///
+/// Unlike the previous count-capped map (which silently stopped caching when
+/// full, degrading to decode-every-query), this evicts the least-recently-used
+/// entries once `used > limit`, so it always serves cached data within a memory
+/// budget — mirroring DataFusion's `DefaultFilesMetadataCache`. Entry size is
+/// `ParquetMetaData::memory_size()` (dominated by the decoded page index for the
+/// predicate columns).
+struct ScopedLru {
+    map: HashMap<ScopedKey, ScopedEntry>,
+    used: usize,
+    limit: usize,
+    /// Monotonic clock for LRU ordering. Avoids `Instant` (which the workflow
+    /// harness forbids) and is fine single-process.
+    tick: u64,
+    /// Observability counters (cumulative since process start / last reset).
+    hits: u64,
+    misses: u64,
+    evictions: u64,
+}
+
+/// Snapshot of scoped page-index cache counters.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct ScopedCacheStats {
+    pub hits: u64,
+    pub misses: u64,
+    pub evictions: u64,
+    pub entries: usize,
+    pub used_bytes: usize,
+    pub limit_bytes: usize,
+}
+
+impl ScopedLru {
+    fn new(limit: usize) -> Self {
+        Self {
+            map: HashMap::new(),
+            used: 0,
+            limit,
+            tick: 0,
+            hits: 0,
+            misses: 0,
+            evictions: 0,
+        }
+    }
+
+    fn next_tick(&mut self) -> u64 {
+        self.tick += 1;
+        self.tick
+    }
+
+    fn get(&mut self, key: &ScopedKey) -> Option<Arc<ParquetMetaData>> {
+        let t = self.next_tick();
+        match self.map.get_mut(key) {
+            Some(entry) => {
+                entry.last_used = t;
+                self.hits += 1;
+                Some(Arc::clone(&entry.meta))
+            }
+            None => {
+                self.misses += 1;
+                None
+            }
+        }
+    }
+
+    fn stats(&self) -> ScopedCacheStats {
+        ScopedCacheStats {
+            hits: self.hits,
+            misses: self.misses,
+            evictions: self.evictions,
+            entries: self.map.len(),
+            used_bytes: self.used,
+            limit_bytes: self.limit,
+        }
+    }
+
+    fn insert(&mut self, key: ScopedKey, meta: Arc<ParquetMetaData>) {
+        let size = meta.memory_size();
+        // An entry larger than the whole budget can never be retained; skip it
+        // rather than evicting everything else for something we'd drop anyway.
+        if size > self.limit {
+            return;
+        }
+        let t = self.next_tick();
+        if let Some(old) = self.map.insert(
+            key,
+            ScopedEntry { meta, size, last_used: t },
+        ) {
+            self.used -= old.size;
+        }
+        self.used += size;
+        self.evict();
+    }
+
+    fn evict(&mut self) {
+        while self.used > self.limit {
+            // Find the least-recently-used key.
+            let Some(victim) = self
+                .map
+                .iter()
+                .min_by_key(|(_, e)| e.last_used)
+                .map(|(k, _)| k.clone())
+            else {
+                break;
+            };
+            if let Some(removed) = self.map.remove(&victim) {
+                self.used -= removed.size;
+                self.evictions += 1;
+            }
+        }
+    }
+
+    fn set_limit(&mut self, limit: usize) {
+        self.limit = limit;
+        self.evict();
+    }
+}
+
+/// Process-wide scoped page-index cache.
+static SCOPED_CACHE: Lazy<Mutex<ScopedLru>> =
+    Lazy::new(|| Mutex::new(ScopedLru::new(DEFAULT_SCOPED_CACHE_LIMIT)));
+
+/// Set the scoped cache's byte budget. Called once per query from the executor
+/// with the runtime's configured metadata-cache limit, so the scoped cache
+/// tracks the same tuning as the footer metadata cache. Idempotent and cheap;
+/// shrinking the limit evicts immediately.
+pub fn set_scoped_cache_limit(limit: usize) {
+    if limit == 0 {
+        return; // ignore unset/zero; keep the existing budget
+    }
+    if let Ok(mut c) = SCOPED_CACHE.lock() {
+        c.set_limit(limit);
+    }
+}
+
+/// Snapshot of the scoped page-index cache's hit/miss/eviction counters plus
+/// current occupancy. For node-stats / observability surfaces and tests.
+pub fn scoped_cache_stats() -> ScopedCacheStats {
+    SCOPED_CACHE.lock().map(|c| c.stats()).unwrap_or_default()
+}
+
+#[cfg(test)]
+pub(crate) fn clear_scoped_cache_for_test() {
+    if let Ok(mut c) = SCOPED_CACHE.lock() {
+        c.map.clear();
+        c.used = 0;
+        c.tick = 0;
+        c.limit = DEFAULT_SCOPED_CACHE_LIMIT;
+        c.hits = 0;
+        c.misses = 0;
+        c.evictions = 0;
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn scoped_cache_len_for_test() -> usize {
+    SCOPED_CACHE.lock().map(|c| c.map.len()).unwrap_or(0)
+}
+
+#[cfg(test)]
+pub(crate) fn set_scoped_cache_limit_for_test(limit: usize) {
+    if let Ok(mut c) = SCOPED_CACHE.lock() {
+        c.set_limit(limit);
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn scoped_cache_bytes_for_test() -> usize {
+    SCOPED_CACHE.lock().map(|c| c.used).unwrap_or(0)
+}
+
+/// Reset entries + counters but KEEP the configured limit — for eviction tests
+/// that set a tight budget then want clean counters from an empty cache.
+#[cfg(test)]
+pub(crate) fn clear_counters_keep_limit() {
+    if let Ok(mut c) = SCOPED_CACHE.lock() {
+        c.map.clear();
+        c.used = 0;
+        c.tick = 0;
+        c.hits = 0;
+        c.misses = 0;
+        c.evictions = 0;
+    }
+}
+
+/// A [`ChunkReader`] over an in-memory byte buffer that represents the file
+/// region `[base, base + bytes.len())`. The arrow-rs page-index readers call
+/// `get_bytes(absolute_offset, len)`; we translate the absolute file offset
+/// into the buffer.
+struct BufferChunkReader {
+    /// Absolute file offset of `bytes[0]`.
+    base: u64,
+    bytes: Bytes,
+}
+
+impl Length for BufferChunkReader {
+    fn len(&self) -> u64 {
+        self.base + self.bytes.len() as u64
+    }
+}
+
+impl ChunkReader for BufferChunkReader {
+    type T = prost::bytes::buf::Reader<Bytes>;
+
+    fn get_read(&self, start: u64) -> ParquetResult<Self::T> {
+        let rel = self.rel(start, 0)?;
+        Ok(self.bytes.slice(rel..).reader())
+    }
+
+    fn get_bytes(&self, start: u64, length: usize) -> ParquetResult<Bytes> {
+        let rel = self.rel(start, length)?;
+        Ok(self.bytes.slice(rel..rel + length))
+    }
+}
+
+impl BufferChunkReader {
+    /// Translate an absolute file offset (and a length to validate) into a
+    /// buffer-relative start, erroring if it falls outside the prefetched span.
+    fn rel(&self, start: u64, length: usize) -> ParquetResult<usize> {
+        let rel = start.checked_sub(self.base).ok_or_else(|| {
+            ParquetError::General(format!(
+                "page-index read offset {} precedes buffer base {}",
+                start, self.base
+            ))
+        })?;
+        let rel = usize::try_from(rel)
+            .map_err(|e| ParquetError::General(format!("offset overflow: {}", e)))?;
+        if rel + length > self.bytes.len() {
+            return Err(ParquetError::General(format!(
+                "page-index read [{}..{}) exceeds buffer of len {}",
+                rel,
+                rel + length,
+                self.bytes.len()
+            )));
+        }
+        Ok(rel)
+    }
+}
+
+/// Union of `column_index` byte ranges across the given column chunks. `None`
+/// if any chunk lacks a column index (we require all predicate columns to have
+/// one, else we fall back to footer-only).
+fn column_index_union(chunks: &[ColumnChunkMetaData]) -> Option<Range<u64>> {
+    range_union(chunks, |c| {
+        let off = u64::try_from(c.column_index_offset()?).ok()?;
+        let len = u64::try_from(c.column_index_length()?).ok()?;
+        Some(off..off + len)
+    })
+}
+
+/// Union of `offset_index` byte ranges across the given column chunks.
+fn offset_index_union(chunks: &[ColumnChunkMetaData]) -> Option<Range<u64>> {
+    range_union(chunks, |c| {
+        let off = u64::try_from(c.offset_index_offset()?).ok()?;
+        let len = u64::try_from(c.offset_index_length()?).ok()?;
+        Some(off..off + len)
+    })
+}
+
+fn range_union(
+    chunks: &[ColumnChunkMetaData],
+    f: impl Fn(&ColumnChunkMetaData) -> Option<Range<u64>>,
+) -> Option<Range<u64>> {
+    let mut acc: Option<Range<u64>> = None;
+    for c in chunks {
+        let r = f(c)?; // any missing range → bail (caller falls back)
+        acc = Some(match acc {
+            None => r,
+            Some(a) => a.start.min(r.start)..a.end.max(r.end),
+        });
+    }
+    acc
+}
+
+/// Map the query's arrow predicate-column names to this file's parquet column
+/// indices, using the same resolution `PagePruner` uses
+/// (`StatisticsConverter::parquet_column_index`). Columns absent from the
+/// parquet file (schema evolution) are skipped. Returns a sorted, deduped set.
+pub fn resolve_predicate_parquet_columns(
+    arrow_schema: &SchemaRef,
+    metadata: &ParquetMetaData,
+    predicate_column_names: &[String],
+) -> Vec<usize> {
+    let parquet_schema = metadata.file_metadata().schema_descr();
+    let mut set = std::collections::BTreeSet::new();
+    for name in predicate_column_names {
+        if let Ok(conv) = StatisticsConverter::try_new(name, arrow_schema, parquet_schema) {
+            if let Some(idx) = conv.parquet_column_index() {
+                set.insert(idx);
+            }
+        }
+    }
+    set.into_iter().collect()
+}
+
+/// Build metadata carrying page index for `parquet_cols` only, fetching their
+/// `ColumnIndex`/`OffsetIndex` bytes over `store`. Returns `None` (caller keeps
+/// footer-only metadata) on any condition that would make page pruning unsafe
+/// or impossible: empty column set, file without a page index, or a decode/IO
+/// error.
+///
+/// Consults and populates the scoped `(file, column-set)` cache.
+pub async fn load_scoped_page_index(
+    store: &Arc<dyn ObjectStore>,
+    location: &object_store::path::Path,
+    footer_meta: &Arc<ParquetMetaData>,
+    parquet_cols: &[usize],
+) -> Option<Arc<ParquetMetaData>> {
+    if parquet_cols.is_empty() {
+        return None;
+    }
+
+    let key = ScopedKey {
+        path: location.as_ref().to_string(),
+        parquet_cols: parquet_cols.to_vec(),
+    };
+    // Cache hit: return the already-decoded scoped page index, no I/O, no decode.
+    if let Ok(mut cache) = SCOPED_CACHE.lock() {
+        if let Some(hit) = cache.get(&key) {
+            return Some(hit);
+        }
+    }
+
+    let augmented = build_augmented_metadata(store, location, footer_meta, parquet_cols).await?;
+
+    // Publish to the byte-bounded LRU (evicts least-recently-used over budget).
+    if let Ok(mut cache) = SCOPED_CACHE.lock() {
+        cache.insert(key, Arc::clone(&augmented));
+    }
+    Some(augmented)
+}
+
+async fn build_augmented_metadata(
+    store: &Arc<dyn ObjectStore>,
+    location: &object_store::path::Path,
+    footer_meta: &Arc<ParquetMetaData>,
+    parquet_cols: &[usize],
+) -> Option<Arc<ParquetMetaData>> {
+    let num_rgs = footer_meta.num_row_groups();
+    if num_rgs == 0 {
+        return None;
+    }
+    let num_cols = footer_meta.file_metadata().schema_descr().num_columns();
+    // Predicate indices must be in range for every RG (they index into the
+    // file schema, shared across RGs).
+    if parquet_cols.iter().any(|&i| i >= num_cols) {
+        return None;
+    }
+
+    // Phase 1: per RG, gather the predicate columns' chunks and compute the
+    // union byte ranges for the column index and offset index. Bail to
+    // footer-only if any predicate column in any RG lacks a page index.
+    struct RgPlan {
+        pred_chunks: Vec<ColumnChunkMetaData>,
+        col_range: Range<u64>,
+        off_range: Range<u64>,
+    }
+    let mut plans: Vec<RgPlan> = Vec::with_capacity(num_rgs);
+    // Flat list of ranges for a single vectored fetch: [rg0_col, rg0_off, rg1_col, ...].
+    let mut fetch_ranges: Vec<Range<u64>> = Vec::with_capacity(num_rgs * 2);
+    for rg_idx in 0..num_rgs {
+        let rg = footer_meta.row_group(rg_idx);
+        let pred_chunks: Vec<ColumnChunkMetaData> =
+            parquet_cols.iter().map(|&i| rg.column(i).clone()).collect();
+        let col_range = column_index_union(&pred_chunks)?;
+        let off_range = offset_index_union(&pred_chunks)?;
+        fetch_ranges.push(col_range.clone());
+        fetch_ranges.push(off_range.clone());
+        plans.push(RgPlan {
+            pred_chunks,
+            col_range,
+            off_range,
+        });
+    }
+
+    // Phase 2: one vectored fetch of all index byte ranges (on the IO runtime
+    // via the SpawnIoStore-wrapped object store).
+    let buffers = store.get_ranges(location, &fetch_ranges).await.ok()?;
+    if buffers.len() != fetch_ranges.len() {
+        return None;
+    }
+
+    // Phase 3: per RG, decode the predicate columns and scatter into full-width
+    // vectors.
+    let mut column_index: ParquetColumnIndex = Vec::with_capacity(num_rgs);
+    let mut offset_index: ParquetOffsetIndex = Vec::with_capacity(num_rgs);
+
+    for (rg_idx, plan) in plans.iter().enumerate() {
+        let col_buf = buffers[rg_idx * 2].clone();
+        let off_buf = buffers[rg_idx * 2 + 1].clone();
+
+        let col_reader = BufferChunkReader {
+            base: plan.col_range.start,
+            bytes: col_buf,
+        };
+        let off_reader = BufferChunkReader {
+            base: plan.off_range.start,
+            bytes: off_buf,
+        };
+
+        // `read_columns_indexes` / `read_offset_indexes` are deprecated in
+        // arrow-rs (slated for removal) but are the only PUBLIC API that decodes
+        // a *column subset*; the per-column primitives are `pub(crate)`. They
+        // return a Vec aligned to the `pred_chunks` slice we pass.
+        #[allow(deprecated)]
+        let decoded_cols = read_columns_indexes(&col_reader, &plan.pred_chunks).ok()??;
+        #[allow(deprecated)]
+        let decoded_offs = read_offset_indexes(&off_reader, &plan.pred_chunks).ok()??;
+        if decoded_cols.len() != parquet_cols.len() || decoded_offs.len() != parquet_cols.len() {
+            return None;
+        }
+
+        // Full-width rows: NONE / empty placeholders everywhere, real entries at
+        // predicate positions. `StatisticsConverter` only ever dereferences the
+        // predicate positions; placeholders keep absolute indexing valid and are
+        // zero-allocation.
+        let mut col_row: Vec<ColumnIndexMetaData> =
+            (0..num_cols).map(|_| ColumnIndexMetaData::NONE).collect();
+        let mut off_row: Vec<OffsetIndexMetaData> = (0..num_cols)
+            .map(|_| OffsetIndexMetaData {
+                page_locations: Vec::new(),
+                unencoded_byte_array_data_bytes: None,
+            })
+            .collect();
+        for (k, &parquet_col) in parquet_cols.iter().enumerate() {
+            col_row[parquet_col] = decoded_cols[k].clone();
+            off_row[parquet_col] = decoded_offs[k].clone();
+        }
+        column_index.push(col_row);
+        offset_index.push(off_row);
+    }
+
+    // Phase 4: rebuild metadata with the sparse page index grafted on.
+    let base = ParquetMetaData::clone(footer_meta);
+    let rebuilt = base
+        .into_builder()
+        .set_column_index(Some(column_index))
+        .set_offset_index(Some(offset_index))
+        .build();
+    Some(Arc::new(rebuilt))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::indexed_table::page_pruner::{build_pruning_predicate, PagePruner};
+    use arrow::array::{Int32Array, RecordBatch};
+    use arrow::datatypes::{DataType, Field, Schema};
+    use datafusion::logical_expr::Operator;
+    use datafusion::parquet::arrow::arrow_reader::{ArrowReaderMetadata, ArrowReaderOptions};
+    use datafusion::parquet::arrow::ArrowWriter;
+    use datafusion::parquet::arrow::arrow_reader::RowSelection;
+    use datafusion::parquet::file::properties::{EnabledStatistics, WriterProperties};
+    use datafusion::physical_expr::expressions::{BinaryExpr, Column as PhysColumn, Literal};
+    use datafusion::physical_expr::PhysicalExpr;
+    use datafusion::common::ScalarValue;
+    use object_store::memory::InMemory;
+    use object_store::path::Path as ObjPath;
+    use object_store::{ObjectStore, ObjectStoreExt, PutPayload};
+
+    /// Two int columns (`price`, `qty`), one row group, four 8-row data pages.
+    /// Returns the raw parquet bytes.
+    fn two_col_parquet() -> (Bytes, SchemaRef) {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("price", DataType::Int32, false),
+            Field::new("qty", DataType::Int32, false),
+        ]));
+        let prices: Vec<i32> = (0..32).collect();
+        let qtys: Vec<i32> = (100..132).collect();
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(prices)),
+                Arc::new(Int32Array::from(qtys)),
+            ],
+        )
+        .unwrap();
+        let props = WriterProperties::builder()
+            .set_max_row_group_size(32)
+            .set_data_page_row_count_limit(8)
+            .set_write_batch_size(8)
+            .set_statistics_enabled(EnabledStatistics::Page)
+            .build();
+        let mut buf: Vec<u8> = Vec::new();
+        let mut w = ArrowWriter::try_new(&mut buf, schema.clone(), Some(props)).unwrap();
+        w.write(&batch).unwrap();
+        w.close().unwrap();
+        (Bytes::from(buf), schema)
+    }
+
+    async fn stage(bytes: Bytes) -> (Arc<dyn ObjectStore>, ObjPath) {
+        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let loc = ObjPath::from("data.parquet");
+        store.put(&loc, PutPayload::from_bytes(bytes)).await.unwrap();
+        (store, loc)
+    }
+
+    /// Decode footer-only metadata (no page index) from the staged bytes.
+    fn footer_only(bytes: &Bytes) -> Arc<ParquetMetaData> {
+        let meta = ArrowReaderMetadata::load(
+            &bytes.clone(),
+            ArrowReaderOptions::new().with_page_index(false),
+        )
+        .unwrap();
+        meta.metadata().clone()
+    }
+
+    /// Full page index baseline (what we want the scoped path to match).
+    fn full_index(bytes: &Bytes) -> Arc<ParquetMetaData> {
+        let meta = ArrowReaderMetadata::load(
+            &bytes.clone(),
+            ArrowReaderOptions::new().with_page_index(true),
+        )
+        .unwrap();
+        meta.metadata().clone()
+    }
+
+    fn col(name: &str, idx: usize) -> Arc<dyn PhysicalExpr> {
+        Arc::new(PhysColumn::new(name, idx))
+    }
+    fn lit_int(v: i32) -> Arc<dyn PhysicalExpr> {
+        Arc::new(Literal::new(ScalarValue::Int32(Some(v))))
+    }
+    fn pred(name: &str, idx: usize, op: Operator, v: i32) -> Arc<dyn PhysicalExpr> {
+        Arc::new(BinaryExpr::new(col(name, idx), op, lit_int(v)))
+    }
+    fn kept(sel: &RowSelection) -> usize {
+        sel.iter().filter(|s| !s.skip).map(|s| s.row_count).sum()
+    }
+
+    #[tokio::test]
+    async fn footer_only_has_no_page_index() {
+        let (bytes, _schema) = two_col_parquet();
+        let fo = footer_only(&bytes);
+        assert!(
+            fo.column_index().is_none() && fo.offset_index().is_none(),
+            "fixture footer-only metadata must lack a page index"
+        );
+        // And the full baseline DOES have one (else the test is vacuous).
+        let full = full_index(&bytes);
+        assert!(full.column_index().is_some() && full.offset_index().is_some());
+    }
+
+    /// The crux: scoped augmentation of footer-only metadata must reproduce the
+    /// EXACT pruning result of the full page index, for the predicate column.
+    #[tokio::test]
+    async fn scoped_augmentation_matches_full_index_pruning() {
+        clear_scoped_cache_for_test();
+        let (bytes, schema) = two_col_parquet();
+        let (store, loc) = stage(bytes.clone()).await;
+        let fo = footer_only(&bytes);
+
+        // Predicate references `price` (parquet col 0). price page ranges are
+        // 0..8, 8..16, 16..24, 24..32 — `price >= 20` keeps pages 3 and 4.
+        let parquet_cols = resolve_predicate_parquet_columns(&schema, &fo, &["price".to_string()]);
+        assert_eq!(parquet_cols, vec![0]);
+
+        let augmented = load_scoped_page_index(&store, &loc, &fo, &parquet_cols)
+            .await
+            .expect("augmentation must succeed for a file with a page index");
+        assert!(
+            augmented.column_index().is_some() && augmented.offset_index().is_some(),
+            "augmented metadata must carry a page index"
+        );
+
+        let predicate = pred("price", 0, Operator::GtEq, 20);
+        let pp = build_pruning_predicate(&predicate, schema.clone()).unwrap();
+
+        let scoped_pruner = PagePruner::new(&schema, Arc::clone(&augmented));
+        let full_pruner = PagePruner::new(&schema, full_index(&bytes));
+
+        let scoped_sel = scoped_pruner.prune_rg(&pp, 0, None).unwrap();
+        let full_sel = full_pruner.prune_rg(&pp, 0, None).unwrap();
+
+        assert_eq!(
+            kept(&scoped_sel),
+            kept(&full_sel),
+            "scoped page index must prune identically to the full index"
+        );
+        // Sanity: `price >= 20` keeps the last two 8-row pages (rows 16..32).
+        assert_eq!(kept(&full_sel), 16);
+        assert_eq!(kept(&scoped_sel), 16);
+    }
+
+    #[tokio::test]
+    async fn empty_column_set_returns_none() {
+        clear_scoped_cache_for_test();
+        let (bytes, _schema) = two_col_parquet();
+        let (store, loc) = stage(bytes.clone()).await;
+        let fo = footer_only(&bytes);
+        assert!(load_scoped_page_index(&store, &loc, &fo, &[]).await.is_none());
+    }
+
+    // The scoped cache is process-global; the lib test binary runs tests in
+    // parallel, so cache-population tests serialize on this mutex (and clear
+    // under it) to keep their (file, column-set) keys from colliding / racing
+    // with siblings. Distinct fixtures alone aren't enough because the InMemory
+    // path is always "data.parquet".
+    static CACHE_TEST_GUARD: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    #[tokio::test]
+    async fn second_load_is_cache_hit() {
+        let _g = CACHE_TEST_GUARD.lock().unwrap();
+        clear_scoped_cache_for_test();
+        let (bytes, schema) = two_col_parquet();
+        let (store, loc) = stage(bytes.clone()).await;
+        let fo = footer_only(&bytes);
+        let cols = resolve_predicate_parquet_columns(&schema, &fo, &["price".to_string()]);
+
+        let first = load_scoped_page_index(&store, &loc, &fo, &cols).await.unwrap();
+        assert_eq!(scoped_cache_len_for_test(), 1);
+        let second = load_scoped_page_index(&store, &loc, &fo, &cols).await.unwrap();
+        assert!(
+            Arc::ptr_eq(&first, &second),
+            "second load with same (file, column-set) must hit the scoped cache"
+        );
+        assert_eq!(scoped_cache_len_for_test(), 1);
+    }
+
+    /// Different predicate-column sets over the same file are cached
+    /// independently, and each scoped index prunes correctly for ITS OWN
+    /// predicate — which is the only way the pruner uses them in production
+    /// (one cache entry per query's predicate-column set).
+    #[tokio::test]
+    async fn distinct_column_sets_cached_independently() {
+        let _g = CACHE_TEST_GUARD.lock().unwrap();
+        clear_scoped_cache_for_test();
+        let (bytes, schema) = two_col_parquet();
+        let (store, loc) = stage(bytes.clone()).await;
+        let fo = footer_only(&bytes);
+
+        let c_price = resolve_predicate_parquet_columns(&schema, &fo, &["price".to_string()]);
+        let c_qty = resolve_predicate_parquet_columns(&schema, &fo, &["qty".to_string()]);
+        assert_eq!(c_price, vec![0]);
+        assert_eq!(c_qty, vec![1]);
+
+        let a_price = load_scoped_page_index(&store, &loc, &fo, &c_price).await.unwrap();
+        let a_qty = load_scoped_page_index(&store, &loc, &fo, &c_qty).await.unwrap();
+        assert_eq!(scoped_cache_len_for_test(), 2);
+        assert!(
+            !Arc::ptr_eq(&a_price, &a_qty),
+            "distinct column-sets must produce distinct cache entries"
+        );
+
+        // qty-scoped index prunes a qty predicate: `qty >= 120` (qty pages
+        // 100..108,108..116,116..124,124..132) keeps the last two pages → 16.
+        let pp_qty =
+            build_pruning_predicate(&pred("qty", 1, Operator::GtEq, 120), schema.clone()).unwrap();
+        let sel_qty = PagePruner::new(&schema, Arc::clone(&a_qty))
+            .prune_rg(&pp_qty, 0, None)
+            .unwrap();
+        assert_eq!(kept(&sel_qty), 16);
+
+        // price-scoped index prunes a price predicate: `price >= 20` keeps the
+        // last two 8-row pages → 16.
+        let pp_price =
+            build_pruning_predicate(&pred("price", 0, Operator::GtEq, 20), schema.clone()).unwrap();
+        let sel_price = PagePruner::new(&schema, Arc::clone(&a_price))
+            .prune_rg(&pp_price, 0, None)
+            .unwrap();
+        assert_eq!(kept(&sel_price), 16);
+    }
+
+    /// Byte-bounded LRU: with a tiny limit the cache holds at most a couple of
+    /// entries and evicts the least-recently-used, never exceeding the budget —
+    /// it does NOT silently stop caching (the old count-cap bug).
+    #[tokio::test]
+    async fn lru_evicts_over_byte_budget() {
+        let _g = CACHE_TEST_GUARD.lock().unwrap();
+        clear_scoped_cache_for_test();
+
+        // Three distinct column-sets over the same file → three would-be entries.
+        // (price), (qty), (price,qty).
+        let (bytes, schema) = two_col_parquet();
+        let (store, loc) = stage(bytes.clone()).await;
+        let fo = footer_only(&bytes);
+        let c_price = resolve_predicate_parquet_columns(&schema, &fo, &["price".to_string()]);
+        let c_qty = resolve_predicate_parquet_columns(&schema, &fo, &["qty".to_string()]);
+        let c_both =
+            resolve_predicate_parquet_columns(&schema, &fo, &["price".to_string(), "qty".to_string()]);
+
+        // Size one entry, then set the budget to ~1.5 entries so only one fits.
+        let one = load_scoped_page_index(&store, &loc, &fo, &c_price).await.unwrap();
+        let one_size = one.memory_size();
+        set_scoped_cache_limit_for_test(one_size + one_size / 2);
+
+        // Re-clear so the budget applies from empty, keeping the new limit.
+        if let Ok(mut c) = SCOPED_CACHE.lock() {
+            c.map.clear();
+            c.used = 0;
+        }
+
+        // Insert three distinct entries; each is ~one_size, budget holds ~1.
+        let _ = load_scoped_page_index(&store, &loc, &fo, &c_price).await.unwrap();
+        let _ = load_scoped_page_index(&store, &loc, &fo, &c_qty).await.unwrap();
+        let _ = load_scoped_page_index(&store, &loc, &fo, &c_both).await.unwrap();
+
+        // Never exceeds the budget, and didn't degrade to "cache nothing".
+        assert!(
+            scoped_cache_bytes_for_test() <= one_size + one_size / 2,
+            "cache bytes {} must stay within budget {}",
+            scoped_cache_bytes_for_test(),
+            one_size + one_size / 2
+        );
+        assert!(
+            scoped_cache_len_for_test() >= 1,
+            "LRU must retain at least the most-recent entry, not stop caching"
+        );
+
+        // The most-recently-used (c_both) must still be a hit (same Arc on reload).
+        let again = load_scoped_page_index(&store, &loc, &fo, &c_both).await.unwrap();
+        let again2 = load_scoped_page_index(&store, &loc, &fo, &c_both).await.unwrap();
+        assert!(
+            Arc::ptr_eq(&again, &again2),
+            "most-recently-used entry must remain cached"
+        );
+
+        clear_scoped_cache_for_test(); // restore default limit for other tests
+    }
+
+    /// Hit/miss accounting: first load of a (file, column-set) is a miss; the
+    /// next is a hit. A different column-set is another miss. Counters reflect
+    /// exactly that.
+    #[tokio::test]
+    async fn stats_count_hits_and_misses() {
+        let _g = CACHE_TEST_GUARD.lock().unwrap();
+        clear_scoped_cache_for_test();
+
+        let (bytes, schema) = two_col_parquet();
+        let (store, loc) = stage(bytes.clone()).await;
+        let fo = footer_only(&bytes);
+        let c_price = resolve_predicate_parquet_columns(&schema, &fo, &["price".to_string()]);
+        let c_qty = resolve_predicate_parquet_columns(&schema, &fo, &["qty".to_string()]);
+
+        // 1st price load → miss (and populates).
+        let _ = load_scoped_page_index(&store, &loc, &fo, &c_price).await.unwrap();
+        let s = scoped_cache_stats();
+        assert_eq!((s.hits, s.misses), (0, 1), "first load must be a miss");
+
+        // 2nd price load → hit.
+        let _ = load_scoped_page_index(&store, &loc, &fo, &c_price).await.unwrap();
+        let s = scoped_cache_stats();
+        assert_eq!((s.hits, s.misses), (1, 1), "second same-key load must be a hit");
+
+        // qty load → another miss (distinct column-set).
+        let _ = load_scoped_page_index(&store, &loc, &fo, &c_qty).await.unwrap();
+        let s = scoped_cache_stats();
+        assert_eq!((s.hits, s.misses), (1, 2));
+
+        // Two more price + qty loads → two more hits.
+        let _ = load_scoped_page_index(&store, &loc, &fo, &c_price).await.unwrap();
+        let _ = load_scoped_page_index(&store, &loc, &fo, &c_qty).await.unwrap();
+        let s = scoped_cache_stats();
+        assert_eq!((s.hits, s.misses), (3, 2));
+        assert_eq!(s.entries, 2);
+        assert_eq!(s.evictions, 0, "budget is ample; nothing should evict");
+
+        clear_scoped_cache_for_test();
+    }
+
+    /// Eviction counter increments when entries are pushed out under a tight
+    /// budget, and a subsequent reload of an evicted key is a miss again.
+    #[tokio::test]
+    async fn stats_count_evictions() {
+        let _g = CACHE_TEST_GUARD.lock().unwrap();
+        clear_scoped_cache_for_test();
+
+        let (bytes, schema) = two_col_parquet();
+        let (store, loc) = stage(bytes.clone()).await;
+        let fo = footer_only(&bytes);
+        let c_price = resolve_predicate_parquet_columns(&schema, &fo, &["price".to_string()]);
+        let c_qty = resolve_predicate_parquet_columns(&schema, &fo, &["qty".to_string()]);
+
+        let one = load_scoped_page_index(&store, &loc, &fo, &c_price).await.unwrap();
+        let one_size = one.memory_size();
+        // Budget that fits only ~1 entry.
+        set_scoped_cache_limit_for_test(one_size + one_size / 2);
+        clear_counters_keep_limit();
+
+        // price then qty: inserting qty over budget evicts price.
+        let _ = load_scoped_page_index(&store, &loc, &fo, &c_price).await.unwrap();
+        let _ = load_scoped_page_index(&store, &loc, &fo, &c_qty).await.unwrap();
+        let s = scoped_cache_stats();
+        assert!(s.evictions >= 1, "tight budget must have evicted at least once");
+        assert!(s.used_bytes <= s.limit_bytes, "must stay within budget");
+
+        clear_scoped_cache_for_test();
+    }
+
+    /// A warm cache hit must be dramatically faster than a cold decode (which
+    /// does range I/O + thrift decode + scatter). Asserts a hit is at least 5×
+    /// faster than the miss on the same key — a loose bound that still catches a
+    /// regression where the "hit" path accidentally re-decodes.
+    #[tokio::test]
+    async fn cache_hit_is_faster_than_cold_decode() {
+        use std::time::Instant;
+        let _g = CACHE_TEST_GUARD.lock().unwrap();
+        clear_scoped_cache_for_test();
+
+        let (bytes, schema) = two_col_parquet();
+        let (store, loc) = stage(bytes.clone()).await;
+        let fo = footer_only(&bytes);
+        let cols = resolve_predicate_parquet_columns(&schema, &fo, &["price".to_string()]);
+
+        // Cold: miss → range-read + decode + scatter.
+        let t0 = Instant::now();
+        let _ = load_scoped_page_index(&store, &loc, &fo, &cols).await.unwrap();
+        let cold = t0.elapsed();
+        assert_eq!(scoped_cache_stats().misses, 1);
+
+        // Warm: average several hits to reduce timer noise on a fast op.
+        const N: u32 = 50;
+        let t1 = Instant::now();
+        for _ in 0..N {
+            let _ = load_scoped_page_index(&store, &loc, &fo, &cols).await.unwrap();
+        }
+        let warm_avg = t1.elapsed() / N;
+        let s = scoped_cache_stats();
+        assert_eq!(s.misses, 1, "no further misses");
+        assert_eq!(s.hits, N as u64);
+
+        eprintln!(
+            "scoped cache: cold decode = {:?}, warm hit (avg of {}) = {:?} ({}x faster)",
+            cold, N, warm_avg,
+            if warm_avg.as_nanos() > 0 { cold.as_nanos() / warm_avg.as_nanos() } else { u128::MAX }
+        );
+        // Loose bound: a hit must be at least 5× faster than the cold path.
+        // (In practice it's 100s–1000s×; 5× tolerates CI jitter while still
+        // failing loudly if a "hit" secretly re-decodes.)
+        assert!(
+            warm_avg * 5 < cold,
+            "cache hit ({:?}) not materially faster than cold decode ({:?}) — is the hit path re-decoding?",
+            warm_avg, cold
+        );
+
+        clear_scoped_cache_for_test();
+    }
+}
+
+/// Tests that run against **real production parquet files**, gated behind the
+/// `OPENSEARCH_REAL_PARQUET_DIR` env var so they never run in CI or the normal
+/// `cargo test` sweep. Point the var at a directory of `.parquet` files:
+///
+/// ```sh
+/// OPENSEARCH_REAL_PARQUET_DIR=/path/to/parquet \
+///   cargo test -p opensearch-datafusion --lib real_parquet -- --nocapture --test-threads=1
+/// ```
+///
+/// These verify the scoped page-index logic against ground truth: for each file
+/// and a chosen predicate column, our scoped (single-column) page index must
+/// drive `PagePruner` to the EXACT same per-row-group selection as a full
+/// page-index decode — on real wide schemas with real page layouts.
+#[cfg(test)]
+mod real_parquet {
+    use super::*;
+    use crate::indexed_table::page_pruner::{build_pruning_predicate, PagePruner};
+    use datafusion::arrow::array::Array;
+    use datafusion::arrow::datatypes::DataType;
+    use datafusion::common::ScalarValue;
+    use datafusion::logical_expr::Operator;
+    use datafusion::parquet::arrow::arrow_reader::{ArrowReaderMetadata, ArrowReaderOptions};
+    use datafusion::parquet::arrow::async_reader::ParquetObjectReader;
+    use datafusion::parquet::arrow::ParquetRecordBatchStreamBuilder;
+    use datafusion::parquet::arrow::parquet_to_arrow_schema;
+    use datafusion::physical_expr::expressions::{BinaryExpr, Column as PhysColumn, Literal};
+    use datafusion::physical_expr::PhysicalExpr;
+    use object_store::local::LocalFileSystem;
+    use object_store::path::Path as ObjPath;
+    use object_store::{ObjectStore, ObjectStoreExt};
+
+    fn dir_from_env() -> Option<std::path::PathBuf> {
+        std::env::var_os("OPENSEARCH_REAL_PARQUET_DIR").map(std::path::PathBuf::from)
+    }
+
+    fn list_parquet(dir: &std::path::Path) -> Vec<std::path::PathBuf> {
+        let mut v: Vec<_> = std::fs::read_dir(dir)
+            .unwrap()
+            .filter_map(|e| e.ok().map(|e| e.path()))
+            .filter(|p| p.extension().map(|e| e == "parquet").unwrap_or(false))
+            .collect();
+        // Smallest first — keeps the default run fast; the big 3 GB files are
+        // exercised only if you let it run to completion.
+        v.sort_by_key(|p| std::fs::metadata(p).map(|m| m.len()).unwrap_or(u64::MAX));
+        v
+    }
+
+    /// Load full-page-index metadata for a local file (ground truth).
+    fn full_index_meta(path: &std::path::Path) -> Arc<ParquetMetaData> {
+        let file = std::fs::File::open(path).unwrap();
+        let meta = ArrowReaderMetadata::load(
+            &file,
+            ArrowReaderOptions::new().with_page_index(true),
+        )
+        .unwrap();
+        meta.metadata().clone()
+    }
+
+    /// Load footer-only metadata for a local file.
+    fn footer_only_meta(path: &std::path::Path) -> Arc<ParquetMetaData> {
+        let file = std::fs::File::open(path).unwrap();
+        let meta = ArrowReaderMetadata::load(
+            &file,
+            ArrowReaderOptions::new().with_page_index(false),
+        )
+        .unwrap();
+        meta.metadata().clone()
+    }
+
+    fn arrow_schema(meta: &ParquetMetaData) -> SchemaRef {
+        let fm = meta.file_metadata();
+        Arc::new(parquet_to_arrow_schema(fm.schema_descr(), fm.key_value_metadata()).unwrap())
+    }
+
+    /// Pick a predicate column that's actually prunable AND derive a threshold
+    /// near the column's real maximum so the predicate forces genuine page
+    /// skips (otherwise a trivial `>= 0` would keep every page and the
+    /// equivalence check wouldn't exercise the decode/scatter path).
+    ///
+    /// Uses the FULL page index's per-page stats to find a high value, so the
+    /// `>= threshold` predicate prunes most pages. Returns
+    /// (arrow_field_name, parquet_col_idx, threshold).
+    fn pick_prunable_column(
+        full_meta: &ParquetMetaData,
+        schema: &SchemaRef,
+    ) -> Option<(String, usize, ScalarValue)> {
+        pick_prunable_columns(full_meta, schema, 1).into_iter().next()
+    }
+
+    /// Find up to `n` distinct prunable numeric columns, each with a threshold
+    /// near its real per-page max (so `>= threshold` forces genuine page skips).
+    /// Returns `(arrow_field_name, parquet_col_idx, threshold)` per column.
+    fn pick_prunable_columns(
+        full_meta: &ParquetMetaData,
+        schema: &SchemaRef,
+        n: usize,
+    ) -> Vec<(String, usize, ScalarValue)> {
+        let Some(rg0) = full_meta.row_groups().first() else { return vec![] };
+        let (Some(col_idx), Some(off_idx)) = (full_meta.column_index(), full_meta.offset_index())
+        else {
+            return vec![];
+        };
+        let mut out = Vec::new();
+        for field in schema.fields() {
+            if out.len() >= n {
+                break;
+            }
+            let name = field.name();
+            let Ok(conv) = StatisticsConverter::try_new(
+                name,
+                schema,
+                full_meta.file_metadata().schema_descr(),
+            ) else { continue };
+            let Some(pq_idx) = conv.parquet_column_index() else { continue };
+            let col = rg0.column(pq_idx);
+            if col.column_index_offset().is_none() || col.offset_index_offset().is_none() {
+                continue;
+            }
+            // Per-page maxes for RG0; pick the overall max so `>= max` keeps only
+            // the page(s) reaching it and skips the rest — a real, selective prune.
+            let Ok(maxes) = conv.data_page_maxes(col_idx, off_idx, [&0usize]) else { continue };
+            let threshold = match field.data_type() {
+                DataType::Int8 | DataType::Int16 | DataType::Int32 => {
+                    let Some(a) = maxes.as_any().downcast_ref::<datafusion::arrow::array::Int32Array>() else { continue };
+                    let Some(m) = (0..a.len()).filter(|&i| a.is_valid(i)).map(|i| a.value(i)).max() else { continue };
+                    ScalarValue::Int32(Some(m))
+                }
+                DataType::Int64 => {
+                    let Some(a) = maxes.as_any().downcast_ref::<datafusion::arrow::array::Int64Array>() else { continue };
+                    let Some(m) = (0..a.len()).filter(|&i| a.is_valid(i)).map(|i| a.value(i)).max() else { continue };
+                    ScalarValue::Int64(Some(m))
+                }
+                DataType::UInt32 => {
+                    let Some(a) = maxes.as_any().downcast_ref::<datafusion::arrow::array::UInt32Array>() else { continue };
+                    let Some(m) = (0..a.len()).filter(|&i| a.is_valid(i)).map(|i| a.value(i)).max() else { continue };
+                    ScalarValue::UInt32(Some(m))
+                }
+                DataType::UInt64 => {
+                    let Some(a) = maxes.as_any().downcast_ref::<datafusion::arrow::array::UInt64Array>() else { continue };
+                    let Some(m) = (0..a.len()).filter(|&i| a.is_valid(i)).map(|i| a.value(i)).max() else { continue };
+                    ScalarValue::UInt64(Some(m))
+                }
+                _ => continue, // numeric int columns only — simplest reliable threshold
+            };
+            out.push((name.clone(), pq_idx, threshold));
+        }
+        out
+    }
+
+    fn col_expr(name: &str, idx: usize) -> Arc<dyn PhysicalExpr> {
+        Arc::new(PhysColumn::new(name, idx))
+    }
+    fn ge(name: &str, idx: usize, v: ScalarValue) -> Arc<dyn PhysicalExpr> {
+        Arc::new(BinaryExpr::new(col_expr(name, idx), Operator::GtEq, Arc::new(Literal::new(v))))
+    }
+    fn lt(name: &str, idx: usize, v: ScalarValue) -> Arc<dyn PhysicalExpr> {
+        Arc::new(BinaryExpr::new(col_expr(name, idx), Operator::Lt, Arc::new(Literal::new(v))))
+    }
+    fn and(l: Arc<dyn PhysicalExpr>, r: Arc<dyn PhysicalExpr>) -> Arc<dyn PhysicalExpr> {
+        Arc::new(BinaryExpr::new(l, Operator::And, r))
+    }
+    fn or(l: Arc<dyn PhysicalExpr>, r: Arc<dyn PhysicalExpr>) -> Arc<dyn PhysicalExpr> {
+        Arc::new(BinaryExpr::new(l, Operator::Or, r))
+    }
+    fn not(e: Arc<dyn PhysicalExpr>) -> Arc<dyn PhysicalExpr> {
+        Arc::new(datafusion::physical_expr::expressions::NotExpr::new(e))
+    }
+
+    fn selection_skips(sel: &datafusion::parquet::arrow::arrow_reader::RowSelection) -> Vec<(bool, usize)> {
+        sel.iter().map(|s| (s.skip, s.row_count)).collect()
+    }
+
+    #[tokio::test]
+    async fn scoped_matches_full_index_on_real_files() {
+        let Some(dir) = dir_from_env() else {
+            eprintln!("OPENSEARCH_REAL_PARQUET_DIR not set — skipping real-file test");
+            return;
+        };
+        clear_scoped_cache_for_test();
+        let store: Arc<dyn ObjectStore> = Arc::new(LocalFileSystem::new());
+
+        let files = list_parquet(&dir);
+        assert!(!files.is_empty(), "no .parquet files in {}", dir.display());
+
+        let mut checked = 0usize;
+        for path in &files {
+            let footer = footer_only_meta(path);
+            let schema = arrow_schema(&footer);
+            let num_cols = footer.file_metadata().schema_descr().num_columns();
+            let num_rgs = footer.num_row_groups();
+
+            // Footer-only load must NOT carry a page index.
+            assert!(
+                footer.column_index().is_none() && footer.offset_index().is_none(),
+                "{}: footer-only load unexpectedly has a page index",
+                path.display()
+            );
+
+            // Ground truth: full page index (also used to derive a selective
+            // threshold from real per-page stats).
+            let full = full_index_meta(path);
+
+            let Some((col_name, pq_idx, threshold)) = pick_prunable_column(&full, &schema) else {
+                eprintln!(
+                    "{}: no prunable numeric column with a page index — skipping (cols={}, rgs={})",
+                    path.display(), num_cols, num_rgs
+                );
+                continue;
+            };
+            let arrow_idx = schema.index_of(&col_name).unwrap();
+
+            eprintln!(
+                "{}: cols={} rgs={} rows={} → testing column '{}' (parquet idx {}), threshold {:?}",
+                path.file_name().unwrap().to_string_lossy(),
+                num_cols, num_rgs, footer.file_metadata().num_rows(), col_name, pq_idx, threshold
+            );
+
+            // Build our scoped index for just this column.
+            let loc = ObjPath::from(path.to_string_lossy().as_ref());
+            let augmented = load_scoped_page_index(&store, &loc, &footer, &[pq_idx])
+                .await
+                .unwrap_or_else(|| panic!("{}: scoped page-index load returned None", path.display()));
+            assert!(
+                augmented.column_index().is_some() && augmented.offset_index().is_some(),
+                "{}: augmented metadata missing page index", path.display()
+            );
+
+            let predicate = ge(&col_name, arrow_idx, threshold);
+            let pp = match build_pruning_predicate(&predicate, schema.clone()) {
+                Some(pp) => pp,
+                None => {
+                    eprintln!("  predicate not prunable, skipping file");
+                    continue;
+                }
+            };
+
+            let scoped_pruner = PagePruner::new(&schema, Arc::clone(&augmented));
+            let full_pruner = PagePruner::new(&schema, Arc::clone(&full));
+
+            // Compare per-RG selections across EVERY row group.
+            let mut total_rows = 0usize;
+            let mut kept_rows = 0usize;
+            for rg in 0..num_rgs {
+                let s = scoped_pruner.prune_rg(&pp, rg, None);
+                let f = full_pruner.prune_rg(&pp, rg, None);
+                match (s, f) {
+                    (Some(s), Some(f)) => {
+                        assert_eq!(
+                            selection_skips(&s),
+                            selection_skips(&f),
+                            "{} rg {}: scoped selection differs from full-index selection",
+                            path.display(), rg
+                        );
+                        for sel in s.iter() {
+                            total_rows += sel.row_count;
+                            if !sel.skip { kept_rows += sel.row_count; }
+                        }
+                    }
+                    (None, None) => {}
+                    (s, f) => panic!(
+                        "{} rg {}: scoped/full disagree on prunability: scoped.is_some={}, full.is_some={}",
+                        path.display(), rg, s.is_some(), f.is_some()
+                    ),
+                }
+            }
+            checked += 1;
+            if total_rows > 0 {
+                eprintln!(
+                    "  ✓ {} row groups matched full-index pruning; predicate kept {}/{} rows ({:.1}% pruned)",
+                    num_rgs, kept_rows, total_rows,
+                    100.0 * (total_rows - kept_rows) as f64 / total_rows as f64
+                );
+            } else {
+                eprintln!("  ✓ {} row groups matched full-index pruning", num_rgs);
+            }
+        }
+        assert!(checked > 0, "no file had a prunable numeric column to verify");
+        eprintln!("verified scoped==full pruning on {}/{} files", checked, files.len());
+    }
+
+    /// Complex multi-column boolean predicates (`AND` / `OR` / `NOT` / nested)
+    /// on real files. This is the case single-column tests can't cover: the
+    /// scoped index must carry real entries for *several* columns scattered into
+    /// their distinct absolute parquet slots, and `CommonGridPageStats` must
+    /// build a correct union page-grid across columns whose page layouts differ.
+    /// For each boolean shape, the scoped multi-column index must drive
+    /// `prune_rg` to the exact same selection as a full page-index decode.
+    #[tokio::test]
+    async fn complex_boolean_matches_full_index_on_real_files() {
+        let Some(dir) = dir_from_env() else {
+            eprintln!("OPENSEARCH_REAL_PARQUET_DIR not set — skipping real-file boolean test");
+            return;
+        };
+        clear_scoped_cache_for_test();
+        let store: Arc<dyn ObjectStore> = Arc::new(LocalFileSystem::new());
+        let files = list_parquet(&dir);
+        assert!(!files.is_empty(), "no .parquet files in {}", dir.display());
+
+        let mut checked = 0usize;
+        for path in &files {
+            let footer = footer_only_meta(path);
+            let schema = arrow_schema(&footer);
+            let num_rgs = footer.num_row_groups();
+            let full = full_index_meta(path);
+
+            // Need at least 3 prunable columns to build interesting trees.
+            let cols = pick_prunable_columns(&full, &schema, 3);
+            if cols.len() < 3 {
+                eprintln!(
+                    "{}: only {} prunable numeric columns — need 3, skipping",
+                    path.file_name().unwrap().to_string_lossy(), cols.len()
+                );
+                continue;
+            }
+            let (n0, p0, t0) = cols[0].clone();
+            let (n1, p1, t1) = cols[1].clone();
+            let (n2, p2, t2) = cols[2].clone();
+            let a0 = schema.index_of(&n0).unwrap();
+            let a1 = schema.index_of(&n1).unwrap();
+            let a2 = schema.index_of(&n2).unwrap();
+
+            // Scope the index to ALL three columns (sorted/deduped as production does).
+            let mut parquet_cols = vec![p0, p1, p2];
+            parquet_cols.sort_unstable();
+            parquet_cols.dedup();
+            let loc = ObjPath::from(path.to_string_lossy().as_ref());
+            let augmented = load_scoped_page_index(&store, &loc, &footer, &parquet_cols)
+                .await
+                .unwrap_or_else(|| panic!("{}: scoped multi-col load returned None", path.display()));
+
+            let scoped_pruner = PagePruner::new(&schema, Arc::clone(&augmented));
+            let full_pruner = PagePruner::new(&schema, Arc::clone(&full));
+
+            // A range of boolean shapes. `>= max` is selective; `< max` is its
+            // complement; combine with AND/OR/NOT and nest.
+            // Note: `NOT(col >= v)` is conservatively non-translatable by
+            // DataFusion's `PruningPredicate` (collapses to always-true), so we
+            // also include `NOT(col < v)` which IS prunable (≡ `col >= v`) to
+            // exercise negation through the scoped index, not just skip it.
+            let shapes: Vec<(&str, Arc<dyn PhysicalExpr>)> = vec![
+                ("c0 AND c1", and(ge(&n0, a0, t0.clone()), ge(&n1, a1, t1.clone()))),
+                ("c0 OR c1", or(ge(&n0, a0, t0.clone()), ge(&n1, a1, t1.clone()))),
+                ("NOT(c0 < t0)  [≡ c0 >= t0, prunable]", not(lt(&n0, a0, t0.clone()))),
+                ("c0 AND (c1 OR c2)", and(ge(&n0, a0, t0.clone()), or(ge(&n1, a1, t1.clone()), ge(&n2, a2, t2.clone())))),
+                ("(c0 AND c1) OR NOT(c2 < t2)", or(and(ge(&n0, a0, t0.clone()), ge(&n1, a1, t1.clone())), not(lt(&n2, a2, t2.clone())))),
+                ("c0 AND NOT(c1 < t1 AND c2 < t2)", and(ge(&n0, a0, t0.clone()), not(and(lt(&n1, a1, t1.clone()), lt(&n2, a2, t2.clone()))))),
+            ];
+
+            eprintln!(
+                "{}: rgs={} cols=[{}({}), {}({}), {}({})]",
+                path.file_name().unwrap().to_string_lossy(),
+                num_rgs, n0, a0, n1, a1, n2, a2
+            );
+
+            for (label, expr) in &shapes {
+                let Some(pp) = build_pruning_predicate(expr, schema.clone()) else {
+                    eprintln!("  [{}] not prunable (always-true) — skipping shape", label);
+                    continue;
+                };
+                let mut total = 0usize;
+                let mut kept = 0usize;
+                for rg in 0..num_rgs {
+                    let s = scoped_pruner.prune_rg(&pp, rg, None);
+                    let f = full_pruner.prune_rg(&pp, rg, None);
+                    match (s, f) {
+                        (Some(s), Some(f)) => {
+                            assert_eq!(
+                                selection_skips(&s),
+                                selection_skips(&f),
+                                "{} [{}] rg {}: scoped multi-col selection differs from full-index",
+                                path.display(), label, rg
+                            );
+                            for sel in s.iter() {
+                                total += sel.row_count;
+                                if !sel.skip { kept += sel.row_count; }
+                            }
+                        }
+                        (None, None) => {}
+                        (s, f) => panic!(
+                            "{} [{}] rg {}: scoped/full disagree on prunability: scoped={} full={}",
+                            path.display(), label, rg, s.is_some(), f.is_some()
+                        ),
+                    }
+                }
+                let pruned_pct = if total > 0 {
+                    100.0 * (total - kept) as f64 / total as f64
+                } else { 0.0 };
+                eprintln!("  ✓ [{}] matched across {} RGs ({:.1}% pruned)", label, num_rgs, pruned_pct);
+            }
+            checked += 1;
+        }
+        assert!(checked > 0, "no file had >=3 prunable numeric columns for boolean tests");
+        eprintln!("verified complex-boolean scoped==full on {}/{} files", checked, files.len());
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/parquet_bridge.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/parquet_bridge.rs
@@ -24,12 +24,17 @@ use std::time::{Duration, Instant};
 
 use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::common::Result;
-use datafusion::datasource::physical_plan::parquet::metadata::DFParquetMetadata;
+use datafusion::datasource::physical_plan::parquet::metadata::{
+    CachedParquetMetaData, DFParquetMetadata,
+};
 use datafusion::datasource::physical_plan::parquet::{
     ParquetAccessPlan, ParquetFileMetrics, ParquetFileReaderFactory, RowGroupAccess,
 };
 use datafusion::datasource::physical_plan::ParquetSource;
-use datafusion::execution::cache::cache_manager::FileMetadataCache;
+use datafusion::execution::cache::cache_manager::{
+    CachedFileMetadataEntry, FileMetadataCache,
+};
+use datafusion::execution::cache::CacheAccessor;
 use datafusion::execution::object_store::ObjectStoreUrl;
 use datafusion::execution::SendableRecordBatchStream;
 use datafusion::parquet::arrow::arrow_reader::{ArrowReaderOptions, RowSelection};
@@ -48,8 +53,30 @@ use prost::bytes::Bytes;
 
 // ── Parquet Metadata Loading ─────────────────────────────────────────
 
-/// Load parquet metadata via DataFusion's `DFParquetMetadata`, consulting the
-/// caller-supplied `FileMetadataCache`.
+/// Load **footer-only** parquet metadata (row-group stats, schema, key-value
+/// metadata) and publish it into the shared `FileMetadataCache`.
+///
+/// # Why we don't hand the cache to `DFParquetMetadata`
+///
+/// DataFusion's `DFParquetMetadata::fetch_metadata` forces a full page-index
+/// decode (`PageIndexPolicy::Optional` — `ColumnIndex` + `OffsetIndex` for
+/// *every* column of *every* row group) the moment a `file_metadata_cache` is
+/// attached (`datafusion-datasource-parquet/src/metadata.rs:156`). On wide
+/// schemas (hundreds of columns × hundreds of row groups) the decoded page
+/// index dominates the native heap — ~82% in production profiles — even though
+/// only a handful of predicate columns are ever pruned on.
+///
+/// So we decode **footer-only** here (cache *not* attached → `Skip` branch) and
+/// put the result into the shared cache ourselves. Downstream DataFusion calls
+/// that *do* attach the cache (`ParquetFormat::infer_schema`,
+/// `fetch_statistics`) then hit our entry first
+/// (`metadata.rs:134` checks the cache before decoding) and never re-force the
+/// full page index. Page-level pruning is restored separately, scoped to the
+/// predicate columns only (see the page-index augmentation path).
+///
+/// RG-level pruning (`dynamic_filter.rs`), bloom filters, and the scan itself
+/// (`with_enable_page_index(false)`) all read footer/row-group stats, so they
+/// are unaffected by the absent page index.
 pub async fn load_parquet_metadata(
     store: Arc<dyn ObjectStore>,
     location: &object_store::path::Path,
@@ -61,11 +88,47 @@ pub async fn load_parquet_metadata(
         .map_err(|e| format!("object-store head {}: {}", location, e))?;
     let size = meta.size;
 
+    // Cache hit: reuse whatever is already cached for this exact file version.
+    // We accept an entry regardless of whether it carries a page index — a
+    // footer-only entry is what we want, and a fuller entry (e.g. populated by
+    // a path we don't control) is still correct to reuse.
+    if let Some(cached) = metadata_cache.get(location) {
+        if cached.is_valid_for(&meta) {
+            if let Some(cached_parquet) = cached
+                .file_metadata
+                .as_any()
+                .downcast_ref::<CachedParquetMetaData>()
+            {
+                let pq_meta = Arc::clone(cached_parquet.parquet_metadata());
+                let file_meta = pq_meta.file_metadata();
+                let schema = parquet_to_arrow_schema(
+                    file_meta.schema_descr(),
+                    file_meta.key_value_metadata(),
+                )
+                .map_err(|e| format!("parquet_to_arrow_schema {}: {}", location, e))?;
+                return Ok((Arc::new(schema), size, pq_meta));
+            }
+        }
+    }
+
+    // Cache miss: decode footer-only. Crucially we do NOT attach the cache to
+    // `DFParquetMetadata` — that would force `PageIndexPolicy::Optional`. With
+    // no cache attached, `fetch_metadata` takes the `Skip` branch.
     let pq_meta = DFParquetMetadata::new(&*store, &meta)
-        .with_file_metadata_cache(Some(metadata_cache))
         .fetch_metadata()
         .await
         .map_err(|e| format!("load parquet metadata {}: {}", location, e))?;
+
+    // Publish the footer-only entry so DataFusion's own cache-attaching paths
+    // (infer_schema, fetch_statistics) reuse it instead of re-forcing a full
+    // page-index decode.
+    metadata_cache.put(
+        location,
+        CachedFileMetadataEntry::new(
+            meta,
+            Arc::new(CachedParquetMetaData::new(Arc::clone(&pq_meta))),
+        ),
+    );
 
     let file_meta = pq_meta.file_metadata();
     let schema = parquet_to_arrow_schema(file_meta.schema_descr(), file_meta.key_value_metadata())
@@ -295,5 +358,317 @@ impl AsyncFileReader for CachedMetadataReader {
     ) -> BoxFuture<'_, datafusion::parquet::errors::Result<Arc<ParquetMetaData>>> {
         let metadata = Arc::clone(&self.metadata);
         async move { Ok(metadata) }.boxed()
+    }
+}
+
+#[cfg(test)]
+mod io_runtime_tests {
+    use super::*;
+    use datafusion::arrow::array::Int64Array;
+    use datafusion::arrow::datatypes::{DataType, Field, Schema};
+    use datafusion::arrow::record_batch::RecordBatch;
+    use datafusion::parquet::arrow::ArrowWriter;
+    use datafusion::parquet::file::metadata::ParquetMetaDataReader;
+    use object_store::memory::InMemory;
+    use object_store::path::Path as ObjStorePath;
+    use object_store::{
+        GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta, PutMultipartOptions,
+        PutOptions, PutPayload, PutResult,
+    };
+    use std::sync::Mutex;
+
+    /// ObjectStore wrapper that records the name of the thread each `get_opts`
+    /// (and therefore `get_range`/`get_ranges`, which funnel through it) runs
+    /// on. Everything else delegates to the inner store.
+    #[derive(Debug)]
+    struct ThreadRecordingStore {
+        inner: Arc<InMemory>,
+        get_threads: Arc<Mutex<Vec<Option<String>>>>,
+    }
+
+    impl std::fmt::Display for ThreadRecordingStore {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "ThreadRecordingStore({})", self.inner)
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl ObjectStore for ThreadRecordingStore {
+        async fn put_opts(
+            &self,
+            location: &ObjStorePath,
+            payload: PutPayload,
+            opts: PutOptions,
+        ) -> object_store::Result<PutResult> {
+            self.inner.put_opts(location, payload, opts).await
+        }
+
+        async fn put_multipart_opts(
+            &self,
+            location: &ObjStorePath,
+            opts: PutMultipartOptions,
+        ) -> object_store::Result<Box<dyn MultipartUpload>> {
+            self.inner.put_multipart_opts(location, opts).await
+        }
+
+        async fn get_opts(
+            &self,
+            location: &ObjStorePath,
+            options: GetOptions,
+        ) -> object_store::Result<GetResult> {
+            self.get_threads
+                .lock()
+                .unwrap()
+                .push(std::thread::current().name().map(|s| s.to_owned()));
+            self.inner.get_opts(location, options).await
+        }
+
+        fn list(
+            &self,
+            prefix: Option<&ObjStorePath>,
+        ) -> futures::stream::BoxStream<'static, object_store::Result<ObjectMeta>> {
+            self.inner.list(prefix)
+        }
+
+        fn delete_stream(
+            &self,
+            locations: futures::stream::BoxStream<'static, object_store::Result<ObjStorePath>>,
+        ) -> futures::stream::BoxStream<'static, object_store::Result<ObjStorePath>> {
+            self.inner.delete_stream(locations)
+        }
+
+        async fn list_with_delimiter(
+            &self,
+            prefix: Option<&ObjStorePath>,
+        ) -> object_store::Result<ListResult> {
+            self.inner.list_with_delimiter(prefix).await
+        }
+
+        async fn copy_opts(
+            &self,
+            from: &ObjStorePath,
+            to: &ObjStorePath,
+            options: object_store::CopyOptions,
+        ) -> object_store::Result<()> {
+            self.inner.copy_opts(from, to, options).await
+        }
+    }
+
+    /// Writes a tiny single-column parquet file and returns its raw bytes.
+    fn tiny_parquet() -> Bytes {
+        let schema = Arc::new(Schema::new(vec![Field::new("v", DataType::Int64, false)]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(Int64Array::from(vec![1i64, 2, 3, 4, 5]))],
+        )
+        .unwrap();
+        let mut buf: Vec<u8> = Vec::new();
+        let mut w = ArrowWriter::try_new(&mut buf, schema, None).unwrap();
+        w.write(&batch).unwrap();
+        w.close().unwrap();
+        Bytes::from(buf)
+    }
+
+    // The actual data read — `CachedMetadataReader::get_byte_ranges`, the parquet
+    // AsyncFileReader hot path — MUST execute on the dedicated IO runtime, never
+    // inline on the CPU worker that drives the scan stream. IO-runtime dispatch
+    // is provided generically by wrapping the registered store in SpawnIoStore;
+    // this asserts that a read issued from a CPU worker through that wrapped store
+    // lands on a `datafusion-io` thread.
+    #[test]
+    fn test_get_byte_ranges_runs_on_io_runtime() {
+        let mgr = crate::runtime_manager::RuntimeManager::new(2, 1.5, 1.5);
+
+        // Stage a parquet file in the recording store and parse its metadata.
+        let bytes = tiny_parquet();
+        let metadata = Arc::new(
+            ParquetMetaDataReader::new()
+                .parse_and_finish(&bytes)
+                .unwrap(),
+        );
+        let location = ObjStorePath::from("data.parquet");
+        let inner = Arc::new(InMemory::new());
+        mgr.io_runtime
+            .block_on(inner.put(&location, PutPayload::from_bytes(bytes.clone())))
+            .unwrap();
+
+        let get_threads = Arc::new(Mutex::new(Vec::new()));
+        let recording: Arc<dyn ObjectStore> = Arc::new(ThreadRecordingStore {
+            inner,
+            get_threads: Arc::clone(&get_threads),
+        });
+        // Wrap exactly as production does at register_object_store, binding to
+        // THIS manager's IO handle explicitly (the process-global handle may point
+        // at a sibling test's runtime when several managers exist in one binary).
+        let store: Arc<dyn ObjectStore> = Arc::new(crate::spawn_io_store::SpawnIoStore::new(
+            recording,
+            mgr.io_runtime.handle().clone(),
+        ));
+
+        let metrics = ExecutionPlanMetricsSet::new();
+        let file_metrics = ParquetFileMetrics::new(0, location.as_ref(), &metrics);
+        let mut reader = CachedMetadataReader {
+            store,
+            location,
+            metadata,
+            metrics: file_metrics,
+            io_stats: Arc::new(ReadIoStats::default()),
+        };
+
+        // Drive the data fetch from a CPU worker, exactly as the scan stream does.
+        let ranges = vec![0u64..16u64];
+        let task = mgr.cpu_executor().spawn(async move {
+            reader.get_byte_ranges(ranges).await.map(|v| v.len())
+        });
+        let n = mgr.io_runtime.block_on(task).unwrap().unwrap();
+        assert_eq!(n, 1, "expected one byte range back");
+
+        let threads = get_threads.lock().unwrap();
+        assert!(!threads.is_empty(), "store was never read");
+        for t in threads.iter() {
+            assert_eq!(
+                t.as_deref().map(|n| n.starts_with("datafusion-io")),
+                Some(true),
+                "object-store read ran on thread {:?}, expected a `datafusion-io` worker",
+                t,
+            );
+        }
+        drop(threads);
+
+        mgr.cpu_executor.shutdown();
+        std::mem::forget(mgr);
+    }
+}
+
+#[cfg(test)]
+mod footer_only_metadata_tests {
+    use super::*;
+    use datafusion::arrow::array::Int64Array;
+    use datafusion::arrow::datatypes::{DataType, Field, Schema};
+    use datafusion::arrow::record_batch::RecordBatch;
+    use datafusion::execution::cache::DefaultFilesMetadataCache;
+    use datafusion::parquet::arrow::ArrowWriter;
+    use datafusion::parquet::file::properties::{EnabledStatistics, WriterProperties};
+    use object_store::memory::InMemory;
+    use object_store::path::Path as ObjStorePath;
+    use object_store::PutPayload;
+
+    /// Write a multi-page parquet file (page-level statistics enabled, tiny data
+    /// pages so the writer emits several pages → a real page index) and return
+    /// (store, location, ObjectMeta). The page index is what we want to prove we
+    /// DON'T retain on the footer-only load path.
+    async fn staged_parquet_with_page_index(
+    ) -> (Arc<dyn ObjectStore>, ObjStorePath, object_store::ObjectMeta) {
+        let schema = Arc::new(Schema::new(vec![Field::new("v", DataType::Int64, false)]));
+        // 4k rows in tiny data pages → many pages → a populated ColumnIndex /
+        // OffsetIndex in the footer.
+        let values: Vec<i64> = (0..4096).collect();
+        let batch =
+            RecordBatch::try_new(schema.clone(), vec![Arc::new(Int64Array::from(values))]).unwrap();
+        let props = WriterProperties::builder()
+            .set_statistics_enabled(EnabledStatistics::Page)
+            .set_data_page_row_count_limit(128)
+            .build();
+        let mut buf: Vec<u8> = Vec::new();
+        let mut w = ArrowWriter::try_new(&mut buf, schema, Some(props)).unwrap();
+        w.write(&batch).unwrap();
+        w.close().unwrap();
+        let bytes = Bytes::from(buf);
+
+        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let location = ObjStorePath::from("data.parquet");
+        store
+            .put(&location, PutPayload::from_bytes(bytes))
+            .await
+            .unwrap();
+        let meta = store.head(&location).await.unwrap();
+        (store, location, meta)
+    }
+
+    fn fresh_cache() -> Arc<dyn FileMetadataCache> {
+        Arc::new(DefaultFilesMetadataCache::new(64 * 1024 * 1024))
+    }
+
+    /// The whole point of Part 1: the metadata we load (and cache) carries the
+    /// footer row-group stats but NOT the per-column page index. Sanity-check
+    /// the fixture first by confirming a full decode would have produced one.
+    #[tokio::test]
+    async fn load_returns_footer_only_no_page_index() {
+        let (store, location, _meta) = staged_parquet_with_page_index().await;
+
+        // Control: a full decode (cache attached → PageIndexPolicy::Optional)
+        // DOES produce a page index for this file. If this ever stops holding,
+        // the fixture is wrong and the assertion below would be vacuous.
+        let full = DFParquetMetadata::new(&*store, &store.head(&location).await.unwrap())
+            .with_file_metadata_cache(Some(fresh_cache()))
+            .fetch_metadata()
+            .await
+            .unwrap();
+        assert!(
+            full.column_index().is_some() && full.offset_index().is_some(),
+            "fixture must have a page index for the test to be meaningful"
+        );
+
+        // Subject: our footer-only loader must NOT retain the page index.
+        let cache = fresh_cache();
+        let (_schema, _size, pq_meta) =
+            load_parquet_metadata(Arc::clone(&store), &location, Arc::clone(&cache))
+                .await
+                .unwrap();
+        assert!(
+            pq_meta.column_index().is_none() && pq_meta.offset_index().is_none(),
+            "footer-only load must drop the page index (column_index={:?}, offset_index={:?})",
+            pq_meta.column_index().map(|c| c.len()),
+            pq_meta.offset_index().map(|o| o.len()),
+        );
+        // Footer row-group stats must survive — RG pruning / bloom depend on them.
+        assert_eq!(pq_meta.num_row_groups(), full.num_row_groups());
+        assert!(pq_meta.row_group(0).column(0).statistics().is_some());
+    }
+
+    /// The footer-only entry must be published to the shared cache so
+    /// DataFusion's own cache-attaching paths (infer_schema, fetch_statistics)
+    /// reuse it instead of re-forcing a full page-index decode.
+    #[tokio::test]
+    async fn load_publishes_footer_only_entry_to_cache() {
+        let (store, location, meta) = staged_parquet_with_page_index().await;
+        let cache = fresh_cache();
+
+        let _ = load_parquet_metadata(Arc::clone(&store), &location, Arc::clone(&cache))
+            .await
+            .unwrap();
+
+        let cached = cache.get(&location).expect("entry must be published to cache");
+        assert!(cached.is_valid_for(&meta));
+        let cached_parquet = cached
+            .file_metadata
+            .as_any()
+            .downcast_ref::<CachedParquetMetaData>()
+            .expect("entry must be a CachedParquetMetaData");
+        let cm = cached_parquet.parquet_metadata();
+        assert!(
+            cm.column_index().is_none() && cm.offset_index().is_none(),
+            "the CACHED entry (the one pinned in the heap) must be footer-only"
+        );
+    }
+
+    /// A second load reuses the cached entry (no re-decode, identical Arc).
+    #[tokio::test]
+    async fn second_load_reuses_cached_entry() {
+        let (store, location, _meta) = staged_parquet_with_page_index().await;
+        let cache = fresh_cache();
+
+        let (_, _, first) =
+            load_parquet_metadata(Arc::clone(&store), &location, Arc::clone(&cache))
+                .await
+                .unwrap();
+        let (_, _, second) =
+            load_parquet_metadata(Arc::clone(&store), &location, Arc::clone(&cache))
+                .await
+                .unwrap();
+        assert!(
+            Arc::ptr_eq(&first, &second),
+            "second load must return the same cached Arc, not a fresh decode"
+        );
     }
 }

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/lib.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/lib.rs
@@ -47,6 +47,8 @@ pub mod query_executor;
 pub mod query_tracker;
 pub mod relabel_exec;
 pub mod shard_table_provider;
+pub mod shard_scoped_reader;
+pub mod scoped_page_index_optimizer;
 pub mod runtime_manager;
 pub mod schema_coerce;
 pub mod session_context;

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/project_row_id_optimizer.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/project_row_id_optimizer.rs
@@ -96,12 +96,29 @@ impl PhysicalOptimizerRule for ProjectRowIdOptimizer {
             let row_base_partition_idx = file_schema.fields().len();
             new_proj_indices.push(row_base_partition_idx);
 
-            // Rebuild the DataSourceExec with new projections
+            // Rebuild the DataSourceExec with new projections, preserving the
+            // pushed-down predicate (and any reader factory) from the original
+            // ParquetSource. Dropping the predicate here would disable page
+            // pruning for row-id queries and would also strip the scoped
+            // page-index reader factory installed downstream.
             let new_table_schema = TableSchema::new(
                 file_schema.clone(),
                 partition_cols.clone(),
             );
-            let new_source = Arc::new(ParquetSource::new(new_table_schema));
+            let mut new_source = ParquetSource::new(new_table_schema);
+            if let Some(old_parquet) = (file_scan_config.file_source().as_ref()
+                as &dyn std::any::Any)
+                .downcast_ref::<ParquetSource>()
+            {
+                if let Some(pred) = old_parquet.predicate() {
+                    new_source = new_source.with_predicate(Arc::clone(pred));
+                }
+                if let Some(factory) = old_parquet.parquet_file_reader_factory() {
+                    new_source =
+                        new_source.with_parquet_file_reader_factory(Arc::clone(factory));
+                }
+            }
+            let new_source = Arc::new(new_source);
 
             let new_config = FileScanConfigBuilder::from(file_scan_config.clone())
                 .with_source(new_source)

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/query_executor.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/query_executor.rs
@@ -162,7 +162,7 @@ pub async fn execute_query(
                 .await
                 .map_err(|e| { error!("Failed to infer schema: {}", e); e })?;
             let resolved_schema = crate::schema_coerce::coerce_inferred_schema(resolved_schema);
-            let table_config = ListingTableConfig::new(table_path)
+            let table_config = ListingTableConfig::new(table_path.clone())
                 .with_listing_options(listing_options)
                 .with_schema(resolved_schema);
             let provider = Arc::new(ListingTable::try_new(table_config)
@@ -192,14 +192,32 @@ pub async fn execute_query(
     // Apply row ID optimizer when ShardTableProvider injected `row_base`.
     // For other strategies the vanilla scan output is already what the plan expects.
     use datafusion::physical_optimizer::PhysicalOptimizerRule;
+    let opt_config = datafusion::common::config::ConfigOptions::default();
     let physical_plan = match query_config.query_strategy {
         QueryStrategy::ListingTable => {
-            // Rewrites ___row_id to ___row_id + row_base.
+            // Rewrites ___row_id to ___row_id + row_base. Preserves the
+            // ParquetSource predicate + reader factory when it rebuilds the scan.
             let optimizer = crate::project_row_id_optimizer::ProjectRowIdOptimizer;
-            let config = datafusion::common::config::ConfigOptions::default();
-            optimizer.optimize(physical_plan, &config)?
+            optimizer.optimize(physical_plan, &opt_config)?
         }
         _ => physical_plan,
+    };
+
+    // Install the scoped page-index reader factory on EVERY parquet scan in the
+    // plan, regardless of QueryStrategy/provider. Runs last so it sees the final
+    // ParquetSource (with predicate pushed by DataFusion's optimizers, and after
+    // the row-id rebuild). This is what gives `QueryStrategy::None` plain scans
+    // (stock ListingTable) the same scoped page-index loading + shared cache the
+    // indexed path already has. See `crate::scoped_page_index_optimizer`.
+    let physical_plan = {
+        let store = ctx.state().runtime_env().object_store(&table_path)?;
+        let metadata_cache =
+            ctx.state().runtime_env().cache_manager.get_file_metadata_cache();
+        let scoped = crate::scoped_page_index_optimizer::ScopedPageIndexOptimizer::new(
+            store,
+            metadata_cache,
+        );
+        scoped.optimize(physical_plan, &opt_config)?
     };
 
     let df_stream = execute_stream(physical_plan, ctx.task_ctx()).map_err(|e| {

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/query_executor.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/query_executor.rs
@@ -105,6 +105,17 @@ pub async fn execute_query(
     // therefore matters only for distinguishing the ShardTableProvider rewrite
     // (ListingTable) from the plain ListingTable scan (None / IndexedPredicateOnly).
     use crate::datafusion_query_config::QueryStrategy;
+
+    // Pre-seed the shared metadata cache footer-only so the upcoming
+    // `infer_schema` / `ListingTable` scan get cache hits instead of forcing a
+    // full page-index decode into the shared cache. See
+    // `preseed_footer_only_metadata`.
+    {
+        let store = ctx.state().runtime_env().object_store(&table_path)?;
+        let metadata_cache = ctx.state().runtime_env().cache_manager.get_file_metadata_cache();
+        preseed_footer_only_metadata(&store, metadata_cache, object_metas.as_ref()).await;
+    }
+
     match query_config.query_strategy {
         QueryStrategy::ListingTable => {
             use crate::shard_table_provider::{ShardTableConfig, ShardTableProvider};
@@ -254,6 +265,19 @@ pub async fn execute_with_context(
         handle.ctx.deregister_table(&handle.table_name)?;
 
         let store = handle.ctx.state().runtime_env().object_store(&handle.table_path)?;
+
+        // Pre-seed the shared metadata cache footer-only so `infer_schema` and the
+        // scan opener hit the cache instead of force-decoding the full page index.
+        // See `preseed_footer_only_metadata`.
+        {
+            let metadata_cache = handle
+                .ctx
+                .state()
+                .runtime_env()
+                .cache_manager
+                .get_file_metadata_cache();
+            preseed_footer_only_metadata(&store, metadata_cache, handle.object_metas.as_ref()).await;
+        }
 
         // Infer schema from existing files
         let listing_options = ListingOptions::new(Arc::new(ParquetFormat::new()))
@@ -450,6 +474,46 @@ pub async fn build_shard_file_infos(
         cumulative_rows += num_rows;
     }
     Ok(files)
+}
+
+/// Pre-seed the shared file-metadata cache with **footer-only** entries for the
+/// vanilla `ListingTable` path, BEFORE `infer_schema` / `ListingTable` run.
+///
+/// # Why
+///
+/// DataFusion's `ParquetFormat` (via `infer_schema` and the scan opener) hands
+/// the session's `file_metadata_cache` to `DFParquetMetadata::fetch_metadata`,
+/// which forces a full page-index decode (`PageIndexPolicy::Optional`) and
+/// stores that bloated entry in the shared cache
+/// (`datafusion-datasource-parquet/src/metadata.rs:156`). On wide schemas the
+/// decoded page index dominates the native heap, and because the cache is a
+/// shared LRU keyed by path, those large entries also evict the footer-only
+/// entries the indexed path relies on.
+///
+/// `fetch_metadata` checks the cache *before* decoding (`metadata.rs:134`), so
+/// if we publish a footer-only entry first, DataFusion gets a cache hit and
+/// never force-decodes. The vanilla scan still does page-level pruning when it
+/// needs it: the opener re-reads the page index on demand, transiently, without
+/// pinning it in the shared cache (`opener/mod.rs::load_page_index`).
+///
+/// Best-effort: a per-file failure is logged and skipped (DataFusion will then
+/// fall back to its own decode for that file) rather than failing the query.
+async fn preseed_footer_only_metadata(
+    store: &Arc<dyn object_store::ObjectStore>,
+    metadata_cache: Arc<dyn datafusion::execution::cache::cache_manager::FileMetadataCache>,
+    object_metas: &[ObjectMeta],
+) {
+    for meta in object_metas {
+        if let Err(e) = crate::indexed_table::parquet_bridge::load_parquet_metadata(
+            Arc::clone(store),
+            &meta.location,
+            Arc::clone(&metadata_cache),
+        )
+        .await
+        {
+            log_debug!("preseed footer-only metadata for {}: {}", meta.location, e);
+        }
+    }
 }
 
 /// Parse a ListingTableUrl into an ObjectStoreUrl (scheme + authority).

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/scoped_page_index_optimizer.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/scoped_page_index_optimizer.rs
@@ -1,0 +1,383 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+//! Physical optimizer rule that installs the scoped page-index reader factory on
+//! **every** parquet scan in the plan — provider-agnostic.
+//!
+//! # Why a rule (not a TableProvider)
+//!
+//! The scoped page-index loader is a property of *how we read parquet*, not of
+//! *which TableProvider* produced the scan. Wiring it into a specific provider
+//! (e.g. `ShardTableProvider`) leaves other scan paths — the stock
+//! `ListingTable` used for `QueryStrategy::None` plain scans — on DataFusion's
+//! default reader, which loads the full all-column page index every query and
+//! caches none of it.
+//!
+//! This rule walks the physical plan, finds each parquet `DataSourceExec`, reads
+//! the predicate already pushed onto its `ParquetSource`, derives the predicate
+//! columns, and swaps in a [`ScopedPageIndexReaderFactory`] scoped to those
+//! columns. It runs after DataFusion's own optimizers (which is when filter
+//! pushdown has populated `ParquetSource::predicate`), so it works uniformly for
+//! `ListingTable`, `ShardTableProvider`, and any future parquet provider.
+//!
+//! # No-op cases (left exactly as DataFusion would run them)
+//!
+//!  - A `DataSourceExec` that isn't parquet, or whose source already has a custom
+//!    reader factory (e.g. the indexed path's `CachedMetadataReaderFactory`, or
+//!    `ShardTableProvider` once it installs its own scoped factory) — skipped, so
+//!    we never double-wrap.
+//!  - A parquet scan with no predicate, or whose predicate references no file
+//!    columns — skipped (nothing to scope; the opener loads on demand as today).
+//!
+//! Correctness of the scoped index itself (real OffsetIndex for all columns) is
+//! handled in `page_index_loader::build_augmented_metadata`; this rule only
+//! decides *where* to attach the loader.
+
+use std::sync::Arc;
+
+use datafusion::common::config::ConfigOptions;
+use datafusion::common::tree_node::{Transformed, TreeNode};
+use datafusion::common::Result;
+use datafusion::datasource::physical_plan::ParquetSource;
+use datafusion::datasource::source::DataSourceExec;
+use datafusion::execution::cache::cache_manager::FileMetadataCache;
+use datafusion::physical_expr::utils::collect_columns;
+use datafusion::physical_optimizer::PhysicalOptimizerRule;
+use datafusion::physical_plan::ExecutionPlan;
+use datafusion_datasource::file_scan_config::{FileScanConfig, FileScanConfigBuilder};
+use object_store::ObjectStore;
+
+use crate::shard_scoped_reader::ScopedPageIndexReaderFactory;
+
+/// Installs the scoped page-index reader factory on parquet scans.
+///
+/// Carries the object store and shared metadata cache because a
+/// `PhysicalOptimizerRule` has no access to the session; the caller constructs
+/// it from the query's `RuntimeEnv`.
+#[derive(Debug)]
+pub struct ScopedPageIndexOptimizer {
+    store: Arc<dyn ObjectStore>,
+    metadata_cache: Arc<dyn FileMetadataCache>,
+}
+
+impl ScopedPageIndexOptimizer {
+    pub fn new(
+        store: Arc<dyn ObjectStore>,
+        metadata_cache: Arc<dyn FileMetadataCache>,
+    ) -> Self {
+        Self { store, metadata_cache }
+    }
+}
+
+impl PhysicalOptimizerRule for ScopedPageIndexOptimizer {
+    fn optimize(
+        &self,
+        plan: Arc<dyn ExecutionPlan>,
+        _config: &ConfigOptions,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let rewritten = plan.transform_up(|node| {
+            let Some(dse) = node.downcast_ref::<DataSourceExec>() else {
+                return Ok(Transformed::no(node));
+            };
+            let Some(config) = dse.data_source().as_ref().downcast_ref::<FileScanConfig>() else {
+                return Ok(Transformed::no(node));
+            };
+            let Some(parquet) = (config.file_source().as_ref() as &dyn std::any::Any)
+                .downcast_ref::<ParquetSource>()
+            else {
+                return Ok(Transformed::no(node));
+            };
+
+            // Need a predicate to scope to. No predicate → nothing to do.
+            //
+            // Note: we intentionally do NOT skip when a factory is already set.
+            // DataFusion's `ParquetFormat::create_physical_plan` ALWAYS installs
+            // its own `CachedParquetFileReaderFactory` (which loads the full
+            // all-column page index) — that is exactly the factory we want to
+            // replace. Replacing it with our scoped factory is the whole point.
+            // The indexed path does not run this rule (it uses its own executor),
+            // and `ShardTableProvider` installs an equivalent scoped factory at
+            // construction, so replacing that with another scoped factory is
+            // harmless/idempotent.
+            let Some(predicate) = parquet.predicate() else {
+                return Ok(Transformed::no(node));
+            };
+
+            // Derive predicate column NAMES that exist in the file schema. The
+            // reader resolves them to per-file parquet leaf indices.
+            let file_schema = config.file_schema();
+            let mut names: Vec<String> = collect_columns(predicate)
+                .into_iter()
+                .map(|c| c.name().to_string())
+                .filter(|n| file_schema.index_of(n).is_ok())
+                .collect();
+            names.sort();
+            names.dedup();
+            if names.is_empty() {
+                return Ok(Transformed::no(node));
+            }
+
+            // Build the scoped factory and reinstall the source.
+            let factory = Arc::new(ScopedPageIndexReaderFactory::new(
+                Arc::clone(&self.store),
+                Arc::clone(&self.metadata_cache),
+                names,
+                Arc::clone(file_schema),
+            ));
+            let new_source = parquet.clone().with_parquet_file_reader_factory(factory);
+            let new_config = FileScanConfigBuilder::from(config.clone())
+                .with_source(Arc::new(new_source))
+                .build();
+            let new_dse: Arc<dyn ExecutionPlan> = DataSourceExec::from_data_source(new_config);
+            Ok(Transformed::yes(new_dse))
+        })?;
+        Ok(rewritten.data)
+    }
+
+    fn name(&self) -> &str {
+        "ScopedPageIndexOptimizer"
+    }
+
+    /// We swap a reader factory only; the scan's output schema is unchanged.
+    fn schema_check(&self) -> bool {
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::datatypes::{DataType, Field, Schema};
+    use datafusion::execution::cache::DefaultFilesMetadataCache;
+    use datafusion::execution::object_store::ObjectStoreUrl;
+    use datafusion::physical_expr::expressions::{lit, BinaryExpr, Column};
+    use datafusion::logical_expr::Operator;
+    use datafusion::physical_expr::PhysicalExpr;
+    use datafusion_datasource::table_schema::TableSchema;
+    use object_store::memory::InMemory;
+
+    fn schema() -> Arc<Schema> {
+        Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int32, false),
+            Field::new("b", DataType::Int32, false),
+        ]))
+    }
+
+    fn deps() -> (Arc<dyn ObjectStore>, Arc<dyn FileMetadataCache>) {
+        (
+            Arc::new(InMemory::new()),
+            Arc::new(DefaultFilesMetadataCache::new(64 * 1024 * 1024)),
+        )
+    }
+
+    fn datasource_exec(parquet: ParquetSource) -> Arc<dyn ExecutionPlan> {
+        let config = FileScanConfigBuilder::new(
+            ObjectStoreUrl::local_filesystem(),
+            Arc::new(parquet),
+        )
+        .build();
+        DataSourceExec::from_data_source(config)
+    }
+
+    fn predicate_on_a() -> Arc<dyn PhysicalExpr> {
+        Arc::new(BinaryExpr::new(
+            Arc::new(Column::new("a", 0)),
+            Operator::Gt,
+            lit(5i32),
+        ))
+    }
+
+    fn parquet_for(sch: &Arc<Schema>) -> ParquetSource {
+        ParquetSource::new(TableSchema::new(sch.clone(), vec![]))
+    }
+
+    fn get_factory(plan: &Arc<dyn ExecutionPlan>) -> Option<bool> {
+        let dse = plan.downcast_ref::<DataSourceExec>()?;
+        let cfg = (dse.data_source().as_ref() as &dyn std::any::Any)
+            .downcast_ref::<FileScanConfig>()?;
+        let pq = (cfg.file_source().as_ref() as &dyn std::any::Any)
+            .downcast_ref::<ParquetSource>()?;
+        Some(pq.parquet_file_reader_factory().is_some())
+    }
+
+    #[test]
+    fn installs_factory_when_predicate_present() {
+        let sch = schema();
+        let (store, cache) = deps();
+        let parquet = parquet_for(&sch).with_predicate(predicate_on_a());
+        let plan = datasource_exec(parquet);
+        assert_eq!(get_factory(&plan), Some(false), "precondition: no factory yet");
+
+        let rule = ScopedPageIndexOptimizer::new(store, cache);
+        let out = rule.optimize(plan, &ConfigOptions::default()).unwrap();
+        assert_eq!(
+            get_factory(&out),
+            Some(true),
+            "optimizer must install a scoped reader factory when a predicate is present"
+        );
+    }
+
+    #[test]
+    fn noop_without_predicate() {
+        let sch = schema();
+        let (store, cache) = deps();
+        let plan = datasource_exec(parquet_for(&sch)); // no predicate
+        let rule = ScopedPageIndexOptimizer::new(store, cache);
+        let out = rule.optimize(plan, &ConfigOptions::default()).unwrap();
+        assert_eq!(
+            get_factory(&out),
+            Some(false),
+            "no predicate → nothing to scope → no factory installed"
+        );
+    }
+
+    /// End-to-end through a real `SessionContext` + stock `ListingTable` (the
+    /// provider used by `QueryStrategy::None` plain scans): write a parquet file,
+    /// register it, build the physical plan for `SELECT s0 WHERE n1 > k`, apply
+    /// `ScopedPageIndexOptimizer`, execute, and assert (a) results are correct and
+    /// (b) the shared scoped page-index cache filled — proving the rule installs a
+    /// working scoped reader on the vanilla listing path, not just in isolation.
+    #[tokio::test]
+    async fn end_to_end_listing_scan_fills_scoped_cache() {
+        use arrow::array::{Int32Array, StringArray};
+        use arrow::record_batch::RecordBatch;
+        use datafusion::datasource::file_format::parquet::ParquetFormat;
+        use datafusion::datasource::listing::{
+            ListingOptions, ListingTable, ListingTableConfig, ListingTableUrl,
+        };
+        use datafusion::parquet::arrow::ArrowWriter;
+        use datafusion::parquet::file::properties::{EnabledStatistics, WriterProperties};
+        use datafusion::physical_optimizer::PhysicalOptimizerRule;
+        use datafusion::prelude::SessionContext;
+        use futures::StreamExt;
+
+        crate::indexed_table::page_index_loader::clear_scoped_cache_for_test();
+
+        // 2 numeric + 2 wide-string columns, many pages → real page index.
+        let sch = Arc::new(Schema::new(vec![
+            Field::new("n0", DataType::Int32, false),
+            Field::new("n1", DataType::Int32, false),
+            Field::new("s0", DataType::Utf8, false),
+            Field::new("s1", DataType::Utf8, false),
+        ]));
+        const ROWS: i32 = 4096;
+        let n0: Vec<i32> = (0..ROWS).collect();
+        let n1: Vec<i32> = (0..ROWS).collect();
+        let s0: Vec<String> = (0..ROWS).map(|r| format!("s0_{r:06}_padding_padding")).collect();
+        let s1: Vec<String> = (0..ROWS).map(|r| format!("s1_{r:06}_padding_padding")).collect();
+        let batch = RecordBatch::try_new(
+            sch.clone(),
+            vec![
+                Arc::new(Int32Array::from(n0)),
+                Arc::new(Int32Array::from(n1)),
+                Arc::new(StringArray::from(s0)),
+                Arc::new(StringArray::from(s1)),
+            ],
+        )
+        .unwrap();
+
+        let dir = std::env::temp_dir().join(format!("scoped_e2e_{}", std::process::id()));
+        let _ = std::fs::create_dir_all(&dir);
+        let file_path = dir.join("data.parquet");
+        {
+            let props = WriterProperties::builder()
+                .set_data_page_row_count_limit(256)
+                .set_write_batch_size(256)
+                .set_statistics_enabled(EnabledStatistics::Page)
+                .build();
+            let f = std::fs::File::create(&file_path).unwrap();
+            let mut w = ArrowWriter::try_new(f, sch.clone(), Some(props)).unwrap();
+            w.write(&batch).unwrap();
+            w.close().unwrap();
+        }
+
+        // Stock ListingTable over the temp dir — the QueryStrategy::None provider.
+        let ctx = SessionContext::new();
+        let store: Arc<dyn ObjectStore> = Arc::new(object_store::local::LocalFileSystem::new());
+        let table_url =
+            ListingTableUrl::parse(format!("file://{}", dir.to_str().unwrap())).unwrap();
+        ctx.register_object_store(table_url.as_ref(), Arc::clone(&store));
+        let listing_options = ListingOptions::new(Arc::new(ParquetFormat::new()))
+            .with_file_extension(".parquet")
+            .with_collect_stat(true);
+        let resolved = listing_options.infer_schema(&ctx.state(), &table_url).await.unwrap();
+        let config = ListingTableConfig::new(table_url.clone())
+            .with_listing_options(listing_options)
+            .with_schema(resolved);
+        let provider = Arc::new(ListingTable::try_new(config).unwrap());
+        ctx.register_table("t", provider).unwrap();
+
+        // Predicate on n1 (parquet col 1), project the non-predicate string col s0.
+        // n1 >= 4080 keeps rows 4080..4096 (16 rows).
+        let df = ctx.sql("SELECT s0 FROM t WHERE n1 >= 4080").await.unwrap();
+        let physical = df.create_physical_plan().await.unwrap();
+
+        // Apply our rule exactly as query_executor does, with this ctx's store + cache.
+        let metadata_cache = ctx.runtime_env().cache_manager.get_file_metadata_cache();
+        let rule = ScopedPageIndexOptimizer::new(Arc::clone(&store), metadata_cache);
+        let physical = rule.optimize(physical, &ConfigOptions::default()).unwrap();
+
+        // Execute.
+        let mut stream =
+            datafusion::physical_plan::execute_stream(physical, ctx.task_ctx()).unwrap();
+        let mut rows = 0usize;
+        while let Some(b) = stream.next().await {
+            rows += b.unwrap().num_rows();
+        }
+
+        // (a) Correct result: 16 rows survive n1 >= 4080.
+        assert_eq!(rows, 16, "predicate n1>=4080 must keep 16 rows");
+
+        // (b) The scoped page-index cache filled — the rule installed a working
+        // scoped reader on the stock ListingTable scan.
+        let stats = crate::indexed_table::page_index_loader::scoped_cache_stats();
+        assert!(
+            stats.entries >= 1 && stats.used_bytes > 0,
+            "scoped cache must have filled on the listing path: {stats:?}"
+        );
+        assert!(stats.misses >= 1, "first scan must register a scoped-cache miss: {stats:?}");
+
+        crate::indexed_table::page_index_loader::clear_scoped_cache_for_test();
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The rule REPLACES an already-installed factory when a predicate is present.
+    /// This is required: DataFusion's `ParquetFormat::create_physical_plan` always
+    /// pre-installs its own `CachedParquetFileReaderFactory` (full-page-index
+    /// loader) — that is precisely the factory we must swap out for our scoped one.
+    /// (A skip-if-present guard was the original bug that made the end-to-end
+    /// listing scan never use the scoped reader.)
+    #[test]
+    fn replaces_existing_default_factory() {
+        let sch = schema();
+        let (store, cache) = deps();
+        // Pre-install some factory + a predicate (mirrors what ParquetFormat does).
+        let pre = Arc::new(ScopedPageIndexReaderFactory::new(
+            Arc::clone(&store),
+            Arc::clone(&cache),
+            vec!["a".to_string()],
+            sch.clone(),
+        ));
+        let parquet = parquet_for(&sch)
+            .with_predicate(predicate_on_a())
+            .with_parquet_file_reader_factory(pre);
+        let plan = datasource_exec(parquet);
+        assert_eq!(get_factory(&plan), Some(true), "precondition: a factory is present");
+
+        let rule = ScopedPageIndexOptimizer::new(store, cache);
+        let out = rule.optimize(Arc::clone(&plan), &ConfigOptions::default()).unwrap();
+
+        // The rule rewrites the node (does not return the same Arc) and the result
+        // still carries a (scoped) factory.
+        assert_eq!(get_factory(&out), Some(true), "scoped factory present after rule");
+        assert!(
+            !Arc::ptr_eq(&plan, &out),
+            "rule must rewrite the scan to install the scoped factory, replacing the default"
+        );
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/session_context.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/session_context.rs
@@ -237,6 +237,22 @@ pub async unsafe fn create_session_context(
             );
     }
 
+    // Scoped page-index loading for the vanilla (ListingTable) scan path — applies
+    // to every QueryStrategy that reaches this session (None / ListingTable). The
+    // rule replaces DataFusion's default CachedParquetFileReaderFactory with one
+    // that loads a page index scoped to the query's predicate columns (real
+    // ColumnIndex for predicate cols + real OffsetIndex for all cols), sharing the
+    // process-wide scoped cache with the indexed path. Registered as a session
+    // physical-optimizer rule so it runs as part of `create_physical_plan` (after
+    // filter pushdown has populated `ParquetSource::predicate`). Must run AFTER
+    // ProjectRowIdOptimizer (which rebuilds the scan but preserves the factory).
+    state_builder = state_builder.with_physical_optimizer_rule(Arc::new(
+        crate::scoped_page_index_optimizer::ScopedPageIndexOptimizer::new(
+            Arc::clone(&shard_view.store),
+            runtime.runtime_env.cache_manager.get_file_metadata_cache(),
+        ),
+    ));
+
     let state = state_builder.build();
 
     let ctx = SessionContext::new_with_state(state);

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/shard_scoped_reader.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/shard_scoped_reader.rs
@@ -1,0 +1,447 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+//! Scoped page-index reader factory for the **listing-table** scan path.
+//!
+//! # Why this exists
+//!
+//! The indexed-table path already loads page index lazily and scoped to the
+//! predicate columns (see [`crate::indexed_table::page_index_loader`]). The
+//! listing-table path (`ShardTableProvider` / vanilla `ListingTable`) does not:
+//! it uses DataFusion's default reader factory, so when page pruning is enabled
+//! the `ParquetOpener` loads the **entire** page index (`ColumnIndex` +
+//! `OffsetIndex` for *every* column) of each surviving file, every query, and
+//! caches none of it.
+//!
+//! This factory closes that gap by reusing the indexed path's machinery. The
+//! seam is DataFusion's [`ParquetFileReaderFactory`]: the `ParquetOpener` asks
+//! the reader for metadata via `get_metadata`, and — per the trait's own
+//! contract and `opener::load_page_index` — if the returned `ParquetMetaData`
+//! *already* carries a page index, the opener uses it and skips the full,
+//! all-column load. So our reader's `get_metadata`:
+//!
+//!   1. loads footer-only metadata (shared cache hit — see
+//!      [`crate::indexed_table::parquet_bridge::load_parquet_metadata`]), then
+//!   2. augments it with a page index scoped to the predicate columns via
+//!      [`crate::indexed_table::page_index_loader::load_scoped_page_index`]
+//!      (real `ColumnIndex` for predicate columns, real `OffsetIndex` for all
+//!      columns — the same correctness contract the indexed path relies on), and
+//!   3. returns that augmented metadata.
+//!
+//! The opener then finds both indexes present and never triggers a full decode.
+//! The scoped `(file, predicate-columns)` cache is shared with the indexed path,
+//! so repeated queries reuse the decoded index across both scan paths.
+//!
+//! # Fallback
+//!
+//! If there are no predicate columns, or scoped augmentation fails for a file
+//! (no page index, decode/IO error), `get_metadata` returns the footer-only
+//! metadata. The opener then loads the page index on demand exactly as it does
+//! today — correct, just without the scoping benefit for that file. Never a
+//! wrong result.
+
+use std::sync::Arc;
+
+use arrow::datatypes::SchemaRef;
+use datafusion::datasource::physical_plan::parquet::{
+    ParquetFileMetrics, ParquetFileReaderFactory,
+};
+use datafusion::parquet::arrow::arrow_reader::ArrowReaderOptions;
+use datafusion::parquet::arrow::async_reader::AsyncFileReader;
+use datafusion::parquet::file::metadata::ParquetMetaData;
+use datafusion::physical_plan::metrics::ExecutionPlanMetricsSet;
+use datafusion::execution::cache::cache_manager::FileMetadataCache;
+use datafusion_datasource::PartitionedFile;
+use futures::future::BoxFuture;
+use futures::FutureExt;
+use object_store::{ObjectStore, ObjectStoreExt};
+use prost::bytes::Bytes;
+
+use crate::indexed_table::page_index_loader::{
+    load_scoped_page_index, resolve_predicate_parquet_columns,
+};
+use crate::indexed_table::parquet_bridge::load_parquet_metadata;
+
+/// A [`ParquetFileReaderFactory`] that, on `get_metadata`, returns metadata whose
+/// page index is scoped to the query's predicate columns. Data reads go straight
+/// to the object store.
+///
+/// Carries predicate column *names* + the file schema rather than pre-resolved
+/// parquet indices: the reader resolves names → parquet leaf indices per file via
+/// the same `resolve_predicate_parquet_columns` the indexed path uses, which is
+/// robust to schema evolution across files (a column absent from one file is just
+/// skipped there).
+#[derive(Debug)]
+pub struct ScopedPageIndexReaderFactory {
+    store: Arc<dyn ObjectStore>,
+    metadata_cache: Arc<dyn FileMetadataCache>,
+    /// File-column names referenced by the query predicate. Empty means "no
+    /// scoping" — `get_metadata` returns footer-only and the opener loads the
+    /// page index on demand as usual.
+    predicate_column_names: Arc<Vec<String>>,
+    /// File schema (no partition columns), for per-file column resolution.
+    file_schema: SchemaRef,
+}
+
+impl ScopedPageIndexReaderFactory {
+    pub fn new(
+        store: Arc<dyn ObjectStore>,
+        metadata_cache: Arc<dyn FileMetadataCache>,
+        predicate_column_names: Vec<String>,
+        file_schema: SchemaRef,
+    ) -> Self {
+        Self {
+            store,
+            metadata_cache,
+            predicate_column_names: Arc::new(predicate_column_names),
+            file_schema,
+        }
+    }
+}
+
+impl ParquetFileReaderFactory for ScopedPageIndexReaderFactory {
+    fn create_reader(
+        &self,
+        partition_index: usize,
+        file: PartitionedFile,
+        _metadata_size_hint: Option<usize>,
+        metrics: &ExecutionPlanMetricsSet,
+    ) -> datafusion::common::Result<Box<dyn AsyncFileReader + Send>> {
+        let file_metrics =
+            ParquetFileMetrics::new(partition_index, file.object_meta.location.as_ref(), metrics);
+        Ok(Box::new(ScopedPageIndexReader {
+            store: Arc::clone(&self.store),
+            metadata_cache: Arc::clone(&self.metadata_cache),
+            predicate_column_names: Arc::clone(&self.predicate_column_names),
+            file_schema: Arc::clone(&self.file_schema),
+            location: file.object_meta.location.clone(),
+            metrics: file_metrics,
+        }))
+    }
+}
+
+struct ScopedPageIndexReader {
+    store: Arc<dyn ObjectStore>,
+    metadata_cache: Arc<dyn FileMetadataCache>,
+    predicate_column_names: Arc<Vec<String>>,
+    file_schema: SchemaRef,
+    location: object_store::path::Path,
+    metrics: ParquetFileMetrics,
+}
+
+impl AsyncFileReader for ScopedPageIndexReader {
+    fn get_bytes(
+        &mut self,
+        range: std::ops::Range<u64>,
+    ) -> BoxFuture<'_, datafusion::parquet::errors::Result<Bytes>> {
+        self.metrics
+            .bytes_scanned
+            .add((range.end - range.start) as usize);
+        let store = Arc::clone(&self.store);
+        let location = self.location.clone();
+        // IO-runtime dispatch is handled by the SpawnIoStore wrapper around the
+        // registered store, so a plain `.await` already runs on the IO runtime.
+        async move {
+            store
+                .get_range(&location, range)
+                .await
+                .map_err(|e| datafusion::parquet::errors::ParquetError::External(Box::new(e)))
+        }
+        .boxed()
+    }
+
+    fn get_byte_ranges(
+        &mut self,
+        ranges: Vec<std::ops::Range<u64>>,
+    ) -> BoxFuture<'_, datafusion::parquet::errors::Result<Vec<Bytes>>> {
+        let total: u64 = ranges.iter().map(|r| r.end - r.start).sum();
+        self.metrics.bytes_scanned.add(total as usize);
+        let store = Arc::clone(&self.store);
+        let location = self.location.clone();
+        async move {
+            store
+                .get_ranges(&location, &ranges)
+                .await
+                .map_err(|e| datafusion::parquet::errors::ParquetError::External(Box::new(e)))
+        }
+        .boxed()
+    }
+
+    fn get_metadata(
+        &mut self,
+        _options: Option<&ArrowReaderOptions>,
+    ) -> BoxFuture<'_, datafusion::parquet::errors::Result<Arc<ParquetMetaData>>> {
+        let store = Arc::clone(&self.store);
+        let metadata_cache = Arc::clone(&self.metadata_cache);
+        let predicate_names = Arc::clone(&self.predicate_column_names);
+        let file_schema = Arc::clone(&self.file_schema);
+        let location = self.location.clone();
+        async move {
+            // 1. Footer-only metadata (shared cache hit if pre-seeded). This is
+            //    the same loader the indexed path uses; it never retains a page
+            //    index in the shared cache.
+            let (_schema, _size, footer) =
+                load_parquet_metadata(Arc::clone(&store), &location, Arc::clone(&metadata_cache))
+                    .await
+                    .map_err(|e| {
+                        datafusion::parquet::errors::ParquetError::General(format!(
+                            "footer metadata {}: {e}",
+                            location
+                        ))
+                    })?;
+
+            // 2. Resolve predicate column names → this file's parquet leaf indices
+            //    (per-file, so schema evolution across files is handled), then
+            //    augment with a predicate-scoped page index. On empty column set
+            //    or any failure, `load_scoped_page_index` returns None and we fall
+            //    back to footer-only; the opener then loads the page index on
+            //    demand exactly as it does today.
+            if !predicate_names.is_empty() {
+                let parquet_cols =
+                    resolve_predicate_parquet_columns(&file_schema, &footer, &predicate_names);
+                if let Some(augmented) =
+                    load_scoped_page_index(&store, &location, &footer, &parquet_cols).await
+                {
+                    return Ok(augmented);
+                }
+            }
+
+            Ok(footer)
+        }
+        .boxed()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::{Int32Array, RecordBatch};
+    use arrow::datatypes::{DataType, Field, Schema};
+    use datafusion::execution::cache::cache_manager::FileMetadataCache;
+    use datafusion::parquet::arrow::ArrowWriter;
+    use datafusion::parquet::file::page_index::column_index::ColumnIndexMetaData;
+    use datafusion::parquet::file::properties::{EnabledStatistics, WriterProperties};
+    use datafusion::physical_plan::metrics::ExecutionPlanMetricsSet;
+    use object_store::memory::InMemory;
+    use object_store::path::Path as ObjPath;
+    use object_store::{ObjectStore, ObjectStoreExt, PutPayload};
+
+    /// Two int columns (`price`, `qty`), one row group, four 8-row data pages —
+    /// enough to produce a real page index.
+    fn two_col_parquet() -> (Bytes, SchemaRef) {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("price", DataType::Int32, false),
+            Field::new("qty", DataType::Int32, false),
+        ]));
+        let prices: Vec<i32> = (0..32).collect();
+        let qtys: Vec<i32> = (100..132).collect();
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(prices)),
+                Arc::new(Int32Array::from(qtys)),
+            ],
+        )
+        .unwrap();
+        let props = WriterProperties::builder()
+            .set_max_row_group_size(32)
+            .set_data_page_row_count_limit(8)
+            .set_write_batch_size(8)
+            .set_statistics_enabled(EnabledStatistics::Page)
+            .build();
+        let mut buf: Vec<u8> = Vec::new();
+        let mut w = ArrowWriter::try_new(&mut buf, schema.clone(), Some(props)).unwrap();
+        w.write(&batch).unwrap();
+        w.close().unwrap();
+        (Bytes::from(buf), schema)
+    }
+
+    async fn stage(bytes: Bytes) -> (Arc<dyn ObjectStore>, ObjPath) {
+        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let loc = ObjPath::from("data.parquet");
+        store.put(&loc, PutPayload::from_bytes(bytes)).await.unwrap();
+        (store, loc)
+    }
+
+    fn fresh_cache() -> Arc<dyn FileMetadataCache> {
+        Arc::new(crate::cache::MutexFileMetadataCache::new(
+            datafusion::execution::cache::DefaultFilesMetadataCache::new(64 * 1024 * 1024),
+        ))
+    }
+
+    /// The factory's reader must, on `get_metadata`, return metadata whose page
+    /// index is scoped to the predicate column (`price`) — a real ColumnIndex for
+    /// `price`, a NONE placeholder ColumnIndex for `qty` — while keeping a REAL
+    /// OffsetIndex for BOTH columns (so reads of a projected non-predicate column
+    /// work; this is the listing-path mirror of the indexed-path read-path fix).
+    #[tokio::test]
+    async fn get_metadata_returns_scoped_page_index() {
+        crate::indexed_table::page_index_loader::clear_scoped_cache_for_test();
+        let (bytes, schema) = two_col_parquet();
+        let (store, loc) = stage(bytes).await;
+        let cache = fresh_cache();
+
+        let factory = ScopedPageIndexReaderFactory::new(
+            Arc::clone(&store),
+            cache,
+            vec!["price".to_string()],
+            schema,
+        );
+
+        let pf = PartitionedFile::new(loc.as_ref().to_string(), {
+            store.head(&loc).await.unwrap().size
+        });
+        let metrics = ExecutionPlanMetricsSet::new();
+        let mut reader = factory
+            .create_reader(0, pf, None, &metrics)
+            .expect("create_reader");
+
+        let meta = reader.get_metadata(None).await.expect("get_metadata");
+
+        // Page index present and scoped.
+        let ci = meta.column_index().expect("augmented has column index");
+        let oi = meta.offset_index().expect("augmented has offset index");
+        // price (col 0) is the predicate column → real ColumnIndex.
+        assert!(
+            !matches!(ci[0][0], ColumnIndexMetaData::NONE),
+            "predicate column (price) must have a real ColumnIndex"
+        );
+        // qty (col 1) is NOT a predicate column → NONE ColumnIndex placeholder.
+        assert!(
+            matches!(ci[0][1], ColumnIndexMetaData::NONE),
+            "non-predicate column (qty) ColumnIndex must be the NONE placeholder"
+        );
+        // BOTH columns must keep a real OffsetIndex (the read-path requirement).
+        assert!(
+            !oi[0][0].page_locations.is_empty(),
+            "price must keep a real OffsetIndex"
+        );
+        assert!(
+            !oi[0][1].page_locations.is_empty(),
+            "qty (non-predicate) must keep a real OffsetIndex, not an empty placeholder"
+        );
+    }
+
+    /// DECISIVE EXPERIMENT: build a `DataSourceExec` with the factory installed at
+    /// `ParquetSource` construction (exactly like the working indexed path,
+    /// `parquet_bridge::create_stream_with_access_plan`) and execute it directly.
+    /// If the scoped cache fills here, the factory-at-construction approach works
+    /// end-to-end and the bug is specifically the post-planning source swap in the
+    /// optimizer rule.
+    #[tokio::test]
+    async fn factory_at_construction_executes_through_scoped_reader() {
+        use datafusion::datasource::physical_plan::ParquetSource;
+        use datafusion::datasource::source::DataSourceExec;
+        use datafusion::execution::object_store::ObjectStoreUrl;
+        use datafusion::physical_expr::expressions::{lit, BinaryExpr, Column};
+        use datafusion::logical_expr::Operator;
+        use datafusion::physical_expr::PhysicalExpr;
+        use datafusion::physical_plan::{execute_stream, ExecutionPlan};
+        use datafusion_datasource::file_scan_config::FileScanConfigBuilder;
+        use datafusion_datasource::table_schema::TableSchema;
+        use datafusion_datasource::PartitionedFile;
+        use futures::StreamExt;
+
+        crate::indexed_table::page_index_loader::clear_scoped_cache_for_test();
+
+        // Stage a real file on local FS (InMemory has no offset-index range reads
+        // through get_ranges in the same way; local mirrors production closely).
+        let (bytes, schema) = two_col_parquet();
+        let dir = std::env::temp_dir().join(format!("scoped_ctor_{}", std::process::id()));
+        let _ = std::fs::create_dir_all(&dir);
+        let file_path = dir.join("data.parquet");
+        std::fs::write(&file_path, &bytes).unwrap();
+
+        let store: Arc<dyn ObjectStore> = Arc::new(object_store::local::LocalFileSystem::new());
+        let cache = fresh_cache();
+
+        // Factory at construction — predicate column `price`.
+        let factory = Arc::new(ScopedPageIndexReaderFactory::new(
+            Arc::clone(&store),
+            cache,
+            vec!["price".to_string()],
+            schema.clone(),
+        ));
+
+        // Predicate `price >= 16` (keeps the last two 8-row pages → 16 rows).
+        let predicate: Arc<dyn PhysicalExpr> = Arc::new(BinaryExpr::new(
+            Arc::new(Column::new("price", 0)),
+            Operator::GtEq,
+            lit(16i32),
+        ));
+
+        let parquet = ParquetSource::new(TableSchema::new(schema.clone(), vec![]))
+            .with_predicate(predicate)
+            .with_parquet_file_reader_factory(factory);
+
+        let loc_str = file_path.to_string_lossy().to_string();
+        let pf = PartitionedFile::new(loc_str, std::fs::metadata(&file_path).unwrap().len());
+        let store_url = ObjectStoreUrl::local_filesystem();
+        let config = FileScanConfigBuilder::new(store_url.clone(), Arc::new(parquet))
+            .with_file(pf)
+            .build();
+        let exec: Arc<dyn ExecutionPlan> = DataSourceExec::from_data_source(config);
+
+        // Register the store on a TaskContext's runtime.
+        let ctx = datafusion::prelude::SessionContext::new();
+        ctx.register_object_store(store_url.as_ref(), Arc::clone(&store));
+
+        // Wrap in CoalesceBatches + Repartition to mirror the e2e plan shape and
+        // rule out "parent operators break it".
+        use datafusion::physical_plan::repartition::RepartitionExec;
+        use datafusion::physical_plan::Partitioning;
+        let exec: Arc<dyn ExecutionPlan> = Arc::new(
+            RepartitionExec::try_new(exec, Partitioning::RoundRobinBatch(4)).unwrap(),
+        );
+
+        let mut stream = execute_stream(exec, ctx.task_ctx()).unwrap();
+        let mut rows = 0usize;
+        while let Some(b) = stream.next().await {
+            rows += b.unwrap().num_rows();
+        }
+
+        let stats = crate::indexed_table::page_index_loader::scoped_cache_stats();
+        eprintln!("CTOR EXPERIMENT (with repartition): rows={rows} stats={stats:?}");
+
+        assert_eq!(rows, 16, "price>=16 must keep 16 rows");
+        assert!(
+            stats.misses >= 1 && stats.entries >= 1 && stats.used_bytes > 0,
+            "factory-at-construction must route the scan through our scoped reader: {stats:?}"
+        );
+
+        crate::indexed_table::page_index_loader::clear_scoped_cache_for_test();
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// With no predicate columns, the reader returns footer-only metadata (no page
+    /// index) — the opener then loads on demand exactly as it does today.
+    #[tokio::test]
+    async fn get_metadata_no_predicate_returns_footer_only() {
+        crate::indexed_table::page_index_loader::clear_scoped_cache_for_test();
+        let (bytes, schema) = two_col_parquet();
+        let (store, loc) = stage(bytes).await;
+        let cache = fresh_cache();
+
+        let factory = ScopedPageIndexReaderFactory::new(
+            Arc::clone(&store),
+            cache,
+            vec![], // no predicate columns
+            schema,
+        );
+        let pf = PartitionedFile::new(loc.as_ref().to_string(), {
+            store.head(&loc).await.unwrap().size
+        });
+        let metrics = ExecutionPlanMetricsSet::new();
+        let mut reader = factory.create_reader(0, pf, None, &metrics).unwrap();
+        let meta = reader.get_metadata(None).await.unwrap();
+        assert!(
+            meta.column_index().is_none() && meta.offset_index().is_none(),
+            "no-predicate reader must return footer-only metadata"
+        );
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/shard_table_provider.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/shard_table_provider.rs
@@ -65,14 +65,18 @@ impl TableProvider for ShardTableProvider {
         &self,
         filters: &[&Expr],
     ) -> Result<Vec<TableProviderFilterPushDown>> {
+        // Inexact: we use the predicate for page-index pruning (and optional
+        // decode-time pushdown), but DataFusion keeps the FilterExec to apply
+        // the predicate exactly. This is the same contract DataFusion's own
+        // ListingTable uses for non-partition filters.
         Ok(vec![TableProviderFilterPushDown::Inexact; filters.len()])
     }
 
     async fn scan(
         &self,
-        _state: &dyn Session,
+        state: &dyn Session,
         projection: Option<&Vec<usize>>,
-        _filters: &[Expr],
+        filters: &[Expr],
         _limit: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         // Invariant: files are ordered by ascending row_base (build_shard_files contract).
@@ -109,7 +113,58 @@ impl TableProvider for ShardTableProvider {
             vec![Arc::new(Field::new("row_base", DataType::Int64, true))],
         );
 
-        let parquet_source = ParquetSource::new(table_schema);
+        let mut parquet_source = ParquetSource::new(table_schema);
+
+        // Push a physical predicate built from the pushed-down filters so the
+        // ParquetOpener can do page-index pruning, and so `ScopedPageIndexOptimizer`
+        // (applied after planning) can read it to scope the page-index reader
+        // factory. Without a predicate the opener never builds a page-pruning
+        // predicate and never loads a page index. We convert against the *file*
+        // schema (predicates reference file columns, not the appended row_base
+        // partition column); any filter referencing row_base or failing physical
+        // conversion is dropped from the pushed predicate (the FilterExec still
+        // applies the full predicate exactly, so results stay correct).
+        if !filters.is_empty() {
+            if let Ok(df_schema) = datafusion::common::DFSchema::try_from(
+                self.config.file_schema.as_ref().clone(),
+            ) {
+                let file_field_names: std::collections::HashSet<&str> = self
+                    .config
+                    .file_schema
+                    .fields()
+                    .iter()
+                    .map(|f| f.name().as_str())
+                    .collect();
+                let mut physical_preds: Vec<Arc<dyn datafusion::physical_expr::PhysicalExpr>> =
+                    Vec::new();
+                for filter in filters {
+                    let refs_only_file_cols = filter
+                        .column_refs()
+                        .iter()
+                        .all(|c| file_field_names.contains(c.name.as_str()));
+                    if !refs_only_file_cols {
+                        continue;
+                    }
+                    if let Ok(phys) = state.create_physical_expr(filter.clone(), &df_schema) {
+                        physical_preds.push(phys);
+                    }
+                }
+                if let Some(combined) =
+                    datafusion::physical_expr::utils::conjunction_opt(physical_preds)
+                {
+                    parquet_source = parquet_source.with_predicate(combined);
+                }
+            }
+        }
+
+        // The scoped page-index reader factory is installed by
+        // `ScopedPageIndexOptimizer` (a physical optimizer rule applied after
+        // planning, for all strategies), which reads the predicate we pushed
+        // above. Installing it uniformly in the rule — rather than here — means
+        // the stock-`ListingTable` path (`QueryStrategy::None`) gets the same
+        // treatment: there the rule REPLACES DataFusion's own
+        // `CachedParquetFileReaderFactory`; here it installs onto a scan that has
+        // none yet. One mechanism, both paths.
 
         let mut builder = FileScanConfigBuilder::new(
             self.config.store_url.clone(),


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Changes to reduce the memory and cpu compute of parquet metadata decode in wide columns

```
INDEX TIME (refresh / catalog snapshot)
  ────────────────────────────────────────
    Lucene refresh → new parquet files
          │
          ▼
    df_cache_manager_add_files(paths)
          │
          ▼
    fetch footer metadata, strip page index
          │
          ▼
    ┌─────────────────────────────┐
    │ CACHE 1  (metadata cache)   │  ← FILLED HERE, index-time
    │ key: file path              │
    │ holds: footer-only          │
    │   (schema + RG min/max)     │
    │ NO page index               │
    └─────────────────────────────┘


  QUERY TIME (a scan runs)
  ────────────────────────────────────────
    ParquetOpener.get_metadata(file)
          │
          ▼
    load_parquet_metadata(file)
          │
          ├──► CACHE 1 .get(path)  ──HIT──► footer-only meta   (filled at index time)
          │                         (miss → fetch footer, put into Cache 1)
          ▼
    has predicate cols?  ── no ──► return footer-only  (no page pruning)
          │ yes
          ▼
    load_scoped_page_index(file, predicate_cols)
          │
          ├──► CACHE 2 .get((path, cols)) ──HIT──► augmented meta  (no I/O, no decode)
          │                                  │
          │                            miss: range-read predicate-col ColumnIndex
          │                                  + all-col OffsetIndex from disk,
          │                                  decode, build augmented meta,
          │                                  put into CACHE 2
          ▼
    ┌─────────────────────────────┐
    │ CACHE 2 (scoped page index) │  ← FILLED HERE, query-time
    │ key: (file path, pred cols) │
    │ holds: footer + SCOPED      │
    │   page index                │
    └─────────────────────────────┘
          │
          ▼
    return augmented meta to DataFusion
          │
          ▼
    DataFusion: page-prune using ColumnIndex,
                compute page byte-ranges via OffsetIndex
          │
          ▼
    get_byte_ranges → DISK (object store)   ← actual data pages, NOT cached in 1 or 2
```

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
