### PR TITLE
Align yearweek and str_to_date with MySQL semantics

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/os_strftime.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/os_strftime.rs
@@ -353,8 +353,13 @@ pub(crate) fn parse_os_strftime(input: &str, format: &str) -> Option<Parsed> {
     let mut pos = 0;
     let mut f = Parsed::default();
     for tok in tokens {
-        if pos > input_bytes.len() {
-            return None;
+        // Input exhausted before format: trailing tokens default to zero via Parsed::to_naive.
+        // An empty input (pos still 0) is a hard failure — don't let it default to all zeros.
+        if pos >= input_bytes.len() {
+            if pos == 0 {
+                return None;
+            }
+            break;
         }
         while pos < input_bytes.len() && (input_bytes[pos] as char).is_whitespace() {
             pos += 1;
@@ -362,6 +367,10 @@ pub(crate) fn parse_os_strftime(input: &str, format: &str) -> Option<Parsed> {
         match tok {
             Token::Literal(c) => {
                 if c.is_whitespace() {
+                    // Accept ISO-8601 `T` where the format expects whitespace.
+                    if pos < input_bytes.len() && input_bytes[pos] == b'T' {
+                        pos += 1;
+                    }
                     continue;
                 }
                 if pos >= input_bytes.len() || input_bytes[pos] as char != c {
@@ -417,8 +426,9 @@ pub(crate) fn parse_os_strftime(input: &str, format: &str) -> Option<Parsed> {
                 pos = np;
             }
             Token::HLower | Token::IUpper | Token::L => {
+                // MySQL accepts "00" for %h/%I/%l; Parsed::to_naive maps h12=0 → hour 0.
                 let (v, np) = read_digits(input_bytes, pos, 1, 2)?;
-                if !(1..=12).contains(&v) {
+                if v > 12 {
                     return None;
                 }
                 f.hour_12 = Some(v);
@@ -457,7 +467,7 @@ pub(crate) fn parse_os_strftime(input: &str, format: &str) -> Option<Parsed> {
             }
             Token::R => {
                 let (h, np) = read_digits(input_bytes, pos, 1, 2)?;
-                if !(1..=12).contains(&h) {
+                if h > 12 {
                     return None;
                 }
                 pos = expect_literal(input_bytes, np, b':')?;
@@ -732,5 +742,35 @@ mod tests {
     fn parse_fractional_seconds() {
         let p = parse_os_strftime("2020-03-15 10:30:45.123456", "%Y-%m-%d %H:%i:%S.%f").unwrap();
         assert_eq!(p.to_naive().unwrap().and_utc().timestamp_micros(), 1_584_268_245_123_456);
+    }
+
+    #[test]
+    fn parse_lenient_when_input_runs_out_before_format() {
+        let p = parse_os_strftime("2017-10-23", "%Y-%m-%d %h:%i:%s").unwrap();
+        assert_eq!(p.to_naive().unwrap().to_string(), "2017-10-23 00:00:00");
+        let p = parse_os_strftime("2020-03", "%Y-%m-%d").unwrap();
+        assert_eq!(p.to_naive().unwrap().to_string(), "2020-03-01 00:00:00");
+    }
+
+    #[test]
+    fn parse_h12_accepts_zero() {
+        let p = parse_os_strftime("23-Oct-17 00:00:00", "%d-%b-%y %h:%i:%s").unwrap();
+        assert_eq!(p.to_naive().unwrap().to_string(), "2017-10-23 00:00:00");
+        let p = parse_os_strftime("00:00:00 AM", "%r").unwrap();
+        assert_eq!(p.to_naive().unwrap().time().to_string(), "00:00:00");
+    }
+
+    #[test]
+    fn parse_h12_rejects_above_twelve() {
+        assert!(parse_os_strftime("13:00:00", "%h:%i:%s").is_none());
+    }
+
+    #[test]
+    fn parse_iso_t_separator_accepted_for_format_space() {
+        let p = parse_os_strftime("2017-10-23T00:00:00", "%Y-%m-%d %h:%i:%s").unwrap();
+        assert_eq!(p.to_naive().unwrap().to_string(), "2017-10-23 00:00:00");
+        let p = parse_os_strftime("2017-10-23 00:00:00", "%Y-%m-%d %h:%i:%s").unwrap();
+        assert_eq!(p.to_naive().unwrap().to_string(), "2017-10-23 00:00:00");
+        assert!(parse_os_strftime("2017-10-23X00:00:00", "%Y-%m-%d %h:%i:%s").is_none());
     }
 }

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/os_week.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/os_week.rs
@@ -219,10 +219,8 @@ impl ScalarUDFImpl for OsYearweekUdf {
     }
 }
 
-/// MySQL `YEARWEEK(date, mode)` — `year * 100 + week`. Keeps the caller's mode unless its week
-/// number is 0, in which case it bumps to mode 2 (for mode ≤ 4) or 7 so the date rolls into the
-/// prior year's last week; the year is the calendar year, decremented when an early-January date
-/// falls in the 52/53 week range (i.e. belongs to the prior year). Reuses [`os_week_number`].
+/// MySQL `YEARWEEK(date, mode)` — `year * 100 + week`. Bumps mode to 2 or 7 when the
+/// per-mode week number is 0 so the date is re-counted in the prior year's frame.
 fn os_yearweek_number(date: NaiveDate, mode: i32) -> i32 {
     let mode_resolved = if os_week_number(date, mode) != 0 {
         mode
@@ -232,97 +230,79 @@ fn os_yearweek_number(date: NaiveDate, mode: i32) -> i32 {
         7
     };
     let week = os_week_number(date, mode_resolved);
-    let mut year = date.year();
-    if week > 51 && date.day() < 7 {
-        year -= 1;
-    }
+    let year = os_year_number(date, mode_resolved);
     year * 100 + week as i32
 }
 
-/// MySQL `WEEK()` modes 0..7; see
-/// https://dev.mysql.com/doc/refman/8.0/en/date-and-time-functions.html#function_week.
-/// Modes 1/3/4/6 use the ≥4-days-in-year rule; the rest use simple counting.
+/// MySQL `WEEK()` modes 0..7. Modes 0/1/4/5 wrap early-January dates to week 0;
+/// see https://dev.mysql.com/doc/refman/8.0/en/date-and-time-functions.html#function_week.
 fn os_week_number(date: NaiveDate, mode: i32) -> u32 {
-    let mode = mode.rem_euclid(8) as u32;
-    let (start, four_day_rule, range_starts_at_one) = match mode {
-        0 => (Weekday::Sun, false, false),
-        1 => (Weekday::Mon, true, false),
-        2 => (Weekday::Sun, false, true),
-        3 => (Weekday::Mon, true, true),
-        4 => (Weekday::Sun, true, false),
-        5 => (Weekday::Mon, false, false),
-        6 => (Weekday::Sun, true, true),
-        7 => (Weekday::Mon, false, true),
-        _ => unreachable!(),
-    };
-    if four_day_rule {
-        week_number_iso_fold(date, start)
-    } else if range_starts_at_one {
-        // Range 1-53: week 0 (dates before the first start-day of the year)
-        // rolls into the prior year's last week.
-        let wn = week_number_simple(date, start);
-        if wn == 0 {
-            let last_of_prior = NaiveDate::from_ymd_opt(date.year() - 1, 12, 31).unwrap();
-            week_number_simple(last_of_prior, start)
-        } else {
-            wn
-        }
-    } else {
-        week_number_simple(date, start)
-    }
-}
-
-/// Modes 0/1: simple count. Week 1 starts at the first `start`-day of the year;
-/// dates before that are week 0.
-fn week_number_simple(date: NaiveDate, start: Weekday) -> u32 {
-    let jan1 = NaiveDate::from_ymd_opt(date.year(), 1, 1).unwrap();
-    let offset = days_until_start(jan1.weekday(), start);
-    let first_doy = 1 + offset;
-    let doy = date.ordinal();
-    if doy < first_doy {
+    let m = mode.rem_euclid(8) as u32;
+    let raw = java_calendar_week_of_year(date, week_params(m));
+    if raw > 51 && date.day() < 7 && matches!(m, 0 | 1 | 4 | 5) {
         0
     } else {
-        (doy - first_doy) / 7 + 1
+        raw
     }
 }
 
-/// Modes 2/3: week 1 must contain at least 4 days of the new year; otherwise
-/// the early days roll into the prior year's last week (52 or 53).
-fn week_number_iso_fold(date: NaiveDate, start: Weekday) -> u32 {
+/// Year that owns the week. Decrements for early-January dates that belong to the
+/// prior year's last week.
+fn os_year_number(date: NaiveDate, mode: i32) -> i32 {
+    let m = mode.rem_euclid(8) as u32;
+    let raw = java_calendar_week_of_year(date, week_params(m));
+    if raw > 51 && date.day() < 7 {
+        date.year() - 1
+    } else {
+        date.year()
+    }
+}
+
+/// `(firstDayOfWeek, minimalDaysInFirstWeek)` for MySQL modes 0..7.
+fn week_params(mode: u32) -> (Weekday, u32) {
+    let first = if mode % 2 == 0 { Weekday::Sun } else { Weekday::Mon };
+    let min_days = match mode {
+        1 | 3 => 5,
+        4 | 6 => 4,
+        _ => 7,
+    };
+    (first, min_days)
+}
+
+/// Java `Calendar.WEEK_OF_YEAR` under `(firstDayOfWeek, minimalDaysInFirstWeek)`.
+fn java_calendar_week_of_year(date: NaiveDate, (start, min_days): (Weekday, u32)) -> u32 {
     let year = date.year();
-    let week1_start = first_anchored_week_start(year, start);
-    if date < week1_start {
-        // Roll into prior year's last week.
-        let prev_week1 = first_anchored_week_start(year - 1, start);
-        let days = (date - prev_week1).num_days();
+    let this_w1 = week1_start(year, start, min_days);
+    if date < this_w1 {
+        let prev_w1 = week1_start(year - 1, start, min_days);
+        let days = (date - prev_w1).num_days();
         (days / 7) as u32 + 1
     } else {
-        let next_week1 = first_anchored_week_start(year + 1, start);
-        if date >= next_week1 {
+        let next_w1 = week1_start(year + 1, start, min_days);
+        if date >= next_w1 {
             1
         } else {
-            let days = (date - week1_start).num_days();
+            let days = (date - this_w1).num_days();
             (days / 7) as u32 + 1
         }
     }
 }
 
-/// First day of the year's week 1 under the "≥4 days of new year" anchor —
-/// MySQL modes 2/3 (and ISO 8601, with start=Mon).
-fn first_anchored_week_start(year: i32, start: Weekday) -> NaiveDate {
+/// First day of `year`'s week 1: the week containing Jan 1 owns week 1 iff it has
+/// at least `min_days` days in `year`, else week 1 starts the next `start`-day.
+fn week1_start(year: i32, start: Weekday, min_days: u32) -> NaiveDate {
     let jan1 = NaiveDate::from_ymd_opt(year, 1, 1).unwrap();
-    let offset = days_until_start(jan1.weekday(), start);
-    if offset <= 3 {
-        // Jan 1's week-start lands on Jan {1 - offset}; that week has ≥4 days of new year.
-        jan1 - chrono::Duration::days(offset as i64)
+    let back = back_offset(jan1.weekday(), start);
+    if 7 - back >= min_days {
+        jan1 - chrono::Duration::days(back as i64)
     } else {
-        // Jan 1's week-start lands in prior year; week 1 starts the next start-day.
-        jan1 + chrono::Duration::days((7 - offset) as i64)
+        jan1 + chrono::Duration::days((7 - back) as i64)
     }
 }
 
-fn days_until_start(from: Weekday, start: Weekday) -> u32 {
-    (weekday_idx(start) + 7 - weekday_idx(from)) % 7
+/// Days from `from` back to the most recent `start` weekday.
+fn back_offset(from: Weekday, start: Weekday) -> u32 {
+    (weekday_idx(from) + 7 - weekday_idx(start)) % 7
 }
 
 fn weekday_idx(w: Weekday) -> u32 {
@@ -380,18 +360,24 @@ mod tests {
     }
 
     #[test]
-    fn os_yearweek_delegates_per_mode_to_os_week_number() {
-        // 2008-02-20 is mid-February — far enough from year boundaries that neither the
-        // mode-bump branch (week == 0) nor the year-decrement branch (week > 51 && day < 7)
-        // can fire. Under those conditions, the algebraic contract is:
-        //     os_yearweek_number(d, mode) == year * 100 + os_week_number(d, mode)
-        // Pins that the per-mode math comes from os_week_number for every mode 0..7 — without
-        // claiming exact week numbers for each mode (which the os_week_number tests already
-        // cover for the modes they exercise).
-        let d = NaiveDate::from_ymd_opt(2008, 2, 20).unwrap();
-        for mode in 0..8 {
-            let expected = 2008 * 100 + os_week_number(d, mode) as i32;
-            assert_eq!(os_yearweek_number(d, mode), expected, "mode={mode}");
+    fn os_yearweek_dec_1899_to_jan_1900_boundary() {
+        let dec30_1899 = NaiveDate::from_ymd_opt(1899, 12, 30).unwrap();
+        let jan1_1900 = NaiveDate::from_ymd_opt(1900, 1, 1).unwrap();
+        assert_eq!(os_yearweek_number(dec30_1899, 0), 189952);
+        assert_eq!(os_yearweek_number(dec30_1899, 4), 189952);
+        assert_eq!(os_yearweek_number(jan1_1900, 0), 189953);
+        assert_eq!(os_yearweek_number(jan1_1900, 4), 190001);
+    }
+
+    #[test]
+    fn os_yearweek_jan1_1900_all_modes() {
+        let d = NaiveDate::from_ymd_opt(1900, 1, 1).unwrap();
+        let expected: [(i32, i32); 8] = [
+            (0, 189953), (1, 190001), (2, 189953), (3, 190001),
+            (4, 190001), (5, 190001), (6, 190001), (7, 190001),
+        ];
+        for (mode, want) in expected {
+            assert_eq!(os_yearweek_number(d, mode), want, "mode={mode}");
         }
     }
 }

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/str_to_date.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/str_to_date.rs
@@ -153,5 +153,39 @@ mod tests {
     fn unparseable_input_returns_none() {
         assert!(parse_to_micros("not-a-date", "%Y-%m-%d").is_none());
         assert!(parse_to_micros("2020-13-01", "%Y-%m-%d").is_none());
+        assert!(parse_to_micros("hello", "%Y-%m-%d").is_none());
+    }
+
+    #[test]
+    fn parses_short_input_with_time_format_tokens() {
+        let want = chrono::NaiveDate::from_ymd_opt(2017, 10, 23)
+            .unwrap()
+            .and_hms_opt(0, 0, 0)
+            .unwrap()
+            .and_utc()
+            .timestamp_micros();
+        assert_eq!(parse_to_micros("2017-10-23", "%Y-%m-%d %h:%i:%s"), Some(want));
+    }
+
+    #[test]
+    fn parses_full_iso_date_with_zero_hour_lower_h() {
+        let want = chrono::NaiveDate::from_ymd_opt(2017, 10, 23)
+            .unwrap()
+            .and_hms_opt(0, 0, 0)
+            .unwrap()
+            .and_utc()
+            .timestamp_micros();
+        assert_eq!(parse_to_micros("2017-10-23 00:00:00", "%Y-%m-%d %h:%i:%s"), Some(want));
+    }
+
+    #[test]
+    fn parses_short_year_and_month_name_with_zero_hour() {
+        let want = chrono::NaiveDate::from_ymd_opt(2017, 10, 23)
+            .unwrap()
+            .and_hms_opt(0, 0, 0)
+            .unwrap()
+            .and_utc()
+            .timestamp_micros();
+        assert_eq!(parse_to_micros("23-Oct-17 00:00:00", "%d-%b-%y %h:%i:%s"), Some(want));
     }
 }

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/DateTimeScalarFunctionsIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/DateTimeScalarFunctionsIT.java
@@ -647,6 +647,30 @@ public class DateTimeScalarFunctionsIT extends AnalyticsRestTestCase {
         assertFirstRowLong(oneRow("key00") + "| eval y = yearweek(datetime0) | fields y", 200_427L);
     }
 
+    /** Year-rollover boundary: late-Dec 1899 reports as 1899's last week under both modes. */
+    public void testYearweekDec1899Boundary() throws IOException {
+        assertFirstRowLong(oneRow("key00") + "| eval y = yearweek('1899-12-30') | fields y", 189_952L);
+        assertFirstRowLong(oneRow("key00") + "| eval y = yearweek('1899-12-30', 4) | fields y", 189_952L);
+    }
+
+    /** STR_TO_DATE accepts %h="00" zero-hour 12-hour-clock input. */
+    public void testStrToDateZeroHour12h() throws IOException {
+        assertFirstRowString(
+            oneRow("key00")
+                + "| eval v = date_format(str_to_date('2017-10-23 00:00:00', '%Y-%m-%d %h:%i:%s'), '%Y-%m-%d %H:%i:%s') | fields v",
+            "2017-10-23 00:00:00"
+        );
+    }
+
+    /** STR_TO_DATE on a date-only input with date+time format defaults time to 00:00:00. */
+    public void testStrToDateDateOnlyWithTimeFormat() throws IOException {
+        assertFirstRowString(
+            oneRow("key00")
+                + "| eval v = date_format(str_to_date('2017-10-23', '%Y-%m-%d %h:%i:%s'), '%Y-%m-%d %H:%i:%s') | fields v",
+            "2017-10-23 00:00:00"
+        );
+    }
+
     /**
      * {@code time_format(time_column, fmt)} against a TIME column — distinct from the
      * {@code time_format(maketime(...), fmt)} path covered by {@link #testAddTimeOnTimeReturnsTime}.


### PR DESCRIPTION
### Description

Two MySQL-compat semantics bugs in the analytics-engine DataFusion path made `YEARWEEK` and `STR_TO_DATE` return wrong or null values. This PR aligns both with MySQL behavior:

- **YEARWEEK** was off-by-one near year boundaries because `os_yearweek_number` decremented the year only when `week > 51 && day < 7` and otherwise relied on a hand-rolled per-mode counter that didn't honour `minimalDaysInFirstWeek`. Replaced with a Java `Calendar.WEEK_OF_YEAR` replica that mirrors the SQL plugin's `CalendarLookup` so the per-mode week numbers and the year-rollover both match `extractYearweek`.
- **STR_TO_DATE** returned `null` for inputs with `%h="00"` (zero-hour 12-hour-clock) and for date-only inputs paired with date+time formats. The 12-hour validators were `1..=12` instead of `<=12`, so chrono rejected the value before reaching `Parsed::to_naive` (which already maps `hour_12=0` to midnight). Trailing format tokens after an exhausted input now apply zero defaults instead of failing the whole parse.
- The same parser also tolerates a literal `T` where the format expects whitespace, so `CAST(date AS STRING)` ISO-8601 outputs round-trip through MySQL-shaped formats like `'%Y-%m-%d %h:%i:%s'`.

### Semantics

`YEARWEEK(date, mode)` returns `year * 100 + week` where `(year, week)` come from a Java `Calendar.WEEK_OF_YEAR` evaluation under `(firstDayOfWeek, minimalDaysInFirstWeek)` derived from the mode. Late-Dec dates that fall into the next year's week 1 keep the calendar year; early-Jan dates that fall into the prior year's last week decrement the year. Single-arg `YEARWEEK(date)` defaults to mode 0.

`STR_TO_DATE(string, format)` parses `string` using MySQL format codes (`%Y %m %d %H %h %i %s %f %p %b %M %y %T %r %j …`) and returns a `TIMESTAMP`. Returns `NULL` when the input cannot be parsed.

### Query shapes now supported

```sql
-- YEARWEEK at year boundaries (1899-12-30 Sat → 189952; 1900-01-01 Mon mode 0 → 189953, mode 4 → 190001)
SELECT yearweek(time0), yearweek(time0, 4) FROM opensearch-sql_test_index_calcs LIMIT 2

-- STR_TO_DATE with zero-hour 12-hour-clock and date+time format
SELECT str_to_date(CAST(birthdate AS STRING), '%Y-%m-%d %h:%i:%s') FROM opensearch-sql_test_index_bank LIMIT 2

-- STR_TO_DATE on a literal with month-name / 2-digit-year tokens
SELECT str_to_date('23-Oct-17 00:00:00', '%d-%b-%y %h:%i:%s')

-- STR_TO_DATE with date-only input but date+time format (time defaults to 00:00:00)
SELECT str_to_date('2017-10-23', '%Y-%m-%d %h:%i:%s')
```

### Tests

- **Sandbox QA IT** (`sandbox/qa/analytics-engine-rest/.../DateTimeScalarFunctionsIT.java`)
  - `testYearweekDec1899Boundary` — `yearweek('1899-12-30')` and `yearweek('1899-12-30', 4)` both 189952.
  - `testStrToDateZeroHour12h` — `str_to_date('2017-10-23 00:00:00', '%Y-%m-%d %h:%i:%s')` → `'2017-10-23 00:00:00'`.
  - `testStrToDateDateOnlyWithTimeFormat` — `str_to_date('2017-10-23', '%Y-%m-%d %h:%i:%s')` → `'2017-10-23 00:00:00'`.

### PPL Calcite tests in the SQL plugin unblocked

- `DateTimeFunctionIT.testStrToDate`
- `DateTimeFunctionIT.testYearweek`

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).