### PR TITLE
Properly reflect SETTING_HTTP_MAX_HEADER_SIZE for ReactorNetty4HttpServerTransport

### DIFF
--- a/modules/transport-netty4/src/main/java/org/opensearch/http/netty4/Netty4Http3ServerTransport.java
+++ b/modules/transport-netty4/src/main/java/org/opensearch/http/netty4/Netty4Http3ServerTransport.java
@@ -327,7 +327,7 @@ public class Netty4Http3ServerTransport extends AbstractHttpServerTransport {
                 ).build();
 
                 final Http3Settings http3Settings = new Http3Settings();
-                http3Settings.maxFieldSectionSize(SETTING_HTTP_MAX_HEADER_SIZE.get(settings).getBytes());
+                http3Settings.maxFieldSectionSize(maxHeaderSize.getBytes());
 
                 ch.pipeline().addLast(Http3.newQuicServerCodecBuilder().sslEngineProvider(q -> {
                     final QuicSslEngine engine = sslContext.newEngine(q.alloc());

--- a/plugins/transport-reactor-netty4/src/main/java/org/opensearch/http/reactor/netty4/ReactorNetty4HttpServerTransport.java
+++ b/plugins/transport-reactor-netty4/src/main/java/org/opensearch/http/reactor/netty4/ReactorNetty4HttpServerTransport.java
@@ -383,6 +383,7 @@ public class ReactorNetty4HttpServerTransport extends AbstractHttpServerTranspor
                         .http3Settings(
                             spec -> spec.tokenHandler(new SecureQuicTokenHandler(Randomness.createSecure()))
                                 .idleTimeout(Duration.ofMillis(connectTimeoutMillis))
+                                .maxFieldSectionSize(maxHeaderSize.bytesAsInt())
                                 .maxData(SETTING_HTTP_MAX_CONTENT_LENGTH.get(settings).getBytes())
                                 .maxStreamDataBidirectionalLocal(SETTING_H3_MAX_STREAM_LOCAL_LENGTH.get(settings).getBytes())
                                 .maxStreamDataBidirectionalRemote(SETTING_H3_MAX_STREAM_REMOTE_LENGTH.get(settings).getBytes())


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Brings https://github.com/opensearch-project/OpenSearch/pull/22004 to the `ReactorNetty4HttpServerTransport` transport (it was not available at the moment of the fix, but it is now since https://github.com/opensearch-project/OpenSearch/pull/22059).

### Related Issues
N/A

<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
