### PR TITLE
[analytics-engine] Fix TopK sort key mismatch

### DIFF
--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchTopKRewriter.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchTopKRewriter.java
@@ -88,6 +88,9 @@ public final class OpenSearchTopKRewriter {
         // PPL emits measures-first output via a column-swapping Project (e.g. Project(c=$1, key=$0)).
         // The outer Sort's indices reference the Project's output; the shard Sort must reference
         // the PARTIAL Aggregate's output (group-keys first, measures second).
+        // If the Project contains computed expressions (literals, casts, arithmetic) rather than
+        // simple column references, we bail — the sort key has no direct mapping to the aggregate
+        // output and TopK cannot be safely applied.
         RelCollation adjustedCollation = sort.getCollation();
         if (match.intermediateProject != null) {
             List<RelFieldCollation> remapped = new ArrayList<>();
@@ -211,6 +214,17 @@ public final class OpenSearchTopKRewriter {
         return findFinalAgg(node, null);
     }
 
+    /**
+     * Walks toward the FINAL aggregate, capturing at most one intermediate Project.
+     * The {@code seenProject == null} guard assumes CoreRules.PROJECT_MERGE has collapsed
+     * adjacent Projects during RBO — if that rule is ever removed, multiple Projects may
+     * appear and this method will skip the second one (returning null for the project field),
+     * which safely disables the collation remapping (TopK still fires with the raw collation,
+     * correct when no reordering exists between the two).
+     *
+     * <p>Multi-input nodes (joins, unions) terminate the walk — TopK only applies to
+     * single-path Sort → Aggregate chains.
+     */
     private static PathToFinal findFinalAgg(RelNode node, OpenSearchProject seenProject) {
         if (node instanceof OpenSearchAggregate agg && agg.getMode() == AggregateMode.FINAL) {
             return new PathToFinal(seenProject, agg);

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchTopKRewriter.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchTopKRewriter.java
@@ -14,6 +14,7 @@ import org.apache.calcite.rel.RelFieldCollation;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexInputRef;
 import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.type.SqlTypeName;
@@ -83,10 +84,27 @@ public final class OpenSearchTopKRewriter {
             true
         );
 
-        RelNode sortInput = partial;
+        // Remap collation through the intermediate Project (if any) between Sort and FINAL Aggregate.
+        // PPL emits measures-first output via a column-swapping Project (e.g. Project(c=$1, key=$0)).
+        // The outer Sort's indices reference the Project's output; the shard Sort must reference
+        // the PARTIAL Aggregate's output (group-keys first, measures second).
         RelCollation adjustedCollation = sort.getCollation();
+        if (match.intermediateProject != null) {
+            List<RelFieldCollation> remapped = new ArrayList<>();
+            for (RelFieldCollation fc : sort.getCollation().getFieldCollations()) {
+                RexNode expr = match.intermediateProject.getProjects().get(fc.getFieldIndex());
+                if (expr instanceof RexInputRef ref) {
+                    remapped.add(new RelFieldCollation(ref.getIndex(), fc.getDirection(), fc.nullDirection));
+                } else {
+                    return Optional.empty();
+                }
+            }
+            adjustedCollation = RelCollations.of(remapped);
+        }
 
-        if (hasEngineNativeMergeMeasure(partial, sort.getCollation())) {
+        RelNode sortInput = partial;
+
+        if (hasEngineNativeMergeMeasure(partial, adjustedCollation)) {
             RelDataType partialRowType = partial.getRowType();
             int fieldCount = partialRowType.getFieldCount();
             int groupCount = partial.getGroupSet().cardinality();
@@ -99,7 +117,7 @@ public final class OpenSearchTopKRewriter {
             }
 
             List<RelFieldCollation> newCollations = new ArrayList<>();
-            for (RelFieldCollation fc : sort.getCollation().getFieldCollations()) {
+            for (RelFieldCollation fc : adjustedCollation.getFieldCollations()) {
                 int sortIdx = fc.getFieldIndex();
                 if (sortIdx >= groupCount && AggregateFunction.isEngineNativeMerge(partial.getAggCallList().get(sortIdx - groupCount))) {
                     AggregateFunction aggFunc = AggregateFunction.fromSqlAggFunction(
@@ -183,15 +201,24 @@ public final class OpenSearchTopKRewriter {
             if (found != null) return found;
         }
         if (node instanceof OpenSearchSort sort && !sort.getCollation().getFieldCollations().isEmpty()) {
-            OpenSearchAggregate finalAgg = findFinalAgg(sort.getInput());
-            if (finalAgg != null) return new SortAboveFinal(sort, finalAgg);
+            PathToFinal path = findFinalAgg(sort.getInput());
+            if (path != null) return new SortAboveFinal(sort, path.project, path.finalAgg);
         }
         return null;
     }
 
-    private static OpenSearchAggregate findFinalAgg(RelNode node) {
-        if (node instanceof OpenSearchAggregate agg && agg.getMode() == AggregateMode.FINAL) return agg;
-        if (node.getInputs().size() == 1) return findFinalAgg(node.getInputs().get(0));
+    private static PathToFinal findFinalAgg(RelNode node) {
+        return findFinalAgg(node, null);
+    }
+
+    private static PathToFinal findFinalAgg(RelNode node, OpenSearchProject seenProject) {
+        if (node instanceof OpenSearchAggregate agg && agg.getMode() == AggregateMode.FINAL) {
+            return new PathToFinal(seenProject, agg);
+        }
+        if (node instanceof OpenSearchProject proj && seenProject == null) {
+            return findFinalAgg(proj.getInput(), proj);
+        }
+        if (node.getInputs().size() == 1) return findFinalAgg(node.getInputs().get(0), seenProject);
         return null;
     }
 
@@ -224,6 +251,9 @@ public final class OpenSearchTopKRewriter {
         return context.getOversamplingFactor();
     }
 
-    private record SortAboveFinal(OpenSearchSort sort, OpenSearchAggregate finalAgg) {
+    private record PathToFinal(OpenSearchProject project, OpenSearchAggregate finalAgg) {
+    }
+
+    private record SortAboveFinal(OpenSearchSort sort, OpenSearchProject intermediateProject, OpenSearchAggregate finalAgg) {
     }
 }

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/settings/AnalyticsQuerySettings.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/settings/AnalyticsQuerySettings.java
@@ -43,6 +43,7 @@ public final class AnalyticsQuerySettings {
                 ? List.of(
                     "IS_NULL",
                     "IS_NOT_NULL",
+                    "NOT_EQUALS",
                     "LIKE",
                     "GREATER_THAN",
                     "GREATER_THAN_OR_EQUAL",

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/TopKRewriterPlanShapeTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/TopKRewriterPlanShapeTests.java
@@ -364,6 +364,8 @@ public class TopKRewriterPlanShapeTests extends PlanShapeTestBase {
     /**
      * q13: {@code stats count() as c by SearchPhrase | sort - c | head 10}.
      * Single group-by, single COUNT, sort on measure. Shard sort must use $1.
+     * Two coordinator Sorts (fetch=10000 + fetch=10) survive because this planner does not
+     * register SORT_REMOVE_REDUNDANT. DF collapses them in the physical plan.
      */
     public void testRewrite_pplShape_q13_sortKeyRemappedThroughProject() {
         RelNode result = runPlanner(buildPplSwapPlan(ImmutableBitSet.of(0), List.of(countStarCall()), 10), contextWithOversampling(2.0));
@@ -499,6 +501,70 @@ public class TopKRewriterPlanShapeTests extends PlanShapeTestBase {
         RelNode result = runPlanner(sort, contextWithOversampling(2.0));
         String plan = RelOptUtil.toString(result);
         assertEquals("AVG decomposition prevents TopK — no shard Sort", 0, countShardSortsBelowER(plan));
+    }
+
+    /**
+     * Multiple adjacent Projects between Sort and Aggregate: if PROJECT_MERGE is ever removed,
+     * the rewriter should still work (captures only the first Project, skips remapping for the
+     * second). This test verifies TopK still fires — sort key passes through un-remapped since
+     * the second Project is not captured.
+     */
+    public void testDetection_multipleProjects_topKStillFires() {
+        RelOptTable table = mockTable("test_index", "status", "size");
+        RelNode scan = stubScan(table);
+        LogicalAggregate agg = LogicalAggregate.create(scan, List.of(), ImmutableBitSet.of(0), null, List.of(countStarCall()));
+
+        // First Project: identity (no swap)
+        RelNode proj1 = LogicalProject.create(
+            agg,
+            List.of(),
+            List.of(rexBuilder.makeInputRef(agg, 0), rexBuilder.makeInputRef(agg, 1)),
+            List.of("status", "cnt")
+        );
+        // Second Project: also identity
+        RelNode proj2 = LogicalProject.create(
+            proj1,
+            List.of(),
+            List.of(rexBuilder.makeInputRef(proj1, 0), rexBuilder.makeInputRef(proj1, 1)),
+            List.of("status", "cnt")
+        );
+
+        RelNode sort = LogicalSort.create(
+            proj2,
+            RelCollations.of(new RelFieldCollation(1, RelFieldCollation.Direction.DESCENDING)),
+            null,
+            rexBuilder.makeLiteral(10, typeFactory.createSqlType(SqlTypeName.INTEGER), true)
+        );
+        RelNode result = runPlanner(sort, contextWithOversampling(2.0));
+        String plan = RelOptUtil.toString(result);
+        long sortCount = plan.lines().filter(l -> l.contains("OpenSearchSort")).count();
+        assertTrue("TopK should still fire with multiple projects (PROJECT_MERGE collapses them)", sortCount >= 2);
+    }
+
+    /** Computed expression (literal) in Project between Sort and Aggregate — rewriter bails. */
+    public void testDetection_computedProjectExpression_topKBails() {
+        RelOptTable table = mockTable("test_index", "status", "size");
+        RelNode scan = stubScan(table);
+        LogicalAggregate agg = LogicalAggregate.create(scan, List.of(), ImmutableBitSet.of(0), null, List.of(countStarCall()));
+
+        // Project with a literal expression (not a column reference)
+        RelNode proj = LogicalProject.create(
+            agg,
+            List.of(),
+            List.of(rexBuilder.makeLiteral(42, typeFactory.createSqlType(SqlTypeName.INTEGER), true), rexBuilder.makeInputRef(agg, 0)),
+            List.of("const", "status")
+        );
+
+        // Sort on $0 which is the literal — cannot be remapped
+        RelNode sort = LogicalSort.create(
+            proj,
+            RelCollations.of(new RelFieldCollation(0, RelFieldCollation.Direction.DESCENDING)),
+            null,
+            rexBuilder.makeLiteral(10, typeFactory.createSqlType(SqlTypeName.INTEGER), true)
+        );
+        RelNode result = runPlanner(sort, contextWithOversampling(2.0));
+        String plan = RelOptUtil.toString(result);
+        assertEquals("Computed expression in Project — TopK must bail", 0, countShardSortsBelowER(plan));
     }
 
     // ── Rewrite: PPL swap Project shapes ────────────────────────────────────────

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/TopKRewriterPlanShapeTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/TopKRewriterPlanShapeTests.java
@@ -15,6 +15,7 @@ import org.apache.calcite.rel.RelFieldCollation;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.AggregateCall;
 import org.apache.calcite.rel.logical.LogicalAggregate;
+import org.apache.calcite.rel.logical.LogicalProject;
 import org.apache.calcite.rel.logical.LogicalSort;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
@@ -23,6 +24,7 @@ import org.apache.calcite.util.ImmutableBitSet;
 import org.opensearch.analytics.settings.DelegationBlockList;
 import org.opensearch.analytics.settings.PlannerSettings;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -355,5 +357,321 @@ public class TopKRewriterPlanShapeTests extends PlanShapeTestBase {
         PlannerContext ctx = buildContext("parquet", 2, intFields());
         ctx.setPlannerSettings(PlannerSettings.of(factor, DelegationBlockList.empty()));
         return ctx;
+    }
+
+    // ── PPL column-swap tests: Sort key remapped through intermediate Project ──
+
+    /**
+     * q13: {@code stats count() as c by SearchPhrase | sort - c | head 10}.
+     * Single group-by, single COUNT, sort on measure. Shard sort must use $1.
+     */
+    public void testRewrite_pplShape_q13_sortKeyRemappedThroughProject() {
+        RelNode result = runPlanner(buildPplSwapPlan(ImmutableBitSet.of(0), List.of(countStarCall()), 10), contextWithOversampling(2.0));
+        assertPlanShape(
+            """
+                OpenSearchSort(sort0=[$0], dir0=[DESC], fetch=[10000], viableBackends=[[mock-parquet]])
+                  OpenSearchSort(sort0=[$0], dir0=[DESC], fetch=[10], viableBackends=[[mock-parquet]])
+                    OpenSearchProject(cnt=[$1], status=[$0], viableBackends=[[mock-parquet]])
+                      OpenSearchAggregate(group=[{0}], cnt=[SUM($1)], mode=[FINAL], viableBackends=[[mock-parquet]])
+                        OpenSearchExchangeReducer(viableBackends=[[mock-parquet]], exchange=[ExchangeInfo[distributionType=SINGLETON, partitionKeyIndices=[]]])
+                          OpenSearchSort(sort0=[$1], dir0=[DESC], fetch=[30], viableBackends=[[mock-parquet]])
+                            OpenSearchAggregate(group=[{0}], cnt=[COUNT()], mode=[PARTIAL], viableBackends=[[mock-parquet]])
+                              OpenSearchTableScan(table=[[test_index]], viableBackends=[[mock-parquet]])
+                """,
+            result
+        );
+    }
+
+    /**
+     * q15: {@code stats count() as c by X, Y | sort - c | head 10}.
+     * Multi-group-by, single COUNT, sort on measure. Shard sort must use $2.
+     */
+    public void testRewrite_pplShape_q15_multiGroup_sortKeyRemappedThroughProject() {
+        RelNode result = runPlanner(
+            buildPplSwapPlan(ImmutableBitSet.of(0, 1), List.of(countStarCall(stubScan(mockTable("test_index", "status", "size")))), 10),
+            contextWithOversampling(2.0)
+        );
+        assertPlanShape(
+            """
+                OpenSearchSort(sort0=[$0], dir0=[DESC], fetch=[10000], viableBackends=[[mock-parquet]])
+                  OpenSearchSort(sort0=[$0], dir0=[DESC], fetch=[10], viableBackends=[[mock-parquet]])
+                    OpenSearchProject(cnt=[$2], status=[$0], size=[$1], viableBackends=[[mock-parquet]])
+                      OpenSearchAggregate(group=[{0, 1}], cnt=[SUM($2)], mode=[FINAL], viableBackends=[[mock-parquet]])
+                        OpenSearchExchangeReducer(viableBackends=[[mock-parquet]], exchange=[ExchangeInfo[distributionType=SINGLETON, partitionKeyIndices=[]]])
+                          OpenSearchSort(sort0=[$2], dir0=[DESC], fetch=[30], viableBackends=[[mock-parquet]])
+                            OpenSearchAggregate(group=[{0, 1}], cnt=[COUNT()], mode=[PARTIAL], viableBackends=[[mock-parquet]])
+                              OpenSearchTableScan(table=[[test_index]], viableBackends=[[mock-parquet]])
+                """,
+            result
+        );
+    }
+
+    /**
+     * q11: {@code stats dc(UserID) as u by MobilePhoneModel | sort - u | head 10}.
+     * dc() with column swap — combines reduce_eval logic with the Project remapping.
+     */
+    public void testRewrite_pplShape_q11_dcWithSwap_sortKeyRemapped() {
+        RelOptTable table = mockTable("test_index", "status", "size");
+        RelNode scan = stubScan(table);
+        RelNode result = runPlanner(
+            buildPplSwapPlan(ImmutableBitSet.of(0), List.of(approxCountDistinctCall(scan)), 10),
+            contextWithOversampling(2.0)
+        );
+        assertPlanShape(
+            """
+                OpenSearchSort(sort0=[$0], dir0=[DESC], fetch=[10000], viableBackends=[[mock-parquet]])
+                  OpenSearchSort(sort0=[$0], dir0=[DESC], fetch=[10], viableBackends=[[mock-parquet]])
+                    OpenSearchProject(dc=[$1], status=[$0], viableBackends=[[mock-parquet]])
+                      OpenSearchAggregate(group=[{0}], dc=[APPROX_COUNT_DISTINCT($1)], mode=[FINAL], viableBackends=[[mock-parquet]])
+                        OpenSearchExchangeReducer(viableBackends=[[mock-parquet]], exchange=[ExchangeInfo[distributionType=SINGLETON, partitionKeyIndices=[]]])
+                          OpenSearchProject(status=[$0], dc=[$1], viableBackends=[[mock-parquet]])
+                            OpenSearchSort(sort0=[$2], dir0=[DESC], fetch=[30], viableBackends=[[mock-parquet]])
+                              OpenSearchProject(status=[$0], dc=[$1], __reduce_eval_1=[reduce_eval('approx_distinct', $1)], viableBackends=[[mock-parquet]])
+                                OpenSearchAggregate(group=[{0}], dc=[APPROX_COUNT_DISTINCT($1)], mode=[PARTIAL], viableBackends=[[mock-parquet]])
+                                  OpenSearchTableScan(table=[[test_index]], viableBackends=[[mock-parquet]])
+                """,
+            result
+        );
+    }
+
+    /**
+     * Sort by group key (not measure) with swap Project: the swap puts the key at $1 in
+     * post-project schema. Remapping should produce shard sort on $0 (the group key at
+     * partial agg level). Ensures the fix doesn't break sort-by-key queries.
+     */
+    public void testRewrite_pplShape_sortByGroupKey_remapsCorrectly() {
+        RelOptTable table = mockTable("test_index", "status", "size");
+        RelNode scan = stubScan(table);
+        LogicalAggregate agg = LogicalAggregate.create(scan, List.of(), ImmutableBitSet.of(0), null, List.of(countStarCall()));
+
+        // PPL swap: (cnt=$1, status=$0)
+        RelNode swapProject = LogicalProject.create(
+            agg,
+            List.of(),
+            List.of(rexBuilder.makeInputRef(agg, 1), rexBuilder.makeInputRef(agg, 0)),
+            List.of("cnt", "status")
+        );
+
+        // Sort on $1 (which is status/group-key in the swapped schema)
+        RelNode innerSort = LogicalSort.create(
+            swapProject,
+            RelCollations.of(new RelFieldCollation(1, RelFieldCollation.Direction.DESCENDING)),
+            null,
+            rexBuilder.makeLiteral(10, typeFactory.createSqlType(SqlTypeName.INTEGER), true)
+        );
+
+        RelNode outerLimit = LogicalSort.create(
+            innerSort,
+            RelCollations.of(new RelFieldCollation(1, RelFieldCollation.Direction.DESCENDING)),
+            null,
+            rexBuilder.makeLiteral(10000, typeFactory.createSqlType(SqlTypeName.INTEGER), true)
+        );
+
+        RelNode result = runPlanner(outerLimit, contextWithOversampling(2.0));
+        assertPlanShape(
+            """
+                OpenSearchSort(sort0=[$1], dir0=[DESC], fetch=[10000], viableBackends=[[mock-parquet]])
+                  OpenSearchSort(sort0=[$1], dir0=[DESC], fetch=[10], viableBackends=[[mock-parquet]])
+                    OpenSearchProject(cnt=[$1], status=[$0], viableBackends=[[mock-parquet]])
+                      OpenSearchAggregate(group=[{0}], cnt=[SUM($1)], mode=[FINAL], viableBackends=[[mock-parquet]])
+                        OpenSearchExchangeReducer(viableBackends=[[mock-parquet]], exchange=[ExchangeInfo[distributionType=SINGLETON, partitionKeyIndices=[]]])
+                          OpenSearchSort(sort0=[$0], dir0=[DESC], fetch=[30], viableBackends=[[mock-parquet]])
+                            OpenSearchAggregate(group=[{0}], cnt=[COUNT()], mode=[PARTIAL], viableBackends=[[mock-parquet]])
+                              OpenSearchTableScan(table=[[test_index]], viableBackends=[[mock-parquet]])
+                """,
+            result
+        );
+    }
+
+    // ── Detection: AVG does NOT get TopK (reduce decomposition inserts computed Project) ──
+
+    /** AVG is decomposed into SUM/COUNT with a divide Project — rewriter bails. */
+    public void testDetection_avgByGroup_noTopK() {
+        RelOptTable table = mockTable("test_index", "status", "size");
+        RelNode scan = stubScan(table);
+        LogicalAggregate agg = LogicalAggregate.create(scan, List.of(), ImmutableBitSet.of(0), null, List.of(avgCall(scan)));
+        RelNode sort = LogicalSort.create(
+            agg,
+            RelCollations.of(new RelFieldCollation(1, RelFieldCollation.Direction.DESCENDING)),
+            null,
+            rexBuilder.makeLiteral(10, typeFactory.createSqlType(SqlTypeName.INTEGER), true)
+        );
+        RelNode result = runPlanner(sort, contextWithOversampling(2.0));
+        String plan = RelOptUtil.toString(result);
+        assertEquals("AVG decomposition prevents TopK — no shard Sort", 0, countShardSortsBelowER(plan));
+    }
+
+    // ── Rewrite: PPL swap Project shapes ────────────────────────────────────────
+
+    /** SUM with swap Project: shard sort must use $1 (the SUM measure). */
+    public void testRewrite_pplShape_sumWithSwap_sortKeyRemapped() {
+        RelOptTable table = mockTable("test_index", "status", "size");
+        RelNode scan = stubScan(table);
+        RelNode result = runPlanner(buildPplSwapPlan(ImmutableBitSet.of(0), List.of(sumCall(scan)), 10), contextWithOversampling(2.0));
+        String plan = RelOptUtil.toString(result);
+        assertTrue("shard sort must use $1", planHasShardSortOn(plan, "$1"));
+    }
+
+    /** Multi-group dc() with swap: shard sort must use $3 (reduce_eval appended column). */
+    public void testRewrite_pplShape_multiGroupDcWithSwap_sortKeyRemapped() {
+        RelOptTable table = mockTable("test_index", "status", "size");
+        RelNode scan = stubScan(table);
+        RelNode result = runPlanner(
+            buildPplSwapPlan(ImmutableBitSet.of(0, 1), List.of(approxCountDistinctCall(scan)), 10),
+            contextWithOversampling(2.0)
+        );
+        String plan = RelOptUtil.toString(result);
+        assertTrue("multi-group dc shard sort must use $3 (reduce_eval column), plan:\n" + plan, planHasShardSortOn(plan, "$3"));
+    }
+
+    /** Swap with offset: shard fetch must honor offset. */
+    public void testRewrite_pplShape_swapWithOffset_shardFetchHonorsOffset() {
+        RelOptTable table = mockTable("test_index", "status", "size");
+        RelNode scan = stubScan(table);
+        LogicalAggregate agg = LogicalAggregate.create(scan, List.of(), ImmutableBitSet.of(0), null, List.of(countStarCall()));
+        RelNode swapProject = LogicalProject.create(
+            agg,
+            List.of(),
+            List.of(rexBuilder.makeInputRef(agg, 1), rexBuilder.makeInputRef(agg, 0)),
+            List.of("cnt", "status")
+        );
+        RelNode innerSort = LogicalSort.create(
+            swapProject,
+            RelCollations.of(new RelFieldCollation(0, RelFieldCollation.Direction.DESCENDING)),
+            rexBuilder.makeLiteral(100, typeFactory.createSqlType(SqlTypeName.INTEGER), true),
+            rexBuilder.makeLiteral(10, typeFactory.createSqlType(SqlTypeName.INTEGER), true)
+        );
+        RelNode outerLimit = LogicalSort.create(
+            innerSort,
+            RelCollations.of(new RelFieldCollation(0, RelFieldCollation.Direction.DESCENDING)),
+            null,
+            rexBuilder.makeLiteral(10000, typeFactory.createSqlType(SqlTypeName.INTEGER), true)
+        );
+        RelNode result = runPlanner(outerLimit, contextWithOversampling(2.0));
+        String plan = RelOptUtil.toString(result);
+        // coordLimit = 100+10 = 110, shardSize = ceil(110*2)+110 = 330
+        assertTrue("shard fetch must be 330, plan:\n" + plan, plan.contains("fetch=[330]"));
+        assertTrue("shard sort must use $1", planHasShardSortOn(plan, "$1"));
+    }
+
+    /** ASC sort direction with swap: direction must be preserved in shard sort. */
+    public void testRewrite_pplShape_ascDirection_preserved() {
+        RelOptTable table = mockTable("test_index", "status", "size");
+        RelNode scan = stubScan(table);
+        LogicalAggregate agg = LogicalAggregate.create(scan, List.of(), ImmutableBitSet.of(0), null, List.of(countStarCall()));
+        RelNode swapProject = LogicalProject.create(
+            agg,
+            List.of(),
+            List.of(rexBuilder.makeInputRef(agg, 1), rexBuilder.makeInputRef(agg, 0)),
+            List.of("cnt", "status")
+        );
+        RelNode innerSort = LogicalSort.create(
+            swapProject,
+            RelCollations.of(new RelFieldCollation(0, RelFieldCollation.Direction.ASCENDING)),
+            null,
+            rexBuilder.makeLiteral(10, typeFactory.createSqlType(SqlTypeName.INTEGER), true)
+        );
+        RelNode outerLimit = LogicalSort.create(
+            innerSort,
+            RelCollations.of(new RelFieldCollation(0, RelFieldCollation.Direction.ASCENDING)),
+            null,
+            rexBuilder.makeLiteral(10000, typeFactory.createSqlType(SqlTypeName.INTEGER), true)
+        );
+        RelNode result = runPlanner(outerLimit, contextWithOversampling(2.0));
+        String plan = RelOptUtil.toString(result);
+        assertTrue("shard sort must use $1 ASC", planHasShardSortOn(plan, "$1") && plan.contains("dir0=[ASC]"));
+    }
+
+    /** Factor=1.5 with swap: verifies arithmetic (ceil(10*1.5)+10 = 25). */
+    public void testRewrite_pplShape_factor1_5_shardFetchCorrect() {
+        RelNode result = runPlanner(buildPplSwapPlan(ImmutableBitSet.of(0), List.of(countStarCall()), 10), contextWithOversampling(1.5));
+        String plan = RelOptUtil.toString(result);
+        assertTrue("shard fetch must be 25, plan:\n" + plan, plan.contains("fetch=[25]"));
+    }
+
+    /** Large fetch (head 1000) with swap: shard fetch = ceil(1000*2)+1000 = 3000. */
+    public void testRewrite_pplShape_largeFetch_shardFetchCorrect() {
+        RelNode result = runPlanner(buildPplSwapPlan(ImmutableBitSet.of(0), List.of(countStarCall()), 1000), contextWithOversampling(2.0));
+        String plan = RelOptUtil.toString(result);
+        assertTrue("shard fetch must be 3000, plan:\n" + plan, plan.contains("fetch=[3000]"));
+    }
+
+    private static boolean planHasShardSortOn(String plan, String expectedField) {
+        String[] lines = plan.split("\n");
+        boolean belowER = false;
+        for (String line : lines) {
+            if (line.contains("ExchangeReducer")) {
+                belowER = true;
+                continue;
+            }
+            if (belowER && line.contains("OpenSearchSort")) {
+                return line.contains("sort0=[" + expectedField + "]");
+            }
+        }
+        return false;
+    }
+
+    private static long countShardSortsBelowER(String plan) {
+        String[] lines = plan.split("\n");
+        boolean belowER = false;
+        long count = 0;
+        for (String line : lines) {
+            if (line.contains("ExchangeReducer")) {
+                belowER = true;
+                continue;
+            }
+            if (belowER && line.contains("OpenSearchSort")) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    // ── PPL swap plan builder ───────────────────────────────────────────────────
+
+    /**
+     * Builds the PPL-style plan shape with a column-swapping Project:
+     * SystemLimit($0 DESC, 10000) → Sort($0 DESC, fetch) → Project(measures..., keys...) → Agg
+     *
+     * <p>PPL always puts measures first in output. This builder reorders the Aggregate's
+     * output (keys first, measures second) into (measures first, keys second) via a Project,
+     * then creates a Sort on $0 (the first measure in swapped output).
+     */
+    private RelNode buildPplSwapPlan(ImmutableBitSet groupSet, List<AggregateCall> aggCalls, int fetch) {
+        RelOptTable table = mockTable("test_index", "status", "size");
+        RelNode scan = stubScan(table);
+        LogicalAggregate agg = LogicalAggregate.create(scan, List.of(), groupSet, null, aggCalls);
+
+        int groupCount = groupSet.cardinality();
+        int measureCount = aggCalls.size();
+
+        // Build swap project: measures first, then keys
+        List<RexNode> swapExprs = new ArrayList<>();
+        List<String> swapNames = new ArrayList<>();
+        for (int i = 0; i < measureCount; i++) {
+            swapExprs.add(rexBuilder.makeInputRef(agg, groupCount + i));
+            swapNames.add(agg.getRowType().getFieldNames().get(groupCount + i));
+        }
+        for (int i = 0; i < groupCount; i++) {
+            swapExprs.add(rexBuilder.makeInputRef(agg, i));
+            swapNames.add(agg.getRowType().getFieldNames().get(i));
+        }
+
+        RelNode swapProject = LogicalProject.create(agg, List.of(), swapExprs, swapNames);
+
+        // Sort on $0 (first measure in swapped output)
+        RelNode innerSort = LogicalSort.create(
+            swapProject,
+            RelCollations.of(new RelFieldCollation(0, RelFieldCollation.Direction.DESCENDING)),
+            null,
+            rexBuilder.makeLiteral(fetch, typeFactory.createSqlType(SqlTypeName.INTEGER), true)
+        );
+
+        return LogicalSort.create(
+            innerSort,
+            RelCollations.of(new RelFieldCollation(0, RelFieldCollation.Direction.DESCENDING)),
+            null,
+            rexBuilder.makeLiteral(10000, typeFactory.createSqlType(SqlTypeName.INTEGER), true)
+        );
     }
 }

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/settings/DelegationBlockListTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/settings/DelegationBlockListTests.java
@@ -186,6 +186,7 @@ public class DelegationBlockListTests extends OpenSearchTestCase {
         assertFalse("defaults should be seeded", blockList.isEmpty());
         assertTrue(blockList.isBlocked(LUCENE, ScalarFunction.IS_NULL));
         assertTrue(blockList.isBlocked(LUCENE, ScalarFunction.IS_NOT_NULL));
+        assertTrue(blockList.isBlocked(LUCENE, ScalarFunction.NOT_EQUALS));
         assertTrue(blockList.isBlocked(LUCENE, ScalarFunction.LIKE));
         assertTrue(blockList.isBlocked(LUCENE, ScalarFunction.GREATER_THAN));
         assertTrue(blockList.isBlocked(LUCENE, ScalarFunction.GREATER_THAN_OR_EQUAL));
@@ -193,7 +194,6 @@ public class DelegationBlockListTests extends OpenSearchTestCase {
         assertTrue(blockList.isBlocked(LUCENE, ScalarFunction.LESS_THAN_OR_EQUAL));
         assertTrue(blockList.isBlocked(LUCENE, ScalarFunction.SARG_PREDICATE));
         assertFalse(blockList.isBlocked(LUCENE, ScalarFunction.EQUALS));
-        assertFalse(blockList.isBlocked(LUCENE, ScalarFunction.NOT_EQUALS));
     }
 
     /** The cluster-settings layer wraps the validator's IllegalArgumentException; search the chain. */


### PR DESCRIPTION
## Summary
  - Fix TopK rewriter pushing wrong sort column to shards. It was sorting by group key instead of measure due to PPL's column-swap Project between Sort and Aggregate
  - Add `NOT_EQUALS` to lucene delegation blocklist defaults
  - ~Add `PlanShapeITs` with golden-file plan assertions for all 42 ClickBench queries (topk on/off)~

  ## Root Cause
  Commit `03283ee45b6` removed `SORT_PROJECT_TRANSPOSE`, leaving PPL's column-swap Project between Sort and FINAL Aggregate. The TopK rewriter copied the Sort's column index verbatim without remapping through this Project — causing shards to sort alphabetically by key, truncating high-count results.

  ## Fix
  `findFinalAgg` now captures the intermediate Project. Before pushing the Sort to shards, collation indices are remapped through the Project's inverse mapping.

  ## Test plan
  - [ ] 25 unit tests in `TopKRewriterPlanShapeTests` (edge cases, PPL swap shapes, AVG exclusion)


### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
