### PR TITLE
Use partial-state schema in indexed-executor empty-shard guard

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_executor.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_executor.rs
@@ -745,11 +745,16 @@ async unsafe fn execute_indexed_with_context_inner(
         use datafusion::physical_plan::empty::EmptyExec;
         use datafusion::physical_plan::ExecutionPlan;
         let context_id_early = handle.query_context.context_id();
-        let plan = Plan::decode(substrait_bytes.as_slice())
-            .map_err(|e| DataFusionError::Execution(format!("decode substrait: {}", e)))?;
-        let logical_plan = from_substrait_plan(&handle.ctx.state(), &plan).await?;
-        let plan_schema: arrow::datatypes::SchemaRef =
-            Arc::new(logical_plan.schema().as_arrow().clone());
+        // engine-native-merge: borrow the partial-state schema from the prepared plan so the
+        // empty stream matches the populated shards' wire shape (e.g. Binary HLL for dc()).
+        let plan_schema: arrow::datatypes::SchemaRef = if let Some(prepared) = handle.prepared_plan.as_ref() {
+            Arc::new(prepared.schema().as_ref().clone())
+        } else {
+            let plan = Plan::decode(substrait_bytes.as_slice())
+                .map_err(|e| DataFusionError::Execution(format!("decode substrait: {}", e)))?;
+            let logical_plan = from_substrait_plan(&handle.ctx.state(), &plan).await?;
+            Arc::new(logical_plan.schema().as_arrow().clone())
+        };
         let plan_schema = crate::schema_coerce::coerce_inferred_schema(plan_schema);
         let empty_exec = EmptyExec::new(Arc::clone(&plan_schema));
         let df_stream = empty_exec.execute(0, handle.ctx.task_ctx())?;

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/MultiIndexQueryShapesIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/MultiIndexQueryShapesIT.java
@@ -341,6 +341,79 @@ public class MultiIndexQueryShapesIT extends AnalyticsRestTestCase {
         assertContains(error, "score");
     }
 
+    // ── Empty-sibling multi-index dc(): regression for engine-native-merge empty-shard schema ──
+
+    private static final String EMPTY_DC_DATA = "multi_empty_dc_data";
+    private static final String EMPTY_DC_EMPTY = "multi_empty_dc_empty";
+    private static final String EMPTY_DC_ALIAS = "multi_empty_dc_alias";
+    private static final String EMPTY_DC_FIELDS =
+        "{\"properties\":{\"user_id\":{\"type\":\"long\"},\"phrase\":{\"type\":\"keyword\"}}}";
+    private static boolean emptyDcProvisioned = false;
+
+    private void ensureEmptyDcProvisioned() throws IOException {
+        if (emptyDcProvisioned) return;
+        createIndexWithSettings(EMPTY_DC_DATA, EMPTY_DC_FIELDS, true, 2);
+        createIndexWithSettings(EMPTY_DC_EMPTY, EMPTY_DC_FIELDS, true, 2);
+        bulk(EMPTY_DC_DATA,
+            "{\"user_id\":1,\"phrase\":\"alpha\"}\n"
+            + "{\"user_id\":2,\"phrase\":\"alpha\"}\n"
+            + "{\"user_id\":3,\"phrase\":\"beta\"}\n"
+            + "{\"user_id\":4,\"phrase\":\"gamma\"}\n");
+        // EMPTY_DC_EMPTY is intentionally never bulk-loaded.
+        putAlias(EMPTY_DC_ALIAS, List.of(EMPTY_DC_DATA, EMPTY_DC_EMPTY));
+        emptyDcProvisioned = true;
+    }
+
+    /** dc() with no WHERE → populated shards take the non-indexed path. */
+    public void testEmptySiblingDcScalar() throws IOException {
+        ensureEmptyDcProvisioned();
+        assertScalarDc("source=" + EMPTY_DC_ALIAS + " | stats dc(user_id)", 4L);
+    }
+
+    /** dc() with a lucene-delegated WHERE → populated shards take the indexed path (the regression case). */
+    public void testEmptySiblingDcWithDelegatedFilter() throws IOException {
+        ensureEmptyDcProvisioned();
+        assertScalarDc("source=" + EMPTY_DC_ALIAS + " | where phrase != '' | stats dc(user_id)", 4L);
+    }
+
+    /** dc() with a non-delegable WHERE (arithmetic) → populated shards stay on the non-indexed path. */
+    public void testEmptySiblingDcWithNonDelegatedFilter() throws IOException {
+        ensureEmptyDcProvisioned();
+        assertScalarDc("source=" + EMPTY_DC_ALIAS + " | where user_id + 1 > 2 | stats dc(user_id)", 3L);
+    }
+
+    /** Grouped dc() with a delegated WHERE → exercises FinalPartitioned/Partial on data shards + EmptyExec on empties. */
+    public void testEmptySiblingDcGroupedWithDelegatedFilter() throws IOException {
+        ensureEmptyDcProvisioned();
+        Map<String, Object> body = executePpl(
+            "source=" + EMPTY_DC_ALIAS + " | where phrase != '' | stats dc(user_id) as u by phrase"
+        );
+        @SuppressWarnings("unchecked")
+        List<List<Object>> rows = (List<List<Object>>) body.get("datarows");
+        assertEquals(3, rows.size());
+        long total = 0;
+        for (List<Object> row : rows) total += ((Number) row.get(0)).longValue();
+        assertEquals(4L, total);
+    }
+
+    /** All-empty union: every shard hits the empty-guard. */
+    public void testAllEmptyDc() throws IOException {
+        ensureEmptyDcProvisioned();
+        String secondEmpty = "multi_empty_dc_empty_second";
+        createIndexWithSettings(secondEmpty, EMPTY_DC_FIELDS, true, 2);
+        assertScalarDc(
+            "source=" + EMPTY_DC_EMPTY + "," + secondEmpty + " | where phrase != '' | stats dc(user_id)",
+            0L);
+    }
+
+    private void assertScalarDc(String ppl, long expected) throws IOException {
+        Map<String, Object> body = executePpl(ppl);
+        @SuppressWarnings("unchecked")
+        List<List<Object>> rows = (List<List<Object>>) body.get("datarows");
+        assertEquals(1, rows.size());
+        assertEquals(expected, ((Number) rows.get(0).get(0)).longValue());
+    }
+
     private String executePplExpectingFailure(String ppl) throws IOException {
         Request request = new Request("POST", "/_plugins/_ppl");
         request.setJsonEntity("{\"query\": \"" + escapeJson(ppl) + "\"}");


### PR DESCRIPTION
### Description

Multi-index `dc()` queries (`APPROX_COUNT_DISTINCT`) failed when one of the source indices was empty and a lucene-delegable `WHERE` was present. The data-node side returned HTTP 500 from the coordinator's reduce sink with a wire-schema mismatch:

```
DatafusionReduceSink: batch schema types do not match declared schema.
declared=Schema<dc(UserID): Binary not null>
batch=Schema<dc(UserID): Int(64, true)>
```

#### Root cause

For engine-native-merge aggregates (today only `dc()`), `prepare_partial_plan` strips the FINAL half of the physical plan and stores a `mode=Partial` plan on the session handle, so populated shards emit PARTIAL state (`Binary` HLL sketch) on the wire.

The empty-shard guard in `indexed_executor.rs` (added in #21754 to avoid the zero-parquet-files crash) bypassed this — it built `EmptyExec` from the substrait logical plan's schema, which carries the FINAL coordinator types (`Int64` for `dc()`). When at least one sibling index was empty, the empty shards advertised `Int64` while the populated shards advertised `Binary`, and the coordinator's `DatafusionReduceSink` rejected the mismatch.

Only the indexed (lucene-delegation) executor was affected. The non-indexed `query_executor.rs` short-circuits on `prepared_plan` before reaching its empty guard, so its empty path was already correct.

#### Fix

When `handle.prepared_plan` is set, borrow its root schema for the `EmptyExec` instead of re-deriving from substrait. The prepared plan's root is the stripped `mode=Partial` `AggregateExec`, whose `schema()` is the partial-state shape (`Binary` for HLL, struct for any future state-shape aggregate). This matches the schema the populated shards already emit. No `prepared_plan` ⇒ `Mode::Default` ⇒ keep the existing logical-schema fallback.

Reading `prepared.schema()` is a pure metadata lookup — no I/O, no parquet files touched, so the original empty-shard crash that motivated the guard stays fixed.

### Query shapes now supported

```ppl
# Multi-index dc() with delegated WHERE (the reported failure)
source = idx-001,idx-002,idx-003,idx-004,idx-005 | where SearchPhrase != '' | stats dc(UserID)

# Grouped variant
source = idx-001,idx-002,idx-003,idx-004,idx-005 | where SearchPhrase != '' | stats dc(UserID) as u by SearchPhrase | sort - u | head 10

# All-empty union
source = empty-a,empty-b | where phrase != '' | stats dc(user_id)

# Differing-fields union (one index has extra columns, that index is empty)
source = narrow-data,wide-empty | where phrase != '' | stats dc(user_id)
```

The pre-existing `dc()` cases (no `WHERE`, with non-delegable `WHERE`, no empty siblings) continue to work.

### Tests

Extends `MultiIndexQueryShapesIT` with six `dc()` cases over a parquet+lucene composite multi-index alias where one member is empty:

- scalar `dc()` no `WHERE` (non-indexed path)
- scalar `dc()` with delegated `WHERE` (the regression)
- scalar `dc()` with non-delegable `WHERE` (non-indexed path, symmetry)
- grouped `dc()` with delegated `WHERE` (`FinalPartitioned`/`Partial` pair)
- differing-fields union (empty sibling has extra columns the populated index doesn't)
- all-empty union

### Related issues

Same bug class as #21754 (empty-shard parquet crash) and #22102 (`apply_aggregate_mode` strip in indexed executor). Both prior fixes addressed parts of the engine-native-merge wire contract; this PR closes the remaining gap on the empty path.

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.