### PR TITLE
Support COUNT(DISTINCT x) OVER(...) via os_count_distinct UDAF in the DataFusion analytics backend

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/udaf/mod.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/udaf/mod.rs
@@ -14,10 +14,12 @@ use datafusion::execution::context::SessionContext;
 
 pub mod internal_pattern;
 pub mod list_merge;
+pub mod os_count_distinct;
 pub mod take;
 
 pub fn register_all(ctx: &SessionContext) {
     take::register_all(ctx);
     list_merge::register_all(ctx);
     internal_pattern::register_all(ctx);
+    os_count_distinct::register_all(ctx);
 }

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/udaf/os_count_distinct.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/udaf/os_count_distinct.rs
@@ -1,0 +1,333 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+//! `os_count_distinct(x)` — exact distinct count for use in a window context.
+//!
+//! Why this UDAF exists: DataFusion 54.x's substrait crate drops the
+//! `AggregationInvocation::DISTINCT` bit on window aggregates (the consumer
+//! hardcodes `distinct: false` and the producer writes `invocation: 0`). A
+//! plain `count(DISTINCT x) OVER(...)` therefore reaches the executor as a
+//! plain `count(x)`. By encoding DISTINCT in the *operator name* instead of
+//! the invocation enum, we sidestep the bug without vendoring a fork of
+//! `datafusion-substrait`.
+//!
+//! Semantics: emits the count of distinct, non-null values per group / per
+//! frame. NULL inputs are skipped — matches `count(DISTINCT x)` SQL semantics
+//! and the running cumulative behavior expected by `OVER(ORDER BY)`.
+//!
+//! Distributed correctness: state is `List<value>` (the dedup'd set), so
+//! `merge_batch` unions per-shard sets. PARTIAL emits the dedup'd values,
+//! FINAL re-unions and counts.
+
+use std::collections::HashSet;
+use std::fmt::{Debug, Formatter};
+use std::hash::{Hash, Hasher};
+use std::sync::Arc;
+
+use datafusion::arrow::array::{Array, ArrayRef, AsArray, ListArray};
+use datafusion::arrow::datatypes::{DataType, Field, FieldRef};
+use datafusion::common::{exec_err, Result, ScalarValue};
+use datafusion::execution::context::SessionContext;
+use datafusion::logical_expr::function::{AccumulatorArgs, StateFieldsArgs};
+use datafusion::logical_expr::{Accumulator, AggregateUDF, AggregateUDFImpl, Signature, Volatility};
+
+pub fn register_all(ctx: &SessionContext) {
+    ctx.register_udaf(AggregateUDF::from(OsCountDistinctUdaf::new()));
+}
+
+#[derive(Debug)]
+pub struct OsCountDistinctUdaf {
+    signature: Signature,
+}
+
+impl OsCountDistinctUdaf {
+    pub fn new() -> Self {
+        Self { signature: Signature::any(1, Volatility::Immutable) }
+    }
+}
+
+impl Default for OsCountDistinctUdaf {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PartialEq for OsCountDistinctUdaf {
+    fn eq(&self, _other: &Self) -> bool {
+        true
+    }
+}
+impl Eq for OsCountDistinctUdaf {}
+impl Hash for OsCountDistinctUdaf {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        "os_count_distinct".hash(state);
+    }
+}
+
+/// If `dt` is a list type, return its element type; otherwise return `dt`.
+/// PARTIAL sees the raw element column; FINAL sees a `List<element>` carrying
+/// each shard's dedup'd state. Both paths land in the same accumulator.
+fn inner_element_type(dt: &DataType) -> DataType {
+    match dt {
+        DataType::List(field) | DataType::LargeList(field) => field.data_type().clone(),
+        DataType::FixedSizeList(field, _) => field.data_type().clone(),
+        other => other.clone(),
+    }
+}
+
+impl AggregateUDFImpl for OsCountDistinctUdaf {
+    fn name(&self) -> &str {
+        "os_count_distinct"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, _arg_types: &[DataType]) -> Result<DataType> {
+        Ok(DataType::Int64)
+    }
+
+    fn accumulator(&self, acc_args: AccumulatorArgs) -> Result<Box<dyn Accumulator>> {
+        let raw_arg0 = acc_args
+            .exprs
+            .first()
+            .map(|e| e.data_type(acc_args.schema))
+            .transpose()?
+            .ok_or_else(|| {
+                datafusion::common::DataFusionError::Execution(
+                    "os_count_distinct: missing argument".to_string(),
+                )
+            })?;
+        let arg0_is_list = matches!(
+            raw_arg0,
+            DataType::List(_) | DataType::LargeList(_) | DataType::FixedSizeList(_, _),
+        );
+        let element_type = inner_element_type(&raw_arg0);
+        Ok(Box::new(OsCountDistinctAccumulator::new(element_type, arg0_is_list)))
+    }
+
+    fn state_fields(&self, args: StateFieldsArgs) -> Result<Vec<FieldRef>> {
+        // State is the dedup'd value set so merge_batch can union shard sets
+        // and recount on the coordinator. Reusing the input's element type
+        // avoids re-introducing a list of i64 counts (which would lose
+        // distinct semantics across shards).
+        let element_type = match args.input_fields.first() {
+            Some(f) => inner_element_type(f.data_type()),
+            None => {
+                return exec_err!("os_count_distinct: state_fields needs at least one input field")
+            }
+        };
+        Ok(vec![Arc::new(Field::new(
+            format!("{}[set]", args.name),
+            DataType::List(Arc::new(Field::new("item", element_type, true))),
+            true,
+        ))])
+    }
+}
+
+pub struct OsCountDistinctAccumulator {
+    element_type: DataType,
+    seen: HashSet<ScalarValue>,
+    /// True when arg 0 is a list column (FINAL stage) — `update_batch` must
+    /// un-nest each list-row into individual elements rather than treating the
+    /// whole list as a single value.
+    arg0_is_list: bool,
+}
+
+impl OsCountDistinctAccumulator {
+    pub fn new(element_type: DataType, arg0_is_list: bool) -> Self {
+        Self { element_type, seen: HashSet::new(), arg0_is_list }
+    }
+
+    fn add_from_array(&mut self, col: &ArrayRef) -> Result<()> {
+        for i in 0..col.len() {
+            if col.is_null(i) {
+                continue;
+            }
+            self.seen.insert(ScalarValue::try_from_array(col, i)?);
+        }
+        Ok(())
+    }
+
+    fn add_from_list(&mut self, col: &ArrayRef) -> Result<()> {
+        let lists: &ListArray = col.as_list();
+        for i in 0..lists.len() {
+            if lists.is_null(i) {
+                continue;
+            }
+            let inner = lists.value(i);
+            for j in 0..inner.len() {
+                if inner.is_null(j) {
+                    continue;
+                }
+                self.seen.insert(ScalarValue::try_from_array(&inner, j)?);
+            }
+        }
+        Ok(())
+    }
+}
+
+impl Debug for OsCountDistinctAccumulator {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OsCountDistinctAccumulator")
+            .field("len", &self.seen.len())
+            .finish()
+    }
+}
+
+impl Accumulator for OsCountDistinctAccumulator {
+    fn update_batch(&mut self, values: &[ArrayRef]) -> Result<()> {
+        if values.is_empty() {
+            return Ok(());
+        }
+        let col = &values[0];
+        if self.arg0_is_list {
+            self.add_from_list(col)
+        } else {
+            self.add_from_array(col)
+        }
+    }
+
+    fn evaluate(&mut self) -> Result<ScalarValue> {
+        Ok(ScalarValue::Int64(Some(self.seen.len() as i64)))
+    }
+
+    fn size(&self) -> usize {
+        std::mem::size_of_val(self) + self.seen.iter().map(|s| s.size()).sum::<usize>()
+    }
+
+    fn state(&mut self) -> Result<Vec<ScalarValue>> {
+        let values: Vec<ScalarValue> = self.seen.iter().cloned().collect();
+        let arr = ScalarValue::new_list_nullable(&values, &self.element_type);
+        Ok(vec![ScalarValue::List(arr)])
+    }
+
+    fn merge_batch(&mut self, states: &[ArrayRef]) -> Result<()> {
+        if states.is_empty() {
+            return Ok(());
+        }
+        self.add_from_list(&states[0])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::arrow::array::{Int32Array, StringArray};
+
+    fn run_int_batches(batches: &[&[Option<i32>]]) -> i64 {
+        let mut acc = OsCountDistinctAccumulator::new(DataType::Int32, false);
+        for b in batches {
+            let arr: ArrayRef = Arc::new(Int32Array::from_iter(b.iter().copied()));
+            acc.update_batch(&[arr]).unwrap();
+        }
+        match acc.evaluate().unwrap() {
+            ScalarValue::Int64(Some(n)) => n,
+            other => panic!("expected Int64, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn counts_distinct_non_null_values() {
+        // {1, 2, 3} → 3
+        let n = run_int_batches(&[&[Some(1), Some(2), Some(2), Some(3), Some(1)]]);
+        assert_eq!(n, 3);
+    }
+
+    #[test]
+    fn skips_nulls() {
+        // {1, 2} (None ignored) → 2
+        let n = run_int_batches(&[&[Some(1), None, Some(2), None, Some(1)]]);
+        assert_eq!(n, 2);
+    }
+
+    #[test]
+    fn dedupes_across_batches() {
+        // {1, 2, 3} → 3
+        let n = run_int_batches(&[&[Some(1), Some(2)], &[Some(2), Some(3)]]);
+        assert_eq!(n, 3);
+    }
+
+    #[test]
+    fn empty_input_returns_zero() {
+        let n = run_int_batches(&[&[]]);
+        assert_eq!(n, 0);
+    }
+
+    #[test]
+    fn all_nulls_return_zero() {
+        let n = run_int_batches(&[&[None, None, None]]);
+        assert_eq!(n, 0);
+    }
+
+    #[test]
+    fn merge_unions_per_shard_states() {
+        let mut s1 = OsCountDistinctAccumulator::new(DataType::Int32, false);
+        s1.update_batch(&[Arc::new(Int32Array::from(vec![Some(1), Some(2)])) as ArrayRef])
+            .unwrap();
+        let mut s2 = OsCountDistinctAccumulator::new(DataType::Int32, false);
+        s2.update_batch(&[Arc::new(Int32Array::from(vec![Some(2), Some(3), Some(4)])) as ArrayRef])
+            .unwrap();
+
+        let st1: ArrayRef = match s1.state().unwrap().pop().unwrap() {
+            ScalarValue::List(l) => l,
+            o => panic!("expected list state, got {o:?}"),
+        };
+        let st2: ArrayRef = match s2.state().unwrap().pop().unwrap() {
+            ScalarValue::List(l) => l,
+            o => panic!("expected list state, got {o:?}"),
+        };
+        let combined: ArrayRef =
+            datafusion::arrow::compute::concat(&[st1.as_ref(), st2.as_ref()]).unwrap();
+
+        let mut coord = OsCountDistinctAccumulator::new(DataType::Int32, false);
+        coord.merge_batch(&[combined]).unwrap();
+        match coord.evaluate().unwrap() {
+            // {1, 2, 3, 4} → 4
+            ScalarValue::Int64(Some(n)) => assert_eq!(n, 4),
+            o => panic!("expected Int64, got {o:?}"),
+        }
+    }
+
+    #[test]
+    fn final_shape_un_nests_list_input_rows() {
+        let mut shard1 = OsCountDistinctAccumulator::new(DataType::Utf8, false);
+        shard1
+            .update_batch(&[
+                Arc::new(StringArray::from(vec![Some("a"), Some("b"), Some("a")])) as ArrayRef
+            ])
+            .unwrap();
+        let mut shard2 = OsCountDistinctAccumulator::new(DataType::Utf8, false);
+        shard2
+            .update_batch(&[
+                Arc::new(StringArray::from(vec![Some("b"), Some("c")])) as ArrayRef
+            ])
+            .unwrap();
+        let s1: ArrayRef = match shard1.state().unwrap().pop().unwrap() {
+            ScalarValue::List(l) => l,
+            o => panic!("expected list, got {o:?}"),
+        };
+        let s2: ArrayRef = match shard2.state().unwrap().pop().unwrap() {
+            ScalarValue::List(l) => l,
+            o => panic!("expected list, got {o:?}"),
+        };
+        let combined: ArrayRef =
+            datafusion::arrow::compute::concat(&[s1.as_ref(), s2.as_ref()]).unwrap();
+
+        // FINAL stage: arg0_is_list=true, drives update_batch on the
+        // List-typed column rather than merge_batch.
+        let mut coord = OsCountDistinctAccumulator::new(DataType::Utf8, true);
+        coord.update_batch(&[combined]).unwrap();
+        match coord.evaluate().unwrap() {
+            // {a, b, c} → 3
+            ScalarValue::Int64(Some(n)) => assert_eq!(n, 3),
+            o => panic!("expected Int64, got {o:?}"),
+        }
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionAnalyticsBackendPlugin.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionAnalyticsBackendPlugin.java
@@ -553,7 +553,11 @@ public class DataFusionAnalyticsBackendPlugin implements AnalyticsSearchBackendP
                     WindowFunction.ARG_MAX,
                     WindowFunctionAdapters.argMax(),
                     WindowFunction.DISTINCT_COUNT_APPROX,
-                    WindowFunctionAdapters.distinctCountApprox()
+                    WindowFunctionAdapters.distinctCountApprox(),
+                    // COUNT(DISTINCT x) OVER(...) → os_count_distinct(x) OVER(...). Non-distinct
+                    // COUNT(x) passes through unchanged.
+                    WindowFunction.COUNT,
+                    WindowFunctionAdapters.countDistinctExact()
                 );
             }
 

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionFragmentConvertor.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionFragmentConvertor.java
@@ -407,6 +407,26 @@ public class DataFusionFragmentConvertor implements FragmentConvertor {
     ) {
     };
 
+    /**
+     * Exact distinct count for use in a window context — replaces
+     * {@code count(distinct x) OVER(...)} via {@link WindowFunctionAdapters#countDistinctExact()}.
+     * Encoding DISTINCT in the operator name avoids the dropped-DISTINCT bug in DataFusion 54.x's
+     * substrait window consumer. Custom Rust UDAF in {@code rust/src/udaf/os_count_distinct.rs}.
+     */
+    static final SqlAggFunction LOCAL_OS_COUNT_DISTINCT_OP = new SqlAggFunction(
+        "os_count_distinct",
+        null,
+        SqlKind.OTHER_FUNCTION,
+        ReturnTypes.BIGINT,
+        null,
+        OperandTypes.ANY,
+        SqlFunctionCategory.USER_DEFINED_FUNCTION,
+        false,
+        false,
+        Optionality.FORBIDDEN
+    ) {
+    };
+
     private static final List<FunctionMappings.Sig> ADDITIONAL_AGGREGATE_SIGS = List.of(
         FunctionMappings.s(SqlStdOperatorTable.APPROX_COUNT_DISTINCT, "approx_distinct"),
         FunctionMappings.s(LOCAL_TAKE_OP, "take"),
@@ -416,13 +436,15 @@ public class DataFusionFragmentConvertor implements FragmentConvertor {
         FunctionMappings.s(LOCAL_LIST_MERGE_OP, "list_merge"),
         FunctionMappings.s(LOCAL_LIST_MERGE_DISTINCT_OP, "list_merge_distinct"),
         FunctionMappings.s(LOCAL_PERCENTILE_APPROX_OP, "approx_percentile_cont"),
-        FunctionMappings.s(LOCAL_INTERNAL_PATTERN_OP, "internal_pattern")
+        FunctionMappings.s(LOCAL_INTERNAL_PATTERN_OP, "internal_pattern"),
+        FunctionMappings.s(LOCAL_OS_COUNT_DISTINCT_OP, "os_count_distinct")
     );
 
     private static final List<FunctionMappings.Sig> ADDITIONAL_WINDOW_SIGS = List.of(
         FunctionMappings.s(LOCAL_INTERNAL_PATTERN_WINDOW_OP, "internal_pattern"),
         // Mirror ADDITIONAL_AGGREGATE_SIGS: rename APPROX_COUNT_DISTINCT to DataFusion's `approx_distinct`.
-        FunctionMappings.s(SqlStdOperatorTable.APPROX_COUNT_DISTINCT, "approx_distinct")
+        FunctionMappings.s(SqlStdOperatorTable.APPROX_COUNT_DISTINCT, "approx_distinct"),
+        FunctionMappings.s(LOCAL_OS_COUNT_DISTINCT_OP, "os_count_distinct")
     );
 
     /**

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/WindowFunctionAdapters.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/WindowFunctionAdapters.java
@@ -28,10 +28,13 @@ import java.util.List;
  * <ul>
  *   <li>{@link #argMin()} / {@link #argMax()} — {@code ARG_MIN/MAX(value, ts)} →
  *       {@code FIRST_VALUE/LAST_VALUE(value) ORDER BY ts ASC} (no native arg_min/max UDAF in DataFusion 53.x).</li>
- *   <li>{@link #distinctCountApprox()} — {@code DISTINCT_COUNT_APPROX(x)} → Calcite
+ *   <li>{@link #distinctCountApprox()} — PPL {@code DISTINCT_COUNT_APPROX(x)} → Calcite
  *       {@code APPROX_COUNT_DISTINCT(x)}, which the convertor renames to substrait {@code approx_distinct}
- *       (DataFusion's built-in HLL UDAF). Direct rewrite to {@code COUNT(DISTINCT x)} is unsafe — the
- *       DataFusion substrait consumer drops the DISTINCT flag on window functions.</li>
+ *       (DataFusion's built-in HLL UDAF).</li>
+ *   <li>{@link #countDistinctExact()} — {@code COUNT(DISTINCT x) OVER(...)} → sandbox
+ *       {@code os_count_distinct(x)}. DataFusion 54.x's substrait window consumer drops the
+ *       {@code AggregationInvocation::DISTINCT} bit, so a vanilla COUNT-with-distinct lowers to
+ *       a plain non-distinct COUNT. Encoding DISTINCT in the operator name sidesteps the bug.</li>
  * </ul>
  *
  * @opensearch.internal
@@ -58,6 +61,30 @@ final class WindowFunctionAdapters {
             over.isDistinct(),
             cluster
         );
+    }
+
+    /**
+     * Replaces {@code COUNT(DISTINCT x) OVER(...)} with {@code os_count_distinct(x) OVER(...)}.
+     * Non-distinct {@code COUNT(x) OVER(...)} passes through unchanged. The distinct flag is
+     * cleared on the rebuilt RexOver because it's already encoded in the operator name —
+     * leaving it set would emit a substrait operator named {@code os_count_distinct} carrying a
+     * redundant {@code AggregationInvocation::DISTINCT} bit.
+     */
+    static WindowFunctionAdapter countDistinctExact() {
+        return (over, operands, partitions, orderKeys, cluster) -> {
+            if (!over.isDistinct()) {
+                return rebuild(over, over.getAggOperator(), operands, partitions, orderKeys, /* distinct */ false, cluster);
+            }
+            return rebuild(
+                over,
+                DataFusionFragmentConvertor.LOCAL_OS_COUNT_DISTINCT_OP,
+                operands,
+                partitions,
+                orderKeys,
+                /* distinct */ false,
+                cluster
+            );
+        };
     }
 
     /** Rewrites {@code ARG_MIN(value, ts)} / {@code ARG_MAX(value, ts)} to

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/resources/opensearch_aggregate_functions.yaml
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/resources/opensearch_aggregate_functions.yaml
@@ -117,6 +117,19 @@ aggregate_functions:
           - name: percentile
             value: any2
         return: any1
+  - name: os_count_distinct
+    description: >-
+      Exact distinct count for use in a window context. PPL
+      `count(distinct x) OVER(...)` would normally lower to substrait `count`
+      with `AggregationInvocation::DISTINCT`, but DataFusion 54.x's substrait
+      consumer drops that bit on window functions. Routing through this named
+      UDAF encodes DISTINCT in the operator name, sidestepping the bug.
+      Custom Rust UDAF in `rust/src/udaf/os_count_distinct.rs`.
+    impls:
+      - args:
+          - name: x
+            value: any
+        return: i64
   - name: internal_pattern
     description: >-
       PPL `patterns ... method=BRAIN` (aggregation mode). Custom Rust UDAF in

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/resources/opensearch_window_functions.yaml
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/resources/opensearch_window_functions.yaml
@@ -2,6 +2,22 @@
 ---
 urn: extension:org.opensearch:window_functions
 window_functions:
+  - name: os_count_distinct
+    description: >-
+      Window form of `os_count_distinct(x)`. Emitted as the substrait window
+      function for `count(distinct x) OVER(...)` (a partner of the like-named
+      aggregate UDAF) so the operator name carries DISTINCT semantics — see
+      `os_count_distinct` in `opensearch_aggregate_functions.yaml` for the
+      rationale (DataFusion 54.x's substrait window consumer drops the
+      AggregationInvocation::DISTINCT bit).
+    impls:
+      - args:
+          - name: x
+            value: any
+        decomposable: MANY
+        intermediate: any?
+        return: i64
+        window_type: STREAMING
   - name: internal_pattern
     description: >-
       PPL `patterns ... method=BRAIN mode=label`. Window form of

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/WindowFunctionAdaptersTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/WindowFunctionAdaptersTests.java
@@ -41,6 +41,8 @@ import java.util.List;
  *   <li>{@code ARG_MIN(value, ts)} → {@code FIRST_VALUE(value) ORDER BY ts ASC}</li>
  *   <li>{@code ARG_MAX(value, ts)} → {@code LAST_VALUE(value) ORDER BY ts ASC}</li>
  *   <li>{@code DISTINCT_COUNT_APPROX(x)} → {@code APPROX_COUNT_DISTINCT(x)}</li>
+ *   <li>{@code COUNT(DISTINCT x) OVER(...)} → {@code os_count_distinct(x) OVER(...)}</li>
+ *   <li>{@code COUNT(x) OVER(...)} (non-distinct) — passthrough, distinct flag stays cleared</li>
  * </ul>
  */
 public class WindowFunctionAdaptersTests extends OpenSearchTestCase {
@@ -179,6 +181,63 @@ public class WindowFunctionAdaptersTests extends OpenSearchTestCase {
         assertEquals("rewritten call's return type must equal the original", original.getType(), over.getType());
     }
 
+    /** {@code COUNT(DISTINCT x) OVER(...)} → {@code os_count_distinct(x) OVER(...)} with the
+     *  distinct flag cleared on the rebuilt RexOver (the operator name now carries the DISTINCT
+     *  semantic). Pinning this contract guards the workaround for DataFusion 54.x's substrait
+     *  window consumer that drops {@code AggregationInvocation::DISTINCT}. */
+    public void testCountDistinctRewritesToOsCountDistinct() {
+        RexNode argument = rexBuilder.makeInputRef(varcharNullable, 0);
+        RexNode partitionKey = rexBuilder.makeInputRef(varcharNullable, 1);
+        RexFieldCollation orderKey = new RexFieldCollation(rexBuilder.makeInputRef(varcharNullable, 2), Collections.emptySet());
+
+        RexOver original = (RexOver) makeOver(
+            SqlStdOperatorTable.COUNT,
+            bigintNullable,
+            List.of(argument),
+            List.of(partitionKey),
+            ImmutableList.of(orderKey),
+            /* distinct */ true
+        );
+
+        RexNode adapted = WindowFunctionAdapters.countDistinctExact()
+            .adapt(original, List.of(argument), List.of(partitionKey), List.of(orderKey), cluster);
+
+        RexOver over = (RexOver) adapted;
+        assertSame(
+            "COUNT(DISTINCT) must rewrite to LOCAL_OS_COUNT_DISTINCT_OP",
+            DataFusionFragmentConvertor.LOCAL_OS_COUNT_DISTINCT_OP,
+            over.getAggOperator()
+        );
+        assertFalse("distinct flag must be cleared on the rebuilt over", over.isDistinct());
+        assertEquals("operand list must be preserved", List.of(argument), over.getOperands());
+        assertEquals("partition keys must be preserved", List.of(partitionKey), over.getWindow().partitionKeys);
+        assertEquals("order keys must be preserved", 1, over.getWindow().orderKeys.size());
+        assertEquals("rewritten call's return type must equal the original", original.getType(), over.getType());
+    }
+
+    /** {@code COUNT(x) OVER(...)} (non-distinct) — must pass through unchanged. The adapter
+     *  is registered for {@link org.opensearch.analytics.spi.WindowFunction#COUNT} so it sees
+     *  every COUNT-OVER call; only DISTINCT-flagged ones get rewritten. */
+    public void testNonDistinctCountIsPassthrough() {
+        RexNode argument = rexBuilder.makeInputRef(varcharNullable, 0);
+
+        RexOver original = (RexOver) makeOver(
+            SqlStdOperatorTable.COUNT,
+            bigintNullable,
+            List.of(argument),
+            ImmutableList.of(),
+            ImmutableList.of(),
+            /* distinct */ false
+        );
+
+        RexNode adapted = WindowFunctionAdapters.countDistinctExact()
+            .adapt(original, List.of(argument), ImmutableList.of(), ImmutableList.of(), cluster);
+
+        RexOver over = (RexOver) adapted;
+        assertSame("non-distinct COUNT must keep its operator", SqlStdOperatorTable.COUNT, over.getAggOperator());
+        assertFalse("non-distinct COUNT must remain non-distinct", over.isDistinct());
+    }
+
     /** Build a {@link RexOver} with the given function, operand list, partition keys, order keys,
      *  and an UNBOUNDED PRECEDING / UNBOUNDED FOLLOWING frame — the default frame eventstats
      *  uses for ARG_MIN/ARG_MAX/DISTINCT_COUNT_APPROX. The 13-arg {@link RexBuilder#makeOver}
@@ -190,6 +249,17 @@ public class WindowFunctionAdaptersTests extends OpenSearchTestCase {
         List<RexNode> operands,
         List<RexNode> partitions,
         List<RexFieldCollation> orderKeys
+    ) {
+        return makeOver(op, returnType, operands, partitions, orderKeys, /* distinct */ false);
+    }
+
+    private RexNode makeOver(
+        SqlAggFunction op,
+        RelDataType returnType,
+        List<RexNode> operands,
+        List<RexNode> partitions,
+        List<RexFieldCollation> orderKeys,
+        boolean distinct
     ) {
         return rexBuilder.makeOver(
             returnType,
@@ -203,7 +273,7 @@ public class WindowFunctionAdaptersTests extends OpenSearchTestCase {
             true,
             true,
             false,
-            false,
+            distinct,
             false
         );
     }

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/AnalyticsRestTestCase.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/AnalyticsRestTestCase.java
@@ -125,6 +125,18 @@ public abstract class AnalyticsRestTestCase extends OpenSearchRestTestCase {
     }
 
     /**
+     * Execute a SQL query against the real opensearch-sql plugin at {@code /_plugins/_sql},
+     * asserting HTTP 200 and returning the parsed JSON body. Same {@code @Before} provisioning
+     * hook flow as {@link #executePpl(String)} — subclasses don't need to ensure datasets here.
+     */
+    protected Map<String, Object> executeSql(String sql) throws IOException {
+        Request request = new Request("POST", "/_plugins/_sql");
+        request.setJsonEntity("{\"query\": \"" + escapeJson(sql) + "\"}");
+        Response response = client().performRequest(request);
+        return assertOkAndParse(response, "SQL: " + sql);
+    }
+
+    /**
      * Execute a PPL query against the {@code test-ppl-frontend} shim at {@code /_analytics/ppl}.
      * Use this for tests that exercise <em>engine-internal</em> behavior (e.g. perf-delegation
      * marker placement, explain output shape) where the opensearch-sql plugin's user-facing PPL

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/WindowCountDistinctIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/WindowCountDistinctIT.java
@@ -1,0 +1,229 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.qa;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Integration test for {@code COUNT(DISTINCT x) OVER(...)} on the analytics-engine route.
+ *
+ * <p>DataFusion 54.x's substrait window consumer hardcodes {@code distinct: false} on
+ * window-aggregate calls (see
+ * {@code datafusion/substrait/src/logical_plan/consumer/expr/window_function.rs:116}),
+ * so a vanilla {@code COUNT(DISTINCT x) OVER(...)} would lower to a plain non-distinct
+ * COUNT. The DataFusion plugin's {@link org.opensearch.be.datafusion.WindowFunctionAdapters}
+ * rewrites the call to a sandbox-namespace UDAF {@code os_count_distinct(x)}, encoding
+ * DISTINCT in the operator name so the bug doesn't matter. This IT pins the three failing
+ * shapes from {@code WindowFunctionIT} (sql plugin):
+ * <ul>
+ *   <li>{@code OVER(ORDER BY ...)} — running cumulative distinct count</li>
+ *   <li>{@code OVER()} — global distinct count repeated on every row</li>
+ *   <li>{@code OVER(PARTITION BY ... ORDER BY ...)} — per-partition running distinct count</li>
+ * </ul>
+ *
+ * <p>Uses the shared {@code calcs} dataset. {@code str0} (FURNITURE / OFFICE SUPPLIES /
+ * TECHNOLOGY) is a 3-distinct, fully-populated string column; {@code str3} ('e' or null) is
+ * a 1-distinct string column with 7 nulls.
+ */
+public class WindowCountDistinctIT extends AnalyticsRestTestCase {
+
+    private static final Dataset DATASET = new Dataset("calcs", "calcs");
+
+    private static boolean dataProvisioned = false;
+
+    @Override
+    protected void onBeforeQuery() throws IOException {
+        if (dataProvisioned == false) {
+            DatasetProvisioner.provision(client(), DATASET);
+            dataProvisioned = true;
+        }
+    }
+
+    /** {@code COUNT(DISTINCT x) OVER(ORDER BY key)} — running cumulative distinct count.
+     *  str0 has 3 values appearing in key order: FURNITURE (key00..01), OFFICE SUPPLIES
+     *  (key02..07), TECHNOLOGY (key08..16). The running distinct count over str0 walks 1,1,
+     *  then 2 starting at key02, then 3 starting at key08. */
+    public void testCountDistinctOverOrderBy() throws IOException {
+        Map<String, Object> response = executeSql(
+            "SELECT `key`, COUNT(DISTINCT str0) OVER(ORDER BY `key`) AS dc FROM "
+                + DATASET.indexName + " ORDER BY `key`"
+        );
+        assertRowsEqual(
+            response,
+            row("key00", 1L),
+            row("key01", 1L),
+            row("key02", 2L),
+            row("key03", 2L),
+            row("key04", 2L),
+            row("key05", 2L),
+            row("key06", 2L),
+            row("key07", 2L),
+            row("key08", 3L),
+            row("key09", 3L),
+            row("key10", 3L),
+            row("key11", 3L),
+            row("key12", 3L),
+            row("key13", 3L),
+            row("key14", 3L),
+            row("key15", 3L),
+            row("key16", 3L)
+        );
+    }
+
+    /** {@code COUNT(DISTINCT x) OVER()} — global distinct count repeated on every row.
+     *  Calcs has 3 distinct {@code str0} values, so every row returns 3. */
+    public void testCountDistinctOverEmpty() throws IOException {
+        Map<String, Object> response = executeSql(
+            "SELECT `key`, COUNT(DISTINCT str0) OVER() AS dc FROM "
+                + DATASET.indexName + " ORDER BY `key`"
+        );
+        assertRowsEqual(
+            response,
+            row("key00", 3L),
+            row("key01", 3L),
+            row("key02", 3L),
+            row("key03", 3L),
+            row("key04", 3L),
+            row("key05", 3L),
+            row("key06", 3L),
+            row("key07", 3L),
+            row("key08", 3L),
+            row("key09", 3L),
+            row("key10", 3L),
+            row("key11", 3L),
+            row("key12", 3L),
+            row("key13", 3L),
+            row("key14", 3L),
+            row("key15", 3L),
+            row("key16", 3L)
+        );
+    }
+
+    /** {@code COUNT(DISTINCT x) OVER(PARTITION BY ... ORDER BY ...)} — per-partition running
+     *  distinct count. Each {@code str0} partition has exactly one {@code str0} value (the
+     *  partition key itself), so the running distinct count is always 1 within the partition. */
+    public void testCountDistinctOverPartition() throws IOException {
+        Map<String, Object> response = executeSql(
+            "SELECT `key`, str0, COUNT(DISTINCT str0) OVER(PARTITION BY str0 ORDER BY `key`) AS dc"
+                + " FROM " + DATASET.indexName + " ORDER BY str0, `key`"
+        );
+        assertRowsEqual(
+            response,
+            row("key00", "FURNITURE", 1L),
+            row("key01", "FURNITURE", 1L),
+            row("key02", "OFFICE SUPPLIES", 1L),
+            row("key03", "OFFICE SUPPLIES", 1L),
+            row("key04", "OFFICE SUPPLIES", 1L),
+            row("key05", "OFFICE SUPPLIES", 1L),
+            row("key06", "OFFICE SUPPLIES", 1L),
+            row("key07", "OFFICE SUPPLIES", 1L),
+            row("key08", "TECHNOLOGY", 1L),
+            row("key09", "TECHNOLOGY", 1L),
+            row("key10", "TECHNOLOGY", 1L),
+            row("key11", "TECHNOLOGY", 1L),
+            row("key12", "TECHNOLOGY", 1L),
+            row("key13", "TECHNOLOGY", 1L),
+            row("key14", "TECHNOLOGY", 1L),
+            row("key15", "TECHNOLOGY", 1L),
+            row("key16", "TECHNOLOGY", 1L)
+        );
+    }
+
+    /** {@code str3} has 7 nulls + 10 'e' rows. {@code COUNT(DISTINCT str3) OVER(ORDER BY key)}
+     *  should ignore nulls — the running count stays at 1 once the first non-null is seen and
+     *  never increments because there's only one distinct non-null value. */
+    public void testCountDistinctIgnoresNulls() throws IOException {
+        Map<String, Object> response = executeSql(
+            "SELECT `key`, str3, COUNT(DISTINCT str3) OVER(ORDER BY `key`) AS dc FROM "
+                + DATASET.indexName + " ORDER BY `key`"
+        );
+        assertRowsEqual(
+            response,
+            row("key00", "e",  1L),
+            row("key01", "e",  1L),
+            row("key02", "e",  1L),
+            row("key03", "e",  1L),
+            row("key04", null, 1L),
+            row("key05", null, 1L),
+            row("key06", "e",  1L),
+            row("key07", "e",  1L),
+            row("key08", null, 1L),
+            row("key09", "e",  1L),
+            row("key10", "e",  1L),
+            row("key11", null, 1L),
+            row("key12", null, 1L),
+            row("key13", null, 1L),
+            row("key14", "e",  1L),
+            row("key15", "e",  1L),
+            row("key16", null, 1L)
+        );
+    }
+
+    /** Sanity check: non-distinct {@code COUNT(x) OVER(...)} must keep working — the adapter
+     *  is registered for {@link org.opensearch.analytics.spi.WindowFunction#COUNT} so it sees
+     *  every COUNT-OVER call, but only DISTINCT-flagged ones get rewritten to os_count_distinct. */
+    public void testNonDistinctCountOverIsUnaffected() throws IOException {
+        Map<String, Object> response = executeSql(
+            "SELECT `key`, COUNT(str0) OVER(ORDER BY `key`) AS cnt FROM "
+                + DATASET.indexName + " ORDER BY `key`"
+        );
+        assertRowsEqual(
+            response,
+            row("key00", 1L),
+            row("key01", 2L),
+            row("key02", 3L),
+            row("key03", 4L),
+            row("key04", 5L),
+            row("key05", 6L),
+            row("key06", 7L),
+            row("key07", 8L),
+            row("key08", 9L),
+            row("key09", 10L),
+            row("key10", 11L),
+            row("key11", 12L),
+            row("key12", 13L),
+            row("key13", 14L),
+            row("key14", 15L),
+            row("key15", 16L),
+            row("key16", 17L)
+        );
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────────────
+
+    private static List<Object> row(Object... values) {
+        return Arrays.asList(values);
+    }
+
+    @SafeVarargs
+    @SuppressWarnings({"unchecked", "varargs"})
+    private final void assertRowsEqual(Map<String, Object> response, List<Object>... expected) {
+        List<List<Object>> actualRows = (List<List<Object>>) response.get("datarows");
+        assertNotNull("Response missing 'datarows'", actualRows);
+        assertEquals("Row count mismatch", expected.length, actualRows.size());
+        for (int i = 0; i < expected.length; i++) {
+            List<Object> want = expected[i];
+            List<Object> got = actualRows.get(i);
+            assertEquals("Column count mismatch at row " + i, want.size(), got.size());
+            for (int j = 0; j < want.size(); j++) {
+                assertEquals("Cell mismatch at row " + i + ", col " + j,
+                    normalize(want.get(j)), normalize(got.get(j)));
+            }
+        }
+    }
+
+    /** Jackson returns Integer/Long interchangeably — coerce to Long for COUNT comparisons. */
+    private static Object normalize(Object v) {
+        if (v instanceof Number n) return n.longValue();
+        return v;
+    }
+}


### PR DESCRIPTION
<table><tr><td width="1400">

## What changed

Adds an `os_count_distinct(x)` aggregate UDF to the DataFusion analytics backend, plus a planner-side adapter that rewrites `COUNT(DISTINCT x) OVER(...)` into `os_count_distinct(x) OVER(...)` before substrait emission. Non-distinct `COUNT(x) OVER(...)` passes through unchanged.

## Why

DataFusion 54.x's `datafusion-substrait` consumer hardcodes `distinct: false` on window-aggregate calls (`datafusion/substrait/src/logical_plan/consumer/expr/window_function.rs:116`), and the producer destructure-discards the same field (`producer/expr/window_function.rs:45,99`, with a `// TODO: fix`). Result: a vanilla `COUNT(DISTINCT x) OVER(...)` reaches the executor as a plain non-distinct `COUNT`, returning the wrong rows.

Every JVM-side layer threads DISTINCT to the wire correctly; the bug is purely in DataFusion's substrait crate. Vendoring or forking that crate would work but adds a sustained maintenance tax. Encoding DISTINCT in the operator *name* — by routing through a sandbox-namespace UDAF — sidesteps the consumer's broken `invocation` field and ships entirely inside the sandbox tree.

## Semantics

`os_count_distinct(x)` returns the count of distinct, non-null values:

| Input | Output |
|---|---|
| `{}` (empty) | 0 |
| `{NULL, NULL}` | 0 |
| `{1, 1, 2}` | 2 |
| `{1, NULL, 2, NULL, 1}` | 2 |

Cross-shard correctness: state is `List<element>` (the dedup'd value set). PARTIAL emits the per-shard set; FINAL unions the lists and recounts on the coordinator. NULLs are skipped at every stage, matching SQL `COUNT(DISTINCT x)` semantics.

## Query shapes supported

| Shape | Example |
|---|---|
| `OVER(ORDER BY ...)` running cumulative distinct count | `SELECT k, COUNT(DISTINCT g) OVER(ORDER BY k) FROM t` |
| `OVER()` global distinct count repeated on every row | `SELECT k, COUNT(DISTINCT g) OVER() FROM t` |
| `OVER(PARTITION BY ... ORDER BY ...)` per-partition running distinct count | `SELECT k, COUNT(DISTINCT g) OVER(PARTITION BY p ORDER BY k) FROM t` |
| Non-distinct passthrough — adapter is a no-op | `SELECT k, COUNT(g) OVER(ORDER BY k) FROM t` |

## PPL Calcite tests in opensearch-project/sql unblocked

- `WindowFunctionIT.testDistinctCountOver`
- `WindowFunctionIT.testDistinctCountOverNull`
- `WindowFunctionIT.testDistinctCountPartition`

These are the three failing cases that previously returned plain non-distinct counts because the substrait window invocation field was dropped.

## Tests

- `udaf::os_count_distinct::tests` — 7 Rust unit tests cover dedup, null skipping, multi-batch accumulation, cross-shard merge, and the FINAL list-input shape.
- `WindowFunctionAdaptersTests` — 2 new Java unit tests pin the rewrite contract: `COUNT(DISTINCT)` rebinds to `LOCAL_OS_COUNT_DISTINCT_OP` with the distinct flag cleared, and non-distinct `COUNT` passes through.
- `WindowCountDistinctIT` — sandbox QA IT covering the three failing test shapes plus null handling and non-distinct passthrough on the shared `calcs` dataset (`/_plugins/_sql` route).

## Test plan

- [x] Rust UDAF unit tests pass (`cargo test --lib udaf::os_count_distinct`)
- [x] Java adapter unit tests pass (`./gradlew :sandbox:plugins:analytics-backend-datafusion:test --tests WindowFunctionAdaptersTests`)
- [x] Live verified on Variant B (2-node, `-PrustDebug`) with `calcs` ingested:
  - `COUNT(DISTINCT str0) OVER(ORDER BY key)` → 1,1,2,2,...,3
  - `COUNT(DISTINCT str0) OVER()` → 3 on every row
  - `COUNT(DISTINCT str0) OVER(PARTITION BY str0 ORDER BY key)` → 1 within each partition
  - `COUNT(DISTINCT str3) OVER(ORDER BY key)` (str3 has nulls) → 1 once first non-null seen
  - `COUNT(str0) OVER(ORDER BY key)` (passthrough) → 1..17
- [x] `:precommit` clean on `analytics-backend-datafusion` and `analytics-engine`

</td></tr></table>