### PR TITLE
[Backport 3.1] Fix default SSE type to send AES256 header

### DIFF
--- a/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3Repository.java
+++ b/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3Repository.java
@@ -131,7 +131,7 @@ class S3Repository extends MeteredBlobStoreRepository {
      */
     static final Setting<String> SERVER_SIDE_ENCRYPTION_TYPE_SETTING = Setting.simpleString(
         "server_side_encryption_type",
-        BUCKET_DEFAULT_ENCRYPTION_TYPE,
+        ServerSideEncryption.AES256.toString(),
         value -> {
             if (!(value.equals(ServerSideEncryption.AES256.toString())
                 || value.equals(ServerSideEncryption.AWS_KMS.toString())


### PR DESCRIPTION
 ### Description
  Backport of #22144 to 3.1 branch.
  
  Changes the default value of `server_side_encryption_type` from `bucket_default` to `AES256` to ensure the encryption header is always sent on S3 PutObject requests.
  
  ### Related Issues
  Backport of https://github.com/opensearch-project/OpenSearch/pull/22144
    
  By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
  For more information on following Developer Certificate of Origin and signing off your commits, please check
  [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).