### PR TITLE
[Performance] Ensure that Partial Aggs go below the Exchange for Multiple predicate Filter

### DIFF
--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rel/OpenSearchAggregate.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rel/OpenSearchAggregate.java
@@ -298,10 +298,7 @@ public class OpenSearchAggregate extends Aggregate implements OpenSearchRelNode 
             boolean inputIsSingleton = distribution.getType() == RelDistribution.Type.SINGLETON
                 || distribution.getType() == RelDistribution.Type.ANY;
 
-            // SINGLE must sit over gathered input (partitioned input → shards aggregate in
-            // isolation, partials never merge). PARTIAL must sit over partitioned input
-            // (over gathered input it is a no-op that beats the correct shard-PARTIAL+ER on a
-            // cost tie). Reject the wrong placement for each.
+            // Prices a SINGLE over partitioned input out (infinite cost) so it's never chosen.
             if (mode == AggregateMode.SINGLE && !inputIsSingleton) {
                 return planner.getCostFactory().makeInfiniteCost();
             }

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rel/OpenSearchAggregate.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rel/OpenSearchAggregate.java
@@ -292,15 +292,22 @@ public class OpenSearchAggregate extends Aggregate implements OpenSearchRelNode 
      */
     @Override
     public RelOptCost computeSelfCost(RelOptPlanner planner, RelMetadataQuery mq) {
-        if (mode == AggregateMode.SINGLE) {
-            for (int index = 0; index < getInput().getTraitSet().size(); index++) {
-                RelTrait trait = getInput().getTraitSet().getTrait(index);
-                if (!(trait instanceof OpenSearchDistribution distribution)) continue;
-                boolean singletonOrAny = distribution.getType() == RelDistribution.Type.SINGLETON
-                    || distribution.getType() == RelDistribution.Type.ANY;
-                if (!singletonOrAny) {
-                    return planner.getCostFactory().makeInfiniteCost();
-                }
+        for (int index = 0; index < getInput().getTraitSet().size(); index++) {
+            RelTrait trait = getInput().getTraitSet().getTrait(index);
+            if (!(trait instanceof OpenSearchDistribution distribution)) continue;
+            boolean inputIsSingleton = distribution.getType() == RelDistribution.Type.SINGLETON
+                || distribution.getType() == RelDistribution.Type.ANY;
+
+            // SINGLE must sit over gathered input (partitioned input → shards aggregate in
+            // isolation, partials never merge). PARTIAL must sit over partitioned input
+            // (over gathered input it is a no-op that beats the correct shard-PARTIAL+ER on a
+            // cost tie). Reject the wrong placement for each.
+            if (mode == AggregateMode.SINGLE && !inputIsSingleton) {
+                return planner.getCostFactory().makeInfiniteCost();
+            }
+            // Prices a PARTIAL above the Exchange out (infinite cost) so it's never chosen.
+            if (mode == AggregateMode.PARTIAL && inputIsSingleton) {
+                return planner.getCostFactory().makeInfiniteCost();
             }
         }
         return planner.getCostFactory().makeTinyCost();

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchAggregateSplitRule.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchAggregateSplitRule.java
@@ -32,8 +32,11 @@ import org.opensearch.analytics.planner.rel.AggregateMode;
 import org.opensearch.analytics.planner.rel.OpenSearchAggregate;
 import org.opensearch.analytics.planner.rel.OpenSearchConvention;
 import org.opensearch.analytics.planner.rel.OpenSearchDistribution;
-import org.opensearch.analytics.planner.rel.OpenSearchExchangeReducer;
+import org.opensearch.analytics.planner.rel.OpenSearchFilter;
+import org.opensearch.analytics.planner.rel.OpenSearchJoin;
 import org.opensearch.analytics.planner.rel.OpenSearchProject;
+import org.opensearch.analytics.planner.rel.OpenSearchSort;
+import org.opensearch.analytics.planner.rel.OpenSearchUnion;
 import org.opensearch.analytics.spi.AggregateFunction;
 import org.opensearch.analytics.spi.AggregateFunction.IntermediateField;
 
@@ -135,8 +138,11 @@ public class OpenSearchAggregateSplitRule extends RelOptRule {
         // perturbs the global cost model for unrelated query shapes). For unpartitioned input
         // (1 shard / already gathered) or a non-splittable aggregate, the single-stage plan is the
         // correct and only choice.
+        // Split into PARTIAL/FINAL only when the input is genuinely partitioned AND no operator
+        // below forces a gather (a gather-forced input is already singleton — a PARTIAL over it
+        // would be invalid). Otherwise emit the single coordinator aggregate.
         boolean partitioned = isPartitioned(child);
-        if (!partitioned || childGatheredByWindow(child) || shouldSkipPartialFinalSplit(aggregate)) {
+        if (!partitioned || childForcesGather(child) || shouldSkipPartialFinalSplit(aggregate)) {
             call.transformTo(singleOnSingleton);
             return;
         }
@@ -210,35 +216,54 @@ public class OpenSearchAggregateSplitRule extends RelOptRule {
     }
 
     /**
-     * True when a window (a {@code RexOver}-bearing Project) sits between this aggregate and its
-     * scan. A global-frame window has infinite cost unless its input is SINGLETON, so the planner
-     * gathers below it — meaning this aggregate's input is already on one node and splitting it
-     * would add a redundant PARTIAL/FINAL pass.
+     * True when a gather-forcing operator sits between this aggregate and its scan, so the
+     * aggregate's input is already (or will be) gathered to one node — splitting it into
+     * PARTIAL/FINAL is invalid (the PARTIAL would sit over SINGLETON input, and the shard-side
+     * PARTIAL is unsatisfiable). Walks the single-input chain, descending past pass-through
+     * Projects (no {@code RexOver}) and Filters; stops at the first gather-forcing op or a terminal.
      *
-     * <p>This only runs after {@link #isPartitioned} confirmed {@code node} carries the RANDOM
-     * trait, i.e. {@code node} is on the shard-side (pre-gather) segment of the plan. The
-     * window's gather is a not-yet-materialized converter and the FINAL aggregate of any
-     * lower split outputs SINGLETON (which {@code isPartitioned} would have screened out), so
-     * there is no {@link OpenSearchExchangeReducer} between {@code node} and its scan to walk
-     * past — the descent stays within this one RANDOM segment. The walk simply looks for a
-     * window over the single-input chain down to the scan; a multi-input op (join/union) ends it.
+     * <p>Gather-forcing operators (each returns infinite cost over non-SINGLETON input in its own
+     * {@code computeSelfCost}, so Volcano gathers below them):
+     * <ul>
+     *   <li>collated or limited {@link OpenSearchSort} (global order/limit can't run per-shard);</li>
+     *   <li>a {@code RexOver}-bearing {@link OpenSearchProject} (window needs gathered input);</li>
+     *   <li>{@link OpenSearchJoin} and {@link OpenSearchUnion} (coordinator-gathered today);</li>
+     *   <li>a nested {@link OpenSearchAggregate} (its FINAL/SINGLE output is gathered).</li>
+     * </ul>
+     * Pass-through Project / Filter are walked past; scans/values and anything else end the walk
+     * as not-gather-forcing (split allowed).
      */
-    private static boolean childGatheredByWindow(RelNode node) {
+    private static boolean childForcesGather(RelNode node) {
         RelNode cur = unwrapForWalk(node);
         while (cur != null) {
-            if (cur instanceof OpenSearchProject project && project.containsOver()) {
-                return true; // window forces a gather above its input → our input is already singleton
+            // Gather-forcing operators: each returns infinite cost over non-SINGLETON input in its
+            // own computeSelfCost (verified: Sort-collated/limited, RexOver-Project, Join, Union,
+            // nested Aggregate), so Volcano gathers below them → our input is already singleton.
+            if (cur instanceof OpenSearchSort sort) {
+                return !sort.getCollation().getFieldCollations().isEmpty() || sort.fetch != null || sort.offset != null;
             }
-            if (cur.getInputs().size() != 1) {
-                return false; // scan (no inputs) or a multi-input op (join/union) — no single window gather
+            if (cur instanceof OpenSearchJoin || cur instanceof OpenSearchUnion || cur instanceof OpenSearchAggregate) {
+                return true;
             }
-            cur = unwrapForWalk(cur.getInput(0));
+            if (cur instanceof OpenSearchProject project) {
+                if (project.containsOver()) return true;      // window → gathered input
+                cur = unwrapForWalk(cur.getInput(0));          // pass-through project → keep walking
+                continue;
+            }
+            // Pass-through, non-gathering: Filter (q37's split must still happen) → keep walking.
+            if (cur instanceof OpenSearchFilter) {
+                cur = unwrapForWalk(cur.getInput(0));
+                continue;
+            }
+            // Terminals that do not force a gather: TableScan / StageInputScan / Values, or any
+            // other shape we don't explicitly treat as gather-forcing. Conservative: allow split.
+            return false;
         }
         return false;
     }
 
     /**
-     * Resolves a node to its concrete rel for the {@link #childGatheredByWindow} walk. During
+     * Resolves a node to its concrete rel for the {@link #childForcesGather} walk. During
      * Volcano, {@code getInput(0)} returns a {@link RelSubset}, not a concrete rel — its
      * {@code getInputs()} is empty, which would end the walk one hop below the aggregate and miss a
      * window sitting behind an intermediate op (e.g. a {@code where} Filter). Unwrap the HEP vertex,

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/AggregateSplitCostTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/AggregateSplitCostTests.java
@@ -8,13 +8,30 @@
 
 package org.opensearch.analytics.planner;
 
+import com.google.common.collect.ImmutableList;
 import org.apache.calcite.plan.RelOptTable;
+import org.apache.calcite.plan.RelOptUtil;
 import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.CorrelationId;
+import org.apache.calcite.rel.core.JoinRelType;
+import org.apache.calcite.rel.logical.LogicalJoin;
 import org.apache.calcite.rel.logical.LogicalProject;
 import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexWindowBounds;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.util.ImmutableBitSet;
+import org.opensearch.analytics.planner.rel.AggregateMode;
+import org.opensearch.analytics.planner.rel.OpenSearchAggregate;
+import org.opensearch.analytics.planner.rel.OpenSearchExchangeReducer;
 
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.mockito.Mockito.when;
 
 /**
  * Aggregate split decision — driven deterministically by partitioning, NOT cost.
@@ -85,5 +102,253 @@ public class AggregateSplitCostTests extends PlanShapeTestBase {
                 """,
             result
         );
+    }
+
+    /**
+     * Aggregate over a collated Sort at multi-shard must NOT split. The Sort forces its input to a
+     * single node (global order can't run per-shard), so the aggregate's input is already gathered —
+     * a PARTIAL below it would be invalid. The rule emits a single SINGLE aggregate over the Sort.
+     */
+    public void testAggregateOverCollatedSort_2shard_doesNotSplit() {
+        RelOptTable table = mockTable("test_index", "status", "size");
+        RelNode scan = stubScan(table);
+        RelNode sort = makeSort(scan, 100);
+        RelNode plan = makeAggregate(sort, countStarCall(sort));
+        RelNode result = runPlanner(plan, multiShardContext());
+        assertPlanShape(
+            """
+                OpenSearchAggregate(group=[{0}], cnt=[COUNT()], mode=[SINGLE], viableBackends=[[mock-parquet]])
+                  OpenSearchSort(sort0=[$0], dir0=[ASC], fetch=[100], viableBackends=[[mock-parquet]])
+                    OpenSearchExchangeReducer(viableBackends=[[mock-parquet]], exchange=[ExchangeInfo[distributionType=SINGLETON, partitionKeyIndices=[]]])
+                      OpenSearchSort(sort0=[$0], dir0=[ASC], fetch=[100], viableBackends=[[mock-parquet]])
+                        OpenSearchTableScan(table=[[test_index]], viableBackends=[[mock-parquet]])
+                """,
+            result
+        );
+    }
+
+    /**
+     * {@code where <4 eq-preds> | stats count() by status_code}, multi-shard — the PARTIAL must
+     * stay below the Exchange. Two ingredients make the bad coordinator-PARTIAL look cheaper, so
+     * this exercises the gate that forbids it:
+     * <ul>
+     *   <li>Row count 100 + 4 {@code =} conjuncts: default 0.25 selectivity floors the estimate to
+     *       1.0 row, erasing the coordinator-PARTIAL's cost margin over the shard-PARTIAL+ER.</li>
+     *   <li>Narrowing Project (status_code only): the projected row is narrower than the PARTIAL
+     *       state (key + count), so shipping rows below a coordinator-PARTIAL beats shipping the
+     *       partial state above a shard-PARTIAL.</li>
+     * </ul>
+     * Comment out the gate in {@code OpenSearchAggregate.computeSelfCost} and this fails with the
+     * FINAL → coordinator-PARTIAL → ER bad shape.
+     */
+    public void testFourPredicateFilterBelowCountByKey_2shard_partialStaysBelowExchange() {
+        // HTTP-access-log shape: count() by status_code, filtered on 4 fields.
+        Map<String, Map<String, Object>> fields = new LinkedHashMap<>();
+        for (String name : List.of("status_code", "size", "region_id", "endpoint_id")) {
+            fields.put(name, Map.of("type", "integer"));
+        }
+        PlannerContext context = buildContext("parquet", 2, fields);
+        RelOptTable table = mockTable("test_index", "status_code", "size", "region_id", "endpoint_id");
+        when(table.getRowCount()).thenReturn(100d);
+        RelNode scan = stubScan(table);
+        RelNode filter = makeFilter(
+            scan,
+            makeAnd(
+                makeEquals(0, SqlTypeName.INTEGER, 200),
+                makeEquals(1, SqlTypeName.INTEGER, 1024),
+                makeEquals(2, SqlTypeName.INTEGER, 3),
+                makeEquals(3, SqlTypeName.INTEGER, 5)
+            )
+        );
+        RelDataType intType = typeFactory.createSqlType(SqlTypeName.INTEGER);
+        LogicalProject project = LogicalProject.create(
+            filter,
+            List.of(),
+            List.of(rexBuilder.makeInputRef(intType, 0)),
+            List.of("status_code")
+        );
+        RelNode plan = makeAggregate(project, ImmutableBitSet.of(0), countStarCall(project));
+        RelNode result = runPlanner(plan, context);
+        assertPlanShape(
+            """
+                OpenSearchAggregate(group=[{0}], cnt=[SUM($1)], mode=[FINAL], viableBackends=[[mock-parquet]])
+                  OpenSearchExchangeReducer(viableBackends=[[mock-parquet]], exchange=[ExchangeInfo[distributionType=SINGLETON, partitionKeyIndices=[]]])
+                    OpenSearchAggregate(group=[{0}], cnt=[COUNT()], mode=[PARTIAL], viableBackends=[[mock-parquet]])
+                      OpenSearchProject(status_code=[$0], viableBackends=[[mock-parquet]])
+                        OpenSearchFilter(condition=[AND(ANNOTATED_PREDICATE(id=0, backends=[mock-lucene, mock-parquet], =($0, 200)), ANNOTATED_PREDICATE(id=1, backends=[mock-lucene, mock-parquet], =($1, 1024)), ANNOTATED_PREDICATE(id=2, backends=[mock-lucene, mock-parquet], =($2, 3)), ANNOTATED_PREDICATE(id=3, backends=[mock-lucene, mock-parquet], =($3, 5)))], viableBackends=[[mock-parquet]])
+                          OpenSearchTableScan(table=[[test_index]], viableBackends=[[mock-parquet]])
+                """,
+            result
+        );
+    }
+
+    /**
+     * Same invariant for an aggregate whose PARTIAL state genuinely differs from its output —
+     * {@code avg(size) by status_code} decomposes to SUM + COUNT primitives at the shard, reduced
+     * additively at the coordinator. 7 {@code =} conjuncts drive the row-count estimate to the 1.0
+     * floor; the narrowing Project (status_code, size) keeps the shipped row narrower than the
+     * 3-column PARTIAL state, so without the gate the coordinator-PARTIAL wins on cost. The gate
+     * keeps the SUM/COUNT PARTIAL below the Exchange.
+     */
+    public void testSevenPredicateFilterBelowAvgByKey_2shard_partialStaysBelowExchange() {
+        Map<String, Map<String, Object>> fields = new LinkedHashMap<>();
+        for (String name : List.of("status_code", "size", "region_id", "endpoint_id", "user_id", "method_id", "cache_hit")) {
+            fields.put(name, Map.of("type", "integer"));
+        }
+        PlannerContext context = buildContext("parquet", 2, fields);
+        RelOptTable table = mockTable("test_index", "status_code", "size", "region_id", "endpoint_id", "user_id", "method_id", "cache_hit");
+        when(table.getRowCount()).thenReturn(100d);
+        RelNode scan = stubScan(table);
+        RelNode filter = makeFilter(
+            scan,
+            makeAnd(
+                makeEquals(0, SqlTypeName.INTEGER, 200),
+                makeEquals(1, SqlTypeName.INTEGER, 1024),
+                makeEquals(2, SqlTypeName.INTEGER, 3),
+                makeEquals(3, SqlTypeName.INTEGER, 5),
+                makeEquals(4, SqlTypeName.INTEGER, 7),
+                makeEquals(5, SqlTypeName.INTEGER, 1),
+                makeEquals(6, SqlTypeName.INTEGER, 1)
+            )
+        );
+        RelDataType intType = typeFactory.createSqlType(SqlTypeName.INTEGER);
+        LogicalProject project = LogicalProject.create(
+            filter,
+            List.of(),
+            List.of(rexBuilder.makeInputRef(intType, 0), rexBuilder.makeInputRef(intType, 1)),
+            List.of("status_code", "size")
+        );
+        RelNode plan = makeAggregate(project, ImmutableBitSet.of(0), avgCall(project));
+        RelNode result = runPlanner(plan, context);
+        assertPlanShape(
+            """
+                OpenSearchProject(status_code=[$0], avg_size=[ANNOTATED_PROJECT_EXPR(id=10, backends=[mock-parquet], CAST(ANNOTATED_PROJECT_EXPR(id=9, backends=[mock-parquet], /($1, $2))):INTEGER NOT NULL)], viableBackends=[[mock-parquet]])
+                  OpenSearchAggregate(group=[{0}], $f1=[SUM($1)], $f2=[SUM($2)], mode=[FINAL], viableBackends=[[mock-parquet]])
+                    OpenSearchExchangeReducer(viableBackends=[[mock-parquet]], exchange=[ExchangeInfo[distributionType=SINGLETON, partitionKeyIndices=[]]])
+                      OpenSearchAggregate(group=[{0}], agg#0=[SUM($1)], agg#1=[COUNT()], mode=[PARTIAL], viableBackends=[[mock-parquet]])
+                        OpenSearchProject(status_code=[$0], size=[$1], viableBackends=[[mock-parquet]])
+                          OpenSearchFilter(condition=[AND(ANNOTATED_PREDICATE(id=0, backends=[mock-lucene, mock-parquet], =($0, 200)), ANNOTATED_PREDICATE(id=1, backends=[mock-lucene, mock-parquet], =($1, 1024)), ANNOTATED_PREDICATE(id=2, backends=[mock-lucene, mock-parquet], =($2, 3)), ANNOTATED_PREDICATE(id=3, backends=[mock-lucene, mock-parquet], =($3, 5)), ANNOTATED_PREDICATE(id=4, backends=[mock-lucene, mock-parquet], =($4, 7)), ANNOTATED_PREDICATE(id=5, backends=[mock-lucene, mock-parquet], =($5, 1)), ANNOTATED_PREDICATE(id=6, backends=[mock-lucene, mock-parquet], =($6, 1)))], viableBackends=[[mock-parquet]])
+                            OpenSearchTableScan(table=[[test_index]], viableBackends=[[mock-parquet]])
+                """,
+            result
+        );
+    }
+
+    /**
+     * Aggregate over a Join at multi-shard must NOT split. A Join gathers both inputs to the
+     * coordinator (its {@code computeSelfCost} is infinite over non-SINGLETON input), so the
+     * aggregate's input is already singleton — {@code childForcesGather} stops at the Join and the
+     * rule emits a single SINGLE aggregate.
+     */
+    public void testAggregateOverJoin_2shard_doesNotSplit() {
+        RelOptTable left = mockTable("test_index", "status", "size");
+        RelOptTable right = mockTable("test_index", "status", "size");
+        RexNode cond = rexBuilder.makeCall(
+            SqlStdOperatorTable.EQUALS,
+            rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.INTEGER), 0),
+            rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.INTEGER), 2)
+        );
+        RelNode join = LogicalJoin.create(stubScan(left), stubScan(right), List.of(), cond, Set.<CorrelationId>of(), JoinRelType.INNER);
+        RelNode plan = makeAggregate(join, ImmutableBitSet.of(0), countStarCall(join));
+        RelNode result = runPlanner(plan, multiShardContext());
+        assertModeAndNoPartialAboveExchange(result, AggregateMode.SINGLE);
+    }
+
+    /**
+     * {@code childForcesGather} must walk PAST a pass-through Project (no {@code RexOver}) and a
+     * Filter — neither forces a gather — and still split over the partitioned scan beneath. Asserts
+     * the walk doesn't false-positive on intermediate ops it's meant to see through.
+     */
+    public void testAggregateOverPassthroughProjectOverFilter_2shard_splits() {
+        RelOptTable table = mockTable("test_index", "status", "size");
+        RelNode scan = stubScan(table);
+        RelDataType intType = typeFactory.createSqlType(SqlTypeName.INTEGER);
+        LogicalProject project = LogicalProject.create(
+            scan,
+            List.of(),
+            List.of(rexBuilder.makeInputRef(intType, 0), rexBuilder.makeInputRef(intType, 1)),
+            List.of("status", "size")
+        );
+        RelNode filter = makeFilter(project, makeEquals(0, SqlTypeName.INTEGER, 200));
+        RelNode plan = makeAggregate(filter, countStarCall(filter));
+        RelNode result = runPlanner(plan, multiShardContext());
+        assertModeAndNoPartialAboveExchange(result, AggregateMode.FINAL);
+    }
+
+    /**
+     * A Project carrying a window ({@code RexOver}) DOES force a gather — its global frame needs
+     * SINGLETON input, so the walk must stop at it (not treat it as pass-through). Aggregate over
+     * such a Project at multi-shard stays SINGLE, no split.
+     */
+    public void testAggregateOverWindowInProject_2shard_doesNotSplit() {
+        RelOptTable table = mockTable("test_index", "status", "size");
+        RelNode scan = stubScan(table);
+        RexNode countOverEmpty = rexBuilder.makeOver(
+            typeFactory.createSqlType(SqlTypeName.BIGINT),
+            SqlStdOperatorTable.COUNT,
+            List.of(),
+            ImmutableList.of(),
+            ImmutableList.of(),
+            RexWindowBounds.UNBOUNDED_PRECEDING,
+            RexWindowBounds.UNBOUNDED_FOLLOWING,
+            true,
+            true,
+            false,
+            false,
+            false
+        );
+        LogicalProject windowProject = LogicalProject.create(
+            scan,
+            List.of(),
+            List.of(rexBuilder.makeInputRef(scan, 0), countOverEmpty),
+            List.of("status", "w")
+        );
+        RelNode plan = makeAggregate(windowProject, ImmutableBitSet.of(0), countStarCall(windowProject));
+        RelNode result = runPlanner(plan, multiShardContext());
+        assertModeAndNoPartialAboveExchange(result, AggregateMode.SINGLE);
+    }
+
+    /**
+     * Structural assertion shared by the no-split / split cases: the top OpenSearchAggregate carries
+     * {@code expectedTopMode}, and no PARTIAL aggregate sits directly above an ExchangeReducer
+     * (the bug shape). For SINGLE this confirms no split happened; for FINAL it confirms the split
+     * placed PARTIAL below the Exchange.
+     */
+    private static void assertModeAndNoPartialAboveExchange(RelNode root, AggregateMode expectedTopMode) {
+        OpenSearchAggregate top = findTopAggregate(root);
+        assertNotNull("expected an OpenSearchAggregate in the plan:\n" + explain(root), top);
+        assertEquals("top aggregate mode\n" + explain(root), expectedTopMode, top.getMode());
+        assertFalse("PARTIAL sits directly above an ExchangeReducer (bad shape):\n" + explain(root), hasPartialAboveExchange(root));
+    }
+
+    private static OpenSearchAggregate findTopAggregate(RelNode node) {
+        if (node instanceof OpenSearchAggregate aggregate) {
+            return aggregate;
+        }
+        for (RelNode input : node.getInputs()) {
+            OpenSearchAggregate found = findTopAggregate(input);
+            if (found != null) {
+                return found;
+            }
+        }
+        return null;
+    }
+
+    private static boolean hasPartialAboveExchange(RelNode node) {
+        if (node instanceof OpenSearchAggregate aggregate
+            && aggregate.getMode() == AggregateMode.PARTIAL
+            && aggregate.getInput() instanceof OpenSearchExchangeReducer) {
+            return true;
+        }
+        for (RelNode input : node.getInputs()) {
+            if (hasPartialAboveExchange(input)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static String explain(RelNode node) {
+        return RelOptUtil.toString(node);
     }
 }

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/LateMaterializationPlanShapeTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/LateMaterializationPlanShapeTests.java
@@ -31,6 +31,7 @@ import org.opensearch.analytics.spi.AnalyticsSearchBackendPlugin;
 import org.opensearch.analytics.spi.FieldStorageInfo;
 import org.opensearch.analytics.spi.FieldType;
 import org.opensearch.cluster.ClusterState;
+import org.opensearch.test.junit.annotations.TestLogging;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -434,6 +435,8 @@ public class LateMaterializationPlanShapeTests extends BasePlannerRulesTests {
 
     // ── Tests that decline QTF ─────────────────────────────────────────
 
+    // FIXME [RemoveBeforeMerge]: temporary diagnostic logging to probe pure-LIMIT sort placement.
+    @TestLogging(value = "org.opensearch.analytics.planner:DEBUG", reason = "probe pure-LIMIT sort placement (shard topN vs gather)")
     public void testQtfDeclined_pureLimit() {
         // SELECT URL FROM hits LIMIT 10
         // No ORDER BY → no anchor → no rewrite.
@@ -459,6 +462,8 @@ public class LateMaterializationPlanShapeTests extends BasePlannerRulesTests {
         assertQtfDeclined("SELECT CounterID, COUNT(*) AS c FROM hits GROUP BY CounterID ORDER BY CounterID LIMIT 10", 2);
     }
 
+    // FIXME [RemoveBeforeMerge]: temporary diagnostic logging for agg-over-LIMIT-sort diagnosis.
+    @TestLogging(value = "org.opensearch.analytics.planner:DEBUG", reason = "capture pre/post-CBO plan for agg-over-LIMIT-sort diagnosis")
     public void testQtfDeclined_aggregateAboveAnchor() {
         // Aggregate above the anchor — explicitly excluded from ABOVE_ALLOWED in v2.
         // (Above-Aggregate group/aggCall remap under a moving wrapper rowType is a follow-up.)

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/LateMaterializationPlanShapeTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/LateMaterializationPlanShapeTests.java
@@ -31,7 +31,6 @@ import org.opensearch.analytics.spi.AnalyticsSearchBackendPlugin;
 import org.opensearch.analytics.spi.FieldStorageInfo;
 import org.opensearch.analytics.spi.FieldType;
 import org.opensearch.cluster.ClusterState;
-import org.opensearch.test.junit.annotations.TestLogging;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -435,8 +434,6 @@ public class LateMaterializationPlanShapeTests extends BasePlannerRulesTests {
 
     // ── Tests that decline QTF ─────────────────────────────────────────
 
-    // FIXME [RemoveBeforeMerge]: temporary diagnostic logging to probe pure-LIMIT sort placement.
-    @TestLogging(value = "org.opensearch.analytics.planner:DEBUG", reason = "probe pure-LIMIT sort placement (shard topN vs gather)")
     public void testQtfDeclined_pureLimit() {
         // SELECT URL FROM hits LIMIT 10
         // No ORDER BY → no anchor → no rewrite.
@@ -462,8 +459,6 @@ public class LateMaterializationPlanShapeTests extends BasePlannerRulesTests {
         assertQtfDeclined("SELECT CounterID, COUNT(*) AS c FROM hits GROUP BY CounterID ORDER BY CounterID LIMIT 10", 2);
     }
 
-    // FIXME [RemoveBeforeMerge]: temporary diagnostic logging for agg-over-LIMIT-sort diagnosis.
-    @TestLogging(value = "org.opensearch.analytics.planner:DEBUG", reason = "capture pre/post-CBO plan for agg-over-LIMIT-sort diagnosis")
     public void testQtfDeclined_aggregateAboveAnchor() {
         // Aggregate above the anchor — explicitly excluded from ABOVE_ALLOWED in v2.
         // (Above-Aggregate group/aggCall remap under a moving wrapper rowType is a follow-up.)

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/UnionPlanShapeTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/UnionPlanShapeTests.java
@@ -13,6 +13,7 @@ import org.apache.calcite.rel.logical.LogicalUnion;
 import org.apache.calcite.rel.logical.LogicalValues;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.util.ImmutableBitSet;
 import org.opensearch.analytics.spi.EngineCapability;
 
 import java.util.HashSet;
@@ -155,6 +156,30 @@ public class UnionPlanShapeTests extends PlanShapeTestBase {
         assertPlanShape("""
             OpenSearchTableScan(table=[[test_index]], viableBackends=[[mock-parquet]])
             """, result);
+    }
+
+    public void testAggregateOverUnion_2shard_doesNotSplit() {
+        // Aggregate over a Union must NOT split into PARTIAL/FINAL: the Union gathers its arms to
+        // the coordinator (each arm forced to SINGLETON), so the aggregate's input is already
+        // gathered — a shard-side PARTIAL would have nothing partitioned to pre-aggregate.
+        // OpenSearchAggregateSplitRule.childForcesGather stops at the Union → single SINGLE aggregate.
+        RelNode union = LogicalUnion.create(
+            List.of(stubScan(mockTable("test_index", "status", "size")), stubScan(mockTable("test_index", "status", "size"))),
+            /* all */ true
+        );
+        RelNode plan = makeAggregate(union, ImmutableBitSet.of(0), countStarCall(union));
+        RelNode result = runPlanner(plan, unionContextSingleIndex("test_index", 2));
+        assertPlanShape(
+            """
+                OpenSearchAggregate(group=[{0}], cnt=[COUNT()], mode=[SINGLE], viableBackends=[[mock-parquet]])
+                  OpenSearchUnion(all=[true], viableBackends=[[mock-parquet]])
+                    OpenSearchExchangeReducer(viableBackends=[[mock-parquet]], exchange=[ExchangeInfo[distributionType=SINGLETON, partitionKeyIndices=[]]])
+                      OpenSearchTableScan(table=[[test_index]], viableBackends=[[mock-parquet]])
+                    OpenSearchExchangeReducer(viableBackends=[[mock-parquet]], exchange=[ExchangeInfo[distributionType=SINGLETON, partitionKeyIndices=[]]])
+                      OpenSearchTableScan(table=[[test_index]], viableBackends=[[mock-parquet]])
+                """,
+            result
+        );
     }
 
     // ── Context helpers ───────────────────────────────────────────────────────


### PR DESCRIPTION
### What
Multi shard aggregations whose filter has **4 or more AND'd predicates** (e.g. several Clickbench queries onwards number 37 ) placed *both* aggregation phases on the coordinator. The exchange shipped raw filtered rows instead of compact per-shard partials. This fix keeps the partial aggregate on the shards: pre-aggregate locally, then gather and finalize on the coordinator.

### Why
The correct plan (pre-aggregate on shards → ship partials) and the bad plan (ship filtered rows → aggregate only on coordinator) came out **cost-equivalent** in the optimizer.

The filter's row-count estimate shrinks by a constant factor (~0.25) per AND'd predicate:
  - **≤ 3 predicates:** the estimate still carries a fraction → the bad plan is strictly costlier → the correct plan wins.
  - **≥ 4 predicates:** the estimate hits the **1-row floor**, erasing that margin → the two plans tie → the bad plan wins purely on registration (rel-id) order.

So the regression triggered exactly at the **4-predicate threshold** and hit every ClickBench query at or above it. Outcome was correct but did network + coordinator work that scales with data size.

### How
Two deterministic guards, independent of cost magnitude:
  1. **Forbid a partial aggregate over already-gathered input** — never a valid placement, so it is dropped as an option instead of relying on a fragile cost tiebreak.
  2. **Skip the split when an operator below the aggregate already forces a gather** (sort/limit, join, union, window) — run a single aggregate on the coordinator.

  ### Testing
  - Plan-shape unit tests that **reproduce the tie** (row count + ≥4 predicates + the narrowing projection that makes the bad plan cheaper); removing either guard makes them fail with the bad shape.
  - Coverage for each gather-forcing operator, and for pass-through operators that must *not* block the split.
  - Full plugin test suite green; verified end-to-end on a 2-shard local cluster across all ClickBench queries (every `by`-aggregation now pre-aggregates on the shard).