### PR TITLE
[Analytics-Engine] Fix delegation panic on multi-index queries

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_executor.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_executor.rs
@@ -804,10 +804,19 @@ async unsafe fn execute_indexed_with_context_inner(
     // callback to the correct per-query FilterDelegationHandle and DelegationThreadTracker.
     let context_id = query_context.context_id();
 
+    // The substrait scan binds to the plan's NamedTable name (the alias/pattern like "tb-1,tb-2"
+    // for multi-index queries, the concrete name otherwise), not the per-shard table_name.
+    // create_session_context registered the provider under that name, so re-register under the
+    // same name. Using table_name for a multi-index query leaves the scan unbound, so DataFusion
+    // never consults supports_filters_pushdown and keeps the delegated_predicate FilterExec —
+    // which then executes the marker UDF and errors.
+    let register_name = crate::api::first_named_table_name(substrait_bytes.as_slice())
+        .unwrap_or_else(|| table_name.clone());
+
     // SessionContext already has RuntimeEnv, caches, memory pool, UDF from create_session_context_indexed.
     // Deregister the default ListingTable (registered by create_session_context) — will be replaced
     // with IndexedTableProvider after plan decoding.
-    ctx.deregister_table(&table_name)?;
+    ctx.deregister_table(&register_name)?;
 
     let store = ctx
         .state()
@@ -829,12 +838,12 @@ async unsafe fn execute_indexed_with_context_inner(
     .map_err(DataFusionError::Execution)?;
     let schema = crate::schema_coerce::coerce_inferred_schema(schema);
     // Widen to the plan's base_schema so columns absent from this shard's parquet (cross-shard drift) are null-filled at read time.
-    let schema = crate::session_context::widen_schema_from_plan(&ctx, &substrait_bytes, &table_name, &schema);
+    let schema = crate::session_context::widen_schema_from_plan(&ctx, &substrait_bytes, &register_name, &schema);
 
     let placeholder: Arc<dyn TableProvider> = Arc::new(PlaceholderProvider {
         schema: schema.clone(),
     });
-    ctx.register_table(&table_name, placeholder)?;
+    ctx.register_table(&register_name, placeholder)?;
 
     let plan = Plan::decode(substrait_bytes.as_slice())
         .map_err(|e| DataFusionError::Execution(format!("decode substrait: {}", e)))?;
@@ -1180,7 +1189,7 @@ async unsafe fn execute_indexed_with_context_inner(
         }
     };
 
-    ctx.deregister_table(&table_name)?;
+    ctx.deregister_table(&register_name)?;
     // Extract the scheme+authority portion of the table URL for
     // DataFusion's FileScanConfig. The full URL includes the path
     // (e.g. "file:///Users/.../parquet/"); ObjectStoreUrl wants only
@@ -1204,7 +1213,7 @@ async unsafe fn execute_indexed_with_context_inner(
         sort_fields: sort_fields.clone(),
         sort_orders: sort_orders.clone(),
     }));
-    ctx.register_table(&table_name, provider)?;
+    ctx.register_table(&register_name, provider)?;
 
     let logical_plan = from_substrait_plan(&ctx.state(), &plan).await?;
     log_debug!("DataFusion logical plan:\n{}", logical_plan.display_indent());

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/MultiIndexQueryShapesIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/MultiIndexQueryShapesIT.java
@@ -35,6 +35,12 @@ public class MultiIndexQueryShapesIT extends AnalyticsRestTestCase {
     private static final String PQLUC_B = "multi_pqluc_b";
     private static final String PQLUC_ALIAS = "multi_pqluc_alias";
 
+    // ── Full-text delegation indices: composite, multi-shard, with a text body + keyword
+    //    service/trace so match() delegates to Lucene across multiple indices. ──
+    private static final String FT_A = "multi_ft_a";
+    private static final String FT_B = "multi_ft_b";
+    private static final String FT_ALIAS = "multi_ft_alias";
+
     private static boolean provisioned = false;
 
     private void ensureProvisioned() throws IOException {
@@ -53,6 +59,16 @@ public class MultiIndexQueryShapesIT extends AnalyticsRestTestCase {
         bulk(PQLUC_A, "{\"status\":200,\"message\":\"ok\"}\n{\"status\":500,\"message\":\"error\"}\n{\"status\":200,\"message\":\"hello\"}\n");
         bulk(PQLUC_B, "{\"status\":200,\"message\":\"world\",\"source\":\"app1\"}\n{\"status\":404,\"message\":\"not found\",\"source\":\"app2\"}\n");
         putAlias(PQLUC_ALIAS, List.of(PQLUC_A, PQLUC_B));
+
+        String ftMapping = "{\"properties\":{\"service\":{\"type\":\"keyword\"},\"trace\":{\"type\":\"keyword\"},\"body\":{\"type\":\"text\"}}}";
+        createIndexWithSettings(FT_A, ftMapping, true, 2);
+        createIndexWithSettings(FT_B, ftMapping, true, 2);
+        bulk(FT_A, "{\"service\":\"checkout\",\"trace\":\"a1\",\"body\":\"exception timeout failed\"}\n"
+            + "{\"service\":\"checkout\",\"trace\":\"a2\",\"body\":\"timeout while reading\"}\n"
+            + "{\"service\":\"frontend\",\"trace\":\"a3\",\"body\":\"all good\"}\n");
+        bulk(FT_B, "{\"service\":\"checkout\",\"trace\":\"b1\",\"body\":\"timeout exception\"}\n"
+            + "{\"service\":\"frontend\",\"trace\":\"b2\",\"body\":\"connection reset\"}\n");
+        putAlias(FT_ALIAS, List.of(FT_A, FT_B));
 
         provisioned = true;
     }
@@ -155,6 +171,90 @@ public class MultiIndexQueryShapesIT extends AnalyticsRestTestCase {
         assertEquals("index A rows have null source", 3, nullCount);
     }
 
+    // ── Full-text delegation across multiple indices ──
+    // Regression for the bug where a delegated match() on a multi-index source kept the
+    // delegated_predicate FilterExec (the IndexedTableProvider was registered under the
+    // per-shard name, not the plan's multi-index NamedTable, so the scan never bound to it
+    // and DataFusion executed the marker UDF). Single-index match() always worked; these
+    // exercise the comma-list and alias multi-index shapes with every row-materializing op.
+
+    public void testMatchDelegationCommaListCount() throws IOException {
+        ensureProvisioned();
+        long count = singleCount("source=" + FT_A + "," + FT_B + " | where match(body, 'timeout') | stats count() as c");
+        assertEquals("timeout matches: 2 in A + 1 in B", 3L, count);
+    }
+
+    public void testMatchDelegationCommaListGroupBy() throws IOException {
+        ensureProvisioned();
+        Map<String, Object> body = executePpl(
+            "source=" + FT_A + "," + FT_B + " | where match(body, 'timeout') | stats count() as c by service | sort -c");
+        @SuppressWarnings("unchecked")
+        List<List<Object>> rows = (List<List<Object>>) body.get("datarows");
+        assertEquals(1, rows.size());
+        assertEquals(3L, ((Number) rows.get(0).get(0)).longValue());
+        assertEquals("checkout", rows.get(0).get(1));
+    }
+
+    public void testMatchDelegationDistinctCount() throws IOException {
+        ensureProvisioned();
+        long dc = singleCount("source=" + FT_A + "," + FT_B + " | where match(body, 'timeout') | stats dc(trace) as ut");
+        assertEquals("3 distinct traces match timeout across both indices", 3L, dc);
+    }
+
+    public void testMatchDelegationCountAndDistinctCountGroupBy() throws IOException {
+        ensureProvisioned();
+        Map<String, Object> body = executePpl(
+            "source=" + FT_A + "," + FT_B
+                + " | where match(body, 'timeout') | stats count() as c, dc(trace) as ut by service | sort -c");
+        @SuppressWarnings("unchecked")
+        List<List<Object>> rows = (List<List<Object>>) body.get("datarows");
+        assertEquals(1, rows.size());
+        assertEquals("count", 3L, ((Number) rows.get(0).get(0)).longValue());
+        assertEquals("distinct traces", 3L, ((Number) rows.get(0).get(1)).longValue());
+        assertEquals("checkout", rows.get(0).get(2));
+    }
+
+    public void testMatchDelegationFieldsMaterialization() throws IOException {
+        ensureProvisioned();
+        Map<String, Object> body = executePpl(
+            "source=" + FT_A + "," + FT_B + " | where match(body, 'timeout') | fields trace, service | head 20");
+        @SuppressWarnings("unchecked")
+        List<List<Object>> rows = (List<List<Object>>) body.get("datarows");
+        assertEquals("3 rows match timeout", 3, rows.size());
+    }
+
+    public void testMatchDelegationAcrossAlias() throws IOException {
+        ensureProvisioned();
+        long count = singleCount("source=" + FT_ALIAS + " | where match(body, 'exception') | stats count() as c");
+        assertEquals("exception matches: 1 in A + 1 in B", 2L, count);
+    }
+
+    public void testMatchDelegationWildcardDistinctCount() throws IOException {
+        ensureProvisioned();
+        Map<String, Object> body = executePpl(
+            "source=multi_ft_* | where match(body, 'timeout') | stats dc(trace) as ut by service | sort -ut");
+        @SuppressWarnings("unchecked")
+        List<List<Object>> rows = (List<List<Object>>) body.get("datarows");
+        assertEquals(1, rows.size());
+        assertEquals("checkout has 3 distinct timeout traces", 3L, ((Number) rows.get(0).get(0)).longValue());
+        assertEquals("checkout", rows.get(0).get(1));
+    }
+
+    // A delegated match() that trims one populated index to zero rows: 'reset' is only in B,
+    // so A's shards run the filter and emit nothing while B returns data. Exercises the
+    // runtime-empty path on a populated shard (distinct from the zero-doc EmptyExec guard).
+
+    public void testMatchDelegationOneIndexTrimmedToZeroCount() throws IOException {
+        ensureProvisioned();
+        long count = singleCount("source=" + FT_A + "," + FT_B + " | where match(body, 'reset') | stats count() as c");
+        assertEquals("reset matches: 0 in A + 1 in B", 1L, count);
+    }
+
+    public void testMatchDelegationOneIndexTrimmedToZeroDistinctCount() throws IOException {
+        ensureProvisioned();
+        long dc = singleCount("source=" + FT_A + "," + FT_B + " | where match(body, 'reset') | stats dc(trace) as ut");
+        assertEquals("1 distinct trace matches reset (B only, A trimmed to zero)", 1L, dc);
+    }
 
     // ── Multi-shard: verifies reduce handles null-filled batches from different shards ──
 


### PR DESCRIPTION


<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
The indexed executor registered IndexedTableProvider under the per-shard table_name, but the substrait scan binds to the plan's NamedTable name to support multi-index queries.
Ex. The alias/pattern "tb-1,tb-2" for multi-index
queries.
DataFusion never consulted supports_filters_pushdown, kept the delegated_predicate FilterExec, and executed the marker UDF which panics.

Register under first_named_table_name(plan) so the provider binds and the Lucene-delegated filter is pushed down as a single-index.

Adds match()-delegation coverage to MultiIndexQueryShapesIT across comma-list, alias, and wildcard sources with count/dc/group-by/fields.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
