### PR TITLE
Handle unbounded fielddata cache size in dynamic updates

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/index/fielddata/FieldDataLoadingIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/index/fielddata/FieldDataLoadingIT.java
@@ -133,6 +133,23 @@ public class FieldDataLoadingIT extends OpenSearchIntegTestCase {
         });
     }
 
+    public void testIndicesFieldDataCacheSizeCanBeSetToUnbounded() {
+        try {
+            updateFieldDataCacheSize("1b");
+            updateFieldDataCacheSize("-1");
+        } finally {
+            ClusterUpdateSettingsRequest updateSettingsRequest = new ClusterUpdateSettingsRequest();
+            updateSettingsRequest.persistentSettings(Settings.builder().putNull(INDICES_FIELDDATA_CACHE_SIZE_KEY.getKey()));
+            assertAcked(client().admin().cluster().updateSettings(updateSettingsRequest).actionGet());
+        }
+    }
+
+    private void updateFieldDataCacheSize(String value) {
+        ClusterUpdateSettingsRequest updateSettingsRequest = new ClusterUpdateSettingsRequest();
+        updateSettingsRequest.persistentSettings(Settings.builder().put(INDICES_FIELDDATA_CACHE_SIZE_KEY.getKey(), value));
+        assertAcked(client().admin().cluster().updateSettings(updateSettingsRequest).actionGet());
+    }
+
     private void createIndex(String index, int numFieldsPerIndex, String fieldPrefix) throws Exception {
         assert numFieldsPerIndex >= 1;
         XContentBuilder req = jsonBuilder().startObject().startObject("properties");

--- a/server/src/main/java/org/opensearch/common/cache/Cache.java
+++ b/server/src/main/java/org/opensearch/common/cache/Cache.java
@@ -163,6 +163,10 @@ public class Cache<K, V> {
         this.maximumWeight = maximumWeight;
     }
 
+    public void unsetMaximumWeight() {
+        this.maximumWeight = -1;
+    }
+
     public long getMaximumWeight() {
         return maximumWeight;
     }

--- a/server/src/main/java/org/opensearch/indices/fielddata/cache/IndicesFieldDataCache.java
+++ b/server/src/main/java/org/opensearch/indices/fielddata/cache/IndicesFieldDataCache.java
@@ -118,9 +118,11 @@ public class IndicesFieldDataCache implements RemovalListener<IndicesFieldDataCa
     ) {
         this.indicesFieldDataCacheListener = indicesFieldDataCacheListener;
         final long sizeInBytes = INDICES_FIELDDATA_CACHE_SIZE_KEY.get(settings).getBytes();
-        CacheBuilder<Key, Accountable> cacheBuilder = CacheBuilder.<Key, Accountable>builder().removalListener(this);
+        CacheBuilder<Key, Accountable> cacheBuilder = CacheBuilder.<Key, Accountable>builder()
+            .removalListener(this)
+            .weigher(new FieldDataWeigher());
         if (sizeInBytes > 0) {
-            cacheBuilder.setMaximumWeight(sizeInBytes).weigher(new FieldDataWeigher());
+            cacheBuilder.setMaximumWeight(sizeInBytes);
         }
         cache = cacheBuilder.build();
         if (clusterService != null) {
@@ -409,8 +411,13 @@ public class IndicesFieldDataCache implements RemovalListener<IndicesFieldDataCa
 
     private void updateMaximumWeight(ByteSizeValue newMaximumWeight) {
         long oldMaximumWeight = cache.getMaximumWeight();
-        cache.setMaximumWeight(newMaximumWeight.getBytes());
-        if (newMaximumWeight.getBytes() < oldMaximumWeight) {
+        long newMaximumWeightBytes = newMaximumWeight.getBytes();
+        if (newMaximumWeightBytes <= 0) {
+            cache.unsetMaximumWeight();
+            return;
+        }
+        cache.setMaximumWeight(newMaximumWeightBytes);
+        if (oldMaximumWeight == -1 || newMaximumWeightBytes < oldMaximumWeight) {
             // Evict entries if needed, if the new size is smaller than the old.
             // Do it asynchronously to avoid blocking cluster applier thread
             if (threadPool != null) {

--- a/server/src/test/java/org/opensearch/common/cache/CacheTests.java
+++ b/server/src/test/java/org/opensearch/common/cache/CacheTests.java
@@ -956,6 +956,20 @@ public class CacheTests extends OpenSearchTestCase {
         }
     }
 
+    public void testUnsetMaximumWeightDisablesWeightEviction() {
+        Cache<Integer, String> cache = CacheBuilder.<Integer, String>builder().setMaximumWeight(10).weigher((k, v) -> 6).build();
+        cache.put(1, "one");
+        assertEquals(6, cache.weight());
+
+        cache.unsetMaximumWeight();
+        cache.put(2, "two");
+        cache.put(3, "three");
+
+        assertEquals(-1, cache.getMaximumWeight());
+        assertEquals(3, cache.count());
+        assertEquals(18, cache.weight());
+    }
+
     public void testWithInvalidSegmentNumber() {
         assertThrows(
             "Number of segments for cache should be a power of two up-to 256",

--- a/server/src/test/java/org/opensearch/indices/fielddata/cache/IndicesFieldDataCacheTests.java
+++ b/server/src/test/java/org/opensearch/indices/fielddata/cache/IndicesFieldDataCacheTests.java
@@ -1,0 +1,125 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.indices.fielddata.cache;
+
+import org.apache.lucene.analysis.core.KeywordAnalyzer;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.store.ByteBuffersDirectory;
+import org.apache.lucene.util.Accountable;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.cache.Cache;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.core.index.Index;
+import org.opensearch.index.fielddata.IndexFieldDataCache;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import static org.opensearch.indices.fielddata.cache.IndicesFieldDataCache.INDICES_FIELDDATA_CACHE_SIZE_KEY;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class IndicesFieldDataCacheTests extends OpenSearchTestCase {
+
+    private static final IndexFieldDataCache.Listener NOOP_LISTENER = new IndexFieldDataCache.Listener() {
+    };
+
+    public void testUnboundedCacheCanBecomeBoundedAndUnboundedAgain() throws Exception {
+        Settings settings = Settings.builder().put(INDICES_FIELDDATA_CACHE_SIZE_KEY.getKey(), "-1").build();
+        ClusterSettings clusterSettings = new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        ClusterService clusterService = mock(ClusterService.class);
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
+
+        try (
+            ByteBuffersDirectory directory = new ByteBuffersDirectory();
+            IndexWriter writer = new IndexWriter(directory, new IndexWriterConfig(new KeywordAnalyzer()))
+        ) {
+            writer.addDocument(new Document());
+            try (DirectoryReader reader = DirectoryReader.open(writer)) {
+                IndicesFieldDataCache fieldDataCache = new IndicesFieldDataCache(settings, NOOP_LISTENER, clusterService, null);
+                Cache<IndicesFieldDataCache.Key, Accountable> cache = fieldDataCache.getCache();
+                IndexReader.CacheKey readerKey = reader.getReaderCacheHelper().getKey();
+
+                assertEquals(-1, cache.getMaximumWeight());
+                cache.computeIfAbsent(key(fieldDataCache, "field1", readerKey), ignored -> accountable(10));
+                cache.computeIfAbsent(key(fieldDataCache, "field2", readerKey), ignored -> accountable(10));
+                assertEquals(20, cache.weight());
+
+                clusterSettings.applySettings(Settings.builder().put(INDICES_FIELDDATA_CACHE_SIZE_KEY.getKey(), "15b").build());
+                assertEquals(15, cache.getMaximumWeight());
+                assertTrue(cache.weight() <= 15);
+
+                clusterSettings.applySettings(Settings.builder().put(INDICES_FIELDDATA_CACHE_SIZE_KEY.getKey(), "-1").build());
+                assertEquals(-1, cache.getMaximumWeight());
+                cache.computeIfAbsent(key(fieldDataCache, "field3", readerKey), ignored -> accountable(10));
+                cache.computeIfAbsent(key(fieldDataCache, "field4", readerKey), ignored -> accountable(10));
+                assertTrue(cache.weight() > 15);
+
+                clusterSettings.applySettings(Settings.builder().put(INDICES_FIELDDATA_CACHE_SIZE_KEY.getKey(), "0").build());
+                assertEquals(-1, cache.getMaximumWeight());
+            }
+        }
+    }
+
+    private IndicesFieldDataCache.Key key(IndicesFieldDataCache fieldDataCache, String fieldName, IndexReader.CacheKey readerKey) {
+        IndicesFieldDataCache.IndexFieldCache indexFieldCache = new IndicesFieldDataCache.IndexFieldCache(
+            logger,
+            fieldDataCache,
+            new Index("index", "uuid"),
+            fieldName,
+            shardId -> IndicesFieldDataCache.Key.NO_SHARD_IDENTITY,
+            NOOP_LISTENER
+        );
+        return new IndicesFieldDataCache.Key(indexFieldCache, readerKey, null);
+    }
+
+    private static Accountable accountable(long ramBytesUsed) {
+        return new Accountable() {
+            @Override
+            public long ramBytesUsed() {
+                return ramBytesUsed;
+            }
+
+            @Override
+            public Collection<Accountable> getChildResources() {
+                return Collections.emptyList();
+            }
+        };
+    }
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This change fixes dynamic updates for `indices.fielddata.cache.size` when switching between bounded and unbounded values.

`indices.fielddata.cache.size=-1` is valid during initialization, but the dynamic update path passed `-1` directly to `Cache#setMaximumWeight`, which rejects negative values. This makes runtime updates to the documented unbounded value fail.

The change also keeps fielddata cache weighing consistent across setting changes. `IndicesFieldDataCache` now installs `FieldDataWeigher` when the cache is created, regardless of whether the initial size is bounded. That avoids the case where a node starts with `-1`, later switches to a positive cache size, and continues weighing entries as `1` each instead of by `ramBytesUsed()`.

The update path now treats non-positive values as unbounded, matching the existing initialization behavior, and refreshes the cache when switching from unbounded to bounded or when lowering a positive bound.


### Related Issues
Resolves #22180
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
