### PR TITLE
fix: Correct StatsPruneTree rg_can_match absolute-to-relative index t…

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_executor.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_executor.rs
@@ -940,7 +940,7 @@ async unsafe fn execute_indexed_with_context_inner(
                 .and_then(|expr| build_pruning_predicate(expr, Arc::clone(&schema_for_pruner)));
 
             Arc::new(
-                move |segment: &SegmentFileInfo, chunk, stream_metrics: &StreamMetrics, stats_prune_tree: Option<&StatsPruneTree>| {
+                move |segment: &SegmentFileInfo, chunk, stream_metrics: &StreamMetrics, stats_prune_tree: Option<&Arc<StatsPruneTree>>| {
                     let pruner = Arc::new(PagePruner::new(
                         &schema_for_pruner,
                         Arc::clone(&segment.metadata),
@@ -1020,7 +1020,7 @@ async unsafe fn execute_indexed_with_context_inner(
             let bloom_schema = schema.clone();
             let bloom_on_read = query_config.bloom_filter_on_read;
             Arc::new(
-                move |segment: &SegmentFileInfo, chunk, stream_metrics: &StreamMetrics, stats_prune_tree: Option<&StatsPruneTree>| {
+                move |segment: &SegmentFileInfo, chunk, stream_metrics: &StreamMetrics, stats_prune_tree: Option<&Arc<StatsPruneTree>>| {
                     let collector_opt: Option<Arc<dyn RowGroupDocsCollector>> = match &correctness_provider {
                         Some(provider) => {
                             let collector = FfmSegmentCollector::create(
@@ -1139,7 +1139,7 @@ async unsafe fn execute_indexed_with_context_inner(
             };
 
             Arc::new(
-                move |segment: &SegmentFileInfo, chunk, stream_metrics: &StreamMetrics, stats_prune_tree: Option<&StatsPruneTree>| {
+                move |segment: &SegmentFileInfo, chunk, stream_metrics: &StreamMetrics, stats_prune_tree: Option<&Arc<StatsPruneTree>>| {
                     // Build one collector per Collector leaf for this chunk.
                     let mut per_leaf: Vec<(i32, Arc<dyn RowGroupDocsCollector>)> =
                         Vec::with_capacity(providers.len());

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_executor.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_executor.rs
@@ -906,7 +906,7 @@ async unsafe fn execute_indexed_with_context_inner(
         FilterClass::Tree => None,
     };
 
-    let prune_tree_config = extraction.as_ref().and_then(|e| {
+    let mut prune_tree_config = extraction.as_ref().and_then(|e| {
         let mut leaf_exprs: Vec<Arc<dyn PhysicalExpr>> = Vec::new();
         collect_predicate_exprs(&e.tree, &mut leaf_exprs);
         let leaf_predicates: HashMap<usize, Arc<PruningPredicate>> = leaf_exprs
@@ -919,7 +919,7 @@ async unsafe fn execute_indexed_with_context_inner(
         if leaf_predicates.is_empty() {
             return None;
         }
-        Some((e.tree.clone(), Arc::new(leaf_predicates), schema.clone()))
+        Some((Arc::new(e.tree.clone()), Arc::new(leaf_predicates), schema.clone()))
     });
 
     let predicate_columns = collect_predicate_column_indices(extraction.as_ref());
@@ -940,11 +940,13 @@ async unsafe fn execute_indexed_with_context_inner(
                 .and_then(|expr| build_pruning_predicate(expr, Arc::clone(&schema_for_pruner)));
 
             Arc::new(
-                move |segment: &SegmentFileInfo, _chunk, stream_metrics: &StreamMetrics, stats_prune_tree: Option<&StatsPruneTree>| {
+                move |segment: &SegmentFileInfo, chunk, stream_metrics: &StreamMetrics, stats_prune_tree: Option<&StatsPruneTree>| {
                     let pruner = Arc::new(PagePruner::new(
                         &schema_for_pruner,
                         Arc::clone(&segment.metadata),
                     ));
+                    let rg_index_to_pos: HashMap<usize, usize> = chunk.row_group_indices.iter()
+                        .enumerate().map(|(pos, &idx)| (idx, pos)).collect();
                     let eval: Arc<dyn RowGroupBitsetSource> =
                         Arc::new(crate::indexed_table::eval::predicate_evaluator::PredicateOnlyEvaluator::new(
                             pruner,
@@ -952,6 +954,7 @@ async unsafe fn execute_indexed_with_context_inner(
                             residual_expr.clone(),
                             Some(PagePruneMetrics::from_stream_metrics(stream_metrics)),
                             stats_prune_tree.cloned(),
+                            rg_index_to_pos,
                         ));
                     Ok(eval)
                 },
@@ -1074,6 +1077,7 @@ async unsafe fn execute_indexed_with_context_inner(
                             context_id,
                             bloom_config,
                             stats_prune_tree.cloned(),
+                            chunk.row_group_indices.iter().enumerate().map(|(pos, &idx)| (idx, pos)).collect(),
                         ));
                     Ok(eval)
                 },
@@ -1125,6 +1129,15 @@ async unsafe fn execute_indexed_with_context_inner(
                     .collect(),
             );
 
+            // Build prune_tree_config from the normalized tree. This ensures
+            // StatsPruneTree children indices align with ResolvedNode children
+            // (same push_not_down + flatten normalization applied above).
+            prune_tree_config = if pruning_predicates.is_empty() {
+                None
+            } else {
+                Some((Arc::clone(&tree), Arc::clone(&pruning_predicates), schema_for_pruner.clone()))
+            };
+
             Arc::new(
                 move |segment: &SegmentFileInfo, chunk, stream_metrics: &StreamMetrics, stats_prune_tree: Option<&StatsPruneTree>| {
                     // Build one collector per Collector leaf for this chunk.
@@ -1171,6 +1184,7 @@ async unsafe fn execute_indexed_with_context_inner(
                         )),
                         collector_strategy,
                         stats_prune_tree: stats_prune_tree.cloned(),
+                        rg_index_to_pos: chunk.row_group_indices.iter().enumerate().map(|(pos, &idx)| (idx, pos)).collect(),
                     });
                     Ok(eval)
                 },

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/eval/bitmap_tree.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/eval/bitmap_tree.rs
@@ -89,6 +89,7 @@ impl TreeEvaluator for BitmapTreeEvaluator {
         pruning_predicates: &HashMap<usize, Arc<PruningPredicate>>,
         page_prune_metrics: Option<&PagePruneMetrics>,
         stats_prune_tree: Option<&StatsPruneTree>,
+        rg_index_to_pos: &HashMap<usize, usize>,
     ) -> Result<TreePrefetch, String> {
         let mut per_leaf = Vec::new();
         let mut dfs_counter = 0usize;
@@ -106,6 +107,7 @@ impl TreeEvaluator for BitmapTreeEvaluator {
             &mut per_leaf,
             /* under_all_and_path */ true,
             stats_prune_tree,
+            rg_index_to_pos,
         )?;
         Ok(TreePrefetch {
             candidates,
@@ -184,23 +186,26 @@ fn prefetch_node(
     out: &mut Vec<(usize, RoaringBitmap)>,
     under_all_and_path: bool,
     stats_prune_tree: Option<&StatsPruneTree>,
+    rg_index_to_pos: &HashMap<usize, usize>,
 ) -> Result<RoaringBitmap, String> {
     // RG-level subtree pruning: if this subtree provably can't match
     // the current RG, skip the entire tree walk. Since collectors are
     // always-true in the resolution, a false here means a Predicate
     // under AND proved no match — collector bitmaps are irrelevant.
     if let Some(spt) = stats_prune_tree {
-        if let Some(&false) = spt.rg_can_match.get(ctx.rg_idx) {
-            native_bridge_common::log_debug!(
-                "BitmapTree: skipping subtree for RG {} — pruned by RG-level stats",
-                ctx.rg_idx
-            );
-            if under_all_and_path {
-                skip_dfs(node, dfs);
-            } else {
-                skip_dfs_with_empty_bitmaps(node, dfs, out);
+        if let Some(&pos) = rg_index_to_pos.get(&ctx.rg_idx) {
+            if let Some(&false) = spt.rg_can_match.get(pos) {
+                native_bridge_common::log_debug!(
+                    "BitmapTree: skipping subtree for RG {} — pruned by RG-level stats",
+                    ctx.rg_idx
+                );
+                if under_all_and_path {
+                    skip_dfs(node, dfs);
+                } else {
+                    skip_dfs_with_empty_bitmaps(node, dfs, out);
+                }
+                return Ok(RoaringBitmap::new());
             }
-            return Ok(RoaringBitmap::new());
         }
     }
 
@@ -231,6 +236,7 @@ fn prefetch_node(
                     out,
                     under_all_and_path,
                     stats_prune_tree.and_then(|spt| spt.children.get(i)),
+                    rg_index_to_pos,
                 )?;
                 result_bitmap = Some(match result_bitmap {
                     None => child_bitmap,
@@ -295,6 +301,7 @@ fn prefetch_node(
                     // OR breaks all-AND propagation for its subtree.
                     false,
                     stats_prune_tree.and_then(|spt| spt.children.get(val)),
+                    rg_index_to_pos,
                 )?;
                 result_bitmap |= &filtered_bitmap;
 
@@ -329,6 +336,7 @@ fn prefetch_node(
                 out,
                 /* under_all_and_path */ false,
                 stats_prune_tree.and_then(|spt| spt.children.first()),
+                rg_index_to_pos,
             )?;
             // Candidate-stage is a superset. Inverting a superset does
             // NOT yield a superset of the true NOT — it yields a subset
@@ -1210,7 +1218,7 @@ mod tests {
         };
         let pruner = empty_pruner();
         let result = BitmapTreeEvaluator
-            .prefetch(&tree, &test_ctx(), &leaves, &pruner, &HashMap::new(), None, None)
+            .prefetch(&tree, &test_ctx(), &leaves, &pruner, &HashMap::new(), None, None, &HashMap::new())
             .unwrap();
         assert_eq!(result.candidates, bm(&[3, 4]));
         assert_eq!(result.per_leaf.len(), 2);
@@ -1224,7 +1232,7 @@ mod tests {
         };
         let pruner = empty_pruner();
         let result = BitmapTreeEvaluator
-            .prefetch(&tree, &test_ctx(), &leaves, &pruner, &HashMap::new(), None, None)
+            .prefetch(&tree, &test_ctx(), &leaves, &pruner, &HashMap::new(), None, None, &HashMap::new())
             .unwrap();
         assert_eq!(result.candidates, bm(&[1, 2, 3]));
     }
@@ -1237,7 +1245,7 @@ mod tests {
         };
         let pruner = empty_pruner();
         let result = BitmapTreeEvaluator
-            .prefetch(&tree, &test_ctx(), &leaves, &pruner, &HashMap::new(), None, None)
+            .prefetch(&tree, &test_ctx(), &leaves, &pruner, &HashMap::new(), None, None, &HashMap::new())
             .unwrap();
         // Universe is [0, 16). Minus {0,1,2} = {3..15}
         let expected: RoaringBitmap = (3u32..16).collect();
@@ -1252,7 +1260,7 @@ mod tests {
         };
         let pruner = empty_pruner();
         let state = BitmapTreeEvaluator
-            .prefetch(&tree, &test_ctx(), &leaves, &pruner, &HashMap::new(), None, None)
+            .prefetch(&tree, &test_ctx(), &leaves, &pruner, &HashMap::new(), None, None, &HashMap::new())
             .unwrap();
 
         let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, false)]));
@@ -1512,7 +1520,7 @@ mod tests {
         let pruner = empty_pruner();
 
         let result = BitmapTreeEvaluator
-            .prefetch(&tree, &test_ctx(), &leaves, &pruner, &HashMap::new(), None, None)
+            .prefetch(&tree, &test_ctx(), &leaves, &pruner, &HashMap::new(), None, None, &HashMap::new())
             .unwrap();
         assert!(result.candidates.is_empty());
     }
@@ -1552,7 +1560,7 @@ mod tests {
         let pruner = empty_pruner();
 
         let result = BitmapTreeEvaluator
-            .prefetch(&tree, &test_ctx(), &leaves, &pruner, &HashMap::new(), None, None)
+            .prefetch(&tree, &test_ctx(), &leaves, &pruner, &HashMap::new(), None, None, &HashMap::new())
             .unwrap();
         // OR contributes {5} from standalone_leaf → non-empty candidates.
         assert!(!result.candidates.is_empty());
@@ -1590,7 +1598,7 @@ mod tests {
         let pruner = empty_pruner();
 
         let result = BitmapTreeEvaluator
-            .prefetch(&tree, &test_ctx(), &leaves, &pruner, &HashMap::new(), None, None)
+            .prefetch(&tree, &test_ctx(), &leaves, &pruner, &HashMap::new(), None, None, &HashMap::new())
             .unwrap();
         // NOT inverts empty AND → universe.
         assert_eq!(result.candidates.len(), 16);
@@ -1832,7 +1840,7 @@ mod tests {
             prune_tree_leaf(vec![true]),
         ]);
         let result = BitmapTreeEvaluator
-            .prefetch(&tree, &test_ctx(), &leaves, &pruner, &HashMap::new(), None, Some(&spt))
+            .prefetch(&tree, &test_ctx(), &leaves, &pruner, &HashMap::new(), None, Some(&spt), &HashMap::from([(0, 0)]))
             .unwrap();
         assert!(result.candidates.is_empty());
     }
@@ -1849,7 +1857,7 @@ mod tests {
             prune_tree_leaf(vec![true]),
         ]);
         let result = BitmapTreeEvaluator
-            .prefetch(&tree, &test_ctx(), &leaves, &pruner, &HashMap::new(), None, Some(&spt))
+            .prefetch(&tree, &test_ctx(), &leaves, &pruner, &HashMap::new(), None, Some(&spt), &HashMap::from([(0, 0)]))
             .unwrap();
         assert_eq!(result.candidates, bm(&[3, 4]));
     }
@@ -1866,7 +1874,7 @@ mod tests {
             prune_tree_leaf(vec![false]),
         ]);
         let result = BitmapTreeEvaluator
-            .prefetch(&tree, &test_ctx(), &leaves, &pruner, &HashMap::new(), None, Some(&spt))
+            .prefetch(&tree, &test_ctx(), &leaves, &pruner, &HashMap::new(), None, Some(&spt), &HashMap::from([(0, 0)]))
             .unwrap();
         assert!(result.candidates.is_empty());
     }
@@ -1890,7 +1898,7 @@ mod tests {
         ]);
         let spt = prune_tree_and(vec![or_spt, prune_tree_leaf(vec![true])]);
         let result = BitmapTreeEvaluator
-            .prefetch(&tree, &test_ctx(), &leaves, &pruner, &HashMap::new(), None, Some(&spt))
+            .prefetch(&tree, &test_ctx(), &leaves, &pruner, &HashMap::new(), None, Some(&spt), &HashMap::from([(0, 0)]))
             .unwrap();
         // collector2 (dfs=0) → {3,4,5}; OR-child1 (dfs=2) → {3,4,5,6}; OR = {3,4,5,6}
         // AND = {3,4,5} ∩ {3,4,5,6} = {3,4,5}
@@ -1913,7 +1921,7 @@ mod tests {
         ]);
         let spt = prune_tree_and(vec![or_spt, prune_tree_leaf(vec![true])]);
         let result = BitmapTreeEvaluator
-            .prefetch(&tree, &test_ctx(), &leaves, &pruner, &HashMap::new(), None, Some(&spt))
+            .prefetch(&tree, &test_ctx(), &leaves, &pruner, &HashMap::new(), None, Some(&spt), &HashMap::from([(0, 0)]))
             .unwrap();
         assert!(result.candidates.is_empty());
     }
@@ -1926,8 +1934,203 @@ mod tests {
         };
         let pruner = empty_pruner();
         let result = BitmapTreeEvaluator
-            .prefetch(&tree, &test_ctx(), &leaves, &pruner, &HashMap::new(), None, None)
+            .prefetch(&tree, &test_ctx(), &leaves, &pruner, &HashMap::new(), None, None, &HashMap::new())
             .unwrap();
         assert_eq!(result.candidates, bm(&[3, 4]));
+    }
+
+    /// When `rg_idx` is an absolute index not present in the reverse map,
+    /// the subtree must NOT be pruned (conservative: can-match). This
+    /// exercises the offset RG scenario where a chunk doesn't start at 0.
+    #[test]
+    fn stats_prune_tree_offset_rg_idx_not_in_map_does_not_prune() {
+        // Tree: AND(collector0, collector1) with spt root saying position 0 = false.
+        // But rg_idx=5 is NOT in the reverse map → should NOT prune.
+        let tree = ResolvedNode::And(vec![collector_leaf(0), collector_leaf(1)]);
+        let leaves = FixedLeafBitmaps {
+            bitmaps: vec![bm(&[1, 2, 3]), bm(&[2, 3, 4])],
+        };
+        let pruner = empty_pruner();
+        let spt = prune_tree_and(vec![
+            prune_tree_leaf(vec![false]),
+            prune_tree_leaf(vec![true]),
+        ]);
+        // Map has {0→0} but ctx.rg_idx=5 → not in map → no pruning.
+        let rg_map = HashMap::from([(0usize, 0usize)]);
+        let mut ctx = test_ctx();
+        ctx.rg_idx = 5;
+        let result = BitmapTreeEvaluator
+            .prefetch(&tree, &ctx, &leaves, &pruner, &HashMap::new(), None, Some(&spt), &rg_map)
+            .unwrap();
+        // Not pruned — both collectors contribute.
+        assert_eq!(result.candidates, bm(&[2, 3]));
+    }
+
+    /// When `rg_idx` IS in the reverse map and maps to a position where
+    /// `rg_can_match[pos] == false`, the subtree is correctly pruned.
+    #[test]
+    fn stats_prune_tree_offset_rg_idx_in_map_prunes_correctly() {
+        let tree = ResolvedNode::And(vec![collector_leaf(0), collector_leaf(1)]);
+        let leaves = FixedLeafBitmaps {
+            bitmaps: vec![bm(&[1, 2, 3]), bm(&[2, 3, 4])],
+        };
+        let pruner = empty_pruner();
+        // rg_can_match has 3 positions: [true, false, true]
+        // RG indices [2,3,4] → map: {2→0, 3→1, 4→2}
+        let spt = prune_tree_and(vec![
+            prune_tree_leaf(vec![true, false, true]),
+            prune_tree_leaf(vec![true, true, true]),
+        ]);
+        let rg_map = HashMap::from([(2usize, 0usize), (3, 1), (4, 2)]);
+        // rg_idx=3 → pos=1 → root rg_can_match[1] = false (from AND) → pruned
+        let mut ctx = test_ctx();
+        ctx.rg_idx = 3;
+        let result = BitmapTreeEvaluator
+            .prefetch(&tree, &ctx, &leaves, &pruner, &HashMap::new(), None, Some(&spt), &rg_map)
+            .unwrap();
+        assert!(result.candidates.is_empty());
+    }
+
+    /// Regression: when an AND subtree under an OR is stats-pruned because
+    /// a native Predicate leaf proves no-match via column stats, all
+    /// Collector leaves inside the same subtree must still get empty bitmap
+    /// entries in `per_leaf`. Otherwise on_batch refinement panics with
+    /// "leaf bitmap missing for key".
+    ///
+    /// Realistic tree shape (mirrors a PPL query like
+    /// `WHERE (GoodEvent=1 AND (match(Title,'x') OR Age>18)) OR match(URL,'y')`):
+    /// ```text
+    ///           OR
+    ///          /   \
+    ///        AND    coll2
+    ///       /   \
+    ///   Predicate  OR(coll0, coll1)
+    /// ```
+    /// Stats prune: AND subtree → false (Predicate child proves no-match).
+    /// coll0 and coll1 inside the pruned AND must still get empty per_leaf
+    /// entries since coll2 survives → candidates non-empty → refinement runs.
+    #[test]
+    fn stats_prune_under_or_materialises_empty_bitmaps_for_collectors() {
+        use datafusion::physical_expr::expressions::Literal;
+        use datafusion::common::ScalarValue;
+        let always_true_expr: Arc<dyn datafusion::physical_expr::PhysicalExpr> =
+            Arc::new(Literal::new(ScalarValue::Boolean(Some(true))));
+
+        // OR(AND(Predicate, OR(coll0, coll1)), coll2)
+        let tree = ResolvedNode::Or(vec![
+            ResolvedNode::And(vec![
+                ResolvedNode::Predicate(always_true_expr),
+                ResolvedNode::Or(vec![collector_leaf(0), collector_leaf(1)]),
+            ]),
+            collector_leaf(2),
+        ]);
+        // DFS order by cost-sorted evaluation:
+        //   OR sorts: coll2 (cost=10) before AND(Pred+OR) (cost=1+20=21)
+        //   So: coll2 dfs=0, then AND subtree (pruned): Predicate dfs=1, coll0 dfs=2, coll1 dfs=3
+        let leaves = FixedLeafBitmaps {
+            bitmaps: vec![bm(&[5, 6, 7]), bm(&[99]), bm(&[99]), bm(&[99])],
+        };
+        let pruner = empty_pruner();
+        // Stats: AND subtree = false (Predicate child stats=false), coll2 = true
+        let and_spt = prune_tree_and(vec![
+            prune_tree_leaf(vec![false]),  // Predicate
+            prune_tree_or(vec![           // OR(coll0, coll1)
+                prune_tree_leaf(vec![true]),
+                prune_tree_leaf(vec![true]),
+            ]),
+        ]);
+        let spt = prune_tree_or(vec![and_spt, prune_tree_leaf(vec![true])]);
+        let result = BitmapTreeEvaluator
+            .prefetch(&tree, &test_ctx(), &leaves, &pruner, &HashMap::new(), None, Some(&spt), &HashMap::from([(0, 0)]))
+            .unwrap();
+        // AND subtree pruned → empty; coll2 → {5,6,7}; OR = {5,6,7}
+        assert_eq!(result.candidates, bm(&[5, 6, 7]));
+        // Critical: both collector leaves from pruned subtree must have
+        // per_leaf entries (empty bitmaps) so refinement doesn't panic.
+        // coll2 (dfs=0) → real bitmap; coll0 (dfs=2), coll1 (dfs=3) → empty.
+        assert_eq!(
+            result.per_leaf.len(),
+            3,
+            "stats-pruned collectors under OR must still have per_leaf entries; got {}",
+            result.per_leaf.len()
+        );
+        // coll2 (dfs=0) gets real bitmap
+        assert!(!result.per_leaf[0].1.is_empty(), "coll2 should have non-empty bitmap");
+        // coll0 (dfs=2) and coll1 (dfs=3) get empty bitmaps from pruned subtree
+        assert!(result.per_leaf[1].1.is_empty(), "pruned coll0 should have empty bitmap");
+        assert!(result.per_leaf[2].1.is_empty(), "pruned coll1 should have empty bitmap");
+    }
+
+    /// Same scenario but deeper — mirrors a query like:
+    /// `WHERE (GoodEvent=1 AND Income>0 AND (match(T,'x') OR Age>18)) OR (match(S,'buy') AND CounterID>100)`
+    ///
+    /// ```text
+    ///              AND (root)
+    ///             /         \
+    ///         coll3          OR
+    ///                       /   \
+    ///                     AND    coll2
+    ///                    /   \
+    ///              Predicate  OR(coll0, coll1)
+    /// ```
+    /// The inner AND subtree is stats-pruned (Predicate proves no-match).
+    /// coll0 and coll1 must still get empty per_leaf entries.
+    #[test]
+    fn stats_prune_deep_or_under_and_materialises_all_collector_bitmaps() {
+        use datafusion::physical_expr::expressions::Literal;
+        use datafusion::common::ScalarValue;
+        let pred_expr: Arc<dyn datafusion::physical_expr::PhysicalExpr> =
+            Arc::new(Literal::new(ScalarValue::Boolean(Some(true))));
+
+        // AND(coll3, OR(AND(Predicate, OR(coll0, coll1)), coll2))
+        let tree = ResolvedNode::And(vec![
+            collector_leaf(3),
+            ResolvedNode::Or(vec![
+                ResolvedNode::And(vec![
+                    ResolvedNode::Predicate(pred_expr),
+                    ResolvedNode::Or(vec![collector_leaf(0), collector_leaf(1)]),
+                ]),
+                collector_leaf(2),
+            ]),
+        ]);
+        // Cost sort at root AND: coll3(10) before OR(10+1+20=31)
+        // Cost sort at OR: coll2(10) before AND(Pred+OR=1+20=21)
+        // DFS: coll3=0, coll2=1, Predicate=2, coll0=3, coll1=4
+        let leaves = FixedLeafBitmaps {
+            bitmaps: vec![bm(&[5, 6, 7, 8]), bm(&[6, 7, 8]), bm(&[99]), bm(&[99]), bm(&[99])],
+        };
+        let pruner = empty_pruner();
+        // Stats: outer AND[coll3=true, OR=true]
+        //   OR[inner AND=false (pruned), coll2=true]
+        //     inner AND[Predicate=false, OR(coll0=true, coll1=true)]
+        let inner_and_spt = prune_tree_and(vec![
+            prune_tree_leaf(vec![false]),  // Predicate stats=false
+            prune_tree_or(vec![
+                prune_tree_leaf(vec![true]),
+                prune_tree_leaf(vec![true]),
+            ]),
+        ]);
+        let or_spt = prune_tree_or(vec![inner_and_spt, prune_tree_leaf(vec![true])]);
+        let spt = prune_tree_and(vec![prune_tree_leaf(vec![true]), or_spt]);
+        let result = BitmapTreeEvaluator
+            .prefetch(&tree, &test_ctx(), &leaves, &pruner, &HashMap::new(), None, Some(&spt), &HashMap::from([(0, 0)]))
+            .unwrap();
+        // coll3={5,6,7,8}; OR: inner AND pruned→empty, coll2={6,7,8}; OR={6,7,8}
+        // Final AND = {5,6,7,8} ∩ {6,7,8} = {6,7,8}
+        assert_eq!(result.candidates, bm(&[6, 7, 8]));
+        // All 4 collector leaves must have per_leaf entries (coll3, coll2 real;
+        // coll0, coll1 empty from skip_dfs_with_empty_bitmaps).
+        assert_eq!(
+            result.per_leaf.len(),
+            4,
+            "expected 4 per_leaf entries; got {}",
+            result.per_leaf.len()
+        );
+        // coll3 (dfs=0) and coll2 (dfs=1) are real
+        assert!(!result.per_leaf[0].1.is_empty(), "coll3 should have non-empty bitmap");
+        assert!(!result.per_leaf[1].1.is_empty(), "coll2 should have non-empty bitmap");
+        // coll0 (dfs=3) and coll1 (dfs=4) are empty from pruned subtree
+        assert!(result.per_leaf[2].1.is_empty(), "pruned coll0 should have empty bitmap");
+        assert!(result.per_leaf[3].1.is_empty(), "pruned coll1 should have empty bitmap");
     }
 }

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/eval/mod.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/eval/mod.rs
@@ -274,6 +274,7 @@ pub trait TreeEvaluator: Send + Sync {
         pruning_predicates: &HashMap<usize, Arc<PruningPredicate>>,
         page_prune_metrics: Option<&PagePruneMetrics>,
         stats_prune_tree: Option<&StatsPruneTree>,
+        rg_index_to_pos: &HashMap<usize, usize>,
     ) -> Result<TreePrefetch, String>;
 
     /// Refinement stage: produce the exact per-row `BooleanArray` for one
@@ -352,6 +353,8 @@ pub struct TreeBitsetSource {
     pub collector_strategy: CollectorCallStrategy,
     /// Precomputed per-subtree RG match vectors. Built once at construction.
     pub stats_prune_tree: Option<StatsPruneTree>,
+    /// Reverse map: absolute RG index → position in `rg_can_match` vectors.
+    pub rg_index_to_pos: HashMap<usize, usize>,
 }
 
 impl RowGroupBitsetSource for TreeBitsetSource {
@@ -365,12 +368,14 @@ impl RowGroupBitsetSource for TreeBitsetSource {
 
         // RG-level early-exit: precomputed from column stats at construction.
         if let Some(ref ann) = self.stats_prune_tree {
-            if let Some(&false) = ann.rg_can_match.get(rg.index) {
-                native_bridge_common::log_debug!(
-                    "BitmapTree: skipping RG {} — pruned by RG-level stats",
-                    rg.index
-                );
-                return Ok(None);
+            if let Some(&pos) = self.rg_index_to_pos.get(&rg.index) {
+                if let Some(&false) = ann.rg_can_match.get(pos) {
+                    native_bridge_common::log_debug!(
+                        "BitmapTree: skipping RG {} — pruned by RG-level stats",
+                        rg.index
+                    );
+                    return Ok(None);
+                }
             }
         }
 
@@ -422,6 +427,7 @@ impl RowGroupBitsetSource for TreeBitsetSource {
                 // after the bitmap tree is fully resolved.
                 None,
                 self.stats_prune_tree.as_ref(),
+                &self.rg_index_to_pos,
             )
             .map_err(|e| format!("TreeBitsetSource::prefetch_rg(rg={}): {}", rg.index, e))?;
         if prefetch.candidates.is_empty() {
@@ -773,6 +779,7 @@ mod tests {
             _pruning_predicates: &HashMap<usize, Arc<PruningPredicate>>,
             _page_prune_metrics: Option<&PagePruneMetrics>,
             _stats_prune_tree: Option<&StatsPruneTree>,
+            _rg_index_to_pos: &HashMap<usize, usize>,
         ) -> Result<TreePrefetch, String> {
             Ok(TreePrefetch {
                 candidates: roaring::RoaringBitmap::new(),
@@ -822,6 +829,7 @@ mod tests {
             page_prune_metrics: None,
             collector_strategy: CollectorCallStrategy::TightenOuterBounds,
             stats_prune_tree: None,
+            rg_index_to_pos: HashMap::new(),
         };
         assert!(!source.needs_row_mask());
     }

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/eval/mod.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/eval/mod.rs
@@ -352,7 +352,7 @@ pub struct TreeBitsetSource {
     /// be expensive in multi-collector trees.
     pub collector_strategy: CollectorCallStrategy,
     /// Precomputed per-subtree RG match vectors. Built once at construction.
-    pub stats_prune_tree: Option<StatsPruneTree>,
+    pub stats_prune_tree: Option<Arc<StatsPruneTree>>,
     /// Reverse map: absolute RG index → position in `rg_can_match` vectors.
     pub rg_index_to_pos: HashMap<usize, usize>,
 }
@@ -426,7 +426,7 @@ impl RowGroupBitsetSource for TreeBitsetSource {
                 // inflate counts. We compute final page-level metrics below
                 // after the bitmap tree is fully resolved.
                 None,
-                self.stats_prune_tree.as_ref(),
+                self.stats_prune_tree.as_deref(),
                 &self.rg_index_to_pos,
             )
             .map_err(|e| format!("TreeBitsetSource::prefetch_rg(rg={}): {}", rg.index, e))?;

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/eval/predicate_evaluator.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/eval/predicate_evaluator.rs
@@ -13,6 +13,7 @@
 //! Candidates default to the page-pruned universe; `on_batch_mask` evaluates
 //! only the residual predicate.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -36,6 +37,8 @@ pub struct PredicateOnlyEvaluator {
     residual_expr: Option<Arc<dyn datafusion::physical_expr::PhysicalExpr>>,
     page_prune_metrics: Option<PagePruneMetrics>,
     stats_prune_tree: Option<StatsPruneTree>,
+    /// Reverse map: absolute RG index → position in `rg_can_match` vectors.
+    rg_index_to_pos: HashMap<usize, usize>,
 }
 
 impl PredicateOnlyEvaluator {
@@ -45,6 +48,7 @@ impl PredicateOnlyEvaluator {
         residual_expr: Option<Arc<dyn datafusion::physical_expr::PhysicalExpr>>,
         page_prune_metrics: Option<PagePruneMetrics>,
         stats_prune_tree: Option<StatsPruneTree>,
+        rg_index_to_pos: HashMap<usize, usize>,
     ) -> Self {
         Self {
             page_pruner,
@@ -52,6 +56,7 @@ impl PredicateOnlyEvaluator {
             residual_expr,
             page_prune_metrics,
             stats_prune_tree,
+            rg_index_to_pos,
         }
     }
 }
@@ -67,12 +72,14 @@ impl RowGroupBitsetSource for PredicateOnlyEvaluator {
 
         // RG-level early-exit: precomputed from column stats at construction.
         if let Some(ref spt) = self.stats_prune_tree {
-            if let Some(&false) = spt.rg_can_match.get(rg.index) {
-                native_bridge_common::log_debug!(
-                    "PredicateOnly: skipping RG {} — pruned by RG-level stats",
-                    rg.index
-                );
-                return Ok(None);
+            if let Some(&pos) = self.rg_index_to_pos.get(&rg.index) {
+                if let Some(&false) = spt.rg_can_match.get(pos) {
+                    native_bridge_common::log_debug!(
+                        "PredicateOnly: skipping RG {} — pruned by RG-level stats",
+                        rg.index
+                    );
+                    return Ok(None);
+                }
             }
         }
 
@@ -152,7 +159,7 @@ mod tests {
             rg_can_match: vec![false],
             children: vec![],
         };
-        let eval = PredicateOnlyEvaluator::new(pruner, None, None, None, Some(spt));
+        let eval = PredicateOnlyEvaluator::new(pruner, None, None, None, Some(spt), HashMap::from([(0, 0)]));
         let rg = RowGroupInfo { index: 0, first_row: 0, num_rows: 8 };
         assert!(eval.prefetch_rg(&rg, 0, 8).unwrap().is_none());
     }
@@ -164,7 +171,7 @@ mod tests {
             rg_can_match: vec![true],
             children: vec![],
         };
-        let eval = PredicateOnlyEvaluator::new(pruner, None, None, None, Some(spt));
+        let eval = PredicateOnlyEvaluator::new(pruner, None, None, None, Some(spt), HashMap::from([(0, 0)]));
         let rg = RowGroupInfo { index: 0, first_row: 0, num_rows: 8 };
         let prefetched = eval.prefetch_rg(&rg, 0, 8).unwrap().expect("should have candidates");
         assert_eq!(prefetched.candidates.len(), 8);
@@ -173,7 +180,7 @@ mod tests {
     #[test]
     fn stats_prune_tree_none_does_not_prune() {
         let pruner = minimal_page_pruner();
-        let eval = PredicateOnlyEvaluator::new(pruner, None, None, None, None);
+        let eval = PredicateOnlyEvaluator::new(pruner, None, None, None, None, HashMap::new());
         let rg = RowGroupInfo { index: 0, first_row: 0, num_rows: 8 };
         let prefetched = eval.prefetch_rg(&rg, 0, 8).unwrap().expect("should have candidates");
         assert_eq!(prefetched.candidates.len(), 8);

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/eval/predicate_evaluator.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/eval/predicate_evaluator.rs
@@ -36,7 +36,7 @@ pub struct PredicateOnlyEvaluator {
     pruning_predicate: Option<Arc<PruningPredicate>>,
     residual_expr: Option<Arc<dyn datafusion::physical_expr::PhysicalExpr>>,
     page_prune_metrics: Option<PagePruneMetrics>,
-    stats_prune_tree: Option<StatsPruneTree>,
+    stats_prune_tree: Option<Arc<StatsPruneTree>>,
     /// Reverse map: absolute RG index → position in `rg_can_match` vectors.
     rg_index_to_pos: HashMap<usize, usize>,
 }
@@ -47,7 +47,7 @@ impl PredicateOnlyEvaluator {
         pruning_predicate: Option<Arc<PruningPredicate>>,
         residual_expr: Option<Arc<dyn datafusion::physical_expr::PhysicalExpr>>,
         page_prune_metrics: Option<PagePruneMetrics>,
-        stats_prune_tree: Option<StatsPruneTree>,
+        stats_prune_tree: Option<Arc<StatsPruneTree>>,
         rg_index_to_pos: HashMap<usize, usize>,
     ) -> Self {
         Self {
@@ -159,7 +159,7 @@ mod tests {
             rg_can_match: vec![false],
             children: vec![],
         };
-        let eval = PredicateOnlyEvaluator::new(pruner, None, None, None, Some(spt), HashMap::from([(0, 0)]));
+        let eval = PredicateOnlyEvaluator::new(pruner, None, None, None, Some(Arc::new(spt)), HashMap::from([(0, 0)]));
         let rg = RowGroupInfo { index: 0, first_row: 0, num_rows: 8 };
         assert!(eval.prefetch_rg(&rg, 0, 8).unwrap().is_none());
     }
@@ -171,7 +171,7 @@ mod tests {
             rg_can_match: vec![true],
             children: vec![],
         };
-        let eval = PredicateOnlyEvaluator::new(pruner, None, None, None, Some(spt), HashMap::from([(0, 0)]));
+        let eval = PredicateOnlyEvaluator::new(pruner, None, None, None, Some(Arc::new(spt)), HashMap::from([(0, 0)]));
         let rg = RowGroupInfo { index: 0, first_row: 0, num_rows: 8 };
         let prefetched = eval.prefetch_rg(&rg, 0, 8).unwrap().expect("should have candidates");
         assert_eq!(prefetched.candidates.len(), 8);

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/eval/single_collector.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/eval/single_collector.rs
@@ -178,6 +178,8 @@ pub struct SingleCollectorEvaluator {
     bloom_config: Option<BloomConfig>,
     /// Precomputed per-RG/subtree match status from RG-level column stats.
     stats_prune_tree: Option<StatsPruneTree>,
+    /// Reverse map: absolute RG index → position in `rg_can_match` vectors.
+    rg_index_to_pos: HashMap<usize, usize>,
 }
 
 /// Resources needed for per-RG bloom filter pruning.
@@ -206,6 +208,7 @@ impl SingleCollectorEvaluator {
         context_id: i64,
         bloom_config: Option<BloomConfig>,
         stats_prune_tree: Option<StatsPruneTree>,
+        rg_index_to_pos: HashMap<usize, usize>,
     ) -> Self {
         Self {
             collector,
@@ -221,6 +224,7 @@ impl SingleCollectorEvaluator {
             context_id,
             bloom_config,
             stats_prune_tree,
+            rg_index_to_pos,
         }
     }
 }
@@ -263,12 +267,14 @@ impl RowGroupBitsetSource for SingleCollectorEvaluator {
 
         // RG-level early-exit: precomputed from column stats at construction.
         if let Some(ref spt) = self.stats_prune_tree {
-            if let Some(&false) = spt.rg_can_match.get(rg.index) {
-                native_bridge_common::log_debug!(
-                    "SingleCollector: skipping RG {} — pruned by RG-level stats",
-                    rg.index
-                );
-                return Ok(None);
+            if let Some(&pos) = self.rg_index_to_pos.get(&rg.index) {
+                if let Some(&false) = spt.rg_can_match.get(pos) {
+                    native_bridge_common::log_debug!(
+                        "SingleCollector: skipping RG {} — pruned by RG-level stats",
+                        rg.index
+                    );
+                    return Ok(None);
+                }
             }
         }
 
@@ -704,7 +710,7 @@ mod tests {
             docs: vec![0, 3, 7],
         }) as Arc<dyn RowGroupDocsCollector>;
         let pruner = minimal_page_pruner();
-        let eval = SingleCollectorEvaluator::new(Some(collector), pruner, None, None, None, None, CollectorCallStrategy::FullRange, Arc::new(HashMap::new()), 0, Arc::new(FfmDelegatedBackendCollectorFactory), 0, None, None);
+        let eval = SingleCollectorEvaluator::new(Some(collector), pruner, None, None, None, None, CollectorCallStrategy::FullRange, Arc::new(HashMap::new()), 0, Arc::new(FfmDelegatedBackendCollectorFactory), 0, None, None, HashMap::new());
 
         let rg = RowGroupInfo {
             index: 0,
@@ -720,7 +726,7 @@ mod tests {
     fn on_batch_mask_returns_none_for_path_b() {
         let collector = Arc::new(StubCollector { docs: vec![0] }) as Arc<dyn RowGroupDocsCollector>;
         let pruner = minimal_page_pruner();
-        let eval = SingleCollectorEvaluator::new(Some(collector), pruner, None, None, None, None, CollectorCallStrategy::FullRange, Arc::new(HashMap::new()), 0, Arc::new(FfmDelegatedBackendCollectorFactory), 0, None, None);
+        let eval = SingleCollectorEvaluator::new(Some(collector), pruner, None, None, None, None, CollectorCallStrategy::FullRange, Arc::new(HashMap::new()), 0, Arc::new(FfmDelegatedBackendCollectorFactory), 0, None, None, HashMap::new());
         let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, false)]));
         let batch = datafusion::arrow::record_batch::RecordBatch::try_new(
             schema,
@@ -748,7 +754,7 @@ mod tests {
         // (it's the only post-decode filter we have on this path).
         let collector = Arc::new(StubCollector { docs: vec![0] }) as Arc<dyn RowGroupDocsCollector>;
         let pruner = minimal_page_pruner();
-        let eval = SingleCollectorEvaluator::new(Some(collector), pruner, None, None, None, None, CollectorCallStrategy::FullRange, Arc::new(HashMap::new()), 0, Arc::new(FfmDelegatedBackendCollectorFactory), 0, None, None);
+        let eval = SingleCollectorEvaluator::new(Some(collector), pruner, None, None, None, None, CollectorCallStrategy::FullRange, Arc::new(HashMap::new()), 0, Arc::new(FfmDelegatedBackendCollectorFactory), 0, None, None, HashMap::new());
         assert!(eval.needs_row_mask());
     }
 
@@ -756,7 +762,7 @@ mod tests {
     fn empty_match_returns_none() {
         let collector = Arc::new(StubCollector { docs: vec![] }) as Arc<dyn RowGroupDocsCollector>;
         let pruner = minimal_page_pruner();
-        let eval = SingleCollectorEvaluator::new(Some(collector), pruner, None, None, None, None, CollectorCallStrategy::FullRange, Arc::new(HashMap::new()), 0, Arc::new(FfmDelegatedBackendCollectorFactory), 0, None, None);
+        let eval = SingleCollectorEvaluator::new(Some(collector), pruner, None, None, None, None, CollectorCallStrategy::FullRange, Arc::new(HashMap::new()), 0, Arc::new(FfmDelegatedBackendCollectorFactory), 0, None, None, HashMap::new());
         let rg = RowGroupInfo {
             index: 0,
             first_row: 0,
@@ -776,7 +782,7 @@ mod tests {
             docs: vec![0, 3, 7],
         }) as Arc<dyn RowGroupDocsCollector>;
         let pruner = minimal_page_pruner();
-        let eval = SingleCollectorEvaluator::new(Some(collector), pruner, None, None, None, None, CollectorCallStrategy::FullRange, Arc::new(HashMap::new()), 0, Arc::new(FfmDelegatedBackendCollectorFactory), 0, None, None);
+        let eval = SingleCollectorEvaluator::new(Some(collector), pruner, None, None, None, None, CollectorCallStrategy::FullRange, Arc::new(HashMap::new()), 0, Arc::new(FfmDelegatedBackendCollectorFactory), 0, None, None, HashMap::new());
 
         let rg = RowGroupInfo {
             index: 0,
@@ -798,7 +804,7 @@ mod tests {
             rg_can_match: vec![false],
             children: vec![],
         };
-        let eval = SingleCollectorEvaluator::new(Some(collector), pruner, None, None, None, None, CollectorCallStrategy::FullRange, Arc::new(HashMap::new()), 0, Arc::new(FfmDelegatedBackendCollectorFactory), 0, None, Some(spt));
+        let eval = SingleCollectorEvaluator::new(Some(collector), pruner, None, None, None, None, CollectorCallStrategy::FullRange, Arc::new(HashMap::new()), 0, Arc::new(FfmDelegatedBackendCollectorFactory), 0, None, Some(spt), HashMap::from([(0, 0)]));
         let rg = RowGroupInfo {
             index: 0,
             first_row: 0,
@@ -817,7 +823,7 @@ mod tests {
             rg_can_match: vec![true],
             children: vec![],
         };
-        let eval = SingleCollectorEvaluator::new(Some(collector), pruner, None, None, None, None, CollectorCallStrategy::FullRange, Arc::new(HashMap::new()), 0, Arc::new(FfmDelegatedBackendCollectorFactory), 0, None, Some(spt));
+        let eval = SingleCollectorEvaluator::new(Some(collector), pruner, None, None, None, None, CollectorCallStrategy::FullRange, Arc::new(HashMap::new()), 0, Arc::new(FfmDelegatedBackendCollectorFactory), 0, None, Some(spt), HashMap::from([(0, 0)]));
         let rg = RowGroupInfo {
             index: 0,
             first_row: 0,
@@ -834,7 +840,7 @@ mod tests {
             docs: vec![1, 5],
         }) as Arc<dyn RowGroupDocsCollector>;
         let pruner = minimal_page_pruner();
-        let eval = SingleCollectorEvaluator::new(Some(collector), pruner, None, None, None, None, CollectorCallStrategy::FullRange, Arc::new(HashMap::new()), 0, Arc::new(FfmDelegatedBackendCollectorFactory), 0, None, None);
+        let eval = SingleCollectorEvaluator::new(Some(collector), pruner, None, None, None, None, CollectorCallStrategy::FullRange, Arc::new(HashMap::new()), 0, Arc::new(FfmDelegatedBackendCollectorFactory), 0, None, None, HashMap::new());
         let rg = RowGroupInfo {
             index: 0,
             first_row: 0,

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/eval/single_collector.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/eval/single_collector.rs
@@ -177,7 +177,7 @@ pub struct SingleCollectorEvaluator {
     /// Bloom filter pruning config. None = disabled.
     bloom_config: Option<BloomConfig>,
     /// Precomputed per-RG/subtree match status from RG-level column stats.
-    stats_prune_tree: Option<StatsPruneTree>,
+    stats_prune_tree: Option<Arc<StatsPruneTree>>,
     /// Reverse map: absolute RG index → position in `rg_can_match` vectors.
     rg_index_to_pos: HashMap<usize, usize>,
 }
@@ -207,7 +207,7 @@ impl SingleCollectorEvaluator {
         delegated_backend_collector_factory: Arc<dyn DelegatedBackendCollectorFactory>,
         context_id: i64,
         bloom_config: Option<BloomConfig>,
-        stats_prune_tree: Option<StatsPruneTree>,
+        stats_prune_tree: Option<Arc<StatsPruneTree>>,
         rg_index_to_pos: HashMap<usize, usize>,
     ) -> Self {
         Self {
@@ -804,7 +804,7 @@ mod tests {
             rg_can_match: vec![false],
             children: vec![],
         };
-        let eval = SingleCollectorEvaluator::new(Some(collector), pruner, None, None, None, None, CollectorCallStrategy::FullRange, Arc::new(HashMap::new()), 0, Arc::new(FfmDelegatedBackendCollectorFactory), 0, None, Some(spt), HashMap::from([(0, 0)]));
+        let eval = SingleCollectorEvaluator::new(Some(collector), pruner, None, None, None, None, CollectorCallStrategy::FullRange, Arc::new(HashMap::new()), 0, Arc::new(FfmDelegatedBackendCollectorFactory), 0, None, Some(Arc::new(spt)), HashMap::from([(0, 0)]));
         let rg = RowGroupInfo {
             index: 0,
             first_row: 0,
@@ -823,7 +823,7 @@ mod tests {
             rg_can_match: vec![true],
             children: vec![],
         };
-        let eval = SingleCollectorEvaluator::new(Some(collector), pruner, None, None, None, None, CollectorCallStrategy::FullRange, Arc::new(HashMap::new()), 0, Arc::new(FfmDelegatedBackendCollectorFactory), 0, None, Some(spt), HashMap::from([(0, 0)]));
+        let eval = SingleCollectorEvaluator::new(Some(collector), pruner, None, None, None, None, CollectorCallStrategy::FullRange, Arc::new(HashMap::new()), 0, Arc::new(FfmDelegatedBackendCollectorFactory), 0, None, Some(Arc::new(spt)), HashMap::from([(0, 0)]));
         let rg = RowGroupInfo {
             index: 0,
             first_row: 0,

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/page_pruner.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/page_pruner.rs
@@ -1583,7 +1583,7 @@ mod tests {
                 Arc::new(Int32Array::from(vec![0, 5, 10, 17])),
             ],
         )
-        .unwrap();
+            .unwrap();
         let tmp = NamedTempFile::new().unwrap();
         let mut w = ArrowWriter::try_new(tmp.reopen().unwrap(), file_schema, None).unwrap();
         w.write(&batch).unwrap();
@@ -1600,5 +1600,79 @@ mod tests {
             vec![true],
             "severity >= 0 is always true; eval_leaf must not prune under schema drift"
         );
+    }
+
+    /// Verifies that `build_from_bool_node` works correctly when
+    /// `rg_indices` is a subset that doesn't start at 0 (e.g. chunk
+    /// contains RGs [2,3,4] out of a 5-RG file). The `rg_can_match`
+    /// vector should be 3 elements long, indexed 0..2 mapping to
+    /// absolute RGs 2,3,4. Consumers use a reverse map to translate.
+    #[test]
+    fn stats_prune_tree_offset_rg_indices() {
+        use crate::indexed_table::bool_tree::BoolNode;
+
+        // 5 RGs: price [0..9], [10..19], [20..29], [30..39], [40..49]
+        let schema = Arc::new(Schema::new(vec![Field::new("price", DataType::Int32, false)]));
+        let tmp = NamedTempFile::new().unwrap();
+        let props = WriterProperties::builder()
+            .set_max_row_group_size(10)
+            .set_statistics_enabled(EnabledStatistics::Chunk)
+            .build();
+        let mut w = ArrowWriter::try_new(tmp.reopen().unwrap(), schema.clone(), Some(props)).unwrap();
+        for i in 0..5i32 {
+            let vals: Vec<i32> = (i * 10..(i + 1) * 10).collect();
+            let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(Int32Array::from(vals))]).unwrap();
+            w.write(&batch).unwrap();
+        }
+        w.close().unwrap();
+        let meta = ArrowReaderMetadata::load(&tmp.reopen().unwrap(), ArrowReaderOptions::new()).unwrap();
+        let arc_meta = meta.metadata().clone();
+        assert_eq!(arc_meta.num_row_groups(), 5);
+
+        // Chunk only has RGs [2, 3, 4] (prices [20..49])
+        let rg_indices: Vec<usize> = vec![2, 3, 4];
+
+        // price < 35 → full file would be [T,T,T,T,F]; subset [2,3,4] → [T,T,F]
+        let p1 = pred_leaf("price", Operator::Lt, 35, &schema);
+        // price >= 30 → full file would be [F,F,F,T,T]; subset [2,3,4] → [F,T,T]
+        let p2 = pred_leaf("price", Operator::GtEq, 30, &schema);
+
+        // AND(p1, p2) on subset → [T,T,F] & [F,T,T] = [F,T,F]
+        let tree = BoolNode::And(vec![p1.clone(), p2.clone()]);
+
+        let mut leaf_predicates: HashMap<usize, Arc<PruningPredicate>> = HashMap::new();
+        for node in [&p1, &p2] {
+            if let BoolNode::Predicate(expr) = node {
+                let key = Arc::as_ptr(expr) as *const () as usize;
+                let pp = build_pruning_predicate(expr, schema.clone()).unwrap();
+                leaf_predicates.insert(key, pp);
+            }
+        }
+
+        let spt = StatsPruneTree::build_from_bool_node(
+            &tree, &leaf_predicates, &arc_meta, &schema, &rg_indices,
+        );
+
+        // rg_can_match is 3 elements (one per chunk RG), relative indexing.
+        assert_eq!(spt.rg_can_match.len(), 3);
+        // Position 0 → absolute RG 2 (price [20..29]): p1=T, p2=F → AND=F
+        // Position 1 → absolute RG 3 (price [30..39]): p1=T, p2=T → AND=T
+        // Position 2 → absolute RG 4 (price [40..49]): p1=F, p2=T → AND=F
+        assert_eq!(spt.rg_can_match, vec![false, true, false]);
+
+        // Verify consumer-side reverse map lookup works correctly:
+        let rg_index_to_pos: HashMap<usize, usize> = rg_indices.iter()
+            .enumerate().map(|(pos, &idx)| (idx, pos)).collect();
+
+        // Absolute RG 3 should map to position 1 → can_match = true
+        let pos = rg_index_to_pos.get(&3).unwrap();
+        assert_eq!(spt.rg_can_match[*pos], true);
+
+        // Absolute RG 2 should map to position 0 → can_match = false
+        let pos = rg_index_to_pos.get(&2).unwrap();
+        assert_eq!(spt.rg_can_match[*pos], false);
+
+        // Absolute RG 0 (not in chunk) should have no entry
+        assert!(rg_index_to_pos.get(&0).is_none());
     }
 }

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/table_provider.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/table_provider.rs
@@ -195,7 +195,7 @@ pub struct IndexedTableConfig {
     /// Query-level data for building StatsPruneTree per segment.
     /// (BoolNode tree, prebuilt PruningPredicates keyed by Arc ptr, schema)
     pub prune_tree_config: Option<(
-        BoolNode,
+        Arc<BoolNode>,
         Arc<std::collections::HashMap<usize, Arc<PruningPredicate>>>,
         SchemaRef,
     )>,

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/table_provider.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/table_provider.rs
@@ -113,7 +113,7 @@ pub type EvaluatorFactory = Arc<
             &SegmentFileInfo,
             &SegmentChunk,
             &StreamMetrics,
-            Option<&StatsPruneTree>,
+            Option<&Arc<StatsPruneTree>>,
         ) -> Result<Arc<dyn RowGroupBitsetSource>, String>
         + Send
         + Sync,
@@ -646,9 +646,9 @@ impl ExecutionPlan for QueryShardExec {
             // Build stats prune tree for segment/RG/subtree-level pruning.
             let stats_prune_tree = self.config.prune_tree_config.as_ref().map(|(tree, preds, schema)| {
                 let rg_indices: Vec<usize> = row_groups.iter().map(|rg| rg.index).collect();
-                StatsPruneTree::build_from_bool_node(
+                Arc::new(StatsPruneTree::build_from_bool_node(
                     tree, preds, &segment.metadata, schema, &rg_indices,
-                )
+                ))
             });
 
             // Segment-level skip: if no RG in the chunk can match, skip entirely.

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/constant_predicate.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/constant_predicate.rs
@@ -11,6 +11,7 @@
 //! `no index_filter(...) in plan`. Asserts constant-true keeps every row and
 //! constant-false drops every row (the residual is evaluated, not ignored).
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use datafusion::arrow::array::{Array, Int32Array, StringArray};
@@ -90,6 +91,7 @@ async fn run_constant_residual(residual: Arc<dyn PhysicalExpr>) -> usize {
                 Some(Arc::clone(&residual)),
                 Some(PagePruneMetrics::from_stream_metrics(stream_metrics)),
                 None,
+                HashMap::new(),
             ));
             Ok(eval)
         })

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/dynamic_filter_pushdown.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/dynamic_filter_pushdown.rs
@@ -157,6 +157,7 @@ async fn run_indexed(
                     0,
                     None,
                     None,
+                    std::collections::HashMap::new(),
                 ),
             );
             Ok(eval)

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/fuzz/delegation.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/fuzz/delegation.rs
@@ -421,6 +421,7 @@ pub(in crate::indexed_table::tests_e2e) async fn execute_delegation_tree(
                 0,
                 None,
                 None,
+                HashMap::new(),
             ));
             Ok(eval)
         })

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/fuzz/harness.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/fuzz/harness.rs
@@ -13,6 +13,7 @@
 //! is paid once per test, then many iterations run cheap tree
 //! generation + execution against the same file.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use datafusion::arrow::array::{Array, Int32Array};
@@ -213,32 +214,36 @@ pub(in crate::indexed_table::tests_e2e) async fn execute_tree_with_plan_pushdown
     let cfg_target_partitions = _corpus.config.target_partitions;
     let cfg_min_skip_run = _corpus.config.min_skip_run_override;
 
+    // Build per-leaf PruningPredicates the same way indexed_executor.rs
+    // does in production, so our harness exercises real page-pruning
+    // behavior instead of silently falling back to universe bitmaps.
+    let mut leaf_exprs: Vec<Arc<dyn datafusion::physical_expr::PhysicalExpr>> = Vec::new();
+    collect_predicate_exprs_harness(&bool_tree, &mut leaf_exprs);
+    let pruning_predicates: Arc<
+        std::collections::HashMap<
+            usize,
+            Arc<datafusion::physical_optimizer::pruning::PruningPredicate>,
+        >,
+    > = Arc::new(
+        leaf_exprs
+            .iter()
+            .filter_map(|expr| {
+                crate::indexed_table::page_pruner::build_pruning_predicate(expr, loaded.schema.clone())
+                    .map(|pp| (Arc::as_ptr(expr) as *const () as usize, pp))
+            })
+            .collect(),
+    );
+
     let factory: EvaluatorFactory = {
         let per_leaf = per_leaf.clone();
         let tree = Arc::clone(&bool_tree);
         let schema = loaded.schema.clone();
-        // Build per-leaf PruningPredicates the same way indexed_executor.rs
-        // does in production, so our harness exercises real page-pruning
-        // behavior instead of silently falling back to universe bitmaps.
-        let mut leaf_exprs: Vec<Arc<dyn datafusion::physical_expr::PhysicalExpr>> = Vec::new();
-        collect_predicate_exprs_harness(&bool_tree, &mut leaf_exprs);
-        let pruning_predicates: Arc<
-            std::collections::HashMap<
-                usize,
-                Arc<datafusion::physical_optimizer::pruning::PruningPredicate>,
-            >,
-        > = Arc::new(
-            leaf_exprs
-                .iter()
-                .filter_map(|expr| {
-                    crate::indexed_table::page_pruner::build_pruning_predicate(expr, schema.clone())
-                        .map(|pp| (Arc::as_ptr(expr) as *const () as usize, pp))
-                })
-                .collect(),
-        );
-        Arc::new(move |segment, _chunk, stream_metrics, _stats_prune_tree| {
+        let pruning_predicates = Arc::clone(&pruning_predicates);
+        Arc::new(move |segment, chunk, stream_metrics, stats_prune_tree| {
             let resolved = tree.resolve(&per_leaf)?;
             let pruner = Arc::new(PagePruner::new(&schema, Arc::clone(&segment.metadata)));
+            let rg_index_to_pos: HashMap<usize, usize> = chunk.row_group_indices.iter()
+                .enumerate().map(|(pos, &idx)| (idx, pos)).collect();
             let eval: Arc<dyn RowGroupBitsetSource> = Arc::new(TreeBitsetSource {
                 tree: Arc::new(resolved),
                 evaluator: Arc::new(BitmapTreeEvaluator),
@@ -266,7 +271,7 @@ pub(in crate::indexed_table::tests_e2e) async fn execute_tree_with_plan_pushdown
                     crate::indexed_table::eval::CollectorCallStrategy::FullRange,
                     crate::indexed_table::eval::CollectorCallStrategy::PageRangeSplit,
                 ][seed as usize % 3],
-                stats_prune_tree: None,
+                stats_prune_tree: stats_prune_tree.cloned(), rg_index_to_pos,
             });
             Ok(eval)
         })
@@ -294,7 +299,11 @@ pub(in crate::indexed_table::tests_e2e) async fn execute_tree_with_plan_pushdown
         query_config: Arc::new(qc),
         predicate_columns: collect_predicate_column_indices(&bool_tree),
         emit_row_ids: false,
-        prune_tree_config: None,
+        prune_tree_config: Some((
+            Arc::clone(&bool_tree),
+            Arc::clone(&pruning_predicates),
+            loaded.schema.clone(),
+        )),
         sort_fields: vec![],
         sort_orders: vec![],
     }));
@@ -410,6 +419,7 @@ pub(in crate::indexed_table::tests_e2e) async fn execute_tree_single_collector(
                 0,
                 None,
                     None,
+                    std::collections::HashMap::new(),
             ));
             let _ = segment;
             Ok(eval)

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/mod.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/mod.rs
@@ -15,6 +15,7 @@
 
 #![cfg(test)]
 
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::OnceLock;
 
@@ -273,7 +274,7 @@ async fn run_tree_and_plan(
                     ),
                 ),
                 collector_strategy: crate::indexed_table::eval::CollectorCallStrategy::TightenOuterBounds,
-                stats_prune_tree: None,
+                stats_prune_tree: None, rg_index_to_pos: HashMap::new(),
             });
             Ok(eval)
         })

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/multi_segment.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/multi_segment.rs
@@ -1699,7 +1699,7 @@ async fn stats_prune_direct_prefetch_asserts_pruning_and_empty_bitsets() {
         pruning_predicates: Arc::new(pruning_predicates),
         page_prune_metrics: None,
         collector_strategy: crate::indexed_table::eval::CollectorCallStrategy::TightenOuterBounds,
-        stats_prune_tree: Some(spt_low),
+        stats_prune_tree: Some(Arc::new(spt_low)),
         rg_index_to_pos: rg_indices_low.iter().enumerate().map(|(pos, &idx)| (idx, pos)).collect(),
     };
 
@@ -1727,7 +1727,7 @@ async fn stats_prune_direct_prefetch_asserts_pruning_and_empty_bitsets() {
         pruning_predicates: source.pruning_predicates.clone(),
         page_prune_metrics: None,
         collector_strategy: crate::indexed_table::eval::CollectorCallStrategy::TightenOuterBounds,
-        stats_prune_tree: Some(spt),
+        stats_prune_tree: Some(Arc::new(spt)),
         rg_index_to_pos: rg_index_to_pos,
     };
 
@@ -1832,7 +1832,7 @@ async fn stats_prune_asserts_empty_collector_bitset_in_pruned_subtree() {
         pruning_predicates: Arc::new(pruning_predicates),
         page_prune_metrics: None,
         collector_strategy: crate::indexed_table::eval::CollectorCallStrategy::TightenOuterBounds,
-        stats_prune_tree: Some(spt),
+        stats_prune_tree: Some(Arc::new(spt)),
         rg_index_to_pos,
     };
 

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/multi_segment.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/multi_segment.rs
@@ -164,6 +164,7 @@ async fn run_two_segment_query(
                     0,
                     None,
                     None,
+                    std::collections::HashMap::new(),
                 ),
             );
                 Ok(eval)
@@ -376,6 +377,7 @@ async fn run_two_segment_query_witness(
                     0,
                     None,
                     None,
+                    std::collections::HashMap::new(),
                 ),
             );
             Ok(eval)
@@ -586,6 +588,7 @@ async fn run_segments(specs: Vec<SegSpec>, num_partitions: usize) -> Vec<(i32, S
                     0,
                     None,
                     None,
+                    std::collections::HashMap::new(),
                 ),
             );
                 Ok(eval)
@@ -1094,7 +1097,7 @@ async fn run_wide_segments(
                     pruning_predicates: std::sync::Arc::new(std::collections::HashMap::new()),
                 page_prune_metrics: None,
                     collector_strategy: crate::indexed_table::eval::CollectorCallStrategy::TightenOuterBounds,
-                stats_prune_tree: None,
+                stats_prune_tree: None, rg_index_to_pos: HashMap::new(),
                 },
             );
             Ok(eval)
@@ -1316,5 +1319,662 @@ async fn wide_multi_segment_deep_tree_four_predicate_columns() {
     for np in [1usize, 2, 5] {
         let rows = run_wide_segments(clone_wide_specs(&specs), tree.clone(), np).await;
         assert_eq!(rows, expected, "np={} failed", np);
+    }
+}
+
+// ── StatsPruneTree integration with offset RG indices ───────────────
+//
+// These tests exercise the full pipeline with `prune_tree_config: Some(...)`
+// enabled, causing `table_provider` to build `StatsPruneTree` per chunk.
+// Verifies correctness when chunks have offset RG indices and when AND
+// subtrees with native predicates get stats-pruned while OR subtrees
+// containing collectors still produce empty bitmaps.
+//
+// Tree shape: AND(Predicate(price > X), OR(Collector, Predicate(qty/active)))
+// Mirrors the failing PPL pattern.
+
+fn collect_pred_exprs(
+    tree: &BoolNode,
+    out: &mut Vec<Arc<dyn datafusion::physical_expr::PhysicalExpr>>,
+) {
+    match tree {
+        BoolNode::And(c) | BoolNode::Or(c) => c.iter().for_each(|ch| collect_pred_exprs(ch, out)),
+        BoolNode::Not(inner) => collect_pred_exprs(inner, out),
+        BoolNode::Collector { .. } => {}
+        BoolNode::Predicate(expr) => out.push(Arc::clone(expr)),
+        BoolNode::DelegationPossible { original_expr, .. } => out.push(Arc::clone(original_expr)),
+    }
+}
+
+async fn run_wide_segments_with_stats_pruning(
+    specs: Vec<WideSegSpec>,
+    tree: BoolNode,
+    num_partitions: usize,
+) -> Vec<(i32, i32, i32, String, bool)> {
+    #[derive(Debug)]
+    struct AllDocs;
+    impl RowGroupDocsCollector for AllDocs {
+        fn collect_packed_u64_bitset(
+            &self,
+            min_doc: i32,
+            max_doc: i32,
+        ) -> Result<Vec<u64>, String> {
+            let span = (max_doc - min_doc) as usize;
+            let mut out = vec![0u64; span.div_ceil(64)];
+            for i in 0..span {
+                out[i / 64] |= 1u64 << (i % 64);
+            }
+            Ok(out)
+        }
+    }
+
+    let tmps: Vec<NamedTempFile> = specs
+        .iter()
+        .map(|s| write_wide_segment(s.brand, s.rows, s.max_rg_rows))
+        .collect();
+
+    let mut segments: Vec<SegmentFileInfo> = Vec::new();
+    let mut schema_opt: Option<SchemaRef> = None;
+    for (ord, tmp) in tmps.iter().enumerate() {
+        let path = tmp.path().to_path_buf();
+        let size = std::fs::metadata(&path).unwrap().len();
+        let file = std::fs::File::open(&path).unwrap();
+        let meta =
+            ArrowReaderMetadata::load(&file, ArrowReaderOptions::new().with_page_index(true))
+                .unwrap();
+        if schema_opt.is_none() {
+            schema_opt = Some(meta.schema().clone());
+        }
+        let parquet_meta = meta.metadata().clone();
+        let mut rgs = Vec::new();
+        let mut offset = 0i64;
+        for i in 0..parquet_meta.num_row_groups() {
+            let n = parquet_meta.row_group(i).num_rows();
+            rgs.push(RowGroupInfo {
+                index: i,
+                first_row: offset,
+                num_rows: n,
+            });
+            offset += n;
+        }
+        let object_path = object_store::path::Path::from(path.to_string_lossy().as_ref());
+        segments.push(SegmentFileInfo {
+            writer_generation: ord as i64,
+            max_doc: offset,
+            object_path,
+            parquet_size: size,
+            row_groups: rgs,
+            metadata: Arc::clone(&parquet_meta),
+            global_base: 0,
+            sort_min: None,
+            sort_max: None,
+        });
+    }
+
+    let schema = schema_opt.unwrap();
+    let tree = tree.push_not_down().flatten();
+
+    let mut leaf_exprs: Vec<Arc<dyn datafusion::physical_expr::PhysicalExpr>> = Vec::new();
+    collect_pred_exprs(&tree, &mut leaf_exprs);
+    let pruning_predicates: Arc<HashMap<usize, Arc<datafusion::physical_optimizer::pruning::PruningPredicate>>> = Arc::new(
+        leaf_exprs
+            .iter()
+            .filter_map(|expr| {
+                crate::indexed_table::page_pruner::build_pruning_predicate(expr, schema.clone())
+                    .map(|pp| (Arc::as_ptr(expr) as *const () as usize, pp))
+            })
+            .collect(),
+    );
+
+    let tree = Arc::new(tree);
+
+    let factory: super::super::table_provider::EvaluatorFactory = {
+        let tree = Arc::clone(&tree);
+        let schema = schema.clone();
+        let pruning_predicates = Arc::clone(&pruning_predicates);
+        Arc::new(move |segment, chunk, stream_metrics, stats_prune_tree| {
+            let leaf_count = tree.collector_leaf_count();
+            let per_leaf: Vec<(i32, Arc<dyn RowGroupDocsCollector>)> = (0..leaf_count)
+                .map(|i| (i as i32, Arc::new(AllDocs) as Arc<dyn RowGroupDocsCollector>))
+                .collect();
+            let resolved = tree.resolve(&per_leaf)?;
+            let pruner = Arc::new(PagePruner::new(&schema, Arc::clone(&segment.metadata)));
+            let rg_index_to_pos: HashMap<usize, usize> = chunk.row_group_indices.iter()
+                .enumerate().map(|(pos, &idx)| (idx, pos)).collect();
+            let eval: Arc<dyn RowGroupBitsetSource> = Arc::new(
+                crate::indexed_table::eval::TreeBitsetSource {
+                    tree: Arc::new(resolved),
+                    evaluator: Arc::new(crate::indexed_table::eval::bitmap_tree::BitmapTreeEvaluator),
+                    leaves: Arc::new(crate::indexed_table::eval::bitmap_tree::CollectorLeafBitmaps::without_metrics()),
+                    page_pruner: pruner,
+                    cost_predicate: 1,
+                    cost_collector: 10,
+                    max_collector_parallelism: 1,
+                    pruning_predicates: Arc::clone(&pruning_predicates),
+                    page_prune_metrics: Some(
+                        crate::indexed_table::page_pruner::PagePruneMetrics::from_stream_metrics(stream_metrics),
+                    ),
+                    collector_strategy: crate::indexed_table::eval::CollectorCallStrategy::TightenOuterBounds,
+                    stats_prune_tree: stats_prune_tree.cloned(),
+                    rg_index_to_pos,
+                },
+            );
+            Ok(eval)
+        })
+    };
+
+    let store: Arc<dyn object_store::ObjectStore> =
+        Arc::new(object_store::local::LocalFileSystem::new());
+    let store_url = datafusion::execution::object_store::ObjectStoreUrl::local_filesystem();
+    let qc = crate::datafusion_query_config::DatafusionQueryConfig::builder()
+        .target_partitions(num_partitions)
+        .force_strategy(Some(FilterStrategy::BooleanMask))
+        .force_pushdown(Some(false))
+        .build();
+    let provider = Arc::new(IndexedTableProvider::new(IndexedTableConfig {
+        schema: schema.clone(),
+        segments,
+        store,
+        store_url,
+        evaluator_factory: factory,
+        pushdown_predicate: None,
+        query_config: std::sync::Arc::new(qc),
+        predicate_columns: vec![],
+        emit_row_ids: false,
+        prune_tree_config: Some((Arc::clone(&tree), Arc::clone(&pruning_predicates), schema.clone())),
+        sort_fields: vec![],
+        sort_orders: vec![],
+    }));
+
+    let ctx = SessionContext::new();
+    ctx.register_table("t", provider).unwrap();
+    let df = ctx.sql("SELECT brand, price, qty, region, active FROM t").await.unwrap();
+    let mut stream = df.execute_stream().await.unwrap();
+    let mut rows: Vec<(i32, i32, i32, String, bool)> = Vec::new();
+    while let Some(batch) = stream.next().await {
+        let b = batch.unwrap();
+        let brand = b.column(0).as_any().downcast_ref::<StringArray>().unwrap();
+        let price = b.column(1).as_any().downcast_ref::<Int32Array>().unwrap();
+        let qty = b.column(2).as_any().downcast_ref::<Int32Array>().unwrap();
+        let region = b.column(3).as_any().downcast_ref::<StringArray>().unwrap();
+        let active = b.column(4).as_any().downcast_ref::<datafusion::arrow::array::BooleanArray>().unwrap();
+        for i in 0..b.num_rows() {
+            let ord = specs.iter().position(|s| s.brand == brand.value(i)).unwrap_or(0) as i32;
+            rows.push((ord, price.value(i), qty.value(i), region.value(i).to_string(), active.value(i)));
+        }
+    }
+    rows.sort();
+    rows
+}
+
+/// Single segment (4 RGs of 4 rows), single partition.
+/// Tree: AND(price > 50, OR(Collector, qty < 3))
+/// RGs with prices [0..30] are stats-pruned by `price > 50`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn stats_prune_single_segment_single_partition() {
+    let specs = vec![WideSegSpec { brand: "amazon", rows: 16, max_rg_rows: 4 }];
+    let tree = BoolNode::And(vec![
+        pred_wide_int("price", Operator::Gt, 50),
+        BoolNode::Or(vec![
+            BoolNode::Collector { annotation_id: 0 },
+            pred_wide_int("qty", Operator::Lt, 3),
+        ]),
+    ]);
+    // Collector matches all docs; OR(all, qty<3) = all; so just price > 50.
+    let expected = wide_oracle(&specs, |i| (i as i32) * 10 > 50);
+    let rows = run_wide_segments_with_stats_pruning(specs, tree, 1).await;
+    assert_eq!(rows, expected);
+}
+
+/// Single segment (4 RGs), multi partition (4 partitions → 1 RG per chunk).
+/// Each chunk has rg_indices=[N] where N>0 for non-first chunks.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn stats_prune_single_segment_multi_partition() {
+    let specs = vec![WideSegSpec { brand: "amazon", rows: 16, max_rg_rows: 4 }];
+    let tree = BoolNode::And(vec![
+        pred_wide_int("price", Operator::Gt, 50),
+        BoolNode::Or(vec![
+            BoolNode::Collector { annotation_id: 0 },
+            pred_wide_int("qty", Operator::Lt, 3),
+        ]),
+    ]);
+    let expected = wide_oracle(&specs, |i| (i as i32) * 10 > 50);
+    let rows = run_wide_segments_with_stats_pruning(specs, tree, 4).await;
+    assert_eq!(rows, expected);
+}
+
+/// Multi segment (4 segments × 4 RGs), single partition.
+/// All segments in one partition — verifies stats pruning across segments.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn stats_prune_multi_segment_single_partition() {
+    let specs = wide_four_seg_specs();
+    let tree = BoolNode::And(vec![
+        pred_wide_int("price", Operator::Gt, 80),
+        BoolNode::Or(vec![
+            BoolNode::Collector { annotation_id: 0 },
+            pred_wide_bool("active", Operator::Eq, true),
+        ]),
+    ]);
+    let expected = wide_oracle(&specs, |i| (i as i32) * 10 > 80);
+    let rows = run_wide_segments_with_stats_pruning(clone_wide_specs(&specs), tree, 1).await;
+    assert_eq!(rows, expected);
+}
+
+/// Multi segment (4 segments × 4 RGs), multi partition (2, 3, 5, 8).
+/// Maximum fragmentation — chunks split across segments with offset RGs.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn stats_prune_multi_segment_multi_partition() {
+    let specs = wide_four_seg_specs();
+    let tree = BoolNode::And(vec![
+        pred_wide_int("price", Operator::Gt, 80),
+        BoolNode::Or(vec![
+            BoolNode::Collector { annotation_id: 0 },
+            pred_wide_bool("active", Operator::Eq, true),
+        ]),
+    ]);
+    let expected = wide_oracle(&specs, |i| (i as i32) * 10 > 80);
+    for np in [2usize, 3, 5, 8] {
+        let rows = run_wide_segments_with_stats_pruning(clone_wide_specs(&specs), tree.clone(), np).await;
+        assert_eq!(rows, expected, "np={} failed", np);
+    }
+}
+
+/// Deep tree with NOT under multi-partition multi-segment.
+/// AND(NOT(price < 40), OR(Collector, qty >= 5))
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn stats_prune_multi_segment_multi_partition_with_not() {
+    let specs = wide_four_seg_specs();
+    let tree = BoolNode::And(vec![
+        BoolNode::Not(Box::new(pred_wide_int("price", Operator::Lt, 40))),
+        BoolNode::Or(vec![
+            BoolNode::Collector { annotation_id: 0 },
+            pred_wide_int("qty", Operator::GtEq, 5),
+        ]),
+    ]);
+    // NOT is conservative in stats (always true), so actual predicate filters.
+    let expected = wide_oracle(&specs, |i| !((i as i32) * 10 < 40));
+    for np in [1usize, 3, 5] {
+        let rows = run_wide_segments_with_stats_pruning(clone_wide_specs(&specs), tree.clone(), np).await;
+        assert_eq!(rows, expected, "np={} failed", np);
+    }
+}
+
+/// Directly exercises `prefetch_rg` to assert:
+/// 1. RGs with stats that prove no-match return `None` (pruned)
+/// 2. RGs at offset indices (index > 0) are correctly handled
+/// 3. Empty collector bitsets are produced for pruned subtrees
+///
+/// Uses a single segment with 4 RGs (prices [0..30],[30..70],[70..110],[110..150])
+/// and tree AND(price > 60, OR(Collector, qty < 2)).
+/// RG0 and RG1 should be pruned (max price < 60). RG2 and RG3 survive.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn stats_prune_direct_prefetch_asserts_pruning_and_empty_bitsets() {
+    use crate::indexed_table::page_pruner::StatsPruneTree;
+
+    // Build a segment with 4 RGs of 4 rows each.
+    // prices: [0,10,20,30], [40,50,60,70], [80,90,100,110], [120,130,140,150]
+    let spec = WideSegSpec { brand: "amazon", rows: 16, max_rg_rows: 4 };
+    let tmp = write_wide_segment(spec.brand, spec.rows, spec.max_rg_rows);
+    let path = tmp.path().to_path_buf();
+    let file = std::fs::File::open(&path).unwrap();
+    let meta = ArrowReaderMetadata::load(&file, ArrowReaderOptions::new().with_page_index(true)).unwrap();
+    let parquet_meta = meta.metadata().clone();
+    let schema = meta.schema().clone();
+    assert_eq!(parquet_meta.num_row_groups(), 4);
+
+    // Tree: AND(price > 60, OR(Collector, qty < 2))
+    let tree = BoolNode::And(vec![
+        pred_wide_int("price", Operator::Gt, 60),
+        BoolNode::Or(vec![
+            BoolNode::Collector { annotation_id: 0 },
+            pred_wide_int("qty", Operator::Lt, 2),
+        ]),
+    ]);
+    let tree = tree.push_not_down().flatten();
+
+    // Build pruning predicates.
+    let mut leaf_exprs: Vec<Arc<dyn datafusion::physical_expr::PhysicalExpr>> = Vec::new();
+    collect_pred_exprs(&tree, &mut leaf_exprs);
+    let pruning_predicates: HashMap<usize, Arc<datafusion::physical_optimizer::pruning::PruningPredicate>> =
+        leaf_exprs
+            .iter()
+            .filter_map(|expr| {
+                crate::indexed_table::page_pruner::build_pruning_predicate(expr, schema.clone())
+                    .map(|pp| (Arc::as_ptr(expr) as *const () as usize, pp))
+            })
+            .collect();
+
+    // Simulate a chunk with RGs [2, 3] (offset — doesn't start at 0).
+    let rg_indices: Vec<usize> = vec![2, 3];
+    let spt = StatsPruneTree::build_from_bool_node(
+        &tree, &pruning_predicates, &parquet_meta, &schema, &rg_indices,
+    );
+
+    // Assert: rg_can_match for position 0 (RG2, prices 80-110) should be true (price>60 matches).
+    // Assert: rg_can_match for position 1 (RG3, prices 120-150) should be true.
+    let rg_index_to_pos: HashMap<usize, usize> = rg_indices.iter()
+        .enumerate().map(|(pos, &idx)| (idx, pos)).collect();
+    assert_eq!(spt.rg_can_match.len(), 2, "subset-relative: 2 RGs in chunk");
+    assert!(spt.rg_can_match[0], "RG2 (prices 80-110) should match price>60");
+    assert!(spt.rg_can_match[1], "RG3 (prices 120-150) should match price>60");
+
+    // Now simulate a chunk with RGs [0, 1] — these SHOULD be pruned.
+    let rg_indices_low: Vec<usize> = vec![0, 1];
+    let spt_low = StatsPruneTree::build_from_bool_node(
+        &tree, &pruning_predicates, &parquet_meta, &schema, &rg_indices_low,
+    );
+    // RG0 (prices 0-30): price>60 → false → AND=false
+    assert!(!spt_low.rg_can_match[0], "RG0 (prices 0-30) should be pruned by price>60");
+    // RG1 (prices 40-70): price>60 might be true for row with price=70
+    // (stats: min=40, max=70, so max > 60 → can_match=true at RG stats level)
+    // This is expected: stats pruning is conservative.
+
+    // Build a TreeBitsetSource with the offset chunk [2,3] and call prefetch_rg.
+    #[derive(Debug)]
+    struct AllDocs;
+    impl RowGroupDocsCollector for AllDocs {
+        fn collect_packed_u64_bitset(&self, min_doc: i32, max_doc: i32) -> Result<Vec<u64>, String> {
+            let span = (max_doc - min_doc) as usize;
+            let mut out = vec![0u64; span.div_ceil(64)];
+            for i in 0..span { out[i / 64] |= 1u64 << (i % 64); }
+            Ok(out)
+        }
+    }
+
+    let tree_arc = Arc::new(tree);
+    let per_leaf: Vec<(i32, Arc<dyn RowGroupDocsCollector>)> = vec![
+        (0, Arc::new(AllDocs) as Arc<dyn RowGroupDocsCollector>),
+    ];
+    let resolved = tree_arc.resolve(&per_leaf).unwrap();
+    let pruner = Arc::new(PagePruner::new(&schema, Arc::clone(&parquet_meta)));
+
+    let source = crate::indexed_table::eval::TreeBitsetSource {
+        tree: Arc::new(resolved),
+        evaluator: Arc::new(crate::indexed_table::eval::bitmap_tree::BitmapTreeEvaluator),
+        leaves: Arc::new(crate::indexed_table::eval::bitmap_tree::CollectorLeafBitmaps::without_metrics()),
+        page_pruner: pruner,
+        cost_predicate: 1,
+        cost_collector: 10,
+        max_collector_parallelism: 1,
+        pruning_predicates: Arc::new(pruning_predicates),
+        page_prune_metrics: None,
+        collector_strategy: crate::indexed_table::eval::CollectorCallStrategy::TightenOuterBounds,
+        stats_prune_tree: Some(spt_low),
+        rg_index_to_pos: rg_indices_low.iter().enumerate().map(|(pos, &idx)| (idx, pos)).collect(),
+    };
+
+    // Assert: prefetch_rg for RG0 (offset index 0, pruned) returns None.
+    let rg0 = RowGroupInfo { index: 0, first_row: 0, num_rows: 4 };
+    let result_rg0 = source.prefetch_rg(&rg0, 0, 4).unwrap();
+    assert!(result_rg0.is_none(), "RG0 should be pruned by stats (price>60 fails for prices 0-30)");
+
+    // Assert: prefetch_rg for RG1 at offset index 1 — may or may not be pruned
+    // depending on stats (max price in RG1 is 70 which > 60, so can_match=true).
+    let rg1 = RowGroupInfo { index: 1, first_row: 4, num_rows: 4 };
+    let result_rg1 = source.prefetch_rg(&rg1, 4, 8).unwrap();
+    // RG1 (prices 40-70): max=70 > 60, so stats say can-match. Not pruned.
+    assert!(result_rg1.is_some(), "RG1 (max price=70) should not be stats-pruned");
+
+    // Now build source for chunk [2,3] — both survive. Verify offset lookup works.
+    let source2 = crate::indexed_table::eval::TreeBitsetSource {
+        tree: source.tree.clone(),
+        evaluator: Arc::new(crate::indexed_table::eval::bitmap_tree::BitmapTreeEvaluator),
+        leaves: Arc::new(crate::indexed_table::eval::bitmap_tree::CollectorLeafBitmaps::without_metrics()),
+        page_pruner: Arc::new(PagePruner::new(&schema, Arc::clone(&parquet_meta))),
+        cost_predicate: 1,
+        cost_collector: 10,
+        max_collector_parallelism: 1,
+        pruning_predicates: source.pruning_predicates.clone(),
+        page_prune_metrics: None,
+        collector_strategy: crate::indexed_table::eval::CollectorCallStrategy::TightenOuterBounds,
+        stats_prune_tree: Some(spt),
+        rg_index_to_pos: rg_index_to_pos,
+    };
+
+    // RG2 at absolute index 2: should NOT be pruned (prices 80-110, all > 60).
+    let rg2 = RowGroupInfo { index: 2, first_row: 8, num_rows: 4 };
+    let result_rg2 = source2.prefetch_rg(&rg2, 8, 12).unwrap();
+    assert!(result_rg2.is_some(), "RG2 at offset index should not be pruned");
+    // Verify the collector bitmap is non-empty (all docs match).
+    let prefetched = result_rg2.unwrap();
+    assert!(!prefetched.candidates.is_empty(), "RG2 should have non-empty candidates");
+
+    // RG3 at absolute index 3: should NOT be pruned.
+    let rg3 = RowGroupInfo { index: 3, first_row: 12, num_rows: 4 };
+    let result_rg3 = source2.prefetch_rg(&rg3, 12, 16).unwrap();
+    assert!(result_rg3.is_some(), "RG3 at offset index should not be pruned");
+}
+
+/// Directly asserts that when a subtree under OR is stats-pruned, the
+/// collector inside it gets an empty bitmap in `per_leaf`.
+///
+/// Tree: OR(AND(price > 100, Collector0), Collector1)
+/// For RG1 (prices 40-70): AND subtree is pruned (price>100 fails).
+/// Collector1 survives → RG not skipped → refinement runs.
+/// Collector0 must have an empty per_leaf entry.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn stats_prune_asserts_empty_collector_bitset_in_pruned_subtree() {
+    use crate::indexed_table::eval::RowGroupBitsetSource;
+    use crate::indexed_table::page_pruner::StatsPruneTree;
+
+    let spec = WideSegSpec { brand: "amazon", rows: 16, max_rg_rows: 4 };
+    let tmp = write_wide_segment(spec.brand, spec.rows, spec.max_rg_rows);
+    let path = tmp.path().to_path_buf();
+    let file = std::fs::File::open(&path).unwrap();
+    let meta = ArrowReaderMetadata::load(&file, ArrowReaderOptions::new().with_page_index(true)).unwrap();
+    let parquet_meta = meta.metadata().clone();
+    let schema = meta.schema().clone();
+
+    // Tree: OR(AND(price > 100, Collector0), Collector1)
+    // Collector0 is under AND with a predicate that fails for low-price RGs.
+    // Collector1 always matches → OR always has candidates.
+    let tree = BoolNode::Or(vec![
+        BoolNode::And(vec![
+            pred_wide_int("price", Operator::Gt, 100),
+            BoolNode::Collector { annotation_id: 0 },
+        ]),
+        BoolNode::Collector { annotation_id: 1 },
+    ]);
+    let tree = tree.push_not_down().flatten();
+
+    let mut leaf_exprs: Vec<Arc<dyn datafusion::physical_expr::PhysicalExpr>> = Vec::new();
+    collect_pred_exprs(&tree, &mut leaf_exprs);
+    let pruning_predicates: HashMap<usize, Arc<datafusion::physical_optimizer::pruning::PruningPredicate>> =
+        leaf_exprs
+            .iter()
+            .filter_map(|expr| {
+                crate::indexed_table::page_pruner::build_pruning_predicate(expr, schema.clone())
+                    .map(|pp| (Arc::as_ptr(expr) as *const () as usize, pp))
+            })
+            .collect();
+
+    // Chunk with RG1 only (prices 40-70). Offset index = 1.
+    let rg_indices: Vec<usize> = vec![1];
+    let spt = StatsPruneTree::build_from_bool_node(
+        &tree, &pruning_predicates, &parquet_meta, &schema, &rg_indices,
+    );
+    // Root OR should still be true (Collector1 child is always-true).
+    assert!(spt.rg_can_match[0], "OR root should be true (Collector1 always matches)");
+    // AND child should be false (price>100 fails for RG1 max=70).
+    assert!(!spt.children[0].rg_can_match[0], "AND(price>100, Coll0) should be false for RG1");
+    // Collector1 child should be true.
+    assert!(spt.children[1].rg_can_match[0], "Collector1 should be true");
+
+    // Build evaluator and call prefetch_rg for RG1.
+    #[derive(Debug)]
+    struct AllDocs;
+    impl RowGroupDocsCollector for AllDocs {
+        fn collect_packed_u64_bitset(&self, min_doc: i32, max_doc: i32) -> Result<Vec<u64>, String> {
+            let span = (max_doc - min_doc) as usize;
+            let mut out = vec![0u64; span.div_ceil(64)];
+            for i in 0..span { out[i / 64] |= 1u64 << (i % 64); }
+            Ok(out)
+        }
+    }
+
+    let per_leaf: Vec<(i32, Arc<dyn RowGroupDocsCollector>)> = vec![
+        (0, Arc::new(AllDocs) as Arc<dyn RowGroupDocsCollector>),
+        (1, Arc::new(AllDocs) as Arc<dyn RowGroupDocsCollector>),
+    ];
+    let resolved = Arc::new(tree).resolve(&per_leaf).unwrap();
+    let pruner = Arc::new(PagePruner::new(&schema, Arc::clone(&parquet_meta)));
+    let rg_index_to_pos: HashMap<usize, usize> = rg_indices.iter()
+        .enumerate().map(|(pos, &idx)| (idx, pos)).collect();
+
+    let source = crate::indexed_table::eval::TreeBitsetSource {
+        tree: Arc::new(resolved),
+        evaluator: Arc::new(crate::indexed_table::eval::bitmap_tree::BitmapTreeEvaluator),
+        leaves: Arc::new(crate::indexed_table::eval::bitmap_tree::CollectorLeafBitmaps::without_metrics()),
+        page_pruner: pruner,
+        cost_predicate: 1,
+        cost_collector: 10,
+        max_collector_parallelism: 1,
+        pruning_predicates: Arc::new(pruning_predicates),
+        page_prune_metrics: None,
+        collector_strategy: crate::indexed_table::eval::CollectorCallStrategy::TightenOuterBounds,
+        stats_prune_tree: Some(spt),
+        rg_index_to_pos,
+    };
+
+    // RG1 at absolute index 1: NOT pruned at root (OR is true).
+    let rg1 = RowGroupInfo { index: 1, first_row: 4, num_rows: 4 };
+    let result = source.prefetch_rg(&rg1, 4, 8).unwrap();
+    assert!(result.is_some(), "RG1 should NOT be pruned at root (OR has surviving child)");
+
+    let prefetched = result.unwrap();
+    // Candidates should be non-empty (Collector1 matches all docs).
+    assert!(!prefetched.candidates.is_empty(), "Collector1 should produce non-empty candidates");
+
+    // Downcast context to TreePrefetch to inspect per_leaf bitmaps.
+    let tree_prefetch = prefetched.context
+        .downcast_ref::<crate::indexed_table::eval::TreePrefetch>()
+        .expect("context should be TreePrefetch");
+
+    // Critical assertion: per_leaf must have 2 entries (one per collector).
+    assert_eq!(
+        tree_prefetch.per_leaf.len(), 2,
+        "both collectors must have per_leaf entries; got {}",
+        tree_prefetch.per_leaf.len()
+    );
+
+    // Collector0 (inside pruned AND subtree) must have EMPTY bitmap.
+    let has_empty = tree_prefetch.per_leaf.iter().any(|(_, bm)| bm.is_empty());
+    assert!(has_empty, "pruned Collector0 should have an empty bitmap in per_leaf");
+
+    // Collector1 (surviving) must have NON-EMPTY bitmap.
+    let has_nonempty = tree_prefetch.per_leaf.iter().any(|(_, bm)| !bm.is_empty());
+    assert!(has_nonempty, "surviving Collector1 should have a non-empty bitmap in per_leaf");
+}
+
+/// Regression test for the flatten-misalignment bug: when the BoolNode tree
+/// used for StatsPruneTree is not normalized (push_not_down + flatten), child
+/// indices in spt.children don't match ResolvedNode children, causing the
+/// wrong branch's rg_can_match to be applied — pruning rows that match via
+/// a sibling OR branch.
+///
+/// Scenario: 3-way OR built as nested OR(OR(A,B), C) — after flatten becomes
+/// OR(A, B, C). Each AND branch pairs a Collector with a Predicate. One
+/// Predicate is prunable by RG stats. The test verifies that rows matching
+/// a non-pruned branch still appear in results regardless of clause ordering.
+///
+/// Tree: OR(AND(Collector0, price > 100), AND(Collector1, region = "us-east"), AND(Collector2, qty > 5))
+/// Data: 16 rows, 4 RGs of 4 rows each.
+///   prices: 0,10,20,30 | 40,50,60,70 | 80,90,100,110 | 120,130,140,150
+///   qtys: 0,1,2,3 | 4,5,6,0 | 1,2,3,4 | 5,6,0,1
+///   regions: us-east,us-west,eu-west,us-east | us-west,eu-west,us-east,us-west | ...
+///
+/// RG0: price max=30 → price>100 pruned. RG0 has region="us-east" rows → branch1 should match.
+/// Without the fix, branch0's pruning would incorrectly affect branch1.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn stats_prune_three_way_or_flatten_misalignment_regression() {
+    let specs = vec![WideSegSpec { brand: "amazon", rows: 16, max_rg_rows: 4 }];
+
+    // Build as nested OR(OR(A,B), C) — this is how convert_expr produces it
+    // from `A OR B OR C` (left-associative binary OR).
+    let tree = BoolNode::Or(vec![
+        BoolNode::Or(vec![
+            BoolNode::And(vec![
+                BoolNode::Collector { annotation_id: 0 },
+                pred_wide_int("price", Operator::Gt, 100),
+            ]),
+            BoolNode::And(vec![
+                BoolNode::Collector { annotation_id: 1 },
+                pred_wide_str("region", Operator::Eq, "us-east"),
+            ]),
+        ]),
+        BoolNode::And(vec![
+            BoolNode::Collector { annotation_id: 2 },
+            pred_wide_int("qty", Operator::Gt, 5),
+        ]),
+    ]);
+
+    // Oracle: row matches if (price > 100) OR (region == "us-east") OR (qty > 5)
+    let expected = wide_oracle(&specs, |i| {
+        let price = (i as i32) * 10;
+        let qty = (i as i32) % 7;
+        let region = match i % 3 {
+            0 => "us-east",
+            1 => "us-west",
+            _ => "eu-west",
+        };
+        price > 100 || region == "us-east" || qty > 5
+    });
+
+    let rows = run_wide_segments_with_stats_pruning(specs, tree, 1).await;
+    assert_eq!(rows, expected, "3-way OR with nested structure must produce correct results after flatten");
+}
+
+/// Same as above but tests different clause orderings to ensure no
+/// order-dependent pruning bugs.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn stats_prune_three_way_or_ordering_independence() {
+    let specs = vec![WideSegSpec { brand: "amazon", rows: 16, max_rg_rows: 4 }];
+
+    let expected = wide_oracle(&specs, |i| {
+        let price = (i as i32) * 10;
+        let qty = (i as i32) % 7;
+        let region = match i % 3 {
+            0 => "us-east",
+            1 => "us-west",
+            _ => "eu-west",
+        };
+        price > 100 || region == "us-east" || qty > 5
+    });
+
+    // All 3 orderings of a nested OR that flatten differently.
+    let orderings: Vec<BoolNode> = vec![
+        // OR(OR(A,B), C)
+        BoolNode::Or(vec![
+            BoolNode::Or(vec![
+                BoolNode::And(vec![BoolNode::Collector { annotation_id: 0 }, pred_wide_int("price", Operator::Gt, 100)]),
+                BoolNode::And(vec![BoolNode::Collector { annotation_id: 1 }, pred_wide_str("region", Operator::Eq, "us-east")]),
+            ]),
+            BoolNode::And(vec![BoolNode::Collector { annotation_id: 2 }, pred_wide_int("qty", Operator::Gt, 5)]),
+        ]),
+        // OR(A, OR(B,C))
+        BoolNode::Or(vec![
+            BoolNode::And(vec![BoolNode::Collector { annotation_id: 0 }, pred_wide_int("price", Operator::Gt, 100)]),
+            BoolNode::Or(vec![
+                BoolNode::And(vec![BoolNode::Collector { annotation_id: 1 }, pred_wide_str("region", Operator::Eq, "us-east")]),
+                BoolNode::And(vec![BoolNode::Collector { annotation_id: 2 }, pred_wide_int("qty", Operator::Gt, 5)]),
+            ]),
+        ]),
+        // OR(OR(B,C), A)
+        BoolNode::Or(vec![
+            BoolNode::Or(vec![
+                BoolNode::And(vec![BoolNode::Collector { annotation_id: 1 }, pred_wide_str("region", Operator::Eq, "us-east")]),
+                BoolNode::And(vec![BoolNode::Collector { annotation_id: 2 }, pred_wide_int("qty", Operator::Gt, 5)]),
+            ]),
+            BoolNode::And(vec![BoolNode::Collector { annotation_id: 0 }, pred_wide_int("price", Operator::Gt, 100)]),
+        ]),
+    ];
+
+    for (idx, tree) in orderings.into_iter().enumerate() {
+        let rows = run_wide_segments_with_stats_pruning(
+            vec![WideSegSpec { brand: "amazon", rows: 16, max_rg_rows: 4 }],
+            tree,
+            1,
+        ).await;
+        assert_eq!(rows, expected, "ordering {} produced wrong results", idx);
     }
 }

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/null_columns.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/null_columns.rs
@@ -363,7 +363,7 @@ async fn assert_engine_matches_reference_null(name: &str, tree: NT) {
                 page_prune_metrics: None,
                 collector_strategy:
                     crate::indexed_table::eval::CollectorCallStrategy::TightenOuterBounds,
-                stats_prune_tree: None,
+                stats_prune_tree: None, rg_index_to_pos: HashMap::new(),
             });
             Ok(eval)
         })

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/page_pruning.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/page_pruning.rs
@@ -328,7 +328,7 @@ async fn run_bitmap_tree(tree: BoolNode) -> (Vec<i32>, Arc<dyn ExecutionPlan>) {
                 ),
                 collector_strategy:
                     crate::indexed_table::eval::CollectorCallStrategy::TightenOuterBounds,
-                stats_prune_tree: None,
+                stats_prune_tree: None, rg_index_to_pos: HashMap::new(),
             });
             Ok(eval)
         })
@@ -367,6 +367,7 @@ async fn run_single_collector(
                 0,
                 None,
                     None,
+                    std::collections::HashMap::new(),
             ));
             Ok(eval)
         })

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/qtf_fetch_phase.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/qtf_fetch_phase.rs
@@ -101,7 +101,7 @@ async fn query_phase(tree: BoolNode) -> Vec<i64> {
                 ),
                 collector_strategy:
                     crate::indexed_table::eval::CollectorCallStrategy::TightenOuterBounds,
-                stats_prune_tree: None,
+                stats_prune_tree: None, rg_index_to_pos: HashMap::new(),
             });
             Ok(eval)
         })

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/row_id_emission.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/row_id_emission.rs
@@ -91,7 +91,7 @@ async fn run_tree_row_ids(tree: BoolNode) -> Vec<i64> {
                 ),
                 collector_strategy:
                     crate::indexed_table::eval::CollectorCallStrategy::TightenOuterBounds,
-                stats_prune_tree: None,
+                stats_prune_tree: None, rg_index_to_pos: HashMap::new(),
             });
             Ok(eval)
         })
@@ -261,7 +261,7 @@ async fn run_tree_row_ids_with_global_base(tree: BoolNode, global_base: u64) -> 
                 ),
                 collector_strategy:
                     crate::indexed_table::eval::CollectorCallStrategy::TightenOuterBounds,
-                stats_prune_tree: None,
+                stats_prune_tree: None, rg_index_to_pos: HashMap::new(),
             });
             Ok(eval)
         })
@@ -529,7 +529,7 @@ async fn test_row_id_with_data_columns() {
                 ),
                 collector_strategy:
                     crate::indexed_table::eval::CollectorCallStrategy::TightenOuterBounds,
-                stats_prune_tree: None,
+                stats_prune_tree: None, rg_index_to_pos: HashMap::new(),
             });
             Ok(eval)
         })
@@ -784,7 +784,7 @@ async fn run_two_segments_row_ids(tree: BoolNode) -> Vec<i64> {
                 ),
                 collector_strategy:
                     crate::indexed_table::eval::CollectorCallStrategy::TightenOuterBounds,
-                stats_prune_tree: None,
+                stats_prune_tree: None, rg_index_to_pos: HashMap::new(),
             });
             Ok(eval)
         })

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/schema_drift.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/schema_drift.rs
@@ -119,7 +119,7 @@ async fn run_missing_col_tree(tree_bool: BoolNode) -> usize {
                 pruning_predicates: std::sync::Arc::new(std::collections::HashMap::new()),
                 page_prune_metrics: None,
                     collector_strategy: crate::indexed_table::eval::CollectorCallStrategy::TightenOuterBounds,
-                stats_prune_tree: None,
+                stats_prune_tree: None, rg_index_to_pos: HashMap::new(),
             });
             Ok(eval)
         })
@@ -432,7 +432,7 @@ async fn query_with_mismatched_schema(
                 page_prune_metrics: None,
                 collector_strategy:
                     crate::indexed_table::eval::CollectorCallStrategy::TightenOuterBounds,
-                stats_prune_tree: None,
+                stats_prune_tree: None, rg_index_to_pos: HashMap::new(),
             });
             Ok(eval)
         })

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/sort_reverse_row_id.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/sort_reverse_row_id.rs
@@ -22,6 +22,7 @@
 //! `reverse_segment_iteration_order` preserves each segment's original
 //! `global_base`, which is exactly what these tests verify end-to-end.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use datafusion::arrow::array::{Int32Array, Int64Array, StringArray};
@@ -207,7 +208,7 @@ async fn collect_row_ids(
                     ),
                 ),
                 collector_strategy: crate::indexed_table::eval::CollectorCallStrategy::TightenOuterBounds,
-                stats_prune_tree: None,
+                stats_prune_tree: None, rg_index_to_pos: HashMap::new(),
             });
             Ok(eval)
         })

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/streaming_at_scale.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/streaming_at_scale.rs
@@ -435,7 +435,7 @@ async fn run_large(
                 pruning_predicates: std::sync::Arc::new(std::collections::HashMap::new()),
                 page_prune_metrics: None,
                     collector_strategy: crate::indexed_table::eval::CollectorCallStrategy::TightenOuterBounds,
-                    stats_prune_tree: None,
+                    stats_prune_tree: None, rg_index_to_pos: HashMap::new(),
             });
             Ok(eval)
         })
@@ -893,7 +893,7 @@ async fn run_large_partitioned(
                 pruning_predicates: std::sync::Arc::new(std::collections::HashMap::new()),
                 page_prune_metrics: None,
                     collector_strategy: crate::indexed_table::eval::CollectorCallStrategy::TightenOuterBounds,
-                    stats_prune_tree: None,
+                    stats_prune_tree: None, rg_index_to_pos: HashMap::new(),
             });
             Ok(eval)
         })


### PR DESCRIPTION


Add rg_index_to_pos reverse map (absolute RG index → position in rg_can_match vector) to fix incorrect lookups when chunks don't start at RG 0. Previously consumers indexed rg_can_match by absolute rg.index into a subset-relative vector, causing wrong pruning decisions or panics for non-zero-offset chunks.

Changes:
- Add rg_index_to_pos: HashMap<usize, usize> to TreeBitsetSource, SingleCollectorEvaluator, PredicateOnlyEvaluator
- Thread rg_index_to_pos through TreeEvaluator::prefetch and bitmap_tree::prefetch_node
- Build reverse map from chunk.row_group_indices at each factory site
- Enable StatsPruneTree in fuzz harness (prune_tree_config: Some)

Tests added:
- page_pruner: offset rg_indices [2,3,4] with reverse map verification
- bitmap_tree: offset rg_idx not in map (no prune), in map (prune), empty collector bitsets under pruned OR subtree with Predicate nodes
- ITs: single/multi segment × single/multi partition with stats pruning enabled end-to-end, direct prefetch_rg assertions for RG prune, offset access, and empty collector bitset registration

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
