### PR TITLE
Tighten convert_tz offsets to MySQL band [-13:59, +14:00]

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/convert_tz.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/convert_tz.rs
@@ -220,11 +220,12 @@ fn parse_tz(s: &str) -> Option<TzSpec> {
 
 /// Parse `±HH:MM` → seconds east of UTC; None if not an offset literal.
 ///
-/// Bounds ({@code hours ∈ [0,14], minutes ∈ [0,59]}) match the Java adapter's
-/// {@code canonicalizeTz}. For literal-path inputs the Java side has already
-/// validated and canonicalized, so the defensive checks here only fire for
-/// column-valued tz — where a malformed entry yields a NULL row, matching the
-/// documented lenient behavior.
+/// Bounds match MySQL's `CONVERT_TZ` band: `[-13:59, +14:00]` (legacy parity
+/// with `DateTimeUtils.isValidMySqlTimeZoneId`). The Java adapter
+/// (`ConvertTzAdapter::canonicalizeTz`) folds out-of-band literals to NULL at
+/// plan time; this defensive check covers column-valued tz strings, where a
+/// malformed entry yields a NULL row and matches the documented lenient
+/// behavior.
 fn parse_offset_seconds(s: &str) -> Option<i32> {
     let bytes = s.as_bytes();
     if bytes.len() != 6 {
@@ -240,7 +241,12 @@ fn parse_offset_seconds(s: &str) -> Option<i32> {
     }
     let hours: i32 = s.get(1..3)?.parse().ok()?;
     let minutes: i32 = s.get(4..6)?.parse().ok()?;
-    if hours > 14 || minutes > 59 {
+    if minutes > 59 {
+        return None;
+    }
+    let total_minutes = hours * 60 + minutes;
+    let max_minutes = if sign < 0 { 13 * 60 + 59 } else { 14 * 60 };
+    if total_minutes > max_minutes {
         return None;
     }
     Some(sign * (hours * 3600 + minutes * 60))
@@ -325,10 +331,24 @@ mod tests {
     fn parse_offset_rejects_malformed() {
         assert_eq!(parse_offset_seconds("bogus"), None);
         assert_eq!(parse_offset_seconds("0500"), None);
-        // Hour >14 is beyond canonicalization bounds — Java rejects at plan time,
-        // we reject at runtime for column-valued paths.
+        // Out-of-band offsets — Java folds these to NULL at plan time;
+        // this catches the column-valued path.
         assert_eq!(parse_offset_seconds("+15:00"), None);
         assert_eq!(parse_offset_seconds("+05:60"), None);
+    }
+
+    // MySQL's CONVERT_TZ band: positive offsets cap at +14:00, negative offsets
+    // cap at -13:59. Matches legacy DateTimeUtils.isValidMySqlTimeZoneId.
+    #[test]
+    fn parse_offset_enforces_mysql_band() {
+        // Boundary OKs.
+        assert_eq!(parse_offset_seconds("+14:00"), Some(14 * 3600));
+        assert_eq!(parse_offset_seconds("-13:59"), Some(-(13 * 3600 + 59 * 60)));
+        // Just outside.
+        assert_eq!(parse_offset_seconds("+14:01"), None);
+        assert_eq!(parse_offset_seconds("-14:00"), None);
+        // Well outside.
+        assert_eq!(parse_offset_seconds("-17:00"), None);
     }
 
     // Offset → offset: simple wall-clock delta, no calendar.

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/convert_tz.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/convert_tz.rs
@@ -525,4 +525,58 @@ mod tests {
         assert!(arr.is_null(1));
         assert!(arr.is_null(2));
     }
+
+    // Column-valued tz strings can't be validated plan-side, so the UDF must
+    // null them out at row time. Both just-outside-the-band entries (-14:00,
+    // +14:01) and well-outside ones (+15:00) must collapse to NULL.
+    #[test]
+    fn invoke_out_of_band_offset_strings_yield_nulls() {
+        let udf = ConvertTzUdf::new();
+        let ts = TimestampMillisecondArray::from(vec![
+            Some(1_704_456_000_000),
+            Some(1_704_456_000_000),
+            Some(1_704_456_000_000),
+            Some(1_704_456_000_000),
+        ]);
+        let from = StringArray::from(vec![
+            Some("+00:00"),
+            Some("-14:00"), // just past negative cap
+            Some("+15:00"), // well past positive cap
+            Some("+00:00"),
+        ]);
+        let to = StringArray::from(vec![
+            Some("+14:00"), // boundary OK
+            Some("+00:00"),
+            Some("+00:00"),
+            Some("+14:01"), // just past positive cap
+        ]);
+        let args = ScalarFunctionArgs {
+            args: vec![
+                ColumnarValue::Array(Arc::new(ts)),
+                ColumnarValue::Array(Arc::new(from)),
+                ColumnarValue::Array(Arc::new(to)),
+            ],
+            number_rows: 4,
+            arg_fields: vec![],
+            return_field: Arc::new(datafusion::arrow::datatypes::Field::new(
+                "out",
+                DataType::Timestamp(TimeUnit::Millisecond, None),
+                true,
+            )),
+            config_options: Arc::new(datafusion::config::ConfigOptions::new()),
+        };
+        let out = udf.invoke_with_args(args).unwrap();
+        let arr = match out {
+            ColumnarValue::Array(a) => a,
+            _ => panic!("expected array"),
+        };
+        let arr = arr
+            .as_any()
+            .downcast_ref::<TimestampMillisecondArray>()
+            .unwrap();
+        assert!(!arr.is_null(0), "in-band +14:00 must produce a value");
+        assert!(arr.is_null(1), "from=-14:00 (out-of-band) must yield NULL");
+        assert!(arr.is_null(2), "from=+15:00 (out-of-band) must yield NULL");
+        assert!(arr.is_null(3), "to=+14:01 (out-of-band) must yield NULL");
+    }
 }

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/ConvertTzAdapter.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/ConvertTzAdapter.java
@@ -60,8 +60,12 @@ class ConvertTzAdapter implements ScalarFunctionAdapter {
         SqlFunctionCategory.TIMEDATE
     );
 
-    /** Matches {@code ±H:MM} / {@code ±HH:MM} with hours [0,14] and minutes [0,59]. */
+    /** Matches {@code ±H:MM} / {@code ±HH:MM}. Band enforcement lives in {@link #isWithinMySqlOffsetBand}. */
     private static final Pattern OFFSET_PATTERN = Pattern.compile("^([+-])(\\d{1,2}):(\\d{2})$");
+
+    /** MySQL accepts {@code [-13:59, +14:00]}. Outside this band {@code CONVERT_TZ} returns NULL. */
+    private static final int MAX_POSITIVE_OFFSET_MINUTES = 14 * 60;
+    private static final int MAX_NEGATIVE_OFFSET_MINUTES = 13 * 60 + 59;
 
     /** invalid timestamp literal -> typed NULL (peels CAST wrapping that PPL adds for non-TIMESTAMP args). */
     private static RexNode foldInvalidTimestampLiteralToNull(
@@ -132,20 +136,25 @@ class ConvertTzAdapter implements ScalarFunctionAdapter {
 
     /**
      * True when the canonicalized literal is something the runtime UDF will accept
-     * (in-range ±HH:MM offset or recognized IANA zone). Out-of-range offsets that
-     * canonicalize to themselves return false here so the identity short-circuit
-     * defers to the UDF's runtime NULL behavior.
+     * (in-range ±HH:MM offset or recognized IANA zone). After the boundary
+     * tightening in {@link #canonicalizeTz(String)}, out-of-range offsets are
+     * rejected at plan time, so reaching this method means the literal is valid.
      */
     private static boolean isInRangeTz(String canonical) {
         Matcher offset = OFFSET_PATTERN.matcher(canonical);
         if (offset.matches()) {
-            int hours = Integer.parseInt(offset.group(2));
-            int minutes = Integer.parseInt(offset.group(3));
-            return hours <= 14 && minutes <= 59;
+            return isWithinMySqlOffsetBand(offset.group(1), Integer.parseInt(offset.group(2)), Integer.parseInt(offset.group(3)));
         }
         // Non-offset canonical forms reach here only via ZoneId.of() success path
         // in canonicalizeTz, so they're already valid IANA ids.
         return true;
+    }
+
+    /** MySQL CONVERT_TZ band: {@code +00:00..+14:00} and {@code -00:00..-13:59}. */
+    private static boolean isWithinMySqlOffsetBand(String sign, int hours, int minutes) {
+        if (minutes > 59) return false;
+        int totalMinutes = hours * 60 + minutes;
+        return "-".equals(sign) ? totalMinutes <= MAX_NEGATIVE_OFFSET_MINUTES : totalMinutes <= MAX_POSITIVE_OFFSET_MINUTES;
     }
 
     /** String value of a canonicalized tz literal, or null for non-literal/non-string operands. */
@@ -185,9 +194,12 @@ class ConvertTzAdapter implements ScalarFunctionAdapter {
     }
 
     /**
-     * Canonicalize a tz string: {@code ±H:MM}/{@code ±HH:MM} (hours 0-14, minutes 0-59,
-     * matches Rust {@code parse_offset_seconds}) or an IANA id resolvable by {@link ZoneId#of}.
-     * Throws {@link IllegalArgumentException} for unrecognized inputs.
+     * Canonicalize a tz string: {@code ±H:MM}/{@code ±HH:MM} within MySQL's
+     * {@code CONVERT_TZ} band ({@code -13:59..+14:00}, matching legacy
+     * {@code DateTimeUtils.isValidMySqlTimeZoneId}) or an IANA id resolvable by
+     * {@link ZoneId#of}. Throws {@link IllegalArgumentException} for offsets
+     * outside the band or unrecognized strings; the caller folds the
+     * exception into a typed NULL.
      */
     static String canonicalizeTz(String raw) {
         Matcher offset = OFFSET_PATTERN.matcher(raw);
@@ -195,13 +207,8 @@ class ConvertTzAdapter implements ScalarFunctionAdapter {
             String sign = offset.group(1);
             int hours = Integer.parseInt(offset.group(2));
             int minutes = Integer.parseInt(offset.group(3));
-            // Out-of-range but syntactically-valid offsets pass through unchanged so the
-            // runtime UDF (rust/src/udf/convert_tz.rs::parse_offset_seconds) sees the
-            // raw string, returns None, and the row surfaces as NULL — matching legacy
-            // PPL semantics (DateTimeFunctionIT#testConvertTZ expects NULL rows for
-            // '-17:00' / '+15:00').
-            if (hours > 14 || minutes > 59) {
-                return raw;
+            if (!isWithinMySqlOffsetBand(sign, hours, minutes)) {
+                throw new IllegalArgumentException("convert_tz: offset [" + raw + "] outside MySQL band [-13:59, +14:00]");
             }
             return String.format(Locale.ROOT, "%s%02d:%02d", sign, hours, minutes);
         }

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/ConvertTzAdapterTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/ConvertTzAdapterTests.java
@@ -85,13 +85,21 @@ public class ConvertTzAdapterTests extends OpenSearchTestCase {
         assertEquals("UTC", ConvertTzAdapter.canonicalizeTz("UTC"));
     }
 
-    public void testCanonicalizeTzPassesOutOfRangeOffsetsThroughUnchanged() {
-        // Syntactically-valid but out-of-range offsets are NOT rejected at plan time.
-        // They pass through verbatim so the runtime UDF (rust convert_tz::parse_offset_seconds)
-        // returns None and the row surfaces as NULL — matching legacy PPL semantics
-        // (DateTimeFunctionIT#testConvertTZ expects NULL rows for '-17:00' / '+15:00').
-        assertEquals("hours > 14 must pass through, not throw", "+15:00", ConvertTzAdapter.canonicalizeTz("+15:00"));
-        assertEquals("minutes > 59 must pass through, not throw", "+05:60", ConvertTzAdapter.canonicalizeTz("+05:60"));
+    public void testCanonicalizeTzAcceptsBoundaryOffsets() {
+        // MySQL CONVERT_TZ band: [-13:59, +14:00] (legacy DateTimeUtils.isValidMySqlTimeZoneId).
+        assertEquals("+14:00", ConvertTzAdapter.canonicalizeTz("+14:00"));
+        assertEquals("-13:59", ConvertTzAdapter.canonicalizeTz("-13:59"));
+    }
+
+    public void testCanonicalizeTzRejectsOffsetsOutsideMysqlBand() {
+        // The Java adapter folds these to typed NULL at plan time; the catch in adapt()
+        // turns the IAE into a NULL literal so callers see {@code SELECT CONVERT_TZ(...,'-14:00','+08:00')}
+        // return NULL, matching ConvertTZFunctionIT#nullField2Under / nullField3Over.
+        expectThrows(IllegalArgumentException.class, () -> ConvertTzAdapter.canonicalizeTz("+14:01"));
+        expectThrows(IllegalArgumentException.class, () -> ConvertTzAdapter.canonicalizeTz("-14:00"));
+        expectThrows(IllegalArgumentException.class, () -> ConvertTzAdapter.canonicalizeTz("-17:00"));
+        expectThrows(IllegalArgumentException.class, () -> ConvertTzAdapter.canonicalizeTz("+15:00"));
+        expectThrows(IllegalArgumentException.class, () -> ConvertTzAdapter.canonicalizeTz("+05:60"));
     }
 
     public void testCanonicalizeTzRejectsUnknownIana() {
@@ -186,7 +194,7 @@ public class ConvertTzAdapterTests extends OpenSearchTestCase {
         );
     }
 
-    /** unknown IANA literal -> typed NULL (out-of-range offsets fall through to the UDF for runtime NULL). */
+    /** unknown IANA literal -> typed NULL. */
     public void testAdaptUnknownIanaLiteralReturnsTypedNull() {
         RexCall original = buildConvertTz("Mars/Olympus", "UTC");
         RexNode adapted = new ConvertTzAdapter().adapt(original, List.of(), cluster);
@@ -194,6 +202,22 @@ public class ConvertTzAdapterTests extends OpenSearchTestCase {
         assertTrue(adapted instanceof RexLiteral);
         assertTrue(((RexLiteral) adapted).isNull());
         assertEquals(original.getType(), adapted.getType());
+    }
+
+    /** Out-of-band offset literal -> typed NULL (matches MySQL CONVERT_TZ semantics). */
+    public void testAdaptOutOfBandOffsetLiteralReturnsTypedNull() {
+        for (String[] pair : new String[][] {
+            { "-14:00", "+08:00" }, // ConvertTZFunctionIT#nullField2Under
+            { "-12:00", "+14:01" }, // ConvertTZFunctionIT#nullField3Over
+            { "+15:00", "+00:00" }, // legacy PPL DateTimeFunctionIT#testConvertTZ
+        }) {
+            RexCall original = buildConvertTz(pair[0], pair[1]);
+            RexNode adapted = new ConvertTzAdapter().adapt(original, List.of(), cluster);
+
+            assertTrue("expected NULL literal for [" + pair[0] + "," + pair[1] + "], got " + adapted, adapted instanceof RexLiteral);
+            assertTrue(((RexLiteral) adapted).isNull());
+            assertEquals(original.getType(), adapted.getType());
+        }
     }
 
     /**

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/ConvertTzFunctionIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/ConvertTzFunctionIT.java
@@ -52,20 +52,60 @@ public class ConvertTzFunctionIT extends AnalyticsRestTestCase {
     }
 
     /**
-     * Out-of-range {@code from} offset ({@code -17:00}, beyond ±14:00) → NULL, matching reference PPL
-     * (ConvertTZFunctionIT#nullFromFieldUnder). Pins the canonicalize pass-through that lets the
-     * runtime UDF surface NULL instead of the identity short-circuit folding the call away.
+     * Out-of-range {@code from} offset ({@code -17:00}, well below the negative cap) → NULL, matching
+     * reference PPL (ConvertTZFunctionIT#nullFromFieldUnder).
      */
     public void testNullOnOutOfRangeFromOffset() throws IOException {
         assertFirstRowNull(oneRow() + "| eval v = convert_tz('2021-05-30 11:34:50', '-17:00', '+08:00') | fields v");
     }
 
     /**
-     * Out-of-range {@code to} offset ({@code +15:00}, beyond ±14:00) → NULL, matching reference PPL
-     * (ConvertTZFunctionIT#nullToFieldOver).
+     * Out-of-range {@code to} offset ({@code +15:00}, above the positive cap) → NULL, matching reference
+     * PPL (ConvertTZFunctionIT#nullToFieldOver).
      */
     public void testNullOnOutOfRangeToOffset() throws IOException {
         assertFirstRowNull(oneRow() + "| eval v = convert_tz('2021-05-12 11:34:50', '-12:00', '+15:00') | fields v");
+    }
+
+    /**
+     * Just below the negative cap ({@code -14:00}) → NULL. MySQL's CONVERT_TZ band is
+     * {@code [-13:59, +14:00]}; pre-fix the adapter accepted any {@code hours <= 14}
+     * and returned a shifted timestamp. Mirrors {@code ConvertTZFunctionIT#nullField2Under}.
+     */
+    public void testNullOnJustBelowNegativeCap() throws IOException {
+        assertFirstRowNull(oneRow() + "| eval v = convert_tz('2021-05-30 11:34:50', '-14:00', '+08:00') | fields v");
+    }
+
+    /**
+     * Just above the positive cap ({@code +14:01}) → NULL. Mirrors
+     * {@code ConvertTZFunctionIT#nullField3Over} — the boundary the original adapter missed.
+     */
+    public void testNullOnJustAbovePositiveCap() throws IOException {
+        assertFirstRowNull(oneRow() + "| eval v = convert_tz('2021-05-12 11:34:50', '-12:00', '+14:01') | fields v");
+    }
+
+    /**
+     * Negative-cap boundary ({@code -13:59}) is in-band on both sides → identity short-circuit
+     * returns the timestamp unchanged. Mirrors {@code ConvertTZFunctionIT#inRangeMinOnPoint};
+     * regression guard against the boundary-tightening accidentally rejecting the cap itself.
+     */
+    public void testInBandNegativeCapShortCircuits() throws IOException {
+        assertFirstRowString(
+            oneRow() + "| eval v = convert_tz('2021-05-12 15:00:00', '-13:59', '-13:59') | fields v",
+            "2021-05-12 15:00:00"
+        );
+    }
+
+    /**
+     * Positive-cap boundary ({@code +14:00}) is in-band → UDF fallback applies the offset.
+     * Pre-fix this passed because the bound was {@code hours <= 14}; post-fix the explicit
+     * band check still admits {@code +14:00} exactly.
+     */
+    public void testInBandPositiveCapAppliesOffset() throws IOException {
+        assertFirstRowString(
+            oneRow() + "| eval v = convert_tz('2021-05-12 00:00:00', '+00:00', '+14:00') | fields v",
+            "2021-05-12 14:00:00"
+        );
     }
 
     private void assertFirstRowString(String ppl, String expected) throws IOException {


### PR DESCRIPTION
### Description

`CONVERT_TZ(timestamp, from_tz, to_tz)` shifts a wall-clock time from one timezone to another. The two offset arguments must be valid timezones — there is no real-world timezone outside `[-13:59, +14:00]` (the deepest west is Baker Island at `-12:00`; the farthest east is Kiribati's Line Islands at `+14:00`, with a one-minute buffer to `-13:59`). MySQL — and legacy V2 (`DateTimeUtils.isValidMySqlTimeZoneId`) — return `NULL` for any offset outside that band, treating it as garbage input rather than computing a fictional shift.

`ConvertTzAdapter` and the Rust UDF previously enforced only `hours <= 14, minutes <= 59`, which let `-14:00` and `+14:01` through and produced a shifted timestamp where the contract says `NULL`.

```
SELECT CONVERT_TZ('2021-05-30 11:34:50','-14:00','+08:00') -> '2021-05-31 09:34:50'   (was)
SELECT CONVERT_TZ('2021-05-30 11:34:50','-14:00','+08:00') -> NULL                    (now)

SELECT CONVERT_TZ('2021-05-12 11:34:50','-12:00','+14:01') -> shifted timestamp       (was)
SELECT CONVERT_TZ('2021-05-12 11:34:50','-12:00','+14:01') -> NULL                    (now)
```

The fix runs at two layers:

- **Java adapter (plan-time fold).** `canonicalizeTz` now throws `IllegalArgumentException` for offsets outside `[-13:59, +14:00]`. The existing catch in `adapt()` folds the IAE into a typed `NULL` literal, so out-of-band literal offsets collapse before the call ever reaches the engine.
- **Rust UDF (runtime fold).** `parse_offset_seconds` enforces the same band as defense-in-depth for column-valued tz strings, where the Java side cannot validate.

### Semantics

`CONVERT_TZ(ts, from, to)` interprets `ts` as a wall-clock time in `from` and returns the wall-clock time in `to` for the same instant. Both `from` and `to` may be IANA names (`'America/New_York'`) or signed `±HH:MM` offsets within MySQL's band. Any operand `NULL` → `NULL` output. Out-of-band offsets, unparseable strings, unknown IANA ids, and invalid timestamp literals (e.g. `'2021-02-30 ...'`) all surface as `NULL` — never an exception.

### Query shapes now supported

```sql
-- Out-of-band offsets correctly yield NULL (MySQL semantics)
SELECT CONVERT_TZ('2021-05-30 11:34:50', '-14:00', '+08:00')   -- → NULL
SELECT CONVERT_TZ('2021-05-12 11:34:50', '-12:00', '+14:01')   -- → NULL
SELECT CONVERT_TZ('2021-05-30 11:34:50', '-17:00', '+08:00')   -- → NULL
SELECT CONVERT_TZ('2021-05-12 11:34:50', '-12:00', '+15:00')   -- → NULL

-- Boundary offsets remain in-band (regression guards)
SELECT CONVERT_TZ('2021-05-12 15:00:00', '-13:59', '-13:59')   -- → '2021-05-12 15:00:00'
SELECT CONVERT_TZ('2021-05-12 00:00:00', '+00:00', '+14:00')   -- → '2021-05-12 14:00:00'

-- Pre-existing in-range cases unchanged
SELECT CONVERT_TZ('2021-05-12 11:34:50', '-08:00', '+09:00')   -- → '2021-05-13 04:34:50'
SELECT CONVERT_TZ('2021-05-12 11:34:50', '-12:00', '+12:00')   -- → '2021-05-13 11:34:50'
SELECT CONVERT_TZ('2021-05-12 13:00:00', '+09:30', '+05:45')   -- → '2021-05-12 09:15:00'
```

### Tests

- **Unit (Java)**: `ConvertTzAdapterTests` — replaced the pass-through-on-out-of-range assertions with explicit boundary acceptance (`+14:00`, `-13:59`) and reject (`+14:01`, `-14:00`, `-17:00`, `+15:00`, `+05:60`) tests; added `testAdaptOutOfBandOffsetLiteralReturnsTypedNull` covering the three IT pairs.
- **Unit (Rust)**: `parse_offset_enforces_mysql_band` exercises both caps and just-outside / well-outside inputs; `invoke_out_of_band_offset_strings_yield_nulls` runs four column-valued rows through full UDF dispatch (boundary OK, just past negative cap, well past positive cap, just past positive cap).
- **Sandbox QA IT**: `ConvertTzFunctionIT` gains four cases — `testNullOnJustBelowNegativeCap` (`-14:00`), `testNullOnJustAbovePositiveCap` (`+14:01`), and the in-band cap regression guards `testInBandNegativeCapShortCircuits` (`-13:59`) and `testInBandPositiveCapAppliesOffset` (`+14:00`).

### PPL Calcite tests in the SQL plugin unblocked

- `org.opensearch.sql.sql.ConvertTZFunctionIT.nullField2Under`
- `org.opensearch.sql.sql.ConvertTZFunctionIT.nullField3Over`

The same band tightening also covers the existing PPL boundary tests `org.opensearch.sql.ppl.ConvertTZFunctionIT.nullFromFieldUnder` (`-17:00`) and `nullToFieldOver` (`+15:00`).

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.