### PR TITLE
Only carry relevant trailers into StreamException metadata in FlightErrorMapper

### DIFF
--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightErrorMapper.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightErrorMapper.java
@@ -19,8 +19,10 @@ import org.opensearch.transport.stream.StreamException;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.opensearch.OpenSearchException.OPENSEARCH_PREFIX_KEY;
+import static org.opensearch.arrow.flight.transport.ClientHeaderMiddleware.CORRELATION_ID_KEY;
 
 /**
  * Maps between OpenSearch StreamException and Arrow Flight CallStatus/FlightRuntimeException.
@@ -31,6 +33,12 @@ import static org.opensearch.OpenSearchException.OPENSEARCH_PREFIX_KEY;
 class FlightErrorMapper {
     private static final Logger logger = LogManager.getLogger(FlightErrorMapper.class);
     private static final boolean skipMetadata = true;
+
+    /**
+     * Arrow Flight trailers worth surfacing on the exception metadata. Other internal transport
+     * trailers (such as {@code raw-header} and {@code content-type}) are dropped.
+     */
+    static final Set<String> SAFE_METADATA_KEYS = Set.of(CORRELATION_ID_KEY);
 
     /**
      * Maps a StreamException to a FlightRuntimeException.
@@ -57,6 +65,9 @@ class FlightErrorMapper {
     /**
      * Maps a FlightRuntimeException to a StreamException.
      *
+     * <p>Only trailers in {@link #SAFE_METADATA_KEYS} are copied onto the exception metadata; other
+     * internal transport trailers are dropped to keep them out of user-facing error responses.
+     *
      * @param exception the FlightRuntimeException to map
      * @return a StreamException with equivalent error information
      */
@@ -65,7 +76,9 @@ class FlightErrorMapper {
         StreamException streamException = new StreamException(errorCode, exception.getMessage(), exception.getCause());
         ErrorFlightMetadata metadata = exception.status().metadata();
         for (String key : metadata.keys()) {
-            streamException.addMetadata(OPENSEARCH_PREFIX_KEY + key, metadata.get(key));
+            if (SAFE_METADATA_KEYS.contains(key)) {
+                streamException.addMetadata(OPENSEARCH_PREFIX_KEY + key, metadata.get(key));
+            }
         }
         return streamException;
     }

--- a/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/FlightErrorMapperTests.java
+++ b/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/FlightErrorMapperTests.java
@@ -1,0 +1,57 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.arrow.flight.transport;
+
+import org.apache.arrow.flight.CallStatus;
+import org.apache.arrow.flight.ErrorFlightMetadata;
+import org.apache.arrow.flight.FlightRuntimeException;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.transport.stream.StreamErrorCode;
+import org.opensearch.transport.stream.StreamException;
+
+import java.util.List;
+
+import static org.opensearch.OpenSearchException.OPENSEARCH_PREFIX_KEY;
+import static org.opensearch.arrow.flight.transport.ClientHeaderMiddleware.CORRELATION_ID_KEY;
+import static org.opensearch.arrow.flight.transport.ClientHeaderMiddleware.RAW_HEADER_KEY;
+
+public class FlightErrorMapperTests extends OpenSearchTestCase {
+
+    public void testFromFlightExceptionKeepsOnlyRelevantTrailers() {
+        ErrorFlightMetadata metadata = new ErrorFlightMetadata();
+        metadata.insert(RAW_HEADER_KEY, "c29tZS1pbnRlcm5hbC1oZWFkZXI=");
+        metadata.insert("content-type", "application/grpc");
+        metadata.insert(CORRELATION_ID_KEY, "12345");
+
+        FlightRuntimeException flightException = CallStatus.INTERNAL.withDescription("boom").withMetadata(metadata).toRuntimeException();
+
+        StreamException streamException = FlightErrorMapper.fromFlightException(flightException);
+
+        assertEquals(StreamErrorCode.INTERNAL, streamException.getErrorCode());
+        // Internal transport trailers are not carried over into the exception metadata.
+        assertNull(streamException.getMetadata(OPENSEARCH_PREFIX_KEY + RAW_HEADER_KEY));
+        assertNull(streamException.getMetadata(OPENSEARCH_PREFIX_KEY + "content-type"));
+        // The allow-listed correlation-id is preserved.
+        assertEquals(List.of("12345"), streamException.getMetadata(OPENSEARCH_PREFIX_KEY + CORRELATION_ID_KEY));
+
+        // The rendered exception only reflects the allow-listed trailers.
+        String rendered = streamException.toString();
+        assertFalse(rendered, rendered.contains(RAW_HEADER_KEY));
+        assertFalse(rendered, rendered.contains("application/grpc"));
+    }
+
+    public void testFromFlightExceptionWithNoMetadata() {
+        FlightRuntimeException flightException = CallStatus.UNAVAILABLE.withDescription("unavailable").toRuntimeException();
+
+        StreamException streamException = FlightErrorMapper.fromFlightException(flightException);
+
+        assertEquals(StreamErrorCode.UNAVAILABLE, streamException.getErrorCode());
+        assertTrue(streamException.getMetadataKeys().isEmpty());
+    }
+}


### PR DESCRIPTION
### Description

`FlightErrorMapper.fromFlightException` copied every Arrow Flight gRPC trailer onto the `StreamException` metadata using the `opensearch.` prefix. Most of these trailers (e.g. `content-type`, `raw-header`) are internal stream-transport framing that is not useful to the caller and just adds noise to the error metadata.

This change restricts the copied trailers to an allow-list of relevant keys (`SAFE_METADATA_KEYS`, currently just `correlation-id`), so the correlation id is preserved for debugging/tracing while the irrelevant transport trailers are not carried over. This also aligns the inbound mapping with the outbound `toFlightException` path, which already does not copy this metadata.

### Related Issues
N/A

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
