### PR TITLE
Fix snapshot listing failing on legacy Elasticsearch snapshots

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/snapshots/LegacySnapshotVersionIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/snapshots/LegacySnapshotVersionIT.java
@@ -1,0 +1,171 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.snapshots;
+
+import org.apache.lucene.codecs.CodecUtil;
+import org.apache.lucene.store.OutputStreamIndexOutput;
+import org.opensearch.action.admin.cluster.snapshots.create.CreateSnapshotResponse;
+import org.opensearch.action.admin.cluster.snapshots.get.GetSnapshotsResponse;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.lucene.store.IndexOutputOutputStream;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.compress.CompressorRegistry;
+import org.opensearch.core.xcontent.MediaTypeRegistry;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.repositories.blobstore.BlobStoreRepository;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.Collections;
+import java.util.List;
+
+import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.nullValue;
+
+/**
+ * Integration test verifying that snapshot listing tolerates legacy Elasticsearch version IDs in
+ * snapshot metadata, and that restore of such snapshots fails gracefully. A real snapshot is taken
+ * in an fs repository and its {@code snap-{uuid}.dat} blob is overwritten with one containing
+ * {@code version_id: 7100299} (ES 7.10.2, which lacks the OpenSearch mask bit).
+ */
+public class LegacySnapshotVersionIT extends AbstractSnapshotIntegTestCase {
+
+    private static final int LEGACY_ES_VERSION_ID = 7_10_02_99;
+
+    private static final String SNAPSHOT_CODEC = "snapshot";
+    private static final int SNAPSHOT_FORMAT_VERSION = 1;
+
+    public void testListingSucceedsAndRestoreFailsForLegacyEsSnapshot() throws Exception {
+        final Path repoPath = randomRepoPath();
+        final String repoName = "legacy-test-repo";
+        final String snapshotName = "legacy-es-snapshot";
+
+        createRepository(
+            repoName,
+            "fs",
+            Settings.builder()
+                .put("location", repoPath)
+                .put("compress", false)
+                .put(BlobStoreRepository.CACHE_REPOSITORY_DATA.getKey(), false)
+        );
+
+        createIndex("test-index");
+        indexRandom(true, client().prepareIndex().setIndex("test-index").setSource("field", "value"));
+
+        CreateSnapshotResponse createResponse = client().admin()
+            .cluster()
+            .prepareCreateSnapshot(repoName, snapshotName)
+            .setWaitForCompletion(true)
+            .setIndices("test-index")
+            .get();
+        assertThat(createResponse.getSnapshotInfo().successfulShards(), greaterThan(0));
+        assertThat(createResponse.getSnapshotInfo().successfulShards(), equalTo(createResponse.getSnapshotInfo().totalShards()));
+
+        final String snapshotUUID = createResponse.getSnapshotInfo().snapshotId().getUUID();
+        overwriteSnapshotBlobWithLegacyVersion(repoPath, snapshotName, snapshotUUID, LEGACY_ES_VERSION_ID);
+
+        GetSnapshotsResponse getResponse = client().admin().cluster().prepareGetSnapshots(repoName).get();
+        List<SnapshotInfo> snapshots = getResponse.getSnapshots();
+        assertThat(snapshots.size(), equalTo(1));
+
+        SnapshotInfo listedSnapshot = snapshots.get(0);
+        assertThat(listedSnapshot.snapshotId().getName(), equalTo(snapshotName));
+        assertThat(listedSnapshot.snapshotId().getUUID(), equalTo(snapshotUUID));
+        assertThat(listedSnapshot.version(), nullValue());
+        assertThat(listedSnapshot.state(), equalTo(SnapshotState.SUCCESS));
+        assertThat(listedSnapshot.indices(), equalTo(Collections.singletonList("test-index")));
+
+        assertAcked(client().admin().indices().prepareDelete("test-index"));
+
+        SnapshotRestoreException e = expectThrows(
+            SnapshotRestoreException.class,
+            () -> client().admin().cluster().prepareRestoreSnapshot(repoName, snapshotName).setWaitForCompletion(true).get()
+        );
+        assertThat(e.getMessage(), containsString("unsupported"));
+    }
+
+    /**
+     * Overwrites the {@code snap-{uuid}.dat} blob with a serialized snapshot info blob that uses the
+     * given legacy {@code version_id}, matching the format produced by {@link BlobStoreRepository#SNAPSHOT_FORMAT}.
+     */
+    private void overwriteSnapshotBlobWithLegacyVersion(Path repoPath, String snapshotName, String snapshotUUID, int legacyVersionId)
+        throws IOException {
+        final String blobName = BlobStoreRepository.SNAPSHOT_PREFIX + snapshotUUID + ".dat";
+        final Path blobPath = repoPath.resolve(blobName);
+
+        ToXContent legacySnapshotContent = (builder, params) -> {
+            builder.startObject("snapshot");
+            builder.field("name", snapshotName);
+            builder.field("uuid", snapshotUUID);
+            builder.field("version_id", legacyVersionId);
+            builder.startArray("indices");
+            builder.value("test-index");
+            builder.endArray();
+            builder.startArray("data_streams");
+            builder.endArray();
+            builder.field("state", "SUCCESS");
+            builder.field("include_global_state", true);
+            builder.field("metadata", Collections.emptyMap());
+            builder.field("start_time", 1_000_000L);
+            builder.field("end_time", 2_000_000L);
+            builder.field("total_shards", 1);
+            builder.field("successful_shards", 1);
+            builder.startArray("failures");
+            builder.endArray();
+            builder.endObject();
+            return builder;
+        };
+
+        BytesReference bytes = serializeSnapshotBlob(legacySnapshotContent, blobName);
+        Files.write(blobPath, BytesReference.toBytes(bytes), StandardOpenOption.TRUNCATE_EXISTING);
+    }
+
+    /**
+     * Serializes the given content into a valid {@code snap-*.dat} blob: Lucene codec header,
+     * uncompressed SMILE x-content, and Lucene codec footer.
+     */
+    private BytesReference serializeSnapshotBlob(ToXContent content, String blobName) throws IOException {
+        try (BytesStreamOutput outputStream = new BytesStreamOutput()) {
+            try (
+                OutputStreamIndexOutput indexOutput = new OutputStreamIndexOutput(
+                    "LegacySnapshotVersionIT.serializeSnapshotBlob(blob=\"" + blobName + "\")",
+                    blobName,
+                    outputStream,
+                    4096
+                )
+            ) {
+                CodecUtil.writeHeader(indexOutput, SNAPSHOT_CODEC, SNAPSHOT_FORMAT_VERSION);
+                try (OutputStream indexOutputOutputStream = new IndexOutputOutputStream(indexOutput) {
+                    @Override
+                    public void close() {}
+                };
+                    XContentBuilder builder = MediaTypeRegistry.contentBuilder(
+                        XContentType.SMILE,
+                        CompressorRegistry.none().threadLocalOutputStream(indexOutputOutputStream)
+                    )
+                ) {
+                    builder.startObject();
+                    content.toXContent(builder, ToXContent.EMPTY_PARAMS);
+                    builder.endObject();
+                }
+                CodecUtil.writeFooter(indexOutput);
+            }
+            return outputStream.bytes();
+        }
+    }
+}

--- a/server/src/internalClusterTest/java/org/opensearch/snapshots/LegacySnapshotVersionIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/snapshots/LegacySnapshotVersionIT.java
@@ -96,7 +96,7 @@ public class LegacySnapshotVersionIT extends AbstractSnapshotIntegTestCase {
             SnapshotRestoreException.class,
             () -> client().admin().cluster().prepareRestoreSnapshot(repoName, snapshotName).setWaitForCompletion(true).get()
         );
-        assertThat(e.getMessage(), containsString("unsupported"));
+        assertThat(e.getMessage(), containsString("unknown or unsupported version"));
     }
 
     /**

--- a/server/src/main/java/org/opensearch/common/util/FeatureFlags.java
+++ b/server/src/main/java/org/opensearch/common/util/FeatureFlags.java
@@ -128,6 +128,18 @@ public class FeatureFlags {
     public static final Setting<Boolean> STREAM_TRANSPORT_SETTING = Setting.boolSetting(STREAM_TRANSPORT, false, Property.NodeScope);
 
     /**
+     * Gates strict snapshot version parsing. When enabled, reading snapshot metadata whose stored
+     * version_id is unsupported (e.g. a legacy Elasticsearch snapshot) fails instead of resolving the
+     * version to unknown. Disabled by default so snapshot listing tolerates such repositories.
+     */
+    public static final String SNAPSHOT_STRICT_VERSION_PARSING = FEATURE_FLAG_PREFIX + "snapshot.strict_version_parsing.enabled";
+    public static final Setting<Boolean> SNAPSHOT_STRICT_VERSION_PARSING_SETTING = Setting.boolSetting(
+        SNAPSHOT_STRICT_VERSION_PARSING,
+        false,
+        Property.NodeScope
+    );
+
+    /**
      * Underlying implementation for feature flags.
      * All settable feature flags are tracked here in FeatureFlagsImpl.featureFlags.
      * Contains all functionality across test and server use cases.
@@ -153,6 +165,7 @@ public class FeatureFlags {
                 put(STREAM_TRANSPORT_SETTING, STREAM_TRANSPORT_SETTING.getDefault(Settings.EMPTY));
                 put(CONTEXT_AWARE_MIGRATION_EXPERIMENTAL_SETTING, CONTEXT_AWARE_MIGRATION_EXPERIMENTAL_SETTING.getDefault(Settings.EMPTY));
                 put(PLUGGABLE_DATAFORMAT_EXPERIMENTAL_SETTING, PLUGGABLE_DATAFORMAT_EXPERIMENTAL_SETTING.getDefault(Settings.EMPTY));
+                put(SNAPSHOT_STRICT_VERSION_PARSING_SETTING, SNAPSHOT_STRICT_VERSION_PARSING_SETTING.getDefault(Settings.EMPTY));
             }
         };
 

--- a/server/src/main/java/org/opensearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/opensearch/snapshots/RestoreService.java
@@ -1379,7 +1379,7 @@ public class RestoreService implements ClusterStateApplier {
         if (snapshotInfo.version() == null) {
             throw new SnapshotRestoreException(
                 new Snapshot(repository, snapshotInfo.snapshotId()),
-                "the snapshot was created by an unsupported (e.g. legacy Elasticsearch) version and cannot be restored"
+                "the snapshot has an unknown or unsupported version and cannot be restored"
             );
         }
         if (Version.CURRENT.before(snapshotInfo.version())) {

--- a/server/src/main/java/org/opensearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/opensearch/snapshots/RestoreService.java
@@ -1376,6 +1376,12 @@ public class RestoreService implements ClusterStateApplier {
                 "unsupported snapshot state [" + snapshotInfo.state() + "]"
             );
         }
+        if (snapshotInfo.version() == null) {
+            throw new SnapshotRestoreException(
+                new Snapshot(repository, snapshotInfo.snapshotId()),
+                "the snapshot was created by an unsupported (e.g. legacy Elasticsearch) version and cannot be restored"
+            );
+        }
         if (Version.CURRENT.before(snapshotInfo.version())) {
             throw new SnapshotRestoreException(
                 new Snapshot(repository, snapshotInfo.snapshotId()),

--- a/server/src/main/java/org/opensearch/snapshots/SnapshotInfo.java
+++ b/server/src/main/java/org/opensearch/snapshots/SnapshotInfo.java
@@ -31,6 +31,8 @@
 
 package org.opensearch.snapshots;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.opensearch.Version;
 import org.opensearch.action.admin.cluster.snapshots.get.GetSnapshotsRequest;
 import org.opensearch.cluster.SnapshotsInProgress;
@@ -69,6 +71,8 @@ import java.util.stream.Collectors;
  */
 @PublicApi(since = "1.0.0")
 public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent, Writeable {
+
+    private static final Logger logger = LogManager.getLogger(SnapshotInfo.class);
 
     public static final String CONTEXT_MODE_PARAM = "context_mode";
     public static final String CONTEXT_MODE_SNAPSHOT = "SNAPSHOT";
@@ -800,25 +804,16 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent,
     }
 
     /**
-     * Resolves the OpenSearch {@link Version} that a snapshot was created with from its stored
-     * {@code version_id}.
-     * <p>
-     * Snapshots created on unsupported versions (for example, indices originally created on legacy
-     * Elasticsearch versions) cannot be restored into this OpenSearch version. However, their
-     * metadata must still be readable so that read-only operations such as listing snapshots
-     * ({@code _snapshot/_all}) and retrieving snapshot status ({@code _snapshot/.../_status}) do not
-     * fail for an entire repository because of a single incompatible snapshot. In that case the
-     * version is reported as unknown ({@code null}); the nullable {@code version} field is already
-     * handled gracefully throughout {@link SnapshotInfo} (see {@link #toXContent}).
-     *
-     * @param versionId the stored {@code version_id}
-     * @return the resolved {@link Version}, or {@code null} if the version is not supported
+     * Resolves the {@link Version} a snapshot was created with from its stored {@code version_id},
+     * returning {@code null} for unsupported (e.g. legacy Elasticsearch) versions so that read-only
+     * operations such as listing snapshots do not fail for the whole repository.
      */
     @Nullable
     private static Version resolveSnapshotVersion(int versionId) {
         try {
             return Version.fromId(versionId);
         } catch (Version.UnsupportedVersionException e) {
+            logger.debug("Encountered unsupported snapshot version_id [{}]; reporting version as unknown", versionId);
             return null;
         }
     }

--- a/server/src/main/java/org/opensearch/snapshots/SnapshotInfo.java
+++ b/server/src/main/java/org/opensearch/snapshots/SnapshotInfo.java
@@ -201,7 +201,12 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent,
             }
 
             SnapshotState snapshotState = state == null ? null : SnapshotState.valueOf(state);
-            Version version = this.version == -1 ? Version.CURRENT : Version.fromId(this.version);
+            final Version version;
+            if (this.version == -1) {
+                version = Version.CURRENT;
+            } else {
+                version = resolveSnapshotVersion(this.version);
+            }
 
             int totalShards = shardStatsBuilder == null ? 0 : shardStatsBuilder.getTotalShards();
             int successfulShards = shardStatsBuilder == null ? 0 : shardStatsBuilder.getSuccessfulShards();
@@ -795,6 +800,30 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent,
     }
 
     /**
+     * Resolves the OpenSearch {@link Version} that a snapshot was created with from its stored
+     * {@code version_id}.
+     * <p>
+     * Snapshots created on unsupported versions (for example, indices originally created on legacy
+     * Elasticsearch versions) cannot be restored into this OpenSearch version. However, their
+     * metadata must still be readable so that read-only operations such as listing snapshots
+     * ({@code _snapshot/_all}) and retrieving snapshot status ({@code _snapshot/.../_status}) do not
+     * fail for an entire repository because of a single incompatible snapshot. In that case the
+     * version is reported as unknown ({@code null}); the nullable {@code version} field is already
+     * handled gracefully throughout {@link SnapshotInfo} (see {@link #toXContent}).
+     *
+     * @param versionId the stored {@code version_id}
+     * @return the resolved {@link Version}, or {@code null} if the version is not supported
+     */
+    @Nullable
+    private static Version resolveSnapshotVersion(int versionId) {
+        try {
+            return Version.fromId(versionId);
+        } catch (Version.UnsupportedVersionException e) {
+            return null;
+        }
+    }
+
+    /**
      * This method creates a SnapshotInfo from internal x-content.  It does not
      * handle x-content written with the external version as external x-content
      * is only for display purposes and does not need to be parsed.
@@ -848,7 +877,7 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent,
                         } else if (SUCCESSFUL_SHARDS.equals(currentFieldName)) {
                             successfulShards = parser.intValue();
                         } else if (VERSION_ID.equals(currentFieldName)) {
-                            version = Version.fromId(parser.intValue());
+                            version = resolveSnapshotVersion(parser.intValue());
                         } else if (INCLUDE_GLOBAL_STATE.equals(currentFieldName)) {
                             includeGlobalState = parser.booleanValue();
                         } else if (REMOTE_STORE_INDEX_SHALLOW_COPY.equals(currentFieldName)) {

--- a/server/src/main/java/org/opensearch/snapshots/SnapshotInfo.java
+++ b/server/src/main/java/org/opensearch/snapshots/SnapshotInfo.java
@@ -40,6 +40,7 @@ import org.opensearch.common.Nullable;
 import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.common.time.DateFormatter;
 import org.opensearch.common.unit.TimeValue;
+import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.core.ParseField;
 import org.opensearch.core.action.ShardOperationFailedException;
 import org.opensearch.core.common.io.stream.StreamInput;
@@ -813,6 +814,9 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent,
         try {
             return Version.fromId(versionId);
         } catch (Version.UnsupportedVersionException e) {
+            if (FeatureFlags.isEnabled(FeatureFlags.SNAPSHOT_STRICT_VERSION_PARSING_SETTING)) {
+                throw e;
+            }
             logger.debug("Encountered unsupported snapshot version_id [{}]; reporting version as unknown", versionId);
             return null;
         }

--- a/server/src/test/java/org/opensearch/snapshots/SnapshotInfoTests.java
+++ b/server/src/test/java/org/opensearch/snapshots/SnapshotInfoTests.java
@@ -32,17 +32,93 @@
 
 package org.opensearch.snapshots;
 
+import org.opensearch.Version;
+import org.opensearch.common.xcontent.json.JsonXContent;
 import org.opensearch.core.common.io.stream.Writeable;
 import org.opensearch.core.index.shard.ShardId;
+import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.test.AbstractWireSerializingTestCase;
 import org.opensearch.test.OpenSearchTestCase;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 public class SnapshotInfoTests extends AbstractWireSerializingTestCase<SnapshotInfo> {
+
+    /**
+     * A snapshot whose {@code version_id} refers to an unsupported version (for example, an index
+     * originally created on a legacy Elasticsearch version) must still be readable so that listing
+     * snapshots and retrieving snapshot status do not fail for the whole repository. The version is
+     * reported as {@code null} in that case rather than throwing.
+     */
+    public void testFromXContentInternalToleratesUnsupportedVersionId() throws IOException {
+        // 7100299 is the legacy Elasticsearch 7.10.2 version id; it lacks the OpenSearch mask bit
+        // and is therefore not supported by OpenSearch 3.x.
+        final String json = "{\"snapshot\":{"
+            + "\"name\":\"snap-legacy\","
+            + "\"uuid\":\"abc123\","
+            + "\"version_id\":7100299,"
+            + "\"state\":\"SUCCESS\","
+            + "\"indices\":[\"idx-1\"],"
+            + "\"total_shards\":1,"
+            + "\"successful_shards\":1"
+            + "}}";
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, json)) {
+            SnapshotInfo snapshotInfo = SnapshotInfo.fromXContentInternal(parser);
+            assertEquals("snap-legacy", snapshotInfo.snapshotId().getName());
+            assertNull("unsupported version id must resolve to null instead of throwing", snapshotInfo.version());
+            assertEquals(SnapshotState.SUCCESS, snapshotInfo.state());
+        }
+    }
+
+    /**
+     * A supported {@code version_id} must continue to resolve to the corresponding {@link Version}.
+     */
+    public void testFromXContentInternalResolvesSupportedVersionId() throws IOException {
+        final String json = "{\"snapshot\":{"
+            + "\"name\":\"snap-ok\","
+            + "\"uuid\":\"def456\","
+            + "\"version_id\":"
+            + Version.CURRENT.id
+            + ","
+            + "\"state\":\"SUCCESS\","
+            + "\"indices\":[\"idx-1\"],"
+            + "\"total_shards\":1,"
+            + "\"successful_shards\":1"
+            + "}}";
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, json)) {
+            SnapshotInfo snapshotInfo = SnapshotInfo.fromXContentInternal(parser);
+            assertEquals(Version.CURRENT, snapshotInfo.version());
+        }
+    }
+
+    /**
+     * A {@link SnapshotInfo} with an unknown (null) version, as produced for a snapshot created on an
+     * unsupported version, must survive a transport-layer serialization round trip. This guards the
+     * coordinating-node to client path used by snapshot listing and status APIs.
+     */
+    public void testWireRoundTripWithUnknownVersion() throws IOException {
+        final String json = "{\"snapshot\":{"
+            + "\"name\":\"snap-legacy\","
+            + "\"uuid\":\"abc123\","
+            + "\"version_id\":7100299,"
+            + "\"state\":\"SUCCESS\","
+            + "\"indices\":[\"idx-1\"],"
+            + "\"total_shards\":1,"
+            + "\"successful_shards\":1"
+            + "}}";
+        final SnapshotInfo original;
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, json)) {
+            original = SnapshotInfo.fromXContentInternal(parser);
+        }
+        assertNull(original.version());
+        SnapshotInfo roundTripped = copyInstance(original);
+        assertNull("null version must be preserved across the wire", roundTripped.version());
+        assertEquals(original, roundTripped);
+    }
 
     @Override
     protected SnapshotInfo createTestInstance() {

--- a/server/src/test/java/org/opensearch/snapshots/SnapshotInfoTests.java
+++ b/server/src/test/java/org/opensearch/snapshots/SnapshotInfoTests.java
@@ -48,75 +48,47 @@ import java.util.Map;
 
 public class SnapshotInfoTests extends AbstractWireSerializingTestCase<SnapshotInfo> {
 
-    /**
-     * A snapshot whose {@code version_id} refers to an unsupported version (for example, an index
-     * originally created on a legacy Elasticsearch version) must still be readable so that listing
-     * snapshots and retrieving snapshot status do not fail for the whole repository. The version is
-     * reported as {@code null} in that case rather than throwing.
-     */
+    // Legacy Elasticsearch 7.10.2 version id: it lacks the OpenSearch version mask bit, so it is not
+    // supported and Version.fromId rejects it.
+    private static final int LEGACY_ES_7_10_2_VERSION_ID = 7100299;
+
+    private static String snapshotJson(String name, int versionId) {
+        return "{\"snapshot\":{\"name\":\""
+            + name
+            + "\",\"uuid\":\"uuid\",\"version_id\":"
+            + versionId
+            + ",\"state\":\"SUCCESS\",\"indices\":[\"idx-1\"],\"total_shards\":1,\"successful_shards\":1}}";
+    }
+
+    /** An unsupported {@code version_id} must parse to an unknown ({@code null}) version, not throw. */
     public void testFromXContentInternalToleratesUnsupportedVersionId() throws IOException {
-        // 7100299 is the legacy Elasticsearch 7.10.2 version id; it lacks the OpenSearch mask bit
-        // and is therefore not supported by OpenSearch 3.x.
-        final String json = "{\"snapshot\":{"
-            + "\"name\":\"snap-legacy\","
-            + "\"uuid\":\"abc123\","
-            + "\"version_id\":7100299,"
-            + "\"state\":\"SUCCESS\","
-            + "\"indices\":[\"idx-1\"],"
-            + "\"total_shards\":1,"
-            + "\"successful_shards\":1"
-            + "}}";
+        final String json = snapshotJson("snap-legacy", LEGACY_ES_7_10_2_VERSION_ID);
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, json)) {
             SnapshotInfo snapshotInfo = SnapshotInfo.fromXContentInternal(parser);
             assertEquals("snap-legacy", snapshotInfo.snapshotId().getName());
-            assertNull("unsupported version id must resolve to null instead of throwing", snapshotInfo.version());
+            assertNull(snapshotInfo.version());
             assertEquals(SnapshotState.SUCCESS, snapshotInfo.state());
         }
     }
 
-    /**
-     * A supported {@code version_id} must continue to resolve to the corresponding {@link Version}.
-     */
+    /** A supported {@code version_id} must still resolve to its {@link Version}. */
     public void testFromXContentInternalResolvesSupportedVersionId() throws IOException {
-        final String json = "{\"snapshot\":{"
-            + "\"name\":\"snap-ok\","
-            + "\"uuid\":\"def456\","
-            + "\"version_id\":"
-            + Version.CURRENT.id
-            + ","
-            + "\"state\":\"SUCCESS\","
-            + "\"indices\":[\"idx-1\"],"
-            + "\"total_shards\":1,"
-            + "\"successful_shards\":1"
-            + "}}";
+        final String json = snapshotJson("snap-ok", Version.CURRENT.id);
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, json)) {
-            SnapshotInfo snapshotInfo = SnapshotInfo.fromXContentInternal(parser);
-            assertEquals(Version.CURRENT, snapshotInfo.version());
+            assertEquals(Version.CURRENT, SnapshotInfo.fromXContentInternal(parser).version());
         }
     }
 
-    /**
-     * A {@link SnapshotInfo} with an unknown (null) version, as produced for a snapshot created on an
-     * unsupported version, must survive a transport-layer serialization round trip. This guards the
-     * coordinating-node to client path used by snapshot listing and status APIs.
-     */
+    /** A {@link SnapshotInfo} with an unknown (null) version must survive a wire round trip. */
     public void testWireRoundTripWithUnknownVersion() throws IOException {
-        final String json = "{\"snapshot\":{"
-            + "\"name\":\"snap-legacy\","
-            + "\"uuid\":\"abc123\","
-            + "\"version_id\":7100299,"
-            + "\"state\":\"SUCCESS\","
-            + "\"indices\":[\"idx-1\"],"
-            + "\"total_shards\":1,"
-            + "\"successful_shards\":1"
-            + "}}";
+        final String json = snapshotJson("snap-legacy", LEGACY_ES_7_10_2_VERSION_ID);
         final SnapshotInfo original;
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, json)) {
             original = SnapshotInfo.fromXContentInternal(parser);
         }
         assertNull(original.version());
         SnapshotInfo roundTripped = copyInstance(original);
-        assertNull("null version must be preserved across the wire", roundTripped.version());
+        assertNull(roundTripped.version());
         assertEquals(original, roundTripped);
     }
 

--- a/server/src/test/java/org/opensearch/snapshots/SnapshotInfoTests.java
+++ b/server/src/test/java/org/opensearch/snapshots/SnapshotInfoTests.java
@@ -33,6 +33,7 @@
 package org.opensearch.snapshots;
 
 import org.opensearch.Version;
+import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.common.xcontent.json.JsonXContent;
 import org.opensearch.core.common.io.stream.Writeable;
 import org.opensearch.core.index.shard.ShardId;
@@ -90,6 +91,15 @@ public class SnapshotInfoTests extends AbstractWireSerializingTestCase<SnapshotI
         SnapshotInfo roundTripped = copyInstance(original);
         assertNull(roundTripped.version());
         assertEquals(original, roundTripped);
+    }
+
+    /** With strict version parsing enabled, an unsupported {@code version_id} must fail fast rather than resolve to null. */
+    @LockFeatureFlag(FeatureFlags.SNAPSHOT_STRICT_VERSION_PARSING)
+    public void testUnsupportedVersionIdFailsWhenStrictParsingEnabled() throws IOException {
+        final String json = snapshotJson("snap-legacy", LEGACY_ES_7_10_2_VERSION_ID);
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, json)) {
+            expectThrows(Version.UnsupportedVersionException.class, () -> SnapshotInfo.fromXContentInternal(parser));
+        }
     }
 
     @Override


### PR DESCRIPTION
### Description

Reading snapshot metadata fails for an entire repository when that repository
contains even a single snapshot that was created on an unsupported version (for
example, indices originally created on a Elasticsearch version).

`SnapshotInfo` deserialization calls `Version.fromId()` unconditionally on the
stored `version_id`. After legacy Elasticsearch version support was removed
(#19793), `Version.fromId()` throws `UnsupportedVersionException` for legacy ES
version IDs (which lack the OpenSearch mask bit), and #20512 made that exception
message human-readable. However, this throw also propagates out of the read-only
snapshot enumeration path, so operations such as:

- `GET /_snapshot/<repo>/_all`
- `GET /_snapshot/<repo>/<snapshot>/_status`

fail with a 500 for the whole repository, even though the offending snapshot
cannot be restored anyway. Any tooling that lists snapshots as a precondition
is therefore blocked.


### Fix

Resolve the snapshot version defensively at the two `SnapshotInfo`
deserialization call sites (`SnapshotInfoBuilder#build` and
`fromXContentInternal`) 


### Behavior matrix

| `version_id` input | Before | After |
|---|---|---|
| `-1` (absent sentinel, builder path) | `Version.CURRENT` | `Version.CURRENT` (unchanged) |
| `0` | `fromId(0)` (no throw) | unchanged |
| Legacy ES id, e.g. `7100299` (no mask bit) | **throws** `UnsupportedVersionException` | resolves to `null` (unknown) |
| Known OpenSearch id (mask bit set) | resolves | resolves (unchanged) |
| Unknown future OpenSearch id (mask bit set) | best-effort via `fromIdSlow` | best-effort via `fromIdSlow` (unchanged) |
| Garbage id without mask bit (`!= 0`) | throws | resolves to `null` |

Only `UnsupportedVersionException` is caught (not `Exception`), so genuine
parse/format errors still propagate. Restore-time and index-open compatibility
checks are unaffected: those paths do not go through `SnapshotInfo`
deserialization and continue to reject unsupported versions.

### Testing

`SnapshotInfoTests`:
- `testFromXContentInternalToleratesUnsupportedVersionId` — a blob with
  `version_id = 7100299` deserializes to `version() == null` instead of throwing.
- `testFromXContentInternalResolvesSupportedVersionId` — a supported id still
  resolves to the correct `Version`.
- `testWireRoundTripWithUnknownVersion` — a `SnapshotInfo` with a `null` version
  survives a transport-layer serialization round trip (guards the
  coordinating-node -> client path used by listing/status).



### Related issues

- Follow-up to #19793 (removed legacy ES version support).
- Builds on #20512 (human-readable `UnsupportedVersionException`).
- Addresses the snapshot-listing breakage reported in #20499.

### Check List
- [x] Functionality includes tests.
- [x] Commit messages are signed off (DCO).
- [x] CHANGELOG no longer used as of 3.6 (per `CHANGELOG.md`); PR labeled `skip-changelog`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.