### PR TITLE
Add parent action name to ProcessorGenerationContext for system gener…

### DIFF
--- a/plugins/examples/system-search-processor/src/test/java/org/opensearch/example/systemsearchprocessor/ExampleSearchPhaseResultsProcessorTests.java
+++ b/plugins/examples/system-search-processor/src/test/java/org/opensearch/example/systemsearchprocessor/ExampleSearchPhaseResultsProcessorTests.java
@@ -27,7 +27,7 @@ import static org.mockito.Mockito.when;
 
 public class ExampleSearchPhaseResultsProcessorTests extends OpenSearchTestCase {
     private final ExampleSearchPhaseResultsProcessor.Factory factory = new ExampleSearchPhaseResultsProcessor.Factory();
-    private final ProcessorGenerationContext context = new ProcessorGenerationContext(mock(SearchRequest.class));
+    private final ProcessorGenerationContext context = new ProcessorGenerationContext(mock(SearchRequest.class), null);
 
     public void testShouldGenerate_thenAlwaysTrue() {
         assertTrue(factory.shouldGenerate(context));

--- a/plugins/examples/system-search-processor/src/test/java/org/opensearch/example/systemsearchprocessor/ExampleSearchRequestPostProcessorTests.java
+++ b/plugins/examples/system-search-processor/src/test/java/org/opensearch/example/systemsearchprocessor/ExampleSearchRequestPostProcessorTests.java
@@ -58,12 +58,12 @@ public class ExampleSearchRequestPostProcessorTests extends OpenSearchTestCase {
 
         ExampleSearchRequestPostProcessor.Factory factory = new ExampleSearchRequestPostProcessor.Factory();
 
-        ProcessorGenerationContext smallContext = new ProcessorGenerationContext(smallRequest);
-        ProcessorGenerationContext largeContext = new ProcessorGenerationContext(largeRequest);
+        ProcessorGenerationContext smallContext = new ProcessorGenerationContext(smallRequest, null);
+        ProcessorGenerationContext largeContext = new ProcessorGenerationContext(largeRequest, null);
 
         assertTrue(factory.shouldGenerate(smallContext));
         assertFalse(factory.shouldGenerate(largeContext));
-        assertFalse(factory.shouldGenerate(new ProcessorGenerationContext(null)));
+        assertFalse(factory.shouldGenerate(new ProcessorGenerationContext(null, null)));
     }
 
     public void testFactoryCreate() throws Exception {

--- a/plugins/examples/system-search-processor/src/test/java/org/opensearch/example/systemsearchprocessor/ExampleSearchRequestPreProcessorTests.java
+++ b/plugins/examples/system-search-processor/src/test/java/org/opensearch/example/systemsearchprocessor/ExampleSearchRequestPreProcessorTests.java
@@ -71,28 +71,28 @@ public class ExampleSearchRequestPreProcessorTests extends OpenSearchTestCase {
         // original size < 5 => should generate
         SearchRequest smallRequest = new SearchRequest();
         smallRequest.source(new SearchSourceBuilder().size(4));
-        ProcessorGenerationContext smallContext = new ProcessorGenerationContext(smallRequest);
+        ProcessorGenerationContext smallContext = new ProcessorGenerationContext(smallRequest, null);
         assertTrue(factory.shouldGenerate(smallContext));
 
         // original size = 5 => should not generate
         SearchRequest boundaryRequest = new SearchRequest();
         boundaryRequest.source(new SearchSourceBuilder().size(5));
-        ProcessorGenerationContext boundaryContext = new ProcessorGenerationContext(boundaryRequest);
+        ProcessorGenerationContext boundaryContext = new ProcessorGenerationContext(boundaryRequest, null);
         assertFalse(factory.shouldGenerate(boundaryContext));
 
         // original size > 5 => should not generate
         SearchRequest largeRequest = new SearchRequest();
         largeRequest.source(new SearchSourceBuilder().size(6));
-        ProcessorGenerationContext largeContext = new ProcessorGenerationContext(largeRequest);
+        ProcessorGenerationContext largeContext = new ProcessorGenerationContext(largeRequest, null);
         assertFalse(factory.shouldGenerate(largeContext));
 
         // null request => should not generate
-        ProcessorGenerationContext nullContext = new ProcessorGenerationContext(null);
+        ProcessorGenerationContext nullContext = new ProcessorGenerationContext(null, null);
         assertFalse(factory.shouldGenerate(nullContext));
 
         // null source => should not generate
         SearchRequest nullSourceRequest = new SearchRequest();
-        ProcessorGenerationContext nullSourceContext = new ProcessorGenerationContext(nullSourceRequest);
+        ProcessorGenerationContext nullSourceContext = new ProcessorGenerationContext(nullSourceRequest, null);
         assertFalse(factory.shouldGenerate(nullSourceContext));
     }
 

--- a/plugins/examples/system-search-processor/src/test/java/org/opensearch/example/systemsearchprocessor/ExampleSearchResponseProcessorTests.java
+++ b/plugins/examples/system-search-processor/src/test/java/org/opensearch/example/systemsearchprocessor/ExampleSearchResponseProcessorTests.java
@@ -111,7 +111,7 @@ public class ExampleSearchResponseProcessorTests extends OpenSearchTestCase {
         sourceBuilder.query(new MatchQueryBuilder("trigger_field", "value"));
         request.source(sourceBuilder);
 
-        ProcessorGenerationContext ctx = new ProcessorGenerationContext(request);
+        ProcessorGenerationContext ctx = new ProcessorGenerationContext(request, null);
         assertTrue(factory.shouldGenerate(ctx));
     }
 
@@ -122,7 +122,7 @@ public class ExampleSearchResponseProcessorTests extends OpenSearchTestCase {
         sourceBuilder.query(new MatchQueryBuilder("field", "value"));
         request.source(sourceBuilder);
 
-        ProcessorGenerationContext ctx = new ProcessorGenerationContext(request);
+        ProcessorGenerationContext ctx = new ProcessorGenerationContext(request, null);
         assertFalse(factory.shouldGenerate(ctx));
     }
 

--- a/server/src/main/java/org/opensearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/opensearch/action/search/TransportSearchAction.java
@@ -485,7 +485,8 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
             PipelinedRequest searchRequest;
             ActionListener<SearchResponse> listener;
             try {
-                searchRequest = searchPipelineService.resolvePipeline(originalSearchRequest, indexNameExpressionResolver);
+                final Task parentTask = extractParentTask(originalSearchRequest);
+                searchRequest = searchPipelineService.resolvePipeline(originalSearchRequest, parentTask, indexNameExpressionResolver);
                 listener = searchRequest.transformResponseListener(updatedListener);
             } catch (Exception e) {
                 updatedListener.onFailure(e);
@@ -514,6 +515,14 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
             }, listener::onFailure);
             searchRequest.transformRequest(requestTransformListener);
         }
+    }
+
+    private Task extractParentTask(final SearchRequest searchRequest) {
+        TaskId taskId = searchRequest.getParentTask();
+        if (taskId != null && taskId != TaskId.EMPTY_TASK_ID) {
+            return taskManager.getTask(taskId.getId());
+        }
+        return null;
     }
 
     private ActionListener<SearchSourceBuilder> buildRewriteListener(

--- a/server/src/main/java/org/opensearch/plugins/SearchPipelinePlugin.java
+++ b/server/src/main/java/org/opensearch/plugins/SearchPipelinePlugin.java
@@ -197,5 +197,6 @@ public interface SearchPipelinePlugin {
          * The parsed search request sent by users
          */
         public static final String SEARCH_REQUEST = "search_request";
+        public static final String PARENT_ACTION = "parent_action";
     }
 }

--- a/server/src/main/java/org/opensearch/search/pipeline/ProcessorGenerationContext.java
+++ b/server/src/main/java/org/opensearch/search/pipeline/ProcessorGenerationContext.java
@@ -9,9 +9,10 @@
 package org.opensearch.search.pipeline;
 
 import org.opensearch.action.search.SearchRequest;
+import org.opensearch.common.Nullable;
 
 /**
  * A DTO to hold the context used for a system generated factory to evaluate should we generate the processor
  */
-public record ProcessorGenerationContext(SearchRequest searchRequest) {
+public record ProcessorGenerationContext(SearchRequest searchRequest, @Nullable String parentAction) {
 }

--- a/server/src/main/java/org/opensearch/search/pipeline/SearchPipelineService.java
+++ b/server/src/main/java/org/opensearch/search/pipeline/SearchPipelineService.java
@@ -47,6 +47,7 @@ import org.opensearch.index.analysis.AnalysisRegistry;
 import org.opensearch.ingest.ConfigurationUtils;
 import org.opensearch.plugins.SearchPipelinePlugin;
 import org.opensearch.script.ScriptService;
+import org.opensearch.tasks.Task;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.client.Client;
 
@@ -66,6 +67,7 @@ import java.util.stream.Collectors;
 
 import static org.opensearch.cluster.service.ClusterManagerTask.DELETE_SEARCH_PIPELINE;
 import static org.opensearch.cluster.service.ClusterManagerTask.PUT_SEARCH_PIPELINE;
+import static org.opensearch.plugins.SearchPipelinePlugin.SystemGeneratedSearchPipelineConfigKeys.PARENT_ACTION;
 import static org.opensearch.plugins.SearchPipelinePlugin.SystemGeneratedSearchPipelineConfigKeys.SEARCH_REQUEST;
 
 /**
@@ -458,8 +460,11 @@ public class SearchPipelineService implements ClusterStateApplier, ReportingServ
         return newState.build();
     }
 
-    public PipelinedRequest resolvePipeline(SearchRequest searchRequest, IndexNameExpressionResolver indexNameExpressionResolver)
-        throws Exception {
+    public PipelinedRequest resolvePipeline(
+        SearchRequest searchRequest,
+        Task parentTask,
+        IndexNameExpressionResolver indexNameExpressionResolver
+    ) throws Exception {
         Pipeline pipeline = Pipeline.NO_OP_PIPELINE;
         if (searchRequest.source() != null && searchRequest.source().searchPipelineSource() != null) {
             // Pipeline defined in search request (ad hoc pipeline).
@@ -520,7 +525,10 @@ public class SearchPipelineService implements ClusterStateApplier, ReportingServ
             }
         }
         // Resolve system generated search pipeline
-        final Map<String, Object> config = Map.of(SEARCH_REQUEST, searchRequest);
+        final String parentAction = parentTask != null ? parentTask.getAction() : null;
+        final Map<String, Object> config = new HashMap<>();
+        config.put(SEARCH_REQUEST, searchRequest);
+        config.put(PARENT_ACTION, parentAction);
         final SystemGeneratedPipelineHolder systemGeneratedPipelineHolder = SystemGeneratedPipelineWithMetrics.create(
             config,
             systemGeneratedRequestProcessorFactories,

--- a/server/src/main/java/org/opensearch/search/pipeline/SystemGeneratedPipelineWithMetrics.java
+++ b/server/src/main/java/org/opensearch/search/pipeline/SystemGeneratedPipelineWithMetrics.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import java.util.function.LongSupplier;
 import java.util.stream.Collectors;
 
+import static org.opensearch.plugins.SearchPipelinePlugin.SystemGeneratedSearchPipelineConfigKeys.PARENT_ACTION;
 import static org.opensearch.plugins.SearchPipelinePlugin.SystemGeneratedSearchPipelineConfigKeys.SEARCH_REQUEST;
 import static org.opensearch.search.pipeline.SystemGeneratedProcessor.ExecutionStage.POST_USER_DEFINED;
 import static org.opensearch.search.pipeline.SystemGeneratedProcessor.ExecutionStage.PRE_USER_DEFINED;
@@ -141,7 +142,7 @@ class SystemGeneratedPipelineWithMetrics extends Pipeline {
             return lists;
         }
         boolean isAllEnabled = enabledSystemGeneratedFactories.contains("*");
-        ProcessorGenerationContext context = new ProcessorGenerationContext((SearchRequest) config.get(SEARCH_REQUEST));
+        ProcessorGenerationContext context = new ProcessorGenerationContext((SearchRequest) config.get(SEARCH_REQUEST), (String) config.get(PARENT_ACTION));
 
         for (Map.Entry<String, SystemGeneratedProcessor.SystemGeneratedFactory<T>> entry : factories.entrySet()) {
             String factoryType = entry.getKey();

--- a/server/src/main/java/org/opensearch/search/pipeline/SystemGeneratedPipelineWithMetrics.java
+++ b/server/src/main/java/org/opensearch/search/pipeline/SystemGeneratedPipelineWithMetrics.java
@@ -142,7 +142,10 @@ class SystemGeneratedPipelineWithMetrics extends Pipeline {
             return lists;
         }
         boolean isAllEnabled = enabledSystemGeneratedFactories.contains("*");
-        ProcessorGenerationContext context = new ProcessorGenerationContext((SearchRequest) config.get(SEARCH_REQUEST), (String) config.get(PARENT_ACTION));
+        ProcessorGenerationContext context = new ProcessorGenerationContext(
+            (SearchRequest) config.get(SEARCH_REQUEST),
+            (String) config.get(PARENT_ACTION)
+        );
 
         for (Map.Entry<String, SystemGeneratedProcessor.SystemGeneratedFactory<T>> entry : factories.entrySet()) {
             String factoryType = entry.getKey();

--- a/server/src/test/java/org/opensearch/index/query/QueryCoordinatorContextTests.java
+++ b/server/src/test/java/org/opensearch/index/query/QueryCoordinatorContextTests.java
@@ -92,7 +92,7 @@ public class QueryCoordinatorContextTests extends OpenSearchTestCase {
             client
         );
         final SearchRequest searchRequest = new SearchRequest();
-        return searchPipelineService.resolvePipeline(searchRequest, indexNameExpressionResolver);
+        return searchPipelineService.resolvePipeline(searchRequest, null, indexNameExpressionResolver);
     }
 
     public void testGetContextVariables_whenNotPipelinedSearchRequest_thenReturnEmpty() {

--- a/server/src/test/java/org/opensearch/search/pipeline/PipelinedRequestTests.java
+++ b/server/src/test/java/org/opensearch/search/pipeline/PipelinedRequestTests.java
@@ -76,13 +76,13 @@ public class PipelinedRequestTests extends SearchPipelineTestCase {
         // This request doesn't specify a pipeline, it doesn't get transformed.
         SearchRequest request = new SearchRequest("my-index").source(sourceBuilder);
         PipelinedRequest pipelinedRequest = syncTransformRequest(
-            searchPipelineService.resolvePipeline(request, indexNameExpressionResolver)
+            searchPipelineService.resolvePipeline(request, null, indexNameExpressionResolver)
         );
         assertEquals(size, pipelinedRequest.source().size());
 
         // Specify the pipeline and use it to transform the request
         request = new SearchRequest("my-index").source(sourceBuilder).pipeline("p1");
-        pipelinedRequest = syncTransformRequest(searchPipelineService.resolvePipeline(request, indexNameExpressionResolver));
+        pipelinedRequest = syncTransformRequest(searchPipelineService.resolvePipeline(request, null, indexNameExpressionResolver));
         assertEquals(2 * size, pipelinedRequest.source().size());
     }
 
@@ -92,7 +92,7 @@ public class PipelinedRequestTests extends SearchPipelineTestCase {
         enabledAllSystemGeneratedFactories(service);
 
         SearchRequest searchRequest = new SearchRequest("my_index").source(SearchSourceBuilder.searchSource().size(5));
-        PipelinedRequest pipelinedRequest = service.resolvePipeline(searchRequest, indexNameExpressionResolver);
+        PipelinedRequest pipelinedRequest = service.resolvePipeline(searchRequest, null, indexNameExpressionResolver);
         pipelinedRequest.transformRequest(new ActionListener<SearchRequest>() {
             @Override
             public void onResponse(SearchRequest searchRequest) {
@@ -137,14 +137,14 @@ public class PipelinedRequestTests extends SearchPipelineTestCase {
         // First try without specifying a pipeline, which should be a no-op.
         SearchRequest searchRequest = new SearchRequest();
         searchRequest.source(createDefaultSearchSourceBuilder());
-        PipelinedRequest pipelinedRequest = searchPipelineService.resolvePipeline(searchRequest, indexNameExpressionResolver);
+        PipelinedRequest pipelinedRequest = searchPipelineService.resolvePipeline(searchRequest, null, indexNameExpressionResolver);
         SearchResponse notTransformedResponse = syncTransformResponse(pipelinedRequest, searchResponse);
         assertSame(searchResponse, notTransformedResponse);
 
         // Now apply a pipeline
         searchRequest = new SearchRequest().pipeline("p1");
         searchRequest.source(createDefaultSearchSourceBuilder());
-        pipelinedRequest = searchPipelineService.resolvePipeline(searchRequest, indexNameExpressionResolver);
+        pipelinedRequest = searchPipelineService.resolvePipeline(searchRequest, null, indexNameExpressionResolver);
         SearchResponse transformedResponse = syncTransformResponse(pipelinedRequest, searchResponse);
         assertEquals(size, transformedResponse.getHits().getHits().length);
         for (int i = 0; i < size; i++) {
@@ -158,7 +158,7 @@ public class PipelinedRequestTests extends SearchPipelineTestCase {
         enabledAllSystemGeneratedFactories(service);
         int size = 10;
         SearchRequest searchRequest = new SearchRequest("my_index").source(SearchSourceBuilder.searchSource().size(size));
-        PipelinedRequest pipelinedRequest = service.resolvePipeline(searchRequest, indexNameExpressionResolver);
+        PipelinedRequest pipelinedRequest = service.resolvePipeline(searchRequest, null, indexNameExpressionResolver);
 
         ActionListener<SearchResponse> listener = pipelinedRequest.transformResponseListener(new ActionListener<SearchResponse>() {
 
@@ -224,7 +224,7 @@ public class PipelinedRequestTests extends SearchPipelineTestCase {
         // First try without specifying a pipeline, which should be a no-op.
         SearchRequest searchRequest = new SearchRequest();
         searchRequest.source(createDefaultSearchSourceBuilder());
-        PipelinedRequest pipelinedRequest = searchPipelineService.resolvePipeline(searchRequest, indexNameExpressionResolver);
+        PipelinedRequest pipelinedRequest = searchPipelineService.resolvePipeline(searchRequest, null, indexNameExpressionResolver);
         AtomicArray<SearchPhaseResult> notTransformedSearchPhaseResults = searchPhaseResults.getAtomicArray();
         pipelinedRequest.transformSearchPhaseResults(
             searchPhaseResults,
@@ -237,7 +237,7 @@ public class PipelinedRequestTests extends SearchPipelineTestCase {
         // Now set the pipeline as p1
         searchRequest = new SearchRequest().pipeline("p1");
         searchRequest.source(createDefaultSearchSourceBuilder());
-        pipelinedRequest = searchPipelineService.resolvePipeline(searchRequest, indexNameExpressionResolver);
+        pipelinedRequest = searchPipelineService.resolvePipeline(searchRequest, null, indexNameExpressionResolver);
 
         pipelinedRequest.transformSearchPhaseResults(
             searchPhaseResults,
@@ -256,7 +256,7 @@ public class PipelinedRequestTests extends SearchPipelineTestCase {
         // Check Processor doesn't run for between other phases
         searchRequest = new SearchRequest().pipeline("p1");
         searchRequest.source(createDefaultSearchSourceBuilder());
-        pipelinedRequest = searchPipelineService.resolvePipeline(searchRequest, indexNameExpressionResolver);
+        pipelinedRequest = searchPipelineService.resolvePipeline(searchRequest, null, indexNameExpressionResolver);
         AtomicArray<SearchPhaseResult> notTransformedSearchPhaseResult = searchPhaseResults.getAtomicArray();
         pipelinedRequest.transformSearchPhaseResults(
             searchPhaseResults,
@@ -295,7 +295,7 @@ public class PipelinedRequestTests extends SearchPipelineTestCase {
         searchPhaseResults.consumeResult(querySearchResult, () -> {});
 
         SearchRequest searchRequest = new SearchRequest("my_index").source(SearchSourceBuilder.searchSource().size(10));
-        PipelinedRequest pipelinedRequest = service.resolvePipeline(searchRequest, indexNameExpressionResolver);
+        PipelinedRequest pipelinedRequest = service.resolvePipeline(searchRequest, null, indexNameExpressionResolver);
 
         pipelinedRequest.transformSearchPhaseResults(
             searchPhaseResults,

--- a/server/src/test/java/org/opensearch/search/pipeline/SearchPipelineServiceTests.java
+++ b/server/src/test/java/org/opensearch/search/pipeline/SearchPipelineServiceTests.java
@@ -161,7 +161,7 @@ public class SearchPipelineServiceTests extends SearchPipelineTestCase {
         final SearchRequest searchRequest = new SearchRequest("_index").pipeline("bar");
         IllegalArgumentException e = expectThrows(
             IllegalArgumentException.class,
-            () -> searchPipelineService.resolvePipeline(searchRequest, indexNameExpressionResolver)
+            () -> searchPipelineService.resolvePipeline(searchRequest, null, indexNameExpressionResolver)
         );
         assertTrue(e.getMessage(), e.getMessage().contains(" not defined"));
     }
@@ -171,13 +171,13 @@ public class SearchPipelineServiceTests extends SearchPipelineTestCase {
         setUpForResolvePipeline(service);
 
         SearchRequest searchRequest = new SearchRequest("my_index").source(SearchSourceBuilder.searchSource().size(5));
-        PipelinedRequest pipelinedRequest = syncTransformRequest(service.resolvePipeline(searchRequest, indexNameExpressionResolver));
+        PipelinedRequest pipelinedRequest = syncTransformRequest(service.resolvePipeline(searchRequest, null, indexNameExpressionResolver));
         assertEquals("p1", pipelinedRequest.getPipeline().getId());
         assertEquals(10, pipelinedRequest.source().size());
 
         // Bypass the default pipeline
         searchRequest = new SearchRequest("my_index").source(SearchSourceBuilder.searchSource().size(5)).pipeline("_none");
-        pipelinedRequest = service.resolvePipeline(searchRequest, indexNameExpressionResolver);
+        pipelinedRequest = service.resolvePipeline(searchRequest, null, indexNameExpressionResolver);
         assertEquals("_none", pipelinedRequest.getPipeline().getId());
         assertEquals(5, pipelinedRequest.source().size());
         assertTrue(pipelinedRequest.getSystemGeneratedPipelineHolder().isNoOp());
@@ -189,7 +189,7 @@ public class SearchPipelineServiceTests extends SearchPipelineTestCase {
         enabledAllSystemGeneratedFactories(service);
 
         SearchRequest searchRequest = new SearchRequest("my_index").source(SearchSourceBuilder.searchSource().size(5));
-        PipelinedRequest pipelinedRequest = service.resolvePipeline(searchRequest, indexNameExpressionResolver);
+        PipelinedRequest pipelinedRequest = service.resolvePipeline(searchRequest, null, indexNameExpressionResolver);
         // user defined pipeline is resolved
         assertEquals("p1", pipelinedRequest.getPipeline().getId());
         // system generated pipelines are resolved
@@ -249,7 +249,7 @@ public class SearchPipelineServiceTests extends SearchPipelineTestCase {
         SearchRequest searchRequest = new SearchRequest("my_index").source(SearchSourceBuilder.searchSource().size(5));
         IllegalArgumentException exception = assertThrows(
             IllegalArgumentException.class,
-            () -> service.resolvePipeline(searchRequest, indexNameExpressionResolver)
+            () -> service.resolvePipeline(searchRequest, null, indexNameExpressionResolver)
         );
 
         String expectedError =
@@ -264,7 +264,7 @@ public class SearchPipelineServiceTests extends SearchPipelineTestCase {
 
         // set a large size to not meet the condition to generate the system generated request processor
         SearchRequest searchRequest = new SearchRequest("my_index").source(SearchSourceBuilder.searchSource().size(20));
-        PipelinedRequest pipelinedRequest = service.resolvePipeline(searchRequest, indexNameExpressionResolver);
+        PipelinedRequest pipelinedRequest = service.resolvePipeline(searchRequest, null, indexNameExpressionResolver);
 
         // verify the system generated request processor is not generated
         assertTrue(
@@ -279,13 +279,104 @@ public class SearchPipelineServiceTests extends SearchPipelineTestCase {
 
         // set a large size to not meet the condition to generate the system generated request processor
         SearchRequest searchRequest = new SearchRequest("my_index").source(SearchSourceBuilder.searchSource().size(5));
-        PipelinedRequest pipelinedRequest = service.resolvePipeline(searchRequest, indexNameExpressionResolver);
+        PipelinedRequest pipelinedRequest = service.resolvePipeline(searchRequest, null, indexNameExpressionResolver);
 
         // verify no system generated processors
         assertTrue(
             "Should not systematically generate the search processors",
             pipelinedRequest.getSystemGeneratedPipelineHolder().isNoOp()
         );
+    }
+
+    public void testResolveSystemGeneratedSearchPipeline_whenParentTaskProvided_thenContextHasParentAction() throws Exception {
+        AtomicReference<String> capturedParentAction = new AtomicReference<>();
+        Map<String, SystemGeneratedProcessor.SystemGeneratedFactory<SearchRequestProcessor>> systemGeneratedRequestProcessors =
+            new HashMap<>();
+        systemGeneratedRequestProcessors.put(
+            "action_aware_processor",
+            new SystemGeneratedProcessor.SystemGeneratedFactory<>() {
+                @Override
+                public boolean shouldGenerate(ProcessorGenerationContext context) {
+                    capturedParentAction.set(context.parentAction());
+                    return false;
+                }
+
+                @Override
+                public SearchRequestProcessor create(
+                    Map<String, Processor.Factory<SearchRequestProcessor>> processorFactories,
+                    String tag,
+                    String description,
+                    boolean ignoreFailure,
+                    Map<String, Object> config,
+                    Processor.PipelineContext pipelineContext
+                ) {
+                    return null;
+                }
+            }
+        );
+
+        SearchPipelineService service = createWithProcessors(
+            buildBaseProcessors().request,
+            buildBaseProcessors().response,
+            buildBaseProcessors().phase,
+            systemGeneratedRequestProcessors,
+            Collections.emptyMap(),
+            Collections.emptyMap()
+        );
+        setUpForResolvePipeline(service);
+        enabledAllSystemGeneratedFactories(service);
+
+        org.opensearch.tasks.Task parentTask = mock(org.opensearch.tasks.Task.class);
+        when(parentTask.getAction()).thenReturn("indices:data/read/msearch");
+
+        SearchRequest searchRequest = new SearchRequest("my_index").source(SearchSourceBuilder.searchSource().size(5));
+        service.resolvePipeline(searchRequest, parentTask, indexNameExpressionResolver);
+
+        assertEquals("indices:data/read/msearch", capturedParentAction.get());
+    }
+
+    public void testResolveSystemGeneratedSearchPipeline_whenNoParentTask_thenContextHasNullParentAction() throws Exception {
+        AtomicReference<String> capturedParentAction = new AtomicReference<>("sentinel");
+        Map<String, SystemGeneratedProcessor.SystemGeneratedFactory<SearchRequestProcessor>> systemGeneratedRequestProcessors =
+            new HashMap<>();
+        systemGeneratedRequestProcessors.put(
+            "action_aware_processor",
+            new SystemGeneratedProcessor.SystemGeneratedFactory<>() {
+                @Override
+                public boolean shouldGenerate(ProcessorGenerationContext context) {
+                    capturedParentAction.set(context.parentAction());
+                    return false;
+                }
+
+                @Override
+                public SearchRequestProcessor create(
+                    Map<String, Processor.Factory<SearchRequestProcessor>> processorFactories,
+                    String tag,
+                    String description,
+                    boolean ignoreFailure,
+                    Map<String, Object> config,
+                    Processor.PipelineContext pipelineContext
+                ) {
+                    return null;
+                }
+            }
+        );
+
+        SearchPipelineService service = createWithProcessors(
+            buildBaseProcessors().request,
+            buildBaseProcessors().response,
+            buildBaseProcessors().phase,
+            systemGeneratedRequestProcessors,
+            Collections.emptyMap(),
+            Collections.emptyMap()
+        );
+        setUpForResolvePipeline(service);
+        enabledAllSystemGeneratedFactories(service);
+
+        SearchRequest searchRequest = new SearchRequest("my_index").source(SearchSourceBuilder.searchSource().size(5));
+        service.resolvePipeline(searchRequest, null, indexNameExpressionResolver);
+
+        assertNull(capturedParentAction.get());
     }
 
     @Override
@@ -645,7 +736,7 @@ public class SearchPipelineServiceTests extends SearchPipelineTestCase {
 
         // Verify pipeline
         PipelinedRequest pipelinedRequest = syncTransformRequest(
-            searchPipelineService.resolvePipeline(searchRequest, indexNameExpressionResolver)
+            searchPipelineService.resolvePipeline(searchRequest, null, indexNameExpressionResolver)
         );
         Pipeline pipeline = pipelinedRequest.getPipeline();
         assertEquals(SearchPipelineService.AD_HOC_PIPELINE_ID, pipeline.getId());
@@ -703,7 +794,7 @@ public class SearchPipelineServiceTests extends SearchPipelineTestCase {
 
         // Verify pipeline
         PipelinedRequest pipelinedRequest = syncTransformRequest(
-            searchPipelineService.resolvePipeline(searchRequest, indexNameExpressionResolver)
+            searchPipelineService.resolvePipeline(searchRequest, null, indexNameExpressionResolver)
         );
         Pipeline pipeline = pipelinedRequest.getPipeline();
         assertEquals("p1", pipeline.getId());
@@ -752,7 +843,7 @@ public class SearchPipelineServiceTests extends SearchPipelineTestCase {
         // Exception thrown when creating the pipeline
         expectThrows(
             SearchPipelineProcessingException.class,
-            () -> searchPipelineService.resolvePipeline(searchRequest, indexNameExpressionResolver)
+            () -> searchPipelineService.resolvePipeline(searchRequest, null, indexNameExpressionResolver)
         );
 
     }
@@ -781,7 +872,7 @@ public class SearchPipelineServiceTests extends SearchPipelineTestCase {
         // Exception thrown when processing the request
         expectThrows(
             SearchPipelineProcessingException.class,
-            () -> syncTransformRequest(searchPipelineService.resolvePipeline(searchRequest, indexNameExpressionResolver))
+            () -> syncTransformRequest(searchPipelineService.resolvePipeline(searchRequest, null, indexNameExpressionResolver))
         );
     }
 
@@ -806,7 +897,7 @@ public class SearchPipelineServiceTests extends SearchPipelineTestCase {
         SearchSourceBuilder sourceBuilder = SearchSourceBuilder.searchSource().size(100).searchPipelineSource(pipelineSourceMap);
         SearchRequest searchRequest = new SearchRequest().source(sourceBuilder);
 
-        PipelinedRequest pipelinedRequest = searchPipelineService.resolvePipeline(searchRequest, indexNameExpressionResolver);
+        PipelinedRequest pipelinedRequest = searchPipelineService.resolvePipeline(searchRequest, null, indexNameExpressionResolver);
 
         SearchResponse response = createDefaultSearchResponse();
         // Exception thrown when processing response
@@ -844,7 +935,7 @@ public class SearchPipelineServiceTests extends SearchPipelineTestCase {
                     "The exception from request processor [throwing_request] in the search pipeline [_ad_hoc_pipeline] was ignored"
                 )
             );
-            syncTransformRequest(searchPipelineService.resolvePipeline(searchRequest, indexNameExpressionResolver));
+            syncTransformRequest(searchPipelineService.resolvePipeline(searchRequest, null, indexNameExpressionResolver));
             mockAppender.assertAllExpectationsMatched();
         }
     }
@@ -870,7 +961,7 @@ public class SearchPipelineServiceTests extends SearchPipelineTestCase {
         SearchSourceBuilder sourceBuilder = SearchSourceBuilder.searchSource().size(100).searchPipelineSource(pipelineSourceMap);
         SearchRequest searchRequest = new SearchRequest().source(sourceBuilder);
 
-        PipelinedRequest pipelinedRequest = searchPipelineService.resolvePipeline(searchRequest, indexNameExpressionResolver);
+        PipelinedRequest pipelinedRequest = searchPipelineService.resolvePipeline(searchRequest, null, indexNameExpressionResolver);
 
         SearchResponse response = createDefaultSearchResponse();
 
@@ -916,24 +1007,24 @@ public class SearchPipelineServiceTests extends SearchPipelineTestCase {
         SearchResponse response = createDefaultSearchResponse();
 
         syncExecutePipeline(
-            searchPipelineService.resolvePipeline(request.pipeline("good_request_pipeline"), indexNameExpressionResolver),
+            searchPipelineService.resolvePipeline(request.pipeline("good_request_pipeline"), null, indexNameExpressionResolver),
             response
         );
         expectThrows(
             SearchPipelineProcessingException.class,
             () -> syncExecutePipeline(
-                searchPipelineService.resolvePipeline(request.pipeline("bad_request_pipeline"), indexNameExpressionResolver),
+                searchPipelineService.resolvePipeline(request.pipeline("bad_request_pipeline"), null, indexNameExpressionResolver),
                 response
             )
         );
         syncExecutePipeline(
-            searchPipelineService.resolvePipeline(request.pipeline("good_response_pipeline"), indexNameExpressionResolver),
+            searchPipelineService.resolvePipeline(request.pipeline("good_response_pipeline"), null, indexNameExpressionResolver),
             response
         );
         expectThrows(
             SearchPipelineProcessingException.class,
             () -> syncExecutePipeline(
-                searchPipelineService.resolvePipeline(request.pipeline("bad_response_pipeline"), indexNameExpressionResolver),
+                searchPipelineService.resolvePipeline(request.pipeline("bad_response_pipeline"), null, indexNameExpressionResolver),
                 response
             )
         );
@@ -1015,21 +1106,21 @@ public class SearchPipelineServiceTests extends SearchPipelineTestCase {
         SearchResponse response = createDefaultSearchResponse();
 
         syncExecutePipeline(
-            searchPipelineService.resolvePipeline(request.pipeline("good_request_pipeline"), indexNameExpressionResolver),
+            searchPipelineService.resolvePipeline(request.pipeline("good_request_pipeline"), null, indexNameExpressionResolver),
             response
         );
         // Caught Exception here
         syncExecutePipeline(
-            searchPipelineService.resolvePipeline(request.pipeline("bad_request_pipeline"), indexNameExpressionResolver),
+            searchPipelineService.resolvePipeline(request.pipeline("bad_request_pipeline"), null, indexNameExpressionResolver),
             response
         );
         syncExecutePipeline(
-            searchPipelineService.resolvePipeline(request.pipeline("good_response_pipeline"), indexNameExpressionResolver),
+            searchPipelineService.resolvePipeline(request.pipeline("good_response_pipeline"), null, indexNameExpressionResolver),
             response
         );
         // Caught Exception here
         syncExecutePipeline(
-            searchPipelineService.resolvePipeline(request.pipeline("bad_response_pipeline"), indexNameExpressionResolver),
+            searchPipelineService.resolvePipeline(request.pipeline("bad_response_pipeline"), null, indexNameExpressionResolver),
             response
         );
 
@@ -1175,7 +1266,7 @@ public class SearchPipelineServiceTests extends SearchPipelineTestCase {
         SearchRequest searchRequest = new SearchRequest().source(sourceBuilder);
         expectThrows(
             SearchPipelineProcessingException.class,
-            () -> searchPipelineService.resolvePipeline(searchRequest, indexNameExpressionResolver)
+            () -> searchPipelineService.resolvePipeline(searchRequest, null, indexNameExpressionResolver)
         );
     }
 
@@ -1190,7 +1281,7 @@ public class SearchPipelineServiceTests extends SearchPipelineTestCase {
         SearchSourceBuilder sourceBuilder = SearchSourceBuilder.searchSource().searchPipelineSource(pipelineSourceMap);
         SearchRequest searchRequest = new SearchRequest().source(sourceBuilder);
         try {
-            searchPipelineService.resolvePipeline(searchRequest, indexNameExpressionResolver);
+            searchPipelineService.resolvePipeline(searchRequest, null, indexNameExpressionResolver);
             fail("Exception should have been thrown");
         } catch (SearchPipelineProcessingException e) {
             assertTrue(
@@ -1285,6 +1376,7 @@ public class SearchPipelineServiceTests extends SearchPipelineTestCase {
 
         PipelinedRequest request = searchPipelineService.resolvePipeline(
             new SearchRequest().source(createDefaultSearchSourceBuilder()).pipeline("p1"),
+            null,
             indexNameExpressionResolver
         );
         assertNull(contextHolder.get());
@@ -1329,13 +1421,13 @@ public class SearchPipelineServiceTests extends SearchPipelineTestCase {
         service.applyClusterState(cce);
 
         SearchRequest searchRequest = new SearchRequest("bar").source(SearchSourceBuilder.searchSource().size(5));
-        PipelinedRequest pipelinedRequest = syncTransformRequest(service.resolvePipeline(searchRequest, indexNameExpressionResolver));
+        PipelinedRequest pipelinedRequest = syncTransformRequest(service.resolvePipeline(searchRequest, null, indexNameExpressionResolver));
         assertEquals("p1", pipelinedRequest.getPipeline().getId());
         assertEquals(10, pipelinedRequest.source().size());
 
         // Bypass the default pipeline
         searchRequest = new SearchRequest("bar").source(SearchSourceBuilder.searchSource().size(5)).pipeline("_none");
-        pipelinedRequest = service.resolvePipeline(searchRequest, indexNameExpressionResolver);
+        pipelinedRequest = service.resolvePipeline(searchRequest, null, indexNameExpressionResolver);
         assertEquals("_none", pipelinedRequest.getPipeline().getId());
         assertEquals(5, pipelinedRequest.source().size());
     }
@@ -1390,7 +1482,7 @@ public class SearchPipelineServiceTests extends SearchPipelineTestCase {
         service.applyClusterState(cce);
 
         SearchRequest searchRequest = new SearchRequest("bar").source(SearchSourceBuilder.searchSource().size(5));
-        PipelinedRequest pipelinedRequest = syncTransformRequest(service.resolvePipeline(searchRequest, indexNameExpressionResolver));
+        PipelinedRequest pipelinedRequest = syncTransformRequest(service.resolvePipeline(searchRequest, null, indexNameExpressionResolver));
         assertEquals("_none", pipelinedRequest.getPipeline().getId());
         assertEquals(5, pipelinedRequest.source().size());
     }
@@ -1425,7 +1517,7 @@ public class SearchPipelineServiceTests extends SearchPipelineTestCase {
         service.applyClusterState(cce);
 
         SearchRequest searchRequest = new SearchRequest().source(SearchSourceBuilder.searchSource().size(5));
-        PipelinedRequest pipelinedRequest = syncTransformRequest(service.resolvePipeline(searchRequest, indexNameExpressionResolver));
+        PipelinedRequest pipelinedRequest = syncTransformRequest(service.resolvePipeline(searchRequest, null, indexNameExpressionResolver));
         assertEquals("_none", pipelinedRequest.getPipeline().getId());
         assertEquals(5, pipelinedRequest.source().size());
     }
@@ -1460,7 +1552,7 @@ public class SearchPipelineServiceTests extends SearchPipelineTestCase {
         service.applyClusterState(cce);
 
         SearchRequest searchRequest = new SearchRequest("xyz").source(SearchSourceBuilder.searchSource().size(5));
-        PipelinedRequest pipelinedRequest = syncTransformRequest(service.resolvePipeline(searchRequest, indexNameExpressionResolver));
+        PipelinedRequest pipelinedRequest = syncTransformRequest(service.resolvePipeline(searchRequest, null, indexNameExpressionResolver));
         assertEquals("_none", pipelinedRequest.getPipeline().getId());
         assertEquals(5, pipelinedRequest.source().size());
     }
@@ -1495,7 +1587,7 @@ public class SearchPipelineServiceTests extends SearchPipelineTestCase {
         searchRequest.source().verbosePipeline(true);
 
         PipelinedRequest pipelinedRequest = syncTransformRequest(
-            searchPipelineService.resolvePipeline(searchRequest, indexNameExpressionResolver)
+            searchPipelineService.resolvePipeline(searchRequest, null, indexNameExpressionResolver)
         );
 
         SearchResponseSections sections = new SearchResponseSections(
@@ -1528,7 +1620,7 @@ public class SearchPipelineServiceTests extends SearchPipelineTestCase {
 
         IllegalArgumentException e = expectThrows(
             IllegalArgumentException.class,
-            () -> searchPipelineService.resolvePipeline(searchRequest, indexNameExpressionResolver)
+            () -> searchPipelineService.resolvePipeline(searchRequest, null, indexNameExpressionResolver)
         );
         assertTrue(e.getMessage(), e.getMessage().contains("The 'verbose pipeline' option requires a search pipeline to be defined."));
     }
@@ -1559,7 +1651,7 @@ public class SearchPipelineServiceTests extends SearchPipelineTestCase {
         searchRequest.source().verbosePipeline(true);
 
         PipelinedRequest pipelinedRequest = syncTransformRequest(
-            searchPipelineService.resolvePipeline(searchRequest, indexNameExpressionResolver)
+            searchPipelineService.resolvePipeline(searchRequest, null, indexNameExpressionResolver)
         );
 
         SearchResponseSections sections = new SearchResponseSections(
@@ -1609,7 +1701,7 @@ public class SearchPipelineServiceTests extends SearchPipelineTestCase {
         searchRequest.source().verbosePipeline(true);
 
         PipelinedRequest pipelinedRequest = syncTransformRequest(
-            searchPipelineService.resolvePipeline(searchRequest, indexNameExpressionResolver)
+            searchPipelineService.resolvePipeline(searchRequest, null, indexNameExpressionResolver)
         );
 
         SearchResponseSections sections = new SearchResponseSections(

--- a/server/src/test/java/org/opensearch/search/pipeline/SearchPipelineServiceTests.java
+++ b/server/src/test/java/org/opensearch/search/pipeline/SearchPipelineServiceTests.java
@@ -292,28 +292,25 @@ public class SearchPipelineServiceTests extends SearchPipelineTestCase {
         AtomicReference<String> capturedParentAction = new AtomicReference<>();
         Map<String, SystemGeneratedProcessor.SystemGeneratedFactory<SearchRequestProcessor>> systemGeneratedRequestProcessors =
             new HashMap<>();
-        systemGeneratedRequestProcessors.put(
-            "action_aware_processor",
-            new SystemGeneratedProcessor.SystemGeneratedFactory<>() {
-                @Override
-                public boolean shouldGenerate(ProcessorGenerationContext context) {
-                    capturedParentAction.set(context.parentAction());
-                    return false;
-                }
-
-                @Override
-                public SearchRequestProcessor create(
-                    Map<String, Processor.Factory<SearchRequestProcessor>> processorFactories,
-                    String tag,
-                    String description,
-                    boolean ignoreFailure,
-                    Map<String, Object> config,
-                    Processor.PipelineContext pipelineContext
-                ) {
-                    return null;
-                }
+        systemGeneratedRequestProcessors.put("action_aware_processor", new SystemGeneratedProcessor.SystemGeneratedFactory<>() {
+            @Override
+            public boolean shouldGenerate(ProcessorGenerationContext context) {
+                capturedParentAction.set(context.parentAction());
+                return false;
             }
-        );
+
+            @Override
+            public SearchRequestProcessor create(
+                Map<String, Processor.Factory<SearchRequestProcessor>> processorFactories,
+                String tag,
+                String description,
+                boolean ignoreFailure,
+                Map<String, Object> config,
+                Processor.PipelineContext pipelineContext
+            ) {
+                return null;
+            }
+        });
 
         SearchPipelineService service = createWithProcessors(
             buildBaseProcessors().request,
@@ -339,28 +336,25 @@ public class SearchPipelineServiceTests extends SearchPipelineTestCase {
         AtomicReference<String> capturedParentAction = new AtomicReference<>("sentinel");
         Map<String, SystemGeneratedProcessor.SystemGeneratedFactory<SearchRequestProcessor>> systemGeneratedRequestProcessors =
             new HashMap<>();
-        systemGeneratedRequestProcessors.put(
-            "action_aware_processor",
-            new SystemGeneratedProcessor.SystemGeneratedFactory<>() {
-                @Override
-                public boolean shouldGenerate(ProcessorGenerationContext context) {
-                    capturedParentAction.set(context.parentAction());
-                    return false;
-                }
-
-                @Override
-                public SearchRequestProcessor create(
-                    Map<String, Processor.Factory<SearchRequestProcessor>> processorFactories,
-                    String tag,
-                    String description,
-                    boolean ignoreFailure,
-                    Map<String, Object> config,
-                    Processor.PipelineContext pipelineContext
-                ) {
-                    return null;
-                }
+        systemGeneratedRequestProcessors.put("action_aware_processor", new SystemGeneratedProcessor.SystemGeneratedFactory<>() {
+            @Override
+            public boolean shouldGenerate(ProcessorGenerationContext context) {
+                capturedParentAction.set(context.parentAction());
+                return false;
             }
-        );
+
+            @Override
+            public SearchRequestProcessor create(
+                Map<String, Processor.Factory<SearchRequestProcessor>> processorFactories,
+                String tag,
+                String description,
+                boolean ignoreFailure,
+                Map<String, Object> config,
+                Processor.PipelineContext pipelineContext
+            ) {
+                return null;
+            }
+        });
 
         SearchPipelineService service = createWithProcessors(
             buildBaseProcessors().request,


### PR DESCRIPTION
…ated processors

This exposes the parent transport action (e.g., _msearch, _async_search) to SystemGeneratedFactory.shouldGenerate() so processors can conditionally generate based on the calling action.


### Related Issues
Resolves [#22165](https://github.com/opensearch-project/OpenSearch/issues/22165)
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
