### PR TITLE
bugfix: Fix NestedQueryBuilder visit to recursively visit child query…

### DIFF
--- a/server/src/main/java/org/opensearch/index/query/NestedQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/NestedQueryBuilder.java
@@ -517,7 +517,8 @@ public class NestedQueryBuilder extends AbstractQueryBuilder<NestedQueryBuilder>
     public void visit(QueryBuilderVisitor visitor) {
         visitor.accept(this);
         if (query != null) {
-            visitor.getChildVisitor(BooleanClause.Occur.MUST).accept(query);
+            final QueryBuilderVisitor subVisitor = visitor.getChildVisitor(BooleanClause.Occur.MUST);
+            query.visit(subVisitor);
         }
     }
 }

--- a/server/src/main/java/org/opensearch/index/query/NestedQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/NestedQueryBuilder.java
@@ -518,7 +518,9 @@ public class NestedQueryBuilder extends AbstractQueryBuilder<NestedQueryBuilder>
         visitor.accept(this);
         if (query != null) {
             final QueryBuilderVisitor subVisitor = visitor.getChildVisitor(BooleanClause.Occur.MUST);
-            query.visit(subVisitor);
+            if (subVisitor != null) {
+                query.visit(subVisitor);
+            }
         }
     }
 }

--- a/server/src/test/java/org/opensearch/index/query/NestedQueryBuilderTests.java
+++ b/server/src/test/java/org/opensearch/index/query/NestedQueryBuilderTests.java
@@ -601,4 +601,26 @@ public class NestedQueryBuilderTests extends AbstractQueryTestCase<NestedQueryBu
         assertThat(visitedQueries.get(3), instanceOf(TermQueryBuilder.class));
     }
 
+    public void testVisitWithNullChildVisitor() {
+        NestedQueryBuilder builder = new NestedQueryBuilder("path", new MatchAllQueryBuilder(), ScoreMode.None);
+
+        List<QueryBuilder> visitedQueries = new ArrayList<>();
+        QueryBuilderVisitor visitor = new QueryBuilderVisitor() {
+            @Override
+            public void accept(QueryBuilder qb) {
+                visitedQueries.add(qb);
+            }
+
+            @Override
+            public QueryBuilderVisitor getChildVisitor(BooleanClause.Occur occur) {
+                return null;
+            }
+        };
+        builder.visit(visitor);
+
+        // Should only visit the NestedQueryBuilder itself, not recurse into children
+        assertEquals(1, visitedQueries.size());
+        assertThat(visitedQueries.get(0), instanceOf(NestedQueryBuilder.class));
+    }
+
 }

--- a/server/src/test/java/org/opensearch/index/query/NestedQueryBuilderTests.java
+++ b/server/src/test/java/org/opensearch/index/query/NestedQueryBuilderTests.java
@@ -585,4 +585,20 @@ public class NestedQueryBuilderTests extends AbstractQueryTestCase<NestedQueryBu
 
         assertEquals(2, visitedQueries.size());
     }
+
+    public void testVisitRecursivelyVisitsNestedChildren() {
+        BoolQueryBuilder boolQuery = new BoolQueryBuilder().must(new MatchAllQueryBuilder()).filter(new TermQueryBuilder("field", "value"));
+        NestedQueryBuilder builder = new NestedQueryBuilder("path", boolQuery, ScoreMode.None);
+
+        List<QueryBuilder> visitedQueries = new ArrayList<>();
+        builder.visit(createTestVisitor(visitedQueries));
+
+        // Should visit: NestedQueryBuilder, BoolQueryBuilder, MatchAllQueryBuilder, TermQueryBuilder
+        assertEquals(4, visitedQueries.size());
+        assertThat(visitedQueries.get(0), instanceOf(NestedQueryBuilder.class));
+        assertThat(visitedQueries.get(1), instanceOf(BoolQueryBuilder.class));
+        assertThat(visitedQueries.get(2), instanceOf(MatchAllQueryBuilder.class));
+        assertThat(visitedQueries.get(3), instanceOf(TermQueryBuilder.class));
+    }
+
 }


### PR DESCRIPTION
… tree

Previously, visit() only called accept() on the immediate child query, which skipped recursion into deeper nested queries. Now it calls query.visit(subVisitor) to ensure the entire subtree is
  traversed.


### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
