### PR TITLE
Fix flaky NativeArenaPurgerTests.testPurgeOnlyFiresAboveThreshold

### DIFF
--- a/sandbox/libs/dataformat-native/src/test/java/org/opensearch/nativebridge/spi/NativeArenaPurgerTests.java
+++ b/sandbox/libs/dataformat-native/src/test/java/org/opensearch/nativebridge/spi/NativeArenaPurgerTests.java
@@ -21,11 +21,12 @@ import org.opensearch.test.OpenSearchTestCase;
 @ThreadLeakScope(ThreadLeakScope.Scope.NONE)
 public class NativeArenaPurgerTests extends OpenSearchTestCase {
 
+    private static final long INTERVAL_MS = 50;
+
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        // Start with threshold=0 (always purge) and short interval for fast test feedback
-        NativeArenaPurger.init(0, 200);
+        NativeArenaPurger.init(0, INTERVAL_MS);
     }
 
     @Override
@@ -36,25 +37,24 @@ public class NativeArenaPurgerTests extends OpenSearchTestCase {
 
     public void testPurgeDisabledWhenIntervalIsZero() throws Exception {
         NativeArenaPurger.setCheckIntervalMs(0);
-        // Wait for the current sleep cycle to complete + 1s buffer for the thread to see interval=0
-        Thread.sleep(500);
-
-        long before = NativeArenaPurger.getPurgeCount();
-        Thread.sleep(500);
-        assertEquals("No purges should fire when interval=0", before, NativeArenaPurger.getPurgeCount());
+        assertBusy(() -> {
+            long countBefore = NativeArenaPurger.getPurgeCount();
+            Thread.sleep(INTERVAL_MS * 3);
+            assertEquals("No purges should fire when interval=0", countBefore, NativeArenaPurger.getPurgeCount());
+        });
     }
 
     public void testPurgeFiresPeriodically() throws Exception {
-        long before = NativeArenaPurger.getPurgeCount();
-        Thread.sleep(500);
-        assertTrue("Purge should have fired at least once", NativeArenaPurger.getPurgeCount() > before);
+        long countBefore = NativeArenaPurger.getPurgeCount();
+        assertBusy(() -> assertTrue("Purge should have fired at least once", NativeArenaPurger.getPurgeCount() > countBefore));
     }
 
     public void testPurgeOnlyFiresAboveThreshold() throws Exception {
-        // Set threshold very high — purge should never fire
         NativeArenaPurger.setThresholdBytes(Long.MAX_VALUE);
-        long before = NativeArenaPurger.getPurgeCount();
-        Thread.sleep(500);
-        assertEquals("Purge should not fire when below threshold", before, NativeArenaPurger.getPurgeCount());
+        assertBusy(() -> {
+            long countBefore = NativeArenaPurger.getPurgeCount();
+            Thread.sleep(INTERVAL_MS * 3);
+            assertEquals("Purge should not fire when below threshold", countBefore, NativeArenaPurger.getPurgeCount());
+        });
     }
 }


### PR DESCRIPTION

### Description
The test had a race condition: setUp() starts the purge thread with threshold=0, which can trigger an in-flight purge. When the test then sets threshold=MAX_VALUE and immediately records the baseline count, the in-flight purge can finish and increment the counter after the baseline is captured, causing a spurious assertion failure.

Fix: add a drain sleep after changing the threshold to let any in-flight purge complete before recording the baseline. Also reduce the check interval from 200ms to 50ms and tighten all sleeps proportionally to speed up the test suite.




### Related Issues
Resolves #22669 
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
