### PR TITLE
Validate total_primary_shards_per_node on index templates against the cluster

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/cluster/routing/allocation/decider/ShardsLimitAllocationDeciderRemoteStoreEnabledIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/routing/allocation/decider/ShardsLimitAllocationDeciderRemoteStoreEnabledIT.java
@@ -12,6 +12,7 @@ import org.opensearch.action.admin.indices.flush.FlushRequest;
 import org.opensearch.action.admin.indices.settings.put.UpdateSettingsRequest;
 import org.opensearch.action.support.clustermanager.AcknowledgedResponse;
 import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.routing.IndexShardRoutingTable;
 import org.opensearch.cluster.routing.ShardRouting;
 import org.opensearch.common.settings.Settings;
@@ -20,6 +21,7 @@ import org.opensearch.test.OpenSearchIntegTestCase;
 import org.junit.Before;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -172,6 +174,78 @@ public class ShardsLimitAllocationDeciderRemoteStoreEnabledIT extends RemoteStor
             }
         });
         cleanUp("test1");
+    }
+
+    public void testIndexTemplateWithPrimaryShardLimit() throws Exception {
+        // Put an index template that carries index.routing.allocation.total_primary_shards_per_node.
+        // On an all-remote-store cluster this must be acknowledged: the template validator should
+        // recognise the cluster as remote-store-enabled (via node attributes) rather than looking for
+        // the index-local index.remote_store.enabled flag, which a template can never carry.
+        AcknowledgedResponse templateResponse = client().admin()
+            .indices()
+            .preparePutTemplate("primary-shard-limit-template")
+            .setPatterns(Collections.singletonList("template-test*"))
+            .setSettings(
+                Settings.builder()
+                    .put(remoteStoreIndexSettings(0, 4))  // 4 shards, 0 replicas
+                    .put(INDEX_TOTAL_PRIMARY_SHARDS_PER_NODE_SETTING.getKey(), 1)
+            )
+            .get();
+
+        assertTrue("Template carrying total_primary_shards_per_node should be acknowledged", templateResponse.isAcknowledged());
+
+        // Auto-create the index by indexing a document so the template (not a create-request settings
+        // block) fully drives the index settings — including number_of_shards and the primary shard limit.
+        client().prepareIndex("template-test1").setId("1").setSource("field", "value").get();
+
+        // The setting (and the injected remote-store flag) must have flowed from the template onto the
+        // concrete index — this is the core of the bug: previously the template PUT was rejected with 400.
+        ClusterState createdState = client().admin().cluster().prepareState().get().getState();
+        Settings indexSettings = createdState.metadata().index("template-test1").getSettings();
+        assertEquals(
+            "Index created from template should carry 4 primary shards",
+            4,
+            createdState.metadata().index("template-test1").getNumberOfShards()
+        );
+        assertEquals(
+            "Index created from template should carry the primary shard limit",
+            Integer.valueOf(1),
+            INDEX_TOTAL_PRIMARY_SHARDS_PER_NODE_SETTING.get(indexSettings)
+        );
+        assertTrue(
+            "Index created from template on a remote-store cluster should be remote-store enabled",
+            IndexMetadata.INDEX_REMOTE_STORE_ENABLED_SETTING.get(indexSettings)
+        );
+
+        // And the limit must actually be enforced at allocation time: with 4 primaries, a limit of 1
+        // per node and 3 data nodes, at least one primary stays unassigned and no node holds more than one.
+        assertBusy(() -> {
+            ClusterState state = client().admin().cluster().prepareState().get().getState();
+
+            int assignedShards = 0;
+            int unassignedShards = 0;
+            Map<String, Integer> nodePrimaryCount = new HashMap<>();
+
+            for (IndexShardRoutingTable shardRouting : state.routingTable().index("template-test1")) {
+                for (ShardRouting shard : shardRouting) {
+                    if (shard.assignedToNode()) {
+                        assignedShards++;
+                        nodePrimaryCount.merge(shard.currentNodeId(), 1, Integer::sum);
+                    } else {
+                        unassignedShards++;
+                    }
+                }
+            }
+
+            assertEquals("template-test1 should have 3 assigned primaries (one per data node)", 3, assignedShards);
+            assertEquals("template-test1 should have 1 unassigned primary (blocked by the per-node limit)", 1, unassignedShards);
+            for (Integer count : nodePrimaryCount.values()) {
+                assertTrue("No node should have more than 1 primary shard of template-test1", count <= 1);
+            }
+        });
+
+        client().admin().indices().prepareDeleteTemplate("primary-shard-limit-template").get();
+        cleanUp("template-test1");
     }
 
     public void testClusterPrimaryShardLimitss() throws Exception {

--- a/server/src/main/java/org/opensearch/cluster/metadata/MetadataIndexTemplateService.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/MetadataIndexTemplateService.java
@@ -98,9 +98,9 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static org.opensearch.cluster.metadata.MetadataCreateDataStreamService.validateTimestampFieldMapping;
-import static org.opensearch.cluster.metadata.MetadataCreateIndexService.validateIndexTotalPrimaryShardsPerNodeSetting;
 import static org.opensearch.cluster.metadata.MetadataCreateIndexService.validateRefreshIntervalSettings;
 import static org.opensearch.cluster.metadata.MetadataCreateIndexService.validateTranslogFlushIntervalSettingsForCompositeIndex;
+import static org.opensearch.cluster.metadata.MetadataUpdateSettingsService.validateIndexTotalPrimaryShardsPerNodeSetting;
 import static org.opensearch.cluster.service.ClusterManagerTask.CREATE_COMPONENT_TEMPLATE;
 import static org.opensearch.cluster.service.ClusterManagerTask.CREATE_INDEX_TEMPLATE;
 import static org.opensearch.cluster.service.ClusterManagerTask.CREATE_INDEX_TEMPLATE_V2;
@@ -1670,8 +1670,9 @@ public class MetadataIndexTemplateService {
             validateTranslogFlushIntervalSettingsForCompositeIndex(settings, clusterService.getClusterSettings());
             validateTranslogDurabilitySettingsInTemplate(settings, clusterService.getClusterSettings());
 
-            // validate index total primary shards per node setting
-            validateIndexTotalPrimaryShardsPerNodeSetting(settings);
+            // validate index total primary shards per node setting against the cluster (a template has no
+            // index-local remote_store flag, so use the cluster-aware overload like the _settings update path).
+            validateIndexTotalPrimaryShardsPerNodeSetting(settings, clusterService);
         }
 
         if (indexPatterns.stream().anyMatch(Regex::isMatchAllPattern)) {

--- a/server/src/main/java/org/opensearch/cluster/metadata/MetadataUpdateSettingsService.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/MetadataUpdateSettingsService.java
@@ -67,6 +67,7 @@ import org.opensearch.threadpool.ThreadPool;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
@@ -573,13 +574,11 @@ public class MetadataUpdateSettingsService {
             return;
         }
 
-        // Check if remote store is enabled
-        boolean isRemoteStoreEnabled = clusterService.state()
-            .nodes()
-            .getNodes()
-            .values()
-            .stream()
-            .allMatch(DiscoveryNode::isRemoteStoreNode);
+        // Remote store is enabled only when there is at least one node and every node is a
+        // remote-store node (allMatch is vacuously true on an empty node set, which must not
+        // count as remote-store enabled).
+        Collection<DiscoveryNode> nodes = clusterService.state().nodes().getNodes().values();
+        boolean isRemoteStoreEnabled = !nodes.isEmpty() && nodes.stream().allMatch(DiscoveryNode::isRemoteStoreNode);
         if (!isRemoteStoreEnabled) {
             throw new IllegalArgumentException(
                 "Setting ["

--- a/server/src/test/java/org/opensearch/cluster/metadata/MetadataIndexTemplateServiceRemoteStoreTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/MetadataIndexTemplateServiceRemoteStoreTests.java
@@ -1,0 +1,173 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.cluster.metadata;
+
+import org.opensearch.cluster.ClusterName;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.metadata.MetadataIndexTemplateService.PutRequest;
+import org.opensearch.cluster.node.DiscoveryNodes;
+import org.opensearch.cluster.routing.allocation.AwarenessReplicaBalance;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.IndexScopedSettings;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.env.Environment;
+import org.opensearch.index.shard.IndexShardTestUtils;
+import org.opensearch.indices.DefaultRemoteStoreSettings;
+import org.opensearch.indices.IndicesService;
+import org.opensearch.indices.SystemIndices;
+import org.opensearch.indices.replication.common.ReplicationType;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static java.util.Collections.singletonList;
+import static org.opensearch.cluster.metadata.IndexMetadata.INDEX_REPLICATION_TYPE_SETTING;
+import static org.opensearch.cluster.routing.allocation.decider.ShardsLimitAllocationDecider.INDEX_TOTAL_PRIMARY_SHARDS_PER_NODE_SETTING;
+import static org.opensearch.common.settings.Settings.builder;
+import static org.opensearch.env.Environment.PATH_HOME_SETTING;
+import static org.opensearch.indices.ShardLimitValidatorTests.createTestShardLimitService;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.not;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests that index-template validation of {@code index.routing.allocation.total_primary_shards_per_node}
+ * uses the cluster/node-aware precondition (is this a remote-store cluster?) rather than the index-local
+ * {@code index.remote_store.enabled} flag a template can never carry.
+ *
+ * <p>Kept in its own class (rather than {@link MetadataIndexTemplateServiceTests}) because these cases are
+ * fully mock-driven and do not need the shared single-node fixture; isolating them also avoids perturbing
+ * the randomized method ordering of that (state-sharing) suite.
+ */
+public class MetadataIndexTemplateServiceRemoteStoreTests extends OpenSearchTestCase {
+
+    public void testTotalPrimaryShardsTemplateValidatesOnRemoteStoreCluster() {
+        // Every node is a remote-store node → the template must validate successfully.
+        PutRequest request = new PutRequest("test", "test_index_primary_shard_constraint_remote");
+        request.patterns(singletonList("test_shards_wait*"));
+        request.settings(
+            builder().put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, "1")
+                .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, "1")
+                .put(INDEX_TOTAL_PRIMARY_SHARDS_PER_NODE_SETTING.getKey(), 2)
+                .put(INDEX_REPLICATION_TYPE_SETTING.getKey(), ReplicationType.SEGMENT.toString())
+                .build()
+        );
+
+        DiscoveryNodes remoteNodes = DiscoveryNodes.builder()
+            .add(IndexShardTestUtils.getFakeRemoteEnabledNode("node1"))
+            .add(IndexShardTestUtils.getFakeRemoteEnabledNode("node2"))
+            .build();
+
+        List<Throwable> throwables = putTemplate(xContentRegistry(), request, remoteNodes);
+        assertThat(throwables, empty());
+    }
+
+    public void testTotalPrimaryShardsTemplateRejectedOnEmptyNodeCluster() {
+        // No nodes → not a remote-store cluster (allMatch is vacuously true on an empty set, so the
+        // !nodes.isEmpty() guard must reject). Covers the empty-node branch of the hardened check.
+        PutRequest request = new PutRequest("test", "test_index_primary_shard_constraint_empty");
+        request.patterns(singletonList("test_shards_wait*"));
+        request.settings(
+            builder().put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, "1")
+                .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, "1")
+                .put(INDEX_TOTAL_PRIMARY_SHARDS_PER_NODE_SETTING.getKey(), 2)
+                .put(INDEX_REPLICATION_TYPE_SETTING.getKey(), ReplicationType.SEGMENT.toString())
+                .build()
+        );
+
+        List<Throwable> throwables = putTemplate(xContentRegistry(), request, DiscoveryNodes.EMPTY_NODES);
+        assertThat(throwables, not(empty()));
+        assertThat(throwables.get(0), instanceOf(IllegalArgumentException.class));
+        assertThat(throwables.get(0).getMessage(), containsString("can only be used with remote store enabled clusters"));
+    }
+
+    public void testTotalPrimaryShardsTemplateRejectedWhenSomeNodeIsNotRemoteStore() {
+        // Mixed cluster (one non-remote node) → not every node is a remote-store node, so the
+        // setting must be rejected. Covers the allMatch==false branch of the hardened check.
+        PutRequest request = new PutRequest("test", "test_index_primary_shard_constraint_mixed");
+        request.patterns(singletonList("test_shards_wait*"));
+        request.settings(
+            builder().put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, "1")
+                .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, "1")
+                .put(INDEX_TOTAL_PRIMARY_SHARDS_PER_NODE_SETTING.getKey(), 2)
+                .put(INDEX_REPLICATION_TYPE_SETTING.getKey(), ReplicationType.SEGMENT.toString())
+                .build()
+        );
+
+        DiscoveryNodes mixedNodes = DiscoveryNodes.builder()
+            .add(IndexShardTestUtils.getFakeRemoteEnabledNode("remote1"))
+            .add(IndexShardTestUtils.getFakeDiscoNode("plain1"))
+            .build();
+
+        List<Throwable> throwables = putTemplate(xContentRegistry(), request, mixedNodes);
+        assertThat(throwables, not(empty()));
+        assertThat(throwables.get(0), instanceOf(IllegalArgumentException.class));
+        assertThat(throwables.get(0).getMessage(), containsString("can only be used with remote store enabled clusters"));
+    }
+
+    private static List<Throwable> putTemplate(NamedXContentRegistry xContentRegistry, PutRequest request, DiscoveryNodes discoveryNodes) {
+        ClusterService clusterService = mock(ClusterService.class);
+        Settings settings = Settings.builder().put(PATH_HOME_SETTING.getKey(), "dummy").build();
+        ClusterSettings clusterSettings = new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        Metadata metadata = Metadata.builder().build();
+        ClusterState clusterState = ClusterState.builder(ClusterName.CLUSTER_NAME_SETTING.getDefault(Settings.EMPTY))
+            .metadata(metadata)
+            .nodes(discoveryNodes)
+            .build();
+        when(clusterService.state()).thenReturn(clusterState);
+        when(clusterService.getSettings()).thenReturn(settings);
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
+        IndicesService indicesServices = mock(IndicesService.class);
+        MetadataCreateIndexService createIndexService = new MetadataCreateIndexService(
+            Settings.EMPTY,
+            clusterService,
+            indicesServices,
+            null,
+            null,
+            createTestShardLimitService(randomIntBetween(1, 1000), false),
+            new Environment(builder().put(Environment.PATH_HOME_SETTING.getKey(), createTempDir().toString()).build(), null),
+            IndexScopedSettings.DEFAULT_SCOPED_SETTINGS,
+            null,
+            xContentRegistry,
+            new SystemIndices(Collections.emptyMap()),
+            true,
+            new AwarenessReplicaBalance(Settings.EMPTY, clusterService.getClusterSettings()),
+            DefaultRemoteStoreSettings.INSTANCE,
+            null
+        );
+        MetadataIndexTemplateService service = new MetadataIndexTemplateService(
+            clusterService,
+            createIndexService,
+            new AliasValidator(),
+            null,
+            new IndexScopedSettings(Settings.EMPTY, IndexScopedSettings.BUILT_IN_INDEX_SETTINGS),
+            xContentRegistry,
+            null
+        );
+
+        final List<Throwable> throwables = new ArrayList<>();
+        service.putTemplate(request, new MetadataIndexTemplateService.PutListener() {
+            @Override
+            public void onResponse(MetadataIndexTemplateService.PutResponse response) {}
+
+            @Override
+            public void onFailure(Exception e) {
+                throwables.add(e);
+            }
+        });
+        return throwables;
+    }
+}


### PR DESCRIPTION
### Description

An index template carrying `index.routing.allocation.total_primary_shards_per_node` is rejected with a **400** (`Setting [...total_primary_shards_per_node] ... can only be used with remote store enabled clusters`) on an all-remote-store cluster — even though the **same setting is accepted** via `PUT <index>/_settings` and at index creation on that same cluster.

**Root cause.** There are two overloads of `validateIndexTotalPrimaryShardsPerNodeSetting` with different "is remote store enabled?" logic:

| Overload | Caller | Check |
|---|---|---|
| `MetadataCreateIndexService...(Settings)` | template PUT **and** create-index | reads `index.remote_store.enabled` from the passed-in `Settings` |
| `MetadataUpdateSettingsService...(Settings, ClusterService)` | `_settings` update | every discovery node `isRemoteStoreNode()` |

The 1-arg check is correct for **create-index**, because `aggregateIndexSettings` → `updateRemoteStoreSettings(...)` injects `index.remote_store.enabled=true` (derived from a remote node's attributes) *before* validation runs. But a **template is validated before any index exists**, so that injection never happens and the flag is never present in the template's own settings block — the validator reads the default `false` and throws. The flag is also a private setting, so it cannot be added to the template by hand: the template is a dead end for this setting.

The real precondition for `total_primary_shards_per_node` is *"is this a remote-store cluster?"* — the setting is consumed by `ShardsLimitAllocationDecider` at allocation time, long after the index is remote-store-enabled. The `_settings` path already asks this correctly via node attributes.

**Fix.** Validate the template with the cluster/node-aware overload (`MetadataUpdateSettingsService.validateIndexTotalPrimaryShardsPerNodeSetting(settings, clusterService)`), matching the `_settings` update path. `MetadataIndexTemplateService` already holds a `ClusterService`. Create-index keeps the 1-arg overload (correct there). The shared node-aware check is also hardened so an **empty node set** no longer counts as remote-store enabled (`allMatch` is vacuously `true` on an empty stream).

**Tests.**
- IT `ShardsLimitAllocationDeciderRemoteStoreEnabledIT.testIndexTemplateWithPrimaryShardLimit`: PUTs a template with the setting on a 3-data-node remote-store cluster (asserts acknowledged — the operation that previously 400'd), auto-creates a matching index so the template drives its settings, asserts the setting + injected `index.remote_store.enabled` propagate, and that the per-node primary cap is enforced at allocation (3 assigned / 1 unassigned across 3 nodes). Verified this IT **fails without the fix** with the exact 400 message and **passes with it**.
- Unit `MetadataIndexTemplateServiceTests.testIndexPrimaryShardsSettingOnRemoteStoreCluster`: positive validation path with remote-store `DiscoveryNodes`; complements the existing negative test.

### Related Issues
<!-- none filed -->

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
