### PR TITLE
Flush CPU runtime deferred drops on query cancellation

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/api.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/api.rs
@@ -1333,6 +1333,10 @@ pub unsafe fn stream_close(stream_ptr: i64) {
         return;
     }
     let mut handle = Box::from_raw(stream_ptr as *mut QueryStreamHandle);
+    let context_id = handle._query_tracking_context.context_id();
+    // Grab the CPU runtime handle BEFORE drop — drop removes the tracker from
+    // the registry, making it unreachable for flush_cpu_runtime.
+    let cpu_rt_handle = query_tracker::take_cpu_runtime_handle(context_id);
     // Dropping the handle aborts the CPU task but does not wait for it; on the coordinator-reduce
     // path that task still holds Java-borrowed input batches. Wait for it to fully unwind (signal
     // fires once its batches drop) before returning, so the caller's allocator close is safe.
@@ -1354,6 +1358,13 @@ pub unsafe fn stream_close(stream_ptr: i64) {
                 );
             }
         }
+    }
+    // After dropping the QueryStreamHandle (which drops CrossRtStream → JoinSet →
+    // aborts the CPU task), flush the runtime so the cascading abort of
+    // pull_from_input tasks (holding GroupValues buffers) is processed now rather
+    // than lingering in tokio's deferred drop queue on an idle runtime.
+    if let Some(rt) = cpu_rt_handle {
+        query_tracker::flush_cpu_runtime_with_handle(&rt, context_id);
     }
 }
 
@@ -1810,10 +1821,14 @@ pub async unsafe fn execute_local_plan(
     // shape as `execute_query`, so existing `stream_next` / `stream_close`
     // drain this handle unchanged. Use the cancellable variant so the CPU
     // task can be aborted mid-execution when cancel_query fires.
+    let cpu_exec = manager.cpu_executor();
     let (cross_rt_stream, abort_handle, task_done) =
-        CrossRtStream::new_with_df_error_stream_cancellable(df_stream, manager.cpu_executor());
+        CrossRtStream::new_with_df_error_stream_cancellable(df_stream, cpu_exec.clone());
     if let Some(h) = abort_handle {
         query_tracker::set_abort_handle(context_id, h);
+    }
+    if let Some(rt) = cpu_exec.handle() {
+        query_tracker::set_cpu_runtime_handle(context_id, rt);
     }
     let wrapped = RecordBatchStreamAdapter::new(cross_rt_stream.schema(), cross_rt_stream);
 
@@ -1854,10 +1869,14 @@ pub unsafe fn execute_local_prepared_plan(
     let _guard = manager.io_runtime.enter();
     let df_stream = session.execute_prepared()?;
 
+    let cpu_exec = manager.cpu_executor();
     let (cross_rt_stream, abort_handle, task_done) =
-        CrossRtStream::new_with_df_error_stream_cancellable(df_stream, manager.cpu_executor());
+        CrossRtStream::new_with_df_error_stream_cancellable(df_stream, cpu_exec.clone());
     if let Some(h) = abort_handle {
         query_tracker::set_abort_handle(context_id, h);
+    }
+    if let Some(rt) = cpu_exec.handle() {
+        query_tracker::set_cpu_runtime_handle(context_id, rt);
     }
     let wrapped = RecordBatchStreamAdapter::new(cross_rt_stream.schema(), cross_rt_stream);
 

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_executor.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_executor.rs
@@ -745,9 +745,12 @@ async unsafe fn execute_indexed_with_context_inner(
         let empty_exec = EmptyExec::new(Arc::clone(&plan_schema));
         let df_stream = empty_exec.execute(0, handle.ctx.task_ctx())?;
         let (cross_rt_stream, abort_handle, _task_done) =
-            CrossRtStream::new_with_df_error_stream_cancellable(df_stream, cpu_executor);
+            CrossRtStream::new_with_df_error_stream_cancellable(df_stream, cpu_executor.clone());
         if let Some(h) = abort_handle {
             crate::query_tracker::set_abort_handle(context_id_early, h);
+        }
+        if let Some(rt) = cpu_executor.handle() {
+            crate::query_tracker::set_cpu_runtime_handle(context_id_early, rt);
         }
         let wrapped = datafusion::physical_plan::stream::RecordBatchStreamAdapter::new(
             cross_rt_stream.schema(),
@@ -1223,10 +1226,13 @@ async unsafe fn execute_indexed_with_context_inner(
         .map_err(|e| DataFusionError::Execution(format!("execute_stream: {}", e)))?;
 
     let (cross_rt_stream, abort_handle, _task_done) =
-        CrossRtStream::new_with_df_error_stream_cancellable(df_stream, cpu_executor);
+        CrossRtStream::new_with_df_error_stream_cancellable(df_stream, cpu_executor.clone());
 
     if let Some(h) = abort_handle {
         crate::query_tracker::set_abort_handle(context_id, h);
+    }
+    if let Some(rt) = cpu_executor.handle() {
+        crate::query_tracker::set_cpu_runtime_handle(context_id, rt);
     }
 
     let schema = cross_rt_stream.schema();

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/query_executor.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/query_executor.rs
@@ -198,10 +198,13 @@ pub async fn execute_query(
 
     // Wrap in CrossRtStream — CPU work runs on DedicatedExecutor
     let (cross_rt_stream, abort_handle, _task_done) =
-        CrossRtStream::new_with_df_error_stream_cancellable(df_stream, cpu_executor);
+        CrossRtStream::new_with_df_error_stream_cancellable(df_stream, cpu_executor.clone());
 
     if let Some(h) = abort_handle {
         crate::query_tracker::set_abort_handle(context_id, h);
+    }
+    if let Some(rt) = cpu_executor.handle() {
+        crate::query_tracker::set_cpu_runtime_handle(context_id, rt);
     }
 
     // Attach phantom corrector for self-correcting budget (if provided)
@@ -293,9 +296,12 @@ pub async fn execute_with_context(
                 e
             })?;
             let (cross_rt_stream, abort_handle, _task_done) =
-                CrossRtStream::new_with_df_error_stream_cancellable(df_stream, cpu_executor);
+                CrossRtStream::new_with_df_error_stream_cancellable(df_stream, cpu_executor.clone());
             if let Some(h) = abort_handle {
                 crate::query_tracker::set_abort_handle(context_id, h);
+            }
+            if let Some(rt) = cpu_executor.handle() {
+                crate::query_tracker::set_cpu_runtime_handle(context_id, rt);
             }
             let wrapped = datafusion::physical_plan::stream::RecordBatchStreamAdapter::new(
                 cross_rt_stream.schema(),
@@ -330,9 +336,12 @@ pub async fn execute_with_context(
             })?;
 
             let (cross_rt_stream, abort_handle, _task_done) =
-                CrossRtStream::new_with_df_error_stream_cancellable(df_stream, cpu_executor);
+                CrossRtStream::new_with_df_error_stream_cancellable(df_stream, cpu_executor.clone());
             if let Some(h) = abort_handle {
                 crate::query_tracker::set_abort_handle(context_id, h);
+            }
+            if let Some(rt) = cpu_executor.handle() {
+                crate::query_tracker::set_cpu_runtime_handle(context_id, rt);
             }
             let wrapped = datafusion::physical_plan::stream::RecordBatchStreamAdapter::new(
                 cross_rt_stream.schema(),
@@ -356,10 +365,13 @@ pub async fn execute_with_context(
         })?;
 
         let (cross_rt_stream, abort_handle, _task_done) =
-            CrossRtStream::new_with_df_error_stream_cancellable(df_stream, cpu_executor);
+            CrossRtStream::new_with_df_error_stream_cancellable(df_stream, cpu_executor.clone());
 
         if let Some(h) = abort_handle {
             crate::query_tracker::set_abort_handle(context_id, h);
+        }
+        if let Some(rt) = cpu_executor.handle() {
+            crate::query_tracker::set_cpu_runtime_handle(context_id, rt);
         }
 
         let wrapped = datafusion::physical_plan::stream::RecordBatchStreamAdapter::new(

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/query_tracker.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/query_tracker.rs
@@ -22,7 +22,7 @@ use std::sync::{Arc, OnceLock};
 use std::time::{Duration, Instant};
 
 use dashmap::DashMap;
-use log::debug;
+use log::{debug, warn};
 use once_cell::sync::Lazy;
 use tokio::task::AbortHandle;
 use tokio_util::sync::CancellationToken;
@@ -172,6 +172,10 @@ pub struct QueryTracker {
     pub cancellation_token: CancellationToken,
     /// CPU task abort handle, set after the stream is created.
     pub abort_handle: OnceLock<AbortHandle>,
+    /// Handle to the DedicatedExecutor's tokio runtime. Used by `cancel_query`
+    /// to flush pending deferred drops (pull_from_input tasks holding GroupValues
+    /// buffers) after aborting the outer CrossRtStream task.
+    pub cpu_runtime_handle: OnceLock<tokio::runtime::Handle>,
     /// Nanos since PROCESS_START when cancellation was signalled, or 0 if not cancelled.
     /// Set atomically via CAS in cancel_query — no lock needed.
     pub cancelled_at_nanos: AtomicU64,
@@ -351,8 +355,32 @@ pub fn snapshot_top_n_by_current(out: &mut [WireQueryMetric]) -> usize {
     written
 }
 
-/// Fire the cancellation token for the given context_id.
+/// Maximum time the flush will block waiting for the CPU runtime to process
+/// deferred drops (pull_from_input tasks holding GroupValues buffers).
+const CANCEL_FLUSH_TIMEOUT: Duration = Duration::from_millis(500);
+
+/// Yields per flush worker. The abort cascade has 3 scheduling levels:
+///   Level 1: CrossRtStream CPU task abort → drops CoalescePartitions receiver
+///   Level 2: CoalescePartitions' run_input tasks see closed channel → exit →
+///            drop PerPartitionStream → Arc<SpawnedTask> refcount hits 0
+///   Level 3: SpawnedTask::drop aborts pull_from_input → drops GroupValues
+/// Each level needs at least one scheduling round per task. With
+/// target_partitions = N, levels 2 and 3 each have N tasks.
+/// 32 yields per worker covers up to 32 partitions per level on a single worker.
+const FLUSH_YIELDS_PER_WORKER: usize = 32;
+
+/// Number of flush tasks to spawn. Spawning across multiple workers ensures
+/// the woken tasks (which may land on different workers' queues) are processed
+/// in parallel rather than serialized through one worker's yields.
+const FLUSH_WORKER_COUNT: usize = 4;
+
+/// Fire the cancellation token for the given context_id and abort the CPU task.
 /// No-op for unknown or already-completed queries.
+///
+/// Note: this does NOT flush the runtime — the abort cascade only completes
+/// after the `QueryStreamHandle` is dropped (via `stream_close`). Call
+/// [`flush_cpu_runtime`] after `stream_close` to ensure deferred drops are
+/// processed and GroupValues buffers are freed.
 pub fn cancel_query(context_id: i64) {
     if let Some(tracker) = QUERY_REGISTRY.get(&context_id) {
         tracker.cancellation_token.cancel();
@@ -364,6 +392,60 @@ pub fn cancel_query(context_id: i64) {
     }
 }
 
+/// Flush the CPU runtime for the given context_id, giving tokio workers
+/// scheduling opportunities to process deferred drops from the abort cascade.
+///
+/// Call this AFTER `stream_close` has dropped the `QueryStreamHandle` (which
+/// drops the JoinSet, releasing aborted task futures for collection). The flush
+/// spawns lightweight tasks that yield repeatedly, ensuring workers wake up and
+/// process the pending drops (pull_from_input futures → GroupValues buffers).
+///
+/// No-op if no runtime handle is registered or the query is unknown.
+pub fn flush_cpu_runtime(context_id: i64) {
+    let rt_handle = QUERY_REGISTRY
+        .get(&context_id)
+        .and_then(|tracker| tracker.cpu_runtime_handle.get().cloned());
+
+    if let Some(handle) = rt_handle {
+        flush_cpu_runtime_with_handle(&handle, context_id);
+    }
+}
+
+/// Flush variant that takes the runtime handle directly — used by `stream_close`
+/// which must extract the handle before dropping the tracker (drop removes it
+/// from the registry).
+pub fn flush_cpu_runtime_with_handle(handle: &tokio::runtime::Handle, context_id: i64) {
+    let (tx, rx) = std::sync::mpsc::sync_channel(FLUSH_WORKER_COUNT);
+    for _ in 0..FLUSH_WORKER_COUNT {
+        let tx = tx.clone();
+        handle.spawn(async move {
+            for _ in 0..FLUSH_YIELDS_PER_WORKER {
+                tokio::task::yield_now().await;
+            }
+            let _ = tx.send(());
+        });
+    }
+    drop(tx);
+    for _ in 0..FLUSH_WORKER_COUNT {
+        if rx.recv_timeout(CANCEL_FLUSH_TIMEOUT).is_err() {
+            warn!(
+                "flush_cpu_runtime({}): timed out after {}ms",
+                context_id, CANCEL_FLUSH_TIMEOUT.as_millis()
+            );
+            break;
+        }
+    }
+}
+
+/// Extract the CPU runtime handle from the tracker, removing it. Used by
+/// `stream_close` to grab the handle before the tracker is dropped (which
+/// removes it from the registry).
+pub fn take_cpu_runtime_handle(context_id: i64) -> Option<tokio::runtime::Handle> {
+    QUERY_REGISTRY
+        .get(&context_id)
+        .and_then(|tracker| tracker.cpu_runtime_handle.get().cloned())
+}
+
 /// Clone the cancellation token for the given context_id, if registered.
 pub fn get_cancellation_token(context_id: i64) -> Option<CancellationToken> {
     QUERY_REGISTRY.get(&context_id).map(|t| t.cancellation_token.clone())
@@ -373,6 +455,14 @@ pub fn get_cancellation_token(context_id: i64) -> Option<CancellationToken> {
 pub fn set_abort_handle(context_id: i64, handle: AbortHandle) {
     if let Some(tracker) = QUERY_REGISTRY.get(&context_id) {
         tracker.abort_handle.set(handle).ok();
+    }
+}
+
+/// Store the CPU runtime handle for the given context_id so that
+/// `cancel_query` can flush deferred drops on that runtime.
+pub fn set_cpu_runtime_handle(context_id: i64, handle: tokio::runtime::Handle) {
+    if let Some(tracker) = QUERY_REGISTRY.get(&context_id) {
+        tracker.cpu_runtime_handle.set(handle).ok();
     }
 }
 
@@ -430,6 +520,7 @@ impl QueryTrackingContext {
             memory_pool: query_pool,
             cancellation_token: CancellationToken::new(),
             abort_handle: OnceLock::new(),
+            cpu_runtime_handle: OnceLock::new(),
             cancelled_at_nanos: AtomicU64::new(0),
             completed: AtomicBool::new(false),
             wall_nanos: std::sync::atomic::AtomicU64::new(0),
@@ -858,6 +949,74 @@ mod tests {
         drop(coord_ctx);
     }
 
+
+    // -----------------------------------------------------------------------
+    // Flush-on-cancel tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_cancel_query_flushes_deferred_drops() {
+        use std::sync::atomic::AtomicBool;
+
+        // Tracks whether the captured state inside the spawned future was dropped.
+        struct DropSentinel(Arc<AtomicBool>);
+        impl Drop for DropSentinel {
+            fn drop(&mut self) {
+                self.0.store(true, Ordering::Release);
+            }
+        }
+
+        let global = make_global_pool(10_000);
+        let ctx_id = 70_001;
+        let ctx = QueryTrackingContext::new(ctx_id, global, QueryType::Shard);
+
+        // Build a dedicated executor with its own tokio runtime.
+        let mut builder = tokio::runtime::Builder::new_multi_thread();
+        builder.worker_threads(2).enable_all();
+        let exec = crate::executor::DedicatedExecutor::new("test-flush", builder, 2);
+
+        // Store the runtime handle in the tracker (mirrors production path).
+        if let Some(rt) = exec.handle() {
+            set_cpu_runtime_handle(ctx_id, rt);
+        }
+
+        // Spawn a task that holds the sentinel and blocks forever at an await.
+        let dropped = Arc::new(AtomicBool::new(false));
+        let sentinel = DropSentinel(Arc::clone(&dropped));
+
+        let (abort_handle, _join_fut) = exec.spawn_with_abort_handle(async move {
+            let _hold = sentinel; // captured in the future's state
+            // Block forever — only abort can end this.
+            futures::future::pending::<()>().await;
+        });
+
+        if let Some(h) = abort_handle {
+            set_abort_handle(ctx_id, h);
+        }
+
+        // Small delay to let the task actually park at the pending().await
+        thread::sleep(Duration::from_millis(10));
+
+        // Verify not yet dropped
+        assert!(!dropped.load(Ordering::Acquire), "sentinel should be alive before cancel");
+
+        // cancel_query aborts the task (marks it cancelled in the runtime)
+        cancel_query(ctx_id);
+
+        // The abort is async — the task future may not be dropped yet.
+        // flush_cpu_runtime gives the runtime scheduling opportunities to
+        // process the abort and drop the future (freeing the sentinel).
+        flush_cpu_runtime(ctx_id);
+
+        // After flush, the sentinel should have been dropped.
+        assert!(
+            dropped.load(Ordering::Acquire),
+            "sentinel must be dropped after flush — deferred drop was not processed"
+        );
+
+        drop(ctx);
+        exec.join_blocking();
+    }
 
     // -----------------------------------------------------------------------
     // Top-N snapshot tests


### PR DESCRIPTION
After cancel_query aborts the CPU task, RepartitionExec's pull_from_input tasks (holding GroupedHashAggregateStream with GB-scale GroupValues buffers) remain in tokio's deferred drop queue until a worker processes them. On an idle runtime this can take seconds or never complete promptly.

Store the DedicatedExecutor's runtime Handle in QueryTracker. After abort, spawn flush tasks across multiple workers that yield repeatedly, giving the scheduler opportunities to poll the aborted tasks and drop their captured futures (freeing the GroupValues buffers). Block the calling Java thread (via std::sync::mpsc) until the flush completes or 500ms timeout.

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
