### PR TITLE
Fix NPE in bitmap terms lookup when stored field is missing

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/380_bitmap_filtering.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/380_bitmap_filtering.yml
@@ -48,6 +48,8 @@ setup:
           -  { "enrolled": "OjAAAAEAAAAAAAAAEAAAAE0B" }     # 333
           -  { "index": { "_index": "classes", "_id": "104" } }
           -  { "enrolled": "OjAAAAEAAAAAAAEAEAAAAN4ATQE=" } # 222,333
+          -  { "index": { "_index": "classes", "_id": "105" } }
+          -  {} # "enrolled" stored field intentionally missing
   - do:
       cluster.health:
         wait_for_status: green
@@ -182,3 +184,24 @@ setup:
   - match: { hits.hits.1._source.student_id: 111 }
   - match: { hits.hits.2._source.name: John Doe }
   - match: { hits.hits.2._source.student_id: 333 }
+
+---
+"Terms lookup on a missing stored bitmap field returns no matches":
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        index: students
+        body: {
+          "query": {
+            "terms": {
+              "student_id": {
+                "index": "classes",
+                "id": "105",
+                "path": "enrolled",
+                "store": true
+              },
+              "value_type": "bitmap"
+            }
+          }
+        }
+  - match: { hits.total: 0 }

--- a/server/src/main/java/org/opensearch/index/query/TermsQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/TermsQueryBuilder.java
@@ -42,6 +42,7 @@ import org.opensearch.Version;
 import org.opensearch.action.get.GetRequest;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.common.SetOnce;
+import org.opensearch.common.document.DocumentField;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.support.XContentMapValues;
@@ -582,13 +583,18 @@ public class TermsQueryBuilder extends AbstractQueryBuilder<TermsQueryBuilder> i
             client.get(getRequest, ActionListener.delegateFailure(actionListener, (delegatedListener, getResponse) -> {
                 List<Object> terms = new ArrayList<>();
                 if (termsLookup.store()) {
-                    List<Object> values = getResponse.getField(termsLookup.path()).getValues();
-                    if (values.size() != 1 && valueType == ValueType.BITMAP) {
-                        throw new IllegalArgumentException(
-                            "Invalid value for bitmap type: Expected a single base64 encoded serialized bitmap."
-                        );
+                    DocumentField storedField = getResponse.getField(termsLookup.path());
+                    // A stored field that is absent from the looked-up document yields a null
+                    // DocumentField; treat it as no terms (no matches) instead of failing.
+                    if (storedField != null) {
+                        List<Object> values = storedField.getValues();
+                        if (values.size() != 1 && valueType == ValueType.BITMAP) {
+                            throw new IllegalArgumentException(
+                                "Invalid value for bitmap type: Expected a single base64 encoded serialized bitmap."
+                            );
+                        }
+                        terms.addAll(values);
                     }
-                    terms.addAll(values);
                 } else {
                     if (getResponse.isSourceEmpty() == false) { // extract terms only if the doc source exists
                         List<Object> extractedValues = XContentMapValues.extractRawValues(termsLookup.path(), getResponse.getSourceAsMap());

--- a/server/src/test/java/org/opensearch/index/query/TermsQueryBuilderTests.java
+++ b/server/src/test/java/org/opensearch/index/query/TermsQueryBuilderTests.java
@@ -90,6 +90,9 @@ public class TermsQueryBuilderTests extends AbstractQueryTestCase<TermsQueryBuil
     private String termsPath;
     private boolean maybeIncludeType = true;
     private Set<String> assertedWarnings = new HashSet<>();
+    // When true, executeGet() returns a document that does not contain the looked-up
+    // stored field, so getResponse.getField(path) yields a null DocumentField.
+    private boolean storedFieldMissing = false;
 
     @Before
     public void randomTerms() {
@@ -103,6 +106,7 @@ public class TermsQueryBuilderTests extends AbstractQueryTestCase<TermsQueryBuil
         }
         this.randomTerms = randomTerms;
         termsPath = randomAlphaOfLength(10).replace('.', '_');
+        storedFieldMissing = false;
     }
 
     @Override
@@ -281,7 +285,11 @@ public class TermsQueryBuilderTests extends AbstractQueryTestCase<TermsQueryBuil
                 nonNullTerms.add(obj);
             }
         }
-        documentField.put(termsPath, new DocumentField(termsPath, nonNullTerms));
+        // Leaving the path out of the document makes getResponse.getField(path) return null,
+        // mirroring a stored field that is absent from the looked-up document.
+        if (storedFieldMissing == false) {
+            documentField.put(termsPath, new DocumentField(termsPath, nonNullTerms));
+        }
         return new GetResponse(
             new GetResult(getRequest.index(), getRequest.id(), 0, 1, 0, true, new BytesArray(json), documentField, null)
         );
@@ -472,6 +480,19 @@ public class TermsQueryBuilderTests extends AbstractQueryTestCase<TermsQueryBuil
         QueryBuilder rewritten = rewriteQuery(query, new QueryShardContext(context));
         Query luceneQuery = rewritten.toQuery(context);
         assertTrue(luceneQuery instanceof IndexOrDocValuesQuery);
+    }
+
+    public void testTermsLookupBitmapStoredFieldMissing() throws IOException {
+        // The looked-up document does not contain the stored field, so getField(path) returns null.
+        // The query should resolve to no terms (match none) instead of throwing an NPE.
+        storedFieldMissing = true;
+
+        TermsQueryBuilder query = new TermsQueryBuilder(INT_FIELD_NAME, randomTermsLookup().store(true)).valueType(
+            TermsQueryBuilder.ValueType.BITMAP
+        );
+        QueryShardContext context = createShardContext();
+        QueryBuilder rewritten = rewriteAndFetch(query, context);
+        assertEquals(new MatchNoneQueryBuilder(), rewritten);
     }
 
     public void testGetComplementWholeNumber() throws Exception {


### PR DESCRIPTION
### Description
A `terms` query using terms lookup with `value_type: bitmap` and `store: true` throws a
`NullPointerException` when the looked-up document exists but the stored field at `path` is
missing.

Root cause: in `TermsQueryBuilder#fetch`, `getResponse.getField(termsLookup.path())` returns
`null` for an absent stored field, and `getValues()` was called on it unconditionally.

This change guards the null `DocumentField` and treats a missing stored field as no terms
(no matches), which is consistent with how a missing source field is already handled. Existing
single-value bitmap validation is preserved for the present-field case.

Added a REST yaml test in `search/380_bitmap_filtering.yml`: a lookup document missing the stored
bitmap field now returns `hits.total: 0` instead of erroring.

### Related Issues
Resolves #21995

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.