### PR TITLE
Schema alignment fix for dynamic mapping

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/dynamic_filter.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/dynamic_filter.rs
@@ -204,10 +204,19 @@ impl RgPruningContext {
         let Some(rg_meta) = metadata.row_groups().get(rg_idx) else {
             return false;
         };
+        // Resolve stats against the segment's OWN parquet schema, not the full table
+        // schema: StatisticsConverter maps name→parquet-column positionally, so the full
+        // schema reads the wrong/no column under dynamic-mapping schema drift.
+        let descr = metadata.file_metadata().schema_descr();
+        let seg_schema = datafusion::parquet::arrow::parquet_to_arrow_schema(
+            descr,
+            metadata.file_metadata().key_value_metadata(),
+        )
+        .unwrap_or_else(|_| self.schema.as_ref().clone());
         let stats = SingleRowGroupStatistics {
-            parquet_schema: metadata.file_metadata().schema_descr(),
+            parquet_schema: descr,
             rg_meta,
-            arrow_schema: self.schema.as_ref(),
+            arrow_schema: &seg_schema,
         };
         // `prune` returns one bool per container (we have exactly one). `false`
         // means "provably cannot match" → safe to skip. Any error => keep.
@@ -215,5 +224,67 @@ impl RgPruningContext {
             Ok(keep) => keep.first().is_some_and(|k| !*k),
             Err(_) => false,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::arrow::array::{Int32Array, RecordBatch};
+    use datafusion::arrow::datatypes::{DataType, Field};
+    use datafusion::parquet::arrow::arrow_reader::{ArrowReaderMetadata, ArrowReaderOptions};
+    use datafusion::parquet::arrow::ArrowWriter;
+    use datafusion::physical_expr::expressions::{BinaryExpr, Column as PhysColumn, Literal};
+    use datafusion::logical_expr::Operator;
+    use tempfile::NamedTempFile;
+
+    // Schema drift: the table schema orders columns differently from the segment's own
+    // parquet file. StatisticsConverter maps a column name to a parquet index positionally,
+    // so resolving `severity` against the table schema lands on a DIFFERENT real file column
+    // (here `neg`, all-negative). The always-true dynamic filter `severity >= 0` then reads
+    // neg's stats (max < 0) and wrongly prunes the whole RG. Resolving against the segment's
+    // own schema reads the real `severity` stats and keeps the RG.
+    #[test]
+    fn dynamic_rg_prune_resolves_stats_against_segment_schema_under_drift() {
+        // File order: name, neg, severity.
+        let file_schema = Arc::new(Schema::new(vec![
+            Field::new("name", DataType::Int32, false),
+            Field::new("neg", DataType::Int32, false),
+            Field::new("severity", DataType::Int32, false),
+        ]));
+        // Table order puts `severity` at the position the file holds `neg`.
+        let table_schema = Arc::new(Schema::new(vec![
+            Field::new("name", DataType::Int32, false),
+            Field::new("severity", DataType::Int32, false),
+            Field::new("neg", DataType::Int32, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            file_schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2, 3, 4])),
+                Arc::new(Int32Array::from(vec![-9, -8, -7, -6])),
+                Arc::new(Int32Array::from(vec![0, 5, 10, 17])),
+            ],
+        )
+        .unwrap();
+        let tmp = NamedTempFile::new().unwrap();
+        let mut w = ArrowWriter::try_new(tmp.reopen().unwrap(), file_schema, None).unwrap();
+        w.write(&batch).unwrap();
+        w.close().unwrap();
+        let md = ArrowReaderMetadata::load(&tmp.reopen().unwrap(), ArrowReaderOptions::new())
+            .unwrap()
+            .metadata()
+            .clone();
+
+        let sev: Arc<dyn PhysicalExpr> = Arc::new(PhysColumn::new("severity", 1));
+        let zero: Arc<dyn PhysicalExpr> = Arc::new(Literal::new(ScalarValue::Int32(Some(0))));
+        let expr: Arc<dyn PhysicalExpr> = Arc::new(BinaryExpr::new(sev, Operator::GtEq, zero));
+        let predicate = Arc::new(PruningPredicate::try_new(expr, table_schema.clone()).unwrap());
+        let ctx = RgPruningContext { predicate, schema: table_schema };
+
+        assert!(
+            !ctx.rg_provably_excluded(&md, 0),
+            "severity >= 0 is always true for this segment; it must not be pruned under schema drift"
+        );
     }
 }

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/page_pruner.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/page_pruner.rs
@@ -116,12 +116,21 @@ impl PagePruner {
             Option<(StatisticsConverter<'_>, usize)>,
         )> = Vec::new();
 
+        // Resolve against the segment's own schema (see eval_leaf): the full table
+        // schema misaligns StatisticsConverter's positional column lookup under
+        // dynamic-mapping schema drift.
+        let descr = self.metadata.file_metadata().schema_descr();
+        let seg_arrow_schema = match datafusion::parquet::arrow::parquet_to_arrow_schema(
+            descr,
+            self.metadata.file_metadata().key_value_metadata(),
+        ) {
+            Ok(s) => Arc::new(s),
+            Err(_) => Arc::clone(&self.schema),
+        };
+
         for col in &columns {
-            let converter = match StatisticsConverter::try_new(
-                col.name(),
-                &self.schema,
-                self.metadata.file_metadata().schema_descr(),
-            ) {
+            let converter = match StatisticsConverter::try_new(col.name(), &seg_arrow_schema, descr)
+            {
                 Ok(c) => c,
                 Err(_) => {
                     // Column not in Arrow schema either — nothing we can
@@ -525,7 +534,20 @@ fn eval_leaf(
     if columns.is_empty() {
         return vec![true; num];
     }
-    let arrow_schema = schema.as_ref();
+    // Resolve stats against the segment's OWN parquet schema, not the full table
+    // schema. StatisticsConverter maps a column name to a parquet index positionally
+    // (parquet crate `parquet_column`), so passing the full schema reads the wrong /
+    // no column when the segment's schema is narrower or reordered (dynamic-mapping
+    // schema drift) — yielding null stats that prune RGs that actually match.
+    let descr = metadata.file_metadata().schema_descr();
+    let seg_arrow_schema = match datafusion::parquet::arrow::parquet_to_arrow_schema(
+        descr,
+        metadata.file_metadata().key_value_metadata(),
+    ) {
+        Ok(s) => Arc::new(s),
+        Err(_) => Arc::clone(schema),
+    };
+    let arrow_schema = seg_arrow_schema.as_ref();
     let rg_metas: Vec<_> = rg_indices
         .iter()
         .filter_map(|&idx| metadata.row_groups().get(idx))
@@ -538,9 +560,7 @@ fn eval_leaf(
         if arrow_schema.index_of(col.name()).is_err() {
             continue;
         }
-        let converter = match StatisticsConverter::try_new(
-            col.name(), arrow_schema, metadata.file_metadata().schema_descr(),
-        ) {
+        let converter = match StatisticsConverter::try_new(col.name(), arrow_schema, descr) {
             Ok(c) => c,
             Err(_) => continue,
         };
@@ -1536,5 +1556,49 @@ mod tests {
         assert_eq!(spt.children[2].children[1].rg_can_match, vec![true, true, true, true, true]);
         // AND₃/NOT/p8
         assert_eq!(spt.children[2].children[1].children[0].rg_can_match, vec![true, true, false, false, false]);
+    }
+
+    // Schema drift: the table schema orders columns differently from the segment's own
+    // parquet file, so resolving `severity` positionally against the table schema lands on
+    // a DIFFERENT real file column (`neg`, all-negative). The always-true `severity >= 0`
+    // then reads neg's stats (max < 0) and `eval_leaf` wrongly prunes the RG. Resolving
+    // against the segment's own schema reads the real `severity` stats and keeps it.
+    #[test]
+    fn eval_leaf_resolves_stats_against_segment_schema_under_drift() {
+        let file_schema = Arc::new(Schema::new(vec![
+            Field::new("name", DataType::Int32, false),
+            Field::new("neg", DataType::Int32, false),
+            Field::new("severity", DataType::Int32, false),
+        ]));
+        let table_schema = Arc::new(Schema::new(vec![
+            Field::new("name", DataType::Int32, false),
+            Field::new("severity", DataType::Int32, false),
+            Field::new("neg", DataType::Int32, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            file_schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2, 3, 4])),
+                Arc::new(Int32Array::from(vec![-9, -8, -7, -6])),
+                Arc::new(Int32Array::from(vec![0, 5, 10, 17])),
+            ],
+        )
+        .unwrap();
+        let tmp = NamedTempFile::new().unwrap();
+        let mut w = ArrowWriter::try_new(tmp.reopen().unwrap(), file_schema, None).unwrap();
+        w.write(&batch).unwrap();
+        w.close().unwrap();
+        let md = ArrowReaderMetadata::load(&tmp.reopen().unwrap(), ArrowReaderOptions::new())
+            .unwrap()
+            .metadata()
+            .clone();
+
+        let expr = bin(col("severity", 1), Operator::GtEq, lit_int(0));
+        let pp = build_pruning_predicate(&expr, table_schema.clone()).unwrap();
+        assert_eq!(
+            eval_leaf(&pp, &md, &table_schema, &[0]),
+            vec![true],
+            "severity >= 0 is always true; eval_leaf must not prune under schema drift"
+        );
     }
 }

--- a/sandbox/qa/analytics-engine-rest/build.gradle
+++ b/sandbox/qa/analytics-engine-rest/build.gradle
@@ -129,6 +129,7 @@ integTest {
     exclude '**/SpillStatsEnabledIT.class'
     exclude '**/SpillCleanupOnBootIT.class'
     exclude '**/YmlOversamplingIT.class'
+    exclude '**/*NoMergeIT.class'
 
     // Note: parallel forks against the same 2-node testCluster slow the suite down
     // (cluster is the bottleneck, not JVM startup) and cause cross-fork data races
@@ -187,6 +188,30 @@ check.dependsOn(integTestStreaming)
 testClusters.integTestStreaming {
     numberOfNodes = 2
     configureAnalyticsCluster(delegate)
+}
+
+// ── No-merge variant: 2 nodes, parquet segment merge disabled ────────────────
+// Runs every *NoMergeIT with the dataformat merge gate turned off. The gate
+// (DataFormatAwareEngine.MERGE_ENABLED_PROPERTY) defaults to ENABLED, so background
+// merges would otherwise collapse per-flush parquet segments. Tests that need each
+// flush to persist as its own segment (e.g. to exercise multi-segment / schema-drift
+// behavior) belong here — name them with the *NoMergeIT suffix. They are excluded from
+// the default integTest above so they only run under this merge-disabled cluster.
+task integTestNoMerge(type: RestIntegTestTask) {
+    description = 'Runs *NoMergeIT tests with parquet segment merge disabled'
+    testClassesDirs = sourceSets.test.output.classesDirs
+    classpath = sourceSets.test.runtimeClasspath
+    filter {
+        includeTestsMatching 'org.opensearch.analytics.qa.*NoMergeIT'
+    }
+    systemProperty 'tests.security.manager', 'false'
+}
+check.dependsOn(integTestNoMerge)
+
+testClusters.integTestNoMerge {
+    numberOfNodes = 2
+    configureAnalyticsCluster(delegate)
+    systemProperty 'opensearch.pluggable.dataformat.merge.enabled', 'false'
 }
 
 // ── Spill-enabled variant: 2 nodes, datafusion.spill_directory + spill_memory_limit ──

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/SchemaDriftPruneNoMergeIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/SchemaDriftPruneNoMergeIT.java
@@ -1,0 +1,286 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.qa;
+
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Regression test for parquet row-group / page statistics pruning under dynamic-mapping
+ * <b>schema drift</b> across segments. Automates the manual cluster reproduction that
+ * surfaced the bug (24 segments, wide dynamic schemas, merges off).
+ *
+ * <p><b>The bug.</b> {@code StatisticsConverter} resolves a column name to a parquet leaf
+ * <em>positionally</em>: it finds the column's ordinal in the Arrow schema it is handed and
+ * uses that ordinal to index into the parquet file (parquet crate {@code parquet_column}).
+ * The stats-pruning paths ({@code eval_leaf} / {@code PagePruner::prune_rg} in
+ * {@code page_pruner.rs}, and {@code rg_provably_excluded} in {@code dynamic_filter.rs}) used
+ * to pass the <em>union table schema</em>. That schema's field order is first-seen across
+ * segments, but each individual segment's parquet column order follows the Java mapper's
+ * {@code HashMap} iteration order for <em>that segment's own field set</em>. When segments
+ * have different-sized field sets (dynamic mapping adding fields over time), {@code severity}
+ * lands at a different ordinal in each segment than it has in the union schema. The positional
+ * lookup then reads the wrong leaf — or finds none — yielding all-null stats, and the
+ * always-true residual {@code severity >= 0} wrongly prunes those row groups / segments,
+ * silently dropping matching rows. The fix resolves stats against each segment's <em>own</em>
+ * arrow schema (derived from its parquet footer).
+ *
+ * <p><b>How drift is induced.</b> {@code message} (text) and {@code severity} (byte) are
+ * declared up front, but each flush also indexes a <em>growing</em> set of dynamically-mapped
+ * numeric fields {@code pad_0..pad_W(s)} (segment {@code s} is wider than segment {@code s-1}).
+ * Because every flush becomes its own parquet segment, merge is disabled (see the
+ * {@code integTestNoMerge} cluster variant in build.gradle), and {@code row_group_max_rows} is
+ * small (multi-RG segments), successive segments carry differently-sized field sets — the
+ * HashMap-order divergence that drifts {@code severity}'s per-segment ordinal away from its
+ * union ordinal. The high field count (~300 in the widest segment) is what makes the
+ * divergence reliable; small fixtures (a handful of fields) do not drift and pass even without
+ * the fix.
+ *
+ * <p>The {@code text} field is declared in the initial mapping on purpose:
+ * {@code match()} on a <em>dynamically-added</em> field across segments is a separate, known
+ * issue ({@code DynamicMappingSearchIT#testSearchOnDynamicallyAddedFields}, {@code @AwaitsFix}
+ * PR #21701), so the full-text field stays stable and only the numeric pad fields drift.
+ *
+ * <p><b>Query shapes</b> (each asserted against a ground truth computed during ingest):
+ * <ol>
+ *   <li>Numeric filter only — {@code where severity >= 0 | stats count()}
+ *       (hits {@code eval_leaf} / {@code prune_rg} on the parquet-only path).</li>
+ *   <li>Sort + limit (TopK) — {@code where severity >= 0 | sort - severity | head k}
+ *       (adds the {@code DynamicRgPruner} / {@code rg_provably_excluded} path).</li>
+ *   <li>match() + numeric residual — {@code where match(message,'alpha') and severity >= 0 | stats count()}
+ *       (the production shape: Lucene-delegated text predicate AND a stats-pruned residual).</li>
+ *   <li>match() + filter + sort + limit — all three prune paths at once.</li>
+ * </ol>
+ *
+ * <p>Pre-fix, the always-true {@code severity >= 0} residual prunes drifted segments and the
+ * counts come in <em>below</em> ground truth. Post-fix every count matches exactly.
+ */
+public class SchemaDriftPruneNoMergeIT extends AnalyticsRestTestCase {
+
+    private static final String INDEX = "schema_drift_prune";
+    private static final String TARGET = "alpha";
+
+    // The bug is driven by per-segment dynamic-field WIDTH: the Java mapper's HashMap column
+    // order scatters `severity` to a different ordinal in each differently-sized segment,
+    // diverging from its first-seen ordinal in the union table schema, so the positional
+    // StatisticsConverter lookup reads the wrong/no column. Reproducing it reliably needs many
+    // segments of widely-varying width (smaller fixtures — e.g. 4 segments up to 150 fields —
+    // do not diverge enough and pass even without the fix). These values mirror the manual
+    // cluster reproduction (24 segments, dynamic widths up to ~300, multi-RG segments) and were
+    // verified to fail without the fix (match()+severity>=0 returned 6600 instead of 7200).
+
+    /** Each flush becomes one parquet segment; widths grow so per-segment field sets differ. */
+    private static final int SEGMENTS = 24;
+    /** Docs per segment. With row_group_max_rows small this yields multiple RGs per segment. */
+    private static final int DOCS_PER_SEGMENT = 500;
+    /** Matching (contain TARGET) docs per segment; the rest are non-matching. */
+    private static final int MATCHING_PER_SEGMENT = 300;
+    /** Widest segment's pad-field count. Segment s carries pad_0..pad_{W(s)-1}. */
+    private static final int MAX_PAD_FIELDS = 300;
+    /** Parquet row-group size — small so each segment has several row groups (multi-RG like prod). */
+    private static final int ROW_GROUP_MAX_ROWS = 100;
+
+    private static final String[] MATCHING_TEMPLATES = new String[] {
+        "bravo alpha charlie",
+        "delta alpha echo foxtrot",
+        "alpha golf hotel india",
+        "juliet kilo alpha lima" };
+
+    private static final String[] NON_MATCHING_TEMPLATES = new String[] {
+        "bravo charlie delta",
+        "echo foxtrot golf",
+        "hotel india juliet kilo",
+        "papa quebec romeo sierra" };
+
+    // Ground truth accumulated during ingest.
+    private long totalDocs = 0L;
+    private long totalMatching = 0L;
+
+    public void testStatsPruningCorrectUnderSchemaDrift() throws Exception {
+        createCompositeIndex();
+        seedDriftingSegments();
+
+        // 1) Numeric-filter-only: severity >= 0 is true for every doc → full count.
+        long filterOnly = scalarCount("source = " + INDEX + " | where severity >= 0 | stats count()");
+        assertEquals("numeric filter only (severity>=0) must not drop rows under schema drift", totalDocs, filterOnly);
+
+        // 2) Sort + limit (TopK): exercises the dynamic-filter prune path. head k over the
+        //    filtered set must return exactly min(k, totalDocs) rows, all with severity >= 0.
+        int k = 50;
+        List<List<Object>> topk = datarows(
+            executePpl("source = " + INDEX + " | where severity >= 0 | sort - severity | head " + k + " | fields severity")
+        );
+        assertEquals("sort+limit row count under schema drift", Math.min(k, (int) totalDocs), topk.size());
+        for (List<Object> r : topk) {
+            assertTrue("every returned row satisfies severity >= 0", num(r.get(0)) >= 0);
+        }
+
+        // 3) match() + numeric residual: the production shape. Lucene-delegated match() AND a
+        //    stats-pruned residual. Must equal the matching-doc ground truth.
+        long matchAndResidual = scalarCount(
+            "source = " + INDEX + " | where match(message, '" + TARGET + "') and severity >= 0 | stats count()"
+        );
+        assertEquals("match() AND severity>=0 must not drop rows under schema drift", totalMatching, matchAndResidual);
+
+        // Sanity: match() alone agrees with the residual-combined count (residual is always true).
+        long matchOnly = scalarCount("source = " + INDEX + " | where match(message, '" + TARGET + "') | stats count()");
+        assertEquals("match() alone equals match()+residual (residual is always true)", matchOnly, matchAndResidual);
+
+        // 4) match() + filter + sort + limit: all three prune paths together.
+        List<List<Object>> combined = datarows(
+            executePpl(
+                "source = " + INDEX + " | where match(message, '" + TARGET + "') and severity >= 0 "
+                    + "| sort - severity | head " + k + " | fields severity"
+            )
+        );
+        assertEquals("match()+filter+sort+limit row count under schema drift", Math.min(k, (int) totalMatching), combined.size());
+        for (List<Object> r : combined) {
+            assertTrue("every combined row satisfies severity >= 0", num(r.get(0)) >= 0);
+        }
+    }
+
+    // ── Setup / ingest ───────────────────────────────────────────────────────────
+
+    private void createCompositeIndex() throws IOException {
+        try {
+            client().performRequest(new Request("DELETE", "/" + INDEX));
+        } catch (Exception ignored) {
+            // index may not exist yet
+        }
+
+        // message + severity declared up front; dynamic:true (the default) lets pad_* fields
+        // be auto-mapped per segment, producing the schema drift this test depends on.
+        // total_fields.limit is raised to admit the ~300 dynamic pad fields; row_group_max_rows
+        // is small so each segment has several row groups.
+        String body = "{"
+            + "\"settings\": {"
+            + "  \"number_of_shards\": 1,"
+            + "  \"number_of_replicas\": 0,"
+            + "  \"index.mapping.total_fields.limit\": 2000,"
+            + "  \"index.parquet.row_group_max_rows\": " + ROW_GROUP_MAX_ROWS + ","
+            + "  \"index.pluggable.dataformat.enabled\": true,"
+            + "  \"index.pluggable.dataformat\": \"composite\","
+            + "  \"index.composite.primary_data_format\": \"parquet\","
+            + "  \"index.composite.secondary_data_formats\": \"lucene\""
+            + "},"
+            + "\"mappings\": {"
+            + "  \"dynamic\": true,"
+            + "  \"properties\": {"
+            + "    \"message\": { \"type\": \"text\" },"
+            + "    \"severity\": { \"type\": \"byte\" }"
+            + "  }"
+            + "}"
+            + "}";
+
+        Request createIndex = new Request("PUT", "/" + INDEX);
+        createIndex.setJsonEntity(body);
+        Map<String, Object> response = assertOkAndParse(client().performRequest(createIndex), "create index");
+        assertEquals(true, response.get("acknowledged"));
+
+        Request health = new Request("GET", "/_cluster/health/" + INDEX);
+        health.addParameter("wait_for_status", "green");
+        health.addParameter("timeout", "30s");
+        client().performRequest(health);
+    }
+
+    /**
+     * Seeds {@link #SEGMENTS} segments of growing width. Segment {@code s} writes documents
+     * carrying {@code pad_0..pad_{W(s)-1}} dynamically-mapped numeric fields, where {@code W(s)}
+     * grows from a few fields up to {@link #MAX_PAD_FIELDS}. Successive segments therefore have
+     * different-sized field sets → divergent per-segment HashMap column order → {@code severity}
+     * drifts to a different ordinal than its union-schema ordinal. Every doc has a non-negative
+     * {@code severity}, so {@code severity >= 0} is always true and must never prune.
+     */
+    private void seedDriftingSegments() throws IOException {
+        for (int s = 0; s < SEGMENTS; s++) {
+            int width = padWidthForSegment(s);
+            StringBuilder bulk = new StringBuilder(DOCS_PER_SEGMENT * 64);
+            for (int i = 0; i < DOCS_PER_SEGMENT; i++) {
+                boolean matching = i < MATCHING_PER_SEGMENT;
+                String message = matching
+                    ? MATCHING_TEMPLATES[i % MATCHING_TEMPLATES.length]
+                    : NON_MATCHING_TEMPLATES[i % NON_MATCHING_TEMPLATES.length];
+                // severity in 0..17, always non-negative.
+                int severity = (i % 18);
+
+                StringBuilder doc = new StringBuilder();
+                doc.append("{\"message\":\"").append(escapeJson(message)).append("\"");
+                doc.append(",\"severity\":").append(severity);
+                // Pad values are strongly NEGATIVE so that if `severity` misresolves onto a
+                // pad column (positional drift), the wrong column's max < 0 makes the always-true
+                // `severity >= 0` evaluate to "cannot match" → the RG/segment is wrongly pruned.
+                // (With non-negative pads, a misresolution onto a pad would still satisfy
+                // severity >= 0 and silently hide the bug.)
+                for (int p = 0; p < width; p++) {
+                    doc.append(",\"pad_").append(p).append("\":").append(-1000000 - p);
+                }
+                doc.append("}");
+
+                bulk.append("{\"index\":{}}\n");
+                bulk.append(doc).append("\n");
+            }
+
+            Request req = new Request("POST", "/" + INDEX + "/_bulk");
+            req.setJsonEntity(bulk.toString());
+            Map<String, Object> parsed = assertOkAndParse(client().performRequest(req), "bulk segment " + s);
+            assertFalse("bulk errors in segment " + s + ": " + parsed, Boolean.TRUE.equals(parsed.get("errors")));
+
+            totalDocs += DOCS_PER_SEGMENT;
+            totalMatching += MATCHING_PER_SEGMENT;
+
+            refresh();
+            flush(); // force a parquet segment write; merge is disabled on this cluster variant
+        }
+    }
+
+    /** Growing pad width per segment: a few fields in segment 0 up to MAX_PAD_FIELDS in the last. */
+    private static int padWidthForSegment(int s) {
+        int w = (int) (((long) (s + 1) * MAX_PAD_FIELDS) / SEGMENTS);
+        return Math.max(1, Math.min(MAX_PAD_FIELDS, w));
+    }
+
+    // ── REST helpers ───────────────────────────────────────────────────────────────
+
+    private void refresh() throws IOException {
+        client().performRequest(new Request("POST", "/" + INDEX + "/_refresh"));
+    }
+
+    private void flush() throws IOException {
+        Request req = new Request("POST", "/" + INDEX + "/_flush");
+        req.addParameter("force", "true");
+        client().performRequest(req);
+    }
+
+    private long scalarCount(String ppl) throws IOException {
+        Request req = new Request("POST", "/_plugins/_ppl");
+        req.setJsonEntity("{\"query\": \"" + escapeJson(ppl) + "\"}");
+        Response resp = client().performRequest(req);
+        Map<String, Object> parsed = assertOkAndParse(resp, "PPL: " + ppl);
+        List<List<Object>> rows = datarows(parsed);
+        assertNotNull("PPL response missing datarows for: " + ppl, rows);
+        assertEquals("scalar count should return exactly 1 row for: " + ppl, 1, rows.size());
+        assertEquals("scalar count should return exactly 1 column for: " + ppl, 1, rows.get(0).size());
+        Object v = rows.get(0).get(0);
+        assertNotNull("scalar count value must not be null for: " + ppl, v);
+        return ((Number) v).longValue();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<List<Object>> datarows(Map<String, Object> result) {
+        return (List<List<Object>>) result.get("datarows");
+    }
+
+    private static double num(Object cell) {
+        return ((Number) cell).doubleValue();
+    }
+}


### PR DESCRIPTION
### Description

Row-group / page statistics pruning in the composite indexed-parquet scan resolved `StatisticsConverter` against the **full union table schema**. `StatisticsConverter` maps a column name to a parquet leaf **positionally** (parquet crate `parquet_column`): it finds the column's ordinal in the arrow schema it is handed and indexes into the parquet file by that ordinal.

Under **dynamic-mapping schema drift** — where a segment's own parquet schema is narrower or reordered relative to the union schema — that ordinal lands on the wrong leaf, or off the end of the file. The converter then returns all-null / wrong-column statistics, and an always-true residual such as `severity >= 0` evaluates to *"cannot match"*, so the whole row group / segment is wrongly pruned and matching rows are **silently dropped** (e.g. `match('…') AND severity >= 0` returned far fewer rows than `match('…')` alone).

### Fix

Resolve statistics against each **segment's own** parquet schema, reconstructed from its footer via `parquet_to_arrow_schema(descr, kv)`, at all three stats-resolution sites:

- `page_pruner.rs` `eval_leaf` — RG-level / whole-segment prune
- `page_pruner.rs` `PagePruner::prune_rg` — page-level prune
- `dynamic_filter.rs` `RgPruningContext::rg_provably_excluded` — dynamic-filter prefetch prune

The `PruningPredicate` is still built against the table schema (its column refs are table-schema relative); only the stats-extraction step — mapping a name to a physical leaf — uses the segment schema. Falls back to the table schema if footer conversion fails.

### Testing

- Two Rust unit tests (one per fixed file) build a fixture where the filter column resolves positionally onto a different real column and assert the row group is not pruned.
- `SchemaDriftPrunePplIT`: end-to-end REST IT over a composite index with a Lucene secondary and dynamic mapping, run under a new `integTestNoMerge` cluster variant. Asserts numeric-filter-only, sort+limit, `match() + numeric residual`, and `match() + filter + sort + limit` all return correct counts under schema drift.

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [ ] API changes companion pull request created, if applicable.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.