### PR TITLE
Gate Rust log macros on level to avoid format! on hot path

### DIFF
--- a/sandbox/libs/dataformat-native/rust/common/src/logger.rs
+++ b/sandbox/libs/dataformat-native/rust/common/src/logger.rs
@@ -10,13 +10,22 @@
 //!
 //! Java registers a function pointer at startup via `native_logger_init`.
 //! Rust calls that pointer to log. No JNI.
+//!
+//! Level short-circuit: the `log_debug!`/`log_info!` macros gate on a Rust-side
+//! atomic level BEFORE `format!`, so a suppressed log costs only one relaxed
+//! atomic load + branch — no string allocation, no FFM crossing. Java keeps
+//! this atomic in sync via `native_logger_set_level`.
 
-use std::sync::atomic::{AtomicPtr, Ordering};
+use std::sync::atomic::{AtomicI32, AtomicPtr, Ordering};
 
 /// Callback signature: `void log(int level, const char* msg, long msg_len)`
 type LogCallback = unsafe extern "C" fn(i32, *const u8, i64);
 
 static LOG_CALLBACK: AtomicPtr<()> = AtomicPtr::new(std::ptr::null_mut());
+
+/// Minimum level that will be formatted + forwarded to Java. Defaults to Info
+/// so `log_debug!` is suppressed until Java enables DEBUG.
+static MAX_LEVEL: AtomicI32 = AtomicI32::new(LogLevel::Info as i32);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(i32)]
@@ -24,6 +33,20 @@ pub enum LogLevel {
     Debug = 0,
     Info = 1,
     Error = 2,
+}
+
+/// True if a message at `level` would be emitted. Cheap (one relaxed load).
+#[inline]
+pub fn enabled(level: LogLevel) -> bool {
+    (level as i32) >= MAX_LEVEL.load(Ordering::Relaxed)
+}
+
+/// Set the minimum forwarded log level. Called by Java at init and whenever the
+/// logger level changes dynamically.
+#[no_mangle]
+pub extern "C" fn native_logger_set_level(level: i32) {
+    let clamped = level.clamp(LogLevel::Debug as i32, LogLevel::Error as i32);
+    MAX_LEVEL.store(clamped, Ordering::Relaxed);
 }
 
 /// Called by Java at startup to register the log callback.
@@ -46,20 +69,26 @@ pub fn log(level: LogLevel, message: &str) {
 #[macro_export]
 macro_rules! log_debug {
     ($($arg:tt)*) => {
-        $crate::logger::log($crate::logger::LogLevel::Debug, &format!($($arg)*))
+        if $crate::logger::enabled($crate::logger::LogLevel::Debug) {
+            $crate::logger::log($crate::logger::LogLevel::Debug, &format!($($arg)*))
+        }
     };
 }
 
 #[macro_export]
 macro_rules! log_info {
     ($($arg:tt)*) => {
-        $crate::logger::log($crate::logger::LogLevel::Info, &format!($($arg)*))
+        if $crate::logger::enabled($crate::logger::LogLevel::Info) {
+            $crate::logger::log($crate::logger::LogLevel::Info, &format!($($arg)*))
+        }
     };
 }
 
 #[macro_export]
 macro_rules! log_error {
     ($($arg:tt)*) => {
-        $crate::logger::log($crate::logger::LogLevel::Error, &format!($($arg)*))
+        if $crate::logger::enabled($crate::logger::LogLevel::Error) {
+            $crate::logger::log($crate::logger::LogLevel::Error, &format!($($arg)*))
+        }
     };
 }

--- a/sandbox/libs/dataformat-native/src/main/java/org/opensearch/nativebridge/spi/NativeLibraryLoader.java
+++ b/sandbox/libs/dataformat-native/src/main/java/org/opensearch/nativebridge/spi/NativeLibraryLoader.java
@@ -63,8 +63,10 @@ public final class NativeLibraryLoader {
                 LOOKUP.find("native_error_free").orElseThrow(),
                 FunctionDescriptor.ofVoid(ValueLayout.JAVA_LONG)
             );
-            // Register the Rust→Java log callback
+            // Register the Rust→Java log callback, then push the active log level
+            // so the logging macros short-circuit `format!` for suppressed levels.
             LOOKUP.find("native_logger_init").ifPresent(sym -> RustLoggerBridge.register(linker, sym));
+            LOOKUP.find("native_logger_set_level").ifPresent(sym -> RustLoggerBridge.registerSetLevel(linker, sym));
         }
     }
 

--- a/sandbox/libs/dataformat-native/src/main/java/org/opensearch/nativebridge/spi/RustLoggerBridge.java
+++ b/sandbox/libs/dataformat-native/src/main/java/org/opensearch/nativebridge/spi/RustLoggerBridge.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.nativebridge.spi;
 
+import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -27,18 +28,23 @@ import java.nio.charset.StandardCharsets;
  * <p>At startup, {@link NativeLibraryLoader} registers {@link #log} as a function pointer
  * with the native library. Rust calls it directly — no JNI.
  *
- * <p>TODO: the Rust {@code log_debug!} / {@code log_info!} macros currently format
- * their message ({@code format!(...)}) unconditionally and only filter by level here,
- * after the FFM call lands. Hot-path debug sites pay the formatting + allocation cost
- * regardless of whether debug is enabled on the Java side. Expose the active log
- * level from Java back to Rust (e.g. an atomic refreshed on level changes) so the
- * macros can short-circuit before {@code format!} runs. Until then, hot-path Rust
- * call sites either need to be commented out (see {@code single_collector.rs}) or
- * gated with a manual level check.
+ * <p>Level short-circuit: the Rust {@code log_debug!}/{@code log_info!} macros gate on a
+ * Rust-side atomic level BEFORE {@code format!}, so a suppressed log costs only an atomic
+ * load + branch (no string allocation, no FFM crossing). Java keeps that atomic in sync
+ * via {@link #pushLevel()} — called at registration and re-pushed on every upcall if the
+ * level has drifted (detecting dynamic changes from {@code _cluster/settings}).
  */
 public class RustLoggerBridge {
 
     private static final Logger logger = LogManager.getLogger(RustLoggerBridge.class);
+
+    /** Level codes shared with Rust's {@code LogLevel}: 0=Debug, 1=Info, 2=Error. */
+    private static final int LEVEL_DEBUG = 0;
+    private static final int LEVEL_INFO = 1;
+    private static final int LEVEL_ERROR = 2;
+
+    /** Bound downcall to Rust's {@code native_logger_set_level(int)}; null until registered. */
+    private static volatile MethodHandle setLevelHandle;
 
     /**
      * Called from Rust via the registered function pointer.
@@ -72,6 +78,48 @@ public class RustLoggerBridge {
         } catch (Throwable t) {
             logger.error("Failed to register native logger callback", t);
         }
+    }
+
+    /**
+     * Binds Rust's {@code native_logger_set_level(int)} and pushes the current level.
+     * Called once by {@link NativeLibraryLoader} after {@link #register}.
+     * Dynamic level changes are handled by a cluster settings listener that calls
+     * {@link #pushLevel()} when any {@code logger.*} setting is updated.
+     */
+    static void registerSetLevel(Linker linker, MemorySegment setLevelSymbol) {
+        try {
+            setLevelHandle = linker.downcallHandle(setLevelSymbol, FunctionDescriptor.ofVoid(ValueLayout.JAVA_INT));
+            pushLevel();
+        } catch (Throwable t) {
+            logger.error("Failed to register native logger set-level callback", t);
+        }
+    }
+
+    /**
+     * Push this class's current Log4j level to Rust so the macros short-circuit
+     * suppressed levels. Called at registration and by the cluster settings listener.
+     */
+    public static void pushLevel() {
+        MethodHandle handle = setLevelHandle;
+        if (handle == null) {
+            return;
+        }
+        int level = toRustLevel(logger.getLevel());
+        try {
+            handle.invokeExact(level);
+        } catch (Throwable t) {
+            logger.error("Failed to push native log level", t);
+        }
+    }
+
+    /** Map a Log4j {@link Level} to the Rust LogLevel int (0=Debug, 1=Info, 2=Error). */
+    private static int toRustLevel(Level level) {
+        if (level.intLevel() >= Level.DEBUG.intLevel()) {
+            return LEVEL_DEBUG;
+        } else if (level.intLevel() >= Level.INFO.intLevel()) {
+            return LEVEL_INFO;
+        }
+        return LEVEL_ERROR;
     }
 
     private RustLoggerBridge() {}

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionPlugin.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionPlugin.java
@@ -24,6 +24,7 @@ import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.node.DiscoveryNodes;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.Nullable;
+import org.opensearch.common.logging.Loggers;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.IndexScopedSettings;
 import org.opensearch.common.settings.Setting;
@@ -45,6 +46,7 @@ import org.opensearch.index.engine.exec.EngineReaderManager;
 import org.opensearch.indices.breaker.BreakerSettings;
 import org.opensearch.monitor.os.OsProbe;
 import org.opensearch.nativebridge.spi.NativeMemoryFetcher;
+import org.opensearch.nativebridge.spi.RustLoggerBridge;
 import org.opensearch.node.resource.tracker.ResourceTrackerSettings;
 import org.opensearch.plugin.stats.AnalyticsBackendNativeMemoryStats;
 import org.opensearch.plugin.stats.AnalyticsBackendTaskCancellationStats;
@@ -448,6 +450,11 @@ public class DataFusionPlugin extends Plugin
             .addSettingsUpdateConsumer(DATAFUSION_MEMORY_GUARD_ADMISSION_THROTTLE_THRESHOLD, v -> updateMemoryGuardThresholds());
         clusterService.getClusterSettings()
             .addSettingsUpdateConsumer(DATAFUSION_MEMORY_GUARD_ADMISSION_REJECT_THRESHOLD, v -> updateMemoryGuardThresholds());
+
+        // Push Rust log level whenever any logger.* cluster setting changes, so Rust macros
+        // can short-circuit format!() for suppressed levels without polling.
+        clusterService.getClusterSettings()
+            .addAffixUpdateConsumer(Loggers.LOG_LEVEL_SETTING, (namespace, level) -> RustLoggerBridge.pushLevel(), (k, v) -> {});
         clusterService.getClusterSettings()
             .addSettingsUpdateConsumer(DATAFUSION_MEMORY_GUARD_EXECUTION_SPILL_THRESHOLD, v -> updateMemoryGuardThresholds());
         clusterService.getClusterSettings()


### PR DESCRIPTION
## Summary

Rust `log_debug!`/`log_info!` macros unconditionally call `format!(...)` before the FFM upcall to Java, paying string allocation + formatting cost even when the log level is suppressed on the Java side. On hot paths (per-row-group, per-segment), this is a measurable overhead.

## Changes

These changes register  a cluster settings listener via `addAffixUpdateConsumer(Loggers.LOG_LEVEL_SETTING, ...)`. Whenever the log level is modified in cluster settings we use rust down call `RustLoggerBridge.pushLevel()` to update atomic static `MAX_LEVEL`. When log level is higher than `MAX_LEVEL` skip `format!` call entirely and short circuit the log.

## Testing

Manually tested.

1. Start single-node cluster with analytics-backend-datafusion plugin, delegation-enabled index (keyword field with Lucene secondary format).
2. Query at default log level (INFO). Confirm no debug logs.
3. Enable debug logs.
```
 PUT /_cluster/settings
  {"transient": {"logger.org.opensearch.nativebridge.spi.RustLoggerBridge": "DEBUG"}}
```
4. Re-run query, observe debug logs in output.
```
  [2026-06-17T20:40:42,804][INFO ][o.o.c.s.ClusterSettings  ] [integTest-0] updating [logger.org.opensearch.nativebridge.spi.RustLoggerBridge] from [INFO] to [DEBUG]
  [2026-06-17T20:40:45,440][DEBUG][o.o.n.s.RustLoggerBridge ] [integTest-0] create_session_context: registered table 'logtest_delegation' with file_sort_order_keys=0
  [2026-06-17T20:40:45,441][DEBUG][o.o.n.s.RustLoggerBridge ] [integTest-0] DataFusion logical plan:
  [2026-06-17T20:40:45,441][DEBUG][o.o.n.s.RustLoggerBridge ] [integTest-0] DataFusion physical plan:
  [2026-06-17T20:40:45,442][DEBUG][o.o.n.s.RustLoggerBridge ] [integTest-0] [scf-rust] lazy provider initialized context_id=49 annotation_id=0 provider_key=1
  [2026-06-17T20:40:45,443][DEBUG][o.o.n.s.RustLoggerBridge ] [integTest-0] [scf-segment-done] file=_parquet_file_generation_1.parquet row_groups=1 elapsed=1.073266ms
```