### PR TITLE
Return 400 for unsupported functions in analytics engine

### DIFF
--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/UnsupportedFunctionException.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/UnsupportedFunctionException.java
@@ -1,0 +1,28 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.planner;
+
+import org.opensearch.OpenSearchException;
+import org.opensearch.core.rest.RestStatus;
+
+/**
+ * Thrown when a query uses a function that is not currently supported by the analytics engine.
+ * Maps to HTTP 400 (Bad Request) since this is a user error, not a server error.
+ */
+public class UnsupportedFunctionException extends OpenSearchException {
+
+    public UnsupportedFunctionException(String functionName, String context) {
+        super("Function [" + functionName + "] is not currently supported" + (context != null ? " " + context : ""));
+    }
+
+    @Override
+    public RestStatus status() {
+        return RestStatus.BAD_REQUEST;
+    }
+}

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchAggregateRule.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchAggregateRule.java
@@ -19,6 +19,7 @@ import org.apache.logging.log4j.Logger;
 import org.opensearch.analytics.planner.CapabilityRegistry;
 import org.opensearch.analytics.planner.PlannerContext;
 import org.opensearch.analytics.planner.RelNodeUtils;
+import org.opensearch.analytics.planner.UnsupportedFunctionException;
 import org.opensearch.analytics.planner.rel.AggregateCallAnnotation;
 import org.opensearch.analytics.planner.rel.AggregateMode;
 import org.opensearch.analytics.planner.rel.OpenSearchAggregate;
@@ -87,7 +88,7 @@ public class OpenSearchAggregateRule extends RelOptRule {
             AggregateCall aggCall = aggCalls.get(i);
             List<String> callViable = resolveViableBackendsForCall(aggCall, childFieldStorage);
             if (callViable.isEmpty()) {
-                throw new IllegalStateException("No backend supports aggregate function [" + aggCall.getAggregation().getName() + "]");
+                throw new UnsupportedFunctionException(aggCall.getAggregation().getName(), "as an aggregate function");
             }
             callAnnotations.put(i, new AggregateCallAnnotation(callViable, context.nextAnnotationId()));
         }
@@ -97,12 +98,7 @@ public class OpenSearchAggregateRule extends RelOptRule {
 
         if (viableBackends.isEmpty()) {
             List<String> funcNames = aggCalls.stream().map(aggCall -> aggCall.getAggregation().getName()).toList();
-            throw new IllegalStateException(
-                "No backend can execute aggregate: functions "
-                    + funcNames
-                    + " not supported by any viable backend among "
-                    + childViableBackends
-            );
+            throw new UnsupportedFunctionException(funcNames.toString(), "as aggregate functions in combination");
         }
 
         LOGGER.debug("Aggregate viable backends: {} (child viable: {})", viableBackends, childViableBackends);

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchProjectRule.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchProjectRule.java
@@ -20,6 +20,7 @@ import org.apache.calcite.sql.SqlFunction;
 import org.opensearch.analytics.planner.CapabilityRegistry;
 import org.opensearch.analytics.planner.PlannerContext;
 import org.opensearch.analytics.planner.RelNodeUtils;
+import org.opensearch.analytics.planner.UnsupportedFunctionException;
 import org.opensearch.analytics.planner.rel.AnnotatedProjectExpression;
 import org.opensearch.analytics.planner.rel.OpenSearchProject;
 import org.opensearch.analytics.planner.rel.OpenSearchRelNode;
@@ -91,7 +92,11 @@ public class OpenSearchProjectRule extends RelOptRule {
         }
 
         if (viableBackends.isEmpty()) {
-            throw new IllegalStateException("No backend can execute all project expressions among " + childViableBackends);
+            List<String> funcNames = annotatedExprs.stream()
+                .filter(e -> e instanceof RexCall)
+                .map(e -> ((RexCall) e).getOperator().getName())
+                .toList();
+            throw new UnsupportedFunctionException(funcNames.toString(), "in combination in this query");
         }
 
         call.transformTo(
@@ -131,7 +136,7 @@ public class OpenSearchProjectRule extends RelOptRule {
             if (isOpaqueOperation(funcName)) {
                 List<String> exprViable = resolveOpaqueViableBackends(funcName, childViableBackends);
                 if (exprViable.isEmpty()) {
-                    throw new IllegalStateException("No backend can evaluate [" + funcName + "] and no delegation path exists");
+                    throw new UnsupportedFunctionException(funcName, null);
                 }
                 return new AnnotatedProjectExpression(rexCall.getType(), rexCall, exprViable, context.nextAnnotationId());
             }
@@ -142,7 +147,7 @@ public class OpenSearchProjectRule extends RelOptRule {
         if (scalarViable.isEmpty()) {
             ScalarFunction resolved = ScalarFunction.fromSqlOperatorWithFallback(rexCall.getOperator());
             String label = resolved != null ? resolved.name() : rexCall.getOperator().getName();
-            throw new IllegalStateException("No backend supports scalar function [" + label + "] among " + childViableBackends);
+            throw new UnsupportedFunctionException(label, "as a scalar function");
         }
 
         // Recurse into operands
@@ -291,7 +296,7 @@ public class OpenSearchProjectRule extends RelOptRule {
                 public RexNode visitOver(RexOver over) {
                     WindowFunction fn = WindowFunction.resolveFunction(over.getAggOperator());
                     if (fn == null) {
-                        throw new IllegalStateException("Window function [" + over.getAggOperator().getName() + "] is not supported");
+                        throw new UnsupportedFunctionException(over.getAggOperator().getName(), "as a window function");
                     }
                     fns.add(fn);
                     return super.visitOver(over);
@@ -316,7 +321,7 @@ public class OpenSearchProjectRule extends RelOptRule {
             if (covers) out.add(backend);
         }
         if (out.isEmpty()) {
-            throw new IllegalStateException("No backend supports window functions " + required + " among " + candidates);
+            throw new UnsupportedFunctionException(required.toString(), "as window functions");
         }
         return out;
     }

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/AggregateRuleTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/AggregateRuleTests.java
@@ -103,8 +103,11 @@ public class AggregateRuleTests extends BasePlannerRulesTests {
             }
         };
         PlannerContext context = buildContext("parquet", 1, intFields(), List.of(noAggFunctions));
-        IllegalStateException exception = expectThrows(IllegalStateException.class, () -> runPlanner(makeAggregate(sumCall()), context));
-        assertTrue(exception.getMessage().contains("No backend supports aggregate function"));
+        UnsupportedFunctionException exception = expectThrows(
+            UnsupportedFunctionException.class,
+            () -> runPlanner(makeAggregate(sumCall()), context)
+        );
+        assertTrue(exception.getMessage().contains("is not currently supported"));
     }
 
     public void testAggregateViableBackendsIntersection() {
@@ -270,11 +273,11 @@ public class AggregateRuleTests extends BasePlannerRulesTests {
             // No acceptedDelegations() override → delegation is refused.
         };
         PlannerContext context = buildContext("parquet", 1, intFields(), List.of(dfNoSum, luceneWithSum));
-        IllegalStateException exception = expectThrows(
-            IllegalStateException.class,
+        UnsupportedFunctionException exception = expectThrows(
+            UnsupportedFunctionException.class,
             () -> runPlanner(makeMultiCallAggregate(sumCall(), stddevCall()), context)
         );
-        assertTrue(exception.getMessage().contains("No backend supports aggregate function"));
+        assertTrue(exception.getMessage().contains("is not currently supported"));
     }
 
     // ---- Helpers ----

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/ProjectRuleTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/ProjectRuleTests.java
@@ -118,8 +118,8 @@ public class ProjectRuleTests extends BasePlannerRulesTests {
         LogicalProject project = LogicalProject.create(stubScan(table), List.of(), List.of(ceilExpr), List.of("ceil_v"));
         PlannerContext context = buildContext("parquet", nameValueFields(), List.of(new MockDataFusionBackend(), LUCENE));
 
-        IllegalStateException exception = expectThrows(IllegalStateException.class, () -> runPlanner(project, context));
-        assertTrue(exception.getMessage().contains("No backend supports scalar function"));
+        UnsupportedFunctionException exception = expectThrows(UnsupportedFunctionException.class, () -> runPlanner(project, context));
+        assertTrue(exception.getMessage().contains("is not currently supported"));
     }
 
     // ---- Scalar functions ----
@@ -154,8 +154,8 @@ public class ProjectRuleTests extends BasePlannerRulesTests {
         LogicalProject project = LogicalProject.create(stubScan(table), List.of(), List.of(ceilExpr), List.of("casted"));
         PlannerContext context = buildContext("parquet", nameValueFields());
 
-        IllegalStateException exception = expectThrows(IllegalStateException.class, () -> runPlanner(project, context));
-        assertTrue(exception.getMessage().contains("No backend supports scalar function"));
+        UnsupportedFunctionException exception = expectThrows(UnsupportedFunctionException.class, () -> runPlanner(project, context));
+        assertTrue(exception.getMessage().contains("is not currently supported"));
     }
 
     /**
@@ -218,8 +218,8 @@ public class ProjectRuleTests extends BasePlannerRulesTests {
             List.of(DATAFUSION, luceneWithPainless)
         );
 
-        IllegalStateException exception = expectThrows(IllegalStateException.class, () -> runPlanner(project, context));
-        assertTrue(exception.getMessage().contains("no delegation path exists"));
+        UnsupportedFunctionException exception = expectThrows(UnsupportedFunctionException.class, () -> runPlanner(project, context));
+        assertTrue(exception.getMessage().contains("is not currently supported"));
     }
 
     public void testMixedFieldAndPainlessWithDelegation() {
@@ -384,10 +384,10 @@ public class ProjectRuleTests extends BasePlannerRulesTests {
             List.of("name", "rn")
         );
         PlannerContext context = buildContext("parquet", nameValueFields(), List.of(dfNoWindow, LUCENE));
-        IllegalStateException exception = expectThrows(IllegalStateException.class, () -> runPlanner(project, context));
+        UnsupportedFunctionException exception = expectThrows(UnsupportedFunctionException.class, () -> runPlanner(project, context));
         assertTrue(
             "Expected planner to surface window-function capability gap, got: " + exception.getMessage(),
-            exception.getMessage().contains("No backend supports window functions") && exception.getMessage().contains("ROW_NUMBER")
+            exception.getMessage().contains("ROW_NUMBER") && exception.getMessage().contains("is not currently supported")
         );
     }
 
@@ -599,8 +599,8 @@ public class ProjectRuleTests extends BasePlannerRulesTests {
             List.of(dfWithDelegation, luceneAccepting, thirdBackend)
         );
 
-        IllegalStateException exception = expectThrows(IllegalStateException.class, () -> runPlanner(project, context));
-        assertTrue(exception.getMessage().contains("no delegation path exists"));
+        UnsupportedFunctionException exception = expectThrows(UnsupportedFunctionException.class, () -> runPlanner(project, context));
+        assertTrue(exception.getMessage().contains("is not currently supported"));
     }
 
     public void testDelegationFailsWhenAcceptorRejectsDelegationType() {
@@ -627,8 +627,8 @@ public class ProjectRuleTests extends BasePlannerRulesTests {
             List.of(dfWithDelegation, luceneWithPainlessNoAccept)
         );
 
-        IllegalStateException exception = expectThrows(IllegalStateException.class, () -> runPlanner(project, context));
-        assertTrue(exception.getMessage().contains("no delegation path exists"));
+        UnsupportedFunctionException exception = expectThrows(UnsupportedFunctionException.class, () -> runPlanner(project, context));
+        assertTrue(exception.getMessage().contains("is not currently supported"));
     }
 
     // ---- Composed pipeline shapes ----

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/UnsupportedFunctionIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/UnsupportedFunctionIT.java
@@ -1,0 +1,69 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.qa;
+
+import org.opensearch.client.Request;
+import org.opensearch.client.ResponseException;
+import org.opensearch.test.rest.OpenSearchRestTestCase;
+
+import java.io.IOException;
+
+/**
+ * Integration tests verifying that unsupported functions return HTTP 400
+ * with a user-friendly error message.
+ */
+public class UnsupportedFunctionIT extends OpenSearchRestTestCase {
+
+    private static boolean provisioned = false;
+
+    @Override
+    protected boolean preserveIndicesUponCompletion() {
+        return true;
+    }
+
+    private void ensureProvisioned() throws IOException {
+        if (provisioned == false) {
+            DatasetProvisioner.provision(client(), new Dataset("calcs", "calcs"));
+            provisioned = true;
+        }
+    }
+
+    public void testUnsupportedScalarFunctionReturns400() throws Exception {
+        ensureProvisioned();
+
+        ResponseException e = expectThrows(ResponseException.class, () -> {
+            Request r = new Request("POST", "/_analytics/ppl");
+            r.setJsonEntity("{\"query\": \"source=calcs | eval x = MATCH(str0, 'hello')\"}");
+            client().performRequest(r);
+        });
+
+        assertEquals(400, e.getResponse().getStatusLine().getStatusCode());
+        String body = new String(e.getResponse().getEntity().getContent().readAllBytes(), java.nio.charset.StandardCharsets.UTF_8);
+        assertTrue("error type should be unsupported_function_exception: " + body,
+            body.contains("unsupported_function_exception"));
+        assertTrue("error should mention function name MATCH: " + body,
+            body.contains("Function [MATCH] is not currently supported"));
+    }
+
+    public void testUnsupportedScalarDoesNotLeakBackendNames() throws Exception {
+        ensureProvisioned();
+
+        ResponseException e = expectThrows(ResponseException.class, () -> {
+            Request r = new Request("POST", "/_analytics/ppl");
+            r.setJsonEntity("{\"query\": \"source=calcs | eval x = MATCH(str0, 'hello')\"}");
+            client().performRequest(r);
+        });
+
+        String body = new String(e.getResponse().getEntity().getContent().readAllBytes(), java.nio.charset.StandardCharsets.UTF_8);
+        assertFalse("error should not mention internal backend 'datafusion': " + body,
+            body.contains("datafusion"));
+        assertFalse("error should not mention internal backend 'lucene': " + body,
+            body.contains("lucene"));
+    }
+}


### PR DESCRIPTION
## Summary

When a query uses a function not supported by the analytics engine, the error now returns HTTP 400 with a clear message instead of a 500 internal server error.

**Before:**
```json
{"status": 500, "error": {"type": "illegal_state_exception", "reason": "No backend supports scalar function [MATCH] among [lucene, datafusion]"}}
```

**After:**
```json
{"status": 400, "error": {"type": "unsupported_function_exception", "reason": "Function [MATCH] is not currently supported as a scalar function"}}
```

## Changes

- Add `UnsupportedFunctionException` (extends `OpenSearchException`, returns `RestStatus.BAD_REQUEST`)