### PR TITLE
[analytics-engine] Persist delegation blocklist defaults to cluster state

### DIFF
--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/AnalyticsPlugin.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/AnalyticsPlugin.java
@@ -15,6 +15,7 @@ import org.apache.calcite.sql.util.SqlOperatorTables;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.action.ActionRequest;
+import org.opensearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest;
 import org.opensearch.analytics.exec.AnalyticsFragmentSlowLog;
 import org.opensearch.analytics.exec.AnalyticsSearchService;
 import org.opensearch.analytics.exec.AnalyticsSearchSlowLog;
@@ -28,7 +29,10 @@ import org.opensearch.analytics.exec.action.AnalyticsQueryAction;
 import org.opensearch.analytics.planner.CapabilityRegistry;
 import org.opensearch.analytics.planner.FieldStorageResolver;
 import org.opensearch.analytics.schema.OpenSearchSchemaBuilder;
+import org.opensearch.analytics.settings.AnalyticsQuerySettings;
 import org.opensearch.analytics.spi.AnalyticsSearchBackendPlugin;
+import org.opensearch.analytics.spi.DelegationType;
+import org.opensearch.analytics.spi.ScalarFunction;
 import org.opensearch.analytics.stats.AnalyticsStats;
 import org.opensearch.analytics.stats.AnalyticsStatsCollector;
 import org.opensearch.analytics.stats.RestAnalyticsStatsAction;
@@ -36,7 +40,9 @@ import org.opensearch.analytics.stats.transport.AnalyticsStatsAction;
 import org.opensearch.analytics.stats.transport.TransportAnalyticsStatsAction;
 import org.opensearch.arrow.allocator.ArrowNativeAllocator;
 import org.opensearch.arrow.spi.NativeAllocatorPoolConfig;
+import org.opensearch.cluster.ClusterChangedEvent;
 import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.ClusterStateListener;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.node.DiscoveryNodes;
 import org.opensearch.cluster.service.ClusterService;
@@ -47,6 +53,7 @@ import org.opensearch.common.settings.IndexScopedSettings;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.settings.SettingsFilter;
+import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.action.ActionResponse;
 import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
@@ -73,6 +80,7 @@ import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Supplier;
 
 /**
@@ -192,6 +200,8 @@ public class AnalyticsPlugin extends Plugin implements ExtensiblePlugin, ActionP
             nativeAllocator.getPoolAllocator(NativeAllocatorPoolConfig.POOL_QUERY).newChildAllocator("coordinator", 0, Long.MAX_VALUE)
         );
 
+        seedDelegationBlockListDefaults(client, clusterService, capabilityRegistry);
+
         return List.of(searchService, ctx, capabilityRegistry, coordinatorAllocatorHandle, analyticsSearchSlowLog, statsCollector);
     }
 
@@ -264,6 +274,44 @@ public class AnalyticsPlugin extends Plugin implements ExtensiblePlugin, ActionP
         }
         SearchStats.Stats stats = new SearchStats.Stats.Builder().queryCount(elapsed.count()).queryTimeInMillis(elapsed.sumMs()).build();
         return new SearchStats(stats, 0, null);
+    }
+
+    private void seedDelegationBlockListDefaults(Client client, ClusterService clusterService, CapabilityRegistry registry) {
+        clusterService.addListener(new ClusterStateListener() {
+            @Override
+            public void clusterChanged(ClusterChangedEvent event) {
+                if (event.state().nodes().isLocalNodeElectedClusterManager() == false) return;
+                clusterService.removeListener(this);
+
+                Settings persistent = event.state().metadata().persistentSettings();
+                for (String acceptor : registry.delegationAcceptors(DelegationType.FILTER)) {
+                    String key = AnalyticsQuerySettings.DELEGATION_BLOCKED_PREDICATES_PREFIX + acceptor + ".blocked_predicates";
+                    if (persistent.getAsList(key, null) != null) {
+                        // Already persisted. Apply to in-memory blocklist.
+                        clusterService.getClusterSettings().applySettings(persistent);
+                        continue;
+                    }
+
+                    Setting<List<ScalarFunction>> concrete = AnalyticsQuerySettings.DELEGATION_BLOCKED_PREDICATES
+                        .getConcreteSettingForNamespace(acceptor);
+                    Set<ScalarFunction> delegatable = registry.getBackend(acceptor).delegatedPredicateSerializers().keySet();
+                    List<String> defaults = concrete.getDefault(Settings.EMPTY)
+                        .stream()
+                        .filter(delegatable::contains)
+                        .map(ScalarFunction::name)
+                        .toList();
+                    if (defaults.isEmpty()) continue;
+
+                    Settings toApply = Settings.builder().putList(key, defaults).build();
+                    ClusterUpdateSettingsRequest req = new ClusterUpdateSettingsRequest();
+                    req.persistentSettings(toApply);
+                    client.admin().cluster().updateSettings(req, ActionListener.wrap(r -> {
+                        clusterService.getClusterSettings().applySettings(toApply);
+                        logger.info("Seeded delegation blocklist for [{}]: {}", acceptor, defaults);
+                    }, e -> logger.warn("Failed to seed delegation blocklist for [{}]: {}", acceptor, e.getMessage())));
+                }
+            }
+        });
     }
 
     @Override

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/settings/DelegationBlockList.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/settings/DelegationBlockList.java
@@ -14,11 +14,9 @@ import org.opensearch.analytics.planner.CapabilityRegistry;
 import org.opensearch.analytics.spi.DelegationType;
 import org.opensearch.analytics.spi.ScalarFunction;
 import org.opensearch.common.settings.ClusterSettings;
-import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
 
 import java.util.EnumSet;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -75,22 +73,6 @@ public final class DelegationBlockList {
         Map<String, EnumSet<ScalarFunction>> map = new ConcurrentHashMap<>();
         DelegationBlockList blockList = new DelegationBlockList(map);
         Map<String, List<ScalarFunction>> initial = AnalyticsQuerySettings.DELEGATION_BLOCKED_PREDICATES.getAsMap(initialSettings);
-        // Seed missing namespaces with setting defaults (getAsMap skips unset keys).
-        for (String acceptor : registry.delegationAcceptors(DelegationType.FILTER)) {
-            if (!initial.containsKey(acceptor)) {
-                Setting<List<ScalarFunction>> concrete = AnalyticsQuerySettings.DELEGATION_BLOCKED_PREDICATES
-                    .getConcreteSettingForNamespace(acceptor);
-                List<ScalarFunction> defaults = concrete.get(initialSettings);
-                if (!defaults.isEmpty()) {
-                    Set<ScalarFunction> delegatable = registry.getBackend(acceptor).delegatedPredicateSerializers().keySet();
-                    List<ScalarFunction> applicable = defaults.stream().filter(delegatable::contains).toList();
-                    if (!applicable.isEmpty()) {
-                        initial = new HashMap<>(initial);
-                        initial.put(acceptor, applicable);
-                    }
-                }
-            }
-        }
         for (Map.Entry<String, List<ScalarFunction>> e : initial.entrySet()) {
             validate(registry, e.getKey(), e.getValue());
             if (!e.getValue().isEmpty()) {

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/settings/DelegationBlockListTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/settings/DelegationBlockListTests.java
@@ -82,9 +82,9 @@ public class DelegationBlockListTests extends OpenSearchTestCase {
     }
 
     public void testDynamicUpdate() {
-        ClusterSettings clusterSettings = clusterSettings(Settings.EMPTY);
-        DelegationBlockList blockList = DelegationBlockList.create(clusterSettings, Settings.EMPTY, registry());
-        // Defaults seed LIKE (the only default that has a serializer in this fixture).
+        Settings initial = Settings.builder().putList("analytics.delegation.lucene.blocked_predicates", "LIKE").build();
+        ClusterSettings clusterSettings = clusterSettings(initial);
+        DelegationBlockList blockList = DelegationBlockList.create(clusterSettings, initial, registry());
         assertTrue(blockList.isBlocked(LUCENE, ScalarFunction.LIKE));
 
         // Explicit update overrides the seeded default.
@@ -141,58 +141,16 @@ public class DelegationBlockListTests extends OpenSearchTestCase {
         expectThrows(IllegalArgumentException.class, () -> DelegationBlockList.create(clusterSettings(settings), settings, registry()));
     }
 
-    public void testDefaultsSeededWhenSettingsEmpty() {
-        // Fixture with IS_NULL, IS_NOT_NULL, LIKE serializers — mirrors the real Lucene backend.
-        DelegatedPredicateSerializer stub = (call, fieldStorage) -> new byte[0];
-        AnalyticsSearchBackendPlugin luceneWithDefaults = new AnalyticsSearchBackendPlugin() {
-            @Override
-            public String name() {
-                return LUCENE;
-            }
+    public void testEmptySettingsProducesEmptyBlockList() {
+        DelegationBlockList blockList = DelegationBlockList.create(clusterSettings(Settings.EMPTY), Settings.EMPTY, registry());
+        assertTrue("empty settings = empty blocklist (persistence seeds later)", blockList.isEmpty());
+    }
 
-            @Override
-            public BackendCapabilityProvider getCapabilityProvider() {
-                return new BackendCapabilityProvider() {
-                    @Override
-                    public Set<EngineCapability> supportedEngineCapabilities() {
-                        return Set.of();
-                    }
-
-                    @Override
-                    public Set<DelegationType> acceptedDelegations() {
-                        return Set.of(DelegationType.FILTER);
-                    }
-                };
-            }
-
-            @Override
-            public Map<ScalarFunction, DelegatedPredicateSerializer> delegatedPredicateSerializers() {
-                return Map.ofEntries(
-                    Map.entry(ScalarFunction.EQUALS, stub),
-                    Map.entry(ScalarFunction.NOT_EQUALS, stub),
-                    Map.entry(ScalarFunction.IS_NULL, stub),
-                    Map.entry(ScalarFunction.IS_NOT_NULL, stub),
-                    Map.entry(ScalarFunction.LIKE, stub),
-                    Map.entry(ScalarFunction.GREATER_THAN, stub),
-                    Map.entry(ScalarFunction.GREATER_THAN_OR_EQUAL, stub),
-                    Map.entry(ScalarFunction.LESS_THAN, stub),
-                    Map.entry(ScalarFunction.LESS_THAN_OR_EQUAL, stub),
-                    Map.entry(ScalarFunction.SARG_PREDICATE, stub)
-                );
-            }
-        };
-        CapabilityRegistry reg = new CapabilityRegistry(List.of(luceneWithDefaults), FieldStorageResolver::new);
-        DelegationBlockList blockList = DelegationBlockList.create(clusterSettings(Settings.EMPTY), Settings.EMPTY, reg);
-        assertFalse("defaults should be seeded", blockList.isEmpty());
-        assertTrue(blockList.isBlocked(LUCENE, ScalarFunction.IS_NULL));
-        assertTrue(blockList.isBlocked(LUCENE, ScalarFunction.IS_NOT_NULL));
-        assertTrue(blockList.isBlocked(LUCENE, ScalarFunction.NOT_EQUALS));
+    public void testPersistedDefaultsApplied() {
+        Settings persisted = Settings.builder().putList("analytics.delegation.lucene.blocked_predicates", "LIKE").build();
+        DelegationBlockList blockList = DelegationBlockList.create(clusterSettings(persisted), persisted, registry());
+        assertFalse(blockList.isEmpty());
         assertTrue(blockList.isBlocked(LUCENE, ScalarFunction.LIKE));
-        assertTrue(blockList.isBlocked(LUCENE, ScalarFunction.GREATER_THAN));
-        assertTrue(blockList.isBlocked(LUCENE, ScalarFunction.GREATER_THAN_OR_EQUAL));
-        assertTrue(blockList.isBlocked(LUCENE, ScalarFunction.LESS_THAN));
-        assertTrue(blockList.isBlocked(LUCENE, ScalarFunction.LESS_THAN_OR_EQUAL));
-        assertTrue(blockList.isBlocked(LUCENE, ScalarFunction.SARG_PREDICATE));
         assertFalse(blockList.isBlocked(LUCENE, ScalarFunction.EQUALS));
     }
 

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/FilterDelegationGoldenIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/FilterDelegationGoldenIT.java
@@ -169,9 +169,9 @@ public class FilterDelegationGoldenIT extends AnalyticsRestTestCase {
         OR_DUAL_DELEGATED_NATIVE(29, df("INTERLEAVED_BOOLEAN_EXPRESSION"), df("INTERLEAVED_BOOLEAN_EXPRESSION")),
 
         // NOT(leaf) (3)
-        NOT_DUAL(30, lucene(), df("CONJUNCTIVE")),
+        NOT_DUAL(30, df("CONJUNCTIVE"), df("CONJUNCTIVE")),
         NOT_NATIVE(31, df(null), df(null)),
-        NOT_DELEGATED(32, lucene(), df("CONJUNCTIVE")),
+        NOT_DELEGATED(32, df("CONJUNCTIVE"), df("CONJUNCTIVE")),
 
         // Mixed connectors, depth 2 (6)
         MIXED_OR_OF_ANDS_OF_DUALS(33, lucene(), df("CONJUNCTIVE")),
@@ -179,7 +179,7 @@ public class FilterDelegationGoldenIT extends AnalyticsRestTestCase {
         MIXED_OR_OF_DUAL_DELEGATED_ANDS(35, lucene(), df("CONJUNCTIVE")),
         MIXED_AND_OF_DUAL_DELEGATED_ORS(36, lucene(), df("CONJUNCTIVE")),
         MIXED_OR_OF_AND_OF_DUALS_AND_NATIVE(37, df("INTERLEAVED_BOOLEAN_EXPRESSION"), df("INTERLEAVED_BOOLEAN_EXPRESSION")),
-        MIXED_NOT_OF_AND_OF_DUALS(38, lucene(), df("CONJUNCTIVE"));
+        MIXED_NOT_OF_AND_OF_DUALS(38, df("CONJUNCTIVE"), df("CONJUNCTIVE"));
 
         final int queryNumber;
         final Map<Boolean, ChosenBackendandTreeShape> cells;

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/FilterDelegationIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/FilterDelegationIT.java
@@ -515,4 +515,19 @@ public class FilterDelegationIT extends AnalyticsRestTestCase {
         client().performRequest(new Request("POST", "/" + INDEX_NAME + "/_flush?force=true"));
     }
 
+    @SuppressWarnings("unchecked")
+    public void testDelegationBlockListPersistedOnBoot() throws Exception {
+        Request req = new Request("GET", "/_cluster/settings");
+        req.addParameter("flat_settings", "true");
+        Map<String, Object> settings = assertOkAndParse(client().performRequest(req), "GET /_cluster/settings");
+        Map<String, Object> persistent = (Map<String, Object>) settings.get("persistent");
+        assertNotNull("persistent settings present", persistent);
+        Object blocklist = persistent.get("analytics.delegation.lucene.blocked_predicates");
+        assertNotNull("blocklist seeded on boot", blocklist);
+        List<String> predicates = (List<String>) blocklist;
+        assertTrue("blocklist contains IS_NULL", predicates.contains("IS_NULL"));
+        assertTrue("blocklist contains NOT_EQUALS", predicates.contains("NOT_EQUALS"));
+        assertTrue("blocklist contains LIKE", predicates.contains("LIKE"));
+    }
+
 }


### PR DESCRIPTION
## Summary
  Seed `analytics.delegation.lucene.blocked_predicates` into persistent cluster settings on first master election. Removes redundant in-memory seeding — cluster state is the single source of truth.

  ## Why
  Previously, defaults were applied in-memory but invisible via `GET /_cluster/settings`. Users had to read source code to know what was blocked.

  ## Test plan
  - Unit: `DelegationBlockListTests.testPersistedDefaultsApplied` — asserts all applicable predicates blocked/unblocked
  - IT: `FilterDelegationIT.testDelegationBlockListPersistedOnBoot` — verifies GET returns the list after boot

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
