### PR TITLE
[sandbox] Fix AnalyticsQueryTask onCancel callback race

### DIFF
--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/task/AnalyticsQueryTask.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/task/AnalyticsQueryTask.java
@@ -81,11 +81,19 @@ public class AnalyticsQueryTask extends SearchTask {
         if (onCancelCallback.compareAndSet(null, callback) == false) {
             throw new IllegalStateException("onCancelCallback already set for AnalyticsQueryTask " + queryId);
         }
+        // Cancel may have arrived before this install — fire inline if so. Mirrors AnalyticsShardTask.setCancellationListener.
+        if (isCancelled()) {
+            runCallbackOnce();
+        }
     }
 
     @Override
     protected void onCancelled() {
-        Runnable cb = onCancelCallback.get();
+        runCallbackOnce();
+    }
+
+    private void runCallbackOnce() {
+        Runnable cb = onCancelCallback.getAndSet(null);
         if (cb != null) {
             try {
                 cb.run();

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/task/AnalyticsQueryTaskCancellationCallbackTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/task/AnalyticsQueryTaskCancellationCallbackTests.java
@@ -1,0 +1,64 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.exec.task;
+
+import org.opensearch.core.tasks.TaskId;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class AnalyticsQueryTaskCancellationCallbackTests extends OpenSearchTestCase {
+
+    private AnalyticsQueryTask createTask() {
+        return new AnalyticsQueryTask(1L, "type", "action", "queryId", TaskId.EMPTY_TASK_ID, Collections.emptyMap());
+    }
+
+    public void testCallbackFiresOnCancellation() {
+        AnalyticsQueryTask task = createTask();
+        AtomicInteger callCount = new AtomicInteger();
+        task.setOnCancelCallback(callCount::incrementAndGet);
+
+        task.cancel("test reason");
+
+        assertEquals(1, callCount.get());
+    }
+
+    public void testCallbackFiresImmediatelyIfAlreadyCancelled() {
+        AnalyticsQueryTask task = createTask();
+        task.cancel("cancel before install");
+
+        AtomicInteger callCount = new AtomicInteger();
+        task.setOnCancelCallback(callCount::incrementAndGet);
+
+        assertEquals("callback must fire when installed after cancel", 1, callCount.get());
+    }
+
+    public void testCallbackFiresExactlyOnce() {
+        AnalyticsQueryTask task = createTask();
+        AtomicInteger callCount = new AtomicInteger();
+        task.setOnCancelCallback(callCount::incrementAndGet);
+
+        task.cancel("first");
+        task.cancel("second");
+
+        assertEquals(1, callCount.get());
+    }
+
+    public void testNullCallbackDoesNotThrowOnCancellation() {
+        AnalyticsQueryTask task = createTask();
+        task.cancel("no callback installed");
+    }
+
+    public void testSecondSetThrows() {
+        AnalyticsQueryTask task = createTask();
+        task.setOnCancelCallback(() -> {});
+        expectThrows(IllegalStateException.class, () -> task.setOnCancelCallback(() -> {}));
+    }
+}


### PR DESCRIPTION
### Description

When the analytics-engine transport action runs on the coordinator, there's a time gap between when the task becomes available to cancel and when the cancel callback is wired up:

1. `TransportAction.execute:101` — `taskManager.register(...)` puts `AnalyticsQueryTask` into `cancellableTasks`. From this moment on, `_tasks/_cancel` can find and fire it.
2. `DefaultPlanExecutor.doExecute:414` — `searchExecutor.execute(...)` queues the lambda containing planning + scheduler setup; the transport thread returns immediately.
3. The lambda is picked up by a SEARCH worker, runs Calcite planning, builds the DAG, and finally hits `QueryScheduler.setCancellationCallback:139` which calls `setOnCancelCallback(...)`.

The gap (1) → (3) is determined by SEARCH pool queue depth and Calcite planning latency (cold path with schema fetch). Sub-millisecond on a quiet cluster, noticeably reachable under load.

A cancel landing in that gap — server-side timeout, HTTP disconnect via `RestCancellableNodeClient` (fires inline on the Netty event loop), or parent-task cascade — runs `onCancelled()` while `onCancelCallback` is still null. The current code returns silently; the task is marked cancelled but the analytics query keeps running to completion. 

This regresses the disconnect-cancel guarantee #22229 + opensearch-project/sql#5563 set up.

### Fix

Mirror the pattern already used by `AnalyticsShardTask.setCancellationListener` on the data-node side: after the install-time CAS, re-check `isCancelled()` and run the callback inline if it's already set. Switch consumption to `getAndSet(null)` so the install-side and `onCancelled()` paths can't both fire it.

### Test

`testCallbackFiresImmediatelyIfAlreadyCancelled` is the regression guard — empirically fails on the pre-fix `AnalyticsQueryTask` (callCount=0) and passes after this change. Other four tests confirm existing semantics unchanged: callback fires once on normal cancel, idempotent under repeated cancel, no-op when no callback installed, second-set throws.

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).